### PR TITLE
[rocgdb] Ignore non-FAIL and non-UNRESOLVED timeouts

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocgdb.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocgdb.py
@@ -421,6 +421,13 @@ class TestResults:
                         test_name
                     )
 
+                # Ignore timeouts that happen on anything other than FAIL or
+                # UNRESOLVED. For instance, if we have a timeout for a KFAIL,
+                # we don't want to add it to the failed tests list since it is
+                # harmless.
+                if is_timeout and status not in ["FAIL", "UNRESOLVED"]:
+                    is_timeout = False
+
                 # Track the current list of failed tests.
                 if status in ["FAIL", "UNRESOLVED"] or is_timeout:
                     self.failed_tests[compiler_label].add(test_file)


### PR DESCRIPTION
I spotted the testing script considering a timeout in a KFAIL result as a failure, when it shouldn't be.

The patch adjusts things so we only consider a timeout a failure when it is in a FAIL or UNRESOLVED category.