### PR TITLE
Patch FindPython3 usage in rocFFT and hipFFT.

### DIFF
--- a/patches/amd-mainline/hipFFT/0001-PYTHON3_EXE-should-be-Python3_EXECUTABLE.-Either-way.patch
+++ b/patches/amd-mainline/hipFFT/0001-PYTHON3_EXE-should-be-Python3_EXECUTABLE.-Either-way.patch
@@ -1,0 +1,23 @@
+From 6df0ce0c602dfc1720eac78703f85a09038e70ab Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Wed, 12 Mar 2025 13:49:43 -0700
+Subject: [PATCH] PYTHON3_EXE should be Python3_EXECUTABLE. Either way, it is
+ unused.
+
+---
+ toolchain-windows.cmake | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/toolchain-windows.cmake b/toolchain-windows.cmake
+index f94d3c9..7364186 100644
+--- a/toolchain-windows.cmake
++++ b/toolchain-windows.cmake
+@@ -55,5 +55,3 @@ set(CMAKE_STATIC_LIBRARY_SUFFIX ".a")
+ set(CMAKE_STATIC_LIBRARY_PREFIX "static_")
+ set(CMAKE_SHARED_LIBRARY_SUFFIX ".dll")
+ set(CMAKE_SHARED_LIBRARY_PREFIX "")
+-
+-set(PYTHON3_EXE python)
+-- 
+2.47.1.windows.2
+

--- a/patches/amd-mainline/rocFFT/0001-Use-build-RPATH-correctly.patch
+++ b/patches/amd-mainline/rocFFT/0001-Use-build-RPATH-correctly.patch
@@ -1,7 +1,7 @@
-From 35fa8a14e252bcffd344a4591aff0adf8910ee88 Mon Sep 17 00:00:00 2001
+From e38f8dabef90545adab6b6feb2e1ea35776660b9 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Fri, 21 Feb 2025 13:02:46 -0800
-Subject: [PATCH 1/2] Use build RPATH correctly.
+Subject: [PATCH 1/3] Use build RPATH correctly.
 
 * Using BUILD_WITH_INSTALL_RPATH is *only* ever valid if the build and install trees share the same layout and both should have the same origin-relative setup. That is not the case here, and the proper thing to do is to rely on CMake to make sure that RPATHs for the build tree are absolute (which is its normal invariant) and to only use the install RPATH for install.
 * Hard-coding of an LD_LIBRARY_PATH to a presumed installed ROCM is not allowed and is dangerous. It is also not necessary if the build RPATHs are managed by CMake vs being overriden.
