### PR TITLE
install_rocm_from_artifacts.py: dev_regex: match alpha releases too

### DIFF
--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -253,7 +253,7 @@ def retrieve_artifacts_by_release(args):
     artifact_group = args.artifact_group
     # Determine if version is nightly-tarball or dev-tarball
     nightly_regex_expression = (
-        "(\\d+\\.)?(\\d+\\.)?(\\*|\\d+)rc(\\d{4})(\\d{2})(\\d{2})"
+        "(\\d+\\.)?(\\d+\\.)?(\\*|\\d+)(a|rc)(\\d{4})(\\d{2})(\\d{2})"
     )
     dev_regex_expression = "(\\d+\\.)?(\\d+\\.)?(\\*|\\d+).dev0+"
     nightly_release = re.search(nightly_regex_expression, args.release) != None
@@ -262,7 +262,7 @@ def retrieve_artifacts_by_release(args):
         log("This script requires a nightly-tarball or dev-tarball version.")
         log("Please retrieve the correct release version from:")
         log(
-            "\t - https://therock-nightly-tarball.s3.amazonaws.com/ (nightly-tarball example: 6.4.0rc20250416)"
+            "\t - https://therock-nightly-tarball.s3.amazonaws.com/ (nightly-tarball examples: 6.4.0rc20250416, 7.10.0a20251024)"
         )
         log(
             "\t - https://therock-dev-tarball.s3.amazonaws.com/ (dev-tarball example: 6.4.0.dev0+8f6cdfc0d95845f4ca5a46de59d58894972a29a9)"


### PR DESCRIPTION
## Motivation

This PR modifies `install_rocm_from_artifacts.py` so that alpha releases (typical version format: `<rocm-version>a<yyyymmdd>`
are also accepted as valid argument for the `--release` switch.

## Technical Details

**Last `*rc*` tarball was for ROCm 7.0.0:**
 
I've noticed that there have not been any recent RC tarballs published, the last such tarball was released for ROCm 7.0.0.
It seems that the (a)lpha versions are now the typical TheRock nightly build output.

https://therock-nightly-tarball.s3.amazonaws.com/

## Test Plan

This PR affects a build tool. As I work for AMD, I will test this PR via an internal Jenkins pipeline and provide a link
to the build log output to another AMD reviewer that reviews this PR.

## Test Result

```log
+ install_args+=' --release 7.11.0a20251203'
+ [[ -n /secrets ]]
+ set +x
( + python3 build_tools/install_rocm_from_artifacts.py ${install_args} # log disabled because of GITHUB_TOKEN use)
### Installing TheRock using artifacts ###
Creating output directory '/opt/rocm'
Created output directory '/opt/rocm'
Retrieving artifacts from release bucket therock-nightly-tarball
Extracting therock-dist-linux-gfx90X-dcgpu-7.11.0a20251203.tar.gz to /opt/rocm
+ hipconfig
HIP version: 7.2.53150-ea50e8f03e

==hipconfig
HIP_PATH           :/opt/rocm
ROCM_PATH          :/opt/rocm
HIP_COMPILER       :clang
HIP_PLATFORM       :amd
HIP_RUNTIME        :rocclr
CPP_CONFIG         : -D__HIP_PLATFORM_HCC__= -D__HIP_PLATFORM_AMD__= -I/opt/rocm/include -I/include

==hip-clang
HIP_CLANG_PATH     :/opt/rocm/lib/llvm/bin
AMD clang version 22.0.0git (https://github.com/ROCm/llvm-project.git 8e85e3138dd485c4221cc12aff9eb60ab48ed3b5+PATCHED:371bd8145f7e4d1d481987d05427c94e17708b91)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/rocm/lib/llvm/bin
sh: 1: /opt/rocm/lib/llvm/bin/llc: not found
hip-clang-cxxflags :
 -O3
hip-clang-ldflags :
--driver-mode=g++ -O3 --hip-link

== Environment Variables
PATH =/opt/rocm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HIP_VISIBLE_DEVICES=0

== Linux Kernel
Hostname      :
hpe-hq-08
Linux hpe-hq-08 5.15.0-139-generic #149~20.04.1-Ubuntu SMP Wed Apr 16 08:29:56 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux

+ hipcc --version
HIP version: 7.2.53150-ea50e8f03e
AMD clang version 22.0.0git (https://github.com/ROCm/llvm-project.git 8e85e3138dd485c4221cc12aff9eb60ab48ed3b5+PATCHED:371bd8145f7e4d1d481987d05427c94e17708b91)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/rocm/lib/llvm/bin
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
