### PR TITLE
Add CODEOWNERS coverage for the file itself using TheRock-infra-admin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# This file itself
+/.github/CODEOWNERS     @ROCm/TheRock-infra-admins
+
 # Regularly updated submodules
 /rocm-libraries         @ROCm/TheRock-infra-write
 /rocm-systems           @ROCm/TheRock-infra-write


### PR DESCRIPTION
(Following up on https://github.com/ROCm/TheRock/pull/3102#discussion_r2733082278)

## Motivation

This prevents circumventing the CODEOWNERS file by
1. first merging a PR that modifies CODEOWNERS, removing coverage
2. then sending a PR that modifies previously covered lines
3. merging the second PR that should have been blocked by CODEOWNERS review

See the docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection

> To protect a repository fully against unauthorized changes, you also need to define an owner for the CODEOWNERS file itself. The most secure method is to define a CODEOWNERS file in the `.github` directory of the repository and define the repository owner as the owner of either the CODEOWNERS file (`/.github/CODEOWNERS @owner_username`) or the whole directory (`/.github/ @owner_username`).

## Technical details

Team page: [therock-infra-admins](https://github.com/orgs/ROCm/teams/therock-infra-admins) (a subset of [therock-infra-write](https://github.com/orgs/ROCm/teams/therock-infra-write))

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
