### PR TITLE
Revert "Add missing third_party/printf to iree nested submodules (#3953)"

### DIFF
--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -432,7 +432,6 @@ def main(argv):
                     "third_party/benchmark",
                     "third_party/llvm-project",
                     "third_party/torch-mlir",
-                    "third_party/printf",
                 ],
             )
         ],


### PR DESCRIPTION
This reverts commit 67f5e586971df754cd293f4ea3dedc1a0012d8eb. The printf submodule was added with commit iree-org/iree@b4af1cd1 but the submodule in TheRock points to iree-org/iree@1fe030b which does not include the commit that adds the printf submodule. The iree-compiler stage is therefore failing in multi-arch CI:

```
Traceback (most recent call last):
  File "/__w/TheRock/TheRock/./build_tools/fetch_sources.py", line 611, in <module>
    main(sys.argv[1:])
  File "/__w/TheRock/TheRock/./build_tools/fetch_sources.py", line 607, in main
    run(args)
  File "/__w/TheRock/TheRock/./build_tools/fetch_sources.py", line 182, in run
    fetch_nested_submodules(args, projects)
  File "/__w/TheRock/TheRock/./build_tools/fetch_sources.py", line 142, in fetch_nested_submodules
    get_submodule_path(nested_submodule, cwd=parent_dir)
  File "/__w/TheRock/TheRock/./build_tools/fetch_sources.py", line 310, in get_submodule_path
    subprocess.check_output(
  File "/opt/python/cp312-cp312/lib/python3.12/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/cp312-cp312/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'config', '--file', '.gitmodules', '--get', 'submodule.third_party/printf.path']' returned non-zero exit status 1.
```
https://github.com/ROCm/TheRock/actions/runs/23186306856/job/67376934713