### PR TITLE
Switch Python index pages to relative links

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -205,7 +205,6 @@ jobs:
         env:
           # Environment variables to be set for `manage.py`
           CUSTOM_PREFIX: "${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}"
-          STRIP_PREFIX: "v3/"
         run: |
           pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}
@@ -299,7 +298,6 @@ jobs:
         env:
           # Environment variables to be set for `manage.py`
           CUSTOM_PREFIX: "${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}"
-          STRIP_PREFIX: "v3/"
         run: |
           pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -240,7 +240,6 @@ jobs:
         env:
           # Environment variables to be set for `manage.py`
           CUSTOM_PREFIX: "${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}"
-          STRIP_PREFIX: "v3/"
         shell: cmd
         run: |
           pip install boto3 packaging
@@ -332,7 +331,6 @@ jobs:
         env:
           # Environment variables to be set for `manage.py`
           CUSTOM_PREFIX: "${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}"
-          STRIP_PREFIX: "v3/"
         run: |
           pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -154,7 +154,6 @@ jobs:
       S3_BUCKET_PY: "therock-${{ needs.setup_metadata.outputs.release_type }}-python"
       S3_SUBDIR: ${{ inputs.s3_subdir || 'v2' }}
       S3_STAGING_SUBDIR: ${{ inputs.s3_staging_subdir || 'v2-staging' }}
-      STRIP_PREFIX: "v3/" # Environment variable to be set for `manage.py`
 
     steps:
       - name: "Checking out repository"

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -162,7 +162,6 @@ jobs:
       S3_BUCKET_PY: "therock-${{ needs.setup_metadata.outputs.release_type }}-python"
       S3_SUBDIR: ${{ inputs.s3_subdir || 'v2' }}
       S3_STAGING_SUBDIR: ${{ inputs.s3_staging_subdir || 'v2-staging' }}
-      STRIP_PREFIX: "v3/" # Environment variable to be set for `manage.py`
 
     steps:
       - name: "Checking out repository"

--- a/build_tools/third_party/s3_management/manage.py
+++ b/build_tools/third_party/s3_management/manage.py
@@ -54,8 +54,6 @@ CUSTOM_PREFIX = getenv('CUSTOM_PREFIX')
 if CUSTOM_PREFIX:
     PREFIXES.append(CUSTOM_PREFIX)
 
-STRIP_PREFIX = getenv('STRIP_PREFIX', '')
-
 # NOTE: This refers to the name on the wheels themselves and not the name of
 # package as specified by setuptools, for packages with "-" (hyphens) in their
 # names you need to convert them to "_" (underscores) in order for them to be
@@ -289,10 +287,10 @@ class S3Index:
             if any(obj.key.endswith(x) for x in ("networkx-3.3-py3-none-any.whl", "networkx-3.4.2-py3-none-any.whl")):
                 attributes += ' data-requires-python="&gt;=3.10"'
 
-            stripped_key = obj.key.removeprefix(STRIP_PREFIX) if STRIP_PREFIX else obj.key
+            stripped_key = obj.key.split("/")[-1]
 
             out.append(
-                f'    <a href="/{stripped_key}{maybe_fragment}"{attributes}>{path.basename(obj.key).replace("%2B","+")}</a><br/>'
+                f'    <a href="../{stripped_key}{maybe_fragment}"{attributes}>{path.basename(obj.key).replace("%2B","+")}</a><br/>'
             )
         # Adding html footer
         out.append('  </body>')


### PR DESCRIPTION
`manage.py` creates an index.html file for every package which is placed in a subdirectory named after the package. Packages are located one level above whereas links where abolsute. This refactors to use relative links instead as this allows to move the index to a different directory without rewriting.

This is compliant with PEP 503 [1]:
URLs may be either absolute or relative as long as they point to the correct location.

[1] https://peps.python.org/pep-0503/