### PR TITLE
[llvm-tools] enable build/install of llvm-dis llvm-as

### DIFF
--- a/compiler/pre_hook_amd-llvm.cmake
+++ b/compiler/pre_hook_amd-llvm.cmake
@@ -172,7 +172,9 @@ if(NOT THEROCK_ENABLE_LLVM_TESTS)
     # on a missing tool).
     set(_llvm_required_tools
       LLVM_AR
+      LLVM_AS
       LLVM_CONFIG
+      LLVM_DIS
       LLVM_DWARFDUMP
       LLVM_LINK
       LLVM_MC


### PR DESCRIPTION
There are internal/external customers that compile with -save-temps and then convert the bc to ll using llvm-dis so they can edit/protype changes, then they convert the ll back to bc and feed it to compiler.


