### PR TITLE
[torch] Sanity check installed torch before using it.

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -175,6 +175,7 @@ def exec(args: list[str | Path], cwd: Path, env: dict[str, str] | None = None):
 
 def capture(args: list[str | Path], cwd: Path) -> str:
     args = [str(arg) for arg in args]
+    print(f"++ Capture [{cwd}]$ {shlex.join(args)}")
     try:
         return subprocess.check_output(args, cwd=str(cwd)).decode().strip()
     except subprocess.CalledProcessError as e:
@@ -644,6 +645,13 @@ def do_build_pytorch(
     exec(
         [sys.executable, "-m", "pip", "install", built_wheel], cwd=tempfile.gettempdir()
     )
+
+    print("+++ Sanity checking installed torch (unavailable is okay on CPU machines):")
+    sanity_check_output = capture(
+        [sys.executable, "-c", "import torch; print(torch.cuda.is_available())"],
+        cwd=tempfile.gettempdir(),
+    )
+    print(f"Sanity check output:\n{sanity_check_output}")
 
 
 def do_build_pytorch_audio(


### PR DESCRIPTION
This will give us clearer signal for issues like https://github.com/ROCm/TheRock/issues/1155 in the future.

Sample logs:
```
Found built wheel: D:\b\pytorch_main\dist\torch-2.9.0a0+rocmsdk20250801-cp312-cp312-win_amd64.whl
++ Copy D:\b\pytorch_main\dist\torch-2.9.0a0+rocmsdk20250801-cp312-cp312-win_amd64.whl -> C:\Users\Nod-Shark16\.therock\pytorch
+++ Installing built torch:
++ Exec [C:\Users\NOD-SH~1\AppData\Local\Temp]$ 'D:\projects\TheRock\external-builds\pytorch\.venv\Scripts\python.exe' -m pip install 'D:\b\pytorch_main\dist\torch-2.9.0a0+rocmsdk20250801-cp312-cp312-win_amd64.whl'
+++ Sanity checking installed torch:
++ Capture [C:\Users\NOD-SH~1\AppData\Local\Temp]$ 'D:\projects\TheRock\external-builds\pytorch\.venv\Scripts\python.exe' -c 'import torch; print(torch.cuda.is_available())'
Sanity check output:
HIP Library Path: D:\projects\TheRock\external-builds\pytorch\.venv\Lib\site-packages\_rocm_sdk_core\bin\amdhip64_7.dll
True
  Default pytorch audio BUILD_VERSION: 2.8.0a0+rocmsdk20250801
++ Removing D:\b\audio_main\dist
```

Note: this is currently broken on Linux: see https://colab.research.google.com/gist/ScottTodd/766fde88a670b0733e5638d5f569d426/therock_torch_import.ipynb.

```python
import torch

---------------------------------------------------------------------------

ImportError                               Traceback (most recent call last)

/tmp/ipython-input-4265195184.py in <cell line: 0>()
----> 1 import torch

/usr/local/lib/python3.11/dist-packages/torch/__init__.py in <module>
    422     if USE_GLOBAL_DEPS:
    423         _load_global_deps()
--> 424     from torch._C import *  # noqa: F403
    425 
    426 

ImportError: libroctracer64.so.4: cannot open shared object file: No such file or directory
```
