### PR TITLE
Disable rocprofiler-compute in all gfx103X targets

### DIFF
--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -109,6 +109,7 @@ therock_add_amdgpu_target(gfx1031 "AMD RX 6700 / XT" FAMILY dgpu-all gfx103X-all
   hipBLASLt # https://github.com/ROCm/TheRock/issues/1062
   hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
   rocWMMA # https://github.com/ROCm/TheRock/issues/1944
+  rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 therock_add_amdgpu_target(gfx1032 "AMD RX 6600" FAMILY dgpu-all gfx103X-all gfx103X-dgpu
   EXCLUDE_TARGET_PROJECTS
@@ -122,6 +123,7 @@ therock_add_amdgpu_target(gfx1033 "AMD Van Gogh iGPU" FAMILY igpu-all gfx103X-al
     hipBLASLt # https://github.com/ROCm/TheRock/issues/1062
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
+    rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
     composable_kernel
 )
 therock_add_amdgpu_target(gfx1034 "AMD RX 6500 XT" FAMILY dgpu-all gfx103X-all gfx103X-dgpu
@@ -129,6 +131,7 @@ therock_add_amdgpu_target(gfx1034 "AMD RX 6500 XT" FAMILY dgpu-all gfx103X-all g
     hipBLASLt # https://github.com/ROCm/TheRock/issues/1062
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
+    rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 therock_add_amdgpu_target(gfx1035 "AMD Radeon 680M Laptop iGPU" FAMILY igpu-all gfx103X-all gfx103X-igpu
   EXCLUDE_TARGET_PROJECTS


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
gfx103X builds appear to be failing since #2300 got merged. This should address these build errors and unblock gfx103X releases.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- rocprofiler-compute does not support gfx103X architectures, so we added the project to the `EXCLUDE_TARGET_PROJECTS` list for the gfx103X family in `therock_amdgpu_targets.cmake`
- It appears that `EXCLUDE_TARGET_PROJECTS` entries for rocprofiler-compute gfx1031, gfx1033, and gfx1034 were missing
  - This was due to #1629 being merged two weeks ago, and the changes related to `therock_amdgpu_targets.cmake` in the #2300 PR happening before this new inclusion
  - Failures were not found before merging due to PR not running gfx103X builds

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ensure that gfx103X builds are able to pass without any errors from rocprofiler-compute

## Test Result

<!-- Briefly summarize test outcomes. -->
- Ran a manual gfx103X workflow with these changes: https://github.com/ROCm/TheRock/actions/runs/22497338111/job/65175257319

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
