### PR TITLE
Fix run_pytorch_tests.py crash on Python 3.14 (BooleanOptionalAction --no- prefix)

### DIFF
--- a/external-builds/pytorch/run_pytorch_tests.py
+++ b/external-builds/pytorch/run_pytorch_tests.py
@@ -195,7 +195,7 @@ By default the pytorch directory is determined based on this script's location
         default=True,
         required=False,
         action=argparse.BooleanOptionalAction,
-        help="""Enable pytest caching. Use --no-cache when only having read-only access to pytorch directory""",
+        help="""Enable pytest caching (default). Use --no-cache when only having read-only access to pytorch directory""",
     )
 
     args = parser.parse_args(argv)


### PR DESCRIPTION
## Summary

Python 3.14 no longer allows `--no-` prefixed option names with `argparse.BooleanOptionalAction` (python/cpython#117941).

`run_pytorch_tests.py` defined `--no-cache` with `BooleanOptionalAction`, which crashes on Python 3.14:

## Failing job

- https://github.com/ROCm/TheRock/actions/runs/22133299032/job/64272029131 for branch `users/subodh-dubey-amd/pytorch-314`

## Testing

- **Test py 3.10–3.13:** https://github.com/ROCm/TheRock/actions/runs/22222064763
- **Python 3.14 fix:** https://github.com/ROCm/TheRock/actions/runs/22222485256

## Dependency chain

#3535 (this) → #3540 (skip test failures) → #2783 (add py3.14 to matrix)

## Related

- Fixes #2640
- Tracks #2985
- Unblocks #2783


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.'