### PR TITLE
[torch] Skip tests that fail on Windows with Python 3.11

### DIFF
--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -170,6 +170,10 @@ skip_tests = {
             #   Error checking compiler version for cl: [WinError 2] The system cannot find the file specified
             #   AssertionError: Object comparison failed: <torch.cuda.Stream device=cuda:0 cuda_stream=0x1fa05550b50> != <torch.cuda.Stream device=cuda:0 cuda_stream=0x0>
             "test_consumer_to_single_producer_case_2_correctness",
+            # Failures on Python 3.11 (not 3.12 or 3.13) with
+            #   Windows fatal exception: code 0xc0000374
+            # Possibly due to use of `torch.jit.script`?
+            "test_fork_join_in_middle",
             # This test JIT compiles and fails if MSVC is not installed on Windows:
             # We should fix the test to fail/skip more gracefully.
             #   subprocess.CalledProcessError: Command '['where', 'cl']' returned non-zero exit status 1.
@@ -178,6 +182,13 @@ skip_tests = {
             #   AssertionError: "Simulate error" does not match "grad can be implicitly created only for scalar outputs"
             "test_reentrant_parent_error_on_cpu_cuda",
         ],
+        "binary_ufuncs": [
+            # Failures on Python 3.11 (not 3.12 or 3.13) with
+            #   Windows fatal exception: code 0xc0000374
+            # Possibly due to use of `torch.jit.script`?
+            "test_div_and_floordiv_script_vs_python_cuda",
+            "test_idiv_and_ifloordiv_vs_python_cuda",
+        ],
         "cuda": [
             # RuntimeError: miopenStatusUnknownError
             "test_autocast_rnn",
@@ -185,6 +196,9 @@ skip_tests = {
             #   AssertionError: False is not true
             #   self.assertTrue(abs(check_workspace_size(a) - default_workspace_size) < 524288)
             "test_cublas_workspace_explicit_allocation",
+            # For Python 3.11, this fails with
+            #   torch.AcceleratorError: HIP error: operation not permitted when stream is capturing
+            "test_cuda_graph_tensor_item_not_allowed",
             # *** Test hang (see above) ***
             "test_graph_error",
             # This test conflicts with how our test script and runners are


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/2600. Progress on https://github.com/ROCm/TheRock/issues/2258.

We started running PyTorch 2.9 tests on Windows across all Python versions in https://github.com/ROCm/TheRock/pull/2565. Testing prior to merge only exercised Python 3.12. These additional tests are failing just on Python 3.11.

## Test Plan

* Tested locally on gfx1100 (and gfx1151):

    ```
    py -V:3.11 -m venv 3.11.venv && .\3.11.venv\Scripts\activate.bat
    pip install --index-url=https://rocm.nightlies.amd.com/v2-staging/gfx110X-all/ torch==2.9.1+rocm7.11.0a20251217
    pip install -r D:/b/pytorch/.ci/docker/requirements-ci.txt
    python D:/projects/TheRock/external-builds/pytorch/run_pytorch_tests.py --pytorch-dir D:/b/pytorch --amdgpu-family=gfx1100 -- --continue-on-collection-errors --import-mode=importlib -v > %HOME%\.therock\logs\run_pytorch_tests_%date%_%time::=%.txt 2>&1
    ```
    
    ```
    Supported AMD GPUs: ['gfx1100', 'gfx1101', 'gfx1102', 'gfx1103']
    Visible AMD GPUs: ['gfx1100', 'gfx1100']
    Detected PyTorch supported architecture at device indices: {'gfx1100': [0, 1]}
    Policy 'single': Using device 0 (gfx1100)
    Using AMDGPU family: gfx1100
    Using PyTorch version: 2.9
    Creating list of tests to be skipped for AMDGPU family 'gfx1100' and PyTorch version '2.9'... done
    ================================================= test session starts =================================================

    ...

    ==================== 15599 passed, 26163 skipped, 280 deselected, 45 xfailed in 573.97s (0:09:33) =====================
    Pytest finished with return code: 0
    ```

* Tests with our workflows:
  * gfx110x: https://github.com/ROCm/TheRock/actions/runs/20315247088
  * ~~gfx1151: https://github.com/ROCm/TheRock/actions/runs/20315366906~~ (this used tests from the 2.7 release branch)
  * ~~gfx1151: https://github.com/ROCm/TheRock/actions/runs/20316643227~~ (machine issues)
  * gfx1151: https://github.com/ROCm/TheRock/actions/runs/20316643227
    
## Test Result

See above (one successful test run per GPU family)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
