### PR TITLE
feat: Add libiberty as a bundled sysdep for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ option(THEROCK_COMPOSABLE_KERNEL_FOR_MIOPEN_ONLY
 option(THEROCK_BUILD_LLVM_TOOLS "Enables building all LLVM tools (not just minimum required)" OFF)
 option(THEROCK_BUILD_LLVM_TESTS "Enables building LLVM LIT tests" OFF)
 option(THEROCK_ENABLE_HOTSWAP "Enables the comgr hotswap transpiler/tool and loads it in the runtime via HSA_TOOLS_LIB" ON)
+option(THEROCK_USE_NEW_HOSTCALL_IMPL "Use the new phase/occupancy-based hostcall implementation in device-libs and clr" OFF)
 
 set(THEROCK_SANITIZER "" CACHE STRING "Enable project wide sanitizer build ('ASAN' for host+device, 'HOST_ASAN' for host-only)")
 
@@ -264,9 +265,10 @@ include("${CMAKE_CURRENT_BINARY_DIR}/cmake/therock_topology.cmake")
 # The HIP runtime for ROCm uses different implementations per platform today:
 #   * HIP on Linux uses the HSA runtime in ROCR-Runtime, used by CLR.
 #   * HIP on Windows uses the PAL runtime included directly as part of CLR.
+#     The ROCR-Runtime/rocminfo payload in core-runtime can be enabled
+#     experimentally with THEROCK_FLAG_HSA_WINDOWS_SHARED_RUNTIME.
 # https://rocm.docs.amd.com/projects/install-on-windows/en/latest/reference/component-support.html
-# Platform-specific dependencies are handled automatically by therock_add_feature()
-# which filters out CORE_RUNTIME dependency for HIP_RUNTIME on Windows.
+# Platform-specific dependencies are handled automatically by therock_add_feature().
 
 # Optional sub-features that control behavior within artifacts
 cmake_dependent_option(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL
@@ -373,7 +375,6 @@ endif()
 ################################################################################
 
 set(THEROCK_BUNDLED_BZIP2)
-set(THEROCK_BUNDLED_LIBIBERTY)
 set(THEROCK_BUNDLED_ELFUTILS)
 set(THEROCK_BUNDLED_EXPAT)
 set(THEROCK_BUNDLED_GMP)
@@ -381,6 +382,7 @@ set(THEROCK_BUNDLED_HWLOC)
 set(THEROCK_BUNDLED_LIBBACKTRACE)
 set(THEROCK_BUNDLED_LIBCAP)
 set(THEROCK_BUNDLED_LIBDRM)
+set(THEROCK_BUNDLED_LIBIBERTY)
 set(THEROCK_BUNDLED_LIBLZMA)
 set(THEROCK_BUNDLED_LIBMNL)
 set(THEROCK_BUNDLED_LIBNL)
@@ -403,11 +405,11 @@ if(THEROCK_BUNDLE_SYSDEPS)
     endif()
     # Core sysdeps (always part of the 'sysdeps' artifact)
     set(THEROCK_BUNDLED_BZIP2 therock-bzip2)
-    set(THEROCK_BUNDLED_LIBIBERTY therock-libiberty)
     set(THEROCK_BUNDLED_ELFUTILS therock-elfutils)
     set(THEROCK_BUNDLED_LIBBACKTRACE therock-libbacktrace)
     set(THEROCK_BUNDLED_LIBCAP therock-libcap)
     set(THEROCK_BUNDLED_LIBDRM therock-libdrm)
+    set(THEROCK_BUNDLED_LIBIBERTY therock-libiberty)
     set(THEROCK_BUNDLED_LIBLZMA therock-liblzma)
     set(THEROCK_BUNDLED_LIBMNL therock-libmnl)
     set(THEROCK_BUNDLED_LIBNL therock-libnl)
@@ -498,6 +500,10 @@ add_subdirectory(compiler)
 add_subdirectory(third-party)
 add_subdirectory(core)
 add_subdirectory(debug-tools)
+# media-libs (rocdecode/rocjpeg) must be added before profiler: rocprofiler-sdk
+# performs optional find_package(rocdecode)/find_package(rocjpeg) for trace
+# feature detection.
+add_subdirectory(media-libs)
 # Note that rocprofiler-register is in base and is what higher level clients
 # depend on. The profiler itself is independent.
 add_subdirectory(profiler)
@@ -509,7 +515,6 @@ add_subdirectory(comm-libs)
 add_subdirectory(storage-libs)
 add_subdirectory(math-libs)
 add_subdirectory(ml-libs)
-add_subdirectory(media-libs)
 
 if(THEROCK_BUILD_TESTING)
   add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,6 @@ option(THEROCK_COMPOSABLE_KERNEL_FOR_MIOPEN_ONLY
 option(THEROCK_BUILD_LLVM_TOOLS "Enables building all LLVM tools (not just minimum required)" OFF)
 option(THEROCK_BUILD_LLVM_TESTS "Enables building LLVM LIT tests" OFF)
 option(THEROCK_ENABLE_HOTSWAP "Enables the comgr hotswap transpiler/tool and loads it in the runtime via HSA_TOOLS_LIB" ON)
-option(THEROCK_USE_NEW_HOSTCALL_IMPL "Use the new phase/occupancy-based hostcall implementation in device-libs and clr" OFF)
 
 set(THEROCK_SANITIZER "" CACHE STRING "Enable project wide sanitizer build ('ASAN' for host+device, 'HOST_ASAN' for host-only)")
 
@@ -265,10 +264,9 @@ include("${CMAKE_CURRENT_BINARY_DIR}/cmake/therock_topology.cmake")
 # The HIP runtime for ROCm uses different implementations per platform today:
 #   * HIP on Linux uses the HSA runtime in ROCR-Runtime, used by CLR.
 #   * HIP on Windows uses the PAL runtime included directly as part of CLR.
-#     The ROCR-Runtime/rocminfo payload in core-runtime can be enabled
-#     experimentally with THEROCK_FLAG_HSA_WINDOWS_SHARED_RUNTIME.
 # https://rocm.docs.amd.com/projects/install-on-windows/en/latest/reference/component-support.html
-# Platform-specific dependencies are handled automatically by therock_add_feature().
+# Platform-specific dependencies are handled automatically by therock_add_feature()
+# which filters out CORE_RUNTIME dependency for HIP_RUNTIME on Windows.
 
 # Optional sub-features that control behavior within artifacts
 cmake_dependent_option(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL
@@ -375,6 +373,7 @@ endif()
 ################################################################################
 
 set(THEROCK_BUNDLED_BZIP2)
+set(THEROCK_BUNDLED_LIBIBERTY)
 set(THEROCK_BUNDLED_ELFUTILS)
 set(THEROCK_BUNDLED_EXPAT)
 set(THEROCK_BUNDLED_GMP)
@@ -404,6 +403,7 @@ if(THEROCK_BUNDLE_SYSDEPS)
     endif()
     # Core sysdeps (always part of the 'sysdeps' artifact)
     set(THEROCK_BUNDLED_BZIP2 therock-bzip2)
+    set(THEROCK_BUNDLED_LIBIBERTY therock-libiberty)
     set(THEROCK_BUNDLED_ELFUTILS therock-elfutils)
     set(THEROCK_BUNDLED_LIBBACKTRACE therock-libbacktrace)
     set(THEROCK_BUNDLED_LIBCAP therock-libcap)
@@ -498,10 +498,6 @@ add_subdirectory(compiler)
 add_subdirectory(third-party)
 add_subdirectory(core)
 add_subdirectory(debug-tools)
-# media-libs (rocdecode/rocjpeg) must be added before profiler: rocprofiler-sdk
-# performs optional find_package(rocdecode)/find_package(rocjpeg) for trace
-# feature detection.
-add_subdirectory(media-libs)
 # Note that rocprofiler-register is in base and is what higher level clients
 # depend on. The profiler itself is independent.
 add_subdirectory(profiler)
@@ -513,6 +509,7 @@ add_subdirectory(comm-libs)
 add_subdirectory(storage-libs)
 add_subdirectory(math-libs)
 add_subdirectory(ml-libs)
+add_subdirectory(media-libs)
 
 if(THEROCK_BUILD_TESTING)
   add_subdirectory(examples)

--- a/cmake/finders/FindLibIberty.cmake
+++ b/cmake/finders/FindLibIberty.cmake
@@ -1,0 +1,25 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# This finder is injected at the front of CMAKE_MODULE_PATH for all TheRock
+# sub-projects via therock_subproject.cmake.
+#
+# When LibIberty is bundled (present in THEROCK_PROVIDED_PACKAGES), the
+# therock_subproject_dep_provider intercepts find_package(LibIberty) before
+# this module is reached and loads libiberty-config.cmake directly.  That
+# config file creates the LibIberty::LibIberty SHARED IMPORTED GLOBAL target.
+#
+# When LibIberty is not bundled, the dep provider falls back here and we
+# report not-found so that the sub-project (rocprofiler-systems / Dyninst)
+# can use its own build mechanism (ROCPROFSYS_BUILD_LIBIBERTY=ON).
+cmake_policy(PUSH)
+cmake_policy(SET CMP0057 NEW)
+
+if("LibIberty" IN_LIST THEROCK_PROVIDED_PACKAGES)
+  message(STATUS "Resolving bundled libiberty from super-project")
+  find_package(LibIberty CONFIG REQUIRED)
+else()
+  set(LibIberty_FOUND FALSE)
+endif()
+
+cmake_policy(POP)

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -6,6 +6,18 @@ if(THEROCK_ENABLE_MPI)
   set(_openmpi_optional_dep therock-openmpi)
 endif()
 
+# rocprofiler-sdk performs optional find_package(rocdecode)/find_package(rocjpeg)
+# to detect the rocDecode/rocJPEG trace features. Declare them as dependencies
+# when available so they resolve from the super-project dist rather than
+# escaping to a stray build tree.
+set(_rocprofiler_sdk_optional_deps)
+if(THEROCK_ENABLE_ROCDECODE AND THEROCK_ENABLE_SYSDEPS_AMD_MESA)
+  list(APPEND _rocprofiler_sdk_optional_deps rocdecode)
+endif()
+if(THEROCK_ENABLE_ROCJPEG AND THEROCK_ENABLE_SYSDEPS_AMD_MESA)
+  list(APPEND _rocprofiler_sdk_optional_deps rocjpeg)
+endif()
+
 if(THEROCK_ENABLE_ROCPROFV3)
 
   ##############################################################################
@@ -20,6 +32,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprof-trace-decoder"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprof-trace-decoder"
     BACKGROUND_BUILD
+    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_provide_package(rocprof-trace-decoder rocprof-trace-decoder lib/cmake/rocprof-trace-decoder)
   therock_cmake_subproject_activate(rocprof-trace-decoder)
@@ -50,6 +63,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
       hip-clr
       amd-llvm
       ROCR-Runtime
+    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_glob_c_sources(aqlprofile
     SUBDIRS .
@@ -120,6 +134,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
       rocprof-trace-decoder
       rocprofiler-register
       therock-yaml-cpp
+      ${_rocprofiler_sdk_optional_deps}
       ${THEROCK_BUNDLED_ELFUTILS}
       ${THEROCK_BUNDLED_LIBDRM}
       ${THEROCK_BUNDLED_SQLITE3}
@@ -131,6 +146,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
     INTERFACE_INSTALL_RPATH_DIRS
       lib
       lib/rocm_sysdeps/lib
+    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_glob_c_sources(rocprofiler-sdk
     SUBDIRS .
@@ -185,6 +201,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
     RUNTIME_DEPS
       hip-clr
       ROCR-Runtime
+    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_glob_c_sources(roctracer
     SUBDIRS .
@@ -246,6 +263,7 @@ if(THEROCK_ENABLE_ROCPROFILER_COMPUTE)
       ${THEROCK_BUNDLED_LIBDRM}
       ${THEROCK_BUNDLED_SQLITE3}
       ${_openmpi_optional_dep}
+    TEST_SUBPROJECTS
     )
     therock_cmake_subproject_glob_c_sources(rocprofiler-compute
       SUBDIRS .
@@ -346,6 +364,7 @@ if(THEROCK_ENABLE_ROCPROFSYS)
       ${THEROCK_BUNDLED_LIBDRM}
       ${THEROCK_BUNDLED_SQLITE3}
       ${_openmpi_optional_dep}
+    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_glob_c_sources(rocprofiler-systems
     SUBDIRS .

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -6,18 +6,6 @@ if(THEROCK_ENABLE_MPI)
   set(_openmpi_optional_dep therock-openmpi)
 endif()
 
-# rocprofiler-sdk performs optional find_package(rocdecode)/find_package(rocjpeg)
-# to detect the rocDecode/rocJPEG trace features. Declare them as dependencies
-# when available so they resolve from the super-project dist rather than
-# escaping to a stray build tree.
-set(_rocprofiler_sdk_optional_deps)
-if(THEROCK_ENABLE_ROCDECODE AND THEROCK_ENABLE_SYSDEPS_AMD_MESA)
-  list(APPEND _rocprofiler_sdk_optional_deps rocdecode)
-endif()
-if(THEROCK_ENABLE_ROCJPEG AND THEROCK_ENABLE_SYSDEPS_AMD_MESA)
-  list(APPEND _rocprofiler_sdk_optional_deps rocjpeg)
-endif()
-
 if(THEROCK_ENABLE_ROCPROFV3)
 
   ##############################################################################
@@ -32,7 +20,6 @@ if(THEROCK_ENABLE_ROCPROFV3)
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprof-trace-decoder"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprof-trace-decoder"
     BACKGROUND_BUILD
-    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_provide_package(rocprof-trace-decoder rocprof-trace-decoder lib/cmake/rocprof-trace-decoder)
   therock_cmake_subproject_activate(rocprof-trace-decoder)
@@ -63,7 +50,6 @@ if(THEROCK_ENABLE_ROCPROFV3)
       hip-clr
       amd-llvm
       ROCR-Runtime
-    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_glob_c_sources(aqlprofile
     SUBDIRS .
@@ -134,7 +120,6 @@ if(THEROCK_ENABLE_ROCPROFV3)
       rocprof-trace-decoder
       rocprofiler-register
       therock-yaml-cpp
-      ${_rocprofiler_sdk_optional_deps}
       ${THEROCK_BUNDLED_ELFUTILS}
       ${THEROCK_BUNDLED_LIBDRM}
       ${THEROCK_BUNDLED_SQLITE3}
@@ -146,7 +131,6 @@ if(THEROCK_ENABLE_ROCPROFV3)
     INTERFACE_INSTALL_RPATH_DIRS
       lib
       lib/rocm_sysdeps/lib
-    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_glob_c_sources(rocprofiler-sdk
     SUBDIRS .
@@ -201,7 +185,6 @@ if(THEROCK_ENABLE_ROCPROFV3)
     RUNTIME_DEPS
       hip-clr
       ROCR-Runtime
-    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_glob_c_sources(roctracer
     SUBDIRS .
@@ -263,7 +246,6 @@ if(THEROCK_ENABLE_ROCPROFILER_COMPUTE)
       ${THEROCK_BUNDLED_LIBDRM}
       ${THEROCK_BUNDLED_SQLITE3}
       ${_openmpi_optional_dep}
-    TEST_SUBPROJECTS
     )
     therock_cmake_subproject_glob_c_sources(rocprofiler-compute
       SUBDIRS .
@@ -314,6 +296,13 @@ if(THEROCK_ENABLE_ROCPROFSYS)
     message(STATUS "Detected Python root dirs for rocprofiler-systems: ${_ROCPROFSYS_PYTHON_ROOT_DIRS_STR}")
   endif()
 
+  # When libiberty is bundled; otherwise let rocprofiler-systems build its own.
+  if(THEROCK_BUNDLED_LIBIBERTY)
+    set(_rocprofsys_build_libiberty OFF)
+  else()
+    set(_rocprofsys_build_libiberty ON)
+  endif()
+
   therock_cmake_subproject_declare(rocprofiler-systems
     USE_DIST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprofiler-systems"
@@ -322,7 +311,7 @@ if(THEROCK_ENABLE_ROCPROFSYS)
     CMAKE_ARGS
       -DHIP_PLATFORM=amd
       -DROCPROFSYS_BUILD_TBB=ON
-      -DROCPROFSYS_BUILD_LIBIBERTY=ON
+      -DROCPROFSYS_BUILD_LIBIBERTY="${_rocprofsys_build_libiberty}"
       -DROCPROFSYS_BUILD_DYNINST=ON
       -DROCPROFSYS_BUILD_FOR_THEROCK=ON
       -DROCPROFSYS_USE_PYTESTS=OFF
@@ -352,11 +341,11 @@ if(THEROCK_ENABLE_ROCPROFSYS)
       hip-clr
       rocprofiler-register
       rocprofiler-sdk
+      ${THEROCK_BUNDLED_LIBIBERTY}
       ${THEROCK_BUNDLED_ELFUTILS}
       ${THEROCK_BUNDLED_LIBDRM}
       ${THEROCK_BUNDLED_SQLITE3}
       ${_openmpi_optional_dep}
-    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_glob_c_sources(rocprofiler-systems
     SUBDIRS .

--- a/third-party/sysdeps/linux/CMakeLists.txt
+++ b/third-party/sysdeps/linux/CMakeLists.txt
@@ -18,8 +18,8 @@ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../common/zlib" "${CMAKE_CURRENT_B
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../common/zstd" "${CMAKE_CURRENT_BINARY_DIR}/zstd")
 
 # Core system deps that depend on the above.
-add_subdirectory(libiberty)
 add_subdirectory(elfutils)
+add_subdirectory(libiberty)
 
 therock_provide_artifact(sysdeps
   TARGET_NEUTRAL
@@ -30,12 +30,12 @@ therock_provide_artifact(sysdeps
     lib
     run
   SUBPROJECT_DEPS
-    therock-libiberty
     therock-bzip2
     therock-elfutils
     therock-libbacktrace
     therock-libcap
     therock-libdrm
+    therock-libiberty
     therock-liblzma
     therock-libmnl
     therock-libnl

--- a/third-party/sysdeps/linux/CMakeLists.txt
+++ b/third-party/sysdeps/linux/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../common/zlib" "${CMAKE_CURRENT_B
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../common/zstd" "${CMAKE_CURRENT_BINARY_DIR}/zstd")
 
 # Core system deps that depend on the above.
+add_subdirectory(libiberty)
 add_subdirectory(elfutils)
 
 therock_provide_artifact(sysdeps
@@ -29,6 +30,7 @@ therock_provide_artifact(sysdeps
     lib
     run
   SUBPROJECT_DEPS
+    therock-libiberty
     therock-bzip2
     therock-elfutils
     therock-libbacktrace

--- a/third-party/sysdeps/linux/artifact.toml
+++ b/third-party/sysdeps/linux/artifact.toml
@@ -13,10 +13,6 @@ include = [
 ]
 [components.lib."third-party/sysdeps/linux/bzip2/build/stage"]
 
-# libiberty
-[components.lib."third-party/sysdeps/linux/libiberty/build/stage"]
-[components.dev."third-party/sysdeps/linux/libiberty/build/stage"]
-
 # elfutils
 [components.lib."third-party/sysdeps/linux/elfutils/build/stage"]
 [components.dev."third-party/sysdeps/linux/elfutils/build/stage"]
@@ -36,6 +32,10 @@ include = [
   "**/share/**",
 ]
 [components.dev."third-party/sysdeps/linux/libdrm/build/stage"]
+
+# libiberty
+[components.lib."third-party/sysdeps/linux/libiberty/build/stage"]
+[components.dev."third-party/sysdeps/linux/libiberty/build/stage"]
 
 # liblzma
 [components.lib."third-party/sysdeps/linux/liblzma/build/stage"]

--- a/third-party/sysdeps/linux/artifact.toml
+++ b/third-party/sysdeps/linux/artifact.toml
@@ -13,6 +13,10 @@ include = [
 ]
 [components.lib."third-party/sysdeps/linux/bzip2/build/stage"]
 
+# libiberty
+[components.lib."third-party/sysdeps/linux/libiberty/build/stage"]
+[components.dev."third-party/sysdeps/linux/libiberty/build/stage"]
+
 # elfutils
 [components.lib."third-party/sysdeps/linux/elfutils/build/stage"]
 [components.dev."third-party/sysdeps/linux/elfutils/build/stage"]

--- a/third-party/sysdeps/linux/libiberty/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libiberty/CMakeLists.txt
@@ -12,7 +12,6 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
       URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/binutils-2.46.0.tar.gz"
       URL_HASH "SHA512=30d24f7461d459dcbd04e506bb74e487a92748ed411878aacf7388a79ac5b73f968569f43385c9f12c669a5c0b0295d3083a8a4f3ab1be1bb826b3a15ec1f029"
       TOUCH "${_download_stamp}"
-      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     )
 
     therock_cmake_subproject_declare(therock-libiberty

--- a/third-party/sysdeps/linux/libiberty/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libiberty/CMakeLists.txt
@@ -1,0 +1,121 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    # When included in TheRock, we download sources and set up the sub-project.
+    set(_source_dir "${CMAKE_CURRENT_BINARY_DIR}/source")
+    set(_download_stamp "${_source_dir}/download.stamp")
+
+    therock_subproject_fetch(therock-libiberty-sources
+      SOURCE_DIR "${_source_dir}"
+      # Originally mirrored from: "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.46.0.tar.gz"
+      URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/binutils-2.46.0.tar.gz"
+      URL_HASH "SHA512=30d24f7461d459dcbd04e506bb74e487a92748ed411878aacf7388a79ac5b73f968569f43385c9f12c669a5c0b0295d3083a8a4f3ab1be1bb826b3a15ec1f029"
+      TOUCH "${_download_stamp}"
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+
+    therock_cmake_subproject_declare(therock-libiberty
+      USE_DIST_AMDGPU_TARGETS
+      EXTERNAL_SOURCE_DIR .
+      FPRINT_SOURCE_DIR "${_source_dir}"
+      FPRINT_FILE_GLOBS "${CMAKE_CURRENT_LIST_DIR}/*"
+      BINARY_DIR build
+      NO_MERGE_COMPILE_COMMANDS
+      BACKGROUND_BUILD
+      OUTPUT_ON_FAILURE
+      CMAKE_ARGS
+        "-DSOURCE_DIR=${_source_dir}"
+        "-DPATCHELF=${PATCHELF}"
+        "-DCC=${CMAKE_C_COMPILER}"
+      INSTALL_DESTINATION
+        lib/rocm_sysdeps
+      INTERFACE_LINK_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_INSTALL_RPATH_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_PKG_CONFIG_DIRS
+        lib/rocm_sysdeps/lib/pkgconfig
+      EXTRA_DEPENDS
+        "${_download_stamp}"
+    )
+
+    therock_cmake_subproject_provide_package(therock-libiberty LibIberty lib/rocm_sysdeps/lib/cmake/libiberty)
+    therock_cmake_subproject_activate(therock-libiberty)
+
+    return()
+endif()
+
+# Otherwise, this is the sub-project build.
+cmake_minimum_required(VERSION 3.25)
+project(LIBIBERTY_BUILD VERSION 2.46.0)
+
+include(ProcessorCount)
+ProcessorCount(PAR_JOBS)
+
+if(NOT PATCHELF)
+  message(FATAL_ERROR "Missing PATCHELF from super-project")
+endif()
+
+# -fPIC must be in CFLAGS/CXXFLAGS (compiler flags), so that libiberty object
+# files are compiled as position-independent code and can be linked into shared
+# libraries by downstream consumers (e.g. dyninst). Append to any existing
+# flags from the environment so we do not discard flags set by the caller.
+set(EXTRA_CFLAGS "-fPIC")
+set(EXTRA_CXXFLAGS "-fPIC")
+message(STATUS "EXTRA_CFLAGS=${EXTRA_CFLAGS}")
+message(STATUS "EXTRA_CXXFLAGS=${EXTRA_CXXFLAGS}")
+
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+add_custom_target(
+  build ALL
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  COMMAND
+    "${CMAKE_COMMAND}" -E rm -rf -- "${CMAKE_INSTALL_PREFIX}" "${CMAKE_CURRENT_BINARY_DIR}/s"
+  COMMAND
+    "${CMAKE_COMMAND}" -E copy_directory "${SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/s"
+  COMMAND
+    "${CMAKE_COMMAND}" -E env
+      "CFLAGS=$ENV{CFLAGS} ${EXTRA_CFLAGS}"
+      "CXXFLAGS=$ENV{CXXFLAGS} ${EXTRA_CXXFLAGS}"
+      --
+    "${CMAKE_CURRENT_BINARY_DIR}/s/configure"
+      --prefix "${CMAKE_INSTALL_PREFIX}"
+      --enable-install-libiberty
+      # --disable-shared and -fPIC together are intentional: we ask
+      # autoconf not to build a shared library (we do that ourselves in
+      # patch_install.py from the PIC-compiled static archive), while
+      # -fPIC ensures the object files can be relinked into a shared
+      # library.  This satisfies the LGPL relinking requirement without
+      # relying on autoconf's shared-library support.
+      --disable-shared
+      --libdir="${CMAKE_INSTALL_PREFIX}/lib"
+      --includedir="${CMAKE_INSTALL_PREFIX}/include"
+      --disable-nls
+      --disable-werror
+      --disable-gprofng
+      --disable-maintainer-mode
+  COMMAND
+    make -j "${PAR_JOBS}" V=1 all-libiberty
+  COMMAND
+    make -C libiberty install
+  COMMAND
+    "${CMAKE_COMMAND}" -E env
+      "PATCHELF=${PATCHELF}"
+      "CC=${CC}"
+      --
+    "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/patch_install.py" ${CMAKE_INSTALL_PREFIX}
+
+  DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/patch_install.py"
+)
+
+# This matches the conventions of the FindLibIberty.cmake module.
+# Other than that, there is no source of truth for this.
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/libiberty-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/libiberty-config.cmake
+  @ONLY
+)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libiberty-config.cmake" DESTINATION lib/cmake/libiberty)

--- a/third-party/sysdeps/linux/libiberty/libiberty-config.cmake.in
+++ b/third-party/sysdeps/linux/libiberty/libiberty-config.cmake.in
@@ -1,0 +1,22 @@
+# CMAKE_CURRENT_LIST_FILE is installed at:
+#   <prefix>/lib/rocm_sysdeps/lib/cmake/libiberty/libiberty-config.cmake
+# Strip the known trailing suffix to arrive at <prefix>/lib/rocm_sysdeps/.
+string(REGEX REPLACE "/lib/cmake/libiberty/?$" "" _IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}")
+if(_IMPORT_PREFIX STREQUAL "/")
+  set(_IMPORT_PREFIX "")
+endif()
+
+set(LibIberty_FOUND TRUE)
+set(LibIberty_LIBRARIES "${_IMPORT_PREFIX}/lib/libiberty.so")
+set(LibIberty_INCLUDE_DIRS "${_IMPORT_PREFIX}/include;${_IMPORT_PREFIX}/include/libiberty")
+set(LibIberty_LIBRARY_DIRS "${_IMPORT_PREFIX}/lib")
+
+if(NOT TARGET LibIberty::LibIberty)
+  add_library(LibIberty::LibIberty SHARED IMPORTED GLOBAL)
+  set_target_properties(LibIberty::LibIberty PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;${_IMPORT_PREFIX}/include/libiberty"
+    IMPORTED_LOCATION "${_IMPORT_PREFIX}/lib/libiberty.so"
+  )
+endif()
+
+set(_IMPORT_PREFIX)

--- a/third-party/sysdeps/linux/libiberty/patch_install.py
+++ b/third-party/sysdeps/linux/libiberty/patch_install.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Post-install fixup script for the libiberty build (source: binutils tarball).
+
+Creates a versioned libiberty shared library from the PIC-compiled static
+archive, and removes build artifacts that are not needed at runtime.
+"""
+
+import glob
+import os
+import shutil
+import subprocess
+import sys
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: patch_install.py <install-prefix>", file=sys.stderr)
+        sys.exit(1)
+
+    prefix = sys.argv[1]
+    patchelf = os.environ.get("PATCHELF", "patchelf")
+    cc = os.environ.get("CC", "cc")
+
+    print("Patching libiberty install...")
+
+    lib_dir = os.path.join(prefix, "lib")
+    lib64_dir = os.path.join(prefix, "lib64")
+
+    # Copy lib64 to lib if it exists.  libiberty installs only flat
+    # library files (.a, .la) into lib(64) — no subdirectories — so
+    # shutil.copy2 is sufficient here.
+    if os.path.isdir(lib64_dir):
+        for item in os.listdir(lib64_dir):
+            shutil.copy2(os.path.join(lib64_dir, item), lib_dir)
+        shutil.rmtree(lib64_dir)
+
+    # Remove libtool descriptors.
+    for la_file in glob.glob(os.path.join(lib_dir, "*.la")):
+        os.remove(la_file)
+
+    # Create a versioned libiberty shared library from the PIC-compiled static
+    # archive. libiberty is LGPL-licensed so it must be dynamically linked (not
+    # statically) in this MIT-licensed project.
+    #
+    # We follow the standard Linux SO versioning convention:
+    #   libiberty.so.0  - the actual versioned shared library (SONAME libiberty.so.0)
+    #   libiberty.so    - unversioned symlink used at link time
+    #
+    # The SONAME libiberty.so.0 is embedded in the binary so that consumers
+    # encode the SONAME (not the build-tree path) in their DT_NEEDED entry,
+    # allowing the runtime linker to resolve it via RPATH.
+    libiberty_a = os.path.join(lib_dir, "libiberty.a")
+    if os.path.isfile(libiberty_a):
+        print("Creating libiberty.so.0 from libiberty.a...")
+        so_versioned = os.path.join(lib_dir, "libiberty.so.0")
+        so_link = os.path.join(lib_dir, "libiberty.so")
+        subprocess.run(
+            [
+                cc,
+                "-shared",
+                "-Wl,-soname,libiberty.so.0",
+                "-Wl,--whole-archive",
+                libiberty_a,
+                "-Wl,--no-whole-archive",
+                "-o",
+                so_versioned,
+            ],
+            check=True,
+        )
+        if not os.path.isfile(so_versioned) or os.path.getsize(so_versioned) == 0:
+            raise RuntimeError(
+                f"Expected {so_versioned} to be created but it is missing or empty"
+            )
+        subprocess.run(
+            [patchelf, "--set-rpath", "$ORIGIN", so_versioned],
+            check=True,
+        )
+        # Create the unversioned symlink for link-time use.
+        if os.path.lexists(so_link):
+            os.remove(so_link)
+        os.symlink("libiberty.so.0", so_link)
+        print(f"Created {so_versioned}")
+        print(f"Created symlink {so_link} -> libiberty.so.0")
+        # Remove the static archive so downstream consumers cannot
+        # accidentally link libiberty statically instead of via the .so.
+        os.remove(libiberty_a)
+        print(f"Removed {libiberty_a}")
+
+    # Remove internal build artifacts we do not need.
+    for subdir in ["bfd-plugins", "gprofng"]:
+        path = os.path.join(lib_dir, subdir)
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+
+    for topdir in ["bin", "share", "etc"]:
+        path = os.path.join(prefix, topdir)
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+
+    # Remove the architecture-specific sysroot directory (e.g. x86_64-pc-linux-gnu).
+    for entry in glob.glob(os.path.join(prefix, "*-*-*")):
+        if os.path.isdir(entry):
+            shutil.rmtree(entry)
+
+    print("Done patching libiberty install.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Motivation

- Provide **binutils 2.46.0** (specifically `libiberty`) as a **Linux sysdep** under `lib/rocm_sysdeps`, consistent with other bundled third-party sysdeps.
- **rocprofiler-systems** previously built its own `libiberty` (`ROCPROFSYS_BUILD_LIBIBERTY=ON`). That duplicates work and does not align with TheRock's portable layout. This PR **turns that off** and instead consumes **therock-binutils** via `${THEROCK_BUNDLED_LIBIBERTY}`.
- `libiberty` is normally distributed as a static-only library because its API is unstable and upstream discourages dynamic linking. However, `libiberty` is licensed under **LGPL**, which requires that end users be able to relink against a modified version. Statically linking LGPL code into an MIT-licensed shared library (as Dyninst does) is therefore not acceptable for distribution. This PR resolves the conflict by building `libiberty.a` with `-fPIC` and wrapping it into `libiberty.so` during the install phase, satisfying the LGPL relinking requirement without any API-stability risk (the version bundled in TheRock is pinned and controlled).
- Addresses [TheRock#1903](https://github.com/ROCm/TheRock/issues/1903); related to [TheRock#1905](https://github.com/ROCm/TheRock/issues/1905).

JIRA ID: AIPROFSYST-21

## Technical Details

- **Topology**: `THEROCK_BUNDLED_LIBIBERTY` is added to `CMakeLists.txt` as a core sysdep (set to `therock-binutils` whenever sysdeps are bundled). `rocprofiler-systems` depends on `${THEROCK_BUNDLED_LIBIBERTY}`, so the profiler subproject always has binutils available when bundling is enabled.
- **binutils build**: `third-party/sysdeps/linux/binutils/` fetches **binutils 2.46.0** (mirrored tarball with `URL_HASH`). The autotools build is driven from a custom CMake subproject with `--enable-install-libiberty`, `--disable-shared`, `-fPIC` in `CFLAGS/CXXFLAGS` (so `libiberty.a` contains position-independent object files suitable for wrapping into a shared library), and `--disable-gprofng` to skip unnecessary build time. Libraries and headers install under `lib/rocm_sysdeps`.
- **libiberty.so creation**: `patch_install.sh` runs after `make install` and wraps `libiberty.a` into a shared library via `cc -shared -Wl,--whole-archive`, then sets its `RPATH` to `$ORIGIN` with `patchelf`. Unneeded installed artifacts (binaries, `share/`, `etc/`, `bfd-plugins/`, `x86_64-pc-linux-gnu/`) are removed to keep the staging directory clean.
- **CMake** package: `libiberty-config.cmake.in` generates a `LibIberty::LibIberty` imported target pointing at `libiberty.so`. `therock_cmake_subproject_provide_package(therock-binutils LibIberty ...)` makes it discoverable by Dyninst (which rocprofiler-systems builds internally).
- **Profiler integration**: `profiler/CMakeLists.txt` — `ROCPROFSYS_BUILD_LIBIBERTY` is set to `OFF` when `THEROCK_BUNDLED_LIBIBERTY` is populated, and `ON` as a fallback when binutils is not bundled. `${THEROCK_BUNDLED_LIBIBERTY}` is added to `RUNTIME_DEPS` so the sysdep is staged before rocprofiler-systems builds.
- **Artifacts**: `third-party/sysdeps/linux/artifact.toml` adds `lib` and `dev` components for the binutils stage directory, consistent with other core sysdep artifact entries.

## Test Plan

- Build TheRock with `THEROCK_BUNDLE_SYSDEPS=ON`.
- Run the rocprofiler-systems test suite.
- Verify:
  - `libiberty.so` is present under `dist/rocm/lib/rocm_sysdeps/lib`.
  - `libiberty.so` does not appear under `dist/rocm/lib/rocprofiler-systems` (no libiberty leaked from the profiler subtree).
  - Dyninst (built inside rocprofiler-systems) links against `dist/rocm/lib/rocm_sysdeps/lib/libiberty.so` and not a privately-built copy.

## Test Result

Built successful, tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
