### PR TITLE
[windows] Add boilerplate `release_windows_packages.yml` workflow.

### DIFF
--- a/.github/workflows/publish_pytorch_dev_docker.yml
+++ b/.github/workflows/publish_pytorch_dev_docker.yml
@@ -20,8 +20,9 @@ jobs:
       - name: Generating package target matrix
         id: configure
         env:
-          PYTORCH_DEV_DOCKER: "true"
           AMDGPU_FAMILIES: ${{ inputs.families }}
+          PYTORCH_DEV_DOCKER: "true"
+          THEROCK_PACKAGE_PLATFORM: "linux"
         run: python ./build_tools/github_actions/fetch_package_targets.py
 
   build-and-push-image:

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -71,18 +71,23 @@ jobs:
       - name: Generating package target matrix
         id: configure
         env:
-          PYTORCH_DEV_DOCKER: "false"
           AMDGPU_FAMILIES: ${{ inputs.families }}
+          PYTORCH_DEV_DOCKER: "false"
+          THEROCK_PACKAGE_PLATFORM: "linux"
         run: python ./build_tools/github_actions/fetch_package_targets.py
 
   portable_linux_packages:
     name: ${{ matrix.target_bundle.amdgpu_family }}::Build Portable Linux
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+    needs: [setup_metadata]
     permissions:
       contents: write
       actions: write # Added permission to trigger workflows
       id-token: write # Added permission for AWS S3 upload
-    needs: [setup_metadata]
+    strategy:
+      fail-fast: false
+      matrix:
+        target_bundle: ${{ fromJSON(needs.setup_metadata.outputs.package_targets) }}
     env:
       TEATIME_LABEL_GH_GROUP: 1
       OUTPUT_DIR: ${{ github.workspace }}/output
@@ -92,10 +97,6 @@ jobs:
       RELEASE_TYPE: "${{ needs.setup_metadata.outputs.release_type }}"
       S3_TARBALL: "therock-${{ needs.setup_metadata.outputs.release_type }}-tarball"
       S3_PYTHON: "therock-${{ needs.setup_metadata.outputs.release_type }}-python"
-    strategy:
-      fail-fast: false
-      matrix:
-        target_bundle: ${{ fromJSON(needs.setup_metadata.outputs.package_targets) }}
 
     steps:
       - name: "Checking out repository"

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -22,10 +22,12 @@ on:
       families:
         description: "Please enter a comma separated list of AMD GPU family (ex: gfx94X, gfx103x)"
         type: string
