### PR TITLE
[torch] Backport warpsize patch to 2.7.0 to fix release builds.

### DIFF
--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0001-Disable-hipSPARSE-and-CK-declarations-and-remove-ref.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0001-Disable-hipSPARSE-and-CK-declarations-and-remove-ref.patch
@@ -1,8 +1,8 @@
-From 455f219101bbb23503cd390c7aedce8566b6ba21 Mon Sep 17 00:00:00 2001
+From d82715939800da1f713b5a1bc9e7cffcfa33f92c Mon Sep 17 00:00:00 2001
 From: ikalinic <ilija.kalinic@amd.com>
 Date: Wed, 19 Mar 2025 07:30:50 +0000
-Subject: [PATCH 01/02] Disable hipSPARSE and CK declarations and remove references
- for Windows (#149195)
+Subject: [PATCH 1/2] Disable hipSPARSE and CK declarations and remove
+ references for Windows (#149195)
 
 This PR removes references to `hipSPARSE` and `ck` functions and disables declarations which are not supported on Windows.
 
@@ -178,6 +178,5 @@ index 6075e7b9c9d..637b48c797f 100644
 +
  } // namespace at::cuda::blas
 -- 
---
 2.47.1.windows.2
 

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0001-Disable-hipSPARSE-and-CK-declarations-and-remove-ref.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0001-Disable-hipSPARSE-and-CK-declarations-and-remove-ref.patch
@@ -1,7 +1,7 @@
 From 455f219101bbb23503cd390c7aedce8566b6ba21 Mon Sep 17 00:00:00 2001
 From: ikalinic <ilija.kalinic@amd.com>
 Date: Wed, 19 Mar 2025 07:30:50 +0000
-Subject: [PATCH] Disable hipSPARSE and CK declarations and remove references
+Subject: [PATCH 01/02] Disable hipSPARSE and CK declarations and remove references
  for Windows (#149195)
 
 This PR removes references to `hipSPARSE` and `ck` functions and disables declarations which are not supported on Windows.
@@ -178,5 +178,6 @@ index 6075e7b9c9d..637b48c797f 100644
 +
  } // namespace at::cuda::blas
 -- 
+--
 2.47.1.windows.2
 

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0002-Backport-Remove-use-of-warpsize-on-host-side-compila.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0002-Backport-Remove-use-of-warpsize-on-host-side-compila.patch
@@ -1,20 +1,20 @@
-From 55d67353e58c8c63683f9f1228a4b58f0c3ef824 Mon Sep 17 00:00:00 2001
+From 79733204924519c15d04d9b8f43f4a42c64f50cd Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Wed, 16 Jul 2025 12:09:14 -0700
-Subject: [PATCH 02/02] [ROCm] Backport "Remove use of warpsize on host-side
+Subject: [PATCH 2/2] Backport "Remove use of warpsize on host-side
  compilation".
 
 https://github.com/pytorch/pytorch/commit/04bd7e6850e8efec77994963ffee87549555b9c3
 ---
- aten/src/ATen/native/cuda/Embedding.cu        |  2 +-
- .../src/ATen/native/cuda/MultinomialKernel.cu |  2 +-
- aten/src/ATen/native/cuda/SoftMax.cu          | 19 ++++++++++---------
- aten/src/ATen/native/cuda/TensorModeKernel.cu |  2 +-
- aten/src/ATen/native/cuda/block_reduce.cuh    | 12 +++++++++++-
- c10/macros/Macros.h                           | 16 +++++++++++++++-
- .../distributed/c10d/CUDASymmetricMemory.cu   |  6 +++---
- .../c10d/CUDASymmetricMemoryOps.cu            |  2 +-
- 8 files changed, 43 insertions(+), 18 deletions(-)
+ aten/src/ATen/native/cuda/Embedding.cu           |  2 +-
+ aten/src/ATen/native/cuda/MultinomialKernel.cu   |  2 +-
+ aten/src/ATen/native/cuda/SoftMax.cu             | 15 ++++++++-------
+ aten/src/ATen/native/cuda/TensorModeKernel.cu    |  2 +-
+ aten/src/ATen/native/cuda/block_reduce.cuh       | 12 +++++++++++-
+ c10/macros/Macros.h                              | 16 +++++++++++++++-
+ .../csrc/distributed/c10d/CUDASymmetricMemory.cu |  6 +++---
+ .../distributed/c10d/CUDASymmetricMemoryOps.cu   |  2 +-
+ 8 files changed, 41 insertions(+), 16 deletions(-)
 
 diff --git a/aten/src/ATen/native/cuda/Embedding.cu b/aten/src/ATen/native/cuda/Embedding.cu
 index 5d19b95b32f..4b1e420d5da 100644
@@ -43,7 +43,7 @@ index 65770e40a8b..8132e7df57b 100644
    int warp_size = at::cuda::warp_size();
    dim3 grid(rows < numSM * 4 ? rows : numSM * 4);
 diff --git a/aten/src/ATen/native/cuda/SoftMax.cu b/aten/src/ATen/native/cuda/SoftMax.cu
-index 2062a14cdba..bd45e8c0a08 100644
+index 2062a14cdba..2946b19853c 100644
 --- a/aten/src/ATen/native/cuda/SoftMax.cu
 +++ b/aten/src/ATen/native/cuda/SoftMax.cu
 @@ -177,15 +177,16 @@ inline dim3 SoftMaxForward_getBlockSize(uint64_t dim_size) {

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0002-Backport-Remove-use-of-warpsize-on-host-side-compila.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0002-Backport-Remove-use-of-warpsize-on-host-side-compila.patch
@@ -1,4 +1,4 @@
-From 79733204924519c15d04d9b8f43f4a42c64f50cd Mon Sep 17 00:00:00 2001
+From 4ad1931afefb714d84c3b371c41bb6c19cb8d226 Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Wed, 16 Jul 2025 12:09:14 -0700
 Subject: [PATCH 2/2] Backport "Remove use of warpsize on host-side
@@ -10,11 +10,12 @@ https://github.com/pytorch/pytorch/commit/04bd7e6850e8efec77994963ffee87549555b9
  aten/src/ATen/native/cuda/MultinomialKernel.cu   |  2 +-
  aten/src/ATen/native/cuda/SoftMax.cu             | 15 ++++++++-------
  aten/src/ATen/native/cuda/TensorModeKernel.cu    |  2 +-
+ aten/src/ATen/native/cuda/TensorTopK.cu          |  4 ++++
  aten/src/ATen/native/cuda/block_reduce.cuh       | 12 +++++++++++-
  c10/macros/Macros.h                              | 16 +++++++++++++++-
  .../csrc/distributed/c10d/CUDASymmetricMemory.cu |  6 +++---
  .../distributed/c10d/CUDASymmetricMemoryOps.cu   |  2 +-
- 8 files changed, 41 insertions(+), 16 deletions(-)
+ 9 files changed, 45 insertions(+), 16 deletions(-)
 
 diff --git a/aten/src/ATen/native/cuda/Embedding.cu b/aten/src/ATen/native/cuda/Embedding.cu
 index 5d19b95b32f..4b1e420d5da 100644
@@ -107,6 +108,23 @@ index 4764b078c05..0c97ab74210 100644
    const auto memsize =
        (sizeof(scalar_t) * size) + (2 * size * sizeof(unsigned int));
    compute_mode<scalar_t, size>
+diff --git a/aten/src/ATen/native/cuda/TensorTopK.cu b/aten/src/ATen/native/cuda/TensorTopK.cu
+index 103b360bcb8..49086c42cd4 100644
+--- a/aten/src/ATen/native/cuda/TensorTopK.cu
++++ b/aten/src/ATen/native/cuda/TensorTopK.cu
+@@ -439,8 +439,12 @@ __global__ void computeBlockwiseWithinKCounts(
+     warp_counts[warp] = count;
+   }
+   __syncthreads();
++#ifdef USE_ROCM
++  CUDA_KERNEL_ASSERT(RADIX_DIGITS < C10_WARP_SIZE * C10_WARP_SIZE);
++#else
+   static_assert(RADIX_DIGITS < C10_WARP_SIZE * C10_WARP_SIZE,
+     "Assuming only 1 warp is needed for final reduction");
++#endif
+   if (warp != 0) {
+     return;
+   }
 diff --git a/aten/src/ATen/native/cuda/block_reduce.cuh b/aten/src/ATen/native/cuda/block_reduce.cuh
 index 2a272d22c0c..1818987c6a5 100644
 --- a/aten/src/ATen/native/cuda/block_reduce.cuh

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0002-ROCm-Backport-Remove-use-of-warpsize-on-host-side-co.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0002-ROCm-Backport-Remove-use-of-warpsize-on-host-side-co.patch
@@ -1,0 +1,224 @@
+From 55d67353e58c8c63683f9f1228a4b58f0c3ef824 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Wed, 16 Jul 2025 12:09:14 -0700
+Subject: [PATCH 02/02] [ROCm] Backport "Remove use of warpsize on host-side
+ compilation".
+
+https://github.com/pytorch/pytorch/commit/04bd7e6850e8efec77994963ffee87549555b9c3
+---
+ aten/src/ATen/native/cuda/Embedding.cu        |  2 +-
+ .../src/ATen/native/cuda/MultinomialKernel.cu |  2 +-
+ aten/src/ATen/native/cuda/SoftMax.cu          | 19 ++++++++++---------
+ aten/src/ATen/native/cuda/TensorModeKernel.cu |  2 +-
+ aten/src/ATen/native/cuda/block_reduce.cuh    | 12 +++++++++++-
+ c10/macros/Macros.h                           | 16 +++++++++++++++-
+ .../distributed/c10d/CUDASymmetricMemory.cu   |  6 +++---
+ .../c10d/CUDASymmetricMemoryOps.cu            |  2 +-
+ 8 files changed, 43 insertions(+), 18 deletions(-)
+
+diff --git a/aten/src/ATen/native/cuda/Embedding.cu b/aten/src/ATen/native/cuda/Embedding.cu
+index 5d19b95b32f..4b1e420d5da 100644
+--- a/aten/src/ATen/native/cuda/Embedding.cu
++++ b/aten/src/ATen/native/cuda/Embedding.cu
+@@ -369,7 +369,7 @@ Tensor & embedding_renorm_cuda_(Tensor & self, const Tensor & indices,
+ 
+     int warp_size = at::cuda::warp_size();
+     TORCH_INTERNAL_ASSERT(num_threads() % warp_size == 0 &&
+-                  num_threads() <= cuda_utils::kCUDABlockReduceMaxThreads,
++                  num_threads() <= cuda_utils::kCUDABlockReduceMaxThreads(),
+                   "BlockReduceSum requires all warps be active");
+     const int64_t *num_unique_indices_ptr = num_unique_indices.const_data_ptr<int64_t>();
+     dim3 grid = unique_indices.numel();
+diff --git a/aten/src/ATen/native/cuda/MultinomialKernel.cu b/aten/src/ATen/native/cuda/MultinomialKernel.cu
+index 65770e40a8b..8132e7df57b 100644
+--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
++++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
+@@ -86,7 +86,7 @@ void renormRows(Tensor& t) {
+   TORCH_CHECK(props != nullptr);
+   int numSM = props->multiProcessorCount;
+   const int64_t maxThreads = std::min(
+-      props->maxThreadsPerBlock, cuda_utils::kCUDABlockReduceMaxThreads);
++      props->maxThreadsPerBlock, cuda_utils::kCUDABlockReduceMaxThreads());
+ 
+   int warp_size = at::cuda::warp_size();
+   dim3 grid(rows < numSM * 4 ? rows : numSM * 4);
+diff --git a/aten/src/ATen/native/cuda/SoftMax.cu b/aten/src/ATen/native/cuda/SoftMax.cu
+index 2062a14cdba..bd45e8c0a08 100644
+--- a/aten/src/ATen/native/cuda/SoftMax.cu
++++ b/aten/src/ATen/native/cuda/SoftMax.cu
+@@ -177,15 +177,16 @@ inline dim3 SoftMaxForward_getBlockSize(uint64_t dim_size) {
+   uint64_t block_size = 1;
+   uint64_t max_block_size = std::min(dim_size, static_cast<uint64_t>(max_threads));
+ 
+-  // We need a block size that is a multiple of C10_WARP_SIZE in order
++  // We need a block size that is a multiple of at::cuda::warp_size() in order
+   // to perform block size reductions using warp shuffle instructions.
+-  // Since max_threads is also a multiple of C10_WARPS_SIZE we do not
++  // Since max_threads is also a multiple of at::cuda::warp_size() we do not
+   // risk creating a block size larger than the limit.
+ 
+-  if (max_block_size % C10_WARP_SIZE == 0) {
++  int warp_size = at::cuda::warp_size();
++  if (max_block_size % warp_size == 0) {
+     block_size = max_block_size;
+   } else {
+-    block_size = (max_block_size / C10_WARP_SIZE + 1) * C10_WARP_SIZE;
++    block_size = (max_block_size / warp_size + 1) * warp_size;
+   }
+ 
+   return dim3(block_size);
+@@ -409,7 +410,7 @@ blockReduce(AccumT* smem, AccumT val,
+     if (lane < blockDim.x / C10_WARP_SIZE) {
+ #pragma unroll
+       for (int i = 0; i < C10_WARP_SIZE; ++i) {
+-        warpVal = r(warpVal, smem[lane * C10_WARP_SIZE + i]);
++        warpVal = r(warpVal, smem[lane * at::cuda::warp_size() + i]);
+       }
+ #if !defined(USE_ROCM)
+       __syncwarp(mask);
+@@ -424,7 +425,7 @@ blockReduce(AccumT* smem, AccumT val,
+   AccumT blockVal = defaultVal;
+ 
+   if (threadIdx.x == 0) {
+-    for (int i = 0; i < blockDim.x / C10_WARP_SIZE; ++i) {
++    for (int i = 0; i < blockDim.x / at::cuda::warp_size(); ++i) {
+       blockVal = r(blockVal, smem[i]);
+     }
+     smem[0] = blockVal;
+@@ -978,7 +979,7 @@ Tensor host_softmax(const Tensor & input_, const int64_t dim_, const bool half_t
+           } else {
+             constexpr int ILP = sizeof(float4) / sizeof(scalar_t);
+             dim3 block = SoftMaxForward_getBlockSize(dim_size);
+-            size_t smem_reduction_sz = block.x / C10_WARP_SIZE * sizeof(accscalar_t);
++            size_t smem_reduction_sz = block.x / at::cuda::warp_size() * sizeof(accscalar_t);
+             auto max_elements_per_smem = (at::cuda::getCurrentDeviceProperties()->sharedMemPerBlock -
+               smem_reduction_sz) / sizeof(scalar_t);
+ 
+@@ -1057,7 +1058,7 @@ Tensor host_softmax(const Tensor & input_, const int64_t dim_, const bool half_t
+           } else {
+             constexpr int ILP = sizeof(float4) / sizeof(scalar_t);
+             dim3 block = SoftMaxForward_getBlockSize(dim_size);
+-            size_t smem_reduction_sz = block.x / C10_WARP_SIZE * sizeof(accscalar_t);
++            size_t smem_reduction_sz = block.x / at::cuda::warp_size() * sizeof(accscalar_t);
+             auto max_elements_per_smem = (at::cuda::getCurrentDeviceProperties()->sharedMemPerBlock -
+               smem_reduction_sz) / sizeof(scalar_t);
+ 
+@@ -1122,7 +1123,7 @@ void dispatch_host_softmax_backward(int64_t dim_size, dim3 grid, Tensor &grad, T
+   constexpr int ILP = sizeof(float4) / sizeof(output_t);
+   dim3 block = SoftMax_getBlockSize(ILP, dim_size);
+ 
+-  size_t smem_reduction_sz = block.x / C10_WARP_SIZE * sizeof(accscalar_t);
++  size_t smem_reduction_sz = block.x / at::cuda::warp_size() * sizeof(accscalar_t);
+   auto max_elements_per_smem = (at::cuda::getCurrentDeviceProperties()->sharedMemPerBlock -
+     smem_reduction_sz) / sizeof(output_t);
+   bool can_use_smem = static_cast<size_t>(dim_size) < max_elements_per_smem;
+diff --git a/aten/src/ATen/native/cuda/TensorModeKernel.cu b/aten/src/ATen/native/cuda/TensorModeKernel.cu
+index 4764b078c05..0c97ab74210 100644
+--- a/aten/src/ATen/native/cuda/TensorModeKernel.cu
++++ b/aten/src/ATen/native/cuda/TensorModeKernel.cu
+@@ -207,7 +207,7 @@ void handle_fused_mode(
+   constexpr int num_threads = size / 2;
+   int warp_size = at::cuda::warp_size();
+   TORCH_INTERNAL_ASSERT(num_threads % warp_size == 0 &&
+-                num_threads <= cuda_utils::kCUDABlockReduceMaxThreads, "");
++                num_threads <= cuda_utils::kCUDABlockReduceMaxThreads(), "");
+   const auto memsize =
+       (sizeof(scalar_t) * size) + (2 * size * sizeof(unsigned int));
+   compute_mode<scalar_t, size>
+diff --git a/aten/src/ATen/native/cuda/block_reduce.cuh b/aten/src/ATen/native/cuda/block_reduce.cuh
+index 2a272d22c0c..1818987c6a5 100644
+--- a/aten/src/ATen/native/cuda/block_reduce.cuh
++++ b/aten/src/ATen/native/cuda/block_reduce.cuh
+@@ -12,7 +12,17 @@ constexpr int kCUDABlockReduceNumThreads = 512;
+ // of which reduces C10_WARP_SIZE elements. So, at most
+ // C10_WARP_SIZE**2 elements can be reduced at a time.
+ // NOTE: This is >= the max block size on current hardware anyway (1024).
+-constexpr int kCUDABlockReduceMaxThreads = C10_WARP_SIZE * C10_WARP_SIZE;
++// ROCm NOTE: C10_WARP_SIZE should only be used inside device functions,
++// and kCUDABlockReduceMaxThreads is a host-side variable.
++#ifdef USE_ROCM
++static int kCUDABlockReduceMaxThreads() {
++    return at::cuda::warp_size() * at::cuda::warp_size();
++}
++#else
++constexpr int kCUDABlockReduceMaxThreads() {
++    return C10_WARP_SIZE * C10_WARP_SIZE;
++}
++#endif
+ 
+ // Sums `val` across all threads in a warp.
+ //
+diff --git a/c10/macros/Macros.h b/c10/macros/Macros.h
+index 919eb6c8567..1c4e451df94 100644
+--- a/c10/macros/Macros.h
++++ b/c10/macros/Macros.h
+@@ -312,7 +312,21 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
+ #endif
+ 
+ #if defined(USE_ROCM)
+-#define C10_WARP_SIZE warpSize // = 64 or 32 (Defined in hip_runtime.h)
++// C10_WARP_SIZE is only allowed for device code.
++// Host code _must_ use at::cuda::warp_size()
++// HIP header used to define warpSize as a constexpr that was either 32 or 64
++// depending on the target device, and then always set it to 64 for host code.
++// Host pass of HIP compiler needs C10_WARP_SIZE defined to _something_ so we
++// set it to something unreasonable to trigger obvious host code errors.
++#if defined(__HIP_DEVICE_COMPILE__)
++#if defined(__GFX9__)
++static constexpr int C10_WARP_SIZE = 64;
++#else // __GFX9__
++static constexpr int C10_WARP_SIZE = 32;
++#endif // __GFX9__
++#else
++static constexpr int C10_WARP_SIZE = 1;
++#endif // __HIP_DEVICE_COMPILE__
+ #else
+ #define C10_WARP_SIZE 32
+ #endif
+diff --git a/torch/csrc/distributed/c10d/CUDASymmetricMemory.cu b/torch/csrc/distributed/c10d/CUDASymmetricMemory.cu
+index 172304479e9..ac77aba2e7b 100644
+--- a/torch/csrc/distributed/c10d/CUDASymmetricMemory.cu
++++ b/torch/csrc/distributed/c10d/CUDASymmetricMemory.cu
+@@ -471,7 +471,7 @@ static __global__ void barrier_kernel(
+ void CUDASymmetricMemory::barrier(int channel, size_t timeout_ms) {
+   check_channel(channel, world_size_);
+   c10::cuda::CUDAGuard guard(local_device_idx_);
+-  barrier_kernel<<<1, C10_WARP_SIZE, 0, at::cuda::getCurrentCUDAStream()>>>(
++  barrier_kernel<<<1, at::cuda::warp_size(), 0, at::cuda::getCurrentCUDAStream()>>>(
+       reinterpret_cast<uint32_t**>(signal_pads_dev_),
+       channel,
+       rank_,
+@@ -509,7 +509,7 @@ void CUDASymmetricMemory::put_signal(
+     size_t timeout_ms) {
+   check_channel(channel, world_size_);
+   c10::cuda::CUDAGuard guard(local_device_idx_);
+-  put_signal_kernel<<<1, C10_WARP_SIZE, 0, at::cuda::getCurrentCUDAStream()>>>(
++  put_signal_kernel<<<1, at::cuda::warp_size(), 0, at::cuda::getCurrentCUDAStream()>>>(
+       reinterpret_cast<uint32_t**>(signal_pads_dev_),
+       dst_rank,
+       channel,
+@@ -553,7 +553,7 @@ void CUDASymmetricMemory::wait_signal(
+     size_t timeout_ms) {
+   check_channel(channel, world_size_);
+   c10::cuda::CUDAGuard guard(local_device_idx_);
+-  wait_signal_kernel<<<1, C10_WARP_SIZE, 0, at::cuda::getCurrentCUDAStream()>>>(
++  wait_signal_kernel<<<1, at::cuda::warp_size(), 0, at::cuda::getCurrentCUDAStream()>>>(
+       reinterpret_cast<uint32_t**>(signal_pads_dev_),
+       src_rank,
+       channel,
+diff --git a/torch/csrc/distributed/c10d/CUDASymmetricMemoryOps.cu b/torch/csrc/distributed/c10d/CUDASymmetricMemoryOps.cu
+index 438624f4bc0..9fe3146e399 100644
+--- a/torch/csrc/distributed/c10d/CUDASymmetricMemoryOps.cu
++++ b/torch/csrc/distributed/c10d/CUDASymmetricMemoryOps.cu
+@@ -104,7 +104,7 @@ void init_elementwise_launch_config(
+     num_blocks = 1;
+     num_threads = at::round_up(
+         at::ceil_div(numel_per_split, numel_per_thread),
+-        static_cast<size_t>(C10_WARP_SIZE));
++        static_cast<size_t>(at::cuda::warp_size()));
+   } else {
+     num_blocks = std::min(
+         at::ceil_div(numel_per_split, max_num_threads * numel_per_thread),
+-- 
+2.47.1.windows.2
+

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0002-ROCm-Backport-Remove-use-of-warpsize-on-host-side-co.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0002-ROCm-Backport-Remove-use-of-warpsize-on-host-side-co.patch
@@ -67,24 +67,6 @@ index 2062a14cdba..bd45e8c0a08 100644
    }
  
    return dim3(block_size);
-@@ -409,7 +410,7 @@ blockReduce(AccumT* smem, AccumT val,
-     if (lane < blockDim.x / C10_WARP_SIZE) {
- #pragma unroll
-       for (int i = 0; i < C10_WARP_SIZE; ++i) {
--        warpVal = r(warpVal, smem[lane * C10_WARP_SIZE + i]);
-+        warpVal = r(warpVal, smem[lane * at::cuda::warp_size() + i]);
-       }
- #if !defined(USE_ROCM)
-       __syncwarp(mask);
-@@ -424,7 +425,7 @@ blockReduce(AccumT* smem, AccumT val,
-   AccumT blockVal = defaultVal;
- 
-   if (threadIdx.x == 0) {
--    for (int i = 0; i < blockDim.x / C10_WARP_SIZE; ++i) {
-+    for (int i = 0; i < blockDim.x / at::cuda::warp_size(); ++i) {
-       blockVal = r(blockVal, smem[i]);
-     }
-     smem[0] = blockVal;
 @@ -978,7 +979,7 @@ Tensor host_softmax(const Tensor & input_, const int64_t dim_, const bool half_t
            } else {
              constexpr int ILP = sizeof(float4) / sizeof(scalar_t);

--- a/external-builds/pytorch/repo_management.py
+++ b/external-builds/pytorch/repo_management.py
@@ -289,7 +289,7 @@ def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
         commit_hipify(args)
 
     # Hipified patches.
-    if args.patch and patches_dir_name:
+    if args.hipify and args.patch and patches_dir_name:
         apply_all_patches(
             repo_dir,
             repo_patch_dir_base / patches_dir_name,


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/1048.

This backports https://github.com/pytorch/pytorch/commit/04bd7e6850e8efec77994963ffee87549555b9c3 onto our 2.7.0 patches to accommodate the breaking changes in https://github.com/ROCm/clr/commit/54503f0d677df44d1a17a8e66f0c60a4e000393f. The commit did not apply cleanly with a regular cherry-pick and needed to be applied _before_ running HIPIFY, so I made these changes manually (which was quite painful). We can't sustain this style of backporting patches so need to make progress on https://github.com/ROCm/TheRock/issues/1039 and using https://github.com/ROCm/pytorch/ soon.

Tested locally on Windows:
```bash
# Install last night's rocm packages
python -m pip install --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ rocm[libraries,devel] --upgrade

# Checkout, apply patches, HIPIFY, etc.
python pytorch_torch_repo.py checkout --repo D:/b/pytorch_v2.7.0

# Build
python build_prod_wheels.py build --output-dir %HOME%/.therock/pytorch --pytorch-dir D:/b/pytorch_v2.7.0
```