### PR TITLE
Add nightly schedule for Pytorch Wheels

### DIFF
--- a/.github/workflows/build_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_linux_pytorch_wheels.yml
@@ -15,6 +15,7 @@ on:
       find_links:
         required: true
         type: string
+  workflow_dispatch:
 
 permissions:
   id-token: write

--- a/.github/workflows/build_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_linux_pytorch_wheels.yml
@@ -16,6 +16,19 @@ on:
         required: true
         type: string
   workflow_dispatch:
+    inputs:
+      family:
+        required: true
+        type: string
+      target:
+        required: true
+        type: string
+      python_version:
+        required: true
+        type: string
+      find_links:
+        required: true
+        type: string
 
 permissions:
   id-token: write

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -33,7 +33,9 @@ jobs:
         with:
           workflow: build_linux_pytorch_wheels.yml
           inputs: |
-            family: ${{ steps.set_family.outputs.family }}
-            target: ${{ matrix.target }}
-            python_version: ${{ matrix.python_version }}
-            find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ steps.set_family.outputs.family }}/index.html
+            {
+              "family": "${{ steps.set_family.outputs.family }}",
+              "target": "${{ matrix.target }}",
+              "python_version": "${{ matrix.python_version }}",
+              "find_links": "https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ steps.set_family.outputs.family }}/index.html"
+            }

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -10,29 +10,30 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    runs-on: ubuntu-24.04
+  dispatch:
     strategy:
       fail-fast: false
       matrix:
         target: [gfx942, gfx1100, gfx1201]
         python_version: ["3.11", "3.12"]
-
+    runs-on: ubuntu-24.04
     steps:
-      - name: Set family based on target
+      - name: Set family
         id: set_family
         run: |
           case "${{ matrix.target }}" in
             gfx942) echo "family=gfx94X-dcgpu" >> $GITHUB_OUTPUT ;;
             gfx1100) echo "family=gfx110X-dgpu" >> $GITHUB_OUTPUT ;;
             gfx1201) echo "family=gfx120X-all" >> $GITHUB_OUTPUT ;;
-            *) echo "Unknown target: ${{ matrix.target }}" && exit 1 ;;
+            *) echo "Unknown target"; exit 1 ;;
           esac
 
-      - name: Call build workflow
-        uses: ROCm/TheRock/.github/workflows/build_linux_pytorch_wheels.yml@main
+      - name: Trigger reusable workflow  
+        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc #1.2.4
         with:
-          family: ${{ steps.set_family.outputs.family }}
-          target: ${{ matrix.target }}
-          python_version: ${{ matrix.python_version }}
-          find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ steps.set_family.outputs.family }}/index.html
+          workflow: build_linux_pytorch_wheels.yml
+          inputs: |
+            family: ${{ steps.set_family.outputs.family }}
+            target: ${{ matrix.target }}
+            python_version: ${{ matrix.python_version }}
+            find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ steps.set_family.outputs.family }}/index.html

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -2,15 +2,8 @@ name: Release Linux PyTorch Wheels
 
 on:
   workflow_dispatch:
-    inputs:
-      target:
-        description: "Target gfx architecture (e.g., gfx942)"
-        required: true
-        type: string
-      family:
-        description: "Family name (e.g., gfx94X-dcgpu)"
-        required: true
-        type: string
+  schedule:
+    - cron: "0 2 * * *" # Runs nightly at 2 AM UTC
 
 permissions:
   id-token: write
@@ -21,11 +14,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        include:
+          - target: gfx942
+            family: gfx94X-dcgpu
+          - target: gfx1100
+            family: gfx110X-dgpu
+          - target: gfx1201
+            family: gfx120X-all
         python_version: ["3.11", "3.12"]
 
     uses: ./.github/workflows/build_linux_pytorch_wheels.yml
     with:
-      family: ${{ inputs.family }}
+      family: ${{ matrix.family }}
       python_version: ${{ matrix.python_version }}
-      target: ${{ inputs.target }}
-      find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ inputs.family }}/index.html
+      target: ${{ matrix.target }}
+      find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ matrix.family }}/index.html
+    secrets: inherit

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -38,4 +38,3 @@ jobs:
           python_version: ${{ matrix.python_version }}
           target: ${{ matrix.target }}
           find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ steps.set_family.outputs.family }}/index.html
-        secrets: inherit

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -10,7 +10,6 @@ permissions:
   contents: read
   actions: write # Added permission to trigger workflows
 
-
 jobs:
   dispatch:
     strategy:
@@ -30,7 +29,7 @@ jobs:
             *) echo "Unknown target"; exit 1 ;;
           esac
 
-      - name: Trigger reusable workflow  
+      - name: Trigger Build-Linux-PyTorch-Wheels workflow
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc #1.2.4
         with:
           workflow: build_linux_pytorch_wheels.yml

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -3,41 +3,40 @@ name: Release Linux PyTorch Wheels
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 2 * * *"  # Runs nightly at 2 AM UTC
+    - cron: "0 2 * * *"  # Nightly at 2 AM UTC
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  set_family_and_dispatch:
-    runs-on: ubuntu-24.04
+  build:
     strategy:
       fail-fast: false
       matrix:
