### PR TITLE
[torch] Drop `--pre` from release install instructions

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -254,28 +254,32 @@ Using the index pages [listed above](#installing-rocm-python-packages), you can
 also install `torch`, `torchaudio`, and `torchvision`.
 
 > [!NOTE]
-> By default, pip will install the latest versions of each package. If you want to
-> install older versions take note of the compatibility matrix:
+> By default, pip will install the latest stable versions of each package.
 >
-> | torch version | torchaudio version | torchvision version |
-> | ------------- | ------------------ | ------------------- |
-> | 2.10          | 2.10               | 0.25                |
-> | 2.9           | 2.9                | 0.24                |
-> | 2.8           | 2.8                | 0.23                |
-> | 2.7           | 2.7.1a0            | 0.22.1              |
+> - If you want to allow installing prerelease versions, use the `--pre`
 >
-> For example, `torch` 2.7.1 and compatible wheels can be installed by specifying
+> - If you want to install other versions, take note of the compatibility
+>   matrix:
 >
-> ```
-> torch==2.7.1 torchaudio==2.7.1a0 torchvision==0.22.1
-> ```
+>   | torch version | torchaudio version | torchvision version |
+>   | ------------- | ------------------ | ------------------- |
+>   | 2.10          | 2.10               | 0.25                |
+>   | 2.9           | 2.9                | 0.24                |
+>   | 2.8           | 2.8                | 0.23                |
+>   | 2.7           | 2.7.1a0            | 0.22.1              |
 >
-> See also
+>   For example, `torch` 2.7.1 and compatible wheels can be installed by specifying
 >
-> - [Supported PyTorch versions in TheRock](https://github.com/ROCm/TheRock/tree/main/external-builds/pytorch#supported-pytorch-versions)
-> - [Installing previous versions of PyTorch](https://pytorch.org/get-started/previous-versions/)
-> - [torchvision installation - compatixbility matrix](https://github.com/pytorch/vision?tab=readme-ov-file#installation)
-> - [torchaudio installation - compatixbility matrix](https://docs.pytorch.org/audio/main/installation.html#compatibility-matrix)
+>   ```
+>   torch==2.7.1 torchaudio==2.7.1a0 torchvision==0.22.1
+>   ```
+>
+>   See also
+>
+>   - [Supported PyTorch versions in TheRock](https://github.com/ROCm/TheRock/tree/main/external-builds/pytorch#supported-pytorch-versions)
+>   - [Installing previous versions of PyTorch](https://pytorch.org/get-started/previous-versions/)
+>   - [torchvision installation - compatixbility matrix](https://github.com/pytorch/vision?tab=readme-ov-file#installation)
+>   - [torchaudio installation - compatixbility matrix](https://docs.pytorch.org/audio/main/installation.html#compatibility-matrix)
 
 > [!TIP]
 > The `torch` packages depend on `rocm[libraries]`, so ROCm packages should
@@ -301,7 +305,7 @@ Supported devices in this family:
 | MI300A/MI300X | gfx942     |
 
 ```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ --pre torch torchaudio torchvision
+pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ torch torchaudio torchvision
 ```
 
 #### torch for gfx950-dcgpu
@@ -313,7 +317,7 @@ Supported devices in this family:
 | MI350X/MI355X | gfx950     |
 
 ```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ --pre torch torchaudio torchvision
+pip install --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ torch torchaudio torchvision
 ```
 
 #### torch for gfx110X-all
@@ -328,7 +332,7 @@ Supported devices in this family:
 | AMD Radeon 780M Laptop iGPU        | gfx1103    |
 
 ```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ --pre torch torchaudio torchvision
+pip install --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ torch torchaudio torchvision
 ```
 
 #### torch for gfx1151
@@ -340,7 +344,7 @@ Supported devices in this family:
 | AMD Strix Halo iGPU | gfx1151    |
 
 ```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ --pre torch torchaudio torchvision
+pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ torch torchaudio torchvision
 ```
 
 #### torch for gfx120X-all
@@ -353,7 +357,7 @@ Supported devices in this family:
 | AMD RX 9070 / XT | gfx1201    |
 
 ```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ --pre torch torchaudio torchvision
+pip install --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ torch torchaudio torchvision
 ```
 
 ### Using PyTorch Python packages


### PR DESCRIPTION
## Motivation

There has been some confusion lately over the use of `--pre` in the install commands we recommend, such as https://github.com/ROCm/TheRock/issues/2822. We added it to workaround inconsistent use of prerelease versions in the packages that we published, but that is no longer needed.

> [!IMPORTANT]
> Users will now get _"nightly rocm built against stable pytorch"_ instead of _"nightly rocm built against nightly pytorch"_.
>
> Concretely today, that will switch the installed versions from torch 2.11.0a to 2.9.1. Once we explicitly add the 2.10 release branch to our workflows that will then get picked up.

## Technical Details

We added `--pre` to these install commands back in https://github.com/ROCm/TheRock/pull/1385#discussion_r2322687433:

> Ah... okay, so the torch-2.7.1 wheels built from the rocm backport release branch have no prerelease segment [1] as of [ROCm/pytorch@e294d4d](https://github.com/ROCm/pytorch/commit/e294d4d6fb7f0552e430fd38b2acf864c8e051f2), while the torch-2.9.0a0 wheels do. It would be nice if that was consistent across all torch packages we distribute. Maybe we can suggest `--pre` in our install comments [2] as another workaround...
> 
> * [1] https://packaging.python.org/en/latest/specifications/version-specifiers/#public-version-identifiers
> * [2] https://pip.pypa.io/en/stable/development/architecture/upgrade-options/#controlling-what-gets-considered

> Nice find, `--pre` works and pulls in the latest versions on Ubuntu. With that we shouldn't need to specify version numbers on Linux (as long as our latest wheels are compatible with each other), and shouldn't affect Windows installation at the moment. Will update PR to use this in the default commands instead of the explicit versioning, and present the latter as an alternative on Linux for older versions.

Since then, we've been building from the ROCm backport release branches with stable (not prerelease) versions for torch, torchaudio, and torchvision. Nightly release builds do still have prerelease versions as expected.

## Testing

Tested install instructions on Windows for gfx1100

```bash
λ py -V:3.12 -m venv 3.12.venv && .\3.12.venv\Scripts\activate.bat

# Install without `--pre`
(3.12.venv) λ pip install --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ torch torchaudio torchvision
(3.12.venv) λ pip freeze | grep torch
# torch==2.9.1+rocm7.11.0a20260109
# torchaudio==2.9.0+rocm7.11.0a20260109
# torchvision==0.24.0+rocm7.11.0a20260109

# Install with `--pre --upgrade` (note the `a0` in the packages)
(3.12.venv) λ pip install --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ torch torchaudio torchvision --pre --upgrade
(3.12.venv) λ pip freeze | grep torch
# torch==2.11.0a0+rocm7.11.0a20260109
# torchaudio==2.11.0a0+rocm7.11.0a20260109
# torchvision==0.25.0a0+rocm7.11.0a20260109
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.