### PR TITLE
Update libcap source code to build libraries with new ROCm sysdeps prefix

### DIFF
--- a/third-party/sysdeps/linux/libcap/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libcap/CMakeLists.txt
@@ -99,6 +99,7 @@ add_custom_target(
     "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh"
     "${CMAKE_CURRENT_SOURCE_DIR}/patch_install.sh"
     "${CMAKE_CURRENT_SOURCE_DIR}/libcap.map"
+    "${CMAKE_CURRENT_SOURCE_DIR}/libpsx.map"
   VERBATIM
 )
 

--- a/third-party/sysdeps/linux/libcap/libpsx.map
+++ b/third-party/sysdeps/linux/libcap/libpsx.map
@@ -1,0 +1,3 @@
+AMDROCM_SYSDEPS_1.0 {
+  global: *;
+};

--- a/third-party/sysdeps/linux/libcap/patch_install.sh
+++ b/third-party/sysdeps/linux/libcap/patch_install.sh
@@ -3,26 +3,56 @@ set -e
 
 PREFIX="${1:?Expected install prefix argument}"
 PATCHELF="${PATCHELF:-patchelf}"
-THEROCK_SOURCE_DIR="${THEROCK_SOURCE_DIR:?THEROCK_SOURCE_DIR not defined}"
-Python3_EXECUTABLE="${Python3_EXECUTABLE:?Python3_EXECUTABLE not defined}"
 
-declare -A _unique_targets
-while IFS= read -r -d '' candidate; do
-  real_path=$(readlink -f "$candidate" 2>/dev/null || printf '%s' "$candidate")
-  if [ -f "$real_path" ]; then
-    _unique_targets["$real_path"]=1
-  fi
-done < <(find "${PREFIX}/lib" -maxdepth 1 \( -name "libcap.so*" -o -name "libpsx.so*" \) -print0)
+# update_library_links
+# ---------------------
+# Purpose:
+#   Normalize a shared library so that its real file is named exactly as its ELF SONAME,
+#   and rename the input file (usually a symlink) to a desired linker name (e.g., libfoo.so).
+#
+# Synopsis:
+#   update_library_links <libfile> <linker_name>
+#
+# Arguments:
+#   libfile      Path to the library file or symlink.
+#                Example: $PREFIX/lib/librocm_sysdeps_cap.so
+#   linker_name  Desired linker-name filename to exist in the same directory.
+#                Example: libcap.so
+update_library_links() {
+    local libfile="$1"        # e.g. $PREFIX/lib/librocm_sysdeps_cap.so
+    local linker_name="$2"    # e.g. libcap.so
 
-patch_targets=("${!_unique_targets[@]}")
-if [ ${#patch_targets[@]} -eq 0 ]; then
-  echo "libcap patch_install: no shared libraries found under ${PREFIX}/lib" >&2
-  exit 1
-fi
+    if [ ! -e "$libfile" ]; then
+        echo "Error: File '$libfile' not found" >&2
+        return 1
+    fi
 
-"$Python3_EXECUTABLE" "$THEROCK_SOURCE_DIR/build_tools/patch_linux_so.py" \
-  --patchelf "${PATCHELF}" --add-prefix rocm_sysdeps_ \
-  "${patch_targets[@]}"
+    local dir="$(dirname -- "$libfile")"
+    # Get the soname and realname
+    local lib_soname="$("$PATCHELF" --print-soname "$libfile" 2>/dev/null || true)"
+    local realname="$(readlink -f -- "$libfile" 2>/dev/null || true)"
+
+    if [[ -z "$lib_soname" || -z "$realname" ]]; then
+        [[ -z "$lib_soname" ]] && echo "Error: No SONAME found in '$libfile'" >&2
+        [[ -z "$realname" ]] && echo "Error: readlink -f failed for '$libfile'" >&2
+        return 1
+    fi
+
+    if [[ "$realname" != "$dir/$lib_soname" ]]; then
+        # Move the real file to $dir/$lib_soname
+        mv -v -- "$realname" "$dir/$lib_soname"
+        pushd "$dir" > /dev/null
+        ln -sf "$lib_soname" "$linker_name"
+        popd > /dev/null
+        rm "$libfile"
+    else
+    # Rename symlink in the same directory
+        mv "$libfile" "$dir/$linker_name"
+    fi
+}
+
+update_library_links "$PREFIX/lib/librocm_sysdeps_cap.so" "libcap.so"
+update_library_links "$PREFIX/lib/librocm_sysdeps_psx.so" "libpsx.so"
 
 # pc files are not output with a relative prefix. Sed it to relative.
 if [ -d "$PREFIX/lib/pkgconfig" ]; then

--- a/third-party/sysdeps/linux/libcap/patch_source.sh
+++ b/third-party/sysdeps/linux/libcap/patch_source.sh
@@ -5,7 +5,9 @@ set -e
 SOURCE_DIR="${1:?Source directory must be given}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIBCAP_MAP="${SCRIPT_DIR}/libcap.map"
+LIBPSX_MAP="${SCRIPT_DIR}/libpsx.map"
 MAKEFILE="${SOURCE_DIR}/libcap/Makefile"
+PROGS_MAKEFILE="${SOURCE_DIR}/progs/Makefile"
 
 if [ ! -f "$LIBCAP_MAP" ]; then
   echo "ERROR: libcap.map not found at $LIBCAP_MAP" >&2
@@ -20,13 +22,15 @@ fi
 echo "==> Applying symbol versioning patches to libcap"
 
 # Copy version script
-echo "    Copying libcap.map to source directory"
+echo "    Copying libcap.map and libpsx.map to source directory"
 cp "$LIBCAP_MAP" "${SOURCE_DIR}/libcap/libcap.map"
+cp "$LIBPSX_MAP" "${SOURCE_DIR}/libcap/libpsx.map"
 
 # Prefix version tag
 echo "    Prefixing version tag with AMDROCM_SYSDEPS_1.0_"
 sed -i 's/\bLIBCAP_2\.69\b/AMDROCM_SYSDEPS_1.0_LIBCAP_2.69/g' \
   "${SOURCE_DIR}/libcap/libcap.map"
+# libpsx.map is having AMDROCM_SYSDEPS_1.0, no need to edit again
 
 # Add --version-script to Makefile
 echo "    Patching Makefile to use version script"
@@ -34,9 +38,30 @@ sed -i '/\$(LD).*-Wl,-soname,\$(MAJCAPLIBNAME)/ {
   /--version-script/! s|-o \$(MINCAPLIBNAME)|-Wl,--version-script,libcap.map -o $(MINCAPLIBNAME)|
 }' "$MAKEFILE"
 
+sed -i '/\$(LD).*-Wl,-soname,\$(MAJPSXLIBNAME)/ {
+  /--version-script/! s|-o \$(MINPSXLIBNAME)|-Wl,--version-script,libpsx.map -o $(MINPSXLIBNAME)|
+}' "$MAKEFILE"
+
+
 if ! grep -q -- "--version-script,libcap.map" "$MAKEFILE"; then
   echo "ERROR: Failed to patch Makefile with --version-script" >&2
   exit 1
 fi
 
