### PR TITLE
Add `init` option to `rocm-sdk`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -240,7 +240,7 @@ contents:
 
 ```console
 $ rocm-sdk init
-Devel contents expanded to '.venv/lib/python3.12/site-packages/_rocm_sdk_devel'.
+Devel contents expanded to '.venv/lib/python3.12/site-packages/_rocm_sdk_devel'
 ```
 
 These contents are useful for using the package outside of Python and _lazily_ expanded on the

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -224,7 +224,7 @@ positional arguments:
     test                Run installation tests to verify integrity
     version             Print version information
     targets             Print information about the GPU targets that are supported
-    init                Expand devel contents to initialize rocm[dev]
+    init                Expand devel contents to initialize rocm[devel]
 
 $ rocm-sdk test
 ...
@@ -235,12 +235,16 @@ $ rocm-sdk targets
 gfx1100;gfx1101;gfx1102
 ```
 
-To initialize the `rocm[devel]` package, use the `rocm-sdk` tool to expand development contents:
+To initialize the `rocm[devel]` package, use the `rocm-sdk` tool to _eagerly_ expand development
+contents:
 
 ```console
 $ rocm-sdk init
 Devel contents expanded to '.venv/lib/python3.12/site-packages/_rocm_sdk_devel'.
 ```
+
+These contents are useful for using the package outside of Python and _lazily_ expanded on the
+first use when used from Python.
 
 Once you have verified your installation, you can continue to use it for
 standard ROCm development or install PyTorch or another supported Python ML

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -219,11 +219,12 @@ usage: rocm-sdk {command} ...
 ROCm SDK Python CLI
 
 positional arguments:
-  {path,test,version,targets}
+  {path,test,version,targets,init}
     path                Print various paths to ROCm installation
     test                Run installation tests to verify integrity
     version             Print version information
     targets             Print information about the GPU targets that are supported
+    init                Expand devel contents to initialize rocm[dev]
 
 $ rocm-sdk test
 ...
@@ -232,6 +233,13 @@ OK
 
 $ rocm-sdk targets
 gfx1100;gfx1101;gfx1102
+```
+
+To initialize the `rocm[devel]` package, use the `rocm-sdk` tool to expand development contents:
+
+```console
+$ rocm-sdk init
+Devel contents expanded to '.venv/lib/python3.12/site-packages/_rocm_sdk_devel'.
 ```
 
 Once you have verified your installation, you can continue to use it for

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
@@ -38,13 +38,10 @@ def _do_init(args: argparse.Namespace):
     from . import _devel
 
     try:
+        # The function `_devel.get_devel_root()` calls into `_expand_devel_contents`
+        # if contetens for development were not yet unpacked.
         root_path = _devel.get_devel_root()
     except ModuleNotFoundError as e:
-        print(
-            "ERROR: Could not load the `rocm[devel]` package, which is required. "
-            "Please install it with your package manager (pip, uv, etc)",
-            file=sys.stderr,
-        )
         print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(1)
     print(f"Devel contents expanded to '{root_path}'.")

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
@@ -39,12 +39,12 @@ def _do_init(args: argparse.Namespace):
 
     try:
         # The function `_devel.get_devel_root()` calls into `_expand_devel_contents`
-        # if contetens for development were not yet unpacked.
+        # if contents for development were not yet unpacked.
         root_path = _devel.get_devel_root()
     except ModuleNotFoundError as e:
         print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(1)
-    print(f"Devel contents expanded to '{root_path}'.")
+    print(f"Devel contents expanded to '{root_path}'")
 
 
 def _do_test(args: argparse.Namespace):
@@ -142,7 +142,7 @@ def main(argv: list[str] | None = None):
 
     # 'init' subcommand.
     init_p = sub_p.add_parser(
-        "init", help="Expand devel contents to initialize rocm[dev]"
+        "init", help="Expand devel contents to initialize rocm[devel]"
     )
     init_p.set_defaults(func=_do_init)
 

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
@@ -34,6 +34,22 @@ def _do_path(args: argparse.Namespace):
         sys.exit(1)
 
 
+def _do_init(args: argparse.Namespace):
+    from . import _devel
+
+    try:
+        root_path = _devel.get_devel_root()
+    except ModuleNotFoundError as e:
+        print(
+            "ERROR: Could not load the `rocm[devel]` package, which is required. "
+            "Please install it with your package manager (pip, uv, etc)",
+            file=sys.stderr,
+        )
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(f"Devel contents expanded to '{root_path}'.")
+
+
 def _do_test(args: argparse.Namespace):
     import unittest
 
@@ -126,6 +142,12 @@ def main(argv: list[str] | None = None):
         "targets", help="Print information about the GPU targets that are supported"
     )
     targets_p.set_defaults(func=_do_targets)
+
+    # 'init' subcommand.
+    init_p = sub_p.add_parser(
+        "init", help="Expand devel contents to initialize rocm[dev]"
+    )
+    init_p.set_defaults(func=_do_init)
 
     args = p.parse_args(argv)
     args.func(args)


### PR DESCRIPTION
This adds an `init` option and some more documentation to make expanding the development contents more accessible.

Closes #1239.