### PR TITLE
Add aqlprofile artifact and composable_kernel dev component to packaging

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1168,6 +1168,20 @@
             ]
           }
         ]
+      },
+      {
+        "Artifact": "aqlprofile",
+        "Artifact_Subdir": [
+          {
+            "Name": "aqlprofile",
+            "Components": [
+              "lib",
+              "dev",
+              "run",
+              "doc"
+            ]
+          }
+        ]
       }
     ],
 
@@ -1649,6 +1663,7 @@
             "Name": "composable_kernel",
             "Components": [
               "run",
+              "dev",
               "doc"
             ]
           }


### PR DESCRIPTION
  Update package.json to include:
  - New aqlprofile artifact entry under amdrocm-profiler-base with all component types (lib, dev, run, doc)
  - Missing 'dev' component for composable_kernel artifact in amdrocm-ck package

  These changes ensure proper packaging of profiler tooling and CK
  development files.