### PR TITLE
Add support for building rocgdb from external source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,10 +146,8 @@ set(THEROCK_ROCM_SYSTEMS_SOURCE_DIR_DEFAULT "${THEROCK_SOURCE_DIR}/rocm-systems"
 set(THEROCK_ROCM_SYSTEMS_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR_DEFAULT}" CACHE STRING "Path to rocm-systems superrepo")
 cmake_path(ABSOLUTE_PATH THEROCK_ROCM_SYSTEMS_SOURCE_DIR NORMALIZE)
 
-# Source configuration for ROCgdb.
-set(THEROCK_ROCGDB_SOURCE_DIR_DEFAULT "${THEROCK_SOURCE_DIR}/debug-tools/rocgdb/source")
-set(THEROCK_ROCGDB_SOURCE_DIR "${THEROCK_ROCGDB_SOURCE_DIR_DEFAULT}" CACHE STRING "Path to rocgdb's sources")
-cmake_path(ABSOLUTE_PATH THEROCK_ROCGDB_SOURCE_DIR NORMALIZE)
+# Allow specifying alternative source location for ROCgdb.
+therock_enable_external_source("rocgdb" "${THEROCK_SOURCE_DIR}/debug-tools/rocgdb/source" OFF)
 
 # Allow to specify alternative source locations instead of using
 # repositories tracked in TheRock's `.gitmodules`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,11 @@ set(THEROCK_ROCM_SYSTEMS_SOURCE_DIR_DEFAULT "${THEROCK_SOURCE_DIR}/rocm-systems"
 set(THEROCK_ROCM_SYSTEMS_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR_DEFAULT}" CACHE STRING "Path to rocm-systems superrepo")
 cmake_path(ABSOLUTE_PATH THEROCK_ROCM_SYSTEMS_SOURCE_DIR NORMALIZE)
 
+# Source configuration for ROCgdb.
+set(THEROCK_ROCGDB_SOURCE_DIR_DEFAULT "${THEROCK_SOURCE_DIR}/debug-tools/rocgdb/source")
+set(THEROCK_ROCGDB_SOURCE_DIR "${THEROCK_ROCGDB_SOURCE_DIR_DEFAULT}" CACHE STRING "Path to rocgdb's sources")
+cmake_path(ABSOLUTE_PATH THEROCK_ROCGDB_SOURCE_DIR NORMALIZE)
+
 # Allow to specify alternative source locations instead of using
 # repositories tracked in TheRock's `.gitmodules`.
 therock_enable_external_source("composable-kernel" "${THEROCK_SOURCE_DIR}/ml-libs/composable_kernel" OFF)

--- a/README.md
+++ b/README.md
@@ -216,12 +216,20 @@ hipDNN provider plugins:
 > CMake configure.
 
 By default, components are built from the sources fetched via the submodules.
-For some components, external sources can be used instead.
+For some components, external sources can be used by setting the following couple
+options:
 
-| External source settings                        | Description                                    |
-| ----------------------------------------------- | ---------------------------------------------- |
-| `-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=OFF`  | Use external composable-kernel source location |
-| `-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=<PATH>` | Path to composable-kernel sources              |
+| External source settings                         | Description                                             |
+| ------------------------------------------------ | ------------------------------------------------------- |
+| `-DTHEROCK_USE_EXTERNAL_<COMPONENT STRING>=OFF`  | Enable/Disable external source location for a component |
+| `-DTHEROCK_<COMPONENT_STRING>_SOURCE_DIR=<PATH>` | External path to the component sources                  |
+
+The following components accept specifying alternative source locations:
+
+| Component string    |
+| ------------------- |
+| `COMPOSABLE_KERNEL` |
+| `ROCGDB`            |
 
 Further flags allow to build components with specific features enabled.
 

--- a/debug-tools/CMakeLists.txt
+++ b/debug-tools/CMakeLists.txt
@@ -196,6 +196,10 @@ if(THEROCK_ENABLE_ROCGDB)
     message(WARNING "No Python with shared libpython found. rocgdb will be built without Python support.")
   endif()
 
+  if(NOT ${THEROCK_ROCGDB_SOURCE_DIR} STREQUAL ${THEROCK_ROCGDB_SOURCE_DIR_DEFAULT})
+    message(WARNING "Configuring ROCgdb with modified source directory: ${THEROCK_ROCGDB_SOURCE_DIR}")
+  endif()
+
   therock_cmake_subproject_declare(rocgdb
     USE_DIST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "rocgdb"
@@ -206,6 +210,7 @@ if(THEROCK_ENABLE_ROCGDB)
       "-DROCM_VERSION=${ROCM_MAJOR_VERSION}.${ROCM_MINOR_VERSION}.${ROCM_PATCH_VERSION}"
       "-DSHARED_PYTHON_EXECUTABLES=${_rocgdb_python_executables_escaped}"
       "-DTHEROCK_BUNDLE_SYSDEPS=${THEROCK_BUNDLE_SYSDEPS}"
+      "-DROCGDB_SOURCE_DIR=${THEROCK_ROCGDB_SOURCE_DIR}"
     COMPILER_TOOLCHAIN
       amd-llvm
     RUNTIME_DEPS

--- a/debug-tools/CMakeLists.txt
+++ b/debug-tools/CMakeLists.txt
@@ -196,7 +196,7 @@ if(THEROCK_ENABLE_ROCGDB)
     message(WARNING "No Python with shared libpython found. rocgdb will be built without Python support.")
   endif()
 
-  if(NOT ${THEROCK_ROCGDB_SOURCE_DIR} STREQUAL ${THEROCK_ROCGDB_SOURCE_DIR_DEFAULT})
+  if(THEROCK_USE_EXTERNAL_ROCGDB AND THEROCK_ROCGDB_SOURCE_DIR)
     message(WARNING "Configuring ROCgdb with modified source directory: ${THEROCK_ROCGDB_SOURCE_DIR}")
   endif()
 

--- a/debug-tools/rocgdb/CMakeLists.txt
+++ b/debug-tools/rocgdb/CMakeLists.txt
@@ -50,6 +50,12 @@ project(rocgdb C CXX)
 include(ExternalProject)
 include(ProcessorCount)
 
+# Allow external rocgdb source directory.
+if(NOT ROCGDB_SOURCE_DIR)
+  set(ROCGDB_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/source")
+endif()
+message(STATUS "ROCgdb source directory: ${ROCGDB_SOURCE_DIR}")
+
 # Function to extract a single path that matches a given regex pattern
 # from a list of paths.
 #
@@ -229,7 +235,7 @@ macro(add_python_variant minor_version configure_flags libpython_dir)
         "LDFLAGS=${ALL_LDFLAGS}"
       --
       # The actual configure command.
-      ${CMAKE_CURRENT_SOURCE_DIR}/source/configure
+      ${ROCGDB_SOURCE_DIR}/configure
         "--prefix=${ROCGDB_INTERMEDIATE_INSTALL_DIR}"
         --program-prefix=roc
         "--program-transform-name=${ROCGDB_PROGRAM_TRANSFORM_STR}"
@@ -290,7 +296,7 @@ macro(add_python_variant minor_version configure_flags libpython_dir)
     COMMAND
       ${CMAKE_COMMAND} -E make_directory ${ROCGDB_INTERMEDIATE_INSTALL_DIR}/share/doc
     COMMAND
-      ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/source/gdb/NOTICES.txt ${ROCGDB_INTERMEDIATE_INSTALL_DIR}/share/doc/
+      ${CMAKE_COMMAND} -E copy ${ROCGDB_SOURCE_DIR}/gdb/NOTICES.txt ${ROCGDB_INTERMEDIATE_INSTALL_DIR}/share/doc/
     # Rename rocgcore to rocgcore-py<python version>.
     COMMAND
       ${CMAKE_COMMAND} -E rename ${ROCGDB_INTERMEDIATE_INSTALL_DIR}/bin/rocgcore ${ROCGDB_INTERMEDIATE_INSTALL_DIR}/bin/rocgcore-py${minor_version}
@@ -604,7 +610,7 @@ if(BUILD_TESTING)
     # Get the directory part of the file.
     get_filename_component(file_dir ${rocgdb_file} DIRECTORY)
 
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/source/${rocgdb_file}
+    install(FILES ${ROCGDB_SOURCE_DIR}/${rocgdb_file}
       DESTINATION tests/rocgdb/${file_dir}
       COMPONENT tests)
   endforeach()
@@ -613,7 +619,7 @@ if(BUILD_TESTING)
     # Get the directory part of the file.
     get_filename_component(file_dir ${rocgdb_file} DIRECTORY)
 
-    install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/source/${rocgdb_file}
+    install(PROGRAMS ${ROCGDB_SOURCE_DIR}/${rocgdb_file}
       DESTINATION tests/rocgdb/${file_dir}
       COMPONENT tests)
   endforeach()
@@ -626,7 +632,7 @@ if(BUILD_TESTING)
   )
 
   foreach(rocgdb_testsuite_dir ${ROCGDB_TESTSUITE_DIRS})
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/source/${rocgdb_testsuite_dir}
+    install(DIRECTORY ${ROCGDB_SOURCE_DIR}/${rocgdb_testsuite_dir}
       DESTINATION tests/rocgdb/gdb
       COMPONENT tests
       USE_SOURCE_PERMISSIONS)

--- a/debug-tools/rocgdb/CMakeLists.txt
+++ b/debug-tools/rocgdb/CMakeLists.txt
@@ -27,6 +27,12 @@
 # post-install RPATH patching can take place.
 #
 #
+# ROCGDB_SOURCE_DIR
+#
+# Specifies the location of the ROCgdb sources. Used by TheRock to build
+# ROCgdb from an alternative source location.
+#
+#
 # ROCM_VERSION
 #
 # Specifies the ROCM version we are building for. If empty or non-existent
@@ -49,12 +55,6 @@ project(rocgdb C CXX)
 
 include(ExternalProject)
 include(ProcessorCount)
-
-# Allow external rocgdb source directory.
-if(NOT ROCGDB_SOURCE_DIR)
-  set(ROCGDB_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/source")
-endif()
-message(STATUS "ROCgdb source directory: ${ROCGDB_SOURCE_DIR}")
 
 # Function to extract a single path that matches a given regex pattern
 # from a list of paths.


### PR DESCRIPTION
This enables developers to build rocgdb from a custom source location while preserving the TheRock wrapper infrastructure, supporting local development and testing of rocgdb modifications.

Also update README.md to clarify how and what components can be built with external sources.