### PR TITLE
[ci] Removing Instinct hip-test test failures

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -39,20 +39,7 @@ if not os.path.isdir(CATCH_TESTS_PATH):
     logging.info(f"++ Error: catch tests not found in {CATCH_TESTS_PATH}")
     sys.exit(1)
 
-# TODO(#3204): Re-enable tests once issues are resolved
-TEST_TO_IGNORE = {
-    "gfx94X-dcgpu": {
-        "linux": [
-            "Unit_hipGetProcAddress_spt_Stream",
-        ]
-    },
-    "gfx950-dcgpu": {
-        "linux": [
-            "Unit_hipManagedKeyword_SingleGpu",
-            "Unit_hipGetProcAddress_spt_Stream",
-        ]
-    },
-}
+TEST_TO_IGNORE = {}
 
 
 def get_asan_lib_path():


### PR DESCRIPTION
From issue #3204 , hip-tests failed on gfx94X and gfx950. Now they pass: 

- gfx94X: https://github.com/ROCm/TheRock/actions/runs/22590470812/job/65448336726
- gfx950: https://github.com/ROCm/TheRock/actions/runs/22592003494

progress on #3204

Since this is test only, we add the skip-ci label