### PR TITLE
Add LLVM concurrency options to main config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,10 @@ option(THEROCK_ENABLE_LLVM_TESTS "Enables building LLVM LIT tests" OFF)
 
 set(THEROCK_SANITIZER "" CACHE STRING "Enable project wide sanitizer build ('ASAN' for host+device, 'HOST_ASAN' for host-only)")
 
+# Options to control the concurrency for building LLVM.
+set(FLANG_PARALLEL_COMPILE_JOBS "" CACHE STRING "Limit parallel compile jobs for Flang (reduces memory usage on systems with many cores)")
+set(LLVM_PARALLEL_LINK_JOBS "" CACHE STRING "Limit parallel link jobs for LLVM (reduces memory usage on systems with many cores)")
+
 # List of python executables to use for multi-version python builds
 set(THEROCK_DIST_PYTHON_EXECUTABLES "" CACHE STRING "Build for multiple python versions in supported projects (default to Python3_EXECUTABLE if empty)")
 

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -18,7 +18,16 @@ if(THEROCK_ENABLE_COMPILER)
     message(STATUS "Flang build concurrency level set to ${FLANG_PARALLEL_COMPILE_JOBS}")
     list(APPEND _extra_llvm_cmake_args "-DFLANG_PARALLEL_COMPILE_JOBS=${FLANG_PARALLEL_COMPILE_JOBS}")
   else()
-     message(STATUS "Flang concurrency is unlimited. Memory usage may be much higher.")
+     message(WARNING "Flang concurrency is unlimited. Memory usage may be much higher. Set -DFLANG_PARALLEL_COMPILE_JOBS to reduce memory use.")
+  endif()
+
+  # LLVM linking is also very memory intensive. Allow users to adjust the number
+  # of parallel link jobs.
+  if(LLVM_PARALLEL_LINK_JOBS)
+    message(STATUS "LLVM parallel link jobs set to ${LLVM_PARALLEL_LINK_JOBS}")
+    list(APPEND _extra_llvm_cmake_args "-DLLVM_PARALLEL_LINK_JOBS=${LLVM_PARALLEL_LINK_JOBS}")
+  else()
+     message(WARNING "LLVM parallel link jobs is unlimited. Memory usage may be much higher. Set -DLLVM_PARALLEL_LINK_JOBS to reduce memory use.")
   endif()
 
   # If the compiler is not pristine (i.e. has patches), then there will be a


### PR DESCRIPTION
The FLANG_PARALLEL_COMPILE_JOBS flag exists in compiler/CMakeLists.txt to limit Flang build concurrency (which is very memory-intensive), but it's buried and easy to forget about.

When not set, it prints a warning:

Flang concurrency is unlimited. Memory usage may be much higher.

Add this option to the top-level CMakeLists.txt alongside other build configuration options so it's discoverable and documented in one place.

This makes it visible in ccmake/cmake-gui and easier to find when configuring builds.

While at it, also add an option to set LLVM_PARALLEL_LINK_JOBS, which is also useful for controlling memory intensive linking jobs.

Add some code to compiler/CMakeLists.txt so we handle both options correctly.

If the options are not set (unlimited concurrency), emit a cmake warning that should be more visible than a regular status message.