### PR TITLE
Remove rocWMMA empty target workaround

### DIFF
--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -289,8 +289,6 @@ if(THEROCK_ENABLE_ROCWMMA)
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/rocwmma"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocWMMA"
     BACKGROUND_BUILD
-    DEFAULT_GPU_TARGETS
-      gfx1100  # TODO: Fix rocwmma to accept an empty target list.
     CMAKE_ARGS
       -DHIP_PLATFORM=amd
       -DROCM_PATH=


### PR DESCRIPTION
## Motivation

Remove the workaround for when we try to build rocWMMA with an empty target.

## Technical Details

As of 2025/11/19 rocWMMA will default to the first compatible target in the case where we explicitly specify an empty GPU_TARGET. See https://github.com/ROCm/rocm-libraries/pull/2678

## Test Plan

Test against gfx103X:
https://github.com/ROCm/TheRock/actions/runs/19517010601

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
