### PR TITLE
Adding missing output for test_release_packages.yml

### DIFF
--- a/.github/workflows/test_release_packages.yml
+++ b/.github/workflows/test_release_packages.yml
@@ -121,4 +121,4 @@ jobs:
         with:
           tag_name: ${{ env.TAG_NAME }}
           body_path: ${{ github.workspace }}/test_notes.md
-          append_body: ${{ steps.release_note.append == 'true' }}
+          append_body: ${{ steps.release_note.outputs.append == 'true' }}


### PR DESCRIPTION
Currently, test notes are not being appended due to missing output. This will fix that.