### PR TITLE
[ci] Adding list option for `extra_cmake_options`

### DIFF
--- a/build_tools/github_actions/build_linux_configure.py
+++ b/build_tools/github_actions/build_linux_configure.py
@@ -23,6 +23,10 @@ extra_cmake_options = os.getenv("extra_cmake_options")
 
 def build_linux_configure():
     logging.info(f"Building package {package_version}")
+
+    # Splitting cmake options into an array (ex: "-flag X" -> ["-flag", "X"]) for subprocess.run
+    cmake_options_arr = extra_cmake_options.split(" ")
+
     cmd = [
         "cmake",
         "-B",
@@ -35,8 +39,7 @@ def build_linux_configure():
         f"-DTHEROCK_PACKAGE_VERSION='{package_version}'",
         "-DTHEROCK_VERBOSE=ON",
         "-DBUILD_TESTING=ON",
-        extra_cmake_options,
-    ]
+    ] + cmake_options_arr
     subprocess.run(cmd, cwd=THEROCK_DIR, check=True)
 
 

--- a/build_tools/github_actions/build_linux_configure.py
+++ b/build_tools/github_actions/build_linux_configure.py
@@ -10,6 +10,7 @@ Required environment variables:
 import logging
 import os
 from pathlib import Path
+import shlex
 import subprocess
 
 logging.basicConfig(level=logging.INFO)
@@ -40,6 +41,7 @@ def build_linux_configure():
         "-DTHEROCK_VERBOSE=ON",
         "-DBUILD_TESTING=ON",
     ] + cmake_options_arr
+    logging.info(shlex.join(cmd))
     subprocess.run(cmd, cwd=THEROCK_DIR, check=True)
 
 

--- a/build_tools/github_actions/build_linux_configure.py
+++ b/build_tools/github_actions/build_linux_configure.py
@@ -25,7 +25,7 @@ def build_linux_configure():
     logging.info(f"Building package {package_version}")
 
     # Splitting cmake options into an array (ex: "-flag X" -> ["-flag", "X"]) for subprocess.run
-    cmake_options_arr = extra_cmake_options.split(" ")
+    cmake_options_arr = extra_cmake_options.split()
 
     cmd = [
         "cmake",


### PR DESCRIPTION
This makes `extra_cmake_options` to convert flags to a list, in order for subprocess.run() to work properly.

Noticed failures in [rocm-libraries](https://github.com/ROCm/rocm-libraries/actions/runs/15688669189/job/44198245967?pr=156) where I pass in many cmake options

Added a `ref` to this branch, and it works in [rocm-libraries TheRock CI](https://github.com/ROCm/rocm-libraries/actions/runs/15689418446/job/44200737766?pr=156)