### PR TITLE
[windows] Patch hipcc to use HIP_PATH env var at lower priority.

### DIFF
--- a/patches/amd-mainline/llvm-project/0001-Enable-MSVC-support-in-comgr.patch
+++ b/patches/amd-mainline/llvm-project/0001-Enable-MSVC-support-in-comgr.patch
@@ -1,14 +1,14 @@
-From 2fcbc3fc1fe34eae9fd647b79d6b0a15252c06ae Mon Sep 17 00:00:00 2001
+From bcdc455a08df8527e8946eb33fee714c28e30836 Mon Sep 17 00:00:00 2001
 From: Scott <scott.todd0@gmail.com>
 Date: Fri, 14 Feb 2025 15:22:48 -0800
-Subject: [PATCH 1/3] Enable MSVC support in comgr.
+Subject: [PATCH 1/5] Enable MSVC support in comgr.
 
 ---
  amd/comgr/CMakeLists.txt | 7 ++++++-
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/amd/comgr/CMakeLists.txt b/amd/comgr/CMakeLists.txt
-index ed01d21cea30..e643256f2a89 100644
+index 2eeb8c2ac6ac..8b16fb9377e1 100644
 --- a/amd/comgr/CMakeLists.txt
 +++ b/amd/comgr/CMakeLists.txt
 @@ -228,7 +228,12 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
@@ -26,5 +26,5 @@ index ed01d21cea30..e643256f2a89 100644
  endif()
  
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/llvm-project/0002-hipcc-fix-default-include-path-on-Windows-and-adapt-.patch
+++ b/patches/amd-mainline/llvm-project/0002-hipcc-fix-default-include-path-on-Windows-and-adapt-.patch
@@ -1,7 +1,7 @@
-From 993fefc7d2295fd34219534c5971c50758526d96 Mon Sep 17 00:00:00 2001
+From d70e7d2166d478ead5d9bd3f6e4b1408190ea666 Mon Sep 17 00:00:00 2001
 From: Scott Tsai <scottt.tw@gmail.com>
 Date: Tue, 15 Apr 2025 09:30:13 +0800
-Subject: [PATCH 4/4] hipcc: fix default include path on Windows and adapt to
+Subject: [PATCH 2/5] hipcc: fix default include path on Windows and adapt to
  TheRock rocm layout
 
 getCppConfig in the orignial code did not add the content of
@@ -18,10 +18,10 @@ separators to make the output obviously correct.
  1 file changed, 22 insertions(+), 38 deletions(-)
 
 diff --git a/amd/hipcc/src/hipBin_amd.h b/amd/hipcc/src/hipBin_amd.h
-index 550e4b248128..f66852b8352d 100644
+index ecea39e071b4..c74b43ff598f 100644
 --- a/amd/hipcc/src/hipBin_amd.h
 +++ b/amd/hipcc/src/hipBin_amd.h
