### PR TITLE
[doc] Suggest installing torchvision and torchaudio.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -188,15 +188,15 @@ framework.
 > [!WARNING]
 > This is under **active** development.
 
-Using the index pages listed above, you can install `torch` instead of
-`rocm[libraries,devel]`:
+Using the index pages listed above, you can install `torch`, `torchaudio`, and
+`torchvision` instead of `rocm[libraries,devel]`:
 
 #### gfx94X-dcgpu
 
 ```bash
 python -m pip install \
   --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx94X-dcgpu/ \
-  torch
+  torch torchaudio torchvision
 ```
 
 #### gfx950-dcgpu
@@ -204,7 +204,7 @@ python -m pip install \
 ```bash
 python -m pip install \
   --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx950-dcgpu/ \
-  torch
+  torch torchaudio torchvision
 ```
 
 #### gfx110X-dgpu
@@ -212,7 +212,7 @@ python -m pip install \
 ```bash
 python -m pip install \
   --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ \
-  torch
+  torch torchaudio torchvision
 ```
 
 #### gfx1151
@@ -220,7 +220,7 @@ python -m pip install \
 ```bash
 python -m pip install \
   --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx1151/ \
-  torch
+  torch torchaudio torchvision
 ```
 
 #### gfx120X-all
@@ -228,7 +228,7 @@ python -m pip install \
 ```bash
 python -m pip install \
   --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx120X-all/ \
-  torch
+  torch torchaudio torchvision
 ```
 
 ### Using PyTorch Python packages


