### PR TITLE
Add missing explicit dep from fft to rand artifact in BUILD_TOPOLOGY.toml

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -552,15 +552,15 @@ type = "target-specific"
 artifact_deps = ["core-runtime", "core-hip", "core-amdsmi", "host-blas", "host-suite-sparse", "rocprofiler-sdk", "spdlog"]
 split_databases = ["rocblas", "hipblaslt"]
 
-[artifacts.fft]
-artifact_group = "math-libs"
-type = "target-specific"
-artifact_deps = ["core-runtime", "core-hip", "fftw3", "rocprofiler-sdk"]
-
 [artifacts.rand]
 artifact_group = "math-libs"
 type = "target-specific"
 artifact_deps = ["core-runtime", "core-hip"]
+
+[artifacts.fft]
+artifact_group = "math-libs"
+type = "target-specific"
+artifact_deps = ["core-runtime", "core-hip", "fftw3", "rand", "rocprofiler-sdk"]
 
 [artifacts.prim]
 artifact_group = "math-libs"


### PR DESCRIPTION
## Motivation

Similar to https://github.com/ROCm/rocm-libraries/issues/6435 (fixed by https://github.com/ROCm/TheRock/pull/4553), configuring with `-DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_FFT=ON` fails as this dep was missing from the topology:
```
[cmake] -- Including subproject rocFFT (from D:/projects/TheRock/rocm-libraries/projects/rocfft)
[cmake] CMake Error at cmake/therock_subproject.cmake:1222 (get_target_property):
[cmake]   get_target_property() called with non-existent target "hipRAND".
[cmake] Call Stack (most recent call first):
[cmake]   cmake/therock_subproject.cmake:1322 (_therock_assert_is_cmake_subproject)
[cmake]   cmake/therock_subproject.cmake:401 (_therock_cmake_subproject_collect_build_deps)
[cmake]   math-libs/CMakeLists.txt:235 (therock_cmake_subproject_declare)
[cmake] 
[cmake] 
[cmake] CMake Error at cmake/therock_subproject.cmake:1323 (get_target_property):
[cmake]   get_target_property() called with non-existent target "hipRAND".
[cmake] Call Stack (most recent call first):
[cmake]   cmake/therock_subproject.cmake:401 (_therock_cmake_subproject_collect_build_deps)
[cmake]   math-libs/CMakeLists.txt:235 (therock_cmake_subproject_declare)
```

## Technical Details

See where `rocFFT` takes a dep on `hipRAND` here: https://github.com/ROCm/TheRock/blob/7b942606d986f47bbd5a8f3b4e8ce41fd7a065e5/math-libs/CMakeLists.txt#L235-L260

I detected this via some new validation that I prototyped at https://github.com/ScottTodd/TheRock/commit/7d3b938a8fb639c25158ec88e5a66ab914c130f5:
```
[cmake] CMake Error at cmake/therock_topology_validation.cmake:95 (message):
[cmake]   Topology validation failed: CMake subproject dependencies are not reflected
[cmake]   in BUILD_TOPOLOGY.toml.
[cmake]
# note: there were false positives here for deps on 'rocm-cmake', 'therock-flatbuffers', etc.
[cmake]
[cmake]   Subproject 'rocFFT' (artifact 'fft') depends on 'rocRAND' (artifact
[cmake]   'rand'), but BUILD_TOPOLOGY.toml has no dependency path from 'fft' to
[cmake]   'rand'.  Add 'rand' to artifact_deps for 'fft' in BUILD_TOPOLOGY.toml.
[cmake]
[cmake]   Subproject 'rocFFT' (artifact 'fft') depends on 'hipRAND' (artifact
[cmake]   'rand'), but BUILD_TOPOLOGY.toml has no dependency path from 'fft' to
[cmake]   'rand'.  Add 'rand' to artifact_deps for 'fft' in BUILD_TOPOLOGY.toml.
[cmake]
[cmake]   Subproject 'hipFFT' (artifact 'fft') depends on 'rocRAND' (artifact
[cmake]   'rand'), but BUILD_TOPOLOGY.toml has no dependency path from 'fft' to
[cmake]   'rand'.  Add 'rand' to artifact_deps for 'fft' in BUILD_TOPOLOGY.toml.
[cmake]
[cmake]   Subproject 'hipFFT' (artifact 'fft') depends on 'hipRAND' (artifact
[cmake]   'rand'), but BUILD_TOPOLOGY.toml has no dependency path from 'fft' to
[cmake]   'rand'.  Add 'rand' to artifact_deps for 'fft' in BUILD_TOPOLOGY.toml.
```

## Test Plan

CI builds should continue to work. May land the validation code separately.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
