### PR TITLE
Promotion of RC: Adjust logic for triton rename

### DIFF
--- a/build_tools/packaging/promote_from_rc_to_final.py
+++ b/build_tools/packaging/promote_from_rc_to_final.py
@@ -128,7 +128,8 @@ def wheel_change_extra_files(new_dir_path: pathlib.Path, old_version, new_versio
 
     print("    Changing ROCm-specific files that contain the version")
 
-    if not "torch" in new_dir_path.name:  # rocm packages
+    # rocm packages
+    if new_dir_path.name.startswith("rocm"):
         files_to_change = [
             new_dir_path / package_name_no_version / "_dist_info.py",
         ]


### PR DESCRIPTION
Triton got renamed and does not contain "torch" anymore. change rocm package recognition to not accidentally trigger for any "non-torch" package but only for true rocm packages that start with "rocm".
