### PR TITLE
Reworks pkg-config handling so that it is based on CMAKE_PREFIX_PATH.

### DIFF
--- a/patches/amd-mainline/llvm-project/0001-Enable-MSVC-support-in-comgr.patch
+++ b/patches/amd-mainline/llvm-project/0001-Enable-MSVC-support-in-comgr.patch
@@ -1,7 +1,7 @@
-From bcdc455a08df8527e8946eb33fee714c28e30836 Mon Sep 17 00:00:00 2001
+From 3b4c18a7f9c6deaebebb957edf171fb65f462c72 Mon Sep 17 00:00:00 2001
 From: Scott <scott.todd0@gmail.com>
 Date: Fri, 14 Feb 2025 15:22:48 -0800
-Subject: [PATCH 1/5] Enable MSVC support in comgr.
+Subject: [PATCH 1/8] Enable MSVC support in comgr.
 
 ---
  amd/comgr/CMakeLists.txt | 7 ++++++-
@@ -26,5 +26,5 @@ index 2eeb8c2ac6ac..8b16fb9377e1 100644
  endif()
  
 -- 
-2.47.1.windows.2
+2.48.1
 

--- a/patches/amd-mainline/llvm-project/0002-hipcc-fix-default-include-path-on-Windows-and-adapt-.patch
+++ b/patches/amd-mainline/llvm-project/0002-hipcc-fix-default-include-path-on-Windows-and-adapt-.patch
@@ -1,7 +1,7 @@
-From d70e7d2166d478ead5d9bd3f6e4b1408190ea666 Mon Sep 17 00:00:00 2001
+From f2b6842a134c57526bb2a304d2f85c473be3c957 Mon Sep 17 00:00:00 2001
 From: Scott Tsai <scottt.tw@gmail.com>
 Date: Tue, 15 Apr 2025 09:30:13 +0800
-Subject: [PATCH 2/5] hipcc: fix default include path on Windows and adapt to
+Subject: [PATCH 2/8] hipcc: fix default include path on Windows and adapt to
  TheRock rocm layout
 
 getCppConfig in the orignial code did not add the content of
