### PR TITLE
pytorch: Remove rocm-openblas from Linux library preloads

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -143,7 +143,6 @@ LINUX_LIBRARY_PRELOADS = [
     "hipblaslt",
     "miopen",
     "rocm_sysdeps_liblzma",
-    "rocm-openblas",
 ]
 
 # List of library preloads for Windows to generate into _rocm_init.py


### PR DESCRIPTION
Follow-up to #2013

Linux preload was not needed before for the build and seems to have an adverse effect.