### PR TITLE
[Windows/pytorch] Add DISTUTILS_USE_SDK=1 for torchaudio builds

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -871,6 +871,13 @@ def do_build_pytorch_audio(
         }
     )
 
+    if is_windows:
+        env.update(
+            {
+                "DISTUTILS_USE_SDK": "1",
+            }
+        )
+
     remove_dir_if_exists(pytorch_audio_dir / "dist")
     if args.clean:
         remove_dir_if_exists(pytorch_audio_dir / "build")


### PR DESCRIPTION
pytorch builds seem to be failing atm:
https://github.com/ROCm/TheRock/actions/runs/20709738546/job/59447303344
 
Error logs suggest it is during the sanity check, right before the torchaudio build. Or the torchaudio build is failing at setup.py
 
```
2026-01-05T09:34:35.3995428Z ++ Capture [C:\Users\ContainerAdministrator\AppData\Local\Temp]$ 'C:\home\runner\_work\_tool\Python\3.11.9\x64\python.exe' -c 'import torch; print(torch.cuda.is_available())'
2026-01-05T09:34:35.3996861Z Error capturing output: Command '['C:\\home\\runner\\_work\\_tool\\Python\\3.11.9\\x64\\python.exe', '-c', 'import torch; print(torch.cuda.is_available())']' returned non-zero exit status 1.
2026-01-05T09:34:35.3997717Z Output from the failed command:
2026-01-05T09:34:35.3998032Z Traceback (most recent call last):
2026-01-05T09:34:35.3998571Z   File "<string>", line 1, in <module>
2026-01-05T09:34:35.3999436Z   File "C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\torch\__init__.py", line 156, in <module>
2026-01-05T09:34:35.4000040Z     _rocm_init.initialize()
2026-01-05T09:34:35.4000644Z   File "C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\torch\_rocm_init.py", line 4, in initialize
2026-01-05T09:34:35.4001250Z     rocm_sdk.initialize_process(
2026-01-05T09:34:35.4001912Z   File "C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\rocm_sdk\__init__.py", line 133, in initialize_process
2026-01-05T09:34:35.4002688Z     preload_libraries(*preload_shortnames, rtld_global=rtld_global)
2026-01-05T09:34:35.4003541Z   File "C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\rocm_sdk\__init__.py", line 102, in preload_libraries
2026-01-05T09:34:35.4004223Z     cdll = ctypes.CDLL(str(path), mode=mode)
2026-01-05T09:34:35.4004565Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-01-05T09:34:35.4005122Z   File "C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\ctypes\__init__.py", line 376, in __init__
2026-01-05T09:34:35.4005999Z     self._handle = _dlopen(self._name, mode)
2026-01-05T09:34:35.4006329Z                    ^^^^^^^^^^^^^^^^^^^^^^^^^
2026-01-05T09:34:35.4006916Z OSError: [WinError 193] %1 is not a valid Win32 application
```

