### PR TITLE
Rename URLs / paths `v2` -> `whl`

### DIFF
--- a/.github/workflows/build_jax_dockerfile.yml
+++ b/.github/workflows/build_jax_dockerfile.yml
@@ -39,7 +39,7 @@ on:
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family
         type: string
-        default: "v2"
+        default: "v3/whl"
       rocm_version:
         description: ROCm version to install
         type: string

--- a/.github/workflows/build_linux_jax_wheels.yml
+++ b/.github/workflows/build_linux_jax_wheels.yml
@@ -50,7 +50,7 @@ on:
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family
         type: string
-        default: "v2"
+        default: "v3/whl"
       rocm_version:
         description: ROCm version to install
         type: string

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -72,19 +72,19 @@ on:
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family
         type: string
-        default: "v2"
+        default: "v3/whl"
       s3_staging_subdir:
         description: S3 staging subdirectory, not including the GPU-family
         type: string
-        default: "v2-staging"
+        default: "v3/whl-staging"
       cloudfront_url:
         description: CloudFront base URL pointing to Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2"
+        default: "https://d25kgig7rdsyks.cloudfront.net/whl"
       cloudfront_staging_url:
         description: CloudFront base URL pointing to staging Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2-staging"
+        default: "https://d25kgig7rdsyks.cloudfront.net/whl-staging"
       rocm_version:
         description: ROCm version to pip install
         type: string

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -72,19 +72,19 @@ on:
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family
         type: string
-        default: "v2"
+        default: "v3/whl"
       s3_staging_subdir:
         description: S3 staging subdirectory, not including the GPU-family
         type: string
-        default: "v2-staging"
+        default: "v3/whl-staging"
       cloudfront_url:
         description: CloudFront base URL pointing to Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2"
+        default: "https://d25kgig7rdsyks.cloudfront.net/whl"
       cloudfront_staging_url:
         description: CloudFront base URL pointing to staging Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2-staging"
+        default: "https://d25kgig7rdsyks.cloudfront.net/whl-staging"
       rocm_version:
         description: ROCm version to pip install
         type: string

--- a/.github/workflows/copy_release.yml
+++ b/.github/workflows/copy_release.yml
@@ -31,11 +31,11 @@ on:
       sourcesubdir:
         type: choice
         options:
-          - v2
-          - v2-staging
+          - v3/whl
+          - v3/whl-staging
       destsubdir:
         type: string
-        default: v2
+        default: whl
       sourcebucket:
         type: choice
         options:

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -13,11 +13,11 @@ on:
       s3_subdir:
         description: "Subdirectory to push the packages"
         type: string
-        default: "v2"
+        default: "v3/whl"
       s3_staging_subdir:
         description: "Staging subdirectory to push the packages"
         type: string
-        default: "v2-staging"
+        default: "v3/whl-staging"
       families:
         description: "Comma separated list of AMD GPU families, e.g. `gfx94X,gfx103x`"
         type: string
@@ -42,11 +42,11 @@ on:
       s3_subdir:
         description: "Subdirectory to push the packages"
         type: string
-        default: "v2"
+        default: "v3/whl"
       s3_staging_subdir:
         description: "Staging subdirectory to push the packages"
         type: string
-        default: "v2-staging"
+        default: "v3/whl-staging"
       families:
         description: "Comma separated list of AMD GPU families, e.g. `gfx94X,gfx103x`"
         type: string
@@ -96,8 +96,8 @@ jobs:
       - name: Set variables for nightly release
         if: ${{ env.release_type == 'nightly' }}
         run: |
-          echo "tmp_cloudfront_url=https://rocm.nightlies.amd.com/v2" >> $GITHUB_ENV
-          echo "tmp_cloudfront_staging_url=https://rocm.nightlies.amd.com/v2-staging" >> $GITHUB_ENV
+          echo "tmp_cloudfront_url=https://rocm.nightlies.amd.com/whl" >> $GITHUB_ENV
+          echo "tmp_cloudfront_staging_url=https://rocm.nightlies.amd.com/whl-staging" >> $GITHUB_ENV
           echo "tmp_s3_subdir_tar=''" >> $GITHUB_ENV
 
       - name: Set variables for prerelease
