### PR TITLE
add build-essential to docker file installation

### DIFF
--- a/dockerfiles/no_rocm_image_ubuntu24_04.Dockerfile
+++ b/dockerfiles/no_rocm_image_ubuntu24_04.Dockerfile
@@ -18,6 +18,7 @@ RUN sudo apt-get update -y \
     && sudo add-apt-repository -y ppa:git-core/ppa \
     && sudo apt-get update -y \
     && sudo apt-get install -y --no-install-recommends \
+    build-essential \
     curl \
     ca-certificates \
     git \


### PR DESCRIPTION
## Motivation

For libhipcxx we need to be able to compile our project with cmake. For that we need build-essential to be installed within the docker container.

## Technical Details

Installs build-essential within the tester container.

## Test Plan


## Test Result


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
