### PR TITLE
[ci] Rename xfail matrix to nightly, mark 90x and 101x as passing.

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -1,7 +1,11 @@
 """
-This AMD GPU Family Matrix is the "source of truth" for GitHub workflows, indicating which families and test runners are available to use
+This AMD GPU Family Matrix is the "source of truth" for GitHub workflows.
+
+* Each entry determines which families and test runners are available to use
+* Each group determines which entries run by default on workflow triggers
 """
 
+# The 'presubmit' matrix runs on 'pull_request' triggers (on all PRs).
 amdgpu_family_info_matrix_presubmit = {
     "gfx94x": {
         "linux": {
@@ -21,6 +25,7 @@ amdgpu_family_info_matrix_presubmit = {
     },
 }
 
+# The 'postsubmit' matrix runs on 'push' triggers (for every commit to the default branch).
 amdgpu_family_info_matrix_postsubmit = {
     "gfx950": {
         "linux": {
@@ -50,19 +55,20 @@ amdgpu_family_info_matrix_postsubmit = {
     },
 }
 
-amdgpu_family_matrix_xfail = {
+# The 'nightly' matrix runs on 'schedule' triggers.
+amdgpu_family_info_matrix_nightly = {
     "gfx90x": {
         "linux": {
             "test-runs-on": "",
             "family": "gfx90X-dcgpu",
-            "expect_failure": True,
+            "expect_failure": False,
         }
     },
     "gfx101x": {
         "linux": {
             "test-runs-on": "",
             "family": "gfx101X-dgpu",
-            "expect_failure": True,
+            "expect_failure": False,
         }
     },
     "gfx103x": {

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -79,3 +79,9 @@ amdgpu_family_info_matrix_nightly = {
         }
     },
 }
+
+amdgpu_family_info_matrix_all = (
+    amdgpu_family_info_matrix_presubmit
+    | amdgpu_family_info_matrix_postsubmit
+    | amdgpu_family_info_matrix_nightly
+)

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -298,6 +298,7 @@ def main(base_args, linux_families, windows_families):
     print(f"  is_push: {is_push}")
     print(f"  is_workflow_dispatch: {is_workflow_dispatch}")
     print(f"  is_pull_request: {is_pull_request}")
+    print("")
 
     print(f"Generating build matrix for Linux: {str(linux_families)}")
     linux_target_output = matrix_generator(
@@ -309,8 +310,9 @@ def main(base_args, linux_families, windows_families):
         linux_families,
         platform="linux",
     )
+    print("")
 
-    print(f"Generating test matrix for Windows: {str(windows_families)}")
+    print(f"Generating build matrix for Windows: {str(windows_families)}")
     windows_target_output = matrix_generator(
         is_pull_request,
         is_workflow_dispatch,
@@ -320,6 +322,7 @@ def main(base_args, linux_families, windows_families):
         windows_families,
         platform="windows",
     )
+    print("")
 
     # In the case of a scheduled run, we always want to build
     if is_schedule:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -173,7 +173,7 @@ def should_ci_run_given_modified_paths(paths: Optional[Iterable[str]]) -> bool:
 
 
 # --------------------------------------------------------------------------- #
-# Matrix creation logic based on PR, push or workflow_dispatch
+# Matrix creation logic based on PR, push, or workflow_dispatch
 # --------------------------------------------------------------------------- #
 
 
@@ -186,7 +186,7 @@ def get_pr_labels(args) -> List[str]:
     return labels
 
 
-def filter_known_target_names(requested_target_names: List[str]):
+def filter_known_target_names(requested_target_names: List[str]) -> List[str]:
     """Filters a requested target names list down to known target names."""
     target_names = []
     for target_name in requested_target_names:
@@ -196,6 +196,10 @@ def filter_known_target_names(requested_target_names: List[str]):
 
         if target_name in amdgpu_family_info_matrix_all:
             target_names.append(target_name)
+        else:
+            print(
+                f"WARNING: unknown target name '{target_name}' not found in matrix:\n{amdgpu_family_info_matrix_all}"
+            )
 
     return target_names
 

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -17,6 +17,9 @@ class ConfigureCITest(unittest.TestCase):
                 any(entry.get("expect_failure") for entry in target_output)
             )
 
+    ###########################################################################
+    # Tests for should_ci_run_given_modified_paths
+
     def test_run_ci_if_source_file_edited(self):
         paths = ["source_file.h"]
         run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
@@ -57,6 +60,15 @@ class ConfigureCITest(unittest.TestCase):
         paths = ["source_file.h", ".github/workflows/pre-commit.yml"]
         run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
         self.assertTrue(run_ci)
+
+    ###########################################################################
+    # Tests for matrix_generator and helper functions
+
+    def test_filter_known_target_names(self):
+        requested_target_names = ["gfx110X", "abcdef"]
+        target_names = configure_ci.filter_known_target_names(requested_target_names)
+        self.assertIn("gfx110x", target_names)
+        self.assertNotIn("abcdef", target_names)
 
     def test_valid_linux_workflow_dispatch_matrix_generator(self):
         build_families = {"amdgpu_families": "   gfx94X , gfx103X"}

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -8,9 +8,14 @@ import configure_ci
 
 
 class ConfigureCITest(unittest.TestCase):
-    def assert_target_output_is_valid(self, target_output):
+    def assert_target_output_is_valid(self, target_output, allow_xfail):
         self.assertTrue(all("test-runs-on" in entry for entry in target_output))
         self.assertTrue(all("family" in entry for entry in target_output))
+
+        if not allow_xfail:
+            self.assertFalse(
+                any(entry.get("expect_failure") for entry in target_output)
+            )
 
     def test_run_ci_if_source_file_edited(self):
         paths = ["source_file.h"]
@@ -71,8 +76,9 @@ class ConfigureCITest(unittest.TestCase):
             any("gfx103X-dgpu" == entry["family"] for entry in linux_target_output)
         )
         self.assertGreaterEqual(len(linux_target_output), 2)
-        self.assert_target_output_is_valid(linux_target_output)
-        self.assertTrue(any("expect_failure" in entry for entry in linux_target_output))
+        self.assert_target_output_is_valid(
+            target_output=linux_target_output, allow_xfail=True
+        )
 
     def test_invalid_linux_workflow_dispatch_matrix_generator(self):
         build_families = {
@@ -109,7 +115,9 @@ class ConfigureCITest(unittest.TestCase):
             any("gfx110X-dgpu" == entry["family"] for entry in linux_target_output)
         )
         self.assertGreaterEqual(len(linux_target_output), 2)
-        self.assert_target_output_is_valid(linux_target_output)
+        self.assert_target_output_is_valid(
+            target_output=linux_target_output, allow_xfail=False
+        )
 
     def test_duplicate_windows_pull_request_matrix_generator(self):
         base_args = {
@@ -128,7 +136,9 @@ class ConfigureCITest(unittest.TestCase):
             any("gfx110X-dgpu" == entry["family"] for entry in windows_target_output)
         )
         self.assertGreaterEqual(len(windows_target_output), 1)
-        self.assert_target_output_is_valid(windows_target_output)
+        self.assert_target_output_is_valid(
+            target_output=windows_target_output, allow_xfail=False
+        )
 
     def test_invalid_linux_pull_request_matrix_generator(self):
         base_args = {
@@ -144,7 +154,9 @@ class ConfigureCITest(unittest.TestCase):
             platform="linux",
         )
         self.assertGreaterEqual(len(linux_target_output), 1)
-        self.assert_target_output_is_valid(linux_target_output)
+        self.assert_target_output_is_valid(
+            target_output=linux_target_output, allow_xfail=False
+        )
 
     def test_empty_windows_pull_request_matrix_generator(self):
         base_args = {"pr_labels": "{}"}
@@ -158,7 +170,9 @@ class ConfigureCITest(unittest.TestCase):
             platform="windows",
         )
         self.assertGreaterEqual(len(windows_target_output), 1)
-        self.assert_target_output_is_valid(windows_target_output)
+        self.assert_target_output_is_valid(
+            target_output=windows_target_output, allow_xfail=False
+        )
 
     def test_main_linux_branch_push_matrix_generator(self):
         base_args = {"branch_name": "main"}
@@ -172,8 +186,9 @@ class ConfigureCITest(unittest.TestCase):
             platform="linux",
         )
         self.assertGreaterEqual(len(linux_target_output), 1)
-        self.assertGreaterEqual(len(linux_target_output), 1)
-        self.assert_target_output_is_valid(linux_target_output)
+        self.assert_target_output_is_valid(
+            target_output=linux_target_output, allow_xfail=False
+        )
 
     def test_main_windows_branch_push_matrix_generator(self):
         base_args = {"branch_name": "main"}
@@ -187,8 +202,9 @@ class ConfigureCITest(unittest.TestCase):
             platform="windows",
         )
         self.assertGreaterEqual(len(windows_target_output), 1)
