### PR TITLE
Changing tagging bot to systems assistant

### DIFF
--- a/.github/workflows/hip_tagging_automation.yml
+++ b/.github/workflows/hip_tagging_automation.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.PULL_REQUEST_APP_ID }}
-          private-key: ${{ secrets.PULL_REQUEST_APP_KEY }}
+          app-id: ${{ secrets.ROCM_SYSTEMS_APP_ID }}
+          private-key: ${{ secrets.ROCM_SYSTEMS_APP_PRIVATE_KEY }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Motivation

Current bot does not have access and permissions to tag rocm-systems repo, switching it out to use systems-assistant bot

## Technical Details

Changing APP-ID and KEY
