### PR TITLE
[windows] Update hipblaslt.dll to libhipblaslt.dll to fix rocm packages.

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -197,7 +197,7 @@ LibraryEntry("hiprand", "libraries", "libhiprand.so.1", "hiprand.dll")
 LibraryEntry("hipsparse", "libraries", "libhipsparse.so.4", "hipsparse.dll")
 LibraryEntry("hipsolver", "libraries", "libhipsolver.so.1", "hipsolver.dll")
 LibraryEntry("rccl", "libraries", "librccl.so.1", "")
-LibraryEntry("hipblaslt", "libraries", "libhipblaslt.so.1", "hipblaslt.dll")
+LibraryEntry("hipblaslt", "libraries", "libhipblaslt.so.1", "libhipblaslt.dll")
 LibraryEntry("miopen", "libraries", "libMIOpen.so.1", "MIOpen.dll")
 
 # Overall ROCM package version.


### PR DESCRIPTION
## Motivation

Quick fix for https://github.com/ROCm/TheRock/issues/1552.

## Technical Details

TODO: find the culprit commit that changed the DLL name

## Test Plan

Sanity checked locally with `rocm-sdk test`

## Test Result

Failing:
```
(3.12.venv) λ rocm-sdk test
testCLI (rocm_sdk.tests.base_test.ROCmBaseTest.testCLI) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\3.12.venv\Scripts\python.exe' -P -m rocm_sdk --help
ok
testTargets (rocm_sdk.tests.base_test.ROCmBaseTest.testTargets) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\3.12.venv\Scripts\python.exe' -P -m rocm_sdk targets
ok
testVersion (rocm_sdk.tests.base_test.ROCmBaseTest.testVersion) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\3.12.venv\Scripts\python.exe' -P -m rocm_sdk version
ok
test_initialize_process_check_version (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version) ... ok
test_initialize_process_check_version_asterisk (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_asterisk) ... ok
test_initialize_process_check_version_mismatch (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_mismatch) ... ok
test_initialize_process_check_version_mismatch_warning (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_mismatch_warning) ... ok
test_initialize_process_check_version_pattern (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_pattern) ... ok
test_initialize_process_env_preload_1 (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_1) ... ok
test_initialize_process_env_preload_2_comma (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_2_comma) ... ok
test_initialize_process_env_preload_2_semi (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_2_semi) ... ok
test_initialize_process_preload_libraries (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_preload_libraries) ... ok
testConsoleScripts (rocm_sdk.tests.core_test.ROCmCoreTest.testConsoleScripts) ... ok
testInstallationLayout (rocm_sdk.tests.core_test.ROCmCoreTest.testInstallationLayout)
The `rocm_sdk` and core module must be siblings on disk. ... ok
testPreloadLibraries (rocm_sdk.tests.core_test.ROCmCoreTest.testPreloadLibraries) ...
  testPreloadLibraries (rocm_sdk.tests.core_test.ROCmCoreTest.testPreloadLibraries) [Check rocm_sdk.preload_libraries] (shortname='hipblaslt') ... ERROR
testSharedLibrariesLoad (rocm_sdk.tests.core_test.ROCmCoreTest.testSharedLibrariesLoad) ... ok
testConsoleScripts (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testConsoleScripts) ... ok
testInstallationLayout (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testInstallationLayout)
The `rocm_sdk` and libraries module must be siblings on disk. ... ok
testSharedLibrariesLoad (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testSharedLibrariesLoad) ... ok
testCLIPathBin (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathBin) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\3.12.venv\Scripts\python.exe' -P -m rocm_sdk path --bin
ok
testCLIPathCMake (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathCMake) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\3.12.venv\Scripts\python.exe' -P -m rocm_sdk path --cmake
ok
testCLIPathRoot (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathRoot) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\3.12.venv\Scripts\python.exe' -P -m rocm_sdk path --root
ok
testInstallationLayout (rocm_sdk.tests.devel_test.ROCmDevelTest.testInstallationLayout)
The `rocm_sdk` and devel module must be siblings on disk. ... ok
testRootLLVMSymlinkExists (rocm_sdk.tests.devel_test.ROCmDevelTest.testRootLLVMSymlinkExists) ... skipped 'root LLVM symlink only exists on Linux'
testSharedLibrariesLoad (rocm_sdk.tests.devel_test.ROCmDevelTest.testSharedLibrariesLoad) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\3.12.venv\Scripts\python.exe' -P -m rocm_sdk path --root
ok

======================================================================
ERROR: testPreloadLibraries (rocm_sdk.tests.core_test.ROCmCoreTest.testPreloadLibraries) [Check rocm_sdk.preload_libraries] (shortname='hipblaslt')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\rocm_sdk\tests\core_test.py", line 136, in testPreloadLibraries
    rocm_sdk.preload_libraries(lib_entry.shortname)
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\rocm_sdk\__init__.py", line 87, in preload_libraries
    paths = find_libraries(*shortnames)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\scratch\therock\3.12.venv\Lib\site-packages\rocm_sdk\__init__.py", line 58, in find_libraries
    raise FileNotFoundError(
FileNotFoundError: Could not find rocm library 'hipblaslt' at path D:\scratch\therock\3.12.venv\Lib\site-packages\_rocm_sdk_libraries_gfx110X_dgpu\bin\hipblaslt.dll

----------------------------------------------------------------------
Ran 25 tests in 4.739s

FAILED (errors=1, skipped=1)
```

