### PR TITLE
[torch] Add `--find-links` support to `--install-rocm` mode of build_prod_wheels.py

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -317,6 +317,8 @@ def do_install_rocm(args: argparse.Namespace):
         pip_args.extend(["--pre"])
     if args.index_url:
         pip_args.extend(["--index-url", args.index_url])
+    if args.find_links:
+        pip_args.extend(["--find-links", args.find_links])
     if args.pip_cache_dir:
         pip_args.extend(["--cache-dir", args.pip_cache_dir])
     pip_args += cache_dir_args
@@ -983,6 +985,10 @@ def main(argv: list[str]):
 
     def add_common(p: argparse.ArgumentParser):
         p.add_argument("--index-url", help="Base URL of the Python Package Index.")
+        p.add_argument(
+            "--find-links",
+            help="URL or path for pip --find-links (flat package index).",
+        )
         p.add_argument("--pip-cache-dir", type=Path, help="Pip cache dir")
         # Note that we default to >1.0 because at the time of writing, we had
         # 0.1.0 release placeholder packages out on pypi and we don't want them


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/3291.

As part of https://github.com/ROCm/TheRock/issues/1559, CI workflows (see https://github.com/ROCm/TheRock/pull/3261) will upload ROCm Python packages to e.g. https://therock-ci-artifacts.s3.amazonaws.com/21733299154-windows/python/gfx110X-all/index.html, and those packages can be installed with `--find-links`, NOT `--index-url`. This allows PyTorch builds to install those packages. Future PRs will use this new functionality from CI workflows.

## Technical Details

See also https://github.com/ROCm/TheRock/pull/3242, which added `--find-links` support to [`build_tools/setup_venv.py`](https://github.com/ROCm/TheRock/blob/main/build_tools/setup_venv.py). This script uses the current Python environment and only supports pip installs (not uv) as a convenience, so the plumbing was simpler.

## Test Plan and Results

Tested locally:

```bash
cd external-builds/pytorch
py -V:3.13 -m venv 3.13.venv && .\3.13.venv\Scripts\activate.bat
pip install packaging

python pytorch_torch_repo.py checkout ^
  --checkout-dir D:/b/pytorch ^
  --gitrepo-origin https://github.com/rocm/pytorch.git ^
  --repo-hashtag release/2.9

python build_prod_wheels.py build ^
  --pytorch-dir D:/b/pytorch --no-build-pytorch-audio --no-build-pytorch-vision ^
  --output-dir %HOME%/.therock/pytorch ^
  --install-rocm ^
  --find-links=https://therock-ci-artifacts.s3.amazonaws.com/21733299154-windows/python/gfx110X-all/index.html ^
  --use-ccache > C:\Users\Nod-Shark16\.therock\logs\build_prod_wheels_%date%_%time::=%.txt 2>&1

pip freeze | grep rocm
# rocm==7.12.0.dev0+7282a0974b9c29519265ce590c284544938d36e4
# rocm-sdk-core==7.12.0.dev0+7282a0974b9c29519265ce590c284544938d36e4
# rocm-sdk-devel==7.12.0.dev0+7282a0974b9c29519265ce590c284544938d36e4
# rocm-sdk-libraries-gfx110X-all==7.12.0.dev0+7282a0974b9c29519265ce590c284544938d36e4
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
