### PR TITLE
Search scripts directory for amdgpu-arch in rocm_sdk.

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -7,6 +7,7 @@ of bootstrapping, we are including it inline for the moment.
 import importlib.util
 import os
 import subprocess
+from pathlib import Path
 
 
 CACHED_TARGET_FAMILY: str | None = None


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/1421.

## Technical Details

1. When run with a venv activated the scripts directory is included on PATH and discovery succeeds:

    ```
    (3.12.venv) λ python -c "import rocm_sdk; print(rocm_sdk._dist_info.determine_target_family())"
    gfx110X-dgpu
    ```

2. When run _without a venv activated_, the tool is not found:
    
    ```
    λ .\3.12.venv\Scripts\python -c "import rocm_sdk; print(rocm_sdk._dist_info.determine_target_family())"
    [ERROR] amdgpu-arch not found.
    gfx110X-dgpu
    ```

This fixes that case by explicitly adding the scripts directory to the PATH environment when running the command.

## Test Plan

Tested on Windows with a venv. Not tested on Linux.
