### PR TITLE
Use Python pathlib to find the directory containing the current script.

### DIFF
--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -146,7 +146,7 @@ def generate_changelog_file(pkg_info, deb_dir, config: PackageConfig):
         + config.version_suffix
     )
 
-    env = Environment(loader=FileSystemLoader("."))
+    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
     template = env.get_template("template/debian_changelog.j2")
 
     # Prepare context dictionary
@@ -182,7 +182,7 @@ def generate_install_file(pkg_info, deb_dir, config: PackageConfig):
     print("Generate install file")
     install_file = Path(deb_dir) / "install"
 
-    env = Environment(loader=FileSystemLoader("."))
+    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
     template = env.get_template("template/debian_install.j2")
     # Prepare your context dictionary
     context = {
@@ -207,7 +207,7 @@ def generate_rules_file(pkg_info, deb_dir, config: PackageConfig):
     rules_file = Path(deb_dir) / "rules"
     disable_dh_strip = is_key_defined(pkg_info, "Disable_DH_STRIP")
     disable_dwz = is_key_defined(pkg_info, "Disable_DWZ")
-    env = Environment(loader=FileSystemLoader("."))
+    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
     template = env.get_template("template/debian_rules.j2")
     # Prepare  context dictionary
     context = {
@@ -242,7 +242,7 @@ def generate_control_file(pkg_info, deb_dir, config: PackageConfig):
     # Package.json maintains development package name as devel
     depends = depends.replace("-devel", "-dev")
 
-    env = Environment(loader=FileSystemLoader("."))
+    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
     template = env.get_template("template/debian_control.j2")
     # Prepare your context dictionary
     # TODO: description short and long need to defined in package.json
@@ -393,7 +393,7 @@ def generate_spec_file(pkginfo, specfile, config: PackageConfig):
         for path in sourcedir_list:
             convert_runpath_to_rpath(path)
 
-    env = Environment(loader=FileSystemLoader("."))
+    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
     template = env.get_template("template/rpm_specfile.j2")
 
     # Prepare your context dictionary
@@ -655,12 +655,12 @@ def download_and_extract_artifacts(run_id, gfxarch):
     Returns: None
     """
     gfxarch_params = gfxarch + "-dcgpu"
-
+    fetch_script = (SCRIPT_DIR / ".." / ".." / "fetch_artifacts.py").resolve()
     try:
         subprocess.run(
             [
                 "python3",
-                "../../fetch_artifacts.py",
+                str(fetch_script),
                 "--run-id",
                 run_id,
                 "--target",

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -48,6 +48,7 @@ class PackageConfig:
     enable_rpath: bool
 
 
+SCRIPT_DIR = Path(__file__).resolve().parent
 ARTIFACTS_DIR = Path.cwd() / "artifacts_tar"
 # Directory for debian and RPM packaging
 DEBIAN_CONTENTS_DIR = Path.cwd() / "DEB"

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -5,6 +5,7 @@ import json
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 
+
 def read_package_json_file():
     """Reads a JSON file and returns the parsed data
     Parameters: None

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -3,6 +3,7 @@ import json
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+SCRIPT_DIR = Path(__file__).resolve().parent
 
 def read_package_json_file():
     """Reads a JSON file and returns the parsed data
@@ -10,8 +11,8 @@ def read_package_json_file():
 
     Returns: List of package details read from Json
     """
-
-    with open("package.json", "r") as file:
+    file_path = SCRIPT_DIR / "package.json"
+    with file_path.open("r", encoding="utf-8") as file:
         data = json.load(file)
     return data
 

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT


### PR DESCRIPTION
Replaced hardcoded or relative path handling with Path(__file__).resolve().parent 
This improves portability and ensures correct path resolution regardless of the current working directory

## Motivation

Relative paths were used and invoking the scripts from a different directory was failing

## Technical Details

Makes the script location-independent by using Python pathlib expression

## Test Plan

Invoke the script from different paths and test the functionality

## Test Result

Invoking from different paths is also working as expected 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
