### PR TITLE
[torch][windows] Enable pytorch_audio build on Windows.

### DIFF
--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -99,8 +99,9 @@ jobs:
           git config --global core.longpaths true
           python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --repo ${{ env.CHECKOUT_ROOT }}/torch
-          # TODO(#910): Support torchvision and torchaudio on Windows
-          # python ./external-builds/pytorch/pytorch_audio_repo.py checkout
+          python ./external-builds/pytorch/pytorch_audio_repo.py checkout \
+            --repo ${{ env.CHECKOUT_ROOT }}/audio
+          # TODO(#910): Support torchvision on Windows
           # python ./external-builds/pytorch/pytorch_vision_repo.py checkout
 
       - name: Determine optional arguments passed to `build_prod_wheels.py`
@@ -121,6 +122,7 @@ jobs:
             --install-rocm ^
             --index-url "${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/" ^
             --pytorch-dir ${{ env.CHECKOUT_ROOT }}/torch ^
+            --pytorch-audio-dir ${{ env.CHECKOUT_ROOT }}/audio ^
             --clean ^
             --output-dir ${{ env.PACKAGE_DIST_DIR }} ^
             ${{ env.optional_build_prod_arguments }}

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -21,7 +21,7 @@ patches locally until they can be upstreamed. See the
 | Feature                  | Linux support | Windows support                                                       |
 | ------------------------ | ------------- | --------------------------------------------------------------------- |
 | PyTorch                  | ✅ Supported  | ✅ Supported                                                          |
