### PR TITLE
Ignore MIOpen tests that cause failures when run with sharding on TheRock CI

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -151,9 +151,15 @@ negative_filter.append(
 )  # https://github.com/ROCm/TheRock/issues/1682
 
 # Tests that fail when run with sharding
-negative_filter.append("Smoke/GPU_ConvGrpBiasActivInfer_BFP16.ConvCKIgemmGrpFwdBiasActivFused/0")
-negative_filter.append("Smoke/GPU_ConvGrpBiasActivInfer_BFP16.ConvCKIgemmGrpFwdBiasActivFused/2")
-negative_filter.append("Smoke/GPU_ConvBiasActivInfer_FP16.ConvCKIgemmFwdBiasActivFused/1")
+negative_filter.append(
+    "Smoke/GPU_ConvGrpBiasActivInfer_BFP16.ConvCKIgemmGrpFwdBiasActivFused/0"
+)
+negative_filter.append(
+    "Smoke/GPU_ConvGrpBiasActivInfer_BFP16.ConvCKIgemmGrpFwdBiasActivFused/2"
+)
+negative_filter.append(
+    "Smoke/GPU_ConvBiasActivInfer_FP16.ConvCKIgemmFwdBiasActivFused/1"
+)
 
 ####################################################
 


### PR DESCRIPTION
## Motivation

Running MIOpen tests on TheRock CI with sharding enabled causes 3 tests to fail and this is blocking integration with CK and rocm-libraries. These tests pass when sharding is disabled but the tests take longer than 60 minutes to run and get timed out.

## Technical Details

Temporarily ignore these tests while we investigate the root cause.

## Test Plan

Run TheRock CI

## Test Result

Test pass pending

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
