### PR TITLE
[ci] adding `expect_failure` for windows CI nightly

### DIFF
--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -9,6 +9,8 @@ on:
       amdgpu_families:
         type: string
         default: gfx110X-dgpu
+      expect_failure:
+        type: boolean
       extra_cmake_options:
         type: string
 
@@ -19,6 +21,8 @@ on:
         default: ADHOCBUILD
       amdgpu_families:
         type: string
+      expect_failure:
+        type: boolean
       extra_cmake_options:
         type: string
 
@@ -27,8 +31,9 @@ permissions:
 
 jobs:
   build_windows_packages:
-    name: Build Windows Packages
+    name: Build Windows Packages (xfail ${{ inputs.expect_failure }})
     runs-on: azure-windows-scale-rocm
+    continue-on-error: ${{ inputs.expect_failure }}
     permissions:
       id-token: write
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
       test_runs_on: ${{ matrix.families.test-runs-on }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
       extra_cmake_options: ${{ matrix.extra_cmake_options }}
+      expect_failure: ${{ matrix.families.expect_failure == true }}
       windows_use_prebuilt_artifacts: ${{ inputs.windows_use_prebuilt_artifacts == true && 'true' || 'false' }}
     permissions:
       contents: read

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -9,6 +9,8 @@ on:
         type: string
       test_runs_on:
         type: string
+      expect_failure:
+        type: boolean
       windows_use_prebuilt_artifacts:
         type: string
       extra_cmake_options:
@@ -26,6 +28,7 @@ jobs:
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       extra_cmake_options: ${{ inputs.extra_cmake_options }}
+      expect_failure: ${{ inputs.expect_failure }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
a test fail job working here: https://github.com/ROCm/TheRock/actions/runs/17470521668/job/49617493256