### PR TITLE
add libdrm-dev to ubuntu build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ instructions and configurations for alternatives.
 
 ```bash
 # Install Ubuntu dependencies
-sudo apt install gfortran git git-lfs ninja-build cmake g++ pkg-config xxd patchelf automake libtool python3-venv python3-dev libegl1-mesa-dev
+sudo apt install gfortran git git-lfs ninja-build cmake g++ pkg-config xxd patchelf automake libtool python3-venv python3-dev libegl1-mesa-dev libdrm-dev
 
 # Clone the repository
 git clone https://github.com/ROCm/TheRock.git


### PR DESCRIPTION
libdrm-dev is requied on Ubuntu 24.04 builds to fix a following build error:

[rocm_smi_lib] therock/base/rocm_smi_lib/include/rocm_smi/kfd_ioctl.h:
  26:10: fatal error: libdrm/drm.h: No such file or directory