### PR TITLE
Adding test packages for rocdecode and rocjpeg

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -2076,6 +2076,41 @@
     "Gfxarch": "False"
   },
   {
+    "Package": "amdrocm-decode-test",
+    "Version": "",
+    "Architecture": "amd64",
+    "BuildArch": "x86_64",
+    "DEBDepends": [
+      "amdrocm-decode-devel"
+    ],
+    "RPMRequires": [
+      "amdrocm-decode-devel"
+    ],
+    "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
+    "Description_Short": "AMD ROCm video decode test files",
+    "Description_Long": "Test files for rocdecode",
+    "Section": "devel",
+    "Priority": "optional",
+    "Group": "unknown",
+    "License": "MIT",
+    "Vendor": "Advanced Micro Devices, Inc",
+    "Homepage": "https://github.com/ROCm/rocm-systems",
+    "Artifactory": [
+      {
+        "Artifact": "rocdecode",
+        "Artifact_Subdir": [
+          {
+            "Name": "rocdecode",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
+      }
+    ],
+    "Gfxarch": "False"
+  },
+  {
     "Package": "amdrocm-decode",
     "Version": "",
     "Architecture": "amd64",
@@ -2142,6 +2177,41 @@
             "Name": "rocdecode",
             "Components": [
               "dev"
+            ]
+          }
+        ]
+      }
+    ],
+    "Gfxarch": "False"
+  },
+  {
+    "Package": "amdrocm-jpeg-test",
+    "Version": "",
+    "Architecture": "amd64",
+    "BuildArch": "x86_64",
+    "DEBDepends": [
+      "amdrocm-jpeg-devel"
+    ],
+    "RPMRequires": [
+      "amdrocm-jpeg-devel"
+    ],
+    "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
+    "Description_Short": "AMD ROCm JPEG decode library",
+    "Description_Long": "rocjpeg provides high-performance JPEG decoding on AMD GPUs using VA-API",
+    "Section": "devel",
+    "Priority": "optional",
+    "Group": "unknown",
+    "License": "MIT",
+    "Vendor": "Advanced Micro Devices, Inc",
+    "Homepage": "https://github.com/ROCm/rocm-systems",
+    "Artifactory": [
+      {
+        "Artifact": "rocjpeg",
+        "Artifact_Subdir": [
+          {
+            "Name": "rocjpeg",
+            "Components": [
+              "test"
             ]
           }
         ]


### PR DESCRIPTION
## Motivation

Add test packages for both rocdecode, and rocjpeg

## Technical Details

Add additional test packages under build_tools/packaging/linux/package.json and edit respective toml files media-libs/artifact-rocdecode.toml and media-libs/artifact-rocjpeg.toml if changing the contents of the test package is needed. 

## Test Plan

1) Fetch artifacts 
2) Build artifacts 

./build_tools/packaging/linux/build_package.py --dest-dir OUTPUT_DEB --rocm-version  7.12.0~dev20260311  --target gfx94X-dcgpu --artifacts-dir artifacts/ --pkg-type deb --version-suffix 1111111 --pkg-names amdrocm-decode-test

./build_tools/packaging/linux/build_package.py --dest-dir OUTPUT_DEB --rocm-version  7.12.0~dev20260311  --target gfx94X-dcgpu --artifacts-dir artifacts/ --pkg-type deb --version-suffix 1111111 --pkg-names amdrocm-jpeg-test

3) verify contents of packages with dpkg -c 

## Test Result

Expected files in packages

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
