### PR TITLE
Unpin CMake from pytorch build_prod_wheels.py.

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -613,8 +613,6 @@ def do_build_pytorch(
             "install",
             "-r",
             pytorch_dir / "requirements.txt",
-            # TODO: Remove cmake<4 pin once the world adapts (check at end of 2025).
-            "cmake<4",
         ]
         + pip_install_args,
         cwd=pytorch_dir,


### PR DESCRIPTION
The https://github.com/ROCm/pytorch/tree/release/2.7 branch is now pinning to `cmake==4.0.3` (see https://github.com/ROCm/pytorch/pull/2444), so this is a conflicting requirement that causes our builds to fail:
```
Ignoring numpy: markers 'python_version == "3.9"' don't match your environment
Requirement already satisfied: cmake<4 in /opt/python/cp312-cp312/lib/python3.12/site-packages (3.31.6)
Collecting astunparse==1.6.3 (from -r /__w/TheRock/TheRock/external-builds/pytorch/pytorch/requirements.txt (line 2))
  Downloading astunparse-1.6.3-py2.py3-none-any.whl.metadata (4.4 kB)
ERROR: Cannot install cmake<4 and cmake==4.0.3 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested cmake<4
    The user requested cmake==4.0.3

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict


Notice:  A new release of pip is available: 25.1.1 -> 25.2
Notice:  To update, run: pip install --upgrade pip
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```
(full logs at https://github.com/ROCm/TheRock/actions/runs/16787789191/job/47543320786#step:11:2286)

Testing at:
* Linux: https://github.com/ROCm/TheRock/actions/runs/16790506303
* Windows: no test triggered yet (runners have been queued for 6 hours, not sure I want to make that worse)