### PR TITLE
Reduce LZMA compression for faster therock-archives builds.

### DIFF
--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -235,7 +235,7 @@ def do_artifact_archive(args):
         output_path.unlink()
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with _open_archive(output_path) as arc:
+    with _open_archive(output_path, args.compression_level) as arc:
         for artifact_path in args.artifact:
             manifest_path: Path = artifact_path / "artifact_manifest.txt"
             relpaths = manifest_path.read_text().splitlines()
@@ -258,8 +258,8 @@ def do_artifact_archive(args):
         write_hash(args.hash_file, digest)
 
 
-def _open_archive(p: Path) -> tarfile.TarFile:
-    return tarfile.TarFile.open(p, mode="x:xz")
+def _open_archive(p: Path, compression_level: int) -> tarfile.TarFile:
+    return tarfile.TarFile.open(p, mode="x:xz", preset=compression_level)
 
 
 def _do_artifact_flatten(args):
@@ -370,6 +370,12 @@ def main(cl_args: list[str]):
     )
     artifact_archive_p.add_argument(
         "-o", type=Path, required=True, help="Output archive name"
+    )
+    artifact_archive_p.add_argument(
+        "--compression-level",
+        type=int,
+        default=6,
+        help="LZMA compression preset level [0-9, default 6]",
     )
     artifact_archive_p.add_argument(
         "--hash-file",

--- a/cmake/therock_artifacts.cmake
+++ b/cmake/therock_artifacts.cmake
@@ -91,6 +91,9 @@ function(therock_provide_artifact slice_name)
     set(_archive_file "${THEROCK_BINARY_DIR}/artifacts/${slice_name}_${_component}${_bundle_suffix}${THEROCK_ARTIFACT_ARCHIVE_SUFFIX}.tar.xz")
     list(APPEND _archive_files "${_archive_file}")
     set(_archive_sha_file "${_archive_file}.sha256sum")
+    # TODO(#726): Lower compression levels are much faster for development and CI.
+    #             Set back to 6+ for production builds?
+    set(_archive_compression_level 2)
     add_custom_command(
       OUTPUT
         "${_archive_file}"
@@ -100,6 +103,7 @@ function(therock_provide_artifact slice_name)
         "${Python3_EXECUTABLE}" "${_fileset_tool}"
         artifact-archive "${_component_dir}"
           -o "${_archive_file}"
+          --compression-level "${_archive_compression_level}"
           --hash-file "${_archive_sha_file}" --hash-algorithm sha256
       DEPENDS
         "${_manifest_file}"


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/726.

That issue has more data, but the most relevant experiment was generating `amd-llvm_dev_generic.tar.xz` on my dev machine with different compression settings:

preset | size | time | notes
-- | -- | -- | --
0 | 139.8 MB | 15.6 seconds |
1 | 123.9 MB | 17.6 seconds |
2 | 115.3 MB | 23.0 seconds | Proposal A
3 | 109.5 MB | 35.7 seconds | Proposal B
4 | 107.6 MB | 66.9 seconds |
5 | 98.24 MB | 107.2 seconds |
6 | 95.14 MB | 140.7 seconds | Default
7 | 91.75 MB | 158.7 seconds |
8 | 89.44 MB | 175.7 seconds |
9 | 87.47 MB | 183.7 seconds |

Timing before (https://github.com/ROCm/TheRock/actions/runs/15327687672):

job | `therock-dist` time | `therock-archives` time
-- | --: | --:
Linux gfx94x | 1h 35m | 6m 50s
Linux gfx110x | 1h 50m | 4m 20s
Windows gfx110x | 50m | 1h 1m 30s

Timing after (https://github.com/ROCm/TheRock/actions/runs/15327687672):

job | `therock-dist` time | `therock-archives` time
-- | --: | --:
Linux gfx94x | 1h 51m  | 2m35s
Linux gfx110x | 2h 20m | 1m 13s
Windows gfx110x | 48m | 10m 17s