### PR TITLE
Completes implementation of python rocm-sdk[devel] package.

### DIFF
--- a/build_tools/linux_python_dist_split.py
+++ b/build_tools/linux_python_dist_split.py
@@ -601,16 +601,16 @@ def maybe_materialize_lib_so(
     if soname != src_entry.name:
         return
 
-    if src_entry.is_symlink():
-        # We're just going to "rotate" the symlinks so that the SONAME based
-        # one is primary and everything else points to that.
-        link_target = os.readlink(src_entry.path)
-        if not link_target.count("/"):
-            # It is just the normal libfoo.so.0 -> libfoo.so.0.1 style thing.
-            # Note that this path was materialized to dest_path too.
-            link_target_relpath = str(Path(relpath).parent / link_target)
-            assert link_target_relpath not in materialized_paths
-            materialized_paths[link_target_relpath] = dest_path
+    # if src_entry.is_symlink():
+    #     # We're just going to "rotate" the symlinks so that the SONAME based
+    #     # one is primary and everything else points to that.
+    #     link_target = os.readlink(src_entry.path)
+    #     if link_target.count("/") == 0:
+    #         # It is just the normal libfoo.so.0 -> libfoo.so.0.1 style thing.
+    #         # Note that this path was materialized to dest_path too.
+    #         link_target_relpath = str(Path(relpath).parent / link_target)
+    #         assert link_target_relpath not in materialized_paths
+    #         #materialized_paths[link_target_relpath] = dest_path
     return materialize_file(
         relpath, dest_path, src_entry, materialized_paths, resolve_src=True
     )
@@ -632,6 +632,14 @@ def materialize_lib_file(
     if file_type == "so":
         soname = get_soname(src_entry.path)
         if soname != dest_path.name:
+            # It is a concrete library like libfoo.so.0.1 where the soname
+            # is libfoo.so.0. We don't want to ever write such a thing (the
+            # actual soname link will be materialized with the contents in
+            # maybe_materialize_lib_so), but we want to advertise that it has
+            # been materialized as the soname (so we kind of invert the linkage).
+            inverted_dest_path = dest_path.with_name(soname)
+            log(f"INVLINK: {relpath} -> {inverted_dest_path} ({soname})")
+            materialized_paths[relpath] = inverted_dest_path
             return
     return materialize_file(relpath, dest_path, src_entry, materialized_paths)
 
@@ -680,10 +688,24 @@ def materialize_devel_file(
         return
 
     if relpath in materialized_paths:
-        # Materialize as a symlink to the original placement.
+        # Materialize as a symlink to the original placement. This is tricky
+        # because the symlink needs to be correct with respect to the install
+        # placement, which is something like:
+        #   _rocm_sdk_core/path/to/foo.txt
+        #   _rocm_sdk_devel/path/to/foo.txt
+        # In this example, relpath would be "path/to/foo.txt" and the proper
+        # symlink:
+        #   ../../../_rocm_sdk_core/path/to/foo.txt
+        # Conveniently, the root sibling is len(relpath_segments) up from the
+        # original_path.
+        # This is admittedly ugly, but there is not a super convenient way to
+        # do it given that the relative path is computed for an installation
+        # layout that is different from the packaging input layout.
         original_path = materialized_paths[relpath]
-        link_target = original_path.relative_to(dest_path.parent, walk_up=True)
-        log(f"LINK: {relpath} -> {link_target}", vlog=2)
+        relpath_segment_count = len(Path(relpath).parts)
+        root_sibling_path = original_path.parts[-(relpath_segment_count + 1) :]
+        link_target = Path(*([".."] * relpath_segment_count + list(root_sibling_path)))
+        log(f"DEVLINK: {relpath} -> {link_target} ({root_sibling_path})", vlog=2)
         if dest_path.exists(follow_symlinks=False):
             dest_path.unlink()
         dest_path.parent.mkdir(parents=True, exist_ok=True)

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/__main__.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/__main__.py
@@ -1,9 +1,34 @@
 """Main ROCm SDK CLI for managing the Python installation."""
 
 import argparse
+import importlib.util
 import sys
 
 from . import _dist_info as di
+
+
+def _do_path(args: argparse.Namespace):
+    from . import _devel
+
+    try:
+        root_path = _devel.get_devel_root()
+    except ModuleNotFoundError as e:
+        print(
+            "ERROR: Could not find the `rocm-sdk[devel]` package, which is required "
+            "to access runtime tools and development files. Please install it with "
+            "your package manager (pip, uv, etc)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if args.cmake:
+        print(root_path / "lib" / "cmake")
+    elif args.bin:
+        print(root_path / "bin")
+    elif args.root:
+        print(root_path)
+    else:
+        print("ERROR: Expected path type flag", file=sys.stderr)
+        sys.exit(1)
 
 
 def _do_test(args: argparse.Namespace):
@@ -23,6 +48,11 @@ def _do_test(args: argparse.Namespace):
         ALL_TEST_MODULES.append("rocm_sdk.tests.libraries_test")
     else:
         print("NOTE: Skipping libraries tests (not installed for this arch)")
+
+    # The devel platform package may not exist yet since it is populated on-demand,
+    # so check that the pure package exists.
+    if importlib.util.find_spec("rocm_sdk_devel") is not None:
+        ALL_TEST_MODULES.append("rocm_sdk.tests.devel_test")
 
     # Load all tests.
     for test_module_name in ALL_TEST_MODULES:
@@ -45,6 +75,25 @@ def main(argv: list[str] | None = None):
         description="ROCm SDK Python CLI",
     )
     sub_p = p.add_subparsers(required=True)
+    path_p = sub_p.add_parser("path", help="Print various paths to ROCm installation")
+    path_p_group = path_p.add_mutually_exclusive_group(required=True)
+    path_p_group.add_argument(
+        "--cmake",
+        action="store_true",
+        help="Print the CMAKE_PATH_PREFIX for the ROCm development package",
+    )
+    path_p_group.add_argument(
+        "--bin",
+        action="store_true",
+        help="Print the ROCm development package binary directory",
+    )
+    path_p_group.add_argument(
+        "--root",
+        action="store_true",
+        help="Print the ROCm development package root directory",
+    )
+    path_p.set_defaults(func=_do_path)
+
     test_p = sub_p.add_parser("test", help="Run installation tests to verify integrity")
     test_p.set_defaults(func=_do_test)
     args = p.parse_args(argv)

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/_devel.py
@@ -1,0 +1,183 @@
+"""Manages the rocm-sdk-devel package.
+
+The devel package is special in some key ways:
+
+* Since it contains distribution (wheel) unsafe files like symlinks, it is
+  distributed under the `rocm_sdk_devel` package as a `_devel.tar` or
+  `_devel.tar.xz` file that is intended to be expanded on use.
+* This tarball is intended to be expanded into the site-lib directory that
+  contains the ROCM distribution packages and will result in a top-level
+  python package named like `_rocm_sdk_devel_linux_x86_64` that is a sibling
+  to other packages like `_rocm_sdk_core_linux_x86_64`.
+* For any files already contained in one of the runtime packages, a relative
+  symlink to the correct sibling will be stored.
+* Any files not in one of the runtime packages will be included verbatim in the
+  tarball.
+* RPATH setup relies on this sibling behavior and is already encoded properly
+  in the runtime packages.
+
+In order to make this work, we dynamically extend the distribution package on
+use, modifying the dist-info RECORD file to include all newly expanded files in
+accordance with the PyPA documentation:
+  https://packaging.python.org/en/latest/specifications/recording-installed-packages/
+Note that this puts us in the category of creating a self-modifying package,
+which is strongly discouraged but not prohibited. We deem the tradeoff worth
+it, as the alternative is to increase the package size by 2-5x and break
+symlink relationships.
+"""
+
+import importlib.metadata as md
+from pathlib import Path
+import shutil
+import tarfile
+
+from . import _dist_info as di
+
+
+def get_devel_root() -> Path:
+    try:
+        import rocm_sdk_devel
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "ROCm SDK development package is not installed. This can typically be "
+            "obtained by installing `rocm-sdk[devel]` from your package manager"
+        ) from e
+    rocm_sdk_devel_path = _get_package_path(rocm_sdk_devel)
+    if rocm_sdk_devel_path is None:
+        raise ModuleNotFoundError(
+            "rocm_sdk_devel expected to be defined by an __init__.py file"
+        )
+    site_lib_path = rocm_sdk_devel_path.parent
+    devel_py_pkg_name = di.ALL_PACKAGES["devel"].get_py_package_name()
+    devel_py_pkg_path = site_lib_path / devel_py_pkg_name
+    if (devel_py_pkg_path / "__init__.py").exists():
+        return devel_py_pkg_path
+
+    _expand_devel_contents(rocm_sdk_devel_path, site_lib_path)
+    if not (devel_py_pkg_path / "__init__.py").exists():
+        raise ImportError(
+            f"Expanding {devel_py_pkg_name} did not produce a valid Python package"
+        )
+    return devel_py_pkg_path
+
+
+# Gets the path of a module presumed to be a package defined by an __init__.py
+# file. Returns None if it is a namespace package or another kind of module.
+def _get_package_path(m) -> Path | None:
+    if m.__file__ is None:
+        return None
+    p = Path(m.__file__)
+    if p.name == "__init__.py":
+        return p.parent  # Directory containing __init__.py
+    return None
+
+
+def _expand_devel_contents(rocm_sdk_devel_path: Path, site_lib_path: Path):
+    # Resolve the Python package to its distribution package name and find the
+    # RECORD file.
+    dist_names = md.packages_distributions()["rocm_sdk_devel"]
+    assert len(dist_names) == 1  # Would only be != 1 for namespace package.
+    dist_name = dist_names[0]
+    dist_files = md.files(dist_name)
+    if dist_files is None:
+        raise ImportError(
+            "Cannot expand the `rocm-sdk[devel]` package because it was not installed "
+            "by a user-mode package manager and is managed by the system. Please "
+            "install the `rocm-sdk` in a virtual environment."
+        )
+    for record_pkg_file in dist_files:
+        if record_pkg_file.name == "RECORD" and record_pkg_file.parent.name.endswith(
+            ".dist-info"
+        ):
+            break
+    else:
+        raise ImportError(
+            f"No distribution RECORD found for the `{dist_name}` distribution package."
+        )
+
+    # Resolve to a physical file.
+    record_path = record_pkg_file.locate()
+
+    # Find the tarfile.
+    tarfile_path = rocm_sdk_devel_path / "_devel.tar.xz"
+    if tarfile_path.exists():
+        tarfile_mode = "r:xz"
+    else:
+        tarfile_path = rocm_sdk_devel_path / "_devel.tar"
+        if not tarfile_path.exists():
+            raise ImportError(
+                f"Expected to find _devel.tar or _devel.tar.xz in {rocm_sdk_devel_path}"
+            )
+        tarfile_mode = "r"
+
+    dist_file_path_names = [str(df) for df in dist_files]
+    _lock_and_expand(
+        site_lib_path,
+        tarfile_path,
+        tarfile_mode,
+        record_path,
+        dist_file_path_names,
+    )
+
+
+def _lock_and_expand(
+    site_lib_path: Path,
+    tarfile_path: Path,
+    tarfile_mode: str,
+    record_path: Path,
+    dist_file_path_names: set[str],
+):
+    # When extracting, we note the directory paths of each entry and on the first
+    # access, clean it up if it is already present. This works around package manager
+    # races where in certain uninstall situations, some amount of the directory tree
+    # may not be fully removed (this presently happens with dangling symlinks).
+    # Cleaning it ensures consistent re-install behavior.
+    clean_dir_paths: set[Path] = set()
+
+    def _clean_dir(dir: Path):
+        clean_dir_paths.add(dir)
+        if dir.exists():
+            shutil.rmtree(dir, ignore_errors=False)
+
+    with open(record_path, "at") as record_file:
+        _lock_file(record_file)
+        try:
+            with tarfile.open(tarfile_path, tarfile_mode) as tf:
+                while ti := tf.next():
+                    dest_path = site_lib_path / ti.name
+                    if ti.isfile() or ti.issym():
+                        parent_path = dest_path.parent
+                        if parent_path not in clean_dir_paths:
+                            _clean_dir(parent_path)
+                        tf.extract(ti, path=site_lib_path)
+                        if ti.name not in dist_file_path_names:
+                            # CSV record:
+                            #   path
+                            #   hash (empty)
+                            #   size (empty)
+                            record_file.write(f"{ti.name},,\n")
+                    elif ti.isdir():
+                        # We don't generally have directory entries, but handle
+                        # them if we do.
+                        if dest_path not in clean_dir_paths:
+                            _clean_dir(dest_path)
+                        tf.extract(ti, path=site_lib_path)
+            tarfile_path.unlink()
+        finally:
+            _unlock_file(record_file)
+
+
+def _lock_file(f):
+    # TODO: This is Posix specific file locking. We should fork on Windows to use
+    # msvcrt locking.
+    import fcntl, os
+
+    fcntl.lockf(f, fcntl.LOCK_EX)
+
+
+def _unlock_file(f):
+    # TODO: This is Posix specific file locking. We should fork on Windows to use
+    # msvcrt locking.
+    import fcntl, os
+
+    fcntl.lockf(f, fcntl.LOCK_UN)

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/base_test.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/base_test.py
@@ -1,29 +1,16 @@
 """Installation package tests for the base installation."""
 
-from pathlib import Path
-import shlex
-import subprocess
 import sys
 import unittest
 
 from .. import _dist_info as di
 
-
-def exec(args: list[str | Path], cwd: Path | None = None, capture: bool = False):
-    args = [str(arg) for arg in args]
-    if cwd is None:
-        cwd = Path.cwd()
-    print(f"++ Exec [{cwd}]$ {shlex.join(args)}")
-    sys.stdout.flush()
-    if capture:
-        return subprocess.check_output(args, cwd=str(cwd), stdin=subprocess.DEVNULL)
-    else:
-        subprocess.check_call(args, cwd=str(cwd), stdin=subprocess.DEVNULL)
+from . import utils
 
 
 class ROCmBaseTest(unittest.TestCase):
     def testCLI(self):
-        output = exec(
+        output = utils.exec(
             [sys.executable, "-P", "-m", "rocm_sdk", "--help"], capture=True
         ).decode()
         self.assertIn("usage:", output)

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/devel_test.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/devel_test.py
@@ -1,0 +1,114 @@
+"""Test of the library trees."""
+
+"""Installation package tests for the core package."""
+
+import importlib
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+
+from .. import _dist_info as di
+from . import utils
+
+import rocm_sdk
+
+
+class ROCmDevelTest(unittest.TestCase):
+    def testInstallationLayout(self):
+        """The `rocm_sdk` and devel module must be siblings on disk."""
+        sdk_path = Path(rocm_sdk.__file__)
+        self.assertEqual(
+            sdk_path.name,
+            "__init__.py",
+            msg="Expected `rocm_sdk` module to be a non-namespace package",
+        )
+        import rocm_sdk_devel
+
+        devel_path = Path(rocm_sdk_devel.__file__)
+        self.assertEqual(
+            devel_path.name,
+            "__init__.py",
+            msg=f"Expected `rocm_sdk_devel` module to be a non-namespace package",
+        )
+        self.assertEqual(
+            sdk_path.parent.parent,
+            devel_path.parent.parent,
+            msg="Paths are not siblings",
+        )
+
+    def testCLIPathBin(self):
+        output = (
+            utils.exec(
+                [sys.executable, "-P", "-m", "rocm_sdk", "path", "--bin"], capture=True
+            )
+            .decode()
+            .strip()
+        )
+        path = Path(output)
+        self.assertTrue(path.exists(), msg=f"Expected bin path {path} to exist")
+
+    def testCLIPathCMake(self):
+        output = (
+            utils.exec(
+                [sys.executable, "-P", "-m", "rocm_sdk", "path", "--cmake"],
+                capture=True,
+            )
+            .decode()
+            .strip()
+        )
+        path = Path(output)
+        self.assertTrue(path.exists(), msg=f"Expected cmake path {path} to exist")
+        hip_file = path / "hip" / "hip-config.cmake"
+        self.assertTrue(
+            hip_file.exists(), msg=f"Expected hip config to exist {hip_file}"
+        )
+
+    def testCLIPathRoot(self):
+        output = (
+            utils.exec(
+                [sys.executable, "-P", "-m", "rocm_sdk", "path", "--root"], capture=True
+            )
+            .decode()
+            .strip()
+        )
+        path = Path(output)
+        self.assertTrue(path.exists(), msg=f"Expected root path {path} to exist")
+        bin_path = path / "bin"
+        self.assertTrue(bin_path.exists(), msg=f"Expected bin path {bin_path} to exist")
+
+    def testSharedLibrariesLoad(self):
+        # Make sure the devel package is expanded.
+        _ = (
+            utils.exec(
+                [sys.executable, "-P", "-m", "rocm_sdk", "path", "--root"], capture=True
+            )
+            .decode()
+            .strip()
+        )
+
+        # Ensure that the platform package exists now.
+        mod_name = di.ALL_PACKAGES["devel"].get_py_package_name(
+            target_family=di.determine_target_family()
+        )
+        mod = importlib.import_module(mod_name)
+        utils.assert_is_physical_package(mod)
+        so_paths = utils.get_module_shared_libraries(mod)
+
+        self.assertTrue(
+            so_paths, msg="Expected core package to contain shared libraries"
+        )
+
+        for so_path in so_paths:
+            if "clang_rt" in str(so_path):
+                # clang_rt and sanitizer libraries are not all intended to be
+                # loadable arbitrarily.
+                continue
+            with self.subTest(msg="Check shared library loads", so_path=so_path):
+                # Load each in an isolated process because not all libraries in the tree
+                # are designed to load into the same process (i.e. LLVM runtime libs,
+                # etc).
+                command = "import ctypes; import sys; ctypes.CDLL(sys.argv[1])"
+                subprocess.check_call(
+                    [sys.executable, "-P", "-c", command, str(so_path)]
+                )

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/utils.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/utils.py
@@ -2,7 +2,21 @@
 
 from pathlib import Path
 import platform
-import unittest
+import shlex
+import subprocess
+import sys
+
+
+def exec(args: list[str | Path], cwd: Path | None = None, capture: bool = False):
+    args = [str(arg) for arg in args]
+    if cwd is None:
+        cwd = Path.cwd()
+    print(f"++ Exec [{cwd}]$ {shlex.join(args)}")
+    sys.stdout.flush()
+    if capture:
+        return subprocess.check_output(args, cwd=str(cwd), stdin=subprocess.DEVNULL)
+    else:
+        subprocess.check_call(args, cwd=str(cwd), stdin=subprocess.DEVNULL)
 
 
 def assert_is_physical_package(mod):


### PR DESCRIPTION
* New CLI commands that coordinate with the rocm-sdk[devel] package to self-install and print the corresponding paths:
  * `rocm-sdk path --cmake`
  * `rocm-sdk path --bin`
  * `rocm-sdk path --root`
* This *should* be sufficient to build frameworks and such, but I have not actually tested any downstream build on these wheels.
* Frameworks and users will need a new API call added to their __init__.py which preloads the libraries they depend on (we will add a `rocm_sdk.loader` for this instead of how CUDA does it where they scatter random dlopens and paths in the code).
* The result should be that at *build* time, the rocm-sdk[devel] package will provide a full ROCm installation with all dev tools, etc.
* But at runtime/deployment time, dependent projects need only depend on the runtime packages they require, which have been managed for size.
* I'm using a discouraged but supported feature of the Python package ecosystem where the devel package is a self-modifying package. This is necessary because, unlike the runtime packages, the devel package has path structures and link farms that cannot be represented in normal Python packages. Therefore, we treat it as an overlay, distributing an embedded tarball that is dynamically expanded to augment the development package when requested. The recommended PyPA accounting of the RECORD is done, and the result is that `pip uninstall` of the package does in fact clean up all installation artifacts, whether the embedded development image has been expanded or not. There are some corner cases that I will make more robust in the future.
* Now that I have the POC and know exactly what it needs to do, I will be rewriting linux_python_dist_split.py for better scalability (i.e. so that we can easily support more libraries and have less fragility). The symlink handling specifically is getting quite thick and needs a rewrite. But the tests pass and are fairly comprehensive in terms of what can go wrong from a packaging perspective. That will aid the rewrite.