### PR TITLE
[ci] disabling gfx90a

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -225,7 +225,9 @@ amdgpu_family_info_matrix_nightly = {
     },
     "gfx90a": {
         "linux": {
-            "test-runs-on": "linux-gfx90a-gpu-rocm",
+            # Label is linux-gfx90a-gpu-rocm
+            # Downtime in 3/17/26 - 3/18/26 for maintenance
+            "test-runs-on": "",
             "family": "gfx90a",
             "fetch-gfx-targets": ["gfx90a"],
             "sanity_check_only_for_family": True,


### PR DESCRIPTION
Due to lab maintenance, gfx90a machines are down from 3/17 - 3/18. Disabling to prevent delays.

I am working on better way of updating labels in a separate PR

Tests work here and properly ignored: https://github.com/ROCm/TheRock/actions/runs/23162961369

Since this is a test update only, we are adding `skip-ci` label.