### PR TITLE
Add 'rand' to artifact_deps in BUILD_TOPOLOGY.toml for prim library

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -565,7 +565,7 @@ artifact_deps = ["core-runtime", "core-hip"]
 [artifacts.prim]
 artifact_group = "math-libs"
 type = "target-specific"
-artifact_deps = ["core-runtime", "core-hip"]
+artifact_deps = ["core-runtime", "core-hip", "rand"]
 
 [artifacts.sparse]
 artifact_group = "math-libs"


### PR DESCRIPTION
## Motivation

When bumping TheRock back to rocm-libraries, hit an issue with rocthrust missing rand, https://github.com/ROCm/rocm-libraries/issues/6435#issuecomment-4248868685

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
