### PR TITLE
Check if build dir exists

### DIFF
--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -206,6 +206,9 @@ def run(args):
     run_id = args.run_id
     target = args.target
     build_dir = args.build_dir
+    if not Path(build_dir).is_dir():
+        print(f"Build dir '{build_dir}' does not exist. Exiting...")
+        return
     s3_artifacts = retrieve_s3_artifacts(run_id, target)
     if not s3_artifacts:
         print(f"S3 artifacts for {run_id} does not exist. Exiting...")


### PR DESCRIPTION
If a build dir specified via `--build-dir` does not exist the output looks like the following:

```
(venv) mbrehler@vm:/TheRock$ python /TheRock/build_tools/fetch_artifacts.py --target gfx110X-dgpu --run-id 15457527876 --build-dir /tmp/artifacts
Retrieving artifacts from https://therock-artifacts.s3.amazonaws.com/15457527876-linux/index-gfx110X-dgpu.html
++ Downloading from https://therock-artifacts.s3.us-east-2.amazonaws.com/15457527876-linux/core-runtime_run_generic.tar.xz to /tmp/artifacts/core-runtime_run_generic.tar.xz
++ Downloading from https://therock-artifacts.s3.us-east-2.amazonaws.com/15457527876-linux/core-runtime_lib_generic.tar.xz to /tmp/artifacts/core-runtime_lib_generic.tar.xz
++ Downloading from https://therock-artifacts.s3.us-east-2.amazonaws.com/15457527876-linux/sysdeps_lib_generic.tar.xz to /tmp/artifacts/sysdeps_lib_generic.tar.xz
++ Downloading from https://therock-artifacts.s3.us-east-2.amazonaws.com/15457527876-linux/base_lib_generic.tar.xz to /tmp/artifacts/base_lib_generic.tar.xz
++ Downloading from https://therock-artifacts.s3.us-east-2.amazonaws.com/15457527876-linux/amd-llvm_run_generic.tar.xz to /tmp/artifacts/amd-llvm_run_generic.tar.xz
++ Downloading from https://therock-artifacts.s3.us-east-2.amazonaws.com/15457527876-linux/amd-llvm_lib_generic.tar.xz to /tmp/artifacts/amd-llvm_lib_generic.tar.xz
++ Downloading from https://therock-artifacts.s3.us-east-2.amazonaws.com/15457527876-linux/core-hip_lib_generic.tar.xz to /tmp/artifacts/core-hip_lib_generic.tar.xz
++ Downloading from https://therock-artifacts.s3.us-east-2.amazonaws.com/15457527876-linux/core-hip_dev_generic.tar.xz to /tmp/artifacts/core-hip_dev_generic.tar.xz
++ Downloading from https://therock-artifacts.s3.us-east-2.amazonaws.com/15457527876-linux/rocprofiler-sdk_lib_generic.tar.xz to /tmp/artifacts/rocprofiler-sdk_lib_generic.tar.xz
++ Downloading from https://therock-artifacts.s3.us-east-2.amazonaws.com/15457527876-linux/host-suite-sparse_lib_generic.tar.xz to /tmp/artifacts/host-suite-sparse_lib_generic.tar.xz
Traceback (most recent call last):
  File "/TheRock/build_tools/fetch_artifacts.py", line 300, in <module>
    main(sys.argv[1:])
  File "/TheRock/build_tools/fetch_artifacts.py", line 296, in main
    run(args)
  File "/TheRock/build_tools/fetch_artifacts.py", line 213, in run
    retrieve_base_artifacts(args, run_id, build_dir, s3_artifacts)
  File "/TheRock/build_tools/fetch_artifacts.py", line 160, in retrieve_base_artifacts
    parallel_exec_commands(artifacts_to_retrieve)
  File "/TheRock/build_tools/fetch_artifacts.py", line 137, in parallel_exec_commands
    future.result(timeout=60)
  File "/usr/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/TheRock/build_tools/fetch_artifacts.py", line 122, in urllib_retrieve_artifact
    with urllib.request.urlopen(artifact_url) as in_stream, open(
                                                            ^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/artifacts/host-suite-sparse_lib_generic.tar.xz'
```

Instead of preteding the artifacts have been successfully downloaded we should check if the directory exist and exit if not. Instead of simply returning we could also raise a `NotADirectoryError` exception but I vote for doing this in a follow up as the script currently also simply exists if an S3 artifact does not exist. Furthermore, we might consider renaming `--build-dir` to `--output-dir` or `--artifacts-dir` as `--build-dir` might be misleading.