### PR TITLE
Do not bump by default non-listed component modules

### DIFF
--- a/build_tools/bump_submodules.py
+++ b/build_tools/bump_submodules.py
@@ -196,9 +196,9 @@ def main(argv):
                   ml-libs,
                   rocm-libraries,
                   rocm-systems,
-                  profiler
-                  iree-libs
-                  debug-tools
+                  profiler,
+                  iree-libs,
+                  debug-tools.
                   rocm-media
              """,
     )


### PR DESCRIPTION
./build_tools/bump_submodules --components rocm-libraries fetched also the following

- base/rocm-kpack
- iree-tools (--include-iree-tools, --no-include-iree-tools)
- debug-tools (--include-debug-tools, --no-include-debug-tools)
- third-party/sysdeps/amd-mesa (--include-rocm-media, --no-include-rocm-media)

After this change the iree-tools, debug-tools and amd-mesa is not anymore bumped if iree-tools, debug-tools or rocm-media is not mentioned in the list components to bump with --components flag.

However the rocm-kpack will still be fetched even if the ./bump_submodules.py --components flag does not specify it because because base/rocm-kpack is in a ALWAYS_SUBMODULE_PATHS list on fetch_sources.py and I am not sure how to handle this at this point.

fixes for: https://github.com/ROCm/TheRock/issues/2876