-        target: [gfx942, gfx1100, gfx1201]
-        python_version: ["3.11", "3.12"]
-    outputs:
-      build-matrix: ${{ steps.set.outputs.build_matrix }}
+        include:
+          - target: gfx942
+            family: gfx94X-dcgpu
+            python_version: "3.11"
+          - target: gfx942
+            family: gfx94X-dcgpu
+            python_version: "3.12"
+          - target: gfx1100
+            family: gfx110X-dgpu
+            python_version: "3.11"
+          - target: gfx1100
+            family: gfx110X-dgpu
+            python_version: "3.12"
+          - target: gfx1201
+            family: gfx120X-all
+            python_version: "3.11"
+          - target: gfx1201
+            family: gfx120X-all
+            python_version: "3.12"
 
-    steps:
-      - name: Set family from target
-      - id: set
-        run: |
-          family=""
-          case "${{ matrix.target }}" in
-            gfx942) family="gfx94X-dcgpu" ;;
-            gfx1100) family="gfx110X-dgpu" ;;
-            gfx1201) family="gfx120X-all" ;;
-            *) echo "Unknown target"; exit 1 ;;
-          esac
-          echo "FAMILY=$family" >> $GITHUB_ENV
-          echo "family=$family" >> $GITHUB_OUTPUT
-
-      - name: Dispatch Build Linux Pytorch Wheels
-        uses: ./.github/workflows/build_linux_pytorch_wheels.yml
-        with:
-          family: ${{ steps.set.outputs.family }}
-          python_version: ${{ matrix.python_version }}
-          target: ${{ matrix.target }}
-          find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ steps.set.outputs.family }}/index.html
+    uses: ./.github/workflows/build_linux_pytorch_wheels.yml
+    with:
+      family: ${{ matrix.family }}
+      python_version: ${{ matrix.python_version }}
+      target: ${{ matrix.target }}
+      find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ matrix.family }}/index.html

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   id-token: write
   contents: read
+  actions: write # Added permission to trigger workflows
+
 
 jobs:
   dispatch:

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -32,6 +32,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc #1.2.4
         with:
           workflow: build_linux_pytorch_wheels.yml
+          token: ${{ secrets.GITHUB_TOKEN }}
           inputs: |
             {
               "family": "${{ steps.set_family.outputs.family }}",

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python_version: ["3.11", "3.12"]
         include:
           - target: gfx942
             family: gfx94X-dcgpu
@@ -21,7 +22,6 @@ jobs:
             family: gfx110X-dgpu
           - target: gfx1201
             family: gfx120X-all
-        python_version: ["3.11", "3.12"]
 
     uses: ./.github/workflows/build_linux_pytorch_wheels.yml
     with:

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -10,31 +10,34 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  set_family_and_dispatch:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         target: [gfx942, gfx1100, gfx1201]
         python_version: ["3.11", "3.12"]
+    outputs:
+      build-matrix: ${{ steps.set.outputs.build_matrix }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Set family from target
-        id: set_family
+      - id: set
         run: |
-          case ${{ matrix.target }} in
-            gfx942) echo "family=gfx94X-dcgpu" >> $GITHUB_OUTPUT ;;
-            gfx1100) echo "family=gfx110X-dgpu" >> $GITHUB_OUTPUT ;;
-            gfx1201) echo "family=gfx120X-all" >> $GITHUB_OUTPUT ;;
+          family=""
+          case "${{ matrix.target }}" in
+            gfx942) family="gfx94X-dcgpu" ;;
+            gfx1100) family="gfx110X-dgpu" ;;
+            gfx1201) family="gfx120X-all" ;;
+            *) echo "Unknown target"; exit 1 ;;
           esac
+          echo "FAMILY=$family" >> $GITHUB_ENV
+          echo "family=$family" >> $GITHUB_OUTPUT
 
-      - name: Reinvoke reusable build workflow
+      - name: Dispatch Build Linux Pytorch Wheels
         uses: ./.github/workflows/build_linux_pytorch_wheels.yml
         with:
-          family: ${{ steps.set_family.outputs.family }}
+          family: ${{ steps.set.outputs.family }}
           python_version: ${{ matrix.python_version }}
           target: ${{ matrix.target }}
-          find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ steps.set_family.outputs.family }}/index.html
+          find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ steps.set.outputs.family }}/index.html

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -11,32 +11,28 @@ permissions:
 
 jobs:
   build:
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - target: gfx942
-            family: gfx94X-dcgpu
-            python_version: "3.11"
-          - target: gfx942
-            family: gfx94X-dcgpu
-            python_version: "3.12"
-          - target: gfx1100
-            family: gfx110X-dgpu
-            python_version: "3.11"
-          - target: gfx1100
-            family: gfx110X-dgpu
-            python_version: "3.12"
-          - target: gfx1201
-            family: gfx120X-all
-            python_version: "3.11"
-          - target: gfx1201
-            family: gfx120X-all
-            python_version: "3.12"
+        target: [gfx942, gfx1100, gfx1201]
+        python_version: ["3.11", "3.12"]
 
