### PR TITLE
Windows Pytorch builds gating with tests

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -260,26 +260,7 @@ jobs:
           TEST_RESULT: ${{ needs.test_pytorch_wheels.result }}
           TEST_RUNS_ON: ${{ needs.generate_target_to_run.outputs.test_runs_on }}
           BYPASS_TESTS_FOR_RELEASES: ${{ needs.generate_target_to_run.outputs.bypass_tests_for_releases }}
-        run: |
-          # 1) If the build failed → upload=false
-          if [[ "$BUILD_RESULT" != "success" ]]; then
-            echo "::warning::Build failed. Skipping upload."
-            echo "upload=false" >> "$GITHUB_ENV"
-
-          # 2) Else if there was a test runner AND tests failed or were skipped → upload=false
-          elif [[ -n "$TEST_RUNS_ON" && ( "$TEST_RESULT" == "failure" || "$TEST_RESULT" == "skipped" ) ]]; then
-            echo "::warning::Tests failed or were skipped (runner present). Skipping upload."
-            echo "upload=false" >> "$GITHUB_ENV"
-
-          # 3) Else if BYPASS_TESTS_FOR_RELEASES is not set and there was no test runner → upload=false
-          elif [[ -z "$BYPASS_TESTS_FOR_RELEASES" && -z "$TEST_RUNS_ON" ]]; then
-            echo "::warning::No test runner and BYPASS_TESTS_FOR_RELEASES not set. Skipping upload."
-            echo "upload=false" >> "$GITHUB_ENV"
-
-          # 4) Otherwise → upload=true
-          else
-            echo "upload=true" >> "$GITHUB_ENV"
-          fi
+        run: python ./build_tools/github_actions/promote_wheels_based_on_policy.py
 
       - name: Copy PyTorch wheels from staging to release S3
         if: ${{ env.upload == 'true' }}

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -172,12 +172,14 @@ jobs:
 
       - name: Upload wheels to S3 staging
         if: ${{ github.repository_owner == 'ROCm' }}
+        shell: cmd
         run: |
           aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}/ \
             --recursive --exclude "*" --include "*.whl"
 
       - name: (Re-)Generate Python package release index for staging
         if: ${{ github.repository_owner == 'ROCm' }}
+        shell: cmd
         run: |
           pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}
@@ -222,7 +224,6 @@ jobs:
       TORCH_VERSION: "${{ needs.build_pytorch_wheels.outputs.torch_version }}"
       TORCHAUDIO_VERSION: "${{ needs.build_pytorch_wheels.outputs.torchaudio_version }}"
       TORCHVISION_VERSION: "${{ needs.build_pytorch_wheels.outputs.torchvision_version }}"
-      TRITON_VERSION: "${{ needs.build_pytorch_wheels.outputs.triton_version }}"
 
     steps:
       - name: Checkout
@@ -242,26 +243,7 @@ jobs:
           TEST_RESULT: ${{ needs.test_pytorch_wheels.result }}
           TEST_RUNS_ON: ${{ needs.generate_target_to_run.outputs.test_runs_on }}
           BYPASS_TESTS_FOR_RELEASES: ${{ needs.generate_target_to_run.outputs.bypass_tests_for_releases }}
-        run: |
-          # 1) If the build failed → upload=false
-          if [[ "$BUILD_RESULT" != "success" ]]; then
-            echo "::warning::Build failed. Skipping upload."
-            echo "upload=false" >> "$GITHUB_ENV"
-
-          # 2) Else if there was a test runner AND tests failed or were skipped → upload=false
-          elif [[ -n "$TEST_RUNS_ON" && ( "$TEST_RESULT" == "failure" || "$TEST_RESULT" == "skipped" ) ]]; then
-            echo "::warning::Tests failed or were skipped (runner present). Skipping upload."
-            echo "upload=false" >> "$GITHUB_ENV"
-
-          # 3) Else if BYPASS_TESTS_FOR_RELEASES is not set and there was no test runner → upload=false
-          elif [[ -z "$BYPASS_TESTS_FOR_RELEASES" && -z "$TEST_RUNS_ON" ]]; then
-            echo "::warning::No test runner and BYPASS_TESTS_FOR_RELEASES not set. Skipping upload."
-            echo "upload=false" >> "$GITHUB_ENV"
-
-          # 4) Otherwise → upload=true
-          else
-            echo "upload=true" >> "$GITHUB_ENV"
-          fi
+        run: python ./build_tools/github_actions/promote_wheels_based_on_policy.py
 
       - name: Copy PyTorch wheels from staging to release S3
         if: ${{ env.upload == 'true' }}
