### PR TITLE
[torch] Revert intel-openmp dependency change.

### DIFF
--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0001-Include-native_transformers-srcs-to-fix-link-errors.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0001-Include-native_transformers-srcs-to-fix-link-errors.patch
@@ -1,14 +1,14 @@
-From 7437670ec49462d10b31473408b19088b23d5b36 Mon Sep 17 00:00:00 2001
+From 164836b8f966b4ed6afd499e5dc6fd71aeb02298 Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Mon, 11 Aug 2025 13:05:44 -0700
-Subject: [PATCH 1/2] Include native_transformers srcs to fix link errors.
+Subject: [PATCH 1/3] Include native_transformers srcs to fix link errors.
 
 ---
  aten/src/ATen/CMakeLists.txt | 4 ----
  1 file changed, 4 deletions(-)
 
 diff --git a/aten/src/ATen/CMakeLists.txt b/aten/src/ATen/CMakeLists.txt
-index 5f4997357f..e1939323fc 100644
+index 5f4997357f8..e1939323fc9 100644
 --- a/aten/src/ATen/CMakeLists.txt
 +++ b/aten/src/ATen/CMakeLists.txt
 @@ -470,10 +470,6 @@ if(USE_ROCM)
@@ -23,5 +23,5 @@ index 5f4997357f..e1939323fc 100644
    # TODO: Codegen separate files for HIP and use those (s/cuda_generated_sources/hip_generated_sources)
    list(APPEND all_hip_cpp
 -- 
-2.50.1.windows.1
+2.47.1.windows.2
 

--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0002-Support-FLASH_ATTENTION-MEM_EFF_ATTENTION-via.-aotri.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0002-Support-FLASH_ATTENTION-MEM_EFF_ATTENTION-via.-aotri.patch
@@ -1,7 +1,7 @@
-From 9bb3a5176853782d8cde5f7a035311b672cf5dda Mon Sep 17 00:00:00 2001
+From a7483e33408b05e622d6be3b43e4357e4121ffbc Mon Sep 17 00:00:00 2001
 From: Aaryaman Vasishta <aaryaman.vasishta@amd.com>
 Date: Sun, 10 Aug 2025 00:16:27 +0900
-Subject: [PATCH 2/2] Support FLASH_ATTENTION, MEM_EFF_ATTENTION via. aotriton
+Subject: [PATCH 2/3] Support FLASH_ATTENTION, MEM_EFF_ATTENTION via. aotriton
  on windows
 
 ---
@@ -12,7 +12,7 @@ Subject: [PATCH 2/2] Support FLASH_ATTENTION, MEM_EFF_ATTENTION via. aotriton
  4 files changed, 235 insertions(+), 68 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9fe3855242..120f2384a0 100644
+index 9fe3855242e..120f2384a0a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -872,7 +872,7 @@ cmake_dependent_option(
@@ -34,7 +34,7 @@ index 9fe3855242..120f2384a0 100644
    endif()
  endif()
 diff --git a/aten/src/ATen/native/transformers/hip/attention.hip b/aten/src/ATen/native/transformers/hip/attention.hip
-index 93c523ff71..c12ac43ce0 100644
+index 93c523ff71e..c12ac43ce0d 100644
 --- a/aten/src/ATen/native/transformers/hip/attention.hip
 +++ b/aten/src/ATen/native/transformers/hip/attention.hip
 @@ -97,6 +97,72 @@
@@ -111,7 +111,7 @@ index 93c523ff71..c12ac43ce0 100644
  
  namespace cuda::philox {
 diff --git a/aten/src/ATen/native/transformers/hip/flash_attn/flash_api.h b/aten/src/ATen/native/transformers/hip/flash_attn/flash_api.h
-index f6f2240d4f..71a1959065 100644
+index f6f2240d4f0..71a19590659 100644
 --- a/aten/src/ATen/native/transformers/hip/flash_attn/flash_api.h
 +++ b/aten/src/ATen/native/transformers/hip/flash_attn/flash_api.h
 @@ -270,7 +270,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_varle
@@ -168,7 +168,7 @@ index f6f2240d4f..71a1959065 100644
  inline std::tuple<
      at::Tensor,
 diff --git a/cmake/External/aotriton.cmake b/cmake/External/aotriton.cmake
-index 54564e42c9..40e401154e 100644
+index 54564e42c90..1580373cf31 100644
 --- a/cmake/External/aotriton.cmake
 +++ b/cmake/External/aotriton.cmake
 @@ -22,7 +22,7 @@ if(NOT __AOTRITON_INCLUDED)
@@ -414,5 +414,5 @@ index 54564e42c9..40e401154e 100644
 +endif() # __AOTRITON_INCLUDED
 \ No newline at end of file
 -- 
-2.50.1.windows.1
+2.47.1.windows.2
 

--- a/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0003-Revert-inductor-Windows-inductor-use-intel-openmp.-1.patch
+++ b/external-builds/pytorch/patches/pytorch/main/pytorch/hipified/0003-Revert-inductor-Windows-inductor-use-intel-openmp.-1.patch
@@ -1,0 +1,64 @@
+From 3e03542f92b4702e10655133d8dff04bbc771f53 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Tue, 19 Aug 2025 15:51:55 -0700
+Subject: [PATCH 3/3] Revert "[inductor] Windows inductor use intel-openmp.
+ (#160258)"
+
+This reverts commit 41673110cd7c5960824cc74a6fcaeda1a8bc7a23.
+---
+ setup.py                       |  1 -
+ torch/_inductor/cpp_builder.py | 18 ++++++------------
+ 2 files changed, 6 insertions(+), 13 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 9ae29fc8fd2..203e09f1b73 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1588,7 +1588,6 @@ def main() -> None:
+         "networkx>=2.5.1",
+         "jinja2",
+         "fsspec>=0.8.5",
+-        'intel-openmp==2025.1.1 ;platform_system == "Windows" ',  # for Windows inductor
+     ]
+     if BUILD_PYTHON_ONLY:
+         install_requires += [f"{LIBTORCH_PKG_NAME}=={TORCH_VERSION}"]
+diff --git a/torch/_inductor/cpp_builder.py b/torch/_inductor/cpp_builder.py
+index 74f45583ccd..c58849f9bf5 100644
+--- a/torch/_inductor/cpp_builder.py
++++ b/torch/_inductor/cpp_builder.py
+@@ -910,15 +910,8 @@ def _get_python_related_args() -> tuple[list[str], list[str]]:
+             str(
+                 (
+                     Path(sysconfig.get_path("include", scheme="nt")).parent / "libs"
+-                ).absolute()  # python[ver].lib
+-            ),
+-            str(
+-                (
+-                    Path(sysconfig.get_path("include", scheme="nt")).parent
+-                    / "Library"
+-                    / "lib"
+-                ).absolute()  # install python librarys location, such as intel-openmp
+-            ),
++                ).absolute()
++            )
+         ]
+     else:
+         python_lib_path = [sysconfig.get_config_var("LIBDIR")]
+@@ -1084,10 +1077,11 @@ def _get_openmp_args(
+             libs.append("libiomp5md")
+             perload_icx_libomp_win(cpp_compiler)
+         else:
++            # /openmp, /openmp:llvm
++            # llvm on Windows, new openmp: https://devblogs.microsoft.com/cppblog/msvc-openmp-update/
++            # msvc openmp: https://learn.microsoft.com/zh-cn/cpp/build/reference/openmp-enable-openmp-2-0-support?view=msvc-170
+             cflags.append("openmp")
+-            cflags.append("openmp:experimental")
+-            libs.append("libiomp5md")  # intel-openmp
+-            ldflags.append("nodefaultlib:vcomp")
++            cflags.append("openmp:experimental")  # MSVC CL
+     else:
+         if config.is_fbcode():
+             include_dir_paths.append(build_paths.openmp_include)
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/1257 and https://github.com/ROCm/TheRock/issues/1261 and expected to fix errors like on

* https://github.com/ROCm/TheRock/actions/runs/17069813390/job/48400376426#step:6:64

  `ERROR: Could not find a version that satisfies the requirement intel-cmplr-lib-ur==2025.1.1 (from intel-openmp) (from versions: none)`
* https://github.com/ROCm/TheRock/actions/runs/16965353747/job/48092417765#step:6:53

  `ERROR: Could not find a version that satisfies the requirement intel-openmp==2025.1.1; platform_system == "Windows" (from torch) (from versions: none)`

## Technical Details

The upstream PR https://github.com/pytorch/pytorch/pull/160258 is under consideration to be reverted or reworked but the fix-forward PR https://github.com/pytorch/pytorch/pull/160976 is not yet working/ready/merged. That PR added a new dep on `intel-openmp` for all Windows PyTorch wheels when it should probably remain isolated to `torch_xpu` (Intel XPU) wheels, which already include the dep.

We should also be able to drop `intel-openmp` and any other deps that are isolated to `torch_xpu` in https://github.com/pytorch/test-infra/blob/main/s3_management/update_dependencies.py from our local version of that script (https://github.com/ROCm/TheRock/blob/main/build_tools/third_party/s3_management/update_dependencies.py, recently updated in https://github.com/ROCm/TheRock/pull/1266).

## Test Plan

Watch https://github.com/ROCm/TheRock/actions/workflows/release_windows_pytorch_wheels.yml?query=branch%3Amain to see if tests start working on gfx1151 again.

We will need to revert this (i.e. drop the patch) once upstream gets moving.

## Test Result

(test in prod)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
