### PR TITLE
Refactor fetch_library_prefix to shared CMake utility

### DIFF
--- a/cmake/therock_subproject_utils.cmake
+++ b/cmake/therock_subproject_utils.cmake
@@ -45,6 +45,40 @@ function(therock_set_install_rpath)
 endfunction()
 
 
+# Extracts a dependency prefix path from a path list (typically CMAKE_PREFIX_PATH)
+# by filtering for a specific pattern. This is useful for autotools-based builds
+# that require explicit --with-* configure flags, as autotools doesn't use
+# CMAKE_PREFIX_PATH directly.
+#
+# Args:
+#   input_path_list: Name of the variable containing the list of paths (e.g., "CMAKE_PREFIX_PATH")
+#   pattern: Regex pattern to filter the paths (e.g., "/gmp/build/stage")
+#   output_var: Name of the variable to store the result in
+#
+# Example:
+#   fetch_library_prefix(CMAKE_PREFIX_PATH "/gmp/build/stage" GMP_PREFIX)
+#   # Sets GMP_PREFIX to the first path in CMAKE_PREFIX_PATH matching the pattern
+#
+function(therock_fetch_library_prefix input_path_list pattern output_var)
+  # Access the list contents using the input variable name
+  set(_input_list "${${input_path_list}}")
+
+  # Filter the list to include only items matching the pattern
+  list(FILTER _input_list INCLUDE REGEX "${pattern}")
+
+  # Check if a match was found
+  if(_input_list)
+    # Get the first match and return it
+    list(GET _input_list 0 _result_path)
+    set(${output_var} "${_result_path}" PARENT_SCOPE)
+    message(STATUS "Extracted path for pattern '${pattern}': ${_result_path}")
+  else()
+    # Error if no match found
+    message(SEND_ERROR "Did not find a path containing '${pattern}' in ${input_path_list}.")
+  endif()
+endfunction()
+
+
 # Replaces a library linked with `-l` with a CMake target.
 # Args:
 # OLD_LIBRARY: Deprecated library linked with `-l`

--- a/cmake/therock_subproject_utils.cmake
+++ b/cmake/therock_subproject_utils.cmake
@@ -49,23 +49,18 @@ endfunction()
 # by filtering for a specific pattern. This is useful for autotools-based builds
 # that require explicit --with-* configure flags, as autotools doesn't use
 # CMAKE_PREFIX_PATH directly.
-#
 # Args:
 #   input_path_list: Name of the variable containing the list of paths (e.g., "CMAKE_PREFIX_PATH")
 #   pattern: Regex pattern to filter the paths (e.g., "/gmp/build/stage")
 #   output_var: Name of the variable to store the result in
-#
 # Example:
 #   fetch_library_prefix(CMAKE_PREFIX_PATH "/gmp/build/stage" GMP_PREFIX)
 #   # Sets GMP_PREFIX to the first path in CMAKE_PREFIX_PATH matching the pattern
-#
 function(therock_fetch_library_prefix input_path_list pattern output_var)
   # Access the list contents using the input variable name
   set(_input_list "${${input_path_list}}")
-
   # Filter the list to include only items matching the pattern
   list(FILTER _input_list INCLUDE REGEX "${pattern}")
-
   # Check if a match was found
   if(_input_list)
     # Get the first match and return it

--- a/debug-tools/rocgdb/CMakeLists.txt
+++ b/debug-tools/rocgdb/CMakeLists.txt
@@ -66,34 +66,7 @@ project(rocgdb C CXX)
 
 include(ExternalProject)
 include(ProcessorCount)
-
-# Function to extract a single path that matches a given regex pattern
-# from a list of paths.
-#
-# Usage:
-#   fetch_library_prefix(<input_path_list> <pattern> <output_var>)
-#
-# Example:
-#   fetch_library_prefix(CMAKE_PREFIX_PATH "gmp" GMP_PREFIX)
-#
-function(fetch_library_prefix input_path_list pattern output_var)
-  # Access the list contents using the input variable name
-  set(_input_list "${${input_path_list}}")
-
-  # Filter the list using the provided pattern
-  list(FILTER _input_list INCLUDE REGEX "${pattern}")
-
-  # Check if a match was found.
-  if(_input_list)
-    # Store the first match in the output variable provided by the caller.
-    list(GET _input_list 0 _result_path)
-    set(${output_var} "${_result_path}" PARENT_SCOPE)
-    message(STATUS "Extracted path for pattern '${pattern}': ${_result_path}")
-  else()
-    # No match found, issue a fatal error.
-    message(SEND_ERROR "Did not find a path containing '${pattern}' in ${input_list_var_name}.")
-  endif()
-endfunction()
+include(therock_subproject_utils)
 
 # By default install the ROCgdb testsuite files.
 option(ENABLE_TESTS "Enable installation of ROCgdb testsuite files" OFF)
@@ -131,11 +104,11 @@ endif()
 message(STATUS "Build type set to: ${CMAKE_BUILD_TYPE}")
 
 # Fetch the install prefixes for the library and executables rocgdb
-# depends on.
-fetch_library_prefix(CMAKE_PREFIX_PATH "/gmp/build/stage" GMP_PREFIX)
-fetch_library_prefix(CMAKE_PREFIX_PATH "/mpfr/build/stage" MPFR_PREFIX)
-fetch_library_prefix(CMAKE_PREFIX_PATH "/expat/build/stage" EXPAT_PREFIX)
-fetch_library_prefix(CMAKE_PREFIX_PATH "/ncurses/build/stage" NCURSES_PREFIX)
+# Depends on and uses therock_fetch_library_prefix from therock_subproject_utils.cmake.
+therock_fetch_library_prefix(CMAKE_PREFIX_PATH "/gmp/build/stage" GMP_PREFIX)
+therock_fetch_library_prefix(CMAKE_PREFIX_PATH "/mpfr/build/stage" MPFR_PREFIX)
+therock_fetch_library_prefix(CMAKE_PREFIX_PATH "/expat/build/stage" EXPAT_PREFIX)
+therock_fetch_library_prefix(CMAKE_PREFIX_PATH "/ncurses/build/stage" NCURSES_PREFIX)
 
 # We need to explicitly pass ncurses' include path and set the rpath for
 # the library. The reason we need to explicitly pass rpath is because gdb's


### PR DESCRIPTION
## Motivation

Move the fetch_library_prefix function from debug-tools/rocgdb into cmake/therock_subproject_utils.cmake as therock_fetch_library_prefix to make it reusable across the project. Inspired by this comment: https://github.com/ROCm/TheRock/pull/3020#discussion_r2758821456

Changes:
- Add therock_fetch_library_prefix() to cmake/therock_subproject_utils.cmake
- Update debug-tools/rocgdb/CMakeLists.txt to use the shared function
- Remove local copy of fetch_library_prefix from rocgdb

This enables hwloc (PR #3020) to use the same shared function instead
of maintaining a duplicate local copy.

## Technical Details

Move the fetch_library_prefix function from debug-tools/rocgdb into cmake/therock_subproject_utils.cmake

## Test Plan

Verify that rocgdb still builds correctly with the refactored function. The function behavior is identical, just moved to a shared location.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
