### PR TITLE
Add missing `libhipblas_fortran.so` to artifact

### DIFF
--- a/math-libs/BLAS/artifact-blas.toml
+++ b/math-libs/BLAS/artifact-blas.toml
@@ -9,9 +9,13 @@
 [components.dev."math-libs/BLAS/hipBLAS/stage"]
 [components.doc."math-libs/BLAS/hipBLAS/stage"]
 [components.lib."math-libs/BLAS/hipBLAS/stage"]
+exclude = [
+  "lib/libhipblas_fortran.so",
+]
 [components.test."math-libs/BLAS/hipBLAS/stage"]
 include = [
   "bin/hipblas_*.yaml",
+  "lib/libhipblas_fortran.so",
   # Clients benchmarks
   "bin/hipblas-bench",
   "bin/hipblas_v2-bench",

--- a/patches/amd-mainline/hipBLAS/0003-Install-libhipblas_fortran.so.patch
+++ b/patches/amd-mainline/hipBLAS/0003-Install-libhipblas_fortran.so.patch
@@ -1,0 +1,26 @@
+From 436360742b499f0838ee90bfbbf912f4f52106db Mon Sep 17 00:00:00 2001
+From: Marius Brehler <marius.brehler@amd.com>
+Date: Tue, 1 Apr 2025 20:58:38 +0000
+Subject: [PATCH 3/3] Install `libhipblas_fortran.so`
+
+This is required by the test and benchmark clients but was not part of
+the installation so far.
+---
+ library/src/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/library/src/CMakeLists.txt b/library/src/CMakeLists.txt
+index 083e8eb..d6c849f 100755
+--- a/library/src/CMakeLists.txt
++++ b/library/src/CMakeLists.txt
+@@ -51,6 +51,7 @@ set (hipblas_f90_source
+ # Create hipBLAS Fortran module
+ if(NOT WIN32)
+     add_library(hipblas_fortran ${hipblas_f90_source})
++    rocm_install(TARGETS hipblas_fortran)
+ endif()
+ 
+ if(BUILD_ADDRESS_SANITIZER)
+-- 
+2.43.0
+


### PR DESCRIPTION
`libhipblas_fortran.so` is required by the test and benchmark clients but was not part of an installation and therefore also not included in the artifact so far.