### PR TITLE
Allow building tensilelite-client from TheRock

### DIFF
--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -139,6 +139,7 @@ therock_cmake_subproject_declare(hipBLASLt
   BUILD_DEPS
     hipBLAS-common
     rocm-cmake
+    therock-boost
     therock-googletest
     therock-msgpack-cxx
     ${hipBLASLt_rocRoller_build_deps}
@@ -315,6 +316,7 @@ if(THEROCK_ENABLE_SPARSE)
         rocm-cmake
         hipSPARSE
         rocSPARSE
+        therock-boost
         therock-googletest
         therock-msgpack-cxx
       RUNTIME_DEPS

--- a/third-party/boost/CMakeLists.txt
+++ b/third-party/boost/CMakeLists.txt
@@ -3,6 +3,7 @@
 #   atomic
 #   filesystem
 #   multi_index
+#   program_options
 #   system
 #   Static libraries only
 #   Release build
@@ -29,7 +30,7 @@ therock_cmake_subproject_declare(therock-boost
   OUTPUT_ON_FAILURE
   CMAKE_ARGS
     "-DBOOST_SOURCE_DIR=${_source_dir}"
-    "-DTHEROCK_BOOST_LIBRARIES=atomic,filesystem,multi_index,system"
+    "-DTHEROCK_BOOST_LIBRARIES=atomic,filesystem,multi_index,program_options,system"
   EXTRA_DEPENDS
     "${_download_stamp}"
 )
@@ -43,6 +44,7 @@ therock_cmake_subproject_provide_package(therock-boost Boost "lib/cmake/Boost-${
 therock_cmake_subproject_provide_package(therock-boost boost_atomic "lib/cmake/boost_atomic-${_boost_version}")
 therock_cmake_subproject_provide_package(therock-boost boost_filesystem "lib/cmake/boost_filesystem-${_boost_version}")
 therock_cmake_subproject_provide_package(therock-boost boost_headers "lib/cmake/boost_headers-${_boost_version}")
+therock_cmake_subproject_provide_package(therock-boost boost_program_options "lib/cmake/boost_program_options-${_boost_version}")
 therock_cmake_subproject_provide_package(therock-boost boost_system "lib/cmake/boost_system-${_boost_version}")
 therock_cmake_subproject_activate(therock-boost)
 


### PR DESCRIPTION
## Motivation

Needed to build tensilite-client to do tuning on a specific architecture and iterate over a few changes to the source code. When trying to enable the binary like so:

``` diff
diff --git a/projects/hipblaslt/CMakeLists.txt b/projects/hipblaslt/CMakeLists.txt
index 55b2c0e0c8..bbcd41a5c6 100644
--- a/projects/hipblaslt/CMakeLists.txt
+++ b/projects/hipblaslt/CMakeLists.txt
@@ -59,7 +59,7 @@ option(HIPBLASLT_ENABLE_THEROCK "Build hipBLASLt for TheRock." OFF)
 
 option(TENSILELITE_ENABLE_HOST "Build the tensilelite host library." ON)
 option(TENSILELITE_BUILD_TESTING "Build client when building tests" OFF)
-option(TENSILELITE_ENABLE_CLIENT "Build tensilelite client" ${TENSILELITE_BUILD_TESTING})
+option(TENSILELITE_ENABLE_CLIENT "Build tensilelite client" ON)
 option(TENSILELITE_ENABLE_AUTOBUILD "Generate scripts for wrapping tensile python scripts" OFF)
 
 if(HIPBLASLT_ENABLE_CLIENT)
```

Found several problems that I fix in this PR.

## Technical Details

Also add program_options boost package and add therock-boost dependency to hipBLASLt and hipSPARSELt.

## Test Plan

Build needs to pass.

## Test Result

Build passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
