### PR TITLE
Makes the INSTALL_INTERFACE sysdeps include conditioned properly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install -r requirements.txt
 Dev tools:
 
 ```
-sudo apt install gfortran git-lfs ninja-build cmake g++ pkg-config xxd libgtest-dev patchelf automake
+sudo apt install gfortran git-lfs ninja-build cmake g++ pkg-config xxd libgmock-dev libgtest-dev patchelf automake
 ```
 
 ## On Windows

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -52,6 +52,10 @@ if(NOT WIN32)  # TODO(#36): Enable on Windows and/or make subproject inclusion g
 
 therock_cmake_subproject_declare(rocm_smi_lib
   EXTERNAL_SOURCE_DIR "rocm_smi_lib"
+  CMAKE_ARGS
+    # See the post_hook, which needs to advertise install interface directories
+    # in this case.
+    "-DTHEROCK_HAS_BUNDLED_LIBDRM=${THEROCK_BUNDLED_LIBDRM}"
   INTERFACE_LINK_DIRS
     "lib"
   RUNTIME_DEPS

--- a/base/post_hook_rocm_smi_lib.cmake
+++ b/base/post_hook_rocm_smi_lib.cmake
@@ -1,6 +1,15 @@
-target_include_directories(rocm_smi64 PUBLIC
-  "$<INSTALL_INTERFACE:lib/rocm_sysdeps/include>"
-)
-target_include_directories(oam PUBLIC
-  "$<INSTALL_INTERFACE:lib/rocm_sysdeps/include>"
-)
+# smi_lib public headers include DRM, so in the bundled case, we must ensure
+# that the installed libraries add the include directory. This is because
+# libdrm does not cross the install boundary as a dep (since it is pkgconfig
+# and was not set up that way).
+# Conversely, if we include directories that do not exist, CMake consumers
+# will error out due to the missing directories.
+# See the project declaration for where this flag is defined.
+if(THEROCK_HAS_BUNDLED_LIBDRM)
+  target_include_directories(rocm_smi64 PUBLIC
+    "$<INSTALL_INTERFACE:lib/rocm_sysdeps/include>"
+  )
+  target_include_directories(oam PUBLIC
+    "$<INSTALL_INTERFACE:lib/rocm_sysdeps/include>"
+  )
+endif()

--- a/base/post_hook_rocm_smi_lib.cmake
+++ b/base/post_hook_rocm_smi_lib.cmake
@@ -1,4 +1,4 @@
-# smi_lib public headers include DRM, so in the bundled case, we must ensure
+# smi_lib public headers include libdrm, so in the bundled case, we must ensure
 # that the installed libraries add the include directory. This is because
 # libdrm does not cross the install boundary as a dep (since it is pkgconfig
 # and was not set up that way).


### PR DESCRIPTION
* Also adds to the doc page for ubuntu to install gmock-dev, since that was needed on my machine to test and not documented.
* Tested by attempting to build rccl without bundled sysdeps. Broke before with the reported error, worked after.

Fixes #198
Fixes #295