### PR TITLE
Merge build_containers.md into dockerfiles/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ separately.
 - [Environment Setup Guide](docs/environment_setup_guide.md): Comprehensive guide for setting up a build environment, known workarounds, and other operating specific information.
 - [Git Chores](docs/development/git_chores.md): Procedures for managing the codebase, specifically focused on version control, upstream/downstream, etc.
 - [Dependencies](docs/development/dependencies.md): Further specifications on ROCm-wide standards for depending on various components.
-- [Build Containers](docs/development/build_containers.md): Further information about containers used for building TheRock on CI.
+- [Dockerfiles for TheRock](dockerfiles/README.md): Information about containers used for building, testing, and distributing ROCm using TheRock.
 - [Build Artifacts](docs/development/artifacts.md): Documentation about the outputs of the build system.
 - [Releases Page](RELEASES.md): Documentation for how to leverage our build artifacts.
 - [Roadmap for Support](ROADMAP.md): Documentation for our prioritized roadmap to support AMD GPUs.

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -13,11 +13,11 @@ well as supporting scripts.
 | [`build_manylinux_rccl_x86_64.Dockerfile`](build_manylinux_rccl_x86_64.Dockerfile) | https://github.com/ROCm/TheRock/pkgs/container/therock_build_manylinux_rccl_x86_64 |
 
 These Dockerfiles are used to build ROCm, PyTorch, and other packages for
-release across multiple Linux distributions. They are derived from
+release across a wide variety of Linux distributions. They are derived from
 [manylinux](https://github.com/pypa/manylinux) Docker images which are based on
-older RHEL derivatives, provide a minimal set of development libraries, and
-support building binaries compatible with most Linux distributions that use
-glibc 2.39 or greater.
+older RHEL (Red Hat Enterprise Linux) derivatives, provide a minimal set of
+development libraries, and support building binaries compatible with most Linux
+distributions that use glibc 2.39 or greater.
 
 Requirements for these files:
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -9,7 +9,6 @@
 ### Build system
 
 - [Artifacts](artifacts.md)
-- [Build Containers](build_containers.md)
 - [Build System](build_system.md)
 - [Dependencies](dependencies.md)
 - [Development Guide](development_guide.md)

--- a/docs/development/build_containers.md
+++ b/docs/development/build_containers.md
@@ -1,7 +1,0 @@
-# Build Containers
-
-## ManyLinux
-
-The project aims to build on a wide variety of Linux operating systems and compilers, but when it comes to producing portable builds, we use EL containers based on the [manylinux](https://github.com/pypa/manylinux) project. This gives us the ability to produce binaries with wide compatibility by default to facilitate tarball distribution and embedding into other packages.
-
-The CI uses a custom built [therock_build_manylinux_x86_64](https://github.com/ROCm/TheRock/pkgs/container/therock_build_manylinux_x86_64). See the [`dockerfiles/build_manylinux_x86_64.Dockerfile`](../../dockerfiles/build_manylinux_x86_64.Dockerfile). It is automatically rebuilt on pushes to `main`. For testing, changes can be pushed to a `stage/docker/BRANCH_NAME` branch, which will automatically result in a corresponding container rebuilt with `stage-BRANCH_NAME` tag in the package registry. See the dockerfile for instructions to build locally.


### PR DESCRIPTION
## Motivation

When I added the dockerfiles/README.md file in https://github.com/ROCm/TheRock/pull/2776, I missed that we already had this `docs/development/build_containers.md` file.

Given the increased scope of the dockerfiles directory (build _and_ test containers), I think we should just delete the smaller page. We could also merge the other way instead, but I think keeping the docs close to the dockerfiles themselves makes more sense. If we later publish files from `docs/` to some website then that would be a strong reason to centralize.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
