### PR TITLE
[ALMIOPEN-990] Exclude miopen driver tests causing ci failures to unblock PRs

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -99,10 +99,6 @@ positive_filter.append("*/GPU_VecAddTest_*")
 
 positive_filter.append("*/GPU_KernelTuningNetTest*")
 
-# Don't run while investigating to allow CI to pass
-# Jira Ticket ALMIOPEN-990
-# positive_filter.append("*/GPU_MIOpenDriver*")
-
 positive_filter.append("*/GPU_Bwd_Mha_*")
 positive_filter.append("*/GPU_Fwd_Mha_*")
 positive_filter.append("*/GPU_Softmax*")
@@ -156,6 +152,10 @@ negative_filter.append("Full/GPU_ConvGrpActivInfer3D_FP16*")  # 0 min 16 sec
 negative_filter.append(
     "Smoke/GPU_UnitTestConvSolverHipImplicitGemmV4R1Fwd_BFP16.ConvHipImplicitGemmV4R1Fwd/0"
 )  # https://github.com/ROCm/TheRock/issues/1682
+
+# Don't run while investigating to allow CI to pass
+# Jira Ticket ALMIOPEN-990
+negative_filter.append("*/GPU_MIOpenDriver*")
 
 # TODO(rocm-libraries#2266): re-enable test for gfx950-dcgpu
 if AMDGPU_FAMILIES == "gfx950-dcgpu":


### PR DESCRIPTION
## Motivation

Unblock miopen PRs by disabling these test from running until fixing
[ALMIOPEN-990] Jira to investigate
tests to disable: */GPU_MIOpenDriver*
## Technical Details

These tests currently cauding CI failures and blocking PRs, they will be investigated and re-enabled
## Test Plan

Unblocking PR CI

## Test Result

No New GPU_MIOpenDriver failures
Targeted Linux MIOpen is passing
<img width="209" height="340" alt="image" src="https://github.com/user-attachments/assets/115145d8-d356-43ec-9af5-abccbd48752a" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[ALMIOPEN-990]: https://amd-hub.atlassian.net/browse/ALMIOPEN-990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