### PR TITLE
[ci] adjust rocprim timeout time

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -57,7 +57,7 @@ test_matrix = {
     "rocprim": {
         "job_name": "rocprim",
         "fetch_artifact_args": "--prim --tests",
-        "timeout_minutes": 60,
+        "timeout_minutes": 30,
         "test_script": f"python {_get_script_path('test_rocprim.py')}",
         "platform": ["linux", "windows"],
         "total_shards": 1,


### PR DESCRIPTION
typically, rocprim takes around 8mins for linux and around 15 mins for windows. recently, there have been long timeout issues with `device_select`, which causes the test to timeout after 1h. 

This PR adjusts the rocprim timeout to catch this issue earlier. I'm actively working with the prim team to figure out and resolve this error