### PR TITLE
[build] Re-enabling sanitizer build for RCCL

### DIFF
--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -1,8 +1,7 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-# TODO(#2632): Re-enable RCCL for sanitizer builds once RCCL build time is acceptable
-if(THEROCK_ENABLE_RCCL AND THEROCK_SANITIZER STREQUAL "")
+if(THEROCK_ENABLE_RCCL)
   # Most libraries need to depend on the profiler, but is conditionally only used
   # on Posix.
   set(optional_profiler_deps)
@@ -104,4 +103,4 @@ if(THEROCK_ENABLE_RCCL AND THEROCK_SANITIZER STREQUAL "")
     SUBPROJECT_DEPS
       ${_rccl_subproject_names}
   )
-endif(THEROCK_ENABLE_RCCL AND THEROCK_SANITIZER STREQUAL "")
+endif()


### PR DESCRIPTION
According to [CI ASAN workflow run](https://github.com/ROCm/TheRock/actions/runs/22351395421/job/64679260038), RCCL has reduced to a reasonable time, through https://github.com/ROCm/rocm-systems/pull/3136

Progress on #2632