-  # Trigger on a schedule to build nightly release candidates.
-  schedule:
-    # Runs at 11:00 AM UTC, which is 3:00 AM PST (UTC-8)
-    - cron: '0 11 * * *'
+
+  # TODO(#542): Enable schedule once working
+  # # Trigger on a schedule to build nightly release candidates.
+  # schedule:
+  #   # Runs at 11:00 AM UTC, which is 3:00 AM PST (UTC-8)
+  #   - cron: '0 11 * * *'
 
 permissions:
   contents: read

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -1,0 +1,213 @@
+name: Release portable Linux packages
+
+on:
+  # Trigger from another workflow (typically to build dev packages and then test them)
+  workflow_call:
+    inputs:
+      build_type:
+        description: The type of build version to produce ("rc", or "dev")
+        type: string
+        default: "dev"
+      package_suffix:
+        type: string
+  # Trigger manually (typically to test the workflow or manually build a release [candidate])
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: The type of build version to produce ("rc", or "dev")
+        type: string
+        default: "rc"
+      package_suffix:
+        type: string
+      families:
+        description: "Please enter a comma separated list of AMD GPU family (ex: gfx94X, gfx103x)"
+        type: string
+  # Trigger on a schedule to build nightly release candidates.
+  schedule:
+    # Runs at 11:00 AM UTC, which is 3:00 AM PST (UTC-8)
+    - cron: '0 11 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  setup_metadata:
+    if: ${{ github.repository_owner == 'ROCm' || github.event_name != 'schedule' }}
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.release_information.outputs.version }}
+      release_type: ${{ steps.release_information.outputs.type }}
+      package_targets: ${{ steps.configure.outputs.package_targets }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: 3.12
+
+      # Compute version suffix based on inputs (default to 'rc')
+      - name: Set variables for nightly release
+        if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}
+        run: |
+          version_suffix="$(printf 'rc%(%Y%m%d)T')"
+          echo "version_suffix=${version_suffix}" >> $GITHUB_ENV
+          echo "release_type=nightly" >> $GITHUB_ENV
+
+      - name: Set variables for development release
+        if: ${{ inputs.build_type == 'dev' }}
+        run: |
+          version_suffix=".dev0+${{ github.sha }}"
+          echo "version_suffix=${version_suffix}" >> $GITHUB_ENV
+          echo "release_type=dev" >> $GITHUB_ENV
+
+      - name: Generate release information
+        id: release_information
+        run: |
+          base_version=$(jq -r '.["rocm-version"]' version.json)
+          echo "version=${base_version}${version_suffix}" >> $GITHUB_OUTPUT
+          echo "type=${release_type}" >> $GITHUB_OUTPUT
+
+      - name: Generating package target matrix
+        id: configure
+        env:
+          PYTORCH_DEV_DOCKER: "false"
+          AMDGPU_FAMILIES: ${{ inputs.families }}
+        run: python ./build_tools/github_actions/fetch_package_targets.py
+
+  portable_linux_packages:
+    name: ${{ matrix.target_bundle.amdgpu_family }}::Build Portable Linux
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+    permissions:
+      contents: write
+      actions: write # Added permission to trigger workflows
+      id-token: write # Added permission for AWS S3 upload
+    needs: [setup_metadata]
+    env:
+      TEATIME_LABEL_GH_GROUP: 1
+      OUTPUT_DIR: ${{ github.workspace }}/output
+      BUILD_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64:main
+      DIST_ARCHIVE: "${{ github.workspace }}/output/therock-dist-linux-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
+      FILE_NAME: "therock-dist-linux-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
+      RELEASE_TYPE: "${{ needs.setup_metadata.outputs.release_type }}"
+      S3_TARBALL: "therock-${{ needs.setup_metadata.outputs.release_type }}-tarball"
+      S3_PYTHON: "therock-${{ needs.setup_metadata.outputs.release_type }}-python"
+    strategy:
+      fail-fast: false
+      matrix:
+        target_bundle: ${{ fromJSON(needs.setup_metadata.outputs.package_targets) }}
+
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: '3.10'
+      # TODO: We shouldn't be using a cache on actual release branches, but it
+      # really helps for iteration time.
+      - name: Enable cache
+        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: ${{ env.OUTPUT_DIR }}/caches
+          key: portable-linux-package-matrix-v1-${{ matrix.target_bundle.amdgpu_family }}-${{ github.sha }}
+          restore-keys: |
+            portable-linux-package-matrix-v1-${{ matrix.target_bundle.amdgpu_family }}-
+
+      - name: Install the AWS tool
+        run: ./dockerfiles/cpubuilder/install_awscli.sh
+
+      - name: Fetch sources
+        run: |
+          # Prefetch docker container in background.
+          docker pull ${{ env.BUILD_IMAGE }} &
+          ./build_tools/fetch_sources.py --jobs 10
+          wait
+
+      - name: Build Projects
+        run: |
+          ./build_tools/linux_portable_build.py \
+            --image=${{ env.BUILD_IMAGE }} \
+            --output-dir=${{ env.OUTPUT_DIR }} \
+            -- \
+            "-DTHEROCK_AMDGPU_FAMILIES=${{ matrix.target_bundle.amdgpu_family }}"
+          cd ${{ env.OUTPUT_DIR }}/build/dist/rocm
+          echo "Building ${{ env.DIST_ARCHIVE }}"
+          tar cfz "${{ env.DIST_ARCHIVE }}" .
+
+      - name: Build Python Packages
+        run: |
+          ./build_tools/linux_portable_build.py \
+            --image=${{ env.BUILD_IMAGE }} \
+            --output-dir=${{ env.OUTPUT_DIR }}/packages \
+            --build-python-only \
+            --artifact-dir=${{ env.OUTPUT_DIR }}/build/artifacts \
+            -- \
+            "--version=${{ needs.setup_metadata.outputs.version }}"
+
+      - name: Upload Tarball to GitHub
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
+        with:
+          artifacts: "${{ env.DIST_ARCHIVE }}"
+          tag: "${{ env.RELEASE_TYPE }}-tarball"
+          name: "${{ env.RELEASE_TYPE }}-tarball"
+          body: "Automatic ${{ env.RELEASE_TYPE }} tarball of TheRock."
+          removeArtifacts: false
+          allowUpdates: true
+          replacesArtifacts: true
+          makeLatest: false
+
+      - name: Configure AWS Credentials
+        if: ${{ github.repository_owner == 'ROCm' }}
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ env.RELEASE_TYPE }}-releases
+
+      - name: Upload Releases to S3
+        if: ${{ github.repository_owner == 'ROCm' }}
+        run: |
+          aws s3 cp ${{ env.DIST_ARCHIVE }} s3://${{ env.S3_TARBALL }}
+          aws s3 cp ${{ env.OUTPUT_DIR }}/packages/dist/ s3://${{ env.S3_PYTHON }}/${{ matrix.target_bundle.amdgpu_family }}/ \
+          --recursive --no-follow-symlinks \
+          --exclude "*" \
+          --include "*.whl" \
+          --include "*.tar.gz"
+
+      - name: Setup Python
+        if: ${{ github.repository_owner == 'ROCm' }}
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: 3.12
+
+      - name: (Re-)Generate Python package release index
+        if: ${{ github.repository_owner == 'ROCm' }}
+        run: |
+          pip install boto3
+          ./build_tools/packaging/python/generate_release_index.py \
+            --bucket=${{ env.S3_PYTHON }} \
+            --endpoint=s3.us-east-2.amazonaws.com \
+            --subdir=${{ matrix.target_bundle.amdgpu_family }} \
+            --output=${{ github.workspace }}/index.html
+          # TODO: Integrate upload into `generate_release_index.py`
+          aws s3 cp ${{ github.workspace }}/index.html s3://${{ env.S3_PYTHON }}/${{ matrix.target_bundle.amdgpu_family }}/
+
+      - name: Trigger testing nightly tarball
+        if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}
+        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
+        with:
+          workflow: test_release_packages.yml
+          inputs: '{ "version": "${{ needs.setup_metadata.outputs.version }}", "tag": "nightly-tarball", "file_name": "${{ env.FILE_NAME }}", "target": "${{ matrix.target_bundle.amdgpu_family }}" }'
+
+      - name: Report
+        if: ${{ !cancelled() }}
+        run: |
+          echo "Full SDK du:"
+          echo "------------"
+          du -h -d 1 ${{ env.OUTPUT_DIR }}/build/dist/rocm
+
+      - name: Save cache
+        uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        if: always()
+        with:
+          path: ${{ env.OUTPUT_DIR }}/caches
+          key: portable-linux-package-matrix-v1-${{ matrix.target_bundle.amdgpu_family }}-${{ github.sha }}

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -1,4 +1,4 @@
-name: Release portable Linux packages
+name: Release Windows packages
 
 on:
   # Trigger from another workflow (typically to build dev packages and then test them)
