### PR TITLE
<Do Not Merge><Only For Testing> CI: Add OrchestrAI eval workflow for RDNA Reservation Service

### DIFF
--- a/.github/workflows/orchestrai_eval.yml
+++ b/.github/workflows/orchestrai_eval.yml
@@ -9,6 +9,7 @@ name: CI - OrchestrAI Eval Only
 
 on:
   workflow_dispatch:
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/orchestrai_gpu_release.yml
+++ b/.github/workflows/orchestrai_gpu_release.yml
@@ -6,6 +6,7 @@ name: CI - OrchestrAI Release Runners
 
 on:
   workflow_dispatch:
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/orchestrai_linux_gpu_request.yml
+++ b/.github/workflows/orchestrai_linux_gpu_request.yml
@@ -8,6 +8,7 @@ name: CI - OrchestrAI Linux GPU Request
 
 on:
   workflow_dispatch:
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/orchestrai_windows_gpu_request.yml
+++ b/.github/workflows/orchestrai_windows_gpu_request.yml
@@ -7,6 +7,7 @@ name: CI - OrchestrAI Windows GPU Request
 
 on:
   workflow_dispatch:
+  pull_request:
 
 permissions:
   contents: read
@@ -74,7 +75,7 @@ jobs:
               "repository": "${{ github.repository }}",
               "platform": "windows",
               "gpu": "gpu_navi4x",
-              "count": 1  
+              "count": 1
             }
 
       - name: Wait for runners to be ready


### PR DESCRIPTION
The intention of this PR is to do a temporary evaluation for using runners from Orchestrator AI team before they assign a dedicated label pool. what is PR is essentially doing is Option B from https://amd.atlassian.net/wiki/spaces/~jpiatkow/pages/1382919624/RDNA+Reservation+Service+-+Integration+Guide . Regarding their mention of PATs in Option B we have already asked them about it and communicated that we don't use PATs and don't encourage in any of our workflows. we are waiting to hear back from them.


- Add request/run/release jobs per handbook (allocate, run on gpu_navi3x, release)
- Trigger on workflow_dispatch
- Requires RUNNER_SERVICE_PAT and UCICD repo registration
