### PR TITLE
[ci] Allocating 5 shards for rocwmma to reduce flaky timeout risk

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -211,7 +211,7 @@ test_matrix = {
         "timeout_minutes": 60,
         "test_script": f"python {_get_script_path('test_rocwmma.py')}",
         "platform": ["linux", "windows"],
-        "total_shards": 4,
+        "total_shards": 5,
     },
 }
 


### PR DESCRIPTION
Currently, rocwmma tests would occasionally timeout due to three shards typically running longer. As we are now allocating 300 minutes total for each test (based on needs), we will increase rocwmma shards to 5, which will allow each shard to run in ~ 30 mins 

With this, this will cause less flaky timeouts

Tests ran here: https://github.com/ROCm/TheRock/actions/runs/19863037729/job/56918284994