### PR TITLE
Update top-level timeout to support more than 60 minutes

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -24,7 +24,7 @@ jobs:
   test_component:
     name: 'Test ${{ fromJSON(inputs.component).job_name }} (shard ${{ matrix.shard }} of ${{ fromJSON(inputs.component).total_shards }})'
     runs-on: ${{ inputs.test_runs_on }}
-    timeout-minutes: ${{ fromJSON(inputs.component).timeout_minutes }}
+    timeout-minutes: 90
     container:
       image: ${{ inputs.platform == 'linux' && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98' || null }}
       options: --ipc host


### PR DESCRIPTION
The top-level timeout for the test workflow was hard-set to 60 minutes, ignoring the values from `fetch_test_configurations.py` when they're above 60 minutes.