### PR TITLE
Patch "Initialize CMAKE_Fortran_COMPILER for hipblaslt".

### DIFF
--- a/patches/amd-mainline/rocm-libraries/0001-Work-around-race-condition.patch
+++ b/patches/amd-mainline/rocm-libraries/0001-Work-around-race-condition.patch
@@ -1,7 +1,7 @@
-From de507351b531aeefbb1db6d4988e128df6f9f686 Mon Sep 17 00:00:00 2001
+From f4040e8e880da0bcf996df8a9a16209538256fb9 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Mon, 31 Mar 2025 22:24:41 +0000
-Subject: [PATCH 01/17] Work around race condition
+Subject: [PATCH 01/11] Work around race condition
 
 With `add_dependency`, compiling the `hipsolver_fortran_client` target
 fails as `hipsolver.mod` is not created in time for the first build
@@ -25,5 +25,5 @@ index d715fd236a..2590d8535a 100644
      include_directories(${CMAKE_BINARY_DIR}/include/hipsolver/internal)
      target_compile_definitions(hipsolver_fortran_client INTERFACE HAVE_HIPSOLVER_FORTRAN_CLIENT)
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocm-libraries/0002-Workaround-CK-include-issue-for-unit-tests-in-TheRoc.patch
+++ b/patches/amd-mainline/rocm-libraries/0002-Workaround-CK-include-issue-for-unit-tests-in-TheRoc.patch
@@ -1,8 +1,8 @@
-From c42a9bd55f3db752f08767999edcf1d36ec9c64c Mon Sep 17 00:00:00 2001
+From f178bbe0e8c44ca948cad3b42be20c8dec2f340b Mon Sep 17 00:00:00 2001
 From: Jonathan Lichtner
  <195780826+JonathanLichtnerAMD@users.noreply.github.com>
 Date: Thu, 3 Jul 2025 21:00:13 +0000
-Subject: [PATCH 04/17] Workaround CK include issue for unit tests in TheRock
+Subject: [PATCH 02/11] Workaround CK include issue for unit tests in TheRock
 
 The test unit_implicitgemm_ck_util.cpp includes from CK, but this
 currently fails.  Skip this test as a temporary workaround.
@@ -11,7 +11,7 @@ currently fails.  Skip this test as a temporary workaround.
  1 file changed, 4 insertions(+)
 
 diff --git a/projects/miopen/test/gtest/CMakeLists.txt b/projects/miopen/test/gtest/CMakeLists.txt
-index 1ceaf69547..4d5f87c9cd 100644
+index 45b6d99859..5c3c58ff1a 100644
 --- a/projects/miopen/test/gtest/CMakeLists.txt
 +++ b/projects/miopen/test/gtest/CMakeLists.txt
 @@ -22,6 +22,10 @@ if(MIOPEN_BACKEND_OPENCL)
@@ -26,5 +26,5 @@ index 1ceaf69547..4d5f87c9cd 100644
      set (TMP_FILTER ${MIOPEN_GTEST_FILTER_NEGATIVE})
  
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocm-libraries/0003-Find-rocm_smi-via-config-files.patch
+++ b/patches/amd-mainline/rocm-libraries/0003-Find-rocm_smi-via-config-files.patch
@@ -1,7 +1,7 @@
-From 66e663065ffbb12beb725bbeb39c76d169c68bf6 Mon Sep 17 00:00:00 2001
+From 368062f5a23460955ef62ebd6d169d11cbffa331 Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Wed, 12 Mar 2025 14:26:45 +0000
-Subject: [PATCH 06/17] Find `rocm_smi` via config files
+Subject: [PATCH 03/11] Find `rocm_smi` via config files
 
 Use the config files provided by upstream instead of a custom finder.
 ---
@@ -11,10 +11,10 @@ Use the config files provided by upstream instead of a custom finder.
  delete mode 100644 projects/rocblas/clients/cmake/FindROCmSMI.cmake
 
 diff --git a/projects/rocblas/clients/CMakeLists.txt b/projects/rocblas/clients/CMakeLists.txt
-index 3abff7ffa7..16ccedd3da 100644
+index b9e1dc4816..0f326755a0 100644
 --- a/projects/rocblas/clients/CMakeLists.txt
 +++ b/projects/rocblas/clients/CMakeLists.txt
-@@ -212,8 +212,8 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
+@@ -210,8 +210,8 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
  
    # Find the package ROCmSMI
    if(NOT WIN32)
