### PR TITLE
[torch][windows] Apply fixes for PyTorch+ROCm on Windows.

### DIFF
--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
@@ -1,7 +1,7 @@
-From 4537246723a3998d218a30a04faec2f305933f94 Mon Sep 17 00:00:00 2001
+From a614a3c8bec3e8392f88b02498eaec9255baeaf0 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 17 Feb 2025 16:47:57 -0800
-Subject: [PATCH 01/12] Rework LoadHIP.cmake to be based purely on
+Subject: [PATCH 01/13] Rework LoadHIP.cmake to be based purely on
  CMAKE_PREFIX_PATH.
 
 * Eliminates dependence on `/opt/rocm` and path based heuristics.

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
@@ -1,7 +1,7 @@
-From 16b6619e27958d06fa5c6d0e7d8d629d1d1636db Mon Sep 17 00:00:00 2001
+From 747afb477a4cbed44296028530298defa6e70808 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Wed, 19 Feb 2025 17:14:59 -0800
-Subject: [PATCH 02/12] Generate composable_kernel ck/config.h as part of main
+Subject: [PATCH 02/13] Generate composable_kernel ck/config.h as part of main
  build.
 
 Without this, the ck/config.h comes from somewhere, most probably a ROCM SDK that has it installed as a sibling to the HIP headers. Not all ROCM SDKs include this, and even so, it is dangerous to have a sheared header dependency like this.

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
@@ -1,7 +1,7 @@
-From 681b27e46a32ced5a515c716c71fa3cb041a25eb Mon Sep 17 00:00:00 2001
+From 8f8d7e793521f20e5bb48ef9ee7f288c777489b1 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 31 Mar 2025 18:54:56 +0100
-Subject: [PATCH 03/12] TEMPORARY: Manually disable roctx until compatibility
+Subject: [PATCH 03/13] TEMPORARY: Manually disable roctx until compatibility
  with rocprofv3 is established.
 
 ---

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0004-enable-hipBLASLt-for-gfx-1102-1150-1151-1201.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0004-enable-hipBLASLt-for-gfx-1102-1150-1151-1201.patch
@@ -1,7 +1,7 @@
-From 4f90cc79198c4ac797b2396ad418e303a8c10478 Mon Sep 17 00:00:00 2001
+From 355f8293ed394ae9b934a65cc5cd6e9f4fd47132 Mon Sep 17 00:00:00 2001
 From: Scott Tsai <scottt.tw@gmail.com>
 Date: Sun, 23 Mar 2025 13:16:25 +0800
-Subject: [PATCH 04/12] enable hipBLASLt for gfx{1102,1150,1151,1201}
+Subject: [PATCH 04/13] enable hipBLASLt for gfx{1102,1150,1151,1201}
 
 Pytorch upstream should integrate this once the following change
 is in a ROCm release:

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0005-Add-gfx1150-gfx1151-to-hipblaslt-support-list-in-Bla.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0005-Add-gfx1150-gfx1151-to-hipblaslt-support-list-in-Bla.patch
@@ -1,7 +1,7 @@
-From 13ccab3d1bca34c59f2a43a8d88222b3c6eafbfb Mon Sep 17 00:00:00 2001
+From fc7ad160d22c2c378def8fd0fff48d60e6c12e00 Mon Sep 17 00:00:00 2001
 From: Aaryaman Vasishta <jem456.vasishta@gmail.com>
 Date: Mon, 31 Mar 2025 19:27:48 +0100
-Subject: [PATCH 05/12] Add gfx1150/gfx1151 to hipblaslt support list in
+Subject: [PATCH 05/13] Add gfx1150/gfx1151 to hipblaslt support list in
  Blas.cpp
 
 ---

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0006-Support-gfx1151-in-aotriton.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0006-Support-gfx1151-in-aotriton.patch
@@ -1,7 +1,7 @@
-From 62c274b5dfedbaa57656b619aa2773414c6e1fe8 Mon Sep 17 00:00:00 2001
+From d2b5d52a173582c0c95dbad5340e81c5b82f5f21 Mon Sep 17 00:00:00 2001
 From: Aaryaman Vasishta <jem456.vasishta@gmail.com>
 Date: Mon, 31 Mar 2025 19:27:59 +0100
