### PR TITLE
Set flags for FFT math libs on Windows.

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -60,6 +60,15 @@ set(THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS
   -Wno-unused-command-line-argument
 )
 
+if(WIN32)
+  # TODO(#36): Could we fix these warnings as part of enabling shared library builds?
+  # These are frequently set in subproject toolchain-windows.cmake files.
+  # For "__declspec attribute 'dllexport' is not supported [-Wignored-attributes]"
+  list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS -Wno-ignored-attributes)
+  # For "unknown attribute '__dllimport__' ignored [-Wunknown-attributes]"
+  list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS -Wno-unknown-attributes)
+endif()
+
 # Generates a command prefix that can be prepended to any custom command line
 # to perform log/console redirection and pretty printing.
 # LOG_FILE: If given, command output will also be sent to this log file. If
@@ -1050,7 +1059,7 @@ function(_therock_cmake_subproject_setup_toolchain
     # here. If any flags are load bearing we can either add them to all projects
     # or source those flags from the projects themselves more locally.
     string(APPEND _toolchain_contents "set(CMAKE_C_FLAGS_INIT )\n")
-    string(APPEND _toolchain_contents "set(CMAKE_CXX_FLAGS_INIT \"-DWIN32 -D_CRT_SECURE_NO_WARNINGS\")\n")
+    string(APPEND _toolchain_contents "set(CMAKE_CXX_FLAGS_INIT \"-DWIN32 -D_CRT_SECURE_NO_WARNINGS -DNOMINMAX \")\n")
     string(APPEND _toolchain_contents "set(CMAKE_EXE_LINKER_FLAGS_INIT )\n")
     string(APPEND _toolchain_contents "set(CMAKE_SHARED_LINKER_FLAGS_INIT )\n")
   else()

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -45,8 +45,8 @@ mainline, in open source, using MSVC, etc.).
 | math-libs        | [rocPRIM](https://github.com/ROCm/rocPRIM)                                   | ❔        |                                               |
 | math-libs        | [hipCUB](https://github.com/ROCm/hipCUB)                                     | ❔        |                                               |
 | math-libs        | [rocThrust](https://github.com/ROCm/rocThrust)                               | ❔        |                                               |
-| math-libs        | [rocFFT](https://github.com/ROCm/rocFFT)                                     | ❔        |                                               |
-| math-libs        | [hipFFT](https://github.com/ROCm/hipFFT)                                     | ❔        |                                               |
+| math-libs        | [rocFFT](https://github.com/ROCm/rocFFT)                                     | ✅        | No shared libraries                           |
+| math-libs        | [hipFFT](https://github.com/ROCm/hipFFT)                                     | ✅        | No shared libraries                           |
 | math-libs (blas) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ❔        |                                               |
 | math-libs (blas) | [hipBLASlt](https://github.com/ROCm/hipBLASlt)                               | ❔        |                                               |
 | math-libs (blas) | [rocBLAS](https://github.com/ROCm/rocBLAS)                                   | ❔        |                                               |

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -150,14 +150,14 @@ if(THEROCK_ENABLE_FFT)
   if(WIN32)
     # TODO(#36): enable shared libraries / dynamic linking?
     #   "lld-link: error: undefined symbol: hiprtcCreateProgram"
-    set(_shared_libs_arg "OFF")
+    set(_fft_shared_libs_arg "OFF")
 
     # TODO(#36): enable once `rocfft_aot_helper.exe` can access hiprtc0605.dll
     #   "The code execution cannot proceed because hiprtc0605.dll was not found."
-    set(_kernel_cache_enable "OFF")
+    set(_fft_kernel_cache_enable "OFF")
   else()
-    set(_shared_libs_arg "ON")
-    set(_kernel_cache_enable "ON")
+    set(_fft_shared_libs_arg "ON")
+    set(_fft_kernel_cache_enable "ON")
   endif()
 
   ##############################################################################
@@ -174,8 +174,8 @@ if(THEROCK_ENABLE_FFT)
       -DROCM_DIR=
       -DBUILD_CLIENTS=OFF
       -DUSE_HIPRAND=ON
-      -DROCFFT_KERNEL_CACHE_ENABLE=${_kernel_cache_enable}
-      -DBUILD_SHARED_LIBS=${_shared_libs_arg}
+      -DROCFFT_KERNEL_CACHE_ENABLE=${_fft_kernel_cache_enable}
+      -DBUILD_SHARED_LIBS=${_fft_shared_libs_arg}
     COMPILER_TOOLCHAIN
       amd-hip
     RUNTIME_DEPS
@@ -201,7 +201,7 @@ if(THEROCK_ENABLE_FFT)
       -DHIP_PLATFORM=amd
       -DROCM_PATH=
       -DROCM_DIR=
-      -DBUILD_SHARED_LIBS=${_shared_libs_arg}
+      -DBUILD_SHARED_LIBS=${_fft_shared_libs_arg}
     COMPILER_TOOLCHAIN
       amd-hip
     RUNTIME_DEPS

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -147,6 +147,19 @@ if(THEROCK_ENABLE_PRIM)
 endif(THEROCK_ENABLE_PRIM)
 
 if(THEROCK_ENABLE_FFT)
+  if(WIN32)
+    # TODO(#36): enable shared libraries / dynamic linking?
+    #   "lld-link: error: undefined symbol: hiprtcCreateProgram"
+    set(_shared_libs_arg "OFF")
+
+    # TODO(#36): enable once `rocfft_aot_helper.exe` can access hiprtc0605.dll
+    #   "The code execution cannot proceed because hiprtc0605.dll was not found."
+    set(_kernel_cache_enable "OFF")
+  else()
+    set(_shared_libs_arg "ON")
+    set(_kernel_cache_enable "ON")
+  endif()
+
   ##############################################################################
   # rocFFT
   ##############################################################################
@@ -161,6 +174,8 @@ if(THEROCK_ENABLE_FFT)
       -DROCM_DIR=
       -DBUILD_CLIENTS=OFF
       -DUSE_HIPRAND=ON
+      -DROCFFT_KERNEL_CACHE_ENABLE=${_kernel_cache_enable}
+      -DBUILD_SHARED_LIBS=${_shared_libs_arg}
     COMPILER_TOOLCHAIN
       amd-hip
     RUNTIME_DEPS
@@ -186,6 +201,7 @@ if(THEROCK_ENABLE_FFT)
       -DHIP_PLATFORM=amd
       -DROCM_PATH=
       -DROCM_DIR=
+      -DBUILD_SHARED_LIBS=${_shared_libs_arg}
     COMPILER_TOOLCHAIN
       amd-hip
     RUNTIME_DEPS


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/36.

Now I can build `librocfft.lib` and `hipfft.lib` with `-DTHEROCK_ENABLE_FFT=ON` on Windows.