@@ -120,5 +120,5 @@ index ecea39e071b4..c74b43ff598f 100644
  
    if (!compileOnly) {
 -- 
-2.47.1.windows.2
+2.48.1
 

--- a/patches/amd-mainline/llvm-project/0003-HACK-Handle-ROCM-installation-layout-of-lib-llvm-bin.patch
+++ b/patches/amd-mainline/llvm-project/0003-HACK-Handle-ROCM-installation-layout-of-lib-llvm-bin.patch
@@ -1,7 +1,7 @@
-From 7dab0ed787cbde9d4aaaf99e24b7f33efda8f2a5 Mon Sep 17 00:00:00 2001
+From 926d3aec2cb96b615f70e29c7c8ea3a99c97d136 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Thu, 13 Feb 2025 17:58:53 -0800
-Subject: [PATCH 3/5] HACK: Handle ROCM installation layout of
+Subject: [PATCH 3/8] HACK: Handle ROCM installation layout of
  lib/llvm/bin/clang++.
 
 ---
@@ -32,5 +32,5 @@ index 798ea8aad6de..c45f07a6e285 100644
      // and it seems ParentDir is already pointing to correct place.
      return Candidate(ParentDir.str(), /*StrictChecking=*/true);
 -- 
-2.47.1.windows.2
+2.48.1
 

--- a/patches/amd-mainline/llvm-project/0004-Disable-hipcc-passing-hip-device-libs.patch
+++ b/patches/amd-mainline/llvm-project/0004-Disable-hipcc-passing-hip-device-libs.patch
@@ -1,7 +1,7 @@
-From 0dd361bc6ae2e9ab9e19b9eeed808d719e58ad71 Mon Sep 17 00:00:00 2001
+From 0c49dff21a4552035f38d9eaa5100fa024707678 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Thu, 13 Feb 2025 19:07:07 -0800
-Subject: [PATCH 4/5] Disable hipcc passing hip-device-libs.
+Subject: [PATCH 4/8] Disable hipcc passing hip-device-libs.
 
 In modern times, the clang driver is far more knowledgable about this stuff and can operate without instruction.
 ---
@@ -39,5 +39,5 @@ index c74b43ff598f..cb70026f6abf 100644
    // to avoid using dk linker or MSVC linker
    if (isWindows()) {
 -- 
-2.47.1.windows.2
+2.48.1
 

--- a/patches/amd-mainline/llvm-project/0005-Ensure-to-use-libamdhip64-with-major-version.patch
+++ b/patches/amd-mainline/llvm-project/0005-Ensure-to-use-libamdhip64-with-major-version.patch
@@ -1,7 +1,7 @@
-From 86c6b4964766089d13137fff660f545f25ee5bb7 Mon Sep 17 00:00:00 2001
+From 9045d0fce9eff0fc910a623a14b43e8000ad2bb6 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Tue, 5 Aug 2025 21:41:09 +0000
-Subject: [PATCH] Ensure to use libamdhip64 with major version
+Subject: [PATCH 5/8] Ensure to use libamdhip64 with major version
 
 ---
  clang/lib/Driver/ToolChains/Linux.cpp       | 2 +-
@@ -44,5 +44,5 @@ index 0ae4cbe34e93..db7b8a4f86eb 100644
  }
  
 -- 
-2.43.0
+2.48.1
 

--- a/patches/amd-mainline/llvm-project/0006-Rework-constructHipPath-so-HIP_PATH-env-var-is-lower.patch
+++ b/patches/amd-mainline/llvm-project/0006-Rework-constructHipPath-so-HIP_PATH-env-var-is-lower.patch
@@ -1,7 +1,7 @@
-From cac004dd1df8e7db1bac39859aca6c2a271e906c Mon Sep 17 00:00:00 2001
+From 767cd4083eaacf7a6da1f8ca62966766767cfd41 Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Tue, 5 Aug 2025 12:40:12 -0700
-Subject: [PATCH 5/5] Rework constructHipPath so HIP_PATH env var is lower
+Subject: [PATCH 6/8] Rework constructHipPath so HIP_PATH env var is lower
  priority.
 
 ---
@@ -53,5 +53,5 @@ index ea37e6fd12fc..4aa7431fdba6 100644
  
  
 -- 
-2.47.1.windows.2
+2.48.1
 

--- a/patches/amd-mainline/llvm-project/0007-Policy-CMP0053-is-no-longer-supported-by-CMake-4-151.patch
+++ b/patches/amd-mainline/llvm-project/0007-Policy-CMP0053-is-no-longer-supported-by-CMake-4-151.patch
@@ -1,8 +1,8 @@
-From f54a4a6a4e8ecbac6a491f0decf9883df0642666 Mon Sep 17 00:00:00 2001
+From fcdc0aecbad584c21f089e2b27432383250bf673 Mon Sep 17 00:00:00 2001
 From: "Tian, Shilei" <Shilei.Tian@amd.com>
 Date: Mon, 14 Apr 2025 15:02:17 -0400
-Subject: [PATCH] [DeviceLibs][CMake] Policy `CMP0053` is no longer supported
- by CMake 4+ (#1519)
+Subject: [PATCH 7/8] Policy `CMP0053` is no longer supported by CMake 4+
+ (#1519)
 
 The part of the code needs to be refined; otherwise we will have
 multiple breaks
@@ -28,5 +28,5 @@ index 4f16d8cd81d7..1dabde51b8c0 100644
  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.20.0")
    # The policy change was for handling of relative paths for
 -- 
-2.43.0
+2.48.1
 

--- a/patches/amd-mainline/llvm-project/0008-offload-Tunnel-CMAKE_PREFIX_PATH-with-proper-escapin.patch
+++ b/patches/amd-mainline/llvm-project/0008-offload-Tunnel-CMAKE_PREFIX_PATH-with-proper-escapin.patch
@@ -1,0 +1,50 @@
+From a70031a9f55a11d1912816ffe7f51ce3fb2e4706 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Fri, 12 Sep 2025 16:55:57 -0700
+Subject: [PATCH 8/8] [offload] Tunnel CMAKE_PREFIX_PATH with proper escaping.
+
+Prior to this patch, if CMAKE_PREFIX_PATH contained precisely zero or one entries, behavior would work as expected. However, with more than one, the extra cmake args would be emitted with literal semicolons, expanding to multiple command line arguments vs a single list as expected.
+
+This normalizes the CMAKE_PREFIX_PATH to use the $<SEMICOLON> generator and generalizes the case where one of the branches was setting it twice on the command line.
+---
+ llvm/runtimes/CMakeLists.txt | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/llvm/runtimes/CMakeLists.txt b/llvm/runtimes/CMakeLists.txt
+index f070cd767f2e..6baffc04e5a9 100644
+--- a/llvm/runtimes/CMakeLists.txt
++++ b/llvm/runtimes/CMakeLists.txt
+@@ -494,10 +494,18 @@ if(build_runtimes)
+   endif()
+ 
+   # Forward user-provived system configuration to runtimes for requirement introspection.
+-  # CMAKE_PREFIX_PATH is the search path for CMake packages.
++  # CMAKE_PREFIX_PATH is the search path for CMake packages. In order to pass through
++  # the command line interface, the CMake semicolon separator needs to be replaced
++  # with $<SEMICOLON>
+   if(CMAKE_PREFIX_PATH)
+-    list(APPEND extra_cmake_args "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}")
++    string(JOIN "$<SEMICOLON>" escaped_cmake_prefix_path ${CMAKE_PREFIX_PATH})
++    # Some projects require access to the LLVM lib/cmake directory
++    if (OFFLOAD_EXTERNAL_PROJECT_UNIFIED_ROCR OR DEFINED LIBOMPTARGET_EXTERNAL_PROJECT_ROCM_DEVICE_LIBS_PATH)
++      string(PREPEND escaped_cmake_prefix_path "${CMAKE_BINARY_DIR}/lib/cmake$<SEMICOLON>")
++    endif()
++    list(APPEND extra_cmake_args "-DCMAKE_PREFIX_PATH=${escaped_cmake_prefix_path}")
+   endif()
++
+   # CMAKE_PROGRAM_PATH is the search path for executables such as python.
+   if(CMAKE_PROGRAM_PATH)
+     list(APPEND extra_cmake_args "-DCMAKE_PROGRAM_PATH=${CMAKE_PROGRAM_PATH}")
+@@ -506,9 +514,6 @@ if(build_runtimes)
+   if("offload" IN_LIST LLVM_ENABLE_RUNTIMES)
+     # With ROCm 6.3 the ROCr runtime and the thunk layer share a single repository.
+     # No need to provide a separate path for ROCt.
+-    if (OFFLOAD_EXTERNAL_PROJECT_UNIFIED_ROCR OR DEFINED LIBOMPTARGET_EXTERNAL_PROJECT_ROCM_DEVICE_LIBS_PATH)
+-      list(APPEND extra_cmake_args "-DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/lib/cmake$<SEMICOLON>${CMAKE_PREFIX_PATH}")
+-    endif()
+     if (OFFLOAD_EXTERNAL_PROJECT_UNIFIED_ROCR)
+       if(NOT DEFINED LIBOMPTARGET_EXTERNAL_PROJECT_HSA_PATH)
+         message(SEND_ERROR "External ROCr requires setting LIBOMPTARGET_EXTERNAL_PROJECT_HSA_PATH")
+-- 
+2.48.1
+


### PR DESCRIPTION
Previously, we were manually setting the PKG_CONFIG_PATH environment variable at configure time, but this cannot be reliably propagated to sub-configures that are invoked at build time (as is done for the LLVM runtimes).

This patch switches to adding these prefixes to the CMAKE_PREFIX_PATH, which is the standard way of chaining between top-level and nested configure invocations. It requires a bit of path munging since the CMake pkg-config macros expect to get a prefix, not the fully nested path to the files (which is what the env var expects).

Also inlines a patch to LLVM which fixes an escaping bug for tunneling CMAKE_PREFIX_PATH when it contains more than one entry. I will upstream this to LLVM next week.

Fixes #1481
