### PR TITLE
Revert "Include rocr-debug-agent-tests in Python package (#3815)"

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -155,7 +155,6 @@ def core_artifact_filter(an: ArtifactName) -> bool:
         "rocjpeg",
         "rocprofiler-sdk",
         "rocr-debug-agent",
-        "rocr-debug-agent-tests",
         "sysdeps",
         "sysdeps-amd-mesa",
         "sysdeps-expat",


### PR DESCRIPTION
This reverts commit f5a25316bc84ec3945e1f28e059c6bfa8385e048.

Test artifacts are entirely excluded from Python packaging and thus rocr-debug-agent-tests should not be added to the list as it won't have any effect.

build_python_packages.py builds four package types - core, libraries, meta, and devel - using two artifact filters:

* core_artifact_filter: accepts lib and run components only (plus dev for HIP headers)
* libraries_artifact_filter: accepts lib component only

Neither filter includes the test component. There is no test package type defined and dedicated test artifacts are intentionally excluded.