### PR TITLE
Supporting git longpaths for `fetch_sources.py`

### DIFF
--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -40,13 +40,10 @@ def get_enabled_projects(args) -> list[str]:
     return projects
 
 
-def enable_longpaths():
-    exec(["git", "config", "core.longpaths", "true"], cwd=THEROCK_DIR)
-
-
 def run(args):
     projects = get_enabled_projects(args)
-    enable_longpaths()
+    # Support git long paths before submodule retrieval
+    exec(["git", "config", "core.longpaths", "true"], cwd=THEROCK_DIR)
     submodule_paths = [get_submodule_path(project) for project in projects]
     update_args = []
     if args.depth:

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -40,8 +40,13 @@ def get_enabled_projects(args) -> list[str]:
     return projects
 
 
+def enable_longpaths():
+    exec(["git", "config", "core.longpaths", "true"], cwd=THEROCK_DIR)
+
+
 def run(args):
     projects = get_enabled_projects(args)
+    enable_longpaths()
     submodule_paths = [get_submodule_path(project) for project in projects]
     update_args = []
     if args.depth:


### PR DESCRIPTION
Currently, windows fetch_sources fail due to some long path files.

This update enables long files to be retrieved