### PR TITLE
[ci] Adding rocprim test `device_scan` to exclude

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocprim.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprim.py
@@ -18,6 +18,7 @@ TESTS_TO_IGNORE = [
     "rocprim.device_merge_sort",
     "rocprim.device_partition",
     "rocprim.device_radix_sort",
+    "rocprim.device_scan",
     "rocprim.device_select",
     "rocprim.device_find_first_of",
     "rocprim.device_reduce_by_key",


### PR DESCRIPTION
monorepo gardener noticed test timeouts here: https://github.com/ROCm/rocm-libraries/actions/runs/18458030785/job/52600126252

Excluding this test, noted on #1724 and noted with internal ticket for PRIM team