### PR TITLE
[sysdeps] Fix zstd symbol visibility and -Bsymbolic linking

### DIFF
--- a/third-party/sysdeps/common/zstd/CMakeLists.txt
+++ b/third-party/sysdeps/common/zstd/CMakeLists.txt
@@ -65,7 +65,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(CONFIGURE_ARGS
     -DZSTD_BUILD_STATIC=OFF
     -DZSTD_BUILD_SHARED=ON
-    "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds -Bsymbolic"
+    "-DCMAKE_C_FLAGS=-fvisibility=hidden"
+    -DZSTDLIB_VISIBLE=default
+    -DZSTDERRORLIB_VISIBLE=default
+    -DZDICTLIB_VISIBLE=default
+    "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/version.lds -Wl,-Bsymbolic"
   )
   set(POST_INSTALL_COMMANDS
     COMMAND


### PR DESCRIPTION
The original -Bsymbolic flag was missing the -Wl, prefix so it never
reached the linker. Additionally, zstd was exporting 391 symbols
(including internals like FSE_*, XXH*, HUF_*) due to default visibility.

This caused crashes on systems (e.g. Debian) where system zstd loaded
alongside ROCm's bundled copy, with system zstd's ZSTD_freeDCtx being
called during ROCm zstd's ZSTD_decompress.

Changes:
- Fix -Bsymbolic to -Wl,-Bsymbolic so the flag reaches the linker
- Build with -fvisibility=hidden and set ZSTDLIB_VISIBLE,
  ZSTDERRORLIB_VISIBLE, ZDICTLIB_VISIBLE to "default" so only the
  public API is exported (391 -> 187 symbols)

Verified locally: readelf shows SYMBOLIC flag present, internal symbols
(FSE_*, XXH*, HUF_*) no longer exported.

Progress on https://github.com/ROCm/TheRock/issues/4211

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>