### PR TITLE
[ci] Adding correct arguments for kernel check under `Driver / GPU Check`

### DIFF
--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -123,8 +123,8 @@ def run_sanity(os_name: str) -> None:
         )
         run_command_with_search(
             label="Kernel version",
-            command="uname -r",
-            args=[],
+            command="uname",
+            args=["-r"],
             extra_command_search_paths=[bin_dir],
         )
 


### PR DESCRIPTION
Previously, this is what would print for this uname check:

```
=== Kernel version ===
uname -r: command not found
```

Noticing uname flag was not working properly. Works here under `Driver / GPU Check`: https://github.com/ROCm/TheRock/actions/runs/21680681160/job/62514043596

```
=== Kernel version ===
++ Exec [/__w/TheRock/TheRock]$ /usr/bin/uname -r
6.8.0-87-generic
```

Adding `skip-ci` flag as no build is needed for this