-Subject: [PATCH 06/12] Support gfx1151 in aotriton
+Subject: [PATCH 06/13] Support gfx1151 in aotriton
 
 ---
  cmake/External/aotriton.cmake | 6 ++++--

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0007-link-correct-version-of-hsa-runtime-with-c10_hip.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0007-link-correct-version-of-hsa-runtime-with-c10_hip.patch
@@ -1,7 +1,7 @@
-From 5041993ecc50597d9c350f4c116087c187c7b973 Mon Sep 17 00:00:00 2001
+From 246eb780d56294066bd3fd3785759ea87a03800e Mon Sep 17 00:00:00 2001
 From: Mika Laitio <mika.laitio@amd.com>
 Date: Tue, 29 Apr 2025 01:28:14 -0700
-Subject: [PATCH 07/12] link correct version of hsa-runtime with c10_hip
+Subject: [PATCH 07/13] link correct version of hsa-runtime with c10_hip
 
 link the version of hsa-runtime64 that is searched
 by LoadHIP.cmake instead of relying to it to be linked

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0008-rocm-clang-version-check-fix.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0008-rocm-clang-version-check-fix.patch
@@ -1,7 +1,7 @@
-From db731ac5cb486e5d2c0fe24ea33a7aab2f9950da Mon Sep 17 00:00:00 2001
+From 8cd9e4fec0dbf0337723c8ca9d66846d05774fb4 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Sat, 22 Mar 2025 08:51:34 -0700
-Subject: [PATCH 08/12] rocm clang version check fix
+Subject: [PATCH 08/13] rocm clang version check fix
 
 clang in rocm sdk 6.3.3 returns 18.0git as a version.
 fix this by adding a check which converts it to

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0009-Enable-torchvision-build-with-ROCm-on-Windows-147382.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0009-Enable-torchvision-build-with-ROCm-on-Windows-147382.patch
@@ -1,7 +1,7 @@
-From bee6f3c21ebe0cf5ccd19e9df805bc3738009dc3 Mon Sep 17 00:00:00 2001
+From 6dfc91490c5b9722eb96445b970f7e6d8ad73909 Mon Sep 17 00:00:00 2001
 From: tvukovic-amd <tvukovic@amd.com>
 Date: Tue, 18 Mar 2025 23:37:01 +0000
