### PR TITLE
Pass THEROCK_SHARED_PYTHON_EXECUTABLES in linux_portable_build contai…

### DIFF
--- a/build_tools/detail/linux_portable_build_in_container.sh
+++ b/build_tools/detail/linux_portable_build_in_container.sh
@@ -31,10 +31,12 @@ else
   export CMAKE_CXX_COMPILER_LAUNCHER=ccache
 fi
 
-# Build manylinux Python executables argument if MANYLINUX is set
+# Build manylinux Python executables and Python shared executables argument if MANYLINUX is set
 PYTHON_EXECUTABLES_ARG=""
+PYTHON_SHARED_EXECUTABLES_ARG=""
 if [ "${MANYLINUX}" = "1" ] || [ "${MANYLINUX}" = "true" ]; then
   PYTHON_EXECUTABLES_ARG="-DTHEROCK_DIST_PYTHON_EXECUTABLES=/opt/python/cp38-cp38/bin/python;/opt/python/cp39-cp39/bin/python;/opt/python/cp310-cp310/bin/python;/opt/python/cp311-cp311/bin/python;/opt/python/cp312-cp312/bin/python;/opt/python/cp313-cp313/bin/python"
+  PYTHON_SHARED_EXECUTABLES_ARG="-DTHEROCK_SHARED_PYTHON_EXECUTABLES=/opt/python-shared/cp310-cp310/bin/python3;/opt/python-shared/cp311-cp311/bin/python3;/opt/python-shared/cp312-cp312/bin/python3;/opt/python-shared/cp313-cp313/bin/python3;/opt/python-shared/cp314-cp314/bin/python3"
 fi
 
 set -o xtrace
@@ -42,5 +44,6 @@ time cmake -GNinja -S /therock/src -B "$OUTPUT_DIR/build" \
   -DTHEROCK_BUNDLE_SYSDEPS=ON \
   -DTHEROCK_ENABLE_SYSDEPS_AMD_MESA=ON \
   ${PYTHON_EXECUTABLES_ARG} \
+  ${PYTHON_SHARED_EXECUTABLES_ARG} \
   "$@"
 time cmake --build "$OUTPUT_DIR/build" --target therock-archives therock-dist


### PR DESCRIPTION
Update the portable manylinux container build script to pass -DTHEROCK_SHARED_PYTHON_EXECUTABLES=... (in addition to THEROCK_DIST_PYTHON_EXECUTABLES) when MANYLINUX is enabled. This allows TheRock’s rocgdb subproject to detect shared-libpython interpreters under /opt/python-shared and build Python-enabled rocgdb-pyX.Y variants instead of only the pythonless rocgdb-pynone in release_portable_linux_packages CI runs.