### PR TITLE
Build rocThrust tests

### DIFF
--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -118,6 +118,7 @@ if(THEROCK_ENABLE_PRIM)
       -DHIP_PLATFORM=amd
       -DROCM_PATH=
       -DROCM_DIR=
+      -DBUILD_TEST=ON
     COMPILER_TOOLCHAIN
       amd-hip
     RUNTIME_DEPS
@@ -137,6 +138,7 @@ if(THEROCK_ENABLE_PRIM)
     COMPONENTS
       dev
       doc
+      test
     SUBPROJECT_DEPS rocPRIM hipCUB rocThrust
   )
 endif(THEROCK_ENABLE_PRIM)

--- a/math-libs/artifact-prim.toml
+++ b/math-libs/artifact-prim.toml
@@ -9,3 +9,9 @@
 # rocThrust
 [components.dev."math-libs/rocThrust/stage"]
 [components.doc."math-libs/rocThrust/stage"]
+[components.test."math-libs/rocThrust/stage"]
+include = [
+  "bin/test_*",
+  "bin/*.hip",
+  "bin/rocthrust/CTestTestfile.cmake",
+]


### PR DESCRIPTION
Builds tests for rocThrust and add them to the prim-tests artifact.