### PR TITLE
Add `upload_python_packages.py`, similar to `post_build_upload.py`

### DIFF
--- a/build_tools/github_actions/upload_python_packages.py
+++ b/build_tools/github_actions/upload_python_packages.py
@@ -3,7 +3,7 @@
 """
 This script uploads built Python packages (wheels, sdists) along with an index
 page to S3 or a local directory for testing. Once packages are uploaded, they
-can be downloaded directly or via `pip install --find-links {index_url}` by
+can be downloaded directly or via `pip install --find-links {url}` by
 developers, users, and test workflows.
 
 Usage:

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -118,8 +118,20 @@ ls ${PACKAGES_DIR}
 
 ### Installing Locally Built Packages
 
-To install packages with `pip install rocm[...]`, you need a pip-compatible
-index. One way to generate an index is with the
+To install locally built packages, you can use the
+[`-f, --find-links`](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-f)
+option:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install rocm[libraries,devel] --pre \
+    --find-links=${PACKAGES_DIR}/dist
+
+# Run sanity tests to verify the installation
+rocm-sdk test
+```
+
+You can also create an index.html page with the
 [`indexer.py` script](/third-party/indexer/indexer.py):
 
 ```bash
@@ -131,18 +143,6 @@ python ./third-party/indexer/indexer.py ${PACKAGES_DIR}/dist \
 python -m venv .venv && source .venv/bin/activate
 pip install rocm[libraries,devel] --pre \
     --find-links=${PACKAGES_DIR}/dist/index.html
-
-# Run sanity tests to verify the installation
-rocm-sdk test
-```
-
-Alternatively, install packages directly by file path (no index needed):
-
-```bash
-python3 -m venv .venv && source .venv/bin/activate
-pip install ${PACKAGES_DIR}/dist/rocm-*.tar.gz \
-            ${PACKAGES_DIR}/dist/rocm_sdk_core-*.whl
-# Optionally install rocm_sdk_devel and rocm_sdk_libraries wheels too
 ```
 
 > [!TIP]


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/1559.

For CI workflows, the [`build_portable_linux_python_packages.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/build_portable_linux_python_packages.yml) and [`build_windows_python_packages.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/build_windows_python_packages.yml) workflows which run on CPU machines do not currently upload the packages that they build, so there is no connection between them and [`test_rocm_wheels.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/test_rocm_wheels.yml) which runs on GPU machines.

This adds a script that will upload built Python packages and an index.html page usable with `pip install --find-links` to bridge that gap.

## Technical Details

Uploading will reuse the existing CI artifact buckets (typically `therock-ci-artifacts` or `therock-ci-artifacts-external`), so we'll have a single subdirectory per workflow run ID in those buckets that contains:

File type | Status
-- | --
artifacts | Already uploaded
artifact build logs | Already uploaded
artifact build reports | Already uploaded
manifest files | Already uploaded
ROCm Python packages | *Adding in this PR*
PyTorch Python packages | Future
Native Linux packages | Future

The specific layout here is currently

```
S3 Layout:
  {bucket}/{external_repo}{run_id}-{platform}/python/{artifact_group}/
    *.whl, *.tar.gz   # Wheel and sdist files
    index.html        # File listing for pip --find-links
```

I have plans to centralize and document such output layout information in https://github.com/ROCm/TheRock/pull/3000.

> [!NOTE]
> The [`release_portable_linux_packages.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/release_portable_linux_packages.yml) and [`release_windows_packages.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/release_windows_packages.yml) workflows have been building python packages and uploading them directly to the `therock-{release_type}-python` buckets.
>
> As part of future workflow alignment we could reuse these workflows and then _copy_ packages from the "artifacts" buckets to those "release" buckets.

## Test Plan

Tested locally in various configurations. Will integrate into workflows next.

Could design some unit tests for this too?

## Test Result

```bash
# Prep: download artifacts and build python packages
python ./build_tools/fetch_artifacts.py \
  --run-id=21440027240 \
  --artifact-group=gfx110X-dgpu \
  --output-dir=%HOME%/.therock/21440027240/artifacts
python ./build_tools/build_python_packages.py \
  --artifact-dir=%HOME%/.therock/21440027240/artifacts \
  --dest-dir=%HOME%/.therock/21440027240/packages
```

```bash
# Test with a local directory
python ./build_tools/github_actions/upload_python_packages.py \
  --packages-dir="%HOME%/.therock/21440027240/packages" \
  --artifact-group=gfx110X-all \
  --run-id=21440027240 \
  --output-dir="%HOME%/.therock/21440027240/upload-test"

find ${HOME}/.therock/21440027240/upload-test
# .../upload-test
# .../upload-test/21440027240-windows
# .../upload-test/21440027240-windows/python
# .../upload-test/21440027240-windows/python/gfx110X-all
# .../upload-test/21440027240-windows/python/gfx110X-all/index.html
# .../upload-test/21440027240-windows/python/gfx110X-all/rocm-7.12.0.dev0.tar.gz
# .../upload-test/21440027240-windows/python/gfx110X-all/rocm_sdk_core-7.12.0.dev0-py3-none-win_amd64.whl
# .../upload-test/21440027240-windows/python/gfx110X-all/rocm_sdk_devel-7.12.0.dev0-py3-none-win_amd64.whl
# .../upload-test/21440027240-windows/python/gfx110X-all/rocm_sdk_libraries_gfx110x_all-7.12.0.dev0-py3-none-win_amd64.whl
```

```bash
# Real upload
python ./build_tools/github_actions/upload_python_packages.py \
  --packages-dir="%HOME%/.therock/21440027240/packages" \
  --artifact-group=gfx110X-all \
  --run-id=21440027240 \
  --bucket therock-artifacts-testing
```

That uploaded https://therock-artifacts-testing.s3.amazonaws.com/21440027240-windows/python/gfx110X-all/index.html

```bash
pip install rocm[libraries,devel] --pre \
  --find-links=https://therock-artifacts-testing.s3.amazonaws.com/21440027240-windows/python/gfx110X-all/index.html
# NOTE: 5 MB/s download speed (nightly releases from cloudfront get 60 MB/s)
rocm-sdk test
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
