### PR TITLE
Disable MIOpen tests on Windows while they crash clang.

### DIFF
--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -92,6 +92,13 @@ if(THEROCK_ENABLE_MIOPEN)
     else()
       message(WARNING "Unhandled MSVC_VERSION '${MSVC_VERSION}', Boost may not configure correctly")
     endif()
+
+    # TODO(#1407): re-enable MIOpen tests on Windows when they don't crash clang on CI builders
+    #   We also don't run MIOpen tests on Windows, see
+    #   build_tools/github_actions/fetch_test_configurations.py
+    set(_THEROCK_MIOPEN_ENABLE_TESTING OFF)
+  else()
+    set(_THEROCK_MIOPEN_ENABLE_TESTING ${THEROCK_BUILD_TESTING})
   endif()
 
   therock_cmake_subproject_declare(MIOpen
@@ -102,10 +109,9 @@ if(THEROCK_ENABLE_MIOPEN)
       -DHIP_PLATFORM=amd
       -DROCM_PATH=
       -DROCM_DIR=
-      "-DBUILD_TESTING=${THEROCK_BUILD_TESTING}"
+      "-DBUILD_TESTING=${_THEROCK_MIOPEN_ENABLE_TESTING}"
       "-DMIOPEN_USE_COMPOSABLEKERNEL=${THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL}"
       -DMIOPEN_USE_MLIR=OFF # TODO: enable
-      -DMIOPEN_BUILD_DRIVER=ON
       -DMIOPEN_TEST_DISCRETE=OFF
       -DBoost_COMPILER=${_THEROCK_MIOPEN_OVERRIDE_BOOST_COMPILER}
     CMAKE_INCLUDES


### PR DESCRIPTION
## Motivation

Workaround for https://github.com/ROCm/TheRock/issues/1407. Related to https://github.com/ROCm/TheRock/issues/709.

## Technical Details

This builds on https://github.com/ROCm/TheRock/pull/1431.

## Test Plan

See if the CI build and tests complete.

## Test Result

Builds continue to pass now:
* gfx110X-dgpu: https://github.com/ROCm/TheRock/actions/runs/17659964574/job/50191276990?pr=1466
* gfx1151: https://github.com/ROCm/TheRock/actions/runs/17659964574/job/50191276960?pr=1466

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
