### PR TITLE
Maintain backward compatibility with legacy ROCm directory structure

### DIFF
--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-postinst.j2
@@ -56,6 +56,15 @@ do_update_alternatives(){
     update-alternatives --install "/opt/rocm/core" "core" "$PKG_INSTALL_PREFIX" "$altscore"
     update-alternatives --install "/opt/rocm/core-{{ version_major }}" "core-{{ version_major }}" "$PKG_INSTALL_PREFIX" "$altscore"
 
+    # Install /opt/rocm/bin, /opt/rocm/lib, and /opt/rocm/include soft links
+    update-alternatives --install "/opt/rocm/bin" "rocm-bin" "$PKG_INSTALL_PREFIX/bin" "$altscore"
+    update-alternatives --install "/opt/rocm/lib" "rocm-lib" "$PKG_INSTALL_PREFIX/lib" "$altscore"
+    update-alternatives --install "/opt/rocm/include" "rocm-include" "$PKG_INSTALL_PREFIX/include" "$altscore"
+
+    # Install /opt/rocm/llvm, /opt/rocm/amdgcn, and /opt/rocm/libexec soft links
+    update-alternatives --install "/opt/rocm/llvm" "rocm-llvm" "$PKG_INSTALL_PREFIX/llvm" "$altscore"
+    update-alternatives --install "/opt/rocm/amdgcn" "rocm-amdgcn" "$PKG_INSTALL_PREFIX/amdgcn" "$altscore"
+    update-alternatives --install "/opt/rocm/libexec" "rocm-libexec" "$PKG_INSTALL_PREFIX/libexec" "$altscore"
 
     for i in "${binaries[@]}"
     do

--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-prerm.j2
@@ -33,6 +33,16 @@ do_update_alternatives(){
     # Remove /opt/rocm/core soft link
     update-alternatives --remove "core" "$PKG_INSTALL_PREFIX"
     update-alternatives --remove "core-{{ version_major }}" "$PKG_INSTALL_PREFIX"
+
+    # Remove /opt/rocm/bin, /opt/rocm/lib, and /opt/rocm/include soft links
+    update-alternatives --remove "rocm-bin" "$PKG_INSTALL_PREFIX/bin"
+    update-alternatives --remove "rocm-lib" "$PKG_INSTALL_PREFIX/lib"
+    update-alternatives --remove "rocm-include" "$PKG_INSTALL_PREFIX/include"
+
+    # Remove /opt/rocm/llvm, /opt/rocm/amdgcn, and /opt/rocm/libexec soft links
+    update-alternatives --remove "rocm-llvm" "$PKG_INSTALL_PREFIX/llvm"
+    update-alternatives --remove "rocm-amdgcn" "$PKG_INSTALL_PREFIX/amdgcn"
+    update-alternatives --remove "rocm-libexec" "$PKG_INSTALL_PREFIX/libexec"
 }
 
 if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"

--- a/build_tools/packaging/linux/template/scripts/amdrocm-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-postinst.j2
@@ -56,6 +56,15 @@ do_update_alternatives(){
     update-alternatives --install "/opt/rocm/core" "core" "$PKG_INSTALL_PREFIX" "$altscore"
     update-alternatives --install "/opt/rocm/core-{{ version_major }}" "core-{{ version_major }}" "$PKG_INSTALL_PREFIX" "$altscore"
 
+    # Install /opt/rocm/bin, /opt/rocm/lib, and /opt/rocm/include soft links
+    update-alternatives --install "/opt/rocm/bin" "rocm-bin" "$PKG_INSTALL_PREFIX/bin" "$altscore"
+    update-alternatives --install "/opt/rocm/lib" "rocm-lib" "$PKG_INSTALL_PREFIX/lib" "$altscore"
+    update-alternatives --install "/opt/rocm/include" "rocm-include" "$PKG_INSTALL_PREFIX/include" "$altscore"
+
+    # Install /opt/rocm/llvm, /opt/rocm/amdgcn, and /opt/rocm/libexec soft links
+    update-alternatives --install "/opt/rocm/llvm" "rocm-llvm" "$PKG_INSTALL_PREFIX/llvm" "$altscore"
+    update-alternatives --install "/opt/rocm/amdgcn" "rocm-amdgcn" "$PKG_INSTALL_PREFIX/amdgcn" "$altscore"
+    update-alternatives --install "/opt/rocm/libexec" "rocm-libexec" "$PKG_INSTALL_PREFIX/libexec" "$altscore"
 
     for i in "${binaries[@]}"
     do

--- a/build_tools/packaging/linux/template/scripts/amdrocm-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-prerm.j2
@@ -33,6 +33,16 @@ do_update_alternatives(){
     # Remove /opt/rocm/core soft link
     update-alternatives --remove "core" "$PKG_INSTALL_PREFIX"
     update-alternatives --remove "core-{{ version_major }}" "$PKG_INSTALL_PREFIX"
+
+    # Remove /opt/rocm/bin, /opt/rocm/lib, and /opt/rocm/include soft links
+    update-alternatives --remove "rocm-bin" "$PKG_INSTALL_PREFIX/bin"
+    update-alternatives --remove "rocm-lib" "$PKG_INSTALL_PREFIX/lib"
+    update-alternatives --remove "rocm-include" "$PKG_INSTALL_PREFIX/include"
+
+    # Remove /opt/rocm/llvm, /opt/rocm/amdgcn, and /opt/rocm/libexec soft links
+    update-alternatives --remove "rocm-llvm" "$PKG_INSTALL_PREFIX/llvm"
+    update-alternatives --remove "rocm-amdgcn" "$PKG_INSTALL_PREFIX/amdgcn"
+    update-alternatives --remove "rocm-libexec" "$PKG_INSTALL_PREFIX/libexec"
 }
 
 if [ -e /etc/os-release ] && source /etc/os-release && is_debian_like "${ID_LIKE:-$ID}"


### PR DESCRIPTION
Add update-alternatives symlinks to preserve the traditional /opt/rocm directory layout (bin, lib, include, llvm, amdgcn, libexec) for applications built against previous ROCm versions

**Test Results:**
(.venv) root@dell-rack-13:/opt/rocm# ls -l
amdgcn -> /etc/alternatives/rocm-amdgcn
 bin -> /etc/alternatives/rocm-bin
 core -> /etc/alternatives/core
 core-8 -> /etc/alternatives/core-8
 core-8.1
 include -> /etc/alternatives/rocm-include
 lib -> /etc/alternatives/rocm-lib
 libexec -> /etc/alternatives/rocm-libexec
 llvm -> /etc/alternatives/rocm-llvm
 
 ls -l /etc/alternatives/rocm-*      
 /etc/alternatives/rocm-amdgcn -> /opt/rocm/core-8.1/amdgcn
 /etc/alternatives/rocm-bin -> /opt/rocm/core-8.1/bin
 /etc/alternatives/rocm-include -> /opt/rocm/core-8.1/include
 /etc/alternatives/rocm-lib -> /opt/rocm/core-8.1/lib
 /etc/alternatives/rocm-libexec -> /opt/rocm/core-8.1/libexec
 /etc/alternatives/rocm-llvm -> /opt/rocm/core-8.1/llvm
 /etc/alternatives/rocm-smi -> /opt/rocm/core-8.1/bin/rocm-smi