### PR TITLE
Add extra_cmake_options to workflow_call inputs for Windows release workflow

### DIFF
--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -27,6 +27,9 @@ on:
       prerelease_version:
         description: "(Optional) Number of the prerelease"
         type: string
+      extra_cmake_options:
+        description: "Extra options to pass to the CMake configure command"
+        type: string
       repository:
         description: "Repository to checkout. Otherwise, defaults to `github.repository`."
         type: string


### PR DESCRIPTION
The wrapper workflow passes extra_cmake_options when calling the reusable Windows release workflow, but this input is only defined under workflow_dispatch and not workflow_call. This causes the workflow validation to fail.

Failed run: [https://github.com/[ROCm/rockrel](https://github.com/ROCm/rockrel/actions/runs/22926931213)/actions/runs/22926931213](https://github.com/%5BROCm/rockrel%5D(https://github.com/ROCm/rockrel/actions/runs/22926931213)/actions/runs/22926931213)

This change adds extra_cmake_options to workflow_call.inputs so the reusable workflow accepts the same parameter when triggered by another workflow.