### PR TITLE
[ci] Fixing pytorch release for gfx950

### DIFF
--- a/dockerfiles/pytorch-dev/install_rocm_from_release.sh
+++ b/dockerfiles/pytorch-dev/install_rocm_from_release.sh
@@ -102,6 +102,7 @@ echo "[INFO] Output dir: $OUTPUT_ARTIFACTS_DIR"
 fallback_target_name() {
   case "$1" in
     gfx942) echo "gfx94X-dcgpu" ;;
+    gfx950) echo "gfx950-dcgpu" ;;
     gfx1100) echo "gfx110X-dgpu" ;;
     gfx1201) echo "gfx120X-all" ;;
     *) echo "" ;;


### PR DESCRIPTION
Noticing failures for [`Pytorch dev docker`](https://github.com/ROCm/TheRock/actions/runs/15696667365/job/44222993444)

where it seems like it tries to find tarballs for `gfx950`, fails to find them (which is typical for gfx942, gfx1100, gfx1201) and should use the fallback target to find the correct tarball.

However, gfx950 doesn't have a fallback target and fails to find it! Providing a fallback target will allow this script to find the correct tarball