### PR TITLE
Deactivate post-submit tests on gfx950

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -27,7 +27,7 @@ amdgpu_family_info_matrix_presubmit = {
 amdgpu_family_info_matrix_postsubmit = {
     "gfx950": {
         "linux": {
-            "test-runs-on": "linux-mi355-1gpu-ossci-rocm",
+            "test-runs-on": "",  # removed due to failing sanity check, label is "linux-mi355-1gpu-ossci-rocm"
             "family": "gfx950-dcgpu",
             "pytorch-target": "gfx950",
         }


### PR DESCRIPTION
Deactivating tests as the sanity test is failing with
```
FileNotFoundError: [Errno 2] No such file or directory: './hipcc_check'
..
FAILED tests/test_rocm_sanity.py::TestROCmSanity::test_hip_printf - FileNotFoundError: [Errno 2] No such file or directory: './hipcc_check'
```