### PR TITLE
[rocprofiler-compute] Disable test_profile_pc_sampling

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_compute.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_compute.py
@@ -15,9 +15,7 @@ THEROCK_LIB_PATH = str(THEROCK_PATH / "lib")
 ROCPROFILER_COMPUTE_DIRECTORY = THEROCK_PATH / "libexec" / "rocprofiler-compute"
 
 # Set up excluded tests
-EXCLUDED_TESTS = [
-    "test_profile_live_attach_detach",
-]
+EXCLUDED_TESTS = ["test_profile_live_attach_detach", "test_profile_pc_sampling"]
 
 # quick Tests
 QUICK_TESTS = [


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
#4034 
The `test_profile_pc_sampling` test consistently fails due to the CI runners not supporting the pc_sampling feature. This PR will disable this test from running.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Add `test_profile_pc_sampling` to `EXCLUDED_TESTS` list in `test_rocprofiler_compute.py`

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Run a test run using this branch and confirm that the `test_profile_pc_sampling` test does not run

## Test Result

<!-- Briefly summarize test outcomes. -->
- https://github.com/ROCm/TheRock/actions/runs/23442786556
  - Tests pass, and the `test_profile_pc_sampling` test is not ran

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
