### PR TITLE
(Do not review) Fix #2460: Add developer-friendly defaults to build_configure.py

### DIFF
--- a/build_tools/github_actions/build_configure.py
+++ b/build_tools/github_actions/build_configure.py
@@ -124,8 +124,7 @@ if __name__ == "__main__":
         try:
             default_package_version = compute_version(release_type="dev")
         except Exception:
-            # Fallback to 0.0.0 if compute_version fails
-            default_package_version = "0.0.0"
+            default_package_version = "ADHOCBUILD"
 
     parser.add_argument(
         "--package-version",


### PR DESCRIPTION
## Motivation

It is important to reproduce the number of background jobs used by CI as used by local build. One of the steps is to run python script **build_tools\github_actions\build_configure.py**. However, when running it, issue #2460 is observed.

## Technical Details

Set package_version default to "0.0.0"
Set extra_cmake_options default to empty string
Set build_dir default to "build"
but require user to set amdgpu_families

## Test Plan

1) Set amdgpu_familie then follow the 7 steps mentioned in issue #2460, observe the config for build is created
2) Unset amdgpu_familie then follow the 7 steps mentioned in issue #2460, observe the error caused by exception which says **Missing required environment variables amdgpu_familie**

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
