### PR TITLE
[GitHub Actions] Update workflows calling setup.yml with their inputs

### DIFF
--- a/.github/workflows/ci_asan.yml
+++ b/.github/workflows/ci_asan.yml
@@ -12,6 +12,7 @@ on:
       linux_use_prebuilt_artifacts:
         type: boolean
         description: "If enabled, the CI will pull Linux artifacts using artifact_run_id and only run tests"
+        default: false
       artifact_run_id:
         type: string
         description: "If provided, the tests will run on this artifact ID"
@@ -33,8 +34,8 @@ jobs:
     uses: ./.github/workflows/setup.yml
     with:
       build_variant: "asan"
-      linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || '' }}
-      linux_use_prebuilt_artifacts: ${{ inputs.linux_use_prebuilt_artifacts || false }}
+      linux_amdgpu_families: ${{ inputs.linux_amdgpu_families }}
+      linux_use_prebuilt_artifacts: ${{ inputs.linux_use_prebuilt_artifacts }}
 
   linux_build_and_test:
     name: Linux::${{ matrix.variant.family }}::${{ matrix.variant.build_variant_label }}

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -23,6 +23,7 @@ on:
       linux_use_prebuilt_artifacts:
         type: boolean
         description: "If enabled, the CI will pull Linux artifacts using artifact_run_id and only run tests"
+        default: false
       windows_amdgpu_families:
         type: string
         description: "Insert comma-separated list of Windows GPU families to build and test. ex: gfx94X, gfx1201X"
@@ -34,6 +35,7 @@ on:
       windows_use_prebuilt_artifacts:
         type: boolean
         description: "If enabled, the CI will pull Windows artifacts using artifact_run_id and only run tests"
+        default: false
       artifact_run_id:
         type: string
         description: "If provided, the tests will run on this artifact ID"
@@ -55,12 +57,12 @@ jobs:
     uses: ./.github/workflows/setup.yml
     with:
       build_variant: "release"
-      linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || '' }}
-      linux_test_labels: ${{ inputs.linux_test_labels || '' }}
-      linux_use_prebuilt_artifacts: ${{ inputs.linux_use_prebuilt_artifacts || false }}
-      windows_amdgpu_families: ${{ inputs.windows_amdgpu_families || '' }}
-      windows_test_labels: ${{ inputs.windows_test_labels || '' }}
-      windows_use_prebuilt_artifacts: ${{ inputs.windows_use_prebuilt_artifacts || false }}
+      linux_amdgpu_families: ${{ inputs.linux_amdgpu_families }}
+      linux_test_labels: ${{ inputs.linux_test_labels }}
+      linux_use_prebuilt_artifacts: ${{ inputs.linux_use_prebuilt_artifacts }}
+      windows_amdgpu_families: ${{ inputs.windows_amdgpu_families }}
+      windows_test_labels: ${{ inputs.windows_test_labels }}
+      windows_use_prebuilt_artifacts: ${{ inputs.windows_use_prebuilt_artifacts }}
 
   linux_build_and_test:
     name: Linux::${{ matrix.variant.family }}::${{ matrix.variant.build_variant_label }}

--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -25,6 +25,7 @@ on:
       linux_use_prebuilt_artifacts:
         type: boolean
         description: "If enabled, the CI will pull Linux artifacts using artifact_run_id and only run tests"
+        default: false
       windows_amdgpu_families:
         type: string
         description: "Insert comma-separated list of Windows GPU families to build and test. ex: gfx94X, gfx1201X"
@@ -36,6 +37,7 @@ on:
       windows_use_prebuilt_artifacts:
         type: boolean
         description: "If enabled, the CI will pull Windows artifacts using artifact_run_id and only run tests"
+        default: false
       artifact_run_id:
         type: string
         description: "If provided, the tests will run on this artifact ID"
@@ -63,12 +65,12 @@ jobs:
     with:
       build_variant: "release"
       multi_arch: true
-      linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || '' }}
-      linux_test_labels: ${{ inputs.linux_test_labels || '' }}
-      linux_use_prebuilt_artifacts: ${{ inputs.linux_use_prebuilt_artifacts || false }}
-      windows_amdgpu_families: ${{ inputs.windows_amdgpu_families || '' }}
-      windows_test_labels: ${{ inputs.windows_test_labels || '' }}
-      windows_use_prebuilt_artifacts: ${{ inputs.windows_use_prebuilt_artifacts || false }}
+      linux_amdgpu_families: ${{ inputs.linux_amdgpu_families }}
+      linux_test_labels: ${{ inputs.linux_test_labels }}
+      linux_use_prebuilt_artifacts: ${{ inputs.linux_use_prebuilt_artifacts }}
+      windows_amdgpu_families: ${{ inputs.windows_amdgpu_families }}
+      windows_test_labels: ${{ inputs.windows_test_labels }}
+      windows_use_prebuilt_artifacts: ${{ inputs.windows_use_prebuilt_artifacts }}
 
   linux_build_and_test:
     name: Linux::${{ matrix.variant.build_variant_label }}


### PR DESCRIPTION
After #2771, these workflows were calling setup.yml but not forwarding their workflow_dispatch inputs (linux_amdgpu_families, test_labels, etc). This caused the setup job to use default empty values instead of the user-provided inputs or the workflow's own defaults.

Forward all relevant inputs from workflow_dispatch to setup.yml's workflow_call to fix this.

**Affected workflows:**
- ci_nightly.yml
- ci_asan.yml
- multi_arch_ci.yml

