### PR TITLE
Add secrets inherit to ci_nightly workflow

### DIFF
--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -59,6 +59,7 @@ jobs:
       matrix:
         families: ${{ fromJSON(needs.setup.outputs.linux_amdgpu_families) }}
     uses: ./.github/workflows/ci_linux.yml
+    secrets: inherit
     with:
       amdgpu_families: ${{ matrix.families.family }}
       test_runs_on: ${{ matrix.families.test-runs-on }}


### PR DESCRIPTION
Adding secrets inherit to pass redshift access details to ci_linux.yml workflow as part of the nightly workflow.

Support added Based on the Closed github issue:

https://github.com/ROCm/TheRock/issues/780