### PR TITLE
Mark rocSPARSE as supported on Windows.

### DIFF
--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -50,7 +50,7 @@ mainline, in open source, using MSVC, etc.).
 | math-libs (blas) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ✅        |                                               |
 | math-libs (blas) | [hipBLASLt](https://github.com/ROCm/hipBLASLt)                               | ✅        |                                               |
 | math-libs (blas) | [rocBLAS](https://github.com/ROCm/rocBLAS)                                   | ✅        | Running tests needs PyYAML and a dll copied   |
-| math-libs (blas) | [rocSPARSE](https://github.com/ROCm/rocSPARSE)                               | ❔        |                                               |
+| math-libs (blas) | [rocSPARSE](https://github.com/ROCm/rocSPARSE)                               | ✅        | Tests need rocblas.dll and can't find files   |
 | math-libs (blas) | [hipSPARSE](https://github.com/ROCm/hipSPARSE)                               | ❔        |                                               |
 | math-libs (blas) | [rocSOLVER](https://github.com/ROCm/rocSOLVER)                               | ❔        |                                               |
 | math-libs (blas) | [hipSOLVER](https://github.com/ROCm/hipSOLVER)                               | ❔        |                                               |


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/36.

Tests need a bit of help to run, but otherwise seems to be working:

1. I manually copied `rocblas.dll` from `build/math-libs/BLAS/rocBLAS/dist/bin` to `build\math-libs\BLAS\rocSPARSE\dist\bin`
2. Some tests need files from relative paths that aren't copied into the dist dir (they can be found at `build\math-libs\BLAS\rocSPARSE\build\clients\matrices`):

    ```
    .\build\math-libs\BLAS\rocSPARSE\dist\bin\rocsparse-test.exe

    ...
    [ RUN      ] quick/bsrmv.level2/f64_c_10_33_n0p5_n0p5_0p5_1_row_2_NT_0b_zero_0
    [       OK ] quick/bsrmv.level2/f64_c_10_33_n0p5_n0p5_0p5_1_row_2_NT_0b_zero_0 (159 ms)
    [ RUN      ] quick/bsrmv.level2/f64_c_10_33_n0p5_n0p5_0p5_1_row_2_NT_0b_zero_0_t2
    [       OK ] quick/bsrmv.level2/f64_c_10_33_n0p5_n0p5_0p5_1_row_2_NT_0b_zero_0_t2 (160 ms)
    [ RUN      ] quick/bsrmv.level2/f32_r_1_1_1_0_n1_0_column_3_NT_1b_csr_0_nos1
    Opening file 'D:\projects\TheRock\build\math-libs\BLAS\rocSPARSE\dist\bin\/../matrices/nos1.csr' ...
    #
    # error:
    # cannot open file 'D:\projects\TheRock\build\math-libs\BLAS\rocSPARSE\dist\bin\/../matrices/nos1.csr'
    ```