### PR TITLE
Install sccache to /opt/sccache/bin to avoid meson auto-detection

### DIFF
--- a/dockerfiles/install_sccache.sh
+++ b/dockerfiles/install_sccache.sh
@@ -23,9 +23,13 @@ curl --silent --fail --show-error --location \
     "${SCCACHE_URL}" \
     --output sccache.tar.gz
 
+INSTALL_DIR="/opt/sccache/bin"
+mkdir -p "${INSTALL_DIR}"
+
 tar xf sccache.tar.gz
-cp "sccache-v${SCCACHE_VERSION}-${SCCACHE_ARCH}/sccache" /usr/local/bin/
-chmod +x /usr/local/bin/sccache
+cp "sccache-v${SCCACHE_VERSION}-${SCCACHE_ARCH}/sccache" "${INSTALL_DIR}/"
+chmod +x "${INSTALL_DIR}/sccache"
 
 echo "sccache installed successfully:"
-sccache --version
+"${INSTALL_DIR}/sccache" --version
+echo "Installed to ${INSTALL_DIR} (not on PATH by default)"


### PR DESCRIPTION
## Motivation

Fixes #3522 — meson auto-detects sccache on PATH and uses it as a compiler launcher during TheRock builds. Without S3 credentials or config, this causes `Resource temporarily unavailable (os error 11)` failures (e.g. libdrm).

## Fix

Install sccache to `/opt/sccache/bin/` instead of `/usr/local/bin/` so it's available in the image but **not on PATH by default**. Workflows that need sccache (PyTorch builds in #3532) will explicitly add it to PATH.

## Follow-up

After this merges and the image rebuilds, a separate PR will update the image SHA in workflows (per [dockerfile update process](https://github.com/ROCm/TheRock/tree/main/dockerfiles#updating-images-used-by-github-actions-workflows)).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.