### PR TITLE
[torch][windows] Move CK patch from 'hipified' to 'base'.

### DIFF
--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0001-Disable-hipSPARSE-and-CK-declarations-and-remove-ref.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0001-Disable-hipSPARSE-and-CK-declarations-and-remove-ref.patch
@@ -1,8 +1,8 @@
-From e92b736fbbaffd4b3b128684501a4714ee43c0d2 Mon Sep 17 00:00:00 2001
+From 455f219101bbb23503cd390c7aedce8566b6ba21 Mon Sep 17 00:00:00 2001
 From: ikalinic <ilija.kalinic@amd.com>
 Date: Wed, 19 Mar 2025 07:30:50 +0000
-Subject: [PATCH 12/13] Disable hipSPARSE and CK declarations and remove
- references for Windows (#149195)
+Subject: [PATCH] Disable hipSPARSE and CK declarations and remove references
+ for Windows (#149195)
 
 This PR removes references to `hipSPARSE` and `ck` functions and disables declarations which are not supported on Windows.
 
@@ -17,7 +17,7 @@ Co-authored-by: Jeff Daily <jeff.daily@amd.com>
  2 files changed, 49 insertions(+), 18 deletions(-)
 
 diff --git a/aten/src/ATen/cuda/CUDABlas.cpp b/aten/src/ATen/cuda/CUDABlas.cpp
-index a62b028fd4..cb66a6fc24 100644
+index a62b028fd4f..cb66a6fc247 100644
 --- a/aten/src/ATen/cuda/CUDABlas.cpp
 +++ b/aten/src/ATen/cuda/CUDABlas.cpp
 @@ -708,7 +708,7 @@ void bgemm_internal<at::BFloat16>(CUDABLAS_BGEMM_ARGTYPES(at::BFloat16))
@@ -82,7 +82,7 @@ index a62b028fd4..cb66a6fc24 100644
  
  } // namespace at::cuda::blas
 diff --git a/aten/src/ATen/cuda/CUDABlas.h b/aten/src/ATen/cuda/CUDABlas.h
-index 6075e7b9c9..637b48c797 100644
+index 6075e7b9c9d..637b48c797f 100644
 --- a/aten/src/ATen/cuda/CUDABlas.h
 +++ b/aten/src/ATen/cuda/CUDABlas.h
 @@ -292,6 +292,21 @@ void vdot<c10::complex<double>>(CUDABLAS_DOT_ARGTYPES(c10::complex<double>));

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0001-Rework-LoadHIP.cmake-to-be-based-purely-on-CMAKE_PRE.patch
@@ -1,7 +1,7 @@
-From a614a3c8bec3e8392f88b02498eaec9255baeaf0 Mon Sep 17 00:00:00 2001
+From 502e9e63887274f3fa5f975a7990addea61cdb93 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 17 Feb 2025 16:47:57 -0800
-Subject: [PATCH 01/13] Rework LoadHIP.cmake to be based purely on
+Subject: [PATCH 01/12] Rework LoadHIP.cmake to be based purely on
  CMAKE_PREFIX_PATH.
 
 * Eliminates dependence on `/opt/rocm` and path based heuristics.
@@ -14,7 +14,7 @@ Co-authored-by: Scott Tsai <scottt.tw@gmail.com>
  1 file changed, 111 insertions(+), 192 deletions(-)
 
 diff --git a/cmake/public/LoadHIP.cmake b/cmake/public/LoadHIP.cmake
-index 58c74ddda3..57910495fc 100644
+index 58c74ddda35..57910495fcc 100644
 --- a/cmake/public/LoadHIP.cmake
 +++ b/cmake/public/LoadHIP.cmake
 @@ -1,206 +1,125 @@

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0002-Generate-composable_kernel-ck-config.h-as-part-of-ma.patch
@@ -1,7 +1,7 @@
-From 747afb477a4cbed44296028530298defa6e70808 Mon Sep 17 00:00:00 2001
+From 281a67dce7f54430b7551a4eb23f87b96d93e265 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Wed, 19 Feb 2025 17:14:59 -0800
-Subject: [PATCH 02/13] Generate composable_kernel ck/config.h as part of main
+Subject: [PATCH 02/12] Generate composable_kernel ck/config.h as part of main
  build.
 
 Without this, the ck/config.h comes from somewhere, most probably a ROCM SDK that has it installed as a sibling to the HIP headers. Not all ROCM SDKs include this, and even so, it is dangerous to have a sheared header dependency like this.
@@ -10,7 +10,7 @@ Without this, the ck/config.h comes from somewhere, most probably a ROCM SDK tha
  1 file changed, 21 insertions(+)
 
 diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
-index 085af373ec..67322e8f56 100644
+index 085af373ec2..67322e8f56e 100644
 --- a/aten/src/ATen/CMakeLists.txt
 +++ b/aten/src/ATen/CMakeLists.txt
 @@ -343,9 +343,30 @@ if(USE_CUDA)

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0003-TEMPORARY-Manually-disable-roctx-until-compatibility.patch
@@ -1,7 +1,7 @@
-From 8f8d7e793521f20e5bb48ef9ee7f288c777489b1 Mon Sep 17 00:00:00 2001
+From 797112515489313882fa49bcaa39efca98e9e5b4 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 31 Mar 2025 18:54:56 +0100
-Subject: [PATCH 03/13] TEMPORARY: Manually disable roctx until compatibility
+Subject: [PATCH 03/12] TEMPORARY: Manually disable roctx until compatibility
  with rocprofv3 is established.
 
 ---
@@ -10,7 +10,7 @@ Subject: [PATCH 03/13] TEMPORARY: Manually disable roctx until compatibility
  2 files changed, 21 insertions(+), 11 deletions(-)
 
 diff --git a/torch/csrc/cuda/shared/nvtx.cpp b/torch/csrc/cuda/shared/nvtx.cpp
-index 40e9821389..0ce2dd34b5 100644
+index 40e9821389f..0ce2dd34b56 100644
 --- a/torch/csrc/cuda/shared/nvtx.cpp
 +++ b/torch/csrc/cuda/shared/nvtx.cpp
 @@ -1,13 +1,14 @@
@@ -69,7 +69,7 @@ index 40e9821389..0ce2dd34b5 100644
    nvtx.def("deviceRangeEnd", device_nvtxRangeEnd);
  }
 diff --git a/torch/csrc/profiler/stubs/cuda.cpp b/torch/csrc/profiler/stubs/cuda.cpp
