### PR TITLE
[torch][windows] Build Windows release PyTorch wheels.

### DIFF
--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -3,26 +3,58 @@ name: Build Windows PyTorch Wheels
 on:
   workflow_call:
     inputs:
-      AMDGPU_FAMILIES:
+      amdgpu_family:
         required: true
         type: string
       python_version:
         required: true
         type: string
-      s3_bucket:
+      release_type:
+        description: The type of release to build ("nightly", or "dev")
         required: true
+        type: string
+      s3_subdir:
+        description: S3 subdirectory, not including the GPU-family
+        required: true
+        type: string
+      cloudfront_url:
+        description: CloudFront URL pointing to Python index
+        required: true
+        type: string
+      rocm_version:
+        description: ROCm version to pip install
         type: string
   workflow_dispatch:
     inputs:
-      AMDGPU_FAMILIES:
+      amdgpu_family:
         required: true
         type: string
+        # default: "gfx110X-dgpu"
+        default: "gfx1151"
       python_version:
         required: true
         type: string
-      s3_bucket:
-        required: true
+        default: "3.12"
+      release_type:
+        description: The type of release to build ("nightly", or "dev")
         type: string
+        default: "dev"
+      s3_subdir:
+        description: S3 subdirectory, not including the GPU-family
+        type: string
+        default: "v2"
+      cloudfront_url:
+        description: CloudFront base URL pointing to Python index
+        type: string
+        # nightly
+        # default: "d2awnip2yjpvqn.cloudfront.net/v2"
+
+        # dev
+        default: "d25kgig7rdsyks.cloudfront.net/v2"
+      rocm_version:
+        description: ROCm version to pip install
+        type: string
+        default: 7.0.0.dev0+98ed4ad77f79822694ec01a36180ec3b95f4bd00
 
 permissions:
   id-token: write
@@ -33,10 +65,11 @@ jobs:
     name: Build Windows PyTorch Wheels | ${{ inputs.AMDGPU_FAMILIES }} | Python ${{ inputs.python_version }}
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-windows-scale-rocm' || 'windows-2022' }}
     env:
+      CHECKOUT_ROOT: C:/src
       OUTPUT_DIR: ${{ github.workspace }}/output
-      PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
-      S3_BUCKET: ${{ inputs.s3_bucket }}
-      S3_ENDPOINT: "s3.us-east-2.amazonaws.com"
+      PACKAGE_DIST_DIR: ${{ github.workspace }}\output\packages\dist
+      S3_BUCKET_PY: "therock-${{ inputs.release_type }}-python"
+      optional_build_prod_arguments: ""
     defaults:
       run:
         shell: bash
@@ -53,30 +86,107 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
+      # TODO(amd-justchen): share with build_windows_packages.yml. Include in VM image? Dockerfile?
+      - name: Install requirements
+        run: |
+          # ninja pinned due to a bug in the 1.13.0 release:
+          # https://github.com/ninja-build/ninja/issues/2616
+          choco install --no-progress -y ninja --version 1.12.1
+          choco install --no-progress -y awscli
+          echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
+
+      - name: Determine optional arguments passed to `build_prod_wheels.py`
+        if: ${{ inputs.rocm_version }}
+        run: |
+          pip install packaging
+          python build_tools/github_actions/determine_version.py \
+            --rocm-version ${{ inputs.rocm_version }}
+
+      - name: Install ROCm Wheels
+        shell: cmd
+        run: |
+          echo "Installing ROCm wheels for ${{ inputs.amdgpu_family }}"
+          python ./external-builds/pytorch/build_prod_wheels.py install-rocm --index-url "https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/" --rocm-sdk-version ==7.0.0.dev0+98ed4ad77f79822694ec01a36180ec3b95f4bd00
+          pip freeze
+
+          echo "pip show rocm"
+          pip show rocm
+
+          echo "pip show rocm-sdk-core"
+          pip show rocm-sdk-core
+
+          echo "pip show rocm-sdk-devel"
+          pip show rocm-sdk-devel
+
+          echo "pip show rocm-sdk-libraries-${{ inputs.amdgpu_family }}"
+          pip show rocm-sdk-libraries-${{ inputs.amdgpu_family }}
+
+      - name: Check python site-packages location
+        run: |
+          python -m site
+
+      - name: Check directory structure (tree)
+        shell: cmd
+        run: |
+          tree /f C:\home\runner\_work\_tool\Python\
+
+      - name: Check system32
+        shell: cmd
+        run: |
+          tree /f C:\Windows\system32
+
+      - name: Test ROCm Wheels
+        run: |
+          rocm-sdk test
+
+      - name: Check directory structure (ls)
+        if: always()
+        run: |
+          ls -la C:/home/runner/_work/_tool/Python/3.12.10/x64/Lib/site-packages/_rocm_sdk_devel/bin
+
+      # - name: Suspend for interactive debugging
+      #   if: ${{ !cancelled() }}
+      #   run: |
+      #     sleep 21600
+
       - name: Checkout PyTorch Source Repos
         run: |
