### PR TITLE
Add publish_to_release_buckets job to multi_arch_release_linux.yml

### DIFF
--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -39,9 +39,6 @@ jobs:
       contents: read
       id-token: write
 
-  # TODO: dispatch test artifacts per family (add workflow_dispatch to
-  #   test_artifacts.yml, then use benc-uk/workflow-dispatch here)
-
   build_tarballs:
     needs: [build_artifacts]
     name: Build Tarballs
@@ -55,14 +52,10 @@ jobs:
       contents: read
       id-token: write
 
-  # TODO: publish_tarballs - copy from artifacts bucket to release bucket
-  #       (as part of multi_arch_build_tarballs or a separate job?)
-
   # TODO(#3334): build python packages
   # build_python_packages:
   #   needs: [build_artifacts]
   #   name: Build Python Packages
-  #   if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
   #   uses: ./.github/workflows/build_portable_linux_python_packages.yml
   #   with:
   #     artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
@@ -74,9 +67,40 @@ jobs:
   #     contents: read
   #     id-token: write
 
-  # TODO: publish_python_packages
+  # TODO(#3334): build native packages (build_native_linux_packages.yml)
 
-  # TODO: dispatch native packages (build_native_linux_packages.yml)
+  publish_to_release_buckets:
+    needs: [build_tarballs]
+    name: Publish to Release Buckets
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setting up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Python requirements
+        run: pip install -r requirements.txt
+
+      - name: Configure AWS Credentials
+        uses: ./.github/actions/configure_aws_artifacts_credentials
+        with:
+          release_type: ${{ inputs.release_type }}
+
+      - name: Copy to release buckets
+        run: |
+          python build_tools/github_actions/publish_rocm_to_release_buckets.py \
+            --run-id="${{ github.run_id }}" \
+            --platform=linux \
+            --release-type="${{ inputs.release_type }}"
+
+  # TODO: dispatch test artifacts per family (add workflow_dispatch to
+  #   test_artifacts.yml, then use benc-uk/workflow-dispatch here)
 
   # TODO: dispatch pytorch wheels (release_portable_linux_pytorch_wheels.yml)
 

--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -77,6 +77,8 @@ _BUCKET_CONFIGS_BY_NAME = {c.name: c for c in s3_bucket_configs}
 
 _ALLOWED_RELEASE_TYPES = {"dev", "nightly", "prerelease"}
 
+_ALLOWED_RELEASE_BUCKET_TYPES = {"tarball", "python", "packages"}
+
 # Repositories allowed to use release_type. Only these repositories are trusted
 # to assume release IAM roles that grant write access to release buckets.
 _ALLOWED_RELEASE_REPOS = {"ROCm/TheRock", "ROCm/rockrel"}
