### PR TITLE
Update rocm-libraries to flatbuffers-sdk-adoption and fix C2y warnings

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -410,16 +410,14 @@ test_matrix = {
             "windows": 1,
         },
     },
-    # TODO(iree-org/fusilli/issues/57): Enable fusilli tests once build is
-    # enabled by default.
-    # "fusilliprovider": {
-    #     "job_name": "fusilliprovider",
-    #     "fetch_artifact_args": "--hipdnn --fusilliprovider --iree-compiler --tests",
-    #     "timeout_minutes": 15,
-    #     "test_script": f"python {_get_script_path('test_fusilliprovider.py')}",
-    #     "platform": ["linux"],
-    #     "total_shards": 1,
-    # },
+    "fusilliprovider": {
+        "job_name": "fusilliprovider",
+        "fetch_artifact_args": "--hipdnn --fusilliprovider --iree-compiler --tests",
+        "timeout_minutes": 15,
+        "test_script": f"python {_get_script_path('test_fusilliprovider.py')}",
+        "platform": ["linux"],
+        "total_shards_dict": {"linux": 1},
+    },
     # hipBLASLt provider tests
     "hipblasltprovider": {
         "job_name": "hipblasltprovider",

--- a/build_tools/github_actions/test_executable_scripts/test_fusilliprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_fusilliprovider.py
@@ -13,11 +13,13 @@ THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
 logging.basicConfig(level=logging.INFO)
 
+fusilli_test_dir = THEROCK_BIN_DIR / "fusilli_plugin_test_infra"
+
 # Build the ctest command
 cmd = [
     "ctest",
     "--test-dir",
-    f"{THEROCK_BIN_DIR}/fusilli_plugin_test_infra",
+    str(fusilli_test_dir),
     "--output-on-failure",
     "--parallel",
     "8",
@@ -33,6 +35,14 @@ test_type = os.getenv("TEST_TYPE", "full")
 if test_type == "quick":
     # Exclude tests that start with "Full" during quick tests
     environ_vars["GTEST_FILTER"] = "-Full*"
+
+if not fusilli_test_dir.exists():
+    logging.info(
+        "Fusilli test artifacts not found at %s. Treating this as a pass because "
+        "Fusilli is not built in all currently active CI pipelines.",
+        fusilli_test_dir,
+    )
+    raise SystemExit(0)
 
 # As a sanity check, verify libIREECompiler.so is available in the build artifacts.
 # TODO: check for .dll on windows

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -66,6 +66,7 @@ set(THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS
   -Wno-documentation-unknown-command
   -Wno-documentation-pedantic
   -Wno-unused-command-line-argument
+  -Wno-c2y-extensions
 
   # There are real issues here but rocBLAS and rocSPARSE generate 300-400MB of
   # warning logs with this enabled, practically breaking build tooling.

--- a/iree-libs/CMakeLists.txt
+++ b/iree-libs/CMakeLists.txt
@@ -36,6 +36,9 @@ if(THEROCK_ENABLE_IREE_COMPILER)
       -DIREE_BUILD_BINDINGS_TFLITE_JAVA=OFF
       # Disable runtime, it's built into fusilli, we only need the compiler
       -DIREE_HAL_DRIVER_DEFAULTS=OFF
+      # Suppress -Werror in bundled google benchmark to work around
+      # __COUNTER__ C2y extension warnings with newer clang.
+      -DBENCHMARK_ENABLE_WERROR=OFF
     INSTALL_OPTIONAL_COMPONENTS
       IREEDevLibraries-Compiler
     BUILD_DEPS


### PR DESCRIPTION
## Summary
- Cherry-picks fusilli test enablement from AaronStGeorge/p046-dual-path-therock-ci-for-fusilli
- Points rocm-libraries submodule to `users/sareeder/flatbuffers-sdk-adoption` (includes GraphWrapper namespace fix and flatbuffers SDK migration)
- Adds `-Wno-c2y-extensions` to `THEROCK_AMD_LLVM_DEFAULT_CXX_FLAGS` to suppress `__COUNTER__` C2y extension warnings from fusilli macros and google benchmark with newer clang
- Adds `BENCHMARK_ENABLE_WERROR=OFF` to iree-compiler cmake args to prevent `-Werror` failures in bundled google benchmark

## Test plan
- [ ] Build fusilliprovider target with `THEROCK_ENABLE_IREE_LIBS=ON`
- [ ] Verify iree-compiler builds without C2y warnings
- [ ] Verify fusilliprovider builds with updated rocm-libraries

🤖 Generated with [Claude Code](https://claude.com/claude-code)