### PR TITLE
[ci] Enabling schedule builds always

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -352,6 +352,10 @@ def main(base_args, linux_families, windows_families):
     #     * workflow_dispatch or workflow_call with inputs controlling enabled jobs?
     enable_build_jobs = should_ci_run_given_modified_paths(modified_paths)
 
+    # In the case of a scheduled run, we always want to build
+    if is_schedule:
+        enable_build_jobs = True
+
     write_job_summary(
         f"""## Workflow configure results
 

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -321,9 +321,6 @@ def main(base_args, linux_families, windows_families):
     print(f"  is_workflow_dispatch: {is_workflow_dispatch}")
     print(f"  is_pull_request: {is_pull_request}")
 
-    modified_paths = get_modified_paths(base_ref)
-    print("modified_paths (max 200):", modified_paths[:200])
-
     print(f"Generating build matrix for Linux: {str(linux_families)}")
     linux_target_output = matrix_generator(
         is_pull_request,
@@ -346,15 +343,16 @@ def main(base_args, linux_families, windows_families):
         platform="windows",
     )
 
-    enable_build_jobs = False
-    print(f"Checking modified files since this had a {github_event_name} trigger")
-    # TODO(#199): other behavior changes
-    #     * workflow_dispatch or workflow_call with inputs controlling enabled jobs?
-    enable_build_jobs = should_ci_run_given_modified_paths(modified_paths)
-
     # In the case of a scheduled run, we always want to build
     if is_schedule:
-        enable_build_jobs = True
+        enable_build_jobs = False
+    else:
+        modified_paths = get_modified_paths(base_ref)
+        print("modified_paths (max 200):", modified_paths[:200])
+        print(f"Checking modified files since this had a {github_event_name} trigger")
+        # TODO(#199): other behavior changes
+        #     * workflow_dispatch or workflow_call with inputs controlling enabled jobs?
+        enable_build_jobs = should_ci_run_given_modified_paths(modified_paths)
 
     write_job_summary(
         f"""## Workflow configure results


### PR DESCRIPTION
Currently, if HEAD is a doc change, our scheduled builds do not run like [this CI run](https://github.com/ROCm/TheRock/actions/runs/15127547635)

For scheduled runs, we always want to attempt to build!