### PR TITLE
Update `build_python_packages.py` to package `rocprofiler-compute` and `rocprofiler-systems` into profiler wheel: Phase 3

### DIFF
--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -502,6 +502,27 @@ class PopulatedDistPackage:
         # any emitted runtime artifacts plus additional requested.
         devel_artifact_names = set(self.params.runtime_artifact_names)
         devel_artifact_names.update(addl_artifact_names)
+        # Exclude profiler-owned artifacts from the devel package.
+        #
+        # The profiler runtime (rocprofiler-compute and rocprofiler-systems)
+        # is now packaged in the separate `rocm-profiler` wheel. However,
+        # devel packaging automatically includes all runtime artifacts via
+        # `runtime_artifact_names`, which would otherwise pull these profiler
+        # artifacts back into the devel package.
+        #
+        # This leads to CI failures where devel tests attempt to load profiler
+        # shared libraries without their full dependency closure (e.g. missing
+        # rocprofiler-sdk or libomp resolution).
+        #
+        # Explicitly removing them here ensures correct package ownership:
+        #   - rocm-profiler → owns profiler runtime
+        #   - rocm-sdk-devel → does NOT include profiler runtime
+        devel_artifact_names.difference_update(
+            {
+                "rocprofiler-compute",
+                "rocprofiler-systems",
+            }
+        )
         excluded = set(exclude_components)
         log(f":: Devel artifact inclusions: {devel_artifact_names}")
 

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -49,6 +49,22 @@ def load_therock_manifest(artifact_dir: Path) -> dict:
         )
     return json.loads(manifest_path.read_text())
 
+def ensure_profiler_library_symlinks(profiler: PopulatedDistPackage) -> None:
+    """Recreate unversioned profiler library symlinks expected by dlopen()."""
+    profiler_lib_dir = profiler.platform_dir / "lib"
+
+    symlink_pairs = [
+        ("librocprof-sys.so", "librocprof-sys.so.1"),
+        ("librocprof-sys-dl.so", "librocprof-sys-dl.so.1"),
+        ("librocprof-sys-rt.so", "librocprof-sys-rt.so.1"),
+        ("librocprof-sys-user.so", "librocprof-sys-user.so.1"),
+    ]
+
+    for link_name, target_name in symlink_pairs:
+        target = profiler_lib_dir / target_name
+        link = profiler_lib_dir / link_name
+        if target.exists() and not link.exists():
+            link.symlink_to(target_name)
 
 def run(args: argparse.Namespace):
     manifest = load_therock_manifest(args.artifact_dir)
@@ -89,6 +105,7 @@ def run(args: argparse.Namespace):
     profiler = PopulatedDistPackage(params, logical_name="profiler")
     profiler.rpath_dep(core, "lib")
     profiler.rpath_dep(core, "lib/llvm/lib")
+    profiler.rpath_dep(core, "lib/rocm_sysdeps/lib")
     profiler.populate_runtime_files(
         params.filter_artifacts(
             profiler_artifact_filter,
@@ -104,11 +121,10 @@ def run(args: argparse.Namespace):
                 # rocprofiler-compute
                 "bin/rocprof-*",
                 "libexec/rocprofiler-compute/**",
-                # rocprofiler-systems sysdeps
-                "lib/rocm_sysdeps/lib/**",
             ],
         ),
     )
+    ensure_profiler_library_symlinks(profiler)
 
     # The rocprofiler-compute artifact installs the launcher as a symlink:
     # bin/rocprof-compute -> ../libexec/rocprofiler-compute/rocprof-compute
@@ -361,7 +377,7 @@ def profiler_artifact_filter(an: ArtifactName) -> bool:
             "rocprofiler-systems",
         ]
         and an.component in ["lib", "run"]
