### PR TITLE
Add log upload support for build target failed

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -22,6 +22,8 @@ on:
       expect_failure:
         type: boolean
 
+# See the details regarding permissions from the link:
+# https://github.com/aws-actions/configure-aws-credentials?tab=readme-ov-file#oidc
 permissions:
   contents: read
 
@@ -122,6 +124,7 @@ jobs:
           key: linux-build-packages-manylinux-v2-${{ github.sha }}
 
       - name: Configure AWS Credentials
+        if: always()
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           aws-region: us-east-2
@@ -129,13 +132,15 @@ jobs:
 
       # TODO: Move to script
       - name: Create Index Files
+        if: always()
         run: |
           curl --silent --fail --show-error --location \
             https://raw.githubusercontent.com/joshbrunty/Indexer/6d8cbfd15d3853b482e6a49f2d875ded9188b721/indexer.py \
             --output build/indexer.py
           python build/indexer.py -f '*.tar.xz*' build/artifacts/
-          python build/indexer.py -f '*.log' build/logs/
-          sed -i 's,a href="..",a href="../../index-${{env.AMDGPU_FAMILIES}}.html",g' build/logs/index.html
+          python3 build_tools/create_log_index.py
+        env:
+            AMDGPU_FAMILIES: ${{ env.AMDGPU_FAMILIES }}
 
       # TODO: Move to script
       - name: Upload Artifacts
@@ -148,15 +153,25 @@ jobs:
 
       # TODO: Move to script
       - name: Upload Logs
+        if: always()
         run: |
-          aws s3 cp build/logs/ s3://therock-artifacts/${{github.run_id}}-linux/logs/${{env.AMDGPU_FAMILIES}}/ \
-            --recursive \
-            --content-type="text/plain" \
-            --exclude "*" \
-            --include "*.log"
-          aws s3 cp build/logs/index.html s3://therock-artifacts/${{github.run_id}}-linux/logs/${{env.AMDGPU_FAMILIES}}/
+          python3 build_tools/upload_logs_to_s3.py
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          AMDGPU_FAMILIES: ${{ env.AMDGPU_FAMILIES }}
+          S3_BUCKET: therock-artifacts
 
       - name: Add Links to Job Summary
+        if: always()
         run: |
-          echo '* [Artifacts](https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}-linux/index-${{env.AMDGPU_FAMILIES}}.html)' >> $GITHUB_STEP_SUMMARY
-          echo '* [Build logs](https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}-linux/logs/${{env.AMDGPU_FAMILIES}}/index.html)' >> $GITHUB_STEP_SUMMARY
+          LOG_URL="https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}-linux/logs/${{env.AMDGPU_FAMILIES}}/index.html"
+          echo "[Build Logs](${LOG_URL})" >> $GITHUB_STEP_SUMMARY
+
+          ARTIFACT_INDEX=build/artifacts/index.html
+          if [ -f "${ARTIFACT_INDEX}" ]; then
+            ARTIFACT_URL="https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}-linux/index-${{env.AMDGPU_FAMILIES}}.html"
+
+            echo "[Artifacts](${ARTIFACT_URL})" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "[INFO] No artifacts index found. Skipping artifact link."
+          fi

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -151,15 +151,12 @@ jobs:
             --include "*.tar.xz*"
           aws s3 cp build/artifacts/index.html s3://therock-artifacts/${{github.run_id}}-linux/index-${{env.AMDGPU_FAMILIES}}.html
 
-      # TODO: Move to script
       - name: Upload Logs
         if: always()
         run: |
-          python3 build_tools/upload_logs_to_s3.py
-        env:
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          AMDGPU_FAMILIES: ${{ env.AMDGPU_FAMILIES }}
-          S3_BUCKET: therock-artifacts
+          python3 build_tools/upload_logs_to_s3.py \
+            --build-dir=build \
+            --s3-base-path="s3://therock-artifacts/${{github.run_id}}-linux/logs/${{env.AMDGPU_FAMILIES}}"
 
       - name: Add Links to Job Summary
         if: always()

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -138,9 +138,9 @@ jobs:
             https://raw.githubusercontent.com/joshbrunty/Indexer/6d8cbfd15d3853b482e6a49f2d875ded9188b721/indexer.py \
             --output build/indexer.py
           python build/indexer.py -f '*.tar.xz*' build/artifacts/
