### PR TITLE
[ci] adding check call for hipblas test

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hipblas.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblas.py
@@ -57,4 +57,4 @@ else:
 
 
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
-result = subprocess.run(cmd, cwd=THEROCK_DIR, env=environ_vars)
+subprocess.check_call(cmd, cwd=THEROCK_DIR, env=environ_vars)


### PR DESCRIPTION
Currently, hipblas tests fail but are showing as passing as no check is added (https://github.com/ROCm/TheRock/actions/runs/23775619092/job/69287733773?pr=4257)

This PR adds `check_call` which will properly check pass / fail for hipblas

working here: https://github.com/ROCm/TheRock/actions/runs/23818966052/job/69430417043