### PR TITLE
[ci] Updating variable group-id for OSSCI

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -40,7 +40,7 @@ jobs:
         --group-add video
         --device /dev/kfd
         --device /dev/dri
-        --group-add ${{ vars.OSSCI_GPU_GROUP_ID }}
+        --group-add 992
         --ulimit memlock=-1:-1
         --security-opt seccomp=unconfined
         --env-file /etc/podinfo/gha-gpu-isolation-settings

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -51,7 +51,7 @@ jobs:
         --group-add video
         --device /dev/kfd
         --device /dev/dri
-        --group-add ${{ vars.OSSCI_GPU_GROUP_ID }}
+        --group-add 992
         --cap-add SYS_MODULE
         -v /lib/modules:/lib/modules
         --ulimit memlock=-1:-1


### PR DESCRIPTION
OSSCI migrated mi325s, so need a new groupID

Sanity works here: https://github.com/ROCm/TheRock/actions/runs/21723540679/job/62659665907
normal run works here: https://github.com/ROCm/TheRock/actions/runs/21723540679/job/62659791422

I've dabbled with organization variables, however, this does not work for forks so for now, we will do the manual update