### PR TITLE
STACKED PR B: Introduce StorageConfig dataclass for URL schema configuration

### DIFF
--- a/build_tools/_therock_utils/artifact_backend.py
+++ b/build_tools/_therock_utils/artifact_backend.py
@@ -429,12 +429,15 @@ class HTTPBackend(ArtifactBackend):
         """Fetch artifact list from index-{gfx_family}.html."""
         index_url = self.output_root.artifact_index(gfx_family).https_url
         try:
-            with urllib.request.urlopen(index_url) as response:
+            with urllib.request.urlopen(index_url, timeout=30) as response:
                 html_content = response.read().decode("utf-8")
             return self._parse_index_html(html_content)
-        except Exception:
-            # Index doesn't exist for this target
-            return []
+        except urllib.error.HTTPError as e:
+            if e.code in (403, 404):
+                return []  # Index doesn't exist for this target
+            raise  # Re-raise server errors (500, etc.)
+        except urllib.error.URLError:
+            return []  # Network error - treat as unavailable
 
     def _discover_gfx_families_from_master_index(self) -> List[str]:
         """Discover available GFX families from master index.

--- a/build_tools/_therock_utils/artifact_backend.py
+++ b/build_tools/_therock_utils/artifact_backend.py
@@ -439,47 +439,6 @@ class HTTPBackend(ArtifactBackend):
         except urllib.error.URLError:
             return []  # Network error - treat as unavailable
 
-    def _discover_gfx_families_from_master_index(self) -> List[str]:
-        """Discover available GFX families from master index.
-
-        TODO: Future enhancement - Master index discovery
-        ==================================================
-        This stub will be implemented to fetch and parse the master index at:
-        {base_url}/{workflow_id}-linux/index.html
-
-        The master index should contain links to all available index files:
-          <a href="../{run_id}-{platform}/index-gfx94X-dcgpu.html">...</a>
-          <a href="../{run_id}-{platform}/index-gfx120X-all.html">...</a>
-
-        Implementation plan:
-        1. Fetch {base_url}/{workflow_id}-linux/index.html
-        2. Parse HTML for links matching pattern: index-{gfx_family}.html
-        3. Extract gfx_family from each link
-        4. Return list of discovered targets
-
-        This will replace the hardcoded common_targets list and enable
-        automatic discovery of all available GFX families.
-
-        Returns:
-            List of discovered GFX families (e.g., ["gfx94X-dcgpu", "gfx120X-all", "gfx908"])
-        """
-        # TODO: Implement master index parsing
-        # master_index_url = f"{self.base_url}/{workflow_id}-linux/index.html"
-        # try:
-        #     with urllib.request.urlopen(master_index_url) as response:
-        #         html_content = response.read().decode("utf-8")
-        #
-        #     # Parse for links like: href="../{run_id}-{platform}/index-{gfx_family}.html"
-        #     pattern = rf'href="[^"]*/{self.run_id}-{self.platform}/index-([^"]+)\.html"'
-        #     matches = re.findall(pattern, html_content)
-        #     return matches
-        # except Exception:
-        #     # Fall back to hardcoded targets if master index unavailable
-        #     return []
-
-        # For now, return empty list to indicate not implemented
-        return []
-
     def list_artifacts(self, name_filter: Optional[str] = None) -> List[str]:
         """List available artifact filenames across all specified GFX families.
 

--- a/build_tools/_therock_utils/artifact_backend.py
+++ b/build_tools/_therock_utils/artifact_backend.py
@@ -30,6 +30,7 @@ import shutil
 import urllib.error
 import urllib.request
 
+from .storage_location import StorageConfig
 from .workflow_outputs import WorkflowOutputRoot
 
 
@@ -588,9 +589,7 @@ def create_backend_from_env(
     run_id: Optional[str] = None,
     platform: Optional[str] = None,
     gfx_families: Optional[List[str]] = None,
-    s3_url_schema: Optional[str] = None,
-    https_url_schema: Optional[str] = None,
-    bucket_schema: Optional[str] = None,
+    storage_config: Optional[StorageConfig] = None,
 ) -> ArtifactBackend:
     """Create the appropriate backend based on environment variables.
 
@@ -605,9 +604,8 @@ def create_backend_from_env(
         gfx_families: List of GFX families for HTTP backend (e.g., ["gfx94X-dcgpu", "gfx1200"])
                     If None, reads from THEROCK_AMDGPU_FAMILIES environment variable (comma-separated)
                     Required for HTTP backend.
-        s3_url_schema: Template for S3 URIs. If None, uses default.
-        https_url_schema: Template for HTTPS URLs. If None, uses default.
-        bucket_schema: Template for bucket naming. If None, uses default.
+        storage_config: Storage configuration for URL schemas and bucket naming.
+            If None, uses defaults.
 
     Environment variables:
     - THEROCK_RUN_ID: Workflow run ID (default: GITHUB_RUN_ID or "local")
@@ -636,9 +634,7 @@ def create_backend_from_env(
         output_root = WorkflowOutputRoot.for_local(
             run_id=run_id,
             platform=platform_name,
-            s3_url_schema=s3_url_schema,
-            https_url_schema=https_url_schema,
-            # bucket_schema not applicable for local backend
+            storage_config=storage_config,
         )
         return LocalDirectoryBackend(
             staging_dir=Path(local_staging),
@@ -656,9 +652,7 @@ def create_backend_from_env(
         output_root = WorkflowOutputRoot.from_workflow_run(
             run_id=run_id,
             platform=platform_name,
-            s3_url_schema=s3_url_schema,
-            https_url_schema=https_url_schema,
-            bucket_schema=bucket_schema,
+            storage_config=storage_config,
         )
         return S3Backend(output_root=output_root)
 
@@ -683,8 +677,6 @@ def create_backend_from_env(
     output_root = WorkflowOutputRoot.from_workflow_run(
         run_id=run_id,
         platform=platform_name,
-        s3_url_schema=s3_url_schema,
-        https_url_schema=https_url_schema,
-        bucket_schema=bucket_schema,
+        storage_config=storage_config,
     )
     return HTTPBackend(output_root=output_root, gfx_families=targets)

--- a/build_tools/_therock_utils/artifact_backend.py
+++ b/build_tools/_therock_utils/artifact_backend.py
@@ -30,7 +30,6 @@ import shutil
 import urllib.error
 import urllib.request
 
-from .storage_location import StorageLocation
 from .workflow_outputs import WorkflowOutputRoot
 
 
@@ -589,6 +588,9 @@ def create_backend_from_env(
     run_id: Optional[str] = None,
     platform: Optional[str] = None,
     gfx_families: Optional[List[str]] = None,
+    s3_url_schema: Optional[str] = None,
+    https_url_schema: Optional[str] = None,
+    bucket_schema: Optional[str] = None,
 ) -> ArtifactBackend:
     """Create the appropriate backend based on environment variables.
 
