### PR TITLE
Install strace package to no_rocm_image_ubuntu24_04_ocl_rt

### DIFF
--- a/dockerfiles/no_rocm_image_ubuntu24_04_ocl_rt.Dockerfile
+++ b/dockerfiles/no_rocm_image_ubuntu24_04_ocl_rt.Dockerfile
@@ -3,4 +3,5 @@ FROM ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
 # packages for runtime hip/ocl validation
 RUN sudo apt-get install -y --no-install-recommends \
     ocl-icd-libopencl1 \
-    ocl-icd-opencl-dev
+    ocl-icd-opencl-dev \
+    strace


### PR DESCRIPTION
strace package required to look at the libs loaded while execution of ocltst ldd does not list all the libraries, so strace is required

## Motivation
strace package required to look at the libs loaded while execution of ocltst ldd does not list all the libraries, so strace is required


## Technical Details
strace package required to look at the libs loaded while execution of ocltst ldd does not list all the libraries, so strace is required

## Test Plan
no_rocm_image_ubuntu24_04_ocl_rt should have strace package installed for testing of ocltst

## Test Result
no_rocm_image_ubuntu24_04_ocl_rt should have strace package installed for testing of ocltst

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
