### PR TITLE
Add test validating benc-uk/workflow-dispatch inputs

### DIFF
--- a/build_tools/github_actions/tests/workflow_dispatch_inputs_test.py
+++ b/build_tools/github_actions/tests/workflow_dispatch_inputs_test.py
@@ -1,11 +1,33 @@
-"""Validate that benc-uk/workflow-dispatch calls only pass inputs defined by target workflows.
+"""Tests validating inputs to benc-uk/workflow-dispatch in workflow files.
 
-The benc-uk/workflow-dispatch action triggers workflows via the GitHub REST API's
-"Create a workflow dispatch event" endpoint. This endpoint rejects any inputs that
-are not defined in the target workflow's `on: workflow_dispatch: inputs:` section.
+The https://github.com/benc-uk/workflow-dispatch action triggers workflows via
+the GitHub REST API's "Create a workflow dispatch event" endpoint. This endpoint
+rejects any inputs that are not defined in the target workflow's
+`on: workflow_dispatch: inputs:` section. Changes to workflow files that
+pass basic parsing checks and https://github.com/rhysd/actionlint can still
+fail at runtime, like the bug at
+https://github.com/ROCm/TheRock/pull/2557#discussion_r2717677336. These tests
+add an extra layer of validation.
 
-This test catches mismatches at lint time rather than waiting for CI failures.
-See: https://github.com/ROCm/TheRock/pull/2557 for an example of this class of bug.
+This file creates test cases for each file in .github/workflows/ that uses
+benc-uk/workflow-dispatch. It is run like a standard unit test, e.g.:
+
+```
+python ./build_tools/github_actions/tests/workflow_dispatch_inputs_test.py --v
+test_no_unexpected_inputs__release_portable_linux_packages (__main__.WorkflowDispatchInputsTest.test_no_unexpected_inputs__release_portable_linux_packages)
+No unexpected dispatch inputs in release_portable_linux_packages.yml ... ok
+test_no_unexpected_inputs__release_windows_packages (__main__.WorkflowDispatchInputsTest.test_no_unexpected_inputs__release_windows_packages)
+No unexpected dispatch inputs in release_windows_packages.yml ... ok
+test_required_inputs_passed__release_portable_linux_packages (__main__.WorkflowDispatchInputsTest.test_required_inputs_passed__release_portable_linux_packages)
+All required dispatch inputs passed in release_portable_linux_packages.yml ... ok
+test_required_inputs_passed__release_windows_packages (__main__.WorkflowDispatchInputsTest.test_required_inputs_passed__release_windows_packages)
+All required dispatch inputs passed in release_windows_packages.yml ... ok
+
+----------------------------------------------------------------------
+Ran 4 tests in 0.087s
+
+OK
+```
 """
 
 from dataclasses import dataclass
@@ -116,7 +138,7 @@ class DispatchCall:
 
 
 def find_dispatch_calls_in_workflow(workflow: dict) -> list[DispatchCall]:
-    """Find benc-uk/workflow-dispatch steps in a single workflow."""
+    """Finds benc-uk/workflow-dispatch steps in a single workflow."""
     if not workflow or "jobs" not in workflow:
         return []
 
@@ -141,7 +163,7 @@ def find_dispatch_calls_in_workflow(workflow: dict) -> list[DispatchCall]:
 
 
 class WorkflowDispatchInputsTest(unittest.TestCase):
-    """Verify benc-uk/workflow-dispatch calls only pass valid inputs.
+    """Verifies benc-uk/workflow-dispatch calls only pass valid inputs.
 
     Test cases are generated dynamically, one per workflow file.
     """
@@ -212,7 +234,7 @@ def _make_required_inputs_test(workflow_path: Path):
 
 
 def _workflow_name_to_test_suffix(workflow_path: Path) -> str:
-    """Convert a workflow filename to a valid Python identifier suffix."""
+    """Converts a workflow filename to a valid Python identifier suffix."""
     return workflow_path.stem.replace("-", "_").replace(".", "_")
 
 


### PR DESCRIPTION
## Motivation

This adds a unit test that would have caught the bugs introduced by these PRs, where they were either missing required inputs or were passing unknown inputs:
* https://github.com/ROCm/TheRock/pull/2239
  * Revert: https://github.com/ROCm/TheRock/pull/2290
  * (note that most of our `workflow_dispatch` usage has `default` values, so this is a fuzzier error condition)
* https://github.com/ROCm/TheRock/pull/2557
  * Revert: https://github.com/ROCm/TheRock/pull/3045

## Technical Details

Test written mostly by Claude Code and then refined with some iteration.

