### PR TITLE
[ci] Fixing datetime for `install_rocm_from_artifacts.py` python3.10 compatibility

### DIFF
--- a/build_tools/github_actions/github_actions_utils.py
+++ b/build_tools/github_actions/github_actions_utils.py
@@ -221,7 +221,7 @@ def retrieve_bucket_info(
             workflow_run["updated_at"], "%Y-%m-%dT%H:%M:%SZ"
         )
         curr_commit_dt = curr_commit_dt.replace(tzinfo=timezone.utc)
-        commit_to_compare_dt = datetime.fromisoformat("2025-11-11 08:18:48 -0800")
+        commit_to_compare_dt = datetime.fromisoformat("2025-11-11T16:18:48+00:00")
     else:
         is_pr_from_fork = os.getenv("IS_PR_FROM_FORK", "false") == "true"
         _log(f"  (implicit) is_pr_from_fork  : {is_pr_from_fork}")


### PR DESCRIPTION
## Motivation

Specific date time does not work for py3.10

## Technical Details

Updating correct datetime

## Test Plan

local testing

## Test Result

py3.12
```
(.venv) geom@geom:~/Code/TheRock$ python --version
Python 3.12.3
(.venv) geom@geom:~/Code/TheRock$ python build_tools/install_rocm_from_artifacts.py --run-id 19767587598 --amdgpu-family gfx94X-dcgpu --base-only
...
Retrieving bucket info...
  (implicit) github_repository: ROCm/TheRock
  workflow_run_id             : 19767587598
...
Retrieving S3 artifacts for 19767587598 in 'therock-ci-artifacts' at '19767587598-linux'

Filtered artifacts to download:
  therock-ci-artifacts:19767587598-linux/amd-llvm_lib_generic.tar.xz
  therock-ci-artifacts:19767587598-linux/amd-llvm_run_generic.tar.xz
  therock-ci-artifacts:19767587598-linux/base_lib_generic.tar.xz
  therock-ci-artifacts:19767587598-linux/base_run_generic.tar.xz
  therock-ci-artifacts:19767587598-linux/core-hip_dev_generic.tar.xz
```

py3.10
```
(venv-3.10) geom@geom:~/Code/TheRock$ python --version
Python 3.10.19
(venv-3.10) geom@geom:~/Code/TheRock$ python build_tools/install_rocm_from_artifacts.py --run-id 19767587598 --amdgpu-family gfx94X-dcgpu --base-only
...
Retrieving bucket info...
  (implicit) github_repository: ROCm/TheRock
  workflow_run_id             : 19767587598
...
Retrieving S3 artifacts for 19767587598 in 'therock-ci-artifacts' at '19767587598-linux'

Filtered artifacts to download:
  therock-ci-artifacts:19767587598-linux/amd-llvm_lib_generic.tar.xz
  therock-ci-artifacts:19767587598-linux/amd-llvm_run_generic.tar.xz
  therock-ci-artifacts:19767587598-linux/base_lib_generic.tar.xz
  therock-ci-artifacts:19767587598-linux/base_run_generic.tar.xz
  therock-ci-artifacts:19767587598-linux/core-hip_dev_generic.tar.xz
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