-          python3 build_tools/create_log_index.py
-        env:
-            AMDGPU_FAMILIES: ${{ env.AMDGPU_FAMILIES }}
+          python3 build_tools/create_log_index.py \
+            --build-dir=build \
+            --amdgpu-family=${{ env.AMDGPU_FAMILIES }}
 
       # TODO: Move to script
       - name: Upload Artifacts

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -86,6 +86,7 @@ jobs:
           # Generate a new build id.
           package_version="${{ inputs.package_version }}"
           echo "Building package ${package_version}"
+          mkdir -p build/logs
           touch build/logs/test_linux.log
 
       - name: Test Packaging

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -86,8 +86,15 @@ jobs:
           # Generate a new build id.
           package_version="${{ inputs.package_version }}"
           echo "Building package ${package_version}"
-          mkdir -p build/logs
-          touch build/logs/test_linux.log
+
+          # Build.
+          cmake -B build -GNinja . \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DTHEROCK_AMDGPU_FAMILIES=${{env.AMDGPU_FAMILIES}} \
+            -DTHEROCK_PACKAGE_VERSION="${package_version}" \
+            -DTHEROCK_VERBOSE=ON \
+            -DBUILD_TESTING=ON
+          cmake --build build --target therock-archives therock-dist
 
       - name: Test Packaging
         run: |

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -86,15 +86,7 @@ jobs:
           # Generate a new build id.
           package_version="${{ inputs.package_version }}"
           echo "Building package ${package_version}"
-
-          # Build.
-          cmake -B build -GNinja . \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DTHEROCK_AMDGPU_FAMILIES=${{env.AMDGPU_FAMILIES}} \
-            -DTHEROCK_PACKAGE_VERSION="${package_version}" \
-            -DTHEROCK_VERBOSE=ON \
-            -DBUILD_TESTING=ON
-          cmake --build build --target therock-archives therock-dist
+          touch build/logs/test_linux.log
 
       - name: Test Packaging
         run: |

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -162,7 +162,10 @@ jobs:
             ${extra_cmake_options}
 
       - name: Build Projects
-        run: touch build/logs/test_windows.log
+        run: |
+          New-Item -ItemType Directory -Force -Path build\logs
+          New-Item -ItemType File -Force -Path build\logs\test_linux.log
+
 
       - name: Report
         if: ${{ !cancelled() }}

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -162,10 +162,7 @@ jobs:
             ${extra_cmake_options}
 
       - name: Build Projects
-        run: |
-          New-Item -ItemType Directory -Force -Path build\logs
-          New-Item -ItemType File -Force -Path build\logs\test_linux.log
-
+        run: cmake --build "${{ env.BUILD_DIR_BASH }}" -j $(nproc --all) --target therock-archives therock-dist
 
       - name: Report
         if: ${{ !cancelled() }}

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -211,8 +211,8 @@ jobs:
             https://raw.githubusercontent.com/joshbrunty/Indexer/6d8cbfd15d3853b482e6a49f2d875ded9188b721/indexer.py \
             --output ${{ env.BUILD_DIR_BASH }}/indexer.py
           python ${{ env.BUILD_DIR_BASH }}/indexer.py -f '*.tar.xz*' ${{ env.BUILD_DIR_BASH }}/artifacts/
-          python build_tools/create_log_index.py `
-            --build-dir=${{ env.BUILD_DIR_BASH }} `
+          python build_tools/create_log_index.py \
+            --build-dir=${{ env.BUILD_DIR_BASH }} \
             --amdgpu-family=${{ env.AMDGPU_FAMILIES }}
 
       # TODO: Move to script

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -223,17 +223,13 @@ jobs:
             --include "*.tar.xz*"
           aws s3 cp ${{ env.BASE_BUILD_DIR_POWERSHELL }}\artifacts\index.html s3://therock-artifacts/${{github.run_id}}-windows/index-${{env.AMDGPU_FAMILIES}}.html
 
-      # TODO: Move to script
       - name: Upload Logs
         shell: powershell
         run: |
           $Env:PATH += ";C:\Program Files\Amazon\AWSCLIV2"
