### PR TITLE
[ci] Re-enable rocprim device_reduce_by_key test

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocprim.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprim.py
@@ -21,8 +21,6 @@ TEST_TO_IGNORE = {
             "rocprim.device_merge_sort",
             # TODO(#2836): Re-enable test once issues are resolved
             "rocprim.device_radix_sort",
-            # TODO(#3155): Re-enable test once consistent issues are resolved
-            "rocprim.device_reduce_by_key",
         ]
     }
 }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR re-enables the previously disabled rocprim device_reduce_by_key test due to issue https://github.com/ROCm/TheRock/issues/3155.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Issue https://github.com/ROCm/TheRock/issues/3155 has been resolved by PR https://github.com/ROCm/rocm-libraries/pull/4391.

Closes #3155

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Run the latest nightly build and this test should now pass on Strix Halo Windows.

## Test Result

<!-- Briefly summarize test outcomes. -->
The test passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
