### PR TITLE
[ci] Fixing rate limiting issue for Github API calls

### DIFF
--- a/build_tools/github_actions/github_actions_utils.py
+++ b/build_tools/github_actions/github_actions_utils.py
@@ -113,7 +113,7 @@ def gha_get_request_headers():
     # If GITHUB_TOKEN environment variable is available, include it in the API request to avoid a lower rate limit
     gh_token = os.getenv("GITHUB_TOKEN", "")
     if gh_token:
-        headers["Authentication"] = f"Bearer {gh_token}"
+        headers["Authorization"] = f"Bearer {gh_token}"
 
     return headers
 


### PR DESCRIPTION
According to [docs](https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?utm_source=chatgpt.com&apiVersion=2022-11-28#about-authentication), it is supposed to use `Authorization` rather than `Authentication`

Tested locally with evidence here: https://github.com/ROCm/TheRock/issues/1796#issuecomment-3404004171

Closes #1796 

Next: update rocm-libraries to pick up this change. I see some tests failing with rate limiting issues!