### PR TITLE
[ci] Adding new groupid for OSSCI mi325 test machines

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -56,6 +56,7 @@ jobs:
         --group-add video
         --device /dev/kfd
         --device /dev/dri
+        --group-add 993
         --group-add 992
         --group-add 110
         --ulimit memlock=-1:-1


### PR DESCRIPTION
Adding new group ID for OSSCI

Test here: https://github.com/ROCm/TheRock/actions/runs/23442311648 (as this is only relevant to testing, we are adding skip CI label)

Explanation:
Interesting, found that some new nodes added have Ubuntu 24.04 on them unlike the rest of our Ubuntu 22.04 nodes indicating different Vultr images deployed. This matters because the render group which owns kfd gets a different GID: 109 on 22.04 and 993 on 24.04.
 
Just adding 993 group id should fix for your PRs. Unfortunately, GHA's container launcher wrapper options are static so we can't set the gid to add dynamically. If we switch to directly invoking docker instead (like [pytorch](https://github.com/pytorch/pytorch/blob/main/.github/workflows/_rocm-test.yml#L225)), we can get around this manual step and also pull out container launch to a streamlined action/step that workflows across all ROCm projects use. Also, we should standardize on image deployed across all our nodes in a cluster to avoid these issues and ensure a consistent environment for CI.