### PR TITLE
Disable building torch with MPI

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -569,6 +569,7 @@ def do_build_pytorch(
     )
     env["USE_ROCM"] = "ON"
     env["USE_CUDA"] = "OFF"
+    env["USE_MPI"] = "OFF"
     env["PYTORCH_BUILD_VERSION"] = pytorch_build_version
     env["PYTORCH_BUILD_NUMBER"] = args.pytorch_build_number
 


### PR DESCRIPTION
Disables to build torch wheels with Message Passing Interface support. With our newer Docker images having Open MPI pre-installed, `find_package(MPI)` will pick up MPI and add a dependency but we don't bundle this. Users reported this to let `import torch` fail. To avoid this, `USE_MPI` must be explicitly set to `OFF`.