### PR TITLE
Fix issue link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Further flags allow to build components with specific features enabled.
 
 > [!NOTE]
 > Building components with MPI support, currently requires MPI to be
-> pre-installed until [issue #128](https://github.com/ROCm/TheRock/issues/128)
+> pre-installed until [issue #1284](https://github.com/ROCm/TheRock/issues/1284)
 > is resolved.
 
 ### CMake build usage


### PR DESCRIPTION
https://github.com/ROCm/TheRock/pull/1283 probably meant to link to https://github.com/ROCm/TheRock/issues/1284 instead of 128