### PR TITLE
Append ROCm version to trition version suffix

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -470,8 +470,13 @@ def do_build_triton(
     # The below only works for the latter and a better fix is needed.
     version_suffix = env.get("TRITON_WHEEL_VERSION_SUFFIX", "")
 
-    # If TRITON_WHEEL_VERSION_SUFFIX contains a "+", replace the one
-    # in `args.version_suffix` with a "-".
+    # Append the version suffix passed via `arg.version_suffix` to
+    # TRITON_WHEEL_VERSION_SUFFIX. If the latter was set before,
+    # replace any "+" in `args.version_suffix` with a "-" as multiple
+    # "+" characters result in an invalid version.
+    # If TRITON_WHEEL_VERSION_SUFFIX is not set, the version for a build
+    # based on ROCm 7.0.0rc20250728 will be `3.3.1+rocm7.0.0rc20250728`
+    # insteaf of `3.3.1`.
     if re.search(r"\+", version_suffix):
         version_suffix += str(args.version_suffix).replace("+", "-")
     else:


### PR DESCRIPTION
The `pytorch-triton-rocm` package is build now on a nightly cadence as will get overwritten as long as the package version is not updated. While upstream includes a git hash in the version extra, this is not the case for the ROCm/trition version currently tracked and build alongside to PyTorch 2.7 from ROCm/pytorch.