### PR TITLE
Add libdrm patch to inline device ids.

### DIFF
--- a/third-party/sysdeps/linux/libdrm/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libdrm/CMakeLists.txt
@@ -48,13 +48,23 @@ if(NOT PATCHELF OR NOT MESON_BUILD)
   message(FATAL_ERROR "Missing PATCHELF or MESON_BUILD from super-project")
 endif()
 
+# Meson refuses to build if the source dir is a subdir of the build dir, so
+# make it a sibling.
+set(PATCH_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/../patch_source")
+
 add_custom_target(
   meson_build ALL
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   COMMAND
-    "${CMAKE_COMMAND}" -E rm -rf -- "${CMAKE_INSTALL_PREFIX}"
+    "${CMAKE_COMMAND}" -E rm -rf -- "${CMAKE_INSTALL_PREFIX}" "${PATCH_SOURCE_DIR}"
   COMMAND
-    "${CMAKE_COMMAND}" -E chdir "${SOURCE_DIR}"
+    # We have to patch the sources so make a fresh copy.
+    "${CMAKE_COMMAND}" -E copy_directory "${SOURCE_DIR}" "${PATCH_SOURCE_DIR}"
+  COMMAND
+    # Inline the amdgpu device table.
+    "${CMAKE_CURRENT_SOURCE_DIR}/inline_amdgpu_ids.sh" "${PATCH_SOURCE_DIR}"
+  COMMAND
+    "${CMAKE_COMMAND}" -E chdir "${PATCH_SOURCE_DIR}"
     "${CMAKE_COMMAND}" -E env
       # Escaping hack: experimentally determined to persist through the layers.
       "LDFLAGS=-Wl,-rpath='$$ORIGIN' -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds"

--- a/third-party/sysdeps/linux/libdrm/inline_amdgpu_ids.sh
+++ b/third-party/sysdeps/linux/libdrm/inline_amdgpu_ids.sh
@@ -43,7 +43,7 @@ struct inline_amdgpu_id {
   # And export a lookup function.
   echo "
 void amdgpu_parse_asic_ids(struct amdgpu_device *dev) {
-  size_t count = sizeof inline_amdgpu_ids / sizeof inline_amdgpu_ids[0];
+  const size_t count = sizeof inline_amdgpu_ids / sizeof inline_amdgpu_ids[0];
   for (size_t i = 0; i < count; ++i) {
     if (inline_amdgpu_ids[i].did == dev->info.asic_id &&
         inline_amdgpu_ids[i].rid == dev->info.pci_rev_id) {

--- a/third-party/sysdeps/linux/libdrm/inline_amdgpu_ids.sh
+++ b/third-party/sysdeps/linux/libdrm/inline_amdgpu_ids.sh
@@ -3,6 +3,8 @@
 # with a fully inlined table that does not need to consult a fixed place on
 # the filesystem.
 
+set -euo pipefail
+
 SOURCE_DIR="${1:?Expected source directory}"
 
 generate() {

--- a/third-party/sysdeps/linux/libdrm/inline_amdgpu_ids.sh
+++ b/third-party/sysdeps/linux/libdrm/inline_amdgpu_ids.sh
@@ -21,7 +21,7 @@ struct inline_amdgpu_id {
 };
 '
   # Output an inline table.
-  echo "static struct inline_amdgpu_id inline_amdgpu_ids[] = {"
+  echo 'static struct inline_amdgpu_id inline_amdgpu_ids[] = {'
 
   # Syntax: device_id,  revision_id,  product_name
   # Fields are separated by {comma} {tab}.
@@ -38,10 +38,10 @@ struct inline_amdgpu_id {
     fi
     echo "  {0x${parts[0]}, 0x${parts[1]}, \"${parts[2]}\"},"
   done < "${SOURCE_DIR}/data/amdgpu.ids"
-  echo "};"
+  echo '};'
 
   # And export a lookup function.
-  echo "
+  echo '
 void amdgpu_parse_asic_ids(struct amdgpu_device *dev) {
   const size_t count = sizeof inline_amdgpu_ids / sizeof inline_amdgpu_ids[0];
   for (size_t i = 0; i < count; ++i) {
@@ -56,7 +56,7 @@ void amdgpu_parse_asic_ids(struct amdgpu_device *dev) {
     }
   }
 }
-"
+'
 }
 
 generate > "${SOURCE_DIR}/amdgpu/amdgpu_asic_id.c"

--- a/third-party/sysdeps/linux/libdrm/inline_amdgpu_ids.sh
+++ b/third-party/sysdeps/linux/libdrm/inline_amdgpu_ids.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Reads the data/amdgpu.ids file and replaces the amdgpu/amdgpu_asic_id.c file
+# with a fully inlined table that does not need to consult a fixed place on
+# the filesystem.
+
+SOURCE_DIR="${1:?Expected source directory}"
+
+generate() {
+  echo '
+#include <ctype.h>
+#include <stdint.h>
+#include <string.h>
+#include "amdgpu_drm.h"
+#include "amdgpu_internal.h"
+struct inline_amdgpu_id {
+  uint32_t did;
+  uint32_t rid;
+  const char *name;
+};
+'
+  # Output an inline table.
+  echo "static struct inline_amdgpu_id inline_amdgpu_ids[] = {"
+
+  # Syntax: device_id,  revision_id,  product_name
+  # Fields are separated by {comma} {tab}.
+  while read -r line; do
+    if [[ "$line" =~ ^# ]]; then
+      # Skip comment lines.
+      continue
+    fi
+    IFS=$',\t' read -ra parts <<< "$line"
+    if [[ ${#parts[@]} != 3 ]]; then
+      # Skip any lines that are not three fields. This also skips blanks and
+      # the file version leading line.
+      continue
+    fi
+    echo "  {0x${parts[0]}, 0x${parts[1]}, \"${parts[2]}\"},"
+  done < "${SOURCE_DIR}/data/amdgpu.ids"
+  echo "};"
+
+  # And export a lookup function.
+  echo "
+void amdgpu_parse_asic_ids(struct amdgpu_device *dev) {
+  size_t count = sizeof inline_amdgpu_ids / sizeof inline_amdgpu_ids[0];
+  for (size_t i = 0; i < count; ++i) {
+    if (inline_amdgpu_ids[i].did == dev->info.asic_id &&
+        inline_amdgpu_ids[i].rid == dev->info.pci_rev_id) {
+      // Trim leading whitespace/tabs.
+      const char *name = inline_amdgpu_ids[i].name;
+      while (isblank(*name)) name++;
+      if (strlen(name) == 0) continue;
+      dev->marketing_name = strdup(name);
+      break;
+    }
+  }
+}
+"
+}
+
+generate > "${SOURCE_DIR}/amdgpu/amdgpu_asic_id.c"


### PR DESCRIPTION
* Upstream chose to store the device ids at a static location on the file system. While this perhaps has a use case in a long term support OS situation, it is fine for us to just embed the id/name associations.
* We need relocatable packages, so eliminating this filesystem lookup is helpful.
* This just replaces the amdgpu_asic_id.c with an inline lookup. The ids file is still copied to the output (didn't patch the meson build to exclude it).
* Verified with `rocm-smi -a` on my GPU and also manually hacked the device id list to change my device name (and verified that this gets reported).

Fixes #147