### PR TITLE
[rocprofiler-systems] Add `test` artifact

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -278,6 +278,7 @@ endif(THEROCK_BUILD_TESTING)
         doc
         lib
         run
+        test
       SUBPROJECT_DEPS
         amdsmi
         rocprofiler-sdk

--- a/profiler/artifact-rocprofiler-systems.toml
+++ b/profiler/artifact-rocprofiler-systems.toml
@@ -8,10 +8,18 @@ include = [
 [components.lib."profiler/rocprofiler-systems/stage"]
 include = [
   "libexec/rocprofiler-systems/**",
-  "share/rocprofiler-systems/**",
 ]
 [components.run."profiler/rocprofiler-systems/stage"]
 include = [
   "bin/**",
-  "share/rocprofiler-systems/**"
+  "share/rocprofiler-systems/**",
+]
+exclude = [
+  "share/rocprofiler-systems/examples/**",
+  "share/rocprofiler-systems/tests/**",
+]
+[components.test."profiler/rocprofiler-systems/stage"]
+include = [
+  "share/rocprofiler-systems/examples/**",
+  "share/rocprofiler-systems/tests/**",
 ]


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

I noticed in #3602 that our GPU tests would be skipped.
For now, adding a test artifact may help as previously, both `lib` and `run` would include the example binaries and that may have caused problems.

AIPROFSYST-222

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Add `test` artifact to `rocprofiler-systems` and exclude `share/rocprofiler-systems/examples` and `share/rocprofiler-systems/tests` from being part of both the `run` and `lib` artifacts. 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
