### PR TITLE
[ci] Enable disabled hipBLASLt tests 

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
@@ -23,19 +23,5 @@ logging.basicConfig(level=logging.INFO)
 
 cmd = [f"{THEROCK_BIN_DIR}/hipblaslt-test", "--gtest_filter=*pre_checkin*"]
 
-tests_to_exclude = {
-    # Related issue: https://github.com/ROCm/TheRock/issues/1114
-    "gfx1151": {
-        "windows": ["_/aux_test.conversion/pre_checkin_aux_auxiliary_func_f16_r"]
-    }
-}
-
-if AMDGPU_FAMILIES in tests_to_exclude and PLATFORM in tests_to_exclude.get(
-    AMDGPU_FAMILIES, {}
-):
-    exclusion_list = ":".join(tests_to_exclude[AMDGPU_FAMILIES][PLATFORM])
-    cmd.append(f"--gtest_filter=-{exclusion_list}")
-
-
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 subprocess.run(cmd, cwd=THEROCK_DIR, check=True, env=envion_vars)


### PR DESCRIPTION
#1114 is fixed! 

Working here: https://github.com/ROCm/TheRock/actions/runs/18023622950

Removing exclude logic as no longer needed for hipBLASLt. The tests still run into an occasional GPU hang but that is a separate and known issue