### PR TITLE
Update `manylinux_2_28_x86_64` image pin

### DIFF
--- a/dockerfiles/cpubuilder/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder/build_manylinux_x86_64.Dockerfile
@@ -9,7 +9,7 @@
 # We build our portable linux releases on the manylinux (RHEL-based)
 # images, with custom additional packages installed. We switch to
 # new upstream versions as needed.
-FROM quay.io/pypa/manylinux_2_28_x86_64@sha256:9042a22d33af2223ff7a3599f236aff1e4ffd07e1ed1ac93a58877638317515f
+FROM quay.io/pypa/manylinux_2_28_x86_64@sha256:634656edbdeb07f955667e645762ad218eefe25f0d185fef913221855d610456
 
 ######## Python setup #######
 # These images come with multiple python versions. We pin one for


### PR DESCRIPTION
Based on the website below, it is used the latest:
`sha256:634656edbdeb07f955667e645762ad218eefe25f0d185fef913221855d610456
`https://quay.io/repository/pypa/manylinux_2_28_x86_64?tab=tags