### PR TITLE
Add rocm-cmake to amdrocm-base native package

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1360,6 +1360,13 @@
               "dev",
               "doc"
             ]
+          },
+          {
+            "Name": "rocm-cmake",
+            "Components": [
+              "dev",
+              "doc"
+            ]
           }
         ]
       },


### PR DESCRIPTION
## Motivation

Building composable_kernel (and any other project that calls `find_package(ROCM REQUIRED)`) against a native-package-based TheRock installation fails with:

```
CMake Error at CMakeLists.txt:181 (find_package):
  Could not find a package configuration file provided by "ROCM" with any of
  the following names:
    ROCMConfig.cmake
    rocm-config.cmake
  Add the installation prefix of "ROCM" to CMAKE_PREFIX_PATH or set "ROCM_DIR" to a directory containing one of the above files.  If "ROCM" provides a separate development package or SDK, be sure it has been installed.
-- Configuring incomplete, errors occurred!
```

`rocm-cmake` subproject installs `ROCMConfig.cmake` and the associated ROCM* CMake modules (ROCMInstallTargets, ROCMSetupVersion, ROCMCreatePackage, etc.) to `share/rocm/cmake/`. The `base` artifact already maps `rocm-cmake` to its `dev` and `doc` components in `base/artifact.toml`, but `package.json` never referenced `rocm-cmake` in any native package entry, so the files were absent from all native packages.

## Technical Details

Added `rocm-cmake` with its `dev` and `doc` components to the `amdrocm-base` package's `Artifact_Subdir` list under the `base` artifact in `build_tools/packaging/linux/package.json`.

## Test Plan

- Verify `amdrocm-base` package now contains files under `share/rocm/cmake/`
- Build composable_kernel against the package-based installation

## Test Result
https://github.com/ROCm/TheRock/actions/runs/24501740181
https://github.com/ROCm/TheRock/actions/runs/24511931199/job/71645132238