### PR TITLE
[CI] Fix GITHUB_PATH prepends in Windows workflows

### DIFF
--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -95,10 +95,10 @@ jobs:
           # https://github.com/ninja-build/ninja/issues/2616
           choco install --no-progress -y ninja --version 1.12.1
           choco install --no-progress -y strawberryperl
-          echo "$PATH;C:\Strawberry\c\bin" >> $GITHUB_PATH
+          echo "C:\Strawberry\c\bin" >> $GITHUB_PATH
           choco install --no-progress -y awscli
           choco install --no-progress -y pkgconfiglite
-          echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
+          echo "C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
 
       - uses: iterative/setup-dvc@4bdfd2b0f6f1ad7e08afadb03b1a895c352a5239 # v2.0.0
         with:

--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -70,7 +70,7 @@ jobs:
           choco source disable -n=chocolatey
           choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
           choco install --no-progress -y awscli
-          echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
+          echo "C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
 
       - name: Fetch artifacts
         run: |

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           choco install --no-progress -y ninja --version 1.13.1
           choco install --no-progress -y awscli
-          echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
+          echo "C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
 
       # After other installs, so MSVC get priority in the PATH.
       - name: Configure MSVC

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -191,10 +191,10 @@ jobs:
           # https://github.com/ninja-build/ninja/issues/2616
           choco install --no-progress -y ninja --version 1.12.1
           choco install --no-progress -y strawberryperl
-          echo "$PATH;C:\Strawberry\c\bin" >> $GITHUB_PATH
+          echo "C:\Strawberry\c\bin" >> $GITHUB_PATH
           choco install --no-progress -y awscli
           choco install --no-progress -y pkgconfiglite
-          echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
+          echo "C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
 
       - uses: iterative/setup-dvc@4bdfd2b0f6f1ad7e08afadb03b1a895c352a5239 # v2.0.0
         with:


### PR DESCRIPTION
## Motivation

These was needlessly prepending the existing `$PATH` variable (which I believe then gets de-dup'd internally).

## Technical Details

Docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#adding-a-system-path

## Test Plan

CI workflows only (not triggering release builds for this)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
