### PR TITLE
[ci] Prune test_type / test_labels from build jobs

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -34,13 +34,9 @@ on:
         type: string
       build_variant_suffix:
         type: string
-      test_labels:
-        type: string
       expect_failure:
         type: boolean
       rocm_package_version:
-        type: string
-      test_type:
         type: string
       prebuilt_stages:
         type: string

--- a/.github/workflows/multi_arch_build_windows.yml
+++ b/.github/workflows/multi_arch_build_windows.yml
@@ -40,8 +40,6 @@ on:
         description: "Comma-separated build stages to skip (artifacts already copied by the orchestrator)"
       rocm_package_version:
         type: string
-      test_type:
-        type: string
       release_type:
         description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -79,7 +79,6 @@ jobs:
       expect_failure: ${{ fromJSON(inputs.build_config).expect_failure }}
       prebuilt_stages: ${{ fromJSON(inputs.build_config).prebuilt_stages }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
-      test_type: ${{ inputs.test_type }}
       release_type: ${{ inputs.release_type }}
     permissions:
       contents: read

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -84,7 +84,6 @@ jobs:
       expect_failure: ${{ fromJSON(inputs.build_config).expect_failure }}
       prebuilt_stages: ${{ fromJSON(inputs.build_config).prebuilt_stages }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
-      test_type: ${{ inputs.test_type }}
       release_type: ${{ inputs.release_type }}
     permissions:
       contents: read


### PR DESCRIPTION
## Motivation

These inputs are unused and do not belong in build jobs. Removing them will help with:
* https://github.com/ROCm/TheRock/issues/3336
* https://github.com/ROCm/TheRock/issues/3334

## Technical Details

These other inputs are also candidates for cleanup:

input | notes
-- | --
`expect_failure` | See https://github.com/ROCm/TheRock/pull/4500
`artifact_group` | Previously used here, may need to line up with `build_variant_suffix`: https://github.com/ROCm/TheRock/blob/15558f4240876c7b4eb667f20182db4e3673e4e6/.github/workflows/build_portable_linux_artifacts.yml#L172-L177
`build_variant_label` | Previously used here, may be useful later: https://github.com/ROCm/TheRock/blob/15558f4240876c7b4eb667f20182db4e3673e4e6/.github/workflows/build_portable_linux_artifacts.yml#L66 (but see also https://github.com/ROCm/TheRock/pull/4415)
`build_variant_suffix` | Partially handled: https://github.com/ROCm/TheRock/blob/15558f4240876c7b4eb667f20182db4e3673e4e6/build_tools/github_actions/configure_multi_arch_ci.py#L862-L869 https://github.com/ROCm/TheRock/blob/15558f4240876c7b4eb667f20182db4e3673e4e6/.github/workflows/multi_arch_ci_linux.yml#L120-L126

## Test Plan

* CI run should include expected build/test jobs

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
