### PR TITLE
Disable ASAN instrumentation for third-party dependencies

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -43,7 +43,24 @@
         "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_CXX_FLAGS": "-g1",
-        "CMAKE_C_FLAGS": "-g1"
+        "CMAKE_C_FLAGS": "-g1",
+        "therock-boost_SANITIZER": "OFF",
+        "therock-catch2_SANITIZER": "OFF",
+        "therock-googletest_SANITIZER": "OFF",
+        "therock-eigen_SANITIZER": "OFF",
+        "therock-fftw3_SANITIZER": "OFF",
+        "therock-flatbuffers_SANITIZER": "OFF",
+        "therock-fmt_SANITIZER": "OFF",
+        "therock-frugally-deep_SANITIZER": "OFF",
+        "therock-FunctionalPlus_SANITIZER": "OFF",
+        "therock-grpc_SANITIZER": "OFF",
+        "therock-host-blas_SANITIZER": "OFF",
+        "therock-libdivide_SANITIZER": "OFF",
+        "therock-msgpack-cxx_SANITIZER": "OFF",
+        "therock-nlohmann-json_SANITIZER": "OFF",
+        "therock-simde_SANITIZER": "OFF",
+        "therock-SuiteSparse_SANITIZER": "OFF",
+        "therock-yaml-cpp_SANITIZER": "OFF"
       }
     },
     {


### PR DESCRIPTION
## Motivation

This PR disables ASAN (AddressSanitizer) instrumentation for third-party components in the CMake build configuration. The goal is to prevent Address Sanitizer from instrumenting external dependencies, which can cause false positives, increased build times, and potential compatibility issues when these libraries are built with different instrumentation settings than the main ROCm codebase.

## Technical Details

Modified `CMakePresets.json` to disable ASAN instrumentation for the following third-party libraries by setting their respective `*_SANITIZER` cache variables to "OFF":

- boost
- Catch2
- googletest
- eigen
- fftw3
- flatbuffers
- fmt
- frugally-deep
- FunctionalPlus
- grpc
- host-blas
- libdivide
- msgpack-cxx
- nlohmann-json
- simde
- SuiteSparse
- yaml-cpp

This ensures that these external dependencies are built without ASAN instrumentation while allowing the main ROCm components to maintain their sanitizer settings independently.

## Test Plan

- Verified CMakePresets.json is valid JSON syntax
- Built TheRock with the new configuration to ensure all third-party components configure and compile successfully
- Confirmed that the sanitizer settings do not affect the main ROCm build process

## Test Result

All builds completed successfully. Third-party components compile without ASAN instrumentation, and the main ROCm codebase can still apply its own sanitizer settings as appropriate.
