### PR TITLE
link correct version of hsa-runtime with c10_hip on pytorch 2.6.0 and 2.7.0

### DIFF
--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
@@ -1,7 +1,7 @@
-From 2da1e65ba8b479efc656c633d899b5617107a61d Mon Sep 17 00:00:00 2001
+From 55fc80d889a2bd4894251c180a9cb5526f4099f4 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 17 Feb 2025 16:47:57 -0800
-Subject: [PATCH 1/5] Rework LoadHIP.cmake to be based purely on
+Subject: [PATCH 1/6] Rework LoadHIP.cmake to be based purely on
  CMAKE_PREFIX_PATH.
 
 * Eliminates dependence on `/opt/rocm` and path based heuristics.

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
@@ -1,7 +1,7 @@
-From 106542c653c52b50d408d6ae6589e3f18591d899 Mon Sep 17 00:00:00 2001
+From 50c04297b254e60c286be570e2f9600d8f938620 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Wed, 19 Feb 2025 17:14:59 -0800
-Subject: [PATCH 2/5] Generate composable_kernel ck/config.h as part of main
+Subject: [PATCH 2/6] Generate composable_kernel ck/config.h as part of main
  build.
 
 Without this, the ck/config.h comes from somewhere, most probably a ROCM SDK that has it installed as a sibling to the HIP headers. Not all ROCM SDKs include this, and even so, it is dangerous to have a sheared header dependency like this.

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
@@ -1,7 +1,7 @@
-From 519669d34dfaa980604f6014898f1ed4cb4d943a Mon Sep 17 00:00:00 2001
+From c3ea1cbe49ebdc1a39f1b652c177cfda59a93316 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Wed, 19 Feb 2025 17:16:27 -0800
-Subject: [PATCH 3/5] TEMPORARY: Manually disable roctx until compatibility
+Subject: [PATCH 3/6] TEMPORARY: Manually disable roctx until compatibility
  with rocprofv3 is established.
 
 ---

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0004-Pin-cmake-4-since-v4-broke-old-pytorch-builds.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0004-Pin-cmake-4-since-v4-broke-old-pytorch-builds.patch
@@ -1,7 +1,7 @@
-From 77a75ffce90524e6e5fafed0759d30b63a156286 Mon Sep 17 00:00:00 2001
+From 8305f036fcba8aadb986f008fb7151e35439d323 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Tue, 1 Apr 2025 14:52:15 -0700
-Subject: [PATCH 4/5] Pin cmake<4 since v4 broke old pytorch builds.
+Subject: [PATCH 4/6] Pin cmake<4 since v4 broke old pytorch builds.
 
 ---
  requirements.txt | 2 +-

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0005-Preload-rocm-sdk-binaries-if-available.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0005-Preload-rocm-sdk-binaries-if-available.patch
@@ -1,7 +1,7 @@
-From f177e4c066b796990b950d9739149dcba7070b37 Mon Sep 17 00:00:00 2001
+From 4c446b9ea5171a14e15ce17fbc58b05df5b29025 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Tue, 1 Apr 2025 18:49:42 -0700
-Subject: [PATCH 5/5] Preload rocm-sdk binaries if available.
+Subject: [PATCH 5/6] Preload rocm-sdk binaries if available.
 
 ---
  torch/__init__.py | 27 ++++++++++++++++++++++++++-

