### PR TITLE
Add ArtifactName.from_filename util function.

### DIFF
--- a/build_tools/_therock_utils/artifacts.py
+++ b/build_tools/_therock_utils/artifacts.py
@@ -45,12 +45,16 @@ class ArtifactName:
                 return None
             return ArtifactName(m.group(1), m.group(2), m.group(3))
         else:
-            # Matches {name}_{component}_{target_family} with an optional
-            # extra suffix that we ignore and an archive extension.
-            m = re.match(r"^([^_]+)_([^_]+)_([^_]+)(_.+)?\.tar.xz$", filename)
-            if not m:
-                return None
-            return ArtifactName(m.group(1), m.group(2), m.group(3))
+            return ArtifactName.from_filename(filename)
+
+    @staticmethod
+    def from_filename(filename: str) -> Optional["ArtifactName"]:
+        # Matches {name}_{component}_{target_family} with an optional
+        # extra suffix that we ignore and an archive extension.
+        m = re.match(r"^([^_]+)_([^_]+)_([^_]+)(_.+)?\.tar.xz$", filename)
+        if not m:
+            return None
+        return ArtifactName(m.group(1), m.group(2), m.group(3))
 
     def __repr__(self):
         return f"Artifact({self.name}[{self.component}:{self.target_family}])"

--- a/build_tools/tests/artifacts_test.py
+++ b/build_tools/tests/artifacts_test.py
@@ -39,6 +39,17 @@ class ArtifactNameTest(unittest.TestCase):
         self.assertEqual(an1, an2)
         self.assertEqual(hash(an1), hash(an2))
 
+    def testFromFilename(self):
+        f1 = "name_component_generic.tar.xz"
+        an1 = ArtifactName.from_filename(f1)
+        self.assertEqual(an1.name, "name")
+        self.assertEqual(an1.component, "component")
+        self.assertEqual(an1.target_family, "generic")
+
+        f2 = "invalid_name.zip"
+        an2 = ArtifactName.from_filename(f2)
+        self.assertIsNone(an2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Splitting this change off from https://github.com/ROCm/TheRock/pull/772.

This will make it easier to work with artifacts that are on S3 and other non-local locations, where we'll have a URL and a filename, not a Path. We can also see about using [`cloudpathlib`](https://cloudpathlib.drivendata.org/stable/), "A Python library with classes that mimic `pathlib.Path`'s interface for URIs from different cloud storage services".