### PR TITLE
Wire up testing PyTorch wheels

### DIFF
--- a/.github/workflows/build_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_linux_pytorch_wheels.yml
@@ -75,9 +75,14 @@ jobs:
           git config --global user.name "therockbot"
           git config --global user.email "therockbot@amd.com"
 
+      - name: Select Python version
+        run: |
+          python build_tools/github_actions/python_to_cp_version.py \
+            --python-version ${{ inputs.python_version }}
+
       - name: Add selected Python version to PATH
         run: |
-          python_dir="/opt/python/${{ inputs.python_version }}"
+          python_dir="/opt/python/${{ env.cp_version }}"
           if ! [ -x "${python_dir}/bin/python" ]; then
             echo "ERROR: Could not find python: ${python_dir}"
             exit 1
@@ -137,6 +142,7 @@ jobs:
           python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}
 
   generate_target_to_run:
+    name: Generate target_to_run
     runs-on: ubuntu-24.04
     outputs:
       test_runs_on: ${{ steps.configure.outputs.test-runs-on }}

--- a/.github/workflows/build_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_linux_pytorch_wheels.yml
@@ -64,6 +64,8 @@ jobs:
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
       S3_BUCKET_PY: "therock-${{ inputs.release_type }}-python"
       optional_build_prod_arguments: ""
+    outputs:
+      torch_version: ${{ steps.build-pytorch-wheels.outputs.torch_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -99,6 +101,7 @@ jobs:
             --rocm-version ${{ inputs.rocm_version }}
 
       - name: Build PyTorch Wheels
+        id: build-pytorch-wheels
         run: |
           echo "Building PyTorch wheels for ${{ inputs.amdgpu_family }}"
           ./external-builds/pytorch/build_prod_wheels.py \
@@ -108,6 +111,7 @@ jobs:
             --index-url "https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/" \
             --clean \
             --output-dir ${{ env.PACKAGE_DIST_DIR }} ${{ env.optional_build_prod_arguments }}
+          echo "torch_version=`cd ${{ env.PACKAGE_DIST_DIR }}; python -c 'import glob; print(glob.glob("torch-*.whl")[0].split("-")[1])'`" >> $GITHUB_OUTPUT
 
       - name: Configure AWS Credentials
         if: always()
@@ -131,3 +135,30 @@ jobs:
         run: |
           pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}
+
+  generate_target_to_run:
+    runs-on: ubuntu-24.04
+    outputs:
+      test_runs_on: ${{ steps.configure.outputs.test-runs-on }}
+    steps:
+      - name: Checking out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Generating target to run
+        id: configure
+        env:
+          TARGET: ${{ inputs.amdgpu_family }}
+        run: python ./build_tools/github_actions/configure_target_run.py
+
+
+  test_pytorch_wheels:
+    if: ${{ needs.generate_target_to_run.outputs.test_runs_on != '' }}
+    needs: [build_pytorch_wheels, generate_target_to_run]
+
+    uses: ./.github/workflows/test_pytorch_wheels.yml
+    with:
+      amdgpu_family: ${{ inputs.amdgpu_family }}
+      test_runs_on: ${{ needs.generate_target_to_run.outputs.test_runs_on }}
+      cloudfront_url: ${{ inputs.cloudfront_url }}
+      python_version: ${{ inputs.python_version }}
+      torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -49,6 +49,7 @@ permissions:
 
 jobs:
   build:
+    name: PyTorch Wheels | ${{ inputs.amdgpu_family }} | Python ${{ matrix.python_version }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_linux_pytorch_wheels.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["cp311-cp311", "cp312-cp312", cp313-cp313]
+        python_version: ["3.11", "3.12", 3.13]
 
     uses: ./.github/workflows/build_linux_pytorch_wheels.yml
     with:

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -3,7 +3,7 @@ name: Test PyTorch Wheels
 on:
   workflow_dispatch:
     inputs:
-      amdgpu_families:
+      amdgpu_family:
         required: true
         type: string
         default: "gfx94X-dcgpu"
@@ -26,7 +26,7 @@ on:
 
   workflow_call:
     inputs:
-      amdgpu_families:
+      amdgpu_family:
         required: true
         type: string
       test_runs_on:
@@ -47,11 +47,11 @@ permissions:
 
 jobs:
   test_wheels:
-    name: Test PyTorch Wheels | ${{ inputs.amdgpu_families }}
+    name: Test PyTorch Wheels | ${{ inputs.amdgpu_family }}
     runs-on: ${{ inputs.test_runs_on }}
     env:
       VENV_DIR: ${{ github.workspace }}/venv
-      INDEX_URL: https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_families }}/
+      INDEX_URL: https://${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/
       TORCH_VERSION: ${{ inputs.torch_version }}
 
     steps:

--- a/build_tools/github_actions/CMakeLists.txt
+++ b/build_tools/github_actions/CMakeLists.txt
@@ -15,3 +15,9 @@ add_test(
     COMMAND "${Python3_EXECUTABLE}"
         "${CMAKE_CURRENT_SOURCE_DIR}/tests/fetch_package_targets_test.py"
 )
