### PR TITLE
Fixing Release Workflow

### DIFF
--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -41,6 +41,8 @@ jobs:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
       ARTIFACTS_DIR: "${{ github.workspace }}/artifacts"
       PACKAGES_DIR: "${{ github.workspace }}/packages"
+      MANYLINUX: 1
+
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -154,6 +154,7 @@ jobs:
       S3_BUCKET_PY: "therock-${{ needs.setup_metadata.outputs.release_type }}-python"
       S3_SUBDIR: ${{ inputs.s3_subdir || 'v2' }}
       S3_STAGING_SUBDIR: ${{ inputs.s3_staging_subdir || 'v2-staging' }}
+      MANYLINUX: 1
 
     steps:
       - name: "Checking out repository"

--- a/build_tools/linux_portable_build.py
+++ b/build_tools/linux_portable_build.py
@@ -100,7 +100,6 @@ def do_build(args: argparse.Namespace, *, rest_args: list[str]):
                 args.image,
                 "/bin/bash",
                 "/therock/src/build_tools/detail/linux_portable_build_in_container.sh",
-                "--manylinux",
             ]
         )
         cl += rest_args


### PR DESCRIPTION
## Motivation

In the previous update, `linux_portable_build.py` invoked the `linux_portable_build_in_container.sh` script using the --manylinux argument. However, the correct approach is to enable manylinux mode by setting the `MANYLINUX=1` environment variable. This issue arose because the change was inadvertently mixed with another modification in `build_configure.py`, which legitimately uses the `--manylinux` argument. As a result, the two mechanisms were conflated, leading to this error.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
