### PR TITLE
Apply Python3_EXECUTABLE patches to rocSPARSE and hipBLAS.

### DIFF
--- a/patches/amd-mainline/hipBLAS/0001-Fix-finding-LAPACK-and-CBLAS.patch
+++ b/patches/amd-mainline/hipBLAS/0001-Fix-finding-LAPACK-and-CBLAS.patch
@@ -1,7 +1,7 @@
-From 953a6e2dad2072dfa1434aa038a855383f636185 Mon Sep 17 00:00:00 2001
+From 85c2dced6733577970876d8c437ac4d8cf0cfe42 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Tue, 25 Mar 2025 12:13:13 +0000
-Subject: [PATCH 1/5] Fix finding LAPACK and CBLAS
+Subject: [PATCH 1/6] Fix finding LAPACK and CBLAS
 
 Use target names provided by `find_package()` instead of assuming that
 the reference NETLIB libraries should be used.
@@ -43,5 +43,5 @@ index 4b01cc8..5198853 100644
    if( BUILD_CLIENTS_TESTS )
      add_subdirectory( gtest )
 -- 
-2.43.0
+2.45.1.windows.1
 

--- a/patches/amd-mainline/hipBLAS/0002-Work-around-race-condition.patch
+++ b/patches/amd-mainline/hipBLAS/0002-Work-around-race-condition.patch
@@ -1,7 +1,7 @@
-From 5aecac67b1268870eda32b9f3dee4f92e723774e Mon Sep 17 00:00:00 2001
+From 97e3010ee29d5e372e02c6291a7dafe1555a2e00 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Fri, 21 Mar 2025 17:01:20 +0000
-Subject: [PATCH 2/5] Work around race condition
+Subject: [PATCH 2/6] Work around race condition
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -28,5 +28,5 @@ index 5198853..983951b 100644
    include_directories(${CMAKE_BINARY_DIR}/include/hipblas)
    include_directories(${CMAKE_BINARY_DIR}/include)
 -- 
-2.43.0
+2.45.1.windows.1
 

--- a/patches/amd-mainline/hipBLAS/0003-Install-libhipblas_fortran.so.patch
+++ b/patches/amd-mainline/hipBLAS/0003-Install-libhipblas_fortran.so.patch
@@ -1,7 +1,7 @@
-From ad1edcc0049752ffd94beef545ba6b8831089044 Mon Sep 17 00:00:00 2001
+From 909dbe87ae3da0b94d551bb0d580d9d2c63c5612 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Tue, 1 Apr 2025 20:58:38 +0000
-Subject: [PATCH 3/5] Install `libhipblas_fortran.so`
+Subject: [PATCH 3/6] Install `libhipblas_fortran.so`
 
 This is required by the test and benchmark clients but was not part of
 the installation so far.
@@ -22,5 +22,5 @@ index ceee022..5da9875 100755
  
  if(BUILD_ADDRESS_SANITIZER)
 -- 
-2.43.0
+2.45.1.windows.1
 

--- a/patches/amd-mainline/hipBLAS/0004-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
+++ b/patches/amd-mainline/hipBLAS/0004-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
@@ -1,7 +1,7 @@
-From e63fe52eaaa8bbc607d1c412674c03dea1b1edbe Mon Sep 17 00:00:00 2001
+From 50d46c2069b14fbede1a9a8a4df19b583369f3ca Mon Sep 17 00:00:00 2001
 From: Scott <scott.todd0@gmail.com>
 Date: Tue, 8 Apr 2025 16:10:37 -0700
-Subject: [PATCH 4/5] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
+Subject: [PATCH 4/6] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
 
 ---
  CMakeLists.txt | 4 +++-
@@ -23,5 +23,5 @@ index 7b60619..f22f44d 100644
    SET( CPACK_SET_DESTDIR FALSE )
    SET( CPACK_PACKAGE_INSTALL_DIRECTORY "C:/hipSDK" )
 -- 
-2.43.0
+2.45.1.windows.1
 

