### PR TITLE
Updating ci trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ on:
     types:
       - labeled
       - opened
+      - synchronize
 
 permissions:
   contents: read


### PR DESCRIPTION
Right now, PR triggers only happen upon opened or labeled. Adding synchronize will help the user experience with PRs, so a new job gets triggered and the previous job gets cancelled

Progress on #221 