### PR TITLE
Fix rocprofiler-compute python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,25 @@ msgpack>=1.1.0
 
 # AWS Redshift connector
 redshift_connector==2.1.8
+
+# rocprofiler-compute dependencies
+astunparse==1.6.2
+colorlover
+dash-bootstrap-components
+dash-svg
+dash>=3.0.0
+kaleido==0.2.1
+matplotlib
+numpy>=1.17.5
+pandas>=1.4.3
+plotext
+plotille
+pymongo
+pyyaml
+setuptools
+sqlalchemy>=2.0.42
+tabulate
+textual
+textual_plotext
+textual-fspicker>=0.4.3
+tqdm


### PR DESCRIPTION
Updated requirements.txt for python dependencies to fix a following error:

[rocprofiler-compute configure] -- Checking for required Python package dependencies...
[rocprofiler-compute configure] --   astunparse = missing
[rocprofiler-compute configure] --   colorlover = missing
[rocprofiler-compute configure] --   dash_bootstrap_components = missing
[rocprofiler-compute configure] --   dash_svg = missing
[rocprofiler-compute configure] --   dash = missing
[rocprofiler-compute configure] --   kaleido = missing
[rocprofiler-compute configure] --   matplotlib = missing
[rocprofiler-compute configure] --   numpy = missing
[rocprofiler-compute configure] --   pandas = missing
[rocprofiler-compute configure] --   plotext = missing
[rocprofiler-compute configure] --   plotille = missing
[rocprofiler-compute configure] --   pymongo = missing
[rocprofiler-compute configure] --   pyyaml = yes
[rocprofiler-compute configure] --   setuptools = yes
[rocprofiler-compute configure] --   sqlalchemy = missing
[rocprofiler-compute configure] --   tabulate = missing
[rocprofiler-compute configure] --   textual = missing
[rocprofiler-compute configure] --   textual_plotext = missing
[rocprofiler-compute configure] --   textual_fspicker = missing
[rocprofiler-compute configure] --   tqdm = missing
[rocprofiler-compute configure] CMake Error at CMakeLists.txt:130 (message):
[rocprofiler-compute configure]
[rocprofiler-compute configure]
[rocprofiler-compute configure]   Necessary Python package dependencies not found.  Please install required
[rocprofiler-compute configure]   dependencies above using your favorite package manager.

Fixes a following error:
https://github.com/ROCm/TheRock/issues/2319