### PR TITLE
TheRock Software Packaging RFC

### DIFF
--- a/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
+++ b/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
@@ -14,9 +14,9 @@ With the implementation of TheRock build system, new software packaging requirem
 Our goals are to:
 
 1. **Standardize packaging behavior across Linux, Windows WSL2**
-2. **Ensure predictable upgrade behavior, side-by-side support, and compatibility with OS package managers (apt, dnf, yum, zypper for SLES)**
-3. **Comply with legal, licensing, and redistribution rules**
-4. **Support automated packaging workflows in TheRock with productized deliverables**
+1. **Ensure predictable upgrade behavior, side-by-side support, and compatibility with OS package managers (apt, dnf, yum, zypper for SLES)**
+1. **Comply with legal, licensing, and redistribution rules**
+1. **Support automated packaging workflows in TheRock with productized deliverables**
 
 ## Scope
 
@@ -88,16 +88,16 @@ repo.amd.com/rocm/packages/<primary_os>/
 
 The primary OS root folder will include the following distributions where the packages can be found:
 
-| Primary OS | Secondary |
-| :------------- |:-------------|
-| debian12 |  |
-| ubuntu2204 |  |
-| ubuntu2404 |  |
-| rhel8 | Centros 8 |
-| rhel9 | Oracle 9, Rock 9, Alma 9 |
-| rhel10 |  |
-| sles15 |  |
-| azl3 |  |
+| Primary OS | Secondary                |
+| :--------- | :----------------------- |
+| debian12   |                          |
+| ubuntu2204 |                          |
+| ubuntu2404 |                          |
+| rhel8      | Centros 8                |
+| rhel9      | Oracle 9, Rock 9, Alma 9 |
+| rhel10     |                          |
+| sles15     |                          |
+| azl3       |                          |
 
 ASAN packages may be separated into:
 
@@ -114,10 +114,10 @@ This will reduce the number of packages visible via the package manager.
 The four possible naming strategies for packages were analyzed:
 
 1. Prefix `amd-`
-2. Prefix `amdi-`: Legally the safest option, as no one can claim to AMD incorporated
-3. Suffix `-amd`
-4. Do nothing: Manage through versioning
-5. Prefix `amd`
+1. Prefix `amdi-`: Legally the safest option, as no one can claim to AMD incorporated
+1. Suffix `-amd`
+1. Do nothing: Manage through versioning
+1. Prefix `amd`
 
 A working group concluded that TheRock will adopt `amdrocm-<package>` for Linux distro-native package disambiguation.
 This avoids namespace conflicts with distro-provided packages. Distros will use `rocm-<package>` i.e., upstream distributions like Ubuntu and Redhat should not use `amdrocm-`, this will be recommended by AMD but not enforced by any restrictive covenants.
@@ -126,12 +126,12 @@ This avoids namespace conflicts with distro-provided packages. Distros will use 
 
 Users are encouraged to identify their local GPU architecture and install packages exclusive to the GPU architectures present. Otherwise, users can install a complete ROCm installation with all GPU architectures to enable all GPUs. Users not familiar with their GPU architecture may be directed to runfile installers with autodetection capabilities. These compromises are made with the understanding that package managers cannot autodetect local hardware to select package families.
 
-| Component | Meta package for all device packages |
-| :------------- | :------------- |
-| component-host | Host-only package |
+| Component         | Meta package for all device packages                                                               |
+| :---------------- | :------------------------------------------------------------------------------------------------- |
+| component-host    | Host-only package                                                                                  |
 | component-$device | $device is the llvm gfx architecture; each device package must have no conflict with other devices |
 
-Example: 
+Example:
 
 ```
 yum install miopen-gfx906 miopen-gfx908
@@ -159,50 +159,51 @@ yum install rocm-core<ver>
 yum install rocm-core-devel
 yum install rocm-core-devel<ver>
 ```
+
 The following table shows the meta packages that will be available:
 
