### PR TITLE
Trigger building PyTorch wheels via portable linux packages workflow

### DIFF
--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -1,8 +1,11 @@
 name: Release Linux PyTorch Wheels
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
+      amdgpu_family:
+        required: true
+        type: string
       release_type:
         description: The type of release to build ("nightly", or "dev")
         type: string
@@ -15,11 +18,30 @@ on:
         description: CloudFront URL pointing to Python index
         type: string
         default: "d25kgig7rdsyks.cloudfront.net/v2"
-      # rocm_version:
-      #   description: ROCm version to install (e.g. "==1.0", ">1.0")
-      #   type: string
-  schedule:
-    - cron: "0 2 * * *"  # Nightly at 2 AM UTC
+      rocm_version:
+        description: ROCm version to pip install
+        type: string
+  workflow_dispatch:
+    inputs:
+      amdgpu_family:
+        required: true
+        type: string
+      release_type:
+        description: The type of release to build ("nightly", or "dev")
+        type: string
+        default: "dev"
+      s3_subdir:
+        description: S3 subdirectory, not including the GPU-family
+        type: string
+        default: "v2"
+      cloudfront_url:
+        description: CloudFront URL pointing to Python index
+        type: string
+        default: "d25kgig7rdsyks.cloudfront.net/v2"
+      rocm_version:
+        description: ROCm version to pip install
+        type: string
+
 
 permissions:
   id-token: write
@@ -30,17 +52,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - { AMDGPU_FAMILIES: gfx94X-dcgpu }
-          - { AMDGPU_FAMILIES: gfx110X-dgpu }
-          - { AMDGPU_FAMILIES: gfx120X-all }
         python_version: ["cp311-cp311", "cp312-cp312", cp313-cp313]
 
     uses: ./.github/workflows/build_linux_pytorch_wheels.yml
     with:
-      amdgpu_family: ${{ matrix.config.AMDGPU_FAMILIES }}
+      amdgpu_family: ${{ inputs.amdgpu_family }}
       python_version: ${{ matrix.python_version }}
-      release_type: ${{ inputs.release_type || 'nightly' }}
-      s3_subdir: ${{ inputs.s3_subdir || 'v2' }}
-      cloudfront_url: ${{ inputs.cloudfront_url  || 'd2awnip2yjpvqn.cloudfront.net/v2' }}
-      # rocm_version: ${{ inputs.rocm_version }}
+      release_type: ${{ inputs.release_type }}
+      s3_subdir: ${{ inputs.s3_subdir }}
+      cloudfront_url: ${{ inputs.cloudfront_url }}
+      rocm_version: ${{ inputs.rocm_version }}

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -4,8 +4,8 @@ on:
   # Trigger from another workflow (typically to build dev packages and then test them)
   workflow_call:
     inputs:
-      build_type:
-        description: The type of build version to produce ("rc", or "dev")
+      release_type:
+        description: The type of build version to produce ("nightly", or "dev")
         type: string
         default: "dev"
       package_suffix:
@@ -17,10 +17,10 @@ on:
   # Trigger manually (typically to test the workflow or manually build a release [candidate])
   workflow_dispatch:
     inputs:
-      build_type:
-        description: The type of build version to produce ("rc", or "dev")
+      release_type:
+        description: The type of build version to produce ("nightly", or "dev")
         type: string
-        default: "rc"
+        default: "dev"
       package_suffix:
         type: string
       s3_subdir:
@@ -42,10 +42,14 @@ jobs:
   setup_metadata:
     if: ${{ github.repository_owner == 'ROCm' || github.event_name != 'schedule' }}
     runs-on: ubuntu-24.04
+    env:
+      S3_SUBDIR: ${{ inputs.s3_subdir || 'v2' }}
+      release_type: ${{ inputs.release_type || 'nightly' }}
     outputs:
       version: ${{ steps.release_information.outputs.version }}
-      release_type: ${{ steps.release_information.outputs.type }}
+      release_type: ${{ env.release_type }}
       package_targets: ${{ steps.configure.outputs.package_targets }}
+      cloudfront_url: ${{ steps.release_information.outputs.cloudfront_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -56,25 +60,25 @@ jobs:
 
       # Compute version suffix based on inputs (default to 'rc')
       - name: Set variables for nightly release
-        if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}
+        if: ${{ env.release_type == 'nightly' }}
         run: |
           version_suffix="$(printf 'rc%(%Y%m%d)T')"
           echo "version_suffix=${version_suffix}" >> $GITHUB_ENV
-          echo "release_type=nightly" >> $GITHUB_ENV
+          echo "cloudfront_base_url=d2awnip2yjpvqn.cloudfront.net" >> $GITHUB_ENV
 
       - name: Set variables for development release
-        if: ${{ inputs.build_type == 'dev' }}
+        if: ${{ env.release_type == 'dev' }}
         run: |
           version_suffix=".dev0+${{ github.sha }}"
           echo "version_suffix=${version_suffix}" >> $GITHUB_ENV
-          echo "release_type=dev" >> $GITHUB_ENV
+          echo "cloudfront_base_url=d25kgig7rdsyks.cloudfront.net" >> $GITHUB_ENV
 
       - name: Generate release information
         id: release_information
         run: |
           base_version=$(jq -r '.["rocm-version"]' version.json)
           echo "version=${base_version}${version_suffix}" >> $GITHUB_OUTPUT
-          echo "type=${release_type}" >> $GITHUB_OUTPUT
+          echo "cloudfront_url=${cloudfront_base_url}/${{ env.S3_SUBDIR }}" >> $GITHUB_OUTPUT
 
       - name: Generating package target matrix
         id: configure
@@ -208,11 +212,24 @@ jobs:
           python ./build_tools/third_party/s3_management/manage.py ${{ env.S3_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}
 
       - name: Trigger testing nightly tarball
-        if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}
+        if: ${{ env.RELEASE_TYPE == 'nightly' }}
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
         with:
           workflow: test_release_packages.yml
           inputs: '{ "version": "${{ needs.setup_metadata.outputs.version }}", "tag": "nightly-tarball", "file_name": "${{ env.FILE_NAME }}", "target": "${{ matrix.target_bundle.amdgpu_family }}" }'
+
+      - name: Trigger building PyTorch wheels
+        if: ${{ github.repository_owner == 'ROCm' }}
+        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
+        with:
+          workflow: release_linux_pytorch_wheels.yml
+          inputs: |
+            { "amdgpu_family": "${{ matrix.target_bundle.amdgpu_family }}",
+              "release_type": "${{ env.RELEASE_TYPE }}",
+              "s3_subdir": "${{ env.S3_SUBDIR }}",
+              "cloudfront_url": "${{ needs.setup_metadata.outputs.cloudfront_url }}",
+              "rocm_version": "${{ needs.setup_metadata.outputs.version }}"
+            }
 
       - name: Save cache
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3


### PR DESCRIPTION
Till now, the `release_linux_pytorch_wheels.yml` workflow was run on schedule. As a consequence `build_linux_pytorch_wheels.yml` picked up the latest available ROCm Python packages, not necessarily matching the version number later encoded in the PyTorch wheel.

This is revised and instead of building PyTorch wheels on schedule, the build is triggered from the workflow used to build the ROCm Python packages. To make sure the correct nightly or dev version is used, or rather pip installed, the explicit version is passed by the triggering workflow.
As a side effect this also enables building PyTorch wheels for gfx950.

We may want to further revise this later, as there is no clear and easy to follow link between the triggering and the triggered workflow.

Closes #923