@@ -272,10 +254,9 @@ jobs:
             s3://${S3_BUCKET_PY}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ \
             --recursive \
             --exclude "*" \
-            --include "torch-${TORCH_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
-            --include "torchaudio-${TORCHAUDIO_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
-            --include "torchvision-${TORCHVISION_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
-            --include "pytorch_triton_rocm-${TRITON_VERSION}-${CP_VERSION}-linux_x86_64.whl"
+            --include "torch-${TORCH_VERSION}-${CP_VERSION}-win_amd64.whl" \
+            --include "torchaudio-${TORCHAUDIO_VERSION}-${CP_VERSION}-win_amd64.whl" \
+            --include "torchvision-${TORCHVISION_VERSION}-${CP_VERSION}-win_amd64.whl"
 
       - name: (Re-)Generate Python package release index
         if: ${{ env.upload == 'true' }}

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -170,11 +170,22 @@ jobs:
       #   run: |
       #     python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}
 
-      - name: Upload wheels to S3 staging
+      - name: Upload wheels to S3
         if: ${{ github.repository_owner == 'ROCm' }}
+        # Using 'cmd' here since PACKAGE_DIST_DIR uses \ in paths instead of /
         shell: cmd
         run: |
-          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}/ \
+          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ ^
+            s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ ^
+            --recursive --exclude "*" --include "*.whl"
+
+      - name: Upload wheels to S3 staging
+        if: ${{ github.repository_owner == 'ROCm' }}
+        # Using 'cmd' here since PACKAGE_DIST_DIR uses \ in paths instead of /
+        shell: cmd
+        run: |
+          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ ^
+            s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}/ ^
             --recursive --exclude "*" --include "*.whl"
 
       - name: (Re-)Generate Python package release index for staging

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -172,13 +172,6 @@ jobs:
 
       - name: Upload wheels to S3 staging
         if: ${{ github.repository_owner == 'ROCm' }}
-        shell: cmd
-        run: |
-          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}/ \
-            --recursive --exclude "*" --include "*.whl"
-
-      - name: Upload wheels to S3 staging
-        if: ${{ github.repository_owner == 'ROCm' }}
         # Using 'cmd' here since PACKAGE_DIST_DIR uses \ in paths instead of /
         shell: cmd
         run: |

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -109,6 +109,11 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
+      - name: Select Python version
+        run: |
+          python build_tools/github_actions/python_to_cp_version.py \
+            --python-version ${{ inputs.python_version }}
+
       # TODO(amd-justchen): share with build_windows_packages.yml. Include in VM image? Dockerfile?
       - name: Install requirements
         run: |

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -87,7 +87,11 @@ jobs:
       S3_BUCKET_PY: "therock-${{ inputs.release_type }}-python"
       optional_build_prod_arguments: ""
     outputs:
+      cp_version: ${{ env.cp_version }}
       torch_version: ${{ steps.build-pytorch-wheels.outputs.torch_version }}
+      torchaudio_version: ${{ steps.build-pytorch-wheels.outputs.torchaudio_version }}
+      torchvision_version: ${{ steps.build-pytorch-wheels.outputs.torchvision_version }}
+
     defaults:
       run:
         # Note: there are mixed uses of 'bash' (this default) and 'cmd' below
