### PR TITLE
Don't set RPATH if targets do not exist

### DIFF
--- a/math-libs/BLAS/post_hook_hipBLASLt.cmake
+++ b/math-libs/BLAS/post_hook_hipBLASLt.cmake
@@ -8,19 +8,21 @@ therock_set_install_rpath(
     .
 )
 
-therock_set_install_rpath(
-  TARGETS
-    hipblaslt-bench
-    hipblaslt-bench-extop-amax
-    hipblaslt-bench-extop-layernorm
-    hipblaslt-bench-extop-matrixtransform
-    hipblaslt-bench-extop-softmax
-    hipblaslt-bench-groupedgemm-fixed-mk
-    hipblaslt-sequence
-    hipblaslt-test
-  PATHS
-    ../lib
-    ../lib/host-math/lib
-    ../lib/llvm/lib
-    ../lib/rocm_sysdeps/lib
-)
+if(THEROCK_BUILD_TESTING)
+  therock_set_install_rpath(
+    TARGETS
+      hipblaslt-bench
+      hipblaslt-bench-extop-amax
+      hipblaslt-bench-extop-layernorm
+      hipblaslt-bench-extop-matrixtransform
+      hipblaslt-bench-extop-softmax
+      hipblaslt-bench-groupedgemm-fixed-mk
+      hipblaslt-sequence
+      hipblaslt-test
+    PATHS
+      ../lib
+      ../lib/host-math/lib
+      ../lib/llvm/lib
+      ../lib/rocm_sysdeps/lib
+  )
+endif()

--- a/math-libs/BLAS/post_hook_hipSPARSE.cmake
+++ b/math-libs/BLAS/post_hook_hipSPARSE.cmake
@@ -8,12 +8,14 @@ therock_set_install_rpath(
     .
 )
 
-therock_set_install_rpath(
-  TARGETS
-    hipsparse-bench
-    hipsparse-test
-  PATHS
-    ../lib
-    ../lib/llvm/lib
-    ../lib/rocm_sysdeps/lib
-)
+if(THEROCK_BUILD_TESTING)
+  therock_set_install_rpath(
+    TARGETS
+      hipsparse-bench
+      hipsparse-test
+    PATHS
+      ../lib
+      ../lib/llvm/lib
+      ../lib/rocm_sysdeps/lib
+  )
+endif()

--- a/math-libs/BLAS/post_hook_rocBLAS.cmake
+++ b/math-libs/BLAS/post_hook_rocBLAS.cmake
@@ -8,14 +8,16 @@ therock_set_install_rpath(
     .
 )
 
-therock_set_install_rpath(
-  TARGETS
-    rocblas-bench
-    rocblas-gemm-tune
-    rocblas-test
-  PATHS
-    ../lib
-    ../lib/host-math/lib
-    ../lib/llvm/lib
-    ../lib/rocm_sysdeps/lib
-)
+if(THEROCK_BUILD_TESTING)
+  therock_set_install_rpath(
+    TARGETS
+      rocblas-bench
+      rocblas-gemm-tune
+      rocblas-test
+    PATHS
+      ../lib
+      ../lib/host-math/lib
+      ../lib/llvm/lib
+      ../lib/rocm_sysdeps/lib
+  )
+endif()

--- a/math-libs/BLAS/post_hook_rocSPARSE.cmake
+++ b/math-libs/BLAS/post_hook_rocSPARSE.cmake
@@ -8,12 +8,14 @@ therock_set_install_rpath(
     .
 )
 
-therock_set_install_rpath(
-  TARGETS
-    rocsparse-bench
-    rocsparse-test
-  PATHS
-    ../lib
-    ../lib/llvm/lib
-    ../lib/rocm_sysdeps/lib
-)
+if(THEROCK_BUILD_TESTING)
+  therock_set_install_rpath(
+    TARGETS
+      rocsparse-bench
+      rocsparse-test
+    PATHS
+      ../lib
+      ../lib/llvm/lib
+      ../lib/rocm_sysdeps/lib
+  )
+endif()


### PR DESCRIPTION
If `THEROCK_BUILD_TESTING` isn't set to `ON` targets like `hipblaslt-test` do not exist and thus setting the RPATH in post_hook fails.