### PR TITLE
[windows]  Patch hipBLAS to delete dll copying code.

### DIFF
--- a/patches/amd-mainline/hipBLAS/0001-Fix-finding-LAPACK-and-CBLAS.patch
+++ b/patches/amd-mainline/hipBLAS/0001-Fix-finding-LAPACK-and-CBLAS.patch
@@ -1,4 +1,4 @@
-From 1309778af290bf11d323bba02787ec4d2c378e44 Mon Sep 17 00:00:00 2001
+From 23d3f782de5880905a8f2307aaee59161b17c537 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Tue, 25 Mar 2025 12:13:13 +0000
 Subject: [PATCH 1/7] Fix finding LAPACK and CBLAS
@@ -43,5 +43,5 @@ index 44b17af..9154cce 100644
    if( BUILD_CLIENTS_TESTS )
      add_subdirectory( gtest )
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/hipBLAS/0002-Work-around-race-condition.patch
+++ b/patches/amd-mainline/hipBLAS/0002-Work-around-race-condition.patch
@@ -1,4 +1,4 @@
-From bf20e250a6fab40f54021790ee085eac5c576729 Mon Sep 17 00:00:00 2001
+From 8efc7d127ab2189a44bc64b862c9feebf82b73f3 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Fri, 21 Mar 2025 17:01:20 +0000
 Subject: [PATCH 2/7] Work around race condition
@@ -28,5 +28,5 @@ index 9154cce..86b470b 100644
    include_directories(${CMAKE_BINARY_DIR}/include/hipblas)
    include_directories(${CMAKE_BINARY_DIR}/include)
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/hipBLAS/0003-Install-libhipblas_fortran.so.patch
+++ b/patches/amd-mainline/hipBLAS/0003-Install-libhipblas_fortran.so.patch
@@ -1,4 +1,4 @@
-From cbef28b246697fcc9469c12646ea7cb189b1081f Mon Sep 17 00:00:00 2001
+From a45367b0cf6d1a91a37a67bed5ebae13ff7a0478 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Tue, 1 Apr 2025 20:58:38 +0000
 Subject: [PATCH 3/7] Install `libhipblas_fortran.so`
@@ -22,5 +22,5 @@ index 3cb9b77..a1bad50 100755
  
  if(BUILD_ADDRESS_SANITIZER)
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/hipBLAS/0004-Replace-python-with-official-Python3_EXECUTABLE-vari.patch
+++ b/patches/amd-mainline/hipBLAS/0004-Replace-python-with-official-Python3_EXECUTABLE-vari.patch
@@ -1,4 +1,4 @@
-From 1742534e5c6184b9e15b7b9e3da3b0b9584ad61f Mon Sep 17 00:00:00 2001
+From afddd12890c02a436a471bf160eae4514ae2a5d0 Mon Sep 17 00:00:00 2001
 From: Scott <scott.todd0@gmail.com>
 Date: Wed, 30 Apr 2025 12:03:23 -0700
 Subject: [PATCH 4/7] Replace ${python} with official ${Python3_EXECUTABLE}
@@ -22,5 +22,5 @@ index 9434c4d..82d97da 100644
                      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
  
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/hipBLAS/0005-Setup-Fortran-on-Windows.patch
+++ b/patches/amd-mainline/hipBLAS/0005-Setup-Fortran-on-Windows.patch
@@ -1,4 +1,4 @@
-From c26a4575cfee4dc18a251dd8ba730af23ba7189e Mon Sep 17 00:00:00 2001
+From e178e55e601d7595d1476571dba8020ee2cc492a Mon Sep 17 00:00:00 2001
 From: Scott <scott.todd0@gmail.com>
 Date: Thu, 1 May 2025 11:29:42 -0700
 Subject: [PATCH 5/7] Setup Fortran on Windows.
@@ -30,5 +30,5 @@ index 42dfd62..2322567 100644
  project( hipblas LANGUAGES CXX ${fortran_language} )
  
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/hipBLAS/0006-Fix-OpenBLAS-package-name-for-Windows.patch
+++ b/patches/amd-mainline/hipBLAS/0006-Fix-OpenBLAS-package-name-for-Windows.patch
@@ -1,4 +1,4 @@
-From 259e93ed7697ea2ae2ba2e236c142c70255e88c1 Mon Sep 17 00:00:00 2001
+From b230ed25c6e75d8da2e75ddd88584d6bc3c90369 Mon Sep 17 00:00:00 2001
 From: Scott <scott.todd0@gmail.com>
 Date: Thu, 1 May 2025 11:29:55 -0700
 Subject: [PATCH 6/7] Fix OpenBLAS package name for Windows.
