### PR TITLE
Add missing entries to SUPPORTED_GPUS.md

### DIFF
--- a/SUPPORTED_GPUS.md
+++ b/SUPPORTED_GPUS.md
@@ -39,6 +39,12 @@ Note that some fully supported GPU architectures may show a more limited state o
 | **RDNA3**    | **gfx1102** | ✅            | ✅            |               |
 | **RDNA3**    | **gfx1101** | ✅            | ✅            |               |
 | **RDNA3**    | **gfx1100** | ✅            | ✅            |               |
+| RDNA2        | gfx1036     | ✅            |               |               |
+| RDNA2        | gfx1035     | ✅            |               |               |
+| RDNA2        | gfx1034     | ✅            |               |               |
+| RDNA2        | gfx1033     | ✅            |               |               |
+| RDNA2        | gfx1032     | ✅            |               |               |
+| RDNA2        | gfx1031     | ✅            |               |               |
 | RDNA2        | gfx1030     | ✅            | ✅            |               |
 | RDNA1        | gfx1012     | ✅            |               |               |
 | RDNA1        | gfx1011     | ✅            |               |               |
@@ -63,6 +69,12 @@ Check [windows_support.md](https://github.com/ROCm/TheRock/blob/main/docs/develo
 | **RDNA3**    | **gfx1102** | ✅            |               |               |
 | **RDNA3**    | **gfx1101** | ✅            |               |               |
 | **RDNA3**    | **gfx1100** | ✅            |               |               |
+| RDNA2        | gfx1036     | ✅            |               |               |
+| RDNA2        | gfx1035     | ✅            |               |               |
+| RDNA2        | gfx1034     | ✅            |               |               |
+| RDNA2        | gfx1033     | ✅            |               |               |
+| RDNA2        | gfx1032     | ✅            |               |               |
+| RDNA2        | gfx1031     | ✅            |               |               |
 | RDNA2        | gfx1030     | ✅            | ✅            |               |
 | RDNA1        | gfx1012     | ✅            |               |               |
 | RDNA1        | gfx1011     | ✅            |               |               |

--- a/SUPPORTED_GPUS.md
+++ b/SUPPORTED_GPUS.md
@@ -23,6 +23,7 @@ Note that some fully supported GPU architectures may show a more limited state o
 | CDNA2        | gfx90a      | ✅            |               |               |
 | CDNA         | gfx908      | ✅            |               |               |
 | GCN5.1       | gfx906      | ✅            |               |               |
+| GCN5.0       | gfx900      | ✅            |               |               |
 
 ### AMD Radeon - Linux
 
@@ -43,6 +44,8 @@ Note that some fully supported GPU architectures may show a more limited state o
 | RDNA1        | gfx1011     | ✅            |               |               |
 | RDNA1        | gfx1010     | ✅            |               |               |
 | GCN5.1       | gfx906      | ✅            |               |               |
+| GCN5.0       | gfx90c      |               |               |               |
+| GCN5.0       | gfx900      | ✅            |               |               |
 
 ## ROCm on Windows
 
@@ -65,3 +68,5 @@ Check [windows_support.md](https://github.com/ROCm/TheRock/blob/main/docs/develo
 | RDNA1        | gfx1011     | ✅            |               |               |
 | RDNA1        | gfx1010     | ✅            |               |               |
 | GCN5.1       | gfx906      | ✅            |               |               |
+| GCN5.0       | gfx90c      |               |               |               |
+| GCN5.0       | gfx900      | ✅            |               |               |


### PR DESCRIPTION
## Motivation

Entries for `gfx900`, `gfx90c`, `gfx1031`, `gfx1032`, `gfx1033`, `gfx1034`, `gfx1035`, and `gfx1036` were previously added to `ROADMAP.md`, but not here (that PR linked below).

## Technical Details

Build status breakdowns are outlined [here](https://github.com/ROCm/TheRock/pull/3933).

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
