### PR TITLE
[MIOpen] Re-add gtests from MIOpen  and optimize execution time if needed

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -56,8 +56,6 @@ positive_filter.append("*/GPU_UnitTestConv*")
 positive_filter.append("*/GPU_GetitemBwd*")
 positive_filter.append("*/GPU_GLU_*")
 
-positive_filter.append("*/GPU_MhaBackward_*")
-positive_filter.append("*/GPU_MhaForward_*")
 positive_filter.append("*/GPU_GroupConv*")
 positive_filter.append("*/GPU_GroupNorm_*")
 positive_filter.append("*/GPU_GRUExtra_*")
@@ -108,6 +106,9 @@ negative_filter.append("*/GPU_Bwd_Mha_*")
 negative_filter.append("*/GPU_Fwd_Mha_*")
 negative_filter.append("*/GPU_Softmax*")
 negative_filter.append("*/GPU_Dropout*")
+negative_filter.append("*/GPU_MhaBackward_*")
+negative_filter.append("*/GPU_MhaForward_*")
+
 
 # For sake of time saving on pre-commit step
 ####################################################


### PR DESCRIPTION
A lot of tests were added.

Several tests were disabled because of fatal error: 'rocrand/rocrand_xorwow.h' file not found
negative_filter.append("*/GPU_Bwd_Mha_*")
negative_filter.append("*/GPU_Fwd_Mha_*")
negative_filter.append("*/GPU_Softmax*")
negative_filter.append("*/GPU_Dropout*")
negative_filter.append("*/GPU_MhaBackward_*")
negative_filter.append("*/GPU_MhaForward_*")
Should be investigated further.

Shard 1: ~21m
Shard 2: ~31m
Shard 3: ~22m
Shard 4: ~20m