### PR TITLE
[torch][windows] Apply fix to jit_utils.cpp for ROCm 7.

### DIFF
--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0001-Disable-hipSPARSE-and-CK-declarations-and-remove-ref.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0001-Disable-hipSPARSE-and-CK-declarations-and-remove-ref.patch
@@ -1,7 +1,7 @@
 From d82715939800da1f713b5a1bc9e7cffcfa33f92c Mon Sep 17 00:00:00 2001
 From: ikalinic <ilija.kalinic@amd.com>
 Date: Wed, 19 Mar 2025 07:30:50 +0000
-Subject: [PATCH 1/2] Disable hipSPARSE and CK declarations and remove
+Subject: [PATCH 1/3] Disable hipSPARSE and CK declarations and remove
  references for Windows (#149195)
 
 This PR removes references to `hipSPARSE` and `ck` functions and disables declarations which are not supported on Windows.

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0002-Backport-Remove-use-of-warpsize-on-host-side-compila.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0002-Backport-Remove-use-of-warpsize-on-host-side-compila.patch
@@ -1,7 +1,7 @@
 From 4ad1931afefb714d84c3b371c41bb6c19cb8d226 Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Wed, 16 Jul 2025 12:09:14 -0700
-Subject: [PATCH 2/2] Backport "Remove use of warpsize on host-side
+Subject: [PATCH 2/3] Backport "Remove use of warpsize on host-side
  compilation".
 
 https://github.com/pytorch/pytorch/commit/04bd7e6850e8efec77994963ffee87549555b9c3

--- a/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0003-Apply-fix-to-jit_utils.cpp-for-ROCm-7.patch
+++ b/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/base/0003-Apply-fix-to-jit_utils.cpp-for-ROCm-7.patch
@@ -1,0 +1,26 @@
+From 9651b2559c4384b8a590196f03ef76508419a1d7 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Wed, 23 Jul 2025 08:46:39 -0700
+Subject: [PATCH 3/3] Apply fix to jit_utils.cpp for ROCm 7.
+
+See https://github.com/ROCm/pytorch/commit/28806f842c9c019866019e44026c984c63779082.
+---
+ aten/src/ATen/native/cuda/jit_utils.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/aten/src/ATen/native/cuda/jit_utils.cpp b/aten/src/ATen/native/cuda/jit_utils.cpp
+index 0d49ec9c187..deac503827b 100644
+--- a/aten/src/ATen/native/cuda/jit_utils.cpp
++++ b/aten/src/ATen/native/cuda/jit_utils.cpp
+@@ -45,7 +45,7 @@ namespace at::cuda::jit {
+ // Copied from aten/src/ATen/cuda/llvm_basic.cpp, then modified as above.
+ // If not compiling for ROCm, return the original get_traits_string().
+ std::string get_traits_string_but_hiprtc_safe() {
+-#ifdef USE_ROCM
++#if defined(USE_ROCM) && ROCM_VERSION < 70000
+     return R"ESCAPE(
+ namespace std {
+ 
+-- 
+2.45.1.windows.1
+


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/1073. This fixes failures in PyTorch tests on Windows with logs like:
```
#pragma clang force_cuda_host_device end
C:\Users\NOD-SH~1\AppData\Local\Temp\comgr-e8a38b\input\CompileSourcea25628:58:80: error: expected class name
   58 |   template <class _Tp> struct __libcpp_is_floating_point              : public false_type {};
      |                                                                                ^
...

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "D:\b\pytorch_v2.7.0\test\test_torch.py", line 6947, in test_index_add_all_dtypes
    self.assertEqual(added, tensor)
  File "D:\scratch\therock\.venv\Lib\site-packages\torch\testing\_internal\common_utils.py", line 4055, in assertEqual
    error_metas = not_close_error_metas(
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "D:\scratch\therock\.venv\Lib\site-packages\torch\testing\_comparison.py", line 1227, in not_close_error_metas
    raise RuntimeError(
RuntimeError: Comparing

...

resulted in the unexpected exception above. If you are a user and see this message during normal operation please file an issue at https://github.com/pytorch/pytorch/issues. If you are a developer and working on the comparison functions, please except the previous error and raise an expressive `ErrorMeta` instead.
=============================================== short test summary info =============================================== FAILED [0.1847s]
test_torch.py::TestTorch::test_index_add_all_dtypes - RuntimeError: Comparing
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================== 1 failed, 62 passed, 2 skipped, 2 rerun in 4.15s ===================================
```

The patch is copied from https://github.com/ROCm/pytorch/pull/2319. Presumably we'll need the same change upstream in https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cuda/jit_utils.cpp once we rebase on pytorch `main` (https://github.com/ROCm/TheRock/issues/1039).

Tested on Windows and may also help on Linux, at least until we switch our Linux PyTorch builds fully to the ROCm backport release branches (https://github.com/ROCm/TheRock/issues/1070).