### PR TITLE
Add ROCM_PATH to MIOpen tests

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -18,6 +18,11 @@ environ_vars = os.environ.copy()
 environ_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
 environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 
+# Some of our runtime kernel compilations have been relying on either ROCM_PATH being set, or ROCm being installed at
+# /opt/rocm. Neither of these is true in TheRock so we need to supply ROCM_PATH to our tests.
+ROCM_PATH = Path(THEROCK_BIN_DIR).resolve().parent
+environ_vars["ROCM_PATH"] = str(ROCM_PATH)
+
 logging.basicConfig(level=logging.INFO)
 
 ###########################################


### PR DESCRIPTION
## Motivation

Some MIOpen tests are failing because they can't find ROCm headers that they currently rely on to build. This issue is also blocking PR #1774 as MIOpen tests are failing in it.

## Technical Details

Some of our runtime kernel compilations have been relying on either ROCM_PATH being set, or ROCm being installed at /opt/rocm. Neither of these is true in TheRock so we need to supply ROCM_PATH to our tests. 

## Test Plan

* Tested against reproduced test environment from failures on #1774 
* Full test suite

## Test Result

* Broken tests pass in test environment from #1774 
* Waiting for CI run

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
