### PR TITLE
Pass `THEROCK_AMDGPU_TARGETS` to `amd-llvm`

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -46,6 +46,8 @@ if(THEROCK_ENABLE_COMPILER)
     message(STATUS "Using stable amd-llvm revision info: Repo='${LLVM_SMREV_REPO}', Revision='${LLVM_SMREV_REVISION}'")
   endif()
 
+  list(JOIN THEROCK_AMDGPU_TARGETS "\\;" THEROCK_AMDGPU_TARGETS_ESCAPED)
+
   therock_cmake_subproject_declare(amd-llvm
     USE_DIST_AMDGPU_TARGETS
     NO_INSTALL_RPATH  # See manual handling in the pre_hook.
@@ -83,6 +85,9 @@ if(THEROCK_ENABLE_COMPILER)
       -DCLANG_ENABLE_AMDCLANG=ON
       -DLLVM_INSTALL_TOOLCHAIN_ONLY=OFF
       -DLLVM_BUILD_LLVM_C_DYLIB=OFF
+
+      # GPU Targets
+      "-DTHEROCK_AMDGPU_TARGETS=${THEROCK_AMDGPU_TARGETS_ESCAPED}"
 
       # Build optimizations
       -DLLVM_BUILD_EXAMPLES=${THEROCK_ENABLE_LLVM_TESTS}


### PR DESCRIPTION
## Motivation

This corrects an issue where the gpu targets selected doesn't propagate into the llvm build resulting in components in rocm-system building with the default gpu list rather then the list that was actually selected.

## Technical Details

Simply defines `THEROCK_AMDGPU_TARGETS` correctly for the `amd-llvm` project. Because of the way that the llvm project  is invoked it is required to escape the semicolons in the list.

At current this does very little as the sub module will ignore this parameter anyway due to the incorrect usage of `THEROCK_DIST_AMDGPU_TARGETS`. This is just the first step needed to fix these issues.

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
