### PR TITLE
[windows] Add minimum MSVC_VERSION check.

### DIFF
--- a/cmake/therock_compiler_config.cmake
+++ b/cmake/therock_compiler_config.cmake
@@ -19,6 +19,23 @@ if(WIN32 AND NOT MSVC AND NOT THEROCK_DISABLE_MSVC_CHECK)
       "Set THEROCK_DISABLE_MSVC_CHECK to bypass this check.")
 endif()
 
+if(MSVC AND MSVC_VERSION LESS_EQUAL 1941 AND NOT THEROCK_DISABLE_MSVC_VERSION_CHECK)
+  # See https://github.com/ROCm/TheRock/issues/711. We can probably remove this
+  # check after adding openmp to LLVM_ENABLE_RUNTIMES in pre_hook_amd-llvm.cmake.
+  #
+  # For the compiler version mapping, see
+  # https://learn.microsoft.com/en-us/cpp/overview/compiler-versions
+  message(FATAL_ERROR
+      "Detected MSVC_VERSION is too old and may encounter OpenMP linker errors.\n"
+      "  Detected MSVC_VERSION: ${MSVC_VERSION}\n"
+      "  Detected MSVC_TOOLSET_VERSION: ${MSVC_TOOLSET_VERSION}\n"
+      "  Detected CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}\n"
+      "We recommend at least Visual Studio [Build Tools] version 17.12.*, with:\n"
+      "  * MSVC_VERSION 1942\n"
+      "  * CMAKE_CXX_COMPILER_VERSION version 19.42.*\n"
+      "Set THEROCK_DISABLE_MSVC_VERSION_CHECK to bypass this check.")
+endif()
+
 if(MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 4)
   message(FATAL_ERROR
     "Cannot build 32-bit ROCm with MSVC. You must enable the Windows x64 "


### PR DESCRIPTION
This is a workaround for https://github.com/ROCm/TheRock/issues/711, where `libomp.lib` from MSVC produces link errors against hipSPARSE if the MSVC version is too old. I've separately started trying to enable openmp source builds on Windows via amd-llvm so this will be less brittle, but the support story there is less clear.

From the table at https://learn.microsoft.com/en-us/cpp/overview/compiler-versions:

Visual Studio version | `_MSC_VER` | Notes
-- | -- | --
Visual Studio 2022 version 17.11 | 1941 | issues for that user, so checking for LESS_EQUAL this
Visual Studio 2022 version 17.12 | 1942 | okay for me
Visual Studio 2022 version 17.13 | 1943
Visual Studio 2022 version 17.14 | 1944 | okay for that user