### PR TITLE
Re-enable artifact verification and switch to linux-release-package preset.

### DIFF
--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -48,8 +48,7 @@ def do_artifact(args):
     """
     descriptor = artifact_builder.ArtifactDescriptor.load_toml_file(args.descriptor)
     scanner = artifact_builder.ComponentScanner(args.root_dir, descriptor)
-    # Disable strict verification temporarily until debug builds are tested/fixed.
-    # scanner.verify()
+    scanner.verify()
     component_dirs = args.component_dirs
     # It is an alternating list of <component> <dir> so must be divisible by 2.
     if len(component_dirs) % 2:

--- a/build_tools/github_actions/build_configure.py
+++ b/build_tools/github_actions/build_configure.py
@@ -41,9 +41,14 @@ platform_options = {
     ],
 }
 
+platform_presets = {
+    "linux": "linux-release-package",
+}
+
 
 def build_configure():
-    logging.info(f"Building package {package_version}")
+    preset = platform_presets.get(PLATFORM)
+    logging.info(f"Building package {package_version} (preset {preset})")
 
     cmd = [
         "cmake",
@@ -51,13 +56,19 @@ def build_configure():
         build_dir,
         "-GNinja",
         ".",
-        f"-DTHEROCK_AMDGPU_FAMILIES={amdgpu_families}",
-        f"-DTHEROCK_PACKAGE_VERSION='{package_version}'",
-        "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
-        "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
-        "-DTHEROCK_VERBOSE=ON",
-        "-DBUILD_TESTING=ON",
     ]
+    if preset:
+        cmd.extend(["--preset", str(preset)])
+    cmd.extend(
+        [
+            f"-DTHEROCK_AMDGPU_FAMILIES={amdgpu_families}",
+            f"-DTHEROCK_PACKAGE_VERSION='{package_version}'",
+            "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
+            "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+            "-DTHEROCK_VERBOSE=ON",
+            "-DBUILD_TESTING=ON",
+        ]
+    )
 
     # Adding platform specific options
     cmd += platform_options.get(PLATFORM, [])


### PR DESCRIPTION
The referenced issue notes that the stricter verification was failing with debug-info release builds. The intent was that we should always be building with this option. Enabling it and fixing any issues that result.

Fixes #1537
