### PR TITLE
Replace mi300 self-hosted runner in OSSCI with mi325

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -10,7 +10,7 @@ on:
       test_runs_on:
         required: true
         type: string
-        default: "linux-mi300-1gpu-ossci-rocm"
+        default: "linux-mi325-1gpu-ossci-rocm"
       cloudfront_url:
         description: CloudFront URL pointing to Python index
         required: true

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -5,7 +5,7 @@ This AMD GPU Family Matrix is the "source of truth" for GitHub workflows, indica
 amdgpu_family_info_matrix_presubmit = {
     "gfx94x": {
         "linux": {
-            "test-runs-on": "linux-mi300-1gpu-ossci-rocm",
+            "test-runs-on": "linux-mi325-1gpu-ossci-rocm",
             "family": "gfx94X-dcgpu",
         }
     },

--- a/build_tools/github_actions/populate_redshift_db.py
+++ b/build_tools/github_actions/populate_redshift_db.py
@@ -117,14 +117,14 @@ def populate_redshift_db(
 
                     Example:
                     Given input_dict['jobs'][6]['name'] as:
-                    'Linux (linux-mi300-1gpu-ossci-rocm, gfx94X-dcgpu, gfx942) / Build / Build Linux Packages (xfail false)'
+                    'Linux (linux-mi325-1gpu-ossci-rocm, gfx94X-dcgpu, gfx942) / Build / Build Linux Packages (xfail false)'
 
                     This will extract:
                     ['gfx94X-dcgpu', 'gfx942']
                     """
                     platform_str = input_dict["jobs"][i]["name"]
                     if "gfx" in platform_str:
-                        # Extract first group to filter out GPUs from platform_str Linux (linux-mi300-1gpu-ossci-rocm, gfx94X-dcgpu, gfx942) / Build / Build Linux Packages (xfail false) into list [gfx94X-dcgpu, gfx942]
+                        # Extract first group to filter out GPUs from platform_str Linux (linux-mi325-1gpu-ossci-rocm, gfx94X-dcgpu, gfx942) / Build / Build Linux Packages (xfail false) into list [gfx94X-dcgpu, gfx942]
                         match = re.search(r"\(([^)]*)\)", platform_str)
                         inside = match.group(1) if match else ""
                         # Split by comma and filter for entries starting with 'gfx'


### PR DESCRIPTION
The OSSCI cluster is losing a bunch of mi300 capacity and getting more mi325 capacity for the time being. Hence moving the self-hosted runner usage from mi300 to mi325.  