### PR TITLE
[build_tools] Add missing debug tools artifacts to --debug-tools

### DIFF
--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -215,10 +215,22 @@ def retrieve_artifacts_by_run_id(args):
         if args.blas:
             extra_artifacts.append("blas")
         if args.debug_tools:
+            # Add extra artifacts so we generate _lib and _test artifact
+            # entries later.
             extra_artifacts.append("amd-dbgapi")
             extra_artifacts.append("rocgdb")
             extra_artifacts.append("rocr-debug-agent")
             extra_artifacts.append("rocr-debug-agent-tests")
+
+            # Add the rest of the artifacts not handled automatically (non-lib
+            # and non-test).
+            argv.append("rocgdb_run")
+
+            # Libraries rocgdb depends on.
+            extra_artifacts.append("gmp")
+            extra_artifacts.append("mpfr")
+            extra_artifacts.append("expat")
+            extra_artifacts.append("ncurses")
         if args.fft:
             extra_artifacts.append("fft")
             extra_artifacts.append("fftw3")


### PR DESCRIPTION
I noticed calling install_rocm_from_artifacts.py with --debug-tools does not
pull all of the required artifacts. We were missing rocgdb_run and,
most importantly, the gmp/mpfr/expat/ncurses sysdeps artifacts.

The artifacts for the 4 libraries were split into their own entries, so
we need to include those in the debug-tools pull to actually be able to
run rocgdb.