### PR TITLE
Update INSTALL_RPATH_DIRS for rocprof-sys

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -233,6 +233,9 @@ endif(THEROCK_BUILD_TESTING)
         -DROCPROFSYS_BUILD_LIBIBERTY=ON
         -DROCPROFSYS_BUILD_BOOST=ON
         -DROCPROFSYS_BUILD_DYNINST=ON
+      INSTALL_RPATH_DIRS
+        "lib"
+        "lib/rocprofiler-systems"
       CMAKE_INCLUDES
         therock_explicit_finders.cmake
       RUNTIME_DEPS


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Project libraries in `lib/rocprofiler-systems` were not resolved without the LD_LIBRRARY_PATH being set. 

Related to AIPROFSYST-168

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Add `lib/rocprofiler-systems` to INSTALL_RPATH_DIRS of our subproject's declaration.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Run CIs. 
Verify internal libraries are resolved with `ldd`.
Verify RPATH of librocprof-sys*.so with `chrpath` (or similar utility).

## Test Result

<!-- Briefly summarize test outcomes. -->
`ldd` shows that all libraries are found. 
`readelf` shows that RPATH are set as expected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
