### PR TITLE
Add simde as a dependency for ocl-clr

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -309,6 +309,7 @@ if(THEROCK_ENABLE_OCL_RUNTIME)
       ${OCL_CLR_CMAKE_ARGS}
     BUILD_DEPS
       rocm-cmake
+      therock-simde
     RUNTIME_DEPS
       amd-llvm
       amd-comgr


### PR DESCRIPTION
## Motivation
simde has already been added as dependency for hip-clr here https://github.com/ROCm/TheRock/pull/2081 
It needs to be added for ocl-clr as well.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Added therock-simde into BUILD_DEPS for ocl-clr
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
This PR should pass rock-ci https://github.com/ROCm/rocm-systems/pull/500
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
This PR should pass rock-ci https://github.com/ROCm/rocm-systems/pull/500
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
