### PR TITLE
[ci] enabling all archs for nightly tests

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -114,7 +114,7 @@ amdgpu_family_info_matrix_presubmit = {
             "fetch-gfx-targets": ["gfx1151"],
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
-            "sanity_check_only_for_family": True,
+            "nightly_check_only_for_family": True,
         },
         "windows": {
             "test-runs-on": "windows-gfx1151-gpu-rocm",

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -115,7 +115,6 @@ amdgpu_family_info_matrix_presubmit = {
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
             "sanity_check_only_for_family": True,
-            "nightly_check_only_for_family": True,
         },
         "windows": {
             "test-runs-on": "windows-gfx1151-gpu-rocm",

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -89,14 +89,12 @@ amdgpu_family_info_matrix_presubmit = {
     },
     "gfx110x": {
         "linux": {
-            # TODO(#3298): Re-enable machine once HSA_STATUS_ERROR_OUT_OF_RESOURCES issues are resolved
-            # Label is linux-gfx110X-gpu-rocm, fetch-gfx-targets should be ["gfx1100"]
-            "test-runs-on": "",
+            "test-runs-on": "linux-gfx110X-gpu-rocm",
             "family": "gfx110X-all",
             "fetch-gfx-targets": [],
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
-            "sanity_check_only_for_family": True,
+            "nightly_check_only_for_family": True,
         },
         "windows": {
             "test-runs-on": "windows-gfx110X-gpu-rocm",
@@ -117,6 +115,7 @@ amdgpu_family_info_matrix_presubmit = {
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
             "sanity_check_only_for_family": True,
+            "nightly_check_only_for_family": True,
         },
         "windows": {
             "test-runs-on": "windows-gfx1151-gpu-rocm",
@@ -131,23 +130,20 @@ amdgpu_family_info_matrix_presubmit = {
     },
     "gfx120x": {
         "linux": {
-            # TODO(#2683): Re-enable label once stable
-            # Label is linux-gfx120X-gpu-rocm
-            "test-runs-on": "",
+            "test-runs-on": "linux-gfx120X-gpu-rocm",
             "family": "gfx120X-all",
             "fetch-gfx-targets": ["gfx1200", "gfx1201"],
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
-            "sanity_check_only_for_family": True,
+            "nightly_check_only_for_family": True,
         },
         "windows": {
-            # TODO(#2962): Re-enable machine once sanity checks work with this architecture
-            # Label is windows-gfx120X-gpu-rocm, fetch-gfx-targets should be ["gfx1200", "gfx1201"]
-            "test-runs-on": "",
+            "test-runs-on": "windows-gfx120X-gpu-rocm",
             "family": "gfx120X-all",
             "fetch-gfx-targets": [],
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
+            "nightly_check_only_for_family": True,
         },
     },
 }
@@ -256,27 +252,23 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx103X-dgpu",
             "fetch-gfx-targets": ["gfx1030"],
             "build_variants": ["release"],
-            "sanity_check_only_for_family": True,
+            "nightly_check_only_for_family": True,
         },
         "windows": {
-            # TODO(#3200): Re-enable machine once it is stable
-            # Label is "windows-gfx1030-gpu-rocm"
-            "test-runs-on": "",
+            "test-runs-on": "windows-gfx1030-gpu-rocm",
             "family": "gfx103X-dgpu",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
-            "sanity_check_only_for_family": True,
+            "nightly_check_only_for_family": True,
         },
     },
     "gfx1150": {
         "linux": {
-            # TODO(#3199): Re-enable machine once it is stable
-            # Label is "linux-gfx1150-gpu-rocm"
-            "test-runs-on": "",
+            "test-runs-on": "linux-gfx1150-gpu-rocm",
             "family": "gfx1150",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
-            "sanity_check_only_for_family": True,
+            "nightly_check_only_for_family": True,
         },
         "windows": {
             "test-runs-on": "",
@@ -301,13 +293,11 @@ amdgpu_family_info_matrix_nightly = {
     },
     "gfx1153": {
         "linux": {
-            # TODO(#2682): Re-enable machine once it is stable
-            # Label is "linux-gfx1153-gpu-rocm"
-            "test-runs-on": "",
+            "test-runs-on": "linux-gfx1153-gpu-rocm",
             "family": "gfx1153",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
-            "sanity_check_only_for_family": True,
+            "nightly_check_only_for_family": True,
         },
         "windows": {
             "test-runs-on": "",

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -594,12 +594,6 @@ def main(base_args, linux_families, windows_families):
             # If the "run-full-tests-only" flag is set for this family, we do not run tests if it is a quick test type
             if matrix_row.get("run-full-tests-only", False) and test_type == "quick":
                 matrix_row["test-runs-on"] = ""
-            # For nightly_check_only_for_family architectures, we want to run only full tests during nightly (scheduled) run
-            # Otherwise, we run sanity checks in all other scenarios (presubmit/postsubmit)
-            if matrix_row.get("nightly_check_only_for_family", False) and (
-                is_pull_request or is_push
-            ):
-                matrix_row["sanity_check_only_for_family"] = True
 
         # If a test filter label is included, we set the "test_type" to the designated filter
         if pr_labels and any("test_filter:" in label for label in pr_labels):

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -770,18 +770,6 @@ class TestExpandBuildConfigs(unittest.TestCase):
         # Windows has no asan variant config at all.
         self.assertIsNone(result.windows)
 
-    def test_test_runner_kernel_overrides_runner_label(self):
-        """test_runner:oem label swaps in kernel-specific runner for gfx1151."""
-        targets = cm.TargetSelection(linux_families=["gfx1151"])
-        result = cm.expand_build_configs(
-            targets=targets,
-            ci_inputs=self._inputs(pr_labels=["test_runner:oem"]),
-            test_type="quick",
-        )
-        self.assertIsNotNone(result.linux)
-        entry = result.linux.per_family_info[0]
-        self.assertEqual(entry["test-runs-on"], "")
-
     def test_test_runner_kernel_clears_unsupported_family(self):
         """test_runner:oem label clears runner for families without kernel support."""
         # gfx94x has no test-runs-on-kernel entry

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -804,7 +804,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
         self.assertIsNotNone(result.linux)
         entry = result.linux.per_family_info[0]
         # Default runner, not the oem one
-        self.assertNotEqual(entry["test-runs-on"], 'linux-gfx1151-gpu-rocm')
+        self.assertNotEqual(entry["test-runs-on"], "linux-gfx1151-gpu-rocm")
         self.assertNotIn("oem", entry["test-runs-on"])
 
 

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -797,14 +797,14 @@ class TestExpandBuildConfigs(unittest.TestCase):
 
     def test_no_test_runner_label_uses_default(self):
         """Without test_runner: label, default runner labels are used."""
-        targets = cm.TargetSelection(linux_families=["gfx1151"])
+        targets = cm.TargetSelection(linux_families=["gfx908"])
         result = cm.expand_build_configs(
             targets=targets, ci_inputs=self._inputs(), test_type="quick"
         )
         self.assertIsNotNone(result.linux)
         entry = result.linux.per_family_info[0]
         # Default runner, not the oem one
-        self.assertNotEqual(entry["test-runs-on"], "")
+        self.assertNotEqual(entry["test-runs-on"], 'linux-gfx1151-gpu-rocm')
         self.assertNotIn("oem", entry["test-runs-on"])
 
 

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -780,7 +780,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
         )
         self.assertIsNotNone(result.linux)
         entry = result.linux.per_family_info[0]
-        self.assertEqual(entry["test-runs-on"], "linux-strix-halo-gpu-rocm-oem")
+        self.assertEqual(entry["test-runs-on"], "")
 
     def test_test_runner_kernel_clears_unsupported_family(self):
         """test_runner:oem label clears runner for families without kernel support."""

--- a/build_tools/github_actions/tests/configure_target_run_test.py
+++ b/build_tools/github_actions/tests/configure_target_run_test.py
@@ -32,7 +32,7 @@ class ConfigureTargetRunTest(unittest.TestCase):
     def test_windows_gfx120X_all(self):
         runner_label = configure_target_run.get_runner_label("gfx120X-all", "windows")
         # No runner label yet.
-        self.assertEqual(runner_label, "")
+        self.assertEqual(runner_label, "windows-gfx120X-gpu-rocm")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As mentioned, we are enabling all archs for nightly test runs to determine what is missing and fixing tests