### PR TITLE
Add option to override the default project version with a --<project_name>-version parameter in rockbuilder

### DIFF
--- a/experimental/rockbuilder/README.md
+++ b/experimental/rockbuilder/README.md
@@ -122,6 +122,22 @@ python torch_audio_hello_world.py
 
 Wheels that have been build can be found from the packages/wheels directory.
 
+## Checkout all projects (without build and install)
+
+```bash
+python rockbuilder.py --checkout
+```
+
+Source code would be checked out to directory `src_projects`
+
+## Checkout all projects to custom directory
+
+```bash
+python rockbuilder.py --checkout --src-base-dir src_prj
+```
+
+Source code for each project would be checked out under the directory `src_prj`
+
 ## Checkout and build only pytorch_audio
 
 In this example we build and install only the pytorch audio and
@@ -132,13 +148,7 @@ Note that pytorch audio requires that pytorch has been built and installed first
 python rockbuilder.py --project pytorch_audio --output-dir test
 ```
 
-## Checkout only the pytorch_audio sources
-
-```bash
-python rockbuilder.py --checkout --project pytorch_audio
-```
-
-By default this checks out source to `src_projects/`:
+By default this checks out pytorch audio source to directory `src_projects/pytorch_audio`:
 
 ```bash
 $ ls src_projects/
@@ -158,26 +168,12 @@ $ ls src_prj/
 py_audio/
 ```
 
-## Checkout all projects (without build and install)
+## Checkout custom pytorch_audio version
+
+This would checkout the v2.6.0 version instead of the version specified in the pytorch_audio.cfg file
 
 ```bash
