### PR TITLE
SWDEV-555589 - Edit numactl source code to create libraries with updated name

### DIFF
--- a/third-party/sysdeps/linux/elfutils/patch_install.sh
+++ b/third-party/sysdeps/linux/elfutils/patch_install.sh
@@ -41,9 +41,14 @@ update_library_links() {
     if [[ "$realname" != "$dir/$lib_soname" ]]; then
         # Move the real file to $dir/$lib_soname
         mv -v -- "$realname" "$dir/$lib_soname"
-    fi
+        pushd "$dir" > /dev/null
+        ln -sf "$lib_soname" "$linker_name"
+        popd > /dev/null
+        rm "$libfile"
+    else
     # Rename symlink in the same directory
-    mv "$libfile" "$dir/$linker_name"
+        mv "$libfile" "$dir/$linker_name"
+    fi
 }
 
 update_library_links "$PREFIX/lib/librocm_sysdeps_elf.so" "libelf.so"

--- a/third-party/sysdeps/linux/libdrm/patch_install.sh
+++ b/third-party/sysdeps/linux/libdrm/patch_install.sh
@@ -5,6 +5,52 @@ set -e
 
 PREFIX="${1:?Expected install prefix argument}"
 
-# Create symbolic links for libdrm.so and libdrm_amdgpu.so.
-mv $PREFIX/lib/librocm_sysdeps_drm.so $PREFIX/lib/libdrm.so
-mv $PREFIX/lib/librocm_sysdeps_drm_amdgpu.so $PREFIX/lib/libdrm_amdgpu.so
+# update_library_links
+# ---------------------
+# Purpose:
+#   Normalize a shared library so that its real file is named exactly as its ELF SONAME,
+#   and rename the input file (usually a symlink) to a desired linker name (e.g., libfoo.so).
+#
+# Synopsis:
+#   update_library_links <libfile> <linker_name>
+#
+# Arguments:
+#   libfile      Path to the library file or symlink.
+#                Example: $PREFIX/lib/librocm_sysdeps_numa.so
+#   linker_name  Desired linker-name filename to exist in the same directory.
+#                Example: libnuma.so
+update_library_links() {
+    local libfile="$1"        # e.g. $PREFIX/lib/librocm_sysdeps_numa.so
+    local linker_name="$2"    # e.g. libnuma.so
+
+    if [ ! -e "$libfile" ]; then
+        echo "Error: File '$libfile' not found" >&2
+        return 1
+    fi
+
+    local dir="$(dirname -- "$libfile")"
+    # Get the soname and realname
+    local lib_soname="$("$PATCHELF" --print-soname "$libfile" 2>/dev/null || true)"
+    local realname="$(readlink -f -- "$libfile" 2>/dev/null || true)"
+
+    if [[ -z "$lib_soname" || -z "$realname" ]]; then
+        [[ -z "$lib_soname" ]] && echo "Error: No SONAME found in '$libfile'" >&2
+        [[ -z "$realname" ]] && echo "Error: readlink -f failed for '$libfile'" >&2
+        return 1
+    fi
+
+    if [[ "$realname" != "$dir/$lib_soname" ]]; then
+        # Move the real file to $dir/$lib_soname
+        mv -v -- "$realname" "$dir/$lib_soname"
+        pushd "$dir" > /dev/null
+        ln -sf "$lib_soname" "$linker_name"
+        popd > /dev/null
+        rm "$libfile"
+    else
+    # Rename symlink in the same directory
+        mv "$libfile" "$dir/$linker_name"
+    fi
+}
+
+update_library_links "$PREFIX/lib/librocm_sysdeps_drm.so" "libdrm.so"
+update_library_links "$PREFIX/lib/librocm_sysdeps_drm_amdgpu.so" "libdrm_amdgpu.so"

--- a/third-party/sysdeps/linux/numactl/patch_install.sh
+++ b/third-party/sysdeps/linux/numactl/patch_install.sh
@@ -3,12 +3,55 @@ set -e
 
 PREFIX="${1:?Expected install prefix argument}"
 PATCHELF="${PATCHELF:-patchelf}"
-THEROCK_SOURCE_DIR="${THEROCK_SOURCE_DIR:?THEROCK_SOURCE_DIR not defined}"
-Python3_EXECUTABLE="${Python3_EXECUTABLE:?Python3_EXECUTABLE not defined}"
 
