### PR TITLE
Finish getting pytorch to build with rocm-sdk wheels.

### DIFF
--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -390,12 +390,12 @@ class PopulatedDistPackage:
         tar_path = self.pure_dir / f"_devel{tar_suffix}"
         log(f"::: Building secondary devel tarball: {tar_path}")
         with tarfile.open(tar_path, mode=tar_mode) as tf:
-            for root, _, files in os.walk(package_path):
-                for file in files:
+            for root, dirnames, files in os.walk(package_path):
+                for file in list(files) + list(dirnames):
                     file_path = os.path.join(root, file)
                     arcname = os.path.relpath(file_path, package_path.parent)
                     log(f"Adding {arcname}", vlog=2)
-                    tf.add(file_path, arcname=arcname)
+                    tf.add(file_path, arcname=arcname, recursive=False)
         shutil.rmtree(package_path)
 
     def _populate_devel_file(

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -1,6 +1,6 @@
 """Utilities for producing Python packages."""
 
-from typing import Callable
+from typing import Callable, Sequence
 
 import importlib.util
 import magic
@@ -75,6 +75,7 @@ class Parameters:
         self.all_target_families = artifacts.all_target_families
         self.default_target_family = sorted(self.all_target_families)[0]
         self.files = PopulatedFiles()
+        self.runtime_artifact_names: set[str] = set()
 
         # Load and interpolate the _dist_info.py template.
         dist_info_contents = DIST_INFO_PATH.read_text()
@@ -225,6 +226,9 @@ class PopulatedDistPackage:
         )
         for an, an_path in artifacts.artifact_basedirs:
             log(f"  + {an}: {an_path}")
+            # Accumulate the artifact names we have created runtime packages for.
+            # This will be used later to restrict devel packages to only these.
+            self.params.runtime_artifact_names.add(an.name)
 
         files = self.params.files
         package_dest_dir = self.platform_dir
@@ -338,10 +342,34 @@ class PopulatedDistPackage:
             ]
             subprocess.check_call(patchelf_cl)
 
-    def populate_devel_files(self, tarball_compression: bool = True):
+    def populate_devel_files(
+        self,
+        *,
+        addl_artifact_names: Sequence[str] = (),
+        tarball_compression: bool = True,
+    ):
         """Populates all files that have not yet been materialized and symlink the rest."""
         package_path = self.platform_dir
-        artifacts = self.params.artifacts
+        # Set up for what artifacts to include in the devel package, including
+        # any emitted runtime artifacts plus additional requested.
+        devel_artifact_names = set(self.params.runtime_artifact_names)
+        devel_artifact_names.update(addl_artifact_names)
+        log(f":: Devel artifact inclusions: {devel_artifact_names}")
+
+        def _devel_artifact_filter(an: ArtifactName) -> bool:
+            if an.name not in devel_artifact_names:
+                # We didn't generate a runtime artifact for it, so no devel
+                # artifact.
+                return False
+            if (
+                an.target_family != "generic"
+                and an.target_family != self.params.default_target_family
+            ):
+                # We only materialize the default target family for devel packages.
+                return False
+            return True
+
+        artifacts = self.params.filter_artifacts(_devel_artifact_filter)
         log(f"::: Populating devel package {package_path}")
         for an, an_path in artifacts.artifact_basedirs:
             log(f"  + {an}: {an_path}")

--- a/build_tools/linux_python_package.py
+++ b/build_tools/linux_python_package.py
@@ -99,7 +99,14 @@ def run(args: argparse.Namespace):
 
     # And populate the devel package, which catches everything else.
     devel = PopulatedDistPackage(params, logical_name="devel")
-    devel.populate_devel_files(tarball_compression=args.devel_tarball_compression)
+    devel.populate_devel_files(
+        addl_artifact_names=[
+            # Since prim is a header only library, it is not included in runtime
+            # packages, but we still want it in the devel package.
+            "prim",
+        ],
+        tarball_compression=args.devel_tarball_compression,
+    )
 
     if args.build_packages:
         build_packages(args.dest_dir, wheel_compression=args.wheel_compression)
@@ -113,7 +120,6 @@ def core_artifact_filter(an: ArtifactName) -> bool:
         "core-runtime",
         "host-blas",
         "host-suite-sparse",
-        "rocprofiler-sdk",
         "sysdeps",
     ] and an.component in [
         "lib",
@@ -133,7 +139,6 @@ def libraries_artifact_filter(target_family: str, an: ArtifactName) -> bool:
             "blas",
             "fft",
             "miopen",
-            "prim",
             "rand",
             "rccl",
         ]

