### PR TITLE
<DO NOT MERGE>Test ucicd linux navi3x/navi4x/stxh runners

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -141,7 +141,7 @@ amdgpu_family_info_matrix_presubmit = {
     },
     "gfx110x": {
         "linux": {
-            "test-runs-on": "linux-gfx110X-gpu-rocm",
+            "test-runs-on": "test_setup_linux_gpu_navi3x",
             "family": "gfx110X-all",
             "fetch-gfx-targets": [],
             "bypass_tests_for_releases": True,

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -143,10 +143,17 @@ amdgpu_family_info_matrix_presubmit = {
         "linux": {
             "test-runs-on": "test_setup_linux_gpu_navi3x",
             "family": "gfx110X-all",
-            "fetch-gfx-targets": [],
+            # gfx110X-all family in cmake/therock_amdgpu_targets.cmake includes
+            # gfx1100/gfx1101/gfx1102, so the build already produces split artifacts
+            # for all three. Listing all of them here lets the OrchestrAI navi3x
+            # box's silicon (whichever of the three it carries) load a matching
+            # kernel slice and avoid hipErrorInvalidImage at runtime.
+            "fetch-gfx-targets": ["gfx1100", "gfx1101", "gfx1102"],
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
-            "nightly_check_only_for_family": True,
+            # nightly_check_only_for_family removed on this branch so that
+            # PR-triggered CI exercises the OrchestrAI test_setup_linux_gpu_navi3x
+            # runner setup. Restore before merging the runner-label change to main.
         },
         "windows": {
             "test-runs-on": "windows-gfx110X-gpu-rocm",
@@ -166,7 +173,9 @@ amdgpu_family_info_matrix_presubmit = {
             "fetch-gfx-targets": ["gfx1151"],
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
-            "nightly_check_only_for_family": True,
+            # nightly_check_only_for_family removed on this branch so that
+            # PR-triggered CI exercises the OrchestrAI test_setup_linux_igpu_stxh
+            # runner setup. Restore before merging the runner-label change to main.
         },
         "windows": {
             "test-runs-on": "windows-gfx1151-gpu-rocm",
@@ -186,7 +195,9 @@ amdgpu_family_info_matrix_presubmit = {
             "fetch-gfx-targets": ["gfx1200", "gfx1201"],
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
-            "nightly_check_only_for_family": True,
+            # nightly_check_only_for_family removed on this branch so that
+            # PR-triggered CI exercises the OrchestrAI test_setup_linux_gpu_navi4x
+            # runner setup. Restore before merging the runner-label change to main.
         },
         "windows": {
             "test-runs-on": "windows-gfx120X-gpu-rocm",

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -158,7 +158,7 @@ amdgpu_family_info_matrix_presubmit = {
     },
     "gfx1151": {
         "linux": {
-            "test-runs-on": "linux-gfx1151-gpu-rocm",
+            "test-runs-on": "test_setup_linux_igpu_stxh",
             "test-runs-on-kernel": {
                 "oem": "linux-strix-halo-gpu-rocm-oem",
             },
@@ -181,7 +181,7 @@ amdgpu_family_info_matrix_presubmit = {
     },
     "gfx120x": {
         "linux": {
-            "test-runs-on": "linux-gfx120X-gpu-rocm",
+            "test-runs-on": "test_setup_linux_gpu_navi4x",
             "family": "gfx120X-all",
             "fetch-gfx-targets": ["gfx1200", "gfx1201"],
             "bypass_tests_for_releases": True,

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -91,7 +91,7 @@ amdgpu_family_info_matrix_presubmit = {
         "linux": {
             # TODO(#3298): Re-enable machine once HSA_STATUS_ERROR_OUT_OF_RESOURCES issues are resolved
             # Label is linux-gfx110X-gpu-rocm, fetch-gfx-targets should be ["gfx1100"]
-            "test-runs-on": "",
+            "test-runs-on": "test_setup_linux_gpu_navi3x",
             "family": "gfx110X-all",
             "fetch-gfx-targets": [],
             "bypass_tests_for_releases": True,

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -108,7 +108,7 @@ amdgpu_family_info_matrix_presubmit = {
     },
     "gfx1151": {
         "linux": {
-            "test-runs-on": "linux-gfx1151-gpu-rocm",
+            "test-runs-on": "test_setup_linux_gpu_navi3x",
             "test-runs-on-kernel": {
                 "oem": "linux-strix-halo-gpu-rocm-oem",
             },
@@ -133,7 +133,7 @@ amdgpu_family_info_matrix_presubmit = {
         "linux": {
             # TODO(#2683): Re-enable label once stable
             # Label is linux-gfx120X-gpu-rocm
-            "test-runs-on": "",
+            "test-runs-on": "test_setup_linux_gpu_navi4x",
             "family": "gfx120X-all",
             "fetch-gfx-targets": ["gfx1200", "gfx1201"],
             "bypass_tests_for_releases": True,

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -749,6 +749,15 @@ def select_targets(ci_inputs: CIInputs) -> TargetSelection:
     linux_names = _filter_families_by_platform(linux_names, "linux", all_families)
     windows_names = _filter_families_by_platform(windows_names, "windows", all_families)
 
+    # DO NOT MERGE (branch users/chi/test-ucicd-linux-gfx115): on PR triggers,
+    # skip Linux gfx94X-dcgpu tests and ALL Windows builds/tests so the
+    # OrchestrAI navi3x/navi4x/stxh runner provisioning can iterate quickly
+    # without paying the MI300 + Windows pipeline cost on every push.
+    # Restore by removing this block before merging.
+    if ci_inputs.is_pull_request:
+        linux_names = [n for n in linux_names if n != "gfx94x"]
+        windows_names = []
+
     return TargetSelection(
         linux_families=linux_names,
         windows_families=windows_names,

--- a/build_tools/github_actions/tests/fetch_package_targets_test.py
+++ b/build_tools/github_actions/tests/fetch_package_targets_test.py
@@ -182,11 +182,16 @@ class FetchPackageTargetsTest(unittest.TestCase):
             "THEROCK_PACKAGE_PLATFORM": "linux",
         }
 
-        # Run multiple times to ensure consistency
+        # Run multiple times to ensure consistency.
+        # NOTE: matches gfx110x.linux.test-runs-on in amdgpu_family_matrix.py.
+        # On this <DO NOT MERGE> branch the value is the OrchestrAI label
+        # 'test_setup_linux_gpu_navi3x' so the runner setup gets exercised on
+        # PR triggers; main has 'linux-gfx110X-gpu-rocm'. Restore the upstream
+        # value here when reverting the runner-label change before merge.
         for _ in range(5):
             targets = fetch_package_targets.determine_package_targets(args)
             self.assertEqual(len(targets), 1)
-            self.assertEqual(targets[0]["test_machine"], "linux-gfx110X-gpu-rocm")
+            self.assertEqual(targets[0]["test_machine"], "test_setup_linux_gpu_navi3x")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Force TheRock CI run on OrchestrAI linux test runners.  To test OrchestrAI linux setup scripts correctness.
test_setup_linux_gpu_navi4x - gfx120x
test_setup_windows_gpu_navi3x - gfx110x
test_setup_linux_igpu_stxh -gfx115x


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
