### PR TITLE
Move CMake `_system_toolchain` variable up in scope.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,15 +1,15 @@
-if(THEROCK_ENABLE_CORE_RUNTIME)
-  # On Linux, we compile core libraries with our own LLVM. This gets us the
-  # best optimizations and, most importantly, gives us uniform access to
-  # sanitizers. Currently, some of these projects, though, are hard-coded
-  # for MSVC on Windows, so on that platform, just build them with the system
-  # compiler.
-  # TODO: Switch windows to use our own clang.
-  set(_system_toolchain "amd-llvm")
-  if(WIN32)
-    set(_system_toolchain "")
-  endif()
+# On Linux, we compile core libraries with our own LLVM. This gets us the
+# best optimizations and, most importantly, gives us uniform access to
+# sanitizers. Currently, some of these projects, though, are hard-coded
+# for MSVC on Windows, so on that platform, just build them with the system
+# compiler.
+# TODO: Switch windows to use our own clang.
+set(_system_toolchain "amd-llvm")
+if(WIN32)
+  set(_system_toolchain "")
+endif()
 
+if(THEROCK_ENABLE_CORE_RUNTIME)
   ##############################################################################
   # ROCR-Runtime
   ##############################################################################


### PR DESCRIPTION
I noticed this while reviewing https://github.com/ROCm/TheRock/pull/2240 - `THEROCK_ENABLE_CORE_RUNTIME` is always disabled on Windows, so this code would never run there. The variable is used further down in the file under `THEROCK_ENABLE_HIP_RUNTIME` though. This is not causing any issues yet since Windows currently sets the value to empty anyways.

Follow-up to https://github.com/ROCm/TheRock/pull/1663.