### PR TITLE
Statically link libatomic during numactl build

### DIFF
--- a/third-party/sysdeps/linux/numactl/CMakeLists.txt
+++ b/third-party/sysdeps/linux/numactl/CMakeLists.txt
@@ -62,17 +62,24 @@ if(NOT PATCHELF)
 endif()
 
 # Find static libatomic to avoid runtime dependency on libatomic.so.1
-execute_process(
-  COMMAND ${CMAKE_C_COMPILER} -print-file-name=libatomic.a
-  OUTPUT_VARIABLE LIBATOMIC_STATIC
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  ERROR_QUIET
-)
-if(LIBATOMIC_STATIC AND EXISTS "${LIBATOMIC_STATIC}")
-  message(STATUS "Found static libatomic: ${LIBATOMIC_STATIC}")
-  set(NUMACTL_LIBS "${LIBATOMIC_STATIC}")
+# Only attempt this with GCC 
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    execute_process(
+      COMMAND ${CMAKE_C_COMPILER} -print-file-name=libatomic.a
+      OUTPUT_VARIABLE LIBATOMIC_STATIC
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+    )
+    if(LIBATOMIC_STATIC AND EXISTS "${LIBATOMIC_STATIC}")
+      message(STATUS "Found static libatomic: ${LIBATOMIC_STATIC}")
+      set(NUMACTL_LIBS "${LIBATOMIC_STATIC}")
+    else()
+      message(STATUS "Static libatomic not found, will use system default if needed")
+      set(NUMACTL_LIBS "")
+    endif()
 else()
-  message(STATUS "Static libatomic not found, will use system default if needed")
+  # Non-GCC compiler - skip static libatomic lookup
+  message(WARNING "Non-GCC compiler, so skipping static libatomic linking")
   set(NUMACTL_LIBS "")
 endif()
 

--- a/third-party/sysdeps/linux/numactl/CMakeLists.txt
+++ b/third-party/sysdeps/linux/numactl/CMakeLists.txt
@@ -61,6 +61,21 @@ if(NOT PATCHELF)
   message(FATAL_ERROR "Missing PATCHELF from super-project")
 endif()
 
+# Find static libatomic to avoid runtime dependency on libatomic.so.1
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} -print-file-name=libatomic.a
+  OUTPUT_VARIABLE LIBATOMIC_STATIC
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET
+)
+if(LIBATOMIC_STATIC AND EXISTS "${LIBATOMIC_STATIC}")
+  message(STATUS "Found static libatomic: ${LIBATOMIC_STATIC}")
+  set(NUMACTL_LIBS "${LIBATOMIC_STATIC}")
+else()
+  message(STATUS "Static libatomic not found, will use system default if needed")
+  set(NUMACTL_LIBS "")
+endif()
+
 add_custom_target(
   build ALL
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
@@ -75,6 +90,9 @@ add_custom_target(
     # reconfigure the project as the version of autoconf available may differ
     autoreconf -f -i "${CMAKE_CURRENT_BINARY_DIR}/s"
   COMMAND
+    "${CMAKE_COMMAND}" -E env
+      "LIBS=${NUMACTL_LIBS}"
+      --
     "${CMAKE_CURRENT_BINARY_DIR}/s/configure"
       --prefix "${CMAKE_INSTALL_PREFIX}"
       --disable-static

--- a/third-party/sysdeps/linux/numactl/CMakeLists.txt
+++ b/third-party/sysdeps/linux/numactl/CMakeLists.txt
@@ -62,7 +62,7 @@ if(NOT PATCHELF)
 endif()
 
 # Find static libatomic to avoid runtime dependency on libatomic.so.1
-# Only attempt this with GCC 
+# Only attempt this with GCC
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     execute_process(
       COMMAND ${CMAKE_C_COMPILER} -print-file-name=libatomic.a


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/2518.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
- `numactl` dynamically links `libatomic.so.1`
- `libatomic.so.1` is not present on systems without gcc so running commands like `rocminfo` in our tarballs on clean systems leads to errors
- Statically link `libatomic.a` into `librocm_sysdeps_numa.so.1` during build so during runtime libatomic is no longer a dependency
- Added a check to avoid linking if compiler is not GCC; This is to avoid licensing ambiguity on whether another toolchain would qualify under the "Eligible Compiler Process" of the GCC Exception


<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Ran TheRock tarball and tested rocminfo in clean Ubuntu 22.04 Docker container without system libatomic or gcc installed.
```
wget https://therock-dev-tarball.s3.amazonaws.com/therock-dist-linux-gfx1151-7.11.0.dev0%2Bd462cb4c10d22909872ab1be9e1626902f5c8b5c.tar.gz
mkdir install
tar -xf *.tar.gz -C install
rocminfo
# rocminfo works
```

Also verified that libatomic is no longer required:
Before change:
```
readelf -d librocm_sysdeps_numa.so.1.0.0 | grep NEEDED
0x0000000000000001 (NEEDED) Shared library: [libatomic.so.1]
0x0000000000000001 (NEEDED) Shared library: [libc.so.6]
0x0000000000000001 (NEEDED) Shared library: [ld-linux-x86-64.so.2]
```
After:
```
readelf -d librocm_sysdeps_numa.so.1.0.0 | grep NEEDED
0x0000000000000001 (NEEDED) Shared library: [libc.so.6]
0x0000000000000001 (NEEDED) Shared library: [ld-linux-x86-64.so.2]
```
<!-- Explain any relevant testing done to verify this PR. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
