### PR TITLE
Add timeouts to test_rocm_wheels.yml

### DIFF
--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -60,6 +60,7 @@ jobs:
   test_wheels:
     name: Test ${{ matrix.packages }} wheels | ${{ inputs.amdgpu_family }}
     runs-on: ${{ inputs.test_runs_on }}
+    timeout-minutes: 30
     container:
       image: ${{ contains(inputs.test_runs_on, 'linux') && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26' || null }}
       options: --ipc host
@@ -104,5 +105,6 @@ jobs:
           pip freeze
 
       - name: Run 'rocm-sdk test' with '${{ matrix.packages }}' installed
+        timeout-minutes: 5
         run: |
           rocm-sdk test


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/1559. When adding Python package tests to CI workflows on https://github.com/ROCm/TheRock/pull/3182 we noticed that this job hit a 6 hour timeout on the `linux-strix-halo-gpu-rocm-5` runner: https://github.com/ROCm/TheRock/actions/runs/21533668625/job/62060067637?pr=3182.

## Technical Details

I chose a 30 minute timeout for the overall job, to catch slow network issues and then a 5 minute timeout for just the test step, to give enough time for the packages to initialize and then catch any hung subprocesses.

Note that we currently skip tests on Linux gfx1151 here:
* https://github.com/ROCm/TheRock/blob/55fa089eecd5f20d13357b82b74b5572dda1d67b/build_tools/github_actions/amdgpu_family_matrix.py#L77-L87
* https://github.com/ROCm/TheRock/blob/55fa089eecd5f20d13357b82b74b5572dda1d67b/build_tools/print_driver_gpu_info.py#L24-L26

We may want to similarly filter Linux gfx1151 from parts of `rocm-sdk test`.

## Test Plan and Results

Triggered a test run with ROCm version `7.12.0a20260202`: https://github.com/ROCm/TheRock/actions/runs/21644961000

All tests passed in 1 minute, though the `linux-strix-halo-gpu-rocm-7` runner was used for those runs.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
