### PR TITLE
[torch] Skip test_mempool_expandable test for torch 2.11

### DIFF
--- a/external-builds/pytorch/skip_tests/pytorch_2.11.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.11.py
@@ -32,6 +32,9 @@ skip_tests = {
             "test_tensor_delete_after_allocator_delete",
             # RuntimeError: Error building extension 'dummy_allocator'
             "test_deleted_mempool_not_used_on_oom",
+            # Same hipblas.h compilation error as test_mempool_with_allocator.
+            # See https://github.com/pytorch/pytorch/pull/173330
+            "test_mempool_expandable",
             # ModuleNotFoundError: No module named 'torchvision'
             "test_resnet",
             # RuntimeError: miopenStatusUnknownError


### PR DESCRIPTION
## Motivation
Fixes https://github.com/ROCm/TheRock/issues/4524

`test_mempool_expandable` was recently enabled for ROCm for torch 2.11 with https://github.com/ROCm/pytorch/pull/3106 and requires building `dummy_allocator` (which require the rocm[devel] packages). This test was previously skipped for ROCm and is currently skipped for torch 2.12: https://github.com/ROCm/TheRock/blob/3faaafaf8b72c1e500ff99be0616773ecdb64a52/external-builds/pytorch/skip_tests/pytorch_2.12.py#L17 
Adding to skip list for torch 2.11, this is not present in 2.8-2.10, so I didn't want to add it to the generic skip list.
 <!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

- Added `test_mempool_expandable` to `external-builds/pytorch/skip_tests/pytorch_2.11.py` to skip the test
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

- Verify that the tests are unblocked
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
- Tests are unblocked: https://github.com/ROCm/TheRock/actions/runs/24415633738/job/71323862312
- The remaining failures are not related to this test and are reported in other issues
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
