### PR TITLE
Update pytorch to 2.7-rc10 and enable gfx1151

### DIFF
--- a/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
+++ b/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
@@ -1,0 +1,341 @@
+From d4b67827c2dafda5be6fbe6446b422ef542102a0 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Mon, 17 Feb 2025 16:47:57 -0800
+Subject: [PATCH 1/6] Rework LoadHIP.cmake to be based purely on
+ CMAKE_PREFIX_PATH.
+
+* Eliminates dependence on `/opt/rocm` and path based heuristics.
+* Normalizes package finding for Rocm 6.5+ layout.
+* Workaround cmake >= 4.0 for hiprtc
+
+Co-authored-by: Scott Tsai <scottt.tw@gmail.com>
+
+---
+ cmake/public/LoadHIP.cmake | 303 ++++++++++++++-----------------------
+ 1 file changed, 111 insertions(+), 192 deletions(-)
+
+diff --git a/cmake/public/LoadHIP.cmake b/cmake/public/LoadHIP.cmake
+index 58c74ddda3..57910495fc 100644
+--- a/cmake/public/LoadHIP.cmake
++++ b/cmake/public/LoadHIP.cmake
+@@ -1,206 +1,125 @@
+-set(PYTORCH_FOUND_HIP FALSE)
+-
+-# If ROCM_PATH is set, assume intention is to compile with
+-# ROCm support and error out if the ROCM_PATH does not exist.
+-# Else ROCM_PATH does not exist, assume a default of /opt/rocm
+-# In the latter case, if /opt/rocm does not exist emit status
+-# message and return.
+-if(DEFINED ENV{ROCM_PATH})
+-  set(ROCM_PATH $ENV{ROCM_PATH})
+-  if(NOT EXISTS ${ROCM_PATH})
+-    message(FATAL_ERROR
+-      "ROCM_PATH environment variable is set to ${ROCM_PATH} but does not exist.\n"
+-      "Set a valid ROCM_PATH or unset ROCM_PATH environment variable to fix.")
+-  endif()
+-else()
+-  if(UNIX)
+-    set(ROCM_PATH /opt/rocm)
+-  else() # Win32
+-    set(ROCM_PATH C:/opt/rocm)
+-  endif()
+-  if(NOT EXISTS ${ROCM_PATH})
+-    message(STATUS
+-        "ROCM_PATH environment variable is not set and ${ROCM_PATH} does not exist.\n"
+-        "Building without ROCm support.")
+-    return()
+-  endif()
+-endif()
+-
+-if(NOT DEFINED ENV{ROCM_INCLUDE_DIRS})
+-  set(ROCM_INCLUDE_DIRS ${ROCM_PATH}/include)
+-else()
+-  set(ROCM_INCLUDE_DIRS $ENV{ROCM_INCLUDE_DIRS})
+-endif()
+-
+-# MAGMA_HOME
+-if(NOT DEFINED ENV{MAGMA_HOME})
+-  set(MAGMA_HOME ${ROCM_PATH}/magma)
+-  set(ENV{MAGMA_HOME} ${ROCM_PATH}/magma)
+-else()
+-  set(MAGMA_HOME $ENV{MAGMA_HOME})
+-endif()
+-
+-# MIOpen isn't a part of HIP-SDK for Windows and hence, may have a different
+-# installation directory.
+-if(WIN32)
+-  if(NOT DEFINED ENV{MIOPEN_PATH})
+-    set(miopen_DIR C:/opt/miopen/lib/cmake/miopen)
+-  else()
+-    set(miopen_DIR $ENV{MIOPEN_PATH}/lib/cmake/miopen)
+-  endif()
+-endif()
+-
+-torch_hip_get_arch_list(PYTORCH_ROCM_ARCH)
+-if(PYTORCH_ROCM_ARCH STREQUAL "")
+-  message(FATAL_ERROR "No GPU arch specified for ROCm build. Please use PYTORCH_ROCM_ARCH environment variable to specify GPU archs to build for.")
+-endif()
+-message("Building PyTorch for GPU arch: ${PYTORCH_ROCM_ARCH}")
+-
+-# Add HIP to the CMAKE Module Path
+-# needed because the find_package call to this module uses the Module mode search
+-# https://cmake.org/cmake/help/latest/command/find_package.html#search-modes
+-if(UNIX)
+-  set(CMAKE_MODULE_PATH ${ROCM_PATH}/lib/cmake/hip ${CMAKE_MODULE_PATH})
+-else() # Win32
+-  set(CMAKE_MODULE_PATH ${ROCM_PATH}/cmake/ ${CMAKE_MODULE_PATH})
+-endif()
+-
+-# Add ROCM_PATH to CMAKE_PREFIX_PATH, needed because the find_package
+-# call to individual ROCM components uses the Config mode search
+-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
+-
+-macro(find_package_and_print_version PACKAGE_NAME)
+-  find_package("${PACKAGE_NAME}" ${ARGN})
+-  message("${PACKAGE_NAME} VERSION: ${${PACKAGE_NAME}_VERSION}")
+-endmacro()
+-
+-# Find the HIP Package
+-# MODULE argument is added for clarity that CMake is searching
+-# for FindHIP.cmake in Module mode
+-find_package_and_print_version(HIP 1.0 MODULE)
+-
+-if(HIP_FOUND)
+-  set(PYTORCH_FOUND_HIP TRUE)
+-
+-  # Find ROCM version for checks
+-  if(UNIX)
+-    set(ROCM_VERSION_HEADER_PATH ${ROCM_INCLUDE_DIRS}/rocm-core/rocm_version.h)
+-  else()
+-    set(ROCM_VERSION_HEADER_PATH ${ROCM_INCLUDE_DIRS}/hip/hip_version.h)
+-  endif()
+-  get_filename_component(ROCM_HEADER_NAME ${ROCM_VERSION_HEADER_PATH} NAME)
++macro(pytorch_load_hip)
++  find_package(hip REQUIRED CONFIG)
++  message(STATUS "hip version: ${hip_VERSION}")
++  find_package(amd_comgr REQUIRED)
++  message(STATUS "amd_comgr version: ${amd_comgr_VERSION}")
++  find_package(rocrand REQUIRED)
++  message(STATUS "rocrand version: ${rocrand_VERSION}")
++  find_package(hiprand REQUIRED)
++  message(STATUS "hiprand version: ${hiprand_VERSION}")
++  find_package(rocblas REQUIRED)
++  message(STATUS "rocblas version: ${rocblas_VERSION}")
++  find_package(hipblas REQUIRED)
++  message(STATUS "hipblas_VERSION: ${hipblas_VERSION}")
++  find_package(miopen REQUIRED)
++  message(STATUS "miopen version: ${miopen_VERSION}")
++  find_package(hipfft REQUIRED)
++  message(STATUS "hipfft version: ${hipfft_VERSION}")
++  find_package(hipsparse REQUIRED)
++  message(STATUS "hipsparse version: ${hipsparse_VERSION}")
++  find_package(rocprim REQUIRED)
++  message(STATUS "rocprim version: ${rocprim_VERSION}")
++  find_package(hipcub REQUIRED)
++  message(STATUS "hipcub version: ${hipcub_VERSION}")
++  find_package(rocthrust REQUIRED)
++  message(STATUS "rocthrust version: ${rocthrust_VERSION}")
++  find_package(hipsolver REQUIRED)
++  message(STATUS "hipsolver versio: ${hipsolver_VERSION}")
+ 
+-  if(EXISTS ${ROCM_VERSION_HEADER_PATH})
+-    set(ROCM_HEADER_FILE ${ROCM_VERSION_HEADER_PATH})
++  if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
++    message(WARNING "Work around hiprtc cmake failure for cmake >= 4")
++    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
++    find_package(hiprtc REQUIRED)
++    unset(CMAKE_POLICY_VERSION_MINIMUM)
+   else()
+-    message(FATAL_ERROR "********************* ${ROCM_HEADER_NAME} could not be found ******************\n")
++    find_package(hiprtc REQUIRED)
+   endif()
+-
+-  # Read the ROCM headerfile into a variable
+-  file(READ ${ROCM_HEADER_FILE} ROCM_HEADER_CONTENT)
+-
+-  # Since Windows currently supports only a part of ROCm and names it HIP-SDK,
+-  # we need to refer to the HIP-SDK equivalents of entities existing in ROCm lib.
+-  if(UNIX)
+-    set(ROCM_LIB_NAME "ROCM")
+-  else() # Win32
+-    set(ROCM_LIB_NAME "HIP")
+-  endif()
+-  # Below we use a RegEx to find ROCM version numbers.
+-  # Note that CMake does not support \s for blank space. That is
+-  # why in the regular expressions below we have a blank space in
+-  # the square brackets.
+-  # There are three steps:
+-  # 1. Match regular expression
+-  # 2. Strip the non-numerical part of the string
+-  # 3. Strip leading and trailing spaces
+-
+-  string(REGEX MATCH "${ROCM_LIB_NAME}_VERSION_MAJOR[ ]+[0-9]+" TEMP1 ${ROCM_HEADER_CONTENT})
+-  string(REPLACE "${ROCM_LIB_NAME}_VERSION_MAJOR" "" TEMP2 ${TEMP1})
+-  string(STRIP ${TEMP2} ROCM_VERSION_DEV_MAJOR)
+-  string(REGEX MATCH "${ROCM_LIB_NAME}_VERSION_MINOR[ ]+[0-9]+" TEMP1 ${ROCM_HEADER_CONTENT})
+-  string(REPLACE "${ROCM_LIB_NAME}_VERSION_MINOR" "" TEMP2 ${TEMP1})
+-  string(STRIP ${TEMP2} ROCM_VERSION_DEV_MINOR)
+-  string(REGEX MATCH "${ROCM_LIB_NAME}_VERSION_PATCH[ ]+[0-9]+" TEMP1 ${ROCM_HEADER_CONTENT})
+-  string(REPLACE "${ROCM_LIB_NAME}_VERSION_PATCH" "" TEMP2 ${TEMP1})
+-  string(STRIP ${TEMP2} ROCM_VERSION_DEV_PATCH)
++  message(STATUS "hiprtc version: ${hiprtc_VERSION}")
++
++  # Original version made these UNIX-only.
++  find_package(rccl REQUIRED)
++  message(STATUS "rccl version: ${rccl_VERSION}")
++  find_package(hsa-runtime64 REQUIRED)
++  message(STATUS "hsa-runtime64 version: ${hsa-runtime64_VERSION}")
++  find_package(hipblaslt REQUIRED)
++  message(STATUS "hipblaslt version: ${hipblaslt_VERSION}")
++
++  # Extract ROCM version parts from the hip package version.
++  string(REPLACE "." ";" ROCM_VERSION_PARTS "${hip_VERSION}")
++  list(GET ROCM_VERSION_PARTS 0 ROCM_VERSION_DEV_MAJOR)
++  list(GET ROCM_VERSION_PARTS 1 ROCM_VERSION_DEV_MINOR)
++  list(GET ROCM_VERSION_PARTS 2 ROCM_VERSION_DEV_PATCH)
++  set(ROCM_VERSION "${ROCM_VERSION_DEV_MAJOR}.${ROCM_VERSION_DEV_MINOR}.${ROCM_VERSION_DEV_PATCH}")
++
++  message(STATUS "\n***** ROCm version: ****\n")
++  message(STATUS "  ROCM_VERSION: ${ROCM_VERSION}")
++  message(STATUS "  ROCM_VERSION_DEV_MAJOR: ${ROCM_VERSION_DEV_MAJOR}")
++  message(STATUS "  ROCM_VERSION_DEV_MINOR: ${ROCM_VERSION_DEV_MINOR}")
++  message(STATUS "  ROCM_VERSION_DEV_PATCH: ${ROCM_VERSION_DEV_PATCH}")
++  message(STATUS "  HIP_VERSION_MAJOR: ${ROCM_VERSION_DEV_MAJOR}")
++  message(STATUS "  HIP_VERSION_MINOR: ${ROCM_VERSION_DEV_MINOR}")
+ 
+   # Create ROCM_VERSION_DEV_INT which is later used as a preprocessor macros
+   set(ROCM_VERSION_DEV "${ROCM_VERSION_DEV_MAJOR}.${ROCM_VERSION_DEV_MINOR}.${ROCM_VERSION_DEV_PATCH}")
+   math(EXPR ROCM_VERSION_DEV_INT "(${ROCM_VERSION_DEV_MAJOR}*10000) + (${ROCM_VERSION_DEV_MINOR}*100) + ${ROCM_VERSION_DEV_PATCH}")
+-
+-  message("\n***** ROCm version from ${ROCM_HEADER_NAME} ****\n")
+-  message("ROCM_VERSION_DEV: ${ROCM_VERSION_DEV}")
+-  message("ROCM_VERSION_DEV_MAJOR: ${ROCM_VERSION_DEV_MAJOR}")
+-  message("ROCM_VERSION_DEV_MINOR: ${ROCM_VERSION_DEV_MINOR}")
+-  message("ROCM_VERSION_DEV_PATCH: ${ROCM_VERSION_DEV_PATCH}")
+-  message("ROCM_VERSION_DEV_INT:   ${ROCM_VERSION_DEV_INT}")
+-
+-  math(EXPR TORCH_HIP_VERSION "(${HIP_VERSION_MAJOR} * 100) + ${HIP_VERSION_MINOR}")
+-  message("HIP_VERSION_MAJOR: ${HIP_VERSION_MAJOR}")
+-  message("HIP_VERSION_MINOR: ${HIP_VERSION_MINOR}")
+-  message("TORCH_HIP_VERSION: ${TORCH_HIP_VERSION}")
+-
+-  # Find ROCM components using Config mode
+-  # These components will be searced for recursively in ${ROCM_PATH}
+-  message("\n***** Library versions from cmake find_package *****\n")
+-  find_package_and_print_version(hip REQUIRED CONFIG)
+-  find_package_and_print_version(amd_comgr REQUIRED)
+-  find_package_and_print_version(rocrand REQUIRED)
+-  find_package_and_print_version(hiprand REQUIRED)
+-  find_package_and_print_version(rocblas REQUIRED)
+-  find_package_and_print_version(hipblas REQUIRED)
+-  find_package_and_print_version(miopen REQUIRED)
+-  find_package_and_print_version(hipfft REQUIRED)
+-  find_package_and_print_version(hipsparse REQUIRED)
+-  find_package_and_print_version(rocprim REQUIRED)
+-  find_package_and_print_version(hipcub REQUIRED)
+-  find_package_and_print_version(rocthrust REQUIRED)
+-  find_package_and_print_version(hipsolver REQUIRED)
+-  # workaround cmake 4 build issue
+-  if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+-    message(WARNING "Work around hiprtc cmake failure for cmake >= 4")
+-    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+-    find_package_and_print_version(hiprtc REQUIRED)
+-    unset(CMAKE_POLICY_VERSION_MINIMUM)
++  math(EXPR TORCH_HIP_VERSION "(${ROCM_VERSION_DEV_MAJOR} * 100) + ${ROCM_VERSION_DEV_MINOR}")
++
++  message(STATUS "  ROCM_VERSION_DEV_INT:   ${ROCM_VERSION_DEV_INT}")
++  message(STATUS "  TORCH_HIP_VERSION: ${TORCH_HIP_VERSION}")
++
++  # Locate the ROCM_ROCTX_LIB that kineto depends on. This is either part of
++  # roctracer (deprecated) and located with find_library(roctx64) or it is
++  # part of rocprofiler-sdk (aka. rocprofiler v3) as the rocprofiler-sdk-tx
++  # library.
++  # TODO: This isn't quite right and needs to mate up with whether kineto
++  # depends on roctracer or rocprofiler-sdk. The coupling here is fragile and
++  # needs to be reworked.
++  find_package(rocprofiler-sdk-roctx)
++  if(rocprofiler-sdk-roctx_FOUND)
++    message(STATUS "rocprofiler-sdk-roctx version: ${rocprofiler-sdk-roctx_VERSION} found (will use instead of roctracer)")
++    set(ROCM_ROCTX_LIB rocprofiler-sdk-roctx::rocprofiler-sdk-roctx-shared-library)
+   else()
+-    find_package_and_print_version(hiprtc REQUIRED)
++    find_library(ROCM_ROCTX_LIB roctx64)
++    if(NOT ROCM_ROCTX_LIB)
++      cmake(WARNING "Neither rocprofiler-sdk nor libroctx64.so was found: This may result in errors if components rely on it")
++    endif()
+   endif()
+-  find_package_and_print_version(hipblaslt REQUIRED)
+ 
+-  if(UNIX)
+-    find_package_and_print_version(rccl)
+-    find_package_and_print_version(hsa-runtime64 REQUIRED)
++  # PyTorch makes some use of hip_add_library and friends, which are only
++  # available in the legacy FindHIP.cmake finder module. This is bundled in the
++  # same CMAKE_PREFIX_PATH as is used for the regular packages, but is put in
++  # a different place on Linux vs Windows for reasons that are lost to time:
++  #   Linux: lib/cmake/hip/FindHIP.cmake
++  #   Windows: lib/cmake/FindHIP.cmake
++  # While we could ask the user to provide an explicit CMAKE_MODULE_PATH, we
++  # do some path munging in an attempt to make this legacy hiccup transparent
++  # to most. If this mechanism ever breaks, the fix is to configure explicitly
++  # with CMAKE_MODULE_PATH pointing at the directory in the ROCM SDK that
++  # contains FindHIP.cmake.
++  function(find_rocm_sdk_module_path)
++    set(hip_lib_dir "${hip_LIB_INSTALL_DIR}")
++    foreach(candidate_path "${hip_lib_dir}/cmake" "${hip_lib_dir}/cmake/hip")
++      if(EXISTS "${candidate_path}/FindHIP.cmake")
++        list(PREPEND CMAKE_MODULE_PATH "${candidate_path}")
++        message(STATUS "Legacy FindHIP.cmake module found in ${candidate_path}")
++        set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
++        return()
++      endif()
++    endforeach()
+ 
+-    # roctx is part of roctracer
+-    find_library(ROCM_ROCTX_LIB roctx64 HINTS ${ROCM_PATH}/lib)
++    message(STATUS "Could not locate legacy FindHIP.cmake: You may need to set CMAKE_MODULE_PATH explicitly to its location")
++  endfunction()
++  find_rocm_sdk_module_path()
++  find_package(HIP 1.0 MODULE REQUIRED)
+ 
+-    set(PROJECT_RANDOM_BINARY_DIR "${PROJECT_BINARY_DIR}")
++  set(HIP_NEW_TYPE_ENUMS ON)
++  set(PYTORCH_FOUND_HIP ON)
++endmacro()
+ 
+-    if(ROCM_VERSION_DEV VERSION_GREATER_EQUAL "5.7.0")
+-      # check whether hipblaslt provides HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT
+-      set(file "${PROJECT_BINARY_DIR}/hipblaslt_test_vec_ext.cc")
+-      file(WRITE ${file} ""
+-        "#define LEGACY_HIPBLAS_DIRECT\n"
+-        "#include <hipblaslt/hipblaslt.h>\n"
+-        "int main() {\n"
+-        "    hipblasLtMatmulDescAttributes_t attr = HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT;\n"
+-        "    return 0;\n"
+-        "}\n"
+-        )
+-      try_compile(hipblaslt_compile_result_vec_ext ${PROJECT_RANDOM_BINARY_DIR} ${file}
+-        CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${ROCM_INCLUDE_DIRS}"
+-        COMPILE_DEFINITIONS -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
+-        OUTPUT_VARIABLE hipblaslt_compile_output)
+-      if(hipblaslt_compile_result_vec_ext)
+-        set(HIPBLASLT_VEC_EXT ON)
+-        #message("hipblaslt is using scale pointer vec ext: ${hipblaslt_compile_output}")
+-        message("hipblaslt is using scale pointer vec ext")
+-      else()
+-        set(HIPBLASLT_VEC_EXT OFF)
+-        message("hipblaslt is NOT using scale pointer vec ext: ${hipblaslt_compile_output}")
+-        #message("hipblaslt is NOT using scale pointer vec ext")
+-      endif()
+-    endif()
+-  endif()
++message(STATUS "___ROCM")
++set(PYTORCH_FOUND_HIP FALSE)
++set(HIP_PLATFORM "amd")
++find_package(hip CONFIG)
++if(hip_FOUND)
++  pytorch_load_hip()
+ endif()
+-- 
+2.49.0
+

--- a/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
+++ b/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
@@ -1,0 +1,49 @@
+From dc6344fd018e3031775e5cc7ba8db3080ad736d6 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Wed, 19 Feb 2025 17:14:59 -0800
+Subject: [PATCH 2/3] Generate composable_kernel ck/config.h as part of main
+ build.
+
+Without this, the ck/config.h comes from somewhere, most probably a ROCM SDK that has it installed as a sibling to the HIP headers. Not all ROCM SDKs include this, and even so, it is dangerous to have a sheared header dependency like this.
+---
+ aten/src/ATen/CMakeLists.txt | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
+index f0868ea048..293fa8ace3 100644
+--- a/aten/src/ATen/CMakeLists.txt
++++ b/aten/src/ATen/CMakeLists.txt
+@@ -311,9 +311,30 @@ if(USE_CUDA)
+ endif()
+ 
+ if(USE_ROCM)
++  # NOTE: The PyTorch build does not actually add_subdirectory 
++  # third_party/composable_kernel or use it as a CMake library. What is used
++  # is header only, so this should be ok, except that the CMake build generates
++  # a ck/config.h. We just do that part here. Without this, the ck.h from the
++  # ROCM SDK may get accidentally used instead.
++  function(_pytorch_rocm_generate_ck_conf)
++    set(CK_ENABLE_INT8 "ON")
++    set(CK_ENABLE_FP16 "ON")
++    set(CK_ENABLE_FP32 "ON")
++    set(CK_ENABLE_FP64 "ON")
++    set(CK_ENABLE_BF16 "ON")
++    set(CK_ENABLE_FP8 "ON")
++    set(CK_ENABLE_BF8 "ON")
++    configure_file(
++      "${Torch_SOURCE_DIR}/third_party/composable_kernel/include/ck/config.h.in"
++      "${CMAKE_CURRENT_BINARY_DIR}/composable_kernel/ck/config.h"
++      )
++  endfunction()
+   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/hip)
+   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/composable_kernel/include)
+   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/composable_kernel/library/include)
++  list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_BINARY_DIR}/composable_kernel)
++  _pytorch_rocm_generate_ck_conf()
++
+   # Next two lines are needed because TunableOp uses third-party/fmt
+   list(APPEND ATen_HIP_INCLUDE $<TARGET_PROPERTY:fmt::fmt-header-only,INTERFACE_INCLUDE_DIRECTORIES>)
+   list(APPEND ATen_HIP_DEPENDENCY_LIBS fmt::fmt-header-only)
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
+++ b/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
@@ -1,0 +1,113 @@
+From b3b927ac4685a548dba412cf38932d276380e057 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Mon, 31 Mar 2025 18:54:56 +0100
+Subject: [PATCH] TEMPORARY: Manually disable roctx until compatibility with
+ rocprofv3 is established.
+
+---
+ torch/csrc/cuda/shared/nvtx.cpp    | 21 +++++++++++++--------
+ torch/csrc/profiler/stubs/cuda.cpp | 11 ++++++++---
+ 2 files changed, 21 insertions(+), 11 deletions(-)
+
+diff --git a/torch/csrc/cuda/shared/nvtx.cpp b/torch/csrc/cuda/shared/nvtx.cpp
+index 40e9821389..0ce2dd34b5 100644
+--- a/torch/csrc/cuda/shared/nvtx.cpp
++++ b/torch/csrc/cuda/shared/nvtx.cpp
+@@ -1,13 +1,14 @@
+ #ifdef _WIN32
+ #include <wchar.h> // _wgetenv for nvtx
+ #endif
+-
+ #ifndef ROCM_ON_WINDOWS
++/* TODO: Enable when rocprofv3 compat is available.
+ #ifdef TORCH_CUDA_USE_NVTX3
+ #include <roctracer/roctx.h>
+ #else // TORCH_CUDA_USE_NVTX3
+ #include <roctracer/roctx.h>
+ #endif // TORCH_CUDA_USE_NVTX3
++*/
+ #else // ROCM_ON_WINDOWS
+ #include <c10/util/Exception.h>
+ #endif // ROCM_ON_WINDOWS
+@@ -25,7 +26,9 @@ struct RangeHandle {
+ 
+ static void device_callback_range_end(void* userData) {
+   RangeHandle* handle = ((RangeHandle*)userData);
+-  roctxRangeStop(handle->id);
++  // TODO: Enable when rocprofv3 compat is available.
++  // handle->id = roctxRangeStartA(handle->msg);
++  //roctxRangeStop(handle->id);
+   free((void*)handle->msg);
+   free((void*)handle);
+ }
+@@ -37,7 +40,9 @@ static void device_nvtxRangeEnd(void* handle, std::intptr_t stream) {
+ 
+ static void device_callback_range_start(void* userData) {
+   RangeHandle* handle = ((RangeHandle*)userData);
+-  handle->id = roctxRangeStartA(handle->msg);
++  // TODO: Enable when rocprofv3 compat is available.
++  //handle->id = roctxRangeStartA(handle->msg);
++  handle->id = 0;
+ }
+ 
+ static void* device_nvtxRangeStart(const char* msg, std::intptr_t stream) {
+@@ -59,11 +64,11 @@ void initNvtxBindings(PyObject* module) {
+ #else
+   auto nvtx = m.def_submodule("_nvtx", "libNvToolsExt.so bindings");
+ #endif
+-  nvtx.def("rangePushA", roctxRangePushA);
+-  nvtx.def("rangePop", roctxRangePop);
+-  nvtx.def("rangeStartA", roctxRangeStartA);
+-  nvtx.def("rangeEnd", roctxRangeStop);
+-  nvtx.def("markA", roctxMarkA);
++  nvtx.def("rangePushA", [](const char*) {} /*roctxRangePushA*/);
++  nvtx.def("rangePop", []() { } /*roctxRangePop*/);
++  nvtx.def("rangeStartA", [](const char*) { return 0; }/*roctxRangeStartA*/);
++  nvtx.def("rangeEnd", []() {}/*roctxRangeStop*/);
++  nvtx.def("markA", [](const char*) {}/*roctxMarkA */);
+   nvtx.def("deviceRangeStart", device_nvtxRangeStart);
+   nvtx.def("deviceRangeEnd", device_nvtxRangeEnd);
+ }
+diff --git a/torch/csrc/profiler/stubs/cuda.cpp b/torch/csrc/profiler/stubs/cuda.cpp
+index 37364dfc93..0ed35059a1 100644
+--- a/torch/csrc/profiler/stubs/cuda.cpp
++++ b/torch/csrc/profiler/stubs/cuda.cpp
+@@ -1,11 +1,13 @@
+ #include <sstream>
+ 
+ #ifndef ROCM_ON_WINDOWS
++/* TODO: Enable when rocprofv3 compat is in TheRock
+ #ifdef TORCH_CUDA_USE_NVTX3
+ #include <roctracer/roctx.h>
+ #else
+ #include <roctracer/roctx.h>
+ #endif
++*/
+ #else // ROCM_ON_WINDOWS
+ #include <c10/util/Exception.h>
+ #endif // ROCM_ON_WINDOWS
+@@ -76,15 +78,18 @@ struct CUDAMethods : public ProfilerStubs {
+ 
+ #ifndef ROCM_ON_WINDOWS
+   void mark(const char* name) const override {
+-    ::roctxMark(name);
++    // TODO: Enable when rocprofv3 compat is available.
++    // ::roctxMark(name);
+   }
+ 
+   void rangePush(const char* name) const override {
+-    ::roctxRangePushA(name);
++    // TODO: Enable when rocprofv3 compat is available.
++    // ::roctxRangePushA(name);
+   }
+ 
+   void rangePop() const override {
+-    ::roctxRangePop();
++    // TODO: Enable when rocprofv3 compat is available.
++    // ::roctxRangePop();
+   }
+ #else // ROCM_ON_WINDOWS
+   static void printUnavailableWarning() {
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0004-ROCm-enable-hipBLASLt-for-gfx-1102-1150-1151-1201.patch
+++ b/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0004-ROCm-enable-hipBLASLt-for-gfx-1102-1150-1151-1201.patch
@@ -1,0 +1,28 @@
+From d69bdf92bd872ce622ef12f6b927de3c1c128174 Mon Sep 17 00:00:00 2001
+From: Scott Tsai <scottt.tw@gmail.com>
+Date: Sun, 23 Mar 2025 13:16:25 +0800
+Subject: [PATCH] enable hipBLASLt for gfx{1102,1150,1151,1201}
+
+Pytorch upstream should integrate this once the following change
+is in a ROCm release:
+https://github.com/ROCm/hipBLASLt/pull/1766
+---
+ aten/src/ATen/Context.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/aten/src/ATen/Context.cpp b/aten/src/ATen/Context.cpp
+index f598fc3a39..e79144fcb0 100644
+--- a/aten/src/ATen/Context.cpp
++++ b/aten/src/ATen/Context.cpp
+@@ -332,7 +332,7 @@ at::BlasBackend Context::blasPreferredBackend() {
+       static const std::vector<std::string> archs = {
+           "gfx90a", "gfx942",
+ #if ROCM_VERSION >= 60300
+-          "gfx1100", "gfx1101", "gfx1200", "gfx1201"
++          "gfx1100", "gfx1101", "gfx1150", "gfx1151", "gfx1200", "gfx1201"
+ #endif
+ #if ROCM_VERSION >= 60500
+           "gfx950"
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0005-Add-gfx1150-gfx1151-to-hipblaslt-support-list-in-Bla.patch
+++ b/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0005-Add-gfx1150-gfx1151-to-hipblaslt-support-list-in-Bla.patch
@@ -1,0 +1,39 @@
+From da114eb37162fcba198a4edb2869628ad234ca25 Mon Sep 17 00:00:00 2001
+From: Aaryaman Vasishta <jem456.vasishta@gmail.com>
+Date: Mon, 31 Mar 2025 19:27:48 +0100
+Subject: Add gfx1150/gfx1151 to hipblaslt support list in Blas.cpp
+
+---
+ aten/src/ATen/native/cuda/Blas.cpp | 2 +-
+ aten/src/ATen/native/hip/Blas.cpp  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/aten/src/ATen/native/cuda/Blas.cpp b/aten/src/ATen/native/cuda/Blas.cpp
+index 28936cc034..592c04693c 100644
+--- a/aten/src/ATen/native/cuda/Blas.cpp
++++ b/aten/src/ATen/native/cuda/Blas.cpp
+@@ -259,7 +259,7 @@ static bool isSupportedHipLtROCmArch(int index) {
+     static const std::vector<std::string> archs = {
+         "gfx90a", "gfx942",
+ #if ROCM_VERSION >= 60300
+-        "gfx1100", "gfx1101", "gfx1200", "gfx1201"
++        "gfx1100", "gfx1101", "gfx1150", "gfx1151", "gfx1200", "gfx1201"
+ #endif
+ #if ROCM_VERSION >= 60500
+         "gfx950"
+diff --git a/aten/src/ATen/native/hip/Blas.cpp b/aten/src/ATen/native/hip/Blas.cpp
+index 467ff69892..576bd7f72c 100644
+--- a/aten/src/ATen/native/hip/Blas.cpp
++++ b/aten/src/ATen/native/hip/Blas.cpp
+@@ -260,7 +260,7 @@ static bool isSupportedHipLtROCmArch(int index) {
+     static const std::vector<std::string> archs = {
+         "gfx90a", "gfx942",
+ #if ROCM_VERSION >= 60300
+-        "gfx1100", "gfx1101", "gfx1200", "gfx1201"
++        "gfx1100", "gfx1101", "gfx1150", "gfx1151", "gfx1200", "gfx1201"
+ #endif
+ #if ROCM_VERSION >= 60500
+         "gfx950"
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0006-Support-gfx1151-in-aotriton.patch
+++ b/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0006-Support-gfx1151-in-aotriton.patch
@@ -1,0 +1,67 @@
+From e4923146cbdf160c9ea292f115e147944a2a0768 Mon Sep 17 00:00:00 2001
+From: Aaryaman Vasishta <jem456.vasishta@gmail.com>
+Date: Mon, 31 Mar 2025 19:27:59 +0100
+Subject: [PATCH] Support gfx1151 in aotriton
+
+---
+ cmake/External/aotriton.cmake | 6 ++++--
+ cmake/public/LoadHIP.cmake    | 6 ++++++
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/External/aotriton.cmake b/cmake/External/aotriton.cmake
+index 2678cfde3c..2ee7345d9d 100644
+--- a/cmake/External/aotriton.cmake
++++ b/cmake/External/aotriton.cmake
+@@ -2,6 +2,7 @@ macro(get_target_gpus_from_pytorch target_gpus)
+    set(gfx90a_key MI200)
+    set(gfx942_key MI300X)
+    set(gfx1100_key Navi31)
++   set(gfx1151_key Navi3.5)
+ 
+    foreach(X IN LISTS PYTORCH_ROCM_ARCH)
+        set(key ${X})
+@@ -33,7 +34,7 @@ if(NOT __AOTRITON_INCLUDED)
+       "rocm6.3"
+       "rocm6.4"
+       )
+-  set(__AOTRITON_CI_COMMIT "b388d223d8c7213545603e00f6f3148c54d1f525")
++  set(__AOTRITON_CI_COMMIT "00eee4bfb0b1d8eb1ea779865bed1fb92d9b79be")
+   set(__AOTRITON_SHA256_LIST
+       "08d84f96f4c984179f80f517c0431c7511ee26bb0ce9bd05a827573ddd78cc79"  # rocm6.2
+       "9094d59717e7e6eace9126ca100dd0e86510f07fc6c3a349569fc4e2d9056604"  # rocm6.3
+@@ -53,7 +54,7 @@ if(NOT __AOTRITON_INCLUDED)
+     set(target_gpus "")
+     get_target_gpus_from_pytorch(target_gpus)
+     ExternalProject_Add(aotriton_external
+-      GIT_REPOSITORY https://github.com/ROCm/aotriton.git
++      GIT_REPOSITORY https://github.com/scottt/aotriton.git
+       GIT_TAG ${__AOTRITON_CI_COMMIT}
+       PREFIX ${__AOTRITON_EXTERN_PREFIX}
+       INSTALL_DIR ${__AOTRITON_INSTALL_DIR}
+@@ -64,6 +65,7 @@ if(NOT __AOTRITON_INCLUDED)
+       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+       -DAOTRITON_NO_PYTHON=ON
+       -DAOTRITON_NO_SHARED=OFF
++      -DHIP_PLATFORM=amd
+       # CONFIGURE_COMMAND ""
+       BUILD_COMMAND ""  # No build, install command will repeat the build process due to problems in the build system.
+       BUILD_BYPRODUCTS "${__AOTRITON_INSTALL_DIR}/lib/libaotriton_v2.so"
+diff --git a/cmake/public/LoadHIP.cmake b/cmake/public/LoadHIP.cmake
+index da2beeba59..09fb8e99aa 100644
+--- a/cmake/public/LoadHIP.cmake
++++ b/cmake/public/LoadHIP.cmake
+@@ -113,5 +113,11 @@ set(PYTORCH_FOUND_HIP FALSE)
+ set(HIP_PLATFORM "amd")
+ find_package(hip CONFIG)
+ if(hip_FOUND)
++  # Apparently, aotriton compilation breaks if PYTORCH_ROCM_ARCH isn't converted to a list here.
++  torch_hip_get_arch_list(PYTORCH_ROCM_ARCH)
++  if(PYTORCH_ROCM_ARCH STREQUAL "")
++    message(FATAL_ERROR "No GPU arch specified for ROCm build. Please use PYTORCH_ROCM_ARCH environment variable to specify GPU archs to build for.")
++  endif()
++  message("Building PyTorch for GPU arch: ${PYTORCH_ROCM_ARCH}")
+   pytorch_load_hip()
+ endif()
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/v2.7.0/third_party/composable_kernel/base/0001-ck.hpp-define-CK_BUFFER_RESOURCE_3RD_DWORD-for-gfx11.patch
+++ b/external-builds/pytorch/patches/v2.7.0/third_party/composable_kernel/base/0001-ck.hpp-define-CK_BUFFER_RESOURCE_3RD_DWORD-for-gfx11.patch
@@ -1,0 +1,27 @@
+From 8cb4274968c8b2f8b0a66db1d38b17904f5d3424 Mon Sep 17 00:00:00 2001
+From: Scott Tsai <scottt.tw@gmail.com>
+Date: Sat, 22 Mar 2025 06:11:03 +0800
+Subject: [PATCH 2/2] ck.hpp: define CK_BUFFER_RESOURCE_3RD_DWORD for gfx1151
+
+Define CK_BUFFER_RESOURCE_3RD_DWORD with the same value for gfx110x and
+gfx115x (0x31004000) following https://github.com/ROCm/hipBLASLt/pull/1766
+---
+ include/ck/ck.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/ck/ck.hpp b/include/ck/ck.hpp
+index 999eb02..3ded15c 100644
+--- a/include/ck/ck.hpp
++++ b/include/ck/ck.hpp
+@@ -68,7 +68,7 @@ CK_DECLARE_ENV_VAR_BOOL(CK_LOGGING)
+ #define __gfx103__
+ #endif
+ #if defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || \
+-    defined(__gfx1103__) || defined(__gfx11_generic__)
++    defined(__gfx1103__) || defined(__gfx1150__) || defined(__gfx1151__) || defined(__gfx11_generic__)
+ #define __gfx11__
+ #endif
+ #if defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx12_generic__)
+-- 
+2.48.1
+

--- a/external-builds/pytorch/patches/v2.7.0/third_party/fbgemm/hipified/0001-UtilsAvx512.cpp-fix-r-may-be-used-uninitialized-for-.patch
+++ b/external-builds/pytorch/patches/v2.7.0/third_party/fbgemm/hipified/0001-UtilsAvx512.cpp-fix-r-may-be-used-uninitialized-for-.patch
@@ -1,0 +1,31 @@
+From 23831177a4308fb18951537a0b3948e5547da02d Mon Sep 17 00:00:00 2001
+From: Scott Tsai <scottt.tw@gmail.com>
+Date: Sat, 22 Mar 2025 06:17:51 +0800
+Subject: [PATCH] UtilsAvx512.cpp: fix r may be used uninitialized for gcc14
+
+This version of fbgemm uses `-Werror` thus the warning breaks the build.
+This is also reported upstream by others as https://github.com/pytorch/pytorch/issues/129358
+
+ROCm/TheRock is building pytorch in Ubuntu 22.04 but Fedora 41 has a
+newer gcc and would run into this bug.
+---
+ src/UtilsAvx512.cc | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/UtilsAvx512.cc b/src/UtilsAvx512.cc
+index cf00613d..c65eab87 100644
+--- a/src/UtilsAvx512.cc
++++ b/src/UtilsAvx512.cc
+@@ -920,6 +920,9 @@ static inline void transpose_contiguous_16x2_block(
+     int64_t ld_dst,
+     int mrem = 16) {
+   __m512i r[2], d[2];
++  // Zero out r[] to avoid `may be used uninitialized` compilation error
++  r[0] = _mm512_setzero_si512();
++  r[1] = _mm512_setzero_si512();
+   int i = 0;
+   for (; (i + 1) * 16 <= mrem * 2; i++) {
+     // normal load
+-- 
+2.49.0
+


### PR DESCRIPTION
This change locally patches, configures and builds Pytorch to use hipBLASLt and aotriton for gfx1151 support
* Meant to be used with `AOTRITON_INSTALL_FROM_SOURCE=1` to build Pytorch with flash attention kernels

# Pytorch patches:
* [0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch](external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch)
Patch from @stellaraccident updated to Pytorch v2.7-rc10

* [0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch](external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch) and [0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch](external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch)
   Patches from  @stellaraccident. Originally for Pytorch v2.6. Unchanged except for the directory move to apply to Pytorch 2.7

* [0004-ROCm-enable-hipBLASLt-for-gfx-1102-1150-1151-1201.patch](external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0004-ROCm-enable-hipBLASLt-for-gfx-1102-1150-1151-1201.patch) and [0005-Add-gfx1150-gfx1151-to-hipblaslt-support-list-in-Bla.patch](external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0005-Add-gfx1150-gfx1151-to-hipblaslt-support-list-in-Bla.patch)
   Patches from @jammm and myself to enable use of hipBLASLt for gfx1151 in pytorch

* [0006-Support-gfx1151-in-aotriton.patch](external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0006-Support-gfx1151-in-aotriton.patch)
  Patch from @jammm  and myself to enable aotriton in Pytorch. Note that Pytorch uses `cmake`'s `ExternalProject_Add` mechanism for aotriton, so we point to a forked aotriton on Github instead of using local patches.
  *  The forked github.com/scottt/aotriton is based on aotriton-0.9.2 but I've opened separate PRs upstream againsta future aotriton-0.10.x here: https://github.com/ROCm/aotriton/pull/90, https://github.com/ROCm/aotriton/pull/91
  
# Pytorch third_party library patches:
* [third_party/composable_kernel/base/0001-ck.hpp-define-CK_BUFFER_RESOURCE_3RD_DWORD-for-gfx11.patch](external-builds/pytorch/patches/v2.7.0/third_party/composable_kernel/base/0001-ck.hpp-define-CK_BUFFER_RESOURCE_3RD_DWORD-for-gfx11.patch)
Pytorch's third_party directory contains a git submodule reference to https://github.com/ROCm/composable_kernel/blob/8086bbe3a78d931eb96fe12fdc014082e18d18d3/include/ck/ck.hpp
This patches it to define `CK_BUFFER_RESOURCE_3RD_DWORD` so it's the composable_kernel equivalent of https://github.com/ROCm/TheRock/blob/0dfb440f78917445a4dabb7887e547f74fb507cb/patches/amd-mainline/MIOpen/0002-Fix-build-for-gfx1151-gfx1036.patch#L32 and https://github.com/ROCm/TheRock/issues/434