### PR TITLE
[ci] Split therock-dist and therock-archives into two job steps.

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -95,8 +95,7 @@ jobs:
         run: |
           pip install -r requirements.txt
 
-      - name: Build Projects
-        id: build
+      - name: Configure Projects
         run: |
           # Generate a new build id.
           package_version="${{ inputs.package_version }}"
@@ -112,7 +111,11 @@ jobs:
             -DBUILD_TESTING=ON \
             ${extra_cmake_options}
 
-          cmake --build build --target therock-archives therock-dist
+      - name: Build therock-dist
+        run: cmake --build build --target therock-dist
+
+      - name: Build therock-archives
+        run: cmake --build build --target therock-archives
 
       - name: Test Packaging
         if: ${{ github.event.repository.name == 'TheRock' }}

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -161,8 +161,11 @@ jobs:
             -DTHEROCK_ENABLE_ML_LIBS=OFF \
             ${extra_cmake_options}
 
-      - name: Build Projects
-        run: cmake --build "${{ env.BUILD_DIR_BASH }}" --target therock-archives therock-dist
+      - name: Build therock-dist
+        run: cmake --build "${{ env.BUILD_DIR_BASH }}" --target therock-dist
+
+      - name: Build therock-archives
+        run: cmake --build "${{ env.BUILD_DIR_BASH }}" --target therock-archives
 
       - name: Report
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Archive creation is slow (https://github.com/ROCm/TheRock/issues/726), so I'd like to segment the jobs steps so we can see time measurements for each phase more easily.

If building both targets in the same command, we could overlap and exploit CPU parallelism. Not sure how much that practically helps though. Compression is CPU-bound and we don't want to oversubscribe.

Timing from the checks on this PR (sample size of 1): https://github.com/ROCm/TheRock/actions/runs/15311804950?pr=729

job | `therock-dist` time | `therock-archives` time
-- | --: | --:
Linux gfx94x | 1h 35m | 6m 50s
Linux gfx110x | 1h 50m | 4m 20s
Windows gfx110x | 50m | 1h 1m 30s

Timing after the compression level changes in https://github.com/ROCm/TheRock/pull/732:

job | `therock-dist` time | `therock-archives` time
-- | --: | --:
Linux gfx94x | 1h 51m  | 2m35s
Linux gfx110x | 2h 20m | 1m 13s
Windows gfx110x | 48m | 10m 17s