### PR TITLE
Make artifact archives reproducible

### DIFF
--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -33,6 +33,14 @@ on:
         description: "Enable multi-arch indexing (generates per-family indexes)"
         type: boolean
         default: false
+      export_source_date_epoch:
+        description: >-
+          Export SOURCE_DATE_EPOCH so the wheel zip and rocm sdist are
+          byte-reproducible. Off by default: SOURCE_DATE_EPOCH is honored by
+          CPython and setuptools beyond archive metadata. See
+          docs/development/reproducible_archives.md.
+        type: boolean
+        default: false
       package_version:
         description: "package_version to set on packages, e.g. '7.13.0.dev0+dbd7369489260265fc6ddfc9d0de1262a95fe974'"
         type: string
@@ -74,6 +82,9 @@ on:
         type: string
         default: ""
       multiarch_index:
+        type: boolean
+        default: false
+      export_source_date_epoch:
         type: boolean
         default: false
       package_version:
@@ -179,7 +190,8 @@ jobs:
             --dest-dir="${{ env.PACKAGES_DIR }}" \
             --version="${{ inputs.package_version }}" \
             --linux-amdgpu-families="${{ inputs.linux_amdgpu_families }}" \
-            --windows-amdgpu-families="${{ inputs.windows_amdgpu_families }}"
+            --windows-amdgpu-families="${{ inputs.windows_amdgpu_families }}" \
+            ${{ inputs.export_source_date_epoch && '--export-source-date-epoch' || '' }}
 
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure_aws_artifacts_credentials

--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -33,6 +33,14 @@ on:
         description: "Enable multi-arch indexing (generates per-family indexes)"
         type: boolean
         default: false
+      export_source_date_epoch:
+        description: >-
+          Export SOURCE_DATE_EPOCH so the wheel zip and rocm sdist are
+          byte-reproducible. Off by default: SOURCE_DATE_EPOCH is honored by
+          CPython and setuptools beyond archive metadata. See
+          docs/development/reproducible_archives.md.
+        type: boolean
+        default: false
       package_version:
         description: "package_version to set on packages, e.g. '7.13.0.dev0+dbd7369489260265fc6ddfc9d0de1262a95fe974'"
         type: string
@@ -74,6 +82,9 @@ on:
         type: string
         default: ""
       multiarch_index:
+        type: boolean
+        default: false
+      export_source_date_epoch:
         type: boolean
         default: false
       package_version:
@@ -182,7 +193,8 @@ jobs:
             --dest-dir="${{ env.PACKAGES_DIR }}" \
             --version="${{ inputs.package_version }}" \
             --linux-amdgpu-families="${{ inputs.linux_amdgpu_families }}" \
-            --windows-amdgpu-families="${{ inputs.windows_amdgpu_families }}"
+            --windows-amdgpu-families="${{ inputs.windows_amdgpu_families }}" \
+            ${{ inputs.export_source_date_epoch && '--export-source-date-epoch' || '' }}
 
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure_aws_artifacts_credentials

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,50 +66,33 @@ block(SCOPE_FOR VARIABLES)
 endblock()
 
 ################################################################################
-# Source timestamp for reproducible archives
+# Source timestamp for reproducible builds
 ################################################################################
-# Resolved once here rather than by each tool that writes an archive: it costs
-# several git invocations, and every writer must agree on the value or the
-# output is not reproducible. See docs/development/reproducible_archives.md.
-option(THEROCK_EXPORT_SOURCE_DATE_EPOCH
-  "Also export SOURCE_DATE_EPOCH to subproject builds. This makes compilers, \
-CPython and setuptools behave reproducibly too, at the cost of a much wider \
-blast radius: __DATE__/__TIME__ are rewritten in every translation unit and \
-.pyc invalidation changes. See docs/development/reproducible_archives.md."
-  OFF)
-
+# Empty by default, and deliberately not derived here. The build writes no
+# archives -- the tools that do run after it and resolve their own timestamp
+# from the source state at that moment. Resolving it at configure would freeze
+# a value that goes stale the moment anything is pulled, and CMake has no other
+# use for it.
+#
+# Setting it is therefore the whole opt-in: a value can only arrive by an
+# explicit -D, and the only thing CMake does with one is export it as
+# SOURCE_DATE_EPOCH to every subproject configure and build. That makes the
+# compilers themselves reproducible, at the cost of rebuilding the tree whenever
+# the value changes, plus a wider blast radius across the components.
+# See docs/development/reproducible_archives.md.
 set(THEROCK_SOURCE_DATE_EPOCH "" CACHE STRING
-  "Unix timestamp stamped into artifact archives (default: derived from the source state)")
+  "Unix timestamp to export as SOURCE_DATE_EPOCH to subproject builds (empty: do not export)")
 
-# Tested against the empty string rather than with if(NOT ...), which is false
-# for the string "0" and would silently discard an explicit -D...=0.
-if("${THEROCK_SOURCE_DATE_EPOCH}" STREQUAL "")
-  execute_process(
-    COMMAND ${Python3_EXECUTABLE}
-      "${CMAKE_CURRENT_SOURCE_DIR}/build_tools/_therock_utils/source_date.py"
-    OUTPUT_VARIABLE _source_date_epoch
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    COMMAND_ERROR_IS_FATAL ANY
-  )
-  set(THEROCK_SOURCE_DATE_EPOCH "${_source_date_epoch}" CACHE STRING "" FORCE)
+# Compared against the empty string rather than with if(NOT ...), which is false
+# for the string "0" and would silently ignore a deliberate -D...=0.
+if(NOT "${THEROCK_SOURCE_DATE_EPOCH}" STREQUAL "")
+  if(NOT THEROCK_SOURCE_DATE_EPOCH MATCHES "^[0-9]+$")
+    message(FATAL_ERROR
+      "THEROCK_SOURCE_DATE_EPOCH must be a non-negative integer number of "
+      "seconds since the Unix epoch, got '${THEROCK_SOURCE_DATE_EPOCH}'")
+  endif()
+  message(STATUS "Exporting SOURCE_DATE_EPOCH=${THEROCK_SOURCE_DATE_EPOCH} to subprojects")
 endif()
-
-# Everything downstream assumes this is a usable timestamp. Failing here beats
-# writing a malformed value into archives, or silently exporting nothing.
-if(NOT THEROCK_SOURCE_DATE_EPOCH MATCHES "^[0-9]+$")
-  message(FATAL_ERROR
-    "THEROCK_SOURCE_DATE_EPOCH must be a non-negative integer number of seconds "
-    "since the Unix epoch, got '${THEROCK_SOURCE_DATE_EPOCH}'")
-endif()
-message(STATUS "Source timestamp: ${THEROCK_SOURCE_DATE_EPOCH}")
-
-# Written so that tools invoked outside the build graph can read it -- notably
-# `artifact_manager.py push --build-dir`, which compresses artifacts long after
-# CMake has finished and cannot see the configure-time environment.
-file(CONFIGURE
-  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/therock_source_date_epoch.txt"
-  CONTENT "${THEROCK_SOURCE_DATE_EPOCH}\n"
-)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/FLAGS.cmake")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,9 @@ blast radius: __DATE__/__TIME__ are rewritten in every translation unit and \
 set(THEROCK_SOURCE_DATE_EPOCH "" CACHE STRING
   "Unix timestamp stamped into artifact archives (default: derived from the source state)")
 
-if(NOT THEROCK_SOURCE_DATE_EPOCH)
+# Tested against the empty string rather than with if(NOT ...), which is false
+# for the string "0" and would silently discard an explicit -D...=0.
+if("${THEROCK_SOURCE_DATE_EPOCH}" STREQUAL "")
   execute_process(
     COMMAND ${Python3_EXECUTABLE}
       "${CMAKE_CURRENT_SOURCE_DIR}/build_tools/_therock_utils/source_date.py"
@@ -90,6 +92,14 @@ if(NOT THEROCK_SOURCE_DATE_EPOCH)
     COMMAND_ERROR_IS_FATAL ANY
   )
   set(THEROCK_SOURCE_DATE_EPOCH "${_source_date_epoch}" CACHE STRING "" FORCE)
