### PR TITLE
Pass --release-type through upload_tarballs.py explicitly

### DIFF
--- a/.github/workflows/multi_arch_build_tarballs.yml
+++ b/.github/workflows/multi_arch_build_tarballs.yml
@@ -99,4 +99,5 @@ jobs:
           python build_tools/github_actions/upload_tarballs.py \
             --input-tarballs-dir="${{ github.workspace }}/tarballs" \
             --run-id="${{ github.run_id }}" \
-            --platform="${{ inputs.platform }}"
+            --platform="${{ inputs.platform }}" \
+            --release-type="${{ inputs.release_type }}"

--- a/build_tools/_therock_utils/workflow_outputs.py
+++ b/build_tools/_therock_utils/workflow_outputs.py
@@ -226,6 +226,7 @@ class WorkflowOutputRoot:
         github_repository: str | None = None,
         workflow_run: dict | None = None,
         lookup_workflow_run: bool = False,
+        release_type: str | None = None,
     ) -> "WorkflowOutputRoot":
         """Create from CI workflow context.
 
@@ -245,6 +246,8 @@ class WorkflowOutputRoot:
                 Most callers running inside their own CI workflow do not need
                 this — environment variables suffice. Set this when looking up
                 another repository's workflow run (e.g. fetching artifacts).
+            release_type: Release type override (e.g. "dev", "nightly"). If
+                None, falls back to the RELEASE_TYPE environment variable.
         """
         workflow_run_id = (
             run_id if lookup_workflow_run and workflow_run is None else None
@@ -253,6 +256,7 @@ class WorkflowOutputRoot:
             github_repository=github_repository,
             workflow_run_id=workflow_run_id,
             workflow_run=workflow_run,
+            release_type=release_type,
         )
         return cls(
             bucket=bucket,
@@ -289,6 +293,7 @@ def _retrieve_bucket_info(
     github_repository: str | None = None,
     workflow_run_id: str | None = None,
     workflow_run: dict | None = None,
+    release_type: str | None = None,
 ) -> tuple[str, str]:
     """Determine S3 bucket and external_repo prefix for a workflow run.
 
@@ -305,6 +310,7 @@ def _retrieve_bucket_info(
 
     artifact_bucket_config = get_artifacts_bucket_config_for_workflow_run(
         github_repository=github_repository,
+        release_type=release_type,
         workflow_run_id=workflow_run_id,
         workflow_run=workflow_run,
     )

--- a/build_tools/github_actions/upload_tarballs.py
+++ b/build_tools/github_actions/upload_tarballs.py
@@ -7,24 +7,25 @@
 Uploads all .tar.gz files from the input directory to the tarballs/
 subdirectory of the workflow output root in S3.
 
+Example with ``--run-id 12345 --platform linux --release-type dev``:
+
+    /tmp/tarballs/therock-dist-linux-gfx94X-dcgpu-7.10.0.tar.gz
+      -> s3://therock-dev-artifacts/12345-linux/tarballs/therock-dist-linux-gfx94X-dcgpu-7.10.0.tar.gz
+
 Usage:
-    upload_tarballs.py --input-tarballs-dir TARBALLS_DIR --run-id RUN_ID [--platform PLATFORM]
-
-Manual testing:
-    # Test with local output (no S3 credentials needed):
     python build_tools/github_actions/upload_tarballs.py \\
         --input-tarballs-dir /tmp/tarballs \\
-        --run-id 12345 \\
-        --platform linux \\
+        --run-id 12345 --platform linux --release-type dev
+
+    python build_tools/github_actions/upload_tarballs.py \\
+        --input-tarballs-dir /tmp/tarballs \\
+        --run-id 12345 --platform linux --release-type dev --dry-run
+
+    # Local testing (no S3 credentials needed):
+    python build_tools/github_actions/upload_tarballs.py \\
+        --input-tarballs-dir /tmp/tarballs \\
+        --run-id 12345 --platform linux \\
         --output-dir /tmp/upload-test
-
-    # Verify: /tmp/upload-test/12345-linux/tarballs/*.tar.gz
-
-    # Dry run (prints plan without uploading):
-    python build_tools/github_actions/upload_tarballs.py \\
-        --input-tarballs-dir /tmp/tarballs \\
-        --run-id 12345 \\
-        --dry-run
 """
 
 import argparse
@@ -57,6 +58,11 @@ def main():
         type=str,
         required=True,
         help="Workflow run ID",
+    )
+    parser.add_argument(
+        "--release-type",
+        default="",
+        help='Release type: "" for CI, or "dev", "nightly", "prerelease"',
     )
     parser.add_argument(
         "--output-dir",
@@ -95,7 +101,9 @@ def main():
         log(f"  {f.name} ({size_mb:.1f} MB)")
 
     output_root = WorkflowOutputRoot.from_workflow_run(
-        run_id=args.run_id, platform=args.platform
+        run_id=args.run_id,
+        platform=args.platform,
+        release_type=args.release_type or None,
     )
     tarballs_loc = output_root.tarballs()
     backend = create_storage_backend(staging_dir=args.output_dir, dry_run=args.dry_run)

--- a/build_tools/tests/workflow_outputs_test.py
+++ b/build_tools/tests/workflow_outputs_test.py
@@ -296,6 +296,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
             github_repository=None,
             workflow_run_id=None,
             workflow_run=None,
+            release_type=None,
         )
 
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
@@ -314,6 +315,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
             github_repository="SomeUser/TheRock",
             workflow_run_id="99999",
             workflow_run=None,
+            release_type=None,
         )
 
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
@@ -330,6 +332,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
             github_repository=None,
             workflow_run_id=None,
             workflow_run=fake_run,
+            release_type=None,
         )
 
     @mock.patch("_therock_utils.workflow_outputs._retrieve_bucket_info")
@@ -349,6 +352,7 @@ class TestWorkflowOutputRootFromWorkflowRun(unittest.TestCase):
             github_repository=None,
             workflow_run_id=None,
             workflow_run=fake_run,
+            release_type=None,
         )
 
 


### PR DESCRIPTION
## Motivation

This will help on https://github.com/ROCm/TheRock/issues/3334, where other scripts may want to set a release type via CLI arguments instead of relying on the `RELEASE_TYPE` environment variable.

## Test Plan

* Unit tests
* Tested together with other changes at https://github.com/ROCm/TheRock/actions/runs/24429137657

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
