### PR TITLE
Exclude libpython dependencies for amdrocm-debugger package

### DIFF
--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -558,6 +558,11 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
     rpmsuggests = ""
     sourcedir_list = []
     rpm_scripts = []
+    # amdrocm-debugger: Exclude libpython requirements
+    # Multiple Python-version-specific binaries are included; the wrapper script
+    # automatically selects the binary matching the system's Python version
+    exclude_libpython_requires = pkg_name == "amdrocm-debugger"
+
     if config.versioned_pkg:
         recommends_list = pkg_info.get("RPMRecommends", [])
         rpmrecommends = convert_to_versiondependency(recommends_list, config)
@@ -620,6 +625,7 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
         "disable_debug_package": is_debug_package_disabled(pkg_info),
         "sourcedir_list": sourcedir_list,
         "rpm_scripts": rpm_scripts,
+        "exclude_libpython_requires": exclude_libpython_requires,
     }
 
     with open(specfile, "w", encoding="utf-8") as f:

--- a/build_tools/packaging/linux/template/rpm_specfile.j2
+++ b/build_tools/packaging/linux/template/rpm_specfile.j2
@@ -10,6 +10,10 @@
 %global _debugsource_template %{nil}
 %global debug_package %{nil}          # disables -debuginfo
 %define __brp_mangle_shebangs %{nil}
+# Exclue libpython requirements. Used for amdrocm-debugger
+{%- if exclude_libpython_requires %}
+%define __requires_exclude libpython*.*
+{%- endif %}
 
 Name: {{ pkg_name }}
 Version: {{ version }}


### PR DESCRIPTION
  The amdrocm-debugger package includes multiple Python-version-specific
  binaries (rocgdb-py3.10, rocgdb-py3.11, etc.) and uses a wrapper script
  to automatically select the correct binary based on the system's available
  Python version. This change prevents RPM from enforcing a specific Python
  version requirement, allowing the package to be installed on systems with
  different Python versions.

Issue:
For the package to install , need to install all python version in the system
rpm -qpR amdrocm-debugger7.12-7.12.0~20260226-22428091619.x86_64.rpm | grep libpython
libpython3.10.so.1.0()(64bit)
libpython3.11.so.1.0()(64bit)
libpython3.12.so.1.0()(64bit)
libpython3.13.so.1.0()(64bit)
libpython3.14.so.1.0()(64bit)

Test Results:
No dependency to libpython
rpm -qpR amdrocm-debugger7.12-7.12.0~dev20260210-1111111.x86_64.rpm | grep libpython
