### PR TITLE
[Pytorch pytest]: adjust test skipping for gfx950 failures

### DIFF
--- a/external-builds/pytorch/skip_tests/pytorch_2.10.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.10.py
@@ -1,5 +1,55 @@
 skip_tests = {
-    "common": {},
+    "common": {
+        "autograd": [
+            # AssertionError: Booleans mismatch: False is not True
+            "test_warn_on_accumulate_grad_stream_mismatch_flag_cuda",
+        ],
+        "cuda": [
+            # AttributeError: module 'torch.backends.cudnn.rnn' has no attribute 'fp32_precision'
+            "test_fp32_precision_with_float32_matmul_precision",
+            # AttributeError: module 'torch.backends.cudnn.rnn' has no attribute 'fp32_precision'
+            "test_fp32_precision_with_tf32",
+            # AttributeError: module 'torch.backends.cudnn.rnn' has no attribute 'fp32_precision'
+            "test_invalid_status_for_legacy_api",
+            # passes on single run, crashes if run in a group
+            # TypeError: 'CustomDecompTable' object is not a mapping
+            "test_memory_compile_regions",
+            # AssertionError: False is not true
+            "test_memory_plots",
+            # AssertionError: Booleans mismatch: False is not True
+            "test_memory_plots_free_segment_stack",
+            # FileNotFoundError: [Errno 2] No such file or directory: '/github/home/.cache//flamegraph.pl'
+            "test_memory_snapshot",
+            # AssertionError: String comparison failed: 'test_memory_snapshot' != 'foo'
+            "test_memory_snapshot_script",
+            # AssertionError: False is not true
+            "test_memory_snapshot_with_cpp",
+            # AssertionError: Scalars are not equal!
+            "test_mempool_ctx_multithread",
+            # RuntimeError: Error building extension 'dummy_allocator'
+            "test_mempool_empty_cache_inactive",
+            # RuntimeError: Error building extension 'dummy_allocator_v1'
+            "test_mempool_limited_memory_with_allocator",
+            # OSError: libhiprtc.so: cannot open shared object file: No such file or directory
+            # File "/home/tester/TheRock/.venv/lib/python3.12/site-packages/torch/cuda/_utils.py", line 57, in _get_hiprtc_library
+            # lib = ctypes.CDLL("libhiprtc.so")
+            "test_compile_kernel",
+            "test_compile_kernel_advanced",
+            "test_compile_kernel_as_custom_op",
+            "test_compile_kernel_cuda_headers",
+            "test_compile_kernel_custom_op_validation",
+            "test_compile_kernel_dlpack",
+            "test_compile_kernel_double_precision",
+            "test_compile_kernel_large_shared_memory",
+            "test_compile_kernel_template",
+            # torch._dynamo.exc.BackendCompilerFailed: backend='aot_eager' raised:
+            # TypeError: 'CustomDecompTable' object is not a mapping
+            "test_record_stream_on_shifted_view",
+        ],
+        "torch": [
+            "test_index_add_correctness",
+        ],
+    },
     "gfx942": {
         "autograd": [
             # fixed or just good with no caching?
@@ -21,28 +71,9 @@ skip_tests = {
             # # of the custom Function.
             # "test_autograd_simple_views_python",
             "test_grad_dtype",
-            # AssertionError: Booleans mismatch: False is not True
-            "test_warn_on_accumulate_grad_stream_mismatch_flag_cuda",
         ],
         "cuda": [
             # "test_cpp_memory_snapshot_pickle",
-            "test_mempool_ctx_multithread",
-            #
-            # passes on single run, crashes if run in a group
-            "test_memory_plots",
-            "test_memory_compile_regions",
-            "test_memory_plots_free_segment_stack",
-            # FileNotFoundError: [Errno 2] No such file or directory: '/github/home/.cache//flamegraph.pl'
-            "test_memory_snapshot",
-            #  AssertionError: String comparison failed: 'test_memory_snapshot' != 'foo'
-            "test_memory_snapshot_script",
-            "test_memory_snapshot_with_cpp",
-            #
-            # /home/tester/TheRock/.venv/lib/python3.12/site-packages/torch/include/ATen/hip/Exceptions.h:4:10: fatal error: 'hipblas/hipblas.h' file not found
-            # 4 | #include <hipblas/hipblas.h>
-            # |          ^~~~~~~~~~~~~~~~~~~
-            #
-            "test_mempool_empty_cache_inactive",
             #
             # what():  HIP error: operation not permitted when stream is capturing
             # Search for `hipErrorStreamCaptureUnsupported' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__HIPRT__TYPES.html for more information.
@@ -56,29 +87,8 @@ skip_tests = {
             "test_graph_make_graphed_callables_parameterless_nograd_module_without_amp_not_allow_unused_input",
             "test_graph_concurrent_replay ",
             #
-            # Error building extension 'dummy_allocator'
-            "test_mempool_limited_memory_with_allocator",
-            # OSError: libhiprtc.so: cannot open shared object file: No such file or directory
-            # File "/home/tester/TheRock/.venv/lib/python3.12/site-packages/torch/cuda/_utils.py", line 57, in _get_hiprtc_library
-            # lib = ctypes.CDLL("libhiprtc.so")
-            "test_compile_kernel",
-            "test_compile_kernel_advanced",
-            "test_compile_kernel_as_custom_op",
-            "test_compile_kernel_cuda_headers",
-            "test_compile_kernel_custom_op_validation",
-            "test_compile_kernel_dlpack",
-            "test_compile_kernel_double_precision",
-            "test_compile_kernel_large_shared_memory",
-            "test_compile_kernel_template",
-            "test_record_stream_on_shifted_view",
             #
             # for whatever reason these are also flaky: if run standalone they pass?
-            # AttributeError: module 'torch.backends.cudnn.rnn' has no attribute 'fp32_precision'
-            "test_fp32_precision_with_float32_matmul_precision",
-            # AttributeError: module 'torch.backends.cudnn.rnn' has no attribute 'fp32_precision'
-            "test_fp32_precision_with_tf32",
-            # AttributeError: module 'torch.backends.cudnn.rnn' has no attribute 'fp32_precision'
-            "test_invalid_status_for_legacy_api",
             # AttributeError: Unknown attribute allow_bf16_reduced_precision_reduction_split_k
             "test_cublas_allow_bf16_reduced_precision_reduction_get_set",
             # AttributeError: Unknown attribute allow_fp16_reduced_precision_reduction_split_k
@@ -106,8 +116,32 @@ skip_tests = {
             # torch._dynamo.exc.BackendCompilerFailed: backend='aot_eager' raised:
             # TypeError: 'CustomDecompTable' object is not a mapping
             "test_fx_memory_profiler_augmentation",
-            # failure in python 3.13
-            "test_index_add_correctness",
+        ],
+    },
+    "gfx950": {
+        "cuda": [
+            "test_cpp_warnings_have_python_context_cuda",
+        ],
+        "binary_ufuncs": [
+            # AssertionError: Tensor-likes are not close!
+            "test_contig_vs_every_other___rpow___cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_contig_vs_every_other__refs_pow_cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_contig_vs_every_other_pow_cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_non_contig___rpow___cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_non_contig__refs_pow_cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_non_contig_pow_cuda_complex64",
+        ],
+        "torch": [
+            # SEGMENTATION FAULT!!!!!
+            # Kernel Name: _ZN2at6native13reduce_kernelILi512ELi1ENS0_8ReduceOpIbNS0_14func_wrapper_tIbZZZNS0_15and_kernel_cudaERNS_14TensorIteratorEENKUlvE_clEvENKUlvE10_clEvEUlbbE_EEjbLi4ELi4EEEEEvT1_
+            # :0:rocdevice.cpp            :3603: 1544877169487 us:  Callback: Queue 0x7f599b800000 Aborting with error : HSA_STATUS_ERROR_OUT_OF_RESOURCES: The runtime failed to allocate the necessary resources. This error may also occur when the core runtime library needs to spawn threads or create internal OS-specific events. Code: 0x1008 Available Free mem : 17592186044276 MB
+            # see pytorch_2.9.py for more details
+            "test_masked_scatter_cuda_uint8 "
         ],
     },
 }

--- a/external-builds/pytorch/skip_tests/pytorch_2.8.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.8.py
@@ -26,4 +26,20 @@ skip_tests = {
             "test_mempool_limited_memory_with_allocator",
         ]
     },
+    "gfx950": {
+        "binary_ufuncs": [
+            # AssertionError: Tensor-likes are not close!
+            "test_contig_vs_every_other___rpow___cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_contig_vs_every_other__refs_pow_cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_contig_vs_every_other_pow_cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_non_contig___rpow___cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_non_contig__refs_pow_cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_non_contig_pow_cuda_complex64",
+        ]
+    },
 }

--- a/external-builds/pytorch/skip_tests/pytorch_2.9.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.9.py
@@ -1,6 +1,9 @@
 # NOTE: not tested. just combining pytorch_2.7.py and pytorch_2.10.py to see if that resolves the OOM errors
 skip_tests = {
     "common": {
+        "autograd": [
+            "test_side_stream_backward_overlap",
+        ],
         "cuda": [
             # Explicitly deselected since giving segfault
             "test_unused_output_device_cuda",  # this test does not exist in nightly anymore
@@ -12,14 +15,39 @@ skip_tests = {
             # Greatest relative difference: 0.01495361328125 at index (3, 114, 184) (up to 0.01 allowed)
             "test_index_add_correctness",
             "test_graph_concurrent_replay",
-        ]
+            # passes on single run, crashes if run in a group
+            # TypeError: 'CustomDecompTable' object is not a mapping
+            "test_memory_compile_regions",
+            # AssertionError: False is not true
+            "test_memory_plots",
+            # AssertionError: Booleans mismatch: False is not True
+            "test_memory_plots_free_segment_stack",
+            # FileNotFoundError: [Errno 2] No such file or directory: '/github/home/.cache//flamegraph.pl'
+            "test_memory_snapshot",
+            # AssertionError: String comparison failed: 'test_memory_snapshot' != 'foo'
+            "test_memory_snapshot_script",
+            # AssertionError: False is not true
+            "test_memory_snapshot_with_cpp",
+            # AssertionError: Scalars are not equal!
+            "test_mempool_ctx_multithread",
+            # RuntimeError: Error building extension 'dummy_allocator'
+            "test_mempool_empty_cache_inactive",
+            # RuntimeError: Error building extension 'dummy_allocator_v1'
+            "test_mempool_limited_memory_with_allocator",
+            # for whatever reason these are also flaky: if run standalone they pass?
+            # AttributeError: module 'torch.backends.cudnn.rnn' has no attribute 'fp32_precision'
+            "test_fp32_precision_with_float32_matmul_precision",
+            # AttributeError: module 'torch.backends.cudnn.rnn' has no attribute 'fp32_precision'
+            "test_fp32_precision_with_tf32",
+            # AttributeError: module 'torch.backends.cudnn.rnn' has no attribute 'fp32_precision'
+            "test_invalid_status_for_legacy_api",
+        ],
     },
     "gfx942": {
         "autograd": [
             # fixed or just good with no caching?
             # "test_reentrant_parent_error_on_cpu_cuda",
             # "test_multi_grad_all_hooks",
-            "test_side_stream_backward_overlap",
             # "test_side_stream_backward_overlap",
             #
             #  Test run says they are good????
@@ -38,23 +66,6 @@ skip_tests = {
         ],
         "cuda": [
             # "test_cpp_memory_snapshot_pickle",
-            "test_mempool_ctx_multithread",
-            #
-            # passes on single run, crashes if run in a group
-            "test_memory_plots",
-            "test_memory_compile_regions",
-            "test_memory_plots_free_segment_stack",
-            # FileNotFoundError: [Errno 2] No such file or directory: '/github/home/.cache//flamegraph.pl'
-            "test_memory_snapshot",
-            #  AssertionError: String comparison failed: 'test_memory_snapshot' != 'foo'
-            "test_memory_snapshot_script",
-            "test_memory_snapshot_with_cpp",
-            #
-            # /home/tester/TheRock/.venv/lib/python3.12/site-packages/torch/include/ATen/hip/Exceptions.h:4:10: fatal error: 'hipblas/hipblas.h' file not found
-            # 4 | #include <hipblas/hipblas.h>
-            # |          ^~~~~~~~~~~~~~~~~~~
-            #
-            "test_mempool_empty_cache_inactive",
             #
             # what():  HIP error: operation not permitted when stream is capturing
             # Search for `hipErrorStreamCaptureUnsupported' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__HIPRT__TYPES.html for more information.
@@ -68,8 +79,6 @@ skip_tests = {
             "test_graph_make_graphed_callables_parameterless_nograd_module_without_amp_not_allow_unused_input",
             "test_graph_concurrent_replay ",
             #
-            # Error building extension 'dummy_allocator'
-            "test_mempool_limited_memory_with_allocator",
             # OSError: libhiprtc.so: cannot open shared object file: No such file or directory
             # File "/home/tester/TheRock/.venv/lib/python3.12/site-packages/torch/cuda/_utils.py", line 57, in _get_hiprtc_library
             # lib = ctypes.CDLL("libhiprtc.so")
@@ -85,12 +94,6 @@ skip_tests = {
             "test_record_stream_on_shifted_view",
             #
             # for whatever reason these are also flaky: if run standalone they pass?
-            # AttributeError: module 'torch.backends.cudnn.rnn' has no attribute 'fp32_precision'
-            "test_fp32_precision_with_float32_matmul_precision",
-            # AttributeError: module 'torch.backends.cudnn.rnn' has no attribute 'fp32_precision'
-            "test_fp32_precision_with_tf32",
-            # AttributeError: module 'torch.backends.cudnn.rnn' has no attribute 'fp32_precision'
-            "test_invalid_status_for_legacy_api",
             # AttributeError: Unknown attribute allow_bf16_reduced_precision_reduction_split_k
             "test_cublas_allow_bf16_reduced_precision_reduction_get_set",
             # AttributeError: Unknown attribute allow_fp16_reduced_precision_reduction_split_k
@@ -114,6 +117,46 @@ skip_tests = {
         ],
         "torch": [
             "test_terminate_handler_on_crash",  # flaky !! hangs forever or works... can need up to 30 sec to pass
+        ],
+    },
+    "gfx950": {
+        "binary_ufuncs": [
+            # AssertionError: Tensor-likes are not close!
+            "test_contig_vs_every_other___rpow___cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_contig_vs_every_other__refs_pow_cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_contig_vs_every_other_pow_cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_non_contig___rpow___cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_non_contig__refs_pow_cuda_complex64",
+            # AssertionError: Tensor-likes are not close!
+            "test_non_contig_pow_cuda_complex64",
+        ],
+        "torch": [
+            # SEGMENTATION FAULT!!!!!
+            # external-builds/pytorch/pytorch/test/test_torch.py::TestTorchDeviceTypeCUDA::test_masked_scatter_cuda_uint8 Kernel Name: _ZN2at6native13reduce_kernelILi512ELi1ENS0_8ReduceOpIbNS0_14func_wrapper_tIbZZZNS0_15and_kernel_cudaERNS_14TensorIteratorEENKUlvE_clEvENKUlvE10_clEvEUlbbE_EEjbLi4ELi4EEEEEvT1_
+            # :0:rocdevice.cpp            :3603: 1545695326084 us:  Callback: Queue 0x7f3dd8000000 Aborting with error : HSA_STATUS_ERROR_OUT_OF_RESOURCES: The runtime failed to allocate the necessary resources. This error may also occur when the core runtime library needs to spawn threads or create internal OS-specific events. Code: 0x1008 Available Free mem : 17592186044276 MB
+            # Thread 0x00007f4b4fd88b80 (most recent call first):
+            # File "/__w/TheRock/TheRock/.venv/lib/python3.11/site-packages/torch/testing/_comparison.py", line 1087 in _compare_regular_values_close
+            # File "/__w/TheRock/TheRock/.venv/lib/python3.11/site-packages/torch/testing/_comparison.py", line 905 in _compare_values
+            # File "/__w/TheRock/TheRock/.venv/lib/python3.11/site-packages/torch/testing/_comparison.py", line 747 in compare
+            # File "/__w/TheRock/TheRock/.venv/lib/python3.11/site-packages/torch/testing/_comparison.py", line 1298 in not_close_error_metas
+            # File "/__w/TheRock/TheRock/.venv/lib/python3.11/site-packages/torch/testing/_internal/common_utils.py", line 4248 in assertEqual
+            # File "/__w/TheRock/TheRock/external-builds/pytorch/pytorch/test/test_torch.py", line 3683 in test_masked_scatter
+            # File "/__w/TheRock/TheRock/.venv/lib/python3.11/site-packages/torch/testing/_internal/common_device_type.py", line 1473 in only_fn
+            # File "/__w/TheRock/TheRock/.venv/lib/python3.11/site-packages/torch/testing/_internal/common_device_type.py", line 428 in instantiated_test
+            # File "/__w/TheRock/TheRock/.venv/lib/python3.11/site-packages/torch/testing/_internal/common_utils.py", line 3332 in wrapper
+            # File "/__w/_tool/Python/3.11.14/x64/lib/python3.11/unittest/case.py", line 579 in _callTestMethod
+            # File "/__w/_tool/Python/3.11.14/x64/lib/python3.11/unittest/case.py", line 623 in run
+            # File "/__w/TheRock/TheRock/.venv/lib/python3.11/site-packages/torch/testing/_internal/common_utils.py", line 3484 in _run_custom
+            # File "/__w/TheRock/TheRock/.venv/lib/python3.11/site-packages/torch/testing/_internal/common_utils.py", line 3514 in run
+            # File "/__w/TheRock/TheRock/.venv/lib/python3.11/site-packages/torch/testing/_internal/common_device_type.py", line 519 in run
+            # File "/__w/_tool/Python/3.11.14/x64/lib/python3.11/unittest/case.py", line 678 in __call__
+            # File "/__w/TheRock/TheRock/.venv/lib/python3.11/site-packages/_pytest/unittest.py", line 351 in runtest
+            # File "/__w/TheRock/TheRock/.venv/lib/python3.11/site-packages/_pytest/runner.py", line 174 in pytest_runtest_call
+            "test_masked_scatter_cuda_uint8 "
         ],
     },
 }


### PR DESCRIPTION
WARNING: this includes that also a segfault is being skipped "test_masked_scatter_cuda_uint8".

Other than that, some test failures that were also failing on gfx942 are now moved into "common", so they are skipped for all archs.

Common failures over multiple versions are tests related to "test_memory_plots" and "test_compile_kernel".
gfx950 specific failures are 

"test_contig_vs_every_other___rpow___cuda_complex64",
"test_contig_vs_every_other__refs_pow_cuda_complex64",
"test_contig_vs_every_other_pow_cuda_complex64",
"test_non_contig___rpow___cuda_complex64",
"test_non_contig__refs_pow_cuda_complex64",
"test_non_contig_pow_cuda_complex64",