### PR TITLE
Revert "Update inputs, test staging whls and publish to v2"

### DIFF
--- a/.github/workflows/build_linux_jax_wheels.yml
+++ b/.github/workflows/build_linux_jax_wheels.yml
@@ -226,6 +226,7 @@ jobs:
     with:
       amdgpu_family: ${{ inputs.amdgpu_family }}
       release_type: ${{ inputs.release_type }}
+      s3_subdir: ${{ inputs.s3_subdir }}
       package_index_url: ${{ inputs.cloudfront_staging_url }}
       rocm_version: ${{ inputs.rocm_version }}
       tar_url: ${{ inputs.tar_url }}

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -345,12 +345,9 @@ jobs:
             { "amdgpu_family": "${{ matrix.target_bundle.amdgpu_family }}",
               "python_version": "3.12",
               "release_type": "${{ env.RELEASE_TYPE }}",
-              "s3_subdir": "${{ env.S3_SUBDIR }}",
-              "s3_staging_subdir": "${{ env.S3_STAGING_SUBDIR }}",
-              "cloudfront_staging_url": "${{ needs.setup_metadata.outputs.cloudfront_staging_url }}",
+              "s3_subdir": "${{ env.S3_STAGING_SUBDIR }}",
               "rocm_version": "${{ needs.setup_metadata.outputs.version }}",
-              "tar_url": "${{ steps.url-encode-tar.outputs.tar_url }}",
-              "ref": "${{ inputs.ref || '' }}"
+              "tar_url": "${{ steps.url-encode-tar.outputs.tar_url }}"
             }
 
       - name: Trigger build native rpm package

--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -9,6 +9,9 @@ on:
       release_type:
         required: true
         type: string
+      s3_subdir:
+        required: true
+        type: string
       package_index_url:
         description: Base CloudFront URL for the Python package index
         required: true
@@ -61,6 +64,11 @@ on:
         required: true
         type: string
         default: dev
+      s3_subdir:
+        description: S3 subdirectory, not including the GPU-family
+        required: true
+        type: string
+        default: v2
       package_index_url:
         description: Base CloudFront URL for the Python package index
         required: true
@@ -122,7 +130,7 @@ jobs:
       AMDGPU_FAMILY: ${{ inputs.amdgpu_family }}
       THEROCK_TAR_URL: ${{ inputs.tar_url }}
       PYTHON_VERSION: ${{ inputs.python_version }}
-      WHEEL_INDEX_URL: ${{ inputs.package_index_url }}/${{ inputs.amdgpu_family }}/
+      WHEEL_INDEX_URL: ${{ inputs.package_index_url }}/${{ inputs.amdgpu_family }}
 
     steps:
       - name: Checkout
@@ -184,20 +192,19 @@ jobs:
           JAX_VERSION=$(tr -d ' ' < jax/build/requirements.txt \
           | grep -E '^(jax|jaxlib)==[^#]+' | head -n1 | cut -d'=' -f3)
           echo "JAX_VERSION=$JAX_VERSION" >> "$GITHUB_ENV"
-          echo "PACKAGE_VERSION=${JAX_VERSION}+rocm${{ inputs.rocm_version }}" >> "$GITHUB_ENV"
 
       - name: Install JAX wheels from package index
         run: |
           # Install jaxlib/plugin/pjrt from the GPU-family index; install jax from PyPI to match the version
           pip install --index-url "${{ env.WHEEL_INDEX_URL }}" \
-            "jaxlib==${{ env.PACKAGE_VERSION }}" \
-            "jax_rocm7_plugin==${{ env.PACKAGE_VERSION }}" \
-            "jax_rocm7_pjrt==${{ env.PACKAGE_VERSION }}"
-          pip install jax==${{ env.JAX_VERSION }}
+            "jaxlib==${JAX_VERSION}+rocm${{ inputs.rocm_version }}" \
+            "jax-rocm7-plugin==${JAX_VERSION}+rocm${{ inputs.rocm_version }}" \
+            "jax-rocm7-pjrt==${JAX_VERSION}+rocm${{ inputs.rocm_version }}"
+          pip install --extra-index-url https://pypi.org/simple "jax==${JAX_VERSION}"
 
       - name: Run JAX tests
         run: |
-          pytest jax/jax_tests/tests/multi_device_test.py -q --log-cli-level=INFO
-          pytest jax/jax_tests/tests/core_test.py -q --log-cli-level=INFO
-          pytest jax/jax_tests/tests/util_test.py -q --log-cli-level=INFO
-          pytest jax/jax_tests/tests/scipy_stats_test.py -q --log-cli-level=INFO
+            pytest jax/jax_tests/tests/multi_device_test.py -q --log-cli-level=INFO
+            pytest jax/jax_tests/tests/core_test.py -q --log-cli-level=INFO
+            pytest jax/jax_tests/tests/util_test.py -q --log-cli-level=INFO
+            pytest jax/jax_tests/tests/scipy_stats_test.py -q --log-cli-level=INFO


### PR DESCRIPTION
Reverts ROCm/TheRock#2557

This broke releases using the `release_portable_linux_packages.yml` workflow: https://github.com/ROCm/TheRock/actions/runs/21236023290/job/61104164516#step:20:44

```
Run benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc
  with:
    workflow: build_linux_jax_wheels.yml
    inputs: { "amdgpu_family": "gfx94X-dcgpu",
    "python_version": "3.12",
    "release_type": "nightly",
    "s3_subdir": "v2",
    "s3_staging_subdir": "v2-staging",
    "cloudfront_staging_url": "https://rocm.nightlies.amd.com/v2-staging",
    "rocm_version": "7.12.0a20260122",
    "tar_url": "https://rocm.nightlies.amd.com/tarball/therock-dist-linux-gfx94X-dcgpu-7.12.0a20260122.tar.gz",
    "ref": ""
  }

...

🏃 Workflow Dispatch Action v1.2.4
🔎 Found workflow, id: 178566937, name: Build Portable Linux JAX Wheels, path: .github/workflows/build_linux_jax_wheels.yml
🚀 Calling GitHub API to dispatch workflow...
Error: Unexpected inputs provided: ["ref"] - https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event
```

I have some rough notes on how we could catch this with tooling: https://github.com/ScottTodd/claude-rocm-workspace/blob/main/plans/github_actions_static_analysis.md