### PR TITLE
[py] Address comments and add extras

### DIFF
--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -189,17 +189,14 @@ class PopulatedDistPackage:
                 f"AVAILABLE_TARGET_FAMILIES.append('{target_family}')\n"
             )
 
-        # Device packages need to know the libraries package name so their
-        # setup.py can declare the correct install_requires and overlay dir.
+        # Device packages need to know the libraries package's Python package
+        # name so their setup.py can set up the correct overlay directory.
+        # The dist name ("rocm-sdk-libraries") is static and hardcoded in setup.py.
         if logical_name == "device":
             libraries_entry = self.params.dist_info.ALL_PACKAGES["libraries"]
-            libraries_dist_name = libraries_entry.get_dist_package_name(
-                target_family=None
-            )
             libraries_py_package_name = libraries_entry.get_py_package_name(
                 target_family=None
             )
-            dist_info_contents += f"LIBRARIES_DIST_NAME = {repr(libraries_dist_name)}\n"
             dist_info_contents += (
                 f"LIBRARIES_PY_PACKAGE_NAME = {repr(libraries_py_package_name)}\n"
             )

--- a/build_tools/packaging/python/templates/rocm-sdk-device/setup.py
+++ b/build_tools/packaging/python/templates/rocm-sdk-device/setup.py
@@ -61,7 +61,7 @@ setup(
         platform_py_package: package_data_files,
     },
     install_requires=[
-        f"{dist_info.LIBRARIES_DIST_NAME}=={dist_info.__version__}",
+        f"rocm-sdk-libraries=={dist_info.__version__}",
     ],
     zip_safe=False,
     options={

--- a/build_tools/packaging/python/templates/rocm/setup.py
+++ b/build_tools/packaging/python/templates/rocm/setup.py
@@ -77,6 +77,23 @@ if device_entry and device_entry.is_target_specific:
         dist_info.determine_target_family()
     except Exception:
         EXTRAS_REQUIRE.pop("device", None)
+
+# For target-specific packages with multiple available targets (e.g. device
+# packages in kpack-split mode), generate per-target extras so users can
+# explicitly request a specific ISA: pip install rocm[device-gfx942]
+# Also generate a device-all extra that installs all available device shards.
+for pkg in dist_info.ALL_PACKAGES.values():
+    if not pkg.is_target_specific or pkg.required:
+        continue
+    if len(dist_info.AVAILABLE_TARGET_FAMILIES) > 1:
+        all_requires = []
+        for tf in sorted(dist_info.AVAILABLE_TARGET_FAMILIES):
+            extra_name = f"{pkg.logical_name}-{tf}"
+            req = pkg.get_dist_package_require(target_family=tf)
+            EXTRAS_REQUIRE[extra_name] = [req]
+            all_requires.append(req)
+        EXTRAS_REQUIRE[f"{pkg.logical_name}-all"] = all_requires
+
 print(f"extras_require={EXTRAS_REQUIRE}")
 packages = find_packages(where="./src")
 print("Found packages:", packages)

--- a/build_tools/packaging/python/templates/rocm/setup.py
+++ b/build_tools/packaging/python/templates/rocm/setup.py
@@ -60,24 +60,6 @@ EXTRAS_REQUIRE = {
     for pkg in dist_info.ALL_PACKAGES.values()
     if not pkg.required
 }
-# Add explicit per-target device extras (rocm[device-gfx942], etc.) alongside
-# the generic 'device' extra for callers that need to name a specific ISA —
-# e.g. kpack-split CI installs on GPU-less runners where offload-arch is not
-# yet available and the generic extra would silently fall back to
-# DEFAULT_TARGET_FAMILY. Keep the generic 'device' extra when target resolution
-# succeeds (normal install on a GPU machine); drop it only when it would produce
-# an incorrect result.
-device_entry = dist_info.ALL_PACKAGES.get("device")
-if device_entry and device_entry.is_target_specific:
-    for _target in dist_info.AVAILABLE_TARGET_FAMILIES:
-        EXTRAS_REQUIRE[f"device-{_target}"] = [
-            device_entry.get_dist_package_require(target_family=_target)
-        ]
-    try:
-        dist_info.determine_target_family()
-    except Exception:
-        EXTRAS_REQUIRE.pop("device", None)
-
 # For target-specific packages with multiple available targets (e.g. device
 # packages in kpack-split mode), generate per-target extras so users can
 # explicitly request a specific ISA: pip install rocm[device-gfx942]
@@ -93,6 +75,19 @@ for pkg in dist_info.ALL_PACKAGES.values():
             EXTRAS_REQUIRE[extra_name] = [req]
             all_requires.append(req)
         EXTRAS_REQUIRE[f"{pkg.logical_name}-all"] = all_requires
+
+# Drop the generic 'device' extra when target resolution would silently fall
+# back to DEFAULT_TARGET_FAMILY - e.g. kpack-split CI installs on GPU-less
+# runners where offload-arch is not yet available. Callers can still name a
+# specific ISA via the per-target extras emitted above. Keep the generic
+# 'device' extra when target resolution succeeds (normal install on a GPU
+# machine).
+device_entry = dist_info.ALL_PACKAGES.get("device")
+if device_entry and device_entry.is_target_specific:
+    try:
+        dist_info.determine_target_family()
+    except Exception:
+        EXTRAS_REQUIRE.pop("device", None)
 
 print(f"extras_require={EXTRAS_REQUIRE}")
 packages = find_packages(where="./src")

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -417,6 +417,173 @@ class ParametersConstructionTest(TmpDirTestCase):
 
 
 # ---------------------------------------------------------------------------
+# Tests for kpack-split device packaging
+# ---------------------------------------------------------------------------
+
+
+class DevicePackagingTest(TmpDirTestCase):
+    """Tests for kpack-split mode: arch-neutral libraries + per-ISA device wheels."""
+
+    def _add_artifact(
+        self,
+        artifact_dir: Path,
+        name: str,
+        component: str,
+        target_family: str,
+        files: dict[str, str],
+    ):
+        """Create a minimal artifact directory with the given files under stage/."""
+        subdir = artifact_dir / f"{name}_{component}_{target_family}"
+        stage = subdir / "stage"
+        for relpath, content in files.items():
+            f = stage / relpath
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text(content)
+        (subdir / "artifact_manifest.txt").write_text("stage\n")
+
+    def _make_params(self, artifact_dir: Path, kpack_split: bool = False) -> Parameters:
+        dest_dir = self.temp_dir / "packages"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        return Parameters(
+            dest_dir=dest_dir,
+            version="0.0.1.test",
+            version_suffix="",
+            artifacts=ArtifactCatalog(artifact_dir),
+            kpack_split=kpack_split,
+        )
+
+    def _setup_kpack_split_artifacts(self) -> Path:
+        """Create a minimal set of generic + per-ISA artifacts."""
+        artifact_dir = self.temp_dir / "artifacts"
+        # Generic library artifact (host code)
+        self._add_artifact(
+            artifact_dir,
+            "blas",
+            "lib",
+            "generic",
+            {"lib/librocblas.txt": "host library"},
+        )
+        # Per-ISA device artifact
+        self._add_artifact(
+            artifact_dir,
+            "blas",
+            "lib",
+            "gfx942",
+            {
+                ".kpack/blas_lib_gfx942.kpack": "kpack data",
+                "lib/rocblas/library/Foo_gfx942.co": "kernel object",
+            },
+        )
+        return artifact_dir
+
+    def test_kpack_split_libraries_is_arch_neutral(self):
+        """kpack_split=True makes the libraries entry non-target-specific."""
+        artifact_dir = self._setup_kpack_split_artifacts()
+        params = self._make_params(artifact_dir, kpack_split=True)
+
+        libraries_entry = params.dist_info.ALL_PACKAGES["libraries"]
+        # Should not raise — libraries is no longer target-specific.
+        dist_name = libraries_entry.get_dist_package_name(target_family=None)
+        self.assertEqual(dist_name, "rocm-sdk-libraries")
+        # py_package_name should also work without a target.
+        py_name = libraries_entry.get_py_package_name(target_family=None)
+        self.assertTrue(py_name.startswith("_rocm_sdk_libraries"))
+
+    def test_kpack_split_libraries_package_creates_without_target(self):
+        """Libraries package with target_family=None should not raise in kpack-split."""
+        artifact_dir = self._setup_kpack_split_artifacts()
+        params = self._make_params(artifact_dir, kpack_split=True)
+
+        # Should not raise.
+        lib = PopulatedDistPackage(params, logical_name="libraries", target_family=None)
+        self.assertIsNotNone(lib.path)
+
+    def test_populate_device_files_copies_all_files(self):
+        """populate_device_files() should copy .kpack and kernel DB files."""
+        artifact_dir = self._setup_kpack_split_artifacts()
+        params = self._make_params(artifact_dir, kpack_split=True)
+
+        dev = PopulatedDistPackage(
+            params, logical_name="device", target_family="gfx942"
+        )
+        dev.populate_device_files(
+            params.filter_artifacts(
+                lambda an: an.name == "blas"
+                and an.component == "lib"
+                and an.target_family == "gfx942"
+            )
+        )
+
+        # Both files should be materialized.
+        self.assertTrue(dev.files.has(".kpack/blas_lib_gfx942.kpack"))
+        self.assertTrue(dev.files.has("lib/rocblas/library/Foo_gfx942.co"))
+
+        # Files should exist on disk in the platform dir.
+        platform_dir = dev._platform_dir
+        self.assertTrue((platform_dir / ".kpack" / "blas_lib_gfx942.kpack").exists())
+        self.assertTrue(
+            (platform_dir / "lib" / "rocblas" / "library" / "Foo_gfx942.co").exists()
+        )
+
+    def test_device_platform_dir_overlays_libraries(self):
+        """Device package platform dir must match libraries package platform dir name."""
+        artifact_dir = self._setup_kpack_split_artifacts()
+        params = self._make_params(artifact_dir, kpack_split=True)
+
+        lib = PopulatedDistPackage(params, logical_name="libraries", target_family=None)
+        dev = PopulatedDistPackage(
+            params, logical_name="device", target_family="gfx942"
+        )
+
+        # The platform dir names must match for the overlay to work.
+        self.assertEqual(lib._platform_dir.name, dev._platform_dir.name)
+
+    def test_device_artifact_filter(self):
+        """device_artifact_filter selects only per-ISA lib artifacts."""
+        # Import the filter from the build script.
+        sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+        from build_python_packages import device_artifact_filter
+
+        from _therock_utils.artifacts import ArtifactName
+
+        # Should match per-ISA lib artifact.
+        an_gfx942 = ArtifactName("blas", "lib", "gfx942")
+        self.assertTrue(device_artifact_filter("gfx942", an_gfx942))
+
+        # Should NOT match generic.
+        an_generic = ArtifactName("blas", "lib", "generic")
+        self.assertFalse(device_artifact_filter("gfx942", an_generic))
+
+        # Should NOT match wrong ISA.
+        an_gfx1100 = ArtifactName("blas", "lib", "gfx1100")
+        self.assertFalse(device_artifact_filter("gfx942", an_gfx1100))
+
+        # Should NOT match test component.
+        an_test = ArtifactName("blas", "test", "gfx942")
+        self.assertFalse(device_artifact_filter("gfx942", an_test))
+
+        # Should NOT match non-library artifact name.
+        an_core = ArtifactName("core-hip", "lib", "gfx942")
+        self.assertFalse(device_artifact_filter("gfx942", an_core))
+
+    def test_device_dist_info_has_libraries_py_package_name(self):
+        """Device package _dist_info.py must contain LIBRARIES_PY_PACKAGE_NAME."""
+        artifact_dir = self._setup_kpack_split_artifacts()
+        params = self._make_params(artifact_dir, kpack_split=True)
+
+        dev = PopulatedDistPackage(
+            params, logical_name="device", target_family="gfx942"
+        )
+
+        dist_info_path = (
+            dev.path / "src" / dev.entry.pure_py_package_name / "_dist_info.py"
+        )
+        content = dist_info_path.read_text()
+        self.assertIn("LIBRARIES_PY_PACKAGE_NAME", content)
+        self.assertIn("_rocm_sdk_libraries", content)
+
+
+# ---------------------------------------------------------------------------
 # Unit tests for restrict_families (per-family meta package)
 # ---------------------------------------------------------------------------
 

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -8,7 +8,7 @@ alterations.
 
 ## General Design
 
-We generate three types of packages:
+We generate the following types of packages:
 
 - Selector package: The `rocm` package is built as an sdist so that it is
   evaluated at the point of install, allowing it to perform some selection logic
@@ -23,6 +23,15 @@ We generate three types of packages:
   symlinks (instead, only SONAME libraries are included, and any executable
   symlinks are emitted by dynamically compiling an executable that can execle
   a relative binary).
+- Device packages: When kpack artifact splitting is enabled
+  (`KPACK_SPLIT_ARTIFACTS` flag in `therock_manifest.json`), per-ISA device
+  wheels (`rocm-sdk-device-{target}`) are produced alongside an arch-neutral
+  `rocm-sdk-libraries` host wheel. Device wheels contain `.kpack` archives
+  and kernel databases (Tensile `.co`/`.dat`, MIOpen `.kdb`/`.db.txt`, etc.)
+  that overlay into the `rocm-sdk-libraries` platform directory in
+  site-packages. Each device wheel declares `Requires-Dist` on the matching
+  version of `rocm-sdk-libraries`. Users install only the device wheels for
+  their GPU target(s).
 - Devel package: The `rocm-sdk-devel` package is the catch-all for everything.
   For any file already populated in a runtime package, it will include it as
   a relative symlink in the tarball. During extraction, file symlinks are
@@ -33,12 +42,20 @@ We generate three types of packages:
   file. The installed package is extended in response to requesting a path to it
   via the `rocm-sdk` tool.
 
-Runtime packages can either be target neutral or target specific. Target specific
-packages are suffixed with their target family and the setup files have special logic
-to determine what is correct to load based on the system. In the future, this
-will be re-arranged to have more of a thin structure where the host code is
-always emitted as target neutral and separate device code packages are loaded
-as needed.
+### Legacy vs kpack-split packaging modes
+
+The packaging pipeline supports two modes, selected automatically based on the
+`KPACK_SPLIT_ARTIFACTS` flag in the build's `therock_manifest.json`:
+
+- **Legacy mode** (flag absent or false): Runtime packages can be target neutral
+  or target specific. Target specific packages like `rocm-sdk-libraries-{family}`
+  are suffixed with their target family and contain both host code and embedded
+  device code.
+- **Kpack-split mode** (flag true): The `rocm-sdk-libraries` host wheel is
+  arch-neutral (no family suffix, no device code). Device code is distributed
+  via separate `rocm-sdk-device-{target}` wheels, one per GFX ISA target.
+  The devel package is also arch-neutral and excludes test binaries (which
+  require device code to run).
 
 It is expected that all packages are installed in the same site-lib, as they use
 relative symlinks and RPATHs that cross the top-level package boundary. The
@@ -125,6 +142,25 @@ ls ${PACKAGES_DIR}
 # rocm_sdk_devel-7.12.0.dev0-py3-none-win_amd64.whl
 # rocm_sdk_libraries_gfx110x_all-7.12.0.dev0-py3-none-win_amd64.whl
 # rocm-7.12.0.dev0.tar.gz
+```
+
+For kpack-split builds, use `artifact_manager.py` with `--amdgpu-targets` to
+fetch per-ISA artifacts:
+
+```bash
+python ./build_tools/artifact_manager.py fetch --stage all \
+    --output-dir=${ARTIFACTS_DIR} \
+    --run-id=${RUN_ID} --platform linux \
+    --amdgpu-families "gfx94X-dcgpu;gfx120X-all" \
+    --amdgpu-targets "gfx942,gfx1100,gfx1101,gfx1102,gfx1103,gfx1151,gfx1200,gfx1201"
+
+python ./build_tools/build_python_packages.py \
+    --artifact-dir=${ARTIFACTS_DIR}/artifacts \
+    --dest-dir=${PACKAGES_DIR}
+
+# Kpack-split output:
+# rocm_sdk_core-*.whl, rocm_sdk_libraries-*.whl (arch-neutral),
+# rocm_sdk_device_gfx942-*.whl, rocm_sdk_device_gfx1100-*.whl, ...
 ```
 
 ### Installing Locally Built Packages


### PR DESCRIPTION
Follow-up to #4308 per review comments from ScottTodd and marbre.

Changes:
- Document rocm-sdk-device package in python_packaging.md: add device package type description, legacy vs kpack-split mode section, and kpack-split artifact fetching instructions
- Add DevicePackagingTest class with 6 tests covering populate_device_files, device_artifact_filter, kpack-split arch-neutral libraries, platform dir overlay, and dist_info generation
- Hardcode "rocm-sdk-libraries" in device setup.py install_requires instead of reading from injected LIBRARIES_DIST_NAME (marbre nit: the dist name is static, only LIBRARIES_PY_PACKAGE_NAME needs injection)
- Adds extras to the rocm package to install for specific devices. This gets us minimally usable and we can extend later.
