### PR TITLE
Check for Windows symlink prior to tf.extract

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -189,7 +189,6 @@ def _lock_and_expand(
                         parent_path = dest_path.parent
                         if parent_path not in clean_dir_paths:
                             _clean_dir(parent_path)
-                        tf.extract(ti, path=site_lib_path)
                         if ti.name not in dist_file_path_names:
                             # CSV record:
                             #   path
@@ -202,10 +201,13 @@ def _lock_and_expand(
                             # on systems without as robust symlink support.
                             # As needed, we could also generate tarfiles with
                             # copies instead of symlinks, at the cost of disk space.
-                            symlink_target = dest_path.readlink()
+                            # Creating symlinks on Windows also requires admin privileges.
+                            parent_path.mkdir(parents=True, exist_ok=True)
+                            symlink_target = ti.linkname
                             hardlink_target = dest_path.parent / symlink_target
-                            dest_path.unlink()
                             dest_path.hardlink_to(hardlink_target)
+                        else:
+                            tf.extract(ti, path=site_lib_path)
                     elif ti.isdir():
                         # We don't generally have directory entries, but handle
                         # them if we do.


### PR DESCRIPTION
## Motivation

Resolves issues seen in https://github.com/ROCm/TheRock/issues/1913 and https://github.com/ROCm/TheRock/issues/1906

## Technical Details

Without admin privileges, `_rocm_sdk_devel` fails to expand correctly. This is due to `tf.extract()` trying to create symlinks which requires elevated privileges on Windows. To prevent this, we can first check for symlinks in the tarballs and create hardlinks.

In the existing code, we already had logic to convert the newly created symlinks to hardlinks - with this new change we just skip over the symlink creation portion and go straight to creating hardlinks.


## Test Plan

1. On windows, pip installed latest ROCm wheels
2. Run `rocm-sdk init` in a base command prompt window - `FileNotFoundError` error seen when trying to convert symlinks to hardlinks as symlink was never successfully created. This results in a _rocm_sdk_devel folder with empty subdirectories
3. Delete _rocm_sdk_devel folder
4. Apply patch to _devel.py file
5. Run `rocm-sdk init` - Folder successfully extracted with all contents present


## Test Result

Output before and after applying patch

```
(test) C:\Users\harkgill\arch>rocm-sdk init
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\harkgill\arch\test\Scripts\rocm-sdk.exe\__main__.py", line 7, in <module>
  File "C:\Users\harkgill\arch\test\Lib\site-packages\rocm_sdk\__main__.py", line 150, in main
    args.func(args)
  File "C:\Users\harkgill\arch\test\Lib\site-packages\rocm_sdk\__main__.py", line 43, in _do_init
    root_path = _devel.get_devel_root()
                ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\harkgill\arch\test\Lib\site-packages\rocm_sdk\_devel.py", line 63, in get_devel_root
    _expand_devel_contents(rocm_sdk_devel_path, site_lib_path)
  File "C:\Users\harkgill\arch\test\Lib\site-packages\rocm_sdk\_devel.py", line 154, in _expand_devel_contents
    _lock_and_expand(
  File "C:\Users\harkgill\arch\test\Lib\site-packages\rocm_sdk\_devel.py", line 205, in _lock_and_expand
    symlink_target = dest_path.readlink()
                     ^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.2800.0_x64__qbz5n2kfra8p0\Lib\pathlib.py", line 1282, in readlink
    return self.with_segments(os.readlink(self))
                              ^^^^^^^^^^^^^^^^^
FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\Users\\harkgill\\arch\\test\\Lib\\site-packages\\_rocm_sdk_devel\\.info\\version'

(test) C:\Users\harkgill\arch>rocm-sdk init
Devel contents expanded to 'C:\Users\harkgill\arch\test\Lib\site-packages\_rocm_sdk_devel'
```

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
