### PR TITLE
Enable building rocBLAS with client tests

### DIFF
--- a/base/post_hook_rocm_smi_lib.cmake
+++ b/base/post_hook_rocm_smi_lib.cmake
@@ -1,6 +1,6 @@
 target_include_directories(rocm_smi64 PUBLIC
-  "$<INSTALL_INTERFACE:lib/rocm_sysdeps/include>"
+  "$<INSTALL_INTERFACE:include>"
 )
 target_include_directories(oam PUBLIC
-  "$<INSTALL_INTERFACE:lib/rocm_sysdeps/include>"
+  "$<INSTALL_INTERFACE:include>"
 )

--- a/base/pre_hook_rocm_smi_lib.cmake
+++ b/base/pre_hook_rocm_smi_lib.cmake
@@ -1,1 +1,1 @@
-set(CMAKE_INSTALL_RPATH "$ORIGIN;$ORIGIN/llvm/lib;$ORIGIN/rocm_sysdeps/lib")
+set(CMAKE_INSTALL_RPATH "$ORIGIN;$ORIGIN/llvm/lib;$ORIGIN/lib")

--- a/base/pre_hook_rocm_smi_lib.cmake
+++ b/base/pre_hook_rocm_smi_lib.cmake
@@ -1,1 +1,1 @@
-set(CMAKE_INSTALL_RPATH "$ORIGIN;$ORIGIN/llvm/lib;$ORIGIN/lib")
+set(CMAKE_INSTALL_RPATH "$ORIGIN;$ORIGIN/llvm/lib;$ORIGIN/rocm_sysdeps/lib")

