### PR TITLE
Revert "Simplify s3_client auth/credentials setup using boto3 (#4051)"

### DIFF
--- a/build_tools/_therock_utils/artifact_backend.py
+++ b/build_tools/_therock_utils/artifact_backend.py
@@ -217,27 +217,30 @@ class S3Backend(ArtifactBackend):
 
     @property
     def s3_client(self):
-        """Lazy-initialized boto3 S3 client.
-
-        Credentials are resolved through boto3's default credential chain
-        (see https://docs.aws.amazon.com/boto3/latest/guide/credentials.html).
-        Relevant locations are checked in order:
-        1. Environment variables:
-           `AWS_ACCESS_KEY_ID`
-           `AWS_SECRET_ACCESS_KEY`
-           `AWS_SESSION_TOKEN`
-        2. Assume role providers
-        3. Shared credentials file: `AWS_SHARED_CREDENTIALS_FILE`
-        """
+        """Lazy initialization of S3 client."""
         if self._s3_client is None:
             import boto3
+            from botocore import UNSIGNED
             from botocore.config import Config
 
-            self._s3_client = boto3.client(
-                "s3",
-                verify=True,
-                config=Config(max_pool_connections=100),
-            )
+            _access_key_id = os.environ.get("AWS_ACCESS_KEY_ID")
+            _secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+            _session_token = os.environ.get("AWS_SESSION_TOKEN")
+
+            if None not in (_access_key_id, _secret_access_key, _session_token):
+                self._s3_client = boto3.client(
+                    "s3",
+                    verify=True,
+                    aws_access_key_id=_access_key_id,
+                    aws_secret_access_key=_secret_access_key,
+                    aws_session_token=_session_token,
+                )
+            else:
+                self._s3_client = boto3.client(
+                    "s3",
+                    verify=True,
+                    config=Config(max_pool_connections=100, signature_version=UNSIGNED),
+                )
         return self._s3_client
 
     @property

--- a/build_tools/_therock_utils/storage_backend.py
+++ b/build_tools/_therock_utils/storage_backend.py
@@ -185,7 +185,18 @@ def _s3_retry(operation: str, location: str, func, *args, **kwargs):
 
 
 class S3StorageBackend(StorageBackend):
