### PR TITLE
Add details about apex in releases document

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -280,8 +280,7 @@ also install `torch`, `torchaudio`, `torchvision`, and `apex`.
 >   - [Installing previous versions of PyTorch](https://pytorch.org/get-started/previous-versions/)
 >   - [torchvision installation - compatibility matrix](https://github.com/pytorch/vision?tab=readme-ov-file#installation)
 >   - [torchaudio installation - compatibility matrix](https://docs.pytorch.org/audio/main/installation.html#compatibility-matrix)
->
-> - [apex installation - compatibility matrix](https://github.com/ROCm/apex/tree/master?tab=readme-ov-file#supported-versions)
+>   - [apex installation - compatibility matrix](https://github.com/ROCm/apex/tree/master?tab=readme-ov-file#supported-versions)
 
 > [!WARNING]
 > The `torch` packages depend on `rocm[libraries]`, so the compatible ROCm packages


### PR DESCRIPTION
## Motivation

Apex building has been enabled in nightly releases - https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/apex/.
RELEASES.md is updated to include instruction regarding installing apex from nightlies.

[apex-1.11.0+rocm7.12.0a20260211-cp311-cp311-linux_x86_64.whl](https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/apex-1.11.0%2Brocm7.12.0a20260211-cp311-cp311-linux_x86_64.whl)
[apex-1.11.0+rocm7.12.0a20260211-cp312-cp312-linux_x86_64.whl](https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/apex-1.11.0%2Brocm7.12.0a20260211-cp312-cp312-linux_x86_64.whl)
[apex-1.11.0+rocm7.12.0a20260211-cp313-cp313-linux_x86_64.whl](https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/apex-1.11.0%2Brocm7.12.0a20260211-cp313-cp313-linux_x86_64.whl)
[apex-1.7.0+rocm7.12.0a20260211-cp311-cp311-linux_x86_64.whl](https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/apex-1.7.0%2Brocm7.12.0a20260211-cp311-cp311-linux_x86_64.whl)
[apex-1.7.0+rocm7.12.0a20260211-cp312-cp312-linux_x86_64.whl](https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/apex-1.7.0%2Brocm7.12.0a20260211-cp312-cp312-linux_x86_64.whl)
[apex-1.7.0+rocm7.12.0a20260211-cp313-cp313-linux_x86_64.whl](https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/apex-1.7.0%2Brocm7.12.0a20260211-cp313-cp313-linux_x86_64.whl)
[apex-1.8.0+rocm7.12.0a20260211-cp311-cp311-linux_x86_64.whl](https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/apex-1.8.0%2Brocm7.12.0a20260211-cp311-cp311-linux_x86_64.whl)
[apex-1.8.0+rocm7.12.0a20260211-cp312-cp312-linux_x86_64.whl](https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/apex-1.8.0%2Brocm7.12.0a20260211-cp312-cp312-linux_x86_64.whl)
[apex-1.8.0+rocm7.12.0a20260211-cp313-cp313-linux_x86_64.whl](https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/apex-1.8.0%2Brocm7.12.0a20260211-cp313-cp313-linux_x86_64.whl)
[apex-1.9.0+rocm7.12.0a20260211-cp311-cp311-linux_x86_64.whl](https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/apex-1.9.0%2Brocm7.12.0a20260211-cp311-cp311-linux_x86_64.whl)
[apex-1.9.0+rocm7.12.0a20260211-cp312-cp312-linux_x86_64.whl](https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/apex-1.9.0%2Brocm7.12.0a20260211-cp312-cp312-linux_x86_64.whl)
[apex-1.9.0+rocm7.12.0a20260211-cp313-cp313-linux_x86_64.whl](https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/apex-1.9.0%2Brocm7.12.0a20260211-cp313-cp313-linux_x86_64.whl)

## Technical Details

- Add pip install instruction for linux. 
- Add information about compatibility with torch.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
