### PR TITLE
Introducing a new, hierarchical amdgpu_family_matrix layout

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -18,9 +18,9 @@ from github_actions_utils import str2bool
 import json
 import os
 
-#######
+#############################################################################################
 # NOTE: when doing changes here, also check that they are done in new_amdgpu_family_matrix.py
-#######
+#############################################################################################
 
 all_build_variants = {
     "linux": {

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -52,52 +52,9 @@ Generic targets of a family are "all", "dcgpu", "dgpu", ...
 Cmake targets are defined in: cmake/therock_amdgpu_targets.cmake
 """
 
-# blueprint = {
-# "linux": {
-#                 "build": {
-#                   "expect_failure": False,
-#                   "build_variants": ["release"],
-#                 },
-#                 "test": {
-#                     "run_tests": False,
-#                     "runs_on": {
-#                         "test": "",
-#                         "test-multi-gpu": "",
-#                         "benchmark": "",
-#                     },
-#                     "sanity_check_only_for_family": False,
-#                     "expect_pytorch_failure": False,
-#                 },
-#                 "release": {
-#                     "push_on_success": False,
-#                     "bypass_tests_for_releases": False,
-#                 }
-#             },
-#             "windows": {
-#                 "build": {
-#                     "expect_failure": False,
-#                     "build_variants": ["release"],
-#                 },
-#                 "test": {
-#                     "run_tests": False,
-#                     "runs_on": {
-#                         "test": "",
-#                         "test-multi-gpu": "",
-#                         "benchmark": "",
-#                     },
-#                     "sanity_check_only_for_family": False,
-#                     "expect_pytorch_failure": False,
-#                 },
-#                 "release": {
-#                     "push_on_success": False,
-#                     "bypass_tests_for_releases": False
-#                 }
-#             },
-# }
-
-#######
+##########################################################################################
 # NOTE: when doing changes here, also check that they are done in amdgpu_family_matrix.py
-#######
+##########################################################################################
 
 amdgpu_family_predefined_groups = {
     # The 'presubmit' matrix runs on 'pull_request' triggers (on all PRs).
@@ -208,7 +165,10 @@ amdgpu_family_info_matrix_all = {
                     },
                     "sanity_check_only_for_family": True,
                 },
-                "release": {"push_on_success": True, "bypass_tests_for_releases": True},
+                "release": {
+                    "push_on_success": True,
+                    "bypass_tests_for_releases": True,
+                },
             },
         }
     },
@@ -405,7 +365,10 @@ amdgpu_family_info_matrix_all = {
                         "test": "windows-gfx120X-gpu-rocm",
                     },
                 },
-                "release": {"push_on_success": True, "bypass_tests_for_releases": True},
+                "release": {
+                    "push_on_success": True,
+                    "bypass_tests_for_releases": True,
+                },
             },
         }
     },
@@ -449,7 +412,6 @@ amdgpu_family_info_matrix_all = {
         "dgpu": {
             "linux": {
                 "build": {
-                    "expect_failure": True,
                     "build_variants": ["release"],
                 },
                 "test": {
@@ -471,8 +433,6 @@ amdgpu_family_info_matrix_all = {
                 "test": {
                     "run_tests": False,
                     "runs_on": {},
-                    # TODO(#1925): Enable arch for aotriton to enable PyTorch build
-                    "expect_pytorch_failure": True,
                 },
                 "release": {
                     "push_on_success": False,


### PR DESCRIPTION
This PR is part of enabling CI weekly (big picture PR #1732 ) . For this, refactoring of amdgpu_family is needed for easier selection of a specific gpu, and not having to rely on knowing in which group the specific gpu is part of (presubmit/postsubmit/nightlies).

New layout puts all gpus in a single dictionary `amdgpu_family_info_matrix_all`. Choices for pre/postsubmit and nightlies are now done via a list.

`amdgpu_family_info_matrix_all` has more depth in hierarchy to better define which parameters belong to which step: build, test, release.
- Tests can be now turned off with a single bool flag. no need to comment out the runner
- Default runner labels are "test", "benchmark" and "test-runs-on-multi-gpu". Further labels can be introduced, e.g. "oem" which in the future can overwrite the default runners.

This new layout is introduced in parallel to the old one. The old one stays unchanged to allow gradual move for the CI to use the new layout.