### PR TITLE
Revise workflows to build PyTorch wheels

### DIFF
--- a/.github/workflows/build_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_linux_pytorch_wheels.yml
@@ -18,7 +18,7 @@ on:
         required: true
         type: string
       cloudfront_url:
-        description: CloudFront base URL pointing to Python index
+        description: CloudFront URL pointing to Python index
         required: true
         type: string
       # rocm_version:

--- a/.github/workflows/build_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_linux_pytorch_wheels.yml
@@ -63,7 +63,7 @@ jobs:
       OUTPUT_DIR: ${{ github.workspace }}/output
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
       S3_BUCKET_PY: "therock-${{ inputs.release_type }}-python"
-      ROCM_VERSION: ${{ inputs.rocm_version || '>1.0' }}
+      # ROCM_VERSION: ${{ inputs.rocm_version || '>1.0' }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/build_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_linux_pytorch_wheels.yml
@@ -21,9 +21,9 @@ on:
         description: CloudFront base URL pointing to Python index
         required: true
         type: string
-      rocm_version:
-        description: ROCm version to install
-        type: string
+      # rocm_version:
+      #   description: ROCm version to install
+      #   type: string
   workflow_dispatch:
     inputs:
       amdgpu_family:
@@ -45,9 +45,9 @@ on:
         description: CloudFront base URL pointing to Python index
         type: string
         default: "d25kgig7rdsyks.cloudfront.net"
-      rocm_version:
-        description: ROCm version to install, e.g. ==1.0, >1.0
-        type: string
+      # rocm_version:
+      #   description: ROCm version to install (e.g. "==1.0", ">1.0")
+      #   type: string
 
 permissions:
   id-token: write
@@ -97,11 +97,12 @@ jobs:
           ./external-builds/pytorch/build_prod_wheels.py \
             --pip-cache-dir /tmp/pipcache \
             --index-url "https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/" \
-            --rocm-sdk-version "${{ env.ROCM_VERSION }}" \
             build \
             --install-rocm \
             --clean \
             --output-dir ${{ env.PACKAGE_DIST_DIR }} \
+            # TODO(marbre): Enable ones dependencies in rocm package are fixed \
+            # --rocm-sdk-version "${{ env.ROCM_VERSION }}" \
 
       - name: Configure AWS Credentials
         if: always()

--- a/.github/workflows/build_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_linux_pytorch_wheels.yml
@@ -21,10 +21,6 @@ on:
         description: CloudFront base URL pointing to Python index
         required: true
         type: string
-      cloudfront_subdir:
-        description: CloudFront subdirectory, not including the GPU-family
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       AMDGPU_FAMILIES:
@@ -46,10 +42,6 @@ on:
         description: CloudFront base URL pointing to Python index
         type: string
         default: "d25kgig7rdsyks.cloudfront.net"
-      cloudfront_subdir:
-        description: CloudFront subdirectory, not including the GPU-family
-        type: string
-        default: "v2"
 
 permissions:
   id-token: write
@@ -97,7 +89,7 @@ jobs:
           echo "Building PyTorch wheels for ${{ inputs.AMDGPU_FAMILIES }}"
           ./external-builds/pytorch/build_prod_wheels.py \
             --pip-cache-dir /tmp/pipcache \
-            --index-url "https://${{ inputs.cloudfront_url }}/${{ inputs.cloudfront_subdir }}/${{ inputs.AMDGPU_FAMILIES }}/" \
+            --index-url "https://${{ inputs.cloudfront_url }}/${{ inputs.AMDGPU_FAMILIES }}/" \
             build \
             --install-rocm \
             --clean \

--- a/.github/workflows/build_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_linux_pytorch_wheels.yml
@@ -3,7 +3,7 @@ name: Build Linux PyTorch Wheels
 on:
   workflow_call:
     inputs:
-      AMDGPU_FAMILIES:
+      amdgpu_family:
         required: true
         type: string
       python_version:
@@ -21,9 +21,12 @@ on:
         description: CloudFront base URL pointing to Python index
         required: true
         type: string
+      rocm_version:
+        description: ROCm version to install
+        type: string
   workflow_dispatch:
     inputs:
-      AMDGPU_FAMILIES:
+      amdgpu_family:
         required: true
         type: string
       python_version:
@@ -42,6 +45,9 @@ on:
         description: CloudFront base URL pointing to Python index
         type: string
         default: "d25kgig7rdsyks.cloudfront.net"
+      rocm_version:
+        description: ROCm version to install, e.g. ==1.0, >1.0
+        type: string
 
 permissions:
   id-token: write
@@ -49,7 +55,7 @@ permissions:
 
 jobs:
   build_pytorch_wheels:
