### PR TITLE
[ci] Halve rocThrust test parallelism on gfx1152

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
@@ -82,7 +82,9 @@ SMOKE_TESTS = [
 
 # Some platforms are less capable than others.
 ctest_parallel_count = 8
-if AMDGPU_FAMILIES == "gfx1153":
+if AMDGPU_FAMILIES == "gfx1152":
+    ctest_parallel_count = 4
+elif AMDGPU_FAMILIES == "gfx1153":
     ctest_parallel_count = 4
 
 cmd = [


### PR DESCRIPTION


## Motivation

This follows #2658, which did the same for gfx1153 after [CI timeout failures](https://github.com/ROCm/TheRock/actions/runs/20371240849/job/58539352231) were observed on gfx1153.

## Technical Details

Reduce the ctest `--parallel` option from 8 to 4 on gfx1152.

## Test Plan

1. Update workspace to https://github.com/ROCm/TheRock/commit/47512a505c9715de815205f432e333b78b6b7a09.
2. Locally modify test_rocthrust.py to remove `--repeat until-pass:6` to avoid masking intermittent problems.
3. Run the tests with the previous `--parallel 8` option for comparison.
4. Reboot the test host.
5. Run the tests with `--parallel 4` a number of times and record its success rate.

## Test Result

* Using `--parallel 8`, tests timed out on the first run.
* Using `--parallel 4`, tests ran without error at least 7 times in a row.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
