### PR TITLE
Workaround stray "HIP Library Path" offload-arch output in sanity test

### DIFF
--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -89,6 +89,7 @@ class TestROCmSanity:
             / offload_arch_executable_file
         ).resolve()
         process = run_command([str(offload_arch_path)])
+
         # Extract the arch from the command output, working around
         # https://github.com/ROCm/TheRock/issues/1118. We only expect the output
         # to contain 'gfx####` text but some ROCm releases contained stray
@@ -99,11 +100,14 @@ class TestROCmSanity:
         # installs of ROCm (DLLs in system32) take precedence over user
         # installs (PATH env var) under certain conditions. Hopefully a
         # different unit test elsewhere in ROCm catches that more directly.
-        offload_arch = ""
+        offload_arch = None
         for line in process.stdout.splitlines():
             if "gfx" in line:
                 offload_arch = line
                 break
+        assert (
+            offload_arch is not None
+        ), f"Expected offload-arch to return gfx####, got:\n{process.stdout}"
 
         # Compiling .cpp file using hipcc
         hipcc_check_executable_file = f"hipcc_check{platform_executable_suffix}"


### PR DESCRIPTION
## Motivation

Another attempt at stabilizing sanity checks on our CI test machines, following https://github.com/ROCm/TheRock/pull/3257.

## Technical Details

We noticed at https://github.com/ROCm/TheRock/pull/3230#issuecomment-3844854922 that the `windows-strix-halo-gpu-rocm-8` CI runner has a version of `C:\WINDOWS\system32\amdhip64_7.dll` that is affected by https://github.com/ROCm/TheRock/issues/1118, breaking the sanity tests when the output of `offload-arch` is
```
HIP Library Path: C:\WINDOWS\system32\amdhip64_7.dll
gfx1151
```

Instead of the expected
```
gfx1151
```

We don't have a mechanism right now to force using the user library on `PATH` when a matching version exists in `system32`, so this just patches the real underlying issues.

## Test Plan

Tested manually by overriding stdout and running the test:
```python
        stdout = """HIP Library Path: C:\WINDOWS\system32\amdhip64_7.dll
gfx1100"""
```

Without this PR:
```
INFO     test_rocm_sanity:test_rocm_sanity.py:26 ++ Run [D:\projects\TheRock\build\dist\rocm\bin]$ 'D:\projects\TheRock\build\dist\rocm\bin/hipcc' 'D:\projects\TheRock\tests\hipcc_check.cpp' -Xlinker '-rpath=D:\projects\TheRock\build\dist\rocm\bin/../lib/' '--offload-arch=HIP Library Path: C:\WINDOWS\system32mdhip64_7.dll' -o hipcc_check.exe
ERROR    test_rocm_sanity:test_rocm_sanity.py:31 Command failed!
ERROR    test_rocm_sanity:test_rocm_sanity.py:32 command stdout:
ERROR    test_rocm_sanity:test_rocm_sanity.py:35 command stderr:
ERROR    test_rocm_sanity:test_rocm_sanity.py:37 Warning: The Feature:  C is unknown. Correct compilation is not guaranteed.
ERROR    test_rocm_sanity:test_rocm_sanity.py:37 Warning: The Feature: \WINDOWS\system32mdhip64_7.dll is unknown. Correct compilation is not guaranteed.
ERROR    test_rocm_sanity:test_rocm_sanity.py:37 clang: error: no such file or directory: 'Library'
ERROR    test_rocm_sanity:test_rocm_sanity.py:37 clang: error: no such file or directory: 'Path:'
ERROR    test_rocm_sanity:test_rocm_sanity.py:37 clang: error: no such file or directory: 'C:\WINDOWS\system32<U+0007>mdhip64_7.dll'
```

With this PR:
```
INFO     test_rocm_sanity:test_rocm_sanity.py:26 ++ Run [D:\projects\TheRock\build\dist\rocm\bin]$ 'D:\projects\TheRock\build\dist\rocm\bin/hipcc' 'D:\projects\TheRock\tests\hipcc_check.cpp' -Xlinker '-rpath=D:\projects\TheRock\build\dist\rocm\bin/../lib/' --offload-arch=gfx1100 -o hipcc_check.exe
INFO     test_rocm_sanity:test_rocm_sanity.py:26 ++ Run [D:\projects\TheRock\build\dist\rocm\bin]$ hipcc_check
PASSED                                                                                                           [ 66%]
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
