### PR TITLE
Added the appropriate type to the argument torch-dir

### DIFF
--- a/external-builds/pytorch/pytorch_triton_repo.py
+++ b/external-builds/pytorch/pytorch_triton_repo.py
@@ -97,6 +97,7 @@ def main(cl_args: list[str]):
     checkout_p.add_argument(
         "--torch-dir",
         default=THIS_DIR / "pytorch",
+        type=Path,
         help="Directory of the torch checkout",
     )
     checkout_p.add_argument(

--- a/external-builds/pytorch/pytorch_triton_repo.py
+++ b/external-builds/pytorch/pytorch_triton_repo.py
@@ -96,8 +96,8 @@ def main(cl_args: list[str]):
     add_common(checkout_p)
     checkout_p.add_argument(
         "--torch-dir",
-        default=THIS_DIR / "pytorch",
         type=Path,
+        default=THIS_DIR / "pytorch",
         help="Directory of the torch checkout",
     )
     checkout_p.add_argument(


### PR DESCRIPTION
## Motivation

Running the script in a manner that requires the passing of --torch-dir caused a crash due to the argument type not being set to `Path`

Before:
```bash
(.venv) umarinkovic@computer/TheRock/external-builds/pytorch$ python pytorch_triton_repo.py checkout --torch-dir /madeup/path
Traceback (most recent call last):
  File "/workspace/umarinkovic/dev/TheRock/external-builds/pytorch/pytorch_triton_repo.py", line 140, in <module>
    main(sys.argv[1:])
  File "/workspace/umarinkovic/dev/TheRock/external-builds/pytorch/pytorch_triton_repo.py", line 136, in main
    args.func(args)
  File "/workspace/umarinkovic/dev/TheRock/external-builds/pytorch/pytorch_triton_repo.py", line 34, in do_checkout
    if not torch_dir.exists():
           ^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'exists'
```

After:
```bash
(.venv) umarinkovic@computer/workspace/umarinkovic/dev/TheRock/external-builds/pytorch$ python pytorch_triton_repo.py checkout --torch-dir /madeup/dir
Traceback (most recent call last):
  File "/workspace/umarinkovic/dev/TheRock/external-builds/pytorch/pytorch_triton_repo.py", line 141, in <module>
    main(sys.argv[1:])
  File "/workspace/umarinkovic/dev/TheRock/external-builds/pytorch/pytorch_triton_repo.py", line 137, in main
    args.func(args)
  File "/workspace/umarinkovic/dev/TheRock/external-builds/pytorch/pytorch_triton_repo.py", line 35, in do_checkout
    raise ValueError(
ValueError: Could not find torch dir: /madeup/dir (did you check out torch first)
```