@@ -110,8 +110,8 @@ jobs:
       - name: Set variables for development release
         if: ${{ env.release_type == 'dev' }}
         run: |
-          echo "tmp_cloudfront_url=https://d25kgig7rdsyks.cloudfront.net/v2" >> $GITHUB_ENV
-          echo "tmp_cloudfront_staging_url=https://d25kgig7rdsyks.cloudfront.net/v2-staging" >> $GITHUB_ENV
+          echo "tmp_cloudfront_url=https://d25kgig7rdsyks.cloudfront.net/whl" >> $GITHUB_ENV
+          echo "tmp_cloudfront_staging_url=https://d25kgig7rdsyks.cloudfront.net/whl-staging" >> $GITHUB_ENV
           echo "tmp_s3_subdir_tar=''" >> $GITHUB_ENV
 
       - name: Generate release information
@@ -152,8 +152,8 @@ jobs:
       S3_BUCKET_TAR: "therock-${{ needs.setup_metadata.outputs.release_type }}-tarball"
       S3_SUBDIR_TAR: ${{ needs.setup_metadata.outputs.s3_subdir_tar }}
       S3_BUCKET_PY: "therock-${{ needs.setup_metadata.outputs.release_type }}-python"
-      S3_SUBDIR: ${{ inputs.s3_subdir || 'v2' }}
-      S3_STAGING_SUBDIR: ${{ inputs.s3_staging_subdir || 'v2-staging' }}
+      S3_SUBDIR: ${{ inputs.s3_subdir || 'v3/whl' }}
+      S3_STAGING_SUBDIR: ${{ inputs.s3_staging_subdir || 'v3/whl-staging' }}
       MANYLINUX: 1
 
     steps:

--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -13,11 +13,11 @@ on:
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family
         type: string
-        default: "v2"
+        default: "v3/whl"
       s3_staging_subdir:
         description: Staging subdirectory to push the wheels for test
         type: string
-        default: "v2-staging"
+        default: "v3/whl-staging"
       cloudfront_url:
         description: CloudFront URL pointing to Python index
         required: true
@@ -54,19 +54,19 @@ on:
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family
         type: string
-        default: "v2"
+        default: "v3/whl"
       s3_staging_subdir:
         description: "Staging subdirectory to push the wheels for test"
         type: string
-        default: "v2-staging"
+        default: "v3/whl-staging"
       cloudfront_url:
         description: CloudFront URL pointing to Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2"
+        default: "https://d25kgig7rdsyks.cloudfront.net/whl"
       cloudfront_staging_url:
         description: CloudFront base URL pointing to staging Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2-staging"
+        default: "https://d25kgig7rdsyks.cloudfront.net/whl-staging"
       rocm_version:
         description: ROCm version to pip install
         type: string

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -13,11 +13,11 @@ on:
       s3_subdir:
         description: "Subdirectory to push the Python packages"
         type: string
-        default: "v2"
+        default: "v3/whl"
       s3_staging_subdir:
         description: "Staging subdirectory to push the packages"
         type: string
-        default: "v2-staging"
+        default: "v3/whl-staging"
       families:
         description: "Comma separated list of AMD GPU families, e.g. `gfx94X,gfx103x`, or empty for the default list"
         type: string
@@ -42,11 +42,11 @@ on:
       s3_subdir:
         description: "Subdirectory to push the Python packages"
         type: string
-        default: "v2"
+        default: "v3/whl"
       s3_staging_subdir:
         description: "Staging subdirectory to push the packages"
         type: string
-        default: "v2-staging"
+        default: "v3/whl-staging"
       families:
         description: "A comma separated list of AMD GPU families, e.g. `gfx94X,gfx103x`, or empty for the default list"
         type: string
@@ -100,8 +100,8 @@ jobs:
       - name: Set variables for nightly release
         if: ${{ env.release_type == 'nightly' }}
         run: |
