### PR TITLE
[ci] - Extending rocthrust test timeout

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -49,7 +49,7 @@ test_matrix = {
     "rocthrust": {
         "job_name": "rocthrust",
         "fetch_artifact_args": "--prim --tests",
-        "timeout_minutes": 5,
+        "timeout_minutes": 15,
         "test_script": f"python {SCRIPT_DIR / 'test_rocthrust.py'}",
         "platform": ["linux"],
     },

--- a/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
@@ -20,7 +20,7 @@ cmd = [
     "--exclude-regex",
     "^copy.hip$|scan.hip",
     "--timeout",
-    "60",
+    "300",
     "--repeat",
     "until-pass:3",
 ]


### PR DESCRIPTION
Noticing rocthrust timeouts for both TheRock and rocm-libraries (issue [rocm-libraries 472](https://github.com/ROCm/rocm-libraries/issues/472))

Extending timeout as tests do not hang, but do not have enough time to complete tests