### PR TITLE
Document patchelf requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,10 @@ sudo apt install gfortran git ninja-build cmake g++ pkg-config xxd automake libt
 git clone https://github.com/ROCm/TheRock.git
 cd TheRock
 
-# Install a patched patchelf from source. Ubuntu's packaged patchelf
-# silently corrupts kpack-split libraries; see the environment setup
-# guide for details.
+# Install a patched patchelf from source. For details see
 # https://github.com/ROCm/TheRock/blob/main/docs/environment_setup_guide.md#patchelf
 sudo apt install curl make
-PATCHELF_GIT_REF=$(sed -n 's/^ENV PATCHELF_GIT_REF="\(.*\)"/\1/p' \
-  dockerfiles/build_manylinux_x86_64.Dockerfile)
-sudo env INSTALL_PREFIX=/usr/local \
-  ./dockerfiles/install_patchelf.sh "${PATCHELF_GIT_REF}"
+sudo env INSTALL_PREFIX=/usr/local ./dockerfiles/install_pinned_patchelf.sh
 
 # Init python virtual environment and install python dependencies
 python3 -m venv .venv && source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -62,11 +62,21 @@ instructions and configurations for alternatives.
 ```bash
 # Install Ubuntu dependencies
 sudo apt update
-sudo apt install gfortran git ninja-build cmake g++ pkg-config xxd patchelf automake libtool python3-venv python3-dev libegl1-mesa-dev texinfo bison flex
+sudo apt install gfortran git ninja-build cmake g++ pkg-config xxd automake libtool python3-venv python3-dev libegl1-mesa-dev texinfo bison flex
 
 # Clone the repository
 git clone https://github.com/ROCm/TheRock.git
 cd TheRock
+
+# Install a patched patchelf from source. Ubuntu's packaged patchelf
+# silently corrupts kpack-split libraries; see the environment setup
+# guide for details.
+# https://github.com/ROCm/TheRock/blob/main/docs/environment_setup_guide.md#patchelf
+sudo apt install curl make
+PATCHELF_GIT_REF=$(sed -n 's/^ENV PATCHELF_GIT_REF="\(.*\)"/\1/p' \
+  dockerfiles/build_manylinux_x86_64.Dockerfile)
+sudo env INSTALL_PREFIX=/usr/local \
+  ./dockerfiles/install_patchelf.sh "${PATCHELF_GIT_REF}"
 
 # Init python virtual environment and install python dependencies
 python3 -m venv .venv && source .venv/bin/activate

--- a/dockerfiles/install_pinned_patchelf.sh
+++ b/dockerfiles/install_pinned_patchelf.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Install the NixOS/patchelf git ref pinned by the manylinux Dockerfile.
+# Honors INSTALL_PREFIX (passed through to install_patchelf.sh).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+DOCKERFILE="${SCRIPT_DIR}/build_manylinux_x86_64.Dockerfile"
+
+PATCHELF_GIT_REF="$(sed -n 's/^ENV PATCHELF_GIT_REF="\(.*\)"/\1/p' "${DOCKERFILE}")"
+if [ -z "${PATCHELF_GIT_REF}" ]; then
+    echo "error: could not extract PATCHELF_GIT_REF from ${DOCKERFILE}" >&2
+    exit 1
+fi
+
+exec "${SCRIPT_DIR}/install_patchelf.sh" "${PATCHELF_GIT_REF}"

--- a/docs/environment_setup_guide.md
+++ b/docs/environment_setup_guide.md
@@ -17,98 +17,6 @@ See the [project README](../README.md) for quick getting started instructions th
 
 In general, we will keep the home page updated with quick start instructions for recent versions of the above. Additional advanced advice may be found below for specialty quirks and workarounds.
 
-## Common Issues
-
-### CMake
-
-Different project components enforce different CMake version ranges. The `cmake_minimum_version` in the top level CMake file (presently 3.25) should be considered the project wide minimum. As of September 2025, CMake 4 is supported on Linux - but not on Windows.
-
-There are various, easy ways to acquire specific CMake versions. For Windows and users wanting to use CMake 3, it can be easily installed with:
-
-1. Be in your venv for TheRock:
-   - Linux: `source .venv/bin/activate`
-   - Windows: `.venv\Scripts\Activate.bat`
-1. `pip install 'cmake<4'`
-1. For Linux: if afterwards cmake is not found anymore, run `hash -r` to forget the previously cached location of cmake
-
-### patchelf
-
-Building with `THEROCK_BUNDLE_SYSDEPS=ON` (the default for portable Linux
-builds), `THEROCK_ENABLE_ROCGDB=ON`, or generating Python wheels via
-`build_tools/build_python_packages.py` all invoke `patchelf` to rewrite
-`RPATH`, `SONAME`, and `DT_NEEDED` entries on ELF binaries. Upstream
-`patchelf` releases through 0.18.0 contain a bug that corrupts the PHDR
-virtual address on any ELF whose PHDR sits in a trailing LOAD segment,
-which is how `kpack` leaves libraries after splitting device code from
-host code.
-
-#### Failure mode
-
-When the wrong `patchelf` rewrites an affected library you will see one
-or more of:
-
-- `OSError: failed to map segment from shared object` at load time (e.g.
-  during `rocm-sdk test testSharedLibrariesLoad`).
-- `readelf -l <file>` reports `Error: the PHDR segment is not covered by
-  a LOAD segment`.
-- The PHDR `VirtAddr` in `readelf -l` is `0xfffffffffff79040` (a
-  sign-extended negative).
-
-If you see any of these after a local wheel build or `BUNDLE_SYSDEPS`
-build, suspect your host `patchelf`.
-
-#### Fix
-
-The fix is [NixOS/patchelf PR #544](https://github.com/NixOS/patchelf/pull/544)
-("Allocate PHT/SHT at the end of the ELF file"), merged 2025-01-07 to
-master but not yet in a tagged release. Any supported build path needs a
-`patchelf` that includes this commit.
-
-#### Supported install paths
-
-Pick whichever applies to your host:
-
-1. **Portable / manylinux container.** If you build inside
-   `ghcr.io/rocm/therock_build_manylinux_x86_64`, the image already ships
-   a patched `patchelf` built from source and installed at
-   `/usr/local/bin/patchelf`. Nothing to do. See
-   [`dockerfiles/build_manylinux_x86_64.Dockerfile`][dockerfile].
-2. **Fedora.** Recent Fedora releases ship the fix as a downstream patch
-   on the packaged `patchelf 0.18.0` (the Fedora `patchelf` SRPM carries
-   upstream PR #544 as `0001-Allocate-PHT-SHT-at-the-end-of-the-.elf-file.patch`).
-   Verify with:
-
-   ```bash
-   rpm -q --changelog patchelf | head
-   ```
-
-   The changelog entry referencing the "PHT/SHT at the end" patch
-   indicates a good build. `dnf install patchelf` is sufficient on a
-   release that carries it.
-3. **Any other Linux (Ubuntu, Debian, Arch, openSUSE, ...).** Build
-   `patchelf` from source using the script the manylinux image uses:
-
-   ```bash
-   # From the TheRock checkout. The pinned ref tracks the
-   # PATCHELF_GIT_REF ENV in build_manylinux_x86_64.Dockerfile.
-   PATCHELF_GIT_REF=$(sed -n 's/^ENV PATCHELF_GIT_REF="\(.*\)"/\1/p' \
-     dockerfiles/build_manylinux_x86_64.Dockerfile)
-   sudo env INSTALL_PREFIX=/usr/local \
-     ./dockerfiles/install_patchelf.sh "${PATCHELF_GIT_REF}"
-
-   patchelf --version
-   # -> patchelf 0.18.0+therock.<short-ref>
-   ```
-
-   The script needs `curl`, `autoconf`, `automake`, `make`, and a C++
-   compiler. On Ubuntu: `sudo apt install curl autoconf automake make g++`.
-
-[dockerfile]: ../dockerfiles/build_manylinux_x86_64.Dockerfile
-
-### Resource Utilization
-
-ROCm is a very resource hungry project to build. If running with high parallelism (i.e. on systems with a high core:memory ratio), it will likely use more memory than you have without special consideration. Sometimes this will result in a transient "resource exhausted" problem which clears on a restart. Sufficient swap and controlling concurrency may be necessary. TODO: Link to guide on how to control concurrency and resource utilization.
-
 ## Reference Build Environments
 
 When interactively verifying that various Linux based operating systems build properly, we generally use the following procedure:
@@ -142,3 +50,91 @@ Reference image: `ubuntu:22.04`
 Workarounds:
 
 - Shipping CMake is too old (3.22): see above advice for CMake
+
+## Common Issues
+
+### CMake
+
+Different project components enforce different CMake version ranges. The `cmake_minimum_version` in the top level CMake file (presently 3.25) should be considered the project wide minimum. As of September 2025, CMake 4 is supported on Linux - but not on Windows.
+
+There are various, easy ways to acquire specific CMake versions. For Windows and users wanting to use CMake 3, it can be easily installed with:
+
+1. Be in your venv for TheRock:
+   - Linux: `source .venv/bin/activate`
+   - Windows: `.venv\Scripts\Activate.bat`
+1. `pip install 'cmake<4'`
+1. For Linux: if afterwards cmake is not found anymore, run `hash -r` to forget the previously cached location of cmake
+
+### patchelf
+
+Building with `THEROCK_BUNDLE_SYSDEPS=ON` (the default for portable Linux
+builds), `THEROCK_ENABLE_ROCGDB=ON`, or generating Python wheels via
+`build_tools/build_python_packages.py` all invoke `patchelf` to rewrite
+`RPATH`, `SONAME`, and `DT_NEEDED` entries on ELF binaries. Upstream
+`patchelf` releases through 0.18.0 contain a bug that corrupts the PHDR
+virtual address on any ELF whose PHDR sits in a trailing LOAD segment,
+which is how `kpack` leaves libraries after splitting device code from
+host code.
+
+#### Issue with patchelf
+
+When the wrong `patchelf` rewrites an affected library you will see one
+or more of:
+
+- `OSError: failed to map segment from shared object` at load time (e.g.
+  during `rocm-sdk test testSharedLibrariesLoad`).
+- `readelf -l <file>` reports `Error: the PHDR segment is not covered by
+  a LOAD segment`.
+- The PHDR `VirtAddr` in `readelf -l` is `0xfffffffffff79040` (a
+  sign-extended negative).
+
+If you see any of these after a local wheel build or `BUNDLE_SYSDEPS`
+build, suspect your host `patchelf`.
+
+#### Compatible patchelf verion
+
+The fix is [NixOS/patchelf PR #544](https://github.com/NixOS/patchelf/pull/544)
+("Allocate PHT/SHT at the end of the ELF file"), merged 2025-01-07 to
+master but not yet in a tagged release. Any supported build path needs a
+`patchelf` that includes this commit.
+
+#### Supported install paths
+
+Pick whichever applies to your host:
+
+1. **Portable / manylinux container.** If you build inside
+   `ghcr.io/rocm/therock_build_manylinux_x86_64`, the image already ships
+   a patched `patchelf` built from source and installed at
+   `/usr/local/bin/patchelf`. Nothing to do. See
+   [`dockerfiles/build_manylinux_x86_64.Dockerfile`][dockerfile].
+2. **Fedora.** Recent Fedora releases ship the fix as a downstream patch
+   on the packaged `patchelf 0.18.0` (the Fedora `patchelf` SRPM carries
+   upstream PR #544 as `0001-Allocate-PHT-SHT-at-the-end-of-the-.elf-file.patch`).
+   Verify with:
+
+   ```bash
+   rpm -q --changelog patchelf | head
+   ```
+
+   The changelog entry referencing the "PHT/SHT at the end" patch
+   indicates a good build. `dnf install patchelf` is sufficient on a
+   release that carries it.
+3. **Any other Linux (Ubuntu, Debian, Arch, openSUSE, ...).** Build
+   `patchelf` from source using the script the manylinux image uses:
+
+   ```bash
+   sudo env INSTALL_PREFIX=/usr/local ./dockerfiles/install_pinned_patchelf.sh
+   ```
+
+   patchelf --version
+   # -> patchelf 0.18.0+therock.<short-ref>
+   ```
+
+   The script needs `curl`, `autoconf`, `automake`, `make`, and a C++
+   compiler. On Ubuntu: `sudo apt install curl autoconf automake make g++`.
+
+[dockerfile]: ../dockerfiles/build_manylinux_x86_64.Dockerfile
+
+### Resource Utilization
+
+ROCm is a very resource hungry project to build. If running with high parallelism (i.e. on systems with a high core:memory ratio), it will likely use more memory than you have without special consideration. Sometimes this will result in a transient "resource exhausted" problem which clears on a restart. Sufficient swap and controlling concurrency may be necessary. TODO: Link to guide on how to control concurrency and resource utilization.

