### PR TITLE
Add support for <subproject>_CMAKE_ARGS to be passed to subproject configure

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -869,6 +869,8 @@ function(therock_cmake_subproject_activate target_name)
   # Detect whether the stage dir has been pre-built.
   set(_prebuilt_file "${_stage_dir}.prebuilt")
 
+  list(APPEND _cmake_args "${${target_name}_CMAKE_ARGS}")
+
   # Derive the CMAKE_BUILD_TYPE from either {project}_BUILD_TYPE or the global
   # CMAKE_BUILD_TYPE.
   set(_cmake_build_type "${${target_name}_BUILD_TYPE}")

--- a/docs/development/development_guide.md
+++ b/docs/development/development_guide.md
@@ -192,6 +192,15 @@ For example, this will build the "hipBLASLt" subproject in `RelWithDebInfo` and 
 > See the [Tips for using VSCode](#tips-for-using-vscode) section below for an
 > example of how to debug programs built in this way.
 
+- `{project}_CMAKE_ARGS`
+
+This variable will append to a subproject's default CMAKE arguments. It is a semicolon separated list.
+For example, this will add options to set tensilelite build parallel and keep build tmp in the "hipBLASLt" subproject:
+
+```bash
+  -DhipBLASLt_CMAKE_ARGS="-DTENSILELITE_BUILD_PARALLEL_LEVEL=32;-DTENSILELITE_KEEP_BUILD_TMP=ON"
+```
+
 ### Additional CMake developer ergonomic flags
 
 We add developer ergonomic flags as needed in order to support project-wide development activities. This currently includes:


### PR DESCRIPTION
## Motivation

Pass flags to subprojects from top level TheRock cmake.

## Technical Details

Use an indirect variable directly (no `option(..)`). If the variable is not defined the list append is empty and the list is unchanged.
I also added a verbose configure output which I find useful. Please comment if it should be excluded.

## Test Plan

I have been using this feature internally for several weeks

## Test Result

Observed configuration of subprojects with additional flags

## Submission Checklist

- [x] pre-commit run
