### PR TITLE
[pytorch] Extend build_prod_wheels.py to build pytorch nightly.

### DIFF
--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -112,28 +112,32 @@ try:
     from . import _rocm_init
 except ModuleNotFoundError:
     pass
+else:
+    _rocm_init.initialize()
+    del _rocm_init
 ```
 
 Generate a `_rocm_init.py` file like this (using any suitable scripting):
 
 ```bash
 echo "
-import rocm_sdk
-rocm_sdk.initialize_process(library_shortnames=[
-  'amd_comgr',
-  'amdhip64',
-  'roctx64',
-  'hiprtc',
-  'hipblas',
-  'hipfft',
-  'hiprand',
-  'hipsparse',
-  'hipsolver',
-  'rccl',
-  'hipblaslt',
-  'miopen',
-],
-check_version='$(rocm-sdk version)')
+def initialize():
+  import rocm_sdk
+  rocm_sdk.initialize_process(library_shortnames=[
+    'amd_comgr',
+    'amdhip64',
+    'roctx64',
+    'hiprtc',
+    'hipblas',
+    'hipfft',
+    'hiprand',
+    'hipsparse',
+    'hipsolver',
+    'rccl',
+    'hipblaslt',
+    'miopen',
+  ],
+  check_version='$(rocm-sdk version)')
 " > torch/_rocm_init.py
 ```
 

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -123,7 +123,7 @@ Generate a `_rocm_init.py` file like this (using any suitable scripting):
 echo "
 def initialize():
   import rocm_sdk
-  rocm_sdk.initialize_process(library_shortnames=[
+  rocm_sdk.initialize_process(preload_shortnames=[
     'amd_comgr',
     'amdhip64',
     'roctx64',

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -199,8 +199,12 @@ To create patches
 
 ### PyTorch Nightly
 
-This checks out the `nightly` branches from `github.com/pytorch`, tracking
-the latest pytorch.org nightly release.
+This checks out the `nightly` branches from https://github.com/pytorch,
+tracking the latest pytorch.org nightly release:
+
+- https://github.com/pytorch/pytorch/tree/nightly
+- https://github.com/pytorch/audio/tree/nightly
+- https://github.com/pytorch/vision/tree/nightly
 
 ```
 python pytorch_torch_repo.py checkout --repo-hashtag nightly

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -67,8 +67,8 @@ Now checkout repositories:
 
   ```bash
   python pytorch_torch_repo.py checkout
-  python pytorch_torch_audio_repo.py checkout
-  python pytorch_torch_vision_repo.py checkout
+  python pytorch_audio_repo.py checkout
+  python pytorch_vision_repo.py checkout
   ```
 
 - On Windows, use shorter paths to avoid command length limits:
@@ -194,3 +194,18 @@ To create patches
 
 1. Commit your change(s) within the relevant source folder(s)
 1. Run the `save-patches` subcommand of the relevant source management script(s)
+
+## Alternate Branches / Patch Sets
+
+### PyTorch Nightly
+
+This checks out the `nightly` branches from `github.com/pytorch`, tracking
+the latest pytorch.org nightly release.
+
+```
+python pytorch_torch_repo.py checkout --repo-hashtag nightly
+python pytorch_audio_repo.py checkout --repo-hashtag nightly
+python pytorch_vision_repo.py checkout --repo-hashtag nightly
+# Note that triton will be checked out at the PyTorch pin.
+python pytorch_triton_repo.py checkout
+```

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -198,7 +198,7 @@ def get_rocm_init_contents(args: argparse.Namespace):
             f"""
         def initialize():
             import rocm_sdk
-            rocm_sdk.initialize_process(library_shortnames=[
+            rocm_sdk.initialize_process(preload_shortnames=[
                 'amd_comgr',
                 'amdhip64',
                 'hiprtc',
@@ -218,7 +218,7 @@ def get_rocm_init_contents(args: argparse.Namespace):
             f"""
         def initialize():
             import rocm_sdk
