### PR TITLE
[torch] Apply patch for __builtin_clz on Windows.

### DIFF
--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0001-Enable-USE_ROCM-disable-USE_RCCL-on-Windows.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0001-Enable-USE_ROCM-disable-USE_RCCL-on-Windows.patch
@@ -1,7 +1,7 @@
-From 4ed838ae6447d7846c84e786dc58b2e3c63fd217 Mon Sep 17 00:00:00 2001
+From 603c31f1caea93e49d19ff27a4f6491bd9ec0835 Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Thu, 24 Jul 2025 10:38:01 -0700
-Subject: [PATCH 2/4] Enable USE_ROCM, disable USE_RCCL on Windows.
+Subject: [PATCH 1/4] Enable USE_ROCM, disable USE_RCCL on Windows.
 
 ---
  CMakeLists.txt | 3 ++-

--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0002-Fix-LoadHIP-handling-of-environment-variable-paths-o.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0002-Fix-LoadHIP-handling-of-environment-variable-paths-o.patch
@@ -1,7 +1,7 @@
-From 86c8f73ac6cf4d1ca251ab4932555d1c2862d84a Mon Sep 17 00:00:00 2001
+From 3406c1b791c014907504ddacb5d26767d97ba0b3 Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Thu, 24 Jul 2025 12:43:07 -0700
-Subject: [PATCH 3/4] Fix LoadHIP handling of environment variable paths on
+Subject: [PATCH 2/4] Fix LoadHIP handling of environment variable paths on
  Windows.
 
 ---

--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0003-Revert-copying-hipblaslt-and-rocblas-dirs-on-Windows.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0003-Revert-copying-hipblaslt-and-rocblas-dirs-on-Windows.patch
@@ -1,7 +1,7 @@
-From b9f2cdb57e6f43c4a0d86b5fd0494cb288c40d04 Mon Sep 17 00:00:00 2001
+From 1588921730be122c750a0226fd0bc62bf705ceec Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Thu, 24 Jul 2025 12:45:53 -0700
-Subject: [PATCH 4/4] Revert copying hipblaslt and rocblas dirs on Windows.
+Subject: [PATCH 3/4] Revert copying hipblaslt and rocblas dirs on Windows.
 
 Since https://github.com/pytorch/pytorch/commit/30387ab2e485384ab2e67084a1e2c5569190ba92, ROCm is bootstrapped using the 'rocm' Python module which contains these files, so they do not need to be bundled into torch/lib.
 ---

