### PR TITLE
Exclude all static libraries from Debian package stripping

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -175,8 +175,7 @@
       }
     ],
     "Gfxarch": "False",
-    "Disable_RPM_STRIP": "True",
-    "Disable_DEB_STRIP": "True"
+    "Disable_RPM_STRIP": "True"
   },
   {
     "Package": "amdrocm-runtime",

--- a/build_tools/packaging/linux/template/debian_rules.j2
+++ b/build_tools/packaging/linux/template/debian_rules.j2
@@ -26,7 +26,7 @@ override_dh_strip:
 	# Unprefixed names
 	ln -sf "$(shell command -v llvm-strip)"   debian/.llvm-tools/strip
 	ln -sf "$(shell command -v llvm-objcopy)" debian/.llvm-tools/objcopy
-	PATH="$(CURDIR)/debian/.llvm-tools:$(PATH)" dh_strip -Xlibompdevice.a -Xlibclang_rt.builtins.a -Xlibflang_rt.runtime.a
+	PATH="$(CURDIR)/debian/.llvm-tools:$(PATH)" dh_strip -X.a
 {% endif %}
 
 override_dh_installchangelogs:


### PR DESCRIPTION
Strip tools cannot recognize AMDGPU target object files within static                                                                                          
libraries like libclang_rt.builtins.a and libflang_rt.runtime.a, causing                                                                                       
build failures. Generalize the dh_strip exclusion pattern from specific                                                                                        
files to all .a files to prevent these errors while allowing stripping                                                                                         
of other binaries.                                                                                                                                             
                                                                                                                                                                  
Changes:                                                                                                                                                       
   - Update debian_rules.j2 to use -X.a instead of individual file exclusions                                                                                     
   - Disable the stripping of amdrocm-llvm RPM package by setting Disable_RPM_STRIP