### PR TITLE
Revert change to rocm_smi_lib post_hook

### DIFF
--- a/base/post_hook_rocm_smi_lib.cmake
+++ b/base/post_hook_rocm_smi_lib.cmake
@@ -1,6 +1,6 @@
 target_include_directories(rocm_smi64 PUBLIC
-  "$<INSTALL_INTERFACE:include>"
+  "$<INSTALL_INTERFACE:lib/rocm_sysdeps/include>"
 )
 target_include_directories(oam PUBLIC
-  "$<INSTALL_INTERFACE:include>"
+  "$<INSTALL_INTERFACE:lib/rocm_sysdeps/include>"
 )


### PR DESCRIPTION
This was changed with commit a8d40a7 and is now restored. It unbreaks building with `THEROCK_BUNDLE_SYSDEPS=ON` if libdrm and libnuma headers are not available on the systems.

Unfortunatly, it breaks `THEROCK_BUNDLE_SYSDEPS=OFF`:
```
[hipBLASLt configure] CMake Error in clients/gtest/CMakeLists.txt:
[hipBLASLt configure]   Imported target "rocm_smi64" includes non-existent path
[hipBLASLt configure]
[hipBLASLt configure]   "TheRock/build/base/rocm_smi_lib/dist/lib/rocm_sysdeps/include"
```

This will be adressed in a follow up and for now we unbreak the default when `THEROCK_BUNDLE_SYSDEPS` is set to `ON`.