### PR TITLE
[ci] Adding test exclusions for gfx110X windows

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -52,6 +52,12 @@ TEST_TO_IGNORE = {
             "Unit_hipGetProcAddress_spt_Stream",
         ]
     },
+    "gfx110X-all": {
+        "windows": [
+            "Unit_hipStreamValue_Wait_Blocking - uint64_t",
+            "Unit_hipStreamValue_Wait_Blocking - uint32_t",
+        ]
+    },
 }
 
 

--- a/build_tools/github_actions/test_executable_scripts/test_miopenprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopenprovider.py
@@ -6,10 +6,25 @@ import os
 import shlex
 import subprocess
 from pathlib import Path
+import platform
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+
+AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
+os_type = platform.system().lower()
+
+logging.basicConfig(level=logging.INFO)
+
+TEST_TO_IGNORE = {
+    # TODO(#3709): Re-enable gfx110X tests once issues are resolved
+    "gfx110X-all": {
+        "windows": [
+            "miopen_plugin_integration_tests",
+        ]
+    }
+}
 
 logging.basicConfig(level=logging.INFO)
 
@@ -23,6 +38,10 @@ cmd = [
     "--timeout",
     "1200",
 ]
+
+if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILIES]:
+    ignored_tests = TEST_TO_IGNORE[AMDGPU_FAMILIES][os_type]
+    cmd.extend(["--exclude-regex", "|".join(ignored_tests)])
 
 # Determine test filter based on TEST_TYPE environment variable
 environ_vars = os.environ.copy()

--- a/build_tools/github_actions/test_executable_scripts/test_rocprim.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprim.py
@@ -18,6 +18,14 @@ os_type = platform.system().lower()
 logging.basicConfig(level=logging.INFO)
 
 TEST_TO_IGNORE = {
+    # TODO(#2836): Re-enable gfx110X tests once issues are resolved
+    "gfx110X-all": {
+        "windows": [
+            "rocprim.block_discontinuity",
+            "rocprim.device_merge_sort",
+            "rocprim.device_reduce",
+        ]
+    },
     "gfx1151": {
         "windows": [
             # TODO(#2836): Re-enable test once issues are resolved
@@ -25,7 +33,7 @@ TEST_TO_IGNORE = {
             # TODO(#2836): Re-enable test once issues are resolved
             "rocprim.device_radix_sort",
         ]
-    }
+    },
 }
 
 SMOKE_TESTS = [


### PR DESCRIPTION
From [CI nightly runs](https://github.com/ROCm/TheRock/actions/runs/22559535755/job/65441736660), we noticed some flaky errors with particular components. In order to enable gfx110X as postsubmit/presubmit, we are opening issues #3708, #3709 and #3204 to resolve these errors

As this is test-only, the new runs work here: https://github.com/ROCm/TheRock/actions/runs/22590071318, which is why the `skip-ci` label was added

After this is landed, we will enable gfx110X for postsubmit