### PR TITLE
Update Windows Github Action to use static build path on local disk

### DIFF
--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Fetch sources
         run: |
-          python ./build_tools/fetch_sources.py --jobs 12
+          python ./build_tools/fetch_sources.py --jobs 96
 
       - name: Configure MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -68,7 +68,7 @@ jobs:
           echo "Git version: $(git --version)"
           git config fetch.parallel 10
           nthreads=$(nproc --all)
-          echo [*] Logical Processors to be used: $nthreads... 
+          echo [*] Logical Processors to be used: $nthreads...
 
       # TODO: We shouldn't be using a cache on actual release branches, but it
       # really helps for iteration time.

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -148,5 +148,4 @@ jobs:
           $fsout = $fs | Select-Object -Property Name,Used,Free,Root
           $fsout | % {$_.Used/=1GB;$_.Free/=1GB;$_} | Write-Host
           get-disk | Select-object @{Name="Size(GB)";Expression={$_.Size/1GB}} | Write-Host
-          if (Test-Path -Path "$Env:BUILD_DIR_POWERSHELL") {Remove-Item -Path "$Env:BUILD_DIR_POWERSHELL" -Recurse -Force}
         shell: powershell

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: true
     env:
-      BASE_BUILD_DIR_POWERSHELL: C:\tmpbuild
+      BASE_BUILD_DIR_POWERSHELL: B:\tmpbuild
       CACHE_DIR: "${{github.workspace}}/.cache"
       CCACHE_DIR: "${{github.workspace}}/.cache/ccache"
       CCACHE_MAXSIZE: "4000M"
@@ -40,7 +40,7 @@ jobs:
           echo "BUILD_DIR_POWERSHELL=$buildDir" >> $env:GITHUB_ENV
           dir "$buildDir"
           Write-Host "Generated Build Directory: $buildDir"
-          $bashBuildDir = $buildDir -replace '\\', '/' -replace '^C:', '/c'
+          $bashBuildDir = $buildDir -replace '\\', '/' -replace '^B:', '/b'
           echo  "BUILD_DIR_BASH=$bashBuildDir" >> $env:GITHUB_ENV
           Write-Host "Converted Build Directory For Bash: $bashBuildDir"
           $fs = Get-PSDrive -PSProvider "FileSystem"

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -28,8 +28,8 @@ jobs:
       fail-fast: true
     env:
       BASE_BUILD_DIR_POWERSHELL: C:\tmpbuild
-      CACHE_DIR: ${{ github.workspace }}/.cache
-      CCACHE_DIR: "${{ github.workspace }}/.cache/ccache"
+      CACHE_DIR: "ccache-dir/.cache"
+      CCACHE_DIR: "ccache-dir/.cache/ccache"
       CCACHE_MAXSIZE: "4000M"
     steps:
       - name: "Create build dir"

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -142,5 +142,11 @@ jobs:
 
       - name: "Clean up build dir"
         if: always()
-        run: if (Test-Path -Path "$Env:BUILD_DIR_POWERSHELL") {Remove-Item -Path "$Env:BUILD_DIR_POWERSHELL" -Recurse -Force}
+        run: |
+          $fs = Get-PSDrive -PSProvider "FileSystem"
+          $g = [Math]::Pow(2,30) 
+          $fsout = $fs | Select-Object -Property Name,Used,Free,Root
+          $fsout | % {$_.Used/=$g;$_.Free/=$g;$_} | Write-Host
+          echo "lis dis" | diskpart
+          if (Test-Path -Path "$Env:BUILD_DIR_POWERSHELL") {Remove-Item -Path "$Env:BUILD_DIR_POWERSHELL" -Recurse -Force}
         shell: powershell

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -28,8 +28,8 @@ jobs:
       fail-fast: true
     env:
       BASE_BUILD_DIR_POWERSHELL: C:\tmpbuild
