### PR TITLE
Corrected upload to staging s3 source dir

### DIFF
--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -256,7 +256,8 @@ jobs:
       - name: Upload Releases to staging S3
         if: ${{ github.repository_owner == 'ROCm' }}
         run: |
-          aws s3 cp ${{ env.OUTPUT_DIR }}/packages/dist/ s3://${{ env.S3_BUCKET_PY }}/${{ env.S3_STAGING_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}/ \
+          aws s3 cp ${{ env.DIST_ARCHIVE }} s3://${{ env.S3_BUCKET_TAR }}
+          aws s3 cp ${{ env.BUILD_DIR }}/packages/dist/ s3://${{ env.S3_BUCKET_PY }}/${{ env.S3_STAGING_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}/ \
           --recursive --no-follow-symlinks \
           --exclude "*" \
           --include "*.whl" \


### PR DESCRIPTION
Raising this PR to address the failure in Release Windows Packages workflow, recently added an upload to staging S3 step as part of merge #1382.

Failure logs:
[Release Windows packages · ROCm/TheRock@28386af](https://github.com/ROCm/TheRock/actions/runs/17588163557/job/49961710451#step:17:74).
 
Fix has been validated with the workflow run below:

https://github.com/ROCm/TheRock/actions/runs/17594149418/job/49982205211