### PR TITLE
Fix rocgdb missing Python support by passing MANYLINUX env var to container

### DIFF
--- a/build_tools/linux_portable_build.py
+++ b/build_tools/linux_portable_build.py
@@ -69,6 +69,7 @@ def do_build(args: argparse.Namespace, *, rest_args: list[str]):
         "EXTRA_C_COMPILER_LAUNCHER",
         "EXTRA_CXX_COMPILER_LAUNCHER",
         "THEROCK_BUILD_PROF_LOG_DIR",
+        "MANYLINUX",
     ]
     for var in passthrough_env_vars:
         if var in os.environ:


### PR DESCRIPTION
### Summary
`rocgdb` was built without Python support because the `MANYLINUX` environment variable wasn’t passed into the build container.

### Root Cause
The workflow sets `MANYLINUX=1`, but `linux_portable_build.py` doesn’t forward it. Without this variable, `build_configure.py` skips manylinux mode, shared Python detection fails, and `rocgdb` builds without Python support.

### Fix
Add `MANYLINUX` to `passthrough_env_vars` so the manylinux path is enabled and Python support is correctly included.