### PR TITLE
Set empty tags messages during PyTorch checkout.

### DIFF
--- a/external-builds/pytorch/ptbuild.py
+++ b/external-builds/pytorch/ptbuild.py
@@ -236,7 +236,7 @@ def do_checkout(args: argparse.Namespace):
         fetch_args.extend(["-j", str(args.jobs)])
     exec(["git", "fetch"] + fetch_args + ["origin", args.pytorch_ref], cwd=repo_dir)
     exec(["git", "checkout", "FETCH_HEAD"], cwd=repo_dir)
-    exec(["git", "tag", "-f", TAG_UPSTREAM_DIFFBASE], cwd=repo_dir)
+    exec(["git", "tag", "-f", TAG_UPSTREAM_DIFFBASE, "-m", '""'], cwd=repo_dir)
     exec(
         ["git", "submodule", "update", "--init", "--recursive"] + fetch_args,
         cwd=repo_dir,
@@ -247,7 +247,7 @@ def do_checkout(args: argparse.Namespace):
             "submodule",
             "foreach",
             "--recursive",
-            f"git tag -f {TAG_UPSTREAM_DIFFBASE}",
+            f'git tag -f {TAG_UPSTREAM_DIFFBASE} -m ""',
         ],
         cwd=repo_dir,
         stdout_devnull=True,
@@ -290,7 +290,7 @@ def do_hipify(args: argparse.Namespace):
         print(f"HIPIFY made changes to {module_path}: Committing")
         exec(["git", "add", "-A"], cwd=module_path)
         exec(["git", "commit", "-m", HIPIFY_COMMIT_MESSAGE], cwd=module_path)
-        exec(["git", "tag", "-f", TAG_HIPIFY_DIFFBASE], cwd=module_path)
+        exec(["git", "tag", "-f", TAG_HIPIFY_DIFFBASE, "-m", '""'], cwd=module_path)
 
 
 def do_save_patches(args: argparse.Namespace):


### PR DESCRIPTION
Without this, running `ptbuild.py checkout` per https://github.com/ROCm/TheRock/tree/main/external-builds/pytorch#step-1-preparing-sources opens my editor each time a commit is tagged, asking for a tag message.

Here are the details per the docs at https://git-scm.com/docs/git-tag:

1. I have this in my .gitconfig:
    ```
    [tag]
	    gpgsign = true
    ```

2. That makes `git tag` commands default to `-s / --sign` behavior on my system
3. Behavior changes based on which options are set:

    > If one of `-a`, `-s`, or `-u <key-id>` is passed, the command creates a tag object, and requires a tag message. Unless `-m <msg>` or `-F <file>` is given, an editor is started for the user to type in the tag message.

4. Passing a message (empty or not) changes tags from "lightweight tags" to "annotated tags". From the docs:

    > Tag objects (created with `-a`, `-s`, or `-u`) are called "annotated" tags; they contain a creation date, the tagger name and e-mail, a tagging message, and an optional GnuPG signature. Whereas a "lightweight" tag is simply a name for an object (usually a commit object).

If we're okay with annotated tags instead of lightweight tags for this script, this lets me run it without further edits. Otherwise I can change my local git configuration. We could also add meaningful text to the messages if we want to keep this.

---

See also https://stevelosh.com/blog/2013/04/git-koans/ ಠ_ಠ