### PR TITLE
Revert "Rename "pytorch_version" to "pytorch_git_ref" to disambiguate"

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -32,8 +32,8 @@ on:
       rocm_version:
         description: ROCm version to pip install
         type: string
-      pytorch_git_ref:
-        description: PyTorch ref to checkout. (typically "nightly", or "release/X.Y")
+      pytorch_version:
+        description: PyTorch version to checkout. (typically "nightly", or "release/X.Y")
         required: true
         type: string
       pytorch_patchset:
@@ -88,8 +88,8 @@ on:
       rocm_version:
         description: ROCm version to pip install
         type: string
-      pytorch_git_ref:
-        description: PyTorch ref to checkout. (typically "nightly", or "release/X.Y")
+      pytorch_version:
+        description: PyTorch version to checkout. (typically "nightly", or "release/X.Y")
         required: true
         type: string
         default: "release/2.7"
@@ -105,7 +105,7 @@ permissions:
 
 jobs:
   build_pytorch_wheels:
-    name: Build | ${{ inputs.amdgpu_family }} | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_git_ref }}
+    name: Build | ${{ inputs.amdgpu_family }} | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_version }}
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:4af52d56d91ef6ef8b7d0a13c6115af1ab2c9bf4a8a85d9267b489ecb737ed25
@@ -116,19 +116,6 @@ jobs:
       optional_build_prod_arguments: ""
     outputs:
       cp_version: ${{ env.cp_version }}
-      # The following are python package versions produced by the build. The
-      # exact versions will depend on workflow inputs and the underlying code.
-      # For example:
-      #   Inputs
-      #     rocm_version       : 7.10.0a20251120
-      #     pytorch_git_ref    : release/2.9
-      #   Outputs
-      #     torch_version      : 2.9.1+rocm7.10.0a20251120
-      #     torchaudio_version : 2.9.0+rocm7.10.0a20251120
-      #     torchvision_version: 0.24.0+rocm7.10.0a20251120
-      #     triton_version     : 3.5.1+rocm7.10.0a20251120
-      # Future jobs can use these version outputs to identify newly built
-      # packages, for example via `pip install torch==${TORCH_VERSION}`.
       torch_version: ${{ steps.build-pytorch-wheels.outputs.torch_version }}
       torchaudio_version: ${{ steps.build-pytorch-wheels.outputs.torchaudio_version }}
       torchvision_version: ${{ steps.build-pytorch-wheels.outputs.torchvision_version }}
@@ -161,7 +148,7 @@ jobs:
 
       # Checkout nightly sources from https://github.com/pytorch/pytorch
       - name: Checkout PyTorch Source Repos from nightly branch
-        if: ${{ inputs.pytorch_git_ref == 'nightly' }}
+        if: ${{ inputs.pytorch_version == 'nightly' }}
         run: |
           ./external-builds/pytorch/pytorch_torch_repo.py checkout --repo-hashtag nightly
           ./external-builds/pytorch/pytorch_audio_repo.py checkout --repo-hashtag nightly
@@ -170,9 +157,9 @@ jobs:
 
       # Checkout stable sources from https://github.com/ROCm/pytorch
       - name: Checkout PyTorch Source Repos from stable branch
-        if: ${{ inputs.pytorch_git_ref != 'nightly' }}
+        if: ${{ inputs.pytorch_version != 'nightly' }}
         run: |
-          ./external-builds/pytorch/pytorch_torch_repo.py checkout --gitrepo-origin https://github.com/ROCm/pytorch.git --repo-hashtag ${{ inputs.pytorch_git_ref }} --patchset ${{ inputs.pytorch_patchset }}
+          ./external-builds/pytorch/pytorch_torch_repo.py checkout --gitrepo-origin https://github.com/ROCm/pytorch.git --repo-hashtag ${{ inputs.pytorch_version }} --patchset ${{ inputs.pytorch_patchset }}
           ./external-builds/pytorch/pytorch_audio_repo.py checkout --require-related-commit
           ./external-builds/pytorch/pytorch_vision_repo.py checkout --require-related-commit
           ./external-builds/pytorch/pytorch_triton_repo.py checkout
@@ -257,7 +244,7 @@ jobs:
       package_index_url: ${{ inputs.cloudfront_staging_url }}
       python_version: ${{ inputs.python_version }}
       torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}
-      pytorch_git_ref: ${{ inputs.pytorch_git_ref }}
+      pytorch_version: ${{ inputs.pytorch_version }}
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref || '' }}
 

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -32,8 +32,8 @@ on:
       rocm_version:
         description: ROCm version to pip install
         type: string
-      pytorch_git_ref:
-        description: PyTorch ref to checkout. (typically "nightly", or "release/X.Y")
+      pytorch_version:
+        description: PyTorch version to checkout. (typically "nightly", or "release/X.Y")
         required: true
         type: string
       pytorch_patchset:
@@ -88,8 +88,8 @@ on:
       rocm_version:
         description: ROCm version to pip install
         type: string
-      pytorch_git_ref:
-        description: PyTorch ref to checkout. (typically "nightly", or "release/X.Y")
+      pytorch_version:
+        description: PyTorch version to checkout. (typically "nightly", or "release/X.Y")
         required: true
         type: string
         default: "release/2.7"
@@ -105,7 +105,7 @@ permissions:
 
 jobs:
   build_pytorch_wheels:
-    name: Build | ${{ inputs.amdgpu_family }} | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_git_ref }}
+    name: Build | ${{ inputs.amdgpu_family }} | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_version }}
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-windows-scale-rocm' || 'windows-2022' }}
     env:
       CHECKOUT_ROOT: B:/src
@@ -116,18 +116,6 @@ jobs:
       optional_build_prod_arguments: ""
     outputs:
       cp_version: ${{ env.cp_version }}
