### PR TITLE
[fix]: Replace older mirror for libdrm

### DIFF
--- a/third-party/sysdeps/linux/libdrm/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libdrm/CMakeLists.txt
@@ -6,8 +6,8 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     therock_subproject_fetch(therock-libdrm-sources
       SOURCE_DIR "${_source_dir}"
       # Originally mirrored from: "https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-2.4.124/drm-libdrm-2.4.124.tar.bz2"
-      URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/drm-libdrm-2.4.124.tar.bz2"
-      URL_HASH "SHA256=18e66044e0542040614a7904b6a2c0e5249a81e705fe9ba5a1cc2e5df11416e6"
+      URL "https://gitlab.freedesktop.org/mesa/libdrm/-/archive/libdrm-2.4.126/libdrm-libdrm-2.4.126.tar.bz2"
+      URL_HASH "SHA256=794a4d8ad685e66febdc11f981be191205a3c2ce7bcaeb1801ea86ddc666bb2b"
       TOUCH "${_download_stamp}"
     )
 


### PR DESCRIPTION
## Motivation

Closes #1737 

## Technical Details

Modified CMakeLists.txt to specify an alternative URL for `libdrm`. Note that this issue may reoccur due to static version linking. Consider revising the download logic to make it more robust and version-independent.

## Test Plan

Run `rocminfo` and `amd-smi`.

## Test Result

amdsmi:

```bash
/therock/output/build/dist/rocm/bin/amd-smi
+------------------------------------------------------------------------------+
| AMD-SMI 26.1.0+cff30bb0      amdgpu version: 6.12.12  ROCm version: 7.9.0    |
| VBIOS version:                                                               |
| Platform: Linux Baremetal                                                    |
|-------------------------------------+----------------------------------------|
| BDF                        GPU-Name | Mem-Uti   Temp   UEC       Power-Usage |
| GPU  HIP-ID  OAM-ID  Partition-Mode | GFX-Uti    Fan               Mem-Usage |
|=====================================+========================================|
| 0000:63:00.0 AMD Radeon RX 7900 XTX | 0 %      29 °C   0            50/327 W |
|   0       0     N/A             N/A | 1 %      0.0 %             27/24560 MB |
|-------------------------------------+----------------------------------------|
| 0000:a3:00.0  AMD Radeon RX 6700 XT | 0 %      27 °C   0            15/203 W |
|   1       2     N/A             N/A | 0 %      0.0 %             15/12272 MB |
|-------------------------------------+----------------------------------------|
| 0000:c3:00.0  AMD Radeon RX 9070 XT | 0 %      24 °C   0            12/304 W |
|   2       1     N/A             N/A | 0 %      0.0 %            519/16304 MB |
+-------------------------------------+----------------------------------------+
+------------------------------------------------------------------------------+
| Processes:                                                                   |
|  GPU        PID  Process Name          GTT_MEM  VRAM_MEM  MEM_USAGE     CU % |
|==============================================================================|
|  No running processes found                                                  |
+------------------------------------------------------------------------------+
```

rocminfo:

```bash
/therock/output/build/dist/rocm/bin/rocminfo | grep "Marketing Name:"
  Marketing Name:          AMD Radeon RX 7900 XTX
  Marketing Name:          AMD Radeon RX 9070 XT
  Marketing Name:          AMD Radeon RX 6700 XT
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
