### PR TITLE
ci: remove JAX 0.8.0 build support

### DIFF
--- a/.github/workflows/build_linux_jax_wheels.yml
+++ b/.github/workflows/build_linux_jax_wheels.yml
@@ -184,7 +184,9 @@ jobs:
         run: |
           ls -lah
           pushd rocm-jax
-          [[ "${{ inputs.jax_ref }}" != *"0.8.0"* && "${{ inputs.build_jaxlib }}" == "true" ]] && SOURCE_ARG="--jax-source-dir=${{ github.workspace }}/jax" || SOURCE_ARG=""
+          # --jax-source-dir is only needed when building jaxlib from source
+          # (JAX <= 0.9.0). For JAX >= 0.9.1, jaxlib comes from upstream PyPI.
+          [[ "${{ inputs.build_jaxlib }}" == "true" ]] && SOURCE_ARG="--jax-source-dir=${{ github.workspace }}/jax" || SOURCE_ARG=""
           python3 build/ci_build \
             --compiler=clang \
             --python-versions="${{ inputs.python_version }}" \

--- a/.github/workflows/release_portable_linux_jax_wheels.yml
+++ b/.github/workflows/release_portable_linux_jax_wheels.yml
@@ -103,10 +103,8 @@ jobs:
       fail-fast: false
       matrix:
         python_version: ["3.11", "3.12", "3.13", "3.14"]
-        jax_ref: ["rocm-jaxlib-v0.8.0", "rocm-jaxlib-v0.8.2", "rocm-jaxlib-v0.9.0", "rocm-jaxlib-v0.9.1"]
+        jax_ref: ["rocm-jaxlib-v0.8.2", "rocm-jaxlib-v0.9.0", "rocm-jaxlib-v0.9.1"]
         include:
-          - jax_ref: "rocm-jaxlib-v0.8.0"
-            build_jaxlib: true
           - jax_ref: "rocm-jaxlib-v0.8.2"
             build_jaxlib: true
           - jax_ref: "rocm-jaxlib-v0.9.0"

--- a/.github/workflows/test_jax_dockerfile.yml
+++ b/.github/workflows/test_jax_dockerfile.yml
@@ -22,7 +22,7 @@ on:
         required: true
         description: JAX plugin branch to checkout
         type: string
-        default: "rocm-jaxlib-v0.6.0"
+        default: "rocm-jaxlib-v0.8.2"
 
   workflow_call:
     inputs:
@@ -40,7 +40,7 @@ on:
       jax_plugin_branch:
         description: JAX plugin branch to checkout to use for test scripts
         type: string
-        default: "rocm-jaxlib-v0.8.0"
+        default: "rocm-jaxlib-v0.8.2"
 
 permissions:
   contents: read

--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -37,11 +37,11 @@ on:
         type: string
         default: "rocm-jaxlib-v0.8.2"
       jax_version:
-        description: "Base JAX version (e.g. 0.8.0) for installing jax from PyPI. Extracted from built wheels by write_jax_versions.py."
+        description: "Base JAX version (e.g. 0.8.2) for installing jax from PyPI. Extracted from built wheels by write_jax_versions.py."
         required: false
         type: string
       jaxlib_version:
-        description: "jaxlib wheel version (e.g. 0.9.0+rocm7 or 0.8.0+rocm7.12.0). Extracted from built wheels by write_jax_versions.py."
+        description: "jaxlib wheel version (e.g. 0.9.0+rocm7 or 0.8.2+rocm7.12.0). Extracted from built wheels by write_jax_versions.py."
         required: false
         type: string
       jax_plugin_version:
@@ -108,11 +108,11 @@ on:
         type: string
         default: "rocm-jaxlib-v0.8.2"
       jax_version:
-        description: "Base JAX version (e.g. 0.8.0). Leave empty to auto-detect from rocm-jax requirements."
+        description: "Base JAX version (e.g. 0.8.2). Leave empty to auto-detect from rocm-jax requirements."
         required: false
         type: string
       jaxlib_version:
-        description: "jaxlib wheel version (e.g. 0.9.0+rocm7 or 0.8.0+rocm7.12.0). Leave empty to auto-compute from rocm_version."
+        description: "jaxlib wheel version (e.g. 0.9.0+rocm7 or 0.8.2+rocm7.12.0). Leave empty to auto-compute from rocm_version."
         required: false
         type: string
       jax_plugin_version:

--- a/build_tools/github_actions/compute_jax_package_version.py
+++ b/build_tools/github_actions/compute_jax_package_version.py
@@ -23,8 +23,8 @@ Example usage:
   The following strings are appended to the file specified in the "GITHUB_ENV"
   environment variable:
 
