### PR TITLE
Set default values for inputs in release 'run-name' fields

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -61,7 +61,7 @@ on:
 permissions:
   contents: read
 
-run-name: Release portable Linux packages (${{ inputs.families }}, ${{ inputs.release_type }})
+run-name: Release portable Linux packages (${{ inputs.families || 'default' }}, ${{ inputs.release_type || 'nightly' }})
 
 jobs:
   setup_metadata:

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -65,7 +65,7 @@ on:
 permissions:
   contents: read
 
-run-name: Release Windows packages (${{ inputs.families }}, ${{ inputs.release_type }})
+run-name: Release Windows packages (${{ inputs.families || 'default' }}, ${{ inputs.release_type || 'nightly' }})
 
 jobs:
   setup_metadata:


### PR DESCRIPTION
Following up on https://github.com/ROCm/TheRock/pull/2342#discussion_r2589945787.

This should fix scheduled runs of these workflows having just `(, )` in their run names: https://github.com/ROCm/TheRock/actions/workflows/release_portable_linux_packages.yml?query=branch%3Amain
<img width="328" height="172" alt="image" src="https://github.com/user-attachments/assets/f013f891-4927-4c14-b214-fa6846de8f40" />

Tested on my fork: https://github.com/ScottTodd/TheRock/actions/runs/19979471834
<img width="416" height="89" alt="image" src="https://github.com/user-attachments/assets/cfc99db2-b0ea-40de-ab62-32443c7ad72c" />
