### PR TITLE
[ci] Run rocm-sdk wheel tests sequentially

### DIFF
--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -89,7 +89,9 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
-      - name: Setup venv and install 'rocm[libraries]'
+      # Key off install_libraries success (not test_libraries) so devel install/test still run
+      - name: Install rocm[libraries]
+        id: install_libraries
         run: |
           python build_tools/setup_venv.py ${VENV_DIR} \
             --packages "rocm[libraries]==${{ inputs.rocm_version }}" \
@@ -99,15 +101,20 @@ jobs:
             --activate-in-future-github-actions-steps
 
       - name: Show installed packages (libraries)
+        if: ${{ !cancelled() && steps.install_libraries.outcome == 'success' }}
         run: |
           pip freeze
 
-      - name: Run 'rocm-sdk test' with 'rocm[libraries]' installed
+      - name: Test rocm[libraries]
+        id: test_libraries
+        if: ${{ !cancelled() && steps.install_libraries.outcome == 'success' }}
         timeout-minutes: 5
         run: |
           rocm-sdk test
 
-      - name: Install 'rocm[libraries,devel]' into existing venv
+      - name: Install rocm[libraries,devel]
+        id: install_devel
+        if: ${{ !cancelled() && steps.install_libraries.outcome == 'success' }}
         run: |
           python build_tools/setup_venv.py ${VENV_DIR} \
             --packages "rocm[libraries,devel]==${{ inputs.rocm_version }}" \
@@ -116,10 +123,12 @@ jobs:
             --find-links=${{ inputs.package_find_links_url }}
 
       - name: Show installed packages (libraries,devel)
+        if: ${{ !cancelled() && steps.install_devel.outcome == 'success' }}
         run: |
           pip freeze
 
-      - name: Run 'rocm-sdk test' with 'rocm[libraries,devel]' installed
+      - name: Test rocm[libraries,devel]
+        if: ${{ !cancelled() && steps.install_devel.outcome == 'success' }}
         timeout-minutes: 5
         run: |
           rocm-sdk test


### PR DESCRIPTION
Prerequisite of https://github.com/ROCm/TheRock/pull/4248

## Motivation

Using one job for both package stages keeps the matrix dimension free for container images later, so extra base images do not multiply jobs across libraries vs. devel. See https://github.com/ROCm/TheRock/pull/3119#discussion_r2736945862 for more details.

## Technical Details

Replace the `matrix.packages` job split with one job that installs `rocm[libraries]`, runs `rocm-sdk test`, then upgrades the same venv to `rocm[libraries,devel]` and runs `rocm-sdk test` again via `setup_venv` reuse: https://github.com/ROCm/TheRock/blob/76ad42a633edc612ae74c771fde169c1c2686263/build_tools/setup_venv.py#L80

## Test Plan

Observe PR action passed with sequential installation/testing enabled: https://github.com/ROCm/TheRock/actions/runs/24152917536/job/70519071421

## Test Result

Now conditionally installs/tests `devel` package if `libraries` was successfully installed.

Example of a run which fails during testing of `rocm[libraries]` and continues to install/test `rocm[libraries,devel]` as desired: https://github.com/ROCm/TheRock/actions/runs/24411710011/job/71344455349

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
