### PR TITLE
[ci] Adding bug fix for test selection

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -146,6 +146,9 @@ def run():
 
     logging.info(f"Selecting projects: {project_to_test}")
 
+    # This string -> array conversion ensures no partial strings are detected during test selection (ex: "hipblas" in ["hipblaslt", "rocblas"] = false)
+    project_array = [item.strip() for item in project_to_test.split(",")]
+
     output_matrix = []
     for key in test_matrix:
         job_name = test_matrix[key]["job_name"]
@@ -167,10 +170,8 @@ def run():
             continue
 
         # If the test is enabled for a particular platform and a particular (or all) projects are selected
-        # This string -> array conversion ensures no partial strings are detected during test selection (ex: "hipblas" in ["hipblaslt", "rocblas"] = false)
-        project_to_test = [item.strip() for item in project_to_test.split(",")]
         if platform in test_matrix[key]["platform"] and (
-            key in project_to_test or "*" in project_to_test
+            key in project_array or "*" in project_array
         ):
             logging.info(f"Including job {job_name}")
             job_config_data = test_matrix[key]


### PR DESCRIPTION
Fixes test selection bug

Previously when we added "hipblas", the `project_to_test` was set to `hipblaslt, rocblas`. Since `"hipblas" in "hipblaslt, rocblas"` is true, it triggered hipblas tests even though it wasn't included yet