### PR TITLE
[ci] Re-enabling gfx90a runners

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -219,7 +219,6 @@ amdgpu_family_info_matrix_nightly = {
             "test-runs-on": "linux-gfx90a-gpu-rocm",
             "family": "gfx90a",
             "fetch-gfx-targets": ["gfx90a"],
-            "sanity_check_only_for_family": True,
             "build_variants": ["release"],
             "nightly_check_only_for_family": True,
         },


### PR DESCRIPTION
We have gfx90a runners from cirrascale. These labels are set up with actions-prolense! 

Tests here: https://github.com/ROCm/TheRock/actions/runs/24091222142/job/70278066748