### PR TITLE
Sets up CMAKE_PREFIX_PATH so that it can find all super-project packages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ endblock()
 option(THEROCK_SPLIT_DEBUG_INFO "Enables splitting of debug info into dbg artifacts (and strips primary packages)" OFF)
 option(THEROCK_MINIMAL_DEBUG_INFO "Enables compiler-specific flags for minimal debug symbols suitable for shipping in packages" OFF)
 option(THEROCK_QUIET_INSTALL "Enable quiet install logging (install logs only go to the logfile)" ON)
+option(THEROCK_USE_SAFE_DEPENDENCY_PROVIDER "Enable the safe dependency provider, performing strict package checks" ON)
 
 ################################################################################
 # Feature selection

--- a/cmake/templates/find_config.tmpl.cmake
+++ b/cmake/templates/find_config.tmpl.cmake
@@ -1,0 +1,22 @@
+# Template find_package config file used to trampoline to a fixed location.
+# Processed via configure_file with the following variables in scope:
+#   @_package_name@ : Name of the package being searched
+#   @_package_name_lower@ : Lowercase name of the package being searched
+#   @_find_package_path@ : Absolute path to the directory we should redirect to
+
+# This trampolines through the list of file patterns for config scripts that
+# is prescribed in the find_package docs. Since this is presumed to be for
+# a component of the super project that must exist, it is a fatal error if a
+# suitable destination is not found.
+
+if(EXISTS "@_find_package_path@/@_package_name@Config.cmake")
+  message(STATUS "Super-project find_package(${CMAKE_FIND_PACKAGE_NAME}) -> @_find_package_path@/@_package_name@Config.cmake")
+  include("@_find_package_path@/@_package_name@Config.cmake")
+elseif(EXISTS "@_find_package_path@/@_package_name_lower@-config.cmake")
+  message(STATUS "Super-project find_package(${CMAKE_FIND_PACKAGE_NAME}) -> @_find_package_path@/@_package_name_lower@-config.cmake")
+  include("@_find_package_path@/@_package_name_lower@-config.cmake")
+else()
+  message(FATAL_ERROR "Super-project based find_package(@_package_name@) config "
+    "file not found under @_find_package_path@"
+  )
+endif()

