### PR TITLE
[ci] `setup_test_environment.yml` s3 removal as no longer used

### DIFF
--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -53,6 +53,12 @@ runs:
         uv pip install -r requirements-test.txt
         uv pip freeze
 
+    - name: Install Choco tools
+      if: ${{ runner.os == 'Windows' }}
+      shell: bash
+      run: |
+        choco install --no-progress -y ninja
+
     - name: Download and Unpack Artifacts
       shell: bash
       env:


### PR DESCRIPTION
Noticed that we still install s3 even though boto3 is the tool used for package retrieval! Saves some time in environment setup, so we are removing s3 installs as it is no longer needed

Succcesful linux test: https://github.com/ROCm/TheRock/actions/runs/21956437410/job/63421818744
Successful windows test: https://github.com/ROCm/TheRock/actions/runs/21956437410/job/63421820914

As this does not require build and the above tests is sufficient for testing, I added `skip-ci` label