### PR TITLE
[dockerfiles] Add rocgdb testing dependencies to tester image

### DIFF
--- a/dockerfiles/no_rocm_image_ubuntu24_04.Dockerfile
+++ b/dockerfiles/no_rocm_image_ubuntu24_04.Dockerfile
@@ -13,6 +13,10 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # Set as default user
 USER tester
 
+# rocgdb testing dependencies:
+#   - dejagnu
+#   - make
+#   - gcc/g++/gfortran
 RUN sudo apt-get update -y \
     && sudo apt-get install -y software-properties-common \
     && sudo add-apt-repository -y ppa:git-core/ppa \
@@ -31,7 +35,12 @@ RUN sudo apt-get update -y \
     wget \
     psmisc \
     libgfortran5 \
-    valgrind
+    valgrind \
+    dejagnu \
+    make \
+    gcc \
+    g++ \
+    gfortran
 
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && \
     sudo apt-get install git-lfs


### PR DESCRIPTION
We need a few more tools to test rocgdb:

- dejagnu for the expect-based testsuite.
- make because the testsuite is autotools-based.
- gcc/g++/gfortran because we also test against GCC.