### PR TITLE
Address CI failures due to the removal of the positive filter by excluding failing and long tests

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -132,12 +132,13 @@ if AMDGPU_FAMILIES in ["gfx110X-all", "gfx1150", "gfx1151", "gfx120X-all"]:
     negative_filter.append("Smoke/GPU_MultiMarginLoss_*")
     negative_filter.append("CPU_TuningPolicy_NONE")
     negative_filter.append("Full/CPU_CandidateSelection_NONE*")
-    negative_filter.append("GPU_GroupConv2D_Forward_BFP16*")  # It tries to hipMalloc 2.5GB of memory
     negative_filter.append("GPU_OpTensorFwdBiasTest_FP32*")
     negative_filter.append("GPU_ConvGrpBiasActivInfer3D_BFP16*")
     negative_filter.append("GPU_ConvGrpActivInfer_BFP16*")
+    negative_filter.append(
+        "GPU_GroupConv2D_Forward_BFP16*"
+    )  # It tries to hipMalloc 2.5GB of memory
 
-    
     # Tests failing CI now but are not new
 
 ####################################################


### PR DESCRIPTION
## Motivation

The work in this PR https://github.com/ROCm/TheRock/pull/2888 added more tests to the CI for MIOpen and some started to fail for windows gfx1151, they are added to the windows negative filter in this PR.
Also some occasional timeouts due to the increase of number of tests and their run time, added to the negative filter here.

## Technical Details
Collected results from this issue https://github.com/ROCm/rocm-libraries/issues/3956#issuecomment-3775398643
New failing tests added the windows negative filter:
```
# New tests added and failing with the removal of the positive filter
    negative_filter.append("Smoke/GPU_MultiMarginLoss_*")
    negative_filter.append("CPU_TuningPolicy_NONE")
    negative_filter.append("Full/CPU_CandidateSelection_NONE*")
    negative_filter.append("GPU_GroupConv2D_Forward_BFP16*")  # It tries to hipMalloc 2.5GB of memory
    negative_filter.append("GPU_OpTensorFwdBiasTest_FP32*")
    negative_filter.append("GPU_ConvGrpBiasActivInfer3D_BFP16*")
    negative_filter.append("GPU_ConvGrpActivInfer_BFP16*")
```
New long running tests added to the general negative filter:
```
negative_filter.append("Full/GPU_MIOpenDriverConv2dTransTest_BFP16*")  # 1 min 34 sec
negative_filter.append("Smoke/GPU_Reduce_FP32*")  # 1 min 30 sec
negative_filter.append("Smoke/GPU_Reduce_FP16*")  # 1 min 11 sec
```
## Test Plan

The CI need to start passing again specifically windows gfx1151
Check if there is any more test timeout, and continuing collecting run time

## Test Result

TODO: watch the CI

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
