### PR TITLE
Introduce github_actions_utils.py to share common functions.

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -43,7 +43,7 @@ import json
 import os
 import subprocess
 import sys
-from typing import Iterable, List, Mapping, Optional
+from typing import Iterable, List, Optional
 import string
 from amdgpu_family_matrix import (
     amdgpu_family_info_matrix_presubmit,
@@ -51,36 +51,7 @@ from amdgpu_family_matrix import (
     amdgpu_family_matrix_xfail,
 )
 
-# --------------------------------------------------------------------------- #
-# General utilities
-# --------------------------------------------------------------------------- #
-
-
-def set_github_output(d: Mapping[str, str]):
-    """Sets GITHUB_OUTPUT values.
-    See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs
-    """
-    print(f"Setting github output:\n{d}")
-    step_output_file = os.environ.get("GITHUB_OUTPUT", "")
-    if not step_output_file:
-        print("Warning: GITHUB_OUTPUT env var not set, can't set github outputs")
-        return
-    with open(step_output_file, "a") as f:
-        f.writelines(f"{k}={v}" + "\n" for k, v in d.items())
-
-
-def write_job_summary(summary: str):
-    """Appends a string to the GitHub Actions job summary.
-    See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
-    """
-    print(f"Writing job summary:\n{summary}")
-    step_summary_file = os.environ.get("GITHUB_STEP_SUMMARY", "")
-    if not step_summary_file:
-        print("Warning: GITHUB_STEP_SUMMARY env var not set, can't write job summary")
-        return
-    with open(step_summary_file, "a") as f:
-        # Use double newlines to split sections in markdown.
-        f.write(summary + "\n\n")
+from github_actions_utils import *
 
 
 # --------------------------------------------------------------------------- #
@@ -351,7 +322,7 @@ def main(base_args, linux_families, windows_families):
         #     * workflow_dispatch or workflow_call with inputs controlling enabled jobs?
         enable_build_jobs = should_ci_run_given_modified_paths(modified_paths)
 
-    write_job_summary(
+    gha_append_step_summary(
         f"""## Workflow configure results
 
 * `linux_amdgpu_families`: {str([item.get("family") for item in linux_target_output])}
@@ -367,7 +338,7 @@ def main(base_args, linux_families, windows_families):
         "windows_amdgpu_families": json.dumps(windows_target_output),
         "enable_build_jobs": json.dumps(enable_build_jobs),
     }
-    set_github_output(output)
+    gha_set_output(output)
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/configure_target_run.py
+++ b/build_tools/github_actions/configure_target_run.py
@@ -1,9 +1,10 @@
 import os
-from configure_ci import set_github_output
 from amdgpu_family_matrix import (
     amdgpu_family_info_matrix_presubmit,
     amdgpu_family_info_matrix_postsubmit,
 )
+
+from github_actions_utils import *
 
 # This file helps configure which target to run
 
@@ -24,7 +25,7 @@ def main(args):
             )
             # if there is a test machine available for this target
             if test_runs_on_machine:
-                set_github_output({"test-runs-on": test_runs_on_machine})
+                gha_set_output({"test-runs-on": test_runs_on_machine})
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/determine_version.py
+++ b/build_tools/github_actions/determine_version.py
@@ -18,8 +18,9 @@ Writing the output to the "GITHUB_ENV" file can be suppressed by passing
 from packaging.version import Version, parse
 
 import argparse
-import os
 import sys
+
+from github_actions_utils import *
 
 
 def derive_versions(rocm_version: str, verbose_output: bool) -> str:
@@ -37,13 +38,6 @@ def derive_versions(rocm_version: str, verbose_output: bool) -> str:
         print()
 
     return optional_build_prod_arguments
-
-
-def write_env_file(optional_build_prod_arguments: str):
-    env_file = os.getenv("GITHUB_ENV")
-
-    with open(env_file, "a") as f:
-        f.write(f"optional_build_prod_arguments={optional_build_prod_arguments}")
 
 
 def main(argv: list[str]):
@@ -72,7 +66,7 @@ def main(argv: list[str]):
     print(f"{optional_build_prod_arguments}")
 
     if args.write_env_file:
-        write_env_file(optional_build_prod_arguments)
+        gha_set_env({"optional_build_prod_arguments": optional_build_prod_arguments})
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/fetch_job_status.py
+++ b/build_tools/github_actions/fetch_job_status.py
@@ -7,7 +7,6 @@ Required environment variables:
   - ATTEMPT
 """
 
-from configure_ci import set_github_output
 import json
 import os
 from urllib.request import urlopen, Request

--- a/build_tools/github_actions/fetch_package_targets.py
+++ b/build_tools/github_actions/fetch_package_targets.py
@@ -1,11 +1,12 @@
 import os
 import json
-from configure_ci import set_github_output
 from amdgpu_family_matrix import (
     amdgpu_family_info_matrix_presubmit,
     amdgpu_family_info_matrix_postsubmit,
 )
 import string
+
+from github_actions_utils import *
 
 # This file helps generate a package target matrix for workflows.
 
@@ -52,7 +53,7 @@ def determine_package_targets(args):
 
 def main(args):
     package_targets = determine_package_targets(args)
-    set_github_output({"package_targets": json.dumps(package_targets)})
+    gha_set_output({"package_targets": json.dumps(package_targets)})
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -5,11 +5,12 @@ Required environment variables:
   - PLATFORM
 """
 
-from configure_ci import set_github_output
 import json
 import logging
 import os
 from pathlib import Path
+
+from github_actions_utils import *
 
 logging.basicConfig(level=logging.INFO)
 
@@ -118,7 +119,7 @@ def run():
             logging.info(f"Including job {job_name}")
             output_matrix.append(test_matrix[key])
 
-    set_github_output({"components": json.dumps(output_matrix)})
+    gha_set_output({"components": json.dumps(output_matrix)})
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/github_actions_utils.py
+++ b/build_tools/github_actions/github_actions_utils.py
@@ -1,0 +1,99 @@
+"""Utilities for working with GitHub Actions from Python.
+
+See also https://pypi.org/project/github-action-utils/.
+"""
+
+import os
+from pathlib import Path
+import sys
+from typing import Mapping
+
+
+def _log(*args, **kwargs):
+    print(*args, **kwargs)
+    sys.stdout.flush()
+
+
+def gha_warn_if_not_running_on_ci():
+    # https://docs.github.com/en/actions/reference/variables-reference
+    if not os.getenv("CI"):
+        _log("Warning: 'CI' env var not set, not running under GitHub Actions?")
+
+
+def gha_add_to_path(new_path: str | Path):
+    """Adds an entry to the system PATH for future GitHub Actions workflow run steps.
+
+    This appends to the file located at the $GITHUB_PATH environment variable.
+
+    See
+      * https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#example-of-adding-a-system-path
+    """
+    _log(f"Adding to path by appending to $GITHUB_PATH:\n  '{new_path}'")
+
+    path_file = os.getenv("GITHUB_PATH")
+    if not path_file:
+        _log("  Warning: GITHUB_PATH env var not set, can't add to path")
+        return
+
+    with open(path_file, "a") as f:
+        f.write(str(new_path))
+
+
+def gha_set_env(vars: Mapping[str, str | Path]):
+    """Sets environment variables for future GitHub Actions workflow run steps.
+
+    This appends to the file located at the $GITHUB_ENV environment variable.
+
+    See
+      * https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#environment-files
+    """
+    _log(f"Setting environment variable by appending to $GITHUB_ENV:\n  {vars}")
+
+    env_file = os.getenv("GITHUB_ENV")
+    if not env_file:
+        _log("  Warning: GITHUB_ENV env var not set, can't set environment variable")
+        return
+
+    with open(env_file, "a") as f:
+        f.writelines(f"{k}={str(v)}" + "\n" for k, v in vars.items())
+
+
+def gha_set_output(vars: Mapping[str, str | Path]):
+    """Sets values in a step's output parameters.
+
+    This appends to the file located at the $GITHUB_OUTPUT environment variable.
+
+    See
+      * https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
+      * https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs
+    """
+    _log(f"Setting github output:\n{vars}")
+
+    step_output_file = os.getenv("GITHUB_OUTPUT")
+    if not step_output_file:
+        _log("  Warning: GITHUB_OUTPUT env var not set, can't set github outputs")
+        return
+
+    with open(step_output_file, "a") as f:
+        f.writelines(f"{k}={str(v)}" + "\n" for k, v in vars.items())
+
+
+def gha_append_step_summary(summary: str):
+    """Appends a string to the GitHub Actions job summary.
+
+    This appends to the file located at the $GITHUB_STEP_SUMMARY environment variable.
+
+    See
+      * https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-job-summary
+      * https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
+    """
+    _log(f"Writing job summary:\n{summary}")
+
+    step_summary_file = os.getenv("GITHUB_STEP_SUMMARY")
+    if not step_summary_file:
+        _log("  Warning: GITHUB_STEP_SUMMARY env var not set, can't write job summary")
+        return
+
+    with open(step_summary_file, "a") as f:
+        # Use double newlines to split sections in markdown.
+        f.write(summary + "\n\n")

--- a/build_tools/github_actions/python_to_cp_version.py
+++ b/build_tools/github_actions/python_to_cp_version.py
@@ -15,9 +15,10 @@ Writing the output to the "GITHUB_ENV" file can be suppressed by passing
 """
 
 import argparse
-import os
 import re
 import sys
+
+from github_actions_utils import *
 
 
 def is_version(version) -> bool:
@@ -31,13 +32,6 @@ def transform_python_version(python_version: str) -> str:
     version_without_dot = python_version.replace(".", "")
     cp_version = f"cp{version_without_dot}-cp{version_without_dot}"
     return cp_version
-
-
-def write_env_file(cp_version: str):
-    env_file = os.getenv("GITHUB_ENV")
-
-    with open(env_file, "a") as f:
-        f.write(f"cp_version={cp_version}")
 
 
 def main(argv: list[str]):
@@ -60,7 +54,7 @@ def main(argv: list[str]):
     print(cp_version)
 
     if args.write_env_file:
-        write_env_file(cp_version)
+        gha_set_env({"cp_version": cp_version})
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/upload_build_summary.py
+++ b/build_tools/github_actions/upload_build_summary.py
@@ -13,17 +13,12 @@ from pathlib import Path
 import platform
 import sys
 
+from github_actions_utils import *
+
 logging.basicConfig(level=logging.INFO)
 
 THEROCK_DIR = Path(__file__).resolve().parent.parent.parent
 PLATFORM = platform.system().lower()
-
-
-def set_github_step_summary(summary: str):
-    logging.info(f"Appending to github summary: {summary}")
-    step_summary_file = os.environ.get("GITHUB_STEP_SUMMARY", "")
-    with open(step_summary_file, "a") as f:
-        f.write(summary + "\n")
 
 
 def run(args: argparse.Namespace):
@@ -37,10 +32,10 @@ def run(args: argparse.Namespace):
     amdgpu_family = args.amdgpu_family
 
     log_url = f"{bucket_url}/logs/{amdgpu_family}/index.html"
-    set_github_step_summary(f"[Build Logs]({log_url})")
+    gha_append_step_summary(f"[Build Logs]({log_url})")
     if os.path.exists(build_dir / "artifacts" / "index.html"):
         artifact_url = f"{bucket_url}/index-{amdgpu_family}.html"
-        set_github_step_summary(f"[Artifacts]({artifact_url})")
+        gha_append_step_summary(f"[Artifacts]({artifact_url})")
     else:
         logging.info("No artifacts index found. Skipping artifact link.")
 


### PR DESCRIPTION
This moves all code that deals with `GITHUB_OUTPUT`, `GITHUB_ENV`, `GITHUB_PATH`, and `GITHUB_STEP_SUMMARY` to a common utility file. Now we won't be tempted to continue copy/pasting utils or import functions that aren't intended to be exported like
```python
from configure_ci import set_github_output
```

I thought about writing some unit tests for the new file... we could look to https://github.com/saadmk11/github-action-utils/blob/main/tests/test_github_action_utils.py for inspiration.