### PR TITLE
[flag] Add new THEROCK_FLAG_INCLUDE_PROFILER flag.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,17 @@ cmake_dependent_option(
   "Enables delay loading and linker namespacing of the amd_comgr library (Linux only)"
   ON "LINUX" OFF)
 
+# Flag: -DTHEROCK_FLAG_INCLUDE_PROFILER=OFF
+# Note that the profiler is an integral part of the system and disabling it is not
+# fully supported. However, in early bringup, it can be useful to disable building
+# it, even though that may cause problems in other libraries.
+# On some platforms (WIN32 presently), the profiler is always disabled.
+cmake_dependent_option(
+  THEROCK_FLAG_INCLUDE_PROFILER
+  "Allows the profiler to be manually disabled by setting to OFF"
+  ON "NOT WIN32" OFF)
+
+
 ################################################################################
 # Debug Options
 ################################################################################
@@ -214,7 +225,7 @@ therock_add_feature(HIP_RUNTIME
 )
 
 # Profiler Features.
-if(NOT WIN32)
+if(THEROCK_FLAG_INCLUDE_PROFILER)
   therock_add_feature(ROCPROF_TRACE_DECODER_BINARY
     GROUP PROFILER
     DESCRIPTION "Enables the closed-source rocprof trace decoder binary"

--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -2,7 +2,7 @@ if(THEROCK_ENABLE_RCCL)
   # Most libraries need to depend on the profiler, but is conditionally only used
   # on Posix.
   set(optional_profiler_deps)
-  if(NOT WIN32)
+  if(THEROCK_FLAG_INCLUDE_PROFILER)
     list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
   endif()
 

--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_path(APPEND _blas_hack_hip_dir lib/llvm OUTPUT_VARIABLE _toolchain_dir)
 # Most libraries need to depend on the profiler, but is conditionally only used
 # on Posix.
 set(optional_profiler_deps)
-if(NOT WIN32)
+if(THEROCK_FLAG_INCLUDE_PROFILER)
   list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
 endif()
 

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Most libraries need to depend on the profiler, but is conditionally only used
 # on Posix.
 set(optional_profiler_deps)
-if(NOT WIN32)
+if(THEROCK_FLAG_INCLUDE_PROFILER)
   list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
 endif()
 


### PR DESCRIPTION
* Replaces earlier hard-coded `if(WIN32)` style logic.
* Being able to control this at the top level has proven useful for various system bringup tasks.
