### PR TITLE
Remove aws cli and use boto for s3 

### DIFF
--- a/.github/workflows/build_native_linux_packages.yml
+++ b/.github/workflows/build_native_linux_packages.yml
@@ -135,9 +135,6 @@ jobs:
             --pkg-type ${{ inputs.native_package_type }} \
             --version-suffix ${{ env.ARTIFACT_RUN_ID }}
 
-      - name: Install AWS CLI
-        run: bash ./dockerfiles/install_awscli.sh
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:


### PR DESCRIPTION
## Motivation

boto will be used instead of aws cli 

## Technical Details

remove installation of aws cli from build_native_linux_packages.yml

## Test Plan

Run Build native Linux packages to verify removing aws install will not break anything 

## Test Result

passed: 
https://github.com/ROCm/TheRock/actions/runs/23260702178

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
