### PR TITLE
Changes for adding ElfUtils to third-party/sysdeps

### DIFF
--- a/cmake/therock_subproject_dep_provider.cmake
+++ b/cmake/therock_subproject_dep_provider.cmake
@@ -91,7 +91,7 @@ function(therock_reparse_super_project_find_package superproject_path package_na
   cmake_parse_arguments(PARSE_ARGV 1 UNUSED
     "BYPASS_PROVIDER;CONFIG;MODULE;NO_DEFAULT_PATH;NO_CMAKE_PATH;NO_CMAKE_ENVIRONMENT_PATH;NO_SYSTEM_ENVIRONMENT_PATH;NO_CMAKE_PACKAGE_REGISTRY"
     ""
-    "HINTS;PATHS"
+    "HINTS;PATHS;COMPONENTS;OPTIONAL_COMPONENTS"
   )
   if(NOT superproject_path)
     message(FATAL_ERROR "Super-project package path not found for ${package_name}")
@@ -99,6 +99,16 @@ function(therock_reparse_super_project_find_package superproject_path package_na
 
   # The signature of MODULE vs DEFAULT mode is different, so switch.
   set(_rewritten ${UNUSED_UNPARSED_ARGUMENTS})
+
+  # Preserve COMPONENTS and OPTIONAL_COMPONENTS if they were specified. Some packages
+  # (e.g. Boost) require these to be specified in the find_package signature.
+  if(UNUSED_COMPONENTS)
+    list(APPEND _rewritten COMPONENTS ${UNUSED_COMPONENTS})
+  endif()
+  if(UNUSED_OPTIONAL_COMPONENTS)
+    list(APPEND _rewritten OPTIONAL_COMPONENTS ${UNUSED_OPTIONAL_COMPONENTS})
+  endif()
+
   # Some very old code uses explicit MODULE mode, which forces the basic
   # signature (*cough* old FindHIP based junk). In this mode, there is no way
   # to explicitly indicate a search path in the signature (and other options

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -173,7 +173,6 @@ if(THEROCK_ENABLE_ROCPROFV3)
       aqlprofile
       hip-clr
       rocprofiler-register
-      ${THEROCK_BUNDLED_ELFUTILS}
       ${THEROCK_BUNDLED_LIBDRM}
       ${THEROCK_BUNDLED_SQLITE3}
       ${_openmpi_optional_dep}
@@ -296,7 +295,6 @@ if(THEROCK_ENABLE_ROCPROFV3)
       BACKGROUND_BUILD
       CMAKE_ARGS
         -DHIP_PLATFORM=amd
-        -DROCPROFSYS_BUILD_ELFUTILS=ON
         -DROCPROFSYS_BUILD_TBB=ON
         -DROCPROFSYS_BUILD_LIBIBERTY=ON
         -DROCPROFSYS_BUILD_BOOST=ON

--- a/third-party/sysdeps/linux/elfutils/CMakeLists.txt
+++ b/third-party/sysdeps/linux/elfutils/CMakeLists.txt
@@ -65,6 +65,11 @@ if(NOT PATCHELF)
   message(FATAL_ERROR "Missing PATCHELF from super-project")
 endif()
 
+# fPIC needed for rocprofiler-systems
+set(EXTRA_CFLAGS)
+string(APPEND EXTRA_CFLAGS " -fPIC")
+message(STATUS "EXTRA_CFLAGS=${EXTRA_CLFAGS}")
+
 # HACK: elfutils consults pkg-config for cflags for the compression libraries
 # but then does not seem to use them everywhere needed. So we just hard-code
 # paths.
@@ -73,6 +78,7 @@ string(APPEND EXTRA_CPPFLAGS " -I${THEROCK_BINARY_DIR}/third-party/sysdeps/linux
 string(APPEND EXTRA_CPPFLAGS " -I${THEROCK_BINARY_DIR}/third-party/sysdeps/linux/liblzma/build/stage/lib/rocm_sysdeps/include")
 string(APPEND EXTRA_CPPFLAGS " -I${THEROCK_BINARY_DIR}/third-party/sysdeps/linux/zlib/build/stage/lib/rocm_sysdeps/include")
 string(APPEND EXTRA_CPPFLAGS " -I${THEROCK_BINARY_DIR}/third-party/sysdeps/linux/zstd/build/stage/lib/rocm_sysdeps/include")
+string(APPEND EXTRA_CPPFLAGS " -fPIC")
 message(STATUS "EXTRA_CPPFLAGS=${EXTRA_CPPFLAGS}")
 
 add_custom_target(
@@ -99,6 +105,7 @@ add_custom_target(
       # Escaping: Double $ to satisfy CMake, then double $ to satisfy configure,
       # then escaped single quotes to make it to the linker command line.
       "LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath=\\'\\$$\\$$ORIGIN\\'"
+      "CFLAGS=${EXTRA_CFLAGS}"
       "CPPFLAGS=${EXTRA_CPPFLAGS}"
       --
     "${CMAKE_CURRENT_BINARY_DIR}/s/configure"


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Adding ElfUtils to third-party/sysdeps.

## Technical Details
Modified build scripts to add elfutils to third-party/sysdeps. Because elfutils is built as part of sysdeps, ROCPROFSYS_BUILD_ELFUTILS has to be OFF for building rocprofiler-systems.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Build of TheRock has to succeed.

## Test Result

<!-- Briefly summarize test outcomes. -->


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
