### PR TITLE
GHA workflow PoC to configure submodule remote, branch

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -99,12 +99,7 @@ jobs:
 
             echo [*] Fetching latest submodule commit from remote
             git submodule update --init --remote --force -- $proj_submodule_path
-                # python ./build_tools/fetch_sources.py \
-                #   --remote \
-                #   --no-apply-patches \
-                #   --projects $proj_name \
-                #   --no-include-math-libs \
-                #   --no-include-ml-frameworks 
+
             echo "[*] Bump submodule [$proj_name]:$(git submodule status -- $proj_submodule_path)"
               git \
                 -c user.name=therockbot \

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -105,7 +105,10 @@ jobs:
                   --no-include-math-libs \
                   --no-include-ml-frameworks 
             echo "[*] Bump submodule [$proj_name]:$(git submodule status -- $proj_submodule_path)"
-            git commit -a -m "Bump submodule $proj_name with its remote in superproject" 
+              git commit \
+                -c user.name=therockbot \
+                -c user.email=therockbot@amd.com \
+                -a -m "Bump submodule $proj_name with its remote in superproject" 
           fi
 
           #Continue with normal fetching of sources

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -11,14 +11,13 @@ on:
         description: "(etc. gfx110X-dgpu)"
       project_name:
         type: string
-        description: "Insert name of subproject (etc. hipBLASLt) to configure remote url and branch to fetch. Blank to disable."
+        description: "name of subproject (etc. hipBLASLt) to configure remote url and branch to fetch. (disable w/ null name and url)"
       project_seturl:
         type: string
-        description: "Insert url of subproject (etc. https://github.com/ROCm/hipBLASLt) "
+        description: "url of subproject (etc. https://github.com/ROCm/hipBLASLt) (disable w/ null name and url)"
       project_branch:
         type: string
-        description: "Insert name of branch (etc. develop) to configure remote url and branch to fetch"
-
+        description: "name of branch (etc. develop) to configure remote url and branch to fetch"
 
   workflow_call:
     inputs:
@@ -30,14 +29,13 @@ on:
         description: "(etc. gfx110X-dgpu)"
       project_name:
         type: string
-        description: "Insert name of subproject (etc. hipBLASLt) to configure remote url and branch to fetch. Blank to disable."
+        description: "name of subproject (etc. hipBLASLt) to configure remote url and branch to fetch. (disable w/ null name and url)"
       project_seturl:
         type: string
-        description: "Insert url of subproject (etc. https://github.com/ROCm/hipBLASLt) "
+        description: "url of subproject (etc. https://github.com/ROCm/hipBLASLt) (disable w/ null name and url)"
       project_branch:
         type: string
-        description: "Insert name of branch (etc. develop) to configure remote url and branch to fetch"
-
+        description: "name of branch (etc. develop) to configure remote url and branch to fetch"
 
 jobs:
   build_linux_packages:
@@ -81,32 +79,64 @@ jobs:
           restore-keys: |
             linux-build-packages-manylinux-v2-
 
-      - name: Fetch sources
+      - name: Fetch submodule from remote
         run: |
           proj_name="${{ inputs.project_name }}"
           proj_branch="${{ inputs.project_branch }}"
           proj_seturl="${{ inputs.project_seturl }}"
 
+                    echo "[*] Fetch submodule from remote using GHA inputs:"
+          echo "     proj_name: [$proj_name]"
+          echo "     proj_path: [$proj_submodule_path]"
+          echo "     proj_seturl: [$proj_seturl]"
+          echo "     proj_branch: [$proj_branch]"
+
           #Only update submodule if set in github action inputs
-          if [ -n "$proj_name" ]; then
+          if [ "$proj_name" ] || [ "$proj_seturl" ]; then
+            if [ ! "$proj_name" ]; then 
+              proj_name=$(basename "$proj_seturl")
+              echo "[*] proj_name GHA Input not set, deriving from proj_seturl: [$proj_name]"
+            else
+              echo "[*] proj_name GHA Input set to: [$proj_name]"
+            fi 
+
             proj_submodule_path=$(git config --file .gitmodules --get submodule.$proj_name.path)
