### PR TITLE
Rework `test_pytorch_wheels` workflow

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -20,6 +20,9 @@ on:
         required: true
         type: string
         default: "3.12"
+      torch_version:
+        required: true
+        type: string
 
   workflow_call:
     inputs:
@@ -35,6 +38,9 @@ on:
       python_version:
         required: true
         type: string
+      torch_version:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -43,6 +49,10 @@ jobs:
   test_wheels:
     name: Test PyTorch Wheels | ${{ inputs.amdgpu_families }}
     runs-on: ${{ inputs.test_runs_on }}
+    env:
+      VENV_DIR: ${{ github.workspace }}/venv
+      INDEX_URL: https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_families }}/
+      TORCH_VERSION: ${{ inputs.torch_version }}
 
     steps:
       - name: Checkout
@@ -54,9 +64,6 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - name: Set up virtual environment and install dependencies
-        env:
-          VENV_DIR: ${{ github.workspace }}/venv
-          INDEX_URL: https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_families }}/
         working-directory: ${{ github.workspace }}
         run: |
           bash external-builds/pytorch/setup_venv.sh "$VENV_DIR"
@@ -68,9 +75,6 @@ jobs:
           python external-builds/pytorch/pytorch_torch_repo.py checkout --no-hipify --no-patch
 
       - name: Run PyTorch tests
-        env:
-          VENV_DIR: ${{ github.workspace }}/venv
-          INDEX_URL: https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_families }}/
         working-directory: ${{ github.workspace }}
         run: |
           source "$VENV_DIR/bin/activate"

--- a/external-builds/pytorch/pytorch_audio_repo.py
+++ b/external-builds/pytorch/pytorch_audio_repo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Checks out and builds PyTorch against a built from source ROCM SDK.
+"""Checks out PyTorch Audio.
 
 There is nothing that this script does which you couldn't do by hand, but because of
 the following, getting PyTorch sources ready to build with ToT TheRock built SDKs
@@ -14,7 +14,6 @@ consists of multiple steps:
 Primary usage:
 
     ./pytorch_audio_repo.py checkout
-    ./pytorch_audio_repo.py develop
 
 The checkout process combines the following activities:
 

--- a/external-builds/pytorch/pytorch_torch_repo.py
+++ b/external-builds/pytorch/pytorch_torch_repo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Checks out and builds PyTorch against a built from source ROCM SDK.
+"""Checks out PyTorch.
 
 There is nothing that this script does which you couldn't do by hand, but because of
 the following, getting PyTorch sources ready to build with ToT TheRock built SDKs
@@ -14,7 +14,6 @@ consists of multiple steps:
 Primary usage:
 
     ./pytorch_torch_repo.py checkout
-    ./pytorch_torch_repo.py develop
 
 The checkout process combines the following activities:
 

