### PR TITLE
Create release index for Python packages

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Trigger testing nightly tarball
         if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}
-        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc #1.2.4
+        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
         with:
           workflow: test_release_packages.yml
           inputs: '{ "version": "${{ needs.setup_metadata.outputs.version }}", "tag": "nightly-tarball", "file_name": "${{ env.FILE_NAME }}", "target": "${{ matrix.target_bundle.amdgpu_family }}" }'

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -189,7 +189,7 @@ jobs:
             --subdir=${{ matrix.target_bundle.amdgpu_family }} \
             --output=${{ env.OUTPUT_DIR }}/packages/dist/index.html
           # TODO: Integrate upload into `generate_release_index.py`
-          aws s3 cp ${{ env.OUTPUT_DIR }}/packages/dist/index.html s3://therock-${{ env.RELEASE_TYPE }}-python/${{ matrix.target_bundle.amdgpu_family }}/
+          aws s3 cp ${{ env.OUTPUT_DIR }}/packages/dist/index.html s3://${{ env.S3_PYTHON }}/${{ matrix.target_bundle.amdgpu_family }}/
 
       - name: Trigger testing nightly tarball
         if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -90,6 +90,8 @@ jobs:
       DIST_ARCHIVE: "${{ github.workspace }}/output/therock-dist-linux-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
       FILE_NAME: "therock-dist-linux-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
       RELEASE_TYPE: "${{ needs.setup_metadata.outputs.release_type }}"
+      S3_TARBALL: "therock-${{ needs.setup_metadata.outputs.release_type }}-tarball/"
+      S3_PYTHON: "therock-${{ needs.setup_metadata.outputs.release_type }}-python/"
     strategy:
       fail-fast: false
       matrix:
@@ -164,8 +166,8 @@ jobs:
       - name: Upload Releases to S3
         if: ${{ github.repository_owner == 'ROCm' }}
         run: |
-          aws s3 cp ${{ env.DIST_ARCHIVE }} s3://therock-${{ env.RELEASE_TYPE }}-tarball/
-          aws s3 cp ${{ env.OUTPUT_DIR }}/packages/dist/ s3://therock-${{ env.RELEASE_TYPE }}-python/${{ matrix.target_bundle.amdgpu_family }}/ \
+          aws s3 cp ${{ env.DIST_ARCHIVE }} s3://${{ env.S3_TARBALL }}
+          aws s3 cp ${{ env.OUTPUT_DIR }}/packages/dist/ s3://${{ env.S3_PYTHON }}/${{ matrix.target_bundle.amdgpu_family }}/ \
           --recursive --no-follow-symlinks \
           --exclude "*" \
           --include "*.whl" \
@@ -182,7 +184,7 @@ jobs:
         run: |
           pip install boto3
           ./build_tools/packaging/python/generate_release_index.py \
-            --bucket=therock-${{ env.RELEASE_TYPE }}-python \
+            --bucket=${{ env.S3_PYTHON }} \
             --endpoint=s3.us-east-2.amazonaws.com \
             --subdir=${{ matrix.target_bundle.amdgpu_family }} \
             --output=${{ env.OUTPUT_DIR }}/packages/dist/index.html

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -164,13 +164,30 @@ jobs:
       - name: Upload Releases to S3
         if: ${{ github.repository_owner == 'ROCm' }}
         run: |
-          # TODO: Append uploaded files to an index
           aws s3 cp ${{ env.DIST_ARCHIVE }} s3://therock-${{ env.RELEASE_TYPE }}-tarball/
           aws s3 cp ${{ env.OUTPUT_DIR }}/packages/dist/ s3://therock-${{ env.RELEASE_TYPE }}-python/${{ matrix.target_bundle.amdgpu_family }}/ \
           --recursive --no-follow-symlinks \
           --exclude "*" \
           --include "*.whl" \
           --include "*.tar.gz"
