### PR TITLE
add pytorch vision and audio to docker images

### DIFF
--- a/external-builds/pytorch/build_pytorch_audio.sh
+++ b/external-builds/pytorch/build_pytorch_audio.sh
@@ -5,6 +5,9 @@
 set -e
 set -o pipefail
 
+DO_BUILD_STEP="${DO_BUILD_STEP:-1}"
+DO_INSTALL_STEP="${DO_INSTALL_STEP:-1}"
+
 SCRIPT_DIR="$(cd $(dirname $0) && pwd)"
 if ! source $SCRIPT_DIR/env_init.sh; then
     echo "Failed to find python virtual-env"
@@ -16,28 +19,38 @@ unset LDFLAGS
 unset CFLAGS
 unset CPPFLAGS
 unset PKG_CONFIG_PATH
-export CMAKE_PREFIX_PATH="$(realpath $SCRIPT_DIR/../../build/dist/rocm)"
-echo ${CMAKE_PREFIX_PATH}
+
+if [ ! -n "${ROCM_HOME}" ]; then\
+        export ROCM_HOME="$(realpath $SCRIPT_DIR/../../build/dist/rocm)"
+fi
+export CMAKE_PREFIX_PATH="$(realpath ${ROCM_HOME})"
+export DEVICE_LIB_PATH=${CMAKE_PREFIX_PATH}/lib/llvm/amdgcn/bitcode
+export HIP_DEVICE_LIB_PATH=${DEVICE_LIB_PATH}
 export CMAKE_C_COMPILER=${CMAKE_PREFIX_PATH}/bin/hipcc
 export CMAKE_CXX_COMPILER=${CMAKE_PREFIX_PATH}/bin/hipcc
-export HIP_DEVICE_LIB_PATH=${CMAKE_PREFIX_PATH}/lib/llvm/amdgcn/bitcode
+echo "ROCM_HOME: ${ROCM_HOME}"
+echo "CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}"
+echo "DEVICE_LIB_PATH: ${DEVICE_LIB_PATH}"
 
 cd $SCRIPT_DIR/pytorch_audio
-ROCM_PATH=${CMAKE_PREFIX_PATH} USE_ROCM=1 USE_CUDA=0 USE_FFMPEG=1 USE_OPENMP=1 BUILD_SOX=0 CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} BUILD_VERSION="2.7.0" BUILD_NUMBER=1 python setup.py bdist_wheel
+ROCM_PATH=${CMAKE_PREFIX_PATH} USE_ROCM=1 USE_CUDA=0 USE_FFMPEG=1 USE_OPENMP=1 BUILD_SOX=0 CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} BUILD_VERSION="2.7.0" BUILD_NUMBER=1 python3 setup.py bdist_wheel
 
