### PR TITLE
Fix `OCL` runtime `shared-lib` test using `CMake` `RPATH` settings

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -251,9 +251,8 @@ if(THEROCK_ENABLE_OCL_RUNTIME)
       ROCR-Runtime
     )
 
-    # Make libamdocl64.so self-contained via RPATH/RUNPATH, so that it can
-    # find its dependencies (e.g. libamd_comgr_loader.so.1) one level up
-    # from dist/lib/opencl -> dist/lib
+    # Add linked library directories to the installed RPATH, enabling
+    # libamdocl64.so to locate its runtime dependencies.
     list(APPEND OCL_CLR_CMAKE_ARGS
       "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON"
     )


### PR DESCRIPTION
## Motivation

Progress on #2266
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Test on local and CI
## Test Result
`Test Packaging` results from CI looks good and no issue with `therock-validate-shared-lib-libamdocl64.so` test. 

```
Start 26: therock-validate-shared-lib-libamdocl64.so
26/32 Test #26: therock-validate-shared-lib-libamdocl64.so ............   Passed    0.04 sec
```
The link from CI Job is: https://github.com/ROCm/TheRock/actions/runs/19627184489/job/56246327780?pr=2271


```
Run ctest --test-dir build --output-on-failure
Internal ctest changing into directory: /__w/TheRock/TheRock/build
Test project /__w/TheRock/TheRock/build
      Start  1: therock-validate-shared-lib-librocm-openblas.so
 1/32 Test  #1: therock-validate-shared-lib-librocm-openblas.so .......   Passed    0.06 sec
      Start  2: therock-validate-shared-lib-libamd.so
 2/32 Test  #2: therock-validate-shared-lib-libamd.so .................   Passed    0.03 sec
      Start  3: therock-validate-shared-lib-libcamd.so
 3/32 Test  #3: therock-validate-shared-lib-libcamd.so ................   Passed    0.03 sec
      Start  4: therock-validate-shared-lib-libccolamd.so
 4/32 Test  #4: therock-validate-shared-lib-libccolamd.so .............   Passed    0.03 sec
      Start  5: therock-validate-shared-lib-libcholmod.so
 5/32 Test  #5: therock-validate-shared-lib-libcholmod.so .............   Passed    0.04 sec
      Start  6: therock-validate-shared-lib-libcolamd.so
 6/32 Test  #6: therock-validate-shared-lib-libcolamd.so ..............   Passed    0.03 sec
      Start  7: therock-validate-shared-lib-libsuitesparseconfig.so
 7/32 Test  #7: therock-validate-shared-lib-libsuitesparseconfig.so ...   Passed    0.03 sec
      Start  8: therock-validate-shared-lib-libbz2.so
 8/32 Test  #8: therock-validate-shared-lib-libbz2.so .................   Passed    0.03 sec
      Start  9: therock-validate-shared-lib-libcap.so
 9/32 Test  #9: therock-validate-shared-lib-libcap.so .................   Passed    0.03 sec
      Start 10: therock-validate-shared-lib-libdrm.so
10/32 Test #10: therock-validate-shared-lib-libdrm.so .................   Passed    0.03 sec
      Start 11: therock-validate-shared-lib-libdrm_amdgpu.so
11/32 Test #11: therock-validate-shared-lib-libdrm_amdgpu.so ..........   Passed    0.03 sec
      Start 12: therock-validate-shared-lib-liblzma.so
12/32 Test #12: therock-validate-shared-lib-liblzma.so ................   Passed    0.03 sec
      Start 13: therock-validate-shared-lib-libnuma.so
13/32 Test #13: therock-validate-shared-lib-libnuma.so ................   Passed    0.03 sec
      Start 14: therock-validate-shared-lib-libsqlite3.so
14/32 Test #14: therock-validate-shared-lib-libsqlite3.so .............   Passed    0.03 sec
      Start 15: therock-validate-shared-lib-libz.so
15/32 Test #15: therock-validate-shared-lib-libz.so ...................   Passed    0.03 sec
      Start 16: therock-validate-shared-lib-libzstd.so
16/32 Test #16: therock-validate-shared-lib-libzstd.so ................   Passed    0.03 sec
      Start 17: therock-validate-shared-lib-libelf.so
17/32 Test #17: therock-validate-shared-lib-libelf.so .................   Passed    0.03 sec
      Start 18: therock-validate-shared-lib-libdw.so
18/32 Test #18: therock-validate-shared-lib-libdw.so ..................   Passed    0.03 sec
      Start 19: therock-validate-shared-lib-libasm.so
19/32 Test #19: therock-validate-shared-lib-libasm.so .................   Passed    0.03 sec
      Start 20: therock-validate-shared-lib-libamd_comgr.so
20/32 Test #20: therock-validate-shared-lib-libamd_comgr.so ...........   Passed    0.04 sec
      Start 21: amd_comgr_stub_test
21/32 Test #21: amd_comgr_stub_test ...................................   Passed    0.01 sec
      Start 22: therock-validate-shared-lib-libhsa-runtime64.so
22/32 Test #22: therock-validate-shared-lib-libhsa-runtime64.so .......   Passed    0.04 sec
      Start 23: therock-validate-shared-lib-libamdhip64.so
23/32 Test #23: therock-validate-shared-lib-libamdhip64.so ............   Passed    0.04 sec
      Start 24: therock-validate-shared-lib-libhiprtc-builtins.so
24/32 Test #24: therock-validate-shared-lib-libhiprtc-builtins.so .....   Passed    0.03 sec
      Start 25: therock-validate-shared-lib-libhiprtc.so
25/32 Test #25: therock-validate-shared-lib-libhiprtc.so ..............   Passed    0.04 sec
      Start 26: therock-validate-shared-lib-libamdocl64.so
26/32 Test #26: therock-validate-shared-lib-libamdocl64.so ............   Passed    0.04 sec
      Start 27: therock-validate-shared-lib-librdc_bootstrap.so
27/32 Test #27: therock-validate-shared-lib-librdc_bootstrap.so .......   Passed    0.03 sec
      Start 28: therock-validate-shared-lib-librdc_client.so
28/32 Test #28: therock-validate-shared-lib-librdc_client.so ..........   Passed    0.03 sec
      Start 29: rdc-validate-no-grpc-symbol-pollution
29/32 Test #29: rdc-validate-no-grpc-symbol-pollution .................   Passed    0.05 sec
      Start 30: rdc-verify-binaries-exist
30/32 Test #30: rdc-verify-binaries-exist .............................   Passed    0.00 sec
      Start 31: rdc-verify-library-sonames
31/32 Test #31: rdc-verify-library-sonames ............................   Passed    0.00 sec
      Start 32: therock-examples-cpp-sdk-user
32/32 Test #32: therock-examples-cpp-sdk-user .........................   Passed    6.10 sec

100% tests passed, 0 tests failed out of 32

Label Time Summary:
build-verification    =   0.00 sec*proc (2 tests)
rdc                   =   0.06 sec*proc (3 tests)
symbol-visibility     =   0.05 sec*proc (1 test)

Total Test time (real) =   7.32 sec
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
