### PR TITLE
Forward CC/CXX and launcher to Meson-based sysdep builds

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1550,6 +1550,40 @@ function(_therock_cmake_subproject_setup_toolchain
   endif()
 
   string(APPEND _toolchain_contents "${_sanitizer_stanza}")
+
+  # Compute Meson-compatible CC/CXX env strings.
+  # To allow Meson-based subprojects to use the same compiler and launcher
+  # as CMake does, CC and CXX are passed. Otherweise, Meson auto-detects
+  # launchers and will use it automatically, resulting in not using the
+  # one selected in CMake-land.
+  # We mirror the toolchain selection logic above: amd-llvm/amd-hip
+  # subprojects use the built compiler, all others use the CMake-specified
+  # compiler.
+  if(compiler_toolchain STREQUAL "amd-llvm" OR compiler_toolchain STREQUAL "amd-hip")
+    set(_meson_actual_cc "${AMD_LLVM_C_COMPILER}")
+    set(_meson_actual_cxx "${AMD_LLVM_CXX_COMPILER}")
+  else()
+    set(_meson_actual_cc "${CMAKE_C_COMPILER}")
+    set(_meson_actual_cxx "${CMAKE_CXX_COMPILER}")
+  endif()
+  if(CMAKE_C_COMPILER_LAUNCHER)
+    # CMAKE_C_COMPILER_LAUNCHER is a CMake list (semicolon-separated) to support
+    # chained launchers (e.g. "ccache;distcc"). Meson expects a space-separated
+    # string, so convert before concatenating with the compiler path.
+    string(REPLACE ";" " " _meson_c_launcher "${CMAKE_C_COMPILER_LAUNCHER}")
+    set(_meson_cc "${_meson_c_launcher} ${_meson_actual_cc}")
+  else()
+    set(_meson_cc "${_meson_actual_cc}")
+  endif()
+  if(CMAKE_CXX_COMPILER_LAUNCHER)
+    string(REPLACE ";" " " _meson_cxx_launcher "${CMAKE_CXX_COMPILER_LAUNCHER}")
+    set(_meson_cxx "${_meson_cxx_launcher} ${_meson_actual_cxx}")
+  else()
+    set(_meson_cxx "${_meson_actual_cxx}")
+  endif()
+  string(APPEND _toolchain_contents "set(THEROCK_MESON_CC \"@_meson_cc@\")\n")
+  string(APPEND _toolchain_contents "set(THEROCK_MESON_CXX \"@_meson_cxx@\")\n")
+
   set(_compiler_toolchain_addl_depends "${_compiler_toolchain_addl_depends}" PARENT_SCOPE)
   set(_compiler_toolchain_init_contents "${_compiler_toolchain_init_contents}" PARENT_SCOPE)
   set(_build_env_pairs "${_build_env_pairs}" PARENT_SCOPE)

--- a/third-party/sysdeps/linux/amd-mesa/CMakeLists.txt
+++ b/third-party/sysdeps/linux/amd-mesa/CMakeLists.txt
@@ -60,6 +60,8 @@ add_custom_target(
     # This is required before patching because patch_source.sh modifies files in the libva subproject
     "${CMAKE_COMMAND}" -E env
       "LDFLAGS=-Wl,-rpath='$$ORIGIN' -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds"
+      "CC=${THEROCK_MESON_CC}"
+      "CXX=${THEROCK_MESON_CXX}"
       --
       "${MESON_BUILD}" setup
         --reconfigure
@@ -82,6 +84,8 @@ add_custom_target(
     # This ensures the build system uses the modified source files
     "${CMAKE_COMMAND}" -E env
       "LDFLAGS=-Wl,-rpath='$$ORIGIN' -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds"
+      "CC=${THEROCK_MESON_CC}"
+      "CXX=${THEROCK_MESON_CXX}"
       --
       "${MESON_BUILD}" setup
         --reconfigure

--- a/third-party/sysdeps/linux/libdrm/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libdrm/CMakeLists.txt
@@ -77,6 +77,8 @@ add_custom_target(
     "${CMAKE_COMMAND}" -E env
       # Escaping hack: experimentally determined to persist through the layers.
       "LDFLAGS=-Wl,-rpath='$$ORIGIN' -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds"
+      "CC=${THEROCK_MESON_CC}"
+      "CXX=${THEROCK_MESON_CXX}"
       --
       "${MESON_BUILD}" setup "${CMAKE_CURRENT_BINARY_DIR}"
         --reconfigure

--- a/third-party/sysdeps/linux/libpciaccess/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libpciaccess/CMakeLists.txt
@@ -66,6 +66,8 @@ add_custom_target(
     "${CMAKE_COMMAND}" -E env
       # Apply symbol versioning via version.lds. RPATH is set post-install via patch_install.py.
       "LDFLAGS=-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds"
+      "CC=${THEROCK_MESON_CC}"
+      "CXX=${THEROCK_MESON_CXX}"
       --
       "${MESON_BUILD}" setup "${CMAKE_CURRENT_BINARY_DIR}"
         --reconfigure


### PR DESCRIPTION
Meson does not inherit CMAKE_C_COMPILER_LAUNCHER, so any launcher configured at the CMake level (e.g. ccache via -DCMAKE_C_COMPILER_LAUNCHER) was silently dropped for the libdrm, amd-mesa, and libpciaccess builds. Instead Mesa auto-detects and picks a launcher, see https://mesonbuild.com/Feature-autodetection.html#ccache.

This computes THEROCK_MESON_CC and THEROCK_MESON_CXX in _therock_cmake_subproject_setup_toolchain and bakes them into the generated toolchain file. These combine the launcher (if any) and the compiler into a space-separated string as expected by meson. The correct compiler is selected by mirroring the existing toolchain logic: amd-llvm/amd-hip subprojects use the built compiler, all others use the CMake-specified one.

Fixes #3522.