### PR TITLE
Fix rocm-openblas python preload path

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -221,7 +221,13 @@ LibraryEntry(
     "",
     "lib/rocm_sysdeps/lib",
 )
-LibraryEntry("rocm-openblas", "core", "librocm-openblas.so.*", "rocm-openblas*.dll")
+LibraryEntry(
+    "rocm-openblas",
+    "core",
+    "librocm-openblas.so.*",
+    "rocm-openblas*.dll",
+    "lib/host-math/lib",
+)
 LibraryEntry("amd_comgr", "core", "libamd_comgr.so*", "amd_comgr*.dll")
 LibraryEntry("hipblas", "libraries", "libhipblas.so*", "*hipblas*.dll")
 LibraryEntry("hipblaslt", "libraries", "libhipblaslt.so*", "*hipblaslt*.dll")


### PR DESCRIPTION
Change LibraryEntry of rocm-openblas to use lib/host-math/lib.
This should fix failures seen on Linux (but not on Windows)

Issue #2010 