### PR TITLE
[ci] Always shard `hip-tests` due to no filters

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -340,6 +340,7 @@ def run():
             ]
 
             # Due to the lack of test filter options but importance of tests, we allow specific tests to run sharded always
+            # TODO(#2914): remove hip-test off of this list once smoke test filter is provided
             test_jobs_to_full_shard = ["hip-tests"]
 
             # If the test type is smoke tests, we only need one shard for the test job


### PR DESCRIPTION
Currently, hip-tests <b>do not</b> have smoke test filters, with no ETA except for "soon"

Tests take around 35 - 45 mins when running single shard (default for smoke tests, but no smoke test filter is available)

However, `hip-tests` are very important, so we will run these tests always sharded, to help with faster iterations (until filter is provided)

Related #2914

sharding works properly in test runs