### PR TITLE
Add ROCm bin to PATH during test_sanity_check on Windows

### DIFF
--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -104,6 +104,13 @@ jobs:
           FETCH_ARTIFACT_ARGS: "--base-only"
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
+      # The sanity checks run tools like 'offload-arch' which may search for
+      # DLLs on multiple search paths (PATH, CWD, system32, etc.).
+      # For typical "installs" of ROCm, the rocm/bin/ dir can be expected to be
+      # added to PATH, so we do that here. If we don't do this, DLLs on test
+      # runners in system32 may be picked up instead and the tests may not be
+      # representative, see https://github.com/ROCm/TheRock/issues/2019 and
+      # https://github.com/ROCm/TheRock/pull/3230#issuecomment-3844854922.
       - name: Set PATH and HIP_CLANG_PATH for windows
         if: ${{ runner.os == 'Windows' }}
         run: |


### PR DESCRIPTION
## Motivation

This favors loading libraries from our own ROCm install instead of whatever happened to be installed system-wide.

## Technical Details

We noticed at https://github.com/ROCm/TheRock/pull/3230#issuecomment-3844854922 that the `windows-strix-halo-gpu-rocm-8` CI runner has a version of `C:\WINDOWS\system32\amdhip64_7.dll` that is affected by https://github.com/ROCm/TheRock/issues/1118, breaking the sanity tests when the output of `offload-arch` is
```
HIP Library Path: C:\WINDOWS\system32\amdhip64_7.dll
gfx1151
```

Instead of the expected
```
gfx1151
```

Using the version of `amdhip64_*.dll` from our source build should resolve that, and as discussed at https://github.com/ROCm/TheRock/issues/2019, `offload-arch` will search `PATH` ahead of system32.

> [!WARNING]
> The above is only true if the DLL on `PATH` has a newer version, so this solution is not enough on its own. 

## Test Plan

Triggered a test run with additional logging: https://github.com/ROCm/TheRock/actions/runs/21689466137/job/62545226437

## Test Result

Test output:
```bash
# Before setting PATH
# Run ${OUTPUT_ARTIFACTS_DIR}/lib/llvm/bin/offload-arch --verbose
Found HIP runtime: C:/Windows/system32/amdhip64_6.dll
Successfully loaded HIP runtime library
Found symbol: hipGetDeviceCount
Found symbol: hipGetErrorString
Found symbol: hipRuntimeGetVersion
HIP Runtime Version: 6.1.40252

# After setting PATH
# Run ${OUTPUT_ARTIFACTS_DIR}/lib/llvm/bin/offload-arch --verbose
Found HIP runtime: B:/runner/_work/TheRock/TheRock/build/bin/amdhip64_7.dll
Successfully loaded HIP runtime library
Found symbol: hipGetDeviceCount
Found symbol: hipGetErrorString
Found symbol: hipRuntimeGetVersion
HIP Runtime Version: 7.2.0
````

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
