### PR TITLE
Adding owner and repositories to generate PAT for hip-tagging-automation

### DIFF
--- a/.github/workflows/hip_tagging_automation.yml
+++ b/.github/workflows/hip_tagging_automation.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           app-id: ${{ secrets.ROCM_SYSTEMS_APP_ID }}
           private-key: ${{ secrets.ROCM_SYSTEMS_APP_PRIVATE_KEY }}
+          owner: "ROCm"
+          repositories: "rocm-systems"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Motivation

Bot PAT is defaulting to ROCm/TheRock instead of rocm-systems

