### PR TITLE
Enable XNACK for hip-tests when we run with ASAN

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -110,6 +110,7 @@ def setup_env(env):
         # For ASAN mode, we preload it for test count query and test running
         if is_asan():
             env["LD_PRELOAD"] = get_asan_lib_path()
+            env["HSA_XNACK"] = "1"
             # TODO: enable this when we have symbolizer patch in
             # env["ASAN_SYMBOLIZER_PATH"] = str(Path(THEROCK_BIN_DIR).parent / "lib" / "llvm" / "bin" / "llvm-symbolizer")
     else:


### PR DESCRIPTION
## Motivation

Ideally this should be done from `TheRock` itself, when user passes ASAN preset in config, TheRock automatically appends the `xnack+` based on target (if it supports or not). When it does that, it makes sense to TheRock to drive the XNACK env variable as well.
For now, we make sure XNACK is enabled when we run hip-tests.

## Technical Details

If we run hip-tests build with xnack on systems with xnack disable, we will see lots of errors. If we are running ASAN builds, we make sure we enable xnack.

## Test Plan

Running ASAN builds locally to verify.

## Test Result

Script seems to run ok.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
