### PR TITLE
Build RCCL as single generic Instinct-only artifact in multi-arch CI

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -121,22 +121,21 @@ jobs:
       id-token: write
 
   # ==========================================================================
-  # STAGE: comm-libs (per-arch, parallel to math-libs)
+  # STAGE: comm-libs (generic, single job parallel to math-libs)
+  # RCCL and rocshmem are both TARGET_NEUTRAL artifacts. RCCL is built for
+  # Instinct/CDNA targets only (^gfx9 regex) via USE_FILTERED_AMDGPU_TARGETS.
+  # Running as a single generic job avoids redundant per-arch builds.
   # ==========================================================================
   comm-libs:
     needs: compiler-runtime
     if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'comm-libs') }}
-    strategy:
-      fail-fast: false
-      matrix:
-        family_info: ${{ fromJSON(inputs.matrix_per_family_json) }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
       stage_name: comm-libs
-      stage_display_name: "Stage - Comm Libs (${{ matrix.family_info.amdgpu_family }})"
+      stage_display_name: "Stage - Comm Libs"
       timeout_minutes: 240  # 4 hours
-      amdgpu_family: ${{ matrix.family_info.amdgpu_family }}
+      amdgpu_family: ""
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}

--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -153,9 +153,9 @@ artifact_groups = ["math-libs", "ml-libs"]
 type = "per-arch"
 
 [build_stages.comm-libs]
-description = "Communication libraries per architecture (can run parallel to math-libs)"
+description = "Communication libraries (generic, single job parallel to math-libs)"
 artifact_groups = ["comm-libs"]
-type = "per-arch"
+type = "generic"
 
 [build_stages.debug-tools]
 description = "ROCm debug tools"
@@ -268,7 +268,7 @@ source_sets = ["rocm-libraries", "ml-frameworks"]
 
 [artifact_groups.comm-libs]
 description = "Communication libraries"
-type = "per-arch"
+type = "generic"
 artifact_group_deps = ["hip-runtime"]
 # TODO: rocm-systems included for projects/hip/VERSION (see CMakeLists.txt)
 source_sets = ["comm-libs", "rocm-systems"]

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -24,6 +24,7 @@ import argparse
 import functools
 import json
 from pathlib import Path
+import re
 import sys
 
 from _therock_utils.artifacts import ArtifactCatalog, ArtifactName
@@ -302,6 +303,11 @@ def libraries_artifact_filter(target_family: str, an: ArtifactName) -> bool:
     return libraries
 
 
