### PR TITLE
Add native test package for rocprim, hipcub, and rocthrust

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1074,6 +1074,53 @@
     "Gfxarch": "True"
   },
   {
+    "Package": "amdrocm-prim-test",
+    "Version": "",
+    "Architecture": "amd64",
+    "BuildArch": "x86_64",
+    "DEBDepends": [
+      "amdrocm-ccl-devel"
+    ],
+    "RPMRequires": [
+      "amdrocm-ccl-devel"
+    ],
+    "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
+    "Description_Short": "ROCm primitive library test files",
+    "Description_Long": "Contains rocprim, hipcub and rocthrust test files",
+    "Section": "devel",
+    "Priority": "optional",
+    "Group": "unknown",
+    "License": "MIT",
+    "Vendor": "Advanced Micro Devices, Inc",
+    "Homepage": "https://github.com/ROCm/rocm-libraries",
+    "Artifactory": [
+      {
+        "Artifact": "prim",
+        "Artifact_Subdir": [
+          {
+            "Name": "rocPRIM_tests",
+            "Components": [
+              "test"
+            ]
+          },
+          {
+            "Name": "hipCUB",
+            "Components": [
+              "test"
+            ]
+          },
+          {
+            "Name": "rocThrust",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
+      }
+    ],
+    "Gfxarch": "True"
+  },
+  {
     "Package": "amdrocm-ccl-devel",
     "Version": "",
     "Architecture": "amd64",

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1074,7 +1074,7 @@
     "Gfxarch": "True"
   },
   {
-    "Package": "amdrocm-prim-test",
+    "Package": "amdrocm-ccl-test",
     "Version": "",
     "Architecture": "amd64",
     "BuildArch": "x86_64",


### PR DESCRIPTION
## Summary

- Adds `amdrocm-prim-test` native package entry in `package.json` to include test binaries for rocprim, hipcub, and rocthrust.
- The build system already produces the test artifacts (`artifact-prim.toml` defines a `test` component), but no native package was consuming them.
- Uses `rocPRIM_tests` as the subdir name for rocprim since its tests are built as a separate subproject to avoid blocking the critical path.

## Test plan

- Verify `amdrocm-prim-test` package is generated during native packaging
- Confirm the package contains `test_*` binaries for rocprim, hipcub, and rocthrust
- Verify the package installs cleanly with `amdrocm-ccl-devel` as a dependency

## Test Result
https://github.com/ROCm/TheRock/actions/runs/24499089307/job/71601065960
https://github.com/ROCm/TheRock/actions/runs/24505660241/job/71623412479