### PR TITLE
[hipDNN] Add hipdnn_test_sdk package

### DIFF
--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -192,6 +192,7 @@ if(THEROCK_ENABLE_HIPDNN)
   SUBDIRS
     .
   )
+  therock_cmake_subproject_provide_package(hipDNN hipdnn_test_sdk lib/cmake/hipdnn_test_sdk)
   therock_cmake_subproject_provide_package(hipDNN hipdnn_sdk lib/cmake/hipdnn_sdk)
   therock_cmake_subproject_provide_package(hipDNN hipdnn_frontend lib/cmake/hipdnn_frontend)
   therock_cmake_subproject_provide_package(hipDNN hipdnn_backend lib/cmake/hipdnn_backend)


### PR DESCRIPTION
## Motivation

hipDNN is splitting up the SDK into separate focused libraries (test_sdk, plugin_sdk, & data_sdk).
Adding new test_sdk package for hipDNN to enable using it in other components.

## Technical Details

Adding subproject package to hipDNN which will enable including it for plugin builds (MIOpen plugin).

## Test Plan

Build & CI passing (no functional changes).

## Test Result

Passing CI (TBD)