### PR TITLE
[ci] Adding windows proxy fix for choco

### DIFF
--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -65,7 +65,7 @@ jobs:
         # The first two lines removes the default commmunity feed and uses the internal proxy feed
         run: |
           choco source disable -n=chocolatey
-          choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-proxy/ --priority=1
+          choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
           choco install --no-progress -y ccache
           # ninja pinned due to a bug in the 1.13.0 release:
           # https://github.com/ninja-build/ninja/issues/2616


### PR DESCRIPTION
After getting `Too many requests` failures for windows, we were able to get a proxy server up to use internal packages. This way, we will have no more rate limiting issues.

works here: https://github.com/ROCm/TheRock/actions/runs/18420282704/job/52492915128 (please check the install requirements.txt step)

Closes #1761 
