### PR TITLE
[ci] - Retrieve correct path for monorepo

### DIFF
--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -75,7 +75,7 @@ def retrieve_s3_artifacts(run_id, amdgpu_family):
                     and "tar.xz" in artifact_key
                     and (amdgpu_family in artifact_key or "generic" in artifact_key)
                 ):
-                    _, file_name = artifact_key.split("/")
+                    file_name = artifact_key.split("/")[-1]
                     data.add(file_name)
     return data
 

--- a/build_tools/tests/fetch_artifacts_test.py
+++ b/build_tools/tests/fetch_artifacts_test.py
@@ -27,14 +27,16 @@ class ArtifactsIndexPageTest(unittest.TestCase):
             },
             {"Contents": [{"Key": "test/empty_3generic.tar.xz"}]},
             {"Contents": [{"Key": "test/empty_3test.tar.xz.sha256sum"}]},
+            {"Contents": [{"Key": "rocm-libraries/test/empty_4test.tar.xz"}]},
         ]
 
         result = retrieve_s3_artifacts("123", "test")
 
-        self.assertEqual(len(result), 3)
+        self.assertEqual(len(result), 4)
         self.assertTrue("empty_1test.tar.xz" in result)
         self.assertTrue("empty_2test.tar.xz" in result)
         self.assertTrue("empty_3generic.tar.xz" in result)
+        self.assertTrue("empty_4test.tar.xz" in result)
 
     @patch("fetch_artifacts.paginator")
     def testRetrieveS3ArtifactsNotFound(self, mock_paginator):


### PR DESCRIPTION
Noticing failures in rocm-libraries tests: https://github.com/ROCm/rocm-libraries/actions/runs/16678793375/job/47213360035

This change will fix and get the correct filename

(let me know though if I should roll back the previous PR, it works fine for TheRock)