### PR TITLE
Update Debian and RPM Jinja2 templates to include hidden directories  during packaging

### DIFF
--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -143,14 +143,16 @@ def create_versioned_deb_package(pkg_name, config: PackageConfig):
     if not sourcedir_list:
         print(f"{pkg_name} is a Meta package")
     else:
+        # Copy package contents first
         dest_dir = package_dir / Path(config.install_prefix).relative_to("/")
         for source_path in sourcedir_list:
             copy_package_contents(source_path, dest_dir)
 
-        # Install file is required for non-meta packages
-        generate_install_file(pkg_info, deb_dir, config, [dest_dir])
         if config.enable_rpath:
             convert_runpath_to_rpath(package_dir)
+
+        # Generate install file after copying, so we can check for hidden files
+        generate_install_file(pkg_info, deb_dir, config, dest_dir)
 
     package_with_dpkg_build(package_dir)
 
@@ -199,14 +201,14 @@ def generate_changelog_file(pkg_info, deb_dir, config: PackageConfig):
         f.write(template.render(context))
 
 
-def generate_install_file(pkg_info, deb_dir, config: PackageConfig, dir_list):
+def generate_install_file(pkg_info, deb_dir, config: PackageConfig, dest_dir=None):
     """Generate a Debian install entry in `debian/install`.
 
     Parameters:
     pkg_info : Package details from the Json file
     deb_dir: Directory where debian package control file is saved
     config: Configuration object containing package metadata
-    dir_list: List of source directories to check for hidden files
+    dest_dir: Optional path to check for hidden files
 
     Returns: None
     """
@@ -215,15 +217,29 @@ def generate_install_file(pkg_info, deb_dir, config: PackageConfig, dir_list):
     # May be required in future to populate any context
     install_file = Path(deb_dir) / "install"
 
-    # Check if hidden directories/files exist in package content directories
-    has_hidden_dir = is_hidden_directories(dir_list)
+    # Check if hidden files and regular files exist in the destination directory
+    has_hidden_files = False
+    has_regular_files = False
+    if dest_dir and Path(dest_dir).exists():
+        for item in Path(dest_dir).iterdir():
+            name = item.name  # get the filename as a string
+            # Skip "." and ".."
+            if name in [".", ".."]:
+                continue
+
+            # Hidden entry
+            if name.startswith("."):
+                has_hidden_files = True
+            else:
+                has_regular_files = True
 
     env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
     template = env.get_template("template/debian_install.j2")
     # Prepare your context dictionary
     context = {
         "path": config.install_prefix,
-        "has_hidden_dir": has_hidden_dir,
+        "has_hidden_files": has_hidden_files,
+        "has_regular_files": has_regular_files,
     }
 
     with install_file.open("w", encoding="utf-8") as f:

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -594,30 +594,3 @@ def filter_components_fromartifactory(pkg_name, artifacts_dir, gfx_arch):
                     continue
 
     return sourcedir_list
-
-
-def is_hidden_directories(dir_list):
-    """Check if hidden files or directories exist in the given directories.
-
-    Parameters:
-    dir_list: List of directories to check for hidden files/directories
-
-    Returns:
-    bool: True if hidden files or directories are found, False otherwise
-    """
-    if not dir_list:
-        return False
-
-    for source_path in dir_list:
-        source_dir = Path(source_path)
-
-        if source_dir.exists() and source_dir.is_dir():
-            try:
-                # Only check the immediate directory contents (no recursion)
-                for name in os.listdir(source_dir):
-                    if name.startswith(".") and name not in [".", ".."]:
-                        return True
-            except (OSError, PermissionError):
-                pass
-
-    return False

--- a/build_tools/packaging/linux/template/debian_install.j2
+++ b/build_tools/packaging/linux/template/debian_install.j2
@@ -1,4 +1,6 @@
+{%- if has_regular_files %}
 .{{path}}/*  {{path}}
-{% if has_hidden_dir %}
+{%- endif %}
+{%- if has_hidden_files %}
 .{{path}}/.[!.]*  {{path}}
-{% endif %}
+{%- endif %}


### PR DESCRIPTION
Hidden directories (e.g., .info/version) in base artifacts were not being packaged because the existing Jinja2 templates only copied non-hidden paths.

This update enhances both Debian and RPM packaging templates to correctly detect and include hidden directories and files when generating packages.

The hidden version file is required for determining the ROCm version, so ensuring it is included in the final package is essential for correct version reporting.

Test Output:
dpkg -c amdrocm-base7.2_7.2.1-crdnnh_amd64.deb | grep "\.info"
drwxr-xr-x root/root         0 2026-01-26 22:34 ./opt/rocm/core-7.2/.info/
-rw-r--r-- root/root         7 2026-01-26 22:32 ./opt/rocm/core-7.2/.info/version

rpm -qlp amdrocm-base7.1-7.1.0-crdnnh.x86_64.rpm | grep "\.info"
/opt/rocm/core-7.1/.info
/opt/rocm/core-7.1/.info/version