### PR TITLE
Switch to using amdgpu-windows-interop from a git submodule.

### DIFF
--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -110,13 +110,6 @@ jobs:
         run: |
           python ./build_tools/fetch_sources.py --jobs 96
 
-      - name: Checkout closed source AMDGPU/ROCm interop library folder
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: nod-ai/amdgpu-windows-interop
-          path: amdgpu-windows-interop
-          lfs: true
-
       - name: Configure Projects
         env:
           amdgpu_families: ${{ inputs.amdgpu_families }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -140,3 +140,6 @@
 	path = math-libs/BLAS/rocRoller
 	url = https://github.com/ROCm/rocRoller.git
 	branch = main
+[submodule "amdgpu-windows-interop"]
+	path = core/amdgpu-windows-interop
+	url = https://github.com/nod-ai/amdgpu-windows-interop.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,6 @@ endif()
 # Overall build settings.
 option(THEROCK_VERBOSE "Enables verbose CMake statuses" OFF)
 
-set(THEROCK_AMDGPU_WINDOWS_INTEROP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../amdgpu-windows-interop" CACHE PATH "Directory containing the Windows AMDGPU/ROCm driver interop support files")
-
 # Initialize the install directory.
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "${THEROCK_SOURCE_DIR}/install" CACHE PATH "" FORCE)

--- a/README.md
+++ b/README.md
@@ -78,11 +78,6 @@ python ./build_tools/fetch_sources.py
 ```bash
 # Install dependencies following the Windows support guide
 
-# Clone interop library from https://github.com/nod-ai/amdgpu-windows-interop
-# for CLR (the "HIP runtime") on Windows. The path used can also be configured
-# using the `THEROCK_AMDGPU_WINDOWS_INTEROP_DIR` CMake variable.
-git clone https://github.com/nod-ai/amdgpu-windows-interop.git
-
 # Clone the repository
 git clone https://github.com/ROCm/TheRock.git
 cd TheRock

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -43,6 +43,7 @@ def get_enabled_projects(args) -> list[str]:
 def run(args):
     projects = get_enabled_projects(args)
     submodule_paths = [get_submodule_path(project) for project in projects]
+    # TODO(scotttodd): Check for git lfs?
     update_args = []
     if args.depth:
         update_args += ["--depth", str(args.depth)]
@@ -241,7 +242,14 @@ def main(argv):
             # "rocprofiler-systems",
             "roctracer",
             "ROCR-Runtime",
-        ],
+        ]
+        + (
+            [
+                "amdgpu-windows-interop",
+            ]
+            if is_windows()
+            else []
+        ),
     )
     parser.add_argument(
         "--math-lib-projects",

--- a/build_tools/github_actions/build_configure.py
+++ b/build_tools/github_actions/build_configure.py
@@ -69,11 +69,6 @@ def build_configure():
                 "Environment variable VCToolsInstallDir is not set. Please see https://github.com/ROCm/TheRock/blob/main/docs/development/windows_support.md#important-tool-settings about Windows tool configurations. Exiting."
             )
 
-        if os.path.isdir(f"{github_workspace}/amdgpu-windows-interop"):
-            cmd.append(
-                f"-DTHEROCK_AMDGPU_WINDOWS_INTEROP_DIR={github_workspace}/amdgpu-windows-interop"
-            )
-
     # Splitting cmake options into an array (ex: "-flag X" -> ["-flag", "X"]) for subprocess.run
     cmake_options_arr = extra_cmake_options.split()
     cmd += cmake_options_arr

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -77,19 +77,8 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
   set(HIP_CLR_RUNTIME_DEPS)
   if(WIN32)
     # Windows CLR options
-    set(_compute_pal_dir "${THEROCK_AMDGPU_WINDOWS_INTEROP_DIR}/20250515a")
+    set(_compute_pal_dir "${CMAKE_CURRENT_SOURCE_DIR}/amdgpu-windows-interop/20250515a")
     cmake_path(NORMAL_PATH _compute_pal_dir)
-    set(_compute_pal_probe "${_compute_pal_dir}/pal/CMakeLists.txt")
-    if(NOT EXISTS "${_compute_pal_probe}")
-      message(FATAL_ERROR
-        "Can't build CLR: missing closed source AMDGPU/ROCm interop library folder "
-        "expected at '${_compute_pal_dir}': "
-        "This can be obtained by cloning this repository adjacent to TheRock: "
-        "https://github.com/nod-ai/amdgpu-windows-interop.git (and ensuring it is "
-        "updated to include the referenced version directory)")
-    endif()
-    message(STATUS "Found Winows AMDGPU/ROCm interop library: ${_compute_pal_dir}")
-
     list(APPEND HIP_CLR_CMAKE_ARGS
       "-DUSE_PROF_API=OFF"
       "-D__HIP_ENABLE_PCH=OFF"

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -181,11 +181,6 @@ If you prefer to install tools manually, you will need:
 ### Clone and fetch sources
 
 ```bash
-# Clone interop library from https://github.com/nod-ai/amdgpu-windows-interop
-# for CLR (the "HIP runtime") on Windows. The path used can also be configured
-# using the `THEROCK_AMDGPU_WINDOWS_INTEROP_DIR` CMake variable.
-git clone https://github.com/nod-ai/amdgpu-windows-interop.git
-
 # Clone the repository
 git clone https://github.com/ROCm/TheRock.git
 cd TheRock
@@ -328,11 +323,10 @@ An incremental rollout is planned:
 1. The interop folder must be manually copied into place in the source tree.
    This will allow AMD developers to iterate on integration into TheRock while
    we work on making this folder or more source files available.
-1. *(We are here today)* The interop folder will be available publicly
+1. The interop folder will be available publicly
    (currently at https://github.com/nod-ai/amdgpu-windows-interop).
-1. The interop folder will be included automatically from either a git
-   repository or cloud storage (like the existing third party dep mirrors in
-   [`third-party/`](../../third-party/)).
+1. *(We are here today)* The interop folder will be included automatically from
+   a git repository using git LFS.
 1. A more permanent open source strategy for building the CLR (the HIP runtime)
    from source on Windows will eventually be available.
 


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/693.

I considered using "active submodules" for this (https://git-scm.com/docs/gitsubmodules#_active_submodules), but after reading the docs, I don't see a nice way to make a submodule _conditionally_ active. We could have `fetch_sources.py` flip the bit, but that would show up as dirty git state in `.gitmodules`. So, instead of that, I'm using the same approach we took in `fetch_sources.py` to exclude Linux-only submodules from being checked out on Windows. These approaches have the unfortunate effect of making a regular `git submodule update --init` from the project root be an unsupported action though.

TODO: move the repository from https://github.com/nod-ai/amdgpu-windows-interop to https://github.com/ROCm/amdgpu-windows-interop