### PR TITLE
Expand Windows support to include prim math libs.

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -63,10 +63,31 @@ set(THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS
 if(WIN32)
   # TODO(#36): Could we fix these warnings as part of enabling shared library builds?
   # These are frequently set in subproject toolchain-windows.cmake files.
-  # For "__declspec attribute 'dllexport' is not supported [-Wignored-attributes]"
+  # Warning example:
+  #     __declspec attribute 'dllexport' is not supported
   list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS -Wno-ignored-attributes)
-  # For "unknown attribute '__dllimport__' ignored [-Wunknown-attributes]"
+  # Warning example:
+  #     unknown attribute '__dllimport__' ignored
   list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS -Wno-unknown-attributes)
+
+  # Warning example:
+  #     macro '__AMDGCN_WAVEFRONT_SIZE' has been marked as deprecated:
+  #     compile-time-constant access to the wavefront size will be removed in
+  #     a future release"
+  list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS -Wno-deprecated-pragma)
+
+  # Warning example:
+  #     'radix_key_codec' is deprecated: radix_key_codec is now public API.
+  list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS -Wno-deprecated-declarations)
+
+  # Warning example:
+  #     note: GPU printf warnings for invalid rocPRIM warp operations on Navi
+  #     GPUs temporarily disabled, due to performance issues with printf.
+  list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS "-Wno-#pragma-messages")
+
+  # Warning example:
+  #     duplicate 'static' declaration specifier
+  list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS -Wno-duplicate-decl-specifier)
 endif()
 
 # Generates a command prefix that can be prepended to any custom command line
@@ -556,10 +577,15 @@ function(therock_cmake_subproject_activate target_name)
     if(THEROCK_VERBOSE)
       message(STATUS "  LINK_DIR: ${_private_link_dir}")
     endif()
-    if(NOT MSVC OR _compiler_toolchain STREQUAL "amd-llvm" OR _compiler_toolchain STREQUAL "amd-hip")
+    if(NOT MSVC)
       # The normal way.
       string(APPEND _init_contents "string(APPEND CMAKE_EXE_LINKER_FLAGS \" -L ${_private_link_dir} -Wl,-rpath-link,${_private_link_dir}\")\n")
       string(APPEND _init_contents "string(APPEND CMAKE_SHARED_LINKER_FLAGS \" -L ${_private_link_dir} -Wl,-rpath-link,${_private_link_dir}\")\n")
+    elseif(_compiler_toolchain STREQUAL "amd-llvm" OR _compiler_toolchain STREQUAL "amd-hip")
+      # The Windows but using a clang-based toolchain way.
+      #   Working around "lld-link: warning: ignoring unknown argument '-rpath-link'"
+      string(APPEND _init_contents "string(APPEND CMAKE_EXE_LINKER_FLAGS \" -L ${_private_link_dir} \")\n")
+      string(APPEND _init_contents "string(APPEND CMAKE_SHARED_LINKER_FLAGS \" -L ${_private_link_dir} \")\n")
     else()
       # The MSVC way.
       string(APPEND _init_contents "string(APPEND CMAKE_EXE_LINKER_FLAGS \" /LIBPATH:${_private_link_dir}\")\n")

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -71,21 +71,6 @@ if(WIN32)
   list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS -Wno-unknown-attributes)
 
   # Warning example:
-  #     macro '__AMDGCN_WAVEFRONT_SIZE' has been marked as deprecated:
-  #     compile-time-constant access to the wavefront size will be removed in
-  #     a future release"
-  list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS -Wno-deprecated-pragma)
-
-  # Warning example:
-  #     'radix_key_codec' is deprecated: radix_key_codec is now public API.
-  list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS -Wno-deprecated-declarations)
-
-  # Warning example:
-  #     note: GPU printf warnings for invalid rocPRIM warp operations on Navi
-  #     GPUs temporarily disabled, due to performance issues with printf.
-  list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS "-Wno-#pragma-messages")
-
-  # Warning example:
   #     duplicate 'static' declaration specifier
   list(APPEND THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS -Wno-duplicate-decl-specifier)
 endif()

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -42,9 +42,9 @@ mainline, in open source, using MSVC, etc.).
 |                  |                                                                              |           |                                               |
 | math-libs        | [rocRAND](https://github.com/ROCm/rocRAND)                                   | ✅        |                                               |
 | math-libs        | [hipRAND](https://github.com/ROCm/hipRAND)                                   | ✅        |                                               |
-| math-libs        | [rocPRIM](https://github.com/ROCm/rocPRIM)                                   | ❔        |                                               |
-| math-libs        | [hipCUB](https://github.com/ROCm/hipCUB)                                     | ❔        |                                               |
-| math-libs        | [rocThrust](https://github.com/ROCm/rocThrust)                               | ❔        |                                               |
+| math-libs        | [rocPRIM](https://github.com/ROCm/rocPRIM)                                   | ✅        |                                               |
+| math-libs        | [hipCUB](https://github.com/ROCm/hipCUB)                                     | ✅        |                                               |
+| math-libs        | [rocThrust](https://github.com/ROCm/rocThrust)                               | ✅        | Some tests fail to link                       |
 | math-libs        | [rocFFT](https://github.com/ROCm/rocFFT)                                     | ✅        | No shared libraries                           |
 | math-libs        | [hipFFT](https://github.com/ROCm/hipFFT)                                     | ✅        | No shared libraries                           |
 | math-libs (blas) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ❔        |                                               |
@@ -239,3 +239,21 @@ options set:
 ```
 
 then look for `build/core/clr/dist/bin/amdhip64_6.dll` and related outputs.
+
+With the HIP runtime building, these flags can also now be enabled:
+
+```bash
+-DTHEROCK_ENABLE_RAND=ON \
+-DTHEROCK_ENABLE_PRIM=ON \
+-DTHEROCK_ENABLE_FFT=ON \
+```
+
+### Testing
+
+Test builds can be enabled with `-DBUILD_TESTING=ON`.
+
+Some subproject tests have been validated on Windows, like rocPRIM:
+
+```bash
+ctest --test-dir build/math-libs/rocPRIM/dist/bin/rocprim --output-on-failure
+```


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/36.

Tests for rocPRIM run on my gfx1100 dev machine: https://gist.github.com/ScottTodd/5c33611469aa1df9d39b816acecbb7f0.

### Warnings

I silenced a bunch of warnings that were getting in my way and added some notes to https://github.com/ROCm/TheRock/issues/47 about the remaining warnings since the build logs for rocPRIM were 45MB.

Some warnings will be fixed with newer subproject code. rocPRIM in particular is 2 months outdated on `mainline` compared to `develop`, and commits like https://github.com/ROCm/rocPRIM/commit/678701d13b9c1464d59843ead73816acb1716008 fix warnings by removing code like
```C++
    #ifdef _WIN32
        #define ROCPRIM_KERNEL __global__ static
    #else
        #define ROCPRIM_KERNEL __global__
    #endif
```
that had been causing warnings:
```
16.8	D:/projects/TheRock/math-libs/rocPRIM/rocprim/include\rocprim\device/device_find_first_of.hpp:53:12: warning: duplicate 'static' declaration specifier [-Wduplicate-decl-specifier]
16.8	   53 |     static ROCPRIM_KERNEL
16.8	      |            ^
16.8	D:/projects/TheRock/math-libs/rocPRIM/rocprim/include\rocprim\config.hpp:46:43: note: expanded from macro 'ROCPRIM_KERNEL'
16.8	   46 |         #define ROCPRIM_KERNEL __global__ static
16.8	      |                                           ^
```