### PR TITLE
[ci] Disabling gfx110X linux test runner

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -64,7 +64,9 @@ amdgpu_family_info_matrix_presubmit = {
     },
     "gfx110x": {
         "linux": {
-            "test-runs-on": "linux-gfx110X-gpu-rocm",
+            # TODO(#3298): Re-enable machine once HSA_STATUS_ERROR_OUT_OF_RESOURCES issues are resolved
+            # Label is linux-gfx110X-gpu-rocm
+            "test-runs-on": "",
             "family": "gfx110X-all",
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],


### PR DESCRIPTION
The `gfx110X` lab machines are having constant `HSA_STATUS_ERROR_OUT_OF_RESOURCES`, issue #3298

Job failed here: https://github.com/ROCm/TheRock/actions/runs/21810885849/job/62925198191

I will be opening a ticket with XSJ lab to resolve these errors

Test run here: https://github.com/ROCm/TheRock/actions/runs/21840105207

Since the test works, I am adding `skip-ci` flag.