### PR DESCRIPTION
These should generally be installed together from the same release index. If these are not installed by the time you try to install from pypi (e.g. via https://github.com/comfyanonymous/ComfyUI/blob/master/requirements.txt), you can run into pip dependency resolution errors like this:
```
(3.12.venv) λ pip install -r D:\projects\ComfyUI\requirements.txt
Requirement already satisfied: comfyui-frontend-package==1.25.9 in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 1)) (1.25.9)
Requirement already satisfied: comfyui-workflow-templates==0.1.62 in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 2)) (0.1.62)
Requirement already satisfied: comfyui-embedded-docs==0.2.6 in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 3)) (0.2.6)
Requirement already satisfied: torch in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 4)) (2.9.0a0+rocm7.0.0rc20250820)
Collecting torchsde (from -r D:\projects\ComfyUI\requirements.txt (line 5))
  Using cached torchsde-0.2.6-py3-none-any.whl.metadata (5.3 kB)
Collecting torchvision (from -r D:\projects\ComfyUI\requirements.txt (line 6))
  Using cached torchvision-0.23.0-cp312-cp312-win_amd64.whl.metadata (6.1 kB)
Requirement already satisfied: numpy>=1.25.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 8)) (2.3.2)
Requirement already satisfied: einops in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 9)) (0.8.1)
Requirement already satisfied: transformers>=4.37.2 in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 10)) (4.55.3)
Requirement already satisfied: tokenizers>=0.13.3 in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 11)) (0.21.4)
Requirement already satisfied: sentencepiece in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 12)) (0.2.1)
Requirement already satisfied: safetensors>=0.4.2 in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 13)) (0.6.2)
Requirement already satisfied: aiohttp>=3.11.8 in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 14)) (3.12.15)
Requirement already satisfied: yarl>=1.18.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 15)) (1.20.1)
Requirement already satisfied: pyyaml in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 16)) (6.0.2)
Requirement already satisfied: Pillow in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 17)) (11.3.0)
Requirement already satisfied: scipy in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 18)) (1.16.1)
Requirement already satisfied: tqdm in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 19)) (4.67.1)
Requirement already satisfied: psutil in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 20)) (7.0.0)
Requirement already satisfied: alembic in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 21)) (1.16.4)
Requirement already satisfied: SQLAlchemy in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 22)) (2.0.43)
Requirement already satisfied: av>=14.2.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 23)) (15.0.0)
Requirement already satisfied: kornia>=0.7.1 in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 26)) (0.8.1)
Requirement already satisfied: soundfile in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 28)) (0.13.1)
Requirement already satisfied: pydantic~=2.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 29)) (2.11.7)
Requirement already satisfied: pydantic-settings~=2.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from -r D:\projects\ComfyUI\requirements.txt (line 30)) (2.10.1)
Requirement already satisfied: filelock in d:\scratch\therock\3.12.venv\lib\site-packages (from torch->-r D:\projects\ComfyUI\requirements.txt (line 4)) (3.19.1)
Requirement already satisfied: typing-extensions>=4.10.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from torch->-r D:\projects\ComfyUI\requirements.txt (line 4)) (4.14.1)
Requirement already satisfied: setuptools in d:\scratch\therock\3.12.venv\lib\site-packages (from torch->-r D:\projects\ComfyUI\requirements.txt (line 4)) (80.9.0)
Requirement already satisfied: sympy>=1.13.3 in d:\scratch\therock\3.12.venv\lib\site-packages (from torch->-r D:\projects\ComfyUI\requirements.txt (line 4)) (1.14.0)
Requirement already satisfied: networkx>=2.5.1 in d:\scratch\therock\3.12.venv\lib\site-packages (from torch->-r D:\projects\ComfyUI\requirements.txt (line 4)) (3.5)
Requirement already satisfied: jinja2 in d:\scratch\therock\3.12.venv\lib\site-packages (from torch->-r D:\projects\ComfyUI\requirements.txt (line 4)) (3.1.6)
Requirement already satisfied: fsspec>=0.8.5 in d:\scratch\therock\3.12.venv\lib\site-packages (from torch->-r D:\projects\ComfyUI\requirements.txt (line 4)) (2025.7.0)
Requirement already satisfied: rocm==7.0.0rc20250820 in d:\scratch\therock\3.12.venv\lib\site-packages (from rocm[libraries]==7.0.0rc20250820->torch->-r D:\projects\ComfyUI\requirements.txt (line 4)) (7.0.0rc20250820)
Requirement already satisfied: rocm-sdk-core==7.0.0rc20250820 in d:\scratch\therock\3.12.venv\lib\site-packages (from rocm==7.0.0rc20250820->rocm[libraries]==7.0.0rc20250820->torch->-r D:\projects\ComfyUI\requirements.txt (line 4)) (7.0.0rc20250820)
Requirement already satisfied: rocm-sdk-libraries-gfx110X-dgpu==7.0.0rc20250820 in d:\scratch\therock\3.12.venv\lib\site-packages (from rocm[libraries]==7.0.0rc20250820->torch->-r D:\projects\ComfyUI\requirements.txt (line 4)) (7.0.0rc20250820)
Collecting trampoline>=0.1.2 (from torchsde->-r D:\projects\ComfyUI\requirements.txt (line 5))
  Using cached trampoline-0.1.2-py3-none-any.whl.metadata (10 kB)
Collecting torch (from -r D:\projects\ComfyUI\requirements.txt (line 4))
  Using cached torch-2.8.0-cp312-cp312-win_amd64.whl.metadata (30 kB)
Requirement already satisfied: huggingface-hub<1.0,>=0.34.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from transformers>=4.37.2->-r D:\projects\ComfyUI\requirements.txt (line 10)) (0.34.4)
Requirement already satisfied: packaging>=20.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from transformers>=4.37.2->-r D:\projects\ComfyUI\requirements.txt (line 10)) (25.0)
Requirement already satisfied: regex!=2019.12.17 in d:\scratch\therock\3.12.venv\lib\site-packages (from transformers>=4.37.2->-r D:\projects\ComfyUI\requirements.txt (line 10)) (2025.7.34)
Requirement already satisfied: requests in d:\scratch\therock\3.12.venv\lib\site-packages (from transformers>=4.37.2->-r D:\projects\ComfyUI\requirements.txt (line 10)) (2.32.5)
Requirement already satisfied: aiohappyeyeballs>=2.5.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from aiohttp>=3.11.8->-r D:\projects\ComfyUI\requirements.txt (line 14)) (2.6.1)
Requirement already satisfied: aiosignal>=1.4.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from aiohttp>=3.11.8->-r D:\projects\ComfyUI\requirements.txt (line 14)) (1.4.0)
Requirement already satisfied: attrs>=17.3.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from aiohttp>=3.11.8->-r D:\projects\ComfyUI\requirements.txt (line 14)) (25.3.0)
Requirement already satisfied: frozenlist>=1.1.1 in d:\scratch\therock\3.12.venv\lib\site-packages (from aiohttp>=3.11.8->-r D:\projects\ComfyUI\requirements.txt (line 14)) (1.7.0)
Requirement already satisfied: multidict<7.0,>=4.5 in d:\scratch\therock\3.12.venv\lib\site-packages (from aiohttp>=3.11.8->-r D:\projects\ComfyUI\requirements.txt (line 14)) (6.6.4)
Requirement already satisfied: propcache>=0.2.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from aiohttp>=3.11.8->-r D:\projects\ComfyUI\requirements.txt (line 14)) (0.3.2)
Requirement already satisfied: idna>=2.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from yarl>=1.18.0->-r D:\projects\ComfyUI\requirements.txt (line 15)) (3.10)
Requirement already satisfied: colorama in d:\scratch\therock\3.12.venv\lib\site-packages (from tqdm->-r D:\projects\ComfyUI\requirements.txt (line 19)) (0.4.6)
Requirement already satisfied: Mako in d:\scratch\therock\3.12.venv\lib\site-packages (from alembic->-r D:\projects\ComfyUI\requirements.txt (line 21)) (1.3.10)
Requirement already satisfied: greenlet>=1 in d:\scratch\therock\3.12.venv\lib\site-packages (from SQLAlchemy->-r D:\projects\ComfyUI\requirements.txt (line 22)) (3.2.4)
Requirement already satisfied: kornia_rs>=0.1.9 in d:\scratch\therock\3.12.venv\lib\site-packages (from kornia>=0.7.1->-r D:\projects\ComfyUI\requirements.txt (line 26)) (0.1.9)
Requirement already satisfied: cffi>=1.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from soundfile->-r D:\projects\ComfyUI\requirements.txt (line 28)) (1.17.1)
Requirement already satisfied: annotated-types>=0.6.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from pydantic~=2.0->-r D:\projects\ComfyUI\requirements.txt (line 29)) (0.7.0)
Requirement already satisfied: pydantic-core==2.33.2 in d:\scratch\therock\3.12.venv\lib\site-packages (from pydantic~=2.0->-r D:\projects\ComfyUI\requirements.txt (line 29)) (2.33.2)
Requirement already satisfied: typing-inspection>=0.4.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from pydantic~=2.0->-r D:\projects\ComfyUI\requirements.txt (line 29)) (0.4.1)
Requirement already satisfied: python-dotenv>=0.21.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from pydantic-settings~=2.0->-r D:\projects\ComfyUI\requirements.txt (line 30)) (1.1.1)
Requirement already satisfied: pycparser in d:\scratch\therock\3.12.venv\lib\site-packages (from cffi>=1.0->soundfile->-r D:\projects\ComfyUI\requirements.txt (line 28)) (2.22)
Requirement already satisfied: mpmath<1.4,>=1.1.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from sympy>=1.13.3->torch->-r D:\projects\ComfyUI\requirements.txt (line 4)) (1.3.0)
Requirement already satisfied: MarkupSafe>=2.0 in d:\scratch\therock\3.12.venv\lib\site-packages (from jinja2->torch->-r D:\projects\ComfyUI\requirements.txt (line 4)) (3.0.2)
Requirement already satisfied: charset_normalizer<4,>=2 in d:\scratch\therock\3.12.venv\lib\site-packages (from requests->transformers>=4.37.2->-r D:\projects\ComfyUI\requirements.txt (line 10)) (3.4.3)
Requirement already satisfied: urllib3<3,>=1.21.1 in d:\scratch\therock\3.12.venv\lib\site-packages (from requests->transformers>=4.37.2->-r D:\projects\ComfyUI\requirements.txt (line 10)) (2.5.0)
Requirement already satisfied: certifi>=2017.4.17 in d:\scratch\therock\3.12.venv\lib\site-packages (from requests->transformers>=4.37.2->-r D:\projects\ComfyUI\requirements.txt (line 10)) (2025.8.3)

[notice] A new release of pip is available: 25.0.1 -> 25.2
[notice] To update, run: python.exe -m pip install --upgrade pip
ERROR: Exception:
Traceback (most recent call last):
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\pip\_internal\cli\base_command.py", line 106, in _run_wrapper
    status = _inner_run()
             ^^^^^^^^^^^^
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\pip\_internal\cli\base_command.py", line 97, in _inner_run
    return self.run(options, args)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\pip\_internal\cli\req_command.py", line 67, in wrapper
    return func(self, options, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\pip\_internal\commands\install.py", line 386, in run
    requirement_set = resolver.resolve(
                      ^^^^^^^^^^^^^^^^^
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\pip\_internal\resolution\resolvelib\resolver.py", line 95, in resolve
    result = self._result = resolver.resolve(
                            ^^^^^^^^^^^^^^^^^
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 547, in resolve
    return _build_result(state)
           ^^^^^^^^^^^^^^^^^^^^
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 492, in _build_result
    if not _has_route_to_root(state.criteria, key, all_keys, connected):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 473, in _has_route_to_root
    if _has_route_to_root(criteria, pkey, all_keys, connected):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 473, in _has_route_to_root
    if _has_route_to_root(criteria, pkey, all_keys, connected):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 473, in _has_route_to_root
    if _has_route_to_root(criteria, pkey, all_keys, connected):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  [Previous line repeated 982 more times]
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 465, in _has_route_to_root
    for p in criteria[key].iter_parent():
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 81, in iter_parent
    return (i.parent for i in self.information)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded
```