### PR TITLE
Add THEROCK_SPLIT_DEBUG_INFO and do split .build-id based debug files if enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,16 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   message(STATUS "Defaulted CMAKE_INSTALL_PREFIX to ${CMAKE_INSTALL_PREFIX}")
 endif()
 
+
 set(ROCM_MAJOR_VERSION 6)
 set(ROCM_MINOR_VERSION 4)
 set(ROCM_PATCH_VERSION 0)
+
+################################################################################
+# Debug Options
+################################################################################
+
+option(THEROCK_SPLIT_DEBUG_INFO "Enables splitting of debug info into dbg artifacts (and strips primary packages)" OFF)
 
 ################################################################################
 # Feature selection

--- a/base/artifact.toml
+++ b/base/artifact.toml
@@ -3,6 +3,7 @@
 [components.doc."base/half/stage"]
 
 # rocm_smi_lib
+[components.dbg."base/rocm_smi_lib/stage"]
 [components.dev."base/rocm_smi_lib/stage"]
 [components.doc."base/rocm_smi_lib/stage"]
 [components.lib."base/rocm_smi_lib/stage"]
@@ -28,6 +29,7 @@ include = [
 include = "libexec/**"
 
 # rocprofiler-register
+[components.dbg."base/rocprofiler-register/stage"]
 [components.dev."base/rocprofiler-register/stage"]
 [components.doc."base/rocprofiler-register/stage"]
 [components.lib."base/rocprofiler-register/stage"]

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -45,7 +45,7 @@ class ComponentDefaults:
 
 # Debug components collect all platform specific dbg file patterns.
 ComponentDefaults(
-    "dbg", 
+    "dbg",
     includes=[
         # Linux build-id based debug files.
         ".build-id/**/*.debug",

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -44,7 +44,14 @@ class ComponentDefaults:
 
 
 # Debug components collect all platform specific dbg file patterns.
-ComponentDefaults("dbg", includes=["**/*.dbg"])
+ComponentDefaults(
+    "dbg", 
+    includes=[
+        # Linux build-id based debug files.
+        ".build-id/**/*.debug",
+    ],
+)
+
 # Dev components include all static library based file patterns and
 # exclude file name patterns implicitly included for "run" and "lib".
 # Descriptors should explicitly include header file any package file

--- a/cmake/therock_global_post_subproject.cmake
+++ b/cmake/therock_global_post_subproject.cmake
@@ -75,7 +75,7 @@ function(_therock_post_process_rpath_target target)
 endfunction()
 
 
-# Iterate over all shared library and executable targets and set default RPATH 
+# Iterate over all shared library and executable targets and set default RPATH
 # (unless if globally disabled for the subproject).
 block()
   if(NOT THEROCK_NO_INSTALL_RPATH)
@@ -91,15 +91,15 @@ if(THEROCK_SPLIT_DEBUG_INFO AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
   include(CMakeFindBinUtils)
   block()
     install(
-      CODE "set(THEROCK_DEBUG_BUILD_ID_PATHS)" 
+      CODE "set(THEROCK_DEBUG_BUILD_ID_PATHS)"
       CODE "set(THEROCK_OBJCOPY \"${CMAKE_OBJCOPY}\")"
       CODE "set(THEROCK_READELF \"${CMAKE_READELF}\")"
       CODE "set(THEROCK_STAGE_INSTALL_ROOT \"${THEROCK_STAGE_INSTALL_ROOT}\")"
       COMPONENT THEROCK_DEBUG_BUILD_ID
     )
-    foreach(target 
-            ${THEROCK_EXECUTABLE_TARGETS} 
-            ${THEROCK_SHARED_LIBRARY_TARGETS} 
+    foreach(target
+            ${THEROCK_EXECUTABLE_TARGETS}
+            ${THEROCK_SHARED_LIBRARY_TARGETS}
             ${THEROCK_MODULE_TARGETS})
       set(_target_path "$<TARGET_FILE:${target}>")
       install(
@@ -109,7 +109,7 @@ if(THEROCK_SPLIT_DEBUG_INFO AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
     endforeach()
     install(
         SCRIPT "${THEROCK_SOURCE_DIR}/cmake/therock_install_linux_build_id_files.cmake"
-        COMPONENT THEROCK_DEBUG_BUILD_ID        
+        COMPONENT THEROCK_DEBUG_BUILD_ID
     )
   endblock()
 endif()

--- a/cmake/therock_global_post_subproject.cmake
+++ b/cmake/therock_global_post_subproject.cmake
@@ -10,6 +10,31 @@ include(therock_subproject_utils)
 set(THEROCK_ALL_TARGETS)
 therock_get_all_targets(THEROCK_ALL_TARGETS "${CMAKE_CURRENT_SOURCE_DIR}")
 
+# Separate linked targets into categories.
+set(THEROCK_EXECUTABLE_TARGETS)
+set(THEROCK_SHARED_LIBRARY_TARGETS)
+set(THEROCK_MODULE_TARGETS)
+block()
+  foreach(target ${THEROCK_ALL_TARGETS})
+    get_target_property(target_type "${target}" TYPE)
+    get_target_property(target_alias "${target}" ALIASED_TARGET)
+    if(target_alias)
+      continue()
+    endif()
+    if("${target_type}" STREQUAL "SHARED_LIBRARY")
+      list(APPEND THEROCK_SHARED_LIBRARY_TARGETS "${target}")
+    elseif("${target_type}" STREQUAL "EXECUTABLE")
+      list(APPEND THEROCK_EXECUTABLE_TARGETS "${target}")
+    elseif("${target_type}" STREQUAL "MODULE_LIBRARY")
+      list(APPEND THEROCK_MODULE_TARGETS "${target}")
+    endif()
+  endforeach()
+
+  set(THEROCK_SHARED_LIBRARY_TARGETS "${THEROCK_SHARED_LIBRARY_TARGETS}" PARENT_SCOPE)
+  set(THEROCK_EXECUTABLE_TARGETS "${THEROCK_EXECUTABLE_TARGETS}" PARENT_SCOPE)
+  set(THEROCK_MODULE_TARGETS "${THEROCK_MODULE_TARGETS}" PARENT_SCOPE)
+endblock()
+
 # Delegate to user post hook.
 if(THEROCK_USER_POST_HOOK)
   include("${THEROCK_USER_POST_HOOK}")
@@ -20,11 +45,12 @@ endif()
 # Unless if disabled by the global NO_INSTALL_RPATH on the project or locally
 # via THEROCK_NO_INSTALL_RPATH target property, performs default installation
 # RPATH assignment.
-function(_therock_post_process_rpath_target target target_type)
+function(_therock_post_process_rpath_target target)
   get_target_property(_no_install_rpath "${target}" THEROCK_NO_INSTALL_RPATH)
   if(THEROCK_NO_INSTALL_RPATH OR _no_install_rpath)
     return()
   endif()
+  get_target_property(target_type "${target}" TYPE)
 
   # Determine the target's origin, which is what RPATHs must be relative to.
   get_target_property(_origin ${target} THEROCK_INSTALL_RPATH_ORIGIN)
@@ -48,19 +74,42 @@ function(_therock_post_process_rpath_target target target_type)
   therock_set_install_rpath(TARGETS "${target}" PATHS ${_install_rpath})
 endfunction()
 
-# Iterate over all targets and set default RPATH (unless if globally disabled
-# for the subproject).
+
+# Iterate over all shared library and executable targets and set default RPATH 
+# (unless if globally disabled for the subproject).
 block()
   if(NOT THEROCK_NO_INSTALL_RPATH)
-    foreach(target ${THEROCK_ALL_TARGETS})
-      get_target_property(target_type "${target}" TYPE)
-      get_target_property(target_alias "${target}" ALIASED_TARGET)
-      if(ALIASED_TARGET OR
-        (NOT target_type STREQUAL "SHARED_LIBRARY" AND NOT target_type STREQUAL "EXECUTABLE"))
-        continue()
-      endif()
-
-      _therock_post_process_rpath_target(${target} ${target_type})
+    foreach(target ${THEROCK_EXECUTABLE_TARGETS} ${THEROCK_SHARED_LIBRARY_TARGETS})
+      _therock_post_process_rpath_target(${target})
     endforeach()
   endif()
 endblock()
+
+# Process all shared library and executable targets and emit install time code
+# to process their build id and split debug files out.
+if(THEROCK_SPLIT_DEBUG_INFO AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  include(CMakeFindBinUtils)
+  block()
+    install(
+      CODE "set(THEROCK_DEBUG_BUILD_ID_PATHS)" 
+      CODE "set(THEROCK_OBJCOPY \"${CMAKE_OBJCOPY}\")"
+      CODE "set(THEROCK_READELF \"${CMAKE_READELF}\")"
+      CODE "set(THEROCK_STAGE_INSTALL_ROOT \"${THEROCK_STAGE_INSTALL_ROOT}\")"
+      COMPONENT THEROCK_DEBUG_BUILD_ID
+    )
+    foreach(target 
+            ${THEROCK_EXECUTABLE_TARGETS} 
+            ${THEROCK_SHARED_LIBRARY_TARGETS} 
+            ${THEROCK_MODULE_TARGETS})
+      set(_target_path "$<TARGET_FILE:${target}>")
+      install(
+        CODE "list(APPEND THEROCK_DEBUG_BUILD_ID_PATHS \"${_target_path}\")"
+        COMPONENT THEROCK_DEBUG_BUILD_ID
+      )
+    endforeach()
+    install(
+        SCRIPT "${THEROCK_SOURCE_DIR}/cmake/therock_install_linux_build_id_files.cmake"
+        COMPONENT THEROCK_DEBUG_BUILD_ID        
+    )
+  endblock()
+endif()

--- a/cmake/therock_install_linux_build_id_files.cmake
+++ b/cmake/therock_install_linux_build_id_files.cmake
@@ -1,0 +1,53 @@
+# This script is included during cmake_install.cmake at the top level of any
+# sub-project which is seeking to split its debug files into a .build-id
+# root folder on Linux.
+# It runs with the following variables in scope:
+#   THEROCK_DEBUG_BUILD_ID_PATHS: Absolute paths to binaries that are expected
+#     to contain a Build ID for separating out debug info.
+#   THEROCK_OBJCOPY: `objcopy` command found at configure time.
+#   THEROCK_READELF: `readelf` command found at configure time.
+#   THEROCK_STAGE_INSTALL_ROOT: The root of the stage installation tree. This
+#     may be different from the CMAKE_INSTALL_PREFIX for projects that install
+#     into a sub-tree within the overall tree.
+# For each binary, inspects it to find the Build ID from an ELF section like:
+#
+#   Displaying notes found in: .note.gnu.build-id
+#   Owner                Data size        Description
+#   GNU                  0x00000014       NT_GNU_BUILD_ID (unique build ID bitstring)
+#     Build ID: dac12d72d961c9d08880d946cd26618f0107dc4b
+# And then installs the debug sections to an appropriate file in .build-id/
+
+block()
+  foreach(binary_path ${THEROCK_DEBUG_BUILD_ID_PATHS})
+    if(NOT EXISTS "${binary_path}")
+      message("Skipping debug info for ${binary_path} (does not exist)")
+      continue()
+    endif()
+
+    execute_process(
+      OUTPUT_VARIABLE elf_output
+      COMMAND "${THEROCK_READELF}" -n "${binary_path}"
+      COMMAND_ERROR_IS_FATAL ANY
+    )
+    string(REGEX MATCH "Build ID: ([0-9a-zA-Z][0-9a-zA-Z])([0-9a-zA-Z]+)" build_id_match "${elf_output}")
+    if(NOT build_id_match)
+      message(WARNING "Binary ${binary_path} contains no Build ID (possibly not built with compatible flags)")
+      continue()
+    endif()
+
+    set(_build_id_prefix "${CMAKE_MATCH_1}")
+    set(_build_id_suffix "${CMAKE_MATCH_2}")
+    set(_output_path ".build-id/${_build_id_prefix}/${_build_id_suffix}.debug")
+    message(STATUS "Installing debug info from ${binary_path} to ${_output_path}")
+
+    set(_output_path "${THEROCK_STAGE_INSTALL_ROOT}/${_output_path}")
+    cmake_path(GET _output_path PARENT_PATH _parent_dir)
+    file(MAKE_DIRECTORY "${_parent_dir}")
+    execute_process(
+      COMMAND 
+        "${THEROCK_OBJCOPY}" --only-keep-debug
+        "${binary_path}" "${_output_path}"
+      COMMAND_ERROR_IS_FATAL ANY
+    )
+  endforeach()
+endblock()

--- a/cmake/therock_install_linux_build_id_files.cmake
+++ b/cmake/therock_install_linux_build_id_files.cmake
@@ -44,7 +44,7 @@ block()
     cmake_path(GET _output_path PARENT_PATH _parent_dir)
     file(MAKE_DIRECTORY "${_parent_dir}")
     execute_process(
-      COMMAND 
+      COMMAND
         "${THEROCK_OBJCOPY}" --only-keep-debug
         "${binary_path}" "${_output_path}"
       COMMAND_ERROR_IS_FATAL ANY

--- a/compiler/artifact-hipify.toml
+++ b/compiler/artifact-hipify.toml
@@ -1,3 +1,4 @@
+[components.dbg."compiler/hipify/stage"]
 [components.run."compiler/hipify/stage"]
 include = [
   "bin/**",

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -138,6 +138,7 @@ if(THEROCK_ENABLE_PRIM)
   therock_provide_artifact(prim
     DESCRIPTOR artifact-prim.toml
     COMPONENTS
+      dbg
       dev
       doc
       test

--- a/math-libs/artifact-prim.toml
+++ b/math-libs/artifact-prim.toml
@@ -1,4 +1,5 @@
 # rocPRIM
+[components.dbg."math-libs/rocPRIM/stage"]
 [components.dev."math-libs/rocPRIM/stage"]
 [components.doc."math-libs/rocPRIM/stage"]
 [components.test."math-libs/rocPRIM/stage"]
@@ -8,6 +9,7 @@ include = [
 ]
 
 # hipCUB
+[components.dbg."math-libs/hipCUB/stage"]
 [components.dev."math-libs/hipCUB/stage"]
 [components.doc."math-libs/hipCUB/stage"]
 [components.test."math-libs/hipCUB/stage"]
@@ -17,6 +19,7 @@ include = [
 ]
 
 # rocThrust
+[components.dbg."math-libs/rocThrust/stage"]
 [components.dev."math-libs/rocThrust/stage"]
 [components.doc."math-libs/rocThrust/stage"]
 [components.test."math-libs/rocThrust/stage"]


### PR DESCRIPTION
* Linux only.
* If enabled, adds staging install time steps to populate the stage install `.build-id/` directory tree.
* All sub-projects will be augmented to split their debugging files in this way, and the staging install will be done with `--strip`.
* Verified it works by starting gdb and pointing at the debug directory (`set debug-file-directory build/dist/rocm`) and debugging clang (`file build/dist/rocm/lib/llvm/bin/clang`).
* The artifact specific `.build-id` trees can be uploaded to OS specific repositories, served through a symbol server, or hosted on S3 (and gdb can be configured to fetch them by URL as needed).
* Before being usable, we need to tweak debug levels project wide to balance utility with size. And we need to prune the LLVM installation overall: we shouldn't even be building most of the things there that are adding a lot of symbol bloat (~16GiB currently, and the rest is a rounding error compared to that).