### PR TITLE
[hipsparselt] increase default timeout to avoid intermittent test timeouts

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -242,7 +242,7 @@ test_matrix = {
     "hipsparselt": {
         "job_name": "hipsparselt",
         "fetch_artifact_args": "--blas --tests",
-        "timeout_minutes": 30,
+        "timeout_minutes": 60,
         "test_script": f"python {_get_script_path('test_hipsparselt.py')}",
         "platform": ["linux"],
         "total_shards_dict": {


### PR DESCRIPTION
## Motivation

30 minutes isn't quite enough time for hipSPARSElt tests to run.  Sometimes it may take longer, and has been causing failures in other project pipelines.

## Technical Details

Increased the timeout to 60 minutes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
