### PR TITLE
Revert "Use TEST_TYPE directly as categories for test filtering"

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -8,8 +8,7 @@ TEST_COMPONENT: Job name of the component to test (e.g., "miopen", "rocrand", "h
     This is automatically set by the GitHub Actions workflow from the job_name field.
     The script maps these job names to actual test directory names (e.g., "miopen" -> "MIOpen")
     Defaults to "miopen" if not set.
-TEST_TYPE: Test category to run - one of "quick", "standard", "comprehensive", or "full".
-    Defaults to "quick". Invalid values fall back to "quick" with an error message.
+TEST_TYPE: "quick" runs tests with "quick" category, otherwise runs "standard" category
 AMDGPU_FAMILIES: Parsed to extract GPU architecture (e.g., "gfx1151")
 
 The script discovers GPU-specific labels via ctest --print-labels and runs the appropriate tests for the current GPU architecture.
@@ -27,7 +26,6 @@ from pathlib import Path
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
-VALID_TEST_CATEGORIES = {"quick", "standard", "comprehensive", "full"}
 TEST_TYPE = os.getenv("TEST_TYPE", "quick")
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 
@@ -221,15 +219,11 @@ def build_ctest_command(category, gpu_arch, available_gpu_archs):
 
 
 def main():
-    category = TEST_TYPE.lower() if TEST_TYPE else "quick"
-    if category not in VALID_TEST_CATEGORIES:
-        print(
-            f"ERROR: Invalid TEST_TYPE '{TEST_TYPE}'. "
-            f"Must be one of: {', '.join(sorted(VALID_TEST_CATEGORIES))}. "
-            f"Falling back to 'quick'.",
-            file=sys.stderr,
-        )
+    # Use only two categories for now - quick and standard - depending on TEST_TYPE.
+    if TEST_TYPE and TEST_TYPE.lower() == "quick":
         category = "quick"
+    else:
+        category = "standard"
 
     # Use AMDGPU_FAMILIES from environment variable, extract gfx<xxx> part
     gpu_arch = ""


### PR DESCRIPTION
Reverts ROCm/TheRock#4008

This caused issues in miopen CI running the unintended `full` category instead of the `standard`.
CI is blocking PRs now, need to unblock until we address this change from miopen.