### PR TITLE
Add style rule for argparse.Namespace access.

### DIFF
--- a/docs/development/style_guides/python_style_guide.md
+++ b/docs/development/style_guides/python_style_guide.md
@@ -13,6 +13,7 @@ Table of Contents
   - [Script structure and organization](#script-structure-and-organization)
     - [Use `__main__` guard](#use-__main__-guard)
     - [Use `argparse` for CLI flags](#use-argparse-for-cli-flags)
+    - [Access `argparse` attributes directly](#access-argparse-attributes-directly)
     - [Import organization](#import-organization)
     - [Code organization](#code-organization)
     - [No duplicate code](#no-duplicate-code)
@@ -411,6 +412,41 @@ if len(sys.argv) < 3:
 
 run_id = sys.argv[1]  # String, not validated
 output_dir = sys.argv[2]
+```
+
+#### Access `argparse` attributes directly
+
+**Access parsed arguments with `args.foo`, not `getattr(args, "foo", default)`.**
+
+If an argument was added to the parser (or subparser), it is guaranteed to exist
+on the `Namespace`. Using `getattr` obscures that contract and suggests the
+attribute might be missing — which it won't be.
+
+When subcommand handlers pass `args` values into typed function calls, trust the
+unpacking:
+
+✅ **Preferred:**
+
+```python
+def do_copy(args: argparse.Namespace):
+    source_backend = create_backend(
+        run_id=args.source_run_id,
+        platform=args.platform,
+        staging_dir=args.local_staging_dir,  # Always present (None if not given)
+    )
+```
+
+❌ **Avoid:**
+
+```python
+def do_copy(args: argparse.Namespace):
+    source_backend = create_backend(
+        run_id=args.source_run_id,
+        platform=args.platform,
+        staging_dir=getattr(
+            args, "local_staging_dir", None
+        ),  # Suggests it might not exist
+    )
 ```
 
 #### Import organization


### PR DESCRIPTION
## Motivation

Review at https://github.com/ROCm/TheRock/pull/3801#discussion_r2897418528 caught some overly defensive coding:
```python
def do_copy(args: argparse.Namespace):
    ...
    source_backend = _create_source_backend(
        source_run_id=args.source_run_id,
        platform=args.platform,
        local_staging_dir=getattr(args, "local_staging_dir", None),  # Here
```

This adds a style guide rule saying we prefer to trust that `args` contains attributes:

```diff
-       local_staging_dir=getattr(args, "local_staging_dir", None),
+       local_staging_dir=args.local_staging_dir,
```

## Technical Details

Discussion with the agent that authored the change:

```
> Ok for the review comments, how can we stop weird patterns like `getattr(args, "local_staging_dir", None)` from
  appearing in the first place?

● That's on me — I used getattr defensively because argparse.Namespace is untyped, so there's no static analysis telling
   you the attribute exists. But --local-staging-dir is added by _add_backend_args, which is called on the copy parser,
  so args.local_staging_dir is always present.

  The fix is a style guide rule. The Python style guide already says "explicit over implicit" — this is a case of being
  too defensive. A short note like "trust argparse: use args.foo directly, not getattr(args, 'foo', ...)" would catch
  this in reviews.

  Want me to add that to the Python style guide?

> Ah, and `do_copy(args: argparse.Namespace)` is pretty much untyped... yeah. We have this pattern in a few
  scripts. I'm more a fan of having explicit argument lists instead of passing around `args` everywhere. This is in
   a gray area where each subcommand takes `args`, and the subcommand may then call other functions with specific
  argument lists.

● Right. The do_copy(args: argparse.Namespace) → _create_source_backend(source_run_id, platform, local_staging_dir)
  boundary is actually doing the right thing — do_copy unpacks the bag-of-attributes into typed parameters at the call
  site. The getattr crept in because the untyped args makes you second-guess what's in it.

  The pattern is fine as-is: subcommand entry points take args: Namespace, then unpack into typed calls. The rule is
  just "trust the unpacking — if you defined the arg on that parser, access it directly." No need to refactor the whole
  argparse structure for this.

  I'd add a one-liner to the Python style guide: something like "Access argparse.Namespace attributes directly
  (args.foo), not via getattr. The argument is guaranteed to exist if it was added to the subparser."
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
