### PR TITLE
Fix configuring libdir for distros that use lib64

### DIFF
--- a/third-party/openmpi/CMakeLists.txt
+++ b/third-party/openmpi/CMakeLists.txt
@@ -65,7 +65,7 @@ add_custom_target(
   COMMAND
     ${CMAKE_COMMAND} -E chdir "${SOURCE_DIR}" perl autogen.pl --force
   COMMAND
-    "${SOURCE_DIR}/configure" --prefix=${CMAKE_INSTALL_PREFIX} --disable-silent-rules --enable-mpi-fortran=no
+    "${SOURCE_DIR}/configure" --prefix=${CMAKE_INSTALL_PREFIX} --libdir=${CMAKE_INSTALL_PREFIX}/lib --disable-silent-rules --enable-mpi-fortran=no
   COMMAND
     make -j ${PAR_JOBS}
   COMMAND

--- a/third-party/sysdeps/common/expat/CMakeLists.txt
+++ b/third-party/sysdeps/common/expat/CMakeLists.txt
@@ -97,6 +97,7 @@ add_custom_target(
       --
     "${SOURCE_DIR}/configure"
       --prefix "${CMAKE_INSTALL_PREFIX}"
+      --libdir "${CMAKE_INSTALL_PREFIX}/lib"
       # Disable examples and tests.
       --without-examples
       --without-tests

--- a/third-party/sysdeps/common/gmp/CMakeLists.txt
+++ b/third-party/sysdeps/common/gmp/CMakeLists.txt
@@ -96,6 +96,7 @@ add_custom_target(
       --
     "${SOURCE_DIR}/configure"
       --prefix "${CMAKE_INSTALL_PREFIX}"
+      --libdir "${CMAKE_INSTALL_PREFIX}/lib"
   COMMAND
     make V=1
   COMMAND

--- a/third-party/sysdeps/common/hwloc/CMakeLists.txt
+++ b/third-party/sysdeps/common/hwloc/CMakeLists.txt
@@ -103,6 +103,7 @@ add_custom_target(
       --
     "${SOURCE_DIR}/configure"
       --prefix "${CMAKE_INSTALL_PREFIX}"
+      --libdir "${CMAKE_INSTALL_PREFIX}/lib"
       --disable-static
       --enable-libnuma
       # CRITICAL for GPU discovery

--- a/third-party/sysdeps/common/libbacktrace/CMakeLists.txt
+++ b/third-party/sysdeps/common/libbacktrace/CMakeLists.txt
@@ -83,6 +83,7 @@ add_custom_target(
       --
     "${SOURCE_DIR}/configure"
       --prefix "${CMAKE_INSTALL_PREFIX}"
+      --libdir "${CMAKE_INSTALL_PREFIX}/lib"
       --enable-host-shared
   COMMAND
     make -j "${PAR_JOBS}" V=1

--- a/third-party/sysdeps/common/mpfr/CMakeLists.txt
+++ b/third-party/sysdeps/common/mpfr/CMakeLists.txt
@@ -115,6 +115,7 @@ add_custom_target(
       --
     "${SOURCE_DIR}/configure"
       --prefix "${CMAKE_INSTALL_PREFIX}"
+      --libdir "${CMAKE_INSTALL_PREFIX}/lib"
       --with-gmp="${GMP_PREFIX}"
   COMMAND
     make V=1

--- a/third-party/sysdeps/common/ncurses/CMakeLists.txt
+++ b/third-party/sysdeps/common/ncurses/CMakeLists.txt
@@ -138,6 +138,7 @@ add_custom_target(
       --
     "${SOURCE_DIR}/configure"
       --prefix "${CMAKE_INSTALL_PREFIX}"
+      --libdir "${CMAKE_INSTALL_PREFIX}/lib"
       --with-shared
       --without-ada
       --enable-widec

--- a/third-party/sysdeps/linux/elfutils/CMakeLists.txt
+++ b/third-party/sysdeps/linux/elfutils/CMakeLists.txt
@@ -103,6 +103,7 @@ add_custom_target(
       --
     "${CMAKE_CURRENT_BINARY_DIR}/s/configure"
       --prefix "${CMAKE_INSTALL_PREFIX}"
+      --libdir "${CMAKE_INSTALL_PREFIX}/lib"
       --disable-debuginfod
       --enable-install-elfh
       --with-bzlib --with-zlib --with-zstd

--- a/third-party/sysdeps/linux/numactl/CMakeLists.txt
+++ b/third-party/sysdeps/linux/numactl/CMakeLists.txt
@@ -82,6 +82,7 @@ add_custom_target(
   COMMAND
     "${CMAKE_CURRENT_BINARY_DIR}/s/configure"
       --prefix "${CMAKE_INSTALL_PREFIX}"
+      --libdir "${CMAKE_INSTALL_PREFIX}/lib"
       --disable-static
   COMMAND
     make -j "${PAR_JOBS}" V=1


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/4104

On distributions that default libdir to `lib64` (e.g. OpenSuse), the `configure` scripts install libraries to `lib64/` instead of `lib/`. The rest of TheRock expects `lib/`, so making this change to remain consistent.

## Technical Details

Added `--libdir "${CMAKE_INSTALL_PREFIX}/lib"` to all 9 `configure` calls:
- `third-party/sysdeps/linux/numactl`
- `third-party/sysdeps/linux/elfutils`
- `third-party/sysdeps/common/ncurses`
- `third-party/sysdeps/common/mpfr`
- `third-party/sysdeps/common/libbacktrace`
- `third-party/sysdeps/common/hwloc`
- `third-party/sysdeps/common/gmp`
- `third-party/sysdeps/common/expat`
- `third-party/openmpi`

## Test Plan

- I didn't see any issues locally, so the plan is to make sure CI passes

## Test Result

- Waiting on CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.