### PR TITLE
Add unit test for artifact descriptor basedir overlap

### DIFF
--- a/build_tools/tests/artifact_descriptor_overlap_test.py
+++ b/build_tools/tests/artifact_descriptor_overlap_test.py
@@ -14,6 +14,15 @@ included `profiler/aqlprofile/stage`, causing concurrent extraction to race
 
 This test loads the real artifact-*.toml descriptors from the source tree and
 checks that each stage directory (basedir) belongs to exactly one descriptor.
+
+Limitations (cases this test does NOT catch):
+  - Two artifacts with *different* basedirs whose installed files collide
+    after flattening (basedir prefix stripped). If two subprojects both
+    install a file to the same relative path (e.g., "lib/libfoo.so" or
+    "bin/sequence.yaml") in their respective stage dirs, flattening produces
+    duplicate paths even though the basedirs are distinct. Current projects
+    avoid this by using unique file names, but it's convention rather than
+    enforcement. Catching this requires inspecting actual build output.
 """
 
 import tomllib


### PR DESCRIPTION
## Motivation

This unit test would have caught https://github.com/ROCm/TheRock/issues/3758.

## Technical Details

This only looks at surface-level overlaps between artifact descriptors. Artifacts can still contain overlapping files. While many subprojects namespace their files into directories (e.g. `bin/hipblaslt/library/hipblasltExtOpLibrary.dat`), some like `math-libs/BLAS/hipBLASLt/stage/bin/sequence.yaml` go in common locations like `dist/rocm/bin/sequence.yaml`, so I think there's still substantial risk of overlap without a more comprehensive test.

## Test Plan

1. Run the unit test before the fix (https://github.com/ROCm/TheRock/commit/826092d3a9c3015854570b9918dc2066f1eb27b2), check that it fails.
2. Run the unit test after the fix, check that it passes.

## Test Result

1. Local logs:

    ```python
    pytest build_tools/tests/ -v
    ...
    ====================================================== FAILURES ======================================================= _____________________ ArtifactDescriptorOverlapTest.test_no_duplicate_basedirs_across_descriptors _____________________
    
    self = <artifact_descriptor_overlap_test.ArtifactDescriptorOverlapTest testMethod=test_no_duplicate_basedirs_across_descriptors>
    
        def test_no_duplicate_basedirs_across_descriptors(self):
            """Each stage directory must belong to exactly one artifact descriptor.
    
            If two descriptors reference the same basedir, their tarballs will
            contain overlapping files, causing extraction failures.
            """
            # basedir -> first descriptor that claims it
            seen: dict[str, Path] = {}
            errors: list[str] = []
    
            descriptors = sorted(THEROCK_DIR.rglob("artifact-*.toml"))
            self.assertGreater(
                len(descriptors),
                0,
                f"No artifact descriptors found, check THEROCK_DIR ('{THEROCK_DIR}')",
            )
    
            for descriptor_path in descriptors:
                relpath = descriptor_path.relative_to(THEROCK_DIR)
                for basedir in get_basedirs(descriptor_path):
                    if basedir in seen:
                        errors.append(
                            f"basedir '{basedir}' claimed by both "
                            f"{seen[basedir]} and {relpath}"
                        )
                    else:
                        seen[basedir] = relpath
    
            if errors:
    >           self.fail(
                    "Duplicate basedirs across artifact descriptors will cause "
                    "extraction collisions (see "
                    "https://github.com/ROCm/TheRock/issues/3758):\n"
                    + "\n".join(f"  - {e}" for e in errors)
                )
    E           AssertionError: Duplicate basedirs across artifact descriptors will cause extraction collisions (see https://github.com/ROCm/TheRock/issues/3758):
    E             - basedir 'profiler/aqlprofile/stage' claimed by both profiler\artifact-aqlprofile.toml and profiler\artifact-rocprofiler-sdk.toml
    
    build_tools\tests\artifact_descriptor_overlap_test.py:89: AssertionError
    =============================================== short test summary info =============================================== SKIPPED [1] build_tools\tests\fileset_tool_test.py:218: Hardlinks not supported the same way on Windows
    FAILED build_tools\tests\artifact_descriptor_overlap_test.py::ArtifactDescriptorOverlapTest::test_no_duplicate_basedirs_across_descriptors - AssertionError: Duplicate basedirs across artifact descriptors will cause extraction collisions (see https://github...
    ====================================== 1 failed, 155 passed, 1 skipped in 19.40s ======================================
    ```
2. CI: https://github.com/ROCm/TheRock/actions/runs/22692664034/job/65791785712?pr=3765#step:5:49

    ```
    tests/artifact_descriptor_overlap_test.py::ArtifactDescriptorOverlapTest::test_no_duplicate_basedirs_across_descriptors PASSED [  9%]
    ...
    =================== 291 passed, 2 subtests passed in 17.83s ====================
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
