### PR TITLE
Make devel section more robust for purelib and platlib site-packages

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -83,12 +83,14 @@ def _expand_devel_contents(rocm_sdk_devel_path: Path, site_lib_path: Path):
     # Resolve the Python package to its distribution package name and find the
     # RECORD file.
     dist_names = md.packages_distributions()["rocm_sdk_devel"]
-    
+
     # De-duplication, preserving order (handles purelib/platlib duplicates)
     seen_dist_names = set()
-    dist_names_list = [d for d in dist_names if not (d in seen_dist_names or seen_dist_names.add(d))]
-    
-    #to preserve fail-fast behavior
+    dist_names_list = [
+        d for d in dist_names if not (d in seen_dist_names or seen_dist_names.add(d))
+    ]
+
+    # to preserve fail-fast behavior
     assert len(dist_names_list) >= 1, (
         "No distribution candidates found for 'rocm_sdk_devel'. "
         "Ensure rocm-sdk[devel] is installed in the current environment."
@@ -97,7 +99,7 @@ def _expand_devel_contents(rocm_sdk_devel_path: Path, site_lib_path: Path):
     record_pkg_file = None
     dist_files = None
     dist_name = None
-    
+
     for candidate in dist_names_list:
         candidate_files = md.files(candidate)
         if candidate_files is None:
@@ -105,15 +107,18 @@ def _expand_devel_contents(rocm_sdk_devel_path: Path, site_lib_path: Path):
 
         # Look for RECORD inside a *.dist-info directory.
         for record_pkg_file in candidate_files:
-            if record_pkg_file.name == "RECORD" and record_pkg_file.parent.name.endswith(".dist-info"):
-                #Found a usable candidate; set dist_name/dist_files
+            if (
+                record_pkg_file.name == "RECORD"
+                and record_pkg_file.parent.name.endswith(".dist-info")
+            ):
+                # Found a usable candidate; set dist_name/dist_files
                 dist_name = candidate
                 dist_files = candidate_files
                 break
 
         if dist_name is not None:
             break
-            
+
     if dist_files is None:
         raise ImportError(
             "Cannot expand the `rocm-sdk[devel]` package because it was not installed "
@@ -129,7 +134,6 @@ def _expand_devel_contents(rocm_sdk_devel_path: Path, site_lib_path: Path):
         raise ImportError(
             f"No distribution RECORD found for the `{msg_dist_name}` distribution package."
         )
-
 
     # Resolve to a physical file.
     record_path = record_pkg_file.locate()


### PR DESCRIPTION
Motivation fix (https://github.com/ROCm/TheRock/issues/1664)
**Problem**: On openSUSE Tumbleweed, RHEL/UBI, and similar enterprise distros, Python venvs often include both purelib and platlib site-packages on sys.path (lib and lib64). This causes importlib.metadata.packages_distributions() to return multiple entries for the same logical package (rocm_sdk_devel).
**Impact**: The current code assumed a single distribution entry and asserted len(dist_names) == 1. https://github.com/ROCm/TheRock/pull/1833/files relaxed this to `len(dist_names) in [1, 2]`, which unblocks common cases but still depends on ordering and the assumption that there are at most two entries.
**Goal**: Provide a minimal, robust enhancement that handles multiple candidate distributions safely over https://github.com/ROCm/TheRock/pull/1833/

**Root cause:**
On affected distros, both purelib and platlib ends up on sys.path under venvs, so importlib.metadata sees the same distribution from multiple site-packages locations.
packages_distributions() thus returns duplicates, and len(dist_names) > 1 is expected.

**Logic:**
De-duplicate dist_names while preserving order.
Retain assert invariants after normalization: assert len(dist_names) >= 1.
Iterate the candidates and select the first with files and a valid dist-info/RECORD.

References:
Original issue: [#1664](https://github.com/ROCm/TheRock/issues/1664)
Related PR: #1833


## Test Result
```
python3 -m venv venv
source venv/bin/activate
python -m pip install \
  --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
  "rocm[libraries,devel]"

rocm-sdk path --root
rocm-sdk test
```
All Tests Pass
Ran 25 tests in 3.712s

OK (skipped=2)
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