-    name: Build Linux PyTorch Wheels | ${{ inputs.AMDGPU_FAMILIES }} | Python ${{ inputs.python_version }}
+    name: Build Linux PyTorch Wheels | ${{ inputs.amdgpu_family }} | Python ${{ inputs.python_version }}
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:044b113562629f4bd2ec5d2e64b32eee11562d48fb1a75d7493daec9dd8d8292
@@ -57,6 +63,7 @@ jobs:
       OUTPUT_DIR: ${{ github.workspace }}/output
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
       S3_BUCKET_PY: "therock-${{ inputs.release_type }}-python"
+      ROCM_VERSION: ${{ inputs.rocm_version || '>1.0' }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -86,10 +93,11 @@ jobs:
 
       - name: Build PyTorch Wheels
         run: |
-          echo "Building PyTorch wheels for ${{ inputs.AMDGPU_FAMILIES }}"
+          echo "Building PyTorch wheels for ${{ inputs.amdgpu_family }}"
           ./external-builds/pytorch/build_prod_wheels.py \
             --pip-cache-dir /tmp/pipcache \
-            --index-url "https://${{ inputs.cloudfront_url }}/${{ inputs.AMDGPU_FAMILIES }}/" \
+            --index-url "https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/" \
+            --rocm-sdk-version "${{ env.ROCM_VERSION }}" \
             build \
             --install-rocm \
             --clean \
@@ -109,11 +117,11 @@ jobs:
       - name: Upload wheels to S3
         if: ${{ github.repository_owner == 'ROCm' }}
         run: |
-          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.AMDGPU_FAMILIES }}/ \
+          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ \
             --recursive --exclude "*" --include "*.whl"
 
       - name: (Re-)Generate Python package release index
         if: ${{ github.repository_owner == 'ROCm' }}
         run: |
           pip install boto3 packaging
-          python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_subdir }}/${{ inputs.AMDGPU_FAMILIES  }}
+          python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}

--- a/.github/workflows/build_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_linux_pytorch_wheels.yml
@@ -9,13 +9,20 @@ on:
       python_version:
         required: true
         type: string
-      s3_bucket:
+      release_type:
+        description: The type of release to build ("nightly", or "dev")
         required: true
         type: string
       s3_subdir:
+        description: S3 subdirectory, not including the GPU-family
         required: true
         type: string
-      s3_cloudfront:
+      cloudfront_url:
+        description: CloudFront base URL pointing to Python index
+        required: true
+        type: string
+      cloudfront_subdir:
+        description: CloudFront subdirectory, not including the GPU-family
         required: true
         type: string
   workflow_dispatch:
@@ -26,15 +33,23 @@ on:
       python_version:
         required: true
         type: string
-      s3_bucket:
-        required: true
+        default:
+      release_type:
+        description: The type of release to build ("nightly", or "dev")
         type: string
+        default: "dev"
       s3_subdir:
-        required: true
+        description: S3 subdirectory, not including the GPU-family
         type: string
-      s3_cloudfront:
-        required: true
+        default: "v2"
+      cloudfront_url:
+        description: CloudFront base URL pointing to Python index
         type: string
+        default: "d25kgig7rdsyks.cloudfront.net"
+      cloudfront_subdir:
+        description: CloudFront subdirectory, not including the GPU-family
+        type: string
+        default: "v2"
 
 permissions:
   id-token: write
@@ -49,7 +64,7 @@ jobs:
     env:
       OUTPUT_DIR: ${{ github.workspace }}/output
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
-      S3_BUCKET_PY: ${{ inputs.s3_bucket }}
+      S3_BUCKET_PY: "therock-${{ inputs.release_type }}-python"
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -82,7 +97,7 @@ jobs:
           echo "Building PyTorch wheels for ${{ inputs.AMDGPU_FAMILIES }}"
           ./external-builds/pytorch/build_prod_wheels.py \
             --pip-cache-dir /tmp/pipcache \
-            --index-url "https://${{ inputs.s3_cloudfront }}/${{ inputs.s3_subdir }}/${{ inputs.AMDGPU_FAMILIES }}/" \
+            --index-url "https://${{ inputs.cloudfront_url }}/${{ inputs.cloudfront_subdir }}/${{ inputs.AMDGPU_FAMILIES }}/" \
             build \
             --install-rocm \
             --clean \
@@ -93,7 +108,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-nightly-releases
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
 
       - name: Sanity Check Wheel
         run: |

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -15,9 +15,9 @@ on:
         description: CloudFront base URL pointing to Python index
         type: string
         default: "d25kgig7rdsyks.cloudfront.net/v2"
-      rocm_version:
-        description: ROCm version to install
-        type: string
+      # rocm_version:
+      #   description: ROCm version to install (e.g. "==1.0", ">1.0")
+      #   type: string
   schedule:
     - cron: "0 2 * * *"  # Nightly at 2 AM UTC
 
@@ -43,4 +43,4 @@ jobs:
       release_type: ${{ inputs.release_type || 'nightly' }}
       s3_subdir: ${{ inputs.s3_subdir || 'v2' }}
       cloudfront_url: ${{ inputs.cloudfront_url  || 'd2awnip2yjpvqn.cloudfront.net/v2' }}
