### PR TITLE
Invoke Image Verification by Image Publishing using Dispatching

### DIFF
--- a/.github/workflows/publish_pytorch_dev_docker.yml
+++ b/.github/workflows/publish_pytorch_dev_docker.yml
@@ -72,10 +72,10 @@ jobs:
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.9
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
-
       - name: Build and push Docker image
         id: build_push
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0

--- a/.github/workflows/publish_pytorch_dev_docker.yml
+++ b/.github/workflows/publish_pytorch_dev_docker.yml
@@ -111,6 +111,6 @@ jobs:
                 (matrix.targets.amdgpu_family == 'gfx1100' && 'linux-rx7900-gpu-rocm') ||
                 'linux-mi300-1gpu-ossci-rocm'
               }}",
-              "dispatch_id": "${{ env.DISPATCH_ID }}"
+              "dispatch_id": "${{ env.DISPATCH_ID }}",
               "version": "${{ env.VERSION }}"
             }

--- a/.github/workflows/publish_pytorch_dev_docker.yml
+++ b/.github/workflows/publish_pytorch_dev_docker.yml
@@ -2,7 +2,7 @@ name: Publish PyTorch Dev Dockers
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 2 * * *" # Runs Nightly at 2 AM UTC
+    - cron: "0 2 * * *" # Runs nightly at 2 AM UTC
 
 jobs:
   setup_metadata:

--- a/.github/workflows/publish_pytorch_dev_docker.yml
+++ b/.github/workflows/publish_pytorch_dev_docker.yml
@@ -2,7 +2,7 @@ name: Publish PyTorch Dev Dockers
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 2 * * *" # Runs nightly at 2 AM UTC
+    - cron: "0 2 * * *" # Runs Nightly at 2 AM UTC
 
 jobs:
   setup_metadata:
@@ -35,9 +35,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+      actions: write # Added permission to trigger workflows
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Runner Health Settings
         run: |
           df -h
@@ -45,20 +47,26 @@ jobs:
           echo "Git version: $(git --version)"
           git config --global --add safe.directory $PWD
           git config fetch.parallel 10
+
+      - name: Generate unique dispatch ID
+        run: echo "DISPATCH_ID=dispatch-${{ matrix.targets.amdgpu_family }}-${{ github.run_id }}" >> $GITHUB_ENV
+
       - name: Fetch sources
         run: |
           python3 ./build_tools/fetch_sources.py --jobs 10
+
       - name: Log in to the Container registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set nightly version
-        id: nightly_version
         run: |
           BASE_VERSION=$(jq -r '.["rocm-version"]' version.json)
           echo "VERSION=${BASE_VERSION}rc$(date +'%Y%m%d')" >> "$GITHUB_ENV"
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.9
@@ -67,13 +75,9 @@ jobs:
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
-          labels: |
-            org.opencontainers.image.title=PyTorch ROCm Dev Image
-            org.opencontainers.image.description=Nightly ROCm PyTorch Dev Docker for target ${{ matrix.targets.amdgpu_family }}
-            org.opencontainers.image.version=${{ env.VERSION }}
-            org.opencontainers.image.created=${{ steps.meta.outputs.created }}
-            org.opencontainers.image.revision=${{ github.sha }}
+
       - name: Build and push Docker image
