### PR TITLE
Parse EXCLUDE_TARGET_PROJECTS list from cmake/therock_amdgpu_targets.cmake and use that to exclude deb/rpm package creation for those gfx arch

### DIFF
--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -13,6 +13,7 @@ import sys
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Dict, Set, List, Optional
 
 
 # User inputs required for packaging
@@ -24,6 +25,8 @@ from pathlib import Path
 # gfx_arch - gfxarch used for building artifacts
 # enable_rpath - To enable RPATH packages
 # versioned_pkg - Used to indicate versioned or non versioned packages
+# skip_missing_artifacts - Skip packages with missing artifacts instead of failing
+# skipped_packages - List of packages that were skipped (for meta-package filtering)
 @dataclass
 class PackageConfig:
     artifacts_dir: Path
@@ -35,10 +38,312 @@ class PackageConfig:
     gfx_arch: str
     enable_rpath: bool = field(default=False)
     versioned_pkg: bool = field(default=True)
+    skip_missing_artifacts: bool = field(default=False)
+    skipped_packages: List[str] = field(default_factory=list)
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+# SCRIPT_DIR is build_tools/packaging/linux, so go up 3 levels to get to TheRock root
+THEROCK_ROOT = SCRIPT_DIR.parent.parent.parent
 currentFuncName = lambda n=0: sys._getframe(n + 1).f_code.co_name
