### PR TITLE
Correct passing of amdgpu_family to get_tests for skipping pytorch tests.

### DIFF
--- a/external-builds/pytorch/run_pytorch_tests.py
+++ b/external-builds/pytorch/run_pytorch_tests.py
@@ -225,6 +225,9 @@ def main() -> int:
         )
         print(f"Using AMDGPU family: {first_arch}")
 
+        # get_tests amdgpu_family requires list[str]
+        first_arch = [first_arch]
+
         # Determine PyTorch version
         pytorch_version = args.pytorch_version
         if not pytorch_version:

--- a/external-builds/pytorch/run_pytorch_tests_full.py
+++ b/external-builds/pytorch/run_pytorch_tests_full.py
@@ -334,6 +334,9 @@ def main(argv: list[str]) -> int:
     ((first_arch, _),) = set_gpu_execution_policy(args.amdgpu_family, policy="single")
     print(f"Using AMDGPU family: {first_arch}")
 
+    # get_tests amdgpu_family requires list[str]
+    first_arch = [first_arch]
+
     pytorch_version = args.pytorch_version
     if not pytorch_version:
         pytorch_version = detect_pytorch_version()


### PR DESCRIPTION
## Motivation

Filtering of pytorch tests per gpu family was not working correctly due to how the amdgpu_family was being passed.

## Technical Details

It was previously iterating over the string characters to find the filter instead of filtering by the family.

## Test Plan

Testing locally and via ci when pytorch tests are run.

## Test Result

Ran tests locally and the filter I added for my gpu (gfx1150) was applied correctly. This pull request does not contain the added filter. The process finishes with `= 693 failed, 2112 passed, 1101 skipped, 314 deselected, 6 xfailed, 37448 errors in 508.91s (0:08:28) =` vs crashing due to failing to filter problematic tests.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
