### PR TITLE
[rocprofiler-compute] Update EXCLUDED_TESTS in test_rocprofiler_compute.py

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_compute.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_compute.py
@@ -14,10 +14,9 @@ THEROCK_PATH = THEROCK_BIN_PATH.parent
 THEROCK_LIB_PATH = str(THEROCK_PATH / "lib")
 ROCPROFILER_COMPUTE_DIRECTORY = THEROCK_PATH / "libexec" / "rocprofiler-compute"
 
-# Set up excluded tests (include Jiras/GitHub issues)
+# Set up excluded tests
 EXCLUDED_TESTS = [
-    "test_profile_pc_sampling",  # AIPROFSDK-36: rocr issue causing test to fail
-    "test_profile_live_attach_detach",  # https://github.com/ROCm/TheRock/issues/3778
+    "test_profile_live_attach_detach",
 ]
 
 # Smoke Tests


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Disable the `test_profile_live_attach_detach` test in rocprofiler compute due its flakiness which can lead to 60 minute hangs on CI.

Additionally, this PR re-enables `test_profile_pc_sampling` since it is now confirmed to be working again.

Fixes: https://github.com/ROCm/TheRock/issues/3778

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Update `test_rocprofiler_compute.py` to add `test_profile_live_attach_detach` in EXCLUDED_TESTS, while also removing `test_profile_pc_sampling`

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Run a manual workflow trigger to run a full test suite to verify only the `test_profile_live_attach_detach` test is excluded

## Test Result
<!-- Briefly summarize test outcomes. -->
https://github.com/ROCm/TheRock/actions/runs/22905311381
Tests are passing, `test_profile_live_attach_detach` test was excluded as expected

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
