### PR TITLE
Enable FBGEMM_GENAI for pytorch 2.9

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -657,7 +657,8 @@ def do_build_pytorch(
         # Enabling/Disabling FBGEMM_GENAI based on Pytorch version in Linux
         if is_pytorch_2_9:
             # Default ON for 2.9.x, unless explicitly disabled
-            # args.enable_pytorch_fbgemm_genai_linux can be set to false by using --no-enable-pytorch-fbgemm-genai-linux
+            # args.enable_pytorch_fbgemm_genai_linux can be set to false
+            # by passing --no-enable-pytorch-fbgemm-genai-linux as input
             if args.enable_pytorch_fbgemm_genai_linux is False:
                 use_fbgemm_genai = "OFF"
                 print(f"  [WARN] User-requested override to set FBGEMM_GENAI = OFF.")


### PR DESCRIPTION
## Motivation

This PR is aimed at enabling FBEGMM_GENAI only for pytorch version 2.9.X. There was a fix from upstream that was merged recently into rocm/pytoch 2.9 releases that should fix issues for build with pytorch 2.9 and FBEGMM_GENAI enabled

## Technical Details

PR that was merged to rocm/pytorch 

https://github.com/ROCm/pytorch/pull/2882

## Test Result

https://github.com/ROCm/TheRock/actions/runs/20308983418/job/58334386657

2025-12-17T16:32:21.0331894Z FBGEMM_GENAI enabled (PyTorch 2.9.x, Linux): 
2025-12-17T16:32:21.0332148Z FBGEMM_GENAI enabled: True

