### PR TITLE
[ci] Re-enabling SPARSE windows tests

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -128,7 +128,7 @@ test_matrix = {
         "fetch_artifact_args": "--blas --tests",
         "timeout_minutes": 30,
         "test_script": f"python {_get_script_path('test_hipsparse.py')}",
-        "platform": ["linux"],
+        "platform": ["linux", "windows"],
         "total_shards": 2,
     },
     "rocsparse": {
@@ -138,9 +138,6 @@ test_matrix = {
         "test_script": f"python {_get_script_path('test_rocsparse.py')}",
         "platform": ["linux", "windows"],
         "total_shards": 1,
-        "exclude_family": {
-            "windows": ["gfx1151"]  # issue: https://github.com/ROCm/TheRock/issues/1640
-        },
     },
     "hipsparselt": {
         "job_name": "hipsparselt",


### PR DESCRIPTION
Re-enabling SPARSE windows tests

hipsparse works here: https://github.com/ROCm/TheRock/actions/runs/20968688248/job/60269245210
rocsparse works here: https://github.com/ROCm/TheRock/actions/runs/20968688248/job/60269245240

Adding `skip-ci` label to preserve machine usage as workflow_dispatch tests is enough proof

Closes #1696