### PR TITLE
[pytorch/windows] fix aotriton tar extraction to handle UTF8 filenames

### DIFF
--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0001-Include-native_transformers-srcs-to-fix-link-errors.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0001-Include-native_transformers-srcs-to-fix-link-errors.patch
@@ -1,15 +1,14 @@
-From bd9e41913922b372724f31a46fb87d07dfab6d93 Mon Sep 17 00:00:00 2001
+From 7437670ec49462d10b31473408b19088b23d5b36 Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Mon, 11 Aug 2025 13:05:44 -0700
-Subject: [PATCH 4/5] [ROCm][Windows] Include native_transformers srcs to fix
- link errors.
+Subject: [PATCH 1/2] Include native_transformers srcs to fix link errors.
 
 ---
  aten/src/ATen/CMakeLists.txt | 4 ----
  1 file changed, 4 deletions(-)
 
 diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
-index 5f4997357f8..e1939323fc9 100644
+index 5f4997357f..e1939323fc 100644
 --- a/aten/src/ATen/CMakeLists.txt
 +++ b/aten/src/ATen/CMakeLists.txt
 @@ -470,10 +470,6 @@ if(USE_ROCM)
@@ -24,5 +23,5 @@ index 5f4997357f8..e1939323fc9 100644
    # TODO: Codegen separate files for HIP and use those (s/cuda_generated_sources/hip_generated_sources)
    list(APPEND all_hip_cpp
 -- 
-2.45.1.windows.1
+2.50.1.windows.1
 

--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0002-Support-FLASH_ATTENTION-MEM_EFF_ATTENTION-via.-aotri.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0002-Support-FLASH_ATTENTION-MEM_EFF_ATTENTION-via.-aotri.patch
@@ -1,7 +1,7 @@
-From 39a7c6a0645e24ee4be09f21376f4dab50be5667 Mon Sep 17 00:00:00 2001
+From 9bb3a5176853782d8cde5f7a035311b672cf5dda Mon Sep 17 00:00:00 2001
 From: Aaryaman Vasishta <aaryaman.vasishta@amd.com>
 Date: Sun, 10 Aug 2025 00:16:27 +0900
-Subject: [PATCH 5/5] Support FLASH_ATTENTION, MEM_EFF_ATTENTION via. aotriton
+Subject: [PATCH 2/2] Support FLASH_ATTENTION, MEM_EFF_ATTENTION via. aotriton
  on windows
 
 ---
@@ -12,7 +12,7 @@ Subject: [PATCH 5/5] Support FLASH_ATTENTION, MEM_EFF_ATTENTION via. aotriton
  4 files changed, 235 insertions(+), 68 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index cc9476bb001..b5c50bcd60c 100644
+index 9fe3855242..120f2384a0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -872,7 +872,7 @@ cmake_dependent_option(
@@ -34,7 +34,7 @@ index cc9476bb001..b5c50bcd60c 100644
    endif()
  endif()
 diff --git a/aten/src/ATen/native/transformers/hip/attention.hip b/aten/src/ATen/native/transformers/hip/attention.hip
-index 93c523ff71e..c12ac43ce0d 100644
+index 93c523ff71..c12ac43ce0 100644
 --- a/aten/src/ATen/native/transformers/hip/attention.hip
 +++ b/aten/src/ATen/native/transformers/hip/attention.hip
 @@ -97,6 +97,72 @@
@@ -111,7 +111,7 @@ index 93c523ff71e..c12ac43ce0d 100644
  
  namespace cuda::philox {
 diff --git a/aten/src/ATen/native/transformers/hip/flash_attn/flash_api.h b/aten/src/ATen/native/transformers/hip/flash_attn/flash_api.h
-index f6f2240d4f0..71a19590659 100644
+index f6f2240d4f..71a1959065 100644
 --- a/aten/src/ATen/native/transformers/hip/flash_attn/flash_api.h
 +++ b/aten/src/ATen/native/transformers/hip/flash_attn/flash_api.h
 @@ -270,7 +270,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_varle
@@ -168,7 +168,7 @@ index f6f2240d4f0..71a19590659 100644
  inline std::tuple<
      at::Tensor,
 diff --git a/cmake/External/aotriton.cmake b/cmake/External/aotriton.cmake
-index 54564e42c90..fa9beea8026 100644
+index 54564e42c9..40e401154e 100644
 --- a/cmake/External/aotriton.cmake
 +++ b/cmake/External/aotriton.cmake
 @@ -22,7 +22,7 @@ if(NOT __AOTRITON_INCLUDED)
@@ -357,7 +357,7 @@ index 54564e42c90..fa9beea8026 100644
 +        file(REMOVE_RECURSE "${__AOTRITON_TARBALL_EXTRACT_DIR}")
 +        file(MAKE_DIRECTORY "${__AOTRITON_TARBALL_EXTRACT_DIR}")
 +        execute_process(
-+          COMMAND "${CMAKE_COMMAND}" -E tar xf "${__AOTRITON_TARBALL_PATH}"
++          COMMAND tar --options hdrcharset=UTF-8 -xf "${__AOTRITON_TARBALL_PATH}"
 +          WORKING_DIRECTORY "${__AOTRITON_TARBALL_EXTRACT_DIR}"
 +        )
 +
@@ -414,5 +414,5 @@ index 54564e42c90..fa9beea8026 100644
 +endif() # __AOTRITON_INCLUDED
 \ No newline at end of file
 -- 
-2.45.1.windows.1
+2.50.1.windows.1
 


### PR DESCRIPTION
Fixes the invalid value issue reported in https://github.com/ROCm/TheRock/issues/1040#issuecomment-3180225555

The issue was the `cmake -E tar` on Windows didn't handle file paths with unicode characters, even with cmake 4.1.0. Relevant issue cmake side: https://gitlab.kitware.com/cmake/cmake/-/issues/26903

As a workaround, I run the `tar` command directly. It uses `bsdtar` which supports `--options hdrcharset=UTF-8`. It came in my System32 folder on Windows, so I'm hoping the CI is also able to build with this OOTB.