### PR TITLE
Disable merging of compile commands for optional third-party projects.

### DIFF
--- a/third-party/FunctionalPlus/CMakeLists.txt
+++ b/third-party/FunctionalPlus/CMakeLists.txt
@@ -8,6 +8,7 @@ therock_subproject_fetch(therock-FunctionalPlus-sources
 therock_cmake_subproject_declare(therock-FunctionalPlus
   BACKGROUND_BUILD
   EXCLUDE_FROM_ALL
+  NO_MERGE_COMPILE_COMMANDS
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
 )
 therock_cmake_subproject_provide_package(

--- a/third-party/SuiteSparse/CMakeLists.txt
+++ b/third-party/SuiteSparse/CMakeLists.txt
@@ -8,6 +8,7 @@ therock_subproject_fetch(therock-SuiteSparse-sources
 therock_cmake_subproject_declare(therock-SuiteSparse
   BACKGROUND_BUILD
   EXCLUDE_FROM_ALL
+  NO_MERGE_COMPILE_COMMANDS
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
   INSTALL_DESTINATION "lib/host-math"
   CMAKE_ARGS

--- a/third-party/boost/CMakeLists.txt
+++ b/third-party/boost/CMakeLists.txt
@@ -20,6 +20,8 @@ therock_subproject_fetch(boost-sources
 
 therock_cmake_subproject_declare(therock-boost
   EXTERNAL_SOURCE_DIR "cmake_project"
+  EXCLUDE_FROM_ALL
+  NO_MERGE_COMPILE_COMMANDS
   BACKGROUND_BUILD
   CMAKE_ARGS
     "-DBOOST_SOURCE_DIR=${_source_dir}"

--- a/third-party/eigen/CMakeLists.txt
+++ b/third-party/eigen/CMakeLists.txt
@@ -8,6 +8,7 @@ therock_subproject_fetch(therock-eigen-sources
 therock_cmake_subproject_declare(therock-eigen
   BACKGROUND_BUILD
   EXCLUDE_FROM_ALL
+  NO_MERGE_COMPILE_COMMANDS
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
 )
 therock_cmake_subproject_provide_package(therock-eigen Eigen3 share/eigen3/cmake)

--- a/third-party/fmt/CMakeLists.txt
+++ b/third-party/fmt/CMakeLists.txt
@@ -8,6 +8,7 @@ therock_subproject_fetch(therock-fmt-sources
 therock_cmake_subproject_declare(therock-fmt
   BACKGROUND_BUILD
   EXCLUDE_FROM_ALL
+  NO_MERGE_COMPILE_COMMANDS
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
   CMAKE_ARGS
     -DFMT_DOC=OFF

--- a/third-party/frugally-deep/CMakeLists.txt
+++ b/third-party/frugally-deep/CMakeLists.txt
@@ -8,6 +8,7 @@ therock_subproject_fetch(therock-frugally-deep-sources
 therock_cmake_subproject_declare(therock-frugally-deep
   BACKGROUND_BUILD
   EXCLUDE_FROM_ALL
+  NO_MERGE_COMPILE_COMMANDS
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
   BUILD_DEPS
     therock-eigen

--- a/third-party/host-blas/CMakeLists.txt
+++ b/third-party/host-blas/CMakeLists.txt
@@ -14,6 +14,7 @@ therock_subproject_fetch(therock-OpenBLAS-sources
 therock_cmake_subproject_declare(therock-host-blas
   BACKGROUND_BUILD
   EXCLUDE_FROM_ALL
+  NO_MERGE_COMPILE_COMMANDS
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
   INSTALL_DESTINATION "lib/host-math"
   INTERFACE_LINK_DIRS "lib/host-math/lib"

--- a/third-party/msgpack-cxx/CMakeLists.txt
+++ b/third-party/msgpack-cxx/CMakeLists.txt
@@ -8,6 +8,7 @@ therock_subproject_fetch(therock-msgpack-cxx-sources
 therock_cmake_subproject_declare(therock-msgpack-cxx
   BACKGROUND_BUILD
   EXCLUDE_FROM_ALL
+  NO_MERGE_COMPILE_COMMANDS
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
   CMAKE_ARGS
     -DMSGPACK_USE_BOOST=OFF

--- a/third-party/nlohmann-json/CMakeLists.txt
+++ b/third-party/nlohmann-json/CMakeLists.txt
@@ -7,6 +7,7 @@ therock_subproject_fetch(therock-nlohmann-json-sources
 
 therock_cmake_subproject_declare(therock-nlohmann-json
   EXCLUDE_FROM_ALL
+  NO_MERGE_COMPILE_COMMANDS
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
   CMAKE_ARGS
     -DJSON_BuildTests=OFF


### PR DESCRIPTION
* Without this, the dep on compile_commands.json forces building of the project, even if nothing depends on it.
* Building triggers fetching, etc.
* After this patch, third-party libraries are only fetched/built as needed.