### PR TITLE
fix find artifacts to look at index.html now when using find_latest_artifacts.py

### DIFF
--- a/build_tools/find_artifacts_for_commit.py
+++ b/build_tools/find_artifacts_for_commit.py
@@ -74,7 +74,7 @@ class ArtifactRunInfo:
 
     @property
     def s3_index_url(self) -> str:
-        return f"https://{self.s3_bucket}.s3.amazonaws.com/{self.s3_path}index-{self.artifact_group}.html"
+        return f"https://{self.s3_bucket}.s3.amazonaws.com/{self.s3_path}index.html"
 
     def print(self):
         """Prints artifact info in a human-readable format."""


### PR DESCRIPTION
## Motivation

Want to be able to pull latest nightly artifacts, the latest artifacts are now found at index.html and not index-{artifact_group}.html.  
