### PR TITLE
[ci] Adding `hipsparse_test.data` for test executables

### DIFF
--- a/math-libs/BLAS/artifact-blas.toml
+++ b/math-libs/BLAS/artifact-blas.toml
@@ -166,7 +166,6 @@ include = [
   "bin/*_rtest.xml",
   "bin/rocsparse-bench*",
   "bin/rocsparse-test*",
-  "bin/rocsparse_test*",
   "libexec/rocsparse/test/rocsparse_gentest.py",
   "share/rocsparse/test/**",
   "clients/matrices/**"
@@ -195,7 +194,8 @@ include = [
   "bin/*_rtest.xml",
   "bin/hipsparse-bench*",
   "bin/hipsparse-test*",
-  "bin/hipsparse_test*",
+  "libexec/hipsparse/test/hipsparse_gentest.py",
+  "share/hipsparse/test/**",
   "clients/matrices/**"
 ]
 optional = true


### PR DESCRIPTION
After an update from rocm-libraries, [`hipsparse` tests fail now](https://github.com/ROCm/rocm-libraries/actions/runs/18505771743/job/52741890136?pr=1763). 

This change adds the `hipsparse_data` files needed, working here: https://github.com/ROCm/rocm-libraries/actions/runs/18508620569/job/52761185790?pr=1763

This will enable SPARSE testing for monorepo
