### PR TITLE
Rename composable-kernel artifact name to fix parsing.

### DIFF
--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -38,7 +38,7 @@ if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
   therock_cmake_subproject_activate(composable_kernel)
 
   therock_provide_artifact(composable_kernel
-    DESCRIPTOR artifact-composable_kernel.toml
+    DESCRIPTOR artifact-composable-kernel.toml
     COMPONENTS
       dbg
       dev

--- a/ml-libs/artifact-composable-kernel.toml
+++ b/ml-libs/artifact-composable-kernel.toml
@@ -1,4 +1,4 @@
-# composable_kernel
+# composable-kernel
 [components.dbg."ml-libs/composable_kernel/stage"]
 [components.dev."ml-libs/composable_kernel/stage"]
 [components.doc."ml-libs/composable_kernel/stage"]


### PR DESCRIPTION
Tentative fix for https://github.com/ROCm/TheRock/issues/935 (which will also warrant more defensive coding in the CMake and Python scripts along with tests).