### PR TITLE
Add new src_dir parameter to rockbuilder

### DIFF
--- a/experimental/rockbuilder/README.md
+++ b/experimental/rockbuilder/README.md
@@ -138,6 +138,24 @@ python rockbuilder.py --project pytorch_audio --output-dir test
 python rockbuilder.py --checkout --project pytorch_audio
 ```
 
+Source code would be checked out to default location:
+
+```bash
+src_projects/pytorch_audio
+```
+
+## Checkout pytorch_audio sources to custom directory
+
+```bash
+python rockbuilder.py --checkout --project pytorch_audio --src-dir src_prj/py_audio
+```
+
+Source code would be checked out to custom location:
+
+```bash
+src_prj/py_audio
+```
+
 ## Checkout all projects (without build and install)
 
 ```bash

--- a/experimental/rockbuilder/README.md
+++ b/experimental/rockbuilder/README.md
@@ -138,10 +138,11 @@ python rockbuilder.py --project pytorch_audio --output-dir test
 python rockbuilder.py --checkout --project pytorch_audio
 ```
 
-Source code would be checked out to default location:
+By default this checks out source to `src_projects/`:
 
 ```bash
-src_projects/pytorch_audio
+$ ls src_projects/
+pytorch_audio/
 ```
 
 ## Checkout pytorch_audio sources to custom directory
@@ -150,10 +151,11 @@ src_projects/pytorch_audio
 python rockbuilder.py --checkout --project pytorch_audio --src-dir src_prj/py_audio
 ```
 
-Source code would be checked out to custom location:
+Source code would be checked out to directory `src_prj/py_audio`:
 
 ```bash
-src_prj/py_audio
+$ ls src_prj/
+py_audio/
 ```
 
 ## Checkout all projects (without build and install)
@@ -161,6 +163,16 @@ src_prj/py_audio
 ```bash
 python rockbuilder.py --checkout
 ```
+
+Source code would be checked out to directory `src_projects`
+
+## Checkout all projects to custom directory
+
+```bash
+python rockbuilder.py --checkout --src-base-dir src_prj
+```
+
+Source code for each project would be checked out under directory `src_prj`
 
 ## Checkout only the pytorch_audio sources
 

--- a/experimental/rockbuilder/lib_python/project_builder.py
+++ b/experimental/rockbuilder/lib_python/project_builder.py
@@ -22,7 +22,13 @@ class RockProjectBuilder(configparser.ConfigParser):
             ret = None
         return ret
 
-    def __init__(self, rock_builder_root_dir, project_name, package_output_dir):
+    def __init__(
+        self,
+        rock_builder_root_dir,
+        project_src_dir: Path,
+        project_name,
+        package_output_dir,
+    ):
         super(RockProjectBuilder, self).__init__(allow_no_value=True)
 
         self.is_posix = not any(platform.win32_ver())
@@ -100,9 +106,7 @@ class RockProjectBuilder(configparser.ConfigParser):
         self.post_install_cmd = self._get_project_info_config_value("post_install_cmd")
 
         self.project_root_dir_path = Path(rock_builder_root_dir)
-        self.project_src_dir_path = (
-            Path(rock_builder_root_dir) / "src_projects" / self.project_name
-        )
+        self.project_src_dir_path = project_src_dir
         self.project_build_dir_path = (
             Path(rock_builder_root_dir) / "builddir" / self.project_name
         )
@@ -236,7 +240,7 @@ class RockProjectBuilder(configparser.ConfigParser):
 
 
 class RockExternalProjectListManager(configparser.ConfigParser):
-    def __init__(self, rock_builder_root_dir, package_output_dir):
+    def __init__(self, rock_builder_root_dir: Path, package_output_dir: Path):
         # default application list to builds
         self.cfg_file_path = Path(rock_builder_root_dir) / "projects" / "core_apps.pcfg"
         self.rock_builder_root_dir = rock_builder_root_dir
@@ -250,11 +254,14 @@ class RockExternalProjectListManager(configparser.ConfigParser):
         # convert to list of project string names
         return list(filter(None, (x.strip() for x in value.splitlines())))
 
-    def get_rock_project_builder(self, project_name):
+    def get_rock_project_builder(self, project_src_dir: Path, project_name):
         ret = None
         try:
             ret = RockProjectBuilder(
-                self.rock_builder_root_dir, project_name, self.package_output_dir
+                self.rock_builder_root_dir,
+                project_src_dir,
+                project_name,
+                self.package_output_dir,
             )
         except ValueError as e:
             print(str(e))

--- a/experimental/rockbuilder/lib_python/repo_management.py
+++ b/experimental/rockbuilder/lib_python/repo_management.py
@@ -22,13 +22,13 @@ class RockProjectRepo:
         self,
         wheel_install_dir,
         project_name,
-        project_root_dir,
-        project_src_dir,
-        project_build_dir,
-        project_exec_dir,
+        project_root_dir: Path,
+        project_src_dir: Path,
+        project_build_dir: Path,
+        project_exec_dir: Path,
         project_repo_url,
         project_version_hashtag,
-        project_patch_dir_root,
+        project_patch_dir_root: Path,
     ):
         self.wheel_install_dir = wheel_install_dir
         self.project_name = project_name

--- a/experimental/rockbuilder/rockbuilder.py
+++ b/experimental/rockbuilder/rockbuilder.py
@@ -37,7 +37,7 @@ def printout_build_env_info():
     time.sleep(1)
 
 
