### PR TITLE
Build `prim_test` artifact

### DIFF
--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -78,6 +78,7 @@ if(THEROCK_ENABLE_PRIM)
       -DHIP_PLATFORM=amd
       -DROCM_PATH=
       -DROCM_DIR=
+      -DBUILD_TEST=ON
     COMPILER_TOOLCHAIN
       amd-hip
     RUNTIME_DEPS
@@ -97,6 +98,7 @@ if(THEROCK_ENABLE_PRIM)
       -DHIP_PLATFORM=amd
       -DROCM_PATH=
       -DROCM_DIR=
+      -DBUILD_TEST=ON
     COMPILER_TOOLCHAIN
       amd-hip
     RUNTIME_DEPS
@@ -118,6 +120,7 @@ if(THEROCK_ENABLE_PRIM)
       -DHIP_PLATFORM=amd
       -DROCM_PATH=
       -DROCM_DIR=
+      -DBUILD_TEST=ON
     COMPILER_TOOLCHAIN
       amd-hip
     RUNTIME_DEPS
@@ -137,6 +140,7 @@ if(THEROCK_ENABLE_PRIM)
     COMPONENTS
       dev
       doc
+      test
     SUBPROJECT_DEPS rocPRIM hipCUB rocThrust
   )
 endif(THEROCK_ENABLE_PRIM)

--- a/math-libs/artifact-prim.toml
+++ b/math-libs/artifact-prim.toml
@@ -1,11 +1,27 @@
 # rocPRIM
 [components.dev."math-libs/rocPRIM/stage"]
 [components.doc."math-libs/rocPRIM/stage"]
+[components.test."math-libs/rocPRIM/stage"]
+include = [
+  "bin/test_*",
+  "bin/rocprim/CTestTestfile.cmake",
+]
 
 # hipCUB
 [components.dev."math-libs/hipCUB/stage"]
 [components.doc."math-libs/hipCUB/stage"]
+[components.test."math-libs/hipCUB/stage"]
+include = [
+  "bin/test_*",
+  "bin/hipcub/CTestTestfile.cmake",
+]
 
 # rocThrust
 [components.dev."math-libs/rocThrust/stage"]
 [components.doc."math-libs/rocThrust/stage"]
+[components.test."math-libs/rocThrust/stage"]
+include = [
+  "bin/test_*",
+  "bin/*.hip",
+  "bin/rocthrust/CTestTestfile.cmake",
+]


### PR DESCRIPTION
Builds tests for rocPRIM, hipCUB and rocThrust which get bundled in the `prim_test` artifact.

Closes #175 