### PR TITLE
packaging: Exclude .hsaco files from stripping in Debian packages

### DIFF
--- a/build_tools/packaging/linux/template/debian_rules.j2
+++ b/build_tools/packaging/linux/template/debian_rules.j2
@@ -26,7 +26,7 @@ override_dh_strip:
 	# Unprefixed names
 	ln -sf "$(shell command -v llvm-strip-20)"   debian/.llvm-tools/strip
 	ln -sf "$(shell command -v llvm-objcopy-20)" debian/.llvm-tools/objcopy
-	PATH="$(CURDIR)/debian/.llvm-tools:$(PATH)" dh_strip -X.a
+	PATH="$(CURDIR)/debian/.llvm-tools:$(PATH)" dh_strip -X.a -X.hsaco
 {% endif %}
 
 override_dh_installchangelogs:


### PR DESCRIPTION
Fixes ROCM-21670 where rocBLAS tests fail with "InitElf: failed: null
  sections(STRTAB)" error when using Debian packages.

  Root Cause:
  The dh_strip command in debian/rules was stripping GPU kernel files
  (.hsaco), removing critical ELF sections including STRTAB. This caused
  rocBLAS Tensile library initialization to fail with "Unknown exception
  thrown" when loading the corrupted kernel files.

  Evidence:
  - Kernels.so-000-gfx90a-xnack-.hsaco: 334K (corrupted) vs 395K (correct)
  - TensileLibrary files similarly reduced in size
  - readelf showed missing .strtab section in stripped files

  Solution:
  Add -X.hsaco flag to dh_strip to exclude .hsaco files from stripping,
  preserving their ELF sections intact. This matches the exclusion already
  applied to .a (archive) files.

  Testing:
  - Verified fixed packages have correct file sizes matching source artifacts
  - Confirmed STRTAB section present in fixed .hsaco files
  - RPM packages unaffected (stripping already disabled via debug_package)