### PR TITLE
[hipDNN] Increase timeout due to Windows test time variability

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_miopen_plugin.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen_plugin.py
@@ -18,7 +18,7 @@ cmd = [
     "--parallel",
     "8",
     "--timeout",
-    "600",
+    "900",
 ]
 
 # Determine test filter based on TEST_TYPE environment variable


### PR DESCRIPTION
## Motivation

We are seeing the Windows test runs in rocm-libraries have pretty significant variance (appears due to machine variance).

Failing 10 minute timeout:
- https://github.com/ROCm/rocm-libraries/actions/runs/19770723884/job/56658605466?pr=2858

Re-an with the same commit passing in 5 minutes:
- https://github.com/ROCm/rocm-libraries/actions/runs/19770723884/job/56665511846?pr=2858
 
These are identical runs.
Updating the timeout to be 15 minutes to allow for higher variance in Windows test runtimes.

## Technical Details

Updating hipDNN testing timeout to be 15 minutes instead of 10 to allow more room for machine variance.

## Test Plan

Run tests through CI, and confirm passing.