-            echo "[*] Setting remote url and branch for submodule [$proj_name]:"
-            echo "     path: $proj_submodule_path"
-            echo "     url: $proj_seturl"
-            echo "     branch: $proj_branch"
-            git submodule set-url -- $proj_submodule_path $proj_seturl
-            git submodule set-branch --branch $proj_branch -- $proj_submodule_path
+            
+            if [ "$proj_submodule_path" ]; then
+              echo "[*] Existing submodule config for [$proj_name]:"
+              git config --file .gitmodules --get-regexp ^submodule.$proj_name\.
 
-            echo [*] Fetching latest submodule commit from remote
-            git submodule update --init --remote --force -- $proj_submodule_path
+              echo "[*] Submodule status [$proj_name]:$(git submodule status -- $proj_submodule_path)"
 
-            echo "[*] Bump submodule [$proj_name]:$(git submodule status -- $proj_submodule_path)"
-              git \
-                -c user.name=therockbot \
-                -c user.email=therockbot@amd.com \
-                commit -a -m "Bump submodule $proj_name with its remote in superproject" 
+              echo "[*] Setting remote url and branch for submodule [$proj_name]"
+              
+              [ "$proj_seturl" ] && git submodule set-url -- $proj_submodule_path $proj_seturl
+              [ "$proj_branch" ] && git submodule set-branch --branch $proj_branch -- $proj_submodule_path
+
+              echo "[*] Modified submodule config for [$proj_name]:"
+              git config --file .gitmodules --get-regexp ^submodule.$proj_name\.
+
+
+              echo "[*] Fetching latest submodule commit from remote"              
+              git submodule sync -- $proj_submodule_path
+              git submodule update --init --remote --force -- $proj_submodule_path
+              if [ $? -gt 0 ]; then
+                echo "[-] Could not update submodule from remote. Aborting..."
+              else
+                echo "[+] Bump submodule [$proj_name]:$(git submodule status -- $proj_submodule_path)"
+                git \
+                  -c user.name=therockbot \
+                  -c user.email=therockbot@amd.com \
+                  commit -a -m "Bump submodule $proj_name with its remote for parent project"
+              fi
+            else
+              echo "[-] Could not find submodule path. Aborting..."
+            fi
+          else
+            echo [*] No project name or url specicfied. Skipping submodule fetch...
           fi
-
+      - name: Fetch sources
+        run: |
           #Continue with normal fetching of sources
           ./build_tools/fetch_sources.py --jobs 12
 

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -98,12 +98,13 @@ jobs:
             git submodule set-branch --branch $proj_branch -- $proj_submodule_path
 
             echo [*] Fetching latest submodule commit from remote
-                python ./build_tools/fetch_sources.py \
-                  --remote \
-                  --no-apply-patches \
-                  --projects $proj_name \
-                  --no-include-math-libs \
-                  --no-include-ml-frameworks 
+            git submodule update --init --remote --force -- $proj_submodule_path
+                # python ./build_tools/fetch_sources.py \
+                #   --remote \
+                #   --no-apply-patches \
+                #   --projects $proj_name \
+                #   --no-include-math-libs \
+                #   --no-include-ml-frameworks 
             echo "[*] Bump submodule [$proj_name]:$(git submodule status -- $proj_submodule_path)"
               git \
                 -c user.name=therockbot \

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -105,10 +105,10 @@ jobs:
                   --no-include-math-libs \
                   --no-include-ml-frameworks 
             echo "[*] Bump submodule [$proj_name]:$(git submodule status -- $proj_submodule_path)"
-              git commit \
+              git \
                 -c user.name=therockbot \
                 -c user.email=therockbot@amd.com \
-                -a -m "Bump submodule $proj_name with its remote in superproject" 
+                commit -a -m "Bump submodule $proj_name with its remote in superproject" 
           fi
 
           #Continue with normal fetching of sources

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -8,6 +8,16 @@ on:
         default: ADHOCBUILD
       amdgpu_families:
         type: string
+      project_name:
+        type: string
+        description: "Insert name of subproject (etc. hipBLASLt) to configure remote url and branch to fetch. Blank to disable."
+      project_seturl:
+        type: string
+        description: "Insert url of subproject (etc. https://github.com/ROCm/hipBLASLt) "
+      project_branch:
+        type: string
+        description: "Insert name of branch (etc. develop) to configure remote url and branch to fetch"
+
 
   workflow_call:
     inputs:
@@ -16,6 +26,16 @@ on:
         default: ADHOCBUILD
       amdgpu_families:
         type: string
