### PR TITLE
Add PyTorch manifest link to build job summary

### DIFF
--- a/build_tools/github_actions/upload_pytorch_manifest.py
+++ b/build_tools/github_actions/upload_pytorch_manifest.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 from _therock_utils.storage_location import StorageLocation
 from _therock_utils.storage_backend import create_storage_backend
+from github_actions.github_actions_api import gha_append_step_summary
 
 
 PLATFORM = platform.system().lower()
@@ -139,6 +140,11 @@ def main(argv: list[str]) -> None:
 
     backend = create_storage_backend(staging_dir=args.output_dir, dry_run=args.dry_run)
     backend.upload_file(manifest_path, dest)
+
+    # Add manifest link to GitHub Actions job summary.
+    manifest_url = dest.https_url
+    log(f"Manifest URL: {manifest_url}")
+    gha_append_step_summary(f"[PyTorch Manifest]({manifest_url})")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adding "PyTorch Manifest" link to the build job summary for PyTorch wheel builds, matching the existing pattern used for TheRock SDK builds.

## Motivation

Portable Linux artifact build (`build_portable_linux_artifacts.yml`) displays a summary with links to Build Logs, Artifacts, and TheRock Manifest via `post_build_upload.py`. PyTorch wheel build workflows upload an equivalent manifest to S3 but don't surface it in the job summary, requiring manual URL construction to find it.

## Changes

**`build_tools/github_actions/upload_pytorch_manifest.py`**
- Import `gha_append_step_summary` from `github_actions_api`
- After uploading the manifest to S3, write a `[PyTorch Manifest]` link to `$GITHUB_STEP_SUMMARY`

## Testing

https://github.com/ROCm/TheRock/actions/runs/23453482230
https://therock-dev-artifacts.s3.amazonaws.com/23453482230-linux/manifests/gfx94X-dcgpu/therock-manifest_torch_py3.10_release-2.8.json