### PR TITLE
[profiler] Cherry pick commit #3932 into `release/therock-7.12`

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1244,8 +1244,9 @@
       }
     ],
 
+    "Gfxarch": "False",
     "Disable_DWZ": "True",
-    "Gfxarch": "False"
+    "Disable_DEB_STRIP": "True"
   },
   {
     "Package": "amdrocm-hipify",


### PR DESCRIPTION
## Motivation

Cherry pick #3932 ([profiler] [DEB package] Prevent libunwind.so.99 from having non page aligned address/offset).
Resolves ROCM-20115.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->


## Technical Details

Specifies "Disable_DEB_STRIP": "True" for amdrocm-profiler

I have submitted this PR to the cherry-pick approval list for RM approval.

## Test Plan

See #3932

## Test Result

<!-- Briefly summarize test outcomes. -->
See #3932

No more observed failure due to `libunwind.so.99`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.