### PR TITLE
rockbuilder code cleanups

### DIFF
--- a/experimental/rockbuilder/CONFIG.md
+++ b/experimental/rockbuilder/CONFIG.md
@@ -100,6 +100,10 @@ Base environment variables are automatically specified for each application that
   The source code directory for the currently built application
 - `ROCK_BUILDER_APP_BUILD_DIR`:
   The build directory for the currently built application
+- `ROCK_BUILDER_CLANG_HOME`:
+  Home directory for the clang. It location may vary depending whether the rocm_sdk used is build locally or used from the rocm_sdk python wheel.
+- `ROCK_BUILDER_BITCODE_HOME`:
+  Directory containing gpu specific bitcode (\*.bc) files
 
 #### Application-Specific Environment Variables
 

--- a/experimental/rockbuilder/projects/pytorch.cfg
+++ b/experimental/rockbuilder/projects/pytorch.cfg
@@ -9,8 +9,8 @@ env_common=
        USE_CUDA=0
        USE_KINETO=0
        CMAKE_PREFIX_PATH=${ROCM_HOME}
-       DEVICE_LIB_PATH=${ROCM_HOME}/lib/llvm/amdgcn/bitcode
-       HIP_CLANG_PATH=${ROCM_HOME}/lib/llvm/bin
+       DEVICE_LIB_PATH=${ROCK_BUILDER_BITCODE_HOME}
+       HIP_CLANG_PATH=${ROCK_BUILDER_CLANG_HOME}/bin
        HIP_DEVICE_LIB_PATH=${DEVICE_LIB_PATH}
        PYTORCH_BUILD_VERSION=2.7.0
        PYTORCH_BUILD_NUMBER=1
@@ -28,6 +28,11 @@ env_windows =
        CXX=${HIP_CLANG_PATH}/clang-cl
        DISTUTILS_USE_SDK=1
        PYTORCH_ROCM_ARCH=${THEROCK_AMDGPU_TARGETS}
+
+env_linux =
+       CC=${HIP_CLANG_PATH}/amdclang
+       CXX=${HIP_CLANG_PATH}/amdclang
+
 
 init_cmd = python -m pip install -r ./requirements.txt
 clean_cmd = python setup.py clean

--- a/experimental/rockbuilder/projects/pytorch_audio.cfg
+++ b/experimental/rockbuilder/projects/pytorch_audio.cfg
@@ -14,8 +14,8 @@ env_common=
        BUILD_NUMBER=1
        ROCM_PATH=${ROCM_HOME}
        CMAKE_PREFIX_PATH=${ROCM_HOME}
-       HIP_CLANG_PATH=${ROCM_HOME}/lib/llvm/bin
-       DEVICE_LIB_PATH=${ROCM_HOME}/lib/llvm/amdgcn/bitcode
+       HIP_CLANG_PATH=${ROCK_BUILDER_CLANG_HOME}/bin
+       DEVICE_LIB_PATH=${ROCK_BUILDER_BITCODE_HOME}
        HIP_DEVICE_LIB_PATH=${DEVICE_LIB_PATH}
 
 env_linux =

--- a/experimental/rockbuilder/projects/pytorch_vision.cfg
+++ b/experimental/rockbuilder/projects/pytorch_vision.cfg
@@ -14,8 +14,8 @@ env_common=
        VERSION_NAME=0.22.0
        ROCM_PATH=${ROCM_HOME}
        CMAKE_PREFIX_PATH=${ROCM_HOME}
-       HIP_CLANG_PATH=${ROCM_HOME}/lib/llvm/bin
-       DEVICE_LIB_PATH=${ROCM_HOME}/lib/llvm/amdgcn/bitcode
+       HIP_CLANG_PATH=${ROCK_BUILDER_CLANG_HOME}/bin
+       DEVICE_LIB_PATH=${ROCK_BUILDER_BITCODE_HOME}
        HIP_DEVICE_LIB_PATH=${DEVICE_LIB_PATH}
 
 env_linux =

--- a/experimental/rockbuilder/projects/rocm_sdk.cfg
+++ b/experimental/rockbuilder/projects/rocm_sdk.cfg
@@ -1,0 +1,4 @@
+[project_info]
+name=rocm_sdk
+
+install_cmd = python -m pip install --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx94X-dcgpu --cache-dir ${ROCK_BUILDER_APP_BUILD_DIR} rocm_sdk