@@ -603,6 +605,9 @@ def create_backend_from_env(
         gfx_families: List of GFX families for HTTP backend (e.g., ["gfx94X-dcgpu", "gfx1200"])
                     If None, reads from THEROCK_AMDGPU_FAMILIES environment variable (comma-separated)
                     Required for HTTP backend.
+        s3_url_schema: Template for S3 URIs. If None, uses default.
+        https_url_schema: Template for HTTPS URLs. If None, uses default.
+        bucket_schema: Template for bucket naming. If None, uses default.
 
     Environment variables:
     - THEROCK_RUN_ID: Workflow run ID (default: GITHUB_RUN_ID or "local")
@@ -629,7 +634,11 @@ def create_backend_from_env(
     local_staging = os.getenv("THEROCK_LOCAL_STAGING_DIR")
     if local_staging:
         output_root = WorkflowOutputRoot.for_local(
-            run_id=run_id, platform=platform_name
+            run_id=run_id,
+            platform=platform_name,
+            s3_url_schema=s3_url_schema,
+            https_url_schema=https_url_schema,
+            # bucket_schema not applicable for local backend
         )
         return LocalDirectoryBackend(
             staging_dir=Path(local_staging),
@@ -645,7 +654,11 @@ def create_backend_from_env(
     )
     if has_s3_credentials:
         output_root = WorkflowOutputRoot.from_workflow_run(
-            run_id=run_id, platform=platform_name
+            run_id=run_id,
+            platform=platform_name,
+            s3_url_schema=s3_url_schema,
+            https_url_schema=https_url_schema,
+            bucket_schema=bucket_schema,
         )
         return S3Backend(output_root=output_root)
 
@@ -668,6 +681,10 @@ def create_backend_from_env(
         )
 
     output_root = WorkflowOutputRoot.from_workflow_run(
-        run_id=run_id, platform=platform_name
+        run_id=run_id,
+        platform=platform_name,
+        s3_url_schema=s3_url_schema,
+        https_url_schema=https_url_schema,
+        bucket_schema=bucket_schema,
     )
     return HTTPBackend(output_root=output_root, gfx_families=targets)

--- a/build_tools/_therock_utils/storage_backend.py
+++ b/build_tools/_therock_utils/storage_backend.py
@@ -140,8 +140,7 @@ class StorageBackend(ABC):
                 StorageLocation(
                     dest.bucket,
                     f"{dest.relative_path}/{f.relative_to(source_dir).as_posix()}",
-                    dest.s3_url_schema,
-                    dest.https_url_schema,
+                    dest.storage_config,
                 ),
             )
             for f in sorted_files

--- a/build_tools/_therock_utils/storage_backend.py
+++ b/build_tools/_therock_utils/storage_backend.py
@@ -140,6 +140,8 @@ class StorageBackend(ABC):
                 StorageLocation(
                     dest.bucket,
                     f"{dest.relative_path}/{f.relative_to(source_dir).as_posix()}",
+                    dest.s3_url_schema,
+                    dest.https_url_schema,
                 ),
             )
             for f in sorted_files

--- a/build_tools/_therock_utils/storage_location.py
+++ b/build_tools/_therock_utils/storage_location.py
@@ -20,6 +20,10 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+# Default URL schemas (single source of truth)
+DEFAULT_S3_URL_SCHEMA = "s3://{bucket}/{path}"
+DEFAULT_HTTPS_URL_SCHEMA = "https://{bucket}.s3.amazonaws.com/{path}"
+
 
 @dataclass(frozen=True)
 class StorageLocation:
@@ -40,10 +44,17 @@ class StorageLocation:
     relative_path: str
     """Relative path from bucket/staging root (e.g., '12345-linux/file.tar.xz')."""
 
+    s3_url_schema: str | None = None
+    """Template for S3 URI. Must contain {bucket} and {path} placeholders. If None, uses default."""
+
+    https_url_schema: str | None = None
+    """Template for HTTPS URL. Must contain {bucket} and {path} placeholders. If None, uses default."""
+
     @property
     def s3_uri(self) -> str:
         """S3 URI (e.g., ``s3://bucket/path/file``)."""
-        return f"s3://{self.bucket}/{self.relative_path}"
+        schema = self.s3_url_schema or DEFAULT_S3_URL_SCHEMA
+        return schema.format(bucket=self.bucket, path=self.relative_path)
 
     @property
     def https_url(self) -> str:
@@ -52,14 +63,16 @@ class StorageLocation:
         Checks for bucket-specific override via environment variable:
         THEROCK_HTTPS_URL_<bucket> where dashes are replaced with underscores.
 
+        If no env var is set, uses the https_url_schema template.
         """
         # Check for bucket-specific env var override
         env_var_name = f"THEROCK_HTTPS_URL_{self.bucket.replace('-', '_')}"
         base_url = os.getenv(env_var_name)
         if base_url:
             return f"{base_url.rstrip('/')}/{self.relative_path}"
-        # Default: S3 public URL pattern
-        return f"https://{self.bucket}.s3.amazonaws.com/{self.relative_path}"
+        # Use template with placeholders
+        schema = self.https_url_schema or DEFAULT_HTTPS_URL_SCHEMA
+        return schema.format(bucket=self.bucket, path=self.relative_path)
 
     def local_path(self, staging_dir: Path) -> Path:
         """Local filesystem path for this location.

--- a/build_tools/_therock_utils/storage_location.py
+++ b/build_tools/_therock_utils/storage_location.py
@@ -26,7 +26,6 @@ import json
 import string
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 # Allowed placeholders for each schema type
 URL_SCHEMA_PLACEHOLDERS = frozenset({"bucket", "path"})
@@ -51,7 +50,7 @@ def _extract_placeholders(schema: str) -> set[str]:
     return {field for _, field, _, _ in formatter.parse(schema) if field}
 
 
-def _validate_schema(schema: Optional[str], allowed: frozenset[str], name: str) -> None:
+def _validate_schema(schema: str | None, allowed: frozenset[str], name: str) -> None:
     """Validate that schema only uses allowed placeholders.
 
     Args:
@@ -173,26 +172,22 @@ class StorageLocation:
     relative_path: str
     """Relative path from bucket/staging root (e.g., '12345-linux/file.tar.xz')."""
 
-    storage_config: Optional[StorageConfig] = None
-    """Storage configuration for URL schemas. If None, uses defaults."""
+    storage_config: StorageConfig = StorageConfig()
+    """Storage configuration for URL schemas."""
 
     @property
     def s3_uri(self) -> str:
         """S3 URI (e.g., ``s3://bucket/path/file``)."""
-        if self.storage_config:
-            schema = self.storage_config.s3_url_schema
-        else:
-            schema = "s3://{bucket}/{path}"
-        return schema.format(bucket=self.bucket, path=self.relative_path)
+        return self.storage_config.s3_url_schema.format(
+            bucket=self.bucket, path=self.relative_path
+        )
 
     @property
     def https_url(self) -> str:
         """Public HTTPS URL for browser access."""
-        if self.storage_config:
-            schema = self.storage_config.https_url_schema
-        else:
-            schema = "https://{bucket}.s3.amazonaws.com/{path}"
-        return schema.format(bucket=self.bucket, path=self.relative_path)
+        return self.storage_config.https_url_schema.format(
+            bucket=self.bucket, path=self.relative_path
+        )
 
     def local_path(self, staging_dir: Path) -> Path:
         """Local filesystem path for this location.

--- a/build_tools/_therock_utils/storage_location.py
+++ b/build_tools/_therock_utils/storage_location.py
@@ -60,16 +60,8 @@ class StorageLocation:
     def https_url(self) -> str:
         """Public HTTPS URL for browser access.
 
-        Checks for bucket-specific override via environment variable:
-        THEROCK_HTTPS_URL_<bucket> where dashes are replaced with underscores.
-
         If no env var is set, uses the https_url_schema template.
         """
-        # Check for bucket-specific env var override
-        env_var_name = f"THEROCK_HTTPS_URL_{self.bucket.replace('-', '_')}"
-        base_url = os.getenv(env_var_name)
-        if base_url:
-            return f"{base_url.rstrip('/')}/{self.relative_path}"
         # Use template with placeholders
         schema = self.https_url_schema or DEFAULT_HTTPS_URL_SCHEMA
         return schema.format(bucket=self.bucket, path=self.relative_path)

--- a/build_tools/_therock_utils/storage_location.py
+++ b/build_tools/_therock_utils/storage_location.py
@@ -1,4 +1,4 @@
-"""Backend-agnostic storage location.
+"""Backend-agnostic storage location and configuration.
 
 A ``StorageLocation`` represents a file or directory in S3 (or a local staging
 directory) without coupling to any particular layout or upload/download
@@ -6,23 +6,152 @@ direction.  It is the bridge between path computation modules (like
 ``workflow_outputs.WorkflowOutputRoot``) and I/O modules (``storage_backend``,
 ``artifact_backend``).
 
+A ``StorageConfig`` consolidates all URL schema configurations into a single,
+immutable object with validation and sensible defaults.
+
 Usage::
 
-    from _therock_utils.storage_location import StorageLocation
+    from _therock_utils.storage_location import StorageLocation, StorageConfig
 
-    loc = StorageLocation("my-bucket", "some/path/file.tar.xz")
+    # Using StorageConfig for custom schemas
+    config = StorageConfig(https_url_schema="https://cdn.example.com/{path}")
+
+    loc = StorageLocation("my-bucket", "some/path/file.tar.xz", storage_config=config)
     loc.s3_uri        # "s3://my-bucket/some/path/file.tar.xz"
-    loc.https_url     # "https://my-bucket.s3.amazonaws.com/some/path/file.tar.xz"
+    loc.https_url     # "https://cdn.example.com/some/path/file.tar.xz"
     loc.local_path(Path("/tmp/staging"))  # Path("/tmp/staging/some/path/file.tar.xz")
 """
 
-import os
+import json
+import string
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
-# Default URL schemas (single source of truth)
-DEFAULT_S3_URL_SCHEMA = "s3://{bucket}/{path}"
-DEFAULT_HTTPS_URL_SCHEMA = "https://{bucket}.s3.amazonaws.com/{path}"
+# Allowed placeholders for each schema type
+URL_SCHEMA_PLACEHOLDERS = frozenset({"bucket", "path"})
+BUCKET_SCHEMA_PLACEHOLDERS = frozenset({"release_type"})
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_placeholders(schema: str) -> set[str]:
+    """Extract placeholder names from a format string.
+
+    Args:
+        schema: A Python format string (e.g., "s3://{bucket}/{path}")
+
+    Returns:
+        Set of placeholder names (e.g., {"bucket", "path"})
+    """
+    formatter = string.Formatter()
+    return {field for _, field, _, _ in formatter.parse(schema) if field}
+
+
+def _validate_schema(schema: Optional[str], allowed: frozenset[str], name: str) -> None:
+    """Validate that schema only uses allowed placeholders.
+
+    Args:
+        schema: Format string to validate, or None
+        allowed: Set of allowed placeholder names
+        name: Schema name for error messages
+
+    Raises:
+        ValueError: If schema uses placeholders not in allowed set
+    """
+    if schema is None:
+        return
+    used = _extract_placeholders(schema)
+    invalid = used - allowed
+    if invalid:
+        raise ValueError(
+            f"{name} uses invalid placeholder(s): {sorted(invalid)}. "
+            f"Allowed: {sorted(allowed)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# StorageConfig
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StorageConfig:
+    """Configuration for storage URL schema templates.
+
+    Schemas use Python format-string placeholders. Available placeholders:
+
+    For s3_url_schema and https_url_schema:
+        {bucket} - S3 bucket name
+        {path}   - Relative path within the bucket
+
+    For bucket_schema:
+        {release_type} - Release type ('dev', 'nightly', 'prerelease')
+
+    Schemas may omit placeholders (e.g., CDN URLs that ignore {bucket}).
+    Using a placeholder not in the allowed list raises ValueError.
+
+    Usage::
+
+        # Use defaults
+        config = StorageConfig()
+
+        # Custom CDN (omits {bucket})
+        config = StorageConfig(
+            https_url_schema="https://cdn.example.com/{path}"
+        )
+
+        # Invalid - unknown placeholder
+        config = StorageConfig(
+            https_url_schema="https://{bucket}.{region}.s3.amazonaws.com/{path}"
+        )  # Raises ValueError: https_url_schema uses invalid placeholder(s): ['region']
+
+        # Parse from JSON
+        config = StorageConfig.from_json('{"https_url_schema": "https://cdn.example.com/{path}"}')
+    """
+
+    s3_url_schema: str = "s3://{bucket}/{path}"
+    https_url_schema: str = "https://{bucket}.s3.amazonaws.com/{path}"
+    bucket_schema: str = "therock-{release_type}-artifacts"
+
+    def __post_init__(self):
+        """Validate schemas at construction time."""
+        _validate_schema(self.s3_url_schema, URL_SCHEMA_PLACEHOLDERS, "s3_url_schema")
+        _validate_schema(
+            self.https_url_schema, URL_SCHEMA_PLACEHOLDERS, "https_url_schema"
+        )
+        _validate_schema(
+            self.bucket_schema, BUCKET_SCHEMA_PLACEHOLDERS, "bucket_schema"
+        )
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "StorageConfig":
+        """Parse StorageConfig from JSON string.
+
+        Args:
+            json_str: JSON object with optional keys:
+                - s3_url_schema
+                - https_url_schema
+                - bucket_schema
+
+        Returns:
+            StorageConfig instance
+
+        Raises:
+            ValueError: If JSON is invalid or contains unknown keys
+            json.JSONDecodeError: If JSON syntax is invalid
+        """
+        data = json.loads(json_str)
+        if not isinstance(data, dict):
+            raise ValueError("Storage config must be a JSON object")
+        allowed_keys = {"s3_url_schema", "https_url_schema", "bucket_schema"}
+        unknown = set(data.keys()) - allowed_keys
+        if unknown:
+            raise ValueError(f"Unknown keys in storage config: {sorted(unknown)}")
+        return cls(**data)
 
 
 @dataclass(frozen=True)
@@ -44,26 +173,25 @@ class StorageLocation:
     relative_path: str
     """Relative path from bucket/staging root (e.g., '12345-linux/file.tar.xz')."""
 
-    s3_url_schema: str | None = None
-    """Template for S3 URI. Must contain {bucket} and {path} placeholders. If None, uses default."""
-
-    https_url_schema: str | None = None
-    """Template for HTTPS URL. Must contain {bucket} and {path} placeholders. If None, uses default."""
+    storage_config: Optional[StorageConfig] = None
+    """Storage configuration for URL schemas. If None, uses defaults."""
 
     @property
     def s3_uri(self) -> str:
         """S3 URI (e.g., ``s3://bucket/path/file``)."""
-        schema = self.s3_url_schema or DEFAULT_S3_URL_SCHEMA
+        if self.storage_config:
+            schema = self.storage_config.s3_url_schema
+        else:
+            schema = "s3://{bucket}/{path}"
         return schema.format(bucket=self.bucket, path=self.relative_path)
 
     @property
     def https_url(self) -> str:
-        """Public HTTPS URL for browser access.
-
-        If no env var is set, uses the https_url_schema template.
-        """
-        # Use template with placeholders
-        schema = self.https_url_schema or DEFAULT_HTTPS_URL_SCHEMA
+        """Public HTTPS URL for browser access."""
+        if self.storage_config:
+            schema = self.storage_config.https_url_schema
+        else:
+            schema = "https://{bucket}.s3.amazonaws.com/{path}"
         return schema.format(bucket=self.bucket, path=self.relative_path)
 
     def local_path(self, staging_dir: Path) -> Path:

--- a/build_tools/_therock_utils/workflow_outputs.py
+++ b/build_tools/_therock_utils/workflow_outputs.py
@@ -45,11 +45,11 @@ import platform as platform_module
 # Add build_tools to path for sibling package imports.
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
-from _therock_utils.storage_location import StorageLocation
+from _therock_utils.storage_location import (
+    StorageConfig,
+    StorageLocation,
+)
 from github_actions.github_actions_api import gha_query_workflow_run_by_id
-
-# Default bucket naming schema
-DEFAULT_BUCKET_SCHEMA = "therock-{release_type}-artifacts"
 
 
 def _log(*args, **kwargs):
@@ -86,11 +86,8 @@ class WorkflowOutputRoot:
     platform: str
     """Platform name ('linux' or 'windows')."""
 
-    s3_url_schema: str | None = None
-    """Template for S3 URI. Must contain {bucket} and {path} placeholders. If None, uses default."""
-
-    https_url_schema: str | None = None
-    """Template for HTTPS URL. Must contain {bucket} and {path} placeholders. If None, uses default."""
+    storage_config: StorageConfig | None = None
+    """Storage configuration for URL schemas. If None, uses defaults."""
 
     # -- Root -------------------------------------------------------------------
 
@@ -107,8 +104,7 @@ class WorkflowOutputRoot:
         return StorageLocation(
             self.bucket,
             self.prefix,
-            self.s3_url_schema,
-            self.https_url_schema,
+            self.storage_config,
         )
 
     # -- Build artifacts --------------------------------------------------------
@@ -122,8 +118,7 @@ class WorkflowOutputRoot:
         return StorageLocation(
             self.bucket,
             f"{self.prefix}/{filename}",
-            self.s3_url_schema,
-            self.https_url_schema,
+            self.storage_config,
         )
 
     def artifact_index(self, artifact_group: str) -> StorageLocation:
@@ -135,8 +130,7 @@ class WorkflowOutputRoot:
         return StorageLocation(
             self.bucket,
             f"{self.prefix}/index-{artifact_group}.html",
-            self.s3_url_schema,
-            self.https_url_schema,
+            self.storage_config,
         )
 
     # -- Logs -------------------------------------------------------------------
@@ -158,8 +152,7 @@ class WorkflowOutputRoot:
         return StorageLocation(
             self.bucket,
             f"{self.prefix}/logs/{artifact_group}",
-            self.s3_url_schema,
-            self.https_url_schema,
+            self.storage_config,
         )
 
     def log_file(self, artifact_group: str, filename: str) -> StorageLocation:
@@ -172,8 +165,7 @@ class WorkflowOutputRoot:
         return StorageLocation(
             self.bucket,
             f"{self.prefix}/logs/{artifact_group}/{filename}",
-            self.s3_url_schema,
-            self.https_url_schema,
+            self.storage_config,
         )
 
     def log_index(self, artifact_group: str) -> StorageLocation:
@@ -181,8 +173,7 @@ class WorkflowOutputRoot:
         return StorageLocation(
             self.bucket,
             f"{self.prefix}/logs/{artifact_group}/index.html",
-            self.s3_url_schema,
-            self.https_url_schema,
+            self.storage_config,
         )
 
     def build_observability(self, artifact_group: str) -> StorageLocation:
@@ -190,8 +181,7 @@ class WorkflowOutputRoot:
         return StorageLocation(
             self.bucket,
             f"{self.prefix}/logs/{artifact_group}/build_observability.html",
-            self.s3_url_schema,
-            self.https_url_schema,
+            self.storage_config,
         )
 
     # -- Manifests --------------------------------------------------------------
@@ -205,8 +195,7 @@ class WorkflowOutputRoot:
         return StorageLocation(
             self.bucket,
             f"{self.prefix}/manifests/{artifact_group}",
-            self.s3_url_schema,
-            self.https_url_schema,
+            self.storage_config,
         )
 
     def manifest(self, artifact_group: str) -> StorageLocation:
@@ -218,8 +207,7 @@ class WorkflowOutputRoot:
         return StorageLocation(
             self.bucket,
             f"{self.prefix}/manifests/{artifact_group}/therock_manifest.json",
-            self.s3_url_schema,
-            self.https_url_schema,
+            self.storage_config,
         )
 
     # -- Python packages --------------------------------------------------------
@@ -237,8 +225,7 @@ class WorkflowOutputRoot:
         return StorageLocation(
             self.bucket,
             f"{self.prefix}/python{suffix}",
-            self.s3_url_schema,
-            self.https_url_schema,
+            self.storage_config,
         )
 
     # -- Factories --------------------------------------------------------------
@@ -251,9 +238,7 @@ class WorkflowOutputRoot:
         github_repository: str | None = None,
         workflow_run: dict | None = None,
         lookup_workflow_run: bool = False,
-        s3_url_schema: str | None = None,
-        https_url_schema: str | None = None,
-        bucket_schema: str | None = None,
+        storage_config: StorageConfig | None = None,
     ) -> "WorkflowOutputRoot":
         """Create from CI workflow context.
 
@@ -273,9 +258,8 @@ class WorkflowOutputRoot:
                 Most callers running inside their own CI workflow do not need
                 this — environment variables suffice. Set this when looking up
                 another repository's workflow run (e.g. fetching artifacts).
-            s3_url_schema: Template for S3 URIs. If None, uses default.
-            https_url_schema: Template for HTTPS URLs. If None, uses default.
-            bucket_schema: Template for bucket naming. If None, uses default.
+            storage_config: Storage configuration for URL schemas. If None,
+                uses defaults.
         """
         workflow_run_id = (
             run_id if lookup_workflow_run and workflow_run is None else None
@@ -284,15 +268,14 @@ class WorkflowOutputRoot:
             github_repository=github_repository,
             workflow_run_id=workflow_run_id,
             workflow_run=workflow_run,
-            bucket_schema=bucket_schema,
+            storage_config=storage_config,
         )
         return cls(
             bucket=bucket,
             external_repo=external_repo,
             run_id=run_id,
             platform=platform,
-            s3_url_schema=s3_url_schema,
-            https_url_schema=https_url_schema,
+            storage_config=storage_config,
         )
 
     @classmethod
@@ -301,8 +284,7 @@ class WorkflowOutputRoot:
         run_id: str = "local",
         platform: str | None = None,
         bucket: str = "local",
-        s3_url_schema: str | None = None,
-        https_url_schema: str | None = None,
+        storage_config: StorageConfig | None = None,
     ) -> "WorkflowOutputRoot":
         """Create for local development/testing.
 
@@ -310,8 +292,8 @@ class WorkflowOutputRoot:
             run_id: Run identifier (default: 'local').
             platform: Platform name. If None, detects from current system.
             bucket: Bucket name placeholder (default: 'local').
-            s3_url_schema: Template for S3 URIs. If None, uses default.
-            https_url_schema: Template for HTTPS URLs. If None, uses default.
+            storage_config: Storage configuration for URL schemas. If None,
+                uses defaults.
         """
         if platform is None:
             platform = platform_module.system().lower()
@@ -320,8 +302,7 @@ class WorkflowOutputRoot:
             external_repo="",
             run_id=run_id,
             platform=platform,
-            s3_url_schema=s3_url_schema,
-            https_url_schema=https_url_schema,
+            storage_config=storage_config,
         )
 
 
