### PR TITLE
Remove the need for boost for MIOpen

### DIFF
--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -76,21 +76,6 @@ if(THEROCK_ENABLE_MIOPEN)
   endif()
 
   if(MSVC)
-    # HACK, see https://github.com/ROCm/TheRock/issues/525.
-    # Take the most recent few MSVC versions from
-    # https://github.com/boostorg/boost_install/blob/develop/BoostDetectToolset.cmake
-    # and pass them through to the Boost_COMPILER option below. This is messy -
-    # maybe we can drop the Boost dependency or write new build rules for it.
-    if((MSVC_VERSION GREATER 1929) AND (MSVC_VERSION LESS 1950))
-      set(_THEROCK_MIOPEN_OVERRIDE_BOOST_COMPILER "vc143")
-    elseif((MSVC_VERSION GREATER 1919) AND (MSVC_VERSION LESS 1930))
-      set(_THEROCK_MIOPEN_OVERRIDE_BOOST_COMPILER "vc142")
-    elseif((MSVC_VERSION GREATER 1909) AND (MSVC_VERSION LESS 1920))
-      set(_THEROCK_MIOPEN_OVERRIDE_BOOST_COMPILER "vc141")
-    else()
-      message(WARNING "Unhandled MSVC_VERSION '${MSVC_VERSION}', Boost may not configure correctly")
-    endif()
-
     set(_THEROCK_MIOPEN_ENABLE_TESTING ON)
   else()
     set(_THEROCK_MIOPEN_ENABLE_TESTING ${THEROCK_BUILD_TESTING})
@@ -108,7 +93,6 @@ if(THEROCK_ENABLE_MIOPEN)
       "-DMIOPEN_USE_COMPOSABLEKERNEL=${THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL}"
       -DMIOPEN_USE_MLIR=OFF # TODO: enable
       -DMIOPEN_TEST_DISCRETE=OFF
-      -DBoost_COMPILER=${_THEROCK_MIOPEN_OVERRIDE_BOOST_COMPILER}
       "-DMIOPEN_INSTALL_GPU_DATABASES=\"${THEROCK_AMDGPU_TARGETS}\""
     CMAKE_INCLUDES
       therock_explicit_finders.cmake
@@ -116,7 +100,6 @@ if(THEROCK_ENABLE_MIOPEN)
       amd-hip
     BUILD_DEPS
       rocm-cmake
-      therock-boost
       therock-eigen
       therock-frugally-deep
       therock-googletest


### PR DESCRIPTION
## Motivation

MIOpen no longer uses boost but the dependency on it wasn't removed from TheRock build info.