-          echo "tmp_cloudfront_url=https://rocm.nightlies.amd.com/v2" >> $GITHUB_ENV
-          echo "tmp_cloudfront_staging_url=https://rocm.nightlies.amd.com/v2-staging" >> $GITHUB_ENV
+          echo "tmp_cloudfront_url=https://rocm.nightlies.amd.com/whl" >> $GITHUB_ENV
+          echo "tmp_cloudfront_staging_url=https://rocm.nightlies.amd.com/whl-staging" >> $GITHUB_ENV
           echo "tmp_s3_subdir_tar=''" >> $GITHUB_ENV
 
       - name: Set variables for prerelease
@@ -114,8 +114,8 @@ jobs:
       - name: Set variables for development release
         if: ${{ env.release_type == 'dev' }}
         run: |
-          echo "tmp_cloudfront_url=https://d25kgig7rdsyks.cloudfront.net/v2" >> $GITHUB_ENV
-          echo "tmp_cloudfront_staging_url=https://d25kgig7rdsyks.cloudfront.net/v2-staging" >> $GITHUB_ENV
+          echo "tmp_cloudfront_url=https://d25kgig7rdsyks.cloudfront.net/whl" >> $GITHUB_ENV
+          echo "tmp_cloudfront_staging_url=https://d25kgig7rdsyks.cloudfront.net/whl-staging" >> $GITHUB_ENV
           echo "tmp_s3_subdir_tar=''" >> $GITHUB_ENV
 
       - name: Generate release information
@@ -160,8 +160,8 @@ jobs:
       S3_BUCKET_TAR: "therock-${{ needs.setup_metadata.outputs.release_type }}-tarball"
       S3_SUBDIR_TAR: ${{ needs.setup_metadata.outputs.s3_subdir_tar }}
       S3_BUCKET_PY: "therock-${{ needs.setup_metadata.outputs.release_type }}-python"
-      S3_SUBDIR: ${{ inputs.s3_subdir || 'v2' }}
-      S3_STAGING_SUBDIR: ${{ inputs.s3_staging_subdir || 'v2-staging' }}
+      S3_SUBDIR: ${{ inputs.s3_subdir || 'v3/whl' }}
+      S3_STAGING_SUBDIR: ${{ inputs.s3_staging_subdir || 'v3/whl-staging' }}
 
     steps:
       - name: "Checking out repository"

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -13,15 +13,15 @@ on:
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family
         type: string
-        default: "v2"
+        default: "v3/whl"
       s3_staging_subdir:
         description: Staging subdirectory to push the wheels for test
         type: string
-        default: "v2-staging"
+        default: "v3/whl-staging"
       cloudfront_url:
         description: CloudFront URL pointing to Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2"
+        default: "https://d25kgig7rdsyks.cloudfront.net/whl"
       cloudfront_staging_url:
         description: CloudFront base URL pointing to staging Python index
         required: true
@@ -54,19 +54,19 @@ on:
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family
         type: string
-        default: "v2"
+        default: "v3/whl"
       s3_staging_subdir:
         description: "Staging subdirectory to push the wheels for test"
         type: string
-        default: "v2-staging"
+        default: "v3/whl-staging"
       cloudfront_url:
         description: CloudFront URL pointing to Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2"
+        default: "https://d25kgig7rdsyks.cloudfront.net/whl"
       cloudfront_staging_url:
         description: CloudFront base URL pointing to staging Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2-staging"
+        default: "https://d25kgig7rdsyks.cloudfront.net/whl-staging"
       rocm_version:
         description: ROCm version to pip install
         type: string

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -14,10 +14,10 @@ on:
         type: string
         default: "linux-mi325-1gpu-ossci-rocm"
       package_index_url:
-        description: Base Python package index URL to test, typically nightly/dev URL with a "v2" or "v2-staging" subdir (without a GPU family subdir)
+        description: Base Python package index URL to test, typically nightly/dev URL with a "whl" or "whl-staging" subdir (without a GPU family subdir)
         required: true
         type: string
-        default: "https://rocm.nightlies.amd.com/v2"
+        default: "https://rocm.nightlies.amd.com/whl"
       python_version:
         required: true
         type: string

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -112,7 +112,7 @@ Install instructions:
 
 ```bash
 python -m pip install \
-  --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ \
+  --index-url https://rocm.nightlies.amd.com/whl/gfx94X-dcgpu/ \
   "rocm[libraries,devel]"
 ```
 
