### PR TITLE
[third-party] Add fingerprinting to libbacktrace

### DIFF
--- a/third-party/sysdeps/common/libbacktrace/CMakeLists.txt
+++ b/third-party/sysdeps/common/libbacktrace/CMakeLists.txt
@@ -14,6 +14,8 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     )
 
     therock_cmake_subproject_declare(therock-libbacktrace
+      FPRINT_SOURCE_DIR "${_source_dir}"
+      FPRINT_FILE_GLOBS "${CMAKE_CURRENT_LIST_DIR}/*"
       EXTERNAL_SOURCE_DIR .
       BINARY_DIR build
       NO_MERGE_COMPILE_COMMANDS


### PR DESCRIPTION
Fingerprinting was introduced by commit 77f0cb2112d1d0aaae0de6088a6e4337f2488233.

All the sysdeps have been updated to contain fingerprinting, except libbacktrace. Add fingerprinting to libbacktrace as well so we can cache artifacts in the future.