### PR TITLE
Fix missing CMAKE_C_FLAGS for ASAN builds

### DIFF
--- a/cmake/therock_sanitizers.cmake
+++ b/cmake/therock_sanitizers.cmake
@@ -32,6 +32,7 @@ function(therock_sanitizer_configure
     # TODO: Support ASAN_STATIC to use static ASAN linkage. Shared is almost always the right thing,
     # so make "ASAN" imply shared linkage.
     string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS \" -fsanitize=address -fno-omit-frame-pointer -g\")\n")
+    string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS \" -fsanitize=address -fno-omit-frame-pointer -g\")\n")
     # Sharp edge: The -shared-libsan flag is compiler frontend specific:
     #   gcc (and gfortran): defaults to shared sanitizer linkage
     #   clang: defaults to static linkage and requires -shared-libsan to link shared


### PR DESCRIPTION
## Motivation

The ASAN sanitizer configuration in cmake/therock_sanitizers.cmake was only setting CMAKE_CXX_FLAGS, leaving CMAKE_C_FLAGS without ASAN instrumentation. This caused C source files (e.g., libhsakmt in ROCR-Runtime) to be compiled without AddressSanitizer, resulting in incomplete memory error detection coverage.

## Technical Details

**Problem:**
- Only `CMAKE_CXX_FLAGS` was configured with ASAN flags (`-fsanitize=address -fno-omit-frame-pointer -g`)
- `CMAKE_C_FLAGS` was missing the same configuration
- ROCR-Runtime contains significant C code in `libhsakmt/` that handles kernel driver interfaces and memory management

**Impact:**
- Memory errors in C code go undetected during ASAN builds
- Potential symbol conflicts when linking ASAN-instrumented C++ objects with non-instrumented C objects

**Fix:**
Add the same ASAN compile flags to `CMAKE_C_FLAGS`:
```cmake
string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS \" -fsanitize=address -fno-omit-frame-pointer -g\")\n")
```

## Test Plan

- [x] Local ASAN build of ROCR-Runtime completes successfully
- [x] Verify C source files include `-fsanitize=address` in compile commands

## Test Result

Build ROCR-Runtime local ASAN
Run below command line and check hsakmt
    gdb -batch -ex 'file libhsa-runtime64.so' -ex 'disassemble hsaKmtReplaceAsanHeaderPage'
See hsakmt_kfd_open_count__sanitized_padded_global and hsakmt_fmm_replace_asan_header_page:
   0x000000000040e189 <+9>:     lea    0x319cf0(%rip),%rax        # 0x727e80 <hsakmt_debug_level__sanitized_padded_global>
   0x000000000040e1ab <+43>:    lea    0x318f8e(%rip),%rax        # 0x727140 <hsakmt_kfd_open_count__sanitized_padded_global>
   0x000000000040e1cc <+76>:    lea    0x319c4d(%rip),%rax        # 0x727e20 <hsakmt_forked__sanitized_padded_global>
   0x000000000040e1f6 <+118>:   lea    0x2d7343(%rip),%rdi        # 0x6e5540 <hsakmt_primary_kfd_ctx__sanitized_padded_global>
   0x000000000040e225 <+165>:   lea    -0x332f8c(%rip),%rsi        # 0xdb2a0 <.str.11__sanitized_padded_global>
   0x000000000040e22c <+172>:   lea    -0x332733(%rip),%rdx        # 0xdbb00 <__func__.hsaKmtReplaceAsanHeaderPageCtx__sanitized_padded_global>
   0x000000000040e257 <+215>:   lea    0x319c22(%rip),%rdi        # 0x727e80 <hsakmt_debug_level__sanitized_padded_global>
   0x000000000040e275 <+245>:   lea    0x319ba4(%rip),%rdi        # 0x727e20 <hsakmt_forked__sanitized_padded_global>
   0x000000000040e281 <+257>:   lea    0x318eb8(%rip),%rdi        # 0x727140 <hsakmt_kfd_open_count__sanitized_padded_global>
    0x000000000040e206 <+134>:   jmpq   0x402020 <hsakmt_fmm_replace_asan_header_page>

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
