### PR TITLE
[python] Finalize some initialization procedures and add docs.

### DIFF
--- a/build_tools/linux_python_package.py
+++ b/build_tools/linux_python_package.py
@@ -2,8 +2,7 @@
 """Given ROCm artifacts directories, performs surgery to re-layout them for
 distribution as Python packages and builds sdists and wheels as appropriate.
 
-This process involves both a re-organization of the sources and some surgical
-alterations.
+See docs/packaging/python_packaging.md for more information.
 
 Example
 -------
@@ -13,44 +12,6 @@ Example
     --artifact-dir ./output-linux-portable/build/artifacts \
     --dest-dir $HOME/tmp/packages
 ```
-
-Note that this does do some dynamic compilation of files and it performs
-patching via patchelf. It is recommended to run this in the same portable
-Linux container as was used to build the SDK (so as to avoid the possibility
-of accidentally referencing too-new glibc symbols).
-
-General Procedure
------------------
-We generate three types of packages:
-
-* Selector package: The `rocm-sdk` package is built as an sdist so that it is
-  evaluated at the point of install, allowing it to perform some selection logic
-  to detect dependencies and needs. Most other packages are installed by
-  asking to install extras of this one (i.e. `rocm-sdk[libraries]`, etc).
-* Runtime packages: Most packages are runtime packages. These are wheel files
-  that are ready to be expanded directly into a site-lib directory. They contain
-  only the minimal set of files needed to run. Critically, they do not contain
-  symlinks (instead, only SONAME libraries are included, and any executable
-  symlinks are emitted by dynamically compiling an executable that can execle
-  a relative binary).
-* Devel package: The `rocm-sdk-devel` package is the catch-all for everything.
-  For any file already populated in a runtime package, it will include it as
-  a relative symlink (also rewriting shared library soname links as needed).
-  Since symlinks and non-standard attributes cannot be included in a wheel file,
-  the platform contents are stored in a `_devel.tar` or `_devel.tar.xz` file.
-  The installed package is extended in response to requesting a path to it
-  via the `rocm-sdk` tool.
-
-Runtime packages can either be target neutral or target specific. Target specific
-packages are suffixed with their target family and the setup files have special logic
-to determine what is correct to load based on the system. In the future, this
-will be re-arranged to have more of a thin structure where the host code is
-always emitted as target neutral and separate device code packages are loaded
-as needed.
-
-It is expected that all packages are installed in the same site-lib, as they use
-relative symlinks and RPATHs that cross the top-level package boundary. The
-built-in tests (via `rocm-sdk test`) verify these conditions.
 """
 
 import argparse

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/__init__.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/__init__.py
@@ -1,12 +1,16 @@
+from typing import List, Optional
 import importlib
+import os
 from pathlib import Path
 import platform
+import re
 
 from ._dist_info import __version__
 
 __all__ = [
     "__version__",
     "find_libraries",
+    "initialize_process",
 ]
 
 
@@ -57,7 +61,7 @@ def find_libraries(*shortnames: str) -> list[Path]:
     return paths
 
 
-_ALL_CDLLS = []
+_ALL_CDLLS = {}
 
 
 def preload_libraries(*shortnames: str, rtld_global: bool = True):
@@ -74,6 +78,75 @@ def preload_libraries(*shortnames: str, rtld_global: bool = True):
 
     paths = find_libraries(*shortnames)
     mode = ctypes.RTLD_GLOBAL if rtld_global is True else ctypes.RTLD_LOCAL
-    for path in paths:
+    for shortname, path in zip(shortnames, paths):
+        if shortname in _ALL_CDLLS:
+            continue
         cdll = ctypes.CDLL(str(path), mode=mode)
