### PR TITLE
[Tensile] Set up install-tree CTest wiring (test_runner + test matrix)

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -85,6 +85,18 @@ test_matrix = {
             "windows": 6,
         },
     },
+    "tensile": {
+        "job_name": "tensile",
+        # tensile-tests ships with the BLAS test artifact merge today; revisit if split out.
+        "fetch_artifact_args": "--blas --tests",
+        "timeout_minutes": 30,
+        "test_script": f"python {_get_script_path('test_runner.py')}",
+        "platform": ["linux"],
+        "total_shards_dict": {
+            "linux": 1,
+            "windows": 1,
+        },
+    },
     "rocroller": {
         "job_name": "rocroller",
         "fetch_artifact_args": "--blas --tests",

--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -37,6 +37,7 @@ AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 COMPONENT_DIR_MAPPING = {
     "miopen": "MIOpen",
     "rocblas": "rocblas",
+    "tensile": "tensile",
     "rocrand": "rocRAND",
     "hiprand": "hipRAND",
     "rocthrust": "rocthrust",


### PR DESCRIPTION
**Jira:** AIROCBLAS-1259

## Summary

Wires **Tensile** into the same install-tree **CTest** pattern used for rocBLAS/MIOpen: `test_runner.py` resolves `TEST_COMPONENT=tensile` to `THEROCK_BIN_DIR/tensile`, and the shared test matrix defines a **`tensile`** job that uses the BLAS+tests artifact fetch path until Tensile is split out if needed.

## Changes

- **`test_runner.py`:** Add `"tensile": "tensile"` to `COMPONENT_DIR_MAPPING` so `ctest --test-dir …/bin/tensile` matches the install layout (`bin/tensile/CTestTestfile.cmake` + `../tensile-tests`), consistent with [rocm-libraries test filter / CTest standardization](https://github.com/ROCm/rocm-libraries/pull/4659)-style packaging.
- **`fetch_test_configurations.py`:** Add a **`tensile`** entry to `test_matrix` (`fetch_artifact_args`: `--blas --tests`, `test_runner.py`, Linux, single shard, 30 min step timeout).

## Context

This is the **TheRock** side of Tensile host GTest CTest integration; the rocm-libraries changes (YAML, `next-cmake` install rules, `shared/ctest`) land separately. CI will only exercise this path once unified build artifacts include **`bin/tensile-tests`**, **`bin/data/`**, and **`bin/tensile/CTestTestfile.cmake`** under `THEROCK_BIN_DIR`.

## Test plan

- [ ] Confirm `fetch_test_configurations` / matrix selection includes `tensile` when expected.
- [ ] After rocm-libraries + superproject install merge land: run component test workflow with `TEST_COMPONENT=tensile` and verify `ctest` from `bin/tensile`.

## Checklist

- [ ] Contributing guidelines: https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests
