### PR TITLE
Install flex into build manylinux container

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -138,10 +138,6 @@ SKIPPABLE_PATH_PATTERNS = [
     # workflows efficient when only nodes closer to the edges of the build graph
     # are changed.
     "external-builds/*",
-    # Changes to dockerfiles do not currently affect CI workflows directly.
-    # Docker images are built and published after commits are pushed, then
-    # workflows can be updated to use the new image sha256 values.
-    "dockerfiles/*",
     # Changes to experimental code do not run standard build/test workflows.
     "experimental/*",
 ]


### PR DESCRIPTION
## Motivation

I suspect this will help with https://github.com/ROCm/TheRock/issues/2364 :

```
2025-11-30T06:50:31.5504409Z [rocprofiler-systems] make[4]: Entering directory '/therock/output/build/profiler/rocprofiler-systems/build/external/binutils/src/rocprofiler-systems-libiberty-build/binutils'
2025-11-30T06:50:31.5504565Z [rocprofiler-systems]   CC       size.o
2025-11-30T06:50:31.5504719Z [rocprofiler-systems]   CC       bucomm.o
...
2025-11-30T06:50:31.5506987Z [rocprofiler-systems]   CC       arparse.o
2025-11-30T06:50:31.5507135Z [rocprofiler-systems]   LEX      arlex.c
2025-11-30T06:50:31.5508159Z [rocprofiler-systems] /therock/output/build/profiler/rocprofiler-systems/build/external/binutils/src/rocprofiler-systems-libiberty-build/missing: line 81: flex: command not found
2025-11-30T06:50:31.5508461Z [rocprofiler-systems] WARNING: 'flex' is missing on your system.
2025-11-30T06:50:31.5508792Z [rocprofiler-systems]          You should only need it if you modified a '.l' file.
2025-11-30T06:50:31.5509240Z [rocprofiler-systems]          You may want to install the Fast Lexical Analyzer package:
2025-11-30T06:50:31.5509527Z [rocprofiler-systems]          <http://flex.sourceforge.net/>
2025-11-30T06:50:31.5509809Z [rocprofiler-systems] make[4]: *** [Makefile:1241: arlex.c] Error 127
```

## Technical Details

Once merged and a new image is built we will need to update pins like here: https://github.com/ROCm/TheRock/blob/f4e3c625d8718b38a3aa8ba8ba283bbc5fd4eb63/.github/workflows/release_portable_linux_packages.yml#L148

## Test Plan

I don't have a Linux development environment easily accessible to test this right now but here's what I would do:

- [x] Reproduce the build issue locally with our existing docker image
- [x] Build the container locally
- [x] Check if the issue persists or is fixed

Alternately, we could merge this without testing and then update the workflows and hope for the best...

## Test Result

On local setup, reproduced initial failure on gfx950, installed `flex`, rebuild was successful.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
