### PR TITLE
Allow tabs under the patches/ folder.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,4 +41,4 @@ repos:
   rev: v1.5.5
   hooks:
   - id: forbid-tabs
-    exclude: ".gitmodules|docs/development/git_chores.md|build_tools/packaging/linux/template/debian_rules.j2"
+    exclude: ".gitmodules|patches/.*|docs/development/git_chores.md|build_tools/packaging/linux/template/debian_rules.j2"


### PR DESCRIPTION
This fixes failures reported here: https://github.com/ROCm/TheRock/pull/2338#discussion_r2578046353

```
No-tabs checker..........................................................Failed
- hook id: forbid-tabs
- exit code: 1

Tabs detected in file: patches/amd-mainline/rocm-systems/0002-Revert-hsakmt-bump-vgpr-count-for-gfx1151-1807.patch

Error: Process completed with exit code 1.
```

We won't need https://github.com/ROCm/TheRock/pull/2351 once this is merged.

Tested that the hook still runs for other directories:
```
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook

Fixing core/0002-Revert-hsakmt-bump-vgpr-count-for-gfx1151-1807.patch

Check Yaml...........................................(no files to check)Skipped
Check for merge conflicts................................................Passed
Check for added large files..............................................Passed
Mixed line ending........................................................Passed
black................................................(no files to check)Skipped
clang-format.........................................(no files to check)Skipped
mdformat.............................................(no files to check)Skipped
No-tabs checker..........................................................Failed
- hook id: forbid-tabs
- exit code: 1

Tabs detected in file: core/0002-Revert-hsakmt-bump-vgpr-count-for-gfx1151-1807.patch
```