+
+      - name: Setup Python
+        if: ${{ github.repository_owner == 'ROCm' }}
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: 3.12
+
+      - name: (Re-)Generate Python package release index
+        if: ${{ github.repository_owner == 'ROCm' }}
+        run: |
+          pip install boto3
+          ./build_tools/packaging/python/generate_release_index.py \
+            --bucket=therock-${{ env.RELEASE_TYPE }}-python \
+            --endpoint=s3.us-east-2.amazonaws.com \
+            --subdir=${{ matrix.target_bundle.amdgpu_family }} \
+            --output=${{ env.OUTPUT_DIR }}/packages/dist/index.html
+          # TODO: Integrate upload into `generate_release_index.py`
+          aws s3 cp ${{ env.OUTPUT_DIR }}/packages/dist/index.html s3://therock-${{ env.RELEASE_TYPE }}-python/${{ matrix.target_bundle.amdgpu_family }}/
 
       - name: Trigger testing nightly tarball
         if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}

--- a/build_tools/packaging/python/generate_release_index.py
+++ b/build_tools/packaging/python/generate_release_index.py
@@ -53,7 +53,8 @@ def get_objects(bucket_name: str, subdir: str):
     all_objects = bucket.objects.filter(Prefix=subdir)
 
     objects = [obj.key.split(subdir + "/")[1] for obj in all_objects]
-    objects.remove("index.html")
+    if "index.html" in objects:
+        objects.remove("index.html")
 
     return objects
 

--- a/build_tools/packaging/python/generate_release_index.py
+++ b/build_tools/packaging/python/generate_release_index.py
@@ -58,21 +58,26 @@ def get_objects(bucket_name: str, subdir: str):
     return objects
 
 
-def add_releases(objects: list, base_url: str, file: io.TextIOWrapper):
+def add_releases(objects: list, base_url: str, subdir: str, file: io.TextIOWrapper):
 
     file.write(
-        f'    <h2>Packages at <a href="https://{base_url}">{base_url}</a></h2>\n'
+        f'    <h2> <a href="https://github.com/ROCm/TheRock">ROCm/TheRock</a> {subdir} packages</h2>\n'
     )
 
     for obj in objects:
-        url = html.escape(f"https://{base_url}/{obj}")
+        url = html.escape(f"{base_url}/{obj}")
         name = html.escape(obj)
         file.write(f"    <a href={url}>{name}</a><br>\n")
+
+    file.write(
+        "    <br><hr>\n"
+        f'    This file was auto-generated with <a href="https://github.com/ROCm/TheRock/blob/main/build_tools/packaging/python/generate_release_index.py">generate_release_index.py</a>.\n'
+    )
 
 
 def main(args):
     objects = get_objects(args.bucket, args.subdir)
