### PR TITLE
Drop expect_pytorch_failure from windows 900,906,908,90a.

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -180,7 +180,6 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx900",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
-            "expect_pytorch_failure": True,
         },
     },
     # gfx906/908/90a split into separate families - each has different instruction
@@ -200,7 +199,6 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx906",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
-            "expect_pytorch_failure": True,
         },
     },
     "gfx908": {
@@ -217,7 +215,6 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx908",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
-            "expect_pytorch_failure": True,
         },
     },
     "gfx90a": {
@@ -233,7 +230,6 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx90a",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
-            "expect_pytorch_failure": True,
         },
     },
     "gfx101x": {

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -412,8 +412,6 @@ amdgpu_family_info_matrix_all = {
                     "bypass_tests_for_releases": False,
                 },
             },
-            # TODO(#1927): Resolve error generating file `torch_hip_generated_int4mm.hip.obj`,
-            # to enable PyTorch builds
             "windows": {
                 "build": {
                     "build_variants": ["release"],
@@ -422,7 +420,6 @@ amdgpu_family_info_matrix_all = {
                     "run_tests": False,
                     "runs_on": {},
                     "fetch-gfx-targets": [],
-                    "expect_pytorch_failure": True,
                 },
                 "release": {
                     "push_on_success": False,
@@ -496,7 +493,6 @@ amdgpu_family_info_matrix_all = {
                     },
                     "fetch-gfx-targets": [],
                     "sanity_check_only_for_family": True,
-                    "expect_pytorch_failure": True,
                 },
                 "release": {
                     "push_on_success": False,


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/1927.

Now we have _zero_ expected pytorch build failures. We could even remove the CI configuration code that handles that now.

## Technical Details

Previous errors were
```
2025-10-23T22:03:19.3253573Z B:/src/torch/aten/src/ATen/native/hip/int4mm.hip:799:23: note: called by 'tinygemm_m16n8k16_chunk_kernel<at::native::ALayout_RM<at::native::KReductionType::None>, at::native::BLayout_TC_int4<8, 128>, at::native::ALayout_RM<at::native::KReductionType::None>, 8, 8>'
2025-10-23T22:03:19.3254963Z   799 |     BLayout::template load<kInnerKTiles>(
2025-10-23T22:03:19.3255260Z       |                       ^
2025-10-23T22:03:19.3255981Z B:/src/torch/aten/src/ATen/native/hip/int4mm.hip:585:16: error: reference to __host__ function 'memcpy' in __device__ function
2025-10-23T22:03:19.3256685Z   585 |           std::memcpy(&out[i][j], &v, sizeof(bf16x2x4_u32));
2025-10-23T22:03:19.3257019Z       |                ^
2025-10-23T22:03:19.3258128Z B:/src/torch/aten/src/ATen/native/hip/int4mm.hip:693:23: note: called by 'tinygemm_m16n8k16_chunk_kernel<at::native::ALayout_RM<at::native::KReductionType::None>, at::native::BLayout_TC_int4<2, 256>, at::native::ALayout_RM<at::native::KReductionType::None>, 8, 8>'
2025-10-23T22:03:19.3259534Z   693 |     BLayout::template load<KTilesPerIteration>(
2025-10-23T22:03:19.3259885Z       |                       ^
2025-10-23T22:03:19.3260367Z fatal error: too many errors emitted, stopping now [-ferror-limit=]
```

I suspect a change like https://github.com/ROCm/rocm-systems/pull/4047 fixed this.

## Test Plan

* Python 3.12, pytorch `release/2.10` branch
  * Test CI run at https://github.com/ROCm/TheRock/actions/runs/24532353196/job/71741814695
  * CI run on this PR
* All supported python versions, all supported pytorch releases branches
  * After merge, watch nightly pytorch release workflows at https://github.com/ROCm/TheRock/actions/workflows/release_windows_pytorch_wheels.yml?query=branch%3Amain

## Test Result

Limited test builds passed, will monitor others after merge.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
