### PR TITLE
Update DNS resolution temporary fix for cloudfront dns url

### DIFF
--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -120,7 +120,6 @@ jobs:
           --group-add video
           --user root
           --env-file /etc/podinfo/gha-gpu-isolation-settings
-
           --dns 8.8.8.8
           --dns 8.8.4.4
     defaults:


### PR DESCRIPTION
## Motivation
This PR adds Google DNS servers to the Docker container configuration in the JAX wheel testing workflow. The workflow was experiencing connectivity issues when attempting to reach CloudFront endpoints for package downloads. Adding explicit DNS configuration ensures reliable network resolution and allows the workflow to successfully download JAX wheels from the package index.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

The changes add DNS configuration to the container options in the test_jax_wheels job:

- Added --dns 8.8.8.8 (Google's primary DNS server)
- Added --dns 8.8.4.4 (Google's secondary DNS server)

These options are appended to the existing container configuration that includes GPU device access and environment settings. This is a temporary fix to address DNS resolution issues within the GitHub Actions runner environment.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Triggering the workflow manually via workflow_dispatch with test parameters

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

- successfully resolves CloudFront URLs with the added DNS configuration
- All JAX tests pass as expected

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
