### PR TITLE
Refactor rocrtst to use THEROCK_BIN_DIR artifact directly

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocrtst.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocrtst.py
@@ -24,8 +24,7 @@ environ_vars = os.environ.copy()
 environ_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
 environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 
-gpu_arch = get_first_gpu_architecture(env=environ_vars, therock_bin_dir=THEROCK_BIN_DIR)
-cwd_dir = Path(THEROCK_BIN_DIR) / gpu_arch
+cwd_dir = Path(THEROCK_BIN_DIR)
 cmd = ["./rocrtst64"]
 
 # Excluded tests (flaky or disabled in CI).


### PR DESCRIPTION
## Motivation

With the change to https://github.com/ROCm/rocm-systems/pull/3744 we can remove the GPU architecture dependency from cwd_dir assignment. 

## Technical Details

removes the GPU architecture dependency from cwd_dir assignment to run the top level rocrtst64 file in the bin instead.

## Test Plan

Verify rocrtst test with CI 

## Test Result

https://github.com/ROCm/TheRock/actions/runs/22725311846/job/65916612133?pr=3786

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
