### PR TITLE
[windows] Enable BLAS and SPARSE builds on CI.

### DIFF
--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -148,8 +148,6 @@ jobs:
             -DTHEROCK_AMDGPU_FAMILIES=${amdgpu_families} \
             -DTHEROCK_PACKAGE_VERSION="${package_version}" \
             -DTHEROCK_AMDGPU_WINDOWS_INTEROP_DIR=${GITHUB_WORKSPACE}/amdgpu-windows-interop \
-            -DTHEROCK_ENABLE_BLAS=OFF \
-            -DTHEROCK_ENABLE_SPARSE=OFF \
             -DTHEROCK_ENABLE_SOLVER=OFF \
             -DTHEROCK_ENABLE_ML_LIBS=OFF \
             ${extra_cmake_options}


### PR DESCRIPTION
Tested here:

* Just enable BLAS: https://github.com/ROCm/TheRock/actions/runs/14978891816/job/42077990572
* Enable BLAS and SPARSE: https://github.com/ROCm/TheRock/actions/runs/14980452403/job/42083085175 (note that this is taking 10+ minutes to upload the cache?)

I've been triggering those from https://github.com/ROCm/TheRock/actions/workflows/build_windows_packages.yml using `extra_cmake_options`, taking advantage of the fact that CMake options can be specified more than once, taking the last in the list. For example, the first was triggered with `-DBUILD_TESTING=ON -DTHEROCK_ENABLE_BLAS=ON`. I could have also pushed this branch and triggered that way.

Now that we're building more projects, we'll want to keep a closer eye on ccache hit rates and build times, maybe focusing on https://github.com/ROCm/TheRock/issues/132 again. Anecdotally, I've seen a few <1% cache hit rate workflow runs and the cache is consistently at its maximum size of 4GB. My local ccache is currently using 26GB after several rebuilds. We should really set up a ccache/sccache server instead of using github actions cache.