### PR TITLE
Introduce `hash_util` helper

### DIFF
--- a/build_tools/_therock_utils/hash_util.py
+++ b/build_tools/_therock_utils/hash_util.py
@@ -1,0 +1,24 @@
+import hashlib
+
+
+def calculate_hash(file, hash_algorithm):
+    with open(file, "rb") as f:
+        try:
+            digest = hashlib.file_digest(f, hash_algorithm)
+        except AttributeError:  # file_digest() was added in Python 3.11.
+            digest = hashlib.new(hash_algorithm)
+            buffer = bytearray(2**16)
+            view = memoryview(buffer)
+            while True:
+                size = f.readinto(buffer)
+                if size == 0:
+                    break
+                digest.update(view[:size])
+
+    return digest
+
+
+def write_hash(hash_file, digest):
+    with open(hash_file, "wt") as f:
+        f.write(digest.hexdigest())
+        f.write("\n")

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -15,13 +15,13 @@ with the following changes:
 
 from typing import Callable
 import argparse
-import hashlib
 import os
 from pathlib import Path, PurePosixPath
 import sys
 import shutil
 import tarfile
 
+from _therock_utils.hash_util import calculate_hash, write_hash
 from _therock_utils.pattern_match import PatternMatcher
 
 
@@ -221,22 +221,8 @@ def do_artifact_archive(args):
                     arc.add(dir_entry.path, arcname=fullpath, recursive=False)
 
     if args.hash_file:
-        with open(output_path, "rb") as f:
-            try:
-                digest = hashlib.file_digest(f, args.hash_algorithm)
-            except AttributeError:  # file_digest() was added in Python 3.11.
-                digest = hashlib.new(args.hash_algorithm)
-                buffer = bytearray(2**16)
-                view = memoryview(buffer)
-                while True:
-                    size = f.readinto(buffer)
-                    if size == 0:
-                        break
-                    digest.update(view[:size])
-
-        with open(args.hash_file, "wt") as hash_file:
-            hash_file.write(digest.hexdigest())
-            hash_file.write("\n")
+        digest = calculate_hash(output_path, args.hash_algorithm)
+        write_hash(args.hash_file, digest)
 
 
 def _open_archive(p: Path) -> tarfile.TarFile:

--- a/build_tools/tests/_therock_utils
+++ b/build_tools/tests/_therock_utils
@@ -1,0 +1,1 @@
+../_therock_utils/

--- a/build_tools/tests/_therock_utils
+++ b/build_tools/tests/_therock_utils
@@ -1,1 +1,0 @@
-../_therock_utils/

--- a/build_tools/tests/fileset_tool_test.py
+++ b/build_tools/tests/fileset_tool_test.py
@@ -8,6 +8,8 @@ import sys
 import tempfile
 import unittest
 
+from _therock_utils.hash_util import calculate_hash
+
 FILESET_TOOL = Path(__file__).parent.parent / "fileset_tool.py"
 
 ARTIFACT_DESCRIPTOR_1 = r"""
@@ -135,8 +137,7 @@ class FilesetToolTest(unittest.TestCase):
         )
 
         # Verify digest.
-        with open(artifact_archive, "rb") as f:
-            expected_digest = hashlib.file_digest(f, "sha256").hexdigest()
+        expected_digest = calculate_hash(artifact_archive, "sha256").hexdigest()
         actual_digest = hash_file.read_text().strip()
         self.assertEqual(expected_digest, actual_digest)
 

--- a/build_tools/tests/fileset_tool_test.py
+++ b/build_tools/tests/fileset_tool_test.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 import unittest
 
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 from _therock_utils.hash_util import calculate_hash
 
 FILESET_TOOL = Path(__file__).parent.parent / "fileset_tool.py"


### PR DESCRIPTION
Moves hashlib helpers to `hash_util.py` and adds a test for calculating the hash of a file.