### PR TITLE
rccl: Remove rocprofiler-register dependency

### DIFF
--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -6,7 +6,7 @@ if(THEROCK_ENABLE_RCCL)
   # on Posix.
   set(optional_profiler_deps)
   if(THEROCK_FLAG_INCLUDE_PROFILER)
-    list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
+    list(APPEND optional_profiler_deps rocprofiler-register roctracer rocprofiler-sdk)
   endif()
 
   # RCCL can optionally use amdsmi/rocm_smi_lib on Linux, but those may not be
@@ -51,7 +51,6 @@ if(THEROCK_ENABLE_RCCL)
     RUNTIME_DEPS
       hip-clr
       hipify
-      rocprofiler-register
       ${_rccl_optional_runtime_deps}
       ${optional_profiler_deps}
   )


### PR DESCRIPTION
- Full builds triggered on rocm-systems are failing on rccl-tests configure step, looking for rocprofiler-register.
- Remove rocprofiler-register dependency from compilation of rccl.
- ROCm/rocm-systems#3482 removed find_package(rocprofiler-register REQUIRED) calls.

CI runs exhibiting the issue:
- https://github.com/ROCm/rocm-systems/actions/runs/22678969199
- https://github.com/ROCm/rocm-systems/actions/runs/22688924172?pr=3709
- https://github.com/ROCm/rocm-systems/actions/runs/22683526891?pr=3749

Test:
- rocm-systems CI run with workflows pointing TheRock ref to this PR branch.

Test Result:
- pending