### PR TITLE
Error on illegal artifact names

### DIFF
--- a/cmake/therock_artifacts.cmake
+++ b/cmake/therock_artifacts.cmake
@@ -15,8 +15,11 @@ function(therock_provide_artifact slice_name)
     "COMPONENTS;SUBPROJECT_DEPS"
   )
 
-  if(${slice_name} MATCHES "_")
-    message(FATAL_ERROR "Artifact slice name '${slice_name}' is not allowed to contain an underscore")
+  if(NOT ${slice_name} MATCHES "^[A-Za-z][A-Za-z0-9-]*$")
+    message(FATAL_ERROR
+      "Artifact slice name '${slice_name}' must start with a letter "
+      "and may only contain alphanumeric characters and dashes"
+    )
   endif()
 
   # Normalize arguments.

--- a/cmake/therock_artifacts.cmake
+++ b/cmake/therock_artifacts.cmake
@@ -15,6 +15,10 @@ function(therock_provide_artifact slice_name)
     "COMPONENTS;SUBPROJECT_DEPS"
   )
 
+  if(${slice_name} MATCHES "_")
+    message(FATAL_ERROR "Artifact slice name '${slice_name}' is not allowed to contain an underscore")
+  endif()
+
   # Normalize arguments.
   set(_target_name "therock-artifact-${slice_name}")
   set(_archive_target_name "therock-archive-${slice_name}")


### PR DESCRIPTION
* An artifact name needs to start with a letter.
* Any following character must be an alphanumeric character or a dash.

This helps to avoid #935 on the CMake side.