### PR TITLE
[debug-tools/rocgdb] Move dev artifacts to run

### DIFF
--- a/debug-tools/artifact-rocgdb.toml
+++ b/debug-tools/artifact-rocgdb.toml
@@ -1,13 +1,6 @@
 # rocgdb
 [components.dbg."debug-tools/rocgdb/stage"]
 [components.dev."debug-tools/rocgdb/stage"]
-include = [
-  "include/gdb/**",
-  "share/locale/**",
-  "share/rocgdb/python/**",
-  "share/rocgdb/syscalls/**",
-  "share/rocgdb/system-gdbinit/**"
-]
 [components.doc."debug-tools/rocgdb/stage"]
 include = [
   "share/doc/**",
@@ -19,9 +12,15 @@ include = [
 include = [
   "lib/**"
 ]
+# Also include share/ here since rocgdb depends on loading some of
+# these at runtime.
 [components.run."debug-tools/rocgdb/stage"]
 include = [
-  "**/bin/**"
+  "**/bin/**",
+  "share/locale/**",
+  "share/rocgdb/python/**",
+  "share/rocgdb/syscalls/**",
+  "share/rocgdb/system-gdbinit/**"
 ]
 [components.test."debug-tools/rocgdb/stage"]
 include = [


### PR DESCRIPTION
ROCgdb needs some of the files currently in the dev artifacts (for instance,
Python plugin files) to run properly, but testing does not install dev
artifacts.

So move the share/ entries from the dev artifact to the run artifact since
they are a requirement. While at it, stop including include/gdb in artifacts
as that only contains the jit reader header, and we don't need it.