### PR TITLE
Add ASAN_OPTIONS and HSA_XNACK environment variables to test workflow

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -145,7 +145,8 @@ jobs:
           TEST_TYPE: ${{ fromJSON(inputs.component).test_type }}
           ROCM_KPACK_DEBUG: "1"
           ASAN_OPTIONS: "detect_odr_violation=0:quarantine_size_mb=600"
-          HSA_XNACK: 1          
+          HSA_XNACK: 1
+          ASAN_SYMBOLIZER_PATH: ${{ env.VENV_DIR }}/llvm/bin/llvm-symbolizer
         run: |
           ${{ fromJSON(inputs.component).test_script }}
 


### PR DESCRIPTION
## Detail

For ASAN tests, the environment variables HSA_XNACK and ASAN_OPTIONS must be set for all test execution runs. This PR sets these environment variables for all components

## Test Plan

These have been tested thoroughly in the ASAN enablement based on Nightly build 711, for e.g., like here: https://github.com/ROCm/TheRock/actions/runs/22311510308

## Test Result

Test executions have been confirmed to take these environment variables into account. Refer to the results from the test runs in the link above.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