-          aws s3 cp ${{ env.BASE_BUILD_DIR_POWERSHELL }}\logs s3://therock-artifacts/${{github.run_id}}-windows/logs/${{env.AMDGPU_FAMILIES}}/ `
-            --recursive `
-            --content-type="text/plain" `
-            --exclude "*" `
-            --include "*.log"
-          aws s3 cp ${{ env.BASE_BUILD_DIR_POWERSHELL }}\logs\index.html s3://therock-artifacts/${{github.run_id}}-windows/logs/${{env.AMDGPU_FAMILIES}}/
+          python3 build_tools/upload_logs_to_s3.py `
+            --build-dir=${{ env.BASE_BUILD_DIR_POWERSHELL }} `
+            --s3-base-path="s3://therock-artifacts/${{github.run_id}}-windows/logs/${{env.AMDGPU_FAMILIES}}"
 
       - name: Add Links to Job Summary
         run: |

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -217,7 +217,6 @@ jobs:
 
       # TODO: Move to script
       - name: Upload Artifacts
-        if: always()
         shell: powershell
         run: |
           $Env:PATH += ";C:\Program Files\Amazon\AWSCLIV2"

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -217,6 +217,7 @@ jobs:
 
       # TODO: Move to script
       - name: Upload Artifacts
+        if: always()
         shell: powershell
         run: |
           $Env:PATH += ";C:\Program Files\Amazon\AWSCLIV2"

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -197,6 +197,7 @@ jobs:
           get-disk | Select-object @{Name="Size(GB)";Expression={$_.Size/1GB}} | Write-Host
 
       - name: Configure AWS Credentials
+        if: always()
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           aws-region: us-east-2
@@ -204,6 +205,7 @@ jobs:
 
       # TODO: Move to script
       - name: Create Index Files
+        if: always()
         run: |
           curl --silent --fail --show-error --location \
             https://raw.githubusercontent.com/joshbrunty/Indexer/6d8cbfd15d3853b482e6a49f2d875ded9188b721/indexer.py \
@@ -212,6 +214,7 @@ jobs:
           python build_tools/create_log_index.py `
             --build-dir=${{ env.BUILD_DIR_BASH }} `
             --amdgpu-family=${{ env.AMDGPU_FAMILIES }}
+
       # TODO: Move to script
       - name: Upload Artifacts
         shell: powershell
@@ -224,6 +227,7 @@ jobs:
           aws s3 cp ${{ env.BASE_BUILD_DIR_POWERSHELL }}\artifacts\index.html s3://therock-artifacts/${{github.run_id}}-windows/index-${{env.AMDGPU_FAMILIES}}.html
 
       - name: Upload Logs
+        if: always()
         shell: powershell
         run: |
           $Env:PATH += ";C:\Program Files\Amazon\AWSCLIV2"
@@ -232,6 +236,16 @@ jobs:
             --s3-base-path="s3://therock-artifacts/${{github.run_id}}-windows/logs/${{env.AMDGPU_FAMILIES}}"
 
       - name: Add Links to Job Summary
+        if: always()
         run: |
-          echo '* [Artifacts](https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}-windows/index-${{env.AMDGPU_FAMILIES}}.html)' >> $GITHUB_STEP_SUMMARY
-          echo '* [Build logs](https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}-windows/logs/${{env.AMDGPU_FAMILIES}}/index.html)' >> $GITHUB_STEP_SUMMARY
+          LOG_URL="https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}-windows/logs/${{env.AMDGPU_FAMILIES}}/index.html"
+          echo "[Build Logs](${LOG_URL})" >> $GITHUB_STEP_SUMMARY
+
+          ARTIFACT_INDEX=build/artifacts/index.html
+          if [ -f "${ARTIFACT_INDEX}" ]; then
+            ARTIFACT_URL="https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}-windows/index-${{env.AMDGPU_FAMILIES}}.html"
+
+            echo "[Artifacts](${ARTIFACT_URL})" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "[INFO] No artifacts index found. Skipping artifact link."
+          fi

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -241,7 +241,7 @@ jobs:
           LOG_URL="https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}-windows/logs/${{env.AMDGPU_FAMILIES}}/index.html"
           echo "[Build Logs](${LOG_URL})" >> $GITHUB_STEP_SUMMARY
 
-          ARTIFACT_INDEX=build/artifacts/index.html
+          ARTIFACT_INDEX="${{ env.BASE_BUILD_DIR_POWERSHELL }}/artifacts/index.html"
           if [ -f "${ARTIFACT_INDEX}" ]; then
             ARTIFACT_URL="https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}-windows/index-${{env.AMDGPU_FAMILIES}}.html"
 

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -209,9 +209,9 @@ jobs:
             https://raw.githubusercontent.com/joshbrunty/Indexer/6d8cbfd15d3853b482e6a49f2d875ded9188b721/indexer.py \
             --output ${{ env.BUILD_DIR_BASH }}/indexer.py
           python ${{ env.BUILD_DIR_BASH }}/indexer.py -f '*.tar.xz*' ${{ env.BUILD_DIR_BASH }}/artifacts/
-          python ${{ env.BUILD_DIR_BASH }}/indexer.py -f '*.log' ${{ env.BUILD_DIR_BASH }}/logs/
-          sed -i 's,a href="..",a href="../../index-${{env.AMDGPU_FAMILIES}}.html",g' ${{ env.BUILD_DIR_BASH }}/logs/index.html
-
+          python build_tools/create_log_index.py `
+            --build-dir=${{ env.BUILD_DIR_BASH }} `
+            --amdgpu-family=${{ env.AMDGPU_FAMILIES }}
       # TODO: Move to script
       - name: Upload Artifacts
         shell: powershell

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -162,7 +162,7 @@ jobs:
             ${extra_cmake_options}
 
       - name: Build Projects
-        run: cmake --build "${{ env.BUILD_DIR_BASH }}" -j $(nproc --all) --target therock-archives therock-dist
+        run: touch build/logs/test_windows.log
 
       - name: Report
         if: ${{ !cancelled() }}

--- a/build_tools/create_log_index.py
+++ b/build_tools/create_log_index.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+from pathlib import Path
+import sys
+
+
+def log(*args):
+    print(*args)
+    sys.stdout.flush()
+
+
+def index_log_files(build_dir: Path, amdgpu_family: str):
+    log_dir = build_dir / "logs"
+    index_file = log_dir / "index.html"
+
+    if log_dir.is_dir():
+        log(f"[INFO] Found '{log_dir}' directory. Indexing '*.log' files...")
+        subprocess.run(
+            ["python", str(build_dir / "indexer.py"), "-f", "*.log", str(log_dir)],
+            check=True,
+        )
+    else:
+        log(f"[WARN] Log directory '{log_dir}' not found. Skipping indexing.")
+        return
+
+    if index_file.exists():
+        log(
+            f"[INFO] Rewriting links in '{index_file}' with AMDGPU_FAMILIES={amdgpu_family}..."
+        )
+        content = index_file.read_text()
+        updated = content.replace(
+            'a href=".."', f'a href="../../index-{amdgpu_family}.html"'
+        )
+        index_file.write_text(updated)
+        log("[INFO] Log index links updated.")
+    else:
+        log(f"[WARN] '{index_file}' not found. Skipping link rewrite.")
+
+
+if __name__ == "__main__":
+    build_dir = Path(os.getenv("BUILD_DIR", "build"))
+    amdgpu_family = os.getenv("AMDGPU_FAMILIES")
+    if not amdgpu_family:
+        print("[ERROR] AMDGPU_FAMILIES not set")
+        sys.exit(1)
+    index_log_files(build_dir, amdgpu_family)

--- a/build_tools/create_log_index.py
+++ b/build_tools/create_log_index.py
@@ -24,6 +24,8 @@ def normalize_path(p: Path) -> str:
 def index_log_files(build_dir: Path, amdgpu_family: str):
     log_dir = build_dir / "logs"
     index_file = log_dir / "index.html"
+
+    # TODO: Fork indexer.py locally to avoid relying on an external GitHub source at runtime.
     indexer_path = build_dir / "indexer.py"
 
     if log_dir.is_dir():

--- a/build_tools/upload_logs_to_s3.py
+++ b/build_tools/upload_logs_to_s3.py
@@ -20,7 +20,7 @@ def log(*args, **kwargs):
 
 
 def check_aws_cli_available():
-    if shutil.which("aws") is None:
+    if not shutil.which("aws"):
         log("[ERROR] AWS CLI not found in PATH.")
         sys.exit(1)
 

--- a/build_tools/upload_logs_to_s3.py
+++ b/build_tools/upload_logs_to_s3.py
@@ -14,14 +14,17 @@ import argparse
 import subprocess
 from pathlib import Path
 
+
 def log(*args, **kwargs):
     print(*args, **kwargs)
     sys.stdout.flush()
+
 
 def check_aws_cli_available():
     if shutil.which("aws") is None:
         log("[ERROR] AWS CLI not found in PATH.")
         sys.exit(1)
+
 
 def run_aws_cp(src: str, dest: str, content_type: str = None):
     cmd = (
@@ -36,6 +39,7 @@ def run_aws_cp(src: str, dest: str, content_type: str = None):
         subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError as e:
         log(f"[ERROR] Failed to upload {src} to {dest}: {e}")
+
 
 def upload_logs_to_s3(s3_base_path: str, build_dir: Path):
     log_dir = build_dir / "logs"
@@ -60,6 +64,7 @@ def upload_logs_to_s3(s3_base_path: str, build_dir: Path):
     else:
         log("[INFO] No index.html found. Skipping index upload.")
 
+
 def main():
     check_aws_cli_available()
 
@@ -79,6 +84,7 @@ def main():
     args = parser.parse_args()
 
     upload_logs_to_s3(args.s3_base_path, args.build_dir)
+
 
 if __name__ == "__main__":
     main()

--- a/build_tools/upload_logs_to_s3.py
+++ b/build_tools/upload_logs_to_s3.py
@@ -61,7 +61,7 @@ def upload_logs_to_s3(s3_base_path: str, build_dir: Path):
         run_aws_cp(index_path, index_s3_dest, content_type="text/html")
         log(f"[INFO] Uploaded {index_path} to {index_s3_dest}")
     else:
-        log("[INFO] No index.html found. Skipping index upload.")
+        log(f"[INFO] No index.html found at {log_dir}. Skipping index upload.")
 
 
 def main():

--- a/build_tools/upload_logs_to_s3.py
+++ b/build_tools/upload_logs_to_s3.py
@@ -25,11 +25,11 @@ def check_aws_cli_available():
         sys.exit(1)
 
 
-def run_aws_cp(source_directory: Path, s3_destination: str, content_type: str = None):
-    if source_directory.is_dir():
-        cmd = ["aws", "s3", "cp", str(source_directory), s3_destination, "--recursive"]
+def run_aws_cp(source_path: Path, s3_destination: str, content_type: str = None):
+    if source_path.is_dir():
+        cmd = ["aws", "s3", "cp", str(source_path), s3_destination, "--recursive"]
     else:
-        cmd = ["aws", "s3", "cp", str(source_directory), s3_destination]
+        cmd = ["aws", "s3", "cp", str(source_path), s3_destination]
 
     if content_type:
         cmd += ["--content-type", content_type]
@@ -37,7 +37,7 @@ def run_aws_cp(source_directory: Path, s3_destination: str, content_type: str = 
         log(f"[INFO] Running: {' '.join(cmd)}")
         subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError as e:
-        log(f"[ERROR] Failed to upload {source_directory} to {s3_destination}: {e}")
+        log(f"[ERROR] Failed to upload {source_path} to {s3_destination}: {e}")
 
 
 def upload_logs_to_s3(s3_base_path: str, build_dir: Path):

--- a/build_tools/upload_logs_to_s3.py
+++ b/build_tools/upload_logs_to_s3.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+upload_logs_to_s3.py
+
+Uploads log files and index.html to an S3 bucket using the AWS CLI.
+"""
+
+import os
+import sys
+import glob
+import shutil
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def log(*args, **kwargs):
+    print(*args, **kwargs)
+    sys.stdout.flush()
+
+
+def check_aws_cli_available():
+    if shutil.which("aws") is None:
+        log("[ERROR] AWS CLI not found in PATH.")
+        sys.exit(1)
+
+
+def run_aws_cp(src: str, dest: str, content_type: str = None):
+    cmd = (
+        ["aws", "s3", "cp", src, dest, "--recursive"]
+        if os.path.isdir(src)
+        else ["aws", "s3", "cp", src, dest]
+    )
+    if content_type:
+        cmd += ["--content-type", content_type]
+    try:
+        log(f"[INFO] Running: {' '.join(cmd)}")
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        log(f"[ERROR] Failed to upload {src} to {dest}: {e}")
+
+
+def upload_logs_to_s3(
+    bucket_name: str, run_id: str, amdgpu_family: str, build_dir: Path
+):
+    log_dir = build_dir / "logs"
+    s3_base_path = f"s3://{bucket_name}/{run_id}-linux/logs/{amdgpu_family}"
+
+    if not log_dir.is_dir():
+        log(f"[INFO] Log directory {log_dir} not found. Skipping upload.")
+        return
+
+    # Upload .log files
+    log_files = list(log_dir.glob("*.log"))
+    if not log_files:
+        log("[WARN] No .log files found. Skipping log upload.")
+    else:
+        run_aws_cp(str(log_dir), s3_base_path, content_type="text/plain")
+
+    # Upload index.html
+    index_path = log_dir / "index.html"
+    if index_path.is_file():
+        index_s3_dest = f"{s3_base_path}/index.html"
+        run_aws_cp(str(index_path), index_s3_dest, content_type="text/html")
+        log(f"[INFO] Uploaded {index_path} to {index_s3_dest}")
+    else:
+        log("[INFO] No index.html found. Skipping index upload.")
+
+
+def main():
+    check_aws_cli_available()
+
+    # Resolve default directories
+    this_script_dir = Path(__file__).resolve().parent
+    therock_dir = this_script_dir.parent
+
+    parser = argparse.ArgumentParser(description="Upload logs to S3.")
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=Path(os.getenv("BUILD_DIR", therock_dir / "build")),
+        help="Path to the build directory (default: repo_root/build or $BUILD_DIR)",
+    )
+    args = parser.parse_args()
+
+    bucket = os.getenv("S3_BUCKET", "therock-artifacts")
+    run_id = os.getenv("GITHUB_RUN_ID")
+    amdgpu_family = os.getenv("AMDGPU_FAMILIES")
+
+    if not run_id:
+        log("[ERROR] GITHUB_RUN_ID is required.")
+        sys.exit(1)
+    if not amdgpu_family:
+        log("[ERROR] AMDGPU_FAMILIES is required.")
+        sys.exit(1)
+
+    upload_logs_to_s3(bucket, run_id, amdgpu_family, args.build_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/build_tools/upload_logs_to_s3.py
+++ b/build_tools/upload_logs_to_s3.py
@@ -67,12 +67,15 @@ def upload_logs_to_s3(s3_base_path: str, build_dir: Path):
 def main():
     check_aws_cli_available()
 
+    repo_root = Path(__file__).resolve().parent.parent
+    default_build_dir = repo_root / "build"
+
     parser = argparse.ArgumentParser(description="Upload logs to S3.")
     parser.add_argument(
         "--build-dir",
         type=Path,
-        default=Path("build"),
-        help="Path to the build directory (default: build)",
+        default=default_build_dir,
+        help="Path to the build directory (default: <repo_root>/build)",
     )
     parser.add_argument(
         "--s3-base-path",

--- a/build_tools/upload_logs_to_s3.py
+++ b/build_tools/upload_logs_to_s3.py
@@ -1,4 +1,3 @@
-# === Updated build_tools/upload_logs_to_s3.py ===
 #!/usr/bin/env python3
 """
 upload_logs_to_s3.py

--- a/build_tools/upload_logs_to_s3.py
+++ b/build_tools/upload_logs_to_s3.py
@@ -25,11 +25,11 @@ def check_aws_cli_available():
         sys.exit(1)
 
 
-def run_aws_cp(source_directory: Path, s3_destination: Path, content_type: str = None):
+def run_aws_cp(source_directory: Path, s3_destination: str, content_type: str = None):
     if source_directory.is_dir():
-        cmd = ["aws", "s3", "cp", str(source_directory), str(s3_destination), "--recursive"]
+        cmd = ["aws", "s3", "cp", str(source_directory), s3_destination, "--recursive"]
     else:
-        cmd = ["aws", "s3", "cp", str(source_directory), str(s3_destination)]
+        cmd = ["aws", "s3", "cp", str(source_directory), s3_destination]
 
     if content_type:
         cmd += ["--content-type", content_type]


### PR DESCRIPTION
This PR adds the log upload support when the build target failed within the workflow. It is not using `teatime.py` script