### PR TITLE
Stabilize compiler version fingerprint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ sources/
 __pycache__
 /.ccache
 
+# Patch control files.
+.*.smrev
+
 # Output directories.
 /build/
 /install/

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -4,6 +4,7 @@
 # the CI uses to get to a clean state.
 
 import argparse
+import hashlib
 from pathlib import Path
 import platform
 import shlex
@@ -71,8 +72,22 @@ def run(args):
     )
 
     populate_ancillary_sources(args)
+
+    # Remove any stale .smrev files.
+    remove_smrev_files(args, projects)
+
     if args.apply_patches:
         apply_patches(args, projects)
+
+
+def remove_smrev_files(args, projects):
+    for project in projects:
+        submodule_path = get_submodule_path(project)
+        project_dir = THEROCK_DIR / submodule_path
+        project_revision_file = project_dir.with_name(f".{project_dir.name}.smrev")
+        if project_revision_file.exists():
+            print(f"Remove stale project revision file: {project_revision_file}")
+            project_revision_file.unlink()
 
 
 def apply_patches(args, projects):
@@ -90,7 +105,11 @@ def apply_patches(args, projects):
             )
             continue
         submodule_path = get_submodule_path(patch_project_dir.name)
+        submodule_url = get_submodule_url(patch_project_dir.name)
+        submodule_revision = get_submodule_revision(submodule_path)
         project_dir = THEROCK_DIR / submodule_path
+        project_revision_file = project_dir.with_name(f".{project_dir.name}.smrev")
+
         if not project_dir.exists():
             log(f"WARNING: Source directory {project_dir} does not exist. Skipping.")
             continue
@@ -116,6 +135,16 @@ def apply_patches(args, projects):
             cwd=THEROCK_DIR,
         )
 
+        # Generate the .smrev patch state file.
+        patches_hash = hashlib.sha1()
+        for patch_file in patch_files:
+            patch_contents = Path(patch_file).read_bytes()
+            patches_hash.update(patch_contents)
+        patches_digest = patches_hash.digest().hex()
+        project_revision_file.write_text(
+            f"{submodule_url}\n{submodule_revision}+PATCHED:{patches_digest}\n"
+        )
+
 
 # Gets the the relative path to a submodule given its name.
 # Raises an exception on failure.
@@ -136,6 +165,40 @@ def get_submodule_path(name: str) -> str:
         .strip()
     )
     return relpath
+
+
+# Gets the the relative path to a submodule given its name.
+# Raises an exception on failure.
+def get_submodule_url(name: str) -> str:
+    relpath = (
+        subprocess.check_output(
+            [
+                "git",
+                "config",
+                "--file",
+                ".gitmodules",
+                "--get",
+                f"submodule.{name}.url",
+            ],
+            cwd=str(THEROCK_DIR),
+        )
+        .decode()
+        .strip()
+    )
+    return relpath
+
+
+def get_submodule_revision(submodule_path: str) -> str:
+    # Generates a line like:
+    #   160000 5e2093d23f7d34c372a788a6f2b7df8bc1c97947 0       compiler/amd-llvm
+    ls_line = (
+        subprocess.check_output(
+            ["git", "ls-files", "--stage", submodule_path], cwd=str(THEROCK_DIR)
+        )
+        .decode()
+        .strip()
+    )
+    return ls_line.split()[1]
 
 
 def populate_ancillary_sources(args):

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -11,6 +11,19 @@ if(THEROCK_ENABLE_COMPILER)
     list(APPEND _extra_llvm_cmake_args "-DLLVM_ENABLE_PEDANTIC=OFF")
   endif()
 
+  # If the compiler is not pristine (i.e. has patches), then there will be a
+  # ".amd-llvm.smrev" file present which must be used instead of the auto
+  # computed git revision. If present, this will have a stable hash of
+  # revision plus applied patches suitable for run to run compiler
+  # fingerprinting.
+  set(LLVM_SMREV_FILE "${CMAKE_CURRENT_SOURCE_DIR}/.amd-llvm.smrev")
+  if(EXISTS "${LLVM_SMREV_FILE}")
+    file(STRINGS "${LLVM_SMREV_FILE}" LLVM_SMREV_LINES)
+    list(GET LLVM_SMREV_LINES 0 LLVM_SMREV_REPO)
+    list(GET LLVM_SMREV_LINES 1 LLVM_SMREV_REVISION)
+    message(STATUS "Using stable amd-llvm revision info: Repo='${LLVM_SMREV_REPO}', Revision='${LLVM_SMREV_REVISION}'")
+  endif()
+
   therock_cmake_subproject_declare(amd-llvm
     USE_DIST_AMDGPU_TARGETS
     NO_INSTALL_RPATH  # See manual handling in the pre_hook.
@@ -21,6 +34,14 @@ if(THEROCK_ENABLE_COMPILER)
     INTERFACE_PROGRAM_DIRS
       lib/llvm/bin
     CMAKE_ARGS
+      # Version configuration
+      # Note that if LLVM_SMREV_REPO and LLVM_FORCE_VC_REVISION are empty,
+      # LLVM will compute the tip of tree revision, which is appropriate for
+      # pristine checkouts.
+      -DLLVM_APPEND_VC_REV=ON
+      "-DLLVM_FORCE_VC_REPOSITORY=${LLVM_SMREV_REPO}"
+      "-DLLVM_FORCE_VC_REVISION=${LLVM_SMREV_REVISION}"
+
       # LIBCXX
       -DLIBCXX_ENABLE_SHARED=OFF
       -DLIBCXX_ENABLE_STATIC=ON


### PR DESCRIPTION
* On checkout, if submodules are patched, a sibling file `.{name}.smrev` is written containing a line for the origin repository and a mangled revision (indicating the base revision of the repo and a digest of all raw patches applied).
* During build of LLVM, if the .smrev file is present, it is read and LLVM_FORCE_VC_REPOSITORY and LLVM_FORCE_VC_REVISION are set with the hard-coded contents.
* This overrides the auto fingerprinting logic in the LLVM build, resulting in a stable origin stamp regardless of whether patches were applied or not.
* This appears to be enough to produce a bit for bit identical compiler, allowing existing ccache logic to do the right thing. In the future, however, for CI, we could change the cache logic to look at the first line of `$COMPILER --version`. This however does not capture all things that can indicate a different compiler, so we should try the reproducible build as is first.