### PR TITLE
[rocprofiler-systems] Make `lib` artifact include versioned `python<VER>` folder when project is configured with a single python version

### DIFF
--- a/profiler/artifact-rocprofiler-systems.toml
+++ b/profiler/artifact-rocprofiler-systems.toml
@@ -2,7 +2,7 @@
 [components.lib."profiler/rocprofiler-systems/stage"]
 include = [
   "libexec/rocprofiler-systems/**",
-  "lib/python/**",
+  "lib/python*/**",
 ]
 exclude = [
   "share/rocprofiler-systems/tests/**",


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

When testing a testing improvement PR, the python tests would fail when I configured + build TheRock locally with only a single python version being used. 

The `lib` artifact does not include the `python<ver>/` folder that would be seen when project is configured with a single python version, but does include `python/` (which is generated when multiple python versions are used during configure + build).

This was most likely not caught in CI as the runs usually use multiple python versions.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Make ` "lib/python/**"` -> ` "lib/python*/**",` in `artifact-rocprofiler-systems.toml`

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Tested locally using new tests that will be introduced in a future PR. 
Also built locally and checked manually that it is present in `output-linux-portable/build/dist/rocm/lib`

## Test Result

<!-- Briefly summarize test outcomes. -->

Future python tests pass.
 
When built locally so that only `python3.12` is used, I now see that the `rocprofsys` package, located within our generated `python3.12` folder is present in `output-linux-portable/build/dist/rocm/lib`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
