### PR TITLE
[RFC] Add debug tools to TheRock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ option(THEROCK_USE_SAFE_DEPENDENCY_PROVIDER "Enable the safe dependency provider
 option(THEROCK_ENABLE_ALL "Enables building of all feature groups" ON)
 option(THEROCK_ENABLE_CORE "Enable building of core libraries" "${THEROCK_ENABLE_ALL}")
 option(THEROCK_ENABLE_COMM_LIBS "Enable building of comm libraries" "${THEROCK_ENABLE_ALL}")
+option(THEROCK_ENABLE_DEBUG_TOOLS "Enable building the ROCm debug tools" "${THEROCK_ENABLE_ALL}")
 option(THEROCK_ENABLE_MATH_LIBS "Enable building of math libraries" "${THEROCK_ENABLE_ALL}")
 option(THEROCK_ENABLE_ML_LIBS "Enable building of ML libraries" "${THEROCK_ENABLE_ALL}")
 option(THEROCK_ENABLE_PROFILER "Enable building the profiler libraries" "${THEROCK_ENABLE_ALL}")
@@ -239,6 +240,13 @@ therock_add_feature(OCL_RUNTIME
   GROUP CORE
   DESCRIPTION "Enables the OCL runtime"
   REQUIRES COMPILER ${_hip_runtime_platform_requirements}
+)
+
+# Debug Tools Feature.
+therock_add_feature(DEBUG_TOOLS
+  GROUP ALL
+  DESCRIPTION "Enables the ROCm debug tools"
+  REQUIRES COMPILER HIP_RUNTIME
 )
 
 # Profiler Features.
@@ -462,6 +470,7 @@ add_subdirectory(third-party)
 add_subdirectory(base)
 add_subdirectory(compiler)
 add_subdirectory(core)
+add_subdirectory(debug-tools)
 # Note that rocprofiler-register is in base and is what higher level clients
 # depend on. The profiler itself is independent.
 add_subdirectory(profiler)

--- a/README.md
+++ b/README.md
@@ -145,14 +145,15 @@ You can install the `rocm` Python package for any architecture inside a venv and
 By default, the project builds everything available. The following group flags
 enable/disable selected subsets:
 
-| Group flag                       | Description                          |
-| -------------------------------- | ------------------------------------ |
-| `-DTHEROCK_ENABLE_ALL=OFF`       | Disables all optional components     |
-| `-DTHEROCK_ENABLE_CORE=OFF`      | Disables all core components         |
-| `-DTHEROCK_ENABLE_COMM_LIBS=OFF` | Disables all communication libraries |
-| `-DTHEROCK_ENABLE_MATH_LIBS=OFF` | Disables all math libraries          |
-| `-DTHEROCK_ENABLE_ML_LIBS=OFF`   | Disables all ML libraries            |
-| `-DTHEROCK_ENABLE_PROFILER=OFF`  | Disables profilers                   |
+| Group flag                        | Description                          |
+| --------------------------------- | ------------------------------------ |
+| `-DTHEROCK_ENABLE_ALL=OFF`        | Disables all optional components     |
+| `-DTHEROCK_ENABLE_CORE=OFF`       | Disables all core components         |
+| `-DTHEROCK_ENABLE_COMM_LIBS=OFF`  | Disables all communication libraries |
+| `-DTHEROCK_ENABLE_DEBUG_TOOLS=OFF`| Disables debug tools                 |
+| `-DTHEROCK_ENABLE_MATH_LIBS=OFF`  | Disables all math libraries          |
+| `-DTHEROCK_ENABLE_ML_LIBS=OFF`    | Disables all ML libraries            |
+| `-DTHEROCK_ENABLE_PROFILER=OFF`   | Disables profilers                   |
 
 Individual features can be controlled separately (typically in combination with
 `-DTHEROCK_ENABLE_ALL=OFF` or `-DTHEROCK_RESET_FEATURES=ON` to force a

--- a/debug-tools/CMakeLists.txt
+++ b/debug-tools/CMakeLists.txt
@@ -1,0 +1,119 @@
+if(THEROCK_ENABLE_DEBUG_TOOLS)
+
+  ##############################################################################
+  # amd-dbgapi
+  #
+  # A library that provides support for a debugger and other tools to perform
+  # low-level control of the running code and inspection of the running state
+  # of AMD GPU's
+  ##############################################################################
+  if(NOT WIN32) # Disabled on Windows for now.
+
+    therock_cmake_subproject_declare(amd-dbgapi
+      USE_DIST_AMDGPU_TARGETS
+      EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocdbgapi"
+      BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/amd-dbgapi"
+      BACKGROUND_BUILD
+      COMPILER_TOOLCHAIN
+        amd-llvm
+      BUILD_DEPS
+        ROCR-Runtime
+      RUNTIME_DEPS
+        amd-comgr
+      INTERFACE_LINK_DIRS
+        "lib"
+      INTERFACE_INSTALL_RPATH_DIRS
+        "lib"
+    )
+
+    therock_cmake_subproject_glob_c_sources(amd-dbgapi SUBDIRS
+      doc
+      include
+      src
+    )
+
+    therock_cmake_subproject_provide_package(amd-dbgapi amd-dbgapi
+      lib/cmake/amd-dbgapi)
+    therock_cmake_subproject_activate(amd-dbgapi)
+
+    # Check that we built the one library we're supposed to build.
+    therock_test_validate_shared_lib(PATH amd-dbgapi/dist/lib
+      LIB_NAMES
+        librocm-dbgapi.so
+    )
+  endif()
+
+  ##############################################################################
+  # rocr-debug-agent
+  #
+  # A library that can be loaded by the ROCm software runtime to print the
+  # state of wavefronts.
+  ##############################################################################
+  if(NOT WIN32) # Disabled on Windows for now.
+
+    therock_cmake_subproject_declare(rocm-debug-agent
+      USE_DIST_AMDGPU_TARGETS
+      EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-debug-agent"
+      BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocm-debug-agent"
+      BACKGROUND_BUILD
+      CMAKE_ARGS
+        "-DHIP_PLATFORM=amd"
+      COMPILER_TOOLCHAIN
+        amd-hip
+      BUILD_DEPS
+        hip-clr
+      RUNTIME_DEPS
+        amd-dbgapi
+        ROCR-Runtime
+        ${THEROCK_BUNDLED_ELFUTILS}
+    )
+
+    # We may want to adjust this to optimize rebuilds.
+    therock_cmake_subproject_glob_c_sources(rocm-debug-agent SUBDIRS .)
+
+    therock_cmake_subproject_provide_package(rocm-debug-agent rocm-debug-agent
+      lib/cmake/rocr-debug-agent)
+    therock_cmake_subproject_activate(rocm-debug-agent)
+
+    # Check that we built the one library we're supposed to build.
+    therock_test_validate_shared_lib(PATH rocm-debug-agent/dist/lib
+      LIB_NAMES
+        librocm-debug-agent.so
+    )
+  endif()
+
+  ##############################################################################
+  # ROCgdb
+  #
+  # The AMD source-level debugger for Linux, based on the GNU Debugger (GDB).
+  ##############################################################################
+  if(NOT WIN32) # Disabled on Windows for now.
+
+    therock_cmake_subproject_declare(rocgdb
+      USE_DIST_AMDGPU_TARGETS
+      EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocgdb"
+      BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocgdb"
+      BACKGROUND_BUILD
+      COMPILER_TOOLCHAIN
+        amd-llvm
+      CMAKE_ARGS
+        -DROCM_PATH=
+        -DROCM_DIR=
+      RUNTIME_DEPS
+        amd-comgr
+        amd-dbgapi
+    )
+
+    # We may want to adjust this to optimize rebuilds.
+    therock_cmake_subproject_glob_c_sources(rocgdb SUBDIRS
+      bfd
+      gdb
+      gdbsupport
+      includes
+      binutils
+    )
+    therock_cmake_subproject_provide_package(rocgdb rocgdb lib/cmake/rocgdb)
+    therock_cmake_subproject_activate(rocgdb)
+  endif()
+
+endif(THEROCK_ENABLE_DEBUG_TOOLS)


### PR DESCRIPTION
## Motivation

Add debug-tools to TheRock.

## Technical Details

This RFC/Draft creates the minimal set of changes required to support the ROCm debug tools in TheRock build platform.

It adds the following:

- New debug-tools features/subdirectory (updated main CMakeLists.txt)
- Adds the main debug-tools/CMakeLists.txt file with instructions on how to build the amd-dbgapi, rocr-debug-agent and rocgdb.
- Updates the documentation.

The sources for all 3 components will be located within rocm-systems/projects/ once those sources are effectively added to the rocm-systems super-repo.

Adding those projects to the super-repo will come at a later date, as they will need adjustments to their build systems to cope with being built within TheRock and outside of it.

GDB will need more adjustments since it has external dependencies.

Overall thoughts and comments welcome to improve or adjust the current scheme.

## Test Plan

Test that all 3 components build correctly within TheRock.

## Test Result

All 3 components get built using dependencies from within TheRock (minus rocgdb).