### PR TITLE
[expat] Pass --without-docbook to configure

### DIFF
--- a/third-party/sysdeps/common/expat/CMakeLists.txt
+++ b/third-party/sysdeps/common/expat/CMakeLists.txt
@@ -101,6 +101,11 @@ add_custom_target(
       # Disable examples and tests.
       --without-examples
       --without-tests
+      # Disable docbook-based man page generation. The xmlwf man page is
+      # not part of TheRock's artifacts, and expat 2.7.x configure errors
+      # out on SGML-only docbook2man (the default on Debian/Ubuntu via
+      # docbook-utils) rather than falling back gracefully.
+      --without-docbook
       # Disable maintainer-mode, otherwise our copy of the sources directory
       # will potentially alter the timestamp of acinclude.m4, which will
       # trigger a reconfigure with a version of aclocal we do not have.


### PR DESCRIPTION
## Summary

Pass `--without-docbook` to expat's configure so TheRock doesn't require a specific docbook flavor on the build host.

## The failure

TheRock builds expat as a library dep for rocgdb and doesn't ship the `xmlwf` man page. With #4153 (expat bump to 2.7.5), configure now errors out rather than falling back when the host has only the SGML-based `docbook2man` (the default on Debian/Ubuntu via the `docbook-utils` package) rather than the XML-based `docbook2x-man`:

```
[therock-expat] configure: error: Your local docbook2man was found to work with SGML
    rather than XML. Please install docbook2X and use variable DOCBOOK_TO_MAN
    to point configure to command docbook2x-man of docbook2X.
    ...
    You can also configure using --without-docbook if you can do without a man
    page for xmlwf.
```

Reproduced on Ubuntu (stock `docbook-utils`-only install). A pre-#4153 baseline build succeeded on the same system.

## Fix

Add `--without-docbook` alongside the existing `--without-examples` / `--without-tests` / `--disable-maintainer-mode` flags. Skips the docbook check entirely — TheRock doesn't install the man page anyway.

## Test plan

- [x] Fresh configure + build on a system with only `docbook-utils` (SGML) installed, no `docbook2x` — expat now builds through.
- [x] Build also succeeds on systems that have `docbook2x` installed (no behavioral change for them).
