### PR TITLE
Skip uploading iPhone packages

### DIFF
--- a/build_tools/third_party/s3_management/update_dependencies.py
+++ b/build_tools/third_party/s3_management/update_dependencies.py
@@ -133,6 +133,12 @@ def upload_missing_whls(
         # Skip i686 packages
         if "i686" in pkg:
             continue
+        # Skip iphoneos packages
+        if "iphoneos" in pkg:
+            continue
+        # Skip iphonesimulator packages
+        if "iphonesimulator" in pkg:
+            continue
         # Skip unsupported Python version
         if "cp39" in pkg:
             continue


### PR DESCRIPTION
We don't want to provide dependencies for `iphoneos` and `iphonesimulator`.