### PR TITLE
Warn about unstable Windows builds while broken by the rocm-systems migration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(WIN32)
     "Windows builds are currently unstable during the migration to rocm-systems!"
     " Builds are expected to succeed but there are runtime errors and timeouts."
     " The last known good commit on Windows is"
-    " https://github.com/ROCm/TheRock/commit/16ee54fb580a4dde62dc4133f978e73370a545af"
+    " https://github.com/ROCm/TheRock/commit/529fa36d69c7d4295317a70d3c5c88000a364b2c"
     " See https://github.com/ROCm/TheRock/issues/1347 for details.\n"
     "*************************************************")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,22 @@ include(therock_job_pools)
 include(therock_testing)
 
 ################################################################################
+# Notices
+# If there are ongoing issues for specific configurations log them here.
+################################################################################
+
+if(WIN32)
+  message(WARNING
+    "*************************************************\n"
+    "Windows builds are currently unstable during the migration to rocm-systems!"
+    " Builds are expected to succeed but there are runtime errors and timeouts."
+    " The last known good commit on Windows is"
+    " https://github.com/ROCm/TheRock/commit/16ee54fb580a4dde62dc4133f978e73370a545af"
+    " See https://github.com/ROCm/TheRock/issues/1347 for details.\n"
+    "*************************************************")
+endif()
+
+################################################################################
 # Testing Setup
 # Does normal CMake setup so that BUILD_TESTING functions as a master control
 # switch. Then we set THEROCK_BUILD_TESTING if not explicitly set by the user

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ python ./build_tools/fetch_sources.py
 
 ### Setup - Windows 11 (VS 2022)
 
+> [!CAUTION]
+> Windows builds are currently unstable during the subproject migration to
+> [rocm-systems](https://github.com/ROCm/rocm-systems)!
+>
+> **The last known good commit on Windows is [16ee54f](https://github.com/ROCm/TheRock/commit/16ee54fb580a4dde62dc4133f978e73370a545af) .**
+>
+> Builds are expected to succeed but there are runtime errors and timeouts.
+> See https://github.com/ROCm/TheRock/issues/1347 for details.
+
 > [!IMPORTANT]
 > See [windows_support.md](./docs/development/windows_support.md) for setup
 > instructions on Windows, in particular

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ python ./build_tools/fetch_sources.py
 > Windows builds are currently unstable during the subproject migration to
 > [rocm-systems](https://github.com/ROCm/rocm-systems)!
 >
-> **The last known good commit on Windows is [16ee54f](https://github.com/ROCm/TheRock/commit/16ee54fb580a4dde62dc4133f978e73370a545af) .**
+> **The last known good commit on Windows is [16ee54f](https://github.com/ROCm/TheRock/commit/529fa36d69c7d4295317a70d3c5c88000a364b2c) .**
 >
 > Builds are expected to succeed but there are runtime errors and timeouts.
 > See https://github.com/ROCm/TheRock/issues/1347 for details.


### PR DESCRIPTION
See https://github.com/ROCm/TheRock/issues/1347.

The CMake configure warning looks like this in context:
```
[cmake] -- Configuring background job pool for 6 concurrent jobs
[cmake] CMake Warning at CMakeLists.txt:35 (message):
[cmake]   *************************************************
[cmake] 
[cmake]   Windows builds are currently unstable during the migration to rocm-systems!
[cmake]   Builds are expected to succeed but there are runtime errors and timeouts.
[cmake]   The last known good commit on Windows is
[cmake]   https://github.com/ROCm/TheRock/commit/529fa36d69c7d4295317a70d3c5c88000a364b2c
[cmake]   See https://github.com/ROCm/TheRock/issues/1347 for details.
[cmake] 
[cmake]   *************************************************
[cmake] 
[cmake] 
[cmake] -- Enabling building tests
[cmake] -- ROCm version: 7.0.0
[cmake] -- HIP version: 7.1.0
[cmake] -- Implicitly enabled features: HOST_BLAS
```