### PR TITLE
[CI] Poll process status in Pre/Post test job cleanup

### DIFF
--- a/build_tools/github_actions/cleanup_processes.ps1
+++ b/build_tools/github_actions/cleanup_processes.ps1
@@ -42,7 +42,7 @@ function Wait-Process-Filter ([String]$RegexStr, [int] $Tries, [int] $Seconds = 
             Write-Host "    > Waiting for $ps_list_len processes..."
             $ps_list | % {
                 Write-Host "      $(Get-Process-Info $_)"
-            } 
+            }
         } else {
             Write-Host "    > Found no processes after waiting $(($i+1) * $Seconds) second(s)"
             return $true;

--- a/build_tools/github_actions/cleanup_processes.ps1
+++ b/build_tools/github_actions/cleanup_processes.ps1
@@ -44,10 +44,11 @@ function Wait-Process-Filter ([String]$RegexStr, [int] $Tries, [int] $Seconds = 
                 Write-Host "      $(Get-Process-Info $_)"
             } 
         } else {
+            Write-Host "    > Found no processes after waiting $(($i+1) * $Seconds) second(s)"
             return $true;
         }
     }
-    Write-Host "[*] $ps_list_len Processes still exists"
+    Write-Host "    > Found $ps_list_len processes after waiting $($i * $Seconds) second(s)"
     return $false;
 }
 
