### PR TITLE
extended_tests: Disable results API upload and LKG comparison

### DIFF
--- a/tests/extended_tests/benchmark/scripts/benchmark_base.py
+++ b/tests/extended_tests/benchmark/scripts/benchmark_base.py
@@ -22,7 +22,7 @@ from utils.extended_test_base import ExtendedTestBase, gha_append_step_summary
 ENABLE_RESULTS_API = False
 
 
-class BenchmarkBase:
+class BenchmarkBase(ExtendedTestBase):
     """Base class providing common benchmark logic.
 
     Inherits shared infrastructure from ExtendedTestBase (execute_command,
@@ -106,7 +106,7 @@ class BenchmarkBase:
         """
         if not ENABLE_RESULTS_API:
             log.warning(
-                "Results API is disabled (ENABLE_RESULTS_API=False). Skipping upload."
+                "Results API is disabled temporarily (ENABLE_RESULTS_API=False). Skipping upload."
             )
             return False
 
@@ -116,7 +116,7 @@ class BenchmarkBase:
         """Compare results with Last Known Good baseline."""
         if not ENABLE_RESULTS_API:
             log.warning(
-                "Results API is disabled (ENABLE_RESULTS_API=False). Skipping LKG comparison."
+                "Results API is disabled temporarily (ENABLE_RESULTS_API=False). Skipping LKG comparison."
             )
             # Print raw tables so scores are still visible in the log.
             table_list = tables if isinstance(tables, list) else [tables]


### PR DESCRIPTION
### Summary

Temporarily disabling results API upload and LKG comparison in extended_tests/benchmark due to network connectivity issues.

### Problem

Benchmark CI jobs are failing with `403 Client Error: Ip Forbidden` on result upload & LKG fetch
This causes the entire benchmark run to error out even when all benchmarks pass.

### Changes

- Add `ENABLE_RESULTS_API` flag in benchmark_base.py (set to False)
- When disabled:
  - upload_results skips API call, logs warning
  - compare_with_lkg prints raw score tables, skips LKG fetch

### Actions

Set `ENABLE_RESULTS_API = True` in benchmark_base.py once the API network/firewall issue is resolved. Tracked in https://github.com/ROCm/TheRock/issues/3850.