@@ -226,7 +230,6 @@ jobs:
       TORCH_VERSION: "${{ needs.build_pytorch_wheels.outputs.torch_version }}"
       TORCHAUDIO_VERSION: "${{ needs.build_pytorch_wheels.outputs.torchaudio_version }}"
       TORCHVISION_VERSION: "${{ needs.build_pytorch_wheels.outputs.torchvision_version }}"
-
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -237,7 +240,6 @@ jobs:
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
-
 
       - name: Determine upload flag
         env:

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -211,7 +211,7 @@ jobs:
       python_version: ${{ inputs.python_version }}
       torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}
 
-    upload_pytorch_wheels:
+  upload_pytorch_wheels:
     name: Release PyTorch Wheels to S3
     needs: [build_pytorch_wheels, generate_target_to_run, test_pytorch_wheels]
     if: always()

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -17,8 +17,16 @@ on:
         description: S3 subdirectory, not including the GPU-family
         required: true
         type: string
+      s3_staging_subdir:
+        description: S3 staging subdirectory, not including the GPU-family
+        required: true
+        type: string
       cloudfront_url:
         description: CloudFront URL pointing to Python index
+        required: true
+        type: string
+      cloudfront_staging_url:
+        description: CloudFront base URL pointing to staging Python index
         required: true
         type: string
       rocm_version:
@@ -47,10 +55,18 @@ on:
         description: S3 subdirectory, not including the GPU-family
         type: string
         default: "v2"
+      s3_staging_subdir:
+        description: S3 staging subdirectory, not including the GPU-family
+        type: string
+        default: "v2-staging"
       cloudfront_url:
         description: CloudFront base URL pointing to Python index
         type: string
         default: "https://d25kgig7rdsyks.cloudfront.net/v2"
+      cloudfront_staging_url:
+        description: CloudFront base URL pointing to staging Python index
+        type: string
+        default: "https://d25kgig7rdsyks.cloudfront.net/v2-staging"
       rocm_version:
         description: ROCm version to pip install
         type: string
@@ -154,26 +170,24 @@ jobs:
       #   run: |
       #     python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}
 
-      - name: Upload wheels to S3
+      - name: Upload wheels to S3 staging
         if: ${{ github.repository_owner == 'ROCm' }}
-        # Using 'cmd' here since PACKAGE_DIST_DIR uses \ in paths instead of /
-        shell: cmd
         run: |
-          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ ^
-            s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ ^
+          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}/ \
             --recursive --exclude "*" --include "*.whl"
 
-      - name: (Re-)Generate Python package release index
+      - name: (Re-)Generate Python package release index for staging
         if: ${{ github.repository_owner == 'ROCm' }}
         run: |
           pip install boto3 packaging
-          python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}
+          python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}
 
   generate_target_to_run:
     name: Generate target_to_run
     runs-on: ubuntu-24.04
     outputs:
       test_runs_on: ${{ steps.configure.outputs.test-runs-on }}
+      bypass_tests_for_releases: ${{ steps.configure.outputs.bypass_tests_for_releases }}
     steps:
       - name: Checking out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -196,3 +210,75 @@ jobs:
       cloudfront_url: ${{ inputs.cloudfront_url }}
       python_version: ${{ inputs.python_version }}
       torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}
