### PR TITLE
Enable JAX wheel release workflow for prerelease builds

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -349,7 +349,6 @@ jobs:
         run: python -c "from urllib.parse import quote; print('tar_url=${{ needs.setup_metadata.outputs.cloudfront_base_url }}/tarball/' + quote('${{ env.FILE_NAME }}'))" >> ${GITHUB_OUTPUT}
 
       - name: Trigger release JAX wheels
-        # TODO: Enable JAX wheels for prereleases
         if: ${{ github.repository_owner == 'ROCm' }}
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:


### PR DESCRIPTION
This change removes the RELEASE_TYPE != 'prerelease' guard from the JAX wheel release steps so they also run for prerelease builds.

Previously, the steps responsible for URL-encoding the tarball URL and triggering the release_portable_linux_jax_wheels.yml workflow were skipped when RELEASE_TYPE=prerelease. With this change, the workflow will now trigger JAX wheel builds for prerelease releases as well.

This enables prerelease builds to produce JAX wheels consistently alongside other release artifacts.