### PR TITLE
Add documentation for running no_rocm_image dockerfile

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -60,6 +60,32 @@ Requirements for these files:
   - Some extra tools like `lit` for LLVM testing are acceptable and should be
     evaluated on a case-by-case basis.
 
+This test dockerfile is used by various CI/CD workflows, such as:
+
+- [`.github/workflows/test_component.yml`](/.github/workflows/test_component.yml)
+- [`.github/workflows/test_pytorch_wheels.yml`](/.github/workflows/test_pytorch_wheels.yml)
+
+To run this test dockerfile yourself on a machine with a compatible GPU:
+
+```bash
+sudo docker run -it \
+  --device=/dev/kfd --device=/dev/dri \
+  --ipc=host --group-add=video --group-add=render --group-add=110 \
+  ghcr.io/rocm/no_rocm_image_ubuntu24_04@latest
+```
+
+> [!TIP]
+> We recommend creating a Python venv to install Python packages while using
+> this image:
+>
+> ```bash
+> sudo apt update && sudo apt install python3-venv -y
+> python3 -m venv .venv && source .venv/bin/activate
+>
+> # Then install packages. For example, with nightly rocm packages for gfx94X:
+> pip install --index-url=https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu 'rocm[libraries,devel]'
+> ```
+
 ### `rocm_runtime.Dockerfile`
 
 | Source .Dockerfile                                   | Published package |

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -178,8 +178,10 @@ mix/match build steps.
 
 On Linux we run automated tests under our
 [`no_rocm_image_ubuntu24_04.Dockerfile`](dockerfiles/no_rocm_image_ubuntu24_04.Dockerfile)
-container. Docker is optional for developers and users. If you want to use our
-test image, run it like so:
+container (also
+[documented in `dockerfiles/README.md`](/dockerfiles/README.md#no_rocm_image_dockerfile)).
+Docker is optional for developers and users. If you want to use our test image,
+run it like so:
 
 ```bash
 sudo docker run -it \


### PR DESCRIPTION
## Motivation

Adding docs that would have helped me run this dockerfile locally and triage https://github.com/ROCm/TheRock/issues/3115 faster.

This is also a follow-up to https://github.com/ROCm/TheRock/pull/2776#discussion_r2665189207. Docs for how to use the build_manylinux image and how to work on changes to the dockerfiles themselves would still be useful.

## Technical Details

We have a link to the modified section of `external-builds/pytorch/README.md` here: https://github.com/ROCm/TheRock/blob/8e5be537b56753343afa88fc2ef4f405905d8b8a/build_tools/github_actions/summarize_test_pytorch_workflow.py#L55-L57

That is used to generate test summaries like https://github.com/ROCm/TheRock/actions/runs/21178379671#summary-60917404262. Some indirection and duplication in these documentation pages is fine I think.
<img width="724" height="582" alt="image" src="https://github.com/user-attachments/assets/d351175c-767a-4a46-b65e-7d77f273919e" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