-    ) or (an.name == "sysdeps" and an.component == "lib")
+    )
 
 
 def device_artifact_filter(target: str, an: ArtifactName) -> bool:

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -71,9 +71,55 @@ def run(args: argparse.Namespace):
         params.filter_artifacts(
             core_artifact_filter,
             # TODO: The base package is shoving CMake redirects into lib.
-            excludes=["**/cmake/**"],
+            excludes=[
+                "**/cmake/**",
+                # profiler binaries
+                "bin/rocprof-*",
+                # rocprofiler-systems payload
+                "include/rocprofiler-systems/**",
+                "lib/librocprof-sys*",
+                "lib/python/site-packages/rocprofsys/**",
+                "lib/rocprofiler-systems/**",
+                "libexec/rocprofiler-systems/**",
+                "share/**/rocprofiler-systems/**",
+            ],
         ),
     )
+
+    profiler = PopulatedDistPackage(params, logical_name="profiler")
+    profiler.rpath_dep(core, "lib")
+    profiler.populate_runtime_files(
+        params.filter_artifacts(
+            profiler_artifact_filter,
+            includes=[
+                # rocprofiler-systems
+                "bin/rocprof-sys-*",
+                "include/rocprofiler-systems/**",
+                "lib/librocprof-sys*",
+                "lib/python/site-packages/rocprofsys/**",
+                "lib/rocprofiler-systems/**",
+                "libexec/rocprofiler-systems/**",
+                "share/**/rocprofiler-systems/**",
+                # rocprofiler-compute
+                "bin/rocprof-*",
+                "libexec/rocprofiler-compute/**",
+            ],
+        ),
+    )
+
+    # The rocprofiler-compute artifact installs the launcher as a symlink:
+    # bin/rocprof-compute -> ../libexec/rocprofiler-compute/rocprof-compute
+    # However, populate_runtime_files() does not preserve symlinks and only
+    # materializes the real file under libexec/. Recreate the expected bin/
+    # entry here so CLI entrypoints (_exec("bin/rocprof-compute")) continue to work.
+    compute_target = (
+        profiler.platform_dir / "libexec" / "rocprofiler-compute" / "rocprof-compute"
+    )
+    compute_link = profiler.platform_dir / "bin" / "rocprof-compute"
+
+    if compute_target.exists() and not compute_link.exists():
+        compute_link.parent.mkdir(parents=True, exist_ok=True)
+        compute_link.symlink_to("../libexec/rocprofiler-compute/rocprof-compute")
 
     if kpack_split:
         _run_kpack_split(args, params, core)
@@ -302,6 +348,13 @@ def libraries_artifact_filter(target_family: str, an: ArtifactName) -> bool:
         and (an.target_family == target_family or an.target_family == "generic")
     )
     return libraries
+
+
+def profiler_artifact_filter(an: ArtifactName) -> bool:
+    return an.name in [
+        "rocprofiler-compute",
+        "rocprofiler-systems",
+    ] and an.component in ["lib", "run"]
 
 
 def device_artifact_filter(target: str, an: ArtifactName) -> bool:

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -105,12 +105,7 @@ def run(args: argparse.Namespace):
                 "bin/rocprof-*",
                 "libexec/rocprofiler-compute/**",
                 # rocprofiler-systems sysdeps
-                "lib/rocm_sysdeps/lib/librocm_sysdeps_dw.so*",
-                "lib/rocm_sysdeps/lib/librocm_sysdeps_elf.so*",
-                "lib/rocm_sysdeps/lib/librocm_sysdeps_z.so*",
-                "lib/rocm_sysdeps/lib/librocm_sysdeps_zstd.so*",
-                "lib/rocm_sysdeps/lib/librocm_sysdeps_liblzma.so*",
-                "lib/rocm_sysdeps/lib/librocm_sysdeps_bz2.so*",
+                "lib/rocm_sysdeps/lib/**",
             ],
         ),
     )

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -370,10 +370,10 @@ def libraries_artifact_filter(target_family: str, an: ArtifactName) -> bool:
 
 
 def profiler_artifact_filter(an: ArtifactName) -> bool:
