### PR TITLE
Port kpack-split wiring to Windows workflows

### DIFF
--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -56,6 +56,9 @@ on:
       package_find_links_url:
         description: URL for pip --find-links to install built packages
         value: ${{ jobs.build_rocm_wheels.outputs.package_find_links_url }}
+      kpack_split:
+        description: "true if this is a kpack-split flat build, false for legacy per-family"
+        value: ${{ jobs.build_rocm_wheels.outputs.kpack_split }}
 
 permissions:
   contents: read
@@ -70,6 +73,7 @@ jobs:
       id-token: write
     outputs:
       package_find_links_url: ${{ steps.upload.outputs.package_find_links_url }}
+      kpack_split: ${{ steps.upload.outputs.kpack_split }}
     env:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
       ARTIFACTS_DIR: "${{ github.workspace }}/artifacts"
@@ -99,6 +103,7 @@ jobs:
               --run-github-repo="${{ inputs.artifact_github_repo }}" \
               --stage=all \
               --amdgpu-families="${{ inputs.amdgpu_families }}" \
+              --expand-family-to-targets \
               --output-dir="${{ github.workspace }}"
               # NOTE: artifact_manager.py appends /artifacts to --output-dir
               # in non-flatten mode, so pass workspace root here so that

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -46,7 +46,7 @@ on:
       amdgpu_targets:
         description: >-
           Comma-separated individual gfx targets for kpack-split builds
-          (e.g. 'gfx942' or 'gfx1200,gfx1201'). Used to install the correct
+          (e.g. 'gfx1151' or 'gfx1200,gfx1201'). Used to install the correct
           per-target device wheels. Leave empty for legacy per-family builds.
         type: string
         default: ""

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -192,7 +192,7 @@ jobs:
         id: device_extras
         run: |
           if [ "${{ inputs.kpack_split }}" = "true" ] && [ -n "${{ inputs.amdgpu_targets }}" ]; then
-            # Prefix each comma-separated target with "device-": gfx942,gfx1201 -> device-gfx942,device-gfx1201
+            # Prefix each comma-separated target with "device-": gfx1151,gfx1201 -> device-gfx1151,device-gfx1201
             extras=$(echo "${{ inputs.amdgpu_targets }}" | sed 's/\(^\|,\)/\1device-/g')
             echo "value=${extras}" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -43,6 +43,17 @@ on:
         required: false
         type: string
         default: "none"
+      amdgpu_targets:
+        description: >-
+          Comma-separated individual gfx targets for kpack-split builds
+          (e.g. 'gfx942' or 'gfx1200,gfx1201'). Used to install the correct
+          per-target device wheels. Leave empty for legacy per-family builds.
+        type: string
+        default: ""
+      kpack_split:
+        description: "'true' if this is a kpack-split flat build."
+        type: string
+        default: "false"
   workflow_dispatch:
     inputs:
       artifact_group:
@@ -177,6 +188,17 @@ jobs:
           echo "SCCACHE_BUCKET=${SCCACHE_BUCKET}"
           echo "SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX}"
 
+      - name: Compute ROCm device extras
+        id: device_extras
+        run: |
+          if [ "${{ inputs.kpack_split }}" = "true" ] && [ -n "${{ inputs.amdgpu_targets }}" ]; then
+            # Prefix each comma-separated target with "device-": gfx942,gfx1201 -> device-gfx942,device-gfx1201
+            extras=$(echo "${{ inputs.amdgpu_targets }}" | sed 's/\(^\|,\)/\1device-/g')
+            echo "value=${extras}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=" >> "$GITHUB_OUTPUT"
+          fi
+
       # Using 'cmd' here is load bearing! There are configuration issues when
       # run under 'bash': https://github.com/ROCm/TheRock/issues/827#issuecomment-3025858800
       - name: Build PyTorch wheels
@@ -185,6 +207,9 @@ jobs:
           set "CACHE_FLAG="
           if "${{ inputs.cache_type }}"=="sccache" set "CACHE_FLAG=--use-sccache"
           if "${{ inputs.cache_type }}"=="ccache" set "CACHE_FLAG=--use-ccache"
+
+          set "ROCM_EXTRAS_FLAG="
+          if not "${{ steps.device_extras.outputs.value }}"=="" set "ROCM_EXTRAS_FLAG=--rocm-extras ${{ steps.device_extras.outputs.value }}"
 
           echo "Building PyTorch wheels for ${{ inputs.artifact_group }} (cache: ${{ inputs.cache_type }})"
           python ./external-builds/pytorch/build_prod_wheels.py ^
@@ -196,6 +221,7 @@ jobs:
             --clean ^
             --output-dir ${{ env.PACKAGE_DIST_DIR }} ^
             %CACHE_FLAG% ^
+            %ROCM_EXTRAS_FLAG% ^
             ${{ env.optional_build_prod_arguments }}
 
       - name: Report cache stats

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -148,9 +148,20 @@ jobs:
     with:
       amdgpu_family: ${{ matrix.family_info.amdgpu_family }}
       test_runs_on: ${{ matrix.family_info.test-runs-on }}
-      package_find_links_url: "${{ needs.build_python_packages.outputs.package_find_links_url }}/${{ matrix.family_info.amdgpu_family }}/index.html"
+      # TODO: Simplify to just `needs.build_python_packages.outputs.package_find_links_url`
+      # once kpack split is always enabled.
+      package_find_links_url: >-
+        ${{
+          needs.build_python_packages.outputs.kpack_split == 'true'
+          && needs.build_python_packages.outputs.package_find_links_url
+          || format('{0}/{1}/index.html',
+              needs.build_python_packages.outputs.package_find_links_url,
+              matrix.family_info.amdgpu_family)
+        }}
       python_version: "3.12"
       rocm_version: ${{ inputs.rocm_package_version }}
+      amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
+      kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
 
   # NOTE: Per-family PyTorch builds — each family gets its own wheel built
   # against that family's ROCm package index slice.
@@ -169,7 +180,16 @@ jobs:
       artifact_group: ${{ matrix.family_info.amdgpu_family }}
       python_version: "3.12"
       pytorch_git_ref: "release/2.10"
-      rocm_package_find_links_url: "${{ needs.build_python_packages.outputs.package_find_links_url }}/${{ matrix.family_info.amdgpu_family }}/index.html"
+      amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
+      kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
+      rocm_package_find_links_url: >-
+        ${{
+          needs.build_python_packages.outputs.kpack_split == 'true'
+          && needs.build_python_packages.outputs.package_find_links_url
+          || format('{0}/{1}/index.html',
+              needs.build_python_packages.outputs.package_find_links_url,
+              matrix.family_info.amdgpu_family)
+        }}
       rocm_version: ${{ inputs.rocm_package_version }}
     permissions:
       contents: read


### PR DESCRIPTION
Port kpack-split Python packages wiring added with commit 0258e5e9 to the Windows CI equivalents.

Legacy per-family builds are unaffected — all new inputs default to empty/false.
