### PR TITLE
[ci] Enabling TSAN Nightly builds

### DIFF
--- a/.github/workflows/ci_tsan.yml
+++ b/.github/workflows/ci_tsan.yml
@@ -4,8 +4,8 @@
 name: CI TSAN
 
 on:
-#  schedule:
-#    - cron: "0 2 * * *" # Runs nightly at 2 AM UTC
+  schedule:
+    - cron: "0 2 * * *" # Runs nightly at 2 AM UTC
   workflow_dispatch:
     inputs:
       linux_amdgpu_families:

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -39,7 +39,6 @@ all_build_variants = {
             "build_variant_label": "tsan",
             "build_variant_suffix": "tsan",
             "build_variant_cmake_preset": "linux-release-tsan",
-            "expect_failure": True,
         },
     },
     "windows": {


### PR DESCRIPTION
## Motivation

Enabling TSAN Nightly Builds

## Technical Details

This enables cron job setting for TSAN Nightly Builds to launch everyday at 2AM

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
