### PR TITLE
Setup CLR for Windows with PAL static lib patches.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,14 +117,26 @@ therock_add_feature(HIPIFY
 )
 
 # Core Features.
-therock_add_feature(CORE_RUNTIME
-  GROUP CORE
-  DESCRIPTION "Enables the core device runtime and tools"
-)
+# The HIP runtime for ROCm uses different implementations per platform today:
+#   * HIP on Linux uses the HSA runtime in ROCR-Runtime, used by CLR.
+#   * HIP on Windows uses the PAL runtime included directly as part of CLR.
+# https://rocm.docs.amd.com/projects/install-on-windows/en/latest/reference/component-support.html
+if(NOT WIN32)
+  # Other platforms (Linux) _do_ have the "core runtime".
+  therock_add_feature(CORE_RUNTIME
+    GROUP CORE
+    DESCRIPTION "Enables the core device runtime and tools"
+  )
+  set(_hip_runtime_platform_requirements "CORE_RUNTIME")
+else()
+  # No "core runtime" (ROCR-Runtime + rocminfo) on Windows.
+  # TODO(#36): Could provide an alternate or no-op "core runtime" instead?
+  set(_hip_runtime_platform_requirements "")
+endif()
 therock_add_feature(HIP_RUNTIME
   GROUP CORE
   DESCRIPTION "Enables the HIP runtime"
-  REQUIRES COMPILER CORE_RUNTIME
+  REQUIRES COMPILER ${_hip_runtime_platform_requirements}
 )
 
 # Profiler Features.

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,0 +1,2 @@
+# TODO(#36): remove (and delete this file) once this folder is open sourced
+compute-win/

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -72,61 +72,110 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
   # functional from this project (which contributes version and metadata).
   ##############################################################################
 
-  therock_cmake_subproject_declare(hip-clr
-    EXTERNAL_SOURCE_DIR "clr"
-    INTERFACE_PROGRAM_DIRS
-      bin
-    BACKGROUND_BUILD
-    CMAKE_ARGS
-      -DHIP_PLATFORM=amd
-      "-DHIP_COMMON_DIR=${CMAKE_CURRENT_SOURCE_DIR}/HIP"
-      -DCLR_BUILD_HIP=ON
-      # Legacy: Disable various auto-detection logic that breaks out of jail
-      # and can use local machine tools.
-      -DHIPCC_BIN_DIR=
-    BUILD_DEPS
-      rocm-cmake
-    RUNTIME_DEPS
-      amd-llvm
-      amd-comgr
-      hipcc     # For hipconfig
-      rocm-core
-      rocminfo  # Various things expect to be able to find the rocminfo tools
-      rocprofiler-register
-      ROCR-Runtime
-    INTERFACE_LINK_DIRS
-      "lib"
-    INTERFACE_INSTALL_RPATH_DIRS
-      "lib"
-  )
-  therock_cmake_subproject_glob_c_sources(hip-clr SUBDIRS .)
-  therock_cmake_subproject_provide_package(hip-clr hip lib/cmake/hip)
-  # TODO: Some projects resolve "hip" vs "HIP" so we advertise both, but this isn't
-  # great.
-  therock_cmake_subproject_provide_package(hip-clr HIP lib/cmake/hip)
-  therock_cmake_subproject_provide_package(hip-clr hip-lang lib/cmake/hip-lang)
-  therock_cmake_subproject_provide_package(hip-clr hiprtc lib/cmake/hiprtc)
-  therock_cmake_subproject_activate(hip-clr)
+  # CLR configuration is different enough between Linux and Windows that we
+  # branch at a high level here instead of extending individual options.
+  # TODO(#36): Share more code here, once options settle.
+  if(NOT WIN32)
+    therock_cmake_subproject_declare(hip-clr
+      EXTERNAL_SOURCE_DIR "clr"
+      INTERFACE_PROGRAM_DIRS
+        bin
+      BACKGROUND_BUILD
+      CMAKE_ARGS
+        -DHIP_PLATFORM=amd
+        "-DHIP_COMMON_DIR=${CMAKE_CURRENT_SOURCE_DIR}/HIP"
+        -DCLR_BUILD_HIP=ON
+        # Legacy: Disable various auto-detection logic that breaks out of jail
+        # and can use local machine tools.
+        -DHIPCC_BIN_DIR=
+      BUILD_DEPS
+        rocm-cmake
+      RUNTIME_DEPS
+        amd-llvm
+        amd-comgr
+        hipcc     # For hipconfig
+        rocm-core
+        rocminfo  # Various things expect to be able to find the rocminfo tools
+        rocprofiler-register
+        ROCR-Runtime
+      INTERFACE_LINK_DIRS
+        "lib"
+      INTERFACE_INSTALL_RPATH_DIRS
+        "lib"
+    )
+    therock_cmake_subproject_glob_c_sources(hip-clr SUBDIRS .)
+    therock_cmake_subproject_provide_package(hip-clr hip lib/cmake/hip)
+    # TODO: Some projects resolve "hip" vs "HIP" so we advertise both, but this isn't
+    # great.
+    therock_cmake_subproject_provide_package(hip-clr HIP lib/cmake/hip)
+    therock_cmake_subproject_provide_package(hip-clr hip-lang lib/cmake/hip-lang)
+    therock_cmake_subproject_provide_package(hip-clr hiprtc lib/cmake/hiprtc)
+    therock_cmake_subproject_activate(hip-clr)
 
