### PR TITLE
[ci] Extending timeout for hipblaslt tests

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -39,7 +39,7 @@ test_matrix = {
     "hipblaslt": {
         "job_name": "hipblaslt",
         "fetch_artifact_args": "--blas --tests",
-        "timeout_minutes": 30,
+        "timeout_minutes": 60,
         "test_script": f"python {_get_script_path('test_hipblaslt.py')}",
         "platform": ["linux", "windows"],
     },


### PR DESCRIPTION
It seems the `hipblaslt` tests seem to average around 20mins, sometimes going beyond 30 mins. This results in a timeout error like below:

- https://github.com/ROCm/TheRock/actions/runs/17587709994/job/49967842476
- https://github.com/ROCm/TheRock/actions/runs/17587709994/job/49967842476

I actually don't know why the actual runtime was so close to timeout, but regardless, extending timeout to resolve this error