### PR TITLE
Add output-dir parameter to rockbuilder

### DIFF
--- a/experimental/rockbuilder/README.md
+++ b/experimental/rockbuilder/README.md
@@ -120,6 +120,24 @@ python torch_vision_hello_world.py
 python torch_audio_hello_world.py
 ```
 
+Wheels that have been build can be found from the packages/wheels directory.
+
+## Checkout and build only pytorch_audio
+
+In this example we build and install only the pytorch audio and
+copy the produced pytorch audio wheel to directory "test" instead of using default "packages/wheels"
+Note that pytorch audio requires that pytorch has been build and installed first.
+
+```bash
+python rockbuilder.py --project pytorch_audio --output-dir test
+```
+
+## Checkout only the pytorch_audio sources
+
+```bash
+python rockbuilder.py --checkout --project pytorch_audio
+```
+
 ## Checkout all projects (without build and install)
 
 ```bash
@@ -134,11 +152,15 @@ python rockbuilder.py --checkout --project pytorch_audio
 
 ## Build only pytorch audio
 
+Note that pytorch audio requires that pytorch has been build and installed first.
+
 ```bash
 python rockbuilder.py --build --project pytorch_audio
 ```
 
 ## Install only pytorch audio
+
+Note that pytorch audio requires that pytorch has been build and installed first.
 
 ```bash
 python rockbuilder.py --install --project pytorch_audio

--- a/experimental/rockbuilder/README.md
+++ b/experimental/rockbuilder/README.md
@@ -126,7 +126,7 @@ Wheels that have been build can be found from the packages/wheels directory.
 
 In this example we build and install only the pytorch audio and
 copy the produced pytorch audio wheel to directory "test" instead of using default "packages/wheels"
-Note that pytorch audio requires that pytorch has been build and installed first.
+Note that pytorch audio requires that pytorch has been built and installed first.
 
 ```bash
 python rockbuilder.py --project pytorch_audio --output-dir test
@@ -152,7 +152,7 @@ python rockbuilder.py --checkout --project pytorch_audio
 
 ## Build only pytorch audio
 
-Note that pytorch audio requires that pytorch has been build and installed first.
+Note that pytorch audio requires that pytorch has been built and installed first.
 
 ```bash
 python rockbuilder.py --build --project pytorch_audio
@@ -160,7 +160,7 @@ python rockbuilder.py --build --project pytorch_audio
 
 ## Install only pytorch audio
 
-Note that pytorch audio requires that pytorch has been build and installed first.
+Note that pytorch audio requires that pytorch has been built and installed first.
 
 ```bash
 python rockbuilder.py --install --project pytorch_audio

--- a/experimental/rockbuilder/lib_python/project_builder.py
+++ b/experimental/rockbuilder/lib_python/project_builder.py
@@ -22,7 +22,7 @@ class RockProjectBuilder(configparser.ConfigParser):
             ret = None
         return ret
 
-    def __init__(self, rock_builder_root_dir, project_name):
+    def __init__(self, rock_builder_root_dir, project_name, app_output_dir):
         super(RockProjectBuilder, self).__init__(allow_no_value=True)
 
         self.is_posix = not any(platform.win32_ver())
@@ -31,7 +31,7 @@ class RockProjectBuilder(configparser.ConfigParser):
         self.cfg_file_path = (
             Path(rock_builder_root_dir) / "projects" / f"{project_name}.cfg"
         )
-        self.wheel_install_dir = Path(rock_builder_root_dir) / "packages" / "wheels"
+        self.app_output_dir = app_output_dir
         if self.cfg_file_path.exists():
             self.read(self.cfg_file_path)
         else:
