### PR TITLE
Build therock-archives for Linux releases

### DIFF
--- a/build_tools/detail/linux_portable_build_in_container.sh
+++ b/build_tools/detail/linux_portable_build_in_container.sh
@@ -29,4 +29,4 @@ time cmake -GNinja -S /therock/src -B "$OUTPUT_DIR/build" \
   -DTHEROCK_BUNDLE_SYSDEPS=ON \
   ${PYTHON_EXECUTABLES_ARG} \
   "$@"
-time cmake --build "$OUTPUT_DIR/build"
+time cmake --build "$OUTPUT_DIR/build" --target therock-archives therock-dist


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/1522, follow-up to https://github.com/ROCm/TheRock/pull/2046.

This uploads artifact .tar.xz files to S3 as part of our Linux nightly release builds.

## Technical Details

The `therock-archives` CMake utility target populates `build/artifacts/{qualified_name}.tar.xz` files, which are what the `build_tools/github_actions/post_build_upload.py` script is looking for:

* https://github.com/ROCm/TheRock/blob/08fa70ff49b18373612b0580ad9245c801935674/cmake/therock_artifacts.cmake#L17-L21
* https://github.com/ROCm/TheRock/blob/08fa70ff49b18373612b0580ad9245c801935674/build_tools/github_actions/post_build_upload.py#L183-L195

We already build this CMake target in other workflows:
* https://github.com/ROCm/TheRock/blob/08fa70ff49b18373612b0580ad9245c801935674/.github/workflows/build_portable_linux_artifacts.yml#L123-L124

The Python package builds in this workflow already operate on loose artifact files, *not* the .tar.xz archives.

## Test Plan

Triggered https://github.com/ROCm/TheRock/actions/runs/19314427820

## Test Result

Test run succeeded, artifacts were uploaded to https://therock-dev-artifacts.s3.amazonaws.com/19314427820-linux/index-gfx1150.html

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
