### PR TITLE
[ci] Misc improvements to install_rocm_from_artifacts.py.

### DIFF
--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -156,7 +156,7 @@ def retrieve_artifacts_by_run_id(args):
     else:
         argv.append("--all")
 
-    log(f"Calling fetch_artifacts_main with args:\n  {' '.join(argv)}]")
+    log(f"Calling fetch_artifacts_main with args:\n  {' '.join(argv)}")
     fetch_artifacts_main(argv)
 
     log(f"Retrieved artifacts for run ID {run_id}")

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -1,30 +1,57 @@
 #!/usr/bin/env python
 """install_rocm_from_artifacts.py
 
-This script helps CI workflows, developers and testing suites easily install TheRock to their environment using artifacts.
-It installs TheRock to an output directory from one of these sources:
-- GitHub CI workflow run
-- Release tag
-- An existing installation of TheRock
+This script helps CI workflows, developers and testing suites easily install
+TheRock to their environment using artifacts. It installs TheRock to an output
+directory from one of these sources:
+
+  - GitHub CI workflow run
+  - Release tag
+  - An existing installation of TheRock
 
 Usage:
-python build_tools/install_rocm_from_artifacts.py [--output-dir OUTPUT_DIR] [--amdgpu-family AMDGPU_FAMILY] (--run-id RUN_ID | --release RELEASE | --input-dir INPUT_DIR)
-                                        [--blas | --no-blas] [--fft | --no-fft] [--miopen | --no-miopen] [--prim | --no-prim]
-                                        [--rand | --no-rand] [--rccl | --no-rccl] [--tests | --no-tests] [--base-only]
+python build_tools/install_rocm_from_artifacts.py
+    [--output-dir OUTPUT_DIR]
+    [--amdgpu-family AMDGPU_FAMILY]
+    (--run-id RUN_ID | --release RELEASE | --input-dir INPUT_DIR)
+    [--blas | --no-blas] [--fft | --no-fft] [--miopen | --no-miopen] [--prim | --no-prim]
+    [--rand | --no-rand] [--rccl | --no-rccl] [--tests | --no-tests] [--base-only]
 
 Examples:
-- Downloads and unpacks the gfx94X S3 artifacts from GitHub CI workflow run 14474448215 (from https://github.com/ROCm/TheRock/actions/runs/14474448215) to the default output directory `therock-build`:
-    - `python build_tools/install_rocm_from_artifacts.py --run-id 14474448215 --amdgpu-family gfx94X-dcgpu --tests`
-- Downloads and unpacks the version `6.4.0rc20250416` gfx110X artifacts from release tag `nightly-tarball` to the specified output directory `build`:
-    - `python build_tools/install_rocm_from_artifacts.py --release 6.4.0rc20250416 --amdgpu-family gfx110X-dgpu --output-dir build`
-- Downloads and unpacks the version `6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9` gfx120X artifacts from release tag `dev-tarball` to the default output directory `therock-build`:
-    - `python build_tools/install_rocm_from_artifacts.py --release 6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9 --amdgpu-family gfx120X-all`
+- Downloads and unpacks the gfx94X S3 artifacts from GitHub CI workflow run 14474448215
+  (from https://github.com/ROCm/TheRock/actions/runs/14474448215) to the
+  default output directory `therock-build`:
+    ```
+    python build_tools/install_rocm_from_artifacts.py \
+        --run-id 14474448215 \
+        --amdgpu-family gfx94X-dcgpu \
+        --tests
+    ```
+- Downloads and unpacks the version `6.4.0rc20250416` gfx110X artifacts from
+  release tag `nightly-tarball` to the specified output directory `build`:
+    ```
+    python build_tools/install_rocm_from_artifacts.py \
+        --release 6.4.0rc20250416 \
+        --amdgpu-family gfx110X-dgpu \
+        --output-dir build
+    ```
+- Downloads and unpacks the version `6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9`
+  gfx120X artifacts from release tag `dev-tarball` to the default output directory `therock-build`:
+    ```
+    python build_tools/install_rocm_from_artifacts.py \
+        --release 6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9 \
+        --amdgpu-family gfx120X-all
+    ```
 
-You can select your AMD GPU family from this file https://github.com/ROCm/TheRock/blob/59c324a759e8ccdfe5a56e0ebe72a13ffbc04c1f/cmake/therock_amdgpu_targets.cmake#L44-L81
+You can select your AMD GPU family from therock_amdgpu_targets.cmake.
 
-By default for CI workflow retrieval, all artifacts (excluding test artifacts) will be downloaded. For specific artifacts, pass in the flag such as `--rand` (RAND artifacts) For test artifacts, pass in the flag `--tests` (test artifacts). For base artifacts only, pass in the flag `--base-only`
+By default for CI workflow retrieval, all artifacts (excluding test artifacts)
+will be downloaded. For specific artifacts, pass in the flag such as `--rand`
+(RAND artifacts) For test artifacts, pass in the flag `--tests` (test artifacts).
+For base artifacts only, pass in the flag `--base-only`
 
-Note: the script will overwrite the output directory argument. If no argument is passed, it will overwrite the default "therock-build" directory.
+Note: the script will overwrite the output directory argument. If no argument
+is passed, it will overwrite the default "therock-build" directory.
 """
 
 import argparse
