### PR TITLE
Add Python setup scripts for os specific install test

### DIFF
--- a/build_tools/packaging/linux/set_python_cmd.py
+++ b/build_tools/packaging/linux/set_python_cmd.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-
+# Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
 """Resolve ``PYTHON_CMD`` from ``--os-profile`` and optionally install that runtime.
 


### PR DESCRIPTION
## Motivation

This pull request introduces a new script, `set_python_cmd.py`, to the `build_tools/packaging/linux` directory. The script standardizes how the appropriate Python interpreter command is resolved and optionally installed for different Linux distributions in CI and packaging workflows. It supports multiple output formats and can install the correct Python runtime using the native package manager.

## Technical Details

**Python runtime resolution and installation:**

* Adds `set_python_cmd.py`, which maps an `--os-profile` argument to the correct Python interpreter command (e.g., `python3.12` for Ubuntu/Debian, `python3.13` for SLES) and can install the required Python and pip packages using `apt`, `zypper`, or `dnf`, depending on the OS profile.

**Improved CI workflow reliability:**

* Allows CI workflows to reliably install and export the correct `PYTHON_CMD`, reducing dependency on pre-installed Python versions and improving reproducibility across different Linux distributions.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
