### PR TITLE
[ci] Adding gtest sharding

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -14,7 +14,7 @@ on:
         type: string
       component:
         type: string
-        
+
 
 permissions:
   contents: read

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -1,0 +1,87 @@
+name: Test component
+
+on:
+  workflow_call:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: ""
+      amdgpu_families:
+        type: string
+      test_runs_on:
+        type: string
+      platform:
+        type: string
+      component:
+        type: string
+        
+
+permissions:
+  contents: read
+
+jobs:
+  test_components:
+    name: 'Test ${{ fromJSON(inputs.component).job_name }} (shard ${{ matrix.shard }} / ${{ fromJSON(inputs.component).total_shards }})'
+    runs-on: ${{ inputs.test_runs_on }}
+    container:
+      image: ${{ inputs.platform == 'linux' && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98' || null }}
+      options: --ipc host
+        --group-add video
+        --device /dev/kfd
+        --device /dev/dri
+        --group-add 992
+        --env-file /etc/podinfo/gha-gpu-isolation-settings
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(inputs.component).shard_arr }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      VENV_DIR: ${{ github.workspace }}/.venv
+      ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
+      OUTPUT_ARTIFACTS_DIR: "./build"
+      THEROCK_BIN_DIR: "./build/bin"
+      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+    steps:
+      - name: "Fetch 'build_tools' from repository"
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout: build_tools
+          path: "prejob"
+
+      - name: Pre-job cleanup processes on Windows
+        if: ${{ runner.os == 'Windows' }}
+        shell: powershell
+        run: . '${{ github.workspace }}\prejob\build_tools\github_actions\cleanup_processes.ps1'
+
+      - name: Checkout Repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "ROCm/TheRock"
+
+      - name: Run setup test environment workflow
+        uses: './.github/actions/setup_test_environment'
+        with:
+          ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
+          AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+          OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
+          VENV_DIR: ${{ env.VENV_DIR }}
+          FETCH_ARTIFACT_ARGS: ${{ fromJSON(inputs.component).fetch_artifact_args }}
+          IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+
+      - name: Test
+        timeout-minutes: ${{ fromJSON(inputs.component).timeout_minutes }}
+        env:
+          SHARD_INDEX: ${{ matrix.shard }}
+          TOTAL_SHARDS: ${{ fromJSON(inputs.component).total_shards }}
+        run: |
+          ${{ fromJSON(inputs.component).test_script }}
+
+      # GitHub's 'Complete job' step is unaware of launched executables
+      # and will fail to clean up orphan processes.
+      - name: Post-job cleanup processes on Windows
+        if: ${{ always() && runner.os == 'Windows' }}
+        shell: powershell
+        run: . '${{ github.workspace }}\build_tools\github_actions\cleanup_processes.ps1'

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 jobs:
-  test_components:
+  test_component:
     name: 'Test ${{ fromJSON(inputs.component).job_name }} (shard ${{ matrix.shard }} / ${{ fromJSON(inputs.component).total_shards }})'
     runs-on: ${{ inputs.test_runs_on }}
     container:

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   test_component:
-    name: 'Test ${{ fromJSON(inputs.component).job_name }} (shard ${{ matrix.shard }} / ${{ fromJSON(inputs.component).total_shards }})'
+    name: 'Test ${{ fromJSON(inputs.component).job_name }} (shard ${{ matrix.shard }} - ${{ fromJSON(inputs.component).total_shards }})'
     runs-on: ${{ inputs.test_runs_on }}
     container:
       image: ${{ inputs.platform == 'linux' && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98' || null }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   test_component:
-    name: 'Test ${{ fromJSON(inputs.component).job_name }} (shard ${{ matrix.shard }} - ${{ fromJSON(inputs.component).total_shards }})'
+    name: 'Test ${{ fromJSON(inputs.component).job_name }} (shard ${{ matrix.shard }} of ${{ fromJSON(inputs.component).total_shards }})'
     runs-on: ${{ inputs.test_runs_on }}
     container:
       image: ${{ inputs.platform == 'linux' && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98' || null }}
@@ -34,6 +34,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # The shard array is based on "total_shards" from "fetch_test_configurations.py"
+        # The test executable will shard based on the array. (ex: [1, 2, 3, 4] = four test shards)
         shard: ${{ fromJSON(inputs.component).shard_arr }}
     defaults:
       run:

--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         components: ${{ fromJSON(needs.configure_test_matrix.outputs.components) }}
-        shards: ${{ fromJSON(needs.configure_test_matrix.outputs.components.shard_arr) }}
+        shards: ${{ fromJSON(needs.configure_test_matrix.outputs.components).shard_arr }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -73,6 +73,7 @@ jobs:
       platform: ${{ needs.configure_test_matrix.outputs.platform }}
 
   test_components:
+    name: 'Test ${{ matrix.components.job_name }}'
     needs: [test_sanity_check, configure_test_matrix]
     # skip tests if no test matrix to run
     if: ${{ needs.configure_test_matrix.outputs.components != '[]' }}

--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Test
         timeout-minutes: ${{ matrix.components.timeout_minutes }}
         env:
-          SHARD_INDEX: ${{ matrix.components.shards }}
+          SHARD_INDEX: ${{ matrix.shards }}
           TOTAL_SHARDS: ${{ matrix.components.total_shards }}
         run: |
           ${{ matrix.components.test_script }}

--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -73,16 +73,7 @@ jobs:
       platform: ${{ needs.configure_test_matrix.outputs.platform }}
 
   test_components:
-    name: 'Test ${{ matrix.components.job_name }} | shard ${{ matrix.shards }} / ${{ matrix.components.total_shards }}'
-    runs-on: ${{ inputs.test_runs_on }}
-    container:
-      image: ${{ needs.configure_test_matrix.outputs.platform == 'linux' && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98' || null }}
-      options: --ipc host
-        --group-add video
-        --device /dev/kfd
-        --device /dev/dri
-        --group-add 992
-        --env-file /etc/podinfo/gha-gpu-isolation-settings
+    name: 'Test ${{ matrix.components.job_name }}'
     needs: [test_sanity_check, configure_test_matrix]
     # skip tests if no test matrix to run
     if: ${{ needs.configure_test_matrix.outputs.components != '[]' }}
@@ -90,54 +81,10 @@ jobs:
       fail-fast: false
       matrix:
         components: ${{ fromJSON(needs.configure_test_matrix.outputs.components) }}
-        shards: ${{ fromJSON(needs.configure_test_matrix.outputs.shard_arr) }}
-    defaults:
-      run:
-        shell: bash
-    env:
-      VENV_DIR: ${{ github.workspace }}/.venv
-      ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
-      OUTPUT_ARTIFACTS_DIR: "./build"
-      THEROCK_BIN_DIR: "./build/bin"
-      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
-    steps:
-      - name: "Fetch 'build_tools' from repository"
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          sparse-checkout: build_tools
-          path: "prejob"
-
-      - name: Pre-job cleanup processes on Windows
-        if: ${{ runner.os == 'Windows' }}
-        shell: powershell
-        run: . '${{ github.workspace }}\prejob\build_tools\github_actions\cleanup_processes.ps1'
-
-      - name: Checkout Repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          repository: "ROCm/TheRock"
-
-      - name: Run setup test environment workflow
-        uses: './.github/actions/setup_test_environment'
-        with:
-          ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
-          AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
-          OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
-          VENV_DIR: ${{ env.VENV_DIR }}
-          FETCH_ARTIFACT_ARGS: ${{ matrix.components.fetch_artifact_args }}
-          IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
-
-      - name: Test
-        timeout-minutes: ${{ matrix.components.timeout_minutes }}
-        env:
-          SHARD_INDEX: ${{ matrix.shards }}
-          TOTAL_SHARDS: ${{ matrix.components.total_shards }}
-        run: |
-          ${{ matrix.components.test_script }}
-
-      # GitHub's 'Complete job' step is unaware of launched executables
-      # and will fail to clean up orphan processes.
-      - name: Post-job cleanup processes on Windows
-        if: ${{ always() && runner.os == 'Windows' }}
-        shell: powershell
-        run: . '${{ github.workspace }}\build_tools\github_actions\cleanup_processes.ps1'
+    uses: './.github/workflows/test_component.yml'
+    with:
+      artifact_run_id: ${{ inputs.artifact_run_id }}
+      amdgpu_families: ${{ inputs.amdgpu_families }}
+      test_runs_on: ${{ inputs.test_runs_on }}
+      platform: ${{ needs.configure_test_matrix.outputs.platform }}
+      component: ${{ toJSON(matrix.components) }}

--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -73,7 +73,6 @@ jobs:
       platform: ${{ needs.configure_test_matrix.outputs.platform }}
 
   test_components:
-    name: 'Test ${{ matrix.components.job_name }}'
     needs: [test_sanity_check, configure_test_matrix]
     # skip tests if no test matrix to run
     if: ${{ needs.configure_test_matrix.outputs.components != '[]' }}

--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -72,7 +72,7 @@ jobs:
       platform: ${{ needs.configure_test_matrix.outputs.platform }}
 
   test_components:
-    name: 'Test ${{ matrix.components.job_name }}'
+    name: 'Test ${{ matrix.components.job_name }} | shard ${{ matrix.shards }} / ${{ matrix.components.total_shards }}'
     runs-on: ${{ inputs.test_runs_on }}
     container:
       image: ${{ needs.configure_test_matrix.outputs.platform == 'linux' && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98' || null }}
@@ -89,6 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         components: ${{ fromJSON(needs.configure_test_matrix.outputs.components) }}
+        shards: ${{ fromJSON(needs.configure_test_matrix.outputs.components.shard_arr) }}
     defaults:
       run:
         shell: bash
@@ -97,7 +98,6 @@ jobs:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
       OUTPUT_ARTIFACTS_DIR: "./build"
       THEROCK_BIN_DIR: "./build/bin"
-      PLATFORM: ${{ inputs.platform }}
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
     steps:
       - name: "Fetch 'build_tools' from repository"
@@ -128,6 +128,9 @@ jobs:
 
       - name: Test
         timeout-minutes: ${{ matrix.components.timeout_minutes }}
+        env:
+          SHARD_INDEX: ${{ matrix.components.shards }}
+          TOTAL_SHARDS: ${{ matrix.components.total_shards }}
         run: |
           ${{ matrix.components.test_script }}
 

--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -35,6 +35,7 @@ jobs:
     outputs:
       components: ${{ steps.configure.outputs.components }}
       platform: ${{ steps.configure.outputs.platform }}
+      shard_arr: ${{ steps.configure.outputs.shard_arr }}
     steps:
       - name: "Fetch 'build_tools' from repository"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -89,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         components: ${{ fromJSON(needs.configure_test_matrix.outputs.components) }}
-        shards: ${{ fromJSON(needs.configure_test_matrix.outputs.components).shard_arr }}
+        shards: ${{ fromJSON(needs.configure_test_matrix.outputs.shard_arr) }}
     defaults:
       run:
         shell: bash

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -35,7 +35,7 @@ test_matrix = {
         "timeout_minutes": 15,
         "test_script": f"python {_get_script_path('test_rocblas.py')}",
         "platform": ["linux", "windows"],
-        "total_shards": 1
+        "total_shards": 1,
     },
     "hipblaslt": {
         "job_name": "hipblaslt",
@@ -43,7 +43,7 @@ test_matrix = {
         "timeout_minutes": 60,
         "test_script": f"python {_get_script_path('test_hipblaslt.py')}",
         "platform": ["linux", "windows"],
-        "total_shards": 4
+        "total_shards": 4,
     },
     # PRIM tests
     "rocprim": {
@@ -52,7 +52,7 @@ test_matrix = {
         "timeout_minutes": 60,
         "test_script": f"python {_get_script_path('test_rocprim.py')}",
         "platform": ["linux", "windows"],
-        "total_shards": 1
+        "total_shards": 1,
     },
     "hipcub": {
         "job_name": "hipcub",
@@ -60,7 +60,7 @@ test_matrix = {
         "timeout_minutes": 15,
         "test_script": f"python {_get_script_path('test_hipcub.py')}",
         "platform": ["linux", "windows"],
-        "total_shards": 1
+        "total_shards": 1,
     },
     "rocthrust": {
         "job_name": "rocthrust",
@@ -68,7 +68,7 @@ test_matrix = {
         "timeout_minutes": 15,
         "test_script": f"python {_get_script_path('test_rocthrust.py')}",
         "platform": ["linux"],
-        "total_shards": 1
+        "total_shards": 1,
     },
     # SPARSE tests
     "hipsparse": {
@@ -77,7 +77,7 @@ test_matrix = {
         "timeout_minutes": 30,
         "test_script": f"python {_get_script_path('test_hipsparse.py')}",
         "platform": ["linux"],
-        "total_shards": 2
+        "total_shards": 2,
     },
     "rocsparse": {
         "job_name": "rocsparse",
@@ -85,7 +85,7 @@ test_matrix = {
         "timeout_minutes": 120,
         "test_script": f"python {_get_script_path('test_rocsparse.py')}",
         "platform": ["linux", "windows"],
-        "total_shards": 6
+        "total_shards": 6,
     },
     # RAND tests
     "rocrand": {
@@ -94,7 +94,7 @@ test_matrix = {
         "timeout_minutes": 60,
         "test_script": f"python {_get_script_path('test_rocrand.py')}",
         "platform": ["linux", "windows"],
-        "total_shards": 1
+        "total_shards": 1,
     },
     "hiprand": {
         "job_name": "hiprand",
@@ -102,7 +102,7 @@ test_matrix = {
         "timeout_minutes": 5,
         "test_script": f"python {_get_script_path('test_hiprand.py')}",
         "platform": ["linux", "windows"],
-        "total_shards": 1
+        "total_shards": 1,
     },
     # MIOpen tests
     "miopen": {
@@ -111,7 +111,7 @@ test_matrix = {
         "timeout_minutes": 120,
         "test_script": f"python {_get_script_path('test_miopen.py')}",
         "platform": ["linux"],
-        "total_shards": 4
+        "total_shards": 4,
     },
     # RCCL tests
     "rccl": {
@@ -120,7 +120,7 @@ test_matrix = {
         "timeout_minutes": 15,
         "test_script": f"pytest {_get_script_path('test_rccl.py')} -v -s --log-cli-level=info",
         "platform": ["linux"],
-        "total_shards": 1
+        "total_shards": 1,
     },
 }
 
@@ -142,13 +142,17 @@ def run():
             job_config_data = test_matrix[key]
             # For the GitHub Action matrix, we construct array of gtest shards
             # For display purposes, we add "i + 1". During the actual test sharding in `fetch_test_configurations.py`, this will become 0th index
-            job_config_data['shard_arr'] = [i + 1 for i in range(job_config_data["total_shards"])]
+            job_config_data["shard_arr"] = [
+                i + 1 for i in range(job_config_data["total_shards"])
+            ]
             output_matrix.append(job_config_data)
 
-    gha_set_output({
-        "components": json.dumps(output_matrix), 
-        "platform": platform,
-    })
+    gha_set_output(
+        {
+            "components": json.dumps(output_matrix),
+            "platform": platform,
+        }
+    )
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -140,8 +140,9 @@ def run():
             job_name = test_matrix[key]["job_name"]
             logging.info(f"Including job {job_name}")
             job_config_data = test_matrix[key]
-            # For the GitHub Action matrix, we construct array of gtest shards
-            # For display purposes, we add "i + 1". During the actual test sharding in `fetch_test_configurations.py`, this will become 0th index
+            # For CI testing, we construct a shard array based on "total_shards" from "fetch_test_configurations.py"
+            # This way, the test jobs will be split up into X shards. (ex: [1, 2, 3, 4] = 4 test shards)
+            # For display purposes, we add "i + 1" for the job name (ex: 1 of 4). During the actual test sharding in the test executable, this array will become 0th index
             job_config_data["shard_arr"] = [
                 i + 1 for i in range(job_config_data["total_shards"])
             ]

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -35,6 +35,7 @@ test_matrix = {
         "timeout_minutes": 15,
         "test_script": f"python {_get_script_path('test_rocblas.py')}",
         "platform": ["linux", "windows"],
+        "total_shards": 1
     },
     "hipblaslt": {
         "job_name": "hipblaslt",
@@ -42,6 +43,7 @@ test_matrix = {
         "timeout_minutes": 60,
         "test_script": f"python {_get_script_path('test_hipblaslt.py')}",
         "platform": ["linux", "windows"],
+        "total_shards": 4
     },
     # PRIM tests
     "rocprim": {
@@ -50,6 +52,7 @@ test_matrix = {
         "timeout_minutes": 60,
         "test_script": f"python {_get_script_path('test_rocprim.py')}",
         "platform": ["linux", "windows"],
+        "total_shards": 1
     },
     "hipcub": {
         "job_name": "hipcub",
@@ -57,6 +60,7 @@ test_matrix = {
         "timeout_minutes": 15,
         "test_script": f"python {_get_script_path('test_hipcub.py')}",
         "platform": ["linux", "windows"],
+        "total_shards": 1
     },
     "rocthrust": {
         "job_name": "rocthrust",
@@ -64,6 +68,7 @@ test_matrix = {
         "timeout_minutes": 15,
         "test_script": f"python {_get_script_path('test_rocthrust.py')}",
         "platform": ["linux"],
+        "total_shards": 1
     },
     # SPARSE tests
     "hipsparse": {
@@ -72,6 +77,7 @@ test_matrix = {
         "timeout_minutes": 30,
         "test_script": f"python {_get_script_path('test_hipsparse.py')}",
         "platform": ["linux"],
+        "total_shards": 2
     },
     "rocsparse": {
         "job_name": "rocsparse",
@@ -79,6 +85,7 @@ test_matrix = {
         "timeout_minutes": 120,
         "test_script": f"python {_get_script_path('test_rocsparse.py')}",
         "platform": ["linux", "windows"],
+        "total_shards": 6
     },
     # RAND tests
     "rocrand": {
@@ -87,6 +94,7 @@ test_matrix = {
         "timeout_minutes": 60,
         "test_script": f"python {_get_script_path('test_rocrand.py')}",
         "platform": ["linux", "windows"],
+        "total_shards": 1
     },
     "hiprand": {
         "job_name": "hiprand",
@@ -94,6 +102,7 @@ test_matrix = {
         "timeout_minutes": 5,
         "test_script": f"python {_get_script_path('test_hiprand.py')}",
         "platform": ["linux", "windows"],
+        "total_shards": 1
     },
     # MIOpen tests
     "miopen": {
@@ -102,6 +111,7 @@ test_matrix = {
         "timeout_minutes": 120,
         "test_script": f"python {_get_script_path('test_miopen.py')}",
         "platform": ["linux"],
+        "total_shards": 4
     },
     # RCCL tests
     "rccl": {
@@ -110,6 +120,7 @@ test_matrix = {
         "timeout_minutes": 15,
         "test_script": f"pytest {_get_script_path('test_rccl.py')} -v -s --log-cli-level=info",
         "platform": ["linux"],
+        "total_shards": 1
     },
 }
 
@@ -128,7 +139,11 @@ def run():
         ):
             job_name = test_matrix[key]["job_name"]
             logging.info(f"Including job {job_name}")
-            output_matrix.append(test_matrix[key])
+            job_config_data = test_matrix[key]
+            # For the GitHub Action matrix, we construct array of gtest shards
+            # For display purposes, we add "i + 1". During the actual test sharding in `fetch_test_configurations.py`, this will become 0th index
+            job_config_data["shard_arr"] = [i + 1 for i in range(job_config_data["total_shards"])]
+            output_matrix.append(job_config_data)
 
     gha_set_output({"components": json.dumps(output_matrix), "platform": platform})
 

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -132,7 +132,6 @@ def run():
     logging.info(f"Selecting projects: {project_to_test}")
 
     output_matrix = []
-    shard_arr_matrix = []
     for key in test_matrix:
         # If the test is enabled for a particular platform and a particular (or all) projects are selected
         if platform in test_matrix[key]["platform"] and (
@@ -143,13 +142,12 @@ def run():
             job_config_data = test_matrix[key]
             # For the GitHub Action matrix, we construct array of gtest shards
             # For display purposes, we add "i + 1". During the actual test sharding in `fetch_test_configurations.py`, this will become 0th index
-            shard_arr_matrix.append([i + 1 for i in range(job_config_data["total_shards"])])
+            job_config_data['shard_arr'] = [i + 1 for i in range(job_config_data["total_shards"])]
             output_matrix.append(job_config_data)
 
     gha_set_output({
         "components": json.dumps(output_matrix), 
         "platform": platform,
-        "shard_arr": json.dumps(shard_arr_matrix)
     })
 
 

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -132,6 +132,7 @@ def run():
     logging.info(f"Selecting projects: {project_to_test}")
 
     output_matrix = []
+    shard_arr_matrix = []
     for key in test_matrix:
         # If the test is enabled for a particular platform and a particular (or all) projects are selected
         if platform in test_matrix[key]["platform"] and (
@@ -142,10 +143,14 @@ def run():
             job_config_data = test_matrix[key]
             # For the GitHub Action matrix, we construct array of gtest shards
             # For display purposes, we add "i + 1". During the actual test sharding in `fetch_test_configurations.py`, this will become 0th index
-            job_config_data["shard_arr"] = [i + 1 for i in range(job_config_data["total_shards"])]
+            shard_arr_matrix.append([i + 1 for i in range(job_config_data["total_shards"])])
             output_matrix.append(job_config_data)
 
-    gha_set_output({"components": json.dumps(output_matrix), "platform": platform})
+    gha_set_output({
+        "components": json.dumps(output_matrix), 
+        "platform": platform,
+        "shard_arr": json.dumps(shard_arr_matrix)
+    })
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
@@ -11,6 +11,14 @@ THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 PLATFORM = os.getenv("PLATFORM")
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 
+# GTest sharding
+SHARD_INDEX = os.getenv("SHARD_INDEX")
+TOTAL_SHARDS = os.getenv("TOTAL_SHARDS")
+envion_vars = os.environ.copy()
+# For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
+envion_vars["GTEST_SHARD_INDEX"] = int(SHARD_INDEX) - 1
+envion_vars["GTEST_TOTAL_SHARDS"] = TOTAL_SHARDS
+
 logging.basicConfig(level=logging.INFO)
 
 cmd = [f"{THEROCK_BIN_DIR}/hipblaslt-test", "--gtest_filter=*pre_checkin*"]
@@ -28,9 +36,11 @@ if AMDGPU_FAMILIES in tests_to_exclude and PLATFORM in tests_to_exclude.get(
     exclusion_list = ":".join(tests_to_exclude[AMDGPU_FAMILIES][PLATFORM])
     cmd.append(f"--gtest_filter=-{exclusion_list}")
 
+
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 subprocess.run(
     cmd,
     cwd=THEROCK_DIR,
     check=True,
+    env=envion_vars
 )

--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
@@ -16,8 +16,8 @@ SHARD_INDEX = os.getenv("SHARD_INDEX")
 TOTAL_SHARDS = os.getenv("TOTAL_SHARDS")
 envion_vars = os.environ.copy()
 # For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
-envion_vars["GTEST_SHARD_INDEX"] = int(SHARD_INDEX) - 1
-envion_vars["GTEST_TOTAL_SHARDS"] = TOTAL_SHARDS
+envion_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
+envion_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 
 logging.basicConfig(level=logging.INFO)
 

--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
@@ -38,9 +38,4 @@ if AMDGPU_FAMILIES in tests_to_exclude and PLATFORM in tests_to_exclude.get(
 
 
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
-subprocess.run(
-    cmd,
-    cwd=THEROCK_DIR,
-    check=True,
-    env=envion_vars
-)
+subprocess.run(cmd, cwd=THEROCK_DIR, check=True, env=envion_vars)

--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
@@ -12,8 +12,8 @@ PLATFORM = os.getenv("PLATFORM")
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 
 # GTest sharding
-SHARD_INDEX = os.getenv("SHARD_INDEX")
-TOTAL_SHARDS = os.getenv("TOTAL_SHARDS")
+SHARD_INDEX = os.getenv("SHARD_INDEX", 1)
+TOTAL_SHARDS = os.getenv("TOTAL_SHARDS", 1)
 envion_vars = os.environ.copy()
 # For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
 envion_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)

--- a/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
@@ -10,8 +10,8 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
 # GTest sharding
-SHARD_INDEX = os.getenv("SHARD_INDEX")
-TOTAL_SHARDS = os.getenv("TOTAL_SHARDS")
+SHARD_INDEX = os.getenv("SHARD_INDEX", 1)
+TOTAL_SHARDS = os.getenv("TOTAL_SHARDS", 1)
 envion_vars = os.environ.copy()
 # For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
 envion_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)

--- a/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
@@ -9,7 +9,17 @@ OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+# GTest sharding
+SHARD_INDEX = os.getenv("SHARD_INDEX")
+TOTAL_SHARDS = os.getenv("TOTAL_SHARDS")
+envion_vars = os.environ.copy()
+# For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
+envion_vars["GTEST_SHARD_INDEX"] = int(SHARD_INDEX) - 1
+envion_vars["GTEST_TOTAL_SHARDS"] = TOTAL_SHARDS
+
 logging.basicConfig(level=logging.INFO)
+
+envion_vars["HIPSPARSE_CLIENTS_MATRICES_DIR"] = f"{OUTPUT_ARTIFACTS_DIR}/clients/matrices/"
 
 cmd = [f"{THEROCK_BIN_DIR}/hipsparse-test"]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
@@ -17,5 +27,5 @@ subprocess.run(
     cmd,
     cwd=THEROCK_DIR,
     check=True,
-    env={"HIPSPARSE_CLIENTS_MATRICES_DIR": f"{OUTPUT_ARTIFACTS_DIR}/clients/matrices/"},
+    env=envion_vars,
 )

--- a/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
@@ -19,7 +19,9 @@ envion_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 
 logging.basicConfig(level=logging.INFO)
 
-envion_vars["HIPSPARSE_CLIENTS_MATRICES_DIR"] = f"{OUTPUT_ARTIFACTS_DIR}/clients/matrices/"
+envion_vars[
+    "HIPSPARSE_CLIENTS_MATRICES_DIR"
+] = f"{OUTPUT_ARTIFACTS_DIR}/clients/matrices/"
 
 cmd = [f"{THEROCK_BIN_DIR}/hipsparse-test"]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")

--- a/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
@@ -14,8 +14,8 @@ SHARD_INDEX = os.getenv("SHARD_INDEX")
 TOTAL_SHARDS = os.getenv("TOTAL_SHARDS")
 envion_vars = os.environ.copy()
 # For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
-envion_vars["GTEST_SHARD_INDEX"] = int(SHARD_INDEX) - 1
-envion_vars["GTEST_TOTAL_SHARDS"] = TOTAL_SHARDS
+envion_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
+envion_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 
 logging.basicConfig(level=logging.INFO)
 

--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -8,6 +8,14 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+# GTest sharding
+SHARD_INDEX = os.getenv("SHARD_INDEX")
+TOTAL_SHARDS = os.getenv("TOTAL_SHARDS")
+envion_vars = os.environ.copy()
+# For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
+envion_vars["GTEST_SHARD_INDEX"] = int(SHARD_INDEX) - 1
+envion_vars["GTEST_TOTAL_SHARDS"] = TOTAL_SHARDS
+
 logging.basicConfig(level=logging.INFO)
 
 ###########################################
@@ -63,4 +71,5 @@ subprocess.run(
     cmd,
     cwd=THEROCK_DIR,
     check=True,
+    env=envion_vars
 )

--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -9,8 +9,8 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
 # GTest sharding
-SHARD_INDEX = os.getenv("SHARD_INDEX")
-TOTAL_SHARDS = os.getenv("TOTAL_SHARDS")
+SHARD_INDEX = os.getenv("SHARD_INDEX", 1)
+TOTAL_SHARDS = os.getenv("TOTAL_SHARDS", 1)
 envion_vars = os.environ.copy()
 # For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
 envion_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)

--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -67,9 +67,4 @@ gtest_final_filter_cmd = (
 
 cmd = [f"{THEROCK_BIN_DIR}/miopen_gtest", gtest_final_filter_cmd]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
-subprocess.run(
-    cmd,
-    cwd=THEROCK_DIR,
-    check=True,
-    env=envion_vars
-)
+subprocess.run(cmd, cwd=THEROCK_DIR, check=True, env=envion_vars)

--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -13,8 +13,8 @@ SHARD_INDEX = os.getenv("SHARD_INDEX")
 TOTAL_SHARDS = os.getenv("TOTAL_SHARDS")
 envion_vars = os.environ.copy()
 # For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
-envion_vars["GTEST_SHARD_INDEX"] = int(SHARD_INDEX) - 1
-envion_vars["GTEST_TOTAL_SHARDS"] = TOTAL_SHARDS
+envion_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
+envion_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 
 logging.basicConfig(level=logging.INFO)
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocsparse.py
@@ -26,9 +26,4 @@ cmd = [
     f"{OUTPUT_ARTIFACTS_DIR}/clients/matrices/",
 ]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
-subprocess.run(
-    cmd,
-    cwd=THEROCK_DIR,
-    check=True,
-    env=envion_vars
-)
+subprocess.run(cmd, cwd=THEROCK_DIR, check=True, env=envion_vars)

--- a/build_tools/github_actions/test_executable_scripts/test_rocsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocsparse.py
@@ -12,8 +12,8 @@ THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 logging.basicConfig(level=logging.INFO)
 
 # GTest sharding
-SHARD_INDEX = os.getenv("SHARD_INDEX")
-TOTAL_SHARDS = os.getenv("TOTAL_SHARDS")
+SHARD_INDEX = os.getenv("SHARD_INDEX", 1)
+TOTAL_SHARDS = os.getenv("TOTAL_SHARDS", 1)
 envion_vars = os.environ.copy()
 # For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
 envion_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)

--- a/build_tools/github_actions/test_executable_scripts/test_rocsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocsparse.py
@@ -11,6 +11,14 @@ THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
 logging.basicConfig(level=logging.INFO)
 
+# GTest sharding
+SHARD_INDEX = os.getenv("SHARD_INDEX")
+TOTAL_SHARDS = os.getenv("TOTAL_SHARDS")
+envion_vars = os.environ.copy()
+# For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
+envion_vars["GTEST_SHARD_INDEX"] = int(SHARD_INDEX) - 1
+envion_vars["GTEST_TOTAL_SHARDS"] = TOTAL_SHARDS
+
 cmd = [
     f"{THEROCK_BIN_DIR}/rocsparse-test",
     "--gtest_filter=*quick*",
@@ -22,4 +30,5 @@ subprocess.run(
     cmd,
     cwd=THEROCK_DIR,
     check=True,
+    env=envion_vars
 )

--- a/build_tools/github_actions/test_executable_scripts/test_rocsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocsparse.py
@@ -16,8 +16,8 @@ SHARD_INDEX = os.getenv("SHARD_INDEX")
 TOTAL_SHARDS = os.getenv("TOTAL_SHARDS")
 envion_vars = os.environ.copy()
 # For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
-envion_vars["GTEST_SHARD_INDEX"] = int(SHARD_INDEX) - 1
-envion_vars["GTEST_TOTAL_SHARDS"] = TOTAL_SHARDS
+envion_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
+envion_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 
 cmd = [
     f"{THEROCK_BIN_DIR}/rocsparse-test",


### PR DESCRIPTION
Testing for TheRock CI has become longer and longer, resulting in long queues and long waits.

After some testing with pytest-xdist, gtest conversion to ctest and gtest-parallel, all three options resulted in incredibly slower times than the current gtest implementation.

After some testing, I figured out gtest sharding for GitHub action runners. Here's a [test run](https://github.com/ROCm/TheRock/actions/runs/17841452228) which ran tests in 53mins in total!

Currently, only gtest executables are able to be sharded. However, the gtest executables are the most costly in time, so it works out!

Changes:
- gtest executables with extensive times (that are worth sharded) are sharded into around 15min chunks based on historic CI run data. (ex: miopen takes 1h 20m for mi325, it's now 14mins avg between 4 shards)
- Changing from `test_packages.yml` into `test_packages.yml` -> `test_component.yml`. This was due to having to do a matrix of tests based on `fetch_test_configuration.py`, then another round of sharding matrix for each component.

For concerns regarding [the 20 reusable workflow limit](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#limitations-of-reusable-worklows), since this is the same workflow (the 20 limit only applies to <b>unique workflows</b>, that limitation does not apply!

Next steps:
- observe sharding behavior and make changes if needed
- sharding for ctest

working here: https://github.com/ROCm/TheRock/actions/runs/17843284687

Explanation doc: https://[amd.atlassian.net/wiki/spaces/SHARK/pages/1147546104/Geo+s+band-aid+sharding+solution](https://amd.atlassian.net/wiki/spaces/SHARK/pages/1147546104/Geo+s+band-aid+sharding+solution)