### PR TITLE
[ml-libs] Enable composable_kernel build for gfx110x

### DIFF
--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 # limit use of composable kernel to the GPU families it is valid for
 if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
-  set(_ck_supported_gfx_targets gfx908 gfx90a gfx942 gfx950 gfx1150 gfx1151 gfx1152 gfx1153 gfx1200 gfx1201)
+  set(_ck_supported_gfx_targets gfx908 gfx90a gfx942 gfx950 gfx1100 gfx1101 gfx1102 gfx1103 gfx1150 gfx1151 gfx1152 gfx1153 gfx1200 gfx1201)
   foreach(_gfx_target ${THEROCK_AMDGPU_TARGETS})
     if(NOT ${_gfx_target} IN_LIST _ck_supported_gfx_targets)
       message(WARNING


### PR DESCRIPTION
## Motivation

Improve performance of Wan2.x models on gfx110x

Refs: ROCM-5213, ROCM-5215
Fixes: https://github.com/ROCm/TheRock/issues/3499

## Technical Details

Enabled ml-libs cmake file

## Test Plan

* CK compiled stand alone and run tests
* Run shapes extracted from Wan2.1 model
Device gfx1100

## Test Result

* CK test are passed
* Wan2.1 shows significant boost
<img width="1169" height="584" alt="image" src="https://github.com/user-attachments/assets/a0144be7-841a-4a33-a2ae-aa98189f9e4b" />

\* values indicate the best (lowest) latency for each shape.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
