### PR TITLE
[torch] Add --pytorch-dir test arg, replacing --the-rock-root-dir

### DIFF
--- a/external-builds/pytorch/run_linux_pytorch_tests.py
+++ b/external-builds/pytorch/run_linux_pytorch_tests.py
@@ -140,7 +140,9 @@ If no PyTorch version is given, it is auto-determined by the PyTorch used to run
         "--pytorch-dir",
         type=Path,
         default=default_pytorch_dir,
-        help="Path for the pytorch repository, where tests will be sourced from",
+        help="""Path for the pytorch repository, where tests will be sourced from
+By default the pytorch directory is determined based on this script's location
+""",
     )
 
     parser.add_argument(
@@ -170,7 +172,7 @@ If no PyTorch version is given, it is auto-determined by the PyTorch used to run
 
     if not args.pytorch_dir.exists():
         parser.error(
-            f"Directory at '{args.pytorch_dir}' does not exist, checkout pytorch and then set the path via --pytorch-dir"
+            f"Directory at '{args.pytorch_dir}' does not exist, checkout pytorch and then set the path via --pytorch-dir or check it out in TheRock/external-build/pytorch/<your pytorch directory>"
         )
 
     return args


### PR DESCRIPTION
## Motivation

The script was previously assuming that pytorch was always checked out to `TheRock/external-builds/pytorch/pytorch`. This path can be customized, especially when testing multiple pytorch versions/branches or when running on Windows where that default path is too long.

This is part of making it easier to reproduce pytorch test failures, see https://github.com/ROCm/TheRock/issues/2173

## Test Plan

* Sanity check on CI: https://github.com/ROCm/TheRock/actions/runs/19549864812/job/55978264497

* Tested by running the script locally with 

    ```bash
    python ~/dev/projects/TheRock/external-builds/pytorch/run_linux_pytorch_tests.py \
      --amdgpu-family gfx110X-dgpu \
      --pytorch-dir ~/dev/projects/pytorch \
      &> logs/tests_torch2.9_$(date +%F)_01.txt
    ```
    
    (I'd love for some automated way to auto-increment that `01` each run... hmm... maybe put the HH/MM/SS or unix timestamp too?)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
