### PR TITLE
Switch amdgpu-windows-interops to rocm-systems subfolder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,9 +37,6 @@
 [submodule "rocprof-trace-decoder"]
 	path = profiler/rocprof-trace-decoder/binaries
 	url = https://github.com/ROCm/rocprof-trace-decoder.git
-[submodule "amdgpu-windows-interop"]
-	path = core/amdgpu-windows-interop
-	url = https://github.com/ROCm/amdgpu-windows-interop.git
 [submodule "rocm-libraries"]
 	path = rocm-libraries
 	url = https://github.com/ROCm/rocm-libraries

--- a/build_tools/bump_submodules.py
+++ b/build_tools/bump_submodules.py
@@ -89,12 +89,6 @@ def parse_components(components: list[str]) -> list[list]:
             "rccl-tests",
         ]
 
-    # if "core" in components:
-    #     # amdgpu-windows-interop is Windows only and is updated manually.
-    #     # hip-tests is Windows only and is updated manually.
-    #     system_projects += [
-    #     ]
-
     if "profiler" in components:
         system_projects += [
             "rocprof-trace-decoder",

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -79,7 +79,7 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
   set(HIP_CLR_RUNTIME_DEPS)
   if(WIN32)
     # Windows CLR options
-    set(_compute_pal_dir "${CMAKE_CURRENT_SOURCE_DIR}/amdgpu-windows-interop/20250820a")
+    set(_compute_pal_dir "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/shared/amdgpu-windows-interop")
     cmake_path(NORMAL_PATH _compute_pal_dir)
     list(APPEND HIP_CLR_CMAKE_ARGS
       "-DUSE_PROF_API=OFF"

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -375,9 +375,9 @@ An incremental rollout is planned:
    This will allow AMD developers to iterate on integration into TheRock while
    we work on making this folder or more source files available.
 1. The interop folder will be available publicly
-   (currently at https://github.com/ROCm/amdgpu-windows-interop).
+   (currently at https://github.com/ROCm/rocm-systems/tree/develop/shared/amdgpu-windows-interop).
 1. *(We are here today)* The interop folder will be included automatically from
-   a git repository using git LFS.
+   a git repository using [dvc](https://dvc.org/).
 1. A more permanent open source strategy for building the CLR (the HIP runtime)
    from source on Windows will eventually be available.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,8 @@ msgpack>=1.1.0
 
 # AWS Redshift connector
 redshift_connector==2.1.8
+
+# data version control for pal .lib files
+# and eventually large kernels from miopen
+# and large logic files from hipblaslt
+dvc>=3.62.0


### PR DESCRIPTION
Depends on ROCm/rocm-systems#808 and Windows CI being green again. When Windows CI is green, I can temporarily change the rocm-systems submodule to point to PR 808's branch to run CI against the combination of both changes.

The dvc usage is only needed for the pal libs, so it is guarded with an if Windows. However, this tool will be used by miopen and hipblaslt at some point, and I could not confirm that the Linux pipelines install pip modules before the fetch sources sequence. The Windows pipelines appear to install the pip modules before fetch sources.