### PR TITLE
Add RHEL and SLES support to rocm_runtime.Dockerfile

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -122,7 +122,7 @@ Supporting scripts:
 
 - [`install_rocm_deps.sh`](install_rocm_deps.sh): Auto-detects the distribution
   and installs ROCm runtime dependencies using the appropriate package manager
-  (apt, dnf, or tdnf).
+  (apt, dnf, tdnf, or zypper).
 
 - [`install_rocm_tarball.sh`](install_rocm_tarball.sh): Downloads ROCm tarball
   from `rocm.{nightlies|prereleases|devreleases}.amd.com` or `repo.amd.com` (for

--- a/dockerfiles/install_rocm_deps.sh
+++ b/dockerfiles/install_rocm_deps.sh
@@ -11,6 +11,8 @@
 #   - Ubuntu 22.04, 24.04 (apt)
 #   - AlmaLinux 8 (dnf)
 #   - Azure Linux 3 (tdnf)
+#   - RHEL 8.10, 9.7, 10.1 (dnf)
+#   - SLES 15.7, 16.0 (zypper)
 
 set -e
 
@@ -24,8 +26,20 @@ detect_distro() {
     fi
 }
 
+# Detect distribution version from /etc/os-release
+detect_version() {
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        echo "${VERSION_ID:-unknown}"
+    else
+        echo "unknown"
+    fi
+}
+
 DISTRO=$(detect_distro)
+VERSION_ID=$(detect_version)
 echo "Detected distribution: $DISTRO"
+echo "Detected version: $VERSION_ID"
 
 case "$DISTRO" in
     ubuntu)
@@ -101,9 +115,56 @@ case "$DISTRO" in
         tdnf clean all
         ;;
 
+    rhel)
+        echo "Installing dependencies using dnf for RHEL ${VERSION_ID}..."
+        # Use --allowerasing to handle curl-minimal vs curl conflict in UBI images
+        dnf install -y --setopt=install_weak_deps=False --allowerasing \
+            ca-certificates \
+            curl \
+            libatomic \
+            elfutils-libelf \
+            elfutils-libs \
+            numactl-libs \
+            ncurses-libs \
+            openssl-libs \
+            perl \
+            file \
+            python3 \
+            python3-devel \
+            python3-pip \
+            kmod
+        dnf clean all
+        ;;
+
+    sles)
+        echo "Installing dependencies using zypper for SLES ${VERSION_ID}..."
+
+        # Refresh repos
+        zypper --non-interactive refresh || true
+
+        # Install dependencies
+        zypper --non-interactive install --no-recommends \
+            ca-certificates \
+            curl \
+            tar \
+            libatomic1 \
+            libelf1 \
+            libdw1 \
+            libnuma1 \
+            ncurses-utils \
+            perl \
+            file \
+            kmod \
+            python3 \
+            python3-devel \
+            python3-pip
+
+        zypper clean --all
+        ;;
+
     *)
         echo "Error: Unsupported distribution: $DISTRO"
-        echo "Supported distributions: ubuntu, almalinux, azurelinux"
+        echo "Supported distributions: ubuntu, almalinux, azurelinux, rhel, sles"
         exit 1
         ;;
 esac

--- a/dockerfiles/rocm_runtime.Dockerfile
+++ b/dockerfiles/rocm_runtime.Dockerfile
@@ -29,6 +29,11 @@
 # - ubuntu:24.04
 # - almalinux:8
 # - mcr.microsoft.com/azurelinux/base/core:3.0
+# - registry.access.redhat.com/ubi8/ubi:8.10 (RHEL 8.10)
+# - registry.access.redhat.com/ubi9/ubi:9.7 (RHEL 9.7)
+# - registry.access.redhat.com/ubi10/ubi:10.1 (RHEL 10.1)
+# - registry.suse.com/bci/bci-base:15.7 (SLES 15.7)
+# - registry.suse.com/bci/bci-base:16.0 (SLES 16.0)
 #
 # Build arguments
 # - BASE_IMAGE       : Base Docker image (default: ubuntu:24.04)
@@ -48,7 +53,7 @@
 #     dockerfiles/
 #
 #   # AlmaLinux 8 + gfx94X (nightly)
-#   docker build --network=host \
+#   docker build \
 #     --build-arg BASE_IMAGE=almalinux:8 \
 #     --build-arg VERSION=7.11.0a20251211 \
 #     --build-arg AMDGPU_FAMILY=gfx94X-dcgpu \
@@ -73,6 +78,51 @@
 #     --build-arg RELEASE_TYPE=stable \
 #     -f dockerfiles/rocm_runtime.Dockerfile \
 #     -t rocm:ubuntu22.04-gfx94X-7.10.0 \
