### PR TITLE
[ci] Disable mi355 test machines

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -43,7 +43,7 @@ amdgpu_family_info_matrix_postsubmit = {
     "gfx950": {
         "linux": {
             # Networking issue: https://github.com/ROCm/TheRock/issues/1660
-            # Label is "linux-mi355-1gpu-ossci-rocm"s
+            # Label is "linux-mi355-1gpu-ossci-rocm"
             "test-runs-on": "",
             "family": "gfx950-dcgpu",
         }

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -42,7 +42,9 @@ amdgpu_family_info_matrix_presubmit = {
 amdgpu_family_info_matrix_postsubmit = {
     "gfx950": {
         "linux": {
-            "test-runs-on": "linux-mi355-1gpu-ossci-rocm",
+            # Networking issue: https://github.com/ROCm/TheRock/issues/1660
+            # Label is "linux-mi355-1gpu-ossci-rocm"s
+            "test-runs-on": "",
             "family": "gfx950-dcgpu",
         }
     },


### PR DESCRIPTION
Currently, mi355 tests are incredibly flaky due to networking issues (which is a cluster issue). Worked with OSSCI to figure out the root cause, however, it seems to be a conductor mi355 issue that is causing issues with other teams.

This issue may not be resolved for some time, so to prevent flaky results, we will be disabling for the time being

Issue to reenable #1660