### PR TITLE
[Multi-arch] Opt in to `THEROCK_KPACK_SPLIT_ARTIFACTS` in multi-arch CI

### DIFF
--- a/build_tools/configure_stage.py
+++ b/build_tools/configure_stage.py
@@ -129,6 +129,9 @@ def generate_cmake_args(
     # Quote the value since it contains semicolons (CMake list separator)
     if dist_amdgpu_families:
         args.append(f'-DTHEROCK_DIST_AMDGPU_FAMILIES="{dist_amdgpu_families}"')
+        # Multi-arch dist builds require kpack split artifacts so generic host
+        # artifacts and target-specific payloads can be staged independently.
+        args.append("-DTHEROCK_KPACK_SPLIT_ARTIFACTS=ON")
 
     # Disable all features by default, then enable only what we need
     if include_comments:


### PR DESCRIPTION
## Motivation

Closes #3338

Multi-arch CI config is generated through `build_tools/configure_stage.py`.

For `multi-arch` dist builds, `dist_amdgpu_families` is set to describe the full
set of GPU families that should be included in the distribution. In that mode,
CI should opt in to `THEROCK_KPACK_SPLIT_ARTIFACTS` so target-specific payloads
can be staged separately from the generic host artifacts.

This change keeps split-artifact enablement scoped to the `multi-arch CI` path
without changing the regular single-arch configure flow.

## Technical Details

`build_tools/configure_stage.py` now adds:

- `-DTHEROCK_KPACK_SPLIT_ARTIFACTS=ON`

when `dist_amdgpu_families` is present:

- multi-arch configure stages opt in to split artifacts
- single-arch configure stages are unchanged
- regular CI / release paths using `build_configure.py` are unchanged

## Validation

Verified manually with `configure_stage.py`:

Multi-arch style invocation:
```bash
python build_tools/configure_stage.py \
  --stage foundation \
  --amdgpu-families gfx94X-dcgpu \
  --dist-amdgpu-families "gfx94X-dcgpu;gfx110X-dgpu" \
  --print
```  
Result:
  
```  
-DTHEROCK_AMDGPU_FAMILIES=gfx94X-dcgpu
-DTHEROCK_DIST_AMDGPU_FAMILIES="gfx94X-dcgpu;gfx110X-dgpu"
-DTHEROCK_KPACK_SPLIT_ARTIFACTS=ON   <====
-DTHEROCK_ENABLE_ALL=OFF
-DTHEROCK_ENABLE_BASE=ON
-DTHEROCK_ENABLE_SYSDEPS=ON
-DTHEROCK_ENABLE_SYSDEPS_EXPAT=ON
-DTHEROCK_ENABLE_SYSDEPS_GMP=ON
-DTHEROCK_ENABLE_SYSDEPS_HWLOC=ON
-DTHEROCK_ENABLE_SYSDEPS_LIBPCIACCESS=ON
-DTHEROCK_ENABLE_SYSDEPS_MPFR=ON
-DTHEROCK_ENABLE_SYSDEPS_NCURSES=ON
```

Single-arch style invocation:

```bash
 python build_tools/configure_stage.py \
  --stage foundation \
  --amdgpu-families gfx94X-dcgpu \
  --print
  ````
 Result:
 ```
-DTHEROCK_AMDGPU_FAMILIES=gfx94X-dcgpu
-DTHEROCK_ENABLE_ALL=OFF
-DTHEROCK_ENABLE_BASE=ON
-DTHEROCK_ENABLE_SYSDEPS=ON
-DTHEROCK_ENABLE_SYSDEPS_EXPAT=ON
-DTHEROCK_ENABLE_SYSDEPS_GMP=ON
-DTHEROCK_ENABLE_SYSDEPS_HWLOC=ON
-DTHEROCK_ENABLE_SYSDEPS_LIBPCIACCESS=ON
-DTHEROCK_ENABLE_SYSDEPS_MPFR=ON
-DTHEROCK_ENABLE_SYSDEPS_NCURSES=ON
```