### PR TITLE
[debug-tools/rocgdb] Bump test timeout from 30 to 45 minutes

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -184,7 +184,7 @@ test_matrix = {
     "rocgdb": {
         "job_name": "rocgdb",
         "fetch_artifact_args": "--debug-tools --tests",
-        "timeout_minutes": 30,
+        "timeout_minutes": 45,
         "test_script": f"python {_get_script_path('test_rocgdb.py')}",
         "platform": ["linux"],
         "total_shards": 1,


### PR DESCRIPTION
I spotted rocgdb tests timing out after 30 minutes. It looks like we are dangerously close to reaching the 30 minutes timeout if we manage to get allocated a slower machine.

Bump it to 45 minutes for extra safety. We don't want to make it too big since that may take too long to fail in case the tests misbehave.