### PR TITLE
amdclang* executable missing from <rock>/bin

### DIFF
--- a/base/aux-overlay/CMakeLists.txt
+++ b/base/aux-overlay/CMakeLists.txt
@@ -14,12 +14,28 @@ project(therock-aux-overlay)
 
 if(NOT WIN32)
   add_custom_target(symlinks ALL
+    COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/bin"
     COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm" "${CMAKE_CURRENT_BINARY_DIR}/llvm"
     COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/amdgcn" "${CMAKE_CURRENT_BINARY_DIR}/amdgcn"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/bin/amdclang" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/bin/amdflang" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdflang"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/bin/amdclang++" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang++"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/bin/amdclang-cl" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang-cl"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/bin/amdclang-cpp" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang-cpp"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/bin/amdlld" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdlld"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/bin/offload-arch" "${CMAKE_CURRENT_BINARY_DIR}/bin/offload-arch"
   )
   install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/bin"
     "${CMAKE_CURRENT_BINARY_DIR}/llvm"
     "${CMAKE_CURRENT_BINARY_DIR}/amdgcn"
+    "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang"
+    "${CMAKE_CURRENT_BINARY_DIR}/bin/amdflang"
+    "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang++"
+    "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang-cl"
+    "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang-cpp"
+    "${CMAKE_CURRENT_BINARY_DIR}/bin/amdlld"
+    "${CMAKE_CURRENT_BINARY_DIR}/bin/offload-arch"
     DESTINATION .
   )
 endif()


### PR DESCRIPTION
https://amd-hub.atlassian.net/browse/ROCM-2437

This issue was also noticed by the HPC division.

/bin is missing all the symlinks to the amd* executables that were present in the ROCm releases 7.2.x on back to 6.x

These links are a requirement for the HPC customers (ORNL and LLNL). The customer does not want AMD provided flang/clang/clang++/etc executable names to appear in PATH search.

/opt/rocm-7.2.0/bin/amdclang -> ../lib/llvm/bin/amdclang
/opt/rocm-7.2.0/bin/amdclang++ -> ../lib/llvm/bin/amdclang++
/opt/rocm-7.2.0/bin/amdclang-cl -> ../lib/llvm/bin/amdclang-cl
/opt/rocm-7.2.0/bin/amdclang-cpp -> ../lib/llvm/bin/amdclang-cpp
/opt/rocm-7.2.0/bin/amdflang -> ../lib/llvm/bin/amdflang
/opt/rocm-7.2.0/bin/amdlld -> ../lib/llvm/bin/amdlld
/opt/rocm-7.2.0/bin/offload-arch -> ../lib/llvm/bin/offload-arch

 