### PR TITLE
Disable DWZ compression for amdrocm-profiler and fix packaging bugs

### DIFF
--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -372,7 +372,7 @@ def generate_debian_postscripts(pkg_info, deb_dir, config: PackageConfig):
     parts = config.rocm_version.split(".")
     if len(parts) < 3:
         raise ValueError(
-            f"Version string '{args.rocm_version}' does not have major.minor.patch versions"
+            f"Version string '{config.rocm_version}' does not have major.minor.patch versions"
         )
 
     env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
@@ -449,20 +449,16 @@ def package_with_dpkg_build(pkg_dir):
     Returns: None
     """
     print_function_name()
-    current_dir = Path.cwd()
-    os.chdir(Path(pkg_dir))
     # Build the command
     cmd = ["dpkg-buildpackage", "-uc", "-us", "-b"]
 
     # Execute the command
     try:
-        subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True, cwd=pkg_dir)
         print(f"Deb Package built successfully: {os.path.basename(pkg_dir)}")
     except subprocess.CalledProcessError as e:
-        print(f"Error building deb package{os.path.basename(pkg_dir)}: {e}")
+        print(f"Error building deb package: {os.path.basename(pkg_dir)}: {e}")
         sys.exit(e.returncode)
-
-    os.chdir(current_dir)
 
 
 ######################## RPM package creation ####################

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -999,6 +999,7 @@
       }
     ],
 
+    "Disable_DWZ": "True",
     "Gfxarch": "False"
   },
   {


### PR DESCRIPTION
  - Add "Disable_DWZ": "True" for amdrocm-profiler package to prevent DWZ DWARF optimization which is causing packaging build failure
  - Fix incorrect variable reference: args.rocm_version -> config.rocm_version in version validation error message
  - Refactor package_with_dpkg_build to use subprocess cwd parameter instead of manually changing directories with os.chdir
  - Fix error message formatting (add missing colon separator)

Fixes #3582.