### PR TITLE
[math-libs] Add pre_hook workaround for hipCUB ASAN ROCMChecks failure

### DIFF
--- a/math-libs/pre_hook_hipCUB.cmake
+++ b/math-libs/pre_hook_hipCUB.cmake
@@ -1,0 +1,7 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Workaround: Disable ROCMChecks variable_watch before it loads, preventing
+# ASAN build failures from Google Benchmark modifying CMAKE_CXX_FLAGS.
+# Remove once upstream fix lands: https://github.com/ROCm/rocm-libraries/pull/6338
+set(ROCM_WARN_TOOLCHAIN_VAR OFF CACHE BOOL "" FORCE)

--- a/math-libs/pre_hook_hipCUB.cmake
+++ b/math-libs/pre_hook_hipCUB.cmake
@@ -1,7 +1,10 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-# Workaround: Disable ROCMChecks variable_watch before it loads, preventing
-# ASAN build failures from Google Benchmark modifying CMAKE_CXX_FLAGS.
+# Workaround: hipCUB ASAN build failures with BUILD_BENCHMARK=ON.
+# 1) Disable ROCMChecks variable_watch before it loads.
+# 2) Skip Google Benchmark try_run regex detection (fails under ASAN).
 # Remove once upstream fix lands: https://github.com/ROCm/rocm-libraries/pull/6338
 set(ROCM_WARN_TOOLCHAIN_VAR OFF CACHE BOOL "" FORCE)
+set(HAVE_STD_REGEX ON CACHE BOOL "" FORCE)
+set(RUN_HAVE_STD_REGEX 1 CACHE STRING "" FORCE)


### PR DESCRIPTION
## Motivation

hipCUB ASAN builds fail during configure when `BUILD_BENCHMARK=ON`.
https://github.com/ROCm/TheRock/issues/4455

## Technical Details

Add `pre_hook_hipCUB.cmake` to set `ROCM_WARN_TOOLCHAIN_VAR OFF` in the cache before ROCMChecks loads, preventing `variable_watch()` from being installed. This mirrors why rocRAND is unaffected, it sets the variable before ROCMChecks in its own `Dependencies.cmake`.

TheRock issue: https://github.com/ROCm/TheRock/issues/4455
Upstream fix: https://github.com/ROCm/rocm-libraries/pull/6338

## Test Plan

- hipCUB ASAN CI passes with `BUILD_BENCHMARK=ON`
- Non-ASAN hipCUB builds unaffected
