### PR TITLE
Update Upload jax wheels to s3

### DIFF
--- a/.github/workflows/build_linux_jax_wheels.yml
+++ b/.github/workflows/build_linux_jax_wheels.yml
@@ -62,10 +62,13 @@ on:
         type: string
         default: "3.12"
       release_type:
-        description: The type of release to build ("dev", "nightly", or "prerelease"). All developer-triggered jobs should use "dev"!
-        required: true
-        type: string
-        default: "dev"
+        type: choice
+        description: Type of release to create. All developer-triggered jobs should use "dev"!
+        options:
+          - dev
+          - nightly
+          - prerelease
+        default: dev
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family
         type: string
@@ -83,11 +86,11 @@ on:
       cloudfront_url:
         description: CloudFront base URL pointing to Python index
         type: string
-        default: "https://rocm.nightlies.amd.com/v2"
+        default: "https://rocm.devreleases.amd.com/v2"
       cloudfront_staging_url:
         description: CloudFront base URL pointing to staging Python index
         type: string
-        default: "https://rocm.nightlies.amd.com/v2-staging"
+        default: "https://rocm.devreleases.amd.com/v2-staging"
       jax_ref:
         description: rocm-jax repository ref/branch to check out
         type: string
@@ -111,7 +114,7 @@ jobs:
       S3_BUCKET_PY: "therock-${{ inputs.release_type }}-python"
     outputs:
       cp_version: ${{ env.cp_version }}
-      jax_version: ${{ steps.extract_jax_version.outputs.jax_version }} 
+      jax_version: ${{ steps.extract_jax_version.outputs.jax_version }}
     steps:
       - name: Checkout TheRock
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1


### PR DESCRIPTION
## Motivation
Adding Upload Jax wheels to S3 v2 location after testing.
Support jax for build and release https://github.com/ROCm/TheRock/issues/1985

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

After tests Pass successfully for the built wheels. Adding a Stage 

- upload_jax_wheels
- Test jax wheels from v2-staging
- Wheels tested successfully are uploaded to v2 
<img width="342" height="326" alt="image" src="https://github.com/user-attachments/assets/8c245bcb-7bbf-408e-9b85-be7a08ba7169" />


<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- [X] Test in workflow

## Test Result
https://github.com/ROCm/TheRock/actions/runs/20078608865/job/57609026693
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