-"$Python3_EXECUTABLE" "$THEROCK_SOURCE_DIR/build_tools/patch_linux_so.py" \
-  --patchelf "${PATCHELF}" --add-prefix rocm_sysdeps_ \
-  $PREFIX/lib/libnuma.so
+# update_library_links
+# ---------------------
+# Purpose:
+#   Normalize a shared library so that its real file is named exactly as its ELF SONAME,
+#   and rename the input file (usually a symlink) to a desired linker name (e.g., libfoo.so).
+#
+# Synopsis:
+#   update_library_links <libfile> <linker_name>
+#
+# Arguments:
+#   libfile      Path to the library file or symlink.
+#                Example: $PREFIX/lib/librocm_sysdeps_numa.so
+#   linker_name  Desired linker-name filename to exist in the same directory.
+#                Example: libnuma.so
+update_library_links() {
+    local libfile="$1"        # e.g. $PREFIX/lib/librocm_sysdeps_numa.so
+    local linker_name="$2"    # e.g. libnuma.so
+
+    if [ ! -e "$libfile" ]; then
+        echo "Error: File '$libfile' not found" >&2
+        return 1
+    fi
+
+    local dir="$(dirname -- "$libfile")"
+    # Get the soname and realname
+    local lib_soname="$("$PATCHELF" --print-soname "$libfile" 2>/dev/null || true)"
+    local realname="$(readlink -f -- "$libfile" 2>/dev/null || true)"
+
+    if [[ -z "$lib_soname" || -z "$realname" ]]; then
+        [[ -z "$lib_soname" ]] && echo "Error: No SONAME found in '$libfile'" >&2
+        [[ -z "$realname" ]] && echo "Error: readlink -f failed for '$libfile'" >&2
+        return 1
+    fi
+
+    if [[ "$realname" != "$dir/$lib_soname" ]]; then
+        # Move the real file to $dir/$lib_soname
+        mv -v -- "$realname" "$dir/$lib_soname"
+ pushd "$dir" > /dev/null
+ ln -sf "$lib_soname" "$linker_name"
+ popd > /dev/null
+ rm "$libfile"
+    else
+    # Rename symlink in the same directory
+        mv "$libfile" "$dir/$linker_name"
+    fi
+}
+
+update_library_links "$PREFIX/lib/librocm_sysdeps_numa.so" "libnuma.so"
 
 # pc files are not output with a relative prefix. Sed it to relative.
 sed -i -E 's|^prefix=.+|prefix=${pcfiledir}/../..|' $PREFIX/lib/pkgconfig/*.pc

--- a/third-party/sysdeps/linux/numactl/patch_source.sh
+++ b/third-party/sysdeps/linux/numactl/patch_source.sh
@@ -2,7 +2,12 @@
 set -e
 
 SOURCE_DIR="${1:?Source directory must be given}"
+NUMACTL_MAKEFILE="$SOURCE_DIR/Makefile.am"
 
 echo "Patching sources..."
+sed -i 's/libnuma\.la/librocm_sysdeps_numa.la/g' "$NUMACTL_MAKEFILE"
+sed -i 's/libnuma_la_SOURCES/librocm_sysdeps_numa_la_SOURCES/g' "$NUMACTL_MAKEFILE"
+sed -i 's/libnuma_la_LDFLAGS/librocm_sysdeps_numa_la_LDFLAGS/g' "$NUMACTL_MAKEFILE"
+
 sed -i -E 's|\b(libnuma_)|AMDROCM_SYSDEPS_1.0_\1|' $SOURCE_DIR/versions.ldscript
 sed -i -E 's|@(libnuma_)|@AMDROCM_SYSDEPS_1.0_\1|' $SOURCE_DIR/*.c


### PR DESCRIPTION
The renamed and patchelf‑edited libraries in ROCk artifacts do not provide the symbol version tag, which was causing RPM package installation failures. The patch will create the numactl library with the prefix "librocm_sysdeps_" in its name, and patchelf editing will no longer be required.

Corrected the library link normalization in libdrm and elfutils as well
lib<originalname>.so -> lib<rocm_sysdeps_originalname>.so.x
lib<rocm_sysdeps_originalname>.so.x
## Motivation

The patchelf edited libraries are not providing the symbol version tag

## Technical Details

Rather than editing libraries to update soname , create libraries with the updated name by editing the target name in source code

## Test Plan

Verify the soname and elfdeps provides field of the libraries.

## Test Result
Required symbol version tags are provided by the libraries

**Before applying the patch:**
readelf -d libnuma.so | grep soname
 0x000000000000000e (SONAME)             Library soname: [librocm_sysdeps_numa.so.1]

/usr/lib/rpm/elfdeps --provides libnuma.so 
libnuma.so.1(AMDROCM_SYSDEPS_1.0_libnuma_1.1)(64bit)
libnuma.so.1(AMDROCM_SYSDEPS_1.0_libnuma_1.2)(64bit)
libnuma.so.1(AMDROCM_SYSDEPS_1.0_libnuma_1.2)(64bit)
librocm_sysdeps_numa.so.1()(64bit)

**After applying the patch:**
readelf -d libnuma.so | grep soname
 0x000000000000000e (SONAME)             Library soname: [librocm_sysdeps_numa.so.1]

/usr/lib/rpm/elfdeps --provides libnuma.so 
**librocm_sysdeps_numa.so.1**(AMDROCM_SYSDEPS_1.0_libnuma_1.1)(64bit)
**librocm_sysdeps_numa.so.1**(AMDROCM_SYSDEPS_1.0_libnuma_1.2)(64bit)
librocm_sysdeps_numa.so.1(AMDROCM_SYSDEPS_1.0_libnuma_1.2)(64bit)
librocm_sysdeps_numa.so.1()(64bit)

Full detailed readelf output:
https://github.com/user-attachments/files/24020140/TestResults.txt

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
