### PR TITLE
Turn off generation of libdrm man pages

### DIFF
--- a/third-party/sysdeps/linux/libdrm/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libdrm/CMakeLists.txt
@@ -81,6 +81,7 @@ add_custom_target(
         # Only enable the libraries we want.
         -Damdgpu=enabled
         -Dintel=disabled
+        -Dman-pages=disabled
         -Dnouveau=disabled
         -Dradeon=disabled
         -Dvmwgfx=disabled


### PR DESCRIPTION

## Motivation

cmake build was failing because `libdrm` man pages requires `docutils` for generation, but we don't include `docutils` in our `requirements.txt`.

```
[therock-libdrm] ModuleNotFoundError: No module named 'docutils'
[therock-libdrm] ninja: build stopped: subcommand failed.
ninja: build stopped: subcommand failed.
```
Since we don't include these man pages in TheRock distribution anyway, it's best to disable their creation in the first place.

## Technical Details

Update `CMakeLists.txt` for `libdrm` to disable generation of man pages.

## Test Plan

Verify cmake builds successfully.

## Test Result

It builds successfully

## Submission Checklist

- [ X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
