### PR TITLE
Refactor workflow to release nightly releases

### DIFF
--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -62,7 +62,7 @@ jobs:
 
   portable_linux_packages:
     name: ${{ matrix.target_bundle.amdgpu_family }}::Build Portable Linux
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' ||  'ubuntu-24.04'  }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
     permissions:
       contents: write
     needs: [setup_metadata]

--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -1,45 +1,76 @@
-name: Portable Linux Package
+name: Build portable Linux packages
 
 on:
-  workflow_dispatch:
-    inputs:
-      package_suffix:
-        type: string
-        default: -ADHOCBUILD
-      # TODO: make this optional. For now we require it to be set explicitly.
-      # Default behavior could be either:
-      #   A) generate a version or date -based tag for each release
-      #   B) append assets to 'mainline-snapshot' with a version or date suffix
-      #   C) overwrite assets on 'mainline-snapshot'
-      release_tag:
-        description: Publish files to this release tag
-        required: true
-        type: string
-
+  # Trigger from another workflow (typically to build dev packages and then test them)
   workflow_call:
     inputs:
+      build_type:
+        description: The type of build version to produce ("rc", or "dev")
+        type: string
+        default: "dev"
       package_suffix:
         type: string
-        default: -ADHOCBUILD
-      # TODO: make this optional. See above.
-      release_tag:
-        description: Publish files to this release tag
-        required: true
+  # Trigger manually (typically to test the workflow or manually build a release [candidate])
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: The type of build version to produce ("rc", or "dev")
         type: string
+        default: "rc"
+      package_suffix:
+        type: string
+  # Trigger on a schedule to build nightly release candidates.
+  schedule:
+    # Runs at 11:00 AM UTC, which is 3:00 AM PST (UTC-8)
+    - cron: '0 11 * * *'
 
 permissions:
   contents: read
 
-concurrency:
-  # A PR number if a pull request and otherwise the commit hash. This cancels
-  # queued and in-progress runs for the same PR (presubmit) or commit
-  # (postsubmit). The workflow name is prepended to avoid conflicts between
-  # different workflows.
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
-
 jobs:
+  setup_metadata:
+    if: ${{ github.repository_owner == 'ROCm' || github.event_name != 'schedule' }}
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: 3.12
+
+      # Compute version suffix based on inputs (default to 'rc')
+      - name: Compute rc version suffix
+        if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}
+        run: |
+          version_suffix="$(printf 'rc%(%Y%m%d)T')"
+          echo "version_suffix=${version_suffix}" >> $GITHUB_ENV
+
+      - name: Compute dev version suffix
+        if: ${{ inputs.build_type == 'dev' }}
+        run: |
+          version_suffix=".dev0+${{ github.sha }}"
+          echo "version_suffix=${version_suffix}" >> $GITHUB_ENV
+
+      - name: Compute version
+        id: version
+        run: |
+          base_version=$(jq -r '.["rocm-version"]' version.json)
+          echo "version=${base_version}${version_suffix}" >> $GITHUB_OUTPUT
+
   portable_linux_packages:
+    name: ${{ matrix.target_bundle.amdgpu_family }}::Build Portable Linux
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' ||  'ubuntu-24.04'  }}
+    permissions:
+      contents: write
+    needs: [setup_metadata]
+    env:
+      TEATIME_LABEL_GH_GROUP: 1
+      OUTPUT_DIR: ${{ github.workspace }}/output
+      BUILD_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64:main
+      DIST_ARCHIVE: "${{ github.workspace }}/output/therock-dist-linux-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
     strategy:
       fail-fast: false
       matrix:
@@ -49,15 +80,6 @@ jobs:
           - amdgpu_family: "gfx1151"
           - amdgpu_family: "gfx1201"
 
-    permissions:
-      contents: write
-    name: ${{ matrix.target_bundle.amdgpu_family }}::Build Portable Linux
-    runs-on: azure-linux-scale-rocm
-    env:
-      TEATIME_LABEL_GH_GROUP: 1
-      OUTPUT_DIR: ${{ github.workspace }}/output
-      BUILD_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64:main
-      DIST_ARCHIVE: "${{ github.workspace }}/output/therock-dist-${{ matrix.target_bundle.amdgpu_family }}${{ github.events.input.package_suffix }}.tar.gz"
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -94,13 +116,27 @@ jobs:
           echo "Building ${{ env.DIST_ARCHIVE }}"
           tar cfz "${{ env.DIST_ARCHIVE }}" .
 
-      - name: Upload Release Asset
+      - name: Upload Nightly Release
+        if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
-        if: github.event.inputs.release_tag != ''
         with:
           artifacts: "${{ env.DIST_ARCHIVE }}"
-          tag: ${{ inputs.release_tag }}
-          name: ${{ inputs.release_tag }}
+          tag: "nightly-release"
+          name: "nightly-release"
+          body: "Automatic nightly release of TheRock."
+          removeArtifacts: false
+          allowUpdates: true
+          replacesArtifacts: true
+          makeLatest: false
+
+      - name: Upload Development Release
+        if: ${{ inputs.build_type == 'dev'}}
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
+        with:
+          artifacts: "${{ env.DIST_ARCHIVE }}"
+          tag: "dev-release"
+          name: "dev-release"
+          body: "Development release of TheRock."
           removeArtifacts: false
           allowUpdates: true
           replacesArtifacts: true


### PR DESCRIPTION
Refactors the `Portable Linux Package` worflow to build nightly releases whose assets get continously pushed to a release tagged `nightly-release`. Furhter allows to push development release to a release tagged `dev-release`. The latter needs some improvements such as a build number or maybe the build date to sort the files not only based on the git hash (which could be shortened).

Progress on #222