### PR TITLE
[monorepo] Allow building hipCUB and rocThrust from the monorepo

### DIFF
--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -104,8 +104,15 @@ if(THEROCK_ENABLE_PRIM)
   therock_cmake_subproject_provide_package(rocPRIM rocprim lib/cmake/rocprim)
   therock_cmake_subproject_activate(rocPRIM)
 
+  if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+    set(_hipcub_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipcub")
+  else()
+    set(_hipcub_source_dir "hipCUB")
+  endif()
+
   therock_cmake_subproject_declare(hipCUB
-    EXTERNAL_SOURCE_DIR "hipCUB"
+    EXTERNAL_SOURCE_DIR "${_hipcub_source_dir}"
+    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hipCUB"
     BACKGROUND_BUILD
     CMAKE_ARGS
       -DHIP_PLATFORM=amd
@@ -128,8 +135,15 @@ if(THEROCK_ENABLE_PRIM)
   therock_cmake_subproject_provide_package(hipCUB hipcub lib/cmake/hipcub)
   therock_cmake_subproject_activate(hipCUB)
 
+  if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+    set(_rocthrust_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocthrust")
+  else()
+    set(_rocthrust_source_dir "rocThrust")
+  endif()
+
   therock_cmake_subproject_declare(rocThrust
-    EXTERNAL_SOURCE_DIR "rocThrust"
+    EXTERNAL_SOURCE_DIR "${_rocthrust_source_dir}"
+    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocThrust"
     BACKGROUND_BUILD
     CMAKE_ARGS
       -DHIP_PLATFORM=amd


### PR DESCRIPTION
Previously in the monorepo, running into an issue where `hipcub` was searching for a `rocprim` component, however since the `rocprim` version was ahead and `hipcub` was behind in our CMake, it was causing issues from [this monorepo run](https://github.com/ROCm/rocm-libraries/actions/runs/15304213808/job/43053064260) such as:

```
hipCUB] /__w/rocm-libraries/rocm-libraries/math-libs/hipCUB/hipcub/include/hipcub/backend/rocprim/util_type.hpp:786:32: error: no template named 'radix_key_codec' in namespace 'rocprim'
[hipCUB]   786 |     using key_codec = rocprim::radix_key_codec<T>;
[hipCUB]       |                       ~~~~~~~~~^
```


This [TheRock CI monorepo run](https://github.com/ROCm/rocm-libraries/actions/runs/15330308230/job/43135536362) proves it is working! and this will point to the correct commit in monorepo and work! (although s3 upload may not be working, but ignore that since that's in another PR)