-| Name | Content | Description |
-| :------------- | :------------- | :------------- |
-| amdrocm & amdrocm-core | runtime & libraries, components, runtime compiler, amd-smi, rocminfo | Needed to run software built with ROCm Core |
-| amdrocm-core-devel | rocm-core + compiler cmake, static library files, and headers | Needed to build software with ROCm Core |
-| amdrocm-developer-tools | Profiler, debugger, and related tools | Independent set of tools to debug and profile any application built with ROCm |
-| amdrocm-fortran |  | Fortran compiler and related components |
-| amdrocm-opencl |  | Components needed to run OpenCL |
-| amdrocm-openmp |  | Components needed to build OpenMP |
-| amdrocm-core-sdk |  | Everything |
+| Name                    | Content                                                              | Description                                                                   |
+| :---------------------- | :------------------------------------------------------------------- | :---------------------------------------------------------------------------- |
+| amdrocm & amdrocm-core  | runtime & libraries, components, runtime compiler, amd-smi, rocminfo | Needed to run software built with ROCm Core                                   |
+| amdrocm-core-devel      | rocm-core + compiler cmake, static library files, and headers        | Needed to build software with ROCm Core                                       |
+| amdrocm-developer-tools | Profiler, debugger, and related tools                                | Independent set of tools to debug and profile any application built with ROCm |
+| amdrocm-fortran         |                                                                      | Fortran compiler and related components                                       |
+| amdrocm-opencl          |                                                                      | Components needed to run OpenCL                                               |
+| amdrocm-openmp          |                                                                      | Components needed to build OpenMP                                             |
+| amdrocm-core-sdk        |                                                                      | Everything                                                                    |
 
-## Package Granularity 
+## Package Granularity
 
 Package granularity will be increased with ROCm 8.0. Development packages contain all the code required to build the libraries, including headers, Cmake files, and static libraries. Source packages for all of rocm-libraries provide all the files to build the libraries from source in addition to the rocm-rock source package.
 
