### PR TITLE
Bump wheel to a version >=0.46.2

### DIFF
--- a/external-builds/jax/requirements-jax.txt
+++ b/external-builds/jax/requirements-jax.txt
@@ -1,7 +1,7 @@
 boto3==1.41.4
 numpy==2.3.5
 build==1.3.0
-wheel==0.45.1
+wheel>=0.46.2
 six==1.17.0
 auditwheel==6.5.0
 scipy==1.16.3


### PR DESCRIPTION
Update wheel to a version non affected by
https://www.cve.org/CVERecord?id=CVE-2026-24049.