### PR TITLE
[torch] Add exact examples showing how to install older versions

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -261,14 +261,17 @@ also install `torch`, `torchaudio`, and `torchvision`.
 >
 > | torch version | torchaudio version | torchvision version |
 > | ------------- | ------------------ | ------------------- |
-> | 2.10          | 2.10               | 0.25                |
-> | 2.9           | 2.9                | 0.24                |
-> | 2.8           | 2.8                | 0.23                |
-> | 2.7           | 2.7.1a0            | 0.22.1              |
+> | 2.10.0a0      | 2.10.0a0           | 0.25.0a0            |
+> | 2.9.1         | 2.9.0              | 0.24.0              |
+> | 2.8.0         | 2.8.0a0            | 0.23.0a0            |
+> | 2.7.1         | 2.7.1a0            | 0.22.1              |
 >
-> For example, `torch` 2.7.1 and compatible wheels can be installed by specifying
+> For example, `torch` and compatible package versions can be set like so:
 >
 > ```
+> torch==2.10.0a0 torchaudio==2.10.0a0 torchvision==0.25.0a0
+> torch==2.9.1 torchaudio==2.9.0 torchvision==0.24.0
+> torch==2.8.0 torchaudio==2.8.0a0 torchvision==0.23.0a0
 > torch==2.7.1 torchaudio==2.7.1a0 torchvision==0.22.1
 > ```
 >


### PR DESCRIPTION
## Motivation

This adds more precise install instructions for older torch versions from our nightly releases.

I also looked into using `~=` (a "compatible release clause": https://packaging.python.org/en/latest/specifications/version-specifiers/#id5)... that would be more reliable if the versions change from under us, at the cost of the install commands not as closely matching what is actually installed.

Note that for some package versions we still have `a0` suffixes coming through the packages themselves or outdated pins in the rocm/pytorch release branch related_commits files. We might want to fix that.

## Test Plan

Ran the install commands on Linux: https://colab.research.google.com/gist/ScottTodd/2503315bbf7d2c66a14f27a354568bc0/linux-pip-install-testing.ipynb