### PR TITLE
Refresh tarball instructions in RELEASES.md.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -414,9 +414,9 @@ Release tarballs are uploaded to the following locations:
 
 | Tarball index                             | S3 bucket                                                                                | Description                                        |
 | ----------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| https://repo.amd.com/rocm/tarball/        | (Hidden)                                                                                 | Stable releases                                    |
-| https://rocm.prereleases.amd.com/tarball/ | (Hidden)                                                                                 | Prerelease builds for QA testing                   |
+| https://repo.amd.com/rocm/tarball/        | (not publicly accessible)                                                                | Stable releases                                    |
 | https://rocm.nightlies.amd.com/tarball/   | [`therock-nightly-tarball`](https://therock-nightly-tarball.s3.amazonaws.com/index.html) | Nightly builds from the default development branch |
+| https://rocm.prereleases.amd.com/tarball/ | (not publicly accessible)                                                                | ⚠️ Prerelease builds for QA testing ⚠️             |
 | https://rocm.devreleases.amd.com/tarball/ | [`therock-dev-tarball`](https://therock-dev-tarball.s3.amazonaws.com/index.html)         | ⚠️ Development builds from project maintainers ⚠️  |
 
 ### Manual tarball extraction
@@ -463,7 +463,7 @@ ls install
 
 > [!TIP]
 > After extracting a tarball, metadata about which commits were used to build
-> that tarball can be found in the `share/therock/therock_manifest.json` file:
+> TheRock can be found in the `share/therock/therock_manifest.json` file:
 >
 > ```bash
 > cat install/share/therock/therock_manifest.json


### PR DESCRIPTION
## Motivation

Per https://github.com/ROCm/TheRock/issues/2139, tarball releases can now use CloudFront URLs instead of the underlying AWS S3 URLs, which may soon be hidden. See also https://github.com/ROCm/TheRock/pull/3187.

I made a few related changes to the docs:

* Mention all tarball index pages with amd.com URLs (instead of AWS URLs)
* Clarify what a "tarball install" is and steer users towards package managers
* Note the `share/therock/therock_manifest.json` file

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
