### PR TITLE
Update CI workflow to run for PRs to therock-release7.10 and amdgpu_matrix.py to promote torch wheels to release s3 by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - release/therock-7.10
   workflow_dispatch:
     inputs:
       linux_amdgpu_families:

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -45,6 +45,15 @@ amdgpu_family_info_matrix_presubmit = {
         "linux": {
             "test-runs-on": "linux-mi325-1gpu-ossci-rocm-frac",
             "family": "gfx94X-dcgpu",
+            "bypass_tests_for_releases": True,
+            "build_variants": ["release", "asan"],
+        }
+    },
+    "gfx950": {
+        "linux": {
+            "test-runs-on": "linux-mi355-1gpu-ossci-rocm",
+            "family": "gfx950-dcgpu",
+            "bypass_tests_for_releases": True,
             "build_variants": ["release", "asan"],
         }
     },
@@ -64,6 +73,29 @@ amdgpu_family_info_matrix_presubmit = {
             "sanity_check_only_for_family": True,
         },
     },
+    "gfx1150": {
+        "linux": {
+            "test-runs-on": "",
+            "family": "gfx1150",
+            "bypass_tests_for_releases": True,
+            "build_variants": ["release"],
+        },
+        "windows": {
+            "test-runs-on": "",
+            "family": "gfx1150",
+            "bypass_tests_for_releases": True,
+            "build_variants": ["release"],
+        },
+    },
+    "gfx90x": {
+        "linux": {
+            "test-runs-on": "linux-gfx90X-gpu-rocm",
+            "family": "gfx90X-dcgpu",
+            "bypass_tests_for_releases": True,
+            "sanity_check_only_for_family": True,
+            "build_variants": ["release"],
+        },
+    },
     "gfx1151": {
         "linux": {
             "test-runs-on": "linux-strix-halo-gpu-rocm",
@@ -75,6 +107,22 @@ amdgpu_family_info_matrix_presubmit = {
         "windows": {
             "test-runs-on": "windows-strix-halo-gpu-rocm",
             "family": "gfx1151",
+            "bypass_tests_for_releases": True,
+            "build_variants": ["release"],
+        },
+    },
+    "gfx120x": {
+        "linux": {
+            "test-runs-on": "linux-rx9070-gpu-rocm",
+            "family": "gfx120X-all",
+            "bypass_tests_for_releases": True,
+            "build_variants": ["release"],
+            "sanity_check_only_for_family": True,
+        },
+        "windows": {
+            "test-runs-on": "",
+            "family": "gfx120X-all",
+            "bypass_tests_for_releases": True,
             "build_variants": ["release"],
         },
     },
@@ -82,12 +130,75 @@ amdgpu_family_info_matrix_presubmit = {
 
 # The 'postsubmit' matrix runs on 'push' triggers (for every commit to the default branch).
 amdgpu_family_info_matrix_postsubmit = {
+    "gfx94x": {
+        "linux": {
+            "test-runs-on": "linux-mi325-1gpu-ossci-rocm-frac",
+            "family": "gfx94X-dcgpu",
+            "bypass_tests_for_releases": True,
+            "build_variants": ["release", "asan"],
+        }
+    },
     "gfx950": {
         "linux": {
             "test-runs-on": "linux-mi355-1gpu-ossci-rocm",
             "family": "gfx950-dcgpu",
+            "bypass_tests_for_releases": True,
             "build_variants": ["release", "asan"],
         }
+    },
+    "gfx110x": {
+        "linux": {
+            "test-runs-on": "linux-gfx110X-gpu-rocm",
+            "family": "gfx110X-all",
+            "bypass_tests_for_releases": True,
+            "build_variants": ["release"],
+            "sanity_check_only_for_family": True,
+        },
+        "windows": {
+            "test-runs-on": "windows-gfx110X-gpu-rocm",
+            "family": "gfx110X-all",
+            "bypass_tests_for_releases": True,
+            "build_variants": ["release"],
+            "sanity_check_only_for_family": True,
+        },
+    },
+    "gfx1150": {
+        "linux": {
+            "test-runs-on": "",
+            "family": "gfx1150",
+            "bypass_tests_for_releases": True,
+            "build_variants": ["release"],
+        },
+        "windows": {
+            "test-runs-on": "",
+            "family": "gfx1150",
+            "bypass_tests_for_releases": True,
+            "build_variants": ["release"],
+        },
+    },
+    "gfx90x": {
+        "linux": {
+            "test-runs-on": "linux-gfx90X-gpu-rocm",
+            "family": "gfx90X-dcgpu",
+            "bypass_tests_for_releases": True,
+            "sanity_check_only_for_family": True,
+            "build_variants": ["release"],
+        },
+    },
+    "gfx1151": {
+        "linux": {
+            "test-runs-on": "linux-strix-halo-gpu-rocm",
+            "family": "gfx1151",
+            "bypass_tests_for_releases": True,
+            "build_variants": ["release"],
+            "sanity_check_only_for_family": True,
+        },
+        "windows": {
+            "test-runs-on": "windows-strix-halo-gpu-rocm",
+            "family": "gfx1151",
+            "bypass_tests_for_releases": True,
+            "build_variants": ["release"],
+        },
     },
     "gfx120x": {
         "linux": {


### PR DESCRIPTION
This PR aims to address the below:

1. Per PR CI runs on therock-release7.10 branch for both presubmit and postsubmit.
2.  This also includes changes to bypass Pytorch test results and promote torch wheels to release s3(Using "bypass_tests_for_releases" flag in amdgpu_matrx.py file)
3. Also maintains the same GPU archs to be exercised for both pre and post submit CI runs to therock-release7.10 branch 