### PR TITLE
Build torch with NUMA disabled

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -608,6 +608,7 @@ def do_build_pytorch(
     env["USE_ROCM"] = "ON"
     env["USE_CUDA"] = "OFF"
     env["USE_MPI"] = "OFF"
+    env["USE_NUMA"] = "OFF"
     env["PYTORCH_BUILD_VERSION"] = pytorch_build_version
     env["PYTORCH_BUILD_NUMBER"] = args.pytorch_build_number
 


### PR DESCRIPTION
So far torch was build without NUMA
```
CMake Warning at cmake/Dependencies.cmake:777 (message):
  Not compiling with NUMA.  Suppress this warning with -DUSE_NUMA=OFF
Call Stack (most recent call first):
  CMakeLists.txt:868 (include)

-- Could NOT find Numa (missing: Numa_INCLUDE_DIR Numa_LIBRARIES)
```

Commit b414a97 added `numactl-devel` to the Dockerfile and commit bd454a7 update the workflows to use the new Docker image. With these changes, torch is picking up the system installed NUMA:
```
-- Found Numa: /usr/include
-- Found Numa  (include: /usr/include, library: /usr/lib64/libnuma.so)
```
While building passes, running torch fails with
```
    import torch
.venv/lib/python3.11/site-packages/torch/__init__.py:424: in <module>
    from torch._C import *  # noqa: F403
E   ImportError: libnuma.so.1: cannot open shared object file: No such file or directory
```
if `libnuma.so.1` is not installed as the system installed libnuma is expected and not the one bundled with TheRock.

This should bring back the old behavior by explicitly deactivating build with NUMA. To enable NUMA, one needs to teach torch to pick up TheRock's bundled sysdep.