### PR TITLE
ci: skip GPU math lib tests and suppress ASAN noise in host-ASAN builds

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -146,6 +146,23 @@ jobs:
           echo "HSA_XNACK=1" >> $GITHUB_ENV
           echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
 
+          # Generate an LSAN suppression file to filter known non-ROCm leak noise.
+          #
+          # 1. /usr/bin/date: shell test scripts invoke `date` as a subprocess; LD_PRELOAD
+          #    is inherited, causing spurious 128-byte direct leaks from the date binary.
+          # 2. python3.x: the Python interpreter does not free all allocations on exit
+          #    (by design). The exact minor version is detected from the runner environment
+          #    so the suppression is always current without manual updates.
+          PYTHON_BIN=$(python3 -c "import sys; print(f'python{sys.version_info.major}.{sys.version_info.minor}')")
+          LSAN_SUP="${{ github.workspace }}/lsan_suppressions.txt"
+          cat > "${LSAN_SUP}" << EOF
+# /usr/bin/date leaks: LD_PRELOAD inherited by child shell processes in test scripts
+leak:/usr/bin/date
+# Python interpreter exit-time allocations (not freed during interpreter shutdown)
+leak:${PYTHON_BIN}
+EOF
+          echo "LSAN_OPTIONS=suppressions=${LSAN_SUP}" >> $GITHUB_ENV
+
       - name: Test
         id: test
         timeout-minutes: ${{ fromJSON(inputs.component).timeout_minutes }}

--- a/build_tools/github_actions/github_actions_api.py
+++ b/build_tools/github_actions/github_actions_api.py
@@ -609,3 +609,20 @@ def is_asan():
     """Using artifact_group, determines if this is an asan build"""
     ARTIFACT_GROUP = os.getenv("ARTIFACT_GROUP", "")
     return "asan" in ARTIFACT_GROUP
+
+
+def is_host_asan() -> bool:
+    """Returns True when the build uses host-only ASAN.
+
+    Host-ASAN builds instrument CPU-side code only and do not compile GPU math
+    library test binaries (hipblas-test, rocblas-test, etc.).  Use this to skip
+    those tests cleanly instead of failing with a missing-binary error.
+
+    Detection order:
+    1. THEROCK_SANITIZER=HOST_ASAN (set explicitly in the test environment)
+    2. ARTIFACT_GROUP containing "host-asan" (e.g. "gfx94X-dcgpu-host-asan"),
+       following the same convention as is_asan() using ARTIFACT_GROUP.
+    """
+    if os.getenv("THEROCK_SANITIZER", "") == "HOST_ASAN":
+        return True
+    return "host-asan" in os.getenv("ARTIFACT_GROUP", "")

--- a/build_tools/github_actions/test_executable_scripts/test_hipblas.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblas.py
@@ -14,7 +14,7 @@ THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
 # Importing is_asan from github_actions_api.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
-from github_actions_api import is_asan
+from github_actions_api import is_asan, is_host_asan
 
 # GTest sharding
 SHARD_INDEX = os.getenv("SHARD_INDEX", 1)
@@ -23,6 +23,13 @@ environ_vars = os.environ.copy()
 # For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
 environ_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
 environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
 
 if is_asan():
     environ_vars["HSA_XNACK"] = "1"

--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
@@ -16,7 +16,7 @@ THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
 # Importing is_asan from github_actions_api.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
-from github_actions_api import is_asan
+from github_actions_api import is_asan, is_host_asan
 
 logging.basicConfig(level=logging.INFO)
 
@@ -27,6 +27,13 @@ environ_vars = os.environ.copy()
 # For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
 environ_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
 environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
 
 if is_asan():
     environ_vars["HSA_XNACK"] = "1"

