### PR TITLE
[ci] Fixing multi-arch CI to ignore `test_type` if not `is_ci_enabled`

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -876,7 +876,7 @@ def write_outputs(
     """
     linux = outputs.builds.linux
     windows = outputs.builds.windows
-    test_type = outputs.jobs.test_rocm.test_type
+    test_type = outputs.jobs.test_rocm.test_type if outputs.is_ci_enabled else ""
     output_vars = {
         # Workflow YAML references this as 'enable_build_jobs'
         "enable_build_jobs": json.dumps(outputs.is_ci_enabled),

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -797,6 +797,10 @@ class TestFormatSummary(unittest.TestCase):
         # on more exact formatting would create a change detector test.
         self.assertTrue(result.startswith("## Multi-Arch CI Configuration"))
 
+    def test_skipped_ci_write_outputs_summary(self):
+        outputs = cm.CIOutputs(is_ci_enabled=False)
+        cm.write_outputs(self._inputs(), outputs)
+
 
 # ---------------------------------------------------------------------------
 # End-to-end: configure() pipeline
@@ -812,6 +816,7 @@ class TestConfigurePipeline(unittest.TestCase):
         self.assertFalse(outputs.is_ci_enabled)
         self.assertIsNone(outputs.builds.linux)
         self.assertIsNone(outputs.builds.windows)
+        self.assertIsNone(outputs.jobs)
 
     @patch("configure_multi_arch_ci.should_skip_ci")
     def test_pipeline_skips_when_gate_says_skip(self, mock_skip):


### PR DESCRIPTION
Noticing errors here: https://github.com/ROCm/TheRock/actions/runs/23812358293/job/69402529769?pr=4275

Realized if no jobs, test_type can't be called. Made a fix with empty test_type if CI is not enabled, added unit test too