### PR TITLE
Skip CI for changes to dockerfiles.

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -138,6 +138,10 @@ SKIPPABLE_PATH_PATTERNS = [
     # workflows efficient when only nodes closer to the edges of the build graph
     # are changed.
     "external-builds/*",
+    # Changes to dockerfiles do not currently affect CI workflows directly.
+    # Docker images are built and published after commits are pushed, then
+    # workflows can be updated to use the new image sha256 values.
+    "dockerfiles/*",
     # Changes to experimental code do not run standard build/test workflows.
     "experimental/*",
 ]


### PR DESCRIPTION
This will save some CI resources when editing dockerfiles.

We could set up a different workflow that tries to build the dockerfiles and _maybe_ runs CI workflows using the development image, but I think we can revisit this filtering if/when we do that. Perhaps if we centralized the image pin (outside of workflow yml files) we could have workflows redirect that pin with a workflow step somehow?