### PR TITLE
Fixing portable builds pt2

### DIFF
--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -105,9 +105,6 @@ jobs:
           restore-keys: |
             portable-linux-package-matrix-v1-${{ matrix.target_bundle.amdgpu_family }}-
 
-      - name: Install python packages
-        run: pip install -r requirements.txt
-
       - name: Fetch sources
         run: |
           # Prefetch docker container in background.

--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -105,23 +105,18 @@ jobs:
           restore-keys: |
             portable-linux-package-matrix-v1-${{ matrix.target_bundle.amdgpu_family }}-
 
-      - name: Setup python virtual environment and install python packages
-        run: |
-          python3 -m venv venv
-          source venv/bin/activate
-          pip install -r requirements.txt
+      - name: Install python packages
+        run: pip install -r requirements.txt
 
       - name: Fetch sources
         run: |
           # Prefetch docker container in background.
-          source venv/bin/activate
           docker pull ${{ env.BUILD_IMAGE }} &
           ./build_tools/fetch_sources.py --jobs 10
           wait
 
       - name: Build Projects
         run: |
-          source venv/bin/activate
           ./build_tools/linux_portable_build.py \
             --image=${{ env.BUILD_IMAGE }} \
             --output-dir=${{ env.OUTPUT_DIR }} \

--- a/build_tools/detail/linux_portable_build_in_container.sh
+++ b/build_tools/detail/linux_portable_build_in_container.sh
@@ -5,6 +5,8 @@ set -e
 set -o pipefail
 trap 'kill -TERM 0' INT
 
+pip install -r requirements.txt
+
 OUTPUT_DIR="/therock/output"
 mkdir -p "$OUTPUT_DIR/caches"
 

--- a/build_tools/detail/linux_portable_build_in_container.sh
+++ b/build_tools/detail/linux_portable_build_in_container.sh
@@ -5,7 +5,7 @@ set -e
 set -o pipefail
 trap 'kill -TERM 0' INT
 
-pip install -r requirements.txt
+pip install -r ./../../requirements.txt
 
 OUTPUT_DIR="/therock/output"
 mkdir -p "$OUTPUT_DIR/caches"

--- a/build_tools/detail/linux_portable_build_in_container.sh
+++ b/build_tools/detail/linux_portable_build_in_container.sh
@@ -5,8 +5,6 @@ set -e
 set -o pipefail
 trap 'kill -TERM 0' INT
 
-pip install -r /therock/src/requirements.txt
-
 OUTPUT_DIR="/therock/output"
 mkdir -p "$OUTPUT_DIR/caches"
 
@@ -14,6 +12,8 @@ export CCACHE_DIR="$OUTPUT_DIR/caches/container/ccache"
 export PIP_CACHE_DIR="$OUTPUT_DIR/caches/container/pip"
 mkdir -p "$CCACHE_DIR"
 mkdir -p "$PIP_CACHE_DIR"
+
+pip install -r /therock/src/requirements.txt
 
 export CMAKE_C_COMPILER_LAUNCHER=ccache
 export CMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/build_tools/detail/linux_portable_build_in_container.sh
+++ b/build_tools/detail/linux_portable_build_in_container.sh
@@ -5,7 +5,7 @@ set -e
 set -o pipefail
 trap 'kill -TERM 0' INT
 
-pip install -r ./../../requirements.txt
+pip install -r /therock/src/requirements.txt
 
 OUTPUT_DIR="/therock/output"
 mkdir -p "$OUTPUT_DIR/caches"


### PR DESCRIPTION
Works in [this workflow](https://github.com/ROCm/TheRock/actions/runs/14804447398/job/41570165138), fails though bc no release testing doesn't have a matching branch so this is a valid error

#520 was merged it prematurely, but this fixes it!

After this is done, it should have images available, and pytorch images can be properly used