-    JAX_VERSION=0.8.0
-    JAXLIB_VERSION=0.8.0+rocm7.12.0.dev0.e1a5d395
+    JAX_VERSION=0.8.2
+    JAXLIB_VERSION=0.8.2+rocm7.12.0.dev0.e1a5d395
 """
 
 import argparse
@@ -37,7 +37,7 @@ from github_actions_api import *
 def extract_jax_version_from_requirements(requirements_path: str) -> str:
     """Extracts the JAX version from a requirements.txt file.
 
-    Looks for lines like 'jax==0.8.0' or 'jaxlib==0.8.0' and returns
+    Looks for lines like 'jax==0.8.2' or 'jaxlib==0.8.2' and returns
     the version number.
     """
     pattern = re.compile(r"^\s*(jax|jaxlib)\s*==\s*([^#\s]+)")

--- a/external-builds/jax/README.md
+++ b/external-builds/jax/README.md
@@ -36,8 +36,8 @@ Support for JAX is provided via stable release branches of
 | JAX version | Linux                                                                                                           | Windows          |
 | ----------- | --------------------------------------------------------------------------------------------------------------- | ---------------- |
 | 0.9.1       | ✅ Supported via [ROCm/rocm-jax `rocm-jaxlib-v0.9.1`](https://github.com/ROCm/rocm-jax/tree/rocm-jaxlib-v0.9.1) | ❌ Not supported |
+| 0.9.0       | ✅ Supported via [ROCm/rocm-jax `rocm-jaxlib-v0.9.0`](https://github.com/ROCm/rocm-jax/tree/rocm-jaxlib-v0.9.0) | ❌ Not supported |
 | 0.8.2       | ✅ Supported via [ROCm/rocm-jax `rocm-jaxlib-v0.8.2`](https://github.com/ROCm/rocm-jax/tree/rocm-jaxlib-v0.8.2) | ❌ Not supported |
-| 0.8.0       | ✅ Supported via [ROCm/rocm-jax `rocm-jaxlib-v0.8.0`](https://github.com/ROCm/rocm-jax/tree/rocm-jaxlib-v0.8.0) | ❌ Not supported |
 
 See also:
 
@@ -97,7 +97,7 @@ provide it via **tarballs** with arbitrary install locations.
 
 1. Choose your configuration:
 
-   - **JAX version**: e.g. `0.8.2` or `0.8.0`
+   - **JAX version**: e.g. `0.9.1`, `0.9.0`, or `0.8.2`
    - **Python version**: e.g. `3.12`
    - **TheRock tarball**: A tarball URL, a local tarball file path, or a
      directory containing a ROCm installation. Nightly tarballs are available
@@ -118,8 +118,10 @@ provide it via **tarballs** with arbitrary install locations.
    ```
 
    > [!NOTE]
-   > The `--jax-source-dir` flag is required for JAX 0.8.2 and points to the
-   > cloned `jax` repository directory. For JAX 0.8.0, this flag can be omitted.
+   > The `--jax-source-dir` flag is required when building jaxlib from source
+   > (JAX \<= 0.9.0) and points to the cloned `jax` repository directory.
+   > For JAX >= 0.9.1, jaxlib is installed from upstream PyPI, so this flag
+   > can be omitted.
 
 1. Locate built wheels:
 


### PR DESCRIPTION
## Motivation

  JAX 0.8.0 is no longer a supported release branch. This PR removes it from the CI build matrix and cleans up all 0.8.0-specific special cases, default values, and documentation references. Supported JAX branches after this PR: 0.8.2, 0.9.0, 0.9.1.

  Follow-up to [#4303](https://github.com/ROCm/TheRock/pull/4303), which introduced the `build_jaxlib` matrix flag and made the 0.8.0-specific shell guard in `build_linux_jax_wheels.yml` dead code.

## Technical Details

  - `release_portable_linux_jax_wheels.yml`: drop `v0.8.0` from matrix (4×3 = 12 jobs remaining).
  - `build_linux_jax_wheels.yml`: simplify `--jax-source-dir` guard — now conditioned solely on `build_jaxlib`.
  - `test_jax_dockerfile.yml`: bump defaults (`v0.6.0`, `v0.8.0`) → `v0.8.2`.
  - `test_linux_jax_wheels.yml`, `compute_jax_package_version.py`: update `0.8.0` examples in descriptions/docstrings → `0.8.2`.
  - `external-builds/jax/README.md`: drop 0.8.0 row, add missing 0.9.0 row, rewrite `--jax-source-dir` note to match current `build_jaxlib` logic.

## Test Plan

  - Grep to confirm no residual `0.8.0` references in CI / docs scope.
  - Post-merge: trigger `release_portable_linux_jax_wheels.yml` manually and confirm the matrix expands to 12 jobs with no 0.8.0 dispatch.

## Test Result

 - Residual grep: **zero** `0.8.0` matches in `.github/`, `build_tools/github_actions/`, `external-builds/jax/`.
  - GPU matrix verification: **not tested** (pending post-merge CI run).
  - 0.8.0 is removed and all build/test passed
    https://github.com/ROCm/TheRock/actions/runs/24729906597

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
