### PR TITLE
Bump DLL versions from 0700 to 0701 after rocm-systems update.

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -185,12 +185,12 @@ PackageEntry(
 
 # Public libraries.
 LibraryEntry("amdhip64", "core", "libamdhip64.so.7", "amdhip64_7.dll")
-LibraryEntry("hiprtc", "core", "libhiprtc.so.7", "hiprtc0700.dll")
+LibraryEntry("hiprtc", "core", "libhiprtc.so.7", "hiprtc0701.dll")
 LibraryEntry("roctx64", "core", "libroctx64.so.4", "")
 LibraryEntry("rocprofiler-sdk-roctx", "core", "librocprofiler-sdk-roctx.so.1", "")
 LibraryEntry("roctracer64", "core", "libroctracer64.so.4", "")
 
-LibraryEntry("amd_comgr", "core", "libamd_comgr.so.3", "amd_comgr0700.dll")
+LibraryEntry("amd_comgr", "core", "libamd_comgr.so.3", "amd_comgr0701.dll")
 LibraryEntry("hipblas", "libraries", "libhipblas.so.3", "libhipblas.dll")
 LibraryEntry("hipfft", "libraries", "libhipfft.so.0", "hipfft.dll")
 LibraryEntry("hiprand", "libraries", "libhiprand.so.1", "hiprand.dll")


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/1340.

## Technical Details

We still hardcode library names (https://github.com/ROCm/TheRock/issues/1057). We might want to land https://github.com/ROCm/TheRock/pull/1061 in some form to change that.

## Test Plan

I checked the DLL names in my local build directory. This exposed more gaps in our CI/CD test coverage that should have blocked either https://github.com/ROCm/TheRock/commit/0c23e81041c9bd839c5d2c4cf7bc28ab69bf653a or publishing the Python packages.

I also modified `D:\scratch\therock\3.12.venv\Lib\site-packages\rocm_sdk\_dist_info.py` and ran `rocm-sdk test` successfully.

I could also build the Python packages locally to verify.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
