### PR TITLE
SWDEV-555589 - Edit zlib and zstd source code to create libraries with updated name

### DIFF
--- a/third-party/sysdeps/common/zlib/CMakeLists.txt
+++ b/third-party/sysdeps/common/zlib/CMakeLists.txt
@@ -54,6 +54,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT PATCHELF)
   message(FATAL_ERROR "Missing PATCHELF from super-project")
 endif()
 
+# Apply patch source only on Linux
+set(patch_source_commands)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  list(APPEND patch_source_commands   COMMAND
+    bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${CMAKE_CURRENT_BINARY_DIR}/s")
+endif()
 # zlib provides a CMakeLists.txt, however, we have to do some post-processing
 # of the libraries in order to prepare them for our use, so we invoke it as
 # a sub-build. We do this uniformly across all platforms because it is easier
@@ -67,7 +73,7 @@ add_custom_target(
   COMMAND
     "${CMAKE_COMMAND}" -E copy_directory "${SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/s"
   COMMAND
-    bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${CMAKE_CURRENT_BINARY_DIR}/s"
+    ${patch_source_commands}
   COMMAND
     # Provide our own version map with private symbol versions.
     "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/version.lds" "${CMAKE_CURRENT_BINARY_DIR}/s/zlib.map"

--- a/third-party/sysdeps/common/zlib/CMakeLists.txt
+++ b/third-party/sysdeps/common/zlib/CMakeLists.txt
@@ -67,6 +67,8 @@ add_custom_target(
   COMMAND
     "${CMAKE_COMMAND}" -E copy_directory "${SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/s"
   COMMAND
+    bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${CMAKE_CURRENT_BINARY_DIR}/s"
+  COMMAND
     # Provide our own version map with private symbol versions.
     "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/version.lds" "${CMAKE_CURRENT_BINARY_DIR}/s/zlib.map"
   COMMAND

--- a/third-party/sysdeps/common/zlib/patch_install.py
+++ b/third-party/sysdeps/common/zlib/patch_install.py
@@ -1,7 +1,6 @@
-import os
 from pathlib import Path
 import platform
-import subprocess
+import shutil
 import sys
 
 PREFIX = sys.argv[1]
@@ -9,7 +8,7 @@ PREFIX = sys.argv[1]
 if platform.system() == "Linux":
     source = str(Path(PREFIX) / "lib" / "librocm_sysdeps_z.so")
     destination = str(Path(PREFIX) / "lib" / "libz.so")
-    subprocess.run(["mv", source, destination], check=True)
+    shutil.move(source, destination)
     # We don't want the static lib on Linux.
     (Path(PREFIX) / "lib" / "librocm_sysdeps_z.a").unlink()
 elif platform.system() == "Windows":

--- a/third-party/sysdeps/common/zlib/patch_install.py
+++ b/third-party/sysdeps/common/zlib/patch_install.py
@@ -5,29 +5,13 @@ import subprocess
 import sys
 
 PREFIX = sys.argv[1]
-PATCHELF = os.getenv("PATCHELF")
-THEROCK_SOURCE_DIR = os.getenv("THEROCK_SOURCE_DIR")
-
-if not THEROCK_SOURCE_DIR:
-    raise ValueError("Exepcted THEROCK_SOURCE_DIR env var")
 
 if platform.system() == "Linux":
-    if not PATCHELF:
-        raise ValueError("Exepcted PATCHELF env var")
-    # Patch libz.so
-    subprocess.check_call(
-        [
-            sys.executable,
-            str(Path(THEROCK_SOURCE_DIR) / "build_tools" / "patch_linux_so.py"),
-            "--patchelf",
-            PATCHELF,
-            "--add-prefix",
-            "rocm_sysdeps_",
-            str(Path(PREFIX) / "lib" / "libz.so"),
-        ]
-    )
+    source = str(Path(PREFIX) / "lib" / "librocm_sysdeps_z.so")
+    destination = str(Path(PREFIX) / "lib" / "libz.so")
+    subprocess.run(["mv", source, destination], check=True)
     # We don't want the static lib on Linux.
-    (Path(PREFIX) / "lib" / "libz.a").unlink()
+    (Path(PREFIX) / "lib" / "librocm_sysdeps_z.a").unlink()
 elif platform.system() == "Windows":
     # We don't want the libz.dll on Windows.
     (Path(PREFIX) / "bin" / "zlib.dll").unlink()

--- a/third-party/sysdeps/common/zlib/patch_source.sh
+++ b/third-party/sysdeps/common/zlib/patch_source.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+set -e
+
+SOURCE_DIR="${1:?Source directory must be given}"
+ZLIB_CMAKELIST="$SOURCE_DIR/CMakeLists.txt"
+echo "Patching sources..."
+
+sed -i -E 's/(OUTPUT_NAME)[[:space:]]+z\)/\1 rocm_sysdeps_z)/' "$ZLIB_CMAKELIST"

--- a/third-party/sysdeps/common/zstd/CMakeLists.txt
+++ b/third-party/sysdeps/common/zstd/CMakeLists.txt
@@ -86,6 +86,8 @@ add_custom_target(
   COMMAND
     "${CMAKE_COMMAND}" -E rm -rf -- "${CMAKE_INSTALL_PREFIX}"
   COMMAND
+    bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${SOURCE_DIR}"
+  COMMAND
     "${CMAKE_COMMAND}"
       "-G${CMAKE_GENERATOR}"
       "-S${SOURCE_DIR}/build/cmake"

--- a/third-party/sysdeps/common/zstd/CMakeLists.txt
+++ b/third-party/sysdeps/common/zstd/CMakeLists.txt
@@ -80,13 +80,20 @@ else()
   message(FATAL_ERROR "System not recognized")
 endif()
 
+# Apply patch source only on Linux
+set(patch_source_commands)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  list(APPEND patch_source_commands   COMMAND
+       bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${SOURCE_DIR}")
+endif()
+
 add_custom_target(
   build ALL
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   COMMAND
     "${CMAKE_COMMAND}" -E rm -rf -- "${CMAKE_INSTALL_PREFIX}"
   COMMAND
-    bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${SOURCE_DIR}"
+    ${patch_source_commands}
   COMMAND
     "${CMAKE_COMMAND}"
       "-G${CMAKE_GENERATOR}"

--- a/third-party/sysdeps/common/zstd/patch_install.sh
+++ b/third-party/sysdeps/common/zstd/patch_install.sh
@@ -2,20 +2,8 @@
 set -e
 
 PREFIX="${1:?Expected install prefix argument}"
-PATCHELF="${PATCHELF:-patchelf}"
-THEROCK_SOURCE_DIR="${THEROCK_SOURCE_DIR:?THEROCK_SOURCE_DIR not defined}"
-Python3_EXECUTABLE="${Python3_EXECUTABLE:?Python3_EXECUTABLE not defined}"
 
-"$Python3_EXECUTABLE" "$THEROCK_SOURCE_DIR/build_tools/patch_linux_so.py" \
-  --patchelf "${PATCHELF}" --add-prefix rocm_sysdeps_ \
-  $PREFIX/lib/libzstd.so
-
+# Rename librocm_sysdeps_zstd.so to libzstd.so
+mv $PREFIX/lib/librocm_sysdeps_zstd.so $PREFIX/lib/libzstd.so
 # pc files are not output with a relative prefix. Sed it to relative.
 sed -i -E 's|^prefix=.+|prefix=${pcfiledir}/../..|' $PREFIX/lib/pkgconfig/*.pc
-
-# Rename -lzstd in the pc file.
-sed -i -E 's|-lzstd|-lrocm_sysdeps_zstd|' $PREFIX/lib/pkgconfig/*.pc
-
-# Rename the IMPORTED_LOCATION and SONAME in the CMake target files.
-sed -i -E 's|lib/libzstd\.so\.[0-9\.]+|lib/librocm_sysdeps_zstd.so.1|' $PREFIX/lib/cmake/zstd/zstdTargets-*.cmake
-sed -i -E 's|libzstd\.so\.1|librocm_sysdeps_zstd\.so\.1|' $PREFIX/lib/cmake/zstd/zstdTargets-*.cmake

--- a/third-party/sysdeps/common/zstd/patch_source.sh
+++ b/third-party/sysdeps/common/zstd/patch_source.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+set -e
+
+SOURCE_DIR="${1:?Source directory must be given}"
+ZSTD_CMAKELIST="$SOURCE_DIR/build/cmake/lib/CMakeLists.txt"
+echo "Patching sources..."
+
+sed -i -E 's/(OUTPUT_NAME)[[:space:]]+zstd/\1 rocm_sysdeps_zstd/' "$ZSTD_CMAKELIST"


### PR DESCRIPTION
The renamed and patchelf edited libraries in ROCk artifacts are not providing the symbol version tag. This was resulting in rpm package installation failure.
Patch will create the library with the updated name. Patchelf editing is not required.
librocm_sysdeps_z and librocm_sysdeps_zstd libraries will be created as part of  zlib and zstd builds

## Motivation

The patchelf edited libraries are not providing the symbol version tag

## Technical Details

Rather than editing libraries to update soname , create libraries with the updated name by editing the target name in source code

## Test Plan

Verified the elfdeps provides field of the libraries.

## Test Result

Required symbol version tags are provided by the libraries

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
