### PR TITLE
[rocprof] Include trace decoder in the dist artifact.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,11 +127,11 @@ option(THEROCK_QUIET_INSTALL "Enable quiet install logging (install logs only go
 # `THEROCK_ENABLE_${group_name}` if a GROUP is present.
 ################################################################################
 option(THEROCK_ENABLE_ALL "Enables building of all feature groups" ON)
-cmake_dependent_option(THEROCK_ENABLE_CORE "Enable building of core libraries" ON "THEROCK_ENABLE_ALL" OFF)
-cmake_dependent_option(THEROCK_ENABLE_COMM_LIBS "Enable building of comm libraries" ON "THEROCK_ENABLE_ALL" OFF)
-cmake_dependent_option(THEROCK_ENABLE_MATH_LIBS "Enable building of math libraries" ON "THEROCK_ENABLE_ALL" OFF)
-cmake_dependent_option(THEROCK_ENABLE_ML_LIBS "Enable building of ML libraries" ON "THEROCK_ENABLE_ALL" OFF)
-cmake_dependent_option(THEROCK_ENABLE_PROFILER "Enable building the profiler libraries" ON "THEROCK_ENABLE_ALL" OFF)
+option(THEROCK_ENABLE_CORE "Enable building of core libraries" "${THEROCK_ENABLE_ALL}")
+option(THEROCK_ENABLE_COMM_LIBS "Enable building of comm libraries" "${THEROCK_ENABLE_ALL}")
+option(THEROCK_ENABLE_MATH_LIBS "Enable building of math libraries" "${THEROCK_ENABLE_ALL}")
+option(THEROCK_ENABLE_ML_LIBS "Enable building of ML libraries" "${THEROCK_ENABLE_ALL}")
+option(THEROCK_ENABLE_PROFILER "Enable building the profiler libraries" "${THEROCK_ENABLE_ALL}")
 option(THEROCK_ENABLE_HOST_MATH "Build all bundled host math libraries by default" OFF)
 option(THEROCK_RESET_FEATURES "One-shot flag which forces all feature flags to their default state for this configuration run" OFF)
 

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -122,6 +122,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
       aqlprofile
       rocprofiler-sdk
       roctracer
+      ${_rocprofiler_sdk_optional_deps}
   )
 
 endif(THEROCK_ENABLE_ROCPROFV3)

--- a/profiler/artifact-rocprofiler-sdk.toml
+++ b/profiler/artifact-rocprofiler-sdk.toml
@@ -37,3 +37,7 @@ include = [
 [components.lib."profiler/roctracer/stage"]
 [components.run."profiler/roctracer/stage"]
 [components.test."profiler/roctracer/stage"]
+
+# rocprof-trace-decoder-binary
+[components.lib."profiler/rocprof-trace-decoder-binary/stage"]
+optional = true


### PR DESCRIPTION
This was left out of the prior commit by accident.

The dogfooders I had testing this also attempted to use the feature group flags and had hiccups. This made me look at how things like THEROCK_ENABLE_PROFILER were setup, and I can't figure out what I was thinking when I wrote that, because it seems to do the opposite of what someone would want (i.e. disable all by default and then just enable what you want selectively). I converted these to regular options and had them default the THEROCK_ENABLE_ALL vs being locked to it.

Build command to test: `cmake -B build -GNinja . -DTHEROCK_AMDGPU_FAMILIES=gfx1100 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_PROFILER=ON`