### PR TITLE
Fix workflow input descriptions for build_*_python_packages.yml

### DIFF
--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -18,7 +18,7 @@ on:
         description: "artifact_group to build (e.g. 'gfx94X-dcgpu' for single family builds, 'multi-arch-release' for multi-arch builds with 'amdgpu_families' set)"
         type: string
       amdgpu_families:
-        description: "amdgpu_families for multi-arch builds as a semicolon-separated list (e.g. 'gfx94X-dcgpu;gfx120X-all'). Leave empty for single-family builds (those only use artifact_group)."
+        description: "amdgpu_families for multi-arch builds as a semicolon-separated list (e.g. 'gfx94X-dcgpu;gfx120X-all'). Leave empty for single-family builds (those only use artifact_group)"
         type: string
         default: ""
       multiarch_index:

--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -18,7 +18,7 @@ on:
         description: "artifact_group to build (e.g. 'gfx94X-dcgpu' for single family builds, 'multi-arch-release' for multi-arch builds with 'amdgpu_families' set)"
         type: string
       amdgpu_families:
-        description: "amdgpu_families for multi-arch builds as a semicolon-separated list (e.g. 'gfx94X-dcgpu;gfx120X-all'). Leave empty for single-family builds (those only use artifact_group)."
+        description: "amdgpu_families for multi-arch builds as a semicolon-separated list (e.g. 'gfx94X-dcgpu;gfx120X-all'). Leave empty for single-family builds (those only use artifact_group)"
         type: string
         default: ""
       multiarch_index:


### PR DESCRIPTION
## Motivation

Actual inputs did not match the descriptions

Input | Issue
-- | --
`amdgpu_families` | https://github.com/ROCm/TheRock/pull/3854 changed `artifact_manager.py` to accept a semicolon-delimited list instead of a comma-delimited list but these input descriptions still suggested comma
`artifact_group` | multi-arch CI uses "artifact-group" values like `multi-arch-release`: https://github.com/ROCm/TheRock/blob/7cb75f20690d0b49b33b616570c6346cc99033a0/build_tools/github_actions/configure_ci.py#L240 https://github.com/ROCm/TheRock/blob/7cb75f20690d0b49b33b616570c6346cc99033a0/build_tools/github_actions/configure_ci.py#L526-L531

## Technical Details

Example workflow run, issues highlighted with `+`:
https://github.com/ROCm/TheRock/actions/runs/23356803838/job/67968231459#step:1:15
```diff
 Inputs
    artifact_github_repo: 
    artifact_run_id: 
+   artifact_group: multi-arch-release
+   amdgpu_families: gfx94X-dcgpu;gfx1151;gfx120X-all
    multiarch_index: true
    package_version: 7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27
    linux_amdgpu_families: gfx94X, gfx1151, gfx120X
    linux_test_labels: test:aqlprofile
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
