### PR TITLE
[ci] Updating submodules to run only on M-F

### DIFF
--- a/.github/workflows/bump_submodules.yml
+++ b/.github/workflows/bump_submodules.yml
@@ -6,7 +6,7 @@ name: Bump Submodule automation
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *" # Runs every 12 hrs at 12AM and 12PM
+    - cron: "0 */12 * * 1-5" # Runs every 12 hrs at 12AM and 12PM UTC, Monday through Friday
   push:
     branches:
       - main


### PR DESCRIPTION
Getting PR reviews for weekend submodule updates, when no one really observes / checks over weekend in regards to submodule bumps