### PR TITLE
[doc] Wrap `rocm[libraries,devel]` in quotes for Zsh and powershell.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -113,7 +113,7 @@ Install instructions:
 ```bash
 python -m pip install \
   --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ \
-  rocm[libraries,devel]
+  "rocm[libraries,devel]"
 ```
 
 #### rocm for gfx950-dcgpu
@@ -129,7 +129,7 @@ Install instructions:
 ```bash
 python -m pip install \
   --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ \
-  rocm[libraries,devel]
+  "rocm[libraries,devel]"
 ```
 
 #### rocm for gfx110X-dgpu
@@ -147,7 +147,7 @@ Install instructions:
 ```bash
 python -m pip install \
   --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
-  rocm[libraries,devel]
+  "rocm[libraries,devel]"
 ```
 
 #### rocm for gfx1151
@@ -163,7 +163,7 @@ Install instructions:
 ```bash
 python -m pip install \
   --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
-  rocm[libraries,devel]
+  "rocm[libraries,devel]"
 ```
 
 #### rocm for gfx120X-all
@@ -180,7 +180,7 @@ Install instructions:
 ```bash
 python -m pip install \
   --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ \
-  rocm[libraries,devel]
+  "rocm[libraries,devel]"
 ```
 
 ### Using ROCm Python packages


### PR DESCRIPTION
## Motivation

As [reported on Discord](https://discord.com/channels/1239631572886491286/1370146945867448431/1413223080662269983), Zsh can't copy/paste commands with unescaped square brackets. Guidance from https://stackoverflow.com/a/30239714 is to use quotes, which also helps for Windows Powershell.

## Test Plan / Test Result

Tried the commands on Windows (cmd.exe), they still work.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
