### PR TITLE
Add library dependency tracking and recursive preload support

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__init__.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__init__.py
@@ -9,6 +9,7 @@ import platform
 import re
 
 from ._dist_info import __version__
+from ._dist_info import ALL_LIBRARIES
 
 __all__ = [
     "__version__",
@@ -84,6 +85,31 @@ def find_libraries(*shortnames: str) -> list[Path]:
 
 _ALL_CDLLS = {}
 
+def resolve_deps(shortnames: list[str], processed=None) -> list[str]:
+    """Recursively resolve ROCm library dependencies in correct load order.
+    Ensures each dependency is processed only once.
+    """
+    if processed is None:
+        processed = set()
+
+    result = []
+
+    for name in shortnames:
+        if name in processed:
+            continue
+        processed.add(name)
+
+        entry = ALL_LIBRARIES[name]
+        if entry.deps:
+            result.extend(resolve_deps(entry.deps, processed))
+
+        result.append(name)
+
+    seen = set()
+    ordered = [lib for lib in result if not (lib in seen or seen.add(lib))]
+
+    return ordered
+
 
 def preload_libraries(*shortnames: str, rtld_global: bool = True):
     """Preloads a list of library names, caching their handles globally.
@@ -96,6 +122,8 @@ def preload_libraries(*shortnames: str, rtld_global: bool = True):
     Library paths are resolved via `find_libraries`.
     """
     import ctypes
+
+    shortnames = resolve_deps(list(shortnames))
 
     paths = find_libraries(*shortnames)
     mode = ctypes.RTLD_GLOBAL if rtld_global is True else ctypes.RTLD_LOCAL

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__init__.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__init__.py
@@ -85,6 +85,7 @@ def find_libraries(*shortnames: str) -> list[Path]:
 
 _ALL_CDLLS = {}
 
+
 def resolve_deps(shortnames: list[str], processed=None) -> list[str]:
     """Recursively resolve ROCm library dependencies in correct load order.
     Ensures each dependency is processed only once.

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -242,7 +242,9 @@ PackageEntry(
 LibraryEntry("amdhip64", "core", "libamdhip64.so*", "amdhip64*.dll")
 # The DLL glob here uses '0' from the version to avoid matching 'hiprtc-builtins'.
 # If DLLs with no version suffix are later added we will need a different pattern.
-LibraryEntry("hiprtc", "core", "libhiprtc.so*", "hiprtc0*.dll", deps=["amd_comgr", "amdhip64"])
+LibraryEntry(
+    "hiprtc", "core", "libhiprtc.so*", "hiprtc0*.dll", deps=["amd_comgr", "amdhip64"]
+)
 LibraryEntry("roctx64", "core", "libroctx64.so*", "")
 LibraryEntry("rocprofiler-sdk", "core", "librocprofiler-sdk.so*", "")
 LibraryEntry("rocprofiler-sdk-roctx", "core", "librocprofiler-sdk-roctx.so*", "")

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -239,7 +239,13 @@ PackageEntry(
 # TODO(#703,#1057): Use patterns for version suffixes and platform differences too?
 
 # Public libraries.
-LibraryEntry("amdhip64", "core", "libamdhip64.so*", "amdhip64*.dll")
+LibraryEntry(
+    "amdhip64",
+    "core",
+    "libamdhip64.so*",
+    "amdhip64*.dll",
+    deps=["amd_comgr", "rocprofiler-sdk-roctx"],
+)
 # The DLL glob here uses '0' from the version to avoid matching 'hiprtc-builtins'.
 # If DLLs with no version suffix are later added we will need a different pattern.
 LibraryEntry(
@@ -263,19 +269,60 @@ LibraryEntry(
     "rocm-openblas*.dll",
     "lib/host-math/lib",
 )
-LibraryEntry("amd_comgr", "core", "libamd_comgr.so*", "amd_comgr*.dll")
+LibraryEntry(
+    "amd_comgr",
+    "core",
+    "libamd_comgr.so*",
+    "amd_comgr*.dll",
+    deps=["rocm_sysdeps_liblzma"],
+)
 LibraryEntry("rocm_smi64", "core", "librocm_smi64.so*", "")
 LibraryEntry("rocdecode", "core", "librocdecode.so*", "")
 LibraryEntry("rocjpeg", "core", "librocjpeg.so*", "")
-LibraryEntry("hipblas", "libraries", "libhipblas.so*", "*hipblas*.dll")
-LibraryEntry("hipblaslt", "libraries", "libhipblaslt.so*", "*hipblaslt*.dll")
-LibraryEntry("hipfft", "libraries", "libhipfft.so*", "hipfft*.dll")
-LibraryEntry("hiprand", "libraries", "libhiprand.so*", "hiprand*.dll")
-LibraryEntry("hipsparse", "libraries", "libhipsparse.so*", "hipsparse*.dll")
-LibraryEntry("hipsparselt", "libraries", "libhipsparselt.so*", "")
-LibraryEntry("hipsolver", "libraries", "libhipsolver.so*", "hipsolver*.dll")
-LibraryEntry("rccl", "libraries", "librccl.so*", "")
-LibraryEntry("miopen", "libraries", "libMIOpen.so*", "MIOpen*.dll")
+LibraryEntry(
+    "hipblas", "libraries", "libhipblas.so*", "*hipblas*.dll", deps=["amdhip64"]
+)  # missing rocsolver, rocblas
+LibraryEntry(
+    "hipblaslt",
+    "libraries",
+    "libhipblaslt.so*",
+    "*hipblaslt*.dll",
+    deps=["roctx64", "amdhip64"],
+)  # missing rocroller
+LibraryEntry(
+    "hipfft", "libraries", "libhipfft.so*", "hipfft*.dll", deps=["amdhip64"]
+)  # missing rocfft
+LibraryEntry(
+    "hiprand", "libraries", "libhiprand.so*", "hiprand*.dll", deps=["amdhip64"]
+)  # missing rocrand
+LibraryEntry(
+    "hipsparse", "libraries", "libhipsparse.so*", "hipsparse*.dll", deps=["amdhip64"]
+)  # missing rocsparse
+LibraryEntry("hipsparselt", "libraries", "libhipsparselt.so*", "", deps=["roctx64"])
+LibraryEntry(
+    "hipsolver", "libraries", "libhipsolver.so*", "hipsolver*.dll", deps=["amdhip64"]
+)  # missing rocsolver, rocsparse, rocblas)
+LibraryEntry(
+    "rccl",
+    "libraries",
+    "librccl.so*",
+    "",
+    deps=["roctx64", "rocprofiler-sdk-roctx", "amdhip64"],
+)  # missing rocm_smi
+LibraryEntry(
+    "miopen",
+    "libraries",
+    "libMIOpen.so*",
+    "MIOpen*.dll",
+    deps=[
+        "rocm_systems_liblzma",
+        "hiprtc",
+        "roctx64",
+        "hipblaslt",
+        "amd_comgr",
+        "amdhip64",
+    ],
+)  # missing rocblas
 LibraryEntry("hipdnn", "libraries", "libhipdnn_backend.so*", "hipdnn_backend*.dll")
 
 # Others we may want:

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -32,6 +32,7 @@ class LibraryEntry:
         so_pattern: str,
         dll_pattern: str,
         posix_relpath="lib",
+        deps: list[str] | None = None,
     ):
         self.shortname = shortname
         self.package = ALL_PACKAGES[package_name]
@@ -39,6 +40,7 @@ class LibraryEntry:
         self.windows_relpath = "bin"
         self.so_pattern = so_pattern
         self.dll_pattern = dll_pattern
+        self.deps = deps or []
         assert shortname not in ALL_LIBRARIES
         ALL_LIBRARIES[shortname] = self
 
@@ -240,7 +242,7 @@ PackageEntry(
 LibraryEntry("amdhip64", "core", "libamdhip64.so*", "amdhip64*.dll")
 # The DLL glob here uses '0' from the version to avoid matching 'hiprtc-builtins'.
 # If DLLs with no version suffix are later added we will need a different pattern.
-LibraryEntry("hiprtc", "core", "libhiprtc.so*", "hiprtc0*.dll")
+LibraryEntry("hiprtc", "core", "libhiprtc.so*", "hiprtc0*.dll", deps=["amd_comgr", "amdhip64"])
 LibraryEntry("roctx64", "core", "libroctx64.so*", "")
 LibraryEntry("rocprofiler-sdk", "core", "librocprofiler-sdk.so*", "")
 LibraryEntry("rocprofiler-sdk-roctx", "core", "librocprofiler-sdk-roctx.so*", "")

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -252,7 +252,7 @@ LibraryEntry(
     "hiprtc", "core", "libhiprtc.so*", "hiprtc0*.dll", deps=["amd_comgr", "amdhip64"]
 )
 LibraryEntry("roctx64", "core", "libroctx64.so*", "")
-LibraryEntry("rocprofiler-sdk", "core", "librocprofiler-sdk.so*", "")
+LibraryEntry("rocprofiler-sdk", "core", "librocprofiler-sdk.so*", "", deps=["amd_comgr"])
 LibraryEntry("rocprofiler-sdk-roctx", "core", "librocprofiler-sdk-roctx.so*", "")
 LibraryEntry("roctracer64", "core", "libroctracer64.so*", "")
 LibraryEntry(
@@ -277,8 +277,8 @@ LibraryEntry(
     deps=["rocm_sysdeps_liblzma"],
 )
 LibraryEntry("rocm_smi64", "core", "librocm_smi64.so*", "")
-LibraryEntry("rocdecode", "core", "librocdecode.so*", "")
-LibraryEntry("rocjpeg", "core", "librocjpeg.so*", "")
+LibraryEntry("rocdecode", "core", "librocdecode.so*", "", deps=["amdhip64"])
+LibraryEntry("rocjpeg", "core", "librocjpeg.so*", "", deps=["amdhip64"])
 LibraryEntry(
     "hipblas", "libraries", "libhipblas.so*", "*hipblas*.dll", deps=["amdhip64"]
 )  # missing rocsolver, rocblas
@@ -298,7 +298,7 @@ LibraryEntry(
 LibraryEntry(
     "hipsparse", "libraries", "libhipsparse.so*", "hipsparse*.dll", deps=["amdhip64"]
 )  # missing rocsparse
-LibraryEntry("hipsparselt", "libraries", "libhipsparselt.so*", "", deps=["roctx64"])
+LibraryEntry("hipsparselt", "libraries", "libhipsparselt.so*", "", deps=["roctx64", "amdhip64"])
 LibraryEntry(
     "hipsolver", "libraries", "libhipsolver.so*", "hipsolver*.dll", deps=["amdhip64"]
 )  # missing rocsolver, rocsparse, rocblas)
@@ -315,7 +315,7 @@ LibraryEntry(
     "libMIOpen.so*",
     "MIOpen*.dll",
     deps=[
-        "rocm_systems_liblzma",
+        "rocm_sysdeps_liblzma",
         "hiprtc",
         "roctx64",
         "hipblaslt",
@@ -323,7 +323,7 @@ LibraryEntry(
         "amdhip64",
     ],
 )  # missing rocblas
-LibraryEntry("hipdnn", "libraries", "libhipdnn_backend.so*", "hipdnn_backend*.dll")
+LibraryEntry("hipdnn", "libraries", "libhipdnn_backend.so*", "hipdnn_backend*.dll", deps=["amdhip64"])
 
 # Others we may want:
 # hiprtc-builtins

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
@@ -90,7 +90,7 @@ class ROCmLibrariesTest(unittest.TestCase):
                 # in '_rocm_sdk_core/bin'
                 # TODO(#996): track deps in libraries then have the preloader
                 #   recursively get deps instead of hardcoding like this
-                preload_command = "import rocm_sdk; rocm_sdk.preload_libraries('amd_comgr', 'amdhip64', 'hiprtc');"
+                preload_command = "import rocm_sdk; rocm_sdk.preload_libraries('hiprtc');"
 
                 # Load each in an isolated process because not all libraries in the tree
                 # are designed to load into the same process (i.e. LLVM runtime libs,

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
@@ -90,7 +90,9 @@ class ROCmLibrariesTest(unittest.TestCase):
                 # in '_rocm_sdk_core/bin'
                 # TODO(#996): track deps in libraries then have the preloader
                 #   recursively get deps instead of hardcoding like this
-                preload_command = "import rocm_sdk; rocm_sdk.preload_libraries('hiprtc');"
+                preload_command = (
+                    "import rocm_sdk; rocm_sdk.preload_libraries('hiprtc');"
+                )
 
                 # Load each in an isolated process because not all libraries in the tree
                 # are designed to load into the same process (i.e. LLVM runtime libs,

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/libraries_test.py
@@ -88,8 +88,6 @@ class ROCmLibrariesTest(unittest.TestCase):
                 # the "libraries" like hipfft, rocblas, etc. which are siblings
                 # in '_rocm_sdk_libraries_gfx####/bin' while the "compiler" is
                 # in '_rocm_sdk_core/bin'
-                # TODO(#996): track deps in libraries then have the preloader
-                #   recursively get deps instead of hardcoding like this
                 preload_command = (
                     "import rocm_sdk; rocm_sdk.preload_libraries('hiprtc');"
                 )


### PR DESCRIPTION
## Motivation

Enhance the ROCm Python SDK build tools located in `build_tools/packaging/python/templates/rocm` by adding automatic library dependency tracking and recursive preload support. Previously, preloading libraries required manually specifying all dependencies in the correct order. With this change, `preload_libraries` can automatically resolve dependencies for ROCm shared libraries, ensuring proper load order and avoiding duplicate loads.

This PR addresses [Issue #996](https://github.com/ROCm/TheRock/issues/996) by making the preloader self-sufficient and removing the need to hardcode dependency order.

## Technical Details

- Added a `deps` attribute to `LibraryEntry` in `_dist_info.py` to define dependent libraries.
- Implemented `resolve_deps` in `__init__.py` to recursively resolve all dependencies in correct load order, ensuring each library is processed only once.
- Updated `preload_libraries` to call `resolve_deps` automatically, removing the need to manually pass dependent libraries.
- Updated `hiprtc` `LibraryEntry` to include `deps=["amd_comgr", "amdhip64"]`.
- Updated test `libraries_test.py` to preload only `hiprtc`, relying on automatic dependency resolution.
- Ensured `ALL_LIBRARIES` is imported from `_dist_info` to provide a central reference for all libraries.

## Test Plan

- Preloaded `hiprtc` and verified that `amd_comgr` and `amdhip64` are also loaded automatically.
- Ran `libraries_test.py` to confirm libraries load in isolated processes and dependencies are correctly resolved.
- Verified that `ALL_LIBRARIES` entries have correct `deps` populated.

## Test Result

- All tests pass.
- Dependencies are loaded in the correct order.
- No duplicate library loads observed.