### PR TITLE
Update packaging documentation to focus on Ubuntu 24.04 and improve setup instructions

### DIFF
--- a/build_tools/packaging/linux/README.txt
+++ b/build_tools/packaging/linux/README.txt
@@ -3,23 +3,16 @@ The current scope of this is for producing AMD vendor packaging for hosting in A
 
 #Prerequisites:
 Python version required : python 3.12 or above
- Almalinux:
-dnf install rpm-build
-dnf install llvm
-pip install -r requirements.txt
-
- Ubuntu:
+ Ubuntu(24.04):
 apt update
-apt install -y python3
-apt install -y python3-pip
+apt install -y python3 python3-venv python3-pip
 apt install -y debhelper
 apt install -y llvm-20
-pip install -r requirements.txt
+apt install -y rpm
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt (build_tools/packaging/linux/requirements.txt)
 
 #Usage:
-Almalinux:
-./build_package.py --artifacts-dir ./ARTIFACTS_DIR --target gfx94X-dcgpu --dest-dir ./OUTPUT_PKG --rocm-version 7.1.0 --pkg-type rpm --version-suffix build_type
-
 Ubuntu:
 ./build_package.py --artifacts-dir ./ARTIFACTS_DIR --target gfx94X-dcgpu --dest-dir ./OUTPUT_PKG --rocm-version 7.1.0 --pkg-type deb --version-suffix build_type
 

--- a/docs/packaging/native_packaging.md
+++ b/docs/packaging/native_packaging.md
@@ -92,7 +92,7 @@ Optional Fields
 ## Building Packages
 
 ```bash
-./build_package.py \
+./build_tools/packaging/linux/build_package.py \
    --artifacts-dir ./ARTIFACTS_DIR \
    --target gfx94X-dcgpu \
    --dest-dir ./OUTPUT_PKG \
@@ -111,25 +111,26 @@ To install locally built packages
 ### Configuring your Python Project Dependencies
 
 Python version required : python 3.12 or above<br>
-Almalinux:<br>
-dnf install rpm-build<br>
-dnf install llvm<br>
-pip install -r requirements.txt<br>
-
-Ubuntu:<br>
+Ubuntu(24.04):<br>
 apt update<br>
-apt install -y python3<br>
-apt install -y python3-pip<br>
+apt install -y python3 python3-venv python3-pip git<br>
 apt install -y debhelper<br>
+apt install -y rpm<br>
 apt install -y llvm-20<br>
-pip install -r requirements.txt<br>
+
+# Clone the repository
+
+git clone https://github.com/ROCm/TheRock.git
+cd TheRock
+python3 -m venv .venv && source .venv/bin/activate<br>
+pip install -r build_tools/packaging/linux/requirements.txt<br>
 
 ### Usage
 
 RPM package:<br>
 
 ```bash
-./build_package.py \
+./build_tools/packaging/linux/build_package.py \
    --artifacts-dir ./ARTIFACTS_DIR \
    --target gfx94X-dcgpu \
    --dest-dir ./OUTPUT_PKG \
@@ -141,7 +142,7 @@ RPM package:<br>
 Debian package:<br>
 
 ```bash
-./build_package.py \
+./build_tools/packaging/linux/build_package.py \
    --artifacts-dir ./ARTIFACTS_DIR \
    --target gfx94X-dcgpu \
    --dest-dir ./OUTPUT_PKG \
@@ -153,7 +154,7 @@ Debian package:<br>
 Debian RPATH package:<br>
 
 ```bash
-./build_package.py \
+./build_tools/packaging/linux/build_package.py \
    --artifacts-dir ./ARTIFACTS_DIR \
    --target gfx94X-dcgpu \
    --dest-dir ./OUTPUT_PKG \


### PR DESCRIPTION
- Remove AlmaLinux-specific instructions and consolidate on Ubuntu 24.04
- Update script paths to use full path: ./build_tools/packaging/linux/build_package.py
- Add virtual environment setup instructions for better dependency isolation
- Include additional required packages (python3-venv, git, rpm)
- Add repository cloning instructions in native_packaging.md