### PR TITLE
Adapts some in-tree smoke tests to work on Windows.

### DIFF
--- a/build_tools/_therock_utils/artifacts.py
+++ b/build_tools/_therock_utils/artifacts.py
@@ -218,8 +218,10 @@ class ArtifactPopulator:
                                         ) as out_file:
                                             out_file.write(member_file.read())
                                             st = os.fstat(out_file.fileno())
-                                            new_mode = st.st_mode | exec_mask
-                                            os.fchmod(out_file.fileno(), new_mode)
+                                            if hasattr(os, "fchmod"):
+                                                # Windows has no fchmod.
+                                                new_mode = st.st_mode | exec_mask
+                                                os.fchmod(out_file.fileno(), new_mode)
                                 elif member.isdir():
                                     dest_path.mkdir(parents=True, exist_ok=True)
                                 elif member.issym():

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -82,6 +82,7 @@ ComponentDefaults(
     "dev",
     includes=[
         "**/*.a",
+        "**/*.lib",
         "**/cmake/**",
         "**/include/**",
         "**/share/modulefiles/**",

--- a/cmake/therock_testing.cmake
+++ b/cmake/therock_testing.cmake
@@ -8,6 +8,12 @@ function(therock_test_validate_shared_lib)
     "PATH"
     "LIB_NAMES"
   )
+  if(WIN32)
+    # This helper is Linux only. In the future, we can have separate DLL_NAMES
+    # and verify.
+    return()
+  endif()
+
   if(NOT IS_ABSOLUTE ARG_PATH)
     cmake_path(ABSOLUTE_PATH ARG_PATH BASE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
   endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,25 @@
+# TODO: HIP language support not based on an /opt/rocm installed SDK
+# must have these three cache variables set to avoid language setup
+# error. https://github.com/ROCm/TheRock/issues/102
+set(HIP_CMAKE_ARGS
+  -DCMAKE_HIP_PLATFORM=amd
+  "-DCMAKE_HIP_COMPILER_ROCM_ROOT=${THEROCK_BINARY_DIR}/dist/rocm"
+)
+
+if(WIN32)
+  # On Windows, only a unified compiler is supported (i.e. use the HIP compiler
+  # for everything).
+  list(APPEND HIP_CMAKE_ARGS
+    "-DCMAKE_CXX_COMPILER=${THEROCK_BINARY_DIR}/dist/rocm/lib/llvm/bin/clang++${CMAKE_EXECUTABLE_SUFFIX}"
+  )
+else()
+  # On everything else, the HIP language compiler can be independent from the
+  # overall CXX compiler.
+  list(APPEND HIP_CMAKE_ARGS
+    "-DCMAKE_HIP_COMPILER=${THEROCK_BINARY_DIR}/dist/rocm/lib/llvm/bin/clang++${CMAKE_EXECUTABLE_SUFFIX}"
+  )
+endif()
+
 add_test(
   NAME therock-examples-cpp-sdk-user
   COMMAND
@@ -15,13 +37,6 @@ add_test(
         "-DTHEROCK_ENABLE_RCCL=${THEROCK_ENABLE_RCCL}"
         "-DTHEROCK_ENABLE_SOLVER=${THEROCK_ENABLE_SOLVER}"
         "-DTHEROCK_ENABLE_SPARSE=${THEROCK_ENABLE_SPARSE}"
-
-        # TODO: HIP language support not based on an /opt/rocm installed SDK
-        # must have these three cache variables set to avoid language setup
-        # error. https://github.com/ROCm/TheRock/issues/102
-        -DCMAKE_HIP_PLATFORM=amd
-        "-DCMAKE_HIP_COMPILER=${THEROCK_BINARY_DIR}/dist/rocm/lib/llvm/bin/clang++"
-        "-DCMAKE_HIP_COMPILER_ROCM_ROOT=${THEROCK_BINARY_DIR}/dist/rocm"
-
+        ${HIP_CMAKE_ARGS}
       -P "${CMAKE_CURRENT_SOURCE_DIR}/clean_configure_test_project.cmake"
 )

--- a/examples/clean_configure_test_project.cmake
+++ b/examples/clean_configure_test_project.cmake
@@ -4,6 +4,7 @@ if(EXISTS "${BINARY_DIR}")
 endif()
 
 set(propagate_vars
+  CMAKE_CXX_COMPILER
   THEROCK_ENABLE_BLAS
   THEROCK_ENABLE_FFT
   THEROCK_ENABLE_HIP
@@ -31,7 +32,7 @@ execute_process(
     "${BINARY_DIR}"
     --build-generator "${GENERATOR}"
     --build-options ${build_options}
-    --test-command "${CMAKE_CTEST_COMMAND}" --output-on-failure
+    --test-command "${CMAKE_CTEST_COMMAND}" --output-on-failure --verbose
   RESULT_VARIABLE CMD_RESULT
 )
 

--- a/examples/cpp-sdk-user/CMakeLists.txt
+++ b/examples/cpp-sdk-user/CMakeLists.txt
@@ -11,6 +11,8 @@ enable_testing()
 
 set(CMAKE_CXX_STANDARD 17)
 
+include(CMakeDependentOption)
+
 # If defining a new option, ensure it is in the outer CMakeLists.txt and
 # the clean_configure_test_project.cmake to ensure it is passed from the
 # parent when testing.
@@ -23,6 +25,19 @@ option(THEROCK_ENABLE_RAND "Whether rocrand/hiprand are available" ON)
 option(THEROCK_ENABLE_RCCL "Whether rccl is available" ON)
 option(THEROCK_ENABLE_SOLVER "Whether rocsolver/hipsolver are available" ON)
 option(THEROCK_ENABLE_SPARSE "Whether rocsparse/hipsparse are available" ON)
+cmake_dependent_option(
+    ENABLE_DEVICE_TEST "Whether to enable testing that requires a device" ON
+    "$ENV{THEROCK_ENABLE_DEVICE_TEST}" OFF)
+
+set(TEST_PATH)
+if(WIN32)
+    # On Windows, when not installed as a global assembly, the ROCM bin dir
+    # must be on the PATH in order to find DLLs.
+    set(TEST_PATH "${CMAKE_HIP_COMPILER_ROCM_ROOT}/bin")
+    string(APPEND TEST_PATH ";")
+    string(APPEND TEST_PATH "$ENV{PATH}")
+    message(STATUS "Using test path: ${TEST_PATH}")
+endif()
 
 if(THEROCK_ENABLE_HIP)
     # TODO: Don't require HIP_PLATFORM https://github.com/ROCm/TheRock/issues/68
@@ -97,8 +112,29 @@ if(THEROCK_ENABLE_HIP)
         hip-host-test.cpp
     )
     target_link_libraries(hip-host-test PRIVATE hip::host)
-    add_test(NAME hip-host-test COMMAND hip-host-test)
+    set(_DEVICE_ORDINAL)
+    if(ENABLE_DEVICE_TEST)
+        set(_DEVICE_ORDINAL 0)
+    endif()
+    add_test(NAME hip-host-test
+        COMMAND hip-host-test ${_DEVICE_ORDINAL}
+    )
+    if(TEST_PATH)
+        set_tests_properties(
+            hip-host-test
+            PROPERTIES ENVIRONMENT "PATH=${TEST_PATH}"
+        )
+    endif()
 
-    add_library(sample_kernel sample_kernel.hip)
+    add_executable(sample_kernel sample_kernel.hip)
     set_source_files_properties(sample_kernel PROPERTIES LANGUAGE HIP)
+    if(ENABLE_DEVICE_TEST)
+        add_test(NAME sample-kernel-test COMMAND sample_kernel)
+        if(TEST_PATH)
+            set_tests_properties(
+                sample-kernel-test
+                PROPERTIES ENVIRONMENT "PATH=${TEST_PATH}"
+            )
+        endif()
+    endif()
 endif()

--- a/examples/cpp-sdk-user/CMakeLists.txt
+++ b/examples/cpp-sdk-user/CMakeLists.txt
@@ -25,9 +25,7 @@ option(THEROCK_ENABLE_RAND "Whether rocrand/hiprand are available" ON)
 option(THEROCK_ENABLE_RCCL "Whether rccl is available" ON)
 option(THEROCK_ENABLE_SOLVER "Whether rocsolver/hipsolver are available" ON)
 option(THEROCK_ENABLE_SPARSE "Whether rocsparse/hipsparse are available" ON)
-cmake_dependent_option(
-    ENABLE_DEVICE_TEST "Whether to enable testing that requires a device" ON
-    "$ENV{THEROCK_ENABLE_DEVICE_TEST}" OFF)
+option(ENABLE_DEVICE_TEST "Whether to enable testing that requires a device" OFF)
 
 set(TEST_PATH)
 if(WIN32)

--- a/examples/cpp-sdk-user/hip-host-test.cpp
+++ b/examples/cpp-sdk-user/hip-host-test.cpp
@@ -1,8 +1,22 @@
+#include <cstdint>
+#include <string>
+
 #include <hip/hip_runtime_api.h>
 
 #include <iostream>
 
 int main(int argc, char **argv) {
+  int device_ordinal = -1;
+  if (argc > 1) {
+    try {
+      device_ordinal = std::stoi(argv[1]);
+    } catch (std::exception &e) {
+      std::cerr << "could not parse device ordinal from command line: "
+                << e.what() << "\n";
+      return 1;
+    }
+  }
+
   int runtime_version;
   auto err = hipRuntimeGetVersion(&runtime_version);
   if (err != hipSuccess) {
@@ -11,11 +25,41 @@ int main(int argc, char **argv) {
   }
   std::cout << "HIP runtime version: " << runtime_version << "\n";
   err = hipInit(0);
-  if (err != hipSuccess) {
-    // Since this is primarily run on CI to verify that linkage works, we
-    // just ignore any error (this lets us run the test on machines that
-    // lack a GPU).
-    std::cerr << "Error initializing HIP: " << err << " (ignored)\n";
+  if (device_ordinal < 0) {
+    // Not testing actual device - just linkage and ability to run at all.
+    std::cout << "Not testing on GPU device (no device ordinal passed)\n";
+    return 0;
   }
+  if (err != hipSuccess) {
+    std::cerr << "Error initializing HIP: " << err << " (ignored)\n";
+    return 3;
+  }
+
+  // Get the device.
+  hipDevice_t device;
+  err = hipDeviceGet(&device, device_ordinal);
+  if (err != hipSuccess) {
+    std::cerr << "Error getting device ordinal " << device_ordinal << "\n";
+    return 4;
+  }
+
+  // Get device name.
+  char device_name[80];
+  err = hipDeviceGetName(device_name, sizeof(device_name) - 1, device);
+  if (err != hipSuccess) {
+    std::cerr << "Error getting device name \n";
+    return 5;
+  }
+  std::cout << "Device name: " << device_name << "\n";
+
+  // Get device memory.
+  size_t memory_size;
+  err = hipDeviceTotalMem(&memory_size, device);
+  if (err != hipSuccess) {
+    std::cerr << "Error getting device memory\n";
+    return 6;
+  }
+  std::cout << "Device memory: " << (memory_size / 1024 / 1024) << " MiB\n";
+
   return 0;
 }


### PR DESCRIPTION
* This has nothing to do with the full regression test harness: it just makes the default `ctest` unit tests work on Windows:
  * Fixes the example/cpp-sdk-user test so that it sets up the HIP compiler properly and sets the PATH when running tests so that in-tree DLLs can be found.
  * Extends the `hip-host-test` to also take an argument for the device ordinal to validate. This can be used for very basic sanity checking that the runtime works at all on a platform.
  * Conditions running extended device tests (vs just tests that will pass on a build machine without a GPU) by the `THEROCK_ENABLE_DEVICE_TEST=ON` env var. This lets us get some extended sanity checking in client builds by `$env:THEROCK_ENABLE_DEVICE_TEST=ON`.
  * Turns the kernel test into an executable and tests it as well if THEROCK_ENABLE_DEVICE_TEST.
* Disables shared library tests on WIN32.
* Fixes fileset_tool to not attempt to fchmod on Windows when decompressing.
* Fixes fileset_tool to consider `*.lib` files part of dev components.