### PR TITLE
[CI] Allow linux runner to use full 96 vcpu node

### DIFF
--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -60,7 +60,7 @@ jobs:
     name: Build (xfail ${{ inputs.expect_failure }})
     # azure-linux-scale-rocm are used for regular CI builds
     # azure-linux-scale-rocm-heavy are used for CI builds that require more resources (ex: ASAN builds)
-    runs-on: ${{ inputs.build_variant_label == 'asan' && 'azure-linux-u2404-hx176-cpu-rocm' || 'azure-linux-scale-rocm' }}
+    runs-on: ${{ inputs.build_variant_label == 'asan' && 'azure-linux-u2404-hx176-cpu-rocm' || 'azure-linux-scale-rocm-heavy' }}
     continue-on-error: ${{ inputs.expect_failure }}
     timeout-minutes: 720 # 12 hour timeout
     permissions:


### PR DESCRIPTION
## Motivation

Mitigate https://github.com/ROCm/TheRock/issues/2480

## Technical Details

Dedicate 1 linux cpu build runner pod to 1 full 96 core node rather than allowing simultaneous build pods to run on a node. Currently up to 2 pods requesting 40 cores on 96 core nodes) The theory is this will reduce resource contention and lessen the likely hood of runner disconnects. 

Also, add more nodepools with 96 core nodes to allow this

## Test Plan

observe presubmit ci

## Test Result

observe presubmit ci

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
