### PR TITLE
 Add tooling for therock build resource observability

### DIFF
--- a/build_tools/resource_info.py
+++ b/build_tools/resource_info.py
@@ -200,7 +200,7 @@ def _repo_root() -> Path:
 def load_components_from_build_topology(repo_root: Path) -> List[str]:
     """
     Extract component/artifact names from BUILD_TOPOLOGY.toml and print them.
-    TODO: explore use of build_topology.py, get_artifact_groups() 
+    TODO: explore use of build_topology.py, get_artifact_groups()
     or other accessors on the BuildTopology classfor this
     """
     topo_path = repo_root / "BUILD_TOPOLOGY.toml"
@@ -242,11 +242,13 @@ def get_topology_components_cached(repo_root: Path) -> List[str]:
     return TOPOLOGY_COMPONENTS_CACHE
 
 
-def therock_components_compile_classifier(repo_root: Path, _pwd_unused: str, cmd_str: str) -> str:
+def therock_components_compile_classifier(
+    repo_root: Path, _pwd_unused: str, cmd_str: str
+) -> str:
     """
-    Classify a compile/link command into a TheRock component. 
+    Classify a compile/link command into a TheRock component.
     This is needed to figure out which TheRock component a compiler
-    command belongs to, even when CMake/Ninja hides that 
+    command belongs to, even when CMake/Ninja hides that
     information behind indirection.
     """
     comp = "unknown"
@@ -511,7 +513,7 @@ def generate_summaries(log_dir: str) -> None:
 
     for log_path in Path(log_dir).glob("*.log"):
         parse_log_file(log_path, stats, events)
-    
+
     repo_root = _repo_root()
     topo = get_topology_components_cached(repo_root)
     seen = {key[0] for key in stats.keys() if key[1] == "_seen"}


### PR DESCRIPTION
## Motivation

Bringing in observability for different component builds under therock, eg: avg_threads, cpu_sum, user_sum, real_sum, max_rss 

the end report will eventually be: https://github.com/ROCm/TheRock/blob/88d28d496452ad6b5542b0c108635f7964ef23ef/build_tools/comp-summary.md(html)  + https://therock-ci-artifacts.s3.amazonaws.com/19938970730-linux/logs/gfx1151/build_time_analysis.html  and  the html report renamed to therock_build_observability.html

Eventually the goal is to bring in "**buildtime and resource utilization observability**" under **single pane of view** as part of https://therock-ci-artifacts.s3.amazonaws.com/19938970730-linux/logs/gfx1151/build_time_analysis.html 

issue: https://github.com/ROCm/TheRock/issues/2788 

## Technical Details

This Python tool updates the compiler during TheRock’s build so it can measure every compile command’s wall time, CPU time, and memory usage while writing lightweight logs and then automatically generate component-level summaries of the entire build.

At the end of the build it produces CSV and Markdown report showing how much time, CPU, memory, and effective parallelism each build component consumed, giving you a clear breakdown of which parts of the build are expensive and why.

Usage in CMake configure:

```
  cmake -S . -B build -GNinja \
    -DTHEROCK_AMDGPU_FAMILIES=gfx110X-all \
    -DCMAKE_C_COMPILER_LAUNCHER="${PWD}/build_tools/resource_info.py" \
    -DCMAKE_CXX_COMPILER_LAUNCHER="${PWD}/build_tools/resource_info.py"
```
 

`cmake --build build `
          OR 
`ninja -C build -j"$(nproc)"`

when the build is completed as normal the final python tool runs after to generate the report in form of (html and md). this way there is no race conditions while creating the report when the build is happening. 

python3 build_tools/resource_info.py --finalize

## Test Plan
local build verified. 
regular CI checks after integrating with ci worlflow

## sample output: shared via teams chat

python3 build_tools/resource_info.py --finalize

```
[TheRock] Components derived from BUILD_TOPOLOGY.toml (artifacts.*):
amd-llvm, base, blas, composable-kernel, core-hip, core-hipinfo, core-hiptests, core-ocl, core-runtime, fft, fftw3, flatbuffers, fmt, fusilli-plugin, hipdnn, hipify, host-blas, host-suite-sparse, miopen, miopen-plugin, nlohmann-json, prim, rand, rccl, rdc, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems, rocrtst, rocwmma, spdlog, support, sysdeps, sysdeps-amd-mesa


```
[TheRock Build Summary]
HTML (absolute URI): file:///home/shiraz/amd/TheRock/build/logs/therock-build-prof/comp-summary.html
Markdown: /home/shiraz/amd/TheRock/build/logs/therock-build-prof/comp-summary.md
```
```

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
