### PR TITLE
Cherry-pick ROCm/rocm-systems@2e93b9f

### DIFF
--- a/patches/amd-mainline/rocm-systems/0009-clr-Only-enable-comgr-dynamic-loading-if-it-is-a-sha.patch
+++ b/patches/amd-mainline/rocm-systems/0009-clr-Only-enable-comgr-dynamic-loading-if-it-is-a-sha.patch
@@ -1,0 +1,31 @@
+From 2e93b9f6cb7945bd2b1e76d68ee30dd38b1f2226 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Fri, 19 Sep 2025 16:10:15 -0700
+Subject: [PATCH] [clr] Only enable comgr dynamic loading if it is a shared
+ lib. (#1065)
+
+Prior we were enabling dynamic loading mode if BUILD_SHARED_LIBS, but this is not correct. We should only be loading dynamically if the amd_comgr library itself is shared.
+
+Background: we have a configuration where we use a static linked comgr stub in order to achieve LLVM isolation (it dynamically loads the comgr and compiler into a dedicated link namespace) in an otherwise dynamic linked clr.
+---
+ projects/clr/rocclr/cmake/ROCclrLC.cmake | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/projects/clr/rocclr/cmake/ROCclrLC.cmake b/projects/clr/rocclr/cmake/ROCclrLC.cmake
+index 55ffc40169..d8ecf4ad02 100644
+--- a/projects/clr/rocclr/cmake/ROCclrLC.cmake
++++ b/projects/clr/rocclr/cmake/ROCclrLC.cmake
+@@ -36,8 +36,9 @@ if (NOT amd_comgr_FOUND)
+       lib/cmake/amd_comgr)
+ endif()
+ 
++get_target_property(_amd_comgr_lib_type amd_comgr TYPE)
+ target_compile_definitions(rocclr PUBLIC WITH_LIGHTNING_COMPILER USE_COMGR_LIBRARY)
+-if(BUILD_SHARED_LIBS)
++if(_amd_comgr_lib_type STREQUAL "SHARED_LIBRARY")
+   target_compile_definitions(rocclr PUBLIC COMGR_DYN_DLL)
+ endif()
+ target_link_libraries(rocclr PUBLIC amd_comgr)
+-- 
+2.43.0
+


### PR DESCRIPTION
Cherry-picks ROCm/rocm-systems@2e93b9f to apply it locally until rocm-systems can be bumped with test failures.