### PR TITLE
[ci] Rename workflow relating to artifacts.

### DIFF
--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -1,4 +1,4 @@
-name: Build Linux Packages
+name: Build Portable Linux Artifacts
 
 on:
   workflow_dispatch:
@@ -8,6 +8,7 @@ on:
         default: ADHOCBUILD
       amdgpu_families:
         type: string
+        default: gfx94X-dcgpu
       expect_failure:
         type: boolean
         default: false
@@ -32,8 +33,8 @@ permissions:
   contents: read
 
 jobs:
-  build_linux_packages:
-    name: Build Linux Packages (xfail ${{ inputs.expect_failure }})
+  build_portable_linux_artifacts:
+    name: Build Artifacts (xfail ${{ inputs.expect_failure }})
     runs-on: azure-linux-scale-rocm
     continue-on-error: ${{ inputs.expect_failure }}
     permissions:
@@ -94,8 +95,8 @@ jobs:
         run: |
           python3 build_tools/github_actions/build_configure.py
 
-      - name: Build therock-dist
-        run: cmake --build build --target therock-dist therock-archives -- -k 0
+      - name: Build therock-archives and therock-dist
+        run: cmake --build build --target therock-archives therock-dist -- -k 0
 
       - name: Test Packaging
         if: ${{ github.event.repository.name == 'TheRock' }}

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -1,4 +1,4 @@
-name: Build Windows Packages
+name: Build Windows Artifacts
 
 on:
   workflow_dispatch:
@@ -30,8 +30,8 @@ permissions:
   contents: read
 
 jobs:
-  build_windows_packages:
-    name: Build Windows Packages (xfail ${{ inputs.expect_failure }})
+  build_windows_artifacts:
+    name: Build Artifacts (xfail ${{ inputs.expect_failure }})
     runs-on: azure-windows-scale-rocm
     continue-on-error: ${{ inputs.expect_failure }}
     permissions:
@@ -117,8 +117,8 @@ jobs:
           ccache -z
           python3 build_tools/github_actions/build_configure.py
 
-      - name: Build therock-dist
-        run: cmake --build "${{ env.BUILD_DIR }}" --target therock-dist therock-archives -- -k 0
+      - name: Build therock-archives and therock-dist
+        run: cmake --build "${{ env.BUILD_DIR }}" --target therock-archives therock-dist -- -k 0
 
       - name: Report
         if: ${{ !cancelled() }}

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -123,7 +123,7 @@ jobs:
           python build_tools/github_actions/python_to_cp_version.py \
             --python-version ${{ inputs.python_version }}
 