--- a/experimental/rockbuilder/projects/rocm_sdk.cfg
+++ b/experimental/rockbuilder/projects/rocm_sdk.cfg
@@ -1,4 +1,0 @@
-[project_info]
-name=rocm_sdk
-
-install_cmd = python -m pip install --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx94X-dcgpu --cache-dir ${ROCK_BUILDER_APP_BUILD_DIR} rocm_sdk

--- a/experimental/rockbuilder/rockbuilder.py
+++ b/experimental/rockbuilder/rockbuilder.py
@@ -234,9 +234,9 @@ def verify_build_env(args, rock_builder_home_dir):
     else:
         ENV_VARIABLE_NAME__LIB = "LIBPATH"
 
-    # check that THEROCK_AMDGPU_TARGETS has been specified on Windows build
-    # because the pytorch build on windows can not automatically resolve the
-    # build targets by checking the targets support build into the used rocm_sdk
+    # check that THEROCK_AMDGPU_TARGETS has been specified on Windows builds.
+    # This is needdd because on locally build rocm sdk we can not automatically query
+    # what are the build targets that are supported by rocm_sdk used.
     if not is_posix:
         if not "THEROCK_AMDGPU_TARGETS" in os.environ:
             print(
@@ -250,9 +250,12 @@ def verify_build_env(args, rock_builder_home_dir):
     # check rocm
     if "ROCM_HOME" in os.environ:
         rocm_home_root_path = Path(os.environ["ROCM_HOME"])
+        rocm_home_root_path = rocm_home_root_path.resolve()
     else:
         rocm_home_root_path = rock_builder_home_dir / "../../build/dist/rocm"
-    rocm_home_root_path = rocm_home_root_path.resolve()
+        rocm_home_root_path = rocm_home_root_path.resolve()
+        print("using locally build rocm sdk from TheRock:")
+        print("    " + rocm_home_root_path.as_posix())
     if rocm_home_root_path.exists():
         # set ROCM_HOME if not yet set
         if not "ROCM_HOME" in os.environ:

--- a/experimental/rockbuilder/rockbuilder.py
+++ b/experimental/rockbuilder/rockbuilder.py
@@ -9,17 +9,13 @@ import time
 import platform
 from pathlib import Path, PurePosixPath
 
-ROCK_BUILDER_VERSION = "2025-06-03_01"
-is_posix = not any(platform.win32_ver())
+ROCK_BUILDER_VERSION = "2025-06-25_01"
 
-# os.environ["ROCK_BUILDER_HOME_DIR"] = os.getcwd()
-current_file_path = os.path.abspath(__file__)
-rock_builder_home_dir = os.path.dirname(current_file_path)
-os.environ["ROCK_BUILDER_HOME_DIR"] = rock_builder_home_dir
-os.environ["ROCK_BUILDER_SRC_DIR"] = (
-    os.environ["ROCK_BUILDER_HOME_DIR"] + "/src_projects"
-)
-os.environ["ROCK_BUILDER_BUILD_DIR"] = os.environ["ROCK_BUILDER_HOME_DIR"] + "/builddir"
+
+def get_rocm_builder_root_dir():
+    current_file_path = os.path.abspath(__file__)
+    ret = Path(os.path.dirname(current_file_path)).resolve()
+    return ret
 
 
 def printout_rock_builder_info():
@@ -41,7 +37,7 @@ def printout_build_env_info():
     time.sleep(1)
 
 
-def get_build_arguments():
+def get_build_arguments(rock_builder_home_dir):
     # Create an ArgumentParser object
     parser = argparse.ArgumentParser(description="ROCK Project Builders")
 
@@ -107,7 +103,7 @@ def get_build_arguments():
         "--output-dir",
         type=Path,
         help="Directory to copy built wheels to",
-        default=Path(rock_builder_home_dir) / "packages" / "wheels",
+        default=rock_builder_home_dir / "packages" / "wheels",
     )
 
     # Parse the arguments
@@ -144,6 +140,10 @@ def get_build_arguments():
     # force the hipify step always as a part of the checkout
     if args.checkout:
         args.hipify = True
+
+    # add output dir to environment variables
+    os.environ["ROCK_BUILDER_PACKAGE_OUTPUT_DIR"] = args.output_dir.as_posix()
+
     return args
 
 
