### PR TITLE
Build more LLVM/Clang tools from source on Windows, expand CI.

### DIFF
--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -114,7 +114,6 @@ jobs:
             -DTHEROCK_AMDGPU_FAMILIES=${amdgpu_families} \
             -DTHEROCK_PACKAGE_VERSION="${package_version}" \
             -DTHEROCK_AMDGPU_WINDOWS_INTEROP_DIR=${GITHUB_WORKSPACE}/amdgpu-windows-interop \
-            -DTHEROCK_ENABLE_FFT=OFF \
             -DTHEROCK_ENABLE_BLAS=OFF \
             -DTHEROCK_ENABLE_SPARSE=OFF \
             -DTHEROCK_ENABLE_SOLVER=OFF \

--- a/compiler/pre_hook_amd-llvm.cmake
+++ b/compiler/pre_hook_amd-llvm.cmake
@@ -106,6 +106,14 @@ block()
     OPT
     YAML2OBJ
   )
+  if(WIN32)
+    # These can be provided by the "C++ Clang tools for Windows" in MSVC, but
+    # we might as well build them from source ourselves.
+    list(APPEND _llvm_required_tools "LLVM_AR")
+    list(APPEND _llvm_required_tools "LLVM_DLLTOOL")
+    list(APPEND _llvm_required_tools "LLVM_LIB")
+    list(APPEND _llvm_required_tools "LLVM_RANLIB")
+  endif()
   therock_set_implicit_llvm_options(LLVM "${CMAKE_CURRENT_SOURCE_DIR}/tools" "${_llvm_required_tools}")
 
   # Clang tools that are required.
@@ -118,5 +126,10 @@ block()
     CLANG_SHLIB
     DRIVER
   )
+  if(WIN32)
+    # These can be provided by the "C++ Clang tools for Windows" in MSVC, but
+    # we might as well build them from source ourselves.
+    list(APPEND _clang_required_tools "CLANG_SCAN_DEPS")
+  endif()
   therock_set_implicit_llvm_options(CLANG "${CMAKE_CURRENT_SOURCE_DIR}/../clang/tools" "${_clang_required_tools}")
 endblock()


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/543, see that issue for all of the details.

Some subprojects builds use tools like [`CMAKE_AR`](https://cmake.org/cmake/help/latest/variable/CMAKE_AR.html). On my development machine, that picked up the tool at `C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/Llvm/x64/bin/llvm-ar.exe`, but CI machines did not find any compatible tool. We could install the MSVC "C++ Clang tools for Windows" on the CI runners, but we might as well build these tools from source since we are already building other LLVM tools.

I tried to keep this list minimal to save on build time and binary size by searching within one subproject's `CMakeCache.txt` for any references to the `C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/Llvm/` directory, which got me:
```
CMAKE_AR:FILEPATH=C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/Llvm/x64/bin/llvm-ar.exe
CMAKE_CXX_COMPILER_AR:FILEPATH=C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/Llvm/x64/bin/llvm-ar.exe
CMAKE_CXX_COMPILER_CLANG_SCAN_DEPS:FILEPATH=C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/Llvm/x64/bin/clang-scan-deps.exe
CMAKE_CXX_COMPILER_RANLIB:FILEPATH=C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/Llvm/x64/bin/llvm-ranlib.exe
CMAKE_C_COMPILER_AR:FILEPATH=C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/Llvm/x64/bin/llvm-ar.exe
CMAKE_C_COMPILER_CLANG_SCAN_DEPS:FILEPATH=C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/Llvm/x64/bin/clang-scan-deps.exe
CMAKE_C_COMPILER_RANLIB:FILEPATH=C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/Llvm/x64/bin/llvm-ranlib.exe
CMAKE_DLLTOOL:FILEPATH=C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/Llvm/x64/bin/llvm-dlltool.exe
CMAKE_RANLIB:FILEPATH=C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/Llvm/x64/bin/llvm-ranlib.exe
```

After making these changes and rebuilding affected subprojects, I see the new built-from-source tools used instead, e.g.
```
//LLVM archiver
CMAKE_C_COMPILER_AR:FILEPATH=D:/projects/TheRock/build/core/clr/dist/lib/llvm/bin/llvm-ar.exe
```

Test CI run (in addition to what this will trigger on the pull request): https://github.com/ROCm/TheRock/actions/runs/14867545460/job/41747981432