### PR TITLE
[CI] Add choco cache server to prevent rate limiting

### DIFF
--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -179,6 +179,8 @@ jobs:
       # TODO(amd-justchen): share with build_windows_artifacts.yml. Include in VM image? Dockerfile?
       - name: Install requirements
         run: |
+          choco source disable -n=chocolatey
+          choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
           choco install --no-progress -y ninja --version 1.13.1
           choco install --no-progress -y awscli
           echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -119,6 +119,8 @@ jobs:
       # TODO(amd-justchen): share with build_windows_artifacts.yml. Include in VM image? Dockerfile?
       - name: Install requirements
         run: |
+          choco source disable -n=chocolatey
+          choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
           choco install --no-progress -y ninja --version 1.13.1
 
       - name: Install sccache

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -189,6 +189,8 @@ jobs:
       # TODO(amd-justchen): share with build_windows_artifacts.yml. Include in VM image? Dockerfile?
       - name: Install requirements
         run: |
+          choco source disable -n=chocolatey
+          choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
           choco install --no-progress -y ccache
           # ninja pinned due to a bug in the 1.13.0 release:
           # https://github.com/ninja-build/ninja/issues/2616


### PR DESCRIPTION
## Motivation

Mitigates CI failures due to `choco install` rate limiting as observed in
https://github.com/ROCm/TheRock/issues/4060
Previously seen https://github.com/ROCm/TheRock/issues/1761

## Technical Details

Prioritizes the use of choco cache server local to the windows build cluster, Nexus as implemented previously here https://github.com/ROCm/TheRock/pull/1764, but propagate the change to remaining workflow files that use choco.

## Test Plan

Observe CI

## Test Result

TBD

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
