### PR TITLE
Remove stopped containers and dangling networks

### DIFF
--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -75,6 +75,15 @@ jobs:
         with:
           repository: "ROCm/TheRock"
 
+      - name: Pre-job cleanup Docker containers on Linux
+        if: ${{ runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          # Remove any stopped containers
+          docker container prune -f || true
+          # Remove dangling networks
+          docker network prune -f || true
+
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'
         with:


### PR DESCRIPTION
## Motivation

Workflow "Test Sanity Check" fail with the error message: "Error response from daemon: cannot remove container".
Refer to this [link](https://github.com/ROCm/TheRock/actions/runs/19840486914/job/56865350421), Linux::gfx110X-all::release/Sanity ROCM Test failed.

## Technical Details

This PR fix this issue by removing stopped containers and dangling networks.
Refer to this [link ](https://github.com/ROCm/TheRock/actions/runs/19847154536/job/56869969053) which has the fix and Linux::gfx110X-all::release/Sanity ROCM Test passed.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
