### PR TITLE
Test `rocm-sdk test` with and without `rocm[devel]` package

### DIFF
--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -58,7 +58,7 @@ run-name: Test ROCm Wheels (${{ inputs.amdgpu_family }}, ${{ inputs.rocm_version
 
 jobs:
   test_wheels:
-    name: Test ${{ matrix.packages }} Wheels | ${{ inputs.amdgpu_family }}
+    name: Test ${{ matrix.packages }} wheels | ${{ inputs.amdgpu_family }}
     runs-on: ${{ inputs.test_runs_on }}
     container:
       image: ${{ contains(inputs.test_runs_on, 'linux') && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26' || null }}


### PR DESCRIPTION
## Motivation

This `test_rocm_wheels.yml` workflow was added in https://github.com/ROCm/TheRock/pull/3099 as part of https://github.com/ROCm/TheRock/issues/1559, but running the workflow on our GPU runners revealed test failures: https://github.com/ROCm/TheRock/issues/3115. The `rocm-sdk test` tests succeed in our [`test_pytorch_wheels.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/test_pytorch_wheels.yml) workflow since that installs `torch` which depends on just `rocm[libraries]`, _not_ `rocm[libraries,devel]`.

This PR switches to first testing 

## Technical Details

This uses a matrix to test across `rocm[libraries]` and `rocm[libraries,devel]` so we can see error messages from both and they each use their own fully isolated environment. I also considered running both tests sequentially in a single job (sharing or not sharing a venv)

## Test Plan and Results

Triggered workflow runs:

* Linux, gfx94X-dcgpu, rocm version `7.12.0a20260129`: https://github.com/ROCm/TheRock/actions/runs/21489047443
* Windows, gfx110X-all, rocm version `7.12.0a20260129`: https://github.com/ROCm/TheRock/actions/runs/21489109174

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
