### PR TITLE
Correct `gfx1201X` to `gfx120X` in CI workflow descriptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ on:
     inputs:
       linux_amdgpu_families:
         type: string
-        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx1201X"
+        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx120X"
         default: ""
       linux_test_labels:
         type: string
@@ -34,7 +34,7 @@ on:
         description: "If enabled, the CI will pull Linux artifacts using artifact_run_id and only run tests"
       windows_amdgpu_families:
         type: string
-        description: "Insert comma-separated list of Windows GPU families to build and test. ex: gfx94X, gfx1201X"
+        description: "Insert comma-separated list of Windows GPU families to build and test. ex: gfx94X, gfx120X"
         default: ""
       windows_test_labels:
         type: string

--- a/.github/workflows/ci_asan.yml
+++ b/.github/workflows/ci_asan.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       linux_amdgpu_families:
         type: string
-        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx1201X"
+        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx120X"
         default: ""
       linux_use_prebuilt_artifacts:
         type: boolean

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -14,7 +14,7 @@ on:
     inputs:
       linux_amdgpu_families:
         type: string
-        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx1201X"
+        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx120X"
         default: ""
       linux_test_labels:
         type: string
@@ -25,7 +25,7 @@ on:
         description: "If enabled, the CI will pull Linux artifacts using artifact_run_id and only run tests"
       windows_amdgpu_families:
         type: string
-        description: "Insert comma-separated list of Windows GPU families to build and test. ex: gfx94X, gfx1201X"
+        description: "Insert comma-separated list of Windows GPU families to build and test. ex: gfx94X, gfx120X"
         default: ""
       windows_test_labels:
         type: string

--- a/.github/workflows/ci_tsan.yml
+++ b/.github/workflows/ci_tsan.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       linux_amdgpu_families:
         type: string
-        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx1201X"
+        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx120X"
         default: ""
       linux_use_prebuilt_artifacts:
         type: boolean

--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -16,7 +16,7 @@ on:
     inputs:
       linux_amdgpu_families:
         type: string
-        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx1201X"
+        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx120X"
         default: ""
       linux_test_labels:
         type: string
@@ -27,7 +27,7 @@ on:
         description: "If enabled, the CI will pull Linux artifacts using artifact_run_id and only run tests"
       windows_amdgpu_families:
         type: string
-        description: "Insert comma-separated list of Windows GPU families to build and test. ex: gfx94X, gfx1201X"
+        description: "Insert comma-separated list of Windows GPU families to build and test. ex: gfx94X, gfx120X"
         default: ""
       windows_test_labels:
         type: string


### PR DESCRIPTION
## Motivation

Fixes the example in CI workflow files so the GPU family description is accurate.
Resolves https://github.com/ROCm/TheRock/issues/2559.

## Technical Details

Replaced `gfx1201X` with `gfx120X` in all CI workflow YAML files under `.github/workflows/`. No other changes.

## Test Plan

No tests needed; only documentation/example text was updated.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
