### PR TITLE
Refresh Windows support documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ cd TheRock
 # Init python virtual environment and install python dependencies
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-python ./build_tools/fetch_sources.py # Downloads submodules and applies patches
+
+# Download submodules and apply patches
+python ./build_tools/fetch_sources.py
 ```
 
 ### Setup - Windows 11 (VS 2022)
@@ -74,7 +76,9 @@ cd TheRock
 python -m venv .venv
 .venv\Scripts\Activate.ps1
 pip install -r requirements.txt
-python ./build_tools/fetch_sources.py  # Downloads submodules and applies patches
+
+# Download submodules and apply patches
+python ./build_tools/fetch_sources.py
 ```
 
 ### Build configuration

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -15,47 +15,47 @@ This table tracks current support status for each subproject in TheRock on
 Windows. Some subprojects may need extra patches to build within TheRock (on
 mainline, in open source, using MSVC, etc.).
 
-| Component subset | Subproject                                                                   | Supported | Notes                                         |
-| ---------------- | ---------------------------------------------------------------------------- | --------- | --------------------------------------------- |
-| base             | aux-overlay                                                                  | ✅        |                                               |
-| base             | [rocm-cmake](https://github.com/ROCm/rocm-cmake)                             | ✅        |                                               |
-| base             | [rocm-core](https://github.com/ROCm/rocm-core)                               | ✅        | No shared libraries                           |
-| base             | [rocm_smi_lib](https://github.com/ROCm/rocm_smi_lib)                         | ❌        | Unsupported                                   |
-| base             | [rocprofiler-register](https://github.com/ROCm/rocprofiler-register)         | ❌        | Unsupported                                   |
-| base             | [rocm-half](https://github.com/ROCm/half)                                    | ✅        |                                               |
-|                  |                                                                              |           |                                               |
-| compiler         | [amd-llvm](https://github.com/ROCm/llvm-project)                             | ✅        | No shared libraries, limited runtimes         |
-| compiler         | [amd-comgr](https://github.com/ROCm/llvm-project/tree/amd-staging/amd/comgr) | ✅        | No shared libraries                           |
-| compiler         | [hipcc](https://github.com/ROCm/llvm-project/tree/amd-staging/amd/hipcc)     | ✅        |                                               |
-| compiler         | [hipify](https://github.com/ROCm/HIPIFY)                                     | ✅        | Patched for Ninja                             |
-|                  |                                                                              |           |                                               |
-| core             | [ROCR-Runtime](https://github.com/ROCm/ROCR-Runtime)                         | ❌        | Unsupported                                   |
-| core             | [rocminfo](https://github.com/ROCm/rocminfo)                                 | ❌        | Unsupported                                   |
-| core             | [clr](https://github.com/ROCm/clr)                                           | ⭕        | Needs a folder with prebuilt static libraries |
-|                  |                                                                              |           |                                               |
-| profiler         | [rocprofiler-sdk](https://github.com/ROCm/rocprofiler-sdk)                   | ❌        | Unsupported                                   |
-|                  |                                                                              |           |                                               |
-| comm-libs        | [rccl](https://github.com/ROCm/rccl)                                         | ❌        | Unsupported                                   |
-|                  |                                                                              |           |                                               |
-| math-libs        | [rocRAND](https://github.com/ROCm/rocRAND)                                   | ✅        |                                               |
-| math-libs        | [hipRAND](https://github.com/ROCm/hipRAND)                                   | ✅        |                                               |
-| math-libs        | [rocPRIM](https://github.com/ROCm/rocPRIM)                                   | ✅        |                                               |
-| math-libs        | [hipCUB](https://github.com/ROCm/hipCUB)                                     | ✅        |                                               |
-| math-libs        | [rocThrust](https://github.com/ROCm/rocThrust)                               | ✅        |                                               |
-| math-libs        | [rocFFT](https://github.com/ROCm/rocFFT)                                     | ✅        | No shared libraries                           |
-| math-libs        | [hipFFT](https://github.com/ROCm/hipFFT)                                     | ✅        | No shared libraries                           |
-| math-libs (blas) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ✅        |                                               |
-| math-libs (blas) | [hipBLASLt](https://github.com/ROCm/hipBLASLt)                               | ✅        |                                               |
-| math-libs (blas) | [rocBLAS](https://github.com/ROCm/rocBLAS)                                   | ✅        | Running tests needs PyYAML and a dll copied   |
-| math-libs (blas) | [rocSPARSE](https://github.com/ROCm/rocSPARSE)                               | ✅        | Tests need rocblas.dll and can't find files   |
-| math-libs (blas) | [hipSPARSE](https://github.com/ROCm/hipSPARSE)                               | ✅        | Same as rocSPARSE + also needs rocsparse.dll  |
-| math-libs (blas) | [rocSOLVER](https://github.com/ROCm/rocSOLVER)                               | ✅        |                                               |
-| math-libs (blas) | [hipSOLVER](https://github.com/ROCm/hipSOLVER)                               | ✅        | Tests need dlls                               |
-| math-libs (blas) | [hipBLAS](https://github.com/ROCm/hipBLAS)                                   | ✅        | Tests need dlls                               |
-|                  |                                                                              |           |                                               |
-| ml-libs          | [MIOpen](https://github.com/ROCm/MIOpen)                                     | ✅        |                                               |
+| Component subset | Subproject                                                                   | Supported | Notes                                                                                |
+| ---------------- | ---------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------ |
+| base             | aux-overlay                                                                  | ✅        |                                                                                      |
+| base             | [rocm-cmake](https://github.com/ROCm/rocm-cmake)                             | ✅        |                                                                                      |
+| base             | [rocm-core](https://github.com/ROCm/rocm-core)                               | ✅        | No shared libraries                                                                  |
+| base             | [rocm_smi_lib](https://github.com/ROCm/rocm_smi_lib)                         | ❌        | Unsupported                                                                          |
+| base             | [rocprofiler-register](https://github.com/ROCm/rocprofiler-register)         | ❌        | Unsupported                                                                          |
+| base             | [rocm-half](https://github.com/ROCm/half)                                    | ✅        |                                                                                      |
+|                  |                                                                              |           |                                                                                      |
+| compiler         | [amd-llvm](https://github.com/ROCm/llvm-project)                             | ✅        | No shared libraries, limited runtimes                                                |
+| compiler         | [amd-comgr](https://github.com/ROCm/llvm-project/tree/amd-staging/amd/comgr) | ✅        | No shared libraries                                                                  |
+| compiler         | [hipcc](https://github.com/ROCm/llvm-project/tree/amd-staging/amd/hipcc)     | ✅        | Unable to find files at runtime ([#410](https://github.com/ROCm/TheRock/issues/410)) |
+| compiler         | [hipify](https://github.com/ROCm/HIPIFY)                                     | ✅        | Patched for Ninja                                                                    |
+|                  |                                                                              |           |                                                                                      |
+| core             | [ROCR-Runtime](https://github.com/ROCm/ROCR-Runtime)                         | ❌        | Unsupported                                                                          |
+| core             | [rocminfo](https://github.com/ROCm/rocminfo)                                 | ❌        | Unsupported                                                                          |
+| core             | [clr](https://github.com/ROCm/clr)                                           | 🟡        | Needs a folder with prebuilt static libraries                                        |
+|                  |                                                                              |           |                                                                                      |
+| profiler         | [rocprofiler-sdk](https://github.com/ROCm/rocprofiler-sdk)                   | ❌        | Unsupported                                                                          |
+|                  |                                                                              |           |                                                                                      |
+| comm-libs        | [rccl](https://github.com/ROCm/rccl)                                         | ❌        | Unsupported                                                                          |
+|                  |                                                                              |           |                                                                                      |
+| math-libs        | [rocRAND](https://github.com/ROCm/rocRAND)                                   | ✅        |                                                                                      |
+| math-libs        | [hipRAND](https://github.com/ROCm/hipRAND)                                   | ✅        |                                                                                      |
+| math-libs        | [rocPRIM](https://github.com/ROCm/rocPRIM)                                   | ✅        |                                                                                      |
+| math-libs        | [hipCUB](https://github.com/ROCm/hipCUB)                                     | ✅        |                                                                                      |
+| math-libs        | [rocThrust](https://github.com/ROCm/rocThrust)                               | ✅        |                                                                                      |
+| math-libs        | [rocFFT](https://github.com/ROCm/rocFFT)                                     | ✅        | No shared libraries                                                                  |
+| math-libs        | [hipFFT](https://github.com/ROCm/hipFFT)                                     | ✅        | No shared libraries                                                                  |
+| math-libs (blas) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ✅        |                                                                                      |
+| math-libs (blas) | [hipBLASLt](https://github.com/ROCm/hipBLASLt)                               | ✅        |                                                                                      |
+| math-libs (blas) | [rocBLAS](https://github.com/ROCm/rocBLAS)                                   | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
+| math-libs (blas) | [rocSPARSE](https://github.com/ROCm/rocSPARSE)                               | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
+| math-libs (blas) | [hipSPARSE](https://github.com/ROCm/hipSPARSE)                               | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
+| math-libs (blas) | [rocSOLVER](https://github.com/ROCm/rocSOLVER)                               | ✅        |                                                                                      |
+| math-libs (blas) | [hipSOLVER](https://github.com/ROCm/hipSOLVER)                               | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
+| math-libs (blas) | [hipBLAS](https://github.com/ROCm/hipBLAS)                                   | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
+|                  |                                                                              |           |                                                                                      |
+| ml-libs          | [MIOpen](https://github.com/ROCm/MIOpen)                                     | ✅        |                                                                                      |
 
-## Building from source
+## Building TheRock from source
 
 These instructions mostly mirror the instructions in the root
 [README.md](../../README.md), with some extra Windows-specific callouts.
@@ -64,54 +64,76 @@ These instructions mostly mirror the instructions in the root
 
 #### Set up your system
 
-- Choose your shell between cmd, powershell, and git bash as well as your
-  terminal application. Some developers report good experiences with
-  [Windows Terminal](https://learn.microsoft.com/en-us/windows/terminal/)
-  and [Cmder](https://cmder.app/).
+- You will need a powerful system with sufficient RAM (16GB+),
+  CPU (8+ cores), and storage (200GB+) for a full source build.
+  Partial source builds bootstrapped from prebuilt binaries are on our roadmap
+  to enable.
 
-- You will need at least 200GB of storage space for the build. More is
-  recommended.
+  > [!NOTE]
+  > To set expectations, on powerful build servers, the full source build can
+  > still take over an hour.
+
+  > [!NOTE]
+  > The Windows build uses
+  > [hard links](https://learn.microsoft.com/en-us/windows/win32/fileio/hard-links-and-junctions)
+  > to save space, but storage sizes do not often account for this savings.
+  > Reported size used and actual size used may differ substantially.
+
+- Long path support is required. As needed, enable long paths for your system:
+
+  - https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#registry-setting-to-enable-long-paths
 
 - A Dev Drive is recommended, due to how many source and build files are used.
   See the
   [Set up a Dev Drive on Windows 11](https://learn.microsoft.com/en-us/windows/dev-drive/)
   article for setup instructions.
 
-- Symlink support is recommended.
-
-  Test if symlinks work from cmd:
-
-  ```cmd
-  echo "Test 1 2 3" > test.txt
-  mklink link_from_cmd.txt test.txt
-  ```
-
-  Test if symlinks work from Powershell:
-
-  ```powershell
-  echo "Test 1 2 3" > test.txt
-  New-Item -Path link_from_powershell.txt -ItemType SymbolicLink -Value test.txt
-  ```
-
-  If symlink support is not enabled, enable developer mode and/or grant your
+- Symlink support is recommended. If symlink support is not enabled, enable
+  developer mode and/or grant your
   account the "Create symbolic links" permission. These resources may help:
 
   - https://portal.perforce.com/s/article/3472
   - https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/create-symbolic-links
   - https://stackoverflow.com/a/59761201
 
+- We recommend cmd or git bash over PowerShell. Some developers also report
+  good experiences with
+  [Windows Terminal](https://learn.microsoft.com/en-us/windows/terminal/)
+  and [Cmder](https://cmder.app/).
+
 #### Install tools
 
-You will need:
+> [!TIP]
+> These tools are available via package managers like
+> [chocolatey](https://chocolatey.org/):
+>
+> ```bash
+> choco install visualstudio2022buildtools -y --params "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.CMake.Project --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.Windows11SDK.22621"
+> choco install git.install -y --params "'/GitAndUnixToolsOnPath'"
+> choco install cmake --version=3.31.0 -y
+> choco install ninja -y
+> choco install ccache -y
+> choco install python -y
+> choco install strawberryperl -y
+> ```
 
-- Git: https://git-scm.com/downloads, with suggested config settings:
+If you prefer to install tools manually, you will need:
 
-  ```bash
-  git config --global core.symlinks true
-  git config --global core.longpaths true
-  ```
+- The MSVC compiler from https://visualstudio.microsoft.com/downloads/
+  (Using either "Visual Studio" or "Build Tools for Visual Studio"),
+  including these components:
 
-- CMake: https://cmake.org/download/
+  - MSVC
+  - C++ CMake tools for Windows
+  - C++ ATL
+  - C++ AddressSanitizer (optional)
+
+- Git: https://git-scm.com/downloads
+
+  - With "Use Git and optional Unix tools from the Windows Command Prompt" as certain build scripts use Bash.
+
+- CMake: https://cmake.org/download/, version < 4.0.0
+  (see [Issue#318](https://github.com/ROCm/TheRock/issues/318))
 
 - Ninja: https://ninja-build.org/
 
@@ -120,59 +142,50 @@ You will need:
 
 - Python: https://www.python.org/downloads/ (3.11+ recommended)
 
-- The MSVC compiler from https://visualstudio.microsoft.com/downloads/
-  (typically from either Visual Studio or the Build Tools for Visual Studio),
-  including these components:
+- Strawberry Perl, which comes with gfortran: https://strawberryperl.com/
 
-  - MSVC
-  - C++ CMake tools for Windows
-  - C++ ATL
-  - C++ AddressSanitizer (optional)
+#### Important tool settings
 
-  After installing MSVC, use it in your build environment. If you build from an
-  editor like VSCode, CMake can discover the compiler among other "kits". If you
-  use the command line, see
-  https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170.
-  (typically run the appropriate `vcvarsall.bat`)
-
-- Strawberry Perl, which comes with gfortran: https://strawberryperl.com/.
-
-> [!TIP]
-> Some of these tools are available via package managers like
-> https://github.com/chocolatey/choco
+> [!IMPORTANT]
+> Git should be configured with support for symlinks and long paths:
 >
+> ```bash
+> git config --global core.symlinks true
+> git config --global core.longpaths true
 > ```
-> choco install git
-> choco install cmake
-> choco install ninja
-> choco install ccache
-> choco install sccache
-> choco install python
-> ```
+
+> [!IMPORTANT]
+> After installing MSVC, use its 64 bit tools in your build environment.
+>
+> - If you use the command line, see
+>   [Use the Microsoft C++ toolset from the command line](https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170).
+>   Typically this means either `Start > x64 Native Tools Command Prompt for VS 2022` or
+>   running `vcvars64.bat` in an existing shell.
+> - If you build from an editor like VSCode, CMake can discover the compiler
+>   among other "kits".
+> - You can also tell CMake to use MSVC's tools explicitly with
+>   `-DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_LINKER=link.exe`
 
 ### Clone and fetch sources
 
 ```bash
-git clone https://github.com/ROCm/TheRock.git
-
 # Clone interop library from https://github.com/nod-ai/amdgpu-windows-interop
 # for CLR (the "HIP runtime") on Windows. The path used can also be configured
 # using the `THEROCK_AMDGPU_WINDOWS_INTEROP_DIR` CMake variable.
 git clone https://github.com/nod-ai/amdgpu-windows-interop.git
 
+# Clone the repository
+git clone https://github.com/ROCm/TheRock.git
 cd TheRock
-python ./build_tools/fetch_sources.py
-```
 
-### Install Python dependencies
-
-```bash
+# Init python virtual environment and install python dependencies
 python -m venv .venv
-.venv\Scripts\Activate.ps1
+.venv\Scripts\Activate.bat
 pip install -r requirements.txt
+python ./build_tools/fetch_sources.py  # Downloads submodules and applies patches
 ```
 
-### Configure
+### Build configuration
 
 Unsupported subprojects like RCCL are automatically disabled on Windows. See
 the [instructions in the root README](../../README.md#configuration) for other
@@ -197,18 +210,88 @@ cmake -B build -GNinja . -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu
 > instructs CMake to compile with `/Z7` or equivalent, which is supported by
 > ccache.
 
-Ensure that MSVC is used by looking for lines like these in the logs:
+> [!TIP]
+> Ensure that MSVC is used by looking for lines like these in the logs:
+>
+> ```text
+> -- The C compiler identification is MSVC 19.42.34436.0
+> -- The CXX compiler identification is MSVC 19.42.34436.0
+> ```
+>
+> If you see some other compiler there, refer to the MSVC setup instructions up
+> in [Important tool settings](#important-tool-settings).
 
-```text
--- The C compiler identification is MSVC 19.42.34436.0
--- The CXX compiler identification is MSVC 19.42.34436.0
-```
-
-### Build
+### CMake build usage
 
 ```bash
-cmake --build build
+cmake --build build --target therock-dist
 ```
+
+This will start building using MSVC. Once the amd-llvm subproject is built,
+subprojects like the ROCm math libraries will be compiled using `clang.exe` and
+other tools from the amd-llvm toolchain.
+
+When the build completes, you should have a build of ROCm / the HIP SDK
+in `build/dist/rocm/`. See the [Build Artifacts guide](./artifacts.md) for more
+information about the build outputs.
+
+#### Building PyTorch
+
+Once you have `build/dist/rocm`, you can follow the instructions to build
+PyTorch from source over at
+[external-builds/pytorch](../../external-builds/pytorch/README.md).
+
+### Run tests
+
+Test builds can be enabled with `-DBUILD_TESTING=ON` (the default).
+
+Some subproject tests have been validated on Windows, like rocPRIM:
+
+```bash
+ctest --test-dir build/math-libs/rocPRIM/dist/bin/rocprim --output-on-failure
+```
+
+### Build troubleshooting and known issues
+
+#### `No such file or directory: (long path to a source file)`
+
+Ensure that you have long path support enabled in git (see
+[Important tool settings](#important-tool-settings)), then re-run
+
+```bash
+python ./build_tools/fetch_sources.py
+```
+
+#### `error: directive requires gfx90a+`
+
+Errors like this indicate that the value of `-DTHEROCK_AMDGPU_FAMILIES=` or
+`-DTHEROCK_AMDGPU_TARGETS=` is currently unsupported by one or more libraries.
+
+#### `lld-link: error: duplicate symbol`
+
+Several developers have reported link errors in rocBLAS and rocSPARSE like
+
+```
+[rocSPARSE] lld-link: error: duplicate symbol: __hip_cuid_2f7b343d50a9613
+[rocSPARSE] >>> defined at library/CMakeFiles/rocsparse.dir/src/level3/csrmm/row_split/csrmm_device_row_split_256_16_8_3_4.cpp.obj
+[rocSPARSE] >>> defined at library/CMakeFiles/rocsparse.dir/src/level3/csrmm/row_split/csrmm_device_row_split_256_16_8_7_4.cpp.obj
+```
+
+```
+[rocBLAS] lld-link: error: duplicate symbol: rocblas_stbsv_batched
+[rocBLAS] >>> defined at library/src/CMakeFiles/rocblas.dir/blas2/rocblas_tbsv_batched.cpp.obj
+[rocBLAS] >>> defined at library/src/CMakeFiles/rocblas.dir/handle.cpp.obj
+[rocBLAS]
+[rocBLAS] lld-link: error: duplicate symbol: rocblas_dtbsv_batched
+[rocBLAS] >>> defined at library/src/CMakeFiles/rocblas.dir/blas2/rocblas_tbsv_batched.cpp.obj
+[rocBLAS] >>> defined at library/src/CMakeFiles/rocblas.dir/handle.cpp.obj
+[rocBLAS]
+[rocBLAS] lld-link: error: duplicate symbol: __hip_cuid_a201499d9a86b1da
+```
+
+These have been worked around by disabling ccache.
+
+## Other notes
 
 ### Building CLR from partial sources
 
@@ -244,14 +327,4 @@ features should be turned off:
 -DTHEROCK_ENABLE_CORE=OFF \
 -DTHEROCK_ENABLE_MATH_LIBS=OFF \
 -DTHEROCK_ENABLE_ML_LIBS=OFF \
-```
-
-### Testing
-
-Test builds can be enabled with `-DBUILD_TESTING=ON`.
-
-Some subproject tests have been validated on Windows, like rocPRIM:
-
-```bash
-ctest --test-dir build/math-libs/rocPRIM/dist/bin/rocprim --output-on-failure
 ```

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -44,14 +44,14 @@ mainline, in open source, using MSVC, etc.).
 | math-libs        | [rocThrust](https://github.com/ROCm/rocThrust)                               | ✅        |                                                                                      |
 | math-libs        | [rocFFT](https://github.com/ROCm/rocFFT)                                     | ✅        | No shared libraries                                                                  |
 | math-libs        | [hipFFT](https://github.com/ROCm/hipFFT)                                     | ✅        | No shared libraries                                                                  |
-| math-libs (blas) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ✅        |                                                                                      |
-| math-libs (blas) | [hipBLASLt](https://github.com/ROCm/hipBLASLt)                               | ✅        |                                                                                      |
-| math-libs (blas) | [rocBLAS](https://github.com/ROCm/rocBLAS)                                   | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
-| math-libs (blas) | [rocSPARSE](https://github.com/ROCm/rocSPARSE)                               | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
-| math-libs (blas) | [hipSPARSE](https://github.com/ROCm/hipSPARSE)                               | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
-| math-libs (blas) | [rocSOLVER](https://github.com/ROCm/rocSOLVER)                               | ✅        |                                                                                      |
-| math-libs (blas) | [hipSOLVER](https://github.com/ROCm/hipSOLVER)                               | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
-| math-libs (blas) | [hipBLAS](https://github.com/ROCm/hipBLAS)                                   | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
+| math-libs (BLAS) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ✅        |                                                                                      |
+| math-libs (BLAS) | [hipBLASLt](https://github.com/ROCm/hipBLASLt)                               | ✅        |                                                                                      |
+| math-libs (BLAS) | [rocBLAS](https://github.com/ROCm/rocBLAS)                                   | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
+| math-libs (BLAS) | [rocSPARSE](https://github.com/ROCm/rocSPARSE)                               | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
+| math-libs (BLAS) | [hipSPARSE](https://github.com/ROCm/hipSPARSE)                               | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
+| math-libs (BLAS) | [rocSOLVER](https://github.com/ROCm/rocSOLVER)                               | ✅        |                                                                                      |
+| math-libs (BLAS) | [hipSOLVER](https://github.com/ROCm/hipSOLVER)                               | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
+| math-libs (BLAS) | [hipBLAS](https://github.com/ROCm/hipBLAS)                                   | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
 |                  |                                                                              |           |                                                                                      |
 | ml-libs          | [MIOpen](https://github.com/ROCm/MIOpen)                                     | ✅        |                                                                                      |
 

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -182,7 +182,9 @@ cd TheRock
 python -m venv .venv
 .venv\Scripts\Activate.bat
 pip install -r requirements.txt
-python ./build_tools/fetch_sources.py  # Downloads submodules and applies patches
+
+# Download submodules and apply patches
+python ./build_tools/fetch_sources.py
 ```
 
 ### Build configuration
@@ -255,12 +257,16 @@ ctest --test-dir build/math-libs/rocPRIM/dist/bin/rocprim --output-on-failure
 
 #### `No such file or directory: (long path to a source file)`
 
-Ensure that you have long path support enabled in git (see
+If the build looks for a source file with a long path that does not exist,
+ensure that you have long path support enabled in git (see
 [Important tool settings](#important-tool-settings)), then re-run
 
 ```bash
 python ./build_tools/fetch_sources.py
 ```
+
+Once the git operations have run with the new setting, confirm that the missing
+files now exist.
 
 #### `error: directive requires gfx90a+`
 


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/36. Closes https://github.com/ROCm/TheRock/pull/395.

This incorporates feedback from multiple developers and testers, hoping to provide enough context for self-service debugging while steering more users towards the happy path (if one even exists) on Windows.

* Clarify support status of each subproject with more links to known issues
* Reorganize "system setup" section to highlight requirements vs recommendations
* Reorganize "Install tools" section to suggest `choco` commands for all installs _then_ explain tools individually
* Move post-install instructions to a new "Important tool settings" section
* Elaborate on MSVC environment init
* Recommend against PowerShell
* Add more information about what "building" does, then flow into "Building PyTorch" or "Run tests"
* Add new "Build troubleshooting and known issues" section
* Keep "Building CLR from partial sources" at the bottom in a new "Other notes" section