-        _ALL_CDLLS.append(cdll)
+        _ALL_CDLLS[shortname] = cdll
+
+
+def initialize_process(
+    *,
+    preload_shortnames: Optional[List[str]] = None,
+    rtld_global: bool = True,
+    env_override: bool = True,
+    check_version: Optional[str | re.Pattern] = None,
+    fail_on_version_mismatch: bool = False,
+    **kwargs,
+):
+    """Global initialization of a python library which depends on ROCm native
+    libraries via these packages. This is intended to be called by framework
+    initialization code in a consistent and future proof way.
+
+    Args:
+        preload_shortnames: Library short-names to pass to preload_libraries.
+        rtld_global: Whether to preload libraries with RTLD_GLOBAL (default True).
+        env_override: If True, then also consult the `ROCM_SDK_PRELOAD_LIBRARIES`
+          env variable and preload any libraries listed there (default True).
+          Values are either comma or semi-colon delimitted.
+        check_version: If present, checks that the rocm_sdk.__version__ matches
+          what the caller expects. By default, issues a warning on mismatch.
+          The version spec can contain '*' which expands to any number of
+          characters.
+        fail_on_version_mismatch: If True, then fail with a RuntimeError on
+          version mismatch (default False).
+    """
+    if preload_shortnames:
+        preload_libraries(*preload_shortnames, rtld_global=rtld_global)
+
+    # Process environment variable overrides.
+    if env_override:
+        addl_preload_str = os.getenv("ROCM_SDK_PRELOAD_LIBRARIES")
+        if addl_preload_str is not None:
+            addl_preload_split = [s.strip() for s in re.split("[,;]", addl_preload_str)]
+            addl_preload_split = [s for s in addl_preload_split if s]
+            if addl_preload_split:
+                try:
+                    preload_libraries(*addl_preload_split, rtld_global=rtld_global)
+                except Exception as e:
+                    raise RuntimeError(
+                        f"Could not preload libraries from environment variable "
+                        f"ROCM_SDK_PRELOAD_LIBRARIES='{addl_preload_str}'. Check this "
+                        f"environment variable and unset it if not correct/needed."
+                    ) from e
+
+    # Version check.
+    if check_version:
+        if not isinstance(check_version, re.Pattern):
+            pattern_str = re.escape(check_version).replace("\\*", ".*")
+            check_version = re.compile(f"^{pattern_str}$")
+        if not re.match(check_version, __version__):
+            check_fail_message = (
+                f"The program was compiled against a ROCm version matching "
+                f"'{pattern_str}' but the installed ROCm version in this Python "
+                f"environment is {__version__}."
+            )
+            if fail_on_version_mismatch:
+                raise RuntimeError(check_fail_message)
+            else:
+                import warnings
+
+                warnings.warn(
+                    f"{check_fail_message} This incompatibility may result in "
+                    f"unexpected behavior"
+                )

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/_dist_info.py
@@ -160,6 +160,7 @@ PackageEntry(
 # Public libraries.
 LibraryEntry("amdhip64", "core", "libamdhip64.so.6")
 LibraryEntry("hiprtc", "core", "libhiprtc.so.6")
+LibraryEntry("roctx64", "core", "libroctx64.so.4")
 LibraryEntry("rocprofiler-sdk-roctx", "core", "librocprofiler-sdk-roctx.so.1")
 
 LibraryEntry("hipblas", "libraries", "libhipblas.so.3")

--- a/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/base_test.py
+++ b/build_tools/packaging/python/templates/rocm-sdk/src/rocm_sdk/tests/base_test.py
@@ -1,14 +1,28 @@
 """Installation package tests for the base installation."""
 
+import re
+import os
 import sys
 import unittest
 
+import rocm_sdk
 from .. import _dist_info as di
-
 from . import utils
 
 
 class ROCmBaseTest(unittest.TestCase):
+    def setUp(self):
+        self.orig_ROCM_SDK_PRELOAD_LIBRARIES = os.getenv("ROCM_SDK_PRELOAD_LIBRARIES")
+        os.environ.pop("ROCM_SDK_PRELOAD_LIBRARIES", None)
+        rocm_sdk._ALL_CDLLS.clear()
+
+    def tearDown(self):
+        orig_env = self.orig_ROCM_SDK_PRELOAD_LIBRARIES
+        if orig_env:
+            os.putenv("ROCM_SDK_PRELOAD_LIBRARIES", orig_env)
+        else:
+            os.environ.pop("ROCM_SDK_PRELOAD_LIBRARIES", None)
+
     def testCLI(self):
         output = utils.exec(
             [sys.executable, "-P", "-m", "rocm_sdk", "--help"], capture=True
@@ -36,3 +50,51 @@ class ROCmBaseTest(unittest.TestCase):
         )
         self.assertTrue(output)
         self.assertIn("gfx", output)
+
+    def test_initialize_process_preload_libraries(self):
+        rocm_sdk.initialize_process(preload_shortnames=["amdhip64"])
+        self.assertIn("amdhip64", rocm_sdk._ALL_CDLLS)
+
+    def test_initialize_process_env_preload_1(self):
+        os.environ["ROCM_SDK_PRELOAD_LIBRARIES"] = "amdhip64"
+        rocm_sdk.initialize_process()
+        self.assertIn("amdhip64", rocm_sdk._ALL_CDLLS)
+
+    def test_initialize_process_env_preload_2_comma(self):
+        os.environ["ROCM_SDK_PRELOAD_LIBRARIES"] = " ,amdhip64, ,hiprtc,"
+        rocm_sdk.initialize_process()
+        self.assertIn("amdhip64", rocm_sdk._ALL_CDLLS)
+        self.assertIn("hiprtc", rocm_sdk._ALL_CDLLS)
+
+    def test_initialize_process_env_preload_2_semi(self):
+        os.environ["ROCM_SDK_PRELOAD_LIBRARIES"] = " ;amdhip64; ;hiprtc;"
+        rocm_sdk.initialize_process()
+        self.assertIn("amdhip64", rocm_sdk._ALL_CDLLS)
+        self.assertIn("hiprtc", rocm_sdk._ALL_CDLLS)
+
+    def test_initialize_process_check_version(self):
+        rocm_sdk.initialize_process(
+            check_version=rocm_sdk.__version__, fail_on_version_mismatch=True
+        )
+
+    def test_initialize_process_check_version_asterisk(self):
+        rocm_sdk.initialize_process(check_version="*", fail_on_version_mismatch=True)
+
+    def test_initialize_process_check_version_pattern(self):
+        rocm_sdk.initialize_process(
+            check_version=re.compile(".+"), fail_on_version_mismatch=True
+        )
+
+    def test_initialize_process_check_version_mismatch(self):
+        with self.assertRaisesRegex(
+            RuntimeError, "The program was compiled against a ROCm version matching"
+        ):
+            rocm_sdk.initialize_process(
+                check_version="badversion", fail_on_version_mismatch=True
+            )
+
+    def test_initialize_process_check_version_mismatch_warning(self):
+        with self.assertWarnsRegex(
+            UserWarning, "The program was compiled against a ROCm version matching"
+        ):
+            rocm_sdk.initialize_process(check_version="badversion")

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -1,0 +1,175 @@
+# ROCm Python Packaging via TheRock
+
+Given ROCm artifacts directories, performs surgery to re-layout them for
+distribution as Python packages and builds sdists and wheels as appropriate.
+
+This process involves both a re-organization of the sources and some surgical
+alterations.
+
+## General Design
+
+We generate three types of packages:
+
+- Selector package: The `rocm-sdk` package is built as an sdist so that it is
+  evaluated at the point of install, allowing it to perform some selection logic
+  to detect dependencies and needs. Most other packages are installed by
+  asking to install extras of this one (i.e. `rocm-sdk[libraries]`, etc).
+- Runtime packages: Most packages are runtime packages. These are wheel files
+  that are ready to be expanded directly into a site-lib directory. They contain
+  only the minimal set of files needed to run. Critically, they do not contain
+  symlinks (instead, only SONAME libraries are included, and any executable
+  symlinks are emitted by dynamically compiling an executable that can execle
+  a relative binary).
+- Devel package: The `rocm-sdk-devel` package is the catch-all for everything.
+  For any file already populated in a runtime package, it will include it as
+  a relative symlink (also rewriting shared library soname links as needed).
+  Since symlinks and non-standard attributes cannot be included in a wheel file,
+  the platform contents are stored in a `_devel.tar` or `_devel.tar.xz` file.
+  The installed package is extended in response to requesting a path to it
+  via the `rocm-sdk` tool.
+
+Runtime packages can either be target neutral or target specific. Target specific
+packages are suffixed with their target family and the setup files have special logic
+to determine what is correct to load based on the system. In the future, this
+will be re-arranged to have more of a thin structure where the host code is
+always emitted as target neutral and separate device code packages are loaded
+as needed.
+
+It is expected that all packages are installed in the same site-lib, as they use
+relative symlinks and RPATHs that cross the top-level package boundary. The
+built-in tests (via `rocm-sdk test`) verify these conditions.
+
+TODO: For launch, we will be renaming the `rocm-sdk` dist package to `rocm`. The
+Python `import rocm_sdk` Python namespace will still be used as we do not want
+a barename `rocm` for such a use.
+
+## Building Packages
+
+### Example
+
+```
+./build_tools/linux_python_package.py \
+    --artifact-dir ./output-linux-portable/build/artifacts \
+    --dest-dir $HOME/tmp/packages
+```
+
+Note that this does do some dynamic compilation of files and it performs
+patching via patchelf. It is recommended to run this in the same portable
+Linux container as was used to build the SDK (so as to avoid the possibility
+of accidentally referencing too-new glibc symbols).
+
+## Using Packages from Frameworks
+
+### Building Python Based Projects
+
+Generally, Python based framework users will build against installed ROCm
+Python development packages. For frameworks that only depend on the core ROCm
+subset (including runtime, HIP, system libraries and critical path math
+libraries), this is a process of installing the development packages like:
+
+```
+# See RELEASES.md fo exact arch specific incantations, --index-url combinations,
+# etc.
+pip install rocm-sdk[libraries,devel]
+```
+
+Then build your framework by setting appropriate CMake settings or environment
+variables. Examples (exact settings needed will vary by project being built):
+
+```
+-DCMAKE_PREFIX_PATH=$(rocm-sdk path --cmake)
+-DROCM_HOM=$(rocm-sdk path --root)
+export PATH="$(rocm-sdk path --bin):$PATH"
+```
+
+### Configuring your Python Project Dependencies
+
+This is typically sufficient to *build* ROCm based Python projects. However,
+because built projects will typically do dynamic linking to ROCm host libraries
+and this will be done on arbitrary systems, it is also necessary to change the
+project's packaging and initialization.
+
+Taking PyTorch as an example, you want to inject an install requirement on
+the ROCm python packages for a specific version (all projects will have their
+own way to do this):
+
+```
+export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="rocm-sdk[libraries]=={$(rocm-sdk version)}"
+```
+
+### Performing Initialization
+
+Typical ROCm dependent Python projects will have an `__init__.py` which precedes
+using any extensions or native libraries which depend on ROCm. Ultimately,
+this initializer will need to call `rocm_sdk.initialize_process()` to initialize
+needed libraries. We recommend the following common idiom for managing this:
+
+When building from ROCm wheels, add a `_rocm_init.py` to the root of the
+project such that it is included in built wheels. Then in your `__init__.py`
+add code like this:
+
+```
+try:
+  from . import _rocm_init
+except ModuleNotFoundError:
+  pass
+```
+
+Generate a `_rocm_init.py` file like this (using any suitable scripting):
+
+```
+echo "
+import rocm_sdk
+rocm_sdk.initialize_process(library_shortnames=[
+  'amdhip64',
+  'roctx64',
+  'hiprtc',
+  'hipblas',
+  'hipfft',
+  'hiprand',
+  'hipsparse',
+  'hipsolver',
+  'rccl',
+  'hipblaslt',
+  'miopen',
+],
+check_version='$(rocm-sdk version)')
+" > torch/_rocm_init.py
+```
+
+Note that you must preload any libraries that your native extensions depend on
+so that when the operating system attempts to resolve linkage, they are already
+in the namespace. The above is an example that, at the time of writing, was
+suitable for PyTorch. Note that it version locks to a specific ROCm SDK version.
+This is generally appropriate for development/nightly builds. For production
+builds, you will want to lock to a major/minor version only and use a wildcard
+(\*) to match the suffix.
+
+By default, on version mismatch, a Warning will be raised. You can pass
+`fail_on_version_mismatch=True` to make this an exception.
+
+### Dynamic Library Resolution
+
+The above procedure works for libraries that are hard dependencies of native
+extensions or their deps. If code needs to dynamically load libraries, typically
+preloading them in this way will work, and then a subsequent `dlopen()` or
+equiv will find them. However, the `rocm_sdk.find_libraries(*shortnames)`
+entrypoint is also provided and can be used to query an OS independent
+absolute path to a given named library that is known to the distribution.
+
+### Testing
+
+The `rocm-sdk` distribution, if installed, bundles self tests which verify
+API contracts and file/directory layout. Since the Python ecosystem is ever
+evolving, and packages like this use several "adventurous" features, we
+bundle the ability for detailed self checks. Run them with:
+
+```
+rocm-sdk test
+```
+
+If you are having any problem with your ROCm Python installation, it is
+recommended to run this to verify integrity and basic functionality.
+
+Providing the output of `rocm-sdk test` in any bug reports is greatly
+appreciated.


### PR DESCRIPTION
* Adds a `rocm_sdk.initialize_process()` entry point that we intend to standardize/recommend in upstream framework submissions.
* Adds the `roctx64` library.
* Tests for new features.
* Created a standalone doc page that we can refer to when integrating into frameworks.

Once this lands, I will open a PR against PyTorch to add the initialization logic.

Tested: Build ROCm+python packages locally, installed, `rocm-sdk test`.
