### PR TITLE
Use `fusilli-provider` defined in `rocm-libraries`

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -314,7 +314,7 @@ description = "Fusilli hipdnn provider"
 type = "generic"
 artifact_group_deps = ["hip-runtime", "iree-compiler"]
 # TODO: rocm-systems included for projects/hip/VERSION (see CMakeLists.txt)
-source_sets = ["iree-libs", "rocm-systems"]
+source_sets = ["iree-libs", "rocm-libraries", "rocm-systems"]
 
 [artifact_groups.media-libs]
 description = "Media Libraries"

--- a/iree-libs/CMakeLists.txt
+++ b/iree-libs/CMakeLists.txt
@@ -88,7 +88,7 @@ if(THEROCK_ENABLE_FUSILLIPROVIDER)
   ##############################################################################
   therock_cmake_subproject_declare(fusilliprovider
     USE_DIST_AMDGPU_TARGETS
-    EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/fusilli/plugins/hipdnn-plugin"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/dnn-providers/fusilli-provider"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/fusilliprovider"
     BACKGROUND_BUILD
     CMAKE_ARGS


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Update TheRock build for fusilli provider to pull from new location in `rocm-libraries` (see: https://github.com/ROCm/rocm-libraries/pull/5149)

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Really just a couple boilerplate additions.

Note: as an optimization, we may want to add a feature to allow a sparse checkout when fetching the `rocm-libraries` source set ([link](https://github.com/ROCm/TheRock/pull/3791/changes#diff-9c53c23f4ebfe2986e8dfe8af30208eb6a1a6294946bb07b8fd69f9e1b84d379R317)). The `fusilli-libs` stage is only using a very small portion of that repo.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

As the IREE / fusilli build are not enabled by default, see this test branch with temporary changes required to enable the IREE / fusilli build: https://github.com/ROCm/TheRock/pull/3912

## Test Result

<!-- Briefly summarize test outcomes. -->

It works! [successful build + CI](https://github.com/ROCm/TheRock/actions/runs/22972523986/job/66726952506?pr=3912)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
