### PR TITLE
Reapply "Drop expect_pytorch_failure from windows 900,906,908,90a."

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -175,7 +175,6 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx900",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
-            "expect_pytorch_failure": True,
         },
     },
     # gfx906/908/90a split into separate families - each has different instruction
@@ -195,7 +194,6 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx906",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
-            "expect_pytorch_failure": True,
         },
     },
     "gfx908": {
@@ -212,7 +210,6 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx908",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
-            "expect_pytorch_failure": True,
         },
     },
     "gfx90a": {
@@ -228,7 +225,6 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx90a",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
-            "expect_pytorch_failure": True,
         },
     },
     "gfx101x": {

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -412,8 +412,6 @@ amdgpu_family_info_matrix_all = {
                     "bypass_tests_for_releases": False,
                 },
             },
-            # TODO(#1927): Resolve error generating file `torch_hip_generated_int4mm.hip.obj`,
-            # to enable PyTorch builds
             "windows": {
                 "build": {
                     "build_variants": ["release"],
@@ -422,7 +420,6 @@ amdgpu_family_info_matrix_all = {
                     "run_tests": False,
                     "runs_on": {},
                     "fetch-gfx-targets": [],
-                    "expect_pytorch_failure": True,
                 },
                 "release": {
                     "push_on_success": False,
@@ -496,7 +493,6 @@ amdgpu_family_info_matrix_all = {
                     },
                     "fetch-gfx-targets": [],
                     "sanity_check_only_for_family": True,
-                    "expect_pytorch_failure": True,
                 },
                 "release": {
                     "push_on_success": False,


### PR DESCRIPTION
Reverts ROCm/TheRock#4686 to re-apply https://github.com/ROCm/TheRock/pull/4646. Fixes https://github.com/ROCm/TheRock/issues/1927

Testing on the original PR used prebuilt artifacts built for mismatched targets (https://github.com/ROCm/TheRock/issues/4687), so it missed that there were build failures. The build failures were fixed by cherry-picking https://github.com/pytorch/pytorch/commit/0f60458c8ecafe0168363347cfecefdfb7dd8489 onto the ROCm/pytorch release branches.

Tested on this PR at https://github.com/ROCm/TheRock/actions/runs/24684344427?pr=4691
```
2026-04-21T02:38:28.5627900Z Building PyTorch for GPU arch: gfx1100;gfx1101;gfx1102;gfx1103;gfx1151;gfx1200;gfx1201;gfx906;gfx908;gfx90a;gfx900
...
2026-04-21T04:04:32.2352970Z Found built wheel: B:\src\torch\dist\torch-2.10.0+devrocm7.13.0.dev0.b1297d31604dec8bdc7536931799724c20ae4ace-cp312-cp312-win_amd64.whl
2026-04-21T04:04:32.2359921Z --- Builds all completed
```