### PR TITLE
[CherryPick] Fix for amdrocm-amdsmi dependency error

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -622,6 +622,7 @@
     "BuildArch": "x86_64",
     "DEBDepends": [
       "amdrocm-runtime",
+      "amdrocm-amdsmi",
       "amdrocm-blas-devel"
     ],
     "RPMRequires": [
@@ -1198,11 +1199,13 @@
       "libc6",
       "amdrocm-runtime",
       "amdrocm-sysdeps",
+      "amdrocm-amdsmi",
       "amdrocm-profiler-base"
     ],
     "RPMRequires": [
       "amdrocm-runtime",
       "amdrocm-sysdeps",
+      "amdrocm-amdsmi",
       "amdrocm-profiler-base"
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
@@ -1717,7 +1720,6 @@
     "RPMRequires": [
       "amdrocm-base",
       "amdrocm-profiler-base",
-      "amdrocm-amdsmi",
       "amdrocm-rccl-devel"
     ],
     "Maintainer": "RCCL Maintainer <rccl-maintainer@amd.com>",
@@ -1754,10 +1756,12 @@
     "DEBDepends": [
       "libc6",
       "amdrocm-base",
+      "amdrocm-amdsmi",
       "amdrocm-profiler-base"
     ],
     "RPMRequires": [
       "amdrocm-base",
+      "amdrocm-amdsmi",
       "amdrocm-profiler-base"
     ],
     "Maintainer": "RCCL Maintainer <rccl-maintainer@amd.com>",
@@ -1892,7 +1896,6 @@
       "amdrocm-dnn-devel"
     ],
     "RPMRequires": [
-      "amdrocm-amdsmi",
       "amdrocm-dnn-devel"
     ],
     "Maintainer": "MIOpen Maintainer <miopen-lib.support@amd.com>",


### PR DESCRIPTION
## Motivation

This pull request updates the Linux packaging configuration to ensure that the `amdrocm-amdsmi` package is included as a dependency for several components. This change helps guarantee that the required system management interface is available during installation.

Cherrypick of https://github.com/ROCm/TheRock/pull/4033


## Technical Details

Dependency updates:

* Added `amdrocm-amdsmi` to both `DEBDepends` and `RPMRequires` lists for the main package, ensuring it is installed alongside `amdrocm-runtime` and `amdrocm-blas-devel` (`build_tools/packaging/linux/package.json`).
* Included `amdrocm-amdsmi` as a dependency for profiler-related packages, alongside `amdrocm-runtime`, `amdrocm-sysdeps`, and `amdrocm-profiler-base` (`build_tools/packaging/linux/package.json`).
* Added `amdrocm-amdsmi` to the dependency lists for RCCL-related packages, together with `amdrocm-base` and `amdrocm-profiler-base` (`build_tools/packaging/linux/package.json`).

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
