### PR TITLE
[rocmsdk] - Adding roctracer for rocmsdk

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -162,6 +162,7 @@ PackageEntry(
 
 # Public libraries.
 LibraryEntry("amdhip64", "core", "libamdhip64.so.7", "amdhip64_7.dll")
+LibraryEntry("roctracer64", "core", "libroctracer64.so.4", "roctracer64_4.dll")
 LibraryEntry("hiprtc", "core", "libhiprtc.so.7", "hiprtc0700.dll")
 LibraryEntry("roctx64", "core", "libroctx64.so.4", "")
 LibraryEntry("rocprofiler-sdk-roctx", "core", "librocprofiler-sdk-roctx.so.1", "")

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -133,6 +133,7 @@ is_windows = platform.system() == "Windows"
 LINUX_LIBRARY_PRELOADS = [
     "amd_comgr",
     "amdhip64",
+    "roctracer64",
     "rocprofiler-sdk-roctx",  # Linux only for the moment.
     "roctx64",  # Linux only for the moment.
     "hiprtc",


### PR DESCRIPTION
when running `pytest -v external-builds/pytorch/smoke-tests` on mi325/mi355, we run into an `ImportError: libroctracer64.so.4: cannot open shared object file: No such file or directory` error.

This change adds roctracer64 to the rocmsdk and resolves the error

Works with `python -m pip install --index-url=https://d25kgig7rdsyks.cloudfront.net/v2/gfx950-dcgpu torch==2.7.1+rocm7.0.0.dev0.f887e7328413f6a8fd337abf952db856c842c0dd` (rocmsdk / pytorch dev build for gfx950)