### PR TITLE
Add progress printing for git submodule updates

### DIFF
--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -312,10 +312,10 @@ def main(argv):
         "--depth", type=int, help="Git depth when updating submodules", default=None
     )
     parser.add_argument(
-        "--progress", 
+        "--progress",
         default=False,
-        action='store_true',
-        help="Git progress displayed when updating submodules", 
+        action="store_true",
+        help="Git progress displayed when updating submodules",
     )
     parser.add_argument(
         "--jobs",


### PR DESCRIPTION
## Motivation

By default git submodule does not display download progress. This small feature allows users to monitor downloads to insure downloads have not stalled. This is a benefit for the larger submodules that can take some time to download.

## Technical Details

This patch adds an option, --progress, to the script arguments. When passed to the python script it is added to arguments passed to the submodule command.

## Test Plan

Tested running fetch sources with the --progress flag passed.

## Test Result

Flag works as intended.
