### PR TITLE
Support for prerelease repo folder structure

### DIFF
--- a/.github/workflows/build_native_linux_packages.yml
+++ b/.github/workflows/build_native_linux_packages.yml
@@ -131,8 +131,7 @@ jobs:
           echo "Uploading to s3 bucket : ${{ inputs.release_type }}"
           python ./build_tools/packaging/linux/upload_package_repo.py \
             --pkg-type ${{ inputs.native_package_type }} \
-            --s3-bucket "therock-prerelease-packages" \
+            --s3-bucket ${{ env.S3_BUCKET_NATIVE }} \
             --amdgpu-family ${{ inputs.artifact_group }} \
             --artifact-id ${{ env.ARTIFACT_RUN_ID }} \
-            --job "prerelease"
-            #--job ${{ inputs.release_type }}
+            --job ${{ inputs.release_type }}


### PR DESCRIPTION
## Motivation

As per the repo folder structure for prerelease build needs to be s3_bucket/v3/packages/rpm and s3_bucket/v3/packages/deb. Updating the prefix path accordingly.

