### PR TITLE
[profiler] Uses rocprof-trace-decoder from a submodule vs fetching from releases.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -140,3 +140,6 @@
 	path = math-libs/BLAS/rocRoller
 	url = https://github.com/ROCm/rocRoller.git
 	branch = main
+[submodule "rocprof-trace-decoder"]
+	path = profiler/rocprof-trace-decoder/binaries
+	url = https://github.com/ROCm/rocprof-trace-decoder.git

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -237,6 +237,7 @@ def main(argv):
             # TODO: Re-enable when used.
             # "rocprofiler-compute",
             "rocprofiler-sdk",
+            "rocprof-trace-decoder",
             # TODO: Re-enable when used.
             # "rocprofiler-systems",
             "roctracer",

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -8,23 +8,16 @@ if(THEROCK_ENABLE_ROCPROFV3)
   # runtime via `rocprofv3 --att`. If an appropriate shared library is adjacent
   # to the profiler shared libraries, it will be used by default.
   # See: https://github.com/ROCm/rocprof-trace-decoder/
+  # The binaries are contained in the submodule rocprof-trace-decoder/binaries
+  # Our CMakeLists which installs them is local to this project.
   ##############################################################################
   if(THEROCK_ENABLE_ROCPROF_TRACE_DECODER_BINARY)
