### PR TITLE
Remove support for artifact suffixes.

### DIFF
--- a/build_tools/_therock_utils/artifacts.py
+++ b/build_tools/_therock_utils/artifacts.py
@@ -38,9 +38,8 @@ class ArtifactName:
     def from_path(path: Path) -> Optional["ArtifactName"]:
         filename = path.name
         if path.is_dir():
-            # Matches {name}_{component}_{target_family} with an optional
-            # extra suffix that we ignore.
-            m = re.match(r"^([^_]+)_([^_]+)_([^_]+)(_.+)?$", filename)
+            # Matches {name}_{component}_{target_family}.
+            m = re.match(r"^([^_]+)_([^_]+)_([^_]+)$", filename)
             if not m:
                 return None
             return ArtifactName(m.group(1), m.group(2), m.group(3))
@@ -49,9 +48,8 @@ class ArtifactName:
 
     @staticmethod
     def from_filename(filename: str) -> Optional["ArtifactName"]:
-        # Matches {name}_{component}_{target_family} with an optional
-        # extra suffix that we ignore and an archive extension.
-        m = re.match(r"^([^_]+)_([^_]+)_([^_]+)(_.+)?\.tar.xz$", filename)
+        # Matches {name}_{component}_{target_family} and an archive extension.
+        m = re.match(r"^([^_]+)_([^_]+)_([^_]+)\.tar.xz$", filename)
         if not m:
             return None
         return ArtifactName(m.group(1), m.group(2), m.group(3))

--- a/build_tools/tests/artifacts_test.py
+++ b/build_tools/tests/artifacts_test.py
@@ -25,9 +25,9 @@ class ArtifactNameTest(unittest.TestCase):
             self.temp_context.cleanup()
 
     def testFromPath(self):
-        p1 = Path(self.temp_dir / "dir" / "name_component_generic_EXTRA")
+        p1 = Path(self.temp_dir / "dir" / "name_component_generic")
         p1.mkdir(parents=True, exist_ok=True)
-        p2 = Path(self.temp_dir / "other" / "name_component_generic_EXTRA.tar.xz")
+        p2 = Path(self.temp_dir / "other" / "name_component_generic.tar.xz")
         p2.parent.mkdir(parents=True, exist_ok=True)
         p2.touch()
 
@@ -46,9 +46,16 @@ class ArtifactNameTest(unittest.TestCase):
         self.assertEqual(an1.component, "component")
         self.assertEqual(an1.target_family, "generic")
 
-        f2 = "invalid_name.zip"
-        an2 = ArtifactName.from_filename(f2)
-        self.assertIsNone(an2)
+        f_invalid1 = "invalid_name.zip"
+        an_invalid1 = ArtifactName.from_filename(f_invalid1)
+        self.assertIsNone(an_invalid1)
+
+        # Component names containing one underscore could be misinterpretted
+        # as [name]_[component]_[target family]_suffix with each group shifted
+        # over one. See https://github.com/ROCm/TheRock/issues/935.
+        f_invalid2 = "underscore_name_component_generic.tar.xz"
+        an_invalid2 = ArtifactName.from_filename(f_invalid2)
+        self.assertIsNone(an_invalid2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is an opinionated way to harden against https://github.com/ROCm/TheRock/issues/935.

### Background

Artifact names have these main parts: `{name}_{component}_{target_family}`. Here are some examples:

Artifact name | Name | Component | Target family
-- | -- | -- | --
`blas_run_gfx110X-dgpu` | `blas` | `run` | `gfx110X-dgpu`
`host-blas_dev_generic` | `host-blas` | `dev`  | `generic`

Note that each part can use `-` as a delimiter but _not_ `_`. That issue was a bug:

(buggy) Artifact name | Name | Component | Target family
-- | -- | -- | --
`composable_kernel_dbg_gfx1151` | `composable` | `kernel` (bug!) |  `dbg` (bug!)

### Solutions

We added a check in CMake for "name" in https://github.com/ROCm/TheRock/pull/970. We could also check "component" here: https://github.com/ROCm/TheRock/blob/0df2e00d53ed9037398bee80996dc7d46b60aee3/cmake/therock_artifacts.cmake#L95

However, given how freeform these fields are in general, having support for an arbitrary `_suffix` made it possible for any one of the parts to accidentally spill into the next. If we do still want to support arbitrary suffixes, we could consider an allow-list for `generic|gfx.+` in target families that we would check against during parsing.