### PR TITLE
[CI Test] Build + test fusilli pulled from `rocm-libraries`

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -314,7 +314,7 @@ description = "Fusilli hipdnn provider"
 type = "generic"
 artifact_group_deps = ["hip-runtime", "iree-compiler"]
 # TODO: rocm-systems included for projects/hip/VERSION (see CMakeLists.txt)
-source_sets = ["iree-libs", "rocm-systems"]
+source_sets = ["iree-libs", "rocm-libraries", "rocm-systems"]
 
 [artifact_groups.media-libs]
 description = "Media Libraries"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,7 @@ option(THEROCK_ENABLE_MEDIA_LIBS "Enable building of Media libraries" "${THEROCK
 option(THEROCK_ENABLE_HOST_MATH "Build all bundled host math libraries by default" OFF)
 option(THEROCK_RESET_FEATURES "One-shot flag which forces all feature flags to their default state for this configuration run" OFF)
 # TODO(iree-org/fusilli/issues/57): Enable fusilli build once multi-arch support lands.
-option(THEROCK_ENABLE_IREE_LIBS "Enable building of IREE libraries" OFF)
+option(THEROCK_ENABLE_IREE_LIBS "Enable building of IREE libraries" "${THEROCK_ENABLE_ALL}")
 
 ################################################################################
 # Artifact-based features are auto-generated from BUILD_TOPOLOGY.toml

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -483,7 +483,7 @@ def main(argv):
     )
     parser.add_argument(
         "--include-iree-libs",
-        default=False,
+        default=True,
         action=argparse.BooleanOptionalAction,
         help="Include IREE and related libraries",
     )

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -366,14 +366,14 @@ test_matrix = {
     },
     # TODO(iree-org/fusilli/issues/57): Enable fusilli tests once build is
     # enabled by default.
-    # "fusilliprovider": {
-    #     "job_name": "fusilliprovider",
-    #     "fetch_artifact_args": "--hipdnn --fusilliprovider --iree-compiler --tests",
-    #     "timeout_minutes": 15,
-    #     "test_script": f"python {_get_script_path('test_fusilliprovider.py')}",
-    #     "platform": ["linux"],
-    #     "total_shards": 1,
-    # },
+    "fusilliprovider": {
+        "job_name": "fusilliprovider",
+        "fetch_artifact_args": "--hipdnn --fusilliprovider --iree-compiler --tests",
+        "timeout_minutes": 15,
+        "test_script": f"python {_get_script_path('test_fusilliprovider.py')}",
+        "platform": ["linux"],
+        "total_shards": 1,
+    },
     # hipBLASLt provider tests
     "hipblasltprovider": {
         "job_name": "hipblasltprovider",

--- a/iree-libs/CMakeLists.txt
+++ b/iree-libs/CMakeLists.txt
@@ -88,7 +88,7 @@ if(THEROCK_ENABLE_FUSILLIPROVIDER)
   ##############################################################################
   therock_cmake_subproject_declare(fusilliprovider
     USE_DIST_AMDGPU_TARGETS
-    EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/fusilli/plugins/hipdnn-plugin"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/dnn-providers/fusilli-provider"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/fusilliprovider"
     BACKGROUND_BUILD
     CMAKE_ARGS


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This is a test branch for https://github.com/ROCm/TheRock/pull/3791 that includes temporary changes needed to build fusilli provider from it's new location in `rocm-libraries` (merged in https://github.com/ROCm/TheRock/pull/3791).

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

The PR rolls includes the changes from https://github.com/ROCm/TheRock/pull/3791, bumps `rocm-libraries` to the point where (merged) https://github.com/ROCm/rocm-libraries/pull/5149 will be included, enables tests that are otherwise default disabled until such time as fusilli+ IREE build by default.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
