### PR TITLE
replace bash resolve_torch_version with Python for Windows compat

### DIFF
--- a/.github/workflows/ci_nightly_pytorch_full_test.yml
+++ b/.github/workflows/ci_nightly_pytorch_full_test.yml
@@ -87,38 +87,37 @@ jobs:
     outputs:
       torch_version: ${{ steps.resolve.outputs.torch_version }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Resolve latest nightly torch version
         id: resolve
         run: |
-          INDEX_URL="${PACKAGE_INDEX_URL}/${AMDGPU_FAMILY}"
-
-          if [ -n "${TORCH_VERSION_INPUT}" ]; then
-            echo "torch_version=${TORCH_VERSION_INPUT}" >> "$GITHUB_OUTPUT"
-            echo "Using provided torch_version: ${TORCH_VERSION_INPUT}"
-            exit 0
-          fi
-
           pip install packaging
-          # --platform ensures this works even when the runner OS differs from
-          # the target (e.g. querying Linux packages from an ubuntu runner that
-          # might later be replaced by a Windows runner for cross-platform support).
-          # TODO: When adding Windows support, pass --platform win_amd64 for
-          # Windows targets or derive the platform from amdgpu_family/runner.
-          TORCH_VERSION=$(pip index versions torch \
-            --pre \
-            --index-url "${INDEX_URL}" \
-            --python-version "${PYTHON_VERSION}" \
-            --platform linux_x86_64 2>/dev/null \
-            | head -1 \
-            | sed 's/torch (\(.*\))/\1/')
 
-          if [ -z "${TORCH_VERSION}" ]; then
-            echo "::error::Failed to resolve torch version from ${INDEX_URL}"
-            exit 1
-          fi
+          python -c "
+          import os, sys
+          sys.path.insert(0, 'external-builds/pytorch')
+          from pytorch_utils import resolve_torch_version
 
-          echo "torch_version=${TORCH_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Resolved torch_version: ${TORCH_VERSION}"
+          torch_version_input = os.environ.get('TORCH_VERSION_INPUT', '')
+          if torch_version_input:
+              version = torch_version_input
+              print(f'Using provided torch_version: {version}')
+          else:
+              index_url = os.environ['PACKAGE_INDEX_URL'] + '/' + os.environ['AMDGPU_FAMILY']
+              python_version = os.environ.get('PYTHON_VERSION', '')
+              platform = os.environ.get('PIP_PLATFORM', 'linux_x86_64')
+              version = resolve_torch_version(
+                  index_url=index_url,
+                  python_version=python_version,
+                  platform=platform,
+              )
+              print(f'Resolved torch_version: {version}')
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'torch_version={version}\n')
+          "
 
   run_full_tests:
     needs: resolve_torch_version

--- a/external-builds/pytorch/pytorch_utils.py
+++ b/external-builds/pytorch/pytorch_utils.py
@@ -437,3 +437,60 @@ def check_pytorch_source_version(pytorch_dir: Path, allow_mismatch: bool) -> Non
         f"PyTorch version check OK: source and wheel both "
         f"{installed_version.major}.{installed_version.minor}"
     )
+
+
+def resolve_torch_version(
+    index_url: str,
+    python_version: str = "",
+    platform: str = "linux_x86_64",
+    pre: bool = True,
+) -> str:
+    """Resolve the latest torch version from a package index.
+
+    Wraps ``pip index versions`` in a cross-platform way (no bash/sed).
+
+    Args:
+        index_url: Full package index URL including GPU family subdir.
+        python_version: Python version constraint (e.g. "3.12"). Empty = any.
+        platform: Pip platform tag (e.g. "linux_x86_64", "win_amd64").
+        pre: Include pre-release versions.
+
+    Returns:
+        Version string (e.g. "2.12.0a0+rocm7.13.0a20260413").
+
+    Raises:
+        RuntimeError: If pip fails or no version can be parsed.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "index",
+        "versions",
+        "torch",
+        "--index-url",
+        index_url,
+        "--platform",
+        platform,
+    ]
+    if pre:
+        cmd.append("--pre")
+    if python_version:
+        cmd.extend(["--python-version", python_version])
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"pip index versions failed (exit {result.returncode}):\n{result.stderr}"
+        )
+
+    import re
+
+    for line in result.stdout.splitlines():
+        m = re.match(r"^torch\s+\((.+)\)", line)
+        if m:
+            return m.group(1)
+
+    raise RuntimeError(
+        f"Could not parse torch version from pip output:\n{result.stdout}"
+    )


### PR DESCRIPTION
Related: #4082

## Summary
- Replaces the bash-based torch nightly version resolver in the full PyTorch UT workflow with Python.
- Adds `resolve_torch_version()` to `external-builds/pytorch/pytorch_utils.py` so version lookup works without shell-specific parsing.
- Preserves explicit `torch_version` overrides while keeping automatic nightly resolution for normal workflow dispatches.

## Validation
- Dispatched CI Nightly PyTorch Full Test on this branch for gfx94X-dcgpu / Python 3.12 / default+distributed+inductor: https://github.com/ROCm/TheRock/actions/runs/25391942303
