### PR TITLE
Temporarily deactivate scheduled Windows releases

### DIFF
--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -34,10 +34,11 @@ on:
         description: "Extra options to pass to the CMake configure command"
         type: string
 
-  # Trigger on a schedule to build nightly release candidates.
-  schedule:
-    # Runs at 11:00 AM UTC, which is 3:00 AM PST (UTC-8)
-    - cron: '0 11 * * *'
+  # TODO: Re-enable once Windows build got fixed (#1347).
+  # # Trigger on a schedule to build nightly release candidates.
+  # schedule:
+  #   # Runs at 11:00 AM UTC, which is 3:00 AM PST (UTC-8)
+  #   - cron: '0 11 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
Stops scheduled releases until #1347 is fixed.