### PR TITLE
Enable hipBLASLt for gfx1150.

### DIFF
--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -103,7 +103,6 @@ therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all 
 # gfx115X family
 therock_add_amdgpu_target(gfx1150 "AMD Strix Point iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
   EXCLUDE_TARGET_PROJECTS
-    hipBLASLt # https://github.com/ROCm/TheRock/issues/154
     rccl  # https://github.com/ROCm/TheRock/issues/150
 )
 therock_add_amdgpu_target(gfx1151 "AMD Strix Halo iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/154

## Technical Details

gfx1150 has been supported in Tensile since https://github.com/ROCm/rocm-libraries/commit/5db1ccb531c3d7064b9a2f7a22aac48209a8e062

## Test Plan

Configured CMake locally + CI runs. Looks like we don't build gfx1150 on CI or in releases yet.

## Test Result

CMake configure worked.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
