### PR TITLE
[dependabot] Decrease frequency of submodule updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
     schedule:
       # 2:00 AM PST → 10:00 UTC
       interval: "cron"
-      cronjob: "0 10 */2 * *"
+      cronjob: "0 10 * * 1,3,5"
     target-branch: "main"
     allow:
       - dependency-name: "rocm-systems"


### PR DESCRIPTION
## Motivation

- Time-to-signal for the monitoring and triaging of the submodule update CI, including the pytorch build workflow, typically cannot be completed within a work day based on recent history.

## Technical Details

- Add an additional day between submodule update pull requests from dependabot until further CI improvements for build and test time-to-signal is deployed.
