### PR TITLE
Fix syntax error

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -202,7 +202,7 @@ jobs:
             { "version": "${{ needs.setup_metadata.outputs.version }}",
               "tag": "nightly-tarball",
               "file_name": "${{ env.FILE_NAME }}",
-              "target": "${{ matrix.target_bundle.amdgpu_family }}",
+              "target": "${{ matrix.target_bundle.amdgpu_family }}"
             }
 
       - name: Trigger building PyTorch wheels


### PR DESCRIPTION
Workflow was failing with
```
Run benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc
🏃 Workflow Dispatch Action v1.2.4
Error: Expected double-quoted property name in JSON at position 151
```