### PR TITLE
Fix Pytorch gpu detection problem for <single arch>-<gpu type> (e.g. gfx950-dcgpu)

### DIFF
--- a/external-builds/pytorch/pytorch_utils.py
+++ b/external-builds/pytorch/pytorch_utils.py
@@ -193,9 +193,14 @@ def get_all_supported_devices(
             )
     else:
         # Mode 3: Specific GPU arch - validate it is visible and supported by the current PyTorch build.
+
+        # We have gfx1151 -> we want to match exactly gfx1151
+        # We have gfx950-dcgpu -> we need to match exactly gfx950
+        # So remove the suffix after '-'
+        pruned_amdgpu_family = amdgpu_family.split("-")[0]
         for idx, gpu in enumerate(visible_gpus):
             if gpu in supported_gpus:
-                if gpu == amdgpu_family or amdgpu_family in gpu:
+                if gpu == pruned_amdgpu_family or pruned_amdgpu_family in gpu:
                     selected_gpu_indices.append(idx)
                     selected_gpu_archs.append(gpu)
 


### PR DESCRIPTION
This code was somehow lost when PR #2468 was merged.

Original PR #2355 message:
Adjusts arch detection in external-builds/pytorch/run_linux_pytorch_tests.py.
(now: external-builds/pytorch/pytorch_utils.py) 

When a specific arch is given, gpus like gfx950-dcgpu were not correctly recognized.
Any specific gpu, not containing a X before the "-" (= no family) is now pruned to
just the prefix.
gfx1151 --> gfx1151 (unchanged behavior)
gfx950-dcgpu --> gfx950 (new behavior)

this allows to match with the gpu list returned by torch, and no longer throw an errror and exit the program.

Should fix https://github.com/ROCm/TheRock/issues/2324 (and new also #2676 )

