### PR TITLE
Extend our package resolver to error if packages are known.

### DIFF
--- a/cmake/therock_subproject_dep_provider.cmake
+++ b/cmake/therock_subproject_dep_provider.cmake
@@ -8,6 +8,9 @@
 #   THEROCK_IGNORE_PACKAGES: Packages to ignore, even if they are in
 #     THEROCK_PROVIDED_PACKAGES, falling back to the system resolver.
 #   THEROCK_PKG_CONFIG_DIRS: Directories to search for .pc files.
+#   THEROCK_STRICT_PROVIDED_PACKAGES: All packages that the super-project knows
+#     about. If a sub-project attempts to resolve one of these without a
+#     proper declared dependency, it will error.
 # See: _therock_cmake_subproject_setup_deps which assembles these variables
 
 block()
@@ -50,6 +53,10 @@ macro(therock_dependency_provider method package_name)
       "${THEROCK_PACKAGE_DIR_${package_name}}" "${package_name}" ${ARGN})
     find_package(${_therock_rewritten_superproject_find_package_sig})
   else()
+    if("${package_name}" IN_LIST THEROCK_STRICT_PROVIDED_PACKAGES)
+      cmake_policy(POP)
+      message(FATAL_ERROR "Project contains find_package(${package_name}) for a package availabe in the super-project but not declared: Add a BUILD_DEPS or RUNTIME_DEPS appropriately")
+    endif()
     cmake_policy(POP)
     message(STATUS "Resolving system find_package(${package_name}) (not found in super-project ${THEROCK_PROVIDED_PACKAGES})")
     find_package(${package_name} ${ARGN} BYPASS_PROVIDER)

--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -17,13 +17,8 @@ if(THEROCK_ENABLE_RCCL)
       -DENABLE_MSCCL_KERNEL=OFF
     COMPILER_TOOLCHAIN
       amd-hip
-    IGNORE_PACKAGES
-      # The current version of rccl needs to download a 2y old version of rocm-cmake
-      # to work and it will only do so if the system resolver reports it not found
-      # without any other error (which due to the signature, our resolver will
-      # hard fail). Once fixed, `rocm-core` should be added to the BUILD_DEPS
-      # and this removed: https://github.com/ROCm/TheRock/issues/18
-      ROCM
+    BUILD_DEPS
+      rocm-cmake
     RUNTIME_DEPS
       hip-clr
       hipify

--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -18,13 +18,8 @@ CMAKE_ARGS
   -DROCM_DIR=
 COMPILER_TOOLCHAIN
   amd-hip
-IGNORE_PACKAGES
-  # The current version of rccl needs to download a 2y old version of rocm-cmake
-  # to work and it will only do so if the system resolver reports it not found
-  # without any other error (which due to the signature, our resolver will
-  # hard fail). Once fixed, `rocm-core` should be added to the BUILD_DEPS
-  # and this removed: https://github.com/ROCm/TheRock/issues/18
-  ROCM
+BUILD_DEPS
+  rocm-cmake
 RUNTIME_DEPS
   hip-clr
 )


### PR DESCRIPTION
* This strict mode avoids the common problem where a sub-project adds a new find_package dep that was not declared.
* Such cases will now cause an error.

Fixes #18