@@ -21,5 +21,5 @@ index 86b470b..650dc34 100644
          set( BLAS_INCLUDE_DIR "" )
        endif()
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/hipBLAS/0007-Remove-Windows-third_party_dlls-copying-code.patch
+++ b/patches/amd-mainline/hipBLAS/0007-Remove-Windows-third_party_dlls-copying-code.patch
@@ -1,0 +1,70 @@
+From 6aac74f1d48fc9f35234b499fe807909a310dc50 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Mon, 19 May 2025 09:33:33 -0700
+Subject: [PATCH 7/7] Remove Windows third_party_dlls copying code.
+
+This code is built on shaky assumptions that don't hold inside TheRock.
+We'll need a better solution that works across projects.
+---
+ clients/gtest/CMakeLists.txt | 45 ++++++++++++++++++------------------
+ 1 file changed, 23 insertions(+), 22 deletions(-)
+
+diff --git a/clients/gtest/CMakeLists.txt b/clients/gtest/CMakeLists.txt
+index 82d97da..f533ca7 100644
+--- a/clients/gtest/CMakeLists.txt
++++ b/clients/gtest/CMakeLists.txt
+@@ -172,28 +172,29 @@ else( )
+   target_link_libraries( hipblas-test PRIVATE ${CUDA_LIBRARIES} )
+ endif( )
+ 
+-if (WIN32)
+-# for now adding in all .dll as dependency chain is not cmake based on win32
+-  file( GLOB third_party_dlls
+-    LIST_DIRECTORIES OFF
+-    CONFIGURE_DEPENDS
+-    ${LAPACK_DIR}/bin/*.dll
+-    ${BLIS_DIR}/lib/*.dll
+-    ${OPENBLAS_DIR}/bin/*.dll
+-    ${HIP_DIR}/bin/amd*.dll
+-    ${HIP_DIR}/bin/hiprt*.dll
+-    ${HIP_DIR}/bin/hipinfo.exe
+-    ${ROCBLAS_PATH}/bin/rocblas*.dll
+-    ${ROCSOLVER_PATH}/bin/rocsolver*.dll
+-    ${CMAKE_SOURCE_DIR}/rtest.*
+-    C:/Windows/System32/libomp140*.dll
+-  )
+-  foreach( file_i ${third_party_dlls})
+-    add_custom_command( TARGET hipblas-test POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy ${file_i} ${PROJECT_BINARY_DIR}/staging/ )
+-  endforeach( file_i )
+-
+-  add_custom_command( TARGET hipblas-test POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy_directory ${ROCBLAS_PATH}/bin/rocblas/library/ ${PROJECT_BINARY_DIR}/staging/library/)
+-endif()
++# TODO(https://github.com/ROCm/TheRock/issues/513): general solution for DLL handling
++# if (WIN32)
++# # for now adding in all .dll as dependency chain is not cmake based on win32
++#   file( GLOB third_party_dlls
++#     LIST_DIRECTORIES OFF
++#     CONFIGURE_DEPENDS
++#     ${LAPACK_DIR}/bin/*.dll
++#     ${BLIS_DIR}/lib/*.dll
++#     ${OPENBLAS_DIR}/bin/*.dll
++#     ${HIP_DIR}/bin/amd*.dll
++#     ${HIP_DIR}/bin/hiprt*.dll
++#     ${HIP_DIR}/bin/hipinfo.exe
++#     ${ROCBLAS_PATH}/bin/rocblas*.dll
++#     ${ROCSOLVER_PATH}/bin/rocsolver*.dll
++#     ${CMAKE_SOURCE_DIR}/rtest.*
++#     C:/Windows/System32/libomp140*.dll
++#   )
++#   foreach( file_i ${third_party_dlls})
++#     add_custom_command( TARGET hipblas-test POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy ${file_i} ${PROJECT_BINARY_DIR}/staging/ )
++#   endforeach( file_i )
++
++#   add_custom_command( TARGET hipblas-test POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy_directory ${ROCBLAS_PATH}/bin/rocblas/library/ ${PROJECT_BINARY_DIR}/staging/library/)
++# endif()
+ 
+ set_target_properties( hipblas-test PROPERTIES
+     CXX_STANDARD 17
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
This code is built on shaky assumptions that don't hold inside TheRock. We'll need a better solution for DLL handling that works across projects. That work is tracked at https://github.com/ROCm/TheRock/issues/513.

We had a patch that tried to run this code only if some options were set (https://github.com/ROCm/hipBLAS/pull/1007), but that patch got reverted (https://github.com/ROCm/hipBLAS/pull/1018).

---

The specific issue here is that TheRock does not set `ROCBLAS_PATH`, so this code leads to this error:

```cmake
add_custom_command( TARGET hipblas-test POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy_directory ${ROCBLAS_PATH}/bin/rocblas/library/ ${PROJECT_BINARY_DIR}/staging/library/)

# [build] [hipBLAS] Error copying directory from "/bin/rocblas/library/" to "D:/projects/TheRock/build/math-libs/BLAS/hipBLAS/build/clients/staging/library/".
```

We also don't set any of the other `*_DIR` or `*_PATH` variables, resulting in only these files being copied:
```
[build] [hipBLAS] -- file_i: C:/Windows/System32/libomp140.x86_64.dll
[build] [hipBLAS] -- file_i: C:/Windows/System32/libomp140d.x86_64.dll
[build] [hipBLAS] -- file_i: D:/projects/TheRock/math-libs/BLAS/hipBLAS/rtest.py
[build] [hipBLAS] -- file_i: D:/projects/TheRock/math-libs/BLAS/hipBLAS/rtest.xml
```

(CMake should not be doing anything with `C:/Windows/System32`, and we don't use rtest)