### PR TITLE
Use TheRock’s bundled elfutils in rocprofiler-systems

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -7,6 +7,11 @@ if(THEROCK_ENABLE_ROCPROFV3)
     set(_openmpi_optional_dep therock-openmpi)
   endif()
 
+  set(_rocprofsys_build_elfutils ON)
+  if(THEROCK_BUNDLED_ELFUTILS)
+    set(_rocprofsys_build_elfutils OFF)
+  endif()
+
   ##############################################################################
   # rocprof-trace-decoder
   # The trace decoder is responsible for decoding advanced thread traces from the
@@ -263,7 +268,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
       BACKGROUND_BUILD
       CMAKE_ARGS
         -DHIP_PLATFORM=amd
-        -DROCPROFSYS_BUILD_ELFUTILS=ON
+        -DROCPROFSYS_BUILD_ELFUTILS=${_rocprofsys_build_elfutils}
         -DROCPROFSYS_BUILD_TBB=ON
         -DROCPROFSYS_BUILD_LIBIBERTY=ON
         -DROCPROFSYS_BUILD_BOOST=ON
@@ -287,6 +292,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
         hip-clr
         rocprofiler-register
         rocprofiler-sdk
+        ${THEROCK_BUNDLED_ELFUTILS}
         ${THEROCK_BUNDLED_LIBDRM}
         ${THEROCK_BUNDLED_SQLITE3}
         ${_openmpi_optional_dep}


### PR DESCRIPTION
Closes: [#3516](https://github.com/ROCm/TheRock/issues/3516)

This PR updates rocprofiler-systems to use the elfutils provided by TheRock, rather than always downloading and building its own version. Currently rocprofiler-systems downloads elfutils 0.188 which fails to compile with GCC 15 due to restrictive [`-Werror=unterminated-string-initialization`](https://github.com/ROCm/TheRock/issues/3516#:~:text=i386_regs.c%3A88%3A11%3A%20error%3A%20initializer%2Dstring%20for%20array%20of%20%27char%27%20truncates%20NUL%20terminator%0Abut%20destination%20lacks%20%27nonstring%27%20attribute%20%5B%2DWerror%3Dunterminated%2Dstring%2Dinitialization%5D) string truncation bug in `i386_regs.c`.

## Technical Details

Added `_rocprofsys_build_elfutils` variable in `profiler/CMakeLists.txt` to disable rocprofiler-system from building elfutils when `THEROCK_BUNDLED_ELFUTILS` is set. This variable is propagated to `-DROCPROFSYS_BUILD_ELFUTILS` so the build can use TheROck provided elfutils. Also passed `THEROCK_BUNDLED_ELFUTILS` as a runtime dep to the rocprofiler-systems component.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

## Related

- Connected to PR that is in rocm-systems. [See here](https://github.com/ROCm/rocm-systems/pull/4500).