@@ -163,96 +163,10 @@ def printout_build_arguments(args):
     print("Projects:", args.project)
 
 
-def verify_build_env(args):
-    # we may actually need to have the build environment
-    # even during the checkout as we do the hipify during the checkout process
-    """"
-    if ((args.checkout == True) and\
-        (args.init == False) and\
-        (args.clean == False) and\
-        (args.hipify == False) and\
-        (args.pre_config == False) and\
-        (args.config == False) and\
-        (args.post_config == False) and\
-        (args.build == False) and\
-        (args.install == False) and\
-        (args.post_install == False)):
-        # allow code checkout even before TheRock build has been installed
-        printout_rock_builder_info()
-        return
-    """
-    # check ld library path to resolve libraries during the build time
-    if is_posix:
-        ENV_VARIABLE_NAME__LIB = "LD_LIBRARY_PATH"
-    else:
-        ENV_VARIABLE_NAME__LIB = "LIBPATH"
-        if not "THEROCK_AMDGPU_TARGETS" in os.environ:
-            print(
-                "Error, THEROCK_AMDGPU_TARGETS must be set on Windows to select the target GPUs"
-            )
-            print("Target GPU must match with the GPU selected on TheRock core build")
-            print("Example for building for AMD Strix Halo and RX 9070:")
-            print("  set THEROCK_AMDGPU_TARGETS=gfx1151;gfx1201")
-            sys.exit(1)
-
-    # check rocm
-    if "ROCM_HOME" not in os.environ:
-        rocm_home_root_path = Path(rock_builder_home_dir) / "../../build/dist/rocm"
-        rocm_home_root_path = rocm_home_root_path.resolve()
-        # print("ROCM_HOME: " + rocm_home_root_path)
-        if rocm_home_root_path.exists():
-            os.environ["ROCM_HOME"] = rocm_home_root_path.as_posix()
-            rocm_home_bin_path = rocm_home_root_path / "bin"
-            rocm_home_lib_path = rocm_home_root_path / "lib"
-            rocm_home_bin_path = rocm_home_bin_path.resolve()
-            rocm_home_lib_path = rocm_home_lib_path.resolve()
-            rocm_home_llvm_path = rocm_home_root_path / "lib" / "llvm" / "bin"
-            rocm_home_llvm_path = rocm_home_llvm_path.resolve()
-            if rocm_home_bin_path.exists():
-                if rocm_home_lib_path.exists():
-                    if not is_directory_in_env_variable_path(
-                        "PATH", rocm_home_bin_path.as_posix()
-                    ):
-                        # print("Adding " + rocm_home_bin_path.as_posix() + " to PATH")
-                        os.environ["PATH"] = (
-                            rocm_home_bin_path.as_posix()
-                            + os.pathsep
-                            + os.environ.get("PATH", "")
-                        )
-                    if not is_directory_in_env_variable_path(
-                        "PATH", rocm_home_llvm_path.as_posix()
-                    ):
-                        # print("Adding " + rocm_home_bin_path.as_posix() + " to PATH")
-                        os.environ["PATH"] = (
-                            rocm_home_llvm_path.as_posix()
-                            + os.pathsep
-                            + os.environ.get("PATH", "")
-                        )
-                    if not is_directory_in_env_variable_path(
-                        ENV_VARIABLE_NAME__LIB, rocm_home_lib_path.as_posix()
-                    ):
-                        # print("Adding " + rocm_home_lib_path.as_posix() + " to " + ENV_VARIABLE_NAME__LIB)
-                        os.environ[ENV_VARIABLE_NAME__LIB] = (
-                            rocm_home_lib_path.as_posix()
-                            + os.pathsep
-                            + os.environ.get(ENV_VARIABLE_NAME__LIB, "")
-                        )
-                else:
-                    print(
-                        "Error, could not find directory "
-                        + rocm_home_lib_path.as_posix()
-                    )
-            else:
-                print(
-                    "Error, could not find directory " + rocm_home_bin_path.as_posix()
-                )
-        else:
-            print("Error, ROCM_HOME is not defined and")
-            print("ROCM build is not detected in the RockBuilder build environment:")
-            print("    " + rocm_home_root_path.as_posix())
-            print("")
-            sys.exit(1)
-    # check python
+def verify_build_env__python(self):
+    # check the python used. It needs to be by default an virtual env but
+    # this can be overriden to real python version by setting up ENV variable
+    # ROCK_PYTHON_PATH
     python_home_dir = os.path.dirname(sys.executable)
     if "VIRTUAL_ENV" in os.environ:
         os.environ["ROCK_PYTHON_PATH"] = python_home_dir