+    therock_provide_artifact(core-hip
+      TARGET_NEUTRAL
+      DESCRIPTOR artifact-core-hip.toml
+      COMPONENTS
+        dbg
+        dev
+        doc
+        lib
+        run
+      SUBPROJECT_DEPS
+        hip-clr
+    )
 
-  therock_provide_artifact(core-hip
-    TARGET_NEUTRAL
-    DESCRIPTOR artifact-core-hip.toml
-    COMPONENTS
-      dbg
-      dev
-      doc
-      lib
-      run
-    SUBPROJECT_DEPS
-      hip-clr
-  )
+    therock_test_validate_shared_lib(
+      PATH clr/dist/lib
+      LIB_NAMES
+        libamdhip64.so
+        libhiprtc-builtins.so
+        libhiprtc.so
+    )
+  else()
+    set(_compute_win_dir "${CMAKE_CURRENT_SOURCE_DIR}/compute-win")
+    if(NOT EXISTS ${_compute_win_dir})
+      message(FATAL_ERROR "Can't build CLR: missing closed source 'compute-win' folder expected at '${_compute_win_dir}'")
+    endif()
 
-  therock_test_validate_shared_lib(
-    PATH clr/dist/lib
-    LIB_NAMES
-      libamdhip64.so
-      libhiprtc-builtins.so
-      libhiprtc.so
-  )
+    therock_cmake_subproject_declare(hip-clr
+      EXTERNAL_SOURCE_DIR "clr"
+      INTERFACE_PROGRAM_DIRS
+        bin
+      BACKGROUND_BUILD
+      CMAKE_ARGS
+        "-DHIP_PLATFORM=amd"
+        "-DHIP_COMMON_DIR=${CMAKE_CURRENT_SOURCE_DIR}/HIP"
+        "-DCLR_BUILD_HIP=ON"
+        # Legacy: Disable various auto-detection logic that breaks out of jail
+        # and can use local machine tools.
+        "-DHIPCC_BIN_DIR="
+
+        # Windows specific options.
+        "-DUSE_PROF_API=OFF"
+        "-D__HIP_ENABLE_PCH=OFF"
+        "-DROCCLR_ENABLE_PAL=1"
+        "-DROCCLR_ENABLE_HSA=0"
+        "-DAMD_COMPUTE_WIN=${_compute_win_dir}"
+      BUILD_DEPS
+        rocm-cmake
+      RUNTIME_DEPS
+        amd-llvm
+        amd-comgr
+        hipcc     # For hipconfig
+        rocm-core
+      INTERFACE_LINK_DIRS
+        "lib"
+      INTERFACE_INSTALL_RPATH_DIRS
+        "lib"
+    )
+    therock_cmake_subproject_glob_c_sources(hip-clr SUBDIRS .)
+    therock_cmake_subproject_provide_package(hip-clr hip lib/cmake/hip)
+    # TODO: Some projects resolve "hip" vs "HIP" so we advertise both, but this isn't
+    # great.
+    therock_cmake_subproject_provide_package(hip-clr HIP lib/cmake/hip)
+    therock_cmake_subproject_provide_package(hip-clr hip-lang lib/cmake/hip-lang)
+    therock_cmake_subproject_provide_package(hip-clr hiprtc lib/cmake/hiprtc)
+    therock_cmake_subproject_activate(hip-clr)
+  endif()
 endif(THEROCK_ENABLE_HIP_RUNTIME)

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -34,7 +34,7 @@ mainline, in open source, using MSVC, etc.).
 |                  |                                                                              |           |                                                  |
 | core             | [ROCR-Runtime](https://github.com/ROCm/ROCR-Runtime)                         | ❌        | Unsupported                                      |
 | core             | [rocminfo](https://github.com/ROCm/rocminfo)                                 | ❌        | Unsupported                                      |
-| core             | [clr](https://github.com/ROCm/clr)                                           | ❔        | Under review (partly closed source)              |
+| core             | [clr](https://github.com/ROCm/clr)                                           | ⭕        | Needs a folder with prebuilt static libraries    |
 |                  |                                                                              |           |                                                  |
 | profiler         | [rocprofiler-sdk](https://github.com/ROCm/rocprofiler-sdk)                   | ❔        |                                                  |
 |                  |                                                                              |           |                                                  |
@@ -206,3 +206,36 @@ cmake --build build
 
 At the moment this should build some projects in [`base/`](../../base/) as well
 as [`compiler/`](../../compiler/).
+
+### Building CLR from partial sources
+
+We are actively working on enabling source builds of
+https://github.com/ROCm/clr (notably for `amdhip64_6.dll`) on Windows.
+Historically this has been a closed source component due to the dependency on
+[Platform Abstraction Library (PAL)](https://github.com/GPUOpen-Drivers/pal)
+and providing a fully open source build will take more time. As an incremental
+step towards a fully open source build, we will use a `compute-win` folder
+containing header files and static library `.lib` files for PAL and related
+components.
+
+An incremental rollout is planned:
+
+1. *(We are here today)* The `compute-win` folder must be manually copied into
+   place at `core/compute-win`. This will allow AMD developers to iterate on
+   integration into TheRock while we work on making this folder or more source
+   files available.
+1. The `compute-win` folder will be available publicly and will be included
+   automatically from either a git repository or cloud storage (like the
+   existing third party dep mirrors in [`third-party/`](../../third-party/)).
+1. A more permanent open source strategy for building the CLR (the HIP runtime)
+   from source on Windows will eventually be available.
+
+With the `compute-win` folder available, build by configuring CMake with these
+options set:
+
+```bash
+-DTHEROCK_ENABLE_CORE=ON \
+-DTHEROCK_ENABLE_HIP_RUNTIME=ON \
+```
+
+then look for `build/core/clr/dist/bin/amdhip64_6.dll` and related outputs.

--- a/patches/amd-mainline/clr/0001-Disable-HIP_PLATFORM-auto-detect-if-already-defined.patch
+++ b/patches/amd-mainline/clr/0001-Disable-HIP_PLATFORM-auto-detect-if-already-defined.patch
@@ -1,7 +1,7 @@
-From 54553db0d22c76c25863b5af9467d03afb94a9d3 Mon Sep 17 00:00:00 2001
+From e4a9f525ff7620f82927dbac692102979b8510ad Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Wed, 22 Jan 2025 14:01:50 -0800
-Subject: [PATCH] Disable HIP_PLATFORM auto-detect if already defined.
+Subject: [PATCH 1/2] Disable HIP_PLATFORM auto-detect if already defined.
 
 This code appears to be old copy-pasta and is effectively just a no-op if -DHIP_PLATFORM=amd is passed explicitly. It has a number of nit-picky checks which will fail in this case for no real reason.
 
@@ -89,7 +89,7 @@ index cc9cf1654..ad2201073 100644
      option(BUILD_SHARED_LIBS "Build the shared library" ON)
      if (NOT BUILD_SHARED_LIBS)
 diff --git a/hipamd/CMakeLists.txt b/hipamd/CMakeLists.txt
-index 9538dbbad..7babbfc36 100755
+index b9f90e315..ad5eba4d2 100755
 --- a/hipamd/CMakeLists.txt
 +++ b/hipamd/CMakeLists.txt
 @@ -53,7 +53,8 @@ if(MSVC)
@@ -102,7 +102,7 @@ index 9538dbbad..7babbfc36 100755
  
  if(__HIP_ENABLE_PCH)
    set(_pchStatus 1)
-@@ -393,9 +394,11 @@ endif()
+@@ -410,9 +411,11 @@ endif()
  install(FILES ${PROJECT_BINARY_DIR}/include/hip/hip_version.h
          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hip)
  
@@ -151,5 +151,5 @@ index 1fcdcd970..d033c09ac 100755
 +  set(HIP_HIPCONFIG_EXECUTABLE ${hip_HIPCONFIG_EXECUTABLE})
 +endif()
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/clr/0002-Apply-patches-for-PAL-static-library-build.patch
+++ b/patches/amd-mainline/clr/0002-Apply-patches-for-PAL-static-library-build.patch
@@ -1,0 +1,99 @@
+From 78e3449a389c56e906f355a416e23dd5ad34bca7 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Mon, 31 Mar 2025 14:23:27 -0700
+Subject: [PATCH 2/2] Apply patches for PAL static library build.
+
+---
+ CMakeLists.txt                     |  8 ++++++
+ rocclr/cmake/FindAMD_PAL_LIB.cmake | 42 ++++++++++++++++++++++++++++++
+ rocclr/cmake/ROCclrPAL.cmake       |  6 ++++-
+ 3 files changed, 55 insertions(+), 1 deletion(-)
+ create mode 100644 rocclr/cmake/FindAMD_PAL_LIB.cmake
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ad2201073..ab8fd5baa 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -29,6 +29,14 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     string(REPLACE "/GR" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+     string(REPLACE "/W3" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+ endif()
++
++if (AMD_COMPUTE_WIN)
++    add_compile_options("/MT")
++    set(AMD_LIBELF_PATH "${AMD_COMPUTE_WIN}/hsail-compiler/lib/loaders/elf/utils/libelf")
++    set(AMD_SC_PATH "${AMD_COMPUTE_WIN}/sc")
++    message("Public Compute Windows build path: ${AMD_COMPUTE_WIN}, SC: ${AMD_SC_PATH}, LibElf: ${AMD_LIBELF_PATH}")
++endif()
++
+ option(CLR_BUILD_HIP "Build HIP" OFF)
+ option(CLR_BUILD_OCL "Build OCL" OFF)
+ 
+diff --git a/rocclr/cmake/FindAMD_PAL_LIB.cmake b/rocclr/cmake/FindAMD_PAL_LIB.cmake
+new file mode 100644
+index 000000000..d5f600143
+--- /dev/null
++++ b/rocclr/cmake/FindAMD_PAL_LIB.cmake
+@@ -0,0 +1,42 @@
++# Copyright (c) 2020 - 2021 Advanced Micro Devices, Inc. All rights reserved.
++#
++# Permission is hereby granted, free of charge, to any person obtaining a copy
++# of this software and associated documentation files (the "Software"), to deal
++# in the Software without restriction, including without limitation the rights
++# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++# copies of the Software, and to permit persons to whom the Software is
++# furnished to do so, subject to the following conditions:
++#
++# The above copyright notice and this permission notice shall be included in
++# all copies or substantial portions of the Software.
++#
++# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
++# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
++# THE SOFTWARE.
++
++if(AMD_PAL_LIB_FOUND)
++  return()
++endif()
++
++find_path(AMD_PAL_LIB_INCLUDE_DIR pal.h
++  HINTS
++    ${AMD_COMPUTE_WIN}/pal
++  PATHS
++    ${CMAKE_SOURCE_DIR}/pal
++    ${CMAKE_SOURCE_DIR}/../pal
++    ${CMAKE_SOURCE_DIR}/../../pal
++    ${CMAKE_SOURCE_DIR}/../../../pal
++  PATH_SUFFIXES
++    inc/core)
++
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(AMD_PAL_LIB
++  "\nPAL not found"
++  AMD_PAL_LIB_INCLUDE_DIR)
++mark_as_advanced(AMD_PAL_LIB_INCLUDE_DIR)
++
++add_subdirectory("${AMD_PAL_LIB_INCLUDE_DIR}/../.." ${CMAKE_CURRENT_BINARY_DIR}/pal)
+diff --git a/rocclr/cmake/ROCclrPAL.cmake b/rocclr/cmake/ROCclrPAL.cmake
+index 91122433c..681301275 100644
+--- a/rocclr/cmake/ROCclrPAL.cmake
++++ b/rocclr/cmake/ROCclrPAL.cmake
+@@ -52,7 +52,11 @@ set(PAL_BUILD_PHOENIX1      ON)
+ 
+ set(PAL_BRANCHDEFS          ON)
+ 
+-find_package(AMD_PAL)
++if (AMD_COMPUTE_WIN)
++  find_package(AMD_PAL_LIB)
++elseif()
++  find_package(AMD_PAL)
++endif()
+ find_package(AMD_HSA_LOADER)
+ 
+ target_sources(rocclr PRIVATE
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/36.

Now we can build parts of [AMD CLR](https://github.com/ROCm/clr) on Windows by using a mix of open source files and precompiled static libraries for [Platform Abstraction Layer (PAL)](https://github.com/GPUOpen-Drivers/pal). Notably, we can build `amdhip64_6.dll`, which I have used together with `amd_comgr_2.dll` (from [amd-llvm](https://github.com/ROCm/llvm-project/tree/amd-staging/amd/comgr)) to successfully run some binaries from [rocm-examples](https://github.com/ROCm/rocm-examples).

Sequencing details:

* The requisite files for the build are not yet open sourced, so I've set up a placeholder `compute-win/` folder covered by `.gitignore` that I and other AMD developers can use for Windows support bring-up.
* The patch for CLR that connects `-DAMD_COMPUTE_WIN=${PATH}` to the `compute-win/` folder was authored by @gandryey and has not yet landed in https://github.com/ROCm/clr. We'll likely need to adapt in some way as these patches flow across projects.
* This is not yet compatible with the math-lib subprojects, as the toolchain setup that I prefetched in https://github.com/ROCm/TheRock/pull/177 will need some tweaks now that we can use a (partial) source build of CLR instead of only being able to bootstrap from an existing download of the HIP SDK referenced by the `HIP_PATH` environment variable.
  * That will be fixed in fixed in https://github.com/ROCm/TheRock/pull/331