### PR TITLE
[doc] Refresh CONTRIBUTING.md (comms channels, pre-commit, branch naming, etc.).

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,39 @@
-# Contribute to TheRock
+# Contributing to TheRock
 
-We are enthusiastic about contributions to our code and documentation. For contribution guidelines
-to other parts of ROCM outside of **TheRock**, please see
-[CONTRIBUTING.md](https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md).
+We are enthusiastic about contributions to our code and documentation.
 
-## Development workflow
+The project is still in its early days, so please feel free to file issues where documentation or
+functionality is lacking or even better volunteer to help contribute to help close these gaps!
 
-**TheRock** is focused on making it easy for developers to contribute. In order to facilitate this,
-the source of truth for all issue tracking, project planning and code contributions are in GitHub and
+> [!TIP]
+> For contribution guidelines to other parts of ROCm outside of TheRock, please see
+> [ROCm/CONTRIBUTING.md](https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md).
+
+## Developer policies
+
+### Governance
+
+This is currently covered by the
+[ROCm Project Governance](https://github.com/ROCm/ROCm/blob/develop/GOVERNANCE.md),
+which also defines the code of conduct.
+
+### Communication channels
+
+TheRock is focused on making it easy for developers to contribute. In order to facilitate this,
+the source of truth for all issue tracking, project planning, and code contributions are in GitHub and
 we leverage an open source stack for all development tools and infrastructure so that it they can be
 easily leveraged in any fork.
 
-The project is still in its early days, so please feel free to file bugs where documentation or
-functionality is lacking or even better volunteer to help contribute to help close these gaps!
+We are also active on the [AMD Developer Community Discord Server](https://discord.com/invite/amd-dev)
+in channels like `#therock-contributors` and `#rocm-build-install-help`.
+
+## Development workflows
 
 ### Issue tracking
 
-Before filing a new issue, search the
-[existing issues](https://github.com/ROCm/TheRock/issues) to make sure your issue isn't
-already listed.
+Before filing a new issue, please search through
+[existing issues](https://github.com/ROCm/TheRock/issues) to make sure your issue hasn't
+already been reported.
 
 General issue guidelines:
 
@@ -33,10 +48,12 @@ General issue guidelines:
 - Check your issue regularly, as we may require additional information to successfully reproduce the
   issue.
 
-### Governance
+### New feature development
 
-This is currently covered by the
-[ROCM project Governance](https://github.com/ROCm/ROCm/blob/develop/GOVERNANCE.md).
+Please [file a new issue](https://github.com/ROCm/TheRock/issues) or reach out
+[on Discord](https://discord.com/invite/amd-dev) to discuss a new feature. We
+are also considering using
+[GitHub discussions](https://github.com/ROCm/TheRock/discussions) more in the future.
 
 ### Pull requests
 
@@ -52,7 +69,51 @@ When you create a pull request, you should target the *main* branch.
 > By creating a PR, you agree to allow your contribution to be licensed under the
 > terms of the [LICENSE](LICENSE) file.
 
-### New feature development
+### pre-commit checks
 
-For now, please file a new issue to discuss a new feature. We are considering switching to GitHub
-discussions in the future.
+We use [pre-commit](https://pre-commit.com/) to run automated "hooks" like lint
+checks and formatters on each commit. See the list of hooks we currently
+run at [`.pre-commit-config.yaml`](.pre-commit-config.yaml). Contributors are
+encouraged to download pre-commit and run it on their commits before sending
+pull requests for review.
+
+> [!TIP]
+> The pre-commit tool can also be "installed" as a git hook to run automatically
+> on every `git commit`.
+
+For example:
+
+```bash
+# Download.
+pip install pre-commit
+
+# Run locally on staged files.
+pre-commit run
+
+# Run locally on all files.
+pre-commit run --all-files
+
+# Install git hook.
+pre-commit install
+```
+
+### Branch creation and naming
+
+If creating a branch in the shared repository (and not a fork), prefer to choose
+a branch name following one of these patterns:
+
+- `users/[USERNAME]/[feature-or-bug-name]`
+- `shared/[feature-or-bug-name]`
+
+These naming schemes allow for long-lived branches to be more easily sorted and
+possibly cleaned up by repository maintainers.
+
+> [!TIP]
+> Most developer workflows are compatible with pull requests coming from forks.
+> Some good reasons to create branches in the shared repository are:
+>
+> - Collaborating on changes on a shared branch
+> - Stacking a series of pull requests by setting the base branches for each PR
+> - Triggering custom workflows such as "dev" release builds using
+>   [workflow_dispatch](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow)
+>   and running on our self-hosted GitHub Actions runners

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,10 +50,11 @@ General issue guidelines:
 
 ### New feature development
 
-Please [file a new issue](https://github.com/ROCm/TheRock/issues) or reach out
-[on Discord](https://discord.com/invite/amd-dev) to discuss a new feature. We
-are also considering using
-[GitHub discussions](https://github.com/ROCm/TheRock/discussions) more in the future.
+Discussion about new features is welcome via
+
+- Filing a [GitHub issue](https://github.com/ROCm/TheRock/issues)
+- Reaching out [on Discord](https://discord.com/invite/amd-dev)
+- Posting a [GitHub discussion](https://github.com/ROCm/TheRock/discussions) (discussions are not as active)
 
 ### Pull requests
 


### PR DESCRIPTION
* Added "communication channels" section with a link to the AMD Developer Community Discord Server (also linked from https://www.amd.com/en/developer.html)
* Document https://pre-commit.com/ requirement and setup example
* Document branch naming recommendations (similar to https://github.com/ROCm/rocm-systems/blob/develop/CONTRIBUTING.md#1-branch-naming-and-forks)
* Misc grammar/style tweaks