### PR TITLE
ROADMAP.md: gfx103X builds passing; add gfx900/gfx90c rows

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,6 +47,7 @@ See also the [ROCm Device Support Wishlist GitHub Discussion](https://github.com
 | **RDNA3**    | **gfx1100** | ✅            | ✅            |               |
 | RDNA2        | gfx1036     | ✅            |               |               |
 | RDNA2        | gfx1035     | ✅            |               |               |
+| RDNA2        | gfx1034     | ✅            |               |               |
 | RDNA2        | gfx1033     | ✅            |               |               |
 | RDNA2        | gfx1032     | ✅            |               |               |
 | RDNA2        | gfx1031     | ✅            |               |               |
@@ -78,6 +79,7 @@ Check [windows_support.md](docs/development/windows_support.md) on current statu
 | **RDNA3**    | **gfx1100** | ✅            |               |               |
 | RDNA2        | gfx1036     | ✅            |               |               |
 | RDNA2        | gfx1035     | ✅            |               |               |
+| RDNA2        | gfx1034     | ✅            |               |               |
 | RDNA2        | gfx1033     | ✅            |               |               |
 | RDNA2        | gfx1032     | ✅            |               |               |
 | RDNA2        | gfx1031     | ✅            |               |               |


### PR DESCRIPTION
## Motivation

Update `ROADMAP.md` to reflect recently added support.

## Technical Details

`gfx103X-all` builds passing for Linux/Windows: https://github.com/ROCm/TheRock/pull/3763 (Pytorch failing until https://github.com/ROCm/rocm-libraries/pull/5141 lands)

`gfx900` builds passing: https://github.com/ROCm/TheRock/pull/3564

## Test Plan

`gfx90c` builds to be tested (https://github.com/ROCm/TheRock/issues/3818)

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
