### PR TITLE
Add support of python 3.11,3.13,3.14 for jax

### DIFF
--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python_version: ["3.10", "3.11", "3.12", "3.13"]
         pytorch_git_ref: ["release/2.7", "release/2.8", "release/2.9", "release/2.10", "nightly"]
 
     uses: ./.github/workflows/build_portable_linux_pytorch_wheels.yml


### PR DESCRIPTION
## Motivation

https://amd-hub.atlassian.net/browse/AIDEVOPS-67 - Framework support for 7.12 Release
A request came to add python 3.11,3.13,3.14 support for jax

## Technical Details

Add support of python 3.11,3.13,3.14 for jax

## Test Plan

Add python 3.11,3.13,3.14 in the workflow's matrix and run a build. 
https://github.com/ROCm/TheRock/actions/runs/22324002971

## Test Result

Jax built successfully for python 3.11,3.13,3.14

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
