### PR TITLE
Printout GPU's that are visible in torch smoke tests

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Run PyTorch smoketests
         run: |
-          pytest -v external-builds/pytorch/smoke-tests
+          pytest --log-cli-level=INFO -v external-builds/pytorch/smoke-tests
 
       - name: Run PyTorch tests
         if: "contains(inputs.test_runs_on, 'linux')"

--- a/external-builds/pytorch/smoke-tests/pytorch_smoke_test.py
+++ b/external-builds/pytorch/smoke-tests/pytorch_smoke_test.py
@@ -1,9 +1,17 @@
 import torch
 import pytest
+import logging
 
 
 class TestROCmAvailability:
     def test_rocm_available(self):
+        logging.basicConfig(level=logging.INFO)
+        if torch.cuda.is_available():
+            cnt_gpu = torch.cuda.device_count()
+            logging.info("GPU count visible for pytorch: " + str(cnt_gpu))
+            for ii in range(cnt_gpu):
+                gpu_name = torch.cuda.get_device_name(ii)
+                logging.info("GPU[" + str(ii) + "]: " + gpu_name)
         assert (
             torch.cuda.is_available()
         ), "ROCm is not available or not detected by PyTorch"


### PR DESCRIPTION
Add a python/pytorch code to list all GPUs that are visible for the Pytorch.
This information is useful to capture when doing the ci builds and testing.

Related to https://github.com/ROCm/theRock/issues/2088

