### PR TITLE
Fetch binaries as part of `--base-only`.

### DIFF
--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -244,6 +244,7 @@ def filter_base_artifacts(
         "core-runtime_run",
         "core-runtime_lib",
         "sysdeps_lib",
+        "base_run",
         "base_lib",
         "amd-llvm_run",
         "amd-llvm_lib",


### PR DESCRIPTION
The `--base-only` option missed to fetch run files for tools like rocm-smi and amd-smi.