-python rockbuilder.py --checkout
-```
-
-Source code would be checked out to directory `src_projects`
-
-## Checkout all projects to custom directory
-
-```bash
-python rockbuilder.py --checkout --src-base-dir src_prj
-```
-
-Source code for each project would be checked out under directory `src_prj`
-
-## Checkout only the pytorch_audio sources
-
-```bash
-python rockbuilder.py --checkout --project pytorch_audio
+python rockbuilder.py --checkout --project pytorch_audio --pytorch_audio-version=v2.6.0
 ```
 
 ## Build only pytorch audio

--- a/experimental/rockbuilder/rockbuilder.py
+++ b/experimental/rockbuilder/rockbuilder.py
@@ -37,7 +37,9 @@ def printout_build_env_info():
     time.sleep(1)
 
 
-def get_build_arguments(rock_builder_home_dir, default_src_base_dir: Path):
+def get_build_arguments(
+    rock_builder_home_dir, default_src_base_dir: Path, project_list
+):
     # Create an ArgumentParser object
     parser = argparse.ArgumentParser(description="ROCK Project Builders")
 
@@ -117,6 +119,12 @@ def get_build_arguments(rock_builder_home_dir, default_src_base_dir: Path):
         help="Directory to copy built wheels to",
         default=rock_builder_home_dir / "packages" / "wheels",
     )
+    for ii, prj_item in enumerate(project_list):
+        parser.add_argument(
+            "--" + prj_item + "-version",
+            help=prj_item + " version used for the oprations",
+            default=None,
+        )
 
     # Parse the arguments
     args = parser.parse_args()
@@ -447,19 +455,19 @@ default_src_base_dir = rock_builder_home_dir / "src_projects"
 os.environ["ROCK_BUILDER_HOME_DIR"] = rock_builder_home_dir.as_posix()
 os.environ["ROCK_BUILDER_BUILD_DIR"] = (rock_builder_home_dir / "builddir").as_posix()
 
-args = get_build_arguments(rock_builder_home_dir, default_src_base_dir)
-printout_build_arguments(args)
-verify_build_env__python(args)
-verify_build_env(args, rock_builder_home_dir)
-
-project_manager = project_builder.RockExternalProjectListManager(
-    rock_builder_home_dir, args.output_dir
-)
+project_manager = project_builder.RockExternalProjectListManager(rock_builder_home_dir)
 # allow_no_value param says that no value keys are ok
 sections = project_manager.sections()
 # print(sections)
 project_list = project_manager.get_external_project_list()
 # print(project_list)
+
+args = get_build_arguments(rock_builder_home_dir, default_src_base_dir, project_list)
+# store the arguments to dictionary to make it easier to get "project_name"_version parameters
+args_dict = args.__dict__
+printout_build_arguments(args)
+verify_build_env__python(args)
+verify_build_env(args, rock_builder_home_dir)
 
 for ii, prj_item in enumerate(project_list):
     print(f"    Project [{ii}]: {prj_item}")
@@ -477,10 +485,14 @@ if args.project == "all":
         sys.exit(1)
     for ii, prj_item in enumerate(project_list):
         print(f"[{ii}]: {prj_item}")
+        version_override = args_dict[project_list[ii] + "_version"]
         # when issuing a command for all projects, we assume that the src_base_dir
         # is the base source directory under each project specific directory is checked out.
         prj_builder = project_manager.get_rock_project_builder(
-            args.src_base_dir / project_list[ii], project_list[ii]
+            args.src_base_dir / project_list[ii],
+            project_list[ii],
+            args.output_dir,
+            version_override,
         )
         if prj_builder is None:
             sys.exit(1)
@@ -488,13 +500,17 @@ if args.project == "all":
             do_therock(prj_builder)
 else:
     # If the --src-dir parameter is specified for a single project, we assume that path is full
+    version_override = args_dict[args.project + "_version"]
     if args.src_dir:
         prj_builder = project_manager.get_rock_project_builder(
-            args.src_dir, args.project
+            args.src_dir, args.project, args.output_dir, version_override
         )
     else:
         prj_builder = project_manager.get_rock_project_builder(
-            args.src_base_dir / args.project, args.project
+            args.src_base_dir / args.project,
+            args.project,
+            args.output_dir,
+            version_override,
         )
     if prj_builder is None:
         print("Error, failed to get the project builder")

--- a/experimental/rockbuilder/rockbuilder.py
+++ b/experimental/rockbuilder/rockbuilder.py
@@ -122,7 +122,7 @@ def get_build_arguments(
     for ii, prj_item in enumerate(project_list):
         parser.add_argument(
             "--" + prj_item + "-version",
-            help=prj_item + " version used for the oprations",
+            help=prj_item + " version used for the operations",
             default=None,
         )
 

--- a/experimental/rockbuilder/rockbuilder.py
+++ b/experimental/rockbuilder/rockbuilder.py
@@ -463,7 +463,7 @@ project_list = project_manager.get_external_project_list()
 # print(project_list)
 
 args = get_build_arguments(rock_builder_home_dir, default_src_base_dir, project_list)
-# store the arguments to dictionary to make it easier to get "project_name"_version parameters
+# store the arguments to dictionary to make it easier to get "project_name"-version parameters
 args_dict = args.__dict__
 printout_build_arguments(args)
 verify_build_env__python(args)
@@ -485,7 +485,10 @@ if args.project == "all":
         sys.exit(1)
     for ii, prj_item in enumerate(project_list):
         print(f"[{ii}]: {prj_item}")
-        version_override = args_dict[project_list[ii] + "_version"]
+        # argparser --> Keyword for parameter "--my-project-version=xyz" = "my_project_version"
+        prj_version_keyword = project_list[ii] + "_version"
+        prj_version_keyword = prj_version_keyword.replace("-", "_")
+        version_override = args_dict[prj_version_keyword]
         # when issuing a command for all projects, we assume that the src_base_dir
         # is the base source directory under each project specific directory is checked out.
         prj_builder = project_manager.get_rock_project_builder(
@@ -499,13 +502,17 @@ if args.project == "all":
         else:
             do_therock(prj_builder)
 else:
-    # If the --src-dir parameter is specified for a single project, we assume that path is full
-    version_override = args_dict[args.project + "_version"]
+    # argparser --> Keyword for parameter "--my-project-version=xyz" = "my_project_version"
+    prj_version_keyword = args.project + "_version"
+    prj_version_keyword = prj_version_keyword.replace("-", "_")
+    version_override = args_dict[prj_version_keyword]
     if args.src_dir:
+        # source checkout dir = "--src-dir"
         prj_builder = project_manager.get_rock_project_builder(
             args.src_dir, args.project, args.output_dir, version_override
         )
     else:
+        # source checkout dir = "--src-base-dir" / project_name
         prj_builder = project_manager.get_rock_project_builder(
             args.src_base_dir / args.project,
             args.project,

--- a/experimental/rockbuilder/rockbuilder.py
+++ b/experimental/rockbuilder/rockbuilder.py
@@ -48,7 +48,7 @@ def get_build_arguments(
         "--project",
         type=str,
         help="select target for the action. Can be either one project or all projects in core_apps.pcfg.",
-        default="all",
+        default=None,
     )
     parser.add_argument(
         "--init",
@@ -475,7 +475,8 @@ for ii, prj_item in enumerate(project_list):
 # let user to see env variables for a while before build start
 time.sleep(1)
 
-if args.project == "all":
+if not args.project:
+    # process all projects specified in the core_project.pcfg
     if args.src_dir:
         print(
             '\nError, "--src-dir" parameter requires also to specify the project with the "--project"-parameter'
@@ -502,6 +503,7 @@ if args.project == "all":
         else:
             do_therock(prj_builder)
 else:
+    # process only a single project specified with the "--project" parameter
     # argparser --> Keyword for parameter "--my-project-version=xyz" = "my_project_version"
     prj_version_keyword = args.project + "_version"
     prj_version_keyword = prj_version_keyword.replace("-", "_")


### PR DESCRIPTION
Add option for the <project_name>-version parameter to rockbuilder
    
Allow specifying the project versions as an optional parameters  to override the version specified in the project.cfg file:
    
Example:
    
./rockbuilder.py --pytorch-version=v2.7.1 --pytorch_audio-version=v2.7.1  --checkout