### PR TITLE
[rocprofiler-systems] Disable transpose runtime-instrument test

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
@@ -47,9 +47,9 @@ pytest_package_exec = (
 cmd = [
     sys.executable,
     str(pytest_package_exec),
-    # TODO: Once OpenMP target tests are fixed, remove the two lines below
+    # TODO: Once OpenMPTarget validation tests and transpose runtime_instrument tests are fixed, remove the lines below
     "-k",
-    "not TestOpenMPTarget",
+    "not TestOpenMPTarget and not (TestTranspose and runtime_instrument)",
     "--junit-xml=junit.xml",
     "--ci-mode",
     "--log-cli-level=info",


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

I've noticed that since https://github.com/ROCm/TheRock/pull/3731 was merged, our `runtime-instrument` test for `transpose` would timeout.

After my investigation, the best course of action for now is to disable it.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

I noticed that `transpose → libamdhip64.so.7 → libamd_comgr.so → libLLVM.so + libclang-cpp.so` 
The last two shared libraries are huge and Dyninst fails to parse them, causing failure after ~450 seconds.
Even if you exclude both libraries, the test will still take ~370 seconds, which is far too long for now.

A more permanent solution requires some changes to how `rocprof-sys-instrument` works at a core level.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Disable the failing test.

## Test Result

<!-- Briefly summarize test outcomes. -->

See workflows.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
