### PR TITLE
[windows][torch] Revert CUDAAllocatorConfig commits that broke Windows.

### DIFF
--- a/external-builds/pytorch/patches/pytorch/main/base/0001-Revert-Generalize-torch._C._set_allocator_settings-t.patch
+++ b/external-builds/pytorch/patches/pytorch/main/base/0001-Revert-Generalize-torch._C._set_allocator_settings-t.patch
@@ -1,0 +1,275 @@
+From 0a65faf2e1227ce8d2668de82c12b9e848d48b72 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Wed, 30 Jul 2025 15:23:27 -0700
+Subject: [PATCH 1/3] Revert "Generalize torch._C._set_allocator_settings to be
+ generic (#156175)"
+
+This reverts commit d3ce45012ed42cd1e13d5048b046b781f0feabe0.
+---
+ c10/core/AllocatorConfig.cpp     | 14 +++++++-------
+ c10/core/AllocatorConfig.h       |  2 +-
+ c10/cuda/CUDAAllocatorConfig.cpp |  6 +++---
+ test/test_cuda.py                | 12 ++++++------
+ torch/_C/__init__.pyi.in         |  2 +-
+ torch/_dynamo/trace_rules.py     |  2 +-
+ torch/csrc/DeviceAccelerator.cpp |  5 -----
+ torch/csrc/cuda/Module.cpp       | 13 +++++++++++++
+ torch/cuda/memory.py             |  4 ++--
+ 9 files changed, 34 insertions(+), 26 deletions(-)
+
+diff --git a/c10/core/AllocatorConfig.cpp b/c10/core/AllocatorConfig.cpp
+index 5cb0ce27383..39b1d300795 100644
+--- a/c10/core/AllocatorConfig.cpp
++++ b/c10/core/AllocatorConfig.cpp
+@@ -45,7 +45,7 @@ size_t AcceleratorAllocatorConfig::roundup_power2_divisions(size_t size) {
+       63 - llvm::countLeadingZeros(kRoundUpPowerOfTwoStart);
+   const size_t interval_end =
+       63 - llvm::countLeadingZeros(kRoundUpPowerOfTwoEnd);
+-  TORCH_CHECK_VALUE(
++  TORCH_CHECK(
+       interval_end - interval_start == kRoundUpPowerOfTwoIntervals,
+       "kRoundUpPowerOfTwoIntervals mismatch");
+ 
+@@ -64,7 +64,7 @@ size_t AcceleratorAllocatorConfig::parseMaxSplitSize(
+       std::numeric_limits<size_t>::max() / kMB;
+ 
+   size_t val_env = tokenizer.toSizeT(++i);
+-  TORCH_CHECK_VALUE(
++  TORCH_CHECK(
+       val_env >= min_allowed_split_size_mb,
+       "CachingAllocator option max_split_size_mb too small, must be >= ",
+       min_allowed_split_size_mb);
+@@ -83,7 +83,7 @@ size_t AcceleratorAllocatorConfig::parseMaxNonSplitRoundingSize(
+       std::numeric_limits<size_t>::max() / kMB;
+ 
+   size_t val_env = tokenizer.toSizeT(++i);
+-  TORCH_CHECK_VALUE(
++  TORCH_CHECK(
+       val_env >= min_allowed_split_size_mb,
+       "CachingAllocator option max_non_split_rounding_mb too small, must be >= ",
+       min_allowed_split_size_mb);
+@@ -98,7 +98,7 @@ size_t AcceleratorAllocatorConfig::parseGarbageCollectionThreshold(
+     size_t i) {
+   tokenizer.checkToken(++i, ":");
+   double val_env = tokenizer.toDouble(++i);
+-  TORCH_CHECK_VALUE(
++  TORCH_CHECK(
+       val_env > 0 && val_env < 1.0,
+       "garbage_collect_threshold is invalid, set it in (0.0, 1.0)");
+   garbage_collection_threshold_ = val_env;
+@@ -119,7 +119,7 @@ size_t AcceleratorAllocatorConfig::parseRoundUpPower2Divisions(
+       size_t value_index = i;
+       tokenizer.checkToken(++i, ":");
+       size_t value = tokenizer.toSizeT(++i);
+-      TORCH_CHECK_VALUE(
++      TORCH_CHECK(
+           value == 0 || llvm::isPowerOf2_64(value),
+           "For roundups, the divisions has to be power of 2 or 0 to disable roundup ");
+ 
+@@ -133,7 +133,7 @@ size_t AcceleratorAllocatorConfig::parseRoundUpPower2Divisions(
+             value);
+       } else {
+         size_t boundary = tokenizer.toSizeT(value_index);
+-        TORCH_CHECK_VALUE(
++        TORCH_CHECK(
+             llvm::isPowerOf2_64(boundary),
+             "For roundups, the intervals have to be power of 2 ");
+ 
+@@ -163,7 +163,7 @@ size_t AcceleratorAllocatorConfig::parseRoundUpPower2Divisions(
+         "Expected closing bracket ']' in ConfigTokenizer but reached end of config");
+   } else { // Keep this for backwards compatibility
+     size_t value = tokenizer.toSizeT(i);
+-    TORCH_CHECK_VALUE(
++    TORCH_CHECK(
+         llvm::isPowerOf2_64(value),
+         "For roundups, the divisions has to be power of 2 ");
+     std::fill(
+diff --git a/c10/core/AllocatorConfig.h b/c10/core/AllocatorConfig.h
+index 14d94d242f5..3148a8a1655 100644
+--- a/c10/core/AllocatorConfig.h
++++ b/c10/core/AllocatorConfig.h
+@@ -76,7 +76,7 @@ class ConfigTokenizer {
+     } else if (token == "False") {
+       return false;
+     } else {
+-      TORCH_CHECK_VALUE(
++      TORCH_CHECK(
+           false,
+           "Expected 'True' or 'False' at index ",
+           i,
+diff --git a/c10/cuda/CUDAAllocatorConfig.cpp b/c10/cuda/CUDAAllocatorConfig.cpp
+index 3ad84fd345c..49fa2e1e95e 100644
+--- a/c10/cuda/CUDAAllocatorConfig.cpp
++++ b/c10/cuda/CUDAAllocatorConfig.cpp
+@@ -22,7 +22,7 @@ size_t CUDAAllocatorConfig::parseAllocatorConfig(
+ #define PYTORCH_TOKEN2 "hipMallocAsync"
+   tokenizer.checkToken(++i, ":");
+   i++; // Move to the value after the colon
+-  TORCH_CHECK_VALUE(
++  TORCH_CHECK(
+       ((tokenizer[i] == "native") || (tokenizer[i] == PYTORCH_TOKEN1) ||
+        (tokenizer[i] == PYTORCH_TOKEN2)),
+       "Unknown allocator backend, "
+@@ -134,12 +134,12 @@ size_t CUDAAllocatorConfig::parsePinnedNumRegisterThreads(
+     size_t i) {
+   tokenizer.checkToken(++i, ":");
+   size_t val2 = tokenizer.toSizeT(++i);
+-  TORCH_CHECK_VALUE(
++  TORCH_CHECK(
+       llvm::isPowerOf2_64(val2),
+       "Number of register threads has to be power of 2 ",
+       "");
+   auto maxThreads = CUDAAllocatorConfig::pinned_max_register_threads();
+-  TORCH_CHECK_VALUE(
++  TORCH_CHECK(
+       val2 <= maxThreads,
+       "Number of register threads should be less than or equal to " +
+           std::to_string(maxThreads),
+diff --git a/test/test_cuda.py b/test/test_cuda.py
+index 0bf6c08e51f..689f4f38250 100644
+--- a/test/test_cuda.py
++++ b/test/test_cuda.py
+@@ -4471,28 +4471,28 @@ class TestCudaMallocAsync(TestCase):
+         with self.assertRaises(RuntimeError):
+             torch.cuda.memory._set_allocator_settings("foo:1,bar:2")
+ 
+-        with self.assertRaises(ValueError):
++        with self.assertRaises(RuntimeError):
+             torch.cuda.memory._set_allocator_settings(
+                 "garbage_collection_threshold:1.2"
+             )
+ 
+-        with self.assertRaises(ValueError):
++        with self.assertRaises(RuntimeError):
+             torch.cuda.memory._set_allocator_settings("max_split_size_mb:2")
+ 
+-        with self.assertRaises(ValueError):
++        with self.assertRaises(RuntimeError):
+             torch.cuda.memory._set_allocator_settings("release_lock_on_cudamalloc:none")
+ 
+-        with self.assertRaises(ValueError):
++        with self.assertRaises(RuntimeError):
+             torch.cuda.memory._set_allocator_settings(
+                 "pinned_use_cuda_host_register:none"
+             )
+ 
+-        with self.assertRaises(ValueError):
++        with self.assertRaises(RuntimeError):
+             torch.cuda.memory._set_allocator_settings(
+                 "pinned_num_register_threads:none"
+             )
+ 
+-        with self.assertRaises(ValueError):
++        with self.assertRaises(RuntimeError):
+             torch.cuda.memory._set_allocator_settings(
+                 "pinned_num_register_threads:1024"
+             )
+diff --git a/torch/_C/__init__.pyi.in b/torch/_C/__init__.pyi.in
+index 9e03c7dba83..5dbbdaba4d9 100644
+--- a/torch/_C/__init__.pyi.in
++++ b/torch/_C/__init__.pyi.in
+@@ -2017,6 +2017,7 @@ def _cuda_cudaHostAllocator() -> _int: ...
+ def _cuda_cudaCachingAllocator_raw_alloc(size: _int, cuda_stream: _int) -> _int: ...
+ def _cuda_cudaCachingAllocator_raw_delete(ptr: _int) -> None: ...
+ def _cuda_cudaCachingAllocator_enable(val: _bool) -> None: ...
++def _cuda_cudaCachingAllocator_set_allocator_settings(env: str) -> None: ...
+ def _cuda_beginAllocateToPool(device: _int, mempool_id: tuple[_int, _int]) -> None: ...
+ def _cuda_beginAllocateCurrentThreadToPool(
+     device: _int,
+@@ -2434,7 +2435,6 @@ def _accelerator_getStream(device_index: _int) -> Stream: ...
+ def _accelerator_synchronizeDevice(device_index: _int) -> None: ...
+ def _accelerator_exchangeDevice(device_index: _int) -> _int: ...
+ def _accelerator_maybeExchangeDevice(device_index: _int) -> _int: ...
+-def _accelerator_setAllocatorSettings(env: str) -> None: ...
+ 
+ # Defined in torch/csrc/jit/python/python_tracer.cpp
+ class TracingState:
+diff --git a/torch/_dynamo/trace_rules.py b/torch/_dynamo/trace_rules.py
+index a3beb561f18..58d594ddfa4 100644
+--- a/torch/_dynamo/trace_rules.py
++++ b/torch/_dynamo/trace_rules.py
+@@ -447,7 +447,6 @@ torch_c_binding_in_graph_functions = dict.fromkeys(
+         "torch._C._accelerator_getAccelerator",
+         "torch._C._accelerator_getDeviceIndex",
+         "torch._C._accelerator_getStream",
+-        "torch._C._accelerator_setAllocatorSettings",
+         "torch._C._accelerator_setStream",
+         "torch._C._accelerator_synchronizeDevice",
+         "torch._C._activate_gpu_trace",
+@@ -504,6 +503,7 @@ torch_c_binding_in_graph_functions = dict.fromkeys(
+         "torch._C._cuda_clearCublasWorkspaces",
+         "torch._C._cuda_cudaCachingAllocator_raw_alloc",
+         "torch._C._cuda_cudaCachingAllocator_raw_delete",
++        "torch._C._cuda_cudaCachingAllocator_set_allocator_settings",
+         "torch._C._cuda_cudaHostAllocator",
+         "torch._C._cuda_customAllocator",
+         "torch._C._cuda_emptyCache",
+diff --git a/torch/csrc/DeviceAccelerator.cpp b/torch/csrc/DeviceAccelerator.cpp
+index 3a97c079468..37fac325d31 100644
+--- a/torch/csrc/DeviceAccelerator.cpp
++++ b/torch/csrc/DeviceAccelerator.cpp
+@@ -1,4 +1,3 @@
+-#include <c10/core/AllocatorConfig.h>
+ #include <torch/csrc/DeviceAccelerator.h>
+ #include <torch/csrc/utils/device_lazy_init.h>
+ 
+@@ -73,10 +72,6 @@ void initModule(PyObject* module) {
+     torch::utils::maybe_initialize_device(device_type);
+     return at::accelerator::maybeExchangeDevice(device_index);
+   });
+-
+-  m.def("_accelerator_setAllocatorSettings", [](std::string env) {
+-    c10::CachingAllocator::setAllocatorSettings(env);
+-  });
+ }
+ 
+ } // namespace torch::accelerator
+diff --git a/torch/csrc/cuda/Module.cpp b/torch/csrc/cuda/Module.cpp
+index 555f7beb74c..ead46337ff0 100644
+--- a/torch/csrc/cuda/Module.cpp
++++ b/torch/csrc/cuda/Module.cpp
+@@ -422,6 +422,15 @@ PyObject* THCPModule_cudaCachingAllocator_enable(
+   END_HANDLE_TH_ERRORS
+ }
+ 
++PyObject* THCPModule_cudaCachingAllocator_set_allocator_settings(
++    PyObject* _unused,
++    PyObject* env) {
++  HANDLE_TH_ERRORS
++  c10::CachingAllocator::setAllocatorSettings(THPUtils_unpackString(env));
++  Py_RETURN_NONE;
++  END_HANDLE_TH_ERRORS
++}
++
+ PyObject* THCPModule_getAllocatorBackend(PyObject* _unused, PyObject* noargs) {
+   HANDLE_TH_ERRORS
+   return THPUtils_packString(c10::cuda::CUDACachingAllocator::name());
+@@ -2043,6 +2052,10 @@ static struct PyMethodDef _THCPModule_methods[] = {
+      THCPModule_cudaCachingAllocator_enable,
+      METH_O,
+      nullptr},
++    {"_cuda_cudaCachingAllocator_set_allocator_settings",
++     THCPModule_cudaCachingAllocator_set_allocator_settings,
++     METH_O,
++     nullptr},
+     {"_cuda_getAllocatorBackend",
+      THCPModule_getAllocatorBackend,
+      METH_NOARGS,
+diff --git a/torch/cuda/memory.py b/torch/cuda/memory.py
+index 63e59096162..3a2e1bb0f89 100644
+--- a/torch/cuda/memory.py
++++ b/torch/cuda/memory.py
+@@ -1075,8 +1075,8 @@ def _save_memory_usage(filename="output.svg", snapshot=None):
+         f.write(_memory(snapshot))
+ 
+ 
+-# Keep for BC only
+-_set_allocator_settings = torch._C._accelerator_setAllocatorSettings
++def _set_allocator_settings(env: str):
++    return torch._C._cuda_cudaCachingAllocator_set_allocator_settings(env)
+ 
+ 
+ def get_allocator_backend() -> str:
+-- 
+2.47.1.windows.2
+

--- a/external-builds/pytorch/patches/pytorch/main/base/0002-Revert-Deprecate-overleap-functions-in-CUDAAllocator.patch
+++ b/external-builds/pytorch/patches/pytorch/main/base/0002-Revert-Deprecate-overleap-functions-in-CUDAAllocator.patch
@@ -1,0 +1,309 @@
+From cf7598b0517024fca5a330a0da2d99b8b3719ab0 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Wed, 30 Jul 2025 15:30:37 -0700
+Subject: [PATCH 2/3] Revert "Deprecate overleap functions in
+ CUDAAllocatorConfig, use AcceleratorAllocatorConfig instead (#156165)"
+
+This reverts commit 1fc010a9d8ea95bb74e54b31d17eba56ef16c27c.
+---
+ aten/src/ATen/cuda/CachingHostAllocator.cpp |  2 +-
+ c10/cuda/CUDAAllocatorConfig.h              | 19 ++-------
+ c10/cuda/CUDACachingAllocator.cpp           | 47 ++++++++++-----------
+ c10/xpu/XPUCachingAllocator.cpp             |  3 +-
+ torch/csrc/cuda/Module.cpp                  |  5 ++-
+ 5 files changed, 32 insertions(+), 44 deletions(-)
+
+diff --git a/aten/src/ATen/cuda/CachingHostAllocator.cpp b/aten/src/ATen/cuda/CachingHostAllocator.cpp
+index 39fd0e16fac..34aa15d0c06 100644
+--- a/aten/src/ATen/cuda/CachingHostAllocator.cpp
++++ b/aten/src/ATen/cuda/CachingHostAllocator.cpp
+@@ -162,7 +162,7 @@ struct CUDACachingHostAllocatorImpl
+   }
+ 
+   bool pinned_use_background_threads() override {
+-    return c10::CachingAllocator::AcceleratorAllocatorConfig::
++    return c10::cuda::CUDACachingAllocator::CUDAAllocatorConfig::
+         pinned_use_background_threads();
+   }
+ 
+diff --git a/c10/cuda/CUDAAllocatorConfig.h b/c10/cuda/CUDAAllocatorConfig.h
+index 8c4b613473c..382a50c08f6 100644
+--- a/c10/cuda/CUDAAllocatorConfig.h
++++ b/c10/cuda/CUDAAllocatorConfig.h
+@@ -3,7 +3,6 @@
+ #include <c10/core/AllocatorConfig.h>
+ #include <c10/cuda/CUDAException.h>
+ #include <c10/cuda/CUDAMacros.h>
+-#include <c10/util/Deprecated.h>
+ #include <c10/util/Exception.h>
+ #include <c10/util/env.h>
+ 
+@@ -18,13 +17,9 @@ enum class Expandable_Segments_Handle_Type : int {
+ // Environment config parser
+ class C10_CUDA_API CUDAAllocatorConfig {
+  public:
+-  C10_DEPRECATED_MESSAGE(
+-      "c10::cuda::CUDACachingAllocator::CUDAAllocatorConfig::max_split_size() is deprecated. Please use c10::CachingAllocator::AcceleratorAllocatorConfig::max_split_size() instead.")
+   static size_t max_split_size() {
+     return c10::CachingAllocator::AcceleratorAllocatorConfig::max_split_size();
+   }
+-  C10_DEPRECATED_MESSAGE(
+-      "c10::cuda::CUDACachingAllocator::CUDAAllocatorConfig::garbage_collection_threshold() is deprecated. Please use c10::CachingAllocator::AcceleratorAllocatorConfig::garbage_collection_threshold() instead.")
+   static double garbage_collection_threshold() {
+     return c10::CachingAllocator::AcceleratorAllocatorConfig::
+         garbage_collection_threshold();
+@@ -65,8 +60,6 @@ class C10_CUDA_API CUDAAllocatorConfig {
+     return instance().m_pinned_num_register_threads;
+   }
+ 
+-  C10_DEPRECATED_MESSAGE(
+-      "c10::cuda::CUDACachingAllocator::CUDAAllocatorConfig::pinned_use_background_threads() is deprecated. Please use c10::CachingAllocator::AcceleratorAllocatorConfig::pinned_use_background_threads() instead.")
+   static bool pinned_use_background_threads() {
+     return c10::CachingAllocator::AcceleratorAllocatorConfig::
+         pinned_use_background_threads();
+@@ -79,29 +72,25 @@ class C10_CUDA_API CUDAAllocatorConfig {
+     return 128;
+   }
+ 
+-  C10_DEPRECATED_MESSAGE(
+-      "c10::cuda::CUDACachingAllocator::CUDAAllocatorConfig::roundup_power2_divisions() is deprecated. Please use c10::CachingAllocator::AcceleratorAllocatorConfig::roundup_power2_divisions() instead.")
++  // This is used to round-up allocation size to nearest power of 2 divisions.
++  // More description below in function roundup_power2_next_division
++  // As an example, if we want 4 divisions between 2's power, this can be done
++  // using env variable: PYTORCH_CUDA_ALLOC_CONF=roundup_power2_divisions:4
+   static size_t roundup_power2_divisions(size_t size) {
+     return c10::CachingAllocator::AcceleratorAllocatorConfig::
+         roundup_power2_divisions(size);
+   }
+ 
+-  C10_DEPRECATED_MESSAGE(
+-      "c10::cuda::CUDACachingAllocator::CUDAAllocatorConfig::roundup_power2_divisions() is deprecated. Please use c10::CachingAllocator::AcceleratorAllocatorConfig::roundup_power2_divisions() instead.")
+   static std::vector<size_t> roundup_power2_divisions() {
+     return c10::CachingAllocator::AcceleratorAllocatorConfig::
+         roundup_power2_divisions();
+   }
+ 
+-  C10_DEPRECATED_MESSAGE(
+-      "c10::cuda::CUDACachingAllocator::CUDAAllocatorConfig::max_non_split_rounding_size() is deprecated. Please use c10::CachingAllocator::AcceleratorAllocatorConfig::max_non_split_rounding_size() instead.")
+   static size_t max_non_split_rounding_size() {
+     return c10::CachingAllocator::AcceleratorAllocatorConfig::
+         max_non_split_rounding_size();
+   }
+ 
+-  C10_DEPRECATED_MESSAGE(
+-      "c10::cuda::CUDACachingAllocator::CUDAAllocatorConfig::last_allocator_settings() is deprecated. Please use c10::CachingAllocator::AcceleratorAllocatorConfig::last_allocator_settings() instead.")
+   static std::string last_allocator_settings() {
+     return c10::CachingAllocator::getAllocatorSettings();
+   }
+diff --git a/c10/cuda/CUDACachingAllocator.cpp b/c10/cuda/CUDACachingAllocator.cpp
+index b0b1be8937a..1ee03914807 100644
+--- a/c10/cuda/CUDACachingAllocator.cpp
++++ b/c10/cuda/CUDACachingAllocator.cpp
+@@ -1225,7 +1225,7 @@ class DeviceCachingAllocator {
+   DeviceCachingAllocator()
+       : large_blocks(/*small=*/false), small_blocks(/*small=*/true) {
+     stats.max_split_size =
+-        static_cast<int64_t>(AcceleratorAllocatorConfig::max_split_size());
++        static_cast<int64_t>(CUDAAllocatorConfig::max_split_size());
+     context_recorder_.store(nullptr);
+   }
+ 
+@@ -1350,8 +1350,7 @@ class DeviceCachingAllocator {
+       // Do garbage collection if the flag is set.
+       if (C10_UNLIKELY(
+               set_fraction &&
+-              AcceleratorAllocatorConfig::garbage_collection_threshold() >
+-                  0.0)) {
++              CUDAAllocatorConfig::garbage_collection_threshold() > 0.0)) {
+         garbage_collect_cached_blocks(context);
+       }
+       // Attempt allocate
+@@ -1603,7 +1602,7 @@ class DeviceCachingAllocator {
+       stats.active_bytes[stat_type].increase(block->size);
+       stats.requested_bytes[stat_type].increase(block->requested_size);
+     });
+-    if (block->size >= AcceleratorAllocatorConfig::max_split_size())
++    if (block->size >= CUDAAllocatorConfig::max_split_size())
+       stats.oversize_allocations.increase(1);
+ 
+     auto allocated_bytes_gauge =
+@@ -1654,7 +1653,7 @@ class DeviceCachingAllocator {
+         block->pool->owner_MempoolId(),
+         context ? context : block->context_when_allocated);
+ 
+-    if (block->size >= AcceleratorAllocatorConfig::max_split_size())
++    if (block->size >= CUDAAllocatorConfig::max_split_size())
+       stats.oversize_allocations.decrease(1);
+ 
+     if (!block->stream_uses.empty()) {
+@@ -2203,8 +2202,7 @@ class DeviceCachingAllocator {
+     if (size < kMinBlockSize) {
+       return kMinBlockSize;
+     } else {
+-      auto divisions =
+-          AcceleratorAllocatorConfig::roundup_power2_divisions(size);
++      auto divisions = CUDAAllocatorConfig::roundup_power2_divisions(size);
+       if (divisions > 1 && size > (kMinBlockSize * divisions)) {
+         return roundup_power2_next_division(size, divisions);
+       } else {
+@@ -2694,7 +2692,7 @@ class DeviceCachingAllocator {
+     if (block->pool->is_small || CUDAAllocatorConfig::expandable_segments()) {
+       return remaining >= kMinBlockSize;
+     } else {
+-      return (size < AcceleratorAllocatorConfig::max_split_size()) &&
++      return (size < CUDAAllocatorConfig::max_split_size()) &&
+           (remaining > kSmallSize);
+     }
+   }
+@@ -2714,7 +2712,7 @@ class DeviceCachingAllocator {
+ 
+     if (C10_UNLIKELY(
+             set_fraction &&
+-            AcceleratorAllocatorConfig::garbage_collection_threshold() > 0.0)) {
++            CUDAAllocatorConfig::garbage_collection_threshold() > 0.0)) {
+       // Track block reuse interval only when garbage collection is enabled.
+       ++pool.get_free_blocks_call_count;
+     }
+@@ -2756,13 +2754,13 @@ class DeviceCachingAllocator {
+     }
+ 
+     // Do not return an oversized block for a large request
+-    if ((p.size() < AcceleratorAllocatorConfig::max_split_size()) &&
+-        ((*it)->size >= AcceleratorAllocatorConfig::max_split_size()))
++    if ((p.size() < CUDAAllocatorConfig::max_split_size()) &&
++        ((*it)->size >= CUDAAllocatorConfig::max_split_size()))
+       return false;
+     // Allow oversized block size to be rounded up but within a limit
+-    if ((p.size() >= AcceleratorAllocatorConfig::max_split_size()) &&
++    if ((p.size() >= CUDAAllocatorConfig::max_split_size()) &&
+         ((*it)->size >=
+-         p.size() + AcceleratorAllocatorConfig::max_non_split_rounding_size()))
++         p.size() + CUDAAllocatorConfig::max_non_split_rounding_size()))
+       return false;
+     p.block = *it;
+     pool.blocks.erase(it);
+@@ -2785,7 +2783,7 @@ class DeviceCachingAllocator {
+     // therefore should be of less overheads.
+ 
+     size_t gc_threshold = static_cast<size_t>(
+-        AcceleratorAllocatorConfig::garbage_collection_threshold() *
++        CUDAAllocatorConfig::garbage_collection_threshold() *
+         static_cast<double>(allowed_memory_maximum));
+     // No need to trigger GC yet
+     if (total_allocated_memory <= gc_threshold) {
+@@ -2933,7 +2931,7 @@ class DeviceCachingAllocator {
+       stats.segment[stat_type].increase(1);
+       stats.reserved_bytes[stat_type].increase(size);
+     });
+-    if (size >= AcceleratorAllocatorConfig::max_split_size())
++    if (size >= CUDAAllocatorConfig::max_split_size())
+       stats.oversize_segments.increase(1);
+     auto reserved_bytes_gauge =
+         STATIC_GAUGE(pytorch.CUDACachingAllocator.reserved_bytes);
+@@ -2962,7 +2960,7 @@ class DeviceCachingAllocator {
+   bool release_available_cached_blocks(
+       const AllocParams& p,
+       const std::shared_ptr<GatheredContext>& context) {
+-    if (AcceleratorAllocatorConfig::max_split_size() ==
++    if (CUDAAllocatorConfig::max_split_size() ==
+         std::numeric_limits<size_t>::max())
+       return false;
+     BlockPool& pool = *p.pool;
+@@ -2970,8 +2968,8 @@ class DeviceCachingAllocator {
+     // because of std::unique_ptr, block cannot be trivially copied
+     // Use constructor for search key.
+     Block key(p.search_key.device, p.search_key.stream, p.search_key.size);
+-    key.size = (key.size < AcceleratorAllocatorConfig::max_split_size())
+-        ? AcceleratorAllocatorConfig::max_split_size()
++    key.size = (key.size < CUDAAllocatorConfig::max_split_size())
++        ? CUDAAllocatorConfig::max_split_size()
+         : key.size;
+     auto it = pool.blocks.lower_bound(&key);
+     if (it == pool.blocks.end() || (*it)->stream != p.stream() ||
+@@ -2984,7 +2982,7 @@ class DeviceCachingAllocator {
+       --it; // Back up one item.  Now on the largest block for the correct
+             // stream
+       while ((totalReleased < key.size) &&
+-             ((*it)->size >= AcceleratorAllocatorConfig::max_split_size()) &&
++             ((*it)->size >= CUDAAllocatorConfig::max_split_size()) &&
+              ((*it)->stream == p.stream())) {
+         auto cur = it;
+         bool is_first = cur == pool.blocks.begin();
+@@ -3109,7 +3107,7 @@ class DeviceCachingAllocator {
+         stats.reserved_bytes[static_cast<int64_t>(StatType::AGGREGATE)]
+             .current);
+ 
+-    if (block->size >= AcceleratorAllocatorConfig::max_split_size())
++    if (block->size >= CUDAAllocatorConfig::max_split_size())
+       stats.oversize_segments.decrease(1);
+     pool->blocks.erase(block);
+     delete block;
+@@ -3736,8 +3734,8 @@ class NativeCachingAllocator : public CUDAAllocator {
+ 
+     auto& md = result.config_metadata;
+     md.garbage_collection_threshold =
+-        AcceleratorAllocatorConfig::garbage_collection_threshold();
+-    md.max_split_size = AcceleratorAllocatorConfig::max_split_size();
++        CUDAAllocatorConfig::garbage_collection_threshold();
++    md.max_split_size = CUDAAllocatorConfig::max_split_size();
+     md.pinned_num_register_threads =
+         CUDAAllocatorConfig::pinned_num_register_threads();
+     md.expandable_segments = CUDAAllocatorConfig::expandable_segments();
+@@ -3745,10 +3743,9 @@ class NativeCachingAllocator : public CUDAAllocator {
+         CUDAAllocatorConfig::release_lock_on_cudamalloc();
+     md.pinned_use_host_register =
+         CUDAAllocatorConfig::pinned_use_cuda_host_register();
+-    md.last_allocator_settings =
+-        AcceleratorAllocatorConfig::last_allocator_settings();
++    md.last_allocator_settings = CUDAAllocatorConfig::last_allocator_settings();
+     md.roundup_power2_divisions =
+-        AcceleratorAllocatorConfig::roundup_power2_divisions();
++        CUDAAllocatorConfig::roundup_power2_divisions();
+ 
+     return result;
+   }
+diff --git a/c10/xpu/XPUCachingAllocator.cpp b/c10/xpu/XPUCachingAllocator.cpp
+index afae32d92a4..543b48f0811 100644
+--- a/c10/xpu/XPUCachingAllocator.cpp
++++ b/c10/xpu/XPUCachingAllocator.cpp
+@@ -1,4 +1,3 @@
+-#include <c10/core/AllocatorConfig.h>
+ #include <c10/util/flat_hash_map.h>
+ #include <c10/util/irange.h>
+ #include <c10/xpu/XPUCachingAllocator.h>
+@@ -21,6 +20,8 @@ constexpr size_t kMinBlockSize = 512;
+ constexpr size_t kSmallSize = 1048576;
+ // "small" allocations are packed in 2 MiB blocks
+ constexpr size_t kSmallBuffer = 2097152;
++// "large" allocations may be packed in 20 MiB blocks
++constexpr size_t kLargeBuffer = 20971520;
+ // allocations between 1 and 10 MiB may use kLargeBuffer
+ constexpr size_t kMinLargeAlloc = 10485760;
+ // round up large allocations to 2 MiB
+diff --git a/torch/csrc/cuda/Module.cpp b/torch/csrc/cuda/Module.cpp
+index ead46337ff0..b44ce311ecd 100644
+--- a/torch/csrc/cuda/Module.cpp
++++ b/torch/csrc/cuda/Module.cpp
+@@ -20,8 +20,8 @@
+ #include <ATen/cuda/detail/CUDAHooks.h>
+ #include <ATen/cuda/jiterator.h>
+ #include <ATen/cuda/tunable/Tunable.h>
+-#include <c10/core/AllocatorConfig.h>
+ #include <c10/core/StorageImpl.h>
++#include <c10/cuda/CUDAAllocatorConfig.h>
+ #include <c10/cuda/CUDACachingAllocator.h>
+ #include <c10/cuda/CUDAFunctions.h>
+ #include <ATen/cuda/CUDAGraphsUtils.cuh>
+@@ -426,7 +426,8 @@ PyObject* THCPModule_cudaCachingAllocator_set_allocator_settings(
+     PyObject* _unused,
+     PyObject* env) {
+   HANDLE_TH_ERRORS
+-  c10::CachingAllocator::setAllocatorSettings(THPUtils_unpackString(env));
++  c10::cuda::CUDACachingAllocator::setAllocatorSettings(
++      THPUtils_unpackString(env));
+   Py_RETURN_NONE;
+   END_HANDLE_TH_ERRORS
+ }
+-- 
+2.47.1.windows.2
+

--- a/external-builds/pytorch/patches/pytorch/main/base/0003-Revert-Refactor-CUDAAllocatorConfig-to-reuse-Acceler.patch
+++ b/external-builds/pytorch/patches/pytorch/main/base/0003-Revert-Refactor-CUDAAllocatorConfig-to-reuse-Acceler.patch
@@ -1,0 +1,868 @@
+From b7f142b2c39fec45dc435ef9691b701952a95844 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Wed, 30 Jul 2025 15:30:48 -0700
+Subject: [PATCH 3/3] Revert "Refactor CUDAAllocatorConfig to reuse
+ AcceleratorAllocatorConfig (#150312)"
+
+This reverts commit dfacf11f66d6512396382bdf5088f0ba9de00406.
+---
+ c10/cuda/CUDAAllocatorConfig.cpp  | 469 ++++++++++++++++++++++++------
+ c10/cuda/CUDAAllocatorConfig.h    | 130 ++++-----
+ c10/cuda/CUDACachingAllocator.cpp |  50 +++-
+ c10/cuda/CUDACachingAllocator.h   |   4 +-
+ 4 files changed, 495 insertions(+), 158 deletions(-)
+
+diff --git a/c10/cuda/CUDAAllocatorConfig.cpp b/c10/cuda/CUDAAllocatorConfig.cpp
+index 49fa2e1e95e..d2efb8c593e 100644
+--- a/c10/cuda/CUDAAllocatorConfig.cpp
++++ b/c10/cuda/CUDAAllocatorConfig.cpp
+@@ -1,119 +1,389 @@
+ #include <c10/cuda/CUDAAllocatorConfig.h>
++#include <c10/cuda/CUDACachingAllocator.h>
++#include <c10/util/llvmMathExtras.h>
+ 
+ #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
+ #include <c10/cuda/driver_api.h>
+ #endif
+ 
+-#include <cuda_runtime_api.h>
+-
+ namespace c10::cuda::CUDACachingAllocator {
+ 
+-size_t CUDAAllocatorConfig::parseAllocatorConfig(
+-    const c10::CachingAllocator::ConfigTokenizer& tokenizer,
++constexpr size_t kRoundUpPowerOfTwoIntervals = 16;
++
++CUDAAllocatorConfig::CUDAAllocatorConfig()
++    : m_max_split_size(std::numeric_limits<size_t>::max()),
++      m_max_non_split_rounding_size(kLargeBuffer),
++      m_garbage_collection_threshold(0),
++      m_pinned_num_register_threads(1),
++      m_expandable_segments(false),
++#if CUDA_VERSION >= 12030
++      m_expandable_segments_handle_type(
++          Expandable_Segments_Handle_Type::UNSPECIFIED),
++#else
++      m_expandable_segments_handle_type(
++          Expandable_Segments_Handle_Type::POSIX_FD),
++#endif
++      m_release_lock_on_cudamalloc(false),
++      m_pinned_use_cuda_host_register(false),
++      m_pinned_use_background_threads(false) {
++  m_roundup_power2_divisions.assign(kRoundUpPowerOfTwoIntervals, 0);
++}
++
++size_t CUDAAllocatorConfig::roundup_power2_divisions(size_t size) {
++  size_t log_size = (63 - llvm::countLeadingZeros(size));
++
++  // Our intervals start at 1MB and end at 64GB
++  const size_t interval_start =
++      63 - llvm::countLeadingZeros(static_cast<size_t>(1048576));
++  const size_t interval_end =
++      63 - llvm::countLeadingZeros(static_cast<size_t>(68719476736));
++  TORCH_CHECK(
++      (interval_end - interval_start == kRoundUpPowerOfTwoIntervals),
++      "kRoundUpPowerOfTwoIntervals mismatch");
++
++  int index = static_cast<int>(log_size) - static_cast<int>(interval_start);
++
++  index = std::max(0, index);
++  index = std::min(index, static_cast<int>(kRoundUpPowerOfTwoIntervals) - 1);
++  return instance().m_roundup_power2_divisions[index];
++}
++
++void CUDAAllocatorConfig::lexArgs(
++    const std::string& env,
++    std::vector<std::string>& config) {
++  std::vector<char> buf;
++
++  for (char ch : env) {
++    if (ch == ',' || ch == ':' || ch == '[' || ch == ']') {
++      if (!buf.empty()) {
++        config.emplace_back(buf.begin(), buf.end());
++        buf.clear();
++      }
++      config.emplace_back(1, ch);
++    } else if (ch != ' ') {
++      buf.emplace_back(ch);
++    }
++  }
++  if (!buf.empty()) {
++    config.emplace_back(buf.begin(), buf.end());
++  }
++}
++
++void CUDAAllocatorConfig::consumeToken(
++    const std::vector<std::string>& config,
++    size_t i,
++    const char c) {
++  TORCH_CHECK(
++      i < config.size() && config[i] == std::string(1, c),
++      "Error parsing CachingAllocator settings, expected ",
++      c,
++      "");
++}
++
++size_t CUDAAllocatorConfig::parseMaxSplitSize(
++    const std::vector<std::string>& config,
++    size_t i) {
++  consumeToken(config, ++i, ':');
++  constexpr int mb = 1024 * 1024;
++  if (++i < config.size()) {
++    size_t val1 = stoi(config[i]);
++    TORCH_CHECK(
++        val1 > kLargeBuffer / mb,
++        "CachingAllocator option max_split_size_mb too small, must be > ",
++        kLargeBuffer / mb,
++        "");
++    val1 = std::max(val1, kLargeBuffer / mb);
++    val1 = std::min(val1, (std::numeric_limits<size_t>::max() / mb));
++    m_max_split_size = val1 * 1024 * 1024;
++  } else {
++    TORCH_CHECK(false, "Error, expecting max_split_size_mb value", "");
++  }
++  return i;
++}
++
++size_t CUDAAllocatorConfig::parseMaxNonSplitRoundingSize(
++    const std::vector<std::string>& config,
++    size_t i) {
++  consumeToken(config, ++i, ':');
++  constexpr int mb = 1024 * 1024;
++  if (++i < config.size()) {
++    size_t val1 = stoi(config[i]);
++    TORCH_CHECK(
++        val1 > kLargeBuffer / mb,
++        "CachingAllocator option max_non_split_rounding_mb too small, must be > ",
++        kLargeBuffer / mb,
++        "");
++    val1 = std::max(val1, kLargeBuffer / mb);
++    val1 = std::min(val1, (std::numeric_limits<size_t>::max() / mb));
++    m_max_non_split_rounding_size = val1 * 1024 * 1024;
++  } else {
++    TORCH_CHECK(false, "Error, expecting max_non_split_rounding_mb value", "");
++  }
++  return i;
++}
++
++size_t CUDAAllocatorConfig::parseGarbageCollectionThreshold(
++    const std::vector<std::string>& config,
++    size_t i) {
++  consumeToken(config, ++i, ':');
++  if (++i < config.size()) {
++    double val1 = stod(config[i]);
++    TORCH_CHECK(
++        val1 > 0, "garbage_collect_threshold too small, set it 0.0~1.0", "");
++    TORCH_CHECK(
++        val1 < 1.0, "garbage_collect_threshold too big, set it 0.0~1.0", "");
++    m_garbage_collection_threshold = val1;
++  } else {
++    TORCH_CHECK(
++        false, "Error, expecting garbage_collection_threshold value", "");
++  }
++  return i;
++}
++
++size_t CUDAAllocatorConfig::parseRoundUpPower2Divisions(
++    const std::vector<std::string>& config,
+     size_t i) {
++  consumeToken(config, ++i, ':');
++  bool first_value = true;
++
++  if (++i < config.size()) {
++    if (std::string_view(config[i]) == "[") {
++      size_t last_index = 0;
++      // NOLINTNEXTLINE(bugprone-inc-dec-in-conditions)
++      while (++i < config.size() && std::string_view(config[i]) != "]") {
++        const std::string& val1 = config[i];
++        size_t val2 = 0;
++
++        consumeToken(config, ++i, ':');
++        if (++i < config.size()) {
++          val2 = stoi(config[i]);
++        } else {
++          TORCH_CHECK(
++              false, "Error parsing roundup_power2_divisions value", "");
++        }
++        TORCH_CHECK(
++            val2 == 0 || llvm::isPowerOf2_64(val2),
++            "For roundups, the divisions has to be power of 2 or 0 to disable roundup ",
++            "");
++
++        if (std::string_view(val1) == ">") {
++          std::fill(
++              std::next(
++                  m_roundup_power2_divisions.begin(),
++                  static_cast<std::vector<unsigned long>::difference_type>(
++                      last_index)),
++              m_roundup_power2_divisions.end(),
++              val2);
++        } else {
++          size_t val1_long = stoul(val1);
++          TORCH_CHECK(
++              llvm::isPowerOf2_64(val1_long),
++              "For roundups, the intervals have to be power of 2 ",
++              "");
++
++          size_t index = 63 - llvm::countLeadingZeros(val1_long);
++          index = std::max((size_t)0, index);
++          index = std::min(index, m_roundup_power2_divisions.size() - 1);
++
++          if (first_value) {
++            std::fill(
++                m_roundup_power2_divisions.begin(),
++                std::next(
++                    m_roundup_power2_divisions.begin(),
++                    static_cast<std::vector<unsigned long>::difference_type>(
++                        index)),
++                val2);
++            first_value = false;
++          }
++          if (index < m_roundup_power2_divisions.size()) {
++            m_roundup_power2_divisions[index] = val2;
++          }
++          last_index = index;
++        }
++
++        if (std::string_view(config[i + 1]) != "]") {
++          consumeToken(config, ++i, ',');
++        }
++      }
++    } else { // Keep this for backwards compatibility
++      size_t val1 = stoi(config[i]);
++      TORCH_CHECK(
++          llvm::isPowerOf2_64(val1),
++          "For roundups, the divisions has to be power of 2 ",
++          "");
++      std::fill(
++          m_roundup_power2_divisions.begin(),
++          m_roundup_power2_divisions.end(),
++          val1);
++    }
++  } else {
++    TORCH_CHECK(false, "Error, expecting roundup_power2_divisions value", "");
++  }
++  return i;
++}
++
++size_t CUDAAllocatorConfig::parseAllocatorConfig(
++    const std::vector<std::string>& config,
++    size_t i,
++    bool& used_cudaMallocAsync) {
+   // For ease of maintenance and understanding, the CUDA and ROCm
+   // implementations of this function are separated. This avoids having many
+   // #ifdef's throughout.
++#ifdef USE_ROCM
+   // Ease burden on ROCm users by allowing either cuda or hip tokens.
+   // cuda token is broken up to prevent hipify matching it.
+ #define PYTORCH_TOKEN1 \
+   "cud"                \
+   "aMallocAsync"
+ #define PYTORCH_TOKEN2 "hipMallocAsync"
+-  tokenizer.checkToken(++i, ":");
+-  i++; // Move to the value after the colon
+-  TORCH_CHECK(
+-      ((tokenizer[i] == "native") || (tokenizer[i] == PYTORCH_TOKEN1) ||
+-       (tokenizer[i] == PYTORCH_TOKEN2)),
+-      "Unknown allocator backend, "
+-      "options are native, " PYTORCH_TOKEN1 ", and " PYTORCH_TOKEN2);
+-  if (m_is_allocator_loaded) {
+-    bool aync_allocator_at_runtime = (tokenizer[i] != "native");
++  consumeToken(config, ++i, ':');
++  if (++i < config.size()) {
+     TORCH_CHECK(
+-        aync_allocator_at_runtime == m_use_async_allocator,
+-        "Allocator async backend parsed at runtime != allocator async backend parsed at load time, ",
+-        aync_allocator_at_runtime,
++        ((config[i] == "native") || (config[i] == PYTORCH_TOKEN1) ||
++         (config[i] == PYTORCH_TOKEN2)),
++        "Unknown allocator backend, "
++        "options are native, " PYTORCH_TOKEN1 ", and " PYTORCH_TOKEN2);
++    used_cudaMallocAsync =
++        (config[i] == PYTORCH_TOKEN1 || config[i] == PYTORCH_TOKEN2);
++    TORCH_INTERNAL_ASSERT(
++        config[i] == get()->name() ||
++            (config[i] == PYTORCH_TOKEN1 && get()->name() == PYTORCH_TOKEN2),
++        "Allocator backend parsed at runtime != "
++        "allocator backend parsed at load time, ",
++        config[i],
+         " != ",
+-        m_use_async_allocator);
++        get()->name());
++  } else {
++    TORCH_CHECK(false, "Error parsing backend value", "");
+   }
+-  m_use_async_allocator =
+-      (tokenizer[i] == PYTORCH_TOKEN1 || tokenizer[i] == PYTORCH_TOKEN2);
+-  // CUDA allocator is always loaded at the start of the program
+-  m_is_allocator_loaded = true;
+-
+-#if defined(CUDA_VERSION)
+-  if (m_use_async_allocator) {
+-#if CUDA_VERSION >= 11040
+-    int version = 0;
+-    C10_CUDA_CHECK(cudaDriverGetVersion(&version));
++  return i;
++#undef PYTORCH_TOKEN1
++#undef PYTORCH_TOKEN2
++#else // USE_ROCM
++  consumeToken(config, ++i, ':');
++  if (++i < config.size()) {
+     TORCH_CHECK(
+-        version >= 11040,
+-        "backend:cudaMallocAsync requires CUDA runtime "
+-        "11.4 or newer, but cudaDriverGetVersion returned ",
+-        version);
++        ((config[i] == "native") || (config[i] == "cudaMallocAsync")),
++        "Unknown allocator backend, "
++        "options are native and cudaMallocAsync");
++    used_cudaMallocAsync = (config[i] == "cudaMallocAsync");
++    if (used_cudaMallocAsync) {
++#if CUDA_VERSION >= 11040
++      int version = 0;
++      C10_CUDA_CHECK(cudaDriverGetVersion(&version));
++      TORCH_CHECK(
++          version >= 11040,
++          "backend:cudaMallocAsync requires CUDA runtime "
++          "11.4 or newer, but cudaDriverGetVersion returned ",
++          version);
+ #else
+-    TORCH_CHECK(
+-        false,
+-        "backend:cudaMallocAsync requires PyTorch to be built with "
+-        "CUDA 11.4 or newer, but CUDA_VERSION is ",
+-        CUDA_VERSION);
++      TORCH_CHECK(
++          false,
++          "backend:cudaMallocAsync requires PyTorch to be built with "
++          "CUDA 11.4 or newer, but CUDA_VERSION is ",
++          CUDA_VERSION);
+ #endif
++    }
++    TORCH_INTERNAL_ASSERT(
++        config[i] == get()->name(),
++        "Allocator backend parsed at runtime != "
++        "allocator backend parsed at load time");
++  } else {
++    TORCH_CHECK(false, "Error parsing backend value", "");
+   }
+-#endif
+-
+   return i;
+-#undef PYTORCH_TOKEN1
+-#undef PYTORCH_TOKEN2
++#endif // USE_ROCM
+ }
+ 
+-void CUDAAllocatorConfig::parseArgs(const std::string& env) {
++void CUDAAllocatorConfig::parseArgs(const std::optional<std::string>& env) {
+   // If empty, set the default values
++  m_max_split_size = std::numeric_limits<size_t>::max();
++  m_roundup_power2_divisions.assign(kRoundUpPowerOfTwoIntervals, 0);
++  m_garbage_collection_threshold = 0;
++  bool used_cudaMallocAsync = false;
+   bool used_native_specific_option = false;
+ 
+-  c10::CachingAllocator::ConfigTokenizer tokenizer(env);
+-  for (size_t i = 0; i < tokenizer.size(); i++) {
+-    const auto& key = tokenizer[i];
+-    if (key == "backend") {
+-      i = parseAllocatorConfig(tokenizer, i);
++  if (!env.has_value()) {
++    return;
++  }
++  {
++    std::lock_guard<std::mutex> lock(m_last_allocator_settings_mutex);
++    m_last_allocator_settings = env.value();
++  }
++
++  std::vector<std::string> config;
++  lexArgs(env.value(), config);
++
++  for (size_t i = 0; i < config.size(); i++) {
++    std::string_view config_item_view(config[i]);
++    if (config_item_view == "max_split_size_mb") {
++      i = parseMaxSplitSize(config, i);
++      used_native_specific_option = true;
++    } else if (config_item_view == "max_non_split_rounding_mb") {
++      i = parseMaxNonSplitRoundingSize(config, i);
++      used_native_specific_option = true;
++    } else if (config_item_view == "garbage_collection_threshold") {
++      i = parseGarbageCollectionThreshold(config, i);
++      used_native_specific_option = true;
++    } else if (config_item_view == "roundup_power2_divisions") {
++      i = parseRoundUpPower2Divisions(config, i);
++      used_native_specific_option = true;
++    } else if (config_item_view == "backend") {
++      i = parseAllocatorConfig(config, i, used_cudaMallocAsync);
++    } else if (config_item_view == "expandable_segments") {
++      used_native_specific_option = true;
++      consumeToken(config, ++i, ':');
++      ++i;
++      TORCH_CHECK(
++          i < config.size() &&
++              (std::string_view(config[i]) == "True" ||
++               std::string_view(config[i]) == "False"),
++          "Expected a single True/False argument for expandable_segments");
++      config_item_view = config[i];
++      m_expandable_segments = (config_item_view == "True");
+     } else if (
+         // ROCm build's hipify step will change "cuda" to "hip", but for ease of
+         // use, accept both. We must break up the string to prevent hipify here.
+-        key == "release_lock_on_hipmalloc" ||
+-        key ==
++        config_item_view == "release_lock_on_hipmalloc" ||
++        config_item_view ==
+             "release_lock_on_c"
+             "udamalloc") {
+       used_native_specific_option = true;
+-      tokenizer.checkToken(++i, ":");
+-      m_release_lock_on_cudamalloc = tokenizer.toBool(++i);
++      consumeToken(config, ++i, ':');
++      ++i;
++      TORCH_CHECK(
++          i < config.size() &&
++              (std::string_view(config[i]) == "True" ||
++               std::string_view(config[i]) == "False"),
++          "Expected a single True/False argument for release_lock_on_cudamalloc");
++      config_item_view = config[i];
++      m_release_lock_on_cudamalloc = (config_item_view == "True");
+     } else if (
+         // ROCm build's hipify step will change "cuda" to "hip", but for ease of
+         // use, accept both. We must break up the string to prevent hipify here.
+-        key == "pinned_use_hip_host_register" ||
+-        key ==
++        config_item_view == "pinned_use_hip_host_register" ||
++        config_item_view ==
+             "pinned_use_c"
+             "uda_host_register") {
+-      i = parsePinnedUseCudaHostRegister(tokenizer, i);
++      i = parsePinnedUseCudaHostRegister(config, i);
+       used_native_specific_option = true;
+-    } else if (key == "pinned_num_register_threads") {
+-      i = parsePinnedNumRegisterThreads(tokenizer, i);
++    } else if (config_item_view == "pinned_num_register_threads") {
++      i = parsePinnedNumRegisterThreads(config, i);
++      used_native_specific_option = true;
++    } else if (config_item_view == "pinned_use_background_threads") {
++      i = parsePinnedUseBackgroundThreads(config, i);
+       used_native_specific_option = true;
+     } else {
+-      const auto& keys =
+-          c10::CachingAllocator::AcceleratorAllocatorConfig::getKeys();
+       TORCH_CHECK(
+-          keys.find(key) != keys.end(),
+-          "Unrecognized key '",
+-          key,
+-          "' in Accelerator allocator config.");
+-      i = tokenizer.skipKey(i);
++          false, "Unrecognized CachingAllocator option: ", config_item_view);
+     }
+ 
+-    if (i + 1 < tokenizer.size()) {
+-      tokenizer.checkToken(++i, ",");
++    if (i + 1 < config.size()) {
++      consumeToken(config, ++i, ',');
+     }
+   }
+ 
+-  if (m_use_async_allocator && used_native_specific_option) {
++  if (used_cudaMallocAsync && used_native_specific_option) {
+     TORCH_WARN(
+         "backend:cudaMallocAsync ignores max_split_size_mb,"
+         "roundup_power2_divisions, and garbage_collect_threshold.");
+@@ -121,33 +391,64 @@ void CUDAAllocatorConfig::parseArgs(const std::string& env) {
+ }
+ 
+ size_t CUDAAllocatorConfig::parsePinnedUseCudaHostRegister(
+-    const c10::CachingAllocator::ConfigTokenizer& tokenizer,
++    const std::vector<std::string>& config,
+     size_t i) {
+-  tokenizer.checkToken(++i, ":");
+-  m_pinned_use_cuda_host_register = tokenizer.toBool(++i);
+-
++  consumeToken(config, ++i, ':');
++  if (++i < config.size()) {
++    TORCH_CHECK(
++        (config[i] == "True" || config[i] == "False"),
++        "Expected a single True/False argument for pinned_use_cuda_host_register");
++    m_pinned_use_cuda_host_register = (config[i] == "True");
++  } else {
++    TORCH_CHECK(
++        false, "Error, expecting pinned_use_cuda_host_register value", "");
++  }
+   return i;
+ }
+ 
+ size_t CUDAAllocatorConfig::parsePinnedNumRegisterThreads(
+-    const c10::CachingAllocator::ConfigTokenizer& tokenizer,
++    const std::vector<std::string>& config,
+     size_t i) {
+-  tokenizer.checkToken(++i, ":");
+-  size_t val2 = tokenizer.toSizeT(++i);
+-  TORCH_CHECK(
+-      llvm::isPowerOf2_64(val2),
+-      "Number of register threads has to be power of 2 ",
+-      "");
+-  auto maxThreads = CUDAAllocatorConfig::pinned_max_register_threads();
+-  TORCH_CHECK(
+-      val2 <= maxThreads,
+-      "Number of register threads should be less than or equal to " +
+-          std::to_string(maxThreads),
+-      "");
+-  m_pinned_num_register_threads = val2;
++  consumeToken(config, ++i, ':');
++  if (++i < config.size()) {
++    size_t val2 = stoi(config[i]);
++    TORCH_CHECK(
++        llvm::isPowerOf2_64(val2),
++        "Number of register threads has to be power of 2 ",
++        "");
++    auto maxThreads = CUDAAllocatorConfig::pinned_max_register_threads();
++    TORCH_CHECK(
++        val2 <= maxThreads,
++        "Number of register threads should be less than or equal to " +
++            std::to_string(maxThreads),
++        "");
++    m_pinned_num_register_threads = val2;
++  } else {
++    TORCH_CHECK(
++        false, "Error, expecting pinned_num_register_threads value", "");
++  }
++  return i;
++}
++
++size_t CUDAAllocatorConfig::parsePinnedUseBackgroundThreads(
++    const std::vector<std::string>& config,
++    size_t i) {
++  consumeToken(config, ++i, ':');
++  if (++i < config.size()) {
++    TORCH_CHECK(
++        (config[i] == "True" || config[i] == "False"),
++        "Expected a single True/False argument for pinned_use_background_threads");
++    m_pinned_use_background_threads = (config[i] == "True");
++  } else {
++    TORCH_CHECK(
++        false, "Error, expecting pinned_use_background_threads value", "");
++  }
+   return i;
+ }
+ 
+-REGISTER_ALLOCATOR_CONFIG_PARSE_HOOK(CUDAAllocatorConfig)
++// General caching allocator utilities
++void setAllocatorSettings(const std::string& env) {
++  CUDACachingAllocator::CUDAAllocatorConfig::instance().parseArgs(env.c_str());
++}
+ 
+ } // namespace c10::cuda::CUDACachingAllocator
+diff --git a/c10/cuda/CUDAAllocatorConfig.h b/c10/cuda/CUDAAllocatorConfig.h
+index 382a50c08f6..fda3cc02e5d 100644
+--- a/c10/cuda/CUDAAllocatorConfig.h
++++ b/c10/cuda/CUDAAllocatorConfig.h
+@@ -1,11 +1,16 @@
+ #pragma once
+ 
+-#include <c10/core/AllocatorConfig.h>
+-#include <c10/cuda/CUDAException.h>
+ #include <c10/cuda/CUDAMacros.h>
+ #include <c10/util/Exception.h>
+ #include <c10/util/env.h>
+ 
++#include <atomic>
++#include <cstddef>
++#include <cstdlib>
++#include <mutex>
++#include <string>
++#include <vector>
++
+ namespace c10::cuda::CUDACachingAllocator {
+ 
+ enum class Expandable_Segments_Handle_Type : int {
+@@ -18,23 +23,20 @@ enum class Expandable_Segments_Handle_Type : int {
+ class C10_CUDA_API CUDAAllocatorConfig {
+  public:
+   static size_t max_split_size() {
+-    return c10::CachingAllocator::AcceleratorAllocatorConfig::max_split_size();
++    return instance().m_max_split_size;
+   }
+   static double garbage_collection_threshold() {
+-    return c10::CachingAllocator::AcceleratorAllocatorConfig::
+-        garbage_collection_threshold();
++    return instance().m_garbage_collection_threshold;
+   }
+ 
+   static bool expandable_segments() {
+-    bool enabled = c10::CachingAllocator::AcceleratorAllocatorConfig::
+-        use_expandable_segments();
+ #ifndef PYTORCH_C10_DRIVER_API_SUPPORTED
+-    if (enabled) {
++    if (instance().m_expandable_segments) {
+       TORCH_WARN_ONCE("expandable_segments not supported on this platform")
+     }
+     return false;
+ #else
+-    return enabled;
++    return instance().m_expandable_segments;
+ #endif
+   }
+ 
+@@ -61,8 +63,7 @@ class C10_CUDA_API CUDAAllocatorConfig {
+   }
+ 
+   static bool pinned_use_background_threads() {
+-    return c10::CachingAllocator::AcceleratorAllocatorConfig::
+-        pinned_use_background_threads();
++    return instance().m_pinned_use_background_threads;
+   }
+ 
+   static size_t pinned_max_register_threads() {
+@@ -76,97 +77,88 @@ class C10_CUDA_API CUDAAllocatorConfig {
+   // More description below in function roundup_power2_next_division
+   // As an example, if we want 4 divisions between 2's power, this can be done
+   // using env variable: PYTORCH_CUDA_ALLOC_CONF=roundup_power2_divisions:4
+-  static size_t roundup_power2_divisions(size_t size) {
+-    return c10::CachingAllocator::AcceleratorAllocatorConfig::
+-        roundup_power2_divisions(size);
+-  }
++  static size_t roundup_power2_divisions(size_t size);
+ 
+   static std::vector<size_t> roundup_power2_divisions() {
+-    return c10::CachingAllocator::AcceleratorAllocatorConfig::
+-        roundup_power2_divisions();
++    return instance().m_roundup_power2_divisions;
+   }
+ 
+   static size_t max_non_split_rounding_size() {
+-    return c10::CachingAllocator::AcceleratorAllocatorConfig::
+-        max_non_split_rounding_size();
++    return instance().m_max_non_split_rounding_size;
+   }
+ 
+   static std::string last_allocator_settings() {
+-    return c10::CachingAllocator::getAllocatorSettings();
+-  }
+-
+-  static bool use_async_allocator() {
+-    return instance().m_use_async_allocator;
+-  }
+-
+-  static const std::unordered_set<std::string>& getKeys() {
+-    return keys_;
++    std::lock_guard<std::mutex> lock(
++        instance().m_last_allocator_settings_mutex);
++    return instance().m_last_allocator_settings;
+   }
+ 
+   static CUDAAllocatorConfig& instance() {
+     static CUDAAllocatorConfig* s_instance = ([]() {
+       auto inst = new CUDAAllocatorConfig();
+-      auto env = c10::utils::get_env("PYTORCH_ALLOC_CONF");
+-      if (!env.has_value()) {
+-        // For backward compatibility, check for the old environment variable
+-        // PYTORCH_CUDA_ALLOC_CONF.
+-        env = c10::utils::get_env("PYTORCH_CUDA_ALLOC_CONF");
+-      }
++      auto env = c10::utils::get_env("PYTORCH_CUDA_ALLOC_CONF");
+ #ifdef USE_ROCM
+       // convenience for ROCm users, allow alternative HIP token
+       if (!env.has_value()) {
+         env = c10::utils::get_env("PYTORCH_HIP_ALLOC_CONF");
+       }
+ #endif
+-      if (env.has_value()) {
+-        inst->parseArgs(env.value());
+-      }
++      inst->parseArgs(env);
+       return inst;
+     })();
+     return *s_instance;
+   }
+ 
+-  void parseArgs(const std::string& env);
++  void parseArgs(const std::optional<std::string>& env);
+ 
+  private:
+-  CUDAAllocatorConfig() = default;
+-
+-  size_t parseAllocatorConfig(
+-      const c10::CachingAllocator::ConfigTokenizer& tokenizer,
++  CUDAAllocatorConfig();
++
++  static void lexArgs(const std::string& env, std::vector<std::string>& config);
++  static void consumeToken(
++      const std::vector<std::string>& config,
++      size_t i,
++      const char c);
++  size_t parseMaxSplitSize(const std::vector<std::string>& config, size_t i);
++  size_t parseMaxNonSplitRoundingSize(
++      const std::vector<std::string>& config,
++      size_t i);
++  size_t parseGarbageCollectionThreshold(
++      const std::vector<std::string>& config,
++      size_t i);
++  size_t parseRoundUpPower2Divisions(
++      const std::vector<std::string>& config,
+       size_t i);
++  size_t parseAllocatorConfig(
++      const std::vector<std::string>& config,
++      size_t i,
++      bool& used_cudaMallocAsync);
+   size_t parsePinnedUseCudaHostRegister(
+-      const c10::CachingAllocator::ConfigTokenizer& tokenizer,
++      const std::vector<std::string>& config,
+       size_t i);
+   size_t parsePinnedNumRegisterThreads(
+-      const c10::CachingAllocator::ConfigTokenizer& tokenizer,
++      const std::vector<std::string>& config,
++      size_t i);
++  size_t parsePinnedUseBackgroundThreads(
++      const std::vector<std::string>& config,
+       size_t i);
+ 
+-  std::atomic<size_t> m_pinned_num_register_threads{1};
+-  std::atomic<Expandable_Segments_Handle_Type> m_expandable_segments_handle_type
+-#if CUDA_VERSION >= 12030
+-      {Expandable_Segments_Handle_Type::UNSPECIFIED};
+-#else
+-      {Expandable_Segments_Handle_Type::POSIX_FD};
+-#endif
+-  std::atomic<bool> m_release_lock_on_cudamalloc{false};
+-  std::atomic<bool> m_pinned_use_cuda_host_register{false};
+-  std::atomic<bool> m_use_async_allocator{false};
+-  std::atomic<bool> m_is_allocator_loaded{false};
+-  inline static std::unordered_set<std::string> keys_{
+-      "backend",
+-      // keep BC for Rocm: `cuda` -> `cud` `a`, to avoid hipify issues
+-      // NOLINTBEGIN(bugprone-suspicious-missing-comma,-warnings-as-errors)
+-      "release_lock_on_cud"
+-      "amalloc",
+-      "pinned_use_cud"
+-      "a_host_register",
+-      // NOLINTEND(bugprone-suspicious-missing-comma,-warnings-as-errors)
+-      "release_lock_on_hipmalloc",
+-      "pinned_use_hip_host_register",
+-      "pinned_num_register_threads"};
++  std::atomic<size_t> m_max_split_size;
++  std::atomic<size_t> m_max_non_split_rounding_size;
++  std::vector<size_t> m_roundup_power2_divisions;
++  std::atomic<double> m_garbage_collection_threshold;
++  std::atomic<size_t> m_pinned_num_register_threads;
++  std::atomic<bool> m_expandable_segments;
++  std::atomic<Expandable_Segments_Handle_Type>
++      m_expandable_segments_handle_type;
++  std::atomic<bool> m_release_lock_on_cudamalloc;
++  std::atomic<bool> m_pinned_use_cuda_host_register;
++  std::atomic<bool> m_pinned_use_background_threads;
++  std::string m_last_allocator_settings;
++  std::mutex m_last_allocator_settings_mutex;
+ };
+ 
+-// Keep this for backwards compatibility
+-using c10::CachingAllocator::setAllocatorSettings;
++// General caching allocator utilities
++C10_CUDA_API void setAllocatorSettings(const std::string& env);
+ 
+ } // namespace c10::cuda::CUDACachingAllocator
+diff --git a/c10/cuda/CUDACachingAllocator.cpp b/c10/cuda/CUDACachingAllocator.cpp
+index 1ee03914807..db8d2a20789 100644
+--- a/c10/cuda/CUDACachingAllocator.cpp
++++ b/c10/cuda/CUDACachingAllocator.cpp
+@@ -1,6 +1,7 @@
+ #include <c10/cuda/CUDACachingAllocator.h>
+ 
+ #include <c10/core/impl/GPUTrace.h>
++#include <c10/cuda/CUDAAllocatorConfig.h>
+ #include <c10/cuda/CUDAException.h>
+ #include <c10/cuda/CUDAFunctions.h>
+ #include <c10/cuda/CUDAGuard.h>
+@@ -63,6 +64,10 @@ namespace cuda::CUDACachingAllocator {
+ using namespace c10::CachingAllocator;
+ using namespace c10::CachingDeviceAllocator;
+ 
++// Included here as this is externally used in CUDAAllocatorConfig
++const size_t kLargeBuffer =
++    20971520; // "large" allocations may be packed in 20 MiB blocks
++
+ namespace Native {
+ 
+ //
+@@ -4123,10 +4128,49 @@ CUDAAllocator* allocator();
+ } // namespace CudaMallocAsync
+ 
+ struct BackendStaticInitializer {
++  // Parses env for backend at load time, duplicating some logic from
++  // CUDAAllocatorConfig. CUDAAllocatorConfig double-checks it later (at
++  // runtime). Defers verbose exceptions and error checks, including Cuda
++  // version checks, to CUDAAllocatorConfig's runtime doublecheck. If this
++  // works, maybe we should move all of CUDAAllocatorConfig here?
+   CUDAAllocator* parseEnvForBackend() {
+-    // If the environment variable is set, we use the CudaMallocAsync allocator.
+-    if (CUDAAllocatorConfig::use_async_allocator()) {
+-      return CudaMallocAsync::allocator();
++    auto val = c10::utils::get_env("PYTORCH_CUDA_ALLOC_CONF");
++#ifdef USE_ROCM
++    // convenience for ROCm users to allow either CUDA or HIP env var
++    if (!val.has_value()) {
++      val = c10::utils::get_env("PYTORCH_HIP_ALLOC_CONF");
++    }
++#endif
++    if (val.has_value()) {
++      const std::string& config = val.value();
++
++      std::regex exp("[\\s,]+");
++      std::sregex_token_iterator it(config.begin(), config.end(), exp, -1);
++      std::sregex_token_iterator end;
++      std::vector<std::string> options(it, end);
++
++      for (auto option : options) {
++        std::regex exp2("[:]+");
++        std::sregex_token_iterator it2(option.begin(), option.end(), exp2, -1);
++        std::sregex_token_iterator end2;
++        std::vector<std::string> kv(it2, end2);
++        if (kv.size() >= 2) {
++          if (kv[0] == "backend") {
++#ifdef USE_ROCM
++            // convenience for ROCm users to allow either CUDA or HIP env var
++            if (kv[1] ==
++                    "cud"
++                    "aMallocAsync" ||
++                kv[1] == "hipMallocAsync")
++#else
++            if (kv[1] == "cudaMallocAsync")
++#endif
++              return CudaMallocAsync::allocator();
++            if (kv[1] == "native")
++              return &Native::allocator;
++          }
++        }
++      }
+     }
+     return &Native::allocator;
+   }
+diff --git a/c10/cuda/CUDACachingAllocator.h b/c10/cuda/CUDACachingAllocator.h
+index 956411fe228..a6fa61110d6 100644
+--- a/c10/cuda/CUDACachingAllocator.h
++++ b/c10/cuda/CUDACachingAllocator.h
+@@ -1,7 +1,6 @@
+ #pragma once
+ 
+ #include <c10/core/CachingDeviceAllocator.h>
+-#include <c10/cuda/CUDAAllocatorConfig.h>
+ #include <c10/cuda/CUDAGraphsC10Utils.h>
+ #include <c10/cuda/CUDAMacros.h>
+ #include <c10/cuda/CUDAStream.h>
+@@ -50,9 +49,10 @@ namespace c10::cuda::CUDACachingAllocator {
+ 
+ // Preserved only for BC reasons
+ // NOLINTNEXTLINE(misc-unused-using-decls)
+-using c10::CachingAllocator::kLargeBuffer;
+ using c10::CachingDeviceAllocator::DeviceStats;
+ 
++extern const size_t kLargeBuffer;
++
+ typedef std::shared_ptr<GatheredContext> (*CreateContextFn)();
+ 
+ // Struct containing info of an allocation block (i.e. a fractional part of a
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/1155. 

This reverts three upstream PyTorch commits to fix our Windows builds:

* (stacked on top) https://github.com/pytorch/pytorch/commit/d3ce45012ed42cd1e13d5048b046b781f0feabe0
* (stacked on top) https://github.com/pytorch/pytorch/commit/1fc010a9d8ea95bb74e54b31d17eba56ef16c27c
* (culprit) https://github.com/pytorch/pytorch/commit/dfacf11f66d6512396382bdf5088f0ba9de00406

Root cause analysis and an actual fix are still pending more debugging.

> [!NOTE]
> The reverts are applied to `base/`, _not_ `hipified/`, which is quite awkward to manage - I think that's also been partially broken for 1 week and counting: https://github.com/ROCm/TheRock/pull/1092#discussion_r2226039819.

Tested locally with
```bash
python pytorch_torch_repo.py checkout --repo D:/b/pytorch_main --repo-hashtag main
python pytorch_audio_repo.py checkout --repo D:/b/audio_main --repo-hashtag main
python build_prod_wheels.py build --pytorch-dir D:/b/pytorch_main --pytorch-audio-dir D:/b/audio_main --output-dir %HOME%/.therock/pytorch
# torchaudio build succeeding is enough signal, but just confirm:
python -c "import torch; print(str(torch.cuda.is_available()))"
```