### PR TITLE
Fix wrong hip compiler in subproject

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1601,6 +1601,8 @@ function(_therock_cmake_subproject_setup_toolchain
     list(APPEND _compiler_toolchain_addl_depends "${_hip_stamp_dir}/stage.stamp")
     string(APPEND _toolchain_contents "string(APPEND CMAKE_CXX_FLAGS_INIT \" --hip-path=@_hip_dist_dir@\")\n")
     string(APPEND _toolchain_contents "string(APPEND CMAKE_CXX_FLAGS_INIT \" --hip-device-lib-path=@_amd_llvm_device_lib_path@\")\n")
+    string(APPEND _toolchain_contents "set(CMAKE_HIP_COMPILER \"\${CMAKE_CXX_COMPILER}\")\n")
+    string(APPEND _toolchain_contents "set(CMAKE_HIP_FLAGS_INIT \"\${CMAKE_CXX_FLAGS_INIT}\")\n")
     if(THEROCK_VERBOSE)
       message(STATUS "HIP_DIR = ${_hip_dist_dir}")
     endif()


### PR DESCRIPTION
## Motivation

If `CMAKE_HIP_COMPILER` is not set, sub-projects will incorrectly find `/opt/rocm*/lib/llvm/bin/clang++`.

This may causes a build failure if the installed compiler is missing features needed by the sub-project.

I was seeing:

```
FAILED: catch_tests/unit/rtc/CMakeFiles/RTC.dir/RtcFunctions.cpp.o
/opt/rocm-7.1.1/lib/llvm/bin/clang++  ...
In file included from .../rocm-systems/projects/hip-tests/catch/unit/rtc/RtcFunctions.cpp:14:
In file included from .../core/clr/dist/include/hip/hip_fp16.h:13:
.../core/clr/dist/include/hip/amd_detail/amd_hip_fp16.h:952:21: error: use of undeclared identifier '__builtin_elementwise_exp10'
  952 |   return __half_raw{__builtin_elementwise_exp10(static_cast<__half_raw>(x).data)};
      |                     ^
```

## Technical Details

Sets HIP-specific variables to the corresponding CXX variable for amd-hip toolchains.

## Test Plan

## Test Result

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