@@ -32,8 +59,6 @@ import boto3
 from botocore import UNSIGNED
 from botocore.config import Config
 from fetch_artifacts import main as fetch_artifacts_main
-
-import os
 from pathlib import Path
 import platform
 import re
@@ -55,7 +80,7 @@ def log(*args, **kwargs):
     sys.stdout.flush()
 
 
-def _untar_files(output_dir, destination):
+def _untar_files(output_dir: Path, destination: Path):
     """
     Retrieves all tar files in the output_dir, then extracts all files to the output_dir
     """
@@ -65,20 +90,19 @@ def _untar_files(output_dir, destination):
     destination.unlink()
 
 
-def _create_output_directory(args):
+def _create_output_directory(output_dir: Path):
     """
     If the output directory already exists, delete it and its contents.
     Then, create the output directory.
     """
-    output_dir_path = args.output_dir
-    log(f"Creating directory {output_dir_path}")
-    if os.path.isdir(output_dir_path):
+    log(f"Creating output directory '{output_dir.resolve()}'")
+    if output_dir.is_dir():
         log(
-            f"Directory {output_dir_path} already exists, removing existing directory and files"
+            f"Directory '{output_dir}' already exists, removing existing directory and files"
         )
-        shutil.rmtree(output_dir_path)
-    os.mkdir(output_dir_path)
-    log(f"Created directory {output_dir_path}")
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+    log(f"Created output directory '{output_dir.resolve()}'")
 
 
 def _retrieve_s3_release_assets(
@@ -132,7 +156,9 @@ def retrieve_artifacts_by_run_id(args):
     else:
         argv.append("--all")
 
+    log(f"Calling fetch_artifacts_main with args:\n  {' '.join(argv)}]")
     fetch_artifacts_main(argv)
+
     log(f"Retrieved artifacts for run ID {run_id}")
 
 
@@ -201,7 +227,7 @@ def retrieve_artifacts_by_input_dir(args):
 
 def run(args):
     log("### Installing TheRock using artifacts ###")
-    _create_output_directory(args)
+    _create_output_directory(args.output_dir)
     if args.run_id:
         retrieve_artifacts_by_run_id(args)
     elif args.release:


### PR DESCRIPTION
Some changes I made while working on https://github.com/ROCm/TheRock/issues/1559. I tried to use this script via [`.github/actions/setup_test_environment/action.yml`](https://github.com/ROCm/TheRock/blob/main/.github/actions/setup_test_environment/action.yml) but I ended up using [`build_tools/fetch_artifacts.py`](https://github.com/ROCm/TheRock/blob/main/build_tools/fetch_artifacts.py) instead.

Changes:

* Add more logging
* Add more type hints
* Reflow comments
* Mkdir with parents=True