### PR TITLE
Explicitly grant permissions

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -17,6 +17,10 @@ on:
       amdgpu_families:
         type: string
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build_linux_packages:
     name: Build Linux Packages

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -24,6 +24,10 @@ on:
         type: string
         default: "-DBUILD_TESTING=ON"
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build_windows_packages:
     name: Build Windows Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
       artifact_run_id: ${{ inputs.artifact_run_id }}
       linux_use_prebuilt_artifacts: ${{ inputs.linux_use_prebuilt_artifacts == true && 'true' || 'false' }}
     permissions:
+      contents: read
       id-token: write
 
   windows_build_and_test:
@@ -97,6 +98,7 @@ jobs:
       amdgpu_families: ${{ matrix.families.family }}
       windows_use_prebuilt_artifacts: ${{ inputs.windows_use_prebuilt_artifacts == true && 'true' || 'false' }}
     permissions:
+      contents: read
       id-token: write
 
   # build_python_packages:

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -12,6 +12,9 @@ on:
       linux_use_prebuilt_artifacts:
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build_linux_packages:
     name: Build
@@ -20,6 +23,7 @@ jobs:
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
     permissions:
+      contents: read
       id-token: write
 
   test_linux_packages:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -15,6 +15,9 @@ on:
         type: string
         default: "-DBUILD_TESTING=ON"
 
+permissions:
+  contents: read
+
 jobs:
   build_windows_packages:
     name: Build Windows Packages
@@ -24,4 +27,5 @@ jobs:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       extra_cmake_options: ${{ inputs.extra_cmake_options }}
     permissions:
+      contents: read
       id-token: write


### PR DESCRIPTION
Workflows fail if manually dispatched as default permissions get granted in that case and `id-token` permissions are not passed from a calling workfow.