### PR TITLE
Skipping tests for target without test machines

### DIFF
--- a/.github/workflows/test_linux_packages.yml
+++ b/.github/workflows/test_linux_packages.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   test_sanity_check:
     name: 'Test Sanity Check'
+    if: ${{ inputs.test_runs_on != '' }} # if there is a test machine available
     uses: './.github/workflows/test_sanity_check.yml'
     with:
       artifact_run_id: ${{ inputs.artifact_run_id }}


### PR DESCRIPTION
If `test-runs-on` field is empty in the amdgpu matrix, tests will not run on those targets. Once we fill those fields, tests can properly run!
