### PR TITLE
Revert "Change hip-tests and aqlprofile-tests to TARGET_NEUTRAL"

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -493,11 +493,11 @@ platform = "windows"
 artifact_deps = ["core-hip"]
 feature_group = "CORE"  # Part of core, enabled by default
 
-# --- hip-tests ---
+# --- hip-tests (per-arch) ---
 
 [artifacts.core-hiptests]
 artifact_group = "hip-runtime"
-type = "target-neutral"
+type = "target-specific"
 artifact_deps = ["core-hip"]
 feature_group = "CORE"  # Part of core, enabled by default
 
@@ -633,7 +633,7 @@ disable_platforms = ["windows"]
 
 [artifacts.aqlprofile-tests]
 artifact_group = "profiler-core"
-type = "target-neutral"
+type = "target-specific"
 artifact_deps = ["core-runtime"]
 feature_group = "PROFILER"
 disable_platforms = ["windows"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,15 +308,8 @@ therock_report_features()
 ################################################################################
 
 set(THEROCK_AMDGPU_FAMILIES "" CACHE STRING "AMDGPU target families to build for")
-set(THEROCK_AMDGPU_TARGETS "" CACHE STRING "AMDGPU targets to build for (individual gfx targets in addition to those expanded from THEROCK_AMDGPU_FAMILIES)")
+set(THEROCK_AMDGPU_TARGETS "" CACHE STRING "AMDGPU targets to build for")
 set(THEROCK_AMDGPU_DIST_BUNDLE_NAME "" CACHE STRING "Distribution bundle name for AMDGPU packages")
-
-# Note that if THEROCK_DIST_AMDGPU_FAMILIES and THEROCK_DIST_AMDGPU_TARGETS are empty, then
-# this defaults to the build targets (THEROCK_AMDGPU_FAMILIES). These "dist" targets are used
-# for runtime libraries that embed device code and are marked as target-neutral (which typically
-# means generate for all supported architectures).
-set(THEROCK_DIST_AMDGPU_FAMILIES "" CACHE STRING "AMDGPU target families to use for target-neutral projects")
-set(THEROCK_DIST_AMDGPU_TARGETS "" CACHE STRING "AMDGPU targets to build for (individual gfx targets in addition to those expanded from THEROCK_DIST_AMDGPU_FAMILIES)")
 
 therock_validate_amdgpu_targets()
 

--- a/base/aux-overlay/CMakeLists.txt
+++ b/base/aux-overlay/CMakeLists.txt
@@ -43,10 +43,6 @@ endif()
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/overlay/" DESTINATION ".")
 
 # Generate distribution info.
-# GPU_TARGETS comes from THEROCK_DIST_AMDGPU_TARGETS (set via therock_subproject.cmake
-# for USE_DIST_AMDGPU_TARGETS projects). This is read by downstream tools via
-# `rocm-sdk targets` to determine which architectures to build for (e.g. PyTorch
-# sets PYTORCH_ROCM_ARCH from this).
 string(JSON dist_info_json_str SET "{}"
   "dist_amdgpu_targets" "\"${GPU_TARGETS}\""
 )

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -242,19 +242,12 @@ function(therock_validate_amdgpu_targets)
   endforeach()
 
   # Expand dist families (THEROCK_DIST_AMDGPU_FAMILIES -> THEROCK_DIST_AMDGPU_TARGETS).
-  # If neither THEROCK_DIST_AMDGPU_FAMILIES nor THEROCK_DIST_AMDGPU_TARGETS is set,
-  # dist defaults to the build families (THEROCK_AMDGPU_FAMILIES).
-  #
-  # IMPORTANT: The resulting dist targets are encoded into dist_info.json
-  # (via base/aux-overlay) and exposed through `rocm-sdk targets`. Downstream
-  # consumers like PyTorch use this to set PYTORCH_ROCM_ARCH. Defaulting to
-  # all available targets instead of build targets will cause downstream
-  # builds to attempt compilation for ~30 architectures. See #3348/#3442.
-  set(_dist_expanded_targets "${THEROCK_DIST_AMDGPU_TARGETS}")
+  # If THEROCK_DIST_AMDGPU_FAMILIES is not set, it defaults to THEROCK_AMDGPU_FAMILIES.
   set(_dist_families "${THEROCK_DIST_AMDGPU_FAMILIES}")
-  if(NOT _dist_families AND NOT _dist_expanded_targets)
+  if(NOT _dist_families)
     set(_dist_families "${THEROCK_AMDGPU_FAMILIES}")
   endif()
+  set(_dist_expanded_targets)
   foreach(_family ${_dist_families})
     if(NOT "${_family}" IN_LIST _available_families)
       string(JOIN " " _families_pretty ${_available_families})
@@ -269,7 +262,7 @@ function(therock_validate_amdgpu_targets)
 
   # Report dist targets if different from per-arch targets.
   if(_dist_expanded_targets AND NOT "${_dist_expanded_targets}" STREQUAL "${_expanded_targets}")
-    message(STATUS "* Dist targets: ${_dist_expanded_targets}")
+    message(STATUS "Dist targets: ${_dist_expanded_targets}")
   endif()
 
   # Handle the case where per-arch targets are empty but dist targets exist.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -291,7 +291,6 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
     therock_cmake_subproject_activate(hip-tests)
     # Provide it as an artifact:
     therock_provide_artifact(core-hiptests
-      TARGET_NEUTRAL
       DESCRIPTOR artifact-core-hiptests.toml
       COMPONENTS
         test

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -49,7 +49,6 @@ if(THEROCK_ENABLE_ROCPROFV3)
 
 if(THEROCK_BUILD_TESTING)
   therock_provide_artifact(aqlprofile-tests
-    TARGET_NEUTRAL
     DESCRIPTOR artifact-aqlprofile.toml
     COMPONENTS
       test


### PR DESCRIPTION
Noticing `hip-tests` failure after this PR landed, reverting to get `hip-tests` back to green

Reverts ROCm/TheRock#3528