### PR TITLE
Add rocWMMA to Python packages

### DIFF
--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -349,7 +349,7 @@ class PopulatedDistPackage:
             ]
             subprocess.check_call(patchelf_cl)
 
-      def _normalize_rpath(self, file_path: Path):
+    def _normalize_rpath(self, file_path: Path):
         existing_rpath = (
             subprocess.check_output(
                 [


### PR DESCRIPTION
## Motivation

This PR aims to add support for rocWMMA when building the Python packages with `build_python_packages`. Fixes #2168 
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Added rocwmma to the develop packages. Made a change to packaging to not include the wmma test artifact (rocwmma_test_gfxXXXX)
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Tested on Linux by building and installing the generated wheels following [these instructions](https://github.com/ROCm/TheRock/blob/main/docs/packaging/python_packaging.md#example) and verified that wmma is included in the `_rocm_sdk_devel` folder
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

rocWMMA is packaged as expected:
```
include/rocwmma/
include/rocwmma/internal/layout/transforms/transforms_int_wmma_impl.hpp
include/rocwmma/internal/layout/transforms/transforms_wmma_impl.hpp
include/rocwmma/internal/rocwmma_xfloat32.hpp
include/rocwmma/internal/wmma.hpp
include/rocwmma/internal/wmma_impl.hpp
include/rocwmma/rocwmma-version.hpp
include/rocwmma/rocwmma.hpp
include/rocwmma/rocwmma_impl.hpp
include/rocwmma/rocwmma_transforms.hpp
include/rocwmma/rocwmma_transforms_impl.hpp
lib/cmake/rocwmma/
lib/cmake/rocwmma/rocwmma-config-version.cmake
lib/cmake/rocwmma/rocwmma-config.cmake
lib/cmake/rocwmma/rocwmma-targets.cmake
```
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
