### PR TITLE
Update Dockerfile to build OpenMPI 5.0.8 for RCCL and rccl-tests

### DIFF
--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -67,8 +67,7 @@ RUN yum install -y epel-release && \
       gcc-toolset-12-libstdc++-devel \
       patchelf \
       vim-common \
-      git-lfs && \
-      # OMPI build deps
+      git-lfs \
       wget \
       m4 \
       flex \


### PR DESCRIPTION
Summary
###############

This PR replaces the vcpkg-based OpenMPI build (limited to v4.1.7) with OpenMPI v5.0.8, required for 32-node RCCL multi-node tests and for building rccl-tests.

Changes
###############

Updated the Dockerfile to build OpenMPI v5.0.8 from source on the manylinux container.

Added required system packages for the new build.

Ensured RCCL and RCCL-tests are built against OpenMPI 5.0.8.

Impact
###############

Enables 32-node and 64-node RCCL testing with OpenMPI v5.0.8.

Keeps RCCL and RCCL-tests aligned to the same MPI version.

Removes reliance on vcpkg for MPI builds beyond v4.1.7.