--- a/patches/amd-mainline/hipBLAS/0005-Adapt-to-some-upstream-hipblas-common-usage-differen.patch
+++ b/patches/amd-mainline/hipBLAS/0005-Adapt-to-some-upstream-hipblas-common-usage-differen.patch
@@ -1,8 +1,7 @@
-From 9487f34166389d781c5b441823cdc21fbf67b262 Mon Sep 17 00:00:00 2001
+From b37f4ffd49ba0f819907dbf183db773017c1e9d5 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Tue, 29 Apr 2025 22:13:17 -0700
-Subject: [PATCH 5/5] [temporary] Adapt to some upstream hipblas-common usage
- differences.
+Subject: [PATCH 5/6] Adapt to some upstream hipblas-common usage differences.
 
 * The hipblas-common library seems to be in the process of being renamed to hip::hipblas-common but not uniformly yet.
 * This was coming from a dependency in a prior state, thus INTERFACE was ok. However, it is needed within the library and with the dependent not advertising it anymore, compilation fails to find hipblas-common.h.
@@ -24,5 +23,5 @@ index 5da9875..0b3b6f1 100755
  # Build hipblas from source on AMD platform
  if(HIP_PLATFORM STREQUAL amd)
 -- 
-2.43.0
+2.45.1.windows.1
 

