### PR TITLE
[windows][torch] Add Windows support to build_prod_wheels.py.

### DIFF
--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -77,7 +77,7 @@ variables. Examples (exact settings needed will vary by project being built):
 
 ```bash
 -DCMAKE_PREFIX_PATH=$(rocm-sdk path --cmake)
--DROCM_HOM=$(rocm-sdk path --root)
+-DROCM_HOME=$(rocm-sdk path --root)
 export PATH="$(rocm-sdk path --bin):$PATH"
 ```
 

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -65,11 +65,17 @@ throw-away container or CI environment.
 
 ### Build PyTorch, PyTorch vision and PyTorch audio on Linux
 
+> [!WARNING]
+> This is being migrated to `build_prod_wheels.py`, using `rocm` (sdk) wheels.
+
 ```bash
 ./checkout_and_build_all.sh
 ```
 
 ### Build PyTorch on Windows (or the old way on Linux)
+
+> [!WARNING]
+> This is being migrated to `build_prod_wheels.py`, using `rocm` (sdk) wheels.
 
 #### Step 1: Preparing sources
 
@@ -107,6 +113,9 @@ bash build_pytorch_windows.sh gfx1100
 
 ### Windows DLL setup
 
+> [!IMPORTANT]
+> This will no longer be necessary after `rocm` wheels are available.
+
 On Windows, PyTorch needs to be able to find DLL files from the `dist/rocm`
 directory. This can be achieved by either
 
@@ -119,6 +128,9 @@ directory. This can be achieved by either
 - Creating a "fat wheel" that bundles the files together (see the next section).
 
 ### Bundling PyTorch and ROCm together into a "fat wheel"
+
+> [!IMPORTANT]
+> This will no longer be necessary after `rocm` wheels are available.
 
 By default, Python wheels produced by the PyTorch build do not include ROCm
 binaries. Instead, they expect those binaries to be installed elsewhere on the


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/827. These are the build script changes that I needed to build torch wheels on Windows after installing `rocm[libraries,devel]` wheels.

This will all get worked into the docs and integrated into CI/CD later... for now, here's what I'm working with:

1. Build the `rocm` wheels locally
    ```bash
    # Build
    python .\build_tools\linux_python_package.py \
      --artifact-dir=D:/projects/TheRock/build/artifacts \
      --dest-dir=%HOME%\.therock\packages
    
    # Generate local index for easy installation (one time)
    pip install piprepo
    piprepo build %HOME%/.therock/packages/dist
    
    # Install
    pip install rocm[libraries,devel]==0.1.dev0 \
      --extra-index-url %HOME%/.therock/packages/dist/simple \
      --force-reinstall --no-cache-dir
    ```

2. With those `rocm` wheels, build pytorch:

    ```
    python pytorch_torch_repo.py checkout --repo D:/b/pytorch
    python build_prod_wheels.py build --output-dir %HOME%/.therock/pytorch --pytorch-dir D:/b/pytorch
    ```

I still also need to backport a patch to DLL load ordering for PyTorch 2.7.0 and/or rebase us on PyTorch 2.8.0.