### PR TITLE
Add variable to enforce find_package when building hipblaslt

### DIFF
--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -126,6 +126,7 @@ therock_cmake_subproject_declare(hipBLASLt
     -DHIPBLASLT_BUILD_TESTING=${THEROCK_BUILD_TESTING}
     -DHIPBLASLT_ENABLE_ROCROLLER=${_enable_rocRoller}
     -DHIPBLASLT_ENABLE_FETCH=OFF
+    -DHIPBLASLT_ENABLE_THEROCK=ON
   CMAKE_INCLUDES
     therock_explicit_finders.cmake
   COMPILER_TOOLCHAIN


### PR DESCRIPTION
## Motivation

Since hipblaslt is migrating to `add_subdirectory` for rocroller consumption, but TheRock still uses standalone builds via `find_package`, a variable needs to be added to control the code flow between these two builds modes.

## Technical Details

Add `-DHIPBLASLT_ENABLE_THEROCK=ON` to the hipblaslt build. This PR is intended to align with https://github.com/ROCm/rocm-libraries/pull/1588, which resolves an API inconsistency between the rocroller_host in hipblaslt while also updating the dependency mechanism to `add_subdirectory`.

## Test Plan

TheRock CI testing through rocm-libraries

## Test Result

See the latest build results for TheRock CI here: https://github.com/ROCm/rocm-libraries/pull/1588

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
