### PR TITLE
Update windows_support.md to use winget

### DIFF
--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -127,6 +127,7 @@ These instructions mostly mirror the instructions in the root
 
 > [!TIP]
 > These tools are available via package managers like winget on Windows:
+>
 > ```bash
 > winget install --id Microsoft.VisualStudio.2022.BuildTools --source winget --override "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add
 > Microsoft.VisualStudio.Component.VC.CMake.Project --add Microsoft.VisualStudio.Component.VC.ATL --add


### PR DESCRIPTION
Use default on Windows tools `winget` instead of choco

## Motivation

KISS: Use default tools on Windows like winget

## Technical Details

Use winget cli

## Test Plan

Runs on Windows 11 Pro

## Test Result

Tools installed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
