### PR TITLE
Add rocattach package to CMakeLists (#3891)

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -118,6 +118,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
   therock_cmake_subproject_provide_package(rocprofiler-sdk rocprofiler-sdk lib/cmake/rocprofiler-sdk)
   therock_cmake_subproject_provide_package(rocprofiler-sdk rocprofiler-sdk-roctx lib/cmake/rocprofiler-sdk-roctx)
   therock_cmake_subproject_provide_package(rocprofiler-sdk rocprofiler-sdk-rocpd lib/cmake/rocprofiler-sdk-rocpd)
+  therock_cmake_subproject_provide_package(rocprofiler-sdk rocprofiler-sdk-rocattach lib/cmake/rocprofiler-sdk-rocattach)
   therock_cmake_subproject_activate(rocprofiler-sdk)
 
   ##############################################################################

--- a/profiler/artifact-rocprofiler-sdk.toml
+++ b/profiler/artifact-rocprofiler-sdk.toml
@@ -15,6 +15,7 @@ include = [
   "share/rocprofiler-sdk/**",
   "share/rocprofiler-sdk-rocpd/**",
   "share/rocprofiler-sdk-roctx/**",
+  "share/rocprofiler-sdk-rocattach/**",
   "lib/python*/**",
 ]
 [components.test."profiler/rocprofiler-sdk/stage"]


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
`rocprofiler-sdk-rocattach` seems to be missing a "provides" declaration and this leads to `rocprofiler-systems` not being able to find it during it's build.
Cherry picks - https://github.com/ROCm/TheRock/pull/3891. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. --> 
Adds a declaration to provide `rocprofiler-sdk-rocattach`.
Cherry-picks - https://github.com/ROCm/TheRock/pull/3891
I have submitted this PR to the cherry-pick approval list for RM approval.

## JIRA ID
- ROCM-20003

## Test Plan

<!-- Explain any relevant testing done to verify this PR. --> Run a test build, review logs, and verify artifacts are present.

## Test Result

<!-- Briefly summarize test outcomes. -->
`rocprofiler-sdk-rocattach` library is found and, in turn, the `rocprof-sys-attach` binary is built.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
