### PR TITLE
[ci] Adding libgfortran to docker image

### DIFF
--- a/dockerfiles/no_rocm_image_ubuntu24_04.Dockerfile
+++ b/dockerfiles/no_rocm_image_ubuntu24_04.Dockerfile
@@ -29,7 +29,8 @@ RUN sudo apt-get update -y \
     clang \
     lld \
     wget \
-    psmisc
+    psmisc \
+    libgfortran5
 
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && \
     sudo apt-get install git-lfs


### PR DESCRIPTION
Noticing failures for `rocm-sdk` tests on PyTorch tests.

Previously failing with SHA (405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26): https://github.com/ROCm/TheRock/actions/runs/17435693293/job/49508666985

Docker image builds here: https://github.com/ROCm/TheRock/actions/runs/17554856298/job/49856243045

Now passing with new SHA (2c77933be4578150d518041e7974da3cce24520f5d30b57db79964ee25ccb40b): https://github.com/ROCm/TheRock/actions/runs/17555309731/job/49857829596

Conveniently, this will actually remove some GitHub Action test steps:
https://github.com/ROCm/TheRock/blob/01f49e0fff7311cff8b09eceb05c9dd42aa55269/.github/workflows/test_packages.yml#L105-L107

Will update SHAs and do cleanup in a follow up PR after this docker image builds on main

