### PR TITLE
[GitHub Actions] copy was excluding pytorch-triton-rocm wheel

### DIFF
--- a/.github/workflows/copy_release.yml
+++ b/.github/workflows/copy_release.yml
@@ -89,7 +89,7 @@ jobs:
           aws s3 cp \
             s3://therock-${{ inputs.sourcebucket }}-python/${{ inputs.sourcesubdir }}/${{ inputs.amdgpu_family }}/ \
             s3://therock-${{ inputs.destbucket }}-python/${{ inputs.destsubdir }}/${{ inputs.amdgpu_family }}/ \
-            --recursive --exclude "*"  --include "torch*${{ inputs.rocm_version }}*${{ env.cp_version }}*"
+            --recursive --exclude "*"  --include "*torch*${{ inputs.rocm_version }}*${{ env.cp_version }}*"
 
       - name: (Re-)Generate Python package release index
         env:


### PR DESCRIPTION
Previous include string was only looking for wheels that started with `torch`, thus excluding the `pytorch-triton-rocm` wheels during the s3 copy operation.

Verified with https://github.com/ROCm/TheRock/actions/runs/18719775019