### PR TITLE
amdgpu_family_matrix: Remove expect_failure for gfx1152/gfx1153

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -184,13 +184,11 @@ amdgpu_family_info_matrix_nightly = {
         "linux": {
             "test-runs-on": "",
             "family": "gfx1152",
-            "expect_failure": True,
             "build_variants": ["release"],
         },
         "windows": {
             "test-runs-on": "",
             "family": "gfx1152",
-            "expect_failure": True,
             "build_variants": ["release"],
         },
     },
@@ -204,7 +202,6 @@ amdgpu_family_info_matrix_nightly = {
         "windows": {
             "test-runs-on": "",
             "family": "gfx1153",
-            "expect_failure": True,
             "build_variants": ["release"],
         },
     },


### PR DESCRIPTION
gfx1152 and gfx1153 [pass the build](https://github.com/ROCm/TheRock/actions/runs/20357946050) on Linux and Windows since the last rocm-libaries bump.
    
This PR removes the `expect_failure` to allow running the sanity checks.  (Tests are still disabled due to `sanity_check_only_for_family`)
Only linux gfx1153 has runners, so the other combinations will still skip their testing until runners are added.