### PR TITLE
Fix the bundled boost build to configure properly on Windows.

### DIFF
--- a/third-party/boost/cmake_project/CMakeLists.txt
+++ b/third-party/boost/cmake_project/CMakeLists.txt
@@ -2,36 +2,63 @@ cmake_minimum_required(VERSION 3.18)
 
 project(BOOST_BUILD)
 
+include(ProcessorCount)
+ProcessorCount(PROCESSOR_COUNT)
+
 set(_terminal_option)
 if("$ENV{THEROCK_INTERACTIVE}")
   set(_terminal_option "USES_TERMINAL")
 endif()
 
-set(_cflags "-fPIC")
-set(_bootstrap_exec bash "bootstrap.sh")
+set(_b2_args -j "${PROCESSOR_COUNT}" link=static threading=multi variant=release)
+
 if(WIN32)
-  set(_cflags)
-  set(_bootstrap_exec "cmd.exe" "/C" "bootstrap.bat")
+  # The boost batch file does not handle --with-libraries and silently builds
+  # everything. So we run the bootstrap command. And then we run another command
+  # that we generate in order to add the libraries stanza.
+  # Have I mentioned before how painful it is to integrate Boost?
+  string(REPLACE "," ";" boost_libraries_list "${THEROCK_BOOST_LIBRARIES}")
+  set(_config_content "echo libraries =")
+  foreach(_boost_lib ${boost_libraries_list})
+    string(APPEND _config_content " --with-${_boost_lib}")
+  endforeach()
+  string(APPEND _config_content " ; >> project-config.jam\n\n")
+  file(CONFIGURE OUTPUT "${BOOST_SOURCE_DIR}/fix_libraries.bat"
+    CONTENT "${_config_content}"
+  )
+  message(STATUS "Adding windows boost config: ${_config_content}")
+  set(_bootstrap_commands
+    COMMAND
+      "cmd.exe" "/C" "bootstrap.bat"
+    COMMAND
+      "cmd.exe" "/C" "fix_libraries.bat"
+  )
+
+  if(MSVC)
+    list(APPEND _b2_args msvc)
+  endif()
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+    # Don't generate x32 libraries.
+    list(APPEND _b2_args "architecture=x86" "address-model=64")
+  endif()
+else()
+  # The unix bootstrap script takes a --with-libraries parameter.
+  list(APPEND _b2_args "cflags=-fPIC")
+  set(_bootstrap_commands
+    COMMAND
+      bash "bootstrap.sh" "--with-libraries=${THEROCK_BOOST_LIBRARIES}"
+  )
 endif()
+
+message(STATUS "b2 args: ${_b2_args}")
 
 add_custom_target(
   bootstrap_and_build ALL
   ${_terminal_option}
   WORKING_DIRECTORY "${BOOST_SOURCE_DIR}"
+  ${_bootstrap_commands}
   COMMAND
-    ${_bootstrap_exec} "--with-libraries=${THEROCK_BOOST_LIBRARIES}"
-  COMMAND
-    "${BOOST_SOURCE_DIR}/b2" "cflags=${_cflags}" link=static threading=multi
-  COMMAND
-    "${BOOST_SOURCE_DIR}/b2" headers
-  COMMAND
-    # Boost is dumb. It assumes that it's "stage" directory is one level up from
-    # where the headers are. This is hard-coded in the cmake config. So we take
-    # advantage of the fact that our library install location is into our stage/
-    # directory, which is one level up from our build directory. There may be
-    # a better way to do this... but have I said before that Boost's build is
-    # bonkers?
-    "${CMAKE_COMMAND}" -E create_symlink "${BOOST_SOURCE_DIR}/boost" "${CMAKE_CURRENT_BINARY_DIR}/../boost"
+    "${BOOST_SOURCE_DIR}/b2" ${_b2_args}
+      --stagedir="${CMAKE_BINARY_DIR}/b2_out"
+      --prefix="${CMAKE_INSTALL_PREFIX}" install
 )
-
-install(DIRECTORY "${BOOST_SOURCE_DIR}/stage/lib" DESTINATION ".")


### PR DESCRIPTION
* Uses a hack to configure the desired libraries (since the bootstrap.bat is broken and does not parse this).
* Disables x32 builds on Windows.
* Only builds release.
* Uses the b2 install command. This is *really* unforunate but lets us avoid a fragile symlink situation. It has to materialize ~17k headers and will do so regardless of what was asked for. This extends the build time on Windows by dozens of seconds because serial filesystem access at that scale is slow. However, hopefully this overlaps with some other build steps or can be cached.

Have I mentioned before how intolerable Boost is to integrate?