### PR TITLE
[docs] Adding more roadmap details

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,23 +19,26 @@ The following is a list of prioritized roadmaps divided by OS (Linux/Windows) an
 
 **AMD Instinct**
 
-| Architecture | LLVM target | Sanity Tested | Release Ready |
-| ------------ | ----------- | ------------- | ------------- |
-| **CDNA3**    | **gfx942**  | ✅            |               |
-| CDNA2        | gfx90a      |               |               |
-| CDNA         | gfx908      |               |               |
-| GCN5.1       | gfx906      |               |               |
-| GCN5         | gfx900      |               |               |
+| Architecture | LLVM target | Build Passing | Sanity Tested | Release Ready |
+| ------------ | ----------- | ------------- | ------------- | ------------- |
+| CDNA3        | gfx942      | ✅            | ✅            | ✅            |
+| **CDNA2**    | **gfx90a**  |               |               |               |
+| CDNA         | gfx908      |               |               |               |
+| GCN5.1       | gfx906      |               |               |               |
+| GCN5         | gfx900      |               |               |               |
 
 **AMD Radeon**
 
-| Architecture | LLVM target | Sanity Tested | Release Ready |
-| ------------ | ----------- | ------------- | ------------- |
-| **RDNA3**    | **gfx1100** | ✅            |               |
-| **RDNA3**    | **gfx1101** |               |               |
-| **RDNA3**    | **gfx1102** |               |               |
-| RDNA2        | gfx1030     |               |               |
-| GCN5.1       | gfx906      |               |               |
+| Architecture | LLVM target | Build Passing | Sanity Tested | Release Ready |
+| ------------ | ----------- | ------------- | ------------- | ------------- |
+| RDNA4        | gfx1201     | ✅            | ✅            | ✅            |
+| **RDNA3.5**  | **gfx1151** | ✅            |               |               |
+| **RDNA3**    | **gfx1102** | ✅            |               |               |
+| **RDNA3**    | **gfx1101** | ✅            |               |               |
+| **RDNA3**    | **gfx1100** | ✅            |               |               |
+| RDNA2        | gfx1030     |               |               |               |
+| RDNA2        | gfx1010     |               |               |               |
+| GCN5.1       | gfx906      |               |               |               |
 
 ### HIP Runtime and SDK on Windows
 
@@ -43,9 +46,12 @@ Check [windows_support.md](docs/development/windows_support.md) on current statu
 
 **AMD Radeon**
 
-| Architecture | LLVM target | Sanity Tested | Release Ready |
-| ------------ | ----------- | ------------- | ------------- |
-| **RDNA3**    | **gfx1101** |               |               |
-| **RDNA3**    | **gfx1100** |               |               |
-| RDNA2        | gfx1030     |               |               |
-| GCN5.1       | gfx906      |               |               |
+| Architecture | LLVM target | Build Passing | Sanity Tested | Release Ready |
+| ------------ | ----------- | ------------- | ------------- | ------------- |
+| **RDNA4**    | **gfx1201** | ✅            |               |               |
+| **RDNA3.5**  | **gfx1151** | ✅            | ✅            |               |
+| **RDNA3**    | **gfx1101** | ✅            |               |               |
+| **RDNA3**    | **gfx1100** | ✅            |               |               |
+| RDNA2        | gfx1030     |               |               |               |
+| RDNA2        | gfx1010     |               |               |               |
+| GCN5.1       | gfx906      |               |               |               |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,9 +7,9 @@ Our goal here is to document the prioritized roadmap of target architectures we 
 
 ## Prioritized Target Architectures
 