-| torchaudio               | ✅ Supported  | ✅                                                                    |
+| torchaudio               | ✅ Supported  | ✅ Supported                                                          |
 | torchvision              | ✅ Supported  | 🟡 In progress ([#910](https://github.com/ROCm/TheRock/issues/910))   |
 | Flash attention (Triton) | ✅ Supported  | 🟡 In progress ([#1040](https://github.com/ROCm/TheRock/issues/1040)) |
 

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -21,8 +21,8 @@ patches locally until they can be upstreamed. See the
 | Feature                  | Linux support | Windows support                                                       |
 | ------------------------ | ------------- | --------------------------------------------------------------------- |
 | PyTorch                  | ✅ Supported  | ✅ Supported                                                          |
+| torchaudio               | ✅ Supported  | ✅                                                                    |
 | torchvision              | ✅ Supported  | 🟡 In progress ([#910](https://github.com/ROCm/TheRock/issues/910))   |
-| torchaudio               | ✅ Supported  | 🟡 In progress ([#910](https://github.com/ROCm/TheRock/issues/910))   |
 | Flash attention (Triton) | ✅ Supported  | 🟡 In progress ([#1040](https://github.com/ROCm/TheRock/issues/1040)) |
 
 ## Build instructions
@@ -76,6 +76,7 @@ Now checkout repositories:
   ```bash
   # TODO(#910): Support torchvision and torchaudio on Windows
   python pytorch_torch_repo.py checkout --repo C:/b/pytorch
+  python pytorch_audio_repo.py checkout --repo C:/b/audio
   ```
 
 Now note the gfx target you want to build for and then...
@@ -102,6 +103,7 @@ mix/match build steps.
   python build_prod_wheels.py build \
     --install-rocm --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ \
     --pytorch-dir C:/b/pytorch \
+    --pytorch-audio-dir C:/b/audio \
     --output-dir %HOME%/tmp/pyout
   ```
 

--- a/external-builds/pytorch/patches/pytorch_audio/v2.7.0/pytorch_audio/base/0001-Allow-clang-cl-as-the-C-CXX-compiler-on-Windows.patch
+++ b/external-builds/pytorch/patches/pytorch_audio/v2.7.0/pytorch_audio/base/0001-Allow-clang-cl-as-the-C-CXX-compiler-on-Windows.patch
@@ -1,0 +1,25 @@
+From e3cee0316a69a5792b7339d18d634ccea3039966 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Mon, 21 Jul 2025 13:57:40 -0700
+Subject: [PATCH] Allow clang-cl as the C/CXX compiler on Windows.
+
+---
+ tools/setup_helpers/extension.py | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/tools/setup_helpers/extension.py b/tools/setup_helpers/extension.py
+index 2415bbae..8520b43f 100644
+--- a/tools/setup_helpers/extension.py
++++ b/tools/setup_helpers/extension.py
+@@ -162,8 +162,6 @@ class CMakeBuild(build_ext):
+ 
+             python_version = sys.version_info
+             cmake_args += [
+-                "-DCMAKE_C_COMPILER=cl",
+-                "-DCMAKE_CXX_COMPILER=cl",
+                 f"-DPYTHON_VERSION={python_version.major}.{python_version.minor}",
+             ]
+ 
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/910.

Tested at https://github.com/ROCm/TheRock/actions/runs/16429221525 (build only) and locally, with a sanity check:
```bash
$ pip freeze
# ...
# torch @ file:///C:/Users/Nod-Shark16/.therock/pytorch/torch-2.7.0a0%2Brocmsdk20250721-cp312-cp312-win_amd64.whl#sha256=9b70978bb54fa5b40bbd1d792fdb17842b33bd613b7c9756c2e3baa401ed92d6
# torchaudio @ file:///C:/Users/Nod-Shark16/.therock/pytorch/torchaudio-2.7.0a0%2Brocmsdk20250721-cp312-cp312-win_amd64.whl#sha256=7aefe9112d3dd2791a30273890cc6947e5769dd36706a506aec46586f1efda28
```
```python
>>> import torchaudio
>>> print(torchaudio.__version__)
2.7.0a0+rocmsdk20250721
```

For the patch, pytorch_audio had been forcing the compiler to `cl`, while we've been building with `clang-cl` for base pytorch. Trying to build with `cl` fails due to (at least) these clang-specific flags that get set with `USE_ROCM`: https://github.com/pytorch/pytorch/blob/cab28330f8c49cdb66d6a299755dc09c87c14a9d/cmake/Dependencies.cmake#L1028-L1041
```cmake
    list(APPEND HIP_CXX_FLAGS -Wno-shift-count-negative)
    list(APPEND HIP_CXX_FLAGS -Wno-shift-count-overflow)
    list(APPEND HIP_CXX_FLAGS -Wno-duplicate-decl-specifier)
```

Sample error logs:
```
[8/72] D:\tools\bin\ccache.exe C:\PROGRA~2\MICROS~2\2022\BUILDT~1\VC\Tools\MSVC\1442~1.344\bin\Hostx64\x64\cl.exe   /TP -DINCLUDE_ALIGN -DINCLUDE_RIR -DROCM_USE_FLOAT16 -DUSE_PROF_API=1 -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_AMD__=1 -Dlibtorchaudio_EXPORTS -ID:\b\audio\src -external:ID:\projects\TheRock\external-builds\pytorch\.venv\Lib\site-packages\torch\include -external:ID:\projects\TheRock\external-builds\pytorch\.venv\Lib\site-packages\torch\include\torch\csrc\api\include -external:ID:\projects\TheRock\external-builds\pytorch\.venv\Lib\site-packages\_rocm_sdk_devel\include -external:ID:\projects\TheRock\external-builds\pytorch\.venv\Lib\site-packages\_rocm_sdk_devel\include\hiprand -external:ID:\projects\TheRock\external-builds\pytorch\.venv\Lib\site-packages\_rocm_sdk_devel\include\rocrand -external:W0 /DWIN32 /D_WINDOWS /GR /EHsc /wd4819 /W4  /O2 /Ob2 /DNDEBUG -std:c++17 -MD /EHsc /bigobj -fms-runtime-lib=dll -D__HIP_PLATFORM_AMD__=1 -DCUDA_HAS_FP16=1 -DUSE_ROCM -D__HIP_NO_HALF_OPERATORS__=1 -D__HIP_NO_HALF_CONVERSIONS__=1 -DTORCH_HIP_VERSION=700 -Wno-shift-count-negative -Wno-shift-count-overflow -Wno-duplicate-decl-specifier -DCAFFE2_USE_MIOPEN -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP -std=c++17 -DHIPBLAS_V2 -fms-extensions -Wno-ignored-attributes -openmp /showIncludes /Fosrc\libtorchaudio\CMakeFiles\libtorchaudio.dir\rnnt\compute_alphas.cpp.obj /Fdsrc\libtorchaudio\CMakeFiles\libtorchaudio.dir\ /FS -c D:\b\audio\src\libtorchaudio\rnnt\compute_alphas.cpp
FAILED: src/libtorchaudio/CMakeFiles/libtorchaudio.dir/rnnt/compute_alphas.cpp.obj 
D:\tools\bin\ccache.exe C:\PROGRA~2\MICROS~2\2022\BUILDT~1\VC\Tools\MSVC\1442~1.344\bin\Hostx64\x64\cl.exe   /TP -DINCLUDE_ALIGN -DINCLUDE_RIR -DROCM_USE_FLOAT16 -DUSE_PROF_API=1 -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_AMD__=1 -Dlibtorchaudio_EXPORTS -ID:\b\audio\src -external:ID:\projects\TheRock\external-builds\pytorch\.venv\Lib\site-packages\torch\include -external:ID:\projects\TheRock\external-builds\pytorch\.venv\Lib\site-packages\torch\include\torch\csrc\api\include -external:ID:\projects\TheRock\external-builds\pytorch\.venv\Lib\site-packages\_rocm_sdk_devel\include -external:ID:\projects\TheRock\external-builds\pytorch\.venv\Lib\site-packages\_rocm_sdk_devel\include\hiprand -external:ID:\projects\TheRock\external-builds\pytorch\.venv\Lib\site-packages\_rocm_sdk_devel\include\rocrand -external:W0 /DWIN32 /D_WINDOWS /GR /EHsc /wd4819 /W4  /O2 /Ob2 /DNDEBUG -std:c++17 -MD /EHsc /bigobj -fms-runtime-lib=dll -D__HIP_PLATFORM_AMD__=1 -DCUDA_HAS_FP16=1 -DUSE_ROCM -D__HIP_NO_HALF_OPERATORS__=1 -D__HIP_NO_HALF_CONVERSIONS__=1 -DTORCH_HIP_VERSION=700 -Wno-shift-count-negative -Wno-shift-count-overflow -Wno-duplicate-decl-specifier -DCAFFE2_USE_MIOPEN -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP -std=c++17 -DHIPBLAS_V2 -fms-extensions -Wno-ignored-attributes -openmp /showIncludes /Fosrc\libtorchaudio\CMakeFiles\libtorchaudio.dir\rnnt\compute_alphas.cpp.obj /Fdsrc\libtorchaudio\CMakeFiles\libtorchaudio.dir\ /FS -c D:\b\audio\src\libtorchaudio\rnnt\compute_alphas.cpp
Microsoft (R) C/C++ Optimizing Compiler Version 19.42.34436 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

cl : Command line error D8021 : invalid numeric argument '/Wno-shift-count-negative'
```