### PR TITLE
Re-enable sharding for rocWMMA tests

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -208,10 +208,10 @@ test_matrix = {
     "rocwmma": {
         "job_name": "rocwmma",
         "fetch_artifact_args": "--rocwmma --tests --blas",
-        "timeout_minutes": 120,
+        "timeout_minutes": 60,
         "test_script": f"python {_get_script_path('test_rocwmma.py')}",
         "platform": ["linux", "windows"],
-        "total_shards": 1,
+        "total_shards": 4,
     },
 }
 


### PR DESCRIPTION
## Motivation

The rocWMMA tests are _run_ with ctest, but each of the binaries is a gtest executable, so sharding does work.

https://gist.github.com/bsyrowik/30b3377296449a3982e6c23a9aee4192

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
