### PR TITLE
Improve ergonomics of using TheRock as a development driver for sub-projects.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ cmake_policy(SET CMP0135 NEW)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(CMakeDependentOption)
 include(ExternalProject)
+include(therock_default_targets)
 include(therock_amdgpu_targets)
 include(therock_artifacts)
 include(therock_compiler_config)
@@ -447,4 +448,3 @@ endif()
 # Finalization
 ################################################################################
 therock_subproject_merge_compile_commands()
-therock_create_dist()

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -269,8 +269,9 @@ def _do_artifact_flatten(args):
     flattener(*args.artifact)
     relpaths = list(flattener.relpaths)
     relpaths.sort()
-    for relpath in relpaths:
-        print(relpath)
+    if args.verbose:
+        for relpath in relpaths:
+            print(relpath)
 
 
 def _dup_list_or_str(v: list[str] | str) -> list[str]:

--- a/build_tools/tests/fileset_tool_test.py
+++ b/build_tools/tests/fileset_tool_test.py
@@ -173,6 +173,7 @@ class FilesetToolTest(unittest.TestCase):
                 FILESET_TOOL,
                 "artifact-flatten",
                 artifact_archive,
+                "--verbose",
                 "-o",
                 flat2_dir,
             ]

--- a/cmake/therock_default_targets.cmake
+++ b/cmake/therock_default_targets.cmake
@@ -1,0 +1,26 @@
+# Various top level targets that have dependencies added to them build system
+# wide. In general, the canonical name for all such targets is prefixed with
+# "therock-{name}", but also bare name targets are defined if not already.
+
+function(therock_add_convenience_target name)
+  add_custom_target("therock-${name}")
+  if(NOT TARGET "${name}")
+    add_custom_target("${name}" DEPENDS "therock-${name}")
+  endif()
+endfunction()
+
+function(therock_add_convenience_target_all name)
+  add_custom_target("therock-${name}" ALL)
+  if(NOT TARGET "${name}")
+    add_custom_target("${name}" DEPENDS "therock-${name}")
+  endif()
+endfunction()
+
+# Populates all artifacts and distributions (i.e. all artifact-foo targets).
+therock_add_convenience_target(artifacts)
+# Builds archives for all artifacts (i.e. all archive-foo targets).
+therock_add_convenience_target(archives)
+# Populates all distribution directories (i.e. all dist-foo targets).
+therock_add_convenience_target(dist)
+# Expunges configure/build byproducts and artifacts for all projects.
+therock_add_convenience_target(expunge)


### PR DESCRIPTION
The motivation of this change is to enable the following developer productivity features:

* Development in a sub-project `build` directory should cause the super-project to see the sub-project as out of date and take appropriate action. This is done by injecting an ALL `therock-touch` target into each sub-project so that `ninja` will invalidate the super-project stage-install state, causing a re-install and rebuild of dependents.
* One stop commands to build and distribute in a sub-project without switching back and forth. Users can now just run `ninja therock-dist` in any sub-project to build and distribute their local changes (i.e. to `build/dist/rocm`, etc).
* More coverage of `expunge` targets, making sure that project state can be reset more completely.

Key changes:

* Removes some `therock-` prefixes from top level convenience targets.
* Defines `artifacts`, `archives`, `dist`, and `expunge` top level convenience targets explicitly.
* Adds `expunge` steps to all phases of build, artifact assembly and dist population.
* Removes the formal sub-project `+dist` phase, collapsing the creation of the local `dist` directory into the `+stage` (install) step. This separation was done early on when creating the dist/ tree was slow but it doesn't pay for itself anymore and was becoming hard to distinguish the different "dist" concepts in the project.
* Artifacts can be declared as belonging to different distributions (default "rocm"), resulting in population of different trees in `build/dist/{distribution}`. This was a TODO from the beginning.
* `{subproject}+dist` now is a convenience target that builds all artifacts the project is a part of and populates the `build/dist/{distname}` directory.
* Distributions (i.e. `build/dist/rocm`) are now populated incrementally as artifact dependencies are met instead of as part of one top level target which requires the whole project to be (re)built.
* New targets `therock-touch` and `therock-dist` are injected into every sub-project, allowing development to be done completely in a sub-project build directory while keeping super-project level artifacts and distributions populated.

This should be NFC for all automation since the new barename targets (dist, archives) are aliased to their originals. We could simplify this in followups.