### PR TITLE
Fix IndexError when only generic artifacts exist

### DIFF
--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -80,7 +80,10 @@ class Parameters:
         self.version_suffix = version_suffix
         self.artifacts = artifacts
         self.all_target_families = artifacts.all_target_families
-        self.default_target_family = sorted(self.all_target_families)[0]
+        _sorted_families = sorted(self.all_target_families)
+        self.default_target_family: str | None = (
+            _sorted_families[0] if _sorted_families else None
+        )
         self.populated_packages: list["PopulatedDistPackage"] = []
         self.runtime_artifact_names: set[str] = set()
 
@@ -96,9 +99,10 @@ class Parameters:
         # Full: base extended with all families. Used by most packages and by
         # the dynamically loaded self.dist_info module below.
         dist_info_contents = dist_info_base
-        dist_info_contents += (
-            f"DEFAULT_TARGET_FAMILY = '{self.default_target_family}'\n"
-        )
+        if self.default_target_family is not None:
+            dist_info_contents += (
+                f"DEFAULT_TARGET_FAMILY = '{self.default_target_family}'\n"
+            )
         for target_family in self.all_target_families:
             dist_info_contents += (
                 f"AVAILABLE_TARGET_FAMILIES.append('{target_family}')\n"

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -397,6 +397,26 @@ class MultiArchPackagingTest(TmpDirTestCase):
 
 
 # ---------------------------------------------------------------------------
+# Tests for Parameters construction edge cases
+# ---------------------------------------------------------------------------
+
+
+class ParametersConstructionTest(TmpDirTestCase):
+    def test_no_arch_specific_artifacts_does_not_crash(self):
+        # Regression: Parameters.__init__ raised IndexError when all_target_families
+        # was empty because it did sorted(...)[0] unconditionally.
+        artifact_dir = self.temp_dir / "artifacts"
+        artifact_dir.mkdir()
+        params = Parameters(
+            dest_dir=self.temp_dir / "packages",
+            version="0.0.1.test",
+            version_suffix="",
+            artifacts=ArtifactCatalog(artifact_dir),
+        )
+        self.assertIsNone(params.default_target_family)
+
+
+# ---------------------------------------------------------------------------
 # Unit tests for restrict_families (per-family meta package)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
`Parameters.__init__` raised `IndexError` when only generic artifacts were present (e.g. a core-only or headers-only build).

Make `default_target_family` `Optional[str]`, set to `None` when the family set is empty, and guard the `DEFAULT_TARGET_FAMILY` line in the generated `dist_info` contents accordingly. The template's fallback value `DEFAULT_TARGET_FAMILY = "DEFAULT"` is a sentinel for the no-families case; since `AVAILABLE_TARGET_FAMILIES` is also empty in that case, any call to `determine_target_family()` will raise a `ValueError` regardless.