### PR TITLE
Add `ninja` to the requirements

### DIFF
--- a/external-builds/pytorch/requirements-test.txt
+++ b/external-builds/pytorch/requirements-test.txt
@@ -1,8 +1,9 @@
 # Partially retrieved from https://github.com/pytorch/pytorch/blob/main/requirements.txt
-# Python dependencies required for development
+# and https://github.com/pytorch/pytorch/blob/main/requirements-build.txt
 pytest==8.3.5
 pytest-xdist>=3.5.0
 expecttest>=0.3.0
 hypothesis
+ninja
 numpy
 psutil


### PR DESCRIPTION
`pytorch/test/test_cuda.py::TestCudaMallocAsync::test_cpp_memory_snapshot_pickle` and others requires ninja to not fail with:
`RuntimeError: Ninja is required to load C++ extensions`.