### PR TITLE
Cherry-pick hipBLASLt fix for hip::device dep.

### DIFF
--- a/patches/amd-mainline/hipBLASLt/0001-Fix-linkage-for-tensilelite-host-target-and-bump-mxd.patch
+++ b/patches/amd-mainline/hipBLASLt/0001-Fix-linkage-for-tensilelite-host-target-and-bump-mxd.patch
@@ -1,7 +1,7 @@
-From b39962c1e0478f674ca5dc33e636edf8d898a2b7 Mon Sep 17 00:00:00 2001
+From d05e765a273099c2773565e9121628ba04ed1746 Mon Sep 17 00:00:00 2001
 From: David Dixon <david.dixon@amd.com>
 Date: Thu, 17 Jul 2025 10:17:10 +0000
-Subject: [PATCH 2/2] Fix linkage for tensilelite-host target and bump
+Subject: [PATCH 1/3] Fix linkage for tensilelite-host target and bump
  mxdatagen
 
 - Updates linkage for tensilelite-host msgpack dependency because it is
@@ -96,7 +96,7 @@ index 766c548d..6f50adde 100644
                                     int const              scaleBlockRowSize,
                                     int const              scaleBlockColSize,
 diff --git a/next-cmake/CMakeLists.txt b/next-cmake/CMakeLists.txt
-index 67329ebc..a19f886a 100644
+index e8eb960f..096bef82 100644
 --- a/next-cmake/CMakeLists.txt
 +++ b/next-cmake/CMakeLists.txt
 @@ -52,7 +52,7 @@ endif()
@@ -195,5 +195,5 @@ index bd7d7869..c710c283 100644
 +    )
  endif()
 -- 
-2.25.1
+2.47.1.windows.2
 

--- a/patches/amd-mainline/hipBLASLt/0002-Add-.string.patch
+++ b/patches/amd-mainline/hipBLASLt/0002-Add-.string.patch
@@ -1,7 +1,7 @@
-From 61b2e9b395b319e7f1baa47a07da2af2a0dce5e3 Mon Sep 17 00:00:00 2001
+From d80409808da68f1e9f3e27696cf1fbd14609e55d Mon Sep 17 00:00:00 2001
 From: David Dixon <david.dixon@amd.com>
 Date: Fri, 18 Jul 2025 03:12:09 +0000
-Subject: [PATCH 3/3] Add .string()
+Subject: [PATCH 2/3] Add .string()
 
 ---
  library/src/amd_detail/rocblaslt/src/tensile_host.cpp | 2 +-
@@ -21,5 +21,5 @@ index a1bf4a31..645abf31 100644
                          std::cerr << "\nrocblaslt error: Could not initialize Tensile library "
                                       "mapping"
 -- 
-2.25.1
+2.47.1.windows.2
 

--- a/patches/amd-mainline/hipBLASLt/0003-rocm-libraries-ROCm-rocm-libraries-855-commit-e056ca.patch
+++ b/patches/amd-mainline/hipBLASLt/0003-rocm-libraries-ROCm-rocm-libraries-855-commit-e056ca.patch
@@ -1,0 +1,85 @@
+From 831d08eba24b6e9f93b60c8f3304785fb0e70af3 Mon Sep 17 00:00:00 2001
+From: David Dixon <165835255+ellosel@users.noreply.github.com>
+Date: Sat, 26 Jul 2025 01:49:50 +0000
+Subject: [PATCH 3/3] [rocm-libraries] ROCm/rocm-libraries#855 (commit e056cac)
+
+[hipblsalt] Fix leaky hip::device dependency
+
+- Do note use PUBLIC linkage for hip::device
+- Add logic to project config to catch when hip::device is added to
+interface link libraries
+- Fixes the regression noted in
+https://github.com/ROCm/rocm-libraries/pull/650#issuecomment-3120543083
+- Root cause diagnosis of the issue:
+https://chatgpt.com/share/68841788-4564-800d-a6a1-e000c668c0fb
+---
+ next-cmake/CMakeLists.txt                  |  9 ++++++++-
+ next-cmake/cmake/hipblaslt-config.cmake.in | 15 ++++++++++++++-
+ 2 files changed, 22 insertions(+), 2 deletions(-)
+
+diff --git a/next-cmake/CMakeLists.txt b/next-cmake/CMakeLists.txt
+index 096bef82..7a6b0efa 100644
+--- a/next-cmake/CMakeLists.txt
++++ b/next-cmake/CMakeLists.txt
+@@ -270,6 +270,7 @@ if(TENSILELITE_ENABLE_HOST OR HIPBLASLT_ENABLE_HOST)
+     target_link_libraries(tensilelite-host
+         PUBLIC
+             rocisa::rocisa-cpp
++        PRIVATE
+             hip::device
+     )
+ 
+@@ -293,8 +294,8 @@ if(HIPBLASLT_ENABLE_HOST)
+     target_link_libraries(hipblaslt
+         PUBLIC
+             roc::${hipblas_target}
+-            hip::device
+         PRIVATE
++            hip::device
+             tensilelite::tensilelite-host
+             ${CMAKE_DL_LIBS}
+             ${rocTracer}
+@@ -388,6 +389,12 @@ if(HIPBLASLT_ENABLE_HOST)
+         NAMESPACE roc::
+     )
+ 
++    configure_file(
++        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/hipblaslt-config.cmake.in"
++        "${CMAKE_CURRENT_BINARY_DIR}/hipblaslt-config.cmake"
++        COPYONLY
++    )
++
+     if( LEGACY_HIPBLAS_DIRECT )
+         rocm_package_add_dependencies(DEPENDS "hipblas >= 0.50.0")
+     else()
+diff --git a/next-cmake/cmake/hipblaslt-config.cmake.in b/next-cmake/cmake/hipblaslt-config.cmake.in
+index 930c8f11..a49dfad9 100644
+--- a/next-cmake/cmake/hipblaslt-config.cmake.in
++++ b/next-cmake/cmake/hipblaslt-config.cmake.in
+@@ -20,9 +20,22 @@
+ # THE SOFTWARE.
+ #
+ # ########################################################################
++
+ include(CMakeFindDependencyMacro)
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../share/cmake/hipblaslt")
+-find_dependency(hip)
++
+ find_dependency(hipblas-common)
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/hipblaslt-targets.cmake")
++
++block(SCOPE_FOR VARIABLES)
++    if(NOT TARGET roc::hipblaslt)
++        message(FATAL_ERROR "roc::hipblaslt target is missing")
++    endif()
++
++    get_target_property(link_libraries roc::hipblaslt INTERFACE_LINK_LIBRARIES)
++
++    if(link_libraries AND "hip::device" IN_LIST link_libraries)
++        message(FATAL_ERROR "Do not export targets with hip::device as an interface link library")
++    endif()
++endblock()
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/rocm-libraries/pull/855 for testing, with conflicts resolved manually. Patches did not apply cleanly on a roll-up, as https://github.com/ROCm/rocm-libraries/pull/702 is still under review and has conflicts too.