### PR TITLE
[ci] Adding mi350 required group ID

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -41,6 +41,7 @@ jobs:
         --device /dev/kfd
         --device /dev/dri
         --group-add 992
+        --group-add 110
         --ulimit memlock=-1:-1
         --security-opt seccomp=unconfined
         --env-file /etc/podinfo/gha-gpu-isolation-settings

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -73,6 +73,7 @@ jobs:
         --group-add video
         --device /dev/kfd
         --device /dev/dri
+        --group-add 992
         --group-add 110
         --env-file /etc/podinfo/gha-gpu-isolation-settings
         --user 0:0 # Running as root, by recommendation of GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/dockerfile-support#user

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -67,6 +67,7 @@ jobs:
         --group-add video
         --device /dev/kfd
         --device /dev/dri
+        --group-add 992
         --group-add 110
         --env-file /etc/podinfo/gha-gpu-isolation-settings
         --user 0:0 # Running as root, by recommendation of GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/dockerfile-support#user

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -52,6 +52,7 @@ jobs:
         --device /dev/kfd
         --device /dev/dri
         --group-add 992
+        --group-add 110
         --cap-add SYS_MODULE
         -v /lib/modules:/lib/modules
         --ulimit memlock=-1:-1

--- a/.github/workflows/therock_test_harness.yml
+++ b/.github/workflows/therock_test_harness.yml
@@ -65,6 +65,7 @@ jobs:
         --group-add video
         --device /dev/kfd
         --device /dev/dri
+        --group-add 992
         --group-add 110
         --env-file /etc/podinfo/gha-gpu-isolation-settings
     strategy:


### PR DESCRIPTION
After updating mi325 group-id, we are noticing errors for mi350. 

Tested here for mi350: https://github.com/ROCm/TheRock/actions/runs/21733399385/job/62692971370
Tested here for mi325: https://github.com/ROCm/TheRock/actions/runs/21759203211/job/62778060417

Adding both work properly

Adding `skip-ci` flag as tests prove it works