### PR TITLE
Expose hipdnn_flatbuffers_sdk package from hipDNN subproject

### DIFF
--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -190,6 +190,7 @@ if(THEROCK_ENABLE_HIPDNN)
   )
 
   therock_cmake_subproject_provide_package(hipDNN hipdnn_data_sdk lib/cmake/hipdnn_data_sdk)
+  therock_cmake_subproject_provide_package(hipDNN hipdnn_flatbuffers_sdk lib/cmake/hipdnn_flatbuffers_sdk)
   therock_cmake_subproject_provide_package(hipDNN hipdnn_plugin_sdk lib/cmake/hipdnn_plugin_sdk)
   therock_cmake_subproject_provide_package(hipDNN hipdnn_test_sdk lib/cmake/hipdnn_test_sdk)
   therock_cmake_subproject_provide_package(hipDNN hipdnn_frontend lib/cmake/hipdnn_frontend)


### PR DESCRIPTION
## Summary

- Adds `therock_cmake_subproject_provide_package` for `hipdnn_flatbuffers_sdk`, a new SDK recently added to hipDNN in rocm-libraries
- The package name and cmake install path (`lib/cmake/hipdnn_flatbuffers_sdk`) match the upstream hipDNN install rules exactly

## Test plan

- [x] Build with `THEROCK_ENABLE_HIPDNN=ON` and verify `hipdnn_flatbuffers_sdk` is accessible as a provided package downstream
- [x] Include flatbuffers_sdk headers and compile