### PR TITLE
Add rocm-libraries to dependabot submodule updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,4 +21,5 @@ updates:
     target-branch: "main"
     allow:
       - dependency-name: "rocm-systems"
+      - dependency-name: "rocm-libraries"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Motivation
This update will enable dependabot to also check for rocm-libraires updates.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
