### PR TITLE
Include share binaries with rocrtst test artifacts

### DIFF
--- a/core/artifact-core-rocrtst.toml
+++ b/core/artifact-core-rocrtst.toml
@@ -5,11 +5,9 @@
 [components.run."core/rocrtst/stage"]
 exclude = [
   "bin/**",
+  "share/rocrtst/**",
 ]
 [components.test."core/rocrtst/stage"]
-include = [
-    "share/rocrtst/**",
-]
 exclude = [
     "lib/rocrtst/lib/libhwloc.so*",
     "lib/rocrtst/lib/LICENSE",


### PR DESCRIPTION
## Motivation

It looks like the kernel files moved to the share directory as a part of https://github.com/ROCm/rocm-systems/pull/3744 are missing from the rocrtst test artifact causing CI to fail. 

As mentioned by Scott, https://github.com/ROCm/TheRock/pull/3830 removed duplicate files in artifacts. This likely is why share/rocrtst was missing from the rocrtst test artifact.

## Technical Details

including the share/rocrtst directory in the rocrtst test artifact in core/artifact-core-rocrtst.toml (by excluding it from the run artifact)

## Test Plan
CI

## Test Result
rocrtst is passing here: https://github.com/ROCm/TheRock/actions/runs/23011126583/job/66859350156?pr=3920

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
