### PR TITLE
Adds a pytorch-dev docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install CppHeaderParser==2.7.4 meson==1.7.0
 Dev tools:
 
 ```
-sudo apt install gfortran git-lfs ninja-build cmake g++ pkg-config xxd libgtest-dev
+sudo apt install gfortran git-lfs ninja-build cmake g++ pkg-config xxd libgtest-dev patchelf automake
 ```
 
 ## On Windows

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -54,6 +54,8 @@ therock_cmake_subproject_declare(rocm_smi_lib
   EXTERNAL_SOURCE_DIR "rocm_smi_lib"
   INTERFACE_LINK_DIRS
     "lib"
+  RUNTIME_DEPS
+    ${THEROCK_BUNDLED_LIBDRM}
 )
 therock_cmake_subproject_glob_c_sources(rocm_smi_lib
   SUBDIRS

--- a/base/post_hook_rocm_smi_lib.cmake
+++ b/base/post_hook_rocm_smi_lib.cmake
@@ -1,0 +1,6 @@
+target_include_directories(rocm_smi64 PUBLIC
+  "$<INSTALL_INTERFACE:lib/rocm_sysdeps/include>"
+)
+target_include_directories(oam PUBLIC
+  "$<INSTALL_INTERFACE:lib/rocm_sysdeps/include>"
+)

--- a/base/pre_hook_rocm_smi_lib.cmake
+++ b/base/pre_hook_rocm_smi_lib.cmake
@@ -1,0 +1,1 @@
+set(CMAKE_INSTALL_RPATH "$ORIGIN;$ORIGIN/llvm/lib;$ORIGIN/rocm_sysdeps/lib")

--- a/build_tools/save_patches.sh
+++ b/build_tools/save_patches.sh
@@ -34,7 +34,7 @@ fi
 # Directories.
 patch_dir="$root_dir/patches/$patch_subdir/$project_name"
 mkdir -p $patch_dir
-source_dir="$root_dir/sources/$project_name"
+source_dir="$(git config --file $root_dir/.gitmodules --get submodule.${project_name}.path)"
 if ! [ -d "$source_dir" ]; then
   echo "Source directory not found: $source_dir"
   exit 1

--- a/cmake/therock_subproject_dep_provider.cmake
+++ b/cmake/therock_subproject_dep_provider.cmake
@@ -25,6 +25,7 @@ block()
       string(APPEND _accum "${_dir}")
     endforeach()
     set(ENV{PKG_CONFIG_PATH} "${_accum}${_sep}$ENV{PKG_CONFIG_PATH}")
+    message(STATUS "Sub-project PKG_CONFIG_PATH: $ENV{PKG_CONFIG_PATH}")
   endif()
 endblock()
 

--- a/dockerfiles/pytorch-dev/build_rocm.sh
+++ b/dockerfiles/pytorch-dev/build_rocm.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+time cmake -GNinja -S/therock/src -B /therock/build \
+  -DTHEROCK_BUNDLE_SYSDEPS=ON \
+  -DTHEROCK_ENABLE_ALL=ON \
+  -DTHEROCK_AMDGPU_FAMILIES=gfx1100
+cmake --build /therock/build
+ctest --test-dir /therock/build

--- a/dockerfiles/pytorch-dev/build_rocm.sh
+++ b/dockerfiles/pytorch-dev/build_rocm.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
 
+AMDGPU_TARGETS="${1:?Must define --build-arg AMDGPU_TARGETS=gfxZZZZ}"
+
 time cmake -GNinja -S/therock/src -B /therock/build \
   -DTHEROCK_BUNDLE_SYSDEPS=ON \
   -DTHEROCK_ENABLE_ALL=ON \
-  -DTHEROCK_AMDGPU_FAMILIES=gfx1100
+  -DTHEROCK_AMDGPU_DIST_BUNDLE_NAME=custom \
+  "-DTHEROCK_AMDGPU_TARGETS=$AMDGPU_TARGETS"
 cmake --build /therock/build
 ctest --test-dir /therock/build

--- a/dockerfiles/pytorch-dev/pytorch_dev_ubuntu_24.04.Dockerfile
+++ b/dockerfiles/pytorch-dev/pytorch_dev_ubuntu_24.04.Dockerfile
@@ -1,15 +1,17 @@
 # Multi-stage build which builds rocm, then pytorch, and finally produces
 # a docker image with the built pytorch installed.
 # Build with:
-#   docker buildx build --file dockerfiles/pytorch-dev/pytorch_dev_ubuntu_24.04.Dockerfile .
+#   docker buildx --build-arg AMDGPU_TARGETS=gfx1100 \
+#     --file dockerfiles/pytorch-dev/pytorch_dev_ubuntu_24.04.Dockerfile .
 FROM ubuntu:24.04 AS build_rocm
+ARG AMDGPU_TARGETS
 WORKDIR /
 RUN apt update && apt install -y \
   python3 python3-pip python3-pip-whl \
   gfortran git-lfs ninja-build cmake g++ pkg-config \
   xxd libgtest-dev patchelf automake
 # TODO: Remove once https://github.com/ROCm/TheRock/issues/160 is resolved.
-RUN apt install -y opengl-dev
+RUN apt install -y libgl-dev
 # TODO: Remove once https://github.com/ROCm/TheRock/issues/161 is resolved.
 RUN apt install -y python3-venv
 
@@ -18,4 +20,4 @@ RUN python3 -m pip install --break-system-packages \
 COPY dockerfiles/pytorch-dev/build_rocm.sh /
 # TODO: The ROCM components still output some things to the source dir. Remove
 # "rw" when fixed. See https://github.com/ROCm/TheRock/issues/159
-RUN --mount=type=bind,target=/therock/src,rw bash /build_rocm.sh
+RUN --mount=type=bind,target=/therock/src,rw bash /build_rocm.sh "$AMDGPU_TARGETS"

--- a/dockerfiles/pytorch-dev/pytorch_dev_ubuntu_24.04.Dockerfile
+++ b/dockerfiles/pytorch-dev/pytorch_dev_ubuntu_24.04.Dockerfile
@@ -1,0 +1,21 @@
+# Multi-stage build which builds rocm, then pytorch, and finally produces
+# a docker image with the built pytorch installed.
+# Build with:
+#   docker buildx build --file dockerfiles/pytorch-dev/pytorch_dev_ubuntu_24.04.Dockerfile .
+FROM ubuntu:24.04 AS build_rocm
+WORKDIR /
+RUN apt update && apt install -y \
+  python3 python3-pip python3-pip-whl \
+  gfortran git-lfs ninja-build cmake g++ pkg-config \
+  xxd libgtest-dev patchelf automake
+# TODO: Remove once https://github.com/ROCm/TheRock/issues/160 is resolved.
+RUN apt install -y opengl-dev
+# TODO: Remove once https://github.com/ROCm/TheRock/issues/161 is resolved.
+RUN apt install -y python3-venv
+
+RUN python3 -m pip install --break-system-packages \
+  CppHeaderParser==2.7.4 meson==1.7.0
+COPY dockerfiles/pytorch-dev/build_rocm.sh /
+# TODO: The ROCM components still output some things to the source dir. Remove
+# "rw" when fixed. See https://github.com/ROCm/TheRock/issues/159
+RUN --mount=type=bind,target=/therock/src,rw bash /build_rocm.sh

--- a/dockerfiles/pytorch-dev/pytorch_dev_ubuntu_24.04.Dockerfile
+++ b/dockerfiles/pytorch-dev/pytorch_dev_ubuntu_24.04.Dockerfile
@@ -21,3 +21,79 @@ COPY dockerfiles/pytorch-dev/build_rocm.sh /
 # TODO: The ROCM components still output some things to the source dir. Remove
 # "rw" when fixed. See https://github.com/ROCm/TheRock/issues/159
 RUN --mount=type=bind,target=/therock/src,rw bash /build_rocm.sh "$AMDGPU_TARGETS"
+
+
+################################################################################
+# PyTorch sources
+################################################################################
+
+FROM ubuntu:24.04 AS pytorch_sources
+WORKDIR /
+
+RUN apt update && apt install -y \
+  python3 python3-pip python3-pip-whl python3-venv git \
+  ninja-build cmake g++ pkg-config && \
+  apt clean
+
+RUN git config --global user.email "you@example.com" && \
+    git config --global user.name "Your Name"
+
+# Prepare PyTorch sources. We do this in two steps so that we get an image
+# checkpoint with clean sources first (faster iteration).
+RUN --mount=type=bind,target=/therock/src \
+  python3 /therock/src/external-builds/pytorch/ptbuild.py checkout \
+    --repo /therock/pytorch --depth 1 --jobs 10 --no-patch --no-hipify
+RUN --mount=type=bind,target=/therock/src \
+  python3 /therock/src/external-builds/pytorch/ptbuild.py checkout \
+    --repo /therock/pytorch --depth 1 --jobs 10
+
+# Copy ROCM
+COPY --from=build_rocm /therock/build/dist/rocm /opt/rocm
+
+# Setup environment.
+ENV PATH="/opt/rocm/bin:$PATH"
+RUN (echo "/opt/rocm/lib" > /etc/ld.so.conf.d/rocm.conf) && \
+    (echo "/opt/rocm/lib/rocm_sysdeps/lib" >> /etc/ld.so.conf.d/rocm.conf) && \
+    ldconfig -v
+
+
+################################################################################
+# PyTorch Build
+################################################################################
+
+FROM pytorch_sources AS pytorch_build
+ARG AMDGPU_TARGETS
+
+RUN python3 -m pip install --break-system-packages -r /therock/pytorch/requirements.txt
+
+ENV CMAKE_PREFIX_PATH=/opt/rocm
+ENV USE_KINETO=OFF
+ENV PYTORCH_ROCM_ARCH=$AMDGPU_TARGETS
+
+WORKDIR /therock/pytorch
+RUN python3 setup.py bdist_wheel
+
+################################################################################
+# PyTorch Install
+################################################################################
+
+FROM ubuntu:24.04 AS pytorch
+
+RUN apt update && apt install -y \
+  python3 python3-pip python3-pip-whl python3-venv
+
+# Copy ROCM
+COPY --from=build_rocm /therock/build/dist/rocm /opt/rocm
+
+# Setup environment.
+ENV PATH="/opt/rocm/bin:$PATH"
+RUN (echo "/opt/rocm/lib" > /etc/ld.so.conf.d/rocm.conf) && \
+    (echo "/opt/rocm/lib/rocm_sysdeps/lib" >> /etc/ld.so.conf.d/rocm.conf) && \
+    ldconfig -v
+
+# Install pytorch.
+# TODO: It would be better to bind mount the prior stage somehow to avoid
+# leaving the wheel behind in a layer and wasting a half gig.
+COPY --from=pytorch_build /therock/pytorch/dist/torch-*.whl /wheels
+RUN python3 -m pip install --break-system-packages /wheels/torch-*.whl && \
+    rm -Rf /wheels

--- a/external-builds/pytorch/ptbuild.py
+++ b/external-builds/pytorch/ptbuild.py
@@ -221,14 +221,16 @@ def do_checkout(args: argparse.Namespace):
         exec(["git", "remote", "add", "origin", args.pytorch_origin], cwd=repo_dir)
 
     # Fetch and checkout.
-    depth_args = []
+    fetch_args = []
     if args.depth is not None:
-        depth_args = ["--depth", str(args.depth)]
-    exec(["git", "fetch"] + depth_args + ["origin", args.pytorch_ref], cwd=repo_dir)
+        fetch_args.extend(["--depth", str(args.depth)])
+    if args.jobs:
+        fetch_args.extend(["-j", str(args.jobs)])
+    exec(["git", "fetch"] + fetch_args + ["origin", args.pytorch_ref], cwd=repo_dir)
     exec(["git", "checkout", "FETCH_HEAD"], cwd=repo_dir)
     exec(["git", "tag", "-f", TAG_UPSTREAM_DIFFBASE], cwd=repo_dir)
     exec(
-        ["git", "submodule", "update", "--init", "--recursive"] + depth_args,
+        ["git", "submodule", "update", "--init", "--recursive"] + fetch_args,
         cwd=repo_dir,
     )
     exec(
@@ -306,6 +308,7 @@ def main(cl_args: list[str]):
         "--pytorch-ref", default=default_tag, help="PyTorch ref/tag to checkout"
     )
     checkout_p.add_argument("--depth", type=int, help="Fetch depth")
+    checkout_p.add_argument("--jobs", type=int, help="Number of fetch jobs")
     checkout_p.add_argument(
         "--hipify",
         action=argparse.BooleanOptionalAction,

--- a/patches/amd-mainline/rocm_smi_lib/0001-Miscellaneous-CMake-fixes.patch
+++ b/patches/amd-mainline/rocm_smi_lib/0001-Miscellaneous-CMake-fixes.patch
@@ -1,0 +1,65 @@
+From a6ae01b094fb545c82baac8f4f6c332f0b1ea9c8 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Thu, 6 Mar 2025 14:39:58 -0800
+Subject: [PATCH] Miscellaneous CMake fixes.
+
+* Adds a `project` declaration (not having this is a big anti-pattern).
+* Changes the `CMAKE_MODULE_PATH` setup to be based on `list(PREPEND`. It is completely reasonable for a super-project to set `CMAKE_MODULE_PATH` and that should not influence whether the project sets up its own path. Note that PREPEND vs APPEND was chosen because the project also includes an unqualified `utils.cmake`, which is an overly broad name and is an anti-pattern. Project maintainers should properly scope their CMake file names and should change this directive to APPEND.
+* Adds libdrm include directories to `librocm_smi64` and `liboam`. This is needed in situations where a non-system libdrm is being used.
+---
+ CMakeLists.txt          | 6 ++----
+ oam/CMakeLists.txt      | 2 ++
+ rocm_smi/CMakeLists.txt | 2 ++
+ 3 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 129a5ce..7b1643b 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,15 +2,13 @@
+ # Minimum version of cmake and C++ required
+ #
+ cmake_minimum_required(VERSION 3.14)
++project(rocm_smi_lib)
+ 
+ set(ROCM_SMI_LIBS_TARGET "rocm_smi_libraries")
+ 
+ set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared library (.so) or not.")
+ 
+-## Set default module path if not already set
+-if(NOT DEFINED CMAKE_MODULE_PATH)
+-    set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+-endif()
++list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
+ ## Include common cmake modules
+ include(utils)
+ 
+diff --git a/oam/CMakeLists.txt b/oam/CMakeLists.txt
+index 4789bd4..aaf72ab 100644
+--- a/oam/CMakeLists.txt
++++ b/oam/CMakeLists.txt
+@@ -94,6 +94,8 @@ endif ()
+ # use the target_include_directories() command to specify the include directories for the target
+ target_include_directories(${OAM_TARGET}
+                            PUBLIC
++                           "$<BUILD_INTERFACE:${DRM_INCLUDE_DIRS}>"
++                           "$<BUILD_INTERFACE:${AMDGPU_DRM_INCLUDE_DIRS}>"
+                            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                            "$<INSTALL_INTERFACE:{OAM_NAME}/include>")
+ 
+diff --git a/rocm_smi/CMakeLists.txt b/rocm_smi/CMakeLists.txt
+index 75070a2..6c0cdfe 100755
+--- a/rocm_smi/CMakeLists.txt
++++ b/rocm_smi/CMakeLists.txt
+@@ -88,6 +88,8 @@ target_include_directories(${ROCM_SMI_TARGET} PRIVATE
+ # use the target_include_directories() command to specify the include directories for the target
+ target_include_directories(${ROCM_SMI_TARGET}
+                            PUBLIC
++                           "$<BUILD_INTERFACE:${DRM_INCLUDE_DIRS}>"
++                           "$<BUILD_INTERFACE:${AMDGPU_DRM_INCLUDE_DIRS}>"
+                            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+ )
+-- 
+2.43.0
+

--- a/third-party/sysdeps/common/sqlite3/CMakeLists.txt
+++ b/third-party/sysdeps/common/sqlite3/CMakeLists.txt
@@ -70,6 +70,7 @@ if(NOT WIN32)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libsqlite3.so TYPE LIB)
 endif()
 install(FILES "${SOURCE_DIR}/sqlite3.h" TYPE INCLUDE)
+install(FILES "${SOURCE_DIR}/sqlite3ext.h" TYPE INCLUDE)
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/sqlite3-config.cmake.in


### PR DESCRIPTION
Includes a number of fixes that were found upon building in a more stripped down docker container.

* Make rocm_smi_lib depend on the bundled libdrm.
* Patch rocm_smi_lib to fix some poor hygiene issues that were being masked because the project did not contain a `project` declaration (which the super-project uses for integration).
* Report the PKG_CONFIG_PATH in sub-projects.
* sqlite3ext.h header needs to be exported.

Fixes #162
