### PR TITLE
Rename --build-dir to --output-dir in fetch_artifacts.py.

### DIFF
--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python
-# This script provides a somewhat dynamic way to
-# retrieve artifacts from s3
 
-# NOTE: This script currently only retrieves the requested artifacts,
-# but those artifacts may not have all required dependencies.
+"""Fetches artifacts from S3.
+
+NOTE: This script currently only retrieves the requested artifacts,
+but those artifacts may not have all required dependencies.
+
+The install_rocm_from_artifacts.py script builds on top of this script to both
+download artifacts then unpack them into a usable install directory.
+
+Example usage (using https://github.com/ROCm/TheRock/actions/runs/15685736080):
+  mkdir -p ~/.therock/artifacts_15685736080
+  python build_tools/fetch_artifacts.py \
+    --run-id 15685736080 --target gfx110X-dgpu --output-dir ~/.therock/artifacts_15685736080
+"""
 
 import argparse
 import concurrent.futures
@@ -66,6 +75,7 @@ def retrieve_s3_artifacts(run_id, amdgpu_family):
     """Checks that the AWS S3 bucket exists and returns artifact names."""
     EXTERNAL_REPO, BUCKET = retrieve_bucket_info()
     BUCKET_URL = f"https://{BUCKET}.s3.amazonaws.com/{EXTERNAL_REPO}{run_id}-{PLATFORM}"
+    # TODO(scotttodd): hint when amdgpu_family is wrong/missing (root index for all families/platforms)?
     index_page_url = f"{BUCKET_URL}/index-{amdgpu_family}.html"
     log(f"Retrieving artifacts from {index_page_url}")
     request = urllib.request.Request(index_page_url)


### PR DESCRIPTION
Splitting off more changes from https://github.com/ROCm/TheRock/pull/772.

I'm hoping to reuse this script for local rocm Python wheel building, particularly on Windows: https://github.com/ROCm/TheRock/issues/827, so I'll have a few more refactors coming soon. We should also be able to use the script on Linux after some workflow refactors here: https://github.com/ROCm/TheRock/blob/fc8767523fc639a17ba2fd9a5b5137eca334617f/.github/workflows/release_portable_linux_packages.yml#L136-L155

See also discussion on https://github.com/ROCm/TheRock/pull/779.