### PR TITLE
fix: correct typo 'classifer' -> 'classifier' in resource_info.py

### DIFF
--- a/build_tools/resource_info.py
+++ b/build_tools/resource_info.py
@@ -299,7 +299,7 @@ def run_and_log_command(repo_root: Path, log_dir: str) -> int:
     cmd_args = sys.argv[1:]
     cmd_str = " ".join(shlex.quote(arg) for arg in cmd_args)
 
-    comp = therock_components_compile_classifer(repo_root, pwd, cmd_str)
+    comp = therock_components_compile_classifier(repo_root, pwd, cmd_str)
 
     ts = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
     rand = random.randint(0, 999999)


### PR DESCRIPTION
## Motivation

correct typo 'classifer' -> 'classifier' in resource_info.py

## Technical Details

Fixed misspelled function name therock_components_compile_classifer
to therock_components_compile_classifier in build_tools/resource_info.py

## Test Plan

Run locally build

## Test Result

Build passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
