### PR TITLE
[ci] disabling mi355 test machine due to networking issues

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -84,7 +84,9 @@ amdgpu_family_info_matrix_presubmit = {
 amdgpu_family_info_matrix_postsubmit = {
     "gfx950": {
         "linux": {
-            "test-runs-on": "linux-mi355-1gpu-ossci-rocm",
+            # Networking issue: https://github.com/ROCm/TheRock/issues/1660
+            # Label is "linux-mi355-1gpu-ossci-rocm"
+            "test-runs-on": "",
             "family": "gfx950-dcgpu",
             "build_variants": ["release", "asan"],
         }


### PR DESCRIPTION
Noticing networking issues for mi355 test machines:

Some failures:

- https://github.com/ROCm/TheRock/actions/runs/19946374074/job/57227995916
- https://github.com/ROCm/rocm-libraries/actions/runs/19947340653/job/57230395482
- https://github.com/ROCm/rocm-libraries/actions/runs/19947340653/job/57230395478
- https://github.com/ROCm/rocm-libraries/actions/runs/19946282872/job/57202817193?pr=3080
- https://github.com/ROCm/rocm-libraries/actions/runs/19946282872/job/57202817198?pr=3080

Disabling the label as I work with OSSCI to figure out networking issue. need to propagate this change to rocm-libraries as well

Issue is back open: https://github.com/ROCm/TheRock/issues/1660