### PR TITLE
Fix stdout pollution from offload-arch warnings (#3109)

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -144,7 +144,11 @@ def discover_current_target_family() -> str | None:
                     return arch
     except subprocess.CalledProcessError as e:
         if _VERBOSE:
-            print(f"[rocm_sdk] offload-arch failed: {e.returncode}", file=sys.stderr)
+            print(
+                f"[rocm_sdk] offload-arch failed with return code {e.returncode}",
+                file=sys.stderr,
+            )
+            print(f"[rocm_sdk] output: {e.output}", file=sys.stderr)
     except FileNotFoundError:
         if _VERBOSE:
             print("[rocm_sdk] offload-arch not found", file=sys.stderr)


### PR DESCRIPTION
## Motivation

Suppress warning messages printed to stdout when offload-arch fails in GPU-less environments. This fixes build failures in vLLM and other tools that depend on clean stdout from `import torch`.

Fixes: https://github.com/ROCm/TheRock/issues/3109

## Technical Details

- Capture subprocess stdout/stderr to prevent offload-arch output leaking
- Gate warning messages behind ROCM_SDK_VERBOSE environment variable
- Output warnings to stderr instead of stdout when verbose mode enabled
- Use os.environ.copy() to avoid modifying global environment

Set ROCM_SDK_VERBOSE=1 to enable diagnostic messages.

## Test Plan

1. Build ROCm in personal branch with the fix
2. Test in local machine with ROCm build in step 1.
3. Run "python -c 'import torch' 2> /dev/null" to check output.

## Test Result

After fix:
root@b8e75cfcdb2b:/app# python -c 'import torch'  2>/dev/null
(no output)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