@@ -71,143 +71,47 @@ jobs:
       - name: Generating package target matrix
         id: configure
         env:
-          PYTORCH_DEV_DOCKER: "false"
           AMDGPU_FAMILIES: ${{ inputs.families }}
+          PYTORCH_DEV_DOCKER: "false"
+          THEROCK_PACKAGE_PLATFORM: "windows"
         run: python ./build_tools/github_actions/fetch_package_targets.py
 
-  portable_linux_packages:
-    name: ${{ matrix.target_bundle.amdgpu_family }}::Build Portable Linux
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+  windows_packages:
+    name: ${{ matrix.target_bundle.amdgpu_family }}::Build Windows
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-windows-scale-rocm' || 'windows-2022' }}
+    needs: [setup_metadata]
     permissions:
       contents: write
       actions: write # Added permission to trigger workflows
       id-token: write # Added permission for AWS S3 upload
-    needs: [setup_metadata]
-    env:
-      TEATIME_LABEL_GH_GROUP: 1
-      OUTPUT_DIR: ${{ github.workspace }}/output
-      BUILD_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64:main
-      DIST_ARCHIVE: "${{ github.workspace }}/output/therock-dist-linux-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
-      FILE_NAME: "therock-dist-linux-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
-      RELEASE_TYPE: "${{ needs.setup_metadata.outputs.release_type }}"
-      S3_TARBALL: "therock-${{ needs.setup_metadata.outputs.release_type }}-tarball"
-      S3_PYTHON: "therock-${{ needs.setup_metadata.outputs.release_type }}-python"
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
         target_bundle: ${{ fromJSON(needs.setup_metadata.outputs.package_targets) }}
