### PR TITLE
[gfx1200/windows] Bump amdgpu-windows-interop and add enums in clr

### DIFF
--- a/patches/amd-mainline/clr/0004-Support-gfx1200-navi44.patch
+++ b/patches/amd-mainline/clr/0004-Support-gfx1200-navi44.patch
@@ -1,0 +1,37 @@
+From 74b14b84aff8e075be7a9cdcebc5e5694455d29e Mon Sep 17 00:00:00 2001
+From: Aaryaman Vasishta <aaryaman.vasishta@amd.com>
+Date: Thu, 31 Jul 2025 21:05:50 +0900
+Subject: [PATCH] Support gfx1200 (navi44)
+
+---
+ rocclr/device/pal/paldevice.cpp   | 1 +
+ rocclr/device/pal/palsettings.cpp | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/rocclr/device/pal/paldevice.cpp b/rocclr/device/pal/paldevice.cpp
+index 59edc1a23..3f92fb92b 100644
+--- a/rocclr/device/pal/paldevice.cpp
++++ b/rocclr/device/pal/paldevice.cpp
+@@ -102,6 +102,7 @@ static constexpr PalDevice supportedPalDevices[] = {
+   {11, 0,  3,  Pal::GfxIpLevel::GfxIp11_0, "gfx1103",       Pal::AsicRevision::HawkPoint2},
+   {11, 5,  0,  Pal::GfxIpLevel::GfxIp11_5, "gfx1150",       Pal::AsicRevision::Strix1},
+   {11, 5,  1,  Pal::GfxIpLevel::GfxIp11_5, "gfx1151",       Pal::AsicRevision::StrixHalo},
++  {12, 0,  0,  Pal::GfxIpLevel::GfxIp12,   "gfx1200",       Pal::AsicRevision::Navi44},
+   {12, 0,  1,  Pal::GfxIpLevel::GfxIp12,   "gfx1201",       Pal::AsicRevision::Navi48},
+ };
+ 
+diff --git a/rocclr/device/pal/palsettings.cpp b/rocclr/device/pal/palsettings.cpp
+index 0cd5ca70a..11fde4c09 100644
+--- a/rocclr/device/pal/palsettings.cpp
++++ b/rocclr/device/pal/palsettings.cpp
+@@ -163,6 +163,7 @@ bool Settings::create(const Pal::DeviceProperties& palProp,
+   switch (palProp.revision) {
+     // Fall through for Navi4x ...
+     case Pal::AsicRevision::Navi48:
++    case Pal::AsicRevision::Navi44:
+     // Fall through for Navi3x ...
+     case Pal::AsicRevision::Navi33:
+     case Pal::AsicRevision::Navi32:
+-- 
+2.50.1.windows.1
+


### PR DESCRIPTION
For gfx1200 support on Windows.

PR split from https://github.com/ROCm/TheRock/pull/1163