### PR TITLE
Update instructions on `tomli`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ requires some additional development tools, which are included below.
 ## Common
 
 ```
-pip install CppHeaderParser==2.7.4 meson==1.7.0 PyYAML==6.0.2 toml libtoml tomli
+pip install CppHeaderParser==2.7.4 meson==1.7.0 PyYAML==6.0.2
+```
+
+Python 3.10 further require `tomli`:
+
+```
+pip install tomli==2.2.1
 ```
 
 ## On Ubuntu

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ requires some additional development tools, which are included below.
 pip install CppHeaderParser==2.7.4 meson==1.7.0 PyYAML==6.0.2
 ```
 
-Python 3.10 further require `tomli`:
+Python 3.10 also requires `tomli`:
 
 ```
 pip install tomli==2.2.1


### PR DESCRIPTION
`tomli` is required for Python 3.10 but not for more recent Python versions.