### PR TITLE
Remove unused awscli install step from workflow

### DIFF
--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -89,14 +89,6 @@ jobs:
       - name: Install Python requirements
         run: pip install -r requirements.txt
 
-      - name: Install AWS CLI
-        # The first two lines removes the default commmunity feed and uses the internal proxy feed
-        run: |
-          choco source disable -n=chocolatey
-          choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
-          choco install --no-progress -y awscli
-          echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
-
       - name: Fetch artifacts
         run: |
           if [ -n "${{ inputs.amdgpu_families }}" ]; then


### PR DESCRIPTION
## Motivation

We no longer need this dependency, since https://github.com/ROCm/TheRock/pull/3596 switched `build_tools/github_actions/upload_python_packages.py` from running `aws s3 cp`, which depended on having the AWS CLI installed, to using the `boto3` python package.

## Test Plan

Trigger this workflow manually, check that uploads succeed.

## Test Result

https://github.com/ROCm/TheRock/actions/runs/24369567496/job/71169796313#step:8:41
```
[INFO] Uploading 5 total files to s3://therock-ci-artifacts/24369567496-windows/python/gfx1151:
  index.html
  rocm-7.13.0.dev0+ad6f4f2e3463f5529096c0b7d7fcd9e5cb3fdecf.tar.gz
  rocm_sdk_core-7.13.0.dev0+ad6f4f2e3463f5529096c0b7d7fcd9e5cb3fdecf-py3-none-win_amd64.whl
  rocm_sdk_devel-7.13.0.dev0+ad6f4f2e3463f5529096c0b7d7fcd9e5cb3fdecf-py3-none-win_amd64.whl
  rocm_sdk_libraries_gfx1151-7.13.0.dev0+ad6f4f2e3463f5529096c0b7d7fcd9e5cb3fdecf-py3-none-win_amd64.whl
[INFO] Uploaded 5 files
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
