### PR TITLE
[dockerfiles] Build and install Python 3.8 and 3.9 and drop Python 3.14

### DIFF
--- a/dockerfiles/install_shared_pythons.sh
+++ b/dockerfiles/install_shared_pythons.sh
@@ -13,12 +13,16 @@ BUILD_ROOT="${1:?Build directory required}"
 INSTALL_ROOT="/opt/python-shared"
 
 # Python versions to build (major.minor.patch)
+#
+# Though EOL, both python 3.8 and python 3.9 are still actively used on
+# supported distros. We pick their most recent release versions.
 PYTHON_VERSIONS=(
+  "3.8.20"
+  "3.9.25"
   "3.10.16"
   "3.11.11"
   "3.12.9"
   "3.13.2"
-  "3.14.0"
 )
 
 mkdir -p "${BUILD_ROOT}"


### PR DESCRIPTION
To match the Python versions made available by manylinux, extend our list of python-shared to also contain Python 3.8 and 3.9.

Though EOL, those versions are still actively used in distros we support.

Drop Python 3.14 for now. It will eventually be brought back in the future when it becomes more widespread.