### PR TITLE
[torch] Document compatibility for torchaudio and torchvision

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -261,8 +261,8 @@ also install `torch`, `torchaudio`, and `torchvision`.
 >
 > | torch version | torchaudio version | torchvision version |
 > | ------------- | ------------------ | ------------------- |
-> | 2.10          | 2.8 (?)            | 0.25                |
-> | 2.9           | 2.8 (?)            | 0.24                |
+> | 2.10          | 2.10               | 0.25                |
+> | 2.9           | 2.9                | 0.24                |
 > | 2.7           | 2.7.1a0            | 0.22.1              |
 >
 > For example, `torch` 2.7.1 and compatible wheels can be installed by specifying


### PR DESCRIPTION
These docs previously stated that only `torchaudio` needed to be compatible with `torch`, but `torchvision` needs to be compatible too.

> [!CAUTION]
> Prior to https://github.com/pytorch/audio/commit/69bbe7363897764f9e758d851cd0340147d27f94, our torchaudio builds from `nightly` have continued to use version 2.8.0a0 (see https://rocm.nightlies.amd.com/v2/gfx1151/torchaudio/). We don't have a way to differentiate which of these was built for torch 2.8, 2.9, or 2.10. New builds for 2.9 and nightly 2.10 should now use the expected versions.