### PR TITLE
Introduce build_*_python_packages.yml workflows.

### DIFF
--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -1,0 +1,87 @@
+name: Build Portable Linux Python Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: "17865324892" # TODO: default to the most recent successful run (using a script)
+      amdgpu_family:
+        type: choice
+        options:
+          - gfx110X-dgpu
+          - gfx1151
+          - gfx120X-all
+          - gfx94X-dcgpu
+          - gfx950-dcgpu
+        default: gfx94X-dcgpu
+      # TODO: scripts and/or reusable workflow for versions and release types
+      package_version:
+        type: string
+        default: "7.0.0.dev0"
+  workflow_call:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: ""
+      amdgpu_family:
+        type: string
+      package_version:
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build | ${{ inputs.amdgpu_family }}
+    # Note: GitHub-hosted runners run out of disk space for some gpu families
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+    env:
+      BUILD_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:3ac188c17f88f08ce522297b616d8308361b8e9a9b31bcc3c3bbb9429b1efa6c
+      ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
+      ARTIFACTS_DIR: "${{ github.workspace }}/artifacts"
+      PACKAGES_DIR: "${{ github.workspace }}/packages"
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12'
+      - name: Install Python requirements
+        run: pip install boto3 packaging piprepo setuptools
+
+      # Note: we could fetch "all" artifacts if we wanted to include more files
+      - name: Fetch artifacts
+        env:
+          IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          python ./build_tools/fetch_artifacts.py \
+            --run-id=${{ env.ARTIFACT_RUN_ID }} \
+            --target=${{ inputs.amdgpu_family }} \
+            --output-dir=${{ env.ARTIFACTS_DIR }} \
+            _dev_ _lib_ _run_
+
+      - name: Build Python packages
+        run: |
+          ./build_tools/linux_portable_build.py \
+            --image=${{ env.BUILD_IMAGE }} \
+            --output-dir=${{ env.PACKAGES_DIR }} \
+            --artifact-dir=${{ env.ARTIFACTS_DIR }} \
+            --build-python-only \
+            -- \
+            "--version=${{ inputs.package_version }}"
+
+      - name: Inspect Python packages
+        run: |
+          ls -la "${{ env.PACKAGES_DIR }}"
+
+      # TODO(#1559): Sanity check (Linux can't find the directories, maybe Docker issues?)
+
+      # - name: Sanity check Python packages
+      #   run: |
+      #     piprepo build "${{ env.PACKAGES_DIR }}/dist"
+      #     pip install rocm[devel]==${{ inputs.package_version }} \
+      #       --extra-index-url "${{ env.PACKAGES_DIR }}/dist/simple/"
+      #     rocm-sdk test
+
+      # TODO(#1559): upload packages to artifacts S3 bucket and/or a dedicated Python packages bucket

