### PR TITLE
Modularize TheRock manifest generation into schema + writer

### DIFF
--- a/build_tools/generate_therock_manifest.py
+++ b/build_tools/generate_therock_manifest.py
@@ -152,7 +152,13 @@ def main():
     ap = argparse.ArgumentParser(
         description="Generate submodule pin/patch manifest for TheRock."
     )
-    ap.add_argument("-o", "--output", required=True, help="Output JSON path")
+    # make --output optional with a default message and value of None
+    ap.add_argument(
+        "-o",
+        "--output",
+        help="Output JSON path (default: <repo>/therock_manifest.json)",
+        default=None,
+    )
     ap.add_argument(
         "--commit", help="TheRock commit/ref to inspect (default: HEAD)", default="HEAD"
     )
@@ -164,7 +170,10 @@ def main():
     manifest = build_manifest_schema(repo_root, the_rock_commit)
 
     # Decide output path
-    out_path = Path(args.output)
+    # if not provided, write to repo_root / "therock_manifest.json"
+    out_path = (
+        Path(args.output) if args.output else (repo_root / "therock_manifest.json")
+    )
 
     # Write JSON
     write_manifest_json(out_path, manifest)


### PR DESCRIPTION
## Motivation

Recognized one comment missed to address from previous PR: https://github.com/ROCm/TheRock/pull/1790#discussion_r2441463829

These are not functional changes. It improves the code readability with two functions in the main. 

```
manifest = build_manifest_schema(repo_root, the_rock_commit)
write_manifest_json(out_path, manifest)
```

## Test Plan
Test in local and CI.
Check the CI Summary to make sure the generated manifest files exist in the links.


## Test Result
For local, the manifest was generated
For CI, the manifest was generated which can be reach from the summary: https://github.com/ROCm/TheRock/actions/runs/18695993535?pr=1861

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
