### PR TITLE
Add Python 3.10 Support for PyTorch Builds

### DIFF
--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.11", "3.12", "3.13"]
+        python_version: ["3.10", "3.11", "3.12", "3.13"]
         pytorch_git_ref: ["release/2.7", "release/2.8", "release/2.9", "nightly"]
         include:
           - pytorch_git_ref: release/2.7

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.11", "3.12", "3.13"]
+        python_version: ["3.10", "3.11", "3.12", "3.13"]
         pytorch_git_ref: ["release/2.9", "nightly"]
         include:
           - pytorch_git_ref: release/2.9

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -35,7 +35,7 @@ Table of contents:
 We recommend installing ROCm and projects like PyTorch via `pip`, the
 [Python package installer](https://packaging.python.org/en/latest/guides/tool-recommendations/).
 
-We currently support Python 3.11, 3.12, and 3.13.
+We currently support Python 3.10, 3.11, 3.12, and 3.13.
 
 > [!TIP]
 > We highly recommend working within a [Python virtual environment](https://docs.python.org/3/library/venv.html):

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -88,7 +88,7 @@ detailed instructions. That information is summarized here.
 
 ### Prerequisites and setup
 
-You will need a supported Python version (3.11+) on a system which we build the
+You will need a supported Python version (3.10+) on a system which we build the
 `rocm[libraries,devel]` packages for. See the
 [`RELEASES.md`: Installing releases using pip](../../RELEASES.md#installing-releases-using-pip)
 and [Python Packaging](../../docs/packaging/python_packaging.md) documentation


### PR DESCRIPTION
## Motivation

Extends PyTorch build support to include Python 3.10, enabling compatibility for users who require Python 3.10 in their environments.

## Technical Details

- Updated GitHub workflows (`release_portable_linux_pytorch_wheels.yml`, `release_windows_pytorch_wheels.yml`) to include Python 3.10 in the build matrix
- Updated documentation (`RELEASES.md`, `external-builds/pytorch/README.md`) to reflect Python 3.10+ support
- No changes needed for manylinux build configuration (already supports cp310) or CMake (minimum Python 3.9)

## Test Plan

CI/CD pipelines will be build and test PyTorch wheels for Python 3.10 alongside existing versions (3.11, 3.12, 3.13).
https://github.com/ROCm/TheRock/actions/runs/19939030860
https://github.com/ROCm/TheRock/actions/runs/19939030860/job/57171706110

## Test Result

https://github.com/ROCm/TheRock/actions/runs/19939030860
https://github.com/ROCm/TheRock/actions/runs/19939030860/job/57171706110

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.