### PR TITLE
Cherry-pick gfx1201 support patch to clr.

### DIFF
--- a/patches/amd-mainline/clr/0001-Use-is_versioned-true-consistently-in-both-Comgr-Loa.patch
+++ b/patches/amd-mainline/clr/0001-Use-is_versioned-true-consistently-in-both-Comgr-Loa.patch
@@ -1,7 +1,7 @@
-From 481d2f44762911a0cd16569b636e73a935fd956e Mon Sep 17 00:00:00 2001
+From 8de0426f934c5d1587998e7958124021ef7358fa Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Fri, 9 May 2025 19:21:34 -0700
-Subject: [PATCH 1/2] [windows] Use is_versioned = true consistently in both
+Subject: [PATCH 1/3] Use is_versioned = true consistently in both
  Comgr::LoadLib paths.
 
 Prior to this, RTCProgram was using is_version = true and device initialization was using false. On Windows, this was causing us to attempt to load amd_comgr_3.dll at device load and amd_comgr0605.dll for RTC programs. Obviously, there is only one DLL and it must be used consistently.
@@ -10,10 +10,10 @@ Prior to this, RTCProgram was using is_version = true and device initialization 
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rocclr/device/device.cpp b/rocclr/device/device.cpp
-index 0dfec19df..f5b471343 100644
+index a791aa46f..22abd16d2 100644
 --- a/rocclr/device/device.cpp
 +++ b/rocclr/device/device.cpp
-@@ -750,7 +750,7 @@ bool Device::ValidateComgr() {
+@@ -754,7 +754,7 @@ bool Device::ValidateComgr() {
  #if defined(USE_COMGR_LIBRARY)
    // Check if Lightning compiler was requested
    if (settings_->useLightning_) {
@@ -23,5 +23,5 @@ index 0dfec19df..f5b471343 100644
      // Use Lightning only if it's available
      settings_->useLightning_ = amd::Comgr::IsReady();
 -- 
-2.49.0.windows.1
+2.47.1.windows.2
 

--- a/patches/amd-mainline/clr/0002-Fix-assembler-error-in-pal-trap-handler.patch
+++ b/patches/amd-mainline/clr/0002-Fix-assembler-error-in-pal-trap-handler.patch
@@ -1,7 +1,7 @@
-From 31675d06062328c8aa273994785a1e662f6edfdb Mon Sep 17 00:00:00 2001
+From 7f04a22c8b20e319056f6e28a0cc905a9a547c53 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Sat, 10 May 2025 15:56:02 -0700
-Subject: [PATCH 2/2] [windows] Fix assembler error in pal trap handler.
+Subject: [PATCH 2/3] Fix assembler error in pal trap handler.
 
 This has been showing up in real use as an error printed to the console complaining that the ".not_s_trap" label cannot be found on device initialization.
 
@@ -15,7 +15,7 @@ Tested by running hipblaslt tests on Windows/gfx1151 in TheRock and verifying th
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/rocclr/device/pal/palblitcl.cpp b/rocclr/device/pal/palblitcl.cpp
-index 67b8fd020..d059e81d4 100644
+index 6616a7fed..9072073df 100644
 --- a/rocclr/device/pal/palblitcl.cpp
 +++ b/rocclr/device/pal/palblitcl.cpp
 @@ -120,7 +120,7 @@ const char* TrapHandlerCode = RUNTIME_KERNEL(
@@ -28,5 +28,5 @@ index 67b8fd020..d059e81d4 100644
  \n  // Check if the it was an host trap.
  \n  s_bitcmp1_b32                         ttmp1, SQ_WAVE_PC_HI_HT_SHIFT
 -- 
-2.49.0.windows.1
+2.47.1.windows.2
 

--- a/patches/amd-mainline/clr/0003-SWDEV-460151-add-gfx1201-to-amd-staging-clr-183.patch
+++ b/patches/amd-mainline/clr/0003-SWDEV-460151-add-gfx1201-to-amd-staging-clr-183.patch
@@ -1,0 +1,45 @@
+From 06ee649942b4b36188b61e93450972c45e6763a3 Mon Sep 17 00:00:00 2001
+From: "Xie, Jiabao(Jimbo)" <Jiabao.Xie@amd.com>
+Date: Fri, 11 Jul 2025 11:51:47 -0400
+Subject: [PATCH 3/3] SWDEV-460151 - add gfx1201 to amd-staging clr (#183)
+
+* SWDEV-460151 - add gfx1201 to amd-staging clr
+
+* SWDEV-460151 - removed pal macro
+
+---------
+
+Co-authored-by: Jimbo Xie <jiabaxie@amd.com>
+---
+ rocclr/device/pal/paldevice.cpp   | 1 +
+ rocclr/device/pal/palsettings.cpp | 2 ++
+ 2 files changed, 3 insertions(+)
+
+diff --git a/rocclr/device/pal/paldevice.cpp b/rocclr/device/pal/paldevice.cpp
+index e10f8e211..e07e19820 100644
+--- a/rocclr/device/pal/paldevice.cpp
++++ b/rocclr/device/pal/paldevice.cpp
+@@ -102,6 +102,7 @@ static constexpr PalDevice supportedPalDevices[] = {
+   {11, 0,  3,  Pal::GfxIpLevel::GfxIp11_0, "gfx1103",       Pal::AsicRevision::HawkPoint2},
+   {11, 5,  0,  Pal::GfxIpLevel::GfxIp11_5, "gfx1150",       Pal::AsicRevision::Strix1},
+   {11, 5,  1,  Pal::GfxIpLevel::GfxIp11_5, "gfx1151",       Pal::AsicRevision::StrixHalo},
++  {12, 0,  1,  Pal::GfxIpLevel::GfxIp12,   "gfx1201",       Pal::AsicRevision::Navi48},
+ };
+ 
+ static std::tuple<const amd::Isa*, const char*> findIsa(Pal::AsicRevision asicRevision,
+diff --git a/rocclr/device/pal/palsettings.cpp b/rocclr/device/pal/palsettings.cpp
+index 8361a950c..0cd5ca70a 100644
+--- a/rocclr/device/pal/palsettings.cpp
++++ b/rocclr/device/pal/palsettings.cpp
+@@ -161,6 +161,8 @@ bool Settings::create(const Pal::DeviceProperties& palProp,
+   amd::Os::getAppPathAndFileName(appName, appPathAndName);
+ 
+   switch (palProp.revision) {
++    // Fall through for Navi4x ...
++    case Pal::AsicRevision::Navi48:
+     // Fall through for Navi3x ...
+     case Pal::AsicRevision::Navi33:
+     case Pal::AsicRevision::Navi32:
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
Cherry-picking https://github.com/ROCm/clr/commit/a5d932f1606928d48ccdf19ce240032a049d4d01 which we believe should help with https://github.com/ROCm/TheRock/issues/710 (I have not tested it myself). See also https://github.com/ROCm/clr/pull/169.

We can drop the patch when we next do a roll-up of clr.