### PR TITLE
OpenBLAS flag updates to address #1877

### DIFF
--- a/third-party/host-blas/CMakeLists.txt
+++ b/third-party/host-blas/CMakeLists.txt
@@ -55,9 +55,9 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
       CMAKE_ARGS
         "-DSOURCE_DIR=${_source_dir}"
         -DBUILD_SHARED_LIBS=ON
+        -DC_LAPACK=ON
         # https://github.com/OpenMathLib/OpenBLAS?tab=readme-ov-file#x86x86-64
         # Picking HASWELL as a baseline that supports modern AMD and Intel CPUs
-        -DCMAKE_CROSSCOMPILING=ON
         -DTARGET=HASWELL
         -DDYNAMIC_ARCH=${_enable_dynamicArch}
         -DBUILD_TESTING=OFF


### PR DESCRIPTION
- Addresses #1877 
- #1746 introduced an issue in the pytorch workflows, which aren't included in pre-submit CI, so the issue was missed then.
- Switching back to `C_LAPACK` for now as quickest solution.
- `CMAKE_CROSSCOMPILING` is not needed for our current use case.

# Test Plan
- Trigger the pytorch workflows to verify fortran issue is not present.