### PR TITLE
[windows] Preload compiler DLLs in ROCmLibrariesTest.

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
@@ -61,6 +61,8 @@ class ROCmLibrariesTest(unittest.TestCase):
                 # the "libraries" like hipfft, rocblas, etc. which are siblings
                 # in '_rocm_sdk_libraries_gfx####/bin' while the "compiler" is
                 # in '_rocm_sdk_core/bin'
+                # TODO(#996): track deps in libraries then have the preloader
+                #   recursively get deps instead of hardcoding like this
                 preload_command = "import rocm_sdk; rocm_sdk.preload_libraries('amd_comgr', 'amdhip64', 'hiprtc');"
 
                 # Load each in an isolated process because not all libraries in the tree

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
@@ -55,10 +55,21 @@ class ROCmLibrariesTest(unittest.TestCase):
 
         for so_path in so_paths:
             with self.subTest(msg="Check shared library loads", so_path=so_path):
+
+                # For Windows compatibility, we first preload libraries (DLLs)
+                # that are not co-located. Specifically this is for
+                # the "libraries" like hipfft, rocblas, etc. which are siblings
+                # in '_rocm_sdk_libraries_gfx####/bin' while the "compiler" is
+                # in '_rocm_sdk_core/bin'
+                preload_command = "import rocm_sdk; rocm_sdk.preload_libraries('amd_comgr', 'amdhip64', 'hiprtc');"
+
                 # Load each in an isolated process because not all libraries in the tree
                 # are designed to load into the same process (i.e. LLVM runtime libs,
                 # etc).
