### PR TITLE
Allow components to set container image and options on Linux

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -19,6 +19,10 @@ on:
         type: string
       component:
         type: string
+      default_container_image:
+        type: string
+        default: "ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98"
+
 
 permissions:
   contents: read
@@ -34,7 +38,13 @@ jobs:
     continue-on-error: ${{ fromJSON(inputs.component).expect_failure == true }}
     timeout-minutes: 210
     container:
-      image: ${{ inputs.platform == 'linux' && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98' || null }}
+      # If the component has specified an alternate image, honor that option.
+      # Otherwise use the default image.
+      image: >-
+        ${{ inputs.platform == 'linux' &&
+            (fromJSON(inputs.component).container_image || inputs.default_container_image)
+            || null
+        }}
       # --ulimit memlock=-1:-1 - Prevents memory allocation issues with ROCm inside container
       # --security-opt seccomp=unconfined - enables memory mapping, and is recommended for containers running in HPC environments
       # --env-file /etc/podinfo/gha-gpu-isolation-settings - Required for GPU isolation on OSSCI MIXXX runners
@@ -49,6 +59,7 @@ jobs:
         --security-opt seccomp=unconfined
         --env-file /etc/podinfo/gha-gpu-isolation-settings
         --user 0:0
+        ${{ fromJSON(inputs.component).container_options }}
     strategy:
       fail-fast: false
       matrix:

--- a/docs/development/adding_tests.md
+++ b/docs/development/adding_tests.md
@@ -57,13 +57,15 @@ In [`fetch_test_configurations.py`](../../build_tools/github_actions/fetch_test_
 }
 ```
 
-| Field Name          | Type   | Description                                                                                                                        |
-| ------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| job_name            | string | Name of the job                                                                                                                    |
-| fetch_artifact_args | string | Arguments for which artifacts for [`install_rocm_from_artifacts.py`](../../build_tools/install_rocm_from_artifacts.py) to retrieve |
-| timeout_minutes     | int    | The timeout (in minutes) for the test step                                                                                         |
-| test_script         | string | The path to the test script                                                                                                        |
-| platform            | array  | An array of platforms that the test can execute on, options are `linux` and `windows`                                              |
+| Field Name          | Type   | Platform | Description                                                                                                                        |
+| ------------------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| job_name            | string | Any      | Name of the job                                                                                                                    |
+| fetch_artifact_args | string | Any      | Arguments for which artifacts for [`install_rocm_from_artifacts.py`](../../build_tools/install_rocm_from_artifacts.py) to retrieve |
+| timeout_minutes     | int    | Any      | The timeout (in minutes) for the test step                                                                                         |
+| test_script         | string | Any      | The path to the test script                                                                                                        |
+| platform            | array  | Any      | An array of platforms that the test can execute on, options are `linux` and `windows`                                              |
+| container_image     | string | Linux    | The name of a container image to use for this component                                                                            |
+| container_options   | string | Linux    | Additional options to be passed when launching the container                                                                       |
 
 > [!NOTE]
 > When adding a new component to TheRock (typically a new .toml file), you may need to update `install_rocm_from_artifacts.py` to allow CI workflows and users to selectively install it.<br>


### PR DESCRIPTION
ROCgdb needs to specify its own image and options when docker launches a container image on Linux. So use this opportunity to provide a more general mechanism for components to specify their own container images and options.

- Adds a couple new Linux-specific fields for the components
  * container_image: String containing the container image to be used.
  * container_options: String containing additional options to pass when launching the container.
- Sets a default container image to be used by components that choose not to use a specific image.
- Adds documentation of the new component fields.