### PR TITLE
[numactl] run autoreconf before configure

### DIFF
--- a/third-party/sysdeps/linux/numactl/CMakeLists.txt
+++ b/third-party/sysdeps/linux/numactl/CMakeLists.txt
@@ -69,6 +69,9 @@ add_custom_target(
   COMMAND
     bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${CMAKE_CURRENT_BINARY_DIR}/s"
   COMMAND
+    # reconfigure the project as the version of autoconf available may differ
+    autoreconf -f -i "${CMAKE_CURRENT_BINARY_DIR}/s"
+  COMMAND
     "${CMAKE_CURRENT_BINARY_DIR}/s/configure"
       --prefix "${CMAKE_INSTALL_PREFIX}"
       --disable-static


### PR DESCRIPTION
On systems with a newer version of autoconf the build fails because because aclocal 1.15 is expected. This patch runs autoreconf to regenerate the configuration for the version available on the system.

See: #712