### PR TITLE
Draft: Add SGLang development Docker image with TheRock ROCm integration

### DIFF
--- a/.github/workflows/release-sglang-dev-daily-image.yml
+++ b/.github/workflows/release-sglang-dev-daily-image.yml
@@ -1,0 +1,115 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+name: Release SGLang Dev Daily Image
+
+on:
+  # Nightly build at 6 AM UTC (after TheRock nightly artifacts are published)
+  schedule:
+    - cron: "0 6 * * *"
+
+  # Manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      therock_version:
+        description: "TheRock version to use (e.g., 7.12.0a20260318). Leave empty for latest nightly."
+        type: string
+        default: ""
+      amdgpu_family:
+        description: "AMD GPU family"
+        type: choice
+        options:
+          - gfx950
+          - gfx94X-dcgpu
+        default: "gfx950"
+
+  # Trigger on Dockerfile changes
+  push:
+    branches:
+      - 'main'
+      - 'stage/docker/**'
+    paths:
+      - dockerfiles/sglang_dev.Dockerfile
+      - .github/workflows/release-sglang-dev-daily-image.yml
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-24.04
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ROCm/sglang_dev
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: 3.12
+
+      - name: Determine TheRock version
+        id: version
+        run: |
+          AMDGPU_FAMILY="${{ inputs.amdgpu_family || 'gfx950' }}"
+
+          if [ -n "${{ inputs.therock_version }}" ]; then
+            VERSION="${{ inputs.therock_version }}"
+            echo "Using manually specified version: ${VERSION}"
+          else
+            # For scheduled builds, use a default recent nightly version
+            # In production, this could query the latest from S3 or artifacts API
+            VERSION="7.12.0a$(date +%Y%m%d)"
+            echo "Using default nightly version: ${VERSION}"
+            echo "NOTE: Update this logic to fetch actual latest version if needed"
+          fi
+
+          echo "THEROCK_VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "AMDGPU_FAMILY=${AMDGPU_FAMILY}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine Docker tag
+        id: tag
+        run: |
+          ref="${{ github.ref_name }}"
+          if [[ "$ref" == stage/docker/* ]]; then
+            suffix="${ref#stage/docker/}"
+            echo "TAG_SUFFIX=stage-${suffix}" >> "$GITHUB_OUTPUT"
+          elif [[ "$ref" == "main" ]]; then
+            echo "TAG_SUFFIX=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "TAG_SUFFIX=${ref}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.THEROCK_VERSION }}-${{ steps.version.outputs.AMDGPU_FAMILY }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: dockerfiles/
+          file: dockerfiles/sglang_dev.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_IMAGE=ubuntu:24.04
+            THEROCK_VERSION=${{ steps.version.outputs.THEROCK_VERSION }}
+            AMDGPU_FAMILY=${{ steps.version.outputs.AMDGPU_FAMILY }}
+            RELEASE_TYPE=nightlies
+            PYTHON_VERSION=3.12
+            GPU_ARCH=${{ steps.version.outputs.AMDGPU_FAMILY }}

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -118,6 +118,71 @@ access (e.g., `--device=/dev/kfd --device=/dev/dri`).
 See the header comments in [`rocm_runtime.Dockerfile`](rocm_runtime.Dockerfile)
 for supported base images, build arguments, and build/run examples.
 
+### `sglang_dev.Dockerfile`
+
+| Source .Dockerfile                             | Published package                                                   |
+| ---------------------------------------------- | ------------------------------------------------------------------- |
+| [`sglang_dev.Dockerfile`](sglang_dev.Dockerfile) | https://github.com/ROCm/TheRock/pkgs/container/sglang_dev           |
+
+This Dockerfile builds a complete SGLang development environment based on
+TheRock ROCm artifacts. Includes PyTorch ROCm, SGLang, and related ML/AI tools
+optimized for AMD GPUs (primarily gfx950).
+
+**Key Features:**
+- ROCm installation from TheRock nightly artifacts
+- PyTorch ROCm from AMD nightly wheels
+- SGLang with ROCm/HIP support
+- Pre-configured performance environment variables
+- Automated nightly builds
+
+**Build Arguments:**
+- `BASE_IMAGE` - Base Docker image (default: ubuntu:24.04)
+- `THEROCK_VERSION` - TheRock ROCm version (e.g., 7.12.0a20260318)
+- `AMDGPU_FAMILY` - AMD GPU family (default: gfx950)
+- `RELEASE_TYPE` - Release type (default: nightlies)
+- `PYTHON_VERSION` - Python version (default: 3.12, must match base image)
+- `TORCH_INDEX` - PyTorch wheel index URL (see mappings below)
+- `GPU_ARCH` - GPU architecture for kernel compilation (default: gfx950)
+
+**PyTorch Index Mappings:**
+- gfx950 → `https://rocm.nightlies.amd.com/v2-staging/gfx950-dcgpu/`
+- gfx942 → `https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/`
+
+**Build Example:**
+```bash
+docker build \
+  --build-arg THEROCK_VERSION=7.12.0a20260318 \
+  --build-arg AMDGPU_FAMILY=gfx950 \
+  -f dockerfiles/sglang_dev.Dockerfile \
+  -t sglang-dev:gfx950-7.12.0a20260318 \
+  dockerfiles/
+```
+
+**Build Example (gfx942):**
+```bash
+docker build \
+  --build-arg THEROCK_VERSION=7.12.0a20260318 \
+  --build-arg AMDGPU_FAMILY=gfx94X-dcgpu \
+  --build-arg GPU_ARCH=gfx942 \
+  --build-arg TORCH_INDEX=https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/ \
+  -f dockerfiles/sglang_dev.Dockerfile \
+  -t sglang-dev:gfx942-7.12.0a20260318 \
+  dockerfiles/
+```
+
+**Run Example:**
+```bash
+docker run --rm -it --device=/dev/kfd --device=/dev/dri \
+  --security-opt seccomp=unconfined \
+  ghcr.io/rocm/sglang_dev:latest bash
+```
+
+**Published Images:**
+- `ghcr.io/rocm/sglang_dev:<version>-<family>` - Versioned builds (e.g., `7.12.0a20260318-gfx950`)
+
+See [`.github/workflows/release-sglang-dev-daily-image.yml`](/.github/workflows/release-sglang-dev-daily-image.yml)
+for the automated publishing workflow.
+
 Supporting scripts:
 
 - [`install_rocm_deps.sh`](install_rocm_deps.sh): Auto-detects the distribution
@@ -176,6 +241,10 @@ workflow is used by other `publish_*.yml` workflows:
 | [`.github/workflows/publish_build_manylinux_x86_64.yml`](/.github/workflows/publish_build_manylinux_x86_64.yml)           | [actions/workflows/publish_build_manylinux_x86_64.yml](https://github.com/ROCm/TheRock/actions/workflows/publish_build_manylinux_x86_64.yml)           |
 | [`.github/workflows/publish_build_manylinux_rccl_x86_64.yml`](/.github/workflows/publish_build_manylinux_rccl_x86_64.yml) | [actions/workflows/publish_build_manylinux_rccl_x86_64.yml](https://github.com/ROCm/TheRock/actions/workflows/publish_build_manylinux_rccl_x86_64.yml) |
 | [`.github/workflows/publish_no_rocm_image_ubuntu24_04.yml`](/.github/workflows/publish_no_rocm_image_ubuntu24_04.yml)     | [actions/workflows/publish_no_rocm_image_ubuntu24_04.yml](https://github.com/ROCm/TheRock/actions/workflows/publish_no_rocm_image_ubuntu24_04.yml)     |
+| [`.github/workflows/release-sglang-dev-daily-image.yml`](/.github/workflows/release-sglang-dev-daily-image.yml)           | [actions/workflows/release-sglang-dev-daily-image.yml](https://github.com/ROCm/TheRock/actions/workflows/release-sglang-dev-daily-image.yml)           |
+
+**Note:** The `release-sglang-dev-daily-image.yml` workflow uses a custom build process (not `publish_dockerfile.yml`)
+to install TheRock artifacts during Docker build and runs on a nightly schedule.
 
 Tags for built docker images are set based on the branch name pattern:
 

--- a/dockerfiles/sglang_dev.Dockerfile
+++ b/dockerfiles/sglang_dev.Dockerfile
@@ -1,0 +1,208 @@
+# sglang_dev.Dockerfile
+#
+# SGLang Development Environment with TheRock ROCm
+# - Built on Ubuntu 24.04 (configurable via BASE_IMAGE, default: ubuntu:24.04)
+# - Installs ROCm from TheRock artifacts during build
+# - Includes PyTorch ROCm, SGLang, and related ML/AI tools
+#
+# Build arguments:
+# - BASE_IMAGE: Base Docker image (default: ubuntu:24.04)
+# - THEROCK_VERSION: TheRock ROCm version (e.g., 7.12.0a20260318)
+# - AMDGPU_FAMILY: AMD GPU family (default: gfx950)
+# - RELEASE_TYPE: Release type (default: nightlies)
+# - PYTHON_VERSION: Python version (default: 3.12, must match base image)
+# - TORCH_INDEX: PyTorch wheel index URL (default: gfx950-dcgpu nightlies)
+# - GPU_ARCH: GPU architecture for kernel compilation (default: gfx950)
+#
+# Build example:
+#   docker build \
+#     --build-arg THEROCK_VERSION=7.12.0a20260318 \
+#     --build-arg AMDGPU_FAMILY=gfx950 \
+#     -f dockerfiles/sglang_dev.Dockerfile \
+#     -t sglang-dev:gfx950-7.12.0a20260318 \
+#     dockerfiles/
+#
+# Run example:
+#   docker run --rm -it --device=/dev/kfd --device=/dev/dri \
+#     --security-opt seccomp=unconfined \
+#     sglang-dev:latest bash
+
+ARG BASE_IMAGE=ubuntu:24.04
+FROM ${BASE_IMAGE}
+
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-lc"]
+
+# ---- TheRock ROCm Installation ----
+ARG THEROCK_VERSION
+ARG AMDGPU_FAMILY=gfx950
+ARG RELEASE_TYPE=nightlies
+
+# Copy installation scripts
+COPY install_rocm_deps.sh /tmp/
+COPY install_rocm_tarball.sh /tmp/
+
+# Install system dependencies for ROCm
+RUN chmod +x /tmp/install_rocm_deps.sh && \
+    /tmp/install_rocm_deps.sh
+
+# Install ROCm from TheRock tarball
+# Tarball extracts to /opt/rocm-{VERSION}/, with symlink /opt/rocm -> /opt/rocm-{VERSION}
+RUN chmod +x /tmp/install_rocm_tarball.sh && \
+    /tmp/install_rocm_tarball.sh \
+        "${THEROCK_VERSION}" \
+        "${AMDGPU_FAMILY}" \
+        "${RELEASE_TYPE}" && \
+    rm -f /tmp/install_rocm_deps.sh /tmp/install_rocm_tarball.sh
+
+# Configure ROCm environment variables
+ENV ROCM_PATH=/opt/rocm
+ENV PATH="/opt/rocm/bin:${PATH}"
+
+# ---- AMD SMI Installation (optional) ----
+# Installs AMD SMI Python package from ROCm distribution if available
+# Uncomment the following lines to enable:
+# RUN set -eux; \
+#     if [ -d "/opt/rocm/share/amd_smi" ]; then \
+#       cd /opt/rocm/share/amd_smi && python3 -m pip install --no-cache-dir . ; \
+#     fi
+
+# ---- Base OS dependencies ----
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential \
+      python3 python3-dev python3-pip python-is-python3 \
+      wget git \
+      kmod pciutils \
+      ca-certificates \
+      libstdc++-12-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip tooling
+RUN python3 -m pip install --no-cache-dir -U pip setuptools setuptools_scm wheel
+
+# ---- PyTorch ROCm wheels ----
+# PyTorch wheel index - maps to GPU architecture
+# Common mappings:
+#   gfx950  → https://rocm.nightlies.amd.com/v2-staging/gfx950-dcgpu/
+#   gfx942  → https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/
+#   gfx94X  → https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu/
+# Override via --build-arg TORCH_INDEX=... if needed
+ARG TORCH_INDEX=https://rocm.nightlies.amd.com/v2-staging/gfx950-dcgpu/
+ARG TORCH_VER="2.10.0"
+ARG TORCHVISION_VER="0.25.0"
+ARG TORCHAUDIO_VER="2.10.0"
+
+RUN python3 -m pip install --no-cache-dir numpy \
+    && python3 -m pip install --no-cache-dir \
+         --index-url "${TORCH_INDEX}" \
+         "torch==${TORCH_VER}" \
+         "torchvision==${TORCHVISION_VER}" \
+         "torchaudio==${TORCHAUDIO_VER}"
+
+# Record installed packages
+RUN python3 -m pip freeze
+
+# ---- SGLang Build Configuration ----
+ENV BUILD_VLLM="0"
+ENV BUILD_TRITON="0"
+ENV BUILD_LLVM="0"
+ENV BUILD_AITER_ALL="0"
+ENV BUILD_MOONCAKE="0"
+
+# GPU architecture configuration
+ARG GPU_ARCH=gfx950
+ENV GPU_ARCH_LIST=${GPU_ARCH%-*}
+ENV PYTORCH_ROCM_ARCH=gfx942;gfx950
+
+# Repository configuration
+ARG SGL_REPO="https://github.com/sgl-project/sglang.git"
+ARG SGL_DEFAULT="main"
+ARG SGL_BRANCH=060720c5733d3b0dce208f978fb424c851fe109a
+
+# Version override for setuptools_scm (used in nightly builds)
+ARG SETUPTOOLS_SCM_PRETEND_VERSION=""
+
+WORKDIR /sgl-workspace
+
+# ---- Install base dependencies ----
+RUN apt-get purge -y sccache || true; \
+    python -m pip uninstall -y sccache || true; \
+    rm -f "$(which sccache)" || true
+
+# Initialize ROCm SDK
+RUN pip install --no-cache-dir --index-url "${TORCH_INDEX}" 'rocm[libraries,devel,profilers]' \
+    && rocm-sdk init
+
+# Python version (must match base image: Ubuntu 24.04 uses Python 3.12)
+ARG PYTHON_VERSION=3.12
+
+ENV CPATH=/usr/local/lib/python${PYTHON_VERSION}/dist-packages/_rocm_sdk_devel/include
+ENV LIBRARY_PATH=/usr/local/lib/python${PYTHON_VERSION}/dist-packages/_rocm_sdk_devel/lib
+
+# Install SGLang dependencies
+RUN pip install --no-cache-dir \
+    IPython \
+    orjson \
+    python-multipart \
+    torchao==0.9.0 \
+    pybind11
+
+# ---- Build SGLang ----
+ARG BUILD_TYPE=all
+ENV SGLANG_USE_AITER=0
+
+RUN pip uninstall -y sgl_kernel sglang || true
+
+RUN git clone ${SGL_REPO} \
+    && cd sglang \
+    && if [ "${SGL_BRANCH}" = ${SGL_DEFAULT} ]; then \
+         echo "Using ${SGL_DEFAULT}, default branch."; \
+         git checkout ${SGL_DEFAULT}; \
+       else \
+         echo "Using ${SGL_BRANCH} branch."; \
+         git checkout ${SGL_BRANCH}; \
+       fi \
+    && cd sgl-kernel \
+    && rm -f pyproject.toml \
+    && mv pyproject_rocm.toml pyproject.toml \
+    && AMDGPU_TARGET=$GPU_ARCH_LIST python setup_rocm.py install \
+    && cd .. \
+    && rm -rf python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml \
+    && if [ "$BUILD_TYPE" = "srt" ]; then \
+         export SETUPTOOLS_SCM_PRETEND_VERSION="${SETUPTOOLS_SCM_PRETEND_VERSION}" && python -m pip --no-cache-dir install -e "python[srt_hip,diffusion_hip]"; \
+       else \
+         export SETUPTOOLS_SCM_PRETEND_VERSION="${SETUPTOOLS_SCM_PRETEND_VERSION}" && python -m pip --no-cache-dir install -e "python[all_hip]"; \
+       fi
+
+# Patch SGLang to not use AITER
+RUN sed -i '11 s/^_is_hip.*/_is_hip = False/' /sgl-workspace/sglang/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py; \
+   sed -i '26 s/^_is_hip.*/_is_hip = False/' /sgl-workspace/sglang/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py;
+
+RUN python -m pip cache purge
+
+# ---- Python development tools ----
+RUN python3 -m pip install --no-cache-dir \
+    py-spy \
+    pre-commit \
+    tabulate
+
+# ---- Performance environment variables ----
+# Skip CuDNN compatibility check - not applicable for ROCm (uses MIOpen instead)
+ENV SGLANG_DISABLE_CUDNN_CHECK=1
+ENV HIP_FORCE_DEV_KERNARG=1
+ENV HSA_NO_SCRATCH_RECLAIM=1
+ENV SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1
+ENV SGLANG_INT4_WEIGHT=0
+ENV SGLANG_MOE_PADDING=1
+ENV SGLANG_ROCM_DISABLE_LINEARQUANT=0
+ENV SGLANG_ROCM_FUSED_DECODE_MLA=1
+ENV SGLANG_SET_CPU_AFFINITY=1
+ENV SGLANG_USE_ROCM700A=1
+
+ENV NCCL_MIN_NCHANNELS=112
+ENV ROCM_QUICK_REDUCE_QUANTIZATION=INT8
+ENV TORCHINDUCTOR_MAX_AUTOTUNE=1
+ENV TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE=1
+
+# Default command
+CMD ["bash"]


### PR DESCRIPTION
This commit introduces automated nightly builds for SGLang development environments using TheRock ROCm artifacts, following existing TheRock patterns for Docker image publishing.

- Nightly scheduled build workflow (6 AM UTC, after TheRock artifacts)
- Manual trigger with configurable TheRock version and GPU family
- Auto-trigger on Dockerfile changes to main or stage/docker/** branches
- Publishes to ghcr.io/rocm/sglang_dev with version-family tags (e.g., 7.12.0a20260318-gfx950)

- Based on Ubuntu 24.04 (parameterized via BASE_IMAGE)
- Installs ROCm from TheRock nightly artifacts during build (using install_rocm_tarball.sh infrastructure)
- Includes PyTorch ROCm from AMD nightly wheels
- Builds SGLang with ROCm/HIP support
- Configurable for multiple GPU architectures via build args
- Python 3.12 support (parameterized via PYTHON_VERSION)
- PyTorch index mapping documented for different GPU families
- Optimized performance environment variables for ROCm

- Added documentation section for sglang_dev.Dockerfile
- Added workflow to the publishing workflows table
- Documented all build arguments with examples
- Added PyTorch index mappings for different GPU architectures
- Noted custom build process (not using publish_dockerfile.yml)

1. **TheRock Integration**: First automated Docker image to consume TheRock artifacts during build (not at runtime)

2. **Nightly Builds**: Automatic daily builds ensure latest ROCm stack

3. **Build-time Artifact Installation**: Uses install_rocm_tarball.sh to download and install TheRock ROCm during Docker build

4. **Follows TheRock Patterns**:
   - Similar trigger structure to other publish workflows
   - Uses same GitHub Actions (docker/build-push-action, etc.)
   - Publishes to ghcr.io with version-family tagging scheme
   - Uses ubuntu:24.04 as standard base (parameterized)
   - Python 3.12 as standard (parameterized)

5. **Flexible Configuration**: Build args for TheRock version, GPU family, PyTorch index, Python version, and base image
   - Supports matrix builds via ARG override pattern
   - ARG defaults allow single builds without extra configuration

6. **AMD SMI Support**: Included as commented-out optional section

- BASE_IMAGE: Base Docker image (default: ubuntu:24.04)
- THEROCK_VERSION: TheRock ROCm version
- AMDGPU_FAMILY: AMD GPU family (default: gfx950)
- RELEASE_TYPE: Release type (default: nightlies)
- PYTHON_VERSION: Python version (default: 3.12)
- TORCH_INDEX: PyTorch wheel index URL (with documented mappings)
- GPU_ARCH: GPU architecture for kernel compilation (default: gfx950)

- gfx950  → gfx950-dcgpu
- gfx942  → gfx94X-dcgpu

Build locally:
```bash
docker build \
  --build-arg THEROCK_VERSION=7.12.0a20260318 \
  --build-arg AMDGPU_FAMILY=gfx950 \
  -f dockerfiles/sglang_dev.Dockerfile \
  -t sglang-dev:test \
  dockerfiles/
```

Run:
```bash
docker run --rm -it --device=/dev/kfd --device=/dev/dri \
  --security-opt seccomp=unconfined \
  sglang-dev:test bash
```

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
