### PR TITLE
[torch] Set empty tags during torch checkout in new file.

### DIFF
--- a/external-builds/pytorch/repo_management.py
+++ b/external-builds/pytorch/repo_management.py
@@ -207,7 +207,7 @@ def do_checkout(args: argparse.Namespace):
         fetch_args.extend(["-j", str(args.jobs)])
     exec(["git", "fetch"] + fetch_args + ["origin", args.repo_hashtag], cwd=repo_dir)
     exec(["git", "checkout", "FETCH_HEAD"], cwd=repo_dir)
-    exec(["git", "tag", "-f", TAG_UPSTREAM_DIFFBASE], cwd=repo_dir)
+    exec(["git", "tag", "-f", TAG_UPSTREAM_DIFFBASE, "-m", '""'], cwd=repo_dir)
     try:
         exec(
             ["git", "submodule", "update", "--init", "--recursive"] + fetch_args,
@@ -222,7 +222,7 @@ def do_checkout(args: argparse.Namespace):
             "submodule",
             "foreach",
             "--recursive",
-            f"git tag -f {TAG_UPSTREAM_DIFFBASE}",
+            f'git tag -f {TAG_UPSTREAM_DIFFBASE} -m ""',
         ],
         cwd=repo_dir,
         stdout_devnull=True,
@@ -268,7 +268,7 @@ def do_hipify(args: argparse.Namespace):
         print(f"HIPIFY made changes to {module_path}: Committing")
         exec(["git", "add", "-A"], cwd=module_path)
         exec(["git", "commit", "-m", HIPIFY_COMMIT_MESSAGE], cwd=module_path)
-        exec(["git", "tag", "-f", TAG_HIPIFY_DIFFBASE], cwd=module_path)
+        exec(["git", "tag", "-f", TAG_HIPIFY_DIFFBASE, "-m", '""'], cwd=module_path)
 
 
 def do_save_patches(args: argparse.Namespace):


### PR DESCRIPTION
See https://github.com/ROCm/TheRock/pull/531. This applies the same changes to the new `repo_management.py` script.