### PR TITLE
[rocrtst] Mark the artifact as target-neutral.

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -387,7 +387,7 @@ feature_group = "CORE"  # Part of core, enabled by default
 
 [artifacts.rocrtst]
 artifact_group = "rocrtst"
-type = "target-specific"
+type = "target-neutral"
 artifact_deps = ["core-runtime", "core-ocl"]
 feature_name = "CORE_RUNTIME_TESTS"
 feature_group = "CORE"


### PR DESCRIPTION
This is presently redundant in BUILD_TOPOLOGY and therock_provide_artifact and should match. In the future, we will do an LSC to unify these into just the BUILD_TOPOLOGY one. For now, just making a point fix.
