### PR TITLE
Add optional dep on SQLite3

### DIFF
--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -184,6 +184,7 @@ if(THEROCK_ENABLE_PRIM)
       therock-googletest
     RUNTIME_DEPS
       hip-clr
+      ${THEROCK_BUNDLED_SQLITE3}
   )
   therock_cmake_subproject_glob_c_sources(rocThrust
     SUBDIRS


### PR DESCRIPTION
Adds `THEROCK_BUNDLED_SQLITE3` (if set) as a runtime dependency to rocThrust which switches to consume the dependency via TheRock with PR https://github.com/ROCm/rocm-libraries/pull/5899.