-[Prioritized Target Architectures GitHub Discussion](https://github.com/ROCm/ROCm/discussions/4276)
-
 The following is a list of prioritized roadmaps divided by OS (Linux/Windows) and architecture. Each individual section is its own roadmap and we will be in parallel trying to support at least one *new* architecture per section in parallel working top-to-bottom. Current focus areas are in __bold__. There will be exceptions from the "top-to-bottom" ordering occasionally based on test device availability.
+
+See also the [ROCm Device Support Wishlist GitHub Discussion](https://github.com/ROCm/ROCm/discussions/4276)
 
 > [!NOTE]
 > For the purposes of the table below:
@@ -42,9 +42,6 @@ The following is a list of prioritized roadmaps divided by OS (Linux/Windows) an
 | RDNA2        | gfx1035     |               |               |               |
 | RDNA2        | gfx1032     |               |               |               |
 | RDNA2        | gfx1030     |               |               |               |
-| RDNA1        | gfx1012     |               |               |               |
-| RDNA1        | gfx1011     |               |               |               |
-| RDNA1        | gfx1010     |               |               |               |
 | GCN5.1       | gfx906      |               |               |               |
 
 ### HIP Runtime and SDK on Windows
@@ -64,7 +61,4 @@ Check [windows_support.md](docs/development/windows_support.md) on current statu
 | RDNA2        | gfx1035     |               |               |               |
 | RDNA2        | gfx1032     |               |               |               |
 | RDNA2        | gfx1030     |               |               |               |
-| RDNA1        | gfx1012     |               |               |               |
-| RDNA1        | gfx1011     |               |               |               |
-| RDNA1        | gfx1010     |               |               |               |
 | GCN5.1       | gfx906      |               |               |               |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,6 +7,8 @@ Our goal here is to document the prioritized roadmap of target architectures we 
 
 ## Prioritized Target Architectures
 
+[Prioritized Target Architectures GitHub Discussion](https://github.com/ROCm/ROCm/discussions/4276)
+
 The following is a list of prioritized roadmaps divided by OS (Linux/Windows) and architecture. Each individual section is its own roadmap and we will be in parallel trying to support at least one *new* architecture per section in parallel working top-to-bottom. Current focus areas are in __bold__. There will be exceptions from the "top-to-bottom" ordering occasionally based on test device availability.
 
 > [!NOTE]
@@ -21,8 +23,8 @@ The following is a list of prioritized roadmaps divided by OS (Linux/Windows) an
 
 | Architecture | LLVM target | Build Passing | Sanity Tested | Release Ready |
 | ------------ | ----------- | ------------- | ------------- | ------------- |
-| CDNA3        | gfx942      | ✅            | ✅            | ✅            |
-| **CDNA2**    | **gfx90a**  |               |               |               |
+| **CDNA3**    | **gfx942**  | ✅            | ✅            | ✅            |
+| CDNA2        | gfx90a      |               |               |               |
 | CDNA         | gfx908      |               |               |               |
 | GCN5.1       | gfx906      |               |               |               |
 | GCN5         | gfx900      |               |               |               |
@@ -31,13 +33,18 @@ The following is a list of prioritized roadmaps divided by OS (Linux/Windows) an
 
 | Architecture | LLVM target | Build Passing | Sanity Tested | Release Ready |
 | ------------ | ----------- | ------------- | ------------- | ------------- |
-| RDNA4        | gfx1201     | ✅            | ✅            | ✅            |
+| **RDNA4**    | **gfx1201** | ✅            | ✅            | ✅            |
 | **RDNA3.5**  | **gfx1151** | ✅            |               |               |
 | **RDNA3**    | **gfx1102** | ✅            |               |               |
 | **RDNA3**    | **gfx1101** | ✅            |               |               |
 | **RDNA3**    | **gfx1100** | ✅            |               |               |
+| RDNA2        | gfx1036     |               |               |               |
+| RDNA2        | gfx1035     |               |               |               |
+| RDNA2        | gfx1032     |               |               |               |
 | RDNA2        | gfx1030     |               |               |               |
-| RDNA2        | gfx1010     |               |               |               |
+| RDNA1        | gfx1012     |               |               |               |
+| RDNA1        | gfx1011     |               |               |               |
+| RDNA1        | gfx1010     |               |               |               |
 | GCN5.1       | gfx906      |               |               |               |
 
 ### HIP Runtime and SDK on Windows
@@ -50,8 +57,14 @@ Check [windows_support.md](docs/development/windows_support.md) on current statu
 | ------------ | ----------- | ------------- | ------------- | ------------- |
 | **RDNA4**    | **gfx1201** | ✅            |               |               |
 | **RDNA3.5**  | **gfx1151** | ✅            | ✅            |               |
+| **RDNA3**    | **gfx1102** | ✅            |               |               |
 | **RDNA3**    | **gfx1101** | ✅            |               |               |
-| **RDNA3**    | **gfx1100** | ✅            |               |               |
+| **RDNA3**    | **gfx1100** | ✅            | ✅            |               |
+| RDNA2        | gfx1036     |               |               |               |
+| RDNA2        | gfx1035     |               |               |               |
+| RDNA2        | gfx1032     |               |               |               |
 | RDNA2        | gfx1030     |               |               |               |
-| RDNA2        | gfx1010     |               |               |               |
+| RDNA1        | gfx1012     |               |               |               |
+| RDNA1        | gfx1011     |               |               |               |
+| RDNA1        | gfx1010     |               |               |               |
 | GCN5.1       | gfx906      |               |               |               |


### PR DESCRIPTION
Based on a quick skim [ROCm Device wishlist](https://github.com/ROCm/ROCm/discussions/4276), folks seem to want RDNA2+. 

I've added some of each family (although I am not sure if we want to add all targets from [TheRock cmake](https://github.com/ROCm/TheRock/blob/main/cmake/therock_amdgpu_targets.cmake) )

I've also added `Build Passing` (could have better name?) category, as we have builds working for certain targets (but no tests working yet)