### PR TITLE
Temporary Revert: [ci] Adding gfx1103 coverage #1854

### DIFF
--- a/.github/workflows/build_linux_jax_wheels.yml
+++ b/.github/workflows/build_linux_jax_wheels.yml
@@ -30,7 +30,7 @@ on:
         options:
           - gfx101X-dgpu
           - gfx103X-dgpu
-          - gfx110X-all
+          - gfx110X-dgpu
           - gfx1150
           - gfx1151
           - gfx120X-all

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -53,7 +53,7 @@ on:
         options:
           - gfx101X-dgpu
           - gfx103X-dgpu
-          - gfx110X-all
+          - gfx110X-dgpu
           - gfx1150
           - gfx1151
           - gfx120X-all

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -53,7 +53,7 @@ on:
         options:
           - gfx101X-dgpu
           - gfx103X-dgpu
-          - gfx110X-all
+          - gfx110X-dgpu
           - gfx1150
           - gfx1151
           - gfx120X-all

--- a/.github/workflows/copy_release.yml
+++ b/.github/workflows/copy_release.yml
@@ -11,7 +11,7 @@ on:
         options:
           - gfx101X-dgpu
           - gfx103X-dgpu
-          - gfx110X-all
+          - gfx110X-dgpu
           - gfx1150
           - gfx1151
           - gfx120X-all

--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -39,7 +39,7 @@ on:
         options:
           - gfx101X-dgpu
           - gfx103X-dgpu
-          - gfx110X-all
+          - gfx110X-dgpu
           - gfx1150
           - gfx1151
           - gfx120X-all

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -39,7 +39,7 @@ on:
         options:
           - gfx101X-dgpu
           - gfx103X-dgpu
-          - gfx110X-all
+          - gfx110X-dgpu
           - gfx1150
           - gfx1151
           - gfx120X-all

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ In case you don't have an existing ROCm/HIP installation from which you can run 
 
 You can install the `rocm` Python package for any architecture inside a venv and run `offload-arch` from there:
 
-1. `python build_tools/setup_venv.py --index-name nightly --index-subdir gfx110X-all --packages rocm .tmpvenv`
+1. `python build_tools/setup_venv.py --index-name nightly --index-subdir gfx110X-dgpu --packages rocm .tmpvenv`
 1. `.tmpvenv/bin/offload-arch` on Linux, `.tmpvenv\Scripts\offload-arch` on Windows
 1. `rm -rf .tmpvenv`
 
