### PR TITLE
Patches needed to build pytorch 2.6 with current TheRock.

### DIFF
--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -25,13 +25,10 @@ source .venv/bin/activate
 
 ## Step 1: Preparing sources
 
-PyTorch on ROCM relies on pre-processing the sources. In order to avoid dirtying
-the git repository (which will also dirty some submodules and makes a big mess),
-we duplicate the tree and then make modifications on that:
-
 ```
-# Checks out to the src/ dir in this directory
-./ptbuild import --git-dir /path/to/pytorch/checkout
+# Checks out the most recent stable release branch of PyTorch, hipifies and
+# applies patches.
+./ptbuild checkout
 ```
 
 ## Step 2: Install Deps

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -47,5 +47,5 @@ pip install mkl-static mkl-include
 
 ```
 export CMAKE_PREFIX_PATH="$(realpath ../../build/dist/rocm)"
-(cd src && python setup.py build --cmake-only)
+(cd src && USE_KINETO=OFF python setup.py develop)
 ```

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
@@ -1,7 +1,8 @@
-From 2e234ce66e8b0d20096adeccd0298d9353238747 Mon Sep 17 00:00:00 2001
+From 6161376c9cf587097e27d9ebe0a3489849bbd9f1 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 17 Feb 2025 16:47:57 -0800
-Subject: [PATCH] Rework LoadHIP.cmake to be based purely on CMAKE_PREFIX_PATH.
+Subject: [PATCH 1/3] Rework LoadHIP.cmake to be based purely on
+ CMAKE_PREFIX_PATH.
 
 * Eliminates dependence on `/opt/rocm` and path based heuristics.
 * Normalizes package finding for Rocm 6.5+ layout.
@@ -10,7 +11,7 @@ Subject: [PATCH] Rework LoadHIP.cmake to be based purely on CMAKE_PREFIX_PATH.
  1 file changed, 110 insertions(+), 192 deletions(-)
 
 diff --git a/cmake/public/LoadHIP.cmake b/cmake/public/LoadHIP.cmake
