### PR TITLE
Add validation tests for `amd-smi` CLI output

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_sanity.py
+++ b/build_tools/github_actions/test_executable_scripts/test_sanity.py
@@ -12,14 +12,6 @@ logging.basicConfig(level=logging.INFO)
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
-
-def _run_pytest(
-    cmd: list[str], *, cwd: Path, env: dict[str, str], check: bool
-) -> subprocess.CompletedProcess[str]:
-    logging.info("++ Exec [%s]$ %s", cwd, " ".join(cmd))
-    return subprocess.run(cmd, cwd=cwd, env=env, check=check, text=True)
-
-
 env = os.environ.copy()
 # Enable verbose ROCm logging, see
 # https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/debugging.html
@@ -47,6 +39,6 @@ cmd = [
     "--timeout=300",
 ]
 
-# Default sanity behavior: run everything except tests marked as not_sanity.
-phase_cmd = cmd + ["-m", "not not_sanity"]
-_run_pytest(phase_cmd, cwd=THEROCK_DIR, env=env, check=True)
+logging.info(f"++ Exec [{THEROCK_DIR}]$ {' '.join(cmd)}")
+
+subprocess.run(cmd, cwd=THEROCK_DIR, env=env, check=True)


### PR DESCRIPTION
## Motivation

Adding amd-smi list test

## Technical Details

amd-smi list with different options are tested

## Test Plan

--json, --csv, --file and no option is being tested

## Test Result

6 tests passed. https://github.com/ROCm/TheRock/actions/runs/22840058512

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
