### PR TITLE
Exclude amdgcn-amd-amdhsa static libraries from package stripping

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -102,7 +102,8 @@
       }
     ],
     "Gfxarch": "False",
-    "Disable_DWZ": "True"
+    "Disable_DWZ": "True",
+    "Disable_RPM_STRIP": "True"
   },
   {
     "Package": "amdrocm-llvm-devel",
@@ -174,7 +175,8 @@
       }
     ],
     "Gfxarch": "False",
-    "Disable_RPM_STRIP": "True"
+    "Disable_RPM_STRIP": "True",
+    "Disable_DEB_STRIP": "True"
   },
   {
     "Package": "amdrocm-runtime",

--- a/build_tools/packaging/linux/template/debian_rules.j2
+++ b/build_tools/packaging/linux/template/debian_rules.j2
@@ -26,7 +26,7 @@ override_dh_strip:
 	# Unprefixed names
 	ln -sf "$(shell command -v llvm-strip)"   debian/.llvm-tools/strip
 	ln -sf "$(shell command -v llvm-objcopy)" debian/.llvm-tools/objcopy
-	PATH="$(CURDIR)/debian/.llvm-tools:$(PATH)" dh_strip --exclude=libompdevice.a
+	PATH="$(CURDIR)/debian/.llvm-tools:$(PATH)" dh_strip -Xlibompdevice.a -Xlibclang_rt.builtins.a -Xlibflang_rt.runtime.a
 {% endif %}
 
 override_dh_installchangelogs:


### PR DESCRIPTION
Add Disable_RPM_STRIP in amdrocm-llvm and Disable_DEB_STRIP in amdrocm-llvm-devel, and exclude libclang_rt.builtins.a and libflang_rt.runtime.a from dh_strip to prevent build failures when strip tools encounter AMDGPU target object files they cannot recognize
