### PR TITLE
[ci] Adding sanitizer specific test flags

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -137,6 +137,14 @@ jobs:
           python ./build_tools/install_additional_requirements.py \
             --requirements-files=${{ join(fromJSON(inputs.component).additional_requirements_files, ',') }}
 
+        # TODO(#3755): Clean this up after final sanitizer environment variable flags are determined
+      - name: Enable sanitizer-specific test flags
+        if: ${{ contains(inputs.artifact_group, 'asan') }}
+        run: |
+          echo "ASAN_OPTIONS=detect_odr_violation=0:quarantine_size_mb=600" >> $GITHUB_ENV
+          echo "HSA_XNACK=1" >> $GITHUB_ENV
+          echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
+
       - name: Test
         timeout-minutes: ${{ fromJSON(inputs.component).timeout_minutes }}
         env:


### PR DESCRIPTION
As experimentation continues for ASAN, we are enabling these sanitizer test flags

I have issue #3755 to clean this up once the experimentation / ASAN tests are passing

- Regular CI running and skipping step: https://github.com/ROCm/TheRock/actions/runs/22683289975/job/65760585007
- ASAN CI running and picking up env variables correctly: https://github.com/ROCm/TheRock/actions/runs/22683307018/job/65762049349#step:12:21

As this is test specific and local tests pass, I am adding `skip-ci` label