### PR TITLE
Add JSON syntax validation to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
         exclude_types: ["image", "jupyter"]
     -   id: check-yaml
         exclude: patches/
+    -   id: check-json
     -   id: check-merge-conflict
         exclude: patches/
 


### PR DESCRIPTION
Extends the pre-commit validation suite with the check-json hook from
  pre-commit/pre-commit-hooks. This addition ensures that all JSON files
  in the repository are syntactically valid before commits are accepted.