-      # The following are python package versions produced by the build. The
-      # exact versions will depend on workflow inputs and the underlying code.
-      # For example:
-      #   Inputs
-      #     rocm_version       : 7.10.0a20251120
-      #     pytorch_git_ref    : release/2.9
-      #   Outputs
-      #     torch_version      : 2.9.1+rocm7.10.0a20251120
-      #     torchaudio_version : 2.9.0+rocm7.10.0a20251120
-      #     torchvision_version: 0.24.0+rocm7.10.0a20251120
-      # Future jobs can use these version outputs to identify newly built
-      # packages, for example via `pip install torch==${TORCH_VERSION}`.
       torch_version: ${{ steps.build-pytorch-wheels.outputs.torch_version }}
       torchaudio_version: ${{ steps.build-pytorch-wheels.outputs.torchaudio_version }}
       torchvision_version: ${{ steps.build-pytorch-wheels.outputs.torchvision_version }}
@@ -171,7 +159,7 @@ jobs:
       # Checkout nightly sources from https://github.com/pytorch/pytorch
       # TODO: switch to 'nightly' to match our Linux workflows?
       - name: Checkout PyTorch source repos (nightly branch)
-        if: ${{ inputs.pytorch_git_ref == 'nightly' }}
+        if: ${{ inputs.pytorch_version == 'nightly' }}
         run: |
           git config --global core.longpaths true
           python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
@@ -186,13 +174,13 @@ jobs:
 
       # Checkout stable sources from https://github.com/ROCm/pytorch
       - name: Checkout PyTorch Source Repos from stable branch
-        if: ${{ inputs.pytorch_git_ref != 'nightly' }}
+        if: ${{ inputs.pytorch_version != 'nightly' }}
         run: |
           git config --global core.longpaths true
           python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
               --checkout-dir ${{ env.CHECKOUT_ROOT }}/torch \
               --gitrepo-origin https://github.com/ROCm/pytorch.git \
-              --repo-hashtag ${{ inputs.pytorch_git_ref }} \
+              --repo-hashtag ${{ inputs.pytorch_version }} \
               --patchset ${{ inputs.pytorch_patchset }}
           python ./external-builds/pytorch/pytorch_audio_repo.py checkout \
               --checkout-dir ${{ env.CHECKOUT_ROOT }}/audio \
@@ -293,7 +281,7 @@ jobs:
       package_index_url: ${{ inputs.cloudfront_staging_url }}
       python_version: ${{ inputs.python_version }}
       torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}
-      pytorch_git_ref: ${{ inputs.pytorch_git_ref }}
+      pytorch_version: ${{ inputs.pytorch_version }}
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref || '' }}
 

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -23,11 +23,10 @@ on:
         type: string
         default: "3.12"
       torch_version:
-        description: torch package version to install. (e.g. "2.7.1+rocm7.10.0a20251120")
         required: true
         type: string
-      pytorch_git_ref:
-        description: PyTorch ref to checkout test sources from. (e.g. "nightly", or "release/2.7")
+      pytorch_version:
+        description: PyTorch version to checkout. ("nightly", or "release/2.7")
         type: string
         default: "release/2.7"
 
@@ -48,7 +47,8 @@ on:
       torch_version:
         required: true
         type: string
-      pytorch_git_ref:
+      pytorch_version:
+        description: PyTorch version to checkout. ("nightly", or "release/2.7")
         type: string
         default: "release/2.7"
       repository:
@@ -101,14 +101,14 @@ jobs:
       #                  When Windows runs full tests, fix that and re-enable.
       - name: Checkout PyTorch Source Repos from nightly branch
         # Checkout default upstream PyTorch/PyTorch branch.
-        if: ${{ (inputs.pytorch_git_ref == 'nightly') && (contains(inputs.test_runs_on, 'linux')) }}
+        if: ${{ (inputs.pytorch_version == 'nightly') && (contains(inputs.test_runs_on, 'linux')) }}
         run: |
           ./external-builds/pytorch/pytorch_torch_repo.py checkout --repo-hashtag nightly --no-hipify --no-patch
 
       - name: Checkout PyTorch Source Repos from stable branch
-        if: ${{ (inputs.pytorch_git_ref != 'nightly') && (contains(inputs.test_runs_on, 'linux')) }}
+        if: ${{ (inputs.pytorch_version != 'nightly') && (contains(inputs.test_runs_on, 'linux')) }}
         run: |
-          python external-builds/pytorch/pytorch_torch_repo.py checkout --gitrepo-origin https://github.com/ROCm/pytorch.git --repo-hashtag ${{ inputs.pytorch_git_ref }} --no-hipify --no-patch
+          python external-builds/pytorch/pytorch_torch_repo.py checkout --gitrepo-origin https://github.com/ROCm/pytorch.git --repo-hashtag ${{ inputs.pytorch_version }} --no-hipify --no-patch
 
       - name: Set up virtual environment
         run: |


### PR DESCRIPTION
Reverts ROCm/TheRock#2239. Fixes https://github.com/ROCm/TheRock/issues/2289.

This did not update some caller workflows, so they are currently broken: https://github.com/ROCm/TheRock/actions/runs/19670145169
```
[Invalid workflow file: .github/workflows/release_portable_linux_pytorch_wheels.yml#L100](https://github.com/ROCm/TheRock/actions/runs/19670145169/workflow)
The workflow is not valid. .github/workflows/release_portable_linux_pytorch_wheels.yml (Line: 100, Col: 11): Input pytorch_git_ref is required, but not provided while calling. .github/workflows/release_portable_linux_pytorch_wheels.yml (Line: 110, Col: 24): Invalid input, pytorch_version is not defined in the referenced workflow.
```