### PR TITLE
[doc] Switch artifact fetch instructions to a more recent workflow run.

### DIFF
--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -172,19 +172,21 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
 
 - Building the rocm Python packages from artifacts fetched from a CI run:
 
+  <!-- TODO: teach scripts to look up latest stable run and mkdir themselves -->
+
   ```bash
   # From the repository root
-  mkdir $HOME/.therock/15914707463
-  mkdir $HOME/.therock/15914707463/artifacts
+  mkdir $HOME/.therock/17123441166
+  mkdir $HOME/.therock/17123441166/artifacts
   python ./build_tools/fetch_artifacts.py \
-    --run-id=15914707463 \
+    --run-id=17123441166 \
     --target=gfx110X-dgpu \
-    --output-dir=$HOME/.therock/15914707463/artifacts \
+    --output-dir=$HOME/.therock/17123441166/artifacts \
     --all
 
   python ./build_tools/build_python_packages.py \
-    --artifact-dir=$HOME/.therock/15914707463/artifacts \
-    --dest-dir=$HOME/.therock/15914707463/packages
+    --artifact-dir=$HOME/.therock/17123441166/artifacts \
+    --dest-dir=$HOME/.therock/17123441166/packages
   ```
 
 - Building the rocm Python packages from artifacts built from source:


### PR DESCRIPTION
Following up on https://github.com/ROCm/TheRock/pull/1269#discussion_r2291240329. The previous artifact link used `composable_kernel` as an artifact name which did not include the fix to `composable-kernel` by https://github.com/ROCm/TheRock/pull/936. A better solution here will be to have the scripts fetch the latest stable artifacts instead of suggesting users pick an exact workflow run id.

Tested locally on Windows (substituting `$HOME` for `%HOME%`).