### PR TITLE
[Documentation] Update python_packaging.md

### DIFF
--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -66,7 +66,7 @@ defaults to the first available family, in which case it might be necessary to s
 ./build_tools/build_python_packages.py \
     --artifact-dir ./output-linux-portable/build/artifacts \
     --dest-dir ${HOME}/tmp/packages \
-    --version 7.0.0.dev0
+    --version 7.10.0.dev0
 ```
 
 Note that this does do some dynamic compilation of files and it performs
@@ -80,8 +80,8 @@ To install locally built packages you can either
 
    ```bash
    python3 -m venv .venv && source .venv/bin/activate
-   pip install ${HOME}/tmp/packages/dist/rocm-7.0.0.dev0.tar.gz \
-               ${HOME}/tmp/packages/dist/rocm_sdk_core-7.0.0.dev0-py3-none-linux_x86_64.whl
+   pip install ${HOME}/tmp/packages/dist/rocm-7.10.0.dev0.tar.gz \
+               ${HOME}/tmp/packages/dist/rocm_sdk_core-7.10.0.dev0-py3-none-linux_x86_64.whl
    # Optionally install rocm_sdk_devel and rocm_sdk_libraries wheels
    ```
 
@@ -92,7 +92,7 @@ To install locally built packages you can either
    python3 -m venv .venv && source .venv/bin/activate
    pip install piprepo setuptools
    piprepo build ${HOME}/tmp/packages/dist
-   pip install rocm[libraries,devel]==7.0.0.dev0 \
+   pip install rocm[libraries,devel]==7.10.0.dev0 \
      --extra-index-url ${HOME}/tmp/packages/dist/simple \
      --force-reinstall --no-cache-dir
    ```


### PR DESCRIPTION
## Motivation

The example is missing the version flag letting users copy and paste the commands to build. This flag has a default that causes `pip install` to fail down the line (saying it can't find a valid version) that requires the user to dig into the scripts to figure out why.


