### PR TITLE
Add markupsafe to dependencies

### DIFF
--- a/build_tools/third_party/s3_management/update_dependencies.py
+++ b/build_tools/third_party/s3_management/update_dependencies.py
@@ -32,6 +32,7 @@ PACKAGES_PER_PROJECT = {
     "networkx": {"version": "latest", "project": "torch"},
     "numpy": {"version": "latest", "project": "torch"},
     "jinja2": {"version": "latest", "project": "torch"},
+    "markupsafe": {"version": "latest", "project": "torch"},
     "filelock": {"version": "latest", "project": "torch"},
     "fsspec": {"version": "latest", "project": "torch"},
     "typing-extensions": {"version": "latest", "project": "torch"},


### PR DESCRIPTION
Test workflows installing from the prereleases index is failing with
```
ERROR: Could not find a version that satisfies the requirement MarkupSafe>=2.0 (from jinja2) (from versions: none)
ERROR: No matching distribution found for MarkupSafe>=2.0
```

Upstream adds markupsafe as a dependency for torchtune at https://github.com/pytorch/test-infra/blob/8a43a2f1b263018fe9b04ffdc837c8384996e6e3/s3_management/update_dependencies.py#L337C5-L337C67

but jinja2 is a dependency required by torch. Thus adding it to the torch collection