### PR TITLE
Revert "Use amd-llvm as the default toolchain for all RDC builds"

### DIFF
--- a/dctools/CMakeLists.txt
+++ b/dctools/CMakeLists.txt
@@ -14,8 +14,6 @@ if(THEROCK_ENABLE_RDC)
   therock_cmake_subproject_declare(rdc
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rdc"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rdc"
-    COMPILER_TOOLCHAIN
-      amd-llvm
     BACKGROUND_BUILD
     USE_DIST_AMDGPU_TARGETS
 


### PR DESCRIPTION
Reverts ROCm/TheRock#4513

OSError: librdc_bootstrap.so.1: cannot open shared object file: No such file or directory

issue: https://github.com/ROCm/TheRock/issues/4640 