### PR TITLE
[windows] Add hipInfo to Python packages and improve docs.

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -80,6 +80,7 @@ def core_artifact_filter(an: ArtifactName) -> bool:
         "amd-llvm",
         "base",
         "core-hip",
+        "core-hipinfo",
         "core-runtime",
         "host-blas",
         "host-suite-sparse",

--- a/build_tools/buildctl.py
+++ b/build_tools/buildctl.py
@@ -73,7 +73,7 @@ def do_enable_disable(args: argparse.Namespace, enable_mode: bool):
     changed = False
     print("Projects marked with an 'X' will be build enabled:")
     for rp, include in selection:
-        stage_dir = build_dir / PosixPath(rp)
+        stage_dir = build_dir / Path(rp).as_posix()
         prebuilt_file = stage_dir.with_name(stage_dir.name + ".prebuilt")
         if not is_valid_stage_dir(stage_dir):
             action = (False, "(EMPTY)")

--- a/build_tools/buildctl.py
+++ b/build_tools/buildctl.py
@@ -59,7 +59,7 @@ TODO: Merge the functionality in bootstrap_build.py into this script.
 """
 
 import argparse
-from pathlib import Path, PosixPath
+from pathlib import Path
 import os
 import re
 import subprocess

--- a/build_tools/packaging/python/templates/rocm-sdk-core/setup.py
+++ b/build_tools/packaging/python/templates/rocm-sdk-core/setup.py
@@ -74,7 +74,7 @@ setup(
             ]
             if platform.system() != "Windows"
             else [
-                # TODO(#600): add hipInfo on Windows
+                "hipInfo=rocm_sdk_core._cli:hipInfo",
             ]
         ),
     },

--- a/build_tools/packaging/python/templates/rocm-sdk-core/src/rocm_sdk_core/_cli.py
+++ b/build_tools/packaging/python/templates/rocm-sdk-core/src/rocm_sdk_core/_cli.py
@@ -55,6 +55,10 @@ def hipconfig():
     _exec("bin/hipconfig")
 
 
+def hipInfo():
+    _exec("bin/hipInfo")
+
+
 def rocm_agent_enumerator():
     _exec("bin/rocm_agent_enumerator")
 

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import platform
 import subprocess
 import sys
-import sysconfig
 import unittest
 
 from .. import _dist_info as di
@@ -23,15 +22,13 @@ utils.assert_is_physical_package(core_mod)
 so_paths = utils.get_module_shared_libraries(core_mod)
 is_windows = platform.system() == "Windows"
 
-LINUX_CONSOLE_SCRIPT_TESTS = [
-    # These currently only have unprefixed names (e.g. 'clang') on Windows.
-    # These tools are only available on Linux.
-    ("rocm_agent_enumerator", [], "", True),
-    ("rocminfo", [], "", True),
-    ("rocm-smi", [], "Management", True),
-]
-
-CONSOLE_SCRIPT_TESTS = [
+# Console script tests are templated across tuples of
+#   (script_name, cl, expected_text, required)
+# For example:
+#   ("hipcc", ["--help"], "clang LLVM compiler", True)
+#   This will run `hipcc --help` and check the output for "clang LLVM compiler".
+#   If the script does not exist, the test case will fail.
+COMMON_CONSOLE_SCRIPT_TESTS = [
     ("amdclang", ["--help"], "clang LLVM compiler", True),
     ("amdclang++", ["--help"], "clang LLVM compiler", True),
     ("amdclang-cpp", ["--help"], "clang LLVM compiler", True),
@@ -40,7 +37,21 @@ CONSOLE_SCRIPT_TESTS = [
     ("amdlld", ["-flavor", "ld.lld", "--help"], "USAGE:", True),
     ("hipcc", ["--help"], "clang LLVM compiler", True),
     ("hipconfig", [], "HIP version:", True),
-] + (LINUX_CONSOLE_SCRIPT_TESTS if not is_windows else [])
+]
+
+LINUX_CONSOLE_SCRIPT_TESTS = [
+    ("rocm_agent_enumerator", [], "", True),
+    ("rocminfo", [], "", True),
+    ("rocm-smi", [], "Management", True),
+]
+
+WINDOWS_CONSOLE_SCRIPT_TESTS = [
+    ("hipInfo", [], "", True),
+]
+
+CONSOLE_SCRIPT_TESTS = COMMON_CONSOLE_SCRIPT_TESTS + (
+    WINDOWS_CONSOLE_SCRIPT_TESTS if is_windows else LINUX_CONSOLE_SCRIPT_TESTS
+)
 
 
 class ROCmCoreTest(unittest.TestCase):

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -39,6 +39,7 @@ mainline, in open source, using MSVC, etc.).
 |                     |                                                                              |           |                                               |
 | core                | [ROCR-Runtime](https://github.com/ROCm/ROCR-Runtime)                         | ❌        | Unsupported                                   |
 | core                | [rocminfo](https://github.com/ROCm/rocminfo)                                 | ❌        | Unsupported                                   |
+| core                | [hipInfo from hip-tests](https://github.com/ROCm/hip-tests)                  | ✅        |                                               |
 | core                | [clr](https://github.com/ROCm/clr)                                           | 🟡        | Needs a folder with prebuilt static libraries |
 |                     |                                                                              |           |                                               |
 | profiler            | [rocprofiler-sdk](https://github.com/ROCm/rocprofiler-sdk)                   | ❌        | Unsupported                                   |

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -154,14 +154,14 @@ If you prefer to install tools manually, you will need:
 - (Optional) ccache: https://ccache.dev/, or sccache:
   https://github.com/mozilla/sccache
 
+- gfortran, recommended from Strawberry Perl: https://strawberryperl.com/
+
 - Python: https://www.python.org/downloads/ (3.11+ recommended)
 
-  > [!WARNING]
-  > Prefer to install Python for the current user only and to a path
-  > **without spaces** like
-  > `C:\Users\<username>\AppData\Local\Programs\Python\Python312`.
-
-- Strawberry Perl, which comes with gfortran: https://strawberryperl.com/
+> [!WARNING]
+> Prefer to install Python for the current user only and to a path
+> **without spaces** like
+> `C:\Users\<username>\AppData\Local\Programs\Python\Python312`.
 
 #### Important tool settings
 

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -59,7 +59,7 @@ of accidentally referencing too-new glibc symbols).
 
 To install locally built packages you can either
 
-1. Directly install the wheels by file name:
+1. Directly install the Python packages by file name:
 
    ```bash
    python3 -m venv .venv && source .venv/bin/activate

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -49,13 +49,36 @@ built-in tests (via `rocm-sdk test`) verify these conditions.
 ```bash
 ./build_tools/build_python_packages.py \
     --artifact-dir ./output-linux-portable/build/artifacts \
-    --dest-dir $HOME/tmp/packages
+    --dest-dir ${HOME}/tmp/packages
 ```
 
 Note that this does do some dynamic compilation of files and it performs
 patching via patchelf. On Linux, it is recommended to run this in the same
 portable container as was used to build the SDK (so as to avoid the possibility
 of accidentally referencing too-new glibc symbols).
+
+To install locally built packages you can either
+
+1. Directly install the wheels by file name:
+
+   ```bash
+   python3 -m venv .venv && source .venv/bin/activate
+   pip install ${HOME}/tmp/packages/dist/rocm-7.0.0.dev0.tar.gz \
+               ${HOME}/tmp/packages/dist/rocm_sdk_core-7.0.0.dev0-py3-none-linux_x86_64.whl
+   # Optionally install rocm_sdk_devel and rocm_sdk_libraries wheels
+   ```
+
+1. Generate a local index using [piprepo](https://pypi.org/project/piprepo/) and
+   install using more natural package names:
+
+   ```
+   python3 -m venv .venv && source .venv/bin/activate
+   pip install piprepo setuptools
+   piprepo build ${HOME}/tmp/packages/dist
+   pip install rocm[libraries,devel]==7.0.0.dev0 \
+     --extra-index-url ${HOME}/tmp/packages/dist/simple \
+     --force-reinstall --no-cache-dir
+   ```
 
 ## Using Packages from Frameworks
 


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/600, follow-up to https://github.com/ROCm/TheRock/pull/1216.

## Technical Details

* Include hipInfo artifacts during Python wheel generation
* Add console script entry point for hipInfo
* Add console script test case (not checking any output since the test can run on a system with no GPU)
* Expanded on docs for how to use the output of `build_tools/build_python_packages.py`
* Minor fix for `build_tools/buildctl.py` on Windows, which I used for testing (more docs to come on that)

Separately I looked at https://github.com/ROCm/TheRock/blob/main/patches/amd-mainline/rocm-libraries/0018-Revert-remove-options-no-enumerate-966.patch to see if we can drop that patch now that we build `hipInfo`. See https://github.com/ROCm/TheRock/pull/1281 for that.

## Test Plan

Built Python packages locally, ran `hipinfo`, ran `rocm-sdk test`

## Test Result

```
D:\scratch\therock
(3.13.venv) λ hipinfo


D:\scratch\therock
(3.13.venv) λ HIP Library Path: D:\scratch\therock\3.13.venv\Lib\site-packages\_rocm_sdk_core\bin\amdhip64_7.dll
--------------------------------------------------------------------------------
device#                           0
Name:                             AMD Radeon PRO W7900 Dual Slot
pciBusID:                         35
pciDeviceID:                      0
pciDomainID:                      0
multiProcessorCount:              48
maxThreadsPerMultiProcessor:      2048
isMultiGpuBoard:                  0
clockRate:                        1760 Mhz
memoryClockRate:                  1125 Mhz
memoryBusWidth:                   192
totalGlobalMem:                   44.98 GB
totalConstMem:                    2147483647
...
```

(the process returning and a new process starting matches other scripts and is by design with https://docs.python.org/3/library/os.html#os.execv... maybe we can rework that somehow)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