@@ -338,7 +319,7 @@ def _retrieve_bucket_info(
     github_repository: str | None = None,
     workflow_run_id: str | None = None,
     workflow_run: dict | None = None,
-    bucket_schema: str | None = None,
+    storage_config: StorageConfig | None = None,
 ) -> tuple[str, str]:
     """Determine S3 bucket and external_repo prefix for a workflow run.
 
@@ -349,16 +330,18 @@ def _retrieve_bucket_info(
         github_repository: Repository in 'owner/repo' format.
         workflow_run_id: Workflow run ID for API lookup.
         workflow_run: Pre-fetched workflow run data.
-        bucket_schema: Template for bucket naming (default: 'therock-{release_type}-artifacts').
-            Must contain {release_type} placeholder.
+        storage_config: Storage configuration containing bucket_schema.
+            If None, uses default bucket schema.
 
     Returns:
         Tuple of ``(external_repo, bucket)`` where:
         - external_repo: ``''`` for ROCm/TheRock, or ``'{owner}-{repo}/'``
         - bucket: S3 bucket name
     """
-    if bucket_schema is None:
-        bucket_schema = DEFAULT_BUCKET_SCHEMA
+    if storage_config is not None:
+        bucket_schema = storage_config.bucket_schema
+    else:
+        bucket_schema = "therock-{release_type}-artifacts"
     _log("Retrieving bucket info...")
 
     if github_repository:

--- a/build_tools/_therock_utils/workflow_outputs.py
+++ b/build_tools/_therock_utils/workflow_outputs.py
@@ -86,8 +86,8 @@ class WorkflowOutputRoot:
     platform: str
     """Platform name ('linux' or 'windows')."""
 
-    storage_config: StorageConfig | None = None
-    """Storage configuration for URL schemas. If None, uses defaults."""
+    storage_config: StorageConfig = StorageConfig()
+    """Storage configuration for URL schemas."""
 
     # -- Root -------------------------------------------------------------------
 
@@ -259,8 +259,10 @@ class WorkflowOutputRoot:
                 this — environment variables suffice. Set this when looking up
                 another repository's workflow run (e.g. fetching artifacts).
             storage_config: Storage configuration for URL schemas. If None,
-                uses defaults.
+                uses default StorageConfig.
         """
+        if storage_config is None:
+            storage_config = StorageConfig()
         workflow_run_id = (
             run_id if lookup_workflow_run and workflow_run is None else None
         )
@@ -293,8 +295,10 @@ class WorkflowOutputRoot:
             platform: Platform name. If None, detects from current system.
             bucket: Bucket name placeholder (default: 'local').
             storage_config: Storage configuration for URL schemas. If None,
-                uses defaults.
+                uses default StorageConfig.
         """
+        if storage_config is None:
+            storage_config = StorageConfig()
         if platform is None:
             platform = platform_module.system().lower()
         return cls(
@@ -319,7 +323,8 @@ def _retrieve_bucket_info(
     github_repository: str | None = None,
     workflow_run_id: str | None = None,
     workflow_run: dict | None = None,
-    storage_config: StorageConfig | None = None,
+    *,
+    storage_config: StorageConfig,
 ) -> tuple[str, str]:
     """Determine S3 bucket and external_repo prefix for a workflow run.
 
@@ -331,17 +336,12 @@ def _retrieve_bucket_info(
         workflow_run_id: Workflow run ID for API lookup.
         workflow_run: Pre-fetched workflow run data.
         storage_config: Storage configuration containing bucket_schema.
-            If None, uses default bucket schema.
 
     Returns:
         Tuple of ``(external_repo, bucket)`` where:
         - external_repo: ``''`` for ROCm/TheRock, or ``'{owner}-{repo}/'``
         - bucket: S3 bucket name
     """
-    if storage_config is not None:
-        bucket_schema = storage_config.bucket_schema
-    else:
-        bucket_schema = "therock-{release_type}-artifacts"
     _log("Retrieving bucket info...")
 
     if github_repository:
@@ -387,7 +387,7 @@ def _retrieve_bucket_info(
                 f"expected one of {sorted(_VALID_RELEASE_TYPES)}"
             )
         _log(f"  (implicit) RELEASE_TYPE: {release_type}")
-        bucket = bucket_schema.format(release_type=release_type)
+        bucket = storage_config.bucket_schema.format(release_type=release_type)
     else:
         if external_repo == "":
             bucket = "therock-ci-artifacts"

--- a/build_tools/_therock_utils/workflow_outputs.py
+++ b/build_tools/_therock_utils/workflow_outputs.py
@@ -48,6 +48,9 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 from _therock_utils.storage_location import StorageLocation
 from github_actions.github_actions_api import gha_query_workflow_run_by_id
 
+# Default bucket naming schema
+DEFAULT_BUCKET_SCHEMA = "therock-{release_type}-artifacts"
+
 
 def _log(*args, **kwargs):
     """Log to stdout with flush for CI visibility."""
@@ -83,6 +86,12 @@ class WorkflowOutputRoot:
     platform: str
     """Platform name ('linux' or 'windows')."""
 
+    s3_url_schema: str | None = None
+    """Template for S3 URI. Must contain {bucket} and {path} placeholders. If None, uses default."""
+
+    https_url_schema: str | None = None
+    """Template for HTTPS URL. Must contain {bucket} and {path} placeholders. If None, uses default."""
+
     # -- Root -------------------------------------------------------------------
 
     @property
@@ -95,7 +104,12 @@ class WorkflowOutputRoot:
 
     def root(self) -> StorageLocation:
         """Location for the run output root (where build artifacts live)."""
-        return StorageLocation(self.bucket, self.prefix)
+        return StorageLocation(
+            self.bucket,
+            self.prefix,
+            self.s3_url_schema,
+            self.https_url_schema,
+        )
 
     # -- Build artifacts --------------------------------------------------------
 
@@ -105,7 +119,12 @@ class WorkflowOutputRoot:
         Args:
             filename: Artifact filename (e.g., 'blas_lib_gfx94X.tar.xz')
         """
-        return StorageLocation(self.bucket, f"{self.prefix}/{filename}")
+        return StorageLocation(
+            self.bucket,
+            f"{self.prefix}/{filename}",
+            self.s3_url_schema,
+            self.https_url_schema,
+        )
 
     def artifact_index(self, artifact_group: str) -> StorageLocation:
         """Location for the per-group artifact index HTML.
@@ -114,7 +133,10 @@ class WorkflowOutputRoot:
             artifact_group: Build variant (e.g., 'gfx94X-dcgpu')
         """
         return StorageLocation(
-            self.bucket, f"{self.prefix}/index-{artifact_group}.html"
+            self.bucket,
+            f"{self.prefix}/index-{artifact_group}.html",
+            self.s3_url_schema,
+            self.https_url_schema,
         )
 
     # -- Logs -------------------------------------------------------------------
@@ -133,7 +155,12 @@ class WorkflowOutputRoot:
         Args:
             artifact_group: Build variant (e.g., 'gfx94X-dcgpu')
         """
-        return StorageLocation(self.bucket, f"{self.prefix}/logs/{artifact_group}")
+        return StorageLocation(
+            self.bucket,
+            f"{self.prefix}/logs/{artifact_group}",
+            self.s3_url_schema,
+            self.https_url_schema,
+        )
 
     def log_file(self, artifact_group: str, filename: str) -> StorageLocation:
         """Location for a specific file within the log_dir() subtree.
@@ -143,13 +170,19 @@ class WorkflowOutputRoot:
             filename: Log filename (e.g., 'build.log', 'ninja_logs.tar.gz')
         """
         return StorageLocation(
-            self.bucket, f"{self.prefix}/logs/{artifact_group}/{filename}"
+            self.bucket,
+            f"{self.prefix}/logs/{artifact_group}/{filename}",
+            self.s3_url_schema,
+            self.https_url_schema,
         )
 
     def log_index(self, artifact_group: str) -> StorageLocation:
         """Location for the log directory index HTML (within log_dir())."""
         return StorageLocation(
-            self.bucket, f"{self.prefix}/logs/{artifact_group}/index.html"
+            self.bucket,
+            f"{self.prefix}/logs/{artifact_group}/index.html",
+            self.s3_url_schema,
+            self.https_url_schema,
         )
 
     def build_observability(self, artifact_group: str) -> StorageLocation:
@@ -157,6 +190,8 @@ class WorkflowOutputRoot:
         return StorageLocation(
             self.bucket,
             f"{self.prefix}/logs/{artifact_group}/build_observability.html",
+            self.s3_url_schema,
+            self.https_url_schema,
         )
 
     # -- Manifests --------------------------------------------------------------
@@ -167,7 +202,12 @@ class WorkflowOutputRoot:
         Args:
             artifact_group: Build variant (e.g., 'gfx94X-dcgpu')
         """
-        return StorageLocation(self.bucket, f"{self.prefix}/manifests/{artifact_group}")
+        return StorageLocation(
+            self.bucket,
+            f"{self.prefix}/manifests/{artifact_group}",
+            self.s3_url_schema,
+            self.https_url_schema,
+        )
 
     def manifest(self, artifact_group: str) -> StorageLocation:
         """Location for therock_manifest.json.
@@ -178,6 +218,8 @@ class WorkflowOutputRoot:
         return StorageLocation(
             self.bucket,
             f"{self.prefix}/manifests/{artifact_group}/therock_manifest.json",
+            self.s3_url_schema,
+            self.https_url_schema,
         )
 
     # -- Python packages --------------------------------------------------------
@@ -192,7 +234,12 @@ class WorkflowOutputRoot:
                 the build).
         """
         suffix = f"/{artifact_group}" if artifact_group else ""
-        return StorageLocation(self.bucket, f"{self.prefix}/python{suffix}")
+        return StorageLocation(
+            self.bucket,
+            f"{self.prefix}/python{suffix}",
+            self.s3_url_schema,
+            self.https_url_schema,
+        )
 
     # -- Factories --------------------------------------------------------------
 
@@ -204,6 +251,9 @@ class WorkflowOutputRoot:
         github_repository: str | None = None,
         workflow_run: dict | None = None,
         lookup_workflow_run: bool = False,
+        s3_url_schema: str | None = None,
+        https_url_schema: str | None = None,
+        bucket_schema: str | None = None,
     ) -> "WorkflowOutputRoot":
         """Create from CI workflow context.
 
