### PR TITLE
Remove warning about unstable builds from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,6 @@ python ./build_tools/fetch_sources.py
 
 ### Setup - Windows 11 (VS 2022)
 
-> [!CAUTION]
-> Windows builds are currently unstable during the subproject migration to
-> [rocm-systems](https://github.com/ROCm/rocm-systems)!
->
-> **The last known good commit on Windows is [16ee54f](https://github.com/ROCm/TheRock/commit/529fa36d69c7d4295317a70d3c5c88000a364b2c) .**
->
-> Builds are expected to succeed but there are runtime errors and timeouts.
-> See https://github.com/ROCm/TheRock/issues/1347 for details.
-
 > [!IMPORTANT]
 > See [windows_support.md](./docs/development/windows_support.md) for setup
 > instructions on Windows, in particular


### PR DESCRIPTION
Removes the warning introduced with commit 1901eab also from the README as builds have been fixed with commit 21700cd.