### PR TITLE
[ci] Adding valgrind to `no_rocm_image_ubuntu24_04` docker image

### DIFF
--- a/dockerfiles/no_rocm_image_ubuntu24_04.Dockerfile
+++ b/dockerfiles/no_rocm_image_ubuntu24_04.Dockerfile
@@ -30,7 +30,8 @@ RUN sudo apt-get update -y \
     lld \
     wget \
     psmisc \
-    libgfortran5
+    libgfortran5 \
+    valgrind
 
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && \
     sudo apt-get install git-lfs


### PR DESCRIPTION
## Motivation

Adding `valgrind` to the test docker image `no_rocm_image_ubuntu24_04` for debugging purposes

## Technical Details

Adding `valgrind` to the docker file as an apt-get install package

After landing, will land this change in test_components to have the correct docker SHA

## Test Plan

Published the docker image here: https://github.com/ROCm/TheRock/actions/runs/20286530074 and running a local test

## Test Result

Docker publishing worked: https://github.com/ROCm/TheRock/actions/runs/20286530074
Local test here: 
<img width="1900" height="438" alt="Screenshot 2025-12-16 155333" src="https://github.com/user-attachments/assets/c2a08d8b-786d-4781-98dc-6c57249bb7db" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
