### PR TITLE
Add gfx1200 target to the gfx120X-all family.

### DIFF
--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -81,6 +81,7 @@ therock_add_amdgpu_target(gfx1151 "AMD Strix Halo iGPU" FAMILY igpu-all gfx115X-
 )
 
 # gfx120X family
+therock_add_amdgpu_target(gfx1200 "AMD RX 9060 / XT" FAMILY dgpu-all gfx120X-all)
 therock_add_amdgpu_target(gfx1201 "AMD RX 9070 / XT" FAMILY dgpu-all gfx120X-all)
 
 


### PR DESCRIPTION
* This will enable building gfx1200/gfx1201 together (RX9060 and RX9070).
* Does not yet change test fanout.