### PR TITLE
Revise releases and push Python packages

### DIFF
--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -131,38 +131,38 @@ jobs:
           echo "Building ${{ env.DIST_ARCHIVE }}"
           tar cfz "${{ env.DIST_ARCHIVE }}" .
 
-      - name: Upload Nightly Release
+      - name: Upload Nightly Tarball to GitHub
         if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
           artifacts: "${{ env.DIST_ARCHIVE }}"
-          tag: "nightly-release"
-          name: "nightly-release"
-          body: "Automatic nightly release of TheRock."
+          tag: "nightly-tarball"
+          name: "nightly-tarball"
+          body: "Automatic nightly tarball of TheRock."
           removeArtifacts: false
           allowUpdates: true
           replacesArtifacts: true
           makeLatest: false
 
-      - name: Upload Development Release
+      - name: Upload Development Tarball to GitHub
         if: ${{ inputs.build_type == 'dev'}}
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
           artifacts: "${{ env.DIST_ARCHIVE }}"
-          tag: "dev-release"
-          name: "dev-release"
-          body: "Development release of TheRock."
+          tag: "dev-tarball"
+          name: "dev-tarball"
+          body: "Development tarball of TheRock."
           removeArtifacts: false
           allowUpdates: true
           replacesArtifacts: true
           makeLatest: false
 
-      - name: Trigger test nightly release package workflow
+      - name: Trigger testing nightly tarball
         if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc #1.2.4
         with:
           workflow: test_release_packages.yml
-          inputs: '{ "version": "${{ needs.setup_metadata.outputs.version }}", "tag": "nightly-release", "file_name": "${{ env.FILE_NAME }}", "target": "${{ matrix.target_bundle.amdgpu_family }}" }'
+          inputs: '{ "version": "${{ needs.setup_metadata.outputs.version }}", "tag": "nightly-tarball", "file_name": "${{ env.FILE_NAME }}", "target": "${{ matrix.target_bundle.amdgpu_family }}" }'
 
       - name: Report
         if: ${{ !cancelled() }}

--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -136,6 +136,16 @@ jobs:
           echo "Building ${{ env.DIST_ARCHIVE }}"
           tar cfz "${{ env.DIST_ARCHIVE }}" .
 
+      - name: Build Python Packages
+        run: |
+          ./build_tools/linux_portable_build.py \
+            --image=${{ env.BUILD_IMAGE }} \
+            --output-dir=${{ env.OUTPUT_DIR }}/packages \
+            --build-python-only \
+            --artifact-dir=${{ env.OUTPUT_DIR }}/build/artifacts \
+            -- \
+            "--version=${{ needs.setup_metadata.outputs.version }}"
+
       - name: Upload Tarball to GitHub
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
@@ -147,6 +157,24 @@ jobs:
           allowUpdates: true
           replacesArtifacts: true
           makeLatest: false
+
+      - name: Configure AWS Credentials
+        if: ${{ github.repository_owner == 'ROCm' }}
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ env.RELEASE_TYPE }}-releases
+
+      - name: Upload Releases to S3
+        if: ${{ github.repository_owner == 'ROCm' }}
+        run: |
+          # TODO: Append uploaded files to an index
+          aws s3 cp ${{ env.DIST_ARCHIVE }} s3://therock-${{ env.RELEASE_TYPE }}-tarball/
+          aws s3 cp "${{ env.OUTPUT_DIR }}/packages/dist/ s3://therock-${{ env.RELEASE_TYPE }}-python/${{ matrix.target_bundle.amdgpu_family }}/ \
+          --recursive --no-follow-symlinks \
+          --exclude "*" \
+          --include "*.whl" \
+          --include "*.tar.xz*"
 
       - name: Trigger testing nightly tarball
         if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}

--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -35,7 +35,8 @@ jobs:
     if: ${{ github.repository_owner == 'ROCm' || github.event_name != 'schedule' }}
     runs-on: ubuntu-24.04
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      version: ${{ steps.release_information.outputs.version }}
+      release_type: ${{ steps.release_information.outputs.type }}
       package_targets: ${{ steps.configure.outputs.package_targets }}
     steps:
       - name: Checkout repository
