### PR TITLE
Tune debug info configuration to work for package releases on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ include(CMakeDependentOption)
 include(ExternalProject)
 include(therock_amdgpu_targets)
 include(therock_artifacts)
+include(therock_compiler_config)
 include(therock_features)
 include(therock_subproject)
 include(therock_job_pools)
@@ -104,6 +105,8 @@ endblock()
 ################################################################################
 
 option(THEROCK_SPLIT_DEBUG_INFO "Enables splitting of debug info into dbg artifacts (and strips primary packages)" OFF)
+option(THEROCK_MINIMAL_DEBUG_INFO "Enables compiler-specific flags for minimal debug symbols suitable for shipping in packages" OFF)
+option(THEROCK_QUIET_INSTALL "Enable quiet install logging (install logs only go to the logfile)" ON)
 
 ################################################################################
 # Feature selection

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,24 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 25,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "linux-release-package",
+      "displayName": "Settings for Linux release packages",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "amd-llvm_BUILD_TYPE": "Release",
+        "therock-host-blas_BUILD_TYPE": "Release",
+        "therock-SuiteSparse_BUILD_TYPE": "Release",
+        "THEROCK_SPLIT_DEBUG_INFO": "ON",
+        "THEROCK_MINIMAL_DEBUG_INFO": "ON",
+        "THEROCK_QUIET_INSTALL": "OFF"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -155,9 +155,6 @@ cmake -B build -GNinja -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
   .
 
