### PR TITLE
Don't overwrite existing github release descriptions.

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -156,6 +156,11 @@ jobs:
           allowUpdates: true
           replacesArtifacts: true
           makeLatest: false
+          # Keep existing name/body/status.
+          omitNameDuringUpdate: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
 
       - name: Configure AWS Credentials
         if: ${{ github.repository_owner == 'ROCm' }}


### PR DESCRIPTION
I wrote descriptions for https://github.com/ROCm/TheRock/releases/tag/nightly-tarball and https://github.com/ROCm/TheRock/releases/tag/dev-tarball yesterday which were overwritten when I wanted them to stick. See https://github.com/ncipollo/release-action.

Untested.