### PR TITLE
Introduce rocm.devreleases.amd.com

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -80,11 +80,11 @@ on:
       cloudfront_url:
         description: CloudFront base URL pointing to Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2"
+        default: "https://rocm.devreleases.amd.com/v2"
       cloudfront_staging_url:
         description: CloudFront base URL pointing to staging Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2-staging"
+        default: "https://rocm.devreleases.amd.com/v2-staging"
       rocm_version:
         description: ROCm version to pip install
         type: string

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -80,11 +80,11 @@ on:
       cloudfront_url:
         description: CloudFront base URL pointing to Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2"
+        default: "https://rocm.devreleases.amd.com/v2"
       cloudfront_staging_url:
         description: CloudFront base URL pointing to staging Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2-staging"
+        default: "https://rocm.devreleases.amd.com/v2-staging"
       rocm_version:
         description: ROCm version to pip install
         type: string

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -110,8 +110,8 @@ jobs:
       - name: Set variables for development release
         if: ${{ env.release_type == 'dev' }}
         run: |
-          echo "tmp_cloudfront_url=https://d25kgig7rdsyks.cloudfront.net/v2" >> $GITHUB_ENV
-          echo "tmp_cloudfront_staging_url=https://d25kgig7rdsyks.cloudfront.net/v2-staging" >> $GITHUB_ENV
+          echo "tmp_cloudfront_url=https://rocm.devreleases.amd.com/v2" >> $GITHUB_ENV
+          echo "tmp_cloudfront_staging_url=https://rocm.devreleases.amd.com/v2-staging" >> $GITHUB_ENV
           echo "tmp_s3_subdir_tar=''" >> $GITHUB_ENV
 
       - name: Generate release information

--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -62,11 +62,11 @@ on:
       cloudfront_url:
         description: CloudFront URL pointing to Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2"
+        default: "https://rocm.devreleases.amd.com/v2"
       cloudfront_staging_url:
         description: CloudFront base URL pointing to staging Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2-staging"
+        default: "https://rocm.devreleases.amd.com/v2-staging"
       rocm_version:
         description: ROCm version to pip install
         type: string

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -114,8 +114,8 @@ jobs:
       - name: Set variables for development release
         if: ${{ env.release_type == 'dev' }}
         run: |
-          echo "tmp_cloudfront_url=https://d25kgig7rdsyks.cloudfront.net/v2" >> $GITHUB_ENV
-          echo "tmp_cloudfront_staging_url=https://d25kgig7rdsyks.cloudfront.net/v2-staging" >> $GITHUB_ENV
+          echo "tmp_cloudfront_url=https://rocm.devreleases.amd.com/v2" >> $GITHUB_ENV
+          echo "tmp_cloudfront_staging_url=https://rocm.devreleases.amd.com/v2-staging" >> $GITHUB_ENV
           echo "tmp_s3_subdir_tar=''" >> $GITHUB_ENV
 
       - name: Generate release information

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -21,7 +21,7 @@ on:
       cloudfront_url:
         description: CloudFront URL pointing to Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2"
+        default: "https://rocm.devreleases.amd.com/v2"
       cloudfront_staging_url:
         description: CloudFront base URL pointing to staging Python index
         required: true
@@ -62,11 +62,11 @@ on:
       cloudfront_url:
         description: CloudFront URL pointing to Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2"
+        default: "https://rocm.devreleases.amd.com/v2"
       cloudfront_staging_url:
         description: CloudFront base URL pointing to staging Python index
         type: string
-        default: "https://d25kgig7rdsyks.cloudfront.net/v2-staging"
+        default: "https://rocm.devreleases.amd.com/v2-staging"
       rocm_version:
         description: ROCm version to pip install
         type: string

--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -54,7 +54,7 @@ is_windows = platform.system() == "Windows"
 
 INDEX_URLS_MAP = {
     "nightly": "https://rocm.nightlies.amd.com/v2",
-    "dev": "https://d25kgig7rdsyks.cloudfront.net/v2",
+    "dev": "https://rocm.devreleases.amd.com/v2",
 }
 
 

--- a/build_tools/third_party/s3_management/README.md
+++ b/build_tools/third_party/s3_management/README.md
@@ -15,7 +15,7 @@ The Python package buckets we maintain are:
 
 S3 bucket name | S3 URL | User-facing URLs
 -- | -- | --
-`therock-dev-python` | https://therock-dev-python.s3.amazonaws.com/ | <ul><li>https://d25kgig7rdsyks.cloudfront.net/v2/</li><li>https://d25kgig7rdsyks.cloudfront.net/v2-staging/</li></ul>
+`therock-dev-python` | https://therock-dev-python.s3.amazonaws.com/ | <ul><li>https://rocm.devreleases.amd.com/v2/</li><li>https://rocm.devreleases.amd.com/v2-staging/</li></ul>
 `therock-nightly-python` | https://therock-nightly-python.s3.amazonaws.com/ | <ul><li>https://rocm.nightlies.amd.com/v2/</li><li>https://rocm.nightlies.amd.com/v2-staging/</li></ul>
 
 Each bucket has `v2` and `v2-staging` top level folders at the moment. This may
@@ -96,7 +96,7 @@ those changes to the dev bucket:
     ```
 
 1. Visit the URL to check that the index pages look as expected and include the
-  new dep. For example: https://d25kgig7rdsyks.cloudfront.net/v2/gfx120X-all/.
+  new dep. For example: https://rocm.devreleases.amd.com/v2/gfx120X-all/.
 
 Finally, repeat those steps for the nightly bucket:
 

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -235,7 +235,7 @@ The `rocm[libraries,devel]` packages can be installed in multiple ways:
 
   # OR from therock-dev-python
   python -m pip install \
-    --index-url https://d25kgig7rdsyks.cloudfront.net/v2/gfx110X-dgpu/ \
+    --index-url https://rocm.devreleases.amd.com/v2/gfx110X-dgpu/ \
     rocm[libraries,devel]
   ```
 

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -61,7 +61,7 @@ build_prod_wheels.py \
 # For therock-dev-python (unstable but useful for testing outside of prod)
 build_prod_wheels.py \
     install-rocm \
-    --index-url https://d25kgig7rdsyks.cloudfront.net/v2/gfx110X-dgpu/
+    --index-url https://rocm.devreleases.amd.com/v2/gfx110X-dgpu/
 ```
 
 3. Build torch, torchaudio and torchvision for a single gfx architecture.


### PR DESCRIPTION
This is a new URL providing access to our therock-dev-python and therock-dev-tarball S3 buckets via a CloudFront distribution. When developers trigger "dev" release builds to test workflow changes the outputs of those workflows are published there. Now we have no more error-prone or suspicious looking CloudFront URLs across the project.