### PR TITLE
Rename CI labels to use `ci:` namespace

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -394,18 +394,18 @@ def matrix_generator(
                 print(
                     f"    Label '{label}' matched 'test:*' pattern -> test: {test_name}"
                 )
-            # If the "skip-ci" label was added, we skip all builds and tests
+            # If the "ci:skip" label was added, we skip all builds and tests
             # We don't want to check for anymore labels
-            if "skip-ci" == label:
-                print(f"    Label 'skip-ci' detected -> skipping all builds and tests")
+            if "ci:skip" == label:
+                print(f"    Label 'ci:skip' detected -> skipping all builds and tests")
                 selected_target_names = []
                 selected_test_names = []
                 requested_target_names = []
                 requested_test_names = []
                 break
-            if "run-all-archs-ci" == label:
+            if "ci:run-all-archs" == label:
                 print(
-                    f"    Label 'run-all-archs-ci' detected -> enabling all architectures"
+                    f"    Label 'ci:run-all-archs' detected -> enabling all architectures"
                 )
                 selected_target_names = [
                     target

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -346,7 +346,7 @@ class ConfigureCITest(unittest.TestCase):
 
     def test_skip_ci_label(self):
         base_args = {
-            "pr_labels": '{"labels":[{"name":"skip-ci"},{"name":"test:hipblaslt"},{"name":"test:rocblas"},{"name":"gfx94X-linux"},{"name":"gfx110X-linux"},{"name":"gfx110X-windows"},{"name":"test_runner:oem"}]}',
+            "pr_labels": '{"labels":[{"name":"ci:skip"},{"name":"test:hipblaslt"},{"name":"test:rocblas"},{"name":"gfx94X-linux"},{"name":"gfx110X-linux"},{"name":"gfx110X-windows"},{"name":"test_runner:oem"}]}',
             "build_variant": "release",
         }
         linux_target_output, linux_test_labels = configure_ci.matrix_generator(

--- a/docs/development/ci_behavior_manipulation.md
+++ b/docs/development/ci_behavior_manipulation.md
@@ -23,12 +23,12 @@ For `pull_request`, TheRock CI collects the `amdgpu_family_info_matrix_presubmit
 
 However, if additional options are wanted, you can add a label to manipulate the behavior. The labels we provide are:
 
-- `skip-ci`: The CI will skip all builds and tests
-- `run-all-archs-ci`: The CI will build all possible architectures
-- `gfx...`: A build and test (if a test machine is available) is added to the CI matrix for the specified gfx family. (ex: `gfx120X`, `gfx950`)
-- `test:...`: The full test will run only for the specified label and other labeled projects (ex: `test:rocthrust`, `test:hipblaslt`)
-- `test_runner:...`: The CI will run tests on only custom test machines (ex: `test_runner:oem`)
-- `test_filter:...`: The CI will run tests based on the specified filter (ex: `test_filter:comprehensive`). [test_filtering.md](./test_filtering.md) has additional information on allowed test filters.
+- `ci:skip`: Skip all builds and tests
+- `ci:run-all-archs`: Build and test all possible architectures
+- `gfx...`: Add a build and test (if a test machine is available) for the specified gfx family (e.g. `gfx120X`, `gfx950`)
+- `test:...`: Run full tests only for the specified label and other labeled projects (e.g. `test:rocthrust`, `test:hipblaslt`)
+- `test_runner:...`: Run tests on only custom test machines (e.g. `test_runner:oem`)
+- `test_filter:...`: Run tests based on the specified filter (e.g. `test_filter:comprehensive`). See [test_filtering.md](./test_filtering.md) for allowed test filters.
 
 ### Workflow dispatch behavior
 


### PR DESCRIPTION
## Motivation

As part of these issues, multi-arch CI is going to need CI configuration support:
* https://github.com/ROCm/TheRock/issues/3337
* https://github.com/ROCm/TheRock/issues/3399

Rather than add more labels to the "root namespace" (no `namespace:` prefix), I'd like to standardize on the `ci:` namespace so we get alphabetical sorting and developers can more easily see which labels will be used by the CI systems.

## Technical Details

Original label name | New label name
-- | --
`skip-ci` | `ci:skip`
`run-all-archs-ci` | `ci:run-all-archs`

## Rollout Plan

We can either add new labels or rename the existing labels. I'd rather rename the existing labels, but then any open PRs using the old code and old labels will break. There are only a few such PRs though:
* https://github.com/ROCm/TheRock/pulls?q=is%3Aopen+is%3Apr+label%3Askip-ci
* https://github.com/ROCm/TheRock/pulls?q=is%3Aopen+is%3Apr+label%3Arun-all-archs-ci+

Given that, I plan on
1. Getting approval on this PR
2. Renaming the labels
3. Adding "ci:skip" to this PR and confirming that it works
4. Merging this PR

If the test in (3) fails, I'll revert the renaming.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
