### PR TITLE
Move component filtering fully from fetch_artifacts to install script.

### DIFF
--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -10,15 +10,7 @@ Example usage (using https://github.com/ROCm/TheRock/actions/runs/15685736080):
   python build_tools/fetch_artifacts.py \
     --run-id 15685736080 --target gfx110X-dgpu --output-dir ~/.therock/artifacts_15685736080
 
-Or, to fetch _all_ artifacts and not just a subset (this is safest for packaging
-workflows where dependencies may not be accurately modeled, at the cost of
-additional disk space):
-  python build_tools/fetch_artifacts.py \
-    --run-id 15685736080 --target gfx110X-dgpu --output-dir ~/.therock/artifacts_15685736080 \
-    --all
-
-Alternatively, include/exclude regular expressions can be given to control what
-is downloaded (this implies --all):
+Include/exclude regular expressions can be given to control what is downloaded:
   python build_tools/fetch_artifacts.py \
     --run-id 15685736080 --target gfx110X-dgpu --output-dir ~/.therock/artifacts_15685736080 \
     amd-llvm base 'core-(hip|runtime)' sysdeps \
@@ -52,10 +44,8 @@ import time
 from urllib3.exceptions import InsecureRequestWarning
 import warnings
 
-THEROCK_DIR = Path(__file__).resolve().parent.parent
-sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
 from _therock_utils.artifacts import ArtifactName, ArtifactPopulator
-from github_actions_utils import *
+from github_actions.github_actions_utils import retrieve_bucket_info
 
 
 warnings.filterwarnings("ignore", category=InsecureRequestWarning)
@@ -105,7 +95,7 @@ class BucketMetadata:
         self.s3_key_path = f"{self.external_repo}{self.workflow_run_id}-{self.platform}"
 
 
-def retrieve_s3_artifacts(bucket_info: BucketMetadata, amdgpu_family: str):
+def list_s3_artifacts(bucket_info: BucketMetadata, amdgpu_family: str) -> set[str]:
     """Checks that the AWS S3 bucket exists and returns artifact names."""
     s3_key_path = bucket_info.s3_key_path
     log(
@@ -140,30 +130,6 @@ class ArtifactDownloadRequest:
 
     def __str__(self):
         return f"{self.bucket}:{self.artifact_key}"
-
-
-def collect_artifacts_download_requests(
-    artifact_names: list[str],
-    bucket_info: BucketMetadata,
-    output_dir: Path,
-    variant: str,
-    existing_artifacts: set[str],
-) -> list[ArtifactDownloadRequest]:
-    """Collects S3 artifact URLs to execute later in parallel."""
-    artifacts_to_retrieve = []
-    for artifact_name in artifact_names:
-        file_name = f"{artifact_name}_{variant}.tar.xz"
-        # If artifact does exist in s3 bucket
-        if file_name in existing_artifacts:
-            artifacts_to_retrieve.append(
-                ArtifactDownloadRequest(
-                    artifact_key=f"{bucket_info.s3_key_path}/{file_name}",
-                    bucket=bucket_info.bucket,
-                    output_path=output_dir / file_name,
-                )
-            )
-
-    return artifacts_to_retrieve
 
 
 def download_artifact(
@@ -204,28 +170,23 @@ def download_artifacts(artifact_download_requests: list[ArtifactDownloadRequest]
             future.result(timeout=60)
 
 
-def filter_all_artifacts(
+def get_artifact_download_requests(
     bucket_info: BucketMetadata,
-    target: str,
-    output_dir: Path,
     s3_artifacts: set[str],
+    output_dir: Path,
 ) -> list[ArtifactDownloadRequest]:
-    """Filters to all available artifacts."""
-    artifacts_to_retrieve = []
+    """Gets artifact download requests from requested artifacts."""
+    artifacts_to_download = []
 
     for artifact in sorted(list(s3_artifacts)):
-        an = ArtifactName.from_filename(artifact)
-        if an.target_family != "generic" and target != an.target_family:
-            continue
-
-        artifacts_to_retrieve.append(
+        artifacts_to_download.append(
             ArtifactDownloadRequest(
                 artifact_key=f"{bucket_info.s3_key_path}/{artifact}",
                 bucket=bucket_info.bucket,
                 output_path=output_dir / artifact,
             )
         )
-    return artifacts_to_retrieve
+    return artifacts_to_download
 
 
 def get_postprocess_mode(args) -> str | None:
@@ -235,83 +196,6 @@ def get_postprocess_mode(args) -> str | None:
     if args.no_extract:
         return None
     return "extract"
-
-
-def filter_base_artifacts(
-    args: argparse.Namespace,
-    bucket_info: BucketMetadata,
-    output_dir: Path,
-    s3_artifacts: set[str],
-) -> list[ArtifactDownloadRequest]:
-    """Filters TheRock base artifacts."""
-    base_artifacts = [
-        "core-runtime_run",
-        "core-runtime_lib",
-        "sysdeps_lib",
-        "base_run",
-        "base_lib",
-        "amd-llvm_run",
-        "amd-llvm_lib",
-        "core-hip_lib",
-        "core-hip_dev",
-        "rocprofiler-sdk_lib",
-        "host-suite-sparse_lib",
-    ]
-    if args.blas:
-        base_artifacts.append("host-blas_lib")
-
-    artifacts_to_retrieve = collect_artifacts_download_requests(
-        base_artifacts, bucket_info, output_dir, "generic", s3_artifacts
-    )
-    return artifacts_to_retrieve
-
-
-def filter_enabled_artifacts(
-    args: argparse.Namespace,
-    target: str,
-    bucket_info: BucketMetadata,
-    output_dir: Path,
-    s3_artifacts: set[str],
-) -> list[ArtifactDownloadRequest]:
-    """Filters TheRock artifacts using based on the enabled arguments.
-
-    If no artifacts have been collected, we assume that we want to install the default subset.
-    If `args.tests` have been enabled, we also collect test artifacts.
-    """
-    artifact_paths = []
-    all_artifacts = ["blas", "fft", "miopen", "prim", "rand"]
-    # RCCL is disabled for Windows
-    if bucket_info.platform != "windows":
-        all_artifacts.append("rccl")
-
-    if args.blas:
-        artifact_paths.append("blas")
-    if args.fft:
-        artifact_paths.append("fft")
-    if args.miopen:
-        artifact_paths.append("miopen")
-    if args.prim:
-        artifact_paths.append("prim")
-    if args.rand:
-        artifact_paths.append("rand")
-    if args.rccl and bucket_info.platform != "windows":
-        artifact_paths.append("rccl")
-
-    enabled_artifacts = []
-
-    # In the case that no library arguments were passed and base_only args is false, we install all artifacts
-    if not artifact_paths and not args.base_only:
-        artifact_paths = all_artifacts
-
-    for base_path in artifact_paths:
-        enabled_artifacts.append(f"{base_path}_lib")
-        if args.tests:
-            enabled_artifacts.append(f"{base_path}_test")
-
-    artifacts_to_retrieve = collect_artifacts_download_requests(
-        enabled_artifacts, bucket_info, output_dir, target, s3_artifacts
-    )
-    return artifacts_to_retrieve
 
 
 def extract_artifact(
@@ -363,69 +247,80 @@ def run(args):
         platform=args.platform,
     )
 
-    s3_artifacts = retrieve_s3_artifacts(bucket_info=bucket_info, amdgpu_family=target)
+    # Lookup which artifacts exist in the bucket.
+    # Note: this currently does not check that all requested artifacts
+    # (via include patterns) do exist, so this may silently fail to fetch
+    # expected files.
+    s3_artifacts = list_s3_artifacts(bucket_info=bucket_info, amdgpu_family=target)
     if not s3_artifacts:
-        log(f"S3 artifacts for {run_id} does not exist. Exiting...")
+        log(f"No matching S3 artifacts for {run_id} exist. Exiting...")
         sys.exit(1)
 
-    # Filter the artifacts we will retrieve.
-    artifacts_to_retrieve: list[ArtifactDownloadRequest] | None = None
-    if args.include:
-        args.all = True
-    if args.all:
-        artifacts_to_retrieve = filter_all_artifacts(
-            bucket_info, target, output_dir, s3_artifacts
-        )
-    else:
-        artifacts_to_retrieve = filter_base_artifacts(
-            args, bucket_info, output_dir, s3_artifacts
-        )
-        if not args.base_only:
-            artifacts_to_retrieve.extend(
-                filter_enabled_artifacts(
-                    args, target, bucket_info, output_dir, s3_artifacts
-                )
-            )
-
     # Include/exclude filtering.
-    def _should_include(artifact: ArtifactDownloadRequest) -> bool:
-        if not args.include:
+    def _should_include(artifact_name: str) -> bool:
+        if not args.include and not args.exclude:
             return True
+
         # If includes, then one include must match.
-        for include in args.include:
-            pattern = re.compile(include)
-            if pattern.search(artifact.artifact_key):
-                break
-        else:
-            return False
+        if args.include:
+            for include in args.include:
+                pattern = re.compile(include)
+                if pattern.search(artifact_name):
+                    break
+            else:
+                return False
+
         # If excludes, then no excludes must match.
         if args.exclude:
             for exclude in args.exclude:
                 pattern = re.compile(exclude)
-                if pattern.search(artifact.artifact_key):
+                if pattern.search(artifact_name):
                     return False
+
+        # Included and not excluded.
         return True
 
-    artifacts_to_retrieve = [a for a in artifacts_to_retrieve if _should_include(a)]
+    s3_artifacts_filtered = [a for a in s3_artifacts if _should_include(a)]
+    if not s3_artifacts_filtered:
+        log(
+            f"Filtering S3 artifacts for {run_id} resulted in an empty list. Exiting..."
+        )
+        sys.exit(1)
 
-    joined_artifact_summary = "\n  ".join([str(item) for item in artifacts_to_retrieve])
-    log(f"Downloading in parallel:\n  {joined_artifact_summary}\n")
+    artifacts_to_download = get_artifact_download_requests(
+        bucket_info=bucket_info,
+        s3_artifacts=s3_artifacts_filtered,
+        output_dir=output_dir,
+    )
+
+    download_summary = "\n  ".join([str(item) for item in artifacts_to_download])
+    log(f"\nFiltered artifacts to download:\n  {download_summary}\n")
+
+    if args.dry_run:
+        log("Skipping downloads since --dry-run was set")
+        return
 
     # Download and extract in parallel.
-    postprocess_mode = get_postprocess_mode(args)
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=args.download_concurrency
-    ) as download_executor, concurrent.futures.ThreadPoolExecutor(
-        max_workers=args.extract_concurrency
-    ) as extract_executor:
+    ) as download_executor:
         download_futures = [
             download_executor.submit(download_artifact, req)
-            for req in artifacts_to_retrieve
+            for req in artifacts_to_download
         ]
-        extract_futures: list[concurrent.futures.Future] = []
-        for download_future in concurrent.futures.as_completed(download_futures):
-            download_result = download_future.result(timeout=60)
-            if postprocess_mode:
+
+        postprocess_mode = get_postprocess_mode(args)
+        if not postprocess_mode:
+            # No postprocessing to do, wait on downloads then return.
+            [f.result() for f in download_futures]
+            return
+
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=args.extract_concurrency
+        ) as extract_executor:
+            extract_futures: list[concurrent.futures.Future] = []
+            for download_future in concurrent.futures.as_completed(download_futures):
+                download_result = download_future.result(timeout=60)
                 extract_futures.append(
                     extract_executor.submit(
                         extract_artifact,
@@ -435,11 +330,38 @@ def run(args):
                     )
                 )
 
-        [f.result() for f in extract_futures]
+            [f.result() for f in extract_futures]
 
 
 def main(argv):
     parser = argparse.ArgumentParser(prog="fetch_artifacts")
+
+    filter_group = parser.add_argument_group("Artifact filtering")
+    filter_group.add_argument(
+        "include",
+        nargs="*",
+        help="Regular expression patterns of artifacts to include: "
+        "if supplied one pattern must match for an artifact to be included",
+    )
+    filter_group.add_argument(
+        "--exclude",
+        nargs="*",
+        help="Regular expression patterns of artifacts to exclude",
+    )
+    filter_group.add_argument(
+        "--platform",
+        type=str,
+        choices=["linux", "windows"],
+        default=platform.system().lower(),
+        help="Platform to download artifacts for (matches artifact folder name suffixes in S3)",
+    )
+    filter_group.add_argument(
+        "--target",
+        type=str,
+        required=True,
+        help="Target variant for specific GPU target",
+    )
+
     parser.add_argument(
         "--download-concurrency",
         type=int,
@@ -462,31 +384,21 @@ def main(argv):
         required=True,
         help="GitHub run ID to retrieve artifacts from",
     )
-
-    parser.add_argument(
-        "--target",
-        type=str,
-        required=True,
-        help="Target variant for specific GPU target",
-    )
-
-    parser.add_argument(
-        "--platform",
-        type=str,
-        choices=["linux", "windows"],
-        default=platform.system().lower(),
-        help="Platform to download artifacts for (matches artifact folder name suffixes in S3)",
-    )
-
     parser.add_argument(
         "--output-dir",
         type=Path,
         default="build/artifacts",
         help="Output path for fetched artifacts, defaults to `build/artifacts/` as in source builds",
     )
+    parser.add_argument(
+        "--dry-run",
+        default=False,
+        help="If set, will only log which artifacts would be fetched without downloading or extracting",
+        action=argparse.BooleanOptionalAction,
+    )
 
-    # Post processing mode
-    postprocess_p = parser.add_mutually_exclusive_group()
+    postprocess_group = parser.add_argument_group("Postprocessing")
+    postprocess_p = postprocess_group.add_mutually_exclusive_group()
     postprocess_p.add_argument(
         "--no-extract",
         default=False,
@@ -505,91 +417,14 @@ def main(argv):
         action="store_true",
         help="Flattens artifacts after fetching them",
     )
-
-    parser.add_argument(
+    postprocess_group.add_argument(
         "--delete-after-extract",
         default=True,
         action=argparse.BooleanOptionalAction,
         help="Delete archive files after extraction",
     )
-    artifacts_group = parser.add_argument_group("artifacts_group")
-    artifacts_group.add_argument(
-        "--all",
-        default=False,
-        help="Include all artifacts",
-        action=argparse.BooleanOptionalAction,
-    )
-    parser.add_argument(
-        "include",
-        nargs="*",
-        help="Regular expression patterns of artifacts to include (implies --all): "
-        "if supplied one pattern must match for an artifact to be included",
-    )
-    parser.add_argument(
-        "--exclude",
-        nargs="*",
-        help="Regular expression patterns of artifacts to exclude",
-    )
-
-    artifacts_group.add_argument(
-        "--blas",
-        default=False,
-        help="Include 'blas' artifacts",
-        action=argparse.BooleanOptionalAction,
-    )
-    artifacts_group.add_argument(
-        "--fft",
-        default=False,
-        help="Include 'fft' artifacts",
-        action=argparse.BooleanOptionalAction,
-    )
-    artifacts_group.add_argument(
-        "--miopen",
-        default=False,
-        help="Include 'miopen' artifacts",
-        action=argparse.BooleanOptionalAction,
-    )
-    artifacts_group.add_argument(
-        "--prim",
-        default=False,
-        help="Include 'prim' artifacts",
-        action=argparse.BooleanOptionalAction,
-    )
-    artifacts_group.add_argument(
-        "--rand",
-        default=False,
-        help="Include 'rand' artifacts",
-        action=argparse.BooleanOptionalAction,
-    )
-    artifacts_group.add_argument(
-        "--rccl",
-        default=False,
-        help="Include 'rccl' artifacts",
-        action=argparse.BooleanOptionalAction,
-    )
-    artifacts_group.add_argument(
-        "--tests",
-        default=False,
-        help="Include all test artifacts for enabled libraries",
-        action=argparse.BooleanOptionalAction,
-    )
-    artifacts_group.add_argument(
-        "--base-only", help="Include only base artifacts", action="store_true"
-    )
 
     args = parser.parse_args(argv)
-
-    if (args.all or args.include) and (
-        args.blas
-        or args.fft
-        or args.miopen
-        or args.prim
-        or args.rand
-        or args.rccl
-        or args.tests
-        or args.base_only
-    ):
-        parser.error("--all cannot be set together with artifact group options")
 
     run(args)
 

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -136,27 +136,51 @@ def retrieve_artifacts_by_run_id(args):
         str(args.output_dir),
         "--flatten",
     ]
-    if args.base_only:
-        argv.append("--base-only")
-    elif any([args.blas, args.fft, args.miopen, args.prim, args.rand, args.rccl]):
-        if args.blas:
-            argv.append("--blas")
-        if args.fft:
-            argv.append("--fft")
-        if args.miopen:
-            argv.append("--miopen")
-        if args.prim:
-            argv.append("--prim")
-        if args.rand:
-            argv.append("--rand")
-        if args.rccl and PLATFORM != "windows":
-            argv.append("--rccl")
-        if args.tests:
-            argv.append("--tests")
-    else:
-        argv.append("--all")
 
-    log(f"Calling fetch_artifacts_main with args:\n  {' '.join(argv)}")
+    # These artifacts are the "base" requirements for running tests.
+    base_artifact_patterns = [
+        "core-runtime_run",
+        "core-runtime_lib",
+        "sysdeps_lib",
+        "base_run",
+        "base_lib",
+        "amd-llvm_run",
+        "amd-llvm_lib",
+        "core-hip_lib",
+        "core-hip_dev",
+        "rocprofiler-sdk_lib",
+        "host-suite-sparse_lib",
+    ]
+
+    if args.base_only:
+        argv.extend(base_artifact_patterns)
+    elif any([args.blas, args.fft, args.miopen, args.prim, args.rand, args.rccl]):
+        argv.extend(base_artifact_patterns)
+
+        extra_artifacts = []
+        if args.blas:
+            extra_artifacts.append("blas")
+        if args.fft:
+            extra_artifacts.append("fft")
+        if args.miopen:
+            extra_artifacts.append("miopen")
+        if args.prim:
+            extra_artifacts.append("prim")
+        if args.rand:
+            extra_artifacts.append("rand")
+        if args.rccl:
+            extra_artifacts.append("rccl")
+
+        extra_artifact_patterns = [f"{a}_lib" for a in extra_artifacts]
+        if args.tests:
+            extra_artifact_patterns.extend([f"{a}_test" for a in extra_artifacts])
+
+        argv.extend(extra_artifact_patterns)
+    else:
+        # No include (or exclude) patterns, so all artifacts will be fetched.
+        pass
+
+    log(f"\nCalling fetch_artifacts_main with args:\n  {' '.join(argv)}\n")
     fetch_artifacts_main(argv)
 
     log(f"Retrieved artifacts for run ID {run_id}")

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -667,7 +667,6 @@ def download_and_extract_artifacts(run_id, gfxarch):
                 "--target",
                 gfxarch_params,
                 "--extract",
-                "--all",
                 "--output-dir",
                 ARTIFACTS_DIR,
             ],

--- a/build_tools/tests/fetch_artifacts_test.py
+++ b/build_tools/tests/fetch_artifacts_test.py
@@ -9,7 +9,7 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from fetch_artifacts import (
     BucketMetadata,
-    retrieve_s3_artifacts,
+    list_s3_artifacts,
 )
 
 THIS_DIR = Path(__file__).resolve().parent
@@ -18,7 +18,7 @@ REPO_DIR = THIS_DIR.parent.parent
 
 class ArtifactsIndexPageTest(unittest.TestCase):
     @patch("fetch_artifacts.paginator")
-    def testRetrieveS3Artifacts(self, mock_paginator):
+    def testListS3Artifacts(self, mock_paginator):
         bucket_info = BucketMetadata(
             "ROCm-TheRock/", "therock-artifacts", "123", "linux"
         )
@@ -34,7 +34,7 @@ class ArtifactsIndexPageTest(unittest.TestCase):
             {"Contents": [{"Key": "rocm-libraries/test/empty_4test.tar.xz"}]},
         ]
 
-        result = retrieve_s3_artifacts(bucket_info, "test")
+        result = list_s3_artifacts(bucket_info, "test")
 
         self.assertEqual(len(result), 4)
         self.assertTrue("empty_1test.tar.xz" in result)
@@ -43,7 +43,7 @@ class ArtifactsIndexPageTest(unittest.TestCase):
         self.assertTrue("empty_4test.tar.xz" in result)
 
     @patch("fetch_artifacts.paginator")
-    def testRetrieveS3ArtifactsNotFound(self, mock_paginator):
+    def testListS3ArtifactsNotFound(self, mock_paginator):
         bucket_info = BucketMetadata(
             "ROCm-TheRock/", "therock-artifacts", "123", "linux"
         )
@@ -55,7 +55,7 @@ class ArtifactsIndexPageTest(unittest.TestCase):
         )
 
         with self.assertRaises(ClientError) as context:
