### PR TITLE
Temporarily disable building apex wheels

### DIFF
--- a/build_tools/github_actions/write_torch_versions.py
+++ b/build_tools/github_actions/write_torch_versions.py
@@ -11,6 +11,7 @@ import argparse
 import os
 import glob
 import platform
+from packaging.version import parse
 from github_actions_utils import *
 
 
@@ -89,7 +90,15 @@ def get_all_wheel_versions(
     elif os.lower() == "windows":
         _log("Did not find apex (that's okay, is not currently built on Windows)")
     else:
-        raise FileNotFoundError("Did not find apex wheel")
+        # Apex is only built for torch >= 2.10 and disabled otherwise until #3413 is resolved
+        torch_version_parsed = parse(torch_version)
+        is_torch_less_than_2_10 = torch_version_parsed.release[:2] < (2, 10)
+        if is_torch_less_than_2_10:
+            _log(
+                "Did not find apex (that's okay, apex is not built for torch versions < 2.10  on linux)"
+            )
+        else:
+            raise FileNotFoundError("Did not find apex wheel")
 
     return all_versions
 

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -518,6 +518,7 @@ def do_build(args: argparse.Namespace):
     # Build apex.
     # Changed default behavior:
     # Only build apex for torch 2.10 and disable otherwise until #3413 is resolved
+    # changes were also needed in: build_tools/github_actions/write_torch_versions.py
     if args.build_apex is None and apex_dir:
         if pytorch_dir:
             # < this is just copied from do_build_pytorch() >


### PR DESCRIPTION
Apex wheels are currently failing to build due to missing cherry pick https://github.com/pytorch/pytorch/pull/168097 for pytorch branches: 2.7/2.8/2.9.  

As such only build Apex for torch >= 2.10

Re-enable when #3413 is resolved