### PR TITLE
Drop ERROR_VARIABLE capture from topology_to_cmake.py call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,6 @@ block(SCOPE_FOR VARIABLES)
       "--topology" "${CMAKE_CURRENT_SOURCE_DIR}/BUILD_TOPOLOGY.toml"
       "--output" "${CMAKE_CURRENT_BINARY_DIR}/cmake/therock_topology.cmake"
     OUTPUT_VARIABLE _topology_output
-    ERROR_VARIABLE _topology_error
     COMMAND_ERROR_IS_FATAL ANY  # Fail on any error
   )
   message(STATUS "Generated build topology targets from BUILD_TOPOLOGY.toml")


### PR DESCRIPTION
## Motivation

We noticed on https://github.com/ROCm/TheRock/pull/4092#discussion_r2968166367 that if this command failed it would only report a status code and not log stderr.

```
-- Build flags:
--   * KPACK_SPLIT_ARTIFACTS = OFF (-DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=OFF)
-- Found Python3: /opt/python/cp312-cp312/bin/python3.12 (found suitable version "3.12.10", minimum required is "3.9") found components: Interpreter 
CMake Error at CMakeLists.txt:54 (execute_process):
-- Configuring incomplete, errors occurred!
  execute_process failed command indexes:

    1: "Child return code: 1"
```

## Technical Details

* The `_topology_output` and `_topology_error` variables were both unused. 
* Docs: https://cmake.org/cmake/help/latest/command/execute_process.html
  * We could also use `ECHO_ERROR_VARIABLE` if we want to get fancier with logging:
      > The standard output or standard error will not be exclusively redirected to the specified variables.
      >
      > The output will be duplicated into the specified variables and also onto standard output or standard error analogous to the `tee` Unix command.
* I checked other usage of `COMMAND_ERROR_IS_FATAL` across the project and couldn't find any similarly buggy code

## Test Plan

* Configure succeeds on this branch with no change in output
* Output on that PR:
    ```diff
     [cmake] -- Configuring background job pool for 3 concurrent jobs
     [cmake] -- Build flags:
     [cmake] --   * KPACK_SPLIT_ARTIFACTS = OFF (-DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=OFF)
   +[cmake] Topology validation errors:
   +[cmake]   - Artifact 'core-openclICD' should be lowercase-with-hyphens
     [cmake] CMake Error at CMakeLists.txt:54 (execute_process):
     [cmake]   execute_process failed command indexes:
     [cmake] 
     [cmake]     1: "Child return code: 1"
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
