### PR TITLE
[torch] Remove Windows test process exit hacks

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -167,28 +167,10 @@ jobs:
       #
       # Many tests are failing on torch 2.10+ so we limit testing to 2.9.
       # (Obviously that's not ideal, but we need to start somewhere)
-      #
-      # HACK: The test process does not terminate on its own gracefully,
-      # so we write to run_pytorch_tests_exit_code.txt and then kill the process.
-      # After killing the process we read the return code to signal it normally.
-      # See https://github.com/ROCm/TheRock/issues/999.
       - name: (Windows) Run PyTorch tests
         if: ${{ runner.os == 'Windows' && contains(inputs.torch_version, '2.9') }}
-        continue-on-error: true
         run: |
           python ./external-builds/pytorch/run_pytorch_tests.py -- \
             --continue-on-collection-errors \
             --import-mode=importlib \
             -v
-
-      - name: (Windows) Read and propagate exit code
-        if: ${{ runner.os == 'Windows' && contains(inputs.torch_version, '2.9') }}
-        run: |
-          if [ -f run_pytorch_tests_exit_code.txt ]; then
-            EXIT_CODE=$(cat run_pytorch_tests_exit_code.txt)
-            echo "Exit code from file: ${EXIT_CODE}"
-            exit ${EXIT_CODE}
-          else
-            echo "No run_pytorch_tests_exit_code.txt found"
-            exit 1
-          fi

--- a/external-builds/pytorch/.gitignore
+++ b/external-builds/pytorch/.gitignore
@@ -4,8 +4,3 @@ src/
 /pytorch_vision
 /pytorch_audio
 /triton
-
-# Written by run_pytorch_tests.py on Windows as a workaround for
-# https://github.com/ROCm/TheRock/issues/999.
-# Once that is solved we can remove this ignore rule.
-*exit_code.txt

--- a/external-builds/pytorch/run_pytorch_tests.py
+++ b/external-builds/pytorch/run_pytorch_tests.py
@@ -55,7 +55,6 @@ Exit Codes
 0 : All tests passed
 1 : Test failures or collection errors
 ? : Other exit codes from pytest
-15: SIGTERM for Windows (see notes below)
 Other : Pytest-specific error codes
 
 Side-effects
@@ -64,11 +63,6 @@ Side-effects
 - Creates a temporary MIOpen cache directory for each run
 - Sets HIP_VISIBLE_DEVICES environment variable to select specific GPU(s) for testing
 - Runs tests sequentially (--numprocesses=0) by default
-
-Windows special notes
----------------------
-To work around https://github.com/ROCm/TheRock/issues/999, this script
-writes 'run_pytorch_tests_exit_code.txt' to the current directory and then kills the process.
 """
 
 import argparse
@@ -283,39 +277,5 @@ def main() -> int:
         sys.exit(1)
 
 
-def force_exit_with_code(retcode):
-    """Forces termination to work around https://github.com/ROCm/TheRock/issues/999."""
-    import signal
-
-    # We're going to kill the current process with SIGTERM below, which will
-    # return exit code 15. This preserves the original exit code in a file.
-    # Note: this path is relative to CWD, *not the script directory*.
-    # TODO(#2258): output a test report file that can be inspected on both
-    #              Linux and Windows then remove this special file
-    retcode_file = Path("run_pytorch_tests_exit_code.txt")
-    # Convert to int in case retcode is a pytest.ExitCode enum
-    retcode_int = int(retcode)
-    print(f"Writing retcode {retcode_int} to '{retcode_file}'")
-    with open(retcode_file, "w") as f:
-        f.write(str(retcode_int))
-
-    print("Forcefully terminating to avoid https://github.com/ROCm/TheRock/issues/999")
-
-    # Flush output before we force exit so no logs get missed.
-    sys.stdout.flush()
-
-    # In order from "asking nicely" to "tear down immediately":
-    #   1. `sys.exit(retcode)`
-    #   2. `os._exit(retcode)`
-    #   3. `os.kill(os.getpid(), signal.SIGTERM)`
-    #   4. `subprocess.Popen(f'taskkill /F /PID {os.getpid()}', shell=True)`
-    # As options (1) and (2) are not sufficient, we use option (3) here.
-    os.kill(os.getpid(), signal.SIGTERM)
-
-
 if __name__ == "__main__":
