### PR TITLE
Draft docs/packaging/versioning.md

### DIFF
--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -75,15 +75,25 @@ The script produces these versions for each distribution channel:
 | Distribution channel | Version format    | Version example                                                                                                                                                     |
 | -------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | stable releases      | `X.Y.Z`           | `7.10.0`                                                                                                                                                            |
-| prereleases          | `X.Y.ZrcN`        | `7.10.0rc0`                                                                                                                                                         |
-| nightly releases     | `X.Y.ZaYYYYMMDD`  | `7.10.0a20251124`                                                                                                                                                   |
-| dev builds/releases  | `X.Y.Z.dev0+NNNN` | `7.10.0.dev0+efed3c3b10a5cce8578f58f8eb288582c26d18c4`<br>(for commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
+| prereleases          | `X.Y.ZrcN`        | `7.10.0rc0`<br>(The first release candidate for that stable release)                                                                                                |
+| nightly releases     | `X.Y.ZaYYYYMMDD`  | `7.10.0a20251124`<br>(The nightly release on 2025-11-24)                                                                                                            |
+| dev builds/releases  | `X.Y.Z.dev0+NNNN` | `7.10.0.dev0+efed3c3b10a5cce8578f58f8eb288582c26d18c4`<br>(For commit [`efed3c3`](https://github.com/ROCm/TheRock/commit/efed3c3b10a5cce8578f58f8eb288582c26d18c4)) |
 
 Each distribution channel (and GPU family within that channel) is currently
-hosted on a separate release index that can be selected with e.g.
-`pip install --index-url=https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ rocm`.
+hosted on a separate release index that can be passed to `pip` or `uv` via
+`--index-url`. For example:
+
+```bash
+pip install --index-url=https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ rocm`
+```
+
 See [RELEASES.md - Installing releases using pip](../../RELEASES.md#installing-releases-using-pip)
 for details.
+
+> [!NOTE]
+> We plan on later providing a single multi-architecture index as part of
+> multi-arch work, see
+> [RFC0008-Multi-Arch-Packaging.md - Python Packaging](../rfcs/RFC0008-Multi-Arch-Packaging.md#python-packaging).
 
 ### External Python package versions
 
@@ -110,20 +120,24 @@ PyTorch packages versions are handled via scripts:
 
 The scripts produce these versions for each distribution channel:
 
-| Package name        | Example release version                                                           | Example nightly version        |
-| ------------------- | --------------------------------------------------------------------------------- | ------------------------------ |
-| torch               | `2.7.1+rocm7.9.0rc1`<br>_(future releases will drop the 'rc' suffix)_             | `2.10.0a0+rocm7.10.0a20251024` |
-| torchaudio          | `2.7.1a0+rocm7.9.0rc1`<br>_(future releases will drop the 'a' and 'rc' suffixes)_ | `2.10.0a0+rocm7.10.0a20251024` |
-| torchvision         | `0.22.1+rocm7.9.0rc1`<br>_(future releases will drop the 'rc' suffix)_            | `0.24.0+rocm7.11.0a20251124`   |
-| pytorch-triton-rocm | `3.3.1+rocm7.9.0rc1`<br>_(future releases will drop the 'rc' suffix)_             | `3.5.1+rocm7.11.0a20251124`    |
+| Package name        | Example release version | Example nightly version        |
+| ------------------- | ----------------------- | ------------------------------ |
+| torch               | `2.7.1+rocm7.9.0rc1`    | `2.10.0a0+rocm7.10.0a20251024` |
+| torchaudio          | `2.7.1a0+rocm7.9.0rc1`  | `2.10.0a0+rocm7.10.0a20251024` |
+| torchvision         | `0.22.1+rocm7.9.0rc1`   | `0.24.0+rocm7.11.0a20251124`   |
+| pytorch-triton-rocm | `3.3.1+rocm7.9.0rc1`    | `3.5.1+rocm7.11.0a20251124`    |
 
 #### JAX versions
 
-TODO: specific examples of JAX versions, links to how this is done in code
+TODO: fill this in together with:
 
+- https://github.com/ROCm/TheRock/issues/1985
+- https://github.com/ROCm/TheRock/issues/2091
+
+<!--
 - jax-rocm7-pjrt
 - jax-rocm7-plugin
-- jaxlib (no rocm code in here)
+- jaxlib (no rocm code in here) -->
 
 ### Working with Python package versions
 
@@ -131,26 +145,70 @@ When working with versions please use these tools and avoid custom parsing
 (such as regex) if possible:
 
 - The `packaging.version` Python module: https://packaging.pypa.io/en/stable/version.html
+
+  For example:
+
+  ```python
+  >>> from packaging.version import Version
+  >>> v1 = Version("1.1.0")
+  >>> v2 = Version("1.2.0+abc")
+  >>> v2 > v1
+  True
+  >>> v2.base_version
+  '1.2.0'
+  ```
+
 - Existing Python scripts:
+
   - [`build_tools/compute_rocm_package_version.py`](/build_tools/compute_rocm_package_version.py)
   - [`build_tools/github_actions/determine_version.py`](/build_tools/github_actions/determine_version.py)
   - [`build_tools/github_actions/write_torch_versions.py`](/build_tools/github_actions/write_torch_versions.py)
 
-> [!TIP]
-> Python package installers like pip ignore pre-releases by default unless
-> explicitly requested with e.g. `pip install rocm==7.10.0rc0` or
-> `pip install --pre rocm`. See also
-> [Python Packaging User Guide - Versioning](https://packaging.python.org/en/latest/discussions/versioning/).
+#### Tip - installing prereleases
 
-> [!TIP]
-> The `--upgrade` and `--force-reinstall` options can also be useful when
-> switching between version types to ensure that the expected package versions
-> are used. See the documentation for
-> [pip install](https://pip.pypa.io/en/stable/cli/pip_install/).
+Python package installers like pip ignore pre-releases by default if a final
+release exists unless explicitly requested with e.g.
+`pip install rocm==7.10.0rc0` or `pip install --pre rocm`. See also
+[Python Packaging User Guide - Versioning](https://packaging.python.org/en/latest/discussions/versioning/).
 
-<!-- TODO: code samples (e.g. how to compare python package versions) -->
+#### Tip - Upgrading and force reinstalling
 
-<!-- TODO: how to check the version for each package/tool (`--version` commands, `pip show`) -->
+The `--upgrade` and `--force-reinstall` options can also be useful when
+switching between version types to ensure that the expected package versions
+are used. See the documentation for
+[pip install](https://pip.pypa.io/en/stable/cli/pip_install/).
+
+#### Tip - checking package versions
+
+A few ways to look up the version of an installed package are:
+
+- [`pip show`](https://pip.pypa.io/en/stable/cli/pip_show/):
+
+  ```console
+  $ pip show torch | grep Version
+  Version: 2.10.0a0+rocm7.11.0a20251209
+  ```
+
+- [`pip list`](https://pip.pypa.io/en/stable/cli/pip_list/):
+
+  ```console
+  $ pip list | grep torch
+  torch                          2.10.0a0+rocm7.11.0a2025120
+  ```
+
+- [`pip freeze`](https://pip.pypa.io/en/stable/cli/pip_freeze/):
+
+  ```console
+  $ pip freeze | grep torch
+  torch==2.10.0a0+rocm7.11.0a20251209
+  ```
+
+- The `__version__` module attribute:
+
+  ```console
+  $ python -c "import torch; print(torch.__version__)"
+  2.10.0a0+rocm7.11.0a20251209
+  ```
 
 ## Native Linux package versions
 


### PR DESCRIPTION
This documents our current implementation of package versions, starting with Python packages (including PyTorch). This will be extended in the future following
* Product requirement discussions
  * https://github.com/ROCm/TheRock/pull/2159
* JAX support work
  * https://github.com/ROCm/TheRock/issues/1985
  * https://github.com/ROCm/TheRock/issues/2091
* Native Linux packaging work
  * https://github.com/ROCm/TheRock/blob/main/docs/packaging/native_packaging.md
* Native Windows packaging work
  * https://github.com/ROCm/TheRock/issues/1987

Tarball "package versions" (file names) should also be covered here too.

See also questions about "rc" (release candidate) and "a" (alpha) releases [here on Discord](https://discord.com/channels/1239631572886491286/1375223676659564546/1439536547329216684).