### PR TITLE
release_portable_linux_pytorch_wheels: set run-name

### DIFF
--- a/.github/workflows/build_linux_jax_wheels.yml
+++ b/.github/workflows/build_linux_jax_wheels.yml
@@ -62,6 +62,8 @@ permissions:
   id-token: write
   contents: read
 
+run-name: Build Linux JAX Wheels (${{ inputs.amdgpu_family }}, ${{ inputs.python_version }}, ${{ inputs.release_type }})
+
 jobs:
   build_jax_wheels:
     strategy:

--- a/.github/workflows/build_native_linux_packages.yml
+++ b/.github/workflows/build_native_linux_packages.yml
@@ -60,6 +60,8 @@ permissions:
   id-token: write
   contents: read
 
+run-name: Build native Linux packages (${{ inputs.artifact_group }}, ${{ inputs.rocm_version }}, ${{ inputs.native_package_type }}, ${{ inputs.package_suffix }}, ${{ inputs.release_type }})
+
 jobs:
   build_native_packages:
     name: Build Linux native Packages

--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -31,6 +31,8 @@ on:
 permissions:
   contents: read
 
+run-name: Build portable Linux Python Packages (${{ inputs.artifact_group }}, ${{ inputs.package_version }})
+
 jobs:
   build:
     name: Build Python | ${{ inputs.artifact_group }}

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -103,6 +103,8 @@ permissions:
   id-token: write
   contents: read
 
+run-name: Build portable Linux PyTorch Wheels (${{ inputs.amdgpu_family }}, ${{ inputs.python_version }}, ${{ inputs.release_type }})
+
 jobs:
   build_pytorch_wheels:
     name: Build | ${{ inputs.amdgpu_family }} | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_git_ref }}

--- a/.github/workflows/release_native_linux_packages.yml
+++ b/.github/workflows/release_native_linux_packages.yml
@@ -51,6 +51,8 @@ permissions:
   id-token: write
   contents: read
 
+run-name: Release native Linux packages (${{ inputs.amdgpu_family }}, ${{ inputs.rocm_version }}, ${{ inputs.package_type }}, ${{ inputs.package_suffix }})
+
 jobs:
   release:
     name: Release Native Linux Package

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -61,6 +61,8 @@ on:
 permissions:
   contents: read
 
+run-name: Release portable Linux packages (${{ inputs.families }}, ${{ inputs.release_type }})
+
 jobs:
   setup_metadata:
     if: ${{ github.repository_owner == 'ROCm' || github.event_name != 'schedule' }}

--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -80,6 +80,7 @@ permissions:
   contents: read
 
 run-name: Release portable Linux PyTorch Wheels (${{ inputs.amdgpu_family }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
+
 jobs:
   release:
     name: Release | ${{ inputs.amdgpu_family }} | py ${{ matrix.python_version }} | torch ${{ matrix.pytorch_git_ref }}

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -65,6 +65,8 @@ on:
 permissions:
   contents: read
 
+run-name: Release Windows packages (${{ inputs.families }}, ${{ inputs.release_type }})
+
 jobs:
   setup_metadata:
     if: ${{ github.repository_owner == 'ROCm' || github.event_name != 'schedule' }}

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -79,6 +79,8 @@ permissions:
   id-token: write
   contents: read
 
+run-name: Release Windows PyTorch Wheels (${{ inputs.amdgpu_family }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
+
 jobs:
   release:
     name: Release | ${{ inputs.amdgpu_family }} | py ${{ matrix.python_version }} | torch ${{ matrix.pytorch_git_ref }}


### PR DESCRIPTION
## Motivation

The actions page doesn't make it obvious which job was running which target. To quickly find the last run of a given target,
extend the run name with that.
<img width="740" height="874" alt="image" src="https://github.com/user-attachments/assets/7733154d-9d77-49dd-a280-849fdeec76ec" />


## Technical Details

Include important job inputs in the name shown on the Actions/workflow page. This makes it easier to find the last job for a certain target.

## Test Plan

I have used the same trick on other repos; beyond that, github actions are hard to test.

## Test Result

-

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
