### PR TITLE
Recommend git core.longpaths setting on Windows.

### DIFF
--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -104,9 +104,12 @@ These instructions mostly mirror the instructions in the root
 
 You will need:
 
-- Git: https://git-scm.com/downloads
+- Git: https://git-scm.com/downloads, with suggested config settings:
 
-  - Suggested: enable symlinks with `git config --global core.symlinks true`
+  ```bash
+  git config --global core.symlinks true
+  git config --global core.longpaths true
+  ```
 
 - CMake: https://cmake.org/download/
 


### PR DESCRIPTION
Some files, particularly under `external-builds/pytorch`, get long enough to trigger warnings and errors without this setting.