### PR TITLE
[pre-commit] Upgrade actionlint to version 1.7.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
     exclude: ".gitmodules|patches/.*|docs/development/git_chores.md|build_tools/packaging/linux/template/debian_rules.j2"
 
 - repo: https://github.com/rhysd/actionlint
-  rev: v1.7.9
+  rev: v1.7.10
   hooks:
     - id: actionlint
       args: [-shellcheck=, -ignore, 'label ".+" is unknown']


### PR DESCRIPTION
- Updated actionlint version from v1.7.9 to v1.7.10.
- Key feature is GitHub supporting more than 10 workflow_dispatch inputs and actionlint accommodating this.
- Reference 1: https://github.blog/changelog/2025-12-04-actions-workflow-dispatch-workflows-now-support-25-inputs/
- Reference 2: https://github.com/rhysd/actionlint/releases/tag/v1.7.10