### PR TITLE
[debug-tools/rocgdb] Fix rocgdb dev artifacts

### DIFF
--- a/debug-tools/artifact-rocgdb.toml
+++ b/debug-tools/artifact-rocgdb.toml
@@ -2,11 +2,11 @@
 [components.dbg."debug-tools/rocgdb/stage"]
 [components.dev."debug-tools/rocgdb/stage"]
 include = [
-  "include/**",
+  "include/gdb/**",
   "share/locale/**",
-  "share/python/**",
-  "share/syscalls/**",
-  "share/system-gdbinit/**"
+  "share/rocgdb/python/**",
+  "share/rocgdb/syscalls/**",
+  "share/rocgdb/system-gdbinit/**"
 ]
 [components.doc."debug-tools/rocgdb/stage"]
 include = [


### PR DESCRIPTION
Previously I adjusted the rocgdb data directory to share/rocgdb from share/, but neglected to update the rocgdb dev artifacts that were pointing at share/.

Fix this so we go back to copying all of the rocgdb data files we're supposed to copy.

Also fix the path to the jit-reader header in include/gdb/.