### PR TITLE
[hipDNN] [ALMIOPEN-396] Enable hipDNN in Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,21 +351,17 @@ therock_add_feature(MIOPEN
   REQUIRES COMPILER HIP_RUNTIME BLAS RAND ${_optional_profiler_requirements}
 )
 
-# hipDNN on Windows is disabled for now, but will be enabled in a follow-up change.
-# Windows support issue tracked at: https://github.com/ROCm/TheRock/issues/1822
-if(NOT WIN32)
-  therock_add_feature(HIPDNN
-    GROUP ML_LIBS
-    DESCRIPTION "Enables the hipDNN project"
-    REQUIRES COMPILER HIP_RUNTIME
-  )
+therock_add_feature(HIPDNN
+  GROUP ML_LIBS
+  DESCRIPTION "Enables the hipDNN project"
+  REQUIRES COMPILER HIP_RUNTIME
+)
 
-  therock_add_feature(MIOPEN_PLUGIN
-    GROUP ML_LIBS
-    DESCRIPTION "Enables the MIOpen plugin project"
-    REQUIRES COMPILER MIOPEN HIPDNN HIP_RUNTIME
-  )
-endif()
+therock_add_feature(MIOPEN_PLUGIN
+  GROUP ML_LIBS
+  DESCRIPTION "Enables the MIOpen plugin project"
+  REQUIRES COMPILER MIOPEN HIPDNN HIP_RUNTIME
+)
 
 # Finalize all feature flags.
 therock_finalize_features()

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -192,7 +192,7 @@ test_matrix = {
         "fetch_artifact_args": "--hipdnn --tests",
         "timeout_minutes": 5,
         "test_script": f"python {_get_script_path('test_hipdnn.py')}",
-        "platform": ["linux"],
+        "platform": ["linux", "windows"],
         "total_shards": 1,
     },
     # MIOpen plugin tests
@@ -201,7 +201,7 @@ test_matrix = {
         "fetch_artifact_args": "--blas --miopen --hipdnn --miopen-plugin --tests",
         "timeout_minutes": 15,
         "test_script": f"python {_get_script_path('test_miopen_plugin.py')}",
-        "platform": ["linux"],
+        "platform": ["linux", "windows"],
         "total_shards": 1,
     },
     # rocWMMA tests


### PR DESCRIPTION
## Motivation
Enable hipDNN builds in Windows

## Technical Details
- Enable in root CMakeLists.txt
- Enable tests

## Test Plan
- [x] All unit and integrations tests pass
- ⚠️ No ASAN check in Windows

## Test Result
- [x] Tests pass

## Submission Checklist
- [x] clang-tidy
- [x] clang-format
