### PR TITLE
[windows] Bump amdgpu-windows-interop to version 20250722.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -77,7 +77,7 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
   set(HIP_CLR_RUNTIME_DEPS)
   if(WIN32)
     # Windows CLR options
-    set(_compute_pal_dir "${CMAKE_CURRENT_SOURCE_DIR}/amdgpu-windows-interop/20250515a")
+    set(_compute_pal_dir "${CMAKE_CURRENT_SOURCE_DIR}/amdgpu-windows-interop/20250722a")
     cmake_path(NORMAL_PATH _compute_pal_dir)
     list(APPEND HIP_CLR_CMAKE_ARGS
       "-DUSE_PROF_API=OFF"


### PR DESCRIPTION
Latest dump: https://github.com/ROCm/amdgpu-windows-interop/tree/main/20250722a

See https://github.com/ROCm/TheRock/blob/main/docs/development/windows_support.md#building-clr-from-partial-sources for information about this submodule.

Full release notes and commit history would be great... but we don't have that yet. The main thing we're looking forward to in this update is expanded support for navi44 (gfx1200).