### PR TITLE
Add retry logic for PermissionError in `pattern_match.py`

### DIFF
--- a/build_tools/_therock_utils/pattern_match.py
+++ b/build_tools/_therock_utils/pattern_match.py
@@ -116,7 +116,6 @@ class PatternMatcher:
         always_copy: bool = False,
         remove_dest: bool = True,
     ):
-        verbose=True
         if remove_dest and destdir.exists():
             for attempt in range(self.max_attempts):
                 try:

--- a/build_tools/_therock_utils/pattern_match.py
+++ b/build_tools/_therock_utils/pattern_match.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import time
 
+
 class RecursiveGlobPattern:
     def __init__(self, glob: str):
         self.glob = glob
@@ -122,11 +123,17 @@ class PatternMatcher:
                 except PermissionError:
                     wait_time = retry_delay_seconds * (attempt + 2)
                     if verbose:
-                        print(f"PermissionError calling shutil.rmtree('{destdir}') retrying after {wait_time}s", file=sys.stderr)
+                        print(
+                            f"PermissionError calling shutil.rmtree('{destdir}') retrying after {wait_time}s",
+                            file=sys.stderr,
+                        )
                     time.sleep(wait_time)
                     if attempt == max_attempts - 1:
                         if verbose:
-                            print(f"rmtree failed after {attempt} attempts, failing", file=sys.stderr)
+                            print(
+                                f"rmtree failed after {attempt} attempts, failing",
+                                file=sys.stderr,
+                            )
                         raise
         destdir.mkdir(parents=True, exist_ok=True)
 

--- a/build_tools/_therock_utils/pattern_match.py
+++ b/build_tools/_therock_utils/pattern_match.py
@@ -131,7 +131,7 @@ class PatternMatcher:
                     if attempt == max_attempts - 1:
                         if verbose:
                             print(
-                                f"rmtree failed after {attempt} attempts, failing",
+                                f"rmtree failed after {max_attempts} attempts, failing",
                                 file=sys.stderr,
                             )
                         raise

--- a/build_tools/_therock_utils/pattern_match.py
+++ b/build_tools/_therock_utils/pattern_match.py
@@ -5,7 +5,7 @@ from pathlib import Path, PurePosixPath
 import re
 import shutil
 import sys
-
+import time
 
 class RecursiveGlobPattern:
     def __init__(self, glob: str):
@@ -111,9 +111,23 @@ class PatternMatcher:
         remove_dest: bool = True,
     ):
         if remove_dest and destdir.exists():
-            if verbose:
-                print(f"rmtree {destdir}", file=sys.stderr)
-            shutil.rmtree(destdir)
+            max_attempts = 5
+            retry_delay_seconds = 0.2
+            for attempt in range(max_attempts):
+                try:
+                    shutil.rmtree(destdir)
+                    if verbose:
+                        print(f"rmtree {destdir}", file=sys.stderr)
+                    break
+                except PermissionError:
+                    wait_time = retry_delay_seconds * (attempt + 2)
+                    if verbose:
+                        print(f"PermissionError calling shutil.rmtree('{destdir}') retrying after {wait_time}s", file=sys.stderr)
+                    time.sleep(wait_time)
+                    if attempt == max_attempts - 1:
+                        if verbose:
+                            print(f"rmtree failed after {attempt} attempts, failing", file=sys.stderr)
+                        raise
         destdir.mkdir(parents=True, exist_ok=True)
 
         for relpath, direntry in self.matches():

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -19,7 +19,6 @@ from pathlib import Path
 import sys
 import shutil
 import tarfile
-import time
 
 from _therock_utils.artifacts import ArtifactPopulator
 import _therock_utils.artifact_builder as artifact_builder
@@ -35,24 +34,11 @@ def do_list(args: argparse.Namespace, pm: PatternMatcher):
 def do_copy(args: argparse.Namespace, pm: PatternMatcher):
     verbose = args.verbose
     destdir: Path = args.dest_dir
-
-    # Remove destination directory with retry logic
-    if args.remove_dest:
-        for attempt in range(5):  # Retry up to 5 times
-            try:
-                shutil.rmtree(destdir)
-                break
-            except PermissionError:
-                time.sleep(0.2 * (attempt + 2))
-                if attempt == 4:
-                    raise
-
-    # Perform the copy
     pm.copy_to(
         destdir=destdir,
         verbose=verbose,
         always_copy=args.always_copy,
-        remove_dest=False,  # Already handled above
+        remove_dest=args.remove_dest,
     )
 
 

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import sys
 import shutil
 import tarfile
+import time
 
 from _therock_utils.artifacts import ArtifactPopulator
 import _therock_utils.artifact_builder as artifact_builder
@@ -34,11 +35,24 @@ def do_list(args: argparse.Namespace, pm: PatternMatcher):
 def do_copy(args: argparse.Namespace, pm: PatternMatcher):
     verbose = args.verbose
     destdir: Path = args.dest_dir
