### PR TITLE
Expanding AMD GPU matrix and adding options for package generation

### DIFF
--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -20,7 +20,7 @@ on:
       package_suffix:
         type: string
       families:
-        description: "Please enter a comma separated list of AMD GPU family (ex: gfx94X, gfx103x). Please note that docker builds only work for prebuilds availabe here [nightly-release](https://github.com/ROCm/TheRock/releases/tag/nightly-release)"
+        description: "Please enter a comma separated list of AMD GPU family (ex: gfx94X, gfx103x)"
         type: string
   # Trigger on a schedule to build nightly release candidates.
   schedule:

--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -19,6 +19,9 @@ on:
         default: "rc"
       package_suffix:
         type: string
+      families:
+        description: "Please enter a comma separated list of AMD GPU family (ex: gfx94X, gfx103x). Please note that docker builds only work for prebuilds availabe here [nightly-release](https://github.com/ROCm/TheRock/releases/tag/nightly-release)"
+        type: string
   # Trigger on a schedule to build nightly release candidates.
   schedule:
     # Runs at 11:00 AM UTC, which is 3:00 AM PST (UTC-8)
@@ -65,6 +68,7 @@ jobs:
         id: configure
         env:
           PYTORCH_DEV_DOCKER: "false"
+          AMDGPU_FAMILIES: ${{ inputs.families }}
         run: python ./build_tools/github_action/fetch_package_targets.py
 
   portable_linux_packages:

--- a/.github/workflows/publish_pytorch_dev_docker.yml
+++ b/.github/workflows/publish_pytorch_dev_docker.yml
@@ -1,6 +1,10 @@
 name: Publish PyTorch Dev Dockers
 on:
   workflow_dispatch:
+    inputs:
+      families:
+        description: "Please enter a comma separated list of AMD GPU family (ex: gfx94X, gfx103x). Please note that docker builds only work for prebuilds availabe here [nightly-release](https://github.com/ROCm/TheRock/releases/tag/nightly-release)"
+        type: string
   schedule:
     - cron: "0 2 * * *" # Runs nightly at 2 AM UTC
 
@@ -17,6 +21,7 @@ jobs:
         id: configure
         env:
           PYTORCH_DEV_DOCKER: "true"
+          AMDGPU_FAMILIES: ${{ inputs.families }}
         run: python ./build_tools/github_action/fetch_package_targets.py
 
   build-and-push-image:

--- a/.github/workflows/publish_pytorch_dev_docker.yml
+++ b/.github/workflows/publish_pytorch_dev_docker.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       families:
-        description: "Please enter a comma separated list of AMD GPU family (ex: gfx94X, gfx103x). Please note that docker builds only work for prebuilds availabe here [nightly-release](https://github.com/ROCm/TheRock/releases/tag/nightly-release)"
+        description: "Please enter a comma separated list of AMD GPU family (ex: gfx94X, gfx103x). Please note that docker builds only work for prebuilds available here [nightly-release](https://github.com/ROCm/TheRock/releases/tag/nightly-release)"
         type: string
   schedule:
     - cron: "0 2 * * *" # Runs nightly at 2 AM UTC

--- a/.github/workflows/publish_pytorch_dev_docker.yml
+++ b/.github/workflows/publish_pytorch_dev_docker.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       families:
-        description: "Please enter a comma separated list of AMD GPU family (ex: gfx94X, gfx103x). Please note that docker builds only work for prebuilds available here [nightly-release](https://github.com/ROCm/TheRock/releases/tag/nightly-release)"
+        description: "Please enter a comma separated list of AMD GPU family (ex: gfx94X, gfx103x). Please note that docker builds only work for prebuilds available here https://github.com/ROCm/TheRock/releases/tag/nightly-release"
         type: string
   schedule:
     - cron: "0 2 * * *" # Runs nightly at 2 AM UTC

--- a/build_tools/github_action/amdgpu_family_matrix.py
+++ b/build_tools/github_action/amdgpu_family_matrix.py
@@ -3,11 +3,32 @@ This AMD GPU Family Matrix is the "source of truth" for GitHub workflows, indica
 """
 
 amdgpu_family_info_matrix = {
+    "gfx90x": {
+        "linux": {
+            "test-runs-on": "",
+            "family": "gfx90X-dcgpu",
+            "pytorch-target": "gfx90a",
+        }
+    },
     "gfx94x": {
         "linux": {
             "test-runs-on": "linux-mi300-1gpu-ossci-rocm",
             "family": "gfx94X-dcgpu",
             "pytorch-target": "gfx942",
+        }
+    },
+    "gfx101x": {
+        "linux": {
+            "test-runs-on": "",
+            "family": "gfx101X-dgpu",
+            "pytorch-target": "gfx1010",
+        }
+    },
+    "gfx103x": {
+        "linux": {
+            "test-runs-on": "",
+            "family": "gfx103X-dgpu",
+            "pytorch-target": "gfx1030",
         }
     },
     "gfx110x": {
@@ -22,10 +43,7 @@ amdgpu_family_info_matrix = {
         },
     },
     "gfx115x": {
-        "linux": {
-            "test-runs-on": "",
-            "family": "gfx1151",
-        }
+        "linux": {"test-runs-on": "", "family": "gfx1151", "pytorch-target": "gfx1151"}
     },
     "gfx120x": {
         "linux": {


### PR DESCRIPTION
Changes:
- Expanding AMD GPU matrix to support more targets/families
- Adding a workflow_dispatch input option to build specific families

progress on #493 , once this workflow runs, gfx1151 image will be available since prebuilt for 1151 exists. for new targets, we will wait till the 2am run to generate those docker images