### PR TITLE
[release/7.11] Force-disable libhipcxx globally in build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,9 @@ if(THEROCK_BUILD_TESTING)
   message(STATUS "Enabling building tests")
 endif()
 
+# Force-disable libhipcxx everywhere
+set(THEROCK_ENABLE_LIBHIPCXX OFF CACHE BOOL "Force-disable libhipcxx" FORCE)
+
 ################################################################################
 # Options
 ################################################################################


### PR DESCRIPTION
This change forces THEROCK_ENABLE_LIBHIPCXX to OFF at the root CMake level.

By overriding the cached option early in configuration, all downstream checks and subprojects consistently see libhipcxx as disabled, preventing it from being built regardless of default feature settings or prior cache state.

This ensures predictable behavior across local builds and CI.