### PR TITLE
[torch] Update docs for running build_prod_wheels.py.

### DIFF
--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -120,6 +120,7 @@ Generate a `_rocm_init.py` file like this (using any suitable scripting):
 echo "
 import rocm_sdk
 rocm_sdk.initialize_process(library_shortnames=[
+  'amd_comgr',
   'amdhip64',
   'roctx64',
   'hiprtc',

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0016-Move-rocm_sdk-preload-ahead-of-DLL-loading-add-amd_c.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0016-Move-rocm_sdk-preload-ahead-of-DLL-loading-add-amd_c.patch
@@ -1,0 +1,82 @@
+From 07e9a462576394bd0ea707cfbadf879ac8c144f3 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Mon, 30 Jun 2025 11:38:17 -0700
+Subject: [PATCH 16/16] Move rocm_sdk preload ahead of DLL loading, add
+ amd_comgr library.
+
+---
+ torch/__init__.py | 51 ++++++++++++++++++++++++-----------------------
+ 1 file changed, 26 insertions(+), 25 deletions(-)
+
+diff --git a/torch/__init__.py b/torch/__init__.py
+index a14be9b00a..98aa21d414 100644
+--- a/torch/__init__.py
++++ b/torch/__init__.py
+@@ -153,6 +153,32 @@ assert __all__ == sorted(__all__)
+ # Load the extension module
+ ################################################################################
+ 
++
++# Preload ROCm deps if this torch was built to link against rocm wheels.
++# TODO: Use `from . import _rocm_init` code that landed in upstream torch
++try:
++    import rocm_sdk
++except ModuleNotFoundError:
++    pass
++else:
++    import rocm_sdk
++
++    rocm_sdk.preload_libraries(
++        "amd_comgr",
++        "amdhip64",
++        # Enable once aqlprofiler is available.
++        "rocprofiler-sdk-roctx",
++        "hiprtc",
++        "hipblas",
++        "hipfft",
++        "hiprand",
++        "hipsparse",
++        "hipsolver",
++        "rccl",
++        "hipblaslt",
++        "miopen",
++    )
++
+ if sys.platform == "win32":
+ 
+     def _load_dll_libraries() -> None:
+@@ -299,31 +325,6 @@ def _preload_cuda_deps(lib_folder: str, lib_name: str) -> None:
+ 
+ # See Note [Global dependencies]
+ def _load_global_deps() -> None:
+-    # Preload ROCm deps if this torch was built to link against rocm wheels.
+-    # TODO: Lookup distribution info for the torch package and see if it was
+-    # build with PYTORCH_EXTRA_INSTALL_REQUIREMENTS="rocm" to enable
+-    # ROCm preloading.
+-    try:
+-        import rocm_sdk
+-    except ModuleNotFoundError:
+-        pass
+-    else:
+-        import rocm_sdk
+-        rocm_sdk.preload_libraries(
+-            "amdhip64",
+-            # Enable once aqlprofiler is available.
+-            "rocprofiler-sdk-roctx",
+-            "hiprtc",
+-            "hipblas",
+-            "hipfft",
+-            "hiprand",
+-            "hipsparse",
+-            "hipsolver",
+-            "rccl",
+-            "hipblaslt",
+-            "miopen",
+-        )
+-
+     if _running_with_deploy() or platform.system() == "Windows":
+         return
+ 
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/708. Progress on https://github.com/ROCm/TheRock/issues/827. Relates to https://github.com/ROCm/TheRock/issues/703.

This reworks our PyTorch source build instructions to only use the [`external-builds/pytorch/build_prod_wheels.py`](https://github.com/ROCm/TheRock/blob/main/external-builds/pytorch/build_prod_wheels.py) script, for both Linux and Windows. Support on Windows is recent, thanks to https://github.com/ROCm/TheRock/pull/914 and https://github.com/ROCm/TheRock/pull/940.