### PR TITLE
Get target information using `rocm-sdk` in `build_prod_wheels.py`

### DIFF
--- a/.github/workflows/build_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_linux_pytorch_wheels.yml
@@ -6,9 +6,6 @@ on:
       AMDGPU_FAMILIES:
         required: true
         type: string
-      PYTORCH_TARGET_ARCH:
-        required: true
-        type: string
       python_version:
         required: true
         type: string
@@ -18,9 +15,6 @@ on:
   workflow_dispatch:
     inputs:
       AMDGPU_FAMILIES:
-        required: true
-        type: string
-      PYTORCH_TARGET_ARCH:
         required: true
         type: string
       python_version:
@@ -74,15 +68,15 @@ jobs:
 
       - name: Build PyTorch Wheels
         run: |
-          echo "Building PyTorch wheels for ${{ inputs.PYTORCH_TARGET_ARCH }}"
+          echo "Building PyTorch wheels for ${{ inputs.AMDGPU_FAMILIES }}"
           ./external-builds/pytorch/build_prod_wheels.py \
             --pip-cache-dir /tmp/pipcache \
             --find-links "https://${{ env.S3_BUCKET }}.s3.us-east-2.amazonaws.com/${{ inputs.AMDGPU_FAMILIES }}/index.html" \
+            --pre \
             build \
             --install-rocm \
             --clean \
             --output-dir ${{ env.PACKAGE_DIST_DIR }} \
-            --pytorch-rocm-arch ${{ inputs.PYTORCH_TARGET_ARCH }}
 
       - name: Configure AWS Credentials
         if: always()

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -15,14 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { AMDGPU_FAMILIES: gfx94X-dcgpu, PYTORCH_TARGET_ARCH: gfx942 }
-          - { AMDGPU_FAMILIES: gfx110X-dgpu, PYTORCH_TARGET_ARCH: gfx1100 }
-          - { AMDGPU_FAMILIES: gfx120X-all, PYTORCH_TARGET_ARCH: gfx1201 }
+          - { AMDGPU_FAMILIES: gfx94X-dcgpu }
+          - { AMDGPU_FAMILIES: gfx110X-dgpu }
+          - { AMDGPU_FAMILIES: gfx120X-all }
         python_version: ["cp311-cp311", "cp312-cp312"]
 
     uses: ./.github/workflows/build_linux_pytorch_wheels.yml
     with:
       AMDGPU_FAMILIES: ${{ matrix.config.AMDGPU_FAMILIES }}
-      PYTORCH_TARGET_ARCH: ${{ matrix.config.PYTORCH_TARGET_ARCH }}
       python_version: ${{ matrix.python_version }}
       s3_bucket: therock-nightly-python


### PR DESCRIPTION
This PR eliminates target matrix from `release_linux_pytorch_wheels.yml` using `rocm-sdk` in `build_prod_wheels.py`
It uses `rocm-sdk targets` command to get the target.