### PR TITLE
[third-party] Fix libcap symbol versioning

### DIFF
--- a/third-party/sysdeps/linux/libcap/libcap.map
+++ b/third-party/sysdeps/linux/libcap/libcap.map
@@ -81,8 +81,6 @@ LIBCAP_2.69 {
     cap_copy_int_check;
 
     /* System calls - cap_proc.c and libc wrappers */
-    capget;
-    capset;
     capgetp;
     capsetp;
 


### PR DESCRIPTION
Fix the libcap.map file not to try to version undefined symbols.