### PR TITLE
[ci] Fixing CI nightly tests to run all tests

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -59,7 +59,6 @@ from amdgpu_family_matrix import (
     get_all_families_for_trigger_types,
 )
 from fetch_test_configurations import test_matrix
-from benchmarks.benchmark_test_matrix import benchmark_matrix
 
 from github_actions_utils import *
 
@@ -248,7 +247,7 @@ def filter_known_names(
         ), "target_matrix must be provided for 'target' name_type"
         known_references = {"target": target_matrix}
     else:
-        known_references = {"test": test_matrix, "benchmark": benchmark_matrix}
+        known_references = {"test": test_matrix}
 
     filtered_names = []
     if name_type not in known_references:
@@ -511,12 +510,6 @@ def matrix_generator(
         )
         for key in amdgpu_family_info_matrix_all:
             selected_target_names.append(key)
-
-        # Add benchmark labels to selected_test_names so they're included in test labels for nightly runs
-        requested_benchmark_names = list(benchmark_matrix.keys())
-        selected_test_names.extend(
-            filter_known_names(requested_benchmark_names, "benchmark")
-        )
 
     # Ensure the lists are unique
     unique_target_names = list(set(selected_target_names))

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -360,14 +360,7 @@ class ConfigureCITest(unittest.TestCase):
         self.assert_target_output_is_valid(
             target_output=linux_target_output, allow_xfail=True
         )
-        # For nightly runs, benchmark tests should be included in test labels
-        expected_benchmark_labels = set(benchmark_matrix.keys())
-        actual_benchmark_labels = set(linux_test_labels)
-        self.assertEqual(
-            actual_benchmark_labels,
-            expected_benchmark_labels,
-            f"Nightly builds should include all benchmark test labels",
-        )
+        self.assertEqual(linux_test_labels, [])
 
     def test_windows_schedule_matrix_generator(self):
         windows_target_output, windows_test_labels = configure_ci.matrix_generator(
@@ -383,14 +376,7 @@ class ConfigureCITest(unittest.TestCase):
         self.assert_target_output_is_valid(
             target_output=windows_target_output, allow_xfail=True
         )
-        # For nightly runs, benchmark tests should be included in test labels
-        expected_benchmark_labels = set(benchmark_matrix.keys())
-        actual_benchmark_labels = set(windows_test_labels)
-        self.assertEqual(
-            actual_benchmark_labels,
-            expected_benchmark_labels,
-            f"Nightly builds should include all benchmark test labels",
-        )
+        self.assertEqual(windows_test_labels, [])
 
     ###########################################################################
     # Tests for multi_arch mode


### PR DESCRIPTION
## Motivation

Noticed that [CI nightly tests were only running sanity checks and benchmarks, but no other tests](https://github.com/ROCm/TheRock/actions/runs/20631377611/job/59253323328). This PR will fix and run all tests for CI nightly!

I tried reverting https://github.com/ROCm/TheRock/pull/2261 but this error occurs: "Sorry, this pull request couldn’t be reverted automatically. It may have already been reverted, or the content may have changed since it was merged.", so unfortunately cannot  rollback code :( 

## Technical Details

CI nightlies gets a hard-coded test labels during CI nightlies `linux_test_labels: ['rocrand_bench', 'rocsolver_bench', 'rocfft_bench', 'hipblaslt_bench']`, resulting in only running benchmark tests.

Removing this logic as scheduled CI runs can't even pick up labels. as logic is removed, this will pick up all the correct tests via `fetch_test_configurations.py`

## Test Plan

`configure_ci.py` unit tests is fixed and passing to correctly resolve this

local testing done with `fetch_test_configurations.py`

## Test Result

unit tests:
```
 python build_tools/github_actions/tests/configure_ci_test.py
should_ci_run_given_modified_paths findings:
  related_to_ci: False
  contains_other_non_skippable_files: False
Only unrelated and/or skippable paths were modified, skipping build jobs
...
Generated test list: []
.
----------------------------------------------------------------------
Ran 26 tests in 0.008s
```

local testing with fetch_test_configurations.py

```
RUNNER_OS=linux AMDGPU_FAMILIES=gfx94X-dcgpu python build_tools/github_actions/fetch_test_configurations.py
INFO:root:Selecting projects: *
INFO:root:Using test_matrix only (regular tests)
INFO:root:Including job rocblas with test_type full
INFO:root:Including job rocroller with test_type full
INFO:root:Including job hipblas with test_type full
INFO:root:Including job hipblaslt with test_type full
INFO:root:Including job hipsolver with test_type full
INFO:root:Including job rocsolver with test_type full
INFO:root:Including job rocprim with test_type full
INFO:root:Including job hipcub with test_type full
INFO:root:Including job rocthrust with test_type full
INFO:root:Including job hipsparse with test_type full
INFO:root:Including job rocsparse with test_type full
INFO:root:Including job rocrand with test_type full
INFO:root:Including job hiprand with test_type full
INFO:root:Including job rocfft with test_type full
INFO:root:Including job hipfft with test_type full
INFO:root:Including job miopen with test_type full
INFO:root:Including job hipdnn with test_type full
INFO:root:Including job miopen_plugin with test_type full
INFO:root:Including job rocwmma with test_type full
```

benchmark tests
```
 RUNNER_OS=linux AMDGPU_FAMILIES=gfx94X-dcgpu IS_BENCHMARK_WORKFLOW=true python build_tools/github_actions/fetc
h_test_configurations.py
INFO:root:Selecting projects: *
INFO:root:Using benchmark_matrix only (benchmark tests)
INFO:root:Including job hipblaslt_bench with test_type full
INFO:root:Including job rocsolver_bench with test_type full
INFO:root:Including job rocrand_bench with test_type full
INFO:root:Including job rocfft_bench with test_type full
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
