### PR TITLE
[ci] Enable `nightly_check_only_for_family` and `run-full-tests-only` for multi arch CI

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -843,9 +843,6 @@ def _expand_build_config_for_platform(
                     f"disabling tests"
                 )
 
-        # Apply per-family test filtering flags
-        sanity_check_only = platform_info.get("sanity_check_only_for_family", False)
-
         # If run-full-tests-only is set and test_type is "quick", disable testing
         if platform_info.get("run-full-tests-only", False) and test_type == "quick":
             test_runs_on = ""
@@ -854,23 +851,25 @@ def _expand_build_config_for_platform(
                 f"disabling tests for quick test run"
             )
 
-        # If nightly_check_only_for_family is set for non-schedule runs, enable sanity checks
+        # If nightly_check_only_for_family is set for schedule runs only
         if (
             platform_info.get("nightly_check_only_for_family", False)
             and not ci_inputs.is_schedule
         ):
-            sanity_check_only = True
             print(
                 f"  {family_name}: nightly_check_only_for_family flag set, "
-                f"enabling sanity checks for non-schedule run"
+                f"disabling for non-scheduled runs"
             )
+            continue
 
         per_family_info.append(
             {
                 "amdgpu_family": platform_info["family"],
                 "amdgpu_targets": ",".join(platform_info["fetch-gfx-targets"]),
                 "test-runs-on": test_runs_on,
-                "sanity_check_only_for_family": sanity_check_only,
+                "sanity_check_only_for_family": platform_info.get(
+                    "sanity_check_only_for_family", False
+                ),
             }
         )
 

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -856,11 +856,11 @@ def _expand_build_config_for_platform(
             platform_info.get("nightly_check_only_for_family", False)
             and not ci_inputs.is_schedule
         ):
+            test_runs_on = ""
             print(
                 f"  {family_name}: nightly_check_only_for_family flag set, "
-                f"disabling for non-scheduled runs"
+                f"disabling test runner for non-scheduled runs"
             )
