### PR TITLE
Allow to build components from the `rocm-libraries`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,16 @@ set(THEROCK_ARTIFACT_ARCHIVE_SUFFIX "" CACHE STRING "Suffix to add to artifact a
 
 option(THEROCK_BUNDLE_SYSDEPS "Builds bundled system deps for portable builds into lib/rocm_sysdeps" ON)
 
+# Source settings.
+option(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES "Use the `rocm-libraries` monorepo instead of submodules" OFF)
+if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES AND NOT ROCM_LIBRARIES_SOURCE_DIR)
+  message(FATAL_ERROR "If THEROCK_USE_EXTERNAL_ROCM_LIBRARIES is set, ROCM_LIBRARIES_SOURCE_DIR is required!")
+endif()
+
+if(ROCM_LIBRARIES_SOURCE_DIR)
+  cmake_path(ABSOLUTE_PATH ROCM_LIBRARIES_SOURCE_DIR NORMALIZE)
+endif()
+
 # Overall build settings.
 option(THEROCK_VERBOSE "Enables verbose CMake statuses" OFF)
 

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -74,8 +74,15 @@ if(THEROCK_ENABLE_PRIM)
   # rocPRIM
   ##############################################################################
 
+  if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+    set(_rocprim_source_dir "${ROCM_LIBRARIES_SOURCE_DIR}/projects/rocprim")
+  else()
+    set(_rocprim_source_dir "rocPRIM")
+  endif()
+
   therock_cmake_subproject_declare(rocPRIM
-    EXTERNAL_SOURCE_DIR "rocPRIM"
+    EXTERNAL_SOURCE_DIR "${_rocprim_source_dir}"
+    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocPRIM"
     BACKGROUND_BUILD
     CMAKE_ARGS
       -DHIP_PLATFORM=amd


### PR DESCRIPTION
This adds the `THEROCK_USE_EXTERNAL_ROCM_LIBRARIES` option to allow consuming source from the `rocm-libraries` monorepo instead of a submodule. The option must be used together with
`THEROCK_USE_EXTERNAL_ROCM_LIBRARIES` to point to the monorepo (relative and absolute paths are supported). With this, the monorepo can either be a submodule in TheRock itself or can be an checkout outside of TheRock.

For now, this is enabled for rocPRIM.