--- a/external-builds/pytorch/pytorch_vision_repo.py
+++ b/external-builds/pytorch/pytorch_vision_repo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Checks out and builds PyTorch against a built from source ROCM SDK.
+"""Checks out PyTorch Vision.
 
 There is nothing that this script does which you couldn't do by hand, but because of
 the following, getting PyTorch sources ready to build with ToT TheRock built SDKs
@@ -14,7 +14,6 @@ consists of multiple steps:
 Primary usage:
 
     ./pytorch_vision_repo.py checkout
-    ./pytorch_vision_repo.py develop
 
 The checkout process combines the following activities:
 

--- a/external-builds/pytorch/run_linux_pytorch_tests.sh
+++ b/external-builds/pytorch/run_linux_pytorch_tests.sh
@@ -6,23 +6,7 @@ set -euxo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(realpath "$SCRIPT_DIR/../..")"
 PYTORCH_DIR="$ROOT_DIR/external-builds/pytorch/pytorch"
-VENV_DIR="$ROOT_DIR/venv"
 K_EXPR_SCRIPT="$SCRIPT_DIR/skipped_tests.py"
-
-# Ensure INDEX_URL is set
-if [[ -z "${INDEX_URL:-}" ]]; then
-  echo "ERROR: INDEX_URL environment variable must be set"
-  exit 1
-fi
-
-# Create and activate virtual environment
-python -m venv "$VENV_DIR"
-source "$VENV_DIR/bin/activate"
-
-# Install requirements and PyTorch wheel
-pip install --upgrade pip
-pip install -r "$SCRIPT_DIR/requirements-test.txt"
-pip install --index-url "$INDEX_URL" torch --no-cache-dir --force-reinstall
 
 # Set up test environment
 export PYTORCH_PRINT_REPRO_ON_FAILURE=0

--- a/external-builds/pytorch/setup_venv.sh
+++ b/external-builds/pytorch/setup_venv.sh
@@ -10,18 +10,6 @@ VENV_DIR="${1:-$(realpath "$(dirname "${BASH_SOURCE[0]}")/../..")/venv}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REQUIREMENTS_FILE="${SCRIPT_DIR}/requirements-test.txt"
 
-# Ensure INDEX_URL is set
-if [[ -z "${INDEX_URL:-}" ]]; then
-  echo "ERROR: INDEX_URL environment variable must be set"
-  exit 1
-fi
-
-# Ensure TORCH_VERSION is set
-if [[ -z "${TORCH_VERION:-}" ]]; then
-  echo "ERROR: TORCH_VERSION environment variable must be set"
-  exit 1
-fi
-
 # Create and activate virtual environment
 python -m venv "$VENV_DIR"
 source "$VENV_DIR/bin/activate"
@@ -30,4 +18,4 @@ source "$VENV_DIR/bin/activate"
 pip install --upgrade pip
 pip install -r "$REQUIREMENTS_FILE"
 # Install torch, overwriting any previously installed versions.
-pip install --index-url "${INDEX_URL}" torch==${TORCH_VERSION} --no-cache-dir --force-reinstall
+pip install --index-url "${INDEX_URL?}" torch==${TORCH_VERSION?} --no-cache-dir --force-reinstall

--- a/external-builds/pytorch/setup_venv.sh
+++ b/external-builds/pytorch/setup_venv.sh
@@ -10,11 +10,24 @@ VENV_DIR="${1:-$(realpath "$(dirname "${BASH_SOURCE[0]}")/../..")/venv}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REQUIREMENTS_FILE="${SCRIPT_DIR}/requirements-test.txt"
 
-# Create virtual environment
+# Ensure INDEX_URL is set
+if [[ -z "${INDEX_URL:-}" ]]; then
+  echo "ERROR: INDEX_URL environment variable must be set"
+  exit 1
+fi
+
+# Ensure TORCH_VERSION is set
+if [[ -z "${TORCH_VERION:-}" ]]; then
+  echo "ERROR: TORCH_VERSION environment variable must be set"
+  exit 1
+fi
+
+# Create and activate virtual environment
 python -m venv "$VENV_DIR"
+source "$VENV_DIR/bin/activate"
 
 # Install dependencies
-"$VENV_DIR/bin/pip" install --upgrade pip
-"$VENV_DIR/bin/pip" install -r "$REQUIREMENTS_FILE"
+pip install --upgrade pip
+pip install -r "$REQUIREMENTS_FILE"
 # Install torch, overwriting any previously installed versions.
-"$VENV_DIR/bin/pip" install --index-url "$INDEX_URL" torch --no-cache-dir --force-reinstall
+pip install --index-url "${INDEX_URL}" torch==${TORCH_VERSION} --no-cache-dir --force-reinstall


### PR DESCRIPTION
* Moves venv creation to `setup_venv.sh`, it should not be handled in `run_linux_pytorch_tests.sh`.
* Do not longer install packages in `run_linux_pytorch_tests.py` as these are installed in `setup_venv.sh`.
* Cleans up the description in `pytorch_torch_repo.py`.
* Moves environment variables.
* Modifies the workflow and script to install a specific torch version.