+    env:
+      TEATIME_LABEL_GH_GROUP: 1
+      # TODO(scotttodd): ${OUTPUT_DIR}/${FILE_NAME} for DIST_ARCHIVE
+      OUTPUT_DIR: ${{ github.workspace }}/output
+      DIST_ARCHIVE: "${{ github.workspace }}/output/therock-dist-windows-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
+      FILE_NAME: "therock-dist-windows-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
+      RELEASE_TYPE: "${{ needs.setup_metadata.outputs.release_type }}"
+      S3_TARBALL: "therock-${{ needs.setup_metadata.outputs.release_type }}-tarball"
 
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
-          python-version: '3.10'
-      # TODO: We shouldn't be using a cache on actual release branches, but it
-      # really helps for iteration time.
-      - name: Enable cache
-        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
-        with:
-          path: ${{ env.OUTPUT_DIR }}/caches
-          key: portable-linux-package-matrix-v1-${{ matrix.target_bundle.amdgpu_family }}-${{ github.sha }}
-          restore-keys: |
-            portable-linux-package-matrix-v1-${{ matrix.target_bundle.amdgpu_family }}-
+          python-version: '3.12'
 
-      - name: Install the AWS tool
-        run: ./dockerfiles/cpubuilder/install_awscli.sh
-
-      - name: Fetch sources
+      - name: Print status
         run: |
-          # Prefetch docker container in background.
-          docker pull ${{ env.BUILD_IMAGE }} &
-          ./build_tools/fetch_sources.py --jobs 10
-          wait
+          echo "DIST_ARCHIVE: ${DIST_ARCHIVE}"
+          echo "RELEASE_TYPE: ${RELEASE_TYPE}"
+          echo "S3_TARBALL: ${S3_TARBALL}"
 
-      - name: Build Projects
-        run: |
-          ./build_tools/linux_portable_build.py \
-            --image=${{ env.BUILD_IMAGE }} \
-            --output-dir=${{ env.OUTPUT_DIR }} \
-            -- \
-            "-DTHEROCK_AMDGPU_FAMILIES=${{ matrix.target_bundle.amdgpu_family }}"
-          cd ${{ env.OUTPUT_DIR }}/build/dist/rocm
-          echo "Building ${{ env.DIST_ARCHIVE }}"
-          tar cfz "${{ env.DIST_ARCHIVE }}" .
-
-      - name: Build Python Packages
-        run: |
-          ./build_tools/linux_portable_build.py \
-            --image=${{ env.BUILD_IMAGE }} \
-            --output-dir=${{ env.OUTPUT_DIR }}/packages \
-            --build-python-only \
-            --artifact-dir=${{ env.OUTPUT_DIR }}/build/artifacts \
-            -- \
-            "--version=${{ needs.setup_metadata.outputs.version }}"
-
-      - name: Upload Tarball to GitHub
-        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
-        with:
-          artifacts: "${{ env.DIST_ARCHIVE }}"
-          tag: "${{ env.RELEASE_TYPE }}-tarball"
-          name: "${{ env.RELEASE_TYPE }}-tarball"
-          body: "Automatic ${{ env.RELEASE_TYPE }} tarball of TheRock."
-          removeArtifacts: false
-          allowUpdates: true
-          replacesArtifacts: true
-          makeLatest: false
-
-      - name: Configure AWS Credentials
-        if: ${{ github.repository_owner == 'ROCm' }}
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ env.RELEASE_TYPE }}-releases
-
-      - name: Upload Releases to S3
-        if: ${{ github.repository_owner == 'ROCm' }}
-        run: |
-          aws s3 cp ${{ env.DIST_ARCHIVE }} s3://${{ env.S3_TARBALL }}
-          aws s3 cp ${{ env.OUTPUT_DIR }}/packages/dist/ s3://${{ env.S3_PYTHON }}/${{ matrix.target_bundle.amdgpu_family }}/ \
-          --recursive --no-follow-symlinks \
-          --exclude "*" \
-          --include "*.whl" \
-          --include "*.tar.gz"
-
-      - name: Setup Python
-        if: ${{ github.repository_owner == 'ROCm' }}
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
-        with:
-          python-version: 3.12
-
-      - name: (Re-)Generate Python package release index
-        if: ${{ github.repository_owner == 'ROCm' }}
-        run: |
-          pip install boto3
-          ./build_tools/packaging/python/generate_release_index.py \
-            --bucket=${{ env.S3_PYTHON }} \
-            --endpoint=s3.us-east-2.amazonaws.com \
-            --subdir=${{ matrix.target_bundle.amdgpu_family }} \
-            --output=${{ github.workspace }}/index.html
-          # TODO: Integrate upload into `generate_release_index.py`
-          aws s3 cp ${{ github.workspace }}/index.html s3://${{ env.S3_PYTHON }}/${{ matrix.target_bundle.amdgpu_family }}/
-
-      - name: Trigger testing nightly tarball
-        if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}
-        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
-        with:
-          workflow: test_release_packages.yml
-          inputs: '{ "version": "${{ needs.setup_metadata.outputs.version }}", "tag": "nightly-tarball", "file_name": "${{ env.FILE_NAME }}", "target": "${{ matrix.target_bundle.amdgpu_family }}" }'
-
-      - name: Report
-        if: ${{ !cancelled() }}
-        run: |
-          echo "Full SDK du:"
-          echo "------------"
-          du -h -d 1 ${{ env.OUTPUT_DIR }}/build/dist/rocm
-
-      - name: Save cache
-        uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
-        if: always()
-        with:
-          path: ${{ env.OUTPUT_DIR }}/caches
-          key: portable-linux-package-matrix-v1-${{ matrix.target_bundle.amdgpu_family }}-${{ github.sha }}
+      # TODO(#542): Build and upload tarballs
+      # TODO(#703): Build and upload Python wheels

