### PR TITLE
[ci][windows] Pin ninja version in Windows workflows.

### DIFF
--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -58,7 +58,9 @@ jobs:
       - name: Install requirements
         run: |
           choco install --no-progress -y ccache
-          choco install --no-progress -y ninja
+          # ninja pinned due to a bug in the 1.13.0 release:
+          # https://github.com/ninja-build/ninja/issues/2616
+          choco install --no-progress -y ninja --version 1.12.1
           choco install --no-progress -y strawberryperl
           echo "$PATH;C:\Strawberry\c\bin" >> $GITHUB_PATH
           choco install --no-progress -y awscli

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -122,7 +122,9 @@ jobs:
       - name: Install requirements
         run: |
           choco install --no-progress -y ccache
-          choco install --no-progress -y ninja
+          # ninja pinned due to a bug in the 1.13.0 release:
+          # https://github.com/ninja-build/ninja/issues/2616
+          choco install --no-progress -y ninja --version 1.12.1
           choco install --no-progress -y strawberryperl
           echo "$PATH;C:\Strawberry\c\bin" >> $GITHUB_PATH
           choco install --no-progress -y awscli


### PR DESCRIPTION
There are issues in the wild with the latest release on Windows: https://github.com/ninja-build/ninja/issues/2616. We had compilation errors in another project building LLVM: https://github.com/iree-org/iree/pull/21208. Thankfully we've dodged those issues here, but I'd feel safer if we pinned to a version that did not have known issues on Windows.