### PR TITLE
[pytorch] Add build support for the vendored pytorch-triton-rocm wheel.

### DIFF
--- a/external-builds/pytorch/.gitignore
+++ b/external-builds/pytorch/.gitignore
@@ -3,3 +3,4 @@ src/
 /pytorch
 /pytorch_vision
 /pytorch_audio
+/triton

--- a/external-builds/pytorch/pytorch_torch_repo.py
+++ b/external-builds/pytorch/pytorch_torch_repo.py
@@ -37,10 +37,7 @@ in, CI runs for that revision will incorporate them the same as anyone
 interactively using this tool.
 """
 import argparse
-from pathlib import Path, PurePosixPath
-import shlex
-import shutil
-import subprocess
+from pathlib import Path
 import sys
 
 import repo_management
@@ -87,7 +84,7 @@ def main(cl_args: list[str]):
         help="Git repository ref/tag to checkout",
     )
     checkout_p.add_argument("--depth", type=int, help="Fetch depth")
-    checkout_p.add_argument("--jobs", type=int, help="Number of fetch jobs")
+    checkout_p.add_argument("--jobs", default=10, type=int, help="Number of fetch jobs")
     checkout_p.add_argument(
         "--hipify",
         action=argparse.BooleanOptionalAction,

--- a/external-builds/pytorch/pytorch_triton_repo.py
+++ b/external-builds/pytorch/pytorch_triton_repo.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+"""PyTorch depends on a pinned build of Triton.
+
+This script runs after `pytorch_torch_repo.py` and checks out the proper triton
+repository based on pins in the torch repo.
+
+This procedure is adapted from `pytorch/.github/scripts/build_triton_wheel.py`
+"""
+import argparse
+import json
+from pathlib import Path
+import sys
+
+import repo_management
+
+THIS_MAIN_REPO_NAME = "triton"
+THIS_DIR = Path(__file__).resolve().parent
+THIS_PATCHES_DIR = THIS_DIR / "patches" / THIS_MAIN_REPO_NAME
+
+
+def get_triton_pin(torch_dir: Path) -> str:
+    pin_file = torch_dir / ".ci" / "docker" / "ci_commit_pins" / "triton.txt"
+    return pin_file.read_text().strip()
+
+
+def get_triton_version(torch_dir: Path) -> str:
+    version_file = torch_dir / ".ci" / "docker" / "triton_version.txt"
+    return version_file.read_text().strip()
+
+
+def do_checkout(args: argparse.Namespace):
+    repo_dir: Path = args.repo
+    torch_dir: Path = args.torch_dir
+    if not torch_dir.exists():
+        raise ValueError(
+            f"Could not find torch dir: {torch_dir} (did you check out torch first)"
+        )
+
+    build_env = {"TRITON_WHEEL_NAME": "pytorch-triton-rocm"}
+    if args.repo_hashtag is None:
+        if args.release:
+            # Derive the commit pin based on --release.
+            pin_version = get_triton_version(torch_dir)
+            pin_major, pin_minor, *_ = pin_version.split(".")
+            args.repo_hashtag = f"release/{pin_major}.{pin_minor}.x"
+            print(f"Triton version pin: {args.triton_version} -> {args.repo_hashtag}")
+        else:
+            # Derive the commit pin base on ci commit.
+            args.repo_hashtag = get_triton_pin(torch_dir)
+            build_env["TRITON_WHEEL_VERSION_SUFFIX"] = f"+git{args.repo_hashtag[:8]}"
+            print(f"Triton CI commit pin: {args.repo_hashtag}")
+
+    def _do_hipify(args: argparse.Namespace):
+        print("Applying local modifications...")
+        with open(repo_dir / "build_env.json", "w") as f:
+            json.dump(build_env, f, indent=2)
+
+    repo_management.do_checkout(args, custom_hipify=_do_hipify)
+
+
+def main(cl_args: list[str]):
+    def add_common(command_parser: argparse.ArgumentParser):
+        command_parser.add_argument(
+            "--repo",
+            type=Path,
+            default=THIS_DIR / THIS_MAIN_REPO_NAME,
+            help="Git repository path",
+        )
+        command_parser.add_argument(
+            "--patch-dir",
+            type=Path,
+            default=THIS_PATCHES_DIR,
+            help="Git repository patch path",
+        )
+        command_parser.add_argument(
+            "--repo-name",
+            type=Path,
+            default=THIS_MAIN_REPO_NAME,
+            help="Git repository patch path",
+        )
+
+    p = argparse.ArgumentParser("pytorch_triton_repo.py")
+    sub_p = p.add_subparsers(required=True)
+    checkout_p = sub_p.add_parser("checkout", help="Clone Triton locally and checkout")
+    add_common(checkout_p)
+    checkout_p.add_argument(
+        "--torch-dir",
+        default=THIS_DIR / "pytorch",
+        help="Directory of the torch checkout",
+    )
+    checkout_p.add_argument(
+        "--gitrepo-origin",
+        default="https://github.com/ROCm/triton.git",
+        help="git repository url",
+    )
+    checkout_p.add_argument(
+        "--repo-hashtag",
+        help="Git repository ref/tag to checkout",
+    )
+    checkout_p.add_argument(
+        "--release",
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help="Build a release Triton (vs nightly pin)",
+    )
+    checkout_p.add_argument("--depth", type=int, help="Fetch depth")
+    checkout_p.add_argument("--jobs", type=int, help="Number of fetch jobs")
+    checkout_p.add_argument(
+        "--hipify",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run hipify",
+    )
+    checkout_p.add_argument(
+        "--patch",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Apply patches for the repo-hashtag",
+    )
+    checkout_p.set_defaults(func=do_checkout)
+
+    save_patches_p = sub_p.add_parser(
+        "save-patches", help="Save local commits as patch files for later application"
+    )
+    add_common(save_patches_p)
+    save_patches_p.add_argument(
+        "--repo-hashtag",
+        required=True,
+        help="Git repository ref/tag to checkout",
+    )
+    save_patches_p.set_defaults(func=repo_management.do_save_patches)
+
+    args = p.parse_args(cl_args)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/external-builds/pytorch/repo_management.py
+++ b/external-builds/pytorch/repo_management.py
@@ -196,7 +196,7 @@ def do_hipify(args: argparse.Namespace):
     repo_dir: Path = args.repo
     print(f"Hipifying {repo_dir}")
     build_amd_path = repo_dir / "tools" / "amd_build" / "build_amd.py"
-    if os.path.exists(build_amd_path):
+    if build_amd_path.exists():
         exec([sys.executable, build_amd_path], cwd=repo_dir)
 
 

--- a/external-builds/pytorch/repo_management.py
+++ b/external-builds/pytorch/repo_management.py
@@ -192,7 +192,33 @@ def repo_hashtag_to_patches_dir_name(version_ref: str) -> str:
     return version_ref
 
 
-def do_checkout(args: argparse.Namespace):
+def do_hipify(args: argparse.Namespace):
+    repo_dir: Path = args.repo
+    print(f"Hipifying {repo_dir}")
+    build_amd_path = repo_dir / "tools" / "amd_build" / "build_amd.py"
+    if os.path.exists(build_amd_path):
+        exec([sys.executable, build_amd_path], cwd=repo_dir)
+
+
+def commit_hipify(args: argparse.Namespace):
+    repo_dir: Path = args.repo
+    # Iterate over the base repository and all submodules. Because we process
+    # the root repo first, it will not add submodule changes.
+    all_paths = get_all_repositories(repo_dir)
+    for module_path in all_paths:
+        status = list_status(module_path)
+        if not status:
+            continue
+        print(f"HIPIFY made changes to {module_path}: Committing")
+        exec(["git", "add", "-A"], cwd=module_path)
+        exec(
+            ["git", "commit", "-m", HIPIFY_COMMIT_MESSAGE, "--no-gpg-sign"],
+            cwd=module_path,
+        )
+        exec(["git", "tag", "-f", TAG_HIPIFY_DIFFBASE, "--no-sign"], cwd=module_path)
+
+
+def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
     repo_dir: Path = args.repo
     repo_patch_dir_base = args.patch_dir
     check_git_dir = repo_dir / ".git"
@@ -246,7 +272,8 @@ def do_checkout(args: argparse.Namespace):
 
     # Hipify.
     if args.hipify:
-        do_hipify(args)
+        custom_hipify(args)
+        commit_hipify(args)
 
     # Hipified patches.
     if args.patch:
@@ -256,28 +283,6 @@ def do_checkout(args: argparse.Namespace):
             args.repo_name,
             "hipified",
         )
-
-
-def do_hipify(args: argparse.Namespace):
-    repo_dir: Path = args.repo
-    print(f"Hipifying {repo_dir}")
-    build_amd_path = repo_dir / "tools" / "amd_build" / "build_amd.py"
-    if os.path.exists(build_amd_path):
-        exec([sys.executable, build_amd_path], cwd=repo_dir)
-    # Iterate over the base repository and all submodules. Because we process
-    # the root repo first, it will not add submodule changes.
-    all_paths = get_all_repositories(repo_dir)
-    for module_path in all_paths:
-        status = list_status(module_path)
-        if not status:
-            continue
-        print(f"HIPIFY made changes to {module_path}: Committing")
-        exec(["git", "add", "-A"], cwd=module_path)
-        exec(
-            ["git", "commit", "-m", HIPIFY_COMMIT_MESSAGE, "--no-gpg-sign"],
-            cwd=module_path,
-        )
-        exec(["git", "tag", "-f", TAG_HIPIFY_DIFFBASE, "--no-sign"], cwd=module_path)
 
 
 def do_save_patches(args: argparse.Namespace):


### PR DESCRIPTION
* Merely adds scripting support for checking out the proper pinned repository and building if done.
* Should be NFC on any existing build pipelines until enabled.
* The build procedure is a bit annoying because it relies on a couple of action at a distance build flags and pins that need to line up exactly.

As part of this, I did a code review of what the Triton build is doing behind the scenes, some of which is problematic. I have looped the Triton maintainer in and we will fix in followups:

* The AMD backend has bugs in terms of how it is finding the libamdhip64.so having to do with it using dlopen to probe existing loaded libraries by barename (i.e. `libamdhip64.so`) vs soname (i.e. `libamdhip64.so.6`), resulting in some exotic fallbacks to scanning process tables that should not be necessary. The entire procedure is non deterministic and I can imagine ways it can fail in the field.
* We need to add a probe for installation via the ROCM wheels and use the API it provides to find the libraries vs relying on heuristics.
* By default the Triton build fetches pre-built binaries for LLVM static libraries it is pinned to. These appear to be built on manylinux2014 vs newer glibc. Static libraries can have subtle incompatibilities across gcc-toolset versions. Appears to not be a problem now but worth keeping an eye on.
* There is a lot of stuff in the pytorch/AMD scripts for bundling shared libraries and rewriting rpaths. None of this appears to be currently load bearing in present versions of Triton and was left out. In addition, even if it were, the rocm wheels would take care of it vs requiring exotic bundling.

We'll fix all of this going forward once the basic build machinery is in place and functioning.