-index 37364dfc93..0ed35059a1 100644
+index 37364dfc931..0ed35059a1a 100644
 --- a/torch/csrc/profiler/stubs/cuda.cpp
 +++ b/torch/csrc/profiler/stubs/cuda.cpp
 @@ -1,11 +1,13 @@

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0004-enable-hipBLASLt-for-gfx-1102-1150-1151-1201.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0004-enable-hipBLASLt-for-gfx-1102-1150-1151-1201.patch
@@ -1,7 +1,7 @@
-From 355f8293ed394ae9b934a65cc5cd6e9f4fd47132 Mon Sep 17 00:00:00 2001
+From c02d7c7a0d799c5c65eb3ade82b04d5438a23b22 Mon Sep 17 00:00:00 2001
 From: Scott Tsai <scottt.tw@gmail.com>
 Date: Sun, 23 Mar 2025 13:16:25 +0800
-Subject: [PATCH 04/13] enable hipBLASLt for gfx{1102,1150,1151,1201}
+Subject: [PATCH 04/12] enable hipBLASLt for gfx{1102,1150,1151,1201}
 
 Pytorch upstream should integrate this once the following change
 is in a ROCm release:
@@ -11,7 +11,7 @@ https://github.com/ROCm/hipBLASLt/pull/1766
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/aten/src/ATen/Context.cpp b/aten/src/ATen/Context.cpp
-index 01f223f4e5..d384b5e6b2 100644
+index 01f223f4e5c..d384b5e6b2f 100644
 --- a/aten/src/ATen/Context.cpp
 +++ b/aten/src/ATen/Context.cpp
 @@ -359,7 +359,7 @@ at::BlasBackend Context::blasPreferredBackend() {

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0005-Add-gfx1150-gfx1151-to-hipblaslt-support-list-in-Bla.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0005-Add-gfx1150-gfx1151-to-hipblaslt-support-list-in-Bla.patch
@@ -1,7 +1,7 @@
-From fc7ad160d22c2c378def8fd0fff48d60e6c12e00 Mon Sep 17 00:00:00 2001
+From f0162a6ccdca9fb461d280398ff40b121a8a2840 Mon Sep 17 00:00:00 2001
 From: Aaryaman Vasishta <jem456.vasishta@gmail.com>
 Date: Mon, 31 Mar 2025 19:27:48 +0100
-Subject: [PATCH 05/13] Add gfx1150/gfx1151 to hipblaslt support list in
+Subject: [PATCH 05/12] Add gfx1150/gfx1151 to hipblaslt support list in
  Blas.cpp
 
 ---
@@ -10,7 +10,7 @@ Subject: [PATCH 05/13] Add gfx1150/gfx1151 to hipblaslt support list in
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/aten/src/ATen/native/cuda/Blas.cpp b/aten/src/ATen/native/cuda/Blas.cpp
-index 28936cc034..592c04693c 100644
+index 28936cc034a..592c04693c5 100644
 --- a/aten/src/ATen/native/cuda/Blas.cpp
 +++ b/aten/src/ATen/native/cuda/Blas.cpp
 @@ -259,7 +259,7 @@ static bool isSupportedHipLtROCmArch(int index) {
@@ -23,7 +23,7 @@ index 28936cc034..592c04693c 100644
  #if ROCM_VERSION >= 60500
          "gfx950"
 diff --git a/aten/src/ATen/native/hip/Blas.cpp b/aten/src/ATen/native/hip/Blas.cpp
-index c1fdaf7f28..734af694b0 100644
+index c1fdaf7f284..734af694b0f 100644
 --- a/aten/src/ATen/native/hip/Blas.cpp
 +++ b/aten/src/ATen/native/hip/Blas.cpp
 @@ -260,7 +260,7 @@ static bool isSupportedHipLtROCmArch(int index) {

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0006-Support-gfx1151-in-aotriton.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0006-Support-gfx1151-in-aotriton.patch
@@ -1,7 +1,7 @@
-From d2b5d52a173582c0c95dbad5340e81c5b82f5f21 Mon Sep 17 00:00:00 2001
+From dfa703d6452620f6f7c713107bd175f74413d5ed Mon Sep 17 00:00:00 2001
 From: Aaryaman Vasishta <jem456.vasishta@gmail.com>
 Date: Mon, 31 Mar 2025 19:27:59 +0100
-Subject: [PATCH 06/13] Support gfx1151 in aotriton
+Subject: [PATCH 06/12] Support gfx1151 in aotriton
 
 ---
  cmake/External/aotriton.cmake | 6 ++++--
@@ -9,7 +9,7 @@ Subject: [PATCH 06/13] Support gfx1151 in aotriton
  2 files changed, 10 insertions(+), 2 deletions(-)
 
 diff --git a/cmake/External/aotriton.cmake b/cmake/External/aotriton.cmake
-index 2678cfde3c..b70b9311d7 100644
+index 2678cfde3c4..b70b9311d70 100644
 --- a/cmake/External/aotriton.cmake
 +++ b/cmake/External/aotriton.cmake
 @@ -2,6 +2,7 @@ macro(get_target_gpus_from_pytorch target_gpus)
@@ -47,7 +47,7 @@ index 2678cfde3c..b70b9311d7 100644
        BUILD_COMMAND ""  # No build, install command will repeat the build process due to problems in the build system.
        BUILD_BYPRODUCTS "${__AOTRITON_INSTALL_DIR}/lib/libaotriton_v2.so"
 diff --git a/cmake/public/LoadHIP.cmake b/cmake/public/LoadHIP.cmake
-index 57910495fc..7b058199a1 100644
+index 57910495fcc..7b058199a13 100644
 --- a/cmake/public/LoadHIP.cmake
 +++ b/cmake/public/LoadHIP.cmake
 @@ -121,5 +121,11 @@ set(PYTORCH_FOUND_HIP FALSE)

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0007-link-correct-version-of-hsa-runtime-with-c10_hip.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0007-link-correct-version-of-hsa-runtime-with-c10_hip.patch
@@ -1,7 +1,7 @@
-From 246eb780d56294066bd3fd3785759ea87a03800e Mon Sep 17 00:00:00 2001
+From 86a13aadc1740be08cbaae86c48eb0cadfa8ad41 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <mika.laitio@amd.com>
 Date: Tue, 29 Apr 2025 01:28:14 -0700
-Subject: [PATCH 07/13] link correct version of hsa-runtime with c10_hip
+Subject: [PATCH 07/12] link correct version of hsa-runtime with c10_hip
 
 link the version of hsa-runtime64 that is searched
 by LoadHIP.cmake instead of relying to it to be linked
@@ -18,7 +18,7 @@ Signed-off-by: Mika Laitio <mika.laitio@amd.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/c10/hip/CMakeLists.txt b/c10/hip/CMakeLists.txt
-index f153030e79..a98ec6fa23 100644
+index f153030e793..a98ec6fa230 100644
 --- a/c10/hip/CMakeLists.txt
 +++ b/c10/hip/CMakeLists.txt
 @@ -48,7 +48,7 @@ if(NOT BUILD_LIBTORCHLESS)

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0008-rocm-clang-version-check-fix.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0008-rocm-clang-version-check-fix.patch
@@ -1,7 +1,7 @@
-From 8cd9e4fec0dbf0337723c8ca9d66846d05774fb4 Mon Sep 17 00:00:00 2001
+From 1e2ef2d23d24e48468e2be2376be32dc71cecf86 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Sat, 22 Mar 2025 08:51:34 -0700
-Subject: [PATCH 08/13] rocm clang version check fix
+Subject: [PATCH 08/12] rocm clang version check fix
 
 clang in rocm sdk 6.3.3 returns 18.0git as a version.
 fix this by adding a check which converts it to
@@ -13,7 +13,7 @@ Signed-off-by: Mika Laitio <lamikr@gmail.com>
  1 file changed, 9 insertions(+)
 
 diff --git a/torch/utils/cpp_extension.py b/torch/utils/cpp_extension.py
-index 82c23c2c9f..b8dd20bc01 100644
+index 82c23c2c9fe..b8dd20bc01f 100644
 --- a/torch/utils/cpp_extension.py
 +++ b/torch/utils/cpp_extension.py
 @@ -446,6 +446,15 @@ def get_compiler_abi_compatibility_and_version(compiler) -> tuple[bool, TorchVer

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0009-Enable-torchvision-build-with-ROCm-on-Windows-147382.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0009-Enable-torchvision-build-with-ROCm-on-Windows-147382.patch
@@ -1,7 +1,7 @@
-From 6dfc91490c5b9722eb96445b970f7e6d8ad73909 Mon Sep 17 00:00:00 2001
+From d14a60b8fd030e26373b89fdc562c6f23a4a9f9d Mon Sep 17 00:00:00 2001
 From: tvukovic-amd <tvukovic@amd.com>
 Date: Tue, 18 Mar 2025 23:37:01 +0000
-Subject: [PATCH 09/13] Enable torchvision build with ROCm on Windows (#147382)
+Subject: [PATCH 09/12] Enable torchvision build with ROCm on Windows (#147382)
 
 - Updated HIP flags for Windows (removed non Windows flags on Windows case, added runtime library)
 - Set hipcc call for Windows case
@@ -19,7 +19,7 @@ Co-authored-by: Jeff Daily <jeff.daily@amd.com>
  2 files changed, 67 insertions(+), 26 deletions(-)
 
 diff --git a/torch/utils/cpp_extension.py b/torch/utils/cpp_extension.py
-index b8dd20bc01..8dd296bcae 100644
+index b8dd20bc01f..8dd296bcae3 100644
 --- a/torch/utils/cpp_extension.py
 +++ b/torch/utils/cpp_extension.py
 @@ -173,9 +173,6 @@ def _join_rocm_home(*paths) -> str:
@@ -242,7 +242,7 @@ index b8dd20bc01..8dd296bcae 100644
          compile_rule.append(
              '  command = $cxx -MMD -MF $out.d $cflags -c $in -o $out $post_cflags')
 diff --git a/torch/utils/hipify/hipify_python.py b/torch/utils/hipify/hipify_python.py
-index 6cbdf6c7ec..de726e066d 100755
+index 6cbdf6c7ecc..de726e066da 100755
 --- a/torch/utils/hipify/hipify_python.py
 +++ b/torch/utils/hipify/hipify_python.py
 @@ -139,7 +139,6 @@ class GeneratedFileCleaner:

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0010-Include-AOTriton-dependent-sources-in-Windows-build-.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0010-Include-AOTriton-dependent-sources-in-Windows-build-.patch
@@ -1,7 +1,7 @@
-From 10f0f684630ae7da46f782f8043ad907f43ceb7b Mon Sep 17 00:00:00 2001
+From 3da24f6eb10c069a04db92c0369dadfecf69c736 Mon Sep 17 00:00:00 2001
 From: ikalinic <ilija.kalinic@amd.com>
 Date: Tue, 8 Apr 2025 16:18:11 +0000
-Subject: [PATCH 10/13] Include AOTriton dependent sources in Windows build
+Subject: [PATCH 10/12] Include AOTriton dependent sources in Windows build
  (#150521)
 
 Includes ATen native transformers hipified sources in ROCm+Windows build. This was removed due to Trinton not being available on Windows, but this causes further linker errors. Setting `USE_FLASH_ATTENTION=0` and `USE_MEM_EFF_ATTENTION=0` during the build will mitigate the missing headers, but also not cause any linker errors, so we will use this approach for now.
@@ -13,7 +13,7 @@ Approved by: https://github.com/jeffdaily
  1 file changed, 2 insertions(+), 6 deletions(-)
 
 diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
-index 67322e8f56..74e464dda4 100644
+index 67322e8f56e..74e464dda49 100644
 --- a/aten/src/ATen/CMakeLists.txt
 +++ b/aten/src/ATen/CMakeLists.txt
 @@ -382,12 +382,11 @@ endif()

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0011-Fix-HIP-Caffe2-Tests-152014.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0011-Fix-HIP-Caffe2-Tests-152014.patch
@@ -1,7 +1,7 @@
-From 1846fb0621cdd8aec5010df27ac8bae633febddd Mon Sep 17 00:00:00 2001
+From 1c3934e100360b6d37bd00c83e48c2854a9f605a Mon Sep 17 00:00:00 2001
 From: Michal Gallus <Michal.Gallus@amd.com>
 Date: Sat, 26 Apr 2025 01:35:46 +0000
-Subject: [PATCH 11/13] Fix HIP Caffe2 Tests (#152014)
+Subject: [PATCH 11/12] Fix HIP Caffe2 Tests (#152014)
 
 Solves the following problems of caffe2 HIP tests building on Windows:
 1. HIP tests now use `hip_add_executable` to be built with custom_command invoking hip compiler, due to lack of cmake support for HIP in 3.18 (currently used).
@@ -16,7 +16,7 @@ Approved by: https://github.com/jeffdaily
  2 files changed, 11 insertions(+), 2 deletions(-)
 
 diff --git a/aten/src/ATen/test/cuda_vectorized_test.cu b/aten/src/ATen/test/cuda_vectorized_test.cu
-index 6b120f7eb3..7ba7bcb99b 100644
+index 6b120f7eb30..7ba7bcb99bc 100644
 --- a/aten/src/ATen/test/cuda_vectorized_test.cu
 +++ b/aten/src/ATen/test/cuda_vectorized_test.cu
 @@ -27,7 +27,7 @@ void reset_buffers() {
@@ -29,7 +29,7 @@ index 6b120f7eb3..7ba7bcb99b 100644
    // This is a compile-time unit test. If this file compiles without error,
    // then the test passes and during runtime, we just need to return.
 diff --git a/caffe2/CMakeLists.txt b/caffe2/CMakeLists.txt
-index d2d23b7ab6..b32c71c8bd 100644
+index d2d23b7ab65..b32c71c8bd6 100644
 --- a/caffe2/CMakeLists.txt
 +++ b/caffe2/CMakeLists.txt
 @@ -1896,9 +1896,18 @@ if(BUILD_TEST)

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0012-Enable-USE_ROCM-and-fix-assorted-issues.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0012-Enable-USE_ROCM-and-fix-assorted-issues.patch
@@ -1,27 +1,24 @@
-From e4f7cd26a70be2f59763f6066d6c43f9f5473746 Mon Sep 17 00:00:00 2001
+From e7d5568707798d3a0bf87e6988f6d6283f9208b5 Mon Sep 17 00:00:00 2001
 From: Aaryaman Vasishta <jem456.vasishta@gmail.com>
 Date: Sun, 4 May 2025 22:24:50 +0530
-Subject: [PATCH 13/13] [ROCm][Windows] Enable USE_ROCM and fix assorted
- issues.
+Subject: [PATCH 12/12] Enable USE_ROCM and fix assorted issues.
 
 * RCCL, the HSA runtime, and rocprofiler are not supported on Windows
 * hipcc should be run with Windows compatibility flags to avoid warning spam
-* Composable Kernels generate linker errors if sources are excluded
 
 Co-authored-by: Aaryaman Vasishta <jem456.vasishta@gmail.com>
 Co-authored-by: Scott Todd <scott.todd0@gmail.com>
 ---
- CMakeLists.txt               |  4 ++--
- aten/src/ATen/CMakeLists.txt |  6 ------
- c10/hip/CMakeLists.txt       |  6 +++++-
- caffe2/CMakeLists.txt        |  4 ++++
- cmake/Dependencies.cmake     |  3 +++
- cmake/public/LoadHIP.cmake   | 32 ++++++++++++++++++--------------
- functorch/csrc/dim/arena.h   |  2 +-
- 7 files changed, 33 insertions(+), 24 deletions(-)
+ CMakeLists.txt             |  4 ++--
+ c10/hip/CMakeLists.txt     |  6 +++++-
+ caffe2/CMakeLists.txt      |  4 ++++
+ cmake/Dependencies.cmake   |  3 +++
+ cmake/public/LoadHIP.cmake | 32 ++++++++++++++++++--------------
+ functorch/csrc/dim/arena.h |  2 +-
+ 6 files changed, 33 insertions(+), 18 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f3fee2f7ff..6086450e3e 100644
+index f3fee2f7ffc..6086450e3ed 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -248,7 +248,7 @@ option(USE_XPU "Use XPU" ON)
@@ -42,25 +39,8 @@ index f3fee2f7ff..6086450e3e 100644
  cmake_dependent_option(USE_STATIC_NCCL "Use static NCCL" OFF "USE_NCCL" OFF)
  cmake_dependent_option(USE_SYSTEM_NCCL "Use system-wide NCCL" OFF "USE_NCCL"
                         OFF)
-diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
-index 74e464dda4..009859de63 100644
---- a/aten/src/ATen/CMakeLists.txt
-+++ b/aten/src/ATen/CMakeLists.txt
-@@ -382,12 +382,6 @@ endif()
-     ${native_quantized_hip_hip}
-     ${native_transformers_hip_hip} ${native_transformers_src_hip_hip}
-   )
--  if(WIN32) # Windows doesn't support Composable Kernels
--    file(GLOB native_hip_bgemm "native/hip/bgemm_kernels/*.hip")
--    file(GLOB native_hip_ck "native/hip/ck*.hip")
--    exclude(ATen_HIP_SRCS "${ATen_HIP_SRCS}"
--      ${native_hip_bgemm} ${native_hip_ck})
--  endif()
-   # TODO: Codegen separate files for HIP and use those (s/cuda_generated_sources/hip_generated_sources)
-   list(APPEND all_hip_cpp
-     ${native_nested_hip_cpp}
 diff --git a/c10/hip/CMakeLists.txt b/c10/hip/CMakeLists.txt
-index a98ec6fa23..b0510797f4 100644
+index a98ec6fa230..b0510797f44 100644
 --- a/c10/hip/CMakeLists.txt
 +++ b/c10/hip/CMakeLists.txt
 @@ -48,7 +48,11 @@ if(NOT BUILD_LIBTORCHLESS)
@@ -77,7 +57,7 @@ index a98ec6fa23..b0510797f4 100644
    target_include_directories(
        c10_hip PUBLIC
 diff --git a/caffe2/CMakeLists.txt b/caffe2/CMakeLists.txt
-index b32c71c8bd..e76e05c125 100644
+index b32c71c8bd6..e76e05c1255 100644
 --- a/caffe2/CMakeLists.txt
 +++ b/caffe2/CMakeLists.txt
 @@ -1699,6 +1699,10 @@ if(USE_ROCM)
@@ -92,7 +72,7 @@ index b32c71c8bd..e76e05c125 100644
    hip_include_directories(${Caffe2_HIP_INCLUDE})
  
 diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
-index be45936a8e..4f6b2e4837 100644
+index be45936a8ea..4f6b2e4837c 100644
 --- a/cmake/Dependencies.cmake
 +++ b/cmake/Dependencies.cmake
 @@ -1065,6 +1065,9 @@ if(USE_ROCM)
@@ -106,7 +86,7 @@ index be45936a8e..4f6b2e4837 100644
      add_definitions(-DROCM_VERSION=${ROCM_VERSION_DEV_INT})
      add_definitions(-DTORCH_HIP_VERSION=${TORCH_HIP_VERSION})
 diff --git a/cmake/public/LoadHIP.cmake b/cmake/public/LoadHIP.cmake
-index 7b058199a1..d365971337 100644
+index 7b058199a13..d365971337e 100644
 --- a/cmake/public/LoadHIP.cmake
 +++ b/cmake/public/LoadHIP.cmake
 @@ -37,10 +37,12 @@ macro(pytorch_load_hip)
@@ -170,7 +150,7 @@ index 7b058199a1..d365971337 100644
    set(HIP_NEW_TYPE_ENUMS ON)
    set(PYTORCH_FOUND_HIP ON)
 diff --git a/functorch/csrc/dim/arena.h b/functorch/csrc/dim/arena.h
-index aaaf7e772a..4bc627575d 100644
+index aaaf7e772a3..4bc627575de 100644
 --- a/functorch/csrc/dim/arena.h
 +++ b/functorch/csrc/dim/arena.h
 @@ -8,7 +8,7 @@


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/627 (in a better way this time).

This allows us to drop some CMake changes and still avoid linker errors.

Before this change we were carrying https://github.com/pytorch/pytorch/commit/3e78c9e967f154301937d4de1f5d9b4ab2cb5d84 but only applied to `aten/src/ATen/cuda/CUDABlas.cpp`, _not_ the HIPIFY'd `HIPBlas.cpp` that was generating linker errors when CK sources were not included. This might be a performance / functionality degradation, since what we had in TheRock actually _enabled_ the CK kernels that at least appeared to be "supported" (compiled / linked just fine), while that patch was _disabling_ them. I'll leave actually resolving that future work between CK and PyTorch maintainers.