-            continue
 
         per_family_info.append(
             {

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -752,6 +752,7 @@ def _expand_build_config_for_platform(
     ci_inputs: CIInputs,
     all_families: dict[str, dict],
     variant_config: dict,
+    test_type: str,
     prebuilt_stages: list[str] | None = None,
     baseline_run_id: str = "",
 ) -> BuildConfig | None:
@@ -842,13 +843,34 @@ def _expand_build_config_for_platform(
                     f"disabling tests"
                 )
 
+        # Apply per-family test filtering flags
+        sanity_check_only = platform_info.get("sanity_check_only_for_family", False)
+
+        # If run-full-tests-only is set and test_type is "quick", disable testing
+        if platform_info.get("run-full-tests-only", False) and test_type == "quick":
+            test_runs_on = ""
+            print(
+                f"  {family_name}: run-full-tests-only flag set, "
+                f"disabling tests for quick test run"
+            )
+
+        # If nightly_check_only_for_family is set for non-schedule runs, enable sanity checks
+        if platform_info.get("nightly_check_only_for_family", False) and not ci_inputs.is_schedule:
+            sanity_check_only = True
+            print(
+                f"  {family_name}: nightly_check_only_for_family flag set, "
+                f"enabling sanity checks for non-schedule run"
+            )
+
         per_family_info.append(
             {
                 "amdgpu_family": platform_info["family"],
                 "amdgpu_targets": ",".join(platform_info["fetch-gfx-targets"]),
                 "test-runs-on": test_runs_on,
-                "sanity_check_only_for_family": platform_info.get(
-                    "sanity_check_only_for_family", False
+                "sanity_check_only_for_family": sanity_check_only,
+                "run-full-tests-only": platform_info.get("run-full-tests-only", False),
+                "nightly_check_only_for_family": platform_info.get(
+                    "nightly_check_only_for_family", False
                 ),
             }
         )
@@ -878,6 +900,7 @@ def _expand_build_config_for_platform(
 def expand_build_configs(
     targets: TargetSelection,
     ci_inputs: CIInputs,
+    test_type: str,
     prebuilt_stages: list[str] | None = None,
     baseline_run_id: str = "",
 ) -> BuildConfigs:
@@ -911,6 +934,7 @@ def expand_build_configs(
             ci_inputs=ci_inputs,
             all_families=all_families,
             variant_config=variant_config,
+            test_type=test_type,
             prebuilt_stages=prebuilt_stages,
             baseline_run_id=baseline_run_id,
         )
@@ -997,6 +1021,7 @@ def configure(ci_inputs: CIInputs, git_context: GitContext) -> CIOutputs:
     builds = expand_build_configs(
         targets=targets,
         ci_inputs=ci_inputs,
+        test_type=jobs.test_rocm.test_type,
         prebuilt_stages=jobs.build_rocm.prebuilt_stages,
         baseline_run_id=jobs.build_rocm.baseline_run_id,
     )

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -855,7 +855,10 @@ def _expand_build_config_for_platform(
             )
 
         # If nightly_check_only_for_family is set for non-schedule runs, enable sanity checks
-        if platform_info.get("nightly_check_only_for_family", False) and not ci_inputs.is_schedule:
+        if (
+            platform_info.get("nightly_check_only_for_family", False)
+            and not ci_inputs.is_schedule
+        ):
             sanity_check_only = True
             print(
                 f"  {family_name}: nightly_check_only_for_family flag set, "
@@ -868,10 +871,6 @@ def _expand_build_config_for_platform(
                 "amdgpu_targets": ",".join(platform_info["fetch-gfx-targets"]),
                 "test-runs-on": test_runs_on,
                 "sanity_check_only_for_family": sanity_check_only,
-                "run-full-tests-only": platform_info.get("run-full-tests-only", False),
-                "nightly_check_only_for_family": platform_info.get(
-                    "nightly_check_only_for_family", False
-                ),
             }
         )
 

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -598,7 +598,9 @@ class TestExpandBuildConfigs(unittest.TestCase):
     def test_empty_targets_both_none(self):
         """Empty targets on both platforms → both None."""
         targets = cm.TargetSelection()
-        result = cm.expand_build_configs(targets=targets, ci_inputs=self._inputs(), test_type="quick")
+        result = cm.expand_build_configs(
+            targets=targets, ci_inputs=self._inputs(), test_type="quick"
+        )
         self.assertIsNone(result.linux)
         self.assertIsNone(result.windows)
 
@@ -636,14 +638,14 @@ class TestExpandBuildConfigs(unittest.TestCase):
             build_variant="release",
         )
         targets = cm.select_targets(inputs)
-        result = cm.expand_build_configs(targets=targets, ci_inputs=inputs, test_type="quick")
+        result = cm.expand_build_configs(
+            targets=targets, ci_inputs=inputs, test_type="quick"
+        )
         required_keys = {
             "amdgpu_family",
             "amdgpu_targets",
             "test-runs-on",
             "sanity_check_only_for_family",
-            "run-full-tests-only",
-            "nightly_check_only_for_family",
         }
         for config in [result.linux, result.windows]:
             self.assertIsNotNone(config)
@@ -686,7 +688,9 @@ class TestExpandBuildConfigs(unittest.TestCase):
             linux_families=["gfx94x", "gfx110x"],
             windows_families=["gfx110x"],
         )
-        result = cm.expand_build_configs(targets=targets, ci_inputs=self._inputs(), test_type="quick")
+        result = cm.expand_build_configs(
+            targets=targets, ci_inputs=self._inputs(), test_type="quick"
+        )
 
         # All target families that support the variant appear in output.
         linux_per_family = result.linux.per_family_info
@@ -714,7 +718,9 @@ class TestExpandBuildConfigs(unittest.TestCase):
             windows_families=["gfx110x"],
         )
         result = cm.expand_build_configs(
-            targets=targets, ci_inputs=self._inputs(build_variant="asan"), test_type="quick"
+            targets=targets,
+            ci_inputs=self._inputs(build_variant="asan"),
+            test_type="quick",
         )
         # Only gfx94x on linux survives.
         self.assertIsNotNone(result.linux)
@@ -751,7 +757,9 @@ class TestExpandBuildConfigs(unittest.TestCase):
     def test_no_test_runner_label_uses_default(self):
         """Without test_runner: label, default runner labels are used."""
         targets = cm.TargetSelection(linux_families=["gfx1151"])
-        result = cm.expand_build_configs(targets=targets, ci_inputs=self._inputs(), test_type="quick")
+        result = cm.expand_build_configs(
+            targets=targets, ci_inputs=self._inputs(), test_type="quick"
+        )
         self.assertIsNotNone(result.linux)
         entry = result.linux.per_family_info[0]
         # Default runner, not the oem one

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1059,7 +1059,8 @@ class TestFamilyTestFilters(unittest.TestCase):
                     gfx90a_info = family_info
                     break
 
-        self.assertIsNone(gfx90a_info)
+        self.assertIsNotNone(gfx90a_info)
+        self.assertEqual(gfx90a_info["test-runs-on"], "")
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1059,44 +1059,7 @@ class TestFamilyTestFilters(unittest.TestCase):
                     gfx90a_info = family_info
                     break
 
-            # If gfx90a is in the build, it should have sanity_check_only_for_family=True
-            # for non-schedule runs (like this PR)
-            if gfx90a_info:
-                self.assertTrue(
-                    gfx90a_info["sanity_check_only_for_family"],
-                    "gfx90a should have sanity checks enabled for PR runs",
-                )
-
-    def test_real_family_gfx1151_windows_nightly_check_only(self):
-        """Integration test: gfx1151 Windows has nightly_check_only_for_family in the matrix."""
-        # gfx1151 Windows (in presubmit matrix) has nightly_check_only_for_family=True
-        ci_inputs = cm.CIInputs(
-            run_id="12345",
-            event_name="pull_request",  # Non-schedule run
-            commit_ref="feature-branch",
-            base_ref="HEAD^",
-            build_variant="release",
-        )
-        # gfx1151 is in presubmit, so it should be included by default
-        targets = cm.select_targets(ci_inputs)
-        git_context = cm.GitContext.empty()
-        outputs = cm.configure(ci_inputs, git_context)
-
-        # Find gfx1151 in the windows build config
-        if outputs.builds.windows:
-            gfx1151_info = None
-            for family_info in outputs.builds.windows.per_family_info:
-                if family_info["amdgpu_family"] == "gfx1151":
-                    gfx1151_info = family_info
-                    break
-
-            # If gfx1151 is in the build, it should have sanity_check_only_for_family=True
-            # for non-schedule runs (like this PR)
-            if gfx1151_info:
-                self.assertTrue(
-                    gfx1151_info["sanity_check_only_for_family"],
-                    "gfx1151 Windows should have sanity checks enabled for PR runs",
-                )
+        self.assertIsNone(gfx90a_info)
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -598,7 +598,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
     def test_empty_targets_both_none(self):
         """Empty targets on both platforms → both None."""
         targets = cm.TargetSelection()
-        result = cm.expand_build_configs(targets=targets, ci_inputs=self._inputs())
+        result = cm.expand_build_configs(targets=targets, ci_inputs=self._inputs(), test_type="quick")
         self.assertIsNone(result.linux)
         self.assertIsNone(result.windows)
 
@@ -636,12 +636,14 @@ class TestExpandBuildConfigs(unittest.TestCase):
             build_variant="release",
         )
         targets = cm.select_targets(inputs)
