### PR TITLE
Skip cache uploads if jobs are cancelled.

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -254,7 +254,7 @@ jobs:
 
       - name: Save cache
         uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           path: ${{ env.OUTPUT_DIR }}/caches
           key: portable-linux-package-matrix-v1-${{ matrix.target_bundle.amdgpu_family }}-${{ github.sha }}

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -306,7 +306,7 @@ jobs:
 
       - name: Save cache
         uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           path: ${{ env.CACHE_DIR }}
           key: windows-package-matrix-v1-${{ matrix.target_bundle.amdgpu_family }}-${{ github.sha }}


### PR DESCRIPTION
We sometimes cancel jobs to free up CI resources. In those cases we don't typically want to spend a few minutes uploading partial caches from cancelled builds.