### PR TITLE
[ci] Re-run tests on failure

### DIFF
--- a/.github/workflows/test_hipcub.yml
+++ b/.github/workflows/test_hipcub.yml
@@ -69,4 +69,5 @@ jobs:
             --test-dir ${THEROCK_BIN_DIR}/hipcub \
             --output-on-failure \
             --parallel 8 \
-            --timeout 360
+            --timeout 360 \
+            --rerun-failed

--- a/.github/workflows/test_rocprim.yml
+++ b/.github/workflows/test_rocprim.yml
@@ -74,4 +74,5 @@ jobs:
             --output-on-failure \
             --parallel 8 \
             --exclude-regex ${TEST_TO_IGNORE} \
-            --timeout 900
+            --timeout 900 \
+            --rerun-failed

--- a/.github/workflows/test_rocthrust.yml
+++ b/.github/workflows/test_rocthrust.yml
@@ -72,4 +72,5 @@ jobs:
             --output-on-failure \
             --parallel 8 \
             --exclude-regex "^copy.hip$|scan.hip" \
-            --timeout 300
+            --timeout 300 \
+            --rerun-failed


### PR DESCRIPTION
For test failures, we typically run into:

- Flaky tests (when a retry happens, it passes)
- Machine hanging (typically a test that requires high memory causes CI to hang, sometimes we just need a reboot for the machine). #770 will actually get rocPRIM updates where we ignore high memory tests

This PR change will at least retry flaky tests. I'll continue to investigate and find better ways to make our CI not so flaky