### PR TITLE
build_tools: Do not fetch debug tools sources for Windows

### DIFF
--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -546,11 +546,16 @@ def main(argv):
         "--debug-tools",
         nargs="+",
         type=str,
-        default=[
-            "amd-dbgapi",
-            "rocr-debug-agent",
-            "rocgdb",
-        ],
+        default=(
+            []
+            if is_windows()
+            else [
+                # Linux only projects.
+                "amd-dbgapi",
+                "rocr-debug-agent",
+                "rocgdb",
+            ]
+        ),
     )
     parser.add_argument(
         "--math-library-projects",


### PR DESCRIPTION
Debug tools are not supported on Windows yet, only Linux. Therefore restrict source-fetching to Linux.