### PR TITLE
rocDecode Test - Use custom docker

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -478,10 +478,7 @@ test_matrix = {
         # rocdecode requires FFmpeg dev libraries (libavcodec-dev, libavformat-dev,
         # libavutil-dev) for test builds. These are not bundled in TheRock
         # artifacts and are provided via the specialized media image.
-        # TODO: switch to no_rocm_image_ubuntu24_04_media once its first image
-        # is published and the digest is available to pin here (see rocgdb for
-        # the pattern).
-        # "container_image": "ghcr.io/rocm/no_rocm_image_ubuntu24_04_media@sha256:...",
+        "container_image": "ghcr.io/rocm/no_rocm_image_ubuntu24_04_media@sha256:d715ae2db664b055c90343e00588ce9ac3eec387513fe359396e5e08e75521ca",
     },
     "rocjpeg": {
         "job_name": "rocjpeg",


### PR DESCRIPTION
## Motivation

Use custom docker to test rocDecode to run extended tests

## Technical Details

- Pin the `rocdecode` test configuration to the `no_rocm_image_ubuntu24_04_media` container image, resolving the TODO that was waiting for the image to be published.
- The media image includes the FFmpeg dev libraries (`libavcodec-dev`, `libavformat-dev`, `libavutil-dev`) required by rocdecode test builds, which are not bundled in TheRock artifacts.
- Image is pinned by digest (`sha256:d715ae2db664b055c90343e00588ce9ac3eec387513fe359396e5e08e75521ca`), following the same pattern used by `rocgdb`.

## Test plan

- [x] Verify CI picks up the new container image for `rocdecode` test jobs
- [ ] Confirm rocdecode tests pass with the media image (FFmpeg libraries are available at build/test time)

## Test Result

rocdecode test phase should pass with no errors

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
