### PR TITLE
Patch rocThrust gtest build type for Windows compatibility.

### DIFF
--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -44,7 +44,7 @@ mainline, in open source, using MSVC, etc.).
 | math-libs        | [hipRAND](https://github.com/ROCm/hipRAND)                                   | ✅        |                                               |
 | math-libs        | [rocPRIM](https://github.com/ROCm/rocPRIM)                                   | ✅        |                                               |
 | math-libs        | [hipCUB](https://github.com/ROCm/hipCUB)                                     | ✅        |                                               |
-| math-libs        | [rocThrust](https://github.com/ROCm/rocThrust)                               | ✅        | Some tests fail to link                       |
+| math-libs        | [rocThrust](https://github.com/ROCm/rocThrust)                               | ✅        |                                               |
 | math-libs        | [rocFFT](https://github.com/ROCm/rocFFT)                                     | ✅        | No shared libraries                           |
 | math-libs        | [hipFFT](https://github.com/ROCm/hipFFT)                                     | ✅        | No shared libraries                           |
 | math-libs (blas) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ❔        |                                               |

--- a/patches/amd-mainline/rocThrust/0001-Forward-CMAKE_BUILD_TYPE-when-building-gtest.patch
+++ b/patches/amd-mainline/rocThrust/0001-Forward-CMAKE_BUILD_TYPE-when-building-gtest.patch
@@ -1,0 +1,26 @@
+From 3d3bcc3540e3fc09a94483134bbe8813f6fa7495 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Mon, 7 Apr 2025 15:01:18 -0700
+Subject: [PATCH] Forward CMAKE_BUILD_TYPE when building gtest.
+
+This avoids `lld-link: error: /failifmismatch: mismatch detected for '_ITERATOR_DEBUG_LEVEL':` errors on Windows when rocThrust is compiled in Release instead of Debug (the default).
+---
+ cmake/Dependencies.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
+index b0bd252f..2088312f 100644
+--- a/cmake/Dependencies.cmake
++++ b/cmake/Dependencies.cmake
+@@ -53,7 +53,7 @@ if(BUILD_TEST OR BUILD_HIPSTDPAR_TEST)
+       GIT_REPOSITORY      https://github.com/google/googletest.git
+       GIT_TAG             release-1.11.0
+       INSTALL_DIR         ${GTEST_ROOT}
+-      CMAKE_ARGS          -DBUILD_GTEST=ON -DINSTALL_GTEST=ON -Dgtest_force_shared_crt=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
++      CMAKE_ARGS          -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DBUILD_GTEST=ON -DINSTALL_GTEST=ON -Dgtest_force_shared_crt=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+       LOG_DOWNLOAD        TRUE
+       LOG_CONFIGURE       TRUE
+       LOG_BUILD           TRUE
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/36.

I was seeing errors like this:
```
279.4	[119/236  22% :: 279.314] Linking CXX executable test\adjacent_difference.hip.exe
279.4	FAILED: test/adjacent_difference.hip.exe 
282.3	C:\Windows\system32\cmd.exe /C "cd . && D:\projects\TheRock\build\core\clr\dist\lib\llvm\bin\clang++.exe -nostartfiles -nostdlib -DWIN32 -D_CRT_SECURE_NO_WARNINGS -DNOMINMAX -fms-extensions -fms-compatibility -D_ENABLE_EXTENDED_ALIGNED_STORAGE  -Wno-documentation-unknown-command -Wno-documentation-pedantic -Wno-unused-command-line-argument -Wno-ignored-attributes -Wno-unknown-attributes -Wno-duplicate-decl-specifier --hip-path=D:/projects/TheRock/build/core/clr/dist --hip-device-lib-path=D:/projects/TheRock/build/core/clr/dist/lib/llvm/amdgcn/bitcode -O3 -DNDEBUG -D_DLL -D_MT -Xclang --dependent-lib=msvcrt -L D:/projects/TheRock/build/compiler/amd-llvm/stage/lib/llvm/lib  -L D:/projects/TheRock/build/core/clr/stage/lib   -Xlinker /subsystem:console  -fuse-ld=lld-link CMakeFiles/sqlite3.dir/_deps/sqlite_local-src/sqlite3.c.obj test/CMakeFiles/adjacent_difference.hip.dir/test_adjacent_difference.cpp.obj -o test\adjacent_difference.hip.exe -Xlinker /MANIFEST:EMBED -Xlinker /implib:test\adjacent_difference.hip.lib -Xlinker /pdb:test\adjacent_difference.hip.pdb -Xlinker /version:0.0   deps/gtest/lib/gtestd.lib  deps/gtest/lib/gtest_maind.lib  D:/projects/TheRock/build/core/clr/dist/lib/amdhip64.lib  --hip-link  --offload-arch=gfx1100  --offload-arch=gfx1101  --offload-arch=gfx1102  D:/projects/TheRock/build/core/clr/dist/lib/llvm/lib/clang/19/lib/windows/clang_rt.builtins-x86_64.lib  deps/gtest/lib/gtestd.lib  -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 -loldnames  && C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\math-libs\rocThrust\build\test && "C:\Program Files\CMake\bin\cmake.exe" -E copy_if_different D:/projects/TheRock/math-libs/rocThrust/rtest.py D:/projects/TheRock/build/math-libs/rocThrust/build/test && cd /D D:\projects\TheRock\build\math-libs\rocThrust\build\test && "C:\Program Files\CMake\bin\cmake.exe" -E copy_if_different D:/projects/TheRock/math-libs/rocThrust/rtest.xml D:/projects/TheRock/build/math-libs/rocThrust/build/test""
282.3	lld-link: error: /failifmismatch: mismatch detected for '_ITERATOR_DEBUG_LEVEL':

282.3	>>> test/CMakeFiles/adjacent_difference.hip.dir/test_adjacent_difference.cpp.obj has value 0

282.3	>>> gtestd.lib(gtest-all.cc.obj) has value 2

282.3	clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

The documentation for `_ITERATOR_DEBUG_LEVEL` https://learn.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=msvc-170 suggested that gtest was getting built in Debug while the rest of the project was getting built in Release. There are likely other dependencies affected by this issue, but this was minimally what I needed to build all rocThrust tests on Windows:
```
[build] [rocThrust] [235/236  97% :: 2.054] Linking CXX executable test\vector_insert.hip.exe
[build] [rocThrust] [235/236  98% :: 2.054] Linking CXX executable test\vector.hip.exe
[build] [rocThrust] [235/236  98% :: 2.066] Linking CXX executable test\vector_allocators.hip.exe
[build] [rocThrust] [235/236  99% :: 2.126] Linking CXX executable test\binary_search_vector_descending.hip.exe
[build] [rocThrust] [235/236  99% :: 2.160] Linking CXX executable test\binary_search_vector.hip.exe
[build] [rocThrust completed in 2 seconds]
[build] [5/7  71% :: 21.535] Stage installing sub-project rocThrust
[build] [6/7  85% :: 22.261] Merging sub-project dist directory for rocThrust
[driver] Build completed: 00:00:22.298
[build] Build finished with exit code 0
```