### PR TITLE
add torchcodec to pytorch builds

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -128,6 +128,7 @@ jobs:
       torchaudio_version: ${{ steps.build-pytorch-wheels.outputs.torchaudio_version }}
       torchvision_version: ${{ steps.build-pytorch-wheels.outputs.torchvision_version }}
       triton_version: ${{ steps.build-pytorch-wheels.outputs.triton_version }}
+      torchcodec_version: ${{ steps.build-pytorch-wheels.outputs.torchcodec_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -162,6 +163,7 @@ jobs:
           ./external-builds/pytorch/pytorch_audio_repo.py checkout --repo-hashtag nightly
           ./external-builds/pytorch/pytorch_vision_repo.py checkout --repo-hashtag nightly
           ./external-builds/pytorch/pytorch_triton_repo.py checkout
+          ./external-builds/pytorch/pytorch_torchcodec_repo.py checkout --repo-hashtag nightly
 
       # Checkout stable sources from https://github.com/ROCm/pytorch
       - name: Checkout PyTorch Source Repos from stable branch
@@ -171,6 +173,7 @@ jobs:
           ./external-builds/pytorch/pytorch_audio_repo.py checkout --require-related-commit
           ./external-builds/pytorch/pytorch_vision_repo.py checkout --require-related-commit
           ./external-builds/pytorch/pytorch_triton_repo.py checkout
+          ./external-builds/pytorch/pytorch_torchcodec_repo.py checkout
 
       - name: Create pip cache directory
         run: mkdir -p /tmp/pipcache
@@ -271,6 +274,7 @@ jobs:
       TORCHAUDIO_VERSION: "${{ needs.build_pytorch_wheels.outputs.torchaudio_version }}"
       TORCHVISION_VERSION: "${{ needs.build_pytorch_wheels.outputs.torchvision_version }}"
       TRITON_VERSION: "${{ needs.build_pytorch_wheels.outputs.triton_version }}"
+      TORCHCODEC_VERSION: "${{ needs.build_pytorch_wheels.outputs.torchcodec_version }}"
 
     steps:
       - name: Checkout
@@ -306,7 +310,8 @@ jobs:
             --include "torch-${TORCH_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
             --include "torchaudio-${TORCHAUDIO_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
             --include "torchvision-${TORCHVISION_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
-            --include "triton-${TRITON_VERSION}-${CP_VERSION}-linux_x86_64.whl"
+            --include "triton-${TRITON_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
+            --include "torchcodec-${TORCHCODEC_VERSION}-${CP_VERSION}-linux_x86_64.whl"
 
       - name: (Re-)Generate Python package release index
         if: ${{ env.upload == 'true' }}

--- a/external-builds/pytorch/.gitignore
+++ b/external-builds/pytorch/.gitignore
@@ -3,6 +3,7 @@ src/
 /pytorch
 /pytorch_vision
 /pytorch_audio
+/pytorch_torchcodec
 /triton
 
 # Written by run_pytorch_tests.py on Windows as a workaround for

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -1011,6 +1011,13 @@ def do_build_pytorch_torchcodec(
     if args.clean:
         remove_dir_if_exists(pytorch_torchcodec_dir / "build")
 
+    # cmake support for pybind11 to avoid error:
+    # Could not find a package configuration file provided by "pybind11"
+    exec(
+        [sys.executable, "-m", "pip", "install", "pybind11[global]"],
+        cwd=pytorch_torchcodec_dir,
+        env=env,
+    )
     # torchcodec build
     exec(
         [sys.executable, "-m", "build", "--wheel", "-vvv", "--no-isolation"],

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -1011,24 +1011,6 @@ def do_build_pytorch_torchcodec(
     if args.clean:
         remove_dir_if_exists(pytorch_torchcodec_dir / "build")
 
-    # verify that installed setuptools > 80.0 (80.9.0 tested)
-    exec(
-        [sys.executable, "-m", "pip", "install", "setuptools>80.0"],
-        cwd=pytorch_torchcodec_dir,
-        env=env,
-    )
-    # pybind11
-    exec(
-        [sys.executable, "-m", "pip", "install", "pybind11"],
-        cwd=pytorch_torchcodec_dir,
-        env=env,
-    )
-    # cmake support for pybind11
-    exec(
-        [sys.executable, "-m", "pip", "install", "pybind11[global]"],
-        cwd=pytorch_torchcodec_dir,
-        env=env,
-    )
     # torchcodec build
     exec(
         [sys.executable, "-m", "build", "--wheel", "-vvv", "--no-isolation"],

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -972,7 +972,7 @@ def do_build_pytorch_torchcodec(
     except ValueError:
         print("Error, Skipping pytorch torchcodec build")
         print(
-            f"Could not convert version string major and minor to int. Check the format of '{version_string}'."
+            f"Could not convert version string major and minor to int. Check the format of '{build_version}'."
         )
         return
     if version_major_int == 0 and version_minor_int < 9:
@@ -1003,7 +1003,6 @@ def do_build_pytorch_torchcodec(
             "Python3_ROOT_DIR": python_home_dir,
         }
     )
-    print("do_build_pytorch_torchcodec")
     print(f"    BUILD_VERSION: {env['BUILD_VERSION']}")
     print(f"    BUILD_NUMBER:  {env['BUILD_NUMBER']}")
     print(f"    Python3_ROOT_DIR: {env['Python3_ROOT_DIR']}")

--- a/external-builds/pytorch/pytorch_torchcodec_repo.py
+++ b/external-builds/pytorch/pytorch_torchcodec_repo.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+"""Checks out PyTorch torchcodec.
+
+There is nothing that this script does which you couldn't do by hand, but because of
+the following, getting PyTorch sources ready to build with ToT TheRock built SDKs
+consists of multiple steps:
+
+* Sources must be pre-processed with HIPIFY, creating dirty git trees that are hard
+  to develop on further.
+* Both the ROCM SDK and PyTorch are moving targets that are eventually consistent.
+
+Primary usage:
+
+    ./pytorch_torchcodec_repo.py checkout
+
+The checkout process combines the following activities:
+
+* Clones the pytorch repository into `THIS_MAIN_REPO_NAME` with a requested `--repo-hashtag`
+  tag (default to latest release).
+* Configures PyTorch submodules to be ignored for any local changes.
+* Runs `hipify` to prepare sources for AMD GPU and commits the result to the
+  main repo and any modified submodules.
+* Records tag information for tracking upstream and hipify commits.
+"""
+import argparse
+from pathlib import Path
+import sys
+
+import repo_management
+
+THIS_MAIN_REPO_NAME = "pytorch_torchcodec"
+THIS_DIR = Path(__file__).resolve().parent
+
+DEFAULT_ORIGIN = "https://github.com/pytorch/torchcodec.git"
+DEFAULT_HASHTAG = "nightly"
+
+
+def get_pytorch_version(torch_dir: Path) -> str:
+    version_file = torch_dir / "version.txt"
+    return version_file.read_text().strip()
+
+
+def do_checkout(args: argparse.Namespace):
+    print("do_checkout torchcodec")
+    repo_dir: Path = args.checkout_dir
+    torch_dir: Path = args.torch_dir
+    if not torch_dir.exists():
+        raise ValueError(
+            f"do_checkout torchcodec, Could not find torch dir: {torch_dir} (did you check out torch first)"
+        )
+    if args.repo_hashtag is None:
+        pin_version = get_pytorch_version(torch_dir)
+        pin_major, pin_minor, *_ = pin_version.split(".")
+        pin_major = int(pin_major)
+        pin_minor = int(pin_minor)
+        print(f"pytorch <major>.<minor>: {pin_major}.{pin_minor}")
+        if pin_major == 2:
+            if pin_minor == 7:
+                args.repo_hashtag = "v0.5.0"
+            elif pin_minor == 8:
+                args.repo_hashtag = "v0.7.0"
+            elif pin_minor == 9:
+                args.repo_hashtag = "v0.9.1"
+            elif pin_minor == 10:
+                args.repo_hashtag = "v0.10-rc1"
+            elif pin_minor == 11:
+                args.repo_hashtag = "nightly"
+            else:
+                raise ValueError(
+                    f"do_checkout torchcodec, Unsupported torch minor version: {pin_minor}, torch version: {pin_major}.{pin_minor} (did you check out torch first)"
+                )
+        else:
+            raise ValueError(
+                f"do_checkout torchcodec, Unsupported torch major version: {pin_major}, torch version: {pin_major}.{pin_minor} (did you check out torch first)"
+            )
+    print(f"torchcodec version: {args.repo_hashtag}")
+    repo_management.do_checkout(args)
+
+
+def main(cl_args: list[str]):
+    def add_common(command_parser: argparse.ArgumentParser):
+        command_parser.add_argument(
+            "--checkout-dir",
+            type=Path,
+            default=THIS_DIR / THIS_MAIN_REPO_NAME,
+            help=f"Directory path where the git repo is cloned into. Default is {THIS_DIR / THIS_MAIN_REPO_NAME}",
+        )
+        command_parser.add_argument(
+            "--gitrepo-origin",
+            type=str,
+            default=None,
+            help=f"Git repository url. Defaults to the origin in torch/related_commits (see --torch-dir), or '{DEFAULT_ORIGIN}'",
+        )
+        command_parser.add_argument(
+            "--repo-name",
+            type=Path,
+            default=THIS_MAIN_REPO_NAME,
+            help="Subdirectory name in which to checkout repo",
+        )
+        command_parser.add_argument(
+            "--repo-hashtag",
+            type=str,
+            default=None,
+            help=f"Git repository ref/tag to checkout. Defaults to the ref in torch/related_commits (see --torch-dir), or '{DEFAULT_HASHTAG}'",
+        )
+        command_parser.add_argument(
+            "--require-related-commit",
+            action=argparse.BooleanOptionalAction,
+            help="Require that a related commit was found from --torch-dir",
+        )
+        command_parser.add_argument(
+            "--torch-dir",
+            type=Path,
+            default=THIS_DIR / "pytorch",
+            help="Directory of the torch checkout, for loading the related_commits file that can populate alternate default values for --gitrepo-origin and --repo-hashtag. If missing then fallback/upstream defaults will be used",
+        )
+
+    p = argparse.ArgumentParser("pytorch_audio_repo.py")
+    sub_p = p.add_subparsers(required=True)
+    checkout_p = sub_p.add_parser(
+        "checkout", help="Clone PyTorch Audio locally and checkout"
+    )
+    add_common(checkout_p)
+    checkout_p.add_argument("--depth", type=int, help="Fetch depth")
+    checkout_p.add_argument("--jobs", type=int, help="Number of fetch jobs")
+    checkout_p.add_argument(
+        "--hipify",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run hipify",
+    )
+    checkout_p.set_defaults(func=do_checkout)
+
+    hipify_p = sub_p.add_parser("hipify", help="Run HIPIFY on the project")
+    add_common(hipify_p)
+    hipify_p.set_defaults(func=repo_management.do_hipify)
+
+    args = p.parse_args(cl_args)
+
+    # torchcodec has not pin-mapping in file pytorch/.github/ci_commit_pins
+    default_git_origin = DEFAULT_ORIGIN
+
+    # Priority order:
+    #   1. Explicitly set values
+    #   2. Values loaded from the pin in the torch repo
+    #   3. Fallback default values
+    args.gitrepo_origin = args.gitrepo_origin or default_git_origin
+    args.repo_hashtag = args.repo_hashtag
+
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/external-builds/pytorch/pytorch_torchcodec_repo.py
+++ b/external-builds/pytorch/pytorch_torchcodec_repo.py
@@ -31,7 +31,7 @@ import repo_management
 THIS_MAIN_REPO_NAME = "pytorch_torchcodec"
 THIS_DIR = Path(__file__).resolve().parent
 
-DEFAULT_ORIGIN = "https://github.com/pytorch/torchcodec.git"
+DEFAULT_ORIGIN = "https://github.com/meta-pytorch/torchcodec.git"
 DEFAULT_HASHTAG = "nightly"
 
 

--- a/external-builds/pytorch/pytorch_torchcodec_repo.py
+++ b/external-builds/pytorch/pytorch_torchcodec_repo.py
@@ -115,10 +115,10 @@ def main(cl_args: list[str]):
             help="Directory of the torch checkout, for loading the related_commits file that can populate alternate default values for --gitrepo-origin and --repo-hashtag. If missing then fallback/upstream defaults will be used",
         )
 
-    p = argparse.ArgumentParser("pytorch_audio_repo.py")
+    p = argparse.ArgumentParser("pytorch_torchcodec_repo.py")
     sub_p = p.add_subparsers(required=True)
     checkout_p = sub_p.add_parser(
-        "checkout", help="Clone PyTorch Audio locally and checkout"
+        "checkout", help="Clone PyTorch torchcodec locally and checkout"
     )
     add_common(checkout_p)
     checkout_p.add_argument("--depth", type=int, help="Fetch depth")

--- a/external-builds/pytorch/pytorch_torchcodec_repo.py
+++ b/external-builds/pytorch/pytorch_torchcodec_repo.py
@@ -62,7 +62,7 @@ def do_checkout(args: argparse.Namespace):
             elif pin_minor == 9:
                 args.repo_hashtag = "v0.9.1"
             elif pin_minor == 10:
-                args.repo_hashtag = "v0.10-rc1"
+                args.repo_hashtag = "v0.10.0"
             elif pin_minor == 11:
                 args.repo_hashtag = "nightly"
             else:


### PR DESCRIPTION
Add support for checking out and building torchcodec during the pytorch build phase
- version of torchcodec depends from the pytorch version and torchcodecs/README.md lists which torchcodec and pytorch versions are compatible with each others. Because pytorch/.github/ci_commit_pins directory does not mention the torchcodec, we will check the pytorch version in pytorch_torchcodec_repo.py and then use that information to determine which torchcodec version to checkout.
- torchcodec source code checkout and build has been enabled in the linux CI job
- pytorch_torchcodec_repo.py will first install a torchcodec compatible version of setuptools before launching the torchcodec build command (setuptools > 0.80)

Todo:
- Verify windows builds
- Add smoketests

fixes: https://github.com/ROCm/TheRock/issues/1490