Another build was failing while trying to build torchaudio https://github.com/ROCm/TheRock/actions/runs/20663139421/job/59329824328:
```
2026-01-02T18:51:23.9838823Z Sanity check output:
2026-01-02T18:51:23.9839053Z False
2026-01-02T18:51:23.9839503Z   pytorch audio BUILD_VERSION: 2.10.0a0+devrocm7.11.0.dev0-cda2d13bfb392948d2e59e09ccdb0bca9772c7c3
2026-01-02T18:51:23.9840214Z ++ Exec [B:\src\audio]$ 'C:\home\runner\_work\_tool\Python\3.11.9\x64\python.exe' setup.py bdist_wheel
2026-01-02T18:51:23.9840692Z :: Env:
2026-01-02T18:51:23.9840888Z   PYTHONUTF8=1
2026-01-02T18:51:23.9841339Z   CMAKE_PREFIX_PATH=C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\_rocm_sdk_devel\lib\cmake
2026-01-02T18:51:23.9842076Z   ROCM_HOME=C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\_rocm_sdk_devel
2026-01-02T18:51:23.9842704Z   ROCM_PATH=C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\_rocm_sdk_devel
2026-01-02T18:51:23.9843183Z   PYTORCH_ROCM_ARCH=gfx1151
2026-01-02T18:51:23.9843435Z   USE_KINETO=OFF
2026-01-02T18:51:23.9843891Z   HIP_CLANG_PATH=C:/home/runner/_work/_tool/Python/3.11.9/x64/Lib/site-packages/_rocm_sdk_devel/lib/llvm/bin
2026-01-02T18:51:23.9844699Z   CC=C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\_rocm_sdk_devel\lib\llvm\bin\clang-cl.exe
2026-01-02T18:51:23.9845485Z   CXX=C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\_rocm_sdk_devel\lib\llvm\bin\clang-cl.exe
2026-01-02T18:51:23.9846310Z   HIP_DEVICE_LIB_PATH=C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\_rocm_sdk_devel\lib\llvm\amdgcn\bitcode
2026-01-02T18:51:23.9846910Z   BLAS=OpenBLAS
2026-01-02T18:51:23.9847392Z   OpenBLAS_HOME=C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\site-packages\_rocm_sdk_devel\lib\host-math
2026-01-02T18:51:23.9847966Z   OpenBLAS_LIB_NAME=rocm-openblas
2026-01-02T18:51:23.9848475Z   BUILD_VERSION=2.10.0a0+devrocm7.11.0.dev0-cda2d13bfb392948d2e59e09ccdb0bca9772c7c3
2026-01-02T18:51:23.9848935Z   BUILD_NUMBER=1
2026-01-02T18:51:23.9849154Z   USE_ROCM=1
2026-01-02T18:51:23.9849342Z   USE_CUDA=0
2026-01-02T18:51:23.9849544Z   USE_FFMPEG=1
2026-01-02T18:51:23.9849742Z   USE_OPENMP=1
2026-01-02T18:51:23.9849922Z   BUILD_SOX=0
2026-01-02T18:51:23.9850234Z Traceback (most recent call last):
2026-01-02T18:51:23.9851123Z   File "C:\home\runner\_work\TheRock\TheRock\external-builds\pytorch\build_prod_wheels.py", line 1043, in <module>
2026-01-02T18:51:23.9851928Z     main(sys.argv[1:])
2026-01-02T18:51:23.9852699Z   File "C:\home\runner\_work\TheRock\TheRock\external-builds\pytorch\build_prod_wheels.py", line 1039, in main
2026-01-02T18:51:23.9853245Z     args.func(args)
2026-01-02T18:51:23.9853747Z   File "C:\home\runner\_work\TheRock\TheRock\external-builds\pytorch\build_prod_wheels.py", line 496, in do_build
2026-01-02T18:51:23.9855788Z     do_build_pytorch_audio(args, pytorch_audio_dir, dict(env))
2026-01-02T18:51:23.9856648Z   File "C:\home\runner\_work\TheRock\TheRock\external-builds\pytorch\build_prod_wheels.py", line 871, in do_build_pytorch_audio
2026-01-02T18:51:23.9857449Z     exec([sys.executable, "setup.py", "bdist_wheel"], cwd=pytorch_audio_dir, env=env)
2026-01-02T18:51:23.9858505Z   File "C:\home\runner\_work\TheRock\TheRock\external-builds\pytorch\build_prod_wheels.py", line 175, in exec
2026-01-02T18:51:23.9862181Z     subprocess.check_call(args, cwd=str(cwd), env=full_env)
2026-01-02T18:51:23.9862896Z   File "C:\home\runner\_work\_tool\Python\3.11.9\x64\Lib\subprocess.py", line 413, in check_call
2026-01-02T18:51:23.9863454Z     raise CalledProcessError(retcode, cmd)
2026-01-02T18:51:23.9864247Z subprocess.CalledProcessError: Command '['C:\\home\\runner\\_work\\_tool\\Python\\3.11.9\\x64\\python.exe', 'setup.py', 'bdist_wheel']' returned non-zero exit status 1.
```

This PR may fix those builds.