### PR TITLE
Create /opt/rocm/core symlinks

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1571,7 +1571,7 @@
     "Gfxarch": "True"
   },
   {
-    "Comments": "Meta Package defintions start from here. There will not be any artifactory for meta packages. Gfxarch should be false for meta packages",
+    "Comments": "Meta Package defintions start from here. There will not be any artifactory for meta packages.",
     "Package": "amdrocm-core",
     "Version": "",
     "Architecture": "amd64",

--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-postinst.j2
@@ -52,6 +52,11 @@ do_update_alternatives(){
        PKG_INSTALL_PREFIX="$RPM_INSTALL_PREFIX0"
     {% endif %}
 
+    # Install /opt/rocm/core soft link
+    update-alternatives --install "/opt/rocm/core" "core" "$PKG_INSTALL_PREFIX" "$altscore"
+    update-alternatives --install "/opt/rocm/core-{{ version_major }}" "core-{{ version_major }}" "$PKG_INSTALL_PREFIX" "$altscore"
+
+
     for i in "${binaries[@]}"
     do
         # No obvious recover strategy if things fail

--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-prerm.j2
@@ -29,6 +29,10 @@ do_update_alternatives(){
         update-alternatives --remove "$i" \
             "$PKG_INSTALL_PREFIX/bin/$i"
     done
+
+    # Remove /opt/rocm/core soft link
+    update-alternatives --remove "core" "$PKG_INSTALL_PREFIX"
+    update-alternatives --remove "core-{{ version_major }}" "$PKG_INSTALL_PREFIX"
 }
 
 if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"

--- a/build_tools/packaging/linux/template/scripts/amdrocm-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-postinst.j2
@@ -52,6 +52,11 @@ do_update_alternatives(){
        PKG_INSTALL_PREFIX="$RPM_INSTALL_PREFIX0"
     {% endif %}
 
+    # Install /opt/rocm/core soft link
+    update-alternatives --install "/opt/rocm/core" "core" "$PKG_INSTALL_PREFIX" "$altscore"
+    update-alternatives --install "/opt/rocm/core-{{ version_major }}" "core-{{ version_major }}" "$PKG_INSTALL_PREFIX" "$altscore"
+
+
     for i in "${binaries[@]}"
     do
         # No obvious recover strategy if things fail

--- a/build_tools/packaging/linux/template/scripts/amdrocm-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-prerm.j2
@@ -29,6 +29,10 @@ do_update_alternatives(){
         update-alternatives --remove "$i" \
             "$PKG_INSTALL_PREFIX/bin/$i"
     done
+
+    # Remove /opt/rocm/core soft link
+    update-alternatives --remove "core" "$PKG_INSTALL_PREFIX"
+    update-alternatives --remove "core-{{ version_major }}" "$PKG_INSTALL_PREFIX"
 }
 
 if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"


### PR DESCRIPTION
Create the following symlinks during amdrocm and amdrocm-core installation:
/opt/rocm/core -> /opt/rocm/core-versionmajor.versionminor
/opt/rocm/core-<major> -> /opt/rocm/core-versionmajor.versionminor 
Also updated a comment in package.json