### PR TITLE
[ci] Adding options for `rocm-libraries` to run only archs with test machines

### DIFF
--- a/build_tools/github_actions/fetch_package_targets.py
+++ b/build_tools/github_actions/fetch_package_targets.py
@@ -9,13 +9,13 @@ Outputs written to GITHUB_OUTPUT:
     * 'package_targets': JSON list of the form
         [
             {
-                "family": "gfx94X-dcgpu",
+                "amdgpu_family": "gfx94X-dcgpu",
                 "test_machine": "linux-mi300-1gpu-ossci-rocm",
                 "expect_failure": false,
                 "expect_pytorch_failure": false
             },
             {
-                "family": "gfx110X-all",
+                "amdgpu_family": "gfx110X-all",
                 "test_machine": "",
                 "expect_failure": false,
                 "expect_pytorch_failure": true
@@ -40,7 +40,7 @@ jobs:
         run: python ./build_tools/github_actions/fetch_package_targets.py
 
   windows_packages:
-    name: ${{ matrix.target_bundle.family }}::Build Windows
+    name: ${{ matrix.target_bundle.amdgpu_family }}::Build Windows
     runs-on: 'windows-2022'
     needs: [setup_metadata]
     strategy:


### PR DESCRIPTION
## Motivation

Previously, TheRock CI in rocm-libraries used hard-coded gfx1151 (windows) and gfx94X (linux). This introduces more variants and testing for new archs and adjusts the script to support limited builds

## Technical Details

Introducing more variants and testing for new archs

## Test Plan

Tested here: https://github.com/ROCm/rocm-libraries/actions/runs/18951830927/job/54118277730

## Test Result

Tested here: https://github.com/ROCm/rocm-libraries/actions/runs/18951830927/job/54118277730

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
