### PR TITLE
[windows] Skip Linux-only aliases in console script tests.

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
@@ -22,21 +22,24 @@ utils.assert_is_physical_package(core_mod)
 so_paths = utils.get_module_shared_libraries(core_mod)
 is_windows = platform.system() == "Windows"
 
-
-CONSOLE_SCRIPT_TESTS = [
+LINUX_CONSOLE_SCRIPT_TESTS = [
+    # These currently only have unprefixed names (e.g. 'clang') on Windows.
     ("amdclang", ["--help"], "clang LLVM compiler", True),
     ("amdclang++", ["--help"], "clang LLVM compiler", True),
     ("amdclang-cpp", ["--help"], "clang LLVM compiler", True),
     ("amdclang-cl", ["-help"], "clang LLVM compiler", True),
     ("amdflang", ["--help"], "clang LLVM compiler", True),
     ("amdlld", ["-flavor", "ld.lld", "--help"], "USAGE:", True),
+    # These tools are only available on Linux.
+    ("rocm_agent_enumerator", [], "", True),
+    ("rocminfo", [], "", True),
+    ("rocm-smi", [], "Management", True),
+]
+
+CONSOLE_SCRIPT_TESTS = [
     ("hipcc", ["--help"], "clang LLVM compiler", True),
     ("hipconfig", [], "HIP version:", True),
-    # These tools are only available on Linux.
-    ("rocm_agent_enumerator", [], "", not is_windows),
-    ("rocminfo", [], "", not is_windows),
-    ("rocm-smi", [], "Management", not is_windows),
-]
+] + (LINUX_CONSOLE_SCRIPT_TESTS if not is_windows else [])
 
 exe_suffix = ".exe" if is_windows else ""
 


### PR DESCRIPTION
Follow-up to https://github.com/ROCm/TheRock/pull/873, progress on https://github.com/ROCm/TheRock/issues/827.

I'm not sure why Linux has these `amd*` prefixed tool names but Windows does not. If we can unify that then subprojects won't need to jump through all these hoops to use the tools: https://github.com/ROCm/rocm-libraries/blob/6392fd0889abac24a8c7ba15a0ce95a982908635/projects/hipblaslt/tensilelite/Tensile/Toolchain/Validators.py#L116-L122
```python
class ToolchainDefaults(NamedTuple):
    CXX_COMPILER = osSelect(linux="amdclang++", windows="clang++.exe")
    C_COMPILER = osSelect(linux="amdclang", windows="clang.exe")
    OFFLOAD_BUNDLER = osSelect(linux="clang-offload-bundler", windows="clang-offload-bundler.exe")
    DEVICE_ENUMERATOR = osSelect(linux="rocm_agent_enumerator" if isRhel8() else "amdgpu-arch", windows="hipinfo")
    ASSEMBLER = osSelect(linux="amdclang++", windows="clang++.exe")
    HIP_CONFIG = osSelect(linux="hipconfig", windows="hipconfig.exe")
```