### PR TITLE
Fix rocprofiler dependency on MPI

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -667,14 +667,14 @@ disable_platforms = ["windows"]
 [artifacts.rocprofiler-compute]
 artifact_group = "profiler-core"
 type = "target-neutral"
-artifact_deps = ["rocprofiler-sdk"]
+artifact_deps = ["rocprofiler-sdk", "openmpi"]
 feature_group = "PROFILER"
 disable_platforms = ["windows"]
 
 [artifacts.rocprofiler-systems]
 artifact_group = "profiler-apps"
 type = "target-neutral"
-artifact_deps = ["amd-llvm", "core-hip", "rocprofiler-sdk", "core-amdsmi", "spdlog"]
+artifact_deps = ["amd-llvm", "core-hip", "rocprofiler-sdk", "core-amdsmi", "spdlog", "openmpi"]
 feature_name = "ROCPROFSYS"
 feature_group = "PROFILER"
 disable_platforms = ["windows"]

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -4,6 +4,11 @@
 if(THEROCK_ENABLE_ROCPROFV3)
   set(_rocprofiler_sdk_optional_deps)
 
+  set(_openmpi_optional_dep)
+  if(THEROCK_ENABLE_MPI)
+    set(_openmpi_optional_dep therock-openmpi)
+  endif()
+
   ##############################################################################
   # rocprof-trace-decoder-binary
   # The trace decoder is responsible for decoding advanced thread traces from
@@ -149,6 +154,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
       ${THEROCK_BUNDLED_ELFUTILS}
       ${THEROCK_BUNDLED_LIBDRM}
       ${THEROCK_BUNDLED_SQLITE3}
+      ${_openmpi_optional_dep}
     )
     therock_cmake_subproject_glob_c_sources(rocprofiler-compute
       SUBDIRS .
@@ -240,11 +246,6 @@ if(THEROCK_ENABLE_ROCPROFV3)
       string(REPLACE ";" "\\;" _ROCPROFSYS_GFX_TARGETS_ESCAPED "${THEROCK_TEST_AMDGPU_TARGETS}")
     endif()
 
-    set(_rocprofiler_systems_optional_deps)
-    if(THEROCK_ENABLE_MPI)
-      set(_rocprofiler_systems_optional_deps therock-openmpi)
-    endif()
-
     therock_cmake_subproject_declare(rocprofiler-systems
       USE_TEST_AMDGPU_TARGETS
       EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprofiler-systems"
@@ -278,7 +279,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
         rocprofiler-sdk
         ${THEROCK_BUNDLED_LIBDRM}
         ${THEROCK_BUNDLED_SQLITE3}
-        ${_rocprofiler_systems_optional_deps}
+        ${_openmpi_optional_dep}
     )
     therock_cmake_subproject_glob_c_sources(rocprofiler-systems
       SUBDIRS .


### PR DESCRIPTION
rocprofiler-sdk has an optional dependency on MPI which is guarded via `-DROCPROFSYS_USE_MPI=${THEROCK_ENABLE_MPI}`. rocprofiler-compute unconditionally calls `find_package(MPI)` and will fail if the bundled packages is enabled (`THEROCK_ENABLE_MPI` set to `ON`).

This patch adds the dependency to the build topology and adds the missing runtime dep to rocprofiler-compute.