### PR TITLE
Fix CMAKE_INSTALL_PREFIX init behavior on Win32.

### DIFF
--- a/patches/amd-mainline/hipFFT/0001-PYTHON3_EXE-should-be-Python3_EXECUTABLE.-Either-way.patch
+++ b/patches/amd-mainline/hipFFT/0001-PYTHON3_EXE-should-be-Python3_EXECUTABLE.-Either-way.patch
@@ -1,8 +1,8 @@
-From 6df0ce0c602dfc1720eac78703f85a09038e70ab Mon Sep 17 00:00:00 2001
+From 4099a852acb5c21f6d6f6c17367eb3ca20ab13e2 Mon Sep 17 00:00:00 2001
 From: Scott <scott.todd0@gmail.com>
 Date: Wed, 12 Mar 2025 13:49:43 -0700
-Subject: [PATCH] PYTHON3_EXE should be Python3_EXECUTABLE. Either way, it is
- unused.
+Subject: [PATCH 1/2] PYTHON3_EXE should be Python3_EXECUTABLE. Either way, it
+ is unused.
 
 ---
  toolchain-windows.cmake | 2 --

--- a/patches/amd-mainline/hipFFT/0002-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
+++ b/patches/amd-mainline/hipFFT/0002-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
@@ -1,0 +1,27 @@
+From d1eee94139dae6d2f518d06038547704382dc94d Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Wed, 2 Apr 2025 14:40:39 -0700
+Subject: [PATCH 2/2] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 708a40e..cb642d4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -258,7 +258,9 @@ endif()
+ if(WIN32)
+   set(CPACK_SOURCE_GENERATOR "ZIP")
+   set(CPACK_GENERATOR "ZIP")
+-  set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE)
++  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
++    set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE)
++  endif()
+   set(INSTALL_PREFIX "C:/hipSDK")
+   set(CPACK_SET_DESTDIR OFF)
+   set(CPACK_PACKAGE_INSTALL_DIRECTORY "C:/hipSDK")
+-- 
+2.47.1.windows.2
+

--- a/patches/amd-mainline/hipSOLVER/0001-Work-around-race-condition.patch
+++ b/patches/amd-mainline/hipSOLVER/0001-Work-around-race-condition.patch
@@ -1,7 +1,7 @@
-From e1ebcf4389094357894b72eb89290be951e9177c Mon Sep 17 00:00:00 2001
+From c67269d9e0cd3fa0f3a30fb01d044658945f979c Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Mon, 31 Mar 2025 22:24:41 +0000
-Subject: [PATCH 1/2] Work around race condition
+Subject: [PATCH 1/3] Work around race condition
 
 With `add_dependency`, compiling the `hipsolver_fortran_client` target
 fails as `hipsolver.mod` is not created in time for the first build
@@ -25,5 +25,5 @@ index d715fd2..2590d85 100644
      include_directories(${CMAKE_BINARY_DIR}/include/hipsolver/internal)
      target_compile_definitions(hipsolver_fortran_client INTERFACE HAVE_HIPSOLVER_FORTRAN_CLIENT)
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/hipSOLVER/0002-Install-hipsolver_client.so.patch
+++ b/patches/amd-mainline/hipSOLVER/0002-Install-hipsolver_client.so.patch
@@ -1,7 +1,7 @@
-From 084297f8d3771a83084fa2718589c8f8e68f7676 Mon Sep 17 00:00:00 2001
+From 2748b7af8ff0c7e8d1911900eb1558cf1072d7a2 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Tue, 1 Apr 2025 14:41:28 +0000
-Subject: [PATCH 2/2] Install `hipsolver_client.so`
+Subject: [PATCH 2/3] Install `hipsolver_client.so`
 
 This is required by the test and benchmark clients but was not part of
 the installation so far.
@@ -22,5 +22,5 @@ index c1ec52d..a4e8649 100644
  
  add_library(hipsolver
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/hipSOLVER/0003-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
+++ b/patches/amd-mainline/hipSOLVER/0003-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
@@ -1,0 +1,27 @@
+From e91d6d9a772448122ff787adc6d9615f857639a4 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Wed, 2 Apr 2025 14:43:19 -0700
+Subject: [PATCH 3/3] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7c04ae3..571dd52 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -267,7 +267,9 @@ set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+ if(WIN32)
+   set(CPACK_SOURCE_GENERATOR "ZIP")
+   set(CPACK_GENERATOR "ZIP")
+-  set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE)
++  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
++    set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE)
++  endif()
+   set(INSTALL_PREFIX "C:/hipSDK")
+   set(CPACK_SET_DESTDIR OFF)
+   set(CPACK_PACKAGE_INSTALL_DIRECTORY "C:/hipSDK")
+-- 
+2.47.1.windows.2
+

