### PR TITLE
Include win_amd64 packages in python indices.

### DIFF
--- a/build_tools/third_party/s3_management/update_dependencies.py
+++ b/build_tools/third_party/s3_management/update_dependencies.py
@@ -90,9 +90,6 @@ def upload_missing_whls(
         # Skip win_arm64 packages
         if "-win_arm64" in pkg:
             continue
-        # Skip win_amd64 packages
-        if "-win_amd64" in pkg:
-            continue
         # Skip muslinux packages
         if "-musllinux" in pkg:
             continue


### PR DESCRIPTION
Following up on https://github.com/ROCm/TheRock/pull/934#issuecomment-3020832059.

Once we run this script with these changes, our index pages like https://d2awnip2yjpvqn.cloudfront.net/v2/gfx1151/ will include Windows wheels too, for example alongside:

```
Links for numpy
numpy-2.3.0-cp311-cp311-manylinux_2_28_x86_64.whl
numpy-2.3.0-cp312-cp312-manylinux_2_28_x86_64.whl
numpy-2.3.0-cp313-cp313-manylinux_2_28_x86_64.whl
```