### PR TITLE
[rocprof] Include binary-only advanced trace decoder in the build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ else()
   # TODO(#36): Could provide an alternate or no-op "core runtime" instead?
   set(_hip_runtime_platform_requirements "")
 endif()
+
 therock_add_feature(HIP_RUNTIME
   GROUP CORE
   DESCRIPTION "Enables the HIP runtime"
@@ -185,6 +186,10 @@ therock_add_feature(HIP_RUNTIME
 
 # Profiler Features.
 if(NOT WIN32)
+  therock_add_feature(ROCPROF_TRACE_DECODER_BINARY
+    GROUP PROFILER
+    DESCRIPTION "Enables the closed-source rocprof trace decoder binary"
+  )
   # Other platforms (Linux) _do_ have the profiler SDK.
   therock_add_feature(ROCPROFV3
     GROUP PROFILER

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -1,4 +1,31 @@
 if(THEROCK_ENABLE_ROCPROFV3)
+  set(_rocprofiler_sdk_optional_deps)
+
+  ##############################################################################
+  # rocprof-trace-decoder-binary
+  # The trace decoder is responsible for decoding advanced thread traces from
+  # the GPU. It is a binary-only dependency of ROCm which is enabled at
+  # runtime via `rocprofv3 --att`. If an appropriate shared library is adjacent
+  # to the profiler shared libraries, it will be used by default.
+  # See: https://github.com/ROCm/rocprof-trace-decoder/
+  ##############################################################################
+  if(THEROCK_ENABLE_ROCPROF_TRACE_DECODER_BINARY)
+    therock_subproject_fetch(rocprof-trace-decoder-download
+      SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprof-trace-decoder-binary/download"
+      URL https://github.com/ROCm/rocprof-trace-decoder/releases/download/v0.1.0/rocprof-trace-decoder-manylinux-2.28-0.1.0-Linux.tar.gz
+      URL_HASH SHA256=8a6dfd3c100b88ea54e75809136e323a351e8d3aafbf848d66c371ce55a325cb
+      TOUCH
+        "${CMAKE_CURRENT_BINARY_DIR}/rocprof-trace-decoder-binary/download/stamp"
+    )
+    therock_cmake_subproject_declare(rocprof-trace-decoder-binary
+      EXTERNAL_SOURCE_DIR "rocprof-trace-decoder-binary"
+      BACKGROUND_BUILD
+      EXTRA_DEPENDS
+        "${CMAKE_CURRENT_BINARY_DIR}/rocprof-trace-decoder-binary/download/stamp"
+    )
+    therock_cmake_subproject_activate(rocprof-trace-decoder-binary)
+    list(APPEND _rocprofiler_sdk_optional_deps rocprof-trace-decoder-binary)
+  endif()
 
   ##############################################################################
   # aqlprofile
@@ -31,6 +58,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
       aqlprofile
       hip-clr
       rocprofiler-register
+      ${_rocprofiler_sdk_optional_deps}
       ${THEROCK_BUNDLED_ELFUTILS}
       ${THEROCK_BUNDLED_LIBDRM}
       ${THEROCK_BUNDLED_SQLITE3}

--- a/profiler/rocprof-trace-decoder-binary/CMakeLists.txt
+++ b/profiler/rocprof-trace-decoder-binary/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.25)
+project(rocprof-trace-decoder-binary)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(_shlib_path "${CMAKE_CURRENT_BINARY_DIR}/../download/opt/rocm/lib/librocprof-trace-decoder.so")
+  install(FILES "${_shlib_path}" TYPE LIB)
+else()
+  message(FATAL_ERROR "Unsupported system")
+endif()


### PR DESCRIPTION
* Gated by THEROCK_ROCPROF_TRACE_DECODER_BINARY feature flag (default to ON on Linux).
* Fetches the manylinux release artifact and installs it into the dist tree.
* Adds a runtime dep to rocprofiler-sdk so the library goes anywhere it does. Note that `rocprofv3` dynamically loads the library if the `--att` argument is given. Otherwise, it is not implicated in the build.

Intended to stack on top of #752.

When both land, the following test does indeed emit att trace files: `./rocprofv3 --att -r -- ./hipblaslt-test`