-      # TODO(amd-justchen): share with build_windows_packages.yml. Include in VM image? Dockerfile?
+      # TODO(amd-justchen): share with build_windows_artifacts.yml. Include in VM image? Dockerfile?
       - name: Install requirements
         run: |
           choco install --no-progress -y ninja --version 1.13.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       test_runs_on: ${{ matrix.families.test-runs-on }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
       expect_failure: ${{ matrix.families.expect_failure == true }}
-      linux_use_prebuilt_artifacts: ${{ inputs.linux_use_prebuilt_artifacts == true && 'true' || 'false' }}
+      use_prebuilt_artifacts: ${{ inputs.linux_use_prebuilt_artifacts == true && 'true' || 'false' }}
     permissions:
       contents: read
       id-token: write
@@ -102,7 +102,7 @@ jobs:
       artifact_run_id: ${{ inputs.artifact_run_id }}
       extra_cmake_options: ${{ matrix.extra_cmake_options }}
       expect_failure: ${{ matrix.families.expect_failure == true }}
-      windows_use_prebuilt_artifacts: ${{ inputs.windows_use_prebuilt_artifacts == true && 'true' || 'false' }}
+      use_prebuilt_artifacts: ${{ inputs.windows_use_prebuilt_artifacts == true && 'true' || 'false' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -11,17 +11,17 @@ on:
         type: string
       expect_failure:
         type: boolean
-      linux_use_prebuilt_artifacts:
+      use_prebuilt_artifacts:
         type: string
 
 permissions:
   contents: read
 
 jobs:
-  build_linux_packages:
+  build_portable_linux_artifacts:
     name: Build
-    if: ${{ inputs.linux_use_prebuilt_artifacts == 'false' }}
-    uses: ./.github/workflows/build_linux_packages.yml
+    if: ${{ inputs.use_prebuilt_artifacts == 'false' }}
+    uses: ./.github/workflows/build_portable_linux_artifacts.yml
     secrets: inherit
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
@@ -31,17 +31,17 @@ jobs:
       id-token: write
 
   test_linux_packages:
-    needs: [build_linux_packages]
+    needs: [build_portable_linux_artifacts]
     name: Test
     # If the dependent job failed/cancelled, this job will not be run
-    # The linux_use_prebuilt_artifacts "or" statement ensures that tests will run if previous build step is run or skipped.concurrency.
+    # The use_prebuilt_artifacts "or" statement ensures that tests will run if previous build step is run or skipped.concurrency.
     if: >-
       ${{
         !failure() &&
         !cancelled() &&
         (
-          inputs.linux_use_prebuilt_artifacts == 'false' ||
-          inputs.linux_use_prebuilt_artifacts == 'true'
+          inputs.use_prebuilt_artifacts == 'false' ||
+          inputs.use_prebuilt_artifacts == 'true'
         )
       }}
     strategy:

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read
       id-token: write
 
-  test_linux_packages:
+  test_linux_artifacts:
     needs: [build_portable_linux_artifacts]
     name: Test
     # If the dependent job failed/cancelled, this job will not be run
@@ -46,7 +46,7 @@ jobs:
       }}
     strategy:
       fail-fast: false
-    uses: ./.github/workflows/test_packages.yml
+    uses: ./.github/workflows/test_artifacts.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       test_runs_on: ${{ inputs.test_runs_on }}

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -65,7 +65,7 @@ jobs:
       test_runs_on: ${{ matrix.families.test-runs-on }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
       expect_failure: ${{ matrix.families.expect_failure == true }}
-      linux_use_prebuilt_artifacts: ${{ inputs.linux_use_prebuilt_artifacts == true && 'true' || 'false' }}
+      use_prebuilt_artifacts: ${{ inputs.linux_use_prebuilt_artifacts == true && 'true' || 'false' }}
     permissions:
       contents: read
       id-token: write
@@ -89,7 +89,7 @@ jobs:
       artifact_run_id: ${{ inputs.artifact_run_id }}
       extra_cmake_options: ${{ matrix.extra_cmake_options }}
       expect_failure: ${{ matrix.families.expect_failure == true }}
-      windows_use_prebuilt_artifacts: ${{ inputs.windows_use_prebuilt_artifacts == true && 'true' || 'false' }}
+      use_prebuilt_artifacts: ${{ inputs.windows_use_prebuilt_artifacts == true && 'true' || 'false' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -11,7 +11,7 @@ on:
         type: string
       expect_failure:
         type: boolean
-      windows_use_prebuilt_artifacts:
+      use_prebuilt_artifacts:
         type: string
       extra_cmake_options:
         type: string
@@ -21,10 +21,10 @@ permissions:
   contents: read
 
 jobs:
-  build_windows_packages:
+  build_windows_artifacts:
     name: Build
-    if: ${{ inputs.windows_use_prebuilt_artifacts == 'false' }}
-    uses: ./.github/workflows/build_windows_packages.yml
+    if: ${{ inputs.use_prebuilt_artifacts == 'false' }}
+    uses: ./.github/workflows/build_windows_artifacts.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       extra_cmake_options: ${{ inputs.extra_cmake_options }}
@@ -34,17 +34,17 @@ jobs:
       id-token: write
 
   test_windows_packages:
-    needs: [build_windows_packages]
+    needs: [build_windows_artifacts]
     name: Test
     # If the dependent job failed/cancelled, this job will not be run
-    # The windows_use_prebuilt_artifacts "or" statement ensures that tests will run if previous build step is run or skipped.concurrency.
+    # The use_prebuilt_artifacts "or" statement ensures that tests will run if previous build step is run or skipped.concurrency.
     if: >-
       ${{
         !failure() &&
         !cancelled() &&
         (
-          inputs.windows_use_prebuilt_artifacts == 'false' ||
-          inputs.windows_use_prebuilt_artifacts == 'true'
+          inputs.use_prebuilt_artifacts == 'false' ||
+          inputs.use_prebuilt_artifacts == 'true'
         )
       }}
     strategy:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -33,7 +33,7 @@ jobs:
       contents: read
       id-token: write
 
-  test_windows_packages:
+  test_windows_artifacts:
     needs: [build_windows_artifacts]
     name: Test
     # If the dependent job failed/cancelled, this job will not be run
@@ -49,7 +49,7 @@ jobs:
       }}
     strategy:
       fail-fast: false
-    uses: ./.github/workflows/test_packages.yml
+    uses: ./.github/workflows/test_artifacts.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       test_runs_on: ${{ inputs.test_runs_on }}

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           pip install -r requirements.txt
 
-      # TODO(amd-justchen): share with build_windows_packages.yml. Include in VM image? Dockerfile?
+      # TODO(amd-justchen): share with build_windows_artifacts.yml. Include in VM image? Dockerfile?
       - name: Install requirements
         run: |
           choco install --no-progress -y ccache
@@ -175,7 +175,6 @@ jobs:
       - name: Configure MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      # TODO(#762): Move to script and share with build_windows_packages.yml.
       - name: Runner health status
         run: |
           ccache --zero-stats

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -1,4 +1,4 @@
-name: Test Packages
+name: Test Artifacts
 
 on:
   workflow_dispatch:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -92,9 +92,9 @@ SKIPPABLE_PATH_PATTERNS = [
     # At time of writing, workflows run in this sequence:
     #   `ci.yml`
     #   `ci_linux.yml`
-    #   `build_linux_packages.yml`
-    #   `test_linux_packages.yml`
-    #   `test_[rocm subproject].yml`
+    #   `build_linux_artifacts.yml`
+    #   `test_artifacts.yml`
+    #   `test_component.yml`
     # If we add external-builds tests there, we can revisit this, maybe leaning
     # on options like LINUX_USE_PREBUILT_ARTIFACTS or sufficient caching to keep
     # workflows efficient when only nodes closer to the edges of the build graph
@@ -120,9 +120,10 @@ def check_for_non_skippable_path(paths: Optional[Iterable[str]]) -> bool:
 GITHUB_WORKFLOWS_CI_PATTERNS = [
     "setup.yml",
     "ci*.yml",
-    "build*package*.yml",
-    "test*packages.yml",
-    "test*.yml",  # This may be too broad, but there are many test workflows.
+    "build*artifact*.yml",
+    "test*artifacts.yml",
+    "test_sanity_check.yml",
+    "test_component.yml",
 ]
 
 

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -44,15 +44,21 @@ class ConfigureCITest(unittest.TestCase):
         paths = [".github/workflows/ci.yml"]
         run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
         self.assertTrue(run_ci)
-        paths = [".github/workflows/build_package.yml"]
+
+        paths = [".github/workflows/build_portable_linux_artifacts.yml"]
         run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
         self.assertTrue(run_ci)
-        paths = [".github/workflows/test_some_subproject.yml"]
+
+        paths = [".github/workflows/build_artifact.yml"]
         run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
         self.assertTrue(run_ci)
 
     def test_dont_run_ci_if_unrelated_workflow_file_edited(self):
         paths = [".github/workflows/pre-commit.yml"]
+        run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
+        self.assertFalse(run_ci)
+
+        paths = [".github/workflows/test_jax_dockerfile.yml"]
         run_ci = configure_ci.should_ci_run_given_modified_paths(paths)
         self.assertFalse(run_ci)
 

--- a/docs/development/adding_tests.md
+++ b/docs/development/adding_tests.md
@@ -2,7 +2,7 @@
 
 ## Test Flow
 
-After TheRock builds its artifacts, we test those artifacts through [`test_packages.yml`](../../.github/workflows/test_packages.yml). The testing flow works as:
+After TheRock builds its artifacts, we test those artifacts through [`test_artifacts.yml`](../../.github/workflows/test_artifacts.yml). The testing flow works as:
 
 ```mermaid
 graph LR


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/1522, related to https://github.com/ROCm/TheRock/issues/1559.

This allows us to more clearly differentiate between "artifact builds" (the root of our build graph) and "package builds" (which use artifacts). I would like to further refactor these artifact workflows so they can be used from `release_*_packages.yml` workflows instead of having the release workflows reimplement artifact building.

## Technical Details

See this diagram from https://github.com/ROCm/TheRock/blob/main/docs/development/development_guide.md#overall-build-architecture:

![Build architecture (dark)](https://raw.githubusercontent.com/ROCm/TheRock/2db6d353df9849f4a109f5d90e6174686164c69b/docs/development/assets/therock_build_architecture_dark.excalidraw.svg)

## Test Plan

Watch presubmit CI to check that all builds are still running as expected.