### PR TITLE
Add per-family PyTorch wheel builds to multi_arch_ci_linux

### DIFF
--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -94,6 +94,7 @@ jobs:
       use_prebuilt_artifacts: ${{ inputs.linux_use_prebuilt_artifacts == true && 'true' || 'false' }}
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
+      build_pytorch: ${{ matrix.variant.build_pytorch == true }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -32,6 +32,9 @@ on:
         type: string
       test_type:
         type: string
+      build_pytorch:
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -137,6 +140,43 @@ jobs:
       amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       multiarch_index: true
       package_version: ${{ inputs.rocm_package_version }}
+    permissions:
+      contents: read
+      id-token: write
+
+  # NOTE: Per-family PyTorch builds — each family gets its own wheel built
+  # against that family's ROCm package index slice.
+  # TODO(future): Consider adding a combined multi-arch pytorch build job
+  # that builds once against the full multi-arch index (amdgpu_families=all).
+  build_pytorch_wheels_per_family:
+    needs: [build_python_packages]
+    name: Build PyTorch | ${{ matrix.family_info.amdgpu_family }}
+    if: >-
+      ${{
+        !failure() &&
+        !cancelled() &&
+        (
+          inputs.use_prebuilt_artifacts == 'false' ||
+          inputs.use_prebuilt_artifacts == 'true'
+        ) &&
+        inputs.expect_failure == false &&
+        inputs.build_pytorch == true
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        family_info: ${{ fromJSON(inputs.matrix_per_family_json) }}
+        # TODO(TheRock#3288): Re-enable gfx950-dcgpu runners once we get more capacity
+        exclude:
+          - family_info:
+              amdgpu_family: gfx950-dcgpu
+    uses: ./.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+    with:
+      artifact_group: ${{ matrix.family_info.amdgpu_family }}
+      python_version: "3.12"
+      pytorch_git_ref: "release/2.10"
+      rocm_package_find_links_url: "${{ needs.build_python_packages.outputs.package_find_links_url }}/${{ matrix.family_info.amdgpu_family }}/index.html"
+      rocm_version: ${{ inputs.rocm_package_version }}
     permissions:
       contents: read
       id-token: write

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -207,6 +207,14 @@ def generate_multi_arch_matrix(
                         "sanity_check_only_for_family": platform_info.get(
                             "sanity_check_only_for_family", False
                         ),
+                        # Per-family pytorch flag. False for families with known
+                        # build failures. Used to gate per-family pytorch wheel
+                        # builds in multi_arch_ci_linux.yml.
+                        # NOTE: This is distinct from a future combined (multi-arch)
+                        # pytorch build that would build once against the full index.
+                        "build_pytorch": not platform_info.get(
+                            "expect_pytorch_failure", False
+                        ),
                     }
                 )
 

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -46,6 +46,7 @@ class ConfigureCITest(unittest.TestCase):
             self.assertTrue(
                 all("sanity_check_only_for_family" in f for f in family_info_list)
             )
+            self.assertTrue(all("build_pytorch" in f for f in family_info_list))
 
         if not allow_xfail:
             self.assertFalse(
@@ -581,7 +582,8 @@ class ConfigureCITest(unittest.TestCase):
             self.assertIn("test-runs-on", family_info)
 
     def test_multi_arch_sanity_check_field_propagation_logic(self):
-        """Unit test: Verify sanity_check_only_for_family field is correctly propagated.
+        """Unit test: Verify sanity_check_only_for_family and build_pytorch fields
+        are correctly propagated into matrix_per_family_json entries.
 
         Uses synthetic data to test the code logic in isolation.
         This test should never need updates unless the code behavior changes.
@@ -594,7 +596,7 @@ class ConfigureCITest(unittest.TestCase):
                     "family": "testfamily1-stable",
                     "test-runs-on": "linux-stable-runner",
                     "build_variants": ["release"],
-                    # Field not present - should default to False
+                    # Neither field present - sanity_check defaults False, build_pytorch defaults True
                 }
             },
             "testfamily2": {
@@ -603,6 +605,7 @@ class ConfigureCITest(unittest.TestCase):
                     "test-runs-on": "linux-experimental-runner",
                     "build_variants": ["release"],
                     "sanity_check_only_for_family": True,
+                    "expect_pytorch_failure": True,
                 }
             },
             "testfamily3": {
@@ -650,7 +653,7 @@ class ConfigureCITest(unittest.TestCase):
 
             family_dict = {f["amdgpu_family"]: f for f in family_info_list}
 
-            # Verify field is correctly propagated with proper defaults
+            # Verify sanity_check_only_for_family is correctly propagated
             self.assertIn("testfamily1-stable", family_dict)
             self.assertFalse(
                 family_dict["testfamily1-stable"]["sanity_check_only_for_family"],
@@ -671,10 +674,26 @@ class ConfigureCITest(unittest.TestCase):
                 "Explicit False should be preserved",
             )
 
-            # Verify all entries have the field (even if False)
+            # Verify build_pytorch is correctly propagated per family
+            self.assertTrue(
+                family_dict["testfamily1-stable"]["build_pytorch"],
+                "Missing expect_pytorch_failure should default build_pytorch to True",
+            )
+            self.assertFalse(
+                family_dict["testfamily2-experimental"]["build_pytorch"],
+                "expect_pytorch_failure=True should set build_pytorch=False",
+            )
+            self.assertTrue(
+                family_dict["testfamily3-explicit-false"]["build_pytorch"],
+                "Missing expect_pytorch_failure should default build_pytorch to True",
+            )
+
+            # Verify all entries have both fields as booleans
             for family_info in family_info_list:
                 self.assertIn("sanity_check_only_for_family", family_info)
                 self.assertIsInstance(family_info["sanity_check_only_for_family"], bool)
+                self.assertIn("build_pytorch", family_info)
+                self.assertIsInstance(family_info["build_pytorch"], bool)
 
     def test_multi_arch_production_sanity_check_configuration(self):
         """Integration test: Verify production matrix sanity_check configuration.
@@ -775,11 +794,19 @@ class ConfigureCITest(unittest.TestCase):
             family_dict[stable_arch_name]["sanity_check_only_for_family"],
             f"Stable family {stable_arch_name} should have sanity_check=False",
         )
+        self.assertTrue(
+            family_dict[stable_arch_name]["build_pytorch"],
+            f"Stable family {stable_arch_name} should have build_pytorch=True",
+        )
 
         self.assertIn(experimental_arch_name, family_dict)
         self.assertTrue(
             family_dict[experimental_arch_name]["sanity_check_only_for_family"],
             f"Experimental family {experimental_arch_name} should have sanity_check=True",
+        )
+        self.assertTrue(
+            family_dict[experimental_arch_name]["build_pytorch"],
+            f"Experimental family {experimental_arch_name} should have build_pytorch=True",
         )
 
     # TODO(#3433): Remove sandbox logic once ASAN tests are passing and environment is no longer required


### PR DESCRIPTION
Wire up PyTorch CI builds for the multi-arch pipeline, mirroring what
ci_linux.yml already does for single-arch variants.

Each GPU family gets its own wheel built against that family's ROCm
package index slice. The build_pytorch gate follows the same pattern
as ci_linux.yml: a variant-level boolean input threads through
multi_arch_ci.yml into multi_arch_ci_linux.yml and gates the job via
inputs.build_pytorch. All current multi-arch families support PyTorch,
so no per-family filtering is needed in the workflow.

Multi-arch CI run: https://github.com/ROCm/TheRock/actions/runs/22931640914