@@ -93,6 +95,9 @@ def get_artifacts_bucket_config(
         release_type: "" for CI builds, or "dev", "nightly", "prerelease".
         repository: GitHub repository (e.g. "ROCm/TheRock").
         is_pr_from_fork: Whether this is a PR from a fork.
+
+    Raises:
+        ValueError: If release_type is invalid.
     """
     if release_type:
         if release_type not in _ALLOWED_RELEASE_TYPES:
@@ -112,6 +117,36 @@ def get_artifacts_bucket_config(
             bucket_name = "therock-ci-artifacts-external"
         else:
             bucket_name = "therock-ci-artifacts"
+    return _BUCKET_CONFIGS_BY_NAME[bucket_name]
+
+
+def get_release_bucket_config(
+    release_type: str,
+    bucket_type: str,
+) -> S3BucketConfig:
+    """Look up the release bucket config for a given release type and bucket type.
+
+    Args:
+        release_type: "dev", "nightly", or "prerelease".
+        bucket_type: "tarball", "python", or "packages".
+
+    Returns:
+        S3BucketConfig for the bucket ``therock-{release_type}-{bucket_type}``.
+
+    Raises:
+        ValueError: If release_type or bucket_type is invalid.
+    """
+    if release_type not in _ALLOWED_RELEASE_TYPES:
+        raise ValueError(
+            f"release_type={release_type!r} is invalid, "
+            f"expected one of {_ALLOWED_RELEASE_TYPES}"
+        )
+    if bucket_type not in _ALLOWED_RELEASE_BUCKET_TYPES:
+        raise ValueError(
+            f"bucket_type={bucket_type!r} is invalid, "
+            f"expected one of {_ALLOWED_RELEASE_BUCKET_TYPES}"
+        )
+    bucket_name = f"therock-{release_type}-{bucket_type}"
     return _BUCKET_CONFIGS_BY_NAME[bucket_name]
 
 

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Publish ROCm release files from an artifacts bucket to release buckets.
+
+These release file types are supported:
+
+- [x] tarballs
+- [ ] python packages
+- [ ] native linux packages
+- [ ] native windows packages
+
+Example with ``--run-id 12345 --platform linux --release-type dev``:
+
+    s3://therock-dev-artifacts/12345-linux/tarballs/therock-dist-linux-gfx94X-dcgpu-7.10.0.tar.gz
+      -> s3://therock-dev-tarball/v3/tarball/therock-dist-linux-gfx94X-dcgpu-7.10.0.tar.gz
+
+Test usage:
+    python build_tools/github_actions/publish_rocm_to_release_buckets.py \\
+        --run-id 12345 --platform linux --release-type dev --dry-run
+"""
+
+import argparse
+import logging
+import platform as platform_module
+import sys
+from pathlib import Path
+
+_BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_BUILD_TOOLS_DIR))
+
+from _therock_utils.s3_buckets import get_release_bucket_config
+from _therock_utils.storage_backend import StorageBackend, create_storage_backend
+from _therock_utils.storage_location import StorageLocation
+from _therock_utils.workflow_outputs import WorkflowOutputRoot
+
+logger = logging.getLogger(__name__)
+
+
+def publish_tarballs(
+    artifacts_root: WorkflowOutputRoot,
+    release_type: str,
+    backend: StorageBackend,
+) -> int:
+    """Copy tarballs from the artifacts bucket to the release tarball bucket.
+
+    Example:
+        s3://therock-dev-artifacts/12345-linux/tarballs/
+          -> s3://therock-dev-tarball/v3/tarball/
+
+    Returns:
+        Number of tarballs copied.
+    """
+    source = artifacts_root.tarballs()
+    dest_bucket = get_release_bucket_config(release_type, "tarball")
+    dest = StorageLocation(dest_bucket.name, "v3/tarball")
+
+    logger.info("Tarballs: %s -> %s", source.s3_uri, dest.s3_uri)
+    count = backend.copy_directory(source, dest, include=["*.tar.gz"])
+    logger.info("Copied %d tarballs", count)
+    if count == 0:
+        raise FileNotFoundError(f"No tarballs found at {source.s3_uri}")
+
+
+def main(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(
+        description="Publish ROCm release files to release buckets"
+    )
+    parser.add_argument("--run-id", required=True, help="Source workflow run ID")
+    parser.add_argument(
+        "--platform",
+        default=platform_module.system().lower(),
+        choices=["linux", "windows"],
+        help="Platform (default: current system)",
+    )
+    parser.add_argument(
+        "--release-type",
+        required=True,
+        choices=["dev", "nightly", "prerelease"],
+        help="Release type (determines source and destination buckets)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print plan without copying"
+    )
+    args = parser.parse_args(argv)
+
+    artifacts_root = WorkflowOutputRoot.from_workflow_run(
+        run_id=args.run_id, platform=args.platform, release_type=args.release_type
+    )
+    backend = create_storage_backend(dry_run=args.dry_run)
+
+    publish_tarballs(artifacts_root, args.release_type, backend)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main(sys.argv[1:])

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -14,7 +14,7 @@ These release file types are supported:
 Example with ``--run-id 12345 --platform linux --release-type dev``:
 
     s3://therock-dev-artifacts/12345-linux/tarballs/therock-dist-linux-gfx94X-dcgpu-7.10.0.tar.gz
-      -> s3://therock-dev-tarball/v3/tarball/therock-dist-linux-gfx94X-dcgpu-7.10.0.tar.gz
+      -> s3://therock-dev-tarball/v4/tarball/therock-dist-linux-gfx94X-dcgpu-7.10.0.tar.gz
 
 Test usage:
     python build_tools/github_actions/publish_rocm_to_release_buckets.py \\
@@ -47,14 +47,14 @@ def publish_tarballs(
 
     Example:
         s3://therock-dev-artifacts/12345-linux/tarballs/
-          -> s3://therock-dev-tarball/v3/tarball/
+          -> s3://therock-dev-tarball/v4/tarball/
 
     Returns:
         Number of tarballs copied.
     """
     source = artifacts_root.tarballs()
     dest_bucket = get_release_bucket_config(release_type, "tarball")
-    dest = StorageLocation(dest_bucket.name, "v3/tarball")
+    dest = StorageLocation(dest_bucket.name, "v4/tarball")
 
     logger.info("Tarballs: %s -> %s", source.s3_uri, dest.s3_uri)
     count = backend.copy_directory(source, dest, include=["*.tar.gz"])

--- a/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
+++ b/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
@@ -35,7 +35,7 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
         self.assertEqual(source.bucket, "therock-dev-artifacts")
         self.assertEqual(source.relative_path, "123-linux/tarballs")
         self.assertEqual(dest.bucket, "therock-dev-tarball")
-        self.assertEqual(dest.relative_path, "v3/tarball")
+        self.assertEqual(dest.relative_path, "v4/tarball")
 
     @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
     def test_nightly_windows_copies_from_artifacts_to_tarball_bucket(self, mock_copy):
@@ -56,7 +56,7 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
         self.assertEqual(source.bucket, "therock-nightly-artifacts")
         self.assertEqual(source.relative_path, "99-windows/tarballs")
         self.assertEqual(dest.bucket, "therock-nightly-tarball")
-        self.assertEqual(dest.relative_path, "v3/tarball")
+        self.assertEqual(dest.relative_path, "v4/tarball")
 
     @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
     def test_raises_when_no_tarballs_found(self, mock_copy):

--- a/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
+++ b/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""Unit tests for publish_rocm_to_release_buckets.py."""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent))
+
+from github_actions.publish_rocm_to_release_buckets import main
+
+
+class TestPublishRocmToReleaseBuckets(unittest.TestCase):
+    """Tests for the main() CLI entry point."""
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
+    def test_dev_linux_copies_from_artifacts_to_tarball_bucket(self, mock_copy):
+        mock_copy.return_value = 2
+        main(
+            [
+                "--run-id",
+                "123",
+                "--platform",
+                "linux",
+                "--release-type",
+                "dev",
+                "--dry-run",
+            ]
+        )
+
+        mock_copy.assert_called_once()
+        source, dest = mock_copy.call_args.args[0], mock_copy.call_args.args[1]
+        self.assertEqual(source.bucket, "therock-dev-artifacts")
+        self.assertEqual(source.relative_path, "123-linux/tarballs")
+        self.assertEqual(dest.bucket, "therock-dev-tarball")
+        self.assertEqual(dest.relative_path, "v3/tarball")
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
+    def test_nightly_windows_copies_from_artifacts_to_tarball_bucket(self, mock_copy):
+        mock_copy.return_value = 1
+        main(
+            [
+                "--run-id",
+                "99",
+                "--platform",
+                "windows",
+                "--release-type",
+                "nightly",
+                "--dry-run",
+            ]
+        )
+
+        source, dest = mock_copy.call_args.args[0], mock_copy.call_args.args[1]
+        self.assertEqual(source.bucket, "therock-nightly-artifacts")
+        self.assertEqual(source.relative_path, "99-windows/tarballs")
+        self.assertEqual(dest.bucket, "therock-nightly-tarball")
+        self.assertEqual(dest.relative_path, "v3/tarball")
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
+    def test_raises_when_no_tarballs_found(self, mock_copy):
+        mock_copy.return_value = 0
+        with self.assertRaises(FileNotFoundError):
+            main(
+                [
+                    "--run-id",
+                    "123",
+                    "--platform",
+                    "linux",
+                    "--release-type",
+                    "dev",
+                    "--dry-run",
+                ]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/github_actions/upload_tarballs.py
+++ b/build_tools/github_actions/upload_tarballs.py
@@ -29,6 +29,7 @@ Usage:
 """
 
 import argparse
+import logging
 import platform as platform_module
 import sys
 from pathlib import Path
@@ -39,13 +40,10 @@ sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 from _therock_utils.storage_backend import create_storage_backend
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 
-
-def log(*args):
-    print(*args)
-    sys.stdout.flush()
+logger = logging.getLogger(__name__)
 
 
-def main():
+def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description="Upload tarballs to S3")
     parser.add_argument(
         "--input-tarballs-dir",
@@ -53,11 +51,12 @@ def main():
         required=True,
         help="Directory containing .tar.gz tarballs to upload",
     )
+    parser.add_argument("--run-id", required=True, help="Workflow run ID")
     parser.add_argument(
-        "--run-id",
-        type=str,
-        required=True,
-        help="Workflow run ID",
+        "--platform",
+        default=platform_module.system().lower(),
+        choices=["linux", "windows"],
+        help="Platform (default: current system)",
     )
     parser.add_argument(
         "--release-type",
@@ -68,21 +67,12 @@ def main():
         "--output-dir",
         type=Path,
         default=None,
-        help="Output to local directory instead of S3",
+        help="Output to local directory instead of S3 (for testing)",
     )
     parser.add_argument(
-        "--platform",
-        type=str,
-        default=platform_module.system().lower(),
-        choices=["linux", "windows"],
-        help="Platform for the upload path (default: current system)",
+        "--dry-run", action="store_true", help="Print plan without uploading"
     )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Print what would happen without uploading",
-    )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     tarballs_dir = args.input_tarballs_dir.resolve()
     if not tarballs_dir.is_dir():
@@ -92,27 +82,26 @@ def main():
     if not tarball_files:
         raise FileNotFoundError(f"No .tar.gz files found in {tarballs_dir}")
 
-    log(f"[INFO] Tarballs directory: {tarballs_dir}")
-    log(f"[INFO] Run ID: {args.run_id}")
-    log(f"[INFO] Platform: {args.platform}")
-    log(f"[INFO] Found {len(tarball_files)} tarballs:")
+    logger.info("Found %d tarballs in %s:", len(tarball_files), tarballs_dir)
     for f in tarball_files:
         size_mb = f.stat().st_size / (1024 * 1024)
-        log(f"  {f.name} ({size_mb:.1f} MB)")
+        logger.info("  %s (%.1f MB)", f.name, size_mb)
 
     output_root = WorkflowOutputRoot.from_workflow_run(
         run_id=args.run_id,
         platform=args.platform,
         release_type=args.release_type or None,
     )
-    tarballs_loc = output_root.tarballs()
-    backend = create_storage_backend(staging_dir=args.output_dir, dry_run=args.dry_run)
+    dest = output_root.tarballs()
+    logger.info("Destination: %s", dest.s3_uri)
 
-    log(f"\n[INFO] Uploading to {tarballs_loc.s3_uri}")
-    count = backend.upload_directory(tarballs_dir, tarballs_loc, include=["*.tar.gz"])
-    log(f"[INFO] Uploaded {count} files")
-    log("[INFO] Done!")
+    backend = create_storage_backend(staging_dir=args.output_dir, dry_run=args.dry_run)
+    count = backend.upload_directory(tarballs_dir, dest, include=["*.tar.gz"])
+
+    logger.info("Uploaded %d files", count)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    logging.basicConfig(level=logging.INFO)
+    sys.exit(main(sys.argv[1:]))

--- a/build_tools/tests/s3_buckets_test.py
+++ b/build_tools/tests/s3_buckets_test.py
@@ -14,6 +14,7 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 from _therock_utils.s3_buckets import (
     get_artifacts_bucket_config,
     get_artifacts_bucket_config_for_workflow_run,
+    get_release_bucket_config,
 )
 
 
@@ -28,6 +29,10 @@ class TestGetArtifactsBucketConfig(unittest.TestCase):
             release_type="", repository="ROCm/TheRock", is_pr_from_fork=False
         )
         self.assertEqual(config.name, "therock-ci-artifacts")
+        self.assertEqual(
+            config.write_access_iam_role,
+            "arn:aws:iam::692859939525:role/therock-ci",
+        )
 
     def test_ci_fork_pr(self):
         config = get_artifacts_bucket_config(
@@ -71,6 +76,54 @@ class TestGetArtifactsBucketConfig(unittest.TestCase):
                 is_pr_from_fork=False,
             )
         self.assertIn("ROCm/rocm-libraries", str(cm.exception))
+
+
+# ---------------------------------------------------------------------------
+# get_release_bucket_config
+# ---------------------------------------------------------------------------
+
+
+class TestGetReleaseBucketConfig(unittest.TestCase):
+    def test_dev_tarball(self):
+        config = get_release_bucket_config(release_type="dev", bucket_type="tarball")
+        self.assertEqual(config.name, "therock-dev-tarball")
+        self.assertEqual(config.iam_role, "therock-dev")
+        self.assertEqual(
+            config.write_access_iam_role,
+            "arn:aws:iam::692859939525:role/therock-dev",
+        )
+
+    def test_nightly_python(self):
+        config = get_release_bucket_config(release_type="nightly", bucket_type="python")
+        self.assertEqual(config.name, "therock-nightly-python")
+        self.assertEqual(config.iam_role, "therock-nightly")
+
+    def test_prerelease_packages(self):
+        config = get_release_bucket_config(
+            release_type="prerelease", bucket_type="packages"
+        )
+        self.assertEqual(config.name, "therock-prerelease-packages")
+        self.assertEqual(config.iam_role, "therock-prerelease")
+
+    def test_all_combinations_exist(self):
+        for release_type in ("dev", "nightly", "prerelease"):
+            for bucket_type in ("tarball", "python", "packages"):
+                config = get_release_bucket_config(release_type, bucket_type)
+                self.assertEqual(config.name, f"therock-{release_type}-{bucket_type}")
+
+    def test_invalid_release_type_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            get_release_bucket_config(release_type="bogus", bucket_type="tarball")
+        self.assertIn("bogus", str(cm.exception))
+
+    def test_empty_release_type_raises(self):
+        with self.assertRaises(ValueError):
+            get_release_bucket_config(release_type="", bucket_type="tarball")
+
+    def test_invalid_bucket_type_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            get_release_bucket_config(release_type="dev", bucket_type="wheels")
+        self.assertIn("wheels", str(cm.exception))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

Progress on:
* https://github.com/ROCm/TheRock/issues/3334
* https://github.com/ROCm/TheRock/issues/4441

## Technical Details

The copy/promote job is local to release workflows, so:
* CI workflows don't risk also affecting release buckets
* All release files are published in one step, instead of having files upload partially as workflow jobs complete
  * Note that this will also prevent publishing a partial release, but the files will be available in the artifacts bucket if we want to manually salvage a run

## Test Plan

* Unit tests
* Tested together with other changes at https://github.com/ROCm/TheRock/actions/runs/24429137657

## Test Result

Test run uploaded files to `therock-dev-artifacts` then copied to `therock-dev-tarball`:

* Build tarballs job: https://github.com/ROCm/TheRock/actions/runs/24429137657/job/71377961777
  * Index for tarballs in `therock-dev-artifacts`: https://therock-dev-artifacts.s3.amazonaws.com/24429137657-linux/tarballs/index.html
* Publish to release buckets job: https://github.com/ROCm/TheRock/actions/runs/24429137657/job/71378733418
  * Published file in `therock-dev-tarball`: https://therock-dev-tarball.s3.us-east-2.amazonaws.com/v3/tarball/therock-dist-linux-gfx1151-7.13.0.dev0%2B492711f25782d286fd9bad6e26bf83909d651e75.tar.gz

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
