### PR TITLE
Add sccache support to build scripts with ROCm compiler wrapping

### DIFF
--- a/build_tools/setup_sccache_rocm.py
+++ b/build_tools/setup_sccache_rocm.py
@@ -29,6 +29,10 @@ Usage:
     # Restore original compilers
     python setup_sccache_rocm.py --rocm-path /path/to/rocm --restore
 
+    # When called from build_prod_wheels.py:
+    #   --use-sccache                 wraps compilers + sets CMAKE launchers
+    #   --use-sccache --sccache-no-wrap   sets CMAKE launchers only (no wrapping)
+
 Prerequisites:
     sccache must be installed and available in PATH.
     Install: https://github.com/mozilla/sccache#installation

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -82,6 +82,25 @@ python build_prod_wheels.py build ^
     --pytorch-vision-dir C:/b/vision
 ```
 
+4. Compiler caching (optional):
+
+```
+# Use ccache:
+python build_prod_wheels.py build --use-ccache --output-dir ...
+
+# Use sccache with ROCm compiler wrapping (caches host + HIP device code):
+python build_prod_wheels.py build --use-sccache --output-dir ...
+
+# Use sccache without compiler wrapping (caches host C/C++ only):
+python build_prod_wheels.py build --use-sccache --sccache-no-wrap --output-dir ...
+```
+
+``--use-ccache`` and ``--use-sccache`` are mutually exclusive.
+``--sccache-no-wrap`` is a modifier for ``--use-sccache`` that skips ROCm compiler
+wrapping — useful for developers who want basic caching without modifying compiler
+binaries. See ``build_tools/setup_sccache_rocm.py`` for details on the wrapping
+mechanism.
+
 ## Building Linux portable wheels
 
 On Linux, production wheels are typically built in a manylinux container and must have


### PR DESCRIPTION
## Motivation

Add sccache support to PyTorch wheel builds for S3-backed distributed caching. Script placed in `build_tools/` per [reviewer feedback](https://github.com/ROCm/TheRock/pull/3171#discussion_r2790320904), modeled after `build_tools/setup_ccache.py`.

Part of sccache PR sequence: [#3369](https://github.com/ROCm/TheRock/pull/3369) → [#3389](https://github.com/ROCm/TheRock/pull/3389) → **this** → workflow wiring.

## Technical Details

- **New: `build_tools/setup_sccache_rocm.py`** — generic sccache ROCm helper (CLI + importable):
  - `find_sccache()` — locate binary; hard fail if missing
  - `setup_rocm_sccache()` — wrap clang/clang++ with sccache stubs (Linux only)
  - `restore_rocm_compilers()` — undo wrapping
  
- **Modified: `external-builds/pytorch/build_prod_wheels.py`**:
  - `--use-ccache` / `--use-sccache` mutually exclusive args
  - Both hard-fail with `RuntimeError` if the requested cache tool is not found ([per review](https://github.com/ROCm/TheRock/pull/3171#discussion_r2790320904)) — no silent fallback
  - Added explicit ccache availability check (previously would fail with an unclear subprocess error)
  - sccache: wrap compilers → set CMAKE launchers → `try`/`finally` around build for guaranteed compiler restore + stats
  - Moved ccache stats reporting into `finally` block for consistent reporting on both success and failure

## Test Result

No workflow changes — sccache wired but not yet invoked by CI (next PR adds `cache_type` input + AWS config).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.