### PR TITLE
[ci] Ignoring smoke tests for gfx1151 windows

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -104,6 +104,8 @@ amdgpu_family_info_matrix_presubmit = {
             "family": "gfx1151",
             "fetch-gfx-targets": ["gfx1151"],
             "build_variants": ["release"],
+            # TODO(#3299): Re-enable smoke tests once capacity is available for Windows gfx1151
+            "run-full-tests-only": True,
         },
     },
     "gfx120x": {

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -661,6 +661,11 @@ def main(base_args, linux_families, windows_families):
             test_type = "full"
             test_type_reason = f"test label(s) specified: {combined_test_labels}"
 
+    # If the "run-full-tests-only" flag is set for this family, we do not run tests if it is a smoke test type
+    for matrix_row in linux_variants_output + windows_variants_output:
+        if matrix_row.get("run-full-tests-only", False) and test_type == "smoke":
+            matrix_row["test-runs-on"] = ""
+
     print(f"test_type decision: '{test_type}' (reason: {test_type_reason})")
 
     # Format variants for summary - handle both regular and multi-arch modes


### PR DESCRIPTION
To remediate windows gfx1151 queues (#3299 and #3050), we are only running Windows gfx1151 tests if the `test_type` is full. 

This means no smoke tests will be run for this architecture

Tests ran via workflow_dispatch: 
- [full tests](https://github.com/ROCm/TheRock/actions/runs/22412198467/job/64888425151#step:4:77) (cancelled to save resources but you can see it ran both)
- [smoke tests](https://github.com/ROCm/TheRock/actions/runs/22412250700/job/64888603214#step:4:75) (cancelled to save resources but you can see it skipped gfx1151)

Adding `skip-ci` label as tests above prove it working