### PR TITLE
[ci] Skip CI for changes to only experimental/.

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -129,6 +129,8 @@ SKIPPABLE_PATH_PATTERNS = [
     # workflows efficient when only nodes closer to the edges of the build graph
     # are changed.
     "external-builds/*",
+    # Changes to experimental code do not run standard build/test workflows.
+    "experimental/*",
 ]
 
 

--- a/build_tools/github_actions/configure_ci_test.py
+++ b/build_tools/github_actions/configure_ci_test.py
@@ -18,6 +18,11 @@ class ConfigureCITest(TestCase):
         run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
         self.assertFalse(run_ci)
 
+    def test_dont_run_ci_if_only_external_builds_edited(self):
+        paths = ["experimental/file.h"]
+        run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
+        self.assertFalse(run_ci)
+
     def test_run_ci_if_related_workflow_file_edited(self):
         paths = [".github/workflows/ci.yml"]
         run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
@@ -204,7 +209,17 @@ class ConfigureCITest(TestCase):
             platform="windows",
         )
         windows_target_output.sort(key=lambda item: item["family"])
-        windows_target_to_compare = [{"test-runs-on": "", "family": "gfx110X-dgpu"}]
+        windows_target_to_compare = [
+            {
+                "test-runs-on": "",
+                "family": "gfx110X-dgpu",
+            },
+            {
+                "test-runs-on": "windows-strix-halo-gpu-rocm",
+                "family": "gfx1151",
+                "pytorch-target": "gfx1151",
+            },
+        ]
         windows_target_to_compare.sort(key=lambda item: item["family"])
         self.assertEqual(windows_target_output, windows_target_to_compare)
 


### PR DESCRIPTION
Same logic as `external-builds/` for the current code (only affecting pytorch builds, which are not part of the core CI build/test), plus the added "experimental" nature of any future code in that directory.

Also fixed the test (since we don't yet run it).