### PR TITLE
[windows] Skip Linux-only console scripts on Windows.

### DIFF
--- a/build_tools/packaging/python/templates/rocm-sdk-core/setup.py
+++ b/build_tools/packaging/python/templates/rocm-sdk-core/setup.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import os
+import platform
 from setuptools import setup, find_packages
 import sys
 import sysconfig
@@ -63,9 +64,18 @@ setup(
             "roc-obj=rocm_sdk_core._cli:roc_obj",
             "roc-obj-extract=rocm_sdk_core._cli:roc_obj_extract",
             "roc-obj-ls=rocm_sdk_core._cli:roc_obj_ls",
-            "rocm_agent_enumerator=rocm_sdk_core._cli:rocm_agent_enumerator",
-            "rocminfo=rocm_sdk_core._cli:rocm_info",
-            "rocm-smi=rocm_sdk_core._cli:rocm_smi",
-        ],
+        ]
+        + (
+            [
+                # These tools are only available on Linux.
+                "rocm_agent_enumerator=rocm_sdk_core._cli:rocm_agent_enumerator",
+                "rocminfo=rocm_sdk_core._cli:rocm_info",
+                "rocm-smi=rocm_sdk_core._cli:rocm_smi",
+            ]
+            if platform.system() != "Windows"
+            else [
+                # TODO(#600): add hipInfo on Windows
+            ]
+        ),
     },
 )


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/827.

This skips installing console script wrappers for tools that are not provided on Windows and updates a test to check for files with extensions.

Some of the tools and tests still fail, but they are closer to passing now. For example:
```
(.venv) λ amdclang --help
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "D:\scratch\therock\python_rocm_2\.venv\Scripts\amdclang.exe\__main__.py", line 7, in <module>
  File "D:\scratch\therock\python_rocm_2\.venv\Lib\site-packages\rocm_sdk_core\_cli.py", line 23, in amdclang
    _exec("lib/llvm/bin/amdclang")
  File "D:\scratch\therock\python_rocm_2\.venv\Lib\site-packages\rocm_sdk_core\_cli.py", line 19, in _exec
    os.execv(full_path, [str(full_path)] + sys.argv[1:])
FileNotFoundError: [Errno 2] No such file or directory
```

Full `rocm-sdk test` output: https://gist.github.com/ScottTodd/e2bafb1dd5f1921bd4524f25b836f132