### PR TITLE
Switch to new IAM role

### DIFF
--- a/.github/workflows/build_linux_jax_wheels.yml
+++ b/.github/workflows/build_linux_jax_wheels.yml
@@ -177,7 +177,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}
 
       - name: Upload wheels to S3
         if: ${{ github.repository_owner == 'ROCm' }}
@@ -259,7 +259,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}
 
       - name: Determine upload flag
         env:

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -204,7 +204,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}
 
       - name: Upload wheels to S3 staging
         if: ${{ github.repository_owner == 'ROCm' }}
@@ -284,7 +284,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}
 
       - name: Determine upload flag
         env:

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -232,7 +232,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}
           special-characters-workaround: true
 
       - name: Upload wheels to S3 staging
@@ -315,7 +315,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}-releases
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}
           special-characters-workaround: true
 
       - name: Determine upload flag


### PR DESCRIPTION
Switches workflows to assume the harmonized roles. The are already used in the release workflows for ROCm packages but these workflows were still assuming the old role.