@@ -83,5 +83,5 @@ index 698f6884a6..0000000000
 -    IMPORTED_LOCATION "${ROCM_SMI_LIBRARY}"
 -    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${ROCM_SMI_ROOT}/include")
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocm-libraries/0004-Enable-hipblaslt-on-windows-and-for-static-builds.patch
+++ b/patches/amd-mainline/rocm-libraries/0004-Enable-hipblaslt-on-windows-and-for-static-builds.patch
@@ -1,7 +1,7 @@
-From fb18b9b2552839bbc36ea13b64630fb05395984c Mon Sep 17 00:00:00 2001
+From d2c3112da79b5f6883f90e0f9473309c30084241 Mon Sep 17 00:00:00 2001
 From: David Dixon <david.dixon@amd.com>
 Date: Thu, 11 Sep 2025 11:01:02 +0000
-Subject: [PATCH] Enable hipblaslt on windows and for static builds
+Subject: [PATCH 04/11] Enable hipblaslt on windows and for static builds
 
 Co-authored-by: Marius Brehler <marius.brehler@amd.com>
 ---
@@ -11,10 +11,10 @@ Co-authored-by: Marius Brehler <marius.brehler@amd.com>
  3 files changed, 6 insertions(+), 16 deletions(-)
 
 diff --git a/projects/rocblas/CMakeLists.txt b/projects/rocblas/CMakeLists.txt
-index 1ce9ca9e71..6c55a57e5e 100644
+index ab8e3f7454..8fb7ceeb48 100644
 --- a/projects/rocblas/CMakeLists.txt
 +++ b/projects/rocblas/CMakeLists.txt
-@@ -148,7 +148,7 @@ option( BUILD_WITH_HIPBLASLT "Build with HipBLASLt" ON )
+@@ -152,7 +152,7 @@ option( BUILD_WITH_HIPBLASLT "Build with HipBLASLt" ON )
  set( hipblaslt_path "/opt/rocm" CACHE PATH "Use local HipBLASLt directory" )
  set( HIPBLASLT_VERSION 1.0.0 CACHE STRING "The version of HipBLASLt to be used" )
  
@@ -71,5 +71,5 @@ index f4bdfb5f97..12df4f47f3 100644
  
    if( NOT BUILD_SHARED_LIBS )
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocm-libraries/0005-Replace-python-with-official-Python3_EXECUTABLE-vari.patch
+++ b/patches/amd-mainline/rocm-libraries/0005-Replace-python-with-official-Python3_EXECUTABLE-vari.patch
@@ -1,7 +1,7 @@
-From 8fa19ea1bfee62c44d14dac3c63315fa46bf52b2 Mon Sep 17 00:00:00 2001
+From 87b42462157e425d949e209f6d35cc58c694f4b2 Mon Sep 17 00:00:00 2001
 From: Scott <scott.todd0@gmail.com>
 Date: Wed, 30 Apr 2025 12:03:23 -0700
-Subject: [PATCH 14/17] Replace ${python} with official ${Python3_EXECUTABLE}
+Subject: [PATCH 05/11] Replace ${python} with official ${Python3_EXECUTABLE}
  variable.
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 14/17] Replace ${python} with official ${Python3_EXECUTABLE}
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/projects/hipblas/clients/gtest/CMakeLists.txt b/projects/hipblas/clients/gtest/CMakeLists.txt
-index 8341d7f42a..c6fc0a0157 100644
+index 315f8026c3..6c70f62a0b 100644
 --- a/projects/hipblas/clients/gtest/CMakeLists.txt
 +++ b/projects/hipblas/clients/gtest/CMakeLists.txt
 @@ -239,7 +239,7 @@ if( BUILD_WITH_SOLVER )
@@ -22,5 +22,5 @@ index 8341d7f42a..c6fc0a0157 100644
                      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
  
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocm-libraries/0006-Setup-Fortran-on-Windows.patch
+++ b/patches/amd-mainline/rocm-libraries/0006-Setup-Fortran-on-Windows.patch
@@ -1,14 +1,14 @@
-From a7e8c062e1c8828b2fce7c44e5243e03e6920ba6 Mon Sep 17 00:00:00 2001
+From 6d850c017899813d985d8e2038a8d6237078af28 Mon Sep 17 00:00:00 2001
 From: Scott <scott.todd0@gmail.com>
 Date: Thu, 1 May 2025 11:29:42 -0700
-Subject: [PATCH 15/17] Setup Fortran on Windows.
+Subject: [PATCH 06/11] Setup Fortran on Windows.
 
 ---
  projects/hipblas/CMakeLists.txt | 11 +++++------
  1 file changed, 5 insertions(+), 6 deletions(-)
 
 diff --git a/projects/hipblas/CMakeLists.txt b/projects/hipblas/CMakeLists.txt
