### PR TITLE
[ci] Adding ASAN builds as nightly only until reasonable

### DIFF
--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -62,7 +62,7 @@ jobs:
     # azure-linux-scale-rocm-heavy are used for CI builds that require more resources (ex: ASAN builds)
     runs-on: ${{ inputs.build_variant_label == 'asan' && 'azure-linux-u2404-hx176-cpu-rocm' || 'azure-linux-scale-rocm' }}
     continue-on-error: ${{ inputs.expect_failure }}
-    timeout-minutes: 1440 # 24 hour timeout
+    timeout-minutes: 720 # 12 hour timeout
     permissions:
       id-token: write
     container:
@@ -128,19 +128,7 @@ jobs:
 
       - name: Build therock-archives and therock-dist
         run: |
-          # Background telemetry loop
-            ( while true; do
-                echo "--- $(date) ---"
-                free -h
-                top -b -n1 | head -20
-                sleep 30
-              done ) &
-            TELEMETRY_PID=$!
-
-          cmake --build build --target therock-archives therock-dist -- -k 0 -j32
-
-          # Stop telemetry loop
-          kill $TELEMETRY_PID
+          cmake --build build --target therock-archives therock-dist -- -k 0
 
       - name: Test Packaging
         if: ${{ github.event.repository.name == 'TheRock' }}

--- a/.github/workflows/ci_asan.yml
+++ b/.github/workflows/ci_asan.yml
@@ -1,9 +1,8 @@
 name: CI ASAN
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: "0 2 * * *" # Runs nightly at 2 AM UTC
   workflow_dispatch:
     inputs:
       linux_amdgpu_families:


### PR DESCRIPTION
Currently, ASAN builds run for pushes to main. They consistently fail due to OOM errors for the current CPU builders.

The runners that @amd-justchen and I provisioned provide a consistent ASAN run going without OOM issues.

From our research and investigation, the peak memory usage for ASAN is ~ 800 GB. These runs also take 9 hours, so we will limit to nightly runs until we are able to get the times / memory to a reasonable limit. 

With #2453 , we will able to get memory logs as well

CI asan test here: https://github.com/ROCm/TheRock/actions/runs/20041915040 (cancelled it though as don't need to run another 9 hour build)

<br/>

<u>Data from CI ASAN full run</u>

logs from S3: https://[therock-ci-artifacts.s3.amazonaws.com/19940830603-linux/logs/gfx94X-dcgpu-asan/index.html](https://therock-ci-artifacts.s3.amazonaws.com/19940830603-linux/logs/gfx94X-dcgpu-asan/index.html)

[Build logs from CI](https://github.com/user-attachments/files/24041078/2_Linuxgfx94X-dcgpuasan._.Build.Artifacts._.Build.xfail.true.txt)