+        id: build_push
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: .
@@ -82,4 +86,31 @@ jobs:
             AMDGPU_TARGETS=${{ matrix.targets.amdgpu_family }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.title="PyTorch ROCm Dev Image"
+            org.opencontainers.image.description="Nightly ROCm PyTorch Dev Docker for target ${{ matrix.targets.amdgpu_family }}""
+            org.opencontainers.image.version=${{ env.VERSION }}
+            org.opencontainers.image.created=${{ steps.meta.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Log digest
+        run: |
+          echo "Built image with digest: ${{ steps.build_push.outputs.digest }}"
+      - name: Trigger verification workflow
+        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc #1.2.4
+        with:
+          workflow: verify_docker_image.yml
+          inputs: |
+            {
+              "amdgpu_target": "${{ matrix.targets.amdgpu_family }}",
+              "image_digest": "${{ steps.build_push.outputs.digest }}",
+              "runner_type": "${{
+                matrix.targets.amdgpu_family == 'gfx942' && 'linux-mi300-1gpu-ossci-rocm' ||
+                (matrix.targets.amdgpu_family == 'gfx1201' && 'linux-rx9070-gpu-rocm') ||
+                (matrix.targets.amdgpu_family == 'gfx1100' && 'linux-rx7900-gpu-rocm') ||
+                'linux-mi300-1gpu-ossci-rocm'
+              }}",
+              "dispatch_id": "${{ env.DISPATCH_ID }}"
+              "version": "${{ env.VERSION }}"
+            }

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -57,7 +57,6 @@ jobs:
         IMAGE_REF: "ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ inputs.amdgpu_target }}@${{ inputs.image_digest }}"
       run: |
         echo "IMAGE_REF=$IMAGE_REF" >> "$GITHUB_ENV"
-        echo "Image to verify: ${{ env.IMAGE_REF }}"
 
   pull-and-verify-image:
     name: Verify ${{ version }}/${{ env.IMAGE_REF }} Docker Image
@@ -99,16 +98,16 @@ jobs:
       - name: Verify Containers Status
         run: |
           docker ps -a
-      # Tag and push verified image
+
       - name: Tag and push verified image
         run: |
-          IMAGE=ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ inputs.amdgpu_target }}
+          IMAGEBASE=ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ inputs.amdgpu_target }}
           DIGEST=${{ inputs.image_digest  }}
           VERSION=${{ inputs.version }}
 
-          echo "Using image: $IMAGE"
+          echo "Using image: $IMAGEBASE"
           echo "Using digest: $DIGEST"
           echo "Using version: $VERSION"
 
-          docker tag $IMAGE@$DIGEST $IMAGE:$VERSION
+          docker tag $IMAGEBASE@$DIGEST $IMAGEBASE:$VERSION
           docker push $IMAGE:$VERSION

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -54,13 +54,14 @@ jobs:
     steps:
       - name: Identifier ${{ inputs.dispatch_id }}
         run: |
-           echo "Dispatched for: ${{ inputs.dispatch_id }}"
+          echo "Dispatched for: ${{ inputs.dispatch_id }}"
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Authenticate with GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Construct image reference
         id: image_ref

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -18,11 +18,11 @@ on:
         default: "linux-mi300-1gpu-ossci-rocm"
         type: string
       dispatch_id:
-        description: "Auto Generated Id for a dispatch"
+        description: "Auto generated id for a dispatch"
         type: string
         required: true
       version:
-        description: "Version Number as X.Y.ZrcYYYYMMDD format"
+        description: "Version number string"
         type: string
         required: true
   workflow_call:

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -59,9 +59,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Authenticate with GitHub Container Registry
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Log in to the Container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Construct image reference
         id: image_ref

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -1,25 +1,80 @@
 name: Pull and Verify Docker Image
 
 on:
-  workflow_call:
   workflow_dispatch:
+    inputs:
+      amdgpu_target:
+        description: "AMDGPU target to verify"
+        required: true
+        default: "gfx942"
+        type: string
+      image_digest:
+        description: "Digest of image to verify"
+        required: true
+        type: string
+      runner_type:
+        description: "Runner type to use"
+        required: true
+        default: "linux-mi300-1gpu-ossci-rocm"
+        type: string
+      dispatch_id:
+        description: "Auto Generated Id for a dispatch"
+        type: string
+        required: true
+      version:
+        description: "Version Number as X.Y.ZrcYYYYMMDD format"
+        type: string
+        required: true
+  workflow_call:
+    inputs:
+      amdgpu_target:
+        type: string
+        required: true
+      image_digest:
+        type: string
+        required: true
+      runner_type:
+        type: string
+        required: true
+      dispatch_id:
+        type: string
+        required: true
+      version:
+        type: string
+        required: true
+
 jobs:
-  pull-and-build-image:
-    name: Verify Docker Image
-    runs-on: linux-mi300-1gpu-ossci-rocm
+  pull-and-verify-image:
+    name: Verify ${{ inputs.dispatch_id }} Docker Image
+    runs-on: ${{ inputs.runner_type }}
     steps:
+      - name: Identifier ${{ inputs.dispatch_id }}
+        run: |
+           echo "Dispatched for: ${{ inputs.dispatch_id }}"
+
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Construct image reference
+        id: image_ref
+        env:
+          IMAGE_REF: "ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ inputs.amdgpu_target }}@${{ inputs.image_digest }}"
+        run: |
+          echo "IMAGE_REF=$IMAGE_REF" >> "$GITHUB_ENV"
+          echo "Image to verify: $IMAGE_REF"
+
       - name: Pull Docker Image
         run: |
