### PR TITLE
Introduce `rocm.nightlies.amd.com`

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           version_suffix="$(printf 'rc%(%Y%m%d)T')"
           echo "version_suffix=${version_suffix}" >> $GITHUB_ENV
-          echo "cloudfront_base_url=https://d2awnip2yjpvqn.cloudfront.net" >> $GITHUB_ENV
+          echo "cloudfront_base_url=https://rocm.nightlies.amd.com" >> $GITHUB_ENV
 
       - name: Set variables for development release
         if: ${{ env.release_type == 'dev' }}

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           version_suffix="$(printf 'rc%(%Y%m%d)T')"
           echo "version_suffix=${version_suffix}" >> $GITHUB_ENV
-          echo "cloudfront_base_url=https://d2awnip2yjpvqn.cloudfront.net" >> $GITHUB_ENV
+          echo "cloudfront_base_url=https://rocm.nightlies.amd.com" >> $GITHUB_ENV
 
       - name: Set variables for development release
         if: ${{ env.release_type == 'dev' }}

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -15,7 +15,7 @@ on:
         description: CloudFront URL pointing to Python index
         required: true
         type: string
-        default: "https://d2awnip2yjpvqn.cloudfront.net/v2"
+        default: "https://rocm.nightlies.amd.com/v2"
       python_version:
         required: true
         type: string

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -101,7 +101,7 @@ project layouts.**
 
 ```bash
 python -m pip install \
-  --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx94X-dcgpu/ \
+  --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ \
   rocm[libraries,devel]
 ```
 
@@ -109,7 +109,7 @@ python -m pip install \
 
 ```bash
 python -m pip install \
-  --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx950-dcgpu/ \
+  --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ \
   rocm[libraries,devel]
 ```
 
@@ -117,7 +117,7 @@ python -m pip install \
 
 ```bash
 python -m pip install \
-  --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ \
+  --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
   rocm[libraries,devel]
 ```
 
@@ -125,7 +125,7 @@ python -m pip install \
 
 ```bash
 python -m pip install \
-  --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx1151/ \
+  --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
   rocm[libraries,devel]
 ```
 
@@ -133,7 +133,7 @@ python -m pip install \
 
 ```bash
 python -m pip install \
-  --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx120X-all/ \
+  --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ \
   rocm[libraries,devel]
 ```
 
@@ -204,7 +204,7 @@ Using the index pages listed above, you can install `torch`, `torchaudio`, and
 
 ```bash
 python -m pip install \
-  --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx94X-dcgpu/ \
+  --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ \
   torch torchaudio torchvision
 ```
 
@@ -212,7 +212,7 @@ python -m pip install \
 
 ```bash
 python -m pip install \
-  --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx950-dcgpu/ \
+  --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ \
   torch torchaudio torchvision
 ```
 
@@ -220,7 +220,7 @@ python -m pip install \
 
 ```bash
 python -m pip install \
-  --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ \
+  --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
   torch torchaudio torchvision
 ```
 
@@ -228,7 +228,7 @@ python -m pip install \
 
 ```bash
 python -m pip install \
-  --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx1151/ \
+  --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
   torch torchaudio torchvision
 ```
 
@@ -236,7 +236,7 @@ python -m pip install \
 
 ```bash
 python -m pip install \
-  --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx120X-all/ \
+  --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ \
   torch torchaudio torchvision
 ```
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -319,8 +319,6 @@ them from the expanded artifacts down to a ROCm SDK "dist folder" using the
    [AWS CLI](https://aws.amazon.com/cli/) or
    [AWS SDK for Python (Boto3)](https://aws.amazon.com/sdk-for-python/):
 
-   <!-- TODO: replace URLs with cloudfront / some other CDN instead of raw S3 -->
-
    ```bash
    export LOCAL_ARTIFACTS_DIR=~/therock-artifacts
    export LOCAL_INSTALL_DIR=${LOCAL_ARTIFACTS_DIR}/install

--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -45,7 +45,7 @@ from github_actions.github_actions_utils import *
 is_windows = platform.system() == "Windows"
 
 INDEX_URLS_MAP = {
-    "nightly": "https://d2awnip2yjpvqn.cloudfront.net/v2",
+    "nightly": "https://rocm.nightlies.amd.com/v2",
     "dev": "https://d25kgig7rdsyks.cloudfront.net/v2",
 }
 

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -159,7 +159,7 @@ mix/match build steps.
 
   ```bash
   python build_prod_wheels.py build \
-    --install-rocm --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ \
+    --install-rocm --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
     --output-dir $HOME/tmp/pyout
   ```
 
@@ -167,7 +167,7 @@ mix/match build steps.
 
   ```bash
   python build_prod_wheels.py build \
-    --install-rocm --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ \
+    --install-rocm --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
     --pytorch-dir C:/b/pytorch \
     --pytorch-audio-dir C:/b/audio \
     --pytorch-vision-dir C:/b/vision \
@@ -215,7 +215,7 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
 
   ```bash
   build_prod_wheels.py
-      --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ \
+      --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
       install-rocm
   ```
 
@@ -224,7 +224,7 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
   ```bash
   # From therock-nightly-python
   python -m pip install \
-    --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ \
+    --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
     rocm[libraries,devel]
 
   # OR from therock-dev-python

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -60,7 +60,7 @@ to the build sub-command (useful for docker invocations).
 # For therock-nightly-python
 build_prod_wheels.py \
     install-rocm \
-    --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/
+    --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/
 
 # For therock-dev-python (unstable but useful for testing outside of prod)
 build_prod_wheels.py \
@@ -102,7 +102,7 @@ versions):
     build \
         --install-rocm \
         --pip-cache-dir /therock/output/pip_cache \
-        --index-url https://d2awnip2yjpvqn.cloudfront.net/v2/gfx110X-dgpu/ \
+        --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
         --clean \
         --output-dir /therock/output/cp312/wheels
 ```


### PR DESCRIPTION
Replaces `d2awnip2yjpvqn.cloudfront.net` with `rocm.nightlies.amd.com` which redirects to the CloudFront distribution.