### PR TITLE
[dockerfiles] Remove texinfo-tex from list of packages to install

### DIFF
--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -62,7 +62,6 @@ RUN ./install_googletest.sh "${GOOGLE_TEST_VERSION}" && rm -rf /install-googlete
 #
 # Development tool dependencies:
 #   texinfo, flag: rocprofiler-systems
-#   texinfo-tex: rocgdb
 RUN yum install -y epel-release && \
     yum remove -y gcc-toolset* && \
     yum install -y \
@@ -77,7 +76,6 @@ RUN yum install -y epel-release && \
       git-lfs \
     && yum install -y \
       texinfo \
-      texinfo-tex \
       flex \
     && yum clean all && \
     rm -rf /var/cache/yum


### PR DESCRIPTION
The texinfo-tex package was required in order to build the rocgdb pdf documentation, but installation of the rocgdb pdf documentation was dropped.

So drop the texinfo-tex package as well.