### PR TITLE
[rocm_sdk/tests] Compare devel root vs. hipconfig with samefile

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/devel_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/devel_test.py
@@ -84,7 +84,9 @@ class ROCmDevelTest(unittest.TestCase):
             .strip()
         )
         rocmpath = Path(rocmpath_output)
-        self.assertTrue(root_path.is_dir(), msg=f"Expected root path {root_path} to exist")
+        self.assertTrue(
+            root_path.is_dir(), msg=f"Expected root path {root_path} to exist"
+        )
         self.assertTrue(
             rocmpath.is_dir(),
             msg=f"Expected `hipconfig --rocmpath` directory {rocmpath} to exist",


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/4040 (the latter point)

`testCLIUsesDevelRootPath` asserted that `rocm_sdk path --root` and `hipconfig --rocmpath` return identical path strings. On common Linux `venv` layouts (e.g. RHEL-style images where `lib64` is a symlink to `lib`), both commands still refer to the same `_rocm_sdk_devel` tree, but one path may be spelled with `lib64/...` and the other after `realpath`-style resolution as `lib/...`. That produced a false failure though the install was correct.

## Technical Details

- Replace strict `Path` equality with `os.path.samefile(root_path, rocmpath)` so we compare the same directory on disk, not the string form.
- `assertTrue(..., is_dir())` on both paths before `samefile` so failures are clear if either side is missing or not a directory.

## Test Plan

- Run `rocm-sdk test` from a `venv` with `rocm[devel]` installed

## Test Result

- Confirmed `testCLIUsesDevelRootPath` passes when `path --root` and `--rocmpath` differ only by symlink spelling.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
