### PR TITLE
[rocm-sdk] Skipping fortran tests for `rocm-sdk test` if gfortran package not available

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
@@ -61,7 +61,7 @@ class ROCmLibrariesTest(unittest.TestCase):
                 # TODO(#1417): Remove fortran dependency for TheRock testing
                 libgfortran_path = ctypes.util.find_library("gfortran")
                 if (
-                    "fortran" in so_path
+                    "fortran" in str(so_path)
                     and not libgfortran_path
                     and platform.system() == "Linux"
                 ):

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
@@ -57,13 +57,13 @@ class ROCmLibrariesTest(unittest.TestCase):
         for so_path in so_paths:
             with self.subTest(msg="Check shared library loads", so_path=so_path):
 
-                # If libgfortran is not installed for Linux, we skip the fortran tests
+                # If libgfortran is not installed for Linux, we skip the fortran checks
                 # TODO(#1417): Remove fortran dependency for TheRock testing
                 libgfortran_path = ctypes.util.find_library("gfortran")
                 if (
                     "fortran" in so_path
                     and not libgfortran_path
-                    and platform.system() == "Linuxs"
+                    and platform.system() == "Linux"
                 ):
                     self.skipTest(
                         f"Skipping {so_path} test as libgfortran is not installed"

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
@@ -2,11 +2,12 @@
 
 """Installation package tests for the core package."""
 
+import ctypes.util
 import importlib
 from pathlib import Path
+import platform
 import subprocess
 import sys
-import sysconfig
 import unittest
 
 from .. import _dist_info as di
@@ -55,6 +56,18 @@ class ROCmLibrariesTest(unittest.TestCase):
 
         for so_path in so_paths:
             with self.subTest(msg="Check shared library loads", so_path=so_path):
+
+                # If libgfortran is not installed for Linux, we skip the fortran tests
+                # TODO(#1417): Remove fortran dependency for TheRock testing
+                libgfortran_path = ctypes.util.find_library("gfortran")
+                if (
+                    "fortran" in so_path
+                    and not libgfortran_path
+                    and platform.system() == "Linuxs"
+                ):
+                    self.skipTest(
+                        f"Skipping {so_path} test as libgfortran is not installed"
+                    )
 
                 # For Windows compatibility, we first preload libraries (DLLs)
                 # that are not co-located. Specifically this is for


### PR DESCRIPTION
Closes #1418 

Works in [`Release portable Linux packages `](https://github.com/ROCm/TheRock/actions/runs/17564732064) and [`Release portable Linux PyTorch Wheels`](https://github.com/ROCm/TheRock/actions/runs/17569700913)
