### PR TITLE
[windows] Enforce MSVC (64 bit) during CMake configure.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,13 +304,6 @@ if(CMAKE_CXX_VISIBILITY_PRESET)
   list(APPEND DEFAULT_CMAKE_ARGS ${CMAKE_CXX_VISIBILITY_PRESET})
 endif()
 
-if(MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 4)
-  message(
-    FATAL_ERROR
-    "Cannot build 32-bit ROCm with MSVC: You must enable the Windows x64 "
-    "development tools and rebuild (detected compiler ${CMAKE_CXX_COMPILER})")
-endif()
-
 ################################################################################
 # Sysdep bundling
 # Each available bundled sysdep is made available with a global variable like

--- a/cmake/therock_compiler_config.cmake
+++ b/cmake/therock_compiler_config.cmake
@@ -6,3 +6,22 @@
 if(WIN32 AND NOT DEFINED CMAKE_MSVC_DEBUG_INFORMATION_FORMAT)
   set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
 endif()
+
+if(WIN32 AND NOT MSVC AND NOT THEROCK_DISABLE_MSVC_CHECK)
+  message(FATAL_ERROR
+      "Bootstrap compiler was expected to be MSVC (cl.exe). Instead found:\n"
+      "  Detected CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}\n"
+      "  Detected CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}\n"
+      "To use MSVC, try one of these:\n"
+      "  * Use one of the MSVC command prompts like `x64 Native Tools Command Prompt for VS 2022`\n"
+      "  * In your existing terminal, run `vcvars64.bat` from e.g. `C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Auxiliary\\Build`\n"
+      "  * Set `-DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe`\n"
+      "Set THEROCK_DISABLE_MSVC_CHECK to bypass this check.")
+endif()
+
+if(MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+  message(FATAL_ERROR
+    "Cannot build 32-bit ROCm with MSVC. You must enable the Windows x64 "
+    "development tools and rebuild.\n"
+    "  Detected CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")
+endif()


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/560.

This produces errors like:

```
PS D:\projects\TheRock> cmake -B build-win-test -GNinja . -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu
CMake Error at cmake/therock_compiler_config.cmake:11 (message):
  Bootstrap compiler was expected to be MSVC (cl.exe).  Instead found:

    CMAKE_C_COMPILER: C:/Strawberry/c/bin/gcc.exe
    CMAKE_CXX_COMPILER: C:/Strawberry/c/bin/c++.exe

  To use MSVC, try one of these:

    * Use one of the MSVC command prompts like `x64 Native Tools Command Prompt for VS 2022`
    * In your existing terminal, run `vcvars64.bat` from e.g. `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build`
    * Set `-DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe`

  Set THEROCK_DISABLE_MSVC_CHECK to bypass this check.
Call Stack (most recent call first):
  CMakeLists.txt:21 (include)


-- Configuring incomplete, errors occurred!
```

```
**********************************************************************
** Visual Studio 2022 Developer Command Prompt v17.12.4
** Copyright (c) 2022 Microsoft Corporation
**********************************************************************
[vcvarsall.bat] Environment initialized for: 'x86'

D:\projects\TheRock>cmake -B build-win-test-32 -GNinja . -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu
CMake Error at cmake/therock_compiler_config.cmake:23 (message):
  Cannot build 32-bit ROCm with MSVC.  You must enable the Windows x64
  development tools and rebuild.

    Detected CMAKE_CXX_COMPILER: C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/MSVC/14.42.34433/bin/Hostx86/x86/cl.exe
Call Stack (most recent call first):
  CMakeLists.txt:21 (include)


-- Configuring incomplete, errors occurred!
```