@@ -223,6 +273,9 @@ class WorkflowOutputRoot:
                 Most callers running inside their own CI workflow do not need
                 this — environment variables suffice. Set this when looking up
                 another repository's workflow run (e.g. fetching artifacts).
+            s3_url_schema: Template for S3 URIs. If None, uses default.
+            https_url_schema: Template for HTTPS URLs. If None, uses default.
+            bucket_schema: Template for bucket naming. If None, uses default.
         """
         workflow_run_id = (
             run_id if lookup_workflow_run and workflow_run is None else None
@@ -231,12 +284,15 @@ class WorkflowOutputRoot:
             github_repository=github_repository,
             workflow_run_id=workflow_run_id,
             workflow_run=workflow_run,
+            bucket_schema=bucket_schema,
         )
         return cls(
             bucket=bucket,
             external_repo=external_repo,
             run_id=run_id,
             platform=platform,
+            s3_url_schema=s3_url_schema,
+            https_url_schema=https_url_schema,
         )
 
     @classmethod
@@ -245,6 +301,8 @@ class WorkflowOutputRoot:
         run_id: str = "local",
         platform: str | None = None,
         bucket: str = "local",
+        s3_url_schema: str | None = None,
+        https_url_schema: str | None = None,
     ) -> "WorkflowOutputRoot":
         """Create for local development/testing.
 
@@ -252,6 +310,8 @@ class WorkflowOutputRoot:
             run_id: Run identifier (default: 'local').
             platform: Platform name. If None, detects from current system.
             bucket: Bucket name placeholder (default: 'local').
+            s3_url_schema: Template for S3 URIs. If None, uses default.
+            https_url_schema: Template for HTTPS URLs. If None, uses default.
         """
         if platform is None:
             platform = platform_module.system().lower()
@@ -260,6 +320,8 @@ class WorkflowOutputRoot:
             external_repo="",
             run_id=run_id,
             platform=platform,
+            s3_url_schema=s3_url_schema,
+            https_url_schema=https_url_schema,
         )
 
 
@@ -276,17 +338,27 @@ def _retrieve_bucket_info(
     github_repository: str | None = None,
     workflow_run_id: str | None = None,
     workflow_run: dict | None = None,
+    bucket_schema: str | None = None,
 ) -> tuple[str, str]:
     """Determine S3 bucket and external_repo prefix for a workflow run.
 
     This is an internal implementation detail — use
     `WorkflowOutputRoot.from_workflow_run` instead.
 
+    Args:
+        github_repository: Repository in 'owner/repo' format.
+        workflow_run_id: Workflow run ID for API lookup.
+        workflow_run: Pre-fetched workflow run data.
+        bucket_schema: Template for bucket naming (default: 'therock-{release_type}-artifacts').
+            Must contain {release_type} placeholder.
+
     Returns:
         Tuple of ``(external_repo, bucket)`` where:
         - external_repo: ``''`` for ROCm/TheRock, or ``'{owner}-{repo}/'``
         - bucket: S3 bucket name
     """
+    if bucket_schema is None:
+        bucket_schema = DEFAULT_BUCKET_SCHEMA
     _log("Retrieving bucket info...")
 
     if github_repository:
@@ -332,7 +404,7 @@ def _retrieve_bucket_info(
                 f"expected one of {sorted(_VALID_RELEASE_TYPES)}"
             )
         _log(f"  (implicit) RELEASE_TYPE: {release_type}")
-        bucket = f"therock-{release_type}-artifacts"
+        bucket = bucket_schema.format(release_type=release_type)
     else:
         if external_repo == "":
             bucket = "therock-ci-artifacts"

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -64,6 +64,7 @@ from _therock_utils.artifact_backend import (
     create_backend_from_env,
 )
 from _therock_utils.artifacts import ArtifactName, ArtifactPopulator
+from _therock_utils.storage_location import StorageConfig
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 
 # Component types that artifacts are split into
@@ -339,14 +340,17 @@ def do_fetch(args: argparse.Namespace):
 
     target_families = parse_target_families(args)
 
+    # Parse storage config from JSON if provided
+    storage_config = None
+    if args.storage_config:
+        storage_config = StorageConfig.from_json(args.storage_config)
+
     # Create backend
     backend = create_backend_from_env(
         run_id=args.run_id,
         platform=args.platform,
         gfx_families=target_families,
-        s3_url_schema=args.s3_url_schema,
-        https_url_schema=args.https_url_schema,
-        bucket_schema=args.bucket_schema,
+        storage_config=storage_config,
     )
     log(f"Using backend: {backend.base_uri}")
 
@@ -589,13 +593,16 @@ def do_push(args: argparse.Namespace):
         f"Stage '{args.stage}' produces {len(produced)} artifacts: {', '.join(sorted(produced))}"
     )
 
+    # Parse storage config from JSON if provided
+    storage_config = None
+    if args.storage_config:
+        storage_config = StorageConfig.from_json(args.storage_config)
+
     # Create backend
     backend = create_backend_from_env(
         run_id=args.run_id,
         platform=args.platform,
-        s3_url_schema=args.s3_url_schema,
-        https_url_schema=args.https_url_schema,
-        bucket_schema=args.bucket_schema,
+        storage_config=storage_config,
     )
     log(f"Using backend: {backend.base_uri}")
 
@@ -764,9 +771,7 @@ def _create_source_backend(
     source_run_id: str,
     platform: str,
     local_staging_dir: Optional[Path] = None,
-    s3_url_schema: Optional[str] = None,
-    https_url_schema: Optional[str] = None,
-    bucket_schema: Optional[str] = None,
+    storage_config: Optional[StorageConfig] = None,
 ) -> ArtifactBackend:
     """Create a backend for the source run ID.
 
@@ -780,9 +785,7 @@ def _create_source_backend(
         output_root = WorkflowOutputRoot.for_local(
             run_id=source_run_id,
             platform=platform,
-            s3_url_schema=s3_url_schema,
-            https_url_schema=https_url_schema,
-            # bucket_schema not applicable for local backend
+            storage_config=storage_config,
         )
         return LocalDirectoryBackend(
             staging_dir=staging,
@@ -793,9 +796,7 @@ def _create_source_backend(
         run_id=source_run_id,
         platform=platform,
         lookup_workflow_run=True,
-        s3_url_schema=s3_url_schema,
-        https_url_schema=https_url_schema,
-        bucket_schema=bucket_schema,
+        storage_config=storage_config,
     )
     return S3Backend(output_root=output_root)
 
@@ -830,22 +831,23 @@ def do_copy(args: argparse.Namespace):
 
     target_families = parse_target_families(args)
 
+    # Parse storage config from JSON if provided
+    storage_config = None
+    if args.storage_config:
+        storage_config = StorageConfig.from_json(args.storage_config)
+
     # Create source and dest backends
     source_backend = _create_source_backend(
         source_run_id=args.source_run_id,
         platform=args.platform,
         local_staging_dir=args.local_staging_dir,
-        s3_url_schema=args.s3_url_schema,
-        https_url_schema=args.https_url_schema,
-        bucket_schema=args.bucket_schema,
+        storage_config=storage_config,
     )
     dest_backend = create_backend_from_env(
         run_id=args.run_id,
         platform=args.platform,
         gfx_families=target_families,
-        s3_url_schema=args.s3_url_schema,
-        https_url_schema=args.https_url_schema,
-        bucket_schema=args.bucket_schema,
+        storage_config=storage_config,
     )
 
     log(f"Source: {source_backend.base_uri}")
@@ -1019,22 +1021,16 @@ def _add_backend_args(parser: argparse.ArgumentParser):
         help="Local staging directory (sets THEROCK_LOCAL_STAGING_DIR)",
     )
     parser.add_argument(
-        "--s3-url-schema",
+        "--storage-config",
         type=str,
         default=None,
-        help="Template for S3 URIs (default: s3://{bucket}/{path})",
-    )
-    parser.add_argument(
-        "--https-url-schema",
-        type=str,
-        default=None,
-        help="Template for HTTPS URLs (default: https://{bucket}.s3.amazonaws.com/{path})",
-    )
-    parser.add_argument(
-        "--bucket-schema",
-        type=str,
-        default=None,
-        help="Template for bucket naming (default: therock-{release_type}-artifacts)",
+        help=(
+            "JSON object with URL schema configuration. Keys: "
+            "s3_url_schema (default: s3://{bucket}/{path}), "
+            "https_url_schema (default: https://{bucket}.s3.amazonaws.com/{path}), "
+            "bucket_schema (default: therock-{release_type}-artifacts). "
+            'Example: \'{"https_url_schema": "https://cdn.example.com/{path}"}\''
+        ),
     )
 
 

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -344,6 +344,9 @@ def do_fetch(args: argparse.Namespace):
         run_id=args.run_id,
         platform=args.platform,
         gfx_families=target_families,
+        s3_url_schema=args.s3_url_schema,
+        https_url_schema=args.https_url_schema,
+        bucket_schema=args.bucket_schema,
     )
     log(f"Using backend: {backend.base_uri}")
 
@@ -590,6 +593,9 @@ def do_push(args: argparse.Namespace):
     backend = create_backend_from_env(
         run_id=args.run_id,
         platform=args.platform,
+        s3_url_schema=args.s3_url_schema,
+        https_url_schema=args.https_url_schema,
+        bucket_schema=args.bucket_schema,
     )
     log(f"Using backend: {backend.base_uri}")
 
