### PR TITLE
Add gfxarch support to artifact directory generation in package.json

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1495,6 +1495,7 @@
     "Artifactory": [
       {
         "Artifact": "hipdnn",
+        "Artifact_Gfxarch": "False",
         "Artifact_Subdir": [
           {
             "Name": "hipDNN",
@@ -1545,6 +1546,7 @@
     "Artifactory": [
       {
         "Artifact": "hipdnn",
+        "Artifact_Gfxarch": "False",
         "Artifact_Subdir": [
           {
             "Name": "hipDNN",

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -169,6 +169,23 @@ def is_packaging_disabled(pkg_info):
     return is_key_defined(pkg_info, "Disablepackaging")
 
 
+def is_gfxarch_package(pkg_info):
+    """Check whether the package is associated with a graphics architecture
+
+    Parameters:
+    pkg_info (dict): A dictionary containing package details.
+
+    Returns:
+    bool : True if Gfxarch is set, else False.
+           #False if devel package
+    """
+    #  Disabling this for time being as per the requirements
+    #   if pkgname.endswith("-devel"):
+    #       return False
+
+    return is_key_defined(pkg_info, "Gfxarch")
+
+
 def get_package_info(pkgname):
     """Retrieves package details from a JSON file for the given package name
 
@@ -186,26 +203,6 @@ def get_package_info(pkgname):
             return package
 
     return None
-
-
-def check_for_gfxarch(pkgname):
-    """Check whether the package is associated with a graphics architecture
-
-    Parameters:
-    pkgname : Package Name
-
-    Returns:
-    bool : True if Gfxarch is set else False.
-            False if devel package
-    """
-    #  Disabling this for time being as per the requirements
-    #   if pkgname.endswith("-devel"):
-    #       return False
-
-    pkg_info = get_package_info(pkgname)
-    if str(pkg_info.get("Gfxarch", "false")).strip().lower() == "true":
-        return True
-    return False
 
 
 def get_package_list():


### PR DESCRIPTION
Extend the artifact directory generation logic to support gfxarch values
defined at the artifact level. Previously, directory suffix selection
relied solely on the package-level gfxarch setting, which prevented
artifacts from specifying their own architecture requirements.

With this update, each artifact can optionally define an
Artifact_Gfxarch field. When present, this value is used to determine
the directory suffix for that specific artifact. If the field is
missing, the logic falls back to the package-level gfxarch setting to
ensure consistent behavior.

This change improves flexibility for mixed-architecture packages and
ensures that artifact-specific overrides are respected without altering
the behavior of packages that do not define per-artifact gfxarch data.
