### PR TITLE
Disable verbose logging in CI builds

### DIFF
--- a/build_tools/github_actions/build_configure.py
+++ b/build_tools/github_actions/build_configure.py
@@ -62,7 +62,6 @@ def build_configure(manylinux=False):
             f"-DTHEROCK_PACKAGE_VERSION='{package_version}'",
             "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
             "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
-            "-DTHEROCK_VERBOSE=ON",
             "-DBUILD_TESTING=ON",
         ]
     )


### PR DESCRIPTION
Remove -DTHEROCK_VERBOSE=ON from CI configuration to eliminate excessive "hardlink ..." log messages that spam Windows CI logs. The verbose flag causes fileset_tool.py to log every hardlink operation, creating massive log output with no functional benefit.

This affects both Windows and Linux CI, reducing log noise on both platforms while preserving all functional behavior.

Fixes #2082

🤖 Generated with [Claude Code](https://claude.com/claude-code)
