### PR TITLE
Add gfx90c build support

### DIFF
--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -44,6 +44,15 @@ function(therock_add_amdgpu_target gfx_target product_name)
   endforeach()
 endfunction()
 
+therock_add_amdgpu_target(gfx90c "AMD Renoir/Lucienne/Cezanne iGPU" FAMILY igpu-all gfx90c-igpu
+  EXCLUDE_TARGET_PROJECTS
+    hipBLASLt # https://github.com/ROCm/TheRock/issues/1062
+    hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
+    composable_kernel # https://github.com/ROCm/TheRock/issues/1245
+    rocWMMA # https://github.com/ROCm/TheRock/issues/1944
+    rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+)
+
 # gfx906 (separate family - different instruction support from gfx908/gfx90a)
 therock_add_amdgpu_target(gfx906 "Radeon VII / MI50 CDNA" FAMILY dgpu-all gfx906-dgpu
   EXCLUDE_TARGET_PROJECTS


### PR DESCRIPTION
## Motivation

First step in enabling gfx90c https://github.com/ROCm/TheRock/issues/3818.

## Technical Details

Adding in new gfx90c entry that will be apart of igpu-all and gfx90c-igpu families. We could potentially group gfx906, gfx900 and gfx90c into a gfx90X-dgpu (non-dcgpu) family going forward but this should be fine for now.

Following the same excludes as gfx906.

## Test Plan

Building with `-DTHEROCK_AMDGPU_FAMILIES=gfx90c-igpu` in parallel though that shouldn't be a blocker for this.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