+
+    upload_pytorch_wheels:
+    name: Release PyTorch Wheels to S3
+    needs: [build_pytorch_wheels, generate_target_to_run, test_pytorch_wheels]
+    if: always()
+    runs-on: ubuntu-24.04
+    env:
+      S3_BUCKET_PY: "therock-${{ inputs.release_type }}-python"
+      CP_VERSION: "${{ needs.build_pytorch_wheels.outputs.cp_version }}"
+      TORCH_VERSION: "${{ needs.build_pytorch_wheels.outputs.torch_version }}"
+      TORCHAUDIO_VERSION: "${{ needs.build_pytorch_wheels.outputs.torchaudio_version }}"
+      TORCHVISION_VERSION: "${{ needs.build_pytorch_wheels.outputs.torchvision_version }}"
+      TRITON_VERSION: "${{ needs.build_pytorch_wheels.outputs.triton_version }}"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Configure AWS Credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
+
+
+      - name: Determine upload flag
+        env:
+          BUILD_RESULT: ${{ needs.build_pytorch_wheels.result }}
+          TEST_RESULT: ${{ needs.test_pytorch_wheels.result }}
+          TEST_RUNS_ON: ${{ needs.generate_target_to_run.outputs.test_runs_on }}
+          BYPASS_TESTS_FOR_RELEASES: ${{ needs.generate_target_to_run.outputs.bypass_tests_for_releases }}
+        run: |
+          # 1) If the build failed → upload=false
+          if [[ "$BUILD_RESULT" != "success" ]]; then
+            echo "::warning::Build failed. Skipping upload."
+            echo "upload=false" >> "$GITHUB_ENV"
+
+          # 2) Else if there was a test runner AND tests failed or were skipped → upload=false
+          elif [[ -n "$TEST_RUNS_ON" && ( "$TEST_RESULT" == "failure" || "$TEST_RESULT" == "skipped" ) ]]; then
+            echo "::warning::Tests failed or were skipped (runner present). Skipping upload."
+            echo "upload=false" >> "$GITHUB_ENV"
+
+          # 3) Else if BYPASS_TESTS_FOR_RELEASES is not set and there was no test runner → upload=false
+          elif [[ -z "$BYPASS_TESTS_FOR_RELEASES" && -z "$TEST_RUNS_ON" ]]; then
+            echo "::warning::No test runner and BYPASS_TESTS_FOR_RELEASES not set. Skipping upload."
+            echo "upload=false" >> "$GITHUB_ENV"
+
+          # 4) Otherwise → upload=true
+          else
+            echo "upload=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Copy PyTorch wheels from staging to release S3
+        if: ${{ env.upload == 'true' }}
+        run: |
+          echo "Copying exact tested wheels to release S3 bucket..."
+          aws s3 cp \
+            s3://${S3_BUCKET_PY}/${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}/ \
+            s3://${S3_BUCKET_PY}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ \
+            --recursive \
+            --exclude "*" \
+            --include "torch-${TORCH_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
+            --include "torchaudio-${TORCHAUDIO_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
+            --include "torchvision-${TORCHVISION_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
+            --include "pytorch_triton_rocm-${TRITON_VERSION}-${CP_VERSION}-linux_x86_64.whl"
+
+      - name: (Re-)Generate Python package release index
+        if: ${{ env.upload == 'true' }}
+        run: |
+          pip install boto3 packaging
+          python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -14,6 +14,10 @@ on:
         description: "Subdirectory to push the Python packages"
         type: string
         default: "v2"
+      s3_staging_subdir:
+        description: "Staging subdirectory to push the packages"
+        type: string
+        default: "v2-staging"
   # Trigger manually (typically to test the workflow or manually build a release [candidate])
   workflow_dispatch:
     inputs:
@@ -27,6 +31,10 @@ on:
         description: "Subdirectory to push the Python packages"
         type: string
         default: "v2"
+      s3_staging_subdir:
+        description: "Staging subdirectory to push the packages"
+        type: string
+        default: "v2-staging"
       families:
         description: "A comma separated list of AMD GPU families, e.g. `gfx94X,gfx103x`, or empty for the default list"
         type: string
@@ -54,6 +62,7 @@ jobs:
       release_type: ${{ env.release_type }}
       package_targets: ${{ steps.configure.outputs.package_targets }}
       cloudfront_url: ${{ steps.release_information.outputs.cloudfront_url }}
