### PR TITLE
[ci] Re-enabling `hipdnn` tests for `gfx1151` windows

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn.py
@@ -11,11 +11,6 @@ AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 
 logging.basicConfig(level=logging.INFO)
 
-TESTS_TO_IGNORE = {
-    # Issue to fix: https://github.com/ROCm/TheRock/issues/2798
-    "gfx1151": ["hipdnn_backend_tests"],
-}
-
 cmd = [
     "ctest",
     "--test-dir",
@@ -26,10 +21,6 @@ cmd = [
     "--timeout",
     "60",
 ]
-
-if AMDGPU_FAMILIES in TESTS_TO_IGNORE:
-    ignore_list = TESTS_TO_IGNORE[AMDGPU_FAMILIES]
-    cmd.extend(["--exclude-regex", "|".join(ignore_list)])
 
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 


### PR DESCRIPTION
Re-enabling tests for `gfx1151` windows

[Tests work via `workflow_dispatch`](https://github.com/ROCm/TheRock/actions/runs/20786377310/job/59697319709), no need to re-build everything (thus the `skip-ci` flag)

Closes #2798