### PR TITLE
Fix: Add missing backslash (\) in workflow

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -310,7 +310,7 @@ jobs:
             --include "torch-${TORCH_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
             --include "torchaudio-${TORCHAUDIO_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
             --include "torchvision-${TORCHVISION_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
-            --include "triton-${TRITON_VERSION}-${CP_VERSION}-linux_x86_64.whl"
+            --include "triton-${TRITON_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
             --include "apex-${APEX_VERSION}-${CP_VERSION}-linux_x86_64.whl"
 
       - name: (Re-)Generate Python package release index


### PR DESCRIPTION
## Motivation

This PR fixes a missing backslash (\\) in the workflow configuration that was causing file upload failures to the S3 bucket.
bug introduced here: https://github.com/ROCm/TheRock/pull/2280/changes#r2793460592

## File changed
 - `.github/workflows/build_portable_linux_pytorch_wheels.yml`

## Technical Details

- Added the missing backslash (\\) in the affected workflow file.

## Test Plan

- https://github.com/ROCm/TheRock/actions/runs/21912800899

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
