### PR TITLE
Build RCCL as a single generic artifact

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -122,23 +122,21 @@ jobs:
       id-token: write
 
   # ==========================================================================
-  # STAGE: comm-libs (per-arch, parallel to math-libs)
+  # STAGE: comm-libs (generic, single job parallel to math-libs)
+  # RCCL and rocshmem are both TARGET_NEUTRAL artifacts. RCCL is built for
+  # Instinct/CDNA targets only (https://github.com/ROCm/TheRock/issues/2130).
+  # Running as a single generic job avoids redundant per-arch builds.
   # ==========================================================================
   comm-libs:
     needs: compiler-runtime
     if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'comm-libs') }}
-    strategy:
-      # See comment on math-libs fail-fast above.
-      fail-fast: false
-      matrix:
-        family_info: ${{ fromJSON(inputs.matrix_per_family_json) }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
       stage_name: comm-libs
-      stage_display_name: "Stage - Comm Libs (${{ matrix.family_info.amdgpu_family }})"
+      stage_display_name: "Stage - Comm Libs"
       timeout_minutes: 240  # 4 hours
-      amdgpu_family: ${{ matrix.family_info.amdgpu_family }}
+      amdgpu_family: ""
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}

--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -153,9 +153,9 @@ artifact_groups = ["math-libs", "ml-libs"]
 type = "per-arch"
 
 [build_stages.comm-libs]
-description = "Communication libraries per architecture (can run parallel to math-libs)"
+description = "Communication libraries (generic, single job parallel to math-libs)"
 artifact_groups = ["comm-libs"]
-type = "per-arch"
+type = "generic"
 
 [build_stages.debug-tools]
 description = "ROCm debug tools"
@@ -268,7 +268,7 @@ source_sets = ["rocm-libraries", "ml-frameworks"]
 
 [artifact_groups.comm-libs]
 description = "Communication libraries"
-type = "per-arch"
+type = "generic"
 artifact_group_deps = ["hip-runtime"]
 # TODO: rocm-systems included for projects/hip/VERSION (see CMakeLists.txt)
 source_sets = ["comm-libs", "rocm-systems"]

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -325,7 +325,6 @@ def device_artifact_filter(target: str, an: ArtifactName) -> bool:
             "miopenprovider",
             "hipblasltprovider",
             "rand",
