### PR TITLE
[ci] Adding sandbox test runner for ASAN test runs

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -58,6 +58,8 @@ amdgpu_family_info_matrix_presubmit = {
     "gfx94x": {
         "linux": {
             "test-runs-on": "linux-mi325-1gpu-ossci-rocm",
+            # TODO(#3433): Remove sandbox label once ASAN tests are passing
+            "test-runs-on-sandbox": "linux-mi325-8gpu-ossci-rocm-sandbox",
             "test-runs-on-multi-gpu": "linux-mi325-8gpu-ossci-rocm",
             # TODO(#2754): Add new benchmark-runs-on runner for benchmarks
             "benchmark-runs-on": "linux-mi325-8gpu-ossci-rocm",

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -538,6 +538,14 @@ def matrix_generator(
                                 matrix_row["test-runs-on-multi-gpu"] = ""
                         break
 
+                # TODO(#3433): Remove sandbox logic once ASAN tests are passing and environment is no longer required
+                # To avoid impact on the production environment, we use the custom sandbox runners if this is an ASAN test run
+                if (
+                    "asan" in base_args.get("build_variant")
+                    and "test-runs-on-sandbox" in matrix_row
+                ):
+                    matrix_row["test-runs-on"] = matrix_row["test-runs-on-sandbox"]
+
                 matrix_output.append(matrix_row)
 
     print(f"Generated build matrix: {str(matrix_output)}")

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -636,6 +636,22 @@ class ConfigureCITest(unittest.TestCase):
         self.assertIn("linux-gfx110X-gpu-rocm-test", json.dumps(test_matrix))
         self.assertIn("windows-gfx110X-gpu-rocm-test", json.dumps(test_matrix))
 
+    # TODO(#3433): Remove sandbox logic once ASAN tests are passing and environment is no longer required
+    def test_sandbox_test_runner_with_asan(self):
+        base_args = {"build_variant": "asan"}
+        build_families = {"amdgpu_families": "gfx94X"}
+        linux_target_output, linux_test_labels = configure_ci.matrix_generator(
+            is_pull_request=True,
+            is_workflow_dispatch=False,
+            is_push=False,
+            is_schedule=False,
+            base_args=base_args,
+            families=build_families,
+            platform="linux",
+        )
+        entry = linux_target_output[0]
+        self.assertEqual(entry["test-runs-on"], "linux-mi325-8gpu-ossci-rocm-sandbox")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In order for ASAN tests to run on a sandbox environment to avoid production impacts, I am adding this custom logic specific to ASAN.

I will remove with #3433 once testing is complete 

Tests work here: https://github.com/ROCm/TheRock/actions/runs/22078431695 (cancelled to save resources)