### PR TITLE
Fix provider plugin artifact names in Python packaging

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -122,8 +122,8 @@ def libraries_artifact_filter(target_family: str, an: ArtifactName) -> bool:
             "fft",
             "hipdnn",
             "miopen",
-            "miopen-plugin",
-            "hipblaslt-plugin",
+            "miopenprovider",
+            "hipblasltprovider",
             "rand",
             "rccl",
         ]


### PR DESCRIPTION
## Summary

- The CMake targets for MIOpen and hipBLASLt providers were renamed from `miopen-plugin` / `hipblaslt-plugin` to `miopenprovider` / `hipblasltprovider`
- `build_python_packages.py` still referenced the old hyphenated names, so the `libraries_artifact_filter` silently dropped the provider libraries from the wheels
- Updated the artifact name strings to match the current CMake target names

## Test plan

- [ ] Verify wheels build includes the provider libraries (`miopenprovider`, `hipblasltprovider`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)