### PR TITLE
Enable JAX wheel release workflow for prerelease builds (#3899)

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -345,14 +345,11 @@ jobs:
             }
 
       - name: URL-encode .tar URL
-        # TODO: Enable JAX wheels for prereleases
-        if: ${{ env.RELEASE_TYPE != 'prerelease' }}
         id: url-encode-tar
         run: python -c "from urllib.parse import quote; print('tar_url=${{ needs.setup_metadata.outputs.cloudfront_base_url }}/tarball/' + quote('${{ env.FILE_NAME }}'))" >> ${GITHUB_OUTPUT}
 
       - name: Trigger release JAX wheels
-        # TODO: Enable JAX wheels for prereleases
-        if: ${{ env.RELEASE_TYPE != 'prerelease' && github.repository_owner == 'ROCm' }}
+        if: ${{ github.repository_owner == 'ROCm' }}
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
         with:
           workflow: release_portable_linux_jax_wheels.yml


### PR DESCRIPTION
Cherry pick #3899 This change removes the RELEASE_TYPE != 'prerelease' guard from the JAX wheel release steps so they also run for prerelease builds.

Previously, the steps responsible for URL-encoding the tarball URL and triggering the release_portable_linux_jax_wheels.yml workflow were skipped when RELEASE_TYPE=prerelease. With this change, the workflow will now trigger JAX wheel builds for prerelease releases as well.

This enables prerelease builds to produce JAX wheels consistently alongside other release artifacts.