-          python ./external-builds/pytorch/pytorch_torch_repo.py checkout
-      # TODO(scotttodd): include these
+          git config --global core.longpaths true
+          python ./external-builds/pytorch/pytorch_torch_repo.py checkout --repo ${{ env.CHECKOUT_ROOT }}/torch
+          # TODO(#910): Support torchvision and torchaudio on Windows
           # python ./external-builds/pytorch/pytorch_audio_repo.py checkout
           # python ./external-builds/pytorch/pytorch_vision_repo.py checkout
 
-      # TODO(scotttodd): build wheels, put into a directory location for next step to use
+      # After other installs, so MSVC get priority in the PATH.
+      - name: Configure MSVC
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      # TODO(scotttodd): add upload once working
+      - name: Build PyTorch Wheels
+        shell: cmd
+        run: |
+          echo "Building PyTorch wheels for ${{ inputs.amdgpu_family }}"
+          python ./external-builds/pytorch/build_prod_wheels.py build --pytorch-dir ${{ env.CHECKOUT_ROOT }}/torch --clean --output-dir ${{ env.PACKAGE_DIST_DIR }} ${{ env.optional_build_prod_arguments }}
 
-      # - name: Upload wheels to S3
-      #   if: ${{ github.repository_owner == 'ROCm' }}
+      - name: Configure AWS Credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
+
+      # TODO(#827, #910): enable this once we build torch audio and vision on Windows
+      # - name: Sanity Check Wheel
       #   run: |
-      #     aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET }}/${{ inputs.AMDGPU_FAMILIES }}/ \
-      #       --recursive --exclude "*" --include "*.whl"
+      #     python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}/
 
-      # - name: (Re-)Generate Python package release index
-      #   if: ${{ github.repository_owner == 'ROCm' }}
-      #   run: |
-      #     pip install boto3
-      #     python ./build_tools/packaging/python/generate_release_index.py \
-      #       --bucket=${{ env.S3_BUCKET }} \
-      #       --endpoint=${{ env.S3_ENDPOINT }} \
-      #       --subdir=${{ inputs.AMDGPU_FAMILIES }} \
-      #       --output=${{ github.workspace }}/index.html
-      #     aws s3 cp ${{ github.workspace }}/index.html s3://${{ env.S3_BUCKET }}/${{ inputs.AMDGPU_FAMILIES }}/
+      - name: Upload wheels to S3
+        if: ${{ github.repository_owner == 'ROCm' }}
+        shell: cmd
+        run: |
+          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ --recursive --exclude "*" --include "*.whl"
+
+      - name: (Re-)Generate Python package release index
+        if: ${{ github.repository_owner == 'ROCm' }}
+        run: |
+          pip install boto3 packaging
+          python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -29,12 +29,10 @@ on:
       amdgpu_family:
         required: true
         type: string
-        # default: "gfx110X-dgpu"
-        default: "gfx1151"
       python_version:
         required: true
         type: string
