### PR TITLE
[bugfix] prefix is undefined when non-default install prefix is passed

### DIFF
--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -774,10 +774,12 @@ def run(args: argparse.Namespace):
     minor = re.match(r"^\d+", parts[1])
     modified_rocm_version = f"{major.group()}.{minor.group()}"
 
+    prefix = args.install_prefix
+
     # Append rocm version to default install prefix
     # TBD: Do we need to append rocm_version to other prefix?
-    if args.install_prefix == f"{DEFAULT_INSTALL_PREFIX}":
-        prefix = args.install_prefix + "-" + modified_rocm_version
+    if prefix == DEFAULT_INSTALL_PREFIX:
+        prefix = f"{prefix}-{modified_rocm_version}"
 
     # Populate package config details from user arguments
     config = PackageConfig(


### PR DESCRIPTION
This pull request makes a minor update to the logic for setting the installation prefix in the `run` function of `build_package.py`. This fixes a bug where prefix is not defined when `args.install_prefix` is not equal to the `DEFAULT_INSTALL_PREFIX`.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