@@ -262,7 +176,9 @@ def verify_build_env(args):
                 os.environ["ROCK_PYTHON_PATH"]
             ):
                 print("Error, virtual python environment is not active and")
-                print("PYTHON location is different than ROCK_PYTHON_PATH")
+                print(
+                    "PYTHON location is different than specified by the ROCK_PYTHON_PATH"
+                )
                 print("    PYTHON location: " + python_home_dir)
                 print("    ROCK_PYTHON_PATH: " + os.environ["ROCK_PYTHON_PATH"])
                 print(
@@ -290,6 +206,136 @@ def verify_build_env(args):
                 print("    set ROCK_PYTHON_PATH=" + python_home_dir)
             print("Alternatively activate the virtual python environment")
             sys.exit(1)
+
+
+def verify_build_env(args, rock_builder_home_dir):
+    # we may actually need to have the build environment
+    # even during the checkout as we do the hipify during the checkout process
+    """"
+    if ((args.checkout == True) and\
+        (args.init == False) and\
+        (args.clean == False) and\
+        (args.hipify == False) and\
+        (args.pre_config == False) and\
+        (args.config == False) and\
+        (args.post_config == False) and\
+        (args.build == False) and\
+        (args.install == False) and\
+        (args.post_install == False)):
+        # allow code checkout even before TheRock build has been installed
+        printout_rock_builder_info()
+        return
+    """
+
+    # set the ENV_VARIABLE_NAME__LIB to be either LD_LIBRARY_PATH or LIBPATH depending
+    # whether code is executed on Linux or Windows (it is later used to set env-variables)
+    if is_posix:
+        ENV_VARIABLE_NAME__LIB = "LD_LIBRARY_PATH"
+    else:
+        ENV_VARIABLE_NAME__LIB = "LIBPATH"
+
+    # check that THEROCK_AMDGPU_TARGETS has been specified on Windows build
+    # because the pytorch build on windows can not automatically resolve the
+    # build targets by checking the targets support build into the used rocm_sdk
+    if not is_posix:
+        if not "THEROCK_AMDGPU_TARGETS" in os.environ:
+            print(
+                "Error, THEROCK_AMDGPU_TARGETS must be set on Windows to select the target GPUs"
+            )
+            print("Target GPU must match with the GPU selected on TheRock core build")
+            print("Example for building for AMD Strix Halo and RX 9070:")
+            print("  set THEROCK_AMDGPU_TARGETS=gfx1151;gfx1201")
+            sys.exit(1)
+
+    # check rocm
+    if "ROCM_HOME" in os.environ:
+        rocm_home_root_path = Path(os.environ["ROCM_HOME"])
+    else:
+        rocm_home_root_path = rock_builder_home_dir / "../../build/dist/rocm"
+    rocm_home_root_path = rocm_home_root_path.resolve()
+    if rocm_home_root_path.exists():
+        # set ROCM_HOME if not yet set
+        if not "ROCM_HOME" in os.environ:
+            # print("ROCM_HOME: " + rocm_home_root_path.as_posix())
+            os.environ["ROCM_HOME"] = rocm_home_root_path.as_posix()
+
+        rocm_home_bin_path = rocm_home_root_path / "bin"
+        rocm_home_lib_path = rocm_home_root_path / "lib"
+        rocm_home_bin_path = rocm_home_bin_path.resolve()
+        rocm_home_lib_path = rocm_home_lib_path.resolve()
+        rocm_home_llvm_path = rocm_home_root_path / "lib" / "llvm" / "bin"
+        rocm_home_llvm_path = rocm_home_llvm_path.resolve()
+        if rocm_home_bin_path.exists():
+            if rocm_home_lib_path.exists():
+                if not is_directory_in_env_variable_path(
+                    "PATH", rocm_home_bin_path.as_posix()
+                ):
+                    # print("Adding " + rocm_home_bin_path.as_posix() + " to PATH")
+                    os.environ["PATH"] = (
+                        rocm_home_bin_path.as_posix()
+                        + os.pathsep
+                        + os.environ.get("PATH", "")
+                    )
+                if not is_directory_in_env_variable_path(
+                    "PATH", rocm_home_llvm_path.as_posix()
+                ):
+                    # print("Adding " + rocm_home_llvm_path.as_posix() + " to PATH")
+                    os.environ["PATH"] = (
+                        rocm_home_llvm_path.as_posix()
+                        + os.pathsep
+                        + os.environ.get("PATH", "")
+                    )
+                if not is_directory_in_env_variable_path(
+                    ENV_VARIABLE_NAME__LIB, rocm_home_lib_path.as_posix()
+                ):
+                    # print("Adding " + rocm_home_lib_path.as_posix() + " to " + ENV_VARIABLE_NAME__LIB)
+                    os.environ[ENV_VARIABLE_NAME__LIB] = (
+                        rocm_home_lib_path.as_posix()
+                        + os.pathsep
+                        + os.environ.get(ENV_VARIABLE_NAME__LIB, "")
+                    )
+                # find bitcode and put it to path
+                for folder_path in Path(rocm_home_root_path).glob("**/bitcode"):
+                    folder_path = folder_path.resolve()
+                    os.environ["ROCK_BUILDER_BITCODE_HOME"] = folder_path.as_posix()
+                    break
+                # find clang
+                if is_posix:
+                    clang_exec_name = "clang"
+                else:
+                    clang_exec_name = "clang.exe"
+                for folder_path in Path(rocm_home_root_path).glob(
+                    "**/" + clang_exec_name
+                ):
+                    clang_home = folder_path.parent
+                    # make sure that we found bin/clang and not clang folder
+                    if clang_home.name.lower() == "bin":
+                        clang_home = clang_home.parent
+                        if clang_home.is_dir():
+                            clang_home = clang_home.resolve()
+                            os.environ[
+                                "ROCK_BUILDER_CLANG_HOME"
+                            ] = clang_home.as_posix()
+                            break
+            else:
+                print(
+                    "Error, could not find directory ROCM_SDK/lib: "
+                    + rocm_home_lib_path.as_posix()
+                )
+                sys.exit(1)
+        else:
+            print(
+                "Error, could not find directory ROCM_SDK/bin: "
+                + rocm_home_bin_path.as_posix()
+            )
+            sys.exit(1)
+    else:
+        print("Error, ROCM_HOME is not defined and")
+        print("ROCM build is not detected in the RockBuilder build environment:")
+        print("    " + rocm_home_root_path.as_posix())
+        print("")
+        sys.exit(1)
+
     printout_build_env_info()
 
 
@@ -368,9 +414,17 @@ def do_therock(prj_builder):
     return ret
 
 
-args = get_build_arguments()
+is_posix = not any(platform.win32_ver())
+
+rock_builder_home_dir = get_rocm_builder_root_dir()
+os.environ["ROCK_BUILDER_HOME_DIR"] = rock_builder_home_dir.as_posix()
+os.environ["ROCK_BUILDER_SRC_DIR"] = (rock_builder_home_dir / "src_projects").as_posix()
+os.environ["ROCK_BUILDER_BUILD_DIR"] = (rock_builder_home_dir / "builddir").as_posix()
+
+args = get_build_arguments(rock_builder_home_dir)
 printout_build_arguments(args)
-verify_build_env(args)
+verify_build_env__python(args)
+verify_build_env(args, rock_builder_home_dir)
 
 project_manager = project_builder.RockExternalProjectListManager(
     rock_builder_home_dir, args.output_dir


### PR DESCRIPTION
- Move all the code from not belonging to functions to lower to same location in rockbuilder.py
- Set env variable ROCK_BUILDER_PACKAGE_OUTPUT_DIR for the execution time so that the project config files can use it if needed for saving the artifacts that are produced
- Check python env first before checking the rocm sdk location (helps future rockbuilder_config related changes)
- Refactor some of the code to use python Pathlib instead of string for referring to directories and files
- Allow "version" and "repo_url" in project.cfg files to be optional.  This allows to specify a simple project.cfg file for example just to install default application version with pip install command. Example:
```

--------------test_app.cfg ----
[project_info]
name=test_app

install_cmd = python -m pip install test_app
------------
```