-index 56ec2fd5b4..58f33dda67 100644
+index 383785e257..6b3d0b02a0 100644
 --- a/projects/hipblas/CMakeLists.txt
 +++ b/projects/hipblas/CMakeLists.txt
 @@ -42,12 +42,11 @@ if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
@@ -30,5 +30,5 @@ index 56ec2fd5b4..58f33dda67 100644
  project( hipblas LANGUAGES CXX ${fortran_language} )
  
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocm-libraries/0007-Remove-Windows-third_party_dlls-copying-code.patch
+++ b/patches/amd-mainline/rocm-libraries/0007-Remove-Windows-third_party_dlls-copying-code.patch
@@ -1,7 +1,7 @@
-From 352a8172c9216efe2c54b13accf7501065683c5f Mon Sep 17 00:00:00 2001
+From 09d779ac280f5e2db5459f97a464f34f8c5ab3f2 Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Tue, 3 Jun 2025 13:07:11 +0000
-Subject: [PATCH 17/17] Remove Windows third_party_dlls copying code.
+Subject: [PATCH 07/11] Remove Windows third_party_dlls copying code.
 
 This code is built on shaky assumptions that don't hold inside TheRock.
 We'll need a better solution that works across projects.
@@ -10,7 +10,7 @@ We'll need a better solution that works across projects.
  1 file changed, 27 insertions(+), 26 deletions(-)
 
 diff --git a/projects/hipblas/clients/gtest/CMakeLists.txt b/projects/hipblas/clients/gtest/CMakeLists.txt
-index c6fc0a0157..3fc1a04209 100644
+index 6c70f62a0b..97684d19c3 100644
 --- a/projects/hipblas/clients/gtest/CMakeLists.txt
 +++ b/projects/hipblas/clients/gtest/CMakeLists.txt
 @@ -173,32 +173,33 @@ else( )
