### PR TITLE
Enable KPACK_SPLIT_ARTIFACTS flag

### DIFF
--- a/BRANCH_FLAGS.cmake
+++ b/BRANCH_FLAGS.cmake
@@ -1,0 +1,4 @@
+# BRANCH_FLAGS.cmake
+# Integration branch override: enable kpack artifact splitting.
+# See docs/development/flags.md for the branch flag override mechanism.
+therock_override_flag_default(KPACK_SPLIT_ARTIFACTS ON)


### PR DESCRIPTION
Flip the kpack artifact splitting flag to ON via BRANCH_FLAGS.cmake so that CI builds on this branch produce split (generic + arch-specific) artifacts. The kpack runtime in CLR is already enabled unconditionally; this enables the build-side splitting that produces the archives CLR will load.

Changes:
- Add BRANCH_FLAGS.cmake with therock_override_flag_default(KPACK_SPLIT_ARTIFACTS ON)