-    retcode = main()
-    if platform.system() == "Windows":
-        force_exit_with_code(retcode)
-    else:
-        sys.exit(retcode)
+    sys.exit(main())

--- a/external-builds/pytorch/run_pytorch_tests_full.py
+++ b/external-builds/pytorch/run_pytorch_tests_full.py
@@ -364,37 +364,5 @@ def main(argv: list[str]) -> int:
     return result.returncode
 
 
-def force_exit_with_code(retcode: int) -> None:
-    """Forces termination to work around https://github.com/ROCm/TheRock/issues/999."""
-    import signal
-
-    # We're going to kill the current process with SIGTERM below, which will
-    # return exit code 15. This preserves the original exit code in a file.
-    # Note: this path is relative to CWD, *not the script directory*.
-    # TODO(#2258): output a test report file that can be inspected on both
-    #              Linux and Windows then remove this special file
-    retcode_file = Path("run_pytorch_tests_full_exit_code.txt")
-    retcode_int = int(retcode)
-    print(f"Writing retcode {retcode_int} to '{retcode_file}'")
-    retcode_file.write_text(str(retcode_int))
-
-    print("Forcefully terminating to avoid https://github.com/ROCm/TheRock/issues/999")
-
-    # Flush output before we force exit so no logs get missed.
-    sys.stdout.flush()
-
-    # In order from "asking nicely" to "tear down immediately":
-    #   1. `sys.exit(retcode)`
-    #   2. `os._exit(retcode)`
-    #   3. `os.kill(os.getpid(), signal.SIGTERM)`
-    #   4. `subprocess.Popen(f'taskkill /F /PID {os.getpid()}', shell=True)`
-    # As options (1) and (2) are not sufficient, we use option (3) here.
-    os.kill(os.getpid(), signal.SIGTERM)
-
-
 if __name__ == "__main__":
-    retcode = main(sys.argv[1:])
-    if platform.system() == "Windows":
-        force_exit_with_code(retcode)
-    else:
-        sys.exit(retcode)
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Motivation

Now that
* https://github.com/ROCm/TheRock/issues/999

is fixed, we shouldn't need this hack introduced in
* https://github.com/ROCm/TheRock/pull/2265

Progress on running more Windows PyTorch tests on CI/CD:
* https://github.com/ROCm/TheRock/issues/2258
* https://github.com/ROCm/TheRock/issues/3291

## Test Plan and Results

* Tested on CI for gfx1151 + torch 2.9: https://github.com/ROCm/TheRock/actions/runs/23020511361/
  * Test runner is working as expected
  * Attempt 1: failure due to https://github.com/ROCm/TheRock/issues/3173
  * Attempt 2: failure
    ```
    external-builds\pytorch\pytorch\test\test_nn.py::TestNNDeviceTypeCUDA::test_transformerencoderlayer_gelu_cuda_float32 PASSED [0.0955s] [  2%]
    :0:C:\home\runner\_work\TheRock\TheRock\rocm-systems\projects\clr\hipamd\src\hiprtc\hiprtcInternal.hpp:89  : 23043456529 us:  Unable to add internal header
    external-builds\pytorch\pytorch\test\test_nn.py::TestNNDeviceTypeCUDA::test_triplet_margin_with_distance_loss_cuda 
    ```
  * Attempt 3: passing
* Testing locally on gfx1100 + torch 2.9
  * Test runner is working as expected
    ```
    ==================== 15748 passed, 26182 skipped, 112 deselected, 45 xfailed in 550.34s (0:09:10) =====================
    Pytest finished with return code: 0
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
