### PR TITLE
Add mount command to linux_portable_build.py

### DIFF
--- a/build_tools/linux_portable_build.py
+++ b/build_tools/linux_portable_build.py
@@ -66,6 +66,20 @@ def do_build(args: argparse.Namespace, *, rest_args: list[str]):
         ]
     )
 
+    # Add user-specified bind mounts.
+    if args.mounts:
+        for mount_spec in args.mounts:
+            if ":" in mount_spec:
+                src, dst = mount_spec.split(":", 1)
+            else:
+                src = dst = mount_spec
+            cl.extend(
+                [
+                    "--mount",
+                    f"type=bind,src={src},dst={dst}",
+                ]
+            )
+
     # Pass through environment variables that control build behavior.
     # These are set by CI workflows to enable features like build profiling.
     passthrough_env_vars = [
@@ -184,6 +198,12 @@ def main(argv: list[str]):
         default=Path(REPO_DIR / "output-linux-portable" / "build" / "artifacts"),
         type=Path,
         help="Source artifacts/ dir from a build",
+    )
+    p.add_argument(
+        "--mount",
+        action="append",
+        dest="mounts",
+        help="Additional bind mount in format src[:dst]. If dst omitted, uses src for both. Can be specified multiple times.",
     )
 
     args = p.parse_args(argv)


### PR DESCRIPTION
## Motivation

Allow arbitrary mounts to linux_portable_build.py . Utility is for rocm-npi-dev git_reference repo mount so fprints work properly

## Technical Details

Add the option and allow for either src:dst asymmetric mapping or path:path symmetric mapping

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] pre-commit run