### PR TITLE
Run more Python unit tests on CI.

### DIFF
--- a/build_tools/CMakeLists.txt
+++ b/build_tools/CMakeLists.txt
@@ -1,11 +1,19 @@
-add_test(
-    NAME build_tools_fileset_tool_test
-    COMMAND "${Python3_EXECUTABLE}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/tests/fileset_tool_test.py"
-)
+add_subdirectory(github_actions)
 
 add_test(
     NAME build_tools_artifacts_test
     COMMAND "${Python3_EXECUTABLE}"
         "${CMAKE_CURRENT_SOURCE_DIR}/tests/artifacts_test.py"
+)
+
+add_test(
+    NAME build_tools_fetch_artifacts_test
+    COMMAND "${Python3_EXECUTABLE}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/tests/fetch_artifacts_test.py"
+)
+
+add_test(
+    NAME build_tools_fileset_tool_test
+    COMMAND "${Python3_EXECUTABLE}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/tests/fileset_tool_test.py"
 )

--- a/build_tools/github_actions/CMakeLists.txt
+++ b/build_tools/github_actions/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_test(
+    NAME build_tools_github_actions_configure_ci_test
+    COMMAND "${Python3_EXECUTABLE}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/tests/configure_ci_test.py"
+)

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -1,4 +1,9 @@
+from pathlib import Path
 from unittest import TestCase, main
+import os
+import sys
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import configure_ci
 
 

--- a/build_tools/tests/fetch_artifacts_test.py
+++ b/build_tools/tests/fetch_artifacts_test.py
@@ -1,11 +1,15 @@
 from pathlib import Path
+import os
 import subprocess
 import sys
 import tarfile
 import tempfile
 import unittest
-from unittest.mock import patch
 import urllib.request
+from unittest.mock import patch
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
 from fetch_artifacts import (
     IndexPageParser,
     retrieve_s3_artifacts,
@@ -13,14 +17,15 @@ from fetch_artifacts import (
     FetchArtifactException,
 )
 
-PARENT_DIR = Path(__file__).resolve().parent.parent
+THIS_DIR = Path(__file__).resolve().parent
+REPO_DIR = THIS_DIR.parent.parent
 
 
 def run_indexer_file(temp_dir):
     subprocess.run(
         [
             sys.executable,
-            PARENT_DIR / "third-party" / "indexer" / "indexer.py",
+            REPO_DIR / "third-party" / "indexer" / "indexer.py",
             "-f",
             "*.tar.xz*",
             temp_dir,


### PR DESCRIPTION
Running these recently added Python unit tests on CI will help encourage good development practices (see also https://github.com/ROCm/TheRock/issues/750). I just noticed older tests already running here: https://github.com/ROCm/TheRock/blob/13ef7021af1f183e9344ec177ccb79c16426385e/.github/workflows/build_linux_packages.yml#L120-L123

Sample logs from https://github.com/ROCm/TheRock/actions/runs/15339038605/job/43221678538#step:12:12:
```
Run ctest --test-dir build --output-on-failure
Internal ctest changing into directory: /__w/TheRock/TheRock/build
Test project /__w/TheRock/TheRock/build
      Start  1: build_tools_fileset_tool_test
 1/25 Test  #1: build_tools_fileset_tool_test .........................   Passed    0.30 sec
      Start  2: build_tools_artifacts_test
 2/25 Test  #2: build_tools_artifacts_test ............................   Passed    0.06 sec
      Start  3: therock-validate-shared-lib-librocm-openblas.so
 3/25 Test  #3: therock-validate-shared-lib-librocm-openblas.so .......   Passed    0.04 sec
      Start  4: therock-validate-shared-lib-libamd.so
 4/25 Test  #4: therock-validate-shared-lib-libamd.so .................   Passed    0.03 sec
...
```

We'll probably want to run the Python unit tests much earlier in the build, but this is better than not running them anywhere. We could also run these via pytest instead of ctest.