### PR TITLE
Add fftw3 and fftw3f 3.3.10 libraries

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -11,6 +11,7 @@ add_subdirectory(nlohmann-json)
 add_subdirectory(yaml-cpp)
 add_subdirectory(Catch2)
 add_subdirectory(FunctionalPlus)
+add_subdirectory(fftw3)
 
 # frugally-deep depends on eigen, FunctionalPlus and nlohmann-json
 add_subdirectory(frugally-deep)

--- a/third-party/fftw3/CMakeLists.txt
+++ b/third-party/fftw3/CMakeLists.txt
@@ -1,0 +1,69 @@
+therock_subproject_fetch(therock-fftw3-sources
+  CMAKE_PROJECT
+  # Originally mirrored from: https://fftw.org/fftw-3.3.10.tar.gz
+  URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/fftw-3.3.10.tar.gz
+  URL_HASH SHA256=56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467
+)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(FFTW3_ENABLE_THREADS TRUE CACHE BOOL "FFTW3_ENABLE_THREADS set TRUE on Linux" FORCE)
+else()
+  set(FFTW3_ENABLE_THREADS FALSE CACHE BOOL "FFTW3_ENABLE_THREADS set FALSE" FORCE)
+endif()
+
+therock_cmake_subproject_declare(therock-fftw3
+  BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/build_fftw3"
+  BACKGROUND_BUILD
+  EXCLUDE_FROM_ALL
+  NO_MERGE_COMPILE_COMMANDS
+  OUTPUT_ON_FAILURE
+  EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
+  CMAKE_ARGS
+    -DBUILD_SHARED_LIBS=ON
+    -DENABLE_THREADS=${FFTW3_ENABLE_THREADS}
+)
+therock_cmake_subproject_provide_package(therock-fftw3 FFTW3 lib/cmake/fftw3)
+therock_cmake_subproject_activate(therock-fftw3)
+
+add_dependencies(therock-third-party therock-fftw3)
+
+therock_provide_artifact(fftw3
+  DESCRIPTOR artifact_fftw3.toml
+  TARGET_NEUTRAL
+  COMPONENTS
+    dbg
+    dev
+    doc
+    lib
+    run
+  SUBPROJECT_DEPS therock-fftw3
+)
+
+therock_cmake_subproject_declare(therock-fftw3f
+  BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/build_fftw3f"
+  BACKGROUND_BUILD
+  EXCLUDE_FROM_ALL
+  NO_MERGE_COMPILE_COMMANDS
+  OUTPUT_ON_FAILURE
+  EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
+  CMAKE_ARGS
+    -DENABLE_FLOAT=ON
+    -DBUILD_SHARED_LIBS=ON
+    -DENABLE_THREADS=${FFTW3_ENABLE_THREADS}
+)
+therock_cmake_subproject_provide_package(therock-fftw3f FFTW3f lib/cmake/fftw3f)
+therock_cmake_subproject_activate(therock-fftw3f)
+
+add_dependencies(therock-third-party therock-fftw3f)
+
+therock_provide_artifact(fftw3f
+  DESCRIPTOR artifact_fftw3f.toml
+  TARGET_NEUTRAL
+  COMPONENTS
+    dbg
+    dev
+    doc
+    lib
+    run
+  SUBPROJECT_DEPS therock-fftw3f
+)

