### PR TITLE
Temporarily increase hipblaslt test timeout to 75 minutes per shard.

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -57,7 +57,7 @@ test_matrix = {
     "hipblaslt": {
         "job_name": "hipblaslt",
         "fetch_artifact_args": "--blas --tests",
-        "timeout_minutes": 60,
+        "timeout_minutes": 75,
         "test_script": f"python {_get_script_path('test_hipblaslt.py')}",
         "platform": ["linux", "windows"],
         "total_shards": 4,


### PR DESCRIPTION
Recent runs have been hovering around the current timeout threshold of 60 minutes per shard.
A separate discussion has begun on a proper solution to deal with the test creep, including a deeper look on the hardware specs required to run the tests.