### PR TITLE
Fix origin locations for host-math RPATH calculations.

### DIFF
--- a/third-party/SuiteSparse/CMakeLists.txt
+++ b/third-party/SuiteSparse/CMakeLists.txt
@@ -13,6 +13,14 @@ therock_cmake_subproject_declare(therock-SuiteSparse
   OUTPUT_ON_FAILURE
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
   INSTALL_DESTINATION "lib/host-math"
+  # RPATH logic needs to know that executables/libs for this project are in
+  # a non-default location.
+  INSTALL_RPATH_EXECUTABLE_DIR "lib/host-math/bin"
+  INSTALL_RPATH_LIBRARY_DIR "lib/host-math/lib"
+  # We both have inter-library deps and need to advertise that consumers need
+  # their RPATH to include our locations.
+  INSTALL_RPATH_DIRS "lib/host-math/lib"
+  INTERFACE_INSTALL_RPATH_DIRS "lib/host-math/lib"
   CMAKE_ARGS
     "-DSUITESPARSE_ENABLE_PROJECTS=\"suitesparse_config;cholmod\""
     -DBLA_VENDOR=OpenBLAS
@@ -36,6 +44,13 @@ therock_cmake_subproject_provide_package(
 therock_cmake_subproject_provide_package(
   therock-SuiteSparse SuiteSparse_config lib/host-math/lib/cmake/SuiteSparse_config)
 therock_cmake_subproject_activate(therock-SuiteSparse)
+
+therock_test_validate_shared_lib(
+  PATH dist/lib/host-math/lib
+  LIB_NAMES
+    libamd.so libcamd.so libccolamd.so libcholmod.so libcolamd.so
+    libsuitesparseconfig.so
+)
 
 therock_provide_artifact(host-suite-sparse
   DESCRIPTOR artifact-host-suite-sparse.toml

--- a/third-party/host-blas/CMakeLists.txt
+++ b/third-party/host-blas/CMakeLists.txt
@@ -26,6 +26,10 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
       EXTERNAL_SOURCE_DIR .
       INSTALL_DESTINATION "lib/host-math"
       INTERFACE_LINK_DIRS "lib/host-math/lib"
+      # RPATH logic needs to know that executables/libs for this project are in
+      # a non-default location.
+      INSTALL_RPATH_EXECUTABLE_DIR "lib/host-math/bin"
+      INSTALL_RPATH_LIBRARY_DIR "lib/host-math/lib"
       INTERFACE_INSTALL_RPATH_DIRS "lib/host-math/lib"
       CMAKE_ARGS
         "-DSOURCE_DIR=${_source_dir}"
@@ -41,6 +45,11 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     therock_cmake_subproject_provide_package(therock-host-blas OpenBLAS lib/host-math/lib/cmake/OpenBLAS)
     therock_cmake_subproject_provide_package(therock-host-blas cblas lib/host-math/lib/cmake/OpenBLAS)
     therock_cmake_subproject_activate(therock-host-blas)
+
+    therock_test_validate_shared_lib(
+      PATH dist/lib/host-math/lib
+      LIB_NAMES libopenblas.so
+    )
 
     therock_provide_artifact(host-blas
       DESCRIPTOR artifact-host-OpenBLAS.toml


### PR DESCRIPTION
* Sets INSTALL_RPATH_EXECUTABLE_DIR and INSTALL_RPATH_LIBRARY_DIR on blas and suite sparse, since they are installed to a non-default location.
* Forces a private RPATH (via INSTALL_RPATH_DIRS) on suite sparse, since it has inter-library same-directory dependencies.
* Advertises an interface RPATH (via INTERFACE_INSTALL_RPATH_DIRS) on suite sparse, since consumers need to know where its lib directory is.
* Note that the above two are for completeness: since the blas library advertises the same, it gets them from there, but specifying for each project avoids issues of things moving around later.