### PR TITLE
Download prereleases: Fix arch detection in buckets with many elements

### DIFF
--- a/build_tools/packaging/download_prerelease_packages.py
+++ b/build_tools/packaging/download_prerelease_packages.py
@@ -243,7 +243,7 @@ def has_version_in_arch(
 
         for page in pages:
             if "Contents" not in page:
-                return False
+                continue
 
             for obj in page["Contents"]:
                 if version in obj["Key"]:


### PR DESCRIPTION
At the moment we use a paginator on top-level to retrieve the archs from the bucket (`"CommonPrefixes"`). There are just a couple of entries. On the level of the `<bucket>/v3/whl/<arch>`  we use list_objects_v2 with a `MaxKeys=100`. This creates problems as certain archs have >> 100 elements in the bucket. This will fail arch detection (checking if there is a package with <version> available).

To resolve the issue, switch the usage: top-level now uses `list_objects_v2` as there are only a couple of objects. And on arch-level use a paginator to look over all packages, quick return on the first hit of version found.

Other changes introduced:
- update dependency packages to clearly state to which they belong to. comment out jax dependencies as jax is not yet part of the release. when listing packages they will be part of the "unknown packages" section
- Give the full, relative path doe the readme doc so that it can easily be opened from the console output