### PR TITLE
Disabled MIOpen long running tests on windows gfx1151

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -220,7 +220,7 @@ if AMDGPU_FAMILIES in ["gfx110X-all", "gfx1150", "gfx1151", "gfx120X-all"]:
         "*CPU_UnitTestConvSolverImplicitGemmGroupWrwXdlopsDevApplicability_FP16.ConvHipImplicitGemmGroupWrwXdlops*"
     )
 
-    # Diable long running tests on windows gfx1151
+    # Disable long running tests
     negative_filter.append("Full/GPU_Softmax_FP32*")  # 24 min
     negative_filter.append("Full/GPU_Softmax_BFP16*")  # 13 min
     negative_filter.append("Full/GPU_Softmax_FP16*")  # 11.5 min


### PR DESCRIPTION
## Motivation

MIOpen tests on windows gfx1151 take long time that exceeds the expected time per shard.
Some shards took around 50 mins and usually well over 30 mins.
Disabling these tests will free up some resources for other projects to run on this limited architecture.

## Technical Details

From other runs on PR, I gathered these info on the longest running tests:
Test case | Time shard 1 | Time shard 2 | Time shard 3 | Time shard 4 | Total time
-- | -- | -- | -- | -- | --
Full/GPU_Softmax_FP32 | 7:50 | 8:12 | 6:53 | 3:12 | ~26 mins
Full/GPU_Softmax_BFP16 | 4:00 | 3:59 | 3:27 | 1:32 | ~13 mins
Full/GPU_Softmax_FP16 | 3:39 | 3:42 | 2:53 | 1:13 | ~11.5 mins
Smoke/GPU_Reduce_FP32 | 2:18 | 0:52 | 0:00 | 3:14 | ~6:24 mins

With team feedback, these can be excluded from the rock CI and moved into nightly without increasing the risk.

## Test Plan

Monitor the test run time of the shards on windows gfx1151 and compare to previous results.
an example run on 4 shards takes: 27m - 36m - 34m - 36m
we should see a big decrease in run time.

## Test Result

Old run times: 27m - 36m - 34m - 36m
New run times: 11m, 17m, 12m, 18m

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