-                command = "import ctypes; import sys; ctypes.CDLL(sys.argv[1])"
+                command = (
+                    preload_command
+                    + " import ctypes; import sys; ctypes.CDLL(sys.argv[1])"
+                )
                 subprocess.check_call(
                     [sys.executable, "-P", "-c", command, str(so_path)]
                 )


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/827 (see also the specific bug report at https://github.com/ROCm/TheRock/issues/827#issuecomment-3028742585).

Previously, `rocm-sdk test` failed on my dev machine with errors like `FileNotFoundError: Could not find module 'D:\scratch\therock\python_rocm_2\.venv\Lib\site-packages\_rocm_sdk_libraries_gfx110X_dgpu\bin\hipfft.dll' (or one of its dependencies). Try using the full path with constructor syntax.`

<details><summary>Expand for full logs</summary>
<p>

```
(.venv) λ rocm-sdk test
testCLI (rocm_sdk.tests.base_test.ROCmBaseTest.testCLI) ... ++ Exec [D:\scratch\therock\python_rocm_2]$ 'D:\scratch\therock\python_rocm_2\.venv\Scripts\python.exe' -P -m rocm_sdk --help
ok
testTargets (rocm_sdk.tests.base_test.ROCmBaseTest.testTargets) ... ++ Exec [D:\scratch\therock\python_rocm_2]$ 'D:\scratch\therock\python_rocm_2\.venv\Scripts\python.exe' -P -m rocm_sdk targets
ok
testVersion (rocm_sdk.tests.base_test.ROCmBaseTest.testVersion) ... ++ Exec [D:\scratch\therock\python_rocm_2]$ 'D:\scratch\therock\python_rocm_2\.venv\Scripts\python.exe' -P -m rocm_sdk version
ok
test_initialize_process_check_version (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version) ... ok
test_initialize_process_check_version_asterisk (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_asterisk) ... ok
test_initialize_process_check_version_mismatch (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_mismatch) ... ok
test_initialize_process_check_version_mismatch_warning (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_mismatch_warning) ... ok
test_initialize_process_check_version_pattern (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_pattern) ... ok
test_initialize_process_env_preload_1 (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_1) ... ok
test_initialize_process_env_preload_2_comma (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_2_comma) ... ok
test_initialize_process_env_preload_2_semi (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_2_semi) ... ok
test_initialize_process_preload_libraries (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_preload_libraries) ... ok
testConsoleScripts (rocm_sdk.tests.core_test.ROCmCoreTest.testConsoleScripts) ... ok
testInstallationLayout (rocm_sdk.tests.core_test.ROCmCoreTest.testInstallationLayout)
The `rocm_sdk` and core module must be siblings on disk. ... ok
testPreloadLibraries (rocm_sdk.tests.core_test.ROCmCoreTest.testPreloadLibraries) ... ok
testSharedLibrariesLoad (rocm_sdk.tests.core_test.ROCmCoreTest.testSharedLibrariesLoad) ... ok
testConsoleScripts (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testConsoleScripts) ... ok
testInstallationLayout (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testInstallationLayout)
The `rocm_sdk` and libraries module must be siblings on disk. ... ok
testSharedLibrariesLoad (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testSharedLibrariesLoad) ... Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Program Files\Python312\Lib\ctypes\__init__.py", line 379, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: Could not find module 'D:\scratch\therock\python_rocm_2\.venv\Lib\site-packages\_rocm_sdk_libraries_gfx110X_dgpu\bin\hipfft.dll' (or one of its dependencies). Try using the full path with constructor syntax.

  testSharedLibrariesLoad (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testSharedLibrariesLoad) [Check shared library loads] (so_path=WindowsPath('D:/scratch/therock/python_rocm_2/.venv/Lib/site-packages/_rocm_sdk_libraries_gfx110X_dgpu/bin/hipfft.dll')) ... ERROR
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Program Files\Python312\Lib\ctypes\__init__.py", line 379, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: Could not find module 'D:\scratch\therock\python_rocm_2\.venv\Lib\site-packages\_rocm_sdk_libraries_gfx110X_dgpu\bin\MIOpen.dll' (or one of its dependencies). Try using the full path with constructor syntax.
  testSharedLibrariesLoad (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testSharedLibrariesLoad) [Check shared library loads] (so_path=WindowsPath('D:/scratch/therock/python_rocm_2/.venv/Lib/site-packages/_rocm_sdk_libraries_gfx110X_dgpu/bin/MIOpen.dll')) ... ERROR
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Program Files\Python312\Lib\ctypes\__init__.py", line 379, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: Could not find module 'D:\scratch\therock\python_rocm_2\.venv\Lib\site-packages\_rocm_sdk_libraries_gfx110X_dgpu\bin\rocfft.dll' (or one of its dependencies). Try using the full path with constructor syntax.
  testSharedLibrariesLoad (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testSharedLibrariesLoad) [Check shared library loads] (so_path=WindowsPath('D:/scratch/therock/python_rocm_2/.venv/Lib/site-packages/_rocm_sdk_libraries_gfx110X_dgpu/bin/rocfft.dll')) ... ERROR
testCLIPathBin (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathBin) ... ++ Exec [D:\scratch\therock\python_rocm_2]$ 'D:\scratch\therock\python_rocm_2\.venv\Scripts\python.exe' -P -m rocm_sdk path --bin
ok
testCLIPathCMake (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathCMake) ... ++ Exec [D:\scratch\therock\python_rocm_2]$ 'D:\scratch\therock\python_rocm_2\.venv\Scripts\python.exe' -P -m rocm_sdk path --cmake
ok
testCLIPathRoot (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathRoot) ... ++ Exec [D:\scratch\therock\python_rocm_2]$ 'D:\scratch\therock\python_rocm_2\.venv\Scripts\python.exe' -P -m rocm_sdk path --root
ok
testInstallationLayout (rocm_sdk.tests.devel_test.ROCmDevelTest.testInstallationLayout)
The `rocm_sdk` and devel module must be siblings on disk. ... ok
testRootLLVMSymlinkExists (rocm_sdk.tests.devel_test.ROCmDevelTest.testRootLLVMSymlinkExists) ... skipped 'root LLVM symlink only exists on Linux'
testSharedLibrariesLoad (rocm_sdk.tests.devel_test.ROCmDevelTest.testSharedLibrariesLoad) ... ++ Exec [D:\scratch\therock\python_rocm_2]$ 'D:\scratch\therock\python_rocm_2\.venv\Scripts\python.exe' -P -m rocm_sdk path --root
ok

======================================================================
ERROR: testSharedLibrariesLoad (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testSharedLibrariesLoad) [Check shared library loads] (so_path=WindowsPath('D:/scratch/therock/python_rocm_2/.venv/Lib/site-packages/_rocm_sdk_libraries_gfx110X_dgpu/bin/hipfft.dll'))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\scratch\therock\python_rocm_2\.venv\Lib\site-packages\rocm_sdk\tests\libraries_test.py", line 62, in testSharedLibrariesLoad
    subprocess.check_call(
  File "C:\Program Files\Python312\Lib\subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['D:\\scratch\\therock\\python_rocm_2\\.venv\\Scripts\\python.exe', '-P', '-c', 'import ctypes; import sys; ctypes.CDLL(sys.argv[1])', 'D:\\scratch\\therock\\python_rocm_2\\.venv\\Lib\\site-packages\\_rocm_sdk_libraries_gfx110X_dgpu\\bin\\hipfft.dll']' returned non-zero exit status 1.

======================================================================
ERROR: testSharedLibrariesLoad (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testSharedLibrariesLoad) [Check shared library loads] (so_path=WindowsPath('D:/scratch/therock/python_rocm_2/.venv/Lib/site-packages/_rocm_sdk_libraries_gfx110X_dgpu/bin/MIOpen.dll'))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\scratch\therock\python_rocm_2\.venv\Lib\site-packages\rocm_sdk\tests\libraries_test.py", line 62, in testSharedLibrariesLoad
    subprocess.check_call(
  File "C:\Program Files\Python312\Lib\subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['D:\\scratch\\therock\\python_rocm_2\\.venv\\Scripts\\python.exe', '-P', '-c', 'import ctypes; import sys; ctypes.CDLL(sys.argv[1])', 'D:\\scratch\\therock\\python_rocm_2\\.venv\\Lib\\site-packages\\_rocm_sdk_libraries_gfx110X_dgpu\\bin\\MIOpen.dll']' returned non-zero exit status 1.

======================================================================
ERROR: testSharedLibrariesLoad (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testSharedLibrariesLoad) [Check shared library loads] (so_path=WindowsPath('D:/scratch/therock/python_rocm_2/.venv/Lib/site-packages/_rocm_sdk_libraries_gfx110X_dgpu/bin/rocfft.dll'))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\scratch\therock\python_rocm_2\.venv\Lib\site-packages\rocm_sdk\tests\libraries_test.py", line 62, in testSharedLibrariesLoad
    subprocess.check_call(
  File "C:\Program Files\Python312\Lib\subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['D:\\scratch\\therock\\python_rocm_2\\.venv\\Scripts\\python.exe', '-P', '-c', 'import ctypes; import sys; ctypes.CDLL(sys.argv[1])', 'D:\\scratch\\therock\\python_rocm_2\\.venv\\Lib\\site-packages\\_rocm_sdk_libraries_gfx110X_dgpu\\bin\\rocfft.dll']' returned non-zero exit status 1.

----------------------------------------------------------------------
Ran 25 tests in 26.523s

FAILED (errors=3, skipped=1)
```

</p>
</details> 


Now it passes:
```
(.venv) λ rocm-sdk test
testCLI (rocm_sdk.tests.base_test.ROCmBaseTest.testCLI) ... ++ Exec [D:\scratch\therock\python_rocm_2]$ 'D:\scratch\therock\python_rocm_2\.venv\Scripts\python.exe' -P -m rocm_sdk --help
ok
testTargets (rocm_sdk.tests.base_test.ROCmBaseTest.testTargets) ... ++ Exec [D:\scratch\therock\python_rocm_2]$ 'D:\scratch\therock\python_rocm_2\.venv\Scripts\python.exe' -P -m rocm_sdk targets
ok
testVersion (rocm_sdk.tests.base_test.ROCmBaseTest.testVersion) ... ++ Exec [D:\scratch\therock\python_rocm_2]$ 'D:\scratch\therock\python_rocm_2\.venv\Scripts\python.exe' -P -m rocm_sdk version
ok
test_initialize_process_check_version (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version) ... ok
test_initialize_process_check_version_asterisk (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_asterisk) ... ok
test_initialize_process_check_version_mismatch (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_mismatch) ... ok
test_initialize_process_check_version_mismatch_warning (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_mismatch_warning) ... ok
test_initialize_process_check_version_pattern (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_pattern) ... ok
test_initialize_process_env_preload_1 (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_1) ... ok
test_initialize_process_env_preload_2_comma (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_2_comma) ... ok
test_initialize_process_env_preload_2_semi (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_2_semi) ... ok
test_initialize_process_preload_libraries (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_preload_libraries) ... ok
testConsoleScripts (rocm_sdk.tests.core_test.ROCmCoreTest.testConsoleScripts) ... ok
testInstallationLayout (rocm_sdk.tests.core_test.ROCmCoreTest.testInstallationLayout)
The `rocm_sdk` and core module must be siblings on disk. ... ok
testPreloadLibraries (rocm_sdk.tests.core_test.ROCmCoreTest.testPreloadLibraries) ... ok
testSharedLibrariesLoad (rocm_sdk.tests.core_test.ROCmCoreTest.testSharedLibrariesLoad) ... ok
testConsoleScripts (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testConsoleScripts) ... ok
testInstallationLayout (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testInstallationLayout)
The `rocm_sdk` and libraries module must be siblings on disk. ... ok
testSharedLibrariesLoad (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testSharedLibrariesLoad) ... ok
testCLIPathBin (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathBin) ... ++ Exec [D:\scratch\therock\python_rocm_2]$ 'D:\scratch\therock\python_rocm_2\.venv\Scripts\python.exe' -P -m rocm_sdk path --bin
ok
testCLIPathCMake (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathCMake) ... ++ Exec [D:\scratch\therock\python_rocm_2]$ 'D:\scratch\therock\python_rocm_2\.venv\Scripts\python.exe' -P -m rocm_sdk path --cmake
ok
testCLIPathRoot (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathRoot) ... ++ Exec [D:\scratch\therock\python_rocm_2]$ 'D:\scratch\therock\python_rocm_2\.venv\Scripts\python.exe' -P -m rocm_sdk path --root
ok
testInstallationLayout (rocm_sdk.tests.devel_test.ROCmDevelTest.testInstallationLayout)
The `rocm_sdk` and devel module must be siblings on disk. ... ok
testRootLLVMSymlinkExists (rocm_sdk.tests.devel_test.ROCmDevelTest.testRootLLVMSymlinkExists) ... skipped 'root LLVM symlink only exists on Linux'
testSharedLibrariesLoad (rocm_sdk.tests.devel_test.ROCmDevelTest.testSharedLibrariesLoad) ... ++ Exec [D:\scratch\therock\python_rocm_2]$ 'D:\scratch\therock\python_rocm_2\.venv\Scripts\python.exe' -P -m rocm_sdk path --root
ok

----------------------------------------------------------------------
Ran 25 tests in 3.727s

OK (skipped=1)
```