### PR TITLE
amd-llvm: build llc

### DIFF
--- a/compiler/pre_hook_amd-llvm.cmake
+++ b/compiler/pre_hook_amd-llvm.cmake
@@ -105,6 +105,7 @@ block()
     LLVM_OBJDUMP
     OPT
     YAML2OBJ
+    LLC
   )
   therock_set_implicit_llvm_options(LLVM "${CMAKE_CURRENT_SOURCE_DIR}/tools" "${_llvm_required_tools}")
 


### PR DESCRIPTION
`llc` is the LLVM bitcode to amdgcn assembly compiler. hipconfig executes llc and I suspect MIOpen and Triton want it as well.