### PR TITLE
pytorch: Add rocm-openblas to preloads

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -221,7 +221,7 @@ LibraryEntry(
     "",
     "lib/rocm_sysdeps/lib",
 )
-
+LibraryEntry("rocm-openblas", "core", "librocm-openblas.so.*", "rocm-openblas*.dll")
 LibraryEntry("amd_comgr", "core", "libamd_comgr.so*", "amd_comgr*.dll")
 LibraryEntry("hipblas", "libraries", "libhipblas.so*", "*hipblas*.dll")
 LibraryEntry("hipblaslt", "libraries", "libhipblaslt.so*", "*hipblaslt*.dll")
@@ -236,7 +236,6 @@ LibraryEntry("miopen", "libraries", "libMIOpen.so*", "MIOpen*.dll")
 # hiprtc-builtins
 # rocblas
 # rocfft
-# rocm-openblas
 # rocrand
 # rocsolver
 # rocsparse

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -143,6 +143,7 @@ LINUX_LIBRARY_PRELOADS = [
     "hipblaslt",
     "miopen",
     "rocm_sysdeps_liblzma",
+    "rocm-openblas",
 ]
 
 # List of library preloads for Windows to generate into _rocm_init.py
@@ -157,6 +158,7 @@ WINDOWS_LIBRARY_PRELOADS = [
     "hipsolver",
     "hipblaslt",
     "miopen",
+    "rocm-openblas",
 ]
 
 


### PR DESCRIPTION
To address #2010 

#1862 had a gap in testing the Windows pytorch build, as it only verified Linux pytorch build