### PR TITLE
 Add gating mechanism to ensure PyTorch wheels pass tests before uploading to S3 release bucket #1072

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -129,18 +129,6 @@ jobs:
         run: |
           python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}/
 
-      - name: Upload wheels to S3
-        if: ${{ github.repository_owner == 'ROCm' }}
-        run: |
-          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ \
-            --recursive --exclude "*" --include "*.whl"
-
-      - name: (Re-)Generate Python package release index
-        if: ${{ github.repository_owner == 'ROCm' }}
-        run: |
-          pip install boto3 packaging
-          python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}
-
   generate_target_to_run:
     name: Generate target_to_run
     runs-on: ubuntu-24.04
@@ -167,3 +155,25 @@ jobs:
       cloudfront_url: ${{ inputs.cloudfront_url }}
       python_version: ${{ inputs.python_version }}
       torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}
+
+  upload_pytorch_wheels:
+    name: Upload PyTorch Wheels to S3
+    needs: [build_pytorch_wheels, generate_target_to_run, test_pytorch_wheels]
+    if: success() && github.repository_owner == 'ROCm'
+    runs-on: ubuntu-24.04
+    env:
+      PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
+      S3_BUCKET_PY: "therock-${{ inputs.release_type }}-python"
+    steps:
+      - name: Upload wheels to S3
+        run: |
+          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ \
+            --recursive --exclude "*" --include "*.whl"
+
+      - name: (Re-)Generate Python package release index
+        run: |
+          pip install boto3 packaging
+          python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}
+
+
+

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -129,7 +129,7 @@ jobs:
             build \
             --install-rocm \
             --pip-cache-dir /tmp/pipcache \
-            --index-url "${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/" \
+            --index-url "${{ inputs.cloudfront_staging_url }}/${{ inputs.amdgpu_family }}/" \
             --clean \
             --output-dir ${{ env.PACKAGE_DIST_DIR }} ${{ env.optional_build_prod_arguments }}
           echo "torch_version=`cd ${{ env.PACKAGE_DIST_DIR }}; python -c 'import glob; print(glob.glob("torch-*.whl")[0].split("-")[1])'`" >> $GITHUB_OUTPUT
@@ -201,8 +201,9 @@ jobs:
 
       - name: Copy wheels from staging sub-dir to release dir S3
         run: |
-          aws s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}/ \
-          s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ \
+          aws s3 cp \
+            s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}/ \
+            s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ \
             --recursive --exclude "*" --include "*.whl"
 
       - name: (Re-)Generate Python package release index

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -185,7 +185,7 @@ jobs:
 
   upload_pytorch_wheels:
     name: Upload PyTorch Wheels to S3
-    needs: [build_pytorch_wheels, generate_target_to_run]
+    needs: [build_pytorch_wheels, generate_target_to_run, test_pytorch_wheels]
     if: success() && github.repository_owner == 'ROCm'
     runs-on: ubuntu-24.04
     env:

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -165,6 +165,17 @@ jobs:
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
       S3_BUCKET_PY: "therock-${{ inputs.release_type }}-python"
     steps:
+      - name: Configure AWS Credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
+
+      - name: Sanity Check Wheel
+        run: |
+          python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}/
+          
       - name: Upload wheels to S3
         run: |
           aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ \

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -129,6 +129,16 @@ jobs:
         run: |
           python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}/
 
+      - name: Upload wheels to Staging S3
+        run: |
+          aws s3 cp s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/staging/ \
+            --recursive --exclude "*" --include "*.whl"
+
+      - name: (Re-)Generate Python package release index
+        run: |
+          pip install boto3 packaging
+          python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/staging
+
   generate_target_to_run:
     name: Generate target_to_run
     runs-on: ubuntu-24.04
@@ -144,10 +154,12 @@ jobs:
           TARGET: ${{ inputs.amdgpu_family }}
         run: python ./build_tools/github_actions/configure_target_run.py
 
+      - name: Debug test-runs-on
+        run: echo "Test runs on: ${{ steps.configure.outputs.test-runs-on }}"
+
   test_pytorch_wheels:
     if: ${{ needs.generate_target_to_run.outputs.test_runs_on != '' }}
     needs: [build_pytorch_wheels, generate_target_to_run]
