### PR TITLE
Remove composable_kernel from BUILD_TOPOLOGY.

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -100,7 +100,7 @@ submodules = ["rocm-libraries"]
 
 [source_sets.ml-frameworks]
 description = "ML framework submodules"
-submodules = ["composable_kernel"]
+submodules = []
 
 [source_sets.comm-libs]
 description = "Communication library submodules"


### PR DESCRIPTION
This fixes library builds on the multi_arch integration branch which use these source sets for checking out the right cone.
