### PR TITLE
[ci] Adding extended timeout and retries for TheRock CI tests

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -32,7 +32,7 @@ test_matrix = {
     "rocblas": {
         "job_name": "rocblas",
         "fetch_artifact_args": "--blas --tests",
-        "timeout_minutes": 5,
+        "timeout_minutes": 15,
         "test_script": f"python {_get_script_path('test_rocblas.py')}",
         "platform": ["linux", "windows"],
     },

--- a/build_tools/github_actions/test_executable_scripts/test_rocprim.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprim.py
@@ -24,7 +24,7 @@ cmd = [
     "--timeout",
     "900",
     "--repeat",
-    "until-pass:3",
+    "until-pass:6",
 ]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocrand.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocrand.py
@@ -19,6 +19,8 @@ cmd = [
     "8",
     "--timeout",
     "900",
+    "--repeat",
+    "until-pass:3",
 ]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
@@ -22,7 +22,7 @@ cmd = [
     "--timeout",
     "300",
     "--repeat",
-    "until-pass:3",
+    "until-pass:6",
 ]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 


### PR DESCRIPTION
Noticing a lot of flaky issues, specifically:

- rocRAND - flaky tests ([failure](https://github.com/ROCm/TheRock/actions/runs/17662479646/job/50201478842) / [re-run pass](https://github.com/ROCm/TheRock/actions/runs/17662479646/job/50247256994))
- rocPRIM - more retries as flaky tests ([failure](https://github.com/ROCm/TheRock/actions/runs/17659035233/job/50194745218) / [re-run pass](https://github.com/ROCm/TheRock/actions/runs/17659035233/job/50245007309))
- rocthrust - more retries as flaky tests ([failure](https://github.com/ROCm/TheRock/actions/runs/17660152338/job/50196227321) / [re-run pass](https://github.com/ROCm/TheRock/actions/runs/17660152338/job/50245074481))
- rocblas - extending timeout (noticed [one instance of timeout](https://github.com/ROCm/TheRock/actions/runs/17659479425/job/50196172479)

Next PR:
- increased speed for gtest tests (will solve a lot of timeout issues and less time on CI machines)