### PR TITLE
[ci] Adding timeout to `setup_test_environment` and `clean_processes.ps1` steps for `test_sanity_check` and `test_component` YML files

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -90,7 +90,7 @@ jobs:
           repository: "ROCm/TheRock"
 
       - name: Run setup test environment workflow
-        timeout-minutes: 10
+        timeout-minutes: 15
         uses: './.github/actions/setup_test_environment'
         with:
           ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -106,7 +106,7 @@ jobs:
           docker network prune -f || true
 
       - name: Run setup test environment workflow
-        timeout-minutes: 10
+        timeout-minutes: 15
         uses: './.github/actions/setup_test_environment'
         with:
           ARTIFACT_GROUP: ${{ inputs.artifact_group }}


### PR DESCRIPTION
From #3501 and other test jobs, we have noticed crazy timeouts for `cleanup_processes.ps1` and `setup_test_environment` (2h+), so we are adding step timeouts to limit this.

`test_component.yml` already has a 210 min timeout, will need to replicate this over to rocm-libraries and systems as well.

Test ran here fine: https://github.com/ROCm/TheRock/actions/runs/22192247857, so adding `skip-ci` label, as this only affects test_sanity_check + test_component