+      project_name:
+        type: string
+        description: "Insert name of subproject (etc. hipBLASLt) to configure remote url and branch to fetch. Blank to disable."
+      project_seturl:
+        type: string
+        description: "Insert url of subproject (etc. https://github.com/ROCm/hipBLASLt) "
+      project_branch:
+        type: string
+        description: "Insert name of branch (etc. develop) to configure remote url and branch to fetch"
+
 
 jobs:
   build_linux_packages:
@@ -61,6 +81,32 @@ jobs:
 
       - name: Fetch sources
         run: |
+          proj_name="${{ inputs.project_name }}"
+          proj_branch="${{ inputs.project_branch }}"
+          proj_seturl="${{ inputs.project_seturl }}"
+
+          #Only update submodule if set in github action inputs
+          if [ -n "$proj_name" ]; then
+            proj_submodule_path=$(git config --file .gitmodules --get submodule.$proj_name.path)
+            echo "[*] Setting remote url and branch for submodule [$proj_name]:"
+            echo "     path: $proj_submodule_path"
+            echo "     url: $proj_seturl"
+            echo "     branch: $proj_branch"
+            git submodule set-url -- $proj_submodule_path $proj_seturl
+            git submodule set-branch --branch $proj_branch -- $proj_submodule_path
+
+            echo [*] Fetching latest submodule commit from remote
+                python ./build_tools/fetch_sources.py \
+                  --remote \
+                  --no-apply-patches \
+                  --projects $proj_name \
+                  --no-include-math-libs \
+                  --no-include-ml-frameworks 
+            echo "[*] Bump submodule [$proj_name]:$(git submodule status -- $proj_submodule_path)"
+            git commit -a -m "Bump submodule $proj_name with its remote in superproject" 
+          fi
+
+          #Continue with normal fetching of sources
           ./build_tools/fetch_sources.py --jobs 12
 
       - name: Install python deps

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -8,6 +8,7 @@ on:
         default: ADHOCBUILD
       amdgpu_families:
         type: string
+        description: "(etc. gfx110X-dgpu)"
       project_name:
         type: string
         description: "Insert name of subproject (etc. hipBLASLt) to configure remote url and branch to fetch. Blank to disable."
@@ -26,6 +27,7 @@ on:
         default: ADHOCBUILD
       amdgpu_families:
         type: string
+        description: "(etc. gfx110X-dgpu)"
       project_name:
         type: string
         description: "Insert name of subproject (etc. hipBLASLt) to configure remote url and branch to fetch. Blank to disable."

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -157,7 +157,10 @@ jobs:
                   --no-include-math-libs \
                   --no-include-ml-frameworks 
             echo "[*] Bump submodule [$proj_name]:$(git submodule status -- $proj_submodule_path)"
-            git commit -a -m "Bump submodule $proj_name with its remote in superproject" 
+              git commit \
+                -c user.name=therockbot \
+                -c user.email=therockbot@amd.com \
+                -a -m "Bump submodule $proj_name with its remote in superproject" 
           fi
 
           #Continue with normal fetching of sources

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -151,12 +151,7 @@ jobs:
 
             echo [*] Fetching latest submodule commit from remote
             git submodule update --init --remote --force -- $proj_submodule_path
-                # python ./build_tools/fetch_sources.py \
-                #   --remote \
-                #   --no-apply-patches \
-                #   --projects $proj_name \
-                #   --no-include-math-libs \
-                #   --no-include-ml-frameworks 
+
             echo "[*] Bump submodule [$proj_name]:$(git submodule status -- $proj_submodule_path)"
               git \
                 -c user.name=therockbot \

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -150,12 +150,13 @@ jobs:
             git submodule set-branch --branch $proj_branch -- $proj_submodule_path
 
             echo [*] Fetching latest submodule commit from remote
-                python ./build_tools/fetch_sources.py \
-                  --remote \
-                  --no-apply-patches \
-                  --projects $proj_name \
-                  --no-include-math-libs \
-                  --no-include-ml-frameworks 
+            git submodule update --init --remote --force -- $proj_submodule_path
+                # python ./build_tools/fetch_sources.py \
+                #   --remote \
+                #   --no-apply-patches \
+                #   --projects $proj_name \
+                #   --no-include-math-libs \
+                #   --no-include-ml-frameworks 
             echo "[*] Bump submodule [$proj_name]:$(git submodule status -- $proj_submodule_path)"
               git \
                 -c user.name=therockbot \

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -14,13 +14,13 @@ on:
         default: "-DBUILD_TESTING=ON"
       project_name:
         type: string
