### PR TITLE
Update manylinux containers to use gcc-toolset-13

### DIFF
--- a/dockerfiles/build_manylinux_rccl_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_rccl_x86_64.Dockerfile
@@ -89,12 +89,16 @@ RUN pip install dvc[s3]==3.62.0 && \
 ######## Enable GCC Toolset and verify ########
 # This is a subset of what is typically sourced in the gcc-toolset enable
 # script.
+# The base manylinux container has references to its gcc-toolset in its PATHs,
+# clean up LIBRARY_PATH and LD_LIBRARY_PATH since we yum remove that version.
 # -- Predefine variables to avoid Dockerfile linting warnings --
 # Docker requires environment variables to be defined before reuse.
 ENV LIBRARY_PATH=""
+ENV LD_LIBRARY_PATH=""
+ENV DEVTOOLSET_ROOTPATH="/opt/rh/gcc-toolset-13/root"
 ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
-ENV LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LIBRARY_PATH}"
-ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
+ENV LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib:${LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib:${LD_LIBRARY_PATH}"
 
 ######## Enable GCC Toolset and verify ########
 RUN which gcc && gcc --version && \

--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -89,8 +89,8 @@ ENV LIBRARY_PATH=""
 ENV LD_LIBRARY_PATH=""
 ENV DEVTOOLSET_ROOTPATH="/opt/rh/gcc-toolset-13/root"
 ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
-ENV LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LIBRARY_PATH}"
-ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
+ENV LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib:${LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib:${LD_LIBRARY_PATH}"
 
 ######## Enable GCC Toolset and verify ########
 RUN which gcc && gcc --version && \


### PR DESCRIPTION
- To address #1738 and #83
- gcc-toolset-12 ships with binutils 2.38, and this version has a bug exposed by `DYNAMIC_ARCH` turned ON for OpenBLAS. See OpenMathLib/OpenBLAS#3708
- TheRock needs that `DYNAMIC_ARCH` OpenBLAS flag on to support testing of BLAS and SOLVER libraries for cases where test machine's CPU is different than the build machine. The CPU is used for calculating results, and comparing against the test result values produced by the GPU.
- gcc-toolset-13 has a version of binutils that is fixed for this use case.