-      rocm_version: ${{ inputs.rocm_version }}
+      # rocm_version: ${{ inputs.rocm_version }}

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -12,7 +12,7 @@ on:
         type: string
         default: "v2"
       cloudfront_url:
-        description: CloudFront base URL pointing to Python index
+        description: CloudFront URL pointing to Python index
         type: string
         default: "d25kgig7rdsyks.cloudfront.net/v2"
       # rocm_version:

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -14,11 +14,7 @@ on:
       cloudfront_url:
         description: CloudFront base URL pointing to Python index
         type: string
-        default: "d25kgig7rdsyks.cloudfront.net"
-      cloudfront_subdir:
-        description: CloudFront subdirectory, not including the GPU-family
-        type: string
-        default: "v2"
+        default: "d25kgig7rdsyks.cloudfront.net/v2"
   schedule:
     - cron: "0 2 * * *"  # Nightly at 2 AM UTC
 
@@ -43,5 +39,4 @@ jobs:
       python_version: ${{ matrix.python_version }}
       release_type: ${{ inputs.release_type || 'nightly' }}
       s3_subdir: ${{ inputs.s3_subdir || 'v2' }}
-      cloudfront_url: ${{ inputs.cloudfront_url  || 'd2awnip2yjpvqn.cloudfront.net' }}
-      cloudfront_subdir: ${{ inputs.cloudfront_subdir || 'v2' }}
+      cloudfront_url: ${{ inputs.cloudfront_url  || 'd2awnip2yjpvqn.cloudfront.net/v2' }}

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -15,6 +15,9 @@ on:
         description: CloudFront base URL pointing to Python index
         type: string
         default: "d25kgig7rdsyks.cloudfront.net/v2"
+      rocm_version:
+        description: ROCm version to install
+        type: string
   schedule:
     - cron: "0 2 * * *"  # Nightly at 2 AM UTC
 
@@ -35,8 +38,9 @@ jobs:
 
     uses: ./.github/workflows/build_linux_pytorch_wheels.yml
     with:
-      AMDGPU_FAMILIES: ${{ matrix.config.AMDGPU_FAMILIES }}
+      amdgpu_family: ${{ matrix.config.AMDGPU_FAMILIES }}
       python_version: ${{ matrix.python_version }}
       release_type: ${{ inputs.release_type || 'nightly' }}
       s3_subdir: ${{ inputs.s3_subdir || 'v2' }}
       cloudfront_url: ${{ inputs.cloudfront_url  || 'd2awnip2yjpvqn.cloudfront.net/v2' }}
+      rocm_version: ${{ inputs.rocm_version }}

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -3,18 +3,22 @@ name: Release Linux PyTorch Wheels
 on:
   workflow_dispatch:
     inputs:
-      s3_bucket:
-        description: "S3 bucket to upload the wheels"
+      release_type:
+        description: The type of release to build ("nightly", or "dev")
         type: string
-        default: "therock-nightly-python"
+        default: "dev"
       s3_subdir:
-        description: "Subdirectory used in the bucket and CloudFront URL"
+        description: S3 subdirectory, not including the GPU-family
         type: string
         default: "v2"
-      s3_cloudfront:
-        description: "CloudFront URL pointing to the bucket"
+      cloudfront_url:
+        description: CloudFront base URL pointing to Python index
         type: string
-        default: "d2awnip2yjpvqn.cloudfront.net"
+        default: "d25kgig7rdsyks.cloudfront.net"
+      cloudfront_subdir:
+        description: CloudFront subdirectory, not including the GPU-family
+        type: string
+        default: "v2"
   schedule:
     - cron: "0 2 * * *"  # Nightly at 2 AM UTC
 
@@ -37,6 +41,7 @@ jobs:
     with:
       AMDGPU_FAMILIES: ${{ matrix.config.AMDGPU_FAMILIES }}
       python_version: ${{ matrix.python_version }}
-      s3_bucket: ${{ inputs.s3_bucket || 'therock-nightly-python' }}
+      release_type: ${{ inputs.release_type || 'nightly' }}
       s3_subdir: ${{ inputs.s3_subdir || 'v2' }}
-      s3_cloudfront: ${{ inputs.s3_cloudfront  || 'd2awnip2yjpvqn.cloudfront.net' }}
+      cloudfront_url: ${{ inputs.cloudfront_url  || 'd2awnip2yjpvqn.cloudfront.net' }}
+      cloudfront_subdir: ${{ inputs.cloudfront_subdir || 'v2' }}


### PR DESCRIPTION
First revision to of the workflows used to build PyTorch packages. This is among other required to push builds to the dev bucket. Furthermore:

* Allows to point to a CloudFront URL different from the bucket. This enables consuming nightly ROCm packages but pushing torch wheels to a dev bucket.
* Sets defaults for `workflow_dispatch` to consume and build dev packages.