### PR TITLE
Add submodule fetch support to test_component workflow

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Fetch required submodules
         if: ${{ fromJSON(inputs.component).submodules != '' }}
         run: |
-          git submodule update --init --depth 1 ${{ fromJSON(inputs.component).submodules }}
+          git submodule update --init --depth 1 --recursive ${{ fromJSON(inputs.component).submodules }}
 
       - name: Run setup test environment workflow
         timeout-minutes: 15


### PR DESCRIPTION
## Summary

Adds support for test components to declare required submodules through the submodules field in their test matrix. The test_component.yml workflow now conditionally fetches only those submodules before running tests.

## Motivation

Some tests depend on source files stored inside git submodules, but the workflow previously performed only a plain checkout without initializing them. Although the test matrix already defined a submodules field, the workflow never acted on it. This change enables that functionality.