### PR TITLE
[CI]: Enable gfx1152 and gfx1153 as valid input for the CI

### DIFF
--- a/.github/workflows/build_linux_jax_wheels.yml
+++ b/.github/workflows/build_linux_jax_wheels.yml
@@ -52,6 +52,8 @@ on:
           - gfx110X-all
           - gfx1150
           - gfx1151
+          - gfx1152
+          - gfx1153
           - gfx120X-all
           - gfx90X-dcgpu
           - gfx94X-dcgpu

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -56,6 +56,8 @@ on:
           - gfx110X-all
           - gfx1150
           - gfx1151
+          - gfx1152
+          - gfx1153
           - gfx120X-all
           - gfx90X-dcgpu
           - gfx94X-dcgpu

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -56,6 +56,8 @@ on:
           - gfx110X-all
           - gfx1150
           - gfx1151
+          - gfx1152
+          - gfx1153
           - gfx120X-all
           - gfx90X-dcgpu
           - gfx94X-dcgpu

--- a/.github/workflows/copy_release.yml
+++ b/.github/workflows/copy_release.yml
@@ -14,6 +14,8 @@ on:
           - gfx110X-all
           - gfx1150
           - gfx1151
+          - gfx1152
+          - gfx1153
           - gfx120X-all
           - gfx90X-dcgpu
           - gfx94X-dcgpu

--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -42,6 +42,8 @@ on:
           - gfx110X-all
           - gfx1150
           - gfx1151
+          - gfx1152
+          - gfx1153
           - gfx120X-all
           - gfx90X-dcgpu
           - gfx94X-dcgpu

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -42,6 +42,8 @@ on:
           - gfx110X-all
           - gfx1150
           - gfx1151
+          - gfx1152
+          - gfx1153
           - gfx120X-all
           - gfx90X-dcgpu
           - gfx94X-dcgpu

--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -52,6 +52,8 @@ on:
           - gfx110X-all
           - gfx1150
           - gfx1151
+          - gfx1152
+          - gfx1153
           - gfx120X-all
           - gfx90X-dcgpu
           - gfx94X-dcgpu


### PR DESCRIPTION
Allow gfx1152, gfx1153 as a valid input argument for:
.github/workflows/build_linux_jax_wheels.yml
.github/workflows/build_portable_linux_pytorch_wheels.yml
.github/workflows/build_windows_pytorch_wheels.yml
.github/workflows/copy_release.yml
.github/workflows/release_portable_linux_pytorch_wheels.yml
.github/workflows/release_windows_pytorch_wheels.yml
.github/workflows/test_linux_jax_wheels.yml

Issue #2646