### PR TITLE
Enable installation of vendored OpenMPI artifacts via install_rocm_from_artifacts.py

### DIFF
--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -772,6 +772,13 @@ def main(argv):
     )
 
     artifacts_group.add_argument(
+        "--mpi",
+        default=False,
+        help="Include OpenMPI (vendored by TheRock build)",
+        action=argparse.BooleanOptionalAction,
+)
+
+    artifacts_group.add_argument(
         "--rocprofiler-compute",
         default=False,
         help="Include 'rocprofiler-compute' artifacts",

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -354,6 +354,7 @@ def retrieve_artifacts_by_run_id(args):
             args.hipblasltprovider,
             args.hipkernelprovider,
             args.prim,
+            args.mpi,
             args.rand,
             args.rccl,
             args.rocdecode,
@@ -414,6 +415,12 @@ def retrieve_artifacts_by_run_id(args):
             argv.append("rocdecode_test")
             argv.append("base_dev")
             argv.append("amd-llvm_dev")
+        if args.mpi:
+            extra_artifacts.append("openmpi")
+            # Ensure binaries like mpiexec are installed
+            argv.append("openmpi_run")
+            # Optional but useful (headers, dev libs)
+            argv.append("openmpi_dev")
         if args.rocjpeg:
             extra_artifacts.append("sysdeps-amd-mesa")
             extra_artifacts.append("rocjpeg")

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -776,7 +776,7 @@ def main(argv):
         default=False,
         help="Include OpenMPI (vendored by TheRock build)",
         action=argparse.BooleanOptionalAction,
-)
+    )
 
     artifacts_group.add_argument(
         "--rocprofiler-compute",


### PR DESCRIPTION
This PR adds support for installing TheRock’s vendored OpenMPI as part of artifact-based provisioning.

TheRock builds bundle OpenMPI (mpiexec and dependencies) and publish corresponding artifacts (openmpi_run, openmpi_lib, openmpi_dev). However, the current installer does not fetch these,  which are needed especially for MPI-dependent workflows like RCCL multi-node tests.

**Changes**

- Added new CLI flag:
   --mpi / --no-mpi

- When enabled, installs:
   openmpi_run (includes mpiexec)
   openmpi_lib
   openmpi_dev

- Integrated into existing artifact selection logic without changing default behavior

**Usage**
`python build_tools/install_rocm_from_artifacts.py \
  --run-id <RUN_ID> \
  --artifact-group <ARCH> \
  --output-dir <OUTPUT_DIR> \
  --rccl \
  --mpi \
  --tests`