### PR TITLE
[ci][rocprof-sys][test]:Test the transerBench test fix

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
@@ -49,7 +49,7 @@ cmd = [
     str(pytest_package_exec),
     # TODO: Once the corresponding tests are fixed, remove the lines below
     "-k",
-    "not TestOpenMPTarget and not (TestTranspose and runtime_instrument) and not TestGPUConnect",
+    "not TestOpenMPTarget and not (TestTranspose and runtime_instrument)",
     "--junit-xml=junit.xml",
     "--ci-mode",
     "--log-cli-level=info",


### PR DESCRIPTION
## Motivation

The `transferBench` tests are failing only on the rock CI and fails once in several runs.

## Technical Details

Testing this fix to increase iterations and sampling freq to confirm if this is a timing issue. Because otherwise its a very strange issue for debugging. Also will collect samples from all GPUs.

## Test Plan

Tested locally but real testing needs to happen in the CI workflows.

## Test Result

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
