### PR TITLE
  [CI] Add timeout and retry environment variables for actions-prolense support

### DIFF
--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -76,7 +76,7 @@ runs:
         RELEASE_TYPE: ${{ inputs.RELEASE_TYPE }}
         GITHUB_TOKEN: ${{ github.token }}
         STEP_NAME: "Download and Unpack Artifacts"
-        STEP_TIMEOUT_TOLERANCE: "2" 
+        STEP_TIMEOUT_TOLERANCE: "2"
       run: |
         python ./build_tools/install_rocm_from_artifacts.py \
           --run-id=${ARTIFACT_RUN_ID} \

--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -75,6 +75,7 @@ runs:
         FETCH_ARTIFACT_ARGS: ${{ inputs.FETCH_ARTIFACT_ARGS }}
         RELEASE_TYPE: ${{ inputs.RELEASE_TYPE }}
         GITHUB_TOKEN: ${{ github.token }}
+        STEP_NAME: "Download and Unpack Artifacts"
       run: |
         python ./build_tools/install_rocm_from_artifacts.py \
           --run-id=${ARTIFACT_RUN_ID} \

--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -76,6 +76,7 @@ runs:
         RELEASE_TYPE: ${{ inputs.RELEASE_TYPE }}
         GITHUB_TOKEN: ${{ github.token }}
         STEP_NAME: "Download and Unpack Artifacts"
+        STEP_TIMEOUT_TOLERANCE: "2" 
       run: |
         python ./build_tools/install_rocm_from_artifacts.py \
           --run-id=${ARTIFACT_RUN_ID} \

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -167,6 +167,7 @@ jobs:
           RETRY_THIS_STEP: "true"
           RETRY_COUNT: "1"
           RETRY_DELAY: "7"
+          STEP_TIMEOUT_MINUTES: ${{ fromJSON(inputs.component).timeout_minutes }}
           STEP_NAME: >-
             Test ${{ fromJSON(inputs.component).job_name }}
             (shard ${{ matrix.shard }}/${{ fromJSON(inputs.component).total_shards }})

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -109,6 +109,9 @@ jobs:
 
       - name: Run setup test environment workflow
         timeout-minutes: 15
+        env:
+          RETRY_THIS_STEP: "true"
+          STEP_TIMEOUT_MINUTES: "15" # should match timeout-minutes specified above at this step
         uses: './.github/actions/setup_test_environment'
         with:
           ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}


### PR DESCRIPTION
  ## Summary

  Add environment variables to support actions-prolense timeout monitoring and retry functionality in test workflows. This PR enhances the test_component workflow and setup_test_environment action with environment variables needed for the prolense monitoring system.

  ## Changes

  Modified Files:
  - .github/actions/setup_test_environment/action.yml
  - .github/workflows/test_component.yml

  ## Details

  Added the following environment variables to enable prolense timeout monitoring:

  **In setup_test_environment action (Download and Unpack Artifacts step):**
  - `STEP_NAME: "Download and Unpack Artifacts"` - Provides step name for dashboard visualization
  - `STEP_TIMEOUT_TOLERANCE: "2"` - Sets timeout tolerance in minutes for the download step

  **In test_component workflow (Setup test environment step):**
  - `RETRY_THIS_STEP: "true"` - Enables retry logic for environment setup
  - `STEP_TIMEOUT_MINUTES: "15"` - Matches the timeout-minutes specified in the workflow step

  **In test_component workflow (Test execution step):**
  - `STEP_TIMEOUT_MINUTES` - Dynamically set from component configuration for test timeout tracking

  These variables enable the actions-prolense monitoring system to:
  1. Track step execution time against configured timeouts
  2. Apply timeout tolerance before marking steps as timed out
  3. Automatically retry steps when transient failures occur
  4. Provide consistent step naming for dashboard visualization

  For non-prolense orchestrated runners, these variables are ignored and have no effect on workflow execution. 