--- a/build_tools/linux_python_package.py
+++ b/build_tools/linux_python_package.py
@@ -120,6 +120,7 @@ def core_artifact_filter(an: ArtifactName) -> bool:
         "core-runtime",
         "host-blas",
         "host-suite-sparse",
+        "rocprofiler-sdk",
         "sysdeps",
     ] and an.component in [
         "lib",

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/__init__.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/__init__.py
@@ -1,1 +1,79 @@
+import importlib
+from pathlib import Path
+import platform
+
 from ._dist_info import __version__
+
+__all__ = [
+    "__version__",
+    "find_libraries",
+]
+
+
+def find_libraries(*shortnames: str) -> list[Path]:
+    """Finds absolute paths to dynamic libraries by shortname.
+
+    See the list of LibraryEntry in _dist_info for the mapping of short names to
+    dist package and path.
+
+    Raises:
+        ModuleNotFoundError if any packages are not installed which provide the
+        requested libraries.
+    """
+    from . import _dist_info
+
+    paths: list[Path] = []
+    missing_extras: set[str] = set()
+    is_windows = platform.platform() == "Windows"
+    for shortname in shortnames:
+        try:
+            lib_entry = _dist_info.ALL_LIBRARIES[shortname]
+        except KeyError:
+            raise ModuleNotFoundError(f"Unknown rocm-sdk library '{shortname}'")
+        package = lib_entry.package
+        target_family = None
+        if package.is_target_specific:
+            target_family = _dist_info.determine_target_family()
+        py_package_name = package.get_py_package_name(target_family)
+        try:
+            py_module = importlib.import_module(py_package_name)
+        except ModuleNotFoundError:
+            missing_extras.add(package.logical_name)
+        py_root = Path(py_module.__file__).parent  # Chop __init__.py
+        assert not is_windows, "rocm_sdk.find_libraries not yet supported on Windows"
+        path = py_root / lib_entry.posix_relpath / lib_entry.soname
+        if not path.exists():
+            raise FileNotFoundError(
+                f"Could not find rocm-sdk library '{shortname}' at path {path}"
+            )
+        paths.append(path)
+
+    if missing_extras:
+        raise ModuleNotFoundError(
+            f"Missing required rocm-sdk libraries. Please refer to Python "
+            f"setup instructions, reinstall your virtual environment, or attempt to "
+            f"install manually via `pip install rocm-sdk[{','.join(missing_extras)}]`"
+        )
+    return paths
+
+
+_ALL_CDLLS = []
+
+
+def preload_libraries(*shortnames: str, rtld_global: bool = True):
+    """Preloads a list of library names, caching their handles globally.
+
+    This is typically used in applications which depend on rocm-sdk runtime libraries
+    prior to loading any of their own shared libraries that depend on them. By
+    preloading into the linker namespace, it ensures that subsequent resolution of them
+    by name should succeed.
+
+    Library paths are resolved via `find_libraries`.
+    """
+    import ctypes
+
+    paths = find_libraries(*shortnames)
+    mode = ctypes.RTLD_GLOBAL if rtld_global is True else ctypes.RTLD_LOCAL
+    for path in paths:
+        cdll = ctypes.CDLL(str(path), mode=mode)
+        _ALL_CDLLS.append(cdll)

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/__init__.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/__init__.py
@@ -24,7 +24,7 @@ def find_libraries(*shortnames: str) -> list[Path]:
 
     paths: list[Path] = []
     missing_extras: set[str] = set()
-    is_windows = platform.platform() == "Windows"
+    is_windows = platform.system() == "Windows"
     for shortname in shortnames:
         try:
             lib_entry = _dist_info.ALL_LIBRARIES[shortname]

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/_dist_info.py
@@ -161,6 +161,7 @@ PackageEntry(
 # Public libraries.
 LibraryEntry("amdhip64", "core", "libamdhip64.so.6")
 LibraryEntry("hiprtc", "core", "libhiprtc.so.6")
+LibraryEntry("rocprofiler-sdk-roctx", "core", "librocprofiler-sdk-roctx.so.0")
 
 LibraryEntry("hipblas", "libraries", "libhipblas.so.2")
 LibraryEntry("hipfft", "libraries", "libhipfft.so.0")

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/_dist_info.py
@@ -12,6 +12,23 @@ import platform
 CACHED_TARGET_FAMILY: str | None = None
 
 
+class LibraryEntry:
+    """Defines a public library that can be located by name within the overall
+    distribution."""
+
+    def __init__(self, shortname: str, package_name: str, soname: str):
+        self.shortname = shortname
+        self.package = ALL_PACKAGES[package_name]
+        self.posix_relpath = "lib"
+        self.windows_relpath = "bin"
+        self.soname = soname
+        assert shortname not in ALL_LIBRARIES
+        ALL_LIBRARIES[shortname] = self
+
+    def __repr__(self):
+        return f"{self.shortname}(soname={self.soname}, package={self.package})"
+
+
 class PackageEntry:
     """Defines a package known to the SDK.
 
@@ -66,11 +83,11 @@ class PackageEntry:
         dist_name = self.get_dist_package_name(target_family)
         return "_" + dist_name.replace("-", "_") + PY_PACKAGE_SUFFIX_NONCE
 
+    def get_py_package(self, target_family: str | None = None):
+        return importlib.util.find_spec(self.get_py_package_name(target_family))
+
     def has_py_package(self, target_family: str | None = None) -> bool:
-        return (
-            importlib.util.find_spec(self.get_py_package_name(target_family))
-            is not None
-        )
+        return self.get_py_package(self.get_py_package_name(target_family)) is not None
 
     def __repr__(self):
         return self.dist_package_template
@@ -109,6 +126,7 @@ def determine_target_family() -> str:
 
 # All packages that are part of the distribution.
 ALL_PACKAGES: dict[str, PackageEntry] = {}
+ALL_LIBRARIES: dict[str, LibraryEntry] = {}
 
 # Always available packages.
 PackageEntry(
@@ -139,6 +157,18 @@ PackageEntry(
     template_directory="rocm-sdk-devel",
     required=False,
 )
+
+# Public libraries.
+LibraryEntry("amdhip64", "core", "libamdhip64.so.6")
+LibraryEntry("hiprtc", "core", "libhiprtc.so.6")
+
+LibraryEntry("hipblas", "libraries", "libhipblas.so.2")
+LibraryEntry("hipfft", "libraries", "libhipfft.so.0")
+LibraryEntry("hiprand", "libraries", "libhiprand.so.1")
+LibraryEntry("hipsparse", "libraries", "libhipsparse.so.1")
+LibraryEntry("hipsolver", "libraries", "libhipsolver.so.0")
+LibraryEntry("rccl", "libraries", "librccl.so.1")
+LibraryEntry("hipblaslt", "libraries", "libhipblaslt.so.0")
 
 # Overall ROCM package version.
 __version__ = "DEFAULT"

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/core_test.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/core_test.py
@@ -104,3 +104,15 @@ class ROCmCoreTest(unittest.TestCase):
                         f"Expected '{expected_text}' in console-script {script_name} outuput:\n"
                         f"{output_text}"
                     )
+
+    def testPreloadLibraries(self):
+        target_family = di.determine_target_family()
+
+        for lib_entry in di.ALL_LIBRARIES.values():
+            # Only test for packages we have installed.
+            if lib_entry.package.has_py_package(target_family):
+                with self.subTest(
+                    msg="Check rocm_sdk.preload_libraries",
+                    shortname=lib_entry.shortname,
+                ):
+                    rocm_sdk.preload_libraries(lib_entry.shortname)

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/core_test.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/core_test.py
@@ -67,6 +67,14 @@ class ROCmCoreTest(unittest.TestCase):
         for so_path in so_paths:
             if "clang_rt" in so_path.name:
                 continue
+            if (
+                "librocprofiler-sdk" in str(so_path) or "librocprofv3" in str(so_path)
+            ) and "librocprofiler-sdk-roctx" not in str(so_path):
+                # rocprofiler-sdk still depends on aqlprofiler, which is not yet
+                # open-source. But we do need the roctx library to load properly
+                # regardless.
+                # See: https://github.com/ROCm/TheRock/issues/330
+                continue
             with self.subTest(msg="Check shared library loads", so_path=so_path):
                 # Load each in an isolated process because not all libraries in the tree
                 # are designed to load into the same process (i.e. LLVM runtime libs,

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/devel_test.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/devel_test.py
@@ -104,6 +104,14 @@ class ROCmDevelTest(unittest.TestCase):
                 # clang_rt and sanitizer libraries are not all intended to be
                 # loadable arbitrarily.
                 continue
+            if (
+                "librocprofiler-sdk" in str(so_path) or "librocprofv3" in str(so_path)
+            ) and "librocprofiler-sdk-roctx" not in str(so_path):
+                # rocprofiler-sdk still depends on aqlprofiler, which is not yet
+                # open-source. But we do need the roctx library to load properly
+                # regardless.
+                # See: https://github.com/ROCm/TheRock/issues/330
+                continue
             with self.subTest(msg="Check shared library loads", so_path=so_path):
                 # Load each in an isolated process because not all libraries in the tree
                 # are designed to load into the same process (i.e. LLVM runtime libs,

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/devel_test.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/devel_test.py
@@ -77,6 +77,19 @@ class ROCmDevelTest(unittest.TestCase):
         bin_path = path / "bin"
         self.assertTrue(bin_path.exists(), msg=f"Expected bin path {bin_path} to exist")
 
+    def testRootLLVMSymlinkExists(self):
+        # We had a bug where the root llvm/ symlink, which is for backwards compat,
+        # was not materialized. Verify it is.
+        output = (
+            utils.exec(
+                [sys.executable, "-P", "-m", "rocm_sdk", "path", "--root"], capture=True
+            )
+            .decode()
+            .strip()
+        )
+        path = Path(output) / "llvm" / "bin" / "clang++"
+        self.assertTrue(path.exists(), msg=f"Expected {path} to exist")
+
     def testSharedLibrariesLoad(self):
         # Make sure the devel package is expanded.
         _ = (

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
@@ -1,7 +1,7 @@
 From 2da1e65ba8b479efc656c633d899b5617107a61d Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 17 Feb 2025 16:47:57 -0800
-Subject: [PATCH 1/4] Rework LoadHIP.cmake to be based purely on
+Subject: [PATCH 1/5] Rework LoadHIP.cmake to be based purely on
  CMAKE_PREFIX_PATH.
 
 * Eliminates dependence on `/opt/rocm` and path based heuristics.

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
@@ -1,7 +1,7 @@
-From 6161376c9cf587097e27d9ebe0a3489849bbd9f1 Mon Sep 17 00:00:00 2001
+From 2da1e65ba8b479efc656c633d899b5617107a61d Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 17 Feb 2025 16:47:57 -0800
-Subject: [PATCH 1/3] Rework LoadHIP.cmake to be based purely on
+Subject: [PATCH 1/4] Rework LoadHIP.cmake to be based purely on
  CMAKE_PREFIX_PATH.
 
 * Eliminates dependence on `/opt/rocm` and path based heuristics.
@@ -11,7 +11,7 @@ Subject: [PATCH 1/3] Rework LoadHIP.cmake to be based purely on
  1 file changed, 110 insertions(+), 192 deletions(-)
 
 diff --git a/cmake/public/LoadHIP.cmake b/cmake/public/LoadHIP.cmake
-index 3eb34b0b83..c0a69db443 100644
+index 3eb34b0b83..753e146a40 100644
 --- a/cmake/public/LoadHIP.cmake
 +++ b/cmake/public/LoadHIP.cmake
 @@ -1,199 +1,117 @@
@@ -279,7 +279,7 @@ index 3eb34b0b83..c0a69db443 100644
 +  else()
 +    find_library(ROCM_ROCTX_LIB roctx64)
 +    if(NOT ROCM_ROCTX_LIB)
-+      cmake(WARNING "Neither rocprofiler-sdk nor libroctx64.so was found: This may result in errors if components rely on it")
++      message(WARNING "Neither rocprofiler-sdk nor libroctx64.so was found: This may result in errors if components rely on it")
      endif()
 -  else() # Win32
 -    # With HIP-SDK 6.2, HIP declares new enum types on Windows

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
@@ -1,7 +1,7 @@
-From dc6344fd018e3031775e5cc7ba8db3080ad736d6 Mon Sep 17 00:00:00 2001
+From 106542c653c52b50d408d6ae6589e3f18591d899 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Wed, 19 Feb 2025 17:14:59 -0800
-Subject: [PATCH 2/3] Generate composable_kernel ck/config.h as part of main
+Subject: [PATCH 2/4] Generate composable_kernel ck/config.h as part of main
  build.
 
 Without this, the ck/config.h comes from somewhere, most probably a ROCM SDK that has it installed as a sibling to the HIP headers. Not all ROCM SDKs include this, and even so, it is dangerous to have a sheared header dependency like this.

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
@@ -1,7 +1,7 @@
 From 106542c653c52b50d408d6ae6589e3f18591d899 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Wed, 19 Feb 2025 17:14:59 -0800
-Subject: [PATCH 2/4] Generate composable_kernel ck/config.h as part of main
+Subject: [PATCH 2/5] Generate composable_kernel ck/config.h as part of main
  build.
 
 Without this, the ck/config.h comes from somewhere, most probably a ROCM SDK that has it installed as a sibling to the HIP headers. Not all ROCM SDKs include this, and even so, it is dangerous to have a sheared header dependency like this.

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
@@ -1,7 +1,7 @@
 From 519669d34dfaa980604f6014898f1ed4cb4d943a Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Wed, 19 Feb 2025 17:16:27 -0800
-Subject: [PATCH 3/4] TEMPORARY: Manually disable roctx until compatibility
+Subject: [PATCH 3/5] TEMPORARY: Manually disable roctx until compatibility
  with rocprofv3 is established.
 
 ---

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
@@ -1,7 +1,7 @@
-From 3b7899a0fe6b1339d04daf1bbba709bbd04f171c Mon Sep 17 00:00:00 2001
+From 519669d34dfaa980604f6014898f1ed4cb4d943a Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Wed, 19 Feb 2025 17:16:27 -0800
-Subject: [PATCH 3/3] TEMPORARY: Manually disable roctx until compatibility
+Subject: [PATCH 3/4] TEMPORARY: Manually disable roctx until compatibility
  with rocprofv3 is established.
 
 ---

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0004-Pin-cmake-4-since-v4-broke-old-pytorch-builds.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0004-Pin-cmake-4-since-v4-broke-old-pytorch-builds.patch
@@ -1,7 +1,7 @@
 From 77a75ffce90524e6e5fafed0759d30b63a156286 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Tue, 1 Apr 2025 14:52:15 -0700
-Subject: [PATCH 4/4] Pin cmake<4 since v4 broke old pytorch builds.
+Subject: [PATCH 4/5] Pin cmake<4 since v4 broke old pytorch builds.
 
 ---
  requirements.txt | 2 +-

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0004-Pin-cmake-4-since-v4-broke-old-pytorch-builds.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0004-Pin-cmake-4-since-v4-broke-old-pytorch-builds.patch
@@ -1,0 +1,22 @@
+From 77a75ffce90524e6e5fafed0759d30b63a156286 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Tue, 1 Apr 2025 14:52:15 -0700
+Subject: [PATCH 4/4] Pin cmake<4 since v4 broke old pytorch builds.
+
+---
+ requirements.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/requirements.txt b/requirements.txt
+index 642d78e4f6..d02e1e9d7a 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -18,4 +18,4 @@ lintrunner
+ ninja
+ packaging
+ optree>=0.13.0
+-cmake
++cmake<4
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0005-Preload-rocm-sdk-binaries-if-available.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0005-Preload-rocm-sdk-binaries-if-available.patch
@@ -1,0 +1,57 @@
+From f177e4c066b796990b950d9739149dcba7070b37 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Tue, 1 Apr 2025 18:49:42 -0700
+Subject: [PATCH 5/5] Preload rocm-sdk binaries if available.
+
+---
+ torch/__init__.py | 27 ++++++++++++++++++++++++++-
+ 1 file changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/torch/__init__.py b/torch/__init__.py
+index f361c6b6cd..ec8c49e8eb 100644
+--- a/torch/__init__.py
++++ b/torch/__init__.py
+@@ -305,6 +305,29 @@ def _preload_cuda_deps(lib_folder: str, lib_name: str) -> None:
+ 
+ # See Note [Global dependencies]
+ def _load_global_deps() -> None:
++    # Preload ROCm deps if this torch was built to link against rocm-sdk wheels.
++    # TODO: Lookup distribution info for the torch package and see if it was
++    # build with PYTORCH_EXTRA_INSTALL_REQUIREMENTS="rocm-sdk" to enable
++    # ROCm preloading.
++    try:
++        import rocm_sdk
++    except ModuleNotFoundError:
++        pass
++    else:
++        import rocm_sdk
++        rocm_sdk.preload_libraries(
++            "amdhip64",
++            "rocprofiler-sdk-roctx",
++            "hiprtc",
++            "hipblas",
++            "hipfft",
++            "hiprand",
++            "hipsparse",
++            "hipsolver",
++            "rccl",
++            "hipblaslt",
++        )
++
+     if _running_with_deploy() or platform.system() == "Windows":
+         return
+ 
+@@ -2567,7 +2590,9 @@ def compile(
+         nopython=fullgraph,
+         dynamic=dynamic,
+         disable=disable,
+-    )(model)  # type: ignore[return-value]
++    )(
++        model
++    )  # type: ignore[return-value]
+ 
+ 
+ def _register_device_module(device_type, module):
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/v2.6.0/third_party/composable_kernel/base/0001-Work-around-ambiguous-cast-of-half_t-__half-in-call-.patch
+++ b/external-builds/pytorch/patches/v2.6.0/third_party/composable_kernel/base/0001-Work-around-ambiguous-cast-of-half_t-__half-in-call-.patch
@@ -1,4 +1,4 @@
-From 019d6e65d121f6efdbf3875f9fffd4d433e22318 Mon Sep 17 00:00:00 2001
+From 64b64e642fe482acd0d262e22c7e6d9ee3cecc09 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Wed, 19 Feb 2025 17:17:01 -0800
 Subject: [PATCH] Work around ambiguous cast of half_t -> __half in call to

--- a/external-builds/pytorch/patches/v2.6.0/third_party/gloo/hipified/0001-Use-proper-find_package-to-locate-amdhip64.patch
+++ b/external-builds/pytorch/patches/v2.6.0/third_party/gloo/hipified/0001-Use-proper-find_package-to-locate-amdhip64.patch
@@ -1,0 +1,57 @@
+From ba78402efc4e7d9f6546302234e3546f842811d0 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Tue, 1 Apr 2025 15:34:34 -0700
+Subject: [PATCH] Use proper find_package to locate amdhip64.
+
+---
+ cmake/Hip.cmake | 18 ++++--------------
+ 1 file changed, 4 insertions(+), 14 deletions(-)
+
+diff --git a/cmake/Hip.cmake b/cmake/Hip.cmake
+index 18a3c07..ee36d2b 100644
+--- a/cmake/Hip.cmake
++++ b/cmake/Hip.cmake
+@@ -1,36 +1,26 @@
+ set(HAVE_HIP FALSE)
+ 
+-IF(NOT DEFINED ENV{ROCM_PATH})
+-  SET(ROCM_PATH /opt/rocm)
+-ELSE()
+-  SET(ROCM_PATH $ENV{ROCM_PATH})
+-ENDIF()
+-
+ IF(NOT DEFINED ENV{GLOO_ROCM_ARCH})
+   SET(GLOO_ROCM_ARCH gfx906;gfx908;gfx90a)
+ ELSE()
+   SET(GLOO_ROCM_ARCH $ENV{GLOO_ROCM_ARCH})
+ ENDIF()
+ 
+-# Add HIP to the CMAKE Module Path
+-set(CMAKE_MODULE_PATH ${ROCM_PATH}/lib/cmake/hip ${CMAKE_MODULE_PATH})
+-
+ # Disable Asserts In Code (Can't use asserts on HIP stack.)
+ ADD_DEFINITIONS(-DNDEBUG)
+ 
+ # Find the HIP Package
+ find_package(HIP 1.0)
++find_package(hip CONFIG)
+ 
+-IF(HIP_FOUND)
++IF(HIP_FOUND AND hip_FOUND)
+   set(HAVE_HIP TRUE)
+ 
+-  set(hip_library_name amdhip64)
++  set(hip_library_name hip::host)
+   message("HIP library name: ${hip_library_name}")
+-
++  set(GLOO_HIP_HCC_LIBRARIES "hip::host")
+   set(CMAKE_HCC_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+   set(CMAKE_HCC_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+-  FIND_LIBRARY(GLOO_HIP_HCC_LIBRARIES ${hip_library_name} HINTS ${ROCM_PATH}/lib)
+-
+ ENDIF()
+ 
+ ################################################################################
+-- 
+2.43.0
+


### PR DESCRIPTION
* Devel package includes all runtime artifacts plus explicit additional list.
* rocprofiler-sdk workarounds. It is not ready yet and depends on aqlprofiler (without it, it fails self checks).
* Explicitly include prim in the devel package. Since it is header only, no runtime parts were implemented for it, resulting in it being excluded.
* Miscellaneous patches to pytorch to make it work with rocm-sdk wheels.

With this patch, this build procedure for pytorch on a bare system works: https://gist.github.com/stellaraccident/8fb23a37a76c712643fc27acbc4f62ea

Works around #330