### PR TITLE
Revert "Move non-sysdep third-party projects after base and compiler."

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,10 +439,9 @@ endif()
 
 # Add subdirectories in dependency DAG order (which happens to be semi-alpha:
 # don't be fooled).
-add_subdirectory(third-party/sysdeps)
+add_subdirectory(third-party)
 add_subdirectory(base)
 add_subdirectory(compiler)
-add_subdirectory(third-party)
 add_subdirectory(core)
 add_subdirectory(debug-tools)
 # Note that rocprofiler-register is in base and is what higher level clients

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -1,9 +1,3 @@
-# Subdirectory load order here is carefully balanced - see usage from the root
-# CMakeLists.txt. Notably this file does *not* include the sysdeps subdirectory,
-# which is expected to be included *first*. This allows for bootstrapping
-# compiler/, so other projects in this directory can use the amd-llvm compiler
-# toolchain if they so wish (most should eventually).
-
 add_custom_target(therock-third-party)
 
 # No-dep third party libraries (alphabetical)
@@ -33,6 +27,15 @@ if(THEROCK_ENABLE_HOST_BLAS)
 endif()
 if(THEROCK_ENABLE_HOST_SUITE_SPARSE)
   add_subdirectory(SuiteSparse)
+endif()
+
+# TODO: Relocate non header-only libraries here (i.e. boost, host-blas).
+if(THEROCK_BUNDLE_SYSDEPS)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_subdirectory(sysdeps/linux)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    add_subdirectory(sysdeps/windows)
+  endif()
 endif()
 
 # gRPC: Static library for RDC (built on-demand when depended upon)

--- a/third-party/spdlog/CMakeLists.txt
+++ b/third-party/spdlog/CMakeLists.txt
@@ -12,8 +12,6 @@ therock_cmake_subproject_declare(therock-spdlog
   NO_MERGE_COMPILE_COMMANDS
   OUTPUT_ON_FAILURE
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
-  COMPILER_TOOLCHAIN
-    amd-llvm
   BUILD_DEPS
     therock-fmt
   CMAKE_ARGS

--- a/third-party/sysdeps/CMakeLists.txt
+++ b/third-party/sysdeps/CMakeLists.txt
@@ -1,8 +1,0 @@
-# TODO: Relocate non header-only libraries here (i.e. boost, host-blas).
-if(THEROCK_BUNDLE_SYSDEPS)
-  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    add_subdirectory(linux)
-  elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    add_subdirectory(windows)
-  endif()
-endif()


### PR DESCRIPTION
Reverts ROCm/TheRock#2045

Broke multi-arch CI: https://github.com/ROCm/TheRock/actions/runs/22080400734/job/63804324097#step:13:134
```
-- Including subproject therock-frugally-deep (from /__w/TheRock/TheRock/build/third-party/frugally-deep/source)
-- Including subproject therock-spdlog (from /__w/TheRock/TheRock/build/third-party/spdlog/source)
CMake Error at cmake/therock_subproject.cmake:1169 (get_target_property):
  get_target_property() called with non-existent target "amd-llvm".
Call Stack (most recent call first):
```