### PR TITLE
[ci] Adding back torch2.9

### DIFF
--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -86,11 +86,11 @@ jobs:
       fail-fast: false
       matrix:
         python_version: ["3.11", "3.12", "3.13"]
-        pytorch_version: ["release/2.7", "release/2.9_rocm7.9", "nightly"]
+        pytorch_version: ["release/2.7", "release/2.9", "nightly"]
         include:
           - pytorch_version: release/2.7
             pytorch_patchset: rocm_2.7
-          - pytorch_version: release/2.9_rocm7.9
+          - pytorch_version: release/2.9
             pytorch_patchset: rocm_2.9
           - pytorch_version: nightly
             pytorch_patchset: nightly


### PR DESCRIPTION
As Scott mentioned, torch2.9 should work now. This will also fix the current PyTorch linux builds

test running here: https://github.com/ROCm/TheRock/actions/runs/18724387592