### PR TITLE
Add `github_job` into TheRock Manifest

### DIFF
--- a/build_tools/generate_therock_manifest.py
+++ b/build_tools/generate_therock_manifest.py
@@ -175,6 +175,7 @@ def patches_for_submodule_by_name(repo_dir: Path, sub_name: str):
 def build_manifest_schema(
     repo_root: Path,
     the_rock_commit: str,
+    github_job: str | None = None,
     github_run_id: str | None = None,
     rocm_package_version: str | None = None,
 ) -> dict:
@@ -199,6 +200,9 @@ def build_manifest_schema(
         "the_rock_commit": the_rock_commit,
     }
 
+    if github_job:
+        manifest["github_job"] = github_job
+
     if github_run_id:
         manifest["github_run_id"] = github_run_id
 
@@ -211,6 +215,7 @@ def build_manifest_schema(
 
 def build_partial_manifest_schema(
     repo_root: Path,
+    github_job: str | None = None,
     github_run_id: str | None = None,
     rocm_package_version: str | None = None,
 ) -> dict:
@@ -234,6 +239,9 @@ def build_partial_manifest_schema(
     manifest = {
         "the_rock_commit": None,
     }
+
+    if github_job:
+        manifest["github_job"] = github_job
 
     if github_run_id:
         manifest["github_run_id"] = github_run_id
@@ -278,6 +286,7 @@ def main():
     args = ap.parse_args()
 
     repo_root = source_root()
+    github_job = os.getenv("GITHUB_JOB")
     github_run_id = os.getenv("GITHUB_RUN_ID")
     git_available = has_git_metadata(repo_root)
 
@@ -286,12 +295,14 @@ def main():
         manifest = build_manifest_schema(
             repo_root,
             the_rock_commit,
+            github_job,
             github_run_id,
             args.rocm_package_version,
         )
     else:
         manifest = build_partial_manifest_schema(
             repo_root,
+            github_job,
             github_run_id,
             args.rocm_package_version,
         )


### PR DESCRIPTION
## Motivation
This change improves traceability of build artifacts by recording the GitHub Actions job name in the generated manifest.

## Technical Details
```
{
  "the_rock_commit": "...",
  "github_job": "...",
  "github_run_id": "...",
  "rocm_package_version": "...",
  "submodules": [...]
}
```
## Test Plan

Test on CI
## Test Result
```
{
  "the_rock_commit": "369d0f1c06adaecfbc78fd02eb1d65ac72b01a9c",
  "github_job": "build_portable_linux_artifacts",
  "github_run_id": "23622239561",
  "rocm_package_version": "7.13.0.dev0+369d0f1c06adaecfbc78fd02eb1d65ac72b01a9c",
  "submodules": [...]
}
```
https://therock-ci-artifacts.s3.amazonaws.com/23622239561-linux/manifests/gfx120X-all/therock_manifest.json
https://therock-ci-artifacts.s3.amazonaws.com/23622239561-linux/manifests/gfx94X-dcgpu/therock_manifest.json
https://therock-ci-artifacts.s3.amazonaws.com/23622239561-linux/manifests/gfx1151/therock_manifest.json
https://therock-ci-artifacts.s3.amazonaws.com/23622239561-linux/manifests/gfx110X-all/therock_manifest.json
https://therock-ci-artifacts.s3.amazonaws.com/23622239561-windows/manifests/gfx120X-all/therock_manifest.json
https://therock-ci-artifacts.s3.amazonaws.com/23622239561-windows/manifests/gfx1151/therock_manifest.json
https://therock-ci-artifacts.s3.amazonaws.com/23622239561-windows/manifests/gfx110X-all/therock_manifest.json
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
