### PR TITLE
Skip PyTorch tests failing on gfx950

### DIFF
--- a/external-builds/pytorch/skipped_tests.py
+++ b/external-builds/pytorch/skipped_tests.py
@@ -10,6 +10,11 @@ skip_tests = [
     "test_host_memory_stats",
     "test_nvtx",
     "test_device_count_not_cached_pre_init",
+    # TestCuda under test_cuda.py, failing on gfx950
+    "test_preferred_blas_library_settings",
+    # TestCudaAutocast under test_cuda.py, failing on gfx950
+    "test_autocast_torch_bf16",
+    "test_autocast_torch_fp16",
     # TestMemPool under test_cuda.py
     "test_mempool_with_allocator",
     # TestBinaryUfuncsCUDA under test_binary_ufuncs


### PR DESCRIPTION
The following tests are failing on Mi355 / gfx950. Failing tests are tracked in #1005.