-| Name | Dev package components only | Runtime packages | Source package inclusion only |
-| :------------- | :------------- | :------------- | :------------- |
-| amdrocm-amdsmi | | amd-smi | |
-| amdrocm-llvm |  | amdclang++ (flang and openmp here if not separable) |  |
-| amdrocm-flang |  | flang |  |
-| amdrocm-runtimes |  | HIP, ROCR, CLR, runtime compilation, SPIR-V |  |
-| amdrocm-fft |  | rocFFT, hipFFT, hipFFTW |  |
-| amdrocm-math |  | Temporary catch-all if libraries cannot fix circular dependencies by ROCm 8.0 |  |
-| amdrocm-blas | hipBLAS-common | rocBLAS, hipBLAS, hipBLASLt, hipSPARSELt |  |
-| amdrocm-sparse |  | rocSPARSE, hipSPARSE |  |
-| amdrocm-solver |  | rocSOLVER, hipSOLVER |  |
-| amdrocm-dnn |  | hipDNN, MIOpen |  |
-| amdrocm-rand |  | rocRAND, hipRAND |  |
-| amdrocm-ccl | rocPRIM, rocThrust, hipCUB | libhipcxx |  |
-| amdrocm-profiler |  | rocm-systems, rocm-compute, rocprofiler-sdk, tracer |  |
-| amdrocm-profiler-base |  | rocprofiler-sdk, tracer |  |
-| amdrocm-base |  | rocminfo, version (rocm-core) |  |
-| amdrocm-CK |  |  | CK |
-| amdrocm-debugger |  | rocgdb |  |
-| amdrocm-math-common or amdrocm-math-dev |  |  | CK, rocWMMA, rocRoller, Tensile, Origami |
-| amdrocm-hipify |  | HIPIFY |  |
-| amdrocm-opencl |  | OpenCL |  |
-| amdrocm-decode |  | rocDecode |  |
-| amdrocm-jpeg |  | rocJPEG |  |
-| amdrocm-file |  | hipFile, rocFile (future addition) |  |
-| amdrocm-rccl| | rccl |
-| amdrocm-sysdeps |  | Bundled 3rd party dependencies (e.g., libdrm, libelf, numa, subset of libVA) |  |
-| amdrocm-rdc|  | ROCm Datacenter | |
+| Name                                    | Dev package components only | Runtime packages                                                              | Source package inclusion only            |
+| :-------------------------------------- | :-------------------------- | :---------------------------------------------------------------------------- | :--------------------------------------- |
+| amdrocm-amdsmi                          |                             | amd-smi                                                                       |                                          |
+| amdrocm-llvm                            |                             | amdclang++ (flang and openmp here if not separable)                           |                                          |
+| amdrocm-flang                           |                             | flang                                                                         |                                          |
+| amdrocm-runtimes                        |                             | HIP, ROCR, CLR, runtime compilation, SPIR-V                                   |                                          |
+| amdrocm-fft                             |                             | rocFFT, hipFFT, hipFFTW                                                       |                                          |
+| amdrocm-math                            |                             | Temporary catch-all if libraries cannot fix circular dependencies by ROCm 8.0 |                                          |
+| amdrocm-blas                            | hipBLAS-common              | rocBLAS, hipBLAS, hipBLASLt, hipSPARSELt                                      |                                          |
+| amdrocm-sparse                          |                             | rocSPARSE, hipSPARSE                                                          |                                          |
+| amdrocm-solver                          |                             | rocSOLVER, hipSOLVER                                                          |                                          |
+| amdrocm-dnn                             |                             | hipDNN, MIOpen                                                                |                                          |
+| amdrocm-rand                            |                             | rocRAND, hipRAND                                                              |                                          |
+| amdrocm-ccl                             | rocPRIM, rocThrust, hipCUB  | libhipcxx                                                                     |                                          |
+| amdrocm-profiler                        |                             | rocm-systems, rocm-compute, rocprofiler-sdk, tracer                           |                                          |
+| amdrocm-profiler-base                   |                             | rocprofiler-sdk, tracer                                                       |                                          |
+| amdrocm-base                            |                             | rocminfo, version (rocm-core)                                                 |                                          |
+| amdrocm-CK                              |                             |                                                                               | CK                                       |
+| amdrocm-debugger                        |                             | rocgdb                                                                        |                                          |
+| amdrocm-math-common or amdrocm-math-dev |                             |                                                                               | CK, rocWMMA, rocRoller, Tensile, Origami |
+| amdrocm-hipify                          |                             | HIPIFY                                                                        |                                          |
+| amdrocm-opencl                          |                             | OpenCL                                                                        |                                          |
+| amdrocm-decode                          |                             | rocDecode                                                                     |                                          |
+| amdrocm-jpeg                            |                             | rocJPEG                                                                       |                                          |
+| amdrocm-file                            |                             | hipFile, rocFile (future addition)                                            |                                          |
+| amdrocm-rccl                            |                             | rccl                                                                          |                                          |
+| amdrocm-sysdeps                         |                             | Bundled 3rd party dependencies (e.g., libdrm, libelf, numa, subset of libVA)  |                                          |
+| amdrocm-rdc                             |                             | ROCm Datacenter                                                               |                                          |
 
 Note: Product management would like to follow upstream packaging structrures in ROCm in the future with no interim due dates as of now. Today there may be one amdrocm-llvm that includes both flang and the flang compiler; the flang component can be dependent on the llvm component.
 


### PR DESCRIPTION
## Motivation

Packaging requirements must be updated to align with TheRock's packaging and distribution strategy. The Product Management team is proposing the following changes and requirements for cross-platform delivery of the ROCm Core SDK and associated components. 

Proposed Requirements
1. **Standardize packaging behavior across Linux, Windows, and Python ecosystems**. Includes support for `pip`, WheelNext/UV (`amd-variant-provider`), MSI installers, and WinGet.
2. **Guarantee predictable upgrade behavior, side-by-side support/versioning rules, and compatibility with OS package managers (apt, dnf, yum, zypper for SLES)**
3. **Comply with legal, licensing, and redistribution rules**
4. **Support automated packaging workflows in TheRock**. RFC must define productized deliverables, repository layout, artifact naming, versioning scheme, and how SDK components map to TheRock build outputs.
5. **Collect public feedback (internal + external)**. RFC will be published for review before finalizing packaging architecture.

## Technical Details

- RFC will define Linux distro packaging (rpm/deb), Python packaging (pip, WheelNext brackets extras), and Windows/winget/MSI packaging.
- Folder structures and API search paths must remain stable.

## Test Plan

Documentation-only RFC. No functional tests applicable.

## Test Result

N/A - see test plan.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
