### PR TITLE
Bump CMake version to 3.27 in manylinux image to match PyTorch's

### DIFF
--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -31,7 +31,7 @@ RUN ./install_ccache.sh "4.11.2" && rm -rf /install-ccache
 
 ######## CMake ########
 WORKDIR /install-cmake
-ENV CMAKE_VERSION="3.25.2"
+ENV CMAKE_VERSION="3.27.9"
 COPY install_cmake.sh ./
 RUN ./install_cmake.sh "${CMAKE_VERSION}" && rm -rf /install-cmake
 


### PR DESCRIPTION
Bumping the CMake version of the manylinux image used by the CI to match PyTorch's minimum CMake version 3.27. This is required since commit: https://github.com/pytorch/pytorch/commit/c2beeadeb40e927c51bc5bcd409b3f28374a5190

The change is a requirement when building PyTorch nightly wheels.

This should be considered to be the new default policy for our CMake progression for the manylinux image to match the PyTorch CMake progression (if it is higher than ours).