-            rocm_sdk.initialize_process(library_shortnames=[
+            rocm_sdk.initialize_process(preload_shortnames=[
                 'amd_comgr',
                 'amdhip64',
                 'rocprofiler-sdk-roctx',

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -58,12 +58,12 @@ to the build sub-command (useful for docker invocations).
 
 ```
 # For therock-nightly-python
-build_prod_wheels.py
+build_prod_wheels.py \
     install-rocm \
     --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/
 
 # For therock-dev-python (unstable but useful for testing outside of prod)
-build_prod_wheels.py
+build_prod_wheels.py \
     install-rocm \
     --index-url https://d25kgig7rdsyks.cloudfront.net/v2/gfx110X-dgpu/
 ```
@@ -122,6 +122,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
+import textwrap
 
 script_dir = Path(__file__).resolve().parent
 
@@ -187,6 +188,54 @@ def get_rocm_path(path_name: str) -> Path:
             [sys.executable, "-m", "rocm_sdk", "path", f"--{path_name}"], cwd=Path.cwd()
         ).strip()
     )
+
+
+def get_rocm_init_contents(args: argparse.Namespace):
+    """Gets the contents of the _rocm_init.py file to add to the build."""
+    sdk_version = get_rocm_sdk_version()
+    if is_windows:
+        return textwrap.dedent(
+            f"""
+        def initialize():
+            import rocm_sdk
+            rocm_sdk.initialize_process(library_shortnames=[
+                'amd_comgr',
+                'amdhip64',
+                'hiprtc',
+                'hipblas',
+                'hipfft',
+                'hiprand',
+                'hipsparse',
+                'hipsolver',
+                'hipblaslt',
+                'miopen',
+                ],
+                check_version='{sdk_version}')
+        """
+        )
+    else:
+        return textwrap.dedent(
+            f"""
+        def initialize():
+            import rocm_sdk
+            rocm_sdk.initialize_process(library_shortnames=[
+                'amd_comgr',
+                'amdhip64',
+                'rocprofiler-sdk-roctx',
+                'roctx64',
+                'hiprtc',
+                'hipblas',
+                'hipfft',
+                'hiprand',
+                'hipsparse',
+                'hipsolver',
+                'rccl',
+                'hipblaslt',
+                'miopen',
+                ],
+                check_version='{sdk_version}')
+        """
+        )
 
 
 def remove_dir_if_exists(dir: Path):
@@ -255,6 +304,15 @@ def do_install_rocm(args: argparse.Namespace):
     print(f"Installed version: {get_rocm_sdk_version()}")
 
 
+def add_env_compiler_flags(env: dict[str, str], flagname: str, *compiler_flags: str):
+    current = env.get(flagname, "")
+    append = ""
+    for compiler_flag in compiler_flags:
+        append += f" {compiler_flag}"
+    env[flagname] = f"{current}{append}"
+    print(f"-- Appended {flagname}+={append}")
+
+
 def do_build(args: argparse.Namespace):
     if args.install_rocm:
         do_install_rocm(args)
@@ -296,6 +354,7 @@ def do_build(args: argparse.Namespace):
     env: dict[str, str] = {
         "CMAKE_PREFIX_PATH": str(cmake_prefix),
         "ROCM_HOME": str(root_dir),
+        "ROCM_PATH": str(root_dir),
         "PYTORCH_ROCM_ARCH": pytorch_rocm_arch,
         # TODO: Figure out what is blocking GLOO and enable.
         "USE_GLOO": "OFF",
@@ -330,9 +389,30 @@ def do_build(args: argparse.Namespace):
             }
         )
 
+    # Workaround missing devicelib bitcode
+    # TODO: When "ROCM_PATH" and/or "ROCM_HOME" is set in the environment, the
+    # clang frontend ignores its default heuristics and (depending on version)
+    # finds the wrong path to the device library. This is bad/annoying. But
+    # the PyTorch build shouldn't even need these to be set. Unfortunately, it
+    # has been hardcoded for a long time. So we use a clang env var to force
+    # a specific device lib path to workaround the hack to get pytorch to build.
+    # This may or may not only affect the Python wheels with their own quirks
+    # on directory layout.
+    # Obviously, this should be completely burned with fire once the root causes
+    # are eliminted.
+    hip_device_lib_path = get_rocm_path("root") / "llvm" / "amdgcn" / "bitcode"
+    if not hip_device_lib_path.exists():
+        print(
+            "WARNING: Default location of device libs not found. Relying on "
+            "clang heuristics which are known to be buggy in this configuration"
+        )
+    else:
+        env["HIP_DEVICE_LIB_PATH"] = hip_device_lib_path
+
     # Build triton.
     triton_requirement = None
-    if triton_dir:
+    if args.build_triton or (args.build_triton is None and triton_dir):
+        assert triton_dir, "Must specify --triton-dir if --build-triton"
         triton_requirement = do_build_triton(args, triton_dir, dict(env))
     else:
         print("--- Not building triton (no --triton-dir)")
@@ -414,6 +494,7 @@ def do_build_pytorch(
     pytorch_build_version = (pytorch_dir / "version.txt").read_text().strip()
     pytorch_build_version += args.version_suffix
     print(f"  Default PYTORCH_BUILD_VERSION: {pytorch_build_version}")
+    env["USE_ROCM"] = "ON"
     env["PYTORCH_BUILD_VERSION"] = pytorch_build_version
     env["PYTORCH_BUILD_NUMBER"] = args.pytorch_build_number
 
@@ -428,10 +509,13 @@ def do_build_pytorch(
         f"--- PYTORCH_EXTRA_INSTALL_REQUIREMENTS = {env['PYTORCH_EXTRA_INSTALL_REQUIREMENTS']}"
     )
 
+    # Add the _rocm_init.py file.
+    (pytorch_dir / "torch" / "_rocm_init.py").write_text(get_rocm_init_contents(args))
+
+    # Workaround missing features on windows.
     if is_windows:
         env.update(
             {
-                "USE_ROCM": "ON",
                 "USE_FLASH_ATTENTION": "0",
                 "USE_MEM_EFF_ATTENTION": "0",
                 "DISTUTILS_USE_SDK": "1",
@@ -445,6 +529,17 @@ def do_build_pytorch(
                 "BUILD_TEST": "0",
             }
         )
+
+    if not is_windows:
+        # Prepend the ROCm sysdeps dir so that we use bundled libraries.
+        # While a decent thing to be doing, this is presently required because:
+        # TODO: include/rocm_smi/kfd_ioctl.h is included without its advertised
+        # transitive includes. This triggers a compilation error for a missing
+        # libdrm/drm.h.
+        sysdeps_dir = get_rocm_path("root") / "lib" / "rocm_sysdeps"
+        assert sysdeps_dir.exists(), f"No sysdeps directory found: {sysdeps_dir}"
+        add_env_compiler_flags(env, "CXXFLAGS", f"-I{sysdeps_dir / 'include'}")
+        add_env_compiler_flags(env, "LDFLAGS", f"-L{sysdeps_dir / 'lib'}")
 
     print("+++ Uninstalling pytorch:")
     exec(
@@ -634,6 +729,13 @@ def main(argv: list[str]):
     build_p.add_argument(
         "--pytorch-build-number", default="1", help="Build number to append to version"
     )
+    build_p.add_argument(
+        "--build-triton",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable building of triton (requires --triton-dir)",
+    )
+
     today = date.today()
     formatted_date = today.strftime("%Y%m%d")
     build_p.add_argument(

--- a/external-builds/pytorch/pytorch_triton_repo.py
+++ b/external-builds/pytorch/pytorch_triton_repo.py
@@ -47,7 +47,10 @@ def do_checkout(args: argparse.Namespace):
         else:
             # Derive the commit pin base on ci commit.
             args.repo_hashtag = get_triton_pin(torch_dir)
-            build_env["TRITON_WHEEL_VERSION_SUFFIX"] = f"+git{args.repo_hashtag[:8]}"
+            # Latest triton calculates its own git hash and TRITON_WHEEL_VERSION_SUFFIX
+            # goes after the "+". Older versions must supply their own "+". We just
+            # leave it out entirely to avoid version errors.
+            build_env["TRITON_WHEEL_VERSION_SUFFIX"] = ""
             print(f"Triton CI commit pin: {args.repo_hashtag}")
 
     def _do_hipify(args: argparse.Namespace):


### PR DESCRIPTION
* Includes a couple of workarounds that are unfortunate but would be hard to patch/fix at the root in one step:
  * Some of the environment variables needed to locate ROCm for the PyTorch build (which shouldn't be necessary at all but c'est la vie for now) conflict badly with the clang driver heuristics for locating device bitcode. Workaround is to also manually set the `HIP_DEVICE_LIB_PATH` and curse at the stars about removing all of these legacy special vars.
  * PyTorch at head uses rocm-smi-lib for distributed, and including those headers does not advertise the transitive include dirs for the sysdeps, which causes us to not find libdrm (presumably most old ROCm installs treated that as a system library, whereas we vendor it and need to propagate its header path through find_package). Workaround is to manually add the rocm_sysdeps include and lib dir.
* Adds a `--build-triton` `--no-build-triton` flag for ergonomics when iterating.
* Unconditionally sets `USE_ROCM=ON` in all paths, not just for Windows: new branches require this.
* Adds the `_rocm_init.py` for rocm wheel bootstrapping logic as described in `docs/packaging/python_packaging.md` and also updates that to match how it was actually landed in PyTorch.
* Adds docs indicating that it is valid to checkout the pytorch `nightly` branch, which tracks the most recent pytorch.org nightly build.

This should be NFC on every other pytorch build. Followup needs to add an actual head-on-head nightly build pipeline.

Tested: Local build with gfx94X wheels produced a working torch/torchaudio/torchvision install. I wasn't actually running on a 942 system so it didn't do much from there but did import and let me create tensors. The radeon rocm wheels are known broken today due to a CK bug, so can pick up with those tomorrow.