### PR TITLE
Disable AOTriton for gfx900 in PyTorch builds 

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -783,8 +783,8 @@ def do_build_pytorch(
     is_pytorch_2_11_or_later = pytorch_build_version_parsed.release[:2] >= (2, 11)
 
     # aotriton is not supported on certain architectures yet.
-    # gfx906/gfx908/gfx101X/gfx103X: https://github.com/ROCm/TheRock/issues/1925
-    AOTRITON_UNSUPPORTED_ARCHS = ["gfx906", "gfx908", "gfx101", "gfx103"]
+    # gfx900/gfx906/gfx908/gfx101X/gfx103X: https://github.com/ROCm/TheRock/issues/1925
+    AOTRITON_UNSUPPORTED_ARCHS = ["gfx900", "gfx906", "gfx908", "gfx101", "gfx103"]
     # gfx1152/53: supported in aotriton 0.11.2b+ (https://github.com/ROCm/aotriton/pull/142),
     #   which is pinned by pytorch >= 2.11. Older versions don't include it.
     if not is_pytorch_2_11_or_later:


### PR DESCRIPTION
## Motivation
gfx900 support was recently introduced into the system via https://github.com/ROCm/TheRock/pull/3564. However, AOTriton currently does not support gfx900, leading to PyTorch build failures when this architecture is detected.
eg failure log:  https://github.com/ROCm/TheRock/actions/runs/23181751945/job/67356031342

Previously, PyTorch builds were failing due to missing package requirements (see: https://github.com/ROCm/TheRock/issues/3988). Those requirements were later uploaded manually: https://github.com/ROCm/TheRock/tree/main/build_tools/third_party/s3_management#adding-a-new-package-dependency
To ensure stable builds, this PR adds gfx900 to the AOTRITON_UNSUPPORTED_ARCHS list within the PyTorch build script, preventing AOTriton from attempting compilation on unsupported hardware.

## Test Plan
Linux Rocm Run: https://github.com/ROCm/TheRock/actions/runs/23189631595
pytorch: https://github.com/ROCm/TheRock/actions/runs/23198946201

## Test Result:

gfx900 pytorch builds passed.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