-        self.assertGreaterEqual(len(windows_target_output), 1)
-        self.assert_target_output_is_valid(windows_target_output)
+        self.assert_target_output_is_valid(
+            target_output=windows_target_output, allow_xfail=False
+        )
 
     def test_linux_branch_push_matrix_generator(self):
         base_args = {"branch_name": "test_branch"}
@@ -214,9 +230,8 @@ class ConfigureCITest(unittest.TestCase):
             platform="linux",
         )
         self.assertGreaterEqual(len(linux_target_output), 1)
-        self.assert_target_output_is_valid(linux_target_output)
-        self.assertTrue(
-            all(entry.get("expect_failure") for entry in linux_target_output)
+        self.assert_target_output_is_valid(
+            target_output=linux_target_output, allow_xfail=True
         )
 
     def test_windows_schedule_matrix_generator(self):


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/1337. Related to https://github.com/ROCm/TheRock/issues/1097.

## Technical Details

gfx90X-dcgpu and gfx101X-dgpu builds have been passing on nightly runs on https://github.com/ROCm/TheRock/actions/workflows/ci_nightly.yml?query=branch%3Amain

This allows us to separate the _policy decision_ "what support level is a given gfx family" from the _technical reality_ "does that gfx family pass builds/tests". Now we can have the nightly job include gfx families that are passing builds/tests instead of only having "xfail" jobs there.

While I was renaming the matrix variables I also did related refactoring to hopefully make this code easier to maintain going forward.

## Test Plan

* Ran `python .\build_tools\github_actions\tests\configure_ci_test.py` locally
* Confirm which targets are selected to run on this PR
* Watch which targets are selected on postsubmit
* Watch which targets are selected on the next run on https://github.com/ROCm/TheRock/actions/workflows/ci_nightly.yml?query=branch%3Amain

## Test Result

* Local unit tests passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
