### PR TITLE
[torch] Skip test_max_split_expandable for torch 2.7, 2.8 and 2.9

### DIFF
--- a/external-builds/pytorch/skip_tests/pytorch_2.7.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.7.py
@@ -17,6 +17,11 @@ skip_tests = {
             # This test was fixed in torch 2.9, see
             # https://github.com/ROCm/TheRock/issues/2206
             "test_hip_device_count",
+            # Off-by-one due to float truncation (int() without round()) plus
+            # UnboundLocalError on cleanup when the assertion fails.
+            # Fixed upstream in pytorch#163297, landed in 2.10+.
+            # https://github.com/ROCm/pytorch/commit/66abba8f49f05b0998040443813380efc32844f6
+            "test_max_split_expandable",
         ]
     },
 }

--- a/external-builds/pytorch/skip_tests/pytorch_2.8.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.8.py
@@ -30,6 +30,11 @@ skip_tests = {
             # This test was fixed in torch 2.9, see
             # https://github.com/ROCm/TheRock/issues/2206
             "test_hip_device_count",
+            # Off-by-one due to float truncation (int() without round()) plus
+            # UnboundLocalError on cleanup when the assertion fails.
+            # Fixed upstream in pytorch#163297, landed in 2.10+.
+            # https://github.com/ROCm/pytorch/commit/66abba8f49f05b0998040443813380efc32844f6
+            "test_max_split_expandable",
         ]
     },
     "gfx120": {

--- a/external-builds/pytorch/skip_tests/pytorch_2.9.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.9.py
@@ -44,6 +44,11 @@ skip_tests = {
             "test_fp32_precision_with_tf32",
             # AttributeError: module 'torch.backends.cudnn.rnn' has no attribute 'fp32_precision'
             "test_invalid_status_for_legacy_api",
+            # Off-by-one due to float truncation (int() without round()) plus
+            # UnboundLocalError on cleanup when the assertion fails.
+            # Fixed upstream in pytorch#163297, landed in 2.10+.
+            # https://github.com/ROCm/pytorch/commit/66abba8f49f05b0998040443813380efc32844f6
+            "test_max_split_expandable",
         ],
     },
     "gfx94": {


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/3843. 

Skip `TestCudaMallocAsync.test_max_split_expandable` in PyTorch 2.7, 2.8, and 2.9, as it is missing: https://github.com/ROCm/pytorch/commit/66abba8f49f05b0998040443813380efc32844f6. That patch fixes this rounding issue on torch 2.10+.

## Technical Details

This test has two bugs:

1. Off-by-one rounding: `int(fraction_allowed * all_memory)` truncates instead of rounding, producing values like `872415231` instead of `872415232`
2. UnboundLocalError on cleanup: `orig` is assigned after the failing assertion, so the `finally` block crashes with `UnboundLocalError` when trying to restore it

Both issues are fixed upstream in [pytorch#163297](https://github.com/pytorch/pytorch/pull/163297) ([ROCm/pytorch@66abba8](https://github.com/ROCm/pytorch/commit/66abba8f49f05b0998040443813380efc32844f6)), which landed in `release/2.10+`. Rather than cherry-picking the fix into older branches, we skip the test for versions that don't have it.

**Files changed:**
- `skip_tests/pytorch_2.7.py` - skip `test_max_split_expandable`
- `skip_tests/pytorch_2.8.py` -  skip `test_max_split_expandable`
- `skip_tests/pytorch_2.9.py` -  skip `test_max_split_expandable`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.