### PR TITLE
[ci] Fixing` test_label` parsing in `fetch_test_configurations.py`

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -550,7 +550,7 @@ def _determine_test_type(
     # test:rocprim). When someone explicitly asks for tests, run the full
     # suite — they're investigating something specific.
     if _has_test_labels(ci_inputs):
-        return "full", "test labels specified"
+        return "standard", "test labels specified"
 
     # Priority 3: schedule runs the full nightly suite — comprehensive
     # coverage on a cadence, catching regressions that quick tests miss.

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -550,7 +550,7 @@ def _determine_test_type(
     # test:rocprim). When someone explicitly asks for tests, run the full
     # suite — they're investigating something specific.
     if _has_test_labels(ci_inputs):
-        return "standard", "test labels specified"
+        return "full", "test labels specified"
 
     # Priority 3: schedule runs the full nightly suite — comprehensive
     # coverage on a cadence, catching regressions that quick tests miss.

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -578,7 +578,8 @@ def run():
 
         # If test labels are populated, and the test job name is not in the test labels, skip the test
         # Note: Benchmarks never use test_labels (always empty list)
-        if key != "sanity" and test_labels and key not in test_labels:
+        parsed_test_labels = [c.split["test:"][-1] for c in test_labels]
+        if key != "sanity" and parsed_test_labels and key not in parsed_test_labels:
             logging.info(f"Excluding job {job_name} since it's not in the test labels")
             continue
 

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -578,7 +578,7 @@ def run():
 
         # If test labels are populated, and the test job name is not in the test labels, skip the test
         # Note: Benchmarks never use test_labels (always empty list)
-        parsed_test_labels = [c.split["test:"][-1] for c in test_labels]
+        parsed_test_labels = [c.split("test:")[-1] for c in test_labels]
         if key != "sanity" and parsed_test_labels and key not in parsed_test_labels:
             logging.info(f"Excluding job {job_name} since it's not in the test labels")
             continue


### PR DESCRIPTION
Previously, test labels were not picked up properly due to `test:rocrand` -> `rocrand` parsing was not done correctly.

Now if a PR or workflow_dispatch label is specified, it parses correctly

Working here: https://github.com/ROCm/TheRock/actions/runs/24373377057/job/71187119817