### PR TITLE
Add windows-base and windows-release to CMakePresets.json.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,7 +8,8 @@
   "configurePresets": [
     {
       "name": "linux-release-package",
-      "displayName": "Settings for Linux release packages",
+      "displayName": "Linux release packages",
+      "description": "Ninja generator, default compiler, RelWithDebInfo for most subprojects",
       "generator": "Ninja",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
@@ -19,6 +20,41 @@
         "THEROCK_MINIMAL_DEBUG_INFO": "ON",
         "THEROCK_QUIET_INSTALL": "OFF"
       }
+    },
+    {
+      "name": "windows-base",
+      "displayName": "Windows base preset",
+      "description": "Ninja generator, MSVC (cl.exe), x64 architecture",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "architecture": {
+        "value": "host=x64",
+        "strategy": "external"
+      },
+      "toolset": {
+        "value": "host=x64",
+        "strategy": "external"
+      },
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "cl.exe",
+        "CMAKE_CXX_COMPILER": "cl.exe"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "windows-release",
+      "displayName": "Windows release builds preset",
+      "description": "Ninja generator, MSVC (cl.exe), x64 architecture, Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      },
+      "inherits": [
+        "windows-base"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Following up on https://github.com/ROCm/TheRock/pull/691.

The vscode-cmake-tools extension for VSCode defaults to `auto` for the `cmake.useCMakePresets` setting, using `CMakePresets.json` if the file exists and disabling manual configuration via kit and build type selection: https://github.com/microsoft/vscode-cmake-tools/blob/main/docs/cmake-presets.md. Developers can either use a preset or set that option to `never`. I might do both, so this at least seeds the file with a preset that matches my current development setup:

![image](https://github.com/user-attachments/assets/f018c3b7-c6ff-40a9-be0d-3e44dbec05f3)
