### PR TITLE
Replace whitelist with blacklist for CK

### DIFF
--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -11,15 +11,19 @@ endif()
 # Disable composable kernel on GPU families that are explicitly unsupported
 if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
   set(_ck_unsupported_gfx_targets gfx906 gfx1010 gfx1011 gfx1012 gfx1033)
+  set(_ck_is_unsupported OFF)
   foreach(_gfx_target ${THEROCK_AMDGPU_TARGETS})
     if(_gfx_target IN_LIST _ck_unsupported_gfx_targets)
+      set(_ck_is_unsupported ON)
       message(WARNING
         "${_gfx_target} (included in THEROCK_AMDGPU_TARGETS) is not supported by composable kernel. "
         "Disabling composable kernel and its use in MIOpen.")
-      set(THEROCK_ENABLE_COMPOSABLE_KERNEL OFF)
-      set(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL OFF)
     endif()
   endforeach()
+  if(_ck_is_unsupported)
+    set(THEROCK_ENABLE_COMPOSABLE_KERNEL OFF)
+    set(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL OFF)
+  endif()
 endif()
 
 if(THEROCK_ENABLE_COMPOSABLE_KERNEL)


### PR DESCRIPTION
This PR updates how composable kernel support is controlled in ml-libs/CMakeLists.txt. Instead of maintaining a whitelist of supported GPU architectures, the logic now disables composable kernel for a defined set of unsupported GPU families, which simplifies maintenance and reduces churn as new architectures are added.

Summary of changes:
- Replaced the `_ck_supported_gfx_targets` allow‑list with a `_ck_unsupported_gfx_targets` deny‑list, and updated the conditional logic to disable composable kernel when any target matches the unsupported list.
- The unsupported GPU list was derived from architectures where CK was listed under `EXCLUDE_TARGET_PROJECTS` in `therock_amdgpu_targets.cmake`.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