--- a/patches/amd-mainline/hipSPARSE/0001-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
+++ b/patches/amd-mainline/hipSPARSE/0001-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
@@ -1,0 +1,27 @@
+From 2f5f0e3bb45490ea1040bac6a064bcfa86ca6a59 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Wed, 2 Apr 2025 15:00:26 -0700
+Subject: [PATCH] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4fe396a..634721d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -221,7 +221,9 @@ set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+ if(WIN32)
+   set(CPACK_SOURCE_GENERATOR "ZIP")
+   set(CPACK_GENERATOR "ZIP")
+-  set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE)
++  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
++    set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE)
++  endif()
+   set(INSTALL_PREFIX "C:/hipSDK")
+   set(CPACK_SET_DESTDIR OFF)
+   set(CPACK_PACKAGE_INSTALL_DIRECTORY "C:/hipSDK")
+-- 
+2.47.1.windows.2
+

--- a/patches/amd-mainline/rocFFT/0001-Use-build-RPATH-correctly.patch
+++ b/patches/amd-mainline/rocFFT/0001-Use-build-RPATH-correctly.patch
@@ -1,7 +1,7 @@
-From e38f8dabef90545adab6b6feb2e1ea35776660b9 Mon Sep 17 00:00:00 2001
+From b872eda12d4ad146610e904e585b338fc9e8f944 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Fri, 21 Feb 2025 13:02:46 -0800
-Subject: [PATCH 1/3] Use build RPATH correctly.
+Subject: [PATCH 1/4] Use build RPATH correctly.
 
 * Using BUILD_WITH_INSTALL_RPATH is *only* ever valid if the build and install trees share the same layout and both should have the same origin-relative setup. That is not the case here, and the proper thing to do is to rely on CMake to make sure that RPATHs for the build tree are absolute (which is its normal invariant) and to only use the install RPATH for install.
 * Hard-coding of an LD_LIBRARY_PATH to a presumed installed ROCM is not allowed and is dangerous. It is also not necessary if the build RPATHs are managed by CMake vs being overriden.

--- a/patches/amd-mainline/rocFFT/0002-Use-proper-casing-for-hip-and-hiprtc-packages.patch
+++ b/patches/amd-mainline/rocFFT/0002-Use-proper-casing-for-hip-and-hiprtc-packages.patch
@@ -1,7 +1,7 @@
-From 914b58be8d2826b61ff0f154aecf8bc559803cb7 Mon Sep 17 00:00:00 2001
+From 5f562dfcba891f66ecfe60880e4aaa57cb3d92cd Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Fri, 21 Feb 2025 13:17:39 -0800
-Subject: [PATCH 2/3] Use proper casing for 'hip' and 'hiprtc' packages.
+Subject: [PATCH 2/4] Use proper casing for 'hip' and 'hiprtc' packages.
 
 * Package names are case-sensitive, and the name for both of these is lowercase.
 * There are situations where the wrong casing can be made to work (i.e. if you manually specify "-DHIP_DIR=" and "-DHIPRTC_DIR=" config vars with the wrong case, the search procedure will happen to work in this very narrow case, but it isn't right).

--- a/patches/amd-mainline/rocFFT/0003-Use-Python3_Executable-from-FindPython3-not-custom-P.patch
+++ b/patches/amd-mainline/rocFFT/0003-Use-Python3_Executable-from-FindPython3-not-custom-P.patch
@@ -1,7 +1,7 @@
-From af160679bf00c166861c06e0284eb6f659b84e37 Mon Sep 17 00:00:00 2001
+From a4b6d98e7d51224c22e911b63f9baa815277b67b Mon Sep 17 00:00:00 2001
 From: Scott <scott.todd0@gmail.com>
 Date: Wed, 12 Mar 2025 14:53:14 -0700
-Subject: [PATCH 3/3] Use Python3_Executable from FindPython3, not custom
+Subject: [PATCH 3/4] Use Python3_Executable from FindPython3, not custom
  PYTHON3_EXE.
 
 ---
@@ -11,7 +11,7 @@ Subject: [PATCH 3/3] Use Python3_Executable from FindPython3, not custom
  3 files changed, 3 insertions(+), 9 deletions(-)
 
 diff --git a/library/src/CMakeLists.txt b/library/src/CMakeLists.txt
-index 587a04a0..29693469 100644
+index 587a04a0..cb8faa7c 100644
 --- a/library/src/CMakeLists.txt
 +++ b/library/src/CMakeLists.txt
 @@ -84,10 +84,6 @@ include( GenerateExportHeader )
@@ -44,7 +44,7 @@ index 587a04a0..29693469 100644
    --data-folder=${ROCFFT_SOLUTION_MAP_DIR}
    DEPENDS ${solution_map_files}
 diff --git a/library/src/device/CMakeLists.txt b/library/src/device/CMakeLists.txt
-index e1fb9247..6b0e8039 100644
+index e1fb9247..70d518c8 100644
 --- a/library/src/device/CMakeLists.txt
 +++ b/library/src/device/CMakeLists.txt
 @@ -76,7 +76,7 @@ endforeach()

--- a/patches/amd-mainline/rocFFT/0004-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
+++ b/patches/amd-mainline/rocFFT/0004-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
@@ -1,0 +1,27 @@
+From 490ef7e19be9df99f7e23fce4b89e8d17e75464a Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Wed, 2 Apr 2025 14:57:58 -0700
+Subject: [PATCH 4/4] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9559e515..391a5653 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -288,7 +288,9 @@ endif( )
+ if(WIN32)
+   set(CPACK_SOURCE_GENERATOR "ZIP")
+   set(CPACK_GENERATOR "ZIP")
+-  set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE)
++  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
++    set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE)
++  endif()
+   set(INSTALL_PREFIX "C:/hipSDK")
+   set(CPACK_SET_DESTDIR OFF)
+   set(CPACK_PACKAGE_INSTALL_DIRECTORY "C:/hipSDK")
+-- 
+2.47.1.windows.2
+

