### PR TITLE
[ci] Resolving flaky issues for miopen and gfx101X linux

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -80,7 +80,7 @@ amdgpu_family_info_matrix_nightly = {
         "linux": {
             "test-runs-on": "",
             "family": "gfx101X-dgpu",
-            "expect_failure": False,
+            "expect_failure": True,
         },
         "windows": {
             "test-runs-on": "",

--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -144,6 +144,11 @@ negative_filter.append("Full/GPU_ConvGrpActivInfer3D_BFP16")  # 0 min 27 sec
 negative_filter.append("Full/GPU_ConvGrpActivInfer3D_FP32")  # 0 min 22 sec
 negative_filter.append("Full/GPU_ConvGrpActivInfer3D_FP16")  # 0 min 16 sec
 
+# Flaky tests
+negative_filter.append(
+    "Smoke/GPU_UnitTestConvSolverHipImplicitGemmV4R1Fwd_BFP16.ConvHipImplicitGemmV4R1Fwd/0"
+)  # https://github.com/ROCm/TheRock/issues/1682
+
 ####################################################
 
 gtest_final_filter_cmd = (


### PR DESCRIPTION
This will be an incremental effort to fix flaky. This PR will provide immediate resolution to this error:

- [MIOpen failing test](https://github.com/ROCm/TheRock/actions/runs/18204389582/job/51839829249), noted with #1682 
- [gfx101X linux failure](https://github.com/ROCm/TheRock/actions/runs/18211105677/job/51851538269)

Unfortunately, the [hipSPARSE issue](https://github.com/ROCm/TheRock/actions/runs/18204389582/job/51839829208) is deeper and needs to be worked with OSSCI 