--- a/docs/environment_setup_guide.md
+++ b/docs/environment_setup_guide.md
@@ -10,7 +10,8 @@ If you have a configuration that you have found workarounds to support, please s
 
 See the [project README](../README.md) for quick getting started instructions the following combinations:
 
-- Fedora (TODO: looking for contribution)
+- Fedora (TODO: looking for contribution; see [patchelf](#patchelf) for a
+  Fedora-specific note)
 - Ubuntu 24.04
 - Windows (VS2022)
 
@@ -29,6 +30,80 @@ There are various, easy ways to acquire specific CMake versions. For Windows and
    - Windows: `.venv\Scripts\Activate.bat`
 1. `pip install 'cmake<4'`
 1. For Linux: if afterwards cmake is not found anymore, run `hash -r` to forget the previously cached location of cmake
+
+### patchelf
+
+Building with `THEROCK_BUNDLE_SYSDEPS=ON` (the default for portable Linux
+builds), `THEROCK_ENABLE_ROCGDB=ON`, or generating Python wheels via
+`build_tools/build_python_packages.py` all invoke `patchelf` to rewrite
+`RPATH`, `SONAME`, and `DT_NEEDED` entries on ELF binaries. Upstream
+`patchelf` releases through 0.18.0 contain a bug that corrupts the PHDR
+virtual address on any ELF whose PHDR sits in a trailing LOAD segment,
+which is how `kpack` leaves libraries after splitting device code from
+host code.
+
+#### Failure mode
+
+When the wrong `patchelf` rewrites an affected library you will see one
+or more of:
+
+- `OSError: failed to map segment from shared object` at load time (e.g.
+  during `rocm-sdk test testSharedLibrariesLoad`).
+- `readelf -l <file>` reports `Error: the PHDR segment is not covered by
+  a LOAD segment`.
+- The PHDR `VirtAddr` in `readelf -l` is `0xfffffffffff79040` (a
+  sign-extended negative).
+
+If you see any of these after a local wheel build or `BUNDLE_SYSDEPS`
+build, suspect your host `patchelf`.
+
+#### Fix
+
+The fix is [NixOS/patchelf PR #544](https://github.com/NixOS/patchelf/pull/544)
+("Allocate PHT/SHT at the end of the ELF file"), merged 2025-01-07 to
+master but not yet in a tagged release. Any supported build path needs a
+`patchelf` that includes this commit.
+
+#### Supported install paths
+
+Pick whichever applies to your host:
+
+1. **Portable / manylinux container.** If you build inside
+   `ghcr.io/rocm/therock_build_manylinux_x86_64`, the image already ships
+   a patched `patchelf` built from source and installed at
+   `/usr/local/bin/patchelf`. Nothing to do. See
+   [`dockerfiles/build_manylinux_x86_64.Dockerfile`][dockerfile].
+2. **Fedora.** Recent Fedora releases ship the fix as a downstream patch
+   on the packaged `patchelf 0.18.0` (the Fedora `patchelf` SRPM carries
+   upstream PR #544 as `0001-Allocate-PHT-SHT-at-the-end-of-the-.elf-file.patch`).
+   Verify with:
+
+   ```bash
+   rpm -q --changelog patchelf | head
+   ```
+
+   The changelog entry referencing the "PHT/SHT at the end" patch
+   indicates a good build. `dnf install patchelf` is sufficient on a
+   release that carries it.
+3. **Any other Linux (Ubuntu, Debian, Arch, openSUSE, ...).** Build
+   `patchelf` from source using the script the manylinux image uses:
+
+   ```bash
+   # From the TheRock checkout. The pinned ref tracks the
+   # PATCHELF_GIT_REF ENV in build_manylinux_x86_64.Dockerfile.
+   PATCHELF_GIT_REF=$(sed -n 's/^ENV PATCHELF_GIT_REF="\(.*\)"/\1/p' \
+     dockerfiles/build_manylinux_x86_64.Dockerfile)
+   sudo env INSTALL_PREFIX=/usr/local \
+     ./dockerfiles/install_patchelf.sh "${PATCHELF_GIT_REF}"
+
+   patchelf --version
+   # -> patchelf 0.18.0+therock.<short-ref>
+   ```
+
+   The script needs `curl`, `autoconf`, `automake`, `make`, and a C++
+   compiler. On Ubuntu: `sudo apt install curl autoconf automake make g++`.
+
+[dockerfile]: ../dockerfiles/build_manylinux_x86_64.Dockerfile
 
 ### Resource Utilization
 

--- a/docs/environment_setup_guide.md
+++ b/docs/environment_setup_guide.md
@@ -83,8 +83,7 @@ or more of:
 
 - `OSError: failed to map segment from shared object` at load time (e.g.
   during `rocm-sdk test testSharedLibrariesLoad`).
-- `readelf -l <file>` reports `Error: the PHDR segment is not covered by
-  a LOAD segment`.
+- `readelf -l <file>` reports `Error: the PHDR segment is not covered by a LOAD segment`.
 - The PHDR `VirtAddr` in `readelf -l` is `0xfffffffffff79040` (a
   sign-extended negative).
 
@@ -107,7 +106,8 @@ Pick whichever applies to your host:
    a patched `patchelf` built from source and installed at
    `/usr/local/bin/patchelf`. Nothing to do. See
    [`dockerfiles/build_manylinux_x86_64.Dockerfile`][dockerfile].
-2. **Fedora.** Recent Fedora releases ship the fix as a downstream patch
+
+1. **Fedora.** Recent Fedora releases ship the fix as a downstream patch
    on the packaged `patchelf 0.18.0` (the Fedora `patchelf` SRPM carries
    upstream PR #544 as `0001-Allocate-PHT-SHT-at-the-end-of-the-.elf-file.patch`).
    Verify with:
@@ -119,12 +119,12 @@ Pick whichever applies to your host:
    The changelog entry referencing the "PHT/SHT at the end" patch
    indicates a good build. `dnf install patchelf` is sufficient on a
    release that carries it.
-3. **Any other Linux (Ubuntu, Debian, Arch, openSUSE, ...).** Build
+
+1. **Any other Linux (Ubuntu, Debian, Arch, openSUSE, ...).** Build
    `patchelf` from source using the script the manylinux image uses:
 
    ```bash
    sudo env INSTALL_PREFIX=/usr/local ./dockerfiles/install_pinned_patchelf.sh
-   ```
 
    patchelf --version
    # -> patchelf 0.18.0+therock.<short-ref>
@@ -133,8 +133,8 @@ Pick whichever applies to your host:
    The script needs `curl`, `autoconf`, `automake`, `make`, and a C++
    compiler. On Ubuntu: `sudo apt install curl autoconf automake make g++`.
 
-[dockerfile]: ../dockerfiles/build_manylinux_x86_64.Dockerfile
-
 ### Resource Utilization
 
 ROCm is a very resource hungry project to build. If running with high parallelism (i.e. on systems with a high core:memory ratio), it will likely use more memory than you have without special consideration. Sometimes this will result in a transient "resource exhausted" problem which clears on a restart. Sufficient swap and controlling concurrency may be necessary. TODO: Link to guide on how to control concurrency and resource utilization.
+
+[dockerfile]: ../dockerfiles/build_manylinux_x86_64.Dockerfile

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -90,7 +90,8 @@ portable container as was used to build the SDK (so as to avoid the possibility
 of accidentally referencing too-new glibc symbols).
 
 If running on a host rather than the portable container, make sure the host
-`patchelf` carries the PR #544 PHDR-relocation fix. A stock distro `patchelf`
+`patchelf` carries the [PR #544](https://github.com/NixOS/patchelf/pull/544)
+PHDR-relocation fix. A stock distro `patchelf`
 (for example Ubuntu's `apt install patchelf`) will silently corrupt the
 kpack-split libraries produced by TheRock, yielding wheels whose shared
 objects fail to load at install time. See

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -89,6 +89,14 @@ patching via patchelf. On Linux, it is recommended to run this in the same
 portable container as was used to build the SDK (so as to avoid the possibility
 of accidentally referencing too-new glibc symbols).
 
+If running on a host rather than the portable container, make sure the host
+`patchelf` carries the PR #544 PHDR-relocation fix. A stock distro `patchelf`
+(for example Ubuntu's `apt install patchelf`) will silently corrupt the
+kpack-split libraries produced by TheRock, yielding wheels whose shared
+objects fail to load at install time. See
+[environment_setup_guide.md#patchelf](../environment_setup_guide.md#patchelf)
+for supported install paths.
+
 ### Building from CI Artifacts
 
 You can also build packages from artifacts uploaded by CI workflows:


### PR DESCRIPTION
To enable kpack split, the manylinux image is switched to a version building patchelf from source pinned to an upstream version. This version includs a fix to addresses the PHDR-relocation bug that silently corrupts kpack-split libraries.

This adds guidance for developers building outside the container to not let them run into hitting the dlopen failures without a clear pointer to the cause.