### PR TITLE
PyTorch UT: Update skip_tests based on nightly 20260302

### DIFF
--- a/external-builds/pytorch/skip_tests/README.md
+++ b/external-builds/pytorch/skip_tests/README.md
@@ -41,11 +41,17 @@ skip_tests = {
     "common": {
         <PyTorch test module> : [ <Tests> ],
     },
-    "<amdgpu family>": {,
+    "<amdgpu family short form>": {,
         <PyTorch test module> : [ <Tests> ],
     },
 }
 ```
+
+`Amdgpu family short form` is the minimum entry needed to match the right architecture. E.g.
+
+- `gfx94` to match `gf94X-dcgpu` and its arch `gfx942`
+- `gfx120` to match `gfx120X-all` and its archs `gfx1200` and `gfx1201`
+- `gfx1150` to match `gfx1150`
 
 The PyTorch test modules are `nn`, `cuda`, `unary_ufuncs` etc.
 This ordering is mainly added for easier debugging as otherwise it is difficult to determine which test module contains a given tests like `test_host_memory_stats` belongs to.
@@ -62,7 +68,7 @@ skip_tests = {
             "test_host_memory_stats",
         ]
     },
-    "gfx942": {
+    "gfx94": {
         "autograd": [
             "test_multi_grad_all_hooks",
             "test_side_stream_backward_overlap"

--- a/external-builds/pytorch/skip_tests/create_skip_tests.py
+++ b/external-builds/pytorch/skip_tests/create_skip_tests.py
@@ -157,11 +157,17 @@ def create_list(
     # Loop over all loaded skip_tests dictionaries from the different pytorch versions
     for skip_test_module_name, skip_tests in dict_skip_tests.items():
         # Apply each filter (common, amdgpu_family)
-        for filter_name in filters:
-            if filter_name in skip_tests:
-                # For each pytorch test module (e.g., test_nn, test_torch) add all the tests
-                for pytorch_test_module in skip_tests[filter_name].keys():
-                    selected_tests += skip_tests[filter_name][pytorch_test_module]
+        for skip_section_name in skip_tests.keys():
+            for filter_name in filters:
+                # skip_tests has entries e.g. ["common", "gfx94"]
+                # filters has entries e.g. ["common", "gfx942", "gfx1201", "windows"]
+                # so check if skip_tests is a substring of filter_name
+                if skip_section_name in filter_name:
+                    # For each pytorch test module (e.g., test_nn, test_torch) add all the tests
+                    for pytorch_test_module in skip_tests[skip_section_name].keys():
+                        selected_tests += skip_tests[skip_section_name][
+                            pytorch_test_module
+                        ]
 
     # Remove duplicates and return
     return list(set(selected_tests))

--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -9,11 +9,6 @@ skip_tests = {
         }
     },
     "common": {
-        # ----------------
-        # might be failing
-        # ----------------
-        # "binary_ufuncs": [ "test_cuda_tensor_pow_scalar_tensor_cuda" ]
-        # ----------------
         "cuda": [
             # HIP_VISIBLE_DEVICES and CUDA_VISIBLE_DEVICES not working
             # to restrict visibility of devices
@@ -70,6 +65,9 @@ skip_tests = {
             # FLAKY!! AssertionError: 'tensor([2.3000+4.j, 7.0000+6.j])' != 'tensor([2.30000+4.j, 7.00000+6.j])'
             # (Note: this will also skip "test_print" in all other test modules)
             "test_print",
+            # torch._dynamo.exc.BackendCompilerFailed: backend='aot_eager' raised:
+            # TypeError: 'CustomDecompTable' object is not a mapping
+            "test_fx_memory_profiler_augmentation",
         ],
         "unary_ufuncs": [
             # ----------------
@@ -150,29 +148,6 @@ skip_tests = {
             "test_reference_numerics_small_special_spherical_bessel_j0_cuda_int64",
             "test_reference_numerics_small_special_spherical_bessel_j0_cuda_int8",
             "test_reference_numerics_small_special_spherical_bessel_j0_cuda_uint8",
-        ],
-    },
-    "gfx950": {
-        "binary_ufuncs": [
-            # for all the pow() issues see https://github.com/ROCm/TheRock/issues/2070
-            # AssertionError: Tensor-likes are not close!
-            "test_contig_vs_every_other___rpow___cuda_complex64",
-            # AssertionError: Tensor-likes are not close!
-            "test_contig_vs_every_other__refs_pow_cuda_complex64",
-            # AssertionError: Tensor-likes are not close!
-            "test_contig_vs_every_other_pow_cuda_complex64",
-            # AssertionError: Tensor-likes are not close!
-            "test_non_contig___rpow___cuda_complex64",
-            # AssertionError: Tensor-likes are not close!
-            "test_non_contig__refs_pow_cuda_complex64",
-            # AssertionError: Tensor-likes are not close!
-            "test_non_contig_pow_cuda_complex64",
-            # AssertionError: Tensor-likes are not close!
-            "test_batch_vs_slicing_pow_cuda_complex64",
-            # 2.11 specific?
-            "test_batch_vs_slicing__refs_pow_cuda_complex64",
-            "test_batch_vs_slicing__refs_pow_cuda_complex32",
-            "test_batch_vs_slicing___rpow___cuda_complex64",
         ],
     },
     # Special notes for Windows:

--- a/external-builds/pytorch/skip_tests/pytorch_2.10.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.10.py
@@ -48,12 +48,16 @@ skip_tests = {
             # torch._dynamo.exc.BackendCompilerFailed: backend='aot_eager' raised:
             # TypeError: 'CustomDecompTable' object is not a mapping
             "test_record_stream_on_shifted_view",
+            # AssertionError: Scalars are not close!
+            "test_allocator_settings",
         ],
         "torch": [
             "test_index_add_correctness",
+            # AssertionError: False is not true
+            "test_cpp_warnings_have_python_context_cuda",
         ],
     },
-    "gfx942": {
+    "gfx94": {
         "autograd": [
             # fixed or just good with no caching?
             # "test_reentrant_parent_error_on_cpu_cuda",
@@ -96,13 +100,10 @@ skip_tests = {
             "test_cublas_allow_bf16_reduced_precision_reduction_get_set",
             # AttributeError: Unknown attribute allow_fp16_reduced_precision_reduction_split_k
             "test_cublas_allow_fp16_reduced_precision_reduction_get_set",
-            # AssertionError: Scalars are not close!
-            "test_allocator_settings",
             # AttributeError: Unknown attribute allow_bf16_reduced_precision_reduction_split_k
             "test_cublas_allow_bf16_reduced_precision_reduction_get_set",
             # AttributeError: Unknown attribute allow_fp16_reduced_precision_reduction_split_k
             "test_cublas_allow_fp16_reduced_precision_reduction_get_set",
-            "test_allocator_settings",
         ],
         "nn": [
             # Is now skipped.. on pytorch side
@@ -115,15 +116,6 @@ skip_tests = {
         ],
         "torch": [
             "test_terminate_handler_on_crash",  # flaky !! hangs forever or works... can need up to 30 sec to pass
-            "test_cpp_warnings_have_python_context_cuda",
-            # torch._dynamo.exc.BackendCompilerFailed: backend='aot_eager' raised:
-            # TypeError: 'CustomDecompTable' object is not a mapping
-            "test_fx_memory_profiler_augmentation",
-        ],
-    },
-    "gfx950": {
-        "cuda": [
-            "test_cpp_warnings_have_python_context_cuda",
         ],
     },
     "windows": {

--- a/external-builds/pytorch/skip_tests/pytorch_2.11.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.11.py
@@ -44,12 +44,9 @@ skip_tests = {
         ],
         "torch": [
             "test_cpp_warnings_have_python_context_cuda",
-            # torch._dynamo.exc.BackendCompilerFailed: backend='aot_eager' raised:
-            # TypeError: 'CustomDecompTable' object is not a mapping
-            "test_fx_memory_profiler_augmentation",
         ],
     },
-    "gfx120X-all": {
+    "gfx120": {
         "autograd": [
             # AssertionError: False is not true
             "test_side_stream_backward_overlap_cuda"

--- a/external-builds/pytorch/skip_tests/pytorch_2.8.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.8.py
@@ -32,4 +32,10 @@ skip_tests = {
             "test_hip_device_count",
         ]
     },
+    "gfx120": {
+        "cuda": [
+            # AssertionError: True is not false
+            "test_repeat_graph_capture_cublas_workspace_memory"
+        ]
+    },
 }

--- a/external-builds/pytorch/skip_tests/pytorch_2.9.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.9.py
@@ -46,7 +46,7 @@ skip_tests = {
             "test_invalid_status_for_legacy_api",
         ],
     },
-    "gfx942": {
+    "gfx94": {
         "autograd": [
             # fixed or just good with no caching?
             # "test_reentrant_parent_error_on_cpu_cuda",
@@ -107,7 +107,6 @@ skip_tests = {
             "test_cublas_allow_bf16_reduced_precision_reduction_get_set",
             # AttributeError: Unknown attribute allow_fp16_reduced_precision_reduction_split_k
             "test_cublas_allow_fp16_reduced_precision_reduction_get_set",
-            "test_allocator_settings",
         ],
         "nn": [
             # Is now skipped.. on pytorch side


### PR DESCRIPTION
This PR adjust the skip_test logic based on results from nightly 20260302:

- Enable better arch matching strategy for skip_tests
- Move test_allocator_settings and test_cpp_warnings_have_python_context_cuda to common skipping for 2.10
- Move test_fx_memory_profiler_augmentation to generic.py
- Renable all cuda pow tests (see #2070)

To note:
- disabled only for pytorch 2.8 and gfx120X: test_repeat_graph_capture_cublas_workspace_memory --> this might be true regression
