### PR TITLE
fix(libhipcxx): exclude unused dirs from test artifact

### DIFF
--- a/math-libs/artifact-libhipcxx.toml
+++ b/math-libs/artifact-libhipcxx.toml
@@ -12,7 +12,7 @@ include = [
   "libhipcxx/**/*",
 ]
 exclude = [
-  # Exclude folders not needed for testing 
+  # Exclude folders not needed for testing
   "libhipcxx/._upstream/**",
   "libhipcxx/docs/**",
 ]


### PR DESCRIPTION
Exclude ._upstream and docs directories from the libhipcxx test artifact as they are not needed for testing. This reduces artifact size and removes unnecessary clutter.

Fixes #2855

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
