### PR TITLE
Set default value for ARTIFACT_GROUP in github_action_utils

### DIFF
--- a/build_tools/github_actions/github_actions_utils.py
+++ b/build_tools/github_actions/github_actions_utils.py
@@ -598,5 +598,5 @@ def get_first_gpu_architecture(env=None, therock_bin_dir: str | None = None) -> 
 
 def is_asan():
     """Using artifact_group, determines if this is an asan build"""
-    ARTIFACT_GROUP = os.getenv("ARTIFACT_GROUP")
+    ARTIFACT_GROUP = os.getenv("ARTIFACT_GROUP", "")
     return "asan" in ARTIFACT_GROUP


### PR DESCRIPTION
- `ARTIFACT_GROUP` is not set for other repos that leverage TheRock CI yet (e.g., rocm-systems).
- `is_asan()` function leads to TypeError when `ARTIFACT_GROUP` is not set.
- `is_asan()` function is called in some component test scripts.
- Set a default value for `ARTIFACT_GROUP` to allow other repos to pin to a newer SHA of TheRock in their workflows.