-        default: "3.12"
+        default:
       release_type:
         description: The type of release to build ("nightly", or "dev")
         type: string
@@ -46,15 +44,10 @@ on:
       cloudfront_url:
         description: CloudFront base URL pointing to Python index
         type: string
-        # nightly
-        # default: "d2awnip2yjpvqn.cloudfront.net/v2"
-
-        # dev
         default: "d25kgig7rdsyks.cloudfront.net/v2"
       rocm_version:
         description: ROCm version to pip install
         type: string
-        default: 7.0.0.dev0+98ed4ad77f79822694ec01a36180ec3b95f4bd00
 
 permissions:
   id-token: write
@@ -62,7 +55,7 @@ permissions:
 
 jobs:
   build_pytorch_wheels:
-    name: Build Windows PyTorch Wheels | ${{ inputs.AMDGPU_FAMILIES }} | Python ${{ inputs.python_version }}
+    name: Build Windows PyTorch Wheels | ${{ inputs.amdgpu_family }} | Python ${{ inputs.python_version }}
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-windows-scale-rocm' || 'windows-2022' }}
     env:
       CHECKOUT_ROOT: C:/src
@@ -95,59 +88,9 @@ jobs:
           choco install --no-progress -y awscli
           echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
 
-      - name: Determine optional arguments passed to `build_prod_wheels.py`
-        if: ${{ inputs.rocm_version }}
-        run: |
-          pip install packaging
-          python build_tools/github_actions/determine_version.py \
-            --rocm-version ${{ inputs.rocm_version }}
-
-      - name: Install ROCm Wheels
-        shell: cmd
-        run: |
-          echo "Installing ROCm wheels for ${{ inputs.amdgpu_family }}"
-          python ./external-builds/pytorch/build_prod_wheels.py install-rocm --index-url "https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/" --rocm-sdk-version ==7.0.0.dev0+98ed4ad77f79822694ec01a36180ec3b95f4bd00
-          pip freeze
-
-          echo "pip show rocm"
-          pip show rocm
-
-          echo "pip show rocm-sdk-core"
-          pip show rocm-sdk-core
-
-          echo "pip show rocm-sdk-devel"
-          pip show rocm-sdk-devel
-
-          echo "pip show rocm-sdk-libraries-${{ inputs.amdgpu_family }}"
-          pip show rocm-sdk-libraries-${{ inputs.amdgpu_family }}
-
-      - name: Check python site-packages location
-        run: |
-          python -m site
-
-      - name: Check directory structure (tree)
-        shell: cmd
-        run: |
-          tree /f C:\home\runner\_work\_tool\Python\
-
-      - name: Check system32
-        shell: cmd
-        run: |
-          tree /f C:\Windows\system32
-
-      - name: Test ROCm Wheels
-        run: |
-          rocm-sdk test
-
-      - name: Check directory structure (ls)
-        if: always()
-        run: |
-          ls -la C:/home/runner/_work/_tool/Python/3.12.10/x64/Lib/site-packages/_rocm_sdk_devel/bin
-
-      # - name: Suspend for interactive debugging
-      #   if: ${{ !cancelled() }}
-      #   run: |
-      #     sleep 21600
+      # After other installs, so MSVC get priority in the PATH.
+      - name: Configure MSVC
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Checkout PyTorch Source Repos
         run: |
@@ -157,9 +100,12 @@ jobs:
           # python ./external-builds/pytorch/pytorch_audio_repo.py checkout
           # python ./external-builds/pytorch/pytorch_vision_repo.py checkout
 
-      # After other installs, so MSVC get priority in the PATH.
-      - name: Configure MSVC
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      - name: Determine optional arguments passed to `build_prod_wheels.py`
+        if: ${{ inputs.rocm_version }}
+        run: |
+          pip install packaging
+          python build_tools/github_actions/determine_version.py \
+            --rocm-version ${{ inputs.rocm_version }}
 
       - name: Build PyTorch Wheels
         shell: cmd

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -111,7 +111,7 @@ jobs:
         shell: cmd
         run: |
           echo "Building PyTorch wheels for ${{ inputs.amdgpu_family }}"
