### PR TITLE
Build for gfx1201 / gfx1150 / gfx1151.

### DIFF
--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -38,9 +38,9 @@ jobs:
       fail-fast: false
       matrix:
         target_bundle:
-          # - amdgpu_family: "gfx94X-dcgpu"
-          # - amdgpu_family: "gfx110X-dgpu"
-          # - amdgpu_family: "gfx1151"
+          - amdgpu_family: "gfx94X-dcgpu"
+          - amdgpu_family: "gfx110X-dgpu"
+          - amdgpu_family: "gfx1151"
           - amdgpu_family: "gfx1201"
 
     permissions:
@@ -83,8 +83,7 @@ jobs:
             --image=${{ env.BUILD_IMAGE }} \
             --output-dir=${{ env.OUTPUT_DIR }} \
             -- \
-            "-DTHEROCK_AMDGPU_FAMILIES=${{ matrix.target_bundle.amdgpu_family }}" \
-            -DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_HIP_RUNTIME=ON
+            "-DTHEROCK_AMDGPU_FAMILIES=${{ matrix.target_bundle.amdgpu_family }}"
           cd ${{ env.OUTPUT_DIR }}/build/dist/rocm
           echo "Building ${{ env.DIST_ARCHIVE }}"
           tar cfz "${{ env.DIST_ARCHIVE }}" .

--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -74,7 +74,7 @@ jobs:
           docker pull ${{ env.BUILD_IMAGE }} &
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
-          ./build_tools/fetch_sources.py
+          ./build_tools/fetch_sources.py --jobs 10
           wait
 
       - name: Build Projects
@@ -83,7 +83,8 @@ jobs:
             --image=${{ env.BUILD_IMAGE }} \
             --output-dir=${{ env.OUTPUT_DIR }} \
             -- \
-            "-DTHEROCK_AMDGPU_FAMILIES=${{ matrix.target_bundle.amdgpu_family }}"
+            "-DTHEROCK_AMDGPU_FAMILIES=${{ matrix.target_bundle.amdgpu_family }}" \
+            -DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_HIP_RUNTIME=ON
           cd ${{ env.OUTPUT_DIR }}/build/dist/rocm
           echo "Building ${{ env.DIST_ARCHIVE }}"
           tar cfz "${{ env.DIST_ARCHIVE }}" .

--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -74,20 +74,12 @@ jobs:
           docker pull ${{ env.BUILD_IMAGE }} &
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
-          ./build_tools/fetch_sources.py --depth 1
+          ./build_tools/fetch_sources.py
           wait
-
-      # The full checkout is very large: ~16GB, 9 of which is GIT stuff.
-      # So we delete the latter. This must be done after getting any git
-      # stamps or such things.
-      - name: Trim Disk Space
-        run: |
-          rm -Rf sources/.repo
-          df -h
 
       - name: Build Projects
         run: |
-          ./build_tools/linux_build_portable.py \
+          ./build_tools/linux_portable_build.py \
             --image=${{ env.BUILD_IMAGE }} \
             --output-dir=${{ env.OUTPUT_DIR }} \
             -- \

--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -38,9 +38,10 @@ jobs:
       fail-fast: false
       matrix:
         target_bundle:
