### PR TITLE
[ci] Adding mi355 test runner

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -89,9 +89,7 @@ amdgpu_family_info_matrix_presubmit = {
 amdgpu_family_info_matrix_postsubmit = {
     "gfx950": {
         "linux": {
-            # Networking issue: https://github.com/ROCm/TheRock/issues/1660
-            # Label is "linux-mi355-1gpu-ossci-rocm"
-            "test-runs-on": "",
+            "test-runs-on": "linux-mi355-1gpu-ossci-rocm",
             "family": "gfx950-dcgpu",
             "build_variants": ["release", "asan"],
         }


### PR DESCRIPTION
## Motivation

Adding mi355 test runner back to TheRock

## Technical Details

Updating `amdgpu_family_matrix.py` to include test runner

## Test Plan

Testing via CI

## Test Result

Test works here: https://github.com/ROCm/TheRock/actions/runs/20357299644/job/58496086853

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Closes #1660 
