### PR TITLE
[windows] Add .exe suffix to console scripts.

### DIFF
--- a/build_tools/packaging/python/templates/rocm-sdk-core/src/rocm_sdk_core/_cli.py
+++ b/build_tools/packaging/python/templates/rocm-sdk-core/src/rocm_sdk_core/_cli.py
@@ -2,6 +2,7 @@
 
 import importlib
 import os
+import platform
 import sys
 from pathlib import Path
 
@@ -13,9 +14,12 @@ PLATFORM_MODULE = importlib.import_module(PLATFORM_NAME)
 # NOTE: dependent on there being an __init__.py in the platform package.
 PLATFORM_PATH = Path(PLATFORM_MODULE.__file__).parent
 
+is_windows = platform.system() == "Windows"
+exe_suffix = ".exe" if is_windows else ""
+
 
 def _exec(relpath: str):
-    full_path = PLATFORM_PATH / relpath
+    full_path = PLATFORM_PATH / (relpath + exe_suffix)
     os.execv(full_path, [str(full_path)] + sys.argv[1:])
 
 

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
@@ -25,12 +25,6 @@ is_windows = platform.system() == "Windows"
 
 LINUX_CONSOLE_SCRIPT_TESTS = [
     # These currently only have unprefixed names (e.g. 'clang') on Windows.
-    ("amdclang", ["--help"], "clang LLVM compiler", True),
-    ("amdclang++", ["--help"], "clang LLVM compiler", True),
-    ("amdclang-cpp", ["--help"], "clang LLVM compiler", True),
-    ("amdclang-cl", ["-help"], "clang LLVM compiler", True),
-    ("amdflang", ["--help"], "clang LLVM compiler", True),
-    ("amdlld", ["-flavor", "ld.lld", "--help"], "USAGE:", True),
     # These tools are only available on Linux.
     ("rocm_agent_enumerator", [], "", True),
     ("rocminfo", [], "", True),
@@ -38,6 +32,12 @@ LINUX_CONSOLE_SCRIPT_TESTS = [
 ]
 
 CONSOLE_SCRIPT_TESTS = [
+    ("amdclang", ["--help"], "clang LLVM compiler", True),
+    ("amdclang++", ["--help"], "clang LLVM compiler", True),
+    ("amdclang-cpp", ["--help"], "clang LLVM compiler", True),
+    ("amdclang-cl", ["-help"], "clang LLVM compiler", True),
+    ("amdflang", ["--help"], "clang LLVM compiler", True),
+    ("amdlld", ["-flavor", "ld.lld", "--help"], "USAGE:", True),
     ("hipcc", ["--help"], "clang LLVM compiler", True),
     ("hipconfig", [], "HIP version:", True),
 ] + (LINUX_CONSOLE_SCRIPT_TESTS if not is_windows else [])


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/1085. Partial revert of https://github.com/ROCm/TheRock/pull/897.

Tested locally:
```
(.venv) λ rocm-sdk test
testCLI (rocm_sdk.tests.base_test.ROCmBaseTest.testCLI) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\.venv\Scripts\python.exe' -P -m rocm_sdk --help
ok
testTargets (rocm_sdk.tests.base_test.ROCmBaseTest.testTargets) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\.venv\Scripts\python.exe' -P -m rocm_sdk targets
ok
testVersion (rocm_sdk.tests.base_test.ROCmBaseTest.testVersion) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\.venv\Scripts\python.exe' -P -m rocm_sdk version
ok
test_initialize_process_check_version (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version) ... ok
test_initialize_process_check_version_asterisk (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_asterisk) ... ok
test_initialize_process_check_version_mismatch (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_mismatch) ... ok
test_initialize_process_check_version_mismatch_warning (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_mismatch_warning) ... ok
test_initialize_process_check_version_pattern (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_pattern) ... ok
test_initialize_process_env_preload_1 (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_1) ... ok
test_initialize_process_env_preload_2_comma (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_2_comma) ... ok
test_initialize_process_env_preload_2_semi (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_2_semi) ... ok
test_initialize_process_preload_libraries (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_preload_libraries) ... ok
testConsoleScripts (rocm_sdk.tests.core_test.ROCmCoreTest.testConsoleScripts) ... ok
testInstallationLayout (rocm_sdk.tests.core_test.ROCmCoreTest.testInstallationLayout)
The `rocm_sdk` and core module must be siblings on disk. ... ok
testPreloadLibraries (rocm_sdk.tests.core_test.ROCmCoreTest.testPreloadLibraries) ... ok
testSharedLibrariesLoad (rocm_sdk.tests.core_test.ROCmCoreTest.testSharedLibrariesLoad) ... ok
testConsoleScripts (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testConsoleScripts) ... ok
testInstallationLayout (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testInstallationLayout)
The `rocm_sdk` and libraries module must be siblings on disk. ... ok
testSharedLibrariesLoad (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testSharedLibrariesLoad) ... ok
testCLIPathBin (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathBin) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\.venv\Scripts\python.exe' -P -m rocm_sdk path --bin
ok
testCLIPathCMake (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathCMake) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\.venv\Scripts\python.exe' -P -m rocm_sdk path --cmake
ok
testCLIPathRoot (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathRoot) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\.venv\Scripts\python.exe' -P -m rocm_sdk path --root
ok
testInstallationLayout (rocm_sdk.tests.devel_test.ROCmDevelTest.testInstallationLayout)
The `rocm_sdk` and devel module must be siblings on disk. ... ok
testRootLLVMSymlinkExists (rocm_sdk.tests.devel_test.ROCmDevelTest.testRootLLVMSymlinkExists) ... skipped 'root LLVM symlink only exists on Linux'
testSharedLibrariesLoad (rocm_sdk.tests.devel_test.ROCmDevelTest.testSharedLibrariesLoad) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\.venv\Scripts\python.exe' -P -m rocm_sdk path --root
ok

----------------------------------------------------------------------
Ran 25 tests in 4.791s
```

Specifically this line:
```
testConsoleScripts (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testConsoleScripts) ... ok
```