### PR TITLE
pytorch vision and audio linux build support

### DIFF
--- a/external-builds/pytorch/.gitignore
+++ b/external-builds/pytorch/.gitignore
@@ -1,2 +1,5 @@
 .venv
 src/
+/pytorch
+/pytorch_vision
+/pytorch_audio

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -1,5 +1,12 @@
 # Build ROCM PyTorch
 
+## Build Pytorch, Pytorch vision and pytorch audio on Linux
+
+- cd external-builds/pytorch
+- ./checkout_and_build_all.sh
+
+## Build pytorch on Windows or on old way in Linux
+
 There is nothing special about this build procedure except that it is meant
 to run as part of the ROCM CI and development flow and leaves less room for
 interpretation with respect to golden path in upstream docs.
@@ -12,7 +19,7 @@ This incorporates advice from:
 Note that the above statement is currently aspirational as we contain some
 patches locally until they can be upstreamed. See the `patches` directory.
 
-## Step 0: Prep venv
+### Step 0: Prep venv
 
 It is highly recommended to use a virtual environment unless if in a throw-away
 container/CI environment.
@@ -22,7 +29,7 @@ python -m venv .venv
 source .venv/bin/activate
 ```
 
-## Step 1: Preparing sources
+### Step 1: Preparing sources
 
 ```
 # Checks out the most recent stable release branch of PyTorch, hipifies and
@@ -30,7 +37,7 @@ source .venv/bin/activate
 ./ptbuild.py checkout
 ```
 
-## Step 2: Install Deps
+### Step 2: Install Deps
 
 Python deps:
 
@@ -39,7 +46,7 @@ pip install -r src/requirements.txt
 pip install mkl-static mkl-include
 ```
 
