### PR TITLE
Add setuptools_scm to pytorch package allowlist.

### DIFF
--- a/build_tools/third_party/s3_management/manage.py
+++ b/build_tools/third_party/s3_management/manage.py
@@ -132,6 +132,7 @@ PACKAGE_ALLOW_LIST = {x.lower() for x in [
     "xformers",
     "executorch",
     "setuptools",
+    "setuptools_scm",
     "wheel",
     # ---- JAX ----
     "jax",


### PR DESCRIPTION
As in https://github.com/pytorch/test-infra/pull/7109. This dependency was added in https://github.com/pytorch/pytorch/pull/158747, so we'll need it on our release index too.