### PR TITLE
Disable using CK in MIOpen if target is not gfx9{08,0a,42,50}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,7 @@ if(NOT WIN32)
     DESCRIPTION "Enables build of composable kernel, including minimal kernel library"
     REQUIRES COMPILER HIP_RUNTIME RAND
   )
+  cmake_dependent_option(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL "Enables composable kernel in MIOpen" ON ${THEROCK_ENABLE_COMPOSABLE_KERNEL} OFF)
 endif()
 
 # ML-Libs Features.

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -5,21 +5,6 @@ if(NOT WIN32)
   list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
 endif()
 
-# composable kernel is currently only tested and gfx908, gfx90a, gfx942 and
-# gfx950. For other GPU families, building MIOpen with CK enabled, the build is
-# failing with linker errors which need further investigation.
-if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
-  set(_ck_supported_gfx_targets gfx908 gfx90a gfx942 gfx950)
-  foreach(_gfx_target ${THEROCK_AMDGPU_TARGETS})
-    if(NOT ${_gfx_target} IN_LIST _ck_supported_gfx_targets)
-      message(WARNING
-        "${_gfx_target} (included in THEROCK_AMDGPU_TARGETS) is not supported by composable kernel. "
-        "Disabling building composable kernel.")
-      set(THEROCK_ENABLE_COMPOSABLE_KERNEL OFF)
-    endif()
-  endforeach()
-endif()
-
 if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
   ##############################################################################
   # Composable_kernel
@@ -70,9 +55,24 @@ if(THEROCK_ENABLE_MIOPEN)
   # MIOpen
   ##############################################################################
 
+  # composable kernel is currently only tested and gfx908, gfx90a, gfx942 and
+  # gfx950. For other GPU families, building MIOpen with CK enabled, the build is
+  # failing with linker errors which need further investigation.
+  if(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL)
+    set(_ck_supported_gfx_targets gfx908 gfx90a gfx942)
+    foreach(_gfx_target ${THEROCK_AMDGPU_TARGETS})
+      if(NOT ${_gfx_target} IN_LIST _ck_supported_gfx_targets)
+        message(WARNING
+          "${_gfx_target} (included in THEROCK_AMDGPU_TARGETS) is not supported by composable kernel. "
+          "Disabling using composable kernel in MIOpen.")
+        set(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL OFF)
+      endif()
+    endforeach()
+  endif()
+
   # If composable kernel is enabled, add it as an MIOpen dep.
   set(optional_miopen_build_deps)
-  if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
+  if(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL)
     list(APPEND optional_miopen_build_deps composable_kernel)
   endif()
 
@@ -101,7 +101,7 @@ if(THEROCK_ENABLE_MIOPEN)
       -DROCM_PATH=
       -DROCM_DIR=
       "-DBUILD_TESTING=${THEROCK_BUILD_TESTING}"
-      "-DMIOPEN_USE_COMPOSABLEKERNEL=${THEROCK_ENABLE_COMPOSABLE_KERNEL}"
+      "-DMIOPEN_USE_COMPOSABLEKERNEL=${THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL}"
       -DMIOPEN_USE_MLIR=OFF # TODO: enable
       -DMIOPEN_BUILD_DRIVER=ON
       -DBoost_COMPILER=${_THEROCK_MIOPEN_OVERRIDE_BOOST_COMPILER}

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -5,6 +5,21 @@ if(NOT WIN32)
   list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
 endif()
 
+# composable kernel is currently only tested and gfx908, gfx90a, gfx942 and
+# gfx950. For other GPU families, building MIOpen with CK enabled, the build is
+# failing with linker errors which need further investigation.
+if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
+  set(_ck_supported_gfx_targets gfx908 gfx90a gfx942 gfx950)
+  foreach(_gfx_target ${THEROCK_AMDGPU_TARGETS})
+    if(NOT ${_gfx_target} IN_LIST _ck_supported_gfx_targets)
+      message(WARNING
+        "${_gfx_target} (included in THEROCK_AMDGPU_TARGETS) is not supported by composable kernel. "
+        "Disabling building composable kernel.")
+      set(THEROCK_ENABLE_COMPOSABLE_KERNEL OFF)
+    endif()
+  endforeach()
+endif()
+
 if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
   ##############################################################################
   # Composable_kernel

--- a/patches/amd-mainline/MIOpen/0001-Disable-conv_wino_fury_RxS-for-gfx115x.patch
+++ b/patches/amd-mainline/MIOpen/0001-Disable-conv_wino_fury_RxS-for-gfx115x.patch
@@ -1,7 +1,7 @@
-From a956c9720ba37ec99d3eec433a8fb4ceba2c4c1b Mon Sep 17 00:00:00 2001
+From 5b488cc802c23c76d100422df249cdbf272bf65f Mon Sep 17 00:00:00 2001
 From: Scott Tsai <scottt.tw@gmail.com>
 Date: Thu, 10 Apr 2025 18:13:02 +0800
-Subject: [PATCH 3/5] Disable conv_wino_fury_RxS for gfx115x
+Subject: [PATCH 1/2] Disable conv_wino_fury_RxS for gfx115x
 
 MIOpenDriver convfp16 would produce the folloing error on the gfx1151:
 
@@ -32,5 +32,5 @@ index 6f90642fa..66cb1b4d8 100644
          return false;
      if(!(problem.GetDilationH() == 1 && problem.GetDilationW() == 1))
 -- 
-2.41.0.windows.1
+2.43.0
 

--- a/patches/amd-mainline/MIOpen/0002-Fix-no-ck-build-3852.patch
+++ b/patches/amd-mainline/MIOpen/0002-Fix-no-ck-build-3852.patch
@@ -1,0 +1,39 @@
+From 4a0dc8c2e0837cbe0f000fd4acc0fc5907c859cb Mon Sep 17 00:00:00 2001
+From: BrianHarrisonAMD <169072757+BrianHarrisonAMD@users.noreply.github.com>
+Date: Mon, 30 Jun 2025 13:28:43 -0600
+Subject: [PATCH 2/3] Fix no ck build (#3852)
+
+* Fix no ck build
+
+---------
+
+Co-authored-by: Samuel Reeder <samuel.reeder@amd.com>
+---
+ src/include/miopen/solver/implicitgemm_ck_util.hpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/include/miopen/solver/implicitgemm_ck_util.hpp b/src/include/miopen/solver/implicitgemm_ck_util.hpp
+index 8d6b37682..c01031558 100644
+--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
++++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
+@@ -848,6 +848,7 @@ ConvTensors GetTensors(const CastType& data_ctx)
+ template <typename DataType, typename OutElemOp>
+ OutElemOp GetOutElementOp(const miopen::fusion::ActivationOpInvokeParam& activationOp)
+ {
++#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+     auto activationMode = activationOp.activMode;
+     switch(activationMode)
+     {
+@@ -858,6 +859,9 @@ OutElemOp GetOutElementOp(const miopen::fusion::ActivationOpInvokeParam& activat
+         MIOPEN_THROW(miopenStatusInternalError,
+                      "Unsupported activation type: " + std::to_string(activationMode));
+     }
++#else
++    MIOPEN_THROW(miopenStatusNotImplemented, "Not implemented without ck enabled");
++#endif
+ }
+ 
+ #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+-- 
+2.43.0
+


### PR DESCRIPTION
Building MIOpen with CK enabled fails for other GPU targets when linking. Disabling using CK in MIOpen if a non-supported target is in the THEROCK_AMDGPU_TARGETS list.