@@ -215,7 +215,7 @@ See instructions in the next section for [Linux](#ccache-usage-on-linux) and [Wi
 Otherwise, ROCm/HIP can be configured and build with just the following commands:
 
 ```bash
-cmake -B build -GNinja . -DTHEROCK_AMDGPU_FAMILIES=gfx110X-all
+cmake -B build -GNinja . -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu
 cmake --build build
 ```
 
@@ -241,7 +241,7 @@ Example:
 # Any shell used to build must eval setup_ccache.py to set environment
 # variables.
 eval "$(./build_tools/setup_ccache.py)"
-cmake -B build -GNinja -DTHEROCK_AMDGPU_FAMILIES=gfx110X-all \
+cmake -B build -GNinja -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu \
   -DCMAKE_C_COMPILER_LAUNCHER=ccache \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
   .

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -76,10 +76,9 @@ project layouts.**
 | ---------------------------------- | ---------- | ------------ | ------------------------------------------------------------------ |
 | MI300A/MI300X                      | gfx942     | gfx94X-dcgpu | [rocm](#rocm-for-gfx94X-dcgpu) // [torch](#torch-for-gfx94X-dcgpu) |
 | MI350X/MI355X                      | gfx950     | gfx950-dcgpu | [rocm](#rocm-for-gfx950-dcgpu) // [torch](#torch-for-gfx950-dcgpu) |
-| AMD RX 7900 XTX                    | gfx1100    | gfx110X-all  | [rocm](#rocm-for-gfx110X-all) // [torch](#torch-for-gfx110X-all)   |
-| AMD RX 7800 XT                     | gfx1101    | gfx110X-all  | [rocm](#rocm-for-gfx110X-all) // [torch](#torch-for-gfx110X-all)   |
-| AMD RX 7700S / Framework Laptop 16 | gfx1102    | gfx110X-all  | [rocm](#rocm-for-gfx110X-all) // [torch](#torch-for-gfx110X-all)   |
-| AMD Radeon 780M Laptop iGPU        | gfx1103    | gfx110X-all  | [rocm](#rocm-for-gfx110X-all) // [torch](#torch-for-gfx110X-all)   |
+| AMD RX 7900 XTX                    | gfx1100    | gfx110X-dgpu | [rocm](#rocm-for-gfx110X-dgpu) // [torch](#torch-for-gfx110X-dgpu) |
+| AMD RX 7800 XT                     | gfx1101    | gfx110X-dgpu | [rocm](#rocm-for-gfx110X-dgpu) // [torch](#torch-for-gfx110X-dgpu) |
+| AMD RX 7700S / Framework Laptop 16 | gfx1102    | gfx110X-dgpu | [rocm](#rocm-for-gfx110X-dgpu) // [torch](#torch-for-gfx110X-dgpu) |
 | AMD Strix Halo iGPU                | gfx1151    | gfx1151      | [rocm](#rocm-for-gfx1151) // [torch](#torch-for-gfx1151)           |
 | AMD RX 9060 / XT                   | gfx1200    | gfx120X-all  | [rocm](#rocm-for-gfx120X-all) // [torch](#torch-for-gfx120X-all)   |
 | AMD RX 9070 / XT                   | gfx1201    | gfx120X-all  | [rocm](#rocm-for-gfx120X-all) // [torch](#torch-for-gfx120X-all)   |
@@ -133,7 +132,7 @@ python -m pip install \
   "rocm[libraries,devel]"
 ```
 
-#### rocm for gfx110X-all
+#### rocm for gfx110X-dgpu
 
 Supported devices in this family:
 
@@ -142,13 +141,12 @@ Supported devices in this family:
 | AMD RX 7900 XTX                    | gfx1100    |
 | AMD RX 7800 XT                     | gfx1101    |
 | AMD RX 7700S / Framework Laptop 16 | gfx1102    |
-| AMD Radeon 780M Laptop iGPU        | gfx1103    |
 
 Install instructions:
 
 ```bash
 python -m pip install \
-  --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ \
+  --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
   "rocm[libraries,devel]"
 ```
 
@@ -195,7 +193,7 @@ pip freeze | grep rocm
 # rocm==6.5.0rc20250610
 # rocm-sdk-core==6.5.0rc20250610
 # rocm-sdk-devel==6.5.0rc20250610
-# rocm-sdk-libraries-gfx110X-all==6.5.0rc20250610
+# rocm-sdk-libraries-gfx110X-dgpu==6.5.0rc20250610
 ```
 
 You should also see various tools on your `PATH` and in the `bin` directory:
@@ -313,7 +311,7 @@ python -m pip install \
   --pre torch torchaudio torchvision
 ```
 
-#### torch for gfx110X-all
+#### torch for gfx110X-dgpu
 
 Supported devices in this family:
 
@@ -322,11 +320,10 @@ Supported devices in this family:
 | AMD RX 7900 XTX                    | gfx1100    |
 | AMD RX 7800 XT                     | gfx1101    |
 | AMD RX 7700S / Framework Laptop 16 | gfx1102    |
-| AMD Radeon 780M Laptop iGPU        | gfx1103    |
 
 ```bash
 python -m pip install \
-  --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ \
+  --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
   --pre torch torchaudio torchvision
 ```
 
@@ -398,7 +395,7 @@ After downloading, simply extract the release tarball into place:
 ```bash
 mkdir therock-tarball && cd therock-tarball
 # For example...
-wget https://therock-nightly-tarball.s3.us-east-2.amazonaws.com/therock-dist-linux-gfx110X-all-6.5.0rc20250610.tar.gz
+wget https://therock-nightly-tarball.s3.us-east-2.amazonaws.com/therock-dist-linux-gfx110X-dgpu-6.5.0rc20250610.tar.gz
 
 mkdir install
 tar -xf *.tar.gz -C install
@@ -475,13 +472,13 @@ Examples:
 - Downloads the version `6.4.0rc20250516` gfx110X artifacts from GitHub release tag `nightly-tarball` to the specified output directory `build`:
 
   ```bash
-  python build_tools/install_rocm_from_artifacts.py --release 6.4.0rc20250516 --amdgpu-family gfx110X-all --output-dir build
+  python build_tools/install_rocm_from_artifacts.py --release 6.4.0rc20250516 --amdgpu-family gfx110X-dgpu --output-dir build
   ```
 
 - Downloads the version `6.4.0.dev0+e015c807437eaf32dac6c14a9c4f752770c51b14` gfx110X artifacts from GitHub release tag `dev-tarball` to the default output directory `therock-build`:
 
   ```bash
-  python build_tools/install_rocm_from_artifacts.py --release 6.4.0.dev0+e015c807437eaf32dac6c14a9c4f752770c51b14 --amdgpu-family gfx110X-all
+  python build_tools/install_rocm_from_artifacts.py --release 6.4.0.dev0+e015c807437eaf32dac6c14a9c4f752770c51b14 --amdgpu-family gfx110X-dgpu
   ```
 
 Select your AMD GPU family from this file [therock_amdgpu_targets.cmake](https://github.com/ROCm/TheRock/blob/59c324a759e8ccdfe5a56e0ebe72a13ffbc04c1f/cmake/therock_amdgpu_targets.cmake#L44-L81)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,34 +22,33 @@ See also the [ROCm Device Support Wishlist GitHub Discussion](https://github.com
 
 #### AMD Instinct - Linux
 
-| Architecture | LLVM target | Build Passing | Release Available | Sanity Tested |
-| ------------ | ----------- | ------------- | ----------------- | ------------- |
-| **CDNA4**    | **gfx950**  | ✅            | ✅                |               |
-| **CDNA3**    | **gfx942**  | ✅            | ✅                | ✅            |
-| CDNA2        | gfx90a      | ✅            | ✅                |               |
-| CDNA         | gfx908      | ✅            | ✅                |               |
-| GCN5.1       | gfx906      | ✅            | ✅                |               |
+| Architecture | LLVM target | Build Passing | Sanity Tested | Release Ready |
+| ------------ | ----------- | ------------- | ------------- | ------------- |
+| **CDNA4**    | **gfx950**  | ✅            |               |               |
+| **CDNA3**    | **gfx942**  | ✅            | ✅            | ✅            |
+| CDNA2        | gfx90a      | ✅            |               |               |
+| CDNA         | gfx908      | ✅            |               |               |
+| GCN5.1       | gfx906      | ✅            |               |               |
 
 #### AMD Radeon - Linux
 
-| Architecture | LLVM target | Build Passing | Release Available | Sanity Tested |
-| ------------ | ----------- | ------------- | ----------------- | ------------- |
-| **RDNA4**    | **gfx1201** | ✅            | ✅                | ✅            |
-| **RDNA4**    | **gfx1200** | ✅            | ✅                | ✅            |
-| **RDNA3.5**  | **gfx1151** | ✅            | ✅                | ✅            |
-| **RDNA3.5**  | **gfx1150** | ✅            | ✅                |               |
-| **RDNA3**    | **gfx1103** | ✅            | ✅                |               |
-| **RDNA3**    | **gfx1102** | ✅            | ✅                | ✅            |
-| **RDNA3**    | **gfx1101** | ✅            | ✅                | ✅            |
-| **RDNA3**    | **gfx1100** | ✅            | ✅                | ✅            |
-| RDNA2        | gfx1036     |               |                   |               |
-| RDNA2        | gfx1035     |               |                   |               |
-| RDNA2        | gfx1032     | ✅            | ✅                | ✅            |
-| RDNA2        | gfx1030     | ✅            | ✅                | ✅            |
-| RDNA1        | gfx1012     | ✅            | ✅                |               |
-| RDNA1        | gfx1011     | ✅            | ✅                |               |
-| RDNA1        | gfx1010     | ✅            | ✅                |               |
-| GCN5.1       | gfx906      | ✅            | ✅                |               |
+| Architecture | LLVM target | Build Passing | Sanity Tested | Release Ready |
+| ------------ | ----------- | ------------- | ------------- | ------------- |
+| **RDNA4**    | **gfx1201** | ✅            | ✅            | ✅            |
+| **RDNA4**    | **gfx1200** | ✅            | ✅            | ✅            |
+| **RDNA3.5**  | **gfx1151** | ✅            | ✅            |               |
+| **RDNA3.5**  | **gfx1150** | ✅            | ✅            |               |
+| **RDNA3**    | **gfx1102** | ✅            | ✅            |               |
+| **RDNA3**    | **gfx1101** | ✅            | ✅            |               |
+| **RDNA3**    | **gfx1100** | ✅            | ✅            |               |
+| RDNA2        | gfx1036     |               |               |               |
+| RDNA2        | gfx1035     |               |               |               |
+| RDNA2        | gfx1032     |               |               |               |
+| RDNA2        | gfx1030     |               |               |               |
+| RDNA1        | gfx1012     | ✅            |               |               |
+| RDNA1        | gfx1011     | ✅            |               |               |
+| RDNA1        | gfx1010     | ✅            |               |               |
+| GCN5.1       | gfx906      | ✅            |               |               |
 
 ### ROCm on Windows
 
@@ -57,21 +56,20 @@ Check [windows_support.md](docs/development/windows_support.md) on current statu
 
 #### AMD Radeon - Windows
 
-| Architecture | LLVM target | Build Passing | Release Available | Sanity Tested |
-| ------------ | ----------- | ------------- | ----------------- | ------------- |
-| **RDNA4**    | **gfx1201** | ✅            | ✅                |               |
-| **RDNA4**    | **gfx1200** | ✅            | ✅                |               |
-| **RDNA3.5**  | **gfx1151** | ✅            | ✅                | ✅            |
-| **RDNA3.5**  | **gfx1150** | ✅            | ✅                |               |
-| **RDNA3**    | **gfx1103** | ✅            | ✅                |               |
-| **RDNA3**    | **gfx1102** | ✅            | ✅                |               |
-| **RDNA3**    | **gfx1101** | ✅            | ✅                |               |
-| **RDNA3**    | **gfx1100** | ✅            | ✅                |               |
-| RDNA2        | gfx1036     |               |                   |               |
-| RDNA2        | gfx1035     |               |                   |               |
-| RDNA2        | gfx1032     | ✅            | ✅                |               |
-| RDNA2        | gfx1030     | ✅            | ✅                |               |
-| RDNA1        | gfx1012     | ✅            | ✅                |               |
-| RDNA1        | gfx1011     | ✅            | ✅                |               |
-| RDNA1        | gfx1010     | ✅            | ✅                |               |
-| GCN5.1       | gfx906      | ✅            | ✅                |               |
+| Architecture | LLVM target | Build Passing | Sanity Tested | Release Ready |
+| ------------ | ----------- | ------------- | ------------- | ------------- |
+| **RDNA4**    | **gfx1201** | ✅            |               |               |
+| **RDNA4**    | **gfx1200** | ✅            |               |               |
+| **RDNA3.5**  | **gfx1151** | ✅            | ✅            | ✅            |
+| **RDNA3.5**  | **gfx1150** | ✅            |               |               |
+| **RDNA3**    | **gfx1102** | ✅            |               |               |
+| **RDNA3**    | **gfx1101** | ✅            |               |               |
+| **RDNA3**    | **gfx1100** | ✅            |               |               |
+| RDNA2        | gfx1036     |               |               |               |
+| RDNA2        | gfx1035     |               |               |               |
+| RDNA2        | gfx1032     |               |               |               |
+| RDNA2        | gfx1030     |               |               |               |
+| RDNA1        | gfx1012     | ✅            |               |               |
+| RDNA1        | gfx1011     | ✅            |               |               |
+| RDNA1        | gfx1010     | ✅            |               |               |
+| GCN5.1       | gfx906      | ✅            |               |               |

--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -8,11 +8,11 @@ download artifacts then unpack them into a usable install directory.
 Example usage (using https://github.com/ROCm/TheRock/actions/runs/15685736080):
   pip install boto3
   python build_tools/fetch_artifacts.py \
-    --run-id 15685736080 --artifact-group gfx110X-all --output-dir ~/.therock/artifacts_15685736080
+    --run-id 15685736080 --artifact-group gfx110X-dgpu --output-dir ~/.therock/artifacts_15685736080
 
 Include/exclude regular expressions can be given to control what is downloaded:
   python build_tools/fetch_artifacts.py \
-    --run-id 15685736080 --artifact-group gfx110X-all --output-dir ~/.therock/artifacts_15685736080 \
+    --run-id 15685736080 --artifact-group gfx110X-dgpu --output-dir ~/.therock/artifacts_15685736080 \
     amd-llvm base 'core-(hip|runtime)' sysdeps \
     --exclude _dbg_
 

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -44,14 +44,14 @@ amdgpu_family_info_matrix_presubmit = {
     "gfx110x": {
         "linux": {
             "test-runs-on": "linux-gfx110X-gpu-rocm",
-            "family": "gfx110X-all",
+            "family": "gfx110X-dgpu",
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
             "sanity_check_only_for_family": True,
         },
         "windows": {
             "test-runs-on": "",
-            "family": "gfx110X-all",
+            "family": "gfx110X-dgpu",
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
         },

--- a/build_tools/github_actions/fetch_package_targets.py
+++ b/build_tools/github_actions/fetch_package_targets.py
@@ -15,7 +15,7 @@ Outputs written to GITHUB_OUTPUT:
                 "expect_pytorch_failure": false
             },
             {
-                "amdgpu_family": "gfx110X-all",
+                "amdgpu_family": "gfx110X-dgpu",
                 "test_machine": "",
                 "expect_failure": false,
                 "expect_pytorch_failure": true

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -141,7 +141,7 @@ class ConfigureCITest(unittest.TestCase):
             any("gfx94X-dcgpu" == entry["family"] for entry in linux_target_output)
         )
         self.assertTrue(
-            any("gfx110X-all" == entry["family"] for entry in linux_target_output)
+            any("gfx110X-dgpu" == entry["family"] for entry in linux_target_output)
         )
         self.assertGreaterEqual(len(linux_target_output), 2)
         self.assert_target_output_is_valid(
@@ -163,7 +163,7 @@ class ConfigureCITest(unittest.TestCase):
             platform="windows",
         )
         self.assertTrue(
-            any("gfx110X-all" == entry["family"] for entry in windows_target_output)
+            any("gfx110X-dgpu" == entry["family"] for entry in windows_target_output)
         )
         self.assertGreaterEqual(len(windows_target_output), 1)
         self.assert_target_output_is_valid(

--- a/build_tools/github_actions/tests/fetch_package_targets_test.py
+++ b/build_tools/github_actions/tests/fetch_package_targets_test.py
@@ -40,7 +40,7 @@ class FetchPackageTargetsTest(unittest.TestCase):
         self.assertTrue(all("amdgpu_family" in t for t in targets))
         # Standard targets have suffixes and may use X for a family.
         self.assertTrue(any("gfx94X-dcgpu" == t["amdgpu_family"] for t in targets))
-        self.assertTrue(any("gfx110X-all" == t["amdgpu_family"] for t in targets))
+        self.assertTrue(any("gfx110X-dgpu" == t["amdgpu_family"] for t in targets))
 
     def test_windows_single_family(self):
         args = {
@@ -61,7 +61,7 @@ class FetchPackageTargetsTest(unittest.TestCase):
         self.assertTrue(all("amdgpu_family" in t for t in targets))
         # dcgpu targets are Linux only.
         self.assertFalse(any("gfx94X-dcgpu" == t["amdgpu_family"] for t in targets))
-        self.assertTrue(any("gfx110X-all" == t["amdgpu_family"] for t in targets))
+        self.assertTrue(any("gfx110X-dgpu" == t["amdgpu_family"] for t in targets))
         self.assertTrue(any("gfx120X-all" == t["amdgpu_family"] for t in targets))
 
 

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -32,7 +32,7 @@ Examples:
     ```
     python build_tools/install_rocm_from_artifacts.py \
         --release 6.4.0rc20250416 \
-        --amdgpu-family gfx110X-all \
+        --amdgpu-family gfx110X-dgpu \
         --output-dir build
     ```
 - Downloads and unpacks the version `6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9`

--- a/build_tools/linux_portable_build.py
+++ b/build_tools/linux_portable_build.py
@@ -5,7 +5,7 @@ Example usage:
 
     # Build for a specific family. Note that all options after the "--" are
     # passed verbatim to CMake.
-    python linux_build_portable.py -- -DTHEROCK_AMDGPU_FAMILIES=gfx110X-all
+    python linux_build_portable.py -- -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu
 
     # Build with podman vs docker.
     python linux_build_portable.py --docker=podman

--- a/build_tools/packaging/python/generate_release_index.py
+++ b/build_tools/packaging/python/generate_release_index.py
@@ -7,7 +7,7 @@ Sample usage:
     ./build_tools/packaging/python/generate_release_index.py \
         --bucket=therock-dev-python \
         --endpoint=s3.us-east-2.amazonaws.com \
-        --subdir=gfx110X-all \
+        --subdir=gfx110X-dgpu \
         --output=index.html
     ```
 

--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -13,11 +13,11 @@ There are a few modes this can be used in:
     python setup_venv.py .venv
     ```
 
-* To install the latest nightly rocm packages for gfx110X-all into the venv:
+* To install the latest nightly rocm packages for gfx110X-dgpu into the venv:
 
     ```
     python setup_venv.py .venv --packages rocm[libraries,devel] \
-        --index-name nightly --index-subdir gfx110X-all
+        --index-name nightly --index-subdir gfx110X-dgpu
     ```
 
     This is roughly equivalent to:
@@ -26,7 +26,7 @@ There are a few modes this can be used in:
     python -m venv .venv
     source .venv/bin/activate
     python -m pip install --upgrade pip
-    python -m pip install rocm[libraries,devel] --index-url=https://.../gfx110X-all
+    python -m pip install rocm[libraries,devel] --index-url=https://.../gfx110X-dgpu
     deactivate
     ```
 """
@@ -277,7 +277,7 @@ def main(argv: list[str]):
     if not all_subdir_sets_congruent and subdirs:
         index_subdir_help += ". Available options per index: " + str(subdirs)
     elif not subdirs:
-        index_subdir_help += ", such as 'gfx110X-all'"
+        index_subdir_help += ", such as 'gfx110X-dgpu'"
     else:
         index_subdir_help += "."
 

--- a/build_tools/third_party/s3_management/manage.py
+++ b/build_tools/third_party/s3_management/manage.py
@@ -38,12 +38,12 @@ ACCEPTED_FILE_EXTENSIONS = ("whl", "zip", "tar.gz")
 PREFIXES = [
     # Note: v2-staging first, in case issues are observed while the script runs
     # and the developer wants to more safely cancel the script.
-    "v2-staging/gfx110X-all",
+    "v2-staging/gfx110X-dgpu",
     "v2-staging/gfx1151",
     "v2-staging/gfx120X-all",
     "v2-staging/gfx94X-dcgpu",
     "v2-staging/gfx950-dcgpu",
-    "v2/gfx110X-all",
+    "v2/gfx110X-dgpu",
     "v2/gfx1151",
     "v2/gfx120X-all",
     "v2/gfx94X-dcgpu",

--- a/build_tools/third_party/s3_management/update_dependencies.py
+++ b/build_tools/third_party/s3_management/update_dependencies.py
@@ -187,7 +187,7 @@ def main() -> None:
     SUBFOLDERS =  [
         "gfx101X-dgpu",
         "gfx103X-dgpu",
-        "gfx110X-all",
+        "gfx110X-dgpu",
         "gfx1150",
         "gfx1151",
         "gfx120X-all",

--- a/docs/development/development_guide.md
+++ b/docs/development/development_guide.md
@@ -315,7 +315,7 @@ Settings for CMake builds can be specified in `.vscode/settings.json` or a
     "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
     "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
     "-DPython3_EXECUTABLE=${workspaceFolder}/.venv/Scripts/python",
-    "-DTHEROCK_AMDGPU_FAMILIES=gfx110X-all",  // Set to your GPU target family.
+    "-DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu",  // Set to your GPU target family.
     //
     // You can include both option settings for easy toggling.
     "-DBUILD_TESTING=ON",

--- a/docs/development/github_actions_debugging.md
+++ b/docs/development/github_actions_debugging.md
@@ -93,7 +93,7 @@ cd _work/TheRock/TheRock
 export TEATIME_FORCE_INTERACTIVE=1
 
 # Copy the configure command from the "Configure Projects" step
-cmake -B "B:/build" -GNinja . -DTHEROCK_AMDGPU_FAMILIES=gfx110X-all -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DTHEROCK_VERBOSE=ON -DBUILD_TESTING=ON -DCMAKE_C_COMPILER="C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe" -DCMAKE_LINKER="C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/link.exe" -DTHEROCK_BACKGROUND_BUILD_JOBS=4
+cmake -B "B:/build" -GNinja . -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DTHEROCK_VERBOSE=ON -DBUILD_TESTING=ON -DCMAKE_C_COMPILER="C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe" -DCMAKE_CXX_COMPILER="C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe" -DCMAKE_LINKER="C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/link.exe" -DTHEROCK_BACKGROUND_BUILD_JOBS=4
 
 # Build CMake targets
 # You could also run buildctl.py here to enable/disable specific subprojects

--- a/docs/development/installing_artifacts.md
+++ b/docs/development/installing_artifacts.md
@@ -47,14 +47,14 @@ Nightly tarballs are built daily and follow the naming pattern: `MAJOR.MINOR.PAT
 
 1. Visit the [nightly tarball S3 bucket](https://therock-nightly-tarball.s3.amazonaws.com/)
 1. Look for files matching your GPU family. Files are named: `therock-dist-linux-{GPU_FAMILY}-{VERSION}.tar.gz`
-   - Example: `therock-dist-linux-gfx110X-all-6.4.0rc20250514.tar.gz`
+   - Example: `therock-dist-linux-gfx110X-dgpu-6.4.0rc20250514.tar.gz`
 1. Extract the version from the filename (the part after the last hyphen, before `.tar.gz`)
    - In the example above, the version is: `6.4.0rc20250514`
 1. Use this version string with `--release`:
    ```bash
    python build_tools/install_rocm_from_artifacts.py \
        --release 6.4.0rc20250514 \
-       --amdgpu-family gfx110X-all
+       --amdgpu-family gfx110X-dgpu
    ```
 
 **Version format:** `X.Y.ZrcYYYYMMDD`
@@ -98,7 +98,7 @@ Dev tarballs are built from specific commits and follow the naming pattern: `MAJ
 ```bash
 python build_tools/install_rocm_from_artifacts.py \
     --run-id 15575624591 \
-    --amdgpu-family gfx110X-all \
+    --amdgpu-family gfx110X-dgpu \
     --blas --tests
 ```
 
@@ -211,7 +211,7 @@ Test that artifacts can be fetched with your new flag:
 # Test with a CI run
 python build_tools/install_rocm_from_artifacts.py \
     --run-id YOUR_RUN_ID \
-    --amdgpu-family gfx110X-all \
+    --amdgpu-family gfx110X-dgpu \
     --newcomponent --tests
 ```
 

--- a/docs/development/test_environment_reproduction.md
+++ b/docs/development/test_environment_reproduction.md
@@ -28,7 +28,7 @@ $ python build_tools/github_actions/test_executable_scripts/test_rocblas.py
 `install_rocm_from_artifacts.py` parameters
 
 - CI_RUN_ID is sourced from the CI run (ex: https://github.com/ROCm/TheRock/actions/runs/16948046392 -> CI_RUN_ID = 16948046392)
-- GPU_FAMILY is the LLVM target name (ex: gfx94X-dcgpu, gfx1151, gfx110X-all)
+- GPU_FAMILY is the LLVM target name (ex: gfx94X-dcgpu, gfx1151, gfx110X-dgpu)
 - GITHUB_REPO is the GitHub repository that this CI run was executed. (ex: ROCm/rocm-libraries, ROCm/rccl)
 
 To view which python test wrappers we have, please checkout [`test_executable_scripts/`](https://github.com/ROCm/TheRock/tree/main/build_tools/github_actions/test_executable_scripts)

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -231,7 +231,7 @@ the [instructions in the root README](../../README.md#configuration) for other
 options you may want to set.
 
 ```bash
-cmake -B build -GNinja . -DTHEROCK_AMDGPU_FAMILIES=gfx110X-all
+cmake -B build -GNinja . -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu
 
 # If iterating and wishing to cache, add these:
 #  -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -155,7 +155,7 @@ mix/match build steps.
 
   ```bash
   python build_prod_wheels.py build \
-    --install-rocm --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ \
+    --install-rocm --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
     --output-dir $HOME/tmp/pyout
   ```
 
@@ -163,7 +163,7 @@ mix/match build steps.
 
   ```batch
   python build_prod_wheels.py build ^
-    --install-rocm --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ ^
+    --install-rocm --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ ^
     --pytorch-dir C:/b/pytorch ^
     --pytorch-audio-dir C:/b/audio ^
     --pytorch-vision-dir C:/b/vision ^
@@ -221,7 +221,7 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
 
   ```bash
   build_prod_wheels.py
-      --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ \
+      --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
       install-rocm
   ```
 
@@ -230,12 +230,12 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
   ```bash
   # From therock-nightly-python
   python -m pip install \
-    --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ \
+    --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
     rocm[libraries,devel]
 
   # OR from therock-dev-python
   python -m pip install \
-    --index-url https://d25kgig7rdsyks.cloudfront.net/v2/gfx110X-all/ \
+    --index-url https://d25kgig7rdsyks.cloudfront.net/v2/gfx110X-dgpu/ \
     rocm[libraries,devel]
   ```
 
@@ -249,7 +249,7 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
   mkdir $HOME/.therock/17123441166/artifacts
   python ./build_tools/fetch_artifacts.py \
     --run-id=17123441166 \
-    --target=gfx110X-all \
+    --target=gfx110X-dgpu \
     --output-dir=$HOME/.therock/17123441166/artifacts
 
   python ./build_tools/build_python_packages.py \

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -56,12 +56,12 @@ to the build sub-command (useful for docker invocations).
 # For therock-nightly-python
 build_prod_wheels.py \
     install-rocm \
-    --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/
+    --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/
 
 # For therock-dev-python (unstable but useful for testing outside of prod)
 build_prod_wheels.py \
     install-rocm \
-    --index-url https://d25kgig7rdsyks.cloudfront.net/v2/gfx110X-all/
+    --index-url https://d25kgig7rdsyks.cloudfront.net/v2/gfx110X-dgpu/
 ```
 
 3. Build torch, torchaudio and torchvision for a single gfx architecture.
@@ -99,7 +99,7 @@ versions):
     build \
         --install-rocm \
         --pip-cache-dir /therock/output/pip_cache \
-        --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ \
+        --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
         --clean \
         --output-dir /therock/output/cp312/wheels
 ```


### PR DESCRIPTION
Clean revert: [ci] Adding gfx1103 coverage #1854
This is a **temporarily** rollback intended to restore disrupted CI service. We plan to re-enable `gfx1103` coverage once the underlying issues are resolved and validated.
Closes #2011 