### PR TITLE
Iterate on "installing from tarballs" documentation.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -26,6 +26,7 @@ Table of contents:
   - [Installing per-commit CI build tarballs manually](#installing-per-commit-ci-build-tarballs-manually)
   - [Installing tarballs using `install_rocm_from_artifacts.py`](#installing-tarballs-using-install_rocm_from_artifactspy)
   - [Using installed tarballs](#using-installed-tarballs)
+- [Using Dockerfiles](#using-dockerfiles)
 
 ## Installing releases using pip
 
@@ -361,12 +362,18 @@ ls install
 You may also want to add the install directory to your `PATH` or set other
 environment variables like `ROCM_HOME`.
 
-## Where to get artifacts
+## Using Dockerfiles
 
-<!-- TODO: move Dockerfiles to their own top level section -->
+We publish [Dockerfiles](https://www.docker.com/) with packages preinstalled
+for your convenience. See
+https://github.com/orgs/ROCm/packages?repo_name=TheRock for the full list.
 
-- [Packages](https://github.com/orgs/ROCm/packages?repo_name=TheRock): We currently publish docker images for LLVM targets we support (as well as a container for our build machines)
+| Package                                                                                                                               | Description                          |
+| ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| [`therock_build_manylinux_x86_64`](https://github.com/ROCm/TheRock/pkgs/container/therock_build_manylinux_x86_64)                     | ⚠️ Container for our CI/CD pipelines |
+| [`therock_pytorch_dev_ubuntu_24_04_gfx942`](https://github.com/ROCm/TheRock/pkgs/container/therock_pytorch_dev_ubuntu_24_04_gfx942)   | Ubuntu with PyTorch for ROCm gfx942  |
+| [`therock_pytorch_dev_ubuntu_24_04_gfx1100`](https://github.com/ROCm/TheRock/pkgs/container/therock_pytorch_dev_ubuntu_24_04_gfx1100) | Ubuntu with PyTorch for ROCm gfx1100 |
+| [`therock_pytorch_dev_ubuntu_24_04_gfx1151`](https://github.com/ROCm/TheRock/pkgs/container/therock_pytorch_dev_ubuntu_24_04_gfx1151) | Ubuntu with PyTorch for ROCm gfx1151 |
+| [`therock_pytorch_dev_ubuntu_24_04_gfx1201`](https://github.com/ROCm/TheRock/pkgs/container/therock_pytorch_dev_ubuntu_24_04_gfx1201) | Ubuntu with PyTorch for ROCm gfx1201 |
 
-<!-- TODO: delete, merged into other sections -->
-
-- [Per-commit CI builds](https://github.com/ROCm/TheRock/actions/workflows/ci.yml?query=branch%3Amain+is%3Asuccess): Each of our latest passing CI builds has its own artifacts you can leverage. This is the latest and greatest! We will eventually support a nightly release that is at a higher quality bar than CI. Note a quick recipe for getting all of these from the s3 bucket is to use this quick command `aws s3 cp s3://therock-artifacts . --recursive --exclude "*" --include "${RUN_ID}-${OPERATING_SYSTEM}/*.tar.xz" --no-sign-request` where ${RUN_ID} is the runner id you selected (see the URL). Check the [AWS docs](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) to get the aws cli.
+<!-- TODO: how-to's for using the dockerfiles -->

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -231,25 +231,73 @@ instructions in the AMD ROCm documentation.
 
 ## Installing from tarballs
 
-<!-- TODO: clean up these sections and confirm the instructions work -->
-
-Here's a quick way assuming you copied the all the tar files into `${BUILD_ARTIFACTS_DIR}` to "install" TheRock into `${BUILD_ARTIFACTS_DIR}/output_dir`
+Standalone "ROCm SDK tarballs" are assembled from the same
+[artifacts](docs/development/artifacts.md) as the Python packages which can be
+[installed using pip](#installing-releases-using-pip), without the additional
+wrapper Python wheels or utility scripts.
 
 ### Installing release tarballs
 
-Release tarballs are already flattened and simply need untarring, follow the below instructions.
+Release tarballs are automatically uploaded to
+[GitHub releases](https://github.com/ROCm/TheRock/releases) and AWS S3 buckets
+for archival. The S3 buckets do not yet have index pages.
+
+| Release page                                                                      | S3 bucket                                                                    | Description                                       |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------- |
+| [`nightly-tarball`](https://github.com/ROCm/TheRock/releases/tag/nightly-tarball) | [therock-nightly-tarball](https://therock-nightly-tarball.s3.amazonaws.com/) | Nightly builds from the `main` branch             |
+| [`dev-tarball`](https://github.com/ROCm/TheRock/releases/tag/dev-tarball)         | [therock-dev-tarball](https://therock-dev-tarball.s3.amazonaws.com/)         | ⚠️ Development builds from project maintainers ⚠️ |
+
+After downloading, simply extract the release tarball into place:
 
 ```bash
-echo "Unpacking artifacts"
-pushd "${BUILD_ARTIFACTS_DIR}"
-mkdir output_dir
-tar -xf *.tar.gz -C output_dir
-popd
+mkdir therock && cd therock
+# For example...
+wget https://github.com/ROCm/TheRock/releases/download/nightly-tarball/therock-dist-linux-gfx110X-dgpu-6.5.0rc20250610.tar.gz
+
+mkdir install
+tar -xf *.tar.gz -C install
+
+ls install
+# bin  include  lib  libexec  llvm  share
+
+# Now test some of the installed tools:
+./install/bin/rocminfo
+./install/bin/test_hip_api
+
+# You may now also want to add the install directory to your PATH.
 ```
 
 ### Installing per-commit CI build tarballs
 
-Our CI builds artifacts which need to be "flattened" by the `build_tools/fileset_tool.py artifact-flatten` command before they can be used. You will need to have a checkout (see for example [Clone and fetch sources](https://github.com/ROCm/TheRock/blob/main/docs/development/windows_support.md#clone-and-fetch-sources)) in `${SOURCE_DIR}` to use this tool and a Python environment.
+<!-- TODO: Hide this section by default?
+           Maybe move into artifacts.md or another developer page. -->
+
+Our CI builds artifacts at every commit. These can be installed by "flattening"
+them from the expanded artifacts down to a ROCm SDK "dist folder" using the
+`artifact-flatten` command from
+[`build_tools/fileset_tool.py`](https://github.com/ROCm/TheRock/blob/main/build_tools/fileset_tool.py).
+
+1. Download TheRock's source code and setup your Python environment:
+
+   ```bash
+   # Clone the repository
+   git clone https://github.com/ROCm/TheRock.git
+   cd TheRock
+
+   # Init python virtual environment and install python dependencies
+   python3 -m venv .venv && source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+1. Find the CI workflow run that you want to install from. For example, search
+   through recent successful runs of the `ci.yml` workflow for `push` events on
+   the `main` branch
+   [using this page](https://github.com/ROCm/TheRock/actions/workflows/ci.yml?query=branch%3Amain+is%3Asuccess+event%3Apush).
+   (choosing a build that took more than a few minutes)
+
+<!-- TODO: working here, translate this paragraph into a code sample -->
+
+Note a quick recipe for getting all of these from the s3 bucket is to use this quick command `aws s3 cp s3://therock-artifacts . --recursive --exclude "*" --include "${RUN_ID}-${OPERATING_SYSTEM}/*.tar.xz" --no-sign-request` where ${RUN_ID} is the runner id you selected (see the URL). Check the [AWS docs](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) to get the aws cli.
 
 ```bash
 echo "Unpacking artifacts"
@@ -260,6 +308,8 @@ popd
 ```
 
 ### Installing tarballs using `install_rocm_from_artifacts.py`
+
+<!-- TODO: move this above the manual `tar -xf` commands? -->
 
 This script installs ROCm community builds produced by TheRock from either a developer/nightly tarball, a specific CI runner build or an already existing installation of TheRock. This script is used by CI and can be used locally.
 
@@ -300,8 +350,10 @@ popd
 
 ## Where to get artifacts
 
-- [Releases](https://github.com/ROCm/TheRock/releases): Our releases page has the latest "developer" release of our tarball artifacts and source code.
+<!-- TODO: move Dockerfiles to their own top level section -->
 
 - [Packages](https://github.com/orgs/ROCm/packages?repo_name=TheRock): We currently publish docker images for LLVM targets we support (as well as a container for our build machines)
+
+<!-- TODO: delete, merged into other sections -->
 
 - [Per-commit CI builds](https://github.com/ROCm/TheRock/actions/workflows/ci.yml?query=branch%3Amain+is%3Asuccess): Each of our latest passing CI builds has its own artifacts you can leverage. This is the latest and greatest! We will eventually support a nightly release that is at a higher quality bar than CI. Note a quick recipe for getting all of these from the s3 bucket is to use this quick command `aws s3 cp s3://therock-artifacts . --recursive --exclude "*" --include "${RUN_ID}-${OPERATING_SYSTEM}/*.tar.xz" --no-sign-request` where ${RUN_ID} is the runner id you selected (see the URL). Check the [AWS docs](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) to get the aws cli.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -239,9 +239,9 @@ wrapper Python wheels or utility scripts.
 
 ### Installing release tarballs
 
-Release tarballs are automatically uploaded to
-[GitHub releases](https://github.com/ROCm/TheRock/releases) and AWS S3 buckets
-for archival. The S3 buckets do not yet have index pages.
+Release tarballs are automatically uploaded to both
+[GitHub releases](https://github.com/ROCm/TheRock/releases) and AWS S3 buckets.
+The S3 buckets do not yet have index pages.
 
 | Release page                                                                      | S3 bucket                                                                    | Description                                       |
 | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------- |
@@ -368,12 +368,12 @@ We publish [Dockerfiles](https://www.docker.com/) with packages preinstalled
 for your convenience. See
 https://github.com/orgs/ROCm/packages?repo_name=TheRock for the full list.
 
-| Package                                                                                                                               | Description                          |
-| ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| [`therock_build_manylinux_x86_64`](https://github.com/ROCm/TheRock/pkgs/container/therock_build_manylinux_x86_64)                     | ⚠️ Container for our CI/CD pipelines |
-| [`therock_pytorch_dev_ubuntu_24_04_gfx942`](https://github.com/ROCm/TheRock/pkgs/container/therock_pytorch_dev_ubuntu_24_04_gfx942)   | Ubuntu with PyTorch for ROCm gfx942  |
-| [`therock_pytorch_dev_ubuntu_24_04_gfx1100`](https://github.com/ROCm/TheRock/pkgs/container/therock_pytorch_dev_ubuntu_24_04_gfx1100) | Ubuntu with PyTorch for ROCm gfx1100 |
-| [`therock_pytorch_dev_ubuntu_24_04_gfx1151`](https://github.com/ROCm/TheRock/pkgs/container/therock_pytorch_dev_ubuntu_24_04_gfx1151) | Ubuntu with PyTorch for ROCm gfx1151 |
-| [`therock_pytorch_dev_ubuntu_24_04_gfx1201`](https://github.com/ROCm/TheRock/pkgs/container/therock_pytorch_dev_ubuntu_24_04_gfx1201) | Ubuntu with PyTorch for ROCm gfx1201 |
+| Package                                                                                                                               | Description                                                                                                  |
+| ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [`therock_build_manylinux_x86_64`](https://github.com/ROCm/TheRock/pkgs/container/therock_build_manylinux_x86_64)                     | Container for our CI/CD pipelines<br>(This does _not_ include ROCm or PyTorch but can be used to build them) |
+| [`therock_pytorch_dev_ubuntu_24_04_gfx942`](https://github.com/ROCm/TheRock/pkgs/container/therock_pytorch_dev_ubuntu_24_04_gfx942)   | Ubuntu with PyTorch for ROCm gfx942                                                                          |
+| [`therock_pytorch_dev_ubuntu_24_04_gfx1100`](https://github.com/ROCm/TheRock/pkgs/container/therock_pytorch_dev_ubuntu_24_04_gfx1100) | Ubuntu with PyTorch for ROCm gfx1100                                                                         |
+| [`therock_pytorch_dev_ubuntu_24_04_gfx1151`](https://github.com/ROCm/TheRock/pkgs/container/therock_pytorch_dev_ubuntu_24_04_gfx1151) | Ubuntu with PyTorch for ROCm gfx1151                                                                         |
+| [`therock_pytorch_dev_ubuntu_24_04_gfx1201`](https://github.com/ROCm/TheRock/pkgs/container/therock_pytorch_dev_ubuntu_24_04_gfx1201) | Ubuntu with PyTorch for ROCm gfx1201                                                                         |
 
 <!-- TODO: how-to's for using the dockerfiles -->


### PR DESCRIPTION
* Explain what a "release tarball" is
* Rework install instructions
* Show how to test an installation in a bit more detail
* Adjust section headings, pulling "Using Dockerfiles" out into its own section instead of burying it

I'm not touching the `install_rocm_from_artifacts.py` section yet... that's probably going to be most flexible and convenient but it needs some quality of life changes to the script that I'll want us to make together with docs changes.