### PR TITLE
third-party/gmp: fix build on GCC 15

### DIFF
--- a/patches/third-party/gmp/0001-acinclude.m4-fix-function-prototype-for-GCC-15.patch
+++ b/patches/third-party/gmp/0001-acinclude.m4-fix-function-prototype-for-GCC-15.patch
@@ -1,0 +1,122 @@
+From 199a2303b1f08ef69e175048e1f6b292d4e76598 Mon Sep 17 00:00:00 2001
+From: Scott Tsai <scottt@neuralplay.ai>
+Date: Sun, 21 Dec 2025 21:04:46 +0800
+Subject: [PATCH] acinclude.m4: fix function prototype for GCC 15
+
+This combines two trivial upstream patches which touch `acinlude.m4`:
+* https://gmplib.org/repo/gmp/rev/8e7bb4ae7a18
+* https://gmplib.org/repo/gmp/rev/d66d66d82dbb
+to fix "could not find a working compiler" problems for GCC 15+ which defaults to the C23 standard.
+
+The `configure` script in the gmp tarball is also patched
+by one generated with autoconf-2.69 using an AlmaLinux 8 container.
+---
+ acinclude.m4 |  2 +-
+ configure    | 22 ++++++++++++++--------
+ 2 files changed, 15 insertions(+), 9 deletions(-)
+
+diff --git a/acinclude.m4 b/acinclude.m4
+index 9cf9483..b79a431 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -609,7 +609,7 @@ GMP_PROG_CC_WORKS_PART([$1], [long long reliability test 1],
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int a,t1 const*b,t1 c,t2 d,t1 const*e,int f){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
+diff --git a/configure b/configure
+index 7910aa0..3af2249 100755
+--- a/configure
++++ b/configure
+@@ -3121,7 +3121,7 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
+ 
+ 
+ 
+-am__api_version='1.15'
++am__api_version='1.16'
+ 
+ # Find a good install program.  We prefer a C program (faster),
+ # so one script is as good as another.  But avoid the broken or
+@@ -3637,8 +3637,8 @@ MAKEINFO=${MAKEINFO-"${am_missing_run}makeinfo"}
+ 
+ # For better backward compatibility.  To be removed once Automake 1.9.x
+ # dies out for good.  For more background, see:
+-# <http://lists.gnu.org/archive/html/automake/2012-07/msg00001.html>
+-# <http://lists.gnu.org/archive/html/automake/2012-07/msg00014.html>
++# <https://lists.gnu.org/archive/html/automake/2012-07/msg00001.html>
++# <https://lists.gnu.org/archive/html/automake/2012-07/msg00014.html>
+ mkdir_p='$(MKDIR_P)'
+ 
+ # We need awk for the "check" target (and possibly the TAP driver).  The
+@@ -3689,7 +3689,7 @@ END
+ Aborting the configuration process, to ensure you take notice of the issue.
+ 
+ You can download and install GNU coreutils to get an 'rm' implementation
+-that behaves properly: <http://www.gnu.org/software/coreutils/>.
++that behaves properly: <https://www.gnu.org/software/coreutils/>.
+ 
+ If you want to complete the configuration process using your problematic
+ 'rm' anyway, export the environment variable ACCEPT_INFERIOR_RM_PROGRAM
+@@ -6568,7 +6568,7 @@ if test "$gmp_prog_cc_works" = yes; then
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int a,t1 const*b,t1 c,t2 d,t1 const*e,int f){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
+@@ -8187,7 +8187,7 @@ if test "$gmp_prog_cc_works" = yes; then
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int a,t1 const*b,t1 c,t2 d,t1 const*e,int f){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
+@@ -18726,6 +18726,9 @@ fi
+   # before this can be enabled.
+   hardcode_into_libs=yes
+ 
++  # Add ABI-specific directories to the system library path.
++  sys_lib_dlsearch_path_spec="/lib64 /usr/lib64 /lib /usr/lib"
++
+   # Ideally, we could use ldconfig to report *all* directores which are
+   # searched for libraries, however this is still not possible.  Aside from not
+   # being certain /sbin/ldconfig is available, command
+@@ -18734,7 +18737,7 @@ fi
+   # appending ld.so.conf contents (and includes) to the search path.
+   if test -f /etc/ld.so.conf; then
+     lt_ld_extra=`awk '/^include / { system(sprintf("cd /etc; cat %s 2>/dev/null", \$2)); skip = 1; } { if (!skip) print \$0; skip = 0; }' < /etc/ld.so.conf | $SED -e 's/#.*//;/^[	 ]*hwcap[	 ]/d;s/[:,	]/ /g;s/=[^=]*$//;s/=[^= ]* / /g;s/"//g;/^$/d' | tr '\n' ' '`
+-    sys_lib_dlsearch_path_spec="/lib /usr/lib $lt_ld_extra"
++    sys_lib_dlsearch_path_spec="$sys_lib_dlsearch_path_spec $lt_ld_extra"
+   fi
+ 
+   # We used to test for /lib/ld.so.1 and disable shared libraries on
+@@ -22688,6 +22691,9 @@ fi
+   # before this can be enabled.
+   hardcode_into_libs=yes
+ 
++  # Add ABI-specific directories to the system library path.
++  sys_lib_dlsearch_path_spec="/lib64 /usr/lib64 /lib /usr/lib"
++
+   # Ideally, we could use ldconfig to report *all* directores which are
+   # searched for libraries, however this is still not possible.  Aside from not
+   # being certain /sbin/ldconfig is available, command
+@@ -22696,7 +22702,7 @@ fi
+   # appending ld.so.conf contents (and includes) to the search path.
+   if test -f /etc/ld.so.conf; then
+     lt_ld_extra=`awk '/^include / { system(sprintf("cd /etc; cat %s 2>/dev/null", \$2)); skip = 1; } { if (!skip) print \$0; skip = 0; }' < /etc/ld.so.conf | $SED -e 's/#.*//;/^[	 ]*hwcap[	 ]/d;s/[:,	]/ /g;s/=[^=]*$//;s/=[^= ]* / /g;s/"//g;/^$/d' | tr '\n' ' '`
+-    sys_lib_dlsearch_path_spec="/lib /usr/lib $lt_ld_extra"
++    sys_lib_dlsearch_path_spec="$sys_lib_dlsearch_path_spec $lt_ld_extra"
+   fi
+ 
+   # We used to test for /lib/ld.so.1 and disable shared libraries on
+-- 
+2.51.0
+

--- a/third-party/sysdeps/common/gmp/CMakeLists.txt
+++ b/third-party/sysdeps/common/gmp/CMakeLists.txt
@@ -8,6 +8,8 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
       # Originally mirrored from: https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz
       URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/gmp-6.3.0.tar.xz"
       URL_HASH "SHA512=e85a0dab5195889948a3462189f0e0598d331d3457612e2d3350799dba2e244316d256f8161df5219538eb003e4b5343f989aaa00f96321559063ed8c8f29fd2"
+      PATCH_COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/build_tools/patch_third_party_source.py ${CMAKE_SOURCE_DIR}/patches/third-party/gmp
+
       TOUCH "${_download_stamp}"
       # We need DOWNLOAD_EXTRACT_TIMESTAMP set to TRUE to preserve the timestamp
       # of the extracted sources, otherwise the build system will notice


### PR DESCRIPTION
This PR combines two trivial upstream patches to make gmp-6.3.0 build with GCC 15:
* https://gmplib.org/repo/gmp/rev/8e7bb4ae7a18
* https://gmplib.org/repo/gmp/rev/d66d66d82dbb

This fixes "could not find a working compiler" errors when running `configure` with GCC 15+.

The errors happen due to the newer compiler defaulting to the C23 standard.

# Details

* The patch is already upstream and should no longer be required on the next gmp release. Though that could take a while as the release happened in July 2023
* In order to not require (the right version) of `automake` when building TheRock, I've included a newly generated  `configure` script in [0001-acinclude.m4-fix-function-prototype-for-GCC-15.patch](patches/third-party/gmp/0001-acinclude.m4-fix-function-prototype-for-GCC-15.patch).
  * `configure` is generated from `acinclude.m4`.