### PR TITLE
Add amdgcn symlink to fix ROCm device library discovery

### DIFF
--- a/base/aux-overlay/CMakeLists.txt
+++ b/base/aux-overlay/CMakeLists.txt
@@ -15,9 +15,11 @@ project(therock-aux-overlay)
 if(NOT WIN32)
   add_custom_target(symlinks ALL
     COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm" "${CMAKE_CURRENT_BINARY_DIR}/llvm"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/amdgcn" "${CMAKE_CURRENT_BINARY_DIR}/amdgcn"
   )
   install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/llvm"
+    "${CMAKE_CURRENT_BINARY_DIR}/amdgcn"
     DESTINATION .
   )
 endif()


### PR DESCRIPTION
## Motivation

TheRock missing symlink amdgcn causes Multiple sub tests failures observed in AOMP-UT.

**This is a workaround pending resolution of below issue.**
Fixes: ROCM-2026
Cherry-picks 4058a195d828b6776be5ed29320bafaa6195b3f4.

## Technical Details

The fix adds a symlink `amdgcn -> lib/llvm/amdgcn` alongside the existing `llvm -> lib/llvm` symlink in the aux-overlay component, restoring compatibility with the expected ROCm installation layout.

## Test Plan

Test building in local machine and check if amdgcn is pointing to lib/llvm/amdgcn

## Test Result

amdgcn soft link created correctly

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.