### PR TITLE
Fully wire kpack-split into multi-arch Python package CI

### DIFF
--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -56,6 +56,9 @@ on:
       package_find_links_url:
         description: URL for pip --find-links to install built packages
         value: ${{ jobs.build_rocm_wheels.outputs.package_find_links_url }}
+      kpack_split:
+        description: "true if this is a kpack-split flat build, false for legacy per-family"
+        value: ${{ jobs.build_rocm_wheels.outputs.kpack_split }}
 
 permissions:
   contents: read
@@ -74,6 +77,7 @@ jobs:
       options: -v /runner/config:/home/awsconfig/
     outputs:
       package_find_links_url: ${{ steps.upload.outputs.package_find_links_url }}
+      kpack_split: ${{ steps.upload.outputs.kpack_split }}
     env:
       AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
@@ -98,6 +102,7 @@ jobs:
               --run-github-repo="${{ inputs.artifact_github_repo }}" \
               --stage=all \
               --amdgpu-families="${{ inputs.amdgpu_families }}" \
+              --expand-family-to-targets \
               --output-dir="${{ github.workspace }}"
               # NOTE: artifact_manager.py appends /artifacts to --output-dir
               # in non-flatten mode, so pass workspace root here so that

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -44,6 +44,17 @@ on:
         required: false
         type: string
         default: "none"
+      amdgpu_targets:
+        description: >-
+          Comma-separated individual gfx targets for kpack-split builds
+          (e.g. 'gfx942' or 'gfx1200,gfx1201'). Used to install the correct
+          per-target device wheels. Leave empty for legacy per-family builds.
+        type: string
+        default: ""
+      kpack_split:
+        description: "'true' if this is a kpack-split flat build."
+        type: string
+        default: "false"
   workflow_dispatch:
     inputs:
       artifact_group:
@@ -157,6 +168,17 @@ jobs:
           echo "SCCACHE_BUCKET=${SCCACHE_BUCKET}"
           echo "SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX}"
 
+      - name: Compute ROCm device extras
+        id: device_extras
+        run: |
+          if [ "${{ inputs.kpack_split }}" = "true" ] && [ -n "${{ inputs.amdgpu_targets }}" ]; then
+            extras=$(echo "${{ inputs.amdgpu_targets }}" \
+              | tr ',' '\n' | sed 's/^/device-/' | tr '\n' ',' | sed 's/,$//')
+            echo "value=${extras}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build PyTorch wheels
         run: |
           cache_flag=""
@@ -166,6 +188,11 @@ jobs:
             cache_flag="--use-ccache"
           fi
 
+          rocm_extras_flag=""
+          if [ -n "${{ steps.device_extras.outputs.value }}" ]; then
+            rocm_extras_flag="--rocm-extras ${{ steps.device_extras.outputs.value }}"
+          fi
+
           ./external-builds/pytorch/build_prod_wheels.py \
             build \
             --install-rocm \
@@ -173,6 +200,7 @@ jobs:
             --clean \
             --output-dir ${{ env.PACKAGE_DIST_DIR }} \
             ${cache_flag} \
+            ${rocm_extras_flag} \
             ${{ env.optional_build_prod_arguments }}
 
       - name: Report cache stats

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -172,8 +172,8 @@ jobs:
         id: device_extras
         run: |
           if [ "${{ inputs.kpack_split }}" = "true" ] && [ -n "${{ inputs.amdgpu_targets }}" ]; then
-            extras=$(echo "${{ inputs.amdgpu_targets }}" \
-              | tr ',' '\n' | sed 's/^/device-/' | tr '\n' ',' | sed 's/,$//')
+            # Prefix each comma-separated target with "device-": gfx942,gfx1201 -> device-gfx942,device-gfx1201
+            extras=$(echo "${{ inputs.amdgpu_targets }}" | sed 's/\(^\|,\)/\1device-/g')
             echo "value=${extras}" >> "$GITHUB_OUTPUT"
           else
             echo "value=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -172,6 +172,8 @@ jobs:
       artifact_group: ${{ matrix.family_info.amdgpu_family }}
       python_version: "3.12"
       pytorch_git_ref: "release/2.10"
+      amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
+      kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
       rocm_package_find_links_url: >-
         ${{
           needs.build_python_packages.outputs.kpack_split == 'true'

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -144,7 +144,14 @@ jobs:
     with:
       amdgpu_family: ${{ matrix.family_info.amdgpu_family }}
       test_runs_on: ${{ matrix.family_info.test-runs-on }}
-      package_find_links_url: "${{ needs.build_python_packages.outputs.package_find_links_url }}/${{ matrix.family_info.amdgpu_family }}/index.html"
+      package_find_links_url: >-
+        ${{
+          needs.build_python_packages.outputs.kpack_split == 'true'
+          && needs.build_python_packages.outputs.package_find_links_url
+          || format('{0}/{1}/index.html',
+              needs.build_python_packages.outputs.package_find_links_url,
+              matrix.family_info.amdgpu_family)
+        }}
       python_version: "3.12"
       rocm_version: ${{ inputs.rocm_package_version }}
 
@@ -165,7 +172,14 @@ jobs:
       artifact_group: ${{ matrix.family_info.amdgpu_family }}
       python_version: "3.12"
       pytorch_git_ref: "release/2.10"
-      rocm_package_find_links_url: "${{ needs.build_python_packages.outputs.package_find_links_url }}/${{ matrix.family_info.amdgpu_family }}/index.html"
+      rocm_package_find_links_url: >-
+        ${{
+          needs.build_python_packages.outputs.kpack_split == 'true'
+          && needs.build_python_packages.outputs.package_find_links_url
+          || format('{0}/{1}/index.html',
+              needs.build_python_packages.outputs.package_find_links_url,
+              matrix.family_info.amdgpu_family)
+        }}
       rocm_version: ${{ inputs.rocm_package_version }}
     permissions:
       contents: read

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -154,6 +154,8 @@ jobs:
         }}
       python_version: "3.12"
       rocm_version: ${{ inputs.rocm_package_version }}
+      amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
+      kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
 
   # NOTE: Per-family PyTorch builds — each family gets its own wheel built
   # against that family's ROCm package index slice.

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -144,6 +144,8 @@ jobs:
     with:
       amdgpu_family: ${{ matrix.family_info.amdgpu_family }}
       test_runs_on: ${{ matrix.family_info.test-runs-on }}
+      # TODO: Simplify to just `needs.build_python_packages.outputs.package_find_links_url`
+      # once kpack split is always enabled.
       package_find_links_url: >-
         ${{
           needs.build_python_packages.outputs.kpack_split == 'true'

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -115,8 +115,8 @@ jobs:
         id: device_extras
         run: |
           if [ "${{ inputs.kpack_split }}" = "true" ] && [ -n "${{ inputs.amdgpu_targets }}" ]; then
-            extras=$(echo "${{ inputs.amdgpu_targets }}" \
-              | tr ',' '\n' | sed 's/^/device-/' | tr '\n' ',' | sed 's/,$//')
+            # Prefix each comma-separated target with "device-": gfx942,gfx1201 -> device-gfx942,device-gfx1201
+            extras=$(echo "${{ inputs.amdgpu_targets }}" | sed 's/\(^\|,\)/\1device-/g')
             echo "value=${extras}" >> "$GITHUB_OUTPUT"
           else
             echo "value=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -50,6 +50,17 @@ on:
       rocm_version:
         required: true
         type: string
+      amdgpu_targets:
+        description: >-
+          Comma-separated individual gfx targets for kpack-split builds
+          (e.g. 'gfx942' or 'gfx1200,gfx1201'). Used to install the correct
+          per-target device wheels. Leave empty for legacy per-family builds.
+        type: string
+        default: ""
+      kpack_split:
+        description: "'true' if this is a kpack-split flat build."
+        type: string
+        default: "false"
 
 permissions:
   contents: read
@@ -89,12 +100,27 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
+      - name: Compute ROCm device extras
+        id: device_extras
+        run: |
+          if [ "${{ inputs.kpack_split }}" = "true" ] && [ -n "${{ inputs.amdgpu_targets }}" ]; then
+            extras=$(echo "${{ inputs.amdgpu_targets }}" \
+              | tr ',' '\n' | sed 's/^/device-/' | tr '\n' ',' | sed 's/,$//')
+            echo "value=${extras}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=" >> "$GITHUB_OUTPUT"
+          fi
+
       # Key off install_libraries success (not test_libraries) so devel install/test still run
       - name: Install rocm[libraries]
         id: install_libraries
         run: |
+          pkg="rocm[libraries]"
+          if [ -n "${{ steps.device_extras.outputs.value }}" ]; then
+            pkg="${pkg%]},${{ steps.device_extras.outputs.value }}]"
+          fi
           python build_tools/setup_venv.py ${VENV_DIR} \
-            --packages "rocm[libraries]==${{ inputs.rocm_version }}" \
+            --packages "${pkg}==${{ inputs.rocm_version }}" \
             --index-url=${{ inputs.package_index_url_base }} \
             --index-subdir=${{ inputs.amdgpu_family }} \
             --find-links=${{ inputs.package_find_links_url }} \
@@ -116,8 +142,12 @@ jobs:
         id: install_devel
         if: ${{ !cancelled() && steps.install_libraries.outcome == 'success' }}
         run: |
+          pkg="rocm[libraries,devel]"
+          if [ -n "${{ steps.device_extras.outputs.value }}" ]; then
+            pkg="${pkg%]},${{ steps.device_extras.outputs.value }}]"
+          fi
           python build_tools/setup_venv.py ${VENV_DIR} \
-            --packages "rocm[libraries,devel]==${{ inputs.rocm_version }}" \
+            --packages "${pkg}==${{ inputs.rocm_version }}" \
             --index-url=${{ inputs.package_index_url_base }} \
             --index-subdir=${{ inputs.amdgpu_family }} \
             --find-links=${{ inputs.package_find_links_url }}

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -31,6 +31,17 @@ on:
         description: ROCm version to pip install (e.g. "7.10.0a20251124")
         required: true
         type: string
+      amdgpu_targets:
+        description: >-
+          Comma-separated individual gfx targets for kpack-split builds
+          (e.g. 'gfx942' or 'gfx1200,gfx1201'). Used to install the correct
+          per-target device wheels. Leave empty for legacy per-family builds.
+        type: string
+        default: ""
+      kpack_split:
+        description: "'true' if this is a kpack-split flat build."
+        type: string
+        default: "false"
 
   workflow_call:
     inputs:

--- a/build_tools/github_actions/tests/upload_python_packages_test.py
+++ b/build_tools/github_actions/tests/upload_python_packages_test.py
@@ -171,9 +171,9 @@ class TestGenerateIndex(unittest.TestCase):
             dist_dir = Path(tmp)
             (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
             (dist_dir / "gfx94X-dcgpu").mkdir()
-            (dist_dir / "gfx94X-dcgpu" / "rocm_sdk_libraries_gfx94x_dcgpu-1.0.whl").write_bytes(
-                b"libs"
-            )
+            (
+                dist_dir / "gfx94X-dcgpu" / "rocm_sdk_libraries_gfx94x_dcgpu-1.0.whl"
+            ).write_bytes(b"libs")
 
             upload_python_packages.generate_index(dist_dir, multiarch=True)
 
@@ -186,7 +186,9 @@ class TestGenerateIndex(unittest.TestCase):
             dist_dir = Path(tmp)
             (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
 
-            upload_python_packages.generate_index(dist_dir, multiarch=True, dry_run=True)
+            upload_python_packages.generate_index(
+                dist_dir, multiarch=True, dry_run=True
+            )
 
             self.assertFalse((dist_dir / "index.html").is_file())
 

--- a/build_tools/github_actions/tests/upload_python_packages_test.py
+++ b/build_tools/github_actions/tests/upload_python_packages_test.py
@@ -10,6 +10,7 @@ import os
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 # Add build_tools to path so _therock_utils is importable.
@@ -134,6 +135,98 @@ class TestMultiArchUploadPath(unittest.TestCase):
             self.assertTrue((base / "index.html").is_file())
             # Confirm no artifact_group subdirectory was created
             self.assertFalse((base / "multi-arch-release").exists())
+
+
+class TestGenerateIndex(unittest.TestCase):
+    """Tests for generate_index() flat vs per-family auto-detection."""
+
+    def test_flat_layout_creates_top_level_index(self):
+        """Flat dist/ (no subdirs) creates index.html at top level."""
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+            (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
+            (dist_dir / "rocm_sdk_device_gfx942-1.0.whl").write_bytes(b"device")
+
+            upload_python_packages.generate_index(dist_dir, multiarch=True)
+
+            index = dist_dir / "index.html"
+            self.assertTrue(index.is_file())
+            content = index.read_text()
+            self.assertIn("rocm_sdk_core-1.0.whl", content)
+            self.assertIn("rocm_sdk_device_gfx942-1.0.whl", content)
+
+    def test_flat_layout_no_subdir_indexes_created(self):
+        """Flat dist/ does not create any subdirectory index files."""
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+            (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
+
+            upload_python_packages.generate_index(dist_dir, multiarch=True)
+
+            self.assertFalse(any(d.is_dir() for d in dist_dir.iterdir()))
+
+    def test_per_family_layout_creates_family_indexes(self):
+        """Per-family dist/ (with subdirs) creates per-family indexes, not top-level."""
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+            (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
+            (dist_dir / "gfx94X-dcgpu").mkdir()
+            (dist_dir / "gfx94X-dcgpu" / "rocm_sdk_libraries_gfx94x_dcgpu-1.0.whl").write_bytes(
+                b"libs"
+            )
+
+            upload_python_packages.generate_index(dist_dir, multiarch=True)
+
+            self.assertTrue((dist_dir / "gfx94X-dcgpu" / "index.html").is_file())
+            self.assertFalse((dist_dir / "index.html").is_file())
+
+    def test_dry_run_creates_nothing(self):
+        """dry_run=True creates no files regardless of layout."""
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+            (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
+
+            upload_python_packages.generate_index(dist_dir, multiarch=True, dry_run=True)
+
+            self.assertFalse((dist_dir / "index.html").is_file())
+
+
+class TestWriteGhaUploadSummary(unittest.TestCase):
+    """Tests for write_gha_upload_summary() three-way families branch."""
+
+    def _make_loc(self):
+        return _make_output_root().python_packages("")
+
+    @unittest.mock.patch("upload_python_packages.gha_append_step_summary")
+    def test_none_families_single_arch(self, mock_summary):
+        """families=None → single-arch summary with /index.html URL."""
+        upload_python_packages.write_gha_upload_summary(self._make_loc(), families=None)
+
+        text = mock_summary.call_args[0][0]
+        self.assertIn("/index.html", text)
+        self.assertNotIn("kpack-split", text)
+        self.assertNotIn("per-family", text.lower())
+
+    @unittest.mock.patch("upload_python_packages.gha_append_step_summary")
+    def test_empty_families_kpack_split(self, mock_summary):
+        """families=[] → kpack-split summary with /index.html URL."""
+        upload_python_packages.write_gha_upload_summary(self._make_loc(), families=[])
+
+        text = mock_summary.call_args[0][0]
+        self.assertIn("kpack-split", text)
+        self.assertIn("/index.html", text)
+
+    @unittest.mock.patch("upload_python_packages.gha_append_step_summary")
+    def test_nonempty_families_per_family(self, mock_summary):
+        """families=[...] → per-family summary with per-family index URLs."""
+        upload_python_packages.write_gha_upload_summary(
+            self._make_loc(), families=["gfx94X-dcgpu", "gfx120X-all"]
+        )
+
+        text = mock_summary.call_args[0][0]
+        self.assertIn("gfx94X-dcgpu/index.html", text)
+        self.assertIn("gfx120X-all/index.html", text)
+        self.assertNotIn("kpack-split", text)
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/upload_python_packages.py
+++ b/build_tools/github_actions/upload_python_packages.py
@@ -52,7 +52,7 @@ sys.path.insert(0, str(_BUILD_TOOLS_DIR / "packaging" / "python"))
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 from _therock_utils.storage_location import StorageLocation
 from _therock_utils.storage_backend import StorageBackend, create_storage_backend
-from generate_local_index import generate_multiarch_indexes
+from generate_local_index import generate_flat_index, generate_multiarch_indexes
 from github_actions_api import (
     gha_append_step_summary,
     gha_set_output,
@@ -96,9 +96,13 @@ def generate_index(dist_dir: Path, multiarch: bool = False, dry_run: bool = Fals
         return
 
     if multiarch:
-        # Multi-arch mode: generate per-family indexes with relative paths
-        log("[INFO] Multi-arch mode: generating per-family indexes")
-        generate_multiarch_indexes(dist_dir)
+        has_subdirs = any(d.is_dir() for d in dist_dir.iterdir())
+        if has_subdirs:
+            log("[INFO] Multi-arch legacy mode: generating per-family indexes")
+            generate_multiarch_indexes(dist_dir)
+        else:
+            log("[INFO] kpack-split flat mode: generating single top-level index")
+            generate_flat_index(dist_dir)
     else:
         # Single-arch mode: use existing indexer.py for top-level
         log("[INFO] Single-arch mode: using indexer.py")
@@ -158,11 +162,14 @@ def write_gha_upload_summary(
 
     Args:
         packages_loc: Storage location for packages
-        families: For multi-arch builds, the list of GPU family names that were
-            uploaded (e.g. ["gfx94X-dcgpu", "gfx120X-all"]). When provided,
-            per-family install links are emitted. When None, single-arch mode.
+        families: Controls the summary format:
+            - None: single-arch mode — single index URL
+            - [] (empty list): kpack-split flat mode — single index URL covering
+              all per-target wheels
+            - [...] non-empty: legacy per-family mode — per-family install links
     """
-    if families is not None:
+    if families:
+        # Legacy per-family multi-arch
         base_url = packages_loc.https_url
         family_links = "\n".join(
             f"- [{family}]({base_url}/{family}/index.html)" for family in families
@@ -178,6 +185,15 @@ Per-family indexes:
 {family_links}
 
 {family_installs}
+"""
+    elif families is not None:
+        # kpack-split flat build — single index covers all per-target wheels
+        index_url = f"{packages_loc.https_url}/index.html"
+        install_instructions_markdown = f"""[ROCm Python packages (kpack-split)]({index_url})
+```bash
+pip install rocm[libraries,devel] --pre {LINE_CONTINUATION_CHAR}
+    --find-links={index_url}
+```
 """
     else:
         # Single-arch: traditional index URL
@@ -233,29 +249,35 @@ def run(args: argparse.Namespace):
     upload_packages(dist_dir=dist_dir, packages_loc=packages_loc, backend=backend)
 
     if not args.output_dir:
-        # For multi-arch, return base URL without /index.html
-        # so tests can append /{family}/index.html
-        # For single-arch, return traditional URL with /index.html
         if args.multiarch:
-            index_url = packages_loc.https_url
-            log(
-                f"[INFO] Multi-arch base URL (tests append /{{family}}/index.html): {index_url}"
-            )
+            # Detect flat (kpack-split) vs legacy per-family layout from dist/.
+            family_subdirs = sorted(d.name for d in dist_dir.iterdir() if d.is_dir())
+            if family_subdirs:
+                # Legacy per-family: return base URL; downstream appends /{family}/index.html
+                index_url = packages_loc.https_url
+                kpack_split = "false"
+                log(
+                    f"[INFO] Multi-arch legacy URL (tests append /{{family}}/index.html): {index_url}"
+                )
+            else:
+                # kpack-split flat: all wheels at top level; return full /index.html URL
+                index_url = f"{packages_loc.https_url}/index.html"
+                kpack_split = "true"
+                log(f"[INFO] kpack-split flat URL: {index_url}")
         else:
+            family_subdirs = None
             index_url = f"{packages_loc.https_url}/index.html"
+            kpack_split = "false"
             log(f"[INFO] Single-arch index URL: {index_url}")
 
         log("Set github actions output")
         log("-------------------------")
-        gha_set_output({"package_find_links_url": index_url})
+        gha_set_output({"package_find_links_url": index_url, "kpack_split": kpack_split})
 
         log("Write github actions build summary")
         log("----------------------------------")
-        families = (
-            sorted(d.name for d in dist_dir.iterdir() if d.is_dir())
-            if args.multiarch
-            else None
-        )
+        # families: None=single-arch, []=kpack-split flat, [...]=legacy per-family
+        families = family_subdirs if args.multiarch else None
         write_gha_upload_summary(packages_loc, families=families)
 
     log("")

--- a/build_tools/github_actions/upload_python_packages.py
+++ b/build_tools/github_actions/upload_python_packages.py
@@ -273,7 +273,9 @@ def run(args: argparse.Namespace):
 
         log("Set github actions output")
         log("-------------------------")
-        gha_set_output({"package_find_links_url": index_url, "kpack_split": kpack_split})
+        gha_set_output(
+            {"package_find_links_url": index_url, "kpack_split": kpack_split}
+        )
 
         log("Write github actions build summary")
         log("----------------------------------")

--- a/build_tools/github_actions/upload_python_packages.py
+++ b/build_tools/github_actions/upload_python_packages.py
@@ -190,8 +190,9 @@ Per-family indexes:
         # kpack-split flat build — single index covers all per-target wheels
         index_url = f"{packages_loc.https_url}/index.html"
         install_instructions_markdown = f"""[ROCm Python packages (kpack-split)]({index_url})
+Replace `<YOUR_TARGET>` with your GPU target (e.g. `gfx942`, `gfx1201`):
 ```bash
-pip install rocm[libraries,devel] --pre {LINE_CONTINUATION_CHAR}
+pip install rocm[libraries,devel,device-<YOUR_TARGET>] --pre {LINE_CONTINUATION_CHAR}
     --find-links={index_url}
 ```
 """

--- a/build_tools/packaging/python/generate_local_index.py
+++ b/build_tools/packaging/python/generate_local_index.py
@@ -122,7 +122,9 @@ def generate_flat_index(dist_dir: Path, patterns: list[str] | None = None) -> No
     for pattern in patterns:
         local_files.extend([f for f in dist_dir.glob(pattern) if f.is_file()])
 
-    print(f"Generating flat index for kpack-split build: {len(local_files)} files in {dist_dir}")
+    print(
+        f"Generating flat index for kpack-split build: {len(local_files)} files in {dist_dir}"
+    )
 
     generate_simple_index(
         output_path=dist_dir / "index.html",

--- a/build_tools/packaging/python/generate_local_index.py
+++ b/build_tools/packaging/python/generate_local_index.py
@@ -101,6 +101,37 @@ def generate_simple_index(
     )
 
 
+def generate_flat_index(dist_dir: Path, patterns: list[str] | None = None) -> None:
+    """Generate a single flat index.html for kpack-split builds.
+
+    In kpack-split mode all packages (core, libraries, device-per-target, devel,
+    meta) are placed directly in dist/ at the top level — there are no family
+    subdirectories. This function generates a single index.html covering all
+    top-level files so that pip --find-links can discover all wheels.
+
+    Only top-level files are scanned; subdirectories are ignored.
+
+    Args:
+        dist_dir: dist/ directory containing packages at the top level
+        patterns: File patterns to include (default: ["*.whl", "*.tar.gz"])
+    """
+    if patterns is None:
+        patterns = ["*.whl", "*.tar.gz"]
+
+    local_files = []
+    for pattern in patterns:
+        local_files.extend([f for f in dist_dir.glob(pattern) if f.is_file()])
+
+    print(f"Generating flat index for kpack-split build: {len(local_files)} files in {dist_dir}")
+
+    generate_simple_index(
+        output_path=dist_dir / "index.html",
+        local_files=local_files,
+        parent_files=None,
+        title="ROCm Python Packages",
+    )
+
+
 def generate_multiarch_indexes(
     dist_dir: Path, patterns: list[str] | None = None
 ) -> None:

--- a/build_tools/packaging/python/templates/rocm/setup.py
+++ b/build_tools/packaging/python/templates/rocm/setup.py
@@ -60,18 +60,23 @@ EXTRAS_REQUIRE = {
     for pkg in dist_info.ALL_PACKAGES.values()
     if not pkg.required
 }
-# Per-target device extras: rocm[device-gfx942], rocm[device-gfx1201], etc.
-# The generic 'device' extra resolves via determine_target_family() at
-# sdist-build time, which is unreliable since offload-arch (from rocm-sdk-core)
-# is not yet installed at that point. Replace it with explicit per-target entries
-# so callers can request a specific ISA's device wheel unambiguously.
+# Add explicit per-target device extras (rocm[device-gfx942], etc.) alongside
+# the generic 'device' extra for callers that need to name a specific ISA —
+# e.g. kpack-split CI installs on GPU-less runners where offload-arch is not
+# yet available and the generic extra would silently fall back to
+# DEFAULT_TARGET_FAMILY. Keep the generic 'device' extra when target resolution
+# succeeds (normal install on a GPU machine); drop it only when it would produce
+# an incorrect result.
 device_entry = dist_info.ALL_PACKAGES.get("device")
 if device_entry and device_entry.is_target_specific:
-    EXTRAS_REQUIRE.pop("device", None)
     for _target in dist_info.AVAILABLE_TARGET_FAMILIES:
         EXTRAS_REQUIRE[f"device-{_target}"] = [
             device_entry.get_dist_package_require(target_family=_target)
         ]
+    try:
+        dist_info.determine_target_family()
+    except Exception:
+        EXTRAS_REQUIRE.pop("device", None)
 print(f"extras_require={EXTRAS_REQUIRE}")
 packages = find_packages(where="./src")
 print("Found packages:", packages)

--- a/build_tools/packaging/python/templates/rocm/setup.py
+++ b/build_tools/packaging/python/templates/rocm/setup.py
@@ -61,13 +61,13 @@ EXTRAS_REQUIRE = {
     if not pkg.required
 }
 # Per-target device extras: rocm[device-gfx942], rocm[device-gfx1201], etc.
-# In kpack-split builds AVAILABLE_TARGET_FAMILIES contains individual gfx
-# targets, enabling callers to request a specific ISA's device wheel without
-# relying on ROCM_SDK_TARGET_FAMILY being set in the environment.
-# In legacy builds the family names (e.g. gfx94X-dcgpu) become the keys,
-# which is harmless and consistent.
+# The generic 'device' extra resolves via determine_target_family() at
+# sdist-build time, which is unreliable since offload-arch (from rocm-sdk-core)
+# is not yet installed at that point. Replace it with explicit per-target entries
+# so callers can request a specific ISA's device wheel unambiguously.
 device_entry = dist_info.ALL_PACKAGES.get("device")
 if device_entry and device_entry.is_target_specific:
+    EXTRAS_REQUIRE.pop("device", None)
     for _target in dist_info.AVAILABLE_TARGET_FAMILIES:
         EXTRAS_REQUIRE[f"device-{_target}"] = [
             device_entry.get_dist_package_require(target_family=_target)

--- a/build_tools/packaging/python/templates/rocm/setup.py
+++ b/build_tools/packaging/python/templates/rocm/setup.py
@@ -60,6 +60,18 @@ EXTRAS_REQUIRE = {
     for pkg in dist_info.ALL_PACKAGES.values()
     if not pkg.required
 }
+# Per-target device extras: rocm[device-gfx942], rocm[device-gfx1201], etc.
+# In kpack-split builds AVAILABLE_TARGET_FAMILIES contains individual gfx
+# targets, enabling callers to request a specific ISA's device wheel without
+# relying on ROCM_SDK_TARGET_FAMILY being set in the environment.
+# In legacy builds the family names (e.g. gfx94X-dcgpu) become the keys,
+# which is harmless and consistent.
+device_entry = dist_info.ALL_PACKAGES.get("device")
+if device_entry and device_entry.is_target_specific:
+    for _target in dist_info.AVAILABLE_TARGET_FAMILIES:
+        EXTRAS_REQUIRE[f"device-{_target}"] = [
+            device_entry.get_dist_package_require(target_family=_target)
+        ]
 print(f"extras_require={EXTRAS_REQUIRE}")
 packages = find_packages(where="./src")
 print("Found packages:", packages)

--- a/build_tools/packaging/tests/generate_local_index_test.py
+++ b/build_tools/packaging/tests/generate_local_index_test.py
@@ -18,7 +18,11 @@ from pathlib import Path
 # Add build_tools/packaging/python to path so generate_local_index is importable.
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent / "python"))
 
-from generate_local_index import generate_simple_index, generate_multiarch_indexes
+from generate_local_index import (
+    generate_flat_index,
+    generate_multiarch_indexes,
+    generate_simple_index,
+)
 
 
 class TestGenerateSimpleIndex(unittest.TestCase):
@@ -169,6 +173,68 @@ class TestGenerateSimpleIndex(unittest.TestCase):
                 ">rocm_sdk_core-7.0.0+abc123-py3-none-linux_x86_64.whl</a>",
                 content,
             )
+
+
+class TestGenerateFlatIndex(unittest.TestCase):
+    """Tests for generate_flat_index()."""
+
+    def test_generates_top_level_index(self):
+        """Top-level wheels and sdists appear in index.html at dist/ root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+            (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
+            (dist_dir / "rocm_sdk_device_gfx942-1.0.whl").write_bytes(b"device")
+
+            generate_flat_index(dist_dir)
+
+            index = dist_dir / "index.html"
+            self.assertTrue(index.is_file())
+            content = index.read_text()
+            self.assertIn('<a href="./rocm_sdk_core-1.0.whl">', content)
+            self.assertIn('<a href="./rocm_sdk_device_gfx942-1.0.whl">', content)
+
+    def test_excludes_subdir_contents(self):
+        """Files inside subdirectories are not included in the flat index."""
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+            (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
+            subdir = dist_dir / "gfx94X-dcgpu"
+            subdir.mkdir()
+            (subdir / "rocm_sdk_libraries_gfx94x_dcgpu-1.0.whl").write_bytes(b"libs")
+
+            generate_flat_index(dist_dir)
+
+            content = (dist_dir / "index.html").read_text()
+            self.assertIn("rocm_sdk_core-1.0.whl", content)
+            self.assertNotIn("rocm_sdk_libraries_gfx94x_dcgpu", content)
+
+    def test_custom_patterns(self):
+        """Only files matching the specified patterns are included."""
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+            (dist_dir / "package.whl").write_bytes(b"whl")
+            (dist_dir / "package.tar.gz").write_bytes(b"sdist")
+            (dist_dir / "README.md").write_bytes(b"readme")
+
+            generate_flat_index(dist_dir, patterns=["*.whl"])
+
+            content = (dist_dir / "index.html").read_text()
+            self.assertIn("package.whl", content)
+            self.assertNotIn("package.tar.gz", content)
+            self.assertNotIn("README.md", content)
+
+    def test_empty_dist(self):
+        """Empty dist/ produces a valid index.html with no package links."""
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+
+            generate_flat_index(dist_dir)
+
+            index = dist_dir / "index.html"
+            self.assertTrue(index.is_file())
+            content = index.read_text()
+            self.assertIn("<!DOCTYPE html>", content)
+            self.assertNotIn("<a href", content)
 
 
 class TestGenerateMultiarchIndexes(unittest.TestCase):

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -420,7 +420,10 @@ def do_install_rocm(args: argparse.Namespace):
     if args.pip_cache_dir:
         pip_args.extend(["--cache-dir", str(args.pip_cache_dir)])
     rocm_sdk_version = args.rocm_sdk_version if args.rocm_sdk_version else ""
-    pip_args.extend([f"rocm[libraries,devel]{rocm_sdk_version}"])
+    extras = "libraries,devel"
+    if args.rocm_extras:
+        extras += f",{args.rocm_extras}"
+    pip_args.extend([f"rocm[{extras}]{rocm_sdk_version}"])
     run_command(pip_args, cwd=Path.cwd())
     print(f"Installed version: {get_rocm_sdk_version()}")
 
@@ -1253,6 +1256,15 @@ def main(argv: list[str]):
             default=True,
             action=argparse.BooleanOptionalAction,
             help="Include pre-release packages (default True)",
+        )
+        p.add_argument(
+            "--rocm-extras",
+            default="",
+            help=(
+                "Comma-separated additional extras for rocm package install "
+                "(e.g. 'device-gfx942,device-gfx943'). "
+                "Added alongside the base 'libraries,devel' extras."
+            ),
         )
 
     sub_p = p.add_subparsers(required=True)

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -343,13 +343,15 @@ def get_rocm_init_contents(args: argparse.Namespace):
         WINDOWS_LIBRARY_PRELOADS if is_windows else LINUX_LIBRARY_PRELOADS
     )
     library_preloads_formatted = ", ".join(f"'{s}'" for s in library_preloads)
-    return textwrap.dedent(f"""
+    return textwrap.dedent(
+        f"""
         def initialize():
             import rocm_sdk
             rocm_sdk.initialize_process(
                 preload_shortnames=[{library_preloads_formatted}],
                 check_version='{sdk_version}')
-        """)
+        """
+    )
 
 
 def remove_dir_if_exists(dir: Path):

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -343,15 +343,13 @@ def get_rocm_init_contents(args: argparse.Namespace):
         WINDOWS_LIBRARY_PRELOADS if is_windows else LINUX_LIBRARY_PRELOADS
     )
     library_preloads_formatted = ", ".join(f"'{s}'" for s in library_preloads)
-    return textwrap.dedent(
-        f"""
+    return textwrap.dedent(f"""
         def initialize():
             import rocm_sdk
             rocm_sdk.initialize_process(
                 preload_shortnames=[{library_preloads_formatted}],
                 check_version='{sdk_version}')
-        """
-    )
+        """)
 
 
 def remove_dir_if_exists(dir: Path):


### PR DESCRIPTION
## Motivation

This adds the missing pieces to produce kpack-split enabled Python packages.
The end-to-end CI produces a flat layout with per-gfx-targets packages rather then the legacy per-family subdirectory layout.

## Technical Details

- Index generation: A flat layout for kpack-split enabled packages is added
  The upload script auto-detects the playout at runtime.
- Device wheels: Fix device extra resolution for kpack-split installs. The rocm meta sdist now exposes explicit device-gfx{N}
  extras per available target alongside the generic `device` extra. On a GPU machine where offload-arch is available the generic extra continues to work as before; on GPU-less machine one can call `device-gfx{N}` directly.
  The extra is passed to `test_rocm_wheels.yml` and `build_portable_linux_pytorch_wheels_ci.yml` to inject the correct per-ISA extras at install time.

Legacy per-family builds are unaffected - all new inputs default to empty/false and leave existing behavior unchanged.

## Test Plan

https://github.com/ROCm/TheRock/actions/runs/24402771972 - CI run with additional change to build with kpack-split enabled.

## Test Result

- ROCm Python packages get successfully produced and installed
- Sanity checks fail
- Legacy builds unaffected (CI on this PR)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
