### PR TITLE
Re-enable artifact generation on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,7 +370,4 @@ endif()
 # Finalization
 ################################################################################
 therock_subproject_merge_compile_commands()
-if(NOT WIN32)
-  # TODO(#36): Enable on Windows (base/artifact.toml includes rocm_smi_lib that is excluded on Windows)
-  therock_create_dist()
-endif()
+therock_create_dist()

--- a/base/artifact.toml
+++ b/base/artifact.toml
@@ -4,10 +4,15 @@
 
 # rocm_smi_lib
 [components.dbg."base/rocm_smi_lib/stage"]
+optional = "windows"
 [components.dev."base/rocm_smi_lib/stage"]
+optional = "windows"
 [components.doc."base/rocm_smi_lib/stage"]
+optional = "windows"
 [components.lib."base/rocm_smi_lib/stage"]
+optional = "windows"
 [components.run."base/rocm_smi_lib/stage"]
+optional = "windows"
 include = [
   "bin/**",
   "libexec/**",
@@ -30,11 +35,17 @@ include = "libexec/**"
 
 # rocprofiler-register
 [components.dbg."base/rocprofiler-register/stage"]
+optional = "windows"
 [components.dev."base/rocprofiler-register/stage"]
+optional = "windows"
 [components.doc."base/rocprofiler-register/stage"]
+optional = "windows"
 [components.lib."base/rocprofiler-register/stage"]
+optional = "windows"
 [components.run."base/rocprofiler-register/stage"]
+optional = "windows"
 [components.test."base/rocprofiler-register/stage"]
+optional = "windows"
 include = [
   "share/rocprofiler-register/tests/**",
 ]

--- a/third-party/sysdeps/windows/artifact.toml
+++ b/third-party/sysdeps/windows/artifact.toml
@@ -3,5 +3,5 @@
 [components.lib."third-party/sysdeps/windows/sqlite3/build/stage"]
 
 # zlib
-[components.dev."third-party/sysdeps/linux/zlib/build/stage"]
-[components.lib."third-party/sysdeps/linux/zlib/build/stage"]
+[components.dev."third-party/sysdeps/windows/zlib/build/stage"]
+[components.lib."third-party/sysdeps/windows/zlib/build/stage"]


### PR DESCRIPTION
* Makes the existing `optional=` tag able to take an OS name like "windows" or "linux" in order to control optionality in a system specific way.

Progress on #36