### PR TITLE
[ci] - Adding conditional for AWS configure

### DIFF
--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -13,6 +13,9 @@ inputs:
     type: string
   FETCH_ARTIFACT_ARGS:
     type: string
+  IS_PR_FROM_FORK:
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
@@ -56,6 +59,7 @@ runs:
         AMDGPU_FAMILIES: ${{ inputs.AMDGPU_FAMILIES }}
         FETCH_ARTIFACT_ARGS: ${{ inputs.FETCH_ARTIFACT_ARGS }}
         GITHUB_TOKEN: ${{ github.token }}
+        IS_PR_FROM_FORK: ${{ inputs.IS_PR_FROM_FORK }}
       run: |
         python ./build_tools/install_rocm_from_artifacts.py \
           --run-id=${ARTIFACT_RUN_ID} \

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -48,8 +48,7 @@ jobs:
       CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       TEATIME_FORCE_INTERACTIVE: 0
-      IS_FORKED_PR: ${{ github.event.pull_request.head.repo.fork }}
-
+      IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -168,7 +167,7 @@ jobs:
             --build-dir build
 
       - name: Upload job metrics to Redshift database
-        if: ${{ github.repository == 'ROCm/TheRock' && always() && !github.event.pull_request.head.repo.fork }}
+        if: ${{ always() && github.repository == 'ROCm/TheRock' && !github.event.pull_request.head.repo.fork }}
         env:
           RUN_ID: ${{ github.run_id }}
           ATTEMPT: ${{ github.run_attempt }}

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -43,7 +43,7 @@ jobs:
       CCACHE_MAXSIZE: "4000M"
       TEATIME_FORCE_INTERACTIVE: 0
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
-      IS_FORKED_PR: ${{ github.event.pull_request.head.repo.fork }}
+      IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -97,6 +97,7 @@ jobs:
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
           FETCH_ARTIFACT_ARGS: ${{ matrix.components.fetch_artifact_args }}
+          IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
       - name: Install additional packages
         if: ${{ runner.os == 'Linux' && (matrix.components.job_name == 'rocblas' || matrix.components.job_name == 'hipblaslt') }}

--- a/build_tools/github_actions/upload_build_artifacts.py
+++ b/build_tools/github_actions/upload_build_artifacts.py
@@ -31,16 +31,16 @@ def exec(cmd: list[str], cwd: Path):
 
 def retrieve_bucket_info() -> tuple[str, str]:
     github_repository = os.getenv("GITHUB_REPOSITORY", "ROCm/TheRock")
-    is_forked_pr = os.getenv("IS_FORKED_PR", False)
+    is_pr_from_fork = os.getenv("IS_PR_FROM_FORK", False)
     owner, repo_name = github_repository.split("/")
     external_repo = (
         ""
-        if repo_name == "TheRock" and owner == "ROCm" and not is_forked_pr
+        if repo_name == "TheRock" and owner == "ROCm" and not is_pr_from_fork
         else f"{owner}-{repo_name}/"
     )
     bucket = (
         "therock-artifacts"
-        if repo_name == "TheRock" and owner == "ROCm" and not is_forked_pr
+        if repo_name == "TheRock" and owner == "ROCm" and not is_pr_from_fork
         else "therock-artifacts-external"
     )
     return (external_repo, bucket)


### PR DESCRIPTION
Previously, forks were unable to upload to AWS S3 bucket due to insufficient `id-token` permissions. 

Now, the Linux and Windows GitHub runners are authenticated with S3 ([GitHub ARC Setup PR 10](https://github.com/nod-ai/GitHub-ARC-Setup/pull/10)), so forks are able to upload to our external bucket <b>only</b>.

Of course, for forks, we need to allow "approve run" for GitHub runs, so no one exposes the AWS secret. This is already set in settings ("Require approval for all external contributors")

Closes #203 

Next items:
- update in rocm-libraries, CK and RCCL (i plan to do some reusability work to make this updating more seamless)