### PR TITLE
Revert "build ocltst for OpenCL"

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -295,9 +295,6 @@ if(THEROCK_ENABLE_OCL_RUNTIME)
       rocprofiler-register
       ROCR-Runtime
     )
-    list(APPEND OCL_CLR_CMAKE_ARGS
-      "-DBUILD_TESTS=${THEROCK_BUILD_TESTING}"
-    )
   endif()
 
   therock_cmake_subproject_declare(ocl-clr

--- a/core/artifact-core-ocl.toml
+++ b/core/artifact-core-ocl.toml
@@ -9,9 +9,4 @@ include = [
 [components.run."core/ocl-clr/stage"]
 include = [
   "bin/**",
-  "tests/**",
-]
-[components.tests."core/ocl-clr/stage"]
-include = [
-  "tests/**",
 ]


### PR DESCRIPTION
- #2126
- rocm-sdk sanity tests are failing library load with the shared libraries in the ocltst directory.
- Example run from my submodule bump PR: https://github.com/ROCm/TheRock/actions/runs/20379689276