### PR TITLE
Fixing skip condition for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,14 +78,12 @@ jobs:
   test_linux_packages:
     needs: [setup, build_linux_packages]
     name: Test Linux Packages
+    # If there are no linux_amdgpu_families to test or a dependent job failed/cancelled, this job will not be run
     if: |
       ${{
+        !failure() &&
         !cancelled() &&
-        needs.setup.outputs.test_linux_amdgpu_families != '[]' &&
-        (
-          needs.build_linux_packages.result == 'success' ||
-          needs.build_linux_packages.result == 'skipped'
-        )
+        needs.setup.outputs.test_linux_amdgpu_families != '[]'
       }}
     strategy:
       matrix:

--- a/build_tools/configure_ci.py
+++ b/build_tools/configure_ci.py
@@ -346,6 +346,11 @@ def main(base_args, build_families, test_families):
         build_linux_target_output = []
         build_windows_target_output = []
 
+        # If this is a main push or PR trigger, skip the tests since there is no build to use.
+        if not workflow_dispatch:
+            test_linux_target_output = []
+            test_windows_target_output = []
+
     write_job_summary(
         f"""## Workflow configure results
 


### PR DESCRIPTION
This fixes a few scenarios:

- When a PR is opened or main push occurs, if we decide to skip `build_jobs`, the tests have no build to test against, so this fails ([for example in this run](https://github.com/ROCm/TheRock/actions/runs/14385375350/job/40339348217?pr=361). Adding a condition to skip tests if we skip builds for push main or PR.
- Previously, if builds failed or are cancelled, our tests will still run like [this run](https://github.com/ROCm/TheRock/actions/runs/14362468300/job/40276841098?pr=382). Updating the conditions where if the previous required job failed or is cancelled, we skip/cancel the test step.