### PR TITLE
Shift gfx950-dcgpu exclusions over from multi_arch_ci to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,11 @@ jobs:
       fail-fast: false
       matrix:
         variant: ${{ fromJSON(needs.setup.outputs.linux_variants) }}
+        # TODO(TheRock#3288): Re-enable gfx950-dcgpu runners once we get more capacity
+        #     Or delete all of ci.yml as part of https://github.com/ROCm/TheRock/issues/3340 first?
+        exclude:
+          - variant:
+              family: gfx950-dcgpu
     uses: ./.github/workflows/ci_linux.yml
     secrets: inherit
     with:

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -124,10 +124,6 @@ jobs:
       fail-fast: false
       matrix:
         family_info: ${{ fromJSON(inputs.matrix_per_family_json) }}
-        # TODO(TheRock#3288): Re-enable gfx950-dcgpu runners once we get more capacity
-        exclude:
-          - family_info:
-              amdgpu_family: gfx950-dcgpu
     uses: ./.github/workflows/test_artifacts.yml
     with:
       # Use architecture-specific artifact group for fetching per-arch artifacts
@@ -161,10 +157,6 @@ jobs:
       fail-fast: false
       matrix:
         family_info: ${{ fromJSON(inputs.matrix_per_family_json) }}
-        # TODO(TheRock#3288): Re-enable gfx950-dcgpu runners once we get more capacity
-        exclude:
-          - family_info:
-              amdgpu_family: gfx950-dcgpu
     uses: ./.github/workflows/test_rocm_wheels.yml
     with:
       amdgpu_family: ${{ matrix.family_info.amdgpu_family }}
@@ -185,10 +177,6 @@ jobs:
       fail-fast: false
       matrix:
         family_info: ${{ fromJSON(inputs.matrix_per_family_json) }}
-        # TODO(TheRock#3288): Re-enable gfx950-dcgpu runners once we get more capacity
-        exclude:
-          - family_info:
-              amdgpu_family: gfx950-dcgpu
     uses: ./.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
     with:
       artifact_group: ${{ matrix.family_info.amdgpu_family }}


### PR DESCRIPTION
## Motivation

Tracking issue: https://github.com/ROCm/TheRock/issues/3288. We disabled gfx950-dcgpu for multi-arch CI when it was not the default workflow to avoid double runner utilization for scarce runner types. In https://github.com/ROCm/TheRock/pull/4204 we switched the default CI workflow from ci.yml to multi_arch_ci.yml, so this moves the exclusion/skipping over accordingly.

## Technical Details

* Note that the multi-arch CI filtering was still _building_ but only filtered out _testing_. This now filters out testing too. We could filter a different way, but that would need extra plumbing.
  * The current filtering method will show gfx950 in the configure output summary then skip in the matrix. Not ideal, but multi_arch ci had the same issue before
* We may want to similarly strip down other aspects of the ci.yml configuration as we make progress on https://github.com/ROCm/TheRock/issues/3340
* gfx950 is postsubmit only by default: https://github.com/ROCm/TheRock/blob/d1c88f5f78365dc4628d0bf645d4720492e5fa3f/build_tools/github_actions/amdgpu_family_matrix.py#L149-L151

## Test Plan and Results

Add gfx950 label to this PR to opt-in then...

- [x] Check that non-multi-arch CI (ci.yml) does not build or test for gfx950 on this PR
- [ ] Check that non-multi-arch CI (ci.yml) does not build or test for gfx950 on postsubmit
- [x] Check that multi-arch CI builds and tests for gfx950 on this PR
- [ ] Check that multi-arch CI builds and tests for gfx950 on postsubmit

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
