### PR TITLE
CI - Build mesa for linux (#2666)

### DIFF
--- a/build_tools/detail/linux_portable_build_in_container.sh
+++ b/build_tools/detail/linux_portable_build_in_container.sh
@@ -27,6 +27,7 @@ fi
 set -o xtrace
 time cmake -GNinja -S /therock/src -B "$OUTPUT_DIR/build" \
   -DTHEROCK_BUNDLE_SYSDEPS=ON \
+  -DTHEROCK_ENABLE_SYSDEPS_AMD_MESA=ON \
   ${PYTHON_EXECUTABLES_ARG} \
   "$@"
 time cmake --build "$OUTPUT_DIR/build" --target therock-archives therock-dist

--- a/build_tools/github_actions/build_configure.py
+++ b/build_tools/github_actions/build_configure.py
@@ -80,6 +80,7 @@ def build_configure(manylinux=False):
             "/opt/python/cp313-cp313/bin/python"
         )
         cmd.append(f"-DTHEROCK_DIST_PYTHON_EXECUTABLES={python_executables}")
+        cmd.append("-DTHEROCK_ENABLE_SYSDEPS_AMD_MESA=ON")
 
     if PLATFORM == "windows":
         # VCToolsInstallDir is required for build. Throwing an error if environment variable doesn't exist


### PR DESCRIPTION
## Motivation

Turn on mesa for linux to be part of the tarball

## Technical Details

Mesa is turned of by default, users need to explicitly turn on to build mesa/media projects

## Test Plan

Current Tests

## Test Result

Tests should pass and tarball contains the mesa

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
