### PR TITLE
[ci] Disabling gfx950-dcgpu for multi-arch tests

### DIFF
--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -78,7 +78,7 @@ jobs:
         # TODO(TheRock#3288): Re-enable gfx950-dcgpu runners once we get more capacity
         exclude:
           - family_info:
-            amdgpu_family: gfx950-dcgpu
+              amdgpu_family: gfx950-dcgpu
 
     uses: ./.github/workflows/test_artifacts.yml
     with:


### PR DESCRIPTION
Due to large queue times for gfx950-dcgpu, we are excluding gfx950 for multi arch tests. Tagged issue #3288

Here's a cancelled run of gfx950 and gfx94X running properly during a normal CI run: https://github.com/ROCm/TheRock/actions/runs/22237123949 (check CI step summary)

Here's a cancelled run of gfx950 and gfx94X running and gfx950 being ignored properly during multi-arch CI run:
https://github.com/ROCm/TheRock/actions/runs/22237181472 (check CI step summary)

Adding skip-ci label as build is unrelated and no need to waste resources

