### PR TITLE
Disable AOTriton for gfx906 and gfx908 in PyTorch builds

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -265,6 +265,7 @@ def get_rocm_path(path_name: str) -> Path:
         ).strip()
     )
 
+
 def get_rocm_init_contents(args: argparse.Namespace):
     """Gets the contents of the _rocm_init.py file to add to the build."""
     sdk_version = get_rocm_sdk_version()
@@ -281,6 +282,7 @@ def get_rocm_init_contents(args: argparse.Namespace):
                 check_version='{sdk_version}')
         """
     )
+
 
 def remove_dir_if_exists(dir: Path):
     if dir.exists():


### PR DESCRIPTION
This PR adds gfx906 and gfx908 to AOTRITON_UNSUPPORTED_ARCHS in the PyTorch build script.

AOTriton is not currently supported on these architectures, which can lead to build failures when attempting to enable Flash Attention. Disabling it ensures PyTorch wheels build successfully for these targets.

This aligns the build configuration with the current AOTriton architecture support.