### PR TITLE
[ck] Disable CK on win32.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,14 @@ therock_add_feature(SOLVER
   REQUIRES COMPILER HIP_RUNTIME BLAS PRIM SPARSE ${_solver_platform_requirements}
 )
 
+if(NOT WIN32)
+  therock_add_feature(COMPOSABLE_KERNEL
+    GROUP MATH_LIBS
+    DESCRIPTION "Enables build of composable kernel, including minimal kernel library"
+    REQUIRES COMPILER HIP_RUNTIME RAND
+  )
+endif()
+
 # ML-Libs Features.
 therock_add_feature(MIOPEN
   GROUP ML_LIBS

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -275,12 +275,14 @@ def main(argv):
         default=[
             "MIOpen",
         ]
-        + []
-        if is_windows()
-        else [
-            # Linux only projects.
-            "composable_kernel",
-        ],
+        + (
+            []
+            if is_windows()
+            else [
+                # Linux only projects.
+                "composable_kernel",
+            ]
+        ),
     )
     args = parser.parse_args(argv)
     run(args)

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -274,6 +274,11 @@ def main(argv):
         type=str,
         default=[
             "MIOpen",
+        ]
+        + []
+        if is_windows()
+        else [
+            # Linux only projects.
             "composable_kernel",
         ],
     )

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -1,14 +1,15 @@
-if(THEROCK_ENABLE_MIOPEN)
-  # Most libraries need to depend on the profiler, but is conditionally only used
-  # on Posix.
-  set(optional_profiler_deps)
-  if(NOT WIN32)
-    list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
-  endif()
+# Most libraries need to depend on the profiler, but is conditionally only used
+# on Posix.
+set(optional_profiler_deps)
+if(NOT WIN32)
+  list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
+endif()
 
+if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
   ##############################################################################
   # Composable_kernel
   ##############################################################################
+  # TODO: Move this to math-libs
 
   therock_cmake_subproject_declare(composable_kernel
     EXTERNAL_SOURCE_DIR "composable_kernel"
@@ -53,10 +54,18 @@ if(THEROCK_ENABLE_MIOPEN)
     SUBPROJECT_DEPS
       composable_kernel
   )
+endif()
 
+if(THEROCK_ENABLE_MIOPEN)
   ##############################################################################
   # MIOpen
   ##############################################################################
+
+  # If composable kernel is enabled, add it as an MIOpen dep.
+  set(optional_miopen_build_deps)
+  if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
+    list(APPEND optional_miopen_build_deps composable_kernel)
+  endif()
 
   if(MSVC)
     # HACK, see https://github.com/ROCm/TheRock/issues/525.
@@ -83,7 +92,7 @@ if(THEROCK_ENABLE_MIOPEN)
       -DROCM_PATH=
       -DROCM_DIR=
       "-DBUILD_TESTING=${THEROCK_BUILD_TESTING}"
-      -DMIOPEN_USE_COMPOSABLEKERNEL=ON
+      "-DMIOPEN_USE_COMPOSABLEKERNEL=${THEROCK_ENABLE_COMPOSABLE_KERNEL}"
       -DMIOPEN_USE_MLIR=OFF # TODO: enable
       -DMIOPEN_BUILD_DRIVER=ON
       -DBoost_COMPILER=${_THEROCK_MIOPEN_OVERRIDE_BOOST_COMPILER}
@@ -99,8 +108,8 @@ if(THEROCK_ENABLE_MIOPEN)
       therock-googletest
       therock-nlohmann-json
       therock-FunctionalPlus
+      ${optional_miopen_build_deps}
     RUNTIME_DEPS
-      composable_kernel
       hipBLAS-common
       hip-clr
       hipBLAS


### PR DESCRIPTION
Presently on win32, it is not even possible to reliably check out the composable_kernel repository. Disabling on windows for now.

Also adds the feature mapping plumbing and uses that to manage making it conditional deep in the project.

Should fix windows after the break in #876 