### PR TITLE
Update codeowners to include debug tools ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,7 @@
 # Debug tools configs and ROCgdb cmake wrapper.
 /debug-tools            @ROCm/TheRock-infra-write @ROCm-DevTools-Debugger
 /debig-tools/rocgdb     @ROCm/TheRock-infra-write @ROCm-DevTools-Debugger
+
+# Debug tools testing scripts.
+/build_tools/github_actions/test_executable_scripts/test_rocgdb.py           @ROCm-DevTools-Debugger
+/build_tools/github_actions/test_executable_scripts/test_rocr-debug-agent.py @ROCm-DevTools-Debugger


### PR DESCRIPTION
We have a ROCgdb cmake wrapper in debug-tools/rocgdb, so it would be nice to include the debugger folks to review those changes alongside TheRock's folks.

While at it, debugger folks can also help with the recipes and artifacts files in debug-tools/*, as well as the testing scripts in build_tools/github_actions/test_executable_scripts/.