### PR TITLE
Adds a magic env var TEATIME_FORCE_INTERACTIVE and sets it to 0 in CI jobs.

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -29,8 +29,8 @@ jobs:
       CACHE_DIR: ${{ github.workspace }}/.container-cache
       CCACHE_DIR: "${{ github.workspace }}/.container-cache/ccache"
       CCACHE_MAXSIZE: "700M"
-      TEATIME_LABEL_GH_GROUP: 1
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+      TEATIME_FORCE_INTERACTIVE: 0
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -80,9 +80,7 @@ jobs:
             -DTHEROCK_PACKAGE_VERSION="${package_version}" \
             -DTHEROCK_VERBOSE=ON \
             -DBUILD_TESTING=ON
-          ./build_tools/watch_top_processes.sh &
           cmake --build build --target therock-archives therock-dist
-          kill %1
 
       - name: Test Packaging
         run: |

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -31,6 +31,7 @@ jobs:
       CACHE_DIR: "${{github.workspace}}/.cache"
       CCACHE_DIR: "${{github.workspace}}/.cache/ccache"
       CCACHE_MAXSIZE: "4000M"
+      TEATIME_FORCE_INTERACTIVE: 0
     steps:
       - name: "Create build dir"
         shell: powershell

--- a/build_tools/teatime.py
+++ b/build_tools/teatime.py
@@ -180,6 +180,18 @@ def main(cl_args: list[str]):
     )
     p.add_argument("file", type=Path, help="Also log output to this file")
     args = p.parse_args(cl_args)
+
+    # Allow some things to be overriden by env vars.
+    force_interactive = os.getenv("TEATIME_FORCE_INTERACTIVE")
+    if force_interactive:
+        try:
+            force_interactive = int(force_interactive)
+        except ValueError as e:
+            raise ValueError(
+                "Expected 'TEATIME_FORCE_INTERACTIVE' env var to be an int"
+            ) from e
+        args.interactive = bool(force_interactive)
+
     sink = OutputSink(args)
     sink.start()
     try:


### PR DESCRIPTION
This causes subproject logs to only be output to the console on failure vs success. Given the state of warning spew in the projects and how hard it is to track through running console logs for this stuff, this is the better setting. All detailed triage needs to happen on log files, which we persist in S3.

Some third-party subprojects which we don't control were already setting this at the project level. Setting at the CI level just lets us exert special control project wise.

Also switches the Linux output to be prefixed by project name instead of fancy expando handles. I've found this to be more ergonomic, especially in non-interactive mode.

Also removes the watch_top_processes thing on Linux. We have better ways to do this now.

Normal users remain subject to the full fury of the warnings.