### PR TITLE
Refactor artifact fetch and install scripts.

### DIFF
--- a/.github/workflows/test_hipblaslt.yml
+++ b/.github/workflows/test_hipblaslt.yml
@@ -58,7 +58,7 @@ jobs:
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
-          FETCH_ARTIFACT_ARGS: "--blas --tests"
+          FETCH_ARTIFACT_ARGS: "--names blas --test"
           PLATFORM: ${{ inputs.platform }}
 
       - name: Install additional packages

--- a/.github/workflows/test_hipcub.yml
+++ b/.github/workflows/test_hipcub.yml
@@ -60,7 +60,7 @@ jobs:
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
-          FETCH_ARTIFACT_ARGS: "--prim --tests"
+          FETCH_ARTIFACT_ARGS: "--names prim --test"
           PLATFORM: ${{ inputs.platform }}
 
       - name: Run hipcub tests

--- a/.github/workflows/test_rocblas.yml
+++ b/.github/workflows/test_rocblas.yml
@@ -56,7 +56,7 @@ jobs:
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
-          FETCH_ARTIFACT_ARGS: "--blas --tests"
+          FETCH_ARTIFACT_ARGS: "--names blas --test"
           PLATFORM: ${{ inputs.platform }}
 
       - name: Install additional packages

--- a/.github/workflows/test_rocprim.yml
+++ b/.github/workflows/test_rocprim.yml
@@ -62,7 +62,7 @@ jobs:
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
-          FETCH_ARTIFACT_ARGS: "--prim --tests"
+          FETCH_ARTIFACT_ARGS: "--names prim --test"
           PLATFORM: ${{ inputs.platform }}
 
       - name: Run rocprim tests

--- a/.github/workflows/test_rocthrust.yml
+++ b/.github/workflows/test_rocthrust.yml
@@ -62,7 +62,7 @@ jobs:
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
-          FETCH_ARTIFACT_ARGS: "--prim --tests"
+          FETCH_ARTIFACT_ARGS: "--names prim --test"
           PLATFORM: ${{ inputs.platform }}
 
       - name: Run rocthrust tests

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -58,7 +58,7 @@ jobs:
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
-          FETCH_ARTIFACT_ARGS: "--base-only"
+          FETCH_ARTIFACT_ARGS: "--generic-only"
           PLATFORM: ${{ inputs.platform }}
 
       - name: Set HIP_CLANG_PATH for windows

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -94,31 +94,37 @@ popd
 
 ### From `install_rocm_from_artifacts.py`
 
-This script installs ROCm community builds produced by TheRock from either a developer/nightly tarball, a specific CI runner build or an already existing installation of TheRock. This script is used by CI and can be used locally.
+This script installs ROCm community builds produced by TheRock from either a
+developer/nightly tarball, a specific CI runner build or a local build. This
+script can be used by both CI workflows and developers.
 
 Examples:
 
 - Downloads all gfx94X S3 artifacts from [GitHub CI workflow run 15052158890](https://github.com/ROCm/TheRock/actions/runs/15052158890) to the default output directory `therock-build`:
 
-  ```
+  ```bash
   python build_tools/install_rocm_from_artifacts.py --run-id 15052158890 --amdgpu-family gfx94X-dcgpu --tests
   ```
 
 - Downloads the version `6.4.0rc20250516` gfx110X artifacts from GitHub release tag `nightly-tarball` to the specified output directory `build`:
 
-  ```
+  ```bash
   python build_tools/install_rocm_from_artifacts.py --release 6.4.0rc20250516 --amdgpu-family gfx110X-dgpu --output-dir build
   ```
 
 - Downloads the version `6.4.0.dev0+e015c807437eaf32dac6c14a9c4f752770c51b14` gfx110X artifacts from GitHub release tag `dev-tarball` to the default output directory `therock-build`:
 
-  ```
+  ```bash
   python build_tools/install_rocm_from_artifacts.py --release 6.4.0.dev0+e015c807437eaf32dac6c14a9c4f752770c51b14 --amdgpu-family gfx110X-dgpu
   ```
 
 Select your AMD GPU family from this file [therock_amdgpu_targets.cmake](https://github.com/ROCm/TheRock/blob/59c324a759e8ccdfe5a56e0ebe72a13ffbc04c1f/cmake/therock_amdgpu_targets.cmake#L44-L81)
 
-By default for CI workflow retrieval, all artifacts (excluding test artifacts) will be downloaded. For specific artifacts, pass in the flag such as `--rand` (RAND artifacts) For test artifacts, pass in the flag `--tests` (test artifacts). For base artifacts only, pass in the flag `--base-only`
+By default, all artifact names will be downloaded.
+
+- For specific artifacts, pass in the flag such as `--names rand,prim`
+- For test artifacts, pass in the flag `--tests`
+- For generic artifacts only, pass in the flag `--generic-only`
 
 ## Testing your installation
 

--- a/build_tools/_therock_utils/artifacts.py
+++ b/build_tools/_therock_utils/artifacts.py
@@ -45,12 +45,16 @@ class ArtifactName:
                 return None
             return ArtifactName(m.group(1), m.group(2), m.group(3))
         else:
-            # Matches {name}_{component}_{target_family} with an optional
-            # extra suffix that we ignore and an archive extension.
-            m = re.match(r"^([^_]+)_([^_]+)_([^_]+)(_.+)?\.tar.xz$", filename)
-            if not m:
-                return None
-            return ArtifactName(m.group(1), m.group(2), m.group(3))
+            return ArtifactName.from_filename(filename)
+
+    @staticmethod
+    def from_filename(filename: str) -> Optional["ArtifactName"]:
+        # Matches {name}_{component}_{target_family} with an optional
+        # extra suffix that we ignore and an archive extension.
+        m = re.match(r"^([^_]+)_([^_]+)_([^_]+)(_.+)?\.tar.xz$", filename)
+        if not m:
+            return None
+        return ArtifactName(m.group(1), m.group(2), m.group(3))
 
     def __repr__(self):
         return f"Artifact({self.name}[{self.component}:{self.target_family}])"

--- a/build_tools/tests/artifacts_test.py
+++ b/build_tools/tests/artifacts_test.py
@@ -39,6 +39,17 @@ class ArtifactNameTest(unittest.TestCase):
         self.assertEqual(an1, an2)
         self.assertEqual(hash(an1), hash(an2))
 
+    def testFromFilename(self):
+        f1 = "name_component_generic.tar.xz"
+        an1 = ArtifactName.from_filename(f1)
+        self.assertEqual(an1.name, "name")
+        self.assertEqual(an1.component, "component")
+        self.assertEqual(an1.target_family, "generic")
+
+        f2 = "invalid_name.zip"
+        an2 = ArtifactName.from_filename(f2)
+        self.assertIsNone(an2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/build_tools/tests/fetch_artifacts_test.py
+++ b/build_tools/tests/fetch_artifacts_test.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from fetch_artifacts import (
     IndexPageParser,
+    compute_enabled_artifacts,
     retrieve_s3_artifacts,
     ArtifactNotFoundExeption,
     FetchArtifactException,
@@ -48,6 +49,32 @@ def create_sample_tar_files(temp_dir):
 
 
 class ArtifactsIndexPageTest(unittest.TestCase):
+    def testComputeEnabledArtifacts(self):
+        s3_artifacts = set()
+        s3_artifacts.add("foo_dev_generic.tar.xz")
+        s3_artifacts.add("foo_dev_targetABC.tar.xz")
+        s3_artifacts.add("foo_dev_targetXYZ.tar.xz")
+        s3_artifacts.add("bar_dev_generic.tar.xz")
+        s3_artifacts.add("bar_test_generic.tar.xz")
+        s3_artifacts.add("baz_dev_generic.tar.xz")
+
+        enabled_artifacts = compute_enabled_artifacts(
+            s3_artifacts=s3_artifacts,
+            names="foo,bar",
+            generic_only=False,
+            target="targetABC",
+            dev=True,
+            lib=False,
+            test=False,
+        )
+
+        self.assertIn("foo_dev_generic.tar.xz", enabled_artifacts)
+        self.assertIn("foo_dev_targetABC.tar.xz", enabled_artifacts)
+        self.assertNotIn("foo_dev_targetXYZ.tar.xz", enabled_artifacts)
+        self.assertIn("bar_dev_generic.tar.xz", enabled_artifacts)
+        self.assertNotIn("bar_test_generic.tar.xz", enabled_artifacts)
+        self.assertNotIn("baz_dev_generic.tar.xz", enabled_artifacts)
+
     def testCreateIndexPage(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_dir = Path(temp_dir)


### PR DESCRIPTION
(draft PR description, will refine)

The major user-facing changes here are
* Switching from an explicit list of artifact names like `--blas` to a generic `--names [a,b,c]` list, which will decouple this code from the actual artifact names.
* Expanding `--tests` to also handle other artifact component types (lib, dev, test, etc.) in a more generic way

Functionally, that lets us replace the explicit "base_artifacts" list with a more flexible "compute_enabled_artifacts" function