### PR TITLE
[ci] fixing `hipdnn` and `miopen` to prevent duplicate `tar` file extraction

### DIFF
--- a/ml-libs/artifact-hipdnn.toml
+++ b/ml-libs/artifact-hipdnn.toml
@@ -6,6 +6,7 @@
 exclude = [
   "lib/libhipdnn_backend_private.a",
   "lib/test_plugins/**",
+  "bin/*hipdnn_*_test*",
 ]
 [components.test."ml-libs/hipDNN/stage"]
 include = [

--- a/ml-libs/artifact-miopen.toml
+++ b/ml-libs/artifact-miopen.toml
@@ -11,3 +11,6 @@ include = [
   "bin/miopen_gtest*",
 ]
 [components.run."ml-libs/MIOpen/stage"]
+exclude = [
+  "bin/miopen_gtest*",
+]


### PR DESCRIPTION
Resolves #2784

Discovered that MIOpen and hipDNN have identical files, thus causing the failure when trying to extract files in parallel (sometimes)

MIOpen:
<img width="1863" height="989" alt="Screenshot 2026-03-05 110045" src="https://github.com/user-attachments/assets/559d2622-c42f-4a80-8daf-7d20f93da6fb" />

hipDNN:
<img width="1845" height="992" alt="Screenshot 2026-03-05 105851" src="https://github.com/user-attachments/assets/76d33fcb-9416-4386-abfb-66374e234ae8" />
