### PR TITLE
Update package dependencies for ROCm components

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -458,10 +458,12 @@
     "DEBDepends": [
       "libc6",
       "amdrocm-runtime",
+      "amdrocm-solver",
       "amdrocm-profiler-base"
     ],
     "RPMRequires": [
       "amdrocm-runtime",
+      "amdrocm-solver",
       "amdrocm-profiler-base"
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
@@ -737,10 +739,12 @@
     "DEBDepends": [
       "libc6",
       "amdrocm-blas",
+      "amdrocm-profiler-base",
       "amdrocm-runtime"
     ],
     "RPMRequires": [
       "amdrocm-blas",
+      "amdrocm-profiler-base",
       "amdrocm-runtime"
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
@@ -829,20 +833,14 @@
     "DEBDepends": [
       "libc6",
       "amdrocm-math-common",
+      "amdrocm-sparse",
       "amdrocm-blas"
     ],
     "RPMRequires": [
       "amdrocm-math-common",
+      "amdrocm-sparse",
       "amdrocm-blas"
     ],
-    "RPMRecommends": [
-      "amdrocm-sparse"
-    ],
-
-    "DEBRecommends": [
-      "amdrocm-sparse"
-    ],
-
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
     "Description_Short": "AMD library for solver in ROCm",
     "Description_Long": "rocsolver and hipsolver libraries ",
@@ -1839,11 +1837,13 @@
     "BuildArch": "x86_64",
     "DEBDepends": [
       "amdrocm-runtime",
+      "amdrocm-profiler-base",
       "amdrocm-blas",
       "amdrocm-sysdeps"
     ],
     "RPMRequires": [
       "amdrocm-runtime",
+      "amdrocm-profiler-base",
       "amdrocm-blas",
       "amdrocm-sysdeps"
     ],


### PR DESCRIPTION
Cherry pick of https://github.com/ROCm/TheRock/pull/4095
 - Add amdrocm-solver dependency to amdrocm-blas package
 - Add amdrocm-profiler-base dependency to amdrocm-sparse and amdrocm-dnn package
 - Move amdrocm-sparse from recommended to required for amdrocm-solver package

