### PR TITLE
fix(ci): configure ROCm library paths for JAX wheel tests

### DIFF
--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -214,7 +214,7 @@ jobs:
             --artifact-group "${{ inputs.amdgpu_family }}" \
             --output-dir "${DEST}"
           # Temporary CI workaround.
-          # TODO(#<issue-number>): Remove this /opt/rocm symlink once JAX wheel
+          # TODO(#4201): Remove this /opt/rocm symlink once JAX wheel
           # packaging/RUNPATH fixes are validated and CI no longer depends on
           # /opt/rocm -> /opt/rocm-<version> path translation.
           ln -sfn "${DEST}" /opt/rocm


### PR DESCRIPTION
## Motivation

JAX wheel tests in CI can currently report passing results without actually exercising the ROCm backend, which makes the real JAX wheel status hard to evaluate.

Two issues are contributing to this:

1. ROCm tarball installs to `/opt/rocm-<version>/` without a `/opt/rocm` symlink, while JAX wheels expect `/opt/rocm/lib` in their RUNPATH.
2. Without `JAX_PLATFORMS=rocm`, JAX may fall back to CPU, so tests can pass even when ROCm backend initialization is broken.

This PR is intended to improve CI signal for JAX ROCm testing by making the test environment match the wheel expectations and by preventing silent CPU fallback.

Related:
- https://github.com/ROCm/TheRock/issues/3627
- https://github.com/ROCm/jax/pull/737
- https://github.com/ROCm/rocm-jax/pull/362
- https://github.com/ROCm/rocm-jax/pull/363
- https://github.com/ROCm/rocm-jax/pull/364

## Changes

- **`ln -sfn "${DEST}" /opt/rocm`** — create a `/opt/rocm` symlink so wheel RUNPATH entries such as `/opt/rocm/lib` resolve correctly in CI.
- **`JAX_PLATFORMS: rocm`** — force JAX to initialize the ROCm backend in the test step, so CI fails loudly instead of silently running on CPU.

## Scope Of This PR

This PR adjusts the CI test environment and improves test correctness; it does **not** by itself fix the underlying JAX wheel packaging problem reported in `#3627`.

The underlying wheel-side fix is being addressed separately in:
- [ROCm/jax#737](https://github.com/ROCm/jax/pull/737)
- [ROCm/rocm-jax#362](https://github.com/ROCm/rocm-jax/pull/362)
- [ROCm/rocm-jax#363](https://github.com/ROCm/rocm-jax/pull/363)
- [ROCm/rocm-jax#364](https://github.com/ROCm/rocm-jax/pull/364)

## Why `LD_LIBRARY_PATH` Is Not Added Here

This PR intentionally avoids adding `LD_LIBRARY_PATH` as a CI-only workaround.

The goal here is to:
- make CI reflect whether the published wheels work with the expected install layout
- avoid masking remaining wheel packaging issues behind extra linker settings

If the companion wheel fixes are present in the tested artifacts, the `/opt/rocm` symlink should be sufficient for the expected RUNPATHs to resolve in CI.

## Dependency

For CI to pass end-to-end without extra linker overrides, the tested JAX wheels must include the corresponding RUNPATH fixes from:
- [ROCm/jax#737](https://github.com/ROCm/jax/pull/737) for `amd-main`
- [ROCm/rocm-jax#362](https://github.com/ROCm/rocm-jax/pull/362)
- [ROCm/rocm-jax#363](https://github.com/ROCm/rocm-jax/pull/363)
- [ROCm/rocm-jax#364](https://github.com/ROCm/rocm-jax/pull/364) for release branches

Until those fixes are available in the wheels used by CI, this PR may cause CI to fail earlier and more explicitly, which is the intended behavior.

## Test Plan

- [ ] Run the workflow on a GPU runner with ROCm tarball install
- [ ] Confirm JAX does not silently fall back to CPU
- [ ] Verify that backend initialization succeeds when fixed wheels are used
- [ ] Verify logs show ROCm backend initialization rather than CPU-only execution

## Test Result

Pending CI validation

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests