### PR TITLE
Switch CODEOWNERS to use newer TheRock-infra-write team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Regularly updated submodules
-/rocm-libraries         @ROCm/TheRockInfra
-/rocm-systems           @ROCm/TheRockInfra
+/rocm-libraries         @ROCm/TheRock-infra-write
+/rocm-systems           @ROCm/TheRock-infra-write
 
 # New patches are strongly discouraged. See patches/README.md.
 /patches/               @ScottTodd @marbre


### PR DESCRIPTION
The original team no longer has explicit write access to the repository so it has not been getting review requests.

Team page: https://github.com/orgs/ROCm/teams/therock-infra-write

See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

> The people you choose as code owners must have write permissions for the repository. **When the code owner is a team, that team must be visible and it must have write permissions**, even if all the individual members of the team already have write permissions directly, through organization membership, or through another team membership.