### PR TITLE
[Pytorch Tests]: Fix arch detection when a specific arch is given

### DIFF
--- a/external-builds/pytorch/run_linux_pytorch_tests.py
+++ b/external-builds/pytorch/run_linux_pytorch_tests.py
@@ -378,9 +378,14 @@ def detect_amdgpu_family(amdgpu_family: str = "") -> list[str]:
         )
     else:
         # Mode 3: Specific GPU arch - validate it is visible and supported by the current PyTorch build.
+
+        # We have gfx1151 -> we want to match exactly gfx1151
+        # We have gfx950-dcgpu -> we need to match exactly gfx950
+        # So remove the suffix after '-'
+        pruned_amdgpu_family = amdgpu_family.split("-")[0]
         for idx, gpu in enumerate(visible_gpus):
             if gpu in supported_gpus:
-                if gpu == amdgpu_family or amdgpu_family in gpu:
+                if gpu == pruned_amdgpu_family or pruned_amdgpu_family in gpu:
                     selected_gpu_indices += [idx]
                     selected_gpu_archs += [gpu]
 


### PR DESCRIPTION
Adjusts arch detection in external-builds/pytorch/run_linux_pytorch_tests.py.

When a specific arch is given, gpus like gfx950-dcgpu were not correctly recognized.
Any specific gpu, not containing a X before the "-" (= no family) is now pruned to
just the prefix.
gfx1151 --> gfx1151 (unchanged behavior)
gfx950-dcgpu --> gfx950 (new behavior)

this allows to match with the gpu list returned by torch, and no longer throw an errror and exit the program.

Should fix #2324 