### PR TITLE
Use manylinux image with sccache for Linux PyTorch wheel builds

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -103,7 +103,7 @@ jobs:
     name: Build | ${{ inputs.amdgpu_family }} | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_git_ref }}
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:db2b63f938941dde2abc80b734e64b45b9995a282896d513a0f3525d4591d6cb
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858
     env:
       OUTPUT_DIR: ${{ github.workspace }}/output
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist


### PR DESCRIPTION
## Motivation 

https://github.com/ROCm/TheRock/pull/3171#discussion_r2790320904
Use the manylinux image that includes sccache for the Linux PyTorch wheel workflow so future PRs can enable sccache without changing the image. This PR only updates the workflow’s container image; it does not add sccache usage (no `cache_type`, env, or `--use-sccache`).

## Technical Details

- **Updated:** [`.github/workflows/build_portable_linux_pytorch_wheels.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/build_portable_linux_pytorch_wheels.yml)  
  - Set job `container.image` to the manylinux image that includes sccache (from [PR #3369](https://github.com/ROCm/TheRock/pull/3369)).
  - **Image:** `ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858`
  - SHA source: [package page – `latest` tag](https://github.com/ROCm/TheRock/pkgs/container/therock_build_manylinux_x86_64) (digest shown for the tag).
  - Publish run that built this image: [Publish build_manylinux_x86_64 images #131](https://github.com/ROCm/TheRock/actions/runs/21908246353/job/63254367168).

## Test Result
https://github.com/ROCm/TheRock/actions/runs/21940290973

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.