-        description: "Insert name of subproject (etc. hipBLASLt) to configure remote url and branch to fetch. Blank to disable."
+        description: "name of subproject (etc. hipBLASLt) to configure remote url and branch to fetch. (disable w/ null name and url)"
       project_seturl:
         type: string
-        description: "Insert url of subproject (etc. https://github.com/ROCm/hipBLASLt) "
+        description: "url of subproject (etc. https://github.com/ROCm/hipBLASLt) (disable w/ null name and url)"
       project_branch:
         type: string
-        description: "Insert name of branch (etc. develop) to configure remote url and branch to fetch"
+        description: "name of branch (etc. develop) of subproject to fetch"
 
   workflow_call:
     inputs:
@@ -34,13 +34,13 @@ on:
         default: "-DBUILD_TESTING=ON"
       project_name:
         type: string
-        description: "Insert name of subproject (etc. hipBLASLt) to configure remote url and branch to fetch. Blank to disable."
+        description: "name of subproject (etc. hipBLASLt) to configure remote url and branch to fetch. (disable w/ null name and url)"
       project_seturl:
         type: string
-        description: "Insert url of subproject (etc. https://github.com/ROCm/hipBLASLt) "
+        description: "url of subproject (etc. https://github.com/ROCm/hipBLASLt) (disable w/ null name and url)"
       project_branch:
         type: string
-        description: "Insert name of branch (etc. develop) to configure remote url and branch to fetch"
+        description: "name of branch (etc. develop) of subproject to fetch"
 
 
 jobs:
@@ -132,33 +132,64 @@ jobs:
           key: windows-build-packages-v3-${{ github.sha }}
           restore-keys: |
             windows-build-packages-v3-
-
-      - name: Fetch sources
+      - name: Fetch submodule from remote
         run: |
           proj_name="${{ inputs.project_name }}"
           proj_branch="${{ inputs.project_branch }}"
           proj_seturl="${{ inputs.project_seturl }}"
 
+          echo "[*] Fetch submodule from remote using GHA inputs:"
+          echo "     proj_name: [$proj_name]"
+          echo "     proj_path: [$proj_submodule_path]"
+          echo "     proj_seturl: [$proj_seturl]"
+          echo "     proj_branch: [$proj_branch]"
+
           #Only update submodule if set in github action inputs
-          if [ -n "$proj_name" ]; then
+          if [ "$proj_name" ] || [ "$proj_seturl" ]; then
+            if [ ! "$proj_name" ]; then 
+              proj_name=$(basename "$proj_seturl")
+              echo "[*] proj_name GHA Input not set, deriving from proj_seturl: [$proj_name]"
+            else
+              echo "[*] proj_name GHA Input set to: [$proj_name]"
+            fi 
+
             proj_submodule_path=$(git config --file .gitmodules --get submodule.$proj_name.path)
-            echo "[*] Setting remote url and branch for submodule [$proj_name]:"
-            echo "     path: $proj_submodule_path"
-            echo "     url: $proj_seturl"
-            echo "     branch: $proj_branch"
-            git submodule set-url -- $proj_submodule_path $proj_seturl
-            git submodule set-branch --branch $proj_branch -- $proj_submodule_path
+            
+            if [ "$proj_submodule_path" ]; then
+              echo "[*] Existing submodule config for [$proj_name]:"
+              git config --file .gitmodules --get-regexp ^submodule.$proj_name\.
 
-            echo [*] Fetching latest submodule commit from remote
-            git submodule update --init --remote --force -- $proj_submodule_path
+              echo "[*] Submodule status [$proj_name]:$(git submodule status -- $proj_submodule_path)"
 
