### PR TITLE
Enable rocWMMA for gfx1103

### DIFF
--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -142,7 +142,6 @@ therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all 
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rccl  # https://github.com/ROCm/TheRock/issues/150
-    rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     libhipcxx # https://github.com/ROCm/TheRock/issues/2504
 )
 


### PR DESCRIPTION
- Support was added for rocWMMA for gfx1103 with https://github.com/ROCm/rocm-libraries/pull/2301 and is related to https://github.com/ROCm/TheRock/issues/1944
- Do not merge yet, I plan to do manual testing with this PR included first