### PR TITLE
sqlite version upgrade needed to fix BDBA high violation

### DIFF
--- a/third-party/sysdeps/common/sqlite3/CMakeLists.txt
+++ b/third-party/sysdeps/common/sqlite3/CMakeLists.txt
@@ -5,9 +5,9 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 
     therock_subproject_fetch(therock-sqlite3-sources
       SOURCE_DIR "${_source_dir}"
-      # Originally mirrored from: "https://www.sqlite.org/2025/sqlite-amalgamation-3490100.zip"
-      URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/sqlite-amalgamation-3490100.zip"
-      URL_HASH "SHA256=6cebd1d8403fc58c30e93939b246f3e6e58d0765a5cd50546f16c00fd805d2c3"
+      # Originally mirrored from: "https://www.sqlite.org/2025/sqlite-amalgamation-3500400.zip"
+      URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/sqlite-amalgamation-3500400.zip"
+      URL_HASH "SHA256=1d3049dd0f830a025a53105fc79fd2ab9431aea99e137809d064d8ee8356b032"
       TOUCH "${_download_stamp}"
     )
 


### PR DESCRIPTION
## Motivation

Sqlite version 3.49 used by TheRock has a high severity BDBA violation http://protecode-sc.amd.com/#/vulnerabilities/BDSA-2025-11433 

The fix for that violation is in sqlite version 3.50.4.

This PR addresses the issue

## Technical Details

update sqlite from https://www.sqlite.org/2025/sqlite-amalgamation-3500400.zip

SHA256 verification steps:

certutil -hashfile sqlite-amalgamation-3500400.zip SHA256
SHA256 hash of sqlite-amalgamation-3500400.zip:
1d3049dd0f830a025a53105fc79fd2ab9431aea99e137809d064d8ee8356b032

## Test Plan

CI tests runs for all arch types as part of PR checks

## Test Result

CI tests passing for all arch types in PR

## Submission Checklist

- [X ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
