### PR TITLE
Link to https://therock-hud-dev.amd.com/ in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ TheRock includes:
 > See the [Releases Page](RELEASES.md) for instructions on how to install prebuilt
 > ROCm and PyTorch packages.
 
+## Project status
+
+See the unified project HUD at https://therock-hud-dev.amd.com/
+
 ### Nightly release status
 
 Packages and Python wheels:


### PR DESCRIPTION
## Motivation

We have https://therock-hud-dev.amd.com/ now, let's share the link :)

## Technical Details

I considered adding more details to what the HUD has in the text... open to suggestions for phrasing there.

* Release Nightly
* CI HUD
* CI/Nightly
* Bump PRs
* Issues
* ROCm Systems
* ROCm Libraries

I also considered where to put this link. We currently have status badges for "CI", "CI Nightly", "Multi-Arch CI" at the top, then feature discussion, then release status badges.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
