### PR TITLE
[CI] Use windows cluster bazelremote service for builds

### DIFF
--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -68,8 +68,8 @@ jobs:
     env:
       BUILD_DIR: B:\build
       CACHE_DIR: "${{github.workspace}}/.cache"
-      CCACHE_DIR: "${{github.workspace}}/.cache/ccache"
-      CCACHE_MAXSIZE: "4000M"
+      # The ccache.conf will be written by setup_ccache.py before this gets used.
+      CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
       TEATIME_FORCE_INTERACTIVE: 0
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
@@ -107,6 +107,13 @@ jobs:
       - name: Configure MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
+      - name: Setup ccache
+        run: |
+          ./build_tools/setup_ccache.py \
+            --config-preset "github-oss-presubmit" \
+            --dir "$(dirname $CCACHE_CONFIGPATH)" \
+            --local-path "$CACHE_DIR/ccache"
+
       - name: Runner health status
         run: |
           ccache --zero-stats
@@ -115,16 +122,6 @@ jobs:
       - name: Test build_tools
         run: |
           python -m pytest build_tools/tests build_tools/github_actions/tests
-
-      # TODO: We shouldn't be using a cache on actual release branches, but it
-      # really helps for iteration time.
-      - name: Enable cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ${{ env.CACHE_DIR }}
-          key: windows-build-packages-v4-${{ inputs.amdgpu_families }}-${{ github.sha }}
-          restore-keys: |
-            windows-build-packages-v4-${{ inputs.amdgpu_families }}-
 
       - name: Fetch sources
         timeout-minutes: 30
@@ -196,10 +193,3 @@ jobs:
             --artifact-group ${{ inputs.artifact_group }} \
             --build-dir ${{ env.BUILD_DIR }} \
             --upload
-
-      - name: Save cache
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        if: ${{ !cancelled() }}
-        with:
-          path: ${{ env.CACHE_DIR }}
-          key: windows-build-packages-v4-${{ inputs.amdgpu_families }}-${{ github.sha }}

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -115,6 +115,7 @@ jobs:
             --config-preset "github-oss-presubmit" \
             --dir "$(dirname $CCACHE_CONFIGPATH)" \
             --local-path "$CACHE_DIR/ccache"
+            --log-dir "$BUILD_DIR/logs/"
 
       - name: Runner health status
         run: |

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -114,7 +114,7 @@ jobs:
           ./build_tools/setup_ccache.py \
             --config-preset "github-oss-presubmit" \
             --dir "$(dirname $CCACHE_CONFIGPATH)" \
-            --local-path "$CACHE_DIR/ccache"
+            --local-path "$CACHE_DIR/ccache" \
             --log-dir "$BUILD_DIR/logs/"
 
       - name: Runner health status

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -69,7 +69,7 @@ jobs:
       BUILD_DIR: B:\build
       # For Windows CI, build dir must use temp disk vs. default repo workspace
       # set cache dir for setup_ccache.py to save logs in temp disk build dir for upload
-      CACHE_DIR: B:\.cache 
+      CACHE_DIR: B:\.cache
       # The ccache.conf will be written by setup_ccache.py before this gets used.
       CCACHE_CONFIGPATH: B:\.ccache\ccache.conf
       TEATIME_FORCE_INTERACTIVE: 0

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -67,9 +67,11 @@ jobs:
       fail-fast: true
     env:
       BUILD_DIR: B:\build
-      CACHE_DIR: "${{github.workspace}}/.cache"
+      # For Windows CI, build dir must use temp disk vs. default repo workspace
+      # set cache dir for setup_ccache.py to save logs in temp disk build dir for upload
+      CACHE_DIR: B:\.cache 
       # The ccache.conf will be written by setup_ccache.py before this gets used.
-      CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
+      CCACHE_CONFIGPATH: B:\.ccache\ccache.conf
       TEATIME_FORCE_INTERACTIVE: 0
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
@@ -174,8 +176,7 @@ jobs:
         run: |
           $fs = Get-PSDrive -PSProvider "FileSystem"
           $fsout = $fs | Select-Object -Property Name,Used,Free,Root
-          $fsout | % {$_.Used/=1GB;$_.Free/=1GB;$_} | Write-Host
-          get-disk | Select-object @{Name="Size(GB)";Expression={$_.Size/1GB}} | Write-Host
+          $fsout | % {$_.Used/=1GB;$_.For rat;Expression={$_.Size/1GB}} | Write-Host
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -176,7 +176,9 @@ jobs:
         run: |
           $fs = Get-PSDrive -PSProvider "FileSystem"
           $fsout = $fs | Select-Object -Property Name,Used,Free,Root
-          $fsout | % {$_.Used/=1GB;$_.For rat;Expression={$_.Size/1GB}} | Write-Host
+          $fsout | % {$_.Used/=1GB;$_.Free/=1GB;$_} | Write-Host
+          get-disk | Select-object @{Name="Size(GB)";Expression={$_.Size/1GB}} | Write-Host
+
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}

--- a/build_tools/setup_ccache.py
+++ b/build_tools/setup_ccache.py
@@ -39,14 +39,14 @@ CONFIG_PRESETS_MAP = {
     # For initial implementation, pre and post submit will be the same
     "github-oss-presubmit": {
         "secondary_storage": CACHE_SRV,
-        "log_file": REPO_ROOT / "build/logs/ccache.log",
-        "stats_log": REPO_ROOT / "build/logs/ccache_stats.log",
+        "log_file": "ccache.log",
+        "stats_log": "ccache_stats.log",
         "max_size": "5G",
     },
     "github-oss-postsubmit": {
         "secondary_storage": CACHE_SRV,
-        "log_file": REPO_ROOT / "build/logs/ccache.log",
-        "stats_log": REPO_ROOT / "build/logs/ccache_stats.log",
+        "log_file": "ccache.log",
+        "stats_log": "ccache_stats.log",
         "max_size": "5G",
     },
 }
@@ -64,7 +64,8 @@ def gen_config(dir: Path, compiler_check_file: Path, args: argparse.Namespace):
         lines.append(f"{k} = {v}")
         # Ensure full dir path for logs exists, else ccache will fail and stop CI
         if k == "log_file" or k == "stats_log":
-            log_dir = v.parent.absolute()
+            log_dir = args.log_dir / v
+            log_dir = log_dir.parent.absolute()
             if not log_dir.exists():
                 log_dir.mkdir(parents=True, exist_ok=True)
 
@@ -160,6 +161,14 @@ def main(argv: list[str]):
         default=REPO_ROOT / ".ccache",
         help="Location of the .ccache directory (defaults to ../.ccache)",
     )
+
+    p.add_argument(
+        "--log-dir",
+        type=Path,
+        default=REPO_ROOT / "build/logs/",
+        help="Location of the logs directory (defaults to ../build/logs)",
+    )
+
     p.add_argument(
         "--reset-stats",
         action=argparse.BooleanOptionalAction,


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/902 but is the Windows counterpart to https://github.com/ROCm/TheRock/pull/930
Removes the dependency on Github cache servers and their cache size limits. Standing this up in anticipation for AWS migration.

## Technical Details

Switch Windows builders to use a self hosted cache server local to the CPU builder cluster that is defined in this https://github.com/nod-ai/GitHub-ARC-Setup/pull/22 pr.

## Test Plan

Wait for CI

## Test Result

TBD from CI

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
