### PR TITLE
link correct version of hsa-runtime with c10_hip

### DIFF
--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
@@ -1,7 +1,7 @@
-From 2da1e65ba8b479efc656c633d899b5617107a61d Mon Sep 17 00:00:00 2001
+From 55fc80d889a2bd4894251c180a9cb5526f4099f4 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 17 Feb 2025 16:47:57 -0800
-Subject: [PATCH 1/5] Rework LoadHIP.cmake to be based purely on
+Subject: [PATCH 1/6] Rework LoadHIP.cmake to be based purely on
  CMAKE_PREFIX_PATH.
 
 * Eliminates dependence on `/opt/rocm` and path based heuristics.

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
@@ -1,7 +1,7 @@
-From 106542c653c52b50d408d6ae6589e3f18591d899 Mon Sep 17 00:00:00 2001
+From 50c04297b254e60c286be570e2f9600d8f938620 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Wed, 19 Feb 2025 17:14:59 -0800
-Subject: [PATCH 2/5] Generate composable_kernel ck/config.h as part of main
+Subject: [PATCH 2/6] Generate composable_kernel ck/config.h as part of main
  build.
 
 Without this, the ck/config.h comes from somewhere, most probably a ROCM SDK that has it installed as a sibling to the HIP headers. Not all ROCM SDKs include this, and even so, it is dangerous to have a sheared header dependency like this.

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
@@ -1,7 +1,7 @@
-From 519669d34dfaa980604f6014898f1ed4cb4d943a Mon Sep 17 00:00:00 2001
+From c3ea1cbe49ebdc1a39f1b652c177cfda59a93316 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Wed, 19 Feb 2025 17:16:27 -0800
-Subject: [PATCH 3/5] TEMPORARY: Manually disable roctx until compatibility
+Subject: [PATCH 3/6] TEMPORARY: Manually disable roctx until compatibility
  with rocprofv3 is established.
 
 ---

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0004-Pin-cmake-4-since-v4-broke-old-pytorch-builds.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0004-Pin-cmake-4-since-v4-broke-old-pytorch-builds.patch
@@ -1,7 +1,7 @@
-From 77a75ffce90524e6e5fafed0759d30b63a156286 Mon Sep 17 00:00:00 2001
+From 8305f036fcba8aadb986f008fb7151e35439d323 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Tue, 1 Apr 2025 14:52:15 -0700
-Subject: [PATCH 4/5] Pin cmake<4 since v4 broke old pytorch builds.
+Subject: [PATCH 4/6] Pin cmake<4 since v4 broke old pytorch builds.
 
 ---
  requirements.txt | 2 +-

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0005-Preload-rocm-sdk-binaries-if-available.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0005-Preload-rocm-sdk-binaries-if-available.patch
@@ -1,7 +1,7 @@
-From f177e4c066b796990b950d9739149dcba7070b37 Mon Sep 17 00:00:00 2001
+From 4c446b9ea5171a14e15ce17fbc58b05df5b29025 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Tue, 1 Apr 2025 18:49:42 -0700
-Subject: [PATCH 5/5] Preload rocm-sdk binaries if available.
+Subject: [PATCH 5/6] Preload rocm-sdk binaries if available.
 
 ---
  torch/__init__.py | 27 ++++++++++++++++++++++++++-

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0006-link-correct-version-of-hsa-runtime-with-c10_hip.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0006-link-correct-version-of-hsa-runtime-with-c10_hip.patch
@@ -1,0 +1,35 @@
+From 435c349d3323364862d8d37a6325fa19566204fa Mon Sep 17 00:00:00 2001
+From: Mika Laitio <mika.laitio@amd.com>
+Date: Tue, 29 Apr 2025 01:28:14 -0700
+Subject: [PATCH 6/6] link correct version of hsa-runtime with c10_hip
+
+link the version of hsa-runtime64 that is searched
+by LoadHIP.cmake instead of relying to it to be linked
+as an amdhip64 dependency without specifying the location.
+
+This fixes an error where the wrong version of library could
+be tried to be linked causing unresolved symbol errors.
+
+fixes: https://github.com/ROCm/TheRock/issues/474
+
+Signed-off-by: Mika Laitio <mika.laitio@amd.com>
+---
+ c10/hip/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/c10/hip/CMakeLists.txt b/c10/hip/CMakeLists.txt
+index f153030e79..a98ec6fa23 100644
+--- a/c10/hip/CMakeLists.txt
++++ b/c10/hip/CMakeLists.txt
+@@ -48,7 +48,7 @@ if(NOT BUILD_LIBTORCHLESS)
+   endif()
+ 
+   # ---[ Dependency of c10_hip
+-  target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::amdhip64)
++  target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::amdhip64 hsa-runtime64::hsa-runtime64)
+ 
+   target_include_directories(
+       c10_hip PUBLIC
+-- 
+2.43.0
+


### PR DESCRIPTION
link the version of hsa-runtime64 that is searched by LoadHIP.cmake instead of relying to it to be linked as an amdhip64 dependency without specifying the location.

This fixes an error where the wrong version of library could be tried to be linked causing unresolved symbol errors:

  TheRock/build/dist/rocm/lib/libamdhip64.so.6.5.25171-31afa624a:
  undefined reference tohsa_amd_vmem_map@ROCR_1'

Fixes: https://github.com/ROCm/TheRock/issues/474