### PR TITLE
Add amdsmi as runtime dependency to RCCL

### DIFF
--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -35,6 +35,7 @@ if(THEROCK_ENABLE_RCCL AND THEROCK_SANITIZER STREQUAL "")
       therock-fmt
       therock-googletest
     RUNTIME_DEPS
+      amdsmi
       hip-clr
       hipify
       rocm_smi_lib


### PR DESCRIPTION
Adds amdsmi as a dependency to enable the switchover in the codebase.