### PR TITLE
Drop `THEROCK_USE_ROCM_LIBRARIES` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,19 +60,10 @@ option(THEROCK_BUNDLE_SYSDEPS "Builds bundled system deps for portable builds in
 
 # Source settings.
 # Use the rocm-libraries superrepo tracked in TheRock's `.gitmodules` or
-# specify an alternative source location.
-option(THEROCK_USE_ROCM_LIBRARIES "Use the `rocm-libraries` superrepo" ON)
+# allow to specify an alternative source location.
 set(THEROCK_ROCM_LIBRARIES_SOURCE_DIR_DEFAULT "${THEROCK_SOURCE_DIR}/rocm-libraries")
 set(THEROCK_ROCM_LIBRARIES_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR_DEFAULT}" CACHE STRING "Path to rocm-libraries superrepo")
-
 cmake_path(ABSOLUTE_PATH THEROCK_ROCM_LIBRARIES_SOURCE_DIR NORMALIZE)
-if(NOT THEROCK_USE_ROCM_LIBRARIES)
-  message(FATAL_ERROR
-    "Building from indvidual submodules is deprecated. "
-    "Set THEROCK_USE_ROCM_LIBRARIES to `ON` and re-run `fetch_sources.py` "
-    "to clone and patch the rocm-libraries submodule."
-  )
-endif()
 
 # Use the rccl amd rccl-test repos tracked in TheRock's `.gitmodules` or
 # specify alternative source locations.

--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -18,14 +18,8 @@ endif()
 ##############################################################################
 set(_blas_subproject_names)
 
-if(THEROCK_USE_ROCM_LIBRARIES)
-  set(_hipblas_common_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipblas-common")
-else()
-  set(_hipblas_common_source_dir "hipBLAS-common")
-endif()
-
 therock_cmake_subproject_declare(hipBLAS-common
-EXTERNAL_SOURCE_DIR "${_hipblas_common_source_dir}"
+EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipblas-common"
 BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hipBLAS-common"
 BACKGROUND_BUILD
 COMPILER_TOOLCHAIN
@@ -48,12 +42,6 @@ list(APPEND _blas_subproject_names hipBLAS-common)
 # rocRoller
 ##############################################################################
 
-if(THEROCK_USE_ROCM_LIBRARIES)
-  set(_rocroller_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/shared/rocroller")
-else()
-  set(_rocroller_source_dir "rocRoller")
-endif()
-
 if(WIN32)
   set(_enable_rocRoller "OFF")
 else()
@@ -62,7 +50,7 @@ endif()
 
 if(_enable_rocRoller)
   therock_cmake_subproject_declare(rocRoller
-    EXTERNAL_SOURCE_DIR "${_rocroller_source_dir}"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/shared/rocroller"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocRoller"
     BACKGROUND_BUILD
     CMAKE_ARGS
@@ -106,12 +94,6 @@ endif()
 # hipBLASLt
 ##############################################################################
 
-if(THEROCK_USE_ROCM_LIBRARIES)
-  set(_hipblaslt_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipblaslt")
-else()
-  set(_hipblaslt_source_dir "hipBLASLt")
-endif()
-
 set(hipBLASLt_optional_deps)
 if(NOT WIN32)
   # hipBLASLt is hard-coded to not expect rocm-smi on Windows.
@@ -134,7 +116,7 @@ if(_enable_rocRoller)
 endif()
 
 therock_cmake_subproject_declare(hipBLASLt
-  EXTERNAL_SOURCE_DIR "${_hipblaslt_source_dir}"
+  EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipblaslt"
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hipBLASLt"
   BACKGROUND_BUILD
   CMAKE_LISTS_RELPATH "next-cmake"
@@ -174,14 +156,6 @@ list(APPEND _blas_subproject_names hipBLASLt)
 # rocBLAS
 ##############################################################################
 
-if(THEROCK_USE_ROCM_LIBRARIES)
-  set(_rocblas_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocblas")
-  set(_tensile_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/shared/tensile")
-else()
-  set(_rocblas_source_dir "rocBLAS")
-  set(_tensile_source_dir "${CMAKE_CURRENT_SOURCE_DIR}/Tensile")
-endif()
-
 set(rocBLAS_optional_runtime_deps)
 if(NOT WIN32)
   # rocBLAS is hard-coded to not expect rocm-smi.
@@ -191,7 +165,7 @@ elseif(THEROCK_BUILD_TESTING)
 endif()
 
 therock_cmake_subproject_declare(rocBLAS
-  EXTERNAL_SOURCE_DIR "${_rocblas_source_dir}"
+  EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocblas"
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocBLAS"
   BACKGROUND_BUILD
   CMAKE_ARGS
@@ -201,7 +175,7 @@ therock_cmake_subproject_declare(rocBLAS
     -DBUILD_WITH_TENSILE=ON
     -DBUILD_WITH_HIPBLASLT=ON
     # TODO: With `Tensile_TEST_LOCAL_PATH` set, the resulting build path is ${Tensile_TEST_LOCAL_PATH}/build.
-    "-DTensile_TEST_LOCAL_PATH=${_tensile_source_dir}"
+    "-DTensile_TEST_LOCAL_PATH=${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/shared/tensile"
     # Since using a local Tensile vs fetched, unset TENSILE_VERSION to avoid
     # doing a strict check of exact version.
     -DTENSILE_VERSION=
@@ -238,14 +212,8 @@ if(THEROCK_ENABLE_SPARSE)
   ##############################################################################
   set(_sparse_subproject_names)
 
-  if(THEROCK_USE_ROCM_LIBRARIES)
-    set(_rocsparse_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocsparse")
-  else()
-    set(_rocsparse_source_dir "rocSPARSE")
-  endif()
-
   therock_cmake_subproject_declare(rocSPARSE
-    EXTERNAL_SOURCE_DIR "${_rocsparse_source_dir}"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocsparse"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocSPARSE"
     BACKGROUND_BUILD
     CMAKE_ARGS
@@ -281,14 +249,8 @@ if(THEROCK_ENABLE_SPARSE)
   # hipSPARSE
   ##############################################################################
 
-  if(THEROCK_USE_ROCM_LIBRARIES)
-    set(_hipsparse_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipsparse")
-  else()
-    set(_hipsparse_source_dir "hipSPARSE")
-  endif()
-
   therock_cmake_subproject_declare(hipSPARSE
-    EXTERNAL_SOURCE_DIR "${_hipsparse_source_dir}"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipsparse"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hipSPARSE"
     BACKGROUND_BUILD
     CMAKE_ARGS
@@ -413,12 +375,6 @@ endif(THEROCK_ENABLE_SOLVER)
 # hipBLAS
 ##############################################################################
 
-if(THEROCK_USE_ROCM_LIBRARIES)
-  set(_hipblas_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipblas")
-else()
-  set(_hipblas_source_dir "hipBLAS")
-endif()
-
 set(hipBLAS_optional_deps)
 if(THEROCK_ENABLE_SOLVER)
   list(APPEND hipBLAS_optional_deps rocSOLVER)
@@ -428,7 +384,7 @@ if(THEROCK_BUILD_TESTING)
 endif()
 
 therock_cmake_subproject_declare(hipBLAS
-  EXTERNAL_SOURCE_DIR "${_hipblas_source_dir}"
+  EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipblas"
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hipBLAS"
   BACKGROUND_BUILD
   CMAKE_ARGS

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -4,14 +4,8 @@ if(THEROCK_ENABLE_RAND)
   ##############################################################################
   set(_rand_subproject_names)
 
-  if(THEROCK_USE_ROCM_LIBRARIES)
-    set(_rocrand_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocrand")
-  else()
-    set(_rocrand_source_dir "rocRAND")
-  endif()
-
   therock_cmake_subproject_declare(rocRAND
-    EXTERNAL_SOURCE_DIR "${_rocrand_source_dir}"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocrand"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocRAND"
     BACKGROUND_BUILD
     CMAKE_ARGS
@@ -39,14 +33,8 @@ if(THEROCK_ENABLE_RAND)
   # hipRAND
   ##############################################################################
 
-  if(THEROCK_USE_ROCM_LIBRARIES)
-    set(_hiprand_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hiprand")
-  else()
-    set(_hiprand_source_dir "hipRAND")
-  endif()
-
   therock_cmake_subproject_declare(hipRAND
-    EXTERNAL_SOURCE_DIR "${_hiprand_source_dir}"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hiprand"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hipRAND"
     BACKGROUND_BUILD
     CMAKE_ARGS
@@ -93,14 +81,8 @@ if(THEROCK_ENABLE_PRIM)
   # rocPRIM
   ##############################################################################
 
-  if(THEROCK_USE_ROCM_LIBRARIES)
-    set(_rocprim_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocprim")
-  else()
-    set(_rocprim_source_dir "rocPRIM")
-  endif()
-
   therock_cmake_subproject_declare(rocPRIM
-    EXTERNAL_SOURCE_DIR "${_rocprim_source_dir}"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocprim"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocPRIM"
     BACKGROUND_BUILD
     CMAKE_ARGS
@@ -123,14 +105,8 @@ if(THEROCK_ENABLE_PRIM)
   therock_cmake_subproject_provide_package(rocPRIM rocprim lib/cmake/rocprim)
   therock_cmake_subproject_activate(rocPRIM)
 
-  if(THEROCK_USE_ROCM_LIBRARIES)
-    set(_hipcub_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipcub")
-  else()
-    set(_hipcub_source_dir "hipCUB")
-  endif()
-
   therock_cmake_subproject_declare(hipCUB
-    EXTERNAL_SOURCE_DIR "${_hipcub_source_dir}"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipcub"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hipCUB"
     BACKGROUND_BUILD
     CMAKE_ARGS
@@ -154,14 +130,8 @@ if(THEROCK_ENABLE_PRIM)
   therock_cmake_subproject_provide_package(hipCUB hipcub lib/cmake/hipcub)
   therock_cmake_subproject_activate(hipCUB)
 
-  if(THEROCK_USE_ROCM_LIBRARIES)
-    set(_rocthrust_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocthrust")
-  else()
-    set(_rocthrust_source_dir "rocThrust")
-  endif()
-
   therock_cmake_subproject_declare(rocThrust
-    EXTERNAL_SOURCE_DIR "${_rocthrust_source_dir}"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocthrust"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocThrust"
     BACKGROUND_BUILD
     CMAKE_ARGS
@@ -210,14 +180,8 @@ if(THEROCK_ENABLE_FFT)
   ##############################################################################
   set(_fft_subproject_names)
 
-  if(THEROCK_USE_ROCM_LIBRARIES)
-    set(_rocfft_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocfft")
-  else()
-    set(_rocfft_source_dir "rocFFT")
-  endif()
-
   therock_cmake_subproject_declare(rocFFT
-    EXTERNAL_SOURCE_DIR "${_rocfft_source_dir}"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocfft"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocFFT"
     BACKGROUND_BUILD
     CMAKE_ARGS
@@ -248,14 +212,8 @@ if(THEROCK_ENABLE_FFT)
   # hipFFT
   ##############################################################################
 
-  if(THEROCK_USE_ROCM_LIBRARIES)
-    set(_hipfft_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipfft")
-  else()
-    set(_hipfft_source_dir "hipFFT")
-  endif()
-
   therock_cmake_subproject_declare(hipFFT
-    EXTERNAL_SOURCE_DIR "${_hipfft_source_dir}"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipfft"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hipFFT"
     BACKGROUND_BUILD
     CMAKE_ARGS

--- a/math-libs/support/CMakeLists.txt
+++ b/math-libs/support/CMakeLists.txt
@@ -2,14 +2,8 @@
 # mxDataGenerator
 ################################################################################
 
-if(THEROCK_USE_ROCM_LIBRARIES)
-  set(_mxdatagenerator_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/shared/mxdatagenerator")
-else()
-  set(_mxdatagenerator_source_dir "mxDataGenerator")
-endif()
-
 therock_cmake_subproject_declare(mxDataGenerator
-  EXTERNAL_SOURCE_DIR "${_mxdatagenerator_source_dir}"
+  EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/shared/mxdatagenerator"
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/mxDataGenerator"
   BACKGROUND_BUILD
   CMAKE_ARGS

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -94,14 +94,8 @@ if(THEROCK_ENABLE_MIOPEN)
     endif()
   endif()
 
-  if(THEROCK_USE_ROCM_LIBRARIES)
-    set(_miopen_source_dir "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/miopen")
-  else()
-    set(_miopen_source_dir "MIOpen")
-  endif()
-
   therock_cmake_subproject_declare(MIOpen
-    EXTERNAL_SOURCE_DIR "${_miopen_source_dir}"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/miopen"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/MIOpen"
     BACKGROUND_BUILD
     CMAKE_ARGS


### PR DESCRIPTION
The `THEROCK_USE_ROCM_LIBRARIES` is deprecated. Individual submodules for components migrated to rocm-libraries are no longer supported by helper script like `fetch_sources.py`. This removed the option from the CMake configuration.