### PR TITLE
Adding python packages to portable linux builds

### DIFF
--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -105,15 +105,23 @@ jobs:
           restore-keys: |
             portable-linux-package-matrix-v1-${{ matrix.target_bundle.amdgpu_family }}-
 
+      - name: Setup python virtual environment and install python packages
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
+
       - name: Fetch sources
         run: |
           # Prefetch docker container in background.
+          source venv/bin/activate
           docker pull ${{ env.BUILD_IMAGE }} &
           ./build_tools/fetch_sources.py --jobs 10
           wait
 
       - name: Build Projects
         run: |
+          source venv/bin/activate
           ./build_tools/linux_portable_build.py \
             --image=${{ env.BUILD_IMAGE }} \
             --output-dir=${{ env.OUTPUT_DIR }} \


### PR DESCRIPTION
Noticing build issues and realized that we don't install python packages for portable builds

![Screenshot 2025-05-01 170058](https://github.com/user-attachments/assets/daa2e00d-fe24-4c53-83d6-89073315361e)

installing this should fix it, test running [here](https://github.com/ROCm/TheRock/actions/runs/14785966138)
