### PR TITLE
Ignore some of the most spammy warnings.

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -61,6 +61,8 @@ endif()
 # issues.
 # TODO: Clean up warning flags (https://github.com/ROCm/TheRock/issues/47)
 set(THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS
+  -Wno-deprecated-declarations
+  -Wno-deprecated-pragma
   -Wno-documentation-unknown-command
   -Wno-documentation-pedantic
   -Wno-unused-command-line-argument


### PR DESCRIPTION
See https://github.com/ROCm/TheRock/issues/47. The `Wdeprecated-declarations` and `-Wdeprecated-pragma` warnings are the two most spammy warnings in our logs, with several thousand instances each. Ignoring these warnings should shrink the file size of our build logs substantially, which may also help with overall CI time until we switch to streaming logs to a remote endpoint other than GitHub Actions (https://github.com/ROCm/TheRock/issues/348).