### PR TITLE
[windows] Apply patch for hipBLASLt path searching.

### DIFF
--- a/patches/amd-mainline/hipBLASLt/0001-Guard-against-missing-directories-in-Tensile-Validat.patch
+++ b/patches/amd-mainline/hipBLASLt/0001-Guard-against-missing-directories-in-Tensile-Validat.patch
@@ -1,0 +1,43 @@
+From a785e82c8100d36a3d1eeafa74a9fbc356f15954 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Wed, 21 May 2025 15:27:09 -0700
+Subject: [PATCH] Guard against missing directories in Tensile Validators.py.
+
+---
+ tensilelite/Tensile/Toolchain/Validators.py | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/tensilelite/Tensile/Toolchain/Validators.py b/tensilelite/Tensile/Toolchain/Validators.py
+index 3911a2d1..fd5dab53 100644
+--- a/tensilelite/Tensile/Toolchain/Validators.py
++++ b/tensilelite/Tensile/Toolchain/Validators.py
+@@ -50,10 +50,14 @@ def _windowsLatestRocmBin(path: Union[Path, str]) -> Path:
+     Returns:
+         The path to the ROCm bin directory for the latest ROCm version.
+         Typically of the form ``C:/Program Files/AMD/ROCm/X.Y/bin``.
++        May return ``None`` if no ``X.Y`` subdirectories exist, perhaps due to
++        a partial uninstall.
+     """
+     path = Path(path)
+     pattern = re.compile(r"^\d+\.\d+$")
+-    versions = filter(lambda d: d.is_dir() and pattern.match(d.name), path.iterdir())
++    versions = list(filter(lambda d: d.is_dir() and pattern.match(d.name), path.iterdir()))
++    if len(versions) == 0:
++        return None
+     latest = max(versions, key=lambda d: tuple(map(int, d.name.split("."))))
+     return latest / "bin"
+ 
+@@ -67,7 +71,9 @@ def _windowsSearchPaths() -> List[Path]:
+         searchPaths.extend(hipPaths)
+ 
+     if Path(defaultPath).exists():
+-        searchPaths.append(_windowsLatestRocmBin(defaultPath))
++        latestRocmBin = _windowsLatestRocmBin(defaultPath)
++        if latestRocmBin:
++            searchPaths.append(latestRocmBin)
+ 
+     if os.environ.get("PATH"):
+         envPath = [Path(p) for p in os.environ["PATH"].split(os.pathsep)]
+-- 
+2.45.1.windows.1
+


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/683. Patch sent upstream here: https://github.com/ROCm/hipBLASLt/pull/2110.

We've had some users try building with a `C:\Program Files\AMD\ROCm` directory that has no `X.Y` directories (e.g. `C:\Program Files\AMD\ROCm\6.2`). Without a change like this, that produces errors during the build:

```
1.4	[129/234  27% :: 1.354] Creating Layer Norm, Softmax and Amax Assembly for gfx1100
1.4	FAILED: device-library/extops/L_256_4_1_gfx1100.s device-library/extops/L_256_4_0_gfx1100.s device-library/extops/S_8_32_gfx1100.s device-library/extops/S_16_16_gfx1100.s device-library/extops/S_4_64_gfx1100.s device-library/extops/S_2_128_gfx1100.s device-library/extops/S_1_256_gfx1100.s device-library/extops/A_S_S_256_4_gfx1100.s device-library/extops/A_H_H_256_4_gfx1100.s device-library/extops/A_H_S_256_4_gfx1100.s device-library/extops/A_S_H_256_4_gfx1100.s D:/projects/TheRock/build/math-libs/BLAS/hipBLASLt/build/device-library/extops/L_256_4_1_gfx1100.s D:/projects/TheRock/build/math-libs/BLAS/hipBLASLt/build/device-library/extops/L_256_4_0_gfx1100.s D:/projects/TheRock/build/math-libs/BLAS/hipBLASLt/build/device-library/extops/S_8_32_gfx1100.s D:/projects/TheRock/build/math-libs/BLAS/hipBLASLt/build/device-library/extops/S_16_16_gfx1100.s D:/projects/TheRock/build/math-libs/BLAS/hipBLASLt/build/device-library/extops/S_4_64_gfx1100.s D:/projects/TheRock/build/math-libs/BLAS/hipBLASLt/build/device-library/extops/S_2_128_gfx1100.s D:/projects/TheRock/build/math-libs/BLAS/hipBLASLt/build/device-library/extops/S_1_256_gfx1100.s D:/projects/TheRock/build/math-libs/BLAS/hipBLASLt/build/device-library/extops/A_S_S_256_4_gfx1100.s D:/projects/TheRock/build/math-libs/BLAS/hipBLASLt/build/device-library/extops/A_H_H_256_4_gfx1100.s D:/projects/TheRock/build/math-libs/BLAS/hipBLASLt/build/device-library/extops/A_H_S_256_4_gfx1100.s D:/projects/TheRock/build/math-libs/BLAS/hipBLASLt/build/device-library/extops/A_S_H_256_4_gfx1100.s 
1.4	device-library\extops\CMakeFiles\L_256_4_1_gfx1100.s-19cdfe7.bat e14a520751d25829
1.4	Traceback (most recent call last):
1.4	  File "D:\projects\TheRock\math-libs\BLAS\hipBLASLt\tensilelite\LayerNormGenerator.py", line 925, in <module>
1.4	    toolchain_path: str = validateToolchain(args.toolchain)
1.4	                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1.4	  File "D:\projects\TheRock\math-libs\BLAS\hipBLASLt\tensilelite\Tensile\Toolchain\Validators.py", line 264, in validateToolchain
1.4	    searchPaths = _windowsSearchPaths() if os.name == "nt" else _posixSearchPaths()
1.4	                  ^^^^^^^^^^^^^^^^^^^^^
1.4	  File "D:\projects\TheRock\math-libs\BLAS\hipBLASLt\tensilelite\Tensile\Toolchain\Validators.py", line 74, in _windowsSearchPaths
1.4	    latestRocmBin = _windowsLatestRocmBin(defaultPath)
1.4	                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1.4	  File "D:\projects\TheRock\math-libs\BLAS\hipBLASLt\tensilelite\Tensile\Toolchain\Validators.py", line 61, in _windowsLatestRocmBin
1.7	    latest = max(versions, key=lambda d: tuple(map(int, d.name.split("."))))

1.7	             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1.7	ValueError: max() iterable argument is empty

1.7	Batch file failed at line 3 with errorcode 1
```