### PR TITLE
WIP - Adding additional fallback targets

### DIFF
--- a/dockerfiles/pytorch-dev/install_rocm_from_release.sh
+++ b/dockerfiles/pytorch-dev/install_rocm_from_release.sh
@@ -101,8 +101,12 @@ echo "[INFO] Output dir: $OUTPUT_ARTIFACTS_DIR"
 # === Fallback encoding map ===
 fallback_target_name() {
   case "$1" in
+    gfx90a) echo "gfx90X-dcgpu" ;;
     gfx942) echo "gfx94X-dcgpu" ;;
+    gfx1010) echo "gfx101X-dgpu" ;;
+    gfx1030) echo "gfx103X-dgpu" ;;
     gfx1100) echo "gfx110X-dgpu" ;;
+    gfx1151) echo "gfx115X-igpu" ;;
     gfx1201) echo "gfx120X-all" ;;
     *) echo "" ;;
   esac


### PR DESCRIPTION
Currently, pytorch has hard-coded only three targets. This update expands the targets to other available portable builds.

Status as of 5/8/25: BLAS error during build, waiting for fix to test then land this

Progress on #493 