--- a/cmake/templates/find_config_version.tmpl.cmake
+++ b/cmake/templates/find_config_version.tmpl.cmake
@@ -1,0 +1,28 @@
+# Template find_package version file used to trampoline to a fixed location.
+# Processed via configure_file with the following variables in scope:
+#   @_package_name@ : Name of the package being searched
+#   @_package_name_lower@ : Lowercase name of the package being searched
+#   @_find_package_path@ : Absolute path to the directory we should redirect to
+
+# This trampolines through the list of file patterns for version scripts that
+# is prescribed in the find_package docs.
+
+if(EXISTS "@_find_package_path@/@_package_name@ConfigVersion.cmake")
+  message(STATUS "Super-project find_package(${PACKAGE_FIND_NAME} VERSION ${PACKAGE_FIND_VERSION}) -> "
+          "@_find_package_path@/@_package_name@ConfigVersion.cmake")
+  include("@_find_package_path@/@_package_name@ConfigVersion.cmake")
+elseif(EXISTS "@_find_package_path@/@_package_name@Config-version.cmake")
+  message(STATUS "Super-project find_package(${PACKAGE_FIND_NAME} VERSION ${PACKAGE_FIND_VERSION}) -> "
+          "@_find_package_path@/@_package_name@Config-version.cmake")
+  include("@_find_package_path@/@_package_name@Config-version.cmake")
+elseif(EXISTS "@_find_package_path@/@_package_name_lower@-configVersion.cmake")
+  message(STATUS "Super-project find_package(${PACKAGE_FIND_NAME} VERSION ${PACKAGE_FIND_VERSION}) -> "
+          "@_find_package_path@/@_package_name_lower@-configVersion.cmake")
+  include("@_find_package_path@/@_package_name_lower@-configVersion.cmake")
+elseif(EXISTS "@_find_package_path@/@_package_name_lower@-config-version.cmake")
+  message(STATUS "Super-project find_package(${PACKAGE_FIND_NAME} VERSION ${PACKAGE_FIND_VERSION}) -> "
+          "@_find_package_path@/@_package_name_lower@-config-version.cmake")
+  include("@_find_package_path@/@_package_name_lower@-config-version.cmake")
+else()
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+endif()

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -19,6 +19,7 @@ set_property(GLOBAL PROPERTY THEROCK_DEFAULT_CMAKE_VARS
   THEROCK_SOURCE_DIR
   THEROCK_BINARY_DIR
   THEROCK_BUILD_TESTING
+  THEROCK_USE_SAFE_DEPENDENCY_PROVIDER
   ROCM_SYMLINK_LIBS
 
   # RPATH handling.
@@ -28,7 +29,7 @@ set_property(GLOBAL PROPERTY THEROCK_DEFAULT_CMAKE_VARS
   THEROCK_INSTALL_RPATH_LIBRARY_DIR
 
   # Debug info handling.
-  THEROCK_SPLIT_DEBUG_INFO
+  THEROCK_SPLIT_DEBUG_INFO  
 )
 
 # Whenever a new package is advertised by the super-project, it is added here.
@@ -339,6 +340,10 @@ function(therock_cmake_subproject_declare target_name)
   set(_stamp_dir "${ARG_BINARY_DIR}/${ARG_DIR_PREFIX}stamp")
   make_directory("${_stamp_dir}")
 
+  # Prefix directory.
+  set(_prefix_dir "${ARG_BINARY_DIR}/${ARG_DIR_PREFIX}prefix")
+  make_directory("${_prefix_dir}")
+
   # Collect LINK_DIRS and PROGRAM_DIRS from explicit args and RUNTIME_DEPS.
   _therock_cmake_subproject_collect_runtime_deps(
       _private_include_dirs _private_link_dirs _private_program_dirs _private_pkg_config_dirs _interface_install_rpath_dirs
@@ -435,6 +440,7 @@ function(therock_cmake_subproject_declare target_name)
     THEROCK_STAGE_DIR "${_stage_dir}"
     THEROCK_INSTALL_DESTINATION "${ARG_INSTALL_DESTINATION}"
     THEROCK_STAMP_DIR "${_stamp_dir}"
+    THEROCK_PREFIX_DIR "${_prefix_dir}"
     THEROCK_CMAKE_SOURCE_DIR "${_cmake_source_dir}"
     THEROCK_CMAKE_PROJECT_INIT_FILE "${ARG_BINARY_DIR}/${ARG_BUILD_DIR}_init.cmake"
     THEROCK_CMAKE_PROJECT_TOOLCHAIN_FILE "${ARG_BINARY_DIR}/${ARG_BUILD_DIR}_toolchain.cmake"
@@ -536,6 +542,7 @@ function(therock_cmake_subproject_activate target_name)
   get_target_property(_stage_dir "${target_name}" THEROCK_STAGE_DIR)
   get_target_property(_sources "${target_name}" SOURCES)
   get_target_property(_stamp_dir "${target_name}" THEROCK_STAMP_DIR)
+  get_target_property(_prefix_dir "${target_name}" THEROCK_PREFIX_DIR)
   get_target_property(_output_on_failure "${target_name}" THEROCK_OUTPUT_ON_FAILURE)
   # RPATH properties: just mirror these to same named variables because we just
   # mirror them syntactically into the subprojet..
@@ -640,6 +647,7 @@ function(therock_cmake_subproject_activate target_name)
   string(APPEND _init_contents "${_deps_contents}")
   string(APPEND _init_contents "set(THEROCK_IGNORE_PACKAGES \"@_ignore_packages@\")\n")
   string(APPEND _init_contents "list(PREPEND CMAKE_MODULE_PATH \"${THEROCK_SOURCE_DIR}/cmake/finders\")\n")
+  string(APPEND _init_contents "list(PREPEND CMAKE_PREFIX_PATH \"@_prefix_dir@\")\n")
   get_property(_all_provided_packages GLOBAL PROPERTY THEROCK_ALL_PROVIDED_PACKAGES)
   string(APPEND _init_contents "set(THEROCK_STRICT_PROVIDED_PACKAGES \"@_all_provided_packages@\")\n")
 
@@ -664,6 +672,7 @@ function(therock_cmake_subproject_activate target_name)
       # The normal way.
       string(APPEND _init_contents "string(APPEND CMAKE_EXE_LINKER_FLAGS \" -L ${_private_link_dir} -Wl,-rpath-link,${_private_link_dir}\")\n")
       string(APPEND _init_contents "string(APPEND CMAKE_SHARED_LINKER_FLAGS \" -L ${_private_link_dir} -Wl,-rpath-link,${_private_link_dir}\")\n")
+      string(APPEND _init_contents "list(APPEND CMAKE_BUILD_RPATH \"${_private_link_dir}\")\n")
     elseif(_compiler_toolchain STREQUAL "amd-llvm" OR _compiler_toolchain STREQUAL "amd-hip")
       # The Windows but using a clang-based toolchain way.
       #   Working around "lld-link: warning: ignoring unknown argument '-rpath-link'"
@@ -1042,6 +1051,20 @@ function(_therock_cmake_subproject_setup_deps out_contents out_provided dep_dir_
         endif()
         string(APPEND _contents "set(THEROCK_PACKAGE_DIR_${_package_name} \"${_find_package_path}\")\n")
         string(APPEND _contents "list(APPEND THEROCK_PROVIDED_PACKAGES ${_package_name})\n")
+
+        # Now write a trampoline package config file into the prefix so that normal
+        # prefix based find_package() will resolve properly.
+        string(TOLOWER "${_package_name}" _package_name_lower)
+        set(_config_file "${_prefix_dir}/${_package_name}Config.cmake")
+        configure_file(
+          "${THEROCK_SOURCE_DIR}/cmake/templates/find_config.tmpl.cmake"
+          "${_config_file}" @ONLY
+        )
+        set(_version_file "${_prefix_dir}/${_package_name}ConfigVersion.cmake")
+        configure_file(
+          "${THEROCK_SOURCE_DIR}/cmake/templates/find_config_version.tmpl.cmake"
+          "${_version_file}" @ONLY
+        )
       endforeach()
     endif()
   endforeach()

--- a/cmake/therock_subproject_dep_provider.cmake
+++ b/cmake/therock_subproject_dep_provider.cmake
@@ -66,7 +66,8 @@ macro(therock_dependency_provider method package_name)
     endif()
   endif()
 endmacro()
-if(THEROCK_PROVIDED_PACKAGES)
+
+if(THEROCK_USE_SAFE_DEPENDENCY_PROVIDER AND THEROCK_PROVIDED_PACKAGES)
   message(STATUS "Resolving packages from super-project: ${THEROCK_PROVIDED_PACKAGES}")
   cmake_language(
     SET_DEPENDENCY_PROVIDER therock_dependency_provider

--- a/compiler/pre_hook_amd-llvm.cmake
+++ b/compiler/pre_hook_amd-llvm.cmake
@@ -133,3 +133,13 @@ block()
   endif()
   therock_set_implicit_llvm_options(CLANG "${CMAKE_CURRENT_SOURCE_DIR}/../clang/tools" "${_clang_required_tools}")
 endblock()
+
+
+function(_therock_debug_targets)
+  get_target_property(_build_rpath LLVM BUILD_RPATH)
+  get_target_property(_build_rpath_use_origin LLVM BUILD_RPATH_USE_ORIGIN)
+  get_target_property(_skip_build_rpath LLVM SKIP_BUILD_RPATH)
+  message(STATUS "LLVM PROPERTIES: BUILD_RPATH=${_build_rpath} BUILD_RPATH_USE_ORIGIN=${_build_rpath_use_origin} SKIP_BUILD_RPATH=${_skip_build_rpath}")
+endfunction()
+
+cmake_language(DEFER CALL _therock_debug_targets)

--- a/core/pre_hook_ROCR-Runtime.cmake
+++ b/core/pre_hook_ROCR-Runtime.cmake
@@ -1,0 +1,5 @@
+# Prefetch LibElf to nullify the shady embedded find modules.
+# Maddeningly, the find module calls itself "LibElf" (camel case) but sets
+# "LIBELF_FOUND" (uppercase).
+find_package(LibElf CONFIG REQUIRED)
+set(LIBELF_FOUND ON)


### PR DESCRIPTION
* Adds a debug flag `THEROCK_USE_SAFE_DEPENDENCY_PROVIDER` which allows the safe dependency provider to be disabled. This allows debugging that the project is clean with pure find_package semantics.
* For each sub-project, creates a `prefix` directory and adds it to CMAKE_PREFIX_PATH. This prefix directory contains trampoline package config files that are generated to do hard-coded redirects to those at known locations in the sub-projects.
* Uses the new debug flag to sanitize the project for these cases:
  * ROCR-Runtime has some shady finders for LibElf that the dependency provider was handling. Adds a pre-hook to prime the LibElf package explicitly, which is safe/consistent in both modes.
  * Adds explicit BUILD_RPATH propagation logic so that build tree libraries always have their full transitive rpath (which we know from project metadata). This came up because certain styles of depending on the packages disables the usual CMake logic that hard-codes build-tree RPATHs and was causing rpath issues on libLLVM. Triaging shows that this is common on MacOS and some Linux cases and the recommendation is to just manage it yourself, which we now do.
* This should make sub-cmake invocations work properly from a find_package perspective so long as CMAKE_PREFIX_PATH is propagated (which is pretty standard practice).