### PR TITLE
Enable gfx1152/3 for rocWMMA

### DIFF
--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -149,13 +149,11 @@ therock_add_amdgpu_target(gfx1152 "AMD Krackan 1 iGPU" FAMILY igpu-all gfx115X-a
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rccl  # https://github.com/ROCm/TheRock/issues/150
-    rocWMMA # https://github.com/ROCm/TheRock/issues/1944
 )
 therock_add_amdgpu_target(gfx1153 "AMD Radeon 820M iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rccl  # https://github.com/ROCm/TheRock/issues/150
-    rocWMMA # https://github.com/ROCm/TheRock/issues/1944
 )
 
 # gfx120X family


### PR DESCRIPTION
## Motivation

The rocWMMA project will now build with gfx1152/3 targets.  This PR enables them in TheRock as well.

## Technical Details

## Test Plan

Test on gfx1153 once the machine is stable.  See: https://github.com/ROCm/TheRock/issues/2682

TODO: remove the `skip-ci` label and re-run CI.

## Test Result

_pending_

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
