### PR TITLE
ps1 -> bat

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cd TheRock
 
 # Init python virtual environment and install python dependencies
 python -m venv .venv
-.venv\Scripts\Activate.ps1
+.venv\Scripts\Activate.bat
 pip install -r requirements.txt
 
 # Download submodules and apply patches


### PR DESCRIPTION
to match https://github.com/ROCm/TheRock/blob/main/docs/development/windows_support.md#clone-and-fetch-sources

on my system, running the ps1 file opens notepad whereas running the bat file works properly