### PR TITLE
Fix flaky amd-device-libs symlinking in pre_hook-amd-llvm.cmake

### DIFF
--- a/compiler/pre_hook-amd-llvm.cmake
+++ b/compiler/pre_hook-amd-llvm.cmake
@@ -1,0 +1,10 @@
+# TODO: Arrange for the devicelibs to be installed to the clange resource dir
+# by default. This corresponds to the layout for ROCM>=7. However, not all
+# code (specifically the AMDDeviceLibs.cmake file) has adapted to the new
+# location, so we have to also make them available at amdgcn. There are cache
+# options to manage this transition but they require knowing the clange resource
+# dir. In order to avoid drift, we just fixate that too. This can all be
+# removed in a future version.
+set(CLANG_RESOURCE_DIR "../lib/clang/${LLVM_VERSION_MAJOR}" CACHE STRING "Resource dir" FORCE)
+set(ROCM_DEVICE_LIBS_BITCODE_INSTALL_LOC_NEW "lib/clang/${LLVM_VERSION_MAJOR}/amdgcn" CACHE STRING "New devicelibs loc" FORCE)
+set(ROCM_DEVICE_LIBS_BITCODE_INSTALL_LOC_OLD "amdgcn" CACHE STRING "Old devicelibs loc" FORCE)


### PR DESCRIPTION
Closes #74

## Summary
Disable or repair the flaky ROCM_DEVICE_LIBS_BITCODE_INSTALL_LOC_NEW symlinking workaround

## Changes
- `compiler/pre_hook-amd-llvm.cmake`