### PR TITLE
Add vcpkg and OpenMPI

### DIFF
--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -94,3 +94,19 @@ RUN which gcc && gcc --version && \
 # We use the wildcard option to disable the checks. This was added
 # in git 2.35.3
 RUN git config --global --add safe.directory '*'
+
+######## vcpkg ########
+WORKDIR /opt
+ENV VCPKG_HASH="3f5ad7be7693ce6ac5599ddb7cc24f260b9d44f9"
+COPY install_vcpkg.sh ./
+RUN yum install -y zip unzip
+RUN ./install_vcpkg.sh "${VCPKG_HASH}"
+
+######## OpenMPI ########
+RUN /opt/vcpkg/vcpkg install openmpi:x64-linux
+ENV PATH="/opt/vcpkg/installed/x64-linux/tools/openmpi/bin:${PATH}"
+ENV PKG_CONFIG_PATH="/opt/vcpkg/installed/x64-linux/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+ENV LD_LIBRARY_PATH="/opt/vcpkg/installed/x64-linux/lib:${LD_LIBRARY_PATH}"
+
+RUN which mpicc && mpirun && \
+    mpirun --version || true

--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -96,6 +96,8 @@ RUN which gcc && gcc --version && \
 RUN git config --global --add safe.directory '*'
 
 ######## vcpkg ########
+# vcpkg is used to install OpenMPI and can be dropped once the latter
+# is vendored into TheRock.
 WORKDIR /opt
 ENV VCPKG_HASH="3f5ad7be7693ce6ac5599ddb7cc24f260b9d44f9"
 COPY install_vcpkg.sh ./
@@ -103,6 +105,8 @@ RUN yum install -y zip unzip
 RUN ./install_vcpkg.sh "${VCPKG_HASH}"
 
 ######## OpenMPI ########
+# OpenMPI is currently not vendored into TheRock and temorarily installed
+# via vcpkg: https://github.com/ROCm/TheRock/issues/1284
 RUN /opt/vcpkg/vcpkg install openmpi:x64-linux
 ENV PATH="/opt/vcpkg/installed/x64-linux/tools/openmpi/bin:${PATH}"
 ENV PKG_CONFIG_PATH="/opt/vcpkg/installed/x64-linux/lib/pkgconfig:${PKG_CONFIG_PATH:-}"

--- a/dockerfiles/install_vcpkg.sh
+++ b/dockerfiles/install_vcpkg.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright 2025 Advanced Micro Devices, Inc.
+
+set -euo pipefail
+
+VCPKG_HASH="$1"
+
+git clone https://github.com/microsoft/vcpkg.git
+cd vcpkg
+git -c advice.detachedHead=false checkout ${VCPKG_HASH}
+./bootstrap-vcpkg.sh


### PR DESCRIPTION
Adds vcpkg to the Dockerfile to use it for installing OpenMPI until it is added to TheRock.