### PR TITLE
Switch to download tarballs from CloudFront

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -121,7 +121,8 @@ jobs:
           echo "cloudfront_url=${tmp_cloudfront_url}" >> $GITHUB_OUTPUT
           echo "cloudfront_staging_url=${tmp_cloudfront_staging_url}" >> $GITHUB_OUTPUT
           echo "s3_subdir_tar=${tmp_s3_subdir_tar}" >> $GITHUB_OUTPUT
-          # TODO: Refactor to use a single CloudFront URL bucket paths (v2 vs. whl) are harmonized
+          # TODO: Refactor to use the base URL as CloudFront URL once bucket paths (v2 vs. whl) are harmonized.
+          # Uses bash parameter expansion to strip off subdirectories.
           echo "cloudfront_base_url=${tmp_cloudfront_url%/*}" >> $GITHUB_OUTPUT
 
       - name: Generating package target matrix


### PR DESCRIPTION
Instead of downloading tarballs from the S3 bucket, this switches to download these from the CloudFront distribution. This is one missing piece to enable building JAX in the prerelease workflows as the prerelease buckets do not provide public read access and files are only accessible through the CloudFront distribution by design.