### PR TITLE
Fix for native packaging issues

### DIFF
--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -261,7 +261,7 @@ def generate_rules_file(pkg_info, deb_dir, config: PackageConfig):
     """
     print_function_name()
     rules_file = Path(deb_dir) / "rules"
-    disable_dh_strip = is_key_defined(pkg_info, "Disable_DH_STRIP")
+    disable_dh_strip = is_key_defined(pkg_info, "Disable_DEB_STRIP")
     disable_dwz = is_key_defined(pkg_info, "Disable_DWZ")
     env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
     template = env.get_template("template/debian_rules.j2")
@@ -511,6 +511,7 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
         "install_prefix": config.install_prefix,
         "requires": requires,
         "rpmrecommends": rpmrecommends,
+        "disable_rpm_strip": is_rpm_stripping_disabled(pkginfo),
         "disable_debug_package": is_debug_package_disabled(pkginfo),
         "sourcedir_list": sourcedir_list,
     }

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -256,7 +256,8 @@
     ],
     "Artifact": "amd-llvm",
     "Artifact_Subdir": "amd-llvm",
-    "Gfxarch": "False"
+    "Gfxarch": "False",
+    "Disable_RPM_STRIP": "True"
   },
   {
     "Package": "amd-smi-lib",
@@ -371,7 +372,8 @@
     "Components": [
       "lib",
       "dev",
-      "doc"
+      "doc",
+      "run"
     ],
     "Artifact": "amd-llvm",
     "Artifact_Subdir": "hipcc",
@@ -663,7 +665,8 @@
     "Vendor": "Advanced Micro Devices, Inc",
     "Homepage": "https://github.com/ROCm/rocm-systems",
     "Components": [
-      "dev"
+      "dev",
+      "run"
     ],
     "Artifact": "core-runtime",
     "Artifact_Subdir": "ROCR-Runtime",
@@ -794,7 +797,6 @@
     "Homepage": "https://github.com/ROCm/rocm-systems",
     "Components": [
       "lib",
-      "run",
       "doc"
     ],
     "Artifact": "rocprofiler-sdk",
@@ -826,7 +828,8 @@
     "Vendor": "Advanced Micro Devices, Inc",
     "Homepage": "https://github.com/ROCm/rocm-systems",
     "Components": [
-      "dev"
+      "dev",
+      "run"
     ],
     "Artifact": "rocprofiler-sdk",
     "Artifact_Subdir": "roctracer",
@@ -1334,7 +1337,8 @@
     ],
     "Artifact": "composable-kernel",
     "Artifact_Subdir": "composable_kernel",
-    "Gfxarch": "True"
+    "Gfxarch": "True",
+    "DisablePackaging": "True"
   },
 
   {
@@ -1676,7 +1680,6 @@
     "Conflicts": "miopen-opencl",
     "Components": [
       "lib",
-      "run",
       "doc"
     ],
     "Artifact": "miopen",
@@ -1708,7 +1711,8 @@
     "Homepage": "https://github.com/ROCm/rocm-libraries",
     "Conflicts": "miopen-opencl",
     "Components": [
-      "dev"
+      "dev",
+      "run"
     ],
     "Artifact": "miopen",
     "Artifact_Subdir": "MIOpen",
@@ -1984,7 +1988,8 @@
     ],
     "Artifact": "amd-llvm",
     "Gfxarch": "False",
-    "Composite": "Yes"
+    "Composite": "Yes",
+    "Disable_RPM_STRIP": "True"
   },
   {
     "Package": "rocm-hsa-runtime",
@@ -2411,7 +2416,8 @@
     ],
     "Artifact": "composable-kernel",
     "Gfxarch": "True",
-    "Composite": "Yes"
+    "Composite": "Yes",
+    "DisablePackaging": "True"
   },
 
   {
@@ -2501,7 +2507,6 @@
     "Homepage": "https://github.com/ROCm/rocm-libraries",
     "Components": [
       "lib",
-      "run",
       "doc"
     ],
     "Artifact": "miopen",
@@ -2530,6 +2535,7 @@
     "Vendor": "Advanced Micro Devices, Inc",
     "Homepage": "https://github.com/ROCm/rocm-libraries",
     "Components": [
+      "run",
       "dev"
     ],
     "Artifact": "miopen",
@@ -2658,7 +2664,7 @@
     "Artifact": "sysdeps",
     "Gfxarch": "False",
     "Disable_DWZ": "True",
-    "Disable_DH_STRIP": "True",
+    "Disable_DEB_STRIP": "True",
     "Composite": "Yes"
   },
   {

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -97,6 +97,20 @@ def is_composite_package(pkg_info):
     return is_key_defined(pkg_info, "composite")
 
 
+def is_rpm_stripping_disabled(pkg_info):
+    """
+    Verifies whether Disable_RPM_STRIP key is enabled for a package.
+
+    Parameters:
+    pkg_info (dict): A dictionary containing package details.
+
+    Returns:
+    bool: True if Disable_RPM_STRIP key is defined, False otherwise.
+    """
+
+    return is_key_defined(pkg_info, "Disable_RPM_STRIP")
+
+
 def is_debug_package_disabled(pkg_info):
     """
     Verifies whether Disable_Debug_Package key is enabled for a package.

--- a/build_tools/packaging/linux/template/debian_rules.j2
+++ b/build_tools/packaging/linux/template/debian_rules.j2
@@ -27,7 +27,7 @@ override_dh_strip:
 	# Unprefixed names
 	ln -sf "$(shell command -v llvm-strip)"   debian/.llvm-tools/strip
 	ln -sf "$(shell command -v llvm-objcopy)" debian/.llvm-tools/objcopy
-	PATH="$(CURDIR)/debian/.llvm-tools:$(PATH)" dh_strip
+	PATH="$(CURDIR)/debian/.llvm-tools:$(PATH)" dh_strip --exclude=libompdevice.a
 {% endif %}
 
 

--- a/build_tools/packaging/linux/template/rpm_specfile.j2
+++ b/build_tools/packaging/linux/template/rpm_specfile.j2
@@ -1,5 +1,9 @@
 # Use LLVM tools for stripping / objcopy
+{% if disable_rpm_strip %}
+%global __strip   /bin/true
+{% else %}
 %global __strip   /usr/bin/llvm-strip
+{% endif %}
 %global __objcopy /usr/bin/llvm-objcopy
 
 


### PR DESCRIPTION
rocm-llvm-dev/devel package creation was failing while stripping libompdevice.a .The static library contains bitcode(.bc) files.
Disabled the stripping of libompdevice.a 
Files in dev components are moved to run components in multiple ROCk artifacts. The artifact component directories in package.json need to be updated accordingly

Error:
strip: error: 'debian/rocm-llvm-dev7.1.0/opt/rocm-7.1.0/lib/llvm/lib/amdgcn-amd-amdhsa/libompdevice.a(libomptarget-amdgpu.bc)': The file was not recognized as a valid object file

With the fix , the error is not at all observed

