### PR TITLE
[compiler] Allow users to specify Flang concurrency

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -11,6 +11,16 @@ if(THEROCK_ENABLE_COMPILER)
     list(APPEND _extra_llvm_cmake_args "-DLLVM_ENABLE_PEDANTIC=OFF")
   endif()
 
+  # Building Flang is very memory-intensive on systems with many cores. Allow
+  # users to specify the level of concurrency for these tasks so they can
+  # reduce the risk of running out of memory.
+  if(FLANG_PARALLEL_COMPILE_JOBS)
+    message(STATUS "Flang build concurrency level set to ${FLANG_PARALLEL_COMPILE_JOBS}")
+    list(APPEND _extra_llvm_cmake_args "-DFLANG_PARALLEL_COMPILE_JOBS=${FLANG_PARALLEL_COMPILE_JOBS}")
+  else()
+     message(STATUS "Flang concurrency is unlimited. Memory usage may be much higher.")
+  endif()
+
   # If the compiler is not pristine (i.e. has patches), then there will be a
   # ".amd-llvm.smrev" file present which must be used instead of the auto
   # computed git revision. If present, this will have a stable hash of


### PR DESCRIPTION
## Motivation

Making TheRock builds more stable memory-wise on systems with many cores.

## Technical Details

On systems with a large number of cores, building Flang can easily use up all the available memory and swap. To prevent this, allow users to specify the level of concurrency when building Flang.

This can be done with LLVM's FLANG_PARALLEL_COMPILE_JOBS cmake variable. We just forward this setting to the amd-llvm build.

If it is not set, the level of concurrency is unlimited (with all of its consequences).

## Test Plan

Tested by building and checking the Flang concurrency cap is in place.

## Test Result

Confirmed the cap is in place.