### PR TITLE
[ci] Add more workflow file name patterns that trigger CI.

### DIFF
--- a/build_tools/github_action/configure_ci.py
+++ b/build_tools/github_action/configure_ci.py
@@ -127,12 +127,13 @@ def check_for_non_skippable_path(paths: Optional[Iterable[str]]) -> bool:
     return any(not is_path_skippable(p) for p in paths)
 
 
-# TODO(#199): rename all of these to `ci_*.yml` so this is easier to understand?
 GITHUB_WORKFLOWS_CI_PATTERNS = [
-    "ci.yml",
     "setup.yml",
+    "ci.yml",
+    "ci_*.yml",
     "build_*_packages.yml",
     "test_*_packages.yml",
+    "test_*.yml",  # This may be too broad, but there are many test workflows.
 ]
 
 

--- a/build_tools/github_action/configure_ci.py
+++ b/build_tools/github_action/configure_ci.py
@@ -129,11 +129,10 @@ def check_for_non_skippable_path(paths: Optional[Iterable[str]]) -> bool:
 
 GITHUB_WORKFLOWS_CI_PATTERNS = [
     "setup.yml",
-    "ci.yml",
-    "ci_*.yml",
-    "build_*_packages.yml",
-    "test_*_packages.yml",
-    "test_*.yml",  # This may be too broad, but there are many test workflows.
+    "ci*.yml",
+    "build*package*.yml",
+    "test*packages.yml",
+    "test*.yml",  # This may be too broad, but there are many test workflows.
 ]
 
 

--- a/build_tools/github_action/configure_ci_test.py
+++ b/build_tools/github_action/configure_ci_test.py
@@ -17,6 +17,12 @@ class ConfigureCITest(TestCase):
         paths = [".github/workflows/ci.yml"]
         run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
         self.assertTrue(run_ci)
+        paths = [".github/workflows/build_package.yml"]
+        run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
+        self.assertTrue(run_ci)
+        paths = [".github/workflows/test_some_subproject.yml"]
+        run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
+        self.assertTrue(run_ci)
 
     def test_dont_run_ci_if_unrelated_workflow_file_edited(self):
         paths = [".github/workflows/publish_pytorch_dev_docker.yml"]


### PR DESCRIPTION
Context: https://github.com/ROCm/TheRock/issues/199.

Without this, I believe changes to e.g. [`ci_linux.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/ci_linux.yml) or [`test_rocblas.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/test_rocblas.yml) would skip the regular build/test CI.