### PR TITLE
RFC0010: update status after Steps 1–3 completion

### DIFF
--- a/docs/rfcs/RFC0010-Test-Scripts-Migration.md
+++ b/docs/rfcs/RFC0010-Test-Scripts-Migration.md
@@ -1,8 +1,8 @@
 ---
 author: Joseph Macaranas (jayhawk-commits)
 created: 2026-03-11
-modified: 2026-03-11
-status: draft
+modified: 2026-03-18
+status: in-progress
 discussion: https://github.com/ROCm/TheRock/discussions/3964
 ---
 
@@ -40,8 +40,8 @@ within the owning repos. Three options are considered:
 Scripts live alongside the project source under a standard subdirectory:
 
 ```
-rocm-systems/projects/amdsmi/tests/therock/test_amdsmi.py
-rocm-libraries/projects/hipblas/tests/therock/test_hipblas.py
+rocm-systems/projects/amdsmi/test/therock/test_amdsmi.py
+rocm-libraries/projects/hipblas/test/therock/test_hipblas.py
 ```
 
 **Pros:** Tightest coupling to source; easy to find from within a project.
@@ -49,15 +49,15 @@ rocm-libraries/projects/hipblas/tests/therock/test_hipblas.py
 runners across a repo; some projects already have a `tests/` directory with
 different conventions.
 
-### Option B — Centralized `tests/therock/` per repo
+### Option B — Centralized `test/therock/` per repo
 
 All TheRock integration test runners for a given repo live under a single
 top-level directory:
 
 ```
-rocm-systems/tests/therock/test_amdsmi.py
-rocm-systems/tests/therock/test_rccl.py
-rocm-libraries/tests/therock/test_hipblas.py
+rocm-systems/test/therock/test_amdsmi.py
+rocm-systems/test/therock/test_rccl.py
+rocm-libraries/test/therock/test_hipblas.py
 ```
 
 **Pros:** Single location to discover and run all TheRock integration tests
@@ -73,41 +73,67 @@ Keep all scripts in `TheRock` but move them to a more intentional home such as
 **Cons:** Does not resolve the ownership or discoverability problems; component
 teams still submit test PRs to the wrong repo.
 
+## Chosen Approach
+
+**Initial migration: Option B** — all scripts land in `test/therock/` at the
+repo root of `rocm-systems` and `rocm-libraries`. This minimises the number of
+codeowner approvals required (one `CODEOWNERS` entry per repo rather than one
+per project subdirectory) and provides a single predictable location for CI to
+reference.
+
+**Long-term goal: Option A** — once scripts are stable and owned by the right
+teams inside each super-repo, they will be moved to sit alongside
+`test_categories.yaml` in each project's own test subdirectory. That second move
+is a follow-on RFC.
+
 ## Migration Plan
 
-### Step 1: Inventory and map all scripts
+### Step 1: Inventory and map all scripts ✅
 
 Produce a complete mapping of every script to its owning repo and target path.
