### PR TITLE
Switch hip-tests (for hipInfo) to rocm-systems subfolder.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,10 +44,6 @@
 	path = rocm-libraries
 	url = https://github.com/ROCm/rocm-libraries
 	branch = develop
-[submodule "hip-tests"]
-	path = core/hip-tests
-	url = https://github.com/ROCm/hip-tests.git
-	branch = amd-staging
 [submodule "rocm-systems"]
 	path = rocm-systems
 	url = https://github.com/ROCm/rocm-systems.git

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -328,7 +328,6 @@ def main(argv):
         type=str,
         default=[
             "half",
-            "hip-tests",
             "rccl",
             "rccl-tests",
             "rocm-cmake",

--- a/core/hipInfo/CMakeLists.txt
+++ b/core/hipInfo/CMakeLists.txt
@@ -7,8 +7,8 @@ set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 # Use TheRock-provided HIP
 find_package(hip REQUIRED CONFIG)
 
-# Locate upstream sources (hip-tests is a sibling submodule)
-set(HIP_TESTS_DIR "${CMAKE_CURRENT_LIST_DIR}/../hip-tests")
+# Locate sources (hip-tests is a subproject under rocm-systems)
+set(HIP_TESTS_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/hip-tests")
 set(HIPINFO_SRC "${HIP_TESTS_DIR}/samples/1_Utils/hipInfo/hipInfo.cpp")
 set(HIPINFO_INC "${HIP_TESTS_DIR}/samples/common")
 


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/1351.

We may want a full project for hip-tests instead of just extracting hipInfo from it. That's for later.