### PR TITLE
[windows] Fix fetch_package_targets without explicit AMDGPU_FAMILIES.

### DIFF
--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -20,9 +20,8 @@ on:
       package_suffix:
         type: string
       families:
-        description: "A comma separated list of AMD GPU families, e.g. `gfx94X,gfx103x`"
+        description: "A comma separated list of AMD GPU families, e.g. `gfx94X,gfx103x`, or empty for the default list"
         type: string
-        default: gfx110x
       extra_cmake_options:
         description: "Extra options to pass to the CMake configure command"
         type: string

--- a/build_tools/github_actions/CMakeLists.txt
+++ b/build_tools/github_actions/CMakeLists.txt
@@ -3,3 +3,9 @@ add_test(
     COMMAND "${Python3_EXECUTABLE}"
         "${CMAKE_CURRENT_SOURCE_DIR}/tests/configure_ci_test.py"
 )
+
+add_test(
+    NAME build_tools_github_actions_fetch_package_targets_test
+    COMMAND "${Python3_EXECUTABLE}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/tests/fetch_package_targets_test.py"
+)

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -1,7 +1,7 @@
 from pathlib import Path
-from unittest import TestCase, main
 import os
 import sys
+import unittest
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import configure_ci
@@ -11,7 +11,7 @@ from amdgpu_family_matrix import (
 )
 
 
-class ConfigureCITest(TestCase):
+class ConfigureCITest(unittest.TestCase):
     def assert_target_output_is_valid(self, target_output):
         self.assertTrue(all("test-runs-on" in entry for entry in target_output))
         self.assertTrue(all("family" in entry for entry in target_output))
@@ -246,4 +246,4 @@ class ConfigureCITest(TestCase):
 
 
 if __name__ == "__main__":
-    main()
+    unittest.main()

--- a/build_tools/github_actions/tests/fetch_package_targets_test.py
+++ b/build_tools/github_actions/tests/fetch_package_targets_test.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+import fetch_package_targets
+
+
+class FetchPackageTargetsTest(unittest.TestCase):
+    def test_linux_single_family(self):
+        args = {
+            "AMDGPU_FAMILIES": "gfx94x",
+            "PYTORCH_DEV_DOCKER": None,
+            "THEROCK_PACKAGE_PLATFORM": "linux",
+        }
+        targets = fetch_package_targets.determine_package_targets(args)
+
+        self.assertEqual(targets, [{"amdgpu_family": "gfx94X-dcgpu"}])
+
+    def test_linux_multiple_families(self):
+        # Note the punctuation that gets stripped and x that gets changed to X.
+        args = {
+            "AMDGPU_FAMILIES": "gfx94x ,; gfx110x",
+            "PYTORCH_DEV_DOCKER": None,
+            "THEROCK_PACKAGE_PLATFORM": "linux",
+        }
+        targets = fetch_package_targets.determine_package_targets(args)
+
+        self.assertEqual(
+            targets,
+            [{"amdgpu_family": "gfx94X-dcgpu"}, {"amdgpu_family": "gfx110X-dgpu"}],
+        )
+
+    def test_linux_no_families(self):
+        args = {
+            "AMDGPU_FAMILIES": None,
+            "PYTORCH_DEV_DOCKER": None,
+            "THEROCK_PACKAGE_PLATFORM": "linux",
+        }
+        targets = fetch_package_targets.determine_package_targets(args)
+
+        self.assertTrue(all("amdgpu_family" in t for t in targets))
+        # Standard targets have suffixes and may use X for a family.
+        self.assertTrue(any("gfx94X-dcgpu" == t["amdgpu_family"] for t in targets))
+        self.assertTrue(any("gfx110X-dgpu" == t["amdgpu_family"] for t in targets))
+
+    def test_linux_docker_no_families(self):
+        args = {
+            "AMDGPU_FAMILIES": None,
+            "PYTORCH_DEV_DOCKER": "true",
+            "THEROCK_PACKAGE_PLATFORM": "linux",
+        }
+        targets = fetch_package_targets.determine_package_targets(args)
+
+        self.assertTrue(all("amdgpu_family" in t for t in targets))
+        # PyTorch Docker targets do not have suffixes.
+        self.assertTrue(any("gfx942" == t["amdgpu_family"] for t in targets))
+        self.assertTrue(any("gfx1100" == t["amdgpu_family"] for t in targets))
+
+    def test_windows_single_family(self):
+        args = {
+            "AMDGPU_FAMILIES": "gfx120x",
+            "PYTORCH_DEV_DOCKER": None,
+            "THEROCK_PACKAGE_PLATFORM": "linux",
+        }
+        targets = fetch_package_targets.determine_package_targets(args)
+
+        self.assertEqual(targets, [{"amdgpu_family": "gfx120X-all"}])
+
+    def test_windows_no_families(self):
+        args = {
+            "AMDGPU_FAMILIES": None,
+            "PYTORCH_DEV_DOCKER": None,
+            "THEROCK_PACKAGE_PLATFORM": "windows",
+        }
+        targets = fetch_package_targets.determine_package_targets(args)
+
+        self.assertTrue(all("amdgpu_family" in t for t in targets))
+        # dcgpu targets are Linux only.
+        self.assertFalse(any("gfx94X-dcgpu" == t["amdgpu_family"] for t in targets))
+        self.assertTrue(any("gfx110X-dgpu" == t["amdgpu_family"] for t in targets))
+        self.assertTrue(any("gfx120X-all" == t["amdgpu_family"] for t in targets))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/542. The new Release Windows packages job failed last night: https://github.com/ROCm/TheRock/actions/runs/15633080737/job/44041709123

```
Run python ./build_tools/github_actions/fetch_package_targets.py
Traceback (most recent call last):
  File "/home/runner/work/TheRock/TheRock/./build_tools/github_actions/fetch_package_targets.py", line 47, in <module>
    main(args)
  File "/home/runner/work/TheRock/TheRock/./build_tools/github_actions/fetch_package_targets.py", line 35, in main
    family = info_for_key.get(package_platform).get("family")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

That failed because some AMDGPU families in https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/amdgpu_family_matrix.py only have information for "linux" and none for "windows". Fixed that case and added unit tests. I had only tested manually with an explicit family list, so I'm also removing the default "families" value to make it easy to trigger with `workflow_dispatch` what would normally run on `schedule`.