### PR TITLE
[windows] Enables tensile kernels in rocblas on Windows.

### DIFF
--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -82,17 +82,10 @@ list(APPEND _blas_subproject_names hipBLASLt)
 
 set(rocBLAS_optional_runtime_deps)
 if(NOT WIN32)
-  # rocBLAS is hard-coded to not expect rocm-smi on Windows.
-  list(APPEND rocBLAS_optional_runtime_deps rocm_smi_lib)
+  # rocBLAS is hard-coded to not expect rocm-smi and roctx64 on Windows.
+  list(APPEND rocBLAS_optional_runtime_deps rocm_smi_lib roctracer-compat)
 elseif(THEROCK_BUILD_TESTING)
   list(APPEND rocBLAS_optional_runtime_deps therock-host-blas)
-endif()
-
-if(WIN32)
-  set(rocBLAS_build_with_tensile "OFF")
-else()
-  set(rocBLAS_build_with_tensile "ON")
-  list(APPEND rocBLAS_optional_runtime_deps roctracer-compat)
 endif()
 
 therock_cmake_subproject_declare(rocBLAS
@@ -102,7 +95,7 @@ therock_cmake_subproject_declare(rocBLAS
     -DHIP_PLATFORM=amd
     -DROCM_PATH=
     -DROCM_DIR=
-    -DBUILD_WITH_TENSILE=${rocBLAS_build_with_tensile}
+    -DBUILD_WITH_TENSILE=ON
     -DBUILD_WITH_HIPBLASLT=ON
     # TODO: With `Tensile_TEST_LOCAL_PATH` set, the resulting build path is ${Tensile_TEST_LOCAL_PATH}/build.
     "-DTensile_TEST_LOCAL_PATH=${CMAKE_CURRENT_SOURCE_DIR}/Tensile"

--- a/patches/amd-mainline/Tensile/0001-Update-find_package-for-msgpack-to-work-with-5.x-and.patch
+++ b/patches/amd-mainline/Tensile/0001-Update-find_package-for-msgpack-to-work-with-5.x-and.patch
@@ -1,7 +1,7 @@
-From d70eaf6fa8894731020c30747a2762d3714fd23a Mon Sep 17 00:00:00 2001
+From be1e3952f99670511923f58743fc4741cb523461 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Fri, 14 Feb 2025 13:06:48 +0000
-Subject: [PATCH 1/2] Update find_package for msgpack to work with 5.x and 6.x.
+Subject: [PATCH 1/3] Update find_package for msgpack to work with 5.x and 6.x.
 
 Adapted from: https://github.com/msgpack/msgpack-c/wiki/Q%26A#how-to-support-both-msgpack-c-c-version-5x-and-6x-
 
@@ -53,5 +53,5 @@ index 024ebcc4..78c70ab0 100644
  
  if(TENSILE_USE_LLVM)
 -- 
-2.43.0
+2.41.0.windows.1
 

--- a/patches/amd-mainline/Tensile/0002-Capture-configure-time-PATH-when-invoking-tensile-at.patch
+++ b/patches/amd-mainline/Tensile/0002-Capture-configure-time-PATH-when-invoking-tensile-at.patch
@@ -1,31 +1,43 @@
-From 560f1a9f4b725a9b9d0299249b44c19242feddf0 Mon Sep 17 00:00:00 2001
+From 106bf269597b04a3779349b3683005326f66bc1c Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Fri, 14 Feb 2025 16:52:43 -0800
-Subject: [PATCH 2/2] Capture configure-time PATH when invoking tensile at
+Subject: [PATCH 2/3] Capture configure-time PATH when invoking tensile at
  build time.
 
 ---
- Tensile/cmake/TensileConfig.cmake | 9 ++++++++-
- 1 file changed, 8 insertions(+), 1 deletion(-)
+ Tensile/cmake/TensileConfig.cmake | 29 +++++++++++++++++++++++++----
+ 1 file changed, 25 insertions(+), 4 deletions(-)
 
 diff --git a/Tensile/cmake/TensileConfig.cmake b/Tensile/cmake/TensileConfig.cmake
-index e5d0f62a..c2312c14 100644
+index e5d0f62a..dfd848f1 100644
 --- a/Tensile/cmake/TensileConfig.cmake
 +++ b/Tensile/cmake/TensileConfig.cmake
-@@ -219,6 +219,12 @@ function(TensileCreateLibraryFiles
+@@ -215,10 +215,24 @@ function(TensileCreateLibraryFiles
+     set(Options ${Options} "--architecture=${archString}")
+   endif()
+ 
++  # We do not need to do device enumeration at library build time.
++  set(Options ${Options} "--no-enumerate")
++
+   set(CommandLine ${Script} ${Options} ${Tensile_LOGIC_PATH} ${Tensile_OUTPUT_PATH} HIP)
    if (WIN32 OR (VIRTUALENV_BIN_DIR AND VIRTUALENV_PYTHON_EXENAME))
      set(CommandLine ${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} ${CommandLine})
    endif()
 +  # Tensile relies on the tools from the path, so capture the configure time 
 +  # path. It would be better if this were explicit, but that would be a pretty 
 +  # big change.
++  set(ESC_PATH "$ENV{PATH}")
++  if(WIN32)
++    string(REPLACE ";" "$<SEMICOLON>" ESC_PATH "${ESC_PATH}")
++  endif()
++  set(ENV_PATH_ARG "PATH=${ESC_PATH}")
 +  set(CommandLine 
-+    "${CMAKE_COMMAND}" -E env "'PATH=$ENV{PATH}'" --
++    "${CMAKE_COMMAND}" -E env "PATH=${ESC_PATH}" --
 +    ${CommandLine})
    message(STATUS "Tensile_CREATE_COMMAND: ${CommandLine}")
  
    if(Tensile_EMBED_LIBRARY)
-@@ -244,7 +250,8 @@ function(TensileCreateLibraryFiles
+@@ -244,19 +258,25 @@ function(TensileCreateLibraryFiles
            OUTPUT_VARIABLE ASAN_LIB_PATH
            COMMAND_ECHO STDOUT)
          string(STRIP ${ASAN_LIB_PATH} ASAN_LIB_PATH)
@@ -35,6 +47,35 @@ index e5d0f62a..c2312c14 100644
        endif()
  
        add_custom_command(
+         OUTPUT "${Tensile_OUTPUT_PATH}/library"
+         DEPENDS ${Tensile_LOGIC_PATH}
+         COMMAND ${CommandLine}
+-        COMMENT "Generating libraries with TensileCreateLibrary")
++        COMMENT "Generating libraries with TensileCreateLibrary"
++        # To normalize special command line char handling between platforms.
++        VERBATIM
++        # To see progress vs buffering when built with ninja.
++        USES_TERMINAL)
+ 
+       add_custom_target(${Tensile_VAR_PREFIX}_LIBRARY_TARGET
+          DEPENDS "${Tensile_OUTPUT_PATH}/library"
+          COMMAND ${CommandLine} "--verify-manifest"
+-         COMMENT "Verifying files in ${Tensile_MANIFEST_FILE_PATH} were generated")
++         COMMENT "Verifying files in ${Tensile_MANIFEST_FILE_PATH} were generated"
++         VERBATIM)
+   endif()
+ 
+   if(Tensile_EMBED_LIBRARY)
+@@ -272,7 +292,8 @@ function(TensileCreateLibraryFiles
+           COMMAND ${CMAKE_COMMAND} -E copy
+                   ${Tensile_EMBED_LIBRARY_SOURCE}
+                   "${Tensile_OUTPUT_PATH}/library"
+-          DEPENDS ${Tensile_EMBED_LIBRARY_SOURCE})
++          DEPENDS ${Tensile_EMBED_LIBRARY_SOURCE}
++          VERBATIM)
+   endif()
+ 
+ endfunction()
 -- 
-2.43.0
+2.41.0.windows.1
 

--- a/patches/amd-mainline/Tensile/0003-Limit-number-of-Tensile-workers-to-61-on-Windows-due.patch
+++ b/patches/amd-mainline/Tensile/0003-Limit-number-of-Tensile-workers-to-61-on-Windows-due.patch
@@ -1,0 +1,29 @@
+From 206959ef7d064c5f4a2a8afc11979fc942180347 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Fri, 2 May 2025 15:27:13 -0700
+Subject: [PATCH 3/3] Limit number of Tensile workers to 61 on Windows due to
+ system limit.
+
+---
+ Tensile/Parallel.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/Tensile/Parallel.py b/Tensile/Parallel.py
+index a643c1ae..f483d264 100644
+--- a/Tensile/Parallel.py
++++ b/Tensile/Parallel.py
+@@ -36,7 +36,10 @@ def CPUThreadCount(enable=True):
+         return 1
+     else:
+         if os.name == "nt":
+-            cpu_count = os.cpu_count()
++            # Windows supports at most 61 workers because the scheduler uses
++            # WaitForMultipleObjects directly, which has the limit (the limit
++            # is actually 64, but some handles are needed for accounting).
++            cpu_count = min(os.cpu_count(), 61)
+         else:
+             cpu_count = len(os.sched_getaffinity(0))
+         cpuThreads = globalParameters["CpuThreads"]
+-- 
+2.41.0.windows.1
+


### PR DESCRIPTION
* Amends the tensile configure patch to use portable/safe command lines.
* Amends the tensile configure patch to disable enumeration (which should never be needed for library creation and eliminates the rocm_agent_enumerator dep).
* Inlines a new patch to limit workers to 61 on Windows (back-ported from tensile lite).

Fixes #524 