### PR TITLE
Add INTERFACE_INCLUDE_DIRS for amd-mesa/libdrm

### DIFF
--- a/third-party/sysdeps/linux/amd-mesa/CMakeLists.txt
+++ b/third-party/sysdeps/linux/amd-mesa/CMakeLists.txt
@@ -18,6 +18,8 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
         therock-libdrm
       INSTALL_DESTINATION
         lib/rocm_sysdeps
+      INTERFACE_INCLUDE_DIRS
+        lib/rocm_sysdeps/include
       INTERFACE_LINK_DIRS
         lib/rocm_sysdeps/lib
       INTERFACE_INSTALL_RPATH_DIRS

--- a/third-party/sysdeps/linux/libdrm/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libdrm/CMakeLists.txt
@@ -27,6 +27,8 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
         "-DPython3_EXECUTABLE=${Python3_EXECUTABLE}"
       INSTALL_DESTINATION
         lib/rocm_sysdeps
+      INTERFACE_INCLUDE_DIRS
+        lib/rocm_sysdeps/include
       INTERFACE_LINK_DIRS
         lib/rocm_sysdeps/lib
       INTERFACE_INSTALL_RPATH_DIRS


### PR DESCRIPTION
## Motivation

This PR defines INTERFACE_INCLUDE_DIRS for amd-mesa and libdrm, enabling other projects like Media to locate libva and libdrm headers during build with TheRock.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
