### PR TITLE
Adding missing libgfortran5 for test_release_packages

### DIFF
--- a/.github/workflows/test_release_packages.yml
+++ b/.github/workflows/test_release_packages.yml
@@ -63,11 +63,13 @@ jobs:
         with:
           python-version: 3.11
 
-      - name: Create Python venv
+      - name: Create Python venv and other dependencies
         run: |
           python -m venv ${VENV_DIR}
           source ${VENV_DIR}/bin/activate
           pip install -r requirements-test.txt
+          sudo apt install libgfortran5 -y
+          pip freeze
 
       - name: Run Sanity check
         if: '!cancelled()'


### PR DESCRIPTION
Test release packages needs libgfortran to test, causing [failures](https://github.com/ROCm/TheRock/actions/runs/14644086823/job/41093617845)