### PR TITLE
Remove `intel-openmp` from dependencies

### DIFF
--- a/build_tools/third_party/s3_management/update_dependencies.py
+++ b/build_tools/third_party/s3_management/update_dependencies.py
@@ -32,7 +32,6 @@ PACKAGES_PER_PROJECT = {
     "filelock": {"version": "latest", "project": "torch"},
     "fsspec": {"version": "latest", "project": "torch"},
     "typing-extensions": {"version": "latest", "project": "torch"},
-    "intel-openmp": {"version": "2025.1.1", "project": "torch"},
     "setuptools": {"version": "latest", "project": "rocm"},
 }
 


### PR DESCRIPTION
Follow up to commit 1040aab which reverted the upstream change locally until the dependency on intel-openmp is resolved upstream.