### PR TITLE
[ci] Fixing windows for CI nightly

### DIFF
--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -97,24 +97,3 @@ jobs:
   # build_python_packages:
   #   name: Build Python Packages
   #   uses: ./.github/workflows/build_python_packages.yml
-
-  ci_summary:
-    name: CI Summary
-    if: always()
-    needs:
-      - setup
-      - linux_build_and_test
-      - windows_build_and_test
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Output failed jobs
-        run: |
-          echo '${{ toJson(needs) }}'
-          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
-            | jq --raw-output \
-            'map_values(select(.result!="success" and .result!="skipped")) | keys | join(",")' \
-          )"
-          if [[ "${FAILED_JOBS}" != "" ]]; then
-            echo "The following jobs failed: ${FAILED_JOBS}"
-            exit 1
-          fi


### PR DESCRIPTION
Windows CI Nightly never got the `expected_failure`, causing it to actually mark as failure: https://github.com/ROCm/TheRock/actions/runs/17601268270/job/50003536719

Tested here: https://github.com/ROCm/TheRock/actions/runs/17618752696