### PR TITLE
Fix THEROCK_DEV_PROJECTS flag behavior for amd-llvm

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -134,7 +134,7 @@ if(THEROCK_ENABLE_COMPILER)
   )
   # LLVM is too large to glob by default; opt in with THEROCK_DEV_PROJECTS.
   if(THEROCK_DEV_PROJECTS AND "amd-llvm" IN_LIST THEROCK_DEV_PROJECTS)
-    therock_cmake_subproject_glob_c_sources(amd-llvm)
+    therock_cmake_subproject_glob_c_sources(amd-llvm SUBDIRS .)
   endif()
 
   therock_cmake_subproject_provide_package(amd-llvm AMDDeviceLibs lib/llvm/lib/cmake/AMDDeviceLibs)


### PR DESCRIPTION
## Motivation

Fix flag introduced in #4235

## Technical Details

Pass missing mandatory parameter `SUBDIRS .` to `therock_cmake_subproject_glob_c_sources` for `amd-llvm` to prevent globbing into subproject subdirectories, which broke clean re-build

## Test Plan

```
$ cmake .. -DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_HIP_RUNTIME=ON -DTHEROCK_ENABLE_OCL_RUNTIME=ON -DTHEROCK_ENABLE_CORE_RUNTIME=ON -DTHEROCK_AMDGPU_FAMILIES=gfx90a -G Ninja -DTHEROCK_DEV_PROJECTS="amd-llvm"
$ ninja
```
After successful build changed .cpp file in llvm tree and retriggered build with `ninja`

## Test Result

LLVM build is successfully retriggered

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