--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0004-Patch-ifdef-for-__builtin_clz-on-Windows.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0004-Patch-ifdef-for-__builtin_clz-on-Windows.patch
@@ -1,0 +1,25 @@
+From d9bf370882c311123cbda011c18d5f000c9b1ecc Mon Sep 17 00:00:00 2001
+From: Aaryaman Vasishta <jem456.vasishta@gmail.com>
+Date: Sun, 4 May 2025 22:24:50 +0530
+Subject: [PATCH 4/4] Patch ifdef for `__builtin_clz` on Windows.
+
+---
+ functorch/csrc/dim/arena.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/functorch/csrc/dim/arena.h b/functorch/csrc/dim/arena.h
+index aaaf7e772a3..4bc627575de 100644
+--- a/functorch/csrc/dim/arena.h
++++ b/functorch/csrc/dim/arena.h
+@@ -8,7 +8,7 @@
+ #include <ATen/ATen.h>
+ #include "minpybind.h"
+ 
+-#ifdef _WIN32
++#if defined(_WIN32) && !(defined(__clang__) && defined(_MSC_VER))
+ #include <intrin.h>
+ // https://stackoverflow.com/questions/355967/how-to-use-msvc-intrinsics-to-get-the-equivalent-of-this-gcc-code
+ inline unsigned int __builtin_clz(unsigned int x) {
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
This copies a patch from our `v2.7.0` patches folder (https://github.com/ROCm/TheRock/blob/main/external-builds/pytorch/patches/pytorch/v2.7.0/pytorch/hipified/0013-Patch-ifdef-for-__builtin_clz-on-Windows.patch) to the `main` folder

It is expected to fix errors like https://github.com/ROCm/TheRock/actions/runs/16569646709/job/46858176812:
```
2025-07-28T13:46:04.8652913Z [7099/7147] Building CXX object functorch\CMakeFiles\functorch.dir\csrc\dim\dim.cpp.obj
2025-07-28T13:46:04.8653325Z FAILED: functorch/CMakeFiles/functorch.dir/csrc/dim/dim.cpp.obj 
2025-07-28T13:46:04.8662076Z C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\_rocm_sdk_devel\lib\llvm\bin\clang-cl.exe  /nologo -TP -DEXPORT_AOTI_FUNCTIONS -DFUNCTORCH_BUILD_MAIN_LIB -DMINIZ_DISABLE_ZIP_READER_CRC32_CHECKS -DNOMINMAX -DONNXIFI_ENABLE_EXT=1 -DONNX_ML=1 -DONNX_NAMESPACE=onnx_torch -DROCM_ON_WINDOWS -DROCM_USE_FLOAT16 -DROCM_VERSION=70000 -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=_C -DTORCH_HIP_VERSION=700 -DUSE_EXTERNAL_MZCRC -DUSE_MIMALLOC -DUSE_PROF_API=1 -DWIN32_LEAN_AND_MEAN -D_CRT_SECURE_NO_DEPRECATE=1 -D_UCRT_LEGACY_INFINITY -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_AMD__=1 -Dfunctorch_EXPORTS -IB:\src\torch\build\aten\src -IB:\src\torch\aten\src -IB:\src\torch\build -IB:\src\torch -IB:\src\torch\nlohmann -IB:\src\torch\moodycamel -IB:\src\torch\third_party\mimalloc\include -IB:\src\torch\functorch -IB:\src\torch\torch\csrc\api -IB:\src\torch\torch\csrc\api\include -IB:\src\torch\c10\.. -IB:\src\torch\c10\hip\..\.. -IB:\src\torch\torch\.. -IB:\src\torch\torch\..\aten\src -IB:\src\torch\torch\..\aten\src\TH -IB:\src\torch\build\caffe2\aten\src -IB:\src\torch\build\third_party -IB:\src\torch\build\third_party\onnx -IB:\src\torch\torch\..\third_party\valgrind-headers -IB:\src\torch\torch\..\third_party\gloo -IB:\src\torch\torch\..\third_party\onnx -IB:\src\torch\torch\..\third_party\flatbuffers\include -IB:\src\torch\torch\..\third_party\kineto\libkineto\include -IB:\src\torch\torch\..\third_party\cpp-httplib -IB:\src\torch\torch\..\third_party\nlohmann\include -IB:\src\torch\torch\csrc -IB:\src\torch\torch\lib -IB:\src\torch\torch\standalone -IB:\src\torch\torch\lib\libshm_windows -imsvcC:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\_rocm_sdk_devel\include -imsvcB:\src\torch\third_party\protobuf\src -imsvcB:\src\torch\third_party\XNNPACK\include -imsvcB:\src\torch\third_party\ittapi\include -imsvcB:\src\torch\cmake\..\third_party\eigen -imsvcB:\src\torch\third_party\ideep\mkl-dnn\include\oneapi\dnnl -imsvcB:\src\torch\third_party\ideep\include -imsvcB:\src\torch\INTERFACE -imsvcB:\src\torch\third_party\nlohmann\include -imsvcB:\src\torch\third_party\concurrentqueue -imsvcC:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\_rocm_sdk_devel\include\hiprand -imsvcC:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\_rocm_sdk_devel\include\rocrand -imsvcB:\src\torch\cmake\..\third_party\pybind11\include -imsvcC:\home\runner\_work\_tool\Python\3.11.9\x64\include /DWIN32 /D_WINDOWS /EHsc /Zc:__cplusplus /bigobj /FS /utf-8 -DUSE_PTHREADPOOL -DNDEBUG -DUSE_FBGEMM -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE /wd4624 /wd4068 /wd4067 /wd4267 /wd4661 /wd4717 /wd4244 /wd4804 /wd4273 /O2 /Ob2 /DNDEBUG /bigobj -DNDEBUG -std:c++17 -MD -Z7 -Wmissing-prototypes -Werror=missing-prototypes /permissive- /d2implyavx512upperregs- /EHsc /bigobj -fms-runtime-lib=dll -D__HIP_PLATFORM_AMD__=1 -DCUDA_HAS_FP16=1 -DUSE_ROCM -D__HIP_NO_HALF_OPERATORS__=1 -D__HIP_NO_HALF_CONVERSIONS__=1 -DTORCH_HIP_VERSION=700 -Wno-shift-count-negative -Wno-shift-count-overflow -Wno-duplicate-decl-specifier -DCAFFE2_USE_MIOPEN -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP -std=c++17 -DHIPBLAS_V2 -DHIP_ENABLE_WARP_SYNC_BUILTINS -fms-extensions -Wno-ignored-attributes /showIncludes /Fofunctorch\CMakeFiles\functorch.dir\csrc\dim\dim.cpp.obj /Fdfunctorch\CMakeFiles\functorch.dir\ -c -- B:\src\torch\functorch\csrc\dim\dim.cpp
2025-07-28T13:46:04.8669255Z clang-cl: warning: unknown argument ignored in clang-cl: '-std=c++17' [-Wunknown-argument]
2025-07-28T13:46:04.8669712Z clang-cl: warning: argument unused during compilation: '/d2implyavx512upperregs-' [-Wunused-command-line-argument]
2025-07-28T13:46:04.8671033Z In file included from B:\src\torch\functorch\csrc\dim\dim.cpp:36:
2025-07-28T13:46:04.8671433Z B:\src\torch\functorch\csrc\dim\arena.h(14,21): error: functions that differ only in their return type cannot be overloaded
2025-07-28T13:46:04.8671807Z    14 | inline unsigned int __builtin_clz(unsigned int x) {
2025-07-28T13:46:04.8672019Z       |        ~~~~~~~~~~~~ ^
2025-07-28T13:46:05.1369060Z C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\_rocm_sdk_devel\lib\llvm\lib\clang\20\include\ia32intrin.h(60,15): note: '__builtin_clz' is a builtin with type 'int (unsigned int) noexcept'
2025-07-28T13:46:05.1369687Z    60 |   return 31 - __builtin_clz((unsigned int)__A);
2025-07-28T13:46:05.1369887Z       |               ^
2025-07-28T13:46:05.1370019Z 1 error generated.
2025-07-28T13:46:05.1370308Z [7100/7147] Building CXX object caffe2\torch\CMakeFiles\torch_python.dir\csrc\utils\tensor_list.cpp.obj
```

I tried to reproduce those errors locally on Python 3.11 and Python 3.12 with no luck, but the error and associated patch are pretty clear - that code should only be used with MSVC, not other compilers when on Windows (e.g. clang-cl).

Tested at https://github.com/ROCm/TheRock/actions/runs/16575196459/job/46877626039