### PR TITLE
Fix `subprocess.CalledProcessError` in HIPIFY Commit Workflow

### DIFF
--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -139,3 +139,135 @@ jobs:
           python ./external-builds/pytorch/pytorch_vision_repo.py checkout \
             --repo ${{ env.CHECKOUT_ROOT }}/vision \
             --repo-hashtag main
+
+      - name: Determine optional arguments passed to `build_prod_wheels.py`
+        if: ${{ inputs.rocm_version }}
+        run: |
+          pip install packaging
+          python build_tools/github_actions/determine_version.py \
+            --rocm-version ${{ inputs.rocm_version }}
+
+      - name: Build PyTorch Wheels
+        id: build-pytorch-wheels
+        # Using 'cmd' here is load bearing! There are configuration issues when
+        # run under 'bash': https://github.com/ROCm/TheRock/issues/827#issuecomment-3025858800
+        shell: cmd
+        run: |
+          echo "Building PyTorch wheels for ${{ inputs.amdgpu_family }}"
+          python ./external-builds/pytorch/build_prod_wheels.py ^
+            build ^
+            --install-rocm ^
+            --index-url "${{ inputs.cloudfront_url }}/${{ inputs.amdgpu_family }}/" ^
+            --pytorch-dir ${{ env.CHECKOUT_ROOT }}/torch ^
+            --pytorch-audio-dir ${{ env.CHECKOUT_ROOT }}/audio ^
+            --pytorch-vision-dir ${{ env.CHECKOUT_ROOT }}/vision ^
+            --clean ^
+            --output-dir ${{ env.PACKAGE_DIST_DIR }} ^
+            ${{ env.optional_build_prod_arguments }}
+          python ./build_tools/github_actions/write_torch_versions.py --dist-dir ${{ env.PACKAGE_DIST_DIR }}
+
+      - name: Sanity Check Wheel
+        shell: cmd
+        run: |
+          python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}
+
+      - name: Configure AWS Credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
+
+      - name: Upload wheels to S3 staging
+        if: ${{ github.repository_owner == 'ROCm' }}
+        # Using 'cmd' here since PACKAGE_DIST_DIR uses \ in paths instead of /
+        shell: cmd
+        run: |
+          aws s3 cp ${{ env.PACKAGE_DIST_DIR }}/ ^
+            s3://${{ env.S3_BUCKET_PY }}/${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}/ ^
+            --recursive --exclude "*" --include "*.whl"
+
+      - name: (Re-)Generate Python package release index for staging
+        if: ${{ github.repository_owner == 'ROCm' }}
+        shell: cmd
+        run: |
+          pip install boto3 packaging
+          python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}
+
+  generate_target_to_run:
+    name: Generate target_to_run
+    runs-on: ubuntu-24.04
+    outputs:
+      test_runs_on: ${{ steps.configure.outputs.test-runs-on }}
+      bypass_tests_for_releases: ${{ steps.configure.outputs.bypass_tests_for_releases }}
+    steps:
+      - name: Checking out repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Generating target to run
+        id: configure
+        env:
+          TARGET: ${{ inputs.amdgpu_family }}
+          PLATFORM: "windows"
+        run: python ./build_tools/github_actions/configure_target_run.py
+
+  test_pytorch_wheels:
+    name: Test | ${{ inputs.amdgpu_family }} | ${{ needs.generate_target_to_run.outputs.test_runs_on }}
+    if: ${{ needs.generate_target_to_run.outputs.test_runs_on != '' }}
+    needs: [build_pytorch_wheels, generate_target_to_run]
+    uses: ./.github/workflows/test_pytorch_wheels.yml
+    with:
+      amdgpu_family: ${{ inputs.amdgpu_family }}
+      test_runs_on: ${{ needs.generate_target_to_run.outputs.test_runs_on }}
+      cloudfront_url: ${{ inputs.cloudfront_url }}
+      python_version: ${{ inputs.python_version }}
+      torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}
+
+  upload_pytorch_wheels:
+    name: Release PyTorch Wheels to S3
+    needs: [build_pytorch_wheels, generate_target_to_run, test_pytorch_wheels]
+    if: always()
+    runs-on: ubuntu-24.04
+    env:
+      S3_BUCKET_PY: "therock-${{ inputs.release_type }}-python"
+      CP_VERSION: "${{ needs.build_pytorch_wheels.outputs.cp_version }}"
+      TORCH_VERSION: "${{ needs.build_pytorch_wheels.outputs.torch_version }}"
+      TORCHAUDIO_VERSION: "${{ needs.build_pytorch_wheels.outputs.torchaudio_version }}"
+      TORCHVISION_VERSION: "${{ needs.build_pytorch_wheels.outputs.torchvision_version }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Configure AWS Credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
+
+      - name: Determine upload flag
+        env:
+          BUILD_RESULT: ${{ needs.build_pytorch_wheels.result }}
+          TEST_RESULT: ${{ needs.test_pytorch_wheels.result }}
+          TEST_RUNS_ON: ${{ needs.generate_target_to_run.outputs.test_runs_on }}
+          BYPASS_TESTS_FOR_RELEASES: ${{ needs.generate_target_to_run.outputs.bypass_tests_for_releases }}
+        run: python ./build_tools/github_actions/promote_wheels_based_on_policy.py
+
+      - name: Copy PyTorch wheels from staging to release S3
+        if: ${{ env.upload == 'true' }}
+        run: |
+          echo "Copying exact tested wheels to release S3 bucket..."
+          aws s3 cp \
+            s3://${S3_BUCKET_PY}/${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}/ \
+            s3://${S3_BUCKET_PY}/${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}/ \
+            --recursive \
+            --exclude "*" \
+            --include "torch-${TORCH_VERSION}-${CP_VERSION}-win_amd64.whl" \
+            --include "torchaudio-${TORCHAUDIO_VERSION}-${CP_VERSION}-win_amd64.whl" \
+            --include "torchvision-${TORCHVISION_VERSION}-${CP_VERSION}-win_amd64.whl"
+
+      - name: (Re-)Generate Python package release index
+        if: ${{ env.upload == 'true' }}
+        run: |
+          pip install boto3 packaging
+          python ./build_tools/third_party/s3_management/manage.py ${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}

