### PR TITLE
Enable SPIRV for Comgr builds by default

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -162,8 +162,6 @@ if(THEROCK_ENABLE_COMPILER)
       # symbols inside libamd_comgr.so, preventing symbol interposition without
       # requiring namespace isolation via dlmopen.
       -DCOMGR_STATIC_LLVM=ON
-      # TODO: Currently unstable. Enable in >6.4.
-      -DCOMGR_DISABLE_SPIRV=ON
       -DTHEROCK_HIP_MAJOR_VERSION=${THEROCK_HIP_MAJOR_VERSION}
       -DTHEROCK_HIP_MINOR_VERSION=${THEROCK_HIP_MINOR_VERSION}
       "-DLLVM_VERSION_SUFFIX=-rocm${ROCM_MAJOR_VERSION}"

--- a/compiler/pre_hook_amd-comgr.cmake
+++ b/compiler/pre_hook_amd-comgr.cmake
@@ -1,8 +1,6 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-set(COMGR_DISABLE_SPIRV OFF)
-
 # Enable ASAN for Comgr when THEROCK_SANITIZER is set to ASAN or HOST_ASAN
 if(THEROCK_SANITIZER STREQUAL "ASAN" OR THEROCK_SANITIZER STREQUAL "HOST_ASAN")
   set(ADDRESS_SANITIZER ON)


### PR DESCRIPTION
Comgr will still disable SPIRV APIs and Actions if the SPIRV-LLVM-Translator headers are not found.

Also setting in two different place before conflicted