-    """S3 storage backend using boto3."""
+    """S3 storage backend using boto3.
+
+    The S3 client is lazily initialized on first use.  Credentials are
+    resolved through boto3's default credential chain, which checks (in
+    order): environment variables, shared credentials file
+    (``AWS_SHARED_CREDENTIALS_FILE``), instance metadata, etc.  This
+    matches how the ``aws`` CLI resolves credentials.
+
+    ``upload_files()`` uploads in parallel using a thread pool whose size
+    is controlled by *upload_concurrency* (default: 10, matching the AWS
+    CLI).  The boto3 connection pool is sized to match.
+    """
 
     def __init__(
         self,
@@ -199,18 +210,7 @@ class S3StorageBackend(StorageBackend):
 
     @property
     def s3_client(self):
-        """Lazy-initialized boto3 S3 client.
-
-        Credentials are resolved through boto3's default credential chain
-        (see https://docs.aws.amazon.com/boto3/latest/guide/credentials.html).
-        Relevant locations are checked in order:
-        1. Environment variables:
-           `AWS_ACCESS_KEY_ID`
-           `AWS_SECRET_ACCESS_KEY`
-           `AWS_SESSION_TOKEN`
-        2. Assume role providers
-        3. Shared credentials file: `AWS_SHARED_CREDENTIALS_FILE`
-        """
+        """Lazy-initialized boto3 S3 client."""
         if self._s3_client is None:
             import boto3
             from botocore.config import Config

--- a/build_tools/tests/artifact_backend_test.py
+++ b/build_tools/tests/artifact_backend_test.py
@@ -293,6 +293,47 @@ class TestS3Backend(unittest.TestCase):
         """Test that s3_prefix is constructed correctly."""
         self.assertEqual(self.backend.s3_prefix, "external/test-run-456-linux")
 
+    @mock.patch("boto3.client")
+    def test_s3_client_with_credentials(self, mock_boto_client):
+        """Test S3 client initialization with AWS credentials."""
+        mock_client = mock.MagicMock()
+        mock_boto_client.return_value = mock_client
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "AWS_ACCESS_KEY_ID": "test-key",
+                "AWS_SECRET_ACCESS_KEY": "test-secret",
+                "AWS_SESSION_TOKEN": "test-token",
+            },
+        ):
+            backend = S3Backend(output_root=_make_s3_root())
+            # Access client to trigger initialization
+            _ = backend.s3_client
+
+        mock_boto_client.assert_called_once()
+        call_kwargs = mock_boto_client.call_args[1]
+        self.assertEqual(call_kwargs["aws_access_key_id"], "test-key")
+        self.assertEqual(call_kwargs["aws_secret_access_key"], "test-secret")
+        self.assertEqual(call_kwargs["aws_session_token"], "test-token")
+
+    @mock.patch("boto3.client")
+    def test_s3_client_without_credentials(self, mock_boto_client):
+        """Test S3 client initialization without AWS credentials (unsigned)."""
+        mock_client = mock.MagicMock()
+        mock_boto_client.return_value = mock_client
+
+        # Clear any existing credentials
+        with mock.patch.dict(os.environ, {}, clear=True):
+            backend = S3Backend(output_root=_make_s3_root())
+            # Access client to trigger initialization
+            _ = backend.s3_client
+
+        mock_boto_client.assert_called_once()
+        call_kwargs = mock_boto_client.call_args[1]
+        # Should use unsigned config
+        self.assertIn("config", call_kwargs)
+
     @mock.patch.object(S3Backend, "s3_client", new_callable=mock.PropertyMock)
     def test_list_artifacts(self, mock_client_prop):
         """Test listing S3 artifacts (both zstd and xz)."""

--- a/build_tools/tests/storage_backend_test.py
+++ b/build_tools/tests/storage_backend_test.py
@@ -615,6 +615,83 @@ class TestS3StorageBackendMaxPoolConnections(unittest.TestCase):
             self.assertEqual(config.max_pool_connections, 20)
 
 
