### PR TITLE
[debug-tools/rocgdb] Don't install gdb pdf manual

### DIFF
--- a/debug-tools/rocgdb/CMakeLists.txt
+++ b/debug-tools/rocgdb/CMakeLists.txt
@@ -274,7 +274,7 @@ macro(add_python_variant minor_version configure_flags libpython_dir)
     # Install gdb docs.
     COMMAND
       ${CMAKE_COMMAND} -E chdir "${ROCGDB_BUILD_DIR}"
-      ${MAKE_EXECUTABLE} -s -C gdb install-pdf install-html
+      ${MAKE_EXECUTABLE} -s -C gdb install-html
     # Install binutils for coremerge and coremerge manpage.
     COMMAND
       ${CMAKE_COMMAND} -E chdir "${ROCGDB_BUILD_DIR}"


### PR DESCRIPTION
Building the gdb user manual in pdf format requires pulling texlive in Ubuntu, which is an additional 600Mb. The pdf version can be made available elsewhere and we still install the html and info versions.

It can be enabled later if deemed required.