### PR TITLE
Changed rocRAND to runtime dep in hipRAND declaration

### DIFF
--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -46,10 +46,10 @@ if(THEROCK_ENABLE_RAND)
       amd-hip
     BUILD_DEPS
       rocm-cmake
-      rocRAND
       therock-googletest
     RUNTIME_DEPS
       hip-clr
+      rocRAND
   )
   therock_cmake_subproject_glob_c_sources(hipRAND
     SUBDIRS


### PR DESCRIPTION
## Motivation

Before this patch, rocRAND was a BUILD_DEP. This was causing the RPATH to not be set properly and for it to not always include rocrand in its dist directory.

Closes: #1665 


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
