### PR TITLE
[ci] Updating hipsparselt to include correct tests

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hipsparselt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsparselt.py
@@ -29,7 +29,7 @@ test_type = os.getenv("TEST_TYPE", "full")
 test_filter = []
 if test_type == "quick":
     test_filter.append("--gtest_filter=*smoke*")
-elif test_type == "full":
+else:
     test_filter.append("--gtest_filter=*quick*")
 
 cmd = [f"{THEROCK_BIN_DIR}/hipsparselt-test"] + test_filter


### PR DESCRIPTION
hipsparselt is timing out due to the test filtering being quick, standard, comprehensive and full.

This will enable all other filters to run on quick, until test standarization effort is complete

Test here: https://github.com/ROCm/TheRock/actions/runs/23861021022