### PR TITLE
Fixed typo: "x84-64" → "x86-64"

### DIFF
--- a/docs/environment_setup_guide.md
+++ b/docs/environment_setup_guide.md
@@ -49,7 +49,7 @@ If having trouble building on a system, we will typically want to eliminate envi
 
 ## Alternative Configurations
 
-### Manylinux x84-64
+### Manylinux x86-64
 
 Our open-source binaries are typically built within a [manylinux container](https://github.com/pypa/manylinux) (see [the docker file](../dockerfiles/build_manylinux_x86_64.Dockerfile)). These images are versioned by the glibc version they target, and if dependencies are controlled carefully, binaries built on them should work on systems with the same or higher glibc version.
 


### PR DESCRIPTION
## Motivation

- Read an article about recent developments at AMD (TheRock in particular) and wanted to dive into the codebase.
- I was reading the environment setup guide page and noticed the typo.

## Technical Details

The update is not non-technical in nature and an update to the docs.

## Test Plan

No need for tests.

## Test Result

N/A/

## Submission Checklist

- [-] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
