### PR TITLE
[ci] Adding default for release workflow_dispatch triggers

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -53,6 +53,7 @@ on:
       families:
         description: "Comma separated list of AMD GPU families, e.g. `gfx94X,gfx103x`"
         type: string
+        default: "gfx94X"
       prerelease_version:
         description: "(Optional) Number of the prerelease"
         type: string

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -56,6 +56,7 @@ on:
       families:
         description: "A comma separated list of AMD GPU families, e.g. `gfx94X,gfx103x`, or empty for the default list"
         type: string
+        default: "gfx110X"
       prerelease_version:
         description: "(Optional) Number of the prerelease"
         type: string


### PR DESCRIPTION
Somewhat frequently, engineers will trigger a release pipeline with workflow dispatch with no arguments for families. When this occurs, it runs 10 * 16 jobs on both release and pytorch release workflows and cause delays on TheRock CI.

When chatting with the engineer, they usually only need 1-2 archs. 

With this default input, we will no longer run into this issue!

Works here:

<img width="1479" height="765" alt="Screenshot 2026-03-26 152543" src="https://github.com/user-attachments/assets/9ddbf094-eaa2-416d-9c2b-0379947d2c9b" />
<img width="1187" height="775" alt="Screenshot 2026-03-26 152557" src="https://github.com/user-attachments/assets/b720bcba-3d36-4b3a-92ca-584f44e98939" />
