### PR TITLE
[ci] Move test_graph_make_graphed_callables* Pytorch tests to skip_tests/generic.py

### DIFF
--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -58,6 +58,16 @@ skip_tests = {
             # AttributeError: 'Model' object has no attribute '__annotations__'
             # https://github.com/ROCm/TheRock/issues/2985
             "test_autocast_cat_jit",
+            # what():  HIP error: operation not permitted when stream is capturing
+            # Search for `hipErrorStreamCaptureUnsupported' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__HIPRT__TYPES.html for more information.
+            # HIP kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
+            # For debugging consider passing AMD_SERIALIZE_KERNEL=3
+            # Compile with `TORCH_USE_HIP_DSA` to enable device-side assertions.
+            #
+            # Exception raised from ~CUDAGraph at /__w/TheRock/TheRock/external-builds/pytorch/pytorch/aten/src/ATen/hip/HIPGraph.cpp:320 (most recent call first):
+            # frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7f2316f1bdf0 in /home/tester/TheRock/.venv/lib/python3.12/site-packages/torch/lib/libc10.so)
+            "test_graph_make_graphed_callables_parameterless_nograd_module_without_amp_allow_unused_input",
+            "test_graph_make_graphed_callables_parameterless_nograd_module_without_amp_not_allow_unused_input",
             # ----------------
             # maybe failing
             # ----------------

--- a/external-builds/pytorch/skip_tests/pytorch_2.10.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.10.py
@@ -78,17 +78,6 @@ skip_tests = {
         ],
         "cuda": [
             # "test_cpp_memory_snapshot_pickle",
-            #
-            # what():  HIP error: operation not permitted when stream is capturing
-            # Search for `hipErrorStreamCaptureUnsupported' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__HIPRT__TYPES.html for more information.
-            # HIP kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
-            # For debugging consider passing AMD_SERIALIZE_KERNEL=3
-            # Compile with `TORCH_USE_HIP_DSA` to enable device-side assertions.
-            #
-            # Exception raised from ~CUDAGraph at /__w/TheRock/TheRock/external-builds/pytorch/pytorch/aten/src/ATen/hip/HIPGraph.cpp:320 (most recent call first):
-            # frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7f2316f1bdf0 in /home/tester/TheRock/.venv/lib/python3.12/site-packages/torch/lib/libc10.so)
-            "test_graph_make_graphed_callables_parameterless_nograd_module_without_amp_allow_unused_input",
-            "test_graph_make_graphed_callables_parameterless_nograd_module_without_amp_not_allow_unused_input",
             "test_graph_concurrent_replay ",
             #
             #

--- a/external-builds/pytorch/skip_tests/pytorch_2.9.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.9.py
@@ -71,17 +71,6 @@ skip_tests = {
         ],
         "cuda": [
             # "test_cpp_memory_snapshot_pickle",
-            #
-            # what():  HIP error: operation not permitted when stream is capturing
-            # Search for `hipErrorStreamCaptureUnsupported' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__HIPRT__TYPES.html for more information.
-            # HIP kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
-            # For debugging consider passing AMD_SERIALIZE_KERNEL=3
-            # Compile with `TORCH_USE_HIP_DSA` to enable device-side assertions.
-            #
-            # Exception raised from ~CUDAGraph at /__w/TheRock/TheRock/external-builds/pytorch/pytorch/aten/src/ATen/hip/HIPGraph.cpp:320 (most recent call first):
-            # frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7f2316f1bdf0 in /home/tester/TheRock/.venv/lib/python3.12/site-packages/torch/lib/libc10.so)
-            "test_graph_make_graphed_callables_parameterless_nograd_module_without_amp_allow_unused_input",
-            "test_graph_make_graphed_callables_parameterless_nograd_module_without_amp_not_allow_unused_input",
             "test_graph_concurrent_replay ",
             #
             # OSError: libhiprtc.so: cannot open shared object file: No such file or directory


### PR DESCRIPTION
## Motivation

Addresses https://github.com/ROCm/TheRock/issues/4527.

These tests were already skipped for `2.9` and `2.10`, but not elsewhere. Adding them first to `generic.py` to unblock CI.

## Technical Details

See root cause analysis of the test failures in [this comment](https://github.com/ROCm/TheRock/issues/4527#issuecomment-4290763936).

Moving both test names into `generic.py -> common -> cuda` (with the verbatim `hipErrorStreamCaptureUnsupported` comment block retained from the original `2.10` entry) makes the skip apply uniformly across every `pytorch_<ver>.py` (present or not) and every AMDGPU family. The previously-duplicated entries in `pytorch_2.9.py` and `pytorch_2.10.py` are removed so there is a single source of truth.

## Test Plan

Simulate the skip-list loader for every known PyTorch minor version and AMDGPU arches listed in the linked issue, and verify both target test names appear in the computed skip expression.

To observe CI on the upstream-nightly matrix slot.

## Test Result

All combinations reported these tests as freshly skipped, including for `pytorch_version=2.13` where the per-version file (would be `skip_tests/pytorch_2.13.py`, which is warned as missing currently, see https://github.com/ROCm/TheRock/actions/runs/24708625512/job/72280026775) does not exist and only `generic.py` contributes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