-    uses: ./.github/workflows/build_linux_pytorch_wheels.yml
-    with:
-      family: ${{ matrix.family }}
-      python_version: ${{ matrix.python_version }}
-      target: ${{ matrix.target }}
-      find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ matrix.family }}/index.html
+    steps:
+      - name: Set family based on target
+        id: set_family
+        run: |
+          case "${{ matrix.target }}" in
+            gfx942) echo "family=gfx94X-dcgpu" >> $GITHUB_OUTPUT ;;
+            gfx1100) echo "family=gfx110X-dgpu" >> $GITHUB_OUTPUT ;;
+            gfx1201) echo "family=gfx120X-all" >> $GITHUB_OUTPUT ;;
+            *) echo "Unknown target: ${{ matrix.target }}" && exit 1 ;;
+          esac
+
+      - name: Call build workflow
+        uses: ROCm/TheRock/.github/workflows/build_linux_pytorch_wheels.yml@main
+        with:
+          family: ${{ steps.set_family.outputs.family }}
+          target: ${{ matrix.target }}
+          python_version: ${{ matrix.python_version }}
+          find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ steps.set_family.outputs.family }}/index.html

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -3,7 +3,7 @@ name: Release Linux PyTorch Wheels
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 2 * * *" # Runs nightly at 2 AM UTC
+    - cron: "0 2 * * *"  # Runs nightly at 2 AM UTC
 
 permissions:
   id-token: write
@@ -11,22 +11,31 @@ permissions:
 
 jobs:
   build:
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
+        target: [gfx942, gfx1100, gfx1201]
         python_version: ["3.11", "3.12"]
-        include:
-          - target: gfx942
-            family: gfx94X-dcgpu
-          - target: gfx1100
-            family: gfx110X-dgpu
-          - target: gfx1201
-            family: gfx120X-all
 
-    uses: ./.github/workflows/build_linux_pytorch_wheels.yml
-    with:
-      family: ${{ matrix.family }}
-      python_version: ${{ matrix.python_version }}
-      target: ${{ matrix.target }}
-      find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ matrix.family }}/index.html
-    secrets: inherit
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set family from target
+        id: set_family
+        run: |
+          case ${{ matrix.target }} in
+            gfx942) echo "family=gfx94X-dcgpu" >> $GITHUB_OUTPUT ;;
+            gfx1100) echo "family=gfx110X-dgpu" >> $GITHUB_OUTPUT ;;
+            gfx1201) echo "family=gfx120X-all" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Reinvoke reusable build workflow
+        uses: ./.github/workflows/build_linux_pytorch_wheels.yml
+        with:
+          family: ${{ steps.set_family.outputs.family }}
+          python_version: ${{ matrix.python_version }}
+          target: ${{ matrix.target }}
+          find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ steps.set_family.outputs.family }}/index.html
+        secrets: inherit

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -8,36 +8,24 @@ on:
 permissions:
   id-token: write
   contents: read
-  actions: write # Added permission to trigger workflows
 
 jobs:
-  dispatch:
+  build:
     strategy:
       fail-fast: false
       matrix:
-        target: [gfx942, gfx1100, gfx1201]
+        include:
+          - target: gfx942
+            family: gfx94X-dcgpu
+          - target: gfx1100
+            family: gfx110X-dgpu
+          - target: gfx1201
+            family: gfx120X-all
         python_version: ["3.11", "3.12"]
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Set family
-        id: set_family
-        run: |
-          case "${{ matrix.target }}" in
-            gfx942) echo "family=gfx94X-dcgpu" >> $GITHUB_OUTPUT ;;
-            gfx1100) echo "family=gfx110X-dgpu" >> $GITHUB_OUTPUT ;;
-            gfx1201) echo "family=gfx120X-all" >> $GITHUB_OUTPUT ;;
-            *) echo "Unknown target"; exit 1 ;;
-          esac
 
-      - name: Trigger Build-Linux-PyTorch-Wheels workflow
-        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc #1.2.4
-        with:
-          workflow: build_linux_pytorch_wheels.yml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          inputs: |
-            {
-              "family": "${{ steps.set_family.outputs.family }}",
-              "target": "${{ matrix.target }}",
-              "python_version": "${{ matrix.python_version }}",
-              "find_links": "https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ steps.set_family.outputs.family }}/index.html"
-            }
+    uses: ROCm/TheRock/.github/workflows/build_linux_pytorch_wheels.yml@main
+    with:
+      family: ${{ matrix.family }}
+      target: ${{ matrix.target }}
+      python_version: ${{ matrix.python_version }}
+      find_links: https://therock-nightly-python.s3.us-east-2.amazonaws.com/${{ matrix.family }}/index.html


### PR DESCRIPTION
- Add nightly (2 AM UTC) schedule for Pytorch Wheels
- Uses `benc-uk/workflow-dispatch` for triggering
- Added matrix as         
        target: [gfx942, gfx1100, gfx1201]
        python_version: ["3.11", "3.12"]