+See the [Step 1 Inventory](#step-1-inventory) section below.
 
-### Step 2: Create a temporary sync workflow in `TheRock`
+### Step 2: Copy scripts into owning repos ✅
 
-Add a GitHub Actions workflow that copies scripts **from
-`TheRock`'s existing `test_executable_scripts/`** into the agreed canonical
-paths in `rocm-systems` and `rocm-libraries` (e.g., opening a PR in each repo).
-This seeds the owning repos from the current source of truth so that Step 3
-work (cleanup, CODEOWNERS, path fixes) can happen there without starting from
-scratch. This workflow is **temporary** and will be removed in the final step.
+Manually copy scripts from `TheRock` at commit `fc47892f1` into `test/therock/`
+in each owning repo, opening a PR per repo to seed the canonical location.
 
-### Step 3: Finalize scripts in owning repos
+- rocm-systems: [PR #4190](https://github.com/ROCm/rocm-systems/pull/4190)
+- rocm-libraries: [PR #5563](https://github.com/ROCm/rocm-libraries/pull/5563)
+
+Note: the scripts are not usable from their new locations until Step 3 is
+complete and the updated submodule refs have been picked up by TheRock (Step 4).
+
+### Step 3: Finalize scripts in owning repos ✅
 
 For each script, refine the seeded copy in the owning repo:
 
-- Remove `TheRock`-specific path assumptions (e.g., `SCRIPT_DIR.parent.parent.parent`)
-  and replace with environment-variable-driven paths already used by many scripts
-  (e.g., `THEROCK_BIN_DIR`).
-- Resolve the `github_actions_api` import dependency — either vendor the
-  needed helpers, expose them as a small installable package, or accept an
-  import from a checked-out `TheRock` path.
-- Add or update `CODEOWNERS` entries for the new path.
-- Add a brief docstring or `README` note explaining how to run the script.
+- **Path resolution**: Replace the hardcoded `SCRIPT_DIR.parent.parent.parent`
+  fallback with `Path(os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent).resolve()`
+  so scripts work both when the super-repo is a TheRock submodule and when run
+  standalone with `THEROCK_DIR` pointing to a checked-out TheRock installation.
+  Done in rocm-systems [PR #4197](https://github.com/ROCm/rocm-systems/pull/4197)
+  and rocm-libraries [PR #5572](https://github.com/ROCm/rocm-libraries/pull/5572).
+- **`github_actions_api` import**: Scripts that import helpers via `sys.path`
+  automatically benefit from the corrected `THEROCK_DIR`. `test_rccl.py` required
+  an explicit header reorder so `THEROCK_DIR` is defined before the `sys.path`
+  insertion that depends on it.
+- **`CODEOWNERS`**: Add entries for `test/therock/` in each repo.
+- **README**: Add a note explaining how to run the scripts locally.
 
 ### Step 4: Update CI workflow references
+
+> **Blocked**: This step requires the submodule refs for `rocm-systems` and
+> `rocm-libraries` to be bumped in TheRock, incorporating the changes from
+> Steps 2 and 3. Only once those updated refs are present in TheRock can the
+> CI callers be safely switched to the new script locations. This will be done
+> in a separate PR.
 
 Update all `pytest` invocations that reference
 `build_tools/github_actions/test_executable_scripts/test_X.py` to point to the
 new canonical locations. Known callers:
 
-- `TheRock/.github/workflows/unit_tests.yml`
+- `TheRock/build_tools/github_actions/fetch_test_configurations.py`
 - `rocm-systems/.github/workflows/therock-rccl-test-packages-single-node.yml`
 - Any additional callers discovered during the Step 1 inventory.
 
@@ -116,19 +142,142 @@ new canonical locations. Known callers:
 Run a full CI pass with updated workflow references to confirm all tests execute
 correctly from their new locations before removing the old copies.
 
-### Step 6: Remove old scripts and sync workflow
+### Step 6: Remove old scripts from `TheRock`
 
-Once CI is green with all workflows pointing to canonical locations:
+Once CI is green with all workflows pointing to canonical locations, delete
+`TheRock/build_tools/github_actions/test_executable_scripts/` (or the subset
+of migrated files if any are intentionally retained).
 
-- Delete `TheRock/build_tools/github_actions/test_executable_scripts/` (or
-  the subset of migrated files if any are intentionally retained).
-- Delete the temporary sync workflow from `TheRock`.
+## Step 1 Inventory
+
+The tables below map every file in `test_executable_scripts/` to its owning
+repository and target path. Placement follows **Option B** — all scripts for a
+given repo land in a single `test/therock/` directory at the repo root.
+
+### Naming convention
+
+Scripts keep their existing `test_<component>.py` names. In the flat
+`test/therock/` layout every script shares the same directory, so the component
+name in the filename is necessary for disambiguation — there is no redundancy.
+
+Scripts are flagged with the `github_actions_api` helpers they import; see
+[TheRock#3968](https://github.com/ROCm/TheRock/issues/3968) for the planned
+resolution of that dependency once scripts have landed in their owning repos.
+
+**`fetch_test_configurations.py` callers** — indicates whether and how a script
+is invoked from CI (`python`, `pytest`, or `commented-out`). Scripts not listed
+there are currently manual-run only.
+
+### rocm-systems (8 scripts)
+
+| Script                        | Project                        | CI caller   | `github_actions_utils` import | Target path                                |
+| ----------------------------- | ------------------------------ | ----------- | ----------------------------- | ------------------------------------------ |
+| `test_amdsmi.py`              | `projects/amdsmi`              | manual only | —                             | `test/therock/test_amdsmi.py`              |
+| `test_aqlprofile.py`          | `projects/aqlprofile`          | `python`    | —                             | `test/therock/test_aqlprofile.py`          |
+| `test_hiptests.py`            | `projects/hip-tests`           | `python`    | `is_asan`                     | `test/therock/test_hiptests.py`            |
+| `test_rccl.py`                | `projects/rccl`                | `pytest`    | `get_visible_gpu_count`       | `test/therock/test_rccl.py`                |
+| `test_rocprofiler_compute.py` | `projects/rocprofiler-compute` | `python`    | —                             | `test/therock/test_rocprofiler_compute.py` |
+| `test_rocprofiler_systems.py` | `projects/rocprofiler-systems` | `python`    | —                             | `test/therock/test_rocprofiler_systems.py` |
+| `test_rocr-debug-agent.py`    | `projects/rocr-debug-agent`    | `python`    | —                             | `test/therock/test_rocr-debug-agent.py`    |
+| `test_rocrtst.py`             | `projects/rocr-runtime`        | `python`    | —                             | `test/therock/test_rocrtst.py`             |
+
+### rocm-libraries (22 scripts + `hipdnn_install_tests/`)
+
+| Script                   | Project                | CI caller                          | `github_actions_utils` import | Target path                           |
+| ------------------------ | ---------------------- | ---------------------------------- | ----------------------------- | ------------------------------------- |
+| `test_hipblas.py`        | `projects/hipblas`     | `python`                           | `is_asan`                     | `test/therock/test_hipblas.py`        |
+| `test_hipblaslt.py`      | `projects/hipblaslt`   | `python`                           | `is_asan`                     | `test/therock/test_hipblaslt.py`      |
+| `test_hipcub.py`         | `projects/hipcub`      | `python`                           | —                             | `test/therock/test_hipcub.py`         |
+| `test_hipdnn.py`         | `projects/hipdnn`      | `python`                           | —                             | `test/therock/test_hipdnn.py`         |
+| `test_hipdnn_install.py` | `projects/hipdnn`      | `python`                           | —                             | `test/therock/test_hipdnn_install.py` |
+| `test_hipdnn_samples.py` | `projects/hipdnn`      | `python`                           | —                             | `test/therock/test_hipdnn_samples.py` |
+| `test_hipfft.py`         | `projects/hipfft`      | `python`                           | —                             | `test/therock/test_hipfft.py`         |
+| `test_hiprand.py`        | `projects/hiprand`     | `python`                           | —                             | `test/therock/test_hiprand.py`        |
+| `test_hipsolver.py`      | `projects/hipsolver`   | `python`                           | —                             | `test/therock/test_hipsolver.py`      |
+| `test_hipsparse.py`      | `projects/hipsparse`   | `python`                           | —                             | `test/therock/test_hipsparse.py`      |
+| `test_hipsparselt.py`    | `projects/hipsparselt` | `python`                           | —                             | `test/therock/test_hipsparselt.py`    |
+| `test_miopen.py`         | `projects/miopen`      | manual only¹                       | —                             | `test/therock/test_miopen.py`         |
+| `test_rocblas.py`        | `projects/rocblas`     | `python`                           | `is_asan`                     | `test/therock/test_rocblas.py`        |
+| `test_rocfft.py`         | `projects/rocfft`      | `python`                           | —                             | `test/therock/test_rocfft.py`         |
+| `test_rocprim.py`        | `projects/rocprim`     | `python`                           | —                             | `test/therock/test_rocprim.py`        |
+| `test_rocrand.py`        | `projects/rocrand`     | `python`                           | —                             | `test/therock/test_rocrand.py`        |
+| `test_rocroller.py`      | `shared/rocroller`     | `python`                           | —                             | `test/therock/test_rocroller.py`      |
+| `test_rocsolver.py`      | `projects/rocsolver`   | `python`                           | —                             | `test/therock/test_rocsolver.py`      |
+| `test_rocsparse.py`      | `projects/rocsparse`   | `python`                           | —                             | `test/therock/test_rocsparse.py`      |
+| `test_rocthrust.py`      | `projects/rocthrust`   | `python`                           | —                             | `test/therock/test_rocthrust.py`      |
+| `test_rocwmma.py`        | `projects/rocwmma`     | `python`                           | —                             | `test/therock/test_rocwmma.py`        |
+| `hipdnn_install_tests/`  | `projects/hipdnn`      | (used by `test_hipdnn_install.py`) | —                             | `test/therock/hipdnn_install_tests/`  |
+
+¹ The CI `miopen` job uses `test_runner.py` (a generic multi-component runner
+that stays in `TheRock`), not `test_miopen.py` directly. `test_miopen.py` is
+currently manual-run only.
+
+### Standalone submodules — out of scope for initial migration
+
+These scripts test components that live outside both `rocm-systems` and
+`rocm-libraries`. Their destination repos and migration timelines need separate
+discussion.
+
+| Script                     | Source set    | Owning repo (tentative) | CI caller | `github_actions_utils` import |
+| -------------------------- | ------------- | ----------------------- | --------- | ----------------------------- |
+| `test_rocgdb.py`           | `debug-tools` | `ROCm/ROCgdb`           | `python`  | —                             |
+| `test_libhipcxx_hipcc.py`  | `math-libs`   | `ROCm/libhipcxx`        | `python`  | —                             |
+| `test_libhipcxx_hiprtc.py` | `math-libs`   | `ROCm/libhipcxx`        | `python`  | —                             |
+
+### iree-libs / fusilli plugins — out of scope for initial migration
+
+These scripts test Fusilli provider plugins whose build artifacts come from the
+`iree-libs` source set. Their natural home is a Fusilli or IREE repo.
+
+| Script                      | Artifact                    | CI caller     | `github_actions_utils` import |
+| --------------------------- | --------------------------- | ------------- | ----------------------------- |
+| `test_fusilliprovider.py`   | `fusilli_plugin_test_infra` | commented out | —                             |
+| `test_hipblasltprovider.py` | `hipblaslt_plugin`          | `python`      | —                             |
+| `test_miopenprovider.py`    | `miopen_plugin`             | `python`      | —                             |
+
+### Stays in TheRock
+
+| Script           | Reason                                                                                                                        |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `test_sanity.py` | Tests TheRock-level ROCm installation sanity, not a specific component.                                                       |
+| `test_runner.py` | Generic multi-component runner driven by `TEST_COMPONENT` env var; currently used as the CI entry point for the `miopen` job. |
+
+### CI caller summary
+
+The primary CI entry point for all scripts is
+`build_tools/github_actions/fetch_test_configurations.py`, which constructs
+`test_script` strings that reference paths relative to the repo root. That file
+and `test_component.yml` will be the main callers to update in Step 4.
+
+The `rocm-systems` workflow
+`therock-rccl-test-packages-single-node.yml` also directly invokes
+`test_rccl.py` and will need a separate update.
+
+### `github_actions_api` dependency summary
+
+Five scripts have a hard import dependency on helpers from
+`TheRock/build_tools/github_actions/github_actions_api.py` (renamed from
+`github_actions_utils.py` in TheRock @ `76ad42a63`):
+
+| Helper                  | Used by                                                                       |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `is_asan`               | `test_hipblas.py`, `test_hipblaslt.py`, `test_hiptests.py`, `test_rocblas.py` |
+| `get_visible_gpu_count` | `test_rccl.py`                                                                |
+
+These scripts resolve the import via `sys.path` constructed from `THEROCK_DIR`,
+so the dependency is satisfied as long as `THEROCK_DIR` points to a valid
+TheRock checkout. See [TheRock#3968](https://github.com/ROCm/TheRock/issues/3968)
+for longer-term cleanup (vendoring, packaging, or local runnability improvements).
 
 ## Open Questions
 
-- **`github_actions_api` dependency**: Several scripts import shared helpers
-  from a relative path into `TheRock`. The resolution strategy (vendor, package,
-  or reference) should be decided before Step 3 begins.
-- **`hipdnn_install_tests/` subdirectory**: This directory lives alongside the
-  `.py` scripts and must be migrated together with the three `test_hipdnn_*.py`
-  scripts.
+- **`github_actions_api` dependency**: Resolved for Steps 2–3 — scripts use
+  `THEROCK_DIR` to locate and import from TheRock's `build_tools/github_actions/`.
+  Longer-term resolution (vendoring, packaging) tracked in
+  [TheRock#3968](https://github.com/ROCm/TheRock/issues/3968).
+- **`hipdnn_install_tests/` subdirectory**: Resolved — migrated alongside the
+  three `test_hipdnn_*.py` scripts in rocm-libraries
+  [PR #5563](https://github.com/ROCm/rocm-libraries/pull/5563).
+- **Step 4 dependency**: CI caller updates in TheRock are blocked until the
+  rocm-systems and rocm-libraries submodule refs (carrying Steps 2 & 3) are
+  bumped in TheRock. That update and the CI caller changes will be a single PR.


### PR DESCRIPTION
Updates RFC0010 to reflect work completed so far and document the
remaining dependency before CI callers can be updated.

Changes:
- Mark Steps 1, 2, and 3 complete with links to seeding PRs
  (rocm-systems #4190, rocm-libraries #5563) and path-fix PRs
  (rocm-systems #4197, rocm-libraries #5572)
- Document Step 4 as blocked on submodule ref bumps reaching TheRock;
  CI caller updates will be a separate PR once those land
- Remove duplicate "Chosen Approach" section
- Update `github_actions_utils` → `github_actions_api` (renamed @ 76ad42a63)
- Remove `get_first_gpu_architecture` from `test_rocrtst.py` row (dropped in fc47892f1)
- Resolve Open Questions that are now addressed
- Set `status: in-progress`

RFC: https://github.com/ROCm/TheRock/blob/users/jayhawk-commits/rfc0010-update/docs/rfcs/RFC0010-Test-Scripts-Migration.md