### PR TITLE
Add fileset_tool verbose configurable from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,12 @@ therock_enable_external_source("composable-kernel" "${THEROCK_SOURCE_DIR}/ml-lib
 # Overall build settings.
 option(THEROCK_VERBOSE "Enables verbose CMake statuses" OFF)
 
+# Map THEROCK_VERBOSE to a CLI flag for fileset_tool.py
+set(THEROCK_FILESET_VERBOSE_ARG "")
+if(THEROCK_VERBOSE)
+  set(THEROCK_FILESET_VERBOSE_ARG --verbose)
+endif()
+
 # Initialize the install directory.
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "${THEROCK_SOURCE_DIR}/install" CACHE PATH "" FORCE)

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -777,7 +777,7 @@ function(therock_cmake_subproject_activate target_name)
     add_custom_command(
       OUTPUT "${_stage_stamp_file}"
       # Populate local dist directory with this+all transitive stage installs.
-      COMMAND "${Python3_EXECUTABLE}" "${_fileset_tool}" copy "${_dist_dir}" ${_dist_source_dirs}
+      COMMAND "${Python3_EXECUTABLE}" "${_fileset_tool}" copy "${_dist_dir}" ${THEROCK_FILESET_VERBOSE_ARG} ${_dist_source_dirs}
       COMMAND "${CMAKE_COMMAND}" -E touch "${_stage_stamp_file}"
       DEPENDS
         "${_prebuilt_file}"
@@ -911,7 +911,7 @@ function(therock_cmake_subproject_activate target_name)
       # Install to stage directory.
       COMMAND ${_install_log_prefix} "${CMAKE_COMMAND}" --install "${_binary_dir}" ${_install_strip_option}
       # Populate local dist directory with this+all transitive stage installs.
-      COMMAND "${Python3_EXECUTABLE}" "${_fileset_tool}" copy "${_dist_dir}" ${_dist_source_dirs}
+      COMMAND "${Python3_EXECUTABLE}" "${_fileset_tool}" copy "${_dist_dir}" ${THEROCK_FILESET_VERBOSE_ARG} ${_dist_source_dirs}
       COMMAND "${CMAKE_COMMAND}" -E touch "${_stage_stamp_file}"
       WORKING_DIRECTORY "${_binary_dir}"
       COMMENT "Stage installing sub-project ${target_name}"


### PR DESCRIPTION
## Motivation

Add a CMake controlled `--verbose` to `fileset_tool` for better diagnostics.

## Technical Details

Map `THEROCK_VERBOSE` to a `THEROCK_FILESET_VERBOSE_ARG` and pass `--verbose` to `fileset_tool.py` during copy

## Test Plan

Build with `-DTHEROCK_VERBOSE=ON` (baseline), then with `ON` and verify detailed logs appear on stderr

## Test Result

OFF: unchanged output. ON: visible `rmtree` messages.

eg: rmtree `C:\home\runner\_work\TheRock\build\third-party\sysdeps\windows\zstd\build\dist`

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
