### PR TITLE
Revert "Update Python version support in documentation and workflows"

### DIFF
--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.11", "3.12", "3.13"]
         pytorch_git_ref: ["release/2.7", "release/2.8", "release/2.9", "nightly"]
         include:
           - pytorch_git_ref: release/2.7

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.11", "3.12", "3.13"]
         pytorch_git_ref: ["release/2.9", "nightly"]
         include:
           - pytorch_git_ref: release/2.9

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -38,7 +38,7 @@ Table of contents:
 We recommend installing ROCm and projects like PyTorch via `pip`, the
 [Python package installer](https://packaging.python.org/en/latest/guides/tool-recommendations/).
 
-We currently support Python 3.10, 3.11, 3.12, and 3.13.
+We currently support Python 3.11, 3.12, and 3.13.
 
 > [!TIP]
 > We highly recommend working within a [Python virtual environment](https://docs.python.org/3/library/venv.html):

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -88,7 +88,7 @@ detailed instructions. That information is summarized here.
 
 ### Prerequisites and setup
 
-You will need a supported Python version (3.10+) on a system which we build the
+You will need a supported Python version (3.11+) on a system which we build the
 `rocm[libraries,devel]` packages for. See the
 [`RELEASES.md`: Installing releases using pip](../../RELEASES.md#installing-releases-using-pip)
 and [Python Packaging](../../docs/packaging/python_packaging.md) documentation


### PR DESCRIPTION
## Summary

This reverts commit b774df4f671e213d1d0d62dcfcd91afa727b7953 (PR #2574).

## Reason

PR #2574 was merged prematurely. The Python 3.10 compatibility fixes (PR #2779) need to be merged first before enabling Python 3.10 in the build workflows.

The correct order should be:
1. PR #2779: Fix Python 3.10 Compatibility Issues (compatibility fixes)
2. PR #2574: Add Python 3.10 Support for PyTorch Builds (workflow changes)

## Changes Reverted

- `.github/workflows/release_portable_linux_pytorch_wheels.yml`: Remove Python 3.10 from build matrix
- `.github/workflows/release_windows_pytorch_wheels.yml`: Remove Python 3.10 from build matrix
- `RELEASES.md`: Revert Python version requirement
- `external-builds/pytorch/README.md`: Revert minimum Python version
