### PR TITLE
 Fix RPM build failure on Debian-based systems due to sh/bash incompatibility

### DIFF
--- a/build_tools/packaging/linux/template/rpm_specfile.j2
+++ b/build_tools/packaging/linux/template/rpm_specfile.j2
@@ -6,7 +6,7 @@
 {% endif %}
 %global __objcopy /usr/bin/llvm-objcopy
 
-
+%global _buildshell /bin/bash
 %global _debugsource_template %{nil}
 %global debug_package %{nil}          # disables -debuginfo
 %define __brp_mangle_shebangs %{nil}


### PR DESCRIPTION
The %install section uses 'shopt -s dotglob' to copy hidden files, but RPM
defaults to /bin/sh which doesn't support this bash builtin. On Debian-based
systems where /bin/sh is dash, this causes the build to fail with
"shopt: not found".

Set %global _buildshell to /bin/bash to ensure all RPM scriptlets run with
bash, allowing bash-specific syntax throughout the spec file