### PR TITLE
Option-selectable AOMP build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,12 @@ therock_enable_external_source("composable-kernel" "${THEROCK_SOURCE_DIR}/ml-lib
 # Overall build settings.
 option(THEROCK_VERBOSE "Enables verbose CMake statuses" OFF)
 
+# AOMP-related options.
+set(THEROCK_AOMP_BUILD OFF CACHE BOOL "Enable AOMP build configuration settings")
+set(THEROCK_AOMP_VERSION_MOD "" CACHE STRING "Set patch version name for AOMP build")
+set(THEROCK_DEFAULT_LLVM_TOOLSET OFF CACHE BOOL "Build default set of LLVM tools (vs. TheRock subset)")
+set(THEROCK_DEFAULT_CLANG_TOOLSET OFF CACHE BOOL "Build default set of Clang tools (vs. TheRock subset)")
+
 # Initialize the install directory.
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "${THEROCK_SOURCE_DIR}/install" CACHE PATH "" FORCE)

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -11,6 +11,29 @@ if(THEROCK_ENABLE_COMPILER)
     list(APPEND _extra_llvm_cmake_args "-DLLVM_ENABLE_PEDANTIC=OFF")
   endif()
 
+  if(THEROCK_AOMP_BUILD)
+    list(APPEND _extra_llvm_cmake_args
+      -DLLVM_VERSION_SUFFIX=_SROCK
+      -DLLVM_VERSION_PATCH=${THEROCK_AOMP_VERSION_MOD}
+      -DLLVM_BUILD_TESTS=ON
+      -DLLVM_INCLUDE_TESTS=ON
+      -DCLANG_INCLUDE_TESTS=ON
+      -DLLVM_LIT_ARGS="-vv --show-unsupported --show-xfail -j 16"
+      -DCLANG_TOOL_CLANG_LINKER_WRAPPER_BUILD=ON
+      -DCLANG_TOOL_OFFLOAD_ARCH_BUILD=ON
+      -DOPENMP_ENABLE_LIBOMPTARGET=ON
+      -DLIBOMPTARGET_BUILD_DEVICE_FORTRT=ON
+      -DOFFLOAD_EXTERNAL_PROJECT_UNIFIED_ROCR=ON
+      -DLIBOMP_USE_HWLOC=ON
+      -DLIBOMPTARGET_EXTERNAL_PROJECT_HSA_PATH=${CMAKE_CURRENT_SOURCE_DIR}/../rocm-systems/projects/rocr-runtime
+      -DFLANG_RUNTIME_F128_MATH_LIB=libquadmath
+      -DROCM_DEVICE_LIBS_BITCODE_INSTALL_LOC_NEW=${CMAKE_CURRENT_BINARY_DIR}/lib/clang/${LLVM_VERSION_MAJOR}/lib/amdgcn
+      -DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON
+      -DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES=openmp)
+  else()
+    list(APPEND _extra_llvm_cmake_args "-DLLVM_INCLUDE_TESTS=${THEROCK_ENABLE_LLVM_TESTS}")
+  endif()
+
   # Building Flang is very memory-intensive on systems with many cores. Allow
   # users to specify the level of concurrency for these tasks so they can
   # reduce the risk of running out of memory.
@@ -61,7 +84,6 @@ if(THEROCK_ENABLE_COMPILER)
       -DLIBCXXABI_ENABLE_STATIC=ON
 
       # Features
-      -DLLVM_INCLUDE_TESTS=${THEROCK_ENABLE_LLVM_TESTS}
       -DLLVM_ENABLE_ZLIB=FORCE_ON
       -DLLVM_ENABLE_Z3_SOLVER=OFF
       -DLLVM_ENABLE_LIBXML2=OFF

--- a/compiler/artifact-amd-llvm.toml
+++ b/compiler/artifact-amd-llvm.toml
@@ -7,6 +7,7 @@ unmatched_exclude = [
   # Various docs or utilities we don't care about.
   "lib/llvm/share/clang-doc/**",
   "lib/llvm/share/clang/**",
+  "lib/llvm/lib/amdgcn-amd-amdhsa/**"
 ]
 
 # LLVM deviates from the defaults in some key ways:

--- a/compiler/pre_hook_amd-llvm.cmake
+++ b/compiler/pre_hook_amd-llvm.cmake
@@ -13,7 +13,11 @@ if(WIN32)
   # TODO(#36): Enable libunwind, libcxx, and libcxxabi on Windows?
   #     Should they be supported? What depends on them?
   set(LLVM_ENABLE_LIBCXX OFF)
