### PR TITLE
Provide rocprofiler-sdk-rocpd package

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -85,6 +85,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
   )
   therock_cmake_subproject_provide_package(rocprofiler-sdk rocprofiler-sdk lib/cmake/rocprofiler-sdk)
   therock_cmake_subproject_provide_package(rocprofiler-sdk rocprofiler-sdk-roctx lib/cmake/rocprofiler-sdk-roctx)
+  therock_cmake_subproject_provide_package(rocprofiler-sdk rocprofiler-sdk-rocpd lib/cmake/rocprofiler-sdk-rocpd)
   therock_cmake_subproject_activate(rocprofiler-sdk)
 
   ##############################################################################


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
We currently do not provide the rocpd package from rocprofiler-sdk, which led to some build warnings when configuring rocprofiler-systems build.

See `rocprofiler-systems_configure.log` from one of the CI runs for an example of this:

19.1	CMake Warning at /therock/src/cmake/therock_subproject_dep_provider.cmake:69 (find_package):
19.1	  By not providing "Findrocprofiler-sdk-rocpd.cmake" in CMAKE_MODULE_PATH
19.1	  this project has asked CMake to find a package configuration file provided
19.1	  by "rocprofiler-sdk-rocpd", but CMake did not find one.
19.1	
19.1	  Could not find a package configuration file provided by
19.1	  "rocprofiler-sdk-rocpd" with any of the following names:
19.1	
19.1	    rocprofiler-sdk-rocpdConfig.cmake

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Add a `therock_cmake_subproject_provide_package()` call for rocpd in rocprofiler-sdk
- #1808

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ensure that these CMake warnings no longer show up in the build logs

## Test Result

<!-- Briefly summarize test outcomes. -->
CMake warnings about rocpd from rocprofiler-systems are now gone


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