@@ -128,7 +128,7 @@ Install instructions:
 
 ```bash
 python -m pip install \
-  --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ \
+  --index-url https://rocm.nightlies.amd.com/whl/gfx950-dcgpu/ \
   "rocm[libraries,devel]"
 ```
 
@@ -146,7 +146,7 @@ Install instructions:
 
 ```bash
 python -m pip install \
-  --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
+  --index-url https://rocm.nightlies.amd.com/whl/gfx110X-dgpu/ \
   "rocm[libraries,devel]"
 ```
 
@@ -162,7 +162,7 @@ Install instructions:
 
 ```bash
 python -m pip install \
-  --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
+  --index-url https://rocm.nightlies.amd.com/whl/gfx1151/ \
   "rocm[libraries,devel]"
 ```
 
@@ -179,7 +179,7 @@ Install instructions:
 
 ```bash
 python -m pip install \
-  --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ \
+  --index-url https://rocm.nightlies.amd.com/whl/gfx120X-all/ \
   "rocm[libraries,devel]"
 ```
 
@@ -293,7 +293,7 @@ Supported devices in this family:
 
 ```bash
 python -m pip install \
-  --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ \
+  --index-url https://rocm.nightlies.amd.com/whl/gfx94X-dcgpu/ \
   --pre torch torchaudio torchvision
 ```
 
@@ -307,7 +307,7 @@ Supported devices in this family:
 
 ```bash
 python -m pip install \
-  --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ \
+  --index-url https://rocm.nightlies.amd.com/whl/gfx950-dcgpu/ \
   --pre torch torchaudio torchvision
 ```
 
@@ -323,7 +323,7 @@ Supported devices in this family:
 
 ```bash
 python -m pip install \
-  --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
+  --index-url https://rocm.nightlies.amd.com/whl/gfx110X-dgpu/ \
   --pre torch torchaudio torchvision
 ```
 
@@ -337,7 +337,7 @@ Supported devices in this family:
 
 ```bash
 python -m pip install \
-  --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
+  --index-url https://rocm.nightlies.amd.com/whl/gfx1151/ \
   --pre torch torchaudio torchvision
 ```
 
@@ -352,7 +352,7 @@ Supported devices in this family:
 
 ```bash
 python -m pip install \
-  --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ \
+  --index-url https://rocm.nightlies.amd.com/whl/gfx120X-all/ \
   --pre torch torchaudio torchvision
 ```
 

--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -53,8 +53,8 @@ GFX_TARGET_REGEX = r'(gfx(?:\d{2,3}X|\d{3,4})(?:-[^<"/]*)?)</a>'
 is_windows = platform.system() == "Windows"
 
 INDEX_URLS_MAP = {
-    "nightly": "https://rocm.nightlies.amd.com/v2",
-    "dev": "https://d25kgig7rdsyks.cloudfront.net/v2",
+    "nightly": "https://rocm.nightlies.amd.com/whl",
+    "dev": "https://d25kgig7rdsyks.cloudfront.net/whl",
 }
 
 

--- a/build_tools/third_party/s3_management/README.md
+++ b/build_tools/third_party/s3_management/README.md
@@ -15,10 +15,10 @@ The Python package buckets we maintain are:
 
 S3 bucket name | S3 URL | User-facing URLs
 -- | -- | --
-`therock-dev-python` | https://therock-dev-python.s3.amazonaws.com/ | <ul><li>https://d25kgig7rdsyks.cloudfront.net/v2/</li><li>https://d25kgig7rdsyks.cloudfront.net/v2-staging/</li></ul>
-`therock-nightly-python` | https://therock-nightly-python.s3.amazonaws.com/ | <ul><li>https://rocm.nightlies.amd.com/v2/</li><li>https://rocm.nightlies.amd.com/v2-staging/</li></ul>
+`therock-dev-python` | https://therock-dev-python.s3.amazonaws.com/ | <ul><li>https://d25kgig7rdsyks.cloudfront.net/whl/</li><li>https://d25kgig7rdsyks.cloudfront.net/whl-staging/</li></ul>
+`therock-nightly-python` | https://therock-nightly-python.s3.amazonaws.com/ | <ul><li>https://rocm.nightlies.amd.com/whl/</li><li>https://rocm.nightlies.amd.com/whl-staging/</li></ul>
 
