### PR TITLE
[ci] Run full tests during PR and push to `release/therock-*`

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -665,8 +665,6 @@ def main(base_args, linux_families, windows_families):
             combined_test_labels = list(set(linux_test_output + windows_test_output))
             test_type = "full"
             test_type_reason = f"test label(s) specified: {combined_test_labels}"
-            # Functional tests run on nightly/scheduled builds
-            run_functional_tests = True
     else:
         # Conditionally build and conditionally run full tests for other
         # triggers (pull_request), based on modified paths and other inputs.
@@ -718,6 +716,12 @@ def main(base_args, linux_families, windows_families):
                     test_type = filter_type
                     test_type_reason = f"test filter label specified: {label}"
                     break
+
+        # If the branch is "release/therock-*", we run full tests
+        branch_name = base_args.get("branch_name", "")
+        if branch_name.startswith("release/therock-"):
+            test_type = "full"
+            test_type_reason = f"branch name '{branch_name}' indicates release branch -> running full tests"
 
     print(f"test_type decision: '{test_type}' (reason: {test_type_reason})")
 

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -344,6 +344,40 @@ class ConfigureCITest(unittest.TestCase):
             base_args, {"amdgpu_families": "gfx94X"}, {"amdgpu_families": "gfx110X"}
         )
 
+    @patch("subprocess.run")
+    def test_pr_release_branch_ci_run(self, mock_run):
+        base_args = {
+            "build_variant": "release",
+            "github_event_name": "pull_request",
+            "branch_name": "release/therock-7.9",
+            "base_ref": "HEAD^",
+        }
+        mock_process = MagicMock()
+        mock_process.stdout = ".github/workflows/ci.yml"
+        mock_run.return_value = mock_process
+        captured_out = io.StringIO()
+        captured_err = io.StringIO()
+        with redirect_stdout(captured_out), redirect_stderr(captured_err):
+            configure_ci.main(base_args, {}, {})
+        self.assertIn('"test_type": "full"', captured_out.getvalue())
+
+    @patch("subprocess.run")
+    def test_push_release_branch_ci_run(self, mock_run):
+        base_args = {
+            "build_variant": "release",
+            "github_event_name": "push",
+            "branch_name": "release/therock-7.9",
+            "base_ref": "HEAD^",
+        }
+        mock_process = MagicMock()
+        mock_process.stdout = ".github/workflows/ci.yml"
+        mock_run.return_value = mock_process
+        captured_out = io.StringIO()
+        captured_err = io.StringIO()
+        with redirect_stdout(captured_out), redirect_stderr(captured_err):
+            configure_ci.main(base_args, {}, {})
+        self.assertIn('"test_type": "full"', captured_out.getvalue())
+
     def test_skip_ci_label(self):
         base_args = {
             "pr_labels": '{"labels":[{"name":"skip-ci"},{"name":"test:hipblaslt"},{"name":"test:rocblas"},{"name":"gfx94X-linux"},{"name":"gfx110X-linux"},{"name":"gfx110X-windows"},{"name":"test_runner:oem"}]}',


### PR DESCRIPTION
Currently, [PRs and pushes to `release-therock-*` does not run proper testing](https://github.com/ROCm/TheRock/pull/4007). It only runs quick tests (depending on what code changed)

Changes here:
- if branch name is `release/therock-*`, we run full tests on pushes and PRs

As test selection filter is after multi-arch logic, this will work for multi-arch