### PR TITLE
Adding test timeouts

### DIFF
--- a/.github/workflows/test_hipblaslt.yml
+++ b/.github/workflows/test_hipblaslt.yml
@@ -66,6 +66,7 @@ jobs:
         run: sudo apt install libgfortran5 -y
 
       - name: Run hipBLASLt tests
+        timeout-minutes: 30
         run: |
           if [ "${{ inputs.PLATFORM }}" == "linux" ]; then source ${VENV_DIR}/bin/activate ; else . ${VENV_DIR}/Scripts/activate ; fi
           ${THEROCK_BIN_DIR}/hipblaslt-test --gtest_filter=*pre_checkin*

--- a/.github/workflows/test_hipcub.yml
+++ b/.github/workflows/test_hipcub.yml
@@ -65,4 +65,8 @@ jobs:
 
       - name: Run hipcub tests
         run: |
-          ctest --test-dir ${THEROCK_BIN_DIR}/hipcub --output-on-failure --parallel 8
+          ctest \
+            --test-dir ${THEROCK_BIN_DIR}/hipcub \
+            --output-on-failure \
+            --parallel 8 \
+            --timeout 360

--- a/.github/workflows/test_rocblas.yml
+++ b/.github/workflows/test_rocblas.yml
@@ -66,6 +66,7 @@ jobs:
         run: sudo apt install libgfortran5 -y
 
       - name: Run rocBLAS tests
+        timeout-minutes: 5
         run: |
           ROCBLAS_TENSILE_LIBPATH="${BUILD_ARTIFACTS_DIR}/output_dir/lib/rocblas/library/"
           if [ "${{ inputs.PLATFORM }}" == "linux" ]; then source ${VENV_DIR}/bin/activate ; else . ${VENV_DIR}/Scripts/activate ; fi

--- a/.github/workflows/test_rocprim.yml
+++ b/.github/workflows/test_rocprim.yml
@@ -73,4 +73,5 @@ jobs:
           ctest --test-dir ${THEROCK_BIN_DIR}/rocprim \
             --output-on-failure \
             --parallel 8 \
-            --exclude-regex ${TEST_TO_IGNORE}
+            --exclude-regex ${TEST_TO_IGNORE} \
+            --timeout 900

--- a/.github/workflows/test_rocthrust.yml
+++ b/.github/workflows/test_rocthrust.yml
@@ -71,4 +71,5 @@ jobs:
             --test-dir ${THEROCK_BIN_DIR}/rocthrust \
             --output-on-failure \
             --parallel 8 \
-            --exclude-regex "^copy.hip$|scan.hip"
+            --exclude-regex "^copy.hip$|scan.hip" \
+            --timeout 300

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -68,4 +68,4 @@ jobs:
       - name: Run ROCm Sanity Tests
         run: |
           if [ "${{ inputs.PLATFORM }}" == "linux" ]; then source ${VENV_DIR}/bin/activate ; else . ${VENV_DIR}/Scripts/activate ; fi
-          pytest tests/ --log-cli-level=info
+          pytest tests/ --log-cli-level=info --timeout=60

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest==8.3.5
 pytest-check==2.5.3
+pytest-timeout==2.4.0
 PyYAML==6.0.2


### PR DESCRIPTION
this doesn't solve the long timeout waits for tests, but it will make sure we aren't running tests for 6 hours

example working [in this TheRock CI](https://github.com/ROCm/TheRock/actions/runs/15330898545)

Closes on #698 as it will fix the timeout issue