### PR TITLE
Adding 1101 target

### DIFF
--- a/.github/workflows/test_rocprim.yml
+++ b/.github/workflows/test_rocprim.yml
@@ -37,9 +37,6 @@ permissions:
 jobs:
   test_rocprim:
     name: "rocPRIM math-lib test"
-    # Running into memory issues that result in timeout for gfx110X, excluding for now
-    # TODO(geomin12): work with rocPRIM team to ignore high memory tests
-    if: ${{ inputs.amdgpu_families != 'gfx110X-dgpu' }}
     runs-on: ${{ inputs.test_runs_on }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Adding gfx110X target

Status as of 5/8/2025 - rocPRIM tests take a significantly long time, resulting in time outs. Working with rocPRIM team to resolve and ignore high memory tests

Closes #438 