### PR TITLE
Add ROCm env vars to JAX test step to fix plugin discovery (#4269)

### DIFF
--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -255,6 +255,9 @@ jobs:
       - name: Run JAX tests
         env:
           JAX_PLATFORMS: rocm
+          HIP_DEVICE_LIB_PATH: /opt/rocm/lib/llvm/amdgcn/bitcode
+          JAX_ROCM_PLUGIN_INTERNAL_BITCODE_PATH: /opt/rocm/lib/llvm/amdgcn/bitcode
+          JAX_ROCM_PLUGIN_INTERNAL_LLD_PATH: /opt/rocm/lib/llvm/bin
         run: |
           pytest jax/tests/multi_device_test.py -q --log-cli-level=INFO
           pytest jax/tests/core_test.py -q --log-cli-level=INFO


### PR DESCRIPTION
## Motivation

The JAX CI test job on `gfx1151` (and potentially other architectures) aborts with exit code 134 when running `jax/tests/multi_device_test.py`. The root cause is that the `jax_rocm7_plugin` cannot discover the ROCm device bitcode and LLD linker because the tarball-based ROCm installation at `/opt/rocm` does not match the paths the plugin probes by default.

This is a short-term fix to unblock CI while a proper long-term solution (e.g. embedding correct paths in the wheel or improving plugin auto-discovery) is developed.

Fixes https://github.com/ROCm/TheRock/issues/4269

## Technical Details

Added three environment variables to the "Run JAX tests" step in `.github/workflows/test_linux_jax_wheels.yml`:
HIP_DEVICE_LIB_PATH
JAX_ROCM_PLUGIN_INTERNAL_BITCODE_PATH
JAX_ROCM_PLUGIN_INTERNAL_LLD_PATH

These variables were already suggested in [#4269](https://github.com/ROCm/TheRock/issues/4269) by @srinivamd as the short-term workaround.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