-# if there are multiple wheel files, find the newest one and install it
-unset -v latest_wheel_file
-for cur_file in dist/*.whl; do
-    [[ $cur_file -nt "$latest_wheel_file" ]] && latest_wheel_file=$cur_file
-done
-if [ ! -z "$latest_wheel_file" ]; then
-    echo "installing $latest_wheel_file"
-    # do not use "pip install --force-reinstall because it can uninstall
-    # own build other packages and then re-install incorrect onew from internet
-    pip uninstall --yes "$latest_wheel_file"
-    pip install "$latest_wheel_file"
-else
-    echo "Failed to build and find pytorch audio wheel for pip install in directory $SCRIPT_DIR/pytorch_audio/dist"
-    exit 1
+if [ ${DO_INSTALL_STEP} -eq 1 ]; then
+	# if there are multiple wheel files, find the newest one and install it
+	unset -v latest_wheel_file
+	for cur_file in dist/*.whl; do
+		[[ $cur_file -nt "$latest_wheel_file" ]] && latest_wheel_file=$cur_file
+	done
+	if [ ! -z "$latest_wheel_file" ]; then
+		echo "installing $latest_wheel_file"
+		# pip uninstall would fail if there is no whl already installed, we do not want to break there
+		set +e
+		pip uninstall --yes "$latest_wheel_file"
+		set -e
+		PIP_BREAK_SYSTEM_PACKAGES=1 pip install "$latest_wheel_file"
+	else
+		echo "Failed to build and find pytorch audio wheel for pip install in directory $SCRIPT_DIR/pytorch_audio/dist"
+		exit 1
+	fi
 fi
 cd $SCRIPT_DIR

--- a/external-builds/pytorch/build_pytorch_torch.sh
+++ b/external-builds/pytorch/build_pytorch_torch.sh
@@ -5,6 +5,9 @@
 set -e
 set -o pipefail
 
+DO_BUILD_STEP="${DO_BUILD_STEP:-1}"
+DO_INSTALL_STEP="${DO_INSTALL_STEP:-1}"
+
 SCRIPT_DIR="$(cd $(dirname $0) && pwd)"
 if ! source $SCRIPT_DIR/env_init.sh; then
     echo "Failed to find python virtual-env"
@@ -12,29 +15,41 @@ if ! source $SCRIPT_DIR/env_init.sh; then
     exit 1
 fi
 
-export CMAKE_PREFIX_PATH="$(realpath $SCRIPT_DIR/../../build/dist/rocm)"
-#export CMAKE_C_COMPILER=${CMAKE_PREFIX_PATH}/bin/hipcc
-#export CMAKE_CXX_COMPILER=${CMAKE_PREFIX_PATH}/bin/hipcc
-export HIP_DEVICE_LIB_PATH=${CMAKE_PREFIX_PATH}/lib/llvm/amdgcn/bitcode
+if [ ! -n "${ROCM_HOME}" ]; then\
+        export ROCM_HOME="$(realpath $SCRIPT_DIR/../../build/dist/rocm)"
+fi
+export CMAKE_PREFIX_PATH="$(realpath ${ROCM_HOME})"
+export DEVICE_LIB_PATH=${CMAKE_PREFIX_PATH}/lib/llvm/amdgcn/bitcode
+export HIP_DEVICE_LIB_PATH=${DEVICE_LIB_PATH}
 
 cd $SCRIPT_DIR/pytorch
 #USE_KINETO=OFF CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} python setup.py develop
 #USE_KINETO=OFF CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} PYTORCH_BUILD_VERSION=2.7.0 PYTORCH_BUILD_NUMBER=1 python setup.py bdist_wheel
-USE_KINETO=OFF PYTORCH_BUILD_VERSION=2.7.0 PYTORCH_BUILD_NUMBER=1 python setup.py bdist_wheel
+if [ ${DO_BUILD_STEP} -eq 1 ]; then
+	USE_KINETO=OFF PYTORCH_BUILD_VERSION=2.7.0 PYTORCH_BUILD_NUMBER=1 python3 setup.py bdist_wheel
+fi
 
-# if there are multiple wheel files, find the newest one and install it
-unset -v latest_wheel_file
-for cur_file in dist/*.whl; do
-    [[ $cur_file -nt "$latest_wheel_file" ]] && latest_wheel_file=$cur_file
-done
-if [ ! -z "$latest_wheel_file" ]; then
-    echo "installing $latest_wheel_file"
-    # do not use "pip install --force-reinstall because it can uninstall
-    # own build other packages and then re-install incorrect onew from internet
-    pip uninstall --yes "$latest_wheel_file"
-    pip install "$latest_wheel_file"
-else
-    echo "Failed to build and find pytorch wheel for pip install in directory $SCRIPT_DIR/pytorch/dist"
-    exit 1
+if [ ${DO_INSTALL_STEP} -eq 1 ]; then
+	# if there are multiple wheel files, find the newest one and install it
+	unset -v latest_wheel_file
+	for cur_file in dist/*.whl; do
+		[[ $cur_file -nt "$latest_wheel_file" ]] && latest_wheel_file=$cur_file
+	done
+	if [ ! -z "$latest_wheel_file" ]; then
+		echo "installing $latest_wheel_file"
+		# do not use "pip install --force-reinstall because it can uninstall
+		# own build other packages and then re-install incorrect onew from internet
+		echo "pip uninstall first $latest_wheel_file"
+		# pip uninstall would fail if there is no whl already installed, we do not want to break there
+		set +e
+		pip uninstall --yes "$latest_wheel_file"
+		set -e
+		echo "and then pip install $latest_wheel_file"
+		PIP_BREAK_SYSTEM_PACKAGES=1 pip install "$latest_wheel_file"
+		echo "pip install done for $latest_wheel_file"
+	else
+		echo "Failed to build and find pytorch wheel for pip install in directory $SCRIPT_DIR/pytorch/dist"
+		exit 1
+	fi
 fi
 cd $SCRIPT_DIR

--- a/external-builds/pytorch/build_pytorch_vision.sh
+++ b/external-builds/pytorch/build_pytorch_vision.sh
@@ -5,6 +5,9 @@
 set -e
 set -o pipefail
 
+DO_BUILD_STEP="${DO_BUILD_STEP:-1}"
+DO_INSTALL_STEP="${DO_INSTALL_STEP:-1}"
+
 SCRIPT_DIR="$(cd $(dirname $0) && pwd)"
 if ! source $SCRIPT_DIR/env_init.sh; then
         echo "Failed to find python virtual-env"
@@ -16,28 +19,43 @@ unset LDFLAGS
 unset CFLAGS
 unset CPPFLAGS
 unset PKG_CONFIG_PATH
-export CMAKE_PREFIX_PATH="$(realpath $SCRIPT_DIR/../../build/dist/rocm)"
-echo ${CMAKE_PREFIX_PATH}
+
+if [ ! -n "${ROCM_HOME}" ]; then\
+	export ROCM_HOME="$(realpath $SCRIPT_DIR/../../build/dist/rocm)"
+fi
+export CMAKE_PREFIX_PATH="$(realpath ${ROCM_HOME})"
+export DEVICE_LIB_PATH=${CMAKE_PREFIX_PATH}/lib/llvm/amdgcn/bitcode
+export HIP_DEVICE_LIB_PATH=${DEVICE_LIB_PATH}
 export CMAKE_C_COMPILER=${CMAKE_PREFIX_PATH}/bin/hipcc
 export CMAKE_CXX_COMPILER=${CMAKE_PREFIX_PATH}/bin/hipcc
-export HIP_DEVICE_LIB_PATH=${CMAKE_PREFIX_PATH}/lib/llvm/amdgcn/bitcode
+echo "ROCM_HOME: ${ROCM_HOME}"
+echo "CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}"
+echo "DEVICE_LIB_PATH: ${DEVICE_LIB_PATH}"
 
 cd $SCRIPT_DIR/pytorch_vision
-ROCM_PATH=${CMAKE_PREFIX_PATH} FORCE_CUDA=1 TORCHVISION_USE_NVJPEG=0 TORCHVISION_USE_VIDEO_CODEC=0 CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} BUILD_VERSION=0.22.0 BUILD_NUMBER=1 VERSION_NAME=0.22.0 python setup.py bdist_wheel
+ROCM_PATH=${CMAKE_PREFIX_PATH} FORCE_CUDA=1 TORCHVISION_USE_NVJPEG=0 TORCHVISION_USE_VIDEO_CODEC=0 CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} BUILD_VERSION=0.22.0 BUILD_NUMBER=1 VERSION_NAME=0.22.0 python3 setup.py bdist_wheel
 
-# if there are multiple wheel files, find the newest one and install it
-unset -v latest_wheel_file
-for cur_file in dist/*.whl; do
-    [[ $cur_file -nt "$latest_wheel_file" ]] && latest_wheel_file=$cur_file
-done
-if [ ! -z "$latest_wheel_file" ]; then
-    echo "installing $latest_wheel_file"
-    # do not use "pip install --force-reinstall because it can uninstall
-    # own build other packages and then re-install incorrect onew from internet
-    pip uninstall --yes "$latest_wheel_file"
-    pip install "$latest_wheel_file"
-else
-    echo "Failed to build and find pytorch vision wheel for pip install in directory $SCRIPT_DIR/pytorch_vision/dist"
-    exit 1
+if [ ${DO_INSTALL_STEP} -eq 1 ]; then
+	# if there are multiple wheel files, find the newest one and install it
+	unset -v latest_wheel_file
+	for cur_file in dist/*.whl; do
+		[[ $cur_file -nt "$latest_wheel_file" ]] && latest_wheel_file=$cur_file
+	done
+	if [ ! -z "$latest_wheel_file" ]; then
+		echo "installing $latest_wheel_file"
+		# do not use "pip install --force-reinstall because it can uninstall
+		# own build other packages and then re-install incorrect onew from internet
+		echo "pip uninstall first $latest_wheel_file"
+		# pip uninstall would fail if there is no whl already installed, we do not want to break there
+		set +e
+		pip uninstall --yes "$latest_wheel_file"
+		set -e
+		echo "and then pip install $latest_wheel_file"
+		PIP_BREAK_SYSTEM_PACKAGES=1 pip install "$latest_wheel_file"
+		echo "pip install done for $latest_wheel_file"
+	else
+		echo "Failed to build and find pytorch vision wheel for pip install in directory $SCRIPT_DIR/pytorch_vision/dist"
+		exit 1
+	fi
+	cd $SCRIPT_DIR
 fi
-cd $SCRIPT_DIR

--- a/external-builds/pytorch/checkout_pytorch_all.sh
+++ b/external-builds/pytorch/checkout_pytorch_all.sh
@@ -7,9 +7,9 @@ set -o pipefail
 
 SCRIPT_DIR="$(cd $(dirname $0) && pwd)"
 if ! source $SCRIPT_DIR/env_init.sh; then
-        echo "Failed to find python virtual-env"
-        echo "Make sure that TheRock has been build first"
-        exit 1
+	echo "Failed to init ROCK build environment"
+	echo "Make sure that TheRock has been build first"
+	exit 1
 fi
 
 if ! $SCRIPT_DIR/pytorch_torch_repo.py checkout; then

--- a/external-builds/pytorch/env_init.sh
+++ b/external-builds/pytorch/env_init.sh
@@ -21,19 +21,19 @@ if [ -n "${VIRTUAL_ENV}" ]; then
 		echo "THEROCK default Python virtual env not active: ${THEROCK_VENV_DEF_DIR}"
 	fi
 else
-	echo "virtual env not set"
 	if [ -f $SCRIPT_DIR/../../.venv/bin/activate ]; then
 		source $SCRIPT_DIR/../../.venv/bin/activate
 		echo "sourced python VIRTUAL_ENV: ${VIRTUAL_ENV}"
 	else
-		echo "error, no pytorch virtual evn available"
-		exit 1
+		echo "ROCK python virtual env not available"
 	fi
 fi
 
 if [ ! -n "${THEROCK_PATH_SET}" ]; then
 	export THEROCK_PATH_SET=1
-	export ROCM_HOME=$(realpath $SCRIPT_DIR/../../build/dist/rocm)
+	if [ ! -n "${ROCM_HOME}" ]; then
+		export ROCM_HOME=$(realpath $SCRIPT_DIR/../../build/dist/rocm)
+	fi
 	if [ -d ${ROCM_HOME} ]; then
 		export PATH=${ROCM_HOME}/bin:$PATH
 		export LD_LIBRARY_PATH=${ROCM_HOME}/lib


### PR DESCRIPTION
- install pytorch vision and audio to docker images
- add ffmpeg and python-is-python3 to final docker image (ffmpeg required by pytorch audio)
- disable exit on error code on build scripts for the time of execution for pip uninstall as that will fail on cases where there is not previous version of torch/torch vision/torch audio wheel installed
- add possibility to use environment variable to specify whether torch-related scripts will do only a build or only a install part
- check ROCM_HOME environment variable on build scripts