### PR TITLE
Adjust GitHub token permissions

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -19,12 +19,13 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   build_linux_packages:
     name: Build Linux Packages
     runs-on: azure-linux-scale-rocm
+    permissions:
+      id-token: write
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64:main
     strategy:

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -26,12 +26,13 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   build_windows_packages:
     name: Build Windows Packages
     runs-on: azure-windows-scale-rocm
+    permissions:
+      id-token: write
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test_hipblaslt.yml
+++ b/.github/workflows/test_hipblaslt.yml
@@ -23,6 +23,9 @@ on:
     branches:
       - ADHOCBUILD
 
+permissions:
+  contents: read
+
 jobs:
   test_hipblaslt:
     name: "hipBLASLt math-lib test"

--- a/.github/workflows/test_hipcub.yml
+++ b/.github/workflows/test_hipcub.yml
@@ -27,6 +27,9 @@ on:
     branches:
       - ADHOCBUILD
 
+permissions:
+  contents: read
+
 jobs:
   test_hipcub:
     name: "hipCUB math-lib test"

--- a/.github/workflows/test_release_packages.yml
+++ b/.github/workflows/test_release_packages.yml
@@ -12,6 +12,9 @@ on:
       target:
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   generate_target_to_run:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test_rocblas.yml
+++ b/.github/workflows/test_rocblas.yml
@@ -23,6 +23,9 @@ on:
     branches:
       - ADHOCBUILD
 
+permissions:
+  contents: read
+
 jobs:
   test_rocblas:
     name: "rocBLAS math-lib test"

--- a/.github/workflows/test_rocprim.yml
+++ b/.github/workflows/test_rocprim.yml
@@ -26,6 +26,8 @@ on:
   push:
     branches:
       - ADHOCBUILD
+permissions:
+  contents: read
 
 jobs:
   test_rocprim:

--- a/.github/workflows/test_rocprim.yml
+++ b/.github/workflows/test_rocprim.yml
@@ -26,6 +26,7 @@ on:
   push:
     branches:
       - ADHOCBUILD
+
 permissions:
   contents: read
 

--- a/.github/workflows/test_rocthrust.yml
+++ b/.github/workflows/test_rocthrust.yml
@@ -27,6 +27,9 @@ on:
     branches:
       - ADHOCBUILD
 
+permissions:
+  contents: read
+
 jobs:
   test_rocthrust:
     name: "rocTHRUST math-lib test"

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -19,6 +19,9 @@ on:
     branches:
       - ADHOCBUILD
 
+permissions:
+  contents: read
+
 jobs:
   test_sanity_check:
     name: "Sanity ROCM Test"


### PR DESCRIPTION
This starts adjusting token permissions, following recommendations in [1]. With this top-level permissions are set to `contents: read` and further permissions are set at a job level only.

[1] https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions.