### PR TITLE
Add Catch2 to third-party

### DIFF
--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -41,9 +41,6 @@ list(APPEND _blas_subproject_names hipBLAS-common)
 # rocRoller
 ##############################################################################
 
-# rocRoller only works from build tree
-# https://github.com/ROCm/TheRock/issues/870
-
 if(WIN32)
   set(_enable_rocRoller "OFF")
 else()
@@ -60,7 +57,6 @@ if(_enable_rocRoller)
       -DROCROLLER_ENABLE_YAML_CPP=ON
       -DROCROLLER_ENABLE_CLIENT=OFF
       -DROCROLLER_BUILD_TESTING=${THEROCK_BUILD_TESTING}
-      -DROCROLLER_ENABLE_CATCH=OFF
       -DROCROLLER_BUILD_SHARED_LIBS=ON
     CMAKE_INCLUDES
       therock_explicit_finders.cmake
@@ -70,6 +66,7 @@ if(_enable_rocRoller)
       mxDataGenerator
       rocm-cmake
       therock-boost
+      therock-catch2
       therock-fmt
       therock-googletest
       therock-libdivide
@@ -78,6 +75,7 @@ if(_enable_rocRoller)
       therock-yaml-cpp
       # therock-cl11 # will need this dep to enable client
     RUNTIME_DEPS
+      therock-catch2
       therock-host-blas
       hip-clr
       ${optional_profiler_deps}
@@ -90,6 +88,7 @@ if(_enable_rocRoller)
   therock_cmake_subproject_activate(rocRoller)
   list(APPEND _blas_subproject_names rocRoller)
 endif()
+
 
 ##############################################################################
 # hipBLASLt

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -2,6 +2,7 @@ add_custom_target(therock-third-party)
 
 # No-dep third party libraries (alphabetical)
 add_subdirectory(boost)
+add_subdirectory(Catch2)
 add_subdirectory(eigen)
 add_subdirectory(fmt)
 add_subdirectory(googletest)

--- a/third-party/Catch2/CMakeLists.txt
+++ b/third-party/Catch2/CMakeLists.txt
@@ -1,0 +1,17 @@
+therock_subproject_fetch(therock-catch2-sources
+  CMAKE_PROJECT
+  URL https://github.com/catchorg/Catch2/archive/refs/tags/v3.7.0.tar.gz
+  URL_HASH SHA256=5b10cd536fa3818112a82820ce0787bd9f2a906c618429e7c4dea639983c8e88
+)
+
+therock_cmake_subproject_declare(therock-catch2
+  BACKGROUND_BUILD
+  EXCLUDE_FROM_ALL
+  NO_MERGE_COMPILE_COMMANDS
+  OUTPUT_ON_FAILURE
+  EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
+)
+therock_cmake_subproject_provide_package(therock-catch2 Catch2 lib/cmake)
+therock_cmake_subproject_activate(therock-catch2)
+
+add_dependencies(therock-third-party therock-catch2)


### PR DESCRIPTION
- Adds Catch2 unit testing library to third-party
- Updates rocRoller recipe to enable building catch tests