### PR TITLE
Add HTTPBackend for read-only artifact downloads from workflow summary index.html

### DIFF
--- a/build_tools/_therock_utils/artifact_backend.py
+++ b/build_tools/_therock_utils/artifact_backend.py
@@ -670,7 +670,4 @@ def create_backend_from_env(
     output_root = WorkflowOutputRoot.from_workflow_run(
         run_id=run_id, platform=platform_name
     )
-    return HTTPBackend(
-        output_root=output_root,
-        gfx_families=targets
-    )
+    return HTTPBackend(output_root=output_root, gfx_families=targets)

--- a/build_tools/_therock_utils/artifact_backend.py
+++ b/build_tools/_therock_utils/artifact_backend.py
@@ -580,7 +580,6 @@ class HTTPBackend(ArtifactBackend):
             # Artifacts are allowed to be downloaded without checksums
             pass
 
-
     def upload_artifact(self, source_path: Path, artifact_key: str) -> None:
         """Upload is not supported - HTTPBackend is read-only."""
         raise NotImplementedError("HTTPBackend is read-only")

--- a/build_tools/_therock_utils/artifact_backend.py
+++ b/build_tools/_therock_utils/artifact_backend.py
@@ -13,9 +13,10 @@ modules manage S3 clients and local directory mirroring. ArtifactBackend has
 download/list/exists operations that StorageBackend doesn't have yet.
 
 Environment-based switching:
-- THEROCK_HTTP_RUN_ID set → use HTTPBackend (read-only)
 - THEROCK_LOCAL_STAGING_DIR set → use LocalDirectoryBackend
-- Otherwise → use S3Backend
+- AWS credentials present → use S3Backend
+- THEROCK_AMDGPU_FAMILIES set → use HTTPBackend (read-only via public HTTPS URLs)
+- Otherwise → use S3Backend (unsigned requests for public buckets)
 """
 
 from abc import ABC, abstractmethod
@@ -26,8 +27,10 @@ import hashlib
 import os
 import re
 import shutil
+import urllib.error
 import urllib.request
 
+from .storage_location import StorageLocation
 from .workflow_outputs import WorkflowOutputRoot
 
 
@@ -339,18 +342,20 @@ class S3Backend(ArtifactBackend):
 class HTTPBackend(ArtifactBackend):
     """Read-only backend for HTTP artifact server.
 
-    Accesses artifacts from:
-    {base_url}/{run_id}-{platform}/
+    Uses WorkflowOutputRoot.https_url for all artifact downloads, which automatically
+    constructs public HTTPS URLs for S3 buckets (e.g., https://bucket.s3.amazonaws.com/path).
 
-    Artifacts are organized by gfx target via index-{gfx_family}.html files.
+    Uses WorkflowOutputRoot for path computation, ensuring consistent handling
+    of fork prefixes and bucket selection.
 
     Usage:
         # Create backend for specific run
+        output_root = WorkflowOutputRoot.from_workflow_run(
+            run_id="23309603946", platform="linux"
+        )
         backend = HTTPBackend(
-            run_id="23309603946",
-            platform="linux",
+            output_root=output_root,
             gfx_families=["gfx94X-dcgpu", "gfx1200"],
-            base_url="https://example.com/artifacts"
         )
 
         # List available artifacts (across all specified GFX families)
@@ -359,44 +364,49 @@ class HTTPBackend(ArtifactBackend):
         # Download artifact with checksum verification
         backend.download_artifact("blas_lib_gfx1200.tar.zst", Path("/tmp/blas.tar.zst"))
 
-        # Or use factory function with target families
+        # Or use factory function
         import os
         os.environ["THEROCK_RUN_ID"] = "23309603946"
-        os.environ["THEROCK_HTTP_BASE_URL"] = "https://example.com/artifacts"
+        os.environ["THEROCK_AMDGPU_FAMILIES"] = "gfx94X-dcgpu,gfx1200"
         backend = create_backend_from_env(gfx_families=["gfx94X-dcgpu", "gfx1200"])
 
-    Environment Variables:
+    Environment Variables (when using create_backend_from_env):
         THEROCK_RUN_ID: Workflow run ID (falls back to GITHUB_RUN_ID or "local")
-        THEROCK_HTTP_BASE_URL: Base URL for artifact server (required for HTTP backend)
         THEROCK_AMDGPU_FAMILIES: Comma-separated list of GFX families (e.g., "gfx94X-dcgpu,gfx1200")
         THEROCK_PLATFORM: Platform name (default: "linux")
     """
 
     def __init__(
         self,
-        run_id: str,
-        base_url: str,
+        output_root: WorkflowOutputRoot,
         gfx_families: List[str],
-        platform: str = "linux",
     ):
-        self.run_id = run_id
-        self.base_url = base_url
-        self.platform = platform
+        self.output_root = output_root
         self.gfx_families = gfx_families
         self._artifact_cache: Optional[List[str]] = None  # Lazy-loaded artifact list
 
     @property
     def base_uri(self) -> str:
         """Return the base URI for this backend."""
-        return f"{self.base_url}/{self.run_id}-{self.platform}"
+        return self.output_root.root().https_url
 
     def _download_file(self, url: str, dest: Path) -> None:
-        """Download a file from URL to destination path."""
+        """Download a file from URL to destination path.
+
+        Raises:
+            FileNotFoundError: If the resource does not exist (HTTP 404 or 403)
+            ConnectionError: For network errors (timeouts, DNS failures)
+            urllib.error.HTTPError: For other HTTP errors (500, etc.)
+        """
         dest.parent.mkdir(parents=True, exist_ok=True)
         try:
             urllib.request.urlretrieve(url, dest)
-        except Exception as e:
-            raise FileNotFoundError(f"Failed to download {url}: {e}")
+        except urllib.error.HTTPError as e:
+            if e.code == 404 or e.code == 403:
+                raise FileNotFoundError(f"Not found: {url}") from e
+            raise  # Re-raise 500, 403, etc.
+        except urllib.error.URLError as e:
+            raise ConnectionError(f"Failed to download {url}: {e}") from e
 
     def _parse_index_html(self, html_content: str) -> List[str]:
         """Parse artifact index HTML to extract artifact filenames."""
@@ -417,7 +427,7 @@ class HTTPBackend(ArtifactBackend):
 
     def _fetch_index(self, gfx_family: str) -> List[str]:
         """Fetch artifact list from index-{gfx_family}.html."""
-        index_url = f"{self.base_uri}/index-{gfx_family}.html"
+        index_url = self.output_root.artifact_index(gfx_family).https_url
         try:
             with urllib.request.urlopen(index_url) as response:
                 html_content = response.read().decode("utf-8")
@@ -527,8 +537,8 @@ class HTTPBackend(ArtifactBackend):
             FileNotFoundError: If artifact or checksum not found
             ValueError: If checksum verification fails
         """
-        artifact_url = f"{self.base_uri}/{artifact_key}"
-        checksum_url = f"{artifact_url}.sha256sum"
+        artifact_url = self.output_root.artifact(artifact_key).https_url
+        checksum_url = self.output_root.artifact(f"{artifact_key}.sha256sum").https_url
 
         # Download artifact
         self._download_file(artifact_url, dest_path)
@@ -566,7 +576,7 @@ class HTTPBackend(ArtifactBackend):
             return artifact_key in self._artifact_cache
 
         # Otherwise, try HTTP HEAD request
-        artifact_url = f"{self.base_uri}/{artifact_key}"
+        artifact_url = self.output_root.artifact(artifact_key).https_url
         try:
             req = urllib.request.Request(artifact_url, method="HEAD")
             urllib.request.urlopen(req)
@@ -585,8 +595,7 @@ def create_backend_from_env(
     Backend priority:
     1. Local directory (THEROCK_LOCAL_STAGING_DIR) - highest priority for local dev
     2. S3 with credentials (AWS_* vars present) - CI upload contexts
-    3. HTTP (THEROCK_HTTP_BASE_URL set, no S3 creds) - read-only artifact access
-    4. S3 without credentials - fallback for read-only S3 access
+    3. HTTP (THEROCK_AMDGPU_FAMILIES set, no S3 creds) - read-only via public HTTPS URLs
 
     Args:
         run_id: Override run ID (default: THEROCK_RUN_ID or GITHUB_RUN_ID or "local")
@@ -599,15 +608,15 @@ def create_backend_from_env(
     - THEROCK_RUN_ID: Workflow run ID (default: GITHUB_RUN_ID or "local")
     - THEROCK_PLATFORM: Override platform (default: current platform)
     - THEROCK_LOCAL_STAGING_DIR: If set, use local backend
-    - AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN: If all present,
-      prioritize S3 backend for upload capability (CI contexts)
-    - THEROCK_HTTP_BASE_URL: Base URL for HTTP artifact server
-      (if set and no S3 credentials, use HTTP backend for read-only access)
+    - AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY: If both present,
+      prioritize S3 backend for upload capability (CI contexts).
+      Note: AWS_SESSION_TOKEN is optional (only for temporary credentials).
     - THEROCK_AMDGPU_FAMILIES: Comma-separated list of GFX families (e.g., "gfx94X-dcgpu,gfx1200")
-      Required for HTTP backend if gfx_families parameter not provided.
+      When set without S3 credentials, use HTTP backend for read-only artifact downloads
+      via public HTTPS URLs (e.g., https://bucket.s3.amazonaws.com/path).
 
-    For S3 backend:
-    - Uses WorkflowOutputRoot.from_workflow_run() for bucket selection
+    For S3 and HTTP backends:
+    - Uses WorkflowOutputRoot.from_workflow_run() for bucket selection and path construction
     """
     import platform as platform_module
 
@@ -628,10 +637,11 @@ def create_backend_from_env(
         )
 
     # Priority 2: S3 backend when AWS credentials are present (CI upload contexts)
-    # Check for all three required AWS credentials
+    # Check for AWS credentials (both long-term IAM and temporary STS credentials)
+    # Note: AWS_SESSION_TOKEN is only present for temporary credentials; long-term
+    # IAM credentials only have AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
     has_s3_credentials = all(
-        os.getenv(var)
-        for var in ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+        os.getenv(var) for var in ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
     )
     if has_s3_credentials:
         output_root = WorkflowOutputRoot.from_workflow_run(
@@ -639,33 +649,28 @@ def create_backend_from_env(
         )
         return S3Backend(output_root=output_root)
 
-    # Priority 3: HTTP backend for read-only access (no upload capability)
-    # Only use HTTP backend if base URL is explicitly configured
-    http_base_url = os.getenv("THEROCK_HTTP_BASE_URL")
-    if http_base_url:
-        # Get GFX families from parameter or environment variable
-        targets = gfx_families
-        if targets is None:
-            targets_env = os.getenv("THEROCK_AMDGPU_FAMILIES")
-            if targets_env:
-                targets = [t.strip() for t in targets_env.split(",")]
+    # Priority 3: HTTP backend for read-only access via public HTTPS URLs
+    # Only used when THEROCK_AMDGPU_FAMILIES is set (without S3 credentials)
+    # Downloads artifacts from public S3 buckets via https://bucket.s3.amazonaws.com/path
+    targets = gfx_families
+    if targets is None:
+        targets_env = os.getenv("THEROCK_AMDGPU_FAMILIES")
+        if targets_env:
+            targets = [t.strip() for t in targets_env.split(",")]
 
-        if not targets:
-            raise ValueError(
-                "HTTPBackend requires gfx_families. "
-                "Provide via gfx_families parameter or THEROCK_AMDGPU_FAMILIES environment variable "
-                "(comma-separated list, e.g., 'gfx94X-dcgpu,gfx1200')"
-            )
-
-        return HTTPBackend(
-            run_id=run_id,
-            base_url=http_base_url,
-            gfx_families=targets,
-            platform=platform_name,
+    if not targets:
+        raise ValueError(
+            "No backend configuration found. Provide one of:\n"
+            "- THEROCK_LOCAL_STAGING_DIR for local backend\n"
+            "- AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY for S3 backend\n"
+            "- THEROCK_AMDGPU_FAMILIES for HTTP backend (read-only)\n"
+            "or pass gfx_families parameter for HTTP backend"
         )
 
-    # Priority 4: S3 backend without credentials (read-only fallback)
     output_root = WorkflowOutputRoot.from_workflow_run(
         run_id=run_id, platform=platform_name
     )
-    return S3Backend(output_root=output_root)
+    return HTTPBackend(
+        output_root=output_root,
+        gfx_families=targets
+    )

--- a/build_tools/_therock_utils/artifact_backend.py
+++ b/build_tools/_therock_utils/artifact_backend.py
@@ -1,16 +1,19 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Abstraction layer for artifact storage backends (S3 or local directory).
+"""Abstraction layer for artifact storage backends (S3, local directory, or HTTP).
 
-This module provides a unified interface for artifact storage that works with
-both local directories (for prototyping/testing) and S3 (for CI/CD).
+This module provides a unified interface for artifact storage that works with:
+- Local directories (for prototyping/testing)
+- S3 (for CI/CD)
+- HTTP artifact server (read-only access to workflow builds)
 
 TODO(scotttodd): Consolidate with StorageBackend in storage_backend.py? Both
 modules manage S3 clients and local directory mirroring. ArtifactBackend has
 download/list/exists operations that StorageBackend doesn't have yet.
 
 Environment-based switching:
+- THEROCK_HTTP_RUN_ID set → use HTTPBackend (read-only)
 - THEROCK_LOCAL_STAGING_DIR set → use LocalDirectoryBackend
 - Otherwise → use S3Backend
 """
@@ -19,8 +22,11 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Set
+import hashlib
 import os
+import re
 import shutil
+import urllib.request
 
 from .workflow_outputs import WorkflowOutputRoot
 
@@ -330,28 +336,320 @@ class S3Backend(ArtifactBackend):
             return False
 
 
+class HTTPBackend(ArtifactBackend):
+    """Read-only backend for HTTP artifact server.
+
+    Accesses artifacts from:
+    {base_url}/{run_id}-{platform}/
+
+    Artifacts are organized by gfx target via index-{gfx_family}.html files.
+
+    Usage:
+        # Create backend for specific run
+        backend = HTTPBackend(
+            run_id="23309603946",
+            platform="linux",
+            gfx_families=["gfx94X-dcgpu", "gfx1200"],
+            base_url="https://example.com/artifacts"
+        )
+
+        # List available artifacts (across all specified GFX families)
+        artifacts = backend.list_artifacts(name_filter="blas")
+
+        # Download artifact with checksum verification
+        backend.download_artifact("blas_lib_gfx1200.tar.zst", Path("/tmp/blas.tar.zst"))
+
+        # Or use factory function with target families
+        import os
+        os.environ["THEROCK_RUN_ID"] = "23309603946"
+        os.environ["THEROCK_HTTP_BASE_URL"] = "https://example.com/artifacts"
+        backend = create_backend_from_env(gfx_families=["gfx94X-dcgpu", "gfx1200"])
+
+    Environment Variables:
+        THEROCK_RUN_ID: Workflow run ID (falls back to GITHUB_RUN_ID or "local")
+        THEROCK_HTTP_BASE_URL: Base URL for artifact server (required for HTTP backend)
+        THEROCK_AMDGPU_FAMILIES: Comma-separated list of GFX families (e.g., "gfx94X-dcgpu,gfx1200")
+        THEROCK_PLATFORM: Platform name (default: "linux")
+    """
+
+    def __init__(
+        self,
+        run_id: str,
+        base_url: str,
+        gfx_families: List[str],
+        platform: str = "linux",
+    ):
+        self.run_id = run_id
+        self.base_url = base_url
+        self.platform = platform
+        self.gfx_families = gfx_families
+        self._artifact_cache: Optional[List[str]] = None  # Lazy-loaded artifact list
+
+    @property
+    def base_uri(self) -> str:
+        """Return the base URI for this backend."""
+        return f"{self.base_url}/{self.run_id}-{self.platform}"
+
+    def _download_file(self, url: str, dest: Path) -> None:
+        """Download a file from URL to destination path."""
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            urllib.request.urlretrieve(url, dest)
+        except Exception as e:
+            raise FileNotFoundError(f"Failed to download {url}: {e}")
+
+    def _parse_index_html(self, html_content: str) -> List[str]:
+        """Parse artifact index HTML to extract artifact filenames."""
+        # Extract all href values
+        hrefs = re.findall(r'href="([^"]+)"', html_content)
+
+        # Filter to artifact archives only
+        artifacts = []
+        for href in hrefs:
+            # Skip parent directory, index files, http links, anchors
+            if href.startswith(("..", "index", "http", "#")):
+                continue
+            # Only include recognized artifact archives
+            if _is_artifact_archive(href):
+                artifacts.append(href)
+
+        return artifacts
+
+    def _fetch_index(self, gfx_family: str) -> List[str]:
+        """Fetch artifact list from index-{gfx_family}.html."""
+        index_url = f"{self.base_uri}/index-{gfx_family}.html"
+        try:
+            with urllib.request.urlopen(index_url) as response:
+                html_content = response.read().decode("utf-8")
+            return self._parse_index_html(html_content)
+        except Exception:
+            # Index doesn't exist for this target
+            return []
+
+    def _discover_gfx_families_from_master_index(self) -> List[str]:
+        """Discover available GFX families from master index.
+
+        TODO: Future enhancement - Master index discovery
+        ==================================================
+        This stub will be implemented to fetch and parse the master index at:
+        {base_url}/{workflow_id}-linux/index.html
+
+        The master index should contain links to all available index files:
+          <a href="../{run_id}-{platform}/index-gfx94X-dcgpu.html">...</a>
+          <a href="../{run_id}-{platform}/index-gfx120X-all.html">...</a>
+
+        Implementation plan:
+        1. Fetch {base_url}/{workflow_id}-linux/index.html
+        2. Parse HTML for links matching pattern: index-{gfx_family}.html
+        3. Extract gfx_family from each link
+        4. Return list of discovered targets
+
+        This will replace the hardcoded common_targets list and enable
+        automatic discovery of all available GFX families.
+
+        Returns:
+            List of discovered GFX families (e.g., ["gfx94X-dcgpu", "gfx120X-all", "gfx908"])
+        """
+        # TODO: Implement master index parsing
+        # master_index_url = f"{self.base_url}/{workflow_id}-linux/index.html"
+        # try:
+        #     with urllib.request.urlopen(master_index_url) as response:
+        #         html_content = response.read().decode("utf-8")
+        #
+        #     # Parse for links like: href="../{run_id}-{platform}/index-{gfx_family}.html"
+        #     pattern = rf'href="[^"]*/{self.run_id}-{self.platform}/index-([^"]+)\.html"'
+        #     matches = re.findall(pattern, html_content)
+        #     return matches
+        # except Exception:
+        #     # Fall back to hardcoded targets if master index unavailable
+        #     return []
+
+        # For now, return empty list to indicate not implemented
+        return []
+
+    def _list_all_artifacts(self) -> List[str]:
+        """List artifacts across all available index files.
+
+        TODO: Future enhancement - Use master index discovery
+        =======================================================
+        Once _discover_gfx_families_from_master_index() is implemented,
+        this method should:
+        1. First try to discover targets from master index
+        2. Fall back to hardcoded common_targets if master index unavailable
+
+        Example:
+            discovered_targets = self._discover_gfx_families_from_master_index()
+            targets = discovered_targets if discovered_targets else common_targets
+        """
+        # TODO: Replace hardcoded list with master index discovery
+        # discovered_targets = self._discover_gfx_families_from_master_index()
+        # common_targets = discovered_targets if discovered_targets else ["gfx1200", "gfx1201", "generic"]
+
+        common_targets = ["gfx1200", "gfx1201", "generic"]
+        all_artifacts = set()
+
+        for target in common_targets:
+            try:
+                artifacts = self._fetch_index(target)
+                all_artifacts.update(artifacts)
+            except Exception:
+                # Index doesn't exist for this target, skip
+                continue
+
+        return sorted(all_artifacts)
+
+    def list_artifacts(self, name_filter: Optional[str] = None) -> List[str]:
+        """List available artifact filenames across all specified GFX families.
+
+        Args:
+            name_filter: Optional artifact name prefix to filter by (e.g., "blas" to match "blas_lib_*")
+
+        Returns:
+            List of artifact filenames (e.g., ["blas_lib_gfx1200.tar.zst", "rocfft_lib_gfx1200.tar.xz"])
+        """
+        # Use cache if available
+        if self._artifact_cache is None:
+            # Fetch from all specified GFX families
+            all_artifacts = set()
+            for family in self.gfx_families:
+                try:
+                    artifacts = self._fetch_index(family)
+                    all_artifacts.update(artifacts)
+                except Exception:
+                    # Index doesn't exist for this family - this is expected until
+                    # master index is available. Skip silently.
+                    continue
+            self._artifact_cache = sorted(all_artifacts)
+
+        artifacts = self._artifact_cache
+
+        # Apply name filter if provided
+        if name_filter is not None:
+            artifacts = [a for a in artifacts if a.startswith(f"{name_filter}_")]
+
+        return sorted(artifacts)
+
+    def _verify_checksum(self, artifact_path: Path) -> bool:
+        """Verify artifact SHA256 checksum against .sha256sum file."""
+        checksum_file = artifact_path.parent / f"{artifact_path.name}.sha256sum"
+        if not checksum_file.exists():
+            return False
+
+        # Read expected checksum (first word of .sha256sum file)
+        expected = checksum_file.read_text().split()[0]
+
+        # Calculate actual checksum
+        sha256 = hashlib.sha256()
+        with open(artifact_path, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                sha256.update(chunk)
+        actual = sha256.hexdigest()
+
+        return expected == actual
+
+    def download_artifact(self, artifact_key: str, dest_path: Path) -> None:
+        """Download artifact with checksum verification.
+
+        Args:
+            artifact_key: The artifact filename (e.g., "blas_lib_gfx1200.tar.zst")
+            dest_path: Local path to write the artifact to
+
+        Raises:
+            FileNotFoundError: If artifact or checksum not found
+            ValueError: If checksum verification fails
+        """
+        artifact_url = f"{self.base_uri}/{artifact_key}"
+        checksum_url = f"{artifact_url}.sha256sum"
+
+        # Download artifact
+        self._download_file(artifact_url, dest_path)
+
+        # Download checksum
+        checksum_path = dest_path.parent / f"{artifact_key}.sha256sum"
+        try:
+            self._download_file(checksum_url, checksum_path)
+
+            # Verify checksum
+            if not self._verify_checksum(dest_path):
+                # Clean up and raise error
+                dest_path.unlink(missing_ok=True)
+                checksum_path.unlink(missing_ok=True)
+                raise ValueError(f"Checksum verification failed for {artifact_key}")
+
+        except FileNotFoundError:
+            # Artifacts are allowed to be downloaded without checksums
+            pass
+
+
+    def upload_artifact(self, source_path: Path, artifact_key: str) -> None:
+        """Upload is not supported - HTTPBackend is read-only."""
+        raise NotImplementedError("HTTPBackend is read-only")
+
+    def copy_artifact(
+        self, artifact_key: str, source_backend: "ArtifactBackend"
+    ) -> None:
+        """Copy is not supported - HTTPBackend is read-only."""
+        raise NotImplementedError("HTTPBackend is read-only")
+
+    def artifact_exists(self, artifact_key: str) -> bool:
+        """Check if an artifact exists in the backend."""
+        # Check if artifact is in cached list (if cache is populated)
+        if self._artifact_cache is not None:
+            return artifact_key in self._artifact_cache
+
+        # Otherwise, try HTTP HEAD request
+        artifact_url = f"{self.base_uri}/{artifact_key}"
+        try:
+            req = urllib.request.Request(artifact_url, method="HEAD")
+            urllib.request.urlopen(req)
+            return True
+        except Exception:
+            return False
+
+
 def create_backend_from_env(
     run_id: Optional[str] = None,
     platform: Optional[str] = None,
+    gfx_families: Optional[List[str]] = None,
 ) -> ArtifactBackend:
     """Create the appropriate backend based on environment variables.
 
-    Environment variables:
-    - THEROCK_LOCAL_STAGING_DIR: If set, use local backend
-    - THEROCK_RUN_ID: Override run ID (default: "local" or GITHUB_RUN_ID)
-    - THEROCK_PLATFORM: Override platform (default: current platform)
+    Backend priority:
+    1. Local directory (THEROCK_LOCAL_STAGING_DIR) - highest priority for local dev
+    2. S3 with credentials (AWS_* vars present) - CI upload contexts
+    3. HTTP (THEROCK_HTTP_BASE_URL set, no S3 creds) - read-only artifact access
+    4. S3 without credentials - fallback for read-only S3 access
 
-    For S3 backend (when THEROCK_LOCAL_STAGING_DIR is not set):
+    Args:
+        run_id: Override run ID (default: THEROCK_RUN_ID or GITHUB_RUN_ID or "local")
+        platform: Override platform (default: THEROCK_PLATFORM or system platform)
+        gfx_families: List of GFX families for HTTP backend (e.g., ["gfx94X-dcgpu", "gfx1200"])
+                    If None, reads from THEROCK_AMDGPU_FAMILIES environment variable (comma-separated)
+                    Required for HTTP backend.
+
+    Environment variables:
+    - THEROCK_RUN_ID: Workflow run ID (default: GITHUB_RUN_ID or "local")
+    - THEROCK_PLATFORM: Override platform (default: current platform)
+    - THEROCK_LOCAL_STAGING_DIR: If set, use local backend
+    - AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN: If all present,
+      prioritize S3 backend for upload capability (CI contexts)
+    - THEROCK_HTTP_BASE_URL: Base URL for HTTP artifact server
+      (if set and no S3 credentials, use HTTP backend for read-only access)
+    - THEROCK_AMDGPU_FAMILIES: Comma-separated list of GFX families (e.g., "gfx94X-dcgpu,gfx1200")
+      Required for HTTP backend if gfx_families parameter not provided.
+
+    For S3 backend:
     - Uses WorkflowOutputRoot.from_workflow_run() for bucket selection
     """
     import platform as platform_module
 
-    local_staging = os.getenv("THEROCK_LOCAL_STAGING_DIR")
     platform_name = platform or os.getenv(
         "THEROCK_PLATFORM", platform_module.system().lower()
     )
     run_id = run_id or os.getenv("THEROCK_RUN_ID", os.getenv("GITHUB_RUN_ID", "local"))
 
+    # Priority 1: Local directory backend (for local development)
+    local_staging = os.getenv("THEROCK_LOCAL_STAGING_DIR")
     if local_staging:
         output_root = WorkflowOutputRoot.for_local(
             run_id=run_id, platform=platform_name
@@ -361,6 +659,44 @@ def create_backend_from_env(
             output_root=output_root,
         )
 
+    # Priority 2: S3 backend when AWS credentials are present (CI upload contexts)
+    # Check for all three required AWS credentials
+    has_s3_credentials = all(
+        os.getenv(var)
+        for var in ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+    )
+    if has_s3_credentials:
+        output_root = WorkflowOutputRoot.from_workflow_run(
+            run_id=run_id, platform=platform_name
+        )
+        return S3Backend(output_root=output_root)
+
+    # Priority 3: HTTP backend for read-only access (no upload capability)
+    # Only use HTTP backend if base URL is explicitly configured
+    http_base_url = os.getenv("THEROCK_HTTP_BASE_URL")
+    if http_base_url:
+        # Get GFX families from parameter or environment variable
+        targets = gfx_families
+        if targets is None:
+            targets_env = os.getenv("THEROCK_AMDGPU_FAMILIES")
+            if targets_env:
+                targets = [t.strip() for t in targets_env.split(",")]
+
+        if not targets:
+            raise ValueError(
+                "HTTPBackend requires gfx_families. "
+                "Provide via gfx_families parameter or THEROCK_AMDGPU_FAMILIES environment variable "
+                "(comma-separated list, e.g., 'gfx94X-dcgpu,gfx1200')"
+            )
+
+        return HTTPBackend(
+            run_id=run_id,
+            base_url=http_base_url,
+            gfx_families=targets,
+            platform=platform_name,
+        )
+
+    # Priority 4: S3 backend without credentials (read-only fallback)
     output_root = WorkflowOutputRoot.from_workflow_run(
         run_id=run_id, platform=platform_name
     )

--- a/build_tools/_therock_utils/artifact_backend.py
+++ b/build_tools/_therock_utils/artifact_backend.py
@@ -467,37 +467,6 @@ class HTTPBackend(ArtifactBackend):
         # For now, return empty list to indicate not implemented
         return []
 
-    def _list_all_artifacts(self) -> List[str]:
-        """List artifacts across all available index files.
-
-        TODO: Future enhancement - Use master index discovery
-        =======================================================
-        Once _discover_gfx_families_from_master_index() is implemented,
-        this method should:
-        1. First try to discover targets from master index
-        2. Fall back to hardcoded common_targets if master index unavailable
-
-        Example:
-            discovered_targets = self._discover_gfx_families_from_master_index()
-            targets = discovered_targets if discovered_targets else common_targets
-        """
-        # TODO: Replace hardcoded list with master index discovery
-        # discovered_targets = self._discover_gfx_families_from_master_index()
-        # common_targets = discovered_targets if discovered_targets else ["gfx1200", "gfx1201", "generic"]
-
-        common_targets = ["gfx1200", "gfx1201", "generic"]
-        all_artifacts = set()
-
-        for target in common_targets:
-            try:
-                artifacts = self._fetch_index(target)
-                all_artifacts.update(artifacts)
-            except Exception:
-                # Index doesn't exist for this target, skip
-                continue
-
-        return sorted(all_artifacts)
-
     def list_artifacts(self, name_filter: Optional[str] = None) -> List[str]:
         """List available artifact filenames across all specified GFX families.
 

--- a/build_tools/_therock_utils/storage_location.py
+++ b/build_tools/_therock_utils/storage_location.py
@@ -16,6 +16,7 @@ Usage::
     loc.local_path(Path("/tmp/staging"))  # Path("/tmp/staging/some/path/file.tar.xz")
 """
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -46,7 +47,18 @@ class StorageLocation:
 
     @property
     def https_url(self) -> str:
-        """Public HTTPS URL for browser access."""
+        """Public HTTPS URL for browser access.
+
+        Checks for bucket-specific override via environment variable:
+        THEROCK_HTTPS_URL_<bucket> where dashes are replaced with underscores.
+
+        """
+        # Check for bucket-specific env var override
+        env_var_name = f"THEROCK_HTTPS_URL_{self.bucket.replace('-', '_')}"
+        base_url = os.getenv(env_var_name)
+        if base_url:
+            return f"{base_url.rstrip('/')}/{self.relative_path}"
+        # Default: S3 public URL pattern
         return f"https://{self.bucket}.s3.amazonaws.com/{self.relative_path}"
 
     def local_path(self, staging_dir: Path) -> Path:

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -343,6 +343,7 @@ def do_fetch(args: argparse.Namespace):
     backend = create_backend_from_env(
         run_id=args.run_id,
         platform=args.platform,
+        gfx_families=target_families,
     )
     log(f"Using backend: {backend.base_uri}")
 
@@ -818,6 +819,7 @@ def do_copy(args: argparse.Namespace):
     dest_backend = create_backend_from_env(
         run_id=args.run_id,
         platform=args.platform,
+        gfx_families=target_families,
     )
 
     log(f"Source: {source_backend.base_uri}")

--- a/build_tools/tests/artifact_backend_test.py
+++ b/build_tools/tests/artifact_backend_test.py
@@ -16,6 +16,7 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from _therock_utils.artifact_backend import (
     ArtifactBackend,
+    HTTPBackend,
     LocalDirectoryBackend,
     S3Backend,
     create_backend_from_env,
@@ -625,6 +626,326 @@ class TestS3BackendCredentials(unittest.TestCase):
             os.unlink(creds_path)
 
 
+class TestHTTPBackend(unittest.TestCase):
+    """Tests for HTTPBackend with mocked HTTP requests."""
+
+    def setUp(self):
+        """Set up HTTPBackend with test parameters."""
+        self.backend = HTTPBackend(
+            run_id="test-run-789",
+            base_url="https://example.com/artifacts",
+            gfx_families=["gfx1200", "gfx94X-dcgpu"],
+            platform="linux",
+        )
+
+    def test_base_uri(self):
+        """Test that base_uri returns the correct HTTP URL."""
+        expected = "https://example.com/artifacts/test-run-789-linux"
+        self.assertEqual(self.backend.base_uri, expected)
+
+    @mock.patch("urllib.request.urlopen")
+    def test_list_artifacts_single_family(self, mock_urlopen):
+        """Test listing artifacts from a single GFX family index."""
+        # Mock HTML response for gfx1200
+        mock_response_gfx1200 = mock.MagicMock()
+        mock_response_gfx1200.read.return_value = b"""
+        <html>
+        <body>
+        <a href="../">Parent Directory</a>
+        <a href="index.html">Index</a>
+        <a href="blas_lib_gfx1200.tar.zst">blas_lib_gfx1200.tar.zst</a>
+        <a href="rocfft_lib_gfx1200.tar.xz">rocfft_lib_gfx1200.tar.xz</a>
+        <a href="blas_lib_gfx1200.tar.zst.sha256sum">blas_lib_gfx1200.tar.zst.sha256sum</a>
+        <a href="http://external.link.com">External Link</a>
+        <a href="#anchor">Anchor</a>
+        </body>
+        </html>
+        """
+        mock_response_gfx1200.__enter__ = mock.Mock(return_value=mock_response_gfx1200)
+        mock_response_gfx1200.__exit__ = mock.Mock(return_value=False)
+
+        # Mock empty response for gfx94X-dcgpu (index doesn't exist)
+        def urlopen_side_effect(url):
+            if "gfx1200" in url:
+                return mock_response_gfx1200
+            raise Exception("Index not found")
+
+        mock_urlopen.side_effect = urlopen_side_effect
+
+        artifacts = self.backend.list_artifacts()
+        self.assertEqual(len(artifacts), 2)
+        self.assertIn("blas_lib_gfx1200.tar.zst", artifacts)
+        self.assertIn("rocfft_lib_gfx1200.tar.xz", artifacts)
+        # sha256sum should be filtered out
+        self.assertNotIn("blas_lib_gfx1200.tar.zst.sha256sum", artifacts)
+
+    @mock.patch("urllib.request.urlopen")
+    def test_list_artifacts_multiple_families(self, mock_urlopen):
+        """Test listing artifacts from multiple GFX families."""
+        # Mock responses for both families
+        mock_response_gfx1200 = mock.MagicMock()
+        mock_response_gfx1200.read.return_value = b"""
+        <a href="blas_lib_gfx1200.tar.zst">blas_lib_gfx1200.tar.zst</a>
+        <a href="rocfft_lib_gfx1200.tar.zst">rocfft_lib_gfx1200.tar.zst</a>
+        """
+        mock_response_gfx1200.__enter__ = mock.Mock(return_value=mock_response_gfx1200)
+        mock_response_gfx1200.__exit__ = mock.Mock(return_value=False)
+
+        mock_response_gfx94x = mock.MagicMock()
+        mock_response_gfx94x.read.return_value = b"""
+        <a href="blas_lib_gfx94X-dcgpu.tar.zst">blas_lib_gfx94X-dcgpu.tar.zst</a>
+        <a href="rocfft_lib_gfx94X-dcgpu.tar.xz">rocfft_lib_gfx94X-dcgpu.tar.xz</a>
+        """
+        mock_response_gfx94x.__enter__ = mock.Mock(return_value=mock_response_gfx94x)
+        mock_response_gfx94x.__exit__ = mock.Mock(return_value=False)
+
+        def urlopen_side_effect(url):
+            if "gfx1200" in url:
+                return mock_response_gfx1200
+            elif "gfx94X-dcgpu" in url:
+                return mock_response_gfx94x
+            raise Exception("Index not found")
+
+        mock_urlopen.side_effect = urlopen_side_effect
+
+        artifacts = self.backend.list_artifacts()
+        self.assertEqual(len(artifacts), 4)
+        self.assertIn("blas_lib_gfx1200.tar.zst", artifacts)
+        self.assertIn("rocfft_lib_gfx1200.tar.zst", artifacts)
+        self.assertIn("blas_lib_gfx94X-dcgpu.tar.zst", artifacts)
+        self.assertIn("rocfft_lib_gfx94X-dcgpu.tar.xz", artifacts)
+
+    @mock.patch("urllib.request.urlopen")
+    def test_list_artifacts_with_filter(self, mock_urlopen):
+        """Test filtering artifacts by name prefix."""
+        mock_response = mock.MagicMock()
+        mock_response.read.return_value = b"""
+        <a href="blas_lib_gfx1200.tar.zst">blas_lib_gfx1200.tar.zst</a>
+        <a href="blas_dev_gfx1200.tar.zst">blas_dev_gfx1200.tar.zst</a>
+        <a href="rocfft_lib_gfx1200.tar.xz">rocfft_lib_gfx1200.tar.xz</a>
+        """
+        mock_response.__enter__ = mock.Mock(return_value=mock_response)
+        mock_response.__exit__ = mock.Mock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        artifacts = self.backend.list_artifacts(name_filter="blas")
+        self.assertEqual(len(artifacts), 2)
+        self.assertIn("blas_lib_gfx1200.tar.zst", artifacts)
+        self.assertIn("blas_dev_gfx1200.tar.zst", artifacts)
+        self.assertNotIn("rocfft_lib_gfx1200.tar.xz", artifacts)
+
+    @mock.patch("urllib.request.urlopen")
+    def test_list_artifacts_caching(self, mock_urlopen):
+        """Test that artifact list is cached after first fetch."""
+        mock_response = mock.MagicMock()
+        mock_response.read.return_value = b"""
+        <a href="blas_lib_gfx1200.tar.zst">blas_lib_gfx1200.tar.zst</a>
+        """
+        mock_response.__enter__ = mock.Mock(return_value=mock_response)
+        mock_response.__exit__ = mock.Mock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        # First call should fetch from HTTP
+        artifacts1 = self.backend.list_artifacts()
+        self.assertEqual(len(artifacts1), 1)
+        call_count_after_first = mock_urlopen.call_count
+
+        # Second call should use cache
+        artifacts2 = self.backend.list_artifacts()
+        self.assertEqual(artifacts1, artifacts2)
+        # urlopen should not be called again
+        self.assertEqual(mock_urlopen.call_count, call_count_after_first)
+
+    @mock.patch("urllib.request.urlretrieve")
+    @mock.patch("urllib.request.urlopen")
+    def test_download_artifact_with_checksum(self, mock_urlopen, mock_urlretrieve):
+        """Test downloading an artifact with successful checksum verification."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dest_path = Path(temp_dir) / "downloaded.tar.zst"
+            checksum_path = dest_path.parent / "downloaded.tar.zst.sha256sum"
+
+            # Create a fake artifact file with known content
+            fake_artifact_content = b"test artifact content for checksum"
+
+            def urlretrieve_side_effect(url, dest):
+                if url.endswith(".sha256sum"):
+                    # Write checksum file (SHA256 of fake_artifact_content)
+                    Path(dest).write_text(
+                        "e1b51c534d1be613579d8eb289127b2f840f3e7e16e0631c7db728736e5c311f  downloaded.tar.zst\n"
+                    )
+                else:
+                    # Write artifact file
+                    Path(dest).write_bytes(fake_artifact_content)
+
+            mock_urlretrieve.side_effect = urlretrieve_side_effect
+
+            # Download should succeed
+            self.backend.download_artifact("downloaded.tar.zst", dest_path)
+
+            # Verify files were created
+            self.assertTrue(dest_path.exists())
+            self.assertTrue(checksum_path.exists())
+            self.assertEqual(dest_path.read_bytes(), fake_artifact_content)
+
+            # Verify URLs called
+            self.assertEqual(mock_urlretrieve.call_count, 2)
+            mock_urlretrieve.assert_any_call(
+                "https://example.com/artifacts/test-run-789-linux/downloaded.tar.zst",
+                dest_path,
+            )
+            mock_urlretrieve.assert_any_call(
+                "https://example.com/artifacts/test-run-789-linux/downloaded.tar.zst.sha256sum",
+                checksum_path,
+            )
+
+    @mock.patch("urllib.request.urlretrieve")
+    def test_download_artifact_without_checksum(self, mock_urlretrieve):
+        """Test downloading an artifact when checksum file doesn't exist."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dest_path = Path(temp_dir) / "downloaded.tar.zst"
+
+            def urlretrieve_side_effect(url, dest):
+                if url.endswith(".sha256sum"):
+                    # Checksum doesn't exist
+                    raise FileNotFoundError("Checksum not found")
+                else:
+                    # Write artifact file
+                    Path(dest).write_bytes(b"test content")
+
+            mock_urlretrieve.side_effect = urlretrieve_side_effect
+
+            # Download should succeed even without checksum
+            self.backend.download_artifact("downloaded.tar.zst", dest_path)
+
+            self.assertTrue(dest_path.exists())
+            self.assertEqual(dest_path.read_bytes(), b"test content")
+
+    @mock.patch("urllib.request.urlretrieve")
+    def test_download_artifact_checksum_mismatch(self, mock_urlretrieve):
+        """Test that download fails on checksum mismatch."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dest_path = Path(temp_dir) / "downloaded.tar.zst"
+            checksum_path = dest_path.parent / "downloaded.tar.zst.sha256sum"
+
+            def urlretrieve_side_effect(url, dest):
+                if url.endswith(".sha256sum"):
+                    # Write checksum that won't match
+                    Path(dest).write_text("wrongchecksum123  downloaded.tar.zst\n")
+                else:
+                    # Write artifact file
+                    Path(dest).write_bytes(b"test content")
+
+            mock_urlretrieve.side_effect = urlretrieve_side_effect
+
+            # Download should fail with ValueError
+            with self.assertRaises(ValueError) as ctx:
+                self.backend.download_artifact("downloaded.tar.zst", dest_path)
+
+            self.assertIn("Checksum verification failed", str(ctx.exception))
+            # Files should be cleaned up
+            self.assertFalse(dest_path.exists())
+            self.assertFalse(checksum_path.exists())
+
+    @mock.patch("urllib.request.urlretrieve")
+    def test_download_artifact_not_found(self, mock_urlretrieve):
+        """Test that download fails when artifact doesn't exist."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dest_path = Path(temp_dir) / "nonexistent.tar.zst"
+
+            mock_urlretrieve.side_effect = FileNotFoundError("Artifact not found")
+
+            with self.assertRaises(FileNotFoundError):
+                self.backend.download_artifact("nonexistent.tar.zst", dest_path)
+
+    @mock.patch("urllib.request.urlopen")
+    def test_artifact_exists_with_cache(self, mock_urlopen):
+        """Test artifact_exists using cached artifact list."""
+        # Populate cache
+        mock_response = mock.MagicMock()
+        mock_response.read.return_value = b"""
+        <a href="exists.tar.zst">exists.tar.zst</a>
+        """
+        mock_response.__enter__ = mock.Mock(return_value=mock_response)
+        mock_response.__exit__ = mock.Mock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        # Populate cache by calling list_artifacts
+        self.backend.list_artifacts()
+
+        # artifact_exists should use cache (no HEAD request)
+        self.assertTrue(self.backend.artifact_exists("exists.tar.zst"))
+        self.assertFalse(self.backend.artifact_exists("nonexistent.tar.zst"))
+
+    @mock.patch("urllib.request.urlopen")
+    def test_artifact_exists_with_head_request(self, mock_urlopen):
+        """Test artifact_exists using HTTP HEAD request when cache is empty."""
+        # Don't populate cache - should use HEAD request
+        mock_response = mock.MagicMock()
+
+        def urlopen_side_effect(request):
+            if hasattr(request, "method") and request.method == "HEAD":
+                if "exists.tar.zst" in request.full_url:
+                    return mock_response
+                raise Exception("Not found")
+            raise Exception("Expected HEAD request")
+
+        mock_urlopen.side_effect = urlopen_side_effect
+
+        self.assertTrue(self.backend.artifact_exists("exists.tar.zst"))
+        self.assertFalse(self.backend.artifact_exists("nonexistent.tar.zst"))
+
+    def test_upload_artifact_not_supported(self):
+        """Test that upload_artifact raises NotImplementedError."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_path = Path(temp_dir) / "test.tar.zst"
+            source_path.touch()
+
+            with self.assertRaises(NotImplementedError) as ctx:
+                self.backend.upload_artifact(source_path, "test.tar.zst")
+
+            self.assertIn("read-only", str(ctx.exception))
+
+    def test_copy_artifact_not_supported(self):
+        """Test that copy_artifact raises NotImplementedError."""
+        source_backend = mock.MagicMock()
+
+        with self.assertRaises(NotImplementedError) as ctx:
+            self.backend.copy_artifact("test.tar.zst", source_backend)
+
+        self.assertIn("read-only", str(ctx.exception))
+
+    @mock.patch("urllib.request.urlopen")
+    def test_parse_index_html_edge_cases(self, mock_urlopen):
+        """Test parsing index HTML with various edge cases."""
+        mock_response = mock.MagicMock()
+        mock_response.read.return_value = b"""
+        <html>
+        <body>
+        <!-- Valid artifacts -->
+        <a href="valid1.tar.zst">valid1.tar.zst</a>
+        <a href="valid2.tar.xz">valid2.tar.xz</a>
+
+        <!-- Should be filtered out -->
+        <a href="../parent">Parent</a>
+        <a href="index-gfx1200.html">Index</a>
+        <a href="http://external.com/file.tar.zst">External</a>
+        <a href="#section">Anchor</a>
+        <a href="README.txt">Text file</a>
+        <a href="artifact.tar.gz">Wrong extension</a>
+        <a href="file.tar.zst.sha256sum">Checksum file</a>
+        </body>
+        </html>
+        """
+        mock_response.__enter__ = mock.Mock(return_value=mock_response)
+        mock_response.__exit__ = mock.Mock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        artifacts = self.backend.list_artifacts()
+        self.assertEqual(len(artifacts), 2)
+        self.assertIn("valid1.tar.zst", artifacts)
+        self.assertIn("valid2.tar.xz", artifacts)
+
+
 class TestCreateBackendFromEnv(unittest.TestCase):
     """Tests for create_backend_from_env factory function."""
 
@@ -676,6 +997,102 @@ class TestCreateBackendFromEnv(unittest.TestCase):
             self.assertIsInstance(backend, S3Backend)
             self.assertEqual(backend.bucket, "test-bucket")
             self.assertIn("s3-run-id", backend.s3_prefix)
+
+    def test_http_backend_from_env(self):
+        """Test that HTTPBackend is created when THEROCK_HTTP_BASE_URL is set."""
+        with mock.patch.dict(
+            os.environ,
+            {
+                "THEROCK_HTTP_BASE_URL": "https://artifacts.example.com",
+                "THEROCK_RUN_ID": "http-run-123",
+                "THEROCK_PLATFORM": "linux",
+                "THEROCK_AMDGPU_FAMILIES": "gfx1200,gfx94X-dcgpu",
+            },
+            clear=True,
+        ):
+            backend = create_backend_from_env()
+
+            self.assertIsInstance(backend, HTTPBackend)
+            self.assertEqual(backend.run_id, "http-run-123")
+            self.assertEqual(backend.base_url, "https://artifacts.example.com")
+            self.assertEqual(backend.platform, "linux")
+            self.assertEqual(backend.gfx_families, ["gfx1200", "gfx94X-dcgpu"])
+            self.assertIn("http-run-123", backend.base_uri)
+
+    def test_http_backend_with_gfx_families_param(self):
+        """Test HTTPBackend creation with gfx_families parameter overriding env var."""
+        with mock.patch.dict(
+            os.environ,
+            {
+                "THEROCK_HTTP_BASE_URL": "https://artifacts.example.com",
+                "THEROCK_RUN_ID": "http-run-456",
+                "THEROCK_AMDGPU_FAMILIES": "gfx1200",  # This should be overridden
+            },
+            clear=True,
+        ):
+            backend = create_backend_from_env(gfx_families=["gfx94X-dcgpu", "gfx1100"])
+
+            self.assertIsInstance(backend, HTTPBackend)
+            self.assertEqual(backend.gfx_families, ["gfx94X-dcgpu", "gfx1100"])
+
+    def test_http_backend_missing_gfx_families_raises(self):
+        """Test that HTTPBackend creation fails without gfx_families."""
+        with mock.patch.dict(
+            os.environ,
+            {
+                "THEROCK_HTTP_BASE_URL": "https://artifacts.example.com",
+                "THEROCK_RUN_ID": "http-run-789",
+            },
+            clear=True,
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                create_backend_from_env()
+
+            self.assertIn("HTTPBackend requires gfx_families", str(ctx.exception))
+
+    @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
+    def test_s3_backend_with_credentials_priority(self, mock_retrieve):
+        """Test that S3Backend with credentials takes priority over HTTP backend."""
+        mock_retrieve.return_value = ("", "test-bucket")
+        with mock.patch.dict(
+            os.environ,
+            {
+                "AWS_ACCESS_KEY_ID": "test-key",
+                "AWS_SECRET_ACCESS_KEY": "test-secret",
+                "AWS_SESSION_TOKEN": "test-token",
+                "THEROCK_HTTP_BASE_URL": "https://artifacts.example.com",
+                "THEROCK_AMDGPU_FAMILIES": "gfx1200",
+                "THEROCK_RUN_ID": "priority-test",
+            },
+            clear=True,
+        ):
+            backend = create_backend_from_env()
+
+            # Should create S3Backend because credentials are present
+            self.assertIsInstance(backend, S3Backend)
+
+    @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
+    def test_backend_priority_local_over_all(self, mock_retrieve):
+        """Test that local backend has highest priority."""
+        mock_retrieve.return_value = ("", "test-bucket")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "THEROCK_LOCAL_STAGING_DIR": temp_dir,
+                    "AWS_ACCESS_KEY_ID": "test-key",
+                    "AWS_SECRET_ACCESS_KEY": "test-secret",
+                    "AWS_SESSION_TOKEN": "test-token",
+                    "THEROCK_HTTP_BASE_URL": "https://artifacts.example.com",
+                    "THEROCK_AMDGPU_FAMILIES": "gfx1200",
+                    "THEROCK_RUN_ID": "priority-test",
+                },
+                clear=True,
+            ):
+                backend = create_backend_from_env()
+
+                # Should create LocalDirectoryBackend despite other options
+                self.assertIsInstance(backend, LocalDirectoryBackend)
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/artifact_backend_test.py
+++ b/build_tools/tests/artifact_backend_test.py
@@ -631,17 +631,18 @@ class TestHTTPBackend(unittest.TestCase):
 
     def setUp(self):
         """Set up HTTPBackend with test parameters."""
+        self.output_root = _make_local_root(run_id="test-run-789", platform="linux")
         self.backend = HTTPBackend(
-            run_id="test-run-789",
-            base_url="https://example.com/artifacts",
+            output_root=self.output_root,
             gfx_families=["gfx1200", "gfx94X-dcgpu"],
-            platform="linux",
         )
 
     def test_base_uri(self):
-        """Test that base_uri returns the correct HTTP URL."""
-        expected = "https://example.com/artifacts/test-run-789-linux"
-        self.assertEqual(self.backend.base_uri, expected)
+        """Test that base_uri returns the correct HTTPS URL for S3."""
+        # Should use StorageLocation.https_url format
+        # For local output_root with bucket="local", returns: https://local.s3.amazonaws.com/test-run-789-linux
+        self.assertIn("test-run-789-linux", self.backend.base_uri)
+        self.assertTrue(self.backend.base_uri.startswith("https://"))
 
     @mock.patch("urllib.request.urlopen")
     def test_list_artifacts_single_family(self, mock_urlopen):
@@ -787,14 +788,14 @@ class TestHTTPBackend(unittest.TestCase):
             self.assertTrue(checksum_path.exists())
             self.assertEqual(dest_path.read_bytes(), fake_artifact_content)
 
-            # Verify URLs called
+            # Verify URLs called (uses StorageLocation.https_url format)
             self.assertEqual(mock_urlretrieve.call_count, 2)
             mock_urlretrieve.assert_any_call(
-                "https://example.com/artifacts/test-run-789-linux/downloaded.tar.zst",
+                "https://local.s3.amazonaws.com/test-run-789-linux/downloaded.tar.zst",
                 dest_path,
             )
             mock_urlretrieve.assert_any_call(
-                "https://example.com/artifacts/test-run-789-linux/downloaded.tar.zst.sha256sum",
+                "https://local.s3.amazonaws.com/test-run-789-linux/downloaded.tar.zst.sha256sum",
                 checksum_path,
             )
 
@@ -985,11 +986,15 @@ class TestCreateBackendFromEnv(unittest.TestCase):
 
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
     def test_s3_backend_when_no_local_dir(self, mock_retrieve):
-        """Test that S3Backend is created when THEROCK_LOCAL_STAGING_DIR is not set."""
+        """Test that S3Backend is created when AWS credentials are set."""
         mock_retrieve.return_value = ("", "test-bucket")
         with mock.patch.dict(
             os.environ,
-            {"THEROCK_RUN_ID": "s3-run-id"},
+            {
+                "THEROCK_RUN_ID": "s3-run-id",
+                "AWS_ACCESS_KEY_ID": "test-key",
+                "AWS_SECRET_ACCESS_KEY": "test-secret",
+            },
             clear=True,
         ):
             backend = create_backend_from_env()
@@ -999,11 +1004,10 @@ class TestCreateBackendFromEnv(unittest.TestCase):
             self.assertIn("s3-run-id", backend.s3_prefix)
 
     def test_http_backend_from_env(self):
-        """Test that HTTPBackend is created when THEROCK_HTTP_BASE_URL is set."""
+        """Test that HTTPBackend is created when THEROCK_AMDGPU_FAMILIES is set without S3 credentials."""
         with mock.patch.dict(
             os.environ,
             {
-                "THEROCK_HTTP_BASE_URL": "https://artifacts.example.com",
                 "THEROCK_RUN_ID": "http-run-123",
                 "THEROCK_PLATFORM": "linux",
                 "THEROCK_AMDGPU_FAMILIES": "gfx1200,gfx94X-dcgpu",
@@ -1013,9 +1017,8 @@ class TestCreateBackendFromEnv(unittest.TestCase):
             backend = create_backend_from_env()
 
             self.assertIsInstance(backend, HTTPBackend)
-            self.assertEqual(backend.run_id, "http-run-123")
-            self.assertEqual(backend.base_url, "https://artifacts.example.com")
-            self.assertEqual(backend.platform, "linux")
+            self.assertEqual(backend.output_root.run_id, "http-run-123")
+            self.assertEqual(backend.output_root.platform, "linux")
             self.assertEqual(backend.gfx_families, ["gfx1200", "gfx94X-dcgpu"])
             self.assertIn("http-run-123", backend.base_uri)
 
@@ -1036,19 +1039,19 @@ class TestCreateBackendFromEnv(unittest.TestCase):
             self.assertEqual(backend.gfx_families, ["gfx94X-dcgpu", "gfx1100"])
 
     def test_http_backend_missing_gfx_families_raises(self):
-        """Test that HTTPBackend creation fails without gfx_families."""
+        """Test that backend creation fails without any backend configuration."""
         with mock.patch.dict(
             os.environ,
             {
-                "THEROCK_HTTP_BASE_URL": "https://artifacts.example.com",
                 "THEROCK_RUN_ID": "http-run-789",
+                # No THEROCK_AMDGPU_FAMILIES, no AWS credentials, no local staging
             },
             clear=True,
         ):
             with self.assertRaises(ValueError) as ctx:
                 create_backend_from_env()
 
-            self.assertIn("HTTPBackend requires gfx_families", str(ctx.exception))
+            self.assertIn("No backend configuration found", str(ctx.exception))
 
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
     def test_s3_backend_with_credentials_priority(self, mock_retrieve):
@@ -1059,7 +1062,7 @@ class TestCreateBackendFromEnv(unittest.TestCase):
             {
                 "AWS_ACCESS_KEY_ID": "test-key",
                 "AWS_SECRET_ACCESS_KEY": "test-secret",
-                "AWS_SESSION_TOKEN": "test-token",
+                # Note: AWS_SESSION_TOKEN is optional (only for temporary credentials)
                 "THEROCK_HTTP_BASE_URL": "https://artifacts.example.com",
                 "THEROCK_AMDGPU_FAMILIES": "gfx1200",
                 "THEROCK_RUN_ID": "priority-test",
@@ -1082,7 +1085,7 @@ class TestCreateBackendFromEnv(unittest.TestCase):
                     "THEROCK_LOCAL_STAGING_DIR": temp_dir,
                     "AWS_ACCESS_KEY_ID": "test-key",
                     "AWS_SECRET_ACCESS_KEY": "test-secret",
-                    "AWS_SESSION_TOKEN": "test-token",
+                    # Note: AWS_SESSION_TOKEN is optional
                     "THEROCK_HTTP_BASE_URL": "https://artifacts.example.com",
                     "THEROCK_AMDGPU_FAMILIES": "gfx1200",
                     "THEROCK_RUN_ID": "priority-test",

--- a/build_tools/tests/workflow_outputs_test.py
+++ b/build_tools/tests/workflow_outputs_test.py
@@ -30,6 +30,48 @@ class TestStorageLocation(unittest.TestCase):
             "https://my-bucket.s3.amazonaws.com/12345-linux/file.tar.xz",
         )
 
+    def test_https_url_with_env_override(self):
+        """Test https_url with bucket-specific environment variable override."""
+        # Set up env var
+        os.environ["THEROCK_HTTPS_URL_my_custom_bucket"] = (
+            "https://custom.example.com/artifacts"
+        )
+        try:
+            loc = StorageLocation("my-custom-bucket", "12345-linux/file.tar.xz")
+            self.assertEqual(
+                loc.https_url,
+                "https://custom.example.com/artifacts/12345-linux/file.tar.xz",
+            )
+        finally:
+            del os.environ["THEROCK_HTTPS_URL_my_custom_bucket"]
+
+    def test_https_url_env_override_trailing_slash(self):
+        """Test that trailing slash in env var is handled correctly."""
+        os.environ["THEROCK_HTTPS_URL_my_bucket"] = "https://example.com/path/"
+        try:
+            loc = StorageLocation("my-bucket", "file.tar.xz")
+            self.assertEqual(
+                loc.https_url,
+                "https://example.com/path/file.tar.xz",
+            )
+        finally:
+            del os.environ["THEROCK_HTTPS_URL_my_bucket"]
+
+    def test_https_url_default_without_env(self):
+        """Test https_url falls back to S3 pattern when no env var set."""
+        # Ensure env var is not set
+        env_var = "THEROCK_HTTPS_URL_therock_ci_artifacts"
+        old_value = os.environ.pop(env_var, None)
+        try:
+            loc = StorageLocation("therock-ci-artifacts", "12345-linux/file.tar.xz")
+            self.assertEqual(
+                loc.https_url,
+                "https://therock-ci-artifacts.s3.amazonaws.com/12345-linux/file.tar.xz",
+            )
+        finally:
+            if old_value is not None:
+                os.environ[env_var] = old_value
+
     def test_local_path(self):
         loc = StorageLocation("my-bucket", "12345-linux/logs/group/build.log")
         result = loc.local_path(Path("/tmp/staging"))

--- a/docs/development/workflow_outputs.md
+++ b/docs/development/workflow_outputs.md
@@ -10,11 +10,11 @@ Every CI workflow run produces a set of outputs (build artifacts, logs,
 manifests, python packages) that are uploaded to S3. Three modules in
 `_therock_utils` handle the path computation and I/O:
 
-| Module             | Role                         | Key types                                                            |
-| ------------------ | ---------------------------- | -------------------------------------------------------------------- |
-| `storage_location` | Backend-agnostic location    | `StorageLocation`                                                    |
-| `workflow_outputs` | CI path computation (no I/O) | `WorkflowOutputRoot`                                                 |
-| `storage_backend`  | Upload I/O (write)           | `StorageBackend`, `S3StorageBackend`, `LocalStorageBackend`          |
+| Module             | Role                         | Key types                                                              |
+| ------------------ | ---------------------------- | ---------------------------------------------------------------------- |
+| `storage_location` | Backend-agnostic location    | `StorageLocation`                                                      |
+| `workflow_outputs` | CI path computation (no I/O) | `WorkflowOutputRoot`                                                   |
+| `storage_backend`  | Upload I/O (write)           | `StorageBackend`, `S3StorageBackend`, `LocalStorageBackend`            |
 | `artifact_backend` | Download I/O (read)          | `ArtifactBackend`, `S3Backend`, `LocalDirectoryBackend`, `HTTPBackend` |
 
 `StorageLocation` is the bridge between path computation and I/O.
@@ -227,6 +227,7 @@ backend.download_artifact("blas_lib_gfx94X.tar.zst", Path("/tmp/blas.tar.zst"))
 ```
 
 The HTTPBackend downloads artifacts via public HTTPS URLs using `StorageLocation.https_url`:
+
 - Example: `https://therock-ci-artifacts.s3.amazonaws.com/12345-linux/blas_lib_gfx94X.tar.zst`
 - Fork prefixes, bucket selection, and all path logic handled automatically via `WorkflowOutputRoot`
 
@@ -251,9 +252,9 @@ To add a new output type:
 
 ### Download scripts
 
-| File                                                                        | Uses                                                                                  |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| [`fetch_artifacts.py`](/build_tools/fetch_artifacts.py)                     | `WorkflowOutputRoot.from_workflow_run(lookup_workflow_run=True)` + `S3Backend`        |
-| [`find_artifacts_for_commit.py`](/build_tools/find_artifacts_for_commit.py) | `WorkflowOutputRoot.from_workflow_run(workflow_run=...)` for bucket/prefix            |
-| [`artifact_backend.py`](/build_tools/_therock_utils/artifact_backend.py)    | `WorkflowOutputRoot` for `S3Backend`/`HTTPBackend` construction                       |
-| [`artifact_manager.py`](/build_tools/artifact_manager.py)                   | Via `create_backend_from_env()` (supports S3, Local, and HTTP backends)               |
+| File                                                                        | Uses                                                                           |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| [`fetch_artifacts.py`](/build_tools/fetch_artifacts.py)                     | `WorkflowOutputRoot.from_workflow_run(lookup_workflow_run=True)` + `S3Backend` |
+| [`find_artifacts_for_commit.py`](/build_tools/find_artifacts_for_commit.py) | `WorkflowOutputRoot.from_workflow_run(workflow_run=...)` for bucket/prefix     |
+| [`artifact_backend.py`](/build_tools/_therock_utils/artifact_backend.py)    | `WorkflowOutputRoot` for `S3Backend`/`HTTPBackend` construction                |
+| [`artifact_manager.py`](/build_tools/artifact_manager.py)                   | Via `create_backend_from_env()` (supports S3, Local, and HTTP backends)        |

--- a/docs/development/workflow_outputs.md
+++ b/docs/development/workflow_outputs.md
@@ -10,12 +10,12 @@ Every CI workflow run produces a set of outputs (build artifacts, logs,
 manifests, python packages) that are uploaded to S3. Three modules in
 `_therock_utils` handle the path computation and I/O:
 
-| Module             | Role                         | Key types                                                   |
-| ------------------ | ---------------------------- | ----------------------------------------------------------- |
-| `storage_location` | Backend-agnostic location    | `StorageLocation`                                           |
-| `workflow_outputs` | CI path computation (no I/O) | `WorkflowOutputRoot`                                        |
-| `storage_backend`  | Upload I/O (write)           | `StorageBackend`, `S3StorageBackend`, `LocalStorageBackend` |
-| `artifact_backend` | Download I/O (read)          | `ArtifactBackend`, `S3Backend`, `LocalDirectoryBackend`     |
+| Module             | Role                         | Key types                                                            |
+| ------------------ | ---------------------------- | -------------------------------------------------------------------- |
+| `storage_location` | Backend-agnostic location    | `StorageLocation`                                                    |
+| `workflow_outputs` | CI path computation (no I/O) | `WorkflowOutputRoot`                                                 |
+| `storage_backend`  | Upload I/O (write)           | `StorageBackend`, `S3StorageBackend`, `LocalStorageBackend`          |
+| `artifact_backend` | Download I/O (read)          | `ArtifactBackend`, `S3Backend`, `LocalDirectoryBackend`, `HTTPBackend` |
 
 `StorageLocation` is the bridge between path computation and I/O.
 `WorkflowOutputRoot` produces `StorageLocation` instances; backends consume them.
@@ -123,6 +123,30 @@ loc.https_url  # "https://therock-ci-artifacts.s3.amazonaws.com/12345-linux/file
 loc.local_path(Path("/tmp/staging"))  # Path("/tmp/staging/12345-linux/file.tar.xz")
 ```
 
+#### HTTPS URL Override
+
+To use a custom HTTPS URL pattern for a specific bucket, set an environment
+variable with the bucket name (dashes replaced with underscores):
+
+```bash
+THEROCK_HTTPS_URL_<bucket_name>=<base_url>
+```
+
+Example for rocm-npi-dev:
+
+```bash
+export THEROCK_HTTPS_URL_therock_dev_tarball=https://different_domain_altogether.com/tarball
+export THEROCK_HTTPS_URL_therock_dev_artifacts=https://different_domain_altogether.com/artifacts
+export THEROCK_HTTPS_URL_therock_dev_python=https://different_domain_altogether.com/whl
+```
+
+The `relative_path` is appended to the base URL:
+
+```python
+loc = StorageLocation("therock-dev-tarball", "12345-linux/file.tar.xz")
+loc.https_url  # → "https://different_domain_altogether.com/tarball/12345-linux/file.tar.xz"
+```
+
 ### WorkflowOutputRoot
 
 A frozen dataclass that computes `StorageLocation` for every output type.
@@ -179,6 +203,33 @@ backend.upload_directory(source_dir, dest_location, include=["*.tar.xz*"])
 
 Content-type is inferred from file extension — callers don't need to specify it.
 
+### ArtifactBackend
+
+An abstract base class for downloading artifacts from S3, local directories, or HTTP servers.
+Use `create_backend_from_env()` to get the right implementation based on environment variables.
+
+```python
+from _therock_utils.artifact_backend import create_backend_from_env
+
+# With S3 credentials → S3Backend
+backend = create_backend_from_env(gfx_families=["gfx94X-dcgpu"])
+
+# With THEROCK_LOCAL_STAGING_DIR → LocalDirectoryBackend
+os.environ["THEROCK_LOCAL_STAGING_DIR"] = "/tmp/staging"
+backend = create_backend_from_env(gfx_families=["gfx94X-dcgpu"])
+
+# With THEROCK_AMDGPU_FAMILIES (no S3 credentials) → HTTPBackend (read-only)
+os.environ["THEROCK_AMDGPU_FAMILIES"] = "gfx94X-dcgpu,gfx1200"
+backend = create_backend_from_env()
+
+# Download artifact
+backend.download_artifact("blas_lib_gfx94X.tar.zst", Path("/tmp/blas.tar.zst"))
+```
+
+The HTTPBackend downloads artifacts via public HTTPS URLs using `StorageLocation.https_url`:
+- Example: `https://therock-ci-artifacts.s3.amazonaws.com/12345-linux/blas_lib_gfx94X.tar.zst`
+- Fork prefixes, bucket selection, and all path logic handled automatically via `WorkflowOutputRoot`
+
 ### Adding new output types
 
 To add a new output type:
@@ -200,9 +251,9 @@ To add a new output type:
 
 ### Download scripts
 
-| File                                                                        | Uses                                                                           |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| [`fetch_artifacts.py`](/build_tools/fetch_artifacts.py)                     | `WorkflowOutputRoot.from_workflow_run(lookup_workflow_run=True)` + `S3Backend` |
-| [`find_artifacts_for_commit.py`](/build_tools/find_artifacts_for_commit.py) | `WorkflowOutputRoot.from_workflow_run(workflow_run=...)` for bucket/prefix     |
-| [`artifact_backend.py`](/build_tools/_therock_utils/artifact_backend.py)    | `WorkflowOutputRoot` for `S3Backend` construction                              |
-| [`artifact_manager.py`](/build_tools/artifact_manager.py)                   | Via `create_backend_from_env()`                                                |
+| File                                                                        | Uses                                                                                  |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [`fetch_artifacts.py`](/build_tools/fetch_artifacts.py)                     | `WorkflowOutputRoot.from_workflow_run(lookup_workflow_run=True)` + `S3Backend`        |
+| [`find_artifacts_for_commit.py`](/build_tools/find_artifacts_for_commit.py) | `WorkflowOutputRoot.from_workflow_run(workflow_run=...)` for bucket/prefix            |
+| [`artifact_backend.py`](/build_tools/_therock_utils/artifact_backend.py)    | `WorkflowOutputRoot` for `S3Backend`/`HTTPBackend` construction                       |
+| [`artifact_manager.py`](/build_tools/artifact_manager.py)                   | Via `create_backend_from_env()` (supports S3, Local, and HTTP backends)               |


### PR DESCRIPTION
  Implement HTTPBackend to enable downloading prebuilt artifacts
  from workflow summary HTML index files. Supports S3-hosted summaries with
  configurable base URL defaulting to therock-dev-artifacts.s3.amazonaws.com.

  Key features:
  - Read-only access with SHA256 checksum verification
  - HTML index parsing for artifact discovery
  - Environment-based configuration via THEROCK_WORKFLOW_RUN_ID

  Updated create_backend_from_env() to prioritize HTTPBackend
  when THEROCK_WORKFLOW_RUN_ID is set.

## Motivation

Not all tooling has access to S3, but everyone will have access to the hosted HTTP index.html. This provides a read-only backend so artifact_manager.py can be used to fetch artifacts/fprints

## Technical Details

Added HTTPBackend to artifact_backends.py

## Test Plan

Manual + Claude testing. Added new unit tests

## Test Result

It was able to download and parse the index.html from each family. Tested with both public TheRock artifacts base url as well as internal case url

## Submission Checklist

- [x] pre-commit run