### PR TITLE
[ci] Fixing skip CI `build_variant_label` null value for multi arch CI

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -880,8 +880,8 @@ def write_outputs(
     output_vars = {
         # Workflow YAML references this as 'enable_build_jobs'
         "enable_build_jobs": json.dumps(outputs.is_ci_enabled),
-        "linux_build_config": (json.dumps(linux.to_dict()) if linux else ""),
-        "windows_build_config": (json.dumps(windows.to_dict()) if windows else ""),
+        "linux_build_config": json.dumps(linux.to_dict()) if linux else "",
+        "windows_build_config": json.dumps(windows.to_dict()) if windows else "",
         "test_type": test_type,
         "linux_test_labels": outputs.linux_test_labels,
         "windows_test_labels": outputs.windows_test_labels,


### PR DESCRIPTION
during skipped CI runs for multi arch, we get errors such as:

```
evaluate reusable workflow name: Error when evaluating 'name' for job 'windows_build_and_test'. .github/workflows/multi_arch_ci.yml (Line: 88, Col: 11): could not get operand for index access: Error from function 'fromJSON': empty input
evaluate reusable workflow name: Error when evaluating 'name' for job 'linux_build_and_test'. .github/workflows/multi_arch_ci.yml (Line: 69, Col: 11): could not get operand for index access: Error from function 'fromJSON': empty input
```

such as in here: https://github.com/ROCm/TheRock/actions/runs/23817872655?pr=4275

This update fixes it, so inputs are included and not nulled, even if CI is skipped