### PR TITLE
[docs] Update `test_environment_reproduction.md` to actually reflect test repro in CI

### DIFF
--- a/docs/development/test_environment_reproduction.md
+++ b/docs/development/test_environment_reproduction.md
@@ -14,7 +14,7 @@ $ docker run -i \
     -t ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98 /bin/bash
 $ curl -LsSf https://astral.sh/uv/install.sh | bash && source $HOME/.local/bin/env
 $ git clone https://github.com/ROCm/TheRock.git && cd TheRock
-$ python3 build_tools/setup_venv.py .venv --use-uv && source .venv/bin/activate
+$ uv venv .venv && source .venv/bin/activate
 $ uv pip install -r requirements-test.txt
 $ GITHUB_REPOSITORY={GITHUB_REPO} python build_tools/install_rocm_from_artifacts.py --run-id {CI_RUN_ID} --amdgpu-family {GPU_FAMILY} --tests
 $ export THEROCK_BIN_DIR=./therock-build/bin


### PR DESCRIPTION
Updating `test_environment_reproduction.md` to reflect current CI state! this will help developers debug properly in a CI-esque environment

Test done locally:

```
geom@geom:~/Code/rocm-libraries$ docker run -i     -t ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98 /bin/bash
tester@d382b536a7c3:~$  curl -LsSf https://astral.sh/uv/install.sh | bash && source $HOME/.local/bin/env
downloading uv 0.10.2 x86_64-unknown-linux-gnu
no checksums to verify
installing to /home/tester/.local/bin
  uv
  uvx
everything's installed!

To add $HOME/.local/bin to your PATH, either restart your shell or run:

    source $HOME/.local/bin/env (sh, bash, zsh)
    source $HOME/.local/bin/env.fish (fish)
tester@d382b536a7c3:~$ git clone https://github.com/ROCm/TheRock.git && cd TheRock
Cloning into 'TheRock'...
remote: Enumerating objects: 32908, done.
remote: Counting objects: 100% (1805/1805), done.
remote: Compressing objects: 100% (904/904), done.
remote: Total 32908 (delta 1519), reused 949 (delta 895), pack-reused 31103 (from 3)
Receiving objects: 100% (32908/32908), 12.31 MiB | 3.85 MiB/s, done.
Resolving deltas: 100% (22317/22317), done.
tester@d382b536a7c3:~/TheRock$ uv venv .venv && source .venv/bin/activate
Using CPython 3.12.3 interpreter at: /usr/bin/python3
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
(.venv) tester@d382b536a7c3:~/TheRock$ uv pip install -r requirements-test.txt
Resolved 34 packages in 799ms
Prepared 34 packages in 6.92s
Installed 34 packages in 266ms
 + attrs==25.4.0
 + backports-zstd==1.3.0
 + boto3==1.39.15
 + botocore==1.39.17
 + certifi==2026.1.4
 + charset-normalizer==3.4.4
 + coverage==7.13.4
 + idna==3.11
 + iniconfig==2.3.0
 + jmespath==1.1.0
 + jsonschema==4.23.0
 + jsonschema-specifications==2025.9.1
 + lit==18.1.8
 + packaging==25.0
 + pluggy==1.6.0
 + prettytable==3.12.0
 + psutil==7.1.3
 + pytest==8.3.5
 + pytest-check==2.5.3
 + pytest-cov==6.0.0
 + pytest-timeout==2.4.0
 + python-dateutil==2.9.0.post0
 + pyyaml==6.0.2
 + pyzstd==0.19.1
 + referencing==0.37.0
 + requests==2.32.4
 + rpds-py==0.30.0
 + s3transfer==0.13.1
 + sccache==0.10.0
 + six==1.17.0
 + tabulate==0.9.0
 + typing-extensions==4.15.0
 + urllib3==2.6.3
(.venv) tester@d382b536a7c3:~/TheRock$ python build_tools/install_rocm_from_artifacts.py --run-id 21931913831 --amdgpu-family gfx94X-dcgpu --base-only(.venv) tester@d382b536a7c3:~/TheRock$ python build_tools/install_rocm_from_artifacts.py --run-id 21931913831 (.venv) tester@d382b536a7c3:~/TheRock$ python build_tools/install_rocm_from_artifacts.py --run-id 21931913(.venv) tester@d382b536a7c3:~/TheRock$ python build_tools/install_(.venv) tester@d382b536a7c3:~/TheRock$ python build_tools/install_rocm_from_artifacts.py --run-id 2193191383
1 --amdgpu-family gfx94X-dcgpu --base-only^C
(.venv) tester@d382b536a7c3:~/TheRock$ python build_tools/install_rocm_from_artifacts.py --run-id 21931913831 --amdgpu-family gfx94X-dcgpu --base-only
### Installing TheRock using artifacts ###
Creating output directory '/home/tester/TheRock/therock-build'
Created output directory '/home/tester/TheRock/therock-build'
Retrieving artifacts for run ID 21931913831

Calling fetch_artifacts_main with args:
  --run-id 21931913831 --artifact-group gfx94X-dcgpu --output-dir therock-build --flatten core-hipinfo_run core-runtime_run core-runtime_lib sysdeps_lib base_run base_lib amd-llvm_run amd-llvm_lib core-amdsmi_run core-amdsmi_lib core-hip_lib core-hip_dev core-ocl_lib core-ocl_dev rocprofiler-sdk_lib host-suite-sparse_lib

Retrieving bucket info...
  (implicit) github_repository: ROCm/TheRock
Warning: No GitHub auth available, requests may be rate limited
  workflow_run_id             : 21931913831
  head_github_repository      : ROCm/TheRock
  is_pr_from_fork             : False
Retrieved bucket info:
  external_repo:
  bucket       : therock-ci-artifacts
Retrieving artifacts from 's3://therock-ci-artifacts/21931913831-linux'



Filtered artifacts to download:
  s3://therock-ci-artifacts/21931913831-linux/amd-llvm_lib_generic.tar.xz
  s3://therock-ci-artifacts/21931913831-linux/amd-llvm_run_generic.tar.xz
  s3://therock-ci-artifacts/21931913831-linux/base_lib_generic.tar.xz
  s3://therock-ci-artifacts/21931913831-linux/base_run_generic.tar.xz
  s3://therock-ci-artifacts/21931913831-linux/core-amdsmi_lib_generic.tar.xz
  s3://therock-ci-artifacts/21931913831-linux/core-amdsmi_run_generic.tar.xz
  s3://therock-ci-artifacts/21931913831-linux/core-hip_dev_generic.tar.xz
  s3://therock-ci-artifacts/21931913831-linux/core-hip_lib_generic.tar.xz
  s3://therock-ci-artifacts/21931913831-linux/core-ocl_dev_generic.tar.xz
  s3://therock-ci-artifacts/21931913831-linux/core-ocl_lib_generic.tar.xz
  s3://therock-ci-artifacts/21931913831-linux/core-runtime_lib_generic.tar.xz
  s3://therock-ci-artifacts/21931913831-linux/core-runtime_run_generic.tar.xz
  s3://therock-ci-artifacts/21931913831-linux/host-suite-sparse_lib_generic.tar.xz
  s3://therock-ci-artifacts/21931913831-linux/rocprofiler-sdk_lib_generic.tar.xz
  s3://therock-ci-artifacts/21931913831-linux/sysdeps_lib_generic.tar.xz

  ++ Downloading amd-llvm_lib_generic.tar.xz
  ++ Downloading amd-llvm_run_generic.tar.xz
  ++ Downloading base_lib_generic.tar.xz
  ++ Downloading base_run_generic.tar.xz
  ++ Downloading core-amdsmi_run_generic.tar.xz
  ++ Downloading core-amdsmi_lib_generic.tar.xz
  ++ Downloading core-hip_dev_generic.tar.xz
  ++ Downloading core-hip_lib_generic.tar.xz
  ++ Downloading core-ocl_dev_generic.tar.xz
  ++ Downloading core-ocl_lib_generic.tar.xz
  ++ Downloading core-runtime_lib_generic.tar.xz
```