### PR TITLE
Update docs to require gcc for tarball installations

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -370,6 +370,9 @@ Standalone "ROCm SDK tarballs" are assembled from the same
 [installed using pip](#installing-releases-using-pip), without the additional
 wrapper Python wheels or utility scripts.
 
+> [!NOTE]
+> Tarball installations require `gcc` to be installed on your system.
+
 ### Installing release tarballs
 
 Release tarballs are automatically uploaded to AWS S3 buckets.


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

On a fresh system without GCC, users installing with our tarball method will run into issues such as: https://github.com/ROCm/TheRock/issues/2518. This isn't a problem when installing via wheels as pip requires build-essentials which bundles gcc. 

Updated our docs to inform users that gcc needs to be installed when using the tarball. I could also add instructions on how to install gcc by OS but wasn't sure if that was necessary.