### PR TITLE
[ci] Disabling CI machines (`gfx1153`, `gfx120X`) until stable

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -96,7 +96,9 @@ amdgpu_family_info_matrix_postsubmit = {
     },
     "gfx120x": {
         "linux": {
-            "test-runs-on": "linux-gfx1201-gpu-rocm",
+            # TODO(#2683): Re-enable machine once it is stable
+            # Label is "linux-gfx120X-gpu-rocm"
+            "test-runs-on": "",
             "family": "gfx120X-all",
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
@@ -192,7 +194,9 @@ amdgpu_family_info_matrix_nightly = {
     },
     "gfx1153": {
         "linux": {
-            "test-runs-on": "linux-gfx1153-gpu-rocm",
+            # TODO(#2682): Re-enable machine once it is stable
+            # Label is "linux-gfx1153-gpu-rocm"
+            "test-runs-on": "",
             "family": "gfx1153",
             "build_variants": ["release"],
             "sanity_check_only_for_family": True,


### PR DESCRIPTION
## Motivation

Both `gfx1153` and `gfx120X` machines are unstable with errors noted in #2683 and #2682

## Technical Details

Removing from `amdgpu_family_matrix.py`

## Test Plan

CI nightly will test

## Test Result

CI nightly will test

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
