### PR TITLE
[ci] new OSSCI MI325 runners from DigitalOcean

### DIFF
--- a/.github/workflows/test_jax_dockerfile.yml
+++ b/.github/workflows/test_jax_dockerfile.yml
@@ -6,7 +6,7 @@ on:
       test_runs_on:
         required: true
         type: string
-        default: "linux-mi325-1gpu-ossci-rocm-frac"
+        default: "linux-mi325-1gpu-ossci-rocm"
       image_name:
         required: true
         description: JAX docker image to run tests with

--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -87,7 +87,7 @@ on:
         description: Runner label to use. The selected runner should have a GPU supported by amdgpu_family
         required: true
         type: string
-        default: "linux-mi325-1gpu-ossci-rocm-frac"
+        default: "linux-mi325-1gpu-ossci-rocm"
       ref:
         description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow."
         type: string

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -12,7 +12,7 @@ on:
         description: Runner label to use. The selected runner should have a GPU supported by amdgpu_family
         required: true
         type: string
-        default: "linux-mi325-1gpu-ossci-rocm-frac"
+        default: "linux-mi325-1gpu-ossci-rocm"
       package_index_url:
         description: Base Python package index URL to test, typically nightly/dev URL with a "v2" or "v2-staging" subdir (without a GPU family subdir)
         required: true

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -48,10 +48,10 @@ all_build_variants = {
 amdgpu_family_info_matrix_presubmit = {
     "gfx94x": {
         "linux": {
-            "test-runs-on": "linux-mi325-1gpu-ossci-rocm.test",
-            "test-runs-on-multi-gpu": "linux-mi325-8gpu-ossci-rocm.test",
+            "test-runs-on": "linux-mi325-1gpu-ossci-rocm",
+            "test-runs-on-multi-gpu": "linux-mi325-8gpu-ossci-rocm",
             # TODO(#2754): Add new benchmark-runs-on runner for benchmarks
-            "benchmark-runs-on": "linux-mi325-1gpu-ossci-rocm.test",
+            "benchmark-runs-on": "linux-mi325-8gpu-ossci-rocm",
             "family": "gfx94X-dcgpu",
             "build_variants": ["release", "asan"],
         }

--- a/build_tools/github_actions/tests/configure_target_run_test.py
+++ b/build_tools/github_actions/tests/configure_target_run_test.py
@@ -13,14 +13,14 @@ class ConfigureTargetRunTest(unittest.TestCase):
         # gfx94X-dcgpu is the inner key, which we use for package names. When
         # run from a workflow, we expect to only work on the inner keys.
         runner_label = configure_target_run.get_runner_label("gfx94x", "linux")
-        self.assertEqual(runner_label, "linux-mi325-1gpu-ossci-rocm.test")
+        self.assertEqual(runner_label, "linux-mi325-1gpu-ossci-rocm")
 
     def test_linux_gfx94X_dcgpu(self):
         # gfx94x is the outer key used to construct workflow pipelines, while
         # gfx94X-dcgpu is the inner key, which we use for package names. When
         # run from a workflow, we expect to only work on the inner keys.
         runner_label = configure_target_run.get_runner_label("gfx94X-dcgpu", "linux")
-        self.assertEqual(runner_label, "linux-mi325-1gpu-ossci-rocm.test")
+        self.assertEqual(runner_label, "linux-mi325-1gpu-ossci-rocm")
 
     def test_windows_gfx115x(self):
         runner_label = configure_target_run.get_runner_label("gfx1151", "windows")


### PR DESCRIPTION
## Motivation

adding new mi325 runners from digital ocean

## Technical Details

OSSCI has onboarded new mi325 from digital ocean

## Test Plan

Observe CI for the gfx94x tests

## Test Result

in CI results from RCCL and normal components
8-gpu works with RCCL (https://github.com/ROCm/TheRock/actions/runs/21394276627/job/61600608768?pr=3025)
1-gpu works with normal component tests (https://github.com/ROCm/TheRock/actions/runs/21394276627/job/61600608736?pr=3025)

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