@@ -36,5 +36,5 @@ index b625209d..587a04a0 100644
      COMMENT "Compile kernels into shipped cache file"
    )
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocFFT/0002-Use-proper-casing-for-hip-and-hiprtc-packages.patch
+++ b/patches/amd-mainline/rocFFT/0002-Use-proper-casing-for-hip-and-hiprtc-packages.patch
@@ -1,7 +1,7 @@
-From f556a7c7b5be1ae61f43c0fa20a4fe8fded62777 Mon Sep 17 00:00:00 2001
+From 914b58be8d2826b61ff0f154aecf8bc559803cb7 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Fri, 21 Feb 2025 13:17:39 -0800
-Subject: [PATCH 2/2] Use proper casing for 'hip' and 'hiprtc' packages.
+Subject: [PATCH 2/3] Use proper casing for 'hip' and 'hiprtc' packages.
 
 * Package names are case-sensitive, and the name for both of these is lowercase.
 * There are situations where the wrong casing can be made to work (i.e. if you manually specify "-DHIP_DIR=" and "-DHIPRTC_DIR=" config vars with the wrong case, the search procedure will happen to work in this very narrow case, but it isn't right).
@@ -32,5 +32,5 @@ index 53873b78..9559e515 100644
  # The nvidia backend can be used to compile for CUDA devices.
  # Specify the CUDA prefix in the CUDA_PREFIX variable.
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocFFT/0003-Use-Python3_Executable-from-FindPython3-not-custom-P.patch
+++ b/patches/amd-mainline/rocFFT/0003-Use-Python3_Executable-from-FindPython3-not-custom-P.patch
@@ -1,0 +1,71 @@
+From af160679bf00c166861c06e0284eb6f659b84e37 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Wed, 12 Mar 2025 14:53:14 -0700
+Subject: [PATCH 3/3] Use Python3_Executable from FindPython3, not custom
+ PYTHON3_EXE.
+
+---
+ library/src/CMakeLists.txt        | 8 ++------
+ library/src/device/CMakeLists.txt | 2 +-
+ toolchain-windows.cmake           | 2 --
+ 3 files changed, 3 insertions(+), 9 deletions(-)
+
+diff --git a/library/src/CMakeLists.txt b/library/src/CMakeLists.txt
+index 587a04a0..29693469 100644
+--- a/library/src/CMakeLists.txt
++++ b/library/src/CMakeLists.txt
+@@ -84,10 +84,6 @@ include( GenerateExportHeader )
+ 
+ find_package (Python3 3.6 COMPONENTS Interpreter REQUIRED)
+ 
+-if( NOT DEFINED PYTHON3_EXE )
+-  set(PYTHON3_EXE python3)
+-endif()
+-
+ add_subdirectory( device )
+ 
+ #
+@@ -188,7 +184,7 @@ set( kgen_logic_files
+ 
+ add_custom_command(
+   OUTPUT ${kgen_embed_cpp}
+-  COMMAND ${PYTHON3_EXE} ${kgen_embed_command}
++  COMMAND ${Python3_EXECUTABLE}} ${kgen_embed_command}
+   --embed ${kgen_embed_files} --logic ${kgen_logic_files} --output ${kgen_embed_cpp}
+   DEPENDS ${kgen_embed_command} ${kgen_embed_files} ${kgen_logic_files}
+ )
+@@ -208,7 +204,7 @@ file(GLOB solution_map_files "${ROCFFT_SOLUTION_MAP_DIR}/*.dat")
+ 
+ add_custom_command(
+   OUTPUT ${gen_solutions}
+-  COMMAND ${PYTHON3_EXE} ${solship_py}
++  COMMAND ${Python3_EXECUTABLE}} ${solship_py}
+   --gpu-arch="${sol_gpu_arch}"
+   --data-folder=${ROCFFT_SOLUTION_MAP_DIR}
+   DEPENDS ${solution_map_files}
+diff --git a/library/src/device/CMakeLists.txt b/library/src/device/CMakeLists.txt
+index e1fb9247..6b0e8039 100644
+--- a/library/src/device/CMakeLists.txt
++++ b/library/src/device/CMakeLists.txt
+@@ -76,7 +76,7 @@ endforeach()
+ # Set LD_LIBRARY_PATH for running the executable from build directory
+ add_custom_command(OUTPUT function_pool.cpp
+   OUTPUT ${FUNCTION_POOLS}
+-  COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${ROCM_PATH}/${CMAKE_INSTALL_LIBDIR}" ${PYTHON3_EXE} ${kgen}
++  COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${ROCM_PATH}/${CMAKE_INSTALL_LIBDIR}" ${Python3_EXECUTABLE}} ${kgen}
+   --runtime-compile-default=${ROCFFT_RUNTIME_COMPILE_DEFAULT}
+   --num-files=${ROCFFT_FUNCTION_POOL_N}
+   generate $<TARGET_FILE:stockham_gen>
+diff --git a/toolchain-windows.cmake b/toolchain-windows.cmake
+index 1a8361bb..93ee4d91 100644
+--- a/toolchain-windows.cmake
++++ b/toolchain-windows.cmake
+@@ -55,5 +55,3 @@ set(CMAKE_STATIC_LIBRARY_SUFFIX ".a")
+ set(CMAKE_STATIC_LIBRARY_PREFIX "static_")
+ set(CMAKE_SHARED_LIBRARY_SUFFIX ".dll")
+ set(CMAKE_SHARED_LIBRARY_PREFIX "")
+-
+-set(PYTHON3_EXE python)
+-- 
+2.47.1.windows.2
+

--- a/patches/amd-mainline/rocFFT/0003-Use-Python3_Executable-from-FindPython3-not-custom-P.patch
+++ b/patches/amd-mainline/rocFFT/0003-Use-Python3_Executable-from-FindPython3-not-custom-P.patch
@@ -15,18 +15,18 @@ index 587a04a0..29693469 100644
 --- a/library/src/CMakeLists.txt
 +++ b/library/src/CMakeLists.txt
 @@ -84,10 +84,6 @@ include( GenerateExportHeader )
-
+ 
  find_package (Python3 3.6 COMPONENTS Interpreter REQUIRED)
-
+ 
 -if( NOT DEFINED PYTHON3_EXE )
 -  set(PYTHON3_EXE python3)
 -endif()
 -
  add_subdirectory( device )
-
+ 
  #
 @@ -188,7 +184,7 @@ set( kgen_logic_files
-
+ 
  add_custom_command(
    OUTPUT ${kgen_embed_cpp}
 -  COMMAND ${PYTHON3_EXE} ${kgen_embed_command}
@@ -35,7 +35,7 @@ index 587a04a0..29693469 100644
    DEPENDS ${kgen_embed_command} ${kgen_embed_files} ${kgen_logic_files}
  )
 @@ -208,7 +204,7 @@ file(GLOB solution_map_files "${ROCFFT_SOLUTION_MAP_DIR}/*.dat")
-
+ 
  add_custom_command(
    OUTPUT ${gen_solutions}
 -  COMMAND ${PYTHON3_EXE} ${solship_py}
@@ -66,6 +66,6 @@ index 1a8361bb..93ee4d91 100644
  set(CMAKE_SHARED_LIBRARY_PREFIX "")
 -
 -set(PYTHON3_EXE python)
---
+-- 
 2.47.1.windows.2
 

--- a/patches/amd-mainline/rocFFT/0003-Use-Python3_Executable-from-FindPython3-not-custom-P.patch
+++ b/patches/amd-mainline/rocFFT/0003-Use-Python3_Executable-from-FindPython3-not-custom-P.patch
@@ -15,18 +15,18 @@ index 587a04a0..29693469 100644
 --- a/library/src/CMakeLists.txt
 +++ b/library/src/CMakeLists.txt
 @@ -84,10 +84,6 @@ include( GenerateExportHeader )
- 
+
  find_package (Python3 3.6 COMPONENTS Interpreter REQUIRED)
- 
+
 -if( NOT DEFINED PYTHON3_EXE )
 -  set(PYTHON3_EXE python3)
 -endif()
 -
  add_subdirectory( device )
- 
+
  #
 @@ -188,7 +184,7 @@ set( kgen_logic_files
- 
+
  add_custom_command(
    OUTPUT ${kgen_embed_cpp}
 -  COMMAND ${PYTHON3_EXE} ${kgen_embed_command}
@@ -35,7 +35,7 @@ index 587a04a0..29693469 100644
    DEPENDS ${kgen_embed_command} ${kgen_embed_files} ${kgen_logic_files}
  )
 @@ -208,7 +204,7 @@ file(GLOB solution_map_files "${ROCFFT_SOLUTION_MAP_DIR}/*.dat")
- 
+
  add_custom_command(
    OUTPUT ${gen_solutions}
 -  COMMAND ${PYTHON3_EXE} ${solship_py}
@@ -66,6 +66,6 @@ index 1a8361bb..93ee4d91 100644
  set(CMAKE_SHARED_LIBRARY_PREFIX "")
 -
 -set(PYTHON3_EXE python)
--- 
+--
 2.47.1.windows.2
 

--- a/patches/amd-mainline/rocFFT/0003-Use-Python3_Executable-from-FindPython3-not-custom-P.patch
+++ b/patches/amd-mainline/rocFFT/0003-Use-Python3_Executable-from-FindPython3-not-custom-P.patch
@@ -30,7 +30,7 @@ index 587a04a0..29693469 100644
  add_custom_command(
    OUTPUT ${kgen_embed_cpp}
 -  COMMAND ${PYTHON3_EXE} ${kgen_embed_command}
-+  COMMAND ${Python3_EXECUTABLE}} ${kgen_embed_command}
++  COMMAND ${Python3_EXECUTABLE} ${kgen_embed_command}
    --embed ${kgen_embed_files} --logic ${kgen_logic_files} --output ${kgen_embed_cpp}
    DEPENDS ${kgen_embed_command} ${kgen_embed_files} ${kgen_logic_files}
  )
@@ -39,7 +39,7 @@ index 587a04a0..29693469 100644
  add_custom_command(
    OUTPUT ${gen_solutions}
 -  COMMAND ${PYTHON3_EXE} ${solship_py}
-+  COMMAND ${Python3_EXECUTABLE}} ${solship_py}
++  COMMAND ${Python3_EXECUTABLE} ${solship_py}
    --gpu-arch="${sol_gpu_arch}"
    --data-folder=${ROCFFT_SOLUTION_MAP_DIR}
    DEPENDS ${solution_map_files}
@@ -52,7 +52,7 @@ index e1fb9247..6b0e8039 100644
  add_custom_command(OUTPUT function_pool.cpp
    OUTPUT ${FUNCTION_POOLS}
 -  COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${ROCM_PATH}/${CMAKE_INSTALL_LIBDIR}" ${PYTHON3_EXE} ${kgen}
-+  COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${ROCM_PATH}/${CMAKE_INSTALL_LIBDIR}" ${Python3_EXECUTABLE}} ${kgen}
++  COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${ROCM_PATH}/${CMAKE_INSTALL_LIBDIR}" ${Python3_EXECUTABLE} ${kgen}
    --runtime-compile-default=${ROCFFT_RUNTIME_COMPILE_DEFAULT}
    --num-files=${ROCFFT_FUNCTION_POOL_N}
    generate $<TARGET_FILE:stockham_gen>


### PR DESCRIPTION
If https://cmake.org/cmake/help/latest/module/FindPython3.html succeeds (and it must, given the `REQUIRED` argument), the `Python3_EXECUTABLE` result variable will be set. This should be used instead of a custom `PYTHON3_EXE` variable. Fixing this allows for these projects to get further in the configure step on Windows when not using the provided `toolchain-windows.cmake` files.