### PR TITLE
Fix URL encoding in multi-arch Python package index and add logging

### DIFF
--- a/build_tools/_therock_utils/storage_backend.py
+++ b/build_tools/_therock_utils/storage_backend.py
@@ -144,6 +144,17 @@ class StorageBackend(ABC):
             )
             for f in sorted_files
         ]
+        logger.info(
+            "upload_directory: %s -> %s/%s (%d files)",
+            source_dir,
+            dest.bucket,
+            dest.relative_path,
+            len(file_list),
+        )
+        for f, loc in file_list[:100]:
+            logger.info("  %s", f.relative_to(source_dir).as_posix())
+        if len(file_list) > 100:
+            logger.info("  ... and %d more", len(file_list) - 100)
         return self.upload_files(file_list)
 
 
@@ -267,6 +278,7 @@ class S3StorageBackend(StorageBackend):
             logger.info("[DRY RUN] %s -> %s (%s)", source, dest.s3_uri, content_type)
             return
 
+        logger.debug("upload %s -> %s (%s)", source, dest.s3_uri, content_type)
         _s3_retry(
             "upload",
             dest.s3_uri,

--- a/build_tools/github_actions/upload_python_packages.py
+++ b/build_tools/github_actions/upload_python_packages.py
@@ -135,9 +135,17 @@ def upload_packages(
     if not package_files:
         raise FileNotFoundError(f"No package files found in {dist_dir}")
 
-    log(f"[INFO] Found {len(package_files)} package files in {dist_dir}:")
+    log(f"[INFO] Found {len(package_files)} top-level package files in {dist_dir}:")
     for f in package_files:
         log(f"  - {f.relative_to(dist_dir)}")
+
+    # Log all files that will actually be uploaded (including subdirectories).
+    all_files = sorted(
+        f for f in dist_dir.rglob("*") if f.is_file() and not f.is_symlink()
+    )
+    log(f"[INFO] Uploading {len(all_files)} total files to {packages_loc.s3_uri}:")
+    for f in all_files:
+        log(f"  {f.relative_to(dist_dir).as_posix()}")
 
     count = backend.upload_directory(dist_dir, packages_loc)
     log(f"[INFO] Uploaded {count} files")

--- a/build_tools/packaging/python/generate_local_index.py
+++ b/build_tools/packaging/python/generate_local_index.py
@@ -28,6 +28,7 @@ Usage as a script:
 import argparse
 import sys
 from pathlib import Path
+from urllib.parse import quote
 
 
 def generate_simple_index(
@@ -85,12 +86,12 @@ def generate_simple_index(
     # Add local files with ./ prefix
     for file_path in sorted(local_files):
         filename = file_path.name
-        html_parts.append(f'  <a href="./{filename}">{filename}</a><br>')
+        html_parts.append(f'  <a href="./{quote(filename)}">{filename}</a><br>')
 
     # Add parent files with ../ prefix
     for file_path in sorted(parent_files):
         filename = file_path.name
-        html_parts.append(f'  <a href="../{filename}">{filename}</a><br>')
+        html_parts.append(f'  <a href="../{quote(filename)}">{filename}</a><br>')
 
     html_parts.extend(["</body>", "</html>", ""])  # Trailing newline
 

--- a/build_tools/packaging/tests/generate_local_index_test.py
+++ b/build_tools/packaging/tests/generate_local_index_test.py
@@ -136,6 +136,40 @@ class TestGenerateSimpleIndex(unittest.TestCase):
             # Check it ends with newline
             self.assertTrue(content.endswith("\n"))
 
+    def test_plus_in_filename_is_url_encoded(self):
+        """Test that '+' in filenames is percent-encoded in hrefs.
+
+        PEP 440 local versions produce filenames like
+        'pkg-1.0+localver-py3-none-any.whl'. S3 interprets a literal '+'
+        in URL paths as a space, so hrefs must encode '+' as '%2B'.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "index.html"
+            local_files = [
+                Path(tmp) / "rocm_sdk_core-7.0.0+abc123-py3-none-linux_x86_64.whl",
+            ]
+            parent_files = [
+                Path(tmp) / "rocm_sdk_libs-7.0.0+abc123-py3-none-linux_x86_64.whl",
+            ]
+
+            generate_simple_index(output, local_files, parent_files=parent_files)
+
+            content = output.read_text()
+            # href should have %2B, not literal +
+            self.assertIn(
+                'href="./rocm_sdk_core-7.0.0%2Babc123-py3-none-linux_x86_64.whl"',
+                content,
+            )
+            self.assertIn(
+                'href="../rocm_sdk_libs-7.0.0%2Babc123-py3-none-linux_x86_64.whl"',
+                content,
+            )
+            # Display text should still have literal +
+            self.assertIn(
+                ">rocm_sdk_core-7.0.0+abc123-py3-none-linux_x86_64.whl</a>",
+                content,
+            )
+
 
 class TestGenerateMultiarchIndexes(unittest.TestCase):
     """Tests for generate_multiarch_indexes()."""


### PR DESCRIPTION
## Motivation

Multi-arch CI jobs like https://github.com/ROCm/TheRock/actions/runs/23356803838/job/67968231459 produce index pages like https://therock-ci-artifacts.s3.amazonaws.com/23356803838-linux/python/gfx1151/index.html with URLs like https://therock-ci-artifacts.s3.amazonaws.com/23356803838-linux/python/rocm_sdk_core-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl which 404 due to the `+` character which should be escaped as `%2B`.

I also took the chance to add more logging of what files were uploaded, so we can verify that 404s aren't upload failures.

## Technical Details

Here is where the package uploading code branches between index scripts:
https://github.com/ROCm/TheRock/blob/7cb75f20690d0b49b33b616570c6346cc99033a0/build_tools/github_actions/upload_python_packages.py#L98-L105

The `indexer.py` script used by the single-arch CI code path already escapes here: https://github.com/ROCm/TheRock/blob/7cb75f20690d0b49b33b616570c6346cc99033a0/third-party/indexer/indexer.py#L346

## Test Plan

* New unit test
* CI on the PR itself (check logs, index page)
* Manual testing ahead of the PR
  1. Rebase this PR on https://github.com/ROCm/TheRock/pull/4122
  2. Trigger a workflow run with inputs matching those on https://github.com/ROCm/TheRock/actions/runs/23356803838/job/67968231459#step:1:15
      ```
       Inputs
          artifact_github_repo: 
          artifact_run_id: 
          artifact_group: multi-arch-release
          amdgpu_families: gfx94X-dcgpu;gfx1151;gfx120X-all
          multiarch_index: true
          package_version: 7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27
      ```
  3. Check the generated index pages and try downloading files

## Test Result

Manual testing: https://github.com/ROCm/TheRock/actions/runs/23504275622

<details><summary>URL encoding comparison</summary>
<p>

Baseline index: https://therock-ci-artifacts.s3.amazonaws.com/23356803838-linux/python/gfx1151/index.html
Sample URL (404): https://therock-ci-artifacts.s3.amazonaws.com/23356803838-linux/python/rocm_sdk_core-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl

New index: https://therock-ci-artifacts.s3.amazonaws.com/23504275622-linux/python/gfx1151/index.html
Sample URL (working): https://therock-ci-artifacts.s3.amazonaws.com/23504275622-linux/python/rocm_sdk_core-7.13.0.dev0%2B8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl

</p>
</details> 

<details><summary>Logs comparison</summary>
<p>

Baseline logs: https://github.com/ROCm/TheRock/actions/runs/23356803838/job/67968231459#step:8:45
```
[INFO] Found 4 package files in /home/runner/_work/TheRock/TheRock/packages/dist:
  - rocm_sdk_core-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
  - rocm_sdk_libraries_gfx1151-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
  - rocm_sdk_libraries_gfx120x_all-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
  - rocm_sdk_libraries_gfx94x_dcgpu-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
[INFO] Uploaded 13 files
[INFO] Multi-arch base URL (tests append /{family}/index.html): https://therock-ci-artifacts.s3.amazonaws.com/23356803838-linux/python
```

New logs: https://github.com/ROCm/TheRock/actions/runs/23504275622/job/68407671893#step:8:45
```
[INFO] Found 4 top-level package files in /home/runner/_work/TheRock/TheRock/packages/dist:
  - rocm_sdk_core-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
  - rocm_sdk_libraries_gfx1151-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
  - rocm_sdk_libraries_gfx120x_all-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
  - rocm_sdk_libraries_gfx94x_dcgpu-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
[INFO] Uploading 13 total files to s3://therock-ci-artifacts/23504275622-linux/python:
  gfx1151/index.html
  gfx1151/rocm-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27.tar.gz
  gfx1151/rocm_sdk_devel-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
  gfx120X-all/index.html
  gfx120X-all/rocm-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27.tar.gz
  gfx120X-all/rocm_sdk_devel-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
  gfx94X-dcgpu/index.html
  gfx94X-dcgpu/rocm-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27.tar.gz
  gfx94X-dcgpu/rocm_sdk_devel-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
  rocm_sdk_core-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
  rocm_sdk_libraries_gfx1151-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
  rocm_sdk_libraries_gfx120x_all-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
  rocm_sdk_libraries_gfx94x_dcgpu-7.13.0.dev0+8027b7b9eb0d87c9bb0d28ee6a0902a1047feb27-py3-none-linux_x86_64.whl
[INFO] Uploaded 13 files
[INFO] Multi-arch base URL (tests append /{family}/index.html): https://therock-ci-artifacts.s3.amazonaws.com/23504275622-linux/python
```

</p>
</details> 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
