### PR TITLE
Pin composable_kernel by default

### DIFF
--- a/build_tools/bump_submodules.py
+++ b/build_tools/bump_submodules.py
@@ -33,6 +33,22 @@ def pin_tensile():
     )
 
 
+def pin_ck():
+    requirements_file_path = THEROCK_DIR / "ml-libs" / "MIOpen" / "requirements.txt"
+    with open(requirements_file_path) as requirements_file:
+        requirements = requirements_file.read().splitlines()
+
+    ck_requirement = list(
+        filter(lambda x: "ROCm/composable_kernel" in x, requirements)
+    )[0]
+    ck_commit = ck_requirement.split("@")[-1].split()[0]
+
+    exec(
+        ["git", "checkout", ck_commit],
+        cwd=THEROCK_DIR / "ml-libs" / "composable_kernel",
+    )
+
+
 def run(args):
     date = datetime.today().strftime("%Y%m%d")
 
@@ -54,6 +70,9 @@ def run(args):
 
     if args.pin_tensile:
         pin_tensile()
+
+    if args.pin_ck:
+        pin_ck()
 
     exec(
         ["git", "commit", "-a", "-m", "Bump submodules " + date],
@@ -101,6 +120,12 @@ def main(argv):
         default=True,
         action=argparse.BooleanOptionalAction,
         help="Pin Tensile to version tagged in rocBLAS",
+    )
+    parser.add_argument(
+        "--pin-ck",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Pin composable_kernel to version tagged in MIOpen",
     )
     args = parser.parse_args(argv)
     run(args)

--- a/build_tools/bump_submodules.py
+++ b/build_tools/bump_submodules.py
@@ -38,8 +38,11 @@ def pin_ck():
     with open(requirements_file_path) as requirements_file:
         requirements = requirements_file.read().splitlines()
 
+    # The requirements file pins several dependencies. And entry for CK looks like:
+    # 'ROCm/composable_kernel@778ac24376813d18e63c9f77a2dd51cf87eb4a80 -DCMAKE_BUILD_TYPE=Release'
+    # After filtering, the string is split to isolate the CK commit.
     ck_requirement = list(
-        filter(lambda x: "ROCm/composable_kernel" in x, requirements)
+        filter(lambda x: "rocm/composable_kernel" in x.lower(), requirements)
     )[0]
     ck_commit = ck_requirement.split("@")[-1].split()[0]
 


### PR DESCRIPTION
MIOpen requires a compatible version of composable_kernel whose commit hash is specified in MIOpen's requirements file.