### PR TITLE
Add postinstall and prerm support to native packages

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -46,7 +46,6 @@
     "Architecture": "amd64",
     "BuildArch": "x86_64",
     "DEBDepends": [
-      "python3",
       "libc6",
       "libstdc++6|libstdc++8",
       "libstdc++-5-dev|libstdc++-7-dev|libstdc++-11-dev|libstdc++-12-dev|libstdc++-13-dev|libstdc++-14-dev",
@@ -55,10 +54,8 @@
       "amdrocm-runtime"
     ],
     "RPMRequires": [
-      "python3",
       "glibc",
       "libstdc++",
-      "libgcc",
       "amdrocm-sysdeps",
       "amdrocm-runtime"
     ],
@@ -127,7 +124,6 @@
       "python3",
       "glibc",
       "libstdc++",
-      "libgcc",
       "amdrocm-sysdeps",
       "amdrocm-llvm"
     ],
@@ -1618,6 +1614,7 @@
     "Vendor": "Advanced Micro Devices, Inc",
     "Homepage": "https://github.com/ROCm/rocm-libraries",
     "Metapackage": "True",
+    "Postinstall": "True",
     "Gfxarch": "True"
   },
   {
@@ -1641,6 +1638,7 @@
     "Vendor": "Advanced Micro Devices, Inc",
     "Homepage": "https://github.com/ROCm/rocm-libraries",
     "Metapackage": "True",
+    "Postinstall": "True",
     "Gfxarch": "True"
   },
   {

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -85,6 +85,20 @@ def is_key_defined(pkg_info, key):
         return False
 
 
+def is_postinstallscripts_available(pkg_info):
+    """
+    Verifies whether Postinstall key is enabled for a package.
+
+    Parameters:
+    pkg_info (dict): A dictionary containing package details.
+
+    Returns:
+    bool: True if Postinstall key is defined, False otherwise.
+    """
+
+    return is_key_defined(pkg_info, "Postinstall")
+
+
 def is_meta_package(pkg_info):
     """
     Verifies whether Metapackage key is enabled for a package.

--- a/build_tools/packaging/linux/template/rpm_specfile.j2
+++ b/build_tools/packaging/linux/template/rpm_specfile.j2
@@ -57,3 +57,23 @@ cp -R {{ path }}/* $RPM_BUILD_ROOT{{ install_prefix }}
 
 %clean
 rm -rf $RPM_BUILD_ROOT
+
+{% if rpm_scripts['%pre'] %}
+%pre
+{{ rpm_scripts['%pre'] }}
+{% endif %}
+
+{% if rpm_scripts['%post'] %}
+%post
+{{ rpm_scripts['%post'] }}
+{% endif %}
+
+{% if rpm_scripts['%preun'] %}
+%preun
+{{ rpm_scripts['%preun'] }}
+{% endif %}
+
+{% if rpm_scripts['%postun'] %}
+%postun
+{{ rpm_scripts['%postun'] }}
+{% endif %}

--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-postinst.j2
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+is_debian_like() {
+    local id_like="$1"
+    case " $id_like " in
+        (*" debian "*|*" ubuntu "*)
+            return 0
+            ;;
+        (*)
+            return 1
+            ;;
+    esac
+}
+
+do_update_alternatives(){
+    # skip update if program doesn't exist
+    command -v update-alternatives >/dev/null || return 0
+    local binaries altscore now
+    now=$(date -u +%s)          # Number of seconds since 1 Jan 1970
+
+
+    # The reason for this approach rather than using the build number
+    # is to allow for jobs from different builds. In one build job the
+    # job number might be at 1200, whilst in a release job the number
+    # may be only 1. This approach assums that if you install a build
+    # with a different semantic version then the highest is the
+    # desired one, but if you install two with the same semver then
+    # the newest is the desired version.
+
+    # Build up a score. It needs to fit in 32 bits
+    altscore=$(({{ version_major }} - 3))
+    altscore=$((altscore * 14 + {{ version_minor }})) # Allow up to 14 minor
+    altscore=$((altscore * 14 + {{ version_patch }})) # Allow up to 14 patch
+
+    # So far if the version is less than 9 we have a number (altscore)
+    # that is less than 1175.  2**31/1175 is about 1.8 million. So
+    # multiply altscore by 1,000,000 and add in a factor of how many
+    # minutes have passed from an arbitary point in time (1,600,000,000
+    # seconds after 1 Jan 1970 or Sep 13 12:26:40 2020) on the
+    # basis that no one is going to be installing a new version more
+    # often than every minute. This does get things wrong if a million
+    # minutes pass and you are downgrading, but the chances of someone
+    # waiting almost 2 years between installing a version and the
+    # previous patch level is small.
+    altscore=$((altscore*1000000+(now-1600000000)/60))
+
+    binaries=( hipcc rocminfo amd-smi rocm_agent_enumerator rocm-smi rocprofv3 )
+
+    {% if target == "deb" %}
+       PKG_INSTALL_PREFIX={{ install_prefix }}
+    {% else %}
+       PKG_INSTALL_PREFIX="$RPM_INSTALL_PREFIX0"
+    {% endif %}
+
+    for i in "${binaries[@]}"
+    do
+        # No obvious recover strategy if things fail
+        # No manual or other slave pages to install
+        if [ -e $PKG_INSTALL_PREFIX/bin/"$i" ]
+        then
+            update-alternatives --install /usr/bin/"$i" "$i" \
+                                $PKG_INSTALL_PREFIX/bin/"$i" "$altscore"
+        else
+            echo "$PKG_INSTALL_PREFIX/bin/$i not found, but that is OK" >&2
+        fi
+    done
+    true
+}
+
+if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"
+then
+    case "$1" in
+       (configure)
+       do_update_alternatives
+       ;;
+       (abort-upgrade|abort-remove|abort-deconfigure)
+           echo "$1"
+       ;;
+       (*)
+          exit 0
+       ;;
+    esac
+else
+    do_update_alternatives
+fi

--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-prerm.j2
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+binaries=( hipcc rocminfo amd-smi rocm_agent_enumerator rocm-smi rocprofv3  )
+
+is_debian_like() {
+    local id_like="$1"
+    case " $id_like " in
+        (*" debian "*|*" ubuntu "*)
+            return 0
+            ;;
+        (*)
+            return 1
+            ;;
+    esac
+}
+
+do_update_alternatives(){
+    # skip update if program doesn't exist
+    command -v update-alternatives >/dev/null || return 0
+
+    {% if target == "deb" %}
+        PKG_INSTALL_PREFIX={{ install_prefix }}
+    {% else %}
+        PKG_INSTALL_PREFIX="$RPM_INSTALL_PREFIX0"
+    {% endif %}
+
+    for i in "${binaries[@]}"
+    do
+        update-alternatives --remove "$i" \
+            "$PKG_INSTALL_PREFIX/bin/$i"
+    done
+}
+
+if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"
+then
+   case "$1" in
+       (remove|upgrade)
+           do_update_alternatives
+       ;;
+       (purge)
+           # nothing to do
+       ;;
+       (*)
+           exit 0
+       ;;
+   esac
+else
+    do_update_alternatives
+fi

--- a/build_tools/packaging/linux/template/scripts/amdrocm-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-postinst.j2
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+is_debian_like() {
+    local id_like="$1"
+    case " $id_like " in
+        (*" debian "*|*" ubuntu "*)
+            return 0
+            ;;
+        (*)
+            return 1
+            ;;
+    esac
+}
+
+do_update_alternatives(){
+    # skip update if program doesn't exist
+    command -v update-alternatives >/dev/null || return 0
+    local binaries altscore now
+    now=$(date -u +%s)          # Number of seconds since 1 Jan 1970
+
+
+    # The reason for this approach rather than using the build number
+    # is to allow for jobs from different builds. In one build job the
+    # job number might be at 1200, whilst in a release job the number
+    # may be only 1. This approach assums that if you install a build
+    # with a different semantic version then the highest is the
+    # desired one, but if you install two with the same semver then
+    # the newest is the desired version.
+
+    # Build up a score. It needs to fit in 32 bits
+    altscore=$(({{ version_major }} - 3))
+    altscore=$((altscore * 14 + {{ version_minor }})) # Allow up to 14 minor
+    altscore=$((altscore * 14 + {{ version_patch }})) # Allow up to 14 patch
+
+    # So far if the version is less than 9 we have a number (altscore)
+    # that is less than 1175.  2**31/1175 is about 1.8 million. So
+    # multiply altscore by 1,000,000 and add in a factor of how many
+    # minutes have passed from an arbitary point in time (1,600,000,000
+    # seconds after 1 Jan 1970 or Sep 13 12:26:40 2020) on the
+    # basis that no one is going to be installing a new version more
+    # often than every minute. This does get things wrong if a million
+    # minutes pass and you are downgrading, but the chances of someone
+    # waiting almost 2 years between installing a version and the
+    # previous patch level is small.
+    altscore=$((altscore*1000000+(now-1600000000)/60))
+
+    binaries=( hipcc rocminfo amd-smi rocm_agent_enumerator rocm-smi rocprofv3 )
+
+    {% if target == "deb" %}
+       PKG_INSTALL_PREFIX={{ install_prefix }}
+    {% else %}
+       PKG_INSTALL_PREFIX="$RPM_INSTALL_PREFIX0"
+    {% endif %}
+
+    for i in "${binaries[@]}"
+    do
+        # No obvious recover strategy if things fail
+        # No manual or other slave pages to install
+        if [ -e $PKG_INSTALL_PREFIX/bin/"$i" ]
+        then
+            update-alternatives --install /usr/bin/"$i" "$i" \
+                                $PKG_INSTALL_PREFIX/bin/"$i" "$altscore"
+        else
+            echo "$PKG_INSTALL_PREFIX/bin/$i not found, but that is OK" >&2
+        fi
+    done
+    true
+}
+
+if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"
+then
+    case "$1" in
+       (configure)
+       do_update_alternatives
+       ;;
+       (abort-upgrade|abort-remove|abort-deconfigure)
+           echo "$1"
+       ;;
+       (*)
+          exit 0
+       ;;
+    esac
+else
+    do_update_alternatives
+fi

--- a/build_tools/packaging/linux/template/scripts/amdrocm-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-prerm.j2
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+binaries=( hipcc rocminfo amd-smi rocm_agent_enumerator rocm-smi rocprofv3  )
+
+is_debian_like() {
+    local id_like="$1"
+    case " $id_like " in
+        (*" debian "*|*" ubuntu "*)
+            return 0
+            ;;
+        (*)
+            return 1
+            ;;
+    esac
+}
+
+do_update_alternatives(){
+    # skip update if program doesn't exist
+    command -v update-alternatives >/dev/null || return 0
+
+    {% if target == "deb" %}
+        PKG_INSTALL_PREFIX={{ install_prefix }}
+    {% else %}
+        PKG_INSTALL_PREFIX="$RPM_INSTALL_PREFIX0"
+    {% endif %}
+
+    for i in "${binaries[@]}"
+    do
+        update-alternatives --remove "$i" \
+            "$PKG_INSTALL_PREFIX/bin/$i"
+    done
+}
+
+if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"
+then
+   case "$1" in
+       (remove|upgrade)
+           do_update_alternatives
+       ;;
+       (purge)
+           # nothing to do
+       ;;
+       (*)
+           exit 0
+       ;;
+   esac
+else
+    do_update_alternatives
+fi


### PR DESCRIPTION
Implements unified postinstall and prerm script handling for Debian and RPM native package builds.
Remove libgcc and python dependency from amdrocm-llvm package