### PR TITLE
Update packaging: include libhipcxx in amdrocm-ccl-dev/devel and add rocwmma to amdrocm-math-common

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -870,6 +870,17 @@
             ]
           }
         ]
+      },
+      {
+        "Artifact": "libhipcxx",
+        "Artifact_Subdir": [
+          {
+            "Name": "libhipcxx",
+            "Components": [
+              "dev"
+            ]
+          }
+        ]
       }
     ],
 
@@ -1300,8 +1311,19 @@
             ]
           }
         ]
+      },
+      {
+        "Artifact": "rocwmma",
+        "Artifact_Gfxarch": "True",
+        "Artifact_Subdir": [
+          {
+            "Name": "rocWMMA",
+            "Components": [
+              "dev"
+            ]
+          }
+        ]
       }
-
     ],
 
     "Gfxarch": "False"


### PR DESCRIPTION
As per RFC0009-OS-Packaging-Requirements.md, libhipcxx must be included in
the amdrocm-ccl-dev/devel package, and rocwmma must be included in the
amdrocm-math-common package.

Updated package.json to incorporate these requirements and ensure the
correct components are delivered in their respective packages.

