### PR TITLE
Add Apex to the Pytorch Manifest file

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -210,7 +210,8 @@ jobs:
             --pytorch-dir "external-builds/pytorch/pytorch" \
             --pytorch-audio-dir "external-builds/pytorch/pytorch_audio" \
             --pytorch-vision-dir "external-builds/pytorch/pytorch_vision" \
-            --triton-dir "external-builds/pytorch/triton"
+            --triton-dir "external-builds/pytorch/triton" \
+            --apex-dir "external-builds/pytorch/apex"
 
       - name: Configure AWS Credentials
         if: always()

--- a/build_tools/github_actions/tests/generate_pytorch_manifest_test.py
+++ b/build_tools/github_actions/tests/generate_pytorch_manifest_test.py
@@ -78,11 +78,13 @@ class GeneratePyTorchSourcesManifestTest(unittest.TestCase):
         audio_repo = self.tmp_path / "src_audio"
         vision_repo = self.tmp_path / "src_vision"
         triton_repo = self.tmp_path / "src_triton"
+        apex_repo = self.tmp_path / "src_apex"
 
         pytorch_head = "1111111111111111111111111111111111111111"
         audio_head = "2222222222222222222222222222222222222222"
         vision_head = "3333333333333333333333333333333333333333"
         triton_head = "4444444444444444444444444444444444444444"
+        apex_head = "5555555555555555555555555555555555555555"
 
         def fake_git_head(dirpath: Path, *, label: str) -> m.GitSourceInfo:
             p = dirpath.resolve()
@@ -101,6 +103,10 @@ class GeneratePyTorchSourcesManifestTest(unittest.TestCase):
             if p == triton_repo.resolve():
                 return m.GitSourceInfo(
                     commit=triton_head, repo="https://github.com/ROCm/triton.git"
+                )
+            if p == apex_repo.resolve():
+                return m.GitSourceInfo(
+                    commit=apex_head, repo="https://github.com/ROCm/apex.git"
                 )
             raise AssertionError(f"Unexpected repo path: {p}")
 
@@ -123,6 +129,8 @@ class GeneratePyTorchSourcesManifestTest(unittest.TestCase):
                     str(vision_repo),
                     "--triton-dir",
                     str(triton_repo),
+                    "--apex-dir",
+                    str(apex_repo),
                 ]
             )
 
@@ -133,7 +141,7 @@ class GeneratePyTorchSourcesManifestTest(unittest.TestCase):
 
         self.assertEqual(
             set(data.keys()),
-            {"pytorch", "pytorch_audio", "pytorch_vision", "triton", "therock"},
+            {"pytorch", "pytorch_audio", "pytorch_vision", "triton", "apex", "therock"},
         )
 
         self.assertEqual(data["pytorch"]["commit"], pytorch_head)
@@ -155,6 +163,10 @@ class GeneratePyTorchSourcesManifestTest(unittest.TestCase):
         self.assertEqual(data["triton"]["commit"], triton_head)
         self.assertEqual(data["triton"]["repo"], "https://github.com/ROCm/triton.git")
         self.assertNotIn("branch", data["triton"])
+
+        self.assertEqual(data["apex"]["commit"], apex_head)
+        self.assertEqual(data["apex"]["repo"], "https://github.com/ROCm/apex.git")
+        self.assertNotIn("branch", data["apex"])
 
         self.assertEqual(data["therock"]["repo"], "https://github.com/ROCm/TheRock.git")
         self.assertEqual(
@@ -219,6 +231,7 @@ class GeneratePyTorchSourcesManifestTest(unittest.TestCase):
         self.assertIn("pytorch_audio", data)
         self.assertIn("pytorch_vision", data)
         self.assertNotIn("triton", data)
+        self.assertNotIn("apex", data)
 
         self.assertEqual(data["pytorch"]["branch"], "nightly")
         self.assertNotIn("branch", data["pytorch_audio"])


### PR DESCRIPTION
## Motivation
Add Apex to the Pytorch Manifest file
Follow up PR for https://github.com/ROCm/TheRock/pull/2547

See the comment here: https://github.com/ROCm/TheRock/pull/2547#discussion_r2800994240

## Test Plan

Test on CI
## Test Result
The test runs: https://github.com/ROCm/TheRock/actions/runs/22070943413

Example Manifest from the test:
```
{
  "pytorch": {
    "commit": "f466ea7ac710374ce7066d9ead92e57dc42dc76f",
    "repo": "https://github.com/ROCm/pytorch.git",
    "branch": "release/2.7"
  },
  "pytorch_audio": {
    "commit": "95c61b4168fc5133be8dd8c1337d929d066ae6cf",
    "repo": "https://github.com/pytorch/audio"
  },
  "pytorch_vision": {
    "commit": "59a3e1f9f78cfe44cb989877cc6f4ea77c8a75ca",
    "repo": "https://github.com/pytorch/vision"
  },
  "triton": {
    "commit": "95abd4daa02d789ed257178ba35b4ef2d746ca29",
    "repo": "https://github.com/ROCm/triton.git"
  },
  "apex": {
    "commit": "7a57becffa31a4394369152e978fa6f8a0f005c2",
    "repo": "https://github.com/ROCm/apex"
  },
  "therock": {
    "commit": "02024427089134e951fe4063100b93c28e7e01a8",
    "repo": "https://github.com/ROCm/TheRock.git",
    "branch": "users/erman-gurses/add-apex-to-pytorch-manifest"
  }
}
```

Link: https://therock-dev-artifacts.s3.us-east-2.amazonaws.com/22070943413-linux/manifests/gfx94X-dcgpu/therock-manifest_torch_py3.10_release-2.7.json

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