-    return  an.name in [
-            "rocprofiler-compute",
-            "rocprofiler-systems",
-        ] and an.component in ["lib", "run"]
+    return an.name in [
+        "rocprofiler-compute",
+        "rocprofiler-systems",
+    ] and an.component in ["lib", "run"]
     
 
 def device_artifact_filter(target: str, an: ArtifactName) -> bool:

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -49,6 +49,7 @@ def load_therock_manifest(artifact_dir: Path) -> dict:
         )
     return json.loads(manifest_path.read_text())
 
+
 def ensure_profiler_library_symlinks(profiler: PopulatedDistPackage) -> None:
     """Recreate unversioned profiler library symlinks expected by dlopen()."""
     profiler_lib_dir = profiler.platform_dir / "lib"
@@ -65,6 +66,7 @@ def ensure_profiler_library_symlinks(profiler: PopulatedDistPackage) -> None:
         link = profiler_lib_dir / link_name
         if target.exists() and not link.exists():
             link.symlink_to(target_name)
+
 
 def run(args: argparse.Namespace):
     manifest = load_therock_manifest(args.artifact_dir)
@@ -374,7 +376,7 @@ def profiler_artifact_filter(an: ArtifactName) -> bool:
         "rocprofiler-compute",
         "rocprofiler-systems",
     ] and an.component in ["lib", "run"]
-    
+
 
 def device_artifact_filter(target: str, an: ArtifactName) -> bool:
     """Selects per-ISA library artifacts for a specific GFX target.

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -360,15 +360,13 @@ def libraries_artifact_filter(target_family: str, an: ArtifactName) -> bool:
 
 def profiler_artifact_filter(an: ArtifactName) -> bool:
     return (
-        (
-            an.name in [
-                "rocprofiler-compute",
-                "rocprofiler-systems",
-            ]
-            and an.component in ["lib", "run"]
-        )
-        or (an.name == "sysdeps" and an.component == "lib")
-    )
+        an.name
+        in [
+            "rocprofiler-compute",
+            "rocprofiler-systems",
+        ]
+        and an.component in ["lib", "run"]
+    ) or (an.name == "sysdeps" and an.component == "lib")
 
 
 def device_artifact_filter(target: str, an: ArtifactName) -> bool:

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -370,15 +370,11 @@ def libraries_artifact_filter(target_family: str, an: ArtifactName) -> bool:
 
 
 def profiler_artifact_filter(an: ArtifactName) -> bool:
-    return (
-        an.name
-        in [
+    return  an.name in [
             "rocprofiler-compute",
             "rocprofiler-systems",
-        ]
-        and an.component in ["lib", "run"]
-    )
-
+        ] and an.component in ["lib", "run"]
+    
 
 def device_artifact_filter(target: str, an: ArtifactName) -> bool:
     """Selects per-ISA library artifacts for a specific GFX target.

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -88,6 +88,7 @@ def run(args: argparse.Namespace):
 
     profiler = PopulatedDistPackage(params, logical_name="profiler")
     profiler.rpath_dep(core, "lib")
+    profiler.rpath_dep(core, "lib/llvm/lib")
     profiler.populate_runtime_files(
         params.filter_artifacts(
             profiler_artifact_filter,
@@ -103,6 +104,13 @@ def run(args: argparse.Namespace):
                 # rocprofiler-compute
                 "bin/rocprof-*",
                 "libexec/rocprofiler-compute/**",
+                # rocprofiler-systems sysdeps
+                "lib/rocm_sysdeps/lib/librocm_sysdeps_dw.so*",
+                "lib/rocm_sysdeps/lib/librocm_sysdeps_elf.so*",
+                "lib/rocm_sysdeps/lib/librocm_sysdeps_z.so*",
+                "lib/rocm_sysdeps/lib/librocm_sysdeps_zstd.so*",
+                "lib/rocm_sysdeps/lib/librocm_sysdeps_liblzma.so*",
+                "lib/rocm_sysdeps/lib/librocm_sysdeps_bz2.so*",
             ],
         ),
     )