-          docker pull ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_gfx942:main
+          sudo docker pull "$IMAGE_REF"
+
       - name: Pre-download pytest wheel
         run: |
           mkdir -p pytest_wheels
           pip download pytest -d pytest_wheels
+
       - name: Run Docker Container and Execute Commands
         run: |
-          docker run --rm \
+          sudo docker run --rm \
           --device=/dev/kfd \
           --device=/dev/dri \
           --mount type=bind,source="$GITHUB_WORKSPACE/pytest_wheels",target=/wheels \
@@ -27,7 +82,22 @@ jobs:
           --group-add video \
           --cap-add=SYS_PTRACE \
           -w /TheRock \
-          ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_gfx942:main \
+          "$IMAGE_REF" \
           bash external-builds/pytorch/smoke-tests/run_smoke_tests.sh
+
       - name: Verify Containers Status
-        run: docker ps -a
+        run: sudo docker ps -a
+      # Tag and push verified image
+      - name: Tag and push verified image
+        run: |
+          IMAGE=ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ matrix.targets.amdgpu_target }}
+          DIGEST=${{ inputs.image_digest  }}
+          VERSION=${{ inputs.version }}
+
+          echo "Using image: $IMAGE"
+          echo "Using digest: $DIGEST"
+          echo "Using version: $VERSION"
+
+          docker pull $IMAGE@$DIGEST
+          docker tag $IMAGE@$DIGEST $IMAGE:$VERSION
+          docker push $IMAGE:$VERSION

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -43,6 +43,10 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   pull-and-verify-image:
     name: Verify ${{ inputs.dispatch_id }} Docker Image
@@ -55,6 +59,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Authenticate with GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      
       - name: Construct image reference
         id: image_ref
         env:

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -52,10 +52,6 @@ jobs:
     name: Verify ${{ inputs.dispatch_id }} Docker Image
     runs-on: ${{ inputs.runner_type }}
     steps:
-      - name: Identifier ${{ inputs.dispatch_id }}
-        run: |
-          echo "Dispatched for: ${{ inputs.dispatch_id }}"
-
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Pull Docker Image
         run: |
-          sudo docker pull "$IMAGE_REF"
+          docker pull "$IMAGE_REF"
 
       - name: Pre-download pytest wheel
         run: |
@@ -85,7 +85,7 @@ jobs:
 
       - name: Run Docker Container and Execute Commands
         run: |
-          sudo docker run --rm \
+          docker run --rm \
           --device=/dev/kfd \
           --device=/dev/dri \
           --mount type=bind,source="$GITHUB_WORKSPACE/pytest_wheels",target=/wheels \
@@ -97,7 +97,8 @@ jobs:
           bash external-builds/pytorch/smoke-tests/run_smoke_tests.sh
 
       - name: Verify Containers Status
-        run: sudo docker ps -a
+        run: |
+          docker ps -a
       # Tag and push verified image
       - name: Tag and push verified image
         run: |

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -53,6 +53,7 @@ jobs:
     steps:
     - name: Construct image reference
       id: image_ref
+      # Use the IMAGE_REF for pulling purposes using the embedded digest SHA in it
       env:
         IMAGE_REF: "ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ inputs.amdgpu_target }}@${{ inputs.image_digest }}"
       run: |
@@ -100,14 +101,15 @@ jobs:
           docker ps -a
 
       - name: Tag and push verified image
+      # Use the IMAGE_BASE for tagging reference
         run: |
-          IMAGEBASE=ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ inputs.amdgpu_target }}
+          IMAGE_BASE=ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ inputs.amdgpu_target }}
           DIGEST=${{ inputs.image_digest  }}
           VERSION=${{ inputs.version }}
 
-          echo "Using image: $IMAGEBASE"
+          echo "Using image: $IMAGE_BASE"
           echo "Using digest: $DIGEST"
           echo "Using version: $VERSION"
 
-          docker tag $IMAGEBASE@$DIGEST $IMAGEBASE:$VERSION
+          docker tag $IMAGE_BASE@$DIGEST $IMAGE_BASE:$VERSION
           docker push $IMAGE:$VERSION

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -72,11 +72,11 @@ jobs:
           IMAGE_REF: "ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ inputs.amdgpu_target }}@${{ inputs.image_digest }}"
         run: |
           echo "IMAGE_REF=$IMAGE_REF" >> "$GITHUB_ENV"
