### PR TITLE
Update scripts for supporting Native Linux Pkg Install Test

### DIFF
--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -10,18 +10,24 @@ Output is always KEY=value (suitable for GITHUB_OUTPUT).
 Subcommands (get operations):
 
   get-base-url         Get base URL (scheme + netloc) from an input URL. Prints repo_base_url=<value>.
+  get-gpg-url          Get GPG key URL for GITHUB_OUTPUT. With --release-type, emits a non-empty URL only for prerelease/release; otherwise gpg_key_url=. Without --release-type, always derives from --from-url (legacy).
   get-repo-sub-folder  Get repo_sub_folder from an S3 prefix (last segment if YYYYMMDD-<id>, else empty). Prints repo_sub_folder=<value>.
   get-repo-url         Get full repo URL from components(release_type, native_package_type, repo_base_url, os_profile, repo_sub_folder). Prints repo_url=<value>.
+  extract-gfx-arch     Extract and normalize GPU architecture from artifact group. Prints gfx_arch=<value>.
 
 Usage:
   python build_tools/packaging/linux/get_url_repo_params.py get-base-url --from-url <url>
+  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url --from-url <url> [--release-type <type>]
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix <prefix>
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url ...
+  python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch --artifact-group <group>
 
 Examples:
   python build_tools/packaging/linux/get_url_repo_params.py get-base-url --from-url https://example.com/v2/whl
