### PR TITLE
Use cloudfront_staging_url for Windows pytorch testing workflow.

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -253,7 +253,6 @@ jobs:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
 
-
       - name: Determine upload flag
         env:
           BUILD_RESULT: ${{ needs.build_pytorch_wheels.result }}

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -219,7 +219,7 @@ jobs:
     with:
       amdgpu_family: ${{ inputs.amdgpu_family }}
       test_runs_on: ${{ needs.generate_target_to_run.outputs.test_runs_on }}
-      cloudfront_url: ${{ inputs.cloudfront_url }}
+      cloudfront_url: ${{ inputs.cloudfront_staging_url }}
       python_version: ${{ inputs.python_version }}
       torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}
 


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/ROCm/TheRock/pull/1110 and https://github.com/ROCm/TheRock/pull/1382. Progress on https://github.com/ROCm/TheRock/issues/1072.

This test run https://github.com/ROCm/TheRock/actions/runs/17662170140/job/50199734639#step:6:37 failed with
```
 ++ Exec [C:\runner\_work\TheRock\TheRock]$ 'C:\runner\_work\TheRock\TheRock\.venv\Scripts\python.exe' -m pip install --index-url=https://d25kgig7rdsyks.cloudfront.net/v2/gfx1151 torch==2.10.0a0+rocm7.0.0rc20250908
Looking in indexes: https://d25kgig7rdsyks.cloudfront.net/v2/gfx1151
ERROR: Could not find a version that satisfies the requirement torch==2.10.0a0+rocm7.0.0rc20250908 (from versions: 2.7.0a0+rocm7.0.0.dev0.661b3907cf184e33f44256c24b88fc28a9251ec4, 2.7.0a0+rocm7.0.0.dev0.98ed4ad77f79822694ec01a36180ec3b95f4bd00, 2.7.0a0+rocm7.0.0.dev0.dea79b8f65819d046c7ec00a2b3ccdf5e98fbe5a, 2.7.0a0+rocm7.0.0.dev0.e0d25c8e8ca28b56c8155902c8f04e1767de4394, 2.7.0a0+rocm7.0.0.dev0.e96d36b9b628476463ef6cecee752f601052a4d2, 2.9.0a0+rocm7.0.0rc20250804, 2.9.0a0+rocmsdk20250819, 2.9.0a0+rocmsdk20250820, 2.9.0a0+rocmsdk20250821, 2.9.0a0+rocmsdk20250825)
ERROR: No matching distribution found for torch==2.10.0a0+rocm7.0.0rc20250908
```

## Technical Details

The build job only uploaded to v2-staging, so the test job should download from v2-staging, not v2.

* https://d25kgig7rdsyks.cloudfront.net/v2-staging/gfx1151/torch/ uploaded to 
* https://d25kgig7rdsyks.cloudfront.net/v2/gfx1151/torch/ attempted to download from 

The change here was made on Linux but was overlooked during the porting to Windows: https://github.com/ROCm/TheRock/blob/eb05061cb055b8626ec2e083e4eb87e90bd79f02/.github/workflows/build_portable_linux_pytorch_wheels.yml#L219-L227

The https://github.com/ROCm/TheRock/actions/runs/17585233778 test run mentioned at https://github.com/ROCm/TheRock/pull/1382#issuecomment-3271255812 did not run any tests and did not exercise this code because we only have gfx1151 runners and that used gfx110X-dgpu.

Those are easy mistakes to make. We could
1. Rename the `cloudfront_url` input to carry more meaning about what it represents, like `package_index_url` or `staging_package_index_url`
2. Bring up runners for more GPUs or change the default workflow_dispatch GPU type to one we have test runners for

## Test Plan

Untested.

## Test Result

Nope.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
