### PR TITLE
Enable git long paths in Windows release workflow.

### DIFF
--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -187,6 +187,8 @@ jobs:
 
       - name: Fetch sources
         run: |
+          git config --global core.symlinks true
+          git config --global core.longpaths true
           python ./build_tools/fetch_sources.py --jobs 96
 
       - name: Checkout closed source AMDGPU/ROCm interop library folder


### PR DESCRIPTION
Follow-up to https://github.com/ROCm/TheRock/pull/1195.

This should fix errors like https://github.com/ROCm/TheRock/actions/runs/16828883457/job/47671616712
```
error: unable to create file projects/composablekernel/library/src/tensor_operation_instance/gpu/batched_gemm_b_scale/device_batched_gemm_b_scale_xdl_f16_i4_f16/device_batched_gemm_b_scale_xdl_f16_i4_f16_mk_nk_mn_mem_v2_default_instance.cpp: Filename too long
error: unable to create file projects/composablekernel/library/src/tensor_operation_instance/gpu/batched_gemm_softmax_gemm_permute/device_batched_gemm_bias_softmax_gemm_permute_xdl_cshuffle_bf16_bf16_bf16_bf16_gmk_gnk_gno_gmo_instance.cpp: Filename too long
```

Ideally these workflows would share the same setup / building code.