### PR TITLE
Remove push trigger from verify_docker_image.yml

### DIFF
--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -1,7 +1,6 @@
 name: Pull and Verify Docker Image
 
 on:
-  push:
   workflow_call:
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
Follow-up to https://github.com/ROCm/TheRock/pull/185, so this doesn't run on all push triggers (to any branch).