### PR TITLE
Fix prebuilt stage missing RUNTIME_DEPS dependencies

### DIFF
--- a/build_tools/tests/therock_subproject_prebuilt_test.py
+++ b/build_tools/tests/therock_subproject_prebuilt_test.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests that a prebuilt subproject stage respects RUNTIME_DEPS ordering.
+
+A subproject whose stage directory is imported from an artifact (marked by a
+`<stage_dir>.prebuilt` file) still copies its RUNTIME_DEPS stage directories
+into its own dist directory. Those deps may be built from source in the same
+build -- that is the normal shape of a staged CI build, where
+`artifact_manager.py fetch --bootstrap` marks the inbound artifacts prebuilt
+while the stage's own subprojects build normally.
+
+See https://github.com/ROCm/TheRock/issues/7690.
+
+These tests drive `cmake/therock_subproject.cmake` through a miniature
+superproject rather than TheRock itself, so they need no submodules, no
+compiler, and no bundled sysdeps.
+"""
+
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+THEROCK_ROOT = Path(__file__).resolve().parents[2]
+
+# The subset of TheRock's CMake modules that therock_subproject.cmake needs to
+# be usable outside the superproject.
+HARNESS_INCLUDES = (
+    "therock_globals",
+    "therock_sanitizers",
+    "therock_flag_utils",
+    "therock_default_targets",
+    "therock_subproject",
+)
+
+
+def write_file(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(contents), encoding="utf-8")
+
+
+def write_harness(source_dir: Path) -> None:
+    """Writes a two-subproject superproject into `source_dir`.
+
+    `main_project` declares `RUNTIME_DEPS dep_project`, so its dist directory
+    must contain `lib/dep.txt` (installed by `dep_project`) in addition to
+    whatever is in its own stage directory.
+    """
+    includes = "\n".join(f"include({name})" for name in HARNESS_INCLUDES)
+    write_file(
+        source_dir / "CMakeLists.txt",
+        f"""
+        cmake_minimum_required(VERSION 3.25)
+        project(therock_subproject_prebuilt_harness NONE)
+
+        set(THEROCK_SOURCE_DIR "{THEROCK_ROOT.as_posix()}")
+        set(THEROCK_BINARY_DIR "${{CMAKE_BINARY_DIR}}")
+        list(APPEND CMAKE_MODULE_PATH "${{THEROCK_SOURCE_DIR}}/cmake")
+        find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+        # therock_subproject.cmake fingerprints this file. The harness declares
+        # no flags, so an empty state file is enough.
+        set(ROCM_BUILD_FLAGS_STATE_FILE "${{CMAKE_BINARY_DIR}}/rocm_build_flags_state.cmake")
+        file(WRITE "${{ROCM_BUILD_FLAGS_STATE_FILE}}" "# no flags\\n")
+
+        {includes}
+
+        therock_cmake_subproject_declare(dep_project
+          EXTERNAL_SOURCE_DIR "${{CMAKE_CURRENT_SOURCE_DIR}}/dep"
+          BINARY_DIR "${{CMAKE_CURRENT_BINARY_DIR}}/dep"
+        )
+        therock_cmake_subproject_activate(dep_project)
+
+        therock_cmake_subproject_declare(main_project
+          EXTERNAL_SOURCE_DIR "${{CMAKE_CURRENT_SOURCE_DIR}}/main"
+          BINARY_DIR "${{CMAKE_CURRENT_BINARY_DIR}}/main"
+          RUNTIME_DEPS dep_project
+        )
+        therock_cmake_subproject_activate(main_project)
+        """,
+    )
+    write_file(
+        source_dir / "dep" / "CMakeLists.txt",
+        """
+        cmake_minimum_required(VERSION 3.25)
+        project(dep_project NONE)
+        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/dep.txt" "dep\\n")
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/dep.txt" DESTINATION lib)
+        """,
+    )
+    write_file(
+        source_dir / "main" / "CMakeLists.txt",
+        """
+        cmake_minimum_required(VERSION 3.25)
+        project(main_project NONE)
+        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/main.txt" "main\\n")
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/main.txt" DESTINATION lib)
+        """,
+    )
+
+
+def mark_prebuilt(build_dir: Path) -> None:
+    """Imports `main_project`'s stage from an "artifact".
+
+    This mirrors what `ArtifactPopulator` in `build_tools/artifact_manager.py`
+    does under `--bootstrap`: populate the stage directory and drop a
+    `<stage_dir>.prebuilt` marker beside it, before CMake configures.
+    """
+    stage_dir = build_dir / "main" / "stage"
+    write_file(stage_dir / "lib" / "main.txt", "main\n")
+    (build_dir / "main" / "stage.prebuilt").touch()
+
+
+def run(*args: str) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        args,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if result.returncode != 0:
+        raise AssertionError(" ".join(args) + "\n" + result.stdout)
+    return result
+
+
+class PrebuiltRuntimeDepsTest(unittest.TestCase):
+    def _stage_main_project(self, *, prebuilt: bool) -> list[str]:
+        """Builds `main_project+stage` and returns its dist contents."""
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            temp_dir = Path(temp_dir_str)
+            source_dir = temp_dir / "source"
+            build_dir = temp_dir / "build"
+            write_harness(source_dir)
+            if prebuilt:
+                mark_prebuilt(build_dir)
+
+            run("cmake", "-S", str(source_dir), "-B", str(build_dir), "-GNinja")
+            run("cmake", "--build", str(build_dir), "--target", "main_project+stage")
+
+            dist_dir = build_dir / "main" / "dist"
+            return sorted(
+                p.relative_to(dist_dir).as_posix()
+                for p in dist_dir.rglob("*")
+                if p.is_file()
+            )
+
+    def test_built_subproject_dist_contains_runtime_deps(self):
+        # Control: when main_project is built normally, its dist picks up the
+        # runtime dep. This is the behavior the prebuilt path must match.
+        self.assertEqual(
+            self._stage_main_project(prebuilt=False),
+            ["lib/dep.txt", "lib/main.txt"],
+        )
+
+    def test_prebuilt_subproject_dist_contains_runtime_deps(self):
+        # Regression: the prebuilt stage rule copies from dep_project's stage
+        # directory, so it must also depend on dep_project having been staged.
+        # Without that dependency the copy runs first and silently produces a
+        # dist directory holding only the prebuilt artifact's own files.
+        self.assertEqual(
+            self._stage_main_project(prebuilt=True),
+            ["lib/dep.txt", "lib/main.txt"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -917,11 +917,6 @@ function(therock_cmake_subproject_activate target_name)
   list(APPEND _fprint_files "${_cmake_project_init_file}")
   list(APPEND _fprint_files "${ROCM_BUILD_FLAGS_STATE_FILE}")
 
-  # Transform build and run deps from target form (i.e. 'ROCR-Runtime' to a dependency
-  # on the stage.stamp file). These are a dependency for configure.
-  set(_configure_dep_stamps)
-  _therock_cmake_subproject_deps_to_stamp(_configure_dep_stamps stage.stamp ${_build_deps} ${_runtime_deps})
-
   # Target flags.
   set(_all_option)
   if(NOT _exclude_from_all)
@@ -958,6 +953,10 @@ function(therock_cmake_subproject_activate target_name)
     # marker file (which may just be a stamp file or may contain a unique hash
     # for this part of the build).
     message(STATUS "  DISABLING BUILD: Marked as pre-built")
+    # For prebuilt artifacts, we need runtime deps staged before copying from them.
+    set(_runtime_dep_stamps)
+    _therock_cmake_subproject_deps_to_stamp(_runtime_dep_stamps stage.stamp ${_runtime_deps})
+
     add_custom_command(
       OUTPUT "${_configure_stamp_file}"
       COMMAND "${CMAKE_COMMAND}" -E touch "${_configure_stamp_file}"
@@ -976,9 +975,15 @@ function(therock_cmake_subproject_activate target_name)
       DEPENDS
         "${_prebuilt_file}"
         "${_fileset_tool}"
+        ${_runtime_dep_stamps}
     )
   else()
     # Not pre-built: normal configure/build/stage install.
+    # Transform build and run deps from target form (i.e. 'ROCR-Runtime') to a dependency
+    # on the stage.stamp file. These are a dependency for configure.
+    set(_configure_dep_stamps)
+    _therock_cmake_subproject_deps_to_stamp(_configure_dep_stamps stage.stamp ${_build_deps} ${_runtime_deps})
+
     # configure target
     if(THEROCK_VERBOSE)
       message(STATUS "  CONFIGURE_DEPENDS: ${_transitive_configure_depend_files} ")


### PR DESCRIPTION
## Motivation

Closes #7690.

When a subproject's stage directory is imported from a prebuilt artifact (a
`<stage_dir>.prebuilt` marker, as written by `artifact_manager.py fetch --bootstrap`), the generated
stage rule copies from its own stage dir **and from every `RUNTIME_DEPS` stage dir** — but it does
not depend on those runtime deps having been staged.

In a hybrid build, where some subprojects are prebuilt and their runtime deps are still built from
source, ninja is free to run that copy before the runtime deps exist. The resulting `dist/` silently
lacks the runtime libraries, and the rule exits 0. Originally hit with `hip-clr` prebuilt against a
source-built `ROCR-Runtime`: no `libhsa-runtime64.so.1` in `dist/`.

This is the normal shape of every staged multi-arch CI build —
`multi_arch_build_portable_linux_artifacts.yml`, `multi_arch_build_windows_artifacts.yml` and
`multi_arch_build_wsl_rocdxg_artifacts.yml` all fetch inbound artifacts with `--bootstrap` while the
stage's own subprojects build from source.

## Technical Details

The non-prebuilt branch never had this problem, but only by accident of the stamp chain:
`stage.stamp` ← `build.stamp` ← `configure.stamp` ← `_configure_dep_stamps`, which includes the
runtime deps' `stage.stamp`. Marking a subproject prebuilt reduces `configure` and `build` to bare
`touch` commands, which deletes that chain — and with it the only thing sequencing the runtime deps.

The fix adds the `RUNTIME_DEPS` stage stamps to the prebuilt stage command's `DEPENDS`, so the
`fileset_tool.py copy` cannot run until every directory it reads from has been staged.
`_configure_dep_stamps` moves into the non-prebuilt branch, where it is the only branch that uses it.

## Risk Assessment

**Risk level 2.** Superbuild-only change confined to the prebuilt branch of
`therock_cmake_subproject_activate()`; it adds dependency edges and removes none. Builds with no
prebuilt subprojects generate an identical graph. Builds with prebuilt subprojects gain ordering
edges they should already have had, which can only serialize work that was previously free to race —
no new cycles, since these are the same edges the non-prebuilt path already carries transitively.

## Related

- Work tracking / defect: #7690
- Predecessor: #7551 (`fix(bootstrap): write .prebuilt marker at the subproject stage dir`), which
  put the marker where this code path reads it.

## Device / Architecture Coverage

None required. The change is architecture-independent: it only alters CMake dependency-graph
construction, and touches no kernel selection, default, or support surface. Passing PR CI is
sufficient.

## Test Plan

New regression test `build_tools/tests/therock_subproject_prebuilt_test.py`, picked up by the
existing `pytest build_tools/` lane in `unit_tests.yml` (Linux + Windows). It drives
`cmake/therock_subproject.cmake` through a two-subproject miniature superproject — `main_project`
declares `RUNTIME_DEPS dep_project`, and `main_project`'s stage is imported from a `.prebuilt`
marker the way `ArtifactPopulator` writes one under `--bootstrap`. The harness needs no submodules,
no compiler and no bundled sysdeps, and follows the pattern already used by
`build_tools/tests/rocm_build_flags_test.py`.

- `test_prebuilt_subproject_dist_contains_runtime_deps` — the regression: `main_project`'s dist must
  contain `lib/dep.txt`.
- `test_built_subproject_dist_contains_runtime_deps` — control: same assertion for a normally-built
  `main_project`, so the two cases differ only by the prebuilt marker.

Separately verified against real subprojects: `therock-elfutils` marked prebuilt with its
`RUNTIME_DEPS therock-bzip2/liblzma/zlib/zstd` built from source. Full script and both outputs are
in #7690.

## Testing Checklist

- [x] Regression test, fix reverted - `git revert --no-commit HEAD && pytest tests/therock_subproject_prebuilt_test.py` - Status: Failed as expected (`['lib/main.txt'] != ['lib/dep.txt', 'lib/main.txt']`)
- [x] Regression test, fix applied - `cd build_tools && pytest tests/therock_subproject_prebuilt_test.py` - Status: Passed (2 passed in 0.88s)
- [x] Full unit-test lane, locally (Linux) - `cd build_tools && pytest` - Status: Passed (2063 passed, 8 skipped)
- [x] Unit Tests :: ubuntu-24.04 and windows-2022 - GitHub PR checks - Status: Passed (new test green on both; 5-8s per case on Windows)
- [x] `therock-elfutils` end-to-end repro, before/after - Status: Passed (see #7690)
- [x] pre-commit - `pre-commit run --files build_tools/tests/therock_subproject_prebuilt_test.py` - Status: Passed
- [ ] PR CI - GitHub PR checks - Status: Pending

## Test Result

With the fix reverted, `test_prebuilt_subproject_dist_contains_runtime_deps` fails and the control
passes — the two differ only by the `.prebuilt` marker. With the fix, both pass. The full
`build_tools` suite is green.

On real subprojects, `ninja therock-elfutils+stage` went from one edge and a two-file `dist/` (none
of the four runtime deps built, exit 0) to staging all four deps and landing
`librocm_sysdeps_{bz2,liblzma,z,zstd}.so` in `dist/`.

## Flags / Guardrails

None. The change is unconditional and has no runtime behavior to gate.

## Adjacent Tests Considered

`build_tools/tests/configure_stage_test.py` and `build_topology_test.py` cover which artifacts a
stage declares prebuilt, but not the resulting build graph, so they are unaffected. The Consumer
Graph Drift Check is the other consumer of subproject dependency declarations; it was green on the
fix commit and should stay green — this change adds no edges to the consumer graph, only to the
ninja graph.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
