### PR TITLE
[ci] - Exclude one hipblaslt test for windows gfx1151

### DIFF
--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -72,6 +72,8 @@ jobs:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
       OUTPUT_ARTIFACTS_DIR: "./build"
       THEROCK_BIN_DIR: "./build/bin"
+      PLATFORM: ${{ inputs.platform }}
+      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
@@ -17,7 +17,9 @@ cmd = [f"{THEROCK_BIN_DIR}/hipblaslt-test", "--gtest_filter=*pre_checkin*"]
 
 tests_to_exclude = {
     # Related issue: https://github.com/ROCm/TheRock/issues/1114
-    "gfx1151": {"windows": ["_/aux_test.conversion/pre_checkin_aux_auxiliary_func_f16_r"]}
+    "gfx1151": {
+        "windows": ["_/aux_test.conversion/pre_checkin_aux_auxiliary_func_f16_r"]
+    }
 }
 
 if AMDGPU_FAMILIES in tests_to_exclude and PLATFORM in tests_to_exclude.get(

--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
@@ -8,9 +8,24 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+PLATFORM = os.getenv("PLATFORM")
+AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
+
 logging.basicConfig(level=logging.INFO)
 
 cmd = [f"{THEROCK_BIN_DIR}/hipblaslt-test", "--gtest_filter=*pre_checkin*"]
+
+tests_to_exclude = {
+    # Related issue: https://github.com/ROCm/TheRock/issues/1114
+    "gfx1151": {"windows": ["pre_checkin_aux_auxiliary_func_f16_r"]}
+}
+
+if AMDGPU_FAMILIES in tests_to_exclude and PLATFORM in tests_to_exclude.get(
+    AMDGPU_FAMILIES, {}
+):
+    exclusion_list = ":".join(tests_to_exclude[AMDGPU_FAMILIES][PLATFORM])
+    cmd.apppend(f"--gtest_filter=-{exclusion_list}")
+
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 subprocess.run(
     cmd,

--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
@@ -24,7 +24,7 @@ if AMDGPU_FAMILIES in tests_to_exclude and PLATFORM in tests_to_exclude.get(
     AMDGPU_FAMILIES, {}
 ):
     exclusion_list = ":".join(tests_to_exclude[AMDGPU_FAMILIES][PLATFORM])
-    cmd.apppend(f"--gtest_filter=-{exclusion_list}")
+    cmd.append(f"--gtest_filter=-{exclusion_list}")
 
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 subprocess.run(

--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
@@ -17,7 +17,7 @@ cmd = [f"{THEROCK_BIN_DIR}/hipblaslt-test", "--gtest_filter=*pre_checkin*"]
 
 tests_to_exclude = {
     # Related issue: https://github.com/ROCm/TheRock/issues/1114
-    "gfx1151": {"windows": ["pre_checkin_aux_auxiliary_func_f16_r"]}
+    "gfx1151": {"windows": ["_/aux_test.conversion/pre_checkin_aux_auxiliary_func_f16_r"]}
 }
 
 if AMDGPU_FAMILIES in tests_to_exclude and PLATFORM in tests_to_exclude.get(


### PR DESCRIPTION
Ran a test with [failing CI run ID](https://github.com/ROCm/TheRock/actions/runs/16485423682/job/46611899777) and ran a new [CI test run](https://github.com/ROCm/TheRock/actions/runs/16506892410), works!

Linked issue #1114 