### PR TITLE
[windows] Add Windows support to rocm_sdk/_devel.py.

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
@@ -16,11 +16,12 @@ def _do_path(args: argparse.Namespace):
         root_path = _devel.get_devel_root()
     except ModuleNotFoundError as e:
         print(
-            "ERROR: Could not find the `rocm[devel]` package, which is required "
+            "ERROR: Could not load the `rocm[devel]` package, which is required "
             "to access runtime tools and development files. Please install it with "
             "your package manager (pip, uv, etc)",
             file=sys.stderr,
         )
+        print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(1)
     if args.cmake:
         print(root_path / "lib" / "cmake")


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/827.

With this, I can build ROCm SDK wheels on Windows and run the `rocm-sdk path` subcommand:
```bash
# First build artifacts or download them from a CI run, then:
python .\build_tools\linux_python_package.py \
  --artifact-dir=D:\scratch\therock\artifacts_15685736080 \
  --dest-dir=%HOME%\.therock\packages

# Create a local index for easy installation
pip install piprepo
piprepo build %HOME%/.therock/packages/dist

# Install the wheels
pip install rocm[libraries,devel]==0.1.dev0 \
  --extra-index-url %HOME%/.therock/packages/dist/simple \
  --force-reinstall --no-cache-dir

# Try the 'path' subcommand
rocm-sdk path --cmake
# ...\.venv\Lib\site-packages\_rocm_sdk_devel\lib\cmake
```

Note that `rocm-sdk test` still fails since `rocm_sdk.find_libraries()` is not yet implemented. That's next on my list.

References:
* https://docs.python.org/3/library/fcntl.html
* https://docs.python.org/3/library/msvcrt.html

File locking APIs are quite different across Unix and Windows, but this seems to work reliably enough in my testing. If the locking isn't especially load bearing, we could also drop it on Windows instead.