### PR TITLE
Remove `tabs` to pass pre-commit

### DIFF
--- a/patches/amd-mainline/rocm-systems/0002-Revert-hsakmt-bump-vgpr-count-for-gfx1151-1807.patch
+++ b/patches/amd-mainline/rocm-systems/0002-Revert-hsakmt-bump-vgpr-count-for-gfx1151-1807.patch
@@ -17,9 +17,9 @@ index 9581f7bdd4..4ac445c025 100644
     GFX_VERSION_YELLOW_CARP     = 0x0A0305,
     GFX_VERSION_PLUM_BONITO     = 0x0B0000,
     GFX_VERSION_WHEAT_NAS       = 0x0B0001,
--   GFX_VERSION_GFX1151      = 0x0B0501,
-    GFX_VERSION_GFX1200      = 0x0C0000,
-    GFX_VERSION_GFX1201      = 0x0C0001,
+-   GFX_VERSION_GFX1151     = 0x0B0501,
+    GFX_VERSION_GFX1200     = 0x0C0000,
+    GFX_VERSION_GFX1201     = 0x0C0001,
  };
 diff --git a/projects/rocr-runtime/libhsakmt/src/queues.c b/projects/rocr-runtime/libhsakmt/src/queues.c
 index b48235f86f..c2a00734ea 100644


### PR DESCRIPTION
Remove tabs to pass pre-commit