### PR TITLE
Re-enable multi-arch CI on postsubmit

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -681,7 +681,11 @@ def main(base_args, linux_families, windows_families):
         # Multi-arch CI on PRs requires explicit opt-in via label.
         # This avoids doubling CI load during the transition from ci.yml
         # to multi_arch_ci.yml. See https://github.com/ROCm/TheRock/issues/3337
-        if multi_arch and "ci:run-multi-arch" not in (pr_labels or []):
+        if (
+            multi_arch
+            and is_pull_request
+            and "ci:run-multi-arch" not in (pr_labels or [])
+        ):
             print(
                 "Skipping multi-arch CI: 'ci:run-multi-arch' label not found. "
                 "Add the label to opt in."


### PR DESCRIPTION
## Motivation

Accidentally disabled by https://github.com/ROCm/TheRock/pull/4039

https://github.com/ROCm/TheRock/actions/runs/23271004671/job/67663505018#step:4:49
```
Skipping multi-arch CI: 'ci:run-multi-arch' label not found. Add the label to opt in.
```

## Technical Details

This code has a combined branch for `push` and `pull_request`, so this code was filtering in both cases:
```python
if is_schedule:
elif is_workflow_dispatch:
else:
  # This code
```

My upcoming feature branch for https://github.com/ROCm/TheRock/issues/3399 will have more structure for each trigger type.

## Test Plan

Untested. Will watch workflow runs after submit.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
