### PR TITLE
[torch][windows] Rebase aotriton patches, fix undeclared `mha_fwd_aot`.

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -832,7 +832,7 @@ def main(argv: list[str]):
     )
     build_p.add_argument(
         "--enable-pytorch-flash-attention-windows",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=None,
         help="Enable building of torch flash attention on Windows (enabled by default for Linux)",
     )

--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0001-Enable-USE_ROCM-disable-USE_RCCL-on-Windows.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0001-Enable-USE_ROCM-disable-USE_RCCL-on-Windows.patch
@@ -1,14 +1,14 @@
-From 14da974266cdb6a5434eea76988fe2479915f14a Mon Sep 17 00:00:00 2001
+From 504939d0289dccc2b95c2b6001e7e4d328ce7a80 Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Thu, 24 Jul 2025 10:38:01 -0700
-Subject: [PATCH 1/4] Enable USE_ROCM, disable USE_RCCL on Windows.
+Subject: [PATCH 1/5] Enable USE_ROCM, disable USE_RCCL on Windows.
 
 ---
  CMakeLists.txt | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 16fec0c8002..10ad7f71d2d 100644
+index 48b9e2e8df3..cc9476bb001 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -239,7 +239,7 @@ option(USE_XPU "Use XPU" ON)
@@ -20,7 +20,7 @@ index 16fec0c8002..10ad7f71d2d 100644
  cmake_dependent_option(USE_ROCM_CK_GEMM "Use ROCm Composable Kernel for GEMMs" ON "USE_ROCM;NOT WIN32" OFF)
  option(USE_ROCM_CK_SDPA "Use ROCm Composable Kernel for SDPA" OFF)
  option(CAFFE2_STATIC_LINK_CUDA "Statically link CUDA libraries" OFF)
