### PR TITLE
[python] Plumb through distribution info from the build.

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 therock_cmake_subproject_declare(therock-aux-overlay
   EXTERNAL_SOURCE_DIR "aux-overlay"
+  USE_DIST_AMDGPU_TARGETS
   BACKGROUND_BUILD
 )
 therock_cmake_subproject_activate(therock-aux-overlay)
@@ -14,6 +15,7 @@ therock_cmake_subproject_activate(therock-aux-overlay)
 
 therock_cmake_subproject_declare(rocm-cmake
   EXTERNAL_SOURCE_DIR "rocm-cmake"
+  USE_DIST_AMDGPU_TARGETS
   BACKGROUND_BUILD
 )
 therock_cmake_subproject_provide_package(rocm-cmake
@@ -35,6 +37,7 @@ endif()
 
 therock_cmake_subproject_declare(rocm-core
   EXTERNAL_SOURCE_DIR "rocm-core"
+  USE_DIST_AMDGPU_TARGETS
   BACKGROUND_BUILD
   CMAKE_ARGS
     "-DBUILD_SHARED_LIBS=${_shared_libs_arg}"
@@ -55,6 +58,7 @@ if(NOT WIN32)  # TODO(#36): Enable on Windows and/or make subproject inclusion g
 
 therock_cmake_subproject_declare(rocm_smi_lib
   EXTERNAL_SOURCE_DIR "rocm_smi_lib"
+  USE_DIST_AMDGPU_TARGETS
   BACKGROUND_BUILD
   CMAKE_ARGS
     # See the post_hook, which needs to advertise install interface directories
@@ -91,6 +95,7 @@ if(NOT WIN32)  # TODO(#36): Enable on Windows?
 
 therock_cmake_subproject_declare(rocprofiler-register
   EXTERNAL_SOURCE_DIR "rocprofiler-register"
+  USE_DIST_AMDGPU_TARGETS
   BACKGROUND_BUILD
   INTERFACE_LINK_DIRS
     "lib"
@@ -114,6 +119,7 @@ endif()
 
 therock_cmake_subproject_declare(rocm-half
   EXTERNAL_SOURCE_DIR "half"
+  USE_DIST_AMDGPU_TARGETS
   BACKGROUND_BUILD
   INTERFACE_INCLUDE_DIRS
     # No find_package support (just a naked include).

--- a/base/aux-overlay/CMakeLists.txt
+++ b/base/aux-overlay/CMakeLists.txt
@@ -23,3 +23,13 @@ if(NOT WIN32)
 endif()
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/overlay/" DESTINATION ".")
+
+# Generate distribution info.
+string(JSON dist_info_json_str SET "{}"
+  "dist_amdgpu_targets" "\"${GPU_TARGETS}\""
+)
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/dist_info.json" "${dist_info_json_str}")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/dist_info.json"
+  DESTINATION "share/therock"
+)

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/_dist_info.py
@@ -160,7 +160,7 @@ PackageEntry(
 # Public libraries.
 LibraryEntry("amdhip64", "core", "libamdhip64.so.6")
 LibraryEntry("hiprtc", "core", "libhiprtc.so.6")
-LibraryEntry("rocprofiler-sdk-roctx", "core", "librocprofiler-sdk-roctx.so.0")
+LibraryEntry("rocprofiler-sdk-roctx", "core", "librocprofiler-sdk-roctx.so.1")
 
 LibraryEntry("hipblas", "libraries", "libhipblas.so.3")
 LibraryEntry("hipfft", "libraries", "libhipfft.so.0")

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/base_test.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/base_test.py
@@ -14,3 +14,25 @@ class ROCmBaseTest(unittest.TestCase):
             [sys.executable, "-P", "-m", "rocm_sdk", "--help"], capture=True
         ).decode()
         self.assertIn("usage:", output)
+
+    def testVersion(self):
+        output = (
+            utils.exec(
+                [sys.executable, "-P", "-m", "rocm_sdk", "version"], capture=True
+            )
+            .decode()
+            .strip()
+        )
+        self.assertTrue(output)
+        self.assertIn(".", output)
+
+    def testTargets(self):
+        output = (
+            utils.exec(
+                [sys.executable, "-P", "-m", "rocm_sdk", "targets"], capture=True
+            )
+            .decode()
+            .strip()
+        )
+        self.assertTrue(output)
+        self.assertIn("gfx", output)

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/core_test.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/core_test.py
@@ -64,13 +64,15 @@ class ROCmCoreTest(unittest.TestCase):
         for so_path in so_paths:
             if "clang_rt" in so_path.name:
                 continue
-            if (
-                "librocprofiler-sdk" in str(so_path) or "librocprofv3" in str(so_path)
-            ) and "librocprofiler-sdk-roctx" not in str(so_path):
-                # rocprofiler-sdk still depends on aqlprofiler, which is not yet
-                # open-source. But we do need the roctx library to load properly
-                # regardless.
-                # See: https://github.com/ROCm/TheRock/issues/330
+            if "lib/roctracer" in str(so_path) or "share/roctracer" in str(so_path):
+                # Internal roctracer libraries are meant to be pre-loaded
+                # explicitly and cannot necessarily be loaded standalone.
+                continue
+            if "lib/rocprofiler-sdk/" in str(
+                so_path
+            ) or "libexec/rocprofiler-sdk/" in str(so_path):
+                # Internal rocprofiler-sdk libraries are meant to be pre-loaded
+                # explicitly and cannot necessarily be loaded standalone.
                 continue
             with self.subTest(msg="Check shared library loads", so_path=so_path):
                 # Load each in an isolated process because not all libraries in the tree

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/devel_test.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/devel_test.py
@@ -117,13 +117,15 @@ class ROCmDevelTest(unittest.TestCase):
                 # clang_rt and sanitizer libraries are not all intended to be
                 # loadable arbitrarily.
                 continue
-            if (
-                "librocprofiler-sdk" in str(so_path) or "librocprofv3" in str(so_path)
-            ) and "librocprofiler-sdk-roctx" not in str(so_path):
-                # rocprofiler-sdk still depends on aqlprofiler, which is not yet
-                # open-source. But we do need the roctx library to load properly
-                # regardless.
-                # See: https://github.com/ROCm/TheRock/issues/330
+            if "lib/roctracer" in str(so_path) or "share/roctracer" in str(so_path):
+                # Internal roctracer libraries are meant to be pre-loaded
+                # explicitly and cannot necessarily be loaded standalone.
+                continue
+            if "lib/rocprofiler-sdk/" in str(
+                so_path
+            ) or "libexec/rocprofiler-sdk/" in str(so_path):
+                # Internal rocprofiler-sdk libraries are meant to be pre-loaded
+                # explicitly and cannot necessarily be loaded standalone.
                 continue
             with self.subTest(msg="Check shared library loads", so_path=so_path):
                 # Load each in an isolated process because not all libraries in the tree

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -133,6 +133,11 @@ function(therock_validate_amdgpu_targets)
   string(JOIN " " _expanded_targets_spaces ${_expanded_targets})
   set(THEROCK_AMDGPU_TARGETS_SPACES "${_expanded_targets_spaces}" PARENT_SCOPE)
 
+  # Export the dist targets as the same until we have support/need to separate
+  # them.
+  set(THEROCK_DIST_AMDGPU_TARGETS "${_expanded_targets}" PARENT_SCOPE)
+  set(THEROCK_DIST_AMDGPU_TARGETS_SPACES "${_expanded_targets_spaces}" PARENT_SCOPE)
+
   if(NOT THEROCK_AMDGPU_DIST_BUNDLE_NAME)
     list(LENGTH _explicit_selections _explicit_count)
     if(_explicit_count GREATER "1")

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -12,6 +12,7 @@ if(THEROCK_ENABLE_COMPILER)
   endif()
 
   therock_cmake_subproject_declare(amd-llvm
+    USE_DIST_AMDGPU_TARGETS
     NO_INSTALL_RPATH  # See manual handling in the pre_hook.
     EXTERNAL_SOURCE_DIR "amd-llvm"
     # Note that LLVM top level CMakeLists.txt is in the llvm subdir of the
@@ -79,6 +80,7 @@ if(THEROCK_ENABLE_COMPILER)
   ##############################################################################
 
   therock_cmake_subproject_declare(amd-comgr
+    USE_DIST_AMDGPU_TARGETS
     NO_INSTALL_RPATH  # See manual handling in the pre_hook.
     EXTERNAL_SOURCE_DIR "amd-llvm/amd/comgr"
     BINARY_DIR "amd-comgr"
@@ -109,6 +111,7 @@ if(THEROCK_ENABLE_COMPILER)
   ##############################################################################
 
   therock_cmake_subproject_declare(hipcc
+    USE_DIST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "amd-llvm/amd/hipcc"
     BINARY_DIR "hipcc"
     BACKGROUND_BUILD
@@ -143,6 +146,7 @@ if(THEROCK_ENABLE_HIPIFY)
   ##############################################################################
 
   therock_cmake_subproject_declare(hipify
+    USE_DIST_AMDGPU_TARGETS
     NO_INSTALL_RPATH  # See manual handling in the pre_hook.
     EXTERNAL_SOURCE_DIR "hipify"
     BACKGROUND_BUILD

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,6 +4,7 @@ if(THEROCK_ENABLE_CORE_RUNTIME)
   ##############################################################################
 
   therock_cmake_subproject_declare(ROCR-Runtime
+    USE_DIST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "ROCR-Runtime"
     BACKGROUND_BUILD
     CMAKE_ARGS
@@ -39,6 +40,7 @@ if(THEROCK_ENABLE_CORE_RUNTIME)
   ##############################################################################
 
   therock_cmake_subproject_declare(rocminfo
+    USE_DIST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "rocminfo"
     BACKGROUND_BUILD
     RUNTIME_DEPS
@@ -105,6 +107,7 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
   endif()
 
   therock_cmake_subproject_declare(hip-clr
+    USE_DIST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "clr"
     INTERFACE_PROGRAM_DIRS
       bin

--- a/math-libs/pre_hook_rocRAND.cmake
+++ b/math-libs/pre_hook_rocRAND.cmake
@@ -1,0 +1,1 @@
+set(BUILD_SHARED_LIBS ON CACHE BOOL "Workaround https://github.com/ROCm/rocRAND/issues/653." FORCE)

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -4,6 +4,10 @@ if(THEROCK_ENABLE_ROCPROFV3)
   # aqlprofile
   ##############################################################################
   therock_cmake_subproject_declare(aqlprofile
+    # TODO: Tests do not build properly for explicit targets: Switch to
+    # USE_DIST_AMDGPU_TARGETS once fixed.
+    # See: https://github.com/ROCm/aqlprofile/issues/2
+    DISABLE_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "aqlprofile"
     BACKGROUND_BUILD
     INTERFACE_LINK_DIRS
@@ -21,6 +25,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
   # rocprofiler-sdk
   ##############################################################################
   therock_cmake_subproject_declare(rocprofiler-sdk
+    USE_DIST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "rocprofiler-sdk"
     BACKGROUND_BUILD
     CMAKE_ARGS
@@ -52,6 +57,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
   ##############################################################################
 
   therock_cmake_subproject_declare(roctracer
+    USE_DIST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "roctracer"
     BACKGROUND_BUILD
     COMPILER_TOOLCHAIN


### PR DESCRIPTION
* First steps towards building split-gfx-arch packages by supporting "dist" targets (the subset of targets that the overall distribution is built for) and build targets (the subset of dist targets that we are building as part of this shard).