@@ -755,7 +761,12 @@ def copy_single_artifact(request: CopyRequest) -> bool:
 
 
 def _create_source_backend(
-    source_run_id: str, platform: str, local_staging_dir: Optional[Path] = None
+    source_run_id: str,
+    platform: str,
+    local_staging_dir: Optional[Path] = None,
+    s3_url_schema: Optional[str] = None,
+    https_url_schema: Optional[str] = None,
+    bucket_schema: Optional[str] = None,
 ) -> ArtifactBackend:
     """Create a backend for the source run ID.
 
@@ -767,7 +778,11 @@ def _create_source_backend(
     if local_staging_dir or os.getenv("THEROCK_LOCAL_STAGING_DIR"):
         staging = local_staging_dir or Path(os.environ["THEROCK_LOCAL_STAGING_DIR"])
         output_root = WorkflowOutputRoot.for_local(
-            run_id=source_run_id, platform=platform
+            run_id=source_run_id,
+            platform=platform,
+            s3_url_schema=s3_url_schema,
+            https_url_schema=https_url_schema,
+            # bucket_schema not applicable for local backend
         )
         return LocalDirectoryBackend(
             staging_dir=staging,
@@ -775,7 +790,12 @@ def _create_source_backend(
         )
 
     output_root = WorkflowOutputRoot.from_workflow_run(
-        run_id=source_run_id, platform=platform, lookup_workflow_run=True
+        run_id=source_run_id,
+        platform=platform,
+        lookup_workflow_run=True,
+        s3_url_schema=s3_url_schema,
+        https_url_schema=https_url_schema,
+        bucket_schema=bucket_schema,
     )
     return S3Backend(output_root=output_root)
 
@@ -815,11 +835,17 @@ def do_copy(args: argparse.Namespace):
         source_run_id=args.source_run_id,
         platform=args.platform,
         local_staging_dir=args.local_staging_dir,
+        s3_url_schema=args.s3_url_schema,
+        https_url_schema=args.https_url_schema,
+        bucket_schema=args.bucket_schema,
     )
     dest_backend = create_backend_from_env(
         run_id=args.run_id,
         platform=args.platform,
         gfx_families=target_families,
+        s3_url_schema=args.s3_url_schema,
+        https_url_schema=args.https_url_schema,
+        bucket_schema=args.bucket_schema,
     )
 
     log(f"Source: {source_backend.base_uri}")
@@ -991,6 +1017,24 @@ def _add_backend_args(parser: argparse.ArgumentParser):
         type=Path,
         default=os.getenv("THEROCK_LOCAL_STAGING_DIR"),
         help="Local staging directory (sets THEROCK_LOCAL_STAGING_DIR)",
+    )
+    parser.add_argument(
+        "--s3-url-schema",
+        type=str,
+        default=None,
+        help="Template for S3 URIs (default: s3://{bucket}/{path})",
+    )
+    parser.add_argument(
+        "--https-url-schema",
+        type=str,
+        default=None,
+        help="Template for HTTPS URLs (default: https://{bucket}.s3.amazonaws.com/{path})",
+    )
+    parser.add_argument(
+        "--bucket-schema",
+        type=str,
+        default=None,
+        help="Template for bucket naming (default: therock-{release_type}-artifacts)",
     )
 
 

--- a/build_tools/github_actions/post_build_upload.py
+++ b/build_tools/github_actions/post_build_upload.py
@@ -42,6 +42,7 @@ PLATFORM = platform.system().lower()
 
 # Add build_tools to path for _therock_utils imports.
 sys.path.insert(0, str(THEROCK_DIR / "build_tools"))
+from _therock_utils.storage_location import StorageConfig
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 from _therock_utils.storage_backend import StorageBackend, create_storage_backend
 
@@ -291,12 +292,15 @@ def run(args):
     if not args.upload:
         return
 
+    # Parse storage config from JSON if provided
+    storage_config = None
+    if args.storage_config:
+        storage_config = StorageConfig.from_json(args.storage_config)
+
     output_root = WorkflowOutputRoot.from_workflow_run(
         run_id=args.run_id,
         platform=PLATFORM,
-        s3_url_schema=args.s3_url_schema,
-        https_url_schema=args.https_url_schema,
-        bucket_schema=args.bucket_schema,
+        storage_config=storage_config,
     )
     backend = create_storage_backend(staging_dir=args.output_dir, dry_run=args.dry_run)
 
@@ -363,22 +367,16 @@ if __name__ == "__main__":
         help="Print what would be uploaded without actually uploading",
     )
     parser.add_argument(
-        "--s3-url-schema",
+        "--storage-config",
         type=str,
         default=None,
-        help="Template for S3 URIs (default: s3://{bucket}/{path})",
-    )
-    parser.add_argument(
-        "--https-url-schema",
-        type=str,
-        default=None,
-        help="Template for HTTPS URLs (default: https://{bucket}.s3.amazonaws.com/{path})",
-    )
-    parser.add_argument(
-        "--bucket-schema",
-        type=str,
-        default=None,
-        help="Template for bucket naming (default: therock-{release_type}-artifacts)",
+        help=(
+            "JSON object with URL schema configuration. Keys: "
+            "s3_url_schema (default: s3://{bucket}/{path}), "
+            "https_url_schema (default: https://{bucket}.s3.amazonaws.com/{path}), "
+            "bucket_schema (default: therock-{release_type}-artifacts). "
+            'Example: \'{"https_url_schema": "https://cdn.example.com/{path}"}\''
+        ),
     )
     args = parser.parse_args()
 

--- a/build_tools/github_actions/post_build_upload.py
+++ b/build_tools/github_actions/post_build_upload.py
@@ -292,7 +292,11 @@ def run(args):
         return
 
     output_root = WorkflowOutputRoot.from_workflow_run(
-        run_id=args.run_id, platform=PLATFORM
+        run_id=args.run_id,
+        platform=PLATFORM,
+        s3_url_schema=args.s3_url_schema,
+        https_url_schema=args.https_url_schema,
+        bucket_schema=args.bucket_schema,
     )
     backend = create_storage_backend(staging_dir=args.output_dir, dry_run=args.dry_run)
 
@@ -357,6 +361,24 @@ if __name__ == "__main__":
         "--dry-run",
         action="store_true",
         help="Print what would be uploaded without actually uploading",
+    )
+    parser.add_argument(
+        "--s3-url-schema",
+        type=str,
+        default=None,
+        help="Template for S3 URIs (default: s3://{bucket}/{path})",
+    )
+    parser.add_argument(
+        "--https-url-schema",
+        type=str,
+        default=None,
+        help="Template for HTTPS URLs (default: https://{bucket}.s3.amazonaws.com/{path})",
+    )
+    parser.add_argument(
+        "--bucket-schema",
+        type=str,
+        default=None,
+        help="Template for bucket naming (default: therock-{release_type}-artifacts)",
     )
     args = parser.parse_args()
 

--- a/build_tools/tests/artifact_backend_test.py
+++ b/build_tools/tests/artifact_backend_test.py
@@ -666,10 +666,10 @@ class TestHTTPBackend(unittest.TestCase):
         mock_response_gfx1200.__exit__ = mock.Mock(return_value=False)
 
         # Mock empty response for gfx94X-dcgpu (index doesn't exist)
-        def urlopen_side_effect(url):
+        def urlopen_side_effect(url, **kwargs):
             if "gfx1200" in url:
                 return mock_response_gfx1200
-            raise Exception("Index not found")
+            raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
 
         mock_urlopen.side_effect = urlopen_side_effect
 
@@ -700,12 +700,12 @@ class TestHTTPBackend(unittest.TestCase):
         mock_response_gfx94x.__enter__ = mock.Mock(return_value=mock_response_gfx94x)
         mock_response_gfx94x.__exit__ = mock.Mock(return_value=False)
 
-        def urlopen_side_effect(url):
+        def urlopen_side_effect(url, **kwargs):
             if "gfx1200" in url:
                 return mock_response_gfx1200
             elif "gfx94X-dcgpu" in url:
                 return mock_response_gfx94x
-            raise Exception("Index not found")
+            raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
 
         mock_urlopen.side_effect = urlopen_side_effect
 

--- a/build_tools/tests/workflow_outputs_test.py
+++ b/build_tools/tests/workflow_outputs_test.py
@@ -442,13 +442,13 @@ class TestWorkflowOutputRootCustomSchemas(unittest.TestCase):
         )
 
     def test_default_schemas_when_no_config(self):
-        """When storage_config is None, StorageLocation should use defaults."""
+        """When storage_config uses defaults, StorageLocation should use defaults."""
         root = WorkflowOutputRoot(
             bucket="therock-ci-artifacts",
             external_repo="",
             run_id="12345",
             platform="linux",
-            storage_config=None,
+            # storage_config omitted - uses default StorageConfig()
         )
         loc = root.artifact("test.tar.xz")
         # StorageLocation should apply default schemas
@@ -474,8 +474,8 @@ class TestWorkflowOutputRootForLocal(unittest.TestCase):
         self.assertEqual(root.run_id, "local")
         # Platform depends on system, just check it's set
         self.assertIn(root.platform, ("linux", "windows", "darwin"))
-        # storage_config should be None by default
-        self.assertIsNone(root.storage_config)
+        # storage_config should use defaults
+        self.assertEqual(root.storage_config, StorageConfig())
 
     def test_custom_values(self):
         root = WorkflowOutputRoot.for_local(
@@ -510,13 +510,13 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
         self.assertEqual(root.external_repo, "")
         self.assertEqual(root.run_id, "12345")
         self.assertEqual(root.platform, "linux")
-        # storage_config should be None by default
-        self.assertIsNone(root.storage_config)
+        # storage_config should use defaults
+        self.assertEqual(root.storage_config, StorageConfig())
         mock_retrieve.assert_called_once_with(
             github_repository=None,
             workflow_run_id=None,
             workflow_run=None,
-            storage_config=None,
+            storage_config=StorageConfig(),
         )
 
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
@@ -557,7 +557,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
             github_repository="SomeUser/TheRock",
             workflow_run_id="99999",
             workflow_run=None,
-            storage_config=None,
+            storage_config=StorageConfig(),
         )
 
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
@@ -574,7 +574,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
             github_repository=None,
             workflow_run_id=None,
             workflow_run=fake_run,
-            storage_config=None,
+            storage_config=StorageConfig(),
         )
 
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
@@ -594,7 +594,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
             github_repository=None,
             workflow_run_id=None,
             workflow_run=fake_run,
-            storage_config=None,
+            storage_config=StorageConfig(),
         )
 
 
@@ -629,6 +629,9 @@ class TestRetrieveBucketInfo(unittest.TestCase):
     def _call(self, **kwargs):
         from _therock_utils.workflow_outputs import _retrieve_bucket_info
 
+        # Provide default storage_config if not specified
+        if "storage_config" not in kwargs:
+            kwargs["storage_config"] = StorageConfig()
         return _retrieve_bucket_info(**kwargs)
 
     def test_no_env_defaults_to_rocm_therock(self):

--- a/build_tools/tests/workflow_outputs_test.py
+++ b/build_tools/tests/workflow_outputs_test.py
@@ -10,7 +10,113 @@ from unittest import mock
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
-from _therock_utils.storage_location import StorageLocation
+from _therock_utils.storage_location import StorageConfig, StorageLocation
+
+
+# ---------------------------------------------------------------------------
+# StorageConfig
+# ---------------------------------------------------------------------------
+
+
+class TestStorageConfig(unittest.TestCase):
+    """Test StorageConfig dataclass."""
+
+    def test_defaults(self):
+        """Test default values are set correctly."""
+        config = StorageConfig()
+        self.assertEqual(config.s3_url_schema, "s3://{bucket}/{path}")
+        self.assertEqual(
+            config.https_url_schema, "https://{bucket}.s3.amazonaws.com/{path}"
+        )
+        self.assertEqual(config.bucket_schema, "therock-{release_type}-artifacts")
+
+    def test_custom_values(self):
+        """Test custom values are stored."""
+        config = StorageConfig(
+            s3_url_schema="custom://{bucket}/{path}",
+            https_url_schema="https://cdn.example.com/{path}",
+            bucket_schema="my-{release_type}-bucket",
+        )
+        self.assertEqual(config.s3_url_schema, "custom://{bucket}/{path}")
+        self.assertEqual(config.https_url_schema, "https://cdn.example.com/{path}")
+        self.assertEqual(config.bucket_schema, "my-{release_type}-bucket")
+
+    def test_frozen(self):
+        """Test that StorageConfig is immutable."""
+        config = StorageConfig()
+        with self.assertRaises(AttributeError):
+            config.s3_url_schema = "other"
+
+    def test_validation_s3_url_schema_invalid_placeholder(self):
+        """Test validation rejects unknown placeholders in s3_url_schema."""
+        with self.assertRaises(ValueError) as cm:
+            StorageConfig(s3_url_schema="s3://{bucket}.{region}/{path}")
+        self.assertIn("s3_url_schema", str(cm.exception))
+        self.assertIn("region", str(cm.exception))
+
+    def test_validation_https_url_schema_invalid_placeholder(self):
+        """Test validation rejects unknown placeholders in https_url_schema."""
+        with self.assertRaises(ValueError) as cm:
+            StorageConfig(https_url_schema="https://{bucket}.{zone}.example.com/{path}")
+        self.assertIn("https_url_schema", str(cm.exception))
+        self.assertIn("zone", str(cm.exception))
+
+    def test_validation_bucket_schema_invalid_placeholder(self):
+        """Test validation rejects unknown placeholders in bucket_schema."""
+        with self.assertRaises(ValueError) as cm:
+            StorageConfig(bucket_schema="my-{env}-{release_type}-bucket")
+        self.assertIn("bucket_schema", str(cm.exception))
+        self.assertIn("env", str(cm.exception))
+
+    def test_validation_allows_subset_of_placeholders(self):
+        """Test that schemas can omit allowed placeholders."""
+        # CDN URL without {bucket}
+        config = StorageConfig(https_url_schema="https://cdn.example.com/{path}")
+        self.assertEqual(config.https_url_schema, "https://cdn.example.com/{path}")
+
+    def test_from_json_valid(self):
+        """Test from_json with valid JSON."""
+        config = StorageConfig.from_json(
+            '{"https_url_schema": "https://cdn.example.com/{path}"}'
+        )
+        self.assertEqual(config.https_url_schema, "https://cdn.example.com/{path}")
+        # Other fields should have defaults
+        self.assertEqual(config.s3_url_schema, "s3://{bucket}/{path}")
+
+    def test_from_json_all_fields(self):
+        """Test from_json with all fields."""
+        config = StorageConfig.from_json(
+            '{"s3_url_schema": "custom://{bucket}/{path}", '
+            '"https_url_schema": "https://cdn/{path}", '
+            '"bucket_schema": "my-{release_type}"}'
+        )
+        self.assertEqual(config.s3_url_schema, "custom://{bucket}/{path}")
+        self.assertEqual(config.https_url_schema, "https://cdn/{path}")
+        self.assertEqual(config.bucket_schema, "my-{release_type}")
+
+    def test_from_json_empty_object(self):
+        """Test from_json with empty object returns defaults."""
+        config = StorageConfig.from_json("{}")
+        self.assertEqual(config.s3_url_schema, "s3://{bucket}/{path}")
+
+    def test_from_json_unknown_key(self):
+        """Test from_json rejects unknown keys."""
+        with self.assertRaises(ValueError) as cm:
+            StorageConfig.from_json('{"unknown_field": "value"}')
+        self.assertIn("unknown_field", str(cm.exception))
+
+    def test_from_json_invalid_json(self):
+        """Test from_json rejects invalid JSON syntax."""
+        import json
+
+        with self.assertRaises(json.JSONDecodeError):
+            StorageConfig.from_json("not valid json")
+
+    def test_from_json_non_object(self):
+        """Test from_json rejects non-object JSON."""
+        with self.assertRaises(ValueError) as cm:
+            StorageConfig.from_json('"just a string"')
+        self.assertIn("must be a JSON object", str(cm.exception))
 
 
 # ---------------------------------------------------------------------------
@@ -24,11 +130,8 @@ class TestStorageLocation(unittest.TestCase):
         self.assertEqual(loc.s3_uri, "s3://my-bucket/12345-linux/file.tar.xz")
 
     def test_s3_uri_custom_schema(self):
-        loc = StorageLocation(
-            "my-bucket",
-            "12345-linux/file.tar.xz",
-            s3_url_schema="custom://{bucket}/prefix/{path}",
-        )
+        config = StorageConfig(s3_url_schema="custom://{bucket}/prefix/{path}")
+        loc = StorageLocation("my-bucket", "12345-linux/file.tar.xz", config)
         self.assertEqual(
             loc.s3_uri, "custom://my-bucket/prefix/12345-linux/file.tar.xz"
         )
@@ -41,11 +144,10 @@ class TestStorageLocation(unittest.TestCase):
         )
 
     def test_https_url_custom_schema(self):
-        loc = StorageLocation(
-            "my-bucket",
-            "12345-linux/file.tar.xz",
-            https_url_schema="https://cdn.example.com/{bucket}/{path}",
+        config = StorageConfig(
+            https_url_schema="https://cdn.example.com/{bucket}/{path}"
         )
+        loc = StorageLocation("my-bucket", "12345-linux/file.tar.xz", config)
         self.assertEqual(
             loc.https_url, "https://cdn.example.com/my-bucket/12345-linux/file.tar.xz"
         )
@@ -66,12 +168,11 @@ class TestStorageLocation(unittest.TestCase):
 
     def test_s3_uri_and_https_url_with_both_schemas(self):
         """Test that both custom schemas work together."""
-        loc = StorageLocation(
-            "my-bucket",
-            "12345-linux/file.tar.xz",
+        config = StorageConfig(
             s3_url_schema="custom-s3://{bucket}/prefix/{path}",
             https_url_schema="https://cdn.example.com/{bucket}/{path}",
         )
+        loc = StorageLocation("my-bucket", "12345-linux/file.tar.xz", config)
         self.assertEqual(
             loc.s3_uri, "custom-s3://my-bucket/prefix/12345-linux/file.tar.xz"
         )
@@ -289,12 +390,13 @@ class TestWorkflowOutputRootCustomSchemas(unittest.TestCase):
     """Test that custom URL schemas propagate through to StorageLocation."""
 
     def test_custom_s3_schema_propagates(self):
+        config = StorageConfig(s3_url_schema="custom-s3://{bucket}/prefix/{path}")
         root = WorkflowOutputRoot(
             bucket="my-bucket",
             external_repo="",
             run_id="12345",
             platform="linux",
-            s3_url_schema="custom-s3://{bucket}/prefix/{path}",
+            storage_config=config,
         )
         loc = root.artifact("test.tar.xz")
         self.assertEqual(
@@ -302,12 +404,15 @@ class TestWorkflowOutputRootCustomSchemas(unittest.TestCase):
         )
 
     def test_custom_https_schema_propagates(self):
+        config = StorageConfig(
+            https_url_schema="https://cdn.example.com/{bucket}/{path}"
+        )
         root = WorkflowOutputRoot(
             bucket="my-bucket",
             external_repo="",
             run_id="12345",
             platform="linux",
-            https_url_schema="https://cdn.example.com/{bucket}/{path}",
+            storage_config=config,
         )
         loc = root.artifact("test.tar.xz")
         self.assertEqual(
@@ -315,13 +420,16 @@ class TestWorkflowOutputRootCustomSchemas(unittest.TestCase):
         )
 
     def test_both_schemas_propagate(self):
+        config = StorageConfig(
+            s3_url_schema="custom-s3://{bucket}/data/{path}",
+            https_url_schema="https://custom.example.com/{bucket}/{path}",
+        )
         root = WorkflowOutputRoot(
             bucket="my-bucket",
             external_repo="",
             run_id="12345",
             platform="linux",
-            s3_url_schema="custom-s3://{bucket}/data/{path}",
-            https_url_schema="https://custom.example.com/{bucket}/{path}",
+            storage_config=config,
         )
         loc = root.log_file("gfx94X-dcgpu", "build.log")
         self.assertEqual(
@@ -333,15 +441,14 @@ class TestWorkflowOutputRootCustomSchemas(unittest.TestCase):
             "https://custom.example.com/my-bucket/12345-linux/logs/gfx94X-dcgpu/build.log",
         )
 
-    def test_default_schemas_when_none(self):
-        """When schemas are None, StorageLocation should use defaults."""
+    def test_default_schemas_when_no_config(self):
+        """When storage_config is None, StorageLocation should use defaults."""
         root = WorkflowOutputRoot(
             bucket="therock-ci-artifacts",
             external_repo="",
             run_id="12345",
             platform="linux",
-            s3_url_schema=None,
-            https_url_schema=None,
+            storage_config=None,
         )
         loc = root.artifact("test.tar.xz")
         # StorageLocation should apply default schemas
@@ -367,9 +474,8 @@ class TestWorkflowOutputRootForLocal(unittest.TestCase):
         self.assertEqual(root.run_id, "local")
         # Platform depends on system, just check it's set
         self.assertIn(root.platform, ("linux", "windows", "darwin"))
-        # Schema fields should be None by default
-        self.assertIsNone(root.s3_url_schema)
-        self.assertIsNone(root.https_url_schema)
+        # storage_config should be None by default
+        self.assertIsNone(root.storage_config)
 
     def test_custom_values(self):
         root = WorkflowOutputRoot.for_local(
@@ -381,9 +487,10 @@ class TestWorkflowOutputRootForLocal(unittest.TestCase):
         self.assertEqual(root.prefix, "test-42-linux")
 
     def test_custom_schemas(self):
-        root = WorkflowOutputRoot.for_local(
+        config = StorageConfig(
             https_url_schema="https://custom.example.com/{bucket}/{path}"
         )
+        root = WorkflowOutputRoot.for_local(storage_config=config)
         loc = root.artifact("test.tar.xz")
         self.assertEqual(
             loc.https_url,
@@ -403,27 +510,30 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
         self.assertEqual(root.external_repo, "")
         self.assertEqual(root.run_id, "12345")
         self.assertEqual(root.platform, "linux")
-        # Schema fields should be None by default
-        self.assertIsNone(root.s3_url_schema)
-        self.assertIsNone(root.https_url_schema)
+        # storage_config should be None by default
+        self.assertIsNone(root.storage_config)
         mock_retrieve.assert_called_once_with(
             github_repository=None,
             workflow_run_id=None,
             workflow_run=None,
-            bucket_schema=None,
+            storage_config=None,
         )
 
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
     def test_custom_schemas(self, mock_retrieve):
-        """Schema parameters are passed through to WorkflowOutputRoot."""
+        """StorageConfig is passed through to WorkflowOutputRoot."""
         mock_retrieve.return_value = ("", "therock-ci-artifacts")
+        config = StorageConfig(
+            https_url_schema="https://cdn.example.com/{bucket}/{path}"
+        )
         root = WorkflowOutputRoot.from_workflow_run(
             run_id="12345",
             platform="linux",
-            https_url_schema="https://cdn.example.com/{bucket}/{path}",
+            storage_config=config,
         )
         self.assertEqual(
-            root.https_url_schema, "https://cdn.example.com/{bucket}/{path}"
+            root.storage_config.https_url_schema,
+            "https://cdn.example.com/{bucket}/{path}",
         )
         loc = root.artifact("test.tar.xz")
         self.assertEqual(
@@ -447,7 +557,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
             github_repository="SomeUser/TheRock",
             workflow_run_id="99999",
             workflow_run=None,
-            bucket_schema=None,
+            storage_config=None,
         )
 
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
@@ -464,7 +574,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
             github_repository=None,
             workflow_run_id=None,
             workflow_run=fake_run,
-            bucket_schema=None,
+            storage_config=None,
         )
 
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
@@ -484,7 +594,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
             github_repository=None,
             workflow_run_id=None,
             workflow_run=fake_run,
-            bucket_schema=None,
+            storage_config=None,
         )
 
 
@@ -646,7 +756,8 @@ class TestRetrieveBucketInfo(unittest.TestCase):
     )
     def test_custom_bucket_schema(self):
         """Custom bucket schema should be used when provided."""
-        external_repo, bucket = self._call(bucket_schema="custom-{release_type}-bucket")
+        config = StorageConfig(bucket_schema="custom-{release_type}-bucket")
+        external_repo, bucket = self._call(storage_config=config)
         self.assertEqual(external_repo, "")
         self.assertEqual(bucket, "custom-dev-bucket")
 
@@ -657,7 +768,8 @@ class TestRetrieveBucketInfo(unittest.TestCase):
     )
     def test_bucket_schema_ignored_without_release_type(self):
         """Custom bucket schema is ignored when RELEASE_TYPE is not set."""
-        external_repo, bucket = self._call(bucket_schema="custom-{release_type}-bucket")
+        config = StorageConfig(bucket_schema="custom-{release_type}-bucket")
+        external_repo, bucket = self._call(storage_config=config)
         self.assertEqual(external_repo, "")
         # Should use default logic, not custom schema
         self.assertEqual(bucket, "therock-ci-artifacts")

--- a/build_tools/tests/workflow_outputs_test.py
+++ b/build_tools/tests/workflow_outputs_test.py
@@ -386,7 +386,8 @@ class TestWorkflowOutputRootForLocal(unittest.TestCase):
         )
         loc = root.artifact("test.tar.xz")
         self.assertEqual(
-            loc.https_url, "https://custom.example.com/local/local-linux/test.tar.xz"
+            loc.https_url,
+            f"https://custom.example.com/local/local-{root.platform}/test.tar.xz",
         )
 
 

--- a/build_tools/tests/workflow_outputs_test.py
+++ b/build_tools/tests/workflow_outputs_test.py
@@ -23,6 +23,16 @@ class TestStorageLocation(unittest.TestCase):
         loc = StorageLocation("my-bucket", "12345-linux/file.tar.xz")
         self.assertEqual(loc.s3_uri, "s3://my-bucket/12345-linux/file.tar.xz")
 
+    def test_s3_uri_custom_schema(self):
+        loc = StorageLocation(
+            "my-bucket",
+            "12345-linux/file.tar.xz",
+            s3_url_schema="custom://{bucket}/prefix/{path}",
+        )
+        self.assertEqual(
+            loc.s3_uri, "custom://my-bucket/prefix/12345-linux/file.tar.xz"
+        )
+
     def test_https_url(self):
         loc = StorageLocation("my-bucket", "12345-linux/file.tar.xz")
         self.assertEqual(
@@ -30,53 +40,44 @@ class TestStorageLocation(unittest.TestCase):
             "https://my-bucket.s3.amazonaws.com/12345-linux/file.tar.xz",
         )
 
-    def test_https_url_with_env_override(self):
-        """Test https_url with bucket-specific environment variable override."""
-        # Set up env var
-        os.environ["THEROCK_HTTPS_URL_my_custom_bucket"] = (
-            "https://custom.example.com/artifacts"
+    def test_https_url_custom_schema(self):
+        loc = StorageLocation(
+            "my-bucket",
+            "12345-linux/file.tar.xz",
+            https_url_schema="https://cdn.example.com/{bucket}/{path}",
         )
-        try:
-            loc = StorageLocation("my-custom-bucket", "12345-linux/file.tar.xz")
-            self.assertEqual(
-                loc.https_url,
-                "https://custom.example.com/artifacts/12345-linux/file.tar.xz",
-            )
-        finally:
-            del os.environ["THEROCK_HTTPS_URL_my_custom_bucket"]
+        self.assertEqual(
+            loc.https_url, "https://cdn.example.com/my-bucket/12345-linux/file.tar.xz"
+        )
 
-    def test_https_url_env_override_trailing_slash(self):
-        """Test that trailing slash in env var is handled correctly."""
-        os.environ["THEROCK_HTTPS_URL_my_bucket"] = "https://example.com/path/"
-        try:
-            loc = StorageLocation("my-bucket", "file.tar.xz")
-            self.assertEqual(
-                loc.https_url,
-                "https://example.com/path/file.tar.xz",
-            )
-        finally:
-            del os.environ["THEROCK_HTTPS_URL_my_bucket"]
-
-    def test_https_url_default_without_env(self):
-        """Test https_url falls back to S3 pattern when no env var set."""
-        # Ensure env var is not set
-        env_var = "THEROCK_HTTPS_URL_therock_ci_artifacts"
-        old_value = os.environ.pop(env_var, None)
-        try:
-            loc = StorageLocation("therock-ci-artifacts", "12345-linux/file.tar.xz")
-            self.assertEqual(
-                loc.https_url,
-                "https://therock-ci-artifacts.s3.amazonaws.com/12345-linux/file.tar.xz",
-            )
-        finally:
-            if old_value is not None:
-                os.environ[env_var] = old_value
+    def test_https_url_default_schema(self):
+        """Test https_url uses default S3 pattern when no custom schema provided."""
+        loc = StorageLocation("therock-ci-artifacts", "12345-linux/file.tar.xz")
+        self.assertEqual(
+            loc.https_url,
+            "https://therock-ci-artifacts.s3.amazonaws.com/12345-linux/file.tar.xz",
+        )
 
     def test_local_path(self):
         loc = StorageLocation("my-bucket", "12345-linux/logs/group/build.log")
         result = loc.local_path(Path("/tmp/staging"))
         expected = Path("/tmp/staging/12345-linux/logs/group/build.log")
         self.assertEqual(result, expected)
+
+    def test_s3_uri_and_https_url_with_both_schemas(self):
+        """Test that both custom schemas work together."""
+        loc = StorageLocation(
+            "my-bucket",
+            "12345-linux/file.tar.xz",
+            s3_url_schema="custom-s3://{bucket}/prefix/{path}",
+            https_url_schema="https://cdn.example.com/{bucket}/{path}",
+        )
+        self.assertEqual(
+            loc.s3_uri, "custom-s3://my-bucket/prefix/12345-linux/file.tar.xz"
+        )
+        self.assertEqual(
+            loc.https_url, "https://cdn.example.com/my-bucket/12345-linux/file.tar.xz"
+        )
 
     def test_frozen(self):
         loc = StorageLocation("bucket", "path")
@@ -284,6 +285,75 @@ class TestStorageLocationEndToEnd(unittest.TestCase):
         )
 
 
+class TestWorkflowOutputRootCustomSchemas(unittest.TestCase):
+    """Test that custom URL schemas propagate through to StorageLocation."""
+
+    def test_custom_s3_schema_propagates(self):
+        root = WorkflowOutputRoot(
+            bucket="my-bucket",
+            external_repo="",
+            run_id="12345",
+            platform="linux",
+            s3_url_schema="custom-s3://{bucket}/prefix/{path}",
+        )
+        loc = root.artifact("test.tar.xz")
+        self.assertEqual(
+            loc.s3_uri, "custom-s3://my-bucket/prefix/12345-linux/test.tar.xz"
+        )
+
+    def test_custom_https_schema_propagates(self):
+        root = WorkflowOutputRoot(
+            bucket="my-bucket",
+            external_repo="",
+            run_id="12345",
+            platform="linux",
+            https_url_schema="https://cdn.example.com/{bucket}/{path}",
+        )
+        loc = root.artifact("test.tar.xz")
+        self.assertEqual(
+            loc.https_url, "https://cdn.example.com/my-bucket/12345-linux/test.tar.xz"
+        )
+
+    def test_both_schemas_propagate(self):
+        root = WorkflowOutputRoot(
+            bucket="my-bucket",
+            external_repo="",
+            run_id="12345",
+            platform="linux",
+            s3_url_schema="custom-s3://{bucket}/data/{path}",
+            https_url_schema="https://custom.example.com/{bucket}/{path}",
+        )
+        loc = root.log_file("gfx94X-dcgpu", "build.log")
+        self.assertEqual(
+            loc.s3_uri,
+            "custom-s3://my-bucket/data/12345-linux/logs/gfx94X-dcgpu/build.log",
+        )
+        self.assertEqual(
+            loc.https_url,
+            "https://custom.example.com/my-bucket/12345-linux/logs/gfx94X-dcgpu/build.log",
+        )
+
+    def test_default_schemas_when_none(self):
+        """When schemas are None, StorageLocation should use defaults."""
+        root = WorkflowOutputRoot(
+            bucket="therock-ci-artifacts",
+            external_repo="",
+            run_id="12345",
+            platform="linux",
+            s3_url_schema=None,
+            https_url_schema=None,
+        )
+        loc = root.artifact("test.tar.xz")
+        # StorageLocation should apply default schemas
+        self.assertEqual(
+            loc.s3_uri, "s3://therock-ci-artifacts/12345-linux/test.tar.xz"
+        )
+        self.assertEqual(
+            loc.https_url,
+            "https://therock-ci-artifacts.s3.amazonaws.com/12345-linux/test.tar.xz",
+        )
+
+
 # ---------------------------------------------------------------------------
 # WorkflowOutputRoot — factory methods
 # ---------------------------------------------------------------------------
@@ -297,6 +367,9 @@ class TestWorkflowOutputRootForLocal(unittest.TestCase):
         self.assertEqual(root.run_id, "local")
         # Platform depends on system, just check it's set
         self.assertIn(root.platform, ("linux", "windows", "darwin"))
+        # Schema fields should be None by default
+        self.assertIsNone(root.s3_url_schema)
+        self.assertIsNone(root.https_url_schema)
 
     def test_custom_values(self):
         root = WorkflowOutputRoot.for_local(
@@ -306,6 +379,15 @@ class TestWorkflowOutputRootForLocal(unittest.TestCase):
         self.assertEqual(root.platform, "linux")
         self.assertEqual(root.bucket, "test-bucket")
         self.assertEqual(root.prefix, "test-42-linux")
+
+    def test_custom_schemas(self):
+        root = WorkflowOutputRoot.for_local(
+            https_url_schema="https://custom.example.com/{bucket}/{path}"
+        )
+        loc = root.artifact("test.tar.xz")
+        self.assertEqual(
+            loc.https_url, "https://custom.example.com/local/local-linux/test.tar.xz"
+        )
 
 
 class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
@@ -320,10 +402,32 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
         self.assertEqual(root.external_repo, "")
         self.assertEqual(root.run_id, "12345")
         self.assertEqual(root.platform, "linux")
+        # Schema fields should be None by default
+        self.assertIsNone(root.s3_url_schema)
+        self.assertIsNone(root.https_url_schema)
         mock_retrieve.assert_called_once_with(
             github_repository=None,
             workflow_run_id=None,
             workflow_run=None,
+            bucket_schema=None,
+        )
+
+    @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
+    def test_custom_schemas(self, mock_retrieve):
+        """Schema parameters are passed through to WorkflowOutputRoot."""
+        mock_retrieve.return_value = ("", "therock-ci-artifacts")
+        root = WorkflowOutputRoot.from_workflow_run(
+            run_id="12345",
+            platform="linux",
+            https_url_schema="https://cdn.example.com/{bucket}/{path}",
+        )
+        self.assertEqual(
+            root.https_url_schema, "https://cdn.example.com/{bucket}/{path}"
+        )
+        loc = root.artifact("test.tar.xz")
+        self.assertEqual(
+            loc.https_url,
+            "https://cdn.example.com/therock-ci-artifacts/12345-linux/test.tar.xz",
         )
 
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
@@ -342,6 +446,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
             github_repository="SomeUser/TheRock",
             workflow_run_id="99999",
             workflow_run=None,
+            bucket_schema=None,
         )
 
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
@@ -358,6 +463,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
             github_repository=None,
             workflow_run_id=None,
             workflow_run=fake_run,
+            bucket_schema=None,
         )
 
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
@@ -377,6 +483,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
             github_repository=None,
             workflow_run_id=None,
             workflow_run=fake_run,
+            bucket_schema=None,
         )
 
 
@@ -529,6 +636,29 @@ class TestRetrieveBucketInfo(unittest.TestCase):
             workflow_run_id="12345",
         )
         self.mock_api.assert_called_once_with("ROCm/TheRock", "12345")
+        self.assertEqual(bucket, "therock-ci-artifacts")
+
+    @mock.patch.dict(
+        os.environ,
+        {"GITHUB_REPOSITORY": "ROCm/TheRock", "RELEASE_TYPE": "dev"},
+        clear=False,
+    )
+    def test_custom_bucket_schema(self):
+        """Custom bucket schema should be used when provided."""
+        external_repo, bucket = self._call(bucket_schema="custom-{release_type}-bucket")
+        self.assertEqual(external_repo, "")
+        self.assertEqual(bucket, "custom-dev-bucket")
+
+    @mock.patch.dict(
+        os.environ,
+        {"GITHUB_REPOSITORY": "ROCm/TheRock"},
+        clear=False,
+    )
+    def test_bucket_schema_ignored_without_release_type(self):
+        """Custom bucket schema is ignored when RELEASE_TYPE is not set."""
+        external_repo, bucket = self._call(bucket_schema="custom-{release_type}-bucket")
+        self.assertEqual(external_repo, "")
+        # Should use default logic, not custom schema
         self.assertEqual(bucket, "therock-ci-artifacts")
 
 

--- a/docs/development/workflow_outputs.md
+++ b/docs/development/workflow_outputs.md
@@ -116,8 +116,7 @@ artifacts, or any S3 path.
 from _therock_utils.storage_location import StorageLocation
 
 loc = StorageLocation(
-    bucket="therock-ci-artifacts",
-    relative_path="12345-linux/file.tar.xz"
+    bucket="therock-ci-artifacts", relative_path="12345-linux/file.tar.xz"
 )
 loc.s3_uri  # "s3://therock-ci-artifacts/12345-linux/file.tar.xz"
 loc.https_url  # "https://therock-ci-artifacts.s3.amazonaws.com/12345-linux/file.tar.xz"
@@ -134,7 +133,7 @@ Schemas use Python string formatting with `{bucket}` and `{path}` placeholders:
 loc = StorageLocation(
     bucket="my-bucket",
     relative_path="12345-linux/file.tar.xz",
-    s3_url_schema="custom-s3://{bucket}/prefix/{path}"
+    s3_url_schema="custom-s3://{bucket}/prefix/{path}",
 )
 loc.s3_uri  # "custom-s3://my-bucket/prefix/12345-linux/file.tar.xz"
 
@@ -142,7 +141,7 @@ loc.s3_uri  # "custom-s3://my-bucket/prefix/12345-linux/file.tar.xz"
 loc = StorageLocation(
     bucket="my-bucket",
     relative_path="12345-linux/file.tar.xz",
-    https_url_schema="https://cdn.example.com/{bucket}/{path}"
+    https_url_schema="https://cdn.example.com/{bucket}/{path}",
 )
 loc.https_url  # "https://cdn.example.com/my-bucket/12345-linux/file.tar.xz"
 ```
@@ -201,25 +200,21 @@ WorkflowOutputRoot accepts optional schema parameters that are propagated to all
 root = WorkflowOutputRoot.from_workflow_run(
     run_id="12345",
     platform="linux",
-    https_url_schema="https://cdn.example.com/{bucket}/{path}"
+    https_url_schema="https://cdn.example.com/{bucket}/{path}",
 )
 root.artifact("test.tar.xz").https_url
 # → "https://cdn.example.com/therock-ci-artifacts/12345-linux/test.tar.xz"
 
 # Custom S3 schema (e.g., for S3-compatible storage)
 root = WorkflowOutputRoot.from_workflow_run(
-    run_id="12345",
-    platform="linux",
-    s3_url_schema="s3-custom://{bucket}/prefix/{path}"
+    run_id="12345", platform="linux", s3_url_schema="s3-custom://{bucket}/prefix/{path}"
 )
 root.artifact("test.tar.xz").s3_uri
 # → "s3-custom://therock-ci-artifacts/prefix/12345-linux/test.tar.xz"
 
 # Custom bucket naming (e.g., for different environments)
 root = WorkflowOutputRoot.from_workflow_run(
-    run_id="12345",
-    platform="linux",
-    bucket_schema="mycompany-{release_type}-builds"
+    run_id="12345", platform="linux", bucket_schema="mycompany-{release_type}-builds"
 )
 # When RELEASE_TYPE=dev, bucket will be "mycompany-dev-builds"
 ```

--- a/docs/development/workflow_outputs.md
+++ b/docs/development/workflow_outputs.md
@@ -116,36 +116,42 @@ artifacts, or any S3 path.
 from _therock_utils.storage_location import StorageLocation
 
 loc = StorageLocation(
-    bucket="therock-ci-artifacts", relative_path="12345-linux/file.tar.xz"
+    bucket="therock-ci-artifacts",
+    relative_path="12345-linux/file.tar.xz"
 )
 loc.s3_uri  # "s3://therock-ci-artifacts/12345-linux/file.tar.xz"
 loc.https_url  # "https://therock-ci-artifacts.s3.amazonaws.com/12345-linux/file.tar.xz"
 loc.local_path(Path("/tmp/staging"))  # Path("/tmp/staging/12345-linux/file.tar.xz")
 ```
 
-#### HTTPS URL Override
+#### Custom URL Schemas
 
-To use a custom HTTPS URL pattern for a specific bucket, set an environment
-variable with the bucket name (dashes replaced with underscores):
-
-```bash
-THEROCK_HTTPS_URL_<bucket_name>=<base_url>
-```
-
-Example for rocm-npi-dev:
-
-```bash
-export THEROCK_HTTPS_URL_therock_dev_tarball=https://different_domain_altogether.com/tarball
-export THEROCK_HTTPS_URL_therock_dev_artifacts=https://different_domain_altogether.com/artifacts
-export THEROCK_HTTPS_URL_therock_dev_python=https://different_domain_altogether.com/whl
-```
-
-The `relative_path` is appended to the base URL:
+StorageLocation supports custom URL schemas for both S3 URIs and HTTPS URLs.
+Schemas use Python string formatting with `{bucket}` and `{path}` placeholders:
 
 ```python
-loc = StorageLocation("therock-dev-tarball", "12345-linux/file.tar.xz")
-loc.https_url  # → "https://different_domain_altogether.com/tarball/12345-linux/file.tar.xz"
+# Custom S3 schema
+loc = StorageLocation(
+    bucket="my-bucket",
+    relative_path="12345-linux/file.tar.xz",
+    s3_url_schema="custom-s3://{bucket}/prefix/{path}"
+)
+loc.s3_uri  # "custom-s3://my-bucket/prefix/12345-linux/file.tar.xz"
+
+# Custom HTTPS schema
+loc = StorageLocation(
+    bucket="my-bucket",
+    relative_path="12345-linux/file.tar.xz",
+    https_url_schema="https://cdn.example.com/{bucket}/{path}"
+)
+loc.https_url  # "https://cdn.example.com/my-bucket/12345-linux/file.tar.xz"
 ```
+
+When `s3_url_schema` or `https_url_schema` are `None` (the default), the following
+defaults are used:
+
+- S3 URI: `s3://{bucket}/{path}`
+- HTTPS URL: `https://{bucket}.s3.amazonaws.com/{path}`
 
 ### WorkflowOutputRoot
 
@@ -165,7 +171,7 @@ root = WorkflowOutputRoot.from_workflow_run(
 # For local development (no API calls, no env vars needed)
 root = WorkflowOutputRoot.for_local(run_id="local", platform="linux")
 
-# Location methods — each returns an StorageLocation
+# Location methods — each returns a StorageLocation
 root.root()
 root.artifact(filename="blas_lib_gfx94X.tar.xz")
 root.artifact_index(artifact_group="gfx94X-dcgpu")
@@ -184,6 +190,55 @@ cutover dating). Most callers running inside their own CI workflow do not need
 this — environment variables (`GITHUB_REPOSITORY`, `IS_PR_FROM_FORK`) suffice.
 Set `lookup_workflow_run=True` when looking up another repository's workflow
 run, e.g. when fetching artifacts.
+
+#### Custom URL Schemas
+
+WorkflowOutputRoot accepts optional schema parameters that are propagated to all
+`StorageLocation` instances it creates:
+
+```python
+# Custom HTTPS schema (e.g., for CDN)
+root = WorkflowOutputRoot.from_workflow_run(
+    run_id="12345",
+    platform="linux",
+    https_url_schema="https://cdn.example.com/{bucket}/{path}"
+)
+root.artifact("test.tar.xz").https_url
+# → "https://cdn.example.com/therock-ci-artifacts/12345-linux/test.tar.xz"
+
+# Custom S3 schema (e.g., for S3-compatible storage)
+root = WorkflowOutputRoot.from_workflow_run(
+    run_id="12345",
+    platform="linux",
+    s3_url_schema="s3-custom://{bucket}/prefix/{path}"
+)
+root.artifact("test.tar.xz").s3_uri
+# → "s3-custom://therock-ci-artifacts/prefix/12345-linux/test.tar.xz"
+
+# Custom bucket naming (e.g., for different environments)
+root = WorkflowOutputRoot.from_workflow_run(
+    run_id="12345",
+    platform="linux",
+    bucket_schema="mycompany-{release_type}-builds"
+)
+# When RELEASE_TYPE=dev, bucket will be "mycompany-dev-builds"
+```
+
+All three schemas can be passed to `artifact_manager.py` and `post_build_upload.py`
+via command line arguments:
+
+```bash
+# Using custom HTTPS URL for CDN
+python build_tools/artifact_manager.py fetch \
+    --https-url-schema "https://cdn.example.com/{bucket}/{path}" \
+    --stage math-libs
+
+# Using custom S3 and bucket schemas
+python build_tools/github_actions/post_build_upload.py \
+    --s3-url-schema "s3-custom://{bucket}/data/{path}" \
+    --bucket-schema "mycompany-{release_type}-artifacts" \
+    --artifact-group gfx94X-dcgpu
+```
 
 ### StorageBackend
 

--- a/docs/development/workflow_outputs.md
+++ b/docs/development/workflow_outputs.md
@@ -12,7 +12,7 @@ manifests, python packages) that are uploaded to S3. Three modules in
 
 | Module             | Role                         | Key types                                                              |
 | ------------------ | ---------------------------- | ---------------------------------------------------------------------- |
-| `storage_location` | Backend-agnostic location    | `StorageLocation`                                                      |
+| `storage_location` | Backend-agnostic location    | `StorageLocation`, `StorageConfig`                                     |
 | `workflow_outputs` | CI path computation (no I/O) | `WorkflowOutputRoot`                                                   |
 | `storage_backend`  | Upload I/O (write)           | `StorageBackend`, `S3StorageBackend`, `LocalStorageBackend`            |
 | `artifact_backend` | Download I/O (read)          | `ArtifactBackend`, `S3Backend`, `LocalDirectoryBackend`, `HTTPBackend` |
@@ -123,34 +123,75 @@ loc.https_url  # "https://therock-ci-artifacts.s3.amazonaws.com/12345-linux/file
 loc.local_path(Path("/tmp/staging"))  # Path("/tmp/staging/12345-linux/file.tar.xz")
 ```
 
-#### Custom URL Schemas
+#### Custom URL Schemas via StorageConfig
 
-StorageLocation supports custom URL schemas for both S3 URIs and HTTPS URLs.
+StorageLocation supports custom URL schemas via the `StorageConfig` dataclass.
 Schemas use Python string formatting with `{bucket}` and `{path}` placeholders:
 
 ```python
-# Custom S3 schema
-loc = StorageLocation(
-    bucket="my-bucket",
-    relative_path="12345-linux/file.tar.xz",
-    s3_url_schema="custom-s3://{bucket}/prefix/{path}",
-)
-loc.s3_uri  # "custom-s3://my-bucket/prefix/12345-linux/file.tar.xz"
+from _therock_utils.storage_location import StorageLocation, StorageConfig
 
-# Custom HTTPS schema
+# Custom HTTPS schema (e.g., for CDN)
+config = StorageConfig(https_url_schema="https://cdn.example.com/{bucket}/{path}")
 loc = StorageLocation(
     bucket="my-bucket",
     relative_path="12345-linux/file.tar.xz",
-    https_url_schema="https://cdn.example.com/{bucket}/{path}",
+    storage_config=config,
 )
 loc.https_url  # "https://cdn.example.com/my-bucket/12345-linux/file.tar.xz"
+
+# Custom S3 schema
+config = StorageConfig(s3_url_schema="custom-s3://{bucket}/prefix/{path}")
+loc = StorageLocation(
+    bucket="my-bucket",
+    relative_path="12345-linux/file.tar.xz",
+    storage_config=config,
+)
+loc.s3_uri  # "custom-s3://my-bucket/prefix/12345-linux/file.tar.xz"
 ```
 
-When `s3_url_schema` or `https_url_schema` are `None` (the default), the following
-defaults are used:
+When `storage_config` is `None` (the default), the following defaults are used:
 
 - S3 URI: `s3://{bucket}/{path}`
 - HTTPS URL: `https://{bucket}.s3.amazonaws.com/{path}`
+
+### StorageConfig
+
+A frozen dataclass that consolidates all URL schema configurations into a single
+object with validation and sensible defaults.
+
+```python
+from _therock_utils.storage_location import StorageConfig
+
+# Use all defaults
+config = StorageConfig()
+
+# Custom CDN URL (omits {bucket})
+config = StorageConfig(https_url_schema="https://cdn.example.com/{path}")
+
+# Multiple custom schemas
+config = StorageConfig(
+    s3_url_schema="s3-custom://{bucket}/prefix/{path}",
+    https_url_schema="https://cdn.example.com/{path}",
+    bucket_schema="mycompany-{release_type}-builds",
+)
+
+# Parse from JSON (for CLI arguments)
+config = StorageConfig.from_json(
+    '{"https_url_schema": "https://cdn.example.com/{path}"}'
+)
+```
+
+#### Schema placeholders
+
+| Schema             | Default                                    | Allowed Placeholders |
+| ------------------ | ------------------------------------------ | -------------------- |
+| `s3_url_schema`    | `s3://{bucket}/{path}`                     | `{bucket}`, `{path}` |
+| `https_url_schema` | `https://{bucket}.s3.amazonaws.com/{path}` | `{bucket}`, `{path}` |
+| `bucket_schema`    | `therock-{release_type}-artifacts`         | `{release_type}`     |
+
+Schemas may omit placeholders (e.g., CDN URLs that ignore `{bucket}`).
+Using an unknown placeholder raises `ValueError` at construction time.
 
 ### WorkflowOutputRoot
 
@@ -190,48 +231,53 @@ this — environment variables (`GITHUB_REPOSITORY`, `IS_PR_FROM_FORK`) suffice.
 Set `lookup_workflow_run=True` when looking up another repository's workflow
 run, e.g. when fetching artifacts.
 
-#### Custom URL Schemas
+#### Custom URL Schemas via StorageConfig
 
-WorkflowOutputRoot accepts optional schema parameters that are propagated to all
-`StorageLocation` instances it creates:
+WorkflowOutputRoot accepts an optional `storage_config` parameter that is
+propagated to all `StorageLocation` instances it creates:
 
 ```python
+from _therock_utils.storage_location import StorageConfig
+from _therock_utils.workflow_outputs import WorkflowOutputRoot
+
 # Custom HTTPS schema (e.g., for CDN)
+config = StorageConfig(https_url_schema="https://cdn.example.com/{bucket}/{path}")
 root = WorkflowOutputRoot.from_workflow_run(
     run_id="12345",
     platform="linux",
-    https_url_schema="https://cdn.example.com/{bucket}/{path}",
+    storage_config=config,
 )
 root.artifact("test.tar.xz").https_url
 # → "https://cdn.example.com/therock-ci-artifacts/12345-linux/test.tar.xz"
 
 # Custom S3 schema (e.g., for S3-compatible storage)
+config = StorageConfig(s3_url_schema="s3-custom://{bucket}/prefix/{path}")
 root = WorkflowOutputRoot.from_workflow_run(
-    run_id="12345", platform="linux", s3_url_schema="s3-custom://{bucket}/prefix/{path}"
+    run_id="12345", platform="linux", storage_config=config
 )
 root.artifact("test.tar.xz").s3_uri
 # → "s3-custom://therock-ci-artifacts/prefix/12345-linux/test.tar.xz"
 
 # Custom bucket naming (e.g., for different environments)
+config = StorageConfig(bucket_schema="mycompany-{release_type}-builds")
 root = WorkflowOutputRoot.from_workflow_run(
-    run_id="12345", platform="linux", bucket_schema="mycompany-{release_type}-builds"
+    run_id="12345", platform="linux", storage_config=config
 )
 # When RELEASE_TYPE=dev, bucket will be "mycompany-dev-builds"
 ```
 
-All three schemas can be passed to `artifact_manager.py` and `post_build_upload.py`
-via command line arguments:
+Storage configuration can be passed to `artifact_manager.py` and `post_build_upload.py`
+via a single `--storage-config` JSON argument:
 
 ```bash
 # Using custom HTTPS URL for CDN
 python build_tools/artifact_manager.py fetch \
-    --https-url-schema "https://cdn.example.com/{bucket}/{path}" \
+    --storage-config '{"https_url_schema": "https://cdn.example.com/{bucket}/{path}"}' \
     --stage math-libs
 
 # Using custom S3 and bucket schemas
 python build_tools/github_actions/post_build_upload.py \
-    --s3-url-schema "s3-custom://{bucket}/data/{path}" \
-    --bucket-schema "mycompany-{release_type}-artifacts" \
+    --storage-config '{"s3_url_schema": "s3-custom://{bucket}/data/{path}", "bucket_schema": "mycompany-{release_type}-artifacts"}' \
     --artifact-group gfx94X-dcgpu
 ```
 


### PR DESCRIPTION
## Summary

Consolidate `s3_url_schema`, `https_url_schema`, and `bucket_schema` parameters into a single `StorageConfig` frozen dataclass. This addresses PR review feedback about threading ~280 lines of boilerplate through multiple classes.

**Key changes:**
      - Add `StorageConfig` dataclass with placeholder validation and `from_json()` parsing
      - Replace individual schema parameters with single `storage_config` throughout codebase
      - Replace `--s3-url-schema`, `--https-url-schema`, `--bucket-schema` CLI args with single `--storage-config` JSON arg
      - Fix `_fetch_index()` error handling (bare `except Exception` → specific HTTP/URL errors)
      - Remove unused `_discover_gfx_families_from_master_index` stub

## Stacked on

This PR is stacked on #4088 (`users/pmclean/workflow_summary_artifact_backend`)

## Test plan

      - [x] All 69 tests pass in `workflow_outputs_test.py`
      - [x] Pre-commit checks pass
      - [ ] CI validation