### PR TITLE
[hipDNN] [ALMIOPEN-870] Adding flatbuffer::flatc to provided artifacts for hipDNN customer builds

### DIFF
--- a/third-party/flatbuffers/CMakeLists.txt
+++ b/third-party/flatbuffers/CMakeLists.txt
@@ -14,7 +14,7 @@ therock_cmake_subproject_declare(therock-flatbuffers
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
   CMAKE_ARGS
     -DFLATBUFFERS_BUILD_TESTS=OFF
-    -DFLATBUFFERS_BUILD_FLATC=OFF
+    -DFLATBUFFERS_BUILD_FLATC=ON
 )
 therock_cmake_subproject_provide_package(therock-flatbuffers flatbuffers lib/cmake)
 therock_cmake_subproject_activate(therock-flatbuffers)
@@ -24,6 +24,7 @@ therock_provide_artifact(flatbuffers
   DESCRIPTOR artifact-flatbuffers.toml
   COMPONENTS
     dev
+    run
   SUBPROJECT_DEPS
     therock-flatbuffers
 )

--- a/third-party/flatbuffers/artifact-flatbuffers.toml
+++ b/third-party/flatbuffers/artifact-flatbuffers.toml
@@ -1,2 +1,3 @@
 # flatbuffers
 [components.dev."third-party/flatbuffers/stage"]
+[components.run."third-party/flatbuffers/stage"]


### PR DESCRIPTION
## Motivation
hipDNN is a graph-based library that allows consumers to build graphs of operation nodes that are processed and fulfilled on the GPU by engine provider plugins.  The architecture is data-agnostic between the frontend and the engine plugins on the backend, which means that consumers can write new frontend nodes and new engine plugins with the hipDNN software in the middle being none the wiser.

Part of this adaptability is provided by flatbuffers, which allows a data schema that allows forward compatibility as graphs are serialized, passed through hipDNN, and processed by engine plugins.

Since our consuming users can write new graph nodes and new plugins, they must also be able to add new types to the flatbuffer schema and then have them processed from schema .fbs files into header files.

Ideally for them, they can just point at a ROCm distribution and all the utilities are available for them to modify to their hearts content.  `flatc` is one of the utilities necessary for that.

## Technical Details
- Added `flatc` to the build cmake
- Added `flatc` to the provided artifacts toml

## Test Plan
- Verify that flatc is available in the bin folder
- Verify that the appropriate flatbuffer::flatc cmake target is available
- Test by using ROCm artifacts for a standalone hipDNN build

## Test Result
- [x] - `flatc` binary and cmake targets available
- [x] hipDNN builds in standalone (see issue [#3516](https://github.com/ROCm/rocm-libraries/issues/3516))

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
