### PR TITLE
Docker - Include libVA for media libraries

### DIFF
--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -78,6 +78,13 @@ RUN yum install -y \
     && yum clean all && \
     rm -rf /var/cache/yum
 
+######## Yum Packages for amd-mesa, rocdecode, and rocjpeg #######
+# Additional packages required for media libraries to build
+RUN yum install -y \
+      libva-devel \
+    && yum clean all && \
+    rm -rf /var/cache/yum
+
 ######## DVC via pip ######
 # dvc's rpm package includes .so dependencies built against glib 2.29
 # settling for pip install for now, but it installs modules not needed for dvc pull


### PR DESCRIPTION
## Motivation

Media libraries require libva-devel for building mesa, rocdecode, and rocjpeg

## Technical Details

`libva-devel` package brings VA libraries and headers that are used to build mesa and media libraries in the build phase. For Debian based - `libva-drm2`, rpm based`libva-drm2`/`libva` is required for runtime when TheRock is delivered. This is compatible with all system provided VA libraries version 1.8 and higher

## Test Plan

Current test plan

## Test Result

All current tests should pass and PR #2267 should pass

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
