### PR TITLE
Fix checkout repo in reusable JAX wheel workflow

### DIFF
--- a/.github/workflows/build_linux_jax_wheels.yml
+++ b/.github/workflows/build_linux_jax_wheels.yml
@@ -134,6 +134,9 @@ jobs:
     steps:
       - name: Checkout TheRock
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || '' }}
 
       - name: Checkout rocm-jax
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Ensure the reusable JAX wheel build workflow checks out the correct repository when invoked from wrapper repos (e.g. rockrel). Previously, actions/checkout defaulted to github.repository, causing the caller repo to be checked out instead of ROCm/TheRock and resulting in missing build scripts.

The checkout step now explicitly uses the repository and ref inputs, matching the behavior used in the PyTorch wheel workflow.