### PR TITLE
Revert "Split gfx906/gfx908/gfx90a into separate families (#2869)"

### DIFF
--- a/.github/workflows/build_linux_jax_wheels.yml
+++ b/.github/workflows/build_linux_jax_wheels.yml
@@ -62,9 +62,7 @@ on:
           - gfx1152
           - gfx1153
           - gfx120X-all
-          - gfx906
-          - gfx908
-          - gfx90a
+          - gfx90X-dcgpu
           - gfx94X-dcgpu
           - gfx950-dcgpu
         default: gfx94X-dcgpu

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -58,9 +58,7 @@ on:
           - gfx1152
           - gfx1153
           - gfx120X-all
-          - gfx906
-          - gfx908
-          - gfx90a
+          - gfx90X-dcgpu
           - gfx94X-dcgpu
           - gfx950-dcgpu
         default: gfx94X-dcgpu

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -58,9 +58,7 @@ on:
           - gfx1152
           - gfx1153
           - gfx120X-all
-          - gfx906
-          - gfx908
-          - gfx90a
+          - gfx90X-dcgpu
           - gfx94X-dcgpu
           - gfx950-dcgpu
         default: gfx1151

--- a/.github/workflows/copy_release.yml
+++ b/.github/workflows/copy_release.yml
@@ -20,9 +20,7 @@ on:
           - gfx1152
           - gfx1153
           - gfx120X-all
-          - gfx906
-          - gfx908
-          - gfx90a
+          - gfx90X-dcgpu
           - gfx94X-dcgpu
           - gfx950-dcgpu
         default: gfx94X-dcgpu

--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -48,9 +48,7 @@ on:
           - gfx1152
           - gfx1153
           - gfx120X-all
-          - gfx906
-          - gfx908
-          - gfx90a
+          - gfx90X-dcgpu
           - gfx94X-dcgpu
           - gfx950-dcgpu
         default: gfx94X-dcgpu

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -48,9 +48,7 @@ on:
           - gfx1152
           - gfx1153
           - gfx120X-all
-          - gfx906
-          - gfx908
-          - gfx90a
+          - gfx90X-dcgpu
           - gfx94X-dcgpu
           - gfx950-dcgpu
         default: gfx1151

--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -64,9 +64,7 @@ on:
           - gfx1152
           - gfx1153
           - gfx120X-all
-          - gfx906
-          - gfx908
-          - gfx90a
+          - gfx90X-dcgpu
           - gfx94X-dcgpu
           - gfx950-dcgpu
         default: gfx94X-dcgpu

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -146,54 +146,18 @@ amdgpu_family_info_matrix_postsubmit = {
 
 # The 'nightly' matrix runs on 'schedule' triggers.
 amdgpu_family_info_matrix_nightly = {
-    # gfx906/908/90a split into separate families - each has different instruction
-    # support (e.g., fp8 variants, WMMA) so CK/MIOpen need to build/test individually.
-    "gfx906": {
+    "gfx90x": {
         "linux": {
-            # Disabled due to hardware availability
-            "test-runs-on": "",
-            "family": "gfx906",
-            "fetch-gfx-targets": [],
+            "test-runs-on": "linux-gfx90X-gpu-rocm",
+            "family": "gfx90X-dcgpu",
+            "fetch-gfx-targets": ["gfx90a"],
             "sanity_check_only_for_family": True,
             "build_variants": ["release"],
         },
         # TODO(#1927): Resolve error generating file `torch_hip_generated_int4mm.hip.obj`, to enable PyTorch builds
         "windows": {
             "test-runs-on": "",
-            "family": "gfx906",
-            "fetch-gfx-targets": [],
-            "build_variants": ["release"],
-            "expect_pytorch_failure": True,
-        },
-    },
-    "gfx908": {
-        "linux": {
-            # Disabled due to hardware availability
-            "test-runs-on": "",
-            "family": "gfx908",
-            "fetch-gfx-targets": [],
-            "sanity_check_only_for_family": True,
-            "build_variants": ["release"],
-        },
-        "windows": {
-            "test-runs-on": "",
-            "family": "gfx908",
-            "fetch-gfx-targets": [],
-            "build_variants": ["release"],
-            "expect_pytorch_failure": True,
-        },
-    },
-    "gfx90a": {
-        "linux": {
-            "test-runs-on": "linux-gfx90a-gpu-rocm",
-            "family": "gfx90a",
-            "fetch-gfx-targets": ["gfx90a"],
-            "sanity_check_only_for_family": True,
-            "build_variants": ["release"],
-        },
-        "windows": {
-            "test-runs-on": "",
-            "family": "gfx90a",
+            "family": "gfx90X-dcgpu",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
             "expect_pytorch_failure": True,

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -44,8 +44,8 @@ function(therock_add_amdgpu_target gfx_target product_name)
   endforeach()
 endfunction()
 
-# gfx906 (separate family - different instruction support from gfx908/gfx90a)
-therock_add_amdgpu_target(gfx906 "Radeon VII / MI50 CDNA" FAMILY dgpu-all gfx906-dgpu
+# gfx90X family
+therock_add_amdgpu_target(gfx906 "Radeon VII / MI50 CDNA" FAMILY dgpu-all gfx90X-all gfx90X-dgpu gfx90X-dcgpu
   EXCLUDE_TARGET_PROJECTS
     hipBLASLt # https://github.com/ROCm/TheRock/issues/1062
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
@@ -53,15 +53,11 @@ therock_add_amdgpu_target(gfx906 "Radeon VII / MI50 CDNA" FAMILY dgpu-all gfx906
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
-
-# gfx908 (separate family - different instruction support from gfx906/gfx90a)
-therock_add_amdgpu_target(gfx908 "MI100 CDNA" FAMILY dcgpu-all gfx908-dcgpu
+therock_add_amdgpu_target(gfx908 "MI100 CDNA" FAMILY gfx90X-all dcgpu-all gfx90X-dcgpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
 )
-
-# gfx90a (separate family - different instruction support from gfx906/gfx908)
-therock_add_amdgpu_target(gfx90a "MI210/250 CDNA" FAMILY dcgpu-all gfx90a-dcgpu
+therock_add_amdgpu_target(gfx90a "MI210/250 CDNA" FAMILY gfx90X-all dcgpu-all gfx90X-dcgpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
 )


### PR DESCRIPTION
Reverting this PR to solved issue #3701. We see that the latest torch runs fails with the below error. Idea is to get the torch failures resolved and have gfx906 gfx908 and gfx90a enabled back again once tested locally.

`--target_gpus to generate.py - gfx906, gfx908`