### PR TITLE
[ci] - Adding miopen exclusion for MI355

### DIFF
--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -51,6 +51,7 @@ jobs:
       - name: "Configuring CI options"
         env:
           PLATFORM: ${{ inputs.platform }}
+          AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
         id: configure
         run: python ./build_tools/github_actions/fetch_test_configurations.py
 

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -90,18 +90,26 @@ test_matrix = {
         "timeout_minutes": 5,
         "test_script": f"python {SCRIPT_DIR / 'test_miopen.py'}",
         "platform": ["linux"],
+        "exclude_family": ["gfx950-dcgpu"],
     },
 }
 
 
 def run():
     platform = os.getenv("PLATFORM")
+    amdgpu_families = os.getenv("AMDGPU_FAMILIES")
     project_to_test = os.getenv("project_to_test", "*")
 
     logging.info(f"Selecting projects: {project_to_test}")
 
     output_matrix = []
     for key in test_matrix:
+        # Check if amdgpu family is excluded for this test
+        if (
+            "exclude_family" in test_matrix[key]
+            and amdgpu_families in test_matrix[key]["exclude_family"]
+        ):
+            continue
         # If the test is enabled for a particular platform and a particular (or all) projects are selected
         if platform in test_matrix[key]["platform"] and (
             key in project_to_test or project_to_test == "*"


### PR DESCRIPTION
Turns out that MIOpen tests are only configured for `gfx908 gfx90a gfx942` since CK is only building for those three targets. `miopen_gtest` fails if CK is disabled.

[Opened issue MIOpen](https://github.com/ROCm/MIOpen/issues/3882) and Jonathan opened this [internal issue](https://ontrack-internal.amd.com/browse/LWPMIOPEN-1683) to get mi355 enabled for miopen

For now, we will exclude mi355 for miopen tests until resolved

