### PR TITLE
Fix incorrect prefix when uploading release packages

### DIFF
--- a/build_tools/packaging/upload_release_packages.py
+++ b/build_tools/packaging/upload_release_packages.py
@@ -292,9 +292,9 @@ Safety Features:
 
     if args.use_release_buckets:
         args.bucket = "therock-release-python"
-        args.bucket_prefix = "v3/whl/"
+        args.bucket_prefix = "v3/rocm/whl/"
         args.tarball_bucket = "therock-release-tarball"
-        args.tarball_bucket_prefix = "v3/tarball/"
+        args.tarball_bucket_prefix = "v3/rocm/tarball/"
 
     # Validate input directory
     if not args.input_dir.exists():


### PR DESCRIPTION
Releases are hosted under prefix `v3/rocm/<...>` and not `v3/<...>` like prereleases. So fix it to use the correct prefix for releases.