### PR TITLE
[hipBLASLt-provider] Add hipBLASLt kernel provider for hipDNN to TheRock

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -545,6 +545,11 @@ artifact_group = "ml-libs"
 type = "target-neutral"
 artifact_deps = ["core-runtime", "core-hip", "miopen", "hipdnn"]
 
+[artifacts.hipblaslt-plugin]
+artifact_group = "ml-libs"
+type = "target-neutral"
+artifact_deps = ["core-runtime", "core-hip", "blas", "hipdnn"]
+
 [artifacts.hipdnn-samples]
 artifact_group = "ml-libs"
 type = "target-specific"

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ minimal build):
 | `-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON`    | Enables MIOpen_plugin                          |
 | `-DTHEROCK_ENABLE_HIPDNN_SAMPLES=ON`   | Enables hipDNN samples (hipDNN Usage Examples) |
 | `-DTHEROCK_ENABLE_HIPDNN=ON`           | Enables hipDNN                                 |
+| `-DTHEROCK_ENABLE_HIPBLASLT_PLUGIN=ON` | Enables hipBLASLt Plugin                       |
 | `-DTHEROCK_ENABLE_ROCWMMA=ON`          | Enables rocWMMA                                |
 | `-DTHEROCK_ENABLE_RDC=ON`              | Enables ROCm Data Center Tool (Linux only)     |
 | `-DTHEROCK_ENABLE_FUSILLI_PLUGIN=ON`   | Enables Fusilli Plugin                         |

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -257,6 +257,15 @@ test_matrix = {
     #     "platform": ["linux"],
     #     "total_shards": 1,
     # },
+    # hipBLASLt plugin tests
+    "hipblaslt_plugin": {
+        "job_name": "hipblaslt_plugin",
+        "fetch_artifact_args": "--blas --hipdnn --hipblaslt-plugin --tests",
+        "timeout_minutes": 15,
+        "test_script": f"python {_get_script_path('test_hipblaslt_plugin.py')}",
+        "platform": ["linux", "windows"],
+        "total_shards": 1,
+    },
     # rocWMMA tests
     "rocwmma": {
         "job_name": "rocwmma",

--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt_plugin.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt_plugin.py
@@ -1,0 +1,39 @@
+import logging
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
+SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+
+logging.basicConfig(level=logging.INFO)
+
+cmd = [
+    "ctest",
+    "--test-dir",
+    f"{THEROCK_BIN_DIR}/hipblaslt_plugin",
+    "--output-on-failure",
+    "--parallel",
+    "8",
+    "--timeout",
+    "600",
+]
+
+# Determine test filter based on TEST_TYPE environment variable
+environ_vars = os.environ.copy()
+test_type = os.getenv("TEST_TYPE", "full")
+
+if test_type == "smoke":
+    # Exclude tests that start with "Full" during smoke tests
+    environ_vars["GTEST_FILTER"] = "-Full*"
+
+logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
+
+subprocess.run(
+    cmd,
+    cwd=THEROCK_DIR,
+    check=True,
+    env=environ_vars,
+)

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -24,6 +24,8 @@ python build_tools/install_rocm_from_artifacts.py
     [--hipdnn-samples | --no-hipdnn-samples]
     [--miopen | --no-miopen]
     [--miopen-plugin | --no-miopen-plugin]
+    [--fusilli-plugin | --no-fusilli-plugin]
+    [--hipblaslt-plugin | --no-hipblaslt-plugin]
     [--prim | --no-prim]
     [--rand | --no-rand]
     [--rccl | --no-rccl]
@@ -335,6 +337,7 @@ def retrieve_artifacts_by_run_id(args):
             args.miopen,
             args.miopen_plugin,
             args.fusilli_plugin,
+            args.hipblaslt_plugin,
             args.prim,
             args.rand,
             args.rccl,
@@ -385,6 +388,8 @@ def retrieve_artifacts_by_run_id(args):
             extra_artifacts.append("miopen-plugin")
         if args.fusilli_plugin:
             extra_artifacts.append("fusilli-plugin")
+        if args.hipblaslt_plugin:
+            extra_artifacts.append("hipblaslt-plugin")
         if args.prim:
             extra_artifacts.append("prim")
         if args.rand:
@@ -648,6 +653,13 @@ def main(argv):
         "--fusilli-plugin",
         default=False,
         help="Include 'fusilli-plugin' artifacts",
+        action=argparse.BooleanOptionalAction,
+    )
+
+    artifacts_group.add_argument(
+        "--hipblaslt-plugin",
+        default=False,
+        help="Include 'hipblaslt-plugin' artifacts",
         action=argparse.BooleanOptionalAction,
     )
 

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -79,6 +79,7 @@ mainline, in open source, using MSVC, etc.).
 | ml-libs             | [MIOpen](https://github.com/ROCm/MIOpen)                                                                                 | ✅        |                                               |
 | ml-libs             | [hipDNN](https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipdnn)                                            | ✅        |                                               |
 | ml-libs             | [MIOpen Legacy Plugin](https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipdnn/plugins/miopen_legacy_plugin) | ✅        |                                               |
+| ml-libs             | [hipBLASLt Plugin](https://github.com/ROCm/rocm-libraries/tree/develop/dnn-providers/hipblaslt-provider)                 | ✅        |                                               |
 
 ## Building TheRock from source
 

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -254,6 +254,53 @@ if(THEROCK_ENABLE_MIOPEN_PLUGIN)
   )
 endif(THEROCK_ENABLE_MIOPEN_PLUGIN)
 
+if(THEROCK_ENABLE_HIPBLASLT_PLUGIN)
+  ##############################################################################
+  # hipDNN hipBLASlt plugin
+  ##############################################################################
+
+  therock_cmake_subproject_declare(hipBLASLt_plugin
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/dnn-providers/hipblaslt-provider"
+    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hipblaslt_plugin"
+    BACKGROUND_BUILD
+    CMAKE_ARGS
+      -DHIP_PLATFORM=amd
+      -DROCM_PATH=
+      -DROCM_DIR=
+      "-DHIP_DNN_SKIP_TESTS=$<NOT:$<BOOL:${THEROCK_BUILD_TESTING}>>"
+    CMAKE_INCLUDES
+      therock_explicit_finders.cmake
+    COMPILER_TOOLCHAIN
+      amd-hip
+    BUILD_DEPS
+      hipDNN
+      therock-googletest
+      therock-flatbuffers
+      therock-nlohmann-json
+      therock-fmt
+      therock-spdlog
+    RUNTIME_DEPS
+      hipBLAS-common
+      hipBLASLt
+  )
+  therock_cmake_subproject_glob_c_sources(hipBLASLt_plugin
+  SUBDIRS
+    .
+  )
+  therock_cmake_subproject_activate(hipBLASLt_plugin)
+
+  therock_provide_artifact(hipblaslt-plugin
+    TARGET_NEUTRAL
+    DESCRIPTOR artifact-hipblaslt-plugin.toml
+    COMPONENTS
+      dbg
+      lib
+      test
+    SUBPROJECT_DEPS
+      hipBLASLt_plugin
+  )
+endif(THEROCK_ENABLE_HIPBLASLT_PLUGIN)
+
 if(THEROCK_ENABLE_HIPDNN_SAMPLES)
   ##############################################################################
   # hipDNN samples

--- a/ml-libs/artifact-hipblaslt-plugin.toml
+++ b/ml-libs/artifact-hipblaslt-plugin.toml
@@ -1,0 +1,11 @@
+# hipblaslt_plugin
+[components.dbg."ml-libs/hipblaslt_plugin/stage"]
+[components.lib."ml-libs/hipblaslt_plugin/stage"]
+exclude = [
+  "lib/*.a",
+]
+[components.test."ml-libs/hipblaslt_plugin/stage"]
+include = [
+  "bin/hipblaslt_*_test*",
+  "bin/hipblaslt_plugin/CTestTestfile.cmake",
+]

--- a/ml-libs/post_hook_hipBLASLt_plugin.cmake
+++ b/ml-libs/post_hook_hipBLASLt_plugin.cmake
@@ -1,0 +1,6 @@
+# Add the plugin engines directory to the private install RPATH dirs for the unit tests that use the plugin.so
+list(APPEND THEROCK_PRIVATE_INSTALL_RPATH_DIRS "lib/hipdnn_plugins/engines")
+
+# The plugin library is installed in lib/hipdnn_plugins/engines/, and we need to set origin properly for the RPATH to work
+set_target_properties(hipblaslt_plugin PROPERTIES
+    THEROCK_INSTALL_RPATH_ORIGIN "lib/hipdnn_plugins/engines")


### PR DESCRIPTION
## Motivation

Integrated hipBLASLt plugin for hipDNN to TheRock.

## Technical Details

`hipblaslt_plugin` is a separate plugin project to add support for operations to hipDNN.

The project depends on hipDNN and hipBLASLt.

## Test Plan

Added the project tests

## Test Result

Tests are successfully passing

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

## TODO:
- [x] https://github.com/ROCm/rocm-libraries/pull/4025
- [x] https://github.com/ROCm/rocm-systems/pull/2960 (fix for build on Win). Validation PR with this fix: https://github.com/ROCm/TheRock/pull/3140
- [x] Bump the mentioned PRs to TheRock
