### PR TITLE
[ci] Re-enabling gfx1150 linux machine

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -175,9 +175,7 @@ amdgpu_family_info_matrix_nightly = {
     },
     "gfx1150": {
         "linux": {
-            # TODO(#2614): Re-enable machine once it is stable
-            # Label is "linux-gfx1150-gpu-rocm"
-            "test-runs-on": "",
+            "test-runs-on": "linux-gfx1150-gpu-rocm",
             "family": "gfx1150",
             "build_variants": ["release"],
             "sanity_check_only_for_family": True,


### PR DESCRIPTION
## Motivation

From #2614, we are disabling gfx1150 machines. however, `linux-strix-halo-gpu-rocm-1` is nowhere to find and thus cannot debug/fix. however, we have 2 gfx1150 machines that are healthy so we can re-enable this runner

## Technical Details

Re-enabling gfx1150 Linux test machines

## Test Plan

Testing via CI workflow_dispatch. Since this is tested via test machine, CI is skipped

## Test Result

Test works here: https://github.com/ROCm/TheRock/actions/runs/20760306307/job/59615409472

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Closes #2614 
