### PR TITLE
Patch hipSOLVER Windows dll copy code that needs env vars.

### DIFF
--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -52,8 +52,8 @@ mainline, in open source, using MSVC, etc.).
 | math-libs (blas) | [rocBLAS](https://github.com/ROCm/rocBLAS)                                   | ✅        | Running tests needs PyYAML and a dll copied   |
 | math-libs (blas) | [rocSPARSE](https://github.com/ROCm/rocSPARSE)                               | ✅        | Tests need rocblas.dll and can't find files   |
 | math-libs (blas) | [hipSPARSE](https://github.com/ROCm/hipSPARSE)                               | ❔        |                                               |
-| math-libs (blas) | [rocSOLVER](https://github.com/ROCm/rocSOLVER)                               | ❔        |                                               |
-| math-libs (blas) | [hipSOLVER](https://github.com/ROCm/hipSOLVER)                               | ❔        |                                               |
+| math-libs (blas) | [rocSOLVER](https://github.com/ROCm/rocSOLVER)                               | ✅        |                                               |
+| math-libs (blas) | [hipSOLVER](https://github.com/ROCm/hipSOLVER)                               | ✅        | Tests need dlls                               |
 | math-libs (blas) | [hipBLAS](https://github.com/ROCm/hipBLAS)                                   | ❔        |                                               |
 |                  |                                                                              |           |                                               |
 | ml-libs          | [MIOpen](https://github.com/ROCm/MIOpen)                                     | ❔        |                                               |

--- a/patches/amd-mainline/hipSOLVER/0001-Work-around-race-condition.patch
+++ b/patches/amd-mainline/hipSOLVER/0001-Work-around-race-condition.patch
@@ -1,7 +1,7 @@
-From c67269d9e0cd3fa0f3a30fb01d044658945f979c Mon Sep 17 00:00:00 2001
+From ff3eb27319fa8a3c76b00782f37defb9283fd921 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Mon, 31 Mar 2025 22:24:41 +0000
-Subject: [PATCH 1/3] Work around race condition
+Subject: [PATCH 1/5] Work around race condition
 
 With `add_dependency`, compiling the `hipsolver_fortran_client` target
 fails as `hipsolver.mod` is not created in time for the first build

--- a/patches/amd-mainline/hipSOLVER/0002-Install-hipsolver_client.so.patch
+++ b/patches/amd-mainline/hipSOLVER/0002-Install-hipsolver_client.so.patch
@@ -1,7 +1,7 @@
-From 2748b7af8ff0c7e8d1911900eb1558cf1072d7a2 Mon Sep 17 00:00:00 2001
+From 1b21d3bbf8234df5067d44d90bedacdf57341c97 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Tue, 1 Apr 2025 14:41:28 +0000
-Subject: [PATCH 2/3] Install `hipsolver_client.so`
+Subject: [PATCH 2/5] Install `hipsolver_client.so`
 
 This is required by the test and benchmark clients but was not part of
 the installation so far.

--- a/patches/amd-mainline/hipSOLVER/0003-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
+++ b/patches/amd-mainline/hipSOLVER/0003-Fix-CMAKE_INSTALL_PREFIX-init-behavior-on-Win32.patch
@@ -1,17 +1,17 @@
-From e91d6d9a772448122ff787adc6d9615f857639a4 Mon Sep 17 00:00:00 2001
+From 1ecce254b331df6d6f62dfc47bad677005a4b93f Mon Sep 17 00:00:00 2001
 From: Scott <scott.todd0@gmail.com>
 Date: Wed, 2 Apr 2025 14:43:19 -0700
-Subject: [PATCH 3/3] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
+Subject: [PATCH 3/5] Fix CMAKE_INSTALL_PREFIX init behavior on Win32.
 
 ---
  CMakeLists.txt | 4 +++-
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7c04ae3..571dd52 100644
+index 70caba3..ef0262f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -267,7 +267,9 @@ set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+@@ -264,7 +264,9 @@ set(CPACK_RPM_PACKAGE_LICENSE "MIT")
  if(WIN32)
    set(CPACK_SOURCE_GENERATOR "ZIP")
    set(CPACK_GENERATOR "ZIP")

--- a/patches/amd-mainline/hipSOLVER/0004-Replace-deprecated-GTest-GTest-with-GTest-gtest.patch
+++ b/patches/amd-mainline/hipSOLVER/0004-Replace-deprecated-GTest-GTest-with-GTest-gtest.patch
@@ -1,7 +1,7 @@
-From 81af9fa868610b043d0a4093433f98fc2c7c2ac5 Mon Sep 17 00:00:00 2001
+From cdfe6adbd729f2e9cd30e86e83aa6f1bfac8c6fc Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 14 Apr 2025 15:24:10 -0700
-Subject: [PATCH 4/4] Replace deprecated GTest::GTest with GTest::gtest.
+Subject: [PATCH 4/5] Replace deprecated GTest::GTest with GTest::gtest.
 
 ---
  clients/gtest/CMakeLists.txt | 2 +-
@@ -21,5 +21,5 @@ index a3566f9..cdbf9be 100644
    roc::hipsolver
  )
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/hipSOLVER/0005-Check-if-rocblas_DIR-env-var-is-set-before-using-it.patch
+++ b/patches/amd-mainline/hipSOLVER/0005-Check-if-rocblas_DIR-env-var-is-set-before-using-it.patch
@@ -1,0 +1,35 @@
+From fcdd342f60ecd6a4b5544f999819071f7c532e37 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Thu, 1 May 2025 10:59:02 -0700
+Subject: [PATCH 5/5] Check if rocblas_DIR env var is set before using it.
+
+---
+ clients/gtest/CMakeLists.txt | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/clients/gtest/CMakeLists.txt b/clients/gtest/CMakeLists.txt
+index cdbf9be..41d003b 100644
+--- a/clients/gtest/CMakeLists.txt
++++ b/clients/gtest/CMakeLists.txt
+@@ -172,9 +172,13 @@ if(WIN32)
+       ARGS -E copy ${file_i} ${PROJECT_BINARY_DIR}/staging/
+     )
+   endforeach()
+-  add_custom_command(TARGET hipsolver-test
+-    POST_BUILD
+-    COMMAND ${CMAKE_COMMAND}
+-    ARGS -E copy_directory $ENV{rocblas_DIR}/bin/rocblas/library ${PROJECT_BINARY_DIR}/staging/library
+-  )
++  if(DEFINED $ENV{rocblas_DIR})
++    add_custom_command(TARGET hipsolver-test
++      POST_BUILD
++      COMMAND ${CMAKE_COMMAND}
++      ARGS -E copy_directory $ENV{rocblas_DIR}/bin/rocblas/library ${PROJECT_BINARY_DIR}/staging/library
++    )
++  else()
++    message(WARNING "ENV{rocblas_DIR} not set, tests may be missing .dlls")
++  endif()
+ endif()
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/36.

See https://github.com/ROCm/TheRock/issues/513. This avoids a `Error copying directory from "/bin/rocblas/library" to "D:/projects/TheRock/build/math-libs/BLAS/hipSOLVER/build/clients/staging/library"` build time error in hipSOLVER when the `rocblas_DIR` environment variable is not set for some .dll copying code. I'm not sure yet if that copying code will actually be needed in TheRock, given how we model RUNTIME_DEPS in subprojects. For now when _running_ tests, I'm either manually copying .dll files next to test executables or I'm running with a modified PATH.