@@ -74,5 +74,5 @@ index c6fc0a0157..3fc1a04209 100644
  set_target_properties( hipblas-test PROPERTIES
      CXX_STANDARD 17
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocm-libraries/0008-Revert-remove-options-no-enumerate-966.patch
+++ b/patches/amd-mainline/rocm-libraries/0008-Revert-remove-options-no-enumerate-966.patch
@@ -1,7 +1,7 @@
-From 48a727e5a62546131e94cf90d1ce5e9607c5bf92 Mon Sep 17 00:00:00 2001
+From 09c7ea7e00de961ce35653b5dd4924904990f7ac Mon Sep 17 00:00:00 2001
 From: Marius Brehler <marius.brehler@amd.com>
 Date: Wed, 6 Aug 2025 16:08:22 +0000
-Subject: [PATCH 18/18] Revert "remove options --no-enumerate (#966)"
+Subject: [PATCH 08/11] Revert "remove options --no-enumerate (#966)"
 
 This reverts commit 68a380c7dd5498a744d5d63892d7431a5aa31367.
 
@@ -11,7 +11,7 @@ This breaks building rocBLAS on Windows.
  1 file changed, 3 insertions(+)
 
 diff --git a/shared/tensile/Tensile/cmake/TensileConfig.cmake b/shared/tensile/Tensile/cmake/TensileConfig.cmake
-index c9c1084d35..f905935fc1 100644
+index 62682d74ec..794eb10cc2 100644
 --- a/shared/tensile/Tensile/cmake/TensileConfig.cmake
 +++ b/shared/tensile/Tensile/cmake/TensileConfig.cmake
 @@ -215,6 +215,9 @@ function(TensileCreateLibraryFiles
@@ -25,5 +25,5 @@ index c9c1084d35..f905935fc1 100644
    if (WIN32 OR (VIRTUALENV_BIN_DIR AND VIRTUALENV_PYTHON_EXENAME))
      set(CommandLine ${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} ${CommandLine})
 -- 
-2.43.0
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocm-libraries/0009-Use-workgroupMappingDim-in-rocroller_host.patch
+++ b/patches/amd-mainline/rocm-libraries/0009-Use-workgroupMappingDim-in-rocroller_host.patch
@@ -1,7 +1,7 @@
-From 6187c53459567244256d102882dc417ac24c739a Mon Sep 17 00:00:00 2001
+From 02348e224b5e7a0023178ffbc5811f6153566072 Mon Sep 17 00:00:00 2001
 From: David Dixon <david.dixon@amd.com>
 Date: Wed, 20 Aug 2025 20:59:07 +0000
-Subject: [PATCH 17/17] Use workgroupMappingDim in rocroller_host
+Subject: [PATCH 09/11] Use workgroupMappingDim in rocroller_host
 
 The api for command solution changed so
 use the workgroupMappingDim rather than workgroupMapping
@@ -10,10 +10,10 @@ use the workgroupMappingDim rather than workgroupMapping
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
-index c505f9122d..d724d600e7 100644
+index cd4741a5a6..e1f2785c3e 100644
 --- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
 +++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
-@@ -1369,7 +1369,7 @@ std::shared_ptr<GemmKernel> genGemmKernel(std::shared_ptr<SolutionParameters> ge
+@@ -1377,7 +1377,7 @@ std::shared_ptr<GemmKernel> genGemmKernel(std::shared_ptr<SolutionParameters> ge
              "Only 0 (M) or 1 (N) are supported dimensions for workgroup mapping.",
              ShowValue(dim));
  
@@ -23,5 +23,5 @@ index c505f9122d..d724d600e7 100644
  
      if(gemm->workgroupRemapXCC)
 -- 
-2.25.1
+2.47.1.windows.2
 

--- a/patches/amd-mainline/rocm-libraries/0010-Run-gentest.py-with-python-on-Windows-across-_parse_.patch
+++ b/patches/amd-mainline/rocm-libraries/0010-Run-gentest.py-with-python-on-Windows-across-_parse_.patch
@@ -1,7 +1,7 @@
-From 4d57c0ccfd87ca370a948bceed04299a0a772ac1 Mon Sep 17 00:00:00 2001
+From 74bd593aca84c33978a73981fb97a054ede7d405 Mon Sep 17 00:00:00 2001
 From: Scott Todd <scott.todd0@gmail.com>
 Date: Wed, 3 Sep 2025 13:06:42 -0700
-Subject: [PATCH 23/23] Run gentest.py with 'python' on Windows across
+Subject: [PATCH 10/11] Run gentest.py with 'python' on Windows across
  `_parse_data.cpp` files.
 
 ---

--- a/patches/amd-mainline/rocm-libraries/0011-Initialize-CMAKE_Fortran_COMPILER-for-hipblaslt.patch
+++ b/patches/amd-mainline/rocm-libraries/0011-Initialize-CMAKE_Fortran_COMPILER-for-hipblaslt.patch
@@ -1,0 +1,32 @@
+From 4c9f299e3a5a0cc8e36bb9460ab80d9f59c1bf66 Mon Sep 17 00:00:00 2001
+From: Scott Todd <scott.todd0@gmail.com>
+Date: Tue, 16 Sep 2025 10:56:37 -0700
+Subject: [PATCH 11/11] Initialize CMAKE_Fortran_COMPILER for hipblaslt
+
+---
+ projects/hipblaslt/CMakeLists.txt | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/projects/hipblaslt/CMakeLists.txt b/projects/hipblaslt/CMakeLists.txt
+index 708a46d390..021aada5d8 100644
+--- a/projects/hipblaslt/CMakeLists.txt
++++ b/projects/hipblaslt/CMakeLists.txt
+@@ -114,10 +114,15 @@ else()
+ endif()
+ 
+ if(HIPBLASLT_ENABLE_CLIENT)
++    if (NOT DEFINED CMAKE_Fortran_COMPILER AND NOT DEFINED ENV{FC})
++        set(CMAKE_Fortran_COMPILER  "gfortran")
++    endif()
+     enable_language(Fortran)
++
+     if(HIPBLASLT_ENABLE_BLIS)
+         find_package(BLIS REQUIRED)
+     endif()
++
+     # There is an implicit find_package(BLAS) when finding lapack
+     find_package(LAPACK REQUIRED)
+ endif()
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
Patch sent to rocm-libraries as https://github.com/ROCm/rocm-libraries/pull/1608

This fixes build errors reported at https://github.com/ROCm/TheRock/pull/1473#discussion_r2353219606 (just for hipblaslt on Windows, there are remaining build failures after that on Windows and Linux).

https://github.com/ROCm/TheRock/actions/runs/17772815018/job/50513105179?pr=1473#step:12:350
```
[hipBLASLt configure] -- The Fortran compiler identification is unknown
[hipBLASLt configure] -- Detecting Fortran compiler ABI info
[hipBLASLt configure] CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
[hipBLASLt configure] Missing variable is:
[hipBLASLt configure] CMAKE_Fortran_PREPROCESS_SOURCE
[hipBLASLt configure] CMake Error at C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeDetermineCompilerABI.cmake:74 (try_compile):
[hipBLASLt configure]   Failed to generate test project build system.
[hipBLASLt configure] Call Stack (most recent call first):
[hipBLASLt configure]   C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeTestFortranCompiler.cmake:20 (CMAKE_DETERMINE_COMPILER_ABI)
[hipBLASLt configure]   CMakeLists.txt:117 (enable_language)
[hipBLASLt configure] 
[hipBLASLt configure] 
[hipBLASLt configure] -- Configuring incomplete, errors occurred!
```