### PR TITLE
Introduce CODEOWNERS for reviewer assignment of submodule updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Regularly updated submodules
+/rocm-libraries/        @ROCm/TheRockInfra
+/rocm-systems/          @ROCm/TheRockInfra

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  # Submodules that can be updated independently from other submodules
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
@@ -19,8 +21,4 @@ updates:
     target-branch: "main"
     allow:
       - dependency-name: "rocm-systems"
-    reviewers:
-      - "ScottTodd"
-      - "marbre"
-      - "geomin12"
     open-pull-requests-limit: 10

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -125,6 +125,8 @@ SKIPPABLE_PATH_PATTERNS = [
     "*.gitignore",
     "*.md",
     "*.pre-commit-config.*",
+    ".github/dependabot.yml",
+    "*CODEOWNERS",
     "*LICENSE",
     # Changes to 'external-builds/' (e.g. PyTorch) do not affect "CI" workflows.
     # At time of writing, workflows run in this sequence:


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/223.

As reported at https://github.com/ROCm/TheRock/pull/2400#discussion_r2586605066, dependabot no longer supports the `reviewers` field and instead suggests that projects use `CODEOWNERS`: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/.