-        result = cm.expand_build_configs(targets=targets, ci_inputs=inputs)
+        result = cm.expand_build_configs(targets=targets, ci_inputs=inputs, test_type="quick")
         required_keys = {
             "amdgpu_family",
             "amdgpu_targets",
             "test-runs-on",
             "sanity_check_only_for_family",
+            "run-full-tests-only",
+            "nightly_check_only_for_family",
         }
         for config in [result.linux, result.windows]:
             self.assertIsNotNone(config)
@@ -684,7 +686,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             linux_families=["gfx94x", "gfx110x"],
             windows_families=["gfx110x"],
         )
-        result = cm.expand_build_configs(targets=targets, ci_inputs=self._inputs())
+        result = cm.expand_build_configs(targets=targets, ci_inputs=self._inputs(), test_type="quick")
 
         # All target families that support the variant appear in output.
         linux_per_family = result.linux.per_family_info
@@ -712,7 +714,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             windows_families=["gfx110x"],
         )
         result = cm.expand_build_configs(
-            targets=targets, ci_inputs=self._inputs(build_variant="asan")
+            targets=targets, ci_inputs=self._inputs(build_variant="asan"), test_type="quick"
         )
         # Only gfx94x on linux survives.
         self.assertIsNotNone(result.linux)
@@ -727,6 +729,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
         result = cm.expand_build_configs(
             targets=targets,
             ci_inputs=self._inputs(pr_labels=["test_runner:oem"]),
+            test_type="quick",
         )
         self.assertIsNotNone(result.linux)
         entry = result.linux.per_family_info[0]
