### PR TITLE
Patch clr to load `libamdhip64.so.7`

### DIFF
--- a/patches/amd-mainline/clr/0005-Explicitly-load-libamdhip64.so.7.patch
+++ b/patches/amd-mainline/clr/0005-Explicitly-load-libamdhip64.so.7.patch
@@ -1,0 +1,39 @@
+From 71a8f02f13d25632cc579d963c79d406d55f5066 Mon Sep 17 00:00:00 2001
+From: Marius Brehler <marius.brehler@amd.com>
+Date: Wed, 6 Aug 2025 20:53:01 +0000
+Subject: [PATCH 5/5] Explicitly load `libamdhip64.so.7`
+
+---
+ hipamd/src/hip_comgr_helper.cpp | 2 +-
+ hipamd/src/hip_platform.cpp     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/hipamd/src/hip_comgr_helper.cpp b/hipamd/src/hip_comgr_helper.cpp
+index a8ee6ea9b..4b4908a93 100644
+--- a/hipamd/src/hip_comgr_helper.cpp
++++ b/hipamd/src/hip_comgr_helper.cpp
+@@ -1151,7 +1151,7 @@ bool RTCProgram::findIsa() {
+   std::string dll_name = std::string("amdhip64_" + std::to_string(HIP_VERSION_MAJOR) + ".dll");
+   libName = dll_name.c_str();
+ #else
+-  libName = "libamdhip64.so";
++  libName = "libamdhip64.so.7";
+ #endif
+ 
+   void* handle = amd::Os::loadLibrary(libName);
+diff --git a/hipamd/src/hip_platform.cpp b/hipamd/src/hip_platform.cpp
+index da290fd5e..e01667d69 100644
+--- a/hipamd/src/hip_platform.cpp
++++ b/hipamd/src/hip_platform.cpp
+@@ -1014,7 +1014,7 @@ void* PlatformState::getDynamicLibraryHandle() {
+ #ifdef _WIN32
+   const char* libName = "amdhip64.dll";
+ #else
+-  const char* libName = "libamdhip64.so";
++  const char* libName = "libamdhip64.so.7";
+ #endif
+ 
+   dynamicLibraryHandle_ = amd::Os::loadLibrary(libName);
+-- 
+2.43.0
+


### PR DESCRIPTION
While hipcc adds linker flag to link `libamdhip64.so.7`, clr was still loading `libamdhip64.so`. This adds a patch to explicitly load `libamdhip64.so.7`.

Closes #1180.