### PR TITLE
Add multi-arch CI workflow files for sharded pipeline

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -1,0 +1,692 @@
+# Multi-Arch Build - Sharded Pipeline for Linux
+#
+# This workflow builds TheRock in stages:
+# 1. foundation (generic) - sysdeps, base
+# 2. compiler-runtime (generic) - compiler, runtimes, profiler-core
+# 3. math-libs (per-arch) - BLAS, FFT, etc.
+# 4. comm-libs (per-arch) - RCCL (parallel to math-libs)
+# 5. dctools-core (generic) - RDC (parallel to math-libs)
+# 6. profiler-apps (generic) - rocprofiler-systems (parallel to math-libs)
+#
+# Artifacts flow between stages via S3 using the artifact_manager.py tool.
+
+name: Multi-Arch Build (Linux)
+
+on:
+  workflow_call:
+    inputs:
+      amdgpu_families_json:
+        type: string
+        required: true
+        description: "JSON array of GPU families for per-arch stages"
+      artifact_group:
+        type: string
+        required: true
+        description: "Artifact group identifier"
+      build_variant:
+        type: string
+        required: true
+        description: "Build variant (release, asan)"
+      package_version:
+        type: string
+        required: true
+        description: "Package version string"
+      enabled_stages:
+        type: string
+        required: true
+        description: "Comma-separated list of enabled stages"
+
+permissions:
+  contents: read
+
+env:
+  CONTAINER_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:4af52d56d91ef6ef8b7d0a13c6115af1ab2c9bf4a8a85d9267b489ecb737ed25
+  CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
+  CACHE_DIR: ${{ github.workspace }}/.container-cache
+  TEATIME_FORCE_INTERACTIVE: 0
+
+jobs:
+  # ==========================================================================
+  # STAGE: foundation (generic)
+  # ==========================================================================
+  foundation:
+    name: Stage - Foundation
+    if: contains(inputs.enabled_stages, 'foundation')
+    runs-on: azure-linux-scale-rocm
+    timeout-minutes: 180  # 3 hours
+    permissions:
+      id-token: write
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:4af52d56d91ef6ef8b7d0a13c6115af1ab2c9bf4a8a85d9267b489ecb737ed25
+      options: -v /runner/config:/home/awsconfig/
+    env:
+      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
+      STAGE_NAME: foundation
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Install python deps
+        run: pip install -r requirements.txt
+
+      - name: Adjust git config
+        run: |
+          git config --global --add safe.directory $PWD
+          git config fetch.parallel 10
+
+      - name: Setup ccache
+        run: |
+          ./build_tools/setup_ccache.py \
+            --config-preset "github-oss-presubmit" \
+            --dir "$(dirname $CCACHE_CONFIGPATH)" \
+            --local-path "$CACHE_DIR/ccache"
+
+      - name: Runner health status
+        run: |
+          ./build_tools/health_status.py
+
+      - name: Fetch sources
+        timeout-minutes: 30
+        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12
+
+      - name: Install external python deps
+        run: pip install -r requirements-external.txt
+
+      - name: Get stage configuration
+        id: stage_config
+        run: |
+          python build_tools/configure_stage.py \
+            --stage ${STAGE_NAME} \
+            --gha-output
+
+      - name: Configure
+        run: |
+          cmake -B build -S . -GNinja \
+            -DTHEROCK_PACKAGE_VERSION=${{ inputs.package_version }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            ${{ steps.stage_config.outputs.cmake_args }}
+
+      - name: Build stage
+        run: |
+          cmake --build build --target stage-${STAGE_NAME} -- -k 0
+
+      - name: Create artifact directories
+        run: |
+          cmake --build build --target therock-artifacts -- -k 0
+
+      - name: Report
+        if: ${{ !cancelled() }}
+        run: |
+          echo "CCache Stats:"
+          ccache -s -v
+          echo "Artifacts:"
+          ls -lh build/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
+
+      - name: Configure AWS Credentials
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
+
+      - name: Push stage artifacts
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        run: |
+          python build_tools/artifact_manager.py push \
+            --stage ${STAGE_NAME} \
+            --build-dir build \
+            --run-id ${{ github.run_id }}
+
+  # ==========================================================================
+  # STAGE: compiler-runtime (generic)
+  # ==========================================================================
+  compiler-runtime:
+    name: Stage - Compiler Runtime
+    needs: foundation
+    if: >-
+      ${{
+        always() &&
+        (needs.foundation.result == 'success' || needs.foundation.result == 'skipped') &&
+        contains(inputs.enabled_stages, 'compiler-runtime')
+      }}
+    runs-on: azure-linux-scale-rocm
+    timeout-minutes: 480  # 8 hours (compiler is big)
+    permissions:
+      id-token: write
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:4af52d56d91ef6ef8b7d0a13c6115af1ab2c9bf4a8a85d9267b489ecb737ed25
+      options: -v /runner/config:/home/awsconfig/
+    env:
+      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
+      STAGE_NAME: compiler-runtime
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Install python deps
+        run: pip install -r requirements.txt
+
+      - name: Adjust git config
+        run: |
+          git config --global --add safe.directory $PWD
+          git config fetch.parallel 10
+
+      - name: Setup ccache
+        run: |
+          ./build_tools/setup_ccache.py \
+            --config-preset "github-oss-presubmit" \
+            --dir "$(dirname $CCACHE_CONFIGPATH)" \
+            --local-path "$CACHE_DIR/ccache"
+
+      - name: Runner health status
+        run: |
+          ./build_tools/health_status.py
+
+      - name: Configure AWS Credentials
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
+
+      - name: Fetch inbound artifacts
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          python build_tools/artifact_manager.py fetch \
+            --stage ${STAGE_NAME} \
+            --output-dir build \
+            --run-id ${{ github.run_id }} \
+            --bootstrap
+
+      - name: Fetch sources
+        timeout-minutes: 30
+        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12
+
+      - name: Install external python deps
+        run: pip install -r requirements-external.txt
+
+      - name: Get stage configuration
+        id: stage_config
+        run: |
+          python build_tools/configure_stage.py \
+            --stage ${STAGE_NAME} \
+            --gha-output
+
+      - name: Configure
+        run: |
+          cmake -B build -S . -GNinja \
+            -DTHEROCK_PACKAGE_VERSION=${{ inputs.package_version }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            ${{ steps.stage_config.outputs.cmake_args }}
+
+      - name: Build stage
+        run: |
+          cmake --build build --target stage-${STAGE_NAME} -- -k 0
+
+      - name: Create artifact directories
+        run: |
+          cmake --build build --target therock-artifacts -- -k 0
+
+      - name: Report
+        if: ${{ !cancelled() }}
+        run: |
+          echo "CCache Stats:"
+          ccache -s -v
+          echo "Artifacts:"
+          ls -lh build/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
+
+      - name: Push stage artifacts
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        run: |
+          python build_tools/artifact_manager.py push \
+            --stage ${STAGE_NAME} \
+            --build-dir build \
+            --run-id ${{ github.run_id }}
+
+  # ==========================================================================
+  # STAGE: math-libs (per-arch)
+  # ==========================================================================
+  math-libs:
+    name: Stage - Math Libs (${{ matrix.family }})
+    needs: compiler-runtime
+    if: >-
+      ${{
+        always() &&
+        (needs.compiler-runtime.result == 'success' || needs.compiler-runtime.result == 'skipped') &&
+        contains(inputs.enabled_stages, 'math-libs')
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        family: ${{ fromJSON(inputs.amdgpu_families_json) }}
+    runs-on: azure-linux-scale-rocm
+    timeout-minutes: 480  # 8 hours
+    permissions:
+      id-token: write
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:4af52d56d91ef6ef8b7d0a13c6115af1ab2c9bf4a8a85d9267b489ecb737ed25
+      options: -v /runner/config:/home/awsconfig/
+    env:
+      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
+      STAGE_NAME: math-libs
+      AMDGPU_FAMILIES: ${{ matrix.family }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Install python deps
+        run: pip install -r requirements.txt
+
+      - name: Adjust git config
+        run: |
+          git config --global --add safe.directory $PWD
+          git config fetch.parallel 10
+
+      - name: Setup ccache
+        run: |
+          ./build_tools/setup_ccache.py \
+            --config-preset "github-oss-presubmit" \
+            --dir "$(dirname $CCACHE_CONFIGPATH)" \
+            --local-path "$CACHE_DIR/ccache"
+
+      - name: Runner health status
+        run: |
+          ./build_tools/health_status.py
+
+      - name: Configure AWS Credentials
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
+
+      - name: Fetch inbound artifacts
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          python build_tools/artifact_manager.py fetch \
+            --stage ${STAGE_NAME} \
+            --amdgpu-families ${{ matrix.family }} \
+            --output-dir build \
+            --run-id ${{ github.run_id }} \
+            --bootstrap
+
+      - name: Fetch sources
+        timeout-minutes: 30
+        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12
+
+      - name: Install external python deps
+        run: pip install -r requirements-external.txt
+
+      - name: Get stage configuration
+        id: stage_config
+        run: |
+          python build_tools/configure_stage.py \
+            --stage ${STAGE_NAME} \
+            --amdgpu-families ${{ matrix.family }} \
+            --gha-output
+
+      - name: Configure
+        run: |
+          cmake -B build -S . -GNinja \
+            -DTHEROCK_PACKAGE_VERSION=${{ inputs.package_version }} \
+            -DTHEROCK_AMDGPU_FAMILIES=${{ matrix.family }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            ${{ steps.stage_config.outputs.cmake_args }}
+
+      - name: Build stage
+        run: |
+          cmake --build build --target stage-${STAGE_NAME} -- -k 0
+
+      - name: Create artifact directories
+        run: |
+          cmake --build build --target therock-artifacts -- -k 0
+
+      - name: Report
+        if: ${{ !cancelled() }}
+        run: |
+          echo "CCache Stats:"
+          ccache -s -v
+          echo "Artifacts:"
+          ls -lh build/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
+
+      - name: Push stage artifacts
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        run: |
+          python build_tools/artifact_manager.py push \
+            --stage ${STAGE_NAME} \
+            --amdgpu-families ${{ matrix.family }} \
+            --build-dir build \
+            --run-id ${{ github.run_id }}
+
+  # ==========================================================================
+  # STAGE: comm-libs (per-arch, parallel to math-libs)
+  # ==========================================================================
+  comm-libs:
+    name: Stage - Comm Libs (${{ matrix.family }})
+    needs: compiler-runtime
+    if: >-
+      ${{
+        always() &&
+        (needs.compiler-runtime.result == 'success' || needs.compiler-runtime.result == 'skipped') &&
+        contains(inputs.enabled_stages, 'comm-libs')
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        family: ${{ fromJSON(inputs.amdgpu_families_json) }}
+    runs-on: azure-linux-scale-rocm
+    timeout-minutes: 240  # 4 hours
+    permissions:
+      id-token: write
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:4af52d56d91ef6ef8b7d0a13c6115af1ab2c9bf4a8a85d9267b489ecb737ed25
+      options: -v /runner/config:/home/awsconfig/
+    env:
+      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
+      STAGE_NAME: comm-libs
+      AMDGPU_FAMILIES: ${{ matrix.family }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Install python deps
+        run: pip install -r requirements.txt
+
+      - name: Adjust git config
+        run: |
+          git config --global --add safe.directory $PWD
+          git config fetch.parallel 10
+
+      - name: Setup ccache
+        run: |
+          ./build_tools/setup_ccache.py \
+            --config-preset "github-oss-presubmit" \
+            --dir "$(dirname $CCACHE_CONFIGPATH)" \
+            --local-path "$CACHE_DIR/ccache"
+
+      - name: Runner health status
+        run: |
+          ./build_tools/health_status.py
+
+      - name: Configure AWS Credentials
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
+
+      - name: Fetch inbound artifacts
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          python build_tools/artifact_manager.py fetch \
+            --stage ${STAGE_NAME} \
+            --amdgpu-families ${{ matrix.family }} \
+            --output-dir build \
+            --run-id ${{ github.run_id }} \
+            --bootstrap
+
+      - name: Fetch sources
+        timeout-minutes: 30
+        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12
+
+      - name: Install external python deps
+        run: pip install -r requirements-external.txt
+
+      - name: Get stage configuration
+        id: stage_config
+        run: |
+          python build_tools/configure_stage.py \
+            --stage ${STAGE_NAME} \
+            --amdgpu-families ${{ matrix.family }} \
+            --gha-output
+
+      - name: Configure
+        run: |
+          cmake -B build -S . -GNinja \
+            -DTHEROCK_PACKAGE_VERSION=${{ inputs.package_version }} \
+            -DTHEROCK_AMDGPU_FAMILIES=${{ matrix.family }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            ${{ steps.stage_config.outputs.cmake_args }}
+
+      - name: Build stage
+        run: |
+          cmake --build build --target stage-${STAGE_NAME} -- -k 0
+
+      - name: Create artifact directories
+        run: |
+          cmake --build build --target therock-artifacts -- -k 0
+
+      - name: Report
+        if: ${{ !cancelled() }}
+        run: |
+          echo "CCache Stats:"
+          ccache -s -v
+          echo "Artifacts:"
+          ls -lh build/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
+
+      - name: Push stage artifacts
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        run: |
+          python build_tools/artifact_manager.py push \
+            --stage ${STAGE_NAME} \
+            --amdgpu-families ${{ matrix.family }} \
+            --build-dir build \
+            --run-id ${{ github.run_id }}
+
+  # ==========================================================================
+  # STAGE: dctools-core (generic, parallel to math-libs)
+  # ==========================================================================
+  dctools-core:
+    name: Stage - DC Tools Core
+    needs: compiler-runtime
+    if: >-
+      ${{
+        always() &&
+        (needs.compiler-runtime.result == 'success' || needs.compiler-runtime.result == 'skipped') &&
+        contains(inputs.enabled_stages, 'dctools-core')
+      }}
+    runs-on: azure-linux-scale-rocm
+    timeout-minutes: 120  # 2 hours
+    permissions:
+      id-token: write
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:4af52d56d91ef6ef8b7d0a13c6115af1ab2c9bf4a8a85d9267b489ecb737ed25
+      options: -v /runner/config:/home/awsconfig/
+    env:
+      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
+      STAGE_NAME: dctools-core
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Install python deps
+        run: pip install -r requirements.txt
+
+      - name: Adjust git config
+        run: |
+          git config --global --add safe.directory $PWD
+          git config fetch.parallel 10
+
+      - name: Setup ccache
+        run: |
+          ./build_tools/setup_ccache.py \
+            --config-preset "github-oss-presubmit" \
+            --dir "$(dirname $CCACHE_CONFIGPATH)" \
+            --local-path "$CACHE_DIR/ccache"
+
+      - name: Runner health status
+        run: |
+          ./build_tools/health_status.py
+
+      - name: Configure AWS Credentials
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
+
+      - name: Fetch inbound artifacts
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          python build_tools/artifact_manager.py fetch \
+            --stage ${STAGE_NAME} \
+            --output-dir build \
+            --run-id ${{ github.run_id }} \
+            --bootstrap
+
+      - name: Fetch sources
+        timeout-minutes: 30
+        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12
+
+      - name: Install external python deps
+        run: pip install -r requirements-external.txt
+
+      - name: Get stage configuration
+        id: stage_config
+        run: |
+          python build_tools/configure_stage.py \
+            --stage ${STAGE_NAME} \
+            --gha-output
+
+      - name: Configure
+        run: |
+          cmake -B build -S . -GNinja \
+            -DTHEROCK_PACKAGE_VERSION=${{ inputs.package_version }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            ${{ steps.stage_config.outputs.cmake_args }}
+
+      - name: Build stage
+        run: |
+          cmake --build build --target stage-${STAGE_NAME} -- -k 0
+
+      - name: Create artifact directories
+        run: |
+          cmake --build build --target therock-artifacts -- -k 0
+
+      - name: Report
+        if: ${{ !cancelled() }}
+        run: |
+          echo "CCache Stats:"
+          ccache -s -v
+          echo "Artifacts:"
+          ls -lh build/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
+
+      - name: Push stage artifacts
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        run: |
+          python build_tools/artifact_manager.py push \
+            --stage ${STAGE_NAME} \
+            --build-dir build \
+            --run-id ${{ github.run_id }}
+
+  # ==========================================================================
+  # STAGE: profiler-apps (generic, parallel to math-libs)
+  # ==========================================================================
+  profiler-apps:
+    name: Stage - Profiler Apps
+    needs: compiler-runtime
+    if: >-
+      ${{
+        always() &&
+        (needs.compiler-runtime.result == 'success' || needs.compiler-runtime.result == 'skipped') &&
+        contains(inputs.enabled_stages, 'profiler-apps')
+      }}
+    runs-on: azure-linux-scale-rocm
+    timeout-minutes: 180  # 3 hours
+    permissions:
+      id-token: write
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:4af52d56d91ef6ef8b7d0a13c6115af1ab2c9bf4a8a85d9267b489ecb737ed25
+      options: -v /runner/config:/home/awsconfig/
+    env:
+      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
+      STAGE_NAME: profiler-apps
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Install python deps
+        run: pip install -r requirements.txt
+
+      - name: Adjust git config
+        run: |
+          git config --global --add safe.directory $PWD
+          git config fetch.parallel 10
+
+      - name: Setup ccache
+        run: |
+          ./build_tools/setup_ccache.py \
+            --config-preset "github-oss-presubmit" \
+            --dir "$(dirname $CCACHE_CONFIGPATH)" \
+            --local-path "$CACHE_DIR/ccache"
+
+      - name: Runner health status
+        run: |
+          ./build_tools/health_status.py
+
+      - name: Configure AWS Credentials
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
+
+      - name: Fetch inbound artifacts
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          python build_tools/artifact_manager.py fetch \
+            --stage ${STAGE_NAME} \
+            --output-dir build \
+            --run-id ${{ github.run_id }} \
+            --bootstrap
+
+      - name: Fetch sources
+        timeout-minutes: 30
+        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12
+
+      - name: Install external python deps
+        run: pip install -r requirements-external.txt
+
+      - name: Get stage configuration
+        id: stage_config
+        run: |
+          python build_tools/configure_stage.py \
+            --stage ${STAGE_NAME} \
+            --gha-output
+
+      - name: Configure
+        run: |
+          cmake -B build -S . -GNinja \
+            -DTHEROCK_PACKAGE_VERSION=${{ inputs.package_version }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            ${{ steps.stage_config.outputs.cmake_args }}
+
+      - name: Build stage
+        run: |
+          cmake --build build --target stage-${STAGE_NAME} -- -k 0
+
+      - name: Create artifact directories
+        run: |
+          cmake --build build --target therock-artifacts -- -k 0
+
+      - name: Report
+        if: ${{ !cancelled() }}
+        run: |
+          echo "CCache Stats:"
+          ccache -s -v
+          echo "Artifacts:"
+          ls -lh build/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
+
+      - name: Push stage artifacts
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        run: |
+          python build_tools/artifact_manager.py push \
+            --stage ${STAGE_NAME} \
+            --build-dir build \
+            --run-id ${{ github.run_id }}

--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -1,0 +1,134 @@
+# Multi-Arch CI - Sharded Pipeline
+#
+# This workflow implements a multi-stage build pipeline where:
+# - Generic stages (foundation, compiler-runtime) build ONCE for all architectures
+# - Per-arch stages (math-libs, comm-libs) run in PARALLEL per GPU family
+#
+# Stage dependency graph:
+#   foundation (generic)
+#       |
+#   compiler-runtime (generic)
+#       |
+#   +---+---+---+---+
+#   |   |   |   |   |
+#  math comm prof dc  (parallel, math/comm are per-arch)
+#
+# Artifacts flow between stages via S3, keyed by run_id.
+
+name: Multi-Arch CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      linux_amdgpu_families:
+        type: string
+        description: "Comma-separated list of Linux GPU families (e.g., gfx94X-dcgpu,gfx110X-all)"
+        default: "gfx94X-dcgpu,gfx110X-all"
+      build_variant:
+        type: string
+        description: "Build variant (release, asan)"
+        default: "release"
+      package_version:
+        type: string
+        description: "Package version string"
+        default: "ADHOCBUILD"
+      stages:
+        type: string
+        description: "Comma-separated list of stages to build (empty = all). Options: foundation, compiler-runtime, math-libs, comm-libs, dctools-core, profiler-apps"
+        default: ""
+      skip_tests:
+        type: boolean
+        description: "Skip test jobs"
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  # --------------------------------------------------------------------------
+  # Setup job - compute configuration
+  # --------------------------------------------------------------------------
+  setup:
+    name: Setup
+    runs-on: ubuntu-24.04
+    outputs:
+      amdgpu_families_json: ${{ steps.configure.outputs.amdgpu_families_json }}
+      enabled_stages: ${{ steps.configure.outputs.enabled_stages }}
+      artifact_group: ${{ steps.configure.outputs.artifact_group }}
+      rocm_package_version: ${{ steps.version.outputs.rocm_package_version }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Configure pipeline
+        id: configure
+        run: |
+          python ./build_tools/github_actions/configure_multi_arch_ci.py \
+            --amdgpu-families "${{ inputs.linux_amdgpu_families }}" \
+            --stages "${{ inputs.stages }}" \
+            --build-variant "${{ inputs.build_variant }}"
+
+      - name: Compute package version
+        id: version
+        run: |
+          python ./build_tools/compute_rocm_package_version.py --release-type=dev
+
+  # --------------------------------------------------------------------------
+  # Linux Build - Sharded Pipeline
+  # --------------------------------------------------------------------------
+  linux_build:
+    name: Linux Build (${{ inputs.build_variant }})
+    needs: setup
+    uses: ./.github/workflows/multi_arch_build_portable_linux.yml
+    secrets: inherit
+    with:
+      amdgpu_families_json: ${{ needs.setup.outputs.amdgpu_families_json }}
+      artifact_group: ${{ needs.setup.outputs.artifact_group }}
+      build_variant: ${{ inputs.build_variant }}
+      package_version: ${{ needs.setup.outputs.rocm_package_version }}
+      enabled_stages: ${{ needs.setup.outputs.enabled_stages }}
+    permissions:
+      contents: read
+      id-token: write
+
+  # --------------------------------------------------------------------------
+  # Summary
+  # --------------------------------------------------------------------------
+  multi_arch_ci_summary:
+    name: Multi-Arch CI Summary
+    if: always()
+    needs:
+      - setup
+      - linux_build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Output results
+        run: |
+          echo "## Multi-Arch CI Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build Variant**: ${{ inputs.build_variant }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **GPU Families**: ${{ inputs.linux_amdgpu_families }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Stages**: ${{ needs.setup.outputs.enabled_stages }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo '${{ toJson(needs) }}'
+
+          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
+            | jq --raw-output '
+              to_entries
+              | map(select(.value.result != "success" and .value.result != "skipped"))
+              | map(.key)
+              | join(",")
+            ' \
+          )"
+
+          if [[ -n "${FAILED_JOBS}" ]]; then
+            echo "The following jobs failed: ${FAILED_JOBS}"
+            exit 1
+          else
+            echo "All jobs succeeded."
+          fi

--- a/build_tools/configure_stage.py
+++ b/build_tools/configure_stage.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import List, Set
 
 from _therock_utils.build_topology import BuildTopology
+from github_actions.github_actions_utils import gha_set_output
 
 
 def log(msg: str):
@@ -172,6 +173,11 @@ def main(argv: List[str] = None):
         action="store_true",
         help="List available build stages and exit",
     )
+    parser.add_argument(
+        "--gha-output",
+        action="store_true",
+        help="Write cmake_args to GITHUB_OUTPUT (for GitHub Actions)",
+    )
 
     args = parser.parse_args(argv)
 
@@ -202,12 +208,14 @@ def main(argv: List[str] = None):
         cmake_args = [a for a in cmake_args if not a.startswith("#") and a]
 
     # Output
-    if args.oneline:
+    if args.oneline or args.gha_output:
         output = " ".join(cmake_args)
     else:
         output = "\n".join(cmake_args)
 
-    if args.output_cmake_args:
+    if args.gha_output:
+        gha_set_output({"cmake_args": output})
+    elif args.output_cmake_args:
         args.output_cmake_args.write_text(output + "\n")
         log(f"Wrote CMake arguments to {args.output_cmake_args}")
     elif args.print_args:

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""Configure the multi-arch CI pipeline.
+
+This script parses workflow inputs and outputs configuration for the
+multi-arch CI pipeline jobs.
+
+Outputs (via GITHUB_OUTPUT):
+    amdgpu_families_json: JSON array of GPU families for matrix builds
+    enabled_stages: Comma-separated list of enabled stages
+    artifact_group: Artifact group identifier
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from github_actions.github_actions_utils import gha_set_output
+
+
+ALL_STAGES = [
+    "foundation",
+    "compiler-runtime",
+    "math-libs",
+    "comm-libs",
+    "dctools-core",
+    "profiler-apps",
+]
+
+
+def main(argv: list[str] = None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--amdgpu-families",
+        type=str,
+        required=True,
+        help="Comma-separated list of GPU families (e.g., 'gfx94X-dcgpu,gfx110X-all')",
+    )
+    parser.add_argument(
+        "--stages",
+        type=str,
+        default="",
+        help="Comma-separated list of stages to build (empty = all)",
+    )
+    parser.add_argument(
+        "--build-variant",
+        type=str,
+        default="release",
+        help="Build variant (e.g., 'release', 'asan')",
+    )
+    args = parser.parse_args(argv)
+
+    # Parse families into JSON array
+    families = [f.strip() for f in args.amdgpu_families.split(",") if f.strip()]
+    families_json = json.dumps(families)
+
+    # Determine enabled stages
+    if args.stages:
+        enabled_stages = args.stages
+    else:
+        enabled_stages = ",".join(ALL_STAGES)
+
+    # Create artifact group name
+    artifact_group = f"multi-arch-{args.build_variant}"
+
+    # Output to GITHUB_OUTPUT
+    gha_set_output(
+        {
+            "amdgpu_families_json": families_json,
+            "enabled_stages": enabled_stages,
+            "artifact_group": artifact_group,
+        }
+    )
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
Adds workflow files implementing a multi-stage build pipeline where:
- Generic stages (foundation, compiler-runtime) build ONCE
- Per-arch stages (math-libs, comm-libs) run in PARALLEL per GPU family

Workflow structure:
- multi_arch_ci.yml: Entry point with workflow_dispatch
- multi_arch_build_portable_linux.yml: 6-stage build workflow
  - foundation (generic)
  - compiler-runtime (generic)
  - math-libs (per-arch matrix)
  - comm-libs (per-arch matrix)
  - dctools-core (generic)
  - profiler-apps (generic)

Key features:
- Uses artifact_manager.py for S3 artifact flow between stages
- Uses configure_stage.py for CMake configuration
- Uses fetch_sources.py --stage for minimal source checkout
- Uses therock-artifacts target (not therock-archives)

Open items for discussion:
- Test integration not yet included
- Windows support not yet included

Note that this was broken out of #2288 and is being landed separately for safety. It needs to be submitted as-is to make the workflow available for further iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
