### PR TITLE
Fix the 0002 Ubertrace patch to apply correctly

### DIFF
--- a/patches/amd-mainline/rocm-systems/0002-Revert-SWDEV-543498-Some-compute-Ubertrace-profiles-.patch
+++ b/patches/amd-mainline/rocm-systems/0002-Revert-SWDEV-543498-Some-compute-Ubertrace-profiles-.patch
@@ -18,9 +18,9 @@ index d0153d1448..e5777edfdb 100644
    return mgr;
  }
  
--static void UberTraceStateChangeCallback(const GpuUtil::TraceSession& pTraceSession,
--                                         GpuUtil::TraceSessionState newState,
--                                         void* pPrivateData)
+-static void PAL_STDCALL UberTraceStateChangeCallback(const GpuUtil::TraceSession& pTraceSession,
+-                                                     GpuUtil::TraceSessionState newState,
+-                                                     void* pPrivateData)
 -{
 -    UberTraceCaptureMgr* mgr = static_cast<UberTraceCaptureMgr*>(pPrivateData);
 -


### PR DESCRIPTION
## Motivation
Current version of the 0002 Ubertrace patch fails to apply to the most recent version of the rocm-systems develop. This commit fixes the broken signature
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Adjust the UberTraceStateChangeCallback signature to use the same formatting as the current version in develop branch
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Patch applying should pass correctly now, will test that with a feature-branch on rocm-systems
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
WIP
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
