### PR TITLE
Build Correctly In Presence of /opt/rocm

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -7,6 +7,8 @@
 
 include(ExternalProject)
 
+set(ROCM_PATH ${THEROCK_BINARY_DIR}/dist/rocm)
+
 # Global properties.
 # THEROCK_DEFAULT_CMAKE_VARS:
 # List of CMake variables that will be injected by default into the
@@ -23,6 +25,10 @@ set_property(GLOBAL PROPERTY THEROCK_DEFAULT_CMAKE_VARS
   THEROCK_ENABLE_LLVM_TESTS
   LLVM_LIT_ARGS
   THEROCK_USE_SAFE_DEPENDENCY_PROVIDER
+  HIP_DIR
+  HIP_PATH
+  ROCM_DIR
+  ROCM_PATH
   ROCM_SYMLINK_LIBS
 
   # RPATH handling.
@@ -705,10 +711,10 @@ function(therock_cmake_subproject_activate target_name)
   #   * Use `${HIP_PATH}` as a hint for `find_package()` calls
   # We unset both the CMake and environment variables with these names.
   # See also https://github.com/ROCm/TheRock/issues/670.
-  list(APPEND _build_env_pairs "--unset=ROCM_PATH")
-  list(APPEND _build_env_pairs "--unset=ROCM_DIR")
-  list(APPEND _build_env_pairs "--unset=HIP_PATH")
-  list(APPEND _build_env_pairs "--unset=HIP_DIR")
+  list(APPEND _build_env_pairs "ROCM_DIR=${THEROCK_BINARY_DIR}/dist/rocm")
+  list(APPEND _build_env_pairs "ROCM_PATH=${THEROCK_BINARY_DIR}/dist/rocm")
+  list(APPEND _build_env_pairs "HIP_PATH=${THEROCK_BINARY_DIR}/dist/rocm")
+  list(APPEND _build_env_pairs "HIP_DIR=${THEROCK_BINARY_DIR}/dist/rocm")
 
   # Handle compiler toolchain.
   set(_compiler_toolchain_addl_depends)


### PR DESCRIPTION
Various projects built by TheRock are fascinated with the `/opt/rocm` directory on host systems and try to use it for things.  Ideally, they would lose that fascination.  This PR instead attempts to help work around their fascination by exporting more symbols to control the locations of ROCm tools.