+      cloudfront_staging_url: ${{ steps.release_information.outputs.cloudfront_staging_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -83,6 +92,7 @@ jobs:
           base_version=$(jq -r '.["rocm-version"]' version.json)
           echo "version=${base_version}${version_suffix}" >> $GITHUB_OUTPUT
           echo "cloudfront_url=${cloudfront_base_url}/${{ env.S3_SUBDIR }}" >> $GITHUB_OUTPUT
+          echo "cloudfront_staging_url=${cloudfront_base_url}/${{ env.S3_STAGING_SUBDIR }}" >> $GITHUB_OUTPUT
 
       - name: Generating package target matrix
         id: configure
@@ -117,6 +127,7 @@ jobs:
       S3_BUCKET_TAR: "therock-${{ needs.setup_metadata.outputs.release_type }}-tarball"
       S3_BUCKET_PY: "therock-${{ needs.setup_metadata.outputs.release_type }}-python"
       S3_SUBDIR: ${{ inputs.s3_subdir || 'v2' }}
+      S3_STAGING_SUBDIR: ${{ inputs.s3_staging_subdir || 'v2-staging' }}
 
     steps:
       - name: "Checking out repository"
@@ -242,6 +253,22 @@ jobs:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::692859939525:role/therock-${{ env.RELEASE_TYPE }}-releases
 
+      - name: Upload Releases to staging S3
+        if: ${{ github.repository_owner == 'ROCm' }}
+        run: |
+          aws s3 cp ${{ env.OUTPUT_DIR }}/packages/dist/ s3://${{ env.S3_BUCKET_PY }}/${{ env.S3_STAGING_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}/ \
+          --recursive --no-follow-symlinks \
+          --exclude "*" \
+          --include "*.whl" \
+          --include "*.tar.gz"
+
+      - name: (Re-)Generate Python package release index for staging
+        if: ${{ github.repository_owner == 'ROCm' }}
+        run: |
+          pip install boto3 packaging
+          python ./build_tools/third_party/s3_management/manage.py ${{ env.S3_STAGING_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}
+
+      ## TODO: Restrict uploading to the non-staging S3 directory until sanity checks and all validation tests have successfully passed.
       - name: Upload Releases to S3
         if: ${{ github.repository_owner == 'ROCm' }}
         run: |
@@ -271,7 +298,9 @@ jobs:
             { "amdgpu_family": "${{ matrix.target_bundle.amdgpu_family }}",
               "release_type": "${{ env.RELEASE_TYPE }}",
               "s3_subdir": "${{ env.S3_SUBDIR }}",
+              "s3_staging_subdir": "${{ env.S3_STAGING_SUBDIR }}",
               "cloudfront_url": "${{ needs.setup_metadata.outputs.cloudfront_url }}",
+              "cloudfront_staging_url": "${{ needs.setup_metadata.outputs.cloudfront_staging_url }}",
               "rocm_version": "${{ needs.setup_metadata.outputs.version }}"
             }
 

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -21,7 +21,7 @@ on:
       cloudfront_url:
         description: CloudFront URL pointing to Python index
         type: string
-        default: "https://rocm.nightlies.amd.com/v2"
+        default: "https://d25kgig7rdsyks.cloudfront.net/v2"
       cloudfront_staging_url:
         description: CloudFront base URL pointing to staging Python index
         required: true
@@ -55,11 +55,11 @@ on:
       cloudfront_url:
         description: CloudFront URL pointing to Python index
         type: string
-        default: "https://rocm.nightlies.amd.com/v2"
+        default: "https://d25kgig7rdsyks.cloudfront.net/v2"
       cloudfront_staging_url:
         description: CloudFront base URL pointing to staging Python index
         type: string
-        default: "https://rocm.nightlies.amd.com/v2-staging"
+        default: "https://d25kgig7rdsyks.cloudfront.net/v2-staging"
       rocm_version:
         description: ROCm version to pip install
         type: string

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -14,10 +14,18 @@ on:
         description: S3 subdirectory, not including the GPU-family
         type: string
         default: "v2"
+      s3_staging_subdir:
+        description: Staging subdirectory to push the wheels for test
+        type: string
+        default: "v2-staging"
       cloudfront_url:
         description: CloudFront URL pointing to Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2"
+        default: "https://rocm.nightlies.amd.com/v2"
+      cloudfront_staging_url:
+        description: CloudFront base URL pointing to staging Python index
+        required: true
+        type: string
       rocm_version:
         description: ROCm version to pip install
         type: string
@@ -40,10 +48,18 @@ on:
         description: S3 subdirectory, not including the GPU-family
         type: string
         default: "v2"
+      s3_staging_subdir:
+        description: "Staging subdirectory to push the wheels for test"
+        type: string
+        default: "v2-staging"
       cloudfront_url:
         description: CloudFront URL pointing to Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2"
+        default: "https://rocm.nightlies.amd.com/v2"
+      cloudfront_staging_url:
+        description: CloudFront base URL pointing to staging Python index
+        type: string
+        default: "https://rocm.nightlies.amd.com/v2-staging"
       rocm_version:
         description: ROCm version to pip install
         type: string
@@ -66,5 +82,7 @@ jobs:
       python_version: ${{ matrix.python_version }}
       release_type: ${{ inputs.release_type }}
       s3_subdir: ${{ inputs.s3_subdir }}
+      s3_staging_subdir: ${{ inputs.s3_staging_subdir }}
       cloudfront_url: ${{ inputs.cloudfront_url }}
+      cloudfront_staging_url: ${{ inputs.cloudfront_staging_url }}
       rocm_version: ${{ inputs.rocm_version }}

--- a/build_tools/github_actions/promote_wheels_based_on_policy.py
+++ b/build_tools/github_actions/promote_wheels_based_on_policy.py
@@ -1,0 +1,42 @@
+import argparse
+import os
+from github_actions_utils import *
+
+def determine_upload_flag(build_result, test_result, test_runs_on, bypass_tests_for_releases):
+    # Default to false
+    upload = "false"
+    # 1) If the build failed → upload=false
+    if build_result != "success":
+        print("::warning::Build failed. Skipping upload.")
+
+    # 2) Else if there was a test runner AND tests failed or were skipped → upload=false
+    elif test_runs_on and (test_result in ["failure", "skipped"]):
+        print("::warning::Tests failed or were skipped (runner present). Skipping upload.")
+
+    # 3) Else if BYPASS_TESTS_FOR_RELEASES is not set and there was no test runner → upload=false
+    elif not bypass_tests_for_releases and not test_runs_on:
+        print("::warning::No test runner and BYPASS_TESTS_FOR_RELEASES not set. Skipping upload.")
+
+    # 4) Otherwise → upload=true
+    else:
+        upload = "true"
+
+    return upload
+
+def main(argv: list[str]):
+    ## Added argparse for future enhancements to the script
+    p = argparse.ArgumentParser(prog="promote_based_on_policy.py")
+    # Read environment variables
+    build_result = os.getenv("BUILD_RESULT", "").lower()
+    test_result = os.getenv("TEST_RESULT", "").lower()
+    test_runs_on = os.getenv("TEST_RUNS_ON", "")
+    bypass_tests_for_releases = os.getenv("BYPASS_TESTS_FOR_RELEASES", "")
+    
+    upload = determine_upload_flag(build_result, test_result, test_runs_on, bypass_tests_for_releases )
+
+    # Export result so GitHub Actions env variable
+    gha_set_env({"upload": upload})
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/build_tools/github_actions/promote_wheels_based_on_policy.py
+++ b/build_tools/github_actions/promote_wheels_based_on_policy.py
@@ -2,7 +2,10 @@ import argparse
 import os
 from github_actions_utils import *
 
-def determine_upload_flag(build_result, test_result, test_runs_on, bypass_tests_for_releases):
+
+def determine_upload_flag(
+    build_result, test_result, test_runs_on, bypass_tests_for_releases
+):
     # Default to false
     upload = "false"
     # 1) If the build failed → upload=false
@@ -11,17 +14,22 @@ def determine_upload_flag(build_result, test_result, test_runs_on, bypass_tests_
 
     # 2) Else if there was a test runner AND tests failed or were skipped → upload=false
     elif test_runs_on and (test_result in ["failure", "skipped"]):
-        print("::warning::Tests failed or were skipped (runner present). Skipping upload.")
+        print(
+            "::warning::Tests failed or were skipped (runner present). Skipping upload."
+        )
 
     # 3) Else if BYPASS_TESTS_FOR_RELEASES is not set and there was no test runner → upload=false
     elif not bypass_tests_for_releases and not test_runs_on:
-        print("::warning::No test runner and BYPASS_TESTS_FOR_RELEASES not set. Skipping upload.")
+        print(
+            "::warning::No test runner and BYPASS_TESTS_FOR_RELEASES not set. Skipping upload."
+        )
 
     # 4) Otherwise → upload=true
     else:
         upload = "true"
 
     return upload
+
 
 def main(argv: list[str]):
     ## Added argparse for future enhancements to the script
@@ -31,8 +39,10 @@ def main(argv: list[str]):
     test_result = os.getenv("TEST_RESULT", "").lower()
     test_runs_on = os.getenv("TEST_RUNS_ON", "")
     bypass_tests_for_releases = os.getenv("BYPASS_TESTS_FOR_RELEASES", "")
-    
-    upload = determine_upload_flag(build_result, test_result, test_runs_on, bypass_tests_for_releases )
+
+    upload = determine_upload_flag(
+        build_result, test_result, test_runs_on, bypass_tests_for_releases
+    )
 
     # Export result so GitHub Actions env variable
     gha_set_env({"upload": upload})

--- a/build_tools/github_actions/promote_wheels_based_on_policy.py
+++ b/build_tools/github_actions/promote_wheels_based_on_policy.py
@@ -1,5 +1,18 @@
+"""
+Decide whether to upload/promote build artifacts in GitHub Actions.
+
+
+Reads env vars BUILD_RESULT, TEST_RESULT, TEST_RUNS_ON, BYPASS_TESTS_FOR_RELEASES and
+sets `upload` ("true"/"false") via `gha_set_env` using this policy:
+1) build != "success" → false
+2) test runner present and tests failed/skipped → false
+3) no test runner and not bypassing → false
+4) otherwise → true
+"""
+
 import argparse
 import os
+import sys
 from github_actions_utils import *
 
 

--- a/build_tools/github_actions/python_to_cp_version.py
+++ b/build_tools/github_actions/python_to_cp_version.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-"""Determines part of the path to the Python interpreter in a manylinux image.
+"""Determines part of the path to the Python interpreter in a manylinux image, along
+   with being used in populating the wheel names for Linux and Windows
 
 Example usage:
 

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -176,6 +176,17 @@ mix/match build steps.
 
 ## Running/testing PyTorch
 
+## Gating releases with Pytorch tests
+
+With passing builds we upload Pytorch, TorchVisual, TorchAudio and Triton wheels to "v2-staging" s3 bucket
+https://rocm.nightlies.amd.com/<v2-staging>/<gfx110X-dgpu>/
+
+Only with passing Torch tests we promote passed wheels to release s3 bucket
+https://rocm.nightlies.amd.com/<v2>/<gfx110X-dgpu>/
+
+If no runner is available: Promotion is blocked by default. Set bypass_tests_for_releases=true only for exceptional cases under amdgpu_family_matrix.py.
+(/build_tools/github_actions/amdgpu_family_matrix.py)
+
 ### Running ROCm and PyTorch sanity checks
 
 The simplest tests for a working PyTorch with ROCm install are:

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -213,8 +213,7 @@ https://rocm.nightlies.amd.com/<v2-staging>/<gfx110X-dgpu>/
 Only with passing Torch tests we promote passed wheels to release s3 bucket
 https://rocm.nightlies.amd.com/<v2>/<gfx110X-dgpu>/
 
-If no runner is available: Promotion is blocked by default. Set bypass_tests_for_releases=true only for exceptional cases under \[`amdgpu_family_matrix.py`\]
-(/build_tools/github_actions/amdgpu_family_matrix.py)
+If no runner is available: Promotion is blocked by default. Set bypass_tests_for_releases=true only for exceptional cases under [`amdgpu_family_matrix.py`](/build_tools/github_actions/amdgpu_family_matrix.py)
 
 ## Advanced build instructions
 

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -176,17 +176,6 @@ mix/match build steps.
 
 ## Running/testing PyTorch
 
-## Gating releases with Pytorch tests
-
-With passing builds we upload Pytorch, TorchVisual, TorchAudio and Triton wheels to "v2-staging" s3 bucket
-https://rocm.nightlies.amd.com/<v2-staging>/<gfx110X-dgpu>/
-
-Only with passing Torch tests we promote passed wheels to release s3 bucket
-https://rocm.nightlies.amd.com/<v2>/<gfx110X-dgpu>/
-
-If no runner is available: Promotion is blocked by default. Set bypass_tests_for_releases=true only for exceptional cases under amdgpu_family_matrix.py.
-(/build_tools/github_actions/amdgpu_family_matrix.py)
-
 ### Running ROCm and PyTorch sanity checks
 
 The simplest tests for a working PyTorch with ROCm install are:
@@ -213,6 +202,19 @@ pytest -v smoke-tests
 See https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html#testing-the-pytorch-installation
 
 <!-- TODO(erman-gurses): update docs here -->
+
+## Nightly releases
+
+### Gating releases with Pytorch tests
+
+With passing builds we upload Pytorch, TorchVisual, TorchAudio and Triton wheels to "v2-staging" s3 bucket
+https://rocm.nightlies.amd.com/<v2-staging>/<gfx110X-dgpu>/
+
+Only with passing Torch tests we promote passed wheels to release s3 bucket
+https://rocm.nightlies.amd.com/<v2>/<gfx110X-dgpu>/
+
+If no runner is available: Promotion is blocked by default. Set bypass_tests_for_releases=true only for exceptional cases under \[`amdgpu_family_matrix.py`\]
+(/build_tools/github_actions/amdgpu_family_matrix.py)
 
 ## Advanced build instructions
 

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -207,13 +207,11 @@ See https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-pa
 
 ### Gating releases with Pytorch tests
 
-With passing builds we upload Pytorch, TorchVisual, TorchAudio and Triton wheels to "v2-staging" s3 bucket
-https://rocm.nightlies.amd.com/<v2-staging>/<gfx110X-dgpu>/
+With passing builds we upload `torch`, `torchvision`, `torchaudio`, and `pytorch-triton-rocm` wheels to subfolders of the "v2-staging" directory in the nightly release s3 bucket with a public URL at https://rocm.nightlies.amd.com/v2-staging/
 
-Only with passing Torch tests we promote passed wheels to release s3 bucket
-https://rocm.nightlies.amd.com/<v2>/<gfx110X-dgpu>/
+Only with passing Torch tests we promote passed wheels to the "v2" directory in the nightly release s3 bucket with a public URL at https://rocm.nightlies.amd.com/v2/
 
-If no runner is available: Promotion is blocked by default. Set bypass_tests_for_releases=true only for exceptional cases under [`amdgpu_family_matrix.py`](/build_tools/github_actions/amdgpu_family_matrix.py)
+If no runner is available: Promotion is blocked by default. Set `bypass_tests_for_releases=true` for exceptional cases under [`amdgpu_family_matrix.py`](/build_tools/github_actions/amdgpu_family_matrix.py)
 
 ## Advanced build instructions
 


### PR DESCRIPTION
Raising this PR to add the changes we added for Pytorch Gating in Linux through #1110 

Also added the staging bucket mechanism added for Linux builds

Below are the steps we want integrated as part of windows builds too:

Build PyTorch wheels
Upload the built wheels to the v2-staging (staging bucket)
Run PyTorch tests using wheels from the staging bucket
Only if tests pass, copy the validated wheels from the staging bucket to the release bucket

If no runner is available: Promotion is blocked by default. Set bypass_tests_for_releases=true only for exceptional cases under amdgpu_family_matrix.py