-
     uses: ./.github/workflows/test_pytorch_wheels.yml
     with:
       amdgpu_family: ${{ inputs.amdgpu_family }}
@@ -175,10 +187,11 @@ jobs:
       - name: Sanity Check Wheel
         run: |
           python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}/
-          
-      - name: Upload wheels to S3
+
+      - name: Copy wheels from staging sub-dir to release dir S3
         run: |
-          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ \
+          aws s3 cp s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/staging/ \
+          s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ \
             --recursive --exclude "*" --include "*.whl"
 
       - name: (Re-)Generate Python package release index

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -192,6 +192,9 @@ jobs:
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
       S3_BUCKET_PY: "therock-${{ inputs.release_type }}-python"
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Configure AWS Credentials
         if: always()
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -26,7 +26,7 @@ on:
         required: true
         type: string
       cloudfront_staging_url:
-        description: CloudFront URL pointing to Python index
+        description: CloudFront Staging URL pointing to Python index
         required: true
         type: string
       rocm_version:
@@ -58,7 +58,7 @@ on:
         type: string
         default: "https://d25kgig7rdsyks.cloudfront.net/v2"
       cloudfront_staging_url:
-        description: CloudFront base URL pointing to Python index
+        description: CloudFront Staging base URL pointing to Python index
         type: string
         default: "https://d25kgig7rdsyks.cloudfront.net/v2-staging"
       rocm_version:

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -17,6 +17,10 @@ on:
         description: S3 subdirectory, not including the GPU-family
         required: true
         type: string
+      s3_staging_subdir:
+        description: S3 staging subdirectory, not including the GPU-family
+        required: true
+        type: string
       cloudfront_url:
         description: CloudFront URL pointing to Python index
         required: true
@@ -41,6 +45,10 @@ on:
         description: S3 subdirectory, not including the GPU-family
         type: string
         default: "v2"
+      s3_staging_subdir:
+        description: S3 staging subdirectory, not including the GPU-family
+        type: string
+        default: "v2-staging"
       cloudfront_url:
         description: CloudFront base URL pointing to Python index
         type: string
@@ -130,14 +138,16 @@ jobs:
           python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}/
 
       - name: Upload wheels to Staging S3
+        if: ${{ github.repository_owner == 'ROCm' }}
         run: |
-          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/staging/${{ inputs.amdgpu_family }}/ \
+          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}/ \
             --recursive --exclude "*" --include "*.whl"
 
       - name: (Re-)Generate Python package release index
+        if: ${{ github.repository_owner == 'ROCm' }}
         run: |
           pip install boto3 packaging
-          python ./build_tools/third_party/s3_management/manage.py staging/${{ inputs.amdgpu_family }}
+          python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}
 
   generate_target_to_run:
     name: Generate target_to_run
@@ -167,7 +177,7 @@ jobs:
 
   upload_pytorch_wheels:
     name: Upload PyTorch Wheels to S3
-    needs: [build_pytorch_wheels, generate_target_to_run, test_pytorch_wheels]
+    needs: [build_pytorch_wheels, generate_target_to_run]
     if: success() && github.repository_owner == 'ROCm'
     runs-on: ubuntu-24.04
     env:
@@ -187,7 +197,7 @@ jobs:
 
       - name: Copy wheels from staging sub-dir to release dir S3
         run: |
-          aws s3 cp s3://${{ env.S3_BUCKET_PY }}/staging/${{ inputs.amdgpu_family }}/ \
+          aws s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}/ \
           s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ \
             --recursive --exclude "*" --include "*.whl"
 

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -131,13 +131,13 @@ jobs:
 
       - name: Upload wheels to Staging S3
         run: |
-          aws s3 cp s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/staging/ \
+          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/staging/${{ inputs.amdgpu_family }}/ \
             --recursive --exclude "*" --include "*.whl"
 
       - name: (Re-)Generate Python package release index
         run: |
           pip install boto3 packaging
