### PR TITLE
[ci] excluding crashing gfx110X windows tests for `hipsparse`

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
@@ -30,6 +30,7 @@ TEST_TO_IGNORE = {
         # TODO(#3621): Include test once out of resource errors are resolved
         "windows": ["*spmm*"]
     },
+    "gfx110X-all": {"windows": ["csr2csr_compress*"]},
 }
 
 environ_vars["HIPSPARSE_CLIENTS_MATRICES_DIR"] = (

--- a/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
@@ -30,7 +30,7 @@ TEST_TO_IGNORE = {
         # TODO(#3621): Include test once out of resource errors are resolved
         "windows": ["*spmm*"]
     },
-    "gfx110X-all": {"windows": ["csr2csr_compress*"]},
+    "gfx110X-all": {"windows": ["*csr2csr_compress*", "*prune_csr2csr.conversion*"]},
 }
 
 environ_vars["HIPSPARSE_CLIENTS_MATRICES_DIR"] = (


### PR DESCRIPTION
Specific windows gfx110X tests are crashing machines. we are excluding tests and repro-ing and finding root cause

works here: https://github.com/ROCm/TheRock/actions/runs/24524833775/job/71692466269, so adding `ci:skip` label