### PR TITLE
[ci] Skip CI workflows if only external-builds/ is changed.

### DIFF
--- a/build_tools/github_action/configure_ci.py
+++ b/build_tools/github_action/configure_ci.py
@@ -112,6 +112,18 @@ SKIPPABLE_PATH_PATTERNS = [
     "*.md",
     "*.pre-commit-config.*",
     "*LICENSE",
+    # Changes to 'external-builds/' (e.g. PyTorch) do not affect "CI" workflows.
+    # At time of writing, workflows run in this sequence:
+    #   `ci.yml`
+    #   `ci_linux.yml`
+    #   `build_linux_packages.yml`
+    #   `test_linux_packages.yml`
+    #   `test_[rocm subproject].yml`
+    # If we add external-builds tests there, we can revisit this, maybe leaning
+    # on options like LINUX_USE_PREBUILT_ARTIFACTS or sufficient caching to keep
+    # workflows efficient when only nodes closer to the edges of the build graph
+    # are changed.
+    "external-builds/*",
 ]
 
 

--- a/build_tools/github_action/configure_ci_test.py
+++ b/build_tools/github_action/configure_ci_test.py
@@ -13,6 +13,11 @@ class ConfigureCITest(TestCase):
         run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
         self.assertFalse(run_ci)
 
+    def test_dont_run_ci_if_only_external_builds_edited(self):
+        paths = ["external-builds/pytorch/CMakeLists.txt"]
+        run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
+        self.assertFalse(run_ci)
+
     def test_run_ci_if_related_workflow_file_edited(self):
         paths = [".github/workflows/ci.yml"]
         run_ci = configure_ci.should_ci_run_given_modified_paths(paths)


### PR DESCRIPTION
Context: https://github.com/ROCm/TheRock/issues/199.

Currently, changes to PyTorch patches like https://github.com/ROCm/TheRock/pull/606 run all of our CI workflows, despite having no effect on them<sup>1</sup>. We may expand the scope of these workflows, but we should be mindful of the full build graph until we have sufficient caching and incremental build support working well.

[<sup>1</sup>]: PyTorch is currently covered by [`publish_pytorch_dev_docker.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/publish_pytorch_dev_docker.yml) -> [`verify_docker_image.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/verify_docker_image.yml), with the dockerfile installing from the latest release of TheRock, rather than build from source. Do note however: that workflow has been [failing for weeks](https://github.com/ROCm/TheRock/actions/workflows/publish_pytorch_dev_docker.yml?query=branch%3Amain). We will need to give that more attention soon, with from-source builds all the way up to frameworks like PyTorch running on individual commits, especially as Windows catches up on PyTorch support (https://github.com/ROCm/TheRock/issues/589).