### PR TITLE
Fix patching of 3rd party source failing silently.

### DIFF
--- a/build_tools/patch_third_party_source.py
+++ b/build_tools/patch_third_party_source.py
@@ -54,7 +54,7 @@ def main(args):
     patches_dir = Path(patches_dir)
     for i in patches:
         p = patches_dir / i
-        run_command(["git", "apply", p])
+        run_command(["patch", "-p1", "-i", p])
     create_stamp_file(stamp_filename)
 
 


### PR DESCRIPTION
## Motivation

The source of 3rd party libs is fetched and extracted, but if the build folder itself is contained in a Git checkout of TheRock, git apply fails silently.

Discovered during #1267

## Technical Details

`git apply` fails when it is run within a git repository that is not the original repo the patch was generated from.
Switching the command used to apply patch to `patch`, which doesn't take git repo into consideration.

## Test Plan

Build TheRock and ensure yaml-cpp is patched as intended.
```
# third-party/yaml-cpp/CMakeLists.txt

therock_subproject_fetch(therock-yaml-cpp-sources
  CMAKE_PROJECT
  # Originally mirrored from: https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz
  URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/yaml-cpp-0.8.0.tar.gz
  URL_HASH SHA256=fbe74bbdcee21d656715688706da3c8becfd946d92cd44705cc6098bb23b3a16
  PATCH_COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/build_tools/patch_third_party_source.py ${CMAKE_SOURCE_DIR}/patches/third-party/yaml-cpp
)
```

## Test Result

yaml-cpp is patched as expected.

```
# build/third-party/yaml-cpp/source/src/emitterutils.cpp

#include <algorithm>
#include <cstdint>
#include <iomanip>
#include <sstream>
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
