### PR TITLE
[RFC] Add RFC0004 proposing the inclusion of libhipcxx into ROCm-Core

### DIFF
--- a/docs/rfcs/RFC0006-libhipcxx-ROCm-Core-Inclusion.md
+++ b/docs/rfcs/RFC0006-libhipcxx-ROCm-Core-Inclusion.md
@@ -1,7 +1,7 @@
 ---
 author: Marco Grond (marco-grond)
 created: 2025-10-16
-modified: 2025-10-20
+modified: 2025-10-29
 status: draft
 ---
 
@@ -47,3 +47,4 @@ included in TheRock. Release pipelines should also be updated to include libhipc
 
 - 2025-10-16: marco-grond: Create skeleton
 - 2025-10-20: marco-grond: Filled out content
+- 2025-10-29: marco-grond: Updated RFC number


### PR DESCRIPTION
## Motivation

This PR adds a new RFC for the inclusion of libhipcxx into ROCm-Core with 7.10

## Technical Details

No technical details, only an RFC document addition

## Test Plan

No test plan necessary, as this is only a RFC addition to the docs

## Test Result

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
