### PR TITLE
AMDSMI dependency for hipBLASLt and hipSPARSELt

### DIFF
--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -289,14 +289,11 @@ if(THEROCK_ENABLE_SPARSE)
   ##############################################################################
 
   if(NOT WIN32) # Remove this block once hipSPARSELt is supported on Windows
-    set(hipSPARSELt_optional_build_deps)
-    set(hipSPARSELt_optional_runtime_deps)
+    set(hipSPARSELt_optional_deps)
     if(NOT WIN32)
       # hipSPARSELt is hard-coded to not expect rocm-smi and amdsmi on Windows.
-      list(APPEND hipSPARSELt_optional_build_deps
+      list(APPEND hipSPARSELt_optional_deps
         amdsmi
-      )
-      list(APPEND hipSPARSELt_optional_runtime_deps
         rocm_smi_lib
       )
     endif()
@@ -319,11 +316,10 @@ if(THEROCK_ENABLE_SPARSE)
         hipSPARSE
         therock-googletest
         therock-msgpack-cxx
-        ${hipSPARSELt_optional_build_deps}
       RUNTIME_DEPS
         hip-clr
         therock-host-blas
-        ${hipSPARSELt_optional_runtime_deps}
+        ${hipSPARSELt_optional_deps}
         ${optional_profiler_deps}
     )
     therock_cmake_subproject_glob_c_sources(hipSPARSELt


### PR DESCRIPTION
Adding AMDSMI to the dependency lists for hipBLASLt and hipSPARSELt libraries as a preparatory step toward adopting the AMDSMI library and deprecating ROCmSMI.