### PR TITLE
[ci] Enable component flags for `install_rocm_from_artifacts.py`

### DIFF
--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -252,7 +252,7 @@ def filter_base_artifacts(
         "rocprofiler-sdk_lib",
         "host-suite-sparse_lib",
     ]
-    if args.blas or args.all:
+    if args.blas:
         base_artifacts.append("host-blas_lib")
 
     artifacts_to_retrieve = collect_artifacts_download_requests(

--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -252,7 +252,7 @@ def filter_base_artifacts(
         "rocprofiler-sdk_lib",
         "host-suite-sparse_lib",
     ]
-    if args.blas:
+    if args.blas or args.all:
         base_artifacts.append("host-blas_lib")
 
     artifacts_to_retrieve = collect_artifacts_download_requests(

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -224,6 +224,24 @@ def main(argv):
 
     artifacts_group = parser.add_argument_group("artifacts_group")
     artifacts_group.add_argument(
+        "--all",
+        default=False,
+        help="Include all artifacts",
+        action=argparse.BooleanOptionalAction,
+    )
+    parser.add_argument(
+        "include",
+        nargs="*",
+        help="Regular expression patterns of artifacts to include (implies --all): "
+        "if supplied one pattern must match for an artifact to be included",
+    )
+    parser.add_argument(
+        "--exclude",
+        nargs="*",
+        help="Regular expression patterns of artifacts to exclude",
+    )
+
+    artifacts_group.add_argument(
         "--blas",
         default=False,
         help="Include 'blas' artifacts",

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -114,7 +114,7 @@ def retrieve_artifacts_by_run_id(args):
     ]
     if args.base_only:
         argv.append("--base-only")
-    elif args.blas or args.fft or args.miopen or args.prim or args.rand or args.rccl:
+    elif any([args.blas, args.fft, args.miopen, args.prim, args.rand, args.rccl]):
         if args.blas:
             argv.append("--blas")
         if args.fft:
@@ -299,6 +299,12 @@ def main(argv):
     )
 
     args = parser.parse_args(argv)
+
+    if not args.amdgpu_family:
+        raise argparse.ArgumentTypeError(
+            "AMD GPU family argument is required and cannot be empty"
+        )
+
     run(args)
 
 

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -223,6 +223,7 @@ def main(argv):
     parser.add_argument(
         "--amdgpu-family",
         type=str,
+        required=True,
         default="gfx94X-dcgpu",
         help="AMD GPU family to install (please refer to this: https://github.com/ROCm/TheRock/blob/59c324a759e8ccdfe5a56e0ebe72a13ffbc04c1f/cmake/therock_amdgpu_targets.cmake#L44-L81 for family choices)",
     )

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -113,7 +113,7 @@ def retrieve_artifacts_by_run_id(args):
         "--flatten",
     ]
     if args.base_only:
-        argv.append("--base")
+        argv.append("--base-only")
     elif args.blas:
         argv.append("--blas")
     elif args.fft:
@@ -128,7 +128,7 @@ def retrieve_artifacts_by_run_id(args):
         argv.append("--rccl")
     else:
         argv.append("--all")
-    
+
     if args.tests:
         argv.append("--tests")
 
@@ -238,24 +238,6 @@ def main(argv):
     )
 
     artifacts_group = parser.add_argument_group("artifacts_group")
-    artifacts_group.add_argument(
-        "--all",
-        default=False,
-        help="Include all artifacts",
-        action=argparse.BooleanOptionalAction,
-    )
-    parser.add_argument(
-        "include",
-        nargs="*",
-        help="Regular expression patterns of artifacts to include (implies --all): "
-        "if supplied one pattern must match for an artifact to be included",
-    )
-    parser.add_argument(
-        "--exclude",
-        nargs="*",
-        help="Regular expression patterns of artifacts to exclude",
-    )
-
     artifacts_group.add_argument(
         "--blas",
         default=False,

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -114,10 +114,25 @@ def retrieve_artifacts_by_run_id(args):
     ]
     if args.base_only:
         argv.append("--base")
+    elif args.blas:
+        argv.append("--blas")
+    elif args.fft:
+        argv.append("--fft")
+    elif args.miopen:
+        argv.append("--miopen")
+    elif args.prim:
+        argv.append("--prim")
+    elif args.rand:
+        argv.append("--rand")
+    elif args.rccl and PLATFORM != "windows":
+        argv.append("--rccl")
     else:
         argv.append("--all")
-    fetch_artifacts_main(argv)
+    
+    if args.tests:
+        argv.append("--tests")
 
+    fetch_artifacts_main(argv)
     log(f"Retrieved artifacts for run ID {run_id}")
 
 

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -114,23 +114,23 @@ def retrieve_artifacts_by_run_id(args):
     ]
     if args.base_only:
         argv.append("--base-only")
-    elif args.blas:
-        argv.append("--blas")
-    elif args.fft:
-        argv.append("--fft")
-    elif args.miopen:
-        argv.append("--miopen")
-    elif args.prim:
-        argv.append("--prim")
-    elif args.rand:
-        argv.append("--rand")
-    elif args.rccl and PLATFORM != "windows":
-        argv.append("--rccl")
+    elif args.blas or args.fft or args.miopen or args.prim or args.rand or args.rccl:
+        if args.blas:
+            argv.append("--blas")
+        if args.fft:
+            argv.append("--fft")
+        if args.miopen:
+            argv.append("--miopen")
+        if args.prim:
+            argv.append("--prim")
+        if args.rand:
+            argv.append("--rand")
+        if args.rccl and PLATFORM != "windows":
+            argv.append("--rccl")
+        if args.tests:
+            argv.append("--tests")
     else:
         argv.append("--all")
-
-    if args.tests:
-        argv.append("--tests")
 
     fetch_artifacts_main(argv)
     log(f"Retrieved artifacts for run ID {run_id}")


### PR DESCRIPTION
Realizing that `install_rocm_from_artifacts.py` installs everything (after some updates to `fetch_artifacts.py`), like here: https://github.com/ROCm/TheRock/actions/runs/17944455280/job/51030783105

In order to save CI time, I'm enabling the component flags for `install_rocm_from_artifacts.py`