### PR TITLE
Disable HOST_SUITE_SPARSE on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,10 +201,15 @@ therock_add_feature(SPARSE
   DESCRIPTION "Enables sparse libraries (hipsparse, rocsparse)"
   REQUIRES COMPILER HIP_RUNTIME BLAS PRIM
 )
+if(NOT WIN32)
+  set(_solver_platform_requirements "HOST_SUITE_SPARSE")
+else()
+  set(_solver_platform_requirements "")
+endif()
 therock_add_feature(SOLVER
   GROUP MATH_LIBS
   DESCRIPTION "Enables solver libraries (hipsolver, rocsolver)"
-  REQUIRES COMPILER HIP_RUNTIME BLAS PRIM SPARSE HOST_SUITE_SPARSE
+  REQUIRES COMPILER HIP_RUNTIME BLAS PRIM SPARSE ${_solver_platform_requirements}
 )
 
 # ML-Libs Features.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,11 +108,14 @@ therock_add_feature(HOST_BLAS
   GROUP HOST_MATH
   DESCRIPTION "Bundled host BLAS library"
 )
-therock_add_feature(HOST_SUITE_SPARSE
-  GROUP HOST_MATH
-  DESCRIPTION "Bundled SuiteSparse library"
-  REQUIRES HOST_BLAS
-)
+if(NOT WIN32)
+  # Currently unsupported on Windows.
+  therock_add_feature(HOST_SUITE_SPARSE
+    GROUP HOST_MATH
+    DESCRIPTION "Bundled SuiteSparse library"
+    REQUIRES HOST_BLAS
+  )
+endif()
 
 # Base Features.
 therock_add_feature(COMPILER


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/36.

On Windows, SuiteSparse is not currently used and does not build without errors.

Now I can just about build the CMake `all` target when the math and BLAS libraries are enabled. Need to fully validate that after flushing my patch queue and then eventually get the CI/CD caught up.