@@ -46,23 +47,26 @@ jobs:
           python-version: 3.12
 
       # Compute version suffix based on inputs (default to 'rc')
-      - name: Compute rc version suffix
+      - name: Set variables for nightly release
         if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}
         run: |
           version_suffix="$(printf 'rc%(%Y%m%d)T')"
           echo "version_suffix=${version_suffix}" >> $GITHUB_ENV
+          echo "release_type="nightly" >> $GITHUB_ENV
 
-      - name: Compute dev version suffix
+      - name: Set variables for development release
         if: ${{ inputs.build_type == 'dev' }}
         run: |
           version_suffix=".dev0+${{ github.sha }}"
           echo "version_suffix=${version_suffix}" >> $GITHUB_ENV
+          echo "release_type=dev" >> $GITHUB_ENV
 
-      - name: Compute version
-        id: version
+      - name: Generate release information
+        id: release_information
         run: |
           base_version=$(jq -r '.["rocm-version"]' version.json)
           echo "version=${base_version}${version_suffix}" >> $GITHUB_OUTPUT
+          echo "type=${release_type}" >> $GITHUB_OUTPUT
 
       - name: Generating package target matrix
         id: configure
@@ -84,6 +88,7 @@ jobs:
       BUILD_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64:main
       DIST_ARCHIVE: "${{ github.workspace }}/output/therock-dist-linux-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
       FILE_NAME: "therock-dist-linux-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
+      RELEASE_TYPE: "${{ needs.setup_metadata.outputs.release_type }}"
     strategy:
       fail-fast: false
       matrix:
@@ -131,27 +136,13 @@ jobs:
           echo "Building ${{ env.DIST_ARCHIVE }}"
           tar cfz "${{ env.DIST_ARCHIVE }}" .
 
-      - name: Upload Nightly Tarball to GitHub
-        if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}
+      - name: Upload Tarball to GitHub
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
           artifacts: "${{ env.DIST_ARCHIVE }}"
-          tag: "nightly-tarball"
-          name: "nightly-tarball"
-          body: "Automatic nightly tarball of TheRock."
-          removeArtifacts: false
-          allowUpdates: true
-          replacesArtifacts: true
-          makeLatest: false
-
-      - name: Upload Development Tarball to GitHub
-        if: ${{ inputs.build_type == 'dev'}}
-        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
-        with:
-          artifacts: "${{ env.DIST_ARCHIVE }}"
-          tag: "dev-tarball"
-          name: "dev-tarball"
-          body: "Development tarball of TheRock."
+          tag: "${{ env.RELEASE_TYPE }}-tarball"
+          name: "${{ env.RELEASE_TYPE }}-tarball"
+          body: "Automatic ${{ env.RELEASE_TYPE }} tarball of TheRock."
           removeArtifacts: false
           allowUpdates: true
           replacesArtifacts: true

--- a/.github/workflows/publish_pytorch_dev_docker.yml
+++ b/.github/workflows/publish_pytorch_dev_docker.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       families:
-        description: "Please enter a comma separated list of AMD GPU family (ex: gfx94X, gfx103x). Please note that docker builds only work for prebuilds available here https://github.com/ROCm/TheRock/releases/tag/nightly-release"
+        description: "Please enter a comma separated list of AMD GPU family (ex: gfx94X, gfx103x). Please note that docker builds only work for prebuilds available here https://github.com/ROCm/TheRock/releases/tag/nightly-tarball"
         type: string
   schedule:
     - cron: "0 2 * * *" # Runs nightly at 2 AM UTC

