### PR TITLE
Script To Generate Repro Shell Script

### DIFF
--- a/build_tools/generate_repro_checkout.py
+++ b/build_tools/generate_repro_checkout.py
@@ -4,13 +4,15 @@ import os
 import subprocess
 
 def get_output_for_cmd(cmd_str):
-    return subprocess.run(cmd_str,shell=True,stdout=subprocess.PIPE).stdout
+    return subprocess.run(cmd_str,shell=True,text=True,stdout=subprocess.PIPE).stdout
 
 def recurse_git_diff(diffcmd):
-    lines = map(get_output_for_cmd(diffcmd).readlines(),str.rstrip)
+    lines = list(map(str.rstrip,get_output_for_cmd(diffcmd).split('\n')))
     i=0
     while i<len(lines):
         diff_line = lines[i]
+        if diff_line=='':
+            break
         i+=1
         index_line = lines[i]
         if index_line.split(' ')[-1]=="160000":
@@ -18,11 +20,11 @@ def recurse_git_diff(diffcmd):
             submodule_line = lines[i]
             submodule = diff_line.split(' ')[-1][2:]
 
-            sha_dirty = submodule.split(' ')[-1]
+            sha_dirty = submodule_line.split(' ')[-1]
             sha_dirty_parts = sha_dirty.split('-')
             print("pushd "+submodule)
             print("git reset --hard "+sha_dirty_parts[0])
-            if len(sha_dirty_parts > 1) and sha_dirty_parts[1]=="dirty":
+            if len(sha_dirty_parts) > 1 and sha_dirty_parts[1]=="dirty":
                 recurse_git_diff(submodule)
             print("popd")
             i+=1
@@ -34,6 +36,6 @@ def recurse_git_diff(diffcmd):
                 i+=1
             print("DIRTY_EOF")
 
-print("git reset --hard "+get_output_for_cmd("git rev-parse HEAD~1").read().rstrip())
+print("git reset --hard "+get_output_for_cmd("git rev-parse HEAD~1").rstrip())
 recurse_git_diff("git diff")
 recurse_git_diff("git diff HEAD~1")


### PR DESCRIPTION
This script generates a list of shell commands that, when run, will bring a TheRock checkout into the same state used by the CI to run a PR.  This can help with reproducing and debugging CI failures.