+
+    # Remove destination directory with retry logic
+    if args.remove_dest:
+        for attempt in range(5):  # Retry up to 5 times
+            try:
+                shutil.rmtree(destdir)
+                break
+            except PermissionError:
+                time.sleep(0.2 * (attempt + 2))
+                if attempt == 4:
+                    raise
+
+    # Perform the copy
     pm.copy_to(
         destdir=destdir,
         verbose=verbose,
         always_copy=args.always_copy,
-        remove_dest=args.remove_dest,
+        remove_dest=False,  # Already handled above
     )
 
 


### PR DESCRIPTION
## Motivation

Progress on #481
Solving the error below:
```
[build] [34/49  67% :: 52.394] Merging sub-project dist directory for hipcc
[build] FAILED: compiler/hipcc/stamp/dist.stamp D:/projects/TheRock/build/compiler/hipcc/stamp/dist.stamp 
[build] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\compiler && d:\projects\TheRock\.venv\Scripts\python D:/projects/TheRock/build_tools/fileset_tool.py copy D:/projects/TheRock/build/compiler/hipcc/dist D:/projects/TheRock/build/compiler/hipcc/stage D:/projects/TheRock/build/third-party/sysdeps/windows/zlib/build/stage D:/projects/TheRock/build/third-party/sysdeps/windows/zstd/build/stage D:/projects/TheRock/build/compiler/amd-llvm/stage && "C:\Program Files\CMake\bin\cmake.exe" -E touch D:/projects/TheRock/build/compiler/hipcc/stamp/dist.stamp"
[build] Traceback (most recent call last):
[build]   File "D:\projects\TheRock\build_tools\fileset_tool.py", line 405, in <module>
[build]     main(sys.argv[1:])
[build]   File "D:\projects\TheRock\build_tools\fileset_tool.py", line 401, in main
[build]     args.func(args)
[build]   File "D:\projects\TheRock\build_tools\fileset_tool.py", line 311, in run_action
[build]     action(args, pm)
[build]   File "D:\projects\TheRock\build_tools\fileset_tool.py", line 135, in do_copy
[build]     pm.copy_to(
[build]   File "D:\projects\TheRock\build_tools\_therock_utils\pattern_match.py", line 113, in copy_to
[build]     shutil.rmtree(destdir)
[build]   File "C:\Program Files\Python312\Lib\shutil.py", line 781, in rmtree
[build]     return _rmtree_unsafe(path, onexc)
[build]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[build]   File "C:\Program Files\Python312\Lib\shutil.py", line 635, in _rmtree_unsafe
[build]     onexc(os.unlink, fullname, err)
[build]   File "C:\Program Files\Python312\Lib\shutil.py", line 633, in _rmtree_unsafe
[build]     os.unlink(fullname)
[build] PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'D:\\projects\\TheRock\\build\\compiler\\hipcc\\dist\\lib\\llvm\\lib\\clang\\19\\include\\opencl-c.h'
[build] [34/49  69% :: 55.779] Building sub-project amd-comgr (in background)

```
## Technical Details
The processes below (opens "opencl-c.h") run very close time frame which causes permission error. So applying retry logic at  `do_copy` function in `fileset_tool.py` file will solve the permission error since it reduces the overlapping time among the processes.

```
amd-llvm/dist   (PID 5816)  
hipcc/dist      (PID 11396) 
amd-comgr/dist  (PID 9180)   

```
```
2025-09-27 15:46:07.316 | PID= 15560 | C:\home\runner\_work\TheRock\build\base\rocm-cmake\dist
2025-09-27 15:46:12.261 | PID=  7768 | C:\home\runner\_work\TheRock\build\third-party\sysdeps\windows\zlib\build\dist
2025-09-27 15:46:12.728 | PID= 16064 | C:\home\runner\_work\TheRock\build\third-party\sysdeps\windows\zstd\build\dist
2025-09-27 16:06:29.870 | PID=  5816 | C:\home\runner\_work\TheRock\build\compiler\amd-llvm\dist
2025-09-27 16:06:55.573 | PID= 11396 | C:\home\runner\_work\TheRock\build\compiler\hipcc\dist
2025-09-27 16:07:08.557 | PID=  9180 | C:\home\runner\_work\TheRock\build\compiler\amd-comgr\dist
```

