### PR TITLE
[torch] Fix build_prod_wheels argparse and version checking.

### DIFF
--- a/.github/workflows/build_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_linux_pytorch_wheels.yml
@@ -95,10 +95,10 @@ jobs:
         run: |
           echo "Building PyTorch wheels for ${{ inputs.amdgpu_family }}"
           ./external-builds/pytorch/build_prod_wheels.py \
-            --pip-cache-dir /tmp/pipcache \
-            --index-url "https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/" \
             build \
             --install-rocm \
+            --pip-cache-dir /tmp/pipcache \
+            --index-url "https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/" \
             --clean \
             --output-dir ${{ env.PACKAGE_DIST_DIR }} \
             # TODO(marbre): Enable ones dependencies in rocm package are fixed \

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -171,7 +171,7 @@ def get_installed_package_version(dist_package_name: str) -> str:
     ).splitlines()
     if not lines:
         raise ValueError(f"Did not find installed package '{dist_package_name}'")
-    prefix = "Versionaaa: "
+    prefix = "Version: "
     for line in lines:
         if line.startswith(prefix):
             return line[len(prefix) :]

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -59,13 +59,13 @@ to the build sub-command (useful for docker invocations).
 ```
 # For therock-nightly-python
 build_prod_wheels.py
-    --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ \
-    install-rocm
+    install-rocm \
+    --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/
 
 # For therock-dev-python (unstable but useful for testing outside of prod)
 build_prod_wheels.py
-    --index-url https://d25kgig7rdsyks.cloudfront.net/v2/gfx110X-dgpu/ \
-    install-rocm
+    install-rocm \
+    --index-url https://d25kgig7rdsyks.cloudfront.net/v2/gfx110X-dgpu/
 ```
 
 3. Build torch, torchaudio and torchvision for a single gfx architecture.
@@ -99,10 +99,10 @@ versions):
     /usr/bin/env CCACHE_DIR=/therock/output/ccache \
     /opt/python/cp312-cp312/bin/python \
     /therock/src/external-builds/pytorch/build_prod_wheels.py \
-    --pip-cache-dir /therock/output/pip_cache \
-    --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ \
     build \
         --install-rocm \
+        --pip-cache-dir /therock/output/pip_cache \
+        --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ \
         --clean \
         --output-dir /therock/output/cp312/wheels
 ```
@@ -169,12 +169,15 @@ def get_installed_package_version(dist_package_name: str) -> str:
     lines = capture(
         [sys.executable, "-m", "pip", "show", dist_package_name], cwd=Path.cwd()
     ).splitlines()
-    prefix = "Version: "
+    if not lines:
+        raise ValueError(f"Did not find installed package '{dist_package_name}'")
+    prefix = "Versionaaa: "
     for line in lines:
         if line.startswith(prefix):
             return line[len(prefix) :]
+    joined_lines = "\n".join(lines)
     raise ValueError(
-        f"Did not find installed package {dist_package_name} in {'\n'.join(lines)}"
+        f"Did not find Version for installed package '{dist_package_name}' in output:\n{joined_lines}"
     )
 
 


### PR DESCRIPTION
Partially tested at https://github.com/ROCm/TheRock/actions/runs/16005755463 (that failed since the dev bucket does not currently have rocm wheels)

This was broken by both https://github.com/ROCm/TheRock/pull/942 and https://github.com/ROCm/TheRock/pull/948. See full logs on https://github.com/ROCm/TheRock/actions/runs/15988444502.

* Changes to argparse made it so that arguments were moved to subcommands instead of being top level. We could also revert those changes, but I like having the subcommand (`build` or `install-rocm`) be the first part argument, instead of in the middle
* The new `get_installed_package_version` function had an invalid `\` character in an f-string.