### PR TITLE
Add myself as a CODEOWNER for github_actions_utils.py

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,9 @@
 # New patches are strongly discouraged. See patches/README.md.
 /patches/               @ScottTodd @marbre
 
+# This is for _github actions APIs_, not a general dumping ground for random utils.
+/build_tools/github_actions/github_actions_utils.py     @ScottTodd
+
 # Debug tools configs and ROCgdb cmake wrapper.
 /debug-tools            @ROCm/TheRock-infra-write @ROCm/ROCm-DevTools-Debugger
 /debug-tools/rocgdb     @ROCm/TheRock-infra-write @ROCm/ROCm-DevTools-Debugger


### PR DESCRIPTION
## Motivation

Code unrelated to the github actions API keeps landing in this file as if it were a general utility:

* https://github.com/ROCm/TheRock/pull/2873#discussion_r2928014865
* https://github.com/ROCm/TheRock/pull/3595#discussion_r2928037642

See the comment at the top of the file:

https://github.com/ROCm/TheRock/blob/ca2a06c6c9fa47a21e21d1c6f0c133e9566eeb05/build_tools/github_actions/github_actions_utils.py#L4-L7

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
