### PR TITLE
[ci] Removing rocprim flaky tests

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocprim.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprim.py
@@ -11,7 +11,18 @@ THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 logging.basicConfig(level=logging.INFO)
 
 # Issue to fix ignored tests: https://github.com/ROCm/TheRock/issues/1724
-TESTS_TO_IGNORE = "rocprim.lookback_reproducibility|rocprim.linking|rocprim.device_merge_inplace|rocprim.device_merge_sort|rocprim.device_partition|rocprim.device_radix_sort|rocprim.device_select|rocprim.device_find_first_of|rocprim.device_reduce_by_key"
+TESTS_TO_IGNORE = [
+    "rocprim.lookback_reproducibility",
+    "rocprim.linking",
+    "rocprim.device_merge_inplace",
+    "rocprim.device_merge_sort",
+    "rocprim.device_partition",
+    "rocprim.device_radix_sort",
+    "rocprim.device_select",
+    "rocprim.device_find_first_of",
+    "rocprim.device_reduce_by_key",
+]
+
 SMOKE_TESTS = [
     "*ArgIndexIterator",
     "*BasicTests.GetVersion",
@@ -81,7 +92,7 @@ cmd = [
     "--parallel",
     "8",
     "--exclude-regex",
-    TESTS_TO_IGNORE,
+    "|".join(TESTS_TO_IGNORE),
     "--timeout",
     "900",
     "--repeat",


### PR DESCRIPTION
Noticing flaky tests in rocm-libraries, so removing those tests

progress on #1724 

After this is merged, will bump commit hash in rocm-libraries

tests ignored properly here and working here: https://github.com/ROCm/TheRock/actions/runs/18358935169