### PR TITLE
Migrate fetch_artifacts.py to use artifact_backend and artifact_manager

### DIFF
--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -120,6 +120,15 @@ def get_postprocess_mode(args) -> str | None:
 def extract_artifact(
     archive_path: Path, *, delete_archive: bool, postprocess_mode: str
 ):
+    """Extracts and postprocesses an artifact from an archive file in-place.
+
+    Args:
+        archive_path: Path to the archive (e.g. `amd-llvm_lib_generic.tar.xz`)
+        delete_archive: True to delete the archive after extraction
+        postprocess_mode: Either 'flatten' or 'extract'
+          * 'flatten' merges artifacts into a single "dist/" directory
+          * 'extract' puts each artifact in a dir (e.g. `amd-llvm_lib_generic/`)
+    """
     # Get (for example) 'amd-llvm_lib_generic' from '/path/to/amd-llvm_lib_generic.tar.xz'
     # We can't just use .stem since that only removes the last extension.
     #   1. .name gets us 'amd-llvm_lib_generic.tar.xz'

--- a/build_tools/tests/fetch_artifacts_test.py
+++ b/build_tools/tests/fetch_artifacts_test.py
@@ -17,25 +17,6 @@ REPO_DIR = THIS_DIR.parent.parent
 
 
 class ArtifactsIndexPageTest(unittest.TestCase):
-    def testListArtifactsForGroup_Found(self):
-        # Create a mock backend that returns test artifacts
-        backend = MagicMock(spec=ArtifactBackend)
-        backend.base_uri = "s3://therock-ci-artifacts/ROCm-TheRock/123-linux"
-        backend.list_artifacts.return_value = [
-            "empty_1test.tar.xz",
-            "empty_2test.tar.xz",
-            "empty_3generic.tar.xz",
-            "empty_4test.tar.xz",
-        ]
-
-        result = list_artifacts_for_group(backend, "test")
-
-        self.assertEqual(len(result), 4)
-        self.assertTrue("empty_1test.tar.xz" in result)
-        self.assertTrue("empty_2test.tar.xz" in result)
-        self.assertTrue("empty_3generic.tar.xz" in result)
-        self.assertTrue("empty_4test.tar.xz" in result)
-
     def testListArtifactsForGroup_FiltersByArtifactGroup(self):
         # Test that filtering by artifact_group works correctly
         backend = MagicMock(spec=ArtifactBackend)


### PR DESCRIPTION
## Motivation

While working on https://github.com/ROCm/TheRock/pull/3000, I found that this code is directly handling S3 paths like so:

```python
    def __post_init__(self):
        self.s3_key_path = f"{self.external_repo}{self.workflow_run_id}-{self.platform}"
``` 

I'm trying to move that code to a central location and to make it possible to swap out the "s3 cloud backend for a "local backend" for easier testing. Moving string manipulation code is easy enough, but this file _also_ directly communicated with S3:

```python
          log(f"++ Downloading {artifact_key} to {output_path}")
          with open(output_path, "wb") as f:
              s3_client.download_fileobj(bucket, artifact_key, f)
```

That would be harder to refactor... if we didn't already have this abstraction in `ArtifactBackend`. So, I'm first migrating this code to use that class.


## Technical Details

I also considered making `fetch_artifacts.py` just call `artifact_manager.py` directly, but they have different roles:
* `artifact_manager.py` is topology-aware and is currently just used for multi-arch builds
* `fetch_artifacts.py` has regex-based fetching and is currently used by developers to fetch explicit lists of artifacts and by CI workflows to download subsets of artifacts for tests

## Test Plan

* Existing unit tests (light coverage)
* Manual sanity check:
    ```cmd
    python ./build_tools/fetch_artifacts.py ^
      --run-id=18480879899 ^
      --artifact-group=gfx110X-dgpu ^
      --output-dir=%HOME%\.therock\18480879899\artifacts
    ```
* CI test jobs will run this `fetch_artifacts.py` script indirectly via [`build_tools/install_rocm_from_artifacts.py`](https://github.com/ROCm/TheRock/blob/main/build_tools/install_rocm_from_artifacts.py)

## Test Result

* CI jobs run the script with no issues, e.g. https://github.com/ROCm/TheRock/actions/runs/21192582915/job/60969434096?pr=3019#step:6:280

    ```
    Calling fetch_artifacts_main with args:
      --run-id 21192582915 --artifact-group gfx94X-dcgpu --output-dir build --flatten core-hipinfo_run core-runtime_run core-runtime_lib sysdeps_lib base_run base_lib amd-llvm_run amd-llvm_lib core-hip_lib core-hip_dev core-ocl_lib core-ocl_dev rocprofiler-sdk_lib host-suite-sparse_lib blas_lib blas_test
    
    ...
    
    ++ Flattening 'blas_test_gfx94X-dcgpu.tar.xz' to 'blas_test_gfx94X-dcgpu'
    ++ Flattening 'blas_lib_gfx94X-dcgpu.tar.xz' to 'blas_lib_gfx94X-dcgpu'
    Retrieved artifacts for run ID 21192582915
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
