### PR TITLE
Move sparse and solver to build topology

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -490,6 +490,16 @@ artifact_group = "math-libs"
 type = "target-specific"
 artifact_deps = ["core-runtime", "core-hip"]
 
+[artifacts.sparse]
+artifact_group = "math-libs"
+type = "target-specific"
+artifact_deps = ["blas", "prim"]
+
+[artifacts.solver]
+artifact_group = "math-libs"
+type = "target-specific"
+artifact_deps = ["blas", "prim", "sparse", "host-suite-sparse"]
+
 [artifacts.rocwmma]
 artifact_group = "math-libs"
 type = "target-specific"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,26 +284,6 @@ if(THEROCK_FLAG_INCLUDE_PROFILER)
   )
 endif()
 
-# Optional sub-features that control behavior within artifacts
-
-# Math library sub-components (control what gets built within BLAS artifact)
-therock_add_feature(SPARSE
-  GROUP MATH_LIBS
-  DESCRIPTION "Enables sparse libraries (hipsparse, hipsparselt, rocsparse) within BLAS"
-  REQUIRES BLAS PRIM
-)
-
-if(NOT WIN32)
-  set(_solver_platform_requirements "HOST_SUITE_SPARSE")
-else()
-  set(_solver_platform_requirements "")
-endif()
-therock_add_feature(SOLVER
-  GROUP MATH_LIBS
-  DESCRIPTION "Enables solver libraries (hipsolver, rocsolver) within BLAS"
-  REQUIRES BLAS PRIM SPARSE ${_solver_platform_requirements}
-)
-
 # Finalize all feature flags.
 therock_finalize_features()
 therock_report_features()


### PR DESCRIPTION
## Motivation

Instead of defining calls to `therock_add_feature` for sparse and solver in the root CMake configuration, this adds artifact definitions for sparse and solver to the build topology file (using to auto-generate calls to `therock_add_feature`). Without the artifact definition in the build topology file, `build_tools/configure_stage.py` does not generate flags to enable build solver and sparse, the components will not be build, not be included in the (test) artifacts and tests will fail due to the missing files.

## Technical Details

For now resembles the `therock_add_feature` definition in the root CMake configuration, but `artifact_deps` should be revisited in a follow up.

## Test Plan

https://github.com/ROCm/TheRock/actions/runs/21678580454

## Test Result

Passing build and tests for {roc,hip}SOLVER and {roc,hip}SPARSE in linked workflow run.


```
python ./build_tools/configure_stage.py --stage math-libs --dist-amdgpu-families "gfx94X-dcgpu"
```
generates
```
-DTHEROCK_ENABLE_SOLVER=ON
-DTHEROCK_ENABLE_SPARSE=ON
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