-  set(LLVM_ENABLE_RUNTIMES "compiler-rt" CACHE STRING "Enabled runtimes" FORCE)
+  if(THEROCK_AOMP_BUILD)
+    set(LLVM_ENABLE_RUNTIMES "libcxx;libcxxabi;libunwind;openmp;offload;compiler-rt;flang-rt" CACHE STRING "Enabled runtimes" FORCE)
+  else()
+    set(LLVM_ENABLE_RUNTIMES "compiler-rt" CACHE STRING "Enabled runtimes" FORCE)
+  endif()
   set(LLVM_ENABLE_PROJECTS "clang;lld;clang-tools-extra" CACHE STRING "Enable LLVM projects" FORCE)
 else()
   set(LLVM_BUILD_LLVM_DYLIB ON)
@@ -40,7 +44,14 @@ else()
     if(EXISTS "${THEROCK_SOURCE_DIR}/compiler/amd-llvm/openmp/device/CMakeLists.txt")
       list(APPEND LLVM_ENABLE_RUNTIMES "flang-rt")
       set(LLVM_RUNTIME_TARGETS "default;amdgcn-amd-amdhsa")
-      set(RUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES "openmp")
+      if(THEROCK_AOMP_BUILD)
+        set(RUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES "compiler-rt;libc;libcxx;libcxxabi;flang-rt;openmp")
+        set(RUNTIMES_amdgcn-amd-amdhsa_FLANG_RT_LIBC_PROVIDER "llvm")
+        set(RUNTIMES_amdgcn-amd-amdhsa_FLANG_RT_LIBCXX_PROVIDER "llvm")
+        set(RUNTIMES_amdgcn-amd-amdhsa_CACHE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/../libcxx/cmake/caches/AMDGPU.cmake")
+      else()
+        set(RUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES "openmp")
+      endif()
       set(RUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_PER_TARGET_RUNTIME_DIR ON)
       set(FLANG_RUNTIME_F128_MATH_LIB "libquadmath")
       set(LIBOMPTARGET_BUILD_DEVICE_FORTRT ON)
@@ -67,6 +78,9 @@ endif()
 # disabling more explicitly after a bug fix enabled.
 set(LLVM_INCLUDE_BENCHMARKS OFF)
 set(LLVM_TARGETS_TO_BUILD "AMDGPU;X86" CACHE STRING "Enable LLVM Targets" FORCE)
+if(THEROCK_AOMP_BUILD)
+  set(LLVM_RUNTIME_TARGETS "default;amdgcn-amd-amdhsa")
+endif()
 
 # Packaging.
 set(PACKAGE_VENDOR "AMD" CACHE STRING "Vendor" FORCE)
@@ -87,9 +101,11 @@ set(LLVM_EXTERNAL_PROJECTS "rocm-device-libs;spirv-llvm-translator" CACHE STRING
 # options to manage this transition but they require knowing the clange resource
 # dir. In order to avoid drift, we just fixate that too. This can all be
 # removed in a future version.
-# set(CLANG_RESOURCE_DIR "../lib/clang/${LLVM_VERSION_MAJOR}" CACHE STRING "Resource dir" FORCE)
-# set(ROCM_DEVICE_LIBS_BITCODE_INSTALL_LOC_NEW "lib/clang/${LLVM_VERSION_MAJOR}/amdgcn" CACHE STRING "New devicelibs loc" FORCE)
-# set(ROCM_DEVICE_LIBS_BITCODE_INSTALL_LOC_OLD "amdgcn" CACHE STRING "Old devicelibs loc" FORCE)
+if(NOT THEROCK_AOMP_BUILD)
+  set(CLANG_RESOURCE_DIR "../lib/clang/${LLVM_VERSION_MAJOR}" CACHE STRING "Resource dir" FORCE)
+  set(ROCM_DEVICE_LIBS_BITCODE_INSTALL_LOC_NEW "lib/clang/${LLVM_VERSION_MAJOR}/lib/amdgcn" CACHE STRING "New devicelibs loc" FORCE)
+  set(ROCM_DEVICE_LIBS_BITCODE_INSTALL_LOC_OLD "amdgcn" CACHE STRING "Old devicelibs loc" FORCE)
+endif()
 
 # Setup the install rpath (let CMake handle build RPATH per usual):
 # * Executables and libraries can always search their adjacent lib directory
@@ -157,7 +173,9 @@ if(NOT THEROCK_ENABLE_LLVM_TESTS)
       list(APPEND _llvm_required_tools "LLVM_LIB")
       list(APPEND _llvm_required_tools "LLVM_RANLIB")
     endif()
-    therock_set_implicit_llvm_options(LLVM "${CMAKE_CURRENT_SOURCE_DIR}/tools" "${_llvm_required_tools}")
+    if(NOT THEROCK_DEFAULT_LLVM_TOOLSET)
+      therock_set_implicit_llvm_options(LLVM "${CMAKE_CURRENT_SOURCE_DIR}/tools" "${_llvm_required_tools}")
+    endif()
 
     # Clang tools that are required.
     set(_clang_required_tools
@@ -175,6 +193,8 @@ if(NOT THEROCK_ENABLE_LLVM_TESTS)
       # we might as well build them from source ourselves.
       list(APPEND _clang_required_tools "CLANG_SCAN_DEPS")
     endif()
-    therock_set_implicit_llvm_options(CLANG "${CMAKE_CURRENT_SOURCE_DIR}/../clang/tools" "${_clang_required_tools}")
+    if(NOT THEROCK_DEFAULT_CLANG_TOOLSET)
+      therock_set_implicit_llvm_options(CLANG "${CMAKE_CURRENT_SOURCE_DIR}/../clang/tools" "${_clang_required_tools}")
+    endif()
   endblock()
 endif()

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -1,5 +1,7 @@
 if(THEROCK_ENABLE_ROCPROFV3)
   set(_rocprofiler_sdk_optional_deps)
+  set(_rocprofiler_sdk_extra_cmake_args)
+  set(_rocprofiler_sdk_interface_include_dirs)
 
   ##############################################################################
   # rocprof-trace-decoder-binary
@@ -61,16 +63,27 @@ if(THEROCK_ENABLE_ROCPROFV3)
     list(JOIN _detected_python_versions "\;" _detected_python_versions_str)
   endif()
 
+  if(THEROCK_AOMP_BUILD)
+    list(APPEND _rocprofiler_sdk_extra_cmake_args
+         -DCMAKE_CXX_FLAGS=-I${THEROCK_SOURCE_DIR}/build/dist/rocm/include
+         -DCMAKE_C_FLAGS=-I${THEROCK_SOURCE_DIR}/build/dist/rocm/include)
+    list(APPEND _rocprofiler_sdk_interface_include_dirs
+         ${THEROCK_SOURCE_DIR}/build/dist/rocm/include)
+  endif()
+
   therock_cmake_subproject_declare(rocprofiler-sdk
     USE_DIST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprofiler-sdk"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprofiler-sdk"
     BACKGROUND_BUILD
     CMAKE_ARGS
+      ${_rocprofiler_sdk_extra_cmake_args}
       -DHIP_PLATFORM=amd
       -DROCPROFILER_PYTHON_VERSIONS:STRING="${_detected_python_versions_str}"
     CMAKE_INCLUDES
       therock_explicit_finders.cmake
+    INTERFACE_INCLUDE_DIRS
+      ${_rocprofiler_sdk_interface_include_dirs}
     COMPILER_TOOLCHAIN
       amd-hip
     RUNTIME_DEPS
@@ -145,11 +158,13 @@ if(THEROCK_ENABLE_ROCPROFV3)
       # Must build with the HIP compiler.
       amd-hip
     CMAKE_ARGS
+      ${_rocprofiler_sdk_extra_cmake_args}
       -DHIP_PLATFORM=amd
     INTERFACE_INCLUDE_DIRS
       # All old clients of roctx64 expect to just be able to find its include
       # with no further qualification. Bad design, but also deprecated, so meh.
       include
+      ${_rocprofiler_sdk_interface_include_dirs}
     INTERFACE_LINK_DIRS
       # So that dependents can find the roctx library via find_library()
       lib


### PR DESCRIPTION
At present, the AOMP build infrastructure patches these scripts in order to adjust configuration settings appropriately for "AOMP-like" builds. This WIP patch allows the alternate options to be selectable with new CMake options instead, which should be a little more robust.

The changes are mostly adapted from
https://github.com/ROCm/aomp/blob/aomp-dev/srock-bin/patches/amd-staging/_TheRock.patch.

I noticed a bit of crossover on rebasing, so the options might want tweaking a bit.

At the moment the new settings are:

- `THEROCK_AOMP_BUILD`: Enable AOMP build configuration settings.
- `THEROCK_AOMP_VERSION_MOD`: Set patch version name for AOMP build. 
- `THEROCK_DEFAULT_LLVM_TOOLSET`: Build default set of LLVM tools (vs. TheRock subset).
- `THEROCK_DEFAULT_CLANG_TOOLSET`: Build default set of Clang tools (vs. TheRock subset).
