### PR TITLE
Add initial contributor guidelines and current status of project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,11 @@
 # Contribute to TheRock
+
 We are enthusiastic about contributions to our code and documentation. For contribution guidelines
 to other parts of ROCM outside of **TheRock**, please see
 [CONTRIBUTING.md](https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md).
 
 ## Development workflow
+
 **TheRock** is focused on making it easy for developers to contribute. In order to facilitate this, 
 the source of truth for all issue tracking, project planning and code contributions are in GitHub and
 we leverage an open source stack for all development tools and infrastructure so that it they can be
@@ -20,15 +22,15 @@ already listed.
 
 General issue guidelines:
 
-* Use your best judgement for issue creation. If your issue is already listed, upvote the issue and
+- Use your best judgement for issue creation. If your issue is already listed, upvote the issue and
   comment or post to provide additional details, such as how you reproduced this issue.
-* If you're not sure if your issue is the same, err on the side of caution and file your issue.
+- If you're not sure if your issue is the same, err on the side of caution and file your issue.
   You can add a comment to include the issue number (and link) for the similar issue. If we evaluate
   your issue as being the same as the existing issue, we'll close the duplicate.
-* When filing an issue, be sure to provide as much information as possible, including script output so
+- When filing an issue, be sure to provide as much information as possible, including script output so
   we can collect information about your configuration. This helps reduce the time required to
   reproduce your issue.
-* Check your issue regularly, as we may require additional information to successfully reproduce the
+- Check your issue regularly, as we may require additional information to successfully reproduce the
   issue.
 
 ### Governance
@@ -40,11 +42,11 @@ This is currently covered by the
 
 When you create a pull request, you should target the *main* branch.
 
-* Identify the issue you want to fix
-* Target the main branch
-* Ensure your code has all workflows pass
-* Submit your PR and work with the reviewer or maintainer to get your PR approved
-  * If you don't know who to add to a PR as a maintainer, please review the git history to see recently approved PRs in the same file or folder.
+- Identify the issue you want to fix
+- Target the main branch
+- Ensure your code has all workflows pass
+- Submit your PR and work with the reviewer or maintainer to get your PR approved
+  - If you don't know who to add to a PR as a maintainer, please review the git history to see recently approved PRs in the same file or folder.
 
 > [!IMPORTANT]
 > By creating a PR, you agree to allow your contribution to be licensed under the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ functionality is lacking or even better volunteer to help contribute to help clo
 ### Issue tracking
 
 Before filing a new issue, search the
-[existing issues](https://github.com/ROCm/therock/issues) to make sure your issue isn't
+[existing issues](https://github.com/ROCm/TheRock/issues) to make sure your issue isn't
 already listed.
 
 General issue guidelines:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contribute to TheRock
+We are enthusiastic about contributions to our code and documentation. For contribution guidelines
+to other parts of ROCM outside of **TheRock**, please see
+[CONTRIBUTING.md](https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md).
+
+## Development workflow
+**TheRock** is focused on making it easy for developers to contribute. In order to facilitate this, 
+the source of truth for all issue tracking, project planning and code contributions are in GitHub and
+we leverage an open source stack for all development tools and infrastructure so that it they can be
+easily leveraged in any fork.
+
+The project is still in its early days, so please feel free to file bugs where documentation or
+functionality is lacking or even better volunteer to help contribute to help close these gaps!
+
+### Issue tracking
+
+Before filing a new issue, search the
+[existing issues](https://github.com/ROCm/therock/issues) to make sure your issue isn't
+already listed.
+
+General issue guidelines:
+
+* Use your best judgement for issue creation. If your issue is already listed, upvote the issue and
+  comment or post to provide additional details, such as how you reproduced this issue.
+* If you're not sure if your issue is the same, err on the side of caution and file your issue.
+  You can add a comment to include the issue number (and link) for the similar issue. If we evaluate
+  your issue as being the same as the existing issue, we'll close the duplicate.
+* When filing an issue, be sure to provide as much information as possible, including script output so
+  we can collect information about your configuration. This helps reduce the time required to
+  reproduce your issue.
+* Check your issue regularly, as we may require additional information to successfully reproduce the
+  issue.
+
+### Governance
+
+This is currently covered by the
+[ROCM project Governance](https://github.com/ROCm/ROCm/blob/develop/GOVERNANCE.md).
+
+### Pull requests
+
+When you create a pull request, you should target the *main* branch.
+
+* Identify the issue you want to fix
+* Target the main branch
+* Ensure your code has all workflows pass
+* Submit your PR and work with the reviewer or maintainer to get your PR approved
+  * If you don't know who to add to a PR as a maintainer, please review the git history to see recently approved PRs in the same file or folder.
+
+> [!IMPORTANT]
+> By creating a PR, you agree to allow your contribution to be licensed under the
+> terms of the [LICENSE](LICENSE) file.
+
+### New feature development
+
+For now, please file a new issue to discuss a new feature. We are considering switching to GitHub
+discussions in the future.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ to other parts of ROCM outside of **TheRock**, please see
 
 ## Development workflow
 
-**TheRock** is focused on making it easy for developers to contribute. In order to facilitate this, 
+**TheRock** is focused on making it easy for developers to contribute. In order to facilitate this,
 the source of truth for all issue tracking, project planning and code contributions are in GitHub and
 we leverage an open source stack for all development tools and infrastructure so that it they can be
 easily leveraged in any fork.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # TheRock
 
-The HIP Environment and ROCm Kit - A lightweight open source build system for HIP and ROCm
+The HIP Environment and ROCm Kit - A lightweight open source build system for HIP and ROCm.
+
+We are currently in an **early preview state** but welcome contributors. Come try us out!
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for more info.
 
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 
@@ -106,6 +109,7 @@ separately.
 
 ## Development Manuals
 
+- [Contribution Guidelines](CONTRIBUTING.md): Documentation for the process of contributing to this project including a quick pointer to its governance.
 - [Development Guide](docs/development/development_guide.md): Documentation on how to use TheRock as a daily driver for developing any of its contained ROCm components (i.e. vs interacting with each component build individually).
 - [Build System](docs/development/build_system.md): More detailed information about TheRock's build system relevant to people looking to extend TheRock, add components, etc.
 - [Git Chores](docs/development/git_chores.md): Procedures for managing the codebase, specifically focused on version control, upstream/downstream, etc.


### PR DESCRIPTION
Mostly copied/reference parent contributor guidelines and added a quick pointer from the main readme.md. We really do need a quick release/user of existing artifacts though to make this complete