### PR TITLE
[torch][windows] Patch rocm_sdk DLL load order.

### DIFF
--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0016-Move-rocm_sdk-preload-ahead-of-DLL-loading-add-amd_c.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0016-Move-rocm_sdk-preload-ahead-of-DLL-loading-add-amd_c.patch
@@ -1,0 +1,82 @@
+From 07e9a462576394bd0ea707cfbadf879ac8c144f3 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Mon, 30 Jun 2025 11:38:17 -0700
+Subject: [PATCH 16/16] Move rocm_sdk preload ahead of DLL loading, add
+ amd_comgr library.
+
+---
+ torch/__init__.py | 51 ++++++++++++++++++++++++-----------------------
+ 1 file changed, 26 insertions(+), 25 deletions(-)
+
+diff --git a/torch/__init__.py b/torch/__init__.py
+index a14be9b00a..98aa21d414 100644
+--- a/torch/__init__.py
++++ b/torch/__init__.py
+@@ -153,6 +153,32 @@ assert __all__ == sorted(__all__)
+ # Load the extension module
+ ################################################################################
+ 
++
++# Preload ROCm deps if this torch was built to link against rocm wheels.
++# TODO: Use `from . import _rocm_init` code that landed in upstream torch
++try:
++    import rocm_sdk
++except ModuleNotFoundError:
++    pass
++else:
++    import rocm_sdk
++
++    rocm_sdk.preload_libraries(
++        "amd_comgr",
++        "amdhip64",
++        # Enable once aqlprofiler is available.
++        "rocprofiler-sdk-roctx",
++        "hiprtc",
++        "hipblas",
++        "hipfft",
++        "hiprand",
++        "hipsparse",
++        "hipsolver",
++        "rccl",
++        "hipblaslt",
++        "miopen",
++    )
++
+ if sys.platform == "win32":
+ 
+     def _load_dll_libraries() -> None:
+@@ -299,31 +325,6 @@ def _preload_cuda_deps(lib_folder: str, lib_name: str) -> None:
+ 
+ # See Note [Global dependencies]
+ def _load_global_deps() -> None:
+-    # Preload ROCm deps if this torch was built to link against rocm wheels.
+-    # TODO: Lookup distribution info for the torch package and see if it was
+-    # build with PYTORCH_EXTRA_INSTALL_REQUIREMENTS="rocm" to enable
+-    # ROCm preloading.
+-    try:
+-        import rocm_sdk
+-    except ModuleNotFoundError:
+-        pass
+-    else:
+-        import rocm_sdk
+-        rocm_sdk.preload_libraries(
+-            "amdhip64",
+-            # Enable once aqlprofiler is available.
+-            "rocprofiler-sdk-roctx",
+-            "hiprtc",
+-            "hipblas",
+-            "hipfft",
+-            "hiprand",
+-            "hipsparse",
+-            "hipsolver",
+-            "rccl",
+-            "hipblaslt",
+-            "miopen",
+-        )
+-
+     if _running_with_deploy() or platform.system() == "Windows":
+         return
+ 
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/827.

For PyTorch 2.7.0, this moves the rocm_sdk initialization code up to the same location that it currently sits at pytorch HEAD (see https://github.com/pytorch/pytorch/pull/155285), so our DLLs are loaded _before_ `caffe2_nvrtc.dll`, which has a dependency on `hiprtc0605.dll`.

As part of rebasing onto PyTorch 2.8+, this patch will be dropped fully in favor of the dynamic `_rocm_init.initialize()` code from that PR and following the instructions at https://github.com/ROCm/TheRock/blob/main/docs/packaging/python_packaging.md#performing-initialization.

---

Tested with "dev" rocm SDK wheels on Windows. I'll be refreshing the instructions in [`external-builds/pytorch/README.md`](https://github.com/ROCm/TheRock/blob/main/external-builds/pytorch/README.md) and [`external-builds/pytorch/build_prod_wheels.py`](https://github.com/ROCm/TheRock/blob/main/external-builds/pytorch/build_prod_wheels.py) in a follow-up change.

```bash
# Create a venv for building.
python -m venv rocm.venv
.\rocm.venv\Scripts\activate.bat

# Download rocm wheels for your gfx target.
# TODO(#827): This is using therock-dev-python. Use therock-nightly-python
#             once published.
# We can also use 'install-rocm' with --index-url
python -m pip install \
  --extra-index-url https://d25kgig7rdsyks.cloudfront.net/v2/gfx110X-dgpu/ \
  rocm[libraries,devel]==7.0.0dev0

# Checkout sources to a short path.
# Note: do _not_ check out torchaudio or torchvision.
# TODO(#910): Support torchvision and torchaudio on Windows
python pytorch_torch_repo.py checkout --repo D:/b/pytorch_v2.7.0

# Build, redirecting logs to a file.
python build_prod_wheels.py build \
  --output-dir %HOME%/.therock/pytorch \
  --pytorch-dir D:/b/pytorch_v2.7.0 \
  > %HOME%\.therock\build_prod_wheels_logs.txt 2>&1
```

Then test (note: tests still hang after completing, need to kill the process):
```console 
$ pytest -v smoke-tests
======================================= test session starts =======================================
platform win32 -- Python 3.12.8, pytest-8.4.1, pluggy-1.6.0 -- D:\projects\TheRock\external-builds\pytorch\rocm.venv\Scripts\python.exe
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: D:\projects\TheRock\external-builds\pytorch
plugins: hypothesis-6.135.14
collected 11 items

smoke-tests/pytorch_smoke_test.py::TestROCmAvailability::test_rocm_available PASSED          [  9%] smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_matrix_multiplication PASSED   [ 18%] smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_batch_matrix_multiplication PASSED [ 27%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_matrix_multiplication_at_operator PASSED [ 36%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_elementwise_multiplication PASSED [ 45%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_transpose PASSED               [ 54%] smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_dot_product PASSED             [ 63%] smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_matrix_vector_multiplication PASSED [ 72%]
smoke-tests/pytorch_smoke_test.py::TestMatrixOperations::test_matrix_multiplication_matmul PASSED [ 81%]
smoke-tests/pytorch_smoke_test.py::TestConvolutions::test_conv_transpose2d PASSED            [ 90%] smoke-tests/pytorch_smoke_test.py::TestConvolutions::test_conv_cudnn_nhwc_support PASSED     [100%]

======================================= 11 passed in 7.51s ========================================
```