### PR TITLE
Refactor setup_venv.py, including adding --find-links support

### DIFF
--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -46,6 +46,7 @@ is_windows = platform.system() == "Windows"
 
 ROCM_INDEX_URLS_MAP = {
     "stable": "https://repo.amd.com/rocm/whl/",
+    "prerelease": "https://rocm.prereleases.amd.com/whl",
     "nightly": "https://rocm.nightlies.amd.com/v2",
     "dev": "https://rocm.devreleases.amd.com/v2",
 }
@@ -161,10 +162,10 @@ def install_packages_into_venv(
         venv_dir: The venv to install into
         packages: The list of packages to install
         use_uv: True to use 'uv', uses 'pip' otherwise
-        index_url: Url for '--index-url' command argument
+        index_url: URL for '--index-url' command argument
         index_name: Shorthand for a base index_url (e.g. 'nightly')
         index_subdir: Subdirectory for 'index_url' or 'index_name'
-        find_links: Url for '--find-links' command argument
+        find_links: URL for '--find-links' command argument
         pre: Allow pre-release packages (pip: --pre, uv: --prerelease=allow)
         disable_cache: Disable package cache (pip: --no-cache-dir, uv: --no-cache)
     """
@@ -329,7 +330,7 @@ def main(argv: list[str]):
     install_options.add_argument(
         "--index-name",
         type=str,
-        choices=["stable", "nightly", "dev"],
+        choices=["stable", "prerelease", "nightly", "dev"],
         help="Shorthand for a named index (requires --index-subdir)",
     )
     install_options.add_argument(

--- a/build_tools/tests/setup_venv_test.py
+++ b/build_tools/tests/setup_venv_test.py
@@ -117,12 +117,12 @@ class InstallPackagesTest(unittest.TestCase):
         install_packages_into_venv(
             venv_dir=self.venv_dir,
             packages=["rocm"],
-            index_name="nightly",
+            index_name="stable",
             index_subdir="gfx110X-all",
         )
 
         cmd = mock_run.call_args[0][0]
-        self.assertIn("--index-url=https://rocm.nightlies.amd.com/v2/gfx110X-all", cmd)
+        self.assertIn("--index-url=https://repo.amd.com/rocm/whl/gfx110X-all", cmd)
 
     @patch("setup_venv.find_venv_python_exe", return_value="python")
     @patch("setup_venv.run_command")


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/1559. I'm splitting this off from https://github.com/ROCm/TheRock/pull/3182.

In https://github.com/ROCm/TheRock/pull/3136, I'm using [`indexer.py`](https://github.com/ROCm/TheRock/blob/main/third-party/indexer/indexer.py) to generate an index page for a CI workflow run that can be installed from using `--find-links` (and _not_ `--index-url`). For example: https://therock-artifacts-testing.s3.amazonaws.com/21440027240-windows/python/gfx110X-all/index.html. For workflows and developers to be able to conveniently create Python venvs and install those packages, this setup_venv.py script needed support for `--find-links` too.

## Technical Details

Key points about the refactoring:

1. Changed scraping signature / behavior to returns the union of all subdirs instead of a distinct list of subdirs per package index. If someone tries to install a package from an index that doesn't have that package, that will be a later error.
    * before: `scrape_subdirs() -> dict[str, set[str]] | set[str] | None`
    * after: `_scrape_rocm_index_subdirs() -> set[str] | None`
2. Reworked branching between `pip` and `uv` to make it more clear what is being used where and why
3. Streamlined `run()` to emphasize the `create_venv` -> `update_venv` -> `install_packages_into_venv` flow
4. Allowed setting `--packages` without `--index-url` or `--index-name` (to install from the default pypi index)
5. Added new `--find-links` option (can be used together with `--index-url` as they are compatible/complimentary)

Documentation for reference:
* https://pip.pypa.io/en/stable/cli/pip_install/
* https://docs.astral.sh/uv/pip/packages/

## Test Plan

* CI usage in some existing workflows
* New unit tests for helper functions

## Test Result

Manual testing:

<details><summary>With `--find-links` and pip</summary>
<p>

```
D:\scratch\therock
λ python D:\projects\TheRock\build_tools/setup_venv.py test.venv --packages rocm[libraries]==7.12.0.dev0 --find-links=https://therock-artifacts-testing.s3.amazonaws.com/21440027240-windows/python/gfx110X-all/index.html --clean
Clearing existing venv_dir 'test.venv'
Creating venv at 'test.venv'
  Dir relative to CWD: 'test.venv'
  Dir fully resolved : 'D:\scratch\therock\test.venv'

++ Exec [D:\scratch\therock]$ 'C:\Users\Nod-Shark16\AppData\Local\Programs\Python\Python313\python.exe' -m venv 'D:\scratch\therock\test.venv'

++ Exec [D:\scratch\therock]$ 'test.venv\Scripts\python.exe' -m pip install --upgrade pip
Requirement already satisfied: pip in d:\scratch\therock\test.venv\lib\site-packages (25.1.1)
Collecting pip
  Using cached pip-26.0-py3-none-any.whl.metadata (4.7 kB)
Using cached pip-26.0-py3-none-any.whl (1.8 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 25.1.1
    Uninstalling pip-25.1.1:
      Successfully uninstalled pip-25.1.1
Successfully installed pip-26.0

++ Exec [D:\scratch\therock]$ 'test.venv\Scripts\python.exe' -m pip install --find-links=https://therock-artifacts-testing.s3.amazonaws.com/21440027240-windows/python/gfx110X-all/index.html 'rocm[libraries]==7.12.0.dev0'
Looking in links: https://therock-artifacts-testing.s3.amazonaws.com/21440027240-windows/python/gfx110X-all/index.html
Collecting rocm==7.12.0.dev0 (from rocm[libraries]==7.12.0.dev0)
  Using cached rocm-7.12.0.dev0-py3-none-any.whl
Collecting rocm-sdk-core==7.12.0.dev0 (from rocm==7.12.0.dev0->rocm[libraries]==7.12.0.dev0)
  Using cached https://therock-artifacts-testing.s3.amazonaws.com/21440027240-windows/python/gfx110X-all/rocm_sdk_core-7.12.0.dev0-py3-none-win_amd64.whl (654.1 MB)
Collecting rocm-sdk-libraries-gfx110X-all==7.12.0.dev0 (from rocm[libraries]==7.12.0.dev0)
  Using cached https://therock-artifacts-testing.s3.amazonaws.com/21440027240-windows/python/gfx110X-all/rocm_sdk_libraries_gfx110x_all-7.12.0.dev0-py3-none-win_amd64.whl (224.4 MB)
Installing collected packages: rocm-sdk-libraries-gfx110X-all, rocm-sdk-core, rocm
Successfully installed rocm-7.12.0.dev0 rocm-sdk-core-7.12.0.dev0 rocm-sdk-libraries-gfx110X-all-7.12.0.dev0

Setup complete at 'test.venv'! Activate the venv with:
  test.venv\Scripts\activate.bat
```

</p>
</details> 

<details><summary>With `--find-links` and uv</summary>
<p>

```
λ python D:\projects\TheRock\build_tools/setup_venv.py test_uv.venv --packages rocm[libraries]==7.12.0.dev0 --find-links=https://therock-artifacts-testing.s3.amazonaws.com/21440027240-windows/python/gfx110X-all/index.html --clean --use-uv --pre
Clearing existing venv_dir 'test_uv.venv'
Creating venv at 'test_uv.venv'
  Dir relative to CWD: 'test_uv.venv'
  Dir fully resolved : 'D:\scratch\therock\test_uv.venv'

++ Exec [D:\scratch\therock]$ uv venv 'D:\scratch\therock\test_uv.venv'
Using CPython 3.13.5 interpreter at: C:\Users\Nod-Shark16\AppData\Local\Programs\Python\Python313\python.exe
Creating virtual environment at: test_uv.venv
Activate with: test_uv.venv\Scripts\activate

++ Exec [D:\scratch\therock]$ uv pip install --python 'test_uv.venv\Scripts\python.exe' --find-links=https://therock-artifacts-testing.s3.amazonaws.com/21440027240-windows/python/gfx110X-all/index.html --prerelease=allow 'rocm[libraries]==7.12.0.dev0'
Using Python 3.13.5 environment at: test_uv.venv
Resolved 3 packages in 162ms
░░░░░░░░░░░░░░░░░░░░ [0/3] Installing wheels...
warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If the cache and target directories are on different filesystems, hardlinking may not be supported.
         If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning.
Installed 3 packages in 1.09s
 + rocm==7.12.0.dev0
 + rocm-sdk-core==7.12.0.dev0
 + rocm-sdk-libraries-gfx110x-all==7.12.0.dev0

Setup complete at 'test_uv.venv'! Activate the venv with:
  test_uv.venv\Scripts\activate.bat
```

</p>
</details> 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
