### PR TITLE
[ci][windows][torch] Adapt configure_target_run for Windows testing.

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -154,6 +154,7 @@ jobs:
         id: configure
         env:
           TARGET: ${{ inputs.amdgpu_family }}
+          PLATFORM: "linux"
         run: python ./build_tools/github_actions/configure_target_run.py
 
   test_pytorch_wheels:

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -172,7 +172,6 @@ jobs:
   test_pytorch_wheels:
     if: ${{ needs.generate_target_to_run.outputs.test_runs_on != '' }}
     needs: [build_pytorch_wheels, generate_target_to_run]
-
     uses: ./.github/workflows/test_pytorch_wheels.yml
     with:
       amdgpu_family: ${{ inputs.amdgpu_family }}

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -152,3 +152,31 @@ jobs:
         run: |
           pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}
+
+  generate_target_to_run:
+    name: Generate target_to_run
+    runs-on: ubuntu-24.04
+    outputs:
+      test_runs_on: ${{ steps.configure.outputs.test-runs-on }}
+    steps:
+      - name: Checking out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Generating target to run
+        id: configure
+        env:
+          TARGET: ${{ inputs.amdgpu_family }}
+          PLATFORM: "windows"
+        run: python ./build_tools/github_actions/configure_target_run.py
+
+  test_pytorch_wheels:
+    if: ${{ needs.generate_target_to_run.outputs.test_runs_on != '' }}
+    needs: [build_pytorch_wheels, generate_target_to_run]
+
+    uses: ./.github/workflows/test_pytorch_wheels.yml
+    with:
+      amdgpu_family: ${{ inputs.amdgpu_family }}
+      test_runs_on: ${{ needs.generate_target_to_run.outputs.test_runs_on }}
+      cloudfront_url: ${{ inputs.cloudfront_url }}
+      python_version: ${{ inputs.python_version }}
+      torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}

--- a/build_tools/github_actions/configure_target_run.py
+++ b/build_tools/github_actions/configure_target_run.py
@@ -10,25 +10,31 @@ from github_actions_utils import *
 
 # TODO (geomin12): this is very hard-coded to a very specific use-case.
 # Once portable_linux_package_matrix.yml matures, this will mature as well
+# Some logic is duplicated with fetch_package_targets.py
 
 
-def main(args):
-    target = args.get("target").lower()
+def main(target: str, platform: str):
     amdgpu_family_info_matrix = (
         amdgpu_family_info_matrix_presubmit | amdgpu_family_info_matrix_postsubmit
     )
-    for key in amdgpu_family_info_matrix.keys():
-        # If the amdgpu_family matrix key is inside the target (ex: gfx94X in gfx94X-dcgpu)
-        if key in target:
-            test_runs_on_machine = (
-                amdgpu_family_info_matrix.get(key).get("linux").get("test-runs-on")
-            )
-            # if there is a test machine available for this target
-            if test_runs_on_machine:
-                gha_set_output({"test-runs-on": test_runs_on_machine})
+    for key, info_for_key in amdgpu_family_info_matrix.items():
+        # Only consider items containing the amdgpu_family (ex: gfx94X in gfx94X-dcgpu)
+        if key not in target.lower():
+            continue
+
+        platform_for_key = info_for_key.get(platform)
+
+        if not platform_for_key:
+            # Some AMDGPU families are only supported on certain platforms.
+            continue
+
+        # If there is a test machine available for this target, run on it.
+        test_runs_on_machine = platform_for_key.get("test-runs-on")
+        if test_runs_on_machine:
+            gha_set_output({"test-runs-on": test_runs_on_machine})
 
 
 if __name__ == "__main__":
-    args = {}
-    args["target"] = os.environ.get("TARGET", "")
-    main(args)
+    target = os.getenv("TARGET", "")
+    platform = os.getenv("PLATFORM", "")
+    main(target=target, platform=platform)


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/589.

Incomplete test runs were triggered at
* https://github.com/ROCm/TheRock/actions/runs/16424062043
* https://github.com/ROCm/TheRock/actions/runs/16426198049
* https://github.com/ROCm/TheRock/actions/runs/16427212517

(still need an easy way to build and test "dev" pytorch packages using "nightly" rocm packages)