-## Step 3: Setup and Build
+### Step 3: Setup and Build
 
 ```
 export CMAKE_PREFIX_PATH="$(realpath ../../build/dist/rocm)"

--- a/external-builds/pytorch/build_pytorch_all.sh
+++ b/external-builds/pytorch/build_pytorch_all.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+
+# Causes bash process to die immediately after child process returns error
+# to make sure that script does not continue logic if error has happened.
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd $(dirname $0) && pwd)"
+
+if ! source $SCRIPT_DIR/env_init.sh; then
+	echo "Failed to find python virtual-env"
+	echo "Make sure that TheRock has been build first"
+        exit 1
+fi
+
+if ! $SCRIPT_DIR/build_pytorch_torch.sh; then
+	echo "pytorch torch build failed"
+	exit 1
+fi
+
+if ! $SCRIPT_DIR/build_pytorch_vision.sh; then
+	echo "pytorch vision build failed"
+        exit 1
+fi
+
+if ! $SCRIPT_DIR/build_pytorch_audio.sh; then
+	echo "pytorch audio build failed"
+        exit 1
+fi

--- a/external-builds/pytorch/build_pytorch_audio.sh
+++ b/external-builds/pytorch/build_pytorch_audio.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/bash
+
+# Causes bash process to die immediately after child process returns error
+# to make sure that script does not continue logic if error has happened.
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd $(dirname $0) && pwd)"
+if ! source $SCRIPT_DIR/env_init.sh; then
+    echo "Failed to find python virtual-env"
+    echo "Make sure that TheRock has been build first"
+    exit 1
+fi
+
+unset LDFLAGS
+unset CFLAGS
+unset CPPFLAGS
+unset PKG_CONFIG_PATH
+export CMAKE_PREFIX_PATH="$(realpath $SCRIPT_DIR/../../build/dist/rocm)"
+echo ${CMAKE_PREFIX_PATH}
+export CMAKE_C_COMPILER=${CMAKE_PREFIX_PATH}/bin/hipcc
+export CMAKE_CXX_COMPILER=${CMAKE_PREFIX_PATH}/bin/hipcc
+export HIP_DEVICE_LIB_PATH=${CMAKE_PREFIX_PATH}/lib/llvm/amdgcn/bitcode
+
+cd $SCRIPT_DIR/pytorch_audio
+ROCM_PATH=${CMAKE_PREFIX_PATH} USE_ROCM=1 USE_CUDA=0 USE_FFMPEG=1 USE_OPENMP=1 BUILD_SOX=0 CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} BUILD_VERSION="2.7.0" BUILD_NUMBER=1 python setup.py bdist_wheel
+
+# if there are multiple wheel files, find the newest one and install it
+unset -v latest_wheel_file
+for cur_file in dist/*.whl; do
+    [[ $cur_file -nt "$latest_wheel_file" ]] && latest_wheel_file=$cur_file
+done
+if [ ! -z "$latest_wheel_file" ]; then
+    echo "installing $latest_wheel_file"
+    # do not use "pip install --force-reinstall because it can uninstall
+    # own build other packages and then re-install incorrect onew from internet
+    pip uninstall --yes "$latest_wheel_file"
+    pip install "$latest_wheel_file"
+else
+    echo "Failed to build and find pytorch audio wheel for pip install in directory $SCRIPT_DIR/pytorch_audio/dist"
+    exit 1
+fi
+cd $SCRIPT_DIR

--- a/external-builds/pytorch/build_pytorch_torch.sh
+++ b/external-builds/pytorch/build_pytorch_torch.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/bash
+
+# Causes bash process to die immediately after child process returns error
+# to make sure that script does not continue logic if error has happened.
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd $(dirname $0) && pwd)"
+if ! source $SCRIPT_DIR/env_init.sh; then
+    echo "Failed to find python virtual-env"
+    echo "Make sure that TheRock has been build first"
+    exit 1
+fi
+
+export CMAKE_PREFIX_PATH="$(realpath $SCRIPT_DIR/../../build/dist/rocm)"
+#export CMAKE_C_COMPILER=${CMAKE_PREFIX_PATH}/bin/hipcc
+#export CMAKE_CXX_COMPILER=${CMAKE_PREFIX_PATH}/bin/hipcc
+export HIP_DEVICE_LIB_PATH=${CMAKE_PREFIX_PATH}/lib/llvm/amdgcn/bitcode
+
+cd $SCRIPT_DIR/pytorch
+#USE_KINETO=OFF CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} python setup.py develop
+#USE_KINETO=OFF CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} PYTORCH_BUILD_VERSION=2.7.0 PYTORCH_BUILD_NUMBER=1 python setup.py bdist_wheel
+USE_KINETO=OFF PYTORCH_BUILD_VERSION=2.7.0 PYTORCH_BUILD_NUMBER=1 python setup.py bdist_wheel
+
+# if there are multiple wheel files, find the newest one and install it
+unset -v latest_wheel_file
+for cur_file in dist/*.whl; do
+    [[ $cur_file -nt "$latest_wheel_file" ]] && latest_wheel_file=$cur_file
+done
+if [ ! -z "$latest_wheel_file" ]; then
+    echo "installing $latest_wheel_file"
+    # do not use "pip install --force-reinstall because it can uninstall
+    # own build other packages and then re-install incorrect onew from internet
+    pip uninstall --yes "$latest_wheel_file"
+    pip install "$latest_wheel_file"
+else
+    echo "Failed to build and find pytorch wheel for pip install in directory $SCRIPT_DIR/pytorch/dist"
+    exit 1
+fi
+cd $SCRIPT_DIR

--- a/external-builds/pytorch/build_pytorch_vision.sh
+++ b/external-builds/pytorch/build_pytorch_vision.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/bash
+
+# Causes bash process to die immediately after child process returns error
+# to make sure that script does not continue logic if error has happened.
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd $(dirname $0) && pwd)"
+if ! source $SCRIPT_DIR/env_init.sh; then
+        echo "Failed to find python virtual-env"
+        echo "Make sure that TheRock has been build first"
+        exit 1
+fi
+
+unset LDFLAGS
+unset CFLAGS
+unset CPPFLAGS
+unset PKG_CONFIG_PATH
+export CMAKE_PREFIX_PATH="$(realpath $SCRIPT_DIR/../../build/dist/rocm)"
+echo ${CMAKE_PREFIX_PATH}
+export CMAKE_C_COMPILER=${CMAKE_PREFIX_PATH}/bin/hipcc
+export CMAKE_CXX_COMPILER=${CMAKE_PREFIX_PATH}/bin/hipcc
+export HIP_DEVICE_LIB_PATH=${CMAKE_PREFIX_PATH}/lib/llvm/amdgcn/bitcode
+
+cd $SCRIPT_DIR/pytorch_vision
+ROCM_PATH=${CMAKE_PREFIX_PATH} FORCE_CUDA=1 TORCHVISION_USE_NVJPEG=0 TORCHVISION_USE_VIDEO_CODEC=0 CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} BUILD_VERSION=0.22.0 BUILD_NUMBER=1 VERSION_NAME=0.22.0 python setup.py bdist_wheel
+
+# if there are multiple wheel files, find the newest one and install it
+unset -v latest_wheel_file
+for cur_file in dist/*.whl; do
+    [[ $cur_file -nt "$latest_wheel_file" ]] && latest_wheel_file=$cur_file
+done
+if [ ! -z "$latest_wheel_file" ]; then
+    echo "installing $latest_wheel_file"
+    # do not use "pip install --force-reinstall because it can uninstall
+    # own build other packages and then re-install incorrect onew from internet
+    pip uninstall --yes "$latest_wheel_file"
+    pip install "$latest_wheel_file"
+else
+    echo "Failed to build and find pytorch vision wheel for pip install in directory $SCRIPT_DIR/pytorch_vision/dist"
+    exit 1
+fi
+cd $SCRIPT_DIR

--- a/external-builds/pytorch/checkout_and_build_all.sh
+++ b/external-builds/pytorch/checkout_and_build_all.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/bash
+
+# Causes bash process to die immediately after child process returns error
+# to make sure that script does not continue logic if error has happened.
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd $(dirname $0) && pwd)"
+if ! source $SCRIPT_DIR/env_init.sh; then
+	echo "Failed to find python virtual-env"
+	echo "Make sure that TheRock has been build first"
+        exit 1
+fi
+
+if ! $SCRIPT_DIR/checkout_pytorch_all.sh; then
+	echo "Failed to checkout pytorch, pytorch vision and pytorch audio"
+	exit 1
+fi
+
+if ! $SCRIPT_DIR/build_pytorch_all.sh; then
+        echo "Failed to build pytorch, pytorch vision and pytorch audio"
+        exit 1
+fi

--- a/external-builds/pytorch/checkout_pytorch_all.sh
+++ b/external-builds/pytorch/checkout_pytorch_all.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/bash
+
+# Causes bash process to die immediately after child process returns error
+# to make sure that script does not continue logic if error has happened.
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd $(dirname $0) && pwd)"
+if ! source $SCRIPT_DIR/env_init.sh; then
+        echo "Failed to find python virtual-env"
+        echo "Make sure that TheRock has been build first"
+        exit 1
+fi
+
+if ! $SCRIPT_DIR/pytorch_torch_repo.py checkout; then
+	echo "Failed to checkout pytorch"
+	exit 1
+fi
+
+if ! pip install -r pytorch/requirements.txt; then
+	echo "Failed to install python requirements with pip install -r pytorch/requirements.txt"
+	exit 1
+fi
+
+pip install mkl-static mkl-include
+
+if ! $SCRIPT_DIR/pytorch_vision_repo.py checkout; then
+	echo "Failed to checkout pytorch vision"
+	exit 1
+fi
+
+if ! $SCRIPT_DIR/pytorch_audio_repo.py checkout; then
+	echo "Failed to checkout pytorch audio"
+	exit 1
+fi

--- a/external-builds/pytorch/env_init.sh
+++ b/external-builds/pytorch/env_init.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/bash
+
+# Causes bash process to die immediately after child process returns error
+# to make sure that script does not continue logic if error has happened.
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd $(dirname $0) && pwd)"
+if [ -n "${VIRTUAL_ENV}" ]; then
+	echo "virtual env set"
+	VENV_DIR_ENV_VARIABLE=$(realpath ${VIRTUAL_ENV})
+	THEROCK_VENV_DEF_DIR=$(realpath $SCRIPT_DIR/../../.venv)
+
+	echo "VENV_DIR_ENV_VARIABLE: ${VENV_DIR_ENV_VARIABLE}"
+	echo "THEROCK_VENV_DEF_DIR: ${THEROCK_VENV_DEF_DIR}"
+	if [ "${VENV_DIR_ENV_VARIABLE}" == "${THEROCK_VENV_DEF_DIR}" ];
+	then
+		echo "python virtual env: ${VIRTUAL_ENV}"
+	else
+		echo "Python VIRTUAL_ENV: ${VIRTUAL_ENV}"
+		echo "THEROCK default Python virtual env not active: ${THEROCK_VENV_DEF_DIR}"
+	fi
+else
+	echo "virtual env not set"
+	if [ -f $SCRIPT_DIR/../../.venv/bin/activate ]; then
+		source $SCRIPT_DIR/../../.venv/bin/activate
+		echo "sourced python VIRTUAL_ENV: ${VIRTUAL_ENV}"
+	else
+		echo "error, no pytorch virtual evn available"
+		exit 1
+	fi
+fi
+
+if [ ! -n "${THEROCK_PATH_SET}" ]; then
+	export THEROCK_PATH_SET=1
+	export ROCM_HOME=$(realpath $SCRIPT_DIR/../../build/dist/rocm)
+	if [ -d ${ROCM_HOME} ]; then
+		export PATH=${ROCM_HOME}/bin:$PATH
+		export LD_LIBRARY_PATH=${ROCM_HOME}/lib
+		echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+	else
+		echo "Could not find ROCM_HOME: $ROCM_HOME"
+		exit 1
+	fi
+fi

--- a/external-builds/pytorch/patches/pytorch/v2.6.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.6.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
@@ -1,0 +1,329 @@
+From 3db4c6beb3de52f10beb1da72af52cd05726da1c Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Mon, 17 Feb 2025 16:47:57 -0800
+Subject: [PATCH 1/7] Rework LoadHIP.cmake to be based purely on
+ CMAKE_PREFIX_PATH.
+
+* Eliminates dependence on `/opt/rocm` and path based heuristics.
+* Normalizes package finding for Rocm 6.5+ layout.
+---
+ cmake/public/LoadHIP.cmake | 302 ++++++++++++++-----------------------
+ 1 file changed, 110 insertions(+), 192 deletions(-)
+
+diff --git a/cmake/public/LoadHIP.cmake b/cmake/public/LoadHIP.cmake
+index 3eb34b0b83..753e146a40 100644
+--- a/cmake/public/LoadHIP.cmake
++++ b/cmake/public/LoadHIP.cmake
+@@ -1,199 +1,117 @@
+-set(PYTORCH_FOUND_HIP FALSE)
+-
+-# If ROCM_PATH is set, assume intention is to compile with
+-# ROCm support and error out if the ROCM_PATH does not exist.
+-# Else ROCM_PATH does not exist, assume a default of /opt/rocm
+-# In the latter case, if /opt/rocm does not exist emit status
+-# message and return.
+-if(DEFINED ENV{ROCM_PATH})
+-  set(ROCM_PATH $ENV{ROCM_PATH})
+-  if(NOT EXISTS ${ROCM_PATH})
+-    message(FATAL_ERROR
+-      "ROCM_PATH environment variable is set to ${ROCM_PATH} but does not exist.\n"
+-      "Set a valid ROCM_PATH or unset ROCM_PATH environment variable to fix.")
+-  endif()
+-else()
+-  if(UNIX)
+-    set(ROCM_PATH /opt/rocm)
+-  else() # Win32
+-    set(ROCM_PATH C:/opt/rocm)
+-  endif()
+-  if(NOT EXISTS ${ROCM_PATH})
+-    message(STATUS
+-        "ROCM_PATH environment variable is not set and ${ROCM_PATH} does not exist.\n"
+-        "Building without ROCm support.")
+-    return()
+-  endif()
+-endif()
+-
+-if(NOT DEFINED ENV{ROCM_INCLUDE_DIRS})
+-  set(ROCM_INCLUDE_DIRS ${ROCM_PATH}/include)
+-else()
+-  set(ROCM_INCLUDE_DIRS $ENV{ROCM_INCLUDE_DIRS})
+-endif()
+-
+-# MAGMA_HOME
+-if(NOT DEFINED ENV{MAGMA_HOME})
+-  set(MAGMA_HOME ${ROCM_PATH}/magma)
+-  set(ENV{MAGMA_HOME} ${ROCM_PATH}/magma)
+-else()
+-  set(MAGMA_HOME $ENV{MAGMA_HOME})
+-endif()
+-
+-# MIOpen isn't a part of HIP-SDK for Windows and hence, may have a different
+-# installation directory.
+-if(WIN32)
+-  if(NOT DEFINED ENV{MIOPEN_PATH})
+-    set(miopen_DIR C:/opt/miopen/lib/cmake/miopen)
+-  else()
+-    set(miopen_DIR $ENV{MIOPEN_PATH}/lib/cmake/miopen)
+-  endif()
+-endif()
+-
+-torch_hip_get_arch_list(PYTORCH_ROCM_ARCH)
+-if(PYTORCH_ROCM_ARCH STREQUAL "")
+-  message(FATAL_ERROR "No GPU arch specified for ROCm build. Please use PYTORCH_ROCM_ARCH environment variable to specify GPU archs to build for.")
+-endif()
+-message("Building PyTorch for GPU arch: ${PYTORCH_ROCM_ARCH}")
+-
+-# Add HIP to the CMAKE Module Path
+-# needed because the find_package call to this module uses the Module mode search
+-# https://cmake.org/cmake/help/latest/command/find_package.html#search-modes
+-if(UNIX)
+-  set(CMAKE_MODULE_PATH ${ROCM_PATH}/lib/cmake/hip ${CMAKE_MODULE_PATH})
+-else() # Win32
+-  set(CMAKE_MODULE_PATH ${ROCM_PATH}/cmake/ ${CMAKE_MODULE_PATH})
+-endif()
+-
+-# Add ROCM_PATH to CMAKE_PREFIX_PATH, needed because the find_package
+-# call to individual ROCM components uses the Config mode search
+-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
+-
+-macro(find_package_and_print_version PACKAGE_NAME)
+-  find_package("${PACKAGE_NAME}" ${ARGN})
+-  message("${PACKAGE_NAME} VERSION: ${${PACKAGE_NAME}_VERSION}")
+-endmacro()
+-
+-# Find the HIP Package
+-# MODULE argument is added for clarity that CMake is searching
+-# for FindHIP.cmake in Module mode
+-find_package_and_print_version(HIP 1.0 MODULE)
+-
+-if(HIP_FOUND)
+-  set(PYTORCH_FOUND_HIP TRUE)
+-
+-  # Find ROCM version for checks
+-  if(UNIX)
+-    set(ROCM_VERSION_HEADER_PATH ${ROCM_INCLUDE_DIRS}/rocm-core/rocm_version.h)
+-  else()
+-    set(ROCM_VERSION_HEADER_PATH ${ROCM_INCLUDE_DIRS}/hip/hip_version.h)
+-  endif()
+-  get_filename_component(ROCM_HEADER_NAME ${ROCM_VERSION_HEADER_PATH} NAME)
+-
+-  if(EXISTS ${ROCM_VERSION_HEADER_PATH})
+-    set(ROCM_HEADER_FILE ${ROCM_VERSION_HEADER_PATH})
+-  else()
+-    message(FATAL_ERROR "********************* ${ROCM_HEADER_NAME} could not be found ******************\n")
+-  endif()
+-
+-  # Read the ROCM headerfile into a variable
+-  file(READ ${ROCM_HEADER_FILE} ROCM_HEADER_CONTENT)
+-
+-  # Since Windows currently supports only a part of ROCm and names it HIP-SDK,
+-  # we need to refer to the HIP-SDK equivalents of entities existing in ROCm lib.
+-  if(UNIX)
+-    set(ROCM_LIB_NAME "ROCM")
+-  else() # Win32
+-    set(ROCM_LIB_NAME "HIP")
+-  endif()
+-  # Below we use a RegEx to find ROCM version numbers.
+-  # Note that CMake does not support \s for blank space. That is
+-  # why in the regular expressions below we have a blank space in
+-  # the square brackets.
+-  # There are three steps:
+-  # 1. Match regular expression
+-  # 2. Strip the non-numerical part of the string
+-  # 3. Strip leading and trailing spaces
+-
+-  string(REGEX MATCH "${ROCM_LIB_NAME}_VERSION_MAJOR[ ]+[0-9]+" TEMP1 ${ROCM_HEADER_CONTENT})
+-  string(REPLACE "${ROCM_LIB_NAME}_VERSION_MAJOR" "" TEMP2 ${TEMP1})
+-  string(STRIP ${TEMP2} ROCM_VERSION_DEV_MAJOR)
+-  string(REGEX MATCH "${ROCM_LIB_NAME}_VERSION_MINOR[ ]+[0-9]+" TEMP1 ${ROCM_HEADER_CONTENT})
+-  string(REPLACE "${ROCM_LIB_NAME}_VERSION_MINOR" "" TEMP2 ${TEMP1})
+-  string(STRIP ${TEMP2} ROCM_VERSION_DEV_MINOR)
+-  string(REGEX MATCH "${ROCM_LIB_NAME}_VERSION_PATCH[ ]+[0-9]+" TEMP1 ${ROCM_HEADER_CONTENT})
+-  string(REPLACE "${ROCM_LIB_NAME}_VERSION_PATCH" "" TEMP2 ${TEMP1})
+-  string(STRIP ${TEMP2} ROCM_VERSION_DEV_PATCH)
++macro(pytorch_load_hip)
++  find_package(hip REQUIRED CONFIG)
++  message(STATUS "hip version: ${hip_VERSION}")
++  find_package(amd_comgr REQUIRED)
++  message(STATUS "amd_comgr version: ${amd_comgr_VERSION}")
++  find_package(rocrand REQUIRED)
++  message(STATUS "rocrand version: ${rocrand_VERSION}")
++  find_package(hiprand REQUIRED)
++  message(STATUS "hiprand version: ${hiprand_VERSION}")
++  find_package(rocblas REQUIRED)
++  message(STATUS "rocblas version: ${rocblas_VERSION}")
++  find_package(hipblas REQUIRED)
++  message(STATUS "hipblas_VERSION: ${hipblas_VERSION}")
++  find_package(miopen REQUIRED)
++  message(STATUS "miopen version: ${miopen_VERSION}")
++  find_package(hipfft REQUIRED)
++  message(STATUS "hipfft version: ${hipfft_VERSION}")
++  find_package(hipsparse REQUIRED)
++  message(STATUS "hipsparse version: ${hipsparse_VERSION}")
++  find_package(rocprim REQUIRED)
++  message(STATUS "rocprim version: ${rocprim_VERSION}")
++  find_package(hipcub REQUIRED)
++  message(STATUS "hipcub version: ${hipcub_VERSION}")
++  find_package(rocthrust REQUIRED)
++  message(STATUS "rocthrust version: ${rocthrust_VERSION}")
++  find_package(hipsolver REQUIRED)
++  message(STATUS "hipsolver versio: ${hipsolver_VERSION}")
++  find_package(hiprtc REQUIRED)
++  message(STATUS "hiprtc version: ${hiprtc_VERSION}")
++
++  # Original version made these UNIX-only.
++  find_package(rccl REQUIRED)
++  message(STATUS "rccl version: ${rccl_VERSION}")
++  find_package(hsa-runtime64 REQUIRED)
++  message(STATUS "hsa-runtime64 version: ${hsa-runtime64_VERSION}")
++  find_package(hipblaslt REQUIRED)
++  message(STATUS "hipblaslt version: ${hipblaslt_VERSION}")
++
++  # Extract ROCM version parts from the hip package version.
++  string(REPLACE "." ";" ROCM_VERSION_PARTS "${hip_VERSION}")
++  list(GET ROCM_VERSION_PARTS 0 ROCM_VERSION_DEV_MAJOR)
++  list(GET ROCM_VERSION_PARTS 1 ROCM_VERSION_DEV_MINOR)
++  list(GET ROCM_VERSION_PARTS 2 ROCM_VERSION_DEV_PATCH)
++  set(ROCM_VERSION "${ROCM_VERSION_DEV_MAJOR}.${ROCM_VERSION_DEV_MINOR}.${ROCM_VERSION_DEV_PATCH}")
++
++  message(STATUS "\n***** ROCm version: ****\n")
++  message(STATUS "  ROCM_VERSION: ${ROCM_VERSION}")
++  message(STATUS "  ROCM_VERSION_DEV_MAJOR: ${ROCM_VERSION_DEV_MAJOR}")
++  message(STATUS "  ROCM_VERSION_DEV_MINOR: ${ROCM_VERSION_DEV_MINOR}")
++  message(STATUS "  ROCM_VERSION_DEV_PATCH: ${ROCM_VERSION_DEV_PATCH}")
++  message(STATUS "  HIP_VERSION_MAJOR: ${ROCM_VERSION_DEV_MAJOR}")
++  message(STATUS "  HIP_VERSION_MINOR: ${ROCM_VERSION_DEV_MINOR}")
+ 
+   # Create ROCM_VERSION_DEV_INT which is later used as a preprocessor macros
+   set(ROCM_VERSION_DEV "${ROCM_VERSION_DEV_MAJOR}.${ROCM_VERSION_DEV_MINOR}.${ROCM_VERSION_DEV_PATCH}")
+   math(EXPR ROCM_VERSION_DEV_INT "(${ROCM_VERSION_DEV_MAJOR}*10000) + (${ROCM_VERSION_DEV_MINOR}*100) + ${ROCM_VERSION_DEV_PATCH}")
+-
+-  message("\n***** ROCm version from ${ROCM_HEADER_NAME} ****\n")
+-  message("ROCM_VERSION_DEV: ${ROCM_VERSION_DEV}")
+-  message("ROCM_VERSION_DEV_MAJOR: ${ROCM_VERSION_DEV_MAJOR}")
+-  message("ROCM_VERSION_DEV_MINOR: ${ROCM_VERSION_DEV_MINOR}")
+-  message("ROCM_VERSION_DEV_PATCH: ${ROCM_VERSION_DEV_PATCH}")
+-  message("ROCM_VERSION_DEV_INT:   ${ROCM_VERSION_DEV_INT}")
+-
+-  math(EXPR TORCH_HIP_VERSION "(${HIP_VERSION_MAJOR} * 100) + ${HIP_VERSION_MINOR}")
+-  message("HIP_VERSION_MAJOR: ${HIP_VERSION_MAJOR}")
+-  message("HIP_VERSION_MINOR: ${HIP_VERSION_MINOR}")
+-  message("TORCH_HIP_VERSION: ${TORCH_HIP_VERSION}")
+-
+-  # Find ROCM components using Config mode
+-  # These components will be searced for recursively in ${ROCM_PATH}
+-  message("\n***** Library versions from cmake find_package *****\n")
+-  find_package_and_print_version(hip REQUIRED CONFIG)
+-  find_package_and_print_version(amd_comgr REQUIRED)
+-  find_package_and_print_version(rocrand REQUIRED)
+-  find_package_and_print_version(hiprand REQUIRED)
+-  find_package_and_print_version(rocblas REQUIRED)
+-  find_package_and_print_version(hipblas REQUIRED)
+-  find_package_and_print_version(miopen REQUIRED)
+-  find_package_and_print_version(hipfft REQUIRED)
+-  find_package_and_print_version(hipsparse REQUIRED)
+-  find_package_and_print_version(rocprim REQUIRED)
+-  find_package_and_print_version(hipcub REQUIRED)
+-  find_package_and_print_version(rocthrust REQUIRED)
+-  find_package_and_print_version(hipsolver REQUIRED)
+-  find_package_and_print_version(hiprtc REQUIRED)
+-
+-  if(UNIX)
+-    find_package_and_print_version(rccl)
+-    find_package_and_print_version(hsa-runtime64 REQUIRED)
+-    find_package_and_print_version(hipblaslt REQUIRED)
+-
+-    # roctx is part of roctracer
+-    find_library(ROCM_ROCTX_LIB roctx64 HINTS ${ROCM_PATH}/lib)
+-
+-    # check whether HIP declares new types
+-    set(PROJECT_RANDOM_BINARY_DIR "${PROJECT_BINARY_DIR}")
+-    set(file "${PROJECT_BINARY_DIR}/hip_new_types.cc")
+-    file(WRITE ${file} ""
+-      "#include <hip/library_types.h>\n"
+-      "int main() {\n"
+-      "    hipDataType baz = HIP_R_8F_E4M3_FNUZ;\n"
+-      "    return 0;\n"
+-      "}\n"
+-      )
+-
+-    try_compile(hip_compile_result ${PROJECT_RANDOM_BINARY_DIR} ${file}
+-      CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${ROCM_INCLUDE_DIRS}"
+-      COMPILE_DEFINITIONS -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
+-      OUTPUT_VARIABLE hip_compile_output)
+-
+-    if(hip_compile_result)
+-      set(HIP_NEW_TYPE_ENUMS ON)
+-      #message("HIP is using new type enums: ${hip_compile_output}")
+-      message("HIP is using new type enums")
+-    else()
+-      set(HIP_NEW_TYPE_ENUMS OFF)
+-      #message("HIP is NOT using new type enums: ${hip_compile_output}")
+-      message("HIP is NOT using new type enums")
++  math(EXPR TORCH_HIP_VERSION "(${ROCM_VERSION_DEV_MAJOR} * 100) + ${ROCM_VERSION_DEV_MINOR}")
++
++  message(STATUS "  ROCM_VERSION_DEV_INT:   ${ROCM_VERSION_DEV_INT}")
++  message(STATUS "  TORCH_HIP_VERSION: ${TORCH_HIP_VERSION}")
++
++  # Locate the ROCM_ROCTX_LIB that kineto depends on. This is either part of
++  # roctracer (deprecated) and located with find_library(roctx64) or it is
++  # part of rocprofiler-sdk (aka. rocprofiler v3) as the rocprofiler-sdk-tx
++  # library.
++  # TODO: This isn't quite right and needs to mate up with whether kineto
++  # depends on roctracer or rocprofiler-sdk. The coupling here is fragile and
++  # needs to be reworked.
++  find_package(rocprofiler-sdk-roctx)
++  if(rocprofiler-sdk-roctx_FOUND)
++    message(STATUS "rocprofiler-sdk-roctx version: ${rocprofiler-sdk-roctx_VERSION} found (will use instead of roctracer)")
++    set(ROCM_ROCTX_LIB rocprofiler-sdk-roctx::rocprofiler-sdk-roctx-shared-library)
++  else()
++    find_library(ROCM_ROCTX_LIB roctx64)
++    if(NOT ROCM_ROCTX_LIB)
++      message(WARNING "Neither rocprofiler-sdk nor libroctx64.so was found: This may result in errors if components rely on it")
+     endif()
+-  else() # Win32
+-    # With HIP-SDK 6.2, HIP declares new enum types on Windows
+-    set(HIP_NEW_TYPE_ENUMS ON)
+   endif()
++
++  # PyTorch makes some use of hip_add_library and friends, which are only
++  # available in the legacy FindHIP.cmake finder module. This is bundled in the
++  # same CMAKE_PREFIX_PATH as is used for the regular packages, but is put in
++  # a different place on Linux vs Windows for reasons that are lost to time:
++  #   Linux: lib/cmake/hip/FindHIP.cmake
++  #   Windows: lib/cmake/FindHIP.cmake
++  # While we could ask the user to provide an explicit CMAKE_MODULE_PATH, we
++  # do some path munging in an attempt to make this legacy hiccup transparent
++  # to most. If this mechanism ever breaks, the fix is to configure explicitly
++  # with CMAKE_MODULE_PATH pointing at the directory in the ROCM SDK that
++  # contains FindHIP.cmake.
++  function(find_rocm_sdk_module_path)
++    set(hip_lib_dir "${hip_LIB_INSTALL_DIR}")
++    foreach(candidate_path "${hip_lib_dir}/cmake" "${hip_lib_dir}/cmake/hip")
++      if(EXISTS "${candidate_path}/FindHIP.cmake")
++        list(PREPEND CMAKE_MODULE_PATH "${candidate_path}")
++        message(STATUS "Legacy FindHIP.cmake module found in ${candidate_path}")
++        set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
++        return()
++      endif()
++    endforeach()
++
++    message(STATUS "Could not locate legacy FindHIP.cmake: You may need to set CMAKE_MODULE_PATH explicitly to its location")
++  endfunction()
++  find_rocm_sdk_module_path()
++  find_package(HIP 1.0 MODULE REQUIRED)
++
++  set(HIP_NEW_TYPE_ENUMS ON)
++  set(PYTORCH_FOUND_HIP ON)
++endmacro()
++
++message(STATUS "___ROCM")
++set(PYTORCH_FOUND_HIP FALSE)
++set(HIP_PLATFORM "amd")
++find_package(hip CONFIG)
++if(hip_FOUND)
++  pytorch_load_hip()
+ endif()
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.6.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.6.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
@@ -1,0 +1,49 @@
+From 8159ca32bf8dae607ffc31e22d0f9cdcd33c5b89 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Wed, 19 Feb 2025 17:14:59 -0800
+Subject: [PATCH 2/7] Generate composable_kernel ck/config.h as part of main
+ build.
+
+Without this, the ck/config.h comes from somewhere, most probably a ROCM SDK that has it installed as a sibling to the HIP headers. Not all ROCM SDKs include this, and even so, it is dangerous to have a sheared header dependency like this.
+---
+ aten/src/ATen/CMakeLists.txt | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
+index f0868ea048..293fa8ace3 100644
+--- a/aten/src/ATen/CMakeLists.txt
++++ b/aten/src/ATen/CMakeLists.txt
+@@ -311,9 +311,30 @@ if(USE_CUDA)
+ endif()
+ 
+ if(USE_ROCM)
++  # NOTE: The PyTorch build does not actually add_subdirectory 
++  # third_party/composable_kernel or use it as a CMake library. What is used
++  # is header only, so this should be ok, except that the CMake build generates
++  # a ck/config.h. We just do that part here. Without this, the ck.h from the
++  # ROCM SDK may get accidentally used instead.
++  function(_pytorch_rocm_generate_ck_conf)
++    set(CK_ENABLE_INT8 "ON")
++    set(CK_ENABLE_FP16 "ON")
++    set(CK_ENABLE_FP32 "ON")
++    set(CK_ENABLE_FP64 "ON")
++    set(CK_ENABLE_BF16 "ON")
++    set(CK_ENABLE_FP8 "ON")
++    set(CK_ENABLE_BF8 "ON")
++    configure_file(
++      "${Torch_SOURCE_DIR}/third_party/composable_kernel/include/ck/config.h.in"
++      "${CMAKE_CURRENT_BINARY_DIR}/composable_kernel/ck/config.h"
++      )
++  endfunction()
+   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/hip)
+   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/composable_kernel/include)
+   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/composable_kernel/library/include)
++  list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_BINARY_DIR}/composable_kernel)
++  _pytorch_rocm_generate_ck_conf()
++
+   # Next two lines are needed because TunableOp uses third-party/fmt
+   list(APPEND ATen_HIP_INCLUDE $<TARGET_PROPERTY:fmt::fmt-header-only,INTERFACE_INCLUDE_DIRECTORIES>)
+   list(APPEND ATen_HIP_DEPENDENCY_LIBS fmt::fmt-header-only)
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.6.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.6.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
@@ -1,0 +1,109 @@
+From e5275af669b66cc1e96c0b75de1d1865c5686e6b Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Wed, 19 Feb 2025 17:16:27 -0800
+Subject: [PATCH 3/7] TEMPORARY: Manually disable roctx until compatibility
+ with rocprofv3 is established.
+
+---
+ torch/csrc/cuda/shared/nvtx.cpp    | 19 ++++++++++++-------
+ torch/csrc/profiler/stubs/cuda.cpp | 11 ++++++++---
+ 2 files changed, 20 insertions(+), 10 deletions(-)
+
+diff --git a/torch/csrc/cuda/shared/nvtx.cpp b/torch/csrc/cuda/shared/nvtx.cpp
+index a14ba6b8f6..b5457030ce 100644
+--- a/torch/csrc/cuda/shared/nvtx.cpp
++++ b/torch/csrc/cuda/shared/nvtx.cpp
+@@ -1,11 +1,13 @@
+ #ifdef _WIN32
+ #include <wchar.h> // _wgetenv for nvtx
+ #endif
++/* TODO: Enable when rocprofv3 compat is available.
+ #ifdef TORCH_CUDA_USE_NVTX3
+ #include <roctracer/roctx.h>
+ #else
+ #include <roctracer/roctx.h>
+ #endif
++*/
+ #include <hip/hip_runtime.h>
+ #include <torch/csrc/utils/pybind.h>
+ 
+@@ -18,7 +20,8 @@ struct RangeHandle {
+ 
+ static void device_callback_range_end(void* userData) {
+   RangeHandle* handle = ((RangeHandle*)userData);
+-  roctxRangeStop(handle->id);
++  // TODO: Enable when rocprofv3 compat is available.
++  //roctxRangeStop(handle->id);
+   free((void*)handle->msg);
+   free((void*)handle);
+ }
+@@ -29,7 +32,9 @@ static void device_nvtxRangeEnd(void* handle, std::intptr_t stream) {
+ 
+ static void device_callback_range_start(void* userData) {
+   RangeHandle* handle = ((RangeHandle*)userData);
+-  handle->id = roctxRangeStartA(handle->msg);
++  // TODO: Enable when rocprofv3 compat is available.
++  // handle->id = roctxRangeStartA(handle->msg);
++  handle->id = 0;
+ }
+ 
+ static void* device_nvtxRangeStart(const char* msg, std::intptr_t stream) {
+@@ -49,11 +54,11 @@ void initNvtxBindings(PyObject* module) {
+ #else
+   auto nvtx = m.def_submodule("_nvtx", "libNvToolsExt.so bindings");
+ #endif
+-  nvtx.def("rangePushA", roctxRangePushA);
+-  nvtx.def("rangePop", roctxRangePop);
+-  nvtx.def("rangeStartA", roctxRangeStartA);
+-  nvtx.def("rangeEnd", roctxRangeStop);
+-  nvtx.def("markA", roctxMarkA);
++  nvtx.def("rangePushA", [](const char*) {} /*roctxRangePushA*/);
++  nvtx.def("rangePop", []() { } /*roctxRangePop*/);
++  nvtx.def("rangeStartA", [](const char*) { return 0; }/*roctxRangeStartA*/);
++  nvtx.def("rangeEnd", []() {}/*roctxRangeStop*/);
++  nvtx.def("markA", [](const char*) {}/*roctxMarkA */);
+   nvtx.def("deviceRangeStart", device_nvtxRangeStart);
+   nvtx.def("deviceRangeEnd", device_nvtxRangeEnd);
+ }
+diff --git a/torch/csrc/profiler/stubs/cuda.cpp b/torch/csrc/profiler/stubs/cuda.cpp
+index e4ad3fc8e6..a92c5bc95c 100644
+--- a/torch/csrc/profiler/stubs/cuda.cpp
++++ b/torch/csrc/profiler/stubs/cuda.cpp
+@@ -1,10 +1,12 @@
+ #include <sstream>
+ 
++/* TODO: Enable when rocprofv3 compat is in TheRock
+ #ifdef TORCH_CUDA_USE_NVTX3
+ #include <roctracer/roctx.h>
+ #else
+ #include <roctracer/roctx.h>
+ #endif
++*/
+ 
+ #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+ #include <c10/util/ApproximateClock.h>
+@@ -72,15 +74,18 @@ struct CUDAMethods : public ProfilerStubs {
+   }
+ 
+   void mark(const char* name) const override {
+-    ::roctxMark(name);
++    // TODO: Enable when rocprofv3 compat is available.
++    //::roctxMark(name);
+   }
+ 
+   void rangePush(const char* name) const override {
+-    ::roctxRangePushA(name);
++    // TODO: Enable when rocprofv3 compat is available.
++    //::roctxRangePushA(name);
+   }
+ 
+   void rangePop() const override {
+-    ::roctxRangePop();
++    // TODO: Enable when rocprofv3 compat is available.
++    //::roctxRangePop();
+   }
+ 
+   void onEachDevice(std::function<void(int)> op) const override {
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.6.0/pytorch/hipified/0004-Pin-cmake-4-since-v4-broke-old-pytorch-builds.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.6.0/pytorch/hipified/0004-Pin-cmake-4-since-v4-broke-old-pytorch-builds.patch
@@ -1,0 +1,22 @@
+From bb0bda318788d2bd04a1e302f642d6a8730d3c3b Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Tue, 1 Apr 2025 14:52:15 -0700
+Subject: [PATCH 4/7] Pin cmake<4 since v4 broke old pytorch builds.
+
+---
+ requirements.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/requirements.txt b/requirements.txt
+index 642d78e4f6..d02e1e9d7a 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -18,4 +18,4 @@ lintrunner
+ ninja
+ packaging
+ optree>=0.13.0
+-cmake
++cmake<4
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.6.0/pytorch/hipified/0005-Preload-rocm-sdk-binaries-if-available.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.6.0/pytorch/hipified/0005-Preload-rocm-sdk-binaries-if-available.patch
@@ -1,0 +1,57 @@
+From d3b8afe9cf5a8aee4a8151fd723e261d9e7163c0 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Tue, 1 Apr 2025 18:49:42 -0700
+Subject: [PATCH 5/7] Preload rocm-sdk binaries if available.
+
+---
+ torch/__init__.py | 27 ++++++++++++++++++++++++++-
+ 1 file changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/torch/__init__.py b/torch/__init__.py
+index f361c6b6cd..ec8c49e8eb 100644
+--- a/torch/__init__.py
++++ b/torch/__init__.py
+@@ -305,6 +305,29 @@ def _preload_cuda_deps(lib_folder: str, lib_name: str) -> None:
+ 
+ # See Note [Global dependencies]
+ def _load_global_deps() -> None:
++    # Preload ROCm deps if this torch was built to link against rocm-sdk wheels.
++    # TODO: Lookup distribution info for the torch package and see if it was
++    # build with PYTORCH_EXTRA_INSTALL_REQUIREMENTS="rocm-sdk" to enable
++    # ROCm preloading.
++    try:
++        import rocm_sdk
++    except ModuleNotFoundError:
++        pass
++    else:
++        import rocm_sdk
++        rocm_sdk.preload_libraries(
++            "amdhip64",
++            "rocprofiler-sdk-roctx",
++            "hiprtc",
++            "hipblas",
++            "hipfft",
++            "hiprand",
++            "hipsparse",
++            "hipsolver",
++            "rccl",
++            "hipblaslt",
++        )
++
+     if _running_with_deploy() or platform.system() == "Windows":
+         return
+ 
+@@ -2567,7 +2590,9 @@ def compile(
+         nopython=fullgraph,
+         dynamic=dynamic,
+         disable=disable,
+-    )(model)  # type: ignore[return-value]
++    )(
++        model
++    )  # type: ignore[return-value]
+ 
+ 
+ def _register_device_module(device_type, module):
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.6.0/pytorch/hipified/0006-link-correct-version-of-hsa-runtime-with-c10_hip.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.6.0/pytorch/hipified/0006-link-correct-version-of-hsa-runtime-with-c10_hip.patch
@@ -1,0 +1,35 @@
+From 835845d4328a0c774f6e761f1203e888c8045568 Mon Sep 17 00:00:00 2001
+From: Mika Laitio <mika.laitio@amd.com>
+Date: Tue, 29 Apr 2025 01:28:14 -0700
+Subject: [PATCH 6/7] link correct version of hsa-runtime with c10_hip
+
+link the version of hsa-runtime64 that is searched
+by LoadHIP.cmake instead of relying to it to be linked
+as an amdhip64 dependency without specifying the location.
+
+This fixes an error where the wrong version of library could
+be tried to be linked causing unresolved symbol errors.
+
+fixes: https://github.com/ROCm/TheRock/issues/474
+
+Signed-off-by: Mika Laitio <mika.laitio@amd.com>
+---
+ c10/hip/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/c10/hip/CMakeLists.txt b/c10/hip/CMakeLists.txt
+index f153030e79..a98ec6fa23 100644
+--- a/c10/hip/CMakeLists.txt
++++ b/c10/hip/CMakeLists.txt
+@@ -48,7 +48,7 @@ if(NOT BUILD_LIBTORCHLESS)
+   endif()
+ 
+   # ---[ Dependency of c10_hip
+-  target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::amdhip64)
++  target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::amdhip64 hsa-runtime64::hsa-runtime64)
+ 
+   target_include_directories(
+       c10_hip PUBLIC
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.6.0/pytorch/hipified/0007-rocm-clang-version-check-fix.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.6.0/pytorch/hipified/0007-rocm-clang-version-check-fix.patch
@@ -1,0 +1,37 @@
+From b884f8f05a7ca9cf856298321d91b62291acf673 Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Sat, 22 Mar 2025 08:51:34 -0700
+Subject: [PATCH 7/7] rocm clang version check fix
+
+clang in rocm sdk 6.3.3 returns 18.0git as a version.
+fix this by adding a check which converts it to
+18.0 without throwing an exception
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ torch/utils/cpp_extension.py | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/torch/utils/cpp_extension.py b/torch/utils/cpp_extension.py
+index b4a70dcc06..488ad2564f 100644
+--- a/torch/utils/cpp_extension.py
++++ b/torch/utils/cpp_extension.py
+@@ -414,6 +414,15 @@ def get_compiler_abi_compatibility_and_version(compiler) -> Tuple[bool, TorchVer
+         warnings.warn(f'Error checking compiler version for {compiler}: {error}')
+         return (False, TorchVersion('0.0.0'))
+ 
++    # manage version 18.0git returned by clang in rocm sdk 6.3.3
++    for ii in range(len(version)):
++        try:
++            version_item = version[ii]
++            test = int(version_item)
++        except ValueError:
++            version_item = '0'
++            version[ii] = version_item
++        print("version: " + version_item)
+     if tuple(map(int, version)) >= minimum_required_version:
+         return (True, TorchVersion('.'.join(version)))
+ 
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.6.0/third_party/composable_kernel/base/0001-Work-around-ambiguous-cast-of-half_t-__half-in-call-.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.6.0/third_party/composable_kernel/base/0001-Work-around-ambiguous-cast-of-half_t-__half-in-call-.patch
@@ -1,0 +1,29 @@
+From 64b64e642fe482acd0d262e22c7e6d9ee3cecc09 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Wed, 19 Feb 2025 17:17:01 -0800
+Subject: [PATCH] Work around ambiguous cast of half_t -> __half in call to
+ __hneg.
+
+Encountered on gcc 13.3 on a pre-release of ROCM 6.4.
+---
+ include/ck/utility/math_v2.hpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/include/ck/utility/math_v2.hpp b/include/ck/utility/math_v2.hpp
+index b374c4ad5..ca45911d1 100644
+--- a/include/ck/utility/math_v2.hpp
++++ b/include/ck/utility/math_v2.hpp
+@@ -611,7 +611,9 @@ inline __device__ int8_t neg<int8_t>(int8_t x)
+ template <>
+ inline __device__ half_t neg<half_t>(half_t x)
+ {
+-    return __hneg(x);
++    // Matches signature `__half __hneg(__half x)`. Without the cast, some
++    // compilers report an ambiguity.
++    return __hneg(static_cast<__half>(x));
+ };
+ 
+ template <typename T>
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.6.0/third_party/gloo/hipified/0001-Use-proper-find_package-to-locate-amdhip64.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.6.0/third_party/gloo/hipified/0001-Use-proper-find_package-to-locate-amdhip64.patch
@@ -1,0 +1,57 @@
+From ba78402efc4e7d9f6546302234e3546f842811d0 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Tue, 1 Apr 2025 15:34:34 -0700
+Subject: [PATCH] Use proper find_package to locate amdhip64.
+
+---
+ cmake/Hip.cmake | 18 ++++--------------
+ 1 file changed, 4 insertions(+), 14 deletions(-)
+
+diff --git a/cmake/Hip.cmake b/cmake/Hip.cmake
+index 18a3c07..ee36d2b 100644
+--- a/cmake/Hip.cmake
++++ b/cmake/Hip.cmake
+@@ -1,36 +1,26 @@
+ set(HAVE_HIP FALSE)
+ 
+-IF(NOT DEFINED ENV{ROCM_PATH})
+-  SET(ROCM_PATH /opt/rocm)
+-ELSE()
+-  SET(ROCM_PATH $ENV{ROCM_PATH})
+-ENDIF()
+-
+ IF(NOT DEFINED ENV{GLOO_ROCM_ARCH})
+   SET(GLOO_ROCM_ARCH gfx906;gfx908;gfx90a)
+ ELSE()
+   SET(GLOO_ROCM_ARCH $ENV{GLOO_ROCM_ARCH})
+ ENDIF()
+ 
+-# Add HIP to the CMAKE Module Path
+-set(CMAKE_MODULE_PATH ${ROCM_PATH}/lib/cmake/hip ${CMAKE_MODULE_PATH})
+-
+ # Disable Asserts In Code (Can't use asserts on HIP stack.)
+ ADD_DEFINITIONS(-DNDEBUG)
+ 
+ # Find the HIP Package
+ find_package(HIP 1.0)
++find_package(hip CONFIG)
+ 
+-IF(HIP_FOUND)
++IF(HIP_FOUND AND hip_FOUND)
+   set(HAVE_HIP TRUE)
+ 
+-  set(hip_library_name amdhip64)
++  set(hip_library_name hip::host)
+   message("HIP library name: ${hip_library_name}")
+-
++  set(GLOO_HIP_HCC_LIBRARIES "hip::host")
+   set(CMAKE_HCC_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+   set(CMAKE_HCC_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+-  FIND_LIBRARY(GLOO_HIP_HCC_LIBRARIES ${hip_library_name} HINTS ${ROCM_PATH}/lib)
+-
+ ENDIF()
+ 
+ ################################################################################
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
@@ -1,0 +1,340 @@
+From af048d5fc7734d944c01b0f578b1dd4b4ab88820 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Mon, 17 Feb 2025 16:47:57 -0800
+Subject: [PATCH 1/8] Rework LoadHIP.cmake to be based purely on
+ CMAKE_PREFIX_PATH.
+
+* Eliminates dependence on `/opt/rocm` and path based heuristics.
+* Normalizes package finding for Rocm 6.5+ layout.
+* Workaround cmake >= 4.0 for hiprtc
+
+Co-authored-by: Scott Tsai <scottt.tw@gmail.com>
+---
+ cmake/public/LoadHIP.cmake | 303 ++++++++++++++-----------------------
+ 1 file changed, 111 insertions(+), 192 deletions(-)
+
+diff --git a/cmake/public/LoadHIP.cmake b/cmake/public/LoadHIP.cmake
+index 58c74ddda3..57910495fc 100644
+--- a/cmake/public/LoadHIP.cmake
++++ b/cmake/public/LoadHIP.cmake
+@@ -1,206 +1,125 @@
+-set(PYTORCH_FOUND_HIP FALSE)
+-
+-# If ROCM_PATH is set, assume intention is to compile with
+-# ROCm support and error out if the ROCM_PATH does not exist.
+-# Else ROCM_PATH does not exist, assume a default of /opt/rocm
+-# In the latter case, if /opt/rocm does not exist emit status
+-# message and return.
+-if(DEFINED ENV{ROCM_PATH})
+-  set(ROCM_PATH $ENV{ROCM_PATH})
+-  if(NOT EXISTS ${ROCM_PATH})
+-    message(FATAL_ERROR
+-      "ROCM_PATH environment variable is set to ${ROCM_PATH} but does not exist.\n"
+-      "Set a valid ROCM_PATH or unset ROCM_PATH environment variable to fix.")
+-  endif()
+-else()
+-  if(UNIX)
+-    set(ROCM_PATH /opt/rocm)
+-  else() # Win32
+-    set(ROCM_PATH C:/opt/rocm)
+-  endif()
+-  if(NOT EXISTS ${ROCM_PATH})
+-    message(STATUS
+-        "ROCM_PATH environment variable is not set and ${ROCM_PATH} does not exist.\n"
+-        "Building without ROCm support.")
+-    return()
+-  endif()
+-endif()
+-
+-if(NOT DEFINED ENV{ROCM_INCLUDE_DIRS})
+-  set(ROCM_INCLUDE_DIRS ${ROCM_PATH}/include)
+-else()
+-  set(ROCM_INCLUDE_DIRS $ENV{ROCM_INCLUDE_DIRS})
+-endif()
+-
+-# MAGMA_HOME
+-if(NOT DEFINED ENV{MAGMA_HOME})
+-  set(MAGMA_HOME ${ROCM_PATH}/magma)
+-  set(ENV{MAGMA_HOME} ${ROCM_PATH}/magma)
+-else()
+-  set(MAGMA_HOME $ENV{MAGMA_HOME})
+-endif()
+-
+-# MIOpen isn't a part of HIP-SDK for Windows and hence, may have a different
+-# installation directory.
+-if(WIN32)
+-  if(NOT DEFINED ENV{MIOPEN_PATH})
+-    set(miopen_DIR C:/opt/miopen/lib/cmake/miopen)
+-  else()
+-    set(miopen_DIR $ENV{MIOPEN_PATH}/lib/cmake/miopen)
+-  endif()
+-endif()
+-
+-torch_hip_get_arch_list(PYTORCH_ROCM_ARCH)
+-if(PYTORCH_ROCM_ARCH STREQUAL "")
+-  message(FATAL_ERROR "No GPU arch specified for ROCm build. Please use PYTORCH_ROCM_ARCH environment variable to specify GPU archs to build for.")
+-endif()
+-message("Building PyTorch for GPU arch: ${PYTORCH_ROCM_ARCH}")
+-
+-# Add HIP to the CMAKE Module Path
+-# needed because the find_package call to this module uses the Module mode search
+-# https://cmake.org/cmake/help/latest/command/find_package.html#search-modes
+-if(UNIX)
+-  set(CMAKE_MODULE_PATH ${ROCM_PATH}/lib/cmake/hip ${CMAKE_MODULE_PATH})
+-else() # Win32
+-  set(CMAKE_MODULE_PATH ${ROCM_PATH}/cmake/ ${CMAKE_MODULE_PATH})
+-endif()
+-
+-# Add ROCM_PATH to CMAKE_PREFIX_PATH, needed because the find_package
+-# call to individual ROCM components uses the Config mode search
+-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
+-
+-macro(find_package_and_print_version PACKAGE_NAME)
+-  find_package("${PACKAGE_NAME}" ${ARGN})
+-  message("${PACKAGE_NAME} VERSION: ${${PACKAGE_NAME}_VERSION}")
+-endmacro()
+-
+-# Find the HIP Package
+-# MODULE argument is added for clarity that CMake is searching
+-# for FindHIP.cmake in Module mode
+-find_package_and_print_version(HIP 1.0 MODULE)
+-
+-if(HIP_FOUND)
+-  set(PYTORCH_FOUND_HIP TRUE)
+-
+-  # Find ROCM version for checks
+-  if(UNIX)
+-    set(ROCM_VERSION_HEADER_PATH ${ROCM_INCLUDE_DIRS}/rocm-core/rocm_version.h)
+-  else()
+-    set(ROCM_VERSION_HEADER_PATH ${ROCM_INCLUDE_DIRS}/hip/hip_version.h)
+-  endif()
+-  get_filename_component(ROCM_HEADER_NAME ${ROCM_VERSION_HEADER_PATH} NAME)
++macro(pytorch_load_hip)
++  find_package(hip REQUIRED CONFIG)
++  message(STATUS "hip version: ${hip_VERSION}")
++  find_package(amd_comgr REQUIRED)
++  message(STATUS "amd_comgr version: ${amd_comgr_VERSION}")
++  find_package(rocrand REQUIRED)
++  message(STATUS "rocrand version: ${rocrand_VERSION}")
++  find_package(hiprand REQUIRED)
++  message(STATUS "hiprand version: ${hiprand_VERSION}")
++  find_package(rocblas REQUIRED)
++  message(STATUS "rocblas version: ${rocblas_VERSION}")
++  find_package(hipblas REQUIRED)
++  message(STATUS "hipblas_VERSION: ${hipblas_VERSION}")
++  find_package(miopen REQUIRED)
++  message(STATUS "miopen version: ${miopen_VERSION}")
++  find_package(hipfft REQUIRED)
++  message(STATUS "hipfft version: ${hipfft_VERSION}")
++  find_package(hipsparse REQUIRED)
++  message(STATUS "hipsparse version: ${hipsparse_VERSION}")
++  find_package(rocprim REQUIRED)
++  message(STATUS "rocprim version: ${rocprim_VERSION}")
++  find_package(hipcub REQUIRED)
++  message(STATUS "hipcub version: ${hipcub_VERSION}")
++  find_package(rocthrust REQUIRED)
++  message(STATUS "rocthrust version: ${rocthrust_VERSION}")
++  find_package(hipsolver REQUIRED)
++  message(STATUS "hipsolver versio: ${hipsolver_VERSION}")
+ 
+-  if(EXISTS ${ROCM_VERSION_HEADER_PATH})
+-    set(ROCM_HEADER_FILE ${ROCM_VERSION_HEADER_PATH})
++  if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
++    message(WARNING "Work around hiprtc cmake failure for cmake >= 4")
++    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
++    find_package(hiprtc REQUIRED)
++    unset(CMAKE_POLICY_VERSION_MINIMUM)
+   else()
+-    message(FATAL_ERROR "********************* ${ROCM_HEADER_NAME} could not be found ******************\n")
++    find_package(hiprtc REQUIRED)
+   endif()
+-
+-  # Read the ROCM headerfile into a variable
+-  file(READ ${ROCM_HEADER_FILE} ROCM_HEADER_CONTENT)
+-
+-  # Since Windows currently supports only a part of ROCm and names it HIP-SDK,
+-  # we need to refer to the HIP-SDK equivalents of entities existing in ROCm lib.
+-  if(UNIX)
+-    set(ROCM_LIB_NAME "ROCM")
+-  else() # Win32
+-    set(ROCM_LIB_NAME "HIP")
+-  endif()
+-  # Below we use a RegEx to find ROCM version numbers.
+-  # Note that CMake does not support \s for blank space. That is
+-  # why in the regular expressions below we have a blank space in
+-  # the square brackets.
+-  # There are three steps:
+-  # 1. Match regular expression
+-  # 2. Strip the non-numerical part of the string
+-  # 3. Strip leading and trailing spaces
+-
+-  string(REGEX MATCH "${ROCM_LIB_NAME}_VERSION_MAJOR[ ]+[0-9]+" TEMP1 ${ROCM_HEADER_CONTENT})
+-  string(REPLACE "${ROCM_LIB_NAME}_VERSION_MAJOR" "" TEMP2 ${TEMP1})
+-  string(STRIP ${TEMP2} ROCM_VERSION_DEV_MAJOR)
+-  string(REGEX MATCH "${ROCM_LIB_NAME}_VERSION_MINOR[ ]+[0-9]+" TEMP1 ${ROCM_HEADER_CONTENT})
+-  string(REPLACE "${ROCM_LIB_NAME}_VERSION_MINOR" "" TEMP2 ${TEMP1})
+-  string(STRIP ${TEMP2} ROCM_VERSION_DEV_MINOR)
+-  string(REGEX MATCH "${ROCM_LIB_NAME}_VERSION_PATCH[ ]+[0-9]+" TEMP1 ${ROCM_HEADER_CONTENT})
+-  string(REPLACE "${ROCM_LIB_NAME}_VERSION_PATCH" "" TEMP2 ${TEMP1})
+-  string(STRIP ${TEMP2} ROCM_VERSION_DEV_PATCH)
++  message(STATUS "hiprtc version: ${hiprtc_VERSION}")
++
++  # Original version made these UNIX-only.
++  find_package(rccl REQUIRED)
++  message(STATUS "rccl version: ${rccl_VERSION}")
++  find_package(hsa-runtime64 REQUIRED)
++  message(STATUS "hsa-runtime64 version: ${hsa-runtime64_VERSION}")
++  find_package(hipblaslt REQUIRED)
++  message(STATUS "hipblaslt version: ${hipblaslt_VERSION}")
++
++  # Extract ROCM version parts from the hip package version.
++  string(REPLACE "." ";" ROCM_VERSION_PARTS "${hip_VERSION}")
++  list(GET ROCM_VERSION_PARTS 0 ROCM_VERSION_DEV_MAJOR)
++  list(GET ROCM_VERSION_PARTS 1 ROCM_VERSION_DEV_MINOR)
++  list(GET ROCM_VERSION_PARTS 2 ROCM_VERSION_DEV_PATCH)
++  set(ROCM_VERSION "${ROCM_VERSION_DEV_MAJOR}.${ROCM_VERSION_DEV_MINOR}.${ROCM_VERSION_DEV_PATCH}")
++
++  message(STATUS "\n***** ROCm version: ****\n")
++  message(STATUS "  ROCM_VERSION: ${ROCM_VERSION}")
++  message(STATUS "  ROCM_VERSION_DEV_MAJOR: ${ROCM_VERSION_DEV_MAJOR}")
++  message(STATUS "  ROCM_VERSION_DEV_MINOR: ${ROCM_VERSION_DEV_MINOR}")
++  message(STATUS "  ROCM_VERSION_DEV_PATCH: ${ROCM_VERSION_DEV_PATCH}")
++  message(STATUS "  HIP_VERSION_MAJOR: ${ROCM_VERSION_DEV_MAJOR}")
++  message(STATUS "  HIP_VERSION_MINOR: ${ROCM_VERSION_DEV_MINOR}")
+ 
+   # Create ROCM_VERSION_DEV_INT which is later used as a preprocessor macros
+   set(ROCM_VERSION_DEV "${ROCM_VERSION_DEV_MAJOR}.${ROCM_VERSION_DEV_MINOR}.${ROCM_VERSION_DEV_PATCH}")
+   math(EXPR ROCM_VERSION_DEV_INT "(${ROCM_VERSION_DEV_MAJOR}*10000) + (${ROCM_VERSION_DEV_MINOR}*100) + ${ROCM_VERSION_DEV_PATCH}")
+-
+-  message("\n***** ROCm version from ${ROCM_HEADER_NAME} ****\n")
+-  message("ROCM_VERSION_DEV: ${ROCM_VERSION_DEV}")
+-  message("ROCM_VERSION_DEV_MAJOR: ${ROCM_VERSION_DEV_MAJOR}")
+-  message("ROCM_VERSION_DEV_MINOR: ${ROCM_VERSION_DEV_MINOR}")
+-  message("ROCM_VERSION_DEV_PATCH: ${ROCM_VERSION_DEV_PATCH}")
+-  message("ROCM_VERSION_DEV_INT:   ${ROCM_VERSION_DEV_INT}")
+-
+-  math(EXPR TORCH_HIP_VERSION "(${HIP_VERSION_MAJOR} * 100) + ${HIP_VERSION_MINOR}")
+-  message("HIP_VERSION_MAJOR: ${HIP_VERSION_MAJOR}")
+-  message("HIP_VERSION_MINOR: ${HIP_VERSION_MINOR}")
+-  message("TORCH_HIP_VERSION: ${TORCH_HIP_VERSION}")
+-
+-  # Find ROCM components using Config mode
+-  # These components will be searced for recursively in ${ROCM_PATH}
+-  message("\n***** Library versions from cmake find_package *****\n")
+-  find_package_and_print_version(hip REQUIRED CONFIG)
+-  find_package_and_print_version(amd_comgr REQUIRED)
+-  find_package_and_print_version(rocrand REQUIRED)
+-  find_package_and_print_version(hiprand REQUIRED)
+-  find_package_and_print_version(rocblas REQUIRED)
+-  find_package_and_print_version(hipblas REQUIRED)
+-  find_package_and_print_version(miopen REQUIRED)
+-  find_package_and_print_version(hipfft REQUIRED)
+-  find_package_and_print_version(hipsparse REQUIRED)
+-  find_package_and_print_version(rocprim REQUIRED)
+-  find_package_and_print_version(hipcub REQUIRED)
+-  find_package_and_print_version(rocthrust REQUIRED)
+-  find_package_and_print_version(hipsolver REQUIRED)
+-  # workaround cmake 4 build issue
+-  if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+-    message(WARNING "Work around hiprtc cmake failure for cmake >= 4")
+-    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+-    find_package_and_print_version(hiprtc REQUIRED)
+-    unset(CMAKE_POLICY_VERSION_MINIMUM)
++  math(EXPR TORCH_HIP_VERSION "(${ROCM_VERSION_DEV_MAJOR} * 100) + ${ROCM_VERSION_DEV_MINOR}")
++
++  message(STATUS "  ROCM_VERSION_DEV_INT:   ${ROCM_VERSION_DEV_INT}")
++  message(STATUS "  TORCH_HIP_VERSION: ${TORCH_HIP_VERSION}")
++
++  # Locate the ROCM_ROCTX_LIB that kineto depends on. This is either part of
++  # roctracer (deprecated) and located with find_library(roctx64) or it is
++  # part of rocprofiler-sdk (aka. rocprofiler v3) as the rocprofiler-sdk-tx
++  # library.
++  # TODO: This isn't quite right and needs to mate up with whether kineto
++  # depends on roctracer or rocprofiler-sdk. The coupling here is fragile and
++  # needs to be reworked.
++  find_package(rocprofiler-sdk-roctx)
++  if(rocprofiler-sdk-roctx_FOUND)
++    message(STATUS "rocprofiler-sdk-roctx version: ${rocprofiler-sdk-roctx_VERSION} found (will use instead of roctracer)")
++    set(ROCM_ROCTX_LIB rocprofiler-sdk-roctx::rocprofiler-sdk-roctx-shared-library)
+   else()
+-    find_package_and_print_version(hiprtc REQUIRED)
++    find_library(ROCM_ROCTX_LIB roctx64)
++    if(NOT ROCM_ROCTX_LIB)
++      cmake(WARNING "Neither rocprofiler-sdk nor libroctx64.so was found: This may result in errors if components rely on it")
++    endif()
+   endif()
+-  find_package_and_print_version(hipblaslt REQUIRED)
+ 
+-  if(UNIX)
+-    find_package_and_print_version(rccl)
+-    find_package_and_print_version(hsa-runtime64 REQUIRED)
++  # PyTorch makes some use of hip_add_library and friends, which are only
++  # available in the legacy FindHIP.cmake finder module. This is bundled in the
++  # same CMAKE_PREFIX_PATH as is used for the regular packages, but is put in
++  # a different place on Linux vs Windows for reasons that are lost to time:
++  #   Linux: lib/cmake/hip/FindHIP.cmake
++  #   Windows: lib/cmake/FindHIP.cmake
++  # While we could ask the user to provide an explicit CMAKE_MODULE_PATH, we
++  # do some path munging in an attempt to make this legacy hiccup transparent
++  # to most. If this mechanism ever breaks, the fix is to configure explicitly
++  # with CMAKE_MODULE_PATH pointing at the directory in the ROCM SDK that
++  # contains FindHIP.cmake.
++  function(find_rocm_sdk_module_path)
++    set(hip_lib_dir "${hip_LIB_INSTALL_DIR}")
++    foreach(candidate_path "${hip_lib_dir}/cmake" "${hip_lib_dir}/cmake/hip")
++      if(EXISTS "${candidate_path}/FindHIP.cmake")
++        list(PREPEND CMAKE_MODULE_PATH "${candidate_path}")
++        message(STATUS "Legacy FindHIP.cmake module found in ${candidate_path}")
++        set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
++        return()
++      endif()
++    endforeach()
+ 
+-    # roctx is part of roctracer
+-    find_library(ROCM_ROCTX_LIB roctx64 HINTS ${ROCM_PATH}/lib)
++    message(STATUS "Could not locate legacy FindHIP.cmake: You may need to set CMAKE_MODULE_PATH explicitly to its location")
++  endfunction()
++  find_rocm_sdk_module_path()
++  find_package(HIP 1.0 MODULE REQUIRED)
+ 
+-    set(PROJECT_RANDOM_BINARY_DIR "${PROJECT_BINARY_DIR}")
++  set(HIP_NEW_TYPE_ENUMS ON)
++  set(PYTORCH_FOUND_HIP ON)
++endmacro()
+ 
+-    if(ROCM_VERSION_DEV VERSION_GREATER_EQUAL "5.7.0")
+-      # check whether hipblaslt provides HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT
+-      set(file "${PROJECT_BINARY_DIR}/hipblaslt_test_vec_ext.cc")
+-      file(WRITE ${file} ""
+-        "#define LEGACY_HIPBLAS_DIRECT\n"
+-        "#include <hipblaslt/hipblaslt.h>\n"
+-        "int main() {\n"
+-        "    hipblasLtMatmulDescAttributes_t attr = HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT;\n"
+-        "    return 0;\n"
+-        "}\n"
+-        )
+-      try_compile(hipblaslt_compile_result_vec_ext ${PROJECT_RANDOM_BINARY_DIR} ${file}
+-        CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${ROCM_INCLUDE_DIRS}"
+-        COMPILE_DEFINITIONS -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
+-        OUTPUT_VARIABLE hipblaslt_compile_output)
+-      if(hipblaslt_compile_result_vec_ext)
+-        set(HIPBLASLT_VEC_EXT ON)
+-        #message("hipblaslt is using scale pointer vec ext: ${hipblaslt_compile_output}")
+-        message("hipblaslt is using scale pointer vec ext")
+-      else()
+-        set(HIPBLASLT_VEC_EXT OFF)
+-        message("hipblaslt is NOT using scale pointer vec ext: ${hipblaslt_compile_output}")
+-        #message("hipblaslt is NOT using scale pointer vec ext")
+-      endif()
+-    endif()
+-  endif()
++message(STATUS "___ROCM")
++set(PYTORCH_FOUND_HIP FALSE)
++set(HIP_PLATFORM "amd")
++find_package(hip CONFIG)
++if(hip_FOUND)
++  pytorch_load_hip()
+ endif()
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
@@ -1,0 +1,49 @@
+From a25220d766bd9a47c21475e62a213ee2bad64c51 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Wed, 19 Feb 2025 17:14:59 -0800
+Subject: [PATCH 2/8] Generate composable_kernel ck/config.h as part of main
+ build.
+
+Without this, the ck/config.h comes from somewhere, most probably a ROCM SDK that has it installed as a sibling to the HIP headers. Not all ROCM SDKs include this, and even so, it is dangerous to have a sheared header dependency like this.
+---
+ aten/src/ATen/CMakeLists.txt | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
+index 085af373ec..67322e8f56 100644
+--- a/aten/src/ATen/CMakeLists.txt
++++ b/aten/src/ATen/CMakeLists.txt
+@@ -343,9 +343,30 @@ if(USE_CUDA)
+ endif()
+ 
+ if(USE_ROCM)
++  # NOTE: The PyTorch build does not actually add_subdirectory 
++  # third_party/composable_kernel or use it as a CMake library. What is used
++  # is header only, so this should be ok, except that the CMake build generates
++  # a ck/config.h. We just do that part here. Without this, the ck.h from the
++  # ROCM SDK may get accidentally used instead.
++  function(_pytorch_rocm_generate_ck_conf)
++    set(CK_ENABLE_INT8 "ON")
++    set(CK_ENABLE_FP16 "ON")
++    set(CK_ENABLE_FP32 "ON")
++    set(CK_ENABLE_FP64 "ON")
++    set(CK_ENABLE_BF16 "ON")
++    set(CK_ENABLE_FP8 "ON")
++    set(CK_ENABLE_BF8 "ON")
++    configure_file(
++      "${Torch_SOURCE_DIR}/third_party/composable_kernel/include/ck/config.h.in"
++      "${CMAKE_CURRENT_BINARY_DIR}/composable_kernel/ck/config.h"
++      )
++  endfunction()
+   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/hip)
+   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/composable_kernel/include)
+   list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/composable_kernel/library/include)
++  list(APPEND ATen_HIP_INCLUDE ${CMAKE_CURRENT_BINARY_DIR}/composable_kernel)
++  _pytorch_rocm_generate_ck_conf()
++
+   # Next two lines are needed because TunableOp uses third-party/fmt
+   list(APPEND ATen_HIP_INCLUDE $<TARGET_PROPERTY:fmt::fmt-header-only,INTERFACE_INCLUDE_DIRECTORIES>)
+   list(APPEND ATen_HIP_DEPENDENCY_LIBS fmt::fmt-header-only)
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
@@ -1,0 +1,113 @@
+From 9602dc241c0adb1e4f463a1bbc4b5d60e4e74f76 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Mon, 31 Mar 2025 18:54:56 +0100
+Subject: [PATCH 3/8] TEMPORARY: Manually disable roctx until compatibility
+ with rocprofv3 is established.
+
+---
+ torch/csrc/cuda/shared/nvtx.cpp    | 21 +++++++++++++--------
+ torch/csrc/profiler/stubs/cuda.cpp | 11 ++++++++---
+ 2 files changed, 21 insertions(+), 11 deletions(-)
+
+diff --git a/torch/csrc/cuda/shared/nvtx.cpp b/torch/csrc/cuda/shared/nvtx.cpp
+index 40e9821389..0ce2dd34b5 100644
+--- a/torch/csrc/cuda/shared/nvtx.cpp
++++ b/torch/csrc/cuda/shared/nvtx.cpp
+@@ -1,13 +1,14 @@
+ #ifdef _WIN32
+ #include <wchar.h> // _wgetenv for nvtx
+ #endif
+-
+ #ifndef ROCM_ON_WINDOWS
++/* TODO: Enable when rocprofv3 compat is available.
+ #ifdef TORCH_CUDA_USE_NVTX3
+ #include <roctracer/roctx.h>
+ #else // TORCH_CUDA_USE_NVTX3
+ #include <roctracer/roctx.h>
+ #endif // TORCH_CUDA_USE_NVTX3
++*/
+ #else // ROCM_ON_WINDOWS
+ #include <c10/util/Exception.h>
+ #endif // ROCM_ON_WINDOWS
+@@ -25,7 +26,9 @@ struct RangeHandle {
+ 
+ static void device_callback_range_end(void* userData) {
+   RangeHandle* handle = ((RangeHandle*)userData);
+-  roctxRangeStop(handle->id);
++  // TODO: Enable when rocprofv3 compat is available.
++  // handle->id = roctxRangeStartA(handle->msg);
++  //roctxRangeStop(handle->id);
+   free((void*)handle->msg);
+   free((void*)handle);
+ }
+@@ -37,7 +40,9 @@ static void device_nvtxRangeEnd(void* handle, std::intptr_t stream) {
+ 
+ static void device_callback_range_start(void* userData) {
+   RangeHandle* handle = ((RangeHandle*)userData);
+-  handle->id = roctxRangeStartA(handle->msg);
++  // TODO: Enable when rocprofv3 compat is available.
++  //handle->id = roctxRangeStartA(handle->msg);
++  handle->id = 0;
+ }
+ 
+ static void* device_nvtxRangeStart(const char* msg, std::intptr_t stream) {
+@@ -59,11 +64,11 @@ void initNvtxBindings(PyObject* module) {
+ #else
+   auto nvtx = m.def_submodule("_nvtx", "libNvToolsExt.so bindings");
+ #endif
+-  nvtx.def("rangePushA", roctxRangePushA);
+-  nvtx.def("rangePop", roctxRangePop);
+-  nvtx.def("rangeStartA", roctxRangeStartA);
+-  nvtx.def("rangeEnd", roctxRangeStop);
+-  nvtx.def("markA", roctxMarkA);
++  nvtx.def("rangePushA", [](const char*) {} /*roctxRangePushA*/);
++  nvtx.def("rangePop", []() { } /*roctxRangePop*/);
++  nvtx.def("rangeStartA", [](const char*) { return 0; }/*roctxRangeStartA*/);
++  nvtx.def("rangeEnd", []() {}/*roctxRangeStop*/);
++  nvtx.def("markA", [](const char*) {}/*roctxMarkA */);
+   nvtx.def("deviceRangeStart", device_nvtxRangeStart);
+   nvtx.def("deviceRangeEnd", device_nvtxRangeEnd);
+ }
+diff --git a/torch/csrc/profiler/stubs/cuda.cpp b/torch/csrc/profiler/stubs/cuda.cpp
+index 37364dfc93..0ed35059a1 100644
+--- a/torch/csrc/profiler/stubs/cuda.cpp
++++ b/torch/csrc/profiler/stubs/cuda.cpp
+@@ -1,11 +1,13 @@
+ #include <sstream>
+ 
+ #ifndef ROCM_ON_WINDOWS
++/* TODO: Enable when rocprofv3 compat is in TheRock
+ #ifdef TORCH_CUDA_USE_NVTX3
+ #include <roctracer/roctx.h>
+ #else
+ #include <roctracer/roctx.h>
+ #endif
++*/
+ #else // ROCM_ON_WINDOWS
+ #include <c10/util/Exception.h>
+ #endif // ROCM_ON_WINDOWS
+@@ -76,15 +78,18 @@ struct CUDAMethods : public ProfilerStubs {
+ 
+ #ifndef ROCM_ON_WINDOWS
+   void mark(const char* name) const override {
+-    ::roctxMark(name);
++    // TODO: Enable when rocprofv3 compat is available.
++    // ::roctxMark(name);
+   }
+ 
+   void rangePush(const char* name) const override {
+-    ::roctxRangePushA(name);
++    // TODO: Enable when rocprofv3 compat is available.
++    // ::roctxRangePushA(name);
+   }
+ 
+   void rangePop() const override {
+-    ::roctxRangePop();
++    // TODO: Enable when rocprofv3 compat is available.
++    // ::roctxRangePop();
+   }
+ #else // ROCM_ON_WINDOWS
+   static void printUnavailableWarning() {
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0004-enable-hipBLASLt-for-gfx-1102-1150-1151-1201.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0004-enable-hipBLASLt-for-gfx-1102-1150-1151-1201.patch
@@ -1,0 +1,28 @@
+From e467e14796975c863e180b1211535bfc5adbab02 Mon Sep 17 00:00:00 2001
+From: Scott Tsai <scottt.tw@gmail.com>
+Date: Sun, 23 Mar 2025 13:16:25 +0800
+Subject: [PATCH 4/8] enable hipBLASLt for gfx{1102,1150,1151,1201}
+
+Pytorch upstream should integrate this once the following change
+is in a ROCm release:
+https://github.com/ROCm/hipBLASLt/pull/1766
+---
+ aten/src/ATen/Context.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/aten/src/ATen/Context.cpp b/aten/src/ATen/Context.cpp
+index 01f223f4e5..d384b5e6b2 100644
+--- a/aten/src/ATen/Context.cpp
++++ b/aten/src/ATen/Context.cpp
+@@ -359,7 +359,7 @@ at::BlasBackend Context::blasPreferredBackend() {
+       static const std::vector<std::string> archs = {
+           "gfx90a", "gfx942",
+ #if ROCM_VERSION >= 60300
+-          "gfx1100", "gfx1101", "gfx1200", "gfx1201"
++          "gfx1100", "gfx1101", "gfx1150", "gfx1151", "gfx1200", "gfx1201"
+ #endif
+ #if ROCM_VERSION >= 60500
+           "gfx950"
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0005-Add-gfx1150-gfx1151-to-hipblaslt-support-list-in-Bla.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0005-Add-gfx1150-gfx1151-to-hipblaslt-support-list-in-Bla.patch
@@ -1,0 +1,39 @@
+From 2957daeeff9ea1bfc0598f0b372850f746ba7342 Mon Sep 17 00:00:00 2001
+From: Aaryaman Vasishta <jem456.vasishta@gmail.com>
+Date: Mon, 31 Mar 2025 19:27:48 +0100
+Subject: [PATCH 5/8] Add gfx1150/gfx1151 to hipblaslt support list in Blas.cpp
+
+---
+ aten/src/ATen/native/cuda/Blas.cpp | 2 +-
+ aten/src/ATen/native/hip/Blas.cpp  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/aten/src/ATen/native/cuda/Blas.cpp b/aten/src/ATen/native/cuda/Blas.cpp
+index 28936cc034..592c04693c 100644
+--- a/aten/src/ATen/native/cuda/Blas.cpp
++++ b/aten/src/ATen/native/cuda/Blas.cpp
+@@ -259,7 +259,7 @@ static bool isSupportedHipLtROCmArch(int index) {
+     static const std::vector<std::string> archs = {
+         "gfx90a", "gfx942",
+ #if ROCM_VERSION >= 60300
+-        "gfx1100", "gfx1101", "gfx1200", "gfx1201"
++        "gfx1100", "gfx1101", "gfx1150", "gfx1151", "gfx1200", "gfx1201"
+ #endif
+ #if ROCM_VERSION >= 60500
+         "gfx950"
+diff --git a/aten/src/ATen/native/hip/Blas.cpp b/aten/src/ATen/native/hip/Blas.cpp
+index 467ff69892..576bd7f72c 100644
+--- a/aten/src/ATen/native/hip/Blas.cpp
++++ b/aten/src/ATen/native/hip/Blas.cpp
+@@ -260,7 +260,7 @@ static bool isSupportedHipLtROCmArch(int index) {
+     static const std::vector<std::string> archs = {
+         "gfx90a", "gfx942",
+ #if ROCM_VERSION >= 60300
+-        "gfx1100", "gfx1101", "gfx1200", "gfx1201"
++        "gfx1100", "gfx1101", "gfx1150", "gfx1151", "gfx1200", "gfx1201"
+ #endif
+ #if ROCM_VERSION >= 60500
+         "gfx950"
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0006-Support-gfx1151-in-aotriton.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0006-Support-gfx1151-in-aotriton.patch
@@ -1,0 +1,67 @@
+From 6bb1df0b72bb7b12fc0afe7fe05c5dd7a501291f Mon Sep 17 00:00:00 2001
+From: Aaryaman Vasishta <jem456.vasishta@gmail.com>
+Date: Mon, 31 Mar 2025 19:27:59 +0100
+Subject: [PATCH 6/8] Support gfx1151 in aotriton
+
+---
+ cmake/External/aotriton.cmake | 6 ++++--
+ cmake/public/LoadHIP.cmake    | 6 ++++++
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/External/aotriton.cmake b/cmake/External/aotriton.cmake
+index 2678cfde3c..b70b9311d7 100644
+--- a/cmake/External/aotriton.cmake
++++ b/cmake/External/aotriton.cmake
+@@ -2,6 +2,7 @@ macro(get_target_gpus_from_pytorch target_gpus)
+    set(gfx90a_key MI200)
+    set(gfx942_key MI300X)
+    set(gfx1100_key Navi31)
++   set(gfx1151_key Navi3.5)
+ 
+    foreach(X IN LISTS PYTORCH_ROCM_ARCH)
+        set(key ${X})
+@@ -33,7 +34,7 @@ if(NOT __AOTRITON_INCLUDED)
+       "rocm6.3"
+       "rocm6.4"
+       )
+-  set(__AOTRITON_CI_COMMIT "b388d223d8c7213545603e00f6f3148c54d1f525")
++  set(__AOTRITON_CI_COMMIT "00eee4bfb0b1d8eb1ea779865bed1fb92d9b79be")
+   set(__AOTRITON_SHA256_LIST
+       "08d84f96f4c984179f80f517c0431c7511ee26bb0ce9bd05a827573ddd78cc79"  # rocm6.2
+       "9094d59717e7e6eace9126ca100dd0e86510f07fc6c3a349569fc4e2d9056604"  # rocm6.3
+@@ -53,7 +54,7 @@ if(NOT __AOTRITON_INCLUDED)
+     set(target_gpus "")
+     get_target_gpus_from_pytorch(target_gpus)
+     ExternalProject_Add(aotriton_external
+-      GIT_REPOSITORY https://github.com/ROCm/aotriton.git
++      GIT_REPOSITORY https://github.com/scottt/aotriton.git
+       GIT_TAG ${__AOTRITON_CI_COMMIT}
+       PREFIX ${__AOTRITON_EXTERN_PREFIX}
+       INSTALL_DIR ${__AOTRITON_INSTALL_DIR}
+@@ -64,6 +65,7 @@ if(NOT __AOTRITON_INCLUDED)
+       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+       -DAOTRITON_NO_PYTHON=ON
+       -DAOTRITON_NO_SHARED=OFF
++      -DHIP_PLATFORM=amd
+       # CONFIGURE_COMMAND ""
+       BUILD_COMMAND ""  # No build, install command will repeat the build process due to problems in the build system.
+       BUILD_BYPRODUCTS "${__AOTRITON_INSTALL_DIR}/lib/libaotriton_v2.so"
+diff --git a/cmake/public/LoadHIP.cmake b/cmake/public/LoadHIP.cmake
+index 57910495fc..7b058199a1 100644
+--- a/cmake/public/LoadHIP.cmake
++++ b/cmake/public/LoadHIP.cmake
+@@ -121,5 +121,11 @@ set(PYTORCH_FOUND_HIP FALSE)
+ set(HIP_PLATFORM "amd")
+ find_package(hip CONFIG)
+ if(hip_FOUND)
++  # Apparently, aotriton compilation breaks if PYTORCH_ROCM_ARCH isn't converted to a list here.
++  torch_hip_get_arch_list(PYTORCH_ROCM_ARCH)
++  if(PYTORCH_ROCM_ARCH STREQUAL "")
++    message(FATAL_ERROR "No GPU arch specified for ROCm build. Please use PYTORCH_ROCM_ARCH environment variable to specify GPU archs to build for.")
++  endif()
++  message("Building PyTorch for GPU arch: ${PYTORCH_ROCM_ARCH}")
+   pytorch_load_hip()
+ endif()
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0007-link-correct-version-of-hsa-runtime-with-c10_hip.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0007-link-correct-version-of-hsa-runtime-with-c10_hip.patch
@@ -1,0 +1,35 @@
+From b72b276fa0016c8381d4be11a6449bc3a9662d6d Mon Sep 17 00:00:00 2001
+From: Mika Laitio <mika.laitio@amd.com>
+Date: Tue, 29 Apr 2025 01:28:14 -0700
+Subject: [PATCH 7/8] link correct version of hsa-runtime with c10_hip
+
+link the version of hsa-runtime64 that is searched
+by LoadHIP.cmake instead of relying to it to be linked
+as an amdhip64 dependency without specifying the location.
+
+This fixes an error where the wrong version of library could
+be tried to be linked causing unresolved symbol errors.
+
+fixes: https://github.com/ROCm/TheRock/issues/474
+
+Signed-off-by: Mika Laitio <mika.laitio@amd.com>
+---
+ c10/hip/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/c10/hip/CMakeLists.txt b/c10/hip/CMakeLists.txt
+index f153030e79..a98ec6fa23 100644
+--- a/c10/hip/CMakeLists.txt
++++ b/c10/hip/CMakeLists.txt
+@@ -48,7 +48,7 @@ if(NOT BUILD_LIBTORCHLESS)
+   endif()
+ 
+   # ---[ Dependency of c10_hip
+-  target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::amdhip64)
++  target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::amdhip64 hsa-runtime64::hsa-runtime64)
+ 
+   target_include_directories(
+       c10_hip PUBLIC
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0008-rocm-clang-version-check-fix.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0008-rocm-clang-version-check-fix.patch
@@ -1,0 +1,37 @@
+From f2fe747f3f1de6d32804016533c1bddb338a336f Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Sat, 22 Mar 2025 08:51:34 -0700
+Subject: [PATCH 8/8] rocm clang version check fix
+
+clang in rocm sdk 6.3.3 returns 18.0git as a version.
+fix this by adding a check which converts it to
+18.0 without throwing an exception
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ torch/utils/cpp_extension.py | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/torch/utils/cpp_extension.py b/torch/utils/cpp_extension.py
+index 82c23c2c9f..b8dd20bc01 100644
+--- a/torch/utils/cpp_extension.py
++++ b/torch/utils/cpp_extension.py
+@@ -446,6 +446,15 @@ def get_compiler_abi_compatibility_and_version(compiler) -> tuple[bool, TorchVer
+         warnings.warn(f'Error checking compiler version for {compiler}: {error}')
+         return (False, TorchVersion('0.0.0'))
+ 
++    # manage version 18.0git returned by clang in rocm sdk 6.3.3
++    for ii in range(len(version)):
++        try:
++            version_item = version[ii]
++            test = int(version_item)
++        except ValueError:
++            version_item = '0'
++            version[ii] = version_item
++        print("version: " + version_item)
+     if tuple(map(int, version)) >= minimum_required_version:
+         return (True, TorchVersion('.'.join(version)))
+ 
+-- 
+2.43.0
+

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/third_party/composable_kernel/base/0001-ck.hpp-define-CK_BUFFER_RESOURCE_3RD_DWORD-for-gfx11.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/third_party/composable_kernel/base/0001-ck.hpp-define-CK_BUFFER_RESOURCE_3RD_DWORD-for-gfx11.patch
@@ -1,0 +1,27 @@
+From 8cb4274968c8b2f8b0a66db1d38b17904f5d3424 Mon Sep 17 00:00:00 2001
+From: Scott Tsai <scottt.tw@gmail.com>
+Date: Sat, 22 Mar 2025 06:11:03 +0800
+Subject: [PATCH 2/2] ck.hpp: define CK_BUFFER_RESOURCE_3RD_DWORD for gfx1151
+
+Define CK_BUFFER_RESOURCE_3RD_DWORD with the same value for gfx110x and
+gfx115x (0x31004000) following https://github.com/ROCm/hipBLASLt/pull/1766
+---
+ include/ck/ck.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/ck/ck.hpp b/include/ck/ck.hpp
+index 999eb02..3ded15c 100644
+--- a/include/ck/ck.hpp
++++ b/include/ck/ck.hpp
+@@ -68,7 +68,7 @@ CK_DECLARE_ENV_VAR_BOOL(CK_LOGGING)
+ #define __gfx103__
+ #endif
+ #if defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || \
+-    defined(__gfx1103__) || defined(__gfx11_generic__)
++    defined(__gfx1103__) || defined(__gfx1150__) || defined(__gfx1151__) || defined(__gfx11_generic__)
+ #define __gfx11__
+ #endif
+ #if defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx12_generic__)
+-- 
+2.48.1
+

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/third_party/fbgemm/hipified/0001-UtilsAvx512.cpp-fix-r-may-be-used-uninitialized-for-.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/third_party/fbgemm/hipified/0001-UtilsAvx512.cpp-fix-r-may-be-used-uninitialized-for-.patch
@@ -1,0 +1,31 @@
+From 23831177a4308fb18951537a0b3948e5547da02d Mon Sep 17 00:00:00 2001
+From: Scott Tsai <scottt.tw@gmail.com>
+Date: Sat, 22 Mar 2025 06:17:51 +0800
+Subject: [PATCH] UtilsAvx512.cpp: fix r may be used uninitialized for gcc14
+
+This version of fbgemm uses `-Werror` thus the warning breaks the build.
+This is also reported upstream by others as https://github.com/pytorch/pytorch/issues/129358
+
+ROCm/TheRock is building pytorch in Ubuntu 22.04 but Fedora 41 has a
+newer gcc and would run into this bug.
+---
+ src/UtilsAvx512.cc | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/UtilsAvx512.cc b/src/UtilsAvx512.cc
+index cf00613d..c65eab87 100644
+--- a/src/UtilsAvx512.cc
++++ b/src/UtilsAvx512.cc
+@@ -920,6 +920,9 @@ static inline void transpose_contiguous_16x2_block(
+     int64_t ld_dst,
+     int mrem = 16) {
+   __m512i r[2], d[2];
++  // Zero out r[] to avoid `may be used uninitialized` compilation error
++  r[0] = _mm512_setzero_si512();
++  r[1] = _mm512_setzero_si512();
+   int i = 0;
+   for (; (i + 1) * 16 <= mrem * 2; i++) {
+     // normal load
+-- 
+2.49.0
+

--- a/external-builds/pytorch/patches/pytorch_vision/v0.21.0/pytorch_vision/hipified/0001-giflib-files-does-not-build-with-c-extension.patch
+++ b/external-builds/pytorch/patches/pytorch_vision/v0.21.0/pytorch_vision/hipified/0001-giflib-files-does-not-build-with-c-extension.patch
@@ -1,0 +1,56 @@
+From 21f7b61e101538298fbe2b02c4325bc2c1183048 Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Tue, 6 Aug 2024 15:34:06 -0700
+Subject: [PATCH 1/1] giflib files does not build with c-extension
+
+pytorch_vision registers them as a CppExtension files
+in setup.py and this causes the pytorch builder
+to add the -std=c++17 build flag. That flag
+will then cause build break at least on
+mac, Fedora 40 and Mageia 9.
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ setup.py                                                        | 2 +-
+ .../csrc/io/image/cpu/giflib/{dgif_lib.c => dgif_lib.cpp}       | 0
+ .../csrc/io/image/cpu/giflib/{gif_hash.c => gif_hash.cpp}       | 0
+ .../csrc/io/image/cpu/giflib/{gifalloc.c => gifalloc.cpp}       | 0
+ .../giflib/{openbsd-reallocarray.c => openbsd-reallocarray.cpp} | 0
+ 5 files changed, 1 insertion(+), 1 deletion(-)
+ rename torchvision/csrc/io/image/cpu/giflib/{dgif_lib.c => dgif_lib.cpp} (100%)
+ rename torchvision/csrc/io/image/cpu/giflib/{gif_hash.c => gif_hash.cpp} (100%)
+ rename torchvision/csrc/io/image/cpu/giflib/{gifalloc.c => gifalloc.cpp} (100%)
+ rename torchvision/csrc/io/image/cpu/giflib/{openbsd-reallocarray.c => openbsd-reallocarray.cpp} (100%)
+
+diff --git a/setup.py b/setup.py
+index d24903f8f8..c0dd27ef7e 100644
+--- a/setup.py
++++ b/setup.py
+@@ -284,7 +284,7 @@ def make_image_extension():
+     define_macros, extra_compile_args = get_macros_and_flags()
+ 
+     image_dir = CSRS_DIR / "io/image"
+-    sources = list(image_dir.glob("*.cpp")) + list(image_dir.glob("cpu/*.cpp")) + list(image_dir.glob("cpu/giflib/*.c"))
++    sources = list(image_dir.glob("*.cpp")) + list(image_dir.glob("cpu/*.cpp")) + list(image_dir.glob("cpu/giflib/*.cpp"))
+ 
+     if IS_ROCM:
+         sources += list(image_dir.glob("hip/*.cpp"))
+diff --git a/torchvision/csrc/io/image/cpu/giflib/dgif_lib.c b/torchvision/csrc/io/image/cpu/giflib/dgif_lib.cpp
+similarity index 100%
+rename from torchvision/csrc/io/image/cpu/giflib/dgif_lib.c
+rename to torchvision/csrc/io/image/cpu/giflib/dgif_lib.cpp
+diff --git a/torchvision/csrc/io/image/cpu/giflib/gif_hash.c b/torchvision/csrc/io/image/cpu/giflib/gif_hash.cpp
+similarity index 100%
+rename from torchvision/csrc/io/image/cpu/giflib/gif_hash.c
+rename to torchvision/csrc/io/image/cpu/giflib/gif_hash.cpp
+diff --git a/torchvision/csrc/io/image/cpu/giflib/gifalloc.c b/torchvision/csrc/io/image/cpu/giflib/gifalloc.cpp
+similarity index 100%
+rename from torchvision/csrc/io/image/cpu/giflib/gifalloc.c
+rename to torchvision/csrc/io/image/cpu/giflib/gifalloc.cpp
+diff --git a/torchvision/csrc/io/image/cpu/giflib/openbsd-reallocarray.c b/torchvision/csrc/io/image/cpu/giflib/openbsd-reallocarray.cpp
+similarity index 100%
+rename from torchvision/csrc/io/image/cpu/giflib/openbsd-reallocarray.c
+rename to torchvision/csrc/io/image/cpu/giflib/openbsd-reallocarray.cpp
+-- 
+2.48.1
+

--- a/external-builds/pytorch/patches/pytorch_vision/v0.22.0/pytorch_vision/hipified/0001-giflib-files-does-not-build-with-c-extension.patch
+++ b/external-builds/pytorch/patches/pytorch_vision/v0.22.0/pytorch_vision/hipified/0001-giflib-files-does-not-build-with-c-extension.patch
@@ -1,0 +1,56 @@
+From 21f7b61e101538298fbe2b02c4325bc2c1183048 Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Tue, 6 Aug 2024 15:34:06 -0700
+Subject: [PATCH 1/1] giflib files does not build with c-extension
+
+pytorch_vision registers them as a CppExtension files
+in setup.py and this causes the pytorch builder
+to add the -std=c++17 build flag. That flag
+will then cause build break at least on
+mac, Fedora 40 and Mageia 9.
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ setup.py                                                        | 2 +-
+ .../csrc/io/image/cpu/giflib/{dgif_lib.c => dgif_lib.cpp}       | 0
+ .../csrc/io/image/cpu/giflib/{gif_hash.c => gif_hash.cpp}       | 0
+ .../csrc/io/image/cpu/giflib/{gifalloc.c => gifalloc.cpp}       | 0
+ .../giflib/{openbsd-reallocarray.c => openbsd-reallocarray.cpp} | 0
+ 5 files changed, 1 insertion(+), 1 deletion(-)
+ rename torchvision/csrc/io/image/cpu/giflib/{dgif_lib.c => dgif_lib.cpp} (100%)
+ rename torchvision/csrc/io/image/cpu/giflib/{gif_hash.c => gif_hash.cpp} (100%)
+ rename torchvision/csrc/io/image/cpu/giflib/{gifalloc.c => gifalloc.cpp} (100%)
+ rename torchvision/csrc/io/image/cpu/giflib/{openbsd-reallocarray.c => openbsd-reallocarray.cpp} (100%)
+
+diff --git a/setup.py b/setup.py
+index d24903f8f8..c0dd27ef7e 100644
+--- a/setup.py
++++ b/setup.py
+@@ -284,7 +284,7 @@ def make_image_extension():
+     define_macros, extra_compile_args = get_macros_and_flags()
+ 
+     image_dir = CSRS_DIR / "io/image"
+-    sources = list(image_dir.glob("*.cpp")) + list(image_dir.glob("cpu/*.cpp")) + list(image_dir.glob("cpu/giflib/*.c"))
++    sources = list(image_dir.glob("*.cpp")) + list(image_dir.glob("cpu/*.cpp")) + list(image_dir.glob("cpu/giflib/*.cpp"))
+ 
+     if IS_ROCM:
+         sources += list(image_dir.glob("hip/*.cpp"))
+diff --git a/torchvision/csrc/io/image/cpu/giflib/dgif_lib.c b/torchvision/csrc/io/image/cpu/giflib/dgif_lib.cpp
+similarity index 100%
+rename from torchvision/csrc/io/image/cpu/giflib/dgif_lib.c
+rename to torchvision/csrc/io/image/cpu/giflib/dgif_lib.cpp
+diff --git a/torchvision/csrc/io/image/cpu/giflib/gif_hash.c b/torchvision/csrc/io/image/cpu/giflib/gif_hash.cpp
+similarity index 100%
+rename from torchvision/csrc/io/image/cpu/giflib/gif_hash.c
+rename to torchvision/csrc/io/image/cpu/giflib/gif_hash.cpp
+diff --git a/torchvision/csrc/io/image/cpu/giflib/gifalloc.c b/torchvision/csrc/io/image/cpu/giflib/gifalloc.cpp
+similarity index 100%
+rename from torchvision/csrc/io/image/cpu/giflib/gifalloc.c
+rename to torchvision/csrc/io/image/cpu/giflib/gifalloc.cpp
+diff --git a/torchvision/csrc/io/image/cpu/giflib/openbsd-reallocarray.c b/torchvision/csrc/io/image/cpu/giflib/openbsd-reallocarray.cpp
+similarity index 100%
+rename from torchvision/csrc/io/image/cpu/giflib/openbsd-reallocarray.c
+rename to torchvision/csrc/io/image/cpu/giflib/openbsd-reallocarray.cpp
+-- 
+2.48.1
+

--- a/external-builds/pytorch/pytorch_audio_repo.py
+++ b/external-builds/pytorch/pytorch_audio_repo.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+"""Checks out and builds PyTorch against a built from source ROCM SDK.
+
+There is nothing that this script does which you couldn't do by hand, but because of
+the following, getting PyTorch sources ready to build with ToT TheRock built SDKs
+consists of multiple steps:
+
+* Sources must be pre-processed with HIPIFY, creating dirty git trees that are hard
+  to develop on further.
+* Both the ROCM SDK and PyTorch are moving targets that are eventually consistent.
+  We maintain patches for recent PyTorch revisions to adapt to packaging and library
+  compatibility differences until all releases are done and available.
+
+Primary usage:
+
+    ./pytorch_audio_repo.py checkout
+    ./pytorch_audio_repo.py develop
+
+The checkout process combines the following activities:
+
+* Clones the pytorch repository into `THIS_MAIN_REPO_NAME` with a requested `--repo-hashtag`
+  tag (default to latest release).
+* Configures PyTorch submodules to be ignored for any local changes (so that
+  the result is suitable for development with local patches).
+* Applies "base" patches to the pytorch repo and any submodules (by using
+  `git am` with patches from `patches/pytorch_ref_to_patches_dir_name(<repo-hashtag>)/<repo-name>/base`).
+* Runs `hipify` to prepare sources for AMD GPU and commits the result to the
+  main repo and any modified submodules.
+* Applies "hipified" patches to the pytorch repo and any submodules (by using
+  `git am` with patches from `patches/<repo-hashtag>/<repo-name>/hipified`).
+* Records some tag information for subsequent activities.
+
+For one-shot builds and CI use, the above is sufficient. But this tool can also
+be used to develop. Any commits made to PyTorch or any of its submodules can
+be saved locally in TheRock by running `./pybuild.py save-patches`. If checked
+in, CI runs for that revision will incorporate them the same as anyone
+interactively using this tool.
+"""
+import argparse
+from pathlib import Path, PurePosixPath
+import shlex
+import shutil
+import subprocess
+import sys
+
+import repo_management
+
+THIS_MAIN_REPO_NAME = "pytorch_audio"
+THIS_DIR = Path(__file__).resolve().parent
+THIS_PATCHES_DIR = THIS_DIR / "patches" / THIS_MAIN_REPO_NAME
+
+
+def main(cl_args: list[str]):
+    def add_common(command_parser: argparse.ArgumentParser):
+        command_parser.add_argument(
+            "--repo",
+            type=Path,
+            default=THIS_DIR / THIS_MAIN_REPO_NAME,
+            help="Git repository path",
+        )
+        command_parser.add_argument(
+            "--patch-dir",
+            type=Path,
+            default=THIS_PATCHES_DIR,
+            help="Git repository patch path",
+        )
+        command_parser.add_argument(
+            "--repo-name",
+            type=Path,
+            default=THIS_MAIN_REPO_NAME,
+            help="Git repository patch path",
+        )
+
+    p = argparse.ArgumentParser("ptbuild.py")
+    default_repo_hashtag = "v2.7.0"
+    sub_p = p.add_subparsers(required=True)
+    checkout_p = sub_p.add_parser("checkout", help="Clone PyTorch locally and checkout")
+    add_common(checkout_p)
+    checkout_p.add_argument(
+        "--gitrepo-origin",
+        default="https://github.com/pytorch/audio.git",
+        help="git repository url",
+    )
+    checkout_p.add_argument(
+        "--repo-hashtag",
+        default=default_repo_hashtag,
+        help="Git repository ref/tag to checkout",
+    )
+    checkout_p.add_argument("--depth", type=int, help="Fetch depth")
+    checkout_p.add_argument("--jobs", type=int, help="Number of fetch jobs")
+    checkout_p.add_argument(
+        "--hipify",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run hipify",
+    )
+    checkout_p.add_argument(
+        "--patch",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Apply patches for the repo-hashtag",
+    )
+    checkout_p.set_defaults(func=repo_management.do_checkout)
+
+    hipify_p = sub_p.add_parser("hipify", help="Run HIPIFY on the project")
+    add_common(hipify_p)
+    hipify_p.set_defaults(func=repo_management.do_hipify)
+
+    save_patches_p = sub_p.add_parser(
+        "save-patches", help="Save local commits as patch files for later application"
+    )
+    add_common(save_patches_p)
+    save_patches_p.add_argument(
+        "--repo-hashtag",
+        default=default_repo_hashtag,
+        help="Git repository ref/tag to checkout",
+    )
+    save_patches_p.set_defaults(func=repo_management.do_save_patches)
+
+    args = p.parse_args(cl_args)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/external-builds/pytorch/pytorch_torch_repo.py
+++ b/external-builds/pytorch/pytorch_torch_repo.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+"""Checks out and builds PyTorch against a built from source ROCM SDK.
+
+There is nothing that this script does which you couldn't do by hand, but because of
+the following, getting PyTorch sources ready to build with ToT TheRock built SDKs
+consists of multiple steps:
+
+* Sources must be pre-processed with HIPIFY, creating dirty git trees that are hard
+  to develop on further.
+* Both the ROCM SDK and PyTorch are moving targets that are eventually consistent.
+  We maintain patches for recent PyTorch revisions to adapt to packaging and library
+  compatibility differences until all releases are done and available.
+
+Primary usage:
+
+    ./pytorch_torch_repo.py checkout
+    ./pytorch_torch_repo.py develop
+
+The checkout process combines the following activities:
+
+* Clones the pytorch repository into `THIS_MAIN_REPO_NAME` with a requested `--repo-hashtag`
+  tag (default to latest release).
+* Configures PyTorch submodules to be ignored for any local changes (so that
+  the result is suitable for development with local patches).
+* Applies "base" patches to the pytorch repo and any submodules (by using
+  `git am` with patches from `patches/pytorch_ref_to_THIS_PATCHES_DIR_name(<repo-hashtag>)/<repo-name>/base`).
+* Runs `hipify` to prepare sources for AMD GPU and commits the result to the
+  main repo and any modified submodules.
+* Applies "hipified" patches to the pytorch repo and any submodules (by using
+  `git am` with patches from `patches/<repo-hashtag>/<repo-name>/hipified`).
+* Records some tag information for subsequent activities.
+
+For one-shot builds and CI use, the above is sufficient. But this tool can also
+be used to develop. Any commits made to PyTorch or any of its submodules can
+be saved locally in TheRock by running `./pybuild.py save-patches`. If checked
+in, CI runs for that revision will incorporate them the same as anyone
+interactively using this tool.
+"""
+import argparse
+from pathlib import Path, PurePosixPath
+import shlex
+import shutil
+import subprocess
+import sys
+
+import repo_management
+
+THIS_MAIN_REPO_NAME = "pytorch"
+THIS_DIR = Path(__file__).resolve().parent
+THIS_PATCHES_DIR = THIS_DIR / "patches" / THIS_MAIN_REPO_NAME
+
+
+def main(cl_args: list[str]):
+    def add_common(command_parser: argparse.ArgumentParser):
+        command_parser.add_argument(
+            "--repo",
+            type=Path,
+            default=THIS_DIR / THIS_MAIN_REPO_NAME,
+            help="Git repository path",
+        )
+        command_parser.add_argument(
+            "--patch-dir",
+            type=Path,
+            default=THIS_PATCHES_DIR,
+            help="Git repository patch path",
+        )
+        command_parser.add_argument(
+            "--repo-name",
+            type=Path,
+            default=THIS_MAIN_REPO_NAME,
+            help="Git repository patch path",
+        )
+
+    p = argparse.ArgumentParser("ptbuild.py")
+    default_repo_hashtag = "v2.7.0"
+    sub_p = p.add_subparsers(required=True)
+    checkout_p = sub_p.add_parser("checkout", help="Clone PyTorch locally and checkout")
+    add_common(checkout_p)
+    checkout_p.add_argument(
+        "--gitrepo-origin",
+        default="https://github.com/pytorch/pytorch.git",
+        help="git repository url",
+    )
+    checkout_p.add_argument(
+        "--repo-hashtag",
+        default=default_repo_hashtag,
+        help="Git repository ref/tag to checkout",
+    )
+    checkout_p.add_argument("--depth", type=int, help="Fetch depth")
+    checkout_p.add_argument("--jobs", type=int, help="Number of fetch jobs")
+    checkout_p.add_argument(
+        "--hipify",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run hipify",
+    )
+    checkout_p.add_argument(
+        "--patch",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Apply patches for the repo-hashtag",
+    )
+    checkout_p.set_defaults(func=repo_management.do_checkout)
+
+    hipify_p = sub_p.add_parser("hipify", help="Run HIPIFY on the project")
+    add_common(hipify_p)
+    hipify_p.set_defaults(func=repo_management.do_hipify)
+
+    save_patches_p = sub_p.add_parser(
+        "save-patches", help="Save local commits as patch files for later application"
+    )
+    add_common(save_patches_p)
+    save_patches_p.add_argument(
+        "--repo-hashtag",
+        default=default_repo_hashtag,
+        help="Git repository ref/tag to checkout",
+    )
+    save_patches_p.set_defaults(func=repo_management.do_save_patches)
+
+    args = p.parse_args(cl_args)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/external-builds/pytorch/pytorch_vision_repo.py
+++ b/external-builds/pytorch/pytorch_vision_repo.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+"""Checks out and builds PyTorch against a built from source ROCM SDK.
+
+There is nothing that this script does which you couldn't do by hand, but because of
+the following, getting PyTorch sources ready to build with ToT TheRock built SDKs
+consists of multiple steps:
+
+* Sources must be pre-processed with HIPIFY, creating dirty git trees that are hard
+  to develop on further.
+* Both the ROCM SDK and PyTorch are moving targets that are eventually consistent.
+  We maintain patches for recent PyTorch revisions to adapt to packaging and library
+  compatibility differences until all releases are done and available.
+
+Primary usage:
+
+    ./pytorch_vision_repo.py checkout
+    ./pytorch_vision_repo.py develop
+
+The checkout process combines the following activities:
+
+* Clones the pytorch repository into `THIS_MAIN_REPO_NAME` with a requested `--repo-hashtag`
+  tag (default to latest release).
+* Configures PyTorch submodules to be ignored for any local changes (so that
+  the result is suitable for development with local patches).
+* Applies "base" patches to the pytorch repo and any submodules (by using
+  `git am` with patches from `patches/pytorch_ref_to_patches_dir_name(<repo-hashtag>)/<repo-name>/base`).
+* Runs `hipify` to prepare sources for AMD GPU and commits the result to the
+  main repo and any modified submodules.
+* Applies "hipified" patches to the pytorch repo and any submodules (by using
+  `git am` with patches from `patches/<repo-hashtag>/<repo-name>/hipified`).
+* Records some tag information for subsequent activities.
+
+For one-shot builds and CI use, the above is sufficient. But this tool can also
+be used to develop. Any commits made to PyTorch or any of its submodules can
+be saved locally in TheRock by running `./pybuild.py save-patches`. If checked
+in, CI runs for that revision will incorporate them the same as anyone
+interactively using this tool.
+"""
+import argparse
+from pathlib import Path, PurePosixPath
+import shlex
+import shutil
+import subprocess
+import sys
+
+import repo_management
+
+THIS_MAIN_REPO_NAME = "pytorch_vision"
+THIS_DIR = Path(__file__).resolve().parent
+THIS_PATCHES_DIR = THIS_DIR / "patches" / THIS_MAIN_REPO_NAME
+
+
+def main(cl_args: list[str]):
+    def add_common(command_parser: argparse.ArgumentParser):
+        command_parser.add_argument(
+            "--repo",
+            type=Path,
+            default=THIS_DIR / THIS_MAIN_REPO_NAME,
+            help="Git repository path",
+        )
+        command_parser.add_argument(
+            "--patch-dir",
+            type=Path,
+            default=THIS_PATCHES_DIR,
+            help="Git repository patch path",
+        )
+        command_parser.add_argument(
+            "--repo-name",
+            type=Path,
+            default=THIS_MAIN_REPO_NAME,
+            help="Git repository patch path",
+        )
+
+    p = argparse.ArgumentParser("ptbuild.py")
+    default_repo_hashtag = "v0.22.0"
+    sub_p = p.add_subparsers(required=True)
+    checkout_p = sub_p.add_parser("checkout", help="Clone PyTorch locally and checkout")
+    add_common(checkout_p)
+    checkout_p.add_argument(
+        "--gitrepo-origin",
+        default="https://github.com/pytorch/vision.git",
+        help="git repository url",
+    )
+    checkout_p.add_argument(
+        "--repo-hashtag",
+        default=default_repo_hashtag,
+        help="Git repository ref/tag to checkout",
+    )
+    checkout_p.add_argument("--depth", type=int, help="Fetch depth")
+    checkout_p.add_argument("--jobs", type=int, help="Number of fetch jobs")
+    checkout_p.add_argument(
+        "--hipify",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run hipify",
+    )
+    checkout_p.add_argument(
+        "--patch",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Apply patches for the repo-hashtag",
+    )
+    checkout_p.set_defaults(func=repo_management.do_checkout)
+
+    hipify_p = sub_p.add_parser("hipify", help="Run HIPIFY on the project")
+    add_common(hipify_p)
+    hipify_p.set_defaults(func=repo_management.do_hipify)
+
+    save_patches_p = sub_p.add_parser(
+        "save-patches", help="Save local commits as patch files for later application"
+    )
+    add_common(save_patches_p)
+    save_patches_p.add_argument(
+        "--repo-hashtag",
+        default=default_repo_hashtag,
+        help="Git repository ref/tag to checkout",
+    )
+    save_patches_p.set_defaults(func=repo_management.do_save_patches)
+
+    args = p.parse_args(cl_args)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/external-builds/pytorch/repo_management.py
+++ b/external-builds/pytorch/repo_management.py
@@ -1,0 +1,283 @@
+import argparse
+from pathlib import Path, PurePosixPath
+import shlex
+import shutil
+import subprocess
+import sys
+import os
+
+TAG_UPSTREAM_DIFFBASE = "THEROCK_UPSTREAM_DIFFBASE"
+TAG_HIPIFY_DIFFBASE = "THEROCK_HIPIFY_DIFFBASE"
+HIPIFY_COMMIT_MESSAGE = "DO NOT SUBMIT: HIPIFY"
+
+
+def exec(args: list[str | Path], cwd: Path, *, stdout_devnull: bool = False):
+    args = [str(arg) for arg in args]
+    print(f"++ Exec [{cwd}]$ {shlex.join(args)}")
+    subprocess.check_call(
+        args,
+        cwd=str(cwd),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL if stdout_devnull else None,
+    )
+
+
+def rev_parse(repo_path: Path, rev: str) -> str | None:
+    """Parses a revision to a commit hash, returning None if not found."""
+    try:
+        raw_output = subprocess.check_output(
+            ["git", "rev-parse", rev], cwd=str(repo_path), stderr=subprocess.DEVNULL
+        )
+    except subprocess.CalledProcessError:
+        return None
+    return raw_output.decode().strip()
+
+
+def rev_list(repo_path: Path, revlist: str) -> list[str]:
+    raw_output = subprocess.check_output(
+        ["git", "rev-list", revlist], cwd=str(repo_path)
+    )
+    return raw_output.decode().splitlines()
+
+
+def list_submodules(
+    repo_path: Path, *, relative: bool = False, recursive: bool = True
+) -> list[Path]:
+    """Gets paths of all submodules (recursively) in the repository."""
+    recursive_args = ["--recursive"] if recursive else []
+    raw_output = subprocess.check_output(
+        ["git", "submodule", "status"] + recursive_args,
+        cwd=str(repo_path),
+    )
+    lines = raw_output.decode().splitlines()
+    relative_paths = [PurePosixPath(line.strip().split()[1]) for line in lines]
+    if relative:
+        return relative_paths
+    return [repo_path / p for p in relative_paths]
+
+
+def list_status(repo_path: Path) -> list[tuple[str, str]]:
+    """Gets the status as a list of (status_type, relative_path)."""
+    raw_output = subprocess.check_output(
+        ["git", "status", "--porcelain", "-u", "--ignore-submodules"],
+        cwd=str(repo_path),
+    )
+    lines = raw_output.decode().splitlines()
+    return [tuple(line.strip().split()) for line in lines]
+
+
+def get_all_repositories(root_path: Path) -> list[Path]:
+    """Gets all repository paths, starting with the root and then including all
+    recursive submodules."""
+    all_paths = list_submodules(root_path)
+    all_paths.insert(0, root_path)
+    return all_paths
+
+
+def git_config_ignore_submodules(repo_path: Path):
+    """Sets the `submodule.<name>.ignore = true` git config option for all submodules.
+
+    This causes all submodules to not show up in status or diff reports, which is
+    appropriate for our case, since we make arbitrary changes and patches to them.
+    Note that pytorch seems to somewhat arbitrarily have some already set this way.
+    We just set them all.
+    """
+    file_path = repo_path / ".gitmodules"
+    if os.path.exists(file_path):
+        try:
+            config_names = (
+                subprocess.check_output(
+                    [
+                        "git",
+                        "config",
+                        "--file",
+                        ".gitmodules",
+                        "--name-only",
+                        "--get-regexp",
+                        "\\.path$",
+                    ],
+                    cwd=str(repo_path),
+                )
+                .decode()
+                .splitlines()
+            )
+            for config_name in config_names:
+                ignore_name = config_name.removesuffix(".path") + ".ignore"
+                exec(["git", "config", ignore_name, "all"], cwd=repo_path)
+            submodule_paths = list_submodules(repo_path, relative=True, recursive=False)
+            exec(
+                ["git", "update-index", "--skip-worktree"] + submodule_paths,
+                cwd=repo_path,
+            )
+        except Exception as e:
+            # pytorch audio has empty .gitmodules file which can cause exception
+            pass
+
+
+def save_repo_patches(repo_path: Path, patches_path: Path):
+    """Updates the patches directory with any patches committed to the repository."""
+    if patches_path.exists():
+        shutil.rmtree(patches_path)
+    # Get key revisions.
+    upstream_rev = rev_parse(repo_path, TAG_UPSTREAM_DIFFBASE)
+    hipify_rev = rev_parse(repo_path, TAG_HIPIFY_DIFFBASE)
+    if upstream_rev is None:
+        print(f"error: Could not find upstream diffbase tag {TAG_UPSTREAM_DIFFBASE}")
+        sys.exit(1)
+    hipified_count = 0
+    if hipify_rev:
+        hipified_revlist = f"{hipify_rev}..HEAD"
+        base_revlist = f"{upstream_rev}..{hipify_rev}^"
+        hipified_count = len(rev_list(repo_path, hipified_revlist))
+    else:
+        hipified_revlist = None
+        base_revlist = f"{upstream_rev}..HEAD"
+    base_count = len(rev_list(repo_path, base_revlist))
+    if hipified_count == 0 and base_count == 0:
+        return
+    print(
+        f"Saving {patches_path} patches: {base_count} base, {hipified_count} hipified"
+    )
+    if base_count > 0:
+        base_path = patches_path / "base"
+        base_path.mkdir(parents=True, exist_ok=True)
+        exec(["git", "format-patch", "-o", base_path, base_revlist], cwd=repo_path)
+    if hipified_count > 0:
+        hipified_path = patches_path / "hipified"
+        hipified_path.mkdir(parents=True, exist_ok=True)
+        exec(
+            ["git", "format-patch", "-o", hipified_path, hipified_revlist],
+            cwd=repo_path,
+        )
+
+
+def apply_repo_patches(repo_path: Path, patches_path: Path):
+    """Applies patches to a repository from the given patches directory."""
+    patch_files = list(patches_path.glob("*.patch"))
+    print("repo_path: " + str(repo_path) + ", patches_path: " + str(patches_path))
+    if not patch_files:
+        return
+    patch_files.sort(key=lambda p: p.name)
+    exec(
+        ["git", "am", "--whitespace=nowarn", "--committer-date-is-author-date"]
+        + patch_files,
+        cwd=repo_path,
+    )
+
+
+def apply_all_patches(
+    root_repo_path: Path, patches_path: Path, repo_name: str, patchset_name: str
+):
+    relative_sm_paths = list_submodules(root_repo_path, relative=True)
+    # Apply base patches.
+    apply_repo_patches(root_repo_path, patches_path / repo_name / patchset_name)
+    for relative_sm_path in relative_sm_paths:
+        apply_repo_patches(
+            root_repo_path / relative_sm_path,
+            patches_path / relative_sm_path / patchset_name,
+        )
+
+
+# repo_hashtag_to_patches_dir_name('2.7.0-rc9') -> '2.7.0'
+def repo_hashtag_to_patches_dir_name(version_ref: str) -> str:
+    pos = version_ref.find("-")
+    if pos != -1:
+        return version_ref[:pos]
+    return version_ref
+
+
+def do_checkout(args: argparse.Namespace):
+    repo_dir: Path = args.repo
+    repo_patch_dir_base = args.patch_dir
+    check_git_dir = repo_dir / ".git"
+    if check_git_dir.exists():
+        print(f"Not cloning repository ({check_git_dir} exists)")
+    else:
+        print(f"Cloning repository at {args.repo_hashtag}")
+        repo_dir.mkdir(parents=True, exist_ok=True)
+        exec(["git", "init", "--initial-branch=main"], cwd=repo_dir)
+        exec(["git", "config", "advice.detachedHead", "false"], cwd=repo_dir)
+        exec(["git", "remote", "add", "origin", args.gitrepo_origin], cwd=repo_dir)
+
+    # Fetch and checkout.
+    fetch_args = []
+    if args.depth is not None:
+        fetch_args.extend(["--depth", str(args.depth)])
+    if args.jobs:
+        fetch_args.extend(["-j", str(args.jobs)])
+    exec(["git", "fetch"] + fetch_args + ["origin", args.repo_hashtag], cwd=repo_dir)
+    exec(["git", "checkout", "FETCH_HEAD"], cwd=repo_dir)
+    exec(["git", "tag", "-f", TAG_UPSTREAM_DIFFBASE], cwd=repo_dir)
+    try:
+        exec(
+            ["git", "submodule", "update", "--init", "--recursive"] + fetch_args,
+            cwd=repo_dir,
+        )
+    except subprocess.CalledProcessError:
+        print("Failed to fetch git submodules")
+        sys.exit(1)
+    exec(
+        [
+            "git",
+            "submodule",
+            "foreach",
+            "--recursive",
+            f"git tag -f {TAG_UPSTREAM_DIFFBASE}",
+        ],
+        cwd=repo_dir,
+        stdout_devnull=True,
+    )
+    git_config_ignore_submodules(repo_dir)
+
+    # Base patches.
+    if args.patch:
+        apply_all_patches(
+            repo_dir,
+            repo_patch_dir_base / repo_hashtag_to_patches_dir_name(args.repo_hashtag),
+            args.repo_name,
+            "base",
+        )
+
+    # Hipify.
+    if args.hipify:
+        do_hipify(args)
+
+    # Hipified patches.
+    if args.patch:
+        apply_all_patches(
+            repo_dir,
+            repo_patch_dir_base / repo_hashtag_to_patches_dir_name(args.repo_hashtag),
+            args.repo_name,
+            "hipified",
+        )
+
+
+def do_hipify(args: argparse.Namespace):
+    repo_dir: Path = args.repo
+    print(f"Hipifying {repo_dir}")
+    build_amd_path = repo_dir / "tools" / "amd_build" / "build_amd.py"
+    if os.path.exists(build_amd_path):
+        exec([sys.executable, build_amd_path], cwd=repo_dir)
+    # Iterate over the base repository and all submodules. Because we process
+    # the root repo first, it will not add submodule changes.
+    all_paths = get_all_repositories(repo_dir)
+    for module_path in all_paths:
+        status = list_status(module_path)
+        if not status:
+            continue
+        print(f"HIPIFY made changes to {module_path}: Committing")
+        exec(["git", "add", "-A"], cwd=module_path)
+        exec(["git", "commit", "-m", HIPIFY_COMMIT_MESSAGE], cwd=module_path)
+        exec(["git", "tag", "-f", TAG_HIPIFY_DIFFBASE], cwd=module_path)
+
+
+def do_save_patches(args: argparse.Namespace):
+    repo_name = args.repo_name
+    repo_patch_dir_base = args.patch_dir
+    patches_dir = repo_patch_dir_base / repo_hashtag_to_patches_dir_name(
+        args.repo_hashtag
+    )
+    save_repo_patches(args.repo, patches_dir / repo_name)
+    relative_sm_paths = list_submodules(args.repo, relative=True)
+    for relative_sm_path in relative_sm_paths:
+        save_repo_patches(args.repo / relative_sm_path, patches_dir / relative_sm_path)


### PR DESCRIPTION
- split the code from ptbuild.py to repo_management.py and pytorch_repo.py.
- kept also the old ptbuild.py still available until windows builds are also checked to work
- repo_management.py handles the generic code for git and patch management
- pytorch_repo.py, pytorch_vision_repo.py and pytorch_audio_repo.py defines the project specific parameters like application name, repo url, repo version, etc. which are then given as a parameter for repo_management.py to checkout code and manage patches
- checkout_and_build_all.sh script will checkout and build everything as a single command.
- pytorch_visio and audio wheels build are not yet installed automatically. (need to get rid from the git-hash in the wheel filenames build)

- fixes: https://github.com/ROCm/TheRock/issues/495