-            retrieve_s3_artifacts(bucket_info, "test")
+            list_s3_artifacts(bucket_info, "test")
 
         self.assertEqual(context.exception.response["Error"]["Code"], "AccessDenied")
 

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -241,8 +241,7 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
   python ./build_tools/fetch_artifacts.py \
     --run-id=17123441166 \
     --target=gfx110X-dgpu \
-    --output-dir=$HOME/.therock/17123441166/artifacts \
-    --all
+    --output-dir=$HOME/.therock/17123441166/artifacts
 
   python ./build_tools/build_python_packages.py \
     --artifact-dir=$HOME/.therock/17123441166/artifacts \


### PR DESCRIPTION
## Motivation

This PR changes `fetch_artifacts.py` to _exclusively_ use include/exclude patterns for filtering artifact names to fetch. The ability to conveniently filter for "base artifacts" and individual components with flag options like `--blas --test` was retained in `install_rocm_from_artifacts.py` and supporting code was moved there. 

This follows up on https://github.com/ROCm/TheRock/pull/1607 where the build was broken and fixed by https://github.com/ROCm/TheRock/pull/1638. This script had multiple overlapping code paths for different types of artifact name filtering and download preparation, so making changes safely across all code paths was harder than it needed to be.

## Technical Details

Support for filter patterns was added in https://github.com/ROCm/TheRock/pull/1251.