@@ -89,10 +90,11 @@ if($ps_list_begin_len -eq 0) {
 echo "[*] Found $ps_list_begin_len running build executable(s):"
 $ps_list | % { echo "    > $($_.MainModule.FileName)"}
 
-echo "[*] Attempting to stop executable(s) forcefully with 'Stop-Process' ..."
+echo "[*] Attempting to stop executable(s) with WMI: "
 $ps_list | ForEach-Object {
+    #https://stackoverflow.com/questions/40585754/powershell-wont-terminate-hung-process
     echo "    > $(Get-Process-Info $_)"
-    Stop-Process $_ -Force
+    (Get-WmiObject win32_process -Filter "ProcessId = '$($_.id)'").Terminate() | Out-Null
 }
 $IsAllStopped = Wait-Process-Filter -RegexStr $regex_build_exe -Tries 5
 
@@ -101,11 +103,11 @@ $IsAllStopped = Wait-Process-Filter -RegexStr $regex_build_exe -Tries 5
 if(!$IsAllStopped) {
     $ps_list = Get-Process-Filter -RegexStr $regex_build_exe
     if($ps_list.Count -gt 0) {
-        echo "[*] Attemping to stop any remaining executable(s) with WMI: "
+        echo "[*] Attemping to stop any remaining executable(s) forcefully with 'Stop-Process':"
         $ps_list | ForEach-Object {
             #https://stackoverflow.com/questions/40585754/powershell-wont-terminate-hung-process
             echo "    > $(Get-Process-Info $_)"
-            (Get-WmiObject win32_process -Filter "ProcessId = '$($_.id)'").Terminate() | Out-Null
+            Stop-Process $_ -Force
         }
     }
     $IsAllStopped = Wait-Process-Filter -RegexStr $regex_build_exe -Tries 5

--- a/build_tools/github_actions/cleanup_processes.ps1
+++ b/build_tools/github_actions/cleanup_processes.ps1
@@ -22,6 +22,38 @@
 # This script will defer the step of deleting the repo directory to `actions/checkout`
 #
 
+#### Helper functions ####
+
+function Get-Process-Filter ([String]$RegexStr)  {
+    Get-Process | Where-Object { $_.MainModule.FileName -Match $RegexStr }
+}
+function Get-Process-Info ($PSobj) {
+    # Note in powershell this output gets buffered and returned from this function
+    return "[pid:$($PSobj.id)][HasExited:$($PSobj.HasExited)] $($PSobj.MainModule.ModuleName)"
+}
+function Wait-Process-Filter ([String]$RegexStr, [int] $Tries, [int] $Seconds = 1) {
+    Write-Host "[*] Waiting up to $($Tries * $Seconds) seconds for processes to stop..."
+    $ps_list_len = 0
+    for($i = 0; $i -lt $Tries; $i++) {
+        Start-Sleep -Seconds $Seconds
+        $ps_list = Get-Process-Filter($RegexStr)
+        $ps_list_len = $ps_list.Count
+        if($ps_list_len -gt 0) {
+            Write-Host "    > Waiting for $ps_list_len processes..."
+            $ps_list | % {
+                Write-Host "      $(Get-Process-Info $_)"
+            } 
+        } else {
+            return $true;
+        }
+    }
+    Write-Host "[*] $ps_list_len Processes still exists"
+    return $false;
+}
+
+
+#### Script Start ####
+
 # Note use of single '\' for Windows path separator, but it's escaped as '\\' for regex
 $regex_build_exe = "\build\.*[.]exe"
 
@@ -42,46 +74,54 @@ if($ENV:GITHUB_WORKSPACE -ne $null) {
 $regex_build_exe = $regex_build_exe.Replace("\","\\")
 echo "[*] Checking for running build executables filtered by .exe regex: $regex_build_exe"
 
-$ps_list = Get-Process | Where-Object { $_.MainModule.FileName -Match $regex_build_exe }
-$ps_list_len = $ps_list.Count
+$IsAllStopped = $false
 
-if($ps_list.Count -gt 0) {
-    echo "[*] Found $ps_list_len running build executable(s):"
-    $ps_list | % { echo "    > $($_.MainModule.FileName)"}
+$ps_list = Get-Process-Filter($regex_build_exe)
+$ps_list_begin_len = $ps_list.Count
 
-    echo "[*] Attempting to stop executable(s) forcefully with 'Stop-Process' ..."
-    $ps_list | ForEach-Object {
-        echo "    > $($_.MainModule.ModuleName)"
-        echo "      | pid: $($_.id)"
-        Stop-Process $_ -Force
-        echo "      | exited: $($_.HasExited)"
-    }
+# exit early if no processes found
+if($ps_list_begin_len -eq 0) {
+    echo "[+] No executables to clean up."
+    exit 0
+}
 
-    # Try to stop any still running processes with WMI
-    $ps_list = Get-Process | Where-Object { $_.MainModule.FileName -Match $regex_build_exe }
+# First Attempt with powershell `Stop-Process`
+echo "[*] Found $ps_list_begin_len running build executable(s):"
+$ps_list | % { echo "    > $($_.MainModule.FileName)"}
+
+echo "[*] Attempting to stop executable(s) forcefully with 'Stop-Process' ..."
+$ps_list | ForEach-Object {
+    echo "    > $(Get-Process-Info $_)"
+    Stop-Process $_ -Force
+}
+$IsAllStopped = Wait-Process-Filter -RegexStr $regex_build_exe -Tries 5
+
+
+# Second Attempt with `WMI` (if any processes are still running)
+if(!$IsAllStopped) {
+    $ps_list = Get-Process-Filter -RegexStr $regex_build_exe
     if($ps_list.Count -gt 0) {
         echo "[*] Attemping to stop any remaining executable(s) with WMI: "
         $ps_list | ForEach-Object {
-            echo "    > $($_.MainModule.ModuleName)"
-            echo "      | pid: $($_.id)"
             #https://stackoverflow.com/questions/40585754/powershell-wont-terminate-hung-process
+            echo "    > $(Get-Process-Info $_)"
             (Get-WmiObject win32_process -Filter "ProcessId = '$($_.id)'").Terminate() | Out-Null
-            echo "      | exited: $($_.HasExited)"
         }
     }
+    $IsAllStopped = Wait-Process-Filter -RegexStr $regex_build_exe -Tries 5
+}
 
-    # Query list of processes again to see whether processes may have hung
-    $ps_list = Get-Process | Where-Object { $_.MainModule.FileName -Match $regex_build_exe }
+# Query list of processes again to see whether processes may have hung
+# only if at the beginning of the script there were found processes to be stopped
+if(!$IsAllStopped) {
+    $ps_list = Get-Process-Filter -RegexStr $regex_build_exe
     if($ps_list.Count -gt 0) {
         echo "[-] Failed to stop executable(s): "
         $ps_list | ForEach-Object {
-            echo "    > $($_.MainModule.ModuleName)"
+            Write-Host "    > $(Get-Process-Info $_)"
         }
         exit 1
-    } else {
-        echo "[+] All $ps_list_len executable(s) were stopped."
     }
-
 } else {
-    echo "[+] No executables to clean up."
+    echo "[+] All executable(s) were stopped."
 }

--- a/build_tools/github_actions/cleanup_processes.ps1
+++ b/build_tools/github_actions/cleanup_processes.ps1
@@ -103,7 +103,7 @@ $IsAllStopped = Wait-Process-Filter -RegexStr $regex_build_exe -Tries 5
 if(!$IsAllStopped) {
     $ps_list = Get-Process-Filter -RegexStr $regex_build_exe
     if($ps_list.Count -gt 0) {
-        echo "[*] Attemping to stop any remaining executable(s) forcefully with 'Stop-Process':"
+        echo "[*] Attempting to stop any remaining executable(s) forcefully with 'Stop-Process':"
         $ps_list | ForEach-Object {
             #https://stackoverflow.com/questions/40585754/powershell-wont-terminate-hung-process
             echo "    > $(Get-Process-Info $_)"


### PR DESCRIPTION
## Motivation

Get a more accurate and reliable read on whether orphaned processes were cleaned up successfully. Follow up to https://github.com/ROCm/TheRock/pull/1361 and https://github.com/ROCm/TheRock/pull/1521

Additionally since the script does exit with an appropriate exit code based on success or failure, it would cause the test job to fail early if processes could not be stopped.

## Technical Details

Logs from earlier tests would end with `Failed to stop executable(s)` so it was unknown whether the processes stopped, along with the `exited: True` as seen here:
https://github.com/ROCm/TheRock/pull/1518#issuecomment-3305499637

The polling method was suggested in discussions here:
https://github.com/ROCm/TheRock/pull/1518#issuecomment-3308689749

Also prioritizing the use of WMI since it seems to work more effectively:
https://github.com/ROCm/TheRock/pull/1518#issuecomment-3313830132

## Test Plan

- Testing locally with mocked processes (`cmd.exe` renamed as `hiprand-test.exe`, launched with `.\hiprand-test.exe; .\hiprand-test.exe;` in powershell) in a similar build directory path of  ` .\actions-runner\_work\TheRock\TheRock\build\bin`
- Testing on CI with known bad builds (from much older commits) that may cause test processes to hang (with run noted here https://github.com/ROCm/TheRock/pull/1518#issuecomment-3313830132)

## Test Result
- Local testing:
(note: Since this is actually two separate processes that run there is a difference in process IDs and will wait the maximum amount of time, before trying to stop the second process with `stop-process`)
```haskell
[*] Checking if elevated: True | current user: DEVVM\user
[*] GITHUB_WORKSPACE env var undefined, using default regex
[*] Checking for running build executables filtered by .exe regex: \\build\\.*[.]exe     
[*] Found 1 running build executable(s):
    > A:\actions-runner\_work\TheRock\TheRock\build\bin\hiprand-test.exe
[*] Attempting to stop executable(s) with WMI:
    > [pid:7048][HasExited:False] hiprand-test.exe
[*] Waiting up to 5 seconds for processes to stop...
    > Waiting for 1 processes...
      [pid:5000][HasExited:False] hiprand-test.exe
    > Waiting for 1 processes...
      [pid:5000][HasExited:False] hiprand-test.exe
    > Waiting for 1 processes...
      [pid:5000][HasExited:False] hiprand-test.exe
    > Waiting for 1 processes...
      [pid:5000][HasExited:False] hiprand-test.exe
    > Waiting for 1 processes...
      [pid:5000][HasExited:False] hiprand-test.exe
    > Found 1 processes after waiting 5 second(s)
[*] Attempting to stop any remaining executable(s) forcefully with 'Stop-Process':
    > [pid:5000][HasExited:False] hiprand-test.exe
[*] Waiting up to 5 seconds for processes to stop...
    > Found no processes after waiting 1 second(s)
[+] All executable(s) were stopped.
```
- Test on CI with bad build result:
https://github.com/ROCm/TheRock/actions/runs/17869985151/job/50824866894#step:8:27

```haskell
[*] Checking if elevated: True | current user: NT AUTHORITY\SYSTEM
[*] GITHUB_WORKSPACE env var defined: C:\runner\_work\TheRock\TheRock
[*] Checking for running build executables filtered by .exe regex: C:\\runner\\_work\\TheRock\\TheRock\\build\\.*[.]exe
[*] Found 1 running build executable(s):
    > C:\runner\_work\TheRock\TheRock\build\bin\rocsparse-test.exe
[*] Attempting to stop executable(s) with WMI: 
    > [pid:9436][HasExited:True] rocsparse-test.exe
[*] Waiting up to 5 seconds for processes to stop...
    > Found no processes after waiting 1 second(s)
[+] All executable(s) were stopped.
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
