### PR TITLE
Pin wheel to version 0.46.2

### DIFF
--- a/dockerfiles/build_manylinux_rccl_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_rccl_x86_64.Dockerfile
@@ -18,7 +18,7 @@ FROM quay.io/pypa/manylinux_2_28_x86_64@sha256:d632b5e68ab39e59e128dcf0e59e438b2
 ENV PATH="/usr/local/therock-tools/bin:/opt/python/cp312-cp312/bin:${PATH}"
 
 ######## Pip Packages ########
-RUN pip install --upgrade pip setuptools==69.1.1 wheel==0.42.0 && \
+RUN pip install --upgrade pip setuptools==69.1.1 wheel==0.46.2 && \
 pip install CppHeaderParser==2.7.4 meson==1.7.0 tomli==2.2.1 PyYAML==6.0.2
 
 ######## Repo ########

--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -18,7 +18,7 @@ FROM quay.io/pypa/manylinux_2_28_x86_64@sha256:d632b5e68ab39e59e128dcf0e59e438b2
 ENV PATH="/usr/local/therock-tools/bin:/opt/python/cp312-cp312/bin:${PATH}"
 
 ######## Pip Packages ########
-RUN pip install --upgrade pip setuptools==69.1.1 wheel==0.42.0 && \
+RUN pip install --upgrade pip setuptools==69.1.1 wheel==0.46.2 && \
 pip install CppHeaderParser==2.7.4 meson==1.7.0 tomli==2.2.1 PyYAML==6.0.2
 
 ######## Repo ########


### PR DESCRIPTION
Versions below of 0.46.2. are affected by
https://www.cve.org/CVERecord?id=CVE-2026-24049.