### PR TITLE
[ci] Disabling RCCL for sanitizer builds

### DIFF
--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-if(THEROCK_ENABLE_RCCL)
+# TODO(#2632): Re-enable RCCL for sanitizer builds once RCCL build time is acceptable
+if(THEROCK_ENABLE_RCCL AND THEROCK_SANITIZER STREQUAL "")
   # Most libraries need to depend on the profiler, but is conditionally only used
   # on Posix.
   set(optional_profiler_deps)


### PR DESCRIPTION
Tried to revert #3732 but could not. ASAN builds with RCCL now take 12h+: https://github.com/ROCm/TheRock/actions/runs/23034236295/job/66898690674

disabling RCCL for sanitizer builds

```
55084.0	[561/561] Linking CXX executable test/rccl-UnitTests
END	1773385685.3780658	55083.95273709297	0
```
^ above indicates ~ 15 hours

Progress on #2632