### PR TITLE
[ci] - Removing 9070 test machine

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -42,7 +42,7 @@ amdgpu_family_info_matrix = {
     },
     "gfx120x": {
         "linux": {
-            "test-runs-on": "linux-rx9070-gpu-rocm",
+            "test-runs-on": "",  # removed due to machine issues, label is "linux-rx9070-gpu-rocm"
             "family": "gfx120X-all",
             "pytorch-target": "gfx1201",
         },


### PR DESCRIPTION
For the past 6 runs, 4 / 6 of them failed due to 9070 machines issues. To provide good signal, we will remove these test machines. We will look into machine issues (particularly, wifi slowness and HIP out of memory errors)