### PR TITLE
Opt out of KPACK_SPLIT_ARTIFACTS for non-multi-arch CI/CD

### DIFF
--- a/build_tools/github_actions/build_configure.py
+++ b/build_tools/github_actions/build_configure.py
@@ -108,6 +108,13 @@ def build_configure(build_dir, manylinux=False):
             f"-DCMAKE_C_COMPILER_LAUNCHER={c_launcher}",
             f"-DCMAKE_CXX_COMPILER_LAUNCHER={cxx_launcher}",
             "-DBUILD_TESTING=ON",
+            # Opt-out of KPACK_SPLIT_ARTIFACTS for non-multi-arch CI/CD.
+            # * Multi-arch CI/CD uses configure_stage.py instead of this script
+            # * Local developer builds will use the flag default value
+            # Related issues:
+            # * multi-arch kpack parent: https://github.com/ROCm/TheRock/issues/3323
+            # * multi-arch opt-in: https://github.com/ROCm/TheRock/issues/3338
+            "-DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=ON",
         ]
     )
 

--- a/build_tools/github_actions/build_configure.py
+++ b/build_tools/github_actions/build_configure.py
@@ -114,7 +114,7 @@ def build_configure(build_dir, manylinux=False):
             # Related issues:
             # * multi-arch kpack parent: https://github.com/ROCm/TheRock/issues/3323
             # * multi-arch opt-in: https://github.com/ROCm/TheRock/issues/3338
-            "-DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=ON",
+            "-DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=OFF",
         ]
     )
 


### PR DESCRIPTION
## Motivation

Non-multi-arch CI/CD is not set up to support the flag, see failures at https://github.com/ROCm/TheRock/actions/runs/24579570384?pr=4652. We want to
* Keep existing CI in rocm-libraries/rocm-systems/etc. working
* Keep existing releases in TheRock/rockrel working
* Enable `KPACK_SPLIT_ARTIFACTS` for developers
* Enable `KPACK_SPLIT_ARTIFACTS` for multi-arch CI/CD in TheRock/rockrel so we can push through the remaining issues

## Technical Details

At least one issue with non-multi-arch CI/CD is the upload here that only handles `.tar.xz`, not `.tar.zst` (kpack split artifacts use zst compression): https://github.com/ROCm/TheRock/blob/b746d4d90b43df6035b163744c30c5daef209708/build_tools/github_actions/post_build_upload.py#L136-L138