### PR TITLE
Adding "fetch_job_status.py" python script to fetch job status to be used for further CI analysis

### DIFF
--- a/build_tools/github_actions/fetch_job_status.py
+++ b/build_tools/github_actions/fetch_job_status.py
@@ -16,7 +16,6 @@ run_id = os.getenv("run_id")
 attempt = os.getenv("attempt")
 
 def run():
-    print(f"https://api.github.com/repos/RoCm/TheRock/actions/runs/{run_id}/attempts/1/jobs")
     github_release_url = (
         f"https://api.github.com/repos/RoCm/TheRock/actions/runs/{run_id}/attempts/1/jobs"
     )
@@ -41,9 +40,9 @@ def run():
             )
 
         job_data = json.loads(response.read().decode("utf-8"))
-        if job_data['jobs'].keys()>=0:
+        if job_data['jobs'].keys() >= 0:
             # Determine is number of jobs run in the workflow is atleast 1
-            set_github_output({"append": json.dumps(append_release_note)})
+            set_github_output({"append": json.dumps(job_data)})
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
Added a Python script to obtain the Job status and its specific step details to be used in further CI analysis and historical testcase success and failure analysis. 

Script uses Github APIs and extract job status outputs using the below URI:

"https://api.github.com/repos/RoCm/TheRock/actions/runs/{run_id}/attempts/{attempt_id}/jobs:

Changes in Workflow file to be added:

`      - name: Determine job status for workflow run
        if: '!cancelled()'
        env:
          run_id: ${{ github.run_id }}
          attempt: ${{ github.attempt }}
        run: python build_tools/github_actions/fetch_job_status.py`