### PR TITLE
Add `rocm-third-party-deps` to S3 bucket inventory

### DIFF
--- a/docs/development/git_chores.md
+++ b/docs/development/git_chores.md
@@ -161,11 +161,18 @@ Using the CLR submodule as an example:
 
 ## Updating a third-party mirror
 
-Projects in [`third-party/`](../../third-party/) use sources mirrored to AWS
-so we maintain control over all build dependencies and can produce hermetic
-builds (requiring no network access) as needed.
+Projects in [`third-party/`](../../third-party/) use sources mirrored to AWS.
+This serves several purposes:
 
-These are declared like so:
+- **Supply chain integrity**: pinned, checksummed copies prevent sources
+  from changing outside of our control.
+- **Network performance**: dependencies are served over the same network
+  optimized for build machine access, so we're not at the mercy of third party
+  web servers.
+- **Hermetic builds**: by using a shared code path for all source fetching, we
+  can configure the build system to support zero-network-access source builds.
+
+Source fetches are declared like so:
 
 ```cmake
 therock_subproject_fetch(therock-msgpack-cxx-sources

--- a/docs/development/s3_buckets.md
+++ b/docs/development/s3_buckets.md
@@ -119,17 +119,10 @@ prefer the CDN URLs for reading (e.g. `pip install --index-url`).
 ### Build system buckets
 
 We mirror third-party dependency files into S3 for use by the build system.
-This serves several purposes:
 
-- **Supply chain integrity**: pinned, checksummed copies prevent sources
-  from changing outside of our control.
-- **Network performance**: dependencies are served over the same network
-  optimized for build machine access, so we're not at the mercy of third party
-  web servers.
-
-| Bucket                  | Contents                                                           | IAM role                           |
-| ----------------------- | ------------------------------------------------------------------ | ---------------------------------- |
-| `rocm-third-party-deps` | Source/dep mirrors for [`third_party/`](/third-party/) subprojects | None (files are uploaded manually) |
+| Bucket                  | Contents                                                | Details                                                                                                                    |
+| ----------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `rocm-third-party-deps` | Mirrors for [`third_party/`](/third-party/) subprojects | See ["Updating a third-party mirror"](./git_chores.md#updating-a-third-party-mirror) in [`git_chores.md`](./git_chores.md) |
 
 ### Cache buckets
 


### PR DESCRIPTION
I missed documenting this bucket earlier since it doesn't have `therock` in its name.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
