### PR TITLE
Always configure creds prior to log upload for multi-arch CI

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -141,12 +141,17 @@ jobs:
       # Assume the therock-ci OIDC role in ROCm/TheRock. Other repos
       # fall back to runner base credentials (therock-ci-artifacts-external).
       - name: Configure AWS Credentials
-        if: ${{ github.repository == 'ROCm/TheRock' && !github.event.pull_request.head.repo.fork }}
+        if: ${{ always() && github.repository == 'ROCm/TheRock' && !github.event.pull_request.head.repo.fork }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::692859939525:role/therock-ci
 
+      # TODO(#3336): Attempt upload `always()`?
+      #   * If some part of the build failed, partial artifacts may be useful for debugging.
+      #   * This script fails if `build_dir / "artifacts"` does not exist. That's useful
+      #     if the build succeeded but did not produce artifacts. That's _not_ useful
+      #     if the workflow failed or was cancelled before the build even started though.
       - name: Push stage artifacts
         run: |
           python build_tools/artifact_manager.py push --run-id ${{ github.run_id }} \
@@ -154,7 +159,7 @@ jobs:
             --build-dir="${BUILD_DIR}"
 
       - name: Upload stage logs
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         run: |
           python build_tools/github_actions/post_stage_upload.py \
             --run-id=${{ github.run_id }} \

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -167,13 +167,18 @@ jobs:
       # Assume the therock-ci OIDC role in ROCm/TheRock. Other repos
       # fall back to runner base credentials (therock-ci-artifacts-external).
       - name: Configure AWS Credentials
-        if: ${{ github.repository == 'ROCm/TheRock' && !github.event.pull_request.head.repo.fork }}
+        if: ${{ always() && github.repository == 'ROCm/TheRock' && !github.event.pull_request.head.repo.fork }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::692859939525:role/therock-ci
           special-characters-workaround: true
 
+      # TODO(#3336): Attempt upload `always()`?
+      #   * If some part of the build failed, partial artifacts may be useful for debugging.
+      #   * This script fails if `build_dir / "artifacts"` does not exist. That's useful
+      #     if the build succeeded but did not produce artifacts. That's _not_ useful
+      #     if the workflow failed or was cancelled before the build even started though.
       - name: Push stage artifacts
         run: |
           python build_tools/artifact_manager.py push --run-id ${{ github.run_id }} \
@@ -181,7 +186,7 @@ jobs:
             --build-dir="${BUILD_DIR}"
 
       - name: Upload stage logs
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         run: |
           python build_tools/github_actions/post_stage_upload.py \
             --run-id=${{ github.run_id }} \


### PR DESCRIPTION
## Motivation

Related to https://github.com/ROCm/TheRock/issues/3336

On https://github.com/ROCm/TheRock/actions/runs/23663263447/job/68945135064?pr=4209, log upload failed since the configure credentials step did not run:

```
WARNING:_therock_utils.storage_backend:S3 upload attempt 1/3 failed for s3://therock-ci-artifacts/23663263447-windows/logs/math-libs/gfx110X-all/hipBLAS-common_install.log: Failed to upload B:\build\logs\hipBLAS-common_install.log to therock-ci-artifacts/23663263447-windows/logs/math-libs/gfx110X-all/hipBLAS-common_install.log: An error occurred (AccessDenied) when calling the PutObject operation: User: arn:aws:iam::692859939525:user/therock-external-upload is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::therock-ci-artifacts/23663263447-windows/logs/math-libs/gfx110X-all/hipBLAS-common_install.log" because no identity-based policy allows the s3:PutObject action. Retrying in 1.0s...

RuntimeError: Failed to upload 88/88 files. First failure: s3://therock-ci-artifacts/23663263447-windows/logs/math-libs/gfx110X-all/hipBLAS-common_install.log: S3 upload failed after 3 attempts: s3://therock-ci-artifacts/23663263447-windows/logs/math-libs/gfx110X-all/hipBLAS-common_install.log
```

This fixes that by copying the pattern from CI to multi-arch CI: https://github.com/ROCm/TheRock/blob/4a115c720d51397c61a0efd7cc370fb78d862e80/.github/workflows/build_portable_linux_artifacts.yml#L170-L185

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
