### PR TITLE
Add texlive to Ubuntu dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ instructions and configurations for alternatives.
 ```bash
 # Install Ubuntu dependencies
 sudo apt update
-sudo apt install gfortran git ninja-build cmake g++ pkg-config xxd patchelf automake libtool python3-venv python3-dev libegl1-mesa-dev texinfo bison flex
+sudo apt install gfortran git ninja-build cmake g++ pkg-config xxd patchelf automake libtool python3-venv python3-dev libegl1-mesa-dev texinfo bison flex texlive
 
 # Clone the repository
 git clone https://github.com/ROCm/TheRock.git


### PR DESCRIPTION
## Motivation
README fix for fresh Ubuntu 24.04.3 build instruction: Add `texlive` as dependency on Ubuntu in README.

## Technical Details
Texlive dependency was introduced by rocgdb integrating into TheRock. Specifically, a working TeX is needed for building GDB document.

Or we could consider not building the docs? Or supply a flag in TheRock to control docs building for all projects?
Relevant CMakeLists (debug-tools/rocgdb/CMakeLists.txt):
```
# Install gdb docs.
COMMAND
  ${CMAKE_COMMAND} -E chdir "${ROCGDB_BUILD_DIR}"
  ${MAKE_EXECUTABLE} -s -C gdb install-pdf install-html
```
https://github.com/ROCm/TheRock/blob/45532898104eea7a0f2d0fe1556a2d74542c10b3/debug-tools/rocgdb/CMakeLists.txt#L277

Error log snippet:
```
73.6	 /usr/bin/install -c -m 644 'gdbinit.5' '/home/swae-ai/Desktop/rocm-stress/TheRock/build/debug-tools/rocgdb/build/rocgdb-build-py3.12-install/share/man/man5/rocgdbinit.5'
73.6	  TEXI2DVI gdb.pdf
73.6	You don't have a working TeX binary (tex) installed anywhere in
73.6	your PATH, and texi2dvi cannot proceed without one.  If you want to use
73.6	this script, you'll need to install TeX (if you don't have it) or change
73.6	your PATH or TEX environment variable (if you do).  See the --help
73.6	output for more details.
73.6	
73.6	For information about obtaining TeX, please see http://tug.org/texlive,
73.6	or do a web search for TeX and your operating system or distro.
73.6	
73.6	On Debian you can install a working TeX system with
73.6	  apt-get install texlive
73.6	make[2]: *** [Makefile:498: gdb.pdf] Error 1
73.6	make[1]: *** [Makefile:2470: subdir_do] Error 1
73.6	make: *** [Makefile:2222: install-pdf] Error 2
73.6	ninja: build stopped: subcommand failed.
```
Full log:
[rocgdb_configure.log](https://github.com/user-attachments/files/24710811/rocgdb_configure.log)
[rocgdb_build.log](https://github.com/user-attachments/files/24710809/rocgdb_build.log)

## Test Plan
Build no longer fails on TheRock with texlive installed.

## Test Result
Build no longer fails on TheRock with texlive installed.

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