@@ -110,7 +110,7 @@ class RockProjectBuilder(configparser.ConfigParser):
         )
         self.project_patch_dir_root = self.project_patch_dir_root.resolve()
         self.project_repo = RockProjectRepo(
-            self.wheel_install_dir,
+            self.app_output_dir,
             self.project_name,
             self.project_root_dir_path,
             self.project_src_dir_path,
@@ -225,10 +225,11 @@ class RockProjectBuilder(configparser.ConfigParser):
 
 
 class RockExternalProjectListManager(configparser.ConfigParser):
-    def __init__(self, rock_builder_root_dir):
+    def __init__(self, rock_builder_root_dir, app_output_dir):
         # default application list to builds
         self.cfg_file_path = Path(rock_builder_root_dir) / "projects" / "core_apps.pcfg"
         self.rock_builder_root_dir = rock_builder_root_dir
+        self.app_output_dir = app_output_dir
         super(RockExternalProjectListManager, self).__init__(allow_no_value=True)
         if self.cfg_file_path.exists():
             self.read(self.cfg_file_path)
@@ -241,7 +242,9 @@ class RockExternalProjectListManager(configparser.ConfigParser):
     def get_rock_project_builder(self, project_name):
         ret = None
         try:
-            ret = RockProjectBuilder(self.rock_builder_root_dir, project_name)
+            ret = RockProjectBuilder(
+                self.rock_builder_root_dir, project_name, self.app_output_dir
+            )
         except ValueError as e:
             print(str(e))
         return ret

--- a/experimental/rockbuilder/lib_python/project_builder.py
+++ b/experimental/rockbuilder/lib_python/project_builder.py
@@ -22,7 +22,7 @@ class RockProjectBuilder(configparser.ConfigParser):
             ret = None
         return ret
 
-    def __init__(self, rock_builder_root_dir, project_name, app_output_dir):
+    def __init__(self, rock_builder_root_dir, project_name, package_output_dir):
         super(RockProjectBuilder, self).__init__(allow_no_value=True)
 
         self.is_posix = not any(platform.win32_ver())
@@ -31,7 +31,7 @@ class RockProjectBuilder(configparser.ConfigParser):
         self.cfg_file_path = (
             Path(rock_builder_root_dir) / "projects" / f"{project_name}.cfg"
         )
-        self.app_output_dir = app_output_dir
+        self.package_output_dir = package_output_dir
         if self.cfg_file_path.exists():
             self.read(self.cfg_file_path)
         else:
@@ -110,7 +110,7 @@ class RockProjectBuilder(configparser.ConfigParser):
         )
         self.project_patch_dir_root = self.project_patch_dir_root.resolve()
         self.project_repo = RockProjectRepo(
-            self.app_output_dir,
+            self.package_output_dir,
             self.project_name,
             self.project_root_dir_path,
             self.project_src_dir_path,
@@ -225,11 +225,11 @@ class RockProjectBuilder(configparser.ConfigParser):
 
 
 class RockExternalProjectListManager(configparser.ConfigParser):
-    def __init__(self, rock_builder_root_dir, app_output_dir):
+    def __init__(self, rock_builder_root_dir, package_output_dir):
         # default application list to builds
         self.cfg_file_path = Path(rock_builder_root_dir) / "projects" / "core_apps.pcfg"
         self.rock_builder_root_dir = rock_builder_root_dir
-        self.app_output_dir = app_output_dir
+        self.package_output_dir = package_output_dir
         super(RockExternalProjectListManager, self).__init__(allow_no_value=True)
         if self.cfg_file_path.exists():
             self.read(self.cfg_file_path)
@@ -243,7 +243,7 @@ class RockExternalProjectListManager(configparser.ConfigParser):
         ret = None
         try:
             ret = RockProjectBuilder(
-                self.rock_builder_root_dir, project_name, self.app_output_dir
+                self.rock_builder_root_dir, project_name, self.package_output_dir
             )
         except ValueError as e:
             print(str(e))

--- a/experimental/rockbuilder/rockbuilder.py
+++ b/experimental/rockbuilder/rockbuilder.py
@@ -107,7 +107,7 @@ def get_build_arguments():
         "--output-dir",
         type=Path,
         help="Directory to copy built wheels to",
-        default=rock_builder_home_dir + "/packages/wheels",
+        default=Path(rock_builder_home_dir) / "packages" / "wheels",
     )
 
     # Parse the arguments

--- a/experimental/rockbuilder/rockbuilder.py
+++ b/experimental/rockbuilder/rockbuilder.py
@@ -103,6 +103,12 @@ def get_build_arguments():
         help="post-install command for project",
         default=False,
     )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory to copy built wheels to",
+        default=rock_builder_home_dir + "/packages/wheels",
+    )
 
     # Parse the arguments
     args = parser.parse_args()
@@ -366,7 +372,9 @@ args = get_build_arguments()
 printout_build_arguments(args)
 verify_build_env(args)
 
-project_manager = project_builder.RockExternalProjectListManager(rock_builder_home_dir)
+project_manager = project_builder.RockExternalProjectListManager(
+    rock_builder_home_dir, args.output_dir
+)
 # allow_no_value param says that no value keys are ok
 sections = project_manager.sections()
 # print(sections)


### PR DESCRIPTION
Add possibility to specify the directory where the produced (python wheel) files are copied after build. Like earlier, default value is "packages/wheels". This may be useful especially in the ci-builds.

Usage example:
 ./rockbuilder.py --project pytorch --output-dir test