### PR TITLE
Add comfyui v0.3.41 to Linux with rockbuilder

### DIFF
--- a/experimental/rockbuilder/projects/comfyui.cfg
+++ b/experimental/rockbuilder/projects/comfyui.cfg
@@ -1,0 +1,10 @@
+[project_info]
+name=comfyui
+version=v0.3.41
+repo_url=https://github.com/comfyanonymous/ComfyUI
+
+skip_windows=YES
+
+cmd_exec_dir=${ROCK_BUILDER_APP_SRC_DIR}
+init_cmd = python -m pip install -r ./requirements.txt
+install_cmd = ./thr_install.sh ${ROCK_BUILDER_APP_SRC_DIR} ${ROCM_HOME}

--- a/experimental/rockbuilder/projects/core_apps.pcfg
+++ b/experimental/rockbuilder/projects/core_apps.pcfg
@@ -4,3 +4,4 @@ project_list=
     pytorch_vision
     pytorch_audio
     torch_migraphx
+    comfyui

--- a/external-builds/pytorch/patches/comfyui/v0.3.41/comfyui/base/0001-therock-install-and-launch-scripts-for-comfyui.patch
+++ b/external-builds/pytorch/patches/comfyui/v0.3.41/comfyui/base/0001-therock-install-and-launch-scripts-for-comfyui.patch
@@ -1,0 +1,70 @@
+From 77450953af8a3d3080f716c08e0fb9295fb9098b Mon Sep 17 00:00:00 2001
+From: Mika Laitio <mika.laitio@amd.com>
+Date: Tue, 10 Jun 2025 17:37:18 -0700
+Subject: [PATCH] therock install and launch scripts for comfyui
+
+1. thr_install.sh is invoked by the rockbuilders
+  comfyui.cfg to install the comfyui to directory
+  in $ROCM_HOME/apps/comfyui
+  This script will take two parameters:
+  - location containing the git clone of comfyui sources
+  - ROCM_HOME directory
+
+2. thr_comfyui.sh is the launcher script that will start
+  the comfyui from it's install location
+  ($ROCM_HOME/apps/comfyui)
+
+Signed-off-by: Mika Laitio <mika.laitio@amd.com>
+---
+ thr_comfyui.sh | 11 +++++++++++
+ thr_install.sh | 20 ++++++++++++++++++++
+ 2 files changed, 31 insertions(+)
+ create mode 100644 thr_comfyui.sh
+ create mode 100755 thr_install.sh
+
+diff --git a/thr_comfyui.sh b/thr_comfyui.sh
+new file mode 100644
+index 00000000..e5a503b8
+--- /dev/null
++++ b/thr_comfyui.sh
+@@ -0,0 +1,11 @@
++if [ -z "$ROCM_HOME" ]; then
++    echo "Error, ROCM_HOME not specified."
++    exit 1
++fi
++if test -d "${ROCM_HOME}/apps/comfyui"; then
++    cd ${ROCM_HOME}/apps/comfyui
++    export LD_LIBRARY_PATH=${ROCM_HOME}/lib:${ROCM_HOME}/lib/llvm/lib:${LD_LIBRARY_PATH}
++    python main.py
++else
++    echo "Could not find comfyui install from ${ROCM_HOME}/apps/comfyui"
++fi
+diff --git a/thr_install.sh b/thr_install.sh
+new file mode 100755
+index 00000000..df15390f
+--- /dev/null
++++ b/thr_install.sh
+@@ -0,0 +1,20 @@
++if [ -z "$1" ]; then
++    echo "Error, application source directory not specified."
++    exit 1
++else
++    APP_SRC_DIR=${1}
++fi
++if [ -z "$2" ]; then
++    echo "Error, no rocm_root_directory parameter specified."
++    exit 1
++else
++    INSTALL_DIR_PREFIX_ROCM=${2}
++    echo "rocm_root_directory parameter: ${install_dir_prefix_rocm}"
++fi
++INSTALL_DIR_PREFIX_APP=${INSTALL_DIR_PREFIX_ROCM}/apps/comfyui
++
++mkdir -p ${INSTALL_DIR_PREFIX_APP}
++cd ${APP_SRC_DIR}
++git archive HEAD | tar -x -C ${INSTALL_DIR_PREFIX_APP}
++cp ${APP_SRC_DIR}/thr_comfyui.sh ${INSTALL_DIR_PREFIX_ROCM}/bin
++chmod u+x ${INSTALL_DIR_PREFIX_ROCM}/bin/thr_comfyui.sh
+-- 
+2.43.0
+


### PR DESCRIPTION
Add comfyui-integtation to rockbuilder on Linux. This will
- install comfyui files to $ROCM_HOME/apps/comfyui
- add comfyui server launcher script for linux: $ROCM_HOME/bin/thr_comfyui.sh

These steps are done by the thr_install.sh script that is installed to comfyui source code directory and then launched by the rockbuilder's projects/comfyui.cfg

At the moment users will need to download and install models required by the comfyui
to comfyui directories under $ROCM_HOME/apps/comfyui/models.
In ideal situation comfyui would have an option to configure alternative directory where we could store them so that models would remain even if the rocm directory is deleted.

Usage example after install with "rockbuilder.py":

1. Activate pytorch env used during install

```
    cd <therock>
    source .venv/bin/activate
    # set environment variables
    export ROCM_HOME=<therock_location>/build/dist/rocm
    export PATH=$ROCM_HOME/bin:$PATH

```
    
2. Download example to get some basic models required by the comfyui


```
    cd $ROCM_HOME/apps/comfyui/models/checkpoints
    wget -c https://huggingface.co/Comfy-Org/stable-diffusion-v1-5-archive/resolve/main/v1-5-pruned-emaonly-fp16.safetensors

```

3. Start comfyui webserver:

`    thr_comfyui.sh
` 

In Strix-Halo case this will printout this type of information to terminal:

```
Checkpoint files will always be loaded safely.
Total VRAM 47917 MB, total RAM 95834 MB
pytorch version: 2.7.0
AMD arch: gfx1151
ROCm version: (6, 5)
Set vram state to: NORMAL_VRAM
Device: cuda:0 AMD Radeon Graphics : native
To see the GUI go to: http://127.0.0.1:8188
```

4. Connect to comfyui webserver
    - open browser to URL: http://127.0.0.1:8188

5. Test the image creation on comfyui by pressing Run-button

fixes: https://github.com/ROCm/TheRock/issues/867