-Each bucket has `v2` and `v2-staging` top level folders at the moment. This may
+Each bucket has `whl` and `whl-staging` top level folders at the moment. This may
 evolve with `v3` in the future. Within each folder there are subfolders for
 each index we publish, currently corresponding to each GPU family that we
 build releases for. See these other pages for more details:
@@ -29,7 +29,7 @@ The user-facing URLs can be used with `pip install --index-url`. For example:
 
 ```bash
 python -m pip install \
-  --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ \
+  --index-url https://rocm.nightlies.amd.com/whl/gfx94X-dcgpu/ \
   "rocm[libraries,devel]"
 ```
 
@@ -96,7 +96,7 @@ those changes to the dev bucket:
     ```
 
 1. Visit the URL to check that the index pages look as expected and include the
-  new dep. For example: https://d25kgig7rdsyks.cloudfront.net/v2/gfx120X-all/.
+  new dep. For example: https://d25kgig7rdsyks.cloudfront.net/whl/gfx120X-all/.
 
 Finally, repeat those steps for the nightly bucket:
 
@@ -115,7 +115,7 @@ Finally, repeat those steps for the nightly bucket:
     ```
 
 1. Visit the URL to check that the index pages look as expected and include the
-  new dep. For example: https://rocm.nightlies.amd.com/v2/gfx120X-all/.
+  new dep. For example: https://rocm.nightlies.amd.com/whl/gfx120X-all/.
 
 1. If no longer needed, revoke your access to `therock-nightly-releases-access`.
 

--- a/build_tools/third_party/s3_management/manage.py
+++ b/build_tools/third_party/s3_management/manage.py
@@ -36,18 +36,18 @@ INDEX_BUCKETS = {BUCKET} #, BUCKET_CDN}
 
 ACCEPTED_FILE_EXTENSIONS = ("whl", "zip", "tar.gz")
 PREFIXES = [
-    # Note: v2-staging first, in case issues are observed while the script runs
+    # Note: whl-staging first, in case issues are observed while the script runs
     # and the developer wants to more safely cancel the script.
-    "v2-staging/gfx110X-dgpu",
-    "v2-staging/gfx1151",
-    "v2-staging/gfx120X-all",
-    "v2-staging/gfx94X-dcgpu",
-    "v2-staging/gfx950-dcgpu",
-    "v2/gfx110X-dgpu",
-    "v2/gfx1151",
-    "v2/gfx120X-all",
-    "v2/gfx94X-dcgpu",
-    "v2/gfx950-dcgpu",
+    "whl-staging/gfx110X-dgpu",
+    "whl-staging/gfx1151",
+    "whl-staging/gfx120X-all",
+    "whl-staging/gfx94X-dcgpu",
+    "whl-staging/gfx950-dcgpu",
+    "whl/gfx110X-dgpu",
+    "whl/gfx1151",
+    "whl/gfx120X-all",
+    "whl/gfx94X-dcgpu",
+    "whl/gfx950-dcgpu",
 ]
 
 CUSTOM_PREFIX = getenv('CUSTOM_PREFIX')

--- a/build_tools/third_party/s3_management/update_dependencies.py
+++ b/build_tools/third_party/s3_management/update_dependencies.py
@@ -16,9 +16,9 @@ S3 = boto3.resource("s3")
 CLIENT = boto3.client("s3")
 # We also manage `therock-nightly-python` (not the default to make the script safer to test)
 BUCKET = S3.Bucket(getenv("S3_BUCKET_PY", "therock-dev-python"))
-# Note: v2-staging first, in case issues are observed while the script runs
+# Note: whl-staging first, in case issues are observed while the script runs
 # and the developer wants to more safely cancel the script.
