### PR TITLE
MIOpen used categories are quick and standard not full

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -221,7 +221,12 @@ def build_ctest_command(category, gpu_arch, available_gpu_archs):
 
 
 def main():
-    category = TEST_TYPE.lower() if TEST_TYPE else "quick"
+    # Determine test category based on TEST_TYPE and component-specific constraints                                                              
+    # MIOpen currently only maintains 'standard' and 'quick' categories
+    if test_component_job_name == "miopen":
+        category = "standard" if TEST_TYPE else "quick"
+    else:
+        category = TEST_TYPE.lower() if TEST_TYPE else "quick"
     if category not in VALID_TEST_CATEGORIES:
         print(
             f"ERROR: Invalid TEST_TYPE '{TEST_TYPE}'. "
@@ -230,8 +235,6 @@ def main():
             file=sys.stderr,
         )
         category = "quick"
-    elif test_component_job_name == "miopen":
-        category = "standard"
 
     # Use AMDGPU_FAMILIES from environment variable, extract gfx<xxx> part
     gpu_arch = ""


### PR DESCRIPTION
## Motivation

With recent change in this PR https://github.com/ROCm/TheRock/pull/4008/changes, the test runner started running full as the category for miopen, while miopen is using standard.
This caused tests that were not previously run to be executed and fail to cause the bumps in this issue to fail.
https://github.com/ROCm/rocm-libraries/issues/5707

## Technical Details

This PR makes the category for miopen standard
## Test Plan

Full tests should not be selected, only standard.
## Test Result

Standard tests are run and passed
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
