### PR TITLE
Pin frugally deep and enable json multiple headers.

### DIFF
--- a/third-party/frugally-deep/CMakeLists.txt
+++ b/third-party/frugally-deep/CMakeLists.txt
@@ -1,8 +1,10 @@
 therock_subproject_fetch(therock-frugally-deep-sources
   CMAKE_PROJECT
-  # Originally mirrored from: https://github.com/Dobiasd/frugally-deep/archive/refs/tags/v0.16.2.tar.gz
-  URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/frugally-deep-0.16.2.tar.gz
-  URL_HASH SHA256=b16af09606dcf02359de53b7c47323baaeda9a174e1c87e126c3127c55571971
+  # Use frugally-deep 0.15.x for MIOpen until the following issue is fixed
+  # https://github.com/ROCm/MIOpen/issues/3588
+  # Originally mirrored from: https://github.com/Dobiasd/frugally-deep/archive/refs/tags/v0.15.31.tar.gz
+  URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/frugally-deep-0.15.31.tar.gz
+  URL_HASH SHA256=49bf5e30ad2d33e464433afbc8b6fe8536fc959474004a1ce2ac03d7c54bc8ba
 )
 
 therock_cmake_subproject_declare(therock-frugally-deep

--- a/third-party/nlohmann-json/CMakeLists.txt
+++ b/third-party/nlohmann-json/CMakeLists.txt
@@ -12,7 +12,7 @@ therock_cmake_subproject_declare(therock-nlohmann-json
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
   CMAKE_ARGS
     -DJSON_BuildTests=OFF
-    -DJSON_MultipleHeaders=ON    
+    -DJSON_MultipleHeaders=ON
 )
 therock_cmake_subproject_provide_package(
   therock-nlohmann-json nlohmann_json share/cmake/nlohmann_json)

--- a/third-party/nlohmann-json/CMakeLists.txt
+++ b/third-party/nlohmann-json/CMakeLists.txt
@@ -12,6 +12,7 @@ therock_cmake_subproject_declare(therock-nlohmann-json
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
   CMAKE_ARGS
     -DJSON_BuildTests=OFF
+    -DJSON_MultipleHeaders=ON    
 )
 therock_cmake_subproject_provide_package(
   therock-nlohmann-json nlohmann_json share/cmake/nlohmann_json)


### PR DESCRIPTION
* Both changes were found to be required upon additional testing of MIOpen.
* Includes a workaround for https://github.com/ROCm/MIOpen/issues/3588

Part of breaking #392 up for landing.