-    url = f"{args.bucket}.{args.endpoint}/{args.subdir}"
+    url = f"https://{args.bucket}.{args.endpoint}/{args.subdir}"
 
     with sys.stdout if args.output == "-" else open(args.output, "w") as f:
         f.write(
@@ -104,7 +109,7 @@ def main(args):
             """
             )
         )
-        add_releases(objects, url, f)
+        add_releases(objects, url, args.subdir, f)
         f.write(
             textwrap.dedent(
                 """\

--- a/build_tools/packaging/python/generate_release_index.py
+++ b/build_tools/packaging/python/generate_release_index.py
@@ -10,6 +10,11 @@ Sample usage:
         --subdir=gfx110X-dgpu \
         --output=index.html
     ```
+
+S3 buckets in `us-east-2` currently used are:
+
+    * `therock-dev-python`
+    * `therock-nightly-python`
 """
 
 import argparse

--- a/build_tools/packaging/python/generate_release_index.py
+++ b/build_tools/packaging/python/generate_release_index.py
@@ -30,7 +30,7 @@ def parse_arguments():
     p.add_argument(
         "--bucket",
         required=True,
-        help="S3 bucket which in which the subdirectory is indexed",
+        help="S3 bucket in which the subdirectory is indexed",
     )
     p.add_argument(
         "--endpoint",

--- a/build_tools/packaging/python/generate_release_index.py
+++ b/build_tools/packaging/python/generate_release_index.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+"""Creates an HTML page for releases for `pip install --find-links` from a subdirectory in an S3 bucket.
+
+Sample usage:
+
+    ```bash
+    ./build_tools/packaging/python/generate_release_index.py \
+        --bucket=therock-dev-python \
+        --endpoint=s3.us-east-2.amazonaws.com \
+        --subdir=gfx110X-dgpu \
+        --output=index.html
+    ```
+"""
+
+import argparse
+import boto3
+import html
+import io
+import sys
+import textwrap
+
+
+def parse_arguments():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--bucket",
+        required=True,
+        help="S3 bucket name",
+    )
+    p.add_argument(
+        "--endpoint",
+        default="s3.us-east-2.amazonaws.com",
+        help="S3 endpoint",
+    )
+    p.add_argument(
+        "--subdir",
+        "--subdirectory",
+        required=True,
+        help="Subdirectory in S3 bucket",
+    )
+    p.add_argument(
+        "--output",
+        default="-",
+        help="The file to write the HTML to or '-' for stdout (the default)",
+    )
+    return p.parse_args()
+
+
+def get_objects(bucket_name: str, subdir: str):
+    s3 = boto3.resource("s3")
+    bucket = s3.Bucket(bucket_name)
+
+    all_objects = bucket.objects.filter(Prefix=subdir)
+
+    objects = [obj.key.split(subdir + "/")[1] for obj in all_objects]
+    objects.remove("index.html")
+
+    return objects
+
+
+def add_releases(objects: list, base_url: str, file: io.TextIOWrapper):
+
+    file.write(
+        f'    <h2>Packages at <a href="https://{base_url}">{base_url}</a></h2>\n'
+    )
+
+    for obj in objects:
+        url = html.escape(f"https://{base_url}/{obj}")
+        name = html.escape(obj)
+        file.write(f"    <a href={url}>{name}</a><br>\n")
+
+
+def main(args):
+    objects = get_objects(args.bucket, args.subdir)
+    url = f"{args.bucket}.{args.endpoint}/{args.subdir}"
+
+    with sys.stdout if args.output == "-" else open(args.output, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """\
+            <!DOCTYPE html>
+            <html>
+              <head>
+                <meta charset="utf-8">
+                <style>
+                  * { padding: 0; margin: 10; }
+                  body {
+                      font-family: sans-serif;
+                      text-rendering: optimizespeed;
+                      background-color: #ffffff;
+                  }
+                  a {
+                      color: #006ed3;
+                      text-decoration: none;
+                  }
+                  a:hover {
+                      color: #319cff;
+                      text-decoration: underline;
+                  }
+                </style>
+              </head>
+
+              <body>
+            """
+            )
+        )
+        add_releases(objects, url, f)
+        f.write(
+            textwrap.dedent(
+                """\
+      </body>
+    </html>
+    """
+            )
+        )
+
+
+if __name__ == "__main__":
+    main(parse_arguments())

--- a/build_tools/packaging/python/generate_release_index.py
+++ b/build_tools/packaging/python/generate_release_index.py
@@ -30,18 +30,18 @@ def parse_arguments():
     p.add_argument(
         "--bucket",
         required=True,
-        help="S3 bucket name",
+        help="S3 bucket which in which the subdirectory is indexed",
     )
     p.add_argument(
         "--endpoint",
         default="s3.us-east-2.amazonaws.com",
-        help="S3 endpoint",
+        help="S3 endpoint used to form the URL",
     )
     p.add_argument(
         "--subdir",
         "--subdirectory",
         required=True,
-        help="Subdirectory in S3 bucket",
+        help="Subdirectory in S3 bucket which is indexed",
     )
     p.add_argument(
         "--output",


### PR DESCRIPTION
This adds `generate_release_index.py` to create a release index HTML file that lists all wheels and sdist packages in the subdirectory of a specific bucket to enable installing packages via `pip install -f`.