### PR TITLE
Add doc component to rocjpeg and rocdecode packages

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -2105,7 +2105,8 @@
           {
             "Name": "rocdecode",
             "Components": [
-              "lib"
+              "lib",
+              "doc"
             ]
           }
         ]
@@ -2179,7 +2180,8 @@
           {
             "Name": "rocjpeg",
             "Components": [
-              "lib"
+              "lib",
+              "doc"
             ]
           }
         ]


### PR DESCRIPTION
"doc" component is missing in rocjpeg and rocdecode packages. 
Added the same to package.json