### PR TITLE
Expand Windows support to include prim math libs.

### DIFF
--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -42,9 +42,9 @@ mainline, in open source, using MSVC, etc.).
 |                  |                                                                              |           |                                               |
 | math-libs        | [rocRAND](https://github.com/ROCm/rocRAND)                                   | ✅        |                                               |
 | math-libs        | [hipRAND](https://github.com/ROCm/hipRAND)                                   | ✅        |                                               |
-| math-libs        | [rocPRIM](https://github.com/ROCm/rocPRIM)                                   | ❔        |                                               |
-| math-libs        | [hipCUB](https://github.com/ROCm/hipCUB)                                     | ❔        |                                               |
-| math-libs        | [rocThrust](https://github.com/ROCm/rocThrust)                               | ❔        |                                               |
+| math-libs        | [rocPRIM](https://github.com/ROCm/rocPRIM)                                   | ✅        |                                               |
+| math-libs        | [hipCUB](https://github.com/ROCm/hipCUB)                                     | ✅        |                                               |
+| math-libs        | [rocThrust](https://github.com/ROCm/rocThrust)                               | ✅        | Some tests fail to link                       |
 | math-libs        | [rocFFT](https://github.com/ROCm/rocFFT)                                     | ✅        | No shared libraries                           |
 | math-libs        | [hipFFT](https://github.com/ROCm/hipFFT)                                     | ✅        | No shared libraries                           |
 | math-libs (blas) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ❔        |                                               |
@@ -239,3 +239,21 @@ options set:
 ```
 
 then look for `build/core/clr/dist/bin/amdhip64_6.dll` and related outputs.
+
+With the HIP runtime building, these flags can also now be enabled:
+
+```bash
+-DTHEROCK_ENABLE_RAND=ON \
+-DTHEROCK_ENABLE_PRIM=ON \
+-DTHEROCK_ENABLE_FFT=ON \
+```
+
+### Testing
+
+Test builds can be enabled with `-DBUILD_TESTING=ON`.
+
+Some subproject tests have been validated on Windows, like rocPRIM:
+
+```bash
+ctest --test-dir build/math-libs/rocPRIM/dist/bin/rocprim --output-on-failure
+```


### PR DESCRIPTION
Redo of https://github.com/ROCm/TheRock/pull/350 now that https://github.com/ROCm/TheRock/pull/339 is merged.

---

Progress on https://github.com/ROCm/TheRock/issues/36.

Tests for rocPRIM run on my gfx1100 dev machine:
https://gist.github.com/ScottTodd/5c33611469aa1df9d39b816acecbb7f0.

### Warnings

I silenced a bunch of warnings that were getting in my way and added some notes to https://github.com/ROCm/TheRock/issues/47 about the remaining warnings since the build logs for rocPRIM were 45MB.

Some warnings will be fixed with newer subproject code. rocPRIM in particular is 2 months outdated on `mainline` compared to `develop`, and commits like
https://github.com/ROCm/rocPRIM/commit/678701d13b9c1464d59843ead73816acb1716008 fix warnings by removing code like
```C++
    #ifdef _WIN32
        #define ROCPRIM_KERNEL __global__ static
    #else
        #define ROCPRIM_KERNEL __global__
    #endif
```
that had been causing warnings:
```
16.8	D:/projects/TheRock/math-libs/rocPRIM/rocprim/include\rocprim\device/device_find_first_of.hpp:53:12: warning: duplicate 'static' declaration specifier [-Wduplicate-decl-specifier]
16.8	   53 |     static ROCPRIM_KERNEL
16.8	      |            ^
16.8	D:/projects/TheRock/math-libs/rocPRIM/rocprim/include\rocprim\config.hpp:46:43: note: expanded from macro 'ROCPRIM_KERNEL'
16.8	   46 |         #define ROCPRIM_KERNEL __global__ static
16.8	      |                                           ^
```