### PR TITLE
Add fix for version_ref -  use `.find` instead of `.index`

### DIFF
--- a/external-builds/pytorch/ptbuild.py
+++ b/external-builds/pytorch/ptbuild.py
@@ -210,7 +210,7 @@ def apply_all_patches(root_repo_path: Path, patches_path: Path, patchset_name: s
 
 # pytorch_ref_to_patches_dir_name('2.7.0-rc9') -> '2.7.0'
 def pytorch_ref_to_patches_dir_name(version_ref: str) -> str:
-    pos = version_ref.index("-")
+    pos = version_ref.find("-")
     if pos != -1:
         return version_ref[:pos]
     return version_ref


### PR DESCRIPTION
Will do the testing first to build docker images.

Closes #454 