### PR TITLE
Introduce a new configure_ci script.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,20 +23,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup:
+    uses: ./.github/workflows/setup.yml
+
   build_linux_packages:
-    permissions:
-      id-token: write
     name: Build Linux Packages
+    needs: setup
+    if: ${{ fromJSON(needs.setup.outputs.enable_build_jobs) }}
     uses: ./.github/workflows/build_linux_packages.yml
     with:
       amdgpu_families: "${{ inputs.amdgpu_families != '' && inputs.amdgpu_families || 'gfx94X-dcgpu' }}"
+    permissions:
+      id-token: write
 
   build_windows_packages:
     name: Build Windows Packages
+    needs: setup
+    if: ${{ fromJSON(needs.setup.outputs.enable_build_jobs) }}
     uses: ./.github/workflows/build_windows_packages.yml
 
   test_linux_packages:
-    needs: build_linux_packages
+    needs: [setup, build_linux_packages]
     name: Test Linux Packages
     uses: ./.github/workflows/test_linux_packages.yml
     with:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -1,0 +1,32 @@
+name: Setup
+
+on:
+  workflow_call:
+    outputs:
+      enable_build_jobs:
+        description: Whether to enable build jobs.
+        value: ${{ jobs.setup.outputs.enable_build_jobs }}
+
+permissions:
+  contents: read
+
+jobs:
+  setup:
+    runs-on: ubuntu-24.04
+    env:
+      # The commit being checked out is the merge commit for a PR. Its first
+      # parent will be the tip of the base branch.
+      BASE_REF: HEAD^
+    outputs:
+      enable_build_jobs: ${{ steps.configure.outputs.enable_build_jobs }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # We need the parent commit to do a diff
+          fetch-depth: 2
+      - name: "Configuring CI options"
+        id: configure
+        env:
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: ./build_tools/configure_ci.py

--- a/build_tools/configure_ci.py
+++ b/build_tools/configure_ci.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+"""Configures metadata for a CI workflow run.
+
+----------
+| Inputs |
+----------
+
+  Environment variables (for all triggers):
+  * GITHUB_EVENT_NAME    : GitHub event name, e.g. pull_request.
+  * GITHUB_OUTPUT        : path to write workflow output variables.
+  * GITHUB_STEP_SUMMARY  : path to write workflow summary output.
+
+  Environment variables (for pull requests):
+  * PR_LABELS (optional) : JSON list of PR label names.
+  * BASE_REF  (required) : base commit SHA of the PR.
+
+  Local git history with at least fetch-depth of 2 for file diffing.
+
+-----------
+| Outputs |
+-----------
+
+  Written to GITHUB_OUTPUT:
+  * enable_build_jobs : true/false
+
+  Written to GITHUB_STEP_SUMMARY:
+  * Human-readable summary for most contributors
+
+  Written to stdout/stderr:
+  * Detailed information for CI maintainers
+"""
+
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+from typing import Iterable, List, Mapping, Optional
+
+
+# Paths matching any of these patterns are considered to have no influence over
+# build or test workflows so any related jobs can be skipped if all paths
+# modified by a commit/PR match a pattern in this list.
+SKIPPABLE_PATH_PATTERNS = [
+    "docs/*",
+    "*.gitignore",
+    "*.md",
+    "*LICENSE",
+]
+
+
+def is_path_skippable(path: str) -> bool:
+    """Determines if a given relative path to a file matches any skippable patterns."""
+    return any(fnmatch.fnmatch(path, pattern) for pattern in SKIPPABLE_PATH_PATTERNS)
+
+
+def check_for_non_skippable_path(paths: Optional[Iterable[str]]) -> bool:
+    """Returns true if at least one path is not in the skippable set."""
+    if paths is None:
+        return False
+    return any(not is_path_skippable(p) for p in paths)
+
+
+def get_modified_paths(base_ref: str) -> Optional[Iterable[str]]:
+    """Returns the paths of modified files relative to the base reference."""
+    try:
+        return subprocess.run(
+            ["git", "diff", "--name-only", base_ref],
+            stdout=subprocess.PIPE,
+            check=True,
+            text=True,
+            timeout=60,
+        ).stdout.splitlines()
+    except TimeoutError:
+        print(
+            "Computing modified files timed out. Not using PR diff to determine"
+            " jobs to run.",
+            file=sys.stderr,
+        )
+        return None
+
+
+def get_pr_labels() -> List[str]:
+    """Gets a list of labels applied to a pull request."""
+    labels = json.loads(os.environ.get("PR_LABELS", "[]"))
+    return labels
+
+
+def set_github_output(d: Mapping[str, str]):
+    """Sets GITHUB_OUTPUT values.
+    See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs
+    """
+    print(f"Setting github output:\n{d}")
+    step_output_file = os.environ.get("GITHUB_OUTPUT", "")
+    if not step_output_file:
+        print("Warning: GITHUB_OUTPUT env var not set, can't set github outputs")
+        return
+    with open(step_output_file, "a") as f:
+        f.writelines(f"{k}={v}" + "\n" for k, v in d.items())
+
+
+def write_job_summary(summary: str):
+    """Appends a string to the GitHub Actions job summary.
+    See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
+    """
+    print(f"Writing job summary:\n{summary}")
+    step_summary_file = os.environ.get("GITHUB_STEP_SUMMARY", "")
+    if not step_summary_file:
+        print("Warning: GITHUB_STEP_SUMMARY env var not set, can't write job summary")
+        return
+    with open(step_summary_file, "a") as f:
+        # Use double newlines to split sections in markdown.
+        f.write(summary + "\n\n")
+
+
+def main():
+    is_pr = os.environ.get("GITHUB_EVENT_NAME", "") == "pull_request"
+    labels = get_pr_labels() if is_pr else []
+    # TODO(#199): Use labels or remove the code for handling them
+    base_ref = os.environ.get("BASE_REF", "HEAD^1")
+    print("Found metadata:")
+    print("  is_pr:", is_pr)
+    print("  labels:", labels)
+
+    enable_build_jobs = False
+
+    modified_paths = get_modified_paths(base_ref)
+    print("modified_paths (max 200):", modified_paths[:200])
+    includes_non_skippable_path = check_for_non_skippable_path(modified_paths)
+    if includes_non_skippable_path:
+        print("Enabling build jobs since a non-skippable path was modified")
+        enable_build_jobs = True
+    else:
+        print("Only skippable paths were modified, keeping build jobs disabled")
+
+    write_job_summary(
+        f"""## Workflow configure results
+
+* `enable_build_jobs`: {enable_build_jobs}
+    """
+    )
+
+    output = {
+        "enable_build_jobs": json.dumps(enable_build_jobs),
+    }
+    set_github_output(output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/199. This gives us a place to configure what workflows should do, based on inputs like the files changed and labels applied to a pull request. The approach was inspired by prior work over in https://github.com/iree-org/iree/blob/main/build_tools/github_actions/configure_ci.py. Many features there aren't needed here (yet?) though.

## Behavioral changes

For now all this does is skip `build_linux_packages` and `build_windows_packages` in `ci.yml` if the diff relative to the base commit only modifies files matching certain patterns (like `*.md`). This happens for both `push` and `pull_request` triggers but does not happen for `workflow_dispatch` triggers.

## Testing

I've done some testing on my fork with various pull requests (https://github.com/ScottTodd/TheRock/actions/workflows/ci.yml) and the script logs what it does in a few places, but this sort of configuration and scripting is always a bit tricky. I might try using it with https://github.com/nektos/act or a test wrapper script that emulates the environment variables that GitHub sets. We can also add unit tests.

## Future work

The next major feature I'd like to add here is a way to define the matrix of build/test targets and then a way to opt-in to extra targets outside of the default set. I think we'll want this sort of script for that matrix as well as test selection. If this feels over-engineered it should be easy enough to iterate on a few approaches.