### PR TITLE
Always enable build jobs for workflow_dispatch

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -637,19 +637,21 @@ def main(base_args, linux_families, windows_families):
     test_type = "smoke"
     test_type_reason = "default (smoke tests)"
 
-    # Scheduled and manually dispatched runs always build.
     if is_schedule:
+        # Always build and run full tests on scheduled runs.
         enable_build_jobs = True
         test_type = "full"
         test_type_reason = "scheduled run triggers full tests"
     elif is_workflow_dispatch:
+        # Always build and conditionally run full tests for workflow dispatch.
         enable_build_jobs = True
-        # If test labels were specified, run full tests for those.
         if linux_test_output or windows_test_output:
             combined_test_labels = list(set(linux_test_output + windows_test_output))
             test_type = "full"
             test_type_reason = f"test label(s) specified: {combined_test_labels}"
     else:
+        # Conditionally build and conditionally run full tests for other
+        # triggers (pull_request), based on modified paths and other inputs.
         modified_paths = get_git_modified_paths(base_ref)
         print("modified_paths (max 200):", modified_paths[:200])
         print(f"Checking modified files since this had a {github_event_name} trigger")


### PR DESCRIPTION
(Splitting off from https://github.com/ROCm/TheRock/pull/3856, per discussion at https://github.com/ROCm/TheRock/pull/3856#discussion_r2914748768)

## Motivation

When a user manually dispatches a workflow, they explicitly want it to run builds. Note that "build jobs" here means any CI, even with prebuilt artifacts. This option is normally only flipped to `False` when a PR/commit only modifies .md or similar files.

## Technical Details

The path-based filtering (`is_ci_run_required`) was incorrectly skipping builds when the diff against `HEAD^1` only contained docs or other skippable files:

```
modified_paths (max 200): ['docs/development/s3_buckets.md']
Checking modified files since this had a workflow_dispatch trigger
is_ci_run_required findings:
  related_to_ci: False
  contains_other_non_skippable_files: False
Only unrelated and/or skippable paths were modified, skipping build jobs
```

## Test Plan

Waiting to add more unit tests for this file. I want to do a near complete rewrite of it :/

Tested manually: https://github.com/ROCm/TheRock/actions/runs/22927519010 (prebuilt artifacts)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
