### PR TITLE
Remove hipdnn from PyTorch wheel library preloads

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -162,7 +162,6 @@ LINUX_LIBRARY_PRELOADS = [
     "rccl",  # Linux only for the moment.
     "hipblaslt",
     "miopen",
-    "hipdnn",
     "rocm_sysdeps_liblzma",
     "rocm-openblas",
 ]
@@ -180,7 +179,6 @@ WINDOWS_LIBRARY_PRELOADS = [
     "hipsolver",
     "hipblaslt",
     "miopen",
-    "hipdnn",
     "rocm-openblas",
 ]
 


### PR DESCRIPTION
## Summary
- Remove `hipdnn` from both `LINUX_LIBRARY_PRELOADS` and `WINDOWS_LIBRARY_PRELOADS` in `build_prod_wheels.py`
- Preloading hipdnn is causing issues with some build flows due to hipDNN being disabled in that environment
- Currently preloading hipDNN isn't required for Pytorch wheel build flow

## Test plan
- [ ] Verify PyTorch wheel build succeeds without hipdnn in the preload list

🤖 Generated with [Claude Code](https://claude.com/claude-code)