### PR TITLE
[ci] Opt out of KPACK_SPLIT_ARTIFACTS for ASAN multi-arch builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -45,7 +45,8 @@
         "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_CXX_FLAGS": "-g1",
-        "CMAKE_C_FLAGS": "-g1"
+        "CMAKE_C_FLAGS": "-g1",
+        "THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS": "OFF"
       }
     },
     {


### PR DESCRIPTION
## Motivation

Multi-Arch CI ASAN builds failed when `KPACK_SPLIT_ARTIFACTS` was flipped ON by default in #4652. Two failure modes show up in the "Stage - Math Libs" splitting phase:

- `.hipFatBinSegment size XXX is not a multiple of wrapper size (24)` mentioned in JIRA
- `Unexpected magic 0x00000000 at wrapper 1 (offset 0x…). Expected HIPF (0x48495046)` mentioned in #4680

**Root cause:**  `rocm-kpack`'s `rewrite_hipfatbin_magic()` in [`python/rocm_kpack/elf/kpack_transform.py`](https://github.com/ROCm/rocm-kpack/blob/main/python/rocm_kpack/elf/kpack_transform.py), which requires ELF `.hipFatBinSegment` to be a tightly packed array of 24-byte `__CudaFatBinaryWrapper` structs, but ASAN inserts red-zones and alignment padding around every global variable, breaking that layout assumption.

This PR scopes the flag flip so ASAN multi-arch reverts to the pre-#4652 behavior to get a successful ASAN mainline build, matching the non-multi-arch opt-out added in #4659.

## Technical Details

- Added `"THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS": "OFF"` to the `linux-release-asan` configure preset in `CMakePresets.json`.
- Multi-arch CI ASAN (`.github/workflows/multi_arch_ci_asan.yml`) selects `build_variant: "asan"`, which maps to `build_variant_cmake_preset: "linux-release-asan"` in `build_tools/github_actions/amdgpu_family_matrix.py`, so this preset is the single chokepoint for every ASAN multi-arch configure.
- Release multi-arch CI is unaffected since `linux-release-package` / `windows-release` still use the `KPACK_SPLIT_ARTIFACTS` default (ON).
- Non-multi-arch CI is unaffected and it uses `build_tools/github_actions/build_configure.py`, which already opts out via #4659.

## Test Plan

Trigger `multi_arch_ci_asan` via `workflow_dispatch` on this branch and verify:
   - "Stage - Math Libs (gfx94X-dcgpu)" no longer emits the `.hipFatBinSegment size … not a multiple of wrapper size (24)` error on `rand_test_generic`, `prim_test`, `fft_lib_generic`, `fft_test_generic`, `rocwmma_test_generic`, `blas_test_generic`.
   - "Stage - Math Libs" no longer emits `Unexpected magic 0x00000000 at wrapper 1 … Expected HIPF` on `rand_lib_generic`, `blas_lib_generic`.
   - ASAN build completes end-to-end and produces fat-binary (non-kpack) artifacts.

## Test Result

- https://github.com/ROCm/TheRock/actions/runs/24694142991 for `multi_arch_ci_asan` showing Math Libs stage green.
