### PR TITLE
[debug-tools/rocgdb] Pass -latomic when building rocgdb and expand LDFLAGS comment

### DIFF
--- a/debug-tools/rocgdb/CMakeLists.txt
+++ b/debug-tools/rocgdb/CMakeLists.txt
@@ -150,7 +150,15 @@ set(NCURSES_INCLUDE "-I${NCURSES_PREFIX}/include")
 # Adjust the compilation flags and LDFLAGS.
 set(CUSTOM_C_FLAGS "${CUSTOM_C_FLAGS} ${NCURSES_INCLUDE}")
 set(CUSTOM_CXX_FLAGS "${CUSTOM_CXX_FLAGS} ${NCURSES_INCLUDE}")
-set(LDFLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${NCURSES_RPATH} -Wl,--enable-new-dtags")
+
+#
+# -latomic: We need to pass this switch so rocgdb builds properly with LLVM.
+#           The code that parses DWARF may use atomics. GCC does not need
+#           this switch, but it is safe to pass it anyway.
+#
+# -Wl,--enable-new-dtags: Modifies RPATH/RUNPATH shared library discovery logic.
+#
+set(LDFLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${NCURSES_RPATH} -Wl,--enable-new-dtags -latomic")
 
 # Replace all semicolons (the CMake separator) with colons (the ENV separator).
 # We need this to pass it on to rocgdb's configure.


### PR DESCRIPTION
Since we are building rocgdb using amd-llvm, we need to pass -latomic through LDFLAGS for things to build correctly. Otherwise we may run into build errors related to undefined atomics.

This happens because more recent code in the DWARF reader uses atomics.

GCC does not need this switch, but it is safe to pass it and keeps things generic.