### PR TITLE
[CI] Always run post-job cleanup step if test fail

### DIFF
--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -134,6 +134,6 @@ jobs:
       # GitHub's 'Complete job' step is unaware of launched executables
       # and will fail to clean up orphan processes.
       - name: Post-job cleanup processes on Windows
-        if: ${{ runner.os == 'Windows' }}
+        if: ${{ always() && runner.os == 'Windows' }}
         shell: powershell
         run: . '${{ github.workspace }}\build_tools\github_actions\cleanup_processes.ps1'

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -90,6 +90,6 @@ jobs:
           pytest tests/ --log-cli-level=info --timeout=60
 
       - name: Post-job cleanup processes on Windows
-        if: ${{ runner.os == 'Windows' }}
+        if: ${{ always() && runner.os == 'Windows' }}
         shell: powershell
         run: . '${{ github.workspace }}\build_tools\github_actions\cleanup_processes.ps1'


### PR DESCRIPTION
Follow up to https://github.com/ROCm/TheRock/pull/1361


Noticed post job cleanup wasn't running after testing with intentional test workflow timeouts here:
https://github.com/ROCm/TheRock/pull/1518#issuecomment-3304071834

Fix is to add `always()` to post job step