### PR TITLE
[Windows] Execute console_scripts in foreground

### DIFF
--- a/build_tools/packaging/python/templates/rocm-sdk-core/src/rocm_sdk_core/_cli.py
+++ b/build_tools/packaging/python/templates/rocm-sdk-core/src/rocm_sdk_core/_cli.py
@@ -102,6 +102,10 @@ def _exec(relpath: str, expand_devel=True):
     # need the devel files. System info tools (amd-smi, rocminfo, etc.)
     # override with expand_devel=False to avoid the expansion cost.
     full_path = _get_module_path(expand_devel) / (relpath + exe_suffix)
+    if is_windows:
+        # https://bugs.python.org/issue19124
+        # prevent execution from occuring in the backround
+        os._exit(os.spawnv(os.P_WAIT, full_path, [str(full_path)] + sys.argv[1:]))
     os.execv(full_path, [str(full_path)] + sys.argv[1:])
 
 


### PR DESCRIPTION
## Motivation

The `console_scripts` provided in the rocm python packages currently execute in the background on Windows.

## Technical Details

The current behavior is due to a well known bug in Python and it is unlikely to be fixed. https://github.com/python/cpython/issues/63323

The approach of using `os.spawnv(os.P_WAIT, ...)` paired with `os._exit` as seen in the issue linked above.

## Test Plan

Tested locally.

## Test Result

The rocm executable runs in the foreground and behaves as expected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


Fixes #4481