### PR TITLE
Patch upload_pytorch_manifest_test to pass when run from a fork.

### DIFF
--- a/build_tools/github_actions/tests/upload_pytorch_manifest_test.py
+++ b/build_tools/github_actions/tests/upload_pytorch_manifest_test.py
@@ -90,6 +90,8 @@ class TestMain(unittest.TestCase):
                     "nightly",
                     "--output-dir",
                     str(staging_dir),
+                    "--bucket",
+                    "test",
                 ]
             )
 
@@ -127,6 +129,8 @@ class TestMain(unittest.TestCase):
                     "release/2.7",
                     "--output-dir",
                     str(staging_dir),
+                    "--bucket",
+                    "test",
                 ]
             )
 
@@ -160,6 +164,8 @@ class TestMain(unittest.TestCase):
                         "nightly",
                         "--output-dir",
                         str(staging),
+                        "--bucket",
+                        "test",
                     ]
                 )
 
@@ -187,6 +193,8 @@ class TestMain(unittest.TestCase):
                     "nightly",
                     "--output-dir",
                     str(staging_dir),
+                    "--bucket",
+                    "test",
                     "--dry-run",
                 ]
             )


### PR DESCRIPTION
## Motivation

This test was failing when run in a fork: https://github.com/ScottTodd/TheRock/actions/runs/22878438261/job/66375576474

```
>           self.assertTrue(
                (
                    staging_dir
                    / f"99999-{upload_pytorch_manifest.PLATFORM}"
                    / "manifests"
                    / "gfx110X-all"
                    / manifest_name
                ).is_file()
            )
E           AssertionError: False is not true
```

## Technical Details

The underlying code uses `GITHUB_REPOSITORY` to choose a subpath in a bucket like `"ForkName-TheRock/"` instead of `""`. The test expects path `{staging_dir}/12345-linux/manifests/...` but on the fork it becomes `{staging_dir}/ForkName-TheRock/12345-linux/manifests/....`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
