### PR TITLE
Do not bump math-libraries if not requested

### DIFF
--- a/build_tools/bump_submodules.py
+++ b/build_tools/bump_submodules.py
@@ -109,6 +109,11 @@ def parse_components(components: list[str]) -> list[list]:
     else:
         arguments.append("--no-include-rocm-media")
 
+    if "math-libraries" in components:
+        arguments.append("--include-math-libraries")
+    else:
+        arguments.append("--no-include-math-libraries")
+
     log(f"++ Arguments: {shlex.join(arguments)}")
     if system_projects:
         log(f"++ System projects: {shlex.join(system_projects)}")
@@ -198,8 +203,9 @@ def main(argv):
                   rocm-systems,
                   profiler,
                   iree-libs,
-                  debug-tools.
-                  rocm-media
+                  debug-tools,
+                  rocm-media,
+                  math-libraries
              """,
     )
     args = parser.parse_args(argv)


### PR DESCRIPTION
Require that this component is updated/bumped only when specified. Earlier the command:

     ./build_tools/bump_submodules --components rocm-libraries

bumped also math-libraries in addition of the rocm-libraries. Change it so that the library is updated with command:

     ./build_tools/bump_submodules --components math-libraries
