### PR TITLE
third-party/host-blas: upgrade for GCC 15 fix

### DIFF
--- a/third-party/host-blas/CMakeLists.txt
+++ b/third-party/host-blas/CMakeLists.txt
@@ -23,8 +23,8 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
       CMAKE_PROJECT
       SOURCE_DIR "${_source_dir}"
       # Originally mirrored from: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.29/OpenBLAS-0.3.29.tar.gz
-      URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/OpenBLAS-0.3.29.tar.gz
-      URL_HASH SHA256=38240eee1b29e2bde47ebb5d61160207dc68668a54cac62c076bb5032013b1eb
+      URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/OpenBLAS-0.3.30.tar.gz
+      URL_HASH SHA256=27342cff518646afb4c2b976d809102e368957974c250a25ccc965e53063c95d
       # Originally posted MD5 was recomputed as SHA256 manually:
       # URL_HASH MD5=853a0c5c0747c5943e7ef4bbb793162d
       TOUCH "${_download_stamp}"


### PR DESCRIPTION
Upgrade OpenBLAS version from 0.3.29 to 0.3.30 to fix build on GCC 15.

The critical fix is:
https://github.com/OpenMathLib/OpenBLAS/pull/5258
to fix the following build errors:

```
/home/schenker/workspace/OpenBLAS/lapack-netlib/SRC/sgees.c:720:27: error: too many arguments to function ‘select’; expected 0, have 2
 720 |       bwork[i__] = (*select)(&wr[i__], &wi[i__]);
     |                    ~^~~~~~~~ ~~~~~~~~
/home/schenker/workspace/OpenBLAS/lapack-netlib/SRC/sgeesx.c:815:27: error: too many arguments to function ‘select’; expected 0, have 2
 815 |       bwork[i__] = (*select)(&wr[i__], &wi[i__]);
     |                    ~^~~~~~~~ ~~~~~~~~
/home/schenker/workspace/OpenBLAS/lapack-netlib/SRC/sgees.c:836:22: error: too many arguments to function ‘select’; expected 0, have 2
 836 |       cursl = (*select)(&wr[i__], &wi[i__]);
     |               ~^~~~~~~~ ~~~~~~~~
/home/schenker/workspace/OpenBLAS/lapack-netlib/SRC/sgeesx.c:953:22: error: too many arguments to function ‘select’; expected 0, have 2
 953 |       cursl = (*select)(&wr[i__], &wi[i__]);
     |               ~^~~~~~~~ ~~~~~~~~
```