### PR TITLE
Set SG_STAGING_SUBDIR in Windows release workflow.

### DIFF
--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -56,6 +56,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       S3_SUBDIR: ${{ inputs.s3_subdir || 'v2' }}
+      S3_STAGING_SUBDIR: ${{ inputs.s3_staging_subdir || 'v2-staging' }}
       release_type: ${{ inputs.release_type || 'nightly' }}
     outputs:
       version: ${{ steps.release_information.outputs.version }}


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/1072. More follow-up to https://github.com/ROCm/TheRock/pull/1382 for missed plumbing due to workflows being copy/pasted instead of reusing the same scripts.

This workflow run failed: https://github.com/ROCm/TheRock/actions/runs/17788093970/job/50562946451#step:6:35, since it was looking outside of the staging subdirectory:
```
++ Exec [C:\runner\_work\TheRock\TheRock]$ 'C:\runner\_work\TheRock\TheRock\.venv\Scripts\python.exe' -m pip install --index-url=https://rocm.nightlies.amd.com/gfx1151 torch==2.10.0a0+rocm7.0.0rc20250917
Looking in indexes: https://rocm.nightlies.amd.com/gfx1151
ERROR: Could not find a version that satisfies the requirement torch==2.10.0a0+rocm7.0.0rc20250917 (from versions: none)
```

The workflow that triggered it had this variable unset, so it appended empty string to the base URL: https://github.com/ROCm/TheRock/actions/runs/17786272473/job/50554458282#step:6:5
```
  echo "cloudfront_url=${cloudfront_base_url}/v2" >> $GITHUB_OUTPUT
  echo "cloudfront_staging_url=${cloudfront_base_url}/" >> $GITHUB_OUTPUT
```

Untested.