### PR TITLE
Refactor to enable hipBLASLt finding CBLAS

### DIFF
--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -61,6 +61,7 @@ therock_cmake_subproject_declare(hipBLASLt
     therock-msgpack-cxx
   RUNTIME_DEPS
     hip-clr
+    therock-host-blas
 )
 therock_cmake_subproject_glob_c_sources(hipBLASLt
 SUBDIRS

--- a/third-party/host-blas/CMakeLists.txt
+++ b/third-party/host-blas/CMakeLists.txt
@@ -2,42 +2,68 @@
 # This will be extended later, including allowing to use the system BLAS of
 # your choice.
 
-therock_subproject_fetch(therock-OpenBLAS-sources
-  CMAKE_PROJECT
-  # Originally mirrored from: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.29/OpenBLAS-0.3.29.tar.gz
-  URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/OpenBLAS-0.3.29.tar.gz
-  URL_HASH SHA256=38240eee1b29e2bde47ebb5d61160207dc68668a54cac62c076bb5032013b1eb
-  # Originally posted MD5 was recomputed as SHA256 manually:
-  # URL_HASH MD5=853a0c5c0747c5943e7ef4bbb793162d
-)
+if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    # When included in TheRock, we download sources and set up the sub-project.
+    set(_source_dir "${CMAKE_CURRENT_BINARY_DIR}/source")
+    set(_download_stamp "${_source_dir}/download.stamp")
 
-therock_cmake_subproject_declare(therock-host-blas
-  BACKGROUND_BUILD
-  EXCLUDE_FROM_ALL
-  NO_MERGE_COMPILE_COMMANDS
-  OUTPUT_ON_FAILURE
-  EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
-  INSTALL_DESTINATION "lib/host-math"
-  INTERFACE_LINK_DIRS "lib/host-math/lib"
-  CMAKE_ARGS
-    -DBUILD_SHARED_LIBS=ON
-    # TODO: DYNAMIC_ARCH=ON produces illegal elf files
-    # See: https://github.com/ROCm/TheRock/issues/83
-    -DDYNAMIC_ARCH=OFF
-    -DC_LAPACK=ON
-    -DBUILD_TESTING=OFF
-)
-therock_cmake_subproject_provide_package(therock-host-blas OpenBLAS lib/host-math/lib/cmake/OpenBLAS)
-therock_cmake_subproject_activate(therock-host-blas)
+    therock_subproject_fetch(therock-OpenBLAS-sources
+      CMAKE_PROJECT
+      SOURCE_DIR "${_source_dir}"
+      # Originally mirrored from: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.29/OpenBLAS-0.3.29.tar.gz
+      URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/OpenBLAS-0.3.29.tar.gz
+      URL_HASH SHA256=38240eee1b29e2bde47ebb5d61160207dc68668a54cac62c076bb5032013b1eb
+      # Originally posted MD5 was recomputed as SHA256 manually:
+      # URL_HASH MD5=853a0c5c0747c5943e7ef4bbb793162d
+      TOUCH "${_download_stamp}"
+    )
 
-therock_provide_artifact(host-blas
-  DESCRIPTOR artifact-host-OpenBLAS.toml
-  TARGET_NEUTRAL
-  COMPONENTS
-    dbg
-    dev
-    doc
-    lib
-    run
-  SUBPROJECT_DEPS therock-host-blas
+    therock_cmake_subproject_declare(therock-host-blas
+      BACKGROUND_BUILD
+      EXCLUDE_FROM_ALL
+      NO_MERGE_COMPILE_COMMANDS
+      OUTPUT_ON_FAILURE
+      EXTERNAL_SOURCE_DIR .
+      INSTALL_DESTINATION "lib/host-math"
+      INTERFACE_LINK_DIRS "lib/host-math/lib"
+      CMAKE_ARGS
+        "-DSOURCE_DIR=${_source_dir}"
+        -DBUILD_SHARED_LIBS=ON
+        # TODO: DYNAMIC_ARCH=ON produces illegal elf files
+        # See: https://github.com/ROCm/TheRock/issues/83
+        -DDYNAMIC_ARCH=OFF
+        -DC_LAPACK=ON
+        -DBUILD_TESTING=OFF
+      EXTRA_DEPENDS
+        "${_download_stamp}"
+    )
+    therock_cmake_subproject_provide_package(therock-host-blas OpenBLAS lib/host-math/lib/cmake/OpenBLAS)
+    therock_cmake_subproject_provide_package(therock-host-blas cblas lib/host-math/lib/cmake/OpenBLAS)
+    therock_cmake_subproject_activate(therock-host-blas)
+
+    therock_provide_artifact(host-blas
+      DESCRIPTOR artifact-host-OpenBLAS.toml
+      TARGET_NEUTRAL
+      COMPONENTS
+        dbg
+        dev
+        doc
+        lib
+        run
+      SUBPROJECT_DEPS therock-host-blas
+    )
+    return()
+endif()
+
+# Otherwise, this is the sub-project build.
+cmake_minimum_required(VERSION 3.25)
+project(OpenBLAS_BUILD)
+
+add_subdirectory(${SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/build-openblas)
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cblas-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/cblas-config.cmake
+  @ONLY
 )
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cblas-config.cmake" DESTINATION lib/cmake/OpenBLAS)

--- a/third-party/host-blas/cblas-config.cmake.in
+++ b/third-party/host-blas/cblas-config.cmake.in
@@ -1,0 +1,18 @@
+# Traverse from lib/cmake/FOO -> the directory holding lib
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+if(_IMPORT_PREFIX STREQUAL "/")
+  set(_IMPORT_PREFIX "")
+endif()
+
+if(NOT TARGET cblas)
+  add_library(cblas SHARED IMPORTED)
+  set_target_properties(cblas PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/openblas"
+    IMPORTED_LOCATION "${_IMPORT_PREFIX}/lib/libopenblas.so"
+  )
+  set(CBLAS_LIBRARIES cblas)
+endif()
+
+set(_IMPORT_PREFIX)


### PR DESCRIPTION
Refactors the host-blas CMake configuration and adds a config file to enable hipBLASLt finding cblas via `find_package()` in pure Config mode.