### PR TITLE
Add missing python packages needed to upload PyTorch wheels

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -180,6 +180,10 @@ jobs:
           fi
           echo "${python_dir}/bin" >> "$GITHUB_PATH"
 
+      - name: Install python deps for CI
+        run: |
+          pip install -r external-builds/pytorch/requirements-ci.txt
+
       # Checkout nightly sources from https://github.com/pytorch/pytorch
       - name: Checkout PyTorch Source Repos from nightly branch
         if: ${{ inputs.pytorch_git_ref == 'nightly' }}
@@ -205,7 +209,6 @@ jobs:
       - name: Determine optional arguments passed to `build_prod_wheels.py`
         if: ${{ inputs.rocm_version }}
         run: |
-          pip install packaging
           python build_tools/github_actions/determine_version.py \
             --rocm-version ${{ inputs.rocm_version }}
 
@@ -302,7 +305,6 @@ jobs:
           # Environment variables to be set for `manage.py`
           CUSTOM_PREFIX: "${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}"
         run: |
-          pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}
 
   generate_target_to_run:
@@ -398,11 +400,15 @@ jobs:
             --include "triton-${TRITON_VERSION}-${CP_VERSION}-linux_x86_64.whl" \
             --include "apex-${APEX_VERSION}-${CP_VERSION}-linux_x86_64.whl"
 
+
+      - name: Install python deps for CI
+        run: |
+          pip install -r external-builds/pytorch/requirements-ci.txt
+
       - name: (Re-)Generate Python package release index
         if: ${{ env.upload == 'true' }}
         env:
           # Environment variables to be set for `manage.py`
           CUSTOM_PREFIX: "${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}"
         run: |
-          pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -118,6 +118,10 @@ jobs:
           fi
           echo "${python_dir}/bin" >> "$GITHUB_PATH"
 
+      - name: Install python deps for CI
+        run: |
+          pip install -r external-builds/pytorch/requirements-ci.txt
+
       - name: Checkout PyTorch source (nightly)
         if: ${{ inputs.pytorch_git_ref == 'nightly' }}
         run: |
@@ -136,7 +140,6 @@ jobs:
       - name: Determine optional arguments passed to `build_prod_wheels.py`
         if: ${{ inputs.rocm_version }}
         run: |
-          pip install packaging
           python build_tools/github_actions/determine_version.py \
             --rocm-version ${{ inputs.rocm_version }}
 

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -192,6 +192,10 @@ jobs:
       - name: Configure MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
+      - name: Install python deps for CI
+        run: |
+          pip install -r external-builds/pytorch/requirements-ci.txt
+
       # Checkout nightly sources from https://github.com/pytorch/pytorch
       # TODO: switch to 'nightly' to match our Linux workflows?
       - name: Checkout PyTorch source repos (nightly branch)
@@ -231,7 +235,6 @@ jobs:
       - name: Determine optional arguments passed to `build_prod_wheels.py`
         if: ${{ inputs.rocm_version }}
         run: |
-          pip install packaging
           python build_tools/github_actions/determine_version.py \
             --rocm-version ${{ inputs.rocm_version }}
 
@@ -339,7 +342,6 @@ jobs:
           CUSTOM_PREFIX: "${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}"
         shell: cmd
         run: |
-          pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}
 
   generate_target_to_run:
@@ -431,11 +433,14 @@ jobs:
             --include "torchaudio-${TORCHAUDIO_VERSION}-${CP_VERSION}-win_amd64.whl" \
             --include "torchvision-${TORCHVISION_VERSION}-${CP_VERSION}-win_amd64.whl"
 
+      - name: Install python deps for CI
+        run: |
+          pip install -r external-builds/pytorch/requirements-ci.txt
+
       - name: (Re-)Generate Python package release index
         if: ${{ env.upload == 'true' }}
         env:
           # Environment variables to be set for `manage.py`
           CUSTOM_PREFIX: "${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}"
         run: |
-          pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -131,6 +131,10 @@ jobs:
       - name: Configure MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
+      - name: Install python deps for CI
+        run: |
+          pip install -r external-builds/pytorch/requirements-ci.txt
+
       - name: Checkout PyTorch source (nightly)
         if: ${{ inputs.pytorch_git_ref == 'nightly' }}
         run: |
@@ -153,7 +157,6 @@ jobs:
       - name: Determine optional arguments passed to `build_prod_wheels.py`
         if: ${{ inputs.rocm_version }}
         run: |
-          pip install packaging
           python build_tools/github_actions/determine_version.py \
             --rocm-version ${{ inputs.rocm_version }}
 

--- a/external-builds/pytorch/requirements-ci.txt
+++ b/external-builds/pytorch/requirements-ci.txt
@@ -1,0 +1,6 @@
+# Python Requirements needed for the CI workflows
+
+# As this is only for building PyTorch we are not limited by the requirements
+# of dvc[s3] as in TheRock/requirements.txt
+boto3>1.42.0
+packaging>=26.0


### PR DESCRIPTION
With the change in https://github.com/ROCm/TheRock/pull/3596. the workflows to build PyTorch are missing importing boto3 to be able to upload the PyTorch wheels to S3.

This PR introduces a new `external-builds/pytorch/requirements-ci.txt` where the required python packages (packaging, boto3) are listed. Workflows are adjusted to `pip install -r external-builds/pytorch/requirements-ci.txt `

