### PR TITLE
Fix broken links

### DIFF
--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -16,8 +16,8 @@ TheRock aims to support as many subprojects as possible on "native" Windows
 ROCm is composed of many subprojects, some of which are supported on Windows:
 
 - https://rocm.docs.amd.com/en/latest/what-is-rocm.html
-- https://rocm.docs.amd.com/projects/install-on-windows/en/latest/reference/component-support.html
-- https://rocm.docs.amd.com/projects/install-on-windows/en/latest/conceptual/release-versioning.html#windows-builds-from-source
+- https://rocm.docs.amd.com/projects/install-on-windows/en/latest/conceptual/component-support.html
+- https://rocm.docs.amd.com/projects/install-on-windows/en/latest/about/release-versioning.html#windows-builds-from-source
 
 This table tracks current support status for each subproject in TheRock on
 Windows. Some subprojects may need extra patches to build within TheRock (on


### PR DESCRIPTION
## Motivation

There are some broken links in the windows_supported.md

## Technical Details

Some pages were moved and redirects were not set.
https://rocm.docs.amd.com/projects/install-on-windows/en/latest/conceptual/release-versioning.html#windows-builds-from-source -> https://rocm.docs.amd.com/projects/install-on-windows/en/latest/about/release-versioning.html#windows-builds-from-source

https://rocm.docs.amd.com/projects/install-on-windows/en/latest/reference/component-support.html ->
https://rocm.docs.amd.com/projects/install-on-windows/en/latest/conceptual/component-support.html

I will also set redirects.

## Test Plan

Tested the new links.

## Test Result

The new links are tested and working.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
