### PR TITLE
Update ci_behavior_manipulation.md for multi-arch CI

### DIFF
--- a/docs/development/ci_behavior_manipulation.md
+++ b/docs/development/ci_behavior_manipulation.md
@@ -2,10 +2,19 @@
 
 TheRock has two CI pipelines:
 
-- **CI** ([`ci.yml`](https://github.com/ROCm/TheRock/actions/workflows/ci.yml)) — single-arch builds, configured by [`configure_ci.py`](../../build_tools/github_actions/configure_ci.py)
-- **Multi-Arch CI** ([`multi_arch_ci.yml`](https://github.com/ROCm/TheRock/actions/workflows/multi_arch_ci.yml)) — multi-arch builds, configured by [`configure_multi_arch_ci.py`](../../build_tools/github_actions/configure_multi_arch_ci.py)
+- **CI** ([`ci.yml`](https://github.com/ROCm/TheRock/actions/workflows/ci.yml)): single-arch builds, configured by [`configure_ci.py`](../../build_tools/github_actions/configure_ci.py)
+- **Multi-Arch CI** ([`multi_arch_ci.yml`](https://github.com/ROCm/TheRock/actions/workflows/multi_arch_ci.yml)): multi-arch builds, configured by [`configure_ci.py`](../../build_tools/github_actions/configure_ci.py)
+
+<!-- TODO(#3399): link to configure_multi_arch_ci.py when it lands -->
 
 Both read GPU family definitions from [`amdgpu_family_matrix.py`](../../build_tools/github_actions/amdgpu_family_matrix.py).
+
+> [!IMPORTANT]
+> "Multi-arch CI" is set to replace "CI". See these issues for details:
+>
+> - [[Multi-arch] Extend and improve multi-arch CI (#3336)](https://github.com/ROCm/TheRock/issues/3336)
+> - [[Multi-arch] Enable multi-arch CI on pre-submit (#3337)](https://github.com/ROCm/TheRock/issues/3337)
+> - [[Multi-arch] Remove single stage (non-multi-arch) CI (#3340)](https://github.com/ROCm/TheRock/issues/3340)
 
 ## Trigger behavior
 


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/3399. I'm extending the configuration scripts/workflows for multi-arch CI in https://github.com/ROCm/TheRock/pull/4123 and the docs could use a refresh.

## Technical Details

* Highlight the differences between what jobs run on different triggers (I also have changes on https://github.com/ROCm/TheRock/pull/4123 that will surface this in the step summary output)
* Elaborate on "CI" vs "Multi-Arch CI" setup and roadmap

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
