### PR TITLE
Ignore spammy warning introduced in recent clang version.

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -63,6 +63,10 @@ set(THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS
   -Wno-documentation-unknown-command
   -Wno-documentation-pedantic
   -Wno-unused-command-line-argument
+
+  # There are real issues here but rocBLAS and rocSPARSE generate 300-400MB of
+  # warning logs with this enabled, practically breaking build tooling.
+  -Wno-explicit-specialization-storage-class
 )
 
 if(WIN32)


### PR DESCRIPTION
Working around recently introduced warnings. See:
* https://github.com/ROCm/TheRock/issues/47
* https://github.com/ROCm/TheRock/pull/911#discussion_r2169480338
* https://github.com/llvm/llvm-project/commit/a1bce0b89e800cb7ab1d3cf3437f8f34d0695468

Example warning:
```
348.2	/__w/TheRock/TheRock/math-libs/BLAS/rocBLAS/library/src/include/utility.hpp:387:13: warning: explicit specialization cannot have a storage class [-Wexplicit-specialization-storage-class]
348.2	  387 | template <> ROCBLAS_CLANG_STATIC constexpr auto rocblas_datatype_from_type<rocblas_double_complex> = rocblas_datatype_f64_c;
348.2	      |             ^~~~~~~~~~~~~~~~~~~~
348.2	/__w/TheRock/TheRock/math-libs/BLAS/rocBLAS/library/include/internal/rocblas-complex-types.h:46:30: note: expanded from macro 'ROCBLAS_CLANG_STATIC'
348.2	   46 | #define ROCBLAS_CLANG_STATIC static
348.2	      |                              ^
348.2	In file included from /__w/TheRock/TheRock/math-libs/BLAS/rocBLAS/library/src/blas3/rocblas_trsm.cpp:23:
348.2	In file included from /__w/TheRock/TheRock/math-libs/BLAS/rocBLAS/library/src/blas3/rocblas_trsm_imp.hpp:24:
348.2	In file included from /__w/TheRock/TheRock/math-libs/BLAS/rocBLAS/library/src/include/handle.hpp:27:
348.2	In file included from /__w/TheRock/TheRock/math-libs/BLAS/rocBLAS/library/src/include/rocblas_ostream.hpp:26:
```

I attempted to remove `static` from some of the implicated macros and templates but then got duplicate symbol _errors_. I'd need to look closer to see what the right fix is, but heavy template use in headers that even get reimplemented in other parts of the broader codebase make such changes tricky.