### PR TITLE
add LLVM_PARALLEL_COMPILE_JOBS option for building llvm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ set(THEROCK_SANITIZER "" CACHE STRING "Enable project wide sanitizer build ('ASA
 
 # Options to control the concurrency for building LLVM.
 set(FLANG_PARALLEL_COMPILE_JOBS "" CACHE STRING "Limit parallel compile jobs for Flang (reduces memory usage on systems with many cores)")
+set(LLVM_PARALLEL_COMPILE_JOBS "" CACHE STRING "Limit parallel compile jobs for LLVM (reduces memory usage on systems with many cores)")
 set(LLVM_PARALLEL_LINK_JOBS "" CACHE STRING "Limit parallel link jobs for LLVM (reduces memory usage on systems with many cores)")
 
 # List of python executables to use for multi-version python builds

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -14,18 +14,32 @@ if(THEROCK_ENABLE_COMPILER)
     list(APPEND _extra_llvm_cmake_args "-DLLVM_ENABLE_PEDANTIC=OFF")
   endif()
 
-  # Building Flang is very memory-intensive on systems with many cores. Allow
-  # users to specify the level of concurrency for these tasks so they can
+  # Building Flang is very memory-intensive on systems with many cores.
+  # At the same time there can be running compile jobs for flang,
+  # compile jobs for other llvm components and linking jobs for llvm components.
+  # Allow users to specify the level of concurrency for these tasks so they can
   # reduce the risk of running out of memory.
+  #
+  # Example of configure parameters for
+  # 32 GB DDR/16 GB swap/8 CPU core/16 CPU thread Linux system to
+  # allow the LLVM build to pass on single attempt:
+  #     -DLLVM_PARALLEL_COMPILE_JOBS=9
+  #     -DFLANG_PARALLEL_COMPILE_JOBS=4
+  #     -DLLVM_PARALLEL_LINK_JOBS=1
   if(FLANG_PARALLEL_COMPILE_JOBS)
     message(STATUS "Flang build concurrency level set to ${FLANG_PARALLEL_COMPILE_JOBS}")
     list(APPEND _extra_llvm_cmake_args "-DFLANG_PARALLEL_COMPILE_JOBS=${FLANG_PARALLEL_COMPILE_JOBS}")
   else()
      message(WARNING "Flang concurrency is unlimited. Memory usage may be much higher. Set -DFLANG_PARALLEL_COMPILE_JOBS to reduce memory use.")
   endif()
-
-  # LLVM linking is also very memory intensive. Allow users to adjust the number
-  # of parallel link jobs.
+  # Allow users to adjust the number of parallel jobs used for compiling non-Flang related files of the LLVM.
+  if(LLVM_PARALLEL_COMPILE_JOBS)
+    message(STATUS "LLVM build concurrency level set to ${LLVM_PARALLEL_COMPILE_JOBS}")
+    list(APPEND _extra_llvm_cmake_args "-DLLVM_PARALLEL_COMPILE_JOBS=${LLVM_PARALLEL_COMPILE_JOBS}")
+  else()
+    message(WARNING "LLVM concurrency is unlimited. Memory usage may be much higher. Set -DLLVM_PARALLEL_COMPILE_JOBS to reduce memory use.")
+  endif()
+  # Allow users to adjust the number of parallel link jobs when building LLVM.
   if(LLVM_PARALLEL_LINK_JOBS)
     message(STATUS "LLVM parallel link jobs set to ${LLVM_PARALLEL_LINK_JOBS}")
     list(APPEND _extra_llvm_cmake_args "-DLLVM_PARALLEL_LINK_JOBS=${LLVM_PARALLEL_LINK_JOBS}")


### PR DESCRIPTION
Building and linking of LLVM and it's Flang
sub-component is very memory intensive and can cause the system to run out of memory in cases where there is not enough memory for each CPU job that can run in parallel when LLVM is build.

Earlier therock has allowed to pass only the
FLANG_PARALLEL_COMPILE_JOBS and
LLVM_PARALLEL_LINK_JOBS
options but on some systems there still occured
out of memory errors after adjusting those options because there could also be a multiple other
LLVM related compile jobs that were running simultaneously in parallel.

To avoid this we may in some systems need to enable also the LLVM_PARALLEL_COMPILE_JOBS option at the same time.

For example the 32 GB ddr/16 GB swap/8 CPU core/16 CPU thread Linux system failed to build the LLVM for the out of memory error with following configure options:

    cmake -B build -GNinja -DTHEROCK_AMDGPU_FAMILIES=gfx1035 -DFLANG_PARALLEL_COMPILE_JOBS=4 -DLLVM_PARALLEL_LINK_JOBS=1 .

Clean LLVM build passed when LLVM_PARALLEL_COMPILE_JOBS option was added:

    cmake -B build -GNinja -DTHEROCK_AMDGPU_FAMILIES=gfx1035 -DLLVM_PARALLEL_COMPILE_JOBS=9 -DFLANG_PARALLEL_COMPILE_JOBS=4 -DLLVM_PARALLEL_LINK_JOBS=1 .
