### PR TITLE
Start to configure+build rocBLAS on Windows.

### DIFF
--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -94,8 +94,8 @@ if(WIN32)
 else()
   set(rocBLAS_build_with_tensile "ON")
   set(rocBLAS_build_with_hipblaslt "ON")
-  list(APPEND _rocBLAS_optional_runtime_deps hipBLASLt)
-  list(APPEND _rocBLAS_optional_runtime_deps roctracer-compat)
+  list(APPEND rocBLAS_optional_runtime_deps hipBLASLt)
+  list(APPEND rocBLAS_optional_runtime_deps roctracer-compat)
 endif()
 
 therock_cmake_subproject_declare(rocBLAS

--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -87,8 +87,15 @@ set(rocBLAS_optional_runtime_deps)
 if(THEROCK_BUILD_TESTING)
   list(APPEND rocBLAS_optional_runtime_deps rocm_smi_lib)
 endif()
-if(NOT WIN32)
-  list(APPEND rocBLAS_optional_runtime_deps roctracer-compat)
+
+if(WIN32)
+  set(rocBLAS_build_with_tensile "OFF")
+  set(rocBLAS_build_with_hipblaslt "OFF")
+else()
+  set(rocBLAS_build_with_tensile "ON")
+  set(rocBLAS_build_with_hipblaslt "ON")
+  list(APPEND _rocBLAS_optional_runtime_deps hipBLASLt)
+  list(APPEND _rocBLAS_optional_runtime_deps roctracer-compat)
 endif()
 
 therock_cmake_subproject_declare(rocBLAS
@@ -98,8 +105,8 @@ therock_cmake_subproject_declare(rocBLAS
     -DHIP_PLATFORM=amd
     -DROCM_PATH=
     -DROCM_DIR=
-    -DBUILD_WITH_TENSILE=ON
-    -DBUILD_WITH_HIPBLASLT=ON
+    -DBUILD_WITH_TENSILE=${rocBLAS_build_with_tensile}
+    -DBUILD_WITH_HIPBLASLT=${rocBLAS_build_with_hipblaslt}
     # TODO: With `Tensile_TEST_LOCAL_PATH` set, the resulting build path is ${Tensile_TEST_LOCAL_PATH}/build.
     "-DTensile_TEST_LOCAL_PATH=${CMAKE_CURRENT_SOURCE_DIR}/Tensile"
     # Since using a local Tensile vs fetched, unset TENSILE_VERSION to avoid
@@ -116,7 +123,6 @@ therock_cmake_subproject_declare(rocBLAS
     therock-msgpack-cxx
   RUNTIME_DEPS
     hip-clr
-    hipBLASLt
     ${rocBLAS_optional_runtime_deps}
 )
 therock_cmake_subproject_glob_c_sources(rocBLAS


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/36.

This gets rocBLAS configuring and partially building. Currently blocked by errors like these (see https://github.com/ROCm/TheRock/pull/342):

```
[build] -- Configuring done (0.9s)
[build] -- Generating done (0.4s)
[build] -- Build files have been written to: D:/projects/TheRock/build
[build] [1/4   0% :: 0.009] Re-checking globbed directories...
[build] [1/6  16% :: 345.309] Building sub-project rocBLAS (in background)
[build] FAILED: math-libs/BLAS/rocBLAS/stamp/build.stamp D:/projects/TheRock/build/math-libs/BLAS/rocBLAS/stamp/build.stamp 
[build] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\math-libs\BLAS\rocBLAS\build && d:\projects\TheRock\.venv\Scripts\python D:/projects/TheRock/build_tools/teatime.py --log-timestamps --label rocBLAS --interactive D:/projects/TheRock/build/logs/rocBLAS_build.log -- "C:/Program Files/CMake/bin/cmake.exe" -E env -- "C:/Program Files/CMake/bin/cmake.exe" --build D:/projects/TheRock/build/math-libs/BLAS/rocBLAS/build && "C:\Program Files\CMake\bin\cmake.exe" -E touch D:/projects/TheRock/build/math-libs/BLAS/rocBLAS/stamp/build.stamp"
[build] [rocBLAS] [1/2   0% :: 0.007] Re-checking globbed directories...
[build] [rocBLAS] [66/454   0% :: 11.232] Building CXX object library/src/CMakeFiles/rocblas.dir/blas3/rocblas_syrkx_herkx_kernels.cpp.obj
[build] [rocBLAS] FAILED: library/src/CMakeFiles/rocblas.dir/blas3/rocblas_syrkx_herkx_kernels.cpp.obj 
[build] [rocBLAS] ccache D:\projects\TheRock\build\core\clr\dist\lib\llvm\bin\clang++.exe -DROCBLAS_BETA_FEATURES_API -DROCBLAS_INTERNAL_API -DROCM_USE_FLOAT16 -DUSE_PROF_API=1 -D__HIP_PLATFORM_AMD__=1 -Drocblas_EXPORTS -ID:/projects/TheRock/math-libs/BLAS/rocBLAS/library/src -ID:/projects/TheRock/math-libs/BLAS/rocBLAS/library/include -ID:/projects/TheRock/math-libs/BLAS/rocBLAS/library/include/internal -ID:/projects/TheRock/math-libs/BLAS/rocBLAS/library/src/include -ID:/projects/TheRock/build/math-libs/BLAS/rocBLAS/build/include/rocblas/internal -ID:/projects/TheRock/build/math-libs/BLAS/rocBLAS/build/include/rocblas -ID:/projects/TheRock/build/math-libs/BLAS/rocBLAS/build/include -ID:/projects/TheRock/math-libs/BLAS/rocBLAS/library/src/blas3/Tensile -isystem D:/projects/TheRock/build/core/clr/dist/include -DWIN32 -D_CRT_SECURE_NO_WARNINGS -DNOMINMAX -fms-extensions -fms-compatibility -D_ENABLE_EXTENDED_ALIGNED_STORAGE  -Wno-documentation-unknown-command -Wno-documentation-pedantic -Wno-unused-command-line-argument -Wno-ignored-attributes -Wno-unknown-attributes -Wno-duplicate-decl-specifier --hip-path=D:/projects/TheRock/build/core/clr/dist --hip-device-lib-path=D:/projects/TheRock/build/core/clr/dist/lib/llvm/amdgcn/bitcode -D__HIP_HCC_COMPAT_MODE__=1 -O3 -DNDEBUG -std=c++17 -D_DLL -D_MT -Xclang --dependent-lib=msvcrt -fvisibility-inlines-hidden --offload-compress -Wno-unused-result -Werror=vla -x hip --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102 -MD -MT library/src/CMakeFiles/rocblas.dir/blas3/rocblas_syrkx_herkx_kernels.cpp.obj -MF library\src\CMakeFiles\rocblas.dir\blas3\rocblas_syrkx_herkx_kernels.cpp.obj.d -o library/src/CMakeFiles/rocblas.dir/blas3/rocblas_syrkx_herkx_kernels.cpp.obj -c D:/projects/TheRock/math-libs/BLAS/rocBLAS/library/src/blas3/rocblas_syrkx_herkx_kernels.cpp
[build] [rocBLAS] D:\projects\TheRock\build\core\clr\dist\lib\llvm\bin\clang-offload-bundler: error: Compression not supported
```