### PR TITLE
[ci] Call build_*_python_packages in ci_*.yml workflows.

### DIFF
--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   build:
-    name: Build | ${{ inputs.amdgpu_family }}
+    name: Build Python | ${{ inputs.amdgpu_family }}
     # Note: GitHub-hosted runners run out of disk space for some gpu families
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
     env:

--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   build:
-    name: Build | ${{ inputs.amdgpu_family }}
+    name: Build Python | ${{ inputs.amdgpu_family }}
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-windows-scale-rocm' || 'windows-2022' }}
     env:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   build_portable_linux_artifacts:
-    name: Build
+    name: Build Artifacts
     if: ${{ inputs.use_prebuilt_artifacts == 'false' }}
     uses: ./.github/workflows/build_portable_linux_artifacts.yml
     secrets: inherit
@@ -30,11 +30,19 @@ jobs:
       contents: read
       id-token: write
 
+  # TODO: rework "artifact_run_id" and "use_prebuilt_artifacts" here?
+  #   I don't want to copy/paste this condition and special case plumbing
+  #   through multiple workflows. All the packaging and testing workflows need
+  #   to know is what artifact run id to use. That could be the current
+  #   (implicit) run id, or it could be an explicit run id.
+  #   How about having the "build artifacts" job run as a passthrough?
+
   test_linux_artifacts:
     needs: [build_portable_linux_artifacts]
-    name: Test
+    name: Test Artifacts
     # If the dependent job failed/cancelled, this job will not be run
-    # The use_prebuilt_artifacts "or" statement ensures that tests will run if previous build step is run or skipped.concurrency.
+    # The use_prebuilt_artifacts "or" statement ensures that tests will run if
+    # previous build step is run or skipped.concurrency.
     if: >-
       ${{
         !failure() &&
@@ -44,10 +52,29 @@ jobs:
           inputs.use_prebuilt_artifacts == 'true'
         )
       }}
-    strategy:
-      fail-fast: false
     uses: ./.github/workflows/test_artifacts.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       test_runs_on: ${{ inputs.test_runs_on }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
+
+  build_portable_linux_python_packages:
+    needs: [build_portable_linux_artifacts]
+    name: Build Python
+    # If the dependent job failed/cancelled, this job will not be run
+    # The use_prebuilt_artifacts "or" statement ensures that tests will run if
+    # previous build step is run or skipped.concurrency.
+    if: >-
+      ${{
+        !failure() &&
+        !cancelled() &&
+        (
+          inputs.use_prebuilt_artifacts == 'false' ||
+          inputs.use_prebuilt_artifacts == 'true'
+        )
+      }}
+    uses: ./.github/workflows/build_portable_linux_python_packages.yml
+    with:
+      artifact_run_id: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
+      amdgpu_family: ${{ inputs.amdgpu_families }}
+      package_version: "7.0.0.dev0"  # TODO: setup version with a script/workflow

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   build_windows_artifacts:
-    name: Build
+    name: Build Artifacts
     if: ${{ inputs.use_prebuilt_artifacts == 'false' }}
     uses: ./.github/workflows/build_windows_artifacts.yml
     with:
@@ -33,11 +33,19 @@ jobs:
       contents: read
       id-token: write
 
+  # TODO: rework "artifact_run_id" and "use_prebuilt_artifacts" here?
+  #   I don't want to copy/paste this condition and special case plumbing
+  #   through multiple workflows. All the packaging and testing workflows need
+  #   to know is what artifact run id to use. That could be the current
+  #   (implicit) run id, or it could be an explicit run id.
+  #   How about having the "build artifacts" job run as a passthrough?
+
   test_windows_artifacts:
     needs: [build_windows_artifacts]
-    name: Test
+    name: Test Artifacts
     # If the dependent job failed/cancelled, this job will not be run
-    # The use_prebuilt_artifacts "or" statement ensures that tests will run if previous build step is run or skipped.concurrency.
+    # The use_prebuilt_artifacts "or" statement ensures that tests will run if
+    # previous build step is run or skipped.concurrency.
     if: >-
       ${{
         !failure() &&
@@ -47,10 +55,29 @@ jobs:
           inputs.use_prebuilt_artifacts == 'true'
         )
       }}
-    strategy:
-      fail-fast: false
     uses: ./.github/workflows/test_artifacts.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       test_runs_on: ${{ inputs.test_runs_on }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
+
+  build_windows_python_packages:
+    needs: [build_windows_artifacts]
+    name: Build Python
+    # If the dependent job failed/cancelled, this job will not be run
+    # The use_prebuilt_artifacts "or" statement ensures that tests will run if
+    # previous build step is run or skipped.concurrency.
+    if: >-
+      ${{
+        !failure() &&
+        !cancelled() &&
+        (
+          inputs.use_prebuilt_artifacts == 'false' ||
+          inputs.use_prebuilt_artifacts == 'true'
+        )
+      }}
+    uses: ./.github/workflows/build_windows_python_packages.yml
+    with:
+      artifact_run_id: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
+      amdgpu_family: ${{ inputs.amdgpu_families }}
+      package_version: "7.0.0.dev0"  # TODO: setup version with a script/workflow


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/1559. This gets us presubmit coverage for building the Python packages and running sanity check tests on them (fully implemented on Windows, almost finished on Linux).

## Technical Details

As mentioned on https://github.com/ROCm/TheRock/pull/1596, the new `build_*_python_packages.yml` workflows do not yet upload the packages they build anywhere and only run sanity checks on the current (CPU build) machine. Once the workflows upload we can chain another `test_python_packages.yml` workflow similar to how `test_artifacts.yml` is already connected.

The plumbing here exposed a few issues that I'm ignoring in this PR:

1. `artifact_run_id` is overloaded now, working with `use_prebuilt_artifacts` _and_ standard fully pipelined build/test/release runs. See the comments I added in the files for some ideas there.
2. `package_version` should be computed at the start of the pipeline and passed through to all child jobs. We can lift that code from the release workflow into somewhere shared between CI and CD. For now I'm just hardcoding to a version that functionally works, but we should fix that version before uploading these packages anywhere.
    * Addressing that in https://github.com/ROCm/TheRock/pull/1648
3. `amdgpu_family: ${{ inputs.amdgpu_families }}` is changing from plural to singular, but other workflows use plural and then only operate on singular anyways. Might correct that in a follow-up: https://github.com/ROCm/TheRock/blob/8e437abfe31288c9707362941355a858f29ebeb5/.github/workflows/ci.yml#L70-L77

## Test Plan

Watch CI results. I also triggered a run with `use_prebuilt_artifacts` on a prior commit at https://github.com/ROCm/TheRock/actions/runs/18112810485.