### PR TITLE
Enable MIOpen on Windows by patching Boost MSVC options.

### DIFF
--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -56,7 +56,7 @@ mainline, in open source, using MSVC, etc.).
 | math-libs (blas) | [hipSOLVER](https://github.com/ROCm/hipSOLVER)                               | ✅        | Tests need dlls                               |
 | math-libs (blas) | [hipBLAS](https://github.com/ROCm/hipBLAS)                                   | ✅        | Tests need dlls                               |
 |                  |                                                                              |           |                                               |
-| ml-libs          | [MIOpen](https://github.com/ROCm/MIOpen)                                     | ❔        |                                               |
+| ml-libs          | [MIOpen](https://github.com/ROCm/MIOpen)                                     | ✅        |                                               |
 
 ## Building from source
 

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -3,6 +3,23 @@ if(THEROCK_ENABLE_MIOPEN)
   # MIOpen
   ##############################################################################
 
+  if(MSVC)
+    # HACK, see https://github.com/ROCm/TheRock/issues/525.
+    # Take the most recent few MSVC versions from
+    # https://github.com/boostorg/boost_install/blob/develop/BoostDetectToolset.cmake
+    # and pass them through to the Boost_COMPILER option below. This is messy -
+    # maybe we can drop the Boost dependency or write new build rules for it.
+    if((MSVC_VERSION GREATER 1929) AND (MSVC_VERSION LESS 1950))
+      set(_THEROCK_MIOPEN_OVERRIDE_BOOST_COMPILER "vc143")
+    elseif((MSVC_VERSION GREATER 1919) AND (MSVC_VERSION LESS 1930))
+      set(_THEROCK_MIOPEN_OVERRIDE_BOOST_COMPILER "vc142")
+    elseif((MSVC_VERSION GREATER 1909) AND (MSVC_VERSION LESS 1920))
+      set(_THEROCK_MIOPEN_OVERRIDE_BOOST_COMPILER "vc141")
+    else()
+      message(WARNING "Unhandled MSVC_VERSION '${MSVC_VERSION}', Boost may not configure correctly")
+    endif()
+  endif()
+
   therock_cmake_subproject_declare(MIOpen
     EXTERNAL_SOURCE_DIR "MIOpen"
     BACKGROUND_BUILD
@@ -15,6 +32,7 @@ if(THEROCK_ENABLE_MIOPEN)
       -DMIOPEN_USE_MLIR=OFF # TODO: enable
       -DMIOPEN_BUILD_DRIVER=ON
       -DMIOPEN_USE_ROCTRACER=OFF # TODO: enable
+      -DBoost_COMPILER=${_THEROCK_MIOPEN_OVERRIDE_BOOST_COMPILER}
     COMPILER_TOOLCHAIN
       amd-hip
     BUILD_DEPS


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/525. See that issue for other approaches considered.