### PR TITLE
Add liblzma dependency (via xz/xz-devel) for AOTriton build support

### DIFF
--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -66,6 +66,8 @@ RUN yum install -y epel-release && \
       gcc-toolset-12-libatomic-devel \
       gcc-toolset-12-libstdc++-devel \
       patchelf \
+      xz \
+      xz-devel \
       vim-common \
       git-lfs \
       m4 \
@@ -78,6 +80,10 @@ RUN yum install -y epel-release && \
       unzip \
     && yum clean all && \
     rm -rf /var/cache/yum
+
+######## Verify libzma is installed ##########
+
+RUN pkg-config --libs liblzma
 
 ######## DVC via pip ######
 # dvc's rpm package includes .so dependencies built against glib 2.29


### PR DESCRIPTION
## Motivation

This PR explicitly installs liblzma by adding the xz and xz-devel packages to the manylinux container.

liblzma is a required dependency for building AOTriton in TheRock CI.

## Background

Previously, AOTriton downloaded a prebuilt runtime tied to a specific ROCm version.
Now that we are building new ROCm versions directly, the runtime also needs to be built from source.

The source build introduces a dependency on:

pkg_search_module(LZMA REQUIRED liblzma)


By installing xz and xz-devel, the container provides liblzma and its pkg-config files, ensuring AOTriton can configure and compile correctly in CI.