### PR TITLE
Enable ninja `-k 0` to keep going through errors.

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -107,10 +107,7 @@ jobs:
           python3 build_tools/github_actions/build_configure.py
 
       - name: Build therock-dist
-        run: cmake --build build --target therock-dist
-
-      - name: Build therock-archives
-        run: cmake --build build --target therock-archives
+        run: cmake --build build --target therock-dist therock-archives -- -k 0
 
       - name: Test Packaging
         if: ${{ github.event.repository.name == 'TheRock' }}

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -139,10 +139,7 @@ jobs:
           python3 build_tools/github_actions/build_configure.py
 
       - name: Build therock-dist
-        run: cmake --build "${{ env.BUILD_DIR }}" --target therock-dist
-
-      - name: Build therock-archives
-        run: cmake --build "${{ env.BUILD_DIR }}" --target therock-archives
+        run: cmake --build "${{ env.BUILD_DIR }}" --target therock-dist therock-archives -- -k 0
 
       - name: Report
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Fixes #1497
