### PR TITLE
Mention texlive dependency for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ instructions and configurations for alternatives.
 ```bash
 # Install Ubuntu dependencies
 sudo apt update
-sudo apt install gfortran git ninja-build cmake g++ pkg-config xxd patchelf automake libtool python3-venv python3-dev libegl1-mesa-dev texinfo bison flex
+sudo apt install gfortran git ninja-build cmake g++ pkg-config xxd patchelf automake libtool python3-venv python3-dev libegl1-mesa-dev texinfo bison flex texlive
 
 # Clone the repository
 git clone https://github.com/ROCm/TheRock.git


### PR DESCRIPTION
ROCgdb depends on texi2dvi for its pdf documentation generation.

Mention the Ubuntu package required to make this tool available so TheRock builds in Ubuntu work correctly.