### PR TITLE
[ncurses/rocgdb] Add terminfo directory to artifacts and adjust rocgdb launcher

### DIFF
--- a/debug-tools/rocgdb/CMakeLists.txt
+++ b/debug-tools/rocgdb/CMakeLists.txt
@@ -403,6 +403,15 @@ set(ROCGDB_SCRIPT_CONTENT [=[#!/usr/bin/env bash
 python_version=$(python3 --version 2>&1 | sed -n 's/^Python \([0-9]\+\.[0-9]\+\).*$/\1/p' )
 GDB_BIN_DIR="$(dirname "$(realpath -e "${BASH_SOURCE[0]}")")"
 
+# Set the ncurses TERMINFO lookup directory if it isn't set already.
+# This is used to locate our own terminfo database in a relative path, since
+# ncurses doesn't support relative path lookups as a configure option.
+#
+# ROCgdb TUI mode requires this information.
+if [ -z "$TERMINFO" ]; then
+    export TERMINFO="$GDB_BIN_DIR/../lib/rocm_sysdeps/share/terminfo"
+fi
+
 # Create a rocgdb command with the active python version.
 gdb_command="rocgdb-py$python_version"
 if ! [ -f "$GDB_BIN_DIR/$gdb_command" ]; then

--- a/third-party/sysdeps/linux/artifact-ncurses.toml
+++ b/third-party/sysdeps/linux/artifact-ncurses.toml
@@ -6,6 +6,9 @@ unmatched_exclude = [
 
 # NCurses
 [components.dev."third-party/sysdeps/linux/ncurses/build/stage"]
+include = [
+  "lib/rocm_sysdeps/share/terminfo/**"
+]
 [components.doc."third-party/sysdeps/linux/ncurses/build/stage"]
 [components.lib."third-party/sysdeps/linux/ncurses/build/stage"]
 include = [


### PR DESCRIPTION
The ncurses library does not support setting a relative terminfo database
lookup path at configure time. As a result, the library won't be able to
find the terminfo files if the stage install prefix tree doesn't exist, and
rocgdb relies on the terminfo database so its TUI mode can work.

We can make things work by using the TERMINFO environment variable though,
as that allows us to point at a particular terminfo database when launching
gdb via the launcher shell script.

To make that work, we need a couple changes:

1 - Include the terminfo database in the ncurses artifacts, essentially making
    the database available in our dist/rocm tree.

2 - Adjust the rocgdb launcher shell script to set TERMINFO to the relative
    directory where the terminfo database can be found.

One limitation of the above approach is that rocgdb may not be able to find
the terminfo database when users invoke the rocgdb executables directly.

That's acceptable though, as invoking rocgdb executables directly is more of
a development/debugging workflow.