### PR TITLE
[build_tools] Fix artifact installation string/list extend/append mixup

### DIFF
--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -227,9 +227,9 @@ def retrieve_artifacts_by_run_id(args):
         if args.miopen:
             extra_artifacts.append("miopen")
             # We need bin/MIOpenDriver executable for tests.
-            argv.extend("miopen_run")
+            argv.append("miopen_run")
             # Also need these for runtime kernel compilation (rocrand includes).
-            argv.extend("rand_dev")
+            argv.append("rand_dev")
         if args.miopen_plugin:
             extra_artifacts.append("miopen-plugin")
         if args.fusilli_plugin:


### PR DESCRIPTION
While installing artifacts, I spotted this odd log line being output:

Calling fetch_artifacts_main with args:
  --run-id 20825218526 --artifact-group gfx94X-dcgpu --output-dir build
  --flatten core-hipinfo_run core-runtime_run core-runtime_lib sysdeps_lib
  base_run base_lib amd-llvm_run amd-llvm_lib core-hip_lib core-hip_dev
  core-ocl_lib core-ocl_dev rocprofiler-sdk_lib host-suite-sparse_lib
  m i o p e n _ r u n r a n d _ d e v blas_lib miopen_lib blas_test
  miopen_test

In particular, notice " m i o p e n _ r u n r a n d _ d e v". That does not seem to cause any artifact installation failure, but points to a mixup in handling of lists and strings.

Fix this by using append instead of extend in a couple cases where we're appending a string to a list.