--- a/build_tools/provision_machine.py
+++ b/build_tools/provision_machine.py
@@ -13,11 +13,11 @@ python build_tools/provision_machine.py [--output-dir OUTPUT_DIR] [--amdgpu-fami
 Examples:
 - Downloads the gfx94X S3 artifacts from GitHub CI workflow run 14474448215 (from https://github.com/ROCm/TheRock/actions/runs/14474448215) to the default output directory `therock-build`:
     - `python build_tools/provision_machine.py --run-id 14474448215 --amdgpu-family gfx94X-dcgpu`
-- Downloads the latest gfx110X artifacts from GitHub release tag `nightly-release` to the specified output directory `build`:
+- Downloads the latest gfx110X artifacts from GitHub release tag `nightly-tarball` to the specified output directory `build`:
     - `python build_tools/provision_machine.py --release latest --amdgpu-family gfx110X-dgpu --output-dir build`
-- Downloads the version `6.4.0rc20250416` gfx110X artifacts from GitHub release tag `nightly-release` to the specified output directory `build`:
+- Downloads the version `6.4.0rc20250416` gfx110X artifacts from GitHub release tag `nightly-tarball` to the specified output directory `build`:
     - `python build_tools/provision_machine.py --release 6.4.0rc20250416 --amdgpu-family gfx110X-dgpu --output-dir build`
-- Downloads the version `6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9` gfx120X artifacts from GitHub release tag `dev-release` to the default output directory `therock-build`:
+- Downloads the version `6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9` gfx120X artifacts from GitHub release tag `dev-tarball` to the default output directory `therock-build`:
     - `python build_tools/provision_machine.py --release 6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9 --amdgpu-family gfx120X-all`
 
 You can select your AMD GPU family from this file https://github.com/ROCm/TheRock/blob/59c324a759e8ccdfe5a56e0ebe72a13ffbc04c1f/cmake/therock_amdgpu_targets.cmake#L44-L81
@@ -112,23 +112,23 @@ def _get_github_release_assets(release_tag, amdgpu_family, release_version):
     release_data = response.json()
 
     # We retrieve the most recent release asset that matches the amdgpu_family
-    # In the cases of "nightly-release" or "dev-release", this will retrieve the the specified version or latest
+    # In the cases of "nightly-tarball" or "dev-tarball", this will retrieve the the specified version or latest
     asset_data = sorted(
         release_data["assets"], key=lambda item: item["updated_at"], reverse=True
     )
 
-    # For nightly-release
-    if release_tag == "nightly-release" and release_version != "latest":
+    # For nightly-tarball
+    if release_tag == "nightly-tarball" and release_version != "latest":
         for asset in asset_data:
             if amdgpu_family in asset["name"] and release_version in asset["name"]:
                 return asset
-    # For dev-release
-    elif release_tag == "dev-release":
+    # For dev-tarball
+    elif release_tag == "dev-tarball":
         for asset in asset_data:
             if amdgpu_family in asset["name"] and release_version in asset["name"]:
                 return asset
-    # Otherwise, return the latest and amdgpu-matched asset available from the tag nightly-release
-    elif release_tag == "nightly-release" and release_version == "latest":
+    # Otherwise, return the latest and amdgpu-matched asset available from the tag nightly-tarball
+    elif release_tag == "nightly-tarball" and release_version == "latest":
         for asset in asset_data:
             if amdgpu_family in asset["name"]:
                 return asset
@@ -199,33 +199,33 @@ def retrieve_artifacts_by_release(args):
     """
     output_dir = args.output_dir
     amdgpu_family = args.amdgpu_family
-    # In the case that the user passes in latest, we will get the latest nightly-release
+    # In the case that the user passes in latest, we will get the latest nightly-tarball
     if args.release == "latest":
-        release_tag = "nightly-release"
-    # Otherwise, determine if version is nightly-release or dev-release
+        release_tag = "nightly-tarball"
+    # Otherwise, determine if version is nightly-tarball or dev-tarball
     else:
         try:
             version = Version(args.release)
             if not version.is_devrelease and not version.is_prerelease:
-                log(f"This script requires a nightly-release or dev-release version.")
+                log(f"This script requires a nightly-tarball or dev-tarball version.")
                 log("Please retrieve the correct release version from:")
                 log(
-                    "\t - https://github.com/ROCm/TheRock/releases/tag/nightly-release (nightly-release example: 6.4.0rc20250416)"
+                    "\t - https://github.com/ROCm/TheRock/releases/tag/nightly-tarball (nightly-tarball example: 6.4.0rc20250416)"
                 )
                 log(
-                    "\t - https://github.com/ROCm/TheRock/releases/tag/dev-release (dev-release example: 6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9)"
+                    "\t - https://github.com/ROCm/TheRock/releases/tag/dev-tarball (dev-tarball example: 6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9)"
                 )
                 log("Exiting...")
                 return
-            release_tag = "dev-release" if version.is_devrelease else "nightly-release"
+            release_tag = "dev-tarball" if version.is_devrelease else "nightly-tarball"
         except InvalidVersion:
             log(f"Invalid release version '{args.release}'")
             log("Please retrieve the correct release version from:")
             log(
-                "\t - https://github.com/ROCm/TheRock/releases/tag/nightly-release (nightly-release example: 6.4.0rc20250416)"
+                "\t - https://github.com/ROCm/TheRock/releases/tag/nightly-tarball (nightly-tarball example: 6.4.0rc20250416)"
             )
             log(
-                "\t - https://github.com/ROCm/TheRock/releases/tag/dev-release (dev-release example: 6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9)"
+                "\t - https://github.com/ROCm/TheRock/releases/tag/dev-tarball (dev-tarball example: 6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9)"
             )
             log("Exiting...")
             return
@@ -304,7 +304,7 @@ def main(argv):
     group.add_argument(
         "--release",
         type=str,
-        help="Github release version of TheRock to provision, from the nightly-release (X.Y.ZrcYYYYMMDD) or dev-release (X.Y.Z.dev0+{hash})",
+        help="Github release version of TheRock to provision, from the nightly-tarball (X.Y.ZrcYYYYMMDD) or dev-tarball (X.Y.Z.dev0+{hash})",
     )
 
     group.add_argument(

--- a/dockerfiles/pytorch-dev/install_rocm_from_release.sh
+++ b/dockerfiles/pytorch-dev/install_rocm_from_release.sh
@@ -13,7 +13,7 @@ set -xeuo pipefail
 # Environment Variables (optional):
 #   RELEASE_VERSION       - Full version string like 6.4.0rc20250424 (required if no version.json)
 #   ROCM_VERSION          - Base ROCm version like 6.4.0 (optional, auto-extracted from RELEASE_VERSION)
-#   RELEASE_TAG           - GitHub release tag to pull from (default: nightly-release)
+#   RELEASE_TAG           - GitHub release tag to pull from (default: nightly-tarball)
 #   ROCM_VERSION_DATE     - Build date (default: 1 days ago)
 #   INSTALL_PREFIX        - Installation path (default: /therock/build/dist/rocm)
 #   OUTPUT_ARTIFACTS_DIR  - Directory to store downloaded tarballs (default: /rocm-tarballs)
@@ -49,7 +49,7 @@ for tool in curl jq; do
 done
 
 # Configuration
-RELEASE_TAG="${RELEASE_TAG:-nightly-release}"
+RELEASE_TAG="${RELEASE_TAG:-nightly-tarball}"
 ROCM_VERSION_DATE="${ROCM_VERSION_DATE:-$(date -d '1 days ago' +'%Y%m%d')}"
 INSTALL_PREFIX="${INSTALL_PREFIX:-/therock/build/dist/rocm}"
 OUTPUT_ARTIFACTS_DIR="${OUTPUT_ARTIFACTS_DIR:-/rocm-tarballs}"


### PR DESCRIPTION
Renames `nightly-release` to `nightly-tarball` and `dev-release` to `dev-tarball`, respectively, to distinguish more clearly from Python package releases. This allows to publish releases as

* `nightly-tarball`
* `dev-tarball`
* `nightly-python/${target}` (as `nightly-python-${target}` would require a new bucket for each architecture)
* `dev-python/${target}` as (`dev-python-${target}` would require a new bucket for each architecture))

Tarballs are made available via [GitHub](https://github.com/ROCm/TheRock/releases) and will be made available at https://therock-nightly-tarball.s3.us-east-2.amazonaws.com/ or https://therock-dev-tarball.s3.us-east-2.amazonaws.com/, depending on the release type.
Python packages will pushed to https://therock-nightly-python.s3.us-east-2.amazonaws.com/${GPU_FAMILY} and https://therock-dev-python.s3.us-east-2.amazonaws.com/${GPU_FAMILY}.
