### PR TITLE
Update RCCL build compiler flags

### DIFF
--- a/comm-libs/pre_hook_rccl.cmake
+++ b/comm-libs/pre_hook_rccl.cmake
@@ -1,3 +1,12 @@
+# Remove -DNDEBUG: RCCL requires assertions enabled for correct behavior
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(CMAKE_C_FLAGS_RELEASE "-O3" CACHE STRING "Release flags" FORCE)
+  set(CMAKE_CXX_FLAGS_RELEASE "-O3" CACHE STRING "Release flags" FORCE)
+elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+  set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g" CACHE STRING "RelWithDebInfo flags" FORCE)
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g" CACHE STRING "RelWithDebInfo flags" FORCE)
+endif()
+
 if(NOT WIN32)
   # Configure roctracer if on a supported operating system (Linux).
   # rocBLAS has deprecated dependencies on roctracer. We apply a patch to redirect


### PR DESCRIPTION
## Motivation

_Work Item: ROCM-1435, SWDEV-560618_

## Technical Details

Update RCCL build compiler flags as per RCCL toolchain : https://github.com/ROCm/rocm-systems/blob/develop/projects/rccl/toolchain-linux.cmake

## Test Plan

Monitor CI runs on this PR

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
