### PR TITLE
*.hh is should be registered as c++ header

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -981,6 +981,7 @@ function(therock_cmake_subproject_glob_c_sources target_name)
     set(_s "${_project_source_dir}/${_subdir}")
     list(APPEND _globs
       "${_s}/*.h"
+      "${_s}/*.hh"
       "${_s}/*.hpp"
       "${_s}/*.inc"
       "${_s}/*.cc"


### PR DESCRIPTION
## Motivation

`*.hh` should be registered as C++ header.

## Technical Details

Projects can have C++ header ending with extension `*.hh`.

## Test Plan

NA

## Test Result

NA

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
