### PR TITLE
Set rocrtst back to TARGET_NEUTRAL with USE_TEST_AMDGPU_TARGETS

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -249,7 +249,7 @@ source_sets = ["rocm-systems"]  # clr is in rocm-systems
 
 [artifact_groups.rocrtst]
 description = "Core runtime tests (ROCR-Runtime, rocminfo)"
-type = "per-arch"
+type = "generic"
 artifact_group_deps = ["opencl-runtime", "core-runtime"]
 source_sets = ["rocm-systems"]
 
@@ -480,7 +480,7 @@ feature_group = "CORE"  # Part of core, enabled by default
 
 [artifacts.rocrtst]
 artifact_group = "rocrtst"
-type = "target-specific"
+type = "target-neutral"
 artifact_deps = ["core-runtime", "core-ocl", "sysdeps-hwloc"]
 feature_name = "CORE_RUNTIME_TESTS"
 feature_group = "CORE"

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -438,7 +438,7 @@ if(THEROCK_BUILD_TESTING)
     endif()
 
     therock_cmake_subproject_declare(rocrtst
-      USE_DIST_AMDGPU_TARGETS
+      USE_TEST_AMDGPU_TARGETS
       EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime/rocrtst/suites/test_common"
       BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocrtst"
       BACKGROUND_BUILD
@@ -466,6 +466,7 @@ if(THEROCK_BUILD_TESTING)
     therock_cmake_subproject_activate(rocrtst)
 
     therock_provide_artifact(rocrtst
+      TARGET_NEUTRAL
       DESCRIPTOR artifact-core-rocrtst.toml
       COMPONENTS
         dbg


### PR DESCRIPTION
- Extend #3698 to rocrtst.
- Undoes the changes in #3706 while addressing #3666 