### PR TITLE
[torch] Flip `--enable-pytorch-flash-attention-windows` for releases.

### DIFF
--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -117,9 +117,7 @@ jobs:
       # TODO(amd-justchen): share with build_windows_packages.yml. Include in VM image? Dockerfile?
       - name: Install requirements
         run: |
-          # ninja pinned due to a bug in the 1.13.0 release:
-          # https://github.com/ninja-build/ninja/issues/2616
-          choco install --no-progress -y ninja --version 1.12.1
+          choco install --no-progress -y ninja --version 1.13.1
           choco install --no-progress -y awscli
           echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
 
@@ -161,6 +159,7 @@ jobs:
             --pytorch-dir ${{ env.CHECKOUT_ROOT }}/torch ^
             --pytorch-audio-dir ${{ env.CHECKOUT_ROOT }}/audio ^
             --pytorch-vision-dir ${{ env.CHECKOUT_ROOT }}/vision ^
+            --enable-pytorch-flash-attention-windows ^
             --clean ^
             --output-dir ${{ env.PACKAGE_DIST_DIR }} ^
             ${{ env.optional_build_prod_arguments }}

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -95,22 +95,6 @@ for more background on these `rocm` packages.
 > On Windows, when building with "--enable-pytorch-flash-attention-windows",
 > Make sure to use [ninja 1.13.1](https://github.com/ninja-build/ninja/releases/tag/v1.13.1) or above.
 >
-> PyTorch builds aotriton locally, but without the kernel images.
-> Make sure to copy the `aotriton.images` folder from an existing
-> aotriton linux build (`<aotriton_build_dir>/lib/aotriton.images`) and copy
-> that folder into your local pytorch lib directory: `<pytorch_dir>/torch/lib/`.
-> This is a temporary measure for manually producing aotriton builds.
-> NOTE: This will not work without the [corresponding patch](./patches/pytorch/main/pytorch/hipified/0004-Support-FLASH_ATTENTION-MEM_EFF_ATTENTION-via.-aotri.patch) for the main branch.
->
-> On Windows, aotriton uses `dladdr`, which is implemented through
-> [dlfcn-win32](https://github.com/dlfcn-win32/dlfcn-win32), which unfortunately
-> uses `GetModuleFileNameA` (ANSI version) to get the base directory of
-> `libaotriton.so`. This means, if `libaotriton.so` is put under a path with
-> characters that cannot represented in current code page, the loading of GPU
-> kernels will fail.
-> See https://github.com/ROCm/aotriton/commit/e1be21d80b25f46139c2e3b4b0615e0279feccac
-> For possible fixes. A proper fix is planned and will eventually be added.
->
 > NOTE: If you use ccache and face "invalid argument" errors during the aotriton build,
 > disable ccache and try again.
 


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/1040, enabling aotriton for flash attention in pytorch (if it works). This is expected to improve performance in workloads like ComfyUI image generation by upwards of 60% (e.g. 12.6 it/s to 20.0 it/s).

## Technical Details

Follow-up to https://github.com/ROCm/TheRock/pull/1432 and depends on https://github.com/pytorch/pytorch/pull/162330.

Note that support is experimental for some GPUs like gfx1100, so the `TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1` environment variable may be needed to try aotriton on those systems.

## Test Plan

Trigger either https://github.com/ROCm/TheRock/actions/workflows/build_windows_pytorch_wheels.yml or https://github.com/ROCm/TheRock/actions/workflows/release_windows_pytorch_wheels.yml across the matrix of GPU families once that PyTorch PR is merged.

We're still going to need automated tests and documentation for this. I'd like numerics tests running somewhere and documentation that shows how to check which pytorch features are enabled in the wheels that a user installs.

## Test Result

TBD

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