+if ! grep -q -- "--version-script,libpsx.map" "$MAKEFILE"; then
+  echo "ERROR: Failed to patch Makefile with --version-script" >&2
+  exit 1
+fi
+
 echo "==> Symbol versioning patches applied successfully"
+
+
+echo "==> Applying Library renaming patches to libcap and psx"
+
+# Create library with librocm_sysdeps_cap.so and librocm_sysdeps_psx.so
+sed -i 's|CAPLIBNAME=$(LIBTITLE).so|CAPLIBNAME=librocm_sysdeps_cap.so|' "$MAKEFILE"
+sed -i 's|PSXLIBNAME=$(PSXTITLE).so|PSXLIBNAME=librocm_sysdeps_psx.so|' "$MAKEFILE"
+# Change libcap.so with librocm_sysdeps_cap.so in progs/Makefile
+sed -i 's|libcap.so|librocm_sysdeps_cap.so|' "$PROGS_MAKEFILE"
+
+echo "==> Library renaming patches applied successfully"


### PR DESCRIPTION
The renamed and patchelf‑edited libraries in the ROCk artifacts were missing required symbol‑version tags, which caused RPM package installation failures. This patch will create the libraries (libcap and libpsx) with the prefix "librocm_sysdeps_" in their names, eliminating the need for patchelf editing.

The linker‑name libraries will continue to use their original names (i.e., without the rocm_sysdeps_ prefix).

**Issue:**
Error: 
 Problem 1: conflicting requests
  - nothing provides librocm_sysdeps_cap.so.2(AMDROCM_SYSDEPS_1.0_LIBCAP_2.69)(64bit) needed by amdrocm-rdc7.11-7.11.2-21312649741.x86_64 

**Test Results:**
 SONAME:-
 0x000000000000000e (SONAME)             Library soname: [librocm_sysdeps_cap.so.2]
 0x000000000000000e (SONAME)             Library soname: [librocm_sysdeps_psx.so.2]
 
 Provided symbol version tag:-
librocm_sysdeps_cap.so.2(AMDROCM_SYSDEPS_1.0_LIBCAP_2.69)(64bit)
librocm_sysdeps_cap.so.2()(64bit)

librocm_sysdeps_psx.so.2(AMDROCM_SYSDEPS_1.0)(64bit)
librocm_sysdeps_psx.so.2()(64bit)

Library links:
libcap.so -> librocm_sysdeps_cap.so.2
libpsx.so -> librocm_sysdeps_psx.so.2

libcap.pc  and libpsx.pc is having the following dependencies
Libs: -L${libdir} **-lcap**
Libs: -L${libdir} **-lpsx** -lpthread -Wl,-wrap,pthread_create
