### PR TITLE
Fixed missing glob_c_sources(hipCUB...)

### DIFF
--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -124,7 +124,7 @@ if(THEROCK_ENABLE_PRIM)
     RUNTIME_DEPS
       hip-clr
   )
-  therock_cmake_subproject_glob_c_sources(rocPRIM
+  therock_cmake_subproject_glob_c_sources(hipCUB
     SUBDIRS
       .
   )


### PR DESCRIPTION
## Motivation

Fixes missing `therock_cmake_subrpoject_glob_c_sources` call for hipCUB (was referencing rocPRIM for the second time instead)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
