### PR TITLE
Add amdrocm-rdc dependency to metapackage amdrocm-core-sdk

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -2466,11 +2466,13 @@
     "DEBDepends": [
       "amdrocm-core-devel",
       "amdrocm-developer-tools",
+      "amdrocm-rdc",
       "amdrocm-opencl"
     ],
     "RPMRequires": [
       "amdrocm-core-devel",
       "amdrocm-developer-tools",
+      "amdrocm-rdc",
       "amdrocm-opencl"
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",


### PR DESCRIPTION
This change adds amdrocm-rdc to both DEBDepends and RPMRequires lists
for the amdrocm-core-sdk metapackage. This ensures that the ROCm Data
Center (RDC) tool is included as part of the core SDK installation.
