### PR TITLE
[CI] Allow manifest generation without `.git` or `.gitmodules` metadata

### DIFF
--- a/build_tools/generate_therock_manifest.py
+++ b/build_tools/generate_therock_manifest.py
@@ -21,19 +21,30 @@ def _run(cmd, cwd=None, check=True) -> str:
     return res.stdout.strip()
 
 
-def git_root() -> Path:
+def source_root() -> Path:
     """
     Determine the repo root strictly from this script's location:
       <repo>/build_tools/generate_therock_manifest.py  ->  <repo>
     """
     here = Path(__file__).resolve()
     repo_root = here.parents[1]  # .../build_tools -> repo root
-    if not ((repo_root / ".git").exists() or (repo_root / ".gitmodules").exists()):
+    if not (repo_root / "build_tools").exists():
         raise RuntimeError(
             f"Could not locate repo root at {repo_root}. "
             "Expected this script to live under <repo>/build_tools/."
         )
     return repo_root
+
+
+def has_git_metadata(repo_root: Path) -> bool:
+    result = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "true"
 
 
 def list_submodules_from_gitmodules_at_commit(repo_dir: Path, commit: str = "HEAD"):
@@ -70,6 +81,63 @@ def list_submodules_from_gitmodules_at_commit(repo_dir: Path, commit: str = "HEA
         stderr = result.stderr.strip()
         # Exit code 1 with no stderr means no matches (no .gitmodules or no submodule entries)
         # Exit code 1 with stderr means an actual error (invalid commit, etc.)
+        if stderr:
+            raise RuntimeError(f"Git command failed: {' '.join(cmd)}\n{stderr}")
+        return []
+
+    submodules_by_name = {}
+
+    # Output format: submodule.<name>.<key> <value>
+    # Example: submodule.half.path base/half
+    # The regex uses (.+) for name to handle submodule names containing dots.
+    # The explicit \.(path|url|branch) ensures we match the last occurrence,
+    # correctly extracting names like "foo.bar" from "submodule.foo.bar.path".
+    pattern = re.compile(r"^submodule\.(.+)\.(path|url|branch)\s+(.+)$")
+
+    for line in result.stdout.strip().splitlines():
+        match = pattern.match(line)
+        if match:
+            name, key, value = match.groups()
+            if name not in submodules_by_name:
+                submodules_by_name[name] = {
+                    "name": name,
+                    "path": None,
+                    "url": None,
+                    "branch": None,
+                }
+            submodules_by_name[name][key] = value
+
+    # Filter out entries without a path and sort by path
+    results = [r for r in submodules_by_name.values() if r["path"]]
+    results.sort(key=lambda r: r["path"])
+    return results
+
+
+def list_submodules_from_gitmodules_file(repo_dir: Path):
+    """
+    Read path/url/branch for all submodules from the filesystem .gitmodules file.
+
+    This is used when git metadata is not available (for example, source trees
+    created from release archives with .git removed).
+    """
+    gitmodules_path = repo_dir / ".gitmodules"
+    if not gitmodules_path.exists():
+        return []
+
+    cmd = [
+        "git",
+        "config",
+        "--file",
+        str(gitmodules_path),
+        "--get-regexp",
+        r"^submodule\.",
+    ]
+    result = subprocess.run(
+        cmd, cwd=repo_dir, text=True, capture_output=True, check=False
+    )
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
         if stderr:
             raise RuntimeError(f"Git command failed: {' '.join(cmd)}\n{stderr}")
         return []
@@ -139,7 +207,6 @@ def build_manifest_schema(
     github_run_id: str | None = None,
     rocm_package_version: str | None = None,
 ) -> dict:
-
     # Enumerate submodules from .gitmodules at the specified commit.
     entries = list_submodules_from_gitmodules_at_commit(repo_root, the_rock_commit)
 
@@ -159,6 +226,42 @@ def build_manifest_schema(
 
     manifest = {
         "the_rock_commit": the_rock_commit,
+    }
+
+    if github_run_id:
+        manifest["github_run_id"] = github_run_id
+
+    if rocm_package_version:
+        manifest["rocm_package_version"] = rocm_package_version
+
+    manifest["submodules"] = rows
+    return manifest
+
+
+def build_partial_manifest_schema(
+    repo_root: Path,
+    github_run_id: str | None = None,
+    rocm_package_version: str | None = None,
+) -> dict:
+    # Enumerate submodules from the filesystem .gitmodules file when git metadata
+    # is unavailable (for example, source trees with .git removed).
+    entries = list_submodules_from_gitmodules_file(repo_root)
+
+    # Build rows without pins, since gitlink SHAs are not available without git metadata.
+    rows = []
+    for e in sorted(entries, key=lambda x: x["path"] or ""):
+        rows.append(
+            {
+                "submodule_name": e["name"],
+                "submodule_path": e["path"],
+                "submodule_url": e["url"],
+                "pin_sha": None,
+                "patches": patches_for_submodule_by_name(repo_root, e["name"]),
+            }
+        )
+
+    manifest = {
+        "the_rock_commit": None,
     }
 
     if github_run_id:
@@ -203,16 +306,24 @@ def main():
     )
     args = ap.parse_args()
 
-    repo_root = git_root()
-    the_rock_commit = _run(["git", "rev-parse", args.commit], cwd=repo_root)
+    repo_root = source_root()
     github_run_id = os.getenv("GITHUB_RUN_ID")
+    git_available = has_git_metadata(repo_root)
 
-    manifest = build_manifest_schema(
-        repo_root,
-        the_rock_commit,
-        github_run_id,
-        args.rocm_package_version,
-    )
+    if git_available:
+        the_rock_commit = _run(["git", "rev-parse", args.commit], cwd=repo_root)
+        manifest = build_manifest_schema(
+            repo_root,
+            the_rock_commit,
+            github_run_id,
+            args.rocm_package_version,
+        )
+    else:
+        manifest = build_partial_manifest_schema(
+            repo_root,
+            github_run_id,
+            args.rocm_package_version,
+        )
 
     # Merge flag settings into the manifest if provided.
     if args.flag_settings:


### PR DESCRIPTION
## Motivation
Closes: https://github.com/ROCm/TheRock/issues/3245

Building TheRock from source archives where the .git directory is removed (for example when creating reproducible tarballs) currently fails during manifest generation.

generate_therock_manifest.py relies on Git metadata to resolve:

- the_rock_commit via git rev-parse
- submodule metadata via git config --blob
- submodule pin SHAs via git ls-tree

When .git is not present, the script fails at:
```
git rev-parse HEAD
fatal: not a git repository
```
This causes the build to abort even though the source tree itself is otherwise valid.
Packaging systems such as EasyBuild may intentionally remove .git to produce reproducible source archives, so this prevents building TheRock from such sources.

## Technical Details

This change allows manifest generation to succeed even when Git metadata is unavailable.
The script now checks whether the source tree contains usable Git metadata.
When `.git` is available (normal development / CI)

Behavior is unchanged:

- the_rock_commit is resolved via git rev-parse
- submodule metadata is read via git config --blob
- submodule pin SHAs are resolved via git ls-tree

A full manifest is generated.

When `.git` is not available (source archive builds)

Instead of failing, the script generates a partial manifest:

- the_rock_commit is set to null
- pin_sha values are set to null
- submodule metadata (name, path, url) is read from the filesystem .gitmodules if present
- patch lists are still collected from the source tree

If `.gitmodules` is also absent, the manifest will contain an empty submodules list.

This allows builds from tag/source archives to proceed even when Git metadata is unavailable.

## Test Plan and Result
### 1. Normal Git checkout
Run:
```
python build_tools/generate_therock_manifest.py
```
Result:
```
{
  "the_rock_commit": "e1fd32da4203e85e20c0ff355784960573ddc095",
  "submodules": [
    {
      "submodule_name": "half",
      "submodule_path": "base/half",
      "submodule_url": "https://github.com/ROCm/half.git",
      "pin_sha": "207ee58595a64b5c4a70df221f1e6e704b807811",
      "patches": []
    },
    ...
  ]
}
```
### 2. Source tree without .git
Run:
```
cp -a TheRock /tmp/TheRock-no-git
rm -rf /tmp/TheRock-no-git/.git

cd /tmp/TheRock-no-git
python build_tools/generate_therock_manifest.py
```
Result:

```
{
  "the_rock_commit": null,
  "submodules": [
    {
      "submodule_name": "half",
      "submodule_path": "base/half",
      "submodule_url": "https://github.com/ROCm/half.git",
      "pin_sha": null,
      "patches": []
    },
    ...
  ]
}
```
### 3. CI builds (with .git present)
CI runs with a normal Git checkout, so the existing behavior remains unchanged and a full manifest is generated.
https://therock-ci-artifacts.s3.amazonaws.com/23075495685-linux/manifests/gfx94X-dcgpu/therock_manifest.json
