### PR TITLE
Filter mxDataGenerator from rocRoller artifact entries

### DIFF
--- a/math-libs/BLAS/artifact-blas.toml
+++ b/math-libs/BLAS/artifact-blas.toml
@@ -9,19 +9,14 @@
 optional = true
 [components.dev."math-libs/BLAS/rocRoller/stage"]
 optional = true
-include = [
-  "include/rocRoller/**",
-  "lib/cmake/rocroller/**",
+exclude = [
+  "include/mxDataGenerator/**",
+  "lib/cmake/mxDataGenerator/**",
 ]
 [components.doc."math-libs/BLAS/rocRoller/stage"]
 optional = true
 [components.lib."math-libs/BLAS/rocRoller/stage"]
 optional = true
-include = [
-  "lib/librocroller*",
-  "lib/rocroller*",
-  "bin/rocroller*",
-]
 [components.test."math-libs/BLAS/rocRoller/stage"]
 include = [
   "bin/rocroller-test*",


### PR DESCRIPTION
## Motivation

Tentative fix for https://github.com/ROCm/TheRock/issues/3770.

The `blas_dev` artifact includes
```
math-libs/
  BLAS/
    rocRoller/
      stage/
        include/
          mxDataGenerator/
            bf16.hpp
            ...
```
but these files are also in the `support_dev` artifact:
```
math-libs/
  support/
    mxDataGenerator/
      stage/
        include/
          mxDataGenerator/
            bf16.hpp
            ...
```

When flattened, these files conflict. The artifact extra code attempts an unlink/replace (most recent wins), but race conditions are possible during parallel artifact extraction.

## Technical Details

Together with the `aqlprofile-tests` / `rocprofiler-sdk` artifact fixes in https://github.com/ROCm/TheRock/pull/3698, this gets us back to having zero duplicate files _across_ all artifacts (e.g. `blas` and `support`). We still have duplicates _within_ artifacts (e.g. `miopen_test` and `miopen_run`).

## Test Plan

* Regular CI workflows
  * Show that this doesn't break any existing tests
  * Check that `blas_dev` no longer includes the mxDataGenerator files
* New unit tests to enforce no duplicates going forward (future PR, nontrivial to add)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