-          python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/staging
+          python ./build_tools/third_party/s3_management/manage.py staging/${{ inputs.amdgpu_family }}
 
   generate_target_to_run:
     name: Generate target_to_run
@@ -153,7 +153,7 @@ jobs:
         env:
           TARGET: ${{ inputs.amdgpu_family }}
         run: python ./build_tools/github_actions/configure_target_run.py
-        
+
   test_pytorch_wheels:
     if: ${{ needs.generate_target_to_run.outputs.test_runs_on != '' }}
     needs: [build_pytorch_wheels, generate_target_to_run]
@@ -187,7 +187,7 @@ jobs:
 
       - name: Copy wheels from staging sub-dir to release dir S3
         run: |
-          aws s3 cp s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/staging/ \
+          aws s3 cp s3://${{ env.S3_BUCKET_PY }}/staging/${{ inputs.amdgpu_family }}/ \
           s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ \
             --recursive --exclude "*" --include "*.whl"
 

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -25,6 +25,10 @@ on:
         description: CloudFront URL pointing to Python index
         required: true
         type: string
+      cloudfront_staging_url:
+        description: CloudFront URL pointing to Python index
+        required: true
+        type: string
       rocm_version:
         description: ROCm version to pip install
         type: string
@@ -53,6 +57,10 @@ on:
         description: CloudFront base URL pointing to Python index
         type: string
         default: "https://d25kgig7rdsyks.cloudfront.net/v2"
+      cloudfront_staging_url:
+        description: CloudFront base URL pointing to Python index
+        type: string
+        default: "https://d25kgig7rdsyks.cloudfront.net/v2-staging"
       rocm_version:
         description: ROCm version to pip install
         type: string
@@ -171,7 +179,7 @@ jobs:
     with:
       amdgpu_family: ${{ inputs.amdgpu_family }}
       test_runs_on: ${{ needs.generate_target_to_run.outputs.test_runs_on }}
-      cloudfront_url: ${{ inputs.cloudfront_url }}
+      cloudfront_url: ${{ inputs.cloudfront_staging_url }}
       python_version: ${{ inputs.python_version }}
       torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}
 

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -129,7 +129,7 @@ jobs:
             build \
             --install-rocm \
             --pip-cache-dir /tmp/pipcache \
-            --index-url "${{ inputs.cloudfront_staging_url }}/${{ inputs.amdgpu_family }}/" \
+            --index-url "${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/" \
             --clean \
             --output-dir ${{ env.PACKAGE_DIST_DIR }} ${{ env.optional_build_prod_arguments }}
           echo "torch_version=`cd ${{ env.PACKAGE_DIST_DIR }}; python -c 'import glob; print(glob.glob("torch-*.whl")[0].split("-")[1])'`" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -153,10 +153,7 @@ jobs:
         env:
           TARGET: ${{ inputs.amdgpu_family }}
         run: python ./build_tools/github_actions/configure_target_run.py
-
-      - name: Debug test-runs-on
-        run: echo "Test runs on: ${{ steps.configure.outputs.test-runs-on }}"
-
+        
   test_pytorch_wheels:
     if: ${{ needs.generate_target_to_run.outputs.test_runs_on != '' }}
     needs: [build_pytorch_wheels, generate_target_to_run]

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -199,10 +199,6 @@ jobs:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
 
-      - name: Sanity Check Wheel
-        run: |
-          python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}/
-
       - name: Copy wheels from staging sub-dir to release dir S3
         run: |
           aws s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}/ \

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -14,6 +14,10 @@ on:
         description: "Subdirectory to push the Python packages"
         type: string
         default: "v2"
+      s3_staging_subdir:
+        description: "Staging Subdirectory to push the Python packages"
+        type: string
+        default: "v2-staging"
   # Trigger manually (typically to test the workflow or manually build a release [candidate])
   workflow_dispatch:
     inputs:
@@ -27,6 +31,10 @@ on:
         description: "Subdirectory to push the Python packages"
         type: string
         default: "v2"
+      s3_staging_subdir:
+        description: "Staging Subdirectory to push the Python packages"
+        type: string
+        default: "v2-staging"
       families:
         description: "Comma separated list of AMD GPU families, e.g. `gfx94X,gfx103x`"
         type: string