-          python ./external-builds/pytorch/build_prod_wheels.py build --pytorch-dir ${{ env.CHECKOUT_ROOT }}/torch --clean --output-dir ${{ env.PACKAGE_DIST_DIR }} ${{ env.optional_build_prod_arguments }}
+          python ./external-builds/pytorch/build_prod_wheels.py build --install-rocm --index-url "https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/" --pytorch-dir ${{ env.CHECKOUT_ROOT }}/torch --clean --output-dir ${{ env.PACKAGE_DIST_DIR }} ${{ env.optional_build_prod_arguments }}
 
       - name: Configure AWS Credentials
         if: always()

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -60,11 +60,13 @@ jobs:
     env:
       CHECKOUT_ROOT: C:/src
       OUTPUT_DIR: ${{ github.workspace }}/output
+      # Note the \ here instead of /. This should be used from 'cmd' not 'bash'!
       PACKAGE_DIST_DIR: ${{ github.workspace }}\output\packages\dist
       S3_BUCKET_PY: "therock-${{ inputs.release_type }}-python"
       optional_build_prod_arguments: ""
     defaults:
       run:
+        # Note: there are mixed uses of 'bash' (this default) and 'cmd' below
         shell: bash
     steps:
       - name: Checkout
@@ -95,7 +97,8 @@ jobs:
       - name: Checkout PyTorch Source Repos
         run: |
           git config --global core.longpaths true
-          python ./external-builds/pytorch/pytorch_torch_repo.py checkout --repo ${{ env.CHECKOUT_ROOT }}/torch
+          python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
+            --repo ${{ env.CHECKOUT_ROOT }}/torch
           # TODO(#910): Support torchvision and torchaudio on Windows
           # python ./external-builds/pytorch/pytorch_audio_repo.py checkout
           # python ./external-builds/pytorch/pytorch_vision_repo.py checkout
@@ -108,10 +111,19 @@ jobs:
             --rocm-version ${{ inputs.rocm_version }}
 
       - name: Build PyTorch Wheels
+        # Using 'cmd' here is load bearing! There are configuration issues when
+        # run under 'bash': https://github.com/ROCm/TheRock/issues/827#issuecomment-3025858800
         shell: cmd
         run: |
           echo "Building PyTorch wheels for ${{ inputs.amdgpu_family }}"
-          python ./external-builds/pytorch/build_prod_wheels.py build --install-rocm --index-url "https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/" --pytorch-dir ${{ env.CHECKOUT_ROOT }}/torch --clean --output-dir ${{ env.PACKAGE_DIST_DIR }} ${{ env.optional_build_prod_arguments }}
+          python ./external-builds/pytorch/build_prod_wheels.py ^
+            build ^
+            --install-rocm ^
+            --index-url "https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/" ^
+            --pytorch-dir ${{ env.CHECKOUT_ROOT }}/torch ^
+            --clean ^
+            --output-dir ${{ env.PACKAGE_DIST_DIR }} ^
+            ${{ env.optional_build_prod_arguments }}
 
       - name: Configure AWS Credentials
         if: always()
@@ -122,14 +134,18 @@ jobs:
 
       # TODO(#827, #910): enable this once we build torch audio and vision on Windows
       # - name: Sanity Check Wheel
+      #   shell: cmd
       #   run: |
-      #     python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}/
+      #     python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}
 
       - name: Upload wheels to S3
         if: ${{ github.repository_owner == 'ROCm' }}
+        # Using 'cmd' here since PACKAGE_DIST_DIR uses \ in paths instead of /
         shell: cmd
         run: |
-          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ --recursive --exclude "*" --include "*.whl"
+          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ ^
+            s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ ^
+            --recursive --exclude "*" --include "*.whl"
 
       - name: (Re-)Generate Python package release index
         if: ${{ github.repository_owner == 'ROCm' }}

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -4,8 +4,8 @@ on:
   # Trigger from another workflow (typically to build dev packages and then test them)
   workflow_call:
     inputs:
