### PR TITLE
Set release tag and name from workflow inputs.

### DIFF
--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -6,9 +6,14 @@ on:
       package_suffix:
         type: string
         default: -ADHOCBUILD
+      # TODO: make this optional. For now we require it to be set explicitly.
+      # Default behavior could be either:
+      #   A) generate a version or date -based tag for each release
+      #   B) append assets to 'mainline-snapshot' with a version or date suffix
+      #   C) overwrite assets on 'mainline-snapshot'
       release_tag:
         description: Publish files to this release tag
-        required: false
+        required: true
         type: string
 
   workflow_call:
@@ -16,9 +21,10 @@ on:
       package_suffix:
         type: string
         default: -ADHOCBUILD
+      # TODO: make this optional. See above.
       release_tag:
         description: Publish files to this release tag
-        required: false
+        required: true
         type: string
 
 permissions:
@@ -93,8 +99,8 @@ jobs:
         if: github.event.inputs.release_tag != ''
         with:
           artifacts: "${{ env.DIST_ARCHIVE }}"
-          tag: mainline-snapshot
-          name: mainline-snapshot
+          tag: ${{ inputs.release_tag }}
+          name: ${{ inputs.release_tag }}
           removeArtifacts: false
           allowUpdates: true
           replacesArtifacts: true

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -47,8 +47,6 @@ therock_add_amdgpu_target(gfx908 "MI100 CDNA" FAMILY gfx90X-all dcgpu-all gfx90X
 therock_add_amdgpu_target(gfx90a "MI210/250 CDNA" FAMILY gfx90X-all dcgpu-all gfx90X-dcgpu)
 
 # gfx94X family
-therock_add_amdgpu_target(gfx940 "MI300A/MI300X CDNA" FAMILY dcgpu-all gfx94X-all gfx94X-dcgpu)
-therock_add_amdgpu_target(gfx941 "MI300A/MI300X CDNA" FAMILY dcgpu-all gfx94X-all gfx94X-dcgpu)
 therock_add_amdgpu_target(gfx942 "MI300A/MI300X CDNA" FAMILY dcgpu-all gfx94X-all gfx94X-dcgpu)
 
 # gfx101X family


### PR DESCRIPTION
Using this to generate a more recent release build. I triggered runs of the workflow at https://github.com/ROCm/TheRock/actions/runs/13841786867 and https://github.com/ROCm/TheRock/actions/runs/13843372506 with inputs:

* `package_suffix`: `` (empty string)
* `release_tag`: `mainline-snapshot-2025-03-13`

Now that builds are running, I'll look into restructuring the workflow so it supports a configurable set of targets and is less clicky.