### PR TITLE
[release/7.11] Remove jax from Linux release workflow

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -329,27 +329,6 @@ jobs:
               "ref": "${{ inputs.ref || '' }}"
             }
 
-      - name: URL-encode .tar URL
-        # TODO: Enable JAX wheels for prereleases
-        if: ${{ env.RELEASE_TYPE != 'prerelease' }}
-        id: url-encode-tar
-        run: python -c "from urllib.parse import quote; print('tar_url=${{ needs.setup_metadata.outputs.cloudfront_base_url }}/tarball/' + quote('${{ env.FILE_NAME }}'))" >> ${GITHUB_OUTPUT}
-
-      - name: Trigger build JAX wheels
-        # TODO: Enable JAX wheels for prereleases
-        if: ${{ env.RELEASE_TYPE != 'prerelease' && github.repository_owner == 'ROCm' }}
-        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
-        with:
-          workflow: build_linux_jax_wheels.yml
-          inputs: |
-            { "amdgpu_family": "${{ matrix.target_bundle.amdgpu_family }}",
-              "python_version": "3.12",
-              "release_type": "${{ env.RELEASE_TYPE }}",
-              "s3_subdir": "${{ env.S3_STAGING_SUBDIR }}",
-              "rocm_version": "${{ needs.setup_metadata.outputs.version }}",
-              "tar_url": "${{ steps.url-encode-tar.outputs.tar_url }}"
-            }
-
       - name: Trigger build native rpm package
         if: ${{ github.repository_owner == 'ROCm' }}
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4


### PR DESCRIPTION
Jax is not part of the 7.11 release