### PR TITLE
Update triton patch to work with new version 3.5.1

### DIFF
--- a/external-builds/pytorch/patches/triton/nightly/triton/base/0001-Keep-only-one-plus-character-in-version-suffix.patch
+++ b/external-builds/pytorch/patches/triton/nightly/triton/base/0001-Keep-only-one-plus-character-in-version-suffix.patch
@@ -55,8 +55,8 @@ index 8a3007ce4..bdf1c81f5 100644
 +
 +
  # keep it separate for easy substitution
--TRITON_VERSION = "3.5.0" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
-+TRITON_VERSION = "3.5.0" + get_triton_version_suffix()
+-TRITON_VERSION = "3.5.1" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
++TRITON_VERSION = "3.5.1" + get_triton_version_suffix()
  
  # Dynamically define supported Python versions and classifiers
  MIN_PYTHON = (3, 10)


### PR DESCRIPTION
Patch is needed only for nightly due to different version schema and until https://github.com/triton-lang/triton/pull/8205 finally is finally available in nightly
