### PR TITLE
Fix broken amdclang symlinks and duplicate installation paths

### DIFF
--- a/base/aux-overlay/CMakeLists.txt
+++ b/base/aux-overlay/CMakeLists.txt
@@ -20,18 +20,21 @@ if(NOT WIN32)
     COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/bin"
     COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm" "${CMAKE_CURRENT_BINARY_DIR}/llvm"
     COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/amdgcn" "${CMAKE_CURRENT_BINARY_DIR}/amdgcn"
-    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/bin/amdclang" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang"
-    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/bin/amdflang" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdflang"
-    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/bin/amdclang++" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang++"
-    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/bin/amdclang-cl" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang-cl"
-    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/bin/amdclang-cpp" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang-cpp"
-    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/bin/amdlld" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdlld"
-    COMMAND "${CMAKE_COMMAND}" -E create_symlink "lib/llvm/bin/offload-arch" "${CMAKE_CURRENT_BINARY_DIR}/bin/offload-arch"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "../lib/llvm/bin/amdclang" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "../lib/llvm/bin/amdflang" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdflang"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "../lib/llvm/bin/amdclang++" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang++"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "../lib/llvm/bin/amdclang-cl" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang-cl"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "../lib/llvm/bin/amdclang-cpp" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang-cpp"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "../lib/llvm/bin/amdlld" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdlld"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "../lib/llvm/bin/offload-arch" "${CMAKE_CURRENT_BINARY_DIR}/bin/offload-arch"
   )
   install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/bin"
     "${CMAKE_CURRENT_BINARY_DIR}/llvm"
     "${CMAKE_CURRENT_BINARY_DIR}/amdgcn"
+    DESTINATION .
+  )
+  install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang"
     "${CMAKE_CURRENT_BINARY_DIR}/bin/amdflang"
     "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang++"
@@ -39,7 +42,7 @@ if(NOT WIN32)
     "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang-cpp"
     "${CMAKE_CURRENT_BINARY_DIR}/bin/amdlld"
     "${CMAKE_CURRENT_BINARY_DIR}/bin/offload-arch"
-    DESTINATION .
+    DESTINATION bin
   )
 endif()
 


### PR DESCRIPTION
  The aux-overlay component was creating broken symlinks and installing
  them in multiple incorrect locations:

  1. Symlinks were installed both at root (stage/amdclang) and in bin/ (stage/bin/amdclang). Only the bin/ location is correct.

  2. Symlinks in bin/ used incorrect relative paths (lib/llvm/bin/amdclang) that don't resolve from the bin/ directory context.

  This fix:

  - Splits install() commands to separate directory symlinks (bin, llvm, amdgcn) from individual tool symlinks, preventing flattening to root

  - Adds ../ prefix to symlink targets (../lib/llvm/bin/amdclang) so they correctly resolve from the bin/ subdirectory

  - Ensures amdclang, amdflang, amdclang++, amdclang-cl, amdclang-cpp, amdlld, and offload-arch are only installed in bin/ with valid paths

  Fixes broken symlinks in ROCm distribution artifacts.
