### PR TITLE
Build Pytorch Docker Image for gfx942

### DIFF
--- a/.github/workflows/publish_pytorch_dev_docker.yml
+++ b/.github/workflows/publish_pytorch_dev_docker.yml
@@ -8,6 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         targets:
+          - amdgpu_target: "gfx942"
           - amdgpu_target: "gfx1100"
           - amdgpu_target: "gfx1201"
 


### PR DESCRIPTION
The PR adds `gfx942` target to the `Publish PyTorch Dev Dockers`  workflow.
The image was tested manually on MI300X machine and passes the [smoke tests](https://github.com/ROCm/TheRock/blob/main/external-builds/pytorch/smoke-tests/pytorch_smoke_tests.py).