### PR TITLE
Disable LLVM_INCLUDE_BENCHMARKS

### DIFF
--- a/compiler/pre_hook_amd-llvm.cmake
+++ b/compiler/pre_hook_amd-llvm.cmake
@@ -57,7 +57,7 @@ endif()
 # Set the LLVM_ENABLE_PROJECTS variable before including LLVM's CMakeLists.txt
 set(BUILD_TESTING OFF CACHE BOOL "DISABLE BUILDING TESTS IN SUBPROJECTS" FORCE)
 # we have never enabled benchmarks,
-# diabling more explicitly after a bug fix enabled.
+# disabling more explicitly after a bug fix enabled.
 set(LLVM_INCLUDE_BENCHMARKS OFF)
 set(LLVM_TARGETS_TO_BUILD "AMDGPU;X86" CACHE STRING "Enable LLVM Targets" FORCE)
 


### PR DESCRIPTION
disabling the compiler  include benchmarks per request of Kirand and Lenine
we have never run these 
1) we never thought small list was/is relevant
2) until recently there was a bug preventing it, recently fixed by MattA