### PR TITLE
Fix rocm-sdk-devel's manifest

### DIFF
--- a/build_tools/packaging/python/templates/rocm-sdk-devel/MANIFEST.in
+++ b/build_tools/packaging/python/templates/rocm-sdk-devel/MANIFEST.in
@@ -1,2 +1,2 @@
 recursive-include src/* *.tar
-recursive-include src/* *.tar.gz
+recursive-include src/* *.tar.xz


### PR DESCRIPTION
If a compressed tarball is included, this is compressed using XZ-format and not the GNU compression utilities:
https://github.com/ROCm/TheRock/blob/bc413b64743a961841bcb056dce1758d85429798/build_tools/_therock_utils/py_packaging.py#L427-L428
