### PR TITLE
Bump requests to 2.32.4

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,6 @@ pytest-timeout==2.4.0
 PyYAML==6.0.2
 tabulate==0.9.0
 prettytable==3.12.0
-requests==2.32.3
+requests==2.32.4
 jsonschema==4.23.0
 packaging==25.0


### PR DESCRIPTION
## Motivation

Requests releases prior to 2.32.4 may leak .netrc credentials to third parties for specific maliciously-crafted URLs (CVE-2024-47081 [1]). Bumping to a patched version.

## Technical Details

[1] https://seclists.org/fulldisclosure/2025/Jun/2

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