--- a/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0006-link-correct-version-of-hsa-runtime-with-c10_hip.patch
+++ b/external-builds/pytorch/patches/v2.6.0/pytorch/hipified/0006-link-correct-version-of-hsa-runtime-with-c10_hip.patch
@@ -1,0 +1,35 @@
+From 435c349d3323364862d8d37a6325fa19566204fa Mon Sep 17 00:00:00 2001
+From: Mika Laitio <mika.laitio@amd.com>
+Date: Tue, 29 Apr 2025 01:28:14 -0700
+Subject: [PATCH 6/6] link correct version of hsa-runtime with c10_hip
+
+link the version of hsa-runtime64 that is searched
+by LoadHIP.cmake instead of relying to it to be linked
+as an amdhip64 dependency without specifying the location.
+
+This fixes an error where the wrong version of library could
+be tried to be linked causing unresolved symbol errors.
+
+fixes: https://github.com/ROCm/TheRock/issues/474
+
+Signed-off-by: Mika Laitio <mika.laitio@amd.com>
+---
+ c10/hip/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/c10/hip/CMakeLists.txt b/c10/hip/CMakeLists.txt
+index f153030e79..a98ec6fa23 100644
+--- a/c10/hip/CMakeLists.txt
++++ b/c10/hip/CMakeLists.txt
+@@ -48,7 +48,7 @@ if(NOT BUILD_LIBTORCHLESS)
+   endif()
+ 
+   # ---[ Dependency of c10_hip
+-  target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::amdhip64)
++  target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::amdhip64 hsa-runtime64::hsa-runtime64)
+ 
+   target_include_directories(
+       c10_hip PUBLIC
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
+++ b/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
@@ -1,7 +1,7 @@
-From d4b67827c2dafda5be6fbe6446b422ef542102a0 Mon Sep 17 00:00:00 2001
+From eda46d25881f072c6ea2c2a96c500819ba18bbe9 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 17 Feb 2025 16:47:57 -0800
-Subject: [PATCH 1/6] Rework LoadHIP.cmake to be based purely on
+Subject: [PATCH 1/7] Rework LoadHIP.cmake to be based purely on
  CMAKE_PREFIX_PATH.
 
 * Eliminates dependence on `/opt/rocm` and path based heuristics.
@@ -9,13 +9,12 @@ Subject: [PATCH 1/6] Rework LoadHIP.cmake to be based purely on
 * Workaround cmake >= 4.0 for hiprtc
 
 Co-authored-by: Scott Tsai <scottt.tw@gmail.com>
-
 ---
  cmake/public/LoadHIP.cmake | 303 ++++++++++++++-----------------------
  1 file changed, 111 insertions(+), 192 deletions(-)
 
 diff --git a/cmake/public/LoadHIP.cmake b/cmake/public/LoadHIP.cmake
-index 58c74ddda3..57910495fc 100644
+index 58c74ddda35..57910495fcc 100644
 --- a/cmake/public/LoadHIP.cmake
 +++ b/cmake/public/LoadHIP.cmake
 @@ -1,206 +1,125 @@
@@ -337,5 +336,5 @@ index 58c74ddda3..57910495fc 100644
 +  pytorch_load_hip()
  endif()
 -- 
-2.49.0
+2.43.0
 

--- a/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
+++ b/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
@@ -1,7 +1,7 @@
-From dc6344fd018e3031775e5cc7ba8db3080ad736d6 Mon Sep 17 00:00:00 2001
+From 54a58cb63efa76322fbc7393939f37c5b75faae0 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Wed, 19 Feb 2025 17:14:59 -0800
-Subject: [PATCH 2/3] Generate composable_kernel ck/config.h as part of main
+Subject: [PATCH 2/7] Generate composable_kernel ck/config.h as part of main
  build.
 
 Without this, the ck/config.h comes from somewhere, most probably a ROCM SDK that has it installed as a sibling to the HIP headers. Not all ROCM SDKs include this, and even so, it is dangerous to have a sheared header dependency like this.
@@ -10,10 +10,10 @@ Without this, the ck/config.h comes from somewhere, most probably a ROCM SDK tha
  1 file changed, 21 insertions(+)
 
 diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
-index f0868ea048..293fa8ace3 100644
+index 085af373ec2..67322e8f56e 100644
 --- a/aten/src/ATen/CMakeLists.txt
 +++ b/aten/src/ATen/CMakeLists.txt
-@@ -311,9 +311,30 @@ if(USE_CUDA)
+@@ -343,9 +343,30 @@ if(USE_CUDA)
  endif()
  
  if(USE_ROCM)

--- a/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
+++ b/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
@@ -1,8 +1,8 @@
-From b3b927ac4685a548dba412cf38932d276380e057 Mon Sep 17 00:00:00 2001
+From 0525f3167006078e489d76d2b9efc663cbb63769 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 31 Mar 2025 18:54:56 +0100
-Subject: [PATCH] TEMPORARY: Manually disable roctx until compatibility with
- rocprofv3 is established.
+Subject: [PATCH 3/7] TEMPORARY: Manually disable roctx until compatibility
+ with rocprofv3 is established.
 
 ---
  torch/csrc/cuda/shared/nvtx.cpp    | 21 +++++++++++++--------
@@ -10,7 +10,7 @@ Subject: [PATCH] TEMPORARY: Manually disable roctx until compatibility with
  2 files changed, 21 insertions(+), 11 deletions(-)
 
 diff --git a/torch/csrc/cuda/shared/nvtx.cpp b/torch/csrc/cuda/shared/nvtx.cpp
-index 40e9821389..0ce2dd34b5 100644
+index 40e9821389f..0ce2dd34b56 100644
 --- a/torch/csrc/cuda/shared/nvtx.cpp
 +++ b/torch/csrc/cuda/shared/nvtx.cpp
 @@ -1,13 +1,14 @@
@@ -69,7 +69,7 @@ index 40e9821389..0ce2dd34b5 100644
    nvtx.def("deviceRangeEnd", device_nvtxRangeEnd);
  }
 diff --git a/torch/csrc/profiler/stubs/cuda.cpp b/torch/csrc/profiler/stubs/cuda.cpp
