### PR TITLE
[windows] Inline clr patch to fix `.not_s_trap` error message on startup.

### DIFF
--- a/patches/amd-mainline/clr/0004-windows-Fix-assembler-error-in-pal-trap-handler.patch
+++ b/patches/amd-mainline/clr/0004-windows-Fix-assembler-error-in-pal-trap-handler.patch
@@ -1,0 +1,32 @@
+From 31675d06062328c8aa273994785a1e662f6edfdb Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Sat, 10 May 2025 15:56:02 -0700
+Subject: [PATCH 4/4] [windows] Fix assembler error in pal trap handler.
+
+This has been showing up in real use as an error printed to the console complaining that the ".not_s_trap" label cannot be found on device initialization.
+
+Tracked back to this commit: https://github.com/ROCm/clr/commit/7b72c1b7868d5f992fb562bd30db49225caacab2
+
+In [the referenced original source](https://github.com/ROCm/ROCR-Runtime/tree/amd-staging/runtime/hsa-runtime/core/runtime/trap_handler), the `.not_s_trap` label contained conditional code for gfx94x which was removed. Outside of that case, it jumps to `.no_skip_debug_trap`, which we use here.
+
+Tested by running hipblaslt tests on Windows/gfx1151 in TheRock and verifying that the error was not printed and tests run correctly.
+---
+ rocclr/device/pal/palblitcl.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rocclr/device/pal/palblitcl.cpp b/rocclr/device/pal/palblitcl.cpp
+index 67b8fd020..d059e81d4 100644
+--- a/rocclr/device/pal/palblitcl.cpp
++++ b/rocclr/device/pal/palblitcl.cpp
+@@ -120,7 +120,7 @@ const char* TrapHandlerCode = RUNTIME_KERNEL(
+ \ntrap_entry:
+ \n  // Extract trap_id from ttmp2
+ \n  s_bfe_u32                             ttmp2, ttmp1, SQ_WAVE_PC_HI_TRAP_ID_BFE
+-\n  s_cbranch_scc0                        .not_s_trap                      // If trap_id == 0, it's not an s_trap nor host trap
++\n  s_cbranch_scc0                        .no_skip_debugtrap            // If trap_id == 0, it's not an s_trap nor host trap
+ \n
+ \n  // Check if the it was an host trap.
+ \n  s_bitcmp1_b32                         ttmp1, SQ_WAVE_PC_HI_HT_SHIFT
+-- 
+2.49.0.windows.1
+


### PR DESCRIPTION
Upstreamed as https://github.com/ROCm/clr/pull/163