### PR TITLE
Update debug agent CI wrapper for structured test output

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocr-debug-agent.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocr-debug-agent.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
+import json
 import logging
 import os
 import resource
@@ -17,11 +18,21 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+STATUS_PASS = "[✓]"
+STATUS_FAIL = "[X]"
+STATUS_WARN = "[!]"
+STATUS_SKIP = "[~]"
+
+
+def print_section(title: str, border_char: str = "=", width: int = 80) -> None:
+    border = border_char * width
+    logger.info("")
+    logger.info(border)
+    logger.info(f"{title:^{width}}")
+    logger.info(border)
+
 
 def parse_arguments() -> argparse.Namespace:
-    """
-    Parse command-line arguments with all-or-nothing logic.
-    """
     parser = argparse.ArgumentParser(
         description="Run ROCm Debug Agent tests with configurable paths.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -56,11 +67,8 @@ Environment Variables (used when CLI args are not provided):
 
     args = parser.parse_args()
 
-    # Check if any arguments are provided.
     args_provided = [args.test_bin, args.test_script]
     args_count = sum(arg is not None for arg in args_provided)
-
-    # Either all arguments or none.
     if args_count not in (0, 2):
         parser.error(
             "Error: Either provide both arguments (--test-bin, --test-script) or none."
@@ -70,68 +78,37 @@ Environment Variables (used when CLI args are not provided):
 
 
 def set_core_dump_limit() -> None:
-    """
-    Set core dump size limit to 0 (equivalent to ulimit -c 0).
-    """
     try:
         resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
-        logger.info("[✓] Core dump limit set to 0.")
+        logger.info(f"  {STATUS_PASS} Core dump limit set to 0.")
     except (ValueError, OSError) as e:
-        logger.warning(f"[!] Failed to set core dump limit: {e}")
-        logger.warning("Core files may be generated and consume disk space.")
+        logger.warning(f"  {STATUS_WARN} Failed to set core dump limit: {e}")
 
 
 def validate_path(path: Path, path_type: str, must_exist: bool = True) -> Path:
-    """
-    Validate and resolve a path.
-
-    Args:
-        path: Path to validate.
-        path_type: Description of the path (for error messages).
-        must_exist: Whether the path must exist.
-
-    Returns:
-        Resolved path.
-
-    Raises:
-        SystemExit: If path validation fails.
-    """
     try:
         resolved = path.resolve(strict=must_exist)
         if must_exist and not resolved.exists():
-            logger.error(f"[X] Error: {path_type} does not exist: {resolved}")
+            logger.error(f"{STATUS_FAIL} {path_type} does not exist: {resolved}")
             sys.exit(1)
         return resolved
     except (OSError, RuntimeError) as e:
-        logger.error(f"[X] Error: Could not resolve {path_type} '{path}': {e}")
+        logger.error(f"{STATUS_FAIL} Could not resolve {path_type} '{path}': {e}")
         sys.exit(1)
 
 
 def get_default_paths() -> Dict[str, Path]:
-    """
-    Get default paths from environment variables.
-
-    Returns:
-        Dictionary containing 'test_bin' and 'test_script' paths.
-
-    Raises:
-        SystemExit: If environment variables are not defined or paths cannot be resolved.
-    """
     therock_bin_dir_str = os.getenv("THEROCK_BIN_DIR")
     artifacts_dir_str = os.getenv("OUTPUT_ARTIFACTS_DIR")
 
-    # Check if environment variables are defined.
     if therock_bin_dir_str is None:
-        logger.error("[X] Error: THEROCK_BIN_DIR environment variable is not defined.")
+        logger.error(f"{STATUS_FAIL} THEROCK_BIN_DIR environment variable is not defined.")
         sys.exit(1)
 
     if artifacts_dir_str is None:
-        logger.error(
-            "[X] Error: OUTPUT_ARTIFACTS_DIR environment variable is not defined."
-        )
+        logger.error(f"{STATUS_FAIL} OUTPUT_ARTIFACTS_DIR environment variable is not defined.")
         sys.exit(1)
 
-    # Resolve and validate paths.
     therock_bin_dir = validate_path(Path(therock_bin_dir_str), "THEROCK_BIN_DIR")
     artifacts_dir = validate_path(Path(artifacts_dir_str), "OUTPUT_ARTIFACTS_DIR")
 
@@ -142,93 +119,72 @@ def get_default_paths() -> Dict[str, Path]:
 
 
 def get_python_executable() -> str:
-    """
-    Validates and returns the Python executable path.
-
-    Returns:
-        Path to Python executable.
-
-    Raises:
-        SystemExit: If valid Python executable cannot be found.
-    """
     if not sys.executable or not os.path.exists(sys.executable):
-        logger.error("[X] Error: Could not identify a valid Python executable path.")
+        logger.error(f"{STATUS_FAIL} Could not identify a valid Python executable path.")
         sys.exit(1)
     return sys.executable
 
 
-def print_section(
-    title: str,
-    border_char: str = "=",
-    width: int = 80,
-    center: bool = True,
-    inline: bool = False,
-    color: Optional[str] = None,
-) -> None:
-    """
-    Print a visually distinct section header for console output.
+def extract_json_summary(output: str) -> Optional[Dict]:
+    """Extract the JSON summary block emitted by run-test.py --json on stdout."""
+    brace_start = output.find("{")
+    if brace_start == -1:
+        return None
 
-    Supports two modes:
-    1. Full multi-line section:
-        ==============================
-              Section Title
-        ==============================
-    2. Inline single-line section:
-        -------- Section Title --------
+    try:
+        decoder = json.JSONDecoder()
+        result, _ = decoder.raw_decode(output, brace_start)
+        if isinstance(result, dict):
+            return result
+        return None
+    except (json.JSONDecodeError, ValueError):
+        return None
 
-    Args:
-        title (str):
-            The text to display inside the section header.
-        border_char (str, optional):
-            Character used for the border line (default: "=").
-        width (int, optional):
-            Total width of the header including borders (default: 80).
-        center (bool, optional):
-            Whether to center the title text for multi-line sections (default: True).
-        inline (bool, optional):
-            If True, print a single-line header with title inline (default: False).
-        color (str, optional):
-            ANSI color escape code applied to both title and borders (default: None, no color).
 
-            Examples:
-                "\033[92m" → Green
-                "\033[93m" → Yellow
-                "\033[94m" → Blue
-                "\033[91m" → Red
-                "\033[0m" resets color
+def print_ci_summary(summary: Dict) -> None:
+    """Print a concise CI summary — failures only, passes just counted."""
+    total = summary.get("total", 0)
+    passed = summary.get("passed", 0)
+    failed = summary.get("failed", 0)
+    skipped = summary.get("skipped", 0)
 
-    Example:
-        print_section("EXCLUSIVE FAILING TESTS COMPARISON")
-        print_section("Clang/Clang++", border_char="-", inline=True)
-        print_section("WARNING", border_char="!", width=50, color="\033[93m")
+    print_section("ROCm Debug Agent CI Summary")
+    logger.info(f"  Total:              {total}")
+    logger.info(f"  Passed:             {passed}")
+    logger.info(f"  Failed:             {failed}")
+    logger.info(f"  Skipped/Unsupported: {skipped}")
 
-    Notes:
-        - Works in standard terminals and logs.
-    """
-    reset = "\033[0m"
-    apply_color = (
-        (lambda text: f"{color}{text}{reset}") if color else (lambda text: text)
-    )
+    tests = summary.get("tests", [])
+    failed_tests = [t for t in tests if t.get("status") == "FAIL"]
+    skipped_tests = [t for t in tests if t.get("status") in ("SKIP", "UNSUPPORTED")]
 
-    # Always add a newline to the beginning of the section.
-    logger.info("")
+    if failed_tests:
+        logger.info("")
+        logger.info("  Failed tests:")
+        for t in failed_tests:
+            name = t.get("name", "<unknown>")
+            duration = t.get("duration_s", 0)
+            logger.info(f"    {STATUS_FAIL} {name} ({duration:.2f}s)")
+            if t.get("message"):
+                logger.info(f"           Reason: {t['message']}")
+            if t.get("unmatched_patterns"):
+                logger.info(f"           Missing patterns:")
+                for pat in t["unmatched_patterns"]:
+                    logger.info(f"             - {pat}")
 
-    if inline:
-        # Prepare inline title.
-        title_str = f" {title} "
-        remaining = width - len(title_str)
-        if remaining < 0:
-            remaining = 0
-        left = border_char * (remaining // 2)
-        right = border_char * (remaining - len(left))
-        logger.info(apply_color(f"{left}{title_str}{right}"))
-    else:
-        # Multi-line section style.
-        border = border_char * width
-        title_line = f"{title:^{width}}" if center else title
-        logger.info(apply_color(border))
-        logger.info(apply_color(title_line))
-        logger.info(apply_color(border))
+    if skipped_tests:
+        logger.info("")
+        logger.info("  Skipped tests:")
+        for t in skipped_tests:
+            name = t.get("name", "<unknown>")
+            logger.info(f"    {STATUS_SKIP} {name}")
+            if t.get("message"):
+                logger.info(f"           Reason: {t['message']}")
+
+    all_pass = summary.get("all_pass", False)
+    overall = STATUS_PASS if all_pass else STATUS_FAIL
+    status_text = "PASS" if all_pass else "FAIL"
+    print_section(f"{overall} OVERALL: {status_text}")
 
 
 def run_tests(
@@ -240,98 +196,85 @@ def run_tests(
     max_retries: int = 3,
     retry_delay: int = 5,
 ) -> None:
-    """
-    Runs the testsuite with a retry mechanism.
-
-    Args:
-        python_executable: Path to Python interpreter.
-        test_script: Path to test script.
-        working_dir: Working directory for test execution.
-        test_bin_dir: Directory containing test binaries.
-        env_vars: Environment variables for test execution.
-        max_retries: Maximum number of retry attempts.
-        retry_delay: Base delay in seconds between retries.
-
-    Raises:
-        SystemExit: If all retry attempts fail.
-    """
     if env_vars is None:
         env_vars = os.environ.copy()
 
-    cmd = [python_executable, str(test_script), str(test_bin_dir)]
+    cmd = [python_executable, str(test_script), str(test_bin_dir), "--json"]
 
     for attempt in range(1, max_retries + 1):
-        print_section(f"Running tests (Attempt {attempt}/{max_retries})")
-
-        logger.info(f"Exec [{working_dir}]$ {shlex.join(cmd)}")
+        print_section(f"Attempt {attempt}/{max_retries}")
+        logger.info(f"  Exec [{working_dir}]$ {shlex.join(cmd)}")
 
         start_time = time.perf_counter()
-        try:
-            subprocess.run(cmd, cwd=str(working_dir), check=True, env=env_vars)
+        proc = subprocess.run(
+            cmd,
+            cwd=str(working_dir),
+            check=False,
+            env=env_vars,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        output = proc.stdout or ""
+        duration = time.perf_counter() - start_time
+        summary = extract_json_summary(output)
 
-            duration = time.perf_counter() - start_time
-
-            print_section(
-                f"[✓] Tests succeeded on attempt {attempt}. Duration: {duration:.2f}s"
-            )
+        if proc.returncode == 0:
+            if summary:
+                print_ci_summary(summary)
+            else:
+                print_section(
+                    f"{STATUS_PASS} Tests succeeded (attempt {attempt}, {duration:.2f}s)"
+                )
             return
 
-        except subprocess.CalledProcessError as e:
-            duration = time.perf_counter() - start_time
-            logger.error(
-                f"[X] Attempt {attempt}/{max_retries} failed with exit code {e.returncode} "
-                f"after {duration:.2f}s"
-            )
+        for line in output.splitlines():
+            logger.info(line)
 
-            if attempt < max_retries:
-                # Exponential-ish backoff: multiply base delay by attempt number
-                wait_time = attempt * retry_delay
-                logger.info(f"Retrying in {wait_time}s...")
-                time.sleep(wait_time)
-            else:
-                # We failed all the attempts.
-                print_section(f"[X] All {max_retries} attempts failed.")
-                sys.exit(1)
+        logger.error(
+            f"  {STATUS_FAIL} Attempt {attempt}/{max_retries} failed "
+            f"(exit code {proc.returncode}, {duration:.2f}s)"
+        )
+
+        if summary:
+            print_ci_summary(summary)
+
+        if attempt < max_retries:
+            wait_time = attempt * retry_delay
+            logger.info(f"  Retrying in {wait_time}s...")
+            time.sleep(wait_time)
+        else:
+            print_section(f"{STATUS_FAIL} All {max_retries} attempts failed.")
+            sys.exit(1)
 
 
 def main() -> None:
-    """
-    Main entry point for the script.
-    """
-    # Parse command-line arguments.
     args = parse_arguments()
 
-    print_section("Path discovery")
-    # Determine paths to use.
+    print_section("ROCm Debug Agent CI Test Runner")
+
     if args.test_bin is not None:
-        logger.info("Using paths from command-line arguments.")
+        logger.info("  Using paths from command-line arguments.")
         rocr_debug_agent_test_bin = validate_path(args.test_bin, "--test-bin")
         rocr_debug_agent_test_script = validate_path(args.test_script, "--test-script")
     else:
-        # Use default logic.
-        logger.info("Using default paths from environment variables.")
+        logger.info("  Using default paths from environment variables.")
         defaults = get_default_paths()
         rocr_debug_agent_test_bin = defaults["test_bin"]
         rocr_debug_agent_test_script = defaults["test_script"]
 
-    # Derive the test binary directory.
     test_bin_dir = rocr_debug_agent_test_bin.parent
 
-    logger.info(f"Test Binary: {rocr_debug_agent_test_bin}")
-    logger.info(f"Test Script: {rocr_debug_agent_test_script}")
-    logger.info(f"Test Bin Dir: {test_bin_dir}")
+    logger.info(f"  Test Binary:  {rocr_debug_agent_test_bin}")
+    logger.info(f"  Test Script:  {rocr_debug_agent_test_script}")
+    logger.info(f"  Test Bin Dir: {test_bin_dir}")
 
-    # Setup Python executable.
     python_executable = get_python_executable()
+    logger.info(f"  Python:       {python_executable}")
 
-    logger.info(f"Located python executable: {python_executable}")
-
-    print_section("Disabling core file generation")
-
-    # Set core dump limit to 0 (ulimit -c 0).
+    logger.info("")
     set_core_dump_limit()
 
-    # Run tests.
     run_tests(
         python_executable=python_executable,
         test_script=rocr_debug_agent_test_script,


### PR DESCRIPTION
## Motivation

Update TheRock's CI wrapper script for rocr-debug-agent testing to work with the improved run-test.py output. The wrapper now parses structured JSON results from run-test.py and produces a concise, failure-focused CI summary instead of passing through raw output.

## Technical Details

- Pass `--json` to run-test.py for machine-readable results on stdout
- Parse JSON summary using `extract_json_summary()` for CI results display
- Failure-focused summary: counts and failed test details only
- Simplified section formatting to match run-test.py style
- Depends on https://github.com/ROCm/rocm-systems/pull/3903



## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.