-      CACHE_DIR: ${{ github.workspace }}/.cache
-      CCACHE_DIR: "${{ github.workspace }}/.cache/ccache"
+      CACHE_DIR: /tmpbuild/.cache
+      CCACHE_DIR: /tmpbuild/.cache/ccache"
       CCACHE_MAXSIZE: "4000M"
     steps:
       - name: "Create build dir"
@@ -63,7 +63,6 @@ jobs:
         run: |
           echo "CCACHE_DIR=${CCACHE_DIR}"
           df -h
-          ccache -z
           mkdir -p $CCACHE_DIR
           cmake --version
           echo "python: $(which python), python3: $(which python3)"
@@ -91,6 +90,9 @@ jobs:
 
       - name: Configure Projects
         run: |
+          # clear cache before build and after download
+          ccache -z
+
           # Generate a new build id.
           package_version="${{ inputs.package_version }}"
           amdgpu_families="${{ inputs.amdgpu_families }}"

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -35,7 +35,6 @@ jobs:
       - name: "Create build dir"
         shell: powershell
         run: |
-          $currentTime = (Get-Date).ToString('HHmmss')
           $buildDir = "$env:BASE_BUILD_DIR_POWERSHELL\"
           echo "BUILD_DIR_POWERSHELL=$buildDir" >> $env:GITHUB_ENV
           mkdir "$buildDir"
@@ -144,7 +143,7 @@ jobs:
           path: ${{ env.CACHE_DIR }}
           key: windows-build-packages-v2-${{ github.sha }}
 
-      - name: "Clean up build dir"
+      - name: "Build size report"
         if: always()
         run: |
           $fs = Get-PSDrive -PSProvider "FileSystem"

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -47,6 +47,7 @@ jobs:
           $g = [Math]::Pow(2,30) 
           $fsout = $fs | Select-Object -Property Name,Used,Free,Root
           $fsout | % {$_.Used/=$g;$_.Free/=$g;$_} | Write-Host
+          echo "lis dis" | diskpart
 
       - name: "Checking out repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -97,7 +97,6 @@ jobs:
           amdgpu_families="${{ inputs.amdgpu_families }}"
           echo "Building package ${package_version}"
 
-          
           # Build.
           cmake -B "${{ env.BUILD_DIR_BASH }}" -GNinja . \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -38,7 +38,7 @@ jobs:
           $currentTime = (Get-Date).ToString('HHmmss')
           $buildDir = "$env:BASE_BUILD_DIR_POWERSHELL\"
           echo "BUILD_DIR_POWERSHELL=$buildDir" >> $env:GITHUB_ENV
-          mkdir "$buildDir"
+          dir "$buildDir"
           Write-Host "Generated Build Directory: $buildDir"
           $bashBuildDir = $buildDir -replace '\\', '/' -replace '^C:', '/c'
           echo  "BUILD_DIR_BASH=$bashBuildDir" >> $env:GITHUB_ENV
@@ -46,7 +46,7 @@ jobs:
           $fs = Get-PSDrive -PSProvider "FileSystem"
           $fsout = $fs | Select-Object -Property Name,Used,Free,Root
           $fsout | % {$_.Used/=1GB;$_.Free/=1GB;$_} | Write-Host
-          get-disk | Select-object @{Name="Size(GB)";Expression={$_.Size/1GB}}
+          get-disk | Select-object @{Name="Size(GB)";Expression={$_.Size/1GB}} | Write-Host
 
       - name: "Checking out repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -143,9 +143,8 @@ jobs:
         if: always()
         run: |
           $fs = Get-PSDrive -PSProvider "FileSystem"
-          $g = [Math]::Pow(2,30) 
           $fsout = $fs | Select-Object -Property Name,Used,Free,Root