Passing:
```
(3.12.venv) λ rocm-sdk test
testCLI (rocm_sdk.tests.base_test.ROCmBaseTest.testCLI) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\3.12.venv\Scripts\python.exe' -P -m rocm_sdk --help
ok
testTargets (rocm_sdk.tests.base_test.ROCmBaseTest.testTargets) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\3.12.venv\Scripts\python.exe' -P -m rocm_sdk targets
ok
testVersion (rocm_sdk.tests.base_test.ROCmBaseTest.testVersion) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\3.12.venv\Scripts\python.exe' -P -m rocm_sdk version
ok
test_initialize_process_check_version (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version) ... ok
test_initialize_process_check_version_asterisk (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_asterisk) ... ok
test_initialize_process_check_version_mismatch (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_mismatch) ... ok
test_initialize_process_check_version_mismatch_warning (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_mismatch_warning) ... ok
test_initialize_process_check_version_pattern (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_check_version_pattern) ... ok
test_initialize_process_env_preload_1 (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_1) ... ok
test_initialize_process_env_preload_2_comma (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_2_comma) ... ok
test_initialize_process_env_preload_2_semi (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_env_preload_2_semi) ... ok
test_initialize_process_preload_libraries (rocm_sdk.tests.base_test.ROCmBaseTest.test_initialize_process_preload_libraries) ... ok
testConsoleScripts (rocm_sdk.tests.core_test.ROCmCoreTest.testConsoleScripts) ... ok
testInstallationLayout (rocm_sdk.tests.core_test.ROCmCoreTest.testInstallationLayout)
The `rocm_sdk` and core module must be siblings on disk. ... ok
testPreloadLibraries (rocm_sdk.tests.core_test.ROCmCoreTest.testPreloadLibraries) ... ok
testSharedLibrariesLoad (rocm_sdk.tests.core_test.ROCmCoreTest.testSharedLibrariesLoad) ... ok
testConsoleScripts (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testConsoleScripts) ... ok
testInstallationLayout (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testInstallationLayout)
The `rocm_sdk` and libraries module must be siblings on disk. ... ok
testSharedLibrariesLoad (rocm_sdk.tests.libraries_test.ROCmLibrariesTest.testSharedLibrariesLoad) ... ok
testCLIPathBin (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathBin) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\3.12.venv\Scripts\python.exe' -P -m rocm_sdk path --bin
ok
testCLIPathCMake (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathCMake) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\3.12.venv\Scripts\python.exe' -P -m rocm_sdk path --cmake
ok
testCLIPathRoot (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIPathRoot) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\3.12.venv\Scripts\python.exe' -P -m rocm_sdk path --root
ok
testInstallationLayout (rocm_sdk.tests.devel_test.ROCmDevelTest.testInstallationLayout)
The `rocm_sdk` and devel module must be siblings on disk. ... ok
testRootLLVMSymlinkExists (rocm_sdk.tests.devel_test.ROCmDevelTest.testRootLLVMSymlinkExists) ... skipped 'root LLVM symlink only exists on Linux'
testSharedLibrariesLoad (rocm_sdk.tests.devel_test.ROCmDevelTest.testSharedLibrariesLoad) ... ++ Exec [D:\scratch\therock]$ 'D:\scratch\therock\3.12.venv\Scripts\python.exe' -P -m rocm_sdk path --root
ok

----------------------------------------------------------------------
Ran 25 tests in 4.491s

OK (skipped=1)
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
