### PR TITLE
[third-party/sysdeps/common/gmp] Workaround timestamping issues with cmake copies

### DIFF
--- a/third-party/sysdeps/common/gmp/CMakeLists.txt
+++ b/third-party/sysdeps/common/gmp/CMakeLists.txt
@@ -71,6 +71,18 @@ endif()
 # patch the sources.
 set(SOURCE_COPY_DIR "${CMAKE_CURRENT_BINARY_DIR}/s")
 
+# The important timestamped files we want to preserve.
+set(CRITICAL_FILES
+  "doc/gmp.info"
+  "doc/gmp.info-1"
+  "doc/gmp.info-2"
+)
+
+# Add the full path to the critical files.
+foreach(stamped_file ${CRITICAL_FILES})
+  list(APPEND TIMESTAMPED_FILES "${SOURCE_COPY_DIR}/${stamped_file}")
+endforeach()
+
 add_custom_target(
   build ALL
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
@@ -78,6 +90,12 @@ add_custom_target(
     "${CMAKE_COMMAND}" -E rm -rf -- "${CMAKE_INSTALL_PREFIX}" "${SOURCE_COPY_DIR}"
   COMMAND
     "${CMAKE_COMMAND}" -E copy_directory "${SOURCE_DIR}" "${SOURCE_COPY_DIR}"
+  COMMAND
+    # Unfortunately the source directory copy can change all of the timestamps
+    # and GMP's build system is particularly picky with them. As a workaround,
+    # touch a few critical files to make sure the build system is happy and does
+    # not want to call autotools or regenerate the documentation.
+    "${CMAKE_COMMAND}" -E touch ${TIMESTAMPED_FILES}
   #
   # OPTIONAL: Patching of the sources should happen here.
   #


### PR DESCRIPTION
After downloading and extracting the sources we duplicate the source directory so we can potentially patch the sources according to our needs.

This cmake-based copy ends up resetting the timestamp of *every* file in the source directory.

Though this is somewhat harmless, autotools-based projects use timestamps to recognize when files need to be regenerated. Since we use a release tarball for GMP we don't need to regenerate anything.

The workaround for this, until we have a better solution, is to touch some of the documentation files so the timestamp issues don't trigger a call to makeinfo (unavailable on some systems by default) to regenerate the docs.

For an example of the problem, see this: https://github.com/ROCm/rocm-libraries/actions/runs/20577859175/job/59098861004