### PR TITLE
Pin unpinned actions

### DIFF
--- a/.github/workflows/test_linux_packages.yml
+++ b/.github/workflows/test_linux_packages.yml
@@ -28,14 +28,14 @@ jobs:
     # MOSTLY BOILER PLATE ABOVE.
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install the AWS tool
         run: ./dockerfiles/install_awscli.sh
 
       - name: "Setting up Python"
         id: setup_python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: 3.11
 


### PR DESCRIPTION
Pins actions that were not yet pinned with its hashes as recommended by the OpenSSF scorecard project:
https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies