### PR TITLE
[ci] Removing AMDGPU_FAMILIES in `test_sanity_checks.yml`

### DIFF
--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -80,7 +80,6 @@ jobs:
         with:
           ARTIFACT_GROUP: ${{ inputs.artifact_group }}
           ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
-          AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
           FETCH_ARTIFACT_ARGS: "--base-only"


### PR DESCRIPTION
Noticing warnings for `test_sanity_checks`: https://github.com/rocm/therock/pull/1766#discussion_r2479136518

This PR cleans that up

Works here: https://github.com/ROCm/TheRock/actions/runs/18951738541/job/54118450178 ( i pulled a bad artifact id but sanity checks warning is not there!)