### PR TITLE
Fix RDC runtime library lookup failures

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -441,10 +441,20 @@ function(therock_cmake_subproject_declare target_name)
 
   # RPATH Executable and Library dir.
   if(NOT ARG_INSTALL_RPATH_EXECUTABLE_DIR)
-    set(ARG_INSTALL_RPATH_EXECUTABLE_DIR "bin")
+    if(ARG_INSTALL_DESTINATION)
+      set(ARG_INSTALL_RPATH_EXECUTABLE_DIR ARG_INSTALL_DESTINATION)
+      cmake_path(APPEND ARG_INSTALL_RPATH_EXECUTABLE_DIR "bin")
+    else()
+      set(ARG_INSTALL_RPATH_EXECUTABLE_DIR "bin")
+    endif()
   endif()
   if(NOT ARG_INSTALL_RPATH_LIBRARY_DIR)
-    set(ARG_INSTALL_RPATH_LIBRARY_DIR "lib")
+    if(ARG_INSTALL_DESTINATION)
+      set(ARG_INSTALL_RPATH_LIBRARY_DIR ARG_INSTALL_DESTINATION)
+      cmake_path(APPEND ARG_INSTALL_RPATH_EXECUTABLE_DIR "lib")
+    else()
+      set(ARG_INSTALL_RPATH_LIBRARY_DIR "lib")
+    endif()
   endif()
 
   # Build pool determination.

--- a/dctools/CMakeLists.txt
+++ b/dctools/CMakeLists.txt
@@ -37,6 +37,13 @@ if(THEROCK_ENABLE_RDC)
     INSTALL_DESTINATION
       portable-rdc
 
+    # RDC's INSTALL_DESTINATION (portable-rdc/) is flattened away by artifact-flatten.
+    # RPATH must be relative to the final flattened location (bin/, lib/).
+    INSTALL_RPATH_EXECUTABLE_DIR
+      bin
+    INSTALL_RPATH_LIBRARY_DIR
+      lib
+
     INTERFACE_LINK_DIRS
       lib
 


### PR DESCRIPTION
## Motivation

Fix RDC runtime library lookup failures reported in ROCM-393. When running `rdcd`, the binaries fail to find `libcap.so.2.69`, `libamd_smi.so.26`, `librdc_bootstrap.so.1`, and `librocm_sysdeps_z.so.1`.

This PR addresses two issues:
1. Incorrect RPATH calculation when using `INSTALL_DESTINATION` with artifact-flatten
2. Incorrect SONAME for bundled libcap library

## Technical Details

1. Fix RPATH calculation in `cmake/therock_subproject.cmake`
When a subproject uses `INSTALL_DESTINATION` (e.g., RDC with "portable-rdc"), the RPATH was incorrectly calculated relative to the subdirectory path (`portable-rdc/bin`). However, `artifact-flatten` flattens the directory structure to the root level (`bin/`), causing the RUNPATH to have extra `../` components.

Before: `$ORIGIN/../../lib` (incorrect - looks for `dist/lib` which doesn't exist)
After: `$ORIGIN/../lib` (correct - looks for `dist/rocm/lib`)

The fix removes `INSTALL_DESTINATION` from RPATH calculation since artifact-flatten always flattens to standard `bin/` and `lib/` directories.

2. Clean up SONAME handling in `third-party/sysdeps/linux/libcap/patch_install.sh`
Remove redundant manual `patchelf --set-soname` calls since `patch_linux_so.py` already correctly handles SONAME modification, changing `libcap.so.2.69` to `librocm_sysdeps_cap.so.2`.

## Test Plan

1. Build RDC in personal branch with updates above
2. Install built ROCm packages into /opt/rocm-7.11 and enter /opt folder
3. Verify RUNPATH is correct: `readelf -d rocm-7.11/bin/rdcd | grep RUNPAT`
4. Verify library resolution: `ldd rocm-7.11/bin/rdcd`
5. Verify libcap SONAME: `readelf -d rocm-7.11/lib/rocm_sysdeps/lib/librocm_sysdeps_cap.so.2 | grep SONAME`

## Test Result

1. Built RDC in personal branch and generated packages in https://[therock-ci-artifacts.s3.amazonaws.com/20399201218-linux/index-gfx94X-dcgpu.html](https://therock-ci-artifacts.s3.amazonaws.com/20399201218-linux/index-gfx94X-dcgpu.html)
2. Installed packages into a ubuntu24.04 clean docker container
3. RUNPATH verification:
readelf -d rocm-7.11/bin/rdcd | grep RUNPAT
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib:$ORIGIN/../lib/rocm_sysdeps/lib:$ORIGIN/../lib/llvm/lib:/__w/TheRock/TheRock/build/base/amdsmi/dist/lib:/__w/TheRock/TheRock/build/third-party/sysdeps/linux/zlib/build/dist/lib/rocm_sysdeps/lib]
4. Library resolution (ldd): All libraries found correctly
ldd rocm-7.11/bin/rdcd
        linux-vdso.so.1 (0x00007ffcf5b91000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007efdf40bd000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007efdf40b8000)
        librocm_sysdeps_cap.so.2 => /opt/rocm-7.11/bin/../lib/rocm_sysdeps/lib/librocm_sysdeps_cap.so.2 (0x00007efdf40aa000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007efdf40a5000)
        libamd_smi.so.26 => /opt/rocm-7.11/bin/../lib/libamd_smi.so.26 (0x00007efdf3d8f000)
        librdc_bootstrap.so.1 => /opt/rocm-7.11/bin/../lib/librdc_bootstrap.so.1 (0x00007efdf3d6d000)
        librocm_sysdeps_z.so.1 => /opt/rocm-7.11/bin/../lib/rocm_sysdeps/lib/librocm_sysdeps_z.so.1 (0x00007efdf3d4e000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007efdf3ad0000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007efdf39e7000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007efdf39b9000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007efdf37a5000)
        /lib64/ld-linux-x86-64.so.2 (0x00007efdf40c7000)
5. libcap SONAME: `librocm_sysdeps_cap.so.2` (Correct, not libcap.so.2.69)
readelf -d rocm-7.11/lib/rocm_sysdeps/lib/librocm_sysdeps_cap.so.2 | grep SONAME
 0x000000000000000e (SONAME)             Library soname: [librocm_sysdeps_cap.so.2]

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
