### PR TITLE
[ci] Adding new mi325 label

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -80,7 +80,7 @@ amdgpu_family_info_matrix_presubmit = {
             "fetch-gfx-targets": ["gfx942"],
             "build_variants": ["release", "asan", "tsan"],
             # Due to the limited count of mi325 machines, we only run this on non-quick tests
-            "run-full-tests-only": True
+            "run-full-tests-only": True,
         }
     },
     "gfx110x": {

--- a/build_tools/github_actions/tests/configure_target_run_test.py
+++ b/build_tools/github_actions/tests/configure_target_run_test.py
@@ -16,14 +16,14 @@ class ConfigureTargetRunTest(unittest.TestCase):
         # gfx94X-dcgpu is the inner key, which we use for package names. When
         # run from a workflow, we expect to only work on the inner keys.
         runner_label = configure_target_run.get_runner_label("gfx94x", "linux")
-        self.assertEqual(runner_label, "")
+        self.assertEqual(runner_label, "linux-gfx942-1gpu-ossci-rocm")
 
     def test_linux_gfx94X_dcgpu(self):
         # gfx94x is the outer key used to construct workflow pipelines, while
         # gfx94X-dcgpu is the inner key, which we use for package names. When
         # run from a workflow, we expect to only work on the inner keys.
         runner_label = configure_target_run.get_runner_label("gfx94X-dcgpu", "linux")
-        self.assertEqual(runner_label, "")
+        self.assertEqual(runner_label, "linux-gfx942-1gpu-ossci-rocm")
 
     def test_windows_gfx115x(self):
         runner_label = configure_target_run.get_runner_label("gfx1151", "windows")


### PR DESCRIPTION
Adding new mi325 label provided by OSSCI. We have 13N and max of 17N (as of 3/17/2026 5:37pm PST)

As requested in standup, we are only running this when it is a non-quick test (aka submodule bumps)