--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -89,7 +89,8 @@ therock_cmake_subproject_declare(rocBLAS
     # Since using a local Tensile vs fetched, unset TENSILE_VERSION to avoid
     # doing a strict check of exact version.
     -DTENSILE_VERSION=
-    # # TODO: Enable clients.
+    -DBUILD_CLIENTS_TESTS=ON
+    -DLINK_BLIS=OFF
   IGNORE_PACKAGES
       ROCM
   COMPILER_TOOLCHAIN
@@ -100,6 +101,7 @@ therock_cmake_subproject_declare(rocBLAS
   RUNTIME_DEPS
     hip-clr
     hipBLASLt
+    rocm_smi_lib
 )
 therock_cmake_subproject_glob_c_sources(rocBLAS
 SUBDIRS
@@ -289,5 +291,6 @@ therock_provide_artifact(blas
       doc
       lib
       run
+      test
   SUBPROJECT_DEPS ${_blas_subproject_names}
 )

--- a/math-libs/BLAS/artifact-blas.toml
+++ b/math-libs/BLAS/artifact-blas.toml
@@ -24,6 +24,13 @@ include = [
 [components.dev."math-libs/BLAS/rocBLAS/stage"]
 [components.doc."math-libs/BLAS/rocBLAS/stage"]
 [components.lib."math-libs/BLAS/rocBLAS/stage"]
+[components.test."math-libs/BLAS/rocBLAS/stage"]
+include = [
+  "bin/rocblas-test",
+  "bin/rocblas_gentest.py",
+  "bin/rocblas_gtest.data",
+  "bin/rocblas_*.yaml",
+]
 
 # rocSOLVER
 [components.dbg."math-libs/BLAS/rocSOLVER/stage"]

--- a/patches/amd-mainline/rocBLAS/0002-Fix-handling-BLIS-and-finding-BLAS.patch
+++ b/patches/amd-mainline/rocBLAS/0002-Fix-handling-BLIS-and-finding-BLAS.patch
@@ -1,0 +1,43 @@
+From a83ae9e5534082e89bf14d45182187bb3e88f6f0 Mon Sep 17 00:00:00 2001
+From: Marius Brehler <marius.brehler@amd.com>
+Date: Wed, 12 Mar 2025 14:18:00 +0000
+Subject: [PATCH 2/3] Fix handling BLIS and finding BLAS
+
+* Fail if `LINK_BLIS` is set (defaults to `ON`) but the library is not
+  found. Fails otherwise at the end of the build when trying to link.
+* Switches to `find_package()` instead of assuming that the reference
+  BLAS is available without ANY check. This also allows to use OpenBLAS.
+---
+ clients/CMakeLists.txt | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/clients/CMakeLists.txt b/clients/CMakeLists.txt
+index 61942861..0c673368 100644
+--- a/clients/CMakeLists.txt
++++ b/clients/CMakeLists.txt
+@@ -140,10 +140,11 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
+         set( BLAS_LIBRARY /usr/local/lib/libblis.a )
+         set( BLIS_INCLUDE_DIR /usr/local/include/blis )
+       else()
+-        message( WARNING "Could not find libblis" )
++        message( FATAL_ERROR "Could not find libblis" )
+       endif()
+     else()
+-      set( BLAS_LIBRARY "blas" )
++      find_package( BLAS REQUIRED )
++      set( BLAS_LIBRARY "${BLAS_LIBRARIES}" )
+     endif()
+   else() # WIN32
+     file(TO_CMAKE_PATH "C:/Program\ Files/AMD/AOCL-Windows/amd-blis/lib/ILP64/AOCL-LibBlis-Win-MT.lib" AOCL_BLAS_LIBRARY)
+@@ -170,7 +171,7 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
+     set( BLIS_CPP ../common/blis_interface.cpp )
+   endif()
+ 
+-  message(STATUS "Linking Reference BLAS LIB: ${BLAS_LIBRARY}")
++  message(STATUS "Linking BLAS LIB: ${BLAS_LIBRARY}")
+ 
+   if ( WARN_NOT_ILP64_PREFERRED )
+     message( WARNING "Using ${BLAS_LIBRARY} as reference library, 64-bit tests may fail. Test suite should be run with --gtest_filter=-*stress*")
+-- 
+2.43.0
+

--- a/patches/amd-mainline/rocBLAS/0003-Find-rocm_smi-via-config-files.patch
+++ b/patches/amd-mainline/rocBLAS/0003-Find-rocm_smi-via-config-files.patch
@@ -1,0 +1,87 @@
+From 39193b497ddaae7c0bce1468cc7e4916db11848f Mon Sep 17 00:00:00 2001
+From: Marius Brehler <marius.brehler@amd.com>
+Date: Wed, 12 Mar 2025 14:26:45 +0000
+Subject: [PATCH 3/3] Find `rocm_smi` via config files
+
+Use the config files provided by upstream instead of a custom finder.
+---
+ clients/CMakeLists.txt          |  4 +--
+ clients/cmake/FindROCmSMI.cmake | 51 ---------------------------------
+ 2 files changed, 2 insertions(+), 53 deletions(-)
+ delete mode 100644 clients/cmake/FindROCmSMI.cmake
+
+diff --git a/clients/CMakeLists.txt b/clients/CMakeLists.txt
+index 0c673368..d92421ed 100644
+--- a/clients/CMakeLists.txt
++++ b/clients/CMakeLists.txt
+@@ -179,8 +179,8 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
+ 
+   # Find the package ROCmSMI
+   if(NOT WIN32)
+-      find_package(ROCmSMI REQUIRED)
+-      list( APPEND COMMON_LINK_LIBS rocm_smi )
++      find_package(rocm_smi CONFIG REQUIRED)
++      list( APPEND COMMON_LINK_LIBS rocm_smi64 )
+   endif()
+ 
+   find_package( GTest REQUIRED )
+diff --git a/clients/cmake/FindROCmSMI.cmake b/clients/cmake/FindROCmSMI.cmake
+deleted file mode 100644
+index 698f6884..00000000
+--- a/clients/cmake/FindROCmSMI.cmake
++++ /dev/null
+@@ -1,51 +0,0 @@
+-# ########################################################################
+-# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+-#
+-# Permission is hereby granted, free of charge, to any person obtaining a copy
+-# of this software and associated documentation files (the "Software"), to deal
+-# in the Software without restriction, including without limitation the rights
+-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+-# ies of the Software, and to permit persons to whom the Software is furnished
+-# to do so, subject to the following conditions:
+-#
+-# The above copyright notice and this permission notice shall be included in all
+-# copies or substantial portions of the Software.
+-#
+-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+-# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+-# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+-# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+-# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+-# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-#
+-# ########################################################################
+-
+-if(NOT ROCM_ROOT)
+-    if(NOT ROCM_DIR)
+-        set(ROCM_ROOT "/opt/rocm")
+-    else()
+-        set(ROCM_DIR "${ROCM_DIR}/../../..")
+-    endif()
+-endif()
+-
+-
+-# For some reason the *_DIR variables have inconsistent values between Tensile and rocBLAS.  Search various paths.
+-find_path(ROCM_SMI_ROOT "include/rocm_smi/rocm_smi.h"
+-    PATHS "${ROCM_ROOT}" "${HIP_DIR}/../../../.." "${HIP_DIR}/../../.."
+-    PATH_SUFFIXES "rocm_smi"
+-    )
+-mark_as_advanced(ROCM_SMI_ROOT)
+-
+-find_library(ROCM_SMI_LIBRARY rocm_smi64
+-    PATHS "${ROCM_SMI_ROOT}/lib")
+-mark_as_advanced(ROCM_SMI_LIBRARY)
+-
+-include( FindPackageHandleStandardArgs )
+-find_package_handle_standard_args( ROCmSMI DEFAULT_MSG ROCM_SMI_LIBRARY ROCM_SMI_ROOT )
+-
+-add_library(rocm_smi SHARED IMPORTED)
+-
+-set_target_properties(rocm_smi PROPERTIES
+-    INTERFACE_INCLUDE_DIRECTORIES "${ROCM_SMI_ROOT}/include"
+-    IMPORTED_LOCATION "${ROCM_SMI_LIBRARY}"
+-    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${ROCM_SMI_ROOT}/include")
+-- 
+2.43.0
+

--- a/patches/amd-mainline/rocBLAS/0004-Move-blas_ex-common_gemm_ex3-to-different-target.patch
+++ b/patches/amd-mainline/rocBLAS/0004-Move-blas_ex-common_gemm_ex3-to-different-target.patch
@@ -1,0 +1,40 @@
+From 73a3886215d132f602830e5627500dc8a91ead5d Mon Sep 17 00:00:00 2001
+From: Marius Brehler <marius.brehler@amd.com>
+Date: Wed, 12 Mar 2025 16:58:59 +0000
+Subject: [PATCH 4/4] Move `blas_ex/common_gemm_ex3` to different target
+
+`clients/common/blas_ex/common_gemm_ex3.cpp` pulls in cblas via
+`clients/common/common_helpers.hpp` ->
+`clients/common/testing_common.hpp` ->
+`clients/include/testing_common.hpp` ->
+`clients/include/cblas_interface.hpp` -> `cblas.h`
+
+While the `rocblas_clients_testing_common` target depends on BLAS,
+`rocblas_clients_common` does not. This therefore moves the source file
+to the former target. Both libraries get linked into one common
+executable in a later step.
+---
+ clients/common/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/clients/common/CMakeLists.txt b/clients/common/CMakeLists.txt
+index 8b56bf5f..f8e08c1a 100644
+--- a/clients/common/CMakeLists.txt
++++ b/clients/common/CMakeLists.txt
+@@ -158,11 +158,11 @@ if( BUILD_WITH_TENSILE )
+   )
+ endif()
+ 
+-add_library(rocblas_clients_common OBJECT ${rocblas_testing_common_tensile_source} ${rocblas_common_source})
++add_library(rocblas_clients_common OBJECT ${rocblas_common_source})
+ 
+ rocblas_client_library_settings( rocblas_clients_common )
+ 
+-add_library(rocblas_clients_testing_common OBJECT ${rocblas_testing_common_source})
++add_library(rocblas_clients_testing_common OBJECT ${rocblas_testing_common_tensile_source}  ${rocblas_testing_common_source})
+ 
+ rocblas_client_library_settings( rocblas_clients_testing_common )
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
Enables building rocBLAS with `BUILD_CLIENTS_TEST` set to `on`. Furthermore, adds a test artifact to which the client tests get bundled to.