+# Matches Instinct/CDNA targets: gfx906, gfx908, gfx90a, gfx94x, gfx95x.
+# Excludes iGPU targets gfx900 and gfx90c.
+_INSTINCT_TARGET_RE = re.compile(r"^gfx9(0[68a]|[45])")
+
+
 def device_artifact_filter(target: str, an: ArtifactName) -> bool:
     """Selects per-ISA library artifacts for a specific GFX target.
 
@@ -309,15 +315,16 @@ def device_artifact_filter(target: str, an: ArtifactName) -> bool:
     (no generic). Used in kpack-split mode for device wheel population.
 
     For rccl, a generic artifact (rccl_lib_generic) is also accepted when the
-    target family is an Instinct/CDNA target (gfx9xx). This supports multi-arch
-    builds where a single Instinct-only rccl artifact is produced instead of
-    per-arch artifacts.
+    target family is an Instinct/CDNA target (gfx906, gfx908, gfx90a, gfx94x,
+    gfx95x — iGPU targets gfx900 and gfx90c are excluded). This supports
+    multi-arch builds where a single Instinct-only rccl artifact is produced
+    instead of per-arch artifacts.
     """
     is_rccl_generic = (
         an.name == "rccl"
         and an.component == "lib"
         and an.target_family == "generic"
-        and target.startswith("gfx9")
+        and bool(_INSTINCT_TARGET_RE.match(target))
     )
     return (
         an.name

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -292,7 +292,6 @@ def libraries_artifact_filter(target_family: str, an: ArtifactName) -> bool:
             "miopenprovider",
             "hipblasltprovider",
             "rand",
-            "rccl",
         ]
         and an.component
         in [
@@ -308,7 +307,18 @@ def device_artifact_filter(target: str, an: ArtifactName) -> bool:
 
     Unlike libraries_artifact_filter, this only matches the specific ISA target
     (no generic). Used in kpack-split mode for device wheel population.
+
+    For rccl, a generic artifact (rccl_lib_generic) is also accepted when the
+    target family is an Instinct/CDNA target (gfx9xx). This supports multi-arch
+    builds where a single Instinct-only rccl artifact is produced instead of
+    per-arch artifacts.
     """
+    is_rccl_generic = (
+        an.name == "rccl"
+        and an.component == "lib"
+        and an.target_family == "generic"
+        and target.startswith("gfx9")
+    )
     return (
         an.name
         in [
@@ -323,7 +333,7 @@ def device_artifact_filter(target: str, an: ArtifactName) -> bool:
         ]
         and an.component == "lib"
         and an.target_family == target
-    )
+    ) or is_rccl_generic
 
 
 def main(argv: list[str]):

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -219,6 +219,13 @@ endfunction()
 #   artifacts are marked TARGET_NEUTRAL so that the resulting _generic artifact
 #   contains device code for every architecture, making upload races in classic CI
 #   harmless. Does not affect dist_info.json (unlike USE_DIST_AMDGPU_TARGETS).
+# USE_FILTERED_AMDGPU_TARGETS: Like USE_TEST_AMDGPU_TARGETS but applies a regex
+#   filter to the test targets. Takes a REGEX sub-argument specifying the include
+#   pattern. Example:
+#     USE_FILTERED_AMDGPU_TARGETS REGEX "^gfx9"
+#   This selects only Instinct/CDNA targets (gfx9xx) from the full test target
+#   set. Combine with TARGET_NEUTRAL on therock_provide_artifact to produce a
+#   single _generic artifact containing device code for a target subset only.
 # DISABLE_AMDGPU_TARGETS: Do not set any GPU_TARGETS or AMDGPU_TARGETS variables
 #   in the project. This is largely used for broken projects that cannot
 #   build with an explicit target list.
@@ -341,7 +348,7 @@ function(therock_cmake_subproject_declare target_name)
     PARSE_ARGV 1 ARG
     "ACTIVATE;USE_DIST_AMDGPU_TARGETS;USE_TEST_AMDGPU_TARGETS;DISABLE_AMDGPU_TARGETS;EXCLUDE_FROM_ALL;BACKGROUND_BUILD;NO_MERGE_COMPILE_COMMANDS;OUTPUT_ON_FAILURE;NO_INSTALL_RPATH;FPRINT_SOURCE_HASH"
     "EXTERNAL_SOURCE_DIR;BINARY_DIR;DIR_PREFIX;INSTALL_DESTINATION;COMPILER_TOOLCHAIN;INTERFACE_PROGRAM_DIRS;CMAKE_LISTS_RELPATH;INTERFACE_PKG_CONFIG_DIRS;INSTALL_RPATH_EXECUTABLE_DIR;INSTALL_RPATH_LIBRARY_DIR;LOGICAL_TARGET_NAME;FPRINT_SOURCE_DIR"
-    "BUILD_DEPS;RUNTIME_DEPS;CMAKE_ARGS;CMAKE_INCLUDES;INTERFACE_INCLUDE_DIRS;INTERFACE_LINK_DIRS;IGNORE_PACKAGES;EXTRA_DEPENDS;INSTALL_RPATH_DIRS;INTERFACE_INSTALL_RPATH_DIRS;DEFAULT_GPU_TARGETS;FPRINT_FILE_GLOBS;INSTALL_OPTIONAL_COMPONENTS"
+    "BUILD_DEPS;RUNTIME_DEPS;CMAKE_ARGS;CMAKE_INCLUDES;INTERFACE_INCLUDE_DIRS;INTERFACE_LINK_DIRS;IGNORE_PACKAGES;EXTRA_DEPENDS;INSTALL_RPATH_DIRS;INTERFACE_INSTALL_RPATH_DIRS;DEFAULT_GPU_TARGETS;FPRINT_FILE_GLOBS;INSTALL_OPTIONAL_COMPONENTS;USE_FILTERED_AMDGPU_TARGETS"
   )
   if(TARGET "${target_name}")
     message(FATAL_ERROR "Cannot declare subproject '${target_name}': a target with that name already exists")
@@ -480,6 +487,12 @@ function(therock_cmake_subproject_declare target_name)
   # GPU Targets.
   if(ARG_DISABLE_AMDGPU_TARGETS)
     set(_gpu_targets)
+  elseif(ARG_USE_FILTERED_AMDGPU_TARGETS)
+    cmake_parse_arguments(_filter "" "" "REGEX" ${ARG_USE_FILTERED_AMDGPU_TARGETS})
+    set(_gpu_targets "${THEROCK_TEST_AMDGPU_TARGETS}")
+    if(_filter_REGEX)
+      list(FILTER _gpu_targets INCLUDE REGEX "${_filter_REGEX}")
+    endif()
   elseif(ARG_USE_TEST_AMDGPU_TARGETS)
     set(_gpu_targets "${THEROCK_TEST_AMDGPU_TARGETS}")
   elseif(ARG_USE_DIST_AMDGPU_TARGETS)

--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -5,6 +5,17 @@ if(THEROCK_ENABLE_RCCL)
   # Most libraries need to depend on the profiler, but is conditionally only used
   # on Posix.
   set(optional_profiler_deps)
+
+  # In a generic (multi-arch) build THEROCK_AMDGPU_FAMILIES is not set.
+  # Build RCCL and rccl-tests as a single target-neutral artifact containing
+  # device code for Instinct/CDNA targets only (gfx9xx), making upload races
+  # across parallel family jobs harmless.
+  set(_rccl_extra_args)
+  set(_rccl_artifact_extra_args)
+  if(NOT THEROCK_AMDGPU_FAMILIES)
+    list(APPEND _rccl_extra_args USE_FILTERED_AMDGPU_TARGETS REGEX "^gfx9")
+    list(APPEND _rccl_artifact_extra_args TARGET_NEUTRAL)
+  endif()
   if(THEROCK_FLAG_INCLUDE_PROFILER)
     list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
   endif()
@@ -27,6 +38,7 @@ if(THEROCK_ENABLE_RCCL)
   set(_rccl_subproject_names)
 
   therock_cmake_subproject_declare(rccl
+    ${_rccl_extra_args}
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rccl"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rccl"
     # High latency LTO link of a single library.
@@ -71,6 +83,7 @@ if(THEROCK_ENABLE_RCCL)
     endif()
 
     therock_cmake_subproject_declare(rccl-tests
+      ${_rccl_extra_args}
       EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rccl-tests"
       BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rccl-tests"
       BACKGROUND_BUILD
@@ -99,6 +112,7 @@ if(THEROCK_ENABLE_RCCL)
   endif(THEROCK_BUILD_TESTING)
 
   therock_provide_artifact(rccl
+    ${_rccl_artifact_extra_args}
     DESCRIPTOR artifact-rccl.toml
     COMPONENTS
       dbg

--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -8,12 +8,13 @@ if(THEROCK_ENABLE_RCCL)
 
   # In a generic (multi-arch) build THEROCK_AMDGPU_FAMILIES is not set.
   # Build RCCL and rccl-tests as a single target-neutral artifact containing
-  # device code for Instinct/CDNA targets only (gfx9xx), making upload races
-  # across parallel family jobs harmless.
+  # device code for Instinct/CDNA targets only (gfx906, gfx908, gfx90a,
+  # gfx94x, gfx95x — excludes iGPU targets gfx900 and gfx90c), making
+  # upload races across parallel family jobs harmless.
   set(_rccl_extra_args)
   set(_rccl_artifact_extra_args)
   if(NOT THEROCK_AMDGPU_FAMILIES)
-    list(APPEND _rccl_extra_args USE_FILTERED_AMDGPU_TARGETS REGEX "^gfx9")
+    list(APPEND _rccl_extra_args USE_FILTERED_AMDGPU_TARGETS REGEX "^gfx9(0[68a]|[45])")
     list(APPEND _rccl_artifact_extra_args TARGET_NEUTRAL)
   endif()
   if(THEROCK_FLAG_INCLUDE_PROFILER)


### PR DESCRIPTION
In multi-arch builds, RCCL was previously built per-arch for every GPU family including consumer RDNA targets (gfx110X, gfx120X, gfx103X, gfx101X). This changes comm-libs to run as a single generic CI job, producing one target-neutral RCCL artifact containing device code for Instinct/CDNA targets only (gfx9xx), consistent with where RCCL is actually tested and supported.

## Changes

Add `USE_FILTERED_AMDGPU_TARGETS REGEX <pattern>` keyword to `therock_cmake_subproject_declare` (cmake/therock_subproject.cmake). This filters `THEROCK_TEST_AMDGPU_TARGETS` by the given regex, enabling a subproject to build for a named subset of all registered targets while still producing a target-neutral (_generic) artifact. Upload races across parallel family jobs are harmless since all jobs would produce identical output.

In comm-libs/CMakeLists.txt, detect generic (multi-arch) builds via `NOT THEROCK_AMDGPU_FAMILIES` (empty in generic stages, set in per-arch stages) and apply `USE_FILTERED_AMDGPU_TARGETS REGEX "^gfx9"` plus `TARGET_NEUTRAL` to both rccl and rccl-tests subproject declarations. Single-family and developer builds are unaffected.

Change BUILD_TOPOLOGY.toml comm-libs build_stage and artifact_group types from per-arch to generic. The artifacts.rccl type remains target-specific, which is what controls kpack split behavior.

Remove the per-arch matrix from the comm-libs CI job in multi_arch_build_portable_linux.yml, replacing it with a single generic job using `amdgpu_family: ""`. rocshmem already uses USE_TEST_AMDGPU_TARGETS and TARGET_NEUTRAL, so it is unaffected by this change.

Update device_artifact_filter in build_python_packages.py to include rccl_lib_generic in device wheels for Instinct families (target.startswith ("gfx9")) while excluding it from RDNA device wheels. Remove rccl from libraries_artifact_filter since it contains device code and must not go into the generic libraries wheel.
