### PR TITLE
[CI] Move Windows CMake options from build_configure.py to CMake preset

### DIFF
--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -229,6 +229,7 @@ jobs:
 
       - name: Configure Projects
         env:
+          cmake_preset: windows-release
           amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
           package_version: "ADHOCBUILD"
           extra_cmake_options: ${{ inputs.extra_cmake_options }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -118,7 +118,8 @@
       },
       "cacheVariables": {
         "CMAKE_C_COMPILER": "cl.exe",
-        "CMAKE_CXX_COMPILER": "cl.exe"
+        "CMAKE_CXX_COMPILER": "cl.exe",
+        "CMAKE_LINKER": "link.exe"
       },
       "condition": {
         "type": "equals",

--- a/build_tools/github_actions/build_configure.py
+++ b/build_tools/github_actions/build_configure.py
@@ -35,7 +35,6 @@ amdgpu_families = os.getenv("amdgpu_families")
 package_version = os.getenv("package_version")
 extra_cmake_options = os.getenv("extra_cmake_options")
 build_dir = os.getenv("BUILD_DIR")
-vctools_install_dir = os.getenv("VCToolsInstallDir")
 github_workspace = os.getenv("GITHUB_WORKSPACE")
 extra_c_compiler_launcher = os.getenv("EXTRA_C_COMPILER_LAUNCHER", "")
 extra_cxx_compiler_launcher = os.getenv("EXTRA_CXX_COMPILER_LAUNCHER", "")
@@ -77,9 +76,6 @@ def build_compiler_launcher(
 
 platform_options = {
     "windows": [
-        f"-DCMAKE_C_COMPILER={vctools_install_dir}/bin/Hostx64/x64/cl.exe",
-        f"-DCMAKE_CXX_COMPILER={vctools_install_dir}/bin/Hostx64/x64/cl.exe",
-        f"-DCMAKE_LINKER={vctools_install_dir}/bin/Hostx64/x64/link.exe",
         "-DTHEROCK_BACKGROUND_BUILD_JOBS=4",
     ],
 }
@@ -135,13 +131,6 @@ def build_configure(manylinux=False):
             "/opt/python-shared/cp314-cp314/bin/python3"
         )
         cmd.append(f"-DTHEROCK_SHARED_PYTHON_EXECUTABLES={python_shared_executables}")
-
-    if PLATFORM == "windows":
-        # VCToolsInstallDir is required for build. Throwing an error if environment variable doesn't exist
-        if not vctools_install_dir:
-            raise Exception(
-                "Environment variable VCToolsInstallDir is not set. Please see https://github.com/ROCm/TheRock/blob/main/docs/development/windows_support.md#important-tool-settings about Windows tool configurations. Exiting."
-            )
 
     # Splitting cmake options into an array (ex: "-flag X" -> ["-flag", "X"]) for subprocess.run
     cmake_options_arr = extra_cmake_options.split()

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -200,8 +200,11 @@ If you prefer to install tools manually, you will need:
 >   running `vcvars64.bat` in an existing shell.
 > - If you build from an editor like VSCode, CMake can discover the compiler
 >   among other "kits".
+> - Our `windows-base` or `windows-release` presets in
+>   [CMakePresets.json](/CMakePresets.json) set the CMake compiler and linker
+>   for you.
 > - You can also tell CMake to use MSVC's tools explicitly with
->   `-DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_LINKER=link.exe`
+>   `-DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_LINKER=link.exe`.
 
 ### Set the locale
 


### PR DESCRIPTION
## Motivation

For multi-arch CI (https://github.com/ROCm/TheRock/issues/3325), we use [`build_tools/configure_stage.py`](https://github.com/ROCm/TheRock/blob/main/build_tools/configure_stage.py) instead of [`build_tools/github_actions/build_configure.py`](https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/build_configure.py). Rather than copy this `-DCMAKE_C_COMPILER` setting code to that file, I think we can just rely on the CMake preset that is already set here: https://github.com/ROCm/TheRock/blob/fc87910158c6bc456ae5b0da1fd836b8c3c6e039/build_tools/github_actions/amdgpu_family_matrix.py#L47-L53 https://github.com/ROCm/TheRock/blob/fc87910158c6bc456ae5b0da1fd836b8c3c6e039/.github/workflows/build_windows_artifacts.yml#L134-L143

## Technical Details

The configure script used a fully resolved path while the preset uses just a tool name. This hopes that the tool name on its own is sufficient (it should be, based on my testing).

## Test Plan

* CI for the CI workflow
* Hope for the release workflow (revert if it breaks)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
