### PR TITLE
[python] Replace explicit .so/.dll versions with glob patterns.

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__init__.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__init__.py
@@ -35,7 +35,7 @@ def find_libraries(*shortnames: str) -> list[Path]:
         except KeyError:
             raise ModuleNotFoundError(f"Unknown rocm library '{shortname}'")
 
-        if is_windows and not lib_entry.dllname:
+        if is_windows and not lib_entry.dll_pattern:
             # Library is missing on Windows, skip it.
             # TODO(#827): Require callers to filter and error here instead?
             continue
@@ -52,10 +52,10 @@ def find_libraries(*shortnames: str) -> list[Path]:
         py_root = Path(py_module.__file__).parent  # Chop __init__.py
         if is_windows:
             relpath = py_root / lib_entry.windows_relpath
-            entry_pattern = lib_entry.dllname
+            entry_pattern = lib_entry.dll_pattern
         else:
             relpath = py_root / lib_entry.posix_relpath
-            entry_pattern = lib_entry.soname
+            entry_pattern = lib_entry.so_pattern
         matching_paths = sorted(relpath.glob(entry_pattern))
         if len(matching_paths) == 0:
             raise FileNotFoundError(

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -6,7 +6,6 @@ of bootstrapping, we are including it inline for the moment.
 
 import importlib.util
 import os
-import platform
 
 
 CACHED_TARGET_FAMILY: str | None = None
@@ -16,18 +15,20 @@ class LibraryEntry:
     """Defines a public library that can be located by name within the overall
     distribution."""
 
-    def __init__(self, shortname: str, package_name: str, soname: str, dllname: str):
+    def __init__(
+        self, shortname: str, package_name: str, so_pattern: str, dll_pattern: str
+    ):
         self.shortname = shortname
         self.package = ALL_PACKAGES[package_name]
         self.posix_relpath = "lib"
         self.windows_relpath = "bin"
-        self.soname = soname
-        self.dllname = dllname
+        self.so_pattern = so_pattern
+        self.dll_pattern = dll_pattern
         assert shortname not in ALL_LIBRARIES
         ALL_LIBRARIES[shortname] = self
 
     def __repr__(self):
-        return f"{self.shortname}(soname={self.soname}, dllname={self.dllname}, package={self.package})"
+        return f"{self.shortname}(so_pattern={self.so_pattern}, dll_pattern={self.dll_pattern}, package={self.package})"
 
 
 class PackageEntry:
@@ -161,22 +162,22 @@ PackageEntry(
 # TODO(#703,#1057): Use patterns for version suffixes and platform differences too?
 
 # Public libraries.
-LibraryEntry("amdhip64", "core", "libamdhip64.so*", "amdhip64*.dll")
+LibraryEntry("amdhip64", "core", "libamdhip64.so", "amdhip64*.dll")
 # The DLL glob here uses '0' from the version to avoid matching 'hiprtc-builtins'.
 # If DLLs with no version suffix are later added we will need a different pattern.
-LibraryEntry("hiprtc", "core", "libhiprtc.so*", "hiprtc0*.dll")
-LibraryEntry("roctx64", "core", "libroctx64.so*", "")
-LibraryEntry("rocprofiler-sdk-roctx", "core", "librocprofiler-sdk-roctx.so*", "")
+LibraryEntry("hiprtc", "core", "libhiprtc.so", "hiprtc0*.dll")
+LibraryEntry("roctx64", "core", "libroctx64.so", "")
+LibraryEntry("rocprofiler-sdk-roctx", "core", "librocprofiler-sdk-roctx.so", "")
 
-LibraryEntry("amd_comgr", "core", "libamd_comgr.so*", "amd_comgr*.dll")
-LibraryEntry("hipblas", "libraries", "libhipblas.so*", "libhipblas*.dll")
-LibraryEntry("hipfft", "libraries", "libhipfft.so*", "hipfft*.dll")
-LibraryEntry("hiprand", "libraries", "libhiprand.so*", "hiprand*.dll")
-LibraryEntry("hipsparse", "libraries", "libhipsparse.so*", "hipsparse*.dll")
-LibraryEntry("hipsolver", "libraries", "libhipsolver.so*", "hipsolver*.dll")
-LibraryEntry("rccl", "libraries", "librccl.so*", "")
-LibraryEntry("hipblaslt", "libraries", "libhipblaslt.so*", "hipblaslt*.dll")
-LibraryEntry("miopen", "libraries", "libMIOpen.so*", "MIOpen*.dll")
+LibraryEntry("amd_comgr", "core", "libamd_comgr.so", "amd_comgr*.dll")
+LibraryEntry("hipblas", "libraries", "libhipblas.so", "libhipblas*.dll")
+LibraryEntry("hipfft", "libraries", "libhipfft.so", "hipfft*.dll")
+LibraryEntry("hiprand", "libraries", "libhiprand.so", "hiprand*.dll")
+LibraryEntry("hipsparse", "libraries", "libhipsparse.so", "hipsparse*.dll")
+LibraryEntry("hipsolver", "libraries", "libhipsolver.so", "hipsolver*.dll")
+LibraryEntry("rccl", "libraries", "librccl.so", "")
+LibraryEntry("hipblaslt", "libraries", "libhipblaslt.so", "hipblaslt*.dll")
+LibraryEntry("miopen", "libraries", "libMIOpen.so", "MIOpen*.dll")
 
 # Others we may want:
 # hiprtc-builtins

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -158,23 +158,34 @@ PackageEntry(
     required=False,
 )
 
-# TODO(#703): Use patterns for version suffixes and platform differences.
+# TODO(#703,#1057): Use patterns for version suffixes and platform differences too?
 
 # Public libraries.
-LibraryEntry("amdhip64", "core", "libamdhip64.so.7", "amdhip64_7.dll")
-LibraryEntry("hiprtc", "core", "libhiprtc.so.7", "hiprtc0700.dll")
-LibraryEntry("roctx64", "core", "libroctx64.so.4", "")
-LibraryEntry("rocprofiler-sdk-roctx", "core", "librocprofiler-sdk-roctx.so.1", "")
+LibraryEntry("amdhip64", "core", "libamdhip64.so*", "amdhip64*.dll")
+# The DLL glob here uses '0' from the version to avoid matching 'hiprtc-builtins'.
+# If DLLs with no version suffix are later added we will need a different pattern.
+LibraryEntry("hiprtc", "core", "libhiprtc.so*", "hiprtc0*.dll")
+LibraryEntry("roctx64", "core", "libroctx64.so*", "")
+LibraryEntry("rocprofiler-sdk-roctx", "core", "librocprofiler-sdk-roctx.so*", "")
 
-LibraryEntry("amd_comgr", "core", "libamd_comgr.so.3", "amd_comgr0700.dll")
-LibraryEntry("hipblas", "libraries", "libhipblas.so.3", "libhipblas.dll")
-LibraryEntry("hipfft", "libraries", "libhipfft.so.0", "hipfft.dll")
-LibraryEntry("hiprand", "libraries", "libhiprand.so.1", "hiprand.dll")
-LibraryEntry("hipsparse", "libraries", "libhipsparse.so.4", "hipsparse.dll")
-LibraryEntry("hipsolver", "libraries", "libhipsolver.so.1", "hipsolver.dll")
-LibraryEntry("rccl", "libraries", "librccl.so.1", "")
-LibraryEntry("hipblaslt", "libraries", "libhipblaslt.so.1", "hipblaslt.dll")
-LibraryEntry("miopen", "libraries", "libMIOpen.so.1", "MIOpen.dll")
+LibraryEntry("amd_comgr", "core", "libamd_comgr.so*", "amd_comgr*.dll")
+LibraryEntry("hipblas", "libraries", "libhipblas.so*", "libhipblas*.dll")
+LibraryEntry("hipfft", "libraries", "libhipfft.so*", "hipfft*.dll")
+LibraryEntry("hiprand", "libraries", "libhiprand.so*", "hiprand*.dll")
+LibraryEntry("hipsparse", "libraries", "libhipsparse.so*", "hipsparse*.dll")
+LibraryEntry("hipsolver", "libraries", "libhipsolver.so*", "hipsolver*.dll")
+LibraryEntry("rccl", "libraries", "librccl.so*", "")
+LibraryEntry("hipblaslt", "libraries", "libhipblaslt.so*", "hipblaslt*.dll")
+LibraryEntry("miopen", "libraries", "libMIOpen.so*", "MIOpen*.dll")
+
+# Others we may want:
+# hiprtc-builtins
+# rocblas
+# rocfft
+# rocm-openblas
+# rocrand
+# rocsolver
+# rocsparse
 
 # Overall ROCM package version.
 __version__ = "DEFAULT"


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/1057.

* Tested manually on Windows.
* Linux testing will either need someone with a development environment there, for our CI workflows to run `rocm-sdk test`, or for Linux PyTorch builds to be fixed (https://github.com/ROCm/TheRock/issues/1048).