### PR TITLE
Improve doc: Add upgrade pip to install process

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,9 @@ sudo apt install gfortran git git-lfs ninja-build cmake g++ pkg-config xxd patch
 git clone https://github.com/ROCm/TheRock.git
 cd TheRock
 
-# Init python virtual environment
+# Init python virtual environment and install python dependencies
 python3 -m venv .venv && source .venv/bin/activate
-# Optional: Upgrade pip, can resolve problems when installing the requirements.txt
 pip install --upgrade pip
-# Install python dependencies
 pip install -r requirements.txt
 
 # Download submodules and apply patches
@@ -99,6 +97,7 @@ cd TheRock
 # Init python virtual environment and install python dependencies
 python -m venv .venv
 .venv\Scripts\Activate.bat
+pip install --upgrade pip
 pip install -r requirements.txt
 
 # Download submodules and apply patches


### PR DESCRIPTION
Installing the virtual environment and then immediately running `pip install -r requirements.txt` can sometimes fail with cryptic errors. Upgrading pip has shown to resolve this - so add documentation about it.