--- a/patches/amd-mainline/hipBLAS/0006-Replace-python-with-official-Python3_EXECUTABLE-vari.patch
+++ b/patches/amd-mainline/hipBLAS/0006-Replace-python-with-official-Python3_EXECUTABLE-vari.patch
@@ -1,0 +1,26 @@
+From 341468c4728fd6864facdd27d79cd20778e63aa4 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Wed, 30 Apr 2025 12:03:23 -0700
+Subject: [PATCH 6/6] Replace ${python} with official ${Python3_EXECUTABLE}
+ variable.
+
+---
+ clients/gtest/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/clients/gtest/CMakeLists.txt b/clients/gtest/CMakeLists.txt
+index 9434c4d..82d97da 100644
+--- a/clients/gtest/CMakeLists.txt
++++ b/clients/gtest/CMakeLists.txt
+@@ -234,7 +234,7 @@ if( BUILD_WITH_SOLVER )
+ endif()
+ 
+ add_custom_command( OUTPUT "${HIPBLAS_TEST_DATA}"
+-                    COMMAND ${python} ../common/hipblas_gentest.py -I ../include hipblas_gtest.yaml -o "${HIPBLAS_TEST_DATA}"
++                    COMMAND ${Python3_EXECUTABLE} ../common/hipblas_gentest.py -I ../include hipblas_gtest.yaml -o "${HIPBLAS_TEST_DATA}"
+                     DEPENDS ../common/hipblas_gentest.py ../include/hipblas_common.yaml "${HIPBLAS_AUX_YAML_DATA}" "${HIPBLAS_L1_YAML_DATA}" "${HIPBLAS_L2_YAML_DATA}" "${HIPBLAS_L3_YAML_DATA}" "${HIPBLAS_EX_YAML_DATA}" "${HIPBLAS_SOLVER_YAML_DATA}" hipblas_gtest.yaml
+                     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
+ 
+-- 
+2.45.1.windows.1
+

--- a/patches/amd-mainline/rocSPARSE/0001-Drop-setting-library-directory-and-rpath.patch
+++ b/patches/amd-mainline/rocSPARSE/0001-Drop-setting-library-directory-and-rpath.patch
@@ -1,7 +1,7 @@
-From 80d0e133e63e0e61e07f446ccdf67a7b8411d49b Mon Sep 17 00:00:00 2001
+From 7b2e5815945b152d80aedb0da38f8939895c6498 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Thu, 20 Mar 2025 13:19:39 +0000
-Subject: [PATCH 1/2] Drop setting library directory and rpath
+Subject: [PATCH 1/4] Drop setting library directory and rpath
 
 ---
  clients/CMakeLists.txt     | 2 +-
@@ -39,5 +39,5 @@ index 189a10e3..2de17498 100644
  endif()
  
 -- 
-2.47.1.windows.2
+2.45.1.windows.1
 

--- a/patches/amd-mainline/rocSPARSE/0002-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
+++ b/patches/amd-mainline/rocSPARSE/0002-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
@@ -1,7 +1,7 @@
-From d946ec237705a9a18d56a4516e4170da7bf7f680 Mon Sep 17 00:00:00 2001
+From 4e315425317085f2fb47348ad79c6fda44715d9f Mon Sep 17 00:00:00 2001
 From: Scott <scott.todd0@gmail.com>
 Date: Wed, 2 Apr 2025 14:42:25 -0700
-Subject: [PATCH 2/2] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
+Subject: [PATCH 2/4] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
 
 ---
  CMakeLists.txt | 4 +++-
@@ -23,5 +23,5 @@ index 1699c029..c65552b8 100644
    set(CPACK_SET_DESTDIR OFF)
    set(CPACK_PACKAGE_INSTALL_DIRECTORY "C:/hipSDK")
 -- 
-2.47.1.windows.2
+2.45.1.windows.1
 

--- a/patches/amd-mainline/rocSPARSE/0003-Replace-deprecated-reference-GTest-GTest-GTest-gtest.patch
+++ b/patches/amd-mainline/rocSPARSE/0003-Replace-deprecated-reference-GTest-GTest-GTest-gtest.patch
@@ -1,7 +1,7 @@
-From 0ede7ef275102af91769c6ee4af58111fa1c8b49 Mon Sep 17 00:00:00 2001
+From aa3c65907c4b27683ee76ed360e0991693c2fe77 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Fri, 11 Apr 2025 18:11:11 -0700
-Subject: [PATCH 3/3] Replace deprecated reference GTest::GTest ->
+Subject: [PATCH 3/4] Replace deprecated reference GTest::GTest ->
  GTest::gtest.
 
 ---
@@ -22,5 +22,5 @@ index db8e3f32..e3a02198 100644
  # Add OpenMP if available
  if(OPENMP_FOUND)
 -- 
-2.43.0
+2.45.1.windows.1
 

--- a/patches/amd-mainline/rocSPARSE/0004-Replace-python-with-official-Python3_EXECUTABLE-vari.patch
+++ b/patches/amd-mainline/rocSPARSE/0004-Replace-python-with-official-Python3_EXECUTABLE-vari.patch
@@ -1,0 +1,26 @@
+From 9d1e287010db7498edda16a4663cba4128babbc5 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Wed, 30 Apr 2025 11:56:21 -0700
+Subject: [PATCH 4/4] Replace ${python} with official ${Python3_EXECUTABLE}
+ variable.
+
+---
+ clients/tests/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/clients/tests/CMakeLists.txt b/clients/tests/CMakeLists.txt
+index e3a02198..514e8db4 100644
+--- a/clients/tests/CMakeLists.txt
++++ b/clients/tests/CMakeLists.txt
+@@ -405,7 +405,7 @@ string(REGEX REPLACE ".cpp" ".yaml" ROCSPARSE_TEST_YAMLS "${ROCSPARSE_TEST_SOURC
+ # Prepare testing data
+ set(ROCSPARSE_TEST_DATA "${PROJECT_BINARY_DIR}/staging/rocsparse_test.data")
+ add_custom_command(OUTPUT "${ROCSPARSE_TEST_DATA}"
+-                   COMMAND ${python} ../common/rocsparse_gentest.py -m ${PROJECT_BINARY_DIR}/matrices -I ../include rocsparse_test.yaml -o "${ROCSPARSE_TEST_DATA}"
++                   COMMAND ${Python3_EXECUTABLE} ../common/rocsparse_gentest.py -m ${PROJECT_BINARY_DIR}/matrices -I ../include rocsparse_test.yaml -o "${ROCSPARSE_TEST_DATA}"
+                    DEPENDS ../common/rocsparse_gentest.py rocsparse_test.yaml ../include/rocsparse_common.yaml ${ROCSPARSE_TEST_YAMLS}
+                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+ add_custom_target(rocsparse-test-data
+-- 
+2.45.1.windows.1
+


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/36. Now I can build the tests for rocSPARSE on Windows.

After calling `find_package(Python3 COMPONENTS Interpreter)`, the result variable `Python3_EXECUTABLE` should be set. This should be used instead of custom discovery or manual setting like in https://github.com/ROCm/rocSPARSE/blob/develop/toolchain-windows.cmake:

```cmake
if (NOT python)
  set(python "python") # take default for windows
endif()
```

Docs:

* https://cmake.org/cmake/help/latest/module/FindPython3.html
* https://cmake.org/cmake/help/latest/module/FindPython3.html#result-variables

---

I did not fix up _all_ references to the custom `python` CMake variable. Notably, rocBLAS has more convoluted logic using a virtual environment that needs to be untangled more carefully (`FindPython3` has support for virtual envs as needed, but there are other options available up in the super-project or under direct user control): https://github.com/ROCm/rocBLAS/blob/develop/cmake/virtualenv.cmake
```cmake
find_program(VIRTUALENV_PYTHON_EXE ${python})
if(NOT VIRTUALENV_PYTHON_EXE)
    # look for non default name
    if(${python} MATCHES "python3")
        find_program(VIRTUALENV_PYTHON_EXE python)
    else()
        find_program(VIRTUALENV_PYTHON_EXE python3)
    endif()
endif()
```