### PR TITLE
[torch] Re-enable now passing test_cudnn_rnn_dropout_states_device

### DIFF
--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -49,15 +49,6 @@ skip_tests = {
             # ----------------
         ],
         "nn": [
-            # external-builds/pytorch/pytorch/test/test_nn.py::TestNN::test_RNN_dropout_state MIOpen(HIP): Error [Compile] 'hiprtcCompileProgram(prog.get(), c_options.size(), c_options.data())' MIOpenDropoutHIP.cpp: HIPRTC_ERROR_COMPILATION (6)
-            # MIOpen(HIP): Error [BuildHip] HIPRTC status = HIPRTC_ERROR_COMPILATION (6), source file: MIOpenDropoutHIP.cpp
-            # MIOpen(HIP): Warning [BuildHip] In file included from /tmp/comgr-01c423/input/MIOpenDropoutHIP.cpp:32:
-            # /tmp/comgr-01c423/include/miopen_rocrand.hpp:45:10: fatal error: 'rocrand/rocrand_xorwow.h' file not found
-            # 45 | #include <rocrand/rocrand_xorwow.h>
-            #     |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
-            # 1 error generated when compiling for gfx942.
-            # MIOpen Error: /therock/src/rocm-libraries/projects/miopen/src/hipoc/hipoc_program.cpp:299: Code object build failed. Source: MIOpenDropoutHIP.cpp
-            "test_RNN_dropout_state",
             # AssertionError: "Input and parameter tensors are not at the same device" does not match "Expected all tensors
             # to be on the same device, but got weight is on cpu, different from other tensors on cuda:0 (when checking
             # argument in method wrapper_CUDA__miopen_rnn)"

--- a/external-builds/pytorch/skip_tests/pytorch_2.10.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.10.py
@@ -101,15 +101,6 @@ skip_tests = {
             "test_cublas_allow_fp16_reduced_precision_reduction_get_set",
             "test_allocator_settings",
         ],
-        "nn": [
-            # Is now skipped.. on pytorch side
-            # RuntimeError: miopenStatusUnknownError
-            # MIOpen(HIP): Warning [BuildHip] In file included from /tmp/comgr-f75870/input/MIOpenDropoutHIP.cpp:32:
-            # /tmp/comgr-f75870/include/miopen_rocrand.hpp:45:10: fatal error: 'rocrand/rocrand_xorwow.h' file not found
-            # 45 | #include <rocrand/rocrand_xorwow.h>
-            #     |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
-            "test_cudnn_rnn_dropout_states_device",
-        ],
         "torch": [
             "test_terminate_handler_on_crash",  # flaky !! hangs forever or works... can need up to 30 sec to pass
             "test_cpp_warnings_have_python_context_cuda",

--- a/external-builds/pytorch/skip_tests/pytorch_2.9.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.9.py
@@ -106,15 +106,6 @@ skip_tests = {
             "test_cublas_allow_fp16_reduced_precision_reduction_get_set",
             "test_allocator_settings",
         ],
-        "nn": [
-            # Is now skipped.. on pytorch side
-            # RuntimeError: miopenStatusUnknownError
-            # MIOpen(HIP): Warning [BuildHip] In file included from /tmp/comgr-f75870/input/MIOpenDropoutHIP.cpp:32:
-            # /tmp/comgr-f75870/include/miopen_rocrand.hpp:45:10: fatal error: 'rocrand/rocrand_xorwow.h' file not found
-            # 45 | #include <rocrand/rocrand_xorwow.h>
-            #     |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
-            "test_cudnn_rnn_dropout_states_device",
-        ],
         "torch": [
             "test_terminate_handler_on_crash",  # flaky !! hangs forever or works... can need up to 30 sec to pass
         ],


### PR DESCRIPTION
Original issue: https://github.com/ROCm/TheRock/issues/2120
Fix: https://github.com/ROCm/rocm-libraries/pull/4007

## Motivation

Enable pytorch testcases which were skipped due to miopen's compilation issue -> https://github.com/ROCm/TheRock/issues/2120

## Technical Details

Remove from lists for skip

## Test Plan

`PYTORCH_TEST_WITH_ROCM=1 python test/test_nn.py TestNN.test_cudnn_rnn_dropout_states_device`

## Test Result
```
(therock_venv) root@RSB-RORLAB-17-L:~/test_therock/pytorch# PYTORCH_TEST_WITH_ROCM=1 python test/test_nn.py TestNN.test_cudnn_rnn_dropout_states_device
.
----------------------------------------------------------------------
Ran 1 test in 0.655s

OK
```
Compilation log: 
[compile.log](https://github.com/user-attachments/files/25233790/compile.log)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
