### PR TITLE
add additional targets to CK blacklist

### DIFF
--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 # Disable composable kernel on GPU families that are explicitly unsupported
 if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
-  set(_ck_unsupported_gfx_targets gfx900 gfx906 gfx1010 gfx1011 gfx1012 gfx1030, gfx1031, gfx1032, gfx1033, gfx1034)
+  set(_ck_unsupported_gfx_targets gfx900 gfx906 gfx1010 gfx1011 gfx1012 gfx1030 gfx1031 gfx1032 gfx1033 gfx1034)
   set(_ck_is_unsupported OFF)
   foreach(_gfx_target ${THEROCK_AMDGPU_TARGETS})
     if(_gfx_target IN_LIST _ck_unsupported_gfx_targets)


### PR DESCRIPTION
This pull request updates the list of unsupported GPU targets for the composable kernel feature in the `ml-libs/CMakeLists.txt` file. The change expands the set of GPU architectures for which composable kernel is disabled, to address the issue https://github.com/ROCm/TheRock/issues/3931

GPU support configuration:

* Expanded the `_ck_unsupported_gfx_targets` list to include additional AMD GPU architectures (`gfx900`, `gfx1030`, `gfx1031`, `gfx1032`, `gfx1034`), ensuring composable kernel is not enabled on these unsupported targets.
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
