### PR TITLE
Revert "[ALMIOPEN-895] Remove positive filter to include missing test…

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -27,7 +27,88 @@ logging.basicConfig(level=logging.INFO)
 
 ###########################################
 
+positive_filter = []
 negative_filter = []
+
+# Fusion #
+positive_filter.append("*Fusion*")
+
+# Batch Normalization #
+positive_filter.append("*/GPU_BNBWD*_*")
+positive_filter.append("*/GPU_BNOCLBWD*_*")
+positive_filter.append("*/GPU_BNFWD*_*")
+positive_filter.append("*/GPU_BNOCLFWD*_*")
+positive_filter.append("*/GPU_BNInfer*_*")
+positive_filter.append("*/GPU_BNActivInfer_*")
+positive_filter.append("*/GPU_BNOCLInfer*_*")
+positive_filter.append("*/GPU_bn_infer*_*")
+
+# CPU tests
+positive_filter.append("CPU_*")  # tests without a suite
+positive_filter.append("*/CPU_*")  # tests with a suite
+
+# Different
+positive_filter.append("*/GPU_Cat_*")
+positive_filter.append("*/GPU_ConvBiasActiv*")
+
+# Convolutions
+positive_filter.append("*/GPU_Conv*")
+positive_filter.append("*/GPU_conv*")
+
+# Solvers
+positive_filter.append("*/GPU_UnitTestConv*")
+
+# Misc
+
+positive_filter.append("*/GPU_GetitemBwd*")
+positive_filter.append("*/GPU_GLU_*")
+
+positive_filter.append("*/GPU_GroupConv*")
+positive_filter.append("*/GPU_GroupNorm_*")
+positive_filter.append("*/GPU_GRUExtra_*")
+positive_filter.append("*/GPU_TestActivation*")
+positive_filter.append("*/GPU_HipBLASLtGEMMTest*")
+positive_filter.append("*/GPU_KernelTuningNetTestConv*")
+positive_filter.append("*/GPU_Kthvalue_*")
+positive_filter.append("*/GPU_LayerNormTest*")
+positive_filter.append("*/GPU_LayoutTransposeTest_*")
+positive_filter.append("*/GPU_Lrn*")
+positive_filter.append("*/GPU_lstm_extra*")
+
+positive_filter.append("*/GPU_MultiMarginLoss_*")
+positive_filter.append("*/GPU_ConvNonpack*")
+positive_filter.append("*/GPU_PerfConfig_HipImplicitGemm*")
+positive_filter.append("*/GPU_AsymPooling2d_*")
+positive_filter.append("*/GPU_WidePooling2d_*")
+positive_filter.append("*/GPU_PReLU_*")
+positive_filter.append("*/GPU_Reduce*")
+positive_filter.append("*/GPU_reduce_custom_*")
+positive_filter.append("*/GPU_regression_issue_*")
+positive_filter.append("*/GPU_RNNExtra_*")
+positive_filter.append("*/GPU_RoPE*")
+positive_filter.append("*/GPU_SoftMarginLoss*")
+positive_filter.append("*/GPU_T5LayerNormTest_*")
+positive_filter.append("*/GPU_Op4dTensorGenericTest_*")
+positive_filter.append("*/GPU_TernaryTensorOps_*")
+positive_filter.append("*/GPU_unaryTensorOps_*")
+positive_filter.append("*/GPU_Transformers*")
+positive_filter.append("*/GPU_TunaNetTest_*")
+positive_filter.append("*/GPU_UnitTestActivationDescriptor_*")
+positive_filter.append("*/GPU_FinInterfaceTest*")
+positive_filter.append("*/GPU_VecAddTest_*")
+
+positive_filter.append("*/GPU_KernelTuningNetTest*")
+positive_filter.append("*/GPU_MIOpenDriver*")
+
+positive_filter.append("*/GPU_Bwd_Mha_*")
+positive_filter.append("*/GPU_Fwd_Mha_*")
+positive_filter.append("*/GPU_Softmax*")
+positive_filter.append("*/GPU_Dropout*")
+positive_filter.append("*/GPU_MhaBackward_*")
+positive_filter.append("*/GPU_MhaForward_*")
+positive_filter.append("*GPU_TestMhaFind20*")
+
+#############################################
 
 negative_filter.append("*DeepBench*")
 negative_filter.append("*MIOpenTestConv*")
@@ -144,6 +225,7 @@ smoke_filter = [
 # TODO(rocm-libraries#2266): re-enable test for gfx950-dcgpu
 if AMDGPU_FAMILIES != "gfx950-dcgpu":
     smoke_filter.append("*DBSync*")
+    positive_filter.append("*DBSync*")
 
 ####################################################
 
@@ -153,7 +235,9 @@ test_type = os.getenv("TEST_TYPE", "full")
 if test_type == "smoke":
     test_filter = "--gtest_filter=" + ":".join(smoke_filter)
 else:
-    test_filter = "--gtest_filter=" + ":*" + "-" + ":".join(negative_filter)
+    test_filter = (
+        "--gtest_filter=" + ":".join(positive_filter) + "-" + ":".join(negative_filter)
+    )
 #############################################
 
 cmd = [f"{THEROCK_BIN_DIR}/miopen_gtest", test_filter]


### PR DESCRIPTION
This reverts commit 67030d63a2c71118a12ec06c3f0f356ae28c782b.

See [this issue](https://github.com/ROCm/rocm-libraries/issues/3956) for more details.

## Motivation

Removal of the positive filters has caused tests to run that are failing on gfx1151 systems so we need a deeper understanding before we enable more tests.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
