### PR TITLE
Apply gentest.py patch to fix rocblas testing on CI.

### DIFF
--- a/patches/amd-mainline/rocm-libraries/0023-Run-gentest.py-with-python-on-Windows-across-_parse_.patch
+++ b/patches/amd-mainline/rocm-libraries/0023-Run-gentest.py-with-python-on-Windows-across-_parse_.patch
@@ -1,0 +1,131 @@
+From 4d57c0ccfd87ca370a948bceed04299a0a772ac1 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Wed, 3 Sep 2025 13:06:42 -0700
+Subject: [PATCH 23/23] Run gentest.py with 'python' on Windows across
+ `_parse_data.cpp` files.
+
+---
+ .../hipblas/clients/common/hipblas_parse_data.cpp   | 13 +++++++++++--
+ .../clients/common/src/hipblaslt_parse_data.cpp     | 11 ++++++++++-
+ .../clients/common/hipsparselt_parse_data.cpp       | 11 ++++++++++-
+ .../rocblas/clients/common/rocblas_parse_data.cpp   | 13 +++++++++++--
+ .../clients/common/rocsparse_parse_data.cpp         |  2 +-
+ 5 files changed, 43 insertions(+), 7 deletions(-)
+
+diff --git a/projects/hipblas/clients/common/hipblas_parse_data.cpp b/projects/hipblas/clients/common/hipblas_parse_data.cpp
+index 753b8dfca6..936482c6f8 100644
+--- a/projects/hipblas/clients/common/hipblas_parse_data.cpp
++++ b/projects/hipblas/clients/common/hipblas_parse_data.cpp
+@@ -35,10 +35,19 @@
+ // Parse YAML data
+ static std::string hipblas_parse_yaml(const std::string& yaml)
+ {
++#ifdef WIN32
++    // Explicitly run via `python.exe`, without relying on the .py file being
++    // treated as an executable that should be run via the python interpreter.
++    std::string python_command_launcher = "python ";
++#else
++    // Rely on the shebang in the file, e.g. `#!/usr/bin/env python3`.
++    std::string python_command_launcher = "";
++#endif
++
+     std::string tmp     = hipblas_tempname();
+     auto        exepath = hipblas_exepath();
+-    auto cmd = exepath + "hipblas_gentest.py --template " + exepath + "hipblas_template.yaml -o "
+-               + tmp + " " + yaml;
++    auto        cmd = python_command_launcher + exepath + "hipblas_gentest.py --template " + exepath
++               + "hipblas_template.yaml -o " + tmp + " " + yaml;
+     std::cerr << cmd << std::endl;
+ 
+ #ifdef WIN32
+diff --git a/projects/hipblaslt/clients/common/src/hipblaslt_parse_data.cpp b/projects/hipblaslt/clients/common/src/hipblaslt_parse_data.cpp
+index 34a99d7ae8..a180ed8b45 100644
+--- a/projects/hipblaslt/clients/common/src/hipblaslt_parse_data.cpp
++++ b/projects/hipblaslt/clients/common/src/hipblaslt_parse_data.cpp
+@@ -37,12 +37,21 @@
+ // Parse YAML data
+ static std::string hipblaslt_parse_yaml(const std::string& yaml)
+ {
++#ifdef WIN32
++    // Explicitly run via `python.exe`, without relying on the .py file being
++    // treated as an executable that should be run via the python interpreter.
++    std::string python_command_launcher = "python ";
++#else
++    // Rely on the shebang in the file, e.g. `#!/usr/bin/env python3`.
++    std::string python_command_launcher = "";
++#endif
++
+     // TODO: This function is inherently unsafe because it returns a string vs an open
+     // file handle which will block further colliding creates. See comments in
+     // hipblaslt_tempname() and under no circumstances copy this to new code.
+     std::string tmp     = hipblaslt_tempname();
+     auto        exepath = hipblaslt_exepath();
+-    auto        cmd     = exepath + "hipblaslt_gentest.py --template " + exepath
++    auto cmd = python_command_launcher + exepath + "hipblaslt_gentest.py --template " + exepath
+                + "hipblaslt_template.yaml -o " + tmp + " " + yaml;
+     hipblaslt_cerr << cmd << std::endl;
+ 
+diff --git a/projects/hipsparselt/clients/common/hipsparselt_parse_data.cpp b/projects/hipsparselt/clients/common/hipsparselt_parse_data.cpp
+index 5b81b740ca..69badb1e59 100644
+--- a/projects/hipsparselt/clients/common/hipsparselt_parse_data.cpp
++++ b/projects/hipsparselt/clients/common/hipsparselt_parse_data.cpp
+@@ -49,9 +49,18 @@ namespace std
+ // Parse YAML data
+ static std::string hipsparselt_parse_yaml(const std::string& yaml)
+ {
++#ifdef WIN32
++    // Explicitly run via `python.exe`, without relying on the .py file being
++    // treated as an executable that should be run via the python interpreter.
++    std::string python_command_launcher = "python ";
++#else
++    // Rely on the shebang in the file, e.g. `#!/usr/bin/env python3`.
++    std::string python_command_launcher = "";
++#endif
++
+     std::string tmp     = hipsparselt_tempname();
+     auto        exepath = hipsparselt_exepath();
+-    auto        cmd     = exepath + "hipsparselt_gentest.py --template " + exepath
++    auto cmd = python_command_launcher + exepath + "hipsparselt_gentest.py --template " + exepath
+                + "hipsparselt_template.yaml -o " + tmp + " " + yaml;
+     hipsparselt_cerr << cmd << std::endl;
+ 
+diff --git a/projects/rocblas/clients/common/rocblas_parse_data.cpp b/projects/rocblas/clients/common/rocblas_parse_data.cpp
+index 830397511f..20c2778b35 100644
+--- a/projects/rocblas/clients/common/rocblas_parse_data.cpp
++++ b/projects/rocblas/clients/common/rocblas_parse_data.cpp
+@@ -47,8 +47,17 @@ static std::string rocblas_parse_yaml(const std::string& yaml)
+         yaml_path = yaml;
+     }
+ 
+-    auto cmd = exepath + "rocblas_gentest.py --template " + exepath + "rocblas_template.yaml -o "
+-               + tmp + " " + yaml_path;
++#ifdef WIN32
++    // Explicitly run via `python.exe`, without relying on the .py file being
++    // treated as an executable that should be run via the python interpreter.
++    std::string python_command_launcher = "python ";
++#else
++    // Rely on the shebang in the file, e.g. `#!/usr/bin/env python3`.
++    std::string python_command_launcher = "";
++#endif
++
++    auto cmd = python_command_launcher + exepath + "rocblas_gentest.py --template " + exepath
++               + "rocblas_template.yaml -o " + tmp + " " + yaml_path;
+     rocblas_cerr << cmd << std::endl;
+ 
+ #ifdef WIN32
+diff --git a/projects/rocsparse/clients/common/rocsparse_parse_data.cpp b/projects/rocsparse/clients/common/rocsparse_parse_data.cpp
+index 4c04a4aedc..d765573b65 100644
+--- a/projects/rocsparse/clients/common/rocsparse_parse_data.cpp
++++ b/projects/rocsparse/clients/common/rocsparse_parse_data.cpp
+@@ -66,7 +66,7 @@ static std::string rocsparse_parse_yaml(const std::string& yaml, const char* inc
+ 
+     auto        exepath       = rocsparse_exepath();
+     const char* matrices_path = rocsparse_clients_matrices_dir_get(false);
+-    auto        cmd           = exepath + "rocsparse_gentest.py ";
++    auto        cmd           = "python " + exepath + "rocsparse_gentest.py ";
+     if(include_path != nullptr)
+     {
+         cmd += " -I ";
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
## Motivation

> [!NOTE]
> Also sent upstream as https://github.com/ROCm/rocm-libraries/pull/1443

Progress on https://github.com/ROCm/rocm-libraries/issues/535. Seeing if this fixes our rocblas tests that have been failing on WIndows like https://github.com/ROCm/TheRock/actions/runs/17438210230/job/49520134395

```
INFO:root:++ Exec [C:\runner\_work\TheRock\TheRock]$ ./build/bin/rocblas-test --yaml ./build/bin/rocblas_smoke.yaml
rocBLAS info: client (OPENMP) reduced omp_set_num_threads to 10
rocBLAS info: Using reference library 'OpenBLAS::OpenBLAS'
rocBLAS warning: Reference library may not support 64-bit input arguments. If running a test suite, please use --gtest_filter=-*stress* to avoid 64-bit test failures.
rocBLAS version: 5.1.0.3eb64eb743
rocBLAS-commit-hash: ee48e295edc2622868613c021a1c58168f651f81
Tensile-commit-hash: 
hipBLASLt version: 1.1.0 commit-hash: 3eb64eb743
Query device success: there are 1 devices
-------------------------------------------------------------------------------
Device ID 0 : AMD Radeon(TM) 8040S Graphics gfx1151
with 9.0 GB memory, max. SCLK 2700 MHz, max. MCLK 800 MHz, memoryBusWidth 32 Bytes, compute capability 11.5
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 32
-------------------------------------------------------------------------------
info: parsing of test data may take a couple minutes before any test output appears...

C:\runner\_work\TheRock\TheRock\build\bin\/rocblas_gentest.py --template C:\runner\_work\TheRock\TheRock\build\bin\/rocblas_template.yaml -o C:\WINDOWS\SystemTemp\rocblas-fu7qHn ./build/bin/rocblas_smoke.yaml
Traceback (most recent call last):
  File "C:\runner\_work\TheRock\TheRock\build\bin\rocblas_gentest.py", line 31, in <module>
    from yaml import CLoader as Loader
ModuleNotFoundError: No module named 'yaml'
```

## Technical Details

See the linked issue. I suspect that these runners don't have PyYAML installed in the system Python which is being used to open (execute) the gentest.py files. On my dev machine I have VSCode set to open Python files which results in a different failure mode. I'm hoping that by explicitly calling `python *_gentest.py`, the active Python interpreter in the current virtual environment will be used instead, which should already have PyYAML installed.

## Test Plan

* Tested extensively on my dev machine
    ```
    .\build\dist\rocm\bin\rocblas-test --yaml ./build/dist/rocm/bin/rocblas_smoke.yaml
    .\build\dist\rocm\bin\hipblaslt-test --yaml D:\projects\TheRock\rocm-libraries\projects\hipblaslt\clients\tests\data\smoke_gtest.yaml
    .\build\dist\rocm\bin\hipblas-test --yaml ./build/dist/rocm/bin/hipblas_smoke.yaml
    ```
* Opted in to gfx115X-windows tests to see if CI runners are happy with the change too

## Test Result

* Local tests succeeded
* CI rocblas tests succeeded: https://github.com/ROCm/TheRock/actions/runs/17445368488/job/49543726892?pr=1383, see logs `python C:\runner\_work\TheRock\TheRock\build\bin\/rocblas_gentest.py --template C:\runner\_work\TheRock\TheRock\build\bin\/rocblas_template.yaml -o C:\WINDOWS\SystemTemp\rocblas-fu7qHn ./build/bin/rocblas_smoke.yaml`
* CI hipblaslt tests failed but I believe that is unrelated: https://github.com/ROCm/TheRock/actions/runs/17445368488/job/49543726890?pr=1383#step:5:9668 see `Error allocating (0 GB) host memory`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
