### PR TITLE
Add documentation for rocm_runtime.Dockerfile and installer scripts

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -82,6 +82,7 @@ Supporting scripts:
 - [`install_rocm_deps.sh`](install_rocm_deps.sh): Auto-detects the distribution
   and installs ROCm runtime dependencies using the appropriate package manager
   (apt, dnf, or tdnf).
+
 - [`install_rocm_tarball.sh`](install_rocm_tarball.sh): Downloads ROCm tarball
   from `rocm.{nightlies|prereleases|devreleases}.amd.com` or `repo.amd.com` (for
   stable releases), extracts to `/opt/rocm-{VERSION}` with `/opt/rocm` symlink.


### PR DESCRIPTION
## Motivation

Document the multi-distro ROCm runtime Dockerfile and supporting scripts

## Technical Details

Added documentation for the following files in `dockerfiles/README.md`:

- **`rocm_runtime.Dockerfile`**: Multi-distro Dockerfile that builds ROCm runtime images from TheRock prebuilt tarballs. Supports Ubuntu, AlmaLinux, and Azure Linux via `BASE_IMAGE` build argument. References Dockerfile header comments for detailed build arguments and examples.

- **`install_rocm_deps.sh`**: Script that auto-detects the Linux distribution and installs ROCm runtime dependencies using the appropriate package manager (apt, dnf, or tdnf).

- **`install_rocm_tarball.sh`**: Script that downloads ROCm tarballs from `rocm.{nightlies|prereleases|devreleases}.amd.com` or `repo.amd.com` (for stable releases) and extracts to `/opt/rocm-{VERSION}`. Includes one-liner curl command for standalone installation on Linux hosts:

  curl -sSL https://raw.githubusercontent.com/ROCm/TheRock/main/dockerfiles/install_rocm_tarball.sh | \
    sudo bash -s -- <VERSION> <AMDGPU_FAMILY> [RELEASE_TYPE]

## Test Plan

Run below command in Ubuntu24:
```bash
install_rocm_tarball.sh | \
    sudo bash -s -- 7.11.0a20260108 gfx94X-dcgpu nightlies
```
## Test Result

The installation passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
