### PR TITLE
[ci] Adding submodule coverage 

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -43,9 +43,10 @@
 import fnmatch
 import json
 import os
+from pathlib import Path
 import subprocess
 import sys
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, List, Optional
 import string
 from amdgpu_family_matrix import (
     amdgpu_family_info_matrix_presubmit,
@@ -57,6 +58,8 @@ from fetch_test_configurations import test_matrix
 
 from github_actions_utils import *
 
+THIS_SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = THIS_SCRIPT_DIR.parent.parent
 
 # --------------------------------------------------------------------------- #
 # Filtering by modified paths
@@ -80,6 +83,33 @@ def get_modified_paths(base_ref: str) -> Optional[Iterable[str]]:
             file=sys.stderr,
         )
         return None
+
+
+def get_therock_submodule_paths() -> Optional[Iterable[str]]:
+    """Returns TheRock submodules paths."""
+    try:
+        response = subprocess.run(
+            ["git", "submodule", "status"],
+            stdout=subprocess.PIPE,
+            check=True,
+            text=True,
+            timeout=60,
+            cwd=THEROCK_DIR,
+        ).stdout.splitlines()
+
+        submodule_paths = []
+        for line in response:
+            submodule_data_array = line.split()
+            # The line will be "{commit-hash} {path} {branch}". We will retrieve the path.
+            submodule_paths.append(submodule_data_array[1])
+        return submodule_paths
+    except TimeoutError:
+        print(
+            "Computing modified files timed out. Not using PR diff to determine"
+            " jobs to run.",
+            file=sys.stderr,
+        )
+        return []
 
 
 # Paths matching any of these patterns are considered to have no influence over
@@ -364,21 +394,14 @@ def main(base_args, linux_families, windows_families):
         #     * workflow_dispatch or workflow_call with inputs controlling enabled jobs?
         enable_build_jobs = should_ci_run_given_modified_paths(modified_paths)
 
-        # If the modified path contains any submodule bumps, we want to run a full test suite.
+        # If the modified path contains any git submodules, we want to run a full test suite.
         # Otherwise, we just run smoke tests
-        submodule_paths = [
-            "base/amdsmi",
-            "base/half",
-            "base/rocm-cmake",
-            "comm-libs/rccl",
-            "compiler/amd-llvm",
-            "compiler/hipify",
-            "ml-libs/composable_kernel",
-            "rocm-libraries",
-            "rocm-systems",
-        ]
+        submodule_paths = get_therock_submodule_paths()
         matching_submodule_paths = list(set(submodule_paths) & set(modified_paths))
         if matching_submodule_paths:
+            print(
+                f"Found changed submodules: {str(matching_submodule_paths)}. Running full tests."
+            )
             test_type = "full"
 
         # If any test label is included, run full test suite for specified tests


### PR DESCRIPTION
## Motivation

When a submodule bump is added, we run full test suites (particularly since those submodules are paramount to TheRock)

## Technical Details

If a submodule bump occurs, we run all tests

## Test Plan

I did some local Python testing to ensure the operator works as proper to check for matching.

## Test Result

<img width="1373" height="729" alt="Screenshot 2025-10-13 104636" src="https://github.com/user-attachments/assets/dac2e752-e1db-4b20-829a-c2fe470600eb" />

Git submodule check:
```
(venv) C:\Users\geomin12\Code\TheRock>python test.py
['base/amdsmi', 'base/half', 'base/rocm-cmake', 'comm-libs/rccl', 'comm-libs/rccl-tests', 'compiler/amd-llvm', 'compiler/hipify', 'compiler/spirv-llvm-translator', 'ml-libs/composable_kernel', 'profiler/rocprof-trace-decoder/binaries', 'rocm-libraries', 'rocm-systems']
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