-index 37364dfc93..0ed35059a1 100644
+index 37364dfc931..0ed35059a1a 100644
 --- a/torch/csrc/profiler/stubs/cuda.cpp
 +++ b/torch/csrc/profiler/stubs/cuda.cpp
 @@ -1,11 +1,13 @@

--- a/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0004-enable-hipBLASLt-for-gfx-1102-1150-1151-1201.patch
+++ b/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0004-enable-hipBLASLt-for-gfx-1102-1150-1151-1201.patch
@@ -1,7 +1,7 @@
-From d69bdf92bd872ce622ef12f6b927de3c1c128174 Mon Sep 17 00:00:00 2001
+From b675c33c77fbf0ffceb689395249ce4e3853547d Mon Sep 17 00:00:00 2001
 From: Scott Tsai <scottt.tw@gmail.com>
 Date: Sun, 23 Mar 2025 13:16:25 +0800
-Subject: [PATCH] enable hipBLASLt for gfx{1102,1150,1151,1201}
+Subject: [PATCH 4/7] enable hipBLASLt for gfx{1102,1150,1151,1201}
 
 Pytorch upstream should integrate this once the following change
 is in a ROCm release:
@@ -11,10 +11,10 @@ https://github.com/ROCm/hipBLASLt/pull/1766
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/aten/src/ATen/Context.cpp b/aten/src/ATen/Context.cpp
-index f598fc3a39..e79144fcb0 100644
+index 01f223f4e5c..d384b5e6b2f 100644
 --- a/aten/src/ATen/Context.cpp
 +++ b/aten/src/ATen/Context.cpp
