### PR TITLE
Fix triton source code checkout

### DIFF
--- a/external-builds/pytorch/pytorch_triton_repo.py
+++ b/external-builds/pytorch/pytorch_triton_repo.py
@@ -105,10 +105,6 @@ def main(cl_args: list[str]):
         help="git repository url",
     )
     checkout_p.add_argument(
-        "--repo-hashtag",
-        help="Git repository ref/tag to checkout",
-    )
-    checkout_p.add_argument(
         "--release",
         default=False,
         action=argparse.BooleanOptionalAction,


### PR DESCRIPTION
pytorch_triton_repo.py has "repo-hashtag" twice, causing error on source code checkout:

Traceback (most recent call last):
  File "/home/lamikr/own/rock/src/sdk/therock/./external-builds/pytorch/pytorch_triton_repo.py", line 144, in <module>
    main(sys.argv[1:])
  File "/home/lamikr/own/rock/src/sdk/therock/./external-builds/pytorch/pytorch_triton_repo.py", line 107, in main
    checkout_p.add_argument(
  File "/usr/lib/python3.12/argparse.py", line 1507, in add_argument
    return self._add_action(action)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/argparse.py", line 1889, in _add_action
    self._optionals._add_action(action)
  File "/usr/lib/python3.12/argparse.py", line 1709, in _add_action
    action = super(_ArgumentGroup, self)._add_action(action)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/argparse.py", line 1521, in _add_action
    self._check_conflict(action)
  File "/usr/lib/python3.12/argparse.py", line 1658, in _check_conflict
    conflict_handler(action, confl_optionals)
  File "/usr/lib/python3.12/argparse.py", line 1667, in _handle_conflict_error
    raise ArgumentError(action, message % conflict_string)
argparse.ArgumentError: argument --repo-hashtag: conflicting option string: --repo-hashtag