### PR TITLE
Fixing fetch_sources.py for patching

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -48,8 +48,6 @@ jobs:
           echo "Git version: $(git --version)"
           git config --global --add safe.directory $PWD
           git config fetch.parallel 10
-          git config --global user.email "nobody@amd.com"
-          git config --global user.name "Nobody"
 
       # TODO: We shouldn't be using a cache on actual release branches, but it
       # really helps for iteration time.

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -65,8 +65,6 @@ jobs:
           echo "python: $(which python), python3: $(which python3)"
           echo "Git version: $(git --version)"
           git config fetch.parallel 10
-          git config --global user.email "nobody@amd.com"
-          git config --global user.name "Nobody"
 
       # TODO: We shouldn't be using a cache on actual release branches, but it
       # really helps for iteration time.

--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -101,8 +101,6 @@ jobs:
         run: |
           # Prefetch docker container in background.
           docker pull ${{ env.BUILD_IMAGE }} &
-          git config --global user.email "nobody@amd.com"
-          git config --global user.name "Nobody"
           ./build_tools/fetch_sources.py --jobs 10
           wait
 

--- a/.github/workflows/publish_pytorch_dev_docker.yml
+++ b/.github/workflows/publish_pytorch_dev_docker.yml
@@ -32,8 +32,6 @@ jobs:
           echo "Git version: $(git --version)"
           git config --global --add safe.directory $PWD
           git config fetch.parallel 10
-          git config --global user.email "nobody@amd.com"
-          git config --global user.name "Nobody"
       - name: Fetch sources
         run: |
           python3 ./build_tools/fetch_sources.py --jobs 10

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -90,7 +90,7 @@ def apply_patches(args):
         patch_files = list(patch_project_dir.glob("*.patch"))
         patch_files.sort()
         log(f"Applying {len(patch_files)} patches")
-        exec(["git", "am", "--whitespace=nowarn"] + patch_files, cwd=project_dir)
+        exec(["git", "-c", "user.name=therockbot", "-c", "user.email=therockbot@amd.com", "am", "--whitespace=nowarn"] + patch_files, cwd=project_dir)
         # Since it is in a patched state, make it invisible to changes.
         exec(
             ["git", "update-index", "--skip-worktree", "--", submodule_path],

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -71,10 +71,10 @@ def run(args):
 
     populate_ancillary_sources(args)
     if args.apply_patches:
-        apply_patches(args)
+        apply_patches(args, projects)
 
 
-def apply_patches(args):
+def apply_patches(args, projects):
     if not args.patch_tag:
         log("Not patching (no --patch-tag specified)")
     patch_version_dir: Path = PATCHES_DIR / args.patch_tag
@@ -82,6 +82,12 @@ def apply_patches(args):
         log(f"ERROR: Patch directory {patch_version_dir} does not exist")
     for patch_project_dir in patch_version_dir.iterdir():
         log(f"* Processing project patch directory {patch_project_dir}:")
+        # Check that project patch directory was included
+        if not patch_project_dir.name in projects:
+            log(
+                f"* Project patch directory {patch_project_dir.name} was not included. Skipping."
+            )
+            continue
         submodule_path = get_submodule_path(patch_project_dir.name)
         project_dir = THEROCK_DIR / submodule_path
         if not project_dir.exists():
@@ -90,7 +96,19 @@ def apply_patches(args):
         patch_files = list(patch_project_dir.glob("*.patch"))
         patch_files.sort()
         log(f"Applying {len(patch_files)} patches")
-        exec(["git", "-c", "user.name=therockbot", "-c", "user.email=therockbot@amd.com", "am", "--whitespace=nowarn"] + patch_files, cwd=project_dir)
+        exec(
+            [
+                "git",
+                "-c",
+                "user.name=therockbot",
+                "-c",
+                "user.email=therockbot@amd.com",
+                "am",
+                "--whitespace=nowarn",
+            ]
+            + patch_files,
+            cwd=project_dir,
+        )
         # Since it is in a patched state, make it invisible to changes.
         exec(
             ["git", "update-index", "--skip-worktree", "--", submodule_path],


### PR DESCRIPTION
Resolves:
- git login issue
- another issue where script tries to patch things not included, causing "no file found" errors. example cmd: `./build_tools/fetch_sources.py --jobs 8 --no-include-math-libs --no-include-ml-frameworks`

Closes #444 

