### PR TITLE
third-party/yaml-cpp: fix build on GCC 15

### DIFF
--- a/build_tools/patch_third_party_source.py
+++ b/build_tools/patch_third_party_source.py
@@ -1,0 +1,62 @@
+# patch_third_party_source.py is designed to act as the PATCH_COMMAND for
+#  therock_subproject_fetch
+#  ExternalProject_Add
+# from CMake.
+# See https://cmake.org/cmake/help/latest/module/ExternalProject.html#patch-step-options
+#
+# SYNOPSIS: patch_third_party_source.py PATCHES_DIR
+#
+# Uses `git apply PATCH` for the actual patching.
+# Assumes the current working directory is the source directory of the extracted tarball.
+
+import sys
+import os
+import subprocess
+from pathlib import Path
+
+
+def run_command(cmd_list, cwd=None):
+    print(f"\n--- Executing: {' '.join(map(str, cmd_list))} ---", flush=True)
+    try:
+        process = subprocess.run(cmd_list, cwd=cwd, check=True, text=True)
+    except FileNotFoundError:
+        print(
+            f"ERROR: Command not found: {cmd_list[0]}. Is it installed and in PATH?",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: Command failed with exit code {e.returncode}", file=sys.stderr)
+        sys.exit(e.returncode)
+    except Exception as e:
+        print(f"ERROR: An unexpected error occurred: {e}", file=sys.stderr)
+        sys.exit(1)
+    return process
+
+
+def create_stamp_file(filename):
+    with open(filename, "w") as f:
+        pass
+
+
+def main(args):
+    try:
+        (patches_dir,) = args
+    except ValueError:
+        sys.stderr.write("usage: patch_third_party_source PATCHES_DIR\n")
+        sys.exit(2)
+
+    stamp_filename = "patch_third_party_source.stamp"
+    if os.path.exists(stamp_filename):
+        sys.exit(0)
+
+    patches = sorted(os.listdir(patches_dir))
+    patches_dir = Path(patches_dir)
+    for i in patches:
+        p = patches_dir / i
+        run_command(["git", "apply", p])
+    create_stamp_file(stamp_filename)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/patches/third-party/yaml-cpp/0001-emitterutils-Explicitly-include-cstdint.patch
+++ b/patches/third-party/yaml-cpp/0001-emitterutils-Explicitly-include-cstdint.patch
@@ -1,0 +1,41 @@
+From 7b469b4220f96fb3d036cf68cd7bd30bd39e61d2 Mon Sep 17 00:00:00 2001
+From: Christopher Fore <csfore@posteo.net>
+Date: Wed, 14 Aug 2024 21:02:32 -0400
+Subject: [PATCH] emitterutils: Explicitly include <cstdint>
+
+GCC 15 will no longer include it by default, resulting in build
+failures in projects that do not explicitly include it.
+
+Error:
+src/emitterutils.cpp:221:11: error: 'uint16_t' was not declared in this scope
+  221 | std::pair<uint16_t, uint16_t> EncodeUTF16SurrogatePair(int codePoint) {
+      |           ^~~~~~~~
+src/emitterutils.cpp:13:1: note: 'uint16_t' is defined in header '<cstdint>';
+this is probably fixable by adding '#include <cstdint>'
+   12 | #include "yaml-cpp/null.h"
+  +++ |+#include <cstdint>
+   13 | #include "yaml-cpp/ostream_wrapper.h"
+
+Tests pass.
+
+Closes: #1307
+See-also: https://gcc.gnu.org/pipermail/gcc-cvs/2024-August/407124.html
+See-also: https://bugs.gentoo.org/937412
+Signed-off-by: Christopher Fore <csfore@posteo.net>
+---
+ src/emitterutils.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/emitterutils.cpp b/src/emitterutils.cpp
+index fc41011..f801b1d 100644
+--- a/src/emitterutils.cpp
++++ b/src/emitterutils.cpp
+@@ -1,4 +1,5 @@
+ #include <algorithm>
++#include <cstdint>
+ #include <iomanip>
+ #include <sstream>
+ 
+-- 
+2.49.0
+

--- a/third-party/yaml-cpp/CMakeLists.txt
+++ b/third-party/yaml-cpp/CMakeLists.txt
@@ -3,6 +3,7 @@ therock_subproject_fetch(therock-yaml-cpp-sources
   # Originally mirrored from: https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz
   URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/yaml-cpp-0.8.0.tar.gz
   URL_HASH SHA256=fbe74bbdcee21d656715688706da3c8becfd946d92cd44705cc6098bb23b3a16
+  PATCH_COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/build_tools/patch_third_party_source.py ${CMAKE_SOURCE_DIR}/patches/third-party/yaml-cpp
 )
 
 therock_cmake_subproject_declare(therock-yaml-cpp


### PR DESCRIPTION
yaml-cpp upstream has not made a release since 2023: https://github.com/jbeder/yaml-cpp/releases

It currently fails to build with gcc 15+ due to not including `stdint.h` directly.

This PR fixes it by cherry picks this upstream patch:
https://github.com/jbeder/yaml-cpp/commit/7b469b4220f96fb3d036cf68cd7bd30bd39e61d2