--- a/third-party/fftw3/CMakeLists.txt
+++ b/third-party/fftw3/CMakeLists.txt
@@ -6,9 +6,9 @@ therock_subproject_fetch(therock-fftw3-sources
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  set(FFTW3_ENABLE_THREADS TRUE CACHE BOOL "FFTW3_ENABLE_THREADS set TRUE on Linux" FORCE)
+  set(_fftw3_enable_threads "ON")
 else()
-  set(FFTW3_ENABLE_THREADS FALSE CACHE BOOL "FFTW3_ENABLE_THREADS set FALSE" FORCE)
+  set(_fftw3_enable_threads "OFF")
 endif()
 
 therock_cmake_subproject_declare(therock-fftw3
@@ -20,24 +20,12 @@ therock_cmake_subproject_declare(therock-fftw3
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
   CMAKE_ARGS
     -DBUILD_SHARED_LIBS=ON
-    -DENABLE_THREADS=${FFTW3_ENABLE_THREADS}
+    -DENABLE_THREADS=${_fftw3_enable_threads}
 )
 therock_cmake_subproject_provide_package(therock-fftw3 FFTW3 lib/cmake/fftw3)
 therock_cmake_subproject_activate(therock-fftw3)
 
 add_dependencies(therock-third-party therock-fftw3)
-
-therock_provide_artifact(fftw3
-  DESCRIPTOR artifact_fftw3.toml
-  TARGET_NEUTRAL
-  COMPONENTS
-    dbg
-    dev
-    doc
-    lib
-    run
-  SUBPROJECT_DEPS therock-fftw3
-)
 
 therock_cmake_subproject_declare(therock-fftw3f
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/build_fftw3f"
@@ -49,15 +37,15 @@ therock_cmake_subproject_declare(therock-fftw3f
   CMAKE_ARGS
     -DENABLE_FLOAT=ON
     -DBUILD_SHARED_LIBS=ON
-    -DENABLE_THREADS=${FFTW3_ENABLE_THREADS}
+    -DENABLE_THREADS=${_fftw3_enable_threads}
 )
 therock_cmake_subproject_provide_package(therock-fftw3f FFTW3f lib/cmake/fftw3f)
 therock_cmake_subproject_activate(therock-fftw3f)
 
 add_dependencies(therock-third-party therock-fftw3f)
 
-therock_provide_artifact(fftw3f
-  DESCRIPTOR artifact_fftw3f.toml
+therock_provide_artifact(fftw3
+  DESCRIPTOR artifact_fftw3.toml
   TARGET_NEUTRAL
   COMPONENTS
     dbg
@@ -65,5 +53,5 @@ therock_provide_artifact(fftw3f
     doc
     lib
     run
-  SUBPROJECT_DEPS therock-fftw3f
+  SUBPROJECT_DEPS therock-fftw3 therock-fftw3f
 )

--- a/third-party/fftw3/artifact_fftw3.toml
+++ b/third-party/fftw3/artifact_fftw3.toml
@@ -1,0 +1,5 @@
+# fftw
+[components.dbg."third-party/fftw/stage"]
+[components.dev."third-party/fftw/stage"]
+[components.doc."third-party/fftw/stage"]
+[components.lib."third-party/fftw/stage"]

--- a/third-party/fftw3/artifact_fftw3.toml
+++ b/third-party/fftw3/artifact_fftw3.toml
@@ -1,5 +1,11 @@
-# fftw
-[components.dbg."third-party/fftw/stage"]
-[components.dev."third-party/fftw/stage"]
-[components.doc."third-party/fftw/stage"]
-[components.lib."third-party/fftw/stage"]
+# fftw3
+[components.dbg."third-party/fftw3/stage"]
+[components.dev."third-party/fftw3/stage"]
+[components.doc."third-party/fftw3/stage"]
+[components.lib."third-party/fftw3/stage"]
+
+# fftw3f
+[components.dbg."third-party/fftwf3/stage"]
+[components.dev."third-party/fftwf3/stage"]
+[components.doc."third-party/fftwf3/stage"]
+[components.lib."third-party/fftwf3/stage"]

--- a/third-party/fftw3/artifact_fftw3f.toml
+++ b/third-party/fftw3/artifact_fftw3f.toml
@@ -1,0 +1,5 @@
+# fftwf
+[components.dbg."third-party/fftwf/stage"]
+[components.dev."third-party/fftwf/stage"]
+[components.doc."third-party/fftwf/stage"]
+[components.lib."third-party/fftwf/stage"]

--- a/third-party/fftw3/artifact_fftw3f.toml
+++ b/third-party/fftw3/artifact_fftw3f.toml
@@ -1,5 +1,0 @@
-# fftwf
-[components.dbg."third-party/fftwf/stage"]
-[components.dev."third-party/fftwf/stage"]
-[components.doc."third-party/fftwf/stage"]
-[components.lib."third-party/fftwf/stage"]


### PR DESCRIPTION
Add the latest 3.3.10 fftw3 (double precision) and fftw3f (float/single precision) libraries to TheRock.
Libraries are build with the multi-thread support.

Libraries are also build with the cmake and in this way they will automatically include the
FFTW3Configure.cmake and FFTW3fConfigure.cmake and other related cmake files that can
be used by cmake to find these libraries. When libraries are found, these scripts set variables like
FFTW3_FOUND and FFTW3f_FOUND and target properties FFTW3::fftw3 and FFTW3::fftw3f.

These cmake helper files are not produced if the fftw is build with the 
autoconf/configure/make way which is the reason why they are not included
in the fftw-packages that many linux distributions provide.
In those cases applications often use custom FindFFTW.cmake where the variables set
are different. (For exampe FFTW_FOUND instead of the FFTW3_FOUND, FFTW_LIBRARY_DIRS, etc...)