### PR TITLE
[windows][python] Publish rocm wheels in release_windows_packages.yml.

### DIFF
--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -10,6 +10,10 @@ on:
         default: "dev"
       package_suffix:
         type: string
+      s3_subdir:
+        description: "Subdirectory to push the Python packages"
+        type: string
+        default: "v2"
   # Trigger manually (typically to test the workflow or manually build a release [candidate])
   workflow_dispatch:
     inputs:
@@ -19,6 +23,10 @@ on:
         default: "rc"
       package_suffix:
         type: string
+      s3_subdir:
+        description: "Subdirectory to push the Python packages"
+        type: string
+        default: "v2"
       families:
         description: "A comma separated list of AMD GPU families, e.g. `gfx94X,gfx103x`, or empty for the default list"
         type: string
@@ -96,15 +104,16 @@ jobs:
       matrix:
         target_bundle: ${{ fromJSON(needs.setup_metadata.outputs.package_targets) }}
     env:
+      TEATIME_LABEL_GH_GROUP: 1
       BUILD_DIR: B:\build
       CACHE_DIR: "${{github.workspace}}/.cache"
       CCACHE_DIR: "${{github.workspace}}/.cache/ccache"
       CCACHE_MAXSIZE: "4000M"
-      TEATIME_LABEL_GH_GROUP: 1
-      FILE_NAME: "therock-dist-windows-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
       DIST_ARCHIVE: "B:/build/artifacts/therock-dist-windows-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
       RELEASE_TYPE: "${{ needs.setup_metadata.outputs.release_type }}"
-      S3_TARBALL: "therock-${{ needs.setup_metadata.outputs.release_type }}-tarball"
+      S3_BUCKET_TAR: "therock-${{ needs.setup_metadata.outputs.release_type }}-tarball"
+      S3_BUCKET_PY: "therock-${{ needs.setup_metadata.outputs.release_type }}-python"
+      S3_SUBDIR: ${{ inputs.s3_subdir || 'v2' }}
 
     steps:
       - name: "Checking out repository"
@@ -196,13 +205,21 @@ jobs:
       - name: Build therock-dist
         run: cmake --build "${{ env.BUILD_DIR }}" --target therock-dist
 
+      - name: Build therock-archives
+        run: cmake --build "${{ env.BUILD_DIR }}" --target therock-archives
+
       - name: Compress dist folder
         run: |
           cd ${{ env.BUILD_DIR }}/dist/rocm
           echo "Compressing ${{ env.DIST_ARCHIVE }}"
           tar cfz "${{ env.DIST_ARCHIVE }}" --force-local .
 
-      # TODO(#703): Build and upload Python wheels
+      - name: Build Python Packages
+        run: |
+          python ./build_tools/build_python_packages.py \
+            --artifact-dir=${{ env.BUILD_DIR }}/artifacts \
+            --dest-dir=${{ env.BUILD_DIR }}/packages \
+            --version=${{ needs.setup_metadata.outputs.version }}
 
       - name: Build report
         if: ${{ !cancelled() }}
@@ -228,7 +245,22 @@ jobs:
       - name: Upload Releases to S3
         if: ${{ github.repository_owner == 'ROCm' }}
         run: |
