### PR TITLE
Use 12 vs 96 jobs for fetch_sources.py on windows

### DIFF
--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           git config --global core.symlinks true
           git config --global core.longpaths true
-          python ./build_tools/fetch_sources.py --jobs 96
+          python ./build_tools/fetch_sources.py --jobs 12
 
       - name: Configure Projects
         env:


### PR DESCRIPTION
## Motivation

Restore the original parameters from here https://github.com/ROCm/TheRock/pull/448#discussion_r2064867553 after @saienduri noticed the deviation from `build_linux_packages.yml` in a discussion about windows runner disconnects. 

## Technical Details

Restoring `--jobs 96` to `--jobs 12` in `build_windows_packages.yml` as there is a possibility that runner disconnects could be caused from over utilization of the runner node.  Though it is possible that there was an Azure network connectivity outage as local builds were exhibiting an issue where checkouts would fail and interactively block on credential input.

## Test Plan

Will watch CI.

## Test Result

TBD

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
