### PR TITLE
Update CMakeLists.txt to switch off/on the benchmarks for ASAN build

### DIFF
--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -1,6 +1,15 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+# Google Benchmark's try_run() regex detection fails under sanitizer builds
+# because the test binaries require LD_PRELOAD for the sanitizer runtime,
+# which CMake's try_run() does not provide.
+if(THEROCK_SANITIZER)
+  set(_THEROCK_BUILD_BENCHMARK OFF)
+else()
+  set(_THEROCK_BUILD_BENCHMARK ${THEROCK_BUILD_TESTING})
+endif()
+
 if(THEROCK_ENABLE_RAND)
   ##############################################################################
   # rocRAND
@@ -16,7 +25,7 @@ if(THEROCK_ENABLE_RAND)
       -DROCM_PATH=
       -DROCM_DIR=
       -DBUILD_TEST=${THEROCK_BUILD_TESTING}
-      -DBUILD_BENCHMARK=${THEROCK_BUILD_TESTING}
+      -DBUILD_BENCHMARK=${_THEROCK_BUILD_BENCHMARK}
     COMPILER_TOOLCHAIN
       amd-hip
     BUILD_DEPS
@@ -151,7 +160,7 @@ if(THEROCK_ENABLE_PRIM)
       -DROCM_PATH=
       -DROCM_DIR=
       -DBUILD_TEST=${THEROCK_BUILD_TESTING}
-      -DBUILD_BENCHMARK=${THEROCK_BUILD_TESTING}
+      -DBUILD_BENCHMARK=${_THEROCK_BUILD_BENCHMARK}
     COMPILER_TOOLCHAIN
       amd-hip
     BUILD_DEPS


### PR DESCRIPTION
Disable Google Benchmark in sanitizer builds to fix hipCUB configure failure

Google Benchmark's CMake configuration uses try_run() to detect a regex
backend. Under ASan/TSan builds, the test binaries are compiled with
-fsanitize=address but fail to run because CMake's try_run() does not
set LD_PRELOAD for the sanitizer runtime. This causes all three regex
backends (std::regex, GNU POSIX, POSIX) to fail, and Google Benchmark
aborts with "Failed to determine the source files for the regular
expression backend", breaking the hipCUB configure step.

Guard BUILD_BENCHMARK behind THEROCK_SANITIZER so it is set to OFF
when any sanitizer is active, while preserving the existing behavior
for non-sanitizer builds.