### PR TITLE
[kpack] Upgrade patchelf to a later post 0.18 build from source.

### DIFF
--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -84,13 +84,6 @@ RUN yum install -y epel-release && \
     && yum clean all && \
     rm -rf /var/cache/yum
 
-######## PatchELF ########
-WORKDIR /install-patchelf
-ENV PATCHELF_GIT_REF="d0f70eea5397606c486857e0a105e53ec123904a"
-COPY install_patchelf.sh ./
-RUN ./install_patchelf.sh "${PATCHELF_GIT_REF}" && rm -rf /install-patchelf
-
-
 ######## DVC via pip ######
 # dvc's rpm package includes .so dependencies built against glib 2.29
 # settling for pip install for now, but it installs modules not needed for dvc pull
@@ -121,6 +114,13 @@ ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-1
 RUN which gcc && gcc --version && \
     which g++ && g++ --version && \
     which clang++ || true
+
+######## PatchELF ########
+# Note: requires newer gcc toolset so after gcc activation
+WORKDIR /install-patchelf
+ENV PATCHELF_GIT_REF="d0f70eea5397606c486857e0a105e53ec123904a"
+COPY install_patchelf.sh ./
+RUN ./install_patchelf.sh "${PATCHELF_GIT_REF}" && rm -rf /install-patchelf
 
 ######## Shared Python Interpreters ########
 # Build Python with --enable-shared for embedding (e.g., rocgdb).

--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -76,7 +76,6 @@ RUN yum install -y epel-release && \
       gcc-toolset-13-gcc-gfortran \
       gcc-toolset-13-libatomic-devel \
       gcc-toolset-13-libstdc++-devel \
-      patchelf \
       vim-common \
       git-lfs \
     && yum install -y \
@@ -84,6 +83,12 @@ RUN yum install -y epel-release && \
       flex \
     && yum clean all && \
     rm -rf /var/cache/yum
+
+######## PatchELF ########
+WORKDIR /install-patchelf
+ENV PATCHELF_GIT_REF="d0f70eea5397606c486857e0a105e53ec123904a"
+COPY install_patchelf.sh ./
+RUN ./install_patchelf.sh "${PATCHELF_GIT_REF}" && rm -rf /install-patchelf
 
 
 ######## DVC via pip ######

--- a/dockerfiles/install_patchelf.sh
+++ b/dockerfiles/install_patchelf.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2026 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -euo pipefail
+
+PATCHELF_GIT_REF="${1:?usage: $0 <NixOS/patchelf git ref>}"
+INSTALL_PREFIX="${INSTALL_PREFIX:-/usr/local}"
+SOURCE_URL="https://github.com/NixOS/patchelf/archive/${PATCHELF_GIT_REF}.tar.gz"
+SHORT_GIT_REF="${PATCHELF_GIT_REF:0:12}"
+
+# The PyPA manylinux base image installs a pipx patchelf at /usr/local/bin.
+# Remove that known install before installing our pinned source build so PATH
+# cannot silently resolve back to the base image copy.
+PIPX_PATCHELF_VENV="/opt/_internal/pipx/venvs/patchelf"
+PIPX_PATCHELF_BIN="${PIPX_PATCHELF_VENV}/bin/patchelf"
+if [ "$(readlink /usr/local/bin/patchelf || true)" = "${PIPX_PATCHELF_BIN}" ]; then
+    rm -f /usr/local/bin/patchelf
+fi
+rm -rf "${PIPX_PATCHELF_VENV}"
+
+curl --silent --fail --show-error --location \
+    "${SOURCE_URL}" \
+    --output patchelf.tar.gz
+
+mkdir -p src
+tar -xzf patchelf.tar.gz --strip-components=1 -C src
+
+cd src
+BASE_VERSION="$(cat version)"
+LOCAL_VERSION="${BASE_VERSION}+therock.${SHORT_GIT_REF}"
+printf "%s\n" "${LOCAL_VERSION}" > version
+./bootstrap.sh
+./configure --prefix="${INSTALL_PREFIX}"
+make -j"$(nproc)"
+make install
+
+hash -r
+test "$(command -v patchelf)" = "${INSTALL_PREFIX}/bin/patchelf"
+patchelf --version


### PR DESCRIPTION
This fixes a specific bug when attempting to patchelf a file that has already had its PHDR relocated. This builds at d0f70eea5397606c486857e0a105e53ec123904a which has the fix for this exact situation and should be part of the next release. Note that Fedora already back-ported this patch for reasons of their own, giving further credence to the finding.

Fixes #4561
