### PR TITLE
[Enhancement] Use LLD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ include(therock_compiler_config)
 include(therock_external_source)
 include(therock_features)
 include(therock_sanitizers)
+include(therock_setup_linker)
 include(therock_subproject)
 include(therock_job_pools)
 include(therock_testing)
@@ -101,6 +102,23 @@ therock_enable_external_source("composable-kernel" "${THEROCK_SOURCE_DIR}/ml-lib
 
 # Overall build settings.
 option(THEROCK_VERBOSE "Enables verbose CMake statuses" OFF)
+
+# LLD configuration for projects not built with amd-llvm toolchain
+cmake_dependent_option(THEROCK_USE_LLD
+  "Links compiler subproject with system lld when available"
+  ON "NOT WIN32" OFF)
+cmake_dependent_option(THEROCK_FORCE_CMAKE_LINKER
+  "Force CMAKE_LINKER to system LLD in sub-projects not built with amd-llvm toolchain."
+  OFF THEROCK_USE_LLD OFF)
+
+if(THEROCK_USE_LLD)
+  set(SYSTEM_LLD_PATH)
+  therock_setup_linker(SYSTEM_LLD_PATH)
+  if(NOT SYSTEM_LLD_PATH)
+    message(WARNING "THEROCK_USE_LLD set to ON but no system LLD found - setting to OFF")
+    set(THEROCK_USE_LLD OFF CACHE BOOL "Links compiler subproject with system lld when available" FORCE)
+  endif()
+endif()
 
 # Initialize the install directory.
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/cmake/therock_setup_linker.cmake
+++ b/cmake/therock_setup_linker.cmake
@@ -1,47 +1,12 @@
 # therock_setup_linker.cmake
-# Detect and configure LLD linker if available for Clang or GCC on Linux/Windows.
+# Configures system LLD for projects not built with amd-llvm toolchain
 
-# Compiler and system info
-set(_compiler_id "${CMAKE_CXX_COMPILER_ID}")
-set(_system_name "${CMAKE_SYSTEM_NAME}")
+function(therock_setup_linker _out_lld_path)
+  if(WIN32)
+    find_program(${_out_lld_path} NAMES lld-link)
+  else()
+    find_program(${_out_lld_path} NAMES ld.lld lld)
+  endif()
 
-set(LLD_PATH "")
-
-# Function to try finding LLD
-macro(find_lld)
-    # First try CMake package
-    find_package(LLD QUIET)
-    if(LLD_FOUND AND EXISTS "${LLD_EXECUTABLE}")
-        set(LLD_PATH "${LLD_EXECUTABLE}")
-    else()
-        # Fall back to system PATH
-        if(WIN32)
-            find_program(LLD_PATH NAMES lld-link)
-        else()
-            find_program(LLD_PATH NAMES ld.lld lld)
-        endif()
-    endif()
-endmacro()
-
-# Determine if we can use LLD
-if(NOT WIN32 OR _compiler_id MATCHES "Clang")
-    set(LLD_PATH)
-    find_lld()
-
-    if(LLD_PATH)
-        message(STATUS "Configuring sub-project to use LLD: ${LLD_PATH}")
-
-        # Set CMake linker path
-        set(CMAKE_LINKER "${LLD_PATH}" CACHE FILEPATH "Path to system LLD linker" FORCE)
-
-        if(NOT WIN32)
-            set(CMAKE_EXE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS_INIT} -fuse-ld=lld")
-            set(CMAKE_SHARED_LINKER_FLAGS_INIT "${CMAKE_SHARED_LINKER_FLAGS_INIT} -fuse-ld=lld")
-            set(CMAKE_MODULE_LINKER_FLAGS_INIT "${CMAKE_MODULE_LINKER_FLAGS_INIT} -fuse-ld=lld")
-        endif()
-    else()
-        message(STATUS "LLD not found on system PATH, using default linker")
-    endif()
-else()
-    message(STATUS "Compiler ${_compiler_id} does not support LLD — skipping")
-endif()
+  set(${_out_lld_path} "${${_out_lld_path}}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
## Motivation

Issue: #1780 

## Technical Details

Added a new `cmake/therock_setup_linker.cmake` module which defines a function for finding system LLD on Windows and Linux. If the flag 'THEROCK_USE_LLD' is passed and LLD is found via this function, it configures the compiler subproject (and all other projects not compiled with amd-llvm) to use the system LLD instead of the default linker in `_therock_cmake_subproject_setup_toolchain` function call.

## Test Plan

Ran the build successfully on the manylinux image using a `yum` installation of LLD.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
