### PR TITLE
Add missing source set for libhipcxx

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -98,6 +98,10 @@ submodules = ["rocm-systems"]
 description = "ROCm libraries monorepo (math libs)"
 submodules = ["rocm-libraries"]
 
+[source_sets.math-libs]
+description = "Additional math library submodules"
+submodules = ["libhipcxx"]
+
 [source_sets.ml-frameworks]
 description = "ML framework submodules"
 submodules = []
@@ -239,7 +243,7 @@ description = "Math libraries (BLAS, FFT, RAND, etc.)"
 type = "per-arch"  # Built per GPU architecture
 artifact_group_deps = ["hip-runtime", "profiler-core"]
 # TODO: rocm-systems included for projects/hip/VERSION (see CMakeLists.txt)
-source_sets = ["rocm-libraries", "rocm-systems"]
+source_sets = ["rocm-libraries", "rocm-systems", "math-libs"]
 
 [artifact_groups.ml-libs]
 description = "Machine learning libraries"


### PR DESCRIPTION
## Motivation

Adds a source set for libhipcxx.

## Technical Details

`fetch_sources.py --stage` uses the source sets defined in `BUILD_TOPOLOGY.toml` to determine which submodules are required. No source set for libhipcxx was defined.

## Test Plan

`./build_tools/fetch_sources.py --stage math-libs`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