-          $fsout | % {$_.Used/=$g;$_.Free/=$g;$_} | Write-Host
-          get-disk | Select-object @{Name="Size(GB)";Expression={$_.Size/1GB}}
+          $fsout | % {$_.Used/=1GB;$_.Free/=1GB;$_} | Write-Host
+          get-disk | Select-object @{Name="Size(GB)";Expression={$_.Size/1GB}} | Write-Host
           if (Test-Path -Path "$Env:BUILD_DIR_POWERSHELL") {Remove-Item -Path "$Env:BUILD_DIR_POWERSHELL" -Recurse -Force}
         shell: powershell

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -28,8 +28,8 @@ jobs:
       fail-fast: true
     env:
       BASE_BUILD_DIR_POWERSHELL: C:\tmpbuild
-      CACHE_DIR: /tmpbuild/.cache
-      CCACHE_DIR: /tmpbuild/.cache/ccache"
+      CACHE_DIR: ${{ github.workspace }}/.cache
+      CCACHE_DIR: "${{ github.workspace }}/.cache/ccache"
       CCACHE_MAXSIZE: "4000M"
     steps:
       - name: "Create build dir"

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -27,22 +27,26 @@ jobs:
     strategy:
       fail-fast: true
     env:
-      BASE_BUILD_DIR_POWERSHELL: C:\mnt\azure\b
+      BASE_BUILD_DIR_POWERSHELL: C:\tmpbuild
       CACHE_DIR: ${{ github.workspace }}/.cache
       CCACHE_DIR: "${{ github.workspace }}/.cache/ccache"
-      CCACHE_MAXSIZE: "700M"
+      CCACHE_MAXSIZE: "4000M"
     steps:
       - name: "Create build dir"
         shell: powershell
         run: |
           $currentTime = (Get-Date).ToString('HHmmss')
-          $buildDir = "$env:BASE_BUILD_DIR_POWERSHELL\$currentTime"
+          $buildDir = "$env:BASE_BUILD_DIR_POWERSHELL\"
           echo "BUILD_DIR_POWERSHELL=$buildDir" >> $env:GITHUB_ENV
           mkdir "$buildDir"
           Write-Host "Generated Build Directory: $buildDir"
           $bashBuildDir = $buildDir -replace '\\', '/' -replace '^C:', '/c'
           echo  "BUILD_DIR_BASH=$bashBuildDir" >> $env:GITHUB_ENV
           Write-Host "Converted Build Directory For Bash: $bashBuildDir"
+          $fs = Get-PSDrive -PSProvider "FileSystem"
+          $g = [Math]::Pow(2,30) 
+          $fsout = $fs | Select-Object -Property Name,Used,Free,Root
+          $fsout | % {$_.Used/=$g;$_.Free/=$g;$_} | Write-Host
 
       - name: "Checking out repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -100,6 +100,7 @@ jobs:
           amdgpu_families="${{ inputs.amdgpu_families }}"
           echo "Building package ${package_version}"
 
+          
           # Build.
           cmake -B "${{ env.BUILD_DIR_BASH }}" -GNinja . \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
@@ -124,7 +125,7 @@ jobs:
             -DTHEROCK_ENABLE_ML_LIBS=OFF
 
       - name: Build Projects
-        run: cmake --build "${{ env.BUILD_DIR_BASH }}"
+        run: cmake --build "${{ env.BUILD_DIR_BASH }}" -j $(nproc --all)
 
       - name: Report
         if: ${{ !cancelled() }}

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -69,7 +69,7 @@ jobs:
           git config fetch.parallel 10
           nthreads=$(nproc --all)
           echo [*] Logical Processors to be used: $nthreads... 
-          
+
       # TODO: We shouldn't be using a cache on actual release branches, but it
       # really helps for iteration time.
       - name: Enable cache

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -70,6 +70,8 @@ jobs:
           git config fetch.parallel 10
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
+          nthreads=$(nproc --all)
+          echo [*] Logical Processors to be used: $nthreads... 
 
       # TODO: We shouldn't be using a cache on actual release branches, but it
       # really helps for iteration time.

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -38,7 +38,7 @@ jobs:
           $currentTime = (Get-Date).ToString('HHmmss')
           $buildDir = "$env:BASE_BUILD_DIR_POWERSHELL\"
           echo "BUILD_DIR_POWERSHELL=$buildDir" >> $env:GITHUB_ENV
