### PR TITLE
Disable FBGEMM_GENAI and Flash Attention (AOTriton) by Default in Linux Torch Builds

### DIFF
--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -28,12 +28,13 @@ This incorporates advice from:
 
 ### Project and feature support status
 
-| Project / feature              | Linux support | Windows support |
-| ------------------------------ | ------------- | --------------- |
-| torch                          | ✅ Supported  | ✅ Supported    |
-| torchaudio                     | ✅ Supported  | ✅ Supported    |
-| torchvision                    | ✅ Supported  | ✅ Supported    |
-| Flash attention via [ao]triton | ✅ Supported  | ✅ Supported    |
+| Project / feature              | Linux support                              | Windows support |
+| ------------------------------ | ------------------------------------------ | --------------- |
+| torch                          | ✅ Supported                               | ✅ Supported    |
+| torchaudio                     | ✅ Supported                               | ✅ Supported    |
+| torchvision                    | ✅ Supported                               | ✅ Supported    |
+| Flash attention via [ao]triton | ✅ Supported                               | ✅ Supported    |
+|                                | (only for versions < 2.10, disabled ≥2.10) |                 |
 
 ### Supported PyTorch versions
 

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -605,7 +605,7 @@ def do_build_pytorch(
 
     # Enable/disable only for non-Windows
     if not is_windows:
-        if "2.7" in str(args.pytorch_version):
+        if "2.7" in str(pytorch_build_version):
             env["USE_FBGEMM_GENAI"] = "ON"
             use_flash_attention = (
                 "1" if args.enable_pytorch_flash_attention_linux else "0"

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -609,12 +609,12 @@ def do_build_pytorch(
     match = re.match(r"^(\d+)\.(\d+)", pytorch_ver)
     if not match:
         raise ValueError(f"Could not parse version from {pytorch_build_version}")
-    pytorch_version = float(f"{major}.{minor}")
+    major, minor = map(int, match.groups())
 
-    ## Disable only for Linux on 2.10 Pytorch version
+    ## Disable FBGEMM_GENAI and flash_attention only for Linux on 2.10 and higher Pytorch version
     ## https://github.com/ROCm/TheRock/issues/1619
     if not is_windows:
-        if pytorch_version < 2.10:
+        if (major, minor) < (2, 10):
             env["USE_FBGEMM_GENAI"] = "ON"
             use_flash_attention = (
                 "1" if args.enable_pytorch_flash_attention_linux else "0"


### PR DESCRIPTION
## PR Description: Temporary Fix for Linux PyTorch Builds

### Problem

Linux PyTorch builds are failing due to:

1. FBGEMM_GENAI: CMake errors when enabled.
2. AOTriton / Flash Attention: Requires `liblzma` (via `xz` and `xz-devel`), causing build failures.

### Fix

* Disable FBGEMM_GENAI by default.
* Disable Flash Attention (AOTriton) on Linux by default (`USE_FLASH_ATTENTION=0`).
* Plan to bundle `xz`/`xz-devel` with TheRock in future updates to resolve the Triton dependency.

### Outcome

These changes unblock Linux PyTorch builds while upstream issues are addressed.

### Related Issue

#1408 
