### PR TITLE
Clean up Docker image by removing devel packages and OMPI source build

### DIFF
--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -68,14 +68,6 @@ RUN yum install -y epel-release && \
       patchelf \
       vim-common \
       git-lfs \
-      m4 \
-      flex \
-      libevent-devel \
-      hwloc-devel \
-      numactl-devel \
-      pkgconfig \
-      zip \
-      unzip \
     && yum clean all && \
     rm -rf /var/cache/yum
 
@@ -109,20 +101,3 @@ RUN which gcc && gcc --version && \
 # We use the wildcard option to disable the checks. This was added
 # in git 2.35.3
 RUN git config --global --add safe.directory '*'
-
-######## Open MPI 5.0.8 (from source) ########
-# OpenMPI is currently not vendored into TheRock and temorarily installed
-ENV OMPI_VER=5.0.8
-ENV OMPI_PREFIX=/opt/openmpi-${OMPI_VER}
-
-# Copy and execute the build/install portion
-COPY install_openmpi.sh /tmp/install_openmpi.sh
-RUN /tmp/install_openmpi.sh && rm -f /tmp/install_openmpi.sh
-
-# Expose Open MPI by default
-ENV PATH="${OMPI_PREFIX}/bin:${PATH}"
-ENV LD_LIBRARY_PATH="${OMPI_PREFIX}/lib:${LD_LIBRARY_PATH}"
-ENV PKG_CONFIG_PATH="${OMPI_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
-
-RUN which mpicc && mpirun && \
-    mpirun --version || true


### PR DESCRIPTION
Description

This PR addresses [#1707](https://github.com/ROCm/TheRock/issues/1707)
 by removing the devel packages and OpenMPI 5.0.8 source build introduced in [#1517](https://github.com/ROCm/TheRock/pull/1517)
.

A separate workflow was added in [commit cd0270b8](https://github.com/ROCm/TheRock/commit/cd0270b8be590be0f536121834bfe14c8ea9cc6b)
 to handle building and publishing the RCCL/RCCL-Tests manylinux Docker image with OMPI 5.0.8 support.
This separation ensures:

Devel packages (e.g., numactl) are no longer bundled in the build image.

Reduced risk of regressions due to overlapping dependencies already provided by TheRock.

Clear isolation between the main build image and the OMPI-specific environment.

Together with the OMPI publishing workflow, this PR fully resolves once workflows are updated with the new published docker image [#1707](https://github.com/ROCm/TheRock/issues/1707).