+endif()
+
+# Everything downstream assumes this is a usable timestamp. Failing here beats
+# writing a malformed value into archives, or silently exporting nothing.
+if(NOT THEROCK_SOURCE_DATE_EPOCH MATCHES "^[0-9]+$")
+  message(FATAL_ERROR
+    "THEROCK_SOURCE_DATE_EPOCH must be a non-negative integer number of seconds "
+    "since the Unix epoch, got '${THEROCK_SOURCE_DATE_EPOCH}'")
 endif()
 message(STATUS "Source timestamp: ${THEROCK_SOURCE_DATE_EPOCH}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,42 @@ block(SCOPE_FOR VARIABLES)
   message(STATUS "Generated build topology targets from BUILD_TOPOLOGY.toml")
 endblock()
 
+################################################################################
+# Source timestamp for reproducible archives
+################################################################################
+# Resolved once here rather than by each tool that writes an archive: it costs
+# several git invocations, and every writer must agree on the value or the
+# output is not reproducible. See docs/development/reproducible_archives.md.
+option(THEROCK_EXPORT_SOURCE_DATE_EPOCH
+  "Also export SOURCE_DATE_EPOCH to subproject builds. This makes compilers, \
+CPython and setuptools behave reproducibly too, at the cost of a much wider \
+blast radius: __DATE__/__TIME__ are rewritten in every translation unit and \
+.pyc invalidation changes. See docs/development/reproducible_archives.md."
+  OFF)
+
+set(THEROCK_SOURCE_DATE_EPOCH "" CACHE STRING
+  "Unix timestamp stamped into artifact archives (default: derived from the source state)")
+
+if(NOT THEROCK_SOURCE_DATE_EPOCH)
+  execute_process(
+    COMMAND ${Python3_EXECUTABLE}
+      "${CMAKE_CURRENT_SOURCE_DIR}/build_tools/_therock_utils/source_date.py"
+    OUTPUT_VARIABLE _source_date_epoch
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+  set(THEROCK_SOURCE_DATE_EPOCH "${_source_date_epoch}" CACHE STRING "" FORCE)
+endif()
+message(STATUS "Source timestamp: ${THEROCK_SOURCE_DATE_EPOCH}")
+
+# Written so that tools invoked outside the build graph can read it -- notably
+# `artifact_manager.py push --build-dir`, which compresses artifacts long after
+# CMake has finished and cannot see the configure-time environment.
+file(CONFIGURE
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/therock_source_date_epoch.txt"
+  CONTENT "${THEROCK_SOURCE_DATE_EPOCH}\n"
+)
+
 include("${CMAKE_CURRENT_SOURCE_DIR}/FLAGS.cmake")
 
 ################################################################################

--- a/build_tools/_therock_utils/archive_util.py
+++ b/build_tools/_therock_utils/archive_util.py
@@ -7,46 +7,26 @@ from typing import Callable
 import functools
 import os
 from pathlib import Path
-import subprocess
 import tarfile
 import time
 
-THEROCK_DIR = Path(__file__).resolve().parent.parent.parent
+from .source_date import ENV_VAR, STANDARD_ENV_VAR
 
 
-def _git_commit_timestamp() -> int | None:
-    """Commit time of TheRock's HEAD, or None if not a usable git checkout.
-
-    Deliberately the superproject rather than the submodule an artifact's
-    content came from. TheRock pins every submodule, so its HEAD identifies the
-    whole source state, whereas an artifact has no single source submodule to
-    ask: a merged dist tree spans a subproject and its runtime deps, and several
-    subprojects (zlib, zstd, bzip2, elfutils, ...) are tarballs downloaded from
-    S3 with no git history at all.
-
-    The tradeoff is over-invalidation: a docs-only commit here changes every
-    artifact's hash even when the content is byte-identical. That is fine for
-    detecting conflicting uploads within a run, which is what this is for, but
-    it does mean archive hashes cannot be used to dedupe across commits. Set
-    `SOURCE_DATE_EPOCH` to decide that policy somewhere better informed.
-    """
+def _read_timestamp_env(name: str) -> int | None:
+    value = os.environ.get(name)
+    if not value:
+        return None
     try:
-        result = subprocess.run(
-            ["git", "log", "-1", "--format=%ct"],
-            cwd=THEROCK_DIR,
-            capture_output=True,
-            text=True,
-            check=False,
+        timestamp = int(value)
+    except ValueError:
+        raise ValueError(
+            f"{name} must be an integer number of seconds since the Unix "
+            f"epoch, got {value!r}"
         )
-    except OSError:
-        # git is not installed.
-        return None
-    if result.returncode != 0:
-        # Not a git checkout (e.g. building from an exported source archive) or
-        # no commits yet.
-        return None
-    output = result.stdout.strip()
-    return int(output) if output else None
+    if timestamp < 0:
+        raise ValueError(f"{name} must not be negative, got {timestamp}")
+    return timestamp
 
 
 @functools.cache
@@ -61,36 +41,23 @@ def get_archive_timestamp() -> int:
 
     Resolution order:
 
-    1. `SOURCE_DATE_EPOCH`, the reproducible-builds convention. Set this to pin
-       the timestamp explicitly; it is the supported override.
-    2. The commit time of HEAD. Deterministic for a given revision, so parallel
-       CI jobs building the same commit still produce identical archives, and
-       it advances as the source advances.
-    3. The current time, if neither is available. Not reproducible, but a
-       working build beats a deterministically broken one -- set
-       `SOURCE_DATE_EPOCH` where reproducibility is required.
+    1. `SOURCE_DATE_EPOCH`. Nothing in TheRock sets this unless explicitly asked
+       to, so its presence means somebody deliberately pinned the whole build's
+       timestamp, and that intent wins.
+    2. `THEROCK_SOURCE_DATE_EPOCH`, which orchestrators set for their workers
+       from `source_date.compute_source_date_epoch()`. This is the normal path
+       for a TheRock build.
+    3. The current time, for a worker run directly with neither set. Not
+       reproducible, but a working build beats a deterministically broken one.
 
-    Note that a dirty working tree still reports its last commit time. That is
-    fine for CI, which is always clean; set `SOURCE_DATE_EPOCH` locally if a
-    dirty tree's archives need to look newer than something.
+    Deliberately does no git work of its own: resolving the source timestamp
+    costs several git invocations, and this runs once per archive process.
+    `source_date` owns that, and orchestrators call it once.
     """
-    env_value = os.environ.get("SOURCE_DATE_EPOCH")
-    if env_value:
-        try:
-            timestamp = int(env_value)
-        except ValueError:
-            raise ValueError(
-                "SOURCE_DATE_EPOCH must be an integer number of seconds since "
-                f"the Unix epoch, got {env_value!r}"
-            )
-        if timestamp < 0:
-            raise ValueError(f"SOURCE_DATE_EPOCH must not be negative, got {timestamp}")
-        return timestamp
-
-    commit_timestamp = _git_commit_timestamp()
-    if commit_timestamp is not None:
-        return commit_timestamp
-
+    for name in (STANDARD_ENV_VAR, ENV_VAR):
+        timestamp = _read_timestamp_env(name)
+        if timestamp is not None:
+            return timestamp
     return int(time.time())
 
 

--- a/build_tools/_therock_utils/archive_util.py
+++ b/build_tools/_therock_utils/archive_util.py
@@ -3,6 +3,8 @@
 
 """Utilities for reading and writing zstd/xz compressed tar archives."""
 
+from typing import Callable
+import os
 from pathlib import Path
 import tarfile
 
@@ -23,6 +25,36 @@ def normalize_tarinfo(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo:
     tarinfo.uname = "root"
     tarinfo.gname = "root"
     return tarinfo
+
+
+def add_tree(
+    tf: tarfile.TarFile,
+    source_dir: Path,
+    *,
+    relative_to: Path,
+    on_add: Callable[[str], None] | None = None,
+) -> None:
+    """Adds every file and directory under `source_dir` to `tf` reproducibly.
+
+    Member names are computed relative to `relative_to`. Entries are walked and
+    emitted in sorted order and their metadata is normalized, so the same tree
+    always produces the same archive bytes. `on_add`, if given, is called with
+    each member name as it is added.
+    """
+    for root, dirnames, filenames in sorted(
+        os.walk(source_dir), key=lambda entry: entry[0]
+    ):
+        for name in sorted(list(filenames) + list(dirnames)):
+            file_path = os.path.join(root, name)
+            arcname = os.path.relpath(file_path, relative_to)
+            if on_add is not None:
+                on_add(arcname)
+            tf.add(
+                file_path,
+                arcname=arcname,
+                recursive=False,
+                filter=normalize_tarinfo,
+            )
 
 
 def _get_pyzstd():

--- a/build_tools/_therock_utils/archive_util.py
+++ b/build_tools/_therock_utils/archive_util.py
@@ -7,6 +7,24 @@ from pathlib import Path
 import tarfile
 
 
+def normalize_tarinfo(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo:
+    """Normalizes TarInfo metadata so identical content yields identical archives.
+
+    Pass as the `filter` argument to `TarFile.add()`. Timestamps and the uid/gid
+    of the building user otherwise vary from build to build, giving the same
+    content a different archive hash every time.
+
+    Permissions are preserved. Extracting as a non-root user gives files owned by
+    the extracting user; extracting as root with `-p` gives root:root.
+    """
+    tarinfo.mtime = 0
+    tarinfo.uid = 0
+    tarinfo.gid = 0
+    tarinfo.uname = "root"
+    tarinfo.gname = "root"
+    return tarinfo
+
+
 def _get_pyzstd():
     """Lazy import pyzstd with helpful error message."""
     try:

--- a/build_tools/_therock_utils/archive_util.py
+++ b/build_tools/_therock_utils/archive_util.py
@@ -4,22 +4,109 @@
 """Utilities for reading and writing zstd/xz compressed tar archives."""
 
 from typing import Callable
+import functools
 import os
 from pathlib import Path
+import subprocess
 import tarfile
+import time
+
+THEROCK_DIR = Path(__file__).resolve().parent.parent.parent
+
+
+def _git_commit_timestamp() -> int | None:
+    """Commit time of TheRock's HEAD, or None if not a usable git checkout.
+
+    Deliberately the superproject rather than the submodule an artifact's
+    content came from. TheRock pins every submodule, so its HEAD identifies the
+    whole source state, whereas an artifact has no single source submodule to
+    ask: a merged dist tree spans a subproject and its runtime deps, and several
+    subprojects (zlib, zstd, bzip2, elfutils, ...) are tarballs downloaded from
+    S3 with no git history at all.
+
+    The tradeoff is over-invalidation: a docs-only commit here changes every
+    artifact's hash even when the content is byte-identical. That is fine for
+    detecting conflicting uploads within a run, which is what this is for, but
+    it does mean archive hashes cannot be used to dedupe across commits. Set
+    `SOURCE_DATE_EPOCH` to decide that policy somewhere better informed.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%ct"],
+            cwd=THEROCK_DIR,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        # git is not installed.
+        return None
+    if result.returncode != 0:
+        # Not a git checkout (e.g. building from an exported source archive) or
+        # no commits yet.
+        return None
+    output = result.stdout.strip()
+    return int(output) if output else None
+
+
+@functools.cache
+def get_archive_timestamp() -> int:
+    """Resolves the mtime to stamp into reproducible archives.
+
+    Deliberately not 0: extraction restores mtime (`tarfile.extract()` and
+    `tar -x` both do, for root and non-root alike), so an epoch mtime makes
+    freshly installed SDK headers and libraries look older than the objects a
+    downstream project already built against the previous version. Timestamp
+    driven build systems then skip work that needed doing.
+
+    Resolution order:
+
+    1. `SOURCE_DATE_EPOCH`, the reproducible-builds convention. Set this to pin
+       the timestamp explicitly; it is the supported override.
+    2. The commit time of HEAD. Deterministic for a given revision, so parallel
+       CI jobs building the same commit still produce identical archives, and
+       it advances as the source advances.
+    3. The current time, if neither is available. Not reproducible, but a
+       working build beats a deterministically broken one -- set
+       `SOURCE_DATE_EPOCH` where reproducibility is required.
+
+    Note that a dirty working tree still reports its last commit time. That is
+    fine for CI, which is always clean; set `SOURCE_DATE_EPOCH` locally if a
+    dirty tree's archives need to look newer than something.
+    """
+    env_value = os.environ.get("SOURCE_DATE_EPOCH")
+    if env_value:
+        try:
+            timestamp = int(env_value)
+        except ValueError:
+            raise ValueError(
+                "SOURCE_DATE_EPOCH must be an integer number of seconds since "
+                f"the Unix epoch, got {env_value!r}"
+            )
+        if timestamp < 0:
+            raise ValueError(f"SOURCE_DATE_EPOCH must not be negative, got {timestamp}")
+        return timestamp
+
+    commit_timestamp = _git_commit_timestamp()
+    if commit_timestamp is not None:
+        return commit_timestamp
+
+    return int(time.time())
 
 
 def normalize_tarinfo(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo:
     """Normalizes TarInfo metadata so identical content yields identical archives.
 
-    Pass as the `filter` argument to `TarFile.add()`. Timestamps and the uid/gid
-    of the building user otherwise vary from build to build, giving the same
-    content a different archive hash every time.
+    Pass as the `filter` argument to `TarFile.add()`. The wall-clock build time
+    and the uid/gid of the building user otherwise vary from build to build,
+    giving the same content a different archive hash every time.
 
-    Permissions are preserved. Extracting as a non-root user gives files owned by
+    Timestamps are replaced with `get_archive_timestamp()` rather than dropped,
+    for the reasons given there. Permissions, sizes, symlink targets and hardlink
+    identity are preserved. Extracting as a non-root user gives files owned by
     the extracting user; extracting as root with `-p` gives root:root.
     """
-    tarinfo.mtime = 0
+    tarinfo.mtime = get_archive_timestamp()
     tarinfo.uid = 0
     tarinfo.gid = 0
     tarinfo.uname = "root"

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -19,6 +19,7 @@ import shutil
 import sys
 import tarfile
 
+from .archive_util import add_tree
 from .artifacts import ArtifactCatalog, ArtifactName
 from .exe_stub_gen import generate_exe_link_stub
 
@@ -651,12 +652,12 @@ class PopulatedDistPackage:
         tar_path = self.pure_dir / f"_devel{tar_suffix}"
         log(f"::: Building secondary devel tarball: {tar_path}")
         with tarfile.open(tar_path, mode=tar_mode) as tf:
-            for root, dirnames, files in os.walk(package_path):
-                for file in list(files) + list(dirnames):
-                    file_path = os.path.join(root, file)
-                    arcname = os.path.relpath(file_path, package_path.parent)
-                    log(f"Adding {arcname}", vlog=2)
-                    tf.add(file_path, arcname=arcname, recursive=False)
+            add_tree(
+                tf,
+                package_path,
+                relative_to=package_path.parent,
+                on_add=lambda arcname: log(f"Adding {arcname}", vlog=2),
+            )
         shutil.rmtree(package_path)
 
     def _find_populated(

--- a/build_tools/_therock_utils/source_date.py
+++ b/build_tools/_therock_utils/source_date.py
@@ -1,0 +1,275 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Resolves the source timestamp stamped into reproducible archives.
+
+Archives need a timestamp that is identical across two builds of the same
+source, so that the same content produces the same archive hash (see
+https://github.com/ROCm/TheRock/issues/4202), but that is not so old it makes
+freshly installed SDK files look older than a downstream project's existing
+build outputs. Extraction restores mtime, so an epoch timestamp would do exactly
+that and suppress rebuilds.
+
+This is the expensive half of that: it shells out to git several times, so
+orchestrators call it once and pass the result down to the workers that write
+archives, rather than every worker recomputing it. See `archive_util` for the
+consuming side.
+"""
+
+from typing import NamedTuple
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+THEROCK_DIR = Path(__file__).resolve().parent.parent.parent
+
+# The variable orchestrators use to hand the resolved value to workers.
+# Deliberately not SOURCE_DATE_EPOCH: see EXPORT_WARNING below.
+ENV_VAR = "THEROCK_SOURCE_DATE_EPOCH"
+
+# The reproducible-builds standard name. Read as a deliberate user override, and
+# only ever *set* behind an explicit opt-in.
+STANDARD_ENV_VAR = "SOURCE_DATE_EPOCH"
+
+EXPORT_WARNING = f"""\
+Exporting {STANDARD_ENV_VAR} affects far more than TheRock's archives. It is a
+cross-ecosystem convention that many tools honor automatically:
+
+  * GCC and Clang rewrite __DATE__ and __TIME__ in every translation unit.
+  * CPython switches .pyc files from timestamp invalidation to checked-hash
+    invalidation, changing the bytes that ship inside wheels.
+  * setuptools/wheel use it for zip entry timestamps.
+  * dpkg-deb clamps tar entry mtimes to it (it never raises older ones).
+
+Those are usually desirable for a reproducible build, but they are a much wider
+blast radius than stamping archive metadata, so TheRock does not set it for you.
+Use {ENV_VAR} for archives alone, or opt in explicitly when you want the
+ecosystem-wide behavior too."""
+
+
+class SubmoduleEntry(NamedTuple):
+    """One line of `git submodule status`."""
+
+    # ' ' matches the pin, '+' checked out at a different commit, '-' not
+    # initialized, 'U' has merge conflicts.
+    state: str
+    sha: str
+    path: Path
+
+    @property
+    def is_populated(self) -> bool:
+        return self.state != "-"
+
+    @property
+    def differs_from_pin(self) -> bool:
+        return self.state in ("+", "U")
+
+
+def _git(*args: str, cwd: Path) -> str | None:
+    """Runs git, returning raw stdout or None if it could not be run.
+
+    Deliberately unstripped: `git submodule status` encodes state in the first
+    character of each line, and a leading space is the "matches the pin" state.
+    """
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        # git is not installed.
+        return None
+    if result.returncode != 0:
+        # Not a git checkout (e.g. building from an exported source archive).
+        return None
+    return result.stdout
+
+
+def _head_timestamp(repo_dir: Path) -> int | None:
+    output = _git("log", "-1", "--format=%ct", cwd=repo_dir)
+    output = output.strip() if output else ""
+    return int(output) if output else None
+
+
+def submodule_entries(repo_dir: Path = THEROCK_DIR) -> list[SubmoduleEntry]:
+    """Parses `git submodule status`.
+
+    One git call yields the state, hash and path of every submodule. Note that
+    this compares commits only -- a submodule whose working tree is dirty but
+    whose commit still matches the pin reports ' ', not '+'.
+    """
+    output = _git("submodule", "status", cwd=repo_dir)
+    if output is None:
+        return []
+    entries = []
+    for line in output.splitlines():
+        if not line:
+            continue
+        # "<state><40-char sha> <path>[ (<describe>)]". The describe suffix is
+        # absent for submodules that are not initialized.
+        state, sha, rest = line[0], line[1:41], line[42:]
+        path = rest.rsplit(" (", 1)[0] if rest.endswith(")") else rest
+        entries.append(SubmoduleEntry(state, sha, repo_dir / path))
+    return entries
+
+
+def is_worktree_dirty(
+    repo_dir: Path = THEROCK_DIR,
+    entries: list[SubmoduleEntry] | None = None,
+) -> bool:
+    """Whether anything is uncommitted, in the superproject or any submodule.
+
+    Only genuinely uncommitted content counts. A plain `git status --porcelain`
+    is not usable here: it reports ` M <path>` for a submodule that merely sits
+    at a different commit than its pin, which is committed work already handled
+    by folding that submodule's commit time in. Treating it as dirty would jump
+    straight to the current time and mask that logic entirely.
+
+    So the superproject is asked with `--ignore-submodules=all`, and each
+    populated submodule is asked about its own working tree separately.
+    """
+    superproject = _git(
+        "status", "--porcelain", "--ignore-submodules=all", cwd=repo_dir
+    )
+    if superproject and superproject.strip():
+        return True
+
+    if entries is None:
+        entries = submodule_entries(repo_dir)
+    for entry in entries:
+        if not entry.is_populated:
+            continue
+        output = _git("status", "--porcelain", cwd=entry.path)
+        if output and output.strip():
+            return True
+    return False
+
+
+def compute_source_date_epoch(repo_dir: Path = THEROCK_DIR) -> int:
+    """Resolves the timestamp to stamp into archives built from `repo_dir`.
+
+    Starts from the superproject's HEAD, which pins every submodule and so
+    identifies the whole source state. A submodule commit must exist before the
+    superproject can pin it, so on a clean tree the superproject's commit is
+    already the newest and the rest of this is a no-op.
+
+    Two cases make that understate reality, both normal in TheRock's development
+    flow where subproject sources are edited in place:
+
+    * A submodule checked out past its pin (state '+') carries commits the
+      superproject's date does not reflect, so its HEAD time is folded in.
+    * Uncommitted changes anywhere have no commit time at all, so the current
+      time is folded in. Archives from a dirty tree are not reproducible, which
+      is inherent rather than a limitation of this approach.
+    """
+    timestamps = []
+
+    head = _head_timestamp(repo_dir)
+    if head is not None:
+        timestamps.append(head)
+
+    entries = submodule_entries(repo_dir)
+    for entry in entries:
+        if not entry.is_populated or not entry.differs_from_pin:
+            continue
+        submodule_head = _head_timestamp(entry.path)
+        if submodule_head is not None:
+            timestamps.append(submodule_head)
+
+    if is_worktree_dirty(repo_dir, entries):
+        timestamps.append(int(time.time()))
+
+    if not timestamps:
+        # No git at all. Not reproducible, but a working build beats a
+        # deterministically broken one.
+        return int(time.time())
+    return max(timestamps)
+
+
+def child_env(
+    *,
+    export_standard_var: bool = False,
+    repo_dir: Path = THEROCK_DIR,
+    base_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Environment for workers that write archives.
+
+    Sets `THEROCK_SOURCE_DATE_EPOCH`. Also sets `SOURCE_DATE_EPOCH` when
+    `export_standard_var` is true -- see EXPORT_WARNING for what else that
+    changes.
+    """
+    env = dict(os.environ if base_env is None else base_env)
+    timestamp = str(compute_source_date_epoch(repo_dir))
+    env[ENV_VAR] = timestamp
+    if export_standard_var:
+        env[STANDARD_ENV_VAR] = timestamp
+    return env
+
+
+def apply_to_environ(
+    *,
+    export_standard_var: bool = False,
+    repo_dir: Path = THEROCK_DIR,
+) -> int:
+    """Publishes the resolved timestamp into this process's environment.
+
+    For orchestrators that write archives in-process rather than by spawning
+    workers. Returns the resolved value. Does not overwrite an existing
+    `SOURCE_DATE_EPOCH`, which outranks everything (see `archive_util`).
+    """
+    timestamp = compute_source_date_epoch(repo_dir)
+    os.environ[ENV_VAR] = str(timestamp)
+    if export_standard_var and STANDARD_ENV_VAR not in os.environ:
+        os.environ[STANDARD_ENV_VAR] = str(timestamp)
+    return timestamp
+
+
+def add_source_date_arguments(parser: argparse.ArgumentParser) -> None:
+    """Adds the shared opt-in flag to an orchestrator's argument parser."""
+    parser.add_argument(
+        "--export-source-date-epoch",
+        action="store_true",
+        help=(
+            f"Also export {STANDARD_ENV_VAR} to child processes, not just "
+            f"{ENV_VAR}. This makes compilers, CPython and setuptools behave "
+            "reproducibly too, at the cost of a much wider blast radius. See "
+            "docs/development/reproducible_archives.md."
+        ),
+    )
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(
+        description="Print the resolved source timestamp for reproducible archives."
+    )
+    p.add_argument(
+        "--explain",
+        action="store_true",
+        help="Also report how the value was derived.",
+    )
+    args = p.parse_args(argv)
+
+    timestamp = compute_source_date_epoch()
+    print(timestamp)
+    if args.explain:
+        head = _head_timestamp(THEROCK_DIR)
+        print(f"  superproject HEAD: {head}", file=sys.stderr)
+        for entry in submodule_entries():
+            if entry.is_populated and entry.differs_from_pin:
+                print(
+                    f"  submodule past pin: {entry.path.name} "
+                    f"({_head_timestamp(entry.path)})",
+                    file=sys.stderr,
+                )
+        print(f"  worktree dirty: {is_worktree_dirty()}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/build_tools/_therock_utils/source_date.py
+++ b/build_tools/_therock_utils/source_date.py
@@ -34,9 +34,6 @@ ENV_VAR = "THEROCK_SOURCE_DATE_EPOCH"
 # only ever *set* behind an explicit opt-in.
 STANDARD_ENV_VAR = "SOURCE_DATE_EPOCH"
 
-# Written into the build directory by the root CMakeLists.txt at configure time.
-STAMP_FILE_NAME = "therock_source_date_epoch.txt"
-
 EXPORT_WARNING = f"""\
 Exporting {STANDARD_ENV_VAR} affects far more than TheRock's archives. It is a
 cross-ecosystem convention that many tools honor automatically:
@@ -212,41 +209,6 @@ def newest_dirty_mtime(
     return newest
 
 
-def read_build_dir(build_dir: Path) -> int | None:
-    """Reads the value CMake resolved at configure time, if it is there.
-
-    CMake writes `therock_source_date_epoch.txt` into the build directory
-    precisely so that tools running outside the build graph -- `artifact_manager
-    push` compresses artifacts long after CMake has finished -- can agree with
-    the build instead of resolving it again and possibly differently.
-    """
-    stamp_file = build_dir / STAMP_FILE_NAME
-    try:
-        content = stamp_file.read_text().strip()
-    except OSError:
-        return None
-    try:
-        return int(content)
-    except ValueError:
-        raise ValueError(f"{stamp_file} does not contain a timestamp: {content!r}")
-
-
-def resolve(
-    *,
-    build_dir: Path | None = None,
-    repo_dir: Path = THEROCK_DIR,
-) -> int:
-    """The timestamp to use, preferring what the build already decided.
-
-    Falls back to computing it for tools run outside a configured build tree.
-    """
-    if build_dir is not None:
-        from_build = read_build_dir(build_dir)
-        if from_build is not None:
-            return from_build
-    return compute_source_date_epoch(repo_dir)
-
-
 def compute_source_date_epoch(repo_dir: Path = THEROCK_DIR) -> int:
     """Resolves the timestamp to stamp into archives built from `repo_dir`.
 
@@ -295,7 +257,6 @@ def compute_source_date_epoch(repo_dir: Path = THEROCK_DIR) -> int:
 def child_env(
     *,
     export_standard_var: bool = False,
-    build_dir: Path | None = None,
     repo_dir: Path = THEROCK_DIR,
     base_env: dict[str, str] | None = None,
 ) -> dict[str, str]:
@@ -306,7 +267,7 @@ def child_env(
     changes.
     """
     env = dict(os.environ if base_env is None else base_env)
-    timestamp = str(resolve(build_dir=build_dir, repo_dir=repo_dir))
+    timestamp = str(compute_source_date_epoch(repo_dir))
     env[ENV_VAR] = timestamp
     if export_standard_var:
         env[STANDARD_ENV_VAR] = timestamp
@@ -316,7 +277,6 @@ def child_env(
 def apply_to_environ(
     *,
     export_standard_var: bool = False,
-    build_dir: Path | None = None,
     repo_dir: Path = THEROCK_DIR,
 ) -> int:
     """Publishes the resolved timestamp into this process's environment.
@@ -325,7 +285,7 @@ def apply_to_environ(
     workers. Returns the resolved value. Does not overwrite an existing
     `SOURCE_DATE_EPOCH`, which outranks everything (see `archive_util`).
     """
-    timestamp = resolve(build_dir=build_dir, repo_dir=repo_dir)
+    timestamp = compute_source_date_epoch(repo_dir)
     os.environ[ENV_VAR] = str(timestamp)
     if export_standard_var and STANDARD_ENV_VAR not in os.environ:
         os.environ[STANDARD_ENV_VAR] = str(timestamp)

--- a/build_tools/_therock_utils/source_date.py
+++ b/build_tools/_therock_utils/source_date.py
@@ -18,6 +18,7 @@ consuming side.
 
 from typing import NamedTuple
 import argparse
+import json
 import os
 from pathlib import Path
 import subprocess
@@ -209,6 +210,151 @@ def newest_dirty_mtime(
     return newest
 
 
+# Where therock_manifest.json sits, relative to a directory of artifacts. The
+# build installs it to share/therock; the first form is the exploded artifact
+# layout, the second is what `artifact_manager fetch --flatten` produces.
+MANIFEST_RELPATHS = (
+    Path("base_lib_generic/base/aux-overlay/stage/share/therock/therock_manifest.json"),
+    Path("share/therock/therock_manifest.json"),
+)
+
+
+def find_manifest(search_dir: Path) -> Path | None:
+    """Locates therock_manifest.json under a directory of artifacts."""
+    for relpath in MANIFEST_RELPATHS:
+        candidate = search_dir / relpath
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def timestamp_from_manifest(search_dir: Path) -> int | None:
+    """The source timestamp recorded when the artifacts were built.
+
+    This is the only value that survives the jump between jobs. Packaging runs
+    on a different runner from the build, and may be pointed at artifacts from
+    an entirely different run, so re-deriving from the local checkout would
+    describe the packaging checkout rather than the source that was built.
+
+    Returns None when there is no manifest, or when it predates this field, or
+    when it was produced from a tree with no git metadata -- all cases where the
+    caller should fall back to deriving one.
+    """
+    manifest_path = find_manifest(search_dir)
+    if manifest_path is None:
+        return None
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    timestamp = manifest.get("source_date_epoch")
+    return timestamp if isinstance(timestamp, int) else None
+
+
+def _read_manifest(search_dir: Path) -> dict | None:
+    manifest_path = find_manifest(search_dir)
+    if manifest_path is None:
+        return None
+    try:
+        return json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def describe_source_drift(
+    manifest_dir: Path,
+    repo_dir: Path = THEROCK_DIR,
+) -> list[str]:
+    """Ways the artifacts being packaged disagree with this checkout.
+
+    Packaging normally runs against artifacts from its own run, where these
+    agree. They diverge when a job is pointed at another run's artifacts, or
+    when the build came from a dirty tree -- in both cases the archives are
+    stamped with something the local checkout cannot account for. Worth saying
+    out loud rather than resolving silently.
+
+    Returns human-readable reasons; empty means no disagreement was detectable.
+    """
+    manifest = _read_manifest(manifest_dir)
+    if manifest is None:
+        return [
+            f"no therock_manifest.json under {manifest_dir}, so the source "
+            "timestamp is derived from this checkout rather than from the "
+            "artifacts being packaged"
+        ]
+
+    reasons = []
+
+    if manifest.get("source_date_epoch") is None:
+        reasons.append(
+            "the manifest records no source_date_epoch (built without git "
+            "metadata, or predates the field); deriving from this checkout"
+        )
+    if manifest.get("source_dirty"):
+        reasons.append(
+            "the artifacts were built from a tree with uncommitted changes, so "
+            "they are not reproducible from their recorded commit"
+        )
+
+    manifest_commit = manifest.get("the_rock_commit")
+    local_commit = _git("rev-parse", "HEAD", cwd=repo_dir)
+    local_commit = local_commit.strip() if local_commit else None
+    if manifest_commit and local_commit and manifest_commit != local_commit:
+        reasons.append(
+            f"the artifacts were built from {manifest_commit[:12]} but this "
+            f"checkout is at {local_commit[:12]}"
+        )
+    if local_commit and is_worktree_dirty(repo_dir):
+        reasons.append(
+            "this checkout has uncommitted changes, which the artifacts cannot "
+            "contain"
+        )
+
+    return reasons
+
+
+def resolve(
+    *,
+    manifest_dir: Path | None = None,
+    repo_dir: Path = THEROCK_DIR,
+) -> int:
+    """The timestamp to stamp into archives, preferring the built artifacts'.
+
+    Falls back to deriving one from `repo_dir` when the artifacts carry none.
+    """
+    if manifest_dir is not None:
+        from_manifest = timestamp_from_manifest(manifest_dir)
+        if from_manifest is not None:
+            return from_manifest
+    return compute_source_date_epoch(repo_dir)
+
+
+def resolve_checked(
+    *,
+    manifest_dir: Path | None = None,
+    repo_dir: Path = THEROCK_DIR,
+    fail_on_drift: bool = False,
+    report=print,
+) -> int:
+    """`resolve()`, reporting any disagreement with the local checkout.
+
+    Warns by default, because packaging another run's artifacts is a supported
+    workflow. `fail_on_drift` turns it into an error for release builds, where
+    it usually means the wrong artifacts are being packaged.
+    """
+    if manifest_dir is not None:
+        reasons = describe_source_drift(manifest_dir, repo_dir)
+        if reasons:
+            if fail_on_drift:
+                raise RuntimeError(
+                    "Source state drift between the artifacts and this "
+                    "checkout:\n  - " + "\n  - ".join(reasons)
+                )
+            for reason in reasons:
+                report(f"  Warning: {reason}")
+    return resolve(manifest_dir=manifest_dir, repo_dir=repo_dir)
+
+
 def compute_source_date_epoch(repo_dir: Path = THEROCK_DIR) -> int:
     """Resolves the timestamp to stamp into archives built from `repo_dir`.
 
@@ -257,6 +403,8 @@ def compute_source_date_epoch(repo_dir: Path = THEROCK_DIR) -> int:
 def child_env(
     *,
     export_standard_var: bool = False,
+    manifest_dir: Path | None = None,
+    fail_on_drift: bool = False,
     repo_dir: Path = THEROCK_DIR,
     base_env: dict[str, str] | None = None,
 ) -> dict[str, str]:
@@ -267,7 +415,13 @@ def child_env(
     changes.
     """
     env = dict(os.environ if base_env is None else base_env)
-    timestamp = str(compute_source_date_epoch(repo_dir))
+    timestamp = str(
+        resolve_checked(
+            manifest_dir=manifest_dir,
+            repo_dir=repo_dir,
+            fail_on_drift=fail_on_drift,
+        )
+    )
     env[ENV_VAR] = timestamp
     if export_standard_var:
         env[STANDARD_ENV_VAR] = timestamp
@@ -277,6 +431,8 @@ def child_env(
 def apply_to_environ(
     *,
     export_standard_var: bool = False,
+    manifest_dir: Path | None = None,
+    fail_on_drift: bool = False,
     repo_dir: Path = THEROCK_DIR,
 ) -> int:
     """Publishes the resolved timestamp into this process's environment.
@@ -285,7 +441,11 @@ def apply_to_environ(
     workers. Returns the resolved value. Does not overwrite an existing
     `SOURCE_DATE_EPOCH`, which outranks everything (see `archive_util`).
     """
-    timestamp = compute_source_date_epoch(repo_dir)
+    timestamp = resolve_checked(
+        manifest_dir=manifest_dir,
+        repo_dir=repo_dir,
+        fail_on_drift=fail_on_drift,
+    )
     os.environ[ENV_VAR] = str(timestamp)
     if export_standard_var and STANDARD_ENV_VAR not in os.environ:
         os.environ[STANDARD_ENV_VAR] = str(timestamp)
@@ -302,6 +462,15 @@ def add_source_date_arguments(parser: argparse.ArgumentParser) -> None:
             f"{ENV_VAR}. This makes compilers, CPython and setuptools behave "
             "reproducibly too, at the cost of a much wider blast radius. See "
             "docs/development/reproducible_archives.md."
+        ),
+    )
+    parser.add_argument(
+        "--fail-on-source-drift",
+        action="store_true",
+        help=(
+            "Error instead of warning when the artifacts being packaged were "
+            "built from a different commit, or from a dirty tree, than this "
+            "checkout. Recommended for release builds."
         ),
     )
 

--- a/build_tools/_therock_utils/source_date.py
+++ b/build_tools/_therock_utils/source_date.py
@@ -122,36 +122,94 @@ def submodule_entries(repo_dir: Path = THEROCK_DIR) -> list[SubmoduleEntry]:
     return entries
 
 
-def is_worktree_dirty(
+def _parse_porcelain_z(output: str, repo_dir: Path) -> list[Path]:
+    """Paths from `git status --porcelain -z`.
+
+    NUL-separated rather than line-based because paths may contain spaces or
+    newlines, which the line format quotes and escapes. Each record is two
+    status characters, a space, then the path; rename and copy records are
+    followed by a second record holding the original path, which is skipped.
+    """
+    paths = []
+    records = output.split("\0")
+    index = 0
+    while index < len(records):
+        record = records[index]
+        index += 1
+        if len(record) < 4:
+            continue
+        status, path = record[:2], record[3:]
+        if "R" in status or "C" in status:
+            index += 1  # the paired original path
+        if path:
+            paths.append(repo_dir / path)
+    return paths
+
+
+def dirty_paths(
     repo_dir: Path = THEROCK_DIR,
     entries: list[SubmoduleEntry] | None = None,
-) -> bool:
-    """Whether anything is uncommitted, in the superproject or any submodule.
+) -> list[Path]:
+    """Every uncommitted path, in the superproject and in each submodule.
 
     Only genuinely uncommitted content counts. A plain `git status --porcelain`
-    is not usable here: it reports ` M <path>` for a submodule that merely sits
-    at a different commit than its pin, which is committed work already handled
-    by folding that submodule's commit time in. Treating it as dirty would jump
-    straight to the current time and mask that logic entirely.
+    on the superproject is not usable here: it reports ` M <path>` for a
+    submodule that merely sits at a different commit than its pin, which is
+    committed work already accounted for by folding that submodule's commit time
+    in. Counting it here would mask that logic.
 
     So the superproject is asked with `--ignore-submodules=all`, and each
     populated submodule is asked about its own working tree separately.
     """
-    superproject = _git(
-        "status", "--porcelain", "--ignore-submodules=all", cwd=repo_dir
+    output = _git(
+        "status", "--porcelain", "-z", "--ignore-submodules=all", cwd=repo_dir
     )
-    if superproject and superproject.strip():
-        return True
+    paths = _parse_porcelain_z(output, repo_dir) if output else []
 
     if entries is None:
         entries = submodule_entries(repo_dir)
     for entry in entries:
         if not entry.is_populated:
             continue
-        output = _git("status", "--porcelain", cwd=entry.path)
-        if output and output.strip():
-            return True
-    return False
+        submodule_output = _git("status", "--porcelain", "-z", cwd=entry.path)
+        if submodule_output:
+            paths.extend(_parse_porcelain_z(submodule_output, entry.path))
+    return paths
+
+
+def is_worktree_dirty(
+    repo_dir: Path = THEROCK_DIR,
+    entries: list[SubmoduleEntry] | None = None,
+) -> bool:
+    """Whether anything is uncommitted, in the superproject or any submodule."""
+    return bool(dirty_paths(repo_dir, entries))
+
+
+def newest_dirty_mtime(
+    repo_dir: Path = THEROCK_DIR,
+    entries: list[SubmoduleEntry] | None = None,
+) -> int | None:
+    """Modification time of the most recently touched uncommitted file.
+
+    Deliberately not the current time. The value ends up in archives and, when
+    exported, in build inputs, so it must not move every time it is asked --
+    otherwise an untouched dirty tree would produce a different answer on every
+    configure and invalidate everything downstream.
+
+    An untracked *directory* is reported by git as a single entry, and only its
+    own mtime is read: that moves when entries are added or removed, but not
+    when a file inside it is edited. Walking it could mean walking something
+    very large, so this accepts the imprecision.
+    """
+    newest = None
+    for path in dirty_paths(repo_dir, entries):
+        try:
+            mtime = int(path.stat().st_mtime)
+        except OSError:
+            # Deleted, or otherwise not stat-able. It has no mtime to offer.
+            continue
+        newest = mtime if newest is None else max(newest, mtime)
+    return newest
 
 
 def read_build_dir(build_dir: Path) -> int | None:
@@ -202,9 +260,12 @@ def compute_source_date_epoch(repo_dir: Path = THEROCK_DIR) -> int:
 
     * A submodule checked out past its pin (state '+') carries commits the
       superproject's date does not reflect, so its HEAD time is folded in.
-    * Uncommitted changes anywhere have no commit time at all, so the current
-      time is folded in. Archives from a dirty tree are not reproducible, which
-      is inherent rather than a limitation of this approach.
+    * Uncommitted changes have no commit time at all, so the mtime of the most
+      recently touched one is folded in -- not the current time, so that asking
+      twice without touching anything gives the same answer.
+
+    Everything is combined with max(), so a file touched to an old date cannot
+    drag the result back before the commit it sits on.
     """
     timestamps = []
 
@@ -220,8 +281,9 @@ def compute_source_date_epoch(repo_dir: Path = THEROCK_DIR) -> int:
         if submodule_head is not None:
             timestamps.append(submodule_head)
 
-    if is_worktree_dirty(repo_dir, entries):
-        timestamps.append(int(time.time()))
+    dirty = newest_dirty_mtime(repo_dir, entries)
+    if dirty is not None:
+        timestamps.append(dirty)
 
     if not timestamps:
         # No git at all. Not reproducible, but a working build beats a

--- a/build_tools/_therock_utils/source_date.py
+++ b/build_tools/_therock_utils/source_date.py
@@ -34,6 +34,9 @@ ENV_VAR = "THEROCK_SOURCE_DATE_EPOCH"
 # only ever *set* behind an explicit opt-in.
 STANDARD_ENV_VAR = "SOURCE_DATE_EPOCH"
 
+# Written into the build directory by the root CMakeLists.txt at configure time.
+STAMP_FILE_NAME = "therock_source_date_epoch.txt"
+
 EXPORT_WARNING = f"""\
 Exporting {STANDARD_ENV_VAR} affects far more than TheRock's archives. It is a
 cross-ecosystem convention that many tools honor automatically:
@@ -151,6 +154,41 @@ def is_worktree_dirty(
     return False
 
 
+def read_build_dir(build_dir: Path) -> int | None:
+    """Reads the value CMake resolved at configure time, if it is there.
+
+    CMake writes `therock_source_date_epoch.txt` into the build directory
+    precisely so that tools running outside the build graph -- `artifact_manager
+    push` compresses artifacts long after CMake has finished -- can agree with
+    the build instead of resolving it again and possibly differently.
+    """
+    stamp_file = build_dir / STAMP_FILE_NAME
+    try:
+        content = stamp_file.read_text().strip()
+    except OSError:
+        return None
+    try:
+        return int(content)
+    except ValueError:
+        raise ValueError(f"{stamp_file} does not contain a timestamp: {content!r}")
+
+
+def resolve(
+    *,
+    build_dir: Path | None = None,
+    repo_dir: Path = THEROCK_DIR,
+) -> int:
+    """The timestamp to use, preferring what the build already decided.
+
+    Falls back to computing it for tools run outside a configured build tree.
+    """
+    if build_dir is not None:
+        from_build = read_build_dir(build_dir)
+        if from_build is not None:
+            return from_build
+    return compute_source_date_epoch(repo_dir)
+
+
 def compute_source_date_epoch(repo_dir: Path = THEROCK_DIR) -> int:
     """Resolves the timestamp to stamp into archives built from `repo_dir`.
 
@@ -195,6 +233,7 @@ def compute_source_date_epoch(repo_dir: Path = THEROCK_DIR) -> int:
 def child_env(
     *,
     export_standard_var: bool = False,
+    build_dir: Path | None = None,
     repo_dir: Path = THEROCK_DIR,
     base_env: dict[str, str] | None = None,
 ) -> dict[str, str]:
@@ -205,7 +244,7 @@ def child_env(
     changes.
     """
     env = dict(os.environ if base_env is None else base_env)
-    timestamp = str(compute_source_date_epoch(repo_dir))
+    timestamp = str(resolve(build_dir=build_dir, repo_dir=repo_dir))
     env[ENV_VAR] = timestamp
     if export_standard_var:
         env[STANDARD_ENV_VAR] = timestamp
@@ -215,6 +254,7 @@ def child_env(
 def apply_to_environ(
     *,
     export_standard_var: bool = False,
+    build_dir: Path | None = None,
     repo_dir: Path = THEROCK_DIR,
 ) -> int:
     """Publishes the resolved timestamp into this process's environment.
@@ -223,7 +263,7 @@ def apply_to_environ(
     workers. Returns the resolved value. Does not overwrite an existing
     `SOURCE_DATE_EPOCH`, which outranks everything (see `archive_util`).
     """
-    timestamp = compute_source_date_epoch(repo_dir)
+    timestamp = resolve(build_dir=build_dir, repo_dir=repo_dir)
     os.environ[ENV_VAR] = str(timestamp)
     if export_standard_var and STANDARD_ENV_VAR not in os.environ:
         os.environ[STANDARD_ENV_VAR] = str(timestamp)

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -855,8 +855,7 @@ def do_push(args: argparse.Namespace):
     # Resolved once here rather than per archive: it costs several git calls,
     # and every worker must agree on it or the archives are not reproducible.
     archive_env = source_date.child_env(
-        export_standard_var=args.export_source_date_epoch,
-        build_dir=build_dir,
+        export_standard_var=args.export_source_date_epoch
     )
     log(f"  Source timestamp: {archive_env[source_date.ENV_VAR]}")
 

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -855,7 +855,8 @@ def do_push(args: argparse.Namespace):
     # Resolved once here rather than per archive: it costs several git calls,
     # and every worker must agree on it or the archives are not reproducible.
     archive_env = source_date.child_env(
-        export_standard_var=args.export_source_date_epoch
+        export_standard_var=args.export_source_date_epoch,
+        build_dir=build_dir,
     )
     log(f"  Source timestamp: {archive_env[source_date.ENV_VAR]}")
 

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -55,6 +55,7 @@ from pathlib import Path
 from typing import List, Optional, Set
 
 from _therock_utils.archive_util import open_archive_for_read
+from _therock_utils import source_date
 from _therock_utils.os_util import rmtree_with_retry
 from _therock_utils.cmake_amdgpu_targets import (
     amdgpu_family_map,
@@ -637,6 +638,9 @@ class CompressRequest:
     compression_level: Optional[int] = (
         None  # None = use algorithm default (3 for zstd, 6 for xz)
     )
+    # Environment for the fileset_tool worker, carrying the source timestamp.
+    # Resolved once by the caller: see _archive_child_env().
+    child_env: Optional[dict] = None
 
 
 @dataclass
@@ -714,7 +718,9 @@ def compress_artifact(request: CompressRequest) -> Optional[Path]:
             ]
         )
 
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, env=request.child_env
+        )
         if result.returncode != 0:
             raise RuntimeError(
                 f"fileset_tool.py artifact-archive failed (returncode={result.returncode}): {result.stderr}"
@@ -846,6 +852,13 @@ def do_push(args: argparse.Namespace):
     compress_requests = []
     direct_upload_requests = []
 
+    # Resolved once here rather than per archive: it costs several git calls,
+    # and every worker must agree on it or the archives are not reproducible.
+    archive_env = source_date.child_env(
+        export_standard_var=args.export_source_date_epoch
+    )
+    log(f"  Source timestamp: {archive_env[source_date.ENV_VAR]}")
+
     for item in artifacts_dir.iterdir():
         if item.is_dir():
             # Exploded artifact directory - needs compression
@@ -863,6 +876,7 @@ def do_push(args: argparse.Namespace):
                     archive_path=upload_dir / archive_name,
                     compression_type=args.compression_type,
                     compression_level=args.compression_level,
+                    child_env=archive_env,
                 )
             )
         elif (item.suffix == ".xz" and item.name.endswith(".tar.xz")) or (
@@ -1378,6 +1392,7 @@ def main(argv: Optional[List[str]] = None):
         default=10,
         help="Number of concurrent uploads (default: 10)",
     )
+    source_date.add_source_date_arguments(push_parser)
     push_parser.set_defaults(func=do_push)
 
     # copy command

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -855,7 +855,9 @@ def do_push(args: argparse.Namespace):
     # Resolved once here rather than per archive: it costs several git calls,
     # and every worker must agree on it or the archives are not reproducible.
     archive_env = source_date.child_env(
-        export_standard_var=args.export_source_date_epoch
+        export_standard_var=args.export_source_date_epoch,
+        manifest_dir=artifacts_dir,
+        fail_on_drift=args.fail_on_source_drift,
     )
     log(f"  Source timestamp: {archive_env[source_date.ENV_VAR]}")
 

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -192,7 +192,9 @@ def run(args: argparse.Namespace):
     # Resolved once, here: the devel tarball is written in-process, and every
     # writer must agree on the timestamp or the output is not reproducible.
     timestamp = source_date.apply_to_environ(
-        export_standard_var=args.export_source_date_epoch
+        export_standard_var=args.export_source_date_epoch,
+        manifest_dir=args.artifact_dir,
+        fail_on_drift=args.fail_on_source_drift,
     )
     print(f"::: Source timestamp: {timestamp}")
 

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -26,6 +26,7 @@ import json
 from pathlib import Path
 import sys
 
+from _therock_utils import source_date
 from _therock_utils.artifacts import ArtifactCatalog, ArtifactName
 from _therock_utils.cmake_amdgpu_targets import amdgpu_family_map, expand_families
 from _therock_utils.py_packaging import Parameters, PopulatedDistPackage, build_packages
@@ -188,6 +189,13 @@ def validate_required_dist_packages(
 
 
 def run(args: argparse.Namespace):
+    # Resolved once, here: the devel tarball is written in-process, and every
+    # writer must agree on the timestamp or the output is not reproducible.
+    timestamp = source_date.apply_to_environ(
+        export_standard_var=args.export_source_date_epoch
+    )
+    print(f"::: Source timestamp: {timestamp}")
+
     manifest = load_therock_manifest(args.artifact_dir)
     kpack_split = manifest.get("flags", {}).get("KPACK_SPLIT_ARTIFACTS", False)
     if kpack_split:
@@ -685,6 +693,7 @@ def main(argv: list[str]):
             "side of a multi-arch release. See --linux-amdgpu-families."
         ),
     )
+    source_date.add_source_date_arguments(p)
     args = p.parse_args(argv)
 
     if not args.version:

--- a/build_tools/build_tarballs.py
+++ b/build_tools/build_tarballs.py
@@ -54,6 +54,7 @@ files (e.g. ``lib/hipblaslt/library/*.co``) only for the target family.
 import argparse
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
+import functools
 import json
 import os
 import shlex
@@ -64,6 +65,8 @@ import time
 from pathlib import Path
 
 from zlib_ng import gzip_ng_threaded
+
+from _therock_utils import source_date
 
 DEFAULT_EXCLUDED_ARTIFACTS: list[str] = ["fftw3"]
 DEFAULT_EXCLUDED_COMPONENTS: list[str] = ["test"]
@@ -108,6 +111,51 @@ def log_command_duration(*, start_time: float, start_cpu: os.times_result) -> No
         f"++ Completed in {elapsed:.1f}s "
         f"(CPU: {cpu_user:.1f}s user, {cpu_system:.1f}s system)"
     )
+
+
+@functools.cache
+def _tar_is_gnu() -> bool:
+    """Whether `tar` on PATH is GNU tar.
+
+    The reproducibility flags below are GNU extensions. Windows ships bsdtar
+    (libarchive), which rejects `--sort` outright, so they cannot be passed
+    unconditionally.
+    """
+    try:
+        version = subprocess.run(
+            ["tar", "--version"], capture_output=True, text=True, check=False
+        ).stdout
+    except OSError:
+        return False
+    return "GNU tar" in version
+
+
+def reproducible_tar_flags(source_date_epoch: int | None) -> list[str]:
+    """Flags that make `tar` output depend only on the content.
+
+    Without these a tarball varies between builds of identical content: entry
+    order follows directory iteration, and each entry records its own build-time
+    mtime plus the building user's uid/gid. Unlike Python's `tarfile`, `tar`
+    offers no filter hook, so this has to go on the command line.
+
+    Returns an empty list when the timestamp is unknown or `tar` is not GNU, in
+    which case the tarball is simply not reproducible.
+    """
+    if source_date_epoch is None:
+        return []
+    if not _tar_is_gnu():
+        log(
+            "  Warning: tar is not GNU tar; tarball will not be reproducible "
+            "(entry order and metadata will vary between builds)"
+        )
+        return []
+    return [
+        "--sort=name",
+        f"--mtime=@{source_date_epoch}",
+        "--owner=0",
+        "--group=0",
+        "--numeric-owner",
+    ]
 
 
 def run_command(args: list[str | Path], cwd: Path | None = None) -> None:
@@ -189,9 +237,10 @@ def compress_with_zlib_ng(
     tarball_path: Path,
     compression_level: int,
     compression_threads: int,
+    source_date_epoch: int | None = None,
 ) -> None:
     """Stream a tar archive through zlib-ng's threaded gzip writer."""
-    command = ["tar", "cf", "-", "."]
+    command = ["tar", "cf", "-", *reproducible_tar_flags(source_date_epoch), "."]
     log(
         f"++ Exec [{source_dir}]$ {shlex.join(command)} | "
         "zlib_ng.gzip_ng_threaded.open"
@@ -238,6 +287,7 @@ def compress_tarball(
     compression_backend: str = DEFAULT_COMPRESSION_BACKEND,
     compression_level: int = DEFAULT_COMPRESSION_LEVEL,
     compression_threads: int = DEFAULT_COMPRESSION_THREADS,
+    source_date_epoch: int | None = None,
 ) -> None:
     """Compress a directory into a .tar.gz tarball.
 
@@ -254,9 +304,22 @@ def compress_tarball(
                 tarball_path=tarball_path,
                 compression_level=compression_level,
                 compression_threads=compression_threads,
+                source_date_epoch=source_date_epoch,
             )
         elif compression_backend == "system-gzip":
-            run_command(["tar", "cfz", str(tarball_path), "."], cwd=source_dir)
+            # NOTE: gzip embeds its own mtime, which `tar cfz` takes from the
+            # clock. This backend is therefore never fully reproducible; the
+            # zlib-ng path above writes a gzip header with no timestamp.
+            run_command(
+                [
+                    "tar",
+                    "cfz",
+                    str(tarball_path),
+                    *reproducible_tar_flags(source_date_epoch),
+                    ".",
+                ],
+                cwd=source_dir,
+            )
         else:
             raise ValueError(f"Unknown compression backend: {compression_backend}")
     except BaseException:
@@ -357,6 +420,10 @@ def main(argv: list[str] | None = None) -> None:
         help="Concurrent tarballs to compress (default: auto based on CPU count)",
     )
     args = parser.parse_args(argv)
+    # Resolved once here, not per tarball: it costs several git invocations, and
+    # every tarball in a release must carry the same timestamp.
+    source_date_epoch = source_date.resolve()
+    log(f"Source timestamp: {source_date_epoch}")
     if args.compression_threads < 1:
         parser.error("--compression-threads must be at least 1")
     if args.compress_workers is not None and args.compress_workers < 1:
@@ -516,6 +583,7 @@ def main(argv: list[str] | None = None) -> None:
                 compression_backend=args.compression_backend,
                 compression_level=args.compression_level,
                 compression_threads=args.compression_threads,
+                source_date_epoch=source_date_epoch,
             ): task.tarball_path
             for task in compress_tasks
         }

--- a/build_tools/build_tarballs.py
+++ b/build_tools/build_tarballs.py
@@ -419,11 +419,16 @@ def main(argv: list[str] | None = None) -> None:
         default=None,
         help="Concurrent tarballs to compress (default: auto based on CPU count)",
     )
+    parser.add_argument(
+        "--fail-on-source-drift",
+        action="store_true",
+        help=(
+            "Error instead of warning when the artifacts being packaged were "
+            "built from a different commit, or from a dirty tree, than this "
+            "checkout. Recommended for release builds."
+        ),
+    )
     args = parser.parse_args(argv)
-    # Resolved once here, not per tarball: it costs several git invocations, and
-    # every tarball in a release must carry the same timestamp.
-    source_date_epoch = source_date.compute_source_date_epoch()
-    log(f"Source timestamp: {source_date_epoch}")
     if args.compression_threads < 1:
         parser.error("--compression-threads must be at least 1")
     if args.compress_workers is not None and args.compress_workers < 1:
@@ -552,6 +557,25 @@ def main(argv: list[str] | None = None) -> None:
                     priority=MULTIARCH_TESTS_TARBALL_PRIORITY,
                 )
             )
+
+    # Resolved once for the whole release, and only now that a flattened tree
+    # exists to read therock_manifest.json out of. Every tarball in a release
+    # must carry the same timestamp, and it should describe the source the
+    # artifacts were built from rather than whatever this job checked out.
+    manifest_dir = next(
+        (
+            t.source_dir
+            for t in compress_tasks
+            if source_date.find_manifest(t.source_dir)
+        ),
+        None,
+    )
+    source_date_epoch = source_date.resolve_checked(
+        manifest_dir=manifest_dir,
+        fail_on_drift=args.fail_on_source_drift,
+        report=log,
+    )
+    log(f"Source timestamp: {source_date_epoch}")
 
     # Phase 2: Compress tarballs in parallel, with optional intra-archive
     # parallelism from zlib-ng. Start the expected largest archives first to

--- a/build_tools/build_tarballs.py
+++ b/build_tools/build_tarballs.py
@@ -422,7 +422,7 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
     # Resolved once here, not per tarball: it costs several git invocations, and
     # every tarball in a release must carry the same timestamp.
-    source_date_epoch = source_date.resolve()
+    source_date_epoch = source_date.compute_source_date_epoch()
     log(f"Source timestamp: {source_date_epoch}")
     if args.compression_threads < 1:
         parser.error("--compression-threads must be at least 1")

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -78,6 +78,22 @@ def do_artifact(args):
         contents.write_artifact(output_dir)
 
 
+def _normalize_tarinfo(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo:
+    """Normalize TarInfo for reproducible archives.
+
+    Sets fixed timestamp, uid/gid, and uname/gname for deterministic output.
+    File permissions are preserved. When extracted as a non-root user, ownership
+    defaults to the extracting user. When extracted as root with -p, files are
+    owned by root:root.
+    """
+    tarinfo.mtime = 0
+    tarinfo.uid = 0
+    tarinfo.gid = 0
+    tarinfo.uname = "root"
+    tarinfo.gname = "root"
+    return tarinfo
+
+
 def do_artifact_archive(args):
     output_path: Path = args.o
     if output_path.exists():
@@ -91,7 +107,12 @@ def do_artifact_archive(args):
             manifest_path: Path = artifact_path / "artifact_manifest.txt"
             relpaths = manifest_path.read_text().splitlines()
             # Important: The manifest must be stored first.
-            arc.add(manifest_path, arcname=manifest_path.name, recursive=False)
+            arc.add(
+                manifest_path,
+                arcname=manifest_path.name,
+                recursive=False,
+                filter=_normalize_tarinfo,
+            )
             for relpath in relpaths:
                 if not relpath:
                     continue
@@ -100,9 +121,15 @@ def do_artifact_archive(args):
                     continue
                 pm = PatternMatcher()
                 pm.add_basedir(source_dir)
-                for subpath, dir_entry in pm.all.items():
+                # Sort files for deterministic archive order
+                for subpath, dir_entry in sorted(pm.all.items()):
                     fullpath = f"{relpath}/{subpath}"
-                    arc.add(dir_entry.path, arcname=fullpath, recursive=False)
+                    arc.add(
+                        dir_entry.path,
+                        arcname=fullpath,
+                        recursive=False,
+                        filter=_normalize_tarinfo,
+                    )
 
     if args.hash_file:
         digest = calculate_hash(output_path, args.hash_algorithm)

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -21,7 +21,7 @@ import argparse
 from pathlib import Path
 import sys
 
-from _therock_utils.archive_util import open_archive_for_write
+from _therock_utils.archive_util import normalize_tarinfo, open_archive_for_write
 from _therock_utils.artifacts import ArtifactPopulator
 import _therock_utils.artifact_builder as artifact_builder
 from _therock_utils.hash_util import calculate_hash, write_hash
@@ -91,7 +91,12 @@ def do_artifact_archive(args):
             manifest_path: Path = artifact_path / "artifact_manifest.txt"
             relpaths = manifest_path.read_text().splitlines()
             # Important: The manifest must be stored first.
-            arc.add(manifest_path, arcname=manifest_path.name, recursive=False)
+            arc.add(
+                manifest_path,
+                arcname=manifest_path.name,
+                recursive=False,
+                filter=normalize_tarinfo,
+            )
             for relpath in relpaths:
                 if not relpath:
                     continue
@@ -100,9 +105,16 @@ def do_artifact_archive(args):
                     continue
                 pm = PatternMatcher()
                 pm.add_basedir(source_dir)
-                for subpath, dir_entry in pm.all.items():
+                # Sorted so that directory iteration order does not change the
+                # archive hash.
+                for subpath, dir_entry in sorted(pm.all.items()):
                     fullpath = f"{relpath}/{subpath}"
-                    arc.add(dir_entry.path, arcname=fullpath, recursive=False)
+                    arc.add(
+                        dir_entry.path,
+                        arcname=fullpath,
+                        recursive=False,
+                        filter=normalize_tarinfo,
+                    )
 
     if args.hash_file:
         digest = calculate_hash(output_path, args.hash_algorithm)

--- a/build_tools/generate_therock_manifest.py
+++ b/build_tools/generate_therock_manifest.py
@@ -10,6 +10,7 @@ import re
 import subprocess
 import sys
 
+from _therock_utils import source_date
 from github_actions.manifest_utils import capture, capture_optional, log
 
 
@@ -208,6 +209,17 @@ def build_manifest_schema(
         "the_rock_commit": the_rock_commit,
     }
 
+    # Working-tree facts, unlike everything else here, which is read from the
+    # committed object graph. They are what lets a packaging step running in a
+    # later job stamp archives with the source state the artifacts were built
+    # from, rather than re-deriving from whatever it happens to have checked
+    # out. See docs/development/reproducible_archives.md.
+    manifest["source_date_epoch"] = source_date.compute_source_date_epoch(repo_root)
+    # The fields above describe `the_rock_commit`; this says whether the build
+    # actually matched it. A true value means source_date_epoch came from a file
+    # mtime and the commit-derived fields are an incomplete description.
+    manifest["source_dirty"] = source_date.is_worktree_dirty(repo_root)
+
     if github_job:
         manifest["github_job"] = github_job
 
@@ -251,6 +263,11 @@ def build_partial_manifest_schema(
     manifest = {
         "the_rock_commit": None,
     }
+
+    # No git metadata, so there is no source state to describe. Left null rather
+    # than filled with the clock, so a consumer can tell the difference.
+    manifest["source_date_epoch"] = None
+    manifest["source_dirty"] = None
 
     if github_job:
         manifest["github_job"] = github_job

--- a/build_tools/tests/archive_util_test.py
+++ b/build_tools/tests/archive_util_test.py
@@ -4,11 +4,13 @@
 
 import os
 import platform
+import tarfile
 import tempfile
 import unittest
 from pathlib import Path
 
 from _therock_utils.archive_util import (
+    normalize_tarinfo,
     open_archive_for_read,
     open_archive_for_write,
 )
@@ -98,6 +100,51 @@ class HandleLeakTest(unittest.TestCase):
 
             os.unlink(archive)
             self.assertFalse(archive.exists())
+
+
+class NormalizeTarinfoTest(unittest.TestCase):
+    """Verify the metadata normalization applied to reproducible archives."""
+
+    def test_build_specific_metadata_is_cleared(self):
+        tarinfo = tarfile.TarInfo("lib/libfoo.so.1")
+        tarinfo.mtime = 1700000000
+        tarinfo.uid = 1000
+        tarinfo.gid = 1000
+        tarinfo.uname = "builder"
+        tarinfo.gname = "builder"
+
+        normalize_tarinfo(tarinfo)
+
+        self.assertEqual(tarinfo.mtime, 0)
+        self.assertEqual(tarinfo.uid, 0)
+        self.assertEqual(tarinfo.gid, 0)
+        self.assertEqual(tarinfo.uname, "root")
+        self.assertEqual(tarinfo.gname, "root")
+
+    def test_permissions_and_identity_are_preserved(self):
+        tarinfo = tarfile.TarInfo("bin/tool")
+        tarinfo.mode = 0o755
+        tarinfo.size = 1234
+        tarinfo.type = tarfile.REGTYPE
+
+        normalize_tarinfo(tarinfo)
+
+        # Only the varying metadata is touched; anything describing the content
+        # must survive.
+        self.assertEqual(tarinfo.mode, 0o755)
+        self.assertEqual(tarinfo.size, 1234)
+        self.assertEqual(tarinfo.type, tarfile.REGTYPE)
+        self.assertEqual(tarinfo.name, "bin/tool")
+
+    def test_symlink_target_is_preserved(self):
+        tarinfo = tarfile.TarInfo("share/doc/README")
+        tarinfo.type = tarfile.SYMTYPE
+        tarinfo.linkname = "README.txt"
+
+        normalize_tarinfo(tarinfo)
+
+        self.assertEqual(tarinfo.type, tarfile.SYMTYPE)
+        self.assertEqual(tarinfo.linkname, "README.txt")
 
 
 class ErrorHandlingTest(unittest.TestCase):

--- a/build_tools/tests/archive_util_test.py
+++ b/build_tools/tests/archive_util_test.py
@@ -10,6 +10,7 @@ import unittest
 from pathlib import Path
 
 from _therock_utils.archive_util import (
+    add_tree,
     normalize_tarinfo,
     open_archive_for_read,
     open_archive_for_write,
@@ -145,6 +146,80 @@ class NormalizeTarinfoTest(unittest.TestCase):
 
         self.assertEqual(tarinfo.type, tarfile.SYMTYPE)
         self.assertEqual(tarinfo.linkname, "README.txt")
+
+
+class AddTreeTest(unittest.TestCase):
+    """Verify reproducible tree archiving (used for the wheel devel tarball)."""
+
+    def _write_tree(self, root: Path):
+        # Deliberately created out of order so that a passing sort assertion
+        # cannot be explained by creation order.
+        (root / "pkg" / "sub").mkdir(parents=True)
+        (root / "pkg" / "z.txt").write_text("z")
+        (root / "pkg" / "a.txt").write_text("a")
+        (root / "pkg" / "sub" / "m.txt").write_text("m")
+
+    def _archive_tree(self, tmp: Path, archive: Path) -> list[str]:
+        with open_archive_for_write(archive, "xz") as tf:
+            add_tree(tf, tmp / "pkg", relative_to=tmp)
+        with open_archive_for_read(archive) as tf:
+            return tf.getnames()
+
+    def test_member_order_is_deterministic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            self._write_tree(tmp)
+            names = self._archive_tree(tmp, tmp / "out.tar.xz")
+
+        # Sorted within each directory, directories visited in sorted order.
+        # The exact sequence matters less than it being pinned: creation order
+        # and filesystem iteration order must not leak into the archive.
+        self.assertEqual(names, ["pkg/a.txt", "pkg/sub", "pkg/z.txt", "pkg/sub/m.txt"])
+
+    def test_same_tree_archives_identically(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            self._write_tree(tmp)
+
+            first = tmp / "first.tar.xz"
+            with open_archive_for_write(first, "xz") as tf:
+                add_tree(tf, tmp / "pkg", relative_to=tmp)
+
+            # Simulate the same content produced by a later build.
+            for p in (tmp / "pkg").rglob("*"):
+                os.utime(p, (1700000000, 1700000000))
+
+            second = tmp / "second.tar.xz"
+            with open_archive_for_write(second, "xz") as tf:
+                add_tree(tf, tmp / "pkg", relative_to=tmp)
+
+            self.assertEqual(first.read_bytes(), second.read_bytes())
+
+    def test_member_metadata_is_normalized(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            self._write_tree(tmp)
+            archive = tmp / "out.tar.xz"
+            with open_archive_for_write(archive, "xz") as tf:
+                add_tree(tf, tmp / "pkg", relative_to=tmp)
+            with open_archive_for_read(archive) as tf:
+                members = tf.getmembers()
+
+        self.assertTrue(members)
+        for member in members:
+            self.assertEqual(member.mtime, 0, member.name)
+            self.assertEqual(member.uid, 0, member.name)
+            self.assertEqual(member.gid, 0, member.name)
+
+    def test_reports_added_members(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            self._write_tree(tmp)
+            added = []
+            with open_archive_for_write(tmp / "out.tar.xz", "xz") as tf:
+                add_tree(tf, tmp / "pkg", relative_to=tmp, on_add=added.append)
+
+        self.assertIn("pkg/a.txt", [name.replace(os.sep, "/") for name in added])
 
 
 class ErrorHandlingTest(unittest.TestCase):

--- a/build_tools/tests/archive_util_test.py
+++ b/build_tools/tests/archive_util_test.py
@@ -19,6 +19,7 @@ from _therock_utils.archive_util import (
     open_archive_for_read,
     open_archive_for_write,
 )
+from _therock_utils.source_date import ENV_VAR, STANDARD_ENV_VAR
 
 IS_WINDOWS = platform.system() == "Windows"
 
@@ -114,45 +115,48 @@ class ArchiveTimestampTest(unittest.TestCase):
         get_archive_timestamp.cache_clear()
         self.addCleanup(get_archive_timestamp.cache_clear)
 
-    def test_source_date_epoch_is_honored(self):
-        with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+    @staticmethod
+    def _env(**overrides):
+        """Environment with both timestamp vars cleared, then `overrides` applied."""
+        env = {
+            k: v for k, v in os.environ.items() if k not in (STANDARD_ENV_VAR, ENV_VAR)
+        }
+        env.update(overrides)
+        return mock.patch.dict(os.environ, env, clear=True)
+
+    def test_therock_var_is_used(self):
+        with self._env(**{ENV_VAR: "1700000000"}):
             self.assertEqual(get_archive_timestamp(), 1700000000)
 
-    def test_non_integer_source_date_epoch_is_rejected(self):
-        with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "yesterday"}):
-            with self.assertRaisesRegex(ValueError, "SOURCE_DATE_EPOCH"):
+    def test_standard_var_outranks_the_therock_var(self):
+        # Nothing sets SOURCE_DATE_EPOCH unless explicitly asked to, so its
+        # presence is a deliberate decision and beats the computed default.
+        with self._env(**{STANDARD_ENV_VAR: "1600000000", ENV_VAR: "1700000000"}):
+            self.assertEqual(get_archive_timestamp(), 1600000000)
+
+    def test_non_integer_value_is_rejected(self):
+        with self._env(**{ENV_VAR: "yesterday"}):
+            with self.assertRaisesRegex(ValueError, ENV_VAR):
                 get_archive_timestamp()
 
-    def test_negative_source_date_epoch_is_rejected(self):
-        with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "-1"}):
+    def test_negative_value_is_rejected(self):
+        with self._env(**{STANDARD_ENV_VAR: "-1"}):
             with self.assertRaisesRegex(ValueError, "negative"):
                 get_archive_timestamp()
 
-    def test_falls_back_to_git_commit_time(self):
-        with mock.patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("SOURCE_DATE_EPOCH", None)
-            with mock.patch.object(
-                archive_util, "_git_commit_timestamp", return_value=1234567890
-            ):
-                self.assertEqual(get_archive_timestamp(), 1234567890)
-
-    def test_falls_back_to_current_time_outside_a_git_checkout(self):
+    def test_falls_back_to_current_time_when_unset(self):
+        # A worker run directly, with no orchestrator to resolve the source
+        # timestamp. Must never be the epoch.
         before = int(time.time())
-        with mock.patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("SOURCE_DATE_EPOCH", None)
-            with mock.patch.object(
-                archive_util, "_git_commit_timestamp", return_value=None
-            ):
-                timestamp = get_archive_timestamp()
+        with self._env():
+            timestamp = get_archive_timestamp()
         self.assertGreaterEqual(timestamp, before)
 
-    def test_resolves_in_this_checkout_without_configuration(self):
-        # The real resolution path: no SOURCE_DATE_EPOCH, a git checkout. Must
-        # never be the epoch, which is the whole point of not using 0.
-        with mock.patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("SOURCE_DATE_EPOCH", None)
-            timestamp = get_archive_timestamp()
-        self.assertGreater(timestamp, 0)
+    def test_does_no_git_work(self):
+        # Resolving the source timestamp costs several git calls and this runs
+        # once per archive process, so it belongs in source_date, called once by
+        # an orchestrator.
+        self.assertNotIn("subprocess", vars(archive_util))
 
 
 class NormalizeTarinfoTest(unittest.TestCase):
@@ -170,7 +174,7 @@ class NormalizeTarinfoTest(unittest.TestCase):
         tarinfo.uname = "builder"
         tarinfo.gname = "builder"
 
-        with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+        with mock.patch.dict(os.environ, {STANDARD_ENV_VAR: "1700000000"}):
             normalize_tarinfo(tarinfo)
 
         self.assertEqual(tarinfo.mtime, 1700000000)
@@ -267,7 +271,7 @@ class AddTreeTest(unittest.TestCase):
             tmp = Path(tmp)
             self._write_tree(tmp)
             archive = tmp / "out.tar.xz"
-            with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+            with mock.patch.dict(os.environ, {STANDARD_ENV_VAR: "1700000000"}):
                 with open_archive_for_write(archive, "xz") as tf:
                     add_tree(tf, tmp / "pkg", relative_to=tmp)
             with open_archive_for_read(archive) as tf:

--- a/build_tools/tests/archive_util_test.py
+++ b/build_tools/tests/archive_util_test.py
@@ -6,11 +6,15 @@ import os
 import platform
 import tarfile
 import tempfile
+import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
+from _therock_utils import archive_util
 from _therock_utils.archive_util import (
     add_tree,
+    get_archive_timestamp,
     normalize_tarinfo,
     open_archive_for_read,
     open_archive_for_write,
@@ -103,24 +107,85 @@ class HandleLeakTest(unittest.TestCase):
             self.assertFalse(archive.exists())
 
 
+class ArchiveTimestampTest(unittest.TestCase):
+    """Verify how the archive mtime is resolved."""
+
+    def setUp(self):
+        get_archive_timestamp.cache_clear()
+        self.addCleanup(get_archive_timestamp.cache_clear)
+
+    def test_source_date_epoch_is_honored(self):
+        with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+            self.assertEqual(get_archive_timestamp(), 1700000000)
+
+    def test_non_integer_source_date_epoch_is_rejected(self):
+        with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "yesterday"}):
+            with self.assertRaisesRegex(ValueError, "SOURCE_DATE_EPOCH"):
+                get_archive_timestamp()
+
+    def test_negative_source_date_epoch_is_rejected(self):
+        with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "-1"}):
+            with self.assertRaisesRegex(ValueError, "negative"):
+                get_archive_timestamp()
+
+    def test_falls_back_to_git_commit_time(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SOURCE_DATE_EPOCH", None)
+            with mock.patch.object(
+                archive_util, "_git_commit_timestamp", return_value=1234567890
+            ):
+                self.assertEqual(get_archive_timestamp(), 1234567890)
+
+    def test_falls_back_to_current_time_outside_a_git_checkout(self):
+        before = int(time.time())
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SOURCE_DATE_EPOCH", None)
+            with mock.patch.object(
+                archive_util, "_git_commit_timestamp", return_value=None
+            ):
+                timestamp = get_archive_timestamp()
+        self.assertGreaterEqual(timestamp, before)
+
+    def test_resolves_in_this_checkout_without_configuration(self):
+        # The real resolution path: no SOURCE_DATE_EPOCH, a git checkout. Must
+        # never be the epoch, which is the whole point of not using 0.
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SOURCE_DATE_EPOCH", None)
+            timestamp = get_archive_timestamp()
+        self.assertGreater(timestamp, 0)
+
+
 class NormalizeTarinfoTest(unittest.TestCase):
     """Verify the metadata normalization applied to reproducible archives."""
 
+    def setUp(self):
+        get_archive_timestamp.cache_clear()
+        self.addCleanup(get_archive_timestamp.cache_clear)
+
     def test_build_specific_metadata_is_cleared(self):
         tarinfo = tarfile.TarInfo("lib/libfoo.so.1")
-        tarinfo.mtime = 1700000000
+        tarinfo.mtime = 1600000000
         tarinfo.uid = 1000
         tarinfo.gid = 1000
         tarinfo.uname = "builder"
         tarinfo.gname = "builder"
 
-        normalize_tarinfo(tarinfo)
+        with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+            normalize_tarinfo(tarinfo)
 
-        self.assertEqual(tarinfo.mtime, 0)
+        self.assertEqual(tarinfo.mtime, 1700000000)
         self.assertEqual(tarinfo.uid, 0)
         self.assertEqual(tarinfo.gid, 0)
         self.assertEqual(tarinfo.uname, "root")
         self.assertEqual(tarinfo.gname, "root")
+
+    def test_mtime_is_not_the_epoch(self):
+        # Regression guard: an epoch mtime survives extraction and makes fresh
+        # SDK inputs look older than a downstream project's existing objects,
+        # suppressing rebuilds.
+        tarinfo = tarfile.TarInfo("include/foo.h")
+        normalize_tarinfo(tarinfo)
+        self.assertGreater(tarinfo.mtime, 0)
 
     def test_permissions_and_identity_are_preserved(self):
         tarinfo = tarfile.TarInfo("bin/tool")
@@ -196,18 +261,21 @@ class AddTreeTest(unittest.TestCase):
             self.assertEqual(first.read_bytes(), second.read_bytes())
 
     def test_member_metadata_is_normalized(self):
+        get_archive_timestamp.cache_clear()
+        self.addCleanup(get_archive_timestamp.cache_clear)
         with tempfile.TemporaryDirectory() as tmp:
             tmp = Path(tmp)
             self._write_tree(tmp)
             archive = tmp / "out.tar.xz"
-            with open_archive_for_write(archive, "xz") as tf:
-                add_tree(tf, tmp / "pkg", relative_to=tmp)
+            with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+                with open_archive_for_write(archive, "xz") as tf:
+                    add_tree(tf, tmp / "pkg", relative_to=tmp)
             with open_archive_for_read(archive) as tf:
                 members = tf.getmembers()
 
         self.assertTrue(members)
         for member in members:
-            self.assertEqual(member.mtime, 0, member.name)
+            self.assertEqual(member.mtime, 1700000000, member.name)
             self.assertEqual(member.uid, 0, member.name)
             self.assertEqual(member.gid, 0, member.name)
 

--- a/build_tools/tests/build_tarballs_test.py
+++ b/build_tools/tests/build_tarballs_test.py
@@ -17,10 +17,12 @@ from unittest import mock
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from build_tarballs import (
+    _tar_is_gnu,
     compress_tarball,
     determine_compress_workers,
     is_kpack_split,
     main,
+    reproducible_tar_flags,
 )
 
 
@@ -121,6 +123,85 @@ class TestCompressTarball(unittest.TestCase):
 
             with tarfile.open(tarball_path, "r:gz") as tf:
                 self.assertIn("./hello", tf.getnames())
+
+
+class TestReproducibleTarballs(unittest.TestCase):
+    """Release tarballs must depend only on their content.
+
+    `tar` has no filter hook, so unlike the Python archive writers this relies
+    on command-line flags, and those are GNU extensions.
+    """
+
+    FIXED_EPOCH = 1700000000
+
+    def _write_tree(self, root: Path) -> None:
+        # Created out of sorted order so a passing order assertion cannot be
+        # explained by creation order.
+        (root / "sub").mkdir(parents=True)
+        (root / "z.txt").write_text("z")
+        (root / "a.txt").write_text("a")
+        (root / "sub" / "m.txt").write_text("m")
+
+    def test_flags_are_omitted_without_a_timestamp(self):
+        self.assertEqual(reproducible_tar_flags(None), [])
+
+    @unittest.skipUnless(_tar_is_gnu(), "Reproducibility flags are GNU tar extensions")
+    def test_flags_pin_order_metadata_and_time(self):
+        flags = reproducible_tar_flags(self.FIXED_EPOCH)
+        self.assertIn("--sort=name", flags)
+        self.assertIn(f"--mtime=@{self.FIXED_EPOCH}", flags)
+        self.assertIn("--owner=0", flags)
+        self.assertIn("--group=0", flags)
+
+    @unittest.skipUnless(_tar_is_gnu(), "Reproducibility flags are GNU tar extensions")
+    def test_same_content_different_mtimes_gives_identical_bytes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            src = tmpdir / "src"
+            self._write_tree(src)
+
+            first = tmpdir / "first.tar.gz"
+            compress_tarball(
+                source_dir=src,
+                tarball_path=first,
+                source_date_epoch=self.FIXED_EPOCH,
+            )
+
+            # Simulate the same content produced by a later build.
+            for path in src.rglob("*"):
+                os.utime(path, (1600000000, 1600000000))
+
+            second = tmpdir / "second.tar.gz"
+            compress_tarball(
+                source_dir=src,
+                tarball_path=second,
+                source_date_epoch=self.FIXED_EPOCH,
+            )
+
+            self.assertEqual(first.read_bytes(), second.read_bytes())
+
+    @unittest.skipUnless(_tar_is_gnu(), "Reproducibility flags are GNU tar extensions")
+    def test_members_carry_the_pinned_metadata(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            src = tmpdir / "src"
+            self._write_tree(src)
+            tarball = tmpdir / "out.tar.gz"
+            compress_tarball(
+                source_dir=src,
+                tarball_path=tarball,
+                source_date_epoch=self.FIXED_EPOCH,
+            )
+
+            with tarfile.open(tarball, "r:gz") as tf:
+                members = tf.getmembers()
+            self.assertTrue(members)
+            for member in members:
+                self.assertEqual(member.mtime, self.FIXED_EPOCH, member.name)
+                self.assertEqual(member.uid, 0, member.name)
+                self.assertEqual(member.gid, 0, member.name)
+            names = [m.name for m in members]
+            self.assertEqual(names, sorted(names))
 
 
 class TestDetermineCompressWorkers(unittest.TestCase):

--- a/build_tools/tests/fileset_tool_test.py
+++ b/build_tools/tests/fileset_tool_test.py
@@ -39,10 +39,19 @@ def capture(args: list[str | Path], cwd: Path = FILESET_TOOL.parent) -> str:
     ).decode()
 
 
-def run_command(args: list[str | Path], cwd: Path = FILESET_TOOL.parent):
+def run_command(
+    args: list[str | Path],
+    cwd: Path = FILESET_TOOL.parent,
+    env: dict[str, str] | None = None,
+):
     args = [str(arg) for arg in args]
     print(f"++ Exec [{cwd}]$ {shlex.join(args)}")
-    return subprocess.check_call(args, cwd=str(cwd), stdin=subprocess.DEVNULL)
+    child_env = None
+    if env is not None:
+        child_env = os.environ | env
+    return subprocess.check_call(
+        args, cwd=str(cwd), stdin=subprocess.DEVNULL, env=child_env
+    )
 
 
 def write_text(p: Path, text: str):
@@ -408,7 +417,9 @@ class FilesetToolTest(unittest.TestCase):
             ]
         )
 
-    def _archive_digest(self, artifact_dir: Path, archive: Path) -> str:
+    def _archive_digest(
+        self, artifact_dir: Path, archive: Path, env: dict[str, str] | None = None
+    ) -> str:
         run_command(
             [
                 sys.executable,
@@ -417,7 +428,8 @@ class FilesetToolTest(unittest.TestCase):
                 artifact_dir,
                 "-o",
                 archive,
-            ]
+            ],
+            env=env,
         )
         return calculate_hash(archive, "sha256").hexdigest()
 
@@ -447,13 +459,15 @@ class FilesetToolTest(unittest.TestCase):
         artifact_dir = self.temp_dir / "artifact"
         self._build_doc_artifact(artifact_dir)
         archive = self.temp_dir / "archive.tar.xz"
-        self._archive_digest(artifact_dir, archive)
+        self._archive_digest(
+            artifact_dir, archive, env={"SOURCE_DATE_EPOCH": "1700000000"}
+        )
 
         with tarfile.open(archive, mode="r:xz") as tf:
             members = tf.getmembers()
         self.assertTrue(members)
         for member in members:
-            self.assertEqual(member.mtime, 0, member.name)
+            self.assertEqual(member.mtime, 1700000000, member.name)
             self.assertEqual(member.uid, 0, member.name)
             self.assertEqual(member.gid, 0, member.name)
             self.assertEqual(member.uname, "root", member.name)
@@ -464,6 +478,25 @@ class FilesetToolTest(unittest.TestCase):
         names = [m.name for m in members]
         self.assertEqual(names[0], "artifact_manifest.txt")
         self.assertEqual(names[1:], sorted(names[1:]))
+
+    def testArchiveMtimeIsNotTheEpoch(self):
+        """Unconfigured archives still get a real timestamp.
+
+        Extraction restores mtime, so an epoch timestamp would make freshly
+        installed SDK inputs look older than a downstream project's existing
+        build outputs and suppress rebuilds.
+        """
+        artifact_dir = self.temp_dir / "artifact"
+        self._build_doc_artifact(artifact_dir)
+        archive = self.temp_dir / "archive.tar.xz"
+        # No SOURCE_DATE_EPOCH: exercises the git-commit-time path.
+        self._archive_digest(artifact_dir, archive)
+
+        with tarfile.open(archive, mode="r:xz") as tf:
+            members = tf.getmembers()
+        self.assertTrue(members)
+        for member in members:
+            self.assertGreater(member.mtime, 0, member.name)
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/fileset_tool_test.py
+++ b/build_tools/tests/fileset_tool_test.py
@@ -8,6 +8,7 @@ import platform
 import shlex
 import subprocess
 import sys
+import tarfile
 import tempfile
 import unittest
 
@@ -379,6 +380,90 @@ class FilesetToolTest(unittest.TestCase):
         )
         self.assertIn("Warning", output)
         self.assertIn("nonexistent_prefix", output)
+
+    def _build_doc_artifact(self, artifact_dir: Path):
+        """Builds a doc artifact holding several files, into `artifact_dir`."""
+        input_dir = self.temp_dir / "input"
+        descriptor_file = self.temp_dir / "artifact.toml"
+        write_text(descriptor_file, ARTIFACT_DESCRIPTOR_1)
+        doc_dir = input_dir / "example" / "stage" / "share" / "doc"
+        # Deliberately not in sorted order, so the archive order depends on
+        # sorting rather than on creation order.
+        write_text(doc_dir / "z_file.so.1", "z")
+        write_text(doc_dir / "a_file.so.1", "a")
+        write_text(doc_dir / "m_file.so.1", "m")
+        run_command(
+            [
+                sys.executable,
+                FILESET_TOOL,
+                "artifact",
+                "--descriptor",
+                descriptor_file,
+                "--artifact-name",
+                "test",
+                "--root-dir",
+                input_dir,
+                "doc",
+                artifact_dir,
+            ]
+        )
+
+    def _archive_digest(self, artifact_dir: Path, archive: Path) -> str:
+        run_command(
+            [
+                sys.executable,
+                FILESET_TOOL,
+                "artifact-archive",
+                artifact_dir,
+                "-o",
+                archive,
+            ]
+        )
+        return calculate_hash(archive, "sha256").hexdigest()
+
+    def testArchiveReproducibleDespiteMetadataChanges(self):
+        """Identical content archives identically even if mtimes differ.
+
+        Without metadata normalization the two archives differ, which lets the
+        same generic artifact upload under two different SHAs. See
+        https://github.com/ROCm/TheRock/issues/4202.
+        """
+        artifact_dir = self.temp_dir / "artifact"
+        self._build_doc_artifact(artifact_dir)
+
+        digest1 = self._archive_digest(artifact_dir, self.temp_dir / "archive1.tar.xz")
+
+        # Simulate the same content produced by a later build.
+        for p in artifact_dir.rglob("*"):
+            if p.is_file():
+                os.utime(p, (1700000000, 1700000000))
+
+        digest2 = self._archive_digest(artifact_dir, self.temp_dir / "archive2.tar.xz")
+
+        self.assertEqual(digest1, digest2)
+
+    def testArchiveMemberMetadataIsNormalized(self):
+        """Archive members carry no build-specific timestamps or ownership."""
+        artifact_dir = self.temp_dir / "artifact"
+        self._build_doc_artifact(artifact_dir)
+        archive = self.temp_dir / "archive.tar.xz"
+        self._archive_digest(artifact_dir, archive)
+
+        with tarfile.open(archive, mode="r:xz") as tf:
+            members = tf.getmembers()
+        self.assertTrue(members)
+        for member in members:
+            self.assertEqual(member.mtime, 0, member.name)
+            self.assertEqual(member.uid, 0, member.name)
+            self.assertEqual(member.gid, 0, member.name)
+            self.assertEqual(member.uname, "root", member.name)
+            self.assertEqual(member.gname, "root", member.name)
+
+        # The manifest is stored first; the rest are sorted so that directory
+        # iteration order cannot change the archive hash.
+        names = [m.name for m in members]
+        self.assertEqual(names[0], "artifact_manifest.txt")
+        self.assertEqual(names[1:], sorted(names[1:]))
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/source_date_test.py
+++ b/build_tools/tests/source_date_test.py
@@ -199,44 +199,6 @@ class SourceDateTest(unittest.TestCase):
         self.assertFalse(entry.is_populated)
         self.assertEqual(entry.path, self.sub_checkout)
 
-    # -- the configure-time handoff ---------------------------------------
-
-    def test_build_dir_value_is_preferred_over_recomputing(self):
-        # CMake resolved this at configure time; tools running later must agree
-        # with the build rather than resolve it again.
-        build_dir = self.super / "build"
-        build_dir.mkdir()
-        (build_dir / source_date.STAMP_FILE_NAME).write_text("1700000000\n")
-        self.assertEqual(
-            source_date.resolve(build_dir=build_dir, repo_dir=self.super),
-            1700000000,
-        )
-
-    def test_a_dirty_tree_does_not_override_the_build_dir_value(self):
-        # Otherwise a developer's archives would drift from the build they came
-        # from every time they touched a file.
-        build_dir = self.super / "build"
-        build_dir.mkdir()
-        (build_dir / source_date.STAMP_FILE_NAME).write_text("1700000000\n")
-        (self.super / "README.md").write_text("edited")
-        self.assertEqual(
-            source_date.resolve(build_dir=build_dir, repo_dir=self.super),
-            1700000000,
-        )
-
-    def test_missing_build_dir_value_falls_back_to_computing(self):
-        self.assertEqual(
-            source_date.resolve(build_dir=self.super / "nope", repo_dir=self.super),
-            FEB_2026,
-        )
-
-    def test_unparseable_build_dir_value_is_rejected(self):
-        build_dir = self.super / "build"
-        build_dir.mkdir()
-        (build_dir / source_date.STAMP_FILE_NAME).write_text("not-a-timestamp")
-        with self.assertRaisesRegex(ValueError, "does not contain a timestamp"):
-            source_date.resolve(build_dir=build_dir, repo_dir=self.super)
-
     # -- environment plumbing ---------------------------------------------
 
     def test_child_env_sets_only_the_namespaced_var_by_default(self):

--- a/build_tools/tests/source_date_test.py
+++ b/build_tools/tests/source_date_test.py
@@ -15,19 +15,24 @@ import os
 import shutil
 import subprocess
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
 from _therock_utils import source_date
 from _therock_utils.source_date import (
     compute_source_date_epoch,
+    dirty_paths,
     is_worktree_dirty,
+    newest_dirty_mtime,
     submodule_entries,
 )
 
 JAN_2026 = 1767225600  # 2026-01-01T00:00:00Z, the submodule's first commit.
 FEB_2026 = 1769990400  # 2026-02-02T00:00:00Z, the superproject pinning it.
 JUN_2026 = 1781481600  # 2026-06-15T00:00:00Z, later work inside the submodule.
+DEC_2026 = 1798761600  # 2026-12-31T00:00:00Z, an uncommitted edit.
+JAN_2020 = 1577836800  # 2020-01-01T00:00:00Z, deliberately stale.
 
 
 def git(*args: str, cwd: Path, when: int | None = None) -> str:
@@ -101,29 +106,79 @@ class SourceDateTest(unittest.TestCase):
         self.assertEqual([e.state for e in entries], ["+"])
         self.assertEqual(compute_source_date_epoch(self.super), JUN_2026)
 
-    def test_dirty_submodule_worktree_advances_past_every_commit(self):
-        (self.sub_checkout / "f.txt").write_text("uncommitted")
+    def test_dirty_submodule_worktree_uses_the_file_mtime(self):
+        edited = self.sub_checkout / "f.txt"
+        edited.write_text("uncommitted")
+        os.utime(edited, (DEC_2026, DEC_2026))
 
         # The commit still matches the pin, so this is invisible to
-        # `git submodule status` -- the dirty check is what catches it.
+        # `git submodule status` -- the dirty scan is what catches it.
         self.assertEqual([e.state for e in submodule_entries(self.super)], [" "])
         self.assertTrue(is_worktree_dirty(self.super))
-        self.assertGreater(compute_source_date_epoch(self.super), JUN_2026)
+        self.assertEqual(compute_source_date_epoch(self.super), DEC_2026)
 
-    def test_dirty_superproject_advances_past_every_commit(self):
-        (self.super / "README.md").write_text("edited")
+    def test_dirty_superproject_uses_the_file_mtime(self):
+        edited = self.super / "README.md"
+        edited.write_text("edited")
+        os.utime(edited, (DEC_2026, DEC_2026))
         self.assertTrue(is_worktree_dirty(self.super))
-        self.assertGreater(compute_source_date_epoch(self.super), FEB_2026)
+        self.assertEqual(compute_source_date_epoch(self.super), DEC_2026)
 
     def test_untracked_file_counts_as_dirty(self):
-        (self.super / "scratch.txt").write_text("scratch")
+        untracked = self.super / "scratch.txt"
+        untracked.write_text("scratch")
+        os.utime(untracked, (DEC_2026, DEC_2026))
         self.assertTrue(is_worktree_dirty(self.super))
+        self.assertEqual(compute_source_date_epoch(self.super), DEC_2026)
+
+    def test_newest_dirty_file_wins(self):
+        older = self.super / "older.txt"
+        older.write_text("a")
+        os.utime(older, (JUN_2026, JUN_2026))
+        newer = self.super / "newer.txt"
+        newer.write_text("b")
+        os.utime(newer, (DEC_2026, DEC_2026))
+        self.assertEqual(newest_dirty_mtime(self.super), DEC_2026)
+        self.assertEqual(compute_source_date_epoch(self.super), DEC_2026)
+
+    def test_an_old_dirty_file_cannot_drag_the_result_backwards(self):
+        # Touching a file to 2020 must not make the archive look older than the
+        # commit it sits on.
+        stale = self.super / "README.md"
+        stale.write_text("edited")
+        os.utime(stale, (JAN_2020, JAN_2020))
+        self.assertEqual(newest_dirty_mtime(self.super), JAN_2020)
+        self.assertEqual(compute_source_date_epoch(self.super), FEB_2026)
+
+    def test_repeated_calls_on_an_untouched_dirty_tree_agree(self):
+        # The whole reason this is a file mtime rather than the current time:
+        # an unchanged tree must resolve identically every time, or every
+        # reconfigure would invalidate everything downstream.
+        (self.super / "README.md").write_text("edited")
+        first = compute_source_date_epoch(self.super)
+        time.sleep(1.1)
+        self.assertEqual(compute_source_date_epoch(self.super), first)
+
+    def test_a_path_with_spaces_is_handled(self):
+        # `git status --porcelain` quotes these; the -z form does not.
+        spaced = self.super / "a file with spaces.txt"
+        spaced.write_text("x")
+        os.utime(spaced, (DEC_2026, DEC_2026))
+        self.assertIn(spaced, dirty_paths(self.super))
+        self.assertEqual(compute_source_date_epoch(self.super), DEC_2026)
+
+    def test_a_deleted_file_does_not_break_resolution(self):
+        (self.super / "README.md").unlink()
+        self.assertTrue(is_worktree_dirty(self.super))
+        # Nothing to stat, so it falls back to the commit times.
+        self.assertEqual(compute_source_date_epoch(self.super), FEB_2026)
 
     def test_outside_a_git_checkout_falls_back_to_now(self):
+        before = int(time.time())
         with tempfile.TemporaryDirectory() as plain:
             self.assertEqual(submodule_entries(Path(plain)), [])
             self.assertFalse(is_worktree_dirty(Path(plain)))
-            self.assertGreater(compute_source_date_epoch(Path(plain)), FEB_2026)
+            self.assertGreaterEqual(compute_source_date_epoch(Path(plain)), before)
 
     # -- parsing -----------------------------------------------------------
 

--- a/build_tools/tests/source_date_test.py
+++ b/build_tools/tests/source_date_test.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for resolving the source timestamp used by reproducible archives.
+
+Each test builds a real superproject + submodule fixture, because the signals
+this relies on are not interchangeable and the distinctions only show up against
+real git. In particular `git submodule status` compares commits only: a
+submodule whose working tree is dirty but whose commit still matches the pin
+reports ' ', not '+'.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from _therock_utils import source_date
+from _therock_utils.source_date import (
+    compute_source_date_epoch,
+    is_worktree_dirty,
+    submodule_entries,
+)
+
+JAN_2026 = 1767225600  # 2026-01-01T00:00:00Z, the submodule's first commit.
+FEB_2026 = 1769990400  # 2026-02-02T00:00:00Z, the superproject pinning it.
+JUN_2026 = 1781481600  # 2026-06-15T00:00:00Z, later work inside the submodule.
+
+
+def git(*args: str, cwd: Path, when: int | None = None) -> str:
+    env = dict(os.environ)
+    if when is not None:
+        stamp = f"@{when} +0000"
+        env["GIT_AUTHOR_DATE"] = stamp
+        env["GIT_COMMITTER_DATE"] = stamp
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+@unittest.skipUnless(shutil.which("git"), "git is required")
+class SourceDateTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_context = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_context.cleanup)
+        root = Path(self.temp_context.name)
+
+        self.sub = root / "sub"
+        self.sub.mkdir()
+        git("init", "-q", "-b", "main", cwd=self.sub)
+        git("config", "user.email", "t@e.st", cwd=self.sub)
+        git("config", "user.name", "Test", cwd=self.sub)
+        (self.sub / "f.txt").write_text("v1")
+        git("add", "f.txt", cwd=self.sub)
+        git("commit", "-q", "-m", "sub v1", cwd=self.sub, when=JAN_2026)
+
+        self.super = root / "super"
+        self.super.mkdir()
+        git("init", "-q", "-b", "main", cwd=self.super)
+        git("config", "user.email", "t@e.st", cwd=self.super)
+        git("config", "user.name", "Test", cwd=self.super)
+        (self.super / "README.md").write_text("top")
+        git("add", "README.md", cwd=self.super)
+        git("commit", "-q", "-m", "init", cwd=self.super, when=FEB_2026)
+        git(
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            str(self.sub),
+            "deps/sub",
+            cwd=self.super,
+        )
+        git("add", "-A", cwd=self.super)
+        git("commit", "-q", "-m", "pin sub", cwd=self.super, when=FEB_2026)
+
+        self.sub_checkout = self.super / "deps" / "sub"
+
+    # -- the states --------------------------------------------------------
+
+    def test_clean_tree_uses_the_superproject_commit(self):
+        # A submodule commit must exist before it can be pinned, so on a clean
+        # tree the superproject is already the newest and the max is a no-op.
+        self.assertEqual(compute_source_date_epoch(self.super), FEB_2026)
+
+    def test_submodule_past_its_pin_advances_the_timestamp(self):
+        (self.sub_checkout / "f.txt").write_text("v2")
+        git("add", "f.txt", cwd=self.sub_checkout)
+        git("commit", "-q", "-m", "sub v2", cwd=self.sub_checkout, when=JUN_2026)
+
+        entries = [e for e in submodule_entries(self.super) if e.differs_from_pin]
+        self.assertEqual([e.state for e in entries], ["+"])
+        self.assertEqual(compute_source_date_epoch(self.super), JUN_2026)
+
+    def test_dirty_submodule_worktree_advances_past_every_commit(self):
+        (self.sub_checkout / "f.txt").write_text("uncommitted")
+
+        # The commit still matches the pin, so this is invisible to
+        # `git submodule status` -- the dirty check is what catches it.
+        self.assertEqual([e.state for e in submodule_entries(self.super)], [" "])
+        self.assertTrue(is_worktree_dirty(self.super))
+        self.assertGreater(compute_source_date_epoch(self.super), JUN_2026)
+
+    def test_dirty_superproject_advances_past_every_commit(self):
+        (self.super / "README.md").write_text("edited")
+        self.assertTrue(is_worktree_dirty(self.super))
+        self.assertGreater(compute_source_date_epoch(self.super), FEB_2026)
+
+    def test_untracked_file_counts_as_dirty(self):
+        (self.super / "scratch.txt").write_text("scratch")
+        self.assertTrue(is_worktree_dirty(self.super))
+
+    def test_outside_a_git_checkout_falls_back_to_now(self):
+        with tempfile.TemporaryDirectory() as plain:
+            self.assertEqual(submodule_entries(Path(plain)), [])
+            self.assertFalse(is_worktree_dirty(Path(plain)))
+            self.assertGreater(compute_source_date_epoch(Path(plain)), FEB_2026)
+
+    # -- parsing -----------------------------------------------------------
+
+    def test_submodule_status_is_parsed(self):
+        (entry,) = submodule_entries(self.super)
+        self.assertEqual(entry.state, " ")
+        self.assertEqual(len(entry.sha), 40)
+        self.assertEqual(entry.path, self.sub_checkout)
+        self.assertTrue(entry.is_populated)
+        self.assertFalse(entry.differs_from_pin)
+
+    def test_uninitialized_submodule_is_skipped(self):
+        # No trailing "(describe)" field on these lines, and no checkout to ask.
+        shutil.rmtree(self.sub_checkout)
+        self.sub_checkout.mkdir()
+        (entry,) = submodule_entries(self.super)
+        self.assertEqual(entry.state, "-")
+        self.assertFalse(entry.is_populated)
+        self.assertEqual(entry.path, self.sub_checkout)
+
+    # -- environment plumbing ---------------------------------------------
+
+    def test_child_env_sets_only_the_namespaced_var_by_default(self):
+        env = source_date.child_env(repo_dir=self.super, base_env={})
+        self.assertEqual(env[source_date.ENV_VAR], str(FEB_2026))
+        self.assertNotIn(source_date.STANDARD_ENV_VAR, env)
+
+    def test_child_env_opt_in_also_exports_the_standard_var(self):
+        env = source_date.child_env(
+            export_standard_var=True, repo_dir=self.super, base_env={}
+        )
+        self.assertEqual(env[source_date.ENV_VAR], str(FEB_2026))
+        self.assertEqual(env[source_date.STANDARD_ENV_VAR], str(FEB_2026))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/tests/source_date_test.py
+++ b/build_tools/tests/source_date_test.py
@@ -144,6 +144,44 @@ class SourceDateTest(unittest.TestCase):
         self.assertFalse(entry.is_populated)
         self.assertEqual(entry.path, self.sub_checkout)
 
+    # -- the configure-time handoff ---------------------------------------
+
+    def test_build_dir_value_is_preferred_over_recomputing(self):
+        # CMake resolved this at configure time; tools running later must agree
+        # with the build rather than resolve it again.
+        build_dir = self.super / "build"
+        build_dir.mkdir()
+        (build_dir / source_date.STAMP_FILE_NAME).write_text("1700000000\n")
+        self.assertEqual(
+            source_date.resolve(build_dir=build_dir, repo_dir=self.super),
+            1700000000,
+        )
+
+    def test_a_dirty_tree_does_not_override_the_build_dir_value(self):
+        # Otherwise a developer's archives would drift from the build they came
+        # from every time they touched a file.
+        build_dir = self.super / "build"
+        build_dir.mkdir()
+        (build_dir / source_date.STAMP_FILE_NAME).write_text("1700000000\n")
+        (self.super / "README.md").write_text("edited")
+        self.assertEqual(
+            source_date.resolve(build_dir=build_dir, repo_dir=self.super),
+            1700000000,
+        )
+
+    def test_missing_build_dir_value_falls_back_to_computing(self):
+        self.assertEqual(
+            source_date.resolve(build_dir=self.super / "nope", repo_dir=self.super),
+            FEB_2026,
+        )
+
+    def test_unparseable_build_dir_value_is_rejected(self):
+        build_dir = self.super / "build"
+        build_dir.mkdir()
+        (build_dir / source_date.STAMP_FILE_NAME).write_text("not-a-timestamp")
+        with self.assertRaisesRegex(ValueError, "does not contain a timestamp"):
+            source_date.resolve(build_dir=build_dir, repo_dir=self.super)
+
     # -- environment plumbing ---------------------------------------------
 
     def test_child_env_sets_only_the_namespaced_var_by_default(self):

--- a/build_tools/tests/source_date_test.py
+++ b/build_tools/tests/source_date_test.py
@@ -11,6 +11,7 @@ submodule whose working tree is dirty but whose commit still matches the pin
 reports ' ', not '+'.
 """
 
+import json
 import os
 import shutil
 import subprocess
@@ -198,6 +199,99 @@ class SourceDateTest(unittest.TestCase):
         self.assertEqual(entry.state, "-")
         self.assertFalse(entry.is_populated)
         self.assertEqual(entry.path, self.sub_checkout)
+
+    # -- the manifest handoff ---------------------------------------------
+
+    def _write_manifest(self, root: Path, **fields) -> Path:
+        """Writes a manifest in the flattened artifact layout."""
+        manifest = {
+            "the_rock_commit": "a" * 40,
+            "source_date_epoch": DEC_2026,
+            "source_dirty": False,
+            "submodules": [],
+        }
+        manifest.update(fields)
+        path = root / "share" / "therock" / "therock_manifest.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(manifest))
+        return path
+
+    def test_manifest_timestamp_is_preferred_over_this_checkout(self):
+        # The artifacts were built elsewhere; their recorded value is the one
+        # that describes them.
+        artifacts = Path(self.temp_context.name) / "artifacts"
+        self._write_manifest(artifacts)
+        self.assertEqual(
+            source_date.resolve(manifest_dir=artifacts, repo_dir=self.super),
+            DEC_2026,
+        )
+
+    def test_exploded_artifact_layout_is_found_too(self):
+        artifacts = Path(self.temp_context.name) / "exploded"
+        path = artifacts / source_date.MANIFEST_RELPATHS[0]
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps({"source_date_epoch": JUN_2026}))
+        self.assertEqual(source_date.timestamp_from_manifest(artifacts), JUN_2026)
+
+    def test_missing_manifest_falls_back_to_this_checkout(self):
+        empty = Path(self.temp_context.name) / "empty"
+        empty.mkdir()
+        self.assertIsNone(source_date.timestamp_from_manifest(empty))
+        self.assertEqual(
+            source_date.resolve(manifest_dir=empty, repo_dir=self.super), FEB_2026
+        )
+
+    def test_manifest_without_the_field_falls_back(self):
+        # Artifacts built before the field existed, or with no git metadata.
+        artifacts = Path(self.temp_context.name) / "old"
+        self._write_manifest(artifacts, source_date_epoch=None)
+        self.assertIsNone(source_date.timestamp_from_manifest(artifacts))
+        self.assertEqual(
+            source_date.resolve(manifest_dir=artifacts, repo_dir=self.super), FEB_2026
+        )
+
+    # -- drift ------------------------------------------------------------
+
+    def test_matching_commit_and_clean_trees_report_no_drift(self):
+        head = git("rev-parse", "HEAD", cwd=self.super).strip()
+        artifacts = Path(self.temp_context.name) / "matching"
+        self._write_manifest(artifacts, the_rock_commit=head)
+        self.assertEqual(source_date.describe_source_drift(artifacts, self.super), [])
+
+    def test_a_different_commit_is_reported(self):
+        artifacts = Path(self.temp_context.name) / "other_run"
+        self._write_manifest(artifacts, the_rock_commit="b" * 40)
+        reasons = source_date.describe_source_drift(artifacts, self.super)
+        self.assertTrue(any("but this checkout is at" in r for r in reasons))
+
+    def test_artifacts_built_dirty_are_reported(self):
+        head = git("rev-parse", "HEAD", cwd=self.super).strip()
+        artifacts = Path(self.temp_context.name) / "built_dirty"
+        self._write_manifest(artifacts, the_rock_commit=head, source_dirty=True)
+        reasons = source_date.describe_source_drift(artifacts, self.super)
+        self.assertTrue(any("uncommitted changes" in r for r in reasons))
+
+    def test_a_missing_manifest_is_itself_drift(self):
+        empty = Path(self.temp_context.name) / "nothing"
+        empty.mkdir()
+        reasons = source_date.describe_source_drift(empty, self.super)
+        self.assertTrue(any("no therock_manifest.json" in r for r in reasons))
+
+    def test_fail_on_drift_raises_and_otherwise_only_warns(self):
+        artifacts = Path(self.temp_context.name) / "drifted"
+        self._write_manifest(artifacts, the_rock_commit="c" * 40)
+
+        warnings = []
+        value = source_date.resolve_checked(
+            manifest_dir=artifacts, repo_dir=self.super, report=warnings.append
+        )
+        self.assertEqual(value, DEC_2026)
+        self.assertTrue(warnings)
+
+        with self.assertRaisesRegex(RuntimeError, "drift"):
+            source_date.resolve_checked(
+                manifest_dir=artifacts, repo_dir=self.super, fail_on_drift=True
+            )
 
     # -- environment plumbing ---------------------------------------------
 

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1461,6 +1461,21 @@ function(_therock_cmake_subproject_build_env_pairs out_var)
   list(APPEND _build_env_pairs "--unset=HIP_PATH")
   list(APPEND _build_env_pairs "--unset=HIP_DIR")
 
+  # The source timestamp for reproducible archives, resolved once at configure
+  # time. Exported to every subproject so that any tool a build invokes agrees
+  # on it, not just the ones that write artifact archives.
+  if(THEROCK_SOURCE_DATE_EPOCH)
+    list(APPEND _build_env_pairs
+      "THEROCK_SOURCE_DATE_EPOCH=${THEROCK_SOURCE_DATE_EPOCH}")
+    # Opt-in only: SOURCE_DATE_EPOCH is honored by compilers, CPython and
+    # setuptools, so exporting it changes far more than archive metadata.
+    # See docs/development/reproducible_archives.md.
+    if(THEROCK_EXPORT_SOURCE_DATE_EPOCH)
+      list(APPEND _build_env_pairs
+        "SOURCE_DATE_EPOCH=${THEROCK_SOURCE_DATE_EPOCH}")
+    endif()
+  endif()
+
   set("${out_var}" "${_build_env_pairs}" PARENT_SCOPE)
 endfunction()
 

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1473,7 +1473,15 @@ function(_therock_cmake_subproject_build_env_pairs out_var)
   #
   # Under the opt-in that rebuild is the honest price of asking the compilers
   # themselves to be reproducible. See docs/development/reproducible_archives.md.
-  if(THEROCK_EXPORT_SOURCE_DATE_EPOCH AND THEROCK_SOURCE_DATE_EPOCH)
+  # The empty test rather than if(THEROCK_SOURCE_DATE_EPOCH): the latter is
+  # false for "0", which would drop a deliberate epoch-zero override.
+  if(THEROCK_EXPORT_SOURCE_DATE_EPOCH)
+    if("${THEROCK_SOURCE_DATE_EPOCH}" STREQUAL "")
+      message(FATAL_ERROR
+        "THEROCK_EXPORT_SOURCE_DATE_EPOCH is enabled but "
+        "THEROCK_SOURCE_DATE_EPOCH is empty, so there is nothing to export. "
+        "This is normally resolved by the top-level CMakeLists.txt.")
+    endif()
     list(APPEND _build_env_pairs
       "SOURCE_DATE_EPOCH=${THEROCK_SOURCE_DATE_EPOCH}")
   endif()

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1461,27 +1461,18 @@ function(_therock_cmake_subproject_build_env_pairs out_var)
   list(APPEND _build_env_pairs "--unset=HIP_PATH")
   list(APPEND _build_env_pairs "--unset=HIP_DIR")
 
-  # Opt-in only, and deliberately nothing here by default.
+  # Opt-in only, and deliberately empty by default.
   #
   # Anything added to this list lands verbatim in the `cmake -E env` prefix of
   # every subproject's configure and build command, and ninja re-runs a command
-  # whose text changed. A timestamp here would therefore rebuild the entire tree
-  # every time it moved -- on every commit, and on every edit to a dirty tree.
-  # Nothing in the build graph needs it: archives are written by
-  # artifact_manager.py, outside the graph, which reads
-  # <build_dir>/therock_source_date_epoch.txt instead.
+  # whose text changed. So a timestamp here rebuilds the whole tree whenever it
+  # moves. Nothing in the build graph needs one -- archives are written after
+  # the build, by tools that resolve their own -- which is why this is off
+  # unless THEROCK_SOURCE_DATE_EPOCH was set explicitly.
   #
-  # Under the opt-in that rebuild is the honest price of asking the compilers
-  # themselves to be reproducible. See docs/development/reproducible_archives.md.
-  # The empty test rather than if(THEROCK_SOURCE_DATE_EPOCH): the latter is
-  # false for "0", which would drop a deliberate epoch-zero override.
-  if(THEROCK_EXPORT_SOURCE_DATE_EPOCH)
-    if("${THEROCK_SOURCE_DATE_EPOCH}" STREQUAL "")
-      message(FATAL_ERROR
-        "THEROCK_EXPORT_SOURCE_DATE_EPOCH is enabled but "
-        "THEROCK_SOURCE_DATE_EPOCH is empty, so there is nothing to export. "
-        "This is normally resolved by the top-level CMakeLists.txt.")
-    endif()
+  # Compared against the empty string rather than if(THEROCK_SOURCE_DATE_EPOCH):
+  # the latter is false for "0" and would drop a deliberate epoch-zero value.
+  if(NOT "${THEROCK_SOURCE_DATE_EPOCH}" STREQUAL "")
     list(APPEND _build_env_pairs
       "SOURCE_DATE_EPOCH=${THEROCK_SOURCE_DATE_EPOCH}")
   endif()

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1461,19 +1461,21 @@ function(_therock_cmake_subproject_build_env_pairs out_var)
   list(APPEND _build_env_pairs "--unset=HIP_PATH")
   list(APPEND _build_env_pairs "--unset=HIP_DIR")
 
-  # The source timestamp for reproducible archives, resolved once at configure
-  # time. Exported to every subproject so that any tool a build invokes agrees
-  # on it, not just the ones that write artifact archives.
-  if(THEROCK_SOURCE_DATE_EPOCH)
+  # Opt-in only, and deliberately nothing here by default.
+  #
+  # Anything added to this list lands verbatim in the `cmake -E env` prefix of
+  # every subproject's configure and build command, and ninja re-runs a command
+  # whose text changed. A timestamp here would therefore rebuild the entire tree
+  # every time it moved -- on every commit, and on every edit to a dirty tree.
+  # Nothing in the build graph needs it: archives are written by
+  # artifact_manager.py, outside the graph, which reads
+  # <build_dir>/therock_source_date_epoch.txt instead.
+  #
+  # Under the opt-in that rebuild is the honest price of asking the compilers
+  # themselves to be reproducible. See docs/development/reproducible_archives.md.
+  if(THEROCK_EXPORT_SOURCE_DATE_EPOCH AND THEROCK_SOURCE_DATE_EPOCH)
     list(APPEND _build_env_pairs
-      "THEROCK_SOURCE_DATE_EPOCH=${THEROCK_SOURCE_DATE_EPOCH}")
-    # Opt-in only: SOURCE_DATE_EPOCH is honored by compilers, CPython and
-    # setuptools, so exporting it changes far more than archive metadata.
-    # See docs/development/reproducible_archives.md.
-    if(THEROCK_EXPORT_SOURCE_DATE_EPOCH)
-      list(APPEND _build_env_pairs
-        "SOURCE_DATE_EPOCH=${THEROCK_SOURCE_DATE_EPOCH}")
-    endif()
+      "SOURCE_DATE_EPOCH=${THEROCK_SOURCE_DATE_EPOCH}")
   endif()
 
   set("${out_var}" "${_build_env_pairs}" PARENT_SCOPE)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -13,6 +13,7 @@
 - [Dependencies](dependencies.md)
 - [Development Guide](development_guide.md)
 - [Installing Artifacts](installing_artifacts.md)
+- [Reproducible Archives](reproducible_archives.md)
 - [Sanitizers](sanitizers.md)
 
 ### Testing

--- a/docs/development/build_system.md
+++ b/docs/development/build_system.md
@@ -176,27 +176,41 @@ cmake -B build -DTHEROCK_SOURCE_DATE_EPOCH=1700000000 ...
 ```
 
 Resolving it costs several git invocations and every tool that writes an archive
-must agree on it, so it is resolved once here rather than by each tool. It
-reaches them two ways:
+must agree on it, so it is resolved once here rather than by each tool. It is
+written to `<build_dir>/therock_source_date_epoch.txt`, and tools read it from
+there — `artifact_manager.py push --build-dir` compresses artifacts long after
+CMake has finished.
 
-- Exported as `THEROCK_SOURCE_DATE_EPOCH` into every subproject build
-  environment, so any tool the build invokes sees it.
-- Written to `<build_dir>/therock_source_date_epoch.txt`, for tools that run
-  outside the build graph. `artifact_manager.py push --build-dir` compresses
-  artifacts long after CMake has finished and reads it from there.
+It is deliberately **not** put into the subproject build environment. Anything
+added there lands in the `cmake -E env` prefix of every subproject's configure
+and build command, and ninja re-runs a command whose text changed — so a
+timestamp would rebuild the whole tree every time it moved. Nothing in the build
+graph needs it.
 
 ### `THEROCK_EXPORT_SOURCE_DATE_EPOCH`
 
-Off by default. When on, the same value is also exported as the standard
-`SOURCE_DATE_EPOCH`.
+Off by default. When on, the value is exported as the standard
+`SOURCE_DATE_EPOCH` into every subproject configure and build.
 
 > [!WARNING]
-> `SOURCE_DATE_EPOCH` is a cross-ecosystem convention that many tools honor
-> automatically, so this reaches much further than archive metadata: GCC and
-> Clang rewrite `__DATE__`/`__TIME__` in every translation unit, CPython
-> switches `.pyc` files to checked-hash invalidation, and setuptools uses it for
-> zip entry timestamps. That is usually what a fully reproducible build wants,
-> but it is a deliberate choice, which is why TheRock does not do it by default.
+> This rebuilds the tree whenever the timestamp changes, for the reason above,
+> and `SOURCE_DATE_EPOCH` is honored by far more than archive tooling. In this
+> repository the changes that actually land are:
+>
+> - CMake's `string(TIMESTAMP)` is pinned. Most sites are cosmetic copyright
+>   years, but `ROCKE_ENGINE_VERSION` (`rocke/platform/CMakeLists.txt`) embeds a
+>   build date into a shipped version string *on purpose*, to keep successive
+>   builds distinguishable. Pinning it is a behavior change for that component.
+> - Doxygen `HTML_TIMESTAMP`/`LATEX_TIMESTAMP` output is pinned, including the
+>   hip docs target that `clr/hipamd/packaging` runs as part of `ALL`.
+> - setuptools uses it for zip entry timestamps.
+> - GCC/Clang rewrite `__DATE__`/`__TIME__`. Near-harmless here: `rocm-systems`
+>   has no real uses, and the handful in `rocm-libraries` and `openmp` are all
+>   behind default-off flags.
+> - binutils' `ar.exp` test *requires the variable to be unset* and will fail if
+>   rocgdb's test suite runs with it exported.
+> - It does **not** help `rccl`'s Debian/RPM changelog dates, which shell out to
+>   `date -R` and ignore it.
 
 See [Reproducible Archives](reproducible_archives.md) for the full picture.
 

--- a/docs/development/build_system.md
+++ b/docs/development/build_system.md
@@ -163,38 +163,30 @@ Subprojects that opt in to source file globbing even when otherwise skipped
 
 ### `THEROCK_SOURCE_DATE_EPOCH`
 
-The Unix timestamp stamped into artifact archives so that identical content
-produces an identical archive hash. Resolved at configure time from the source
-state (superproject `HEAD`, plus any submodule checked out past its pin, plus
-the current time if the tree is dirty), and reported as
-`-- Source timestamp: <value>`.
-
-Set it explicitly to pin the value:
+Empty by default. When set to a Unix timestamp, it is exported as
+`SOURCE_DATE_EPOCH` to every subproject configure and build:
 
 ```bash
 cmake -B build -DTHEROCK_SOURCE_DATE_EPOCH=1700000000 ...
 ```
 
-Resolving it costs several git invocations and every tool that writes an archive
-must agree on it, so it is resolved once here rather than by each tool. It is
-written to `<build_dir>/therock_source_date_epoch.txt`, and tools read it from
-there — `artifact_manager.py push --build-dir` compresses artifacts long after
-CMake has finished.
+Setting it *is* the opt-in — there is no separate switch, because exporting is
+the only thing the build does with a timestamp. The build itself writes no
+archives; the tools that do run afterwards and resolve their own value from the
+source state at that moment, so nothing is derived here. Deriving it at
+configure would only freeze a value that goes stale as soon as anything is
+pulled.
 
-It is deliberately **not** put into the subproject build environment. Anything
-added there lands in the `cmake -E env` prefix of every subproject's configure
-and build command, and ninja re-runs a command whose text changed — so a
-timestamp would rebuild the whole tree every time it moved. Nothing in the build
-graph needs it.
+To pin the build to the current source state:
 
-### `THEROCK_EXPORT_SOURCE_DATE_EPOCH`
-
-Off by default. When on, the value is exported as the standard
-`SOURCE_DATE_EPOCH` into every subproject configure and build.
+```bash
+cmake -B build -DTHEROCK_SOURCE_DATE_EPOCH=$(python build_tools/_therock_utils/source_date.py) ...
+```
 
 > [!WARNING]
-> This rebuilds the tree whenever the timestamp changes, for the reason above,
-> and `SOURCE_DATE_EPOCH` is honored by far more than archive tooling. In this
+> This rebuilds the tree whenever the value changes — it lands in every
+> subproject's build command, and ninja re-runs a command whose text changed.
+> `SOURCE_DATE_EPOCH` is also honored by far more than archive tooling. In this
 > repository the changes that actually land are:
 >
 > - CMake's `string(TIMESTAMP)` is pinned. Most sites are cosmetic copyright

--- a/docs/development/build_system.md
+++ b/docs/development/build_system.md
@@ -161,6 +161,45 @@ Each sub-project, by default, uses a standard directory layout for its build:
 Subprojects that opt in to source file globbing even when otherwise skipped
 (e.g. `-DTHEROCK_DEV_PROJECTS=amd-llvm`).
 
+### `THEROCK_SOURCE_DATE_EPOCH`
+
+The Unix timestamp stamped into artifact archives so that identical content
+produces an identical archive hash. Resolved at configure time from the source
+state (superproject `HEAD`, plus any submodule checked out past its pin, plus
+the current time if the tree is dirty), and reported as
+`-- Source timestamp: <value>`.
+
+Set it explicitly to pin the value:
+
+```bash
+cmake -B build -DTHEROCK_SOURCE_DATE_EPOCH=1700000000 ...
+```
+
+Resolving it costs several git invocations and every tool that writes an archive
+must agree on it, so it is resolved once here rather than by each tool. It
+reaches them two ways:
+
+- Exported as `THEROCK_SOURCE_DATE_EPOCH` into every subproject build
+  environment, so any tool the build invokes sees it.
+- Written to `<build_dir>/therock_source_date_epoch.txt`, for tools that run
+  outside the build graph. `artifact_manager.py push --build-dir` compresses
+  artifacts long after CMake has finished and reads it from there.
+
+### `THEROCK_EXPORT_SOURCE_DATE_EPOCH`
+
+Off by default. When on, the same value is also exported as the standard
+`SOURCE_DATE_EPOCH`.
+
+> [!WARNING]
+> `SOURCE_DATE_EPOCH` is a cross-ecosystem convention that many tools honor
+> automatically, so this reaches much further than archive metadata: GCC and
+> Clang rewrite `__DATE__`/`__TIME__` in every translation unit, CPython
+> switches `.pyc` files to checked-hash invalidation, and setuptools uses it for
+> zip entry timestamps. That is usually what a fully reproducible build wants,
+> but it is a deliberate choice, which is why TheRock does not do it by default.
+
+See [Reproducible Archives](reproducible_archives.md) for the full picture.
+
 ## Developer Cookbook
 
 TheRock aims to not just be a CI tool but to be a daily driver for developer

--- a/docs/development/reproducible_archives.md
+++ b/docs/development/reproducible_archives.md
@@ -41,10 +41,20 @@ python build_tools/_therock_utils/source_date.py --explain
 1. Plus the current time if anything is uncommitted. Archives from a dirty tree
    are not reproducible, which is inherent rather than a limitation here.
 
-Orchestrators resolve this **once** — `artifact_manager.py push` and
-`build_python_packages.py` — because it costs several git invocations and every
-writer must agree on the value. They hand it to workers in
-`THEROCK_SOURCE_DATE_EPOCH`.
+This is resolved **once**, at CMake configure time, because it costs several git
+invocations and every writer must agree on the value. See
+[`THEROCK_SOURCE_DATE_EPOCH`](build_system.md#therock_source_date_epoch) for the
+build option. It reaches tools two ways:
+
+- Exported as `THEROCK_SOURCE_DATE_EPOCH` into every subproject build
+  environment, so any tool a build invokes sees it — not only the ones that
+  write archives.
+- Written to `<build_dir>/therock_source_date_epoch.txt` for tools that run
+  outside the build graph. `artifact_manager.py push --build-dir` reads it from
+  there, since it compresses artifacts long after CMake has finished.
+
+Tools run with no configured build tree at all (a direct `fileset_tool` call)
+fall back to resolving it themselves.
 
 Consequence worth knowing: a docs-only commit advances the timestamp for every
 artifact, so archive hashes change even when content is byte-identical. That is
@@ -72,17 +82,18 @@ Those are usually what you want from a fully reproducible build, but they are a
 much wider change than stamping archive metadata, and they apply to code TheRock
 builds rather than to TheRock itself.
 
-To opt in:
+To opt in, at configure time for the build itself:
+
+```bash
+cmake -B build -DTHEROCK_EXPORT_SOURCE_DATE_EPOCH=ON ...
+```
+
+or for the archiving and packaging steps, which run outside the build graph:
 
 ```bash
 python build_tools/artifact_manager.py push --export-source-date-epoch ...
 python build_tools/build_python_packages.py --export-source-date-epoch ...
 ```
-
-That sets `SOURCE_DATE_EPOCH` for child processes in addition to
-`THEROCK_SOURCE_DATE_EPOCH`. Note this only covers the archiving and packaging
-steps; making the compile itself reproducible means setting it for the CMake
-build too, which is a separate decision.
 
 ## What this does not do
 

--- a/docs/development/reproducible_archives.md
+++ b/docs/development/reproducible_archives.md
@@ -43,20 +43,16 @@ python build_tools/_therock_utils/source_date.py --explain
    same value every time it is asked. Everything is combined with `max()`, so a
    file touched to an old date cannot drag the result back before its commit.
 
-This is resolved **once**, at CMake configure time, because it costs several git
-invocations and every writer must agree on the value. See
-[`THEROCK_SOURCE_DATE_EPOCH`](build_system.md#therock_source_date_epoch) for the
-build option. CMake writes it to `<build_dir>/therock_source_date_epoch.txt`,
-and tools read it from there — `artifact_manager.py push --build-dir` compresses
-artifacts long after CMake has finished.
+Each tool that writes archives resolves this **once at its own entry** —
+`artifact_manager.py push`, `build_python_packages.py`, `build_tarballs.py` —
+and passes it to everything it spawns. That is deliberate: these run *after* the
+build, so resolving there describes the source being packaged. Resolving at
+CMake configure instead would freeze a value that goes stale as soon as anything
+is pulled, and the build writes no archives of its own.
 
-It is deliberately kept out of the subproject build environment: it would land
-in every subproject's ninja command line, and ninja re-runs a command whose text
-changed, so the whole tree would rebuild every time the timestamp moved. Nothing
-in the build graph writes archives.
-
-Tools run with no configured build tree at all (a direct `fileset_tool` call)
-fall back to resolving it themselves.
+The build can still be pinned, via
+[`THEROCK_SOURCE_DATE_EPOCH`](build_system.md#therock_source_date_epoch), but
+that is a separate opt-in concerned with making the *compilers* reproducible.
 
 Consequence worth knowing: a docs-only commit advances the timestamp for every
 artifact, so archive hashes change even when content is byte-identical. That is
@@ -83,13 +79,13 @@ it changes far more than archive metadata:
 | CPython                   | `.pyc` invalidation switches to checked-hash. No component byte-compiles during the build, so this only matters at `pip install` time                                         |
 | `rccl` changelog          | **Not** affected — shells out to `date -R`, which ignores the variable                                                                                                        |
 
-Also note that turning it on puts the value in every subproject's build command,
-so the tree rebuilds whenever the timestamp moves.
+Also note that pinning the build puts the value in every subproject's build
+command, so the tree rebuilds whenever it changes.
 
 To opt in, at configure time for the build itself:
 
 ```bash
-cmake -B build -DTHEROCK_EXPORT_SOURCE_DATE_EPOCH=ON ...
+cmake -B build -DTHEROCK_SOURCE_DATE_EPOCH=$(python build_tools/_therock_utils/source_date.py) ...
 ```
 
 or for the archiving and packaging steps, which run outside the build graph:

--- a/docs/development/reproducible_archives.md
+++ b/docs/development/reproducible_archives.md
@@ -1,0 +1,98 @@
+# Reproducible archives
+
+TheRock's artifact archives are byte-reproducible: the same source, built twice,
+produces the same `.tar.zst`. This lets the same generic artifact be uploaded
+from parallel CI jobs without one silently overwriting the other with different
+content (see [#4202](https://github.com/ROCm/TheRock/issues/4202)).
+
+Two things would otherwise vary between builds of identical content:
+
+- **Member order.** Filesystem iteration order is not stable, so members are
+  added sorted.
+- **Member metadata.** `tar` records the build time and the building user's
+  uid/gid. These are replaced by `normalize_tarinfo()` in
+  [`build_tools/_therock_utils/archive_util.py`](../../build_tools/_therock_utils/archive_util.py).
+
+Permissions, sizes, symlink targets and hardlink identity are preserved.
+
+## The timestamp
+
+Every member gets the same mtime, resolved from the source rather than the
+clock. It is deliberately **not** zero: extraction restores mtime — Python's
+`tarfile.extract()`, `extractall(filter="tar")`, `extractall(filter="data")` and
+`tar -x` all do, for root and non-root alike — so an epoch timestamp would reach
+installed SDKs and make freshly upgraded headers look older than objects a
+downstream project already built against the previous version. Timestamp-driven
+build systems would then skip work that needed doing.
+
+`build_tools/_therock_utils/source_date.py` resolves it:
+
+```bash
+python build_tools/_therock_utils/source_date.py --explain
+```
+
+1. TheRock's `HEAD` commit time. The superproject pins every submodule, so its
+   HEAD identifies the whole source state. An artifact has no single source
+   submodule to attribute to: a merged `dist/` tree spans a subproject plus its
+   runtime deps, and several subprojects (zlib, zstd, bzip2, elfutils) are
+   tarballs downloaded from S3 with no git history at all.
+1. Plus the `HEAD` time of any submodule checked out past its pin, which is
+   normal when developing against subproject sources in place.
+1. Plus the current time if anything is uncommitted. Archives from a dirty tree
+   are not reproducible, which is inherent rather than a limitation here.
+
+Orchestrators resolve this **once** — `artifact_manager.py push` and
+`build_python_packages.py` — because it costs several git invocations and every
+writer must agree on the value. They hand it to workers in
+`THEROCK_SOURCE_DATE_EPOCH`.
+
+Consequence worth knowing: a docs-only commit advances the timestamp for every
+artifact, so archive hashes change even when content is byte-identical. That is
+fine for detecting conflicting uploads within a run, but archive hashes cannot
+be used to dedupe across commits.
+
+## `SOURCE_DATE_EPOCH` and its blast radius
+
+`SOURCE_DATE_EPOCH` is honored, and outranks `THEROCK_SOURCE_DATE_EPOCH` — if it
+is set, someone decided that deliberately.
+
+TheRock does **not** set it for you, and that is on purpose. It is a
+cross-ecosystem convention that many tools pick up automatically, so exporting
+it changes far more than archive metadata:
+
+| Tool              | What changes                                                                                          |
+| ----------------- | ----------------------------------------------------------------------------------------------------- |
+| GCC, Clang        | `__DATE__` and `__TIME__` are rewritten in every translation unit                                     |
+| CPython           | `.pyc` files switch from timestamp to checked-hash invalidation, changing bytes shipped inside wheels |
+| setuptools, wheel | zip entry timestamps                                                                                  |
+| `dpkg-deb`        | tar entry mtimes are clamped to it (it never raises older ones)                                       |
+| Sphinx, Doxygen   | generated copyright/date strings                                                                      |
+
+Those are usually what you want from a fully reproducible build, but they are a
+much wider change than stamping archive metadata, and they apply to code TheRock
+builds rather than to TheRock itself.
+
+To opt in:
+
+```bash
+python build_tools/artifact_manager.py push --export-source-date-epoch ...
+python build_tools/build_python_packages.py --export-source-date-epoch ...
+```
+
+That sets `SOURCE_DATE_EPOCH` for child processes in addition to
+`THEROCK_SOURCE_DATE_EPOCH`. Note this only covers the archiving and packaging
+steps; making the compile itself reproducible means setting it for the CMake
+build too, which is a separate decision.
+
+## What this does not do
+
+Reproducibility and timestamp-based rebuild correctness want opposite things
+from a single mtime field, and no stored value satisfies both. A source commit
+date can still predate a user's earlier build — a release branch cut weeks
+before publication, or a user moving from a newer nightly to an older stable
+release — in which case installed headers still look older than their existing
+objects.
+
+Guaranteeing *"a newly installed SDK file is newer than anything built against
+the previous one"* requires re-stamping at install time, per distribution
+channel. That is not done today.

--- a/docs/development/reproducible_archives.md
+++ b/docs/development/reproducible_archives.md
@@ -50,6 +50,23 @@ build, so resolving there describes the source being packaged. Resolving at
 CMake configure instead would freeze a value that goes stale as soon as anything
 is pulled, and the build writes no archives of its own.
 
+They prefer `source_date_epoch` from `therock_manifest.json`, which the build
+records and ships inside `base_lib_generic`. That is the only value that
+survives the jump between jobs: packaging runs on a different runner and may be
+pointed at another run's artifacts, so re-deriving locally would describe the
+*packaging* checkout instead. Deriving is the fallback for artifacts that carry
+no manifest, or one predating the field.
+
+Alongside it the build records `source_dirty`, because everything else in that
+manifest (`the_rock_commit`, each `pin_sha`) is read from the committed object
+graph and cannot show uncommitted work.
+
+Each packaging step reports when the artifacts disagree with its own checkout —
+a different commit, a build from a dirty tree, a dirty packaging checkout, or no
+manifest at all. It warns by default, since packaging another run's artifacts is
+supported; `--fail-on-source-drift` makes it an error, which is what a release
+build wants.
+
 The build can still be pinned, via
 [`THEROCK_SOURCE_DATE_EPOCH`](build_system.md#therock_source_date_epoch), but
 that is a separate opt-in concerned with making the *compilers* reproducible.

--- a/docs/development/reproducible_archives.md
+++ b/docs/development/reproducible_archives.md
@@ -95,6 +95,19 @@ python build_tools/artifact_manager.py push --export-source-date-epoch ...
 python build_tools/build_python_packages.py --export-source-date-epoch ...
 ```
 
+The wheel workflows expose it as an `export_source_date_epoch` input, off by
+default, on both `workflow_dispatch` and `workflow_call`:
+
+- `.github/workflows/build_portable_linux_python_packages.yml`
+- `.github/workflows/build_windows_python_packages.yml`
+
+This is the one place where opting in is doing more than hardening metadata.
+`archive_util` only writes the `_devel.tar.xz` **inside** the
+`rocm-sdk-devel` wheel; the `.whl` zip itself and the `rocm` sdist are produced
+by `setup.py bdist_wheel`/`sdist`, and setuptools only makes them reproducible
+when `SOURCE_DATE_EPOCH` is set. That path compiles nothing, so most of the
+blast radius above does not apply to it.
+
 ## What this does not do
 
 Reproducibility and timestamp-based rebuild correctness want opposite things

--- a/docs/development/reproducible_archives.md
+++ b/docs/development/reproducible_archives.md
@@ -38,20 +38,22 @@ python build_tools/_therock_utils/source_date.py --explain
    tarballs downloaded from S3 with no git history at all.
 1. Plus the `HEAD` time of any submodule checked out past its pin, which is
    normal when developing against subproject sources in place.
-1. Plus the current time if anything is uncommitted. Archives from a dirty tree
-   are not reproducible, which is inherent rather than a limitation here.
+1. Plus the mtime of the most recently touched uncommitted file, if the tree is
+   dirty — not the current time, so that an untouched dirty tree resolves to the
+   same value every time it is asked. Everything is combined with `max()`, so a
+   file touched to an old date cannot drag the result back before its commit.
 
 This is resolved **once**, at CMake configure time, because it costs several git
 invocations and every writer must agree on the value. See
 [`THEROCK_SOURCE_DATE_EPOCH`](build_system.md#therock_source_date_epoch) for the
-build option. It reaches tools two ways:
+build option. CMake writes it to `<build_dir>/therock_source_date_epoch.txt`,
+and tools read it from there — `artifact_manager.py push --build-dir` compresses
+artifacts long after CMake has finished.
 
-- Exported as `THEROCK_SOURCE_DATE_EPOCH` into every subproject build
-  environment, so any tool a build invokes sees it — not only the ones that
-  write archives.
-- Written to `<build_dir>/therock_source_date_epoch.txt` for tools that run
-  outside the build graph. `artifact_manager.py push --build-dir` reads it from
-  there, since it compresses artifacts long after CMake has finished.
+It is deliberately kept out of the subproject build environment: it would land
+in every subproject's ninja command line, and ninja re-runs a command whose text
+changed, so the whole tree would rebuild every time the timestamp moved. Nothing
+in the build graph writes archives.
 
 Tools run with no configured build tree at all (a direct `fileset_tool` call)
 fall back to resolving it themselves.
@@ -70,17 +72,19 @@ TheRock does **not** set it for you, and that is on purpose. It is a
 cross-ecosystem convention that many tools pick up automatically, so exporting
 it changes far more than archive metadata:
 
-| Tool              | What changes                                                                                          |
-| ----------------- | ----------------------------------------------------------------------------------------------------- |
-| GCC, Clang        | `__DATE__` and `__TIME__` are rewritten in every translation unit                                     |
-| CPython           | `.pyc` files switch from timestamp to checked-hash invalidation, changing bytes shipped inside wheels |
-| setuptools, wheel | zip entry timestamps                                                                                  |
-| `dpkg-deb`        | tar entry mtimes are clamped to it (it never raises older ones)                                       |
-| Sphinx, Doxygen   | generated copyright/date strings                                                                      |
+| Tool                      | What changes here                                                                                                                                                             |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CMake `string(TIMESTAMP)` | Pinned. Mostly cosmetic copyright years, but `ROCKE_ENGINE_VERSION` embeds a build date into a shipped version string deliberately, to keep successive builds distinguishable |
+| Doxygen                   | `HTML_TIMESTAMP`/`LATEX_TIMESTAMP` pinned, including the hip docs target `clr/hipamd/packaging` runs in `ALL`                                                                 |
+| setuptools, wheel         | zip entry timestamps — see below, this is the one place opting in is load-bearing                                                                                             |
+| GCC, Clang                | `__DATE__`/`__TIME__` rewritten. Near-harmless: `rocm-systems` has no real uses; those in `rocm-libraries` and `openmp` sit behind default-off flags                          |
+| binutils                  | `ar.exp` **requires the variable to be unset** and fails if rocgdb's tests run with it exported                                                                               |
+| `dpkg-deb`                | Clamps tar mtimes downward only, so it never repairs a stale timestamp                                                                                                        |
+| CPython                   | `.pyc` invalidation switches to checked-hash. No component byte-compiles during the build, so this only matters at `pip install` time                                         |
+| `rccl` changelog          | **Not** affected — shells out to `date -R`, which ignores the variable                                                                                                        |
 
-Those are usually what you want from a fully reproducible build, but they are a
-much wider change than stamping archive metadata, and they apply to code TheRock
-builds rather than to TheRock itself.
+Also note that turning it on puts the value in every subproject's build command,
+so the tree rebuilds whenever the timestamp moves.
 
 To opt in, at configure time for the build itself:
 


### PR DESCRIPTION
## Motivation

Part of #4202.

Artifacts uploaded to S3 should never silently overwrite a different artifact at the same key. That
check has to be SHA-based, which only works if identical content reliably produces an identical
archive — and today it does not. `tar` records the build time and the building user's uid/gid, and
members were added in filesystem iteration order, so the same artifact built twice got two different
SHA256s. #4202 cannot distinguish "same artifact, rebuilt" from "different content, same key" until
that noise is gone.

## Technical Details

`normalize_tarinfo()` replaces the metadata that varies per build (`mtime`, `uid`/`gid`,
`uname`/`gname`), and members are added in sorted order. Permissions, sizes, symlink targets and
hardlink identity are untouched. Extracting as a normal user still yields files owned by the
extracting user, since `tar` ignores archived ownership without root.

`mtime` is **replaced, not zeroed** — see the timestamp section below.

Three things changed since this PR was first opened, all from @ScottTodd's review:

- **`archive_util.py` now exists.** He floated it in review and then landed it in #5027, so
  `normalize_tarinfo()` goes there rather than staying private to `fileset_tool.py`. That is also
  what the rebase required: `fileset_tool.py` no longer imports `tarfile` at all now that
  `_open_archive()` has been replaced by `open_archive_for_write()`.
- **`py_packaging.py` is included.** He pointed at the `_devel` tarball built for the
  `rocm-sdk-devel` wheel as having the same problem. It does — `os.walk` order and build-time
  metadata leak into it — so the reproducible tree walk is extracted as `archive_util.add_tree()`
  and both callers share one tested implementation instead of repeating the filter/sort wiring.
- **`mtime = 0` is gone.** His
  [analysis](https://github.com/ScottTodd/rocm-workspace/blob/main/reviews/pr_TheRock_4265.md#-blocking-epoch-mtimes-can-suppress-downstream-rebuilds-after-sdk-upgrades)
  is correct — details below.

Rebased from the original base (`0856406fe`, ~660 commits back) onto current `main`.

### Timestamps

Confirmed empirically that **mtime is restored on extraction**, so this was reaching installed SDKs:

| extraction path | mtime restored? |
|---|---|
| `extractall(filter="tar")` — `artifact_manager.py:434`, `fetch_artifacts.py:203`, `install_rocm_from_artifacts.py:303` | yes |
| `extractall(filter="data")` | yes |
| `tf.extract(ti, ...)` — the devel wheel extractor, `_devel.py:490-498` | yes |
| `tar -xf` as non-root, no flags | yes |

It's *ownership* a non-root extractor drops, not mtime — the original description conflated the two.
It propagates further too: `pattern_match.py` copies with `os.link` (same inode) or `shutil.copy2`,
both of which preserve mtime, so an epoch timestamp entering a stage dir survives into `dist/` and
into whatever is packaged from it.

`get_archive_timestamp()` now resolves, in order:

1. **`SOURCE_DATE_EPOCH`** — the reproducible-builds convention, and the supported override. Set it
   to pin the value explicitly.
2. **The commit time of TheRock's `HEAD`.** TheRock pins every submodule, so its HEAD identifies the
   whole source state. An artifact has no single source submodule to ask: `artifact_subprojects.json`
   maps `sysdeps` to 13 subprojects and `base` to 6, a merged `dist/` tree spans a subproject plus
   its runtime deps, and several subprojects (`zlib`, `zstd`, `bzip2`, `elfutils`) are tarballs
   downloaded from S3 with no git history at all.
3. **The current time**, when neither is available (no git, or an exported source archive). Not
   reproducible, but a working build beats a deterministically broken one.

Parallel jobs building the same commit resolve the same value, so the property #4202 needs is
unchanged.

Two consequences worth deciding on rather than inheriting, both of which I'd rather settle in review
than assume:

- **Over-invalidation.** A docs-only commit here advances the timestamp for every artifact, so every
  archive hash changes even when the content is byte-identical. Harmless for conflict detection
  within a run, but it forecloses using archive hashes to dedupe across commits.
- **Dirty trees** still report the last commit time, which understates a developer's local source
  state. Follow-up — @PeterCDMcLean and I discussed falling back to submodule / working-copy dates
  when the tree is dirty; landing the simple version first so the shape can be reviewed.

This does not by itself give Scott's rebuild-correctness invariant ("a newly installed SDK file is
newer than anything built against the old one"). A commit date can still predate a user's earlier
build — release branches cut weeks before publication, or a user moving from a newer nightly to an
older stable. Guaranteeing that invariant means re-stamping at install time, which is a separate
decision about what each distribution channel should do; this PR just stops the archiver from being
actively wrong.

## Risk Assessment

**Risk level 2.** Metadata-only change to how archives are written; no content, permissions or
layout changes, and readers are unaffected. Blast radius is every artifact archive and the devel
wheel tarball, so it is broad, but the change is uniform and directly covered by tests. The
user-visible differences are that archived files report `root:root` (which only matters when
extracting as root with `-p`) and that every file in an archive now carries the same mtime — the
source commit time — rather than its individual build time.

## Related

- Work tracking: #4202 (SHA-conflict detection on artifact upload). This PR is a prerequisite, not
  the fix — leave #4202 open.
- Builds on: #5027 (`Consolidate zstd/xz archive helpers into archive_util.py`).

## Device / Architecture Coverage

None required. Host-side packaging code with no device or architecture dependence; passing PR CI is
sufficient.

## Test Plan

New coverage, all in the existing `pytest build_tools/` lane (Linux + Windows):

`build_tools/tests/fileset_tool_test.py` — end-to-end through the real `fileset_tool artifact-archive`
command, the shape @ScottTodd sketched in review:

- `testArchiveReproducibleDespiteMetadataChanges` — archive the same artifact twice with the file
  mtimes changed in between; the two SHA256s must match.
- `testArchiveMemberMetadataIsNormalized` — with `SOURCE_DATE_EPOCH` set, every member carries that
  mtime, `uid/gid 0` and `root:root`; the manifest is stored first and the remaining members are
  sorted.
- `testArchiveMtimeIsNotTheEpoch` — with nothing configured, every member's mtime is > 0. This is
  the guard against regressing to the behavior Scott flagged.

`build_tools/tests/archive_util_test.py` — unit coverage for the shared helpers:

- `ArchiveTimestampTest` — `SOURCE_DATE_EPOCH` is honored; non-integer and negative values are
  rejected; falls back to the git commit time, and to the current time outside a checkout; and
  resolves to something > 0 in a real checkout with nothing configured.
- `NormalizeTarinfoTest` — the varying metadata is replaced, mode/size/type/name and symlink targets
  survive, and the mtime is never the epoch.
- `AddTreeTest` — member order is pinned, metadata is normalized, and the same tree archives to
  identical bytes after an mtime change.

Both new files' fixtures create entries out of sorted order deliberately, so a passing ordering
assertion cannot be explained by creation order.

## Testing Checklist

- [x] New tests, production change reverted - `git checkout origin/main -- build_tools/fileset_tool.py && pytest tests/fileset_tool_test.py` - Status: Failed as expected (both new tests; digests differed `040a3058…` vs `eb448499…`)
- [x] `add_tree` mutation check (drop the sort + filter) - `pytest tests/archive_util_test.py` - Status: Failed as expected (all 3 `AddTreeTest` cases)
- [x] Epoch-mtime mutation check (set `tarinfo.mtime = 0` again) - `pytest tests/archive_util_test.py tests/fileset_tool_test.py` - Status: Failed as expected (5 cases across both files)
- [x] Extraction behavior verified by experiment (the table above) - Status: mtime restored on all four paths
- [x] New tests, change applied - `cd build_tools && pytest tests/fileset_tool_test.py tests/archive_util_test.py` - Status: Passed
- [x] Full unit-test lane, locally (Linux) - `cd build_tools && pytest` - Status: Passed (2089 passed, 8 skipped)
- [x] Each commit independently - `pytest` at each of the three commits - Status: Passed (2077, 2081, 2089)
- [x] pre-commit - `pre-commit run --files <changed>` - Status: Passed
- [ ] PR CI - GitHub PR checks - Status: Pending

## Test Result

Both new `fileset_tool` tests fail on unpatched `main` and pass with the change; the reproducibility
test fails with two different digests for byte-identical content, which is exactly the condition
#4202 needs to be able to rely on. All three `AddTreeTest` cases fail when the sort and filter are
removed from `add_tree()`. Full suite green, both commits green in isolation.

### Earlier empirical result, and what it does and does not show

An earlier revision of this branch was run through CI twice with no changes, and the artifacts were
compared file by file
([artifact_comparison_results.txt](https://github.com/user-attachments/files/27369626/artifact_comparison_results.txt)).
57 artifacts still differed between the two runs — `blas_*`, `rccl_lib_*`, `rocprofiler-systems_*`
and others.

That is worth being explicit about: **normalizing archive metadata does not by itself make those
artifacts reproducible.** It removes the archiver as a source of nondeterminism, so any remaining
difference is real content difference produced by the build. Those are separate bugs and are not in
scope here. The value of this PR is that it makes the residue attributable.

## Flags / Guardrails

None. The change is unconditional. It is backward compatible for readers: existing archives still
extract identically, and nothing reads the normalized fields.

## Adjacent Tests Considered

- `py_packaging_test.py` — run, passing. It does not reach `populate_devel_files()`, which needs a
  full artifact catalog fixture, which is why `add_tree()` was extracted and tested directly rather
  than testing the wheel path end to end.
- `artifacts_test.py`, `artifact_manager_tool_test.py`, `build_tarballs_test.py` — the other archive
  readers/writers; run, passing. Readers are unaffected because only metadata changed.
- `install_rocm_from_artifacts_test.py` — exercises extraction; run, passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
