### PR TITLE
[rocprof-sys] Update INSTALL_RPATH_DIRS

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -236,6 +236,7 @@ endif(THEROCK_BUILD_TESTING)
       INSTALL_RPATH_DIRS
         "lib"
         "lib/rocprofiler-systems"
+        "llvm/lib"
       CMAKE_INCLUDES
         therock_explicit_finders.cmake
       RUNTIME_DEPS


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
`rocprof-sys-instrument --help` fails because it cannot find `libomp.so`.
Related to AIPROFSYST-168

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Add "/llvm/lib" to INSTALL_RPATH_DIRS

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Run TheRock CIs
- Build TheRock locally. Install to a clean docker. Run simple tests to ensure dependencies are found.

## Test Result

<!-- Briefly summarize test outcomes. -->
- Local testing passed. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
