### PR TITLE
[torch] Add patch 0015-Preload-rocm-sdk-binaries-if-available.

### DIFF
--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0015-Preload-rocm-sdk-binaries-if-available.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0015-Preload-rocm-sdk-binaries-if-available.patch
@@ -1,0 +1,58 @@
+From d4766226a97bda7ac74acd938404f771702399c3 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Tue, 1 Apr 2025 18:49:42 -0700
+Subject: [PATCH 15/15] Preload rocm-sdk binaries if available.
+
+---
+ torch/__init__.py | 28 +++++++++++++++++++++++++++-
+ 1 file changed, 27 insertions(+), 1 deletion(-)
+
+diff --git a/torch/__init__.py b/torch/__init__.py
+index a531f80bae..5eea9a4c79 100644
+--- a/torch/__init__.py
++++ b/torch/__init__.py
+@@ -299,6 +299,30 @@ def _preload_cuda_deps(lib_folder: str, lib_name: str) -> None:
+ 
+ # See Note [Global dependencies]
+ def _load_global_deps() -> None:
++    # Preload ROCm deps if this torch was built to link against rocm-sdk wheels.
++    # TODO: Lookup distribution info for the torch package and see if it was
++    # build with PYTORCH_EXTRA_INSTALL_REQUIREMENTS="rocm-sdk" to enable
++    # ROCm preloading.
++    try:
++        import rocm_sdk
++    except ModuleNotFoundError:
++        pass
++    else:
++        import rocm_sdk
++        rocm_sdk.preload_libraries(
++            "amdhip64",
++            # Enable once aqlprofiler is available.
++            #"rocprofiler-sdk-roctx",
++            "hiprtc",
++            "hipblas",
++            "hipfft",
++            "hiprand",
++            "hipsparse",
++            "hipsolver",
++            "rccl",
++            "hipblaslt",
++        )
++
+     if _running_with_deploy() or platform.system() == "Windows":
+         return
+ 
+@@ -2574,7 +2598,9 @@ def compile(
+         nopython=fullgraph,
+         dynamic=dynamic,
+         disable=disable,
+-    )(model)  # type: ignore[return-value]
++    )(
++        model
++    )  # type: ignore[return-value]
+ 
+ 
+ def _register_device_module(device_type, module):
+-- 
+2.43.0
+


### PR DESCRIPTION
* This is needed to enable rocm-sdk wheel based builds of PyTorch.
* See also #733.

Progress on #703.