### PR TITLE
[ci] Move 'save cache' steps to the end of workflow files.

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -135,13 +135,6 @@ jobs:
           echo "-------------"
           ccache -s
 
-      - name: Save cache
-        uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
-        if: always()
-        with:
-          path: ${{ env.CACHE_DIR }}
-          key: linux-build-packages-manylinux-v2-${{ github.sha }}
-
       - name: Configure AWS Credentials
         if: always()
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
@@ -191,3 +184,10 @@ jobs:
           else
             echo "[INFO] No artifacts index found. Skipping artifact link."
           fi
+
+      - name: Save cache
+        uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        if: always()
+        with:
+          path: ${{ env.CACHE_DIR }}
+          key: linux-build-packages-manylinux-v2-${{ github.sha }}

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -180,13 +180,6 @@ jobs:
           echo "-------------"
           ccache -s
 
-      - name: Save cache
-        uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
-        if: always()
-        with:
-          path: ${{ env.CACHE_DIR }}
-          key: windows-build-packages-v3-${{ github.sha }}
-
       - name: "Build size report"
         if: always()
         shell: powershell
@@ -249,3 +242,10 @@ jobs:
           else
             echo "[INFO] No artifacts index found. Skipping artifact link."
           fi
+
+      - name: Save cache
+        uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        if: always()
+        with:
+          path: ${{ env.CACHE_DIR }}
+          key: windows-build-packages-v3-${{ github.sha }}


### PR DESCRIPTION
The save cache step is much slower than other post-build steps, particularly on Windows, where it can take upwards of 2 minutes. Reordering like this will ensure that we quickly upload logs and artifacts (which we always want) and later update the cache (which is only nice to have).