### PR TITLE
Adjusting prerelease prefix

### DIFF
--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -762,7 +762,7 @@ def main():
         prefix = f"{args.pkg_type}/{yyyymmdd()}-{args.artifact_id}"
         dedupe = True
     elif args.job == "prerelease":
-        prefix = f"v3/packages/{args.pkg_type}"
+        prefix = f"v3/{args.pkg_type}"
         dedupe = True
 
     if args.pkg_type == "deb":


### PR DESCRIPTION
## Motivation

Adjusting prerelease prefix so that existing index.html logic works.

## Technical Details

Previously packages were getting uploaded to s3://therock-prerelease-packages/v3/**packages**/rpm/x86_64
Now the packages folder is removed. s3://therock-prerelease-packages/v3/rpm/x86_64