### PR TITLE
[ncurses] Set default terminfo dir to stage tree

### DIFF
--- a/third-party/sysdeps/common/ncurses/CMakeLists.txt
+++ b/third-party/sysdeps/common/ncurses/CMakeLists.txt
@@ -150,6 +150,9 @@ add_custom_target(
       # by pkgconfig (which is typically the system root, which is not what
       # we want).
       --with-pkg-config-libdir="${CMAKE_INSTALL_PREFIX}/lib/pkgconfig"
+      # Direct terminfo database installation into the stage tree so
+      # make install does not attempt to write to /usr/share/terminfo.
+      --with-default-terminfo-dir="${CMAKE_INSTALL_PREFIX}/share/terminfo"
       # Prevent build-time LDFLAGS (rpath, version-script) from leaking into
       # the .pc files' Libs: line.
       --disable-pkg-ldflags


### PR DESCRIPTION
## Summary

- ncurses configure defaults `--with-default-terminfo-dir` (ticdir) to `/usr/share/terminfo`. `make install` then attempts to write the terminfo database there, which fails on unprivileged builds on systems without pre-existing write access.
- Additionally, ncurses configure honors `$TERMINFO` from the environment when choosing ticdir, so terminals like Kitty (which set `$TERMINFO=/usr/lib/kitty/terminfo`) cause ticdir to land in a root-owned path.
- Pass `--with-default-terminfo-dir=${CMAKE_INSTALL_PREFIX}/share/terminfo` so the database lands in the stage tree regardless of environment.

Fixes #3511.

## Test plan

Verified with ncurses-6.6 configure (the exact tarball TheRock uses) in four scenarios, inspecting the reported "default terminfo directory" and the resulting `ticdir` in `Makefile`:

| Scenario | `$TERMINFO` | `--with-default-terminfo-dir` | ticdir |
|---|---|---|---|
| Baseline, unpatched | unset | unset | `/usr/share/terminfo` (would fail unprivileged) |
| Kitty, unpatched | `/usr/lib/kitty/terminfo` | unset | `/usr/lib/kitty/terminfo` (reproduces #3511) |
| Kitty, patched | `/usr/lib/kitty/terminfo` | stage | stage path (patch overrides Kitty env) |
| Baseline, patched | unset | stage | stage path (patch fixes default case too) |

- [x] Patch redirects ticdir to the stage tree even when `$TERMINFO` points at a read-only system path (fixes #3511 directly).
- [x] Patch also fixes the broader unprivileged-build failure where `$TERMINFO` is unset but ncurses' default is `/usr/share/terminfo`.
- [x] Without the patch, `$TERMINFO=/usr/lib/kitty/terminfo` → ticdir becomes Kitty's path (trigger confirmed).