### PR TITLE
[ci] Enabling `gfx103X` and adding issues for other torch failures

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -106,28 +106,31 @@ amdgpu_family_info_matrix_nightly = {
         "linux": {
             "test-runs-on": "",
             "family": "gfx90X-dcgpu",
-            "expect_failure": False,
             "build_variants": ["release"],
         },
+        # TODO(#1927): Resolve error generating file `torch_hip_generated_int4mm.hip.obj`, to enable PyTorch builds
         "windows": {
             "test-runs-on": "",
             "family": "gfx90X-dcgpu",
-            "expect_failure": False,
             "build_variants": ["release"],
+            "expect_pytorch_failure": True,
         },
     },
     "gfx101x": {
+        # TODO(#1926): Resolve bgemm kernel hip file generation error, to enable PyTorch builds
         "linux": {
             "test-runs-on": "",
             "family": "gfx101X-dgpu",
             "expect_failure": True,
             "build_variants": ["release"],
+            "expect_pytorch_failure": True,
         },
+        # TODO(#1925): Enable arch for aotriton to enable PyTorch builds
         "windows": {
             "test-runs-on": "",
             "family": "gfx101X-dgpu",
-            "expect_failure": False,
             "build_variants": ["release"],
+            "expect_pytorch_failure": True,
         },
     },
     "gfx103x": {
@@ -135,14 +138,14 @@ amdgpu_family_info_matrix_nightly = {
             "test-runs-on": "linux-rx6950-gpu-rocm",
             "family": "gfx103X-dgpu",
             "build_variants": ["release"],
-            "expect_failure": False,
             "sanity_check_only_for_family": True,
         },
+        # TODO(#1925): Enable arch for aotriton to enable PyTorch builds
         "windows": {
             "test-runs-on": "",
             "family": "gfx103X-dgpu",
             "build_variants": ["release"],
-            "expect_failure": False,
+            "expect_pytorch_failure": True,
         },
     },
     "gfx1150": {
@@ -150,13 +153,11 @@ amdgpu_family_info_matrix_nightly = {
             "test-runs-on": "",
             "family": "gfx1150",
             "build_variants": ["release"],
-            "expect_failure": False,
         },
         "windows": {
             "test-runs-on": "",
             "family": "gfx1150",
             "build_variants": ["release"],
-            "expect_failure": False,
         },
     },
 }


### PR DESCRIPTION
Based on test runs, we are enabling `gfx103X` to begin running pytorch:

- gfx103X Linux: https://github.com/ROCm/TheRock/actions/runs/18761734124

To test the `expect_failure` removal, the test works here: https://github.com/ROCm/TheRock/actions/runs/18782357115 (please check the `xfail true/false`

Linked issues #1925, #1926, #1927