### PR TITLE
Drop comment about uploading Windows packages to to GitHub releases.

### DIFF
--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -242,10 +242,6 @@ jobs:
           echo "-------------"
           ccache -s
 
-      # Note: not uploading to GitHub releases since files are 4GB+, larger than
-      # the 2GB limit for GitHub release files:
-      # https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas
-
       - name: Configure AWS Credentials
         if: ${{ github.repository_owner == 'ROCm' }}
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1


### PR DESCRIPTION
We stopped publishing Linux packages to GitHub releases in https://github.com/ROCm/TheRock/pull/1016, but this comment in the Windows workflow was leftover.