-@@ -268,6 +268,7 @@ cmake_dependent_option(USE_NCCL "Use NCCL" ON
+@@ -267,6 +267,7 @@ cmake_dependent_option(USE_NCCL "Use NCCL" ON
  cmake_dependent_option(USE_XCCL "Use XCCL" ON
                         "USE_XPU;UNIX;NOT APPLE" OFF)
  cmake_dependent_option(USE_RCCL "Use RCCL" ON USE_NCCL OFF)
@@ -29,5 +29,5 @@ index 16fec0c8002..10ad7f71d2d 100644
  cmake_dependent_option(USE_SYSTEM_NCCL "Use system-wide NCCL" OFF "USE_NCCL"
                         OFF)
 -- 
-2.50.1.windows.1
+2.45.1.windows.1
 

--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0002-Fix-LoadHIP-handling-of-environment-variable-paths-o.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0002-Fix-LoadHIP-handling-of-environment-variable-paths-o.patch
@@ -1,7 +1,7 @@
-From aa8c5cbd45d8e499444acf33baabcb0cef8eb609 Mon Sep 17 00:00:00 2001
+From 14b03b3586ac477bbf973dd041387473407a4a4c Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Thu, 24 Jul 2025 12:43:07 -0700
-Subject: [PATCH 2/4] Fix LoadHIP handling of environment variable paths on
+Subject: [PATCH 2/5] Fix LoadHIP handling of environment variable paths on
  Windows.
 
 ---
@@ -31,5 +31,5 @@ index 132f9670ff3..018bca837a5 100644
  
  # MIOpen isn't a part of HIP-SDK for Windows and hence, may have a different
 -- 
-2.50.1.windows.1
+2.45.1.windows.1
 

--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0003-Revert-copying-hipblaslt-and-rocblas-dirs-on-Windows.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0003-Revert-copying-hipblaslt-and-rocblas-dirs-on-Windows.patch
@@ -1,7 +1,7 @@
-From 66fdf8b733f84ba2b50c3d4527377576bfe3c068 Mon Sep 17 00:00:00 2001
+From ec3eb27527df4cd850a8e59e9c5b95fba9a72d1e Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Thu, 24 Jul 2025 12:45:53 -0700
-Subject: [PATCH 3/4] Revert copying hipblaslt and rocblas dirs on Windows.
+Subject: [PATCH 3/5] Revert copying hipblaslt and rocblas dirs on Windows.
 
 Since https://github.com/pytorch/pytorch/commit/30387ab2e485384ab2e67084a1e2c5569190ba92, ROCm is bootstrapped using the 'rocm' Python module which contains these files, so they do not need to be bundled into torch/lib.
 ---
@@ -37,5 +37,5 @@ index ad00317da08..cd04f5313aa 100644
          self.create_compile_commands()
  
 -- 
-2.50.1.windows.1
+2.45.1.windows.1
 

--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0004-ROCm-Windows-Include-native_transformers-srcs-to-fix.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0004-ROCm-Windows-Include-native_transformers-srcs-to-fix.patch
@@ -1,0 +1,28 @@
+From bd9e41913922b372724f31a46fb87d07dfab6d93 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Mon, 11 Aug 2025 13:05:44 -0700
+Subject: [PATCH 4/5] [ROCm][Windows] Include native_transformers srcs to fix
+ link errors.
+
+---
+ aten/src/ATen/CMakeLists.txt | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
+index 5f4997357f8..e1939323fc9 100644
+--- a/aten/src/ATen/CMakeLists.txt
++++ b/aten/src/ATen/CMakeLists.txt
+@@ -470,10 +470,6 @@ if(USE_ROCM)
+     exclude(ATen_HIP_SRCS "${ATen_HIP_SRCS}"
+       ${native_hip_bgemm} ${native_hip_ck})
+   endif()
+-  if(WIN32) # Windows doesn't support Composable Kernels and Triton
+-    exclude(ATen_HIP_SRCS "${ATen_HIP_SRCS}"
+-      ${native_transformers_hip_hip} ${native_transformers_hip_cpp})
+-  endif()
+ 
+   # TODO: Codegen separate files for HIP and use those (s/cuda_generated_sources/hip_generated_sources)
+   list(APPEND all_hip_cpp
+-- 
+2.45.1.windows.1
+

--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0005-Support-FLASH_ATTENTION-MEM_EFF_ATTENTION-via.-aotri.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0005-Support-FLASH_ATTENTION-MEM_EFF_ATTENTION-via.-aotri.patch
@@ -1,19 +1,18 @@
-From 906cc3f60305b08e9fb5f38d9d79235c9373ef71 Mon Sep 17 00:00:00 2001
+From 39a7c6a0645e24ee4be09f21376f4dab50be5667 Mon Sep 17 00:00:00 2001
 From: Aaryaman Vasishta <aaryaman.vasishta@amd.com>
 Date: Sun, 10 Aug 2025 00:16:27 +0900
-Subject: [PATCH 4/4] Support FLASH_ATTENTION, MEM_EFF_ATTENTION via. aotriton
+Subject: [PATCH 5/5] Support FLASH_ATTENTION, MEM_EFF_ATTENTION via. aotriton
  on windows
 
 ---
  CMakeLists.txt                                |   4 +-
- aten/src/ATen/CMakeLists.txt                  |   4 -
- .../native/transformers/hip/attention.hip     |  64 ++++++
+ .../native/transformers/hip/attention.hip     |  66 ++++++
  .../transformers/hip/flash_attn/flash_api.h   |  39 +---
  cmake/External/aotriton.cmake                 | 194 +++++++++++++++---
- 5 files changed, 233 insertions(+), 72 deletions(-)
+ 4 files changed, 235 insertions(+), 68 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 10ad7f71d2d..d90f3505898 100644
+index cc9476bb001..b5c50bcd60c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -872,7 +872,7 @@ cmake_dependent_option(
@@ -34,29 +33,15 @@ index 10ad7f71d2d..d90f3505898 100644
      include(cmake/External/aotriton.cmake)
    endif()
  endif()
-diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
-index 5f4997357f8..e1939323fc9 100644
---- a/aten/src/ATen/CMakeLists.txt
-+++ b/aten/src/ATen/CMakeLists.txt
-@@ -470,10 +470,6 @@ if(USE_ROCM)
-     exclude(ATen_HIP_SRCS "${ATen_HIP_SRCS}"
-       ${native_hip_bgemm} ${native_hip_ck})
-   endif()
--  if(WIN32) # Windows doesn't support Composable Kernels and Triton
--    exclude(ATen_HIP_SRCS "${ATen_HIP_SRCS}"
--      ${native_transformers_hip_hip} ${native_transformers_hip_cpp})
--  endif()
- 
-   # TODO: Codegen separate files for HIP and use those (s/cuda_generated_sources/hip_generated_sources)
-   list(APPEND all_hip_cpp
 diff --git a/aten/src/ATen/native/transformers/hip/attention.hip b/aten/src/ATen/native/transformers/hip/attention.hip
-index 93c523ff71e..53516a161be 100644
+index 93c523ff71e..c12ac43ce0d 100644
 --- a/aten/src/ATen/native/transformers/hip/attention.hip
 +++ b/aten/src/ATen/native/transformers/hip/attention.hip
-@@ -97,6 +97,70 @@
+@@ -97,6 +97,72 @@
  #endif
  #endif
  
++#if defined(USE_FLASH_ATTENTION) || defined(USE_MEM_EFF_ATTENTION)
 +namespace pytorch_flash
 +{
 +std::tuple<
@@ -120,6 +105,7 @@ index 93c523ff71e..53516a161be 100644
 +      gen_);
 +}
 +}
++#endif
 +
  namespace at {
  
@@ -428,5 +414,5 @@ index 54564e42c90..fa9beea8026 100644
 +endif() # __AOTRITON_INCLUDED
 \ No newline at end of file
 -- 
-2.50.1.windows.1
+2.45.1.windows.1
 


### PR DESCRIPTION
## Motivation

Windows nightly PyTorch builds are currently broken: https://github.com/ROCm/TheRock/actions/workflows/release_windows_pytorch_wheels.yml?query=branch%3Amain. This fixes them.

## Technical Details

Builds without `--enable-pytorch-flash-attention-windows` were failing with `error: use of undeclared identifier 'mha_fwd_aot'`, but we also needed to remove the `exclude(ATen_HIP_SRCS` code that was added upstream to resolve `lld-link: error: undefined symbol ... transform_bias_rescale_qkv_cuda`.

This is a minimal fix-forward for the first issue and restructures the patches for the second issue.

Context:
* https://github.com/ROCm/TheRock/pull/1207#discussion_r2267878623
* https://github.com/pytorch/pytorch/pull/152951#discussion_r2267714825

## Test Plan

Built locally with `python build_prod_wheels.py build --pytorch-dir D:/b/pytorch_main --pytorch-audio-dir D:/b/audio_main --pytorch-vision-dir D:/b/vision_main --output-dir %HOME%/.therock/pytorch --no-enable-pytorch-flash-attention-windows`

## Test Result

Local build succeeded.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