-Subject: [PATCH 09/12] Enable torchvision build with ROCm on Windows (#147382)
+Subject: [PATCH 09/13] Enable torchvision build with ROCm on Windows (#147382)
 
 - Updated HIP flags for Windows (removed non Windows flags on Windows case, added runtime library)
 - Set hipcc call for Windows case

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0010-Include-AOTriton-dependent-sources-in-Windows-build-.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0010-Include-AOTriton-dependent-sources-in-Windows-build-.patch
@@ -1,7 +1,7 @@
-From fd6e79d96e49670b18e353cfd2354fdaca37f24f Mon Sep 17 00:00:00 2001
+From 10f0f684630ae7da46f782f8043ad907f43ceb7b Mon Sep 17 00:00:00 2001
 From: ikalinic <ilija.kalinic@amd.com>
 Date: Tue, 8 Apr 2025 16:18:11 +0000
-Subject: [PATCH 10/12] Include AOTriton dependent sources in Windows build
+Subject: [PATCH 10/13] Include AOTriton dependent sources in Windows build
  (#150521)
 
 Includes ATen native transformers hipified sources in ROCm+Windows build. This was removed due to Trinton not being available on Windows, but this causes further linker errors. Setting `USE_FLASH_ATTENTION=0` and `USE_MEM_EFF_ATTENTION=0` during the build will mitigate the missing headers, but also not cause any linker errors, so we will use this approach for now.

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0011-Fix-HIP-Caffe2-Tests-152014.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0011-Fix-HIP-Caffe2-Tests-152014.patch
@@ -1,7 +1,7 @@
-From 994c4609d63037aec803956b672fe1ed504488ce Mon Sep 17 00:00:00 2001
+From 1846fb0621cdd8aec5010df27ac8bae633febddd Mon Sep 17 00:00:00 2001
 From: Michal Gallus <Michal.Gallus@amd.com>
 Date: Sat, 26 Apr 2025 01:35:46 +0000
-Subject: [PATCH 11/12] Fix HIP Caffe2 Tests (#152014)
+Subject: [PATCH 11/13] Fix HIP Caffe2 Tests (#152014)
 
 Solves the following problems of caffe2 HIP tests building on Windows:
 1. HIP tests now use `hip_add_executable` to be built with custom_command invoking hip compiler, due to lack of cmake support for HIP in 3.18 (currently used).

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0012-Disable-hipSPARSE-and-CK-declarations-and-remove-ref.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0012-Disable-hipSPARSE-and-CK-declarations-and-remove-ref.patch
@@ -1,7 +1,7 @@
-From dbb4f0f4452015b674e8db96752464069e51c3ff Mon Sep 17 00:00:00 2001
+From e92b736fbbaffd4b3b128684501a4714ee43c0d2 Mon Sep 17 00:00:00 2001
 From: ikalinic <ilija.kalinic@amd.com>
 Date: Wed, 19 Mar 2025 07:30:50 +0000
-Subject: [PATCH 12/12] Disable hipSPARSE and CK declarations and remove
+Subject: [PATCH 12/13] Disable hipSPARSE and CK declarations and remove
  references for Windows (#149195)
 
 This PR removes references to `hipSPARSE` and `ck` functions and disables declarations which are not supported on Windows.

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0013-ROCm-Windows-Enable-USE_ROCM-and-fix-assorted-issues.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0013-ROCm-Windows-Enable-USE_ROCM-and-fix-assorted-issues.patch
@@ -1,0 +1,187 @@
+From e4f7cd26a70be2f59763f6066d6c43f9f5473746 Mon Sep 17 00:00:00 2001
+From: Aaryaman Vasishta <jem456.vasishta@gmail.com>
+Date: Sun, 4 May 2025 22:24:50 +0530
+Subject: [PATCH 13/13] [ROCm][Windows] Enable USE_ROCM and fix assorted
+ issues.
+
+* RCCL, the HSA runtime, and rocprofiler are not supported on Windows
+* hipcc should be run with Windows compatibility flags to avoid warning spam
+* Composable Kernels generate linker errors if sources are excluded
+
+Co-authored-by: Aaryaman Vasishta <jem456.vasishta@gmail.com>
+Co-authored-by: Scott Todd <scott.todd0@gmail.com>
+---
+ CMakeLists.txt               |  4 ++--
+ aten/src/ATen/CMakeLists.txt |  6 ------
+ c10/hip/CMakeLists.txt       |  6 +++++-
+ caffe2/CMakeLists.txt        |  4 ++++
+ cmake/Dependencies.cmake     |  3 +++
+ cmake/public/LoadHIP.cmake   | 32 ++++++++++++++++++--------------
+ functorch/csrc/dim/arena.h   |  2 +-
+ 7 files changed, 33 insertions(+), 24 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f3fee2f7ff..6086450e3e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -248,7 +248,7 @@ option(USE_XPU "Use XPU" ON)
+ cmake_dependent_option(
+   BUILD_LAZY_CUDA_LINALG "Build cuda linalg ops as separate library" ON
+   "USE_CUDA AND LINUX AND BUILD_PYTHON" OFF)
+-cmake_dependent_option(USE_ROCM "Use ROCm" ON "LINUX" OFF)
++cmake_dependent_option(USE_ROCM "Use ROCm" ON "LINUX OR WIN32" OFF)
+ option(CAFFE2_STATIC_LINK_CUDA "Statically link CUDA libraries" OFF)
+ cmake_dependent_option(USE_CUDNN "Use cuDNN" ON "USE_CUDA" OFF)
+ cmake_dependent_option(USE_STATIC_CUDNN "Use cuDNN static libraries" OFF
+@@ -271,7 +271,7 @@ option(USE_NATIVE_ARCH "Use -march=native" OFF)
+ cmake_dependent_option(USE_MPS "Use MPS for macOS build" ON "MPS_FOUND" OFF)
+ cmake_dependent_option(USE_NCCL "Use NCCL" ON
+                        "USE_CUDA OR USE_ROCM;UNIX;NOT APPLE" OFF)
+-cmake_dependent_option(USE_RCCL "Use RCCL" ON USE_NCCL OFF)
++cmake_dependent_option(USE_RCCL "Use RCCL" ON "USE_NCCL;NOT WIN32" OFF)
+ cmake_dependent_option(USE_STATIC_NCCL "Use static NCCL" OFF "USE_NCCL" OFF)
+ cmake_dependent_option(USE_SYSTEM_NCCL "Use system-wide NCCL" OFF "USE_NCCL"
+                        OFF)
+diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
+index 74e464dda4..009859de63 100644
+--- a/aten/src/ATen/CMakeLists.txt
++++ b/aten/src/ATen/CMakeLists.txt
+@@ -382,12 +382,6 @@ endif()
+     ${native_quantized_hip_hip}
+     ${native_transformers_hip_hip} ${native_transformers_src_hip_hip}
+   )
+-  if(WIN32) # Windows doesn't support Composable Kernels
+-    file(GLOB native_hip_bgemm "native/hip/bgemm_kernels/*.hip")
+-    file(GLOB native_hip_ck "native/hip/ck*.hip")
+-    exclude(ATen_HIP_SRCS "${ATen_HIP_SRCS}"
+-      ${native_hip_bgemm} ${native_hip_ck})
+-  endif()
+   # TODO: Codegen separate files for HIP and use those (s/cuda_generated_sources/hip_generated_sources)
+   list(APPEND all_hip_cpp
+     ${native_nested_hip_cpp}
+diff --git a/c10/hip/CMakeLists.txt b/c10/hip/CMakeLists.txt
+index a98ec6fa23..b0510797f4 100644
+--- a/c10/hip/CMakeLists.txt
++++ b/c10/hip/CMakeLists.txt
+@@ -48,7 +48,11 @@ if(NOT BUILD_LIBTORCHLESS)
+   endif()
+ 
+   # ---[ Dependency of c10_hip
+-  target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::amdhip64 hsa-runtime64::hsa-runtime64)
++  if(NOT WIN32)
++    target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::amdhip64 hsa-runtime64::hsa-runtime64)
++  else()
++    target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::amdhip64)
++  endif()
+ 
+   target_include_directories(
+       c10_hip PUBLIC
+diff --git a/caffe2/CMakeLists.txt b/caffe2/CMakeLists.txt
+index b32c71c8bd..e76e05c125 100644
+--- a/caffe2/CMakeLists.txt
++++ b/caffe2/CMakeLists.txt
+@@ -1699,6 +1699,10 @@ if(USE_ROCM)
+     endforeach()
+   endif()
+ 
++  if(WIN32)
++    list(APPEND HIP_CXX_FLAGS "-fms-extensions")
++  endif()
++
+   # Call again since Caffe2_HIP_INCLUDE is extended with ATen include dirs.
+   hip_include_directories(${Caffe2_HIP_INCLUDE})
+ 
+diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
+index be45936a8e..4f6b2e4837 100644
+--- a/cmake/Dependencies.cmake
++++ b/cmake/Dependencies.cmake
+@@ -1065,6 +1065,9 @@ if(USE_ROCM)
+     list(APPEND HIP_HIPCC_FLAGS --offload-compress)
+     if(WIN32)
+       add_definitions(-DROCM_ON_WINDOWS)
++      list(APPEND HIP_CXX_FLAGS -fms-extensions)
++      # Suppress warnings about dllexport.
++      list(APPEND HIP_CXX_FLAGS -Wno-ignored-attributes)
+     endif()
+     add_definitions(-DROCM_VERSION=${ROCM_VERSION_DEV_INT})
+     add_definitions(-DTORCH_HIP_VERSION=${TORCH_HIP_VERSION})
+diff --git a/cmake/public/LoadHIP.cmake b/cmake/public/LoadHIP.cmake
+index 7b058199a1..d365971337 100644
+--- a/cmake/public/LoadHIP.cmake
++++ b/cmake/public/LoadHIP.cmake
+@@ -37,10 +37,12 @@ macro(pytorch_load_hip)
+   message(STATUS "hiprtc version: ${hiprtc_VERSION}")
+ 
+   # Original version made these UNIX-only.
+-  find_package(rccl REQUIRED)
+-  message(STATUS "rccl version: ${rccl_VERSION}")
+-  find_package(hsa-runtime64 REQUIRED)
+-  message(STATUS "hsa-runtime64 version: ${hsa-runtime64_VERSION}")
++  if(NOT WIN32)  # RCCL is not yet supported on Windows.
++    find_package(rccl REQUIRED)
++    message(STATUS "rccl version: ${rccl_VERSION}")
++    find_package(hsa-runtime64 REQUIRED)
++    message(STATUS "hsa-runtime64 version: ${hsa-runtime64_VERSION}")
++  endif()
+   find_package(hipblaslt REQUIRED)
+   message(STATUS "hipblaslt version: ${hipblaslt_VERSION}")
+ 
+@@ -74,14 +76,16 @@ macro(pytorch_load_hip)
+   # TODO: This isn't quite right and needs to mate up with whether kineto
+   # depends on roctracer or rocprofiler-sdk. The coupling here is fragile and
+   # needs to be reworked.
+-  find_package(rocprofiler-sdk-roctx)
+-  if(rocprofiler-sdk-roctx_FOUND)
+-    message(STATUS "rocprofiler-sdk-roctx version: ${rocprofiler-sdk-roctx_VERSION} found (will use instead of roctracer)")
+-    set(ROCM_ROCTX_LIB rocprofiler-sdk-roctx::rocprofiler-sdk-roctx-shared-library)
+-  else()
+-    find_library(ROCM_ROCTX_LIB roctx64)
+-    if(NOT ROCM_ROCTX_LIB)
+-      cmake(WARNING "Neither rocprofiler-sdk nor libroctx64.so was found: This may result in errors if components rely on it")
++  if(NOT WIN32)
++    find_package(rocprofiler-sdk-roctx)
++    if(rocprofiler-sdk-roctx_FOUND)
++      message(STATUS "rocprofiler-sdk-roctx version: ${rocprofiler-sdk-roctx_VERSION} found (will use instead of roctracer)")
++      set(ROCM_ROCTX_LIB rocprofiler-sdk-roctx::rocprofiler-sdk-roctx-shared-library)
++    else()
++      find_library(ROCM_ROCTX_LIB roctx64)
++      if(NOT ROCM_ROCTX_LIB)
++        cmake(WARNING "Neither rocprofiler-sdk nor libroctx64.so was found: This may result in errors if components rely on it")
++      endif()
+     endif()
+   endif()
+ 
+@@ -98,7 +102,7 @@ macro(pytorch_load_hip)
+   # contains FindHIP.cmake.
+   function(find_rocm_sdk_module_path)
+     set(hip_lib_dir "${hip_LIB_INSTALL_DIR}")
+-    foreach(candidate_path "${hip_lib_dir}/cmake" "${hip_lib_dir}/cmake/hip")
++    foreach(candidate_path "${hip_lib_dir}/cmake" "${hip_lib_dir}/cmake/hip" "${hip_lib_dir}/../cmake")
+       if(EXISTS "${candidate_path}/FindHIP.cmake")
+         list(PREPEND CMAKE_MODULE_PATH "${candidate_path}")
+         message(STATUS "Legacy FindHIP.cmake module found in ${candidate_path}")
+@@ -110,7 +114,7 @@ macro(pytorch_load_hip)
+     message(STATUS "Could not locate legacy FindHIP.cmake: You may need to set CMAKE_MODULE_PATH explicitly to its location")
+   endfunction()
+   find_rocm_sdk_module_path()
+-  find_package(HIP 1.0 MODULE REQUIRED)
++  find_package(HIP MODULE REQUIRED)
+ 
+   set(HIP_NEW_TYPE_ENUMS ON)
+   set(PYTORCH_FOUND_HIP ON)
+diff --git a/functorch/csrc/dim/arena.h b/functorch/csrc/dim/arena.h
+index aaaf7e772a..4bc627575d 100644
+--- a/functorch/csrc/dim/arena.h
++++ b/functorch/csrc/dim/arena.h
+@@ -8,7 +8,7 @@
+ #include <ATen/ATen.h>
+ #include "minpybind.h"
+ 
+-#ifdef _WIN32
++#if defined(_WIN32) && !(defined(__clang__) && defined(_MSC_VER))
+ #include <intrin.h>
+ // https://stackoverflow.com/questions/355967/how-to-use-msvc-intrinsics-to-get-the-equivalent-of-this-gcc-code
+ inline unsigned int __builtin_clz(unsigned int x) {
+-- 
+2.47.1.windows.2
+

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/third_party/composable_kernel/base/0001-ck.hpp-define-CK_BUFFER_RESOURCE_3RD_DWORD-for-gfx11.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/third_party/composable_kernel/base/0001-ck.hpp-define-CK_BUFFER_RESOURCE_3RD_DWORD-for-gfx11.patch
@@ -1,7 +1,7 @@
-From 8cb4274968c8b2f8b0a66db1d38b17904f5d3424 Mon Sep 17 00:00:00 2001
+From 23b99a1fc0d05a801271aca218fbfbba9bb589ac Mon Sep 17 00:00:00 2001
 From: Scott Tsai <scottt.tw@gmail.com>
 Date: Sat, 22 Mar 2025 06:11:03 +0800
-Subject: [PATCH 2/2] ck.hpp: define CK_BUFFER_RESOURCE_3RD_DWORD for gfx1151
+Subject: [PATCH] ck.hpp: define CK_BUFFER_RESOURCE_3RD_DWORD for gfx1151
 
 Define CK_BUFFER_RESOURCE_3RD_DWORD with the same value for gfx110x and
 gfx115x (0x31004000) following https://github.com/ROCm/hipBLASLt/pull/1766
@@ -10,10 +10,10 @@ gfx115x (0x31004000) following https://github.com/ROCm/hipBLASLt/pull/1766
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/include/ck/ck.hpp b/include/ck/ck.hpp
-index 999eb02..3ded15c 100644
+index 1ec0c6bc2..5e096399c 100644
 --- a/include/ck/ck.hpp
 +++ b/include/ck/ck.hpp
-@@ -68,7 +68,7 @@ CK_DECLARE_ENV_VAR_BOOL(CK_LOGGING)
+@@ -70,7 +70,7 @@ CK_DECLARE_ENV_VAR_BOOL(CK_LOGGING)
  #define __gfx103__
  #endif
  #if defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || \
@@ -23,5 +23,5 @@ index 999eb02..3ded15c 100644
  #endif
  #if defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx12_generic__)
 -- 
-2.48.1
+2.47.1.windows.2
 

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/third_party/fbgemm/hipified/0001-UtilsAvx512.cpp-fix-r-may-be-used-uninitialized-for-.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/third_party/fbgemm/hipified/0001-UtilsAvx512.cpp-fix-r-may-be-used-uninitialized-for-.patch
@@ -1,7 +1,8 @@
-From 23831177a4308fb18951537a0b3948e5547da02d Mon Sep 17 00:00:00 2001
+From 71300f1508cb670796caa744a9fb59c30f6915b9 Mon Sep 17 00:00:00 2001
 From: Scott Tsai <scottt.tw@gmail.com>
 Date: Sat, 22 Mar 2025 06:17:51 +0800
-Subject: [PATCH] UtilsAvx512.cpp: fix r may be used uninitialized for gcc14
+Subject: [PATCH 1/2] UtilsAvx512.cpp: fix r may be used uninitialized for
+ gcc14
 
 This version of fbgemm uses `-Werror` thus the warning breaks the build.
 This is also reported upstream by others as https://github.com/pytorch/pytorch/issues/129358
@@ -27,5 +28,5 @@ index cf00613d..c65eab87 100644
    for (; (i + 1) * 16 <= mrem * 2; i++) {
      // normal load
 -- 
-2.49.0
+2.47.1.windows.2
 

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/third_party/fbgemm/hipified/0002-Fix-compilation-on-clang-cl.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/third_party/fbgemm/hipified/0002-Fix-compilation-on-clang-cl.patch
@@ -1,7 +1,7 @@
-From e4ee6caa8309b0685c574a81b7468e6bf57d86ef Mon Sep 17 00:00:00 2001
+From 2450ff31ba63fb12c709126ae59588109b0a2fcc Mon Sep 17 00:00:00 2001
 From: Aaryaman Vasishta <jem456.vasishta@gmail.com>
 Date: Sun, 4 May 2025 22:31:15 +0530
-Subject: [PATCH] Fix compilation on clang-cl
+Subject: [PATCH 2/2] Fix compilation on clang-cl
 
 ---
  include/fbgemm/Fbgemm.h | 2 +-
@@ -19,6 +19,7 @@ index eb1f3a01..4d94e22f 100644
 +  static bool isA() {
      return PT::isA();
    }
+ 
+-- 
+2.47.1.windows.2
 
---
-2.49.0.windows.1


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/589. Fixes https://github.com/ROCm/TheRock/issues/590. Fixes https://github.com/ROCm/TheRock/issues/627.

This is a revised version of a patch from @jammm, made in collaboration with @scottt as well. The diff between the original patch and what I am sending here can be viewed at https://github.com/ScottTodd/TheRock/blob/pytorch-windows-cleanup-wip/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0014-Cleanup-after-testing-with-clang-cl.patch. Summarizing the delta:

* Revert some changes that were not required in my testing
* Trim some MSVC handling, in favor of focusing on just clang-cl first
* Address hipcc warnings

With this patch, I've been able to build PyTorch wheels with ROCm support on Windows using [`build_pytorch_windows.sh`](https://github.com/ROCm/TheRock/blob/main/external-builds/pytorch/build_pytorch_windows.sh), though there are still some remaining changes needed for a good out of the box experience (see https://gist.github.com/ScottTodd/cb4f9f5a697cce91084977ed3674a4bd and https://github.com/ROCm/TheRock/discussions/409). The script at https://github.com/ROCm/TheRock/blob/main/external-builds/pytorch/windows_patch_fat_wheel.py can also be used to produce a "fat wheel" that bundles ROCm instead of relying on a separate install.

I intend to send the patch here to upstream https://github.com/pytorch/pytorch as well, perhaps split into a few smaller PRs.

Co-authored-by: Aaryaman Vasishta <jem456.vasishta@gmail.com>
Co-authored-by: Scott Todd <scott.todd0@gmail.com>