### PR TITLE
Disallow trition to pick up TheRock's LLVM

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -397,9 +397,9 @@ def do_build(args: argparse.Namespace):
         # Here, `CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH` is set
         # and passed via `TRITON_APPEND_CMAKE_ARGS` to avoid this.
         # See also https://github.com/ROCm/TheRock/issues/1999.
-        env["TRITON_APPEND_CMAKE_ARGS"] = (
-            "-DCMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH=FALSE"
-        )
+        env[
+            "TRITON_APPEND_CMAKE_ARGS"
+        ] = "-DCMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH=FALSE"
 
     if is_windows:
         llvm_dir = rocm_dir / "lib" / "llvm" / "bin"


### PR DESCRIPTION
## Motivation

Fix building trition by disallowing to pick up TheRock's LLVM.

## Technical Details

This disallows trition to search the path provided by the `CMAKE_PREFIX_PATH` environment variable to avoid picking up TheRock's LLVM instead of falling back to the bundled LLVM. Picking up TheRock's LLVM results in a configuration failure as it does not provide all targets required by trition.

trition only utilized `find_package()` to find `MLIR`, `Python3` and `pybind11`. Hence, there should be nothing in TheRock's `CMAKE_PREFIX_PATH` it _should_ or needs to find.

Fixes #1999.

## Test Plan

[Build | gfx94X-dcgpu | py 3.12 | torch release/2.7](https://github.com/ROCm/TheRock/actions/runs/19137131332/job/54691974058#logs)
[Build | gfx94X-dcgpu | py 3.12 | torch release/2.9](https://github.com/ROCm/TheRock/actions/runs/19137109402/job/54691902373#logs)

## Test Result

Builds pass.

Test failures seems to be unrelated and pre-existing:
[Release | gfx94X-dcgpu | py 3.11 | torch release/2.7 / Test | gfx94X-dcgpu | linux-mi325-1gpu-ossci-rocm / Test PyTorch Wheels | gfx94X-dcgpu](https://github.com/ROCm/TheRock/actions/runs/19131273643/job/54676115002#logs)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
