### PR TITLE
[nomerge] Isolate low-memory windows APUs such as gfx1151-7

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -113,7 +113,7 @@ amdgpu_family_info_matrix_presubmit = {
             "sanity_check_only_for_family": True,
         },
         "windows": {
-            "test-runs-on": "windows-gfx1151-gpu-rocm",
+            "test-runs-on": "windows-strix-halo-gpu-rocm-8gb",
             # TODO(#2754): Add new benchmark-runs-on runner for benchmarks
             "benchmark-runs-on": "windows-gfx1151-gpu-rocm",
             "family": "gfx1151",

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -305,8 +305,8 @@ test_matrix = {
         "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
-            "linux": 4,
-            "windows": 4,
+            "linux": 12,
+            "windows": 12,
         },
     },
     # RCCL tests

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -305,8 +305,8 @@ test_matrix = {
         "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
-            "linux": 12,
-            "windows": 12,
+            "linux": 1,
+            "windows": 1,
         },
     },
     # RCCL tests

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -241,7 +241,7 @@ amdgpu_family_info_matrix_all = {
                 "test": {
                     "run_tests": True,
                     "runs_on": {
-                        "test": "windows-gfx1151-gpu-rocm",
+                        "test": "windows-strix-halo-gpu-rocm-8gb",
                         # TODO(#2754): Add new benchmark-runs-on runner for benchmarks
                         "benchmark": "windows-gfx1151-gpu-rocm",
                     },

--- a/build_tools/github_actions/tests/configure_target_run_test.py
+++ b/build_tools/github_actions/tests/configure_target_run_test.py
@@ -27,7 +27,7 @@ class ConfigureTargetRunTest(unittest.TestCase):
 
     def test_windows_gfx115x(self):
         runner_label = configure_target_run.get_runner_label("gfx1151", "windows")
-        self.assertEqual(runner_label, "windows-gfx1151-gpu-rocm")
+        self.assertEqual(runner_label, "windows-strix-halo-gpu-rocm-8gb")
 
     def test_windows_gfx120X_all(self):
         runner_label = configure_target_run.get_runner_label("gfx120X-all", "windows")


### PR DESCRIPTION
## Motivation

MIOpen was not designed for low-memory systems, and some tests fail on them. This enables testing on specifically these machines.

## Technical Details

MIOpen tests shall detect memory availability and skip test cases involving shapes that are too large.

Geo created a custom label, `windows-strix-halo-gpu-rocm-8gb`.

## Test Plan

Manual workflows

## Test Result

TBD

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
