### PR TITLE
Add missing explicit rocm-cmake BUILD_DEPS.

### DIFF
--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -66,6 +66,7 @@ therock_cmake_subproject_declare(hipBLASLt
     amd-hip
   BUILD_DEPS
     hipBLAS-common
+    rocm-cmake
     therock-msgpack-cxx
   RUNTIME_DEPS
     hip-clr
@@ -106,13 +107,12 @@ therock_cmake_subproject_declare(rocBLAS
     -DBUILD_CLIENTS_TESTS=${THEROCK_BUILD_TESTING}
     -DBUILD_CLIENTS_BENCHMARKS=${THEROCK_BUILD_TESTING}
     -DLINK_BLIS=OFF
-  IGNORE_PACKAGES
-      ROCM
   COMPILER_TOOLCHAIN
     amd-hip
   BUILD_DEPS
-    therock-msgpack-cxx
     hipBLAS-common
+    rocm-cmake
+    therock-msgpack-cxx
   RUNTIME_DEPS
     hip-clr
     hipBLASLt
@@ -146,6 +146,7 @@ if(THEROCK_ENABLE_SPARSE)
     COMPILER_TOOLCHAIN
       amd-hip
     BUILD_DEPS
+      rocm-cmake
       rocBLAS
       rocPRIM
     RUNTIME_DEPS
@@ -176,6 +177,7 @@ if(THEROCK_ENABLE_SPARSE)
     COMPILER_TOOLCHAIN
       amd-hip
     BUILD_DEPS
+      rocm-cmake
       rocSPARSE
     RUNTIME_DEPS
       hip-clr
@@ -208,6 +210,7 @@ if(THEROCK_ENABLE_SOLVER)
       COMPILER_TOOLCHAIN
         amd-hip
       BUILD_DEPS
+        rocm-cmake
         rocBLAS
         rocPRIM
         therock-fmt
@@ -247,6 +250,8 @@ if(THEROCK_ENABLE_SOLVER)
         -DHIPSOLVER_FIND_PACKAGE_LAPACK_CONFIG=OFF
       COMPILER_TOOLCHAIN
         amd-hip
+      BUILD_DEPS
+        rocm-cmake
       RUNTIME_DEPS
         hip-clr
         rocBLAS
@@ -293,6 +298,7 @@ therock_cmake_subproject_declare(hipBLAS
     amd-hip
   BUILD_DEPS
     hipBLAS-common
+    rocm-cmake
   RUNTIME_DEPS
     hip-clr
     rocBLAS

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -13,6 +13,8 @@ if(THEROCK_ENABLE_RAND)
       -DROCM_DIR=
     COMPILER_TOOLCHAIN
       amd-hip
+    BUILD_DEPS
+      rocm-cmake
     RUNTIME_DEPS
       hip-clr
   )
@@ -38,6 +40,7 @@ if(THEROCK_ENABLE_RAND)
     COMPILER_TOOLCHAIN
       amd-hip
     BUILD_DEPS
+      rocm-cmake
       rocRAND
     RUNTIME_DEPS
       hip-clr
@@ -81,6 +84,8 @@ if(THEROCK_ENABLE_PRIM)
       -DBUILD_TEST=${THEROCK_BUILD_TESTING}
     COMPILER_TOOLCHAIN
       amd-hip
+    BUILD_DEPS
+      rocm-cmake
     RUNTIME_DEPS
       hip-clr
   )
@@ -101,10 +106,11 @@ if(THEROCK_ENABLE_PRIM)
       -DBUILD_TEST=${THEROCK_BUILD_TESTING}
     COMPILER_TOOLCHAIN
       amd-hip
+    BUILD_DEPS
+      rocm-cmake
+      rocPRIM
     RUNTIME_DEPS
       hip-clr
-    BUILD_DEPS
-      rocPRIM
   )
   therock_cmake_subproject_glob_c_sources(rocPRIM
     SUBDIRS
@@ -123,10 +129,11 @@ if(THEROCK_ENABLE_PRIM)
       -DBUILD_TEST=${THEROCK_BUILD_TESTING}
     COMPILER_TOOLCHAIN
       amd-hip
+    BUILD_DEPS
+      rocm-cmake
+      rocPRIM
     RUNTIME_DEPS
       hip-clr
-    BUILD_DEPS
-      rocPRIM
   )
   therock_cmake_subproject_glob_c_sources(rocThrust
     SUBDIRS
@@ -178,6 +185,8 @@ if(THEROCK_ENABLE_FFT)
       -DBUILD_SHARED_LIBS=${_fft_shared_libs_arg}
     COMPILER_TOOLCHAIN
       amd-hip
+    BUILD_DEPS
+      rocm-cmake
     RUNTIME_DEPS
       hip-clr
       hipRAND
@@ -204,6 +213,8 @@ if(THEROCK_ENABLE_FFT)
       -DBUILD_SHARED_LIBS=${_fft_shared_libs_arg}
     COMPILER_TOOLCHAIN
       amd-hip
+    BUILD_DEPS
+      rocm-cmake
     RUNTIME_DEPS
       hip-clr
       rocFFT


### PR DESCRIPTION
Related to https://github.com/ROCm/TheRock/issues/18. These sub-projects first try to find rocm-cmake (https://github.com/ROCm/rocm-cmake) via either the deprecated `find_package(ROCM ...)` or the newer `find_package(ROCmCMakeBuildTools ...)`. If they fail to find the package, they then proceed to set a cached `rocm_cmake_tag` and download whichever version was chosen using `file(DOWNLOAD ...)`. In order to get a predictable and consistent version of the package, this sets our super-project's `rocm-cmake` project in `BUILD_DEPS` for each package that needs it.

I searched through build logs for messages like
```
2025-04-08T12:16:47.5889391Z -- Resolving system find_package(ROCM) (not found in super-project ZLIB;zstd;AMDDeviceLibs;Clang;LLD;LLVM;amd_comgr;rocm-core;rocprofiler-register;BZip2;LibElf;libdw;NUMA;hsakmt;hsa-runtime64;hip;HIP;hip-lang;hiprtc)
2025-04-08T12:16:47.5890521Z -- ROCm CMake not found. Fetching...
```

and added this explicit dep.

Now the logs should be correctly finding the super project package:
```
[build] [rocFFT configure] -- Resolving super-project find_package(ROCmCMakeBuildTools BYPASS_PROVIDER NO_DEFAULT_PATH PATHS D:/projects/TheRock/build/base/rocm-cmake/dist/share/rocmcmakebuildtools/cmake)
```

Note: I did not touch rccl or hipBLAS-common, both of which have comments ignoring the `ROCM` package due to https://github.com/ROCm/TheRock/issues/18.