### PR TITLE
Run multi_arch_ci on release branches

### DIFF
--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -15,6 +15,7 @@ on:
     branches:
       - main
       - multi_arch/**
+      - release/therock-*
   workflow_dispatch:
     inputs:
       linux_amdgpu_families:


### PR DESCRIPTION
## Motivation

Since https://github.com/ROCm/TheRock/pull/4204, `multi_arch_ci.yml` has been the default CI workflow instead of `ci.yml`. We should run it on release branches now too.

Related:
* https://github.com/ROCm/TheRock/issues/3337
* https://github.com/ROCm/TheRock/issues/3340

## Technical Details

Matching https://github.com/ROCm/TheRock/blob/7433970d3a0b66a9541f1fe9027c70e12afab3f1/.github/workflows/ci.yml#L18-L24

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
