### PR TITLE
[packaging] Reserve RPATH pad to avoid `patchelf` breaking ELF layout on RHEL 8.10 (#4271)

### DIFF
--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -52,6 +52,21 @@ ENABLED_VLOG_LEVEL: int = 5
 PATCHELF_PAD_MARKER = "__therock_patchelf_pad__"
 
 
+def _format_rpath_for_log(rpath: str) -> str:
+    """Collapse the pad filler to '<pad>' for readable REWRITE_RPATH logs.
+
+    The pad entry is ~1KB of X's and dumping it unmodified into every log line
+    makes `py_packaging.log` unreadable and spooks users watching the build
+    (issue #4271). The on-disk value is untouched; this only affects logging.
+    """
+    if not rpath:
+        return rpath
+    return ":".join(
+        "<pad>" if PATCHELF_PAD_MARKER in entry else entry
+        for entry in rpath.split(":")
+    )
+
+
 def log(*args, vlog: int = 0, **kwargs):
     if vlog > ENABLED_VLOG_LEVEL:
         return
@@ -499,7 +514,10 @@ class PopulatedDistPackage:
         if new_rpath == existing_rpath:
             return
 
-        log(f"  REWRITE_RPATH: {file_path}: {existing_rpath!r} -> {new_rpath!r}")
+        log(
+            f"  REWRITE_RPATH: {file_path}: "
+            f"{_format_rpath_for_log(existing_rpath)!r} -> {new_rpath!r}"
+        )
         subprocess.check_call(
             [
                 "patchelf",

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -36,6 +36,21 @@ assert DIST_INFO_PATH.exists()
 
 ENABLED_VLOG_LEVEL: int = 5
 
+# Marker substring baked into RPATH pad entries at link time by
+# cmake/therock_subproject_utils.cmake. ELFs TheRock ships are linked with a
+# ~1KB filler RPATH entry containing this marker so that when we later rewrite
+# RPATHs below with `patchelf --set-rpath`, the replacement always fits inside
+# the .dynstr allocation that was reserved at link time. Patchelf therefore
+# overwrites in place and does not need to prepend a new PT_LOAD segment,
+# which is the mutation that crashes execve() on RHEL 8.10 / EL 4.18 kernels.
+# See https://github.com/ROCm/TheRock/issues/4271 for the full diagnosis.
+#
+# The same constant is duplicated in
+# build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
+# because that file ships inside the wheel and cannot import from build-only
+# modules. Keep the two string literals in sync.
+PATCHELF_PAD_MARKER = "__therock_patchelf_pad__"
+
 
 def log(*args, vlog: int = 0, **kwargs):
     if vlog > ENABLED_VLOG_LEVEL:
@@ -428,10 +443,11 @@ class PopulatedDistPackage:
             # Update RPATHs on Linux.
             file_type = get_file_type(dest_path)
             if file_type == "exe" or file_type == "so":
-                self._extend_rpath(dest_path)
-                self._normalize_rpath(dest_path)
+                self._rewrite_rpath(dest_path, self._dep_rpath_entries(dest_path))
 
-    def _extend_rpath(self, file_path: Path):
+    def _dep_rpath_entries(self, file_path: Path) -> list[str]:
+        """$ORIGIN-relative RPATH entries contributed by rpath_deps packages."""
+        entries: list[str] = []
         for dep_project, rpath in self.rpath_deps:
             parent_relpath = self._platform_dir.parent.relative_to(
                 file_path.parent, walk_up=True
@@ -439,40 +455,56 @@ class PopulatedDistPackage:
             dep_py_package_name = dep_project.entry.get_py_package_name(
                 self.target_family
             )
-            addl_rpath = f"$ORIGIN/{parent_relpath}/{dep_py_package_name}/{rpath}"
-            log(f"  ADD_RPATH: {file_path}: {addl_rpath}")
-            patchelf_cl = [
-                "patchelf",
-                "--add-rpath",
-                addl_rpath,
-                str(file_path),
-            ]
-            subprocess.check_call(patchelf_cl)
+            entries.append(f"$ORIGIN/{parent_relpath}/{dep_py_package_name}/{rpath}")
+        return entries
 
-    def _normalize_rpath(self, file_path: Path):
+    def _rewrite_rpath(self, file_path: Path, extra_rpath_entries: Sequence[str] = ()):
+        """Rewrite DT_RPATH in place.
+
+        Reads the existing RPATH, strips any filler entries the build planted
+        at link time (identified by PATCHELF_PAD_MARKER), appends the requested
+        extra_rpath_entries deduplicated against what's already there, and
+        writes the result back with a single `patchelf --set-rpath`.
+
+        Using `--set-rpath` means patchelf overwrites the existing .dynstr
+        entry in place as long as the new string fits within the space that
+        was reserved at link time by the pad. That's the whole point: it
+        avoids the .dynstr-growth path that prepends a new PT_LOAD segment
+        and trips the RHEL 8.10 execve() bug (see PATCHELF_PAD_MARKER docs
+        and issue #4271). If the replacement ever doesn't fit, patchelf will
+        fall back to growing .dynstr and the CI pad-marker grep will flag it.
+        """
         existing_rpath = (
-            subprocess.check_output(
-                [
-                    "patchelf",
-                    "--print-rpath",
-                    str(file_path),
-                ]
-            )
+            subprocess.check_output(["patchelf", "--print-rpath", str(file_path)])
             .decode()
             .strip()
         )
-        if not existing_rpath:
+
+        entries: list[str] = []
+        seen: set[str] = set()
+        if existing_rpath:
+            for entry in existing_rpath.split(":"):
+                if not entry or PATCHELF_PAD_MARKER in entry:
+                    continue
+                if entry in seen:
+                    continue
+                entries.append(entry)
+                seen.add(entry)
+        for entry in extra_rpath_entries:
+            if entry and entry not in seen:
+                entries.append(entry)
+                seen.add(entry)
+
+        new_rpath = ":".join(entries)
+        if new_rpath == existing_rpath:
             return
 
-        # Possibly in the future, do manual normalization of the RPATH.
-        norm_rpath = existing_rpath
-
-        log(f"  NORMALIZE_RPATH: {file_path}: {norm_rpath}")
+        log(f"  REWRITE_RPATH: {file_path}: {existing_rpath!r} -> {new_rpath!r}")
         subprocess.check_call(
             [
                 "patchelf",
                 "--set-rpath",
-                norm_rpath,
+                new_rpath,
                 # Forces the use of RPATH vs RUNPATH, which is more appropriate
                 # for hermetic libraries like these since it does not allow
                 # LD_LIBRARY_PATH to interfere.
@@ -637,10 +669,12 @@ class PopulatedDistPackage:
         shutil.copy2(src_entry.path, dest_path)
 
         if not is_windows:
-            # Update RPATHs on Linux.
+            # Update RPATHs on Linux. Devel files don't pull in new
+            # dep-relative RPATHs, but we still run the rewrite so any link-
+            # time pad entries get stripped in place.
             file_type = get_file_type(dest_path)
             if file_type == "exe" or file_type == "so":
-                self._normalize_rpath(dest_path)
+                self._rewrite_rpath(dest_path)
 
 
 MAGIC_AR_MATCH = re.compile("ar archive")

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -62,8 +62,7 @@ def _format_rpath_for_log(rpath: str) -> str:
     if not rpath:
         return rpath
     return ":".join(
-        "<pad>" if PATCHELF_PAD_MARKER in entry else entry
-        for entry in rpath.split(":")
+        "<pad>" if PATCHELF_PAD_MARKER in entry else entry for entry in rpath.split(":")
     )
 
 

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/core_test.py
@@ -5,8 +5,10 @@
 
 import importlib
 import locale
+import mmap
 from pathlib import Path
 import platform
+import struct
 import subprocess
 import sys
 import unittest
@@ -15,6 +17,17 @@ from .. import _dist_info as di
 from . import utils
 
 import rocm_sdk
+
+# Keep in sync with PATCHELF_PAD_MARKER in
+# build_tools/_therock_utils/py_packaging.py. See that file for why the pad
+# exists and why we want the absence of this marker in shipped binaries.
+PATCHELF_PAD_MARKER_BYTES = b"__therock_patchelf_pad__"
+ELF_MAGIC = b"\x7fELF"
+# ELF program header flag bits.
+PF_X = 0x1
+PF_W = 0x2
+PF_R = 0x4
+PT_LOAD = 1
 
 utils.assert_is_physical_package(rocm_sdk)
 
@@ -58,6 +71,57 @@ WINDOWS_CONSOLE_SCRIPT_TESTS = [
 CONSOLE_SCRIPT_TESTS = COMMON_CONSOLE_SCRIPT_TESTS + (
     WINDOWS_CONSOLE_SCRIPT_TESTS if is_windows else LINUX_CONSOLE_SCRIPT_TESTS
 )
+
+
+def _file_contains_bytes(path: Path, needle: bytes) -> bool:
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return False
+    if size < len(needle):
+        return False
+    with open(path, "rb") as f:
+        with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
+            return mm.find(needle) != -1
+
+
+def _is_elf(path: Path) -> bool:
+    try:
+        with open(path, "rb") as f:
+            return f.read(4) == ELF_MAGIC
+    except OSError:
+        return False
+
+
+def _parse_elf64_pt_loads(path: Path):
+    """Return (e_entry, [(p_flags, p_vaddr, p_memsz), ...]) for PT_LOAD segments.
+
+    Only supports 64-bit little-endian ELFs. Returns None for anything else
+    (32-bit, big-endian, non-ELF). ROCm only ships 64-bit LE binaries.
+    """
+    with open(path, "rb") as f:
+        ehdr = f.read(64)
+        if len(ehdr) < 64 or not ehdr.startswith(ELF_MAGIC):
+            return None
+        if ehdr[4] != 2 or ehdr[5] != 1:
+            return None
+        e_entry, e_phoff = struct.unpack_from("<QQ", ehdr, 0x18)
+        e_phentsize, e_phnum = struct.unpack_from("<HH", ehdr, 0x36)
+        if e_phentsize < 56 or e_phnum == 0:
+            return None
+        f.seek(e_phoff)
+        phdrs = f.read(e_phentsize * e_phnum)
+    segments = []
+    for i in range(e_phnum):
+        base = i * e_phentsize
+        p_type = struct.unpack_from("<I", phdrs, base)[0]
+        if p_type != PT_LOAD:
+            continue
+        p_flags = struct.unpack_from("<I", phdrs, base + 0x04)[0]
+        p_vaddr = struct.unpack_from("<Q", phdrs, base + 0x10)[0]
+        p_memsz = struct.unpack_from("<Q", phdrs, base + 0x28)[0]
+        segments.append((p_flags, p_vaddr, p_memsz))
+    return e_entry, segments
 
 
 class ROCmCoreTest(unittest.TestCase):
@@ -159,3 +223,84 @@ class ROCmCoreTest(unittest.TestCase):
                     shortname=lib_entry.shortname,
                 ):
                     rocm_sdk.preload_libraries(lib_entry.shortname)
+
+    @unittest.skipIf(is_windows, "Patchelf RPATH pad only applies on ELF")
+    def testPatchelfPadStripped(self):
+        """No shipped file should still contain the patchelf RPATH pad marker.
+
+        TheRock links binaries with a ~1KB filler RPATH entry whose job is to
+        reserve .dynstr space for patchelf to overwrite in place at packaging
+        time. Finding the marker in an installed file means py_packaging
+        didn't rewrite that binary's RPATH (likely a file-type detection
+        miss), so the ~1KB pad leaked into the shipped artifact. Harmless at
+        runtime but a packaging bug worth failing CI on.
+
+        Context: https://github.com/ROCm/TheRock/issues/4271
+        """
+        core_root = Path(core_mod.__file__).parent
+        offenders = []
+        for f in core_root.rglob("*"):
+            if not f.is_file() or f.is_symlink():
+                continue
+            if _file_contains_bytes(f, PATCHELF_PAD_MARKER_BYTES):
+                offenders.append(str(f.relative_to(core_root)))
+        self.assertFalse(
+            offenders,
+            msg=(
+                "Files still contain the patchelf RPATH pad marker "
+                f"{PATCHELF_PAD_MARKER_BYTES.decode()!r}; py_packaging did not "
+                "rewrite their RPATHs:\n  " + "\n  ".join(sorted(offenders))
+            ),
+        )
+
+    @unittest.skipIf(is_windows, "ELF layout check only applies on Linux")
+    def testExecutableElfLayoutIntact(self):
+        """Every shipped ELF executable's first PT_LOAD must be non-writable.
+
+        The RHEL 8.10 / EL 4.18 execve() crash reproduced in issue #4271 is
+        triggered by ELFs whose first PT_LOAD segment is read-write at a
+        non-canonical base address (e.g. 0x3ff000 instead of 0x400000). That
+        layout is the telltale signature of patchelf having grown .dynstr and
+        prepended a new PT_LOAD. We assert the invariant directly instead of
+        trying to enumerate every kernel that cares: the first PT_LOAD of a
+        freshly linked executable is always R or RX, never RW.
+
+        Shared objects (`.so`) are excluded because the kernel bug only
+        affects executables loaded via execve(); ld.so handles the layout
+        correctly for DT_NEEDED loads.
+        """
+        core_root = Path(core_mod.__file__).parent
+        bin_dir = core_root / "bin"
+        if not bin_dir.is_dir():
+            self.skipTest("Core package has no bin/ directory")
+
+        offenders = []
+        checked = 0
+        for f in bin_dir.rglob("*"):
+            if not f.is_file() or f.is_symlink():
+                continue
+            if not _is_elf(f):
+                continue
+            parsed = _parse_elf64_pt_loads(f)
+            if parsed is None:
+                continue
+            _, segments = parsed
+            if not segments:
+                continue
+            checked += 1
+            first_flags, first_vaddr, _ = segments[0]
+            if first_flags & PF_W:
+                offenders.append(
+                    f"{f.relative_to(core_root)}: first PT_LOAD is writable "
+                    f"(flags=0x{first_flags:x}, vaddr=0x{first_vaddr:x})"
+                )
+
+        self.assertGreater(checked, 0, msg=f"Found no ELF executables under {bin_dir}")
+        self.assertFalse(
+            offenders,
+            msg=(
+                "ELF layout looks patchelf-mutated (issue #4271); expected "
+                "first PT_LOAD to be read-only on executables:\n  "
+                + "\n  ".join(sorted(offenders))
+            ),
+        )

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -10,6 +10,11 @@
 
 include(ExternalProject)
 
+# therock_subproject_utils defines THEROCK_INSTALL_RPATH_PAD and friends,
+# which are baked into each subproject's init file below. Include it eagerly
+# so the pad is computed before any _init_contents generation runs.
+include(therock_subproject_utils)
+
 # Global properties.
 # THEROCK_DEFAULT_CMAKE_VARS:
 # List of CMake variables that will be injected by default into the
@@ -768,7 +773,15 @@ function(therock_cmake_subproject_activate target_name)
   string(APPEND _init_contents "set(THEROCK_PRIVATE_BUILD_RPATH_DIRS)\n")
   string(APPEND _init_contents "set(THEROCK_BUILD_STAMP_FILE \"@_build_stamp_file@\")\n")
   string(APPEND _init_contents "set(THEROCK_STAGE_STAMP_FILE \"@_stage_stamp_file@\")\n")
-  string(APPEND _init_contents "set(THEROCK_SUBPROJECT_TARGET \"@target_name@\")\n")
+  string(APPEND _init_contents "set(THEROCK_SUBPROJECT_TARGET \"@target_name@\")\n"
+    # Propagate the patchelf pad so pre-hooks and auto-managed targets in the
+    # child CMake invocation see the same reserved RPATH entry that the
+    # super-project uses. See therock_subproject_utils.cmake for the full
+    # rationale (issue #4271).
+    "set(THEROCK_INSTALL_RPATH_PAD_SIZE \"${THEROCK_INSTALL_RPATH_PAD_SIZE}\" CACHE STRING \"\" FORCE)\n"
+    "set(THEROCK_INSTALL_RPATH_PAD_MARKER \"${THEROCK_INSTALL_RPATH_PAD_MARKER}\" CACHE STRING \"\" FORCE)\n"
+    "set(THEROCK_INSTALL_RPATH_PAD \"${THEROCK_INSTALL_RPATH_PAD}\" CACHE INTERNAL \"\")\n"
+    "set(THEROCK_INSTALL_RPATH_PAD_COLON \"${THEROCK_INSTALL_RPATH_PAD_COLON}\" CACHE INTERNAL \"\")\n")
 
   # Support generator expressions in install CODE
   # We rely on this for debug symbol separation and some of our very old projects

--- a/cmake/therock_subproject_utils.cmake
+++ b/cmake/therock_subproject_utils.cmake
@@ -97,12 +97,17 @@ function(therock_set_install_rpath)
       list(APPEND _rpath "$ORIGIN${path_suffix}")
     endif()
   endforeach()
-  # Append the patchelf pad on ELF platforms so py_packaging can rewrite
-  # RPATHs in place (see long comment above).
+  # Log the user-meaningful RPATH before appending the patchelf pad. The pad
+  # is ~1KB of filler and dumping it into every "Set RPATH" status line would
+  # drown out from-source build logs (issue #4271).
+  set(_rpath_log_suffix "")
   if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin" AND THEROCK_INSTALL_RPATH_PAD)
+    set(_rpath_log_suffix " (+patchelf pad)")
+  endif()
+  message(STATUS "Set RPATH ${_rpath}${_rpath_log_suffix} on ${ARG_TARGETS}")
+  if(_rpath_log_suffix)
     list(APPEND _rpath "${THEROCK_INSTALL_RPATH_PAD}")
   endif()
-  message(STATUS "Set RPATH ${_rpath} on ${ARG_TARGETS}")
   set_target_properties(${ARG_TARGETS} PROPERTIES INSTALL_RPATH "${_rpath}")
 endfunction()
 

--- a/cmake/therock_subproject_utils.cmake
+++ b/cmake/therock_subproject_utils.cmake
@@ -14,6 +14,60 @@ function(therock_get_all_targets var dir)
 endfunction()
 
 
+# RPATH padding for patchelf in-place overwrite.
+#
+# Some older kernels (notably RHEL 8.10 / EL kernel 4.18) refuse to execve()
+# ELF binaries whose layout has been mutated by patchelf when patchelf had to
+# grow DT_RPATH/DT_RUNPATH and therefore prepended a new PT_LOAD segment at a
+# non-standard base address (e.g. 0x3ff000 with a read-write first PT_LOAD
+# instead of the canonical 0x400000 read-only one). See
+# https://github.com/ROCm/TheRock/issues/4271.
+#
+# To avoid this, every ELF TheRock produces has a "pad" entry appended to its
+# INSTALL_RPATH at link time. The pad is a syntactically valid ORIGIN-relative
+# path that is long enough to absorb any real RPATH value we later need to
+# inject from the Python packaging layer. When py_packaging rewrites RPATHs
+# with patchelf --set-rpath, the final string always fits inside the existing
+# .dynstr allocation, so patchelf modifies the entry in place without touching
+# program headers. The pad path itself points at a directory that never exists
+# at runtime, so it has no effect on library resolution.
+#
+# The marker substring "__therock_patchelf_pad__" is intentional: CI greps for
+# it in shipped wheels to detect any ELF where py_packaging failed to strip
+# the pad, which would be a sign that the patchelf pass skipped that file.
+set(THEROCK_INSTALL_RPATH_PAD_SIZE 1024 CACHE STRING
+  "Byte length of the filler RPATH entry appended at link time so patchelf --set-rpath can overwrite in place (see issue #4271).")
+set(THEROCK_INSTALL_RPATH_PAD_MARKER "__therock_patchelf_pad__" CACHE STRING
+  "Literal substring embedded in the RPATH pad entry for CI detection of pad-stripping failures.")
+mark_as_advanced(THEROCK_INSTALL_RPATH_PAD_SIZE THEROCK_INSTALL_RPATH_PAD_MARKER)
+
+# Lazily build THEROCK_INSTALL_RPATH_PAD (CMake-list form, single entry) and
+# THEROCK_INSTALL_RPATH_PAD_COLON (colon-joined form for consumers like
+# LIBOMP_INSTALL_RPATH that expect a pre-joined POSIX rpath string). Both
+# forms hold a single RPATH entry that is exactly
+# THEROCK_INSTALL_RPATH_PAD_SIZE bytes long (minus trailing null).
+function(_therock_compute_install_rpath_pad)
+  if(DEFINED CACHE{THEROCK_INSTALL_RPATH_PAD})
+    return()
+  endif()
+  set(_prefix "$ORIGIN/.${THEROCK_INSTALL_RPATH_PAD_MARKER}_")
+  string(LENGTH "${_prefix}" _prefix_len)
+  math(EXPR _fill_len "${THEROCK_INSTALL_RPATH_PAD_SIZE} - ${_prefix_len}")
+  if(_fill_len LESS 1)
+    message(FATAL_ERROR
+      "THEROCK_INSTALL_RPATH_PAD_SIZE=${THEROCK_INSTALL_RPATH_PAD_SIZE} is too "
+      "small to hold the marker prefix (${_prefix_len} bytes).")
+  endif()
+  string(REPEAT "X" "${_fill_len}" _filler)
+  set(_pad "${_prefix}${_filler}")
+  set(THEROCK_INSTALL_RPATH_PAD "${_pad}" CACHE INTERNAL
+    "Single RPATH entry used to reserve .dynstr space for patchelf in-place overwrite (issue #4271).")
+  set(THEROCK_INSTALL_RPATH_PAD_COLON "${_pad}" CACHE INTERNAL
+    "Colon-joined form of THEROCK_INSTALL_RPATH_PAD for rpath variables that expect a POSIX rpath string.")
+endfunction()
+_therock_compute_install_rpath_pad()
+
+
 # Sets a list of relative INSTALL_RPATH values on a target. This is a no-op
 # outside of Posix systems.
 # Args:
@@ -43,6 +97,11 @@ function(therock_set_install_rpath)
       list(APPEND _rpath "$ORIGIN${path_suffix}")
     endif()
   endforeach()
+  # Append the patchelf pad on ELF platforms so py_packaging can rewrite
+  # RPATHs in place (see long comment above).
+  if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin" AND THEROCK_INSTALL_RPATH_PAD)
+    list(APPEND _rpath "${THEROCK_INSTALL_RPATH_PAD}")
+  endif()
   message(STATUS "Set RPATH ${_rpath} on ${ARG_TARGETS}")
   set_target_properties(${ARG_TARGETS} PROPERTIES INSTALL_RPATH "${_rpath}")
 endfunction()

--- a/compiler/post_hook_hipify.cmake
+++ b/compiler/post_hook_hipify.cmake
@@ -1,0 +1,40 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# hipify is declared NO_INSTALL_RPATH, and the submodule's CMakeLists.txt
+# manually bakes hipify-clang's RPATH via LINK_FLAGS:
+#
+#   -Wl,--enable-new-dtags -Wl,--rpath,\$ORIGIN/../lib
+#
+# That leaves no spare .dynstr space for py_packaging's later
+# `patchelf --set-rpath` pass. When patchelf grows .dynstr to fit the new
+# string, it prepends a writable PT_LOAD segment at a non-standard base
+# address and the resulting ELF crashes execve() on RHEL 8.10 / EL 4.18
+# kernels (see https://github.com/ROCm/TheRock/issues/4271 and the long
+# comment in cmake/therock_subproject_utils.cmake).
+#
+# Appending the TheRock pad to the linker's --rpath argument here reserves
+# ~1KB of .dynstr up front so the subsequent patchelf overwrite fits without
+# mutating program headers. We do this from the super-project post-hook so
+# the fix ships without a submodule patch.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND TARGET hipify-clang)
+  get_target_property(_therock_hipify_link_flags hipify-clang LINK_FLAGS)
+  if(NOT _therock_hipify_link_flags)
+    set(_therock_hipify_link_flags "")
+  endif()
+  # The pad value contains literal $ORIGIN; escape $ so Ninja/Make pass it
+  # through to the linker unchanged, matching the submodule's existing
+  # \\$ORIGIN/../lib escaping.
+  string(REPLACE "$" "\\$" _therock_hipify_escaped_pad
+    "${THEROCK_INSTALL_RPATH_PAD_COLON}")
+  # Only patch once and only if the submodule still uses the unpadded
+  # -Wl,--rpath,$ORIGIN/../lib form we audited (issue #4271). If hipify
+  # upstream grows richer rpath handling in the future, the pad-marker CI
+  # gate in rocm_sdk.tests.core_test will flag any regression.
+  if(_therock_hipify_link_flags MATCHES "--rpath,\\\\\\$ORIGIN/\\.\\./lib"
+     AND NOT _therock_hipify_link_flags MATCHES "${THEROCK_INSTALL_RPATH_PAD_MARKER}")
+    set_target_properties(hipify-clang PROPERTIES
+      LINK_FLAGS "${_therock_hipify_link_flags}:${_therock_hipify_escaped_pad}")
+    message(STATUS "Appended TheRock RPATH pad to hipify-clang LINK_FLAGS")
+  endif()
+endif()

--- a/compiler/pre_hook_amd-comgr.cmake
+++ b/compiler/pre_hook_amd-comgr.cmake
@@ -13,7 +13,9 @@ else()
   set(BUILD_TESTING OFF CACHE BOOL "DISABLE BUILDING TESTS IN SUBPROJECTS" FORCE)
 endif()
 
-set(CMAKE_INSTALL_RPATH "$ORIGIN;$ORIGIN/llvm/lib;$ORIGIN/rocm_sysdeps/lib")
+# The pad entry reserves .dynstr space for later patchelf --set-rpath.
+# See comments in pre_hook_amd-llvm.cmake and issue #4271.
+set(CMAKE_INSTALL_RPATH "$ORIGIN;$ORIGIN/llvm/lib;$ORIGIN/rocm_sysdeps/lib;${THEROCK_INSTALL_RPATH_PAD}")
 
 # See Comgr::LoadLib in clr comgrctx.cpp: On windows, this expects the cmgr
 # library to have a versioned output name, but there does not seem to be a

--- a/compiler/pre_hook_amd-llvm.cmake
+++ b/compiler/pre_hook_amd-llvm.cmake
@@ -29,7 +29,7 @@ else()
     set(LIBOMPTARGET_BUILD_DEVICE_FORTRT ON)
     set(LIBOMPTARGET_ENABLE_DEBUG ON)
     set(LIBOMPTARGET_NO_SANITIZER_AMDGPU ON)
-    set(LIBOMP_INSTALL_RPATH "\$ORIGIN:\$ORIGIN/../lib:\$ORIGIN/../../lib:\$ORIGIN/../../../lib")
+    set(LIBOMP_INSTALL_RPATH "\$ORIGIN:\$ORIGIN/../lib:\$ORIGIN/../../lib:\$ORIGIN/../../../lib:${THEROCK_INSTALL_RPATH_PAD_COLON}")
     set(LIBOMPTARGET_EXTERNAL_PROJECT_HSA_PATH "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime")
     set(OFFLOAD_EXTERNAL_PROJECT_UNIFIED_ROCR ON)
     # There is an issue with finding the zstd config built by TheRock when zstd
@@ -141,7 +141,12 @@ set(LLVM_EXTERNAL_PROJECTS "rocm-device-libs;spirv-llvm-translator" CACHE STRING
 #   utilities can be compiled into libLLVM, in which case, that RUNPATH is
 #   primary.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib;$ORIGIN/../../../lib;$ORIGIN/../../rocm_sysdeps/lib")
+  # The pad entry below reserves .dynstr space so py_packaging can rewrite
+  # RPATHs in place with patchelf --set-rpath. Without it, patchelf grows
+  # .dynstr, prepends a new PT_LOAD segment, and the resulting ELF layout
+  # crashes execve() on RHEL 8.10 kernels (issue #4271). The pad path is a
+  # non-existent directory so it has no runtime effect.
+  set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib;$ORIGIN/../../../lib;$ORIGIN/../../rocm_sysdeps/lib;${THEROCK_INSTALL_RPATH_PAD}")
 endif()
 
 # Disable all implicit LLVM tools by default so that we can allow-list just what


### PR DESCRIPTION
## Motivation

Fixes #4271. `pip install rocm[libraries]` on RHEL 8.10 baremetal failed to
compile any HIP program because `clang-offload-bundler` (and every other
shipped executable) crashed with `SIGSEGV` before `main()` ever ran. The
crash is in the kernel's (4.18) `execve()` path, not in the binary itself.

Root cause: `py_packaging.py` runs `patchelf --add-rpath` + `--set-rpath`
on every shipped ELF to rewrite `$ORIGIN` relative paths into the wheel's
final `_rocm_sdk_core` layout. The new RPATH strings are longer than the
originals, so patchelf has to extend `.dynstr`. To make room, patchelf
prepends a writable `PT_LOAD` segment ahead of the canonical read-only
first segment. RHEL 8.10's 4.18 kernel rejects that layout in
`load_elf_binary()` and signals SIGSEGV to the parent. Newer kernels
(>= 5.4) tolerate it, which is why the nightly only broke on RHEL 8.10.

The issue report frames this in `ET_EXEC` terms (base `0x400000` →
`0x3ff000`), but TheRock ships 100% `ET_DYN` / PIE executables, so the
same kernel bug manifests as a **writable first `PT_LOAD`** (base stays
at `0x0`). Either way the invariant "first `PT_LOAD` is not writable" is
what the kernel's ELF loader checks.

## Technical Details

The fix pre-allocates enough RPATH string space at link time that the
later `patchelf --set-rpath` can overwrite in place without ever needing
to grow `.dynstr`. No patchelf behaviour change, no submodule changes,
no kernel workaround.

**CMake side** (`cmake/therock_subproject_utils.cmake`,
`cmake/therock_subproject.cmake`):

- Define `THEROCK_INSTALL_RPATH_PAD_SIZE` (1024), a marker string
  `__therock_patchelf_pad__`, and both a CMake-list form
  (`THEROCK_INSTALL_RPATH_PAD`) and colon-joined form
  (`..._PAD_COLON`) of the pad.
- Inject all four variables into every subproject's `_init.cmake` so the
  pad propagates to every `ExternalProject_Add` configure step without
  per-component boilerplate.
- `therock_set_install_rpath` appends the pad to the auto-managed
  `INSTALL_RPATH` on non-Darwin ELF platforms.
- Log output is kept clean: `message(STATUS ...)` prints
  `(+patchelf pad)` instead of the full 1 KB filler, so from-source
  build logs stay readable.

**NO_INSTALL_RPATH carve-outs** — three subprojects set their own
linker flags and bypass `therock_set_install_rpath`. They get the pad
from the super-project so no submodule changes are needed:

- `compiler/pre_hook_amd-llvm.cmake` — appends the pad to
  `CMAKE_INSTALL_RPATH` and `LIBOMP_INSTALL_RPATH`.
- `compiler/pre_hook_amd-comgr.cmake` — appends the pad to
  `CMAKE_INSTALL_RPATH`.
- `compiler/post_hook_hipify.cmake` (new) — `hipify-clang` bakes its
  RPATH via `LINK_FLAGS` in the submodule's `CMakeLists.txt`. The
  post-hook appends the colon-joined pad to those `LINK_FLAGS` from the
  super-project, guarded on the exact `-Wl,--rpath,$ORIGIN/../lib` form
  the submodule currently uses. If that form ever changes upstream the
  CI gate below catches it.

**Python packaging side** (`build_tools/_therock_utils/py_packaging.py`):

- `_extend_rpath` + `_normalize_rpath` are collapsed into a single
  `_rewrite_rpath` that reads the current RPATH, strips the pad marker
  and any trailing `$ORIGIN/.__therock_patchelf_pad___XXX...` entries,
  appends the dependency RPATHs computed for the wheel layout, and
  writes the result back with one `patchelf --set-rpath --force-rpath`
  call. Because we never exceed the pre-allocated string space,
  `.dynstr` is overwritten in place and the ELF program headers stay
  exactly as the linker produced them.
- Packaging log output collapses the pad entry to `<pad>` in the
  before/after RPATH line.

## Test Plan

Two CI gates added to `rocm_sdk.tests.core_test` (runs via `rocm-sdk
test` in `test_rocm_wheels.yml` on every PR and nightly):

- `testPatchelfPadStripped` — greps every shipped file for
  `__therock_patchelf_pad__`; asserts zero hits. Catches regressions
  where a newly added target bypasses both the auto-RPATH path and
  `_rewrite_rpath` (pad would leak into the wheel).
- `testExecutableElfLayoutIntact` — parses the program headers of every
  64-bit LE ELF under `_rocm_sdk_core/bin` and asserts the first
  `PT_LOAD` segment is not writable. This is the exact invariant the
  RHEL 8.10 kernel checks; an `RW`-first binary would reproduce #4271.

Local validation against a from-source build and `build_python_packages.py`
output:

- CMake configure: every subproject's `_init.cmake` carries the pad
  definitions.
- Compile + link: every auto-managed target, `amd-llvm`, `amd-comgr`,
  and `hipify-clang` ship with the 1 KB pad in their `DT_RUNPATH` /
  `DT_RPATH` at stage time.
- `build_python_packages.py`: every executable logs `REWRITE_RPATH:
  ... -> <final-rpath>` with no pad entry in the final form.
- `rocm_sdk_core-*.whl`: `__therock_patchelf_pad__` not present in any
  wheel member; census of all 102 shipped ELF executables shows first
  `PT_LOAD` is `R`-only and base vaddr is `0x0` (canonical PIE).

End-to-end on the RHEL 8.10 baremetal system from the original repro:
- `readelf -lW` on the installed `clang-offload-bundler` shows
  first `PT_LOAD flags: R vaddr=0x0000000000000000` and a clean
  `DT_RPATH` with no pad marker.
- `strace -e execve` returns `execve(...) = 0` — the kernel accepts the
  layout. The original bug is cured.

## Test Result

Repro environment:
- RHEL 8.10, kernel `4.18.0-553.117.1.el8_10.x86_64`, glibc 2.28
- Wheel built locally from this branch (from-source, Ubuntu 24.04 host)

Before (baseline nightly build):
- `execve()` → SIGSEGV before `ld.so` runs, `dmesg` shows a segfault
  record for the exec'd binary.

After (this branch):
- `execve()` → `0`, `ld.so` runs, binary proceeds to dynamic linking.
- The installed-on-RHEL-8.10 wheel still errors from the newer host's
  glibc 2.38 / `GLIBCXX_3.4.30` symbol references (unrelated ABI
  mismatch — local build was not a manylinux container). CI's
  `manylinux_2_28` pipeline will produce the ABI-correct wheel; the
  kernel-layout cure demonstrated here is independent of the ABI issue.

Full from-source build and packaging logs available on request.

## Follow-up

- Land this, then run the existing manylinux_2_28 CI wheel on the RHEL
  8.10 box to confirm full end-to-end `pip install rocm[libraries]` +
  HIP compile works in the intended deployment configuration.
- The new `compiler/post_hook_hipify.cmake` is the only place where the
  super-project special-cases hipify's hand-rolled `LINK_FLAGS`. If
  hipify upstream grows richer RPATH handling, the
  `testExecutableElfLayoutIntact` CI gate will flag any regression and
  the post-hook can be dropped.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.