-VERSIONS = ["v2-staging", "v2"]
+VERSIONS = ["v3/whl-staging", "v3/whl"]
 
 PACKAGES_PER_PROJECT = {
     "dbus_python": {"version": "latest", "project": "jax"},

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -155,7 +155,7 @@ mix/match build steps.
 
   ```bash
   python build_prod_wheels.py build \
-    --install-rocm --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
+    --install-rocm --index-url https://rocm.nightlies.amd.com/whl/gfx110X-dgpu/ \
     --output-dir $HOME/tmp/pyout
   ```
 
@@ -163,7 +163,7 @@ mix/match build steps.
 
   ```batch
   python build_prod_wheels.py build ^
-    --install-rocm --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ ^
+    --install-rocm --index-url https://rocm.nightlies.amd.com/whl/gfx110X-dgpu/ ^
     --pytorch-dir C:/b/pytorch ^
     --pytorch-audio-dir C:/b/audio ^
     --pytorch-vision-dir C:/b/vision ^
@@ -203,9 +203,9 @@ See https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-pa
 
 ### Gating releases with Pytorch tests
 
-With passing builds we upload `torch`, `torchvision`, `torchaudio`, and `pytorch-triton-rocm` wheels to subfolders of the "v2-staging" directory in the nightly release s3 bucket with a public URL at https://rocm.nightlies.amd.com/v2-staging/
+With passing builds we upload `torch`, `torchvision`, `torchaudio`, and `pytorch-triton-rocm` wheels to subfolders of the "v3/whl-staging" directory in the nightly release s3 bucket with a public URL at https://rocm.nightlies.amd.com/whl-staging/
 
-Only with passing Torch tests we promote passed wheels to the "v2" directory in the nightly release s3 bucket with a public URL at https://rocm.nightlies.amd.com/v2/
+Only with passing Torch tests we promote passed wheels to the "v3/whl" directory in the nightly release s3 bucket with a public URL at https://rocm.nightlies.amd.com/whl/
 
 If no runner is available: Promotion is blocked by default. Set `bypass_tests_for_releases=true` for exceptional cases under [`amdgpu_family_matrix.py`](/build_tools/github_actions/amdgpu_family_matrix.py)
 
@@ -221,7 +221,7 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
 
   ```bash
   build_prod_wheels.py
-      --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
+      --index-url https://rocm.nightlies.amd.com/whl/gfx110X-dgpu/ \
       install-rocm
   ```
 
@@ -230,12 +230,12 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
   ```bash
   # From therock-nightly-python
   python -m pip install \
-    --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
+    --index-url https://rocm.nightlies.amd.com/whl/gfx110X-dgpu/ \
     rocm[libraries,devel]
 
   # OR from therock-dev-python
   python -m pip install \
-    --index-url https://d25kgig7rdsyks.cloudfront.net/v2/gfx110X-dgpu/ \
+    --index-url https://d25kgig7rdsyks.cloudfront.net/whl/gfx110X-dgpu/ \
     rocm[libraries,devel]
   ```
 

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -56,12 +56,12 @@ to the build sub-command (useful for docker invocations).
 # For therock-nightly-python
 build_prod_wheels.py \
     install-rocm \
-    --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/
+    --index-url https://rocm.nightlies.amd.com/whl/gfx110X-dgpu/
 
 # For therock-dev-python (unstable but useful for testing outside of prod)
 build_prod_wheels.py \
     install-rocm \
-    --index-url https://d25kgig7rdsyks.cloudfront.net/v2/gfx110X-dgpu/
+    --index-url https://d25kgig7rdsyks.cloudfront.net/whl/gfx110X-dgpu/
 ```
 
 3. Build torch, torchaudio and torchvision for a single gfx architecture.
@@ -99,7 +99,7 @@ versions):
     build \
         --install-rocm \
         --pip-cache-dir /therock/output/pip_cache \
-        --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/ \
+        --index-url https://rocm.nightlies.amd.com/whl/gfx110X-dgpu/ \
         --clean \
         --output-dir /therock/output/cp312/wheels
 ```


### PR DESCRIPTION
This updates the documentation and workflows to push releases to `v3/whl` instead of `v2` or rather `v3/whl-staging` instead of `v3/whl-staging`. The `v3` will not be revealed to the user via the CloudFront URL but needs to be considered when pushing to the buckets.