### PR TITLE
[ci] Add nightly (attempted) builds for windows gfx90x, gfx101x, and gfx103x.

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -67,21 +67,36 @@ amdgpu_family_info_matrix_nightly = {
             "test-runs-on": "",
             "family": "gfx90X-dcgpu",
             "expect_failure": False,
-        }
+        },
+        "windows": {
+            "test-runs-on": "",
+            "family": "gfx90X-dcgpu",
+            "expect_failure": False,
+        },
     },
     "gfx101x": {
         "linux": {
             "test-runs-on": "",
             "family": "gfx101X-dgpu",
             "expect_failure": False,
-        }
+        },
+        "windows": {
+            "test-runs-on": "",
+            "family": "gfx101X-dgpu",
+            "expect_failure": False,
+        },
     },
     "gfx103x": {
         "linux": {
             "test-runs-on": "",
             "family": "gfx103X-dgpu",
             "expect_failure": True,
-        }
+        },
+        "windows": {
+            "test-runs-on": "",
+            "family": "gfx103X-dgpu",
+            "expect_failure": True,
+        },
     },
 }
 

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -256,7 +256,10 @@ class ConfigureCITest(unittest.TestCase):
             families={},
             platform="windows",
         )
-        self.assertEqual(windows_target_output, [])
+        self.assertGreaterEqual(len(windows_target_output), 1)
+        self.assert_target_output_is_valid(
+            target_output=windows_target_output, allow_xfail=True
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/1337. One step towards having releases is having regular builds (succeeding or failing).

See also the roadmap updates in https://github.com/ROCm/TheRock/pull/1344.

## Technical Details

This branch in the `amdgpu_family_matrix.py` file controls which builds are triggered part of the nightly runs on https://github.com/ROCm/TheRock/actions/workflows/ci_nightly.yml?query=branch%3Amain. For example see last night's run at https://github.com/ROCm/TheRock/actions/runs/17421247050
<img width="1028" height="943" alt="image" src="https://github.com/user-attachments/assets/645e277e-503d-4229-a500-e166d5666267" />


## Test Plan

Untested.

I'm optimistically keeping the same `expect_failure`s as Linux. If they need changing we can update them.

## Test Result

We'll see 😄 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
