### PR TITLE
[ALMIOPEN-895] Remove positive filter to include missing tests from miopen

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -27,88 +27,7 @@ logging.basicConfig(level=logging.INFO)
 
 ###########################################
 
-positive_filter = []
 negative_filter = []
-
-# Fusion #
-positive_filter.append("*Fusion*")
-
-# Batch Normalization #
-positive_filter.append("*/GPU_BNBWD*_*")
-positive_filter.append("*/GPU_BNOCLBWD*_*")
-positive_filter.append("*/GPU_BNFWD*_*")
-positive_filter.append("*/GPU_BNOCLFWD*_*")
-positive_filter.append("*/GPU_BNInfer*_*")
-positive_filter.append("*/GPU_BNActivInfer_*")
-positive_filter.append("*/GPU_BNOCLInfer*_*")
-positive_filter.append("*/GPU_bn_infer*_*")
-
-# CPU tests
-positive_filter.append("CPU_*")  # tests without a suite
-positive_filter.append("*/CPU_*")  # tests with a suite
-
-# Different
-positive_filter.append("*/GPU_Cat_*")
-positive_filter.append("*/GPU_ConvBiasActiv*")
-
-# Convolutions
-positive_filter.append("*/GPU_Conv*")
-positive_filter.append("*/GPU_conv*")
-
-# Solvers
-positive_filter.append("*/GPU_UnitTestConv*")
-
-# Misc
-
-positive_filter.append("*/GPU_GetitemBwd*")
-positive_filter.append("*/GPU_GLU_*")
-
-positive_filter.append("*/GPU_GroupConv*")
-positive_filter.append("*/GPU_GroupNorm_*")
-positive_filter.append("*/GPU_GRUExtra_*")
-positive_filter.append("*/GPU_TestActivation*")
-positive_filter.append("*/GPU_HipBLASLtGEMMTest*")
-positive_filter.append("*/GPU_KernelTuningNetTestConv*")
-positive_filter.append("*/GPU_Kthvalue_*")
-positive_filter.append("*/GPU_LayerNormTest*")
-positive_filter.append("*/GPU_LayoutTransposeTest_*")
-positive_filter.append("*/GPU_Lrn*")
-positive_filter.append("*/GPU_lstm_extra*")
-
-positive_filter.append("*/GPU_MultiMarginLoss_*")
-positive_filter.append("*/GPU_ConvNonpack*")
-positive_filter.append("*/GPU_PerfConfig_HipImplicitGemm*")
-positive_filter.append("*/GPU_AsymPooling2d_*")
-positive_filter.append("*/GPU_WidePooling2d_*")
-positive_filter.append("*/GPU_PReLU_*")
-positive_filter.append("*/GPU_Reduce*")
-positive_filter.append("*/GPU_reduce_custom_*")
-positive_filter.append("*/GPU_regression_issue_*")
-positive_filter.append("*/GPU_RNNExtra_*")
-positive_filter.append("*/GPU_RoPE*")
-positive_filter.append("*/GPU_SoftMarginLoss*")
-positive_filter.append("*/GPU_T5LayerNormTest_*")
-positive_filter.append("*/GPU_Op4dTensorGenericTest_*")
-positive_filter.append("*/GPU_TernaryTensorOps_*")
-positive_filter.append("*/GPU_unaryTensorOps_*")
-positive_filter.append("*/GPU_Transformers*")
-positive_filter.append("*/GPU_TunaNetTest_*")
-positive_filter.append("*/GPU_UnitTestActivationDescriptor_*")
-positive_filter.append("*/GPU_FinInterfaceTest*")
-positive_filter.append("*/GPU_VecAddTest_*")
-
-positive_filter.append("*/GPU_KernelTuningNetTest*")
-positive_filter.append("*/GPU_MIOpenDriver*")
-
-positive_filter.append("*/GPU_Bwd_Mha_*")
-positive_filter.append("*/GPU_Fwd_Mha_*")
-positive_filter.append("*/GPU_Softmax*")
-positive_filter.append("*/GPU_Dropout*")
-positive_filter.append("*/GPU_MhaBackward_*")
-positive_filter.append("*/GPU_MhaForward_*")
-positive_filter.append("*GPU_TestMhaFind20*")
-
-#############################################
 
 negative_filter.append("*DeepBench*")
 negative_filter.append("*MIOpenTestConv*")
@@ -225,7 +144,6 @@ smoke_filter = [
 # TODO(rocm-libraries#2266): re-enable test for gfx950-dcgpu
 if AMDGPU_FAMILIES != "gfx950-dcgpu":
     smoke_filter.append("*DBSync*")
-    positive_filter.append("*DBSync*")
 
 ####################################################
 


### PR DESCRIPTION
## Motivation

Current implementation only allow the list of tests in positive tests to run. Any new tests added in miopen will be missed if not added to the positive list and consistently updated. To avoid missing and having to update in two places at once, we remove the postive list to include all the tests from miopen side to run. and any exclusions should be done via adding to the negative list in case of broken tests, not applicable, etc..


## Technical Details

Currnet filtering is done:
` test_filter = (
        "--gtest_filter=" + ":".join(positive_filter) + "-" + ":".join(negative_filter)
    )`
Changes to wild card in place of the positive filter
`test_filter = "--gtest_filter=" + ":*" + "-" + ":".join(negative_filter) `
## Test Plan

*  Full test pass
* Appropriate MIOpen tests disabled in TheRock 
* Document new tests that are added to the negative filter

## Test Result

CI Passed with the change and additional tests ran within time limit
## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
