### PR TITLE
Add test packages for test binaries

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -323,14 +323,9 @@
     "Architecture": "amd64",
     "BuildArch": "x86_64",
     "DEBDepends": [
-      "libc6",
-      "amdrocm-runtime",
-      "amdrocm-sysdeps",
       "amdrocm-fft-devel"
     ],
     "RPMRequires": [
-      "amdrocm-runtime",
-      "amdrocm-sysdeps",
       "amdrocm-fft-devel"
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
@@ -626,11 +621,11 @@
     "BuildArch": "x86_64",
     "DEBDepends": [
       "amdrocm-runtime",
-      "amdrocm-blas"
+      "amdrocm-blas-devel"
     ],
     "RPMRequires": [
       "amdrocm-runtime",
-      "amdrocm-blas"
+      "amdrocm-blas-devel"
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
     "Description_Short": "AMD test files for BLAS in ROCm",
@@ -1781,10 +1776,10 @@
     "Architecture": "amd64",
     "BuildArch": "x86_64",
     "DEBDepends": [
-      "amdrocm-dnn"
+      "amdrocm-dnn-devel"
     ],
     "RPMRequires": [
-      "amdrocm-dnn"
+      "amdrocm-dnn-devel"
     ],
     "Maintainer": "MIOpen Maintainer <miopen-lib.support@amd.com>",
     "Description_Short": "AMD DNN test files",


### PR DESCRIPTION
## Motivation

Add test packages for fft, rccl, blas, miopen/dnn, sparse, solver, and rand. A separate test package for each will be added which will include test binaries and test related files.  

some test related binary files listed using dpkg -c

ftt: 
./opt/rocm/core-7.12/bin/dyna-rocfft-bench
./opt/rocm/core-7.12/bin/hipfft-test
./opt/rocm/core-7.12/bin/rocfft-bench
 ./opt/rocm/core-7.12/bin/rocfft-test

rccl:
./opt/rocm/core-7.12/bin/rccl-UnitTests

blas:
./opt/rocm/core-7.12/bin/hipblas-test
./opt/rocm/core-7.12/bin/hipblaslt-test
./opt/rocm/core-7.12/bin/rocblas-test
./opt/rocm/core-7.12/bin/rocroller-tests
./opt/rocm/core-7.12/bin/rocroller-tests-catch

miopen:
-rwxr-xr-x root/root   3443616 2026-02-17 15:20 ./opt/rocm/core-7.12/bin/hipdnn_backend_tests
-rwxr-xr-x root/root   2703832 2026-02-17 15:20 ./opt/rocm/core-7.12/bin/hipdnn_data_sdk_tests
-rwxr-xr-x root/root   6652472 2026-02-17 15:20 ./opt/rocm/core-7.12/bin/hipdnn_frontend_tests
-rwxr-xr-x root/root    962400 2026-02-17 15:20 ./opt/rocm/core-7.12/bin/hipdnn_plugin_sdk_tests
-rwxr-xr-x root/root   8644040 2026-02-17 15:20 ./opt/rocm/core-7.12/bin/hipdnn_test_sdk_tests
-rwxr-xr-x root/root  40419976 2026-02-17 15:20 ./opt/rocm/core-7.12/bin/miopen_gtest
-rwxr-xr-x root/root   1381488 2026-02-17 15:20 ./opt/rocm/core-7.12/bin/public_hipdnn_backend_tests
-rwxr-xr-x root/root   1531000 2026-02-17 15:20 ./opt/rocm/core-7.12/bin/public_hipdnn_frontend_tests

solver:
-rwxr-xr-x root/root   2767168 2026-02-18 13:36 ./opt/rocm/core-7.12/bin/hipsolver-bench
-rwxr-xr-x root/root  12111536 2026-02-18 13:36 ./opt/rocm/core-7.12/bin/hipsolver-test
-rwxr-xr-x root/root  15123928 2026-02-18 13:36 ./opt/rocm/core-7.12/bin/rocsolver-bench
-rwxr-xr-x root/root  35200872 2026-02-18 13:36 ./opt/rocm/core-7.12/bin/rocsolver-test

rand: 
-rwxr-xr-x root/root    435624 2026-02-17 15:29 ./opt/rocm/core-7.12/bin/test_normal_distribution
-rwxr-xr-x root/root    423000 2026-02-17 15:29 ./opt/rocm/core-7.12/bin/test_poisson_distribution
-rwxr-xr-x root/root    420192 2026-02-17 15:29 ./opt/rocm/core-7.12/bin/test_rocrand_basic
-rwxr-xr-x root/root    451568 2026-02-17 15:29 ./opt/rocm/core-7.12/bin/test_rocrand_config_dispatch
…

## Technical Details

create new package in json file 

## Test Plan

build package, install, run binary

## Test Result

currently testing

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
