### PR TITLE
Update scripts for supporting Native Linux Pkg Install Test

### DIFF
--- a/build_tools/packaging/linux/get_s3_config.py
+++ b/build_tools/packaging/linux/get_s3_config.py
@@ -6,9 +6,9 @@
 """
 Determine S3 bucket and prefix for ROCm package uploads.
 
-This script implements the S3 bucket selection logic for native Linux packages,
+This script implements the S3 bucket selection logic for native packages,
 determining the appropriate bucket and prefix based on release type, repository,
-and fork status.
+fork status, and platform.
 
 Decision Tree:
   ├─ IF release_type is set (dev/nightly/prerelease/release)
@@ -18,11 +18,11 @@ Decision Tree:
   │
   ├─ ELSE IF fork PR OR non-ROCm/TheRock repository
   │  └─ Use: therock-ci-artifacts-external bucket (external CI)
-  │     └─ prefix: v3/packages/<pkg_type>/<YYYYMMDD>-<artifact_id>
+  │     └─ prefix: <artifact_id>-<platform>/packages/<pkg_type>
   │
   └─ ELSE (default: ROCm/TheRock non-fork)
      └─ Use: therock-ci-artifacts bucket (internal CI)
-        └─ prefix: v3/packages/<pkg_type>/<YYYYMMDD>-<artifact_id>
+        └─ prefix: <artifact_id>-<platform>/packages/<pkg_type>
 
 Usage:
     # GitHub Actions output format
@@ -32,6 +32,8 @@ Usage:
         --is-fork false \\
         --pkg-type deb \\
         --artifact-id 12345678 \\
+        --rocm-version "8.1.0~dev20251203" \\
+        --platform linux \\
         --output-format github
 
     # Environment variables format
@@ -41,15 +43,18 @@ Usage:
         --is-fork false \\
         --pkg-type rpm \\
         --artifact-id 12345678 \\
+        --platform linux \\
         --output-format env
 
-    # JSON format
+    # JSON format with prerelease
     python get_s3_config.py \\
-        --release-type nightly \\
+        --release-type prerelease \\
         --repository "ROCm/TheRock" \\
         --is-fork false \\
         --pkg-type deb \\
         --artifact-id 12345678 \\
+        --rocm-version "8.1.0~pre2" \\
+        --platform linux \\
         --output-format json
 """
 
@@ -92,6 +97,77 @@ def extract_date_from_version(version: Optional[str]) -> str:
     return datetime.now().strftime("%Y%m%d")
 
 
+def generate_package_repository_url(
+    release_type: str,
+    pkg_type: str,
+    yyyymmdd: str,
+    artifact_id: str,
+    platform: str = "linux",
+    s3_bucket: Optional[str] = None,
+    repository: Optional[str] = None,
+) -> str:
+    """
+    Generate the public repository URL for package installation.
+
+    Args:
+        release_type: Release type ('dev', 'nightly', 'prerelease', 'release', 'ci', or empty)
+        pkg_type: Package type ('deb' or 'rpm')
+        yyyymmdd: Date string in YYYYMMDD format
+        artifact_id: Artifact/run ID
+        platform: Platform name ('linux' or 'windows'), defaults to 'linux'
+        s3_bucket: S3 bucket name (for external repos), defaults to None
+        repository: Repository name (for external repos), defaults to None
+
+    Returns:
+        Public repository URL for package installation instructions
+
+    Examples:
+        CI DEB:         https://therock-ci-artifacts.s3.amazonaws.com/12345678-linux/packages/deb
+        CI RPM:         https://therock-ci-artifacts.s3.amazonaws.com/12345678-linux/packages/rpm/x86_64/
+        External DEB:   https://therock-ci-artifacts-external.s3.amazonaws.com/user-fork/12345678-linux/packages/deb
+        Nightly DEB:    https://rocm.nightlies.amd.com/deb/20260320-12345678
+        Nightly RPM:    https://rocm.nightlies.amd.com/rpm/20260320-12345678/x86_64/
+        Prerelease DEB: https://rocm.prereleases.amd.com/packages/ubuntu2404
+        Prerelease RPM: https://rocm.prereleases.amd.com/packages/rhel10/x86_64/
+        Release DEB:    https://repo.amd.com/rocm/packages/ubuntu2404
+        Release RPM:    https://repo.amd.com/rocm/packages/rhel10/x86_64/
+    """
+    if release_type == "nightly":
+        # Nightly packages use CDN domain
+        # RPM repos need /x86_64/ subdirectory for yum/dnf
+        url = f"https://rocm.nightlies.amd.com/{pkg_type}/{yyyymmdd}-{artifact_id}"
+        return f"{url}/x86_64/" if pkg_type == "rpm" else url
+    elif release_type == "prerelease":
+        # Prerelease packages use CDN domain with default OS profile
+        os_profile = "ubuntu2404" if pkg_type == "deb" else "rhel10"
+        base = f"https://rocm.prereleases.amd.com/packages/{os_profile}"
+        return f"{base}/x86_64/" if pkg_type == "rpm" else base
+    elif release_type == "release":
+        # Release packages use official repo domain with default OS profile
+        os_profile = "ubuntu2404" if pkg_type == "deb" else "rhel10"
+        base = f"https://repo.amd.com/rocm/packages/{os_profile}"
+        return f"{base}/x86_64/" if pkg_type == "rpm" else base
+    elif release_type == "dev":
+        # Dev packages use CloudFront CDN domain
+        # RPM repos need /x86_64/ subdirectory for yum/dnf
+        url = f"https://rocm.devreleases.amd.com/{pkg_type}/{yyyymmdd}-{artifact_id}"
+        return f"{url}/x86_64/" if pkg_type == "rpm" else url
+    else:
+        # CI builds (including empty release_type or 'ci')
+        # Use provided bucket or default to therock-ci-artifacts
+        bucket = s3_bucket or "therock-ci-artifacts"
+
+        # For external repos, include repository name in path
+        if repository and bucket == "therock-ci-artifacts-external":
+            repo_name = repository.replace("/", "-")
+            url = f"https://{bucket}.s3.amazonaws.com/{repo_name}/{artifact_id}-{platform}/packages/{pkg_type}"
+        else:
+            url = f"https://{bucket}.s3.amazonaws.com/{artifact_id}-{platform}/packages/{pkg_type}"
+
+        # RPM repos need /x86_64/ subdirectory for yum/dnf
+        return f"{url}/x86_64/" if pkg_type == "rpm" else url
+
+
 def determine_s3_config(
     release_type: str,
     repository: str,
@@ -99,9 +175,10 @@ def determine_s3_config(
     pkg_type: str,
     artifact_id: str,
     rocm_version: Optional[str] = None,
-) -> Tuple[str, str, str]:
+    platform: str = "linux",
+) -> Tuple[str, str, str, str]:
     """
-    Determine S3 bucket, prefix, and job type based on inputs.
+    Determine S3 bucket, prefix, job type, and public repository URL based on inputs.
 
     Args:
         release_type: Release type ('dev', 'nightly', 'prerelease', 'release', 'ci', or empty)
@@ -110,10 +187,21 @@ def determine_s3_config(
         pkg_type: Package type ('deb' or 'rpm')
         artifact_id: Artifact/run ID for versioning
         rocm_version: ROCm package version string (for date extraction)
+        platform: Platform name ('linux' or 'windows'), defaults to 'linux'
 
     Returns:
-        Tuple of (s3_bucket, s3_prefix, job_type)
+        Tuple of (s3_bucket, s3_prefix, job_type, package_repository_url)
+
+    Raises:
+        ValueError: If pkg_type is 'deb' or 'rpm' but platform is not 'linux'
     """
+    # Validate platform for native packages (deb/rpm are Linux-only)
+    if pkg_type in ("deb", "rpm") and platform != "linux":
+        raise ValueError(
+            f"Package type '{pkg_type}' is only supported on Linux platform, "
+            f"but platform is '{platform}'"
+        )
+
     # Extract date from version for consistency between version and S3 path
     yyyymmdd = extract_date_from_version(rocm_version)
 
@@ -129,29 +217,43 @@ def determine_s3_config(
             print(f"✓ Using release-type bucket: {s3_bucket}", file=sys.stderr)
         else:
             # Dev/Nightly packages go to dated subfolder for versioning
-            s3_prefix = f"v3/packages/{pkg_type}/{yyyymmdd}-{artifact_id}"
+            s3_prefix = f"{pkg_type}/{yyyymmdd}-{artifact_id}"
             job_type = release_type
             print(f"✓ Using release-type bucket: {s3_bucket}", file=sys.stderr)
 
     # Branch 2: Fork PRs or external repositories
     elif is_fork or repository != "ROCm/TheRock":
         s3_bucket = "therock-ci-artifacts-external"
-        s3_prefix = f"v3/packages/{pkg_type}/{yyyymmdd}-{artifact_id}"
+        # Include repository name in prefix to organize by repo
+        repo_name = repository.replace("/", "-")  # e.g., "ROCm-TheRock" or "user-fork"
+        s3_prefix = f"{repo_name}/{artifact_id}-{platform}/packages/{pkg_type}"
         job_type = "ci"
         print(f"✓ Using external bucket: {s3_bucket}", file=sys.stderr)
 
     # Branch 3: Default - ROCm/TheRock non-fork (normal CI builds)
     else:
         s3_bucket = "therock-ci-artifacts"
-        s3_prefix = f"v3/packages/{pkg_type}/{yyyymmdd}-{artifact_id}"
+        s3_prefix = f"{artifact_id}-{platform}/packages/{pkg_type}"
         job_type = "ci"
         print(f"✓ Using default CI bucket: {s3_bucket}", file=sys.stderr)
+
+    # Generate public repository URL
+    package_repository_url = generate_package_repository_url(
+        release_type=release_type if release_type else "ci",
+        pkg_type=pkg_type,
+        yyyymmdd=yyyymmdd,
+        artifact_id=artifact_id,
+        platform=platform,
+        s3_bucket=s3_bucket,
+        repository=repository,
+    )
 
     print(f"S3 bucket: {s3_bucket}", file=sys.stderr)
     print(f"S3 prefix: {s3_prefix}", file=sys.stderr)
     print(f"Job type: {job_type}", file=sys.stderr)
+    print(f"Package repository URL: {package_repository_url}", file=sys.stderr)
 
-    return s3_bucket, s3_prefix, job_type
+    return s3_bucket, s3_prefix, job_type, package_repository_url
 
 
 def main():
@@ -194,6 +296,13 @@ def main():
         help="ROCm package version string (for date extraction, e.g., '8.1.0~dev20251203')",
     )
     parser.add_argument(
+        "--platform",
+        required=False,
+        default="linux",
+        choices=["linux", "windows"],
+        help="Platform name (default: 'linux')",
+    )
+    parser.add_argument(
         "--output-format",
         choices=["env", "json", "github"],
         default="env",
@@ -206,13 +315,14 @@ def main():
     is_fork = args.is_fork.lower() in ("true", "1", "yes")
 
     # Determine S3 configuration
-    s3_bucket, s3_prefix, job_type = determine_s3_config(
+    s3_bucket, s3_prefix, job_type, package_repository_url = determine_s3_config(
         release_type=args.release_type,
         repository=args.repository,
         is_fork=is_fork,
         pkg_type=args.pkg_type,
         artifact_id=args.artifact_id,
         rocm_version=args.rocm_version,
+        platform=args.platform,
     )
 
     # Output in requested format
@@ -221,6 +331,7 @@ def main():
             "s3_bucket": s3_bucket,
             "s3_prefix": s3_prefix,
             "job_type": job_type,
+            "package_repository_url": package_repository_url,
         }
         print(json.dumps(output, indent=2))
     elif args.output_format == "github":
@@ -228,10 +339,12 @@ def main():
         print(f"s3_bucket={s3_bucket}")
         print(f"s3_prefix={s3_prefix}")
         print(f"job_type={job_type}")
+        print(f"package_repository_url={package_repository_url}")
     else:  # env format
         print(f"export S3_BUCKET={s3_bucket}")
         print(f"export S3_PREFIX={s3_prefix}")
         print(f"export JOB_TYPE={job_type}")
+        print(f"export PACKAGE_REPOSITORY_URL={package_repository_url}")
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -10,18 +10,24 @@ Output is always KEY=value (suitable for GITHUB_OUTPUT).
 Subcommands (get operations):
 
   get-base-url         Get base URL (scheme + netloc) from an input URL. Prints repo_base_url=<value>.
+  get-gpg-url          Get GPG key URL for GITHUB_OUTPUT. With --release-type, emits a non-empty URL only for prerelease/release; otherwise gpg_key_url=. Without --release-type, always derives from --from-url (legacy).
   get-repo-sub-folder  Get repo_sub_folder from an S3 prefix (last segment if YYYYMMDD-<id>, else empty). Prints repo_sub_folder=<value>.
   get-repo-url         Get full repo URL from components(release_type, native_package_type, repo_base_url, os_profile, repo_sub_folder). Prints repo_url=<value>.
+  extract-gfx-arch     Extract and normalize GPU architecture from artifact group. Prints gfx_arch=<value>.
 
 Usage:
   python build_tools/packaging/linux/get_url_repo_params.py get-base-url --from-url <url>
+  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url --from-url <url> [--release-type <type>]
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix <prefix>
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url ...
+  python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch --artifact-group <group>
 
 Examples:
   python build_tools/packaging/linux/get_url_repo_params.py get-base-url --from-url https://example.com/v2/whl
+  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url --release-type prerelease --from-url https://rocm.prereleases.amd.com/packages/ubuntu2404
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix v3/packages/deb/20260204-12345
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --release-type prerelease --native-package-type deb --repo-base-url https://x.com --os-profile ubuntu2404 --repo-sub-folder ''
+  python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch --artifact-group gfx94X-dcgpu
 """
 
 import argparse
@@ -48,6 +54,52 @@ def cmd_base_url(args: argparse.Namespace) -> int:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     print(f"repo_base_url={base_url}")
+    return 0
+
+
+# --- gpg_key_url ---
+
+
+def get_gpg_key_url(package_url: str) -> str:
+    """
+    Get GPG key URL from package repository URL.
+
+    Extracts base URL and appends /gpg/rocm.gpg path.
+
+    Examples:
+        https://rocm.prereleases.amd.com/packages/ubuntu2404 -> https://rocm.prereleases.amd.com/gpg/rocm.gpg
+        https://repo.amd.com/rocm/packages/rhel10/x86_64/ -> https://repo.amd.com/gpg/rocm.gpg
+    """
+    base_url = get_base_url(package_url)
+    return f"{base_url}/gpg/rocm.gpg"
+
+
+def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
+    """
+    Whether install workflows should use a repo GPG key URL for this release line.
+
+    When release_type is None, callers treat this as "legacy / unspecified" and always
+    derive the GPG URL from the package URL.
+
+    When release_type is set (e.g. from GitHub Actions), only prerelease and release
+    lines use signed-repo GPG keys; dev/nightly/ci/etc. omit it (empty gpg_key_url).
+    """
+    if release_type is None:
+        return True
+    rt = release_type.strip().lower()
+    return rt in ("prerelease", "release")
+
+
+def cmd_gpg_key_url(args: argparse.Namespace) -> int:
+    if not gpg_key_url_needed_for_release_type(args.release_type):
+        print("gpg_key_url=")
+        return 0
+    try:
+        gpg_url = get_gpg_key_url(args.from_url)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(f"gpg_key_url={gpg_url}")
     return 0
 
 
@@ -116,6 +168,50 @@ def cmd_repo_url(args: argparse.Namespace) -> int:
     return 0
 
 
+# --- extract-gfx-arch ---
+
+
+def extract_gfx_arch(artifact_group: str) -> str:
+    """
+    Extract and normalize GPU architecture from artifact group(s).
+
+    Supports both single and comma/semicolon-separated artifact groups.
+    Output is always comma-separated.
+
+    Examples:
+        gfx94X-dcgpu -> gfx94x
+        gfx1100-consumer -> gfx1100
+        GFX942-server -> gfx942
+        gfx94X-dcgpu,gfx1100-consumer -> gfx94x,gfx1100
+        gfx94X-dcgpu;gfx1100-consumer -> gfx94x,gfx1100
+    """
+    if not artifact_group:
+        raise ValueError("artifact_group cannot be empty")
+
+    # Split on comma or semicolon to handle multiple groups
+    # Replace semicolons with commas for consistent splitting
+    normalized = artifact_group.replace(";", ",")
+    groups = [g.strip() for g in normalized.split(",")]
+
+    # Extract first segment (before dash) and lowercase each
+    archs = [g.split("-")[0].lower() for g in groups if g]
+
+    if not archs:
+        raise ValueError("artifact_group cannot be empty after parsing")
+
+    return ",".join(archs)
+
+
+def cmd_extract_gfx_arch(args: argparse.Namespace) -> int:
+    try:
+        gfx_arch = extract_gfx_arch(args.artifact_group)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(f"gfx_arch={gfx_arch}")
+    return 0
+
+
 # --- main ---
 
 
@@ -140,6 +236,26 @@ def main(argv: list[str] | None = None) -> int:
         help="Any URL to derive base URL from (scheme + netloc only; e.g. https://example.com/v2/whl → https://example.com)",
     )
     p_base.set_defaults(func=cmd_base_url)
+
+    # get-gpg-url: get GPG key URL from package repository URL
+    p_gpg = subparsers.add_parser(
+        "get-gpg-url",
+        help="Print gpg_key_url= for GITHUB_OUTPUT. With --release-type, only prerelease/release get a non-empty URL; otherwise gpg_key_url=. Omit --release-type to always derive from --from-url.",
+    )
+    p_gpg.add_argument(
+        "--from-url",
+        type=str,
+        required=True,
+        metavar="URL",
+        help="Package repository URL to derive GPG key URL from when needed (e.g. https://rocm.prereleases.amd.com/packages/ubuntu2404 → https://rocm.prereleases.amd.com/gpg/rocm.gpg)",
+    )
+    p_gpg.add_argument(
+        "--release-type",
+        type=str,
+        default=None,
+        help="If set, emit non-empty GPG URL only for 'prerelease' or 'release'; for dev/nightly/etc. print gpg_key_url=. If omitted, always derive from --from-url.",
+    )
+    p_gpg.set_defaults(func=cmd_gpg_key_url)
 
     # get-repo-sub-folder: get repo_sub_folder from S3 prefix
     p_repo = subparsers.add_parser(
@@ -190,6 +306,20 @@ def main(argv: list[str] | None = None) -> int:
         help="Repo subfolder (e.g. YYYYMMDD-<id> for dev/nightly; empty for prerelease)",
     )
     p_url.set_defaults(func=cmd_repo_url)
+
+    # extract-gfx-arch: extract GPU architecture from artifact group
+    p_gfx = subparsers.add_parser(
+        "extract-gfx-arch",
+        help="Extract and normalize GPU architecture from artifact group (e.g. gfx94X-dcgpu → gfx94x).",
+    )
+    p_gfx.add_argument(
+        "--artifact-group",
+        type=str,
+        required=True,
+        metavar="GROUP",
+        help="Artifact group to extract gfx_arch from (e.g. gfx94X-dcgpu, gfx1100-consumer)",
+    )
+    p_gfx.set_defaults(func=cmd_extract_gfx_arch)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -835,11 +835,8 @@ gpgcheck=0
 
         print(f"\n[PASS] rdhc.py found at: {rdhc_script}")
 
-        # Check if script is executable or can be run with python
-        if os.access(rdhc_script, os.X_OK):
-            cmd = [str(rdhc_script)]
-        else:
-            cmd = [sys.executable, str(rdhc_script)]
+        # Always run rdhc with this process's interpreter.
+        cmd = [sys.executable, str(rdhc_script)]
 
         # Set RDHC arguments for full test
         test_args = ["--rocm-install-prefix", rocm_install_prefix_arg, "--all"]
@@ -944,8 +941,8 @@ def _build_argument_parser() -> ArgumentParser:
     parser.add_argument(
         "--release-type",
         type=str,
-        choices=["nightly", "prerelease"],
-        help="Type of release: 'nightly' or 'prerelease'",
+        choices=["dev", "nightly", "prerelease", "release", "ci"],
+        help="Type of release: 'dev', 'nightly', 'prerelease', 'release', or 'ci'",
     )
     parser.add_argument(
         "--install-prefix",

--- a/build_tools/packaging/linux/setup_python_cmd.sh
+++ b/build_tools/packaging/linux/setup_python_cmd.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Install Python runtime by --os-profile (optional) and emit PYTHON_CMD for CI.
+#
+# Package mapping by os_profile (default: distro python3 on PATH):
+#
+# - ubuntu* / debian* -> apt: python3, python3-venv, python3-pip -> PYTHON_CMD=python3
+# - sles* -> zypper: python313, python313-pip (SLE/BCI; unversioned python3 / python3-pip are not valid package names) -> PYTHON_CMD=python3.13
+# - else (e.g. UBI 10 / RHEL-like) -> dnf: python3, python3-pip -> PYTHON_CMD=python3
+#
+# Optional --python-version X.Y (e.g. 3.12): install that stream where supported
+# (apt + dnf). Use on UBI 9 / RHEL 9 when default python3 is older than you need.
+# On SLES, --python-version is ignored (zypper names vary); distro python3 is used.
+#
+# Use --install-runtime in CI so Python install lives in this script (not the workflow
+# prerequisites). The workflow may run a tiny bootstrap if python3 is missing before
+# calling this script.
+#
+# --output-format matches get_s3_config.py: env, json, github.
+#
+# Sample usage
+# ------------
+#
+# CI (install + append PYTHON_CMD to GITHUB_ENV):
+#
+#     bash build_tools/packaging/linux/setup_python_cmd.sh \
+#         --os-profile ubuntu2404 --install-runtime >> "$GITHUB_ENV"
+#
+# UBI 9 / older RHEL-like: pin 3.12 from AppStream / repos:
+#
+#     bash build_tools/packaging/linux/setup_python_cmd.sh \
+#         --os-profile rhel9 --python-version 3.12 --install-runtime >> "$GITHUB_ENV"
+#
+# Emit PYTHON_CMD only (no package install):
+#
+#     bash build_tools/packaging/linux/setup_python_cmd.sh --os-profile rhel10 --output-format json
+
+set -euo pipefail
+
+# Defaults
+OS_PROFILE=""
+INSTALL_RUNTIME=false
+OUTPUT_FORMAT="github"
+PY_MM="" # e.g. 3.12 when --python-version set; empty = distro default python3
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --os-profile)
+            OS_PROFILE="$2"
+            shift 2
+            ;;
+        --install-runtime)
+            INSTALL_RUNTIME=true
+            shift
+            ;;
+        --python-version)
+            PY_MM="$2"
+            shift 2
+            ;;
+        --output-format)
+            OUTPUT_FORMAT="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$OS_PROFILE" ]]; then
+    echo "Error: --os-profile is required" >&2
+    exit 1
+fi
+
+# Trim whitespace; lowercase for glob matching (e.g. SLES16 must match sles*)
+OS_PROFILE="${OS_PROFILE#"${OS_PROFILE%%[![:space:]]*}"}"
+OS_PROFILE="${OS_PROFILE%"${OS_PROFILE##*[![:space:]]}"}"
+OS_PLC="${OS_PROFILE,,}"
+
+if [[ -n "$PY_MM" ]] && ! [[ "$PY_MM" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: --python-version must be MAJOR.MINOR (e.g. 3.12)" >&2
+    exit 1
+fi
+
+if [[ -n "$PY_MM" ]]; then
+    PYTHON_CMD="python${PY_MM}"
+elif [[ "$OS_PLC" == sles* ]]; then
+    # SLE/BCI: no installable "python3" metapackage; use python313 -> python3.13
+    PYTHON_CMD="python3.13"
+else
+    PYTHON_CMD="python3"
+fi
+
+# Install Python and pip with apt/zypper/dnf
+install_python_runtime() {
+    local os_profile="$1"
+
+    if [[ "$os_profile" == ubuntu* ]] || [[ "$os_profile" == debian* ]]; then
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -qq >&2
+        if [[ -n "$PY_MM" ]]; then
+            apt-get install -y --no-install-recommends \
+                "python${PY_MM}" \
+                "python${PY_MM}-venv" \
+                "python${PY_MM}-pip" >&2
+        else
+            apt-get install -y --no-install-recommends \
+                python3 \
+                python3-venv \
+                python3-pip >&2
+        fi
+    elif [[ "$os_profile" == sles* ]]; then
+        if [[ -n "$PY_MM" ]]; then
+            echo "Warning: --python-version is not applied on SLES; using python313 stack" >&2
+        fi
+        zypper --non-interactive refresh >&2
+        zypper --non-interactive install -y \
+            python313 \
+            python313-pip >&2
+    else
+        # dnf: UBI 9 / RHEL 9 default python3 may be < 3.12; use --python-version 3.12 when needed
+        if [[ -n "$PY_MM" ]]; then
+            dnf install -y --allowerasing \
+                "python${PY_MM}" \
+                "python${PY_MM}-pip" >&2
+        else
+            dnf install -y --allowerasing \
+                python3 \
+                python3-pip >&2
+        fi
+    fi
+}
+
+# Install first so emitted PYTHON_CMD exists on PATH for later workflow steps
+if [[ "$INSTALL_RUNTIME" == true ]]; then
+    install_python_runtime "$OS_PLC"
+fi
+
+# Emit output in requested format
+case "$OUTPUT_FORMAT" in
+    json)
+        echo "{\"python_cmd\": \"$PYTHON_CMD\"}"
+        ;;
+    github)
+        echo "PYTHON_CMD=$PYTHON_CMD"
+        ;;
+    env)
+        echo "export PYTHON_CMD=$PYTHON_CMD"
+        ;;
+    *)
+        echo "Error: Unknown output format: $OUTPUT_FORMAT" >&2
+        exit 1
+        ;;
+esac

--- a/build_tools/packaging/linux/tests/get_s3_config_test.py
+++ b/build_tools/packaging/linux/tests/get_s3_config_test.py
@@ -14,6 +14,99 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import get_s3_config
 
 
+class GeneratePackageRepositoryUrlTest(unittest.TestCase):
+    """Tests for package repository URL generation."""
+
+    def test_ci_url(self):
+        """Test CI build URL format."""
+        url = get_s3_config.generate_package_repository_url(
+            release_type="ci",
+            pkg_type="deb",
+            yyyymmdd="20260320",
+            artifact_id="12345678",
+            platform="linux",
+        )
+        self.assertEqual(
+            url,
+            "https://therock-ci-artifacts.s3.amazonaws.com/12345678-linux/packages/deb",
+        )
+
+    def test_nightly_url(self):
+        """Test nightly build URL format (RPM includes /x86_64/)."""
+        url = get_s3_config.generate_package_repository_url(
+            release_type="nightly",
+            pkg_type="rpm",
+            yyyymmdd="20260320",
+            artifact_id="87654321",
+        )
+        self.assertEqual(
+            url, "https://rocm.nightlies.amd.com/rpm/20260320-87654321/x86_64/"
+        )
+
+    def test_prerelease_url(self):
+        """Test prerelease URL format with default OS profile (ubuntu2404 for deb)."""
+        url = get_s3_config.generate_package_repository_url(
+            release_type="prerelease",
+            pkg_type="deb",
+            yyyymmdd="20260320",
+            artifact_id="12345678",
+        )
+        self.assertEqual(url, "https://rocm.prereleases.amd.com/packages/ubuntu2404")
+
+    def test_release_url(self):
+        """Test release URL format with default OS profile (rhel10 for rpm includes /x86_64/)."""
+        url = get_s3_config.generate_package_repository_url(
+            release_type="release",
+            pkg_type="rpm",
+            yyyymmdd="20260320",
+            artifact_id="12345678",
+        )
+        self.assertEqual(url, "https://repo.amd.com/rocm/packages/rhel10/x86_64/")
+
+    def test_dev_url(self):
+        """Test dev build URL format."""
+        url = get_s3_config.generate_package_repository_url(
+            release_type="dev",
+            pkg_type="deb",
+            yyyymmdd="20260320",
+            artifact_id="11111111",
+        )
+        self.assertEqual(
+            url,
+            "https://rocm.devreleases.amd.com/deb/20260320-11111111",
+        )
+
+    def test_empty_release_type_uses_ci(self):
+        """Test that empty release type falls back to CI URL."""
+        url = get_s3_config.generate_package_repository_url(
+            release_type="",
+            pkg_type="deb",
+            yyyymmdd="20260320",
+            artifact_id="99999999",
+            platform="linux",
+        )
+        self.assertEqual(
+            url,
+            "https://therock-ci-artifacts.s3.amazonaws.com/99999999-linux/packages/deb",
+        )
+
+    def test_external_repo_url(self):
+        """Test external repository URL includes repository name in path."""
+        url = get_s3_config.generate_package_repository_url(
+            release_type="ci",
+            pkg_type="deb",
+            yyyymmdd="20260320",
+            artifact_id="12345678",
+            platform="linux",
+            s3_bucket="therock-ci-artifacts-external",
+            repository="someone/fork",
+        )
+        self.assertEqual(
+            url,
+            "https://therock-ci-artifacts-external.s3.amazonaws.com/someone-fork/12345678-linux/packages/deb",
+        )
+
+
 class ExtractDateFromVersionTest(unittest.TestCase):
     """Tests for date extraction from ROCm package versions."""
 
@@ -67,7 +160,7 @@ class DetermineS3ConfigReleaseTypeTest(unittest.TestCase):
 
     def test_dev_release_type(self):
         """Test dev release type uses dev-packages bucket."""
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="dev",
             repository="ROCm/TheRock",
             is_fork=False,
@@ -76,12 +169,12 @@ class DetermineS3ConfigReleaseTypeTest(unittest.TestCase):
             rocm_version="8.1.0~dev20251203",
         )
         self.assertEqual(bucket, "therock-dev-packages")
-        self.assertEqual(prefix, "v3/packages/deb/20251203-12345678")
+        self.assertEqual(prefix, "deb/20251203-12345678")
         self.assertEqual(job_type, "dev")
 
     def test_nightly_release_type(self):
         """Test nightly release type uses nightly-packages bucket."""
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="nightly",
             repository="ROCm/TheRock",
             is_fork=False,
@@ -90,12 +183,12 @@ class DetermineS3ConfigReleaseTypeTest(unittest.TestCase):
             rocm_version="8.1.0~20251203",
         )
         self.assertEqual(bucket, "therock-nightly-packages")
-        self.assertEqual(prefix, "v3/packages/rpm/20251203-87654321")
+        self.assertEqual(prefix, "rpm/20251203-87654321")
         self.assertEqual(job_type, "nightly")
 
     def test_prerelease_release_type(self):
         """Test prerelease uses prerelease-packages bucket without date."""
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="prerelease",
             repository="ROCm/TheRock",
             is_fork=False,
@@ -109,7 +202,7 @@ class DetermineS3ConfigReleaseTypeTest(unittest.TestCase):
 
     def test_release_release_type(self):
         """Test release uses release-packages bucket without date."""
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="release",
             repository="ROCm/TheRock",
             is_fork=False,
@@ -123,7 +216,7 @@ class DetermineS3ConfigReleaseTypeTest(unittest.TestCase):
 
     def test_ci_release_type(self):
         """Test 'ci' release type falls through to CI bucket logic."""
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="ci",
             repository="ROCm/TheRock",
             is_fork=False,
@@ -132,12 +225,12 @@ class DetermineS3ConfigReleaseTypeTest(unittest.TestCase):
             rocm_version=None,
         )
         self.assertEqual(bucket, "therock-ci-artifacts")
-        self.assertIn("v3/packages/deb/", prefix)
+        self.assertEqual(prefix, "12345678-linux/packages/deb")
         self.assertEqual(job_type, "ci")
 
     def test_empty_release_type(self):
         """Test empty release type falls through to CI bucket logic."""
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="",
             repository="ROCm/TheRock",
             is_fork=False,
@@ -146,7 +239,7 @@ class DetermineS3ConfigReleaseTypeTest(unittest.TestCase):
             rocm_version=None,
         )
         self.assertEqual(bucket, "therock-ci-artifacts")
-        self.assertIn("v3/packages/deb/", prefix)
+        self.assertEqual(prefix, "12345678-linux/packages/deb")
         self.assertEqual(job_type, "ci")
 
 
@@ -154,8 +247,8 @@ class DetermineS3ConfigRepositoryTest(unittest.TestCase):
     """Tests for S3 config with different repositories."""
 
     def test_fork_pr(self):
-        """Test fork PR uses external bucket."""
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        """Test fork PR uses external bucket with repository prefix."""
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="",
             repository="ROCm/TheRock",
             is_fork=True,
@@ -164,12 +257,12 @@ class DetermineS3ConfigRepositoryTest(unittest.TestCase):
             rocm_version="8.1.0~dev20251203",
         )
         self.assertEqual(bucket, "therock-ci-artifacts-external")
-        self.assertEqual(prefix, "v3/packages/rpm/20251203-12345678")
+        self.assertEqual(prefix, "ROCm-TheRock/12345678-linux/packages/rpm")
         self.assertEqual(job_type, "ci")
 
     def test_external_repository(self):
-        """Test external repository uses external bucket."""
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        """Test external repository uses external bucket with repository prefix."""
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="",
             repository="someone/fork",
             is_fork=False,
@@ -178,12 +271,12 @@ class DetermineS3ConfigRepositoryTest(unittest.TestCase):
             rocm_version="8.1.0~dev20251203",
         )
         self.assertEqual(bucket, "therock-ci-artifacts-external")
-        self.assertEqual(prefix, "v3/packages/deb/20251203-12345678")
+        self.assertEqual(prefix, "someone-fork/12345678-linux/packages/deb")
         self.assertEqual(job_type, "ci")
 
     def test_default_rocm_therock(self):
         """Test default ROCm/TheRock uses ci-artifacts bucket."""
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="",
             repository="ROCm/TheRock",
             is_fork=False,
@@ -192,7 +285,7 @@ class DetermineS3ConfigRepositoryTest(unittest.TestCase):
             rocm_version="8.1.0~dev20251203",
         )
         self.assertEqual(bucket, "therock-ci-artifacts")
-        self.assertEqual(prefix, "v3/packages/deb/20251203-12345678")
+        self.assertEqual(prefix, "12345678-linux/packages/deb")
         self.assertEqual(job_type, "ci")
 
 
@@ -201,7 +294,7 @@ class DetermineS3ConfigPackageTypeTest(unittest.TestCase):
 
     def test_deb_package_type(self):
         """Test deb package type in prefix."""
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="dev",
             repository="ROCm/TheRock",
             is_fork=False,
@@ -213,7 +306,7 @@ class DetermineS3ConfigPackageTypeTest(unittest.TestCase):
 
     def test_rpm_package_type(self):
         """Test rpm package type in prefix."""
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="dev",
             repository="ROCm/TheRock",
             is_fork=False,
@@ -230,7 +323,7 @@ class DetermineS3ConfigDateConsistencyTest(unittest.TestCase):
     def test_date_extracted_from_deb_version(self):
         """Test date in S3 path matches date in deb version."""
         version = "8.1.0~dev20251203"
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="dev",
             repository="ROCm/TheRock",
             is_fork=False,
@@ -244,7 +337,7 @@ class DetermineS3ConfigDateConsistencyTest(unittest.TestCase):
     def test_date_extracted_from_rpm_version(self):
         """Test date in S3 path matches date in rpm version."""
         version = "8.1.0~20251203gf689a8e"
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="dev",
             repository="ROCm/TheRock",
             is_fork=False,
@@ -258,7 +351,7 @@ class DetermineS3ConfigDateConsistencyTest(unittest.TestCase):
     def test_date_extracted_from_wheel_version(self):
         """Test date in S3 path matches date in wheel version."""
         version = "7.10.0a20251021"
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="nightly",
             repository="ROCm/TheRock",
             is_fork=False,
@@ -275,7 +368,7 @@ class DetermineS3ConfigDateConsistencyTest(unittest.TestCase):
         mock_now = mock_datetime.now.return_value
         mock_now.strftime.return_value = "20260312"
 
-        bucket, prefix, job_type = get_s3_config.determine_s3_config(
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
             release_type="dev",
             repository="ROCm/TheRock",
             is_fork=False,
@@ -285,6 +378,165 @@ class DetermineS3ConfigDateConsistencyTest(unittest.TestCase):
         )
         # Should use current date
         self.assertIn("20260312", prefix)
+
+
+class PlatformValidationTest(unittest.TestCase):
+    """Tests for platform validation with native packages."""
+
+    def test_deb_on_windows_raises_error(self):
+        """Test that deb packages on Windows platform raises ValueError."""
+        with self.assertRaises(ValueError) as context:
+            get_s3_config.determine_s3_config(
+                release_type="ci",
+                repository="ROCm/TheRock",
+                is_fork=False,
+                pkg_type="deb",
+                artifact_id="12345678",
+                rocm_version=None,
+                platform="windows",
+            )
+        self.assertIn("deb", str(context.exception))
+        self.assertIn("Linux", str(context.exception))
+        self.assertIn("windows", str(context.exception))
+
+    def test_rpm_on_windows_raises_error(self):
+        """Test that rpm packages on Windows platform raises ValueError."""
+        with self.assertRaises(ValueError) as context:
+            get_s3_config.determine_s3_config(
+                release_type="dev",
+                repository="ROCm/TheRock",
+                is_fork=False,
+                pkg_type="rpm",
+                artifact_id="12345678",
+                rocm_version="8.1.0~dev20251203",
+                platform="windows",
+            )
+        self.assertIn("rpm", str(context.exception))
+        self.assertIn("Linux", str(context.exception))
+        self.assertIn("windows", str(context.exception))
+
+    def test_deb_on_linux_succeeds(self):
+        """Test that deb packages on Linux platform works correctly."""
+        bucket, prefix, job_type, _ = get_s3_config.determine_s3_config(
+            release_type="ci",
+            repository="ROCm/TheRock",
+            is_fork=False,
+            pkg_type="deb",
+            artifact_id="12345678",
+            rocm_version=None,
+            platform="linux",
+        )
+        self.assertEqual(bucket, "therock-ci-artifacts")
+        self.assertEqual(prefix, "12345678-linux/packages/deb")
+        self.assertEqual(job_type, "ci")
+
+
+class PackageRepositoryUrlRpmArchTest(unittest.TestCase):
+    """Tests to ensure RPM URLs include /x86_64/ suffix."""
+
+    def test_nightly_rpm_includes_x86_64(self):
+        """Test nightly RPM URL includes /x86_64/ suffix."""
+        _, _, _, repo_url = get_s3_config.determine_s3_config(
+            release_type="nightly",
+            repository="ROCm/TheRock",
+            is_fork=False,
+            pkg_type="rpm",
+            artifact_id="12345678",
+            rocm_version="8.1.0~20251203",
+        )
+        self.assertTrue(repo_url.endswith("/x86_64/"))
+        self.assertIn("rpm/20251203-12345678/x86_64/", repo_url)
+
+    def test_nightly_deb_no_x86_64(self):
+        """Test nightly DEB URL does not include /x86_64/."""
+        _, _, _, repo_url = get_s3_config.determine_s3_config(
+            release_type="nightly",
+            repository="ROCm/TheRock",
+            is_fork=False,
+            pkg_type="deb",
+            artifact_id="12345678",
+            rocm_version="8.1.0~20251203",
+        )
+        self.assertNotIn("/x86_64/", repo_url)
+        self.assertIn("deb/20251203-12345678", repo_url)
+
+    def test_dev_rpm_includes_x86_64(self):
+        """Test dev RPM URL includes /x86_64/ suffix."""
+        _, _, _, repo_url = get_s3_config.determine_s3_config(
+            release_type="dev",
+            repository="ROCm/TheRock",
+            is_fork=False,
+            pkg_type="rpm",
+            artifact_id="12345678",
+            rocm_version="8.1.0~dev20251203",
+        )
+        self.assertTrue(repo_url.endswith("/x86_64/"))
+        self.assertIn("rpm/20251203-12345678/x86_64/", repo_url)
+
+    def test_ci_rpm_includes_x86_64(self):
+        """Test CI RPM URL includes /x86_64/ suffix."""
+        _, _, _, repo_url = get_s3_config.determine_s3_config(
+            release_type="ci",
+            repository="ROCm/TheRock",
+            is_fork=False,
+            pkg_type="rpm",
+            artifact_id="12345678",
+            rocm_version=None,
+        )
+        self.assertTrue(repo_url.endswith("/x86_64/"))
+        self.assertIn("packages/rpm/x86_64/", repo_url)
+
+    def test_ci_deb_no_x86_64(self):
+        """Test CI DEB URL does not include /x86_64/."""
+        _, _, _, repo_url = get_s3_config.determine_s3_config(
+            release_type="ci",
+            repository="ROCm/TheRock",
+            is_fork=False,
+            pkg_type="deb",
+            artifact_id="12345678",
+            rocm_version=None,
+        )
+        self.assertNotIn("/x86_64/", repo_url)
+        self.assertIn("packages/deb", repo_url)
+
+    def test_prerelease_rpm_includes_x86_64(self):
+        """Test prerelease RPM URL includes /x86_64/ suffix."""
+        _, _, _, repo_url = get_s3_config.determine_s3_config(
+            release_type="prerelease",
+            repository="ROCm/TheRock",
+            is_fork=False,
+            pkg_type="rpm",
+            artifact_id="12345678",
+            rocm_version="8.1.0~pre2",
+        )
+        self.assertTrue(repo_url.endswith("/x86_64/"))
+        self.assertIn("rhel10/x86_64/", repo_url)
+
+    def test_prerelease_deb_no_x86_64(self):
+        """Test prerelease DEB URL does not include /x86_64/."""
+        _, _, _, repo_url = get_s3_config.determine_s3_config(
+            release_type="prerelease",
+            repository="ROCm/TheRock",
+            is_fork=False,
+            pkg_type="deb",
+            artifact_id="12345678",
+            rocm_version="8.1.0~pre2",
+        )
+        self.assertNotIn("/x86_64/", repo_url)
+        self.assertIn("ubuntu2404", repo_url)
+
+    def test_release_rpm_includes_x86_64(self):
+        """Test release RPM URL includes /x86_64/ suffix."""
+        _, _, _, repo_url = get_s3_config.determine_s3_config(
+            release_type="release",
+            repository="ROCm/TheRock",
+            is_fork=False,
+            pkg_type="rpm",
+            artifact_id="12345678",
+            rocm_version="8.1.0",
+        )
+        self.assertTrue(repo_url.endswith("/x86_64/"))
+        self.assertIn("rhel10/x86_64/", repo_url)
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -1,8 +1,10 @@
+#!/usr/bin/env python3
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
 # Unit test coverage for get_url_repo_params.py:
-#   get_base_url, get_repo_sub_folder, get_repo_url, and main() subcommands.
+#   get_base_url, get_gpg_key_url, gpg_key_url_needed_for_release_type, get_repo_sub_folder,
+#   get_repo_url, extract_gfx_arch, and main() subcommands.
 
 import os
 import sys
@@ -48,6 +50,63 @@ class GetBaseUrlTest(unittest.TestCase):
         # Test that get_base_url raises ValueError for empty or invalid URL.
         with self.assertRaises(ValueError):
             get_url_repo_params.get_base_url("")
+
+
+class GetGpgKeyUrlTest(unittest.TestCase):
+    """Tests for get_gpg_key_url()."""
+
+    def test_extracts_base_and_adds_gpg_path(self):
+        # Test that get_gpg_key_url extracts base URL and appends /gpg/rocm.gpg.
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url(
+                "https://rocm.prereleases.amd.com/packages/ubuntu2404"
+            ),
+            "https://rocm.prereleases.amd.com/gpg/rocm.gpg",
+        )
+
+    def test_strips_path_from_url(self):
+        # Test that get_gpg_key_url strips path and query from URL.
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url(
+                "https://repo.amd.com/rocm/packages/rhel10/x86_64/"
+            ),
+            "https://repo.amd.com/gpg/rocm.gpg",
+        )
+
+    def test_handles_nightly_url(self):
+        # Test that get_gpg_key_url works with nightly URLs.
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url(
+                "https://rocm.nightlies.amd.com/deb/20260204-12345/"
+            ),
+            "https://rocm.nightlies.amd.com/gpg/rocm.gpg",
+        )
+
+
+class GpgKeyUrlNeededForReleaseTypeTest(unittest.TestCase):
+    """Tests for gpg_key_url_needed_for_release_type()."""
+
+    def test_none_means_always_derive(self):
+        self.assertTrue(get_url_repo_params.gpg_key_url_needed_for_release_type(None))
+
+    def test_prerelease_and_release(self):
+        self.assertTrue(
+            get_url_repo_params.gpg_key_url_needed_for_release_type("prerelease")
+        )
+        self.assertTrue(
+            get_url_repo_params.gpg_key_url_needed_for_release_type("release")
+        )
+        self.assertTrue(
+            get_url_repo_params.gpg_key_url_needed_for_release_type("  Prerelease  ")
+        )
+
+    def test_dev_nightly_ci_empty(self):
+        self.assertFalse(get_url_repo_params.gpg_key_url_needed_for_release_type("dev"))
+        self.assertFalse(
+            get_url_repo_params.gpg_key_url_needed_for_release_type("nightly")
+        )
+        self.assertFalse(get_url_repo_params.gpg_key_url_needed_for_release_type("ci"))
+        self.assertFalse(get_url_repo_params.gpg_key_url_needed_for_release_type(""))
 
 
 class GetRepoSubFolderTest(unittest.TestCase):
@@ -153,6 +212,79 @@ class GetRepoUrlTest(unittest.TestCase):
         )
 
 
+class ExtractGfxArchTest(unittest.TestCase):
+    """Tests for extract_gfx_arch()."""
+
+    def test_extracts_and_lowercases_gfx_arch(self):
+        # Test that extract_gfx_arch returns the first segment lowercased.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu"),
+            "gfx94x",
+        )
+
+    def test_handles_lowercase_input(self):
+        # Test that extract_gfx_arch works with already-lowercase input.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("gfx1100-consumer"),
+            "gfx1100",
+        )
+
+    def test_handles_uppercase_prefix(self):
+        # Test that extract_gfx_arch lowercases uppercase prefix.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("GFX942-server"),
+            "gfx942",
+        )
+
+    def test_handles_no_dash(self):
+        # Test that extract_gfx_arch returns the whole string if no dash present.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("gfx1100"),
+            "gfx1100",
+        )
+
+    def test_empty_string_raises(self):
+        # Test that extract_gfx_arch raises ValueError for empty string.
+        with self.assertRaises(ValueError) as ctx:
+            get_url_repo_params.extract_gfx_arch("")
+        self.assertIn("cannot be empty", str(ctx.exception))
+
+    def test_handles_multiple_dashes(self):
+        # Test that extract_gfx_arch only takes first segment when multiple dashes.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu-extra-info"),
+            "gfx94x",
+        )
+
+    def test_comma_separated_list(self):
+        # Test that extract_gfx_arch handles comma-separated artifact groups.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu,gfx1100-consumer"),
+            "gfx94x,gfx1100",
+        )
+
+    def test_semicolon_separated_list(self):
+        # Test that extract_gfx_arch handles semicolon-separated artifact groups.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu;gfx1100-consumer"),
+            "gfx94x,gfx1100",
+        )
+
+    def test_mixed_case_list(self):
+        # Test that extract_gfx_arch lowercases all items in list.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("GFX942-server,GFX1100-consumer"),
+            "gfx942,gfx1100",
+        )
+
+    def test_list_with_spaces(self):
+        # Test that extract_gfx_arch strips whitespace from list items.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu , gfx1100-consumer"),
+            "gfx94x,gfx1100",
+        )
+
+
 class MainSubcommandsTest(unittest.TestCase):
     """Tests for main() subcommands (get-base-url, get-repo-sub-folder, get-repo-url)."""
 
@@ -227,6 +359,141 @@ class MainSubcommandsTest(unittest.TestCase):
                     ]
                 )
         self.assertEqual(code, 1)
+
+    def test_extract_gfx_arch_success(self):
+        # Test that extract-gfx-arch subcommand prints gfx_arch= and returns 0.
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                ["extract-gfx-arch", "--artifact-group", "gfx94X-dcgpu"]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn("gfx_arch=gfx94x", output)
+
+    def test_extract_gfx_arch_lowercase(self):
+        # Test that extract-gfx-arch handles already-lowercase input.
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                ["extract-gfx-arch", "--artifact-group", "gfx1100-consumer"]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn("gfx_arch=gfx1100", output)
+
+    def test_extract_gfx_arch_empty_returns_one(self):
+        # Test that extract-gfx-arch with empty artifact_group returns 1.
+        with patch("sys.stderr"):
+            code = get_url_repo_params.main(
+                ["extract-gfx-arch", "--artifact-group", ""]
+            )
+        self.assertEqual(code, 1)
+
+    def test_extract_gfx_arch_comma_list(self):
+        # Test that extract-gfx-arch handles comma-separated list.
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                [
+                    "extract-gfx-arch",
+                    "--artifact-group",
+                    "gfx94X-dcgpu,gfx1100-consumer",
+                ]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn("gfx_arch=gfx94x,gfx1100", output)
+
+    def test_extract_gfx_arch_semicolon_list(self):
+        # Test that extract-gfx-arch handles semicolon-separated list.
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                [
+                    "extract-gfx-arch",
+                    "--artifact-group",
+                    "gfx94X-dcgpu;gfx1100-consumer",
+                ]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn("gfx_arch=gfx94x,gfx1100", output)
+
+    def test_get_gpg_url_success(self):
+        # Test that get-gpg-url subcommand prints gpg_key_url= and returns 0.
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                [
+                    "get-gpg-url",
+                    "--from-url",
+                    "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+                ]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn(
+            "gpg_key_url=https://rocm.prereleases.amd.com/gpg/rocm.gpg", output
+        )
+
+    def test_get_gpg_url_with_release_type_dev_emits_empty(self):
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                [
+                    "get-gpg-url",
+                    "--release-type",
+                    "dev",
+                    "--from-url",
+                    "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+                ]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn("gpg_key_url=", output)
+        self.assertNotIn("rocm.gpg", output)
+
+    def test_get_gpg_url_with_release_type_dev_ignores_invalid_url(self):
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                [
+                    "get-gpg-url",
+                    "--release-type",
+                    "nightly",
+                    "--from-url",
+                    "not-a-valid-url",
+                ]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertEqual(output.strip(), "gpg_key_url=")
+
+    def test_get_gpg_url_with_release_type_prerelease(self):
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                [
+                    "get-gpg-url",
+                    "--release-type",
+                    "prerelease",
+                    "--from-url",
+                    "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+                ]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn(
+            "gpg_key_url=https://rocm.prereleases.amd.com/gpg/rocm.gpg", output
+        )
+
+    def test_get_gpg_url_with_release_type_release(self):
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                [
+                    "get-gpg-url",
+                    "--release-type",
+                    "release",
+                    "--from-url",
+                    "https://repo.amd.com/rocm/packages/rhel10/x86_64/",
+                ]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn("gpg_key_url=https://repo.amd.com/gpg/rocm.gpg", output)
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/tests/setup_python_cmd_test.sh
+++ b/build_tools/packaging/linux/tests/setup_python_cmd_test.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Test suite for setup_python_cmd.sh
+# Run with: bash build_tools/packaging/linux/tests/setup_python_cmd_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_SCRIPT="$SCRIPT_DIR/../setup_python_cmd.sh"
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Test helper functions
+assert_equals() {
+    local expected="$1"
+    local actual="$2"
+    local test_name="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [[ "$expected" == "$actual" ]]; then
+        echo -e "${GREEN}✓${NC} $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} $test_name"
+        echo "  Expected: $expected"
+        echo "  Actual: $actual"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+assert_contains() {
+    local substring="$1"
+    local string="$2"
+    local test_name="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [[ "$string" == *"$substring"* ]]; then
+        echo -e "${GREEN}✓${NC} $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} $test_name"
+        echo "  Expected to contain: $substring"
+        echo "  Actual: $string"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# Test resolve_python_cmd logic (output format tests)
+test_ubuntu_profiles() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile ubuntu2404 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "Ubuntu 24.04 resolves to python3.12"
+
+    output=$(bash "$SETUP_SCRIPT" --os-profile ubuntu2204 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "Ubuntu 22.04 resolves to python3.12"
+
+    output=$(bash "$SETUP_SCRIPT" --os-profile ubuntu2004 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "Ubuntu 20.04 resolves to python3.12"
+}
+
+test_debian_profiles() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile debian12 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "Debian 12 resolves to python3.12"
+
+    output=$(bash "$SETUP_SCRIPT" --os-profile debian11 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "Debian 11 resolves to python3.12"
+}
+
+test_sles_profiles() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile sles16 --output-format github)
+    assert_equals "PYTHON_CMD=python3.13" "$output" "SLES 16 resolves to python3.13"
+
+    output=$(bash "$SETUP_SCRIPT" --os-profile sles15 --output-format github)
+    assert_equals "PYTHON_CMD=python3.13" "$output" "SLES 15 resolves to python3.13"
+}
+
+test_rhel_profiles() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile rhel10 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "RHEL 10 resolves to python3.12"
+
+    output=$(bash "$SETUP_SCRIPT" --os-profile rhel9 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "RHEL 9 resolves to python3.12"
+}
+
+test_centos_profiles() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile centos9 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "CentOS 9 resolves to python3.12 (default case)"
+}
+
+# Test output formats
+test_json_output() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile ubuntu2404 --output-format json)
+    assert_equals '{"python_cmd": "python3.12"}' "$output" "JSON output format for Ubuntu"
+
+    output=$(bash "$SETUP_SCRIPT" --os-profile sles16 --output-format json)
+    assert_equals '{"python_cmd": "python3.13"}' "$output" "JSON output format for SLES"
+}
+
+test_github_output() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile rhel10 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "GitHub output format for RHEL"
+}
+
+test_env_output() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile ubuntu2404 --output-format env)
+    assert_equals "export PYTHON_CMD=python3.12" "$output" "Env output format for Ubuntu"
+
+    output=$(bash "$SETUP_SCRIPT" --os-profile sles16 --output-format env)
+    assert_equals "export PYTHON_CMD=python3.13" "$output" "Env output format for SLES"
+}
+
+# Test error handling
+test_missing_os_profile() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if bash "$SETUP_SCRIPT" --output-format github 2>/dev/null; then
+        echo -e "${RED}✗${NC} Missing --os-profile should fail"
+        echo "  Expected: error exit code"
+        echo "  Actual: success"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    else
+        echo -e "${GREEN}✓${NC} Missing --os-profile should fail"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    fi
+}
+
+test_invalid_output_format() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if bash "$SETUP_SCRIPT" --os-profile ubuntu2404 --output-format invalid 2>/dev/null; then
+        echo -e "${RED}✗${NC} Invalid --output-format should fail"
+        echo "  Expected: error exit code"
+        echo "  Actual: success"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    else
+        echo -e "${GREEN}✓${NC} Invalid --output-format should fail"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    fi
+}
+
+# Run all tests
+echo "Running setup_python_cmd.sh tests..."
+echo ""
+
+test_ubuntu_profiles
+test_debian_profiles
+test_sles_profiles
+test_rhel_profiles
+test_centos_profiles
+test_json_output
+test_github_output
+test_env_output
+test_missing_os_profile
+test_invalid_output_format
+
+# Print summary
+echo ""
+echo "========================================"
+echo "Test Summary"
+echo "========================================"
+echo "Tests run: $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+    exit 1
+else
+    echo -e "Tests failed: $TESTS_FAILED"
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -611,12 +611,17 @@ def main():
         "--job",
         default="dev",
         choices=["dev", "nightly", "prerelease", "ci"],
-        help="Job type: dev, nightly, prerelease, or ci",
+        help="Job type: dev, nightly, prerelease, or ci (defaults to dev)",
     )
     parser.add_argument(
         "--s3-prefix",
         required=False,
         help="Override S3 prefix (for backward compatibility, auto-generated if not provided)",
+    )
+    parser.add_argument(
+        "--platform",
+        default="linux",
+        help="Platform name (linux or windows), defaults to linux",
     )
 
     args = parser.parse_args()
@@ -628,7 +633,7 @@ def main():
         prefix = args.s3_prefix
         dedupe = True
     elif args.job in ["nightly", "dev"]:
-        # Legacy behavior: <pkg_type>/<YYYYMMDD>-<artifact_id>
+        # Dev/Nightly: <pkg_type>/<YYYYMMDD>-<artifact_id>
         prefix = f"{args.pkg_type}/{yyyymmdd()}-{args.artifact_id}"
         dedupe = True
     elif args.job == "prerelease":
@@ -636,8 +641,12 @@ def main():
         prefix = f"v3/packages/{args.pkg_type}"
         dedupe = True
     elif args.job == "ci":
-        # CI builds: v3/packages/<pkg_type>/<YYYYMMDD>-<artifact_id>
-        prefix = f"v3/packages/{args.pkg_type}/{yyyymmdd()}-{args.artifact_id}"
+        # CI builds: <artifact_id>-<platform>/packages/<pkg_type>
+        # For external bucket, include repository prefix (defaults to ROCm-TheRock)
+        if args.s3_bucket == "therock-ci-artifacts-external":
+            prefix = f"ROCm-TheRock/{args.artifact_id}-{args.platform}/packages/{args.pkg_type}"
+        else:
+            prefix = f"{args.artifact_id}-{args.platform}/packages/{args.pkg_type}"
         dedupe = True
     else:
         raise ValueError(f"Unknown job type: {args.job}")
@@ -659,8 +668,18 @@ def main():
         s3_client, args.s3_bucket, prefix, args.pkg_type, uploaded_packages, args.job
     )
 
-    # Generate index.html files from S3 state (recursive for specific upload)
-    generate_index_from_s3(s3_client, args.s3_bucket, prefix)
+    # Skip index.html generation for CI builds. Its handled in lamda fn
+    # Only generate indexes for release builds (dev/nightly/prerelease)
+    if args.job != "ci":
+        # Generate index.html files from S3 state (recursive for specific upload)
+        generate_index_from_s3(s3_client, args.s3_bucket, prefix)
+
+        # Generate a top-level index for the pkg type (e.g., 'deb' or 'rpm')
+        # Uses S3 Delimiter for efficiency (only lists folders, not all nested files)
+        top_prefix = prefix.split("/")[0]
+        generate_top_index_from_s3(s3_client, args.s3_bucket, top_prefix)
+    else:
+        print("Skipping index.html generation for CI build")
 
     # Generate a top-level index for the pkg type (e.g., 'deb' or 'rpm')
     # Uses S3 Delimiter for efficiency (only lists folders, not all nested files)


### PR DESCRIPTION
## Motivation

This pull request introduces several enhancements and new features to the Linux packaging tools, focusing on S3 bucket organization, package repository URL generation, and utility improvements for CI and installation workflows. The main changes include improved S3 path logic for native packages, a new function to generate public repository URLs, new CLI utilities for extracting GPG key URLs and GPU architectures, and better cross-platform and release-type handling.

## Technical Details

**S3 Path and Repository URL Logic Improvements:**

* Refactored S3 prefix logic in `get_s3_config.py` to use `<artifact_id>-<platform>/packages/<pkg_type>` for CI builds, and to include the repository name for external/fork builds, improving organization and clarity of S3 storage. [[1]](diffhunk://#diff-76712c319fecda47fa5b0f654679ccf748f5d61760c52b0669d9679fd2fd1f55L21-R25) [[2]](diffhunk://#diff-76712c319fecda47fa5b0f654679ccf748f5d61760c52b0669d9679fd2fd1f55L132-R256)
* Added the `platform` parameter throughout, with validation to ensure native packages (`deb`, `rpm`) are only used on Linux, and updated CLI usage examples accordingly. [[1]](diffhunk://#diff-76712c319fecda47fa5b0f654679ccf748f5d61760c52b0669d9679fd2fd1f55R35-R36) [[2]](diffhunk://#diff-76712c319fecda47fa5b0f654679ccf748f5d61760c52b0669d9679fd2fd1f55R46-R57) [[3]](diffhunk://#diff-76712c319fecda47fa5b0f654679ccf748f5d61760c52b0669d9679fd2fd1f55R190-R204) [[4]](diffhunk://#diff-76712c319fecda47fa5b0f654679ccf748f5d61760c52b0669d9679fd2fd1f55R298-R304)
* Introduced `generate_package_repository_url()` to produce public URLs for package installation, supporting all release types and platforms, and returning this URL from `determine_s3_config()`. Output now includes `package_repository_url` in all formats. [[1]](diffhunk://#diff-76712c319fecda47fa5b0f654679ccf748f5d61760c52b0669d9679fd2fd1f55R100-R181) [[2]](diffhunk://#diff-76712c319fecda47fa5b0f654679ccf748f5d61760c52b0669d9679fd2fd1f55R334-R347)

**New CLI Utilities and Features:**

* Added `get-gpg-url` subcommand to `get_url_repo_params.py` to derive the GPG key URL from a package repo URL, with logic to emit the URL only for prerelease/release lines (or always, in legacy mode). [[1]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R13-R30) [[2]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R60-R105) [[3]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R240-R259)
* Added `extract-gfx-arch` subcommand to extract and normalize GPU architecture names from artifact groups, supporting multiple input formats. [[1]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R13-R30) [[2]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R171-R214) [[3]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R310-R323)

**Cross-Platform and Release-Type Handling:**

* Updated argument parsing and help text to support the new `platform` and expanded `--release-type` options, including support for `dev` and `ci` in test and packaging scripts. [[1]](diffhunk://#diff-76712c319fecda47fa5b0f654679ccf748f5d61760c52b0669d9679fd2fd1f55R298-R304) [[2]](diffhunk://#diff-79959fbf42afa5c33796b97c10d2634bdf16eb7ec4c0b530bd922c466fddeed0L947-R945)

**Testing Improvements:**

* Changed the native package install test to always invoke `rdhc.py` with the current Python interpreter, improving reliability across platforms and environments.

These changes make the packaging tools more robust, extensible, and suitable for multi-platform and multi-release workflows, while improving the clarity and maintainability of S3 and repo URL logic.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
