### PR TITLE
Add missing libdrm-dev to the dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ instructions and configurations for alternatives.
 ```bash
 # Install Ubuntu dependencies
 sudo apt update
-sudo apt install gfortran git ninja-build cmake g++ pkg-config xxd patchelf automake libtool python3-venv python3-dev libegl1-mesa-dev texinfo bison flex
+sudo apt install gfortran git ninja-build cmake g++ pkg-config xxd patchelf automake libtool python3-venv python3-dev libegl1-mesa-dev texinfo bison flex libdrm-dev
 
 # Clone the repository
 git clone https://github.com/ROCm/TheRock.git


### PR DESCRIPTION
## Motivation

`amdsmi` fails to build without `libdrm` on ubuntu 24.04:
```bash
[amdsmi] /usr/bin/c++ -DENABLE_ESMI_LIB=1 -I/home/sareeder/TheRock/rocm-systems/projects/amdsmi/include -I/home/sareeder/TheRock/build/base/amdsmi/build/include -I/home/sareeder/TheRock/rocm-systems/projects/amdsmi/third_party/shared_mutex -I/home/sareeder/TheRock/rocm-systems/projects/amdsmi/include/amd_smi -I/home/sareeder/TheRock/rocm-systems/projects/amdsmi/esmi_ib_library/include -I/home/sareeder/TheRock/rocm-systems/projects/amdsmi/tests/amd_smi_test/amdsmitst -I/home/sareeder/TheRock/rocm-systems/projects/amdsmi/tests/amd_smi_test/.. -I/home/sareeder/TheRock/rocm-systems/projects/amdsmi/rocm_smi/include/rocm_smi/.. -I/home/sareeder/TheRock/rocm-systems/projects/amdsmi/src/include -isystem /home/sareeder/TheRock/build/third-party/googletest/dist/include -Wtrampolines -Wall -Wextra -fno-rtti -m64 -msse -msse2 -Wconversion -Wcast-align -Wformat=2 -fno-common -Wstrict-overflow -Woverloaded-virtual -Wreorder -Wno-write-strings -O3 -DNDEBUG -std=c++17 -fPIE -MD -MT tests/amd_smi_test/CMakeFiles/amdsmitst.dir/functional/gpu_partition_metrics_read.cc.o -MF tests/amd_smi_test/CMakeFiles/amdsmitst.dir/functional/gpu_partition_metrics_read.cc.o.d -o tests/amd_smi_test/CMakeFiles/amdsmitst.dir/functional/gpu_partition_metrics_read.cc.o -c /home/sareeder/TheRock/rocm-systems/projects/amdsmi/tests/amd_smi_test/functional/gpu_partition_metrics_read.cc
[amdsmi] In file included from /home/sareeder/TheRock/rocm-systems/projects/amdsmi/rocm_smi/include/rocm_smi/../rocm_smi/rocm_smi.h:37,
[amdsmi]                  from /home/sareeder/TheRock/rocm-systems/projects/amdsmi/rocm_smi/include/rocm_smi/../rocm_smi/rocm_smi_monitor.h:31,
[amdsmi]                  from /home/sareeder/TheRock/rocm-systems/projects/amdsmi/rocm_smi/include/rocm_smi/../rocm_smi/rocm_smi_device.h:36,
[amdsmi]                  from /home/sareeder/TheRock/rocm-systems/projects/amdsmi/rocm_smi/include/rocm_smi/../rocm_smi/rocm_smi_utils.h:44,
[amdsmi]                  from /home/sareeder/TheRock/rocm-systems/projects/amdsmi/tests/amd_smi_test/functional/gpu_partition_metrics_read.cc:34:
[amdsmi] /home/sareeder/TheRock/rocm-systems/projects/amdsmi/rocm_smi/include/rocm_smi/../rocm_smi/kfd_ioctl.h:26:10: fatal error: libdrm/drm.h: No such file or directory
[amdsmi]    26 | #include <libdrm/drm.h>
[amdsmi]       |          ^~~~~~~~~~~~~~
[amdsmi] compilation terminated.
[amdsmi] [15/23] Creating library symlink src/libamd_smi.so.26 src/libamd_smi.so
[amdsmi] ninja: build stopped: subcommand failed.
[amdsmi FAILED WITH CODE 1 in 0 seconds]
```

So I've added `libdrm-dev` to the `apt install` command in `README.md`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
