### PR TITLE
Unfork the Linux/Windows CLR build and use published interop blob.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,12 @@ if(CMAKE_CXX_VISIBILITY_PRESET)
   list(APPEND DEFAULT_CMAKE_ARGS ${CMAKE_CXX_VISIBILITY_PRESET})
 endif()
 
+if(MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+  message(
+    FATAL_ERROR
+    "Cannot build 32-bit ROCm with MSVC: You must enable the Windows x64 "
+    "development tools and rebuild (detected compiler ${CMAKE_CXX_COMPILER})")
+endif()
 
 ################################################################################
 # Sysdep bundling

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,8 @@ option(THEROCK_BUNDLE_SYSDEPS "Builds bundled system deps for portable builds in
 # Overall build settings.
 option(THEROCK_VERBOSE "Enables verbose CMake statuses" OFF)
 
+set(THEROCK_AMDGPU_WINDOWS_INTEROP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../amdgpu-windows-interop" CACHE PATH "Directory containing the Windows AMDGPU/ROCm driver interop support files")
+
 # Initialize the install directory.
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "${THEROCK_SOURCE_DIR}/install" CACHE PATH "" FORCE)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -79,7 +79,7 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
     cmake_path(NORMAL_PATH _compute_pal_dir)
     set(_compute_pal_probe "${_compute_pal_dir}/pal/CMakeLists.txt")
     if(NOT EXISTS "${_compute_pal_probe}")
-      message(FATAL_ERROR 
+      message(FATAL_ERROR
         "Can't build CLR: missing closed source AMDGPU/ROCm interop library folder "
         "expected at '${_compute_pal_dir}': "
         "This can be obtained by cloning this repository adjacent to TheRock: "

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -71,111 +71,91 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
   # As a particularly sharp edge, the `hipconfig` tool is really only fully
   # functional from this project (which contributes version and metadata).
   ##############################################################################
+  set(HIP_CLR_CMAKE_ARGS)
+  set(HIP_CLR_RUNTIME_DEPS)
+  if(WIN32)
+    # Windows CLR options
+    set(_compute_pal_dir "${THEROCK_AMDGPU_WINDOWS_INTEROP_DIR}/pal-static-lib/compute-win")
+    cmake_path(NORMAL_PATH _compute_pal_dir)
+    set(_compute_pal_probe "${_compute_pal_dir}/pal/CMakeLists.txt")
+    if(NOT EXISTS "${_compute_pal_probe}")
+      message(FATAL_ERROR 
+        "Can't build CLR: missing closed source AMDGPU/ROCm interop library folder "
+        "expected at '${_compute_pal_dir}': "
+        "This can be obtained by cloning this repository adjacent to TheRock: "
+        "https://github.com/nod-ai/amdgpu-windows-interop.git")
+    endif()
+    message(STATUS "Found Winows AMDGPU/ROCm interop library: ${_compute_pal_dir}")
 
-  # CLR configuration is different enough between Linux and Windows that we
-  # branch at a high level here instead of extending individual options.
-  # TODO(#36): Share more code here, once options settle.
-  if(NOT WIN32)
-    therock_cmake_subproject_declare(hip-clr
-      EXTERNAL_SOURCE_DIR "clr"
-      INTERFACE_PROGRAM_DIRS
-        bin
-      BACKGROUND_BUILD
-      CMAKE_ARGS
-        -DHIP_PLATFORM=amd
-        "-DHIP_COMMON_DIR=${CMAKE_CURRENT_SOURCE_DIR}/HIP"
-        -DCLR_BUILD_HIP=ON
-        # Legacy: Disable various auto-detection logic that breaks out of jail
-        # and can use local machine tools.
-        -DHIPCC_BIN_DIR=
-      BUILD_DEPS
-        rocm-cmake
-      RUNTIME_DEPS
-        amd-llvm
-        amd-comgr
-        hipcc     # For hipconfig
-        rocm-core
-        rocminfo  # Various things expect to be able to find the rocminfo tools
-        rocprofiler-register
-        ROCR-Runtime
-      INTERFACE_LINK_DIRS
-        "lib"
-      INTERFACE_INSTALL_RPATH_DIRS
-        "lib"
-    )
-    therock_cmake_subproject_glob_c_sources(hip-clr SUBDIRS .)
-    therock_cmake_subproject_provide_package(hip-clr hip lib/cmake/hip)
-    # TODO: Some projects resolve "hip" vs "HIP" so we advertise both, but this isn't
-    # great.
-    therock_cmake_subproject_provide_package(hip-clr HIP lib/cmake/hip)
-    therock_cmake_subproject_provide_package(hip-clr hip-lang lib/cmake/hip-lang)
-    therock_cmake_subproject_provide_package(hip-clr hiprtc lib/cmake/hiprtc)
-    therock_cmake_subproject_activate(hip-clr)
-
-    therock_provide_artifact(core-hip
-      TARGET_NEUTRAL
-      DESCRIPTOR artifact-core-hip.toml
-      COMPONENTS
-        dbg
-        dev
-        doc
-        lib
-        run
-      SUBPROJECT_DEPS
-        hip-clr
-    )
-
-    therock_test_validate_shared_lib(
-      PATH clr/dist/lib
-      LIB_NAMES
-        libamdhip64.so
-        libhiprtc-builtins.so
-        libhiprtc.so
+    list(APPEND HIP_CLR_CMAKE_ARGS
+      "-DUSE_PROF_API=OFF"
+      "-D__HIP_ENABLE_PCH=OFF"
+      "-DROCCLR_ENABLE_PAL=1"
+      "-DROCCLR_ENABLE_HSA=0"
+      "-DAMD_COMPUTE_WIN=${_compute_pal_dir}"
     )
   else()
-    set(_compute_win_dir "${CMAKE_CURRENT_SOURCE_DIR}/compute-win")
-    if(NOT EXISTS ${_compute_win_dir})
-      message(FATAL_ERROR "Can't build CLR: missing closed source 'compute-win' folder expected at '${_compute_win_dir}'")
-    endif()
-
-    therock_cmake_subproject_declare(hip-clr
-      EXTERNAL_SOURCE_DIR "clr"
-      INTERFACE_PROGRAM_DIRS
-        bin
-      BACKGROUND_BUILD
-      CMAKE_ARGS
-        "-DHIP_PLATFORM=amd"
-        "-DHIP_COMMON_DIR=${CMAKE_CURRENT_SOURCE_DIR}/HIP"
-        "-DCLR_BUILD_HIP=ON"
-        # Legacy: Disable various auto-detection logic that breaks out of jail
-        # and can use local machine tools.
-        "-DHIPCC_BIN_DIR="
-
-        # Windows specific options.
-        "-DUSE_PROF_API=OFF"
-        "-D__HIP_ENABLE_PCH=OFF"
-        "-DROCCLR_ENABLE_PAL=1"
-        "-DROCCLR_ENABLE_HSA=0"
-        "-DAMD_COMPUTE_WIN=${_compute_win_dir}"
-      BUILD_DEPS
-        rocm-cmake
-      RUNTIME_DEPS
-        amd-llvm
-        amd-comgr
-        hipcc     # For hipconfig
-        rocm-core
-      INTERFACE_LINK_DIRS
-        "lib"
-      INTERFACE_INSTALL_RPATH_DIRS
-        "lib"
+    # Non-Windows CLR options.
+    list(APPEND HIP_CLR_RUNTIME_DEPS
+      rocminfo  # Various things expect to be able to find the rocminfo tools
+      rocprofiler-register
+      ROCR-Runtime
     )
-    therock_cmake_subproject_glob_c_sources(hip-clr SUBDIRS .)
-    therock_cmake_subproject_provide_package(hip-clr hip lib/cmake/hip)
-    # TODO: Some projects resolve "hip" vs "HIP" so we advertise both, but this isn't
-    # great.
-    therock_cmake_subproject_provide_package(hip-clr HIP lib/cmake/hip)
-    therock_cmake_subproject_provide_package(hip-clr hip-lang lib/cmake/hip-lang)
-    therock_cmake_subproject_provide_package(hip-clr hiprtc lib/cmake/hiprtc)
-    therock_cmake_subproject_activate(hip-clr)
   endif()
+
+  therock_cmake_subproject_declare(hip-clr
+    EXTERNAL_SOURCE_DIR "clr"
+    INTERFACE_PROGRAM_DIRS
+      bin
+    BACKGROUND_BUILD
+    CMAKE_ARGS
+      "-DHIP_PLATFORM=amd"
+      "-DHIP_COMMON_DIR=${CMAKE_CURRENT_SOURCE_DIR}/HIP"
+      "-DCLR_BUILD_HIP=ON"
+      # Legacy: Disable various auto-detection logic that breaks out of jail
+      # and can use local machine tools.
+      "-DHIPCC_BIN_DIR="
+      ${HIP_CLR_CMAKE_ARGS}
+    BUILD_DEPS
+      rocm-cmake
+    RUNTIME_DEPS
+      amd-llvm
+      amd-comgr
+      hipcc     # For hipconfig
+      rocm-core
+      ${HIP_CLR_RUNTIME_DEPS}
+    INTERFACE_LINK_DIRS
+      "lib"
+    INTERFACE_INSTALL_RPATH_DIRS
+      "lib"
+  )
+  therock_cmake_subproject_glob_c_sources(hip-clr SUBDIRS .)
+  therock_cmake_subproject_provide_package(hip-clr hip lib/cmake/hip)
+  # TODO: Some projects resolve "hip" vs "HIP" so we advertise both, but this isn't
+  # great.
+  therock_cmake_subproject_provide_package(hip-clr HIP lib/cmake/hip)
+  therock_cmake_subproject_provide_package(hip-clr hip-lang lib/cmake/hip-lang)
+  therock_cmake_subproject_provide_package(hip-clr hiprtc lib/cmake/hiprtc)
+  therock_cmake_subproject_activate(hip-clr)
+
+  therock_provide_artifact(core-hip
+    TARGET_NEUTRAL
+    DESCRIPTOR artifact-core-hip.toml
+    COMPONENTS
+      dbg
+      dev
+      doc
+      lib
+      run
+    SUBPROJECT_DEPS
+      hip-clr
+  )
+
+  therock_test_validate_shared_lib(
+    PATH clr/dist/lib
+    LIB_NAMES
+      libamdhip64.so
+      libhiprtc-builtins.so
+      libhiprtc.so
+  )
 endif(THEROCK_ENABLE_HIP_RUNTIME)


### PR DESCRIPTION
* Makes the windows CLR buildable in OSS if the right support library repo is checked out adjacent (this is a temporary measure to unblock progress).
* Unforks the clr cmake config between windows/linux.
* Adds a check that with MSVC we are building 64bit (since so many of the Windows tools default to 32bit and we do not support that).

Progress on #36