### PR TITLE
[ci] Add python3-pip to no_rocm_image_UBI10 for venv/wheel testing

### DIFF
--- a/dockerfiles/no_rocm_image_ubi10.Dockerfile
+++ b/dockerfiles/no_rocm_image_ubi10.Dockerfile
@@ -37,6 +37,7 @@ RUN sudo dnf install -y --nodocs git-lfs \
     && sudo dnf clean all
 
 RUN sudo dnf install -y --nodocs python3-pip python3-setuptools python3-wheel \
+    python-unversioned-command \
     && sudo dnf clean all
 
 WORKDIR /home/tester/

--- a/dockerfiles/no_rocm_image_ubi10.Dockerfile
+++ b/dockerfiles/no_rocm_image_ubi10.Dockerfile
@@ -36,7 +36,7 @@ RUN sudo dnf install -y --nodocs \
 RUN sudo dnf install -y --nodocs git-lfs \
     && sudo dnf clean all
 
-RUN sudo dnf install -y --nodocs python3-setuptools python3-wheel \
+RUN sudo dnf install -y --nodocs python3-pip python3-setuptools python3-wheel \
     && sudo dnf clean all
 
 WORKDIR /home/tester/


### PR DESCRIPTION
Prerequisite of https://github.com/ROCm/TheRock/pull/4248

## Motivation

Avoids the need for the use of `actions/setup-python` within the `test_rocm_wheels` workflow for non-Ubuntu images, which fails for the UBI 10 image with `The version '3.12' with architecture 'x64' was not found for this operating system` (see [job](https://github.com/ROCm/TheRock/actions/runs/24359050466/job/71158930177?pr=4248)). To be paired with https://github.com/ROCm/TheRock/pull/4248 which skips `actions/setup-python` as it does not seem to support UBI and UBI 10 ships `python3 -> python3.12`.

## Technical Details

On UBI 10, `python3-pip` is a separate package. Without it, `ensurepip` has no `pip` to bootstrap into the `venv`, and `pip` commands would fail. The original Dockerfile only had `python3-setuptools` and `python3-wheel` which is sufficient when `actions/setup-python` was providing the full Python, but not when relying on the system Python.

`python-unversioned-command` is a RHEL/Fedora package that creates the `/usr/bin/python -> /usr/bin/python3` symlink.

## Test Plan

Build and test locally, ensure `pip` is provided and manual `venv` creation is successful so we can alley-oop this to `build_tools/setup_venv.py` in the workflow later.

## Test Result

UBI 10 Test ROCm Wheels job (https://github.com/ROCm/TheRock/actions/runs/24472320710/job/71518385301) passed using published image with this change.

```
docker run --rm no_rocm_image_ubi10:test bash -c "python --version && pip     
      --version && python -m venv /tmp/test_venv && /tmp/test_venv/bin/python        
      --version && e…)                                                               
  ⎿  Python 3.12.12                                                               
     pip 23.3.2 from /usr/lib/python3.12/site-packages/pip (python 3.12)             
     Python 3.12.12                                                                  
     venv creation: OK

python command resolves (via python-unversioned-command)
  - pip available (via python3-pip)
  - python -m venv creates a venv successfully
```

Image published via `workflow_dispatch`: https://github.com/ROCm/TheRock/actions/runs/24471951108/job/71514250267
(`sha256:a10f34d6006a20d02cf688982de9dea147710927ed405a3b0d5c73b58a6030c0`)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
