### PR TITLE
[compiler] - Add cmake support for building libompdevice.a

### DIFF
--- a/compiler/pre_hook_amd-llvm.cmake
+++ b/compiler/pre_hook_amd-llvm.cmake
@@ -35,6 +35,18 @@ else()
     # For now we will switch the priorty for find_package to first search in
     # CONFIG mode.
     set(RUNTIMES_CMAKE_ARGS "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON")
+
+    # TODO: Guard for amd-staging only. Remove condition when compiler branch is updated.
+    if(EXISTS "${THEROCK_SOURCE_DIR}/compiler/amd-llvm/openmp/device/CMakeLists.txt")
+      list(APPEND LLVM_ENABLE_RUNTIMES "flang-rt")
+      set(LLVM_RUNTIME_TARGETS "default;amdgcn-amd-amdhsa")
+      set(RUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES "openmp")
+      set(RUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_PER_TARGET_RUNTIME_DIR ON)
+      set(FLANG_RUNTIME_F128_MATH_LIB "libquadmath")
+      set(LIBOMPTARGET_BUILD_DEVICE_FORTRT ON)
+      #TODO: Enable when HWLOC dependency is figured out
+      #set(LIBOMP_USE_HWLOC ON)
+    endif()
   endif()
   # Setting "LIBOMP_COPY_EXPORTS" to `OFF` "aids parallel builds to not interfere
   # with each other" as libomp and generated headers are copied into the original


### PR DESCRIPTION
Currently mainline does not have the code to take advantage of these options. This is to support amd-staging builds that are in progress.

## Motivation

Add support for building libompdevice.a as it is currently missing from staging builds.