-            "rccl",
         ]
         and an.component == "lib"
         and an.target_family == target

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -52,7 +52,7 @@ therock_add_amdgpu_target(gfx900 "Vega 10 / MI25" FAMILY dgpu-all gfx900-dgpu
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 
@@ -64,7 +64,7 @@ therock_add_amdgpu_target(gfx90c "AMD Renoir/Lucienne/Cezanne iGPU" FAMILY igpu-
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 
@@ -104,7 +104,7 @@ therock_add_amdgpu_target(gfx1010 "AMD RX 5700" FAMILY dgpu-all gfx101X-all gfx1
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 therock_add_amdgpu_target(gfx1011 "AMD Radeon Pro V520" FAMILY dgpu-all gfx101X-all gfx101X-dgpu
@@ -114,7 +114,7 @@ therock_add_amdgpu_target(gfx1011 "AMD Radeon Pro V520" FAMILY dgpu-all gfx101X-
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 
@@ -125,7 +125,7 @@ therock_add_amdgpu_target(gfx1012 "AMD RX 5500" FAMILY dgpu-all gfx101X-all gfx1
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 
@@ -136,7 +136,7 @@ therock_add_amdgpu_target(gfx1030 "AMD RX 6800 / XT" FAMILY dgpu-all gfx103X-all
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 therock_add_amdgpu_target(gfx1031 "AMD RX 6700 / XT" FAMILY dgpu-all gfx103X-all gfx103X-dgpu
@@ -145,7 +145,7 @@ therock_add_amdgpu_target(gfx1031 "AMD RX 6700 / XT" FAMILY dgpu-all gfx103X-all
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 therock_add_amdgpu_target(gfx1032 "AMD RX 6600" FAMILY dgpu-all gfx103X-all gfx103X-dgpu
@@ -154,7 +154,7 @@ therock_add_amdgpu_target(gfx1032 "AMD RX 6600" FAMILY dgpu-all gfx103X-all gfx1
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 therock_add_amdgpu_target(gfx1033 "AMD Van Gogh iGPU" FAMILY igpu-all gfx103X-all gfx103X-igpu
@@ -164,7 +164,7 @@ therock_add_amdgpu_target(gfx1033 "AMD Van Gogh iGPU" FAMILY igpu-all gfx103X-al
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
     composable_kernel
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 therock_add_amdgpu_target(gfx1034 "AMD RX 6500 XT" FAMILY dgpu-all gfx103X-all gfx103X-dgpu
@@ -173,7 +173,7 @@ therock_add_amdgpu_target(gfx1034 "AMD RX 6500 XT" FAMILY dgpu-all gfx103X-all g
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 therock_add_amdgpu_target(gfx1035 "AMD Radeon 680M Laptop iGPU" FAMILY igpu-all gfx103X-all gfx103X-igpu
@@ -182,7 +182,7 @@ therock_add_amdgpu_target(gfx1035 "AMD Radeon 680M Laptop iGPU" FAMILY igpu-all 
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 therock_add_amdgpu_target(gfx1036 "AMD Raphael iGPU" FAMILY igpu-all gfx103X-all gfx103X-igpu
@@ -191,7 +191,7 @@ therock_add_amdgpu_target(gfx1036 "AMD Raphael iGPU" FAMILY igpu-all gfx103X-all
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 
@@ -200,21 +200,21 @@ therock_add_amdgpu_target(gfx1100 "AMD RX 7900 XTX" FAMILY dgpu-all gfx110X-all 
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 therock_add_amdgpu_target(gfx1101 "AMD RX 7800 XT" FAMILY dgpu-all gfx110X-all gfx110X-dgpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 therock_add_amdgpu_target(gfx1102 "AMD RX 7700S/Framework Laptop 16" FAMILY dgpu-all gfx110X-all gfx110X-dgpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all gfx110X-all gfx110X-igpu
@@ -260,14 +260,14 @@ therock_add_amdgpu_target(gfx1200 "AMD RX 9060 / XT" FAMILY dgpu-all gfx120X-all
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 therock_add_amdgpu_target(gfx1201 "AMD RX 9070 / XT" FAMILY dgpu-all gfx120X-all
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
     rccl-tests
 )
 

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -52,6 +52,8 @@ therock_add_amdgpu_target(gfx900 "Vega 10 / MI25" FAMILY dgpu-all gfx900-dgpu
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 
 # gfx90c
@@ -62,6 +64,8 @@ therock_add_amdgpu_target(gfx90c "AMD Renoir/Lucienne/Cezanne iGPU" FAMILY igpu-
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 
 # gfx906 (separate family - different instruction support from gfx908/gfx90a)
@@ -100,6 +104,8 @@ therock_add_amdgpu_target(gfx1010 "AMD RX 5700" FAMILY dgpu-all gfx101X-all gfx1
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 therock_add_amdgpu_target(gfx1011 "AMD Radeon Pro V520" FAMILY dgpu-all gfx101X-all gfx101X-dgpu
   EXCLUDE_TARGET_PROJECTS
@@ -108,6 +114,8 @@ therock_add_amdgpu_target(gfx1011 "AMD Radeon Pro V520" FAMILY dgpu-all gfx101X-
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 
 therock_add_amdgpu_target(gfx1012 "AMD RX 5500" FAMILY dgpu-all gfx101X-all gfx101X-dgpu
@@ -117,6 +125,8 @@ therock_add_amdgpu_target(gfx1012 "AMD RX 5500" FAMILY dgpu-all gfx101X-all gfx1
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 
 # gfx103X family
@@ -126,13 +136,17 @@ therock_add_amdgpu_target(gfx1030 "AMD RX 6800 / XT" FAMILY dgpu-all gfx103X-all
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 therock_add_amdgpu_target(gfx1031 "AMD RX 6700 / XT" FAMILY dgpu-all gfx103X-all gfx103X-dgpu
   EXCLUDE_TARGET_PROJECTS
-  hipBLASLt # https://github.com/ROCm/TheRock/issues/1062
-  hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
-  rocWMMA # https://github.com/ROCm/TheRock/issues/1944
-  rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    hipBLASLt # https://github.com/ROCm/TheRock/issues/1062
+    hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
+    rocWMMA # https://github.com/ROCm/TheRock/issues/1944
+    rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 therock_add_amdgpu_target(gfx1032 "AMD RX 6600" FAMILY dgpu-all gfx103X-all gfx103X-dgpu
   EXCLUDE_TARGET_PROJECTS
@@ -140,6 +154,8 @@ therock_add_amdgpu_target(gfx1032 "AMD RX 6600" FAMILY dgpu-all gfx103X-all gfx1
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 therock_add_amdgpu_target(gfx1033 "AMD Van Gogh iGPU" FAMILY igpu-all gfx103X-all gfx103X-igpu
   EXCLUDE_TARGET_PROJECTS
@@ -148,6 +164,8 @@ therock_add_amdgpu_target(gfx1033 "AMD Van Gogh iGPU" FAMILY igpu-all gfx103X-al
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
     composable_kernel
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 therock_add_amdgpu_target(gfx1034 "AMD RX 6500 XT" FAMILY dgpu-all gfx103X-all gfx103X-dgpu
   EXCLUDE_TARGET_PROJECTS
@@ -155,6 +173,8 @@ therock_add_amdgpu_target(gfx1034 "AMD RX 6500 XT" FAMILY dgpu-all gfx103X-all g
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 therock_add_amdgpu_target(gfx1035 "AMD Radeon 680M Laptop iGPU" FAMILY igpu-all gfx103X-all gfx103X-igpu
   EXCLUDE_TARGET_PROJECTS
@@ -162,6 +182,8 @@ therock_add_amdgpu_target(gfx1035 "AMD Radeon 680M Laptop iGPU" FAMILY igpu-all 
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 therock_add_amdgpu_target(gfx1036 "AMD Raphael iGPU" FAMILY igpu-all gfx103X-all gfx103X-igpu
   EXCLUDE_TARGET_PROJECTS
@@ -169,6 +191,8 @@ therock_add_amdgpu_target(gfx1036 "AMD Raphael iGPU" FAMILY igpu-all gfx103X-all
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 
 # gfx110X family
@@ -176,21 +200,28 @@ therock_add_amdgpu_target(gfx1100 "AMD RX 7900 XTX" FAMILY dgpu-all gfx110X-all 
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 therock_add_amdgpu_target(gfx1101 "AMD RX 7800 XT" FAMILY dgpu-all gfx110X-all gfx110X-dgpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 therock_add_amdgpu_target(gfx1102 "AMD RX 7700S/Framework Laptop 16" FAMILY dgpu-all gfx110X-all gfx110X-dgpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all gfx110X-all gfx110X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
-    rccl  # https://github.com/ROCm/TheRock/issues/150
+    rccl # https://github.com/ROCm/TheRock/issues/150
+    rccl-tests
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 
@@ -198,25 +229,29 @@ therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all 
 therock_add_amdgpu_target(gfx1150 "AMD Strix Point iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
-    rccl  # https://github.com/ROCm/TheRock/issues/150
+    rccl # https://github.com/ROCm/TheRock/issues/150
+    rccl-tests
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 therock_add_amdgpu_target(gfx1151 "AMD Strix Halo iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
-    rccl  # https://github.com/ROCm/TheRock/issues/150
+    rccl # https://github.com/ROCm/TheRock/issues/150
+    rccl-tests
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 therock_add_amdgpu_target(gfx1152 "AMD Krackan 1 iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
-    rccl  # https://github.com/ROCm/TheRock/issues/150
+    rccl # https://github.com/ROCm/TheRock/issues/150
+    rccl-tests
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 therock_add_amdgpu_target(gfx1153 "AMD Radeon 820M iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
-    rccl  # https://github.com/ROCm/TheRock/issues/150
+    rccl # https://github.com/ROCm/TheRock/issues/150
+    rccl-tests
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 
@@ -225,11 +260,15 @@ therock_add_amdgpu_target(gfx1200 "AMD RX 9060 / XT" FAMILY dgpu-all gfx120X-all
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 therock_add_amdgpu_target(gfx1201 "AMD RX 9070 / XT" FAMILY dgpu-all gfx120X-all
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+    rccl # https://github.com/ROCm/TheRock/issues/2130
+    rccl-tests
 )
 
 # Optional extension targets (used for out of tree target development).

--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -5,6 +5,7 @@ if(THEROCK_ENABLE_RCCL)
   # Most libraries need to depend on the profiler, but is conditionally only used
   # on Posix.
   set(optional_profiler_deps)
+
   if(THEROCK_FLAG_INCLUDE_PROFILER)
     list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
   endif()
@@ -27,6 +28,9 @@ if(THEROCK_ENABLE_RCCL)
   set(_rccl_subproject_names)
 
   therock_cmake_subproject_declare(rccl
+    # Build all GPU targets in a single target-neutral artifact as long as the
+    # host code isn't fully target agnostic.
+    USE_TEST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rccl"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rccl"
     # High latency LTO link of a single library.
@@ -71,6 +75,7 @@ if(THEROCK_ENABLE_RCCL)
     endif()
 
     therock_cmake_subproject_declare(rccl-tests
+      USE_TEST_AMDGPU_TARGETS
       EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rccl-tests"
       BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rccl-tests"
       BACKGROUND_BUILD
@@ -99,6 +104,7 @@ if(THEROCK_ENABLE_RCCL)
   endif(THEROCK_BUILD_TESTING)
 
   therock_provide_artifact(rccl
+    TARGET_NEUTRAL
     DESCRIPTOR artifact-rccl.toml
     COMPONENTS
       dbg


### PR DESCRIPTION
RCCL's host code isn't target agnostic thus we build it in a single generic multi-arch CI stage. For non-Instinct targets build or rather link time is huge thus we exclude building for those targets for now.

> [!IMPORTANT]
>  This disables rccl and rccl-tests for every non-Instinct target.

Technical details:

- EXCLUDE_TARGET_PROJECTS in therock_amdgpu_targets.cmake now lists rccl and rccl-tests for every non-Instinct target.
- comm-libs uses USE_TEST_AMDGPU_TARGETS so rccl sees all registered targets, then EXCLUDE_TARGET_PROJECTS filters to Instinct only. The artifact is always TARGET_NEUTRAL, making comm-libs a single generic job in both per-arch and multi-arch CI.
- rccl moves from device_artifact_filter to libraries_artifact_filter since in build_python_packages as it is now always a generic (non-per-ISA) artifact.