+#     dockerfiles/
+#
+#   # RHEL 8.10 UBI + gfx94X (nightly)
+#   docker build \
+#     --build-arg BASE_IMAGE=registry.access.redhat.com/ubi8/ubi:8.10 \
+#     --build-arg VERSION=7.11.0a20251211 \
+#     --build-arg AMDGPU_FAMILY=gfx94X-dcgpu \
+#     -f dockerfiles/rocm_runtime.Dockerfile \
+#     -t rocm-nightly:rhel8.10-gfx94X-7.11.0a20251211 \
+#     dockerfiles/
+#
+#   # RHEL 9.7 UBI + gfx94X (nightly)
+#   docker build \
+#     --build-arg BASE_IMAGE=registry.access.redhat.com/ubi9/ubi:9.7 \
+#     --build-arg VERSION=7.11.0a20251211 \
+#     --build-arg AMDGPU_FAMILY=gfx94X-dcgpu \
+#     -f dockerfiles/rocm_runtime.Dockerfile \
+#     -t rocm-nightly:rhel9.7-gfx94X-7.11.0a20251211 \
+#     dockerfiles/
+#
+#   # RHEL 10.1 UBI + gfx110X (nightly)
+#   docker build \
+#     --build-arg BASE_IMAGE=registry.access.redhat.com/ubi10/ubi:10.1 \
+#     --build-arg VERSION=7.11.0a20251211 \
+#     --build-arg AMDGPU_FAMILY=gfx110X-all \
+#     -f dockerfiles/rocm_runtime.Dockerfile \
+#     -t rocm-nightly:rhel10.1-gfx110X-7.11.0a20251211 \
+#     dockerfiles/
+#
+#   # SLES 15.7 BCI + gfx110X (nightly)
+#   docker build \
+#     --build-arg BASE_IMAGE=registry.suse.com/bci/bci-base:15.7 \
+#     --build-arg VERSION=7.11.0a20251211 \
+#     --build-arg AMDGPU_FAMILY=gfx110X-all \
+#     -f dockerfiles/rocm_runtime.Dockerfile \
+#     -t rocm-nightly:sles15.7-gfx110X-7.11.0a20251211 \
+#     dockerfiles/
+#
+#   # SLES 16.0 BCI + gfx94X (nightly)
+#   docker build \
+#     --build-arg BASE_IMAGE=registry.suse.com/bci/bci-base:16.0 \
+#     --build-arg VERSION=7.11.0a20251211 \
+#     --build-arg AMDGPU_FAMILY=gfx94X-dcgpu \
+#     -f dockerfiles/rocm_runtime.Dockerfile \
+#     -t rocm-nightly:sles16.0-gfx94X-7.11.0a20251211 \
 #     dockerfiles/
 #
 # Run example:


### PR DESCRIPTION
## Motivation

Extend the rocm_runtime.Dockerfile multi-distro support to cover RHEL and SLES distributions, addressing the need for broader enterprise Linux compatibility.

Currently only Ubuntu, AlmaLinux, and Azure Linux are supported. This PR adds RHEL 8/9/10 (via Red Hat UBI images) and SLES 15/16 (via SUSE BCI images), bringing total supported distributions from 3 to 8.

Issue: https://github.com/ROCm/TheRock/issues/2425

## Technical Details

This PR builds on https://github.com/ROCm/TheRock/pull/2572 and https://github.com/ROCm/TheRock/pull/2840.

New supported base images:
  - registry.access.redhat.com/ubi8/ubi:8.10
  - registry.access.redhat.com/ubi9/ubi:9.7
  - registry.access.redhat.com/ubi10/ubi:10.1
  - registry.suse.com/bci/bci-base:15.7
  - registry.suse.com/bci/bci-base:16.0

## Test Plan

Full L2 build for all 8 distros: dependency installation + ROCm tarball download (2.8GB) + extraction + hipcc --version verification.

Test configuration: VERSION=7.13.0a20260317, AMDGPU_FAMILY=gfx110X-all, RELEASE_TYPE=nightlies.

## Test Result

| Distro | Base Image | Build | hipcc --version |
| --- | --- | --- | --- |
| Ubuntu 24.04 | `ubuntu:24.04` | PASS | PASS |
| AlmaLinux 8 | `almalinux:8` | PASS | PASS |
| Azure Linux 3 | `mcr.microsoft.com/azurelinux/base/core:3.0` | PASS | PASS |
| RHEL 8.10 | `registry.access.redhat.com/ubi8/ubi:8.10` | PASS | PASS |
| RHEL 9.7 | `registry.access.redhat.com/ubi9/ubi:9.7` | PASS | PASS |
| RHEL 10.1 | `registry.access.redhat.com/ubi10/ubi:10.1` | PASS | PASS |
| SLES 15.7 | `registry.suse.com/bci/bci-base:15.7` | PASS | PASS |
| SLES 16.0 | `registry.suse.com/bci/bci-base:16.0` | PASS | PASS |

All 8 distros report HIP version 7.12.60700-a4fc20f65c and AMD clang 22.0.0git.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
