### PR TITLE
[ci] Adding `release/2.9_rocm79` for linux torch builds

### DIFF
--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -90,7 +90,7 @@ jobs:
         include:
           - pytorch_version: release/2.7
             pytorch_patchset: rocm_2.7
-          - pytorch_version: release/2.9
+          - pytorch_version: release/2.9_rocm7.9
             pytorch_patchset: rocm_2.9
           - pytorch_version: nightly
             pytorch_patchset: nightly


### PR DESCRIPTION
Works here: https://github.com/ROCm/TheRock/actions/runs/18700097752/job/53326829599 (tests don't work as I just ran a sample torch build)

There is a pending fix via cherry pick, but this is the current workaround