### PR TITLE
[windows][docs] Refresh windows_support.md table.

### DIFF
--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -23,46 +23,47 @@ This table tracks current support status for each subproject in TheRock on
 Windows. Some subprojects may need extra patches to build within TheRock (on
 mainline, in open source, using MSVC, etc.).
 
-| Component subset | Subproject                                                                   | Supported | Notes                                                                                |
-| ---------------- | ---------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------ |
-| base             | aux-overlay                                                                  | ✅        |                                                                                      |
-| base             | [rocm-cmake](https://github.com/ROCm/rocm-cmake)                             | ✅        |                                                                                      |
-| base             | [rocm-core](https://github.com/ROCm/rocm-core)                               | ✅        | No shared libraries                                                                  |
-| base             | [rocm_smi_lib](https://github.com/ROCm/rocm_smi_lib)                         | ❌        | Unsupported                                                                          |
-| base             | [rocprofiler-register](https://github.com/ROCm/rocprofiler-register)         | ❌        | Unsupported                                                                          |
-| base             | [rocm-half](https://github.com/ROCm/half)                                    | ✅        |                                                                                      |
-|                  |                                                                              |           |                                                                                      |
-| compiler         | [amd-llvm](https://github.com/ROCm/llvm-project)                             | ✅        | No shared libraries, limited runtimes                                                |
-| compiler         | [amd-comgr](https://github.com/ROCm/llvm-project/tree/amd-staging/amd/comgr) | ✅        | No shared libraries                                                                  |
-| compiler         | [hipcc](https://github.com/ROCm/llvm-project/tree/amd-staging/amd/hipcc)     | ✅        | Unable to find files at runtime ([#410](https://github.com/ROCm/TheRock/issues/410)) |
-| compiler         | [hipify](https://github.com/ROCm/HIPIFY)                                     | ✅        | Patched for Ninja                                                                    |
-|                  |                                                                              |           |                                                                                      |
-| core             | [ROCR-Runtime](https://github.com/ROCm/ROCR-Runtime)                         | ❌        | Unsupported                                                                          |
-| core             | [rocminfo](https://github.com/ROCm/rocminfo)                                 | ❌        | Unsupported                                                                          |
-| core             | [clr](https://github.com/ROCm/clr)                                           | 🟡        | Needs a folder with prebuilt static libraries                                        |
-|                  |                                                                              |           |                                                                                      |
-| profiler         | [rocprofiler-sdk](https://github.com/ROCm/rocprofiler-sdk)                   | ❌        | Unsupported                                                                          |
-|                  |                                                                              |           |                                                                                      |
-| comm-libs        | [rccl](https://github.com/ROCm/rccl)                                         | ❌        | Unsupported                                                                          |
-|                  |                                                                              |           |                                                                                      |
-| math-libs        | [rocRAND](https://github.com/ROCm/rocRAND)                                   | ✅        |                                                                                      |
-| math-libs        | [hipRAND](https://github.com/ROCm/hipRAND)                                   | ✅        |                                                                                      |
-| math-libs        | [rocPRIM](https://github.com/ROCm/rocPRIM)                                   | ✅        |                                                                                      |
-| math-libs        | [hipCUB](https://github.com/ROCm/hipCUB)                                     | ✅        |                                                                                      |
-| math-libs        | [rocThrust](https://github.com/ROCm/rocThrust)                               | ✅        |                                                                                      |
-| math-libs        | [rocFFT](https://github.com/ROCm/rocFFT)                                     | ✅        | No shared libraries                                                                  |
-| math-libs        | [hipFFT](https://github.com/ROCm/hipFFT)                                     | ✅        | No shared libraries                                                                  |
-| math-libs (BLAS) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ✅        |                                                                                      |
-| math-libs (BLAS) | [rocRoller](https://github.com/ROCm/rocRoller)                               | ❌        | Unsupported                                                                          |
-| math-libs (BLAS) | [hipBLASLt](https://github.com/ROCm/hipBLASLt)                               | ✅        |                                                                                      |
-| math-libs (BLAS) | [rocBLAS](https://github.com/ROCm/rocBLAS)                                   | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
-| math-libs (BLAS) | [rocSPARSE](https://github.com/ROCm/rocSPARSE)                               | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
-| math-libs (BLAS) | [hipSPARSE](https://github.com/ROCm/hipSPARSE)                               | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
-| math-libs (BLAS) | [rocSOLVER](https://github.com/ROCm/rocSOLVER)                               | ✅        |                                                                                      |
-| math-libs (BLAS) | [hipSOLVER](https://github.com/ROCm/hipSOLVER)                               | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
-| math-libs (BLAS) | [hipBLAS](https://github.com/ROCm/hipBLAS)                                   | ✅        | Tests need dlls ([#513](https://github.com/ROCm/TheRock/issues/513))                 |
-|                  |                                                                              |           |                                                                                      |
-| ml-libs          | [MIOpen](https://github.com/ROCm/MIOpen)                                     | ✅        |                                                                                      |
+| Component subset | Subproject                                                                   | Supported | Notes                                         |
+| ---------------- | ---------------------------------------------------------------------------- | --------- | --------------------------------------------- |
+| base             | aux-overlay                                                                  | ✅        |                                               |
+| base             | [rocm-cmake](https://github.com/ROCm/rocm-cmake)                             | ✅        |                                               |
+| base             | [rocm-core](https://github.com/ROCm/rocm-core)                               | ✅        |                                               |
+| base             | [rocm_smi_lib](https://github.com/ROCm/rocm_smi_lib)                         | ❌        | Unsupported                                   |
+| base             | [rocprofiler-register](https://github.com/ROCm/rocprofiler-register)         | ❌        | Unsupported                                   |
+| base             | [rocm-half](https://github.com/ROCm/half)                                    | ✅        |                                               |
+|                  |                                                                              |           |                                               |
+| compiler         | [amd-llvm](https://github.com/ROCm/llvm-project)                             | ✅        | Limited runtimes                              |
+| compiler         | [amd-comgr](https://github.com/ROCm/llvm-project/tree/amd-staging/amd/comgr) | ✅        |                                               |
+| compiler         | [hipcc](https://github.com/ROCm/llvm-project/tree/amd-staging/amd/hipcc)     | ✅        |                                               |
+| compiler         | [hipify](https://github.com/ROCm/HIPIFY)                                     | ✅        |                                               |
+|                  |                                                                              |           |                                               |
+| core             | [ROCR-Runtime](https://github.com/ROCm/ROCR-Runtime)                         | ❌        | Unsupported                                   |
+| core             | [rocminfo](https://github.com/ROCm/rocminfo)                                 | ❌        | Unsupported                                   |
+| core             | [clr](https://github.com/ROCm/clr)                                           | 🟡        | Needs a folder with prebuilt static libraries |
+|                  |                                                                              |           |                                               |
+| profiler         | [rocprofiler-sdk](https://github.com/ROCm/rocprofiler-sdk)                   | ❌        | Unsupported                                   |
+|                  |                                                                              |           |                                               |
+| comm-libs        | [rccl](https://github.com/ROCm/rccl)                                         | ❌        | Unsupported                                   |
+|                  |                                                                              |           |                                               |
+| math-libs        | [rocRAND](https://github.com/ROCm/rocRAND)                                   | ✅        |                                               |
+| math-libs        | [hipRAND](https://github.com/ROCm/hipRAND)                                   | ✅        |                                               |
+| math-libs        | [rocPRIM](https://github.com/ROCm/rocPRIM)                                   | ✅        |                                               |
+| math-libs        | [hipCUB](https://github.com/ROCm/hipCUB)                                     | ✅        |                                               |
+| math-libs        | [rocThrust](https://github.com/ROCm/rocThrust)                               | ✅        |                                               |
+| math-libs        | [rocFFT](https://github.com/ROCm/rocFFT)                                     | ✅        |                                               |
+| math-libs        | [hipFFT](https://github.com/ROCm/hipFFT)                                     | ✅        |                                               |
+| math-libs (BLAS) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ✅        |                                               |
+| math-libs (BLAS) | [rocRoller](https://github.com/ROCm/rocRoller)                               | ❌        | Unsupported                                   |
+| math-libs (BLAS) | [hipBLASLt](https://github.com/ROCm/hipBLASLt)                               | ✅        |                                               |
+| math-libs (BLAS) | [rocBLAS](https://github.com/ROCm/rocBLAS)                                   | ✅        |                                               |
+| math-libs (BLAS) | [rocSPARSE](https://github.com/ROCm/rocSPARSE)                               | ✅        |                                               |
+| math-libs (BLAS) | [hipSPARSE](https://github.com/ROCm/hipSPARSE)                               | ✅        |                                               |
+| math-libs (BLAS) | [rocSOLVER](https://github.com/ROCm/rocSOLVER)                               | ✅        |                                               |
+| math-libs (BLAS) | [hipSOLVER](https://github.com/ROCm/hipSOLVER)                               | ✅        |                                               |
+| math-libs (BLAS) | [hipBLAS](https://github.com/ROCm/hipBLAS)                                   | ✅        |                                               |
+|                  |                                                                              |           |                                               |
+| ml-libs          | [Composable Kernel](https://github.com/ROCm/composable_kernel)               | ❌        | Unsupported                                   |
+| ml-libs          | [MIOpen](https://github.com/ROCm/MIOpen)                                     | ✅        |                                               |
 
 ## Building TheRock from source
 

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -23,47 +23,48 @@ This table tracks current support status for each subproject in TheRock on
 Windows. Some subprojects may need extra patches to build within TheRock (on
 mainline, in open source, using MSVC, etc.).
 
-| Component subset | Subproject                                                                   | Supported | Notes                                         |
-| ---------------- | ---------------------------------------------------------------------------- | --------- | --------------------------------------------- |
-| base             | aux-overlay                                                                  | ✅        |                                               |
-| base             | [rocm-cmake](https://github.com/ROCm/rocm-cmake)                             | ✅        |                                               |
-| base             | [rocm-core](https://github.com/ROCm/rocm-core)                               | ✅        |                                               |
-| base             | [rocm_smi_lib](https://github.com/ROCm/rocm_smi_lib)                         | ❌        | Unsupported                                   |
-| base             | [rocprofiler-register](https://github.com/ROCm/rocprofiler-register)         | ❌        | Unsupported                                   |
-| base             | [rocm-half](https://github.com/ROCm/half)                                    | ✅        |                                               |
-|                  |                                                                              |           |                                               |
-| compiler         | [amd-llvm](https://github.com/ROCm/llvm-project)                             | ✅        | Limited runtimes                              |
-| compiler         | [amd-comgr](https://github.com/ROCm/llvm-project/tree/amd-staging/amd/comgr) | ✅        |                                               |
-| compiler         | [hipcc](https://github.com/ROCm/llvm-project/tree/amd-staging/amd/hipcc)     | ✅        |                                               |
-| compiler         | [hipify](https://github.com/ROCm/HIPIFY)                                     | ✅        |                                               |
-|                  |                                                                              |           |                                               |
-| core             | [ROCR-Runtime](https://github.com/ROCm/ROCR-Runtime)                         | ❌        | Unsupported                                   |
-| core             | [rocminfo](https://github.com/ROCm/rocminfo)                                 | ❌        | Unsupported                                   |
-| core             | [clr](https://github.com/ROCm/clr)                                           | 🟡        | Needs a folder with prebuilt static libraries |
-|                  |                                                                              |           |                                               |
-| profiler         | [rocprofiler-sdk](https://github.com/ROCm/rocprofiler-sdk)                   | ❌        | Unsupported                                   |
-|                  |                                                                              |           |                                               |
-| comm-libs        | [rccl](https://github.com/ROCm/rccl)                                         | ❌        | Unsupported                                   |
-|                  |                                                                              |           |                                               |
-| math-libs        | [rocRAND](https://github.com/ROCm/rocRAND)                                   | ✅        |                                               |
-| math-libs        | [hipRAND](https://github.com/ROCm/hipRAND)                                   | ✅        |                                               |
-| math-libs        | [rocPRIM](https://github.com/ROCm/rocPRIM)                                   | ✅        |                                               |
-| math-libs        | [hipCUB](https://github.com/ROCm/hipCUB)                                     | ✅        |                                               |
-| math-libs        | [rocThrust](https://github.com/ROCm/rocThrust)                               | ✅        |                                               |
-| math-libs        | [rocFFT](https://github.com/ROCm/rocFFT)                                     | ✅        |                                               |
-| math-libs        | [hipFFT](https://github.com/ROCm/hipFFT)                                     | ✅        |                                               |
-| math-libs (BLAS) | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ✅        |                                               |
-| math-libs (BLAS) | [rocRoller](https://github.com/ROCm/rocRoller)                               | ❌        | Unsupported                                   |
-| math-libs (BLAS) | [hipBLASLt](https://github.com/ROCm/hipBLASLt)                               | ✅        |                                               |
-| math-libs (BLAS) | [rocBLAS](https://github.com/ROCm/rocBLAS)                                   | ✅        |                                               |
-| math-libs (BLAS) | [rocSPARSE](https://github.com/ROCm/rocSPARSE)                               | ✅        |                                               |
-| math-libs (BLAS) | [hipSPARSE](https://github.com/ROCm/hipSPARSE)                               | ✅        |                                               |
-| math-libs (BLAS) | [rocSOLVER](https://github.com/ROCm/rocSOLVER)                               | ✅        |                                               |
-| math-libs (BLAS) | [hipSOLVER](https://github.com/ROCm/hipSOLVER)                               | ✅        |                                               |
-| math-libs (BLAS) | [hipBLAS](https://github.com/ROCm/hipBLAS)                                   | ✅        |                                               |
-|                  |                                                                              |           |                                               |
-| ml-libs          | [Composable Kernel](https://github.com/ROCm/composable_kernel)               | ❌        | Unsupported                                   |
-| ml-libs          | [MIOpen](https://github.com/ROCm/MIOpen)                                     | ✅        |                                               |
+| Component subset    | Subproject                                                                   | Supported | Notes                                         |
+| ------------------- | ---------------------------------------------------------------------------- | --------- | --------------------------------------------- |
+| base                | aux-overlay                                                                  | ✅        |                                               |
+| base                | [rocm-cmake](https://github.com/ROCm/rocm-cmake)                             | ✅        |                                               |
+| base                | [rocm-core](https://github.com/ROCm/rocm-core)                               | ✅        |                                               |
+| base                | [rocm_smi_lib](https://github.com/ROCm/rocm_smi_lib)                         | ❌        | Unsupported                                   |
+| base                | [rocprofiler-register](https://github.com/ROCm/rocprofiler-register)         | ❌        | Unsupported                                   |
+| base                | [rocm-half](https://github.com/ROCm/half)                                    | ✅        |                                               |
+|                     |                                                                              |           |                                               |
+| compiler            | [amd-llvm](https://github.com/ROCm/llvm-project)                             | ✅        | Limited runtimes                              |
+| compiler            | [amd-comgr](https://github.com/ROCm/llvm-project/tree/amd-staging/amd/comgr) | ✅        |                                               |
+| compiler            | [hipcc](https://github.com/ROCm/llvm-project/tree/amd-staging/amd/hipcc)     | ✅        |                                               |
+| compiler            | [hipify](https://github.com/ROCm/HIPIFY)                                     | ✅        |                                               |
+|                     |                                                                              |           |                                               |
+| core                | [ROCR-Runtime](https://github.com/ROCm/ROCR-Runtime)                         | ❌        | Unsupported                                   |
+| core                | [rocminfo](https://github.com/ROCm/rocminfo)                                 | ❌        | Unsupported                                   |
+| core                | [clr](https://github.com/ROCm/clr)                                           | 🟡        | Needs a folder with prebuilt static libraries |
+|                     |                                                                              |           |                                               |
+| profiler            | [rocprofiler-sdk](https://github.com/ROCm/rocprofiler-sdk)                   | ❌        | Unsupported                                   |
+|                     |                                                                              |           |                                               |
+| comm-libs           | [rccl](https://github.com/ROCm/rccl)                                         | ❌        | Unsupported                                   |
+|                     |                                                                              |           |                                               |
+| math-libs           | [rocRAND](https://github.com/ROCm/rocRAND)                                   | ✅        |                                               |
+| math-libs           | [hipRAND](https://github.com/ROCm/hipRAND)                                   | ✅        |                                               |
+| math-libs           | [rocPRIM](https://github.com/ROCm/rocPRIM)                                   | ✅        |                                               |
+| math-libs           | [hipCUB](https://github.com/ROCm/hipCUB)                                     | ✅        |                                               |
+| math-libs           | [rocThrust](https://github.com/ROCm/rocThrust)                               | ✅        |                                               |
+| math-libs           | [rocFFT](https://github.com/ROCm/rocFFT)                                     | ✅        |                                               |
+| math-libs           | [hipFFT](https://github.com/ROCm/hipFFT)                                     | ✅        |                                               |
+| math-libs (support) | [mxDataGenerator](https://github.com/ROCm/mxDataGenerator)                   | ❌        | Unsupported                                   |
+| math-libs (BLAS)    | [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)                     | ✅        |                                               |
+| math-libs (BLAS)    | [rocRoller](https://github.com/ROCm/rocRoller)                               | ❌        | Unsupported                                   |
+| math-libs (BLAS)    | [hipBLASLt](https://github.com/ROCm/hipBLASLt)                               | ✅        |                                               |
+| math-libs (BLAS)    | [rocBLAS](https://github.com/ROCm/rocBLAS)                                   | ✅        |                                               |
+| math-libs (BLAS)    | [rocSPARSE](https://github.com/ROCm/rocSPARSE)                               | ✅        |                                               |
+| math-libs (BLAS)    | [hipSPARSE](https://github.com/ROCm/hipSPARSE)                               | ✅        |                                               |
+| math-libs (BLAS)    | [rocSOLVER](https://github.com/ROCm/rocSOLVER)                               | ✅        |                                               |
+| math-libs (BLAS)    | [hipSOLVER](https://github.com/ROCm/hipSOLVER)                               | ✅        |                                               |
+| math-libs (BLAS)    | [hipBLAS](https://github.com/ROCm/hipBLAS)                                   | ✅        |                                               |
+|                     |                                                                              |           |                                               |
+| ml-libs             | [Composable Kernel](https://github.com/ROCm/composable_kernel)               | ❌        | Unsupported                                   |
+| ml-libs             | [MIOpen](https://github.com/ROCm/MIOpen)                                     | ✅        |                                               |
 
 ## Building TheRock from source
 


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/513. Progress on https://github.com/ROCm/TheRock/issues/36.

* DLLs are available for tests _in the dist folder_
* HIPIFY ninja patch was dropped
* "No shared libraries" is no longer useful to include in the table... I think
* Added Composable Kernel and mxDataGenerator as unsupported