### PR TITLE
Forward CC/CXX and launcher to Meson-based sysdep builds

### DIFF
--- a/cmake/therock_meson_env.cmake
+++ b/cmake/therock_meson_env.cmake
@@ -1,0 +1,31 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Assemble CC/CXX env strings for Meson from CMake's compiler and launcher
+# variables (which are already set correctly in the sub-project toolchain).
+#
+# CMAKE_C_COMPILER_LAUNCHER is a CMake list (semicolon-separated) to support
+# chained launchers (e.g. "ccache;distcc"). Meson expects a space-separated
+# string, so the launcher is joined with spaces before being prepended to the
+# compiler path.
+#
+# Usage:
+#   include("${THEROCK_SOURCE_DIR}/cmake/therock_meson_env.cmake")
+#   therock_get_meson_compiler_env(_meson_cc _meson_cxx)
+#   # Then pass to meson via cmake -E env:
+#   #   "CC=${_meson_cc}"
+#   #   "CXX=${_meson_cxx}"
+function(therock_get_meson_compiler_env out_cc out_cxx)
+  set(_cc "${CMAKE_C_COMPILER}")
+  set(_cxx "${CMAKE_CXX_COMPILER}")
+  if(CMAKE_C_COMPILER_LAUNCHER)
+    string(REPLACE ";" " " _c_launcher "${CMAKE_C_COMPILER_LAUNCHER}")
+    set(_cc "${_c_launcher} ${_cc}")
+  endif()
+  if(CMAKE_CXX_COMPILER_LAUNCHER)
+    string(REPLACE ";" " " _cxx_launcher "${CMAKE_CXX_COMPILER_LAUNCHER}")
+    set(_cxx "${_cxx_launcher} ${_cxx}")
+  endif()
+  set(${out_cc} "${_cc}" PARENT_SCOPE)
+  set(${out_cxx} "${_cxx}" PARENT_SCOPE)
+endfunction()

--- a/third-party/sysdeps/linux/amd-mesa/CMakeLists.txt
+++ b/third-party/sysdeps/linux/amd-mesa/CMakeLists.txt
@@ -48,6 +48,9 @@ if(NOT PATCHELF OR NOT MESON_BUILD)
   message(FATAL_ERROR "Missing PATCHELF or MESON_BUILD from super-project")
 endif()
 
+include("${THEROCK_SOURCE_DIR}/cmake/therock_meson_env.cmake")
+therock_get_meson_compiler_env(_meson_cc _meson_cxx)
+
 set(PATCH_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/../patch_source")
 
 add_custom_target(
@@ -63,6 +66,8 @@ add_custom_target(
     # This is required before patching because patch_source.sh modifies files in the libva subproject
     "${CMAKE_COMMAND}" -E env
       "LDFLAGS=-Wl,-rpath='$$ORIGIN' -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds"
+      "CC=${_meson_cc}"
+      "CXX=${_meson_cxx}"
       --
       "${MESON_BUILD}" setup
         --reconfigure
@@ -85,6 +90,8 @@ add_custom_target(
     # This ensures the build system uses the modified source files
     "${CMAKE_COMMAND}" -E env
       "LDFLAGS=-Wl,-rpath='$$ORIGIN' -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds"
+      "CC=${_meson_cc}"
+      "CXX=${_meson_cxx}"
       --
       "${MESON_BUILD}" setup
         --reconfigure

--- a/third-party/sysdeps/linux/libdrm/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libdrm/CMakeLists.txt
@@ -58,6 +58,9 @@ if(NOT PATCHELF OR NOT MESON_BUILD)
   message(FATAL_ERROR "Missing PATCHELF or MESON_BUILD from super-project")
 endif()
 
+include("${THEROCK_SOURCE_DIR}/cmake/therock_meson_env.cmake")
+therock_get_meson_compiler_env(_meson_cc _meson_cxx)
+
 # Meson refuses to build if the source dir is a subdir of the build dir, so
 # make it a sibling.
 set(PATCH_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/../patch_source")
@@ -80,6 +83,8 @@ add_custom_target(
     "${CMAKE_COMMAND}" -E env
       # Escaping hack: experimentally determined to persist through the layers.
       "LDFLAGS=-Wl,-rpath='$$ORIGIN' -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds"
+      "CC=${_meson_cc}"
+      "CXX=${_meson_cxx}"
       --
       "${MESON_BUILD}" setup "${CMAKE_CURRENT_BINARY_DIR}"
         --reconfigure

--- a/third-party/sysdeps/linux/libpciaccess/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libpciaccess/CMakeLists.txt
@@ -57,6 +57,9 @@ if(NOT PATCHELF OR NOT MESON_BUILD)
   message(FATAL_ERROR "Missing PATCHELF or MESON_BUILD from super-project")
 endif()
 
+include("${THEROCK_SOURCE_DIR}/cmake/therock_meson_env.cmake")
+therock_get_meson_compiler_env(_meson_cc _meson_cxx)
+
 add_custom_target(
   meson_build ALL
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
@@ -69,6 +72,8 @@ add_custom_target(
     "${CMAKE_COMMAND}" -E env
       # Apply symbol versioning via version.lds. RPATH is set post-install via patch_install.py.
       "LDFLAGS=-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds"
+      "CC=${_meson_cc}"
+      "CXX=${_meson_cxx}"
       --
       "${MESON_BUILD}" setup "${CMAKE_CURRENT_BINARY_DIR}"
         --reconfigure


### PR DESCRIPTION
Meson does not inherit CMAKE_C_COMPILER_LAUNCHER, so any launcher configured at the CMake level (e.g. ccache via -DCMAKE_C_COMPILER_LAUNCHER) was silently dropped for the libdrm, amd-mesa, and libpciaccess builds. Instead Mesa auto-detects and picks a launcher, see https://mesonbuild.com/Feature-autodetection.html#ccache.

Adds cmake/therock_meson_env.cmake with therock_get_meson_compiler_env(), a helper that assembles the CC/CXX strings expected by Meson (space-separated launcher + compiler) from CMake variables already set correctly in each sub-project's toolchain. Each Meson-based sysdep includes the helper and passes CC/CXX via cmake -E env.

Keeping the logic in the consumers (rather than in _therock_cmake_subproject_setup_toolchain) avoids adding Meson-specific code to the common subproject infrastructure and baking THEROCK_MESON_CC/CXX into every sub-project's toolchain file, including those that don't use Meson.

Fixes #3522.