+class TestS3StorageBackendCredentialResolution(unittest.TestCase):
+    """Verify the S3 client uses boto3's default credential chain.
+
+    CI runners provide credentials via AWS_SHARED_CREDENTIALS_FILE (a
+    credentials.ini mounted into the container).  The explicit env vars
+    (AWS_ACCESS_KEY_ID, etc.) may or may not be set depending on whether
+    the configure-aws-credentials step ran.
+
+    The S3 client must use boto3's default credential chain so that all
+    credential sources are respected - matching how the ``aws`` CLI
+    resolves credentials.  Falling back to UNSIGNED when the explicit
+    env vars are absent would bypass the credentials file entirely.
+    """
+
+    def _assert_not_unsigned(self, mock_boto3):
+        """Assert that boto3.client was NOT called with UNSIGNED config."""
+        from botocore import UNSIGNED
+
+        for call in mock_boto3.call_args_list:
+            config = call.kwargs.get("config")
+            self.assertTrue(
+                config is None or config.signature_version != UNSIGNED,
+                "S3 client must not use UNSIGNED signatures - this bypasses "
+                "the credential chain and breaks uploads on CI runners that "
+                "provide credentials via AWS_SHARED_CREDENTIALS_FILE.",
+            )
+
+    def test_shared_credentials_file_only(self):
+        """When only AWS_SHARED_CREDENTIALS_FILE is set (no explicit
+        key/secret/token), the client must still use the default
+        credential chain - not UNSIGNED."""
+        env = {"AWS_SHARED_CREDENTIALS_FILE": "/home/awsconfig/credentials.ini"}
+        cleared = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+        with mock.patch.dict(os.environ, env, clear=False):
+            for var in cleared:
+                os.environ.pop(var, None)
+            with mock.patch("boto3.client") as mock_boto3:
+                backend = S3StorageBackend()
+                _ = backend.s3_client
+
+                self._assert_not_unsigned(mock_boto3)
+
+    def test_explicit_env_vars(self):
+        """When explicit credential env vars are set (e.g. by
+        configure-aws-credentials), the default chain picks them up."""
+        env = {
+            "AWS_ACCESS_KEY_ID": "key",
+            "AWS_SECRET_ACCESS_KEY": "secret",
+            "AWS_SESSION_TOKEN": "token",
+        }
+        with mock.patch.dict(os.environ, env):
+            with mock.patch("boto3.client") as mock_boto3:
+                backend = S3StorageBackend()
+                _ = backend.s3_client
+
+                self._assert_not_unsigned(mock_boto3)
+
+    def test_no_credentials_at_all(self):
+        """Even with no credential sources, the client must not use
+        UNSIGNED - it should let boto3 raise a clear auth error at
+        call time rather than silently making anonymous requests."""
+        cleared = [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_SHARED_CREDENTIALS_FILE",
+        ]
+        with mock.patch.dict(os.environ, {}, clear=False):
+            for var in cleared:
+                os.environ.pop(var, None)
+            with mock.patch("boto3.client") as mock_boto3:
+                backend = S3StorageBackend()
+                _ = backend.s3_client
+
+                self._assert_not_unsigned(mock_boto3)
+
+
 # ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This reverts commit 01e31f77e1c02640f01e1646717bd63565f3ea35. The changes seem to break the `Validate Artifact Structure` workflow which is failing during fetch:

```
Traceback (most recent call last):
  File "/home/runner/_work/TheRock/TheRock/./build_tools/fetch_artifacts.py", line 386, in <module>
    main(sys.argv[1:])
  File "/home/runner/_work/TheRock/TheRock/./build_tools/fetch_artifacts.py", line 382, in main
    run(args)
  File "/home/runner/_work/TheRock/TheRock/./build_tools/fetch_artifacts.py", line 210, in run
    available_artifacts = list_artifacts_for_group(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/TheRock/TheRock/./build_tools/fetch_artifacts.py", line 88, in list_artifacts_for_group
    all_artifacts = backend.list_artifacts()
                    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/TheRock/TheRock/build_tools/_therock_utils/artifact_backend.py", line 253, in list_artifacts
    for page in page_iterator:
                ^^^^^^^^^^^^^
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/paginate.py", line 272, in __iter__
    response = self._make_request(current_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/context.py", line 123, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/paginate.py", line 360, in _make_request
    return self._method(**current_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/client.py", line 601, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/context.py", line 123, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/client.py", line 1056, in _make_api_call
    http, parsed_response = self._make_request(
                            ^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/client.py", line 1080, in _make_request
    return self._endpoint.make_request(operation_model, request_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/endpoint.py", line 118, in make_request
    return self._send_request(request_dict, operation_model)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/endpoint.py", line 195, in _send_request
    request = self.create_request(request_dict, operation_model)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/endpoint.py", line 131, in create_request
    self._event_emitter.emit(
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/hooks.py", line 412, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/hooks.py", line 256, in emit
    return self._emit(event_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/hooks.py", line 239, in _emit
    response = handler(**kwargs)
               ^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/signers.py", line 108, in handler
    return self.sign(operation_name, request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/signers.py", line 200, in sign
    auth.add_auth(request)
  File "/home/runner/_work/_tool/Python/3.12.13/x64/lib/python3.12/site-packages/botocore/auth.py", line 421, in add_auth
    raise NoCredentialsError()
botocore.exceptions.NoCredentialsError: Unable to locate credentials
Error: Process completed with exit code 1.
```
https://github.com/ROCm/TheRock/actions/runs/23274411292/job/67680316698