### PR TITLE
Update docs to install libtool

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ instructions and configurations for alternatives.
 
 ```bash
 # Install Ubuntu dependencies
-sudo apt install gfortran git git-lfs ninja-build cmake g++ pkg-config xxd patchelf automake python3-venv python3-dev libegl1-mesa-dev
+sudo apt install gfortran git git-lfs ninja-build cmake g++ pkg-config xxd patchelf automake libtool python3-venv python3-dev libegl1-mesa-dev
 
 # Clone the repository
 git clone https://github.com/ROCm/TheRock.git


### PR DESCRIPTION
With #831 landed, libtool is needed as numactl otherwise fails to build with
```
[therock-numactl] Patching sources...
[therock-numactl] Can't exec "libtoolize": No such file or directory at /usr/share/autoconf/Autom4te/FileUtils.pm line 293.
[therock-numactl] autoreconf: error: libtoolize failed with exit status: 2
[therock-numactl] ninja: build stopped: subcommand failed
```

automake suggests libtool but does not depend on it.