-            echo "[*] Bump submodule [$proj_name]:$(git submodule status -- $proj_submodule_path)"
-              git \
-                -c user.name=therockbot \
-                -c user.email=therockbot@amd.com \
-                commit -a -m "Bump submodule $proj_name with its remote in superproject" 
+              echo "[*] Setting remote url and branch for submodule [$proj_name]"
+              
+              [ "$proj_seturl" ] && git submodule set-url -- $proj_submodule_path $proj_seturl
+              [ "$proj_branch" ] && git submodule set-branch --branch $proj_branch -- $proj_submodule_path
+
+              echo "[*] Modified submodule config for [$proj_name]:"
+              git config --file .gitmodules --get-regexp ^submodule.$proj_name\.
+
+
+              echo "[*] Fetching latest submodule commit from remote"              
+              git submodule sync -- $proj_submodule_path
+              git submodule update --init --remote --force -- $proj_submodule_path
+              if [ $? -gt 0 ]; then
+                echo "[-] Could not update submodule from remote. Aborting..."
+              else
+                echo "[+] Bump submodule [$proj_name]:$(git submodule status -- $proj_submodule_path)"
+                git \
+                  -c user.name=therockbot \
+                  -c user.email=therockbot@amd.com \
+                  commit -a -m "Bump submodule $proj_name with its remote for parent project"
+              fi
+            else
+              echo "[-] Could not find submodule path. Aborting..."
+            fi
+          else
+            echo [*] No project name or url specicfied. Skipping submodule fetch...
           fi
-
+      - name: Fetch sources
+        run: |
           #Continue with normal fetching of sources
           python ./build_tools/fetch_sources.py --jobs $(nproc --all)
 

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -12,6 +12,15 @@ on:
       extra_cmake_options:
         type: string
         default: "-DBUILD_TESTING=ON"
+      project_name:
+        type: string
+        description: "Insert name of subproject (etc. hipBLASLt) to configure remote url and branch to fetch. Blank to disable."
+      project_seturl:
+        type: string
+        description: "Insert url of subproject (etc. https://github.com/ROCm/hipBLASLt) "
+      project_branch:
+        type: string
+        description: "Insert name of branch (etc. develop) to configure remote url and branch to fetch"
 
   workflow_call:
     inputs:
@@ -23,6 +32,16 @@ on:
       extra_cmake_options:
         type: string
         default: "-DBUILD_TESTING=ON"
+      project_name:
+        type: string
+        description: "Insert name of subproject (etc. hipBLASLt) to configure remote url and branch to fetch. Blank to disable."
+      project_seturl:
+        type: string
+        description: "Insert url of subproject (etc. https://github.com/ROCm/hipBLASLt) "
+      project_branch:
+        type: string
+        description: "Insert name of branch (etc. develop) to configure remote url and branch to fetch"
+
 
 jobs:
   build_windows_packages:
@@ -116,7 +135,33 @@ jobs:
 
       - name: Fetch sources
         run: |
-          python ./build_tools/fetch_sources.py --jobs 96
+          proj_name="${{ inputs.project_name }}"
+          proj_branch="${{ inputs.project_branch }}"
+          proj_seturl="${{ inputs.project_seturl }}"
+
+          #Only update submodule if set in github action inputs
+          if [ -n "$proj_name" ]; then
+            proj_submodule_path=$(git config --file .gitmodules --get submodule.$proj_name.path)
+            echo "[*] Setting remote url and branch for submodule [$proj_name]:"
+            echo "     path: $proj_submodule_path"
+            echo "     url: $proj_seturl"
+            echo "     branch: $proj_branch"
+            git submodule set-url -- $proj_submodule_path $proj_seturl
+            git submodule set-branch --branch $proj_branch -- $proj_submodule_path
+
+            echo [*] Fetching latest submodule commit from remote
+                python ./build_tools/fetch_sources.py \
+                  --remote \
+                  --no-apply-patches \
+                  --projects $proj_name \
+                  --no-include-math-libs \
+                  --no-include-ml-frameworks 
+            echo "[*] Bump submodule [$proj_name]:$(git submodule status -- $proj_submodule_path)"
+            git commit -a -m "Bump submodule $proj_name with its remote in superproject" 
+          fi
+
+          #Continue with normal fetching of sources
+          python ./build_tools/fetch_sources.py --jobs $(nproc --all)
 
       - name: Checkout closed source AMDGPU/ROCm interop library folder
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -157,10 +157,10 @@ jobs:
                   --no-include-math-libs \
                   --no-include-ml-frameworks 
             echo "[*] Bump submodule [$proj_name]:$(git submodule status -- $proj_submodule_path)"
-              git commit \
+              git \
                 -c user.name=therockbot \
                 -c user.email=therockbot@amd.com \
-                -a -m "Bump submodule $proj_name with its remote in superproject" 
+                commit -a -m "Bump submodule $proj_name with its remote in superproject" 
           fi
 
           #Continue with normal fetching of sources


### PR DESCRIPTION
Implementing #559 