-          echo "Image to verify: $IMAGE_REF"
+          echo "Image to verify: ${{ env.IMAGE_REF }}"
 
       - name: Pull Docker Image
         run: |
-          docker pull "$IMAGE_REF"
+          docker pull ${{ env.IMAGE_REF }}
 
       - name: Pre-download pytest wheel
         run: |
@@ -93,7 +93,7 @@ jobs:
           --group-add video \
           --cap-add=SYS_PTRACE \
           -w /TheRock \
-          "$IMAGE_REF" \
+          ${{ env.IMAGE_REF }} \
           bash external-builds/pytorch/smoke-tests/run_smoke_tests.sh
 
       - name: Verify Containers Status
@@ -110,6 +110,5 @@ jobs:
           echo "Using digest: $DIGEST"
           echo "Using version: $VERSION"
 
-          docker pull $IMAGE@$DIGEST
           docker tag $IMAGE@$DIGEST $IMAGE:$VERSION
           docker push $IMAGE:$VERSION

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -50,14 +50,14 @@ permissions:
 jobs:
   setup_metadata:
     runs-on: ubuntu-24.04
-  steps:
-     - name: Construct image reference
-       id: image_ref
-       env:
-          IMAGE_REF: "ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ inputs.amdgpu_target }}@${{ inputs.image_digest }}"
-       run: |
-          echo "IMAGE_REF=$IMAGE_REF" >> "$GITHUB_ENV"
-          echo "Image to verify: ${{ env.IMAGE_REF }}"
+    steps:
+    - name: Construct image reference
+      id: image_ref
+      env:
+        IMAGE_REF: "ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ inputs.amdgpu_target }}@${{ inputs.image_digest }}"
+      run: |
+        echo "IMAGE_REF=$IMAGE_REF" >> "$GITHUB_ENV"
+        echo "Image to verify: ${{ env.IMAGE_REF }}"
 
   pull-and-verify-image:
     name: Verify ${{ version }}/${{ env.IMAGE_REF }} Docker Image

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Authenticate with GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      
+
       - name: Construct image reference
         id: image_ref
         env:

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -90,7 +90,7 @@ jobs:
       # Tag and push verified image
       - name: Tag and push verified image
         run: |
-          IMAGE=ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ matrix.targets.amdgpu_target }}
+          IMAGE=ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ inputs.amdgpu_target }}
           DIGEST=${{ inputs.image_digest  }}
           VERSION=${{ inputs.version }}
 

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Log in to the Container registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/verify_docker_image.yml
+++ b/.github/workflows/verify_docker_image.yml
@@ -48,9 +48,21 @@ permissions:
   packages: write
 
 jobs:
+  setup_metadata:
+    runs-on: ubuntu-24.04
+  steps:
+     - name: Construct image reference
+       id: image_ref
+       env:
+          IMAGE_REF: "ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ inputs.amdgpu_target }}@${{ inputs.image_digest }}"
+       run: |
+          echo "IMAGE_REF=$IMAGE_REF" >> "$GITHUB_ENV"
+          echo "Image to verify: ${{ env.IMAGE_REF }}"
+
   pull-and-verify-image:
-    name: Verify ${{ inputs.dispatch_id }} Docker Image
+    name: Verify ${{ version }}/${{ env.IMAGE_REF }} Docker Image
     runs-on: ${{ inputs.runner_type }}
+    needs: [setup_metadata]
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -61,14 +73,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Construct image reference
-        id: image_ref
-        env:
-          IMAGE_REF: "ghcr.io/rocm/therock_pytorch_dev_ubuntu_24_04_${{ inputs.amdgpu_target }}@${{ inputs.image_digest }}"
-        run: |
-          echo "IMAGE_REF=$IMAGE_REF" >> "$GITHUB_ENV"
-          echo "Image to verify: ${{ env.IMAGE_REF }}"
 
       - name: Pull Docker Image
         run: |


### PR DESCRIPTION
Improved from https://github.com/ROCm/TheRock/pull/361 PR
The workflows, `verify_docker_image.yml` and `publish_pytorch_dev_docker.yml`, are needed to be connected since the published docker images should be verified. The current work plan as below:
Publish -> Verify ->Tag the image if verification passed
Used  https://github.com/benc-uk/workflow-dispatch