### PR TITLE
[release/7.10] Fix typo in configure_ci.py for push-workflow

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -377,7 +377,9 @@ def matrix_generator(
         base_args.get("branch_name") == "main"
         or base_args.get("branch_name").startswith("release/therock")
     ):
-        print(f"[PUSH - MAIN] Generating build matrix with {str(base_args)}")
+        print(
+            f"[PUSH - MAIN OR RELEASE/THEROCK-x.y] Generating build matrix with {str(base_args)}"
+        )
 
         # Add presubmit and postsubmit targets.
         for target in (


### PR DESCRIPTION
This will now correctly run on `release/therock-x.y.` branches