### PR TITLE
[ci] running `CI ASAN` on nightly

### DIFF
--- a/.github/workflows/ci_asan.yml
+++ b/.github/workflows/ci_asan.yml
@@ -6,6 +6,9 @@
 name: CI ASAN
 
 on:
+  schedule:
+    # Runs at 02:00 AM UTC, which is 7:00 PM PST (UTC-8)
+    - cron: '0 02 * * *'
   workflow_dispatch:
     inputs:
       linux_amdgpu_families:


### PR DESCRIPTION
For comparison and existing release work, `CI ASAN` will run on nightlies. Will most likely be removed next week as team transitions to multi arch CI ASAN