### PR TITLE
[Pytorch pytest] Adjust test skipping, add support for pytorch 2.8

### DIFF
--- a/external-builds/pytorch/skip_tests/pytorch_2.10.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.10.py
@@ -104,7 +104,7 @@ skip_tests = {
             "test_terminate_handler_on_crash",  # flaky !! hangs forever or works... can need up to 30 sec to pass
             "test_cpp_warnings_have_python_context_cuda",
             # torch._dynamo.exc.BackendCompilerFailed: backend='aot_eager' raised:
-            # ypeError: 'CustomDecompTable' object is not a mapping
+            # TypeError: 'CustomDecompTable' object is not a mapping
             "test_fx_memory_profiler_augmentation",
             # failure in python 3.13
             "test_index_add_correctness",

--- a/external-builds/pytorch/skip_tests/pytorch_2.7.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.7.py
@@ -1,7 +1,7 @@
 skip_tests = {
     "common": {
         "cuda": [
-            # Explicitly deselected since givind segfault
+            # Explicitly deselected since giving segfault
             "test_unused_output_device_cuda",  # this test does not exist in nightly anymore
             "test_pinned_memory_empty_cache",
             "test_float32_matmul_precision_get_set",

--- a/external-builds/pytorch/skip_tests/pytorch_2.8.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.8.py
@@ -1,7 +1,7 @@
 skip_tests = {
     "common": {
         "cuda": [
-            # Explicitly deselected since givind segfault
+            # Explicitly deselected since giving segfault
             "test_unused_output_device_cuda",  # this test does not exist in nightly anymore
             "test_pinned_memory_empty_cache",
             "test_float32_matmul_precision_get_set",

--- a/external-builds/pytorch/skip_tests/pytorch_2.9.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.9.py
@@ -2,7 +2,7 @@
 skip_tests = {
     "common": {
         "cuda": [
-            # Explicitly deselected since givind segfault
+            # Explicitly deselected since giving segfault
             "test_unused_output_device_cuda",  # this test does not exist in nightly anymore
             "test_pinned_memory_empty_cache",
             "test_float32_matmul_precision_get_set",


### PR DESCRIPTION
Adjust test skipping of pytorch 2.7, 2.8, 2.9, 2.10 (=nightly) based on gfx942.

No other archs are currently available to base the adjustment on.

There are 4 true test regressions that are not skipped (most likely on all pytorch versions [2.9 needs confirmation]):
TestBinaryUfuncsCUDA::test_batch_vs_slicing___rpow___cuda_complex64
TestBinaryUfuncsCUDA::test_batch_vs_slicing__refs_pow_cuda_complex32
TestBinaryUfuncsCUDA::test_batch_vs_slicing__refs_pow_cuda_complex64
TestBinaryUfuncsCUDA::test_batch_vs_slicing_pow_cuda_complex64