### PR TITLE
Disable building torch < 2.10 for gfx1153

### DIFF
--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -94,6 +94,8 @@ jobs:
         # redefine arch as inputs.x vars are not available in matrix context
         arch: ["${{ inputs.amdgpu_family }}"]
         exclude:
+        # gfx1153 support is only available in pytorch 2.10+
+        # see https://github.com/ROCm/TheRock/issues/2723
         - arch: "gfx1153"
           pytorch_git_ref: "release/2.8"
         - arch: "gfx1153"

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -94,6 +94,8 @@ jobs:
         # redefine arch as inputs.x vars are not available in matrix context
         arch: ["${{ inputs.amdgpu_family }}"]
         exclude:
+        # gfx1153 support is only available in pytorch 2.10+
+        # see https://github.com/ROCm/TheRock/issues/2723
         - arch: "gfx1153"
           pytorch_git_ref: "release/2.9"
 


### PR DESCRIPTION
Gfx1153 PyTorch builds are currently failing for PyTorch < 2.10 due to missing CK support.

This resolves #2723 and https://github.com/ROCm/pytorch/issues/2971 by disabling building PyTorch < 2.10 on gfx1153 as CK fix is only backported for 2.10 but not to any older PyTorch versions.

