### PR TITLE
Extend dependency chain for dist-rocm+expunge target.

### DIFF
--- a/cmake/therock_artifacts.cmake
+++ b/cmake/therock_artifacts.cmake
@@ -192,6 +192,7 @@ function(therock_provide_artifact slice_name)
       "${CMAKE_COMMAND}" -E rm -rf ${_component_dirs}
   )
   add_dependencies(therock-expunge "${_target_name}+expunge")
+  add_dependencies("dist-${ARG_DISTRIBUTION}+expunge" "${_target_name}+expunge")
 
   # For each subproject dep, we add a dependency on its +dist target to also
   # trigger overall artifact construction. In this way `ninja myfoo+dist`


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/1273.

## Technical Details

See the root cause analysis here: https://github.com/ROCm/TheRock/issues/1273#issuecomment-3201603049. The dist/rocm directory is populated by each subproject instead of just by one action. Building `dist-rocm+expunge` did not depend on `archive-{NAME}+expunge` targets so the `build/artifacts/` directories (which are hardlink farms from subproject build directories) were not deleted by building that target.

## Test Plan

1. Build `dist-rocm+expunge`
2. Build `dist-rocm`
3. Observe a populated `dist/rocm/` directory

## Test Result

```
[main] Building folder: D:/projects/TheRock/build dist-rocm+expunge
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build D:/projects/TheRock/build --target dist-rocm+expunge --
[build] [0/2] Re-checking globbed directories...
[build] [1/15] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\third-party\host-blas && "C:\Program Files\CMake\bin\cmake.exe" -E rm -rf D:/projects/TheRock/build/artifacts/host-blas_dbg_generic D:/projects/TheRock/build/artifacts/host-blas_dev_generic D:/projects/TheRock/build/artifacts/host-blas_doc_generic D:/projects/TheRock/build/artifacts/host-blas_lib_generic D:/projects/TheRock/build/artifacts/host-blas_run_generic"
[build] [2/15] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\third-party\sysdeps\windows && "C:\Program Files\CMake\bin\cmake.exe" -E rm -rf D:/projects/TheRock/build/artifacts/sysdeps_dev_generic D:/projects/TheRock/build/artifacts/sysdeps_lib_generic"
[build] [3/15] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\base && "C:\Program Files\CMake\bin\cmake.exe" -E rm -rf D:/projects/TheRock/build/artifacts/base_dbg_generic D:/projects/TheRock/build/artifacts/base_dev_generic D:/projects/TheRock/build/artifacts/base_doc_generic D:/projects/TheRock/build/artifacts/base_lib_generic D:/projects/TheRock/build/artifacts/base_run_generic D:/projects/TheRock/build/artifacts/base_test_generic"
[build] [4/15] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\compiler && "C:\Program Files\CMake\bin\cmake.exe" -E rm -rf D:/projects/TheRock/build/artifacts/hipify_run_generic D:/projects/TheRock/build/artifacts/hipify_dbg_generic"
[build] [5/15] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\core && "C:\Program Files\CMake\bin\cmake.exe" -E rm -rf D:/projects/TheRock/build/artifacts/core-hipinfo_run_generic"
[build] [6/15] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\core && "C:\Program Files\CMake\bin\cmake.exe" -E rm -rf D:/projects/TheRock/build/artifacts/core-hip_dbg_generic D:/projects/TheRock/build/artifacts/core-hip_dev_generic D:/projects/TheRock/build/artifacts/core-hip_doc_generic D:/projects/TheRock/build/artifacts/core-hip_lib_generic D:/projects/TheRock/build/artifacts/core-hip_run_generic"
[build] [7/15] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\math-libs\support && "C:\Program Files\CMake\bin\cmake.exe" -E rm -rf D:/projects/TheRock/build/artifacts/support_dev_gfx110X-dgpu D:/projects/TheRock/build/artifacts/support_doc_gfx110X-dgpu"
[build] [8/15] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\math-libs && "C:\Program Files\CMake\bin\cmake.exe" -E rm -rf D:/projects/TheRock/build/artifacts/fft_dbg_gfx110X-dgpu D:/projects/TheRock/build/artifacts/fft_dev_gfx110X-dgpu D:/projects/TheRock/build/artifacts/fft_doc_gfx110X-dgpu D:/projects/TheRock/build/artifacts/fft_lib_gfx110X-dgpu D:/projects/TheRock/build/artifacts/fft_run_gfx110X-dgpu"
[build] [9/15] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\math-libs && "C:\Program Files\CMake\bin\cmake.exe" -E rm -rf D:/projects/TheRock/build/artifacts/rand_dbg_gfx110X-dgpu D:/projects/TheRock/build/artifacts/rand_dev_gfx110X-dgpu D:/projects/TheRock/build/artifacts/rand_doc_gfx110X-dgpu D:/projects/TheRock/build/artifacts/rand_lib_gfx110X-dgpu D:/projects/TheRock/build/artifacts/rand_run_gfx110X-dgpu D:/projects/TheRock/build/artifacts/rand_test_gfx110X-dgpu"
[build] [10/15] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\ml-libs && "C:\Program Files\CMake\bin\cmake.exe" -E rm -rf D:/projects/TheRock/build/artifacts/miopen_dbg_gfx110X-dgpu D:/projects/TheRock/build/artifacts/miopen_dev_gfx110X-dgpu D:/projects/TheRock/build/artifacts/miopen_doc_gfx110X-dgpu D:/projects/TheRock/build/artifacts/miopen_lib_gfx110X-dgpu D:/projects/TheRock/build/artifacts/miopen_run_gfx110X-dgpu D:/projects/TheRock/build/artifacts/miopen_test_gfx110X-dgpu"
[build] [11/15] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\math-libs && "C:\Program Files\CMake\bin\cmake.exe" -E rm -rf D:/projects/TheRock/build/artifacts/prim_dbg_gfx110X-dgpu D:/projects/TheRock/build/artifacts/prim_dev_gfx110X-dgpu D:/projects/TheRock/build/artifacts/prim_doc_gfx110X-dgpu D:/projects/TheRock/build/artifacts/prim_test_gfx110X-dgpu"
[build] [12/15] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\math-libs\BLAS && "C:\Program Files\CMake\bin\cmake.exe" -E rm -rf D:/projects/TheRock/build/artifacts/blas_dbg_gfx110X-dgpu D:/projects/TheRock/build/artifacts/blas_dev_gfx110X-dgpu D:/projects/TheRock/build/artifacts/blas_doc_gfx110X-dgpu D:/projects/TheRock/build/artifacts/blas_lib_gfx110X-dgpu D:/projects/TheRock/build/artifacts/blas_run_gfx110X-dgpu D:/projects/TheRock/build/artifacts/blas_test_gfx110X-dgpu"
[build] [13/15] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\compiler && "C:\Program Files\CMake\bin\cmake.exe" -E rm -rf D:/projects/TheRock/build/artifacts/amd-llvm_dbg_generic D:/projects/TheRock/build/artifacts/amd-llvm_dev_generic D:/projects/TheRock/build/artifacts/amd-llvm_doc_generic D:/projects/TheRock/build/artifacts/amd-llvm_lib_generic D:/projects/TheRock/build/artifacts/amd-llvm_run_generic"
[build] [14/15] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\third-party\host-blas && "C:\Program Files\CMake\bin\cmake.exe" -E rm -rf D:/projects/TheRock/build/dist/rocm"
[driver] Build completed: 00:00:01.240
[build] Build finished with exit code 0

[main] Building folder: D:/projects/TheRock/build dist-rocm
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build D:/projects/TheRock/build --target dist-rocm --
[build] [0/2] Re-checking globbed directories...
[build] [1/14] Populate artifact core-hipinfo
[build] [2/14] Populate artifact hipify
[build] [3/14] Populate artifact sysdeps
[build] [4/14] Populate artifact support
[build] [5/14] Populate artifact host-blas
[build] [6/14] Populate artifact fft
[build] [7/14] Populate artifact core-hip
[build] [8/14] Populate artifact miopen
[build] [9/14] Populate artifact rand
[build] [10/14] Populate artifact base
[build] [11/14] Populate artifact prim
[build] [12/14] Populate artifact blas
[build] [13/14] Populate artifact amd-llvm
[driver] Build completed: 00:00:03.099
[build] Build finished with exit code 0

λ ls D:\projects\TheRock\build\dist\rocm
bin/  clients/  cmake/  include/  lib/  libexec/  share/
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
