### PR TITLE
Include gfx1102 target to hipBLASLt build

### DIFF
--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -136,7 +136,6 @@ therock_add_amdgpu_target(gfx1101 "AMD RX 7800 XT" FAMILY dgpu-all gfx110X-all g
 therock_add_amdgpu_target(gfx1102 "AMD RX 7700S/Framework Laptop 16" FAMILY dgpu-all gfx110X-all gfx110X-dgpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
-    hipBLASLt # https://github.com/ROCm/TheRock/issues/1062
     libhipcxx # https://github.com/ROCm/TheRock/issues/2504
 )
 therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all gfx110X-all gfx110X-igpu


### PR DESCRIPTION
Navi33 is supported by hipBLASLt so it should be re-enabled in TheRock builds
This PR is just a copy of https://github.com/ROCm/TheRock/pull/2328