### PR TITLE
Fix Windows on new rocm-systems with some revert patches.

### DIFF
--- a/patches/amd-mainline/rocm-systems/0010-Revert-SWDEV-547108-Fix-compilation-errors-under-Win.patch
+++ b/patches/amd-mainline/rocm-systems/0010-Revert-SWDEV-547108-Fix-compilation-errors-under-Win.patch
@@ -1,0 +1,634 @@
+From 3b7cf35aab3ac4db5a0146b3935303b3f68be0d2 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Thu, 28 Aug 2025 14:10:41 -0700
+Subject: [PATCH 10/11] Revert "SWDEV-547108 - Fix compilation errors under
+ Windows (#867)"
+
+This reverts commit 72b9408fedb08da67d0f3fec89316fb6e44153f2.
+---
+ projects/clr/hipamd/src/hip_context.cpp       |  6 +-
+ .../clr/rocclr/device/rocm/mesa_glinterop.h   |  4 +-
+ projects/clr/rocclr/device/rocm/rocblit.cpp   |  2 +-
+ projects/clr/rocclr/device/rocm/rocdevice.cpp | 23 ++++---
+ .../clr/rocclr/device/rocm/rocglinterop.hpp   |  6 --
+ projects/clr/rocclr/device/rocm/rockernel.hpp |  6 +-
+ projects/clr/rocclr/device/rocm/rocmemory.cpp | 13 ++--
+ projects/clr/rocclr/device/rocm/rocmemory.hpp |  2 +-
+ projects/clr/rocclr/device/rocm/rocprintf.hpp | 11 ++++
+ .../clr/rocclr/device/rocm/rocvirtual.cpp     | 33 +++-------
+ projects/clr/rocclr/os/os.cpp                 | 15 +++--
+ projects/clr/rocclr/os/os.hpp                 |  8 +--
+ projects/clr/rocclr/os/os_posix.cpp           | 61 ++++++++-----------
+ projects/clr/rocclr/os/os_win32.cpp           |  7 ---
+ 14 files changed, 82 insertions(+), 115 deletions(-)
+
+diff --git a/projects/clr/hipamd/src/hip_context.cpp b/projects/clr/hipamd/src/hip_context.cpp
+index 6982783cf4..b56341878b 100644
+--- a/projects/clr/hipamd/src/hip_context.cpp
++++ b/projects/clr/hipamd/src/hip_context.cpp
+@@ -45,11 +45,7 @@ void init(bool* status) {
+ #if DISABLE_DIRECT_DISPATCH
+   constexpr bool kDirectDispatch = false;
+ #else
+-#ifndef WITHOUT_HSA_BACKEND
+-  constexpr bool kDirectDispatch = true;
+-#else
+-  constexpr bool kDirectDispatch = false;
+-#endif
++  constexpr bool kDirectDispatch = IS_LINUX;
+ #endif
+   AMD_DIRECT_DISPATCH = flagIsDefault(AMD_DIRECT_DISPATCH) ? kDirectDispatch : AMD_DIRECT_DISPATCH;
+   if (!amd::Runtime::init()) {
+diff --git a/projects/clr/rocclr/device/rocm/mesa_glinterop.h b/projects/clr/rocclr/device/rocm/mesa_glinterop.h
+index 79896ab862..91e87d4dd9 100644
+--- a/projects/clr/rocclr/device/rocm/mesa_glinterop.h
++++ b/projects/clr/rocclr/device/rocm/mesa_glinterop.h
+@@ -239,7 +239,7 @@ struct mesa_glinterop_export_out {
+   /* Structure version 1 ends here. */
+ };
+ 
+-#if IS_LINUX
++
+ /**
+  * Query device information.
+  *
+@@ -299,8 +299,6 @@ typedef int(PFNMESAGLINTEROPEGLEXPORTOBJECTPROC)(EGLDisplay dpy, EGLContext cont
+                                                  struct mesa_glinterop_export_in* in,
+                                                  struct mesa_glinterop_export_out* out);
+ 
+-#endif  // IS_LINUX
+-
+ #ifdef __cplusplus
+ }
+ #endif
+diff --git a/projects/clr/rocclr/device/rocm/rocblit.cpp b/projects/clr/rocclr/device/rocm/rocblit.cpp
+index 35fad4d650..cb5623a942 100644
+--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
++++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
+@@ -2706,7 +2706,7 @@ bool KernelBlitManager::runScheduler(uint64_t vqVM, hsa_queue_t* schedulerQueue,
+   sp->child_queue = reinterpret_cast<uint64_t>(schedulerQueue);
+   sp->complete_signal = gpu().Barriers().ActiveSignal(kInitSignalValueOne, nullptr);
+   sp->vqueue_header = vqVM;
+-  sp->parentAQL = aql_wrap;
++  sp->parentAQL = reinterpret_cast<uint64_t>(aql_wrap);
+ 
+   if (dev().info().maxEngineClockFrequency_ > 0) {
+     sp->eng_clk = (1000 * 1024) / dev().info().maxEngineClockFrequency_;
+diff --git a/projects/clr/rocclr/device/rocm/rocdevice.cpp b/projects/clr/rocclr/device/rocm/rocdevice.cpp
+index 0c36b9b209..5f3e2016e2 100644
+--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
++++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
+@@ -56,6 +56,7 @@
+ #include <iostream>
+ #include <iomanip>
+ #include <memory>
++#include <sys/resource.h>
+ #ifdef ROCCLR_SUPPORT_NUMA_POLICY
+ #include <numa.h>
+ #include <numaif.h>
+@@ -1007,7 +1008,7 @@ bool Sampler::create(const amd::Sampler& owner) {
+     return false;
+   }
+ 
+-  hwSrd_ = hsa_sampler.handle;
++  hwSrd_ = reinterpret_cast<uint64_t>(hsa_sampler.handle);
+   hwState_ = reinterpret_cast<address>(hsa_sampler.handle);
+ 
+   return true;
+@@ -1259,7 +1260,8 @@ bool Device::populateOCLDeviceConstants() {
+     assert(alloc_granularity_ > 0);
+   } else {
+     // We suppose half of physical memory can be used by GPU in APU system
+-    info_.globalMemSize_ = amd::Os::hostTotalPhysicalMemory() / 2;
++    info_.globalMemSize_ =
++        uint64_t(sysconf(_SC_PAGESIZE)) * uint64_t(sysconf(_SC_PHYS_PAGES)) / 2;
+     info_.globalMemSize_ = std::max(info_.globalMemSize_, uint64_t(1 * Gi));
+     info_.globalMemSize_ = (static_cast<uint64_t>(std::min(GPU_MAX_HEAP_SIZE, 100u)) *
+                             static_cast<uint64_t>(info_.globalMemSize_)) /
+@@ -3154,16 +3156,19 @@ void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMas
+ void* Device::getOrCreateHostcallBuffer(hsa_queue_t* queue, bool coop_queue,
+                                         const std::vector<uint32_t>& cuMask) {
+   decltype(queuePool_)::value_type::iterator qIter;
+-  bool found = false;
++
+   if (!coop_queue) {
+     for (auto& it : cuMask.size() == 0 ? queuePool_ : queueWithCUMaskPool_) {
+       qIter = it.find(queue);
+       if (qIter != it.end()) {
+-        found = true;
+         break;
+       }
+     }
+-    assert(found && "Couldn't find queue");
++    if (cuMask.size() == 0) {
++      assert(qIter != queuePool_[QueuePriority::High].end());
++    } else {
++      assert(qIter != queueWithCUMaskPool_[QueuePriority::High].end());
++    }
+ 
+     if (qIter->second.hostcallBuffer_) {
+       return qIter->second.hostcallBuffer_;
+@@ -3391,7 +3396,9 @@ hsa_status_t Device::BackendErrorCallBackHandler(const hsa_amd_event_t* event, v
+   }
+ 
+   // Execute the default handler if a GPU core file should be generated ...
+-  if (amd::Os::DumpCoreFile() || !HIP_SKIP_ABORT_ON_GPU_ERROR) {
++  struct rlimit rlimit;
++  if ((getrlimit(RLIMIT_CORE, &rlimit) == 0 && rlimit.rlim_cur != 0) ||
++      !HIP_SKIP_ABORT_ON_GPU_ERROR) {
+     return HSA_STATUS_ERROR;
+   }
+ 
+@@ -3637,7 +3644,9 @@ void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data) {
+               errorMsg, status);
+     }
+ 
+-    if (amd::Os::DumpCoreFile() || !HIP_SKIP_ABORT_ON_GPU_ERROR) {
++    struct rlimit rlimit;
++    if ((getrlimit(RLIMIT_CORE, &rlimit) == 0 && rlimit.rlim_cur != 0) ||
++        !HIP_SKIP_ABORT_ON_GPU_ERROR) {
+       abort();
+     }
+     amd::Device::gpu_error_ = ConvertHSAErrorIntoCLError(status);
+diff --git a/projects/clr/rocclr/device/rocm/rocglinterop.hpp b/projects/clr/rocclr/device/rocm/rocglinterop.hpp
+index 3ba10c1371..47a284bb9a 100644
+--- a/projects/clr/rocclr/device/rocm/rocglinterop.hpp
++++ b/projects/clr/rocclr/device/rocm/rocglinterop.hpp
+@@ -26,14 +26,8 @@
+ #include <GL/glx.h>
+ #include <EGL/egl.h>
+ #else
+-#include <windows.h>
+ #include <GL/gl.h>
+-#include <GL/glext.h>
+ #include <EGL/egl.h>
+-#ifndef GLX_H
+-struct _XDisplay;
+-struct __GLXcontextRec;
+-#endif
+ typedef _XDisplay Display;
+ typedef __GLXcontextRec* GLXContext;
+ #endif
+diff --git a/projects/clr/rocclr/device/rocm/rockernel.hpp b/projects/clr/rocclr/device/rocm/rockernel.hpp
+index 02f2cc3158..708221d24a 100644
+--- a/projects/clr/rocclr/device/rocm/rockernel.hpp
++++ b/projects/clr/rocclr/device/rocm/rockernel.hpp
+@@ -21,6 +21,7 @@
+ #pragma once
+ 
+ #include <memory>
++#include <cxxabi.h>
+ #include "rocprogram.hpp"
+ #include "top.hpp"
+ #include "rocprintf.hpp"
+@@ -59,7 +60,10 @@ class Kernel : public device::Kernel {
+  private:
+   void initDemangledName() {
+     if (demangled_name_.empty()) {
+-      amd::Os::CxaDemangle(name(), &demangled_name_);
++      int status = 0;
++      char* demangled = abi::__cxa_demangle(name().c_str(), nullptr, nullptr, &status);
++      demangled_name_ = (status == 0 && demangled != nullptr) ? demangled : name().c_str();
++      free(demangled);
+     }
+   }
+ 
+diff --git a/projects/clr/rocclr/device/rocm/rocmemory.cpp b/projects/clr/rocclr/device/rocm/rocmemory.cpp
+index f85a1680d9..bd6f8d341a 100644
+--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
++++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
+@@ -203,17 +203,11 @@ void Memory::cpuUnmap(device::VirtualDevice& vDev) {
+ }
+ 
+ // ================================================================================================
+-hsa_status_t Memory::interopMapBuffer(amd::Os::FileDesc fdn) {
++hsa_status_t Memory::interopMapBuffer(int fd) {
+   hsa_agent_t agent = dev().getBackendDevice();
+   size_t size;
+   size_t metadata_size = 0;
+   void* metadata;
+-#if IS_WINDOWS
+-  int fd = 0;
+-  assert(!"Unimplemented");
+-#else
+-  auto fd = fdn;
+-#endif
+   hsa_status_t status = hsa_amd_interop_map_buffer(1, &agent, fd, 0, &size, &interop_deviceMemory_,
+                                                    &metadata_size, (const void**)&metadata);
+   ClPrint(amd::LOG_DEBUG, amd::LOG_MEM, "Map Interop memory %p, size 0x%zx", interop_deviceMemory_,
+@@ -236,7 +230,7 @@ hsa_status_t Memory::interopMapBuffer(amd::Os::FileDesc fdn) {
+ // Setup an interop buffer (dmabuf handle) as an OpenCL buffer
+ // ================================================================================================
+ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
+-#if IS_WINDOWS
++#if defined(_WIN32)
+   return false;
+ #else
+   assert(owner()->isInterop() && "Object is not an interop object.");
+@@ -848,7 +842,8 @@ bool Buffer::create(bool alloc_local) {
+             return false;
+           }
+ 
+-          deviceMemory_ = const_cast<void*>(reinterpret_cast<volatile void*>(signalValuePtr));
++          deviceMemory_ = const_cast<long int*>(signalValuePtr);  // conversion to void * is
++                                                                  // implicit
+ 
+           // Disable host access to force blit path for memeory writes.
+           flags_ &= ~HostMemoryDirectAccess;
+diff --git a/projects/clr/rocclr/device/rocm/rocmemory.hpp b/projects/clr/rocclr/device/rocm/rocmemory.hpp
+index dfeb56de9e..eec46b291f 100644
+--- a/projects/clr/rocclr/device/rocm/rocmemory.hpp
++++ b/projects/clr/rocclr/device/rocm/rocmemory.hpp
+@@ -128,7 +128,7 @@ class Memory : public device::Memory {
+ 
+   // Free / deregister device memory.
+   virtual void destroy() = 0;
+-  hsa_status_t interopMapBuffer(amd::Os::FileDesc fdn);
++  hsa_status_t interopMapBuffer(int fd);
+ 
+   // Place interop object into HSA's flat address space
+   bool createInteropBuffer(GLenum targetType, int miplevel);
+diff --git a/projects/clr/rocclr/device/rocm/rocprintf.hpp b/projects/clr/rocclr/device/rocm/rocprintf.hpp
+index 7f21305762..3256bb9e9d 100644
+--- a/projects/clr/rocclr/device/rocm/rocprintf.hpp
++++ b/projects/clr/rocclr/device/rocm/rocprintf.hpp
+@@ -23,6 +23,17 @@
+ /*! \addtogroup GPU GPU Device Implementation
+  *  @{
+  */
++#ifndef isinf
++#ifdef _MSC_VER
++#define isinf(X) (!_finite(X) && !_isnan(X))
++#endif  //_MSC_VER
++#endif  // isinf
++
++#ifndef isnan
++#ifdef _MSC_VER
++#define isnan(X) (_isnan(X))
++#endif  //_MSC_VER
++#endif  // isnan
+ 
+ #ifndef copysign
+ #ifdef _MSC_VER
+diff --git a/projects/clr/rocclr/device/rocm/rocvirtual.cpp b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+index 1266643e7f..ba82e85b5e 100644
+--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
++++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+@@ -44,8 +44,6 @@
+ #include <string>
+ #include <thread>
+ #include <vector>
+-#include <atomic>
+-#include <cinttypes>
+ 
+ #if defined(__AVX__)
+ #if defined(__MINGW64__)
+@@ -921,12 +919,7 @@ uint64_t VirtualGPU::getQueueID() {
+ 
+ // ================================================================================================
+ static inline void packet_store_release(uint32_t* packet, uint16_t header, uint16_t rest) {
+-#if IS_WINDOWS
+-  std::atomic_ref<uint32_t> atomic_header(*packet);
+-  atomic_header.store(header | (rest << 16), std::memory_order_release);
+-#else
+   __atomic_store_n(packet, header | (rest << 16), __ATOMIC_RELEASE);
+-#endif
+ }
+ 
+ // ================================================================================================
+@@ -969,15 +962,12 @@ void VirtualGPU::AnalyzeAqlQueue() const {
+       } else {
+         printf("VGPU(%p) Queue(%p). Couldn't find kernel\n", this, gpu_queue_);
+       }
+-      printf("VGPU=%p SWq=%p, HWq=%p, id=%" PRIu64
+-             "\n\tDispatch Header ="
++      printf("VGPU=%p SWq=%p, HWq=%p, id=%ld\n\tDispatch Header = "
+              "0x%x (type=%d, barrier=%d, acquire=%d, release=%d), "
+              "setup=%d\n\tgrid=[%u, %u, %u], workgroup=[%u, %u, %u]\n\tprivate_seg_size=%u, "
+-             "group_seg_size=%u\n\tkernel_obj=0x%" PRIx64
+-             ", "
+-             "kernarg_address=0x%p\n\tcompletion_signal=0x%" PRIx64
+-             ", "
+-             "correlation_id=%" PRIu64 "\n\trptr=%" PRIu64 ", wptr=%" PRIu64 "\n ",
++             "group_seg_size=%u\n\tkernel_obj=0x%lx, "
++             "kernarg_address=0x%p\n\tcompletion_signal=0x%lx, "
++             "correlation_id=%lu\n\trptr=%lu, wptr=%lu\n",
+              this, gpu_queue_, gpu_queue_->base_address, gpu_queue_->id, header,
+              extractAqlBits(header, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE),
+              extractAqlBits(header, HSA_PACKET_HEADER_BARRIER, HSA_PACKET_HEADER_WIDTH_BARRIER),
+@@ -990,8 +980,7 @@ void VirtualGPU::AnalyzeAqlQueue() const {
+              packet.group_segment_size, packet.kernel_object, packet.kernarg_address,
+              packet.completion_signal.handle, packet.reserved2, read, index);
+     } else {
+-      printf("VGPU(%p) Queue(%p) rptr=%" PRIu64 ", wptr=%" PRIu64
+-             ". A barrier packet in the queue!\n",
++      printf("VGPU(%p) Queue(%p) rptr=%lu, wptr=%lu. A barrier packet in the queue!\n",
+              this, gpu_queue_, read, index);
+     }
+   } else {
+@@ -1257,7 +1246,7 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
+   hsa_barrier_and_packet_t* aql_loc =
+       &(reinterpret_cast<hsa_barrier_and_packet_t*>(gpu_queue_->base_address))[index & queueMask];
+   *aql_loc = barrier_packet_;
+-  packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), packetHeader, 0);
++  __atomic_store_n(reinterpret_cast<uint32_t*>(aql_loc), packetHeader, __ATOMIC_RELEASE);
+ 
+   hsa_signal_store_screlease(gpu_queue_->doorbell_signal, index);
+   ClPrint(amd::LOG_DEBUG, amd::LOG_AQL,
+@@ -3203,8 +3192,8 @@ bool VirtualGPU::createVirtualQueue(uint deviceQueueSize) {
+ }
+ 
+ // ================================================================================================
+-#if IS_LINUX
+-__attribute__((optimize("unroll-all-loops"), always_inline)) static inline void nontemporalMemcpy(
++__attribute__((optimize("unroll-all-loops"), always_inline))
++static inline void nontemporalMemcpy(
+     void* __restrict dst, const void* __restrict src, size_t size) {
+ #if defined(ATI_ARCH_X86)
+ #if defined(__AVX512F__)
+@@ -3250,12 +3239,6 @@ __attribute__((optimize("unroll-all-loops"), always_inline)) static inline void
+   std::memcpy(dst, src, size);
+ #endif
+ }
+-#else
+-static inline void nontemporalMemcpy(void* __restrict dst, const void* __restrict src,
+-                                     size_t size) {
+-  std::memcpy(dst, src, size);
+-}
+-#endif
+ 
+ void VirtualGPU::HiddenHeapInit() { const_cast<Device&>(dev()).HiddenHeapInit(*this); }
+ 
+diff --git a/projects/clr/rocclr/os/os.cpp b/projects/clr/rocclr/os/os.cpp
+index b13ca84f1c..e15800a7f7 100644
+--- a/projects/clr/rocclr/os/os.cpp
++++ b/projects/clr/rocclr/os/os.cpp
+@@ -37,17 +37,16 @@
+ 
+ namespace amd {
+ 
+-// ================================================================================================
+ bool Os::isValidFileDesc(const amd::Os::FileDesc& desc) {
+-#if IS_WINDOWS
+-  return desc != nullptr;
+-#else
+-  return desc > 0;
+-#endif
++  #if defined(_WIN32)
++    return reinterpret_cast<int>(desc) > 0;
++  #else
++    return static_cast<int>(desc) > 0;
++  #endif
+   return false;
+ }
+ 
+-// ================================================================================================
++
+ void* Os::loadLibrary(const char* libraryname) {
+   void* handle;
+ 
+@@ -58,7 +57,7 @@ void* Os::loadLibrary(const char* libraryname) {
+   namestart = (namestart != std::string::npos) ? namestart + 1 : 0;
+ 
+   if (namestart == 0) {
+-#if IS_WINDOWS
++#if defined(ATI_OS_WIN)
+     // Try with the path of the current loaded dll(OCL runtime) first
+     HMODULE hm = NULL;
+     if (!GetModuleHandleExA(
+diff --git a/projects/clr/rocclr/os/os.hpp b/projects/clr/rocclr/os/os.hpp
+index a65d454fdf..c8a9573257 100644
+--- a/projects/clr/rocclr/os/os.hpp
++++ b/projects/clr/rocclr/os/os.hpp
+@@ -331,14 +331,8 @@ class Os : AllStatic {
+   //! Return the current process id
+   static int getProcessId();
+ 
+-  //! Prints the location of the currently loaded library (shared object or DLL)
++  // Prints the location of the currently loaded library (shared object or DLL)
+   static void PrintLibraryLocation();
+-
+-  //! Checks if a core dump must be generated (rocgdb detection). Returns false in Windows
+-  static bool DumpCoreFile();
+-
+-  //! Demangle a C++ name. The function will return the same name if couldn't demangle
+-  static void CxaDemangle(const std::string& name, std::string* demangle);
+ };
+ 
+ /*@}*/
+diff --git a/projects/clr/rocclr/os/os_posix.cpp b/projects/clr/rocclr/os/os_posix.cpp
+index feb22ae931..02bd8994d8 100644
+--- a/projects/clr/rocclr/os/os_posix.cpp
++++ b/projects/clr/rocclr/os/os_posix.cpp
+@@ -39,10 +39,8 @@
+ #include <pthread.h>
+ #include <dlfcn.h>
+ #include <signal.h>
+-#include <cxxabi.h>
+ 
+ #include <sys/prctl.h>
+-#include <sys/resource.h>
+ 
+ #include <link.h>
+ #include <time.h>
+@@ -240,8 +238,7 @@ address Os::reserveMemory(address start, size_t size, size_t alignment, MemProt
+   if (size >= kLargePageSize) {
+     int status = madvise(aligned, size, MADV_HUGEPAGE);
+     if (status) {
+-      ClPrint(amd::LOG_DEBUG, amd::LOG_CODE,
+-              "madvise with advice MADV_HUGEPAGE"
++      ClPrint(amd::LOG_DEBUG, amd::LOG_CODE, "madvise with advice MADV_HUGEPAGE"
+               " starting at address %p and page size 0x%zx, returned %d, errno: %s",
+               aligned, size, status, strerror(errno));
+     }
+@@ -338,7 +335,7 @@ void Os::setPreferredNumaNode(uint32_t node) {
+ 
+     numa_free_cpumask(bm);
+   }
+-#endif  // ROCCLR_SUPPORT_NUMA_POLICY
++#endif //ROCCLR_SUPPORT_NUMA_POLICY
+ }
+ 
+ void* Thread::entry(Thread* thread) {
+@@ -739,7 +736,8 @@ void Os::getAppPathAndFileName(std::string& appName, std::string& appPathAndName
+     // Get filename without path and extension.
+     appName = std::string(basename(buff.get()));
+     appPathAndName = std::string(buff.get());
+-  } else {
++  }
++  else {
+     appName = "";
+     appPathAndName = "";
+   }
+@@ -749,8 +747,9 @@ void Os::getAppPathAndFileName(std::string& appName, std::string& appPathAndName
+ bool Os::GetURIFromMemory(const void* image, size_t image_size, std::string& uri) {
+   pid_t pid = getpid();
+   std::ostringstream uri_stream;
+-  // Create a unique resource indicator to the memory address
+-  uri_stream << "memory://" << pid << "#offset=0x" << std::hex << (uintptr_t)image << std::dec
++  //Create a unique resource indicator to the memory address
++  uri_stream << "memory://" << pid
++             << "#offset=0x" << std::hex << (uintptr_t)image << std::dec
+              << "&size=" << image_size;
+   uri = uri_stream.str();
+   return true;
+@@ -758,7 +757,7 @@ bool Os::GetURIFromMemory(const void* image, size_t image_size, std::string& uri
+ 
+ bool Os::CloseFileHandle(FileDesc fdesc) {
+   // Return false if close system call fails
+-  if (close(fdesc) < 0) {
++  if(close(fdesc) < 0) {
+     return false;
+   }
+ 
+@@ -777,7 +776,7 @@ bool Os::GetFileHandle(const char* fname, FileDesc* fd_ptr, size_t* sz_ptr) {
+     return false;
+   }
+ 
+-  // Retrieve stat info and size
++  //Retrieve stat info and size
+   if (fstat(*fd_ptr, &stat_buf) != 0) {
+     close(*fd_ptr);
+     return false;
+@@ -790,6 +789,7 @@ bool Os::GetFileHandle(const char* fname, FileDesc* fd_ptr, size_t* sz_ptr) {
+ 
+ bool amd::Os::FindFileNameFromAddress(const void* image, std::string* fname_ptr,
+                                       size_t* foffset_ptr) {
++
+   // Get the list of mapped file list
+   bool ret_value = false;
+   std::ifstream proc_maps;
+@@ -804,7 +804,9 @@ bool amd::Os::FindFileNameFromAddress(const void* image, std::string* fname_ptr,
+     char dash;
+     std::stringstream tokens(line);
+     uintptr_t low_address, high_address;
+-    tokens >> std::hex >> low_address >> std::dec >> dash >> std::hex >> high_address >> std::dec;
++    tokens >> std::hex >> low_address >> std::dec
++           >> dash
++           >> std::hex >> high_address >> std::dec;
+     if (dash != '-') {
+       continue;
+     }
+@@ -816,7 +818,10 @@ bool amd::Os::FindFileNameFromAddress(const void* image, std::string* fname_ptr,
+       std::string permissions, device, uri_file_path;
+       size_t offset;
+       uint64_t inode;
+-      tokens >> permissions >> std::hex >> offset >> std::dec >> device >> inode;
++      tokens >> permissions
++             >> std::hex >> offset >> std::dec
++             >> device
++             >> inode;
+       std::getline(tokens >> std::ws, uri_file_path);
+ 
+       if (inode == 0 || uri_file_path.empty()) {
+@@ -865,7 +870,7 @@ bool Os::MemoryMapFile(const char* fname, const void** mmap_ptr, size_t* mmap_si
+ 
+   struct stat stat_buf;
+   int fd = open(fname, O_RDONLY);
+-  if (fd < 0) {
++  if (fd < 0 ) {
+     return false;
+   }
+ 
+@@ -892,15 +897,15 @@ bool Os::MemoryMapFileTruncated(const char* fname, const void** mmap_ptr, size_t
+   }
+ 
+   struct stat stat_buf;
+-  int fd = shm_open(fname, O_RDWR | O_CREAT, S_IRWXU | S_IRWXG | S_IRWXO);
+-  if (fd < 0) {
++  int fd = shm_open(fname, O_RDWR|O_CREAT, S_IRWXU|S_IRWXG|S_IRWXO);
++  if (fd < 0 ) {
+     return false;
+   }
+ 
+   if (ftruncate(fd, mmap_size) != 0) {
+     return false;
+   }
+-  *mmap_ptr = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
++  *mmap_ptr = mmap(NULL, mmap_size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+ 
+   close(fd);
+ 
+@@ -911,11 +916,13 @@ bool Os::MemoryMapFileTruncated(const char* fname, const void** mmap_ptr, size_t
+   return true;
+ }
+ 
+-int Os::getProcessId() { return ::getpid(); }
++int Os::getProcessId() {
++  return ::getpid();
++}
+ 
+ // ================================================================================================
+ void* Os::CreateIpcMemory(const char* fname, size_t size, FileDesc* desc) {
+-  *desc = shm_open(fname, O_RDWR | O_CREAT, S_IRWXU | S_IRWXG | S_IRWXO);
++  *desc = shm_open(fname, O_RDWR | O_CREAT, S_IRWXU|S_IRWXG|S_IRWXO);
+   if (*desc < 0) {
+     return nullptr;
+   }
+@@ -933,7 +940,7 @@ void* Os::CreateIpcMemory(const char* fname, size_t size, FileDesc* desc) {
+ void* Os::OpenIpcMemory(const char* fname, const FileDesc desc, size_t size) {
+   FileDesc handle = desc;
+   if (fname != nullptr) {
+-    handle = shm_open(fname, O_RDWR, S_IRWXU | S_IRWXG | S_IRWXO);
++    handle = shm_open(fname, O_RDWR, S_IRWXU|S_IRWXG|S_IRWXO);
+   }
+ 
+   if (handle < 0) {
+@@ -954,7 +961,6 @@ void Os::CloseIpcMemory(const FileDesc desc, const void* ptr, size_t size) {
+   }
+ }
+ 
+-// ================================================================================================
+ void Os::PrintLibraryLocation() {
+   Dl_info dl_info;
+   if (dladdr(reinterpret_cast<void*>(Os::loadLibrary), &dl_info) && dl_info.dli_fname) {
+@@ -964,21 +970,6 @@ void Os::PrintLibraryLocation() {
+   }
+ }
+ 
+-// ================================================================================================
+-bool Os::DumpCoreFile() {
+-  // Execute the default handler if a GPU core file should be generated ...
+-  struct rlimit rlimit;
+-  return (getrlimit(RLIMIT_CORE, &rlimit) == 0 && rlimit.rlim_cur != 0);
+-}
+-
+-// ================================================================================================
+-void Os::CxaDemangle(const std::string& name, std::string* result) {
+-  int status = 0;
+-  char* demangled = abi::__cxa_demangle(name.c_str(), nullptr, nullptr, &status);
+-  *result = (status == 0 && demangled != nullptr) ? demangled : name;
+-  free(demangled);
+-}
+-
+ }  // namespace amd
+ 
+ #endif  // !defined(_WIN32) && !defined(__CYGWIN__)
+diff --git a/projects/clr/rocclr/os/os_win32.cpp b/projects/clr/rocclr/os/os_win32.cpp
+index 67d55a21c6..eac2235b9d 100644
+--- a/projects/clr/rocclr/os/os_win32.cpp
++++ b/projects/clr/rocclr/os/os_win32.cpp
+@@ -730,7 +730,6 @@ void Os::CloseIpcMemory(const FileDesc desc, const void* ptr, size_t size) {
+   }
+ }
+ 
+-// ================================================================================================
+ void Os::PrintLibraryLocation() {
+   HMODULE hm = NULL;
+   if (GetModuleHandleExA(
+@@ -745,12 +744,6 @@ void Os::PrintLibraryLocation() {
+   ClPrint(amd::LOG_INFO, amd::LOG_INIT, "HIP Library Path: <unknown>");
+ }
+ 
+-// ================================================================================================
+-bool Os::DumpCoreFile() { return false; }
+-
+-// ================================================================================================
+-void Os::CxaDemangle(const std::string& name, std::string* result) { *result = name; }
+-
+ }  // namespace amd
+ 
+ #endif  // _WIN32 || __CYGWIN__
+-- 
+2.47.1.windows.2
+

--- a/patches/amd-mainline/rocm-systems/0011-Revert-formatting-changes-to-palblitcl.cpp.patch
+++ b/patches/amd-mainline/rocm-systems/0011-Revert-formatting-changes-to-palblitcl.cpp.patch
@@ -1,0 +1,839 @@
+From df17344183fc3168c866f81668f7fec619b364ee Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Thu, 28 Aug 2025 14:25:35 -0700
+Subject: [PATCH 11/11] Revert formatting changes to palblitcl.cpp.
+
+---
+ projects/clr/rocclr/device/pal/palblitcl.cpp | 714 +++++++++----------
+ 1 file changed, 334 insertions(+), 380 deletions(-)
+
+diff --git a/projects/clr/rocclr/device/pal/palblitcl.cpp b/projects/clr/rocclr/device/pal/palblitcl.cpp
+index ec548b08b6..351993e426 100644
+--- a/projects/clr/rocclr/device/pal/palblitcl.cpp
++++ b/projects/clr/rocclr/device/pal/palblitcl.cpp
+@@ -23,16 +23,19 @@ namespace amd::pal {
+ #define RUNTIME_KERNEL(...) #__VA_ARGS__
+ 
+ const char* SchedulerSourceCode = RUNTIME_KERNEL(
+-\n extern void __amd_scheduler(__global void*, __global void*, uint);
+-\n __kernel void __amd_rocclr_scheduler(__global void* queue, __global void* params,
+-                                         uint paramIdx) {
++\n
++extern void __amd_scheduler(__global void*, __global void*, uint);
++\n
++__kernel void __amd_rocclr_scheduler(__global void* queue, __global void* params, uint paramIdx) {
+   __amd_scheduler(queue, params, paramIdx);
+ }
+ \n);
+ 
+ const char* SchedulerSourceCode20 = RUNTIME_KERNEL(
+-\n extern void __amd_scheduler_pal(__global void*, __global void*, uint);
+-\n __kernel void __amd_rocclr_scheduler(__global void* queue, __global void* params,
++\n
++extern void __amd_scheduler_pal(__global void*, __global void*, uint);
++\n
++ __kernel void __amd_rocclr_scheduler(__global void* queue, __global void* params,
+                                          uint paramIdx) {
+   __amd_scheduler_pal(queue, params, paramIdx);
+ }
+@@ -59,166 +62,149 @@ const char* SchedulerSourceCode20 = RUNTIME_KERNEL(
+  */
+ 
+ const char* TrapHandlerCode = RUNTIME_KERNEL(
+-\n.if.amdgcn.gfx_generation_number == 11
+-\n.set SQ_WAVE_PC_HI_ADDRESS_MASK, 0xFFFF
+-\n.set SQ_WAVE_PC_HI_HT_SHIFT, 24
+-\n.set SQ_WAVE_PC_HI_TRAP_ID_SHIFT, 16
+-\n.set SQ_WAVE_PC_HI_TRAP_ID_SIZE, 8
+-\n.set SQ_WAVE_PC_HI_TRAP_ID_BFE,
+-    (SQ_WAVE_PC_HI_TRAP_ID_SHIFT | (SQ_WAVE_PC_HI_TRAP_ID_SIZE << 16))
+-\n.set SQ_WAVE_STATUS_HALT_SHIFT, 13
+-\n.set SQ_WAVE_STATUS_TRAP_SKIP_EXPORT_SHIFT, 18
+-\n.set SQ_WAVE_STATUS_HALT_BFE, (SQ_WAVE_STATUS_HALT_SHIFT | (1 << 16))
+-\n.set SQ_WAVE_TRAPSTS_MEM_VIOL_SHIFT, 8
+-\n.set SQ_WAVE_TRAPSTS_ILLEGAL_INST_SHIFT, 11
+-\n.set SQ_WAVE_TRAPSTS_XNACK_ERROR_SHIFT, 28
+-\n.set SQ_WAVE_TRAPSTS_MATH_EXCP, 0x7F
+-\n.set SQ_WAVE_TRAPSTS_PERF_SNAPSHOT_SHIFT, 26
+-\n.set SQ_WAVE_TRAPSTS_HOST_TRAP_SHIFT, 22
+-\n.set SQ_WAVE_MODE_EXCP_EN_SHIFT, 12
+-\n.set SQ_WAVE_MODE_EXCP_EN_SIZE, 8
+-\n.set TRAP_ID_ABORT, 2
+-\n.set TRAP_ID_DEBUGTRAP, 3
+-\n.set DOORBELL_ID_SIZE, 10
+-\n.set DOORBELL_ID_MASK, ((1 << DOORBELL_ID_SIZE) - 1)
+-\n.set EC_QUEUE_WAVE_ABORT_M0, (1 << (DOORBELL_ID_SIZE + 0))
+-\n.set EC_QUEUE_WAVE_TRAP_M0, (1 << (DOORBELL_ID_SIZE + 1))
+-\n.set EC_QUEUE_WAVE_MATH_ERROR_M0, (1 << (DOORBELL_ID_SIZE + 2))
+-\n.set EC_QUEUE_WAVE_ILLEGAL_INSTRUCTION_M0, (1 << (DOORBELL_ID_SIZE + 3))
+-\n.set EC_QUEUE_WAVE_MEMORY_VIOLATION_M0, (1 << (DOORBELL_ID_SIZE + 4))
+-\n.set EC_QUEUE_WAVE_APERTURE_VIOLATION_M0, (1 << (DOORBELL_ID_SIZE + 5))
+-\n
+-\n.set TTMP6_SPI_TTMPS_SETUP_DISABLED_SHIFT, 31
+-\n.set TTMP6_WAVE_STOPPED_SHIFT, 30
+-\n.set TTMP6_SAVED_STATUS_HALT_SHIFT, 29
+-\n.set TTMP6_SAVED_STATUS_HALT_MASK, (1 << TTMP6_SAVED_STATUS_HALT_SHIFT)
+-\n.set TTMP6_SAVED_TRAP_ID_SHIFT, 25
+-\n.set TTMP6_SAVED_TRAP_ID_SIZE, 4
+-\n.set TTMP6_SAVED_TRAP_ID_MASK,
+-    (((1 << TTMP6_SAVED_TRAP_ID_SIZE) - 1) << TTMP6_SAVED_TRAP_ID_SHIFT)
+-\n.set TTMP6_SAVED_TRAP_ID_BFE, (TTMP6_SAVED_TRAP_ID_SHIFT | (TTMP6_SAVED_TRAP_ID_SIZE << 16))
+-\n
+-\n.set TTMP_PC_HI_SHIFT, 7
+-\n.set TTMP_DEBUG_ENABLED_SHIFT,
+-    23
+-\n
+-\n  // ABI between first and second level trap handler:
+-\n  //   ttmp0  = PC[31:0]
+-\n  //   ttmp6 = 0[6:0], DispatchPktIndx[24:0]
+-\n  //   ttmp8  = WorkgroupIdX
+-\n  //   ttmp9  = WorkgroupIdY
+-\n  //   ttmp10 = WorkgroupIdZ
+-\n  //   ttmp11 = 0[7:0], DebugEnabled[0], 0[15:0], NoScratch[0], WaveIdInWG[5:0]
+-\n  //   ttmp12 = SQ_WAVE_STATUS
+-\n  //   ttmp14 = TMA[31:0]
+-\n  //   ttmp15 = TMA[63:32]
+-\n
+-\n.globl trap_entry
+-\n.type trap_entry,
+-    @function
+-\n.align 256
+-\n
+-\ntrap_entry :
++\n.if .amdgcn.gfx_generation_number == 11
++\n.set SQ_WAVE_PC_HI_ADDRESS_MASK              , 0xFFFF
++\n.set SQ_WAVE_PC_HI_HT_SHIFT                  , 24
++\n.set SQ_WAVE_PC_HI_TRAP_ID_SHIFT             , 16
++\n.set SQ_WAVE_PC_HI_TRAP_ID_SIZE              , 8
++\n.set SQ_WAVE_PC_HI_TRAP_ID_BFE               , (SQ_WAVE_PC_HI_TRAP_ID_SHIFT | (SQ_WAVE_PC_HI_TRAP_ID_SIZE << 16))
++\n.set SQ_WAVE_STATUS_HALT_SHIFT               , 13
++\n.set SQ_WAVE_STATUS_TRAP_SKIP_EXPORT_SHIFT   , 18
++\n.set SQ_WAVE_STATUS_HALT_BFE                 , (SQ_WAVE_STATUS_HALT_SHIFT | (1 << 16))
++\n.set SQ_WAVE_TRAPSTS_MEM_VIOL_SHIFT          , 8
++\n.set SQ_WAVE_TRAPSTS_ILLEGAL_INST_SHIFT      , 11
++\n.set SQ_WAVE_TRAPSTS_XNACK_ERROR_SHIFT       , 28
++\n.set SQ_WAVE_TRAPSTS_MATH_EXCP               , 0x7F
++\n.set SQ_WAVE_TRAPSTS_PERF_SNAPSHOT_SHIFT     , 26
++\n.set SQ_WAVE_TRAPSTS_HOST_TRAP_SHIFT         , 22
++\n.set SQ_WAVE_MODE_EXCP_EN_SHIFT              , 12
++\n.set SQ_WAVE_MODE_EXCP_EN_SIZE               , 8
++\n.set TRAP_ID_ABORT                           , 2
++\n.set TRAP_ID_DEBUGTRAP                       , 3
++\n.set DOORBELL_ID_SIZE                        , 10
++\n.set DOORBELL_ID_MASK                        , ((1 << DOORBELL_ID_SIZE) - 1)
++\n.set EC_QUEUE_WAVE_ABORT_M0                  , (1 << (DOORBELL_ID_SIZE + 0))
++\n.set EC_QUEUE_WAVE_TRAP_M0                   , (1 << (DOORBELL_ID_SIZE + 1))
++\n.set EC_QUEUE_WAVE_MATH_ERROR_M0             , (1 << (DOORBELL_ID_SIZE + 2))
++\n.set EC_QUEUE_WAVE_ILLEGAL_INSTRUCTION_M0    , (1 << (DOORBELL_ID_SIZE + 3))
++\n.set EC_QUEUE_WAVE_MEMORY_VIOLATION_M0       , (1 << (DOORBELL_ID_SIZE + 4))
++\n.set EC_QUEUE_WAVE_APERTURE_VIOLATION_M0     , (1 << (DOORBELL_ID_SIZE + 5))
++\n
++\n.set TTMP6_SPI_TTMPS_SETUP_DISABLED_SHIFT    , 31
++\n.set TTMP6_WAVE_STOPPED_SHIFT                , 30
++\n.set TTMP6_SAVED_STATUS_HALT_SHIFT           , 29
++\n.set TTMP6_SAVED_STATUS_HALT_MASK            , (1 << TTMP6_SAVED_STATUS_HALT_SHIFT)
++\n.set TTMP6_SAVED_TRAP_ID_SHIFT               , 25
++\n.set TTMP6_SAVED_TRAP_ID_SIZE                , 4
++\n.set TTMP6_SAVED_TRAP_ID_MASK                , (((1 << TTMP6_SAVED_TRAP_ID_SIZE) - 1) << TTMP6_SAVED_TRAP_ID_SHIFT)
++\n.set TTMP6_SAVED_TRAP_ID_BFE                 , (TTMP6_SAVED_TRAP_ID_SHIFT | (TTMP6_SAVED_TRAP_ID_SIZE << 16))
++\n
++\n.set TTMP_PC_HI_SHIFT                        , 7
++\n.set TTMP_DEBUG_ENABLED_SHIFT                , 23
++\n
++\n// ABI between first and second level trap handler:
++\n//   ttmp0  = PC[31:0]
++\n//   ttmp6 = 0[6:0], DispatchPktIndx[24:0]
++\n//   ttmp8  = WorkgroupIdX
++\n//   ttmp9  = WorkgroupIdY
++\n//   ttmp10 = WorkgroupIdZ
++\n//   ttmp11 = 0[7:0], DebugEnabled[0], 0[15:0], NoScratch[0], WaveIdInWG[5:0]
++\n//   ttmp12 = SQ_WAVE_STATUS
++\n//   ttmp14 = TMA[31:0]
++\n//   ttmp15 = TMA[63:32]
++\n
++\n     .globl      trap_entry
++\n     .type       trap_entry,@function
++\n     .align      256
++\n
++\ntrap_entry:
+ \n  // Extract trap_id from ttmp2
+-\n s_bfe_u32 ttmp2, ttmp1,
+-    SQ_WAVE_PC_HI_TRAP_ID_BFE
+-\n s_cbranch_scc0.no_skip_debugtrap  // If trap_id == 0, it's not an s_trap nor host trap
++\n  s_bfe_u32                             ttmp2, ttmp1, SQ_WAVE_PC_HI_TRAP_ID_BFE
++\n  s_cbranch_scc0                        .no_skip_debugtrap                      // If trap_id == 0, it's not an s_trap nor host trap
+ \n
+ \n  // Check if the it was an host trap.
+-\n s_bitcmp1_b32 ttmp1,
+-    SQ_WAVE_PC_HI_HT_SHIFT
+-\n s_cbranch_scc1.not_s_trap
++\n  s_bitcmp1_b32                         ttmp1, SQ_WAVE_PC_HI_HT_SHIFT
++\n  s_cbranch_scc1                        .not_s_trap
+ \n
+ \n  // It's an s_trap; advance the PC
+-\n s_add_u32 ttmp0, ttmp0, 0x4
+-\n s_addc_u32 ttmp1, ttmp1,
+-    0x0
++\n  s_add_u32                             ttmp0, ttmp0, 0x4
++\n  s_addc_u32                            ttmp1, ttmp1, 0x0
+ \n
+ \n  // If llvm.debugtrap and debugger is not attached.
+-\n s_cmp_eq_u32 ttmp2, TRAP_ID_DEBUGTRAP
+-\n s_cbranch_scc0.no_skip_debugtrap
+-\n s_bitcmp0_b32 ttmp11,
+-    TTMP_DEBUG_ENABLED_SHIFT
+-\n s_cbranch_scc0
+-        .no_skip_debugtrap
++\n  s_cmp_eq_u32                          ttmp2, TRAP_ID_DEBUGTRAP
++\n  s_cbranch_scc0                        .no_skip_debugtrap
++\n  s_bitcmp0_b32                         ttmp11, TTMP_DEBUG_ENABLED_SHIFT
++\n  s_cbranch_scc0                        .no_skip_debugtrap
+ \n
+ \n  // Ignore llvm.debugtrap.
+-\n s_branch.exit_trap
++\n  s_branch                              .exit_trap
+ \n
+-\n.not_s_trap :
+-\n.no_skip_debugtrap :
++\n.not_s_trap:
++\n.no_skip_debugtrap:
+ \n  // Save trap id and halt status in ttmp6.
+-\n s_andn2_b32 ttmp6,
+-    ttmp6, (TTMP6_SAVED_TRAP_ID_MASK | TTMP6_SAVED_STATUS_HALT_MASK)
+-\n s_bfe_u32 ttmp2, ttmp1, SQ_WAVE_PC_HI_TRAP_ID_BFE
+-\n s_min_u32 ttmp2, ttmp2, 0xF
+-\n s_lshl_b32 ttmp2, ttmp2, TTMP6_SAVED_TRAP_ID_SHIFT
+-\n s_or_b32 ttmp6, ttmp6, ttmp2
+-\n s_bfe_u32 ttmp2, ttmp12, SQ_WAVE_STATUS_HALT_BFE
+-\n s_lshl_b32 ttmp2, ttmp2, TTMP6_SAVED_STATUS_HALT_SHIFT
+-\n s_or_b32 ttmp6, ttmp6,
+-    ttmp2
++\n  s_andn2_b32                           ttmp6, ttmp6, (TTMP6_SAVED_TRAP_ID_MASK | TTMP6_SAVED_STATUS_HALT_MASK)
++\n  s_bfe_u32                             ttmp2, ttmp1, SQ_WAVE_PC_HI_TRAP_ID_BFE
++\n  s_min_u32                             ttmp2, ttmp2, 0xF
++\n  s_lshl_b32                            ttmp2, ttmp2, TTMP6_SAVED_TRAP_ID_SHIFT
++\n  s_or_b32                              ttmp6, ttmp6, ttmp2
++\n  s_bfe_u32                             ttmp2, ttmp12, SQ_WAVE_STATUS_HALT_BFE
++\n  s_lshl_b32                            ttmp2, ttmp2, TTMP6_SAVED_STATUS_HALT_SHIFT
++\n  s_or_b32                              ttmp6, ttmp6, ttmp2
+ \n
+ \n  // Fetch doorbell id for our queue.
+-\n s_sendmsg_rtn_b32 ttmp3, sendmsg(MSG_RTN_GET_DOORBELL)
+-\n s_waitcnt lgkmcnt(0)
+-\n s_and_b32 ttmp3, ttmp3,
+-    DOORBELL_ID_MASK
++\n  s_sendmsg_rtn_b32                     ttmp3, sendmsg(MSG_RTN_GET_DOORBELL)
++\n  s_waitcnt                             lgkmcnt(0)
++\n  s_and_b32                             ttmp3, ttmp3, DOORBELL_ID_MASK
+ \n
+ \n  // Map trap reason to an exception code.
+-\n s_getreg_b32 ttmp2, hwreg(HW_REG_TRAPSTS)
++\n  s_getreg_b32                          ttmp2, hwreg(HW_REG_TRAPSTS)
+ \n
+-\n s_bitcmp1_b32 ttmp2, SQ_WAVE_TRAPSTS_XNACK_ERROR_SHIFT
+-\n s_cbranch_scc0.not_memory_violation
+-\n s_or_b32 ttmp3, ttmp3,
+-    EC_QUEUE_WAVE_MEMORY_VIOLATION_M0
++\n  s_bitcmp1_b32                         ttmp2, SQ_WAVE_TRAPSTS_XNACK_ERROR_SHIFT
++\n  s_cbranch_scc0                        .not_memory_violation
++\n  s_or_b32                              ttmp3, ttmp3, EC_QUEUE_WAVE_MEMORY_VIOLATION_M0
+ \n
+ \n  // Aperture violation requires XNACK_ERROR == 0.
+-\n s_branch.not_aperture_violation
+-\n
+-\n.not_memory_violation :
+-\n s_bitcmp1_b32 ttmp2, SQ_WAVE_TRAPSTS_MEM_VIOL_SHIFT
+-\n s_cbranch_scc0.not_aperture_violation
+-\n s_or_b32 ttmp3, ttmp3, EC_QUEUE_WAVE_APERTURE_VIOLATION_M0
+-\n
+-\n.not_aperture_violation :
+-\n s_bitcmp1_b32 ttmp2, SQ_WAVE_TRAPSTS_ILLEGAL_INST_SHIFT
+-\n s_cbranch_scc0.not_illegal_instruction
+-\n s_or_b32 ttmp3, ttmp3, EC_QUEUE_WAVE_ILLEGAL_INSTRUCTION_M0
+-\n
+-\n.not_illegal_instruction :
+-\n s_and_b32 ttmp2, ttmp2, SQ_WAVE_TRAPSTS_MATH_EXCP
+-\n s_cbranch_scc0.not_math_exception
+-\n s_getreg_b32 ttmp7, hwreg(HW_REG_MODE)
+-\n s_lshl_b32 ttmp2, ttmp2, SQ_WAVE_MODE_EXCP_EN_SHIFT
+-\n s_and_b32 ttmp2, ttmp2, ttmp7
+-\n s_cbranch_scc0.not_math_exception
+-\n s_or_b32 ttmp3, ttmp3, EC_QUEUE_WAVE_MATH_ERROR_M0
+-\n
+-\n.not_math_exception :
+-\n s_bfe_u32 ttmp2, ttmp6, TTMP6_SAVED_TRAP_ID_BFE
+-\n s_cmp_eq_u32 ttmp2, TRAP_ID_ABORT
+-\n s_cbranch_scc0.not_abort_trap
+-\n s_or_b32 ttmp3, ttmp3,
+-    EC_QUEUE_WAVE_ABORT_M0
+-\n
+-\n.not_abort_trap :
++\n  s_branch                              .not_aperture_violation
++\n
++\n.not_memory_violation:
++\n  s_bitcmp1_b32                         ttmp2, SQ_WAVE_TRAPSTS_MEM_VIOL_SHIFT
++\n  s_cbranch_scc0                        .not_aperture_violation
++\n  s_or_b32                              ttmp3, ttmp3, EC_QUEUE_WAVE_APERTURE_VIOLATION_M0
++\n
++\n.not_aperture_violation:
++\n  s_bitcmp1_b32                         ttmp2, SQ_WAVE_TRAPSTS_ILLEGAL_INST_SHIFT
++\n  s_cbranch_scc0                        .not_illegal_instruction
++\n  s_or_b32                              ttmp3, ttmp3, EC_QUEUE_WAVE_ILLEGAL_INSTRUCTION_M0
++\n
++\n.not_illegal_instruction:
++\n  s_and_b32                             ttmp2, ttmp2, SQ_WAVE_TRAPSTS_MATH_EXCP
++\n  s_cbranch_scc0                        .not_math_exception
++\n  s_getreg_b32                          ttmp7, hwreg(HW_REG_MODE)
++\n  s_lshl_b32                            ttmp2, ttmp2, SQ_WAVE_MODE_EXCP_EN_SHIFT
++\n  s_and_b32                             ttmp2, ttmp2, ttmp7
++\n  s_cbranch_scc0                        .not_math_exception
++\n  s_or_b32                              ttmp3, ttmp3, EC_QUEUE_WAVE_MATH_ERROR_M0
++\n
++\n.not_math_exception:
++\n  s_bfe_u32                             ttmp2, ttmp6, TTMP6_SAVED_TRAP_ID_BFE
++\n  s_cmp_eq_u32                          ttmp2, TRAP_ID_ABORT
++\n  s_cbranch_scc0                        .not_abort_trap
++\n  s_or_b32                              ttmp3, ttmp3, EC_QUEUE_WAVE_ABORT_M0
++\n
++\n.not_abort_trap:
+ \n  // If no other exception was flagged then report a generic error.
+-\n s_andn2_b32 ttmp2, ttmp3, DOORBELL_ID_MASK
+-\n s_cbranch_scc1.send_interrupt
+-\n s_or_b32 ttmp3, ttmp3,
+-    EC_QUEUE_WAVE_TRAP_M0
++\n  s_andn2_b32                           ttmp2, ttmp3, DOORBELL_ID_MASK
++\n  s_cbranch_scc1                        .send_interrupt
++\n  s_or_b32                              ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
+ \n
+-\n.send_interrupt :
++\n.send_interrupt:
+ \n  // m0 = interrupt data = (exception_code << DOORBELL_ID_SIZE) | doorbell_id
+-\n s_mov_b32 ttmp2, m0
+-\n s_mov_b32 m0,
+-    ttmp3
+-\n s_nop 0x0  // Manually inserted wait states
+-\n s_sendmsg sendmsg(MSG_INTERRUPT)
+-\n s_waitcnt lgkmcnt(0)  // Wait for the message to go out.
+-\n s_mov_b32 m0,
+-    ttmp2
++\n  s_mov_b32                             ttmp2, m0
++\n  s_mov_b32                             m0, ttmp3
++\n  s_nop                                 0x0                             // Manually inserted wait states
++\n  s_sendmsg                             sendmsg(MSG_INTERRUPT)
++\n  s_waitcnt                             lgkmcnt(0)                      // Wait for the message to go out.
++\n  s_mov_b32                             m0, ttmp2
+ \n
+ \n  // Parking the wave requires saving the original pc in the preserved ttmps.
+ \n  // Register layout before parking the wave:
+@@ -231,147 +217,132 @@ const char* TrapHandlerCode = RUNTIME_KERNEL(
+ \n  // ttmp7:  pc_lo[31:0]
+ \n  // ttmp11: 1st_level_ttmp11[31:23] pc_hi[15:0] 1st_level_ttmp11[6:0]
+ \n  // Save the PC
+-\n s_mov_b32 ttmp7, ttmp0
+-\n s_and_b32 ttmp1, ttmp1, SQ_WAVE_PC_HI_ADDRESS_MASK
+-\n s_lshl_b32 ttmp1, ttmp1, TTMP_PC_HI_SHIFT
+-\n s_andn2_b32 ttmp11, ttmp11, (SQ_WAVE_PC_HI_ADDRESS_MASK << TTMP_PC_HI_SHIFT)
+-\n s_or_b32 ttmp11, ttmp11,
+-    ttmp1
++\n  s_mov_b32                             ttmp7, ttmp0
++\n  s_and_b32                             ttmp1, ttmp1, SQ_WAVE_PC_HI_ADDRESS_MASK
++\n  s_lshl_b32                            ttmp1, ttmp1, TTMP_PC_HI_SHIFT
++\n  s_andn2_b32                           ttmp11, ttmp11, (SQ_WAVE_PC_HI_ADDRESS_MASK << TTMP_PC_HI_SHIFT)
++\n  s_or_b32                              ttmp11, ttmp11, ttmp1
+ \n
+ \n  // Park the wave
+-\n s_getpc_b64[ttmp0, ttmp1]
+-\n s_add_u32 ttmp0, ttmp0, .parked -.
+-\n s_addc_u32 ttmp1, ttmp1,
+-    0x0
++\n  s_getpc_b64                           [ttmp0, ttmp1]
++\n  s_add_u32                             ttmp0, ttmp0, .parked - .
++\n  s_addc_u32                            ttmp1, ttmp1, 0x0
+ \n
+-\n.halt_wave :
++\n.halt_wave:
+ \n  // Halt the wavefront upon restoring STATUS below.
+-\n s_bitset1_b32 ttmp6, TTMP6_WAVE_STOPPED_SHIFT
+-\n s_bitset1_b32 ttmp12,
+-    SQ_WAVE_STATUS_HALT_SHIFT
++\n  s_bitset1_b32                         ttmp6, TTMP6_WAVE_STOPPED_SHIFT
++\n  s_bitset1_b32                         ttmp12, SQ_WAVE_STATUS_HALT_SHIFT
+ \n  // Set WAVE.SKIP_EXPORT as a maker so the debugger knows the trap handler was
+ \n  // entered and has decided to halt the wavee.
+-\n s_bitset1_b32 ttmp12,
+-    SQ_WAVE_STATUS_TRAP_SKIP_EXPORT_SHIFT
++\n  s_bitset1_b32                         ttmp12, SQ_WAVE_STATUS_TRAP_SKIP_EXPORT_SHIFT
+ \n
+-\n.exit_trap :
++\n.exit_trap:
+ \n  // Restore SQ_WAVE_STATUS.
+-\n s_and_b64 exec, exec,
+-    exec  // restore STATUS.EXECZ, not writable by s_setreg_b32
+-\n s_and_b64 vcc, vcc,
+-    vcc  // restore STATUS.VCCZ, not writable by s_setreg_b32
+-\n s_setreg_b32 hwreg(HW_REG_STATUS),
+-    ttmp12
++\n  s_and_b64                             exec, exec, exec               // restore STATUS.EXECZ, not writable by s_setreg_b32
++\n  s_and_b64                             vcc, vcc, vcc                  // restore STATUS.VCCZ, not writable by s_setreg_b32
++\n  s_setreg_b32                          hwreg(HW_REG_STATUS), ttmp12
+ \n
+ \n  // Return to original (possibly modified) PC.
+-\n s_rfe_b64[ttmp0, ttmp1]
++\n  s_rfe_b64                             [ttmp0, ttmp1]
+ \n
+-\n.parked :
+-\n s_trap 0x2
+-\n s_branch.parked
++\n.parked:
++\n  s_trap                                0x2
++\n  s_branch                              .parked
+ \n
+-\n  // For gfx11, add padding instructions so we can ensure instruction cache
+-\n  // prefetch always has something to load.
+-\n.rept(256 - ((.- trap_entry) % 64)) / 4
+-\n s_code_end
++\n// For gfx11, add padding instructions so we can ensure instruction cache
++\n// prefetch always has something to load.
++\n.rept (256 - ((. - trap_entry) % 64)) / 4
++\n  s_code_end
+ \n.endr
+-\n.elseif.amdgcn.gfx_generation_number == 12
+-\n.set DOORBELL_ID_SIZE, 10
+-\n.set DOORBELL_ID_MASK, ((1 << DOORBELL_ID_SIZE) - 1)
+-\n.set EC_QUEUE_WAVE_ABORT_M0, (1 << (DOORBELL_ID_SIZE + 0))
+-\n.set EC_QUEUE_WAVE_TRAP_M0, (1 << (DOORBELL_ID_SIZE + 1))
+-\n.set EC_QUEUE_WAVE_MATH_ERROR_M0, (1 << (DOORBELL_ID_SIZE + 2))
+-\n.set EC_QUEUE_WAVE_ILLEGAL_INSTRUCTION_M0, (1 << (DOORBELL_ID_SIZE + 3))
+-\n.set EC_QUEUE_WAVE_MEMORY_VIOLATION_M0, (1 << (DOORBELL_ID_SIZE + 4))
+-\n.set EC_QUEUE_WAVE_APERTURE_VIOLATION_M0, (1 << (DOORBELL_ID_SIZE + 5))
+-\n
+-\n.set SQ_WAVE_EXCP_FLAG_PRIV_ADDR_WATCH_MASK, (1 << 4) - 1
+-\n.set SQ_WAVE_EXCP_FLAG_PRIV_MEMVIOL_SHIFT, 4
+-\n.set SQ_WAVE_EXCP_FLAG_PRIV_ILLEGAL_INST_SHIFT, 6
+-\n.set SQ_WAVE_EXCP_FLAG_PRIV_HT_SHIFT, 7
+-\n.set SQ_WAVE_EXCP_FLAG_PRIV_WAVE_START_SHIFT, 8
+-\n.set SQ_WAVE_EXCP_FLAG_PRIV_WAVE_END_SHIFT, 9
+-\n.set SQ_WAVE_EXCP_FLAG_PRIV_TRAP_AFTER_INST_SHIFT, 11
+-\n.set SQ_WAVE_EXCP_FLAG_PRIV_XNACK_ERROR_SHIFT, 12
+-\n
+-\n.set SQ_WAVE_EXCP_FLAG_USER_MATH_EXCP_SHIFT, 0
+-\n.set SQ_WAVE_EXCP_FLAG_USER_MATH_EXCP_SIZE, 7
+-\n
+-\n.set SQ_WAVE_TRAP_CTRL_MATH_EXCP_MASK, ((1 << 7) - 1)
+-\n.set SQ_WAVE_TRAP_CTRL_ADDR_WATCH_SHIFT, 7
+-\n.set SQ_WAVE_TRAP_CTRL_WAVE_END_SHIFT, 8
+-\n.set SQ_WAVE_TRAP_CTRL_TRAP_AFTER_INST, 9
+-\n
+-\n.set SQ_WAVE_PC_HI_ADDRESS_MASK, 0xFFFF
+-\n.set SQ_WAVE_PC_HI_TRAP_ID_BFE,
+-    (SQ_WAVE_PC_HI_TRAP_ID_SHIFT | (SQ_WAVE_PC_HI_TRAP_ID_SIZE << 16))
+-\n.set SQ_WAVE_PC_HI_TRAP_ID_SHIFT, 28
+-\n.set SQ_WAVE_PC_HI_TRAP_ID_SIZE, 4
+-\n.set SQ_WAVE_STATE_PRIV_HALT_BFE, (SQ_WAVE_STATE_PRIV_HALT_SHIFT | (1 << 16))
+-\n.set SQ_WAVE_STATE_PRIV_HALT_SHIFT, 14
+-\n.set SQ_WAVE_STATE_PRIV_BARRIER_COMPLETE_SHIFT, 2
+-\n.set TRAP_ID_ABORT, 2
+-\n.set TRAP_ID_DEBUGTRAP, 3
+-\n.set TTMP6_SAVED_STATUS_HALT_MASK, (1 << TTMP6_SAVED_STATUS_HALT_SHIFT)
+-\n.set TTMP6_SAVED_STATUS_HALT_SHIFT, 29
+-\n.set TTMP6_SAVED_TRAP_ID_BFE, (TTMP6_SAVED_TRAP_ID_SHIFT | (TTMP6_SAVED_TRAP_ID_SIZE << 16))
+-\n.set TTMP6_SAVED_TRAP_ID_MASK,
+-    (((1 << TTMP6_SAVED_TRAP_ID_SIZE) - 1) << TTMP6_SAVED_TRAP_ID_SHIFT)
+-\n.set TTMP6_SAVED_TRAP_ID_SHIFT, 25
+-\n.set TTMP6_SAVED_TRAP_ID_SIZE, 4
+-\n.set TTMP6_WAVE_STOPPED_SHIFT, 30
+-\n.set TTMP8_DEBUG_FLAG_SHIFT, 31
+-\n.set TTMP11_DEBUG_ENABLED_SHIFT, 23
+-\n.set TTMP_PC_HI_SHIFT,
+-    7
+-\n
+-\n  // ABI between first and second level trap handler:
+-\n  //   { ttmp1, ttmp0 } = TrapID[3:0], zeros, PC[47:0]
+-\n  //   ttmp11 = 0[7:0], DebugEnabled[0], 0[15:0], NoScratch[0], 0[5:0]
+-\n  //   ttmp12 = SQ_WAVE_STATE_PRIV
+-\n  //   ttmp14 = TMA[31:0]
+-\n  //   ttmp15 = TMA[63:32]
+-\n
+-\n.globl trap_entry
+-\n.type trap_entry,
+-    @function
+-\n.align 256
+-\n
+-\ntrap_entry :
++\n.elseif .amdgcn.gfx_generation_number == 12
++\n.set DOORBELL_ID_SIZE                          , 10
++\n.set DOORBELL_ID_MASK                          , ((1 << DOORBELL_ID_SIZE) - 1)
++\n.set EC_QUEUE_WAVE_ABORT_M0                    , (1 << (DOORBELL_ID_SIZE + 0))
++\n.set EC_QUEUE_WAVE_TRAP_M0                     , (1 << (DOORBELL_ID_SIZE + 1))
++\n.set EC_QUEUE_WAVE_MATH_ERROR_M0               , (1 << (DOORBELL_ID_SIZE + 2))
++\n.set EC_QUEUE_WAVE_ILLEGAL_INSTRUCTION_M0      , (1 << (DOORBELL_ID_SIZE + 3))
++\n.set EC_QUEUE_WAVE_MEMORY_VIOLATION_M0         , (1 << (DOORBELL_ID_SIZE + 4))
++\n.set EC_QUEUE_WAVE_APERTURE_VIOLATION_M0       , (1 << (DOORBELL_ID_SIZE + 5))
++\n
++\n.set SQ_WAVE_EXCP_FLAG_PRIV_ADDR_WATCH_MASK    , (1 << 4) - 1
++\n.set SQ_WAVE_EXCP_FLAG_PRIV_MEMVIOL_SHIFT      , 4
++\n.set SQ_WAVE_EXCP_FLAG_PRIV_ILLEGAL_INST_SHIFT , 6
++\n.set SQ_WAVE_EXCP_FLAG_PRIV_HT_SHIFT           , 7
++\n.set SQ_WAVE_EXCP_FLAG_PRIV_WAVE_START_SHIFT   , 8
++\n.set SQ_WAVE_EXCP_FLAG_PRIV_WAVE_END_SHIFT     , 9
++\n.set SQ_WAVE_EXCP_FLAG_PRIV_TRAP_AFTER_INST_SHIFT , 11
++\n.set SQ_WAVE_EXCP_FLAG_PRIV_XNACK_ERROR_SHIFT  , 12
++\n
++\n.set SQ_WAVE_EXCP_FLAG_USER_MATH_EXCP_SHIFT    , 0
++\n.set SQ_WAVE_EXCP_FLAG_USER_MATH_EXCP_SIZE     , 7
++\n
++\n.set SQ_WAVE_TRAP_CTRL_MATH_EXCP_MASK          , ((1 << 7) - 1)
++\n.set SQ_WAVE_TRAP_CTRL_ADDR_WATCH_SHIFT        , 7
++\n.set SQ_WAVE_TRAP_CTRL_WAVE_END_SHIFT          , 8
++\n.set SQ_WAVE_TRAP_CTRL_TRAP_AFTER_INST         , 9
++\n
++\n.set SQ_WAVE_PC_HI_ADDRESS_MASK                , 0xFFFF
++\n.set SQ_WAVE_PC_HI_TRAP_ID_BFE                 , (SQ_WAVE_PC_HI_TRAP_ID_SHIFT | (SQ_WAVE_PC_HI_TRAP_ID_SIZE << 16))
++\n.set SQ_WAVE_PC_HI_TRAP_ID_SHIFT               , 28
++\n.set SQ_WAVE_PC_HI_TRAP_ID_SIZE                , 4
++\n.set SQ_WAVE_STATE_PRIV_HALT_BFE               , (SQ_WAVE_STATE_PRIV_HALT_SHIFT | (1 << 16))
++\n.set SQ_WAVE_STATE_PRIV_HALT_SHIFT             , 14
++\n.set SQ_WAVE_STATE_PRIV_BARRIER_COMPLETE_SHIFT , 2
++\n.set TRAP_ID_ABORT                             , 2
++\n.set TRAP_ID_DEBUGTRAP                         , 3
++\n.set TTMP6_SAVED_STATUS_HALT_MASK              , (1 << TTMP6_SAVED_STATUS_HALT_SHIFT)
++\n.set TTMP6_SAVED_STATUS_HALT_SHIFT             , 29
++\n.set TTMP6_SAVED_TRAP_ID_BFE                   , (TTMP6_SAVED_TRAP_ID_SHIFT | (TTMP6_SAVED_TRAP_ID_SIZE << 16))
++\n.set TTMP6_SAVED_TRAP_ID_MASK                  , (((1 << TTMP6_SAVED_TRAP_ID_SIZE) - 1) << TTMP6_SAVED_TRAP_ID_SHIFT)
++\n.set TTMP6_SAVED_TRAP_ID_SHIFT                 , 25
++\n.set TTMP6_SAVED_TRAP_ID_SIZE                  , 4
++\n.set TTMP6_WAVE_STOPPED_SHIFT                  , 30
++\n.set TTMP8_DEBUG_FLAG_SHIFT                    , 31
++\n.set TTMP11_DEBUG_ENABLED_SHIFT                , 23
++\n.set TTMP_PC_HI_SHIFT                          , 7
++\n
++\n// ABI between first and second level trap handler:
++\n//   { ttmp1, ttmp0 } = TrapID[3:0], zeros, PC[47:0]
++\n//   ttmp11 = 0[7:0], DebugEnabled[0], 0[15:0], NoScratch[0], 0[5:0]
++\n//   ttmp12 = SQ_WAVE_STATE_PRIV
++\n//   ttmp14 = TMA[31:0]
++\n//   ttmp15 = TMA[63:32]
++\n
++\n     .globl      trap_entry
++\n     .type       trap_entry,@function
++\n     .align      256
++\n
++\ntrap_entry:
+ \n  // Clear ttmp3 as it will contain the exception code.
+-\n s_mov_b32 ttmp3,
+-    0
++\n  s_mov_b32            ttmp3, 0
+ \n
+ \n  // Branch if not a trap (an exception instead).
+-\n s_bfe_u32 ttmp2, ttmp1,
+-    SQ_WAVE_PC_HI_TRAP_ID_BFE
+-\n s_cbranch_scc0.check_exceptions
++\n  s_bfe_u32            ttmp2, ttmp1, SQ_WAVE_PC_HI_TRAP_ID_BFE
++\n  s_cbranch_scc0       .check_exceptions
+ \n
+ \n  // If caused by s_trap then advance PC, then figure out the trap ID:
+ \n  // - if trapID is DEBUGTRAP and debugger is attach, report WAVE_TRAP,
+ \n  // - if trapID is ABORTTRAP, report WAVE_ABORT,
+ \n  // - report WAVE_TRAP for any other trap ID.
+-\n s_add_u32 ttmp0, ttmp0, 0x4
+-\n s_addc_u32 ttmp1, ttmp1,
+-    0x0
++\n  s_add_u32            ttmp0, ttmp0, 0x4
++\n  s_addc_u32           ttmp1, ttmp1, 0x0
+ \n
+ \n  // If llvm.debugtrap and debugger is not attached.
+-\n s_cmp_eq_u32 ttmp2, TRAP_ID_DEBUGTRAP
+-\n s_cbranch_scc0.not_debug_trap
++\n  s_cmp_eq_u32         ttmp2, TRAP_ID_DEBUGTRAP
++\n  s_cbranch_scc0       .not_debug_trap
+ \n
+-\n s_bitcmp1_b32 ttmp11, TTMP11_DEBUG_ENABLED_SHIFT
+-\n s_cbranch_scc0.check_exceptions
+-\n s_or_b32 ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
++\n  s_bitcmp1_b32        ttmp11, TTMP11_DEBUG_ENABLED_SHIFT
++\n  s_cbranch_scc0       .check_exceptions
++\n  s_or_b32             ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
+ \n
+-\n.not_debug_trap :
+-\n s_cmp_eq_u32 ttmp2, TRAP_ID_ABORT
+-\n s_cbranch_scc0.not_abort_trap
+-\n s_or_b32 ttmp3, ttmp3, EC_QUEUE_WAVE_ABORT_M0
+-\n s_branch.check_exceptions
++\n.not_debug_trap:
++\n  s_cmp_eq_u32         ttmp2, TRAP_ID_ABORT
++\n  s_cbranch_scc0       .not_abort_trap
++\n  s_or_b32             ttmp3, ttmp3, EC_QUEUE_WAVE_ABORT_M0
++\n  s_branch             .check_exceptions
+ \n
+-\n.not_abort_trap :
+-\n s_or_b32 ttmp3, ttmp3,
+-    EC_QUEUE_WAVE_TRAP_M0
++\n.not_abort_trap:
++\n  s_or_b32             ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
+ \n
+ \n  // We need to explititly look for all exceptions we want to report to the
+ \n  // host:
+@@ -385,98 +356,89 @@ const char* TrapHandlerCode = RUNTIME_KERNEL(
+ \n  // - TRAP_CTRL.TRAP_AFTER_INST                     -> WAVE_TRAP
+ \n  // - EXCP_FLAG_PRIV.ADDR_WATCH && TRAP_CTL.WATCH   -> WAVE_TRAP
+ \n  // - (EXCP_FLAG_USER[ALU] & TRAP_CTRL[ALU]) != 0   -> WAVE_MATH_ERROR
+-\n.check_exceptions :
+-\n s_getreg_b32 ttmp2, hwreg(HW_REG_EXCP_FLAG_PRIV)
+-\n s_getreg_b32 ttmp13, hwreg(HW_REG_TRAP_CTRL)
++\n.check_exceptions:
++\n  s_getreg_b32         ttmp2, hwreg(HW_REG_EXCP_FLAG_PRIV)
++\n  s_getreg_b32         ttmp13, hwreg(HW_REG_TRAP_CTRL)
+ \n
+-\n s_bitcmp1_b32 ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_XNACK_ERROR_SHIFT
+-\n s_cbranch_scc0.not_memory_violation
+-\n s_or_b32 ttmp3, ttmp3,
+-    EC_QUEUE_WAVE_MEMORY_VIOLATION_M0
++\n  s_bitcmp1_b32        ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_XNACK_ERROR_SHIFT
++\n  s_cbranch_scc0       .not_memory_violation
++\n  s_or_b32             ttmp3, ttmp3, EC_QUEUE_WAVE_MEMORY_VIOLATION_M0
+ \n
+ \n  // Aperture violation requires XNACK_ERROR == 0.
+-\n s_branch.not_aperture_violation
+-\n
+-\n.not_memory_violation :
+-\n s_bitcmp1_b32 ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_MEMVIOL_SHIFT
+-\n s_cbranch_scc0.not_aperture_violation
+-\n s_or_b32 ttmp3, ttmp3, EC_QUEUE_WAVE_APERTURE_VIOLATION_M0
+-\n
+-\n.not_aperture_violation :
+-\n s_bitcmp1_b32 ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_ILLEGAL_INST_SHIFT
+-\n s_cbranch_scc0.not_illegal_instruction
+-\n s_or_b32 ttmp3, ttmp3, EC_QUEUE_WAVE_ILLEGAL_INSTRUCTION_M0
+-\n
+-\n.not_illegal_instruction :
+-\n s_bitcmp1_b32 ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_WAVE_START_SHIFT
+-\n s_cbranch_scc0.not_wave_end
+-\n s_or_b32 ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
+-\n
+-\n.not_wave_start :
+-\n s_bitcmp1_b32 ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_WAVE_END_SHIFT
+-\n s_cbranch_scc0.not_wave_end
+-\n s_bitcmp1_b32 ttmp13, SQ_WAVE_TRAP_CTRL_WAVE_END_SHIFT
+-\n s_cbranch_scc0.not_wave_end
+-\n s_or_b32 ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
+-\n
+-\n.not_wave_end :
+-\n s_bitcmp1_b32 ttmp13, SQ_WAVE_TRAP_CTRL_TRAP_AFTER_INST
+-\n s_cbranch_scc0.not_trap_after_inst
+-\n s_or_b32 ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
+-\n
+-\n.not_trap_after_inst :
+-\n s_and_b32 ttmp2, ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_ADDR_WATCH_MASK
+-\n s_cbranch_scc0.not_addr_watch
+-\n s_bitcmp1_b32 ttmp13, SQ_WAVE_TRAP_CTRL_ADDR_WATCH_SHIFT
+-\n s_cbranch_scc0.not_addr_watch
+-\n s_or_b32 ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
+-\n
+-\n.not_addr_watch :
+-\n s_getreg_b32 ttmp2,
+-    hwreg(HW_REG_EXCP_FLAG_USER, SQ_WAVE_EXCP_FLAG_USER_MATH_EXCP_SHIFT,
+-          SQ_WAVE_EXCP_FLAG_USER_MATH_EXCP_SIZE)
+-\n s_and_b32 ttmp13,
+-    ttmp13, SQ_WAVE_TRAP_CTRL_MATH_EXCP_MASK
+-\n s_and_b32 ttmp2, ttmp2, ttmp13
+-\n s_cbranch_scc0.not_math_exception
+-\n s_or_b32 ttmp3, ttmp3, EC_QUEUE_WAVE_MATH_ERROR_M0
+-\n
+-\n.not_math_exception :
+-\n s_cmp_eq_u32 ttmp3,
+-    0
++\n  s_branch             .not_aperture_violation
++\n
++\n.not_memory_violation:
++\n  s_bitcmp1_b32        ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_MEMVIOL_SHIFT
++\n  s_cbranch_scc0       .not_aperture_violation
++\n  s_or_b32             ttmp3, ttmp3, EC_QUEUE_WAVE_APERTURE_VIOLATION_M0
++\n
++\n.not_aperture_violation:
++\n  s_bitcmp1_b32        ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_ILLEGAL_INST_SHIFT
++\n  s_cbranch_scc0       .not_illegal_instruction
++\n  s_or_b32             ttmp3, ttmp3, EC_QUEUE_WAVE_ILLEGAL_INSTRUCTION_M0
++\n
++\n.not_illegal_instruction:
++\n  s_bitcmp1_b32        ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_WAVE_START_SHIFT
++\n  s_cbranch_scc0       .not_wave_end
++\n  s_or_b32             ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
++\n
++\n.not_wave_start:
++\n  s_bitcmp1_b32        ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_WAVE_END_SHIFT
++\n  s_cbranch_scc0       .not_wave_end
++\n  s_bitcmp1_b32        ttmp13, SQ_WAVE_TRAP_CTRL_WAVE_END_SHIFT
++\n  s_cbranch_scc0       .not_wave_end
++\n  s_or_b32             ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
++\n
++\n.not_wave_end:
++\n  s_bitcmp1_b32        ttmp13, SQ_WAVE_TRAP_CTRL_TRAP_AFTER_INST
++\n  s_cbranch_scc0       .not_trap_after_inst
++\n  s_or_b32             ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
++\n
++\n.not_trap_after_inst:
++\n  s_and_b32            ttmp2, ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_ADDR_WATCH_MASK
++\n  s_cbranch_scc0       .not_addr_watch
++\n  s_bitcmp1_b32        ttmp13, SQ_WAVE_TRAP_CTRL_ADDR_WATCH_SHIFT
++\n  s_cbranch_scc0       .not_addr_watch
++\n  s_or_b32             ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
++\n
++\n.not_addr_watch:
++\n  s_getreg_b32         ttmp2, hwreg(HW_REG_EXCP_FLAG_USER, SQ_WAVE_EXCP_FLAG_USER_MATH_EXCP_SHIFT, SQ_WAVE_EXCP_FLAG_USER_MATH_EXCP_SIZE)
++\n  s_and_b32            ttmp13, ttmp13, SQ_WAVE_TRAP_CTRL_MATH_EXCP_MASK
++\n  s_and_b32            ttmp2, ttmp2, ttmp13
++\n  s_cbranch_scc0       .not_math_exception
++\n  s_or_b32             ttmp3, ttmp3, EC_QUEUE_WAVE_MATH_ERROR_M0
++\n
++\n.not_math_exception:
++\n  s_cmp_eq_u32         ttmp3, 0
+ \n  // This was not a s_trap we are interested in or an exception, return to
+ \n  // the user code.
+-\n s_cbranch_scc1.exit_trap
++\n  s_cbranch_scc1       .exit_trap
+ \n
+-\n.send_interrupt :
++\n.send_interrupt:
+ \n  // Fetch doorbell id for our queue.
+-\n s_sendmsg_rtn_b32 ttmp2, sendmsg(MSG_RTN_GET_DOORBELL)
+-\n s_wait_kmcnt 0
+-\n s_and_b32 ttmp2, ttmp2, DOORBELL_ID_MASK
+-\n s_or_b32 ttmp3, ttmp2,
+-    ttmp3
++\n  s_sendmsg_rtn_b32    ttmp2, sendmsg(MSG_RTN_GET_DOORBELL)
++\n  s_wait_kmcnt         0
++\n  s_and_b32            ttmp2, ttmp2, DOORBELL_ID_MASK
++\n  s_or_b32             ttmp3, ttmp2, ttmp3
+ \n
+ \n  // Save trap id and halt status in ttmp6.
+-\n s_andn2_b32 ttmp6, ttmp6, (TTMP6_SAVED_TRAP_ID_MASK | TTMP6_SAVED_STATUS_HALT_MASK)
+-\n s_bfe_u32 ttmp2, ttmp1, SQ_WAVE_PC_HI_TRAP_ID_BFE
+-\n s_min_u32 ttmp2, ttmp2, 0xF
+-\n s_lshl_b32 ttmp2, ttmp2, TTMP6_SAVED_TRAP_ID_SHIFT
+-\n s_or_b32 ttmp6, ttmp6, ttmp2
+-\n s_bfe_u32 ttmp2, ttmp12, SQ_WAVE_STATE_PRIV_HALT_BFE
+-\n s_lshl_b32 ttmp2, ttmp2, TTMP6_SAVED_STATUS_HALT_SHIFT
+-\n s_or_b32 ttmp6, ttmp6,
+-    ttmp2
++\n  s_andn2_b32          ttmp6, ttmp6, (TTMP6_SAVED_TRAP_ID_MASK | TTMP6_SAVED_STATUS_HALT_MASK)
++\n  s_bfe_u32            ttmp2, ttmp1, SQ_WAVE_PC_HI_TRAP_ID_BFE
++\n  s_min_u32            ttmp2, ttmp2, 0xF
++\n  s_lshl_b32           ttmp2, ttmp2, TTMP6_SAVED_TRAP_ID_SHIFT
++\n  s_or_b32             ttmp6, ttmp6, ttmp2
++\n  s_bfe_u32            ttmp2, ttmp12, SQ_WAVE_STATE_PRIV_HALT_BFE
++\n  s_lshl_b32           ttmp2, ttmp2, TTMP6_SAVED_STATUS_HALT_SHIFT
++\n  s_or_b32             ttmp6, ttmp6, ttmp2
+ \n
+ \n  // m0 = interrupt data = (exception_code << DOORBELL_ID_SIZE) | doorbell_id
+-\n s_mov_b32 ttmp2, m0
+-\n s_mov_b32 m0,
+-    ttmp3
+-\n s_nop 0x0  // Manually inserted wait states
+-\n s_sendmsg sendmsg(MSG_INTERRUPT)
++\n  s_mov_b32            ttmp2, m0
++\n  s_mov_b32            m0, ttmp3
++\n  s_nop                0x0 // Manually inserted wait states
++\n  s_sendmsg            sendmsg(MSG_INTERRUPT)
+ \n  // Wait for the message to go out.
+-\n s_wait_kmcnt 0
+-\n s_mov_b32 m0,
+-    ttmp2
++\n  s_wait_kmcnt         0
++\n  s_mov_b32            m0, ttmp2
+ \n
+ \n  // Parking the wave requires saving the original pc in the preserved ttmps.
+ \n  // Register layout before parking the wave:
+@@ -490,57 +452,49 @@ const char* TrapHandlerCode = RUNTIME_KERNEL(
+ \n  // ttmp11: 1st_level_ttmp11[31:23] pc_hi[15:0] 1st_level_ttmp11[6:0]
+ \n  //
+ \n  // Save the PC
+-\n s_mov_b32 ttmp10, ttmp0
+-\n s_and_b32 ttmp1, ttmp1, SQ_WAVE_PC_HI_ADDRESS_MASK
+-\n s_lshl_b32 ttmp1, ttmp1, TTMP_PC_HI_SHIFT
+-\n s_andn2_b32 ttmp11, ttmp11, (SQ_WAVE_PC_HI_ADDRESS_MASK << TTMP_PC_HI_SHIFT)
+-\n s_or_b32 ttmp11, ttmp11,
+-    ttmp1
++\n  s_mov_b32            ttmp10, ttmp0
++\n  s_and_b32            ttmp1, ttmp1, SQ_WAVE_PC_HI_ADDRESS_MASK
++\n  s_lshl_b32           ttmp1, ttmp1, TTMP_PC_HI_SHIFT
++\n  s_andn2_b32          ttmp11, ttmp11, (SQ_WAVE_PC_HI_ADDRESS_MASK << TTMP_PC_HI_SHIFT)
++\n  s_or_b32             ttmp11, ttmp11, ttmp1
+ \n
+ \n  // Park the wave
+-\n s_getpc_b64[ttmp0, ttmp1]
+-\n s_add_u32 ttmp0, ttmp0, .parked -.
+-\n s_addc_u32 ttmp1, ttmp1,
+-    0x0
++\n  s_getpc_b64          [ttmp0, ttmp1]
++\n  s_add_u32            ttmp0, ttmp0, .parked - .
++\n  s_addc_u32           ttmp1, ttmp1, 0x0
+ \n
+-\n.halt_wave :
++\n.halt_wave:
+ \n  // Halt the wavefront upon restoring STATUS below.
+-\n s_bitset1_b32 ttmp6, TTMP6_WAVE_STOPPED_SHIFT
+-\n s_bitset1_b32 ttmp12,
+-    SQ_WAVE_STATE_PRIV_HALT_SHIFT
++\n  s_bitset1_b32        ttmp6, TTMP6_WAVE_STOPPED_SHIFT
++\n  s_bitset1_b32        ttmp12, SQ_WAVE_STATE_PRIV_HALT_SHIFT
+ \n
+ \n  // Initialize TTMP registers
+-\n s_bitcmp1_b32 ttmp8, TTMP8_DEBUG_FLAG_SHIFT
+-\n s_cbranch_scc1.ttmps_initialized
+-\n s_mov_b32 ttmp4, 0
+-\n s_mov_b32 ttmp5, 0
+-\n s_bitset1_b32 ttmp8,
+-    TTMP8_DEBUG_FLAG_SHIFT
+-\n.ttmps_initialized :
+-\n
+-\n.exit_trap :
++\n  s_bitcmp1_b32        ttmp8, TTMP8_DEBUG_FLAG_SHIFT
++\n  s_cbranch_scc1       .ttmps_initialized
++\n  s_mov_b32            ttmp4, 0
++\n  s_mov_b32            ttmp5, 0
++\n  s_bitset1_b32        ttmp8, TTMP8_DEBUG_FLAG_SHIFT
++\n.ttmps_initialized:
++\n
++\n.exit_trap:
+ \n  // Restore SQ_WAVE_STATUS.
+-\n s_and_b64 exec, exec,
+-    exec  // Restore STATUS.EXECZ, not writable by s_setreg_b32
+-\n s_and_b64 vcc, vcc,
+-    vcc  // Restore STATUS.VCCZ, not writable by s_setreg_b32
+-\n s_setreg_b32 hwreg(HW_REG_STATE_PRIV, 0, SQ_WAVE_STATE_PRIV_BARRIER_COMPLETE_SHIFT), ttmp12
+-\n s_lshr_b32 ttmp12, ttmp12,
+-    (SQ_WAVE_STATE_PRIV_BARRIER_COMPLETE_SHIFT + 1)
+-\n s_setreg_b32 hwreg(HW_REG_STATE_PRIV, SQ_WAVE_STATE_PRIV_BARRIER_COMPLETE_SHIFT + 1,
+-                       32 - SQ_WAVE_STATE_PRIV_BARRIER_COMPLETE_SHIFT - 1),
+-    ttmp12
++\n  s_and_b64            exec, exec, exec // Restore STATUS.EXECZ, not writable by s_setreg_b32
++\n  s_and_b64            vcc, vcc, vcc    // Restore STATUS.VCCZ, not writable by s_setreg_b32
++\n  s_setreg_b32         hwreg(HW_REG_STATE_PRIV, 0, SQ_WAVE_STATE_PRIV_BARRIER_COMPLETE_SHIFT), ttmp12
++\n  s_lshr_b32           ttmp12, ttmp12, (SQ_WAVE_STATE_PRIV_BARRIER_COMPLETE_SHIFT + 1)
++\n  s_setreg_b32         hwreg(HW_REG_STATE_PRIV, SQ_WAVE_STATE_PRIV_BARRIER_COMPLETE_SHIFT + 1, 32 - SQ_WAVE_STATE_PRIV_BARRIER_COMPLETE_SHIFT - 1), ttmp12
+ \n
+ \n  // Return to original (possibly modified) PC.
+-\n s_rfe_b64[ttmp0, ttmp1]
++\n  s_rfe_b64            [ttmp0, ttmp1]
+ \n
+-\n.parked :
+-\n s_trap 0x2
+-\n s_branch.parked
++\n.parked:
++\n  s_trap               0x2
++\n  s_branch             .parked
+ \n
+-\n  // Add s_code_end padding so instruction prefetch always has something to read.
+-\n.rept(256 - ((.- trap_entry) % 64)) / 4
+-\n s_code_end
++\n// Add s_code_end padding so instruction prefetch always has something to read.
++\n.rept (256 - ((. - trap_entry) % 64)) / 4
++\n  s_code_end
+ \n.endr
+-\n.endif \n);
++\n.endif
++\n);
+ }  // namespace amd::pal
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/1347.

## Technical Details

1. Patch 10 is a revert of https://github.com/ROCm/rocm-systems/commit/72b9408fedb08da67d0f3fec89316fb6e44153f2, with conflicts manually resolved. Something in that change causes programs (including many of our math-libs tests) to hang. A fix-forward is also up for review at https://github.com/ROCm/rocm-systems/pull/809.
2. Patch 11 is essentially a cherry-pick of https://github.com/ROCm/rocm-systems/pull/802. This commit https://github.com/ROCm/rocm-systems/commit/2ff2316227dc3bb04447060c719e78baf2d7383f ran clang-format on https://github.com/ROCm/rocm-systems/blob/develop/projects/clr/rocclr/device/pal/palblitcl.cpp, resulting in this broken file: [`palblitcl.cpp` @ df11d9dc](https://github.com/ROCm/rocm-systems/blob/df11d9dcc21dcdd8446d690d8bf0cceca9b14268/projects/clr/rocclr/device/pal/palblitcl.cpp) instead of this working file: [`palblitcl.cpp` @ fe14cc34](https://github.com/ROCm/rocm-systems/blob/fe14cc349baaab4aa79534296bdcef0b5957ee77/projects/clr/rocclr/device/pal/palblitcl.cpp). That resulted in errors like this when running programs like `hipInfo.exe`:
    
    ```
    C:\Users\NOD-SH~1\AppData\Local\Temp\comgr-505531\input\Assembly Text:252:1: error: symbol 'trap_entry' is already defined
    trap_entry :
    ^
    C:\Users\NOD-SH~1\AppData\Local\Temp\comgr-505531\input\Assembly Text:281:1: error: symbol '.not_abort_trap' is already defined
    .not_abort_trap :
    ^
    ```

## Test Plan

* Sanity check with some local builds
* Opt-in to gfx11X-windows tests on presubmit and watch CI

## Test Result

Local builds on gfx1100:

* CMake build completed
  * `hipInfo` works as expected
  * `hipblaslt-test '--gtest_filter=*pre_checkin*'` is passing
* ROCm python package build completed
  * `rocm-sdk test` works as expected
* PyTorch build completed
  * `pytest -v external-builds/pytorch/smoke-tests` passed

All CI workflows for gfx1151 that we expect to pass are passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