@@ -739,6 +742,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
         result = cm.expand_build_configs(
             targets=targets,
             ci_inputs=self._inputs(pr_labels=["test_runner:oem"]),
+            test_type="quick",
         )
         self.assertIsNotNone(result.linux)
         entry = result.linux.per_family_info[0]
@@ -747,7 +751,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
     def test_no_test_runner_label_uses_default(self):
         """Without test_runner: label, default runner labels are used."""
         targets = cm.TargetSelection(linux_families=["gfx1151"])
-        result = cm.expand_build_configs(targets=targets, ci_inputs=self._inputs())
+        result = cm.expand_build_configs(targets=targets, ci_inputs=self._inputs(), test_type="quick")
         self.assertIsNotNone(result.linux)
         entry = result.linux.per_family_info[0]
         # Default runner, not the oem one
@@ -937,7 +941,7 @@ class TestDualLabelRunnerSelection(unittest.TestCase):
 
         # Mock random.random() to return 0.1 (< 0.2 weight)
         with patch("random.random", return_value=0.1):
-            builds = cm.expand_build_configs(targets, ci_inputs)
+            builds = cm.expand_build_configs(targets, ci_inputs, test_type="quick")
 
         self.assertIsNotNone(builds.linux)
         # Check that the alternate label was selected
@@ -959,7 +963,7 @@ class TestDualLabelRunnerSelection(unittest.TestCase):
 
         # Mock random.random() to return 0.5 (>= 0.2 weight)
         with patch("random.random", return_value=0.5):
-            builds = cm.expand_build_configs(targets, ci_inputs)
+            builds = cm.expand_build_configs(targets, ci_inputs, test_type="quick")
 
         self.assertIsNotNone(builds.linux)
         # Check that the primary label was selected
@@ -977,7 +981,7 @@ class TestDualLabelRunnerSelection(unittest.TestCase):
                 build_variant="release",
             )
             targets = cm.TargetSelection(linux_families=["gfx94x"])
-            builds = cm.expand_build_configs(targets, ci_inputs)
+            builds = cm.expand_build_configs(targets, ci_inputs, test_type="quick")
             gfx94x_info = builds.linux.per_family_info[0]
             self.assertEqual(
                 gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm"
@@ -994,7 +998,7 @@ class TestDualLabelRunnerSelection(unittest.TestCase):
                 build_variant="release",
             )
             targets = cm.TargetSelection(linux_families=["gfx94x"])
