### PR TITLE
[CI] initialize exclude_filter in test_rocrtst

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocrtst.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocrtst.py
@@ -70,10 +70,10 @@ QUICK_TESTS = [
     "rocrtstFunc.Memory_Atomic_Xchg_Test",
 ]
 
-exclude_filter = ""
+exclude_filter = "-"
 if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILIES]:
     ignored_tests = TEST_TO_IGNORE[AMDGPU_FAMILIES][os_type]
-    exclude_filter = "-" + ":".join(ignored_tests)
+    exclude_filter += ":".join(ignored_tests)
 
 test_type = os.getenv("TEST_TYPE", "full")
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocrtst.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocrtst.py
@@ -28,6 +28,11 @@ cmd = ["./rocrtst64"]
 
 # TODO(#3851): Excluded tests (flaky or disabled in CI).
 TEST_TO_IGNORE = {
+    "gfx90a": {
+        "linux": [
+            "rocrtstFunc.Memory_Max_Mem",
+        ]
+    },
     "gfx94X-dcgpu": {
         "linux": [
             "rocrtstFunc.Memory_Max_Mem",

--- a/build_tools/github_actions/test_executable_scripts/test_rocrtst.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocrtst.py
@@ -70,6 +70,7 @@ QUICK_TESTS = [
     "rocrtstFunc.Memory_Atomic_Xchg_Test",
 ]
 
+exclude_filter = ""
 if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILIES]:
     ignored_tests = TEST_TO_IGNORE[AMDGPU_FAMILIES][os_type]
     exclude_filter = "-" + ":".join(ignored_tests)


### PR DESCRIPTION
## Motivation

This update initializes the `exclude_filter` variable in the `test_rocrtst.py` to resolve issues where the `exclude_filter` is empty on npi workflows

## Technical Details

initialize `exclude_filter` before the conditional in `test_rocrtst.py` 

## Test Plan

CI

## Test Result

CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