+
+# Cache for parsed exclusions from cmake file
+_GFX_ARCH_EXCLUSIONS_CACHE: Optional[Dict[str, Set[str]]] = None
+# Cache for artifact subdir to package mapping (built from package.json)
+_ARTIFACT_SUBDIR_TO_PACKAGES_CACHE: Optional[Dict[str, List[str]]] = None
+
+
+def build_artifact_subdir_to_packages_map() -> Dict[str, List[str]]:
+    """Build a mapping from artifact subdirectory names to package names.
+
+    This dynamically parses package.json to find which packages use which
+    artifact subdirectories, eliminating the need for a hardcoded map.
+
+    Returns:
+        Dict mapping artifact_subdir names (e.g., "composable_kernel") to list of package names
+    """
+    global _ARTIFACT_SUBDIR_TO_PACKAGES_CACHE
+
+    if _ARTIFACT_SUBDIR_TO_PACKAGES_CACHE is not None:
+        return _ARTIFACT_SUBDIR_TO_PACKAGES_CACHE
+
+    mapping: Dict[str, List[str]] = {}
+    data = read_package_json_file()
+
+    for package in data:
+        pkg_name = package.get("Package")
+        if not pkg_name:
+            continue
+
+        artifactory = package.get("Artifactory")
+        if not artifactory:
+            continue
+
+        for artifact in artifactory:
+            artifact_subdirs = artifact.get("Artifact_Subdir", [])
+            for subdir in artifact_subdirs:
+                subdir_name = subdir.get("Name")
+                if subdir_name:
+                    if subdir_name not in mapping:
+                        mapping[subdir_name] = []
+                    if pkg_name not in mapping[subdir_name]:
+                        mapping[subdir_name].append(pkg_name)
+
+    _ARTIFACT_SUBDIR_TO_PACKAGES_CACHE = mapping
+    return mapping
+
+
+def parse_gfx_arch_exclusions() -> Dict[str, Set[str]]:
+    """Parse the CMake file to extract project exclusions for each GFX architecture.
+
+    This function parses cmake/therock_amdgpu_targets.cmake to build a mapping
+    of GFX architectures to excluded projects.
+
+    Returns:
+        Dict mapping gfx_arch (e.g., "gfx906", "gfx90X-dcgpu") to set of excluded project names
+    """
+    global _GFX_ARCH_EXCLUSIONS_CACHE
+
+    if _GFX_ARCH_EXCLUSIONS_CACHE is not None:
+        return _GFX_ARCH_EXCLUSIONS_CACHE
+
+    cmake_file = THEROCK_ROOT / "cmake" / "therock_amdgpu_targets.cmake"
+
+    if not cmake_file.exists():
+        print(f"Warning: CMake file not found at {cmake_file}")
+        _GFX_ARCH_EXCLUSIONS_CACHE = {}
+        return _GFX_ARCH_EXCLUSIONS_CACHE
+
+    exclusions: Dict[str, Set[str]] = {}
+
+    with open(cmake_file, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    # Simple line-by-line parser to avoid regex catastrophic backtracking
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+
+        # Look for therock_add_amdgpu_target calls
+        if line.startswith("therock_add_amdgpu_target("):
+            # Extract gfx_target from the first line
+            match = re.match(r"therock_add_amdgpu_target\((\w+)", line)
+            if not match:
+                i += 1
+                continue
+
+            gfx_target = match.group(1)
+            families = []
+            excluded_projects = set()
+
+            # Parse the function call (may span multiple lines)
+            in_family_section = False
+            in_exclude_section = False
+
+            # Continue parsing until we find the closing parenthesis
+            j = i
+            while j < len(lines):
+                current_line = lines[j].strip()
+
+                # Remove comments
+                if "#" in current_line:
+                    current_line = current_line.split("#")[0].strip()
+
+                # Check for FAMILY keyword
+                if "FAMILY" in current_line:
+                    in_family_section = True
+                    in_exclude_section = False
+                    # Extract families from the same line if present
+                    parts = current_line.split("FAMILY", 1)
+                    if len(parts) > 1:
+                        family_parts = parts[1].strip().split()
+                        families.extend(
+                            [
+                                f
+                                for f in family_parts
+                                if f and not f.startswith("EXCLUDE")
+                            ]
+                        )
+
+                # Check for EXCLUDE_TARGET_PROJECTS keyword
+                elif "EXCLUDE_TARGET_PROJECTS" in current_line:
+                    in_family_section = False
+                    in_exclude_section = True
+
+                # If we're in family section, collect family names
+                elif (
+                    in_family_section and not "EXCLUDE_TARGET_PROJECTS" in current_line
+                ):
+                    tokens = current_line.split()
+                    for token in tokens:
+                        if token and token not in (")", ""):
+                            families.append(token)
+
+                # If we're in exclude section, collect excluded projects
+                elif in_exclude_section:
+                    tokens = current_line.split()
+                    for token in tokens:
+                        if (
+                            token
+                            and token not in (")", "")
+                            and not token.startswith("#")
+                        ):
+                            excluded_projects.add(token)
+
+                # Check if we've reached the end of the function call
+                if ")" in current_line:
+                    break
+
+                j += 1
+
+            # Store exclusions for the gfx target itself
+            if gfx_target not in exclusions:
+                exclusions[gfx_target] = set()
+            exclusions[gfx_target].update(excluded_projects)
+
+            # Store exclusions for all families this target belongs to
+            for family in families:
+                if family not in exclusions:
+                    exclusions[family] = set()
+                exclusions[family].update(excluded_projects)
+
+            # Move to the line after the function call
+            i = j + 1
+        else:
+            i += 1
+
+    _GFX_ARCH_EXCLUSIONS_CACHE = exclusions
+    return exclusions
+
+
+def is_project_excluded_for_gfx_arch(project_name: str, gfx_arch: str) -> bool:
+    """Check if a CMake project is excluded for a given GFX architecture.
+
+    Parameters:
+        project_name: CMake project name (e.g., "composable_kernel", "hipBLASLt")
+        gfx_arch: GFX architecture string (e.g., "gfx906", "gfx90X-dcgpu")
+
+    Returns:
+        True if the project is excluded for this architecture, False otherwise
+    """
+    exclusions = parse_gfx_arch_exclusions()
+
+    # Check exact match first
+    if gfx_arch in exclusions and project_name in exclusions[gfx_arch]:
+        return True
+
+    # Check family matches (e.g., gfx90X-dcgpu contains gfx906)
+    # Extract base family patterns
+    for arch_pattern, excluded_projects in exclusions.items():
+        if project_name in excluded_projects:
+            # Check if gfx_arch matches this pattern
+            # Simple heuristic: if gfx_arch contains the pattern or vice versa
+            if arch_pattern in gfx_arch or gfx_arch in arch_pattern:
+                return True
+
+    return False
+
+
+def is_package_excluded_for_gfx_arch(pkg_name: str, gfx_arch: str) -> bool:
+    """Check if a package should be excluded for a given GFX architecture.
+
+    This checks if ALL artifact subdirectories for this package are excluded.
+
+    Parameters:
+        pkg_name: Package name (e.g., "amdrocm-ck", "amdrocm-blas")
+        gfx_arch: GFX architecture string (e.g., "gfx906", "gfx90X-dcgpu")
+
+    Returns:
+        True if the package should be excluded, False otherwise
+    """
+    pkg_info = get_package_info(pkg_name)
+    if not pkg_info:
+        return False
+
+    artifactory = pkg_info.get("Artifactory")
+    if not artifactory:
+        # Meta packages or packages without artifacts are not excluded based on gfx_arch
+        return False
+
+    # Collect all artifact subdirectories for this package
+    all_subdirs = []
+    for artifact in artifactory:
+        for subdir in artifact.get("Artifact_Subdir", []):
+            subdir_name = subdir.get("Name")
+            if subdir_name:
+                all_subdirs.append(subdir_name)
+
+    if not all_subdirs:
+        return False
+
+    # Check if ALL subdirectories are excluded
+    excluded_count = 0
+    for subdir_name in all_subdirs:
+        # CMake project names typically match artifact subdir names
+        if is_project_excluded_for_gfx_arch(subdir_name, gfx_arch):
+            excluded_count += 1
+
+    # Package is excluded only if ALL its artifact subdirs are excluded
+    return excluded_count > 0 and excluded_count == len(all_subdirs)
+
+
+def is_artifact_subdir_excluded_for_gfx_arch(
+    artifact_subdir: str, gfx_arch: str
+) -> bool:
+    """Check if an artifact subdirectory is excluded for a given GFX architecture.
+
+    CMake project names typically match artifact subdirectory names, so we check
+    if the artifact_subdir name is excluded as a CMake project.
+
+    Parameters:
+        artifact_subdir: Artifact subdirectory name (e.g., "composable_kernel", "hipBLASLt")
+        gfx_arch: GFX architecture string (e.g., "gfx906", "gfx90X-dcgpu")
+
+    Returns:
+        True if the artifact subdir is excluded, False otherwise
+    """
+    # CMake project names typically match artifact subdir names directly
+    return is_project_excluded_for_gfx_arch(artifact_subdir, gfx_arch)
+
+
+def filter_dependencies_by_gfx_arch(
+    dependency_list: List[str], gfx_arch: str, skipped_packages: List[str] = None
+) -> List[str]:
+    """Filter a dependency list to remove packages excluded for the given GFX architecture.
+
+    This is used primarily for meta-packages to avoid dependencies on packages
+    whose components are completely excluded for the target architecture or were
+    skipped due to missing artifacts.
+
+    Parameters:
+        dependency_list: List of package dependencies
+        gfx_arch: GFX architecture string (e.g., "gfx906", "gfx90X-dcgpu")
+        skipped_packages: List of package names that were skipped during build
+
+    Returns:
+        Filtered list with excluded/skipped packages removed
+    """
+    if skipped_packages is None:
+        skipped_packages = []
+
+    filtered = []
+    for dep in dependency_list:
+        # Extract base package name (remove version constraints, etc.)
+        base_dep = re.split(r"[(<>=\s]", dep)[0].strip()
+
+        # Check if excluded by architecture
+        if is_package_excluded_for_gfx_arch(base_dep, gfx_arch):
+            print(f"  Filtering out dependency '{dep}' (excluded for {gfx_arch})")
+            continue
+
+        # Check if package was skipped during build
+        if base_dep in skipped_packages:
+            print(f"  Filtering out dependency '{dep}' (skipped - missing artifacts)")
+            continue
+
+        filtered.append(dep)
+
+    return filtered
 
 
 def print_function_name():
@@ -360,7 +665,9 @@ def debian_replace_devel_name(pkg_name):
     return pkg_name
 
 
-def convert_to_versiondependency(dependency_list, config: PackageConfig):
+def convert_to_versiondependency(
+    dependency_list, config: PackageConfig, filter_exclusions: bool = False
+):
     """Change ROCm package dependencies to versioned ones.
 
     If a package depends on any packages listed in `pkg_list`,
@@ -369,12 +676,20 @@ def convert_to_versiondependency(dependency_list, config: PackageConfig):
     Parameters:
     dependency_list : List of dependent packages
     config: Configuration object containing package metadata
+    filter_exclusions: If True, filter out packages excluded for the gfx_arch and skipped packages
 
     Returns: A string of comma separated versioned packages
     """
     print_function_name()
     # This function is to add Version dependency
     # Make sure the flag is set to True
+
+    # Filter out excluded dependencies if requested
+    if filter_exclusions:
+        skipped_packages = getattr(config, "skipped_packages", [])
+        dependency_list = filter_dependencies_by_gfx_arch(
+            dependency_list, config.gfx_arch, skipped_packages
+        )
 
     local_config = copy.deepcopy(config)
     local_config.versioned_pkg = True
@@ -472,6 +787,8 @@ def filter_components_fromartifactory(pkg_name, artifacts_dir, gfx_arch):
     """Get the list of Artifactory directories required for creating the package.
 
     The `package.json` file defines the required artifactories for each package.
+    This function now handles missing artifacts gracefully by checking if components
+    are excluded for the given GFX architecture.
 
     Parameters:
     pkg_name : package name
@@ -511,23 +828,57 @@ def filter_components_fromartifactory(pkg_name, artifacts_dir, gfx_arch):
             artifact_subdir = subdir["Name"]
             component_list = subdir["Components"]
 
+            # Check if this artifact subdirectory is excluded for this gfx_arch
+            if is_artifact_subdir_excluded_for_gfx_arch(artifact_subdir, gfx_arch):
+                print(
+                    f"  Skipping artifact subdir '{artifact_subdir}' - "
+                    f"excluded for {gfx_arch}"
+                )
+                continue
+
             for component in component_list:
                 source_dir = (
                     Path(artifacts_dir)
                     / f"{artifact_prefix}_{component}_{artifact_suffix}"
                 )
                 filename = source_dir / "artifact_manifest.txt"
-                with open(filename, "r", encoding="utf-8") as file:
-                    for line in file:
 
-                        match_found = (
-                            isinstance(artifact_subdir, str)
-                            and (artifact_subdir.lower() + "/") in line.lower()
+                # Check if the artifact manifest file exists
+                if not filename.exists():
+                    # Check if this is expected due to exclusion
+                    if is_artifact_subdir_excluded_for_gfx_arch(
+                        artifact_subdir, gfx_arch
+                    ):
+                        print(
+                            f"  Artifact manifest not found (expected): {filename} - "
+                            f"'{artifact_subdir}' excluded for {gfx_arch}"
                         )
+                        continue
+                    else:
+                        print(f"  Warning: Artifact manifest not found: {filename}")
+                        print(f"    Package: {pkg_name}")
+                        print(f"    Artifact: {artifact_prefix}")
+                        print(f"    Component: {component}")
+                        print(f"    Subdir: {artifact_subdir}")
+                        print(f"    Expected path: {source_dir}")
+                        # Don't fail immediately - continue to check other components
+                        continue
 
-                        if match_found and line.strip():
-                            print("Matching line:", line.strip())
-                            source_path = source_dir / line.strip()
-                            sourcedir_list.append(source_path)
+                try:
+                    with open(filename, "r", encoding="utf-8") as file:
+                        for line in file:
+                            match_found = (
+                                isinstance(artifact_subdir, str)
+                                and (artifact_subdir.lower() + "/") in line.lower()
+                            )
+
+                            if match_found and line.strip():
+                                print("Matching line:", line.strip())
+                                source_path = source_dir / line.strip()
+                                sourcedir_list.append(source_path)
+                except FileNotFoundError:
+                    # File was deleted between exists() check and open()
+                    print(f"  Warning: Could not read artifact manifest: {filename}")
+                    continue
 
     return sourcedir_list


### PR DESCRIPTION
Parse EXCLUDE_TARGET_PROJECTS list from cmake/therock_amdgpu_targets.cmake and use that to exclude deb/rpm package creation for those gfx arch. Also added a --skip-missing-artifacts option to overide any artifact errors. Also enabled additional debugging options for any future issues. 

## Motivation

Some of the modules is disabled in particular gfx arch. For eg: composabile kernel is disabled for gfx90X-dcgpu but enabled for gfx94x. But the build_package.py was not handling this case. It was expecting the packages for each and every gfx arch. This change handles this case using the build cmake as the source of truth for disabled modules.

## Technical Details

### 1. Reading CMake Configuration Logic

The exclusion list is maintained in `cmake/therock_amdgpu_targets.cmake` using the `EXCLUDE_TARGET_PROJECTS` parameter:

**When CMake file exists:**
- Exclusions are parsed and applied
- Packages with excluded components are handled gracefully
- Meta-packages have filtered dependencies

**When CMake file is missing:**
- System falls back to old behavior (pre-exclusion logic)
- All exclusion checks return `False`
- Builds fail on missing artifacts (unless `--skip-missing-artifacts` is used)
- No special handling for any architecture
### 2. Parsing and Detection

The packaging system parses the CMake file to extract exclusions:

- **`parse_gfx_arch_exclusions()`**: Parses the CMake file using a line-by-line approach (no complex regex to avoid catastrophic backtracking)
- **`is_project_excluded_for_gfx_arch(project, arch)`**: Checks if a CMake project is excluded
- **`is_artifact_subdir_excluded_for_gfx_arch(subdir, arch)`**: Checks if an artifact subdirectory is excluded
- **`is_package_excluded_for_gfx_arch(package, arch)`**: Checks if ALL components of a package are excluded

### 3. Graceful Handling During Package Build

#### Missing Artifacts

When `filter_components_fromartifactory()` encounters a missing `artifact_manifest.txt`:
- It checks if the artifact is expected to be missing due to exclusion
- Prints informative message and continues (doesn't crash)
- Only fails if artifact is unexpectedly missing

#### Package Skipping

Packages are automatically skipped if all their components are excluded:

#### Partial Exclusions

Packages with partial exclusions (e.g., `amdrocm-blas` has hipBLASLt excluded but rocBLAS included) are NOT skipped - they're built with available components.

### 4. Meta-Package Dependency Filtering

Meta-packages automatically filter out dependencies on excluded packages:


## Test Plan
https://github.com/ROCm/TheRock/actions/runs/20982443324 - Build native for gfx90x-dcgpu which has exclusions
https://github.com/ROCm/TheRock/actions/runs/20981326990 - Build native for gfx1150 which doesnt have any exclusions 


## Test Result

https://rocm.devreleases.amd.com/rpm/20260114-20976589891/x86_64/index.html

The meta package for gfx1150 with NO exclusion shows amdrocm-ck as dependency. 
```
rpm -qpR amdrocm-core7.11-gfx1150-7.11.0~20260113g65c8da21-20976589891.x86_64.rpm
/bin/sh
/bin/sh
amdrocm-amdsmi7.11 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-base7.11 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-blas7.11-gfx1150 = 7.11.0~20260113g65c8da21-20976589891
**amdrocm-ck7.11-gfx1150** = 7.11.0~20260113g65c8da21-20976589891
amdrocm-dnn7.11-gfx1150 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-fft7.11-gfx1150 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-hipify7.11 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-llvm7.11 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-math-common7.11 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-runtime7.11 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-solver7.11-gfx1150 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-sparse7.11-gfx1150 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-sysdeps7.11 = 7.11.0~20260113g65c8da21-20976589891

```
The meta package for gfx90x with exclusion doesnt have amdrocm-ck as dependency. 
```
rpm -qpR amdrocm-core7.11-gfx90x-7.11.0~20260113g65c8da21-20976589891.x86_64.rpm
/bin/sh
/bin/sh
amdrocm-amdsmi7.11 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-base7.11 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-blas7.11-gfx90x = 7.11.0~20260113g65c8da21-20976589891
amdrocm-dnn7.11-gfx90x = 7.11.0~20260113g65c8da21-20976589891
amdrocm-fft7.11-gfx90x = 7.11.0~20260113g65c8da21-20976589891
amdrocm-hipify7.11 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-llvm7.11 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-math-common7.11 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-rccl7.11-gfx90x = 7.11.0~20260113g65c8da21-20976589891
amdrocm-runtime7.11 = 7.11.0~20260113g65c8da21-20976589891
amdrocm-solver7.11-gfx90x = 7.11.0~20260113g65c8da21-20976589891
amdrocm-sparse7.11-gfx90x = 7.11.0~20260113g65c8da21-20976589891
amdrocm-sysdeps7.11 = 7.11.0~20260113g65c8da21-20976589891
```


