### PR TITLE
Bump nlohmann-json to v3.12.0

### DIFF
--- a/third-party/nlohmann-json/CMakeLists.txt
+++ b/third-party/nlohmann-json/CMakeLists.txt
@@ -1,8 +1,8 @@
 therock_subproject_fetch(therock-nlohmann-json-sources
   CMAKE_PROJECT
-  # Originally mirrored from: https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
-  URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/json-3.11.3.tar.gz
-  URL_HASH SHA256=d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d
+  # Originally mirrored from: https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
+  URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/json-3.12.0.tar.gz
+  URL_HASH SHA256=42F6E95CAD6EC532FD372391373363B62A14AF6D771056DBFC86160E6DFFF7AA
 )
 
 therock_cmake_subproject_declare(therock-nlohmann-json


### PR DESCRIPTION
Bumping submodules while using the older version results in build failures:
```
2025-07-01T16:36:01.3809855Z [MIOpen] In file included from /__w/TheRock/TheRock/build/third-party/nlohmann-json/dist/include/nlohmann/adl_serializer.hpp:14:
2025-07-01T16:36:01.3811905Z [MIOpen] /__w/TheRock/TheRock/build/third-party/nlohmann-json/dist/include/nlohmann/detail/conversions/from_json.hpp:53:13: error: cannot convert 'const nlohmann::basic_json<>' to 'value_t' without a conversion operator
2025-07-01T16:36:01.3813339Z [MIOpen]    53 |     switch (static_cast<value_t>(j))
2025-07-01T16:36:01.3813790Z [MIOpen]       |             ^~~~~~~~~~~~~~~~~~~~~~~
2025-07-01T16:36:01.3815523Z [MIOpen] /__w/TheRock/TheRock/build/third-party/nlohmann-json/dist/include/nlohmann/detail/conversions/from_json.hpp:135:5: note: in instantiation of function template specialization 'nlohmann::detail::get_arithmetic_value<nlohmann::basic_json<>, long, 0>' requested here
2025-07-01T16:36:01.3817296Z [MIOpen]   135 |     get_arithmetic_value(j, val);
2025-07-01T16:36:01.3817731Z [MIOpen]       |     ^
2025-07-01T16:36:01.3819333Z [MIOpen] /__w/TheRock/TheRock/build/third-party/nlohmann-json/dist/include/nlohmann/detail/conversions/from_json.hpp:478:16: note: in instantiation of function template specialization 'nlohmann::detail::from_json<nlohmann::basic_json<>>' requested here
2025-07-01T16:36:01.3821527Z [MIOpen]   478 |         return from_json(j, std::forward<T>(val));
2025-07-01T16:36:01.3822018Z [MIOpen]       |                ^
2025-07-01T16:36:01.3823603Z [MIOpen] /__w/TheRock/TheRock/build/third-party/nlohmann-json/dist/include/nlohmann/adl_serializer.hpp:31:9: note: in instantiation of function template specialization 'nlohmann::detail::from_json_fn::operator()<nlohmann::basic_json<>, long &>' requested here
2025-07-01T16:36:01.3825255Z [MIOpen]    31 |         ::nlohmann::from_json(std::forward<BasicJsonType>(j), val);
2025-07-01T16:36:01.3825765Z [MIOpen]       |         ^
2025-07-01T16:36:01.3827295Z [MIOpen] /__w/TheRock/TheRock/build/third-party/nlohmann-json/dist/include/nlohmann/json.hpp:1801:36: note: in instantiation of function template specialization 'nlohmann::adl_serializer<long>::from_json<const nlohmann::basic_json<> &, long>' requested here
2025-07-01T16:36:01.3828996Z [MIOpen]  1801 |         JSONSerializer<ValueType>::from_json(*this, v);
2025-07-01T16:36:01.3829556Z [MIOpen]       |                                    ^
2025-07-01T16:36:01.3830881Z [MIOpen] /__w/TheRock/TheRock/ml-libs/MIOpen/src/graphapi/tensor.cpp:317:37: note: in instantiation of function template specialization 'nlohmann::basic_json<>::get_to<long, 0>' requested here
2025-07-01T16:36:01.3832343Z [MIOpen]   317 |     json.at(Tensor::JsonFields::Id).get_to(tensor.mId);
2025-07-01T16:36:01.3833306Z [MIOpen]       |                                     ^
2025-07-01T16:36:01.3833972Z [MIOpen] 3 warnings and 1 error generated when compiling for gfx1100.
2025-07-01T16:36:01.3834783Z [MIOpen] [168/668] Building CXX object src/CMakeFiles/MIOpen.dir/fin/fin_interface.cpp.o
2025-07-01T16:36:01.3835690Z [MIOpen] [169/668] Building CXX object src/CMakeFiles/MIOpen.dir/mha/mha_descriptor.cpp.o
2025-07-01T16:36:01.3836532Z [MIOpen] FAILED: src/CMakeFiles/MIOpen.dir/mha/mha_descriptor.cpp.o
```