### PR TITLE
[ci] Fixing torch test wheels for linux `gfx120X` and `gfx1151`

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -73,6 +73,7 @@ jobs:
         --device /dev/dri
         --group-add 110
         --env-file /etc/podinfo/gha-gpu-isolation-settings
+        --user 0:0 # Running as root, by recommendation of GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/dockerfile-support#user
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
We have had previous issues due to this:

```
Run actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
/usr/bin/docker exec  82d7e1cd3476d7370c6a5ab888f762019abf4f5b55d387704eab90e6884c7284 sh -c "cat /etc/*release | grep ^ID"
node:fs:2415
    return binding.writeFileUtf8(
                   ^

Error: EACCES: permission denied, open '/__w/_temp/_runner_file_commands/save_state_4c401e05-0944-4c6b-8093-489faf13fe5c'
    at Object.writeFileSync (node:fs:2415:20)
```

We resolved these issues in #1717 and it worked. Now to enable that for pytorch tests

Closes #1930