### PR TITLE
[ci] Investigate/Re-enable linux-gfx1150-gpu-rocm test runner (#3199)

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -270,11 +270,9 @@ amdgpu_family_info_matrix_nightly = {
     },
     "gfx1150": {
         "linux": {
-            # TODO(#3199): Re-enable machine once it is stable
-            # Label is "linux-gfx1150-gpu-rocm"
-            "test-runs-on": "",
+            "test-runs-on": "linux-gfx1150-gpu-rocm",
             "family": "gfx1150",
-            "fetch-gfx-targets": [],
+            "fetch-gfx-targets": ["gfx1150"],
             "build_variants": ["release"],
             "sanity_check_only_for_family": True,
         },

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -49,7 +49,7 @@ test_matrix = {
     "sanity": {
         "job_name": "sanity",
         "fetch_artifact_args": "--base-only",
-        "timeout_minutes": 5,
+        "timeout_minutes": 15,
         "test_script": f"python {_get_script_path('test_sanity.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -58,7 +58,7 @@ test_matrix = {
         },
         # Running docker with cap-add and -v /lib/modules, by recommendation of GitHub:
         # https://rocm.docs.amd.com/projects/amdsmi/en/amd-staging/how-to/setup-docker-container.html
-        "container_options": "--cap-add SYS_MODULE -v /lib/modules:/lib/modules",
+        "container_options": "--cap-add SYS_MODULE --cap-add SYS_PTRACE -v /lib/modules:/lib/modules",
     },
     # hip-tests
     "hip-tests": {

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -187,12 +187,11 @@ amdgpu_family_info_matrix_all = {
                     "build_variants": ["release"],
                 },
                 "test": {
-                    # TODO(#3199): Re-enable machine once it is stable
-                    "run_tests": False,
+                    "run_tests": True,
                     "runs_on": {
                         "test": "linux-gfx1150-gpu-rocm",
                     },
-                    "fetch-gfx-targets": [],
+                    "fetch-gfx-targets": ["gfx1150"],
                     "sanity_check_only_for_family": True,
                 },
                 "release": {

--- a/build_tools/github_actions/test_executable_scripts/test_sanity.py
+++ b/build_tools/github_actions/test_executable_scripts/test_sanity.py
@@ -17,6 +17,11 @@ env = os.environ.copy()
 # https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/debugging.html
 # Note: ROCM_KPACK_DEBUG is set for all components by test_component.yml.
 env["AMD_LOG_LEVEL"] = "4"
+# Extra HIP/HSA diagnostics for debugging gfx1150 hang (TheRock#3199)
+env["HIP_TRACE_API"] = "1"
+env["HIP_LAUNCH_BLOCKING"] = "1"
+env["AMD_SERIALIZE_KERNEL"] = "3"
+env["AMD_SERIALIZE_COPY"] = "3"
 
 # The sanity checks run tools like 'offload-arch' which may search for DLLs on
 # multiple search paths (PATH, CWD, system32, etc.).

--- a/build_tools/github_actions/test_executable_scripts/test_sanity.py
+++ b/build_tools/github_actions/test_executable_scripts/test_sanity.py
@@ -16,12 +16,13 @@ env = os.environ.copy()
 # Enable verbose ROCm logging, see
 # https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/debugging.html
 # Note: ROCM_KPACK_DEBUG is set for all components by test_component.yml.
-env["AMD_LOG_LEVEL"] = "4"
+env["AMD_LOG_LEVEL"] = "7"
 # Extra HIP/HSA diagnostics for debugging gfx1150 hang (TheRock#3199)
 env["HIP_TRACE_API"] = "1"
 env["HIP_LAUNCH_BLOCKING"] = "1"
 env["AMD_SERIALIZE_KERNEL"] = "3"
 env["AMD_SERIALIZE_COPY"] = "3"
+env["HSA_ENABLE_SDMA"] = "0"
 
 # The sanity checks run tools like 'offload-arch' which may search for DLLs on
 # multiple search paths (PATH, CWD, system32, etc.).

--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -130,15 +130,14 @@ def run_sanity(os_name: str) -> None:
             args=["-r"],
             extra_command_search_paths=[bin_dir],
         )
-
-        # Print loaded GPU firmware versions (useful for debugging hangs)
-        firmware_info = Path("/sys/kernel/debug/dri/0/amdgpu_firmware_info")
-        if firmware_info.exists():
-            log(f"\n=== amdgpu firmware info ===")
-            try:
-                log(firmware_info.read_text().rstrip())
-            except PermissionError:
-                log("(permission denied - need root/debugfs access)")
+        # Print per-component firmware versions (useful for debugging hangs)
+        if AMDGPU_FAMILIES not in unsupported_amdsmi_families:
+            run_command_with_search(
+                label="amd-smi firmware",
+                command="amd-smi",
+                args=["firmware"],
+                extra_command_search_paths=[bin_dir],
+            )
 
     log("\n=== End of sanity check ===")
 

--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -131,6 +131,15 @@ def run_sanity(os_name: str) -> None:
             extra_command_search_paths=[bin_dir],
         )
 
+        # Print loaded GPU firmware versions (useful for debugging hangs)
+        firmware_info = Path("/sys/kernel/debug/dri/0/amdgpu_firmware_info")
+        if firmware_info.exists():
+            log(f"\n=== amdgpu firmware info ===")
+            try:
+                log(firmware_info.read_text().rstrip())
+            except PermissionError:
+                log("(permission denied - need root/debugfs access)")
+
     log("\n=== End of sanity check ===")
 
 

--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -93,6 +93,31 @@ def run_command_with_search(
     log(f"{command}: command not found")
 
 
+def print_sysfs_firmware_versions() -> None:
+    """
+    Print per-component firmware versions from /sys/class/drm/card*/device/fw_version/.
+
+    These sysfs files are world-readable and exposed by amdgpu without
+    needing debugfs, so they are reliable inside CI containers. They include
+    mes_fw_version and mes_kiq_fw_version, which are useful when diagnosing
+    MES-related dispatch hangs.
+    """
+    log("\n=== sysfs firmware versions ===")
+    cards = sorted(Path("/sys/class/drm").glob("card*/device/fw_version"))
+    if not cards:
+        log("/sys/class/drm/card*/device/fw_version: not found")
+        return
+    for fw_dir in cards:
+        card = fw_dir.parent.parent.name
+        log(f"-- {card} ({fw_dir})")
+        for entry in sorted(fw_dir.iterdir()):
+            try:
+                value = entry.read_text().strip()
+            except OSError as e:
+                value = f"<read error: {e}>"
+            log(f"  {entry.name}: {value}")
+
+
 def run_sanity(os_name: str) -> None:
     THIS_SCRIPT_DIR = Path(__file__).resolve().parent
     THEROCK_DIR = THIS_SCRIPT_DIR.parent
@@ -130,7 +155,10 @@ def run_sanity(os_name: str) -> None:
             args=["-r"],
             extra_command_search_paths=[bin_dir],
         )
-        # Print per-component firmware versions (useful for debugging hangs)
+        # Print per-component firmware versions (useful for debugging hangs).
+        # Read sysfs first: it works regardless of amd-smi support and always
+        # includes mes_fw_version / mes_kiq_fw_version for diagnosing MES hangs.
+        print_sysfs_firmware_versions()
         if AMDGPU_FAMILIES not in unsupported_amdsmi_families:
             run_command_with_search(
                 label="amd-smi firmware",

--- a/tests/hip_simple_check.cpp
+++ b/tests/hip_simple_check.cpp
@@ -1,0 +1,46 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Minimal HIP kernel WITHOUT printf, to isolate whether the gfx1150
+// sanity-test hang (TheRock#3199) is caused by printf buffer handling
+// or by kernel dispatch itself.
+
+#include <cstdio>
+#include <hip/hip_runtime.h>
+
+__global__ void squares_no_printf(int *buf) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  buf[i] = i * i;
+}
+
+int main() {
+  constexpr int gridsize = 1;
+  constexpr int blocksize = 64;
+  constexpr int size = gridsize * blocksize;
+  int *d_buf;
+  fprintf(stderr, "hip_simple_check: hipHostMalloc\n");
+  hipHostMalloc(&d_buf, size * sizeof(int));
+  fprintf(stderr, "hip_simple_check: hipLaunchKernelGGL\n");
+  hipLaunchKernelGGL(squares_no_printf, gridsize, blocksize, 0, 0, d_buf);
+  fprintf(stderr, "hip_simple_check: hipDeviceSynchronize\n");
+  hipDeviceSynchronize();
+  fprintf(stderr, "hip_simple_check: checking results\n");
+
+  int mismatches_count = 0;
+  for (int i = 0; i < size; ++i) {
+    int square = i * i;
+    if (d_buf[i] != square) {
+      fprintf(stderr,
+              "Element at index %d expected value %d, actual value: %d\n", i,
+              square, d_buf[i]);
+      ++mismatches_count;
+    }
+  }
+  if (mismatches_count > 0) {
+    fprintf(stderr, "There were %d mismatches\n", mismatches_count);
+    return 1;
+  }
+
+  fprintf(stderr, "hip_simple_check: PASSED\n");
+  return 0;
+}

--- a/tests/hip_simple_check.cpp
+++ b/tests/hip_simple_check.cpp
@@ -4,9 +4,51 @@
 // Minimal HIP kernel WITHOUT printf, to isolate whether the gfx1150
 // sanity-test hang (TheRock#3199) is caused by printf buffer handling
 // or by kernel dispatch itself.
+//
+// Includes a SIGALRM watchdog that dumps a backtrace + /proc/self/maps
+// if the process hangs for 20 seconds.
 
+#include <csignal>
 #include <cstdio>
+#include <cstdlib>
+#include <execinfo.h>
 #include <hip/hip_runtime.h>
+#include <unistd.h>
+
+static void dump_backtrace_and_maps(int sig) {
+  fprintf(stderr, "\n=== WATCHDOG: process hung for 20s (signal %d) ===\n",
+          sig);
+
+  // Dump backtrace addresses
+  void *frames[64];
+  int n = backtrace(frames, 64);
+  fprintf(stderr, "=== backtrace (%d frames) ===\n", n);
+  backtrace_symbols_fd(frames, n, STDERR_FILENO);
+
+  // Dump /proc/self/maps so addresses can be resolved offline
+  fprintf(stderr, "\n=== /proc/self/maps ===\n");
+  FILE *maps = fopen("/proc/self/maps", "r");
+  if (maps) {
+    char buf[512];
+    while (fgets(buf, sizeof(buf), maps))
+      fputs(buf, stderr);
+    fclose(maps);
+  }
+
+  // Dump /proc/self/stack (kernel stack, if readable)
+  fprintf(stderr, "\n=== /proc/self/stack ===\n");
+  FILE *stack = fopen("/proc/self/stack", "r");
+  if (stack) {
+    char buf[512];
+    while (fgets(buf, sizeof(buf), stack))
+      fputs(buf, stderr);
+    fclose(stack);
+  } else {
+    fprintf(stderr, "(not readable)\n");
+  }
+
+  _exit(2);
+}
 
 __global__ void squares_no_printf(int *buf) {
   int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -14,6 +56,10 @@ __global__ void squares_no_printf(int *buf) {
 }
 
 int main() {
+  // Set up watchdog: SIGALRM after 20s
+  signal(SIGALRM, dump_backtrace_and_maps);
+  alarm(20);
+
   constexpr int gridsize = 1;
   constexpr int blocksize = 64;
   constexpr int size = gridsize * blocksize;
@@ -24,6 +70,9 @@ int main() {
   hipLaunchKernelGGL(squares_no_printf, gridsize, blocksize, 0, 0, d_buf);
   fprintf(stderr, "hip_simple_check: hipDeviceSynchronize\n");
   hipDeviceSynchronize();
+
+  // Cancel watchdog — we didn't hang
+  alarm(0);
   fprintf(stderr, "hip_simple_check: checking results\n");
 
   int mismatches_count = 0;

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -126,24 +126,58 @@ class TestROCmSanity:
             cwd=str(THEROCK_BIN_DIR),
         )
 
-        # Dump dmesg before running to capture pre-existing GPU firmware
-        # errors that may cause all subsequent kernel launches to stall.
-        try:
-            dmesg_before = subprocess.run(
-                ["dmesg", "--level=err,warn", "-T"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            logger.info("=== dmesg (err+warn) before hip_simple_check ===")
-            for line in dmesg_before.stdout.splitlines()[-50:]:
-                logger.info(line)
-        except Exception as e:
-            logger.warning(f"dmesg failed: {e}")
+        # Dump kernel log to capture GPU firmware errors that may cause
+        # all subsequent kernel launches to stall. Try /dev/kmsg first
+        # (bypasses dmesg_restrict), then fall back to dmesg.
+        def dump_kmsg(label, last_n=50):
+            # Try /dev/kmsg (non-blocking read of kernel ring buffer)
+            try:
+                with open("/dev/kmsg", "r", errors="replace") as f:
+                    import fcntl
 
-        # Run with a 30s grace period; if it hangs, attach gdb to get
-        # userspace backtraces for all threads (TheRock#3199).
-        # The container has --cap-add SYS_PTRACE for this purpose.
+                    # Set non-blocking so we don't hang
+                    fd = f.fileno()
+                    flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+                    fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+                    lines = []
+                    try:
+                        while True:
+                            line = f.readline()
+                            if not line:
+                                break
+                            lines.append(line.rstrip())
+                    except (BlockingIOError, OSError):
+                        pass
+                    if lines:
+                        logger.info(f"=== {label} (last {last_n} from /dev/kmsg) ===")
+                        for line in lines[-last_n:]:
+                            logger.info(line)
+                        return
+            except (PermissionError, OSError):
+                pass
+
+            # Fallback: dmesg command
+            try:
+                result = subprocess.run(
+                    ["dmesg", "-T"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if result.stdout.strip():
+                    logger.info(f"=== {label} (last {last_n} from dmesg) ===")
+                    for line in result.stdout.splitlines()[-last_n:]:
+                        logger.info(line)
+                else:
+                    logger.warning(f"{label}: dmesg returned empty output")
+            except Exception as e:
+                logger.warning(f"{label}: dmesg failed: {e}")
+
+        dump_kmsg("kernel log before hip_simple_check", last_n=50)
+
+        # The C++ binary has a built-in SIGALRM watchdog at 20s that
+        # dumps backtrace + /proc/self/maps + /proc/self/stack to stderr
+        # and exits with code 2. No need for external gdb/strace.
         platform_executable_prefix = "./" if not is_windows() else ""
         exe = f"{platform_executable_prefix}{executable}"
         logger.info(f"++ Run [{THEROCK_BIN_DIR}]$ {exe}")
@@ -156,77 +190,8 @@ class TestROCmSanity:
         try:
             proc.wait(timeout=hang_timeout)
         except subprocess.TimeoutExpired:
-            logger.error(f"hip_simple_check hung for {hang_timeout}s — attaching gdb")
-
-            # Dump dmesg again to see if new GPU errors appeared during hang
-            try:
-                dmesg_after = subprocess.run(
-                    ["dmesg", "-T"],
-                    capture_output=True,
-                    text=True,
-                    timeout=10,
-                )
-                logger.info("=== dmesg (last 100 lines) after hang ===")
-                for line in dmesg_after.stdout.splitlines()[-100:]:
-                    logger.info(line)
-            except Exception as e:
-                logger.warning(f"dmesg failed: {e}")
-
-            # Install gdb (container runs as root, image is Ubuntu 24.04)
-            try:
-                subprocess.run(
-                    ["apt-get", "install", "-y", "-qq", "gdb"],
-                    capture_output=True,
-                    timeout=60,
-                )
-            except Exception as e:
-                logger.warning(f"Failed to install gdb: {e}")
-
-            # Attach gdb and dump backtraces for all threads
-            gdb_cmd = [
-                "gdb",
-                "-batch",
-                "-ex",
-                "thread apply all bt full",
-                "-ex",
-                "info registers",
-                "-ex",
-                "detach",
-                "-p",
-                str(proc.pid),
-            ]
-            try:
-                gdb_proc = subprocess.run(
-                    gdb_cmd,
-                    capture_output=True,
-                    text=True,
-                    timeout=30,
-                )
-                logger.info("=== gdb backtrace output ===")
-                for line in gdb_proc.stdout.splitlines():
-                    logger.info(line)
-                if gdb_proc.stderr:
-                    logger.info("=== gdb stderr ===")
-                    for line in gdb_proc.stderr.splitlines():
-                        logger.info(line)
-            except FileNotFoundError:
-                logger.error("gdb not found, falling back to /proc")
-                # Fallback: read /proc/PID/maps for address info
-                try:
-                    maps = Path(f"/proc/{proc.pid}/maps").read_text()
-                    logger.info(f"=== /proc/{proc.pid}/maps ===")
-                    for line in maps.splitlines():
-                        if (
-                            "libhsa" in line
-                            or "libamdhip" in line
-                            or "hip_simple" in line
-                        ):
-                            logger.info(line)
-                except Exception as e:
-                    logger.warning(f"Cannot read /proc maps: {e}")
-            except Exception as e:
-                logger.error(f"gdb failed: {e}")
-
+            logger.error(f"hip_simple_check hung for {hang_timeout}s, killing")
+            dump_kmsg("kernel log after hang", last_n=100)
             proc.kill()
             proc.wait()
 

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -29,8 +29,39 @@ def is_windows():
     return "windows" == platform.system().lower()
 
 
-def run_command(command: list[str], cwd=None):
+def run_command(command: list[str], cwd=None, timeout=None):
     logger.info(f"++ Run [{cwd}]$ {shlex.join(command)}")
+    if timeout is not None:
+        # Stream output so we can see HIP trace/debug logs even if process hangs
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            cwd=cwd,
+            shell=is_windows(),
+            text=True,
+        )
+        try:
+            stdout, _ = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.error(f"Command timed out after {timeout}s, partial output:")
+            # Read whatever is buffered
+            process.kill()
+            stdout, _ = process.communicate()
+            for line in stdout.splitlines():
+                logger.error(line)
+            raise
+        if process.returncode != 0:
+            logger.error(f"Command failed!")
+            for line in stdout.splitlines():
+                logger.error(line)
+            raise Exception(
+                f"Command failed: `{shlex.join(command)}`, see output above"
+            )
+        # Return a result compatible with subprocess.run
+        return subprocess.CompletedProcess(
+            command, process.returncode, stdout=stdout, stderr=""
+        )
     process = subprocess.run(
         command, capture_output=True, cwd=cwd, shell=is_windows(), text=True
     )
@@ -139,10 +170,13 @@ class TestROCmSanity:
             cwd=str(THEROCK_BIN_DIR),
         )
 
-        # Running and checking the executable
+        # Running and checking the executable (120s timeout to capture debug
+        # output if it hangs, see TheRock#3199)
         platform_executable_prefix = "./" if not is_windows() else ""
         hipcc_check_executable = f"{platform_executable_prefix}hipcc_check"
-        process = run_command([hipcc_check_executable], cwd=str(THEROCK_BIN_DIR))
+        process = run_command(
+            [hipcc_check_executable], cwd=str(THEROCK_BIN_DIR), timeout=120
+        )
         check.equal(process.returncode, 0)
         check.greater(
             os.path.getsize(str(THEROCK_BIN_DIR / hipcc_check_executable_file)), 0

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -29,50 +29,23 @@ def is_windows():
     return "windows" == platform.system().lower()
 
 
-def run_command(command: list[str], cwd=None, timeout=None):
+def run_command(command: list[str], cwd=None, capture=True):
     logger.info(f"++ Run [{cwd}]$ {shlex.join(command)}")
-    if timeout is not None:
-        # Stream output so we can see HIP trace/debug logs even if process hangs
-        process = subprocess.Popen(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            cwd=cwd,
-            shell=is_windows(),
-            text=True,
-        )
-        try:
-            stdout, _ = process.communicate(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            logger.error(f"Command timed out after {timeout}s, partial output:")
-            # Read whatever is buffered
-            process.kill()
-            stdout, _ = process.communicate()
-            for line in stdout.splitlines():
-                logger.error(line)
-            raise
-        if process.returncode != 0:
-            logger.error(f"Command failed!")
-            for line in stdout.splitlines():
-                logger.error(line)
-            raise Exception(
-                f"Command failed: `{shlex.join(command)}`, see output above"
-            )
-        # Return a result compatible with subprocess.run
-        return subprocess.CompletedProcess(
-            command, process.returncode, stdout=stdout, stderr=""
-        )
     process = subprocess.run(
-        command, capture_output=True, cwd=cwd, shell=is_windows(), text=True
+        command,
+        capture_output=capture,
+        cwd=cwd,
+        shell=is_windows(),
+        text=True,
     )
     if process.returncode != 0:
-        logger.error(f"Command failed!")
-        logger.error("command stdout:")
-        for line in process.stdout.splitlines():
-            logger.error(line)
-        logger.error("command stderr:")
-        for line in process.stderr.splitlines():
-            logger.error(line)
+        if capture:
+            logger.error("command stdout:")
+            for line in process.stdout.splitlines():
+                logger.error(line)
+            logger.error("command stderr:")
+            for line in process.stderr.splitlines():
+                logger.error(line)
         raise Exception(f"Command failed: `{shlex.join(command)}`, see output above")
     return process
 
@@ -170,12 +143,13 @@ class TestROCmSanity:
             cwd=str(THEROCK_BIN_DIR),
         )
 
-        # Running and checking the executable (120s timeout to capture debug
-        # output if it hangs, see TheRock#3199)
+        # Running and checking the executable.
+        # capture=False so HIP debug output streams directly to the log
+        # if the process hangs (see TheRock#3199).
         platform_executable_prefix = "./" if not is_windows() else ""
         hipcc_check_executable = f"{platform_executable_prefix}hipcc_check"
         process = run_command(
-            [hipcc_check_executable], cwd=str(THEROCK_BIN_DIR), timeout=120
+            [hipcc_check_executable], cwd=str(THEROCK_BIN_DIR), capture=False
         )
         check.equal(process.returncode, 0)
         check.greater(

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -126,10 +126,9 @@ class TestROCmSanity:
             cwd=str(THEROCK_BIN_DIR),
         )
 
-        # Run with /proc polling to capture kernel stack if it hangs.
-        # strace is not available in the CI container, so we poll
-        # /proc/PID/stack, /proc/PID/syscall, and /proc/PID/wchan
-        # to identify where the process blocks (TheRock#3199).
+        # Run with a 30s grace period; if it hangs, attach gdb to get
+        # userspace backtraces for all threads (TheRock#3199).
+        # The container has --cap-add SYS_PTRACE for this purpose.
         platform_executable_prefix = "./" if not is_windows() else ""
         exe = f"{platform_executable_prefix}{executable}"
         logger.info(f"++ Run [{THEROCK_BIN_DIR}]$ {exe}")
@@ -138,68 +137,66 @@ class TestROCmSanity:
             cwd=str(THEROCK_BIN_DIR),
         )
 
-        timeout = 60
-        poll_interval = 5
-        elapsed = 0
-        last_stack = None
-        while elapsed < timeout:
-            ret = proc.poll()
-            if ret is not None:
-                break
-            time.sleep(poll_interval)
-            elapsed += poll_interval
-
-            # Read /proc info for the hanging process
-            pid = proc.pid
-            for proc_file in ["stack", "syscall", "wchan", "status"]:
-                path = f"/proc/{pid}/task/{pid}/{proc_file}"
-                try:
-                    with open(path) as f:
-                        content = f.read().strip()
-                    if proc_file == "stack":
-                        if content != last_stack:
-                            logger.info(
-                                f"=== /proc/{pid}/{proc_file} (t={elapsed}s) ==="
-                            )
-                            for line in content.splitlines():
-                                logger.info(line)
-                            last_stack = content
-                        else:
-                            logger.info(
-                                f"=== /proc/{pid}/{proc_file} (t={elapsed}s) === (unchanged)"
-                            )
-                    else:
-                        logger.info(
-                            f"/proc/{pid}/{proc_file} (t={elapsed}s): {content}"
-                        )
-                except Exception as e:
-                    logger.warning(f"Cannot read /proc/{pid}/{proc_file}: {e}")
-
-            # Also dump stacks for all threads
+        hang_timeout = 30
+        try:
+            proc.wait(timeout=hang_timeout)
+        except subprocess.TimeoutExpired:
+            logger.error(f"hip_simple_check hung for {hang_timeout}s — attaching gdb")
+            # Install gdb (container runs as root, image is Ubuntu 24.04)
             try:
-                task_dir = Path(f"/proc/{pid}/task")
-                tids = sorted(task_dir.iterdir())
-                if len(tids) > 1:
-                    logger.info(
-                        f"=== Thread stacks ({len(tids)} threads, t={elapsed}s) ==="
-                    )
-                    for tid_path in tids:
-                        tid = tid_path.name
-                        if tid == str(pid):
-                            continue
-                        try:
-                            stack = (tid_path / "stack").read_text().strip()
-                            wchan = (tid_path / "wchan").read_text().strip()
-                            logger.info(f"--- TID {tid} (wchan={wchan}) ---")
-                            for line in stack.splitlines():
-                                logger.info(line)
-                        except Exception:
-                            pass
-            except Exception:
-                pass
+                subprocess.run(
+                    ["apt-get", "install", "-y", "-qq", "gdb"],
+                    capture_output=True,
+                    timeout=60,
+                )
+            except Exception as e:
+                logger.warning(f"Failed to install gdb: {e}")
 
-        if proc.poll() is None:
-            logger.error(f"hip_simple_check hung for {timeout}s, killing")
+            # Attach gdb and dump backtraces for all threads
+            gdb_cmd = [
+                "gdb",
+                "-batch",
+                "-ex",
+                "thread apply all bt full",
+                "-ex",
+                "info registers",
+                "-ex",
+                "detach",
+                "-p",
+                str(proc.pid),
+            ]
+            try:
+                gdb_proc = subprocess.run(
+                    gdb_cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                logger.info("=== gdb backtrace output ===")
+                for line in gdb_proc.stdout.splitlines():
+                    logger.info(line)
+                if gdb_proc.stderr:
+                    logger.info("=== gdb stderr ===")
+                    for line in gdb_proc.stderr.splitlines():
+                        logger.info(line)
+            except FileNotFoundError:
+                logger.error("gdb not found, falling back to /proc")
+                # Fallback: read /proc/PID/maps for address info
+                try:
+                    maps = Path(f"/proc/{proc.pid}/maps").read_text()
+                    logger.info(f"=== /proc/{proc.pid}/maps ===")
+                    for line in maps.splitlines():
+                        if (
+                            "libhsa" in line
+                            or "libamdhip" in line
+                            or "hip_simple" in line
+                        ):
+                            logger.info(line)
+                except Exception as e:
+                    logger.warning(f"Cannot read /proc maps: {e}")
+            except Exception as e:
+                logger.error(f"gdb failed: {e}")
+
             proc.kill()
             proc.wait()
 

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -125,13 +125,44 @@ class TestROCmSanity:
             cwd=str(THEROCK_BIN_DIR),
         )
 
+        # Run under strace to capture the syscall where it hangs.
+        # Use subprocess.Popen with a 60s timeout so we can read the strace
+        # log even if the process hangs (TheRock#3199).
         platform_executable_prefix = "./" if not is_windows() else ""
-        process = run_command(
-            [f"{platform_executable_prefix}{executable}"],
+        exe = f"{platform_executable_prefix}{executable}"
+        strace_log = str(THEROCK_BIN_DIR / "strace_hip_simple.log")
+        strace_cmd = [
+            "strace",
+            "-f",
+            "-tt",
+            "-e",
+            "trace=ioctl,futex,write,openat",
+            "-o",
+            strace_log,
+            exe,
+        ]
+        logger.info(f"++ Run [{THEROCK_BIN_DIR}]$ {shlex.join(strace_cmd)}")
+        proc = subprocess.Popen(
+            strace_cmd,
             cwd=str(THEROCK_BIN_DIR),
-            capture=False,
         )
-        check.equal(process.returncode, 0)
+        try:
+            proc.wait(timeout=60)
+        except subprocess.TimeoutExpired:
+            logger.error("hip_simple_check hung for 60s, killing")
+            proc.kill()
+            proc.wait()
+
+        # Print last 100 lines of strace log to see where it hung
+        try:
+            with open(strace_log) as f:
+                lines = f.readlines()
+                logger.info("=== strace tail (last 100 lines) ===")
+                for line in lines[-100:]:
+                    logger.info(line.rstrip())
+        except Exception as e:
+            logger.error(f"Failed to read strace log: {e}")
+        check.equal(proc.returncode, 0)
 
     # TODO(#3313): Re-enable once hipcc test is fixed for ASAN builds
     @pytest.mark.skipif(

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -90,6 +90,53 @@ class TestROCmSanity:
     @pytest.mark.skipif(
         is_asan(), reason="hipcc test fails with ASAN build, see TheRock#3313"
     )
+    def test_hip_simple(self):
+        """Minimal kernel without printf to isolate gfx1150 hang (TheRock#3199)."""
+        platform_executable_suffix = ".exe" if is_windows() else ""
+        offload_arch_path = (
+            THEROCK_BIN_DIR
+            / ".."
+            / "lib"
+            / "llvm"
+            / "bin"
+            / f"offload-arch{platform_executable_suffix}"
+        ).resolve()
+        process = run_command([str(offload_arch_path)])
+        offload_arch = None
+        for line in process.stdout.splitlines():
+            if "gfx" in line:
+                offload_arch = line
+                break
+        assert (
+            offload_arch is not None
+        ), f"Expected offload-arch to return gfx####, got:\n{process.stdout}"
+
+        executable = f"hip_simple_check{platform_executable_suffix}"
+        run_command(
+            [
+                f"{THEROCK_BIN_DIR}/hipcc",
+                str(THIS_DIR / "hip_simple_check.cpp"),
+                "-Xlinker",
+                f"-rpath={THEROCK_BIN_DIR}/../lib/",
+                f"--offload-arch={offload_arch}",
+                "-o",
+                executable,
+            ],
+            cwd=str(THEROCK_BIN_DIR),
+        )
+
+        platform_executable_prefix = "./" if not is_windows() else ""
+        process = run_command(
+            [f"{platform_executable_prefix}{executable}"],
+            cwd=str(THEROCK_BIN_DIR),
+            capture=False,
+        )
+        check.equal(process.returncode, 0)
+
+    # TODO(#3313): Re-enable once hipcc test is fixed for ASAN builds
+    @pytest.mark.skipif(
+        is_asan(), reason="hipcc test fails with ASAN build, see TheRock#3313"
+    )
     def test_hip_printf(self):
         platform_executable_suffix = ".exe" if is_windows() else ""
 

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -126,6 +126,21 @@ class TestROCmSanity:
             cwd=str(THEROCK_BIN_DIR),
         )
 
+        # Dump dmesg before running to capture pre-existing GPU firmware
+        # errors that may cause all subsequent kernel launches to stall.
+        try:
+            dmesg_before = subprocess.run(
+                ["dmesg", "--level=err,warn", "-T"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            logger.info("=== dmesg (err+warn) before hip_simple_check ===")
+            for line in dmesg_before.stdout.splitlines()[-50:]:
+                logger.info(line)
+        except Exception as e:
+            logger.warning(f"dmesg failed: {e}")
+
         # Run with a 30s grace period; if it hangs, attach gdb to get
         # userspace backtraces for all threads (TheRock#3199).
         # The container has --cap-add SYS_PTRACE for this purpose.
@@ -142,6 +157,21 @@ class TestROCmSanity:
             proc.wait(timeout=hang_timeout)
         except subprocess.TimeoutExpired:
             logger.error(f"hip_simple_check hung for {hang_timeout}s — attaching gdb")
+
+            # Dump dmesg again to see if new GPU errors appeared during hang
+            try:
+                dmesg_after = subprocess.run(
+                    ["dmesg", "-T"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                logger.info("=== dmesg (last 100 lines) after hang ===")
+                for line in dmesg_after.stdout.splitlines()[-100:]:
+                    logger.info(line)
+            except Exception as e:
+                logger.warning(f"dmesg failed: {e}")
+
             # Install gdb (container runs as root, image is Ubuntu 24.04)
             try:
                 subprocess.run(

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -11,6 +11,7 @@ import re
 import shlex
 import subprocess
 import sys
+import time
 
 THIS_DIR = Path(__file__).resolve().parent
 
@@ -125,43 +126,83 @@ class TestROCmSanity:
             cwd=str(THEROCK_BIN_DIR),
         )
 
-        # Run under strace to capture the syscall where it hangs.
-        # Use subprocess.Popen with a 60s timeout so we can read the strace
-        # log even if the process hangs (TheRock#3199).
+        # Run with /proc polling to capture kernel stack if it hangs.
+        # strace is not available in the CI container, so we poll
+        # /proc/PID/stack, /proc/PID/syscall, and /proc/PID/wchan
+        # to identify where the process blocks (TheRock#3199).
         platform_executable_prefix = "./" if not is_windows() else ""
         exe = f"{platform_executable_prefix}{executable}"
-        strace_log = str(THEROCK_BIN_DIR / "strace_hip_simple.log")
-        strace_cmd = [
-            "strace",
-            "-f",
-            "-tt",
-            "-e",
-            "trace=ioctl,futex,write,openat",
-            "-o",
-            strace_log,
-            exe,
-        ]
-        logger.info(f"++ Run [{THEROCK_BIN_DIR}]$ {shlex.join(strace_cmd)}")
+        logger.info(f"++ Run [{THEROCK_BIN_DIR}]$ {exe}")
         proc = subprocess.Popen(
-            strace_cmd,
+            [exe],
             cwd=str(THEROCK_BIN_DIR),
         )
-        try:
-            proc.wait(timeout=60)
-        except subprocess.TimeoutExpired:
-            logger.error("hip_simple_check hung for 60s, killing")
+
+        timeout = 60
+        poll_interval = 5
+        elapsed = 0
+        last_stack = None
+        while elapsed < timeout:
+            ret = proc.poll()
+            if ret is not None:
+                break
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+
+            # Read /proc info for the hanging process
+            pid = proc.pid
+            for proc_file in ["stack", "syscall", "wchan", "status"]:
+                path = f"/proc/{pid}/task/{pid}/{proc_file}"
+                try:
+                    with open(path) as f:
+                        content = f.read().strip()
+                    if proc_file == "stack":
+                        if content != last_stack:
+                            logger.info(
+                                f"=== /proc/{pid}/{proc_file} (t={elapsed}s) ==="
+                            )
+                            for line in content.splitlines():
+                                logger.info(line)
+                            last_stack = content
+                        else:
+                            logger.info(
+                                f"=== /proc/{pid}/{proc_file} (t={elapsed}s) === (unchanged)"
+                            )
+                    else:
+                        logger.info(
+                            f"/proc/{pid}/{proc_file} (t={elapsed}s): {content}"
+                        )
+                except Exception as e:
+                    logger.warning(f"Cannot read /proc/{pid}/{proc_file}: {e}")
+
+            # Also dump stacks for all threads
+            try:
+                task_dir = Path(f"/proc/{pid}/task")
+                tids = sorted(task_dir.iterdir())
+                if len(tids) > 1:
+                    logger.info(
+                        f"=== Thread stacks ({len(tids)} threads, t={elapsed}s) ==="
+                    )
+                    for tid_path in tids:
+                        tid = tid_path.name
+                        if tid == str(pid):
+                            continue
+                        try:
+                            stack = (tid_path / "stack").read_text().strip()
+                            wchan = (tid_path / "wchan").read_text().strip()
+                            logger.info(f"--- TID {tid} (wchan={wchan}) ---")
+                            for line in stack.splitlines():
+                                logger.info(line)
+                        except Exception:
+                            pass
+            except Exception:
+                pass
+
+        if proc.poll() is None:
+            logger.error(f"hip_simple_check hung for {timeout}s, killing")
             proc.kill()
             proc.wait()
 
-        # Print last 100 lines of strace log to see where it hung
-        try:
-            with open(strace_log) as f:
-                lines = f.readlines()
-                logger.info("=== strace tail (last 100 lines) ===")
-                for line in lines[-100:]:
-                    logger.info(line.rstrip())
-        except Exception as e:
-            logger.error(f"Failed to read strace log: {e}")
         check.equal(proc.returncode, 0)
 
     # TODO(#3313): Re-enable once hipcc test is fixed for ASAN builds


### PR DESCRIPTION
The gfx1150 Linux test runner was disabled in bd97652 (Feb 2026) due to ROCm sanity check timeouts. Re-enabling to observe current failure state and unblock investigation.

Nightly tests run: 
https://github.com/ROCm/TheRock/actions/runs/24239158127
https://github.com/ROCm/TheRock/actions/runs/24244204542 (using artifact id 24239158127)
https://github.com/ROCm/TheRock/actions/runs/24745963461

Hanging on
```
-------------------------------- live log call ---------------------------------
INFO     test_rocm_sanity:test_rocm_sanity.py:33 ++ Run [None]$ /__w/TheRock/TheRock/build/lib/llvm/bin/offload-arch
INFO     test_rocm_sanity:test_rocm_sanity.py:33 ++ Run [/__w/TheRock/TheRock/build/bin]$ /__w/TheRock/TheRock/build/bin/hipcc /__w/TheRock/TheRock/tests/hipcc_check.cpp -Xlinker -rpath=/__w/TheRock/TheRock/build/bin/../lib/ --offload-arch=gfx1150 -o hipcc_check
INFO     test_rocm_sanity:test_rocm_sanity.py:33 ++ Run [/__w/TheRock/TheRock/build/bin]$ ./hipcc_check
[12:16:14Z] Mem: 2.5/30.7GB (8%) | Jobs: ~1/24 | Disk: 28GB free
[12:16:44Z] Mem: 2.4/30.7GB (8%) | CPU: 4% | Jobs: ~1/24 | Disk: 28GB free
[12:17:14Z] Mem: 2.4/30.7GB (8%) | CPU: 4% | Jobs: ~1/24 | Disk: 28GB free
[12:17:44Z] Mem: 2.4/30.7GB (8%) | CPU: 4% | Jobs: ~1/24 | Disk: 28GB free
[12:18:14Z] Mem: 2.4/30.7GB (8%) | CPU: 4% | Jobs: ~1/24 | Disk: 28GB free
[12:18:44Z] Mem: 2.4/30.7GB (8%) | CPU: 4% | Jobs: ~1/24 | Disk: 28GB free
[12:19:14Z] Mem: 2.4/30.7GB (8%) | CPU: 4% | Jobs: ~1/24 | Disk: 28GB free
[12:19:44Z] Mem: 2.4/30.7GB (8%) | CPU: 4% | Jobs: ~1/24 | Disk: 28GB free
[12:20:14Z] Mem: 2.4/30.7GB (8%) | CPU: 4% | Jobs: ~1/24 | Disk: 28GB free
Error: The action 'Test' has timed out after 5 minutes.
```
