### PR TITLE
[ci] Fixing CI to correctly exclude `expect_failure` builds

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -384,7 +384,6 @@ def matrix_generator(
                 # If the build variant level notes expect_failure, set it on the overall row.
                 # But if not, honor what is already there.
                 if build_variant_info.get("expect_failure", False):
-                    del build_variant_info["expect_failure"]
                     matrix_row["expect_failure"] = True
                 del matrix_row["build_variants"]
                 matrix_row.update(build_variant_info)


### PR DESCRIPTION
Previously, `del build_variant_info["expect_failure"]` removed the entry in the dictionary itself during the for loop. This means the next build that has `expect_failure` would not be correctly ignored.

Failing job before: https://github.com/ROCm/TheRock/actions/runs/18763327480/job/53543387086

New job that correctly ignores: https://github.com/ROCm/TheRock/actions/runs/18779206059