--- a/patches/amd-mainline/rocSOLVER/0001-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
+++ b/patches/amd-mainline/rocSOLVER/0001-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
@@ -1,0 +1,27 @@
+From 905a6dbb2c0bcbc879a1d4f9ea75de4c99ebd878 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Wed, 2 Apr 2025 14:43:01 -0700
+Subject: [PATCH] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fdd9060..ff05d07 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -269,7 +269,9 @@ set(CPACK_RPM_PACKAGE_LICENSE "BSD")
+ if(WIN32)
+   set(CPACK_SOURCE_GENERATOR "ZIP")
+   set(CPACK_GENERATOR "ZIP")
+-  set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE)
++  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
++    set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE)
++  endif()
+   set(INSTALL_PREFIX "C:/hipSDK")
+   set(CPACK_SET_DESTDIR OFF)
+   set(CPACK_PACKAGE_INSTALL_DIRECTORY "C:/hipSDK")
+-- 
+2.47.1.windows.2
+

--- a/patches/amd-mainline/rocSPARSE/0001-Drop-setting-library-directory-and-rpath.patch
+++ b/patches/amd-mainline/rocSPARSE/0001-Drop-setting-library-directory-and-rpath.patch
@@ -1,7 +1,7 @@
-From 5c47e2e2fb6b57acc9fc4fba5676129c7a9072e8 Mon Sep 17 00:00:00 2001
+From 80d0e133e63e0e61e07f446ccdf67a7b8411d49b Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Thu, 20 Mar 2025 13:19:39 +0000
-Subject: [PATCH] Drop setting library directory and rpath
+Subject: [PATCH 1/2] Drop setting library directory and rpath
 
 ---
  clients/CMakeLists.txt     | 2 +-
@@ -39,5 +39,5 @@ index 189a10e3..2de17498 100644
  endif()
  
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocSPARSE/0002-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
+++ b/patches/amd-mainline/rocSPARSE/0002-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
@@ -1,0 +1,27 @@
+From d946ec237705a9a18d56a4516e4170da7bf7f680 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Wed, 2 Apr 2025 14:42:25 -0700
+Subject: [PATCH 2/2] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1699c029..c65552b8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -326,7 +326,9 @@ set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+ if(WIN32)
+   set(CPACK_SOURCE_GENERATOR "ZIP")
+   set(CPACK_GENERATOR "ZIP")
+-  set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE)
++  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
++    set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE)
++  endif()
+   set(INSTALL_PREFIX "C:/hipSDK")
+   set(CPACK_SET_DESTDIR OFF)
+   set(CPACK_PACKAGE_INSTALL_DIRECTORY "C:/hipSDK")
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/36.

This changes all locations across the project that use the

```cmake
set(CMAKE_INSTALL_PREFIX "${SOME_PATH_HERE}" CACHE PATH "Install path" FORCE)
```

pattern (specifically with `FORCE`) to only do that if `CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT` is set, per the guidance at https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT.html.

Without this,

1. Our setting here is ignored: https://github.com/ROCm/TheRock/blob/bc656e498e2dc3edce9aa5dac1e06fc363273681/cmake/therock_subproject.cmake#L641
2. Subprojects install into the hardcoded `C:/hipSDK` path
3. Subprojects that depend on other subprojects fail to find expected files since they are searching the wrong locations:
    
    ```
    [build] [hipFFT configure] CMake Error at D:/projects/TheRock/cmake/therock_subproject_dep_provider.cmake:51 (find_package):
    [build] [hipFFT configure]   Could not find a package configuration file provided by "rocfft" with any
    [build] [hipFFT configure]   of the following names:
    [build] [hipFFT configure]
    [build] [hipFFT configure]     rocfftConfig.cmake
    [build] [hipFFT configure]     rocfft-config.cmake
    ```

    In that case, `C:\hipSDK\lib\cmake\rocfft\rocfft-config.cmake` exists but `TheRock\build\math-libs\rocFFT\dist\lib\cmake\rocfft\rocfft-config.cmake` does not.