+
+add_test(
+    NAME build_tools_github_actions_python_to_cp_version_test
+    COMMAND "${Python3_EXECUTABLE}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/tests/python_to_cp_version_test.py"
+)

--- a/build_tools/github_actions/python_to_cp_version.py
+++ b/build_tools/github_actions/python_to_cp_version.py
@@ -26,10 +26,10 @@ def is_version(version) -> bool:
 
 def transform_python_version(python_version: str) -> str:
     if not is_version(python_version):
-        raise Exception("Invalid version")
+        raise ValueError(f"Version '{python_version}' did not match accepted regex")
 
-    tmp = python_version.replace(".", "")
-    cp_version = f"cp{tmp}-cp{tmp}"
+    version_without_dot = python_version.replace(".", "")
+    cp_version = f"cp{version_without_dot}-cp{version_without_dot}"
     return cp_version
 
 
@@ -46,7 +46,7 @@ def main(argv: list[str]):
         "--python-version",
         required=True,
         type=str,
-        help="Python version to be transformed",
+        help="Python version to be transformed (e.g. 3.12)",
     )
     p.add_argument(
         "--write-env-file",

--- a/build_tools/github_actions/python_to_cp_version.py
+++ b/build_tools/github_actions/python_to_cp_version.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+"""Determines part of the path to the Python interpreter in a manylinux image.
+
+Example usage:
+
+    python python_to_cp_version.py --python-version 3.12
+
+  The following string is appended to the file specified in the "GITHUB_ENV"
+  environment variable:
+
+    cp_version=cp312-cp312
+
+Writing the output to the "GITHUB_ENV" file can be suppressed by passing
+`--no-write-env-file`.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+
+def is_version(version) -> bool:
+    return re.match(r"^([1-9])\.((0|([1-9][0-9]*)))(t)?$", version) is not None
+
+
+def transform_python_version(python_version: str) -> str:
+    if not is_version(python_version):
+        raise Exception("Invalid version")
+
+    tmp = python_version.replace(".", "")
+    cp_version = f"cp{tmp}-cp{tmp}"
+    return cp_version
+
+
+def write_env_file(cp_version: str):
+    env_file = os.getenv("GITHUB_ENV")
+
+    with open(env_file, "a") as f:
+        f.write(f"cp_version={cp_version}")
+
+
+def main(argv: list[str]):
+    p = argparse.ArgumentParser(prog="python_to_cp_version.py")
+    p.add_argument(
+        "--python-version",
+        required=True,
+        type=str,
+        help="Python version to be transformed",
+    )
+    p.add_argument(
+        "--write-env-file",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Write `cp_version` to GITHUB_ENV file",
+    )
+    args = p.parse_args(argv)
+
+    cp_version = transform_python_version(args.python_version)
+    print(cp_version)
+
+    if args.write_env_file:
+        write_env_file(cp_version)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/build_tools/github_actions/tests/python_to_cp_version_test.py
+++ b/build_tools/github_actions/tests/python_to_cp_version_test.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+import python_to_cp_version
+
+
+class PythonToCpVersionTest(unittest.TestCase):
+    def test_312(self):
+        python_version = "3.12"
+        cp_version = python_to_cp_version.transform_python_version(
+            python_version=python_version
+        )
+
+        self.assertEqual(
+            cp_version,
+            "cp312-cp312",
+        )
+
+    def test_313t(self):
+        python_version = "3.13t"
+        cp_version = python_to_cp_version.transform_python_version(
+            python_version=python_version
+        )
+
+        self.assertEqual(
+            cp_version,
+            "cp313t-cp313t",
+        )
+
+    def test_invalid_version(self):
+        python_version = "0"
+        self.assertRaises(
+            Exception, python_to_cp_version.transform_python_version, python_version
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/github_actions/tests/python_to_cp_version_test.py
+++ b/build_tools/github_actions/tests/python_to_cp_version_test.py
@@ -33,7 +33,7 @@ class PythonToCpVersionTest(unittest.TestCase):
     def test_invalid_version(self):
         python_version = "0"
         self.assertRaises(
-            Exception, python_to_cp_version.transform_python_version, python_version
+            ValueError, python_to_cp_version.transform_python_version, python_version
         )
 
 

--- a/external-builds/pytorch/skipped_tests.py
+++ b/external-builds/pytorch/skipped_tests.py
@@ -3,6 +3,7 @@ skip_tests = [
     "test_RNN_dropout_state",
     "test_rnn_check_device",
     # TestTorch under test_torch.py
+    "test_index_add_correctness",
     "test_print",
     # TestCuda under test_cuda.py
     "test_hip_device_count",


### PR DESCRIPTION
This wires up testing the PyTorch wheels build in the `build_linux_pytorch_wheels` workflow. The package version to test is grabbed from the package name after building it and passed to the next job. This could probably made more robust by moving it to a script but should be acceptable for now. At the moment tests get only triggered for the platforms that are also used to test TheRock nightlies, which for now only is gfx942.

Furthermore, this adds another PyTorch test to the skip tests (here `test_index_add_correctness`), which fails with `AssertionError: Tensor-likes are not close!` on gfx942 using Python 3.11 but passes for 3.12 and 3.13.