### PR TITLE
doc: windows build clarifications

### DIFF
--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -209,13 +209,13 @@ If you prefer to install tools manually, you will need:
 
 - gfortran, recommended from Strawberry Perl: https://strawberryperl.com/
 
+- nasm, recommended from Strawberry Perl: https://strawberryperl.com/
+
 - patch, available in Strawberry Perl or Git.
 
 - dvc: https://dvc.org/doc/install/windows
 
 - Python: https://www.python.org/downloads/ (3.11+ recommended)
-
-- nasm: https://www.nasm.us/, needed for BoringSSL which is a dependency of grpc (therock-grpc)
 
 > [!WARNING]
 > Prefer to install Python for the current user only and to a path


### PR DESCRIPTION
## Motivation

I managed after a lot of effort to build TheRock on my Windows box without any failure for my gfx1031 :-)
this PR tries to clarify some gotchas that blocked me along the way in order to help future Windows builders.

## Technical Details

`nasm` is not mentioned in the doc.
The rest is gotchas that can happen on a living machine where the path may have incompatible installs that pollute the pure visual studio 2022 build chain (w64devkit, msys2, python)

## Test Plan

My objective was to achieve a full build.

## Test Result

I achieved a build with -DBUILD_TESTING=OFF as building the tests was taking too much time and I did not have the patience to wait for them. Now that it works, I could start a full build if necessary & if you tell me which tests are supposed to work when building for gfx1031 only.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