* I settled on a dynamic list of generated test cases, one pair of tests per file that uses workflow-dispatch.
* If there are multiple errors in the same test case (e.g. multiple uses of workflow-dispatch that are missing required inputs or passing unexpected inputs), all errors will be logged.
* If a workflow file has invalid JSON, an unhandled `JSONDecodeError` exception will be raised. The error message isn't very good there, but I think other tests should check for that (maybe `actionlint`? or a different unit test?)

> [!NOTE]
> This will also enforce that we use _filenames_ for the `workflow` parameter in the `benc-uk/workflow-dispatch` action. It also supports _workflow names_ or _IDs_, but these are harder to analyze.

### Alternatives Considered

I have more analysis of the problem and potential solutions here: https://github.com/ScottTodd/claude-rocm-workspace/blob/main/tasks/completed/github_actions_static_analysis.md#context.

* https://github.com/rhysd/actionlint does not analyze uses of https://github.com/benc-uk/workflow-dispatch
* Add a custom pre-commit lint rule 
  * I think the analysis itself is expensive enough that a unit test is more appropriate
* Careful review (human or tool-assisted)
  * Strong enforcement through tests or lint rules is safer

## Test Plan

* Tests pass with current workflows
    
    ```bash
    λ python .\build_tools\github_actions\tests\workflow_dispatch_inputs_test.py --v
    test_no_unexpected_inputs__release_portable_linux_packages (__main__.WorkflowDispatchInputsTest.test_no_unexpected_inputs__release_portable_linux_packages)
    No unexpected dispatch inputs in release_portable_linux_packages.yml ... ok
    test_no_unexpected_inputs__release_windows_packages (__main__.WorkflowDispatchInputsTest.test_no_unexpected_inputs__release_windows_packages)
    No unexpected dispatch inputs in release_windows_packages.yml ... ok
    test_required_inputs_passed__release_portable_linux_packages (__main__.WorkflowDispatchInputsTest.test_required_inputs_passed__release_portable_linux_packages)
    All required dispatch inputs passed in release_portable_linux_packages.yml ... ok
    test_required_inputs_passed__release_windows_packages (__main__.WorkflowDispatchInputsTest.test_required_inputs_passed__release_windows_packages)
    All required dispatch inputs passed in release_windows_packages.yml ... ok
    
    ----------------------------------------------------------------------
    Ran 4 tests in 0.082s
    
    OK
    ```

* Tests catch the issue from https://github.com/ROCm/TheRock/pull/2557

    ```diff
    λ git diff
    diff --git a/.github/workflows/release_portable_linux_packages.yml b/.github/workflows/release_portable_linux_packages.yml
    index 8f53bd4f..e14a7caa 100644
    --- a/.github/workflows/release_portable_linux_packages.yml
    +++ b/.github/workflows/release_portable_linux_packages.yml
    @@ -347,7 +347,8 @@ jobs:
                   "release_type": "${{ env.RELEASE_TYPE }}",
                   "s3_subdir": "${{ env.S3_STAGING_SUBDIR }}",
                   "rocm_version": "${{ needs.setup_metadata.outputs.version }}",
    -              "tar_url": "${{ steps.url-encode-tar.outputs.tar_url }}"
    +              "tar_url": "${{ steps.url-encode-tar.outputs.tar_url }}",
    +              "ref": "${{ inputs.ref || '' }}"
                 }
    
           - name: Trigger build native rpm package
    ```
    
    ```bash
    λ python .\build_tools\github_actions\tests\workflow_dispatch_inputs_test.py
    F...
    ======================================================================
    FAIL: test_no_unexpected_inputs__release_portable_linux_packages (__main__.WorkflowDispatchInputsTest.test_no_unexpected_inputs__release_portable_linux_packages)
    No unexpected dispatch inputs in release_portable_linux_packages.yml
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "D:\projects\TheRock\build_tools\github_actions\tests\workflow_dispatch_inputs_test.py", line 182, in test_method
    
        self.fail("\n".join(errors))
        ~~~~~~~~~^^^^^^^^^^^^^^^^^^^
    AssertionError: step 'Trigger build JAX wheels' passes unexpected inputs to 'build_linux_jax_wheels.yml': ['ref']. Accepted: ['amdgpu_family', 'cloudfront_staging_url', 'cloudfront_url', 'jax_ref', 'python_version', 'release_type', 'rocm_version', 's3_staging_subdir', 's3_subdir', 'tar_url']
    
    ----------------------------------------------------------------------
    Ran 4 tests in 0.081s
    
    FAILED (failures=1)
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
