### PR TITLE
Bump `__AOTRITON_CI_COMMIT` to latest.

### DIFF
--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0002-Support-FLASH_ATTENTION-MEM_EFF_ATTENTION-via.-aotri.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0002-Support-FLASH_ATTENTION-MEM_EFF_ATTENTION-via.-aotri.patch
@@ -176,7 +176,7 @@ index 54564e42c9..40e401154e 100644
        "rocm7.0"
        )
 -  set(__AOTRITON_CI_COMMIT "6fca155f4deeb8d9529326f7b69f350aeeb93477")
-+  set(__AOTRITON_CI_COMMIT "e1be21d80b25f46139c2e3b4b0615e0279feccac")
++  set(__AOTRITON_CI_COMMIT "1f9a37cdfbfce218fa0c07f5c0de40403019e168")
    set(__AOTRITON_SHA256_LIST
        "861cd9f7479eec943933c27cb86920247e5b5dd139bc7c1376c81808abb7d7fe"  # rocm6.3
        "acea7d811a2d3bbe718b6e07fc2a9f739e49eecd60b4b6a36fcb3fe8edf85d78"  # rocm6.4


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/1040.

This updates the pin to https://github.com/ROCm/aotriton/commit/1f9a37cdfbfce218fa0c07f5c0de40403019e168, disabling ccache by default on Windows during the aotriton build to work around https://github.com/ccache/ccache/issues/1619.

I can now build with torch with aotriton on my dev machine with a command like:
```
python build_prod_wheels.py build \
  --pytorch-dir D:/b/pytorch_main \
  --pytorch-audio-dir D:/b/audio_main \
  --pytorch-vision-dir D:/b/vision_main \
  --output-dir %HOME%/.therock/pytorch \
  --enable-pytorch-flash-attention-windows \
  --pytorch-rocm-arch gfx1100
```
Note that `--pytorch-rocm-arch gfx1100` is required for the gfx110X family for now, due to errors like:
```
CMake Error at cmake/External/aotriton.cmake:184 (message):
  AOTriton: unsupported arch 'gfx1101'.  Supported:
  gfx1100;gfx1150;gfx1151;gfx1200;gfx1201
```

Tested with a local build + test of [ComfyUI](https://github.com/comfyanonymous/ComfyUI) (image generation template 12.6 it/s without aotriton, 20.0 it/s with it).