### PR TITLE
Add PyTorch smoketests for convs.

### DIFF
--- a/external-builds/pytorch/smoke-tests/README.md
+++ b/external-builds/pytorch/smoke-tests/README.md
@@ -18,6 +18,7 @@ The following operations are covered in these smoke tests:
 - **Dot Product (`torch.dot`)**
 - **Matrix-Vector Multiplication (`torch.mv`)**
 - **General Matrix Multiplication (`torch.matmul`)**
+- **Convolution (`torch.conv2d` and `torch.nn.functional.conv_transpose2d`)**
 
 ## Running the Tests
 


### PR DESCRIPTION
This will help validate more of the ROCm + PyTorch stack without needing to run larger test suites.

Note that something in the new tests is hanging `pytest` on my system. Tests pass, but the pytest command does not terminate until I kill the process.

See also this discussion thread: https://github.com/ROCm/TheRock/discussions/409#discussioncomment-13032345.