--- a/build_tools/github_actions/test_executable_scripts/test_hipcub.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipcub.py
@@ -12,6 +12,17 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
+
 logging.basicConfig(level=logging.INFO)
 
 QUICK_TESTS = [

--- a/build_tools/github_actions/test_executable_scripts/test_hipfft.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipfft.py
@@ -11,6 +11,17 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
+
 logging.basicConfig(level=logging.INFO)
 
 # GTest sharding

--- a/build_tools/github_actions/test_executable_scripts/test_hiprand.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiprand.py
@@ -11,6 +11,17 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
+
 logging.basicConfig(level=logging.INFO)
 
 cmd = [

--- a/build_tools/github_actions/test_executable_scripts/test_hipsolver.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsolver.py
@@ -11,6 +11,17 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
+
 PLATFORM = os.getenv("PLATFORM")
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 

--- a/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
@@ -12,6 +12,17 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 os_type = platform.system().lower()
 

--- a/build_tools/github_actions/test_executable_scripts/test_hipsparselt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsparselt.py
@@ -12,6 +12,17 @@ OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
+
 logging.basicConfig(level=logging.INFO)
 
 # GTest sharding

--- a/build_tools/github_actions/test_executable_scripts/test_libhipcxx_hipcc.py
+++ b/build_tools/github_actions/test_executable_scripts/test_libhipcxx_hipcc.py
@@ -13,6 +13,17 @@ OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
+
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 

--- a/build_tools/github_actions/test_executable_scripts/test_libhipcxx_hiprtc.py
+++ b/build_tools/github_actions/test_executable_scripts/test_libhipcxx_hiprtc.py
@@ -12,6 +12,17 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 

--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -12,6 +12,17 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
+
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 os_type = platform.system().lower()
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocblas.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocblas.py
@@ -14,7 +14,7 @@ THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
 # Importing is_asan from github_actions_api.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
-from github_actions_api import is_asan
+from github_actions_api import is_asan, is_host_asan
 
 # GTest sharding
 SHARD_INDEX = os.getenv("SHARD_INDEX", 1)
@@ -23,6 +23,13 @@ environ_vars = os.environ.copy()
 # For display purposes in the GitHub Action UI, the shard array is 1th indexed. However for shard indexes, we convert it to 0th index.
 environ_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
 environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
 
 if is_asan():
     environ_vars["HSA_XNACK"] = "1"

--- a/build_tools/github_actions/test_executable_scripts/test_rocfft.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocfft.py
@@ -11,6 +11,17 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
+
 logging.basicConfig(level=logging.INFO)
 
 # GTest sharding

--- a/build_tools/github_actions/test_executable_scripts/test_rocprim.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprim.py
@@ -12,6 +12,17 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
+
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 os_type = platform.system().lower()
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocrand.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocrand.py
@@ -11,6 +11,17 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
+
 logging.basicConfig(level=logging.INFO)
 
 QUICK_TESTS = [

--- a/build_tools/github_actions/test_executable_scripts/test_rocroller.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocroller.py
@@ -13,6 +13,17 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 # repo + dirs
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR", "")
 platform = os.getenv("RUNNER_OS", "linux").lower()
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocsolver.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocsolver.py
@@ -12,6 +12,17 @@ OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
+
 logging.basicConfig(level=logging.INFO)
 
 # GTest sharding

--- a/build_tools/github_actions/test_executable_scripts/test_rocsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocsparse.py
@@ -12,6 +12,17 @@ OUTPUT_ARTIFACTS_DIR = Path(os.getenv("OUTPUT_ARTIFACTS_DIR")).resolve()
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent.resolve()
 
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
+
 logging.basicConfig(level=logging.INFO)
 
 # GTest sharding

--- a/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
@@ -13,6 +13,17 @@ AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
+
 logging.basicConfig(level=logging.INFO)
 
 QUICK_TESTS = [

--- a/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
@@ -13,6 +13,17 @@ platform = os.getenv("RUNNER_OS").lower()
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
+import sys
+sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
+from github_actions_api import is_host_asan
+
+if is_host_asan():
+    print(
+        "SKIP: host-ASAN build (THEROCK_SANITIZER=HOST_ASAN) does not produce "
+        "GPU math library test binaries. Run with linux-release-asan for device tests."
+    )
+    sys.exit(0)
+
 # GTest sharding
 SHARD_INDEX = os.getenv("SHARD_INDEX", 1)
 TOTAL_SHARDS = os.getenv("TOTAL_SHARDS", 1)


### PR DESCRIPTION
## Summary

- **Add `is_host_asan()`** to `github_actions_api.py`: detects host-only ASAN builds via `THEROCK_SANITIZER=HOST_ASAN` or `ARTIFACT_GROUP` containing `"host-asan"` (same pattern as the existing `is_asan()`).
- **Skip guard in 20 GPU math-library test scripts**: `test_hipblas`, `test_hipblaslt`, `test_hipcub`, `test_hipfft`, `test_hiprand`, `test_hipsolver`, `test_hipsparse`, `test_hipsparselt`, `test_libhipcxx_hipcc`, `test_libhipcxx_hiprtc`, `test_miopen`, `test_rocblas`, `test_rocfft`, `test_rocprim`, `test_rocrand`, `test_rocroller`, `test_rocsolver`, `test_rocsparse`, `test_rocthrust`, `test_rocwmma`. Each calls `is_host_asan()` at startup and exits 0 (clean skip) instead of crashing on missing test binaries that are not built in host-ASAN mode.
- **LSAN suppression file** generated at CI runtime in `test_component.yml`'s "Enable sanitizer-specific test flags" step. Suppresses two known noise sources identified in the host-ASAN run:
  - `/usr/bin/date` 128-byte direct leaks caused by `LD_PRELOAD` inheritance when shell test scripts spawn child processes.
  - `python3.x` exit-time allocations the interpreter never frees (by design). The Python minor version is detected from the runner environment at runtime via `python3 -c "..."` so the suppression stays current without manual updates.

## Context

From a host-ASAN CI run (`gfx94X-dcgpu-asan`, preset `linux-release-host-asan`): 22 of 28 components failed with missing-binary errors — expected because `THEROCK_SANITIZER=HOST_ASAN` only instruments host code and does not compile device-side test binaries. The noise from `/usr/bin/date` and Python appeared in every component's ASAN log, obscuring real findings.

## Test plan

- [ ] Trigger a host-ASAN test run with `ARTIFACT_GROUP=gfx94X-dcgpu-host-asan` and confirm all 20 math-lib steps exit 0 (skipped) with the "SKIP: host-ASAN build" message.
- [ ] Confirm non-ASAN runs are unaffected (`is_host_asan()` returns False, scripts run normally).
- [ ] Confirm `is_asan()` still returns True for `gfx94X-dcgpu-asan` (full ASAN), False for host-ASAN group (does not contain plain "asan" without "host-").
- [ ] In a host-ASAN run, verify `lsan_suppressions.txt` is created and `LSAN_OPTIONS` is set; confirm `/usr/bin/date` and `python3.x` entries no longer appear in LSAN output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)