### PR TITLE
[ci] - Enabling gfx950 tests

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -28,7 +28,7 @@ amdgpu_family_info_matrix_postsubmit = {
     "gfx950": {
         "linux": {
             "test-runs-on": "linux-mi355-1gpu-ossci-rocm",  # removed due to failing sanity check, label is "linux-mi355-1gpu-ossci-rocm"
-            "family": "gfx95X-dcgpu",
+            "family": "gfx950-dcgpu",
             "pytorch-target": "gfx950",
         }
     },

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -28,7 +28,7 @@ amdgpu_family_info_matrix_postsubmit = {
     "gfx950": {
         "linux": {
             "test-runs-on": "linux-mi355-1gpu-ossci-rocm",  # removed due to failing sanity check, label is "linux-mi355-1gpu-ossci-rocm"
-            "family": "gfx950-dcgpu",
+            "family": "gfx95X-dcgpu",
             "pytorch-target": "gfx950",
         }
     },

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -27,7 +27,7 @@ amdgpu_family_info_matrix_presubmit = {
 amdgpu_family_info_matrix_postsubmit = {
     "gfx950": {
         "linux": {
-            "test-runs-on": "linux-mi355-1gpu-ossci-rocm",  # removed due to failing sanity check, label is "linux-mi355-1gpu-ossci-rocm"
+            "test-runs-on": "linux-mi355-1gpu-ossci-rocm",
             "family": "gfx950-dcgpu",
             "pytorch-target": "gfx950",
         }

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -27,7 +27,7 @@ amdgpu_family_info_matrix_presubmit = {
 amdgpu_family_info_matrix_postsubmit = {
     "gfx950": {
         "linux": {
-            "test-runs-on": "",  # removed due to failing sanity check, label is "linux-mi355-1gpu-ossci-rocm"
+            "test-runs-on": "linux-mi355-1gpu-ossci-rocm",  # removed due to failing sanity check, label is "linux-mi355-1gpu-ossci-rocm"
             "family": "gfx950-dcgpu",
             "pytorch-target": "gfx950",
         }

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -20,6 +20,7 @@ def is_windows():
 
 def run_command(command, cwd=None):
     process = subprocess.run(command, capture_output=True, text=True, cwd=cwd, shell=is_windows())
+    logger.info(process.stdout)
     logger.info(process.stderr)
     return process
 
@@ -62,7 +63,20 @@ class TestROCmSanity:
         hipcc_check_executable_file = f"hipcc_check{platform_executable_suffix}"
         run_command(
             [
-                "hipcc",
+                "./hipcc",
+                "--version",
+            ],
+            cwd=str(THEROCK_BIN_DIR),
+        )
+        run_command(
+            [
+                f"{THEROCK_BIN_DIR}/hipcc",
+                "--version",
+            ],
+        )
+        run_command(
+            [
+                f"{THEROCK_BIN_DIR}/hipcc",
                 str(THIS_DIR / "hipcc_check.cpp"),
                 "-o",
                 hipcc_check_executable_file,

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -19,7 +19,8 @@ def is_windows():
 
 
 def run_command(command, cwd=None):
-    process = subprocess.run(command, capture_output=True, cwd=cwd, shell=is_windows())
+    process = subprocess.run(command, capture_output=True, cwd=cwd, check=True, shell=is_windows())
+    logger.info(process)
     return process
 
 

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -19,9 +19,11 @@ def is_windows():
 
 
 def run_command(command, cwd=None):
-    process = subprocess.run(command, capture_output=True, text=True, cwd=cwd, shell=is_windows())
-    logger.info(process.stdout)
-    logger.info(process.stderr)
+    process = subprocess.run(
+        command, capture_output=True, cwd=cwd, shell=is_windows()
+    )
+    if process.returncode != 0:
+        raise Exception(str(process.stderr))
     return process
 
 
@@ -63,19 +65,6 @@ class TestROCmSanity:
         hipcc_check_executable_file = f"hipcc_check{platform_executable_suffix}"
         run_command(
             [
-                "./hipcc",
-                "--version",
-            ],
-            cwd=str(THEROCK_BIN_DIR),
-        )
-        run_command(
-            [
-                f"{THEROCK_BIN_DIR}/hipcc",
-                "--version",
-            ],
-        )
-        run_command(
-            [
                 f"{THEROCK_BIN_DIR}/hipcc",
                 str(THIS_DIR / "hipcc_check.cpp"),
                 "-o",
@@ -88,9 +77,7 @@ class TestROCmSanity:
         platform_executable_prefix = "./" if not is_windows() else ""
         hipcc_check_executable = f"{platform_executable_prefix}hipcc_check"
         process = run_command([hipcc_check_executable], cwd=str(THEROCK_BIN_DIR))
-        # TODO(geomin12): Fix Windows 3221225477 error code when running exe.
-        if not is_windows():
-            check.equal(process.returncode, 0)
+        check.equal(process.returncode, 0)
         check.greater(
             os.path.getsize(str(THEROCK_BIN_DIR / hipcc_check_executable_file)), 0
         )

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -19,12 +19,8 @@ def is_windows():
 
 
 def run_command(command, cwd=None):
-    try:
-        process = subprocess.run(command,stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd, check=True, shell=is_windows())
-    except subprocess.CalledProcessError as exc:
-        logging.info("Status : FAIL", exc.returncode, exc.output)
-        logging.info(exc.stderr)
-        logging.info(exc.stdout)
+    process = subprocess.run(command, capture_output=True, text=True, cwd=cwd, shell=is_windows())
+    logger.info(process.stderr)
     return process
 
 

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -19,8 +19,11 @@ def is_windows():
 
 
 def run_command(command, cwd=None):
-    process = subprocess.run(command,stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, check=True, shell=is_windows())
-    logger.info(process.stderr)
+    try:
+        process = subprocess.run(command,stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd, check=True, shell=is_windows())
+    except subprocess.CalledProcessError as exc:
+        logging.info(process.stderr)
+        logging.info("Status : FAIL", exc.returncode, exc.output)
     return process
 
 

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -22,8 +22,9 @@ def run_command(command, cwd=None):
     try:
         process = subprocess.run(command,stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd, check=True, shell=is_windows())
     except subprocess.CalledProcessError as exc:
-        logging.info(process.stderr)
         logging.info("Status : FAIL", exc.returncode, exc.output)
+        logging.info(exc.stderr)
+        logging.info(exc.stdout)
     return process
 
 

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -20,7 +20,7 @@ def is_windows():
 
 def run_command(command, cwd=None):
     process = subprocess.run(command, capture_output=True, cwd=cwd, check=True, shell=is_windows())
-    logger.info(process)
+    logger.info(process.stderr)
     return process
 
 

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -19,9 +19,7 @@ def is_windows():
 
 
 def run_command(command, cwd=None):
-    process = subprocess.run(
-        command, capture_output=True, cwd=cwd, shell=is_windows()
-    )
+    process = subprocess.run(command, capture_output=True, cwd=cwd, shell=is_windows())
     if process.returncode != 0:
         raise Exception(str(process.stderr))
     return process

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -19,7 +19,7 @@ def is_windows():
 
 
 def run_command(command, cwd=None):
-    process = subprocess.run(command, capture_output=True, cwd=cwd, check=True, shell=is_windows())
+    process = subprocess.run(command,stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, check=True, shell=is_windows())
     logger.info(process.stderr)
     return process
 


### PR DESCRIPTION
hipcc test was failing for gfx950 due to hipcc coming from `opt/rocm` (`cwd` didn't work, `hipcc` pulled it from /opt/rocm, silly mistake from me and slipped through the cracks)

Now, it works for gfx950 and also for windows tests! Also adding extra logging

Tested [in CI test workflow](https://github.com/ROCm/TheRock/actions/runs/16206539664)