-          dir "$buildDir"
+          mkdir "$buildDir"
           Write-Host "Generated Build Directory: $buildDir"
           $bashBuildDir = $buildDir -replace '\\', '/' -replace '^B:', '/b'
           echo  "BUILD_DIR_BASH=$bashBuildDir" >> $env:GITHUB_ENV

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -28,8 +28,8 @@ jobs:
       fail-fast: true
     env:
       BASE_BUILD_DIR_POWERSHELL: C:\tmpbuild
-      CACHE_DIR: "ccache-dir/.cache"
-      CCACHE_DIR: "ccache-dir/.cache/ccache"
+      CACHE_DIR: "${{github.workspace}}/.cache"
+      CCACHE_DIR: "${{github.workspace}}/.cache/ccache"
       CCACHE_MAXSIZE: "4000M"
     steps:
       - name: "Create build dir"

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -44,10 +44,9 @@ jobs:
           echo  "BUILD_DIR_BASH=$bashBuildDir" >> $env:GITHUB_ENV
           Write-Host "Converted Build Directory For Bash: $bashBuildDir"
           $fs = Get-PSDrive -PSProvider "FileSystem"
-          $g = [Math]::Pow(2,30) 
           $fsout = $fs | Select-Object -Property Name,Used,Free,Root
-          $fsout | % {$_.Used/=$g;$_.Free/=$g;$_} | Write-Host
-          echo "lis dis" | diskpart
+          $fsout | % {$_.Used/=1GB;$_.Free/=1GB;$_} | Write-Host
+          get-disk | Select-object @{Name="Size(GB)";Expression={$_.Size/1GB}}
 
       - name: "Checking out repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -147,6 +146,6 @@ jobs:
           $g = [Math]::Pow(2,30) 
           $fsout = $fs | Select-Object -Property Name,Used,Free,Root
           $fsout | % {$_.Used/=$g;$_.Free/=$g;$_} | Write-Host
-          echo "lis dis" | diskpart
+          get-disk | Select-object @{Name="Size(GB)";Expression={$_.Size/1GB}}
           if (Test-Path -Path "$Env:BUILD_DIR_POWERSHELL") {Remove-Item -Path "$Env:BUILD_DIR_POWERSHELL" -Recurse -Force}
         shell: powershell


### PR DESCRIPTION
- Use static build path in order to allow ccache to hit 
- Removes use of timestamped directory build path
- Uses local temporary disks on Azure VM via kubernetes container `emptyDir` storage mount 
- AKS Node Pool now uses one of these Azure VM sizes: `Standard_D96ads_v6`, `Standard_HX176rs`, `Standard_HB176rs_v4` (Old was Standard_D64s_v3)
- Output logging for free disk space
- Add taint for spot nodes
- modified gha-runner-scale-set arc-runners yaml configuration to include:
```
      resources:
        limits:
          ephemeral-storage: 400Gi
          memory: 300Gi
        requests:
          ephemeral-storage: 10Gi
          memory: 300Gi
      volumeMounts:
      - name: tmpbuild-dir
        mountPath: "b:"
      - name: src-ccache-dir
        mountPath: "s:"
      - name: src-ccache-dir
        mountPath: /home/runner/_work
    tolerations:
    - effect: NoSchedule
      key: kubernetes.io/os
      operator: Equal
      value: windows
    - effect: NoSchedule
      key: kubernetes.azure.com/scalesetpriority
      operator: Equal
      value: spot
    volumes:
    - name: tmpbuild-dir
      emptyDir: {}
    - name: src-ccache-dir
      emptyDir: {}
```

#132 