### PR TITLE
Fix workflow input name to build_linux_jax_wheels.yml

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -309,7 +309,7 @@ jobs:
           workflow: build_linux_jax_wheels.yml
           inputs: |
             { "amdgpu_family": "${{ matrix.target_bundle.amdgpu_family }}",
-              "python_versions": "3.12",
+              "python_version": "3.12",
               "release_type": "${{ env.RELEASE_TYPE }}",
               "s3_subdir": "${{ env.S3_STAGING_SUBDIR }}",
               "rocm_version": "${{ needs.setup_metadata.outputs.version }}",


### PR DESCRIPTION
Follow-up to https://github.com/ROCm/TheRock/pull/2317. Fixes: https://github.com/ROCm/TheRock/issues/2375.

https://github.com/ROCm/TheRock/actions/runs/19846849654/job/56865923418#step:19:40
```
🏃 Workflow Dispatch Action v1.2.4
🔎 Found workflow, id: 178566937, name: Build Portable Linux JAX Wheels, path: .github/workflows/build_linux_jax_wheels.yml
🚀 Calling GitHub API to dispatch workflow...
Error: Unexpected inputs provided: ["python_versions"] - https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event
```