### PR TITLE
Update windows support table with hipsparselt

### DIFF
--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -61,6 +61,7 @@ mainline, in open source, using MSVC, etc.).
 | math-libs (BLAS)    | [rocBLAS](https://github.com/ROCm/rocBLAS)                                                                               | ✅        |                                               |
 | math-libs (BLAS)    | [rocSPARSE](https://github.com/ROCm/rocSPARSE)                                                                           | ✅        |                                               |
 | math-libs (BLAS)    | [hipSPARSE](https://github.com/ROCm/hipSPARSE)                                                                           | ✅        |                                               |
+| math-libs (BLAS)    | [hipSPARSELt](https://github.com/ROCm/hipSPARSELt)                                                                       | ❌        | Unsupported                                   |
 | math-libs (BLAS)    | [rocSOLVER](https://github.com/ROCm/rocSOLVER)                                                                           | ✅        |                                               |
 | math-libs (BLAS)    | [hipSOLVER](https://github.com/ROCm/hipSOLVER)                                                                           | ✅        |                                               |
 | math-libs (BLAS)    | [hipBLAS](https://github.com/ROCm/hipBLAS)                                                                               | ✅        |                                               |


### PR DESCRIPTION
Following #1659, hipsparselt can be included in the windows support table as "unsupported".
