### PR TITLE
Remove `populate_ancillary_sources` in `build_tools/fetch_sources.py`

### DIFF
--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -82,8 +82,6 @@ def run(args):
         cwd=THEROCK_DIR,
     )
 
-    populate_ancillary_sources(args)
-
     # Remove any stale .smrev files.
     remove_smrev_files(args, projects)
 
@@ -246,40 +244,6 @@ def get_submodule_revision(submodule_path: str) -> str:
         .strip()
     )
     return ls_line.split()[1]
-
-
-def populate_ancillary_sources(args):
-    """Various subprojects have their own mechanisms for populating ancillary sources
-    needed to build. There is often something in CMake that attempts to automate it,
-    but it is also often broken. So we just do the right thing here as a transitionary
-    step to fixing the underlying software packages."""
-    populate_submodules_if_exists(args, THEROCK_DIR / "base" / "rocprofiler-register")
-    populate_submodules_if_exists(args, THEROCK_DIR / "profiler" / "rocprofiler-sdk")
-
-    # TODO(#36): Enable once rocprofiler-systems can be checked out on Windows
-    #     error: invalid path 'src/counter_analysis_toolkit/scripts/sample_data/L2_RQSTS:ALL_DEMAND_REFERENCES.data.reads.stat'
-    #  Upstream issues:
-    #   https://github.com/ROCm/rocprofiler-systems/issues/105
-    #   https://github.com/icl-utk-edu/papi/issues/321
-    if not is_windows():
-        populate_submodules_if_exists(
-            args, THEROCK_DIR / "profiler" / "rocprofiler-systems"
-        )
-
-
-def populate_submodules_if_exists(args, git_dir: Path):
-    if not git_dir.exists():
-        print(f"Not populating submodules for {git_dir} (does not exist)")
-        return
-    print(f"Populating submodules for {git_dir}:")
-    update_args = []
-    if args.depth is not None:
-        update_args = ["--depth", str(args.depth)]
-    if args.jobs:
-        update_args += ["--jobs", str(args.jobs)]
-    if args.progress:
-        update_args += ["--progress"]
-    exec(["git", "submodule", "update", "--init"] + update_args, cwd=git_dir)
 
 
 def main(argv):


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

`populate_ancillary_sources` appears to be dead code. `rocprofiler-register` and `rocprofiler-sdk` live in `rocm-systems`, but `populate_ancillary_sources` is looking for these two directories on the wrong path. What this function _does_ is gated behind finding the directories, so it appears it simply does nothing.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Removed dead code.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

No new features.

## Test Result

<!-- Briefly summarize test outcomes. -->

CI passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
