### PR TITLE
Update INSTALL_RPATH_DIRS for rocprof-sys

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -233,6 +233,10 @@ endif(THEROCK_BUILD_TESTING)
         -DROCPROFSYS_BUILD_LIBIBERTY=ON
         -DROCPROFSYS_BUILD_BOOST=ON
         -DROCPROFSYS_BUILD_DYNINST=ON
+      INSTALL_RPATH_DIRS
+        "lib"
+        "lib/rocprofiler-systems"
+        "llvm/lib"
       CMAKE_INCLUDES
         therock_explicit_finders.cmake
       RUNTIME_DEPS


### PR DESCRIPTION
## Motivation

Project libraries in `lib/rocprofiler-systems` were not resolved without the `LD_LIBRARY_PATH` being set.
Similarly, `rocprof-sys-instrument --help` fails because it cannot find libomp.so.

Related to AIPROFSYST-168

## Technical Details

Add "rocprofiler-systems/lib" and "/llvm/lib" to INSTALL_RPATH_DIRS in the subproject declaration.
Cherry-picks 598691b49db92bfbdb93eff33b3f580d166d48e6 and c94dcd73cfc73e89835e227462dd9668700c746c

## Test Plan

- Verify internal libraries are resolved with `ldd`. 
- Verify RPATH of librocprof-sys*.so with `chrpath` (or similar utility).

## Test Result

`ldd` shows that all libraries are found.
`readelf` shows that RPATH are set as expected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
