### PR TITLE
[ci] Adding correct repo checkout for reusable workflows

### DIFF
--- a/.github/workflows/test_hipblaslt.yml
+++ b/.github/workflows/test_hipblaslt.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/TheRock"
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/test_hipcub.yml
+++ b/.github/workflows/test_hipcub.yml
@@ -52,6 +52,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/TheRock"
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/test_rocblas.yml
+++ b/.github/workflows/test_rocblas.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/TheRock"
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/test_rocthrust.yml
+++ b/.github/workflows/test_rocthrust.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/TheRock"
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/TheRock"
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'


### PR DESCRIPTION
Currently, other repos (like rocm-libraries) use TheRock's test workflows (since it's easily reusable and not much change happens)

In this [rocm-libraries TheRock CI workflow](https://github.com/ROCm/rocm-libraries/actions/runs/15788899766/job/44512015783?pr=324), it is incorrectly checking out the repo! Making this update so other repos can utilize all test workflows (rocprim is already enabled)