### PR TITLE
[CI] Reset global config in case of corrupt .gitconfig

### DIFF
--- a/build_tools/github_actions/cleanup_processes.ps1
+++ b/build_tools/github_actions/cleanup_processes.ps1
@@ -9,7 +9,7 @@
 #
 # This powershell script is used on non-ephemeral Windows runners to stop
 # any processes that still exist after a Github actions job has completed
-# typically due to timing out. Additionally, it will clean up the system 
+# typically due to timing out. Additionally, it will clean up the system
 # environment to restore the system to a clean state for the next job.
 #
 # It's written in powershell per the specifications


### PR DESCRIPTION
## Motivation

Resolve recent issues with corrupted git configs as noted in https://github.com/ROCm/TheRock/issues/2929, https://github.com/ROCm/TheRock/issues/2956 to increase runner stability.

## Technical Details

Malformed global `.gitconfig` file causes `git` commands such as `git config --global ...` to fail and stop test workflows. Due to using persistent runners, workflows will repeatedly fail as a result, so add steps to clean up the git config in `setup_test_environment` action which is used to setup test workflows in all repos.

## Test Plan

Observe CI for test runs on all potentially affected Windows machines, but most notably:
- `windows-strix-halo-gpu-rocm-2`
- `windows-strix-halo-gpu-rocm-4`
- `windows-strix-halo-gpu-rocm-5`
- `windows-strix-halo-gpu-rocm-8`
## Test Result

Initial comments here about results https://github.com/ROCm/TheRock/pull/2967#issuecomment-3759686849

Followup comment about refactored script results being successful https://github.com/ROCm/TheRock/pull/2967#issuecomment-3762861165

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
