### PR TITLE
Skip rocprofiler-sdk on unsupported Windows platform.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,11 +149,18 @@ therock_add_feature(HIP_RUNTIME
 )
 
 # Profiler Features.
-therock_add_feature(PROFILER_SDK
-  GROUP PROFILER
-  DESCRIPTION "Enables the rocprofiler-sdk project"
-  REQUIRES HIP_RUNTIME
-)
+if(NOT WIN32)
+  # Other platforms (Linux) _do_ have the profiler SDK.
+  therock_add_feature(PROFILER_SDK
+    GROUP PROFILER
+    DESCRIPTION "Enables the rocprofiler-sdk project"
+    REQUIRES HIP_RUNTIME
+  )
+  set(_blas_platform_requirements "PROFILER_SDK")
+else()
+  # No profiler SDK on Windows.
+  set(_blas_platform_requirements "")
+endif()
 
 # Comm-libs Features.
 therock_add_feature(RCCL
@@ -174,7 +181,7 @@ therock_add_feature(BLAS
   # NOTE: HOST_BLAS is only needed for some tests and PROFILER_SDK is
   # currently only required for rocblas. We may want to re-evaluate the deps
   # if they continue to be sparse like this as it increases minimum dep length.
-  REQUIRES COMPILER HIP_RUNTIME HOST_BLAS PROFILER_SDK
+  REQUIRES COMPILER HIP_RUNTIME HOST_BLAS ${_blas_platform_requirements}
 )
 therock_add_feature(RAND
   GROUP MATH_LIBS

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -47,8 +47,8 @@ mainline, in open source, using MSVC, etc.).
 | math-libs        | [rocThrust](https://github.com/ROCm/rocThrust)                               | ✅        |                                               |
 | math-libs        | [rocFFT](https://github.com/ROCm/rocFFT)                                     | ✅        | No shared libraries                           |
 | math-libs        | [hipFFT](https://github.com/ROCm/hipFFT)                                     | ✅        | No shared libraries                           |
-| math-libs (blas) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ❔        |                                               |
-| math-libs (blas) | [hipBLASlt](https://github.com/ROCm/hipBLASlt)                               | ❔        |                                               |
+| math-libs (blas) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ✅        |                                               |
+| math-libs (blas) | [hipBLASlt](https://github.com/ROCm/hipBLASlt)                               | ❔        | In progress                                   |
 | math-libs (blas) | [rocBLAS](https://github.com/ROCm/rocBLAS)                                   | ❔        |                                               |
 | math-libs (blas) | [rocSPARSE](https://github.com/ROCm/rocSPARSE)                               | ❔        |                                               |
 | math-libs (blas) | [hipSPARSE](https://github.com/ROCm/hipSPARSE)                               | ❔        |                                               |

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -48,8 +48,8 @@ mainline, in open source, using MSVC, etc.).
 | math-libs        | [rocFFT](https://github.com/ROCm/rocFFT)                                     | ✅        | No shared libraries                           |
 | math-libs        | [hipFFT](https://github.com/ROCm/hipFFT)                                     | ✅        | No shared libraries                           |
 | math-libs (blas) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ✅        |                                               |
-| math-libs (blas) | [hipBLASlt](https://github.com/ROCm/hipBLASlt)                               | ❔        | In progress                                   |
-| math-libs (blas) | [rocBLAS](https://github.com/ROCm/rocBLAS)                                   | ❔        |                                               |
+| math-libs (blas) | [hipBLASLt](https://github.com/ROCm/hipBLASLt)                               | ❔        | Under evaluation                              |
+| math-libs (blas) | [rocBLAS](https://github.com/ROCm/rocBLAS)                                   | ❔        | In progress                                   |
 | math-libs (blas) | [rocSPARSE](https://github.com/ROCm/rocSPARSE)                               | ❔        |                                               |
 | math-libs (blas) | [hipSPARSE](https://github.com/ROCm/hipSPARSE)                               | ❔        |                                               |
 | math-libs (blas) | [rocSOLVER](https://github.com/ROCm/rocSOLVER)                               | ❔        |                                               |

--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -83,9 +83,12 @@ list(APPEND _blas_subproject_names hipBLASLt)
 # rocBLAS
 ##############################################################################
 
-set(rocBLAS_optional_deps)
+set(_rocBLAS_optional_runtime_deps)
 if(THEROCK_BUILD_TESTING)
-  list(APPEND rocBLAS_optional_deps rocm_smi_lib)
+  list(APPEND _rocBLAS_optional_runtime_deps rocm_smi_lib)
+endif()
+if(NOT WIN32)
+  list(APPEND _rocBLAS_optional_runtime_deps roctracer-compat)
 endif()
 
 therock_cmake_subproject_declare(rocBLAS
@@ -114,8 +117,7 @@ therock_cmake_subproject_declare(rocBLAS
   RUNTIME_DEPS
     hip-clr
     hipBLASLt
-    roctracer-compat
-    ${rocBLAS_optional_deps}
+    ${_rocBLAS_optional_runtime_deps}
 )
 therock_cmake_subproject_glob_c_sources(rocBLAS
 SUBDIRS

--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -83,12 +83,12 @@ list(APPEND _blas_subproject_names hipBLASLt)
 # rocBLAS
 ##############################################################################
 
-set(_rocBLAS_optional_runtime_deps)
+set(rocBLAS_optional_runtime_deps)
 if(THEROCK_BUILD_TESTING)
-  list(APPEND _rocBLAS_optional_runtime_deps rocm_smi_lib)
+  list(APPEND rocBLAS_optional_runtime_deps rocm_smi_lib)
 endif()
 if(NOT WIN32)
-  list(APPEND _rocBLAS_optional_runtime_deps roctracer-compat)
+  list(APPEND rocBLAS_optional_runtime_deps roctracer-compat)
 endif()
 
 therock_cmake_subproject_declare(rocBLAS
@@ -117,7 +117,7 @@ therock_cmake_subproject_declare(rocBLAS
   RUNTIME_DEPS
     hip-clr
     hipBLASLt
-    ${_rocBLAS_optional_runtime_deps}
+    ${rocBLAS_optional_runtime_deps}
 )
 therock_cmake_subproject_glob_c_sources(rocBLAS
 SUBDIRS


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/36.

This enables configuring with `-DTHEROCK_ENABLE_BLAS=ON` on Windows and building of hipBLAS-common.

Per https://rocm.docs.amd.com/projects/install-on-windows/en/latest/reference/component-support.html, the [ROCProfiler](https://rocm.docs.amd.com/projects/rocprofiler/en/latest/) program is not supported on Windows today, and users are directed to use [Radeon GPU Profiler](https://gpuopen.com/rgp/) instead. Additionally, the roctracer project reports a fatal error during configuration on Windows: https://github.com/ROCm/roctracer/blob/a847d331ff2886d23fdb7946695df7fe440c5f57/CMakeLists.txt#L38-L41
```cmake
## Build is not supported on Windows plaform
if(WIN32)
  message(FATAL_ERROR "Windows build is not supported.")
endif()
```