### PR TITLE
Exclude driver tests for win gfx110

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -176,13 +176,16 @@ if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILI
 if AMDGPU_FAMILIES == "gfx950-dcgpu":
     negative_filter.append("*DBSync*")
 
+# Failing on on win gfx110x
+if any(prefix in AMDGPU_FAMILIES for prefix in ["gfx110"]):
+    negative_filter.append("*/GPU_MIOpenDriver*")
+    negative_filter.append("Smoke/CPU_Handle_NONE*")
+    negative_filter.append("Full/GPU_reduce_custom_fp32*")
+
 # Tests to be filtered for navi
 # 1- Ignore gfx942 tests
 # TODO: There is no FP32 wmma on Navi, remove all FP32 conv tests. These should already be skipped via applicability for
 # CK solvers
-# Failing on on win gfx110x
-if any(prefix in AMDGPU_FAMILIES for prefix in ["gfx110"]):
-    negative_filter.append("*/GPU_MIOpenDriver*")
 
 if any(prefix in AMDGPU_FAMILIES for prefix in ["gfx110", "gfx115", "gfx120"]):
     # These are ignored in miopen


### PR DESCRIPTION
## Motivation

To address the miopen failures in the rocm-systems bump https://github.com/ROCm/TheRock/pull/3841 for gfx110x

## Technical Details

Add these tests to negative filter:
miopen driver*
Smoke/CPU_Handle_NONE*
Full/GPU_reduce_custom_fp32*

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
