### PR TITLE
Revert "Change hip-tests and aqlprofile-tests to TARGET_NEUTRAL."

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -481,11 +481,11 @@ platform = "windows"
 artifact_deps = ["core-hip"]
 feature_group = "CORE"  # Part of core, enabled by default
 
-# --- hip-tests ---
+# --- hip-tests (per-arch) ---
 
 [artifacts.core-hiptests]
 artifact_group = "hip-runtime"
-type = "target-neutral"
+type = "target-specific"
 artifact_deps = ["core-hip"]
 feature_group = "CORE"  # Part of core, enabled by default
 
@@ -598,7 +598,7 @@ disable_platforms = ["windows"]
 
 [artifacts.aqlprofile-tests]
 artifact_group = "profiler-core"
-type = "target-neutral"
+type = "target-specific"
 artifact_deps = ["core-runtime"]
 feature_group = "PROFILER"
 disable_platforms = ["windows"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,15 +307,8 @@ therock_report_features()
 ################################################################################
 
 set(THEROCK_AMDGPU_FAMILIES "" CACHE STRING "AMDGPU target families to build for")
-set(THEROCK_AMDGPU_TARGETS "" CACHE STRING "AMDGPU targets to build for (individual gfx targets in addition to those expanded from THEROCK_AMDGPU_FAMILIES)")
+set(THEROCK_AMDGPU_TARGETS "" CACHE STRING "AMDGPU targets to build for")
 set(THEROCK_AMDGPU_DIST_BUNDLE_NAME "" CACHE STRING "Distribution bundle name for AMDGPU packages")
-
-# Note that if THEROCK_DIST_AMDGPU_FAMILIES and THEROCK_DIST_AMDGPU_TARGETS are empty, then
-# this defaults to all supported targets. These "dist" targets are used for runtime
-# libraries that embed device code and are marked as target-neutral (which typically means
-# generate for all supported architectures).
-set(THEROCK_DIST_AMDGPU_FAMILIES "" CACHE STRING "AMDGPU target families to use for target-neutral projects")
-set(THEROCK_DIST_AMDGPU_TARGETS "" CACHE STRING "AMDGPU targets to build for (individual gfx targets in addition to those expanded from THEROCK_DIST_AMDGPU_FAMILIES)")
 
 therock_validate_amdgpu_targets()
 

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -258,12 +258,12 @@ function(therock_validate_amdgpu_targets)
   endforeach()
 
   # Expand dist families (THEROCK_DIST_AMDGPU_FAMILIES -> THEROCK_DIST_AMDGPU_TARGETS).
-  # If THEROCK_DIST_AMDGPU_FAMILIES is not set, it defaults to all supported families.
-  set(_dist_expanded_targets "${THEROCK_DIST_AMDGPU_TARGETS}")
+  # If THEROCK_DIST_AMDGPU_FAMILIES is not set, it defaults to THEROCK_AMDGPU_FAMILIES.
   set(_dist_families "${THEROCK_DIST_AMDGPU_FAMILIES}")
-  if(NOT _dist_families AND NOT _dist_expanded_targets)
-    set(_dist_expanded_targets "${_available_targets}")
+  if(NOT _dist_families)
+    set(_dist_families "${THEROCK_AMDGPU_FAMILIES}")
   endif()
+  set(_dist_expanded_targets)
   foreach(_family ${_dist_families})
     if(NOT "${_family}" IN_LIST _available_families)
       string(JOIN " " _families_pretty ${_available_families})
@@ -278,7 +278,7 @@ function(therock_validate_amdgpu_targets)
 
   # Report dist targets if different from per-arch targets.
   if(_dist_expanded_targets AND NOT "${_dist_expanded_targets}" STREQUAL "${_expanded_targets}")
-    message(STATUS "* Dist targets: ${_dist_expanded_targets}")
+    message(STATUS "Dist targets: ${_dist_expanded_targets}")
   endif()
 
   # Handle the case where per-arch targets are empty but dist targets exist.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -291,7 +291,6 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
     therock_cmake_subproject_activate(hip-tests)
     # Provide it as an artifact:
     therock_provide_artifact(core-hiptests
-      TARGET_NEUTRAL
       DESCRIPTOR artifact-core-hiptests.toml
       COMPONENTS
         test

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -49,7 +49,6 @@ if(THEROCK_ENABLE_ROCPROFV3)
 
 if(THEROCK_BUILD_TESTING)
   therock_provide_artifact(aqlprofile-tests
-    TARGET_NEUTRAL
     DESCRIPTOR artifact-aqlprofile.toml
     COMPONENTS
       test


### PR DESCRIPTION
Reverts ROCm/TheRock#3348

Suspected of breaking PyTorch builds:
* https://github.com/ROCm/TheRock/issues/3432
* https://github.com/ROCm/TheRock/issues/3428

Presubmit results pending, look for `Building PyTorch for GPU arch` in logs, should see a limited list like `Building PyTorch for GPU arch: gfx942` instead of `Building PyTorch for GPU arch: gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1010;gfx1011;gfx1012;gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201`