### PR TITLE
[ci] Removing rocroller tests for gfx115X Linux and Windows

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -86,20 +86,20 @@ jobs:
           TEST_LABELS: ${{ inputs.test_labels }}
         run: python ./build_tools/github_actions/fetch_test_configurations.py
 
-  # test_sanity_check:
-  #   name: 'Test Sanity Check'
-  #   needs: configure_test_matrix
-  #   uses: './.github/workflows/test_sanity_check.yml'
-  #   with:
-  #     artifact_group: ${{ inputs.artifact_group }}
-  #     artifact_run_id: ${{ inputs.artifact_run_id }}
-  #     amdgpu_families: ${{ inputs.amdgpu_families }}
-  #     test_runs_on: ${{ inputs.test_runs_on }}
-  #     platform: ${{ needs.configure_test_matrix.outputs.platform }}
+  test_sanity_check:
+    name: 'Test Sanity Check'
+    needs: configure_test_matrix
+    uses: './.github/workflows/test_sanity_check.yml'
+    with:
+      artifact_group: ${{ inputs.artifact_group }}
+      artifact_run_id: ${{ inputs.artifact_run_id }}
+      amdgpu_families: ${{ inputs.amdgpu_families }}
+      test_runs_on: ${{ inputs.test_runs_on }}
+      platform: ${{ needs.configure_test_matrix.outputs.platform }}
 
   test_components:
     name: 'Test ${{ matrix.components.job_name }}'
-    needs: [configure_test_matrix]
+    needs: [test_sanity_check, configure_test_matrix]
     # skip tests if no test matrix to run and sanity check only requested
     if: ${{ needs.configure_test_matrix.outputs.components != '[]' && !inputs.sanity_check_only_for_family }}
     strategy:


### PR DESCRIPTION
As requested from @bnemanich , rocroller tests are not planned to be supported for gfx115X archs. 

There is no way to test this as Linux gfx1151 only runs for sanity and windows tests are not run for rocroller, thus I added the `skip-ci` flag

Ran a quick sanity check here: https://github.com/ROCm/TheRock/actions/runs/20935388667/job/60156721268 to make sure all works well