-          - amdgpu_family: "gfx94X-dcgpu"
-          - amdgpu_family: "gfx110X-dgpu"
-          - amdgpu_family: "gfx1151"
+          # - amdgpu_family: "gfx94X-dcgpu"
+          # - amdgpu_family: "gfx110X-dgpu"
+          # - amdgpu_family: "gfx1151"
+          - amdgpu_family: "gfx1201"
 
     permissions:
       contents: write

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -58,6 +58,9 @@ therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all 
 therock_add_amdgpu_target(gfx1150 "AMD Strix Point iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu)
 therock_add_amdgpu_target(gfx1151 "AMD Strix Halo iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu)
 
+# gfx120X family
+therock_add_amdgpu_target(gfx1201 "AMD WIP RDNA4/NAVI48" FAMILY dgpu-all gfx120X-all)
+
 
 # Validates and normalizes AMDGPU target selection cache variables.
 function(therock_validate_amdgpu_targets)

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -4,15 +4,25 @@
 #   THEROCK_AMDGPU_TARGET_NAME_{gfx_target}: Product name of the gfx target
 #   THEROCK_AMDGPU_TARGET_FAMILY_{family}: List of gfx targets within a named
 #     family
+#   THEROCK_AMDGPU_PROJECT_TARGET_EXCLUDES_${project_name}: Project target keyed
+#     list of gfx targets to exclude when building the target.
 #
 # Note that each gfx_target will also create a family of the same name.
 set_property(GLOBAL PROPERTY THEROCK_AMDGPU_TARGETS)
 
+# Declares an AMDGPU target, associating it with family names and optionally
+# setting additional characteristics.
+# Args: gfx_target product_name
+# Keyword Args:
+# FAMILY: List of family names to associate the gfx target with.
+# EXCLUDE_TARGET_PROJECTS: sub-project names for which this target should be
+# filtered out. This is used to work around bugs during bringup and should
+# not be set on any fully supported targets.
 function(therock_add_amdgpu_target gfx_target product_name)
   cmake_parse_arguments(PARSE_ARGV 2 ARG
     ""
     ""
-    "FAMILY"
+    "FAMILY;EXCLUDE_TARGET_PROJECTS"
   )
 
   get_property(_targets GLOBAL PROPERTY THEROCK_AMDGPU_TARGETS)
@@ -21,6 +31,9 @@ function(therock_add_amdgpu_target gfx_target product_name)
   endif()
   set_property(GLOBAL APPEND PROPERTY THEROCK_AMDGPU_TARGETS "${gfx_target}")
   set_property(GLOBAL PROPERTY "THEROCK_AMDGPU_TARGET_NAME_${gfx_target}" "${product_name}")
+  foreach(project_name in ${ARG_EXCLUDE_TARGET_PROJECTS})
+    set_property(GLOBAL APPEND PROPERTY THEROCK_AMDGPU_PROJECT_TARGET_EXCLUDES_${project_name} "${gfx_target}")
+  endforeach()
   foreach(_family "${gfx_target}" ${ARG_FAMILY})
     set_property(GLOBAL APPEND PROPERTY THEROCK_AMDGPU_TARGET_FAMILIES "${_family}")
     set_property(GLOBAL APPEND PROPERTY "THEROCK_AMDGPU_TARGET_FAMILY_${_family}" "${gfx_target}")
@@ -55,11 +68,20 @@ therock_add_amdgpu_target(gfx1102 "AMD RX 7700S/Framework Laptop 16" FAMILY igpu
 therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all gfx110X-all gfx110X-igpu)
 
 # gfx115X family
-therock_add_amdgpu_target(gfx1150 "AMD Strix Point iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu)
-therock_add_amdgpu_target(gfx1151 "AMD Strix Halo iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu)
+therock_add_amdgpu_target(gfx1150 "AMD Strix Point iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
+  EXCLUDE_TARGET_PROJECTS
+    rccl  # https://github.com/ROCm/TheRock/issues/150
+)
+therock_add_amdgpu_target(gfx1151 "AMD Strix Halo iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
+  EXCLUDE_TARGET_PROJECTS
+    rccl  # https://github.com/ROCm/TheRock/issues/150
+)
 
 # gfx120X family
-therock_add_amdgpu_target(gfx1201 "AMD WIP RDNA4/NAVI48" FAMILY dgpu-all gfx120X-all)
+therock_add_amdgpu_target(gfx1201 "AMD RX 9070 / XT" FAMILY dgpu-all gfx120X-all
+  EXCLUDE_TARGET_PROJECTS
+    hipBLASLt  # https://github.com/ROCm/TheRock/issues/149
+)
 
 
 # Validates and normalizes AMDGPU target selection cache variables.

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -13,11 +13,12 @@ set_property(GLOBAL PROPERTY THEROCK_AMDGPU_TARGETS)
 # Declares an AMDGPU target, associating it with family names and optionally
 # setting additional characteristics.
 # Args: gfx_target product_name
+#
 # Keyword Args:
 # FAMILY: List of family names to associate the gfx target with.
 # EXCLUDE_TARGET_PROJECTS: sub-project names for which this target should be
-# filtered out. This is used to work around bugs during bringup and should
-# not be set on any fully supported targets.
+#   filtered out. This is used to work around bugs during bringup and should
+#   not be set on any fully supported targets.
 function(therock_add_amdgpu_target gfx_target product_name)
   cmake_parse_arguments(PARSE_ARGV 2 ARG
     ""


### PR DESCRIPTION
This adds some target filtering/fallback logic to aid in target bringup by allowing us to build components that are not yet compatible with the target. Warnings are unconditionally issued in such cases.

See #149, #150 