### PR TITLE
Enabling update alternative/symlink for SLES os profile

### DIFF
--- a/build_tools/packaging/linux/native_linux_packages_test.py
+++ b/build_tools/packaging/linux/native_linux_packages_test.py
@@ -577,6 +577,26 @@ gpgcheck=0
                     "-y",
                 ] + self.package_names
             print("[INFO] Using zypper for SLES package installation")
+            # Install update-alternatives (required for SLES) before ROCm packages
+            print("\nInstalling update-alternatives (SLES prerequisite)...")
+            try:
+                result = subprocess.run(
+                    ["zypper", "install", "-y", "update-alternatives"],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    timeout=120,
+                )
+                if result.returncode == 0:
+                    print("[PASS] update-alternatives installed")
+                else:
+                    print(
+                        f"[WARN] zypper install update-alternatives returned {result.returncode} (continuing anyway)"
+                    )
+            except (subprocess.TimeoutExpired, OSError) as e:
+                print(
+                    f"[WARN] Could not install update-alternatives: {e} (continuing anyway)"
+                )
         else:
             cmd = ["dnf", "install", "-y"] + self.package_names
         print(f"\nRunning: {' '.join(cmd)}")


### PR DESCRIPTION


## Motivation

This pull request adds a prerequisite installation step for SLES systems in the `install_rpm_packages`  
The main change ensures that `update-alternatives` is installed before attempting to install ROCm packages (to support the default rocm install prefix)

## Technical Details

SLES-specific installation improvement:
* Added logic to install `update-alternatives` using `zypper` before installing ROCm packages on SLES systems, including error handling and informative logging.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
https://github.com/arvindcheru/TheRock/actions/runs/22650614180
https://github.com/arvindcheru/TheRock/actions/runs/22650522511

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
