### PR TITLE
Update manylinux image to use cmake 3.27

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -39,7 +39,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:543ba2609de3571d2c64f3872e5f1af42fdfa90d074a7baccb1db120c9514be2
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:9d3b77fc375d26dfcbecbeb435d9b9681728e301f434f1e2bbd9789bd004a993
       options: -v /runner/config:/home/awsconfig/
     env:
       AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -98,7 +98,7 @@ jobs:
     name: Build | ${{ inputs.amdgpu_family }} | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_version }}
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:543ba2609de3571d2c64f3872e5f1af42fdfa90d074a7baccb1db120c9514be2
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:9d3b77fc375d26dfcbecbeb435d9b9681728e301f434f1e2bbd9789bd004a993
     env:
       OUTPUT_DIR: ${{ github.workspace }}/output
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -113,7 +113,7 @@ jobs:
     env:
       TEATIME_LABEL_GH_GROUP: 1
       OUTPUT_DIR: ${{ github.workspace }}/output
-      BUILD_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:543ba2609de3571d2c64f3872e5f1af42fdfa90d074a7baccb1db120c9514be2
+      BUILD_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:9d3b77fc375d26dfcbecbeb435d9b9681728e301f434f1e2bbd9789bd004a993
       DIST_ARCHIVE: "${{ github.workspace }}/output/therock-dist-linux-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
       FILE_NAME: "therock-dist-linux-${{ matrix.target_bundle.amdgpu_family }}${{ inputs.package_suffix }}-${{ needs.setup_metadata.outputs.version }}.tar.gz"
       RELEASE_TYPE: "${{ needs.setup_metadata.outputs.release_type }}"

--- a/build_tools/linux_portable_build.py
+++ b/build_tools/linux_portable_build.py
@@ -128,7 +128,7 @@ def main(argv: list[str]):
     p.add_argument("--docker", default="docker", help="Docker or podman binary")
     p.add_argument(
         "--image",
-        default="ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:543ba2609de3571d2c64f3872e5f1af42fdfa90d074a7baccb1db120c9514be2",
+        default="ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:9d3b77fc375d26dfcbecbeb435d9b9681728e301f434f1e2bbd9789bd004a993",
         help="Build docker image",
     )
     p.add_argument(

--- a/docs/environment_setup_guide.md
+++ b/docs/environment_setup_guide.md
@@ -58,7 +58,7 @@ Based on upstream: AlmaLinux 8 with gcc toolset 12
 
 While this generally implies that the project should build on similarly versioned alternative EL distributions, do note that we install several upgraded tools (see dockerfile above) in our standard CI pipelines.
 
-Reference image: `ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:543ba2609de3571d2c64f3872e5f1af42fdfa90d074a7baccb1db120c9514be2`
+Reference image: `ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:9d3b77fc375d26dfcbecbeb435d9b9681728e301f434f1e2bbd9789bd004a993`
 
 ### Ubuntu 22.04
 


### PR DESCRIPTION
With this the manylinux image is now using the minimum required cmake version 3.27 for PyTorch (nightlies).
