### PR TITLE
Teach the build how to bootstrap from a prior phase.

### DIFF
--- a/build_tools/CMakeLists.txt
+++ b/build_tools/CMakeLists.txt
@@ -3,3 +3,9 @@ add_test(
     COMMAND "${Python3_EXECUTABLE}"
         "${CMAKE_CURRENT_SOURCE_DIR}/tests/fileset_tool_test.py"
 )
+
+add_test(
+    NAME build_tools_artifacts_test
+    COMMAND "${Python3_EXECUTABLE}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/tests/artifacts_test.py"
+)

--- a/build_tools/_therock_utils/artifacts.py
+++ b/build_tools/_therock_utils/artifacts.py
@@ -18,10 +18,12 @@ contains one relative path per line. That path represents a path into a TheRock
 build directory that its contents are subset from.
 """
 
-from typing import Callable, Sequence
+from typing import Callable, Optional, Sequence
 
+import os
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+import tarfile
 
 from .pattern_match import PatternMatcher, MatchPredicate
 
@@ -32,11 +34,47 @@ class ArtifactName:
         self.component = component
         self.target_family = target_family
 
+    @staticmethod
+    def from_path(path: Path) -> Optional["ArtifactName"]:
+        filename = path.name
+        if path.is_dir():
+            # Matches {name}_{component}_{target_family} with an optional
+            # extra suffix that we ignore.
+            m = re.match(r"^([^_]+)_([^_]+)_([^_]+)(_.+)?$", filename)
+            if not m:
+                return None
+            return ArtifactName(m.group(1), m.group(2), m.group(3))
+        else:
+            # Matches {name}_{component}_{target_family} with an optional
+            # extra suffix that we ignore and an archive extension.
+            m = re.match(r"^([^_]+)_([^_]+)_([^_]+)(_.+)?\.tar.xz$", filename)
+            if not m:
+                return None
+            return ArtifactName(m.group(1), m.group(2), m.group(3))
+
     def __repr__(self):
         return f"Artifact({self.name}[{self.component}:{self.target_family}])"
 
+    def __eq__(self, other):
+        if not isinstance(other, ArtifactName):
+            return NotImplemented
+        return (
+            self.name == other.name
+            and self.component == other.component
+            and self.target_family == other.target_family
+        )
+
+    def __hash__(self):
+        return hash((self.name, self.component, self.target_family))
+
 
 class ArtifactCatalog:
+    """Scans a directory containing exploded artifact sub-directories.
+
+    This is used for various packaging activities that need to operate on
+    actual files in the file system (vs as part of compressed/remote archives).
+    """
+
     def __init__(
         self,
         artifact_dir: Path,
@@ -51,12 +89,9 @@ class ArtifactCatalog:
         for subdir in self.artifact_dir.iterdir():
             if not subdir.is_dir():
                 continue
-            # Matches {name}_{component}_{target_family} with an optional
-            # extra suffix that we ignore.
-            m = re.match(r"^([^_]+)_([^_]+)_([^_]+)(_.+)?$", subdir.name)
-            if not m:
+            name = ArtifactName.from_path(subdir)
+            if not name:
                 continue
-            name = ArtifactName(m.group(1), m.group(2), m.group(3))
             if not filter(name):
                 continue
             manifest = subdir / "artifact_manifest.txt"
@@ -82,3 +117,118 @@ class ArtifactCatalog:
             for an in self.artifact_names
             if an.target_family != "generic"
         )
+
+
+class ArtifactPopulator:
+    """Populates a list of artifacts into one output directory, optionally flattening.
+
+    Returns:
+    The set of all relative root paths from all encountered artifact manifests.
+    These paths can be interpreted relative to the output_path to get a full
+    populated path on the filesystem.
+    """
+
+    def __init__(
+        self, *, output_path: Path, verbose: bool = False, flatten: bool = False
+    ):
+        self.output_path = output_path
+        self.verbose = verbose
+        self.flatten = flatten
+        self.relpaths: set[str] = set()
+
+    def on_relpath(self, relpath: str):
+        """Callback that is invoked for every top-level relpath encountered."""
+        if relpath not in self.relpaths:
+            self.on_first_relpath(relpath)
+        self.relpaths.add(relpath)
+
+    def on_first_relpath(self, relpath: str):
+        """Called on the first time that a relpath is encountered by this flattener."""
+        pass
+
+    def on_artifact_dir(self, artifact_dir: Path):
+        """Callback that is invoked for every exploded artifact directory encountered."""
+        pass
+
+    def on_artifact_archive(self, artifact_archive: Path):
+        """Callback that is invoked for every artifact archive encountered."""
+        pass
+
+    def __call__(self, *artifact_paths: Sequence[Path]):
+        all_root_relpaths: set[str] = set()
+        for artifact_path in artifact_paths:
+            if artifact_path.is_dir():
+                # Process an exploded artifact dir.
+                self.on_artifact_dir(artifact_path)
+                manifest_path: Path = artifact_path / "artifact_manifest.txt"
+                relpaths = manifest_path.read_text().splitlines()
+                for relpath in relpaths:
+                    if not relpath:
+                        continue
+                    pm = PatternMatcher()
+                    self.on_relpath(relpath)
+                    source_dir = artifact_path / relpath
+                    if not source_dir.exists():
+                        continue
+                    pm.add_basedir(source_dir)
+                    destdir = (
+                        self.output_path if self.flatten else self.output_path / relpath
+                    )
+                    pm.copy_to(destdir=destdir, verbose=self.verbose, remove_dest=False)
+            else:
+                # Process as an archive file.
+                with tarfile.TarFile.open(artifact_path, mode="r:xz") as tf:
+                    self.on_artifact_archive(artifact_path)
+                    # Read manifest first.
+                    manifest_member = tf.next()
+                    if (
+                        manifest_member is None
+                        or manifest_member.name != "artifact_manifest.txt"
+                    ):
+                        raise IOError(
+                            f"Artifact archive {artifact_path} must have artifact_manifest.txt as its first member"
+                        )
+                    with tf.extractfile(manifest_member) as mf_file:
+                        relpaths = mf_file.read().decode().splitlines()
+                        for relpath in relpaths:
+                            self.on_relpath(relpath)
+                    # Iterate over all remaining members.
+                    while member := tf.next():
+                        member_name = member.name
+                        # Figure out which relpath prefix it is a part of.
+                        for prefix_relpath in relpaths:
+                            output_path = self.output_path
+                            if not self.flatten:
+                                output_path = output_path / prefix_relpath
+                            prefix_relpath += "/"
+                            if member_name.startswith(prefix_relpath):
+                                scoped_path = member_name[len(prefix_relpath) :]
+                                dest_path = output_path / PurePosixPath(scoped_path)
+                                if dest_path.is_symlink() or (
+                                    dest_path.exists() and not dest_path.is_dir()
+                                ):
+                                    os.unlink(dest_path)
+                                dest_path.parent.mkdir(parents=True, exist_ok=True)
+                                if member.isfile():
+                                    exec_mask = member.mode & 0o111
+                                    with tf.extractfile(member) as member_file:
+                                        with open(
+                                            dest_path,
+                                            "wb",
+                                        ) as out_file:
+                                            out_file.write(member_file.read())
+                                            st = os.fstat(out_file.fileno())
+                                            new_mode = st.st_mode | exec_mask
+                                            os.fchmod(out_file.fileno(), new_mode)
+                                elif member.isdir():
+                                    dest_path.mkdir(parents=True, exist_ok=True)
+                                elif member.issym():
+                                    dest_path.symlink_to(member.linkname)
+                                else:
+                                    raise IOError(f"Unhandled tar member: {member}")
+                                break
+                        else:
+                            raise IOError(
+                                f"Extracting tar artifact archive, encountered file not in manifest: {member}"
+                            )
+        return all_root_relpaths

--- a/build_tools/bootstrap_build.py
+++ b/build_tools/bootstrap_build.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+"""bootstrap_build.py
+
+Bootstraps a build directory using artifacts from a prior build invocation.
+
+Usage:
+  ./build_tools/bootstrap_build.py --build-dir build \
+      --artifact-dir /path/to/prior/build/artifacts
+  cmake -GNinja -Bbuild -S. -DTHEROCK_AMDGPU_FAMILIES=...
+
+Presently, this will only bootstrap from a directory containing artifacts
+(specified via `--artifact-dir`), but in the future, it will be able to stream
+directly from a remote source.
+
+This will only process "generic" artifacts currently. In the future, it can be
+extended to allow bootstrapping from target specific artifacts.
+
+This works because artifacts are set up to capture the "stage" installation
+directories from each sub-project, sorting their contents into components, each
+in their own directory/archive. By expanding each one of these component
+archives back into the build directory, we end up with pre-populated stage
+installations for each. This script then writes a "*.prebuilt" file for each
+root in the archive, so that whereas in the original build, there would just
+be "stage/" directories, in this secondary build, there will now also be a
+"stage.prebuilt" marker file. The CMake subproject system, upon encountering
+this marker file will skip emitting the configure/build/stage targets, instead
+just writing their stamp files with a dependency on the "stage.prebuilt" file.
+
+Note that currently the "*.prebuilt" files are just empty touch-files. But in
+the future, we can populate them with a hash of the contents. For artifact
+directories, this could come by hashing all files. For artifact archives,
+there is a parallel .sha256sum that is pre-computed and can be the basis of
+the hash. In this way, incremental builds will re-trigger if the build dir
+is bootstrapped with different artifacts. It can also be used in scripting to
+derive an appropriate hash key for the compiler, etc (i.e. setting up a ccache
+namespace based on the hash of all bootstrapped "*.prebuilt" files in the tree).
+"""
+
+import argparse
+from pathlib import Path
+import shutil
+import sys
+
+from _therock_utils.artifacts import ArtifactPopulator, ArtifactName
+
+
+def _do_run(args: argparse.Namespace):
+    class CleaningPopulator(ArtifactPopulator):
+        def on_first_relpath(self, relpath: str):
+            full_path = self.output_path / relpath
+            if full_path.exists():
+                print(f"CLEANING: {full_path}")
+                shutil.rmtree(full_path)
+            # Write the ".prebuilt" marker file that the build system uses to
+            # indicate that the staging install has already been done.
+            prebuilt_path = full_path.with_name(full_path.name + ".prebuilt")
+            prebuilt_path.parent.mkdir(parents=True, exist_ok=True)
+            prebuilt_path.touch()
+
+        def on_artifact_dir(self, artifact_dir: Path):
+            print(f"FLATTENING {artifact_dir.name}")
+
+        def on_artifact_archive(self, artifact_archive: Path):
+            print(f"EXPANDING {artifact_archive.name}")
+
+    args.build_dir.mkdir(parents=True, exist_ok=True)
+    flattener = CleaningPopulator(
+        output_path=args.build_dir, verbose=args.verbose, flatten=False
+    )
+    artifact_names: set[ArtifactName] = set()
+    for entry in args.artifact_dir.iterdir():
+        an = ArtifactName.from_path(entry)
+        if not an:
+            continue
+        if an.target_family != "generic":
+            print(f"SKIP {entry.name}: Not generic target")
+            continue
+        if an in artifact_names:
+            print(f"SKIP {entry.name}: Duplicate")
+            continue
+        artifact_names.add(an)
+        flattener(entry)
+
+
+def main(cl_args: list[str]):
+    p = argparse.ArgumentParser(
+        "bootstrap_build.py",
+        usage="bootstrap_build.py --build-dir <dir> --artifact-dir <artifacts>",
+    )
+    p.add_argument(
+        "--build-dir",
+        type=Path,
+        required=True,
+        help="Path to the CMake build directory to populate",
+    )
+    p.add_argument(
+        "--artifact-dir",
+        type=Path,
+        required=True,
+        help="Directory from which to source artifacts",
+    )
+    p.add_argument("--verbose", action="store_true", help="Print verbose status")
+    args = p.parse_args(cl_args)
+    _do_run(args)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/build_tools/tests/artifacts_test.py
+++ b/build_tools/tests/artifacts_test.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import os
+import tempfile
+import unittest
+import sys
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+from _therock_utils.artifacts import ArtifactName
+
+
+class ArtifactNameTest(unittest.TestCase):
+    def setUp(self):
+        override_temp = os.getenv("TEST_TMPDIR")
+        if override_temp is not None:
+            self.temp_context = None
+            self.temp_dir = Path(override_temp)
+            self.temp_dir.mkdir(parents=True, exist_ok=True)
+        else:
+            self.temp_context = tempfile.TemporaryDirectory()
+            self.temp_dir = Path(self.temp_context.name)
+
+    def tearDown(self):
+        if self.temp_context:
+            self.temp_context.cleanup()
+
+    def testFromPath(self):
+        p1 = Path(self.temp_dir / "dir" / "name_component_generic_EXTRA")
+        p1.mkdir(parents=True, exist_ok=True)
+        p2 = Path(self.temp_dir / "other" / "name_component_generic_EXTRA.tar.xz")
+        p2.parent.mkdir(parents=True, exist_ok=True)
+        p2.touch()
+
+        an1 = ArtifactName.from_path(p1)
+        an2 = ArtifactName.from_path(p2)
+        self.assertEqual(an1.name, "name")
+        self.assertEqual(an1.component, "component")
+        self.assertEqual(an2.target_family, "generic")
+        self.assertEqual(an1, an2)
+        self.assertEqual(hash(an1), hash(an2))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/tests/fileset_tool_test.py
+++ b/build_tools/tests/fileset_tool_test.py
@@ -18,10 +18,12 @@ ARTIFACT_DESCRIPTOR_1 = r"""
 """
 
 
-def exec(args: list[str | Path], cwd: Path = FILESET_TOOL.parent):
+def exec(args: list[str | Path], cwd: Path = FILESET_TOOL.parent) -> str:
     args = [str(arg) for arg in args]
     print(f"++ Exec [{cwd}]$ {shlex.join(args)}")
-    subprocess.check_call(args, cwd=str(cwd), stdin=subprocess.DEVNULL)
+    return subprocess.check_output(
+        args, cwd=str(cwd), stdin=subprocess.DEVNULL
+    ).decode()
 
 
 def write_text(p: Path, text: str):
@@ -165,7 +167,7 @@ class FilesetToolTest(unittest.TestCase):
             self.assertTrue(is_executable(flat1_dir / "share" / "doc" / "executable"))
 
         # Flatten the archive file and verify.
-        exec(
+        flatten_output = exec(
             [
                 sys.executable,
                 FILESET_TOOL,
@@ -175,6 +177,7 @@ class FilesetToolTest(unittest.TestCase):
                 flat2_dir,
             ]
         )
+        self.assertListEqual(flatten_output.splitlines(), ["example/stage"])
         self.assertEqual(
             (flat2_dir / "share" / "doc" / "README.txt").read_text(),
             "Hello World!",

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -615,145 +615,171 @@ function(therock_cmake_subproject_activate target_name)
     set(_all_option "ALL")
   endif()
 
-  # configure target
-  if(THEROCK_VERBOSE)
-    message(STATUS "  CONFIGURE_DEPENDS: ${_transitive_configure_depend_files} ")
-  endif()
+  # Detect whether the stage dir has been pre-built.
+  set(_prebuilt_file "${_stage_dir}.prebuilt")
   set(_configure_stamp_file "${_stamp_dir}/configure.stamp")
-  set(_configure_comment_suffix " (in background)")
-  set(_terminal_option)
-  set(_build_terminal_option "USES_TERMINAL")
-  if("$ENV{THEROCK_INTERACTIVE}")
-    set(_terminal_option "USES_TERMINAL")
-    set(_configure_comment_suffix)
-  elseif(_build_pool)
-    if(THEROCK_VERBOSE)
-      message(STATUS "  JOB_POOL: ${_build_pool}")
-    endif()
-    set(_build_terminal_option JOB_POOL "${_build_pool}")
-    set(_build_comment_suffix " (in background)")
-  endif()
-  set(_stage_destination_dir "${_stage_dir}")
-  if(_install_destination)
-    cmake_path(APPEND _stage_destination_dir "${_install_destination}")
-  endif()
-  set(_compile_commands_file "${PROJECT_BINARY_DIR}/compile_commands_fragment_${target_name}.json")
-  therock_subproject_log_command(_configure_log_prefix
-    LOG_FILE "${target_name}_configure.log"
-    LABEL "${target_name} configure"
-    OUTPUT_ON_FAILURE "${_output_on_failure}"
-  )
-  add_custom_command(
-    OUTPUT "${_configure_stamp_file}"
-    COMMAND
-      ${_configure_log_prefix}
-      "${CMAKE_COMMAND}"
-      "-G${CMAKE_GENERATOR}"
-      "-B${_binary_dir}"
-      "-S${_cmake_source_dir}"
-      "-DCMAKE_INSTALL_PREFIX=${_stage_destination_dir}"
-      "-DTHEROCK_STAGE_INSTALL_ROOT=${_stage_dir}"
-      "-DCMAKE_TOOLCHAIN_FILE=${_cmake_project_toolchain_file}"
-      "-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=${_cmake_project_init_file}"
-      ${_cmake_args}
-    # CMake doesn't always generate a compile_commands.json so touch one to keep
-    # the build graph sane.
-    COMMAND "${CMAKE_COMMAND}" -E touch "${_binary_dir}/compile_commands.json"
-    COMMAND "${CMAKE_COMMAND}" -E touch "${_configure_stamp_file}"
-    COMMAND "${CMAKE_COMMAND}" -E copy "${_binary_dir}/compile_commands.json" "${_compile_commands_file}"
-    WORKING_DIRECTORY "${_binary_dir}"
-    COMMENT "Configure sub-project ${target_name}${_configure_comment_suffix}"
-    ${_terminal_option}
-    BYPRODUCTS
-      "${_binary_dir}/CMakeCache.txt"
-      "${_binary_dir}/cmake_install.cmake"
-      "${_compile_commands_file}"
-    DEPENDS
-      "${_cmake_source_dir}/CMakeLists.txt"
-      "${_cmake_project_toolchain_file}"
-      "${_cmake_project_init_file}"
-      "${_global_post_include}"
-      ${_extra_depends}
-      ${_dep_provider_file}
-      ${_configure_dep_stamps}
-      ${_pre_hook_path}
-      ${_post_hook_path}
-      ${_compiler_toolchain_addl_depends}
-      ${_transitive_configure_depend_files}
-
-      # TODO: Have a mechanism for adding more depends for better rebuild ergonomics
-  )
-  add_custom_target(
-    "${target_name}+configure"
-    ${_all_option}
-    DEPENDS "${_configure_stamp_file}"
-  )
-  add_dependencies("${target_name}" "${target_name}+configure")
-  if(NOT _no_merge_compile_commands)
-    set_property(GLOBAL APPEND PROPERTY THEROCK_SUBPROJECT_COMPILE_COMMANDS_FILES
-      "${_compile_commands_file}"
-    )
-  endif()
-
-  # build target.
-  therock_subproject_log_command(_build_log_prefix
-    LOG_FILE "${target_name}_build.log"
-    LABEL "${target_name}"
-    OUTPUT_ON_FAILURE "${_output_on_failure}"
-  )
   set(_build_stamp_file "${_stamp_dir}/build.stamp")
-  add_custom_command(
-    OUTPUT "${_build_stamp_file}"
-    COMMAND
-      ${_build_log_prefix}
-      "${CMAKE_COMMAND}" -E env ${_build_env_pairs} --
-      "${CMAKE_COMMAND}" "--build" "${_binary_dir}"
-    COMMAND "${CMAKE_COMMAND}" -E touch "${_build_stamp_file}"
-    WORKING_DIRECTORY "${_binary_dir}"
-    COMMENT "Building sub-project ${target_name}${_build_comment_suffix}"
-    ${_build_terminal_option}
-    DEPENDS
-      "${_configure_stamp_file}"
-      ${_sources}
-  )
-  add_custom_target(
-    "${target_name}+build"
-    ${_all_option}
-    DEPENDS
-      "${_build_stamp_file}"
-  )
-  add_dependencies("${target_name}" "${target_name}+build")
-
-  # stage install target.
-  set(_install_strip_option)
-  if(THEROCK_SPLIT_DEBUG_INFO)
-    set(_install_strip_option "--strip")
-  endif()
-  therock_subproject_log_command(_install_log_prefix
-    LOG_FILE "${target_name}_install.log"
-    LABEL "${target_name} install"
-    # While useful for debugging, stage install logs are almost pure noise
-    # for interactive use.
-    OUTPUT_ON_FAILURE ON
-  )
   set(_stage_stamp_file "${_stamp_dir}/stage.stamp")
-  add_custom_command(
-    OUTPUT "${_stage_stamp_file}"
-    COMMAND ${_install_log_prefix} "${CMAKE_COMMAND}" --install "${_binary_dir}" ${_install_strip_option}
-    COMMAND "${CMAKE_COMMAND}" -E touch "${_stage_stamp_file}"
-    WORKING_DIRECTORY "${_binary_dir}"
-    COMMENT "Stage installing sub-project ${target_name}"
-    ${_terminal_option}
-    DEPENDS
-      "${_build_stamp_file}"
-  )
-  add_custom_target(
-    "${target_name}+stage"
-    ${_all_option}
-    DEPENDS
-      "${_stage_stamp_file}"
-  )
-  add_dependencies("${target_name}" "${target_name}+stage")
+
+  if(EXISTS "${_prebuilt_file}")
+    # If pre-built, just touch the stamp files, conditioned on the prebuilt
+    # marker file (which may just be a stamp file or may contain a unique hash
+    # for this part of the build).
+    message(STATUS "  DISABLING BUILD: Marked as pre-built")
+    add_custom_command(
+      OUTPUT "${_configure_stamp_file}"
+      COMMAND "${CMAKE_COMMAND}" -E touch "${_configure_stamp_file}"
+      DEPENDS "${_prebuilt_file}"
+    )
+    add_custom_command(
+      OUTPUT "${_build_stamp_file}"
+      COMMAND "${CMAKE_COMMAND}" -E touch "${_build_stamp_file}"
+      DEPENDS "${_prebuilt_file}"
+    )
+    add_custom_command(
+      OUTPUT "${_stage_stamp_file}"
+      COMMAND "${CMAKE_COMMAND}" -E touch "${_stage_stamp_file}"
+      DEPENDS "${_prebuilt_file}"
+    )
+  else()
+    # Not pre-built: normal configure/build/stage install.
+    # configure target
+    if(THEROCK_VERBOSE)
+      message(STATUS "  CONFIGURE_DEPENDS: ${_transitive_configure_depend_files} ")
+    endif()
+    set(_configure_comment_suffix " (in background)")
+    set(_terminal_option)
+    set(_build_terminal_option "USES_TERMINAL")
+    if("$ENV{THEROCK_INTERACTIVE}")
+      set(_terminal_option "USES_TERMINAL")
+      set(_configure_comment_suffix)
+    elseif(_build_pool)
+      if(THEROCK_VERBOSE)
+        message(STATUS "  JOB_POOL: ${_build_pool}")
+      endif()
+      set(_build_terminal_option JOB_POOL "${_build_pool}")
+      set(_build_comment_suffix " (in background)")
+    endif()
+    set(_stage_destination_dir "${_stage_dir}")
+    if(_install_destination)
+      cmake_path(APPEND _stage_destination_dir "${_install_destination}")
+    endif()
+    set(_compile_commands_file "${PROJECT_BINARY_DIR}/compile_commands_fragment_${target_name}.json")
+    therock_subproject_log_command(_configure_log_prefix
+      LOG_FILE "${target_name}_configure.log"
+      LABEL "${target_name} configure"
+      OUTPUT_ON_FAILURE "${_output_on_failure}"
+    )
+    add_custom_command(
+      OUTPUT "${_configure_stamp_file}"
+      COMMAND
+        ${_configure_log_prefix}
+        "${CMAKE_COMMAND}"
+        "-G${CMAKE_GENERATOR}"
+        "-B${_binary_dir}"
+        "-S${_cmake_source_dir}"
+        "-DCMAKE_INSTALL_PREFIX=${_stage_destination_dir}"
+        "-DTHEROCK_STAGE_INSTALL_ROOT=${_stage_dir}"
+        "-DCMAKE_TOOLCHAIN_FILE=${_cmake_project_toolchain_file}"
+        "-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=${_cmake_project_init_file}"
+        ${_cmake_args}
+      # CMake doesn't always generate a compile_commands.json so touch one to keep
+      # the build graph sane.
+      COMMAND "${CMAKE_COMMAND}" -E touch "${_binary_dir}/compile_commands.json"
+      COMMAND "${CMAKE_COMMAND}" -E touch "${_configure_stamp_file}"
+      COMMAND "${CMAKE_COMMAND}" -E copy "${_binary_dir}/compile_commands.json" "${_compile_commands_file}"
+      WORKING_DIRECTORY "${_binary_dir}"
+      COMMENT "Configure sub-project ${target_name}${_configure_comment_suffix}"
+      ${_terminal_option}
+      BYPRODUCTS
+        "${_binary_dir}/CMakeCache.txt"
+        "${_binary_dir}/cmake_install.cmake"
+        "${_compile_commands_file}"
+      DEPENDS
+        "${_cmake_source_dir}/CMakeLists.txt"
+        "${_cmake_project_toolchain_file}"
+        "${_cmake_project_init_file}"
+        "${_global_post_include}"
+        ${_extra_depends}
+        ${_dep_provider_file}
+        ${_configure_dep_stamps}
+        ${_pre_hook_path}
+        ${_post_hook_path}
+        ${_compiler_toolchain_addl_depends}
+        ${_transitive_configure_depend_files}
+
+        # TODO: Have a mechanism for adding more depends for better rebuild ergonomics
+    )
+    add_custom_target(
+      "${target_name}+configure"
+      ${_all_option}
+      DEPENDS "${_configure_stamp_file}"
+    )
+    add_dependencies("${target_name}" "${target_name}+configure")
+    if(NOT _no_merge_compile_commands)
+      set_property(GLOBAL APPEND PROPERTY THEROCK_SUBPROJECT_COMPILE_COMMANDS_FILES
+        "${_compile_commands_file}"
+      )
+    endif()
+
+    # build target.
+    therock_subproject_log_command(_build_log_prefix
+      LOG_FILE "${target_name}_build.log"
+      LABEL "${target_name}"
+      OUTPUT_ON_FAILURE "${_output_on_failure}"
+    )
+    add_custom_command(
+      OUTPUT "${_build_stamp_file}"
+      COMMAND
+        ${_build_log_prefix}
+        "${CMAKE_COMMAND}" -E env ${_build_env_pairs} --
+        "${CMAKE_COMMAND}" "--build" "${_binary_dir}"
+      COMMAND "${CMAKE_COMMAND}" -E touch "${_build_stamp_file}"
+      WORKING_DIRECTORY "${_binary_dir}"
+      COMMENT "Building sub-project ${target_name}${_build_comment_suffix}"
+      ${_build_terminal_option}
+      DEPENDS
+        "${_configure_stamp_file}"
+        ${_sources}
+    )
+    add_custom_target(
+      "${target_name}+build"
+      ${_all_option}
+      DEPENDS
+        "${_build_stamp_file}"
+    )
+    add_dependencies("${target_name}" "${target_name}+build")
+
+    # stage install target.
+    set(_install_strip_option)
+    if(THEROCK_SPLIT_DEBUG_INFO)
+      set(_install_strip_option "--strip")
+    endif()
+    therock_subproject_log_command(_install_log_prefix
+      LOG_FILE "${target_name}_install.log"
+      LABEL "${target_name} install"
+      # While useful for debugging, stage install logs are almost pure noise
+      # for interactive use.
+      OUTPUT_ON_FAILURE ON
+    )
+    add_custom_command(
+      OUTPUT "${_stage_stamp_file}"
+      COMMAND ${_install_log_prefix} "${CMAKE_COMMAND}" --install "${_binary_dir}" ${_install_strip_option}
+      COMMAND "${CMAKE_COMMAND}" -E touch "${_stage_stamp_file}"
+      WORKING_DIRECTORY "${_binary_dir}"
+      COMMENT "Stage installing sub-project ${target_name}"
+      ${_terminal_option}
+      DEPENDS
+        "${_build_stamp_file}"
+    )
+    add_custom_target(
+      "${target_name}+stage"
+      ${_all_option}
+      DEPENDS
+        "${_stage_stamp_file}"
+    )
+    add_dependencies("${target_name}" "${target_name}+stage")
+  endif()
 
   # dist install target.
   set(_dist_stamp_file "${_stamp_dir}/dist.stamp")


### PR DESCRIPTION
* Adds a new `bootstrap_build.py` script which can be used to pre-populate a build directory from artifacts.
* Updates the subproject CMake support to detect when this has been done and null out sub-project configure/build/stage steps for so populated entities.
* Refactors some artifact handling code to better share with fileset_tool.py.
* Leaves some notes on how to extend this with artifact hashing and ccache namespace handling.
* Leaves notes on how to stream from S3 in the future, which should enable a pretty serviceable development flow for libraries.