### PR TITLE
Revert "Pytorch allow patching which submodule rev is checked out"

### DIFF
--- a/external-builds/pytorch/repo_management.py
+++ b/external-builds/pytorch/repo_management.py
@@ -171,31 +171,17 @@ def apply_repo_patches(repo_path: Path, patches_path: Path):
     )
 
 
-def apply_main_repository_patches(
-    root_repo_path: Path, patches_path: Path, repo_name: str, patchset_name: str
-):
-    # Apply patches to main repository.
-    apply_repo_patches(root_repo_path, patches_path / repo_name / patchset_name)
-
-
-def apply_submodule_patches(
+def apply_all_patches(
     root_repo_path: Path, patches_path: Path, repo_name: str, patchset_name: str
 ):
     relative_sm_paths = list_submodules(root_repo_path, relative=True)
+    # Apply base patches.
+    apply_repo_patches(root_repo_path, patches_path / repo_name / patchset_name)
     for relative_sm_path in relative_sm_paths:
         apply_repo_patches(
             root_repo_path / relative_sm_path,
             patches_path / relative_sm_path / patchset_name,
         )
-
-
-def apply_all_patches(
-    root_repo_path: Path, patches_path: Path, repo_name: str, patchset_name: str
-):
-    apply_main_repository_patches(
-        root_repo_path, patches_path, repo_name, patchset_name
-    )
-    apply_submodule_patches(root_repo_path, patches_path, repo_name, patchset_name)
 
 
 # repo_hashtag_to_patches_dir_name('2.7.0-rc9') -> '2.7.0'
@@ -266,17 +252,6 @@ def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
         fetch_args.extend(["-j", str(args.jobs)])
     exec(["git", "fetch"] + fetch_args + ["origin", args.repo_hashtag], cwd=repo_dir)
     exec(["git", "checkout", "FETCH_HEAD"], cwd=repo_dir)
-    if args.patch and patches_dir_name:
-        # Apply base patches to main repository. Patches to
-        # submodules will be applied later. This enables patches
-        # to modify submodule version to be checked out.
-        apply_main_repository_patches(
-            repo_dir,
-            repo_patch_dir_base / patches_dir_name,
-            args.repo_name,
-            "base",
-        )
-
     exec(["git", "tag", "-f", TAG_UPSTREAM_DIFFBASE, "--no-sign"], cwd=repo_dir)
     try:
         exec(
@@ -299,9 +274,9 @@ def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
     )
     git_config_ignore_submodules(repo_dir)
 
+    # Base patches.
     if args.patch and patches_dir_name:
-        # Apply base patches to submodules.
-        apply_submodule_patches(
+        apply_all_patches(
             repo_dir,
             repo_patch_dir_base / patches_dir_name,
             args.repo_name,
@@ -313,7 +288,7 @@ def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
         custom_hipify(args)
         commit_hipify(args)
 
-    # Apply hipified patches to main repository and submodules.
+    # Hipified patches.
     if args.hipify and args.patch and patches_dir_name:
         apply_all_patches(
             repo_dir,


### PR DESCRIPTION
Reverts ROCm/TheRock#1092

This breaks 'base' patches by incorrectly applying the `THEROCK_UPSTREAM_DIFFBASE` tag, see https://github.com/ROCm/TheRock/pull/1092#discussion_r2226039819.

When I run what should be a no-op:
```
python pytorch_torch_repo.py checkout
python pytorch_torch_repo.py save-patches
```
instead I get this diff, which deletes all the 'base/' patches: https://github.com/ScottTodd/TheRock/commit/7718788aafcf7423b014ef2066d212abe0da439f.

We could also fix forward, but I haven't received a response on the PR after 2 weeks and this has bit me a few times since reporting the issue.