-            builds = cm.expand_build_configs(targets, ci_inputs)
+            builds = cm.expand_build_configs(targets, ci_inputs, test_type="quick")
             gfx94x_info = builds.linux.per_family_info[0]
             self.assertEqual(
                 gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ccs-ossci-rocm"
@@ -1014,11 +1018,77 @@ class TestDualLabelRunnerSelection(unittest.TestCase):
 
         # Run multiple times to ensure consistency
         for _ in range(10):
-            builds = cm.expand_build_configs(targets, ci_inputs)
+            builds = cm.expand_build_configs(targets, ci_inputs, test_type="quick")
             if builds.linux and builds.linux.per_family_info:
                 gfx103x_info = builds.linux.per_family_info[0]
                 # Should always use the primary label
                 self.assertEqual(gfx103x_info["test-runs-on"], "linux-gfx1030-gpu-rocm")
+
+
+class TestFamilyTestFilters(unittest.TestCase):
+    """Tests for run-full-tests-only and nightly_check_only_for_family behavior."""
+
+    def test_real_family_gfx90a_nightly_check_only(self):
+        """Integration test: gfx90a has nightly_check_only_for_family in the matrix."""
+        # gfx90a (in nightly matrix) has nightly_check_only_for_family=True for linux
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="pull_request",  # Non-schedule run
+            commit_ref="feature-branch",
+            base_ref="HEAD^",
+            build_variant="release",
+            pr_labels=["ci:run-all-archs"],  # Include gfx90a from nightly matrix
+        )
+        targets = cm.select_targets(ci_inputs)
+        git_context = cm.GitContext.empty()
+        outputs = cm.configure(ci_inputs, git_context)
+
+        # Find gfx90a in the linux build config
+        if outputs.builds.linux:
+            gfx90a_info = None
+            for family_info in outputs.builds.linux.per_family_info:
+                if family_info["amdgpu_family"] == "gfx90a":
+                    gfx90a_info = family_info
+                    break
+
+            # If gfx90a is in the build, it should have sanity_check_only_for_family=True
+            # for non-schedule runs (like this PR)
+            if gfx90a_info:
+                self.assertTrue(
+                    gfx90a_info["sanity_check_only_for_family"],
+                    "gfx90a should have sanity checks enabled for PR runs",
+                )
+
+    def test_real_family_gfx1151_windows_nightly_check_only(self):
+        """Integration test: gfx1151 Windows has nightly_check_only_for_family in the matrix."""
+        # gfx1151 Windows (in presubmit matrix) has nightly_check_only_for_family=True
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="pull_request",  # Non-schedule run
+            commit_ref="feature-branch",
+            base_ref="HEAD^",
+            build_variant="release",
+        )
+        # gfx1151 is in presubmit, so it should be included by default
+        targets = cm.select_targets(ci_inputs)
+        git_context = cm.GitContext.empty()
+        outputs = cm.configure(ci_inputs, git_context)
+
+        # Find gfx1151 in the windows build config
+        if outputs.builds.windows:
+            gfx1151_info = None
+            for family_info in outputs.builds.windows.per_family_info:
+                if family_info["amdgpu_family"] == "gfx1151":
+                    gfx1151_info = family_info
+                    break
+
+            # If gfx1151 is in the build, it should have sanity_check_only_for_family=True
+            # for non-schedule runs (like this PR)
+            if gfx1151_info:
+                self.assertTrue(
+                    gfx1151_info["sanity_check_only_for_family"],
+                    "gfx1151 Windows should have sanity checks enabled for PR runs",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #4184 , covering gaps from `ci.yml` to `multi_arch_ci.yml`. 

Right now, `multi_arch_ci.yml` does not cover `nightly_check_only_for_family` and `run-full-tests-only`, but this PR updates that and runs the architectures during the proper scheduled run or full-test run


