### PR TITLE
Fix MPFR build failure due to aclocal-1.17 not found

### DIFF
--- a/third-party/sysdeps/common/mpfr/CMakeLists.txt
+++ b/third-party/sysdeps/common/mpfr/CMakeLists.txt
@@ -85,6 +85,23 @@ endif()
 # patch the sources.
 set(SOURCE_COPY_DIR "${CMAKE_CURRENT_BINARY_DIR}/s")
 
+# The important timestamped files we want to preserve so autotools
+# doesn't try to regenerate them (which would require aclocal, automake, etc.).
+set(CRITICAL_FILES
+  "aclocal.m4"
+  "Makefile.in"
+  "src/Makefile.in"
+  "tests/Makefile.in"
+  "tune/Makefile.in"
+  "doc/Makefile.in"
+  "tools/bench/Makefile.in"
+)
+
+# Add the full path to the critical files.
+foreach(stamped_file ${CRITICAL_FILES})
+  list(APPEND TIMESTAMPED_FILES "${SOURCE_COPY_DIR}/${stamped_file}")
+endforeach()
+
 add_custom_target(
   build ALL
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
@@ -92,6 +109,9 @@ add_custom_target(
     "${CMAKE_COMMAND}" -E rm -rf -- "${CMAKE_INSTALL_PREFIX}" "${SOURCE_COPY_DIR}"
   COMMAND
     "${CMAKE_COMMAND}" -E copy_directory "${SOURCE_DIR}" "${SOURCE_COPY_DIR}"
+  COMMAND
+    # Touch generated files to prevent autotools from trying to regenerate them.
+    "${CMAKE_COMMAND}" -E touch ${TIMESTAMPED_FILES}
   #
   # OPTIONAL: Patching of the sources should happen here.
   #


### PR DESCRIPTION
When building therock-mpfr, the build fails with:
  [therock-mpfr] aclocal-1.17: command not found
when automake 1.17 is not installed. In our README.md's `Setup - Ubuntu (24.04)` section, we don't require to install it.

This occurs because `cmake -E copy_directory` does not preserve file timestamps. When the MPFR source is copied to the build directory, autoconf-generated files (aclocal.m4, Makefile.in) end up with newer timestamps than their source files (configure.ac, etc.), causing the autotools build system to attempt regeneration. This regeneration requires the exact automake version (1.17) that was used to generate the original files.

Fix:
Touch the critical autoconf-generated files after copying to ensure their timestamps are newer than the source files. This prevents the autotools build system from trying to regenerate them. This approach matches the existing workaround used in the GMP build (third-party/sysdeps/common/gmp/CMakeLists.txt).

## Test Plan
No aclocal-1.17 installed locally
```
rm -rf build/third-party/sysdeps/linux/mpfr
ninja -C build therock-mpfr
```

## Test Result
Succesful

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
