### PR TITLE
Revert "Redirect base exec path for Python CLI scripts if `rocm[devel]` is installed"

### DIFF
--- a/build_tools/packaging/python/templates/rocm-sdk-core/src/rocm_sdk_core/_cli.py
+++ b/build_tools/packaging/python/templates/rocm-sdk-core/src/rocm_sdk_core/_cli.py
@@ -1,7 +1,6 @@
 """Trampoline for console scripts."""
 
 import importlib
-import importlib.util
 import os
 import platform
 import sys
@@ -10,71 +9,17 @@ from pathlib import Path
 from ._dist_info import ALL_PACKAGES
 
 CORE_PACKAGE = ALL_PACKAGES["core"]
-CORE_PY_PACKAGE_NAME = CORE_PACKAGE.get_py_package_name()
-
-
-def _get_core_module_path():
-    # NOTE: dependent on there being an __init__.py in the core package.
-    core_module = importlib.import_module(CORE_PY_PACKAGE_NAME)
-    return Path(core_module.__file__).parent
-
-
-DEVEL_PACKAGE = ALL_PACKAGES["devel"]
-DEVEL_PURE_PY_PACKAGE_NAME = DEVEL_PACKAGE.pure_py_package_name
-DEVEL_PY_PACKAGE_NAME = DEVEL_PACKAGE.get_py_package_name()
-
-
-def _have_devel_module():
-    return importlib.util.find_spec(DEVEL_PURE_PY_PACKAGE_NAME) is not None
-
-
-def _is_devel_module_expanded():
-    return importlib.util.find_spec(DEVEL_PY_PACKAGE_NAME) is not None
-
-
-def _expand_devel_module():
-    import subprocess
-
-    subprocess.check_call([sys.executable, "-P", "-m", "rocm_sdk", "init", "--quiet"])
-
-
-def _get_devel_module_path():
-    # NOTE: dependent on there being an __init__.py in the devel package.
-    devel_module = importlib.import_module(DEVEL_PY_PACKAGE_NAME)
-    return Path(devel_module.__file__).parent
-
-
-def _get_module_path(should_expand_devel: bool) -> Path:
-    """Gets the module path, either from 'core' or 'devel'.
-
-    If the 'devel' package IS NOT installed then 'core' is used.
-    If the 'devel' package IS installed AND already expanded then it is used.
-    If the 'devel' package IS installed AND NOT already expanded then either
-      A) System information tools like amd-smi can choose to run more quickly
-         with 'core' by skipping the (compute-intensive) 'devel' expansion.
-         These tools should pass `should_expand_devel=False`.
-      B) Other tools that benefit from the extra files in the 'devel' package
-         will expand expand it by passing `should_expand_devel=True`.
-    """
-    if _have_devel_module():
-        if _is_devel_module_expanded():
-            return _get_devel_module_path()
-        elif should_expand_devel:
-            _expand_devel_module()
-            return _get_devel_module_path()
-        else:
-            # Passthrough. Fallback to core module.
-            pass
-
-    return _get_core_module_path()
-
+PLATFORM_NAME = CORE_PACKAGE.get_py_package_name()
+PLATFORM_MODULE = importlib.import_module(PLATFORM_NAME)
+# NOTE: dependent on there being an __init__.py in the platform package.
+PLATFORM_PATH = Path(PLATFORM_MODULE.__file__).parent
 
 is_windows = platform.system() == "Windows"
 exe_suffix = ".exe" if is_windows else ""
 
 
-def _exec(relpath: str, should_expand_devel=True):
-    full_path = _get_module_path(should_expand_devel) / (relpath + exe_suffix)
+def _exec(relpath: str):
+    full_path = PLATFORM_PATH / (relpath + exe_suffix)
     os.execv(full_path, [str(full_path)] + sys.argv[1:])
 
 
@@ -103,7 +48,7 @@ def amdlld():
 
 
 def amd_smi():
-    _exec("bin/amd-smi", should_expand_devel=False)
+    _exec("bin/amd-smi")
 
 
 def hipcc():
@@ -123,7 +68,7 @@ def hipify_perl():
 
 
 def hipInfo():
-    _exec("bin/hipInfo", should_expand_devel=False)
+    _exec("bin/hipInfo")
 
 
 def offload_arch():
@@ -131,12 +76,12 @@ def offload_arch():
 
 
 def rocm_agent_enumerator():
-    _exec("bin/rocm_agent_enumerator", should_expand_devel=False)
+    _exec("bin/rocm_agent_enumerator")
 
 
 def rocm_info():
-    _exec("bin/rocminfo", should_expand_devel=False)
+    _exec("bin/rocminfo")
 
 
 def rocm_smi():
-    _exec("bin/rocm-smi", should_expand_devel=False)
+    _exec("bin/rocm-smi")

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
@@ -42,10 +42,9 @@ def _do_init(args: argparse.Namespace):
         # if contents for development were not yet unpacked.
         root_path = _devel.get_devel_root()
     except ModuleNotFoundError as e:
-        print(f"ERROR running init: {e}", file=sys.stderr)
+        print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(1)
-    if not args.quiet:
-        print(f"Devel contents expanded to '{root_path}'")
+    print(f"Devel contents expanded to '{root_path}'")
 
 
 def _do_test(args: argparse.Namespace):
