### PR TITLE
Add temporary patches for hostcall optimization

### DIFF
--- a/patches/amd-mainline/llvm-project/0020-Optimize-hostcall-for-high-contention.patch
+++ b/patches/amd-mainline/llvm-project/0020-Optimize-hostcall-for-high-contention.patch
@@ -1,0 +1,395 @@
+From 898a178954efd0c5c1fe940cb003970ba17e1c0b Mon Sep 17 00:00:00 2001
+From: Brian Sumner <brian.sumner@amd.com>
+Date: Thu, 9 Apr 2026 09:55:35 -0700
+Subject: [PATCH] Optimize hostcall for high contention
+
+---
+ amd/device-libs/ockl/src/hostcall_impl.cl | 294 ++++++++--------------
+ 1 file changed, 103 insertions(+), 191 deletions(-)
+
+diff --git a/amd/device-libs/ockl/src/hostcall_impl.cl b/amd/device-libs/ockl/src/hostcall_impl.cl
+index 325ee8e45c41..448859ad7942 100644
+--- a/amd/device-libs/ockl/src/hostcall_impl.cl
++++ b/amd/device-libs/ockl/src/hostcall_impl.cl
+@@ -10,180 +10,96 @@
+ #pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable
+ #pragma OPENCL EXTENSION cl_khr_int64_extended_atomics : enable
+ 
+-#define AC(P, E, V, O, R, S)                                                   \
+-    __opencl_atomic_compare_exchange_strong(P, E, V, O, R, S)
+ #define AL(P, O, S) __opencl_atomic_load(P, O, S)
++#define AS(P, V, O, S) __opencl_atomic_store(P, V, O, S)
++#define AX(P, V, O, S) __opencl_atomic_exchange(P, V, O, S)
+ #define AF(K, P, V, O, S) __opencl_atomic_fetch_##K(P, V, O, S)
+ 
+-typedef enum { STATUS_SUCCESS, STATUS_BUSY } status_t;
+-
+-typedef enum {
+-    CONTROL_OFFSET_READY_FLAG = 0,
+-    CONTROL_OFFSET_RESERVED0 = 1,
+-} control_offset_t;
+-
+-typedef enum {
+-    CONTROL_WIDTH_READY_FLAG = 1,
+-    CONTROL_WIDTH_RESERVED0 = 31,
+-} control_width_t;
+-
+ typedef struct {
+-    ulong next;
+     ulong activemask;
+     uint service;
+-    uint control;
+ } header_t;
+ 
+ typedef struct {
+-    // 64 slots of 8 ulongs each
+     ulong slots[64][8];
+ } payload_t;
+ 
+-// Note: Hostcall buffer struct defined here is not an exact
+-// match of runtime buffer layout but matches its prefix that
+-// this code tries to access.
++// The prefix of this struct must match the host-side HostcallBuffer layout.
+ typedef struct {
++    __global uint *device_phase;
++    __global uint *host_phase;
++    __global uint *occupied;
+     __global header_t *headers;
+     __global payload_t *payloads;
+     hsa_signal_t doorbell;
+-    ulong free_stack;
+-    ulong ready_stack;
+-    ulong index_mask;
++    uint num_packets;
+ } buffer_t;
+ 
++static __global atomic_ulong last_signal_time;
++
+ static void
+ send_signal(hsa_signal_t signal)
+ {
+     __ockl_hsa_signal_add(signal, 1, __ockl_memory_order_release);
+ }
+ 
+-static __global header_t *
+-get_header(__global buffer_t *buffer, ulong ptr)
+-{
+-    return buffer->headers + (ptr & buffer->index_mask);
+-}
+-
+-static __global payload_t *
+-get_payload(__global buffer_t *buffer, ulong ptr)
+-{
+-    return buffer->payloads + (ptr & buffer->index_mask);
+-}
+-
+-static uint
+-get_control_field(uint control, uint offset, uint width)
++static bool
++try_claim(__global uint *occupied, uint i)
+ {
+-    return (control >> offset) & ((1 << width) - 1);
++    uint slot = i / 32;
++    uint bit = i % 32;
++    uint prev = AF(or, (__global atomic_uint *)&occupied[slot],
++                   1u << bit,
++                   memory_order_relaxed, memory_scope_device);
++    return !(prev & (1u << bit));
+ }
+ 
+-static uint
+-get_ready_flag(uint control)
+-{
+-    return get_control_field(control, CONTROL_OFFSET_READY_FLAG,
+-                             CONTROL_WIDTH_READY_FLAG);
+-}
+-
+-static uint
+-set_control_field(uint control, uint offset, uint width, uint value)
++static void
++unclaim(__global uint *occupied, uint i, uint me, uint low)
+ {
+-    uint mask = ~(((1 << width) - 1) << offset);
+-    return (control & mask) | (value << offset);
++    if (me == low) {
++        uint slot = i / 32;
++        uint bit = i % 32;
++        AF(and, (__global atomic_uint *)&occupied[slot],
++           ~(1u << bit),
++           memory_order_relaxed, memory_scope_device);
++    }
+ }
+ 
+ static uint
+-set_ready_flag(uint control)
++open_packet(__global buffer_t *buffer, uint me, uint low)
+ {
+-    return set_control_field(control, CONTROL_OFFSET_READY_FLAG,
+-                             CONTROL_WIDTH_READY_FLAG, 1);
+-}
+-
+-static ulong
+-pop(__global ulong *top, __global buffer_t *buffer)
+-{
+-    ulong F = AL((__global atomic_ulong *)top, memory_order_acquire,
+-                 memory_scope_all_svm_devices);
+-    // F is guaranteed to be non-zero, since there are at least as
+-    // many packets as there are waves, and each wave can hold at most
+-    // one packet.
+-    while (true) {
+-        __global header_t *P = get_header(buffer, F);
+-        ulong N = AL((__global atomic_ulong *)&P->next, memory_order_relaxed,
+-                     memory_scope_all_svm_devices);
+-        if (AC((__global atomic_ulong *)top, &F, N, memory_order_acquire,
+-               memory_order_relaxed, memory_scope_all_svm_devices)) {
+-            break;
+-        }
+-        __builtin_amdgcn_s_sleep(1);
+-    }
+-
+-    return F;
+-}
++    uint i = 0;
+ 
+-/** \brief Use the first active lane to get a free packet and
+- *         broadcast to the whole wave.
+- */
+-static ulong
+-pop_free_stack(__global buffer_t *buffer, uint me, uint low)
+-{
+-    ulong packet_ptr = 0;
+     if (me == low) {
+-        packet_ptr = pop(&buffer->free_stack, buffer);
+-    }
++        for (i = 0; ; ++i) {
++            if (i >= buffer->num_packets)
++                i = 0;
++
++            if (!try_claim(buffer->occupied, i)) {
++                __builtin_amdgcn_s_sleep(1);
++                continue;
++            }
++
++            uint dp = AL((__global atomic_uint *)&buffer->device_phase[i],
++                         memory_order_relaxed, memory_scope_all_svm_devices);
++            uint hp = AL((__global atomic_uint *)&buffer->host_phase[i],
++                         memory_order_relaxed, memory_scope_all_svm_devices);
++
++            if (dp != hp) {
++                uint slot = i / 32;
++                uint bit = i % 32;
++                AF(and, (__global atomic_uint *)&buffer->occupied[slot],
++                   ~(1u << bit),
++                   memory_order_relaxed, memory_scope_device);
++                continue;
++            }
+ 
+-    uint ptr_lo = packet_ptr;
+-    uint ptr_hi = packet_ptr >> 32;
+-    ptr_lo = __builtin_amdgcn_readfirstlane(ptr_lo);
+-    ptr_hi = __builtin_amdgcn_readfirstlane(ptr_hi);
+-
+-    return ((ulong)ptr_hi << 32) | ptr_lo;
+-}
+-
+-static void
+-push(__global ulong *top, ulong ptr, __global buffer_t *buffer)
+-{
+-    ulong F = AL((__global const atomic_ulong *)top, memory_order_relaxed,
+-                 memory_scope_all_svm_devices);
+-    __global header_t *P = get_header(buffer, ptr);
+-
+-    while (true) {
+-        P->next = F;
+-        if (AC((__global atomic_ulong *)top, &F, ptr, memory_order_release,
+-               memory_order_relaxed, memory_scope_all_svm_devices))
+             break;
+-        __builtin_amdgcn_s_sleep(1);
+-    }
+-}
+-
+-/** \brief Use the first active lane in a wave to submit a ready
+- *         packet and signal the host.
+- */
+-static void
+-push_ready_stack(__global buffer_t *buffer, ulong ptr, uint me, uint low)
+-{
+-    if (me == low) {
+-        push(&buffer->ready_stack, ptr, buffer);
+-        send_signal(buffer->doorbell);
++        }
+     }
+-}
+-
+-static ulong
+-inc_ptr_tag(ulong ptr, ulong index_mask)
+-{
+-    // Unit step for the tag.
+-    ulong inc = index_mask + 1;
+-    ptr += inc;
+-    // When the tag for index 0 wraps, increment the tag.
+-    return ptr == 0 ? inc : ptr;
+-}
+ 
+-/** \brief Return the packet after incrementing the ABA tag
+- */
+-static void
+-return_free_packet(__global buffer_t *buffer, ulong ptr, uint me, uint low)
+-{
+-    if (me == low) {
+-        ptr = inc_ptr_tag(ptr, buffer->index_mask);
+-        push(&buffer->free_stack, ptr, buffer);
+-    }
++    return __builtin_amdgcn_readfirstlane(i);
+ }
+ 
+ static void
+@@ -195,8 +111,6 @@ fill_packet(__global header_t *header, __global payload_t *payload,
+     if (me == low) {
+         header->service = service_id;
+         header->activemask = active;
+-        uint control = set_ready_flag(0);
+-        header->control = control;
+     }
+ 
+     __global ulong *ptr = payload->slots[me];
+@@ -210,50 +124,48 @@ fill_packet(__global header_t *header, __global payload_t *payload,
+     ptr[7] = arg7;
+ }
+ 
+-/** \brief Wait for the host response and return the first two ulong
+- *         entries per workitem.
+- *
+- *  After the packet is submitted in READY state, the wave spins until
+- *  the host changes the state to DONE. Each workitem reads the first
+- *  two ulong elements in its slot and returns this.
+- */
++// Minimum ticks between doorbell signals (~10us at 100 MHz steady counter).
++#define SIGNAL_THROTTLE_TICKS 1000
++
++static void
++send_to_host(__global buffer_t *buffer, uint i, uint me, uint low)
++{
++    if (me == low) {
++        uint dp = AL((__global atomic_uint *)&buffer->device_phase[i],
++                     memory_order_relaxed, memory_scope_all_svm_devices);
++        AS((__global atomic_uint *)&buffer->device_phase[i], dp ^ 1,
++            memory_order_release, memory_scope_all_svm_devices);
++
++        ulong now = __builtin_readsteadycounter();
++        ulong prev = AL(&last_signal_time,
++                        memory_order_relaxed, memory_scope_device);
++        if (now - prev > SIGNAL_THROTTLE_TICKS) {
++            prev = AX(&last_signal_time, now,
++                memory_order_relaxed, memory_scope_device);
++            if (now - prev > SIGNAL_THROTTLE_TICKS)
++                send_signal(buffer->doorbell);
++        }
++    }
++}
++
+ static long2
+-get_return_value(__global header_t *header, __global payload_t *payload,
+-                 uint me, uint low)
++receive_from_host(__global buffer_t *buffer, uint i,
++                  __global payload_t *payload, uint me, uint low)
+ {
+-    // The while loop needs to be executed by all active
+-    // lanes. Otherwise, later reads from ptr are performed only by
+-    // the first thread, while other threads reuse a value cached from
+-    // previous operations. The use of readfirstlane in the while loop
+-    // prevents this reordering.
+-    //
+-    // In the absence of the readfirstlane, only one thread has a
+-    // sequenced-before relation from the atomic load on
+-    // header->control to the ordinary loads on ptr. As a result, the
+-    // compiler is free to reorder operations in such a way that the
+-    // ordinary loads are performed only by the first thread. The use
+-    // of readfirstlane provides a stronger code-motion barrier, and
+-    // it effectively "spreads out" the sequenced-before relation to
+-    // the ordinary stores in other threads too.
+-    while (true) {
+-        uint ready_flag = 1;
+-        if (me == low) {
+-            uint control =
+-                AL((__global const atomic_uint *)&header->control,
+-                   memory_order_acquire, memory_scope_all_svm_devices);
+-            ready_flag = get_ready_flag(control);
++    if (me == low) {
++        while (true) {
++            uint dp = AL((__global atomic_uint *)&buffer->device_phase[i],
++                         memory_order_acquire, memory_scope_all_svm_devices);
++            uint hp = AL((__global atomic_uint *)&buffer->host_phase[i],
++                         memory_order_acquire, memory_scope_all_svm_devices);
++            if (dp == hp)
++                break;
++            __builtin_amdgcn_s_sleep(1);
+         }
+-        ready_flag = __builtin_amdgcn_readfirstlane(ready_flag);
+-        if (ready_flag == 0)
+-            break;
+-        __builtin_amdgcn_s_sleep(1);
+     }
+ 
+     __global ulong *ptr = (__global ulong *)(payload->slots + me);
+-    ulong value0 = *ptr++;
+-    ulong value1 = *ptr;
+-
+-    long2 retval = {value0, value1};
++    long2 retval = { ptr[0], ptr[1] };
+     return retval;
+ }
+ 
+@@ -263,18 +175,12 @@ get_return_value(__global header_t *header, __global payload_t *payload,
+  *  must be uniform, but the parameters are different for each
+  *  workitem. Parameters from all active lanes are written into a
+  *  hostcall packet. The hostcall blocks until the host processes the
+- *  request, and returns the response it receiveds.
+- *
+- *  TODO: This function and everything above it should eventually move
+- *  to a separate library that is loaded by the language runtime. The
+- *  function itself will be exposed as an orindary function symbol to
+- *  be linked into kernel objects that are loaded after this library.
++ *  request, and returns the response it receives.
+  *
+  *  *** INTERNAL USE ONLY ***
+  *  Internal function, not safe for direct use in user
+  *  code. Application kernels must only use __ockl_hostcall_preview()
+  *  defined elsewhere.
+- *
+  */
+ long2
+ __ockl_hostcall_internal(void *_buffer, uint service_id, ulong arg0, ulong arg1,
+@@ -285,15 +191,21 @@ __ockl_hostcall_internal(void *_buffer, uint service_id, ulong arg0, ulong arg1,
+     uint low = __builtin_amdgcn_readfirstlane(me);
+ 
+     __global buffer_t *buffer = (__global buffer_t *)_buffer;
+-    ulong packet_ptr = pop_free_stack(buffer, me, low);
+-    __global header_t *header = get_header(buffer, packet_ptr);
+-    __global payload_t *payload = get_payload(buffer, packet_ptr);
+ 
+-    fill_packet(header, payload, service_id, arg0, arg1, arg2, arg3, arg4, arg5,
+-                arg6, arg7, me, low);
+-    push_ready_stack(buffer, packet_ptr, me, low);
++    uint i = open_packet(buffer, me, low);
++
++    __global header_t *header = &buffer->headers[i];
++    __global payload_t *payload = &buffer->payloads[i];
++
++    fill_packet(header, payload, service_id,
++                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,
++                me, low);
++
++    send_to_host(buffer, i, me, low);
++
++    long2 retval = receive_from_host(buffer, i, payload, me, low);
++
++    unclaim(buffer->occupied, i, me, low);
+ 
+-    long2 retval = get_return_value(header, payload, me, low);
+-    return_free_packet(buffer, packet_ptr, me, low);
+     return retval;
+ }
+-- 
+2.51.0
+

--- a/patches/amd-mainline/rocm-systems/0001-Optimize-hostcall-performance.patch
+++ b/patches/amd-mainline/rocm-systems/0001-Optimize-hostcall-performance.patch
@@ -1,0 +1,689 @@
+From 9f36b7a9d9082b7f16f77f5de0719d517e295d77 Mon Sep 17 00:00:00 2001
+From: Brian Sumner <brian.sumner@amd.com>
+Date: Wed, 6 May 2026 10:40:36 -0700
+Subject: [PATCH] Optimize hostcall implementation
+
+---
+ projects/clr/rocclr/device/devhostcall.cpp    | 257 ++++++++++--------
+ projects/clr/rocclr/device/devhostcall.hpp    |  92 ++++---
+ projects/clr/rocclr/device/pal/palvirtual.cpp |  41 ++-
+ .../clr/rocclr/device/rocm/rocvirtual.cpp     |  42 ++-
+ 4 files changed, 273 insertions(+), 159 deletions(-)
+
+diff --git a/projects/clr/rocclr/device/devhostcall.cpp b/projects/clr/rocclr/device/devhostcall.cpp
+index 4e2a1163db..30100f84ec 100644
+--- a/projects/clr/rocclr/device/devhostcall.cpp
++++ b/projects/clr/rocclr/device/devhostcall.cpp
+@@ -20,6 +20,7 @@
+ 
+ #include <assert.h>
+ #include <string.h>
++#include <new>
+ #include <set>
+ 
+ #if defined(__clang__)
+@@ -30,22 +31,6 @@
+ 
+ namespace amd {
+ 
+-PacketHeader* HostcallBuffer::getHeader(uint64_t ptr) const {
+-  return headers_ + (ptr & index_mask_);
+-}
+-
+-Payload* HostcallBuffer::getPayload(uint64_t ptr) const { return payloads_ + (ptr & index_mask_); }
+-
+-static uint32_t setControlField(uint32_t control, uint8_t offset, uint8_t width, uint32_t value) {
+-  uint32_t mask = ~(((1 << width) - 1) << offset);
+-  control &= mask;
+-  return control | (value << offset);
+-}
+-
+-static uint32_t resetReadyFlag(uint32_t control) {
+-  return setControlField(control, CONTROL_OFFSET_READY_FLAG, CONTROL_WIDTH_READY_FLAG, 0);
+-}
+-
+ /** \brief Signature for pointer accepted by the function call service.
+  *  \param output Pointer to output arguments.
+  *  \param input Pointer to input arguments.
+@@ -94,9 +79,15 @@ static void handlePayload(MessageHandler& messages, uint32_t service, uint64_t*
+         if (buf) {
+           if (buf->create()) {
+             device::Memory* dm = buf->getDeviceMemory(dev);
+-            va = dm->virtualAddress();
+-            amd::MemObjMap::AddMemObj(reinterpret_cast<void*>(va), buf);
+-            const_cast<amd::Device*>(&dev)->TrackHostcallMemory(buf);
++            if (dm != nullptr) {
++              va = dm->virtualAddress();
++            }
++            if (va != 0) {
++              amd::MemObjMap::AddMemObj(reinterpret_cast<void*>(va), buf);
++              const_cast<amd::Device*>(&dev)->TrackHostcallMemory(buf);
++            } else {
++              buf->release();
++            }
+           } else {
+             buf->release();
+           }
+@@ -111,28 +102,85 @@ static void handlePayload(MessageHandler& messages, uint32_t service, uint64_t*
+   }
+ }
+ 
+-void HostcallBuffer::processPackets(MessageHandler& messages) {
+-  // Grab the entire ready stack and set the top to 0. New requests from the
+-  // device will continue pushing on the stack while we process the packets that
+-  // we have grabbed.
+-
+-  uint64_t ready_stack = std::atomic_exchange_explicit(&ready_stack_, static_cast<uint64_t>(0),
+-                                                       std::memory_order_acquire);
+-  if (!ready_stack) {
+-    return;
++static uintptr_t getDevicePhaseOffset() {
++  return amd::alignUp(sizeof(HostcallBuffer), alignof(uint32_t));
++}
++
++static uintptr_t getHostPhaseOffset(uint32_t num_packets) {
++  return amd::alignUp(getDevicePhaseOffset() + num_packets * sizeof(uint32_t), alignof(uint32_t));
++}
++
++static uintptr_t getHeaderOffset(uint32_t num_packets) {
++  return amd::alignUp(getHostPhaseOffset(num_packets) + num_packets * sizeof(uint32_t),
++                      alignof(PacketHeader));
++}
++
++static uintptr_t getPayloadOffset(uint32_t num_packets) {
++  return amd::alignUp(getHeaderOffset(num_packets) + num_packets * sizeof(PacketHeader),
++                      alignof(Payload));
++}
++
++size_t getHostcallBufferSize(uint32_t num_packets) {
++  return getPayloadOffset(num_packets) + num_packets * sizeof(Payload);
++}
++
++uint32_t getHostcallBufferAlignment() { return alignof(Payload); }
++
++bool HostcallBuffer::initialize(uint32_t num_packets, amd::Memory* occupied_mem) {
++  if (occupied_mem == nullptr || device_ == nullptr) {
++    return false;
++  }
++
++  device::Memory* dm = occupied_mem->getDeviceMemory(*device_);
++  if (dm == nullptr || dm->virtualAddress() == 0) {
++    return false;
++  }
++
++  auto base = reinterpret_cast<uint8_t*>(this);
++  device_phase_ = reinterpret_cast<std::atomic<uint32_t>*>(base + getDevicePhaseOffset());
++  host_phase_ = reinterpret_cast<std::atomic<uint32_t>*>(base + getHostPhaseOffset(num_packets));
++  occupied_ = reinterpret_cast<uint32_t*>(dm->virtualAddress());
++  headers_ = reinterpret_cast<PacketHeader*>(base + getHeaderOffset(num_packets));
++  payloads_ = reinterpret_cast<Payload*>(base + getPayloadOffset(num_packets));
++  doorbell_ = nullptr;
++  num_packets_ = num_packets;
++  occupied_mem_ = occupied_mem;
++  scan_limit_ = num_packets;
++
++  for (uint32_t i = 0; i < num_packets; ++i) {
++    new (&device_phase_[i]) std::atomic<uint32_t>(0);
++    new (&host_phase_[i]) std::atomic<uint32_t>(0);
++  }
++  return true;
++}
++
++bool HostcallBuffer::hasWorkPending() const {
++  for (uint32_t i = 0; i < scan_limit_; ++i) {
++    uint32_t dp = device_phase_[i].load(std::memory_order_relaxed);
++    uint32_t hp = host_phase_[i].load(std::memory_order_relaxed);
++    if (dp != hp) {
++      return true;
++    }
+   }
++  return false;
++}
++
++void HostcallBuffer::processPackets(MessageHandler& messages) {
++  uint32_t new_limit = 0;
++  for (uint32_t i = 0; i < scan_limit_; ++i) {
++    uint32_t dp = device_phase_[i].load(std::memory_order_relaxed);
++    uint32_t hp = host_phase_[i].load(std::memory_order_relaxed);
+ 
+-  // Each wave can submit at most one packet at a time. The ready stack cannot
+-  // contain multiple packets from the same wave, so consuming ready packets in
+-  // a latest-first order does not affect ordering of hostcall within a wave.
+-  for (decltype(ready_stack) iter = ready_stack, next = 0; iter; iter = next) {
+-    auto header = getHeader(iter);
+-    // Remember the next packet pointer, because we will no longer own the
+-    // current packet at the end of this loop.
+-    next = header->next_;
++    if (dp == hp) {
++      continue;
++    }
++
++    new_limit = i + 1;
++    std::atomic_thread_fence(std::memory_order_acquire);
+ 
++    auto* header = &headers_[i];
++    auto* payload = &payloads_[i];
+     auto service = header->service_;
+-    auto payload = getPayload(iter);
+     auto activemask = header->activemask_;
+ 
+ #if defined(__clang__)
+@@ -151,59 +199,13 @@ void HostcallBuffer::processPackets(MessageHandler& messages) {
+       handlePayload(messages, service, slot, *device_);
+     }
+ 
+-    header->control_.store(resetReadyFlag(header->control_), std::memory_order_release);
+-  }
+-}
+-
+-static uintptr_t getHeaderStart() {
+-  return amd::alignUp(sizeof(HostcallBuffer), alignof(PacketHeader));
+-}
+-
+-static uintptr_t getPayloadStart(uint32_t num_packets) {
+-  auto header_start = getHeaderStart();
+-  auto header_end = header_start + sizeof(PacketHeader) * num_packets;
+-  return amd::alignUp(header_end, alignof(Payload));
+-}
+-
+-size_t getHostcallBufferSize(uint32_t num_packets) {
+-  size_t buffer_size = getPayloadStart(num_packets);
+-  buffer_size += num_packets * sizeof(Payload);
+-  return buffer_size;
+-}
+-
+-uint32_t getHostcallBufferAlignment() { return alignof(Payload); }
+-
+-static uint64_t getIndexMask(uint32_t num_packets) {
+-  // The number of packets is at least equal to the maximum number of waves
+-  // supported by the device. That means we do not need to account for the
+-  // border cases where num_packets is zero or one.
+-  assert(num_packets > 1);
+-  if (!amd::isPowerOfTwo(num_packets)) {
+-    num_packets = amd::nextPowerOfTwo(num_packets);
++    std::atomic_thread_fence(std::memory_order_release);
++    host_phase_[i].store(hp ^ 1, std::memory_order_relaxed);
+   }
+-  return num_packets - 1;
+-}
+ 
+-void HostcallBuffer::initialize(uint32_t num_packets) {
+-  auto base = reinterpret_cast<uint8_t*>(this);
+-  headers_ = reinterpret_cast<PacketHeader*>((base + getHeaderStart()));
+-  payloads_ = reinterpret_cast<Payload*>((base + getPayloadStart(num_packets)));
+-  index_mask_ = getIndexMask(num_packets);
+-
+-  // The null pointer is identical to (uint64_t)0. When using tagged pointers,
+-  // the tag and the index part of the array must never be zero at the same
+-  // time. In the initialized free stack, headers[1].next points to headers[0],
+-  // which has index 0. We initialize this pointer to have a tag of 1.
+-  uint64_t next = index_mask_ + 1;
+-
+-  // Initialize the free stack.
+-  headers_[0].next_ = 0;
+-  for (uint32_t ii = 1; ii != num_packets; ++ii) {
+-    headers_[ii].next_ = next;
+-    next = ii;
++  if (new_limit > 0) {
++    scan_limit_ = new_limit;
+   }
+-  free_stack_ = next;
+-  ready_stack_ = 0;
+ }
+ 
+ /** \brief Manage a unique listener thread and its associated buffers.
+@@ -261,8 +263,8 @@ class HostcallListener {
+ 
+ HostcallListener* hostcallListener = nullptr;
+ extern amd::Monitor listenerLock;
+-constexpr static uint64_t kTimeoutFloor = K * K * 4;
+-constexpr static uint64_t kTimeoutCeil = K * K * 16;
++constexpr static uint32_t kSpinIterations = 1024;
++constexpr static uint64_t kSignalTimeout = K * K;
+ static struct Init {
+   enum class State { kDefault = 0, kInit, kDestroy, kExit };
+   volatile State state = State::kDefault;
+@@ -278,42 +280,45 @@ static struct Init {
+   }
+ } kHostThreadActive;
+ void HostcallListener::consumePackets() {
+-  uint64_t timeout = kTimeoutFloor;
+   uint64_t signal_value = SIGNAL_INIT;
+   kHostThreadActive.state = Init::State::kInit;
+   while (true) {
+-    while (true) {
++    if (kHostThreadActive.state == Init::State::kDestroy) {
++      kHostThreadActive.state = Init::State::kExit;
++      return;
++    }
++
++    for (uint32_t spin = 0; spin < kSpinIterations; ++spin) {
+       if (kHostThreadActive.state == Init::State::kDestroy) {
+         kHostThreadActive.state = Init::State::kExit;
+         return;
+       }
+-      uint64_t new_value = doorbell_->Wait(signal_value, device::Signal::Condition::Ne, timeout);
+-      if (new_value != signal_value) {
+-        signal_value = new_value;
+-        // Reduce the timeout for quicker processing
+-        timeout = timeout >> 0x1;
+-        timeout = std::max(kTimeoutFloor, timeout);
+-        break;
+-      }
+-      // Increase the timeout since we dont need to check as frequently
+-      timeout = timeout << 0x1;
+-      timeout = std::min(kTimeoutCeil, timeout);
+-    }
+ 
+-    if (signal_value == SIGNAL_DONE) {
+-      return;
++      amd::ScopedLock lock{listenerLock};
++      for (auto buf : buffers_) {
++        buf->processPackets(messages_);
++      }
+     }
+ 
+-    if (!idle()) {
++    {
+       amd::ScopedLock lock{listenerLock};
+-
+-      for (auto ii : buffers_) {
+-        ii->processPackets(messages_);
++      for (auto buf : buffers_) {
++        buf->resetScanLimit();
++      }
++      for (auto buf : buffers_) {
++        buf->processPackets(messages_);
+       }
+     }
+-  }
+ 
+-  return;
++    uint64_t new_value =
++        doorbell_->Wait(signal_value, device::Signal::Condition::Ne, kSignalTimeout);
++    if (new_value != signal_value) {
++      signal_value = new_value;
++    }
++    if (signal_value == SIGNAL_DONE) {
++      return;
++    }
++  }
+ }
+ 
+ void HostcallListener::terminate() {
+@@ -354,7 +359,12 @@ void HostcallListener::removeBuffer(HostcallBuffer* buffer) {
+ 
+ bool HostcallListener::initSignal(const amd::Device& dev) {
+   doorbell_ = dev.createSignal();
+-  initDevice(dev);
++  if (doorbell_ == nullptr || !initDevice(dev)) {
++    delete doorbell_;
++    doorbell_ = nullptr;
++    devices_.clear();
++    return false;
++  }
+ #if defined(__clang__)
+ #if __has_feature(address_sanitizer)
+   urilocator = dev.createUriLocator();
+@@ -364,10 +374,12 @@ bool HostcallListener::initSignal(const amd::Device& dev) {
+   // everything up and bail out.
+   if (thread_.state() < Thread::INITIALIZED) {
+     delete doorbell_;
++    doorbell_ = nullptr;
+     devices_.clear();
+ #if defined(__clang__)
+ #if __has_feature(address_sanitizer)
+     delete urilocator;
++    urilocator = nullptr;
+ #endif
+ #endif
+     return false;
+@@ -393,14 +405,24 @@ bool HostcallListener::initDevice(const amd::Device& dev) {
+   return true;
+ }
+ 
+-bool enableHostcalls(const amd::Device& dev, void* bfr, uint32_t numPackets) {
++bool enableHostcalls(const amd::Device& dev, void* bfr, uint32_t numPackets,
++                     amd::Memory* occupiedMem) {
+   auto buffer = reinterpret_cast<HostcallBuffer*>(bfr);
+-  buffer->initialize(numPackets);
+   buffer->setDevice(&dev);
++  if (!buffer->initialize(numPackets, occupiedMem)) {
++    ClPrint(amd::LOG_ERROR, (amd::LOG_INIT | amd::LOG_QUEUE | amd::LOG_RESOURCE),
++            "Failed to initialize hostcall buffer");
++    return false;
++  }
+ 
+   amd::ScopedLock lock(listenerLock);
+   if (!hostcallListener) {
+     hostcallListener = new HostcallListener();
++    if (!hostcallListener) {
++      ClPrint(amd::LOG_ERROR, (amd::LOG_INIT | amd::LOG_QUEUE | amd::LOG_RESOURCE),
++              "Failed to allocate hostcall listener");
++      return false;
++    }
+     if (!hostcallListener->initSignal(dev)) {
+       ClPrint(amd::LOG_ERROR, (amd::LOG_INIT | amd::LOG_QUEUE | amd::LOG_RESOURCE),
+               "Failed to launch hostcall listener");
+@@ -428,15 +450,18 @@ bool enableHostcalls(const amd::Device& dev, void* bfr, uint32_t numPackets) {
+ }
+ 
+ void disableHostcalls(void* bfr) {
++  assert(bfr && "expected a hostcall buffer");
++  auto buffer = reinterpret_cast<HostcallBuffer*>(bfr);
+   {
+     amd::ScopedLock lock(listenerLock);
+     if (!hostcallListener) {
++      buffer->getOccupiedMem()->release();
+       return;
+     }
+-    assert(bfr && "expected a hostcall buffer");
+-    auto buffer = reinterpret_cast<HostcallBuffer*>(bfr);
+     hostcallListener->removeBuffer(buffer);
+   }
++  buffer->getOccupiedMem()->release();
++
+   if (hostcallListener->idle()) {
+     hostcallListener->terminate();
+     delete hostcallListener;
+diff --git a/projects/clr/rocclr/device/devhostcall.hpp b/projects/clr/rocclr/device/devhostcall.hpp
+index 55c5c1d27d..4603b64dd2 100644
+--- a/projects/clr/rocclr/device/devhostcall.hpp
++++ b/projects/clr/rocclr/device/devhostcall.hpp
+@@ -9,6 +9,7 @@
+ #include "top.hpp"
+ #include "device/device.hpp"
+ #include "device/devhcmessages.hpp"
++#include <atomic>
+ #include <cstddef>
+ 
+ #if defined(__clang__)
+@@ -25,7 +26,7 @@ namespace amd {
+  *  on the device, for some predefined service provided by the
+  *  host. The life-cycle of a hostcall is as follows:
+  *
+- *  1. A workitem in the some kernel dispatch submits a request as a
++ *  1. A workitem in some kernel dispatch submits a request as a
+  *     "packet" in a "hostcall buffer". The workitem blocks until it
+  *     receives a response from the host.
+  *
+@@ -58,6 +59,16 @@ namespace amd {
+  *  buffers created in the application. The client may also launch
+  *  multiple listeners, as long the same hostcall buffer is not
+  *  registered with multiple listeners.
++ *
++ *  Packet ownership is determined by two per-packet phase arrays:
++ *  - device_phase[i]: toggled by the device when submitting work.
++ *  - host_phase[i]:   toggled by the host when completing work.
++ *  When both phases match, the device owns the packet. When they differ,
++ *  the host owns it.
++ *
++ *  A separate occupied bitfield in device-local memory tracks which packets
++ *  are currently claimed by a wave. This prevents multiple waves from using
++ *  the same packet.
+  */
+ 
+ /** \brief Determine the buffer size to be allocated
+@@ -71,7 +82,8 @@ size_t getHostcallBufferSize(uint32_t num_packets);
+  */
+ uint32_t getHostcallBufferAlignment(void);
+ 
+-bool enableHostcalls(const amd::Device& dev, void* buffer, uint32_t numPackets);
++bool enableHostcalls(const amd::Device& dev, void* buffer, uint32_t numPackets,
++                     amd::Memory* occupiedMem);
+ void disableHostcalls(void* buffer);
+ 
+ enum SignalValue { SIGNAL_DONE = 0, SIGNAL_INIT = 1 };
+@@ -80,7 +92,7 @@ enum SignalValue { SIGNAL_DONE = 0, SIGNAL_INIT = 1 };
+  *
+  *  Contains 64 slots of 8 ulongs each, one for each workitem in the
+  *  wave. A slot with index \c i contains valid data if the
+- *  corresponding bit in PacketHeader::activemask is set.
++ *  corresponding bit in PacketHeader::activemask_ is set.
+  */
+ struct Payload {
+   uint64_t slots[64][8];
+@@ -88,69 +100,63 @@ struct Payload {
+ 
+ /** Packet header */
+ struct PacketHeader {
+-  /** Tagged pointer to the next packet in an intrusive stack */
+-  uint64_t next_;
+   /** Bitmask that represents payload slots with valid data */
+   uint64_t activemask_;
+   /** Service ID requested by the wave */
+   uint32_t service_;
+-  /** Control bits.
+-   *  \li 0: \c READY flag. Indicates packet awaiting a host response.
+-   */
+-  std::atomic<uint32_t> control_;
+ };
+ 
+ static_assert(std::is_standard_layout<PacketHeader>::value,
+               "the hostcall packet must be useable from other languages");
+ 
+-/** Field offsets in the packet control field */
+-enum ControlOffset {
+-  CONTROL_OFFSET_READY_FLAG = 0,
+-  CONTROL_OFFSET_RESERVED0 = 1,
+-};
+-
+-/** Field widths in the packet control field */
+-enum ControlWidth {
+-  CONTROL_WIDTH_READY_FLAG = 1,
+-  CONTROL_WIDTH_RESERVED0 = 31,
+-};
+-
+-/** \brief Shared buffer submitting hostcall requests.
++/** \brief Shared buffer for submitting hostcall requests.
+  *
+  *  Holds hostcall packets requested by all kernels executing on the
+  *  same device queue. Each hostcall buffer is associated with at most
+  *  one device queue.
+  *
+- *  Packets in the buffer are accessed using 64-bit tagged pointers to mitigate
+- *  the ABA problem in lock-free stacks. The index_mask is used to extract the
+- *  lower bits of the pointer, which form the index into the packet array. The
+- *  remaining higher bits define a tag that is incremented on every pop from a
+- *  stack.
++ *  Packet ownership is determined by comparing per-packet phase values. The
++ *  device_phase array is written only by the device; the host_phase array is
++ *  written only by the host. When both match, the device owns the packet. When
++ *  they differ, the host owns it.
++ *
++ *  The occupied bitfield lives in device-local memory and tracks which packets
++ *  are currently in use by a wave. It is referenced by device virtual address
++ *  from this struct.
+  */
+ class HostcallBuffer {
++  // Shared prefix: must match the device-side hostcall buffer layout.
++  /** Per-packet phase toggled by the device on submission */
++  std::atomic<uint32_t>* device_phase_;
++  /** Per-packet phase toggled by the host on completion */
++  std::atomic<uint32_t>* host_phase_;
++  /** Device virtual address of the occupied bitfield */
++  uint32_t* occupied_;
+   /** Array of packet headers */
+   PacketHeader* headers_;
+   /** Array of packet payloads */
+   Payload* payloads_;
+   /** Signal used by kernels to indicate new work */
+   void* doorbell_;
+-  /** Stack of free packets. Uses tagged pointers. */
+-  uint64_t free_stack_;
+-  /** Stack of ready packets. Uses tagged pointers */
+-  std::atomic<uint64_t> ready_stack_;
+-  /** Mask for accessing the packet index in the tagged pointer. */
+-  uint64_t index_mask_;
+-  /** Some services need a device**/
+-  const amd::Device* device_;
++  /** Number of packets in the buffer */
++  uint32_t num_packets_;
+ 
+-  PacketHeader* getHeader(uint64_t ptr) const;
+-  Payload* getPayload(uint64_t ptr) const;
++  // Host-only fields.
++  /** Some services need a device */
++  const amd::Device* device_;
++  /** Owner of the device-local occupied allocation */
++  amd::Memory* occupied_mem_;
++  /** Adaptive upper bound on packets to scan */
++  uint32_t scan_limit_;
+ 
+  public:
+   void processPackets(MessageHandler& messages);
+-  void initialize(uint32_t num_packets);
+-  void setDoorbell(void* doorbell) { doorbell_ = doorbell; };
+-  void setDevice(const amd::Device* dptr) { device_ = dptr; };
++  bool initialize(uint32_t num_packets, amd::Memory* occupied_mem);
++  bool hasWorkPending() const;
++  void resetScanLimit() { scan_limit_ = num_packets_; }
++  void setDoorbell(void* doorbell) { doorbell_ = doorbell; }
++  void setDevice(const amd::Device* dptr) { device_ = dptr; }
++  amd::Memory* getOccupiedMem() const { return occupied_mem_; }
+ 
+ #if defined(__clang__)
+ #if __has_feature(address_sanitizer)
+@@ -158,7 +164,7 @@ class HostcallBuffer {
+   device::UriLocator* uri_locator;
+ 
+  public:
+-  void setUriLocator(device::UriLocator* uri_l) { uri_locator = uri_l; };
++  void setUriLocator(device::UriLocator* uri_l) { uri_locator = uri_l; }
+ #endif
+ #endif
+ };
+@@ -166,4 +172,8 @@ class HostcallBuffer {
+ static_assert(std::is_standard_layout<HostcallBuffer>::value,
+               "the hostcall buffer must be useable from other languages");
+ 
++static_assert(sizeof(std::atomic<uint32_t>) == sizeof(uint32_t) &&
++                  alignof(std::atomic<uint32_t>) == alignof(uint32_t),
++              "std::atomic<uint32_t> must have the same size and alignment as uint32_t");
++
+ }  // namespace amd
+\ No newline at end of file
+diff --git a/projects/clr/rocclr/device/pal/palvirtual.cpp b/projects/clr/rocclr/device/pal/palvirtual.cpp
+index 3a2d09cd9d..d0653d66cd 100644
+--- a/projects/clr/rocclr/device/pal/palvirtual.cpp
++++ b/projects/clr/rocclr/device/pal/palvirtual.cpp
+@@ -3934,14 +3934,53 @@ void* VirtualGPU::getOrCreateHostcallBuffer() {
+     return nullptr;
+   }
+ 
++  uint32_t occupiedWords = (numPackets + 31) / 32;
++  size_t occupiedSize = occupiedWords * sizeof(uint32_t);
++  amd::Buffer* occupiedBuf =
++      new (dev().context()) amd::Buffer(dev().context(), CL_MEM_READ_WRITE, occupiedSize, nullptr);
++  if (occupiedBuf == nullptr || !occupiedBuf->create()) {
++    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE,
++            "Failed to allocate occupied bitfield for hostcall buffer");
++    if (occupiedBuf != nullptr) {
++      occupiedBuf->release();
++    }
++    dev().svmFree(hostcallBuffer_);
++    hostcallBuffer_ = nullptr;
++    return nullptr;
++  }
++
++  device::Memory* occupiedMem = occupiedBuf->getDeviceMemory(dev());
++  if (occupiedMem == nullptr || occupiedMem->virtualAddress() == 0) {
++    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE,
++            "Failed to get device memory for hostcall occupied bitfield");
++    occupiedBuf->release();
++    dev().svmFree(hostcallBuffer_);
++    hostcallBuffer_ = nullptr;
++    return nullptr;
++  }
++
++  uint32_t zero = 0;
++  if (!blitMgr().fillBuffer(*occupiedMem, &zero, sizeof(zero), amd::Coord3D(occupiedSize, 1, 1),
++                            amd::Coord3D(0, 0, 0), amd::Coord3D(occupiedSize, 1, 1), true)) {
++    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE,
++            "Failed to zero-initialize hostcall occupied bitfield");
++    occupiedBuf->release();
++    dev().svmFree(hostcallBuffer_);
++    hostcallBuffer_ = nullptr;
++    return nullptr;
++  }
++
+   ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+           "Created hostcall buffer %p (numPackets == %d, size == %d, align == %d) for virtual "
+           "queue %p\n",
+           hostcallBuffer_, numPackets, size, align, this);
+ 
+-  if (!amd::enableHostcalls(dev(), hostcallBuffer_, numPackets)) {
++  if (!amd::enableHostcalls(dev(), hostcallBuffer_, numPackets, occupiedBuf)) {
+     ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "Failed to register hostcall buffer %p with listener",
+             hostcallBuffer_);
++    occupiedBuf->release();
++    dev().svmFree(hostcallBuffer_);
++    hostcallBuffer_ = nullptr;
+     return nullptr;
+   }
+   return hostcallBuffer_;
+diff --git a/projects/clr/rocclr/device/rocm/rocvirtual.cpp b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+index f4ac11450c..b34d17be49 100644
+--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
++++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+@@ -4638,16 +4638,56 @@ void *VirtualGPU::getOrCreateHostcallBuffer() {
+   }
+   hostcallBufferSize_ = size;
+ 
++  uint32_t occupiedWords = (numPackets + 31) / 32;
++  size_t occupiedSize = occupiedWords * sizeof(uint32_t);
++  amd::Buffer* occupiedBuf =
++      new (dev().context()) amd::Buffer(dev().context(), CL_MEM_READ_WRITE, occupiedSize, nullptr);
++  if (occupiedBuf == nullptr || !occupiedBuf->create()) {
++    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE,
++            "Failed to allocate occupied bitfield for hostcall buffer");
++    if (occupiedBuf != nullptr) {
++      occupiedBuf->release();
++    }
++    dev().hostFree(hostcallBuffer_, hostcallBufferSize_);
++    hostcallBuffer_ = nullptr;
++    hostcallBufferSize_ = 0;
++    return nullptr;
++  }
++
++  device::Memory* occupiedMem = occupiedBuf->getDeviceMemory(dev());
++  if (occupiedMem == nullptr || occupiedMem->virtualAddress() == 0) {
++    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE,
++            "Failed to get device memory for hostcall occupied bitfield");
++    occupiedBuf->release();
++    dev().hostFree(hostcallBuffer_, hostcallBufferSize_);
++    hostcallBuffer_ = nullptr;
++    hostcallBufferSize_ = 0;
++    return nullptr;
++  }
++
++  uint32_t zero = 0;
++  if (!blitMgr().fillBuffer(*occupiedMem, &zero, sizeof(zero), amd::Coord3D(occupiedSize, 1, 1),
++                            amd::Coord3D(0, 0, 0), amd::Coord3D(occupiedSize, 1, 1), true)) {
++    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE,
++            "Failed to zero-initialize hostcall occupied bitfield");
++    occupiedBuf->release();
++    dev().hostFree(hostcallBuffer_, hostcallBufferSize_);
++    hostcallBuffer_ = nullptr;
++    hostcallBufferSize_ = 0;
++    return nullptr;
++  }
++
+   ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+           "Created hostcall buffer %p (numPackets == %d, size == %d, align == "
+           "%d) for virtual "
+           "queue %p\n",
+           hostcallBuffer_, numPackets, size, align, this);
+ 
+-  if (!amd::enableHostcalls(dev(), hostcallBuffer_, numPackets)) {
++  if (!amd::enableHostcalls(dev(), hostcallBuffer_, numPackets, occupiedBuf)) {
+     ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE,
+             "Failed to register hostcall buffer %p with listener",
+             hostcallBuffer_);
++    occupiedBuf->release();
+     dev().hostFree(hostcallBuffer_, hostcallBufferSize_);
+     hostcallBuffer_ = nullptr;
+     hostcallBufferSize_ = 0;
+-- 
+2.51.0
+


### PR DESCRIPTION
## Summary
- Adds temporary patches for both llvm-project (device-libs) and rocm-systems (CLR) to validate a coordinated hostcall protocol change in TheRock CI
- The change replaces the lock-free stack with a phase-toggle scanning approach for improved performance under high contention
- Device-side and host-side must land atomically — buffer layout and sync protocol are incompatible between old and new
- These patches should be removed when both submodules are bumped to include the upstream changes

Component PRs:
- ROCm/llvm-project#2115
- ROCm/rocm-systems#5824