### PR TITLE
Create index files and logs for each GPU family

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -30,6 +30,7 @@ jobs:
       CCACHE_DIR: "${{ github.workspace }}/.container-cache/ccache"
       CCACHE_MAXSIZE: "700M"
       TEATIME_LABEL_GH_GROUP: 1
+      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -68,13 +69,12 @@ jobs:
         run: |
           # Generate a new build id.
           package_version="${{ inputs.package_version }}"
-          amdgpu_families="${{ inputs.amdgpu_families }}"
           echo "Building package ${package_version}"
 
           # Build.
           cmake -B build -GNinja . \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DTHEROCK_AMDGPU_FAMILIES=${amdgpu_families} \
+            -DTHEROCK_AMDGPU_FAMILIES=${AMDGPU_FAMILIES} \
             -DTHEROCK_PACKAGE_VERSION="${package_version}" \
             -DTHEROCK_VERBOSE=ON \
             -DBUILD_TESTING=ON
@@ -121,9 +121,9 @@ jobs:
           curl --silent --fail --show-error --location \
             https://raw.githubusercontent.com/joshbrunty/Indexer/6d8cbfd15d3853b482e6a49f2d875ded9188b721/indexer.py \
             --output build/indexer.py
-          python build/indexer.py -f '*.tar.xz*' build/artifacts/
+          python build/indexer.py -f '*.tar.xz*' build/artifacts/ -o build/artifacts/index-${AMDGPU_FAMILIES}.html
           python build/indexer.py -f '*.log' build/logs/
-          sed -i 's,a href="..",a href="../index.html",g' build/logs/index.html
+          sed -i 's,a href="..",a href="../../index.html",g' build/logs/index.html
 
       # TODO: Move to script
       - name: Upload Artifacts
@@ -131,19 +131,19 @@ jobs:
           aws s3 cp build/artifacts/ s3://therock-artifacts/${{github.run_id}}/ \
             --recursive --no-follow-symlinks \
             --exclude "*" \
-            --include "*.tar.xz*" --include "index.html"
+            --include "*.tar.xz*" --include "index-*.html"
 
       # TODO: Move to script
       - name: Upload Logs
         run: |
-          aws s3 cp build/logs/ s3://therock-artifacts/${{github.run_id}}/logs/ \
+          aws s3 cp build/logs/ s3://therock-artifacts/${{github.run_id}}/logs/${AMDGPU_FAMILIES}/ \
             --recursive \
             --content-type="text/plain" \
             --exclude "*" \
             --include "*.log"
-          aws s3 cp build/logs/index.html s3://therock-artifacts/${{github.run_id}}/logs/
+          aws s3 cp build/logs/index.html s3://therock-artifacts/${{github.run_id}}/logs/${AMDGPU_FAMILIES}/
 
       - name: Add Links to Job Summary
         run: |
-          echo '* [Artifacts](https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}/index.html)' >> $GITHUB_STEP_SUMMARY
-          echo '* [Build logs](https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}/logs/index.html)' >> $GITHUB_STEP_SUMMARY
+          echo '* [Artifacts](https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}/index-${AMDGPU_FAMILIES}.html)' >> $GITHUB_STEP_SUMMARY
+          echo '* [Build logs](https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}/logs/${AMDGPU_FAMILIES}/index.html)' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -121,9 +121,9 @@ jobs:
           curl --silent --fail --show-error --location \
             https://raw.githubusercontent.com/joshbrunty/Indexer/6d8cbfd15d3853b482e6a49f2d875ded9188b721/indexer.py \
             --output build/indexer.py
-          python build/indexer.py -f '*.tar.xz*' build/artifacts/ -o build/artifacts/index-${{env.AMDGPU_FAMILIES}}.html
+          python build/indexer.py -f '*.tar.xz*' build/artifacts/
           python build/indexer.py -f '*.log' build/logs/
