### PR TITLE
Fix syntax errors in test_jax_dockerfile.yml.

### DIFF
--- a/.github/workflows/test_jax_dockerfile.yml
+++ b/.github/workflows/test_jax_dockerfile.yml
@@ -10,9 +10,11 @@ on:
       image_name:
         required: true
         description: JAX docker image to run tests with
+        type: string
       jax_version:
         description: Version of JAX to install
         required: false
+        type: string
       jax_plugin_branch:
         required: true
         description: JAX plugin branch to checkout
@@ -27,9 +29,11 @@ on:
       image_name:
         required: true
         description: JAX docker image to run tests with
+        type: string
       jax_version:
         description: Version of JAX to install instead of the one on the docker image
         required: false
+        type: string
       jax_plugin_branch:
         required: true
         description: JAX plugin branch to checkout to use for test scripts


### PR DESCRIPTION
Context: https://github.com/ROCm/TheRock/pull/1277#discussion_r2288768088

> There are syntax errors in this file, so the workflow is failing to parse and is trying to run: https://github.com/ROCm/TheRock/actions/workflows/test_jax_dockerfile.yml
> 
> https://github.com/ROCm/TheRock/actions/runs/17104558085
> 
> ```
>  Invalid workflow file: .github/workflows/test_jax_dockerfile.yml#L1
> (Line: 28, Col: 9): Required property is missing: type, (Line: 31, Col: 9): Required property is missing: type
> ```