@@ -144,11 +143,6 @@ def main(argv: list[str] | None = None):
     # 'init' subcommand.
     init_p = sub_p.add_parser(
         "init", help="Expand devel contents to initialize rocm[devel]"
-    )
-    init_p.add_argument(
-        "--quiet",
-        action="store_true",
-        help="Run without producing output",
     )
     init_p.set_defaults(func=_do_init)
 

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -47,7 +47,7 @@ def get_devel_root() -> Path:
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError(
             "ROCm SDK development package is not installed. This can typically be "
-            "obtained by installing `rocm[devel]` from your package manager"
+            "obtained by installing `rocm-sdk[devel]` from your package manager"
         ) from e
     rocm_sdk_devel_path = _get_package_path(rocm_sdk_devel)
     if rocm_sdk_devel_path is None:
@@ -93,7 +93,7 @@ def _expand_devel_contents(rocm_sdk_devel_path: Path, site_lib_path: Path):
     # to preserve fail-fast behavior
     assert len(dist_names_list) >= 1, (
         "No distribution candidates found for 'rocm_sdk_devel'. "
-        "Ensure rocm[devel] is installed in the current environment."
+        "Ensure rocm-sdk[devel] is installed in the current environment."
     )
     # Try to find candidates until found one with files and a usable RECORD
     record_pkg_file = None
@@ -121,9 +121,9 @@ def _expand_devel_contents(rocm_sdk_devel_path: Path, site_lib_path: Path):
 
     if dist_files is None:
         raise ImportError(
-            "Cannot expand the `rocm[devel]` package because it was not installed "
+            "Cannot expand the `rocm-sdk[devel]` package because it was not installed "
             "by a user-mode package manager and is managed by the system. Please "
-            "install the `rocm` in a virtual environment."
+            "install the `rocm-sdk` in a virtual environment."
         )
 
     if dist_name is None or record_pkg_file is None:

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/devel_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/devel_test.py
@@ -78,28 +78,6 @@ class ROCmDevelTest(unittest.TestCase):
         bin_path = path / "bin"
         self.assertTrue(bin_path.exists(), msg=f"Expected bin path {bin_path} to exist")
 
-    def testCLIUsesDevelRootPath(self):
-        root_path_output = (
-            utils.exec(
-                [sys.executable, "-P", "-m", "rocm_sdk", "path", "--root"], capture=True
-            )
-            .decode()
-            .strip()
-        )
-        root_path = Path(root_path_output)
-
-        # CLI scripts by default run from _rocm_sdk_core.
-        # When the devel package is installed they should run from _rocm_sdk_devel.
-        rocmpath_output = (
-            utils.exec(["hipconfig", "--rocmpath"], capture=True).decode().strip()
-        )
-        rocmpath = Path(rocmpath_output)
-        self.assertEqual(
-            root_path,
-            rocmpath,
-            msg=f"Expected `hipconfig --rocmpath` to return {root_path}, not {rocmpath}",
-        )
-
     @unittest.skipIf(
         platform.system() == "Windows", "root LLVM symlink only exists on Linux"
     )


### PR DESCRIPTION
Reverts ROCm/TheRock#2428

See https://github.com/ROCm/TheRock/pull/2428#discussion_r2599650550. The new test fails on Linux:
```bash 
python3.12 -m venv 3.12.venv && source 3.12.venv/bin/activate
python -m pip install --index-url=https://rocm.nightlies.amd.com/v2-staging/gfx110X-all rocm[libraries,devel]
# Successfully installed rocm-7.11.0a20251208 rocm-sdk-core-7.11.0a20251208 rocm-sdk-devel-7.11.0a20251208 rocm-sdk-libraries-gfx110X-all-7.11.0a20251208

rocm-sdk test

...

======================================================================
FAIL: testCLIUsesDevelRootPath (rocm_sdk.tests.devel_test.ROCmDevelTest.testCLIUsesDevelRootPath)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nod/dev/scratch/therock/3.12.venv/lib/python3.12/site-packages/rocm_sdk/tests/devel_test.py", line 97, in testCLIUsesDevelRootPath
    self.assertEqual(
AssertionError: Posix[29 chars]herock/3.12.venv/lib/python3.12/site-packages/_rocm_sdk_devel') != Posix[29 chars]herock/3.12.venv/lib/python3.12/site-packages/_rocm_sdk_core') : Expected `hipconfig --rocmpath` to return /home/nod/dev/scratch/therock/3.12.venv/lib/python3.12/site-packages/_rocm_sdk_devel, not /home/nod/dev/scratch/therock/3.12.venv/lib/python3.12/site-packages/_rocm_sdk_core

----------------------------------------------------------------------
Ran 26 tests in 3.900s

FAILED (failures=1, skipped=2)
```


This is because the `rocm[devel]` Python package uses symlinks on Linux while it uses hardlinks on Windows and the symlinks still report their install path as `_rocm_sdk_core`.

I'm considering a few ways to fix this (https://github.com/ROCm/TheRock/issues/1880#issuecomment-3628650180), but I'll just revert for now.