### PR TITLE
Bump gRPC to v1.78.1

### DIFF
--- a/dctools/CMakeLists.txt
+++ b/dctools/CMakeLists.txt
@@ -8,8 +8,12 @@ if(THEROCK_ENABLE_RDC)
     message(FATAL_ERROR "RDC requires Linux (Windows not supported)")
   endif()
 
-  # Get gRPC stage directory for RDC's GRPC_ROOT requirement
-  get_target_property(_grpc_stage therock-grpc THEROCK_STAGE_DIR)
+  # Get gRPC dist directory for RDC's GRPC_ROOT requirement.
+  # Use THEROCK_DIST_DIR (not THEROCK_STAGE_DIR) because the dist directory
+  # includes merged runtime deps (e.g. bundled zlib), ensuring that gRPC
+  # executables like grpc_cpp_plugin can resolve all shared library dependencies
+  # when invoked during RDC's configure step.
+  get_target_property(_grpc_stage therock-grpc THEROCK_DIST_DIR)
 
   therock_cmake_subproject_declare(rdc
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rdc"

--- a/dctools/CMakeLists.txt
+++ b/dctools/CMakeLists.txt
@@ -13,7 +13,7 @@ if(THEROCK_ENABLE_RDC)
   # includes merged runtime deps (e.g. bundled zlib), ensuring that gRPC
   # executables like grpc_cpp_plugin can resolve all shared library dependencies
   # when invoked during RDC's configure step.
-  get_target_property(_grpc_stage therock-grpc THEROCK_DIST_DIR)
+  get_target_property(_grpc_dist therock-grpc THEROCK_DIST_DIR)
 
   therock_cmake_subproject_declare(rdc
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rdc"
@@ -29,7 +29,7 @@ if(THEROCK_ENABLE_RDC)
       -DBUILD_TESTS=${THEROCK_BUILD_TESTING}
       -DHIP_PLATFORM=amd
       -DCMAKE_CXX_STANDARD=17
-      -DGRPC_ROOT=${_grpc_stage}
+      -DGRPC_ROOT=${_grpc_dist}
       -DGRPC_DESIRED_VERSION=${THEROCK_GRPC_VERSION}
 
     BUILD_DEPS

--- a/dctools/CMakeLists.txt
+++ b/dctools/CMakeLists.txt
@@ -26,6 +26,7 @@ if(THEROCK_ENABLE_RDC)
       -DHIP_PLATFORM=amd
       -DCMAKE_CXX_STANDARD=17
       -DGRPC_ROOT=${_grpc_stage}
+      -DGRPC_DESIRED_VERSION=${THEROCK_GRPC_VERSION}
 
     BUILD_DEPS
       therock-grpc

--- a/third-party/grpc/CMakeLists.txt
+++ b/third-party/grpc/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 # gRPC static library for RDC
-set(THEROCK_GRPC_VERSION "1.78.1" CACHE STRING "gRPC version built by TheRock")
+set(THEROCK_GRPC_VERSION "1.78.1" CACHE INTERNAL "gRPC version built by TheRock")
 
 therock_subproject_fetch(therock-grpc-sources
   CMAKE_PROJECT

--- a/third-party/grpc/CMakeLists.txt
+++ b/third-party/grpc/CMakeLists.txt
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: MIT
 
 # gRPC static library for RDC
+set(THEROCK_GRPC_VERSION "1.78.1" CACHE STRING "gRPC version built by TheRock")
+
 therock_subproject_fetch(therock-grpc-sources
   CMAKE_PROJECT
-  # Originally mirrored from: https://github.com/grpc/grpc.git (git tag v1.67.1)
-  URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/grpc-v1.67.1.tar.gz"
-  URL_HASH "SHA256=ed0051771a1ed0ec6583be4ddb0fe9ee4473bc2f8a59d214ff49290ed5edb4ef"
+  # Originally mirrored from: https://github.com/grpc/grpc.git
+  URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/grpc-v1.78.1.tar.gz"
+  URL_HASH "SHA256=96e1d4c82735a6867b9045d782d3f4f7477224496fec5386ca3adae1f2059796"
 )
 
 set(_binary_dir "${CMAKE_CURRENT_BINARY_DIR}/build")

--- a/third-party/grpc/fetch_grpc_tarball.sh
+++ b/third-party/grpc/fetch_grpc_tarball.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 # gRPC source tarball generation script
 
-GRPC_VERSION="${GRPC_VERSION:-v1.67.1}"
+GRPC_VERSION="${GRPC_VERSION:-v1.78.1}"
 GRPC_TAG="${GRPC_VERSION}"
 OUTPUT_DIR="${PWD}/tarballs"
 TEMP_DIR=$(mktemp -d)


### PR DESCRIPTION
Define THEROCK_GRPC_VERSION in third-party/grpc/CMakeLists.txt and pass it to rdc as GRPC_DESIRED_VERSION, so the version is maintained in one place and doesn't require a synchronized rocm-systems change.

## Motivation

There are a lot of CVEs in old grpc version. Mostly in c-ares.
Let's bump it.