### PR TITLE
Only remove the prefix if it is entirely present

### DIFF
--- a/build_tools/third_party/s3_management/manage.py
+++ b/build_tools/third_party/s3_management/manage.py
@@ -289,13 +289,10 @@ class S3Index:
             if any(obj.key.endswith(x) for x in ("networkx-3.3-py3-none-any.whl", "networkx-3.4.2-py3-none-any.whl")):
                 attributes += ' data-requires-python="&gt;=3.10"'
 
-            if STRIP_PREFIX:
-                stripped_key = obj.key.lstrip(STRIP_PREFIX) if obj.key.startswith(STRIP_PREFIX) else obj.key
-            else:
-                stripped_key = obj.key
+            stripped_key = obj.key.removeprefix(STRIP_PREFIX) if STRIP_PREFIX else obj.key
 
             out.append(
-                f'    <a href="{stripped_key}{maybe_fragment}"{attributes}>{path.basename(obj.key).replace("%2B","+")}</a><br/>'
+                f'    <a href="/{stripped_key}{maybe_fragment}"{attributes}>{path.basename(obj.key).replace("%2B","+")}</a><br/>'
             )
         # Adding html footer
         out.append('  </body>')


### PR DESCRIPTION
This is required to e.g. strip `v3`, whereas `v2` should stay intact and should not be touched. With the former implementation the first character gets stripped, resulting in `v2` -> `2`. Furthermore, re-introduced the preceding backslash.