### PR TITLE
[torch][windows] Copy libomp140.x86_64.dll to torch/lib.

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -553,6 +553,46 @@ def do_build_triton(
     return f"{triton_wheel_name}=={installed_triton_version}"
 
 
+def copy_msvc_libomp_to_torch_lib(pytorch_dir: Path):
+    # When USE_OPENMP is set (it is by default), torch_cpu.dll depends on OpenMP.
+    #
+    # Typically implementations of OpenMP are:
+    #   * Intel OpenMP, `libiomp`, which PyTorch upstream uses
+    #   * MSVC OpenMP, `libomp140`, which we'll use here since we have MSVC already
+    #   * (?) LLVM OpenMP (https://openmp.llvm.org/)?
+    #
+    # Torch's CMake build selects which OpenMP to use in `FindOpenMP.cmake`,
+    # then the relevant .dll files must be copied into the torch/lib/ folder or
+    # torch will fail to initialize. This feels like something that could be
+    # handled upstream as part of the centralized setup.py and/or CMake build
+    # processes, but given the varied scripts and build workflows upstream and
+    # multiple choices for where to source an implementation, we handle it here.
+    #
+    # If we wanted to switch to Intel OpenMP, we could:
+    #   1. Install Intel OpenMP (and MKL?)
+    #   2. Set CMAKE_INCLUDE_PATH and CMAKE_LIBRARY_PATH (?) so `FindOpenMP.cmake` finds them
+    #   3. Copy `libiomp5md.dll` to torch/lib
+    # Then remove the rest of the code from this function.
+
+    vc_tools_redist_dir = os.environ.get("VCToolsRedistDir", "")
+    if not vc_tools_redist_dir:
+        print("Warning: VCToolsRedistDir not set, can't copy libomp to torch lib")
+        return
+
+    omp_name = "libomp140.x86_64.dll"
+    dll_paths = sorted(Path(vc_tools_redist_dir).rglob(omp_name))
+    if not dll_paths:
+        print(
+            f"Warning: did not find '{omp_name}' under '{vc_tools_redist_dir}', can't copy libomp to torch lib"
+        )
+        return
+
+    omp_path = dll_paths[0]
+    target_lib = pytorch_dir / "torch" / "lib"
+    print(f"Copying libomp from '{omp_path}' to '{target_lib}'")
+    shutil.copy2(omp_path, target_lib)
+
+
 def do_build_pytorch(
     args: argparse.Namespace,
     pytorch_dir: Path,
@@ -585,8 +625,10 @@ def do_build_pytorch(
     # Add the _rocm_init.py file.
     (pytorch_dir / "torch" / "_rocm_init.py").write_text(get_rocm_init_contents(args))
 
-    # Windows-specific options.
+    # Windows-specific settings.
     if is_windows:
+        copy_msvc_libomp_to_torch_lib(pytorch_dir)
+
         use_flash_attention = (
             "1" if args.enable_pytorch_flash_attention_windows else "0"
         )

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -569,23 +569,21 @@ def copy_msvc_libomp_to_torch_lib(pytorch_dir: Path):
     # multiple choices for where to source an implementation, we handle it here.
     #
     # If we wanted to switch to Intel OpenMP, we could:
-    #   1. Install Intel OpenMP (and MKL?)
+    #   1. Install Intel OpenMP (and/or MKL?)
     #   2. Set CMAKE_INCLUDE_PATH and CMAKE_LIBRARY_PATH (?) so `FindOpenMP.cmake` finds them
     #   3. Copy `libiomp5md.dll` to torch/lib
     # Then remove the rest of the code from this function.
 
     vc_tools_redist_dir = os.environ.get("VCToolsRedistDir", "")
     if not vc_tools_redist_dir:
-        print("Warning: VCToolsRedistDir not set, can't copy libomp to torch lib")
-        return
+        raise RuntimeError("VCToolsRedistDir not set, can't copy libomp to torch lib")
 
     omp_name = "libomp140.x86_64.dll"
     dll_paths = sorted(Path(vc_tools_redist_dir).rglob(omp_name))
     if not dll_paths:
-        print(
-            f"Warning: did not find '{omp_name}' under '{vc_tools_redist_dir}', can't copy libomp to torch lib"
+        raise RuntimeError(
+            f"Did not find '{omp_name}' under '{vc_tools_redist_dir}', can't copy libomp to torch lib"
         )
-        return
 
     omp_path = dll_paths[0]
     target_lib = pytorch_dir / "torch" / "lib"


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/1309, where `import torch` would require `libomp140.x86_64.dll` from an install of Visual Studio.

## Technical Details

See the comments and the linked issue.

This seems to solve the issue on a technical level. I'm wondering

1. Should we prefer Intel OpenMP over MSVC OpenMP? Installing and using it is more of a hassle
2. Should we disable OpenMP instead of go through this effort?
3. If we do bundle MSVC OpenMP, are there any licensing implications? Other random dlls get bundled too 🤔 

The implementation here was inspired by https://github.com/pytorch/pytorch/pull/158922, but I had more success using the `VCToolsRedistDir` environment variable set by the MSVC developer command prompt than using `vswhere`. The specific path that is found on my system is `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.42.34433\debug_nonredist\x64\Microsoft.VC143.OpenMP.LLVM\libomp140.x86_64.dll` (I think that `debug_nonredist` is fine, but it is a bit suspicious...)

## Test Plan

1. Built wheels locally
4. Watched logs showing the DLL file being copied
5. Noted the DLL appearing in the built wheels
6. Installed the built wheels
7. Renamed `C:\Windows\System32\libomp140.x86_64.dll` and ran `python -c "import torch; print(torch.cuda.is_available())"`. This succeeded where it previously failed.

This is brittle without an automated test. Maybe we should have test runners that don't have MSVC installed?