### PR TITLE
Extend pytorch build to work with our official 2.7 backport.

### DIFF
--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -221,7 +221,7 @@ python pytorch_triton_repo.py checkout
 
 ### ROCm PyTorch Release Branches
 
-Because upstream PyTorch freezes at release but AMD needs to keep updating 
+Because upstream PyTorch freezes at release but AMD needs to keep updating
 stable versions for a longer period of time, backport branches are maintained.
 In order to check out and build one of these, use the following instructions:
 
@@ -238,8 +238,8 @@ Change origins and tags as appropriate.
 
 ### v2.7.x
 
-NOTE: Presently broken at runtime on a HIP major version incompatibility in the 
-pre-built aotriton (#1025). Must build with 
+NOTE: Presently broken at runtime on a HIP major version incompatibility in the
+pre-built aotriton (#1025). Must build with
 `USE_FLASH_ATTENTION=0 USE_MEM_EFF_ATTENTION=0` until fixed.
 
 ```

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -218,3 +218,36 @@ python pytorch_vision_repo.py checkout --repo-hashtag nightly
 # Note that triton will be checked out at the PyTorch pin.
 python pytorch_triton_repo.py checkout
 ```
+
+### ROCm PyTorch Release Branches
+
+Because upstream PyTorch freezes at release but AMD needs to keep updating 
+stable versions for a longer period of time, backport branches are maintained.
+In order to check out and build one of these, use the following instructions:
+
+In general, we regularly build PyTorch nightly from upstream sources and the
+most recent stable backport. Generally, backports are only supported on Linux
+at present.
+
+Backport branches have `related_commits` files that point to specific
+sub-project commits, so the main torch repo must be checked out first to
+have proper defaults.
+
+You are welcome to maintain your own branches that extend one of AMD's.
+Change origins and tags as appropriate.
+
+### v2.7.x
+
+NOTE: Presently broken at runtime on a HIP major version incompatibility in the 
+pre-built aotriton (#1025). Must build with 
+`USE_FLASH_ATTENTION=0 USE_MEM_EFF_ATTENTION=0` until fixed.
+
+```
+python pytorch_torch_repo.py checkout \
+  --gitrepo-origin https://github.com/ROCm/pytorch.git \
+  --repo-hashtag release/2.7 \
+  --patchset rocm_2.7
+python pytorch_audio_repo.py checkout --require-related-commit
+python pytorch_vision_repo.py checkout --require-related-commit
+python pytorch_triton_repo.py checkout
+```

--- a/external-builds/pytorch/pytorch_audio_repo.py
+++ b/external-builds/pytorch/pytorch_audio_repo.py
@@ -133,7 +133,7 @@ def main(cl_args: list[str]):
 
     args = p.parse_args(cl_args)
     if args.require_related_commit and not HAS_RELATED_COMMIT:
-        raise ValueError("Could not find torchaudio in pytorch/related-commits")
+        raise ValueError("Could not find torchaudio in pytorch/related_commits")
     args.func(args)
 
 

--- a/external-builds/pytorch/pytorch_audio_repo.py
+++ b/external-builds/pytorch/pytorch_audio_repo.py
@@ -36,10 +36,7 @@ in, CI runs for that revision will incorporate them the same as anyone
 interactively using this tool.
 """
 import argparse
-from pathlib import Path, PurePosixPath
-import shlex
-import shutil
-import subprocess
+from pathlib import Path
 import sys
 
 import repo_management
@@ -47,6 +44,20 @@ import repo_management
 THIS_MAIN_REPO_NAME = "pytorch_audio"
 THIS_DIR = Path(__file__).resolve().parent
 THIS_PATCHES_DIR = THIS_DIR / "patches" / THIS_MAIN_REPO_NAME
+
+(
+    DEFAULT_ORIGIN,
+    DEFAULT_HASHTAG,
+    DEFAULT_PATCHSET,
+    HAS_RELATED_COMMIT,
+) = repo_management.read_pytorch_rocm_pins(
+    THIS_DIR / "pytorch",
+    os="centos",
+    project="torchaudio",
+    default_origin="https://github.com/pytorch/audio.git",
+    default_hashtag="v2.7.0",
+    default_patchset=None,
+)
 
 
 def main(cl_args: list[str]):
@@ -67,23 +78,32 @@ def main(cl_args: list[str]):
             "--repo-name",
             type=Path,
             default=THIS_MAIN_REPO_NAME,
-            help="Git repository patch path",
+            help="Subdirectory name in which to checkout repo",
+        )
+        command_parser.add_argument(
+            "--repo-hashtag",
+            default=DEFAULT_HASHTAG,
+            help="Git repository ref/tag to checkout",
+        )
+        command_parser.add_argument(
+            "--patchset",
+            default=DEFAULT_PATCHSET,
+            help="patch dir subdirectory (defaults to mangled --repo-hashtag)",
+        )
+        command_parser.add_argument(
+            "--require-related-commit",
+            action="store_true",
+            help="Require that a related commit was found",
         )
 
     p = argparse.ArgumentParser("pytorch_audio_repo.py")
-    default_repo_hashtag = "v2.7.0"
     sub_p = p.add_subparsers(required=True)
     checkout_p = sub_p.add_parser("checkout", help="Clone PyTorch locally and checkout")
     add_common(checkout_p)
     checkout_p.add_argument(
         "--gitrepo-origin",
-        default="https://github.com/pytorch/audio.git",
+        default=DEFAULT_ORIGIN,
         help="git repository url",
-    )
-    checkout_p.add_argument(
-        "--repo-hashtag",
-        default=default_repo_hashtag,
-        help="Git repository ref/tag to checkout",
     )
     checkout_p.add_argument("--depth", type=int, help="Fetch depth")
     checkout_p.add_argument("--jobs", type=int, help="Number of fetch jobs")
@@ -109,14 +129,11 @@ def main(cl_args: list[str]):
         "save-patches", help="Save local commits as patch files for later application"
     )
     add_common(save_patches_p)
-    save_patches_p.add_argument(
-        "--repo-hashtag",
-        default=default_repo_hashtag,
-        help="Git repository ref/tag to checkout",
-    )
     save_patches_p.set_defaults(func=repo_management.do_save_patches)
 
     args = p.parse_args(cl_args)
+    if args.require_related_commit and not HAS_RELATED_COMMIT:
+        raise ValueError("Could not find torchaudio in pytorch/related-commits")
     args.func(args)
 
 

--- a/external-builds/pytorch/pytorch_torch_repo.py
+++ b/external-builds/pytorch/pytorch_torch_repo.py
@@ -64,7 +64,16 @@ def main(cl_args: list[str]):
             "--repo-name",
             type=Path,
             default=THIS_MAIN_REPO_NAME,
-            help="Git repository patch path",
+            help="Subdirectory name in which to checkout repo",
+        )
+        command_parser.add_argument(
+            "--repo-hashtag",
+            default=default_repo_hashtag,
+            help="Git repository ref/tag to checkout",
+        )
+        command_parser.add_argument(
+            "--patchset",
+            help="patch dir subdirectory (defaults to mangled --repo-hashtag)",
         )
 
     p = argparse.ArgumentParser("pytorch_torch_repo.py")
@@ -76,11 +85,6 @@ def main(cl_args: list[str]):
         "--gitrepo-origin",
         default="https://github.com/pytorch/pytorch.git",
         help="git repository url",
-    )
-    checkout_p.add_argument(
-        "--repo-hashtag",
-        default=default_repo_hashtag,
-        help="Git repository ref/tag to checkout",
     )
     checkout_p.add_argument("--depth", type=int, help="Fetch depth")
     checkout_p.add_argument("--jobs", default=10, type=int, help="Number of fetch jobs")
@@ -106,11 +110,6 @@ def main(cl_args: list[str]):
         "save-patches", help="Save local commits as patch files for later application"
     )
     add_common(save_patches_p)
-    save_patches_p.add_argument(
-        "--repo-hashtag",
-        default=default_repo_hashtag,
-        help="Git repository ref/tag to checkout",
-    )
     save_patches_p.set_defaults(func=repo_management.do_save_patches)
 
     args = p.parse_args(cl_args)

--- a/external-builds/pytorch/pytorch_triton_repo.py
+++ b/external-builds/pytorch/pytorch_triton_repo.py
@@ -79,7 +79,15 @@ def main(cl_args: list[str]):
             "--repo-name",
             type=Path,
             default=THIS_MAIN_REPO_NAME,
-            help="Git repository patch path",
+            help="Subdirectory name in which to checkout repo",
+        )
+        command_parser.add_argument(
+            "--repo-hashtag",
+            help="Git repository ref/tag to checkout",
+        )
+        command_parser.add_argument(
+            "--patchset",
+            help="patch dir subdirectory (defaults to mangled --repo-hashtag)",
         )
 
     p = argparse.ArgumentParser("pytorch_triton_repo.py")
@@ -126,11 +134,6 @@ def main(cl_args: list[str]):
         "save-patches", help="Save local commits as patch files for later application"
     )
     add_common(save_patches_p)
-    save_patches_p.add_argument(
-        "--repo-hashtag",
-        required=True,
-        help="Git repository ref/tag to checkout",
-    )
     save_patches_p.set_defaults(func=repo_management.do_save_patches)
 
     args = p.parse_args(cl_args)

--- a/external-builds/pytorch/pytorch_vision_repo.py
+++ b/external-builds/pytorch/pytorch_vision_repo.py
@@ -48,6 +48,20 @@ THIS_MAIN_REPO_NAME = "pytorch_vision"
 THIS_DIR = Path(__file__).resolve().parent
 THIS_PATCHES_DIR = THIS_DIR / "patches" / THIS_MAIN_REPO_NAME
 
+(
+    DEFAULT_ORIGIN,
+    DEFAULT_HASHTAG,
+    DEFAULT_PATCHSET,
+    HAS_RELATED_COMMIT,
+) = repo_management.read_pytorch_rocm_pins(
+    THIS_DIR / "pytorch",
+    os="centos",
+    project="torchvision",
+    default_origin="https://github.com/pytorch/vision.git",
+    default_hashtag="v0.22.0",
+    default_patchset=None,
+)
+
 
 def main(cl_args: list[str]):
     def add_common(command_parser: argparse.ArgumentParser):
@@ -67,23 +81,32 @@ def main(cl_args: list[str]):
             "--repo-name",
             type=Path,
             default=THIS_MAIN_REPO_NAME,
-            help="Git repository patch path",
+            help="Subdirectory name in which to checkout repo",
+        )
+        command_parser.add_argument(
+            "--repo-hashtag",
+            default=DEFAULT_HASHTAG,
+            help="Git repository ref/tag to checkout",
+        )
+        command_parser.add_argument(
+            "--patchset",
+            default=DEFAULT_PATCHSET,
+            help="patch dir subdirectory (defaults to mangled --repo-hashtag)",
+        )
+        command_parser.add_argument(
+            "--require-related-commit",
+            action="store_true",
+            help="Require that a related commit was found",
         )
 
     p = argparse.ArgumentParser("pytorch_vision_repo.py")
-    default_repo_hashtag = "v0.22.0"
     sub_p = p.add_subparsers(required=True)
     checkout_p = sub_p.add_parser("checkout", help="Clone PyTorch locally and checkout")
     add_common(checkout_p)
     checkout_p.add_argument(
         "--gitrepo-origin",
-        default="https://github.com/pytorch/vision.git",
+        default=DEFAULT_ORIGIN,
         help="git repository url",
-    )
-    checkout_p.add_argument(
-        "--repo-hashtag",
-        default=default_repo_hashtag,
-        help="Git repository ref/tag to checkout",
     )
     checkout_p.add_argument("--depth", type=int, help="Fetch depth")
     checkout_p.add_argument("--jobs", type=int, help="Number of fetch jobs")
@@ -109,14 +132,11 @@ def main(cl_args: list[str]):
         "save-patches", help="Save local commits as patch files for later application"
     )
     add_common(save_patches_p)
-    save_patches_p.add_argument(
-        "--repo-hashtag",
-        default=default_repo_hashtag,
-        help="Git repository ref/tag to checkout",
-    )
     save_patches_p.set_defaults(func=repo_management.do_save_patches)
 
     args = p.parse_args(cl_args)
+    if args.require_related_commit and not HAS_RELATED_COMMIT:
+        raise ValueError("Could not find torchaudio in pytorch/related-commits")
     args.func(args)
 
 

--- a/external-builds/pytorch/pytorch_vision_repo.py
+++ b/external-builds/pytorch/pytorch_vision_repo.py
@@ -136,7 +136,7 @@ def main(cl_args: list[str]):
 
     args = p.parse_args(cl_args)
     if args.require_related_commit and not HAS_RELATED_COMMIT:
-        raise ValueError("Could not find torchaudio in pytorch/related-commits")
+        raise ValueError("Could not find torchvision in pytorch/related_commits")
     args.func(args)
 
 

--- a/external-builds/pytorch/repo_management.py
+++ b/external-builds/pytorch/repo_management.py
@@ -309,7 +309,7 @@ def do_save_patches(args: argparse.Namespace):
         save_repo_patches(args.repo / relative_sm_path, patches_dir / relative_sm_path)
 
 
-# Reads the ROCm maintained "releated_commits" file from the given pytorch dir.
+# Reads the ROCm maintained "related_commits" file from the given pytorch dir.
 # If present, selects the given os and project, returning origin, hashtag and
 # "rocm-custom" patchset. Otherwise, returns the given defaults.
 def read_pytorch_rocm_pins(

--- a/external-builds/pytorch/repo_management.py
+++ b/external-builds/pytorch/repo_management.py
@@ -192,6 +192,17 @@ def repo_hashtag_to_patches_dir_name(version_ref: str) -> str:
     return version_ref
 
 
+def get_patches_dir_name(args: argparse.Namespace) -> str | None:
+    patchset_name = args.patchset
+    if patchset_name is not None:
+        return patchset_name
+
+    hashtag = args.repo_hashtag
+    if hashtag is not None:
+        return hashtag
+    return None
+
+
 def do_hipify(args: argparse.Namespace):
     repo_dir: Path = args.repo
     print(f"Hipifying {repo_dir}")
@@ -222,8 +233,10 @@ def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
     repo_dir: Path = args.repo
     repo_patch_dir_base = args.patch_dir
     check_git_dir = repo_dir / ".git"
+    patches_dir_name = get_patches_dir_name(args)
     if check_git_dir.exists():
         print(f"Not cloning repository ({check_git_dir} exists)")
+        exec(["git", "remote", "set-url", "origin", args.gitrepo_origin], cwd=repo_dir)
     else:
         print(f"Cloning repository at {args.repo_hashtag}")
         repo_dir.mkdir(parents=True, exist_ok=True)
@@ -262,10 +275,10 @@ def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
     git_config_ignore_submodules(repo_dir)
 
     # Base patches.
-    if args.patch:
+    if args.patch and patches_dir_name:
         apply_all_patches(
             repo_dir,
-            repo_patch_dir_base / repo_hashtag_to_patches_dir_name(args.repo_hashtag),
+            repo_patch_dir_base / patches_dir_name,
             args.repo_name,
             "base",
         )
@@ -276,10 +289,10 @@ def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
         commit_hipify(args)
 
     # Hipified patches.
-    if args.patch:
+    if args.patch and patches_dir_name:
         apply_all_patches(
             repo_dir,
-            repo_patch_dir_base / repo_hashtag_to_patches_dir_name(args.repo_hashtag),
+            repo_patch_dir_base / patches_dir_name,
             args.repo_name,
             "hipified",
         )
@@ -288,10 +301,43 @@ def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
 def do_save_patches(args: argparse.Namespace):
     repo_name = args.repo_name
     repo_patch_dir_base = args.patch_dir
-    patches_dir = repo_patch_dir_base / repo_hashtag_to_patches_dir_name(
-        args.repo_hashtag
-    )
+    patches_dir_name = get_patches_dir_name(args)
+    patches_dir = repo_patch_dir_base / patches_dir_name
     save_repo_patches(args.repo, patches_dir / repo_name)
     relative_sm_paths = list_submodules(args.repo, relative=True)
     for relative_sm_path in relative_sm_paths:
         save_repo_patches(args.repo / relative_sm_path, patches_dir / relative_sm_path)
+
+
+# Reads the ROCm maintained "releated_commits" file from the given pytorch dir.
+# If present, selects the given os and project, returning origin, hashtag and
+# "rocm-custom" patchset. Otherwise, returns the given defaults.
+def read_pytorch_rocm_pins(
+    pytorch_dir: Path,
+    os: str,
+    project: str,
+    *,
+    default_origin: str,
+    default_hashtag: str | None,
+    default_patchset: str | None,
+) -> tuple[str, str | None, str | None, bool]:
+    related_commits_file = pytorch_dir / "related_commits"
+    if related_commits_file.exists():
+        lines = related_commits_file.read_text().splitlines()
+        for line in lines:
+            try:
+                (
+                    rec_os,
+                    rec_source,
+                    rec_project,
+                    rec_branch,
+                    rec_commit,
+                    rec_origin,
+                ) = line.split("|")
+            except ValueError:
+                print(f"WARNING: Could not parse related_commits line: {line}")
+            if rec_os == os and rec_project == project:
+                return rec_origin, rec_commit, "rocm-custom", True
+
+    # Not found.
+    return default_origin, default_hashtag, default_patchset, False


### PR DESCRIPTION
This enables us to build off of the ROCm/pytorch release/2.7 branch, enabling 2.7.1 on ROCm 7.

jeffdaily and I cherry-picked the couple of missing patches from HEAD to make this configuration work with TheRock.

When building with the pre-built aotriton, it hits against #1025.

Should be NFC for all other builds.

Progress on #1026.