### PR TITLE
Refactor multi-arch build workflow to eliminate duplication

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -51,738 +51,132 @@ on:
 permissions:
   contents: read
 
-env:
-  CONTAINER_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858
-  CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
-  CACHE_DIR: ${{ github.workspace }}/.container-cache
-  TEATIME_FORCE_INTERACTIVE: 0
 
 jobs:
   # ==========================================================================
   # STAGE: foundation (generic)
   # ==========================================================================
   foundation:
-    name: Stage - Foundation
-    # Always run all stages
-    runs-on: azure-linux-scale-rocm
-    timeout-minutes: 180  # 3 hours
+    uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+    secrets: inherit
+    with:
+      stage_name: foundation
+      stage_display_name: "Stage - Foundation"
+      timeout_minutes: 180  # 3 hours
+      dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
+      rocm_package_version: ${{ inputs.rocm_package_version }}
     permissions:
+      contents: read
       id-token: write
-    container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858
-      options: -v /runner/config:/home/awsconfig/
-    env:
-      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
-      STAGE_NAME: foundation
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install python deps
-        run: pip install -r requirements.txt
-
-      - name: Adjust git config
-        run: |
-          git config --global --add safe.directory $PWD
-          git config fetch.parallel 10
-
-      - name: Setup ccache
-        run: |
-          ./build_tools/setup_ccache.py \
-            --config-preset "github-oss-presubmit" \
-            --dir "$(dirname $CCACHE_CONFIGPATH)" \
-            --local-path "$CACHE_DIR/ccache"
-
-      - name: Runner health status
-        run: |
-          ./build_tools/health_status.py
-
-      - name: Fetch sources
-        timeout-minutes: 30
-        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1
-
-      - name: Get stage configuration
-        id: stage_config
-        run: |
-          python build_tools/configure_stage.py \
-            --stage ${STAGE_NAME} \
-            --dist-amdgpu-families "${{ inputs.dist_amdgpu_families }}" \
-            --gha-output
-
-      - name: Install stage python deps
-        if: ${{ steps.stage_config.outputs.pip_install_cmd }}
-        run: pip install ${{ steps.stage_config.outputs.pip_install_cmd }}
-
-      - name: Configure
-        run: |
-          cmake -B build -S . -GNinja \
-            -DTHEROCK_PACKAGE_VERSION=${{ inputs.rocm_package_version }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            ${{ steps.stage_config.outputs.cmake_args }}
-
-      - name: Build stage
-        run: |
-          cmake --build build --target stage-${STAGE_NAME} therock-artifacts -- -k 0
-
-      - name: Report
-        if: ${{ !cancelled() }}
-        run: |
-          echo "CCache Stats:"
-          ccache -s -v
-          echo "Artifacts:"
-          ls -lh build/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
-
-      - name: Configure AWS Credentials
-        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Push stage artifacts
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          python build_tools/artifact_manager.py push --run-id ${{ github.run_id }} \
-            --stage ${STAGE_NAME} \
-            --build-dir build
 
   # ==========================================================================
   # STAGE: compiler-runtime (generic)
   # ==========================================================================
   compiler-runtime:
-    name: Stage - Compiler Runtime
     needs: foundation
-    runs-on: azure-linux-scale-rocm
-    timeout-minutes: 480  # 8 hours (compiler is big)
+    uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+    secrets: inherit
+    with:
+      stage_name: compiler-runtime
+      stage_display_name: "Stage - Compiler Runtime"
+      timeout_minutes: 480  # 8 hours (compiler is big)
+      dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
+      rocm_package_version: ${{ inputs.rocm_package_version }}
     permissions:
+      contents: read
       id-token: write
-    container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858
-      options: -v /runner/config:/home/awsconfig/
-    env:
-      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
-      STAGE_NAME: compiler-runtime
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install python deps
-        run: pip install -r requirements.txt
-
-      - name: Adjust git config
-        run: |
-          git config --global --add safe.directory $PWD
-          git config fetch.parallel 10
-
-      - name: Setup ccache
-        run: |
-          ./build_tools/setup_ccache.py \
-            --config-preset "github-oss-presubmit" \
-            --dir "$(dirname $CCACHE_CONFIGPATH)" \
-            --local-path "$CACHE_DIR/ccache"
-
-      - name: Runner health status
-        run: |
-          ./build_tools/health_status.py
-
-      - name: Configure AWS Credentials
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Fetch inbound artifacts
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          python build_tools/artifact_manager.py fetch --run-id ${{ github.run_id }} \
-            --stage ${STAGE_NAME} \
-            --output-dir build \
-            --bootstrap
-
-      - name: Fetch sources
-        timeout-minutes: 30
-        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1
-
-      - name: Get stage configuration
-        id: stage_config
-        run: |
-          python build_tools/configure_stage.py \
-            --stage ${STAGE_NAME} \
-            --dist-amdgpu-families "${{ inputs.dist_amdgpu_families }}" \
-            --gha-output
-
-      - name: Install stage python deps
-        if: ${{ steps.stage_config.outputs.pip_install_cmd }}
-        run: pip install ${{ steps.stage_config.outputs.pip_install_cmd }}
-
-      - name: Configure
-        run: |
-          cmake -B build -S . -GNinja \
-            -DTHEROCK_PACKAGE_VERSION=${{ inputs.rocm_package_version }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            ${{ steps.stage_config.outputs.cmake_args }}
-
-      - name: Build stage
-        run: |
-          cmake --build build --target stage-${STAGE_NAME} therock-artifacts -- -k 0
-
-      - name: Report
-        if: ${{ !cancelled() }}
-        run: |
-          echo "CCache Stats:"
-          ccache -s -v
-          echo "Artifacts:"
-          ls -lh build/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
-
-      - name: Configure AWS Credentials (refresh for push)
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Push stage artifacts
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          python build_tools/artifact_manager.py push --run-id ${{ github.run_id }} \
-            --stage ${STAGE_NAME} \
-            --build-dir build
 
   # ==========================================================================
   # STAGE: math-libs (per-arch)
   # ==========================================================================
   math-libs:
-    name: Stage - Math Libs (${{ matrix.family_info.amdgpu_family }})
     needs: compiler-runtime
     strategy:
       fail-fast: false
       matrix:
         family_info: ${{ fromJSON(inputs.matrix_per_family_json) }}
-    runs-on: azure-linux-scale-rocm
-    timeout-minutes: 480  # 8 hours
+    uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+    secrets: inherit
+    with:
+      stage_name: math-libs
+      stage_display_name: "Stage - Math Libs (${{ matrix.family_info.amdgpu_family }})"
+      timeout_minutes: 480  # 8 hours
+      amdgpu_family: ${{ matrix.family_info.amdgpu_family }}
+      dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
+      rocm_package_version: ${{ inputs.rocm_package_version }}
     permissions:
+      contents: read
       id-token: write
-    container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858
-      options: -v /runner/config:/home/awsconfig/
-    env:
-      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
-      STAGE_NAME: math-libs
-      AMDGPU_FAMILIES: ${{ matrix.family_info.amdgpu_family }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install python deps
-        run: pip install -r requirements.txt
-
-      - name: Adjust git config
-        run: |
-          git config --global --add safe.directory $PWD
-          git config fetch.parallel 10
-
-      - name: Setup ccache
-        run: |
-          ./build_tools/setup_ccache.py \
-            --config-preset "github-oss-presubmit" \
-            --dir "$(dirname $CCACHE_CONFIGPATH)" \
-            --local-path "$CACHE_DIR/ccache"
-
-      - name: Runner health status
-        run: |
-          ./build_tools/health_status.py
-
-      - name: Configure AWS Credentials
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Fetch inbound artifacts
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          python build_tools/artifact_manager.py fetch --run-id ${{ github.run_id }} \
-            --stage ${STAGE_NAME} \
-            --amdgpu-families ${{ matrix.family_info.amdgpu_family }} \
-            --output-dir build \
-            --bootstrap
-
-      - name: Fetch sources
-        timeout-minutes: 30
-        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1
-
-      - name: Get stage configuration
-        id: stage_config
-        run: |
-          python build_tools/configure_stage.py \
-            --stage ${STAGE_NAME} \
-            --amdgpu-families ${{ matrix.family_info.amdgpu_family }} \
-            --dist-amdgpu-families "${{ inputs.dist_amdgpu_families }}" \
-            --gha-output
-
-      - name: Install stage python deps
-        if: ${{ steps.stage_config.outputs.pip_install_cmd }}
-        run: pip install ${{ steps.stage_config.outputs.pip_install_cmd }}
-
-      - name: Configure
-        run: |
-          cmake -B build -S . -GNinja \
-            -DTHEROCK_PACKAGE_VERSION=${{ inputs.rocm_package_version }} \
-            -DTHEROCK_AMDGPU_FAMILIES=${{ matrix.family_info.amdgpu_family }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            ${{ steps.stage_config.outputs.cmake_args }}
-
-      - name: Build stage
-        run: |
-          cmake --build build --target stage-${STAGE_NAME} therock-artifacts -- -k 0
-
-      - name: Report
-        if: ${{ !cancelled() }}
-        run: |
-          echo "CCache Stats:"
-          ccache -s -v
-          echo "Artifacts:"
-          ls -lh build/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
-
-      - name: Configure AWS Credentials (refresh for push)
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Push stage artifacts
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          python build_tools/artifact_manager.py push --run-id ${{ github.run_id }} \
-            --stage ${STAGE_NAME} \
-            --build-dir build
 
   # ==========================================================================
   # STAGE: comm-libs (per-arch, parallel to math-libs)
   # ==========================================================================
   comm-libs:
-    name: Stage - Comm Libs (${{ matrix.family_info.amdgpu_family }})
     needs: compiler-runtime
     strategy:
       fail-fast: false
       matrix:
         family_info: ${{ fromJSON(inputs.matrix_per_family_json) }}
-    runs-on: azure-linux-scale-rocm
-    timeout-minutes: 240  # 4 hours
+    uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+    secrets: inherit
+    with:
+      stage_name: comm-libs
+      stage_display_name: "Stage - Comm Libs (${{ matrix.family_info.amdgpu_family }})"
+      timeout_minutes: 240  # 4 hours
+      amdgpu_family: ${{ matrix.family_info.amdgpu_family }}
+      dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
+      rocm_package_version: ${{ inputs.rocm_package_version }}
     permissions:
+      contents: read
       id-token: write
-    container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858
-      options: -v /runner/config:/home/awsconfig/
-    env:
-      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
-      STAGE_NAME: comm-libs
-      AMDGPU_FAMILIES: ${{ matrix.family_info.amdgpu_family }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install python deps
-        run: pip install -r requirements.txt
-
-      - name: Adjust git config
-        run: |
-          git config --global --add safe.directory $PWD
-          git config fetch.parallel 10
-
-      - name: Setup ccache
-        run: |
-          ./build_tools/setup_ccache.py \
-            --config-preset "github-oss-presubmit" \
-            --dir "$(dirname $CCACHE_CONFIGPATH)" \
-            --local-path "$CACHE_DIR/ccache"
-
-      - name: Runner health status
-        run: |
-          ./build_tools/health_status.py
-
-      - name: Configure AWS Credentials
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Fetch inbound artifacts
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          python build_tools/artifact_manager.py fetch --run-id ${{ github.run_id }} \
-            --stage ${STAGE_NAME} \
-            --amdgpu-families ${{ matrix.family_info.amdgpu_family }} \
-            --output-dir build \
-            --bootstrap
-
-      - name: Fetch sources
-        timeout-minutes: 30
-        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1
-
-      - name: Get stage configuration
-        id: stage_config
-        run: |
-          python build_tools/configure_stage.py \
-            --stage ${STAGE_NAME} \
-            --amdgpu-families ${{ matrix.family_info.amdgpu_family }} \
-            --dist-amdgpu-families "${{ inputs.dist_amdgpu_families }}" \
-            --gha-output
-
-      - name: Install stage python deps
-        if: ${{ steps.stage_config.outputs.pip_install_cmd }}
-        run: pip install ${{ steps.stage_config.outputs.pip_install_cmd }}
-
-      - name: Configure
-        run: |
-          cmake -B build -S . -GNinja \
-            -DTHEROCK_PACKAGE_VERSION=${{ inputs.rocm_package_version }} \
-            -DTHEROCK_AMDGPU_FAMILIES=${{ matrix.family_info.amdgpu_family }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            ${{ steps.stage_config.outputs.cmake_args }}
-
-      - name: Build stage
-        run: |
-          cmake --build build --target stage-${STAGE_NAME} therock-artifacts -- -k 0
-
-      - name: Report
-        if: ${{ !cancelled() }}
-        run: |
-          echo "CCache Stats:"
-          ccache -s -v
-          echo "Artifacts:"
-          ls -lh build/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
-
-      - name: Configure AWS Credentials (refresh for push)
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Push stage artifacts
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          python build_tools/artifact_manager.py push --run-id ${{ github.run_id }} \
-            --stage ${STAGE_NAME} \
-            --build-dir build
 
   # ==========================================================================
   # STAGE: dctools-core (generic, parallel to math-libs)
   # ==========================================================================
   dctools-core:
-    name: Stage - DC Tools Core
     needs: compiler-runtime
-    runs-on: azure-linux-scale-rocm
-    timeout-minutes: 120  # 2 hours
+    uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+    secrets: inherit
+    with:
+      stage_name: dctools-core
+      stage_display_name: "Stage - DC Tools Core"
+      timeout_minutes: 120  # 2 hours
+      dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
+      rocm_package_version: ${{ inputs.rocm_package_version }}
     permissions:
+      contents: read
       id-token: write
-    container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858
-      options: -v /runner/config:/home/awsconfig/
-    env:
-      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
-      STAGE_NAME: dctools-core
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install python deps
-        run: pip install -r requirements.txt
-
-      - name: Adjust git config
-        run: |
-          git config --global --add safe.directory $PWD
-          git config fetch.parallel 10
-
-      - name: Setup ccache
-        run: |
-          ./build_tools/setup_ccache.py \
-            --config-preset "github-oss-presubmit" \
-            --dir "$(dirname $CCACHE_CONFIGPATH)" \
-            --local-path "$CACHE_DIR/ccache"
-
-      - name: Runner health status
-        run: |
-          ./build_tools/health_status.py
-
-      - name: Configure AWS Credentials
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Fetch inbound artifacts
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          python build_tools/artifact_manager.py fetch --run-id ${{ github.run_id }} \
-            --stage ${STAGE_NAME} \
-            --output-dir build \
-            --bootstrap
-
-      - name: Fetch sources
-        timeout-minutes: 30
-        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1
-
-      - name: Get stage configuration
-        id: stage_config
-        run: |
-          python build_tools/configure_stage.py \
-            --stage ${STAGE_NAME} \
-            --dist-amdgpu-families "${{ inputs.dist_amdgpu_families }}" \
-            --gha-output
-
-      - name: Install stage python deps
-        if: ${{ steps.stage_config.outputs.pip_install_cmd }}
-        run: pip install ${{ steps.stage_config.outputs.pip_install_cmd }}
-
-      - name: Configure
-        run: |
-          cmake -B build -S . -GNinja \
-            -DTHEROCK_PACKAGE_VERSION=${{ inputs.rocm_package_version }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            ${{ steps.stage_config.outputs.cmake_args }}
-
-      - name: Build stage
-        run: |
-          cmake --build build --target stage-${STAGE_NAME} therock-artifacts -- -k 0
-
-      - name: Report
-        if: ${{ !cancelled() }}
-        run: |
-          echo "CCache Stats:"
-          ccache -s -v
-          echo "Artifacts:"
-          ls -lh build/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
-
-      - name: Configure AWS Credentials (refresh for push)
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Push stage artifacts
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          python build_tools/artifact_manager.py push --run-id ${{ github.run_id }} \
-            --stage ${STAGE_NAME} \
-            --build-dir build
 
   # ==========================================================================
   # STAGE: profiler-apps (generic, parallel to math-libs)
   # ==========================================================================
   profiler-apps:
-    name: Stage - Profiler Apps
     needs: compiler-runtime
-    runs-on: azure-linux-scale-rocm
-    timeout-minutes: 180  # 3 hours
+    uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+    secrets: inherit
+    with:
+      stage_name: profiler-apps
+      stage_display_name: "Stage - Profiler Apps"
+      timeout_minutes: 180  # 3 hours
+      dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
+      rocm_package_version: ${{ inputs.rocm_package_version }}
     permissions:
+      contents: read
       id-token: write
-    container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858
-      options: -v /runner/config:/home/awsconfig/
-    env:
-      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
-      STAGE_NAME: profiler-apps
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install python deps
-        run: pip install -r requirements.txt
-
-      - name: Adjust git config
-        run: |
-          git config --global --add safe.directory $PWD
-          git config fetch.parallel 10
-
-      - name: Setup ccache
-        run: |
-          ./build_tools/setup_ccache.py \
-            --config-preset "github-oss-presubmit" \
-            --dir "$(dirname $CCACHE_CONFIGPATH)" \
-            --local-path "$CACHE_DIR/ccache"
-
-      - name: Runner health status
-        run: |
-          ./build_tools/health_status.py
-
-      - name: Configure AWS Credentials
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Fetch inbound artifacts
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          python build_tools/artifact_manager.py fetch --run-id ${{ github.run_id }} \
-            --stage ${STAGE_NAME} \
-            --output-dir build \
-            --bootstrap
-
-      - name: Fetch sources
-        timeout-minutes: 30
-        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1
-
-      - name: Get stage configuration
-        id: stage_config
-        run: |
-          python build_tools/configure_stage.py \
-            --stage ${STAGE_NAME} \
-            --dist-amdgpu-families "${{ inputs.dist_amdgpu_families }}" \
-            --gha-output
-
-      - name: Install stage python deps
-        if: ${{ steps.stage_config.outputs.pip_install_cmd }}
-        run: pip install ${{ steps.stage_config.outputs.pip_install_cmd }}
-
-      - name: Configure
-        run: |
-          cmake -B build -S . -GNinja \
-            -DTHEROCK_PACKAGE_VERSION=${{ inputs.rocm_package_version }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            ${{ steps.stage_config.outputs.cmake_args }}
-
-      - name: Build stage
-        run: |
-          cmake --build build --target stage-${STAGE_NAME} therock-artifacts -- -k 0
-
-      - name: Report
-        if: ${{ !cancelled() }}
-        run: |
-          echo "CCache Stats:"
-          ccache -s -v
-          echo "Artifacts:"
-          ls -lh build/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
-
-      - name: Configure AWS Credentials (refresh for push)
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Push stage artifacts
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          python build_tools/artifact_manager.py push --run-id ${{ github.run_id }} \
-            --stage ${STAGE_NAME} \
-            --build-dir build
 
   # ==========================================================================
   # STAGE: media (generic)
   # ==========================================================================
   media:
-    name: Stage - Media
     needs: foundation
-    runs-on: azure-linux-scale-rocm
-    timeout-minutes: 180  # 3 hours
+    uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+    secrets: inherit
+    with:
+      stage_name: media
+      stage_display_name: "Stage - Media"
+      timeout_minutes: 180  # 3 hours
+      dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
+      rocm_package_version: ${{ inputs.rocm_package_version }}
     permissions:
+      contents: read
       id-token: write
-    container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858
-      options: -v /runner/config:/home/awsconfig/
-    env:
-      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
-      STAGE_NAME: media
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install python deps
-        run: pip install -r requirements.txt
-
-      - name: Adjust git config
-        run: |
-          git config --global --add safe.directory $PWD
-          git config fetch.parallel 10
-
-      - name: Setup ccache
-        run: |
-          ./build_tools/setup_ccache.py \
-            --config-preset "github-oss-presubmit" \
-            --dir "$(dirname $CCACHE_CONFIGPATH)" \
-            --local-path "$CACHE_DIR/ccache"
-
-      - name: Runner health status
-        run: |
-          ./build_tools/health_status.py
-
-      - name: Configure AWS Credentials
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Fetch inbound artifacts
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          python build_tools/artifact_manager.py fetch --run-id ${{ github.run_id }} \
-            --stage ${STAGE_NAME} \
-            --output-dir build \
-            --bootstrap
-
-      - name: Fetch sources
-        timeout-minutes: 30
-        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1
-
-      - name: Get stage configuration
-        id: stage_config
-        run: |
-          python build_tools/configure_stage.py \
-            --stage ${STAGE_NAME} \
-            --dist-amdgpu-families "${{ inputs.dist_amdgpu_families }}" \
-            --gha-output
-
-      - name: Install stage python deps
-        if: ${{ steps.stage_config.outputs.pip_install_cmd }}
-        run: pip install ${{ steps.stage_config.outputs.pip_install_cmd }}
-
-      - name: Configure
-        run: |
-          cmake -B build -S . -GNinja \
-            -DTHEROCK_PACKAGE_VERSION=${{ inputs.rocm_package_version }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            ${{ steps.stage_config.outputs.cmake_args }}
-
-      - name: Build stage
-        run: |
-          cmake --build build --target stage-${STAGE_NAME} therock-artifacts -- -k 0
-
-      - name: Report
-        if: ${{ !cancelled() }}
-        run: |
-          echo "CCache Stats:"
-          ccache -s -v
-          echo "Artifacts:"
-          ls -lh build/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
-
-      - name: Configure AWS Credentials
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Push stage artifacts
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        run: |
-          python build_tools/artifact_manager.py push --run-id ${{ github.run_id }} \
-            --stage ${STAGE_NAME} \
-            --build-dir build

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -1,0 +1,144 @@
+# Reusable Workflow: Build Stage Artifacts
+#
+# This workflow builds TheRock stage artifacts for all stages.
+# Handles both generic stages (foundation, compiler-runtime, etc.) and
+# per-arch stages (math-libs, comm-libs) using conditional logic.
+
+name: Build Stage Artifacts
+
+on:
+  workflow_call:
+    inputs:
+      stage_name:
+        type: string
+        required: true
+        description: "Stage name (e.g., foundation, math-libs, compiler-runtime)"
+      stage_display_name:
+        type: string
+        required: true
+        description: "Human-readable display name for the job"
+      timeout_minutes:
+        type: number
+        required: true
+        description: "Job timeout in minutes"
+      amdgpu_family:
+        type: string
+        required: false
+        default: ""
+        description: "GPU family for per-arch stages (empty for generic stages)"
+      dist_amdgpu_families:
+        type: string
+        required: true
+        description: "Semicolon-separated list of all GPU families for dist targets"
+      rocm_package_version:
+        type: string
+        required: true
+        description: "ROCm package version string"
+
+jobs:
+  build_stage:
+    name: ${{ inputs.stage_display_name }}
+    runs-on: azure-linux-scale-rocm
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    permissions:
+      id-token: write
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858
+      options: -v /runner/config:/home/awsconfig/
+    env:
+      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
+      STAGE_NAME: ${{ inputs.stage_name }}
+      AMDGPU_FAMILIES: ${{ inputs.amdgpu_family }}
+      CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
+      CACHE_DIR: ${{ github.workspace }}/.container-cache
+      TEATIME_FORCE_INTERACTIVE: 0
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install python deps
+        run: pip install -r requirements.txt
+
+      - name: Adjust git config
+        run: |
+          git config --global --add safe.directory $PWD
+          git config fetch.parallel 10
+
+      - name: Setup ccache
+        run: |
+          ./build_tools/setup_ccache.py \
+            --config-preset "github-oss-presubmit" \
+            --dir "$(dirname $CCACHE_CONFIGPATH)" \
+            --local-path "$CACHE_DIR/ccache"
+
+      - name: Runner health status
+        run: |
+          ./build_tools/health_status.py
+
+      - name: Configure AWS Credentials
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
+
+      - name: Fetch inbound artifacts
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          python build_tools/artifact_manager.py fetch --run-id ${{ github.run_id }} \
+            --stage ${STAGE_NAME} \
+            --amdgpu-families="${{ inputs.amdgpu_family }}" \
+            --output-dir build \
+            --bootstrap
+
+      - name: Fetch sources
+        timeout-minutes: 30
+        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1
+
+      - name: Get stage configuration
+        id: stage_config
+        run: |
+          python build_tools/configure_stage.py \
+            --stage ${STAGE_NAME} \
+            --amdgpu-families="${{ inputs.amdgpu_family }}" \
+            --dist-amdgpu-families "${{ inputs.dist_amdgpu_families }}" \
+            --gha-output
+
+      - name: Install stage python deps
+        if: ${{ steps.stage_config.outputs.pip_install_cmd }}
+        run: pip install ${{ steps.stage_config.outputs.pip_install_cmd }}
+
+      - name: Configure
+        run: |
+          cmake -B build -S . -GNinja \
+            -DTHEROCK_PACKAGE_VERSION=${{ inputs.rocm_package_version }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            ${{ steps.stage_config.outputs.cmake_args }}
+
+      - name: Build stage
+        run: |
+          cmake --build build --target stage-${STAGE_NAME} therock-artifacts -- -k 0
+
+      - name: Report
+        if: ${{ !cancelled() }}
+        run: |
+          echo "CCache Stats:"
+          ccache -s -v
+          echo "Artifacts:"
+          ls -lh build/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
+
+      - name: Configure AWS Credentials (refresh for push)
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
+
+      - name: Push stage artifacts
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          python build_tools/artifact_manager.py push --run-id ${{ github.run_id }} \
+            --stage ${STAGE_NAME} \
+            --build-dir build


### PR DESCRIPTION
## Motivation

The workflow contained 7 stage jobs with massive duplication, refactoring to ease maintenance.

Progress on #3336.

## Technical Details

Creates a new reusable workflow to encapsulate build patterns for generic and per-architecture stages.

## Test Plan

https://github.com/ROCm/TheRock/actions/runs/22075445143

## Test Result

Build stages pass using the new reusable workflow. Test failures are unrelated, filed #3438.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
