### PR TITLE
[Python Requirements] Downgrading setuptools to < 82.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ PyYAML==6.0.2
 pyzstd>=0.16.0
 # `pkg_resources` has been removed from Setuptools in version 82.0.0
 # but it still a dependency in some environments (issue#3311)
-setuptools>=80.9.0,82.0.0
+setuptools>=80.9.0,<82.0.0
 tomli==2.2.1; python_version <= '3.10'
 pytest-cmake==0.13.0
 mako>=1.1.3


### PR DESCRIPTION
## Motivation

This pull request downgrades `setuptools` to a version below 82.0.0 to resolve runtime failures caused by the removal of the `pkg_resources` module in setuptools 82.0.0.
The current environment pulls in `setuptools==82.0.0`, which no longer provides `pkg_resources`.

## Technical Details
The runtime error observed (from Issue https://github.com/ROCm/TheRock/issues/3311) is:
 `ModuleNotFoundError: No module named 'pkg_resources'`
With setuptools 82.0.0, pkg_resources is no longer provided in the way our environment expects, so these imports fail at runtime.



## File changed
- `requirements.txt`

## Test Plan

- CI: https://github.com/ROCm/TheRock/actions/runs/21854150576
- Linux: https://github.com/ROCm/TheRock/actions/runs/21854276906
- Windows: https://github.com/ROCm/TheRock/actions/runs/21854309403
Pytorch:
- Linux: https://github.com/ROCm/TheRock/actions/runs/21863281918
- Windows: https://github.com/ROCm/TheRock/actions/runs/21859870858

## Test Result
Builds passing in CI runs
- Pytorch Build failures need to be fixed in upstream (ex: https://github.com/pytorch/pytorch/blob/nightly/requirements-build.txt#L2)
- Pytorch test failures are existing issues
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
