### PR TITLE
ncurses: build without Ada bindings to fix gcc 15

### DIFF
--- a/third-party/sysdeps/common/ncurses/CMakeLists.txt
+++ b/third-party/sysdeps/common/ncurses/CMakeLists.txt
@@ -123,6 +123,7 @@ add_custom_target(
     "${SOURCE_DIR}/configure"
       --prefix "${CMAKE_INSTALL_PREFIX}"
       --with-shared
+      --without-ada
       --enable-widec
       --enable-pc-files
       # Without this, it will attempt to install pcfiles in the path reported


### PR DESCRIPTION
Build ncurses using `--without-ada`

## Motivation

* Fix ncurses build failure on systems with the GNAT Ada compiler from gcc 15 installed.
* This PR was split from #3253 

## Technical Details

* Nothing in TheRock uses Ada. Let alone the ncurses bindings.
* Both  Fedora and Ubuntu build ncurses with `--without-ada`

## Test Result

Tested that ncurses builds successfully with this change on Fedora

