### PR TITLE
Filter out the failing tests for rocroller

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocroller.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocroller.py
@@ -82,7 +82,7 @@ elif TEST_TYPE == "quick":
     test_filter_arg = "--gtest_filter=*quick*"
 
 # Append to the existing filter or start a negative-only filter
-# TODO(2030): re-enable these tests once compatible with TheRock
+# TODO(#2030): re-enable these tests once compatible with TheRock
 # https://github.com/ROCm/TheRock/issues/2030
 _excluded = [
     "AssertTest/GPU_AssertTest.GPU_Assert/28",


### PR DESCRIPTION
The five tests have failed on CI.
https://github.com/ROCm/TheRock/actions/runs/19087348325/job/54540824645
https://github.com/ROCm/TheRock/actions/runs/19087348325/job/54540824643

The errors are collected in here:
https://gist.github.com/erman-gurses/a4d323aae63b4e4b5d7085854f2b8f0b

Added filter for those tests below for rocroller. 
```
    "AssertTest/GPU_AssertTest.GPU_Assert/28",
    "AssertTest/GPU_AssertTest.GPU_UnconditionalAssert/28",
    "AssertTest/GPU_AssertTest.GPU_Assert/29",
    "AssertTest/GPU_AssertTest.GPU_UnconditionalAssert/29",
    "GPU_KernelTests/GPU_KernelTest.GPU_WholeKernel/1",
```