--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -1,0 +1,83 @@
+name: Build Windows Python Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: "17865324892" # TODO: default to the most recent successful run (using a script)
+      amdgpu_family:
+        type: choice
+        options:
+          - gfx110X-dgpu
+          - gfx1151
+          - gfx120X-all
+          - gfx94X-dcgpu
+          - gfx950-dcgpu
+        default: gfx1151
+      # TODO: scripts and/or reusable workflow for versions and release types
+      package_version:
+        type: string
+        default: "7.0.0.dev0"
+  workflow_call:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: ""
+      amdgpu_family:
+        type: string
+      package_version:
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build | ${{ inputs.amdgpu_family }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-windows-scale-rocm' || 'windows-2022' }}
+    env:
+      ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
+      ARTIFACTS_DIR: "${{ github.workspace }}/artifacts"
+      PACKAGES_DIR: "${{ github.workspace }}/packages"
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12'
+      - name: Install Python requirements
+        run: pip install boto3 packaging piprepo setuptools
+
+      # Note: we could fetch "all" artifacts if we wanted to include more files
+      - name: Fetch artifacts
+        env:
+          IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          python ./build_tools/fetch_artifacts.py \
+            --run-id=${{ env.ARTIFACT_RUN_ID }} \
+            --target=${{ inputs.amdgpu_family }} \
+            --output-dir="${{ env.ARTIFACTS_DIR }}" \
+            _dev_ _lib_ _run_
+
+      - name: Build Python packages
+        run: |
+          python ./build_tools/build_python_packages.py \
+            --artifact-dir="${{ env.ARTIFACTS_DIR }}" \
+            --dest-dir="${{ env.PACKAGES_DIR }}" \
+            --version=${{ inputs.package_version }}
+
+      - name: Inspect Python packages
+        run: |
+          ls -la "${{ env.PACKAGES_DIR }}"
+
+      - name: Sanity check Python packages
+        run: |
+          piprepo build "${{ env.PACKAGES_DIR }}/dist"
+          pip install rocm[libraries,devel]==${{ inputs.package_version }} \
+            --extra-index-url "${{ env.PACKAGES_DIR }}/dist/simple/"
+          rocm-sdk test
+
+      # TODO(#1559): upload packages to artifacts S3 bucket and/or a dedicated Python packages bucket

--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -97,10 +97,11 @@ def log(*args, **kwargs):
     sys.stdout.flush()
 
 
-def retrieve_s3_artifacts(run_id, amdgpu_family):
+def retrieve_s3_artifacts(run_id: str, amdgpu_family: str):
     """Checks that the AWS S3 bucket exists and returns artifact names."""
     EXTERNAL_REPO, BUCKET = retrieve_bucket_info()
     s3_directory_path = f"{EXTERNAL_REPO}{run_id}-{PLATFORM}/"
+    log(f"Retrieving S3 artifacts for {run_id} in '{BUCKET}' at '{s3_directory_path}'")
     page_iterator = paginator.paginate(Bucket=BUCKET, Prefix=s3_directory_path)
     data = set()
     for page in page_iterator:
@@ -114,6 +115,8 @@ def retrieve_s3_artifacts(run_id, amdgpu_family):
                 ):
                     file_name = artifact_key.split("/")[-1]
                     data.add(file_name)
+    if not data:
+        log(f"Found no S3 artifacts for {run_id} at '{s3_directory_path}'")
     return data
 
 


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/1559 and https://github.com/ROCm/TheRock/issues/1522. This gets us closer to having modular workflows for the full set of build and packaging tasks outlined in the [Overall build architecture diagram](https://github.com/ROCm/TheRock/blob/main/docs/development/development_guide.md#overall-build-architecture).


### Current CI / CD workflow setup

CI (on pull requests and commits):
```mermaid
graph TD;
build_packages --> test_packages
subgraph test_packages
  test_hipblaslt
  test_rocblas
end
```

Nightly releases:
```mermaid
graph TD;
build["build artifacts, build python packages, upload both"]
build_pytorch
build -. "workflow dispatch" .-> build_pytorch
build_pytorch --> test_pytorch
test_pytorch --> upload_pytorch
```

### Next step with this incremental improvement

CI (on pull requests and commits):
```mermaid
graph TD;
build_artifacts --> test_artifacts
subgraph test_artifacts
  test_hipblaslt
  test_rocblas
end
build_artifacts --> build_python_packages
```

Nightly releases:
```mermaid
graph TD;
build_artifacts
build_artifacts --> build_python_packages
build_python_packages -. "workflow dispatch" .-> build_pytorch
build_pytorch --> test_pytorch
test_pytorch --> upload_pytorch
```

## Technical Details

This introduces workflows for Linux and Windows which

1. Download build artifacts (see [artifacts.md](https://github.com/ROCm/TheRock/blob/main/docs/development/artifacts.md))
2. Build ROCm Python packages (see [python_packaging.md](https://github.com/ROCm/TheRock/blob/main/docs/packaging/python_packaging.md))
3. Install those Python packages, then run `rocm-sdk test`

A few things are missing to realize the workflow changes in the diagrams above:

* Plumbing and defaults for `artifact_run_id` and `package_version`
* Uploading the built Python packages somewhere (always artifacts bucket, then optionally copy to a python release bucket?)
* (stretch) Running more than sanity checks of the wheels, testing on GPU machines instead of CPU build machines
* (stretch) Ergonomics changes to `retrieve_bucket_info()` to allow for forks to download artifacts from ROCm/TheRock and skip uploading (the code currently assumes workflows run as part of a complete pipeline)

## Test Plan

Triggered runs in my fork, **with some other changes for easier testing**:
* Windows: https://github.com/ScottTodd/TheRock/actions/runs/18021519232/job/51279731246
* Linux: https://github.com/ScottTodd/TheRock/actions/runs/18021518447/job/51279728891

Once landed in this repository I'll also test with our self-hosted runners and connect these new workflows to other workflows.

## Test Result

Runs in my fork succeeded (or close enough).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