This is an initial proof of concept that enables specifying the remote url and branch of a submodule when running the build workflow for linux and windows.

As of now this can be tested when running these build workflows from `users/justchen/build-ci-config-submodule`:
https://github.com/ROCm/TheRock/actions/workflows/build_windows_packages.yml
https://github.com/ROCm/TheRock/actions/workflows/linux_windows_packages.yml

There are now 3 additional input fields:
```haskell
- name of subproject 
- url of subproject
- name of branch
```

To enable, either `name of subproject` or `url of subproject`, or both can be inputted. 
If only `url...` is inputted then the `name of subproject` will be derived from the url. 
if only `name...` is inputted then it will use the existing remote url.
similarly, if no branch is specified, the existing branch will be used.

Details can be found in the build logs under the `Fetch submodule from remote` step.
Internally,  proj_path has to be retrieved based on the project name.

#### Example of url specified but no project name:
```powershell
[*] Fetch submodule from remote using GHA inputs:
     proj_name: []
     proj_path: []
     proj_seturl: [https://github.com/amd-justchen/hipBLASLt]
     proj_branch: [testbranch-other]
[*] proj_name GHA Input not set, deriving from proj_seturl: [hipBLASLt]
[*] Existing submodule config for [hipBLASLt]:
submodule.hipBLASLt.path math-libs/BLAS/hipBLASLt
submodule.hipBLASLt.url https://github.com/ROCm/hipBLASLt.git
submodule.hipBLASLt.branch develop
[*] Submodule status [hipBLASLt]:-50d9abdddc0fda4b00313dfbc19e435d3b3a3500 math-libs/BLAS/hipBLASLt
[*] Setting remote url and branch for submodule [hipBLASLt]
[*] Modified submodule config for [hipBLASLt]:
submodule.hipBLASLt.path math-libs/BLAS/hipBLASLt
submodule.hipBLASLt.url https://github.com/amd-justchen/hipBLASLt
submodule.hipBLASLt.branch testbranch-other
[*] Fetching latest submodule commit from remote
Submodule 'hipBLASLt' (https://github.com/amd-justchen/hipBLASLt) registered for path 'math-libs/BLAS/hipBLASLt'
Cloning into 'C:/home/runner/_work/TheRock/TheRock/math-libs/BLAS/hipBLASLt'...
Submodule path 'math-libs/BLAS/hipBLASLt': checked out '35eb9960f2b16cda449249f00f71d1fefec6532d'
[+] Bump submodule [hipBLASLt]:+35eb9960f2b16cda449249f00f71d1fefec6532d math-libs/BLAS/hipBLASLt (remotes/origin/testbranch-other)
```

#### Example with default url, with subproject name specified:
```powershell
[*] Fetch submodule from remote using GHA inputs:
     proj_name: [hipBLASLt]
     proj_path: []
     proj_seturl: []
     proj_branch: [staging]
[*] proj_name GHA Input set to: [hipBLASLt]
[*] Existing submodule config for [hipBLASLt]:
submodule.hipBLASLt.path math-libs/BLAS/hipBLASLt
submodule.hipBLASLt.url https://github.com/ROCm/hipBLASLt.git
submodule.hipBLASLt.branch develop
[*] Submodule status [hipBLASLt]:-50d9abdddc0fda4b00313dfbc19e435d3b3a3500 math-libs/BLAS/hipBLASLt
[*] Setting remote url and branch for submodule [hipBLASLt]
[*] Modified submodule config for [hipBLASLt]:
submodule.hipBLASLt.path math-libs/BLAS/hipBLASLt
submodule.hipBLASLt.url https://github.com/ROCm/hipBLASLt.git
submodule.hipBLASLt.branch staging
[*] Fetching latest submodule commit from remote
Submodule 'hipBLASLt' (https://github.com/ROCm/hipBLASLt.git) registered for path 'math-libs/BLAS/hipBLASLt'
Cloning into 'C:/home/runner/_work/TheRock/TheRock/math-libs/BLAS/hipBLASLt'...
Submodule path 'math-libs/BLAS/hipBLASLt': checked out '705c0a943b9f5cece2e32d35cdbd6d1c5fc34064'
[+] Bump submodule [hipBLASLt]:+705c0a943b9f5cece2e32d35cdbd6d1c5fc34064 math-libs/BLAS/hipBLASLt (mock-tag-test-263-g705c0a94)
```

