### PR TITLE
Skip 4 PyTorch tests failing on Python 3.14 due to CPython breaking changes.

### DIFF
--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -49,9 +49,6 @@ skip_tests = {
             # AttributeError: 'Model' object has no attribute '__annotations__'
             # https://github.com/ROCm/TheRock/issues/2985
             "test_autocast_cat_jit",
-            # Python 3.14: floating-point precision issue causing UnboundLocalError during cleanup
-            # https://github.com/ROCm/TheRock/issues/2985
-            "test_max_split_expandable",
             # ----------------
             # maybe failing
             # ----------------


### PR DESCRIPTION
## Summary

Skip 4 PyTorch tests failing on Python 3.14 due to CPython breaking changes. ( [CI Failed Run](https://github.com/ROCm/TheRock/actions/runs/22222485256/job/64288500320) )
(https://github.com/ROCm/TheRock/actions/runs/22712976762)



| Test | Cause |
|---|---|
| `test_autocast_cat_jit` | PEP 649: `__annotations__` removed from instances |
| `test_max_split_expandable` | Float precision rounding → `UnboundLocalError` in cleanup |
| `test_storage_dealloc_subclass_resurrected` | Storage deallocation behavior changed |
| `test_storage_dealloc_subclass_zombie` | Storage deallocation behavior changed |

Added to `"common"` section (not `"windows"`) since these affect all platforms with Python 3.14. Impact: 4 of 15,454 tests. Marked `# Python 3.14:` for re-enablement when fixed upstream.


## Tests

- **Python 3.14 validation:** <link after dispatch on this branch>

## Dependency Chain

#3535 (argparse fix) → #3540 (skip test failures) → [#4145](https://github.com/ROCm/TheRock/pull/4145) (add py3.14 to matrix)

```
#3535  Fix argparse crash on Python 3.14
  └── #3540 This PR — skip known test failures
        └── #4145 Add Python 3.14 to build matrix
```

## Related

- Tracks #2985 
- Unblocks #4145
- Supports #2258

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.