### PR TITLE
[ci] - Adding fix for artifact pull

### DIFF
--- a/build_tools/github_actions/upload_build_artifacts.py
+++ b/build_tools/github_actions/upload_build_artifacts.py
@@ -31,7 +31,7 @@ def exec(cmd: list[str], cwd: Path):
 
 def retrieve_bucket_info() -> tuple[str, str]:
     github_repository = os.getenv("GITHUB_REPOSITORY", "ROCm/TheRock")
-    is_pr_from_fork = os.getenv("IS_PR_FROM_FORK", False)
+    is_pr_from_fork = os.getenv("IS_PR_FROM_FORK", "false") == "true"
     owner, repo_name = github_repository.split("/")
     external_repo = (
         ""


### PR DESCRIPTION
Noticed failures in TheRock CI. Due to GitHub's strange typing in workflows, the script always considered pulled artifacts to be external. (boolean for GitHub Actions = string in Python)

This fix pulls the correct artifacts. I decided to do TheRock fix instead of forked fix, since this is easier to test on workflows and prove it is working, since this is breaking the current workflow

working here: https://github.com/ROCm/TheRock/actions/runs/17050492399