### PR TITLE
Fix error text from `rocm-sdk[devel]` to `rocm[devel]` for missing package

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -46,8 +46,8 @@ def get_devel_root() -> Path:
         import rocm_sdk_devel
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError(
-            "ROCm SDK development package is not installed. This can typically be "
-            "obtained by installing `rocm[devel]` from your package manager"
+            "rocm_sdk_devel module for the ROCm SDK development package is not installed. "
+            "This can typically be obtained by installing `rocm[devel]` from your package manager"
         ) from e
     rocm_sdk_devel_path = _get_package_path(rocm_sdk_devel)
     if rocm_sdk_devel_path is None:
@@ -123,7 +123,7 @@ def _expand_devel_contents(rocm_sdk_devel_path: Path, site_lib_path: Path):
         raise ImportError(
             "Cannot expand the `rocm[devel]` package because it was not installed "
             "by a user-mode package manager and is managed by the system. Please "
-            "install the `rocm-sdk` in a virtual environment."
+            "install `rocm[devel]` in a virtual environment."
         )
 
     if dist_name is None or record_pkg_file is None:


### PR DESCRIPTION
## Motivation

Matching the error message to the actual package name:

```bash
pip install --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ torch
rocm-sdk init
# ERROR: ROCm SDK development package is not installed. This can typically be obtained by installing `rocm-sdk[devel]` from your package manager

pip install --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ rocm-sdk[devel]
# Looking in indexes: https://rocm.nightlies.amd.com/v2/gfx110X-all/
# ERROR: Could not find a version that satisfies the requirement rocm-sdk[devel] (from versions: none)

pip install --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ rocm[devel]
rocm-sdk init
# Devel contents expanded to 'D:\scratch\therock\3.12.venv\Lib\site-packages\_rocm_sdk_devel'
```

## Technical Details

See also
* https://github.com/ROCm/TheRock/pull/796
* https://github.com/ROCm/TheRock/pull/3294

## Test Plan

No more results for a `rocm-sdk[` search across the project

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
