### PR TITLE
[ci] Clear Pip cache and UV setup files to fix space issues on windows

### DIFF
--- a/build_tools/github_actions/cleanup_processes.ps1
+++ b/build_tools/github_actions/cleanup_processes.ps1
@@ -160,7 +160,7 @@ if ($currentUser -match "NT AUTHORITY") {
                 $emptyDirs = @(Get-ChildItem -Path $httpCacheDir -Directory -Recurse -ErrorAction SilentlyContinue |
                     Where-Object { (Get-ChildItem -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue).Count -eq 0 } |
                     Sort-Object -Property FullName -Descending)
-                
+
                 if ($emptyDirs.Count -gt 0) {
                     try {
                         $emptyDirs | Remove-Item -Force -ErrorAction Stop


### PR DESCRIPTION
## Motivation

Increases in test frequency are causing runners to run out of disk space even quicker now, and it'll require an automated way to clear it. This is being tracked here https://github.com/ROCm/TheRock/issues/3456 and is a follow up to https://github.com/ROCm/TheRock/issues/2438 and https://github.com/ROCm/TheRock/issues/2885.
Ideally this could be moved to containers/dockers/k8s.

## Technical Details

See previously mentioned issues for more details but, in a nutshell uv install step will accumulate its own setup archives indefinitely, and each ROCm release wheel (of every type) will accumulate in the cache until cleared. So remove packages from the cache that are no longer being tested and only taking up space. 1 day retention was chosen to help save a bit of bandwidth during daily testing (so far indiscriminately across every package)

## Test Plan


- Test locally.
- Observe CI on every GPU runner.

## Test Result
Tested interactively on `windows-strix-halo-gpu-rocm-4` with these results when running as `NT Authority\System` using `psexec -s`:
> UV only
```powershell
C:\develop>powershell -file cleanup_uv.ps1
[*] > Checking for uv.zip archives under: C:\windows\SystemTemp\
[*] >> Found 0 uv.zip file(s), total size: 0 MB
[*] > Checking for empty GUID directories under: C:\windows\SystemTemp\
[*] >> Found 5674 empty GUID folder(s)
[+] >> Removed 5674 empty GUID folder(s)

C:\develop>powershell -file cleanup_processes.ps1
[*] > Checking for uv.zip archives under: C:\windows\SystemTemp\
[*] >> Found 819 uv.zip file(s), total size: 17193.65 MB
[+] >> Removed 819 uv.zip file(s)
[*] > Checking for empty GUID directories under: C:\windows\SystemTemp\
[*] >> Found 819 empty GUID folder(s)
[+] >> Removed 819 empty GUID folder(s)
```

> both UV and pip cache
```powershell
C:\develop>powershell -file cleanup_processes.ps1
[*] > Checking for uv.zip archives under: C:\windows\SystemTemp\
[*] >> Found 6 uv.zip file(s), total size: 126.56 MB
[+] >> Removed 6 uv.zip file(s)
[*] > Checking for empty GUID directories under: C:\windows\SystemTemp\
[*] >> Found 6 empty GUID folder(s)
[+] >> Removed 6 empty GUID folder(s)
[*] > Checking pip http-v2 cache under: C:\windows\system32\config\systemprofile\AppData\Local\pip\cache\http-v2
[*] >> Found 1835 file(s) older than 1 day, total size: 210228.37 MB
[+] >> Removed 1835 old file(s) from http-v2 cache
[+] >> Removed 903 empty directory(ies) from http-v2 cache

C:\develop>powershell -file cleanup_uv_pipcache.ps1
[*] > Checking for uv.zip archives under: C:\windows\SystemTemp\
[*] >> Found 0 uv.zip file(s), total size: 0 MB
[*] > Checking for empty GUID directories under: C:\windows\SystemTemp\
[*] >> Found 0 empty GUID folder(s)
[*] > Checking pip http-v2 cache under: C:\windows\system32\config\systemprofile\AppData\Local\pip\cache\http-v2
[*] >> Found 0 file(s) older than 1 day, total size: 0 MB
```
CI results: TBD

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
