### PR TITLE
Replace `dvc pull` with in-tree boto3-based fetcher

### DIFF
--- a/build_tools/fetch_dvc_artifacts.py
+++ b/build_tools/fetch_dvc_artifacts.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Fetch large binary artifacts referenced by .dvc pointer files from an S3 remote.
+
+Minimal in-tree replacement for `dvc pull` covering TheRock's only use of dvc:
+pulling MD5-content-addressed binary artifacts (MIOpen kernel databases, PAL
+prebuilt libs) from anonymous-public S3 buckets. Does not implement add/push/repro.
+
+Pointer file schema (the only one we handle):
+    outs:
+    - md5: <32-char-hex>      # may end with `.dir` for directory hashes
+      size: <bytes>
+      hash: md5
+      path: <relpath-from-pointer-file-dir>
+
+Remote config (.dvc/config, INI):
+    [core]
+        remote = storage
+    ['remote "storage"']
+        url = s3://<bucket>/<prefix>
+        allow_anonymous_login = true
+
+S3 key scheme (dvc 3.x "new" layout, used by therock-dvc):
+    `<prefix>/files/md5/<md5[:2]>/<md5[2:]>` for both files and `.dir` manifests.
+
+Library:
+    from fetch_dvc_artifacts import pull
+    result = pull(Path("/path/to/project"))
+
+CLI:
+    python fetch_dvc_artifacts.py pull [DIR ...] [--jobs N] [--cache-dir PATH]
+                                       [--no-cache] [-v]
+"""
+
+import argparse
+import concurrent.futures
+import configparser
+import hashlib
+import json
+import logging
+import os
+import shutil
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+from urllib.parse import urlparse
+
+import boto3
+from botocore import UNSIGNED
+from botocore.client import Config
+
+
+DEFAULT_JOBS = 8
+DEFAULT_CACHE_DIR = Path.home() / ".cache" / "therock-dvc"
+
+
+class FetchError(Exception):
+    """Raised on missing config, download failure, or MD5 mismatch."""
+
+
+@dataclass
+class PullResult:
+    fetched: int = 0  # downloaded from remote
+    cached: int = 0  # served from local content-addressed cache
+    skipped: int = 0  # already at destination with matching md5
+
+    def __iadd__(self, other: "PullResult") -> "PullResult":
+        self.fetched += other.fetched
+        self.cached += other.cached
+        self.skipped += other.skipped
+        return self
+
+
+@dataclass(frozen=True)
+class _Out:
+    """One entry from a .dvc pointer file's `outs:` list."""
+
+    md5: str
+    size: int
+    path: str
+
+    @property
+    def is_dir(self) -> bool:
+        return self.md5.endswith(".dir")
+
+    @property
+    def bare_md5(self) -> str:
+        return self.md5[:-4] if self.is_dir else self.md5
+
+
+@dataclass(frozen=True)
+class _Remote:
+    bucket: str
+    prefix: str
+    anonymous: bool
+
+
+# --------------------------------------------------------------------------
+# .dvc YAML subset parser
+# --------------------------------------------------------------------------
+
+
+def _parse_dvc_pointer(path: Path) -> list[_Out]:
+    """Parse a .dvc pointer file. Schema is fixed; full YAML is overkill."""
+    text = path.read_text()
+    outs: list[_Out] = []
+    current: dict[str, str] | None = None
+    in_outs = False
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        if not in_outs:
+            if line == "outs:":
+                in_outs = True
+            continue
+        if line.startswith("- "):
+            if current is not None:
+                outs.append(_to_out(current, path))
+            current = {}
+            line = line[2:]
+        elif line.startswith("  "):
+            line = line[2:]
+        else:
+            # A non-indented line ends the outs: section (e.g., another top-level key).
+            in_outs = False
+            continue
+        if current is None:
+            raise FetchError(f"{path}: 'outs:' content before list item: {raw_line!r}")
+        if ":" not in line:
+            raise FetchError(f"{path}: expected 'key: value', got {raw_line!r}")
+        key, _, value = line.partition(":")
+        current[key.strip()] = value.strip()
+    if current is not None:
+        outs.append(_to_out(current, path))
+    if not outs:
+        raise FetchError(f"{path}: no 'outs:' entries")
+    return outs
+
+
+def _to_out(d: dict[str, str], path: Path) -> _Out:
+    try:
+        md5 = d["md5"]
+        size = int(d["size"])
+        out_path = d["path"]
+    except KeyError as e:
+        raise FetchError(f"{path}: missing required field {e}") from None
+    except ValueError as e:
+        raise FetchError(f"{path}: bad size: {e}") from None
+    hash_alg = d.get("hash", "md5")
+    if hash_alg != "md5":
+        raise FetchError(f"{path}: unsupported hash algorithm {hash_alg!r}")
+    bare = md5[:-4] if md5.endswith(".dir") else md5
+    if len(bare) != 32 or not all(c in "0123456789abcdef" for c in bare):
+        raise FetchError(f"{path}: invalid md5 {md5!r}")
+    return _Out(md5=md5, size=size, path=out_path)
+
+
+# --------------------------------------------------------------------------
+# .dvc/config parser
+# --------------------------------------------------------------------------
+
+
+def _parse_dvc_config(path: Path) -> _Remote:
+    """Extract the configured remote's URL and anonymous flag from .dvc/config.
+
+    DVC's .dvc/config uses INI section headers like ['remote "storage"'] -
+    the single quotes are literally part of the section name in the file, and
+    Python's configparser preserves them. We canonicalize by stripping the
+    surrounding single quotes before matching `remote "<name>"`.
+    """
+    cp = configparser.ConfigParser()
+    cp.read(path)
+    if "core" not in cp:
+        raise FetchError(f"{path}: missing [core] section")
+    remote_name = cp["core"].get("remote")
+    if not remote_name:
+        raise FetchError(f"{path}: [core] missing 'remote' key")
+    target = f'remote "{remote_name}"'
+    section_name: str | None = None
+    for s in cp.sections():
+        if s == target or s.strip("'") == target:
+            section_name = s
+            break
+    if section_name is None:
+        raise FetchError(f"{path}: missing [{target}] section")
+    url = cp[section_name].get("url")
+    if not url:
+        raise FetchError(f"{path}: [{target}] missing 'url'")
+    parsed = urlparse(url)
+    if parsed.scheme != "s3":
+        raise FetchError(f"{path}: only s3:// remotes are supported, got {url!r}")
+    bucket = parsed.netloc
+    prefix = parsed.path.lstrip("/")
+    anonymous = cp[section_name].getboolean("allow_anonymous_login", fallback=False)
+    return _Remote(bucket=bucket, prefix=prefix, anonymous=anonymous)
+
+
+# --------------------------------------------------------------------------
+# S3 key + cache helpers
+# --------------------------------------------------------------------------
+
+
+def _s3_key(remote: _Remote, md5: str) -> str:
+    """Build the S3 key for a content-addressed blob.
+
+    Uses the dvc 3.x "new" layout: <prefix>/files/md5/<first2>/<rest30>.
+    The therock-dvc bucket was migrated to this layout; the older
+    <prefix>/<first2>/<rest30> layout is not in use here.
+    """
+    bare = md5[:-4] if md5.endswith(".dir") else md5
+    if len(bare) != 32:
+        raise FetchError(f"invalid md5 length: {md5!r}")
+    suffix = ".dir" if md5.endswith(".dir") else ""
+    parts = [remote.prefix, "files", "md5", bare[:2], bare[2:] + suffix]
+    return "/".join(p for p in parts if p)
+
+
+def _cache_path(cache_dir: Path, md5: str) -> Path:
+    bare = md5[:-4] if md5.endswith(".dir") else md5
+    suffix = ".dir" if md5.endswith(".dir") else ""
+    return cache_dir / bare[:2] / (bare[2:] + suffix)
+
+
+def _md5_of(path: Path) -> str:
+    h = hashlib.md5()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _materialize_from_cache(cache_file: Path, dest: Path) -> None:
+    """Hardlink cache_file to dest; fall back to copy across filesystems."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        dest.unlink()
+    try:
+        os.link(cache_file, dest)
+    except OSError:
+        shutil.copy2(cache_file, dest)
+
+
+def _store_in_cache(src: Path, cache_file: Path) -> None:
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    if cache_file.exists():
+        return
+    tmp = cache_file.with_suffix(cache_file.suffix + ".tmp")
+    try:
+        try:
+            os.link(src, tmp)
+        except OSError:
+            shutil.copy2(src, tmp)
+        os.replace(tmp, cache_file)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
+# --------------------------------------------------------------------------
+# Atomic-write download with MD5 verification
+# --------------------------------------------------------------------------
+
+
+def _download_blob(
+    s3, remote: _Remote, md5: str, dest: Path, expected_size: int | None
+) -> None:
+    """Download s3://<bucket>/<key> to dest atomically, verifying md5 (and size).
+
+    MD5 is computed by re-reading the file after download, not streamed during
+    write. boto3's multipart download writes chunks out of order via seek+write,
+    which breaks any sequential-hash wrapper. Re-reading costs one extra pass
+    (~150 MB/s on SSD); negligible vs network time for our workload.
+    """
+    key = _s3_key(remote, md5)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    if tmp.exists():
+        tmp.unlink()
+    try:
+        with tmp.open("wb") as f:
+            s3.download_fileobj(remote.bucket, key, f)
+        actual_size = tmp.stat().st_size
+        if expected_size is not None and actual_size != expected_size:
+            raise FetchError(
+                f"{dest}: size mismatch (expected {expected_size}, got {actual_size})"
+            )
+        actual_md5 = _md5_of(tmp)
+        bare_expected = md5[:-4] if md5.endswith(".dir") else md5
+        if actual_md5 != bare_expected:
+            raise FetchError(
+                f"{dest}: md5 mismatch (expected {bare_expected}, got {actual_md5})"
+            )
+        os.replace(tmp, dest)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
+# --------------------------------------------------------------------------
+# Per-pointer-entry materialization
+# --------------------------------------------------------------------------
+
+
+def _human(n: float) -> str:
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if n < 1024:
+            return f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} TiB"
+
+
+def _materialize_file(
+    s3,
+    remote: _Remote,
+    md5: str,
+    size: int | None,
+    dest: Path,
+    cache_dir: Path | None,
+    log: Callable[[str], None],
+) -> PullResult:
+    """Materialize one file: destination check -> cache check -> download.
+
+    `size` may be None for files referenced from a .dir manifest (which carries
+    md5 only). In that case the size check is skipped; md5 verification still
+    happens.
+    """
+    label = f"{dest.name}" if size is None else f"{dest.name} ({_human(size)})"
+
+    # Fast path 1: destination already correct.
+    if dest.exists():
+        if size is None or dest.stat().st_size == size:
+            if _md5_of(dest) == md5:
+                log(f"  ok        {label} [present]")
+                return PullResult(skipped=1)
+
+    # Fast path 2: content-addressed cache hit.
+    if cache_dir is not None:
+        cache_file = _cache_path(cache_dir, md5)
+        if cache_file.exists():
+            if size is None or cache_file.stat().st_size == size:
+                if _md5_of(cache_file) == md5:
+                    _materialize_from_cache(cache_file, dest)
+                    log(f"  cached    {label}")
+                    return PullResult(cached=1)
+            log(f"  warn      cache entry corrupt for {md5[:8]}..., discarding")
+            cache_file.unlink()
+
+    log(f"  fetching  {label}")
+    _download_blob(s3, remote, md5, dest, expected_size=size)
+    if cache_dir is not None:
+        _store_in_cache(dest, _cache_path(cache_dir, md5))
+    return PullResult(fetched=1)
+
+
+def _materialize_dir(
+    s3,
+    remote: _Remote,
+    out: _Out,
+    dest: Path,
+    cache_dir: Path | None,
+    log: Callable[[str], None],
+) -> PullResult:
+    """Handle a `.dir` directory hash: fetch JSON manifest, materialize each entry."""
+    log(f"  manifest  {dest}/ ({out.md5[:8]}...)")
+
+    # Try cache for the manifest first.
+    manifest_bytes: bytes | None = None
+    cache_file = _cache_path(cache_dir, out.md5) if cache_dir is not None else None
+    if cache_file is not None and cache_file.exists():
+        if _md5_of(cache_file) == out.bare_md5:
+            manifest_bytes = cache_file.read_bytes()
+
+    if manifest_bytes is None:
+        # Download manifest. If we have a cache, write it there directly (it's
+        # an immutable content-addressed blob). Otherwise, use a tempfile.
+        if cache_file is not None:
+            _download_blob(s3, remote, out.md5, cache_file, expected_size=None)
+            manifest_bytes = cache_file.read_bytes()
+        else:
+            with tempfile.TemporaryDirectory(prefix="therock-dvc-") as tmp_dir:
+                manifest_path = Path(tmp_dir) / "manifest"
+                _download_blob(s3, remote, out.md5, manifest_path, expected_size=None)
+                manifest_bytes = manifest_path.read_bytes()
+
+    try:
+        entries = json.loads(manifest_bytes)
+    except json.JSONDecodeError as e:
+        raise FetchError(f"{dest}: manifest is not valid JSON: {e}") from None
+    if not isinstance(entries, list):
+        raise FetchError(f"{dest}: manifest is not a JSON array")
+
+    result = PullResult()
+    for entry in entries:
+        if not isinstance(entry, dict) or "md5" not in entry or "relpath" not in entry:
+            raise FetchError(f"{dest}: malformed manifest entry {entry!r}")
+        # Manifest entries don't carry size; trust md5 verification alone.
+        result += _materialize_file(
+            s3,
+            remote,
+            md5=entry["md5"],
+            size=None,
+            dest=dest / entry["relpath"],
+            cache_dir=cache_dir,
+            log=log,
+        )
+    return result
+
+
+# --------------------------------------------------------------------------
+# Discovery + parallel orchestration
+# --------------------------------------------------------------------------
+
+
+def _walk_dvc_pointers(project_dir: Path) -> list[Path]:
+    # rglob("*.dvc") matches the .dvc/ config directory too; filter to files.
+    return sorted(p for p in project_dir.rglob("*.dvc") if p.is_file())
+
+
+# Inner s3transfer max_concurrency is 10 by default; we bump the boto3
+# connection pool to `jobs * INNER_S3TRANSFER_CONCURRENCY` so that multipart
+# ranged GETs don't starve when many outer workers hit S3 simultaneously.
+_INNER_S3TRANSFER_CONCURRENCY = 10
+_MIN_POOL_CONNECTIONS = 50
+_BOTO3_RETRIES = {"max_attempts": 5, "mode": "adaptive"}
+
+
+def _make_s3_client(remote: _Remote, *, max_pool_connections: int):
+    """Build an S3 client. Anonymous (UNSIGNED) when the remote allows it."""
+    config_kwargs: dict[str, object] = {
+        "max_pool_connections": max_pool_connections,
+        "retries": _BOTO3_RETRIES,
+    }
+    if remote.anonymous:
+        config_kwargs["signature_version"] = UNSIGNED
+    return boto3.client("s3", config=Config(**config_kwargs))
+
+
+def _process_pointer(
+    s3,
+    remote: _Remote,
+    pointer: Path,
+    cache_dir: Path | None,
+    log: Callable[[str], None],
+) -> PullResult:
+    """Materialize every entry in one .dvc pointer file."""
+    outs = _parse_dvc_pointer(pointer)
+    result = PullResult()
+    for out in outs:
+        dest = pointer.parent / out.path
+        if out.is_dir:
+            result += _materialize_dir(s3, remote, out, dest, cache_dir, log)
+        else:
+            result += _materialize_file(
+                s3,
+                remote,
+                md5=out.md5,
+                size=out.size,
+                dest=dest,
+                cache_dir=cache_dir,
+                log=log,
+            )
+    return result
+
+
+def pull(
+    project_dir: Path,
+    *,
+    jobs: int = DEFAULT_JOBS,
+    cache_dir: Path | None = DEFAULT_CACHE_DIR,
+    log: Callable[[str], None] = print,
+) -> PullResult:
+    """Materialize every .dvc-tracked file under project_dir from its S3 remote.
+
+    Raises FetchError if .dvc/config is missing or any download fails.
+    """
+    project_dir = Path(project_dir).resolve()
+    config_file = project_dir / ".dvc" / "config"
+    if not config_file.exists():
+        raise FetchError(f"no .dvc/config in {project_dir}")
+    remote = _parse_dvc_config(config_file)
+
+    pointers = _walk_dvc_pointers(project_dir)
+    if not pointers:
+        log(f"no .dvc pointer files found under {project_dir}")
+        return PullResult()
+
+    pool_size = max(jobs * _INNER_S3TRANSFER_CONCURRENCY, _MIN_POOL_CONNECTIONS)
+    s3 = _make_s3_client(remote, max_pool_connections=pool_size)
+
+    log(
+        f"pull: {len(pointers)} pointer file(s) from "
+        f"s3://{remote.bucket}/{remote.prefix}"
+    )
+
+    result = PullResult()
+    errors: list[tuple[Path, Exception]] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as ex:
+        futures = {
+            ex.submit(_process_pointer, s3, remote, p, cache_dir, log): p
+            for p in pointers
+        }
+        for fut in concurrent.futures.as_completed(futures):
+            pointer = futures[fut]
+            try:
+                result += fut.result()
+            except Exception as e:
+                errors.append((pointer, e))
+
+    if errors:
+        for pointer, err in errors:
+            log(f"  ERROR     {pointer}: {err}")
+        raise FetchError(f"{len(errors)} file(s) failed to fetch (see log above)")
+
+    return result
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="fetch_dvc_artifacts",
+        description="Fetch large binary artifacts referenced by .dvc files from S3.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    p_pull = sub.add_parser("pull", help="Pull all .dvc-referenced artifacts.")
+    p_pull.add_argument(
+        "directories",
+        nargs="*",
+        default=["."],
+        help="Project directories to pull (each must contain .dvc/config). "
+        "Default: cwd.",
+    )
+    p_pull.add_argument(
+        "--jobs",
+        type=int,
+        default=DEFAULT_JOBS,
+        help=f"Parallel pointer-file workers (default {DEFAULT_JOBS}).",
+    )
+    p_pull.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=DEFAULT_CACHE_DIR,
+        help=f"Content-addressed cache directory (default {DEFAULT_CACHE_DIR}).",
+    )
+    p_pull.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Disable the local content-addressed cache.",
+    )
+    p_pull.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable boto3/botocore debug logging.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.verbose:
+        boto3.set_stream_logger("botocore", logging.INFO)
+
+    cache_dir = None if args.no_cache else args.cache_dir
+    total = PullResult()
+    try:
+        for d in args.directories:
+            total += pull(Path(d), jobs=args.jobs, cache_dir=cache_dir)
+    except FetchError as e:
+        print(f"fetch_dvc_artifacts: {e}", file=sys.stderr)
+        return 1
+
+    print(
+        f"summary: fetched={total.fetched} "
+        f"cached={total.cached} skipped={total.skipped}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv[1:]))

--- a/build_tools/fetch_dvc_artifacts.py
+++ b/build_tools/fetch_dvc_artifacts.py
@@ -44,6 +44,7 @@ import os
 import shutil
 import sys
 import tempfile
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -249,7 +250,10 @@ def _store_in_cache(src: Path, cache_file: Path) -> None:
     cache_file.parent.mkdir(parents=True, exist_ok=True)
     if cache_file.exists():
         return
-    tmp = cache_file.with_suffix(cache_file.suffix + ".tmp")
+    # Unique temp name: distinct pointer files referencing the same content hash
+    # are materialized by separate workers, which would otherwise race on a
+    # shared `<cache_file>.tmp` path. os.replace stays atomic and idempotent.
+    tmp = cache_file.with_suffix(f"{cache_file.suffix}.{uuid.uuid4().hex}.tmp")
     try:
         try:
             os.link(src, tmp)

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -20,12 +20,12 @@ import hashlib
 from pathlib import Path
 import platform
 import shlex
-import shutil
 import subprocess
 import sys
 from typing import List
 import os
 
+import fetch_dvc_artifacts
 from _therock_utils.git_mirrors import MIRROR_DIR_ENV, url_to_mirror_relpath
 
 THIS_SCRIPT_DIR = Path(__file__).resolve().parent
@@ -418,26 +418,21 @@ def pull_large_files(dvc_projects, projects):
     if not dvc_projects:
         print("No DVC projects specified, skipping large file pull.")
         return
-    dvc_missing = shutil.which("dvc") is None
-    if dvc_missing:
-        if is_windows():
-            print("Could not find `dvc` on PATH so large files could not be fetched")
-            print("Visit https://dvc.org/doc/install for installation instructions.")
-            sys.exit(1)
-        else:
-            print("`dvc` not found, skipping large file pull on Linux.")
-            return
     for project in dvc_projects:
         if not project in projects:
             continue
         submodule_path = get_submodule_path(project)
         project_dir = THEROCK_DIR / submodule_path
         dvc_config_file = project_dir / ".dvc" / "config"
-        if dvc_config_file.exists():
-            print(f"dvc detected in {project_dir}, running dvc pull")
-            run_command(["dvc", "pull"], cwd=project_dir)
-        else:
+        if not dvc_config_file.exists():
             log(f"WARNING: dvc config not found in {project_dir}, when expected.")
+            continue
+        print(f"dvc config detected in {project_dir}, fetching large files")
+        result = fetch_dvc_artifacts.pull(project_dir)
+        print(
+            f"  done: fetched={result.fetched} "
+            f"cached={result.cached} skipped={result.skipped}"
+        )
 
 
 def remove_smrev_files(args, projects):

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -391,7 +391,7 @@ def run(args):
                 cwd=THEROCK_DIR,
             )
     if args.dvc_projects:
-        pull_large_files(args.dvc_projects, projects)
+        pull_large_files(args.dvc_projects, projects, jobs=args.jobs)
 
     # Fetch nested submodules
     if args.update_submodules:
@@ -414,10 +414,11 @@ def run(args):
         apply_patches(args, projects)
 
 
-def pull_large_files(dvc_projects, projects):
+def pull_large_files(dvc_projects, projects, jobs=None):
     if not dvc_projects:
         print("No DVC projects specified, skipping large file pull.")
         return
+    pull_jobs = jobs if jobs is not None else fetch_dvc_artifacts.DEFAULT_JOBS
     for project in dvc_projects:
         if not project in projects:
             continue
@@ -428,7 +429,7 @@ def pull_large_files(dvc_projects, projects):
             log(f"WARNING: dvc config not found in {project_dir}, when expected.")
             continue
         print(f"dvc config detected in {project_dir}, fetching large files")
-        result = fetch_dvc_artifacts.pull(project_dir)
+        result = fetch_dvc_artifacts.pull(project_dir, jobs=pull_jobs)
         print(
             f"  done: fetched={result.fetched} "
             f"cached={result.cached} skipped={result.skipped}"

--- a/build_tools/tests/fetch_dvc_artifacts_test.py
+++ b/build_tools/tests/fetch_dvc_artifacts_test.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for fetch_dvc_artifacts.py.
+
+These cover only logic we wrote. boto3-owned behavior (HTTP retry, multipart
+download, status-code handling) is the vendor's responsibility and not retested
+here. The mocked-boto3 cases verify only that our orchestration glue around
+download_fileobj preserves atomic-write and MD5-verification invariants.
+"""
+
+import hashlib
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# Add build_tools to path so fetch_dvc_artifacts is importable.
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+import fetch_dvc_artifacts as fda
+
+
+def _md5_hex(data: bytes) -> str:
+    return hashlib.md5(data).hexdigest()
+
+
+class TestParseDvcPointer(unittest.TestCase):
+    """Tests for the .dvc YAML subset parser."""
+
+    def _write(self, tmp: Path, content: str) -> Path:
+        p = tmp / "x.dvc"
+        p.write_text(content)
+        return p
+
+    def test_real_world_example(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "outs:\n"
+                "- md5: 35b9082b72e661dc5e37f14de1d9d4ed\n"
+                "  size: 109795654\n"
+                "  hash: md5\n"
+                "  path: gfx908.kdb.bz2\n",
+            )
+            outs = fda._parse_dvc_pointer(p)
+            self.assertEqual(len(outs), 1)
+            self.assertEqual(outs[0].md5, "35b9082b72e661dc5e37f14de1d9d4ed")
+            self.assertEqual(outs[0].size, 109795654)
+            self.assertEqual(outs[0].path, "gfx908.kdb.bz2")
+            self.assertFalse(outs[0].is_dir)
+
+    def test_missing_outs_section(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(Path(t), "wmd: foo\n")
+            with self.assertRaisesRegex(fda.FetchError, "no 'outs:' entries"):
+                fda._parse_dvc_pointer(p)
+
+    def test_missing_md5_field(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "outs:\n- size: 100\n  hash: md5\n  path: foo.bin\n",
+            )
+            with self.assertRaisesRegex(fda.FetchError, "missing required field"):
+                fda._parse_dvc_pointer(p)
+
+    def test_missing_path_field(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "outs:\n- md5: " + "a" * 32 + "\n  size: 100\n  hash: md5\n",
+            )
+            with self.assertRaisesRegex(fda.FetchError, "missing required field"):
+                fda._parse_dvc_pointer(p)
+
+    def test_bad_size(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "outs:\n- md5: " + "a" * 32 + "\n  size: huge\n  path: f\n",
+            )
+            with self.assertRaisesRegex(fda.FetchError, "bad size"):
+                fda._parse_dvc_pointer(p)
+
+    def test_invalid_md5_chars(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "outs:\n- md5: " + "z" * 32 + "\n  size: 1\n  path: f\n",
+            )
+            with self.assertRaisesRegex(fda.FetchError, "invalid md5"):
+                fda._parse_dvc_pointer(p)
+
+    def test_invalid_md5_length(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "outs:\n- md5: deadbeef\n  size: 1\n  path: f\n",
+            )
+            with self.assertRaisesRegex(fda.FetchError, "invalid md5"):
+                fda._parse_dvc_pointer(p)
+
+    def test_hash_field_optional_defaults_to_md5(self):
+        # Real .dvc files always include `hash: md5`, but the field is redundant
+        # and we accept its absence.
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "outs:\n- md5: " + "a" * 32 + "\n  size: 1\n  path: f\n",
+            )
+            outs = fda._parse_dvc_pointer(p)
+            self.assertEqual(len(outs), 1)
+
+    def test_unsupported_hash_algorithm(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "outs:\n- md5: "
+                + "a" * 32
+                + "\n  size: 1\n  hash: sha256\n  path: f\n",
+            )
+            with self.assertRaisesRegex(fda.FetchError, "unsupported hash"):
+                fda._parse_dvc_pointer(p)
+
+    def test_dir_suffix_recognized(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "outs:\n- md5: " + "a" * 32 + ".dir\n  size: 1\n  path: d\n",
+            )
+            outs = fda._parse_dvc_pointer(p)
+            self.assertTrue(outs[0].is_dir)
+            self.assertEqual(outs[0].bare_md5, "a" * 32)
+
+    def test_comments_and_blank_lines(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "# comment\n\n"
+                "outs:\n"
+                "# another comment\n"
+                "- md5: " + "a" * 32 + "\n"
+                "  size: 1\n"
+                "  path: f\n",
+            )
+            outs = fda._parse_dvc_pointer(p)
+            self.assertEqual(len(outs), 1)
+
+
+class TestParseDvcConfig(unittest.TestCase):
+    """Tests for the .dvc/config INI parser."""
+
+    def _write(self, tmp: Path, content: str) -> Path:
+        p = tmp / "config"
+        p.write_text(content)
+        return p
+
+    def test_real_world_example(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "[core]\n"
+                "    remote = storage\n"
+                "    autostage = true\n"
+                "['remote \"storage\"']\n"
+                "    url = s3://therock-dvc/rocm-libraries\n"
+                "    allow_anonymous_login = true\n",
+            )
+            r = fda._parse_dvc_config(p)
+            self.assertEqual(r.bucket, "therock-dvc")
+            self.assertEqual(r.prefix, "rocm-libraries")
+            self.assertTrue(r.anonymous)
+
+    def test_missing_core_section(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(Path(t), "['remote \"x\"']\n    url = s3://b/p\n")
+            with self.assertRaisesRegex(fda.FetchError, "missing \\[core\\]"):
+                fda._parse_dvc_config(p)
+
+    def test_missing_remote_section(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(Path(t), "[core]\n    remote = ghost\n")
+            with self.assertRaisesRegex(fda.FetchError, "missing.*ghost"):
+                fda._parse_dvc_config(p)
+
+    def test_missing_url(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "[core]\n    remote = storage\n['remote \"storage\"']\n",
+            )
+            with self.assertRaisesRegex(fda.FetchError, "missing 'url'"):
+                fda._parse_dvc_config(p)
+
+    def test_non_s3_remote_rejected(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "[core]\n    remote = storage\n"
+                "['remote \"storage\"']\n    url = gs://bucket/prefix\n",
+            )
+            with self.assertRaisesRegex(fda.FetchError, "only s3:// remotes"):
+                fda._parse_dvc_config(p)
+
+    def test_anonymous_default_false(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "[core]\n    remote = storage\n"
+                "['remote \"storage\"']\n    url = s3://b/p\n",
+            )
+            r = fda._parse_dvc_config(p)
+            self.assertFalse(r.anonymous)
+
+
+class TestS3Key(unittest.TestCase):
+    """Tests for the S3 key builder (dvc 3.x layout: prefix/files/md5/...)."""
+
+    def test_with_prefix(self):
+        r = fda._Remote(bucket="b", prefix="rocm-libraries", anonymous=True)
+        self.assertEqual(
+            fda._s3_key(r, "35b9082b72e661dc5e37f14de1d9d4ed"),
+            "rocm-libraries/files/md5/35/b9082b72e661dc5e37f14de1d9d4ed",
+        )
+
+    def test_without_prefix(self):
+        r = fda._Remote(bucket="b", prefix="", anonymous=True)
+        self.assertEqual(
+            fda._s3_key(r, "35b9082b72e661dc5e37f14de1d9d4ed"),
+            "files/md5/35/b9082b72e661dc5e37f14de1d9d4ed",
+        )
+
+    def test_dir_suffix_preserved(self):
+        r = fda._Remote(bucket="b", prefix="p", anonymous=True)
+        self.assertEqual(
+            fda._s3_key(r, "a" * 32 + ".dir"),
+            "p/files/md5/aa/" + "a" * 30 + ".dir",
+        )
+
+    def test_invalid_length_rejected(self):
+        r = fda._Remote(bucket="b", prefix="p", anonymous=True)
+        with self.assertRaises(fda.FetchError):
+            fda._s3_key(r, "deadbeef")
+
+
+class TestCachePath(unittest.TestCase):
+    def test_layout(self):
+        cache = Path("/cache")
+        self.assertEqual(
+            fda._cache_path(cache, "35b9082b72e661dc5e37f14de1d9d4ed"),
+            Path("/cache/35/b9082b72e661dc5e37f14de1d9d4ed"),
+        )
+
+    def test_dir_suffix(self):
+        cache = Path("/cache")
+        self.assertEqual(
+            fda._cache_path(cache, "a" * 32 + ".dir"),
+            Path("/cache/aa/" + "a" * 30 + ".dir"),
+        )
+
+
+class TestMd5Of(unittest.TestCase):
+    def test_streaming_hash_matches_one_shot(self):
+        with tempfile.TemporaryDirectory() as t:
+            data = b"x" * (3 << 20) + b"tail"  # > 1 chunk
+            p = Path(t) / "f"
+            p.write_bytes(data)
+            self.assertEqual(fda._md5_of(p), _md5_hex(data))
+
+
+class TestCacheMaterialize(unittest.TestCase):
+    def test_hardlink_when_same_filesystem(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            src = tmp / "src.bin"
+            src.write_bytes(b"abc")
+            dest = tmp / "subdir" / "dest.bin"
+            fda._materialize_from_cache(src, dest)
+            self.assertTrue(dest.exists())
+            self.assertEqual(dest.read_bytes(), b"abc")
+            # On the same filesystem we get a hardlink, so inode should match.
+            self.assertEqual(src.stat().st_ino, dest.stat().st_ino)
+
+    def test_replaces_existing_dest(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            src = tmp / "src.bin"
+            src.write_bytes(b"new")
+            dest = tmp / "dest.bin"
+            dest.write_bytes(b"stale")
+            fda._materialize_from_cache(src, dest)
+            self.assertEqual(dest.read_bytes(), b"new")
+
+    def test_falls_back_to_copy_when_link_fails(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            src = tmp / "src.bin"
+            src.write_bytes(b"abc")
+            dest = tmp / "dest.bin"
+            with mock.patch("os.link", side_effect=OSError("xdev")):
+                fda._materialize_from_cache(src, dest)
+            self.assertEqual(dest.read_bytes(), b"abc")
+
+    def test_store_in_cache_creates_entry(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            src = tmp / "src.bin"
+            src.write_bytes(b"hello")
+            cache_file = tmp / "cache" / "ab" / "cdef"
+            fda._store_in_cache(src, cache_file)
+            self.assertTrue(cache_file.exists())
+            self.assertEqual(cache_file.read_bytes(), b"hello")
+
+    def test_store_in_cache_skips_if_already_present(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            src = tmp / "src.bin"
+            src.write_bytes(b"new")
+            cache_file = tmp / "ab" / "cdef"
+            cache_file.parent.mkdir(parents=True)
+            cache_file.write_bytes(b"existing")
+            fda._store_in_cache(src, cache_file)
+            # Existing entry preserved; cache is content-addressed so we trust it.
+            self.assertEqual(cache_file.read_bytes(), b"existing")
+
+
+# --------------------------------------------------------------------------
+# Orchestration glue with mocked boto3.
+# --------------------------------------------------------------------------
+
+
+class _FakeS3:
+    """Minimal stand-in for boto3.client('s3') that serves preconfigured bytes.
+
+    We're not testing boto3 here - we're testing that our wrapper around its
+    download_fileobj preserves atomic-write and MD5-verification invariants.
+    """
+
+    def __init__(self, payloads: dict[tuple[str, str], bytes]):
+        self._payloads = payloads
+        self.calls: list[tuple[str, str]] = []
+
+    def download_fileobj(self, Bucket: str, Key: str, Fileobj) -> None:
+        self.calls.append((Bucket, Key))
+        try:
+            Fileobj.write(self._payloads[(Bucket, Key)])
+        except KeyError:
+            raise RuntimeError(f"FakeS3: no payload for {Bucket}/{Key}")
+
+
+class TestDownloadBlob(unittest.TestCase):
+    """Tests for _download_blob's atomic-write + verify invariants."""
+
+    def _remote(self) -> fda._Remote:
+        return fda._Remote(bucket="bkt", prefix="p", anonymous=True)
+
+    def test_happy_path(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            data = b"contents of the file"
+            md5 = _md5_hex(data)
+            remote = self._remote()
+            key = fda._s3_key(remote, md5)
+            s3 = _FakeS3({(remote.bucket, key): data})
+            dest = tmp / "out.bin"
+            fda._download_blob(s3, remote, md5, dest, expected_size=len(data))
+            self.assertTrue(dest.exists())
+            self.assertEqual(dest.read_bytes(), data)
+
+    def test_md5_mismatch_leaves_no_dest(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            real_data = b"corrupted bytes"
+            wrong_md5 = "0" * 32  # not the actual md5 of real_data
+            remote = self._remote()
+            key = fda._s3_key(remote, wrong_md5)
+            s3 = _FakeS3({(remote.bucket, key): real_data})
+            dest = tmp / "out.bin"
+            with self.assertRaisesRegex(fda.FetchError, "md5 mismatch"):
+                fda._download_blob(
+                    s3, remote, wrong_md5, dest, expected_size=len(real_data)
+                )
+            # Atomic write invariant: no destination file, no .tmp file.
+            self.assertFalse(dest.exists())
+            self.assertFalse(dest.with_suffix(dest.suffix + ".tmp").exists())
+
+    def test_size_mismatch_leaves_no_dest(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            data = b"shorter than expected"
+            md5 = _md5_hex(data)
+            remote = self._remote()
+            key = fda._s3_key(remote, md5)
+            s3 = _FakeS3({(remote.bucket, key): data})
+            dest = tmp / "out.bin"
+            with self.assertRaisesRegex(fda.FetchError, "size mismatch"):
+                fda._download_blob(s3, remote, md5, dest, expected_size=len(data) + 100)
+            self.assertFalse(dest.exists())
+
+
+class TestMaterializeFile(unittest.TestCase):
+    """Tests for the cache fast paths and download fallback."""
+
+    def _remote(self) -> fda._Remote:
+        return fda._Remote(bucket="bkt", prefix="p", anonymous=True)
+
+    def test_skips_when_destination_already_correct(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            data = b"already here"
+            md5 = _md5_hex(data)
+            dest = tmp / "out.bin"
+            dest.write_bytes(data)
+            s3 = _FakeS3({})  # would raise if called
+            cache_dir = tmp / "cache"
+            result = fda._materialize_file(
+                s3,
+                self._remote(),
+                md5=md5,
+                size=len(data),
+                dest=dest,
+                cache_dir=cache_dir,
+                log=lambda _: None,
+            )
+            self.assertEqual(result.skipped, 1)
+            self.assertEqual(result.fetched, 0)
+            self.assertEqual(s3.calls, [])
+
+    def test_uses_cache_when_destination_missing(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            data = b"from cache"
+            md5 = _md5_hex(data)
+            dest = tmp / "out.bin"
+            cache_dir = tmp / "cache"
+            cache_file = fda._cache_path(cache_dir, md5)
+            cache_file.parent.mkdir(parents=True)
+            cache_file.write_bytes(data)
+            s3 = _FakeS3({})
+            result = fda._materialize_file(
+                s3,
+                self._remote(),
+                md5=md5,
+                size=len(data),
+                dest=dest,
+                cache_dir=cache_dir,
+                log=lambda _: None,
+            )
+            self.assertEqual(result.cached, 1)
+            self.assertEqual(s3.calls, [])
+            self.assertEqual(dest.read_bytes(), data)
+
+    def test_poisoned_cache_is_discarded_and_redownloaded(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            data = b"good bytes"
+            md5 = _md5_hex(data)
+            dest = tmp / "out.bin"
+            cache_dir = tmp / "cache"
+            cache_file = fda._cache_path(cache_dir, md5)
+            cache_file.parent.mkdir(parents=True)
+            cache_file.write_bytes(b"X" * len(data))  # same size, wrong content
+            remote = self._remote()
+            key = fda._s3_key(remote, md5)
+            s3 = _FakeS3({(remote.bucket, key): data})
+            result = fda._materialize_file(
+                s3,
+                remote,
+                md5=md5,
+                size=len(data),
+                dest=dest,
+                cache_dir=cache_dir,
+                log=lambda _: None,
+            )
+            self.assertEqual(result.fetched, 1)
+            self.assertEqual(s3.calls, [(remote.bucket, key)])
+            self.assertEqual(dest.read_bytes(), data)
+            # Cache repopulated with good bytes.
+            self.assertEqual(cache_file.read_bytes(), data)
+
+    def test_downloads_and_populates_cache(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            data = b"fresh download"
+            md5 = _md5_hex(data)
+            dest = tmp / "out.bin"
+            cache_dir = tmp / "cache"
+            remote = self._remote()
+            key = fda._s3_key(remote, md5)
+            s3 = _FakeS3({(remote.bucket, key): data})
+            result = fda._materialize_file(
+                s3,
+                remote,
+                md5=md5,
+                size=len(data),
+                dest=dest,
+                cache_dir=cache_dir,
+                log=lambda _: None,
+            )
+            self.assertEqual(result.fetched, 1)
+            self.assertEqual(dest.read_bytes(), data)
+            cache_file = fda._cache_path(cache_dir, md5)
+            self.assertTrue(cache_file.exists())
+            self.assertEqual(cache_file.read_bytes(), data)
+
+
+class TestPullEndToEnd(unittest.TestCase):
+    """End-to-end pull() with mocked boto3."""
+
+    def test_pull_two_files(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            project = tmp / "proj"
+            (project / ".dvc").mkdir(parents=True)
+            (project / ".dvc" / "config").write_text(
+                "[core]\n    remote = storage\n"
+                "['remote \"storage\"']\n    url = s3://b/pfx\n"
+                "    allow_anonymous_login = true\n",
+            )
+            data_a = b"file A contents"
+            data_b = b"file B contents"
+            md5_a = _md5_hex(data_a)
+            md5_b = _md5_hex(data_b)
+            (project / "a.bin.dvc").write_text(
+                f"outs:\n- md5: {md5_a}\n  size: {len(data_a)}\n"
+                f"  hash: md5\n  path: a.bin\n"
+            )
+            (project / "sub").mkdir()
+            (project / "sub" / "b.bin.dvc").write_text(
+                f"outs:\n- md5: {md5_b}\n  size: {len(data_b)}\n"
+                f"  hash: md5\n  path: b.bin\n"
+            )
+
+            payloads = {
+                ("b", f"pfx/files/md5/{md5_a[:2]}/{md5_a[2:]}"): data_a,
+                ("b", f"pfx/files/md5/{md5_b[:2]}/{md5_b[2:]}"): data_b,
+            }
+            fake_s3 = _FakeS3(payloads)
+
+            with mock.patch.object(fda, "_make_s3_client", return_value=fake_s3):
+                result = fda.pull(
+                    project,
+                    cache_dir=tmp / "cache",
+                    log=lambda _: None,
+                )
+
+            self.assertEqual(result.fetched, 2)
+            self.assertEqual((project / "a.bin").read_bytes(), data_a)
+            self.assertEqual((project / "sub" / "b.bin").read_bytes(), data_b)
+            self.assertEqual(len(fake_s3.calls), 2)
+
+    def test_pull_raises_aggregated_error(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            project = tmp / "proj"
+            (project / ".dvc").mkdir(parents=True)
+            (project / ".dvc" / "config").write_text(
+                "[core]\n    remote = storage\n"
+                "['remote \"storage\"']\n    url = s3://b/pfx\n"
+                "    allow_anonymous_login = true\n",
+            )
+            md5 = "0" * 32  # will mismatch any real content
+            (project / "x.bin.dvc").write_text(
+                f"outs:\n- md5: {md5}\n  size: 5\n  hash: md5\n  path: x.bin\n"
+            )
+            fake_s3 = _FakeS3({("b", f"pfx/files/md5/{md5[:2]}/{md5[2:]}"): b"hello"})
+
+            with mock.patch.object(fda, "_make_s3_client", return_value=fake_s3):
+                with self.assertRaisesRegex(fda.FetchError, "1 file"):
+                    fda.pull(project, cache_dir=None, log=lambda _: None)
+            self.assertFalse((project / "x.bin").exists())
+
+    def test_pull_no_dvc_config_raises(self):
+        with tempfile.TemporaryDirectory() as t:
+            with self.assertRaisesRegex(fda.FetchError, "no .dvc/config"):
+                fda.pull(Path(t), log=lambda _: None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

TheRock uses `dvc` for exactly one thing: pulling MD5-content-addressed binary artifacts (MIOpen kernel databases, PAL prebuilt libs) from anonymous-public S3 buckets in `fetch_sources.py`. We never use `dvc add`, `push`, or `repro`.

Pulling in `dvc[s3]` drags `aiobotocore` along, which pins a narrow `botocore` window. That forces the `boto3>=1.42.79,<1.42.85` pin in `requirements.txt:14-19` even though nothing in TheRock actually needs that exact version - it exists solely to make dvc's aiobotocore resolve. Plus a `pathspec<0.13.0` workaround pin in the manylinux Dockerfile because dvc 3.62.0 uses pathspec's private API. Every dvc point release re-shifts this window; the alignment has already been reworked twice.

Replacing `dvc pull` with a small in-tree tool that calls boto3 directly removes the aiobotocore/pathspec workarounds. boto3 stays (it's already used in `build_tools/` for release upload and S3 indexing) but no longer needs to satisfy dvc's transitive pin.

## Technical Details

New `build_tools/fetch_dvc_artifacts.py` provides a drop-in subset of `dvc pull` for TheRock's use case:

- Library API `pull(project_dir, *, jobs, cache_dir, log) -> PullResult` and a `pull` CLI subcommand mirroring `dvc pull`.
- Reads the standard `.dvc` pointer YAML and `.dvc/config` INI in each project; expects the dvc 3.x S3 layout `<prefix>/files/md5/<first2>/<rest30>` used by `therock-dvc`.
- Anonymous S3 access (UNSIGNED), matching `allow_anonymous_login`.
- Parallel downloads across pointer files plus boto3's multipart ranged GETs for large objects.
- Atomic write with post-download MD5 verification; mismatches raise `FetchError` and leave no destination file.
- Optional content-addressed cache at `~/.cache/therock-dvc/` with destination-already-correct and cache-hit fast paths; poisoned cache entries are detected and discarded.
- Supports `.dir` directory hashes for forward compatibility (none in TheRock today).
- Stdlib + boto3 only. No PyYAML, no aiobotocore, no s3fs.

`fetch_sources.py:pull_large_files()` switches from a subprocess call to `dvc pull` to an in-process call to `fetch_dvc_artifacts.pull()`. The `shutil.which("dvc")` probe is dropped since the new tool ships with the repo.

## Out of Scope (Follow-Up)

Per a "tool only first, evaluate before deletion" rollout, this change does not yet:

- Drop `dvc[s3]` and the `pathspec<0.13.0` workaround from `dockerfiles/build_manylinux_x86_64.Dockerfile`.
- Loosen the `boto3` pin in `requirements.txt`.
- Remove the `iterative/setup-dvc@v2.0.0` step from the Windows workflows.
- Swap the standalone `dvc pull` calls in the `rocm-libraries` and `rocm-systems` workflows for the new tool.

A follow-up change will do those after the new tool has had a couple of weeks of bake time in CI alongside dvc.

## Test Plan

Unit:
- `python -m pytest build_tools/tests/fetch_dvc_artifacts_test.py`

Integration (manual, against `s3://therock-dvc/rocm-libraries`):
- Cold pull: delete all `.kdb.bz2` and `~/.cache/therock-dvc`, run the tool, cross-check each fetched file's md5 against its `.dvc` pointer.
- Warm pull (destination present): verify zero S3 calls and skip count equals file count.
- Cache hit pull (destination missing, cache present): verify hardlink path and zero S3 calls.
- Cache poisoning: write garbage to a cache entry, delete the destination, re-pull. Tool must detect size mismatch, discard the cache entry, re-download, and re-populate the cache.
- Atomic write: `kill -9` mid-download. Destination must be absent on disk (the canonical-name file); any leftover `.tmp` is cleaned up on the next pull.
- End-to-end via `fetch_sources.pull_large_files(['rocm-libraries'], ...)`.

## Test Result

- 39 unit tests pass.
- Cold pull: 6 files / 1.2 GiB in 39 s.
- Warm pull: 0.75 s, no S3 calls.
- Cache hit pull: 0.75 s, all 6 files hardlinked from cache.
- Cache poisoning: detected and recovered; cache repopulated with correct bytes.
- Atomic write under SIGKILL: destination absent; `.tmp` cleaned on next pull.
- All 6 fetched files md5-match their `.dvc` pointer values.
- `fetch_sources.pull_large_files()` end-to-end works.
- `pre-commit run --files <changed>` is clean.

## Submission Checklist

- [x]  Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.