### PR TITLE
Fix typo: envion_vars -> environ_vars in test scripts

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hipsolver.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsolver.py
@@ -14,10 +14,10 @@ AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 # GTest sharding
 SHARD_INDEX = os.getenv("SHARD_INDEX", 1)
 TOTAL_SHARDS = os.getenv("TOTAL_SHARDS", 1)
-envion_vars = os.environ.copy()
+environ_vars = os.environ.copy()
 # For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
-envion_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
-envion_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
+environ_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
+environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 
 logging.basicConfig(level=logging.INFO)
 
@@ -45,4 +45,4 @@ cmd = [
 ]
 
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
-subprocess.run(cmd, cwd=THEROCK_DIR, check=True, env=envion_vars)
+subprocess.run(cmd, cwd=THEROCK_DIR, check=True, env=environ_vars)

--- a/build_tools/github_actions/test_executable_scripts/test_rocsolver.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocsolver.py
@@ -14,10 +14,10 @@ logging.basicConfig(level=logging.INFO)
 # GTest sharding
 SHARD_INDEX = os.getenv("SHARD_INDEX", 1)
 TOTAL_SHARDS = os.getenv("TOTAL_SHARDS", 1)
-envion_vars = os.environ.copy()
+environ_vars = os.environ.copy()
 # For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
-envion_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
-envion_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
+environ_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
+environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 
 cmd = [
     f"{THEROCK_BIN_DIR}/rocsolver-test",
@@ -25,4 +25,4 @@ cmd = [
 ]
 
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
-subprocess.run(cmd, cwd=THEROCK_DIR, check=True, env=envion_vars)
+subprocess.run(cmd, cwd=THEROCK_DIR, check=True, env=environ_vars)


### PR DESCRIPTION
## Description
Fixed variable name typo in two test scripts where `envion_vars` was used instead of `environ_vars`.

## Changes
- **test_hipsolver.py**: Corrected `envion_vars` to `environ_vars` (4 occurrences)
- **test_rocsolver.py**: Corrected `envion_vars` to `environ_vars` (4 occurrences)

## Rationale
This brings the naming convention in line with the other 20 test files in the same directory, all of which use `environ_vars` consistently.

## Testing
- No functional changes - the typo was used consistently within each file
- Verified no linter errors after the fix