### PR TITLE
[torch][windows] Workaround torch.randn hang in smoke tests.

### DIFF
--- a/external-builds/pytorch/smoke-tests/pytorch_smoke_test.py
+++ b/external-builds/pytorch/smoke-tests/pytorch_smoke_test.py
@@ -101,6 +101,11 @@ class TestConvolutions:
         # TODO: check conv output values (and don't use randn)
         assert result.device.type == "cuda"
 
+        # TODO(#999): fix tests stalling if the result is not used. Missing a flush() somewhere?
+        #             this occurs with just "torch.randn" on its own too
+        result_cpu = result.cpu()
+        assert result_cpu.device.type == "cpu"
+
     # Lifted from
     # https://github.com/pytorch/pytorch/blob/main/test/nn/test_convolution.py
     def test_conv_cudnn_nhwc_support(self):
@@ -113,3 +118,8 @@ class TestConvolutions:
         weight = weight.to(memory_format=torch.channels_last)
         o = torch.conv2d(input, weight, None, (2, 1), (1, 1), (1, 1), 1)
         assert o.is_contiguous(memory_format=torch.channels_last)
+
+        # TODO(#999): fix tests stalling if the result is not used. Missing a flush() somewhere?
+        #             this occurs with just "torch.randn" on its own too
+        o_cpu = o.cpu()
+        assert o_cpu.device.type == "cpu"


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/999.

This is enough to unblock running these tests on CI. We will need a deeper investigation and fix.

Minimal repro:

```python
# test.py
import torch
tensor_gpu = torch.randn(1, 1, device="cuda")
# Calling `python test.py` does _not_ terminate
```

```python
# test_print.py
import torch
tensor_gpu = torch.randn(1, 1, device="cuda")
print(tensor_gpu)
# Calling `python test_print.py` _does_ terminate
```