### PR TITLE
[CI] Move ci path filtering funcs into separate file

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -59,8 +59,8 @@ from amdgpu_family_matrix import (
 )
 from fetch_test_configurations import test_matrix
 
-from ci_path_filters import (
-    get_git_modified_paths_since,
+from configure_ci_path_filters import (
+    get_git_modified_paths,
     get_git_submodule_paths,
     is_ci_run_required,
 )
@@ -616,7 +616,7 @@ def main(base_args, linux_families, windows_families):
         test_type = "full"
         test_type_reason = "scheduled run triggers full tests"
     else:
-        modified_paths = get_git_modified_paths_since(base_ref)
+        modified_paths = get_git_modified_paths(base_ref)
         print("modified_paths (max 200):", modified_paths[:200])
         print(f"Checking modified files since this had a {github_event_name} trigger")
         # TODO(#199): other behavior changes

--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -7,7 +7,7 @@ This module provides utilities to:
 - Decide whether CI should run based on the modified paths
 
 Public API:
-    get_git_modified_paths_since() - Get modified files from git diff compared to worktree
+    get_git_modified_paths() - Get modified files from git diff compared to worktree
     get_git_submodule_paths() - Get list of git submodule paths in the repository
     is_ci_run_required() - Check if CI run is required based on modified paths
 """
@@ -23,7 +23,7 @@ from typing import Iterable, Optional
 # ============================================================================
 
 
-def get_git_modified_paths_since(base_ref: str) -> Optional[Iterable[str]]:
+def get_git_modified_paths(base_ref: str) -> Optional[Iterable[str]]:
     """Returns the paths of files modified since the base reference commit.
 
     Uses `git diff --name-only` to find files that have changed between the
@@ -179,6 +179,7 @@ _GITHUB_WORKFLOWS_CI_PATTERNS = [
     "ci*.yml",
     "multi_arch*.yml",
     "build*artifact*.yml",
+    "build*python_packages.yml",
     "test*artifacts.yml",
     "test_sanity_check.yml",
     "test_component.yml",

--- a/build_tools/github_actions/tests/configure_ci_path_filters_test.py
+++ b/build_tools/github_actions/tests/configure_ci_path_filters_test.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+from configure_ci_path_filters import is_ci_run_required
+
+
+class ConfigureCIPathFiltersTest(unittest.TestCase):
+    def test_run_ci_if_source_file_edited(self):
+        paths = ["source_file.h"]
+        run_ci = is_ci_run_required(paths)
+        self.assertTrue(run_ci)
+
+    def test_dont_run_ci_if_only_markdown_files_edited(self):
+        paths = ["README.md", "build_tools/README.md"]
+        run_ci = is_ci_run_required(paths)
+        self.assertFalse(run_ci)
+
+    def test_dont_run_ci_if_only_external_builds_edited(self):
+        paths = ["external-builds/pytorch/CMakeLists.txt"]
+        run_ci = is_ci_run_required(paths)
+        self.assertFalse(run_ci)
+
+    def test_dont_run_ci_if_only_external_builds_edited(self):
+        paths = ["experimental/file.h"]
+        run_ci = is_ci_run_required(paths)
+        self.assertFalse(run_ci)
+
+    def test_run_ci_if_related_workflow_file_edited(self):
+        paths = [".github/workflows/ci.yml"]
+        run_ci = is_ci_run_required(paths)
+        self.assertTrue(run_ci)
+
+        paths = [".github/workflows/build_portable_linux_artifacts.yml"]
+        run_ci = is_ci_run_required(paths)
+        self.assertTrue(run_ci)
+
+        paths = [".github/workflows/build_artifact.yml"]
+        run_ci = is_ci_run_required(paths)
+        self.assertTrue(run_ci)
+
+    def test_dont_run_ci_if_unrelated_workflow_file_edited(self):
+        paths = [".github/workflows/pre-commit.yml"]
+        run_ci = is_ci_run_required(paths)
+        self.assertFalse(run_ci)
+
+        paths = [".github/workflows/test_jax_dockerfile.yml"]
+        run_ci = is_ci_run_required(paths)
+        self.assertFalse(run_ci)
+
+    def test_run_ci_if_source_file_and_unrelated_workflow_file_edited(self):
+        paths = ["source_file.h", ".github/workflows/pre-commit.yml"]
+        run_ci = is_ci_run_required(paths)
+        self.assertTrue(run_ci)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import configure_ci
-from ci_path_filters import is_ci_run_required
 from benchmarks.benchmark_test_matrix import benchmark_matrix
 
 therock_test_runner_dict = {
@@ -56,56 +55,6 @@ class ConfigureCITest(unittest.TestCase):
             self.assertFalse(
                 any(entry.get("expect_failure") for entry in target_output)
             )
-
-    ###########################################################################
-    # Tests for is_ci_run_required
-
-    def test_run_ci_if_source_file_edited(self):
-        paths = ["source_file.h"]
-        run_ci = is_ci_run_required(paths)
-        self.assertTrue(run_ci)
-
-    def test_dont_run_ci_if_only_markdown_files_edited(self):
-        paths = ["README.md", "build_tools/README.md"]
-        run_ci = is_ci_run_required(paths)
-        self.assertFalse(run_ci)
-
-    def test_dont_run_ci_if_only_external_builds_edited(self):
-        paths = ["external-builds/pytorch/CMakeLists.txt"]
-        run_ci = is_ci_run_required(paths)
-        self.assertFalse(run_ci)
-
-    def test_dont_run_ci_if_only_external_builds_edited(self):
-        paths = ["experimental/file.h"]
-        run_ci = is_ci_run_required(paths)
-        self.assertFalse(run_ci)
-
-    def test_run_ci_if_related_workflow_file_edited(self):
-        paths = [".github/workflows/ci.yml"]
-        run_ci = is_ci_run_required(paths)
-        self.assertTrue(run_ci)
-
-        paths = [".github/workflows/build_portable_linux_artifacts.yml"]
-        run_ci = is_ci_run_required(paths)
-        self.assertTrue(run_ci)
-
-        paths = [".github/workflows/build_artifact.yml"]
-        run_ci = is_ci_run_required(paths)
-        self.assertTrue(run_ci)
-
-    def test_dont_run_ci_if_unrelated_workflow_file_edited(self):
-        paths = [".github/workflows/pre-commit.yml"]
-        run_ci = is_ci_run_required(paths)
-        self.assertFalse(run_ci)
-
-        paths = [".github/workflows/test_jax_dockerfile.yml"]
-        run_ci = is_ci_run_required(paths)
-        self.assertFalse(run_ci)
-
-    def test_run_ci_if_source_file_and_unrelated_workflow_file_edited(self):
-        paths = ["source_file.h", ".github/workflows/pre-commit.yml"]
-        run_ci = is_ci_run_required(paths)
-        self.assertTrue(run_ci)
 
     ###########################################################################
     # Tests for matrix_generator and helper functions


### PR DESCRIPTION
Move all functions related to ci path filtering and determining based on this if the CI should be run or not into a separate file `configure_ci_path_filters.py`.

Aside from adjusting description, also gives better names to the following functions:
- get_modified_paths -> get_git_modified_paths
- get_therock_submodule_paths -> get_git_submodule_paths
- should_ci_run_given_modified_paths -> is_ci_run_required


Part of CI weekly progress (big picture #1732 ) so that the new and old CI configurators can share those functions.