### PR TITLE
[ci] Resolving #2932 endif() warning for comm-libs

### DIFF
--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -89,4 +89,4 @@ if(THEROCK_ENABLE_RCCL AND THEROCK_SANITIZER STREQUAL "")
     SUBPROJECT_DEPS
       ${_rccl_subproject_names}
   )
-endif(THEROCK_ENABLE_RCCL)
+endif()


### PR DESCRIPTION
Closes #2932 

Noticed warning for endif() condition, cleaning this up to follow modern cmake style