-def get_build_arguments(rock_builder_home_dir, default_src_dir: Path):
+def get_build_arguments(rock_builder_home_dir, default_src_base_dir: Path):
     # Create an ArgumentParser object
     parser = argparse.ArgumentParser(description="ROCK Project Builders")
 
@@ -102,8 +102,14 @@ def get_build_arguments(rock_builder_home_dir, default_src_dir: Path):
     parser.add_argument(
         "--src-dir",
         type=Path,
-        help="Directory where to checkout project source code",
-        default=default_src_dir,
+        help="Directory where to checkout single project source code. Can only be used with the --project parameter.",
+        default=None,
+    )
+    parser.add_argument(
+        "--src-base-dir",
+        type=Path,
+        help="Base directory where each projects source code is checked out. Default is src_projects.",
+        default=default_src_base_dir,
     )
     parser.add_argument(
         "--output-dir",
@@ -148,7 +154,16 @@ def get_build_arguments(rock_builder_home_dir, default_src_dir: Path):
         args.hipify = True
 
     # add output dir to environment variables
-    os.environ["ROCK_BUILDER_SRC_DIR"] = args.src_dir.as_posix()
+    if args.project and args.src_dir:
+        # single project case with optional src_dir specified
+        parent_dir = args.src_dir.parent
+        if parent_dir == args.src_dir:
+            print("Error, --src-dir parameter is not allowed to be a root-directory")
+            sys.exit(1)
+        os.environ["ROCK_BUILDER_SRC_DIR"] = parent_dir.as_posix()
+    else:
+        # directory where each projects source code is checked out
+        os.environ["ROCK_BUILDER_SRC_DIR"] = args.src_base_dir.as_posix()
     os.environ["ROCK_BUILDER_PACKAGE_OUTPUT_DIR"] = args.output_dir.as_posix()
 
     return args
@@ -427,12 +442,12 @@ def do_therock(prj_builder):
 is_posix = not any(platform.win32_ver())
 
 rock_builder_home_dir = get_rocm_builder_root_dir()
-default_src_dir = rock_builder_home_dir / "src_projects"
+default_src_base_dir = rock_builder_home_dir / "src_projects"
 
 os.environ["ROCK_BUILDER_HOME_DIR"] = rock_builder_home_dir.as_posix()
 os.environ["ROCK_BUILDER_BUILD_DIR"] = (rock_builder_home_dir / "builddir").as_posix()
 
-args = get_build_arguments(rock_builder_home_dir, default_src_dir)
+args = get_build_arguments(rock_builder_home_dir, default_src_base_dir)
 printout_build_arguments(args)
 verify_build_env__python(args)
 verify_build_env(args, rock_builder_home_dir)
@@ -453,28 +468,33 @@ for ii, prj_item in enumerate(project_list):
 time.sleep(1)
 
 if args.project == "all":
+    if args.src_dir:
+        print(
+            '\nError, "--src-dir" parameter requires also to specify the project with the "--project"-parameter'
+        )
+        print('Alternatively you could use the "--src-base-dir" parameter.')
+        print("")
+        sys.exit(1)
     for ii, prj_item in enumerate(project_list):
         print(f"[{ii}]: {prj_item}")
-        # when issuing a command for all projects, we assume that the src_dir
-        # is the base source directory. In this case we add the project name to source directory path
+        # when issuing a command for all projects, we assume that the src_base_dir
+        # is the base source directory under each project specific directory is checked out.
         prj_builder = project_manager.get_rock_project_builder(
-            args.src_dir / project_list[ii], project_list[ii]
+            args.src_base_dir / project_list[ii], project_list[ii]
         )
         if prj_builder is None:
             sys.exit(1)
         else:
             do_therock(prj_builder)
 else:
-    # when issuing a command for a single projects and the src_dir paremeter points to default directory
-    # then the parameter has propably not been specified and we we will add the project name to default src dir path.
     # If the --src-dir parameter is specified for a single project, we assume that path is full
-    if args.src_dir == default_src_dir:
+    if args.src_dir:
         prj_builder = project_manager.get_rock_project_builder(
-            args.src_dir / args.project, args.project
+            args.src_dir, args.project
         )
     else:
         prj_builder = project_manager.get_rock_project_builder(
-            args.src_dir, args.project
+            args.src_base_dir / args.project, args.project
         )
     if prj_builder is None:
         print("Error, failed to get the project builder")


### PR DESCRIPTION
Add new "--src-dir" parameter to rockbuilder to specify the location where the project source
code is checked out. This may be needed in WIndows pytorch builds to ensure that the paths are short because otherwise the pytorch build commands can easily
exceed the 8191 characters maximum length that can be used on Windows command prompt.

1) If --src-dir parameter is used to checkout multiple source files, the parameter is used to specify the base-directory under each projects source code is checked out.

Example: ./rockbuilder.py --checkout --src-dir src_prj

In this case there would be following type of source directories: src_prj/pytorch and src_prj/pytorch_vision

2) If --src-dir parameter is instead used while checking out source code only for a single project, it is assumed that the parameter defines the full project path. 

Example: ./rockbuilder.py --checkout --project pytorch_audio --src-prj src_prj/py_a

In this case there pytorch audio source code would be checked out to directory src_prj/py2.