Other changes included here:

* Perform all filtering before wrapping artifact names in `ArtifactDownloadRequest` dataclasses
* Added a `--dry-run` option to log what files would be downloaded without actually downloading
* Simplify control flow for optional artifact extraction
* Rework argparse argument groups
* Fixed a bug in `_should_include` where using excludes with no includes would not work as expected

## Test Plan

- [x] Test `fetch_artifacts.py` locally with a variety of arguments
- [x] Test `install_rocm_from_artifacts.py` locally with a variety of arguments
- [x] Run existing unit tests in `fetch_artifacts_test.py`
- [x] Add new unit tests
- [x] Watch CI tests

## Test Result

CI tests: https://github.com/ROCm/TheRock/actions/runs/18142412801/job/51645862524?pr=1644#step:5:214
```
Retrieving artifacts for run ID 18142412801

Calling fetch_artifacts_main with args:
  --run-id 18142412801 --target gfx1151 --output-dir build --flatten core-runtime_run core-runtime_lib sysdeps_lib base_run base_lib amd-llvm_run amd-llvm_lib core-hip_lib core-hip_dev rocprofiler-sdk_lib host-suite-sparse_lib blas_lib blas_test

Retrieving bucket info...
  (implicit) github_repository: ROCm/TheRock
  workflow_run_id             : 18142412801
Sending request to URL: https://api.github.com/repos/ROCm/TheRock/actions/runs/18142412801
  head_github_repository      : ScottTodd/TheRock
  is_pr_from_fork             : True
Retrieved bucket info:
  external_repo: ROCm-TheRock/
  bucket       : therock-artifacts-external
Retrieving S3 artifacts for 18142412801 in 'therock-artifacts-external' at 'ROCm-TheRock/18142412801-windows'

Filtered artifacts to download:
  therock-artifacts-external:ROCm-TheRock/18142412801-windows/amd-llvm_lib_generic.tar.xz
  therock-artifacts-external:ROCm-TheRock/18142412801-windows/amd-llvm_run_generic.tar.xz
  therock-artifacts-external:ROCm-TheRock/18142412801-windows/base_lib_generic.tar.xz
  therock-artifacts-external:ROCm-TheRock/18142412801-windows/base_run_generic.tar.xz
  therock-artifacts-external:ROCm-TheRock/18142412801-windows/blas_lib_gfx1151.tar.xz
  therock-artifacts-external:ROCm-TheRock/18142412801-windows/blas_test_gfx1151.tar.xz
  therock-artifacts-external:ROCm-TheRock/18142412801-windows/core-hip_dev_generic.tar.xz
  therock-artifacts-external:ROCm-TheRock/18142412801-windows/core-hip_lib_generic.tar.xz
  therock-artifacts-external:ROCm-TheRock/18142412801-windows/host-blas_lib_generic.tar.xz
  therock-artifacts-external:ROCm-TheRock/18142412801-windows/sysdeps_lib_generic.tar.xz

++ Downloading ROCm-TheRock/18142412801-windows/amd-llvm_lib_generic.tar.xz to build\amd-llvm_lib_generic.tar.xz
++ Downloading ROCm-TheRock/18142412801-windows/amd-llvm_run_generic.tar.xz to build\amd-llvm_run_generic.tar.xz
...
```