### PR TITLE
[ci] Extending timeout for amdsmi and sanity checks

### DIFF
--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -120,7 +120,7 @@ jobs:
           # https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/debugging.html
           AMD_LOG_LEVEL: 4
         run: |
-          pytest tests/ --log-cli-level=info --timeout=60
+          pytest tests/ --log-cli-level=info --timeout=300
 
       - name: Post-job cleanup processes on Windows
         if: ${{ always() && runner.os == 'Windows' }}


### PR DESCRIPTION
Noticing timeouts for amdsmi of 60s (https://github.com/ROCm/TheRock/actions/runs/20855472993/job/59932612260), even though the job timeout is 5 mins (they should match).

Extending the timeout to allow more time to run tests in case of machine slowness issues

works here: https://github.com/ROCm/TheRock/actions/runs/20859649109/job/59935771874 (cancelled other jobs to save resources)