### PR TITLE
Revert "[rocshmem] add linux packaging"

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1867,83 +1867,6 @@
   },
 
   {
-    "Package": "amdrocm-rocshmem",
-    "Version": "",
-    "Architecture": "amd64",
-    "BuildArch": "x86_64",
-    "DEBDepends": [
-      "libc6",
-      "amdrocm-base"
-    ],
-    "RPMRequires": [
-      "amdrocm-base"
-    ],
-    "Maintainer": "rocSHMEM Maintainer <rocshmem-maintainer@amd.com>",
-    "Description_Short": "The ROCm OpenSHMEM (rocSHMEM) library, is an intra-kernel networking library that provides GPU-centric networking",
-    "Description_Long": "The ROCm OpenSHMEM (rocSHMEM) library, is an intra-kernel networking library that provides GPU-centric networking",
-    "Section": "devel",
-    "Priority": "optional",
-    "Group": "unknown",
-    "License": "MIT",
-    "Vendor": "Advanced Micro Devices, Inc",
-    "Homepage": "https://github.com/ROCm/rocm-systems/",
-    "Artifactory": [
-      {
-        "Artifact": "rocshmem",
-        "Artifact_Subdir": [
-          {
-            "Name": "rocshmem",
-            "Components": [
-              "lib",
-              "run",
-              "doc"
-            ]
-          }
-        ]
-      }
-    ],
-
-    "Gfxarch": "True"
-  },
-
-  {
-    "Package": "amdrocm-rocshmem-devel",
-    "Version": "",
-    "Architecture": "amd64",
-    "BuildArch": "x86_64",
-    "DEBDepends": [
-      "amdrocm-rocshmem"
-    ],
-    "RPMRequires": [
-      "amdrocm-rocshmem"
-    ],
-    "Maintainer": "rocSHMEM Maintainer <rocshmem-maintainer@amd.com>",
-    "Description_Short": "The ROCm OpenSHMEM (rocSHMEM) library, is an intra-kernel networking library that provides GPU-centric networking",
-    "Description_Long": "The ROCm OpenSHMEM (rocSHMEM) library, is an intra-kernel networking library that provides GPU-centric networking",
-    "Section": "devel",
-    "Priority": "optional",
-    "Group": "unknown",
-    "License": "MIT",
-    "Vendor": "Advanced Micro Devices, Inc",
-    "Homepage": "https://github.com/ROCm/rocm-systems/",
-    "Artifactory": [
-      {
-        "Artifact": "rocshmem",
-        "Artifact_Subdir": [
-          {
-            "Name": "rocshmem",
-            "Components": [
-              "dev"
-            ]
-          }
-        ]
-      }
-    ],
-
-    "Gfxarch": "True"
-  },
-
-  {
     "Package": "amdrocm-dnn",
     "Version": "",
     "Architecture": "amd64",
@@ -2454,7 +2377,6 @@
       "amdrocm-ck",
       "amdrocm-dnn",
       "amdrocm-rccl",
-      "amdrocm-rocshmem",
       "amdrocm-math-common",
       "amdrocm-amdsmi",
       "amdrocm-hipify",
@@ -2474,7 +2396,6 @@
       "amdrocm-ck",
       "amdrocm-dnn",
       "amdrocm-rccl",
-      "amdrocm-rocshmem",
       "amdrocm-math-common",
       "amdrocm-amdsmi",
       "amdrocm-hipify",
@@ -2535,7 +2456,6 @@
       "amdrocm-opencl-devel",
       "amdrocm-hipblas-common-devel",
       "amdrocm-rccl-devel",
-      "amdrocm-rocshmem-devel",
       "amdrocm-dnn-devel",
       "amdrocm-decode-devel",
       "amdrocm-jpeg-devel"
@@ -2553,7 +2473,6 @@
       "amdrocm-opencl-devel",
       "amdrocm-hipblas-common-devel",
       "amdrocm-rccl-devel",
-      "amdrocm-rocshmem-devel",
       "amdrocm-dnn-devel",
       "amdrocm-decode-devel",
       "amdrocm-jpeg-devel"


### PR DESCRIPTION
Reverts ROCm/TheRock#4046
breaking the CI due to missing of `amdrocm-rocshmem` doc artifact manifest`
more details: https://github.com/ROCm/TheRock/issues/4330