-# On Windows, also add
-#   -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded \
-
 cmake --build build
 ```
 

--- a/cmake/therock_compiler_config.cmake
+++ b/cmake/therock_compiler_config.cmake
@@ -1,0 +1,6 @@
+# Project wide compiler configuration.
+
+# On win32 only support embedded debug databases project wide.
+if(WIN32 AND NOT DEFINED CMAKE_MSVC_DEBUG_INFORMATION_FORMAT)
+  set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
+endif()

--- a/cmake/therock_compiler_config.cmake
+++ b/cmake/therock_compiler_config.cmake
@@ -1,6 +1,8 @@
 # Project wide compiler configuration.
 
 # On win32 only support embedded debug databases project wide.
+# This improves compatibility with ccache and sccache:
+# https://github.com/ccache/ccache/issues/1040
 if(WIN32 AND NOT DEFINED CMAKE_MSVC_DEBUG_INFORMATION_FORMAT)
   set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
 endif()

--- a/cmake/therock_install_linux_build_id_files.cmake
+++ b/cmake/therock_install_linux_build_id_files.cmake
@@ -17,7 +17,7 @@
 #     Build ID: dac12d72d961c9d08880d946cd26618f0107dc4b
 # And then installs the debug sections to an appropriate file in .build-id/
 
-block()
+block(SCOPE_FOR VARIABLES)
   foreach(binary_path ${THEROCK_DEBUG_BUILD_ID_PATHS})
     if(NOT EXISTS "${binary_path}")
       message("Skipping debug info for ${binary_path} (does not exist)")

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -12,7 +12,6 @@ include(ExternalProject)
 # List of CMake variables that will be injected by default into the
 # project_init.cmake file of each subproject.
 set_property(GLOBAL PROPERTY THEROCK_DEFAULT_CMAKE_VARS
-  CMAKE_BUILD_TYPE
   CMAKE_PROGRAM_PATH
   CMAKE_PLATFORM_NO_VERSIONED_SONAME
   Python3_EXECUTABLE
@@ -554,6 +553,11 @@ function(therock_cmake_subproject_activate target_name)
   endif()
 
   set(_init_contents)
+  # Support generator expressions in install CODE
+  # We rely on this for debug symbol separation and some of our very old projects
+  # have a CMake minver < 3.14, defaulting them to OLD. Unfortunately, this policy
+  # must be set globally vs in a block scope to have effect.
+  string(APPEND _init_contents "cmake_policy(SET CMP0087 NEW)\n")
   foreach(_var_name ${_mirror_cmake_vars})
     string(APPEND _init_contents "set(${_var_name} \"@${_var_name}@\" CACHE STRING \"\" FORCE)\n")
   endforeach()
@@ -636,6 +640,15 @@ function(therock_cmake_subproject_activate target_name)
   set(_build_stamp_file "${_stamp_dir}/build.stamp")
   set(_stage_stamp_file "${_stamp_dir}/stage.stamp")
 
+  # Derive the CMAKE_BUILD_TYPE from eiether {project}_BUILD_TYPE or the global
+  # CMAKE_BUILD_TYPE.
+  set(_cmake_build_type "${${target_name}_BUILD_TYPE}")
+  if(NOT _cmake_build_type)
+    set(_cmake_build_type "${CMAKE_BUILD_TYPE}")
+  else()
+    message(STATUS "  PROJECT SPECIFIC CMAKE_BUILD_TYPE=${_cmake_build_type}")
+  endif()
+
   if(EXISTS "${_prebuilt_file}")
     # If pre-built, just touch the stamp files, conditioned on the prebuilt
     # marker file (which may just be a stamp file or may contain a unique hash
@@ -693,6 +706,7 @@ function(therock_cmake_subproject_activate target_name)
         "-G${CMAKE_GENERATOR}"
         "-B${_binary_dir}"
         "-S${_cmake_source_dir}"
+        "-DCMAKE_BUILD_TYPE=${_cmake_build_type}"
         "-DCMAKE_INSTALL_PREFIX=${_stage_destination_dir}"
         "-DTHEROCK_STAGE_INSTALL_ROOT=${_stage_dir}"
         "-DCMAKE_TOOLCHAIN_FILE=${_cmake_project_toolchain_file}"
@@ -775,7 +789,7 @@ function(therock_cmake_subproject_activate target_name)
       LABEL "${target_name} install"
       # While useful for debugging, stage install logs are almost pure noise
       # for interactive use.
-      OUTPUT_ON_FAILURE ON
+      OUTPUT_ON_FAILURE "${THEROCK_QUIET_INSTALL}"
     )
     add_custom_command(
       OUTPUT "${_stage_stamp_file}"
@@ -1122,8 +1136,27 @@ function(_therock_cmake_subproject_setup_toolchain
     # simply forward flags from the system compiler to the toolchain compiler.
     string(APPEND _toolchain_contents "set(CMAKE_C_FLAGS_INIT \"@CMAKE_C_FLAGS@\")\n")
     string(APPEND _toolchain_contents "set(CMAKE_CXX_FLAGS_INIT \"@CMAKE_CXX_FLAGS@\")\n")
-    string(APPEND _toolchain_contents "set(CMAKE_EXE_LINKER_FLAGS_INIT @CMAKE_EXE_LINKER_FLAGS@)\n")
-    string(APPEND _toolchain_contents "set(CMAKE_SHARED_LINKER_FLAGS_INIT @CMAKE_SHARED_LINKER_FLAGS@)\n")
+    string(APPEND _toolchain_contents "set(CMAKE_EXE_LINKER_FLAGS_INIT \"@CMAKE_EXE_LINKER_FLAGS@\")\n")
+    string(APPEND _toolchain_contents "set(CMAKE_SHARED_LINKER_FLAGS_INIT \"@CMAKE_SHARED_LINKER_FLAGS@\")\n")
+  endif()
+
+  # Customize debug info generation.
+  if(THEROCK_MINIMAL_DEBUG_INFO)
+    # System toolchain can be either MSVC or another system compiler.
+    if(MSVC AND NOT compiler_toolchain)
+      # Set MSVC style debug options.
+      # TODO: For now, just set the default.
+    elseif((NOT compiler_toolchain AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+           OR compiler_toolchain)
+      # If the system compiler and GCC/clang or an explicit toolchain (which are all
+      # LLVM based).
+      string(APPEND _toolchain_contents "string(APPEND CMAKE_CXX_FLAGS_DEBUG \" -g1 -gz\")\n")
+      string(APPEND _toolchain_contents "string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO \" -g1 -gz\")\n")
+      string(APPEND _toolchain_contents "string(APPEND CMAKE_C_FLAGS_DEBUG \" -g1 -gz\")\n")
+      string(APPEND _toolchain_contents "string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO \" -g1 -gz\")\n")
+    else()
+      message(WARNING "Cannot setup THEROCK_MINIMAL_DEBUG_INFO mode for unknown compiler")
+    endif()
   endif()
 
   if(NOT compiler_toolchain)


### PR DESCRIPTION
This does several things:

* Adds a CMake file to do some global system compiler setup and put the `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` from the README in there for Windows (this file was doing more and I've started this half a dozen times but never finished, so just going to land it now).
* Ensures that `-Wl,--build-id` is set on any binaries that we are doing debug symbol splitting from.
* Hardcodes CMP0087 (enabling generator expressions in install CODE) to NEW. Some of our very old projects need this and it unfortunately is a policy that must be set globally vs scoped.
* Adds a `{project_name}_BUILD_TYPE` override, allowing fine grained setting of build type per project. Used in our packaging preset to have the compiler build in Release vs RelWithDebInfo (which saves us some 600MB of debug info for the common case where we trust the compiler or debug it with reproducers vs stack traces).
* Adds a `THEROCK_QUIET_INSTALL` defaulted to ON (present behavior) and sets it to OFF in our packaging preset as important diagnostic information is displayed at install time for packaging cases.
* Fixes up some toochain init flags and sets DEBUG/RELWITHDEBINFO flag defaults for a new `THEROCK_MINIMAL_DEBUG_INFO` configure option (enabling `-g1` debug info). Note that there may be more tuning needed here for precise incantation, but it gets very compiler specific from here when tuning debug flags.
* Adds a preset file where we can put official combinations used for packaging builds, etc.

A release packaging build can now be done with:

```
cmake --preset linux-release-package -Bbuild -DTHEROCK_AMDGPU_FAMILIES=gfx1100 -DCMAKE_C_COMPILER_LAUNCHER=ccache  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
```

More tuning is possible, but this gets us debug symbols that should be useful and are not of a size that is a non-starter:

```
$ du -h -d 0 *_dbg_*
54M     amd-llvm_dbg_generic
6.3M    base_dbg_generic
464M    blas_dbg_gfx1100
4.8M    core-hip_dbg_generic
3.5M    core-runtime_dbg_generic
25M     fft_dbg_gfx1100
9.8M    hipify_dbg_generic
928K    host-blas_dbg_generic
152K    host-suite-sparse_dbg_generic
34M     miopen_dbg_gfx1100
840M    prim_dbg_gfx1100
5.0M    rand_dbg_gfx1100
2.2M    rccl_dbg_gfx1100
40M     rocprofiler-sdk_dbg_generic
```

Predictably, the C++ template heavy prim is very bad. May add more project specific tuning, compiler specific flag setup to enable `-gmlt` with less debug info, or handle test/client debug symbols differently.