### PR TITLE
Update RFC0009-OS-Packaging-Requirements.md

### DIFF
--- a/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
+++ b/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
@@ -156,8 +156,8 @@ Using `yum` ROCm Core SDK runtime components and ROCm Core SDK runtime + develop
 yum install rocm # ROCm 8.0
 yum install rocm-core # ROCm 8.0
 yum install rocm-core<ver>
-yum install rocm-core-devel
-yum install rocm-core-devel<ver>
+yum install rocm-core-dev
+yum install rocm-core-dev<ver>
 ```
 
 The following table shows the meta packages that will be available:
@@ -165,7 +165,7 @@ The following table shows the meta packages that will be available:
 | Name                    | Content                                                              | Description                                                                   |
 | :---------------------- | :------------------------------------------------------------------- | :---------------------------------------------------------------------------- |
 | amdrocm & amdrocm-core  | runtime & libraries, components, runtime compiler, amd-smi, rocminfo | Needed to run software built with ROCm Core                                   |
-| amdrocm-core-devel      | rocm-core + compiler cmake, static library files, and headers        | Needed to build software with ROCm Core                                       |
+| amdrocm-core-dev        | rocm-core + compiler cmake, static library files, and headers        | Needed to build software with ROCm Core                                       |
 | amdrocm-developer-tools | Profiler, debugger, and related tools                                | Independent set of tools to debug and profile any application built with ROCm |
 | amdrocm-fortran         |                                                                      | Fortran compiler and related components                                       |
 | amdrocm-opencl          |                                                                      | Components needed to run OpenCL                                               |

--- a/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
+++ b/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
@@ -202,6 +202,7 @@ Package granularity will be increased with ROCm 8.0. Development packages contai
 | amdrocm-jpeg                            |                             | rocJPEG                                                                       |                                          |
 | amdrocm-file                            |                             | hipFile, rocFile (future addition)                                            |                                          |
 | amdrocm-rccl                            |                             | rccl                                                                          |                                          |
+| amdrocm-shmem                           |                             | rocSHMEM                                                                      |                                          |
 | amdrocm-sysdeps                         |                             | Bundled 3rd party dependencies (e.g., libdrm, libelf, numa, subset of libVA)  |                                          |
 | amdrocm-rdc                             |                             | ROCm Datacenter                                                               |                                          |
 

--- a/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
+++ b/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
@@ -172,6 +172,8 @@ The following table shows the meta packages that will be available:
 | amdrocm-openmp          |                                                                      | Components needed to build OpenMP                                             |
 | amdrocm-core-sdk        |                                                                      | Everything                                                                    |
 
+Note: ROCm Core includes libraries spanning math & compute, communication, media, storage, and support libraries.
+
 ## Package Granularity
 
 Package granularity will be increased with ROCm 8.0. Development packages contain all the code required to build the libraries, including headers, Cmake files, and static libraries. Source packages for all of rocm-libraries provide all the files to build the libraries from source in addition to the rocm-rock source package.

--- a/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
+++ b/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
@@ -202,7 +202,7 @@ Package granularity will be increased with ROCm 8.0. Development packages contai
 | amdrocm-opencl                          |                             | OpenCL                                                                        |                                          |
 | amdrocm-decode                          |                             | rocDecode                                                                     |                                          |
 | amdrocm-jpeg                            |                             | rocJPEG                                                                       |                                          |
-| amdrocm-file                            |                             | hipFile, rocFile (future addition)                                            |                                          |
+| amdrocm-file                            |                             | hipFile (future addition)                                                     |                                          |
 | amdrocm-rccl                            |                             | rccl                                                                          |                                          |
 | amdrocm-shmem                           |                             | rocSHMEM                                                                      |                                          |
 | amdrocm-sysdeps                         |                             | Bundled 3rd party dependencies (e.g., libdrm, libelf, numa, subset of libVA)  |                                          |


### PR DESCRIPTION
## Motivation

amdrocm-core-devel meta packages don't exist in ROCm 7.11 but they do exist as amdrocm-core-dev. There are too many instances of this package that making engineering change the naming scheme is redundant so instead it makes more sense to update the RFC to reflect the current state.

Additionally, rocSHMEM needs to be included in this RFC as a component-specific package

AIROCSHMEM-328

## Technical Details

N/A

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
