### PR TITLE
Add rocprofiler-compute and rocprofiler-systems to rocm devel wheels

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -70,6 +70,8 @@ def run(args: argparse.Namespace):
             # included in runtime packages, but we still want them in the devel package.
             "prim",
             "rocwmma",
+            "rocprofiler-compute",
+            "rocprofiler-systems",
         ],
         tarball_compression=args.devel_tarball_compression,
     )


### PR DESCRIPTION
As stated in #3208, rocprofiler-compute and rocprofiler-systems are missing in the rocm python packages.

This PR will enable them to be included in rocm devel. Devel is selected to match it with build_tools/packaging/linux/package.json