--- a/build_tools/github_actions/fetch_package_targets.py
+++ b/build_tools/github_actions/fetch_package_targets.py
@@ -8,8 +8,10 @@ import string
 
 
 def main(args):
-    pytorch_dev_docker = args.get("PYTORCH_DEV_DOCKER") == "true"
     amdgpu_families = args.get("AMDGPU_FAMILIES")
+    pytorch_dev_docker = args.get("PYTORCH_DEV_DOCKER") == "true"
+    package_platform = args.get("THEROCK_PACKAGE_PLATFORM")
+
     family_matrix = amdgpu_family_info_matrix
     package_targets = []
     # If the workflow does specify AMD GPU family, package those. Otherwise, then package all families
@@ -23,15 +25,14 @@ def main(args):
         ]
 
     for key in family_matrix:
+        info_for_key = amdgpu_family_info_matrix.get(key)
         if pytorch_dev_docker:
             # If there is not a target specified for the family
-            if not "pytorch-target" in amdgpu_family_info_matrix.get(key).get("linux"):
+            if not "pytorch-target" in info_for_key.get(package_platform):
                 continue
-            family = (
-                amdgpu_family_info_matrix.get(key).get("linux").get("pytorch-target")
-            )
+            family = info_for_key.get(package_platform).get("pytorch-target")
         else:
-            family = amdgpu_family_info_matrix.get(key).get("linux").get("family")
+            family = info_for_key.get(package_platform).get("family")
 
         package_targets.append({"amdgpu_family": family})
 
@@ -40,6 +41,7 @@ def main(args):
 
 if __name__ == "__main__":
     args = {}
-    args["PYTORCH_DEV_DOCKER"] = os.getenv("PYTORCH_DEV_DOCKER")
     args["AMDGPU_FAMILIES"] = os.getenv("AMDGPU_FAMILIES")
+    args["PYTORCH_DEV_DOCKER"] = os.getenv("PYTORCH_DEV_DOCKER")
+    args["THEROCK_PACKAGE_PLATFORM"] = os.getenv("THEROCK_PACKAGE_PLATFORM")
     main(args)


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/542. Starting with a mostly empty workflow file, forked from `.github/workflows/release_portable_linux_packages.yml`. This will let me test using workflow_dispatch in this repository using our self-hosted runners.

Once we have this working, we can clean up the workflow files:

* Have a common workflow compute metadata and trigger all nightly releases
* Move setup specific to our self-hosted runners out of the Windows workflow files and into runner pre-job and post-job hooks (or at least scripts)