-          sed -i 's,a href="..",a href="../../index.html",g' build/logs/index.html
+          sed -i 's,a href="..",a href="../../index-${{env.AMDGPU_FAMILIES}}.html",g' build/logs/index.html
 
       # TODO: Move to script
       - name: Upload Artifacts
@@ -131,7 +131,8 @@ jobs:
           aws s3 cp build/artifacts/ s3://therock-artifacts/${{github.run_id}}/ \
             --recursive --no-follow-symlinks \
             --exclude "*" \
-            --include "*.tar.xz*" --include "index-*.html"
+            --include "*.tar.xz*"
+          aws s3 cp build/artifacts/index.html s3://therock-artifacts/${{github.run_id}}/index-${{env.AMDGPU_FAMILIES}}.html
 
       # TODO: Move to script
       - name: Upload Logs

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -74,7 +74,7 @@ jobs:
           # Build.
           cmake -B build -GNinja . \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DTHEROCK_AMDGPU_FAMILIES=${AMDGPU_FAMILIES} \
+            -DTHEROCK_AMDGPU_FAMILIES=${{env.AMDGPU_FAMILIES}} \
             -DTHEROCK_PACKAGE_VERSION="${package_version}" \
             -DTHEROCK_VERBOSE=ON \
             -DBUILD_TESTING=ON
@@ -121,7 +121,7 @@ jobs:
           curl --silent --fail --show-error --location \
             https://raw.githubusercontent.com/joshbrunty/Indexer/6d8cbfd15d3853b482e6a49f2d875ded9188b721/indexer.py \
             --output build/indexer.py
-          python build/indexer.py -f '*.tar.xz*' build/artifacts/ -o build/artifacts/index-${AMDGPU_FAMILIES}.html
+          python build/indexer.py -f '*.tar.xz*' build/artifacts/ -o build/artifacts/index-${{env.AMDGPU_FAMILIES}}.html
           python build/indexer.py -f '*.log' build/logs/
           sed -i 's,a href="..",a href="../../index.html",g' build/logs/index.html
 
@@ -136,14 +136,14 @@ jobs:
       # TODO: Move to script
       - name: Upload Logs
         run: |
-          aws s3 cp build/logs/ s3://therock-artifacts/${{github.run_id}}/logs/${AMDGPU_FAMILIES}/ \
+          aws s3 cp build/logs/ s3://therock-artifacts/${{github.run_id}}/logs/${{env.AMDGPU_FAMILIES}}/ \
             --recursive \
             --content-type="text/plain" \
             --exclude "*" \
             --include "*.log"
-          aws s3 cp build/logs/index.html s3://therock-artifacts/${{github.run_id}}/logs/${AMDGPU_FAMILIES}/
+          aws s3 cp build/logs/index.html s3://therock-artifacts/${{github.run_id}}/logs/${{env.AMDGPU_FAMILIES}}/
 
       - name: Add Links to Job Summary
         run: |
-          echo '* [Artifacts](https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}/index-${AMDGPU_FAMILIES}.html)' >> $GITHUB_STEP_SUMMARY
-          echo '* [Build logs](https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}/logs/${AMDGPU_FAMILIES}/index.html)' >> $GITHUB_STEP_SUMMARY
+          echo '* [Artifacts](https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}/index-${{env.AMDGPU_FAMILIES}}.html)' >> $GITHUB_STEP_SUMMARY
+          echo '* [Build logs](https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}/logs/${{env.AMDGPU_FAMILIES}}/index.html)' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Till now, artifacts got pushed to `therock-artifacts/${{github.run_id}}` and logs got pushed to `therock-artifacts/${{github.run_id}}/logs`. If building for multiple GPU-families this resulted in pushing over pre-existing files as the `github.run_id` is the same for the jobs that build for different GPU-families. To work around this:

* Create and push an index file for each GPU-family
* Add the GPU-family in the path to the logs

With this the generic artifacts still get replaced by the latest successful job! This reduces the pressure on storage but logs are therefore misleading. This should be fine util pushing to the bucket is moved into scripts.