### PR TITLE
[profiler] [DEB package] Prevent `libunwind.so.99` from having non page aligned address/offset

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1231,8 +1231,9 @@
       }
     ],
 
+    "Gfxarch": "False",
     "Disable_DWZ": "True",
-    "Gfxarch": "False"
+    "Disable_DEB_STRIP": "True"
   },
   {
     "Package": "amdrocm-hipify",


### PR DESCRIPTION
## Motivation

AIPROSYST-337

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

When using the `deb` tarballs, I noticed that running `ldd <dir>/rocprof-sys-instrument` would fail with:
```
ldd build/packages/extracted/opt/rocm/core-7.12/bin/rocprof-sys-instrument
build/packages/extracted/opt/rocm/core-7.12/bin/rocprof-sys-instrument: error while loading shared libraries: libunwind.so.99: ELF load command address/offset not page-aligned
```

Upon investigation, a `LOAD` segment isn't congruent with the virtual address mod page size.

The cause is `llvm-strip` being ran on the library. Specifically, I've only seen this error happen with `llvm-strip` version `18.1.3`, which is the default on my Ubuntu system. I've tested it with v20 and v22, and I was unable to reproduce the error.

The error is not seen with `rpm`. When comparing the `rpm` `libunwind` with an UNSTRIPPED debian `libunwind`, they are identical. So it is not being stripped on `rpm`.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Specify `"Disable_DEB_STRIP": "True"` for `amdrocm-profiler`

Specifically, having this prevents `llvm-strip` from being ran (see `TheRock/build_tools/packaging/linux/template/debian_rules.j2`):
```
{% if disable_dh_strip %}
override_dh_strip:
	:
{% else %}
override_dh_strip:

	mkdir -p debian/.llvm-tools
	# Unprefixed names
	ln -sf "$(shell command -v llvm-strip)"   debian/.llvm-tools/strip
	ln -sf "$(shell command -v llvm-objcopy)" debian/.llvm-tools/objcopy
	PATH="$(CURDIR)/debian/.llvm-tools:$(PATH)" dh_strip -X.a
{% endif %}
```

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Built `rocprofiler-systems` locally.

**Part 1**: Verifying failure:
Ran the following without the proposed fix
```
python3 build_tools/packaging/linux/build_package.py \
  --artifacts-dir build/artifacts \
  --dest-dir build/packages \
  --target gfx94X-all \
  --pkg-type deb \
  --rocm-version 7.12.0 \
  --pkg-names amdrocm-profiler
  ```
I then extracted the resulting deb file.
Observed failure described above when using:
```
ldd build/packages/extracted/opt/rocm/core-7.12/bin/rocprof-sys-instrument
```

**Part 2**: With fix
Ran the same command as in **part 1**, running `ldd build/packages/extracted/opt/rocm/core-7.12/bin/rocprof-sys-instrument` did not produce a failure. LDD worked.

## Test Result

<!-- Briefly summarize test outcomes. -->

No more observed failure due to `libunwind.so.99`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
