### PR TITLE
[torch] Fix rocm package name in `pip cache remove` command

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -299,9 +299,8 @@ def do_install_rocm(args: argparse.Namespace):
 
     # Because the rocm package caches current GPU selection and such, we
     # always purge it to ensure a clean rebuild.
-
     run_command(
-        [sys.executable, "-m", "pip", "cache", "remove", "rocm_sdk"] + cache_dir_args,
+        [sys.executable, "-m", "pip", "cache", "remove", "rocm"] + cache_dir_args,
         cwd=Path.cwd(),
     )
 


### PR DESCRIPTION
## Motivation

It looks like this was missed as part of the renaming of `rocm-sdk` to `rocm` in https://github.com/ROCm/TheRock/commit/a1a521899a465af423186ed0ed76881ededafddc.

## Test Plan

Tested locally:

```bash
(3.13.venv) λ pip cache remove rocm
# Files removed: 82 (1.5 MB)

(3.12.venv) λ pip cache list | grep rocm
# (no output, so no matches)
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
