### PR TITLE
[torch] Compare package version against source version before testing

### DIFF
--- a/external-builds/pytorch/pytorch_utils.py
+++ b/external-builds/pytorch/pytorch_utils.py
@@ -382,7 +382,7 @@ def detect_pytorch_version() -> str:
     return f"{v.major}.{v.minor}"
 
 
-def check_pytorch_source_version(pytorch_dir: Path) -> None:
+def check_pytorch_source_version(pytorch_dir: Path, allow_mismatch: bool) -> None:
     """Verify that the PyTorch test source version matches the installed wheel.
 
     Compares the major.minor version from <pytorch_dir>/version.txt against
@@ -422,7 +422,16 @@ def check_pytorch_source_version(pytorch_dir: Path) -> None:
             f"messages, collection errors). Check out matching test sources or\n"
             f"install a matching wheel."
         )
-        sys.exit(1)
+        if allow_mismatch:
+            print(
+                "[WARNING] allow_mismatch (--allow-version-mismatch) was set, so continuing anyway\n"
+            )
+            return
+        else:
+            print(
+                "[ERROR] Set allow_mismatch (--allow-version-mismatch) to bypass this check. Exiting"
+            )
+            sys.exit(1)
 
     print(
         f"PyTorch version check OK: source and wheel both "

--- a/external-builds/pytorch/run_pytorch_tests.py
+++ b/external-builds/pytorch/run_pytorch_tests.py
@@ -196,6 +196,14 @@ By default the pytorch directory is determined based on this script's location
         help="""Enable pytest caching (default). Use --no-cache when only having read-only access to pytorch directory""",
     )
 
+    parser.add_argument(
+        "--allow-version-mismatch",
+        default=False,
+        required=False,
+        action=argparse.BooleanOptionalAction,
+        help="""Allows version mismatches between pytorch test sources and installed packages. Defaults to False, so mismatched versions block running tests""",
+    )
+
     args = parser.parse_args(argv)
 
     if not args.pytorch_dir.exists():
@@ -216,7 +224,9 @@ def main() -> int:
         args, passthrough_pytest_args = cmd_arguments(sys.argv[1:])
 
         pytorch_dir = args.pytorch_dir
-        check_pytorch_source_version(pytorch_dir)
+        check_pytorch_source_version(
+            pytorch_dir=pytorch_dir, allow_mismatch=args.allow_version_mismatch
+        )
 
         # CRITICAL: Determine AMDGPU family and set HIP_VISIBLE_DEVICES
         # BEFORE importing torch/running pytest. Once torch.cuda is initialized,

--- a/external-builds/pytorch/run_pytorch_tests_full.py
+++ b/external-builds/pytorch/run_pytorch_tests_full.py
@@ -260,6 +260,13 @@ def cmd_arguments(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
         default=False,
         help="Pass --dry-run to run_test.py to list tests without running them.",
     )
+    parser.add_argument(
+        "--allow-version-mismatch",
+        default=False,
+        required=False,
+        action=argparse.BooleanOptionalAction,
+        help="""Allows version mismatches between pytorch test sources and installed packages. Defaults to False, so mismatched versions block running tests""",
+    )
     args = parser.parse_args(argv)
 
     if not args.pytorch_dir.exists():
@@ -327,7 +334,9 @@ def build_run_test_cmd(
 
 def main(argv: list[str]) -> int:
     args, passthrough_args = cmd_arguments(argv)
-    check_pytorch_source_version(args.pytorch_dir)
+    check_pytorch_source_version(
+        pytorch_dir=args.pytorch_dir, allow_mismatch=args.allow_version_mismatch
+    )
 
     # Determine AMDGPU family and set HIP_VISIBLE_DEVICES BEFORE importing
     # torch or running pytest.  Once torch.cuda is initialized, changing


### PR DESCRIPTION
## Motivation

PyTorch tests for a given package version should use matching sources, or else they risk having misleading test failures. This raises an error early pointing out the mismatch.

* Our github actions release workflows use matching versions by construction, but workflow_dispatch triggered tests and local runs are more error-prone.
* In my case, I don't often checkout different pytorch repository versions but I _do_ frequently install different pytorch packages. When I try running tests sometimes the source and packages are in sync but often they are not.

## Technical Details

I also switched `detect_pytorch_version()` to use `packaging.version` instead of manual string splitting, per https://github.com/ROCm/TheRock/blob/main/docs/packaging/versioning.md#working-with-python-package-versions.

## Test Plan and Results

1. Run locally with mismatched versions:
    ```
    [ERROR] PyTorch version mismatch!
      Test sources: 2.12 (from D:\b\pytorch\version.txt: 2.12.0a0)
      Installed wheel: 2.9 (2.9.1+rocm7.13.0a20260312)
    
    Running tests from a different PyTorch version than the installed
    wheel causes misleading failures (missing APIs, changed error
    messages, collection errors). Check out matching test sources or
    install a matching wheel.
    ```
2. Workflow with matching versions: https://github.com/ROCm/TheRock/actions/runs/23023982125/job/66867197879
    * Tests run as expected
3. Workflow with mismatched versions: https://github.com/ROCm/TheRock/actions/runs/23024061935/job/66867463649
    ```
    Error:  PyTorch version mismatch!
      Test sources: 2.8 (from /__w/TheRock/TheRock/external-builds/pytorch/pytorch/version.txt: 2.8.0)
      Installed wheel: 2.9 (2.9.1+rocm7.13.0a20260312)
    
    Running tests from a different PyTorch version than the installed
    wheel causes misleading failures (missing APIs, changed error
    messages, collection errors). Check out matching test sources or
    install a matching wheel.
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
