### PR TITLE
Add missing third_party/printf to iree nested submodules

### DIFF
--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -434,6 +434,7 @@ def main(argv):
                     "third_party/benchmark",
                     "third_party/llvm-project",
                     "third_party/torch-mlir",
+                    "third_party/printf",
                 ],
             )
         ],


### PR DESCRIPTION
## Summary
- iree-org/iree#23694 (merged 2026-03-09) replaced all libc `snprintf`/`vsnprintf` calls in the IREE runtime with `eyalroz/printf`, making `third_party/printf` an unconditional build dependency (`printf::printf` is required by `iree::base`).
- `third_party/printf` was missing from the default `--nested-submodules` list for `iree` in `fetch_sources.py`, causing it not to be fetched and the IREE build to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)