### PR TITLE
[torch] Run sanity_check_wheel.py in build_windows_pytorch_wheels.yml

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -176,16 +176,16 @@ jobs:
             --output-dir ${{ env.PACKAGE_DIST_DIR }} ${{ env.optional_build_prod_arguments }}
           python ./build_tools/github_actions/write_torch_versions.py --dist-dir ${{ env.PACKAGE_DIST_DIR }}
 
+      - name: Sanity Check Wheel
+        run: |
+          python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}/
+
       - name: Configure AWS Credentials
         if: always()
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
-
-      - name: Sanity Check Wheel
-        run: |
-          python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}/
 
       - name: Upload wheels to S3 staging
         if: ${{ github.repository_owner == 'ROCm' }}

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -166,17 +166,17 @@ jobs:
             ${{ env.optional_build_prod_arguments }}
           python ./build_tools/github_actions/write_torch_versions.py --dist-dir ${{ env.PACKAGE_DIST_DIR }}
 
+      - name: Sanity Check Wheel
+        shell: cmd
+        run: |
+          python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}
+
       - name: Configure AWS Credentials
         if: always()
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
-
-      - name: Sanity Check Wheel
-        shell: cmd
-        run: |
-          python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}
 
       - name: Upload wheels to S3 staging
         if: ${{ github.repository_owner == 'ROCm' }}

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -173,11 +173,10 @@ jobs:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
 
-      # TODO(#827, #910): enable this once we build torch audio and vision on Windows
-      # - name: Sanity Check Wheel
-      #   shell: cmd
-      #   run: |
-      #     python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}
+      - name: Sanity Check Wheel
+        shell: cmd
+        run: |
+          python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}
 
       - name: Upload wheels to S3 staging
         if: ${{ github.repository_owner == 'ROCm' }}


### PR DESCRIPTION
## Motivation

See https://github.com/ROCm/TheRock/issues/827 and https://github.com/ROCm/TheRock/issues/910.

We weren't running the [`external-builds/pytorch/sanity_check_wheel.py`](https://github.com/ROCm/TheRock/blob/main/external-builds/pytorch/sanity_check_wheel.py) script on Windows since we weren't building torchaudio and torchvision. Now that we are, we can run this sanity check script.

## Test Plan

Ran the sanity check script locally on Windows after building. I have _not_ tested the workflows.

## Test Result

Truncated output (I've rebuilt many times):
```
λ python .\sanity_check_wheel.py C:\Users\Nod-Shark16\.therock\pytorch
Valid wheel: torch-2.7.0a0+rocmsdk20250624-cp312-cp312-win_amd64.whl (182538029 bytes)
Valid wheel: torch-2.7.0a0+rocmsdk20250716-cp312-cp312-win_amd64.whl (183473493 bytes)
...
Valid wheel: torch-2.9.0a0+rocmsdk20250828-cp312-cp312-win_amd64.whl (568627601 bytes)
Valid wheel: torch-2.9.0a0+rocmsdk20250904-cp312-cp312-win_amd64.whl (244530037 bytes)
Valid wheel: torch-2.9.0a0+rocmsdk20250909-cp312-cp312-win_amd64.whl (631056141 bytes)
Valid wheel: torchaudio-2.7.0a0+rocmsdk20250723-cp312-cp312-win_amd64.whl (1618667 bytes)
Valid wheel: torchaudio-2.8.0a0+rocmsdk20250724-cp312-cp312-win_amd64.whl (1624962 bytes)
...
Valid wheel: torchaudio-2.8.0a0+rocmsdk20250828-cp312-cp312-win_amd64.whl (1548796 bytes)
Valid wheel: torchaudio-2.8.0a0+rocmsdk20250909-cp312-cp312-win_amd64.whl (1557705 bytes)
Valid wheel: torchvision-0.24.0a0+rocmsdk20250804-cp313-cp313-win_amd64.whl (1501788 bytes)
Valid wheel: torchvision-0.24.0a0+rocmsdk20250811-cp312-cp312-win_amd64.whl (1287118 bytes)
...
Valid wheel: torchvision-0.24.0a0+rocmsdk20250904-cp312-cp312-win_amd64.whl (1501770 bytes)
Valid wheel: torchvision-0.24.0a0+rocmsdk20250909-cp312-cp312-win_amd64.whl (1501770 bytes)
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
