### PR TITLE
[NFC] Refactoring and style improvements to post_build_upload.py

### DIFF
--- a/build_tools/github_actions/post_build_upload.py
+++ b/build_tools/github_actions/post_build_upload.py
@@ -5,8 +5,8 @@ Usage:
 post_build_upload.py [-h]
   --artifact-group ARTIFACT_GROUP
   [--build-dir BUILD_DIR]
+  [--upload | --no-upload] (default enabled if the `CI` env var is set)
   [--run-id RUN_ID]
-  [--upload | --no-upload]
 
 This script runs after building TheRock, where this script does:
   1. Create log archives
@@ -285,14 +285,14 @@ if __name__ == "__main__":
         default=Path(os.getenv("BUILD_DIR", "build")),
         help="Build directory containing logs, artifacts, etc. (default: 'build' or $BUILD_DIR)",
     )
-    parser.add_argument("--run-id", type=str, help="GitHub run ID of this workflow run")
     is_ci = str2bool(os.getenv("CI", "false"))
     parser.add_argument(
         "--upload",
         default=is_ci,
-        help="Enable upload steps",
+        help="Enable upload steps (default enabled if $CI is set)",
         action=argparse.BooleanOptionalAction,
     )
+    parser.add_argument("--run-id", type=str, help="GitHub run ID of this workflow run")
     args = parser.parse_args()
 
     # Check preconditions for provided arguments before proceeding.


### PR DESCRIPTION
## Motivation

I'm evaluating reusing this to upload dev python packages as part of https://github.com/ROCm/TheRock/issues/1559, which is itself a stepping stone to https://github.com/ROCm/TheRock/issues/1522.

## Technical Details

This is intended to be a nonfunctional change that preserves existing behavior, in preparation for function changes later.

Notable changes:

* Moved precondition checks for provided arguments closer to `args = parser.parse_args()` (making the flow of the file easier to follow)
* Streamlined `run()` to call `retrieve_bucket_info()` once and precompute `bucket_ur[i,l]` then passed the computed values through to each other function consistently. This will make it easier to change file paths across all file categories (as I may want to include python packages in therock-artifacts too somewhere)
* Adjusted a few variable/function names, inlined some functions, and tweaked some error handling

## Test Plan

* Run the script locally without `--upload` set (unit tests and/or a `--dry-run` mode would help too)
* Watch CI results