### PR TITLE
CUID package proposal

### DIFF
--- a/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
+++ b/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
@@ -203,6 +203,7 @@ Package granularity will be increased with ROCm 8.0. Development packages contai
 | amdrocm-file                            |                             | hipFile, rocFile (future addition)                                            |                                          |
 | amdrocm-rccl                            |                             | rccl                                                                          |                                          |
 | amdrocm-sysdeps                         |                             | Bundled 3rd party dependencies (e.g., libdrm, libelf, numa, subset of libVA)  |                                          |
+| amdrocm-cuid                            |                             | cuid                                                                          |                                          |
 | amdrocm-rdc                             |                             | ROCm Datacenter                                                               |                                          |
 
 Note: Product management would like to follow upstream packaging structrures in ROCm in the future with no interim due dates as of now. Today there may be one amdrocm-llvm that includes both flang and the flang compiler; the flang component can be dependent on the llvm component.


### PR DESCRIPTION
## Motivation

CUID is a new component. Multiple projects will depend on CUID, including AMD-SMI, several internal GPU tools, and possibly the HIP runtime. The internal GPU tools that will use CUID are not dependent on ROCm, so a minimal package is desirable.

CUID is a project in rocm-systems. 

## Technical Details

This proposes a new standalone package for CUID. Alternates considered were:

1. adding to sysdeps which was denied as this is not a system dependency but an AMD project. 
2. create a new rocm common package with commonly used dependencies that we do not expect external app developer to integrate with.

However, we believe the standalone package is the best option.

There are two packages, (1) as devel package with just the static library, headers and cmake and (2) a runtime package with the shared library.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
