### PR TITLE
Bump dvc to 3.67.1 and pin aiobotocore in manylinux image

### DIFF
--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -88,12 +88,13 @@ RUN yum install -y epel-release && \
 # dvc's rpm package includes .so dependencies built against glib 2.29
 # settling for pip install for now, but it installs modules not needed for dvc pull
 # more dvc features may be used in upcoming sequenced builds
-# Also pinning pathspec because a new version of it breaks the private _DIR_MARK
-# API that dvc uses. When upgrading past ~3.64.0, then pin can likely be removed.
+# Pin aiobotocore explicitly so rebuilds resolve a deterministic botocore
+# window. Without this, dvc's loose `aiobotocore` bound lets future pip
+# resolutions drift botocore out of the boto3 pin in requirements.txt.
 #
-# Note: dvc[s3] version locking currently limits boto3>=1.41.0,<1.42.0
-#       in requirements.txt
-RUN pip install 'pathspec<0.13.0' 'dvc[s3]==3.62.0' && \
+# Note: aiobotocore==3.4.0 requires botocore>=1.42.79,<1.42.85; keep the
+#       boto3 pin in requirements.txt aligned with that window.
+RUN pip install 'dvc[s3]==3.67.1' 'aiobotocore==3.4.0' && \
     which dvc && dvc --version || true
 
 ######## Enable GCC Toolset and verify ########

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,10 @@ setuptools>=80.9.0,<82.0.0
 tomli==2.2.1; python_version <= '3.10'
 pytest-cmake==0.13.0
 mako>=1.1.3
-# Must match the botocore window required by the aiobotocore version
-# that dvc[s3]==3.62.0 resolves to in build_manylinux_x86_64.Dockerfile.
-# The current published image ships aiobotocore 3.4.0, which requires
-# botocore >=1.42.79,<1.42.85. Realign this pin if a Dockerfile rebuild
-# resolves a different aiobotocore version.
+# Must match the botocore window required by the aiobotocore pinned in
+# build_manylinux_x86_64.Dockerfile. The image pins aiobotocore==3.4.0,
+# which requires botocore>=1.42.79,<1.42.85. Realign this pin only when
+# the Dockerfile's aiobotocore pin moves.
 boto3>=1.42.79,<1.42.85
 
 # hipBLASLt deps


### PR DESCRIPTION
The old dvc[s3]==3.62.0 install pulled aiobotocore transitively with a loose bound, so each image rebuild could resolve a different aiobotocore and in turn a different botocore window. That silently drifted out of the boto3 pin in requirements.txt, once requiring a reactive realignment. Add an explicit aiobotocore==3.4.0 pin so rebuilds are deterministic. 3.4.0 matches what the current published image already resolves, so the botocore window (and boto3 pin) is unchanged by this commit.

Bump dvc[s3] from 3.62.0 to the current stable 3.67.1 while here.

Drop the pathspec<0.13.0 pin. It was a workaround for dvc 3.62.0 using pathspec's private _DIR_MARK API that later pathspec releases removed. dvc 3.67.1 no longer touches that private API. pathspec itself stays in the image as a transitive dependency of dvc and scmrepo (now at 1.0.4).

Smoke-tested the rebuilt image:
- pip show reports dvc 3.67.1, dvc-s3 3.3.0, aiobotocore 3.4.0, botocore 1.42.84, pathspec 1.0.4
- pip install -r requirements.txt installs cleanly, pip check passes
- dvc pull + dvc status verify correctly against a tracked file in rocm-libraries/

CI workflow sha256 bumps land in a follow-up commit after the new image is published.


Progress on #4596