### PR TITLE
Exclude `libhipsolver_fortran` from lib

### DIFF
--- a/math-libs/BLAS/artifact-blas.toml
+++ b/math-libs/BLAS/artifact-blas.toml
@@ -115,14 +115,14 @@ optional = true
 optional = true
 [components.lib."math-libs/BLAS/hipSOLVER/stage"]
 exclude = [
-  "lib/libhipsolver_fortran.so",
+  "lib/libhipsolver_fortran.so*",
 ]
 optional = true
 [components.test."math-libs/BLAS/hipSOLVER/stage"]
 include = [
   "bin/hipsolver-bench*",
   "bin/hipsolver-test*",
-  "lib/libhipsolver_fortran.so",
+  "lib/libhipsolver_fortran.so*",
   "share/hipsolver/test/**",
 ]
 optional = true


### PR DESCRIPTION
Previously, `libhipsolver_fortran.so` was explicitly excluded from the lib artifact but included in the test artifact as the shared object is only required by the `hipsolver-bench` and `hipsolver-test` executables which are part of the test artifact.

With commit ROCm/hipSOLVER@ddb8256, upstream introduced a soft link to the library target, resulting in the include and excludes not beeing applied anymore. This patches should restore the prior partitioning, avoiding to add an uncessary dependency on Fortran in the lib artifacts and later the `rocm[libraries]` package.