### PR TITLE
Add test_rocm_wheels.yml workflow for testing ROCm Python packages

### DIFF
--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -74,7 +74,6 @@ jobs:
         shell: bash
     env:
       VENV_DIR: ${{ github.workspace }}/.venv
-      AMDGPU_FAMILY: ${{ inputs.amdgpu_family }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/1559 which will build and test ROCm Python packages (and later PyTorch Python packages) as part of our CI workflows so we can catch ROCm packaging and framework build/test issues earlier in development.

## Technical Details

This workflow is forked from [`.github/workflows/test_pytorch_wheels.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/test_pytorch_wheels.yml). We might also want to run some of the system health steps from other workflows like [`.github/workflows/test_sanity_check.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/test_sanity_check.yml) (maybe time to move those into reusable workflows or onto the runners as pre- and post- job scripts).

To start with, this is not integrated into any existing workflows. My plan is to use this from [`ci_linux.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/ci_linux.yml) / [`ci_windows.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/ci_windows.yml) once the [`build_portable_linux_python_packages.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/build_portable_linux_python_packages.yml) and [`build_windows_python_packages.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/build_windows_python_packages.yml) workflows upload the packages they build to S3 / some index.

I also considered keeping the test code in the "build" workflow given how simple it is, but a separate workflow file like this is easier to share across Windows and Linux and makes it easier to test packages from arbitrary sources without first needing to build.

Alternately we could adopt the same "build and upload to staging -> test -> upload" setup as [`build_portable_linux_pytorch_wheels.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/build_portable_linux_pytorch_wheels.yml). That would still be compatible with this being its own workflow file.

## Test Plan

* Triggered test workflows in my fork using standard GitHub-hosted runners (no GPU)
* Will trigger test workflows here using our self-hosted runners _after merge_ (or I can send a PR from a branch in this common repository once the changes are reviewed)

## Test Result

* windows-2022, gfx110X-all, rocm `7.11.0a20260121` from https://rocm.nightlies.amd.com/v2: https://github.com/ScottTodd/TheRock/actions/runs/21374228045/job/61526284273
  * 25 tests with 1 skipped, 0 failures, 0 errors
  * 4 minutes total: 3 minutes downloading packages and 40 seconds running tests (includes devel package init)
* ubuntu 24.04, gfx1151, rocm `7.12.0a20260126` from https://rocm.nightlies.amd.com/v2: https://github.com/ScottTodd/TheRock/actions/runs/21374270003/job/61526430258
  * 25 tests with 1 failure, 2 errors (`amd-smi`, `rocminfo`, and `rocm-smi` tests all fail on systems with no AMD GPU)
  * 1m40s total: 1 minute downloading packages and 36 seconds running tests (includes devel package init)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
