### PR TITLE
copy etc folder to artifacts ocl-lib

### DIFF
--- a/core/artifact-core-ocl.toml
+++ b/core/artifact-core-ocl.toml
@@ -1,5 +1,8 @@
 # ocl-clr
 [components.lib."core/ocl-clr/stage"]
+include = [
+  "etc/**",
+]
 [components.run."core/ocl-clr/stage"]
 include = [
   "bin/**",


### PR DESCRIPTION
## Motivation
ocltst and other Opencl apps need AMD ICD file to execute the app
https://github.com/ROCm/rocm-systems/pull/3818 - Installs the etc folder to stage/etc. 
This PR copies it from stage and packages the files

## Technical Details
https://github.com/ROCm/rocm-systems/pull/3818 - Installs the etc folder to stage/etc. 
This PR copies it from stage and packages the files. 
This requires the above rocm-systems PR 3818 to land in Rock for the artifacts to be populated correctly

ocltst and other Opencl apps need AMD ICD file to execute the app
OCL ICD uses the this file to load the right library.

Without these files, OCL ICD fails to load the library and you get
clGetPlatformIDs failed from ocltst
Previously, opencl apps looks at /etc/OpenCL/vendors/*.icd file which
loads the amdocl lib
Rock packaging works differently by installing to stage folder and then
creates a tar file for installation
this method does not allow opencl to install files to system folder as
it is read-only and rock is clear to not install any files outside Rock.
To overcome this , icd file will be installed to
stage/etc/OpenCL/vendors and then user needs to use OCL_ICD_VENDORS to
point to the vendors path.

## JIRA ID
https://amd-hub.atlassian.net/browse/AIRUNTIME-267

should also fix issue - https://github.com/ROCm/TheRock/issues/3999

## Test Plan
Make sure ocltst executes correctly

## Test Result
Make sure ocltst executes correctly

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
