### PR TITLE
Revert "Drop expect_pytorch_failure from windows 900,906,908,90a."

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -175,6 +175,7 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx900",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
+            "expect_pytorch_failure": True,
         },
     },
     # gfx906/908/90a split into separate families - each has different instruction
@@ -194,6 +195,7 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx906",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
+            "expect_pytorch_failure": True,
         },
     },
     "gfx908": {
@@ -210,6 +212,7 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx908",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
+            "expect_pytorch_failure": True,
         },
     },
     "gfx90a": {
@@ -225,6 +228,7 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx90a",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
+            "expect_pytorch_failure": True,
         },
     },
     "gfx101x": {

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -412,6 +412,8 @@ amdgpu_family_info_matrix_all = {
                     "bypass_tests_for_releases": False,
                 },
             },
+            # TODO(#1927): Resolve error generating file `torch_hip_generated_int4mm.hip.obj`,
+            # to enable PyTorch builds
             "windows": {
                 "build": {
                     "build_variants": ["release"],
@@ -420,6 +422,7 @@ amdgpu_family_info_matrix_all = {
                     "run_tests": False,
                     "runs_on": {},
                     "fetch-gfx-targets": [],
+                    "expect_pytorch_failure": True,
                 },
                 "release": {
                     "push_on_success": False,
@@ -493,6 +496,7 @@ amdgpu_family_info_matrix_all = {
                     },
                     "fetch-gfx-targets": [],
                     "sanity_check_only_for_family": True,
+                    "expect_pytorch_failure": True,
                 },
                 "release": {
                     "push_on_success": False,


### PR DESCRIPTION
Reverts ROCm/TheRock#4646

Builds are not yet successful. Tests tried to build for `gfx90a` but actually built for `gfx1100;gfx1101;gfx1102;gfx1103;gfx1151;gfx1200;gfx1201`