### PR TITLE
[hip-kernel-provider]: Add a FF for hip-kernel-provider

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -630,7 +630,6 @@ artifact_deps = ["core-runtime", "core-hip", "miopen", "hipdnn", "miopenprovider
 artifact_group = "ml-libs"
 type = "target-neutral"
 artifact_deps = ["core-runtime", "core-hip", "hipdnn"]
-disable_platforms = ["linux", "windows"]
 
 # --- IREE Integration ---
 

--- a/FLAGS.cmake
+++ b/FLAGS.cmake
@@ -21,6 +21,16 @@ therock_declare_flag(
   DESCRIPTION "Split target-specific artifacts into generic and arch-specific components"
 )
 
+therock_declare_flag(
+  NAME HIP_KERNEL_PROVIDER_ENABLE
+  DEFAULT_VALUE OFF
+  DESCRIPTION "Enable hip-kernel-provider plugin"
+  CMAKE_VARS
+    HIP_KERNEL_PROVIDER_ENABLE=ON
+  SUB_PROJECTS
+    hipkernelprovider
+)
+
 ###############################################################################
 # Branch-specific flag overrides.
 # BRANCH_FLAGS.cmake is .gitignored on main but can be committed on

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -308,45 +308,47 @@ if(THEROCK_ENABLE_HIPKERNELPROVIDER)
   # hipDNN hip kernel provider
   ##############################################################################
 
-  therock_cmake_subproject_declare(hipkernelprovider
-    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/dnn-providers/hip-kernel-provider"
-    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hipkernelprovider"
-    BACKGROUND_BUILD
-    CMAKE_ARGS
-      -DHIP_PLATFORM=amd
-      -DROCM_PATH=
-      -DROCM_DIR=
-      -DHIPKERNELPROVIDER_ENABLE_TESTS=${THEROCK_BUILD_TESTING}
-      -DENABLE_CLANG_TIDY=OFF
-      -DENABLE_CLANG_FORMAT=OFF
-    CMAKE_INCLUDES
-      therock_explicit_finders.cmake
-    COMPILER_TOOLCHAIN
-      amd-hip
-    BUILD_DEPS
-      hipDNN
-      therock-googletest
-      therock-flatbuffers
-      therock-nlohmann-json
-    RUNTIME_DEPS
-      hip-clr
-  )
-  therock_cmake_subproject_glob_c_sources(hipkernelprovider
-  SUBDIRS
-    .
-  )
-  therock_cmake_subproject_activate(hipkernelprovider)
+  if(HIP_KERNEL_PROVIDER_ENABLE)
+    therock_cmake_subproject_declare(hipkernelprovider
+      EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/dnn-providers/hip-kernel-provider"
+      BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hipkernelprovider"
+      BACKGROUND_BUILD
+      CMAKE_ARGS
+        -DHIP_PLATFORM=amd
+        -DROCM_PATH=
+        -DROCM_DIR=
+        -DHIPKERNELPROVIDER_ENABLE_TESTS=${THEROCK_BUILD_TESTING}
+        -DENABLE_CLANG_TIDY=OFF
+        -DENABLE_CLANG_FORMAT=OFF
+      CMAKE_INCLUDES
+        therock_explicit_finders.cmake
+      COMPILER_TOOLCHAIN
+        amd-hip
+      BUILD_DEPS
+        hipDNN
+        therock-googletest
+        therock-flatbuffers
+        therock-nlohmann-json
+      RUNTIME_DEPS
+        hip-clr
+    )
+    therock_cmake_subproject_glob_c_sources(hipkernelprovider
+    SUBDIRS
+      .
+    )
+    therock_cmake_subproject_activate(hipkernelprovider)
 
-  therock_provide_artifact(hipkernelprovider
-    TARGET_NEUTRAL
-    DESCRIPTOR artifact-hipkernelprovider.toml
-    COMPONENTS
-      dbg
-      lib
-      test
-    SUBPROJECT_DEPS
-      hipkernelprovider
-  )
+    therock_provide_artifact(hipkernelprovider
+      TARGET_NEUTRAL
+      DESCRIPTOR artifact-hipkernelprovider.toml
+      COMPONENTS
+        dbg
+        lib
+        test
+      SUBPROJECT_DEPS
+        hipkernelprovider
+    )
+  endif(HIP_KERNEL_PROVIDER_ENABLE)
 endif(THEROCK_ENABLE_HIPKERNELPROVIDER)
 
 if(THEROCK_ENABLE_HIPDNN_SAMPLES)


### PR DESCRIPTION
## Motivation

Add a FF for the hip-kernel-provider so it can default off for theRock and then I can turn it on in Rocm-libraries

