### PR TITLE
Use `--reference` for nested `llvm-project`(s)

### DIFF
--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -140,17 +140,49 @@ def fetch_nested_submodules(args, projects):
 
         # Fetch the nested submodules
         parent_dir = THEROCK_DIR / get_submodule_path(parent)
-        nested_submodule_paths = [
-            get_submodule_path(nested_submodule, cwd=parent_dir)
-            for nested_submodule in nested_submodules
-        ]
-        run_command(
-            ["git", "submodule", "update", "--init"]
-            + update_args
-            + ["--"]
-            + nested_submodule_paths,
-            cwd=parent_dir,
-        )
+
+        # Use amd-llvm as a reference repo for llvm-project nested submodules.
+        # The ROCm fork (compiler/amd-llvm) and any other llvm fork likely share
+        # the vast majority of git history, so --reference saves significant
+        # clone time.
+        amd_llvm_path = THEROCK_DIR / "compiler" / "amd-llvm"
+        llvm_ref_paths = []
+        other_paths = []
+        for nested_submodule in nested_submodules:
+            sub_path = get_submodule_path(nested_submodule, cwd=parent_dir)
+            # In stage aware CI amd-llvm may not be fetched, so we only use
+            # --reference when it exists on disk.
+            if sub_path.endswith("llvm-project") and amd_llvm_path.exists():
+                llvm_ref_paths.append(sub_path)
+            else:
+                other_paths.append(sub_path)
+
+        # Fetch nested llvm-project forks using --reference.
+        if llvm_ref_paths:
+            run_command(
+                [
+                    "git",
+                    "submodule",
+                    "update",
+                    "--init",
+                    "--reference",
+                    str(amd_llvm_path),
+                ]
+                + update_args
+                + ["--"]
+                + llvm_ref_paths,
+                cwd=parent_dir,
+            )
+
+        # Fetch a regular nested submodule
+        if other_paths:
+            run_command(
+                ["git", "submodule", "update", "--init"]
+                + update_args
+                + ["--"]
+                + other_paths,
+                cwd=parent_dir,
+            )
 
 
 def run(args):
@@ -483,7 +515,7 @@ def main(argv):
     )
     parser.add_argument(
         "--include-iree-libs",
-        default=False,
+        default=True,
         action=argparse.BooleanOptionalAction,
         help="Include IREE and related libraries",
     )

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -515,7 +515,7 @@ def main(argv):
     )
     parser.add_argument(
         "--include-iree-libs",
-        default=True,
+        default=False,
         action=argparse.BooleanOptionalAction,
         help="Include IREE and related libraries",
     )


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

https://github.com/ROCm/TheRock/pull/3738 disabled `iree-libs` projects during `fetch_sources.py` by default as the cost of fetching IREE's LLVM was too high. The `ROCm` and `iree-org` llvm forks share the vast majority of git history, so borrowing objects locally saves ~3.3GB of downloads and minutes of clone time -- making the fetch much more palatable.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

When fetching nested submodules, use `compiler/amd-llvm` as a `--reference` repo for `llvm-project` forks.  In stage-aware CI where `amd-llvm` may not be fetched, the reference is skipped gracefully.

~With the clone cost addressed, re-enable `--include-iree-libs` in `fetch_sources.py` by default.~ We'll leave the fetch disabled for now as there still is a cost.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Fetching sources is adequately covered by existing CI.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
