### PR TITLE
[rocgdb] Extend the cpu builder image with rocgdb deps.

### DIFF
--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -114,7 +114,7 @@ RUN which gcc && gcc --version && \
 # The manylinux /opt/python builds are statically linked and can't be embedded.
 WORKDIR /install-shared-pythons
 COPY install_shared_pythons.sh ./
-RUN ./install_shared_pythons.sh && rm -rf /install-shared-pythons
+RUN ./install_shared_pythons.sh /tmp/python-build && rm -rf /install-shared-pythons /tmp/python-build
 
 ######## GIT CONFIGURATION ########
 # Git started enforcing strict user checking, which thwarts version


### PR DESCRIPTION
* texinfo-tex (discovered missing while working)
* Shared builds of python 3.10-14 so that rocgdb can link against versions suitable for embedding python.

Note that we build these python variants from source sufficient for build time use: they do not have all features.

Adds an estimated ~250MiB to the container size and is unavoidable. Container build on a regular workstation doesn't take much more time. On the default GHA runner, it adds about 10m to the build time (12m total), which is not consequential.

Will unblock #2797 once we roll the hashes to this new version.