-          aws s3 cp ${{ env.DIST_ARCHIVE }} s3://${{ env.S3_TARBALL }}
+          aws s3 cp ${{ env.DIST_ARCHIVE }} s3://${{ env.S3_BUCKET_TAR }}
+          aws s3 cp ${{ env.BUILD_DIR }}/packages/dist/ s3://${{ env.S3_BUCKET_PY }}/${{ env.S3_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}/ \
+          --recursive --no-follow-symlinks \
+          --exclude "*" \
+          --include "*.whl" \
+          --include "*.tar.gz"
+
+      # TODO(marbre): guard against race conditions where multiple workflows update the index at the same time?
+      #    Moving the index computation server-side could help
+      - name: (Re-)Generate Python package release index
+        if: ${{ github.repository_owner == 'ROCm' }}
+        run: |
+          pip install boto3 packaging
+          python ./build_tools/third_party/s3_management/manage.py ${{ env.S3_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}
+
+      # TODO(scotttodd): trigger tests
 
       - name: Save cache
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -3,10 +3,10 @@
 from typing import Callable, Sequence
 
 import importlib.util
-import magic
 import re
 import os
 from pathlib import Path
+import platform
 import shlex
 import subprocess
 import shutil
@@ -16,6 +16,12 @@ import tarfile
 from .artifacts import ArtifactCatalog, ArtifactName
 from .exe_stub_gen import generate_exe_link_stub
 
+is_windows = platform.system() == "Windows"
+
+if not is_windows:
+    # Used on Linux to check file types. Buggy/broken on Windows, but file
+    # types are generally known from file extensions there.
+    import magic
 
 BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
 PYTHON_PACKAGING_DIR = BUILD_TOOLS_DIR / "packaging" / "python" / "templates"
@@ -480,6 +486,16 @@ def get_file_type(dir_entry: os.DirEntry[str] | Path) -> str:
     elif path.endswith(".hsaco") or path.endswith(".co"):
         # These read as shared libraries.
         return "hsaco"
+    elif path.endswith(".lib"):
+        return "ar"
+    elif path.endswith(".exe"):
+        return "exe"
+
+    if is_windows:
+        # Don't try to use 'magic' on Windows, since it is buggy/broken.
+        # Hopefully the file type was covered by an extension check above.
+        return "other"
+
     desc = magic.from_file(path)
     if MAGIC_EXECUTABLE_MATCH.search(desc):
         return "exe"

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -529,9 +529,10 @@ def build_packages(dest_dir: Path, *, wheel_compression: bool = True):
         # and opinions about how to pass arguments to the backends. So we skip
         # the frontends for such a closed case as this.
         build_args = [sys.executable, "-m", "build", "-v", "--outdir", str(dist_dir)]
+        setuppy_path = child_path / "setup.py"
         build_args = [
             sys.executable,
-            str(child_path / "setup.py"),
+            str(setuppy_path.resolve()),
         ]
         if child_name in ["rocm"]:
             build_args.append("sdist")
@@ -544,7 +545,7 @@ def build_packages(dest_dir: Path, *, wheel_compression: bool = True):
             [
                 "-v",
                 "--dist-dir",
-                str(dist_dir),
+                str(dist_dir.resolve()),
             ]
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ build>=1.2.2
 meson>=1.7.0
 python-magic>=0.4.27; platform_system != "Windows"
 PyYAML==6.0.2
-setuptools==80.9.0
+setuptools>=80.9.0
 tomli==2.2.1; python_version <= '3.10'
 
 # hipBLASLt deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 CppHeaderParser>=2.7.4
 build>=1.2.2
 meson>=1.7.0
-python-magic>=0.4.27
+python-magic>=0.4.27; platform_system != "Windows"
 PyYAML==6.0.2
+setuptools==80.9.0
 tomli==2.2.1; python_version <= '3.10'
 
 # hipBLASLt deps


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/827. This builds ROCm SDK Python wheels on Windows and publishes them to our release S3 buckets so the instructions at https://github.com/ROCm/TheRock/blob/main/RELEASES.md#installing-releases-using-pip should work on Windows after the scheduled nightly jobs run.

> [!NOTE]
> Tested here: https://github.com/ROCm/TheRock/actions/runs/15962567326 . I've also tested with artifacts downloaded instead of built from source over on my fork at https://github.com/ScottTodd/TheRock/actions/runs/15934220838.
>
> Tested installing and using a bit here: https://gist.github.com/ScottTodd/4f2532324e02613ed0366f764f77df56

I've tried to keep this workflow similar to [`.github/workflows/release_portable_linux_packages.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/release_portable_linux_packages.yml) so future cleanup can happen uniformly across both workflow files.

Things I'm not certain about / areas for future work:

* Are all the wheel files properly named so Linux and Windows can co-exist in the buckets?
  * **Linux and Windows both upload the same sdist wheels that will overwrite each other. This is probably safe but could be reworked**
* Do we want to build native packages in one workflow then have a second workflow build python packages? That is how I tested in my fork, using `build_tools/fetch_artifacts.py`
* What test workflows do we want to trigger after these builds?
* How do we get these built / sanity checked / tested on pre- and post-submit in addition to on nightly scheduled runs?
* PyTorch wheel building on Windows is next. I've tested locally with wheels and some features in these wheels may not work fully yet. Might need to add some known issues to https://github.com/ROCm/TheRock/issues/808 or warnings about the Windows wheels being newly added and unstable.