### PR TITLE
Increase rocWMMA smoke test timeout

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
@@ -33,10 +33,10 @@ if test_type == "smoke":
     # The emulator regression tests are very fast.
     # If we need something even faster we can use "/smoke" here.
     test_subdir = "/regression"
-    timeout = "300"
+    timeout = "900"
 elif test_type == "regression":
     test_subdir = "/regression"
-    timeout = "300"
+    timeout = "900"
 
 cmd = [
     "ctest",


### PR DESCRIPTION
## Motivation

The original timeout worked well when the test machines were not too busy.  More time is needed for the smoke tests when the test machines are very busy.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
