### PR TITLE
Stop uploading tarballs to GH releases

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -165,23 +165,6 @@ jobs:
           echo "------------"
           du -h -d 1 ${{ env.OUTPUT_DIR }}/build/dist/rocm
 
-      - name: Upload Tarball to GitHub
-        uses: ncipollo/release-action@bcfe5470707e8832e12347755757cec0eb3c22af # v1.18.0
-        with:
-          artifacts: "${{ env.DIST_ARCHIVE }}"
-          tag: "${{ env.RELEASE_TYPE }}-tarball"
-          name: "${{ env.RELEASE_TYPE }}-tarball"
-          body: "Automatic ${{ env.RELEASE_TYPE }} tarball of TheRock."
-          removeArtifacts: false
-          allowUpdates: true
-          replacesArtifacts: true
-          makeLatest: false
-          # Keep existing name/body/status.
-          omitNameDuringUpdate: true
-          omitBodyDuringUpdate: true
-          omitDraftDuringUpdate: true
-          omitPrereleaseDuringUpdate: true
-
       - name: Configure AWS Credentials
         if: ${{ github.repository_owner == 'ROCm' }}
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -232,21 +232,20 @@ wrapper Python wheels or utility scripts.
 
 ### Installing release tarballs
 
-Release tarballs are automatically uploaded to both
-[GitHub releases](https://github.com/ROCm/TheRock/releases) and AWS S3 buckets.
+Release tarballs are automatically uploaded to AWS S3 buckets.
 The S3 buckets do not yet have index pages.
 
-| Release page                                                                      | S3 bucket                                                                    | Description                                       |
-| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------- |
-| [`nightly-tarball`](https://github.com/ROCm/TheRock/releases/tag/nightly-tarball) | [therock-nightly-tarball](https://therock-nightly-tarball.s3.amazonaws.com/) | Nightly builds from the `main` branch             |
-| [`dev-tarball`](https://github.com/ROCm/TheRock/releases/tag/dev-tarball)         | [therock-dev-tarball](https://therock-dev-tarball.s3.amazonaws.com/)         | ⚠️ Development builds from project maintainers ⚠️ |
+| S3 bucket                                                                    | Description                                       |
+| ---------------------------------------------------------------------------- | ------------------------------------------------- |
+| [therock-nightly-tarball](https://therock-nightly-tarball.s3.amazonaws.com/) | Nightly builds from the `main` branch             |
+| [therock-dev-tarball](https://therock-dev-tarball.s3.amazonaws.com/)         | ⚠️ Development builds from project maintainers ⚠️ |
 
 After downloading, simply extract the release tarball into place:
 
 ```bash
 mkdir therock-tarball && cd therock-tarball
 # For example...
-wget https://github.com/ROCm/TheRock/releases/download/nightly-tarball/therock-dist-linux-gfx110X-dgpu-6.5.0rc20250610.tar.gz
+wget https://therock-nightly-tarball.s3.us-east-2.amazonaws.com/therock-dist-linux-gfx110X-dgpu-6.5.0rc20250610.tar.gz
 
 mkdir install
 tar -xf *.tar.gz -C install


### PR DESCRIPTION
Tarballs for gfx942 are above the size limit for assets that can be uploaded to a GH release. With this, the release workflow stops trying to uploading the tarball, which is also uploaded to S3. This will need further work as some scripts still try to fetch tarballs from GH.