### PR TITLE
increasing timeout for hipsparselt from 30min to 40min

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -242,7 +242,7 @@ test_matrix = {
     "hipsparselt": {
         "job_name": "hipsparselt",
         "fetch_artifact_args": "--blas --tests",
-        "timeout_minutes": 30,
+        "timeout_minutes": 40,
         "test_script": f"python {_get_script_path('test_hipsparselt.py')}",
         "platform": ["linux"],
         "total_shards_dict": {


### PR DESCRIPTION
## Motivation
Seeing intermittent test failures on the rock CI due to hipsparselt timeout. In depeth debug is pending on why its seen often now

few example for bump PR runs which failed 
failed runs - https://github.com/ROCm/TheRock/actions/runs/24430275482/job/71383748833?pr=4550#step:12:47834
passed run - https://github.com/ROCm/TheRock/actions/runs/24454409629/job/71475441495#step:12:1

This pull request makes a minor adjustment to the test configuration for the `hipsparselt` job by increasing its timeout limit.

- Increased the `timeout_minutes` for the `hipsparselt` job from 30 to 40 in the `fetch_test_configurations.py` script to allow more time for tests to complete.

## Test
Manual dispatch - https://github.com/ROCm/TheRock/actions/runs/24469151740  - multi arch
https://github.com/ROCm/TheRock/actions/runs/24470375653 - ci.yml