### PR TITLE
Flip `KPACK_SPLIT_ARTIFACTS` to `ON`

### DIFF
--- a/FLAGS.cmake
+++ b/FLAGS.cmake
@@ -17,7 +17,7 @@ include(therock_flag_utils)
 
 therock_declare_flag(
   NAME KPACK_SPLIT_ARTIFACTS
-  DEFAULT_VALUE OFF
+  DEFAULT_VALUE ON
   DESCRIPTION "Split target-specific artifacts into generic and arch-specific components"
 )
 

--- a/build_tools/github_actions/build_configure.py
+++ b/build_tools/github_actions/build_configure.py
@@ -108,6 +108,13 @@ def build_configure(build_dir, manylinux=False):
             f"-DCMAKE_C_COMPILER_LAUNCHER={c_launcher}",
             f"-DCMAKE_CXX_COMPILER_LAUNCHER={cxx_launcher}",
             "-DBUILD_TESTING=ON",
+            # Opt-out of KPACK_SPLIT_ARTIFACTS for non-multi-arch CI/CD.
+            # * Multi-arch CI/CD uses configure_stage.py instead of this script
+            # * Local developer builds will use the flag default value
+            # Related issues:
+            # * multi-arch kpack parent: https://github.com/ROCm/TheRock/issues/3323
+            # * multi-arch opt-in: https://github.com/ROCm/TheRock/issues/3338
+            "-DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=OFF",
         ]
     )
 


### PR DESCRIPTION
This flips the `KPACK_SPLIT_ARTIFACTS` flag to enable kpack artifact splitting by default.

* Fixes https://github.com/ROCm/TheRock/issues/3339
* Fixes https://github.com/ROCm/TheRock/issues/3338

## Impact on multi-arch CI/CD

Libraries will now be processed by kpack, which will produce individual files for each GPU _architecture_ (not GPU _family_!), stored within `.tar.zst` compressed artifacts.

## Impact on non-multi-arch CI/CD

Non-multi-arch CI/CD is not set up to support the flag, see failures at https://github.com/ROCm/TheRock/actions/runs/24579570384?pr=4652. To keep non-multi-arch CI/CD across TheRock/rocm-libraries/rocm-systems/etc., we decided to opt-out of the flag in `build_tools/github_actions/build_configure.py`.