-      build_type:
-        description: The type of build version to produce ("rc", or "dev")
+      release_type:
+        description: The type of build version to produce ("nightly", or "dev")
         type: string
         default: "dev"
       package_suffix:
@@ -17,10 +17,10 @@ on:
   # Trigger manually (typically to test the workflow or manually build a release [candidate])
   workflow_dispatch:
     inputs:
-      build_type:
-        description: The type of build version to produce ("rc", or "dev")
+      release_type:
+        description: The type of build version to produce ("nightly", or "dev")
         type: string
-        default: "rc"
+        default: "dev"
       package_suffix:
         type: string
       s3_subdir:
@@ -46,10 +46,14 @@ jobs:
   setup_metadata:
     if: ${{ github.repository_owner == 'ROCm' || github.event_name != 'schedule' }}
     runs-on: ubuntu-24.04
+    env:
+      S3_SUBDIR: ${{ inputs.s3_subdir || 'v2' }}
+      release_type: ${{ inputs.release_type || 'nightly' }}
     outputs:
       version: ${{ steps.release_information.outputs.version }}
-      release_type: ${{ steps.release_information.outputs.type }}
+      release_type: ${{ env.release_type }}
       package_targets: ${{ steps.configure.outputs.package_targets }}
+      cloudfront_url: ${{ steps.release_information.outputs.cloudfront_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -60,25 +64,25 @@ jobs:
 
       # Compute version suffix based on inputs (default to 'rc')
       - name: Set variables for nightly release
-        if: ${{ inputs.build_type == 'rc' || inputs.build_type == '' }}
+        if: ${{ env.release_type == 'nightly' }}
         run: |
           version_suffix="$(printf 'rc%(%Y%m%d)T')"
           echo "version_suffix=${version_suffix}" >> $GITHUB_ENV
-          echo "release_type=nightly" >> $GITHUB_ENV
+          echo "cloudfront_base_url=d2awnip2yjpvqn.cloudfront.net" >> $GITHUB_ENV
 
       - name: Set variables for development release
-        if: ${{ inputs.build_type == 'dev' }}
+        if: ${{ env.release_type == 'dev' }}
         run: |
           version_suffix=".dev0+${{ github.sha }}"
           echo "version_suffix=${version_suffix}" >> $GITHUB_ENV
-          echo "release_type=dev" >> $GITHUB_ENV
+          echo "cloudfront_base_url=d25kgig7rdsyks.cloudfront.net" >> $GITHUB_ENV
 
       - name: Generate release information
         id: release_information
         run: |
           base_version=$(jq -r '.["rocm-version"]' version.json)
           echo "version=${base_version}${version_suffix}" >> $GITHUB_OUTPUT
-          echo "type=${release_type}" >> $GITHUB_OUTPUT
+          echo "cloudfront_url=${cloudfront_base_url}/${{ env.S3_SUBDIR }}" >> $GITHUB_OUTPUT
 
       - name: Generating package target matrix
         id: configure
@@ -263,6 +267,19 @@ jobs:
           python ./build_tools/third_party/s3_management/manage.py ${{ env.S3_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}
 
       # TODO(scotttodd): trigger tests
+
+      - name: Trigger building PyTorch wheels
+        if: ${{ github.repository_owner == 'ROCm' }}
+        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
+        with:
+          workflow: release_windows_pytorch_wheels.yml
+          inputs: |
+            { "amdgpu_family": "${{ matrix.target_bundle.amdgpu_family }}",
+              "release_type": "${{ env.RELEASE_TYPE }}",
+              "s3_subdir": "${{ env.S3_SUBDIR }}",
+              "cloudfront_url": "${{ needs.setup_metadata.outputs.cloudfront_url }}",
+              "rocm_version": "${{ needs.setup_metadata.outputs.version }}"
+            }
 
       - name: Save cache
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -1,8 +1,11 @@
 name: Release Windows PyTorch Wheels
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
+      amdgpu_family:
+        required: true
+        type: string
       release_type:
         description: The type of release to build ("nightly", or "dev")
         type: string
@@ -15,10 +18,29 @@ on:
         description: CloudFront URL pointing to Python index
         type: string
         default: "d25kgig7rdsyks.cloudfront.net/v2"
-
-  # TODO(scotttodd): add schedule once working
-  # schedule:
-  #   - cron: "0 2 * * *"  # Nightly at 2 AM UTC
+      rocm_version:
+        description: ROCm version to pip install
+        type: string
+  workflow_dispatch:
+    inputs:
+      amdgpu_family:
+        required: true
+        type: string
+      release_type:
+        description: The type of release to build ("nightly", or "dev")
+        type: string
+        default: "dev"
+      s3_subdir:
+        description: S3 subdirectory, not including the GPU-family
+        type: string
+        default: "v2"
+      cloudfront_url:
+        description: CloudFront URL pointing to Python index
+        type: string
+        default: "d25kgig7rdsyks.cloudfront.net/v2"
+      rocm_version:
+        description: ROCm version to pip install
+        type: string
 
 permissions:
   id-token: write
@@ -29,17 +51,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - { AMDGPU_FAMILIES: gfx110X-dgpu }
-          # TODO(scotttodd): enable once nightly builds include these
-          # - { AMDGPU_FAMILIES: gfx1151 }
-          # - { AMDGPU_FAMILIES: gfx120X-all }
-        python_version: ["3.11", "3.12"]
+        python_version: ["3.11", "3.12", "3.13"]
 
     uses: ./.github/workflows/build_windows_pytorch_wheels.yml
     with:
-      amdgpu_family: ${{ matrix.config.AMDGPU_FAMILIES }}
+      amdgpu_family: ${{ inputs.amdgpu_family }}
       python_version: ${{ matrix.python_version }}
-      release_type: ${{ inputs.release_type || 'nightly' }}
-      s3_subdir: ${{ inputs.s3_subdir || 'v2' }}
-      cloudfront_url: ${{ inputs.cloudfront_url  || 'd2awnip2yjpvqn.cloudfront.net/v2' }}
+      release_type: ${{ inputs.release_type }}
+      s3_subdir: ${{ inputs.s3_subdir }}
+      cloudfront_url: ${{ inputs.cloudfront_url }}
+      rocm_version: ${{ inputs.rocm_version }}

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -2,6 +2,19 @@ name: Release Windows PyTorch Wheels
 
 on:
   workflow_dispatch:
+    inputs:
+      release_type:
+        description: The type of release to build ("nightly", or "dev")
+        type: string
+        default: "dev"
+      s3_subdir:
+        description: S3 subdirectory, not including the GPU-family
+        type: string
+        default: "v2"
+      cloudfront_url:
+        description: CloudFront URL pointing to Python index
+        type: string
+        default: "d25kgig7rdsyks.cloudfront.net/v2"
 
   # TODO(scotttodd): add schedule once working
   # schedule:
@@ -25,8 +38,8 @@ jobs:
 
     uses: ./.github/workflows/build_windows_pytorch_wheels.yml
     with:
-      AMDGPU_FAMILIES: ${{ matrix.config.AMDGPU_FAMILIES }}
+      amdgpu_family: ${{ matrix.config.AMDGPU_FAMILIES }}
       python_version: ${{ matrix.python_version }}
-      # TODO: switch to nightly once ready (and allow 'dev' from workflow_dispatch)
-      # s3_bucket: therock-nightly-python
-      s3_bucket: therock-dev-python
+      release_type: ${{ inputs.release_type || 'nightly' }}
+      s3_subdir: ${{ inputs.s3_subdir || 'v2' }}
+      cloudfront_url: ${{ inputs.cloudfront_url  || 'd2awnip2yjpvqn.cloudfront.net/v2' }}

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -99,9 +99,8 @@ mix/match build steps.
 - On Windows:
 
   ```bash
-  # TODO(#827): switch from therock-dev-python index to therock-nightly-python
   python build_prod_wheels.py build \
-    --install-rocm --index-url https://d25kgig7rdsyks.cloudfront.net/v2/gfx110X-dgpu/ \
+    --install-rocm --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ \
     --pytorch-dir C:/b/pytorch \
     --output-dir %HOME%/tmp/pyout
   ```
@@ -125,8 +124,14 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
 - Manually installing from a release index:
 
   ```bash
+  # From therock-nightly-python
   python -m pip install \
     --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ \
+    rocm[libraries,devel]
+
+  # OR from therock-dev-python
+  python -m pip install \
+    --index-url https://d25kgig7rdsyks.cloudfront.net/v2/gfx110X-dgpu/ \
     rocm[libraries,devel]
   ```
 

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -27,8 +27,8 @@ during the build step.
 # Note that triton must be checked out after pytorch as it depends on pins
 # in the former.
 python pytorch_torch_repo.py checkout
-python pytorch_torch_audio_repo.py checkout
-python pytorch_torch_vision_repo.py checkout
+python pytorch_audio_repo.py checkout
+python pytorch_vision_repo.py checkout
 python pytorch_triton_repo.py checkout
 
 # On Windows, using shorter paths to avoid compile command length limits:
@@ -381,11 +381,12 @@ def do_build(args: argparse.Namespace):
             env.update(addl_triton_env)
 
     if is_windows:
+        llvm_dir = root_dir / "lib" / "llvm" / "bin"
         env.update(
             {
-                "HIP_CLANG_PATH": str((root_dir / "lib" / "llvm" / "bin").as_posix()),
-                "CC": str((root_dir / "lib" / "llvm" / "bin" / "clang-cl").as_posix()),
-                "CXX": str((root_dir / "lib" / "llvm" / "bin" / "clang-cl").as_posix()),
+                "HIP_CLANG_PATH": str(llvm_dir.resolve().as_posix()),
+                "CC": str((llvm_dir / "clang-cl.exe").resolve()),
+                "CXX": str((llvm_dir / "clang-cl.exe").resolve()),
             }
         )
     else:


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/827 (!!)

Tested at https://github.com/ROCm/TheRock/actions/runs/16185309410, which triggered these:

* https://github.com/ROCm/TheRock/actions/runs/16186383600 (gfx1151)
* https://github.com/ROCm/TheRock/actions/runs/16186941663 (gfx120X-all)
* https://github.com/ROCm/TheRock/actions/runs/16186966931 (gfx110X-dgpu)

Some next steps after this, roughly in order:

* Monitor scheduled jobs to check that wheels are successfully built and uploaded
* Download/install and test the wheels on various systems, exercising components like hipBLASLt
* Update support status:
  * https://github.com/ROCm/TheRock?tab=readme-ov-file#support-status
  * https://github.com/ROCm/TheRock/blob/main/RELEASES.md#python-packages-support-status
* Build torchvision and torchaudio (need some patches)
* Connect with other build/test/release workflows so we get pre-submit, post-submit, and scheduled coverage for these builds/releases/tests
* Rebase patches onto PyTorch 2.8 (and/or HEAD), land patches upstream
* Add features like Triton support (aotriton?) for optimized flash attention kernels, etc.
* Expand the list of supported gfx targets

---

~~This depends on some other open PRs, but I have tested parts of it all the way through to dev wheel publishing and then installation and testing on a dev machine: https://github.com/ROCm/TheRock/actions/runs/16181411431/job/45678668536, https://github.com/ROCm/TheRock/issues/827#issuecomment-3054389581.~~

~~See the other PRs:~~

* ~~https://github.com/ROCm/TheRock/pull/783~~
* ~~https://github.com/ROCm/TheRock/pull/980~~
* ~~https://github.com/ROCm/TheRock/pull/988~~
* ~~https://github.com/ROCm/TheRock/pull/990~~