### PR TITLE
Add `pytorch-triton-rocm` to index

### DIFF
--- a/build_tools/third_party/s3_management/manage.py
+++ b/build_tools/third_party/s3_management/manage.py
@@ -53,6 +53,8 @@ PACKAGE_ALLOW_LIST = {x.lower() for x in [
     "rocm_sdk",
     "rocm_sdk_core",
     "rocm_sdk_devel",
+    # ---- triton ROCm ----
+    "pytorch_triton_rocm",
     # ---- triton additional packages ----
     "Arpeggio",
     "caliper_reader",


### PR DESCRIPTION
With this, index files for the `pytorch-triton-rocm` get generated via `manage.py`.