### PR TITLE
[ci] Adding `sanity_check_only` for gfx1150 and gfx1153 Linux

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -170,7 +170,7 @@ amdgpu_family_info_matrix_nightly = {
             "test-runs-on": "linux-gfx1150-gpu-rocm",
             "family": "gfx1150",
             "build_variants": ["release"],
-            "sanity_check_only_for_family": True
+            "sanity_check_only_for_family": True,
         },
         "windows": {
             "test-runs-on": "",
@@ -198,7 +198,7 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx1153",
             "expect_failure": True,
             "build_variants": ["release"],
-            "sanity_check_only_for_family": True
+            "sanity_check_only_for_family": True,
         },
         "windows": {
             "test-runs-on": "",


### PR DESCRIPTION
## Motivation

- we only have two runners for gfx1150 Linux, causing a huge amount of failures in CI nightly (https://github.com/ROCm/TheRock/actions/runs/20218733149), with machines crashing. We are planning to run sanity checks only until we are able to onboard more machines
- gfx1153 Linux builds are failing, but would run into the same scenario as Linux gfx1150

## Technical Details

Just updating `amdgpu_family_matrix.py` to reflect changes

## Test Plan

presubmit CI will test this

## Test Result

presubmit CI will test this

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
