### PR TITLE
[ROCm SDK Tests] skip loading rocprim unit test libraries

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
@@ -109,7 +109,7 @@ class ROCmCoreTest(unittest.TestCase):
                 # Internal rocprofiler-sdk libraries are meant to be pre-loaded
                 # explicitly and cannot necessarily be loaded standalone.
                 continue
-            if ("libtest_linking_lib" in str(so_path)):
+            if "libtest_linking_lib" in str(so_path):
                 # rocprim unit tests, not actual library files
                 continue
             with self.subTest(msg="Check shared library loads", so_path=so_path):

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/devel_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/devel_test.py
@@ -142,7 +142,7 @@ class ROCmDevelTest(unittest.TestCase):
                 # Internal rocprofiler-sdk libraries are meant to be pre-loaded
                 # explicitly and cannot necessarily be loaded standalone.
                 continue
-            if ("libtest_linking_lib" in str(so_path)):
+            if "libtest_linking_lib" in str(so_path):
                 # rocprim unit tests, not actual library files
                 continue
             with self.subTest(msg="Check shared library loads", so_path=so_path):


### PR DESCRIPTION
- Manual execution of `rocm-sdk test` is running into issues with loading `.so` files used in rocprim unit tests to guard against versions.
- Skip these libraries in the Python SDK tests.
- To use these libraries, call the rocprim unit tests.