### PR TITLE
Exclude RCCL from gfx1103 build

### DIFF
--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -98,7 +98,10 @@ therock_add_amdgpu_target(gfx1102 "AMD RX 7700S/Framework Laptop 16" FAMILY dgpu
   EXCLUDE_TARGET_PROJECTS
     hipBLASLt # https://github.com/ROCm/TheRock/issues/1062
 )
-therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all gfx110X-all gfx110X-igpu)
+therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all gfx110X-all gfx110X-igpu
+  EXCLUDE_TARGET_PROJECTS
+    rccl  # https://github.com/ROCm/TheRock/issues/150
+)
 
 # gfx115X family
 therock_add_amdgpu_target(gfx1150 "AMD Strix Point iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu


### PR DESCRIPTION
## Motivation

RCCL isn't currently supported by gfx1103. Disable it in the build target to complete the build.

## Technical Details

RCCL currently uses inline assembly not supported by gfx1103.
Issue https://github.com/ROCm/TheRock/issues/150

## Test Plan

Build ROCm for gfx1103 target

## Test Result

Builds completes ROCm successfully for gfx1103

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
