### PR TITLE
Remove BLAS tests from exclusion lists

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hipblas.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblas.py
@@ -20,9 +20,6 @@ logging.basicConfig(level=logging.INFO)
 
 tests_to_exclude = [
     "*known_bug*",
-    "_/getrs*",
-    "_/getri_batched.solver*",
-    "_/gels_batched.solver*",
 ]
 
 exclusion_list = ":".join(tests_to_exclude)

--- a/build_tools/github_actions/test_executable_scripts/test_rocblas.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocblas.py
@@ -25,7 +25,7 @@ if test_type == "smoke":
     test_filter = ["--yaml", f"{THEROCK_BIN_DIR}/rocblas_smoke.yaml"]
 else:
     # only running smoke tests due to openBLAS issue: https://github.com/ROCm/TheRock/issues/1605
-    test_filter = ["--yaml", f"{THEROCK_BIN_DIR}/rocblas_smoke.yaml"]
+    test_filter = [f"--gtest_filter=*quick*:*pre_checkin*-*known_bug*"]
 
 cmd = [f"{THEROCK_BIN_DIR}/rocblas-test"] + test_filter
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")


### PR DESCRIPTION
- Tests were previously added to exclusion lists due to OpenBLAS issues causing test failures.
- Attempting to try these with new OpenBLAS built.
- Will need ROCm/rocm-libraries#2098 to be merged and pulled in a submodule bump.
- Will also need #1826 as OpenBLAS with ILP64 is required for hipblas tests to work, and presumably other BLAS libraries.