### PR TITLE
Ubuntu requirements update to fix rocprofiler-systems build

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ instructions and configurations for alternatives.
 ```bash
 # Install Ubuntu dependencies
 sudo apt update
-sudo apt install gfortran git ninja-build cmake g++ pkg-config xxd patchelf automake libtool python3-venv python3-dev libegl1-mesa-dev texinfo bison
+sudo apt install gfortran git ninja-build cmake g++ pkg-config xxd patchelf automake libtool python3-venv python3-dev libegl1-mesa-dev texinfo bison flex
 
 # Clone the repository
 git clone https://github.com/ROCm/TheRock.git


### PR DESCRIPTION
Add textinfo and bison to README.md for ubuntu build instructions. (fresh ubuntu 24.04.03 install used for testing)
Texinfo install fixes a following error:

```
[rocprofiler-systems] WARNING: 'makeinfo' is missing on your system.
[rocprofiler-systems]          You should only need it if you modified a '.texi' file, or
[rocprofiler-systems]          any other file indirectly affecting the aspect of the manual.
[rocprofiler-systems]          You might want to install the Texinfo package:
[rocprofiler-systems]          <http://www.gnu.org/software/texinfo/>
[rocprofiler-systems]          The spurious makeinfo call might also be the consequence of
[rocprofiler-systems]          using a buggy 'make' (AIX, DU, IRIX), in which case you might
[rocprofiler-systems]          want to install GNU make:
[rocprofiler-systems]          <http://www.gnu.org/software/make/>
[rocprofiler-systems] make[3]: *** [Makefile:1781: doc/bfd.info] Error 127
[rocprofiler-systems] make[3]: Leaving directory '/home/lamikr/own/rock/src/sdk/therock/build/profiler/rocprofiler-systems/build/external/binutils/src/rocprofiler-systems-libiberty-build/bfd'
[rocprofiler-systems] make[2]: *** [Makefile:1941: info-recursive] Error 1
[rocprofiler-systems] make[2]: Leaving directory '/home/lamikr/own/rock/src/sdk/therock/build/profiler/rocprofiler-systems/build/external/binutils/src/rocprofiler-systems-libiberty-build/bfd'
[rocprofiler-systems] make[1]: *** [Makefile:3114: all-bfd] Error 2
[rocprofiler-systems] make[1]: Leaving directory '/home/lamikr/own/rock/src/sdk/therock/build/profiler/rocprofiler-systems/build/external/binutils/src/rocprofiler-systems-libiberty-build'
[rocprofiler-systems] make: *** [Makefile:1028: all] Error 2
[rocprofiler-systems] [8/528] Performing configure step for 'rocprofiler-systems-boost-build'
[rocprofiler-systems] Building B2 engine..


```

Bison install fixes a following error:

```
[rocprofiler-systems] /home/lamikr/own/rock/src/sdk/therock/build/profiler/rocprofiler-systems/build/external/binutils/src/rocprofiler-systems-libiberty-build/missing: 81: bison: not found [rocprofiler-systems] WARNING: 'bison' is missing on your system.
[rocprofiler-systems]          You should only need it if you modified a '.y' file.
[rocprofiler-systems]          You may want to install the GNU Bison package:
[rocprofiler-systems]          <http://www.gnu.org/software/bison/>
[rocprofiler-systems] make[2]: *** [Makefile:1244: defparse.c] Error 127
[rocprofiler-systems] make[2]: Leaving directory '/home/lamikr/own/rock/src/sdk/therock/build/profiler/rocprofiler-systems/build/external/binutils/src/rocprofiler-systems-libiberty-build/binutils'
[rocprofiler-systems] make[1]: *** [Makefile:4100: all-binutils] Error 2

```
fixes: https://github.com/ROCm/TheRock/issues/2316

