### PR TITLE
Disable libhipsolver_fortran python test until it passes

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/devel_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/devel_test.py
@@ -127,7 +127,10 @@ class ROCmDevelTest(unittest.TestCase):
                 continue
             if "libhipsolver_fortran" in str(so_path):
                 # Currently fails to load unless libgfortran.so.5 exists on the system.
-                # TODO(#3115): Re-enable this test once the dep is bundled
+                # TODO(#3115): Decide if this test should be permanently
+                #     disabled or fixed and then re-enabled somehow. This
+                #     library may only be used by tests and we might not care
+                #     about it failing to load standalone.
                 continue
             if "libLLVMOffload" in str(so_path):
                 # recent addition from upstream, issue tracked in


### PR DESCRIPTION
## Motivation

See https://github.com/ROCm/TheRock/issues/3115. This test under `rocm-sdk test` is currently failing after installing `rocm[devel]` if some system packages are not installed for `libgfortran.so.5`. Disabling the test for now will allow us to enforce that other tests pass as part of https://github.com/ROCm/TheRock/issues/1559

## Test plan and results

Tested locally by following the steps outlined on https://github.com/ROCm/TheRock/issues/3115. I edited the test file in-place within the installed python packages while working in the test docker container:

```
# Start our test dockerfile
sudo docker run -it \
  --ipc host --group-add video --group-add render \
  --group-add 110 \
  --device /dev/kfd --device /dev/dri \
  ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26

# Setup python
sudo apt update && sudo apt install python3-venv -y
python3 -m venv .venv && source .venv/bin/activate

# Install rocm[libraries], tests pass
$ python3 -m pip install \
  --index-url=https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu \
  'rocm[libraries]==7.11.0a20260121'
$ rocm-sdk test

# Install rocm[libraries,devel], tests fail
$ python3 -m pip install \
  --index-url=https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu \
  'rocm[libraries,devel]==7.11.0a20260121'
$ rocm-sdk test

# Edit the test and re-run, tests pass
$ sudo apt install nano
$ nano .venv/lib/python3.12/site-packages/rocm_sdk/tests/devel_test.py
$ rocm-sdk test
```

Further work on https://github.com/ROCm/TheRock/issues/1559 will run these tests continuously and ensure that they don't regress.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
