### PR TITLE
Add Python 3.10 Support for PyTorch Builds

### DIFF
--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.11", "3.12", "3.13"]
+        python_version: ["3.10", "3.11", "3.12", "3.13"]
         pytorch_git_ref: ["release/2.7", "release/2.8", "release/2.9", "nightly"]
         include:
           - pytorch_git_ref: release/2.7

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.11", "3.12", "3.13"]
+        python_version: ["3.10", "3.11", "3.12", "3.13"]
         pytorch_git_ref: ["release/2.9", "nightly"]
         include:
           - pytorch_git_ref: release/2.9

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -38,7 +38,7 @@ Table of contents:
 We recommend installing ROCm and projects like PyTorch via `pip`, the
 [Python package installer](https://packaging.python.org/en/latest/guides/tool-recommendations/).
 
-We currently support Python 3.11, 3.12, and 3.13.
+We currently support Python 3.10, 3.11, 3.12, and 3.13.
 
 > [!TIP]
 > We highly recommend working within a [Python virtual environment](https://docs.python.org/3/library/venv.html):

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -88,7 +88,7 @@ detailed instructions. That information is summarized here.
 
 ### Prerequisites and setup
 
-You will need a supported Python version (3.11+) on a system which we build the
+You will need a supported Python version (3.10+) on a system which we build the
 `rocm[libraries,devel]` packages for. See the
 [`RELEASES.md`: Installing releases using pip](../../RELEASES.md#installing-releases-using-pip)
 and [Python Packaging](../../docs/packaging/python_packaging.md) documentation


### PR DESCRIPTION
## Summary

Adds Python 3.10 to the PyTorch build matrix and updates documentation. **This PR depends on #2779 (compatibility fixes) being merged first.**

## Changes

### 1. Build Configuration Updates
- Updated GitHub Actions workflows to include Python 3.10 in the build matrix:
  - `.github/workflows/release_portable_linux_pytorch_wheels.yml`
  - `.github/workflows/release_windows_pytorch_wheels.yml`

### 2. Documentation Updates
- Updated `RELEASES.md` to reflect Python 3.10 support
- Updated `external-builds/pytorch/README.md` minimum Python version to 3.10+

## Motivation

Python 3.10 is still widely used and many users have requested support for it. The compatibility fixes in PR #2779 ensure Python 3.10 works correctly before enabling the builds.

## Test Plan

- [ ] Build PyTorch wheels for Python 3.10 on Linux
- [ ] Build PyTorch wheels for Python 3.10 on Windows
- [ ] Run PyTorch smoke tests with Python 3.10

## Dependencies

- **Depends on PR #2779**: Fix Python 3.10 Compatibility Issues

## Related Issues

- Fixes #2567: Add Python 3.10 Support
