### PR TITLE
Re-admit hipSOLVER fortran shim in kpack-split devel wheel

### DIFF
--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -3,7 +3,7 @@
 
 """Utilities for producing Python packages."""
 
-from typing import Callable, Sequence
+from typing import Callable, Mapping, Sequence
 
 import importlib.util
 import re
@@ -486,9 +486,19 @@ class PopulatedDistPackage:
         *,
         addl_artifact_names: Sequence[str] = (),
         exclude_components: Sequence[str] = (),
+        component_include_overrides: Mapping[str, Sequence[str]] = {},
         tarball_compression: bool = True,
     ):
-        """Populates all files that have not yet been materialized and symlink the rest."""
+        """Populates all files that have not yet been materialized and symlink the rest.
+
+        ``component_include_overrides`` re-admits narrow file patterns from
+        components listed in ``exclude_components``. Keys are component names;
+        values are glob patterns matched against relpaths. Used when an
+        excluded component is the canonical home for files that are still
+        needed in devel (e.g. the BLAS fortran interop shims live in ``test``
+        because the test binary links against them at runtime, yet devel
+        consumers also need them resolved through exported CMake targets).
+        """
         package_path = self.platform_dir
         # Set up for what artifacts to include in the devel package, including
         # any emitted runtime artifacts plus additional requested.
@@ -520,6 +530,36 @@ class PopulatedDistPackage:
                 dest_path,
                 dir_entry,
             )
+
+        for component, include_globs in component_include_overrides.items():
+            if component not in excluded:
+                continue
+
+            def _override_filter(an: ArtifactName, _c=component) -> bool:
+                if an.name not in devel_artifact_names:
+                    return False
+                if an.component != _c:
+                    return False
+                if (
+                    an.target_family != "generic"
+                    and an.target_family != self.target_family
+                ):
+                    return False
+                return True
+
+            override_artifacts = self.params.filter_artifacts(
+                _override_filter, includes=tuple(include_globs)
+            )
+            log(f"::: Re-admitting {component} files matching {list(include_globs)}")
+            for an, an_path in override_artifacts.artifact_basedirs:
+                log(f"  + {an}: {an_path}")
+            for relpath, dir_entry in override_artifacts.pm.matches():
+                dest_path = package_path / relpath
+                self._populate_devel_file(
+                    relpath,
+                    dest_path,
+                    dir_entry,
+                )
 
         # For packaging, the devel platform/ contents are not wheel safe, so we
         # store them into their own tarball and dynamically decompress at runtime.

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -149,6 +149,15 @@ def _run_kpack_split(
             "nlohmann-json",
         ],
         exclude_components=["test"],
+        # hipSOLVER's fortran interop shim lives in the `test` component
+        # alongside `hipsolver-test`, which links against it at runtime. Devel
+        # consumers also need it: `hipsolver-targets.cmake` exports
+        # `roc::hipsolver_fortran` with an IMPORTED_LOCATION pointing at the
+        # shim, and CMake's generated import-check fails the configure step
+        # of downstream projects (e.g. PyTorch) when the file is absent.
+        component_include_overrides={
+            "test": ["lib/libhipsolver_fortran.so*"],
+        },
         tarball_compression=args.devel_tarball_compression,
     )
     if args.build_packages:


### PR DESCRIPTION
## Motivation

Downstream CMake consumers, like PyTorch, that `find_package(hipsolver)` against the kpack-split rocm-sdk-devel wheel fail at configure time with:

```
CMake Error at .../cmake/hipsolver/hipsolver-targets.cmake:92:
  The imported target "roc::hipsolver_fortran" references the file
  ".../lib/libhipsolver_fortran.so.1.0" but this file does not exist.
```

`hipsolver-targets-release.cmake` (shipped in the `dev` component) defines `roc::hipsolver_fortran` with an IMPORTED_LOCATION pointing at `libhipsolver_fortran.so.1.0`. However, the lib lives in the `test` artifact because the hipsolver-test binary links against it. The kpack-split path added `exclude_components=["test"]` (commit b6b306b4) to drop generic test. Moving ther shim into the the lib artifact is not a viable solution as this would introduce a runtime dependency on libgfortran for every consumer. Moving to dev would break tests.

## Technical Details

Adds a `component_include_overrides: Mapping[str, Sequence[str]]` parameter to `populate_devel_files` in `py_packaging.py`. For each excluded component with a mapping entry, run a secondary `filter_artifacts` admitting only that component and scoping the PathMatcher to the supplied include globs, then populate through the same `_populate_devel_file` path as the main pass.

With `{"test": ["lib/libhipsolver_fortran.so*"]}` set and wired into `_run_kpack_split` we have a strict match that only matches the hipsolver fortran libraries and nothing else from the test artifacts.

Legacy-mode devel wheel behavior is unchanged (no override passed from `_run_legacy`).

## Test Plan

1. Rebuild rocm Python packages from an existing kpack-split artifact tree.
2. Inspect the devel wheel tarball for the hipsolver fortran variants and absence of other `test`-component files.
3. End-to-end: install `rocm[libraries,devel,device-gfx1201]` from the local dist in a manylinux container, run the PyTorch release/2.10 build via `external-builds/pytorch/build_prod_wheels.py`, and confirm it progresses past the hipsolver-targets.cmake import check.

## Test Result

* Repackaged locally against `/develop/therock/artifacts` (kpack-split, gfx1200/gfx1201) in the manylinux builder image. The devel wheel's `_devel.tar` now contains `_rocm_sdk_devel/lib/libhipsolver_fortran.so{,.1,.1.0}`. No `hipsolver-test` or `hipsolver-bench`.
* PyTorch `release/2.10` (torch-only, cp312, gfx1201) built successfully end-to-end.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.