### PR TITLE
Add Sivakumar Ganesan as /patches codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 /rocm-systems           @ROCm/TheRock-infra-write
 
 # New patches are strongly discouraged. See patches/README.md.
-/patches/               @ScottTodd @marbre
+/patches/               @ScottTodd @marbre @skganesan008
 
 # This file accumulated unrelated code, tighten reviews until cleaned up.
 /build_tools/github_actions/github_actions_api.py       @ScottTodd


### PR DESCRIPTION
## Motivation
Add to pool of code owners for /patches; the strongly discouraged mantra for addition of new conent into /patches remains

## Technical Details
1-line change to add the additional code owner

## Submission Checklist
Discussed with @stellaraccident 