### PR TITLE
Fix typo and incorrect group name in .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,9 +9,9 @@
 /patches/               @ScottTodd @marbre
 
 # Debug tools configs and ROCgdb cmake wrapper.
-/debug-tools            @ROCm/TheRock-infra-write @ROCm-DevTools-Debugger
-/debug-tools/rocgdb     @ROCm/TheRock-infra-write @ROCm-DevTools-Debugger
+/debug-tools            @ROCm/TheRock-infra-write @ROCm/ROCm-DevTools-Debugger
+/debug-tools/rocgdb     @ROCm/TheRock-infra-write @ROCm/ROCm-DevTools-Debugger
 
 # Debug tools testing scripts.
-/build_tools/github_actions/test_executable_scripts/test_rocgdb.py           @ROCm-DevTools-Debugger
-/build_tools/github_actions/test_executable_scripts/test_rocr-debug-agent.py @ROCm-DevTools-Debugger
+/build_tools/github_actions/test_executable_scripts/test_rocgdb.py           @ROCm/ROCm-DevTools-Debugger
+/build_tools/github_actions/test_executable_scripts/test_rocr-debug-agent.py @ROCm/ROCm-DevTools-Debugger


### PR DESCRIPTION
Fix typo: debig-tools -> debug-tools.

Also fix an incorrect group name on the same file: @ROCm-DevTools-Debugger -> @ROCm/ROCm-DevTools-Debugger.