### PR TITLE
Disable hipSOLVER BUILD_WITH_SPARSE on Windows.

### DIFF
--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -243,6 +243,15 @@ if(THEROCK_ENABLE_SOLVER)
     list(APPEND hipSOLVER_optional_deps therock-host-blas)
   endif()
 
+  if(WIN32)
+    set(hipSOLVER_build_with_sparse "OFF")
+  else()
+    # Note: BUILD_WITH_SPARSE converts rocSPARSE and cholmod to build time vs
+    # runtime/dlopen deps.
+    set(hipSOLVER_build_with_sparse "ON")
+    list(APPEND hipSOLVER_optional_deps therock-SuiteSparse)
+  endif()
+
   therock_cmake_subproject_declare(hipSOLVER
       EXTERNAL_SOURCE_DIR "hipSOLVER"
       BACKGROUND_BUILD
@@ -251,9 +260,7 @@ if(THEROCK_ENABLE_SOLVER)
         -DROCM_PATH=
         -DROCM_DIR=
         -DBUILD_HIPSPARSE_TESTS=OFF
-        # BUILD_WITH_SPARSE converts rocsparse and cholmod to build time vs
-        # runtime/dlopen deps.
-        -DBUILD_WITH_SPARSE=ON
+        -DBUILD_WITH_SPARSE=${hipSOLVER_build_with_sparse}
         -DBUILD_CLIENTS_BENCHMARKS=${THEROCK_BUILD_TESTING}
         -DBUILD_CLIENTS_TESTS=${THEROCK_BUILD_TESTING}
         -DHIPSOLVER_FIND_PACKAGE_LAPACK_CONFIG=OFF
@@ -267,7 +274,6 @@ if(THEROCK_ENABLE_SOLVER)
         rocBLAS
         rocSOLVER
         rocSPARSE
-        therock-SuiteSparse
         ${hipSOLVER_optional_deps}
   )
   therock_cmake_subproject_glob_c_sources(hipSOLVER


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/36. Adapted from a commit by @jammm.

hipSOLVER has built with sparse disabled on Windows since ROCm 6.1.0: https://github.com/ROCm/hipSOLVER/blob/bb8408f52a166c5ce587b204c61a51ae44bc1daa/CHANGELOG.md?plain=1#L101 and trying to enable it leads to build errors in SuiteSparse/cholmod: https://gist.github.com/ScottTodd/f4c10fb150e7f4a5b1c016dcbe0b2bf3.

With it disabled, I can build the hipSOLVER library but not its tests. The tests need some environment/CMake variables changed or plumbed through as described here: https://github.com/ROCm/TheRock/issues/36#issuecomment-2843655001.