Timeline for the processes: 
```
[2025-09-27 15:46:07.316] PID=015560 opencl-c.h file Monitoring enabled by opencl-c.h
[2025-09-27 15:46:07.316] PID=015560 Starting copy on C:\home\runner\_work\TheRock\build\base\rocm-cmake\dist
[2025-09-27 15:46:07.329] PID=015560 Completed file copy on C:\home\runner\_work\TheRock\build\base\rocm-cmake\dist
[2025-09-27 15:46:12.261] PID=007768 opencl-c.h file Monitoring enabled by opencl-c.h
[2025-09-27 15:46:12.261] PID=007768 Starting copy on C:\home\runner\_work\TheRock\build\third-party\sysdeps\windows\zlib\build\dist
[2025-09-27 15:46:12.277] PID=007768 Completed file copy on C:\home\runner\_work\TheRock\build\third-party\sysdeps\windows\zlib\build\dist
[2025-09-27 15:46:12.726] PID=016064 opencl-c.h file Monitoring enabled by opencl-c.h
[2025-09-27 15:46:12.728] PID=016064 Starting copy on C:\home\runner\_work\TheRock\build\third-party\sysdeps\windows\zstd\build\dist
[2025-09-27 15:46:12.733] PID=016064 Completed file copy on C:\home\runner\_work\TheRock\build\third-party\sysdeps\windows\zstd\build\dist
[2025-09-27 16:06:29.807] PID=005816 opencl-c.h file Monitoring enabled by opencl-c.h
[2025-09-27 16:06:29.870] PID=005816 Starting copy on C:\home\runner\_work\TheRock\build\compiler\amd-llvm\dist
[2025-09-27 16:06:29.870] PID=005816 opencl-c.h file Found critical file in basedir by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:29.917] PID=005816 opencl-c.h file Matched critical file by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:29.917] PID=005816 opencl-c.h file Matched critical file by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:29.917] PID=005816 opencl-c.h file Matched critical file by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:31.042] PID=005816 opencl-c.h file Opened by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:31.042] PID=005816 opencl-c.h file Opened successfully by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:32.276] PID=005816 opencl-c.h file Opened by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:32.276] PID=005816 opencl-c.h file Opened successfully by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:33.479] PID=005816 opencl-c.h file Opened by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:33.479] PID=005816 opencl-c.h file Opened successfully by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:38.229] PID=005816 Completed file copy on C:\home\runner\_work\TheRock\build\compiler\amd-llvm\dist
[2025-09-27 16:06:55.511] PID=011396 opencl-c.h file Monitoring enabled by opencl-c.h
[2025-09-27 16:06:55.573] PID=011396 Starting copy on C:\home\runner\_work\TheRock\build\compiler\hipcc\dist
[2025-09-27 16:06:55.573] PID=011396 opencl-c.h file Found critical file in basedir by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:55.589] PID=011396 opencl-c.h file Matched critical file by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:55.589] PID=011396 opencl-c.h file Matched critical file by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:55.589] PID=011396 opencl-c.h file Matched critical file by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:55.651] PID=011396 opencl-c.h file Matched critical file by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:57.745] PID=011396 opencl-c.h file Opened by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:57.745] PID=011396 opencl-c.h file Opened successfully by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:59.120] PID=011396 opencl-c.h file Opened by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:06:59.135] PID=011396 opencl-c.h file Opened successfully by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:00.573] PID=011396 opencl-c.h file Opened by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:00.573] PID=011396 opencl-c.h file Opened successfully by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:02.026] PID=011396 opencl-c.h file Opened by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:02.042] PID=011396 opencl-c.h file Opened successfully by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:07.042] PID=011396 Completed file copy on C:\home\runner\_work\TheRock\build\compiler\hipcc\dist
[2025-09-27 16:07:08.510] PID=009180 opencl-c.h file Monitoring enabled by opencl-c.h
[2025-09-27 16:07:08.557] PID=009180 Starting copy on C:\home\runner\_work\TheRock\build\compiler\amd-comgr\dist
[2025-09-27 16:07:08.557] PID=009180 opencl-c.h file Found critical file in basedir by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:08.557] PID=009180 opencl-c.h file Matched critical file by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:08.573] PID=009180 opencl-c.h file Matched critical file by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:08.573] PID=009180 opencl-c.h file Matched critical file by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:08.620] PID=009180 opencl-c.h file Matched critical file by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:09.729] PID=009180 opencl-c.h file Opened by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:09.729] PID=009180 opencl-c.h file Opened successfully by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:10.932] PID=009180 opencl-c.h file Opened by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:10.932] PID=009180 opencl-c.h file Opened successfully by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:12.135] PID=009180 opencl-c.h file Opened by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:12.135] PID=009180 opencl-c.h file Opened successfully by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:13.354] PID=009180 opencl-c.h file Opened by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:13.354] PID=009180 opencl-c.h file Opened successfully by C:\home\runner\_work\TheRock\build\compiler\amd-llvm\stage\lib\llvm\lib\clang\20\include\opencl-c.h
[2025-09-27 16:07:18.120] PID=009180 Completed file copy on C:\home\runner\_work\TheRock\build\compiler\amd-comgr\dis
```

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Test are run in local machine with the timing logs to detect they run in a close time frame. 
## Test Result
The chart from timing logs that shows they run in a close time frame.
```
Process                      |   Open 1       |    Open 2     |    Open 3     |   Open 4      |  Completed
amd-llvm/dist   (PID 5816)   | 16:06:31.042   | 16:06:32.276  | 16:06:33.479  | NA            | 16:06:38.229
hipcc/dist      (PID 11396)  | 16:06:57.745   | 16:06:59.120  | 16:07:00.573  | 16:07:02.042  | 16:07:07.042
amd-comgr/dist  (PID 9180)   | 16:07:09.729   | 16:07:10.932  | 16:07:12.135  | 16:07:13.354  | 16:07:18.120
```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
