### PR TITLE
Fix CI break for rocprof trace decoder

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -16,6 +16,8 @@ if(THEROCK_ENABLE_ROCPROFV3)
   # See: https://github.com/ROCm/rocprof-trace-decoder/
   ##############################################################################
   therock_cmake_subproject_declare(rocprof-trace-decoder
+    # The build infrastructure requires generic stages to pass through
+    # DIST_AMDGPU_TARGETS even if the list isn't used by the underlying project.
     USE_DIST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprof-trace-decoder"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprof-trace-decoder"


### PR DESCRIPTION
## Motivation

Fixes breakage by PR: https://github.com/ROCm/TheRock/pull/3723 
The build infra requires DIST_AMDGPU_TARGETS even if the list isn't used by the underlying project.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
