### PR TITLE
Update RFC0009 to document legacy directory compatibility

### DIFF
--- a/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
+++ b/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
@@ -78,12 +78,13 @@ The soft links allow for an independent directory structure for ROCm expansions,
 To maintain backward compatibility with applications built against previous ROCm versions (pre-8.0), `update-alternatives` symlinks are created in `/opt/rocm` that preserve the traditional directory layout. These symlinks point to `/etc/alternatives/rocm-*` paths, which in turn reference the versioned core directories:
 
 ```
-/opt/rocm/bin -> /etc/alternatives/rocm-bin -> /opt/rocm/core-8.1/bin
-/opt/rocm/lib -> /etc/alternatives/rocm-lib -> /opt/rocm/core-8.1/lib
-/opt/rocm/include -> /etc/alternatives/rocm-include -> /opt/rocm/core-8.1/include
-/opt/rocm/llvm -> /etc/alternatives/rocm-llvm -> /opt/rocm/core-8.1/llvm
-/opt/rocm/amdgcn -> /etc/alternatives/rocm-amdgcn -> /opt/rocm/core-8.1/amdgcn
-/opt/rocm/libexec -> /etc/alternatives/rocm-libexec -> /opt/rocm/core-8.1/libexec
+/opt/rocm/bin -> /etc/alternatives/rocm-bin -> /opt/rocm/core-X.Y/bin
+/opt/rocm/lib -> /etc/alternatives/rocm-lib -> /opt/rocm/core-X.Y/lib
+/opt/rocm/include -> /etc/alternatives/rocm-include -> /opt/rocm/core-X.Y/include
+/opt/rocm/llvm -> /etc/alternatives/rocm-llvm -> /opt/rocm/core-X.Y/llvm
+/opt/rocm/amdgcn -> /etc/alternatives/rocm-amdgcn -> /opt/rocm/core-X.Y/amdgcn
+/opt/rocm/libexec -> /etc/alternatives/rocm-libexec -> /opt/rocm/core-X.Y/libexec
+/opt/rocm/share -> /etc/alternatives/rocm-share -> /opt/rocm/core-X.Y/share
 ```
 
 This approach allows legacy applications to find expected directory structures without modification while supporting the new versioned installation scheme.

--- a/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
+++ b/docs/rfcs/RFC0009-OS-Packaging-Requirements.md
@@ -73,6 +73,21 @@ The soft links allow for an independent directory structure for ROCm expansions,
 /opt/rocm/hpc/ -> /opt/rocm/hpc-26.2.0
 ```
 
+#### Backward Compatibility with Legacy Directory Structure
+
+To maintain backward compatibility with applications built against previous ROCm versions (pre-8.0), `update-alternatives` symlinks are created in `/opt/rocm` that preserve the traditional directory layout. These symlinks point to `/etc/alternatives/rocm-*` paths, which in turn reference the versioned core directories:
+
+```
+/opt/rocm/bin -> /etc/alternatives/rocm-bin -> /opt/rocm/core-8.1/bin
+/opt/rocm/lib -> /etc/alternatives/rocm-lib -> /opt/rocm/core-8.1/lib
+/opt/rocm/include -> /etc/alternatives/rocm-include -> /opt/rocm/core-8.1/include
+/opt/rocm/llvm -> /etc/alternatives/rocm-llvm -> /opt/rocm/core-8.1/llvm
+/opt/rocm/amdgcn -> /etc/alternatives/rocm-amdgcn -> /opt/rocm/core-8.1/amdgcn
+/opt/rocm/libexec -> /etc/alternatives/rocm-libexec -> /opt/rocm/core-8.1/libexec
+```
+
+This approach allows legacy applications to find expected directory structures without modification while supporting the new versioned installation scheme.
+
 ### RPATH and Relocatability
 
 - All ROCm packages must be built and shipped with `$ORIGIN`-based RPATH


### PR DESCRIPTION
Add documentation for the backward compatibility mechanism introduced
  in PR #4160, which uses update-alternatives to maintain the traditional
  /opt/rocm directory structure (bin, lib, include, llvm, amdgcn, libexec)
  for applications built against ROCm 7.x and earlier versions.

  This ensures legacy applications can continue to find expected directory
  structures without modification while supporting the new versioned
  installation scheme under /opt/rocm/core-X.Y.