### PR TITLE
[Windows] Skip rpath branches during packaging.

### DIFF
--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -324,10 +324,12 @@ class PopulatedDistPackage:
         else:
             self.params.files.mark_populated(self, relpath, dest_path)
 
-        file_type = get_file_type(dest_path)
-        if file_type == "exe" or file_type == "so":
-            self._extend_rpath(dest_path)
-            self._normalize_rpath(dest_path)
+        if not is_windows:
+            # Update RPATHs on Linux.
+            file_type = get_file_type(dest_path)
+            if file_type == "exe" or file_type == "so":
+                self._extend_rpath(dest_path)
+                self._normalize_rpath(dest_path)
 
     def _extend_rpath(self, file_path: Path):
         for dep_project, rpath in self.rpath_deps:
@@ -493,9 +495,12 @@ class PopulatedDistPackage:
             dest_path.unlink()
         dest_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src_entry.path, dest_path)
-        file_type = get_file_type(dest_path)
-        if file_type == "exe" or file_type == "so":
-            self._normalize_rpath(dest_path)
+
+        if not is_windows:
+            # Update RPATHs on Linux.
+            file_type = get_file_type(dest_path)
+            if file_type == "exe" or file_type == "so":
+                self._normalize_rpath(dest_path)
 
 
 MAGIC_AR_MATCH = re.compile("ar archive")


### PR DESCRIPTION
This fixes the release build failures noted here: https://github.com/ROCm/TheRock/pull/1012#discussion_r2207896570. Linux can use RPATH to connect libraries from different packages while Windows relies on DLLs being either co-located, discoverable on the PATH, or already being loaded.

Tested locally:

```bash
# Build archives and python packages
cmake --build ./build --target therock-archives
python .\build_tools\build_python_packages.py --artifact-dir=.\build\artifacts --dest-dir=.\build\packages --version=7.0.0.dev0

# Generate local index
pip install piprepo
piprepo build ./build/packages/dist

# Install and test
pip install rocm[libraries,devel]==7.0.0.dev0 --extra-index-url .\build\packages\dist\simple
rocm-sdk test

# ...
# Ran 25 tests in 10.096s
# OK (skipped=1)
```