--- a/external-builds/pytorch/repo_management.py
+++ b/external-builds/pytorch/repo_management.py
@@ -303,6 +303,24 @@ def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
     except subprocess.CalledProcessError:
         print("Failed to fetch git submodules")
         sys.exit(1)
+    # Delete directories which are the source of flaky pytorch
+    # checkouts on Windows and are not used during the build.
+    # See https://github.com/ROCm/TheRock/issues/1149.
+    exclude_paths = [
+        repo_dir
+        / "third_party"
+        / "onnx"
+        / "onnx"
+        / "backend"
+        / "test"
+        / "data"
+        / "node",
+        repo_dir / "third_party" / "opentelemetry-cpp" / "tools" / "vcpkg" / "ports",
+    ]
+    for exclude_path in exclude_paths:
+        if exclude_path.exists():
+            print(f"Removing excluded directory: {exclude_path}")
+            shutil.rmtree(exclude_path, ignore_errors=True)
     exec(
         [
             "git",


### PR DESCRIPTION
## Motivation
Progress on #1149 
Eliminate the `git commit` errors like below:
```
subprocess.CalledProcessError: Command '['git', 'commit', '-m', 'DO NOT SUBMIT: HIPIFY', '--no-gpg-sign']' returned non-zero exit status 1.
Error: Process completed with exit code 1.
```
## Technical Details

- Added check for staged changes using `git diff --cached --quiet` to skip commits when no changes are staged.
- Handled exit code 1 in `git commit` with a descriptive message instead of raising an exception.
- Refactored commit logic into `commit_hipify_module` for clarity and maintainability, addressing review feedback on control flow.
- Ensured consistent tagging with `tag_hipify_diffbase` even when commits are skipped.

## Test Plan
<!-- Explain any relevant testing done to verify this PR. -->
Run multiple `build_windows_pytorch_wheels` workflow instances and detect missing folder warnings like:

`2025-09-11T17:16:57.6642901Z warning: could not open directory 'onnx/backend/test/data/node/test_dequantizelinear_e4m3fn_float16/': No such file or directory`

And see how the solution is provided for the situation:
```
2025-09-11T17:17:37.8868758Z ++ Exec [B:\src\torch\third_party\onnx]$ git add -A
2025-09-11T17:17:37.8869024Z No staged changes in B:\src\torch\third_party\onnx after git add: Skipping commit
2025-09-11T17:17:37.8869346Z ++ Exec [B:\src\torch\third_party\onnx]$ git tag -f THEROCK_HIPIFY_DIFFBASE --no-sign
```

The test shows that we removed the errors like:
```
subprocess.CalledProcessError: Command '['git', 'commit', '-m', 'DO NOT SUBMIT: HIPIFY', '--no-gpg-sign']' returned non-zero exit status 1.
Error: Process completed with exit code 1.
```
The test link: https://github.com/ROCm/TheRock/actions/runs/17651604534/job/50163840102

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
