### PR TITLE
Add amdgpu_family_matrix_test.py with basic coverage

### DIFF
--- a/build_tools/github_actions/tests/amdgpu_family_matrix_test.py
+++ b/build_tools/github_actions/tests/amdgpu_family_matrix_test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for data invariants in amdgpu_family_matrix.py."""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+from amdgpu_family_matrix import get_all_families_for_trigger_types
+
+ALL_FAMILIES = get_all_families_for_trigger_types(
+    ["presubmit", "postsubmit", "nightly"]
+)
+
+
+class TestFamilyMatrixInvariants(unittest.TestCase):
+    """Validate structural invariants on the family matrix data."""
+
+    def test_no_duplicate_family_names_per_platform(self):
+        """Each (platform, family) pair must be unique across target names.
+
+        Two target names mapping to the same amdgpu_family on the same
+        platform would cause silent data loss in matrix expansion.
+        """
+        for platform in ("linux", "windows"):
+            seen: dict[str, str] = {}  # family → target_name
+            for target_name, entry in ALL_FAMILIES.items():
+                if platform not in entry:
+                    continue
+                family = entry[platform]["family"]
+                if family in seen:
+                    self.fail(
+                        f"Duplicate family {family!r} on {platform}: "
+                        f"target {target_name!r} and {seen[family]!r}"
+                    )
+                seen[family] = target_name
+
+    def test_required_fields_present(self):
+        """Every platform entry must have the required fields."""
+        required = {"family", "fetch-gfx-targets", "test-runs-on", "build_variants"}
+        for target_name, entry in ALL_FAMILIES.items():
+            for platform in ("linux", "windows"):
+                if platform not in entry:
+                    continue
+                platform_info = entry[platform]
+                missing = required - platform_info.keys()
+                if missing:
+                    self.fail(
+                        f"{target_name}/{platform} missing required fields: {missing}"
+                    )
+
+    def test_build_variants_non_empty(self):
+        """Every platform entry must list at least one build variant."""
+        for target_name, entry in ALL_FAMILIES.items():
+            for platform in ("linux", "windows"):
+                if platform not in entry:
+                    continue
+                variants = entry[platform].get("build_variants", [])
+                if not variants:
+                    self.fail(f"{target_name}/{platform} has empty build_variants")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

I'm adding new code that depends on [`amdgpu_family_matrix.py`](https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/amdgpu_family_matrix.py) in https://github.com/ROCm/TheRock/pull/4123 and I want these structural invariants tested locally so I don't need to assert on them in the new downstream code.

## Technical Details

We'll migrate over to https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/new_amdgpu_family_matrix.py soon, so I'm just adding a minimal set of tests for now.

## Test Plan

* Run the unit tests

## Test Results

Tests can fail as expected:
* `test_required_fields_present`
  ```diff
  λ git diff
  diff --git a/build_tools/github_actions/amdgpu_family_matrix.py b/build_tools/github_actions/amdgpu_family_matrix.py
  --- a/build_tools/github_actions/amdgpu_family_matrix.py
  +++ b/build_tools/github_actions/amdgpu_family_matrix.py
  @@ -174,7 +174,6 @@ amdgpu_family_info_matrix_nightly = {
           "windows": {
               "test-runs-on": "",
               "family": "gfx900",
  -            "fetch-gfx-targets": [],
               "build_variants": ["release"],
               "expect_pytorch_failure": True,
           },
  ```
  ```
  (.venv) λ pytest build_tools/github_actions/tests/amdgpu_family_matrix_test.py -vv
  ...
  build_tools\github_actions\tests\amdgpu_family_matrix_test.py::TestFamilyMatrixInvariants::test_required_fields_present
  - AssertionError: gfx900/windows missing required fields: {'fetch-gfx-targets'}
  ```
* `test_no_duplicate_family_names_per_platform`
  ```diff
  diff --git a/build_tools/github_actions/amdgpu_family_matrix.py b/build_tools/github_actions/amdgpu_family_matrix.py
  index 63ad8c83..6eae4125 100644
  --- a/build_tools/github_actions/amdgpu_family_matrix.py
  +++ b/build_tools/github_actions/amdgpu_family_matrix.py
  @@ -146,6 +146,18 @@ amdgpu_family_info_matrix_presubmit = {
               "build_variants": ["release"],
           },
       },
  +    "gfx120x-all": {
  +        "linux": {
  +            # TODO(#2683): Re-enable label once stable
  +            # Label is linux-gfx120X-gpu-rocm
  +            "test-runs-on": "",
  +            "family": "gfx120X-all",
  +            "fetch-gfx-targets": ["gfx1200", "gfx1201"],
  +            "bypass_tests_for_releases": True,
  +            "build_variants": ["release"],
  +            "sanity_check_only_for_family": True,
  +        },
  +    },
   }
  ```
  ```
  (.venv) λ pytest build_tools/github_actions/tests/amdgpu_family_matrix_test.py -vv
  ...
  build_tools\github_actions\tests\amdgpu_family_matrix_test.py::TestFamilyMatrixInvariants::test_no_duplicate_family_names_per_platform
  - AssertionError: Duplicate family 'gfx120X-all' on linux: target 'gfx120x-all' and 'gfx120x'
  ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
