### PR TITLE
opencl ICD package as an artifact

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -514,18 +514,19 @@ artifact_deps = ["core-runtime", "amd-llvm", "core-kpack"]
 feature_name = "HIP_RUNTIME"
 feature_group = "CORE"  # Part of core, enabled by default
 
-[artifacts.core-ocl]
-artifact_group = "opencl-runtime"
-type = "target-neutral"
-artifact_deps = ["core-runtime", "amd-llvm"]
-feature_name = "OCL_RUNTIME"
-feature_group = "CORE"  # Part of core, enabled by default
-
 [artifacts.core-ocl-icd]
 artifact_group = "opencl-runtime"
 type = "target-neutral"
 artifact_deps = ["core-runtime", "amd-llvm"]
 feature_name = "OCL_ICD"
+feature_group = "CORE"  # Part of core, enabled by default
+
+
+[artifacts.core-ocl]
+artifact_group = "opencl-runtime"
+type = "target-neutral"
+artifact_deps = ["core-runtime", "amd-llvm", "core-ocl-icd"]
+feature_name = "OCL_RUNTIME"
 feature_group = "CORE"  # Part of core, enabled by default
 
 [artifacts.rocrtst]

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -342,7 +342,8 @@ endif(THEROCK_ENABLE_HIP_RUNTIME)
 ################################################################################
 # ocl-icd
 ################################################################################
-if(THEROCK_ENABLE_OCL_RUNTIME)
+
+if(THEROCK_ENABLE_OCL_ICD)
 
   therock_cmake_subproject_declare(ocl-icd
   USE_DIST_AMDGPU_TARGETS
@@ -371,6 +372,9 @@ if(THEROCK_ENABLE_OCL_RUNTIME)
     SUBPROJECT_DEPS
       ocl-icd
   )
+endif(THEROCK_ENABLE_OCL_ICD)
+
+if(THEROCK_ENABLE_OCL_RUNTIME)
 
   set(OCL_CLR_CMAKE_ARGS)
   set(OCL_CLR_RUNTIME_DEPS)

--- a/core/artifact-core-ocl-icd.toml
+++ b/core/artifact-core-ocl-icd.toml
@@ -1,5 +1,7 @@
 # opencl
 [components.lib."core/ocl-icd/stage"]
+# Linux implicitly includes lib/libOpenCL.so
+# Windows needs to explicitly include bin/OpenCL.dll
 include = [
   "bin/**",
 ]


### PR DESCRIPTION
## Motivation
AMDs opencl ICD is missed in the package. 

## Technical Details
AMD opencl ICD needs to be packaged and delivered as part of ROCM

## Test Plan
verify the OpenCL.dll is part of an artifact package

## Test Result
verify the OpenCL.dll is part of an artifact package

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
