### PR TITLE
Add libcurl to the manylinux build dockerfile for rocm-bandwidth-test

### DIFF
--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -82,6 +82,7 @@ RUN yum install -y epel-release && \
     && yum install -y \
       texinfo \
       flex \
+      libcurl-devel \
     && yum clean all && \
     rm -rf /var/cache/yum
 


### PR DESCRIPTION
## Motivation

We are onboarding rocm-bandwidth-test (RBT) build as part of #3785, it fails during CMake configure in CI with:

```
CMake Error: Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR)
Call Stack:
cmake/build_utils.cmake:963 (find_package)
CMakeLists.txt:200 (add_bundled_libraries)
```
RBT's work_bench library has a hard dependency on libcurl. Since its not present in base image, cmake fails with above error.

## Technical Details

CURL is required by the following files in the RBT repo:

https://github.com/ROCm/rocm_bandwidth_test/blob/amd-mainline/cmake/build_utils.cmake#L963
-  cmake/build_utils.cmake:963 -- `find_package(CURL REQUIRED)`
- deps/work_bench/CMakeLists.txt:140 -- `target_link_libraries(... CURL::libcurl)`
- deps/work_bench/include/awb/http_ops.hpp:41 -- `#include <curl/curl.h>`
- deps/work_bench/src/http_ops.cpp:39 -- `#include <curl/curl.h>`
- cmake/sdk/CMakeLists.txt:80 -- `find_package(CURL REQUIRED)`

**Changes:**
- Install `libcurl-devel` in manylinux dockerfiles (`build_manylinux_x86_64.Dockerfile`)

## Test Plan

- Ensure Dockerfile is built and contains necessary packages
- Test the docker image in CI workflow to ensure RBT builds as expected

## Test Result

- Full CI validation pending for the docker image rebuild
