### PR TITLE
[ci] Increasing storage for heavy CPU builders for ASAN

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -33,7 +33,7 @@ all_build_variants = {
         "asan": {
             "build_variant_label": "asan",
             "build_variant_suffix": "asan",
-            "build_variant_cmake_preset": "linux-release-host-asan",
+            "build_variant_cmake_preset": "linux-release-asan",
         },
         "tsan": {
             "build_variant_label": "tsan",


### PR DESCRIPTION
During previous CI host asan runs, we noticed storage getting low. In this PR, we are using RAM disk for storage as well as a temporary workaround to continue ASAN builds

Previously failing due to out of storage: https://github.com/ROCm/TheRock/actions/runs/23619639847/job/68795687256

Passing: https://github.com/ROCm/TheRock/actions/runs/23662868089/job/68937403005