### PR TITLE
Fix PyTorch manifest to record real upstream commits instead of HIPIFY commits

### DIFF
--- a/build_tools/github_actions/manifest_utils.py
+++ b/build_tools/github_actions/manifest_utils.py
@@ -75,9 +75,11 @@ def git_upstream_commit(dirpath: Path, *, label: str) -> str:
     commit = capture_optional(
         ["git", "rev-parse", "THEROCK_UPSTREAM_DIFFBASE"], cwd=dirpath
     )
-    if not commit:
+    if commit:
+        log(f"{label} upstream commit (via THEROCK_UPSTREAM_DIFFBASE): {commit}")
+    else:
         commit = capture(["git", "rev-parse", "HEAD"], cwd=dirpath)
-    log(f"[{label}] upstream commit: {commit}")
+        log(f"{label} upstream commit (HEAD fallback): {commit}")
     return commit
 
 


### PR DESCRIPTION
## Motivation
PyTorch manifest (`therock-manifest_torch_*.json`) was recording incorrect commit hashes for PyTorch and Triton. The recorded commits were local-only HIPIFY commits that don't exist in any public repo, making the manifest unusable for repro builds.

## Technical Details
TheRock checkout wrapper (`repo_management.py`) runs HIPIFY after checking out each source repo, creating a local "_DO NOT SUBMIT: HIPIFY_" commit on top of the real upstream commit. The manifest generation in `manifest_utils.git_head()` used `git rev-parse HEAD`, which returned this HIPIFY commit hash instead of the real upstream commit.

For example, the manifest[ therock-manifest_torch_py3.10_release-2.8.json](https://therock-dev-artifacts.s3.amazonaws.com/23453482230-linux/manifests/gfx94X-dcgpu/therock-manifest_torch_py3.10_release-2.8.json) contains,
```
"pytorch": { "commit": "d86475ac62dc45dac9dcf1a9445e71803da27159", ... }
"triton":  { "commit": "3383a11d656995879ce6233ff61549a40253ae0e", ... }
```
Neither of these commits exists in their respective public repos.

**Fix:** Added `git_upstream_commit()` to `manifest_utils.py` that resolves the `THEROCK_UPSTREAM_DIFFBASE` tag, set by repo_management.py at the real upstream commit before HIPIFY runs. Falls back to HEAD for repos that don't use the TheRock checkout wrapper (e.g. JAX).

**Impact:**
- PyTorch / Triton — now records the real upstream commit
- JAX — no change, falls back to HEAD (no HIPIFY, tag absent)

## Test Result
https://github.com/ROCm/TheRock/actions/runs/23478020311