-index 3eb34b0..c0a69db 100644
+index 3eb34b0b83..c0a69db443 100644
 --- a/cmake/public/LoadHIP.cmake
 +++ b/cmake/public/LoadHIP.cmake
 @@ -1,199 +1,117 @@

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
@@ -1,0 +1,49 @@
+From dc6344fd018e3031775e5cc7ba8db3080ad736d6 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Wed, 19 Feb 2025 17:14:59 -0800
+Subject: [PATCH 2/3] Generate composable_kernel ck/config.h as part of main
+ build.
+
+Without this, the ck/config.h comes from somewhere, most probably a ROCM SDK that has it installed as a sibling to the HIP headers. Not all ROCM SDKs include this, and even so, it is dangerous to have a sheared header dependency like this.
+---
+ aten/src/ATen/CMakeLists.txt | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
+index f0868ea048..293fa8ace3 100644
+--- a/aten/src/ATen/CMakeLists.txt
++++ b/aten/src/ATen/CMakeLists.txt
+@@ -311,9 +311,30 @@ if(USE_CUDA)
+ endif()
+ 
+ if(USE_ROCM)
++  # NOTE: The PyTorch build does not actually add_subdirectory 
++  # third_party/composable_kernel or use it as a CMake library. What is used
++  # is header only, so this should be ok, except that the CMake build generates
++  # a ck/config.h. We just do that part here. Without this, the ck.h from the
++  # ROCM SDK may get accidentally used instead.
++  function(_pytorch_rocm_generate_ck_conf)
++    set(CK_ENABLE_INT8 "ON")
++    set(CK_ENABLE_FP16 "ON")
++    set(CK_ENABLE_FP32 "ON")
++    set(CK_ENABLE_FP64 "ON")
++    set(CK_ENABLE_BF16 "ON")
++    set(CK_ENABLE_FP8 "ON")
++    set(CK_ENABLE_BF8 "ON")
++    configure_file(
++      "${Torch_SOURCE_DIR}/third_party/composable_kernel/include/ck/config.h.in"
++      "${CMAKE_CURRENT_BINARY_DIR}/composable_kernel/ck/config.h"
++      )
++  endfunction()
+   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/hip)
+   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/composable_kernel/include)
+   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/composable_kernel/library/include)
++  list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_BINARY_DIR}/composable_kernel)
++  _pytorch_rocm_generate_ck_conf()
++
+   # Next two lines are needed because TunableOp uses third-party/fmt
+   list(APPEND ATen_HIP_INCLUDE $<TARGET_PROPERTY:fmt::fmt-header-only,INTERFACE_INCLUDE_DIRECTORIES>)
+   list(APPEND ATen_HIP_DEPENDENCY_LIBS fmt::fmt-header-only)
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
@@ -1,0 +1,109 @@
+From 3b7899a0fe6b1339d04daf1bbba709bbd04f171c Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Wed, 19 Feb 2025 17:16:27 -0800
+Subject: [PATCH 3/3] TEMPORARY: Manually disable roctx until compatibility
+ with rocprofv3 is established.
+
+---
+ torch/csrc/cuda/shared/nvtx.cpp    | 19 ++++++++++++-------
+ torch/csrc/profiler/stubs/cuda.cpp | 11 ++++++++---
+ 2 files changed, 20 insertions(+), 10 deletions(-)
+
+diff --git a/torch/csrc/cuda/shared/nvtx.cpp b/torch/csrc/cuda/shared/nvtx.cpp
+index a14ba6b8f6..b5457030ce 100644
+--- a/torch/csrc/cuda/shared/nvtx.cpp
++++ b/torch/csrc/cuda/shared/nvtx.cpp
+@@ -1,11 +1,13 @@
+ #ifdef _WIN32
+ #include <wchar.h> // _wgetenv for nvtx
+ #endif
++/* TODO: Enable when rocprofv3 compat is available.
+ #ifdef TORCH_CUDA_USE_NVTX3
+ #include <roctracer/roctx.h>
+ #else
+ #include <roctracer/roctx.h>
+ #endif
++*/
+ #include <hip/hip_runtime.h>
+ #include <torch/csrc/utils/pybind.h>
+ 
+@@ -18,7 +20,8 @@ struct RangeHandle {
+ 
+ static void device_callback_range_end(void* userData) {
+   RangeHandle* handle = ((RangeHandle*)userData);
+-  roctxRangeStop(handle->id);
++  // TODO: Enable when rocprofv3 compat is available.
++  //roctxRangeStop(handle->id);
+   free((void*)handle->msg);
+   free((void*)handle);
+ }
+@@ -29,7 +32,9 @@ static void device_nvtxRangeEnd(void* handle, std::intptr_t stream) {
+ 
+ static void device_callback_range_start(void* userData) {
+   RangeHandle* handle = ((RangeHandle*)userData);
+-  handle->id = roctxRangeStartA(handle->msg);
++  // TODO: Enable when rocprofv3 compat is available.
++  // handle->id = roctxRangeStartA(handle->msg);
++  handle->id = 0;
+ }
+ 
+ static void* device_nvtxRangeStart(const char* msg, std::intptr_t stream) {
+@@ -49,11 +54,11 @@ void initNvtxBindings(PyObject* module) {
+ #else
+   auto nvtx = m.def_submodule("_nvtx", "libNvToolsExt.so bindings");
+ #endif
+-  nvtx.def("rangePushA", roctxRangePushA);
+-  nvtx.def("rangePop", roctxRangePop);
+-  nvtx.def("rangeStartA", roctxRangeStartA);
+-  nvtx.def("rangeEnd", roctxRangeStop);
+-  nvtx.def("markA", roctxMarkA);
++  nvtx.def("rangePushA", [](const char*) {} /*roctxRangePushA*/);
++  nvtx.def("rangePop", []() { } /*roctxRangePop*/);
++  nvtx.def("rangeStartA", [](const char*) { return 0; }/*roctxRangeStartA*/);
++  nvtx.def("rangeEnd", []() {}/*roctxRangeStop*/);
++  nvtx.def("markA", [](const char*) {}/*roctxMarkA */);
+   nvtx.def("deviceRangeStart", device_nvtxRangeStart);
+   nvtx.def("deviceRangeEnd", device_nvtxRangeEnd);
+ }
+diff --git a/torch/csrc/profiler/stubs/cuda.cpp b/torch/csrc/profiler/stubs/cuda.cpp
+index e4ad3fc8e6..a92c5bc95c 100644
+--- a/torch/csrc/profiler/stubs/cuda.cpp
++++ b/torch/csrc/profiler/stubs/cuda.cpp
+@@ -1,10 +1,12 @@
+ #include <sstream>
+ 
++/* TODO: Enable when rocprofv3 compat is in TheRock
+ #ifdef TORCH_CUDA_USE_NVTX3
+ #include <roctracer/roctx.h>
+ #else
+ #include <roctracer/roctx.h>
+ #endif
++*/
+ 
+ #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+ #include <c10/util/ApproximateClock.h>
+@@ -72,15 +74,18 @@ struct CUDAMethods : public ProfilerStubs {
+   }
+ 
+   void mark(const char* name) const override {
+-    ::roctxMark(name);
++    // TODO: Enable when rocprofv3 compat is available.
++    //::roctxMark(name);
+   }
+ 
+   void rangePush(const char* name) const override {
+-    ::roctxRangePushA(name);
++    // TODO: Enable when rocprofv3 compat is available.
++    //::roctxRangePushA(name);
+   }
+ 
+   void rangePop() const override {
+-    ::roctxRangePop();
++    // TODO: Enable when rocprofv3 compat is available.
++    //::roctxRangePop();
+   }
+ 
+   void onEachDevice(std::function<void(int)> op) const override {
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/v2.6.0/third_party/composable_kernel/base/0001-Work-around-ambiguous-cast-of-half_t-__half-in-call-.patch
+++ b/external-builds/pytorch/patches/v2.6.0/third_party/composable_kernel/base/0001-Work-around-ambiguous-cast-of-half_t-__half-in-call-.patch
@@ -1,0 +1,29 @@
+From 019d6e65d121f6efdbf3875f9fffd4d433e22318 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Wed, 19 Feb 2025 17:17:01 -0800
+Subject: [PATCH] Work around ambiguous cast of half_t -> __half in call to
+ __hneg.
+
+Encountered on gcc 13.3 on a pre-release of ROCM 6.4.
+---
+ include/ck/utility/math_v2.hpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/include/ck/utility/math_v2.hpp b/include/ck/utility/math_v2.hpp
+index b374c4ad5..ca45911d1 100644
+--- a/include/ck/utility/math_v2.hpp
++++ b/include/ck/utility/math_v2.hpp
+@@ -611,7 +611,9 @@ inline __device__ int8_t neg<int8_t>(int8_t x)
+ template <>
+ inline __device__ half_t neg<half_t>(half_t x)
+ {
+-    return __hneg(x);
++    // Matches signature `__half __hneg(__half x)`. Without the cast, some
++    // compilers report an ambiguity.
++    return __hneg(static_cast<__half>(x));
+ };
+ 
+ template <typename T>
+-- 
+2.43.0
+


### PR DESCRIPTION
* Temporarily recommends disabling kineto (until rocprofv3 compat is in).
* Inlines patches to:
  * Comment on roctx deps
  * Fix composable_kernel config.h missing issue
  * Work around composable_kernel ambiguous cast