### PR TITLE
Update library entry point to hipBLASLt

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -169,7 +169,7 @@ LibraryEntry("hiprand", "libraries", "libhiprand.so.1")
 LibraryEntry("hipsparse", "libraries", "libhipsparse.so.4")
 LibraryEntry("hipsolver", "libraries", "libhipsolver.so.1")
 LibraryEntry("rccl", "libraries", "librccl.so.1")
-LibraryEntry("hipblaslt", "libraries", "libhipblaslt.so.0")
+LibraryEntry("hipblaslt", "libraries", "libhipblaslt.so.1")
 LibraryEntry("miopen", "libraries", "libMIOpen.so.1")
 
 # Overall ROCM package version.


### PR DESCRIPTION
The so version was updated to 1 recently.

Closes #793.