### PR TITLE
[Jax] Add missing gfx90x values to amdgpu_family inputs

### DIFF
--- a/.github/workflows/release_portable_linux_jax_wheels.yml
+++ b/.github/workflows/release_portable_linux_jax_wheels.yml
@@ -48,11 +48,11 @@ on:
           - gfx1152
           - gfx1153
           - gfx120X-all
-          - gfx94X-dcgpu
-          - gfx950-dcgpu
           - gfx906
           - gfx908
           - gfx90a
+          - gfx94X-dcgpu
+          - gfx950-dcgpu
         default: gfx94X-dcgpu
       release_type:
         description: The type of release to build ("dev", "nightly", or "prerelease"). All developer-triggered jobs should use "dev"!


### PR DESCRIPTION
## Motivation

Nightly Linux packages workflow failed to trigger the JAX workflow because the `workflow_dispatch` input `amdgpu_family` uses type: `choice` with restricted options.

>Error: Provided value 'gfx908' for input 'amdgpu_family' not in the list of allowed values.

 release_portable_linux_jax_wheels.yml was missed in commit https://github.com/ROCm/TheRock/commit/8f17ad65be8002c5ba3d58097f9d44bd5d9131c0

**Change:** Extend `amdgpu_family` choice options to include values `gfx906, gfx908, gfx90a`

## Files Changed
`.github/workflows/release_portable_linux_jax_wheels.yml`

## Test Plan

Linux packages: https://github.com/ROCm/TheRock/actions/runs/22437344248

## Test Result

Successfully triggered jax workflow: https://github.com/ROCm/TheRock/actions/runs/22443708136
## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
