### PR TITLE
Add stub workflow for running JAX tests

### DIFF
--- a/.github/workflows/build_jax_dockerfile.yml
+++ b/.github/workflows/build_jax_dockerfile.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         jax_ref: [master]
-    name: Build Linux JAX Docker Images | ${{ inputs.amdgpu_family }} | Python ${{ inputs.python_version }}
+    name: Build | ${{ inputs.amdgpu_family }} | Python ${{ inputs.python_version }}
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
     env:
       PACKAGE_DIST_DIR: ${{ github.workspace }}/jax_rocm_plugin/wheelhouse

--- a/.github/workflows/build_jax_dockerfile.yml
+++ b/.github/workflows/build_jax_dockerfile.yml
@@ -1,0 +1,79 @@
+name: Build Linux JAX Docker Images
+
+on:
+  workflow_call:
+    inputs:
+      amdgpu_family:
+        required: true
+        type: string
+      python_versions:
+        required: true
+        type: string
+      release_type:
+        description: The type of release to build ("nightly", or "dev")
+        required: true
+        type: string
+      s3_subdir:
+        description: S3 subdirectory, not including the GPU-family
+        required: true
+        type: string
+      rocm_version:
+        description: ROCm version to install
+        type: string
+      tar_url:
+        description: URL to TheRock tarball to build against
+        type: string
+  workflow_dispatch:
+    inputs:
+      amdgpu_family:
+        required: true
+        type: string
+      python_versions:
+        required: true
+        type: string
+      release_type:
+        description: The type of release to build ("nightly", or "dev")
+        required: true
+        type: string
+        default: "dev"
+      s3_subdir:
+        description: S3 subdirectory, not including the GPU-family
+        type: string
+        default: "v2"
+      rocm_version:
+        description: ROCm version to install
+        type: string
+      tar_url:
+        description: URL to TheRock tarball to build against
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build_jax_wheels:
+    strategy:
+      matrix:
+        jax_ref: [master]
+    name: Build Linux JAX Docker Images | ${{ inputs.amdgpu_family }} | Python ${{ inputs.python_version }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+    env:
+      PACKAGE_DIST_DIR: ${{ github.workspace }}/jax_rocm_plugin/wheelhouse
+      S3_BUCKET_PY: "therock-${{ inputs.release_type }}-python"
+    steps:
+      - name: Checkout TheRock
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Checkout JAX
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          path: jax
+          repository: rocm/rocm-jax
+          ref: ${{ inputs.jax_ref }}
+
+      - name: Configure Git Identity
+        run: |
+          git config --global user.name "therockbot"
+          git config --global user.email "therockbot@amd.com"
+      # TODO: Pull down JAX plugin wheels into the wheelhouse directory and run the image build script from rocm-jax

--- a/.github/workflows/test_jax_dockerfile.yml
+++ b/.github/workflows/test_jax_dockerfile.yml
@@ -1,0 +1,51 @@
+name: Test JAX Wheels
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_runs_on:
+        required: true
+        type: string
+        default: "linux-mi325-1gpu-ossci-rocm"
+      image_name:
+        required: true
+        description: JAX docker image to run tests with
+      jax_version:
+        description: Version of JAX to install
+        required: false
+      jax_plugin_branch:
+        required: true
+        description: JAX plugin branch to checkout
+        type: string
+        default: "rocm-jaxlib-v0.6.0"
+
+  workflow_call:
+    inputs:
+      test_runs_on:
+        required: true
+        type: string
+      image_name:
+        required: true
+        description: JAX docker image to run tests with
+      jax_version:
+        description: Version of JAX to install instead of the one on the docker image
+        required: false
+      jax_plugin_branch:
+        required: true
+        description: JAX plugin branch to checkout to use for test scripts
+        type: string
+        default: "rocm-jaxlib-v0.6.0"
+
+permissions:
+  contents: read
+
+jobs:
+  test_wheels:
+    name: Test JAX Wheels | ${{ inputs.amdgpu_family }}
+    runs-on: ${{ inputs.test_runs_on }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repo: rocm/rocm-jax
+      # TODO: Add steps for creating the JAX docker image with an install of TheRock and then running JAX tests on the container

--- a/.github/workflows/test_jax_dockerfile.yml
+++ b/.github/workflows/test_jax_dockerfile.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   test_wheels:
-    name: Test JAX Wheels | ${{ inputs.amdgpu_family }}
+    name: Test | ${{ inputs.amdgpu_family }}
     runs-on: ${{ inputs.test_runs_on }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## Motivation

Add a workflow file that will build a JAX docker image and run the JAX unit tests.

## Test Plan

Will run this after it's merged, and then make another PR that fills in the workflow.