### PR TITLE
Update ncurses source code to build libraries with new ROCm sysdeps prefix

### DIFF
--- a/third-party/sysdeps/common/ncurses/CMakeLists.txt
+++ b/third-party/sysdeps/common/ncurses/CMakeLists.txt
@@ -104,12 +104,25 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT PATCHELF)
   message(FATAL_ERROR "Missing PATCHELF from super-project")
 endif()
 
+# Apply patch source only on Linux
+set(patch_source_commands)
+set(patch_build_commands)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  list(APPEND patch_source_commands   COMMAND
+    bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${SOURCE_DIR}")
+
+  list(APPEND patch_build_commands   COMMAND
+    bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${CMAKE_CURRENT_BINARY_DIR}")
+endif()
+
 add_custom_target(
   build ALL
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   #
   # OPTIONAL: Patching of the sources should happen here.
   #
+  COMMAND
+    ${patch_source_commands}
   COMMAND
     "${CMAKE_COMMAND}" -E env
       "PKG_CONFIG_PATH=$ENV{PKG_CONFIG_PATH}"
@@ -125,6 +138,9 @@ add_custom_target(
       --with-shared
       --enable-widec
       --enable-pc-files
+      --with-form-libname=rocm_sysdeps_form
+      --with-menu-libname=rocm_sysdeps_menu
+      --with-panel-libname=rocm_sysdeps_panel
       # Without this, it will attempt to install pcfiles in the path reported
       # by pkgconfig (which is typically the system root, which is not what
       # we want).
@@ -151,6 +167,8 @@ add_custom_target(
       # standard installation prefixes. We hope the system will provide the
       # additional required terminfo files if the fallbacks are not enough.
       --with-terminfo-dirs="/usr/share/terminfo:/usr/lib/terminfo:/etc/terminfo:/lib/terminfo"
+  COMMAND
+    ${patch_build_commands}
   COMMAND
     make -j "${PAR_JOBS}" V=1
   COMMAND

--- a/third-party/sysdeps/common/ncurses/patch_install.py
+++ b/third-party/sysdeps/common/ncurses/patch_install.py
@@ -6,11 +6,34 @@ import subprocess
 import sys
 
 
+def rename_pc_files(pc_file: Path) -> None:
+    """Rename a .pc file by removing the 'rocm_sysdeps_' prefix if present.
+
+    This function is used when ROCm‑patched pkg‑config files need to be
+    restored to their original upstream names. If the filename begins with the
+    prefix 'rocm_sysdeps_', the prefix is stripped and the file is renamed in place.
+
+    Parameters
+    ----------
+    pc_file : Path Path object pointing to the .pc file to be examined and possibly renamed.
+
+    Returns
+    -------
+    None The function performs an in‑place rename and does not return a value.
+    """
+    prefix = "rocm_sysdeps_"
+    if pc_file.name.startswith(prefix):
+        new_name = pc_file.name[len(prefix) :]
+        new_path = pc_file.with_name(new_name)
+        pc_file.rename(new_path)
+
+
 def relativize_pc_file(pc_file: Path) -> None:
     """Make a .pc file relocatable by using pcfiledir-relative paths.
 
     Replaces the absolute prefix= line with a pcfiledir-relative path,
     then replaces all other occurrences of the absolute prefix with ${prefix}.
+    Also remove the string "rocm_sysdeps_"
     Assumes the .pc file is located at $PREFIX/lib/pkgconfig/.
     """
     content = pc_file.read_text()
@@ -31,7 +54,75 @@ def relativize_pc_file(pc_file: Path) -> None:
     # Replace all other occurrences of the absolute path with ${prefix}.
     # Use trailing / to avoid partial matches.
     content = content.replace(f"{original_prefix}/", "${prefix}/")
+    # Remove "rocm_sysdeps_"
+    content = content.replace(f"rocm_sysdeps_", "")
     pc_file.write_text(content)
+
+
+def update_library_links(libfile: Path) -> None:
+    """
+    Normalize a shared library so that its real file is named exactly as its ELF SONAME,
+    and ensure a canonical linker-visible symlink exists.
+
+    This function is used when a library has been installed under a prefixed or
+    non‑standard filename (e.g., librocm_sysdeps_ncursesw.so).
+    It performs the following operations:
+    - Extracts the library's SONAME using `patchelf --print-soname`.
+    - Resolves the underlying real file (following symlinks).
+    - Renames the real file to match its SONAME if it does not already.
+    - Creates or updates a symlink named `linker_name` pointing to the SONAME file.
+    - Removes or renames the original file or symlink as appropriate.
+
+    Parameters ----------
+    libfile : Path
+    Path to the library file or symlink to normalize.
+    Example: /prefix/lib/librocm_sysdeps_ncursesw.so
+
+    """
+    # Ensure file exists
+    if not libfile.exists():
+        raise FileNotFoundError(f"File '{libfile}' not found")
+
+    dir_path = libfile.parent
+    # Get SONAME
+    try:
+        lib_soname = subprocess.check_output(
+            [patchelf_exe, "--print-soname", str(libfile)],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError:
+        print(f"Error: No SONAME found in '{libfile}'", flush=True)
+        sys.exit(1)
+
+    # Resolve real file path
+    try:
+        realname = libfile.resolve(strict=True)
+    except FileNotFoundError:
+        print(f"Error: resolve() failed for '{libfile}'", flush=True)
+        sys.exit(1)
+
+    linker_name = libfile.name.replace("librocm_sysdeps_", "lib")
+    target_real = dir_path / lib_soname
+    symlink_path = dir_path / linker_name
+
+    if realname != target_real:
+        # Move real file to $dir/$soname
+        shutil.move(str(realname), str(target_real))
+
+        # Create/update symlink
+        if symlink_path.exists() or symlink_path.is_symlink():
+            symlink_path.unlink()
+        symlink_path.symlink_to(lib_soname)
+
+        # Remove the original symlink or file
+        if libfile.is_symlink() or libfile.exists():
+            libfile.unlink()
+    else:
+        # Rename symlink in the same directory
+        if symlink_path.exists():
+            symlink_path.unlink()
+        libfile.rename(symlink_path)
 
 
 # Fetch an environment variable or exit if it is not found.
@@ -44,76 +135,35 @@ def get_env_or_exit(var_name):
 
 
 # Validate the install prefix argument.
-prefix = Path(sys.argv[1]) if len(sys.argv) > 1 else None
-if not prefix:
+if len(sys.argv) < 2:
     print("Error: Expected install prefix argument")
     sys.exit(1)
 
 # 1st argument is the installation prefix.
-install_prefix = sys.argv[1]
+install_prefix = Path(sys.argv[1])
 
 # Required environment variables.
-therock_source_dir = Path(get_env_or_exit("THEROCK_SOURCE_DIR"))
-python_exe = get_env_or_exit("Python3_EXECUTABLE")
 patchelf_exe = get_env_or_exit("PATCHELF")
 
 if platform.system() == "Linux":
     # Specify the directory
     lib_dir = Path(install_prefix) / "lib"
-    LIB_VERSION_SUFFIX = "6"
 
     # Remove static libs (*.a) and descriptors (*.la).
     for file_path in lib_dir.iterdir():
         if file_path.suffix in (".a", ".la"):
             file_path.unlink(missing_ok=True)
 
-    # Now adjust the shared libraries according to our sysdeps rules.
-    script_path = therock_source_dir / "build_tools" / "patch_linux_so.py"
-
-    # Iterate over all shared libraries.
-    for lib_path in lib_dir.glob("*.so"):
-        # Patch the shared library and add our sysdeps prefix.
-        patch_cmd = [
-            python_exe,
-            str(script_path),
-            "--patchelf",
-            patchelf_exe,
-            "--add-prefix",
-            "rocm_sysdeps_",
-            str(lib_path),
-        ]
-
-        try:
-            subprocess.run(patch_cmd, check=True)
-        except subprocess.CalledProcessError as e:
-            print(f"Error: Failed to patch {lib_path.name} (Exit: {e.returncode})")
-            sys.exit(e.returncode)
-
-        # Create symbolic links for versioned library files, as the executables
-        # and libraries expect that naming.
-        # For now we need to add the .MAJOR_VERSION suffixes. This may need to be
-        # updated in the future as the library gets updated.
-        #
-        # We ensure these are RELATIVE so the installation is relocatable.
-        link_path = lib_path.with_name(f"{lib_path.name}.{LIB_VERSION_SUFFIX}")
-
-        # Remove existing link/file if it exists.
-        link_path.unlink(missing_ok=True)
-
-        try:
-            # Passing lib_path.name (the filename) creates a relative link.
-            link_path.symlink_to(lib_path.name)
-        except OSError as e:
-            print(
-                f"Error: Could not create symlink for {lib_path.name} (Exit: {e.returncode})"
-            )
-            sys.exit(1)
+    # Update library linking
+    for so_file in lib_dir.glob("librocm_sysdeps_*.so"):
+        update_library_links(so_file)
 
     # Fix .pc files to use relocatable paths.
     pkgconfig_dir = lib_dir / "pkgconfig"
     if pkgconfig_dir.exists():
         for pc_file in pkgconfig_dir.glob("*.pc"):
             relativize_pc_file(pc_file)
+            rename_pc_files(pc_file)
 
 elif platform.system() == "Windows":
     # Do nothing for now.

--- a/third-party/sysdeps/common/ncurses/patch_source.sh
+++ b/third-party/sysdeps/common/ncurses/patch_source.sh
@@ -13,7 +13,7 @@ if [ -f "$SOURCE_DIR/configure" ]; then
   sed -i 's/^LIB_NAME=ncurses$/LIB_NAME=rocm_sysdeps_ncurses/' "$CONFIGURE"
   # Patch where cf_libname is set from cf_dir for ncurses module
   sed -i 's/^\([[:space:]]*\)cf_libname=$cf_dir$/\1cf_libname=$cf_dir\n\1[ "$cf_dir" = "ncurses" ] \&\& cf_libname="rocm_sysdeps_ncurses"/' "$CONFIGURE"
-  
+
   # Patch gen-pkgconfig.in to add a case for ncursesw in the name substitution
   # This ensures gen-pkgconfig generates rocm_sysdeps_ncursesw.pc (not ncursesw.pc)
   # which can then be properly renamed by patch_install.py
@@ -24,11 +24,11 @@ if [ -f "$SOURCE_DIR/configure" ]; then
     sed -i '/panel\*)[[:space:]]*name=.*PANEL_LIBRARY.*;;/a\
 	ncursesw*)	name="$MAIN_LIBRARY"	;;' "$SOURCE_DIR/misc/gen-pkgconfig.in"
   fi
-  
+
 else
   # This is the build directory - patch generated Makefiles after configure
   echo "Patching build directory (after configure)..."
-  # Patch generated Makefile  
+  # Patch generated Makefile
   find "$SOURCE_DIR" -name "Makefile" -type f | while read -r makefile; do
     if grep -qE "libncursesw|-lncursesw" "$makefile" 2>/dev/null; then
       echo "  Patching $makefile..."
@@ -37,7 +37,7 @@ else
       sed -i 's/libncursesw\.a/librocm_sysdeps_ncursesw.a/g' "$makefile"
       sed -i 's/libncursesw_g\.a/librocm_sysdeps_ncursesw_g.a/g' "$makefile"
       # Fix linker flags
-      sed -i 's/-lncursesw/-lrocm_sysdeps_ncursesw/g' "$makefile"  
+      sed -i 's/-lncursesw/-lrocm_sysdeps_ncursesw/g' "$makefile"
     fi
   done
 fi

--- a/third-party/sysdeps/common/ncurses/patch_source.sh
+++ b/third-party/sysdeps/common/ncurses/patch_source.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/bash
+set -e
+
+echo "Patching ncurses sources to rename main library..."
+SOURCE_DIR="${1:?Source directory must be given}"
+
+# Determine if we're patching source files or generated Makefiles
+if [ -f "$SOURCE_DIR/configure" ]; then
+  CONFIGURE="$SOURCE_DIR/configure"
+  echo "Patching source directory (before configure)..."
+
+  # Change LIB_NAME from 'ncurses' to 'rocm_sysdeps_ncurses'
+  sed -i 's/^LIB_NAME=ncurses$/LIB_NAME=rocm_sysdeps_ncurses/' "$CONFIGURE"
+  # Patch where cf_libname is set from cf_dir for ncurses module
+  sed -i 's/^\([[:space:]]*\)cf_libname=$cf_dir$/\1cf_libname=$cf_dir\n\1[ "$cf_dir" = "ncurses" ] \&\& cf_libname="rocm_sysdeps_ncurses"/' "$CONFIGURE"
+  
+  # Patch gen-pkgconfig.in to add a case for ncursesw in the name substitution
+  # This ensures gen-pkgconfig generates rocm_sysdeps_ncursesw.pc (not ncursesw.pc)
+  # which can then be properly renamed by patch_install.py
+  if [ -f "$SOURCE_DIR/misc/gen-pkgconfig.in" ]; then
+    echo "Patching gen-pkgconfig.in to handle ncursesw library name..."
+    # Insert the ncursesw case right after panel*) case but before ncurses++*) case
+    # The pattern 'ncursesw*)' is specific and won't match 'ncurses++w'
+    sed -i '/panel\*)[[:space:]]*name=.*PANEL_LIBRARY.*;;/a\
+	ncursesw*)	name="$MAIN_LIBRARY"	;;' "$SOURCE_DIR/misc/gen-pkgconfig.in"
+  fi
+  
+else
+  # This is the build directory - patch generated Makefiles after configure
+  echo "Patching build directory (after configure)..."
+  # Patch generated Makefile  
+  find "$SOURCE_DIR" -name "Makefile" -type f | while read -r makefile; do
+    if grep -qE "libncursesw|-lncursesw" "$makefile" 2>/dev/null; then
+      echo "  Patching $makefile..."
+      # Patch all libncursesw variants (including _g debug library)
+      sed -i 's/libncursesw\.so/librocm_sysdeps_ncursesw.so/g' "$makefile"
+      sed -i 's/libncursesw\.a/librocm_sysdeps_ncursesw.a/g' "$makefile"
+      sed -i 's/libncursesw_g\.a/librocm_sysdeps_ncursesw_g.a/g' "$makefile"
+      # Fix linker flags
+      sed -i 's/-lncursesw/-lrocm_sysdeps_ncursesw/g' "$makefile"  
+    fi
+  done
+fi
+
+echo "NCurses patching completed."


### PR DESCRIPTION
The renamed and patchelf‑edited libraries in the ROCk artifacts were missing required symbol‑version tags, leading RPM package installation failures. This patch will create the libraries with the prefix "librocm_sysdeps_" in their names, eliminating the need for patchelf editing and with the required symbol version tag. 
The linker‑name libraries will continue to use their original names (i.e., without the rocm_sysdeps_ prefix).

**Issue:**
The ncurses libraries are not providing the symbol version tag(AMDROCM_SYSDEPS_1.0)  with the name librocm_sysdeps_ncursesw.so.6. 

Current status is as below
/usr/lib/rpm/elfdeps --provides libncursesw.so
libncursesw.so.6(AMDROCM_SYSDEPS_1.0)(64bit)
librocm_sysdeps_ncursesw.so.6()(64bit)

**Expected:**
librocm_sysdeps_ncursesw.so.6(AMDROCM_SYSDEPS_1.0)(64bit)

**Test Results:**
[ncurses_testresults.txt](https://github.com/user-attachments/files/25024125/ncurses_testresults.txt)