@@ -351,10 +359,16 @@ def libraries_artifact_filter(target_family: str, an: ArtifactName) -> bool:
 
 
 def profiler_artifact_filter(an: ArtifactName) -> bool:
-    return an.name in [
-        "rocprofiler-compute",
-        "rocprofiler-systems",
-    ] and an.component in ["lib", "run"]
+    return (
+        (
+            an.name in [
+                "rocprofiler-compute",
+                "rocprofiler-systems",
+            ]
+            and an.component in ["lib", "run"]
+        )
+        or (an.name == "sysdeps" and an.component == "lib")
+    )
 
 
 def device_artifact_filter(target: str, an: ArtifactName) -> bool:

--- a/build_tools/packaging/python/templates/rocm-profiler/MANIFEST.in
+++ b/build_tools/packaging/python/templates/rocm-profiler/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include src *.py
+recursive-include platform/* *

--- a/build_tools/packaging/python/templates/rocm-profiler/setup.py
+++ b/build_tools/packaging/python/templates/rocm-profiler/setup.py
@@ -9,6 +9,7 @@ import importlib.util
 import os
 from pathlib import Path
 import platform
+import sysconfig
 
 from setuptools import find_packages, setup
 
@@ -31,9 +32,14 @@ def _load_local_dist_info():
     return module
 
 
+dist_info = _load_local_dist_info()
+my_package = dist_info.ALL_PACKAGES["profiler"]
+packages = find_packages(where="./src")
+platform_package_name = my_package.get_py_package_name()
+packages.append(platform_package_name)
+
 version = os.environ.get("ROCM_SDK_VERSION")
 if version is None:
-    dist_info = _load_local_dist_info()
     version = dist_info.__version__
 
 if version == "DEFAULT":
@@ -44,10 +50,20 @@ setup(
     name="rocm-profiler",
     version=version,
     description="ROCm profiler applications (rocprofiler-systems and rocprofiler-compute)",
-    packages=find_packages(where="src"),
-    package_dir={"": "src"},
+    packages=packages,
+    package_dir={
+        "": "src",
+        platform_package_name: f"platform/{platform_package_name}",
+    },
     include_package_data=True,
     zip_safe=False,
+    options={
+        "bdist_wheel": {
+            "plat_name": os.getenv(
+                "ROCM_SDK_WHEEL_PLATFORM_TAG", sysconfig.get_platform()
+            ),
+        },
+    },
     entry_points={
         "console_scripts": (
             [

--- a/build_tools/packaging/python/templates/rocm-profiler/src/rocm_profiler/_cli.py
+++ b/build_tools/packaging/python/templates/rocm-profiler/src/rocm_profiler/_cli.py
@@ -6,62 +6,29 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 import sys
 from pathlib import Path
 import platform
 
+from ._dist_info import ALL_PACKAGES
 
-def _find_platform_root() -> Path:
-    """
-    Locate the packaged ROCm platform root inside this wheel.
 
-    Phase 3 will populate runtime files into a subdirectory that contains `bin/`.
-    This function finds it dynamically to avoid hard-coding the exact platform tag.
-    """
-    pkg_dir = Path(__file__).resolve().parent
-    children = list(pkg_dir.iterdir())
-    direct_candidates: list[Path] = [
-        child for child in children if child.is_dir() and (child / "bin").is_dir()
-    ]
-    if len(direct_candidates) == 1:
-        return direct_candidates[0]
-    if len(direct_candidates) > 1:
-        raise RuntimeError(
-            "Ambiguous packaged ROCm profiler binaries: found multiple direct "
-            f"candidates with bin/: {sorted(str(p) for p in direct_candidates)}"
-        )
+PROFILER_PACKAGE = ALL_PACKAGES["profiler"]
+PROFILER_PY_PACKAGE_NAME = PROFILER_PACKAGE.get_py_package_name()
 
-    nested_candidates: list[Path] = []
-    for child in children:
-        if not child.is_dir():
-            continue
-        for grand in child.iterdir():
-            if grand.is_dir() and (grand / "bin").is_dir():
-                nested_candidates.append(grand)
 
-    if len(nested_candidates) == 1:
-        return nested_candidates[0]
-    if len(nested_candidates) > 1:
-        raise RuntimeError(
-            "Ambiguous packaged ROCm profiler binaries: found multiple nested "
-            f"candidates with bin/: {sorted(str(p) for p in nested_candidates)}"
-        )
-
-    raise FileNotFoundError(
-        "Could not locate packaged ROCm profiler binaries. "
-        "Expected a directory containing `bin/` under the installed "
-        "rocm_profiler package."
-    )
+def _get_profiler_module_path() -> Path:
+    profiler_module = importlib.import_module(PROFILER_PY_PACKAGE_NAME)
+    return Path(profiler_module.__file__).parent
 
 
 def _exec(relpath: str) -> None:
-
     if platform.system() == "Windows":
         raise RuntimeError("rocm-profiler is not supported on Windows.")
 
-    root = _find_platform_root()
-    full_path = root / relpath
+    full_path = _get_profiler_module_path() / relpath
     if not full_path.exists():
         raise FileNotFoundError(f"Profiler tool not found: {full_path}")
     os.execv(str(full_path), [str(full_path)] + sys.argv[1:])

--- a/build_tools/packaging/python/templates/rocm-profiler/src/rocm_profiler/_cli.py
+++ b/build_tools/packaging/python/templates/rocm-profiler/src/rocm_profiler/_cli.py
@@ -19,6 +19,28 @@ PROFILER_PACKAGE = ALL_PACKAGES["profiler"]
 PROFILER_PY_PACKAGE_NAME = PROFILER_PACKAGE.get_py_package_name()
 
 
+def _extend_ld_library_path() -> None:
+    if platform.system() == "Windows":
+        return
+
+    try:
+        sdk_module = importlib.import_module("_rocm_sdk_core")
+    except ModuleNotFoundError:
+        return
+
+    sdk_path = Path(sdk_module.__file__).parent
+    sysdeps_path = sdk_path / "lib" / "rocm_sysdeps" / "lib"
+    if not sysdeps_path.exists():
+        return
+
+    existing = os.environ.get("LD_LIBRARY_PATH", "")
+    existing_parts = [p for p in existing.split(":") if p]
+    sysdeps_str = str(sysdeps_path)
+
+    if sysdeps_str not in existing_parts:
+        os.environ["LD_LIBRARY_PATH"] = ":".join([sysdeps_str, *existing_parts])
+
+
 def _get_profiler_module_path() -> Path:
     profiler_module = importlib.import_module(PROFILER_PY_PACKAGE_NAME)
     return Path(profiler_module.__file__).parent
@@ -27,6 +49,8 @@ def _get_profiler_module_path() -> Path:
 def _exec(relpath: str) -> None:
     if platform.system() == "Windows":
         raise RuntimeError("rocm-profiler is not supported on Windows.")
+
+    _extend_ld_library_path()
 
     full_path = _get_profiler_module_path() / relpath
     if not full_path.exists():


### PR DESCRIPTION
Progress on #3573
## Motivation

This PR introduces a dedicated `rocm-profiler` wheel for `rocprof-sys` and `rocprof-compute` by packaging directly from profiler artifacts instead of relying on `base`.

The goal is to:
- Package `rocprofiler-compute` and `rocprofiler-systems` into a dedicated profiler wheel
- Ensure CLI tools (`rocprof-compute`, `rocprof-sys-*`) are available and functional from the installed wheel
- Align packaging with TheRock’s artifact-driven model
- Resolve runtime dependency issues (sysdeps and libomp) so profiler tools execute correctly

---

## Technical Details

### Artifact Selection
- Switched profiler artifact selection to:
  - `rocprofiler-compute` (`lib`, `run`)
  - `rocprofiler-systems` (`lib`, `run`)
- Extended selection to include:
  - `sysdeps` (`lib`) for runtime dependency closure

### Runtime Payload Updates
- Added required `rocm_sysdeps` runtime libraries:
  - `librocm_sysdeps_dw.so*`
  - `librocm_sysdeps_elf.so*`
  - `librocm_sysdeps_z.so*`
  - `librocm_sysdeps_zstd.so*`
  - `librocm_sysdeps_liblzma.so*`
  - `librocm_sysdeps_bz2.so*`

### RPATH Fixes
- Added additional RPATH dependency:
  - `core/lib`
  - `core/lib/llvm/lib`
- This enables resolution of `libomp.so` from `rocm-sdk-core`

### CLI Runtime Fix
- Updated `_cli.py` to extend `LD_LIBRARY_PATH` at runtime:
  - Points to `_rocm_sdk_core/lib/rocm_sysdeps/lib`
- Ensures packaged sysdeps are visible to profiler binaries

### Other Packaging Updates
- Recreated missing symlink:
  - `bin/rocprof-compute -> ../libexec/rocprofiler-compute/rocprof-compute`
- Updated packaging templates to include `_rocm_profiler` platform files
- Ensured artifact-driven packaging instead of relying on `base`

---

## Test Plan

### Artifact Preparation
- Synced CI artifacts:
  ```
  s3://therock-ci-artifacts/24104028483-linux/
  ```
- Extracted:
  - `base_{lib,run}_generic`
  - `rocprofiler-compute_{lib,run}_generic`
  - `rocprofiler-systems_{lib,run}_generic`
  - `sysdeps_lib_generic`
  - `amd-llvm_lib_generic`

### Build
```
python build_tools/build_python_packages.py \
  --artifact-dir ~/therock-multiarch-root \
  --dest-dir /tmp/therock-profiler-test \
  --build-packages
```

### Install
```
pip install --force-reinstall rocm_sdk_core-*.whl
pip install --force-reinstall rocm_profiler-*.whl
```

### Validation
```
rocprof-compute --help
rocprof-sys-python --help
rocprof-sys-run --help
rocprof-sys-avail --help
rocprof-sys-causal --help
rocprof-sys-instrument --help
rocprof-sys-sample --help
```

### Dependency Checks
```
ldd .../rocprof-sys-instrument | grep libomp
ldd .../rocprof-sys-run | grep "not found"
```


---
## Test Result
Verified the following profiler entrypoints execute successfully from the installed wheel:

```

- rocprof-compute --help
- rocprof-sys-python --help
- rocprof-sys-run --help
- rocprof-sys-avail --help
- rocprof-sys-causal --help
- rocprof-sys-instrument --help
- rocprof-sys-sample --help

```
All commands print usage without missing shared library errors.

- `rocprof-compute --help` executes successfully
- All `rocprof-sys-*` entrypoints execute and print usage:
  - `run`, `avail`, `causal`, `instrument`, `sample`

- `libomp.so` is correctly resolved from `rocm-sdk-core`:
  ```
  libomp.so => _rocm_sdk_core/lib/llvm/lib/libomp.so
  ```

- All required sysdeps libraries are now packaged and resolved:
  - `librocm_sysdeps_dw.so.1`
  - `librocm_sysdeps_elf.so.1`
  - `librocm_sysdeps_z.so.1`
  - `librocm_sysdeps_zstd.so.1`
  - `librocm_sysdeps_liblzma.so.5`
  - `librocm_sysdeps_bz2.so`

- No remaining missing dependency errors from `ldd`

- Remaining runtime output is limited to host `/opt/rocm` warnings (e.g. `libamd_smi.so.26`), not missing packaging content

---

## Summary

- `rocm-profiler` is now correctly built from profiler artifacts
- Runtime dependency closure (sysdeps + LLVM/OpenMP) is resolved
- Profiler tools execute successfully from installed wheels
- Remaining issues are limited to external host ROCm linkage, not packaging