-    therock_subproject_fetch(rocprof-trace-decoder-download
-      SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprof-trace-decoder-binary/download"
-      URL https://github.com/ROCm/rocprof-trace-decoder/releases/download/0.1.1/rocprof-trace-decoder-manylinux-2.28-0.1.1-Linux.tar.gz
-      URL_HASH SHA256=31098658f2f4d751e79bf17cb22732683a0d356757be01da5eaf46de0752430b
-      TOUCH
-        "${CMAKE_CURRENT_BINARY_DIR}/rocprof-trace-decoder-binary/download/stamp"
-    )
-    therock_cmake_subproject_declare(rocprof-trace-decoder-binary
-      EXTERNAL_SOURCE_DIR "rocprof-trace-decoder-binary"
+    therock_cmake_subproject_declare(rocprof-trace-decoder
+      EXTERNAL_SOURCE_DIR "rocprof-trace-decoder"
       BACKGROUND_BUILD
-      EXTRA_DEPENDS
-        "${CMAKE_CURRENT_BINARY_DIR}/rocprof-trace-decoder-binary/download/stamp"
     )
-    therock_cmake_subproject_activate(rocprof-trace-decoder-binary)
-    list(APPEND _rocprofiler_sdk_optional_deps rocprof-trace-decoder-binary)
+    therock_cmake_subproject_activate(rocprof-trace-decoder)
+    list(APPEND _rocprofiler_sdk_optional_deps rocprof-trace-decoder)
   endif()
 
   ##############################################################################

--- a/profiler/artifact-rocprofiler-sdk.toml
+++ b/profiler/artifact-rocprofiler-sdk.toml
@@ -39,5 +39,5 @@ include = [
 [components.test."profiler/roctracer/stage"]
 
 # rocprof-trace-decoder-binary
-[components.lib."profiler/rocprof-trace-decoder-binary/stage"]
+[components.lib."profiler/rocprof-trace-decoder/stage"]
 optional = true

--- a/profiler/rocprof-trace-decoder-binary/CMakeLists.txt
+++ b/profiler/rocprof-trace-decoder-binary/CMakeLists.txt
@@ -1,9 +1,0 @@
-cmake_minimum_required(VERSION 3.25)
-project(rocprof-trace-decoder-binary)
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  set(_shlib_path "${CMAKE_CURRENT_BINARY_DIR}/../download/opt/rocm/lib/librocprof-trace-decoder.so")
-  install(FILES "${_shlib_path}" TYPE LIB)
-else()
-  message(FATAL_ERROR "Unsupported system")
-endif()

--- a/profiler/rocprof-trace-decoder/CMakeLists.txt
+++ b/profiler/rocprof-trace-decoder/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.25)
+project(rocprof-trace-decoder-binary)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  try_run(
+    ARCH_DETECT_RUN_RESULT ARCH_DETECT_COMPILE_RESULT
+    SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/compute_release_directory.c
+    NO_CACHE
+    COMPILE_OUTPUT_VARIABLE ARCH_COMPILE_ERR
+    RUN_OUTPUT_VARIABLE ARCH_DETECT_OUTPUT
+  )
+  if(ARCH_DETECT_COMPILE_RESULT AND ARCH_DETECT_RUN_RESULT EQUAL 0)
+    string(STRIP "${ARCH_DETECT_OUTPUT}" RELEASE_ARCH)
+    message(STATUS "Detected librocprof-trace-decoder release arch: ${RELEASE_ARCH}")
+    set(_shlib_path "${CMAKE_CURRENT_SOURCE_DIR}/binaries/releases/${RELEASE_ARCH}/librocprof-trace-decoder.so")
+  else()
+    message(
+      FATAL_ERROR
+      "Failed to find a matching release for librocprof-trace-decoder.so. It may be "
+      "unsupported on your architecture and can be disabled with "
+      "-DTHEROCK_ENABLE_ROCPROF_TRACE_DECODER_BINARY=OFF. See output of check:\n"
+      "${ARCH_COMPILE_ERR}\n"
+      "${ARCH_DETECT_OUTPUT}\n"
+    )
+  endif()
+
+  if(NOT EXISTS "${_shlib_path}")
+    message(FATAL_ERROR "Could not find released decoder binary: ${_shlib_path}")
+  endif()
+  install(FILES "${_shlib_path}" TYPE LIB)
+else()
+  message(FATAL_ERROR "Unsupported system")
+endif()

--- a/profiler/rocprof-trace-decoder/compute_release_directory.c
+++ b/profiler/rocprof-trace-decoder/compute_release_directory.c
@@ -1,0 +1,48 @@
+#include <features.h>
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+#ifdef __GLIBC__
+  int glibc_major = __GLIBC__;
+  int glibc_minor = __GLIBC_MINOR__;
+
+  // We have binaries for a sparse set of glibc versions. We generally want
+  // the binary targeting the newest glibc that we support. Populate an
+  // available version.
+  int selected_glibc_major = 0;
+  int selected_glibc_minor = 0;
+
+  if (glibc_major == 2) {
+    selected_glibc_major = 2;
+    if (glibc_minor >= 28) {
+      selected_glibc_minor = 28;
+    } else {
+      fprintf(stderr, "unsupported glibc minor version %d.%d\n", glibc_major,
+              glibc_minor);
+      return 1;
+    }
+  } else {
+    fprintf(stderr, "unsupported glibc version %d.%d\n", glibc_major,
+            glibc_minor);
+    return 1;
+  }
+
+  // Now select the available architecture.
+  const char *selected_arch = 0;
+#ifdef __x86_64__
+  selected_arch = "x86_64";
+#endif
+
+  if (!selected_arch) {
+    fprintf(stderr, "unsupported machine architecture\n");
+    return 1;
+  }
+
+  printf("linux_glibc_%d_%d_%s\n", selected_glibc_major, selected_glibc_minor,
+         selected_arch);
+  return 0;
+#endif
+
+  fprintf(stderr, "unsupported standard c library\n");
+  return 1;
+}


### PR DESCRIPTION
* The rocprof-trace-decoder binary is now being populated with released binaries, organized by system, arch and libc version vs just being posted to the releases page. We pull the submodule in vs doing a fetch.
* These binaries are small (hundreds of KB) so we just include them unconditionally.
* Codes the selection logic in a way that we can expand it in the future to both older/newer glibc and different arches and libc versions.
* Testing this kind of thing is tricky. I manually induced compile and runtime error into the check program and verified that the error messages were sensible.