-@@ -202,16 +202,11 @@ void HipBinAmd::constructCompilerPath() {
+@@ -201,16 +201,11 @@ void HipBinAmd::constructCompilerPath() {
    const EnvVariables& envVariables = getEnvVariables();
    if (envVariables.hipClangPathEnv_.empty()) {
      fs::path hipClangPath;
@@ -43,7 +43,7 @@ index 550e4b248128..f66852b8352d 100644
      compilerPath = hipClangPath.string();
    } else {
      compilerPath = envVariables.hipClangPathEnv_;
-@@ -227,32 +222,17 @@ const string& HipBinAmd::getCompilerPath() const {
+@@ -226,32 +221,17 @@ const string& HipBinAmd::getCompilerPath() const {
  void HipBinAmd::printCompilerInfo() const {
    const string& hipClangPath = getCompilerPath();
    const string& hipPath = getHipPath();
@@ -87,7 +87,7 @@ index 550e4b248128..f66852b8352d 100644
  }
  
  string HipBinAmd::getCompilerVersion() {
-@@ -294,17 +274,19 @@ string HipBinAmd::getCppConfig() {
+@@ -293,17 +273,19 @@ string HipBinAmd::getCppConfig() {
    hipPathInclude = hipPath;
    hipPathInclude /= "include";
    if (isWindows()) {
@@ -108,7 +108,7 @@ index 550e4b248128..f66852b8352d 100644
    return cppConfig;
  }
  
-@@ -877,7 +859,9 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
+@@ -874,7 +856,9 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
  
    // to avoid using dk linker or MSVC linker
    if (isWindows()) {
@@ -120,5 +120,5 @@ index 550e4b248128..f66852b8352d 100644
  
    if (!compileOnly) {
 -- 
-2.49.0.windows.1
+2.47.1.windows.2
 

--- a/patches/amd-mainline/llvm-project/0003-HACK-Handle-ROCM-installation-layout-of-lib-llvm-bin.patch
+++ b/patches/amd-mainline/llvm-project/0003-HACK-Handle-ROCM-installation-layout-of-lib-llvm-bin.patch
@@ -1,7 +1,7 @@
-From 3d9ccab2c606772c26afe5403cecd4a695bbdb72 Mon Sep 17 00:00:00 2001
+From 7dab0ed787cbde9d4aaaf99e24b7f33efda8f2a5 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Thu, 13 Feb 2025 17:58:53 -0800
-Subject: [PATCH 2/3] HACK: Handle ROCM installation layout of
+Subject: [PATCH 3/5] HACK: Handle ROCM installation layout of
  lib/llvm/bin/clang++.
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 2/3] HACK: Handle ROCM installation layout of
  1 file changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/clang/lib/Driver/ToolChains/AMDGPU.cpp b/clang/lib/Driver/ToolChains/AMDGPU.cpp
-index 5e8a949f5861..f4ee2c460481 100644
+index 798ea8aad6de..c45f07a6e285 100644
 --- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
 +++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
 @@ -244,8 +244,17 @@ RocmInstallationDetector::getInstallationPathCandidates() {
@@ -32,5 +32,5 @@ index 5e8a949f5861..f4ee2c460481 100644
      // and it seems ParentDir is already pointing to correct place.
      return Candidate(ParentDir.str(), /*StrictChecking=*/true);
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/llvm-project/0004-Disable-hipcc-passing-hip-device-libs.patch
+++ b/patches/amd-mainline/llvm-project/0004-Disable-hipcc-passing-hip-device-libs.patch
@@ -1,7 +1,7 @@
-From d9f595be0f7142a8509fd4b5dd82b863d4919c21 Mon Sep 17 00:00:00 2001
+From 0dd361bc6ae2e9ab9e19b9eeed808d719e58ad71 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Thu, 13 Feb 2025 19:07:07 -0800
-Subject: [PATCH 3/3] Disable hipcc passing hip-device-libs.
+Subject: [PATCH 4/5] Disable hipcc passing hip-device-libs.
 
 In modern times, the clang driver is far more knowledgable about this stuff and can operate without instruction.
 ---
@@ -9,10 +9,10 @@ In modern times, the clang driver is far more knowledgable about this stuff and 
  1 file changed, 10 insertions(+), 9 deletions(-)
 
 diff --git a/amd/hipcc/src/hipBin_amd.h b/amd/hipcc/src/hipBin_amd.h
-index a37c07836620..fb3942bee5f7 100644
+index c74b43ff598f..cb70026f6abf 100644
 --- a/amd/hipcc/src/hipBin_amd.h
 +++ b/amd/hipcc/src/hipBin_amd.h
-@@ -864,15 +864,16 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
+@@ -844,15 +844,16 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
      }
    }
  
@@ -39,5 +39,5 @@ index a37c07836620..fb3942bee5f7 100644
    // to avoid using dk linker or MSVC linker
    if (isWindows()) {
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/llvm-project/0005-Rework-constructHipPath-so-HIP_PATH-env-var-is-lower.patch
+++ b/patches/amd-mainline/llvm-project/0005-Rework-constructHipPath-so-HIP_PATH-env-var-is-lower.patch
@@ -1,0 +1,57 @@
+From cac004dd1df8e7db1bac39859aca6c2a271e906c Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Tue, 5 Aug 2025 12:40:12 -0700
+Subject: [PATCH 5/5] Rework constructHipPath so HIP_PATH env var is lower
+ priority.
+
+---
+ amd/hipcc/src/hipBin_base.h | 28 +++++++++++++++++++++++-----
+ 1 file changed, 23 insertions(+), 5 deletions(-)
+
+diff --git a/amd/hipcc/src/hipBin_base.h b/amd/hipcc/src/hipBin_base.h
+index ea37e6fd12fc..4aa7431fdba6 100644
+--- a/amd/hipcc/src/hipBin_base.h
++++ b/amd/hipcc/src/hipBin_base.h
+@@ -320,16 +320,34 @@ void HipBinBase::readEnvVariables() {
+ 
+ // constructs the HIP path
+ void HipBinBase::constructHipPath() {
+-  // we need to use --hip-path option
++  // The --hip-path argument option takes precedence over all other settings.
+   string hip_path_name = gethip_pathOption();
+   if (!hip_path_name.empty()) {
+     variables_.hipPathEnv_ = hip_path_name;
+-  } else if (envVariables_.hipPathEnv_.empty()) {
+-    fs::path full_path(hipcc::utils::getSelfPath());
+-    variables_.hipPathEnv_ = (full_path.parent_path()).string();
+-  } else {
++    return;
++  }
++
++  fs::path full_path(hipcc::utils::getSelfPath());
++  fs::path parent_path = full_path.parent_path();
++
++  // Next, check for `../lib/llvm/bin/`, the standard ROCm install structure.
++  fs::path llvm_path = parent_path / "lib" / "llvm" / "bin";
++  if (fs::exists(llvm_path)) {
++    variables_.hipPathEnv_ = parent_path.string();
++    return;
++  }
++
++  // Otherwise, check the HIP_PATH environment variable from the HIP SDK.
++  // Normally an environment variable setting could take precedence over an
++  // implicit path, but this environment variable is set by system-wide installs
++  // and self-contained builds/installs should not be reading that global state.
++  if (!envVariables_.hipPathEnv_.empty()) {
+     variables_.hipPathEnv_ = envVariables_.hipPathEnv_;
++    return;
+   }
++
++  // Finally, fallback to the parent path (the standard ROCm install structure).
++  variables_.hipPathEnv_ = parent_path.string();
+ }
+ 
+ 
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/1200.

The HIP SDK sets the `HIP_PATH` environment variable, which hipcc and hipconfig were using instead of neighboring files.

A robust way to handle this would be to stamp all information about related tools into the tools themselves during packaging, rather than use global state like environment variables or heuristics like scanning the file system. I think once we've progressed further towards rolling out the new ROCm "superrepos" and open source CI/CD we can make those deeper changes. For now, I've extended the brittle logic with another special case.