### PR TITLE
Rename `THEROCK_USE_EXTERNAL_ROCM_LIBRARIES`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,11 +59,11 @@ set(THEROCK_ARTIFACT_ARCHIVE_SUFFIX "" CACHE STRING "Suffix to add to artifact a
 option(THEROCK_BUNDLE_SYSDEPS "Builds bundled system deps for portable builds into lib/rocm_sysdeps" ON)
 
 # Source settings.
-# Source can be consumed from the https://github.com/ROCm/rocm-libraries monorepo,
+# Source can be consumed from the https://github.com/ROCm/rocm-libraries superrepo,
 # while the default is to consume the submodules defined in TheRock's `.gitmodules`.
-option(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES "Use the `rocm-libraries` monorepo instead of submodules" OFF)
-if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES AND NOT THEROCK_ROCM_LIBRARIES_SOURCE_DIR)
-  message(FATAL_ERROR "If THEROCK_USE_EXTERNAL_ROCM_LIBRARIES is set, THEROCK_ROCM_LIBRARIES_SOURCE_DIR is required!")
+option(THEROCK_USE_ROCM_LIBRARIES "Use the `rocm-libraries` superrepo" OFF)
+if(THEROCK_USE_ROCM_LIBRARIES AND NOT THEROCK_ROCM_LIBRARIES_SOURCE_DIR)
+  message(FATAL_ERROR "If THEROCK_USE_ROCM_LIBRARIES is set, THEROCK_ROCM_LIBRARIES_SOURCE_DIR is required!")
 endif()
 
 if(THEROCK_ROCM_LIBRARIES_SOURCE_DIR)

--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 ##############################################################################
 set(_blas_subproject_names)
 
-if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+if(THEROCK_USE_ROCM_LIBRARIES)
   set(_hipblas_common_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipblas-common")
 else()
   set(_hipblas_common_source_dir "hipBLAS-common")
@@ -48,7 +48,7 @@ list(APPEND _blas_subproject_names hipBLAS-common)
 # rocRoller
 ##############################################################################
 
-if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+if(THEROCK_USE_ROCM_LIBRARIES)
   set(_rocroller_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/shared/rocroller")
 else()
   set(_rocroller_source_dir "rocRoller")
@@ -106,7 +106,7 @@ endif()
 # hipBLASLt
 ##############################################################################
 
-if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+if(THEROCK_USE_ROCM_LIBRARIES)
   set(_hipblaslt_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipblaslt")
 else()
   set(_hipblaslt_source_dir "hipBLASLt")
@@ -174,7 +174,7 @@ list(APPEND _blas_subproject_names hipBLASLt)
 # rocBLAS
 ##############################################################################
 
-if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+if(THEROCK_USE_ROCM_LIBRARIES)
   set(_rocblas_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocblas")
   set(_tensile_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/shared/tensile")
 else()
@@ -238,7 +238,7 @@ if(THEROCK_ENABLE_SPARSE)
   ##############################################################################
   set(_sparse_subproject_names)
 
-  if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+  if(THEROCK_USE_ROCM_LIBRARIES)
     set(_rocsparse_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocsparse")
   else()
     set(_rocsparse_source_dir "rocSPARSE")
@@ -281,7 +281,7 @@ if(THEROCK_ENABLE_SPARSE)
   # hipSPARSE
   ##############################################################################
 
-  if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+  if(THEROCK_USE_ROCM_LIBRARIES)
     set(_hipsparse_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipsparse")
   else()
     set(_hipsparse_source_dir "hipSPARSE")
@@ -413,7 +413,7 @@ endif(THEROCK_ENABLE_SOLVER)
 # hipBLAS
 ##############################################################################
 
-if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+if(THEROCK_USE_ROCM_LIBRARIES)
   set(_hipblas_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipblas")
 else()
   set(_hipblas_source_dir "hipBLAS")

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -4,7 +4,7 @@ if(THEROCK_ENABLE_RAND)
   ##############################################################################
   set(_rand_subproject_names)
 
-  if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+  if(THEROCK_USE_ROCM_LIBRARIES)
     set(_rocrand_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocrand")
   else()
     set(_rocrand_source_dir "rocRAND")
@@ -39,7 +39,7 @@ if(THEROCK_ENABLE_RAND)
   # hipRAND
   ##############################################################################
 
-  if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+  if(THEROCK_USE_ROCM_LIBRARIES)
     set(_hiprand_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hiprand")
   else()
     set(_hiprand_source_dir "hipRAND")
@@ -93,7 +93,7 @@ if(THEROCK_ENABLE_PRIM)
   # rocPRIM
   ##############################################################################
 
-  if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+  if(THEROCK_USE_ROCM_LIBRARIES)
     set(_rocprim_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocprim")
   else()
     set(_rocprim_source_dir "rocPRIM")
@@ -123,7 +123,7 @@ if(THEROCK_ENABLE_PRIM)
   therock_cmake_subproject_provide_package(rocPRIM rocprim lib/cmake/rocprim)
   therock_cmake_subproject_activate(rocPRIM)
 
-  if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+  if(THEROCK_USE_ROCM_LIBRARIES)
     set(_hipcub_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipcub")
   else()
     set(_hipcub_source_dir "hipCUB")
@@ -154,7 +154,7 @@ if(THEROCK_ENABLE_PRIM)
   therock_cmake_subproject_provide_package(hipCUB hipcub lib/cmake/hipcub)
   therock_cmake_subproject_activate(hipCUB)
 
-  if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+  if(THEROCK_USE_ROCM_LIBRARIES)
     set(_rocthrust_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocthrust")
   else()
     set(_rocthrust_source_dir "rocThrust")
@@ -210,7 +210,7 @@ if(THEROCK_ENABLE_FFT)
   ##############################################################################
   set(_fft_subproject_names)
 
-  if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+  if(THEROCK_USE_ROCM_LIBRARIES)
     set(_rocfft_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocfft")
   else()
     set(_rocfft_source_dir "rocFFT")
@@ -248,7 +248,7 @@ if(THEROCK_ENABLE_FFT)
   # hipFFT
   ##############################################################################
 
-  if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+  if(THEROCK_USE_ROCM_LIBRARIES)
     set(_hipfft_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipfft")
   else()
     set(_hipfft_source_dir "hipFFT")

--- a/math-libs/support/CMakeLists.txt
+++ b/math-libs/support/CMakeLists.txt
@@ -2,7 +2,7 @@
 # mxDataGenerator
 ################################################################################
 
-if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+if(THEROCK_USE_ROCM_LIBRARIES)
   set(_mxdatagenerator_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/shared/mxdatagenerator")
 else()
   set(_mxdatagenerator_source_dir "mxDataGenerator")

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -93,7 +93,7 @@ if(THEROCK_ENABLE_MIOPEN)
     endif()
   endif()
 
-  if(THEROCK_USE_EXTERNAL_ROCM_LIBRARIES)
+  if(THEROCK_USE_ROCM_LIBRARIES)
     set(_miopen_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/miopen")
   else()
     set(_miopen_source_dir "MIOpen")


### PR DESCRIPTION
Renames `THEROCK_USE_EXTERNAL_ROCM_LIBRARIES` to
`THEROCK_USE_ROCM_LIBRARIES` in prepration of switching from the individual submodules to the rocm-libraries superrepo.