### PR TITLE
[windows] Include bin/rocblas/library/** in dist.

### DIFF
--- a/math-libs/BLAS/artifact-blas.toml
+++ b/math-libs/BLAS/artifact-blas.toml
@@ -58,6 +58,7 @@ include = [
 [components.doc."math-libs/BLAS/rocBLAS/stage"]
 [components.lib."math-libs/BLAS/rocBLAS/stage"]
 include = [
+  "bin/rocblas/library/**",
   "lib/rocblas/library/**",
 ]
 [components.test."math-libs/BLAS/rocBLAS/stage"]


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/571.

We may want to instead change rocBLAS to output to lib/ on both Windows and Linux.