### PR TITLE
[doc] Warn about Python install dirs containing spaces on Windows.

### DIFF
--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -156,6 +156,11 @@ If you prefer to install tools manually, you will need:
 
 - Python: https://www.python.org/downloads/ (3.11+ recommended)
 
+  > [!WARNING]
+  > Prefer to install Python for the current user only and to a path
+  > **without spaces** like
+  > `C:\Users\<username>\AppData\Local\Programs\Python\Python312`.
+
 - Strawberry Perl, which comes with gfortran: https://strawberryperl.com/
 
 #### Important tool settings

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -42,8 +42,13 @@ and [Python Packaging](../../docs/packaging/python_packaging.md) documentation
 for more background on these `rocm` packages.
 
 > [!WARNING]
-> Windows support for these packages is _very_ new so some instructions
-> may not work yet. Stay tuned!
+> On Windows, prefer to install Python for the current user only and to a path
+> **without spaces** like
+> `C:\Users\<username>\AppData\Local\Programs\Python\Python312`.
+>
+> Several developers have reported issues building torchvision when using
+> "Install Python for all users" with a default path like
+> `C:\Program Files\Python312` (note the space in "Program Files").
 
 ### Quickstart
 


### PR DESCRIPTION
Follow-up to https://github.com/ROCm/TheRock/pull/1190. Related to https://github.com/ROCm/TheRock/issues/910.

I'm also considering adding a check to https://github.com/ROCm/TheRock/blob/main/build_tools/hack/build_env_diag.py.