### PR TITLE
Patch win32 install prefixes in several BLAS libraries.

### DIFF
--- a/patches/amd-mainline/hipBLAS-common/0001-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
+++ b/patches/amd-mainline/hipBLAS-common/0001-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
@@ -1,0 +1,27 @@
+From e2342a8afc7c965e82e58e1f240aeb7b1a33ba81 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Tue, 8 Apr 2025 16:09:56 -0700
+Subject: [PATCH] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8711af4..425f9d9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -73,7 +73,9 @@ set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md" )
+ set( CPACK_RPM_PACKAGE_LICENSE "MIT")
+ 
+ if (WIN32)
+-  SET( CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE )
++  if( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
++    SET( CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE )
++  endif()
+   SET( INSTALL_PREFIX "C:/hipSDK" )
+   SET( CPACK_SET_DESTDIR FALSE )
+   SET( CPACK_PACKAGE_INSTALL_DIRECTORY "C:/hipSDK" )
+-- 
+2.47.1.windows.2
+

--- a/patches/amd-mainline/hipBLAS/0001-Fix-finding-LAPACK-and-CBLAS.patch
+++ b/patches/amd-mainline/hipBLAS/0001-Fix-finding-LAPACK-and-CBLAS.patch
@@ -1,7 +1,7 @@
-From 1bd858122d5bb62dc0738ba6a354e01f3a4c48dc Mon Sep 17 00:00:00 2001
+From d8a87130e4b9e2c3e2ca7e982c735ccb5f19fed2 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Tue, 25 Mar 2025 12:13:13 +0000
-Subject: [PATCH] Fix finding LAPACK and CBLAS
+Subject: [PATCH 1/4] Fix finding LAPACK and CBLAS
 
 Use target names provided by `find_package()` instead of assuming that
 the reference NETLIB libraries should be used.
@@ -43,5 +43,5 @@ index 4b01cc8..5198853 100644
    if( BUILD_CLIENTS_TESTS )
      add_subdirectory( gtest )
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/hipBLAS/0002-Work-around-race-condition.patch
+++ b/patches/amd-mainline/hipBLAS/0002-Work-around-race-condition.patch
@@ -1,7 +1,7 @@
-From b17c0b3436638f7cf4fb6e5df741d4871f9fc10f Mon Sep 17 00:00:00 2001
+From 8cc3f6e7600346e0d2d25c745f298925d7245d86 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Fri, 21 Mar 2025 17:01:20 +0000
-Subject: [PATCH 2/2] Work around race condition
+Subject: [PATCH 2/4] Work around race condition
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -15,7 +15,7 @@ in time for the first run. Using `target_link_libraries` resovles this.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/clients/CMakeLists.txt b/clients/CMakeLists.txt
-index b258ae2..f88f78b 100644
+index 5198853..983951b 100644
 --- a/clients/CMakeLists.txt
 +++ b/clients/CMakeLists.txt
 @@ -99,7 +99,7 @@ if( BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_SAMPLES )
@@ -28,5 +28,5 @@ index b258ae2..f88f78b 100644
    include_directories(${CMAKE_BINARY_DIR}/include/hipblas)
    include_directories(${CMAKE_BINARY_DIR}/include)
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/hipBLAS/0003-Install-libhipblas_fortran.so.patch
+++ b/patches/amd-mainline/hipBLAS/0003-Install-libhipblas_fortran.so.patch
@@ -1,7 +1,7 @@
-From 436360742b499f0838ee90bfbbf912f4f52106db Mon Sep 17 00:00:00 2001
+From b7aef976b732823c73132df637fcd43cffd247a8 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Tue, 1 Apr 2025 20:58:38 +0000
-Subject: [PATCH 3/3] Install `libhipblas_fortran.so`
+Subject: [PATCH 3/4] Install `libhipblas_fortran.so`
 
 This is required by the test and benchmark clients but was not part of
 the installation so far.
@@ -22,5 +22,5 @@ index 083e8eb..d6c849f 100755
  
  if(BUILD_ADDRESS_SANITIZER)
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/hipBLAS/0004-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
+++ b/patches/amd-mainline/hipBLAS/0004-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
@@ -1,0 +1,27 @@
+From 28fa60fa367e26e8c238ffe0a08149f45e41eb08 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Tue, 8 Apr 2025 16:10:37 -0700
+Subject: [PATCH 4/4] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9819d7e..61a7fbc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -224,7 +224,9 @@ set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md" )
+ set( CPACK_RPM_PACKAGE_LICENSE "MIT")
+ 
+ if (WIN32)
+-  SET( CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE )
++  if( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
++    SET( CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE )
++  endif()
+   SET( INSTALL_PREFIX "C:/hipSDK" )
+   SET( CPACK_SET_DESTDIR FALSE )
+   SET( CPACK_PACKAGE_INSTALL_DIRECTORY "C:/hipSDK" )
+-- 
+2.47.1.windows.2
+

--- a/patches/amd-mainline/rocBLAS/0001-Update-packaging-in-pip-venv-to-stabilize-setuptools.patch
+++ b/patches/amd-mainline/rocBLAS/0001-Update-packaging-in-pip-venv-to-stabilize-setuptools.patch
@@ -1,7 +1,7 @@
-From febe154e0f66ca6fd639abbb91f414d0296dd601 Mon Sep 17 00:00:00 2001
+From 3d80616b38d552628a237e907a4364b008d0ab76 Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Thu, 6 Mar 2025 15:16:19 -0800
-Subject: [PATCH 2/6] Update 'packaging' in pip venv to stabilize setuptools.
+Subject: [PATCH 1/6] Update 'packaging' in pip venv to stabilize setuptools.
 
 When using setuptools>=71.0.0 and packaging<22.0, setuptools may fail with `TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'`.
 ---
@@ -29,5 +29,5 @@ index 951755ae..7c9c6cd1 100644
      execute_process(
        RESULT_VARIABLE rc
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocBLAS/0002-Fail-if-BLIS-is-not-found-but-LINK_BLIS-is-set.patch
+++ b/patches/amd-mainline/rocBLAS/0002-Fail-if-BLIS-is-not-found-but-LINK_BLIS-is-set.patch
@@ -1,7 +1,7 @@
-From ac77ca902fd3ba6cee30811ccadbae9457b4caa4 Mon Sep 17 00:00:00 2001
+From 7235f728716519e8f2835ec4d728184cb9d67e08 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Mon, 24 Mar 2025 21:56:24 +0000
-Subject: [PATCH 3/6] Fail if BLIS is not found but `LINK_BLIS` is set
+Subject: [PATCH 2/6] Fail if BLIS is not found but `LINK_BLIS` is set
 
 Fail if `LINK_BLIS` is set (defaults to `ON`) but the library is not
 found. Insteaf of issung only a warning, return with a fatal error as
@@ -33,5 +33,5 @@ index 51d34060..33b71d0d 100644
          endif()
        endif()
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocBLAS/0003-Find-BLAS-with-find_package.patch
+++ b/patches/amd-mainline/rocBLAS/0003-Find-BLAS-with-find_package.patch
@@ -1,7 +1,7 @@
-From 89747834c6bff78103bd5a5ca74027aab89a302e Mon Sep 17 00:00:00 2001
+From 7fcef8049c4e0171531750e53cd3cf1a3e9085e0 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Mon, 24 Mar 2025 22:01:01 +0000
-Subject: [PATCH 4/6] Find BLAS with `find_package()`
+Subject: [PATCH 3/6] Find BLAS with `find_package()`
 
 Switches to `find_package()` insteaf of assuming that the reference BLAS
 is available without any check. This also allows to use OpenBLAS.
@@ -33,5 +33,5 @@ index 33b71d0d..12bd44d7 100644
    if ( WARN_NOT_ILP64_PREFERRED )
      message( WARNING "Using ${BLAS_LIBRARY} as reference library, 64-bit tests may fail. Test suite should be run with --gtest_filter=-*stress*")
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocBLAS/0004-Find-rocm_smi-via-config-files.patch
+++ b/patches/amd-mainline/rocBLAS/0004-Find-rocm_smi-via-config-files.patch
@@ -1,7 +1,7 @@
-From 7413f1b2b01f9ddc03ccff4b4e607af6261225af Mon Sep 17 00:00:00 2001
+From 34125f704aab5300d323ce31dec19aba8a2d5794 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Wed, 12 Mar 2025 14:26:45 +0000
-Subject: [PATCH 5/6] Find `rocm_smi` via config files
+Subject: [PATCH 4/6] Find `rocm_smi` via config files
 
 Use the config files provided by upstream instead of a custom finder.
 ---
@@ -83,5 +83,5 @@ index 698f6884..00000000
 -    IMPORTED_LOCATION "${ROCM_SMI_LIBRARY}"
 -    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${ROCM_SMI_ROOT}/include")
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocBLAS/0005-Move-blas_ex-common_gemm_ex3-to-different-target.patch
+++ b/patches/amd-mainline/rocBLAS/0005-Move-blas_ex-common_gemm_ex3-to-different-target.patch
@@ -1,7 +1,7 @@
-From 86ee73302883dab1311a1a655bbbc3bb0bb05be2 Mon Sep 17 00:00:00 2001
+From 8088cae4581d002abc0cf54ab76f2f179a24ffb7 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Wed, 12 Mar 2025 16:58:59 +0000
-Subject: [PATCH 6/6] Move `blas_ex/common_gemm_ex3` to different target
+Subject: [PATCH 5/6] Move `blas_ex/common_gemm_ex3` to different target
 
 `clients/common/blas_ex/common_gemm_ex3.cpp` pulls in cblas via
 `clients/common/common_helpers.hpp` ->
@@ -36,5 +36,5 @@ index 7fabacf5..7ab67d91 100644
  rocblas_client_library_settings( rocblas_clients_testing_common )
  
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocBLAS/0006-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
+++ b/patches/amd-mainline/rocBLAS/0006-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
@@ -1,0 +1,27 @@
+From 7757c1271711661318314aec9938e1655cf63054 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Tue, 8 Apr 2025 16:10:28 -0700
+Subject: [PATCH 6/6] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f2ff3d15..41c07462 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -362,7 +362,9 @@ set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md" )
+ set( CPACK_RPM_PACKAGE_LICENSE "MIT and BSD")
+ 
+ if (WIN32)
+-  SET( CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE )
++  if( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
++    SET( CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE )
++  endif()
+   SET( INSTALL_PREFIX "C:/hipSDK" )
+   SET( CPACK_SET_DESTDIR FALSE )
+   SET( CPACK_PACKAGE_INSTALL_DIRECTORY "C:/hipSDK" )
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
See https://github.com/ROCm/TheRock/issues/343. On Windows, these projects have been force setting `CMAKE_INSTALL_PREFIX` to `C:/hipSDK`, regardless of what any superproject or user requests. The canonical way to set a default install prefix is to first check `CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT`: https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT.html and then _not_ use `FORCE`. These are minimal changes to stop the sub-projects from grossly misbehaving.