### PR TITLE
[CI] Added commit parameter to load submodules

### DIFF
--- a/build_tools/generate_therock_manifest.py
+++ b/build_tools/generate_therock_manifest.py
@@ -32,9 +32,12 @@ def git_root() -> Path:
     return repo_root
 
 
-def list_submodules_via_gitconfig(repo_dir: Path, commit: str = "HEAD"):
+def list_submodules_from_gitmodules_at_commit(repo_dir: Path, commit: str = "HEAD"):
     """
     Read path/url/branch for all submodules from .gitmodules at a specific commit.
+
+    Uses `git config --blob` to parse .gitmodules directly from git's object database.
+    This approach lets git handle all config file parsing edge cases and works with any valid submodule names.
 
     Args:
         repo_dir: Path to the repository root.
@@ -43,45 +46,54 @@ def list_submodules_via_gitconfig(repo_dir: Path, commit: str = "HEAD"):
                 may have been added or removed since.
 
     Returns: [{name, path, url, branch}]
+
+    Raises:
+        RuntimeError: If git command fails for reasons other than missing .gitmodules.
     """
-    gitmodules_content = _run(
-        ["git", "show", f"{commit}:.gitmodules"],
-        cwd=repo_dir,
-        check=False,
+    cmd = [
+        "git",
+        "config",
+        "--blob",
+        f"{commit}:.gitmodules",
+        "--get-regexp",
+        r"^submodule\.",
+    ]
+    result = subprocess.run(
+        cmd, cwd=repo_dir, text=True, capture_output=True, check=False
     )
-    if not gitmodules_content:
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        # Exit code 1 with no stderr means no matches (no .gitmodules or no submodule entries)
+        # Exit code 1 with stderr means an actual error (invalid commit, etc.)
+        if stderr:
+            raise RuntimeError(f"Git command failed: {' '.join(cmd)}\n{stderr}")
         return []
 
     submodules_by_name = {}
-    current_name = None
 
-    for line in gitmodules_content.splitlines():
-        line = line.strip()
-        if not line:
-            continue
+    # Output format: submodule.<name>.<key> <value>
+    # Example: submodule.half.path base/half
+    # The regex uses (.+) for name to handle submodule names containing dots.
+    # The explicit \.(path|url|branch) ensures we match the last occurrence,
+    # correctly extracting names like "foo.bar" from "submodule.foo.bar.path".
+    pattern = re.compile(r"^submodule\.(.+)\.(path|url|branch)\s+(.+)$")
 
-        if line.startswith("[submodule"):
-            match = re.search(r'"([^"]+)"', line)
-            if match:
-                current_name = match.group(1)
-                submodules_by_name[current_name] = {
-                    "name": current_name,
+    for line in result.stdout.strip().splitlines():
+        match = pattern.match(line)
+        if match:
+            name, key, value = match.groups()
+            if name not in submodules_by_name:
+                submodules_by_name[name] = {
+                    "name": name,
                     "path": None,
                     "url": None,
                     "branch": None,
                 }
-        elif current_name and "=" in line:
-            key, _, value = line.partition("=")
-            key = key.strip()
-            value = value.strip()
-            if key in ("path", "url", "branch"):
-                submodules_by_name[current_name][key] = value
+            submodules_by_name[name][key] = value
 
-    results = [
-        {"name": n, "path": r["path"], "url": r["url"], "branch": r["branch"]}
-        for n, r in submodules_by_name.items()
-        if r["path"]
-    ]
+    # Filter out entries without a path and sort by path
+    results = [r for r in submodules_by_name.values() if r["path"]]
     results.sort(key=lambda r: r["path"])
     return results
 
@@ -120,9 +132,7 @@ def patches_for_submodule_by_name(repo_dir: Path, sub_name: str):
 def build_manifest_schema(repo_root: Path, the_rock_commit: str) -> dict:
 
     # Enumerate submodules from .gitmodules at the specified commit.
-    # This ensures we get the correct submodule list even for historical commits
-    # where submodules may have been added or removed since.
-    entries = list_submodules_via_gitconfig(repo_root, the_rock_commit)
+    entries = list_submodules_from_gitmodules_at_commit(repo_root, the_rock_commit)
 
     # Build rows with pins (from tree) and patch lists
     rows = []


### PR DESCRIPTION
## Motivation

The `generate_therock_manifest.py` script's `list_submodules_via_gitconfig` function previously read `.gitmodules` from the current working directory rather than from the specified commit. This caused incorrect behavior when inspecting historical commits where submodules may have been added or removed.

This limitation prevents accurate comparison of submodule changes across commits, which is critical for the manifest diff report (blamelist) feature being added in PR #3295. Without this fix, the blamelist cannot detect submodules that were **removed** between two commits.

**Example:**
- Commit `42f26ce9` had `rccl` as a submodule
- Commit `5523139d` removed `rccl`
- Old behavior: Would not detect `rccl` removal
- New behavior: Correctly identifies `rccl` and `rccl-tests` were removed

## Technical Details

Modified `list_submodules_via_gitconfig()` to accept a `commit` parameter (default: `"HEAD"`):
- Now uses `git show <commit>:.gitmodules` to read the file at the specified commit
- Removed the previous `git config -f .gitmodules` approach
- Updated `build_manifest_schema()` to pass `the_rock_commit` to the function

This simplifies the code (reduced from 248 to 189 lines) while enabling historical commit inspection.

**Backward Compatibility:**
- CMake builds are unaffected - they use default HEAD behavior
- CLI usage produces identical results for current commits

## Test Plan

Tested with commits where submodules were added/removed:

```bash
# Commit with rccl submodule - should find 18 submodules including rccl
python3 generate_therock_manifest.py --commit 42f26ce9 -o /tmp/old.json

# Commit where rccl was removed - should find 16 submodules without rccl
python3 generate_therock_manifest.py --commit 5523139d -o /tmp/new.json

# Default HEAD behavior - should work as before
python3 generate_therock_manifest.py -o /tmp/head.json
```

## Test Result

- Historical commit with RCCL: Found 18 submodules including `rccl`, `rccl-tests`
- Historical commit without RCCL: Found 16 submodules (rccl correctly absent)
- Default HEAD behavior: Works correctly for CMake builds
- Removed submodule detection: `['rccl', 'rccl-tests']` correctly identified

## Updates (Review Feedback)

Addressed review comments:

1. **Function renamed** from `list_submodules_via_gitconfig` to 
   `list_submodules_from_gitmodules_at_commit` for clarity

2. **Robust parsing** using `git config --blob` instead of manual parsing:
   - Git handles all config edge cases (comments, quoting, escapes)
   - Supports submodule names containing dots
   - Available since Git 1.8.5

3. **Better error handling**:
   - Missing `.gitmodules` returns empty list (no error)
   - Invalid commits raise `RuntimeError` with clear message

# Generated Manifest at 42f26ce9 
```bash
{
  "the_rock_commit": "42f26ce904cacbf4877edf03f6ebfa9da1c16434",
  "submodules": [
    {
      "submodule_name": "half",
      "submodule_path": "base/half",
      "submodule_url": "https://github.com/ROCm/half.git",
      "pin_sha": "207ee58595a64b5c4a70df221f1e6e704b807811",
      "patches": []
    },
    {
      "submodule_name": "rocm-cmake",
      "submodule_path": "base/rocm-cmake",
      "submodule_url": "https://github.com/ROCm/rocm-cmake.git",
      "pin_sha": "10155d7272ea1bf79f6b5a9dbc339657af1aa372",
      "patches": []
    },
    {
      "submodule_name": "rocm-kpack",
      "submodule_path": "base/rocm-kpack",
      "submodule_url": "https://github.com/ROCm/rocm-kpack.git",
      "pin_sha": "fe9dd03a738e6810b2876635de093b2dde1ce243",
      "patches": []
    },
    {
      "submodule_name": "rccl",
      "submodule_path": "comm-libs/rccl",
      "submodule_url": "https://github.com/ROCm/rccl.git",
      "pin_sha": "4b295c9893fa67dbff43702511d818883b704af3",
      "patches": []
    },
    {
      "submodule_name": "rccl-tests",
      "submodule_path": "comm-libs/rccl-tests",
      "submodule_url": "https://github.com/ROCm/rccl-tests.git",
      "pin_sha": "5272cd16efeeb5012f17e5541a39af9de6aa9eae",
      "patches": []
    },
    {
      "submodule_name": "llvm-project",
      "submodule_path": "compiler/amd-llvm",
      "submodule_url": "https://github.com/ROCm/llvm-project.git",
      "pin_sha": "985b939f680e287971357dd4246d822d093bca09",
      "patches": [
        "patches/amd-mainline/llvm-project/0001-Ensure-to-use-libamdhip64-with-major-version.patch",
        "patches/amd-mainline/llvm-project/0002-hipcc-fix-default-include-path-on-Windows-and-adapt-.patch",
        "patches/amd-mainline/llvm-project/0006-Rework-constructHipPath-so-HIP_PATH-env-var-is-lower.patch",
        "patches/amd-mainline/llvm-project/0009-Add-gcc-toolset-13-prefix-detection.patch"
      ]
    },
    {
      "submodule_name": "HIPIFY",
      "submodule_path": "compiler/hipify",
      "submodule_url": "https://github.com/ROCm/HIPIFY.git",
      "pin_sha": "d59429d925c63045239dd59693cf3228dabe540d",
      "patches": []
    },
    {
      "submodule_name": "spirv-llvm-translator",
      "submodule_path": "compiler/spirv-llvm-translator",
      "submodule_url": "https://github.com/ROCm/SPIRV-LLVM-Translator.git",
      "pin_sha": "0eaeb117e9e24f16217352688b31a1c73d8d6b28",
      "patches": []
    },
    {
      "submodule_name": "amd-dbgapi",
      "submodule_path": "debug-tools/amd-dbgapi",
      "submodule_url": "https://github.com/ROCm/ROCdbgapi.git",
      "pin_sha": "e9b61bed8f209e2a8f4b150e6f00c81a5fde465c",
      "patches": []
    },
    {
      "submodule_name": "rocgdb",
      "submodule_path": "debug-tools/rocgdb/source",
      "submodule_url": "https://github.com/ROCm/rocgdb.git",
      "pin_sha": "488cc50ea6906e7fa9e3a5c86c2696395feba68a",
      "patches": []
    },
    {
      "submodule_name": "rocr-debug-agent",
      "submodule_path": "debug-tools/rocr-debug-agent",
      "submodule_url": "https://github.com/ROCm/rocr_debug_agent.git",
      "pin_sha": "d723cf0063eb9a53b5d781202fb4b95b75c9c56b",
      "patches": []
    },
    {
      "submodule_name": "fusilli",
      "submodule_path": "iree-libs/fusilli",
      "submodule_url": "https://github.com/iree-org/fusilli.git",
      "pin_sha": "c605b0296ad33484ec0328a8e391ccad15f82b5c",
      "patches": []
    },
    {
      "submodule_name": "iree",
      "submodule_path": "iree-libs/iree",
      "submodule_url": "https://github.com/iree-org/iree.git",
      "pin_sha": "71967b3ce67a53ffc2823585a8f5c1598323ecbe",
      "patches": []
    },
    {
      "submodule_name": "libhipcxx",
      "submodule_path": "math-libs/libhipcxx",
      "submodule_url": "https://github.com/ROCm/libhipcxx.git",
      "pin_sha": "c1362eb7e2f9a006b095b1a4f83729b0a9e47663",
      "patches": []
    },
    {
      "submodule_name": "rocprof-trace-decoder",
      "submodule_path": "profiler/rocprof-trace-decoder/binaries",
      "submodule_url": "https://github.com/ROCm/rocprof-trace-decoder.git",
      "pin_sha": "12c9d5871b3f803937ef92f1adce9294dfc549a7",
      "patches": []
    },
    {
      "submodule_name": "rocm-libraries",
      "submodule_path": "rocm-libraries",
      "submodule_url": "https://github.com/ROCm/rocm-libraries",
      "pin_sha": "66e22ac6c6c0c286325cabf2b1faa269ea640446",
      "patches": []
    },
    {
      "submodule_name": "rocm-systems",
      "submodule_path": "rocm-systems",
      "submodule_url": "https://github.com/ROCm/rocm-systems.git",
      "pin_sha": "0decb2cfbd4e4753c728fb6fa756a1dbfe52bfc6",
      "patches": [
        "patches/amd-mainline/rocm-systems/0001-Revert-SWDEV-543498-Some-compute-Ubertrace-profiles-.patch",
        "patches/amd-mainline/rocm-systems/0003-Use-is_versioned-true-consistently-in-both-Comgr-Loa.patch"
      ]
    },
    {
      "submodule_name": "amd-mesa",
      "submodule_path": "third-party/sysdeps/linux/amd-mesa/mesa-fork",
      "submodule_url": "https://github.com/ROCm/mesa-fork.git",
      "pin_sha": "1d400ffb3637061fb46117ea0495b541d75eb542",
      "patches": []
    }
  ]
}
```
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
