### PR TITLE
Install `ninja` during test env setup

### DIFF
--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -62,8 +62,7 @@ runs:
       if: ${{ runner.os == 'Windows' }}
       shell: bash
       run: |
-        choco install --no-progress -y ninja
-        choco install --no-progress -y awscli
+        choco install --no-progress -y ninja awscli
         echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
 
     - name: Download and Unpack Artifacts


### PR DESCRIPTION
## Motivation

`ninja` wasn't consistently available in the Windows test env - see this [example](https://github.com/ROCm/TheRock/actions/runs/21720468744/job/62667954649). We attempt to install it during the test env setup to alleviate this source of error.

Install the default stable `ninja` version via choco: https://community.chocolatey.org/packages/ninja

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
