### PR TITLE
[CI] Revert ck target changes as this heavily impacted build times.

### DIFF
--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -8,22 +8,18 @@ if(THEROCK_FLAG_INCLUDE_PROFILER)
   list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
 endif()
 
-# Disable composable kernel on GPU families that are explicitly unsupported
+# limit use of composable kernel to the GPU families it is valid for
 if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
-  set(_ck_unsupported_gfx_targets gfx900 gfx906 gfx1010 gfx1011 gfx1012 gfx1030 gfx1031 gfx1032 gfx1033 gfx1034)
-  set(_ck_is_unsupported OFF)
+  set(_ck_supported_gfx_targets gfx908 gfx90a gfx942 gfx950 gfx1150 gfx1151 gfx1152 gfx1153 gfx1200 gfx1201)
   foreach(_gfx_target ${THEROCK_AMDGPU_TARGETS})
-    if(_gfx_target IN_LIST _ck_unsupported_gfx_targets)
-      set(_ck_is_unsupported ON)
+    if(NOT ${_gfx_target} IN_LIST _ck_supported_gfx_targets)
       message(WARNING
         "${_gfx_target} (included in THEROCK_AMDGPU_TARGETS) is not supported by composable kernel. "
-        "Disabling composable kernel and its use in MIOpen.")
+        "Disabling composable kernel and it's use in MIOpen.")
+      set(THEROCK_ENABLE_COMPOSABLE_KERNEL OFF)
+      set(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL OFF)
     endif()
   endforeach()
-  if(_ck_is_unsupported)
-    set(THEROCK_ENABLE_COMPOSABLE_KERNEL OFF)
-    set(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL OFF)
-  endif()
 endif()
 
 if(THEROCK_ENABLE_COMPOSABLE_KERNEL)


### PR DESCRIPTION
## Motivation

Severe enough build time regression (~2x) to warrant a revert of the following PR's:

https://github.com/ROCm/TheRock/pull/3947
https://github.com/ROCm/TheRock/pull/3863

The run before 3863 merged: [Add gfx90c build support (#3821) · ROCm/TheRock@e14c6db](https://github.com/ROCm/TheRock/actions/runs/22963963576/job/66662229185) (3h - not great)
The run when 3863 merged ([Replace whitelist with blacklist for CK (#3863) · ROCm/TheRock@dc741e2](https://github.com/ROCm/TheRock/actions/runs/22967277614/job/66674214802)) - 6h

## Test Plan
- Check that CI build times have gone back to normal.

## Test Result
- [x] Build times have gone back to normal

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
