### PR TITLE
Enable building rocSOLVER clients

### DIFF
--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -279,6 +279,11 @@ if(THEROCK_ENABLE_SOLVER)
   # rocSOLVER
   ##############################################################################
 
+  set(rocSOLVER_optional_deps)
+  if(THEROCK_BUILD_TESTING)
+    list(APPEND rocSOLVER_optional_deps therock-host-blas)
+  endif()
+
   therock_cmake_subproject_declare(rocSOLVER
       EXTERNAL_SOURCE_DIR "rocSOLVER"
       BACKGROUND_BUILD
@@ -286,19 +291,20 @@ if(THEROCK_ENABLE_SOLVER)
         -DHIP_PLATFORM=amd
         -DROCM_PATH=
         -DROCM_DIR=
-        # Requires LAPACK
-        -DBUILD_CLIENTS_BENCHMARKS=OFF
-        -DBUILD_CLIENTS_TESTS=OFF
+        -DBUILD_CLIENTS_BENCHMARKS=${THEROCK_BUILD_TESTING}
+        -DBUILD_CLIENTS_TESTS=${THEROCK_BUILD_TESTING}
+        -DROCSOLVER_FIND_PACKAGE_LAPACK_CONFIG=OFF
       COMPILER_TOOLCHAIN
         amd-hip
       BUILD_DEPS
         rocm-cmake
-        rocBLAS
         rocPRIM
         therock-fmt
         therock-googletest
       RUNTIME_DEPS
         hip-clr
+        rocBLAS
+        ${rocSOLVER_optional_deps}
   )
   therock_cmake_subproject_glob_c_sources(rocSOLVER
       SUBDIRS

--- a/math-libs/BLAS/artifact-blas.toml
+++ b/math-libs/BLAS/artifact-blas.toml
@@ -98,6 +98,13 @@ optional = true
 optional = true
 [components.lib."math-libs/BLAS/rocSOLVER/stage"]
 optional = true
+[components.test."math-libs/BLAS/rocSOLVER/stage"]
+include = [
+  "bin/rocsolver-bench",
+  "bin/rocsolver-test",
+  "share/rocsolver/test/**",
+]
+optional = true
 
 # hipSOLVER
 [components.dbg."math-libs/BLAS/hipSOLVER/stage"]

--- a/patches/amd-mainline/rocSOLVER/0001-Allow-rocblas_DIR-env-var-to-be-unset-on-Windows.patch
+++ b/patches/amd-mainline/rocSOLVER/0001-Allow-rocblas_DIR-env-var-to-be-unset-on-Windows.patch
@@ -1,0 +1,37 @@
+From baf924dd915b9e7959f13c88da0dbbcd1d903482 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Wed, 16 Jul 2025 13:37:23 -0700
+Subject: [PATCH] Allow rocblas_DIR env var to be unset on Windows.
+
+---
+ clients/gtest/CMakeLists.txt | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/clients/gtest/CMakeLists.txt b/clients/gtest/CMakeLists.txt
+index eaff149..3d95a2c 100755
+--- a/clients/gtest/CMakeLists.txt
++++ b/clients/gtest/CMakeLists.txt
+@@ -197,11 +197,15 @@ if(WIN32)
+       ARGS -E copy ${file_i} $<TARGET_FILE_DIR:rocsolver-test>
+     )
+   endforeach()
+-  add_custom_command(TARGET rocsolver-test
+-    POST_BUILD
+-    COMMAND ${CMAKE_COMMAND}
+-    ARGS -E copy_directory $ENV{rocblas_DIR}/bin/rocblas/library $<TARGET_FILE_DIR:rocsolver-test>/library
+-  )
++  if(DEFINED ENV{rocblas_DIR})
++    add_custom_command(TARGET rocsolver-test
++      POST_BUILD
++      COMMAND ${CMAKE_COMMAND}
++      ARGS -E copy_directory $ENV{rocblas_DIR}/bin/rocblas/library $<TARGET_FILE_DIR:rocsolver-test>/library
++    )
++  else()
++    message(WARNING "rocblas_DIR not set. rocBLAS Tensile runtime kernels will not be copied to client staging directory (insitu testing affected).")
++  endif()
+ endif()
+ 
+ target_link_libraries(rocsolver-test PRIVATE
+-- 
+2.47.1.windows.2
+

--- a/third-party/fmt/pre_hook_therock-fmt.cmake
+++ b/third-party/fmt/pre_hook_therock-fmt.cmake
@@ -1,0 +1,3 @@
+# We want to be able to use the static build fmt lib in shared libraries.
+message(STATUS "Enabling PIC build")
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
This enables building rocSOLVER clients which requires to build fmt with PIC enabled.

Closes #236