### PR TITLE
Fix rocm_sdk.tests.core_test for flang

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
@@ -33,7 +33,7 @@ COMMON_CONSOLE_SCRIPT_TESTS = [
     ("amdclang++", ["--help"], "clang LLVM compiler", True),
     ("amdclang-cpp", ["--help"], "clang LLVM compiler", True),
     ("amdclang-cl", ["-help"], "clang LLVM compiler", True),
-    ("amdflang", ["--help"], "flang LLVM compiler", True),
+    ("amdflang", ["--help"], "LLVM compiler", True),
     ("amdlld", ["-flavor", "ld.lld", "--help"], "USAGE:", True),
     ("hipcc", ["--help"], "clang LLVM compiler", True),
     ("hipconfig", [], "HIP version:", True),


### PR DESCRIPTION
Closes #1997