### PR TITLE
[CI] Fix nightly torch version resolution to include pre-releases

### DIFF
--- a/.github/workflows/ci_nightly_pytorch_full_test.yml
+++ b/.github/workflows/ci_nightly_pytorch_full_test.yml
@@ -105,6 +105,7 @@ jobs:
           # TODO: When adding Windows support, pass --platform win_amd64 for
           # Windows targets or derive the platform from amdgpu_family/runner.
           TORCH_VERSION=$(pip index versions torch \
+            --pre \
             --index-url "${INDEX_URL}" \
             --python-version "${PYTHON_VERSION}" \
             --platform linux_x86_64 2>/dev/null \


### PR DESCRIPTION
 adds --pre to the pip index versions command so it picks up pre-release wheels like 2.12.0a0 instead of falling back to the latest stable (2.11.0), which was causing a version mismatch with the nightly branch test sources.
 https://github.com/ROCm/TheRock/actions/runs/24343272904/job/71077503391