### PR TITLE
Create separate lookups per trigger type

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -174,6 +174,7 @@ amdgpu_family_info_matrix_nightly = {
     },
 }
 
+
 def get_all_families_for_trigger_types(trigger_types):
     """
     Returns a combined family matrix for the specified trigger types.
@@ -181,9 +182,9 @@ def get_all_families_for_trigger_types(trigger_types):
     """
     result = {}
     matrix_map = {
-        'presubmit': amdgpu_family_info_matrix_presubmit,
-        'postsubmit': amdgpu_family_info_matrix_postsubmit,
-        'nightly': amdgpu_family_info_matrix_nightly,
+        "presubmit": amdgpu_family_info_matrix_presubmit,
+        "postsubmit": amdgpu_family_info_matrix_postsubmit,
+        "nightly": amdgpu_family_info_matrix_nightly,
     }
 
     for trigger_type in trigger_types:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -225,7 +225,9 @@ def get_pr_labels(args) -> List[str]:
     return labels
 
 
-def filter_known_names(requested_names: List[str], name_type: str, target_matrix=None) -> List[str]:
+def filter_known_names(
+    requested_names: List[str], name_type: str, target_matrix=None
+) -> List[str]:
     """Filters a requested names list down to known names.
 
     Args:
@@ -282,17 +284,17 @@ def matrix_generator(
     # Determine which trigger types are active for proper matrix lookup
     active_trigger_types = []
     if is_pull_request:
-        active_trigger_types.append('presubmit')
+        active_trigger_types.append("presubmit")
     if is_push and base_args.get("branch_name") == "main":
-        active_trigger_types.extend(['presubmit', 'postsubmit'])
+        active_trigger_types.extend(["presubmit", "postsubmit"])
     if is_schedule:
-        active_trigger_types.append('nightly')
+        active_trigger_types.append("nightly")
 
     # Get the appropriate family matrix based on active triggers
     # For workflow_dispatch and PR labels, we need to check all matrices
     if is_workflow_dispatch or (is_pull_request and len(active_trigger_types) > 0):
         # For workflow_dispatch, check all possible matrices
-        lookup_trigger_types = ['presubmit', 'postsubmit', 'nightly']
+        lookup_trigger_types = ["presubmit", "postsubmit", "nightly"]
         lookup_matrix = get_all_families_for_trigger_types(lookup_trigger_types)
         print(f"Using family matrix for trigger types: {lookup_trigger_types}")
     elif active_trigger_types:

--- a/build_tools/github_actions/fetch_package_targets.py
+++ b/build_tools/github_actions/fetch_package_targets.py
@@ -69,7 +69,7 @@ def determine_package_targets(args):
     # When a family appears in multiple trigger types (e.g., gfx110x in both presubmit and nightly),
     # the presubmit configuration takes priority. This ensures consistent behavior across all
     # packaging workflows.
-    matrix = get_all_families_for_trigger_types(['presubmit', 'postsubmit', 'nightly'])
+    matrix = get_all_families_for_trigger_types(["presubmit", "postsubmit", "nightly"])
     family_matrix = matrix
     package_targets = []
     # If the workflow does specify AMD GPU family, package those. Otherwise, then package all families


### PR DESCRIPTION
## Motivation

Before this change, the nightly version overwrites pre-submit in the `all` matrix, PR builds would incorrectly get the nightly configuration. Refer to this [issue](https://github.com/ROCm/TheRock/issues/1097).

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