-@@ -332,7 +332,7 @@ at::BlasBackend Context::blasPreferredBackend() {
+@@ -359,7 +359,7 @@ at::BlasBackend Context::blasPreferredBackend() {
        static const std::vector<std::string> archs = {
            "gfx90a", "gfx942",
  #if ROCM_VERSION >= 60300

--- a/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0005-Add-gfx1150-gfx1151-to-hipblaslt-support-list-in-Bla.patch
+++ b/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0005-Add-gfx1150-gfx1151-to-hipblaslt-support-list-in-Bla.patch
@@ -1,7 +1,7 @@
-From da114eb37162fcba198a4edb2869628ad234ca25 Mon Sep 17 00:00:00 2001
+From 95634f3299d4da1be04f6c638b70e7326d646c91 Mon Sep 17 00:00:00 2001
 From: Aaryaman Vasishta <jem456.vasishta@gmail.com>
 Date: Mon, 31 Mar 2025 19:27:48 +0100
-Subject: Add gfx1150/gfx1151 to hipblaslt support list in Blas.cpp
+Subject: [PATCH 5/7] Add gfx1150/gfx1151 to hipblaslt support list in Blas.cpp
 
 ---
  aten/src/ATen/native/cuda/Blas.cpp | 2 +-
@@ -9,7 +9,7 @@ Subject: Add gfx1150/gfx1151 to hipblaslt support list in Blas.cpp
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/aten/src/ATen/native/cuda/Blas.cpp b/aten/src/ATen/native/cuda/Blas.cpp
-index 28936cc034..592c04693c 100644
+index 28936cc034a..592c04693c5 100644
 --- a/aten/src/ATen/native/cuda/Blas.cpp
 +++ b/aten/src/ATen/native/cuda/Blas.cpp
 @@ -259,7 +259,7 @@ static bool isSupportedHipLtROCmArch(int index) {
@@ -22,7 +22,7 @@ index 28936cc034..592c04693c 100644
  #if ROCM_VERSION >= 60500
          "gfx950"
 diff --git a/aten/src/ATen/native/hip/Blas.cpp b/aten/src/ATen/native/hip/Blas.cpp
-index 467ff69892..576bd7f72c 100644
+index 467ff69892c..576bd7f72cf 100644
 --- a/aten/src/ATen/native/hip/Blas.cpp
 +++ b/aten/src/ATen/native/hip/Blas.cpp
 @@ -260,7 +260,7 @@ static bool isSupportedHipLtROCmArch(int index) {

--- a/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0006-Support-gfx1151-in-aotriton.patch
+++ b/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0006-Support-gfx1151-in-aotriton.patch
@@ -1,7 +1,7 @@
-From e4923146cbdf160c9ea292f115e147944a2a0768 Mon Sep 17 00:00:00 2001
+From 289727ba62d11ebeeab81948829c19a9ce831041 Mon Sep 17 00:00:00 2001
 From: Aaryaman Vasishta <jem456.vasishta@gmail.com>
 Date: Mon, 31 Mar 2025 19:27:59 +0100
-Subject: [PATCH] Support gfx1151 in aotriton
+Subject: [PATCH 6/7] Support gfx1151 in aotriton
 
 ---
  cmake/External/aotriton.cmake | 6 ++++--
@@ -9,7 +9,7 @@ Subject: [PATCH] Support gfx1151 in aotriton
  2 files changed, 10 insertions(+), 2 deletions(-)
 
 diff --git a/cmake/External/aotriton.cmake b/cmake/External/aotriton.cmake
-index 2678cfde3c..2ee7345d9d 100644
+index 2678cfde3c4..b70b9311d70 100644
 --- a/cmake/External/aotriton.cmake
 +++ b/cmake/External/aotriton.cmake
 @@ -2,6 +2,7 @@ macro(get_target_gpus_from_pytorch target_gpus)
@@ -47,10 +47,10 @@ index 2678cfde3c..2ee7345d9d 100644
        BUILD_COMMAND ""  # No build, install command will repeat the build process due to problems in the build system.
        BUILD_BYPRODUCTS "${__AOTRITON_INSTALL_DIR}/lib/libaotriton_v2.so"
 diff --git a/cmake/public/LoadHIP.cmake b/cmake/public/LoadHIP.cmake
-index da2beeba59..09fb8e99aa 100644
+index 57910495fcc..7b058199a13 100644
 --- a/cmake/public/LoadHIP.cmake
 +++ b/cmake/public/LoadHIP.cmake
-@@ -113,5 +113,11 @@ set(PYTORCH_FOUND_HIP FALSE)
+@@ -121,5 +121,11 @@ set(PYTORCH_FOUND_HIP FALSE)
  set(HIP_PLATFORM "amd")
  find_package(hip CONFIG)
  if(hip_FOUND)

--- a/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0007-link-correct-version-of-hsa-runtime-with-c10_hip.patch
+++ b/external-builds/pytorch/patches/v2.7.0/pytorch/hipified/0007-link-correct-version-of-hsa-runtime-with-c10_hip.patch
@@ -1,0 +1,35 @@
+From 9526585757547f92c08ccd4d106eef96c3abb941 Mon Sep 17 00:00:00 2001
+From: Mika Laitio <mika.laitio@amd.com>
+Date: Tue, 29 Apr 2025 01:28:14 -0700
+Subject: [PATCH 7/7] link correct version of hsa-runtime with c10_hip
+
+link the version of hsa-runtime64 that is searched
+by LoadHIP.cmake instead of relying to it to be linked
+as an amdhip64 dependency without specifying the location.
+
+This fixes an error where the wrong version of library could
+be tried to be linked causing unresolved symbol errors.
+
+fixes: https://github.com/ROCm/TheRock/issues/474
+
+Signed-off-by: Mika Laitio <mika.laitio@amd.com>
+---
+ c10/hip/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/c10/hip/CMakeLists.txt b/c10/hip/CMakeLists.txt
+index f153030e793..a98ec6fa230 100644
+--- a/c10/hip/CMakeLists.txt
++++ b/c10/hip/CMakeLists.txt
+@@ -48,7 +48,7 @@ if(NOT BUILD_LIBTORCHLESS)
+   endif()
+ 
+   # ---[ Dependency of c10_hip
+-  target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::amdhip64)
++  target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::amdhip64 hsa-runtime64::hsa-runtime64)
+ 
+   target_include_directories(
+       c10_hip PUBLIC
+-- 
+2.43.0
+


### PR DESCRIPTION
Link to the version of hsa-runtime64 that is searched by LoadHIP.cmake instead of relying to it to be linked as an amdhip64 dependency without specifying the location. (/usr/lib/x86_64-linux-gnu/libhsa-runtime64.so.1 in ubuntu 24.04)

This resolves following type of linking errors:
    TheRock/build/dist/rocm/lib/libamdhip64.so.6.5.25171-31afa624a:
    undefined reference tohsa_amd_vmem_map@ROCR_1'

fixes: https://github.com/ROCm/TheRock/issues/474