### PR TITLE
Fix amdrocm-amdsmi7.11 dependency error in amdrocm-test rpm

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -631,6 +631,7 @@
     "BuildArch": "x86_64",
     "DEBDepends": [
       "amdrocm-runtime",
+      "amdrocm-amdsmi",
       "amdrocm-blas-devel"
     ],
     "RPMRequires": [
@@ -1207,11 +1208,13 @@
       "libc6",
       "amdrocm-runtime",
       "amdrocm-sysdeps",
+      "amdrocm-amdsmi",
       "amdrocm-profiler-base"
     ],
     "RPMRequires": [
       "amdrocm-runtime",
       "amdrocm-sysdeps",
+      "amdrocm-amdsmi",
       "amdrocm-profiler-base"
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
@@ -1725,7 +1728,6 @@
     "RPMRequires": [
       "amdrocm-base",
       "amdrocm-profiler-base",
-      "amdrocm-amdsmi",
       "amdrocm-rccl-devel"
     ],
     "Maintainer": "RCCL Maintainer <rccl-maintainer@amd.com>",
@@ -1762,10 +1764,12 @@
     "DEBDepends": [
       "libc6",
       "amdrocm-base",
+      "amdrocm-amdsmi",
       "amdrocm-profiler-base"
     ],
     "RPMRequires": [
       "amdrocm-base",
+      "amdrocm-amdsmi",
       "amdrocm-profiler-base"
     ],
     "Maintainer": "RCCL Maintainer <rccl-maintainer@amd.com>",
@@ -1900,7 +1904,6 @@
       "amdrocm-dnn-devel"
     ],
     "RPMRequires": [
-      "amdrocm-amdsmi",
       "amdrocm-dnn-devel"
     ],
     "Maintainer": "MIOpen Maintainer <miopen-lib.support@amd.com>",


### PR DESCRIPTION
## Motivation

Resolve amdrocm-amdsmi7.11 dependency error seen when installing amdrocm-test on rpm 

## Technical Details

Adding direct dependency to amdrocm-amdsmi package in test packages for rpm 

## Test Plan

Install rpm test packages "amdrocm-blas-test", "amdrocm-dnn-test", or "amdrocm-rccl-test", and ensure amdrocm-amdsmi7.11 is no logner used

## Test Result

passed: https://github.com/ROCm/TheRock/actions/runs/23258835228

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
