### PR TITLE
Skip `test_float32_matmul_precision_get_set`

### DIFF
--- a/external-builds/pytorch/skipped_tests.py
+++ b/external-builds/pytorch/skipped_tests.py
@@ -10,6 +10,8 @@ skip_tests = [
     "test_host_memory_stats",
     "test_nvtx",
     "test_device_count_not_cached_pre_init",
+    # TestCuda under test_cuda.py, failing on gfx942 (#1143)
+    "test_float32_matmul_precision_get_set ",
     # TestCuda under test_cuda.py, failing on gfx950
     "test_preferred_blas_library_settings",
     # TestCudaAutocast under test_cuda.py, failing on gfx950


### PR DESCRIPTION
Test is failing as reported in #1143. Skipping for now.