### PR TITLE
Limit collection of matrices files from rocSPARSE and hipSPARSE only when BUILD_TESTING is ON

### DIFF
--- a/math-libs/BLAS/pre_hook_hipSPARSE.cmake
+++ b/math-libs/BLAS/pre_hook_hipSPARSE.cmake
@@ -1,6 +1,9 @@
 # See the artifact descriptor where we require these matrices for the test
 # artifact. Consider installing as part of the main project.
-install(
-  DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/clients/matrices"
-  DESTINATION "clients"
-)
+# The client will only be built if testing is enabled. See hipSPARSE CMakeLists.txt.
+if(THEROCK_BUILD_TESTING)
+  install(
+    DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/clients/matrices"
+    DESTINATION "clients"
+  )
+endif()

--- a/math-libs/BLAS/pre_hook_rocSPARSE.cmake
+++ b/math-libs/BLAS/pre_hook_rocSPARSE.cmake
@@ -11,7 +11,10 @@ endif()
 
 # See the artifact descriptor where we require these matrices for the test
 # artifact. Consider installing as part of the main project.
-install(
-  DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/clients/matrices"
-  DESTINATION "clients"
-)
+# The client will only be built if testing is enabled. See rocSPARSE CMakeLists.txt.
+if(THEROCK_BUILD_TESTING)
+  install(
+    DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/clients/matrices"
+    DESTINATION "clients"
+  )
+endif()


### PR DESCRIPTION
## Motivation
Fixes #2941: During building of hipSPARSE and rocSPARSE, if the -DBUILD_TESTING=OFF CMake flag is specified, the install step fails due to missing matrices file.

## Technical Details
The matrices are only emitted if rocSPARSE / hipSPARSE are configured to build clients. TheRock provides CMake option `BUILD_CLIENTS_TESTS` and `BUILD_CLIENTS_BENCHMARK` based on `THEROCK_BUILD_TESTING`

math-libs/BLAS/CMakeLists.txt
```
  ##############################################################################
  # hipSPARSE
  ##############################################################################

  therock_cmake_subproject_declare(hipSPARSE
    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/projects/hipsparse"
    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hipSPARSE"
    BACKGROUND_BUILD
    CMAKE_ARGS
      -DHIP_PLATFORM=amd
      -DROCM_PATH=
      -DROCM_DIR=
      -DBUILD_CLIENTS_TESTS=${THEROCK_BUILD_TESTING}
      -DBUILD_CLIENTS_BENCHMARKS=${THEROCK_BUILD_TESTING}
      -DBUILD_CLIENTS_SAMPLES=OFF
    COMPILER_TOOLCHAIN
      amd-hip
    BUILD_DEPS
      rocm-cmake
      rocSPARSE
      therock-googletest
    RUNTIME_DEPS
      hip-clr
  )
```

In each subproject, (CLIENTS_TEST | CLIENTS_BENCHMARKS | CLIENTS_SAMPLES) will decide if the client itself is built, this results to missing files if BUILD_TESTING is disabled.

Fix by blocking prehook to not install the matrices files if testing is disabled.

## Test Plan
Build with SPARSE ON + BUILD_TESTING OFF passes without error.

## Test Result
Build with SPARSE ON + BUILD_TESTING OFF passes without error.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