@@ -44,6 +52,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       S3_SUBDIR: ${{ inputs.s3_subdir || 'v2' }}
+      S3_STAGING_SUBDIR: ${{ inputs.s3_subdir || 'v2-staging' }}
       release_type: ${{ inputs.release_type || 'nightly' }}
     outputs:
       version: ${{ steps.release_information.outputs.version }}
@@ -170,12 +179,23 @@ jobs:
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::692859939525:role/therock-${{ env.RELEASE_TYPE }}-releases
-
+      
+      ## TODO: Restrict uploading to the non-staging S3 directory until ROCm sanity checks and all validation tests have successfully passed.
       - name: Upload Releases to S3
         if: ${{ github.repository_owner == 'ROCm' }}
         run: |
           aws s3 cp ${{ env.DIST_ARCHIVE }} s3://${{ env.S3_BUCKET_TAR }}
           aws s3 cp ${{ env.OUTPUT_DIR }}/packages/dist/ s3://${{ env.S3_BUCKET_PY }}/${{ env.S3_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}/ \
+          --recursive --no-follow-symlinks \
+          --exclude "*" \
+          --include "*.whl" \
+          --include "*.tar.gz"
+
+      - name: Upload Releases to Staging S3
+        if: ${{ github.repository_owner == 'ROCm' }}
+        run: |
+          aws s3 cp ${{ env.DIST_ARCHIVE }} s3://${{ env.S3_BUCKET_TAR }}
+          aws s3 cp ${{ env.OUTPUT_DIR }}/packages/dist/ s3://${{ env.S3_BUCKET_PY }}/${{ env.S3_STAGING_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}/ \
           --recursive --no-follow-symlinks \
           --exclude "*" \
           --include "*.whl" \
@@ -192,6 +212,12 @@ jobs:
         run: |
           pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py ${{ env.S3_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}
+
+      - name: (Re-)Generate Python package release index for Staging
+        if: ${{ github.repository_owner == 'ROCm' }}
+        run: |
+          pip install boto3 packaging
+          python ./build_tools/third_party/s3_management/manage.py ${{ env.S3_STAGING_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}
 
       - name: Trigger testing nightly tarball
         if: ${{ env.RELEASE_TYPE == 'nightly' }}

--- a/build_tools/third_party/s3_management/manage.py
+++ b/build_tools/third_party/s3_management/manage.py
@@ -37,10 +37,15 @@ INDEX_BUCKETS = {BUCKET} #, BUCKET_CDN}
 ACCEPTED_FILE_EXTENSIONS = ("whl", "zip", "tar.gz")
 PREFIXES = [
     "v2/gfx110X-dgpu",
+    "v2-staging/gfx110X-dgpu",
     "v2/gfx1151",
+    "v2-staging/gfx1151",
     "v2/gfx120X-all",
+    "v2-staging/gfx120X-all",
     "v2/gfx94X-dcgpu",
+    "v2-staging/gfx94X-dcgpu"
     "v2/gfx950-dcgpu",
+    "v2-staging/gfx950-dcgpu"
 ]
 
 # NOTE: This refers to the name on the wheels themselves and not the name of

--- a/build_tools/third_party/s3_management/manage.py
+++ b/build_tools/third_party/s3_management/manage.py
@@ -43,7 +43,7 @@ PREFIXES = [
     "v2/gfx120X-all",
     "v2-staging/gfx120X-all",
     "v2/gfx94X-dcgpu",
-    "v2-staging/gfx94X-dcgpu"
+    "v2-staging/gfx94X-dcgpu",
     "v2/gfx950-dcgpu",
     "v2-staging/gfx950-dcgpu"
 ]


### PR DESCRIPTION
We are adding a gating mechanism to run pytorch tests before the built pytorch wheels are uploaded to release bucker.

Implementation and design details have been documented in the issue

#1072 

Presently implemented the below:

1. Build Torch builds
2. Upload the Torch builds to v2-staging (Staging bucket)
3. Run torch tests on Staging bucket
4. Copy from staging bucket to release bucket only after tests pass