### PR TITLE
Incorpoate dvc usage with MIOpen pre-compiled kernels

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -77,6 +77,10 @@ jobs:
           git config --global --add safe.directory $PWD
           git config fetch.parallel 10
 
+      - uses: iterative/setup-dvc@4bdfd2b0f6f1ad7e08afadb03b1a895c352a5239 # v2.0.0
+        with:
+          version: '3.62.0'
+
       - name: Fetch sources
         timeout-minutes: 30
         run: |

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -141,6 +141,10 @@ jobs:
       - name: Install the AWS tool
         run: ./dockerfiles/install_awscli.sh
 
+      - uses: iterative/setup-dvc@4bdfd2b0f6f1ad7e08afadb03b1a895c352a5239 # v2.0.0
+        with:
+          version: '3.62.0'
+
       - name: Fetch sources
         timeout-minutes: 30
         run: |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ instructions and configurations for alternatives.
 
 ### Setup - Ubuntu (24.04)
 
+> [!TIP]
+> `dvc` is used for version control of pre-compiled MIOpen kernels.
+> `dvc` is not a hard requirement, but it does reduce compile time.
+> `snap install --classic dvc` can be used to install on Ubuntu.
+> Visit the [DVC website](https://dvc.org/doc/install/linux) for other installation methods.
+
 ```bash
 # Install Ubuntu dependencies
 sudo apt update

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -95,10 +95,15 @@ def pull_large_files(dvc_projects, projects):
     if not dvc_projects:
         print("No DVC projects specified, skipping large file pull.")
         return
-    if shutil.which("dvc") is None:
-        print("Could not find `dvc` on PATH so large files could not be fetched")
-        print("Visit https://dvc.org/doc/install for installation instructions.")
-        sys.exit(1)
+    dvc_missing = shutil.which("dvc") is None
+    if dvc_missing:
+        if is_windows():
+            print("Could not find `dvc` on PATH so large files could not be fetched")
+            print("Visit https://dvc.org/doc/install for installation instructions.")
+            sys.exit(1)
+        else:
+            print("`dvc` not found, skipping large file pull on non-Windows.")
+            return
     for project in dvc_projects:
         if not project in projects:
             continue
@@ -106,14 +111,10 @@ def pull_large_files(dvc_projects, projects):
         project_dir = THEROCK_DIR / submodule_path
         dvc_config_file = project_dir / ".dvc" / "config"
         if dvc_config_file.exists():
-            # check for DVC config in the submodule and run dvc pull if found.
-            # presently, only amdgpu-windows-interop in rocm-systems uses DVC, but...
-            # eventually, DVC will be rolled out to math libraries and in linux
             print(f"dvc detected in {project_dir}, running dvc pull")
             exec(["dvc", "pull"], cwd=project_dir)
         else:
             log(f"WARNING: dvc config not found in {project_dir}, when expected.")
-            continue
 
 
 def remove_smrev_files(args, projects):
@@ -401,10 +402,13 @@ def main(argv):
         type=str,
         default=(
             [
+                "rocm-libraries",
                 "rocm-systems",
             ]
             if is_windows()
-            else []
+            else [
+                "rocm-libraries",
+            ]
         ),
     )
     args = parser.parse_args(argv)


### PR DESCRIPTION
## Motivation

- Follow-up to ROCm/rocm-libraries#1594

## Technical Details

- `dvc` is not a hard requirement on Linux, but it does save on overhead.
- pre-compiled kernels is preferred for release jobs, so adding `dvc` to CI workflows.
- This PR can be merged into TheRock independently of the rocm-libraries submodule being updated.

## Test Plan

- Standard CI/CD workflows

## Test Result

- TBD

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
