### PR TITLE
Pass PyTorch version to checkout the correct repo

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -200,3 +200,4 @@ jobs:
       cloudfront_url: ${{ inputs.cloudfront_url }}
       python_version: ${{ inputs.python_version }}
       torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}
+      pytorch_version: ${{ inputs.pytorch_version }}

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -25,7 +25,6 @@ on:
         type: string
       pytorch_version:
         description: PyTorch version to checkout. ("nightly", or "release/2.7")
-        required: true
         type: string
         default: "release/2.7"
 
@@ -48,7 +47,6 @@ on:
         type: string
       pytorch_version:
         description: PyTorch version to checkout. ("nightly", or "release/2.7")
-        required: true
         type: string
         default: "release/2.7"
 

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -23,6 +23,11 @@ on:
       torch_version:
         required: true
         type: string
+      pytorch_version:
+        description: PyTorch version to checkout. ("nightly", or "release/2.7")
+        required: true
+        type: string
+        default: "release/2.7"
 
   workflow_call:
     inputs:
@@ -41,6 +46,11 @@ on:
       torch_version:
         required: true
         type: string
+      pytorch_version:
+        description: PyTorch version to checkout. ("nightly", or "release/2.7")
+        required: true
+        type: string
+        default: "release/2.7"
 
 permissions:
   contents: read
@@ -70,10 +80,16 @@ jobs:
       # to run HIPIFY or apply any patches, so we skip those steps to save time.
       # TODO(scotttodd): Windows will need to checkout to a shorter path.
       #                  When Windows runs full tests, fix that and re-enable.
-      - name: Checkout PyTorch repository
-        if: "contains(inputs.test_runs_on, 'linux')"
+      - name: Checkout PyTorch Source Repos from nightly branch
+        # Checkout default upstream PyTorch/PyTorch branch.
+        if: ${{ (inputs.pytorch_version == 'nightly') && (contains(inputs.test_runs_on, 'linux')) }}
         run: |
-          python external-builds/pytorch/pytorch_torch_repo.py checkout --no-hipify --no-patch
+          ./external-builds/pytorch/pytorch_torch_repo.py checkout --repo-hashtag nightly --no-hipify --no-patch
+
+      - name: Checkout PyTorch Source Repos from stable branch
+        if: ${{ (inputs.pytorch_version != 'nightly') && (contains(inputs.test_runs_on, 'linux')) }}
+        run: |
+          python external-builds/pytorch/pytorch_torch_repo.py checkout --gitrepo-origin https://github.com/ROCm/pytorch.git --repo-hashtag ${{ inputs.pytorch_version }} --no-hipify --no-patch
 
       - name: Set up virtual environment
         run: |


### PR DESCRIPTION
With commit c2ac13f, sources to build PyTorch get pulled from ROCm/PyTorch but this is not the case when testing the wheels afterwards. The patch makes sure that the same repo / branch is used for testing as for the builds before.