### PR TITLE
[ci] adding test timeouts per job level

### DIFF
--- a/.github/workflows/test_hipcub.yml
+++ b/.github/workflows/test_hipcub.yml
@@ -64,11 +64,11 @@ jobs:
           PLATFORM: ${{ inputs.platform }}
 
       - name: Run hipcub tests
-        timeout-minutes: 6
+        timeout-minutes: 15
         run: |
           ctest \
             --test-dir ${THEROCK_BIN_DIR}/hipcub \
             --output-on-failure \
             --parallel 8 \
-            --timeout 360 \
+            --timeout 300 \
             --repeat until-pass:3

--- a/.github/workflows/test_hipcub.yml
+++ b/.github/workflows/test_hipcub.yml
@@ -64,6 +64,7 @@ jobs:
           PLATFORM: ${{ inputs.platform }}
 
       - name: Run hipcub tests
+        timeout-minutes: 6
         run: |
           ctest \
             --test-dir ${THEROCK_BIN_DIR}/hipcub \

--- a/.github/workflows/test_rocprim.yml
+++ b/.github/workflows/test_rocprim.yml
@@ -66,7 +66,7 @@ jobs:
           PLATFORM: ${{ inputs.platform }}
 
       - name: Run rocprim tests
-        timeout-minutes: 15
+        timeout-minutes: 45
         env:
           TEST_TO_IGNORE: "'rocprim.lookback_reproducibility|rocprim.linking|rocprim.device_merge_inplace|rocprim.device_merge_sort|rocprim.device_partition|rocprim.device_radix_sort|rocprim.device_select'"
         run: |

--- a/.github/workflows/test_rocprim.yml
+++ b/.github/workflows/test_rocprim.yml
@@ -66,6 +66,7 @@ jobs:
           PLATFORM: ${{ inputs.platform }}
 
       - name: Run rocprim tests
+        timeout-minutes: 15
         env:
           TEST_TO_IGNORE: "'rocprim.lookback_reproducibility|rocprim.linking|rocprim.device_merge_inplace|rocprim.device_merge_sort|rocprim.device_partition|rocprim.device_radix_sort|rocprim.device_select'"
         run: |

--- a/.github/workflows/test_rocprim.yml
+++ b/.github/workflows/test_rocprim.yml
@@ -66,7 +66,7 @@ jobs:
           PLATFORM: ${{ inputs.platform }}
 
       - name: Run rocprim tests
-        timeout-minutes: 45
+        timeout-minutes: 60
         env:
           TEST_TO_IGNORE: "'rocprim.lookback_reproducibility|rocprim.linking|rocprim.device_merge_inplace|rocprim.device_merge_sort|rocprim.device_partition|rocprim.device_radix_sort|rocprim.device_select'"
         run: |

--- a/.github/workflows/test_rocthrust.yml
+++ b/.github/workflows/test_rocthrust.yml
@@ -66,12 +66,12 @@ jobs:
           PLATFORM: ${{ inputs.platform }}
 
       - name: Run rocthrust tests
-        timeout-minutes: 5
+        timeout-minutes: 6
         run: |
           ctest \
             --test-dir ${THEROCK_BIN_DIR}/rocthrust \
             --output-on-failure \
             --parallel 8 \
             --exclude-regex "^copy.hip$|scan.hip" \
-            --timeout 300 \
+            --timeout 120 \
             --repeat until-pass:3

--- a/.github/workflows/test_rocthrust.yml
+++ b/.github/workflows/test_rocthrust.yml
@@ -66,12 +66,12 @@ jobs:
           PLATFORM: ${{ inputs.platform }}
 
       - name: Run rocthrust tests
-        timeout-minutes: 6
+        timeout-minutes: 5
         run: |
           ctest \
             --test-dir ${THEROCK_BIN_DIR}/rocthrust \
             --output-on-failure \
             --parallel 8 \
             --exclude-regex "^copy.hip$|scan.hip" \
-            --timeout 120 \
+            --timeout 60 \
             --repeat until-pass:3

--- a/.github/workflows/test_rocthrust.yml
+++ b/.github/workflows/test_rocthrust.yml
@@ -66,6 +66,7 @@ jobs:
           PLATFORM: ${{ inputs.platform }}
 
       - name: Run rocthrust tests
+        timeout-minutes: 5
         run: |
           ctest \
             --test-dir ${THEROCK_BIN_DIR}/rocthrust \

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -66,6 +66,7 @@ jobs:
         run: echo "HIP_CLANG_PATH=${OUTPUT_ARTIFACTS_DIR}\lib\llvm\bin" >> $GITHUB_ENV
 
       - name: Run ROCm Sanity Tests
+        timeout-minutes: 1
         run: |
           if [ "${{ inputs.PLATFORM }}" == "linux" ]; then source ${VENV_DIR}/bin/activate ; else . ${VENV_DIR}/Scripts/activate ; fi
           pytest tests/ --log-cli-level=info --timeout=60

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -69,4 +69,4 @@ jobs:
         timeout-minutes: 1
         run: |
           if [ "${{ inputs.PLATFORM }}" == "linux" ]; then source ${VENV_DIR}/bin/activate ; else . ${VENV_DIR}/Scripts/activate ; fi
-          pytest tests/ --log-cli-level=info --timeout=60
+          pytest tests/ --log-cli-level=info --timeout=20

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -66,7 +66,7 @@ jobs:
         run: echo "HIP_CLANG_PATH=${OUTPUT_ARTIFACTS_DIR}\lib\llvm\bin" >> $GITHUB_ENV
 
       - name: Run ROCm Sanity Tests
-        timeout-minutes: 1
+        timeout-minutes: 5
         run: |
           if [ "${{ inputs.PLATFORM }}" == "linux" ]; then source ${VENV_DIR}/bin/activate ; else . ${VENV_DIR}/Scripts/activate ; fi
-          pytest tests/ --log-cli-level=info --timeout=20
+          pytest tests/ --log-cli-level=info --timeout=60


### PR DESCRIPTION
Previously, ctest had timeouts but sometimes it doesn't respect the timeouts. Now, adding GitHub level timeouts to respect the timeout