### PR TITLE
[compiler] adding `THEROCK_ROCM_SYSTEMS_SOURCE_DIR` for rocm-systems directory

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -73,7 +73,7 @@ if(THEROCK_ENABLE_COMPILER)
       # (since it instruments them). These paths must line up and will be an error
       # in the compiler-rt build if not found.
       "-DSANITIZER_AMDGPU=${THEROCK_CONDITION_IS_NON_WINDOWS}"
-      "-DSANITIZER_HSA_INCLUDE_PATH=${THEROCK_SOURCE_DIR}/rocm-systems/projects/rocr-runtime/runtime/hsa-runtime/inc"
+      "-DSANITIZER_HSA_INCLUDE_PATH=${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime/runtime/hsa-runtime/inc"
       "-DSANITIZER_COMGR_INCLUDE_PATH=${CMAKE_CURRENT_SOURCE_DIR}/amd-llvm/amd/comgr/include"
 
       ${_extra_llvm_cmake_args}


### PR DESCRIPTION
Previously, the rocm-systems repo was getting pulled from TheRock's submodule commit. Now, if we decide to pass in rocm-systems from an external source, it pulls it from there.