### PR TITLE
Mark hip-tests and aqlprofile-tests target neutral

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -481,11 +481,11 @@ platform = "windows"
 artifact_deps = ["core-hip"]
 feature_group = "CORE"  # Part of core, enabled by default
 
-# --- hip-tests (per-arch) ---
+# --- hip-tests ---
 
 [artifacts.core-hiptests]
 artifact_group = "hip-runtime"
-type = "target-specific"
+type = "target-neutral"
 artifact_deps = ["core-hip"]
 feature_group = "CORE"  # Part of core, enabled by default
 
@@ -598,7 +598,7 @@ disable_platforms = ["windows"]
 
 [artifacts.aqlprofile-tests]
 artifact_group = "profiler-core"
-type = "target-specific"
+type = "target-neutral"
 artifact_deps = ["core-runtime"]
 feature_group = "PROFILER"
 disable_platforms = ["windows"]

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -291,6 +291,7 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
     therock_cmake_subproject_activate(hip-tests)
     # Provide it as an artifact:
     therock_provide_artifact(core-hiptests
+      TARGET_NEUTRAL
       DESCRIPTOR artifact-core-hiptests.toml
       COMPONENTS
         test

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -49,6 +49,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
 
 if(THEROCK_BUILD_TESTING)
   therock_provide_artifact(aqlprofile-tests
+    TARGET_NEUTRAL
     DESCRIPTOR artifact-aqlprofile.toml
     COMPONENTS
       test


### PR DESCRIPTION
## Motivation

hip-tests and aqlprofile-tests were failing in multi-arch CI. 

Fixes #3341
Fixes #3342

## Technical Details

This adopts the changes from commit de77353 to mark hip-tests and aqlprofile-tests as target neutral. With this change the tests will include *all* device code for GPUs passed via `THEROCK_DIST_AMDGPU_FAMILIES` in the case of a multi-arch build. The global CMake changes that needed to be reverted are not part of this PR.

## Test Plan

https://github.com/ROCm/TheRock/actions/runs/22187848310

## Test Result

Tests passing in multi-arch CI.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
