### PR TITLE
Ignore if no machine available for release testing

### DIFF
--- a/.github/workflows/test_release_packages.yml
+++ b/.github/workflows/test_release_packages.yml
@@ -29,6 +29,8 @@ jobs:
 
 
   test_release_packages:
+    # If there is a test machine available
+    if: ${{ needs.generate_target_to_run.outputs.test_runs_on != '' }}
     runs-on: ${{ needs.generate_target_to_run.outputs.test_runs_on }}
     needs: generate_target_to_run
     permissions:


### PR DESCRIPTION
fixing [this issue](https://github.com/ROCm/TheRock/actions/runs/14619097334) where matrix doesn't have test machine available, don't run tests