### PR TITLE
[python] Fix has_py_package() logic.

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -88,7 +88,7 @@ class PackageEntry:
         return importlib.util.find_spec(self.get_py_package_name(target_family))
 
     def has_py_package(self, target_family: str | None = None) -> bool:
-        return self.get_py_package(self.get_py_package_name(target_family)) is not None
+        return self.get_py_package(target_family) is not None
 
     def __repr__(self):
         return self.dist_package_template


### PR DESCRIPTION
Related to https://github.com/ROCm/TheRock/issues/703.

Up a few lines, the `get_py_package()` function takes `target_family` and calls `get_py_package_name(target_family)` itself, so it should not be passed a package name string. That might be safe if the `get_py_package_name(target_family)` function looked for a specific string pattern and was idempotent, but it is not.

This fixes `NOTE: Skipping libraries tests (not installed for this arch)` warnings running `rocm-sdk test` here: https://github.com/ROCm/TheRock/blob/195a3e395fdf56337450f42360249414c0cde0ae/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py#L48-L53

I now see new errors with `rocm-sdk test` on Windows thanks to the fix (https://gist.github.com/ScottTodd/d7799ddbf86dc0458dd4a2a76b9ad1a1). I did _not_ test on Linux to see if this uncovers test failures in the newly enabled tests there.