### PR TITLE
Fix ncurses widec detection on modern Linux systems

### DIFF
--- a/third-party/sysdeps/common/ncurses/CMakeLists.txt
+++ b/third-party/sysdeps/common/ncurses/CMakeLists.txt
@@ -151,6 +151,11 @@ add_custom_target(
       # standard installation prefixes. We hope the system will provide the
       # additional required terminfo files if the fallbacks are not enough.
       --with-terminfo-dirs="/usr/share/terminfo:/usr/lib/terminfo:/etc/terminfo:/lib/terminfo"
+      # Fix #3223: Override autoconf's pid_t detection which incorrectly
+      # defines pid_t as int on modern systems with GCC 14+. This conflicts
+      # with glibc's typedef, breaking wchar_t detection and causing
+      # --enable-widec to silently fail.
+      ac_cv_type_pid_t=yes
   COMMAND
     make -j "${PAR_JOBS}" V=1
   COMMAND


### PR DESCRIPTION
## Summary

- Fix ncurses build failure on modern Linux systems (GCC 14+, recent glibc)
- Override broken autoconf pid_t detection that silently disables `--enable-widec`

## Problem

The ncurses autoconf `pid_t` detection test fails on modern systems. When it fails, configure adds `#define pid_t int` which conflicts with glibc's `typedef __pid_t pid_t`, causing subsequent configure tests to fail including `wchar_t` detection.

This silently breaks `--enable-widec`, resulting in build errors:
```
error: unknown type name 'cchar_t'; did you mean 'wchar_t'?
  233 | #define NCURSES_CH_T cchar_t
```

## Solution

Pass `ac_cv_type_pid_t=yes` to configure to override the broken detection. This is safe since `pid_t` is universally available on all POSIX/Linux systems.

## Test plan

- [x] Verified ncurses builds with `USE_WIDEC_SUPPORT=1` and `NCURSES_WIDECHAR=1`
- [x] Verified wide character libraries are produced (`libncursesw.so`, etc.)

Fixes #3223

🤖 Generated with [Claude Code](https://claude.com/claude-code)