### PR TITLE
Revert "Plumb prebuilt_stages input through multi_arch_ci workflows"

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -36,16 +36,16 @@ on:
         type: string
       test_labels:
         type: string
+      artifact_run_id:
+        type: string
       expect_failure:
         type: boolean
+      use_prebuilt_artifacts:
+        type: string
       rocm_package_version:
         type: string
       test_type:
         type: string
-      prebuilt_stages:
-        type: string
-        default: ""
-        description: "Comma-separated build stages to skip (artifacts already copied by the orchestrator)"
 
 permissions:
   contents: read
@@ -56,7 +56,6 @@ jobs:
   # STAGE: foundation (generic)
   # ==========================================================================
   foundation:
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'foundation') }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
@@ -74,7 +73,6 @@ jobs:
   # ==========================================================================
   compiler-runtime:
     needs: foundation
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'compiler-runtime') }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
@@ -92,7 +90,6 @@ jobs:
   # ==========================================================================
   math-libs:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'math-libs') }}
     strategy:
       fail-fast: false
       matrix:
@@ -115,7 +112,6 @@ jobs:
   # ==========================================================================
   comm-libs:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'comm-libs') }}
     strategy:
       fail-fast: false
       matrix:
@@ -138,7 +134,6 @@ jobs:
   # ==========================================================================
   debug-tools:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'debug-tools') }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
@@ -156,7 +151,6 @@ jobs:
   # ==========================================================================
   dctools-core:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'dctools-core') }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
@@ -174,7 +168,6 @@ jobs:
   # ==========================================================================
   profiler-apps:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'profiler-apps') }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
@@ -192,7 +185,6 @@ jobs:
   # ==========================================================================
   iree-compiler:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'iree-compiler') }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
@@ -210,7 +202,6 @@ jobs:
   # ==========================================================================
   fusilli-libs:
     needs: [compiler-runtime, math-libs, iree-compiler]
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'fusilli-libs') }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
@@ -228,7 +219,6 @@ jobs:
   # ==========================================================================
   media-libs:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'media-libs') }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:

--- a/.github/workflows/multi_arch_build_windows.yml
+++ b/.github/workflows/multi_arch_build_windows.yml
@@ -34,10 +34,8 @@ on:
         type: string
       expect_failure:
         type: boolean
-      prebuilt_stages:
+      use_prebuilt_artifacts:
         type: string
-        default: ""
-        description: "Comma-separated build stages to skip (artifacts already copied by the orchestrator)"
       rocm_package_version:
         type: string
       test_type:
@@ -51,7 +49,6 @@ jobs:
   # STAGE: foundation (generic)
   # ==========================================================================
   foundation:
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'foundation') }}
     uses: ./.github/workflows/multi_arch_build_windows_artifacts.yml
     secrets: inherit
     with:
@@ -70,7 +67,6 @@ jobs:
   # ==========================================================================
   compiler-runtime:
     needs: foundation
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'compiler-runtime') }}
     uses: ./.github/workflows/multi_arch_build_windows_artifacts.yml
     secrets: inherit
     with:
@@ -89,7 +85,6 @@ jobs:
   # ==========================================================================
   math-libs:
     needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'math-libs') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -25,6 +25,9 @@ on:
         type: string
         description: "If enabled, reduce test set on Linux to the list of labels prefixed with 'test:'. ex: test:rocprim, test:hipcub"
         default: ""
+      linux_use_prebuilt_artifacts:
+        type: boolean
+        description: "If enabled, the CI will pull Linux artifacts using artifact_run_id and only run tests"
       windows_amdgpu_families:
         type: string
         description: "Insert comma-separated list of Windows GPU families to build and test. ex: gfx94X, gfx120X"
@@ -33,14 +36,13 @@ on:
         type: string
         description: "If enabled, reduce test set on Windows to the list of labels prefixed with 'test:' ex: test:rocprim, test:hipcub"
         default: ""
-      prebuilt_stages:
+      windows_use_prebuilt_artifacts:
+        type: boolean
+        description: "If enabled, the CI will pull Windows artifacts using artifact_run_id and only run tests"
+      artifact_run_id:
         type: string
+        description: "If provided, the tests will run on this artifact ID"
         default: ""
-        description: "Comma-separated build stages to skip; artifacts are copied from baseline_run_id instead"
-      baseline_run_id:
-        type: string
-        default: ""
-        description: "Workflow run ID to copy prebuilt stage artifacts from; required when prebuilt_stages is set"
   # pull_request:
   #   types:
   #     - labeled
@@ -64,7 +66,6 @@ jobs:
     with:
       build_variant: "release"
       multi_arch: true
-      prebuilt_stages: ${{ inputs.prebuilt_stages }}
 
   linux_build_and_test:
     name: Linux::${{ matrix.variant.build_variant_label }}
@@ -88,9 +89,9 @@ jobs:
       build_variant_cmake_preset: ${{ matrix.variant.build_variant_cmake_preset }}
       build_variant_suffix: ${{ matrix.variant.build_variant_suffix }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
+      artifact_run_id: ${{ inputs.artifact_run_id }}
       expect_failure: ${{ matrix.variant.expect_failure == true }}
-      prebuilt_stages: ${{ inputs.prebuilt_stages }}
-      baseline_run_id: ${{ inputs.baseline_run_id }}
+      use_prebuilt_artifacts: ${{ inputs.linux_use_prebuilt_artifacts == true && 'true' || 'false' }}
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
       build_pytorch: ${{ matrix.variant.build_pytorch == true }}
@@ -120,9 +121,9 @@ jobs:
       build_variant_cmake_preset: ${{ matrix.variant.build_variant_cmake_preset }}
       build_variant_suffix: ${{ matrix.variant.build_variant_suffix }}
       test_labels: ${{ needs.setup.outputs.windows_test_labels }}
+      artifact_run_id: ${{ inputs.artifact_run_id }}
       expect_failure: ${{ matrix.variant.expect_failure == true }}
-      prebuilt_stages: ${{ inputs.prebuilt_stages }}
-      baseline_run_id: ${{ inputs.baseline_run_id }}
+      use_prebuilt_artifacts: ${{ inputs.windows_use_prebuilt_artifacts == true && 'true' || 'false' }}
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
     permissions:

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -22,16 +22,12 @@ on:
         type: string
       test_labels:
         type: string
+      artifact_run_id:
+        type: string
       expect_failure:
         type: boolean
-      prebuilt_stages:
+      use_prebuilt_artifacts:
         type: string
-        default: ""
-        description: "Comma-separated build stages to skip; artifacts are copied from baseline_run_id instead"
-      baseline_run_id:
-        type: string
-        default: ""
-        description: "Workflow run ID to copy prebuilt stage artifacts from"
       rocm_package_version:
         type: string
       test_type:
@@ -44,50 +40,9 @@ permissions:
   contents: read
 
 jobs:
-  copy_prebuilt_stages:
-    name: Copy Prebuilt Stages
-    if: ${{ inputs.prebuilt_stages != '' && inputs.baseline_run_id != '' }}
-    runs-on: azure-linux-scale-rocm
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checking out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.12"
-
-      - name: Install artifact manager dependencies
-        run: pip install boto3
-
-      # Assume the therock-ci OIDC role in ROCm/TheRock. Other repos
-      # fall back to runner base credentials (therock-ci-artifacts-external).
-      #
-      # This is just needed for write access to the current run's bucket,
-      # all possible source run buckets have public read access.
-      - name: Configure AWS Credentials
-        if: ${{ github.repository == 'ROCm/TheRock' && !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Copy prebuilt stage artifacts
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          python build_tools/artifact_manager.py copy \
-            --source-run-id=${{ inputs.baseline_run_id }} \
-            --stage="${{ inputs.prebuilt_stages }}" \
-            --amdgpu-families="${{ inputs.dist_amdgpu_families }}"
-
   build_multi_arch_stages:
     name: Build Multi-Arch Stages
-    needs: copy_prebuilt_stages
-    if: ${{ !cancelled() && !failure() }}
+    if: ${{ inputs.use_prebuilt_artifacts == 'false' }}
     uses: ./.github/workflows/multi_arch_build_portable_linux.yml
     secrets: inherit
     with:
@@ -98,7 +53,7 @@ jobs:
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
       build_variant_suffix: ${{ inputs.build_variant_suffix }}
       expect_failure: ${{ inputs.expect_failure }}
-      prebuilt_stages: ${{ inputs.prebuilt_stages }}
+      use_prebuilt_artifacts: ${{ inputs.use_prebuilt_artifacts }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       test_type: ${{ inputs.test_type }}
     permissions:
@@ -108,18 +63,39 @@ jobs:
   validate_artifact_structure:
     needs: [build_multi_arch_stages]
     name: Validate Artifact Structure
-    # If we are expecting a build failure, do not run tests to save machine capacity.
-    if: ${{ !failure() && !cancelled() && inputs.expect_failure == false }}
+    if: >-
+      ${{
+        !failure() &&
+        !cancelled() &&
+        (
+          inputs.use_prebuilt_artifacts == 'false' ||
+          inputs.use_prebuilt_artifacts == 'true'
+        ) &&
+        inputs.expect_failure == false
+      }}
     uses: ./.github/workflows/test_artifacts_structure.yml
     with:
       artifact_group: ${{ inputs.artifact_group }}
+      artifact_run_id: ${{ inputs.artifact_run_id }}
       platform: linux
 
   test_artifacts_per_family:
-    needs: [copy_prebuilt_stages, build_multi_arch_stages]
+    needs: [build_multi_arch_stages]
     name: Test ${{ matrix.family_info.amdgpu_family }}
+    # If the dependent job failed/cancelled, this job will not be run
+    # The use_prebuilt_artifacts "or" statement ensures that tests will run if
+    # previous build step is run or skipped.
     # If we are expecting a build failure, do not run tests to save machine capacity.
-    if: ${{ !failure() && !cancelled() && inputs.expect_failure == false }}
+    if: >-
+      ${{
+        !failure() &&
+        !cancelled() &&
+        (
+          inputs.use_prebuilt_artifacts == 'false' ||
+          inputs.use_prebuilt_artifacts == 'true'
+        ) &&
+        inputs.expect_failure == false
+      }}
     strategy:
       fail-fast: false
       matrix:
@@ -128,6 +104,7 @@ jobs:
         exclude:
           - family_info:
               amdgpu_family: gfx950-dcgpu
+
     uses: ./.github/workflows/test_artifacts.yml
     with:
       # Use architecture-specific artifact group for fetching per-arch artifacts
@@ -135,6 +112,7 @@ jobs:
       amdgpu_families: ${{ matrix.family_info.amdgpu_family }}
       amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
       test_runs_on: ${{ matrix.family_info.test-runs-on }}
+      artifact_run_id: ${{ inputs.artifact_run_id }}
       test_type: ${{ inputs.test_type }}
       test_labels: ${{ inputs.test_labels }}
       sanity_check_only_for_family: ${{ matrix.family_info.sanity_check_only_for_family }}
@@ -142,9 +120,22 @@ jobs:
   build_python_packages:
     needs: [build_multi_arch_stages]
     name: Build Python Packages
-    if: ${{ !failure() && !cancelled() && inputs.expect_failure == false }}
+    # If the dependent job failed/cancelled, this job will not be run
+    # The use_prebuilt_artifacts "or" statement ensures that tests will run if
+    # previous build step is run or skipped.
+    if: >-
+      ${{
+        !failure() &&
+        !cancelled() &&
+        (
+          inputs.use_prebuilt_artifacts == 'false' ||
+          inputs.use_prebuilt_artifacts == 'true'
+        ) &&
+        inputs.expect_failure == false
+      }}
     uses: ./.github/workflows/build_portable_linux_python_packages.yml
     with:
+      artifact_run_id: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
       artifact_group: ${{ inputs.artifact_group }}
       amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       multiarch_index: true
@@ -193,7 +184,19 @@ jobs:
   test_python_packages_per_family:
     needs: [build_python_packages]
     name: Test Python ${{ matrix.family_info.amdgpu_family }}
-    if: ${{ !failure() && !cancelled() && inputs.expect_failure == false }}
+    # If the dependent job failed/cancelled, this job will not be run
+    # The use_prebuilt_artifacts "or" statement ensures that tests will run if
+    # previous build step is run or skipped.
+    if: >-
+      ${{
+        !failure() &&
+        !cancelled() &&
+        (
+          inputs.use_prebuilt_artifacts == 'false' ||
+          inputs.use_prebuilt_artifacts == 'true'
+        ) &&
+        inputs.expect_failure == false
+      }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -22,16 +22,12 @@ on:
         type: string
       test_labels:
         type: string
+      artifact_run_id:
+        type: string
       expect_failure:
         type: boolean
-      prebuilt_stages:
+      use_prebuilt_artifacts:
         type: string
-        default: ""
-        description: "Comma-separated build stages to skip; artifacts are copied from baseline_run_id instead"
-      baseline_run_id:
-        type: string
-        default: ""
-        description: "Workflow run ID to copy prebuilt stage artifacts from"
       rocm_package_version:
         type: string
       test_type:
@@ -41,55 +37,9 @@ permissions:
   contents: read
 
 jobs:
-  copy_prebuilt_stages:
-    name: Copy Prebuilt Stages
-    if: ${{ inputs.prebuilt_stages != '' && inputs.baseline_run_id != '' }}
-    # TODO: Consider running on a Linux runner with --platform=windows to
-    #   avoid Windows runner setup overhead (setup-python ~51s).
-    runs-on: azure-windows-scale-rocm
-    defaults:
-      run:
-        shell: bash
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checking out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.12"
-
-      - name: Install artifact manager dependencies
-        run: pip install boto3
-
-      # Assume the therock-ci OIDC role in ROCm/TheRock. Other repos
-      # fall back to runner base credentials (therock-ci-artifacts-external).
-      #
-      # This is just needed for write access to the current run's bucket,
-      # all possible source run buckets have public read access.
-      - name: Configure AWS Credentials
-        if: ${{ github.repository == 'ROCm/TheRock' && !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-ci
-
-      - name: Copy prebuilt stage artifacts
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          python build_tools/artifact_manager.py copy \
-            --source-run-id=${{ inputs.baseline_run_id }} \
-            --stage="${{ inputs.prebuilt_stages }}" \
-            --amdgpu-families="${{ inputs.dist_amdgpu_families }}"
-
   build_multi_arch_stages:
     name: Build Multi-Arch Stages
-    needs: copy_prebuilt_stages
-    if: ${{ !cancelled() && !failure() }}
+    if: ${{ inputs.use_prebuilt_artifacts == 'false' }}
     uses: ./.github/workflows/multi_arch_build_windows.yml
     secrets: inherit
     with:
@@ -100,7 +50,7 @@ jobs:
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
       build_variant_suffix: ${{ inputs.build_variant_suffix }}
       expect_failure: ${{ inputs.expect_failure }}
-      prebuilt_stages: ${{ inputs.prebuilt_stages }}
+      use_prebuilt_artifacts: ${{ inputs.use_prebuilt_artifacts }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       test_type: ${{ inputs.test_type }}
     permissions:
@@ -110,18 +60,39 @@ jobs:
   validate_artifact_structure:
     needs: [build_multi_arch_stages]
     name: Validate Artifact Structure
-    # If we are expecting a build failure, do not run tests to save machine capacity.
-    if: ${{ !failure() && !cancelled() && inputs.expect_failure == false }}
+    if: >-
+      ${{
+        !failure() &&
+        !cancelled() &&
+        (
+          inputs.use_prebuilt_artifacts == 'false' ||
+          inputs.use_prebuilt_artifacts == 'true'
+        ) &&
+        inputs.expect_failure == false
+      }}
     uses: ./.github/workflows/test_artifacts_structure.yml
     with:
       artifact_group: ${{ inputs.artifact_group }}
+      artifact_run_id: ${{ inputs.artifact_run_id }}
       platform: windows
 
   test_artifacts_per_family:
-    needs: [copy_prebuilt_stages, build_multi_arch_stages]
+    needs: [build_multi_arch_stages]
     name: Test ${{ matrix.family_info.amdgpu_family }}
-    # If we are expecting a build failure, do not run tests to save machine capacity.
-    if: ${{ !failure() && !cancelled() && inputs.expect_failure == false }}
+    # If the dependent job failed/cancelled, this job will not be run
+    # The use_prebuilt_artifacts "or" statement ensures that tests will run if
+    # previous build step is run or skipped.
+    # If we are expecting a build failure, do not run tests to save machine capacity
+    if: >-
+      ${{
+        !failure() &&
+        !cancelled() &&
+        (
+          inputs.use_prebuilt_artifacts == 'false' ||
+          inputs.use_prebuilt_artifacts == 'true'
+        ) &&
+        inputs.expect_failure == false
+      }}
     strategy:
       fail-fast: false
       matrix:
@@ -132,6 +103,7 @@ jobs:
       artifact_group: ${{ matrix.family_info.amdgpu_family }}
       amdgpu_families: ${{ matrix.family_info.amdgpu_family }}
       test_runs_on: ${{ matrix.family_info.test-runs-on }}
+      artifact_run_id: ${{ inputs.artifact_run_id }}
       test_type: ${{ inputs.test_type }}
       test_labels: ${{ inputs.test_labels }}
       sanity_check_only_for_family: ${{ matrix.family_info.sanity_check_only_for_family }}

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -13,10 +13,6 @@ on:
         type: boolean
         default: false
         description: "If true, group all families into one entry per build_variant instead of expanding cross-product"
-      prebuilt_stages:
-        type: string
-        default: ""
-        description: "Comma-separated build stages to skip; passed through for future automatic stage selection"
     outputs:
       enable_build_jobs:
         description: Whether to enable build jobs.

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -1132,7 +1132,7 @@ def main(argv: Optional[List[str]] = None):
     info_parser.add_argument(
         "--amdgpu-families",
         type=str,
-        help="Semicolon-separated GPU families to show file lists for",
+        help="Comma-separated GPU families to show file lists for",
     )
     info_parser.set_defaults(func=do_info)
 

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -600,56 +600,6 @@ class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
             f"Should fetch target archive, got: {fetched_keys}",
         )
 
-    def test_fetch_with_semicolon_separated_families(self):
-        """Test that --amdgpu-families accepts semicolon-separated values."""
-        import artifact_manager
-
-        # Stage artifacts for two families plus generic
-        self._create_staged_artifact("test-artifact", "lib", "generic")
-        self._create_staged_artifact("test-artifact", "lib", "gfx94X-dcgpu")
-        self._create_staged_artifact("test-artifact", "lib", "gfx110X-all")
-
-        extract_calls = []
-
-        def mock_extract(request):
-            extract_calls.append(request)
-            return request.output_dir
-
-        with mock.patch("artifact_manager.extract_artifact", mock_extract):
-            argv = [
-                "fetch",
-                "--stage",
-                "downstream-stage",
-                "--output-dir",
-                str(self.output_dir),
-                "--topology",
-                str(self.topology_path),
-                "--local-staging-dir",
-                str(self.staging_dir),
-                "--platform",
-                TEST_PLATFORM,
-                "--run-id",
-                "local",
-                "--amdgpu-families",
-                "gfx94X-dcgpu;gfx110X-all",
-            ]
-
-            artifact_manager.main(argv)
-
-        fetched_keys = [c.archive_path.name for c in extract_calls]
-        self.assertTrue(
-            any("generic" in k for k in fetched_keys),
-            f"Should fetch generic, got: {fetched_keys}",
-        )
-        self.assertTrue(
-            any("gfx94X-dcgpu" in k for k in fetched_keys),
-            f"Should fetch gfx94X-dcgpu, got: {fetched_keys}",
-        )
-        self.assertTrue(
-            any("gfx110X-all" in k for k in fetched_keys),
-            f"Should fetch gfx110X-all, got: {fetched_keys}",
-        )
-
 
 class TestFetchFlatten(ArtifactManagerTestBase):
     """Tests that fetch command correctly flattens artifacts."""

--- a/docs/development/ci_behavior_manipulation.md
+++ b/docs/development/ci_behavior_manipulation.md
@@ -2,22 +2,11 @@
 
 TheRock CI is controlled by [`configure_ci.py`](../../build_tools/github_actions/configure_ci.py), where it controls push, pull request, workflow dispatch and schedule CI behavior.
 
-## CI (non-multi-arch)
-
-<!-- TODO: restructure this once multi-arch CI is further along
-
-* Selection of which GPUs to build for on each platform
-* Selection of which GPUs to test for on each platform
-* Selection of which tests to run
-* Variants (ASan, etc.)
-* Cache behavior, opt-in builds/tests like PyTorch
--->
-
-### Push behavior
+## Push behavior
 
 For `push`, TheRock CI only runs builds and tests when pushed to the `main` branch. From [`amdgpu_family_matrix.py`](../../build_tools/github_actions/amdgpu_family_matrix.py), TheRock CI collects the AMD GPU families from `amdgpu_family_info_matrix_presubmit` and `amdgpu_family_info_matrix_postsubmit` dictionaries, then runs builds and tests.
 
-### Pull request behavior
+## Pull request behavior
 
 For `pull_request`, TheRock CI collects the `amdgpu_family_info_matrix_presubmit` dictionary from [`amdgpu_family_matrix.py`](../../build_tools/github_actions/amdgpu_family_matrix.py) and runs build/tests.
 
@@ -29,64 +18,12 @@ However, if additional options are wanted, you can add a label to manipulate the
 - `test:...`: The full test will run only for the specified label and other labeled projects (ex: `test:rocthrust`, `test:hipblaslt`)
 - `test_runner:...`: The CI will run tests on only custom test machines (ex: `test_runner:oem`)
 
-### Workflow dispatch behavior
+## Workflow dispatch behavior
 
 For `workflow_dispatch`, you are able to trigger CI in [GitHub's ci.yml workflow page](https://github.com/ROCm/TheRock/actions/workflows/ci.yml). To trigger a workflow dispatch, click "Run workflow" and fill in the fields accordingly:
 
 <img src="./assets/ci_workflow_dispatch.png" />
 
-### Schedule behavior
+## Schedule behavior
 
 For `schedule` runs, the `CI Nightly` runs everyday at 2AM UTC. This collects all families from [`amdgpu_family_matrix.py`](../../build_tools/github_actions/amdgpu_family_matrix.py), running all builds and tests.
-
-## Prebuilt stages (Multi-Arch CI)
-
-> [!NOTE]
-> This feature is under active development and will evolve as
-> automatic stage selection and baseline run lookup are added.
->
-> See https://github.com/ROCm/TheRock/issues/3399 for details.
-
-The [Multi-Arch CI](https://github.com/ROCm/TheRock/actions/workflows/multi_arch_ci.yml)
-workflow supports skipping individual build stages by copying their artifacts
-from a previous workflow run. This will be used in a few scenarios. For example:
-
-- Changes to the rocm-libraries project will use prebuilt artifacts for
-  `foundation,compiler-runtime`
-- Changes to just test scripts or python packages will use prebuilt artifacts for
-  all stages
-
-Two workflow inputs control this:
-
-- **`prebuilt_stages`**: Comma-separated list of stage names to skip
-  (e.g. `foundation,compiler-runtime`). Artifacts for these stages are copied
-  from the baseline run instead of being built. Applied to both Linux and
-  Windows; stages not present on a platform are ignored.
-- **`baseline_run_id`**: The workflow run ID to copy prebuilt artifacts from.
-  Required when `prebuilt_stages` is set. Find this in the URL of a previous
-  successful Multi-Arch CI run
-  (e.g. https://github.com/ROCm/TheRock/actions/runs/22777631940).
-
-> [!IMPORTANT]
-> The baseline run must have built the GPU families you want for the current
-> run, otherwise the copy will find no matching artifacts.
-
-### Stage names
-
-Stage names come from [`BUILD_TOPOLOGY.toml`](/BUILD_TOPOLOGY.toml).
-
-Currently, stage names must be explicitly specified. In the future these may
-be computed based on dependencies and a special "all" option may be available.
-
-<!-- TODO: The workflows currently use `contains(prebuilt_stages, 'name')` for
-     substring matching, which would break if a stage name is a prefix of
-     another. When configure_ci.py generates the stage list automatically,
-     switch to a JSON array and use `fromJSON()` + `contains()` for exact
-     matching. -->
-
-For now, these are the common configurations used for testing:
-
-```
-foundation,compiler-runtime
-foundation,compiler-runtime,math-libs,comm-libs,debug-tools,dctools-core,profiler-apps,media-libs
-```


### PR DESCRIPTION
Reverts ROCm/TheRock#3856

Failed pre-commit after merge: https://github.com/ROCm/TheRock/actions/runs/23009783918/job/66816683310
```
Lint GitHub Actions workflow files.......................................Failed
- hook id: actionlint
- exit code: 1

.github/workflows/multi_arch_ci_linux.yml:167:16: property "use_prebuilt_artifacts" is not defined in object type {artifact_group: string; baseline_run_id: string; build_pytorch: bool; build_variant_cmake_preset: string; build_variant_label: string; build_variant_suffix: string; dist_amdgpu_families: string; expect_failure: bool; matrix_per_family_json: string; prebuilt_stages: string; rocm_package_version: string; test_labels: string; test_type: string} [expression]
.github/workflows/multi_arch_ci_linux.yml:168:16: property "use_prebuilt_artifacts" is not defined in object type {artifact_group: string; baseline_run_id: string; build_pytorch: bool; build_variant_cmake_preset: string; build_variant_label: string; build_variant_suffix: string; dist_amdgpu_families: string; expect_failure: bool; matrix_per_family_json: string; prebuilt_stages: string; rocm_package_version: string; test_labels: string; test_type: string} [expression]
    |
168 |           inputs.use_prebuilt_artifacts == 'false' ||
    |                ^~~~~~~~~~~~~~~~~~~~~~~~
```