+  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url --release-type prerelease --from-url https://rocm.prereleases.amd.com/packages/ubuntu2404
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix v3/packages/deb/20260204-12345
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --release-type prerelease --native-package-type deb --repo-base-url https://x.com --os-profile ubuntu2404 --repo-sub-folder ''
+  python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch --artifact-group gfx94X-dcgpu
 """
 
 import argparse
@@ -48,6 +54,52 @@ def cmd_base_url(args: argparse.Namespace) -> int:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     print(f"repo_base_url={base_url}")
+    return 0
+
+
+# --- gpg_key_url ---
+
+
+def get_gpg_key_url(package_url: str) -> str:
+    """
+    Get GPG key URL from package repository URL.
+
+    Extracts base URL and appends /gpg/rocm.gpg path.
+
+    Examples:
+        https://rocm.prereleases.amd.com/packages/ubuntu2404 -> https://rocm.prereleases.amd.com/gpg/rocm.gpg
+        https://repo.amd.com/rocm/packages/rhel10/x86_64/ -> https://repo.amd.com/gpg/rocm.gpg
+    """
+    base_url = get_base_url(package_url)
+    return f"{base_url}/gpg/rocm.gpg"
+
+
+def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
+    """
+    Whether install workflows should use a repo GPG key URL for this release line.
+
+    When release_type is None, callers treat this as "legacy / unspecified" and always
+    derive the GPG URL from the package URL.
+
+    When release_type is set (e.g. from GitHub Actions), only prerelease and release
+    lines use signed-repo GPG keys; dev/nightly/ci/etc. omit it (empty gpg_key_url).
+    """
+    if release_type is None:
+        return True
+    rt = release_type.strip().lower()
+    return rt in ("prerelease", "release")
+
+
+def cmd_gpg_key_url(args: argparse.Namespace) -> int:
+    if not gpg_key_url_needed_for_release_type(args.release_type):
+        print("gpg_key_url=")
+        return 0
+    try:
+        gpg_url = get_gpg_key_url(args.from_url)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(f"gpg_key_url={gpg_url}")
     return 0
 
 
@@ -116,6 +168,50 @@ def cmd_repo_url(args: argparse.Namespace) -> int:
     return 0
 
 
+# --- extract-gfx-arch ---
+
+
+def extract_gfx_arch(artifact_group: str) -> str:
+    """
+    Extract and normalize GPU architecture from artifact group(s).
+
+    Supports both single and comma/semicolon-separated artifact groups.
+    Output is always comma-separated.
+
+    Examples:
+        gfx94X-dcgpu -> gfx94x
+        gfx1100-consumer -> gfx1100
+        GFX942-server -> gfx942
+        gfx94X-dcgpu,gfx1100-consumer -> gfx94x,gfx1100
+        gfx94X-dcgpu;gfx1100-consumer -> gfx94x,gfx1100
+    """
+    if not artifact_group:
+        raise ValueError("artifact_group cannot be empty")
+
+    # Split on comma or semicolon to handle multiple groups
+    # Replace semicolons with commas for consistent splitting
+    normalized = artifact_group.replace(";", ",")
+    groups = [g.strip() for g in normalized.split(",")]
+
+    # Extract first segment (before dash) and lowercase each
+    archs = [g.split("-")[0].lower() for g in groups if g]
+
+    if not archs:
+        raise ValueError("artifact_group cannot be empty after parsing")
+
+    return ",".join(archs)
+
+
+def cmd_extract_gfx_arch(args: argparse.Namespace) -> int:
+    try:
+        gfx_arch = extract_gfx_arch(args.artifact_group)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(f"gfx_arch={gfx_arch}")
+    return 0
+
+
 # --- main ---
 
 
@@ -140,6 +236,26 @@ def main(argv: list[str] | None = None) -> int:
         help="Any URL to derive base URL from (scheme + netloc only; e.g. https://example.com/v2/whl → https://example.com)",
     )
     p_base.set_defaults(func=cmd_base_url)
+
+    # get-gpg-url: get GPG key URL from package repository URL
+    p_gpg = subparsers.add_parser(
+        "get-gpg-url",
+        help="Print gpg_key_url= for GITHUB_OUTPUT. With --release-type, only prerelease/release get a non-empty URL; otherwise gpg_key_url=. Omit --release-type to always derive from --from-url.",
+    )
+    p_gpg.add_argument(
+        "--from-url",
+        type=str,
+        required=True,
+        metavar="URL",
+        help="Package repository URL to derive GPG key URL from when needed (e.g. https://rocm.prereleases.amd.com/packages/ubuntu2404 → https://rocm.prereleases.amd.com/gpg/rocm.gpg)",
+    )
+    p_gpg.add_argument(
+        "--release-type",
+        type=str,
+        default=None,
+        help="If set, emit non-empty GPG URL only for 'prerelease' or 'release'; for dev/nightly/etc. print gpg_key_url=. If omitted, always derive from --from-url.",
+    )
+    p_gpg.set_defaults(func=cmd_gpg_key_url)
 
     # get-repo-sub-folder: get repo_sub_folder from S3 prefix
     p_repo = subparsers.add_parser(
@@ -190,6 +306,20 @@ def main(argv: list[str] | None = None) -> int:
         help="Repo subfolder (e.g. YYYYMMDD-<id> for dev/nightly; empty for prerelease)",
     )
     p_url.set_defaults(func=cmd_repo_url)
+
+    # extract-gfx-arch: extract GPU architecture from artifact group
+    p_gfx = subparsers.add_parser(
+        "extract-gfx-arch",
+        help="Extract and normalize GPU architecture from artifact group (e.g. gfx94X-dcgpu → gfx94x).",
+    )
+    p_gfx.add_argument(
+        "--artifact-group",
+        type=str,
+        required=True,
+        metavar="GROUP",
+        help="Artifact group to extract gfx_arch from (e.g. gfx94X-dcgpu, gfx1100-consumer)",
+    )
+    p_gfx.set_defaults(func=cmd_extract_gfx_arch)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -835,11 +835,8 @@ gpgcheck=0
 
         print(f"\n[PASS] rdhc.py found at: {rdhc_script}")
 
-        # Check if script is executable or can be run with python
-        if os.access(rdhc_script, os.X_OK):
-            cmd = [str(rdhc_script)]
-        else:
-            cmd = [sys.executable, str(rdhc_script)]
+        # Always run rdhc with this process's interpreter.
+        cmd = [sys.executable, str(rdhc_script)]
 
         # Set RDHC arguments for full test
         test_args = ["--rocm-install-prefix", rocm_install_prefix_arg, "--all"]
@@ -944,8 +941,8 @@ def _build_argument_parser() -> ArgumentParser:
     parser.add_argument(
         "--release-type",
         type=str,
-        choices=["nightly", "prerelease"],
-        help="Type of release: 'nightly' or 'prerelease'",
+        choices=["dev", "nightly", "prerelease", "release", "ci"],
+        help="Type of release: 'dev', 'nightly', 'prerelease', 'release', or 'ci'",
     )
     parser.add_argument(
         "--install-prefix",

--- a/build_tools/packaging/linux/setup_python_cmd.sh
+++ b/build_tools/packaging/linux/setup_python_cmd.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Install Python runtime by --os-profile (optional) and emit PYTHON_CMD for CI.
+#
+# Package mapping by os_profile (default: distro python3 on PATH):
+#
+# - ubuntu* / debian* -> apt: python3, python3-venv, python3-pip -> PYTHON_CMD=python3
+# - sles* -> zypper: python313, python313-pip (SLE/BCI; unversioned python3 / python3-pip are not valid package names) -> PYTHON_CMD=python3.13
+# - else (e.g. UBI 10 / RHEL-like) -> dnf: python3, python3-pip -> PYTHON_CMD=python3
+#
+# Optional --python-version X.Y (e.g. 3.12): install that stream where supported
+# (apt + dnf). Use on UBI 9 / RHEL 9 when default python3 is older than you need.
+# On SLES, --python-version is ignored (zypper names vary); distro python3 is used.
+#
+# Use --install-runtime in CI so Python install lives in this script (not the workflow
+# prerequisites). The workflow may run a tiny bootstrap if python3 is missing before
+# calling this script.
+#
+# --output-format matches get_s3_config.py: env, json, github.
+#
+# Sample usage
+# ------------
+#
+# CI (install + append PYTHON_CMD to GITHUB_ENV):
+#
+#     bash build_tools/packaging/linux/setup_python_cmd.sh \
+#         --os-profile ubuntu2404 --install-runtime >> "$GITHUB_ENV"
+#
+# UBI 9 / older RHEL-like: pin 3.12 from AppStream / repos:
+#
+#     bash build_tools/packaging/linux/setup_python_cmd.sh \
+#         --os-profile rhel9 --python-version 3.12 --install-runtime >> "$GITHUB_ENV"
+#
+# Emit PYTHON_CMD only (no package install):
+#
+#     bash build_tools/packaging/linux/setup_python_cmd.sh --os-profile rhel10 --output-format json
+
+set -euo pipefail
+
+# Defaults
+OS_PROFILE=""
+INSTALL_RUNTIME=false
+OUTPUT_FORMAT="github"
+PY_MM="" # e.g. 3.12 when --python-version set; empty = distro default python3
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --os-profile)
+            OS_PROFILE="$2"
+            shift 2
+            ;;
+        --install-runtime)
+            INSTALL_RUNTIME=true
+            shift
+            ;;
+        --python-version)
+            PY_MM="$2"
+            shift 2
+            ;;
+        --output-format)
+            OUTPUT_FORMAT="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$OS_PROFILE" ]]; then
+    echo "Error: --os-profile is required" >&2
+    exit 1
+fi
+
+# Trim whitespace; lowercase for glob matching (e.g. SLES16 must match sles*)
+OS_PROFILE="${OS_PROFILE#"${OS_PROFILE%%[![:space:]]*}"}"
+OS_PROFILE="${OS_PROFILE%"${OS_PROFILE##*[![:space:]]}"}"
+OS_PLC="${OS_PROFILE,,}"
+
+if [[ -n "$PY_MM" ]] && ! [[ "$PY_MM" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: --python-version must be MAJOR.MINOR (e.g. 3.12)" >&2
+    exit 1
+fi
+
+if [[ -n "$PY_MM" ]]; then
+    PYTHON_CMD="python${PY_MM}"
+elif [[ "$OS_PLC" == sles* ]]; then
+    # SLE/BCI: no installable "python3" metapackage; use python313 -> python3.13
+    PYTHON_CMD="python3.13"
+else
+    PYTHON_CMD="python3"
+fi
+
+# Install Python and pip with apt/zypper/dnf
+install_python_runtime() {
+    local os_profile="$1"
+
+    if [[ "$os_profile" == ubuntu* ]] || [[ "$os_profile" == debian* ]]; then
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -qq >&2
+        if [[ -n "$PY_MM" ]]; then
+            apt-get install -y --no-install-recommends \
+                "python${PY_MM}" \
+                "python${PY_MM}-venv" \
+                "python${PY_MM}-pip" >&2
+        else
+            apt-get install -y --no-install-recommends \
+                python3 \
+                python3-venv \
+                python3-pip >&2
+        fi
+    elif [[ "$os_profile" == sles* ]]; then
+        if [[ -n "$PY_MM" ]]; then
+            echo "Warning: --python-version is not applied on SLES; using python313 stack" >&2
+        fi
+        zypper --non-interactive refresh >&2
+        zypper --non-interactive install -y \
+            python313 \
+            python313-pip >&2
+    else
+        # dnf: UBI 9 / RHEL 9 default python3 may be < 3.12; use --python-version 3.12 when needed
+        if [[ -n "$PY_MM" ]]; then
+            dnf install -y --allowerasing \
+                "python${PY_MM}" \
+                "python${PY_MM}-pip" >&2
+        else
+            dnf install -y --allowerasing \
+                python3 \
+                python3-pip >&2
+        fi
+    fi
+}
+
+# Install first so emitted PYTHON_CMD exists on PATH for later workflow steps
+if [[ "$INSTALL_RUNTIME" == true ]]; then
+    install_python_runtime "$OS_PLC"
+fi
+
+# Emit output in requested format
+case "$OUTPUT_FORMAT" in
+    json)
+        echo "{\"python_cmd\": \"$PYTHON_CMD\"}"
+        ;;
+    github)
+        echo "PYTHON_CMD=$PYTHON_CMD"
+        ;;
+    env)
+        echo "export PYTHON_CMD=$PYTHON_CMD"
+        ;;
+    *)
+        echo "Error: Unknown output format: $OUTPUT_FORMAT" >&2
+        exit 1
+        ;;
+esac

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -1,8 +1,10 @@
+#!/usr/bin/env python3
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
 # Unit test coverage for get_url_repo_params.py:
-#   get_base_url, get_repo_sub_folder, get_repo_url, and main() subcommands.
+#   get_base_url, get_gpg_key_url, gpg_key_url_needed_for_release_type, get_repo_sub_folder,
+#   get_repo_url, extract_gfx_arch, and main() subcommands.
 
 import os
 import sys
@@ -48,6 +50,63 @@ class GetBaseUrlTest(unittest.TestCase):
         # Test that get_base_url raises ValueError for empty or invalid URL.
         with self.assertRaises(ValueError):
             get_url_repo_params.get_base_url("")
+
+
+class GetGpgKeyUrlTest(unittest.TestCase):
+    """Tests for get_gpg_key_url()."""
+
+    def test_extracts_base_and_adds_gpg_path(self):
+        # Test that get_gpg_key_url extracts base URL and appends /gpg/rocm.gpg.
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url(
+                "https://rocm.prereleases.amd.com/packages/ubuntu2404"
+            ),
+            "https://rocm.prereleases.amd.com/gpg/rocm.gpg",
+        )
+
+    def test_strips_path_from_url(self):
+        # Test that get_gpg_key_url strips path and query from URL.
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url(
+                "https://repo.amd.com/rocm/packages/rhel10/x86_64/"
+            ),
+            "https://repo.amd.com/gpg/rocm.gpg",
+        )
+
+    def test_handles_nightly_url(self):
+        # Test that get_gpg_key_url works with nightly URLs.
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url(
+                "https://rocm.nightlies.amd.com/deb/20260204-12345/"
+            ),
+            "https://rocm.nightlies.amd.com/gpg/rocm.gpg",
+        )
+
+
+class GpgKeyUrlNeededForReleaseTypeTest(unittest.TestCase):
+    """Tests for gpg_key_url_needed_for_release_type()."""
+
+    def test_none_means_always_derive(self):
+        self.assertTrue(get_url_repo_params.gpg_key_url_needed_for_release_type(None))
+
+    def test_prerelease_and_release(self):
+        self.assertTrue(
+            get_url_repo_params.gpg_key_url_needed_for_release_type("prerelease")
+        )
+        self.assertTrue(
+            get_url_repo_params.gpg_key_url_needed_for_release_type("release")
+        )
+        self.assertTrue(
+            get_url_repo_params.gpg_key_url_needed_for_release_type("  Prerelease  ")
+        )
+
+    def test_dev_nightly_ci_empty(self):
+        self.assertFalse(get_url_repo_params.gpg_key_url_needed_for_release_type("dev"))
+        self.assertFalse(
+            get_url_repo_params.gpg_key_url_needed_for_release_type("nightly")
+        )
+        self.assertFalse(get_url_repo_params.gpg_key_url_needed_for_release_type("ci"))
+        self.assertFalse(get_url_repo_params.gpg_key_url_needed_for_release_type(""))
 
 
 class GetRepoSubFolderTest(unittest.TestCase):
@@ -153,6 +212,79 @@ class GetRepoUrlTest(unittest.TestCase):
         )
 
 
+class ExtractGfxArchTest(unittest.TestCase):
+    """Tests for extract_gfx_arch()."""
+
+    def test_extracts_and_lowercases_gfx_arch(self):
+        # Test that extract_gfx_arch returns the first segment lowercased.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu"),
+            "gfx94x",
+        )
+
+    def test_handles_lowercase_input(self):
+        # Test that extract_gfx_arch works with already-lowercase input.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("gfx1100-consumer"),
+            "gfx1100",
+        )
+
+    def test_handles_uppercase_prefix(self):
+        # Test that extract_gfx_arch lowercases uppercase prefix.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("GFX942-server"),
+            "gfx942",
+        )
+
+    def test_handles_no_dash(self):
+        # Test that extract_gfx_arch returns the whole string if no dash present.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("gfx1100"),
+            "gfx1100",
+        )
+
+    def test_empty_string_raises(self):
+        # Test that extract_gfx_arch raises ValueError for empty string.
+        with self.assertRaises(ValueError) as ctx:
+            get_url_repo_params.extract_gfx_arch("")
+        self.assertIn("cannot be empty", str(ctx.exception))
+
+    def test_handles_multiple_dashes(self):
+        # Test that extract_gfx_arch only takes first segment when multiple dashes.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu-extra-info"),
+            "gfx94x",
+        )
+
+    def test_comma_separated_list(self):
+        # Test that extract_gfx_arch handles comma-separated artifact groups.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu,gfx1100-consumer"),
+            "gfx94x,gfx1100",
+        )
+
+    def test_semicolon_separated_list(self):
+        # Test that extract_gfx_arch handles semicolon-separated artifact groups.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu;gfx1100-consumer"),
+            "gfx94x,gfx1100",
+        )
+
+    def test_mixed_case_list(self):
+        # Test that extract_gfx_arch lowercases all items in list.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("GFX942-server,GFX1100-consumer"),
+            "gfx942,gfx1100",
+        )
+
+    def test_list_with_spaces(self):
+        # Test that extract_gfx_arch strips whitespace from list items.
+        self.assertEqual(
+            get_url_repo_params.extract_gfx_arch("gfx94X-dcgpu , gfx1100-consumer"),
+            "gfx94x,gfx1100",
+        )
+
+
 class MainSubcommandsTest(unittest.TestCase):
     """Tests for main() subcommands (get-base-url, get-repo-sub-folder, get-repo-url)."""
 
@@ -227,6 +359,141 @@ class MainSubcommandsTest(unittest.TestCase):
                     ]
                 )
         self.assertEqual(code, 1)
+
+    def test_extract_gfx_arch_success(self):
+        # Test that extract-gfx-arch subcommand prints gfx_arch= and returns 0.
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                ["extract-gfx-arch", "--artifact-group", "gfx94X-dcgpu"]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn("gfx_arch=gfx94x", output)
+
+    def test_extract_gfx_arch_lowercase(self):
+        # Test that extract-gfx-arch handles already-lowercase input.
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                ["extract-gfx-arch", "--artifact-group", "gfx1100-consumer"]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn("gfx_arch=gfx1100", output)
+
+    def test_extract_gfx_arch_empty_returns_one(self):
+        # Test that extract-gfx-arch with empty artifact_group returns 1.
+        with patch("sys.stderr"):
+            code = get_url_repo_params.main(
+                ["extract-gfx-arch", "--artifact-group", ""]
+            )
+        self.assertEqual(code, 1)
+
+    def test_extract_gfx_arch_comma_list(self):
+        # Test that extract-gfx-arch handles comma-separated list.
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                [
+                    "extract-gfx-arch",
+                    "--artifact-group",
+                    "gfx94X-dcgpu,gfx1100-consumer",
+                ]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn("gfx_arch=gfx94x,gfx1100", output)
+
+    def test_extract_gfx_arch_semicolon_list(self):
+        # Test that extract-gfx-arch handles semicolon-separated list.
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                [
+                    "extract-gfx-arch",
+                    "--artifact-group",
+                    "gfx94X-dcgpu;gfx1100-consumer",
+                ]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn("gfx_arch=gfx94x,gfx1100", output)
+
+    def test_get_gpg_url_success(self):
+        # Test that get-gpg-url subcommand prints gpg_key_url= and returns 0.
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                [
+                    "get-gpg-url",
+                    "--from-url",
+                    "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+                ]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn(
+            "gpg_key_url=https://rocm.prereleases.amd.com/gpg/rocm.gpg", output
+        )
+
+    def test_get_gpg_url_with_release_type_dev_emits_empty(self):
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                [
+                    "get-gpg-url",
+                    "--release-type",
+                    "dev",
+                    "--from-url",
+                    "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+                ]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn("gpg_key_url=", output)
+        self.assertNotIn("rocm.gpg", output)
+
+    def test_get_gpg_url_with_release_type_dev_ignores_invalid_url(self):
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                [
+                    "get-gpg-url",
+                    "--release-type",
+                    "nightly",
+                    "--from-url",
+                    "not-a-valid-url",
+                ]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertEqual(output.strip(), "gpg_key_url=")
+
+    def test_get_gpg_url_with_release_type_prerelease(self):
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                [
+                    "get-gpg-url",
+                    "--release-type",
+                    "prerelease",
+                    "--from-url",
+                    "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+                ]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn(
+            "gpg_key_url=https://rocm.prereleases.amd.com/gpg/rocm.gpg", output
+        )
+
+    def test_get_gpg_url_with_release_type_release(self):
+        with patch("sys.stdout") as mock_stdout:
+            code = get_url_repo_params.main(
+                [
+                    "get-gpg-url",
+                    "--release-type",
+                    "release",
+                    "--from-url",
+                    "https://repo.amd.com/rocm/packages/rhel10/x86_64/",
+                ]
+            )
+        self.assertEqual(code, 0)
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        self.assertIn("gpg_key_url=https://repo.amd.com/gpg/rocm.gpg", output)
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/tests/setup_python_cmd_test.sh
+++ b/build_tools/packaging/linux/tests/setup_python_cmd_test.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Test suite for setup_python_cmd.sh
+# Run with: bash build_tools/packaging/linux/tests/setup_python_cmd_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_SCRIPT="$SCRIPT_DIR/../setup_python_cmd.sh"
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Test helper functions
+assert_equals() {
+    local expected="$1"
+    local actual="$2"
+    local test_name="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [[ "$expected" == "$actual" ]]; then
+        echo -e "${GREEN}✓${NC} $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} $test_name"
+        echo "  Expected: $expected"
+        echo "  Actual: $actual"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+assert_contains() {
+    local substring="$1"
+    local string="$2"
+    local test_name="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [[ "$string" == *"$substring"* ]]; then
+        echo -e "${GREEN}✓${NC} $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} $test_name"
+        echo "  Expected to contain: $substring"
+        echo "  Actual: $string"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# Test resolve_python_cmd logic (output format tests)
+test_ubuntu_profiles() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile ubuntu2404 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "Ubuntu 24.04 resolves to python3.12"
+
+    output=$(bash "$SETUP_SCRIPT" --os-profile ubuntu2204 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "Ubuntu 22.04 resolves to python3.12"
+
+    output=$(bash "$SETUP_SCRIPT" --os-profile ubuntu2004 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "Ubuntu 20.04 resolves to python3.12"
+}
+
+test_debian_profiles() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile debian12 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "Debian 12 resolves to python3.12"
+
+    output=$(bash "$SETUP_SCRIPT" --os-profile debian11 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "Debian 11 resolves to python3.12"
+}
+
+test_sles_profiles() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile sles16 --output-format github)
+    assert_equals "PYTHON_CMD=python3.13" "$output" "SLES 16 resolves to python3.13"
+
+    output=$(bash "$SETUP_SCRIPT" --os-profile sles15 --output-format github)
+    assert_equals "PYTHON_CMD=python3.13" "$output" "SLES 15 resolves to python3.13"
+}
+
+test_rhel_profiles() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile rhel10 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "RHEL 10 resolves to python3.12"
+
+    output=$(bash "$SETUP_SCRIPT" --os-profile rhel9 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "RHEL 9 resolves to python3.12"
+}
+
+test_centos_profiles() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile centos9 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "CentOS 9 resolves to python3.12 (default case)"
+}
+
+# Test output formats
+test_json_output() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile ubuntu2404 --output-format json)
+    assert_equals '{"python_cmd": "python3.12"}' "$output" "JSON output format for Ubuntu"
+
+    output=$(bash "$SETUP_SCRIPT" --os-profile sles16 --output-format json)
+    assert_equals '{"python_cmd": "python3.13"}' "$output" "JSON output format for SLES"
+}
+
+test_github_output() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile rhel10 --output-format github)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "GitHub output format for RHEL"
+}
+
+test_env_output() {
+    local output=$(bash "$SETUP_SCRIPT" --os-profile ubuntu2404 --output-format env)
+    assert_equals "export PYTHON_CMD=python3.12" "$output" "Env output format for Ubuntu"
+
+    output=$(bash "$SETUP_SCRIPT" --os-profile sles16 --output-format env)
+    assert_equals "export PYTHON_CMD=python3.13" "$output" "Env output format for SLES"
+}
+
+# Test error handling
+test_missing_os_profile() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if bash "$SETUP_SCRIPT" --output-format github 2>/dev/null; then
+        echo -e "${RED}✗${NC} Missing --os-profile should fail"
+        echo "  Expected: error exit code"
+        echo "  Actual: success"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    else
+        echo -e "${GREEN}✓${NC} Missing --os-profile should fail"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    fi
+}
+
+test_invalid_output_format() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if bash "$SETUP_SCRIPT" --os-profile ubuntu2404 --output-format invalid 2>/dev/null; then
+        echo -e "${RED}✗${NC} Invalid --output-format should fail"
+        echo "  Expected: error exit code"
+        echo "  Actual: success"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    else
+        echo -e "${GREEN}✓${NC} Invalid --output-format should fail"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    fi
+}
+
+# Run all tests
+echo "Running setup_python_cmd.sh tests..."
+echo ""
+
+test_ubuntu_profiles
+test_debian_profiles
+test_sles_profiles
+test_rhel_profiles
+test_centos_profiles
+test_json_output
+test_github_output
+test_env_output
+test_missing_os_profile
+test_invalid_output_format
+
+# Print summary
+echo ""
+echo "========================================"
+echo "Test Summary"
+echo "========================================"
+echo "Tests run: $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+    exit 1
+else
+    echo -e "Tests failed: $TESTS_FAILED"
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi


### PR DESCRIPTION

## Motivation

This pull request introduces significant enhancements and new utilities to the Linux packaging tools, focusing on repository parameter extraction, GPU architecture parsing, GPG key URL handling, and Python runtime setup for CI environments. It also expands test coverage and improves argument handling in the native package install test script.
## Technical Details

**New features and utilities:**

* Added support for extracting and normalizing GPU architecture from artifact group strings, with a new `extract-gfx-arch` subcommand in `get_url_repo_params.py`. This helps standardize GPU architecture names for packaging and CI workflows. [[1]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R171-R214) [[2]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R13-R30) [[3]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R310-R323)
* Introduced a new subcommand `get-gpg-url` in `get_url_repo_params.py` to derive the GPG key URL from a package repository URL, with logic to emit the URL only for certain release types (prerelease/release) or always for legacy cases. [[1]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R60-R105) [[2]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R13-R30) [[3]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R240-R259)

**Python runtime setup for CI:**

* Added `setup_python_cmd.sh`, a utility script to install the appropriate Python runtime and emit the correct `PYTHON_CMD` for various Linux distributions and Python versions, supporting CI and workflow automation.

**Testing improvements:**

* Extended unit tests in `get_url_repo_params_test.py` to cover the new GPU architecture extraction and GPG key URL logic, ensuring correctness and robustness of the new features. [[1]](diffhunk://#diff-efbbd087226bbda3741276f7088818d24cf796b4ad4a963e1c13835c0206f99dR1-R7) [[2]](diffhunk://#diff-efbbd087226bbda3741276f7088818d24cf796b4ad4a963e1c13835c0206f99dR55-R111) [[3]](diffhunk://#diff-efbbd087226bbda3741276f7088818d24cf796b4ad4a963e1c13835c0206f99dR215-R287)

**Other improvements:**

* Updated the native package install test script to always invoke `rdhc.py` with the current Python interpreter, improving compatibility.
* Broadened the accepted `--release-type` values in argument parsing to include `dev`, `release`, and `ci`, in addition to `nightly` and `prerelease`.

These changes improve automation, reliability, and flexibility for packaging and CI workflows across various Linux environments.

**References:**
- [[1]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R13-R30) [[2]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R60-R105) [[3]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R171-R214) [[4]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R240-R259) [[5]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R310-R323)
- [build_tools/packaging/linux/setup_python_cmd.shR1-R158](diffhunk://#diff-fd383dce69ee298aa0d2fd1b9eeab9050480a607bbc3a30b8efb9a74adcf9f67R1-R158)
- [[1]](diffhunk://#diff-efbbd087226bbda3741276f7088818d24cf796b4ad4a963e1c13835c0206f99dR1-R7) [[2]](diffhunk://#diff-efbbd087226bbda3741276f7088818d24cf796b4ad4a963e1c13835c0206f99dR55-R111) [[3]](diffhunk://#diff-efbbd087226bbda3741276f7088818d24cf796b4ad4a963e1c13835c0206f99dR215-R287)
- [[1]](diffhunk://#diff-79959fbf42afa5c33796b97c10d2634bdf16eb7ec4c0b530bd922c466fddeed0L838-R838) [[2]](diffhunk://#diff-79959fbf42afa5c33796b97c10d2634bdf16eb7ec4c0b530bd922c466fddeed0L947-R945)


## Test Plan


## Test Result

https://github.com/ROCm/TheRock/actions/runs/24353145372

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
