### PR TITLE
[ci] add spack build workflow

### DIFF
--- a/.github/workflows/build_spack_rocm_packages.yml
+++ b/.github/workflows/build_spack_rocm_packages.yml
@@ -1,0 +1,88 @@
+name: Build Spack ROCm Packages
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - 'stage/docker/**'
+    paths:
+      - dockerfiles/spack_ubuntu24_04.Dockerfile
+      - dockerfiles/rocm-spack-env/**
+      - .github/workflows/build_spack_rocm_packages.yml
+  workflow_dispatch:
+  schedule:
+    # Run weekly on Mondays at 2 AM UTC
+    - cron: "0 2 * * 1"
+
+permissions:
+  contents: read
+  packages: write
+jobs:
+  build:
+    name: Build Spack Image
+    runs-on: ubuntu-22.04
+    timeout-minutes: 210
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: rocm/spack_ubuntu24_04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine Docker Tag
+        id: tag
+        run: |
+          ref="${{ github.ref_name }}"
+          if [[ "$ref" == stage/docker/* ]]; then
+           suffix="${ref#stage/docker/}"
+            echo "TAG_SUFFIX=stage-${suffix}" >> "$GITHUB_OUTPUT"
+          elif [[ "$ref" == "main" ]]; then
+            echo "TAG_SUFFIX=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "TAG_SUFFIX=${ref}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract Metadata for Docker
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=ref,event=pr
+            type=raw,value=${{ steps.tag.outputs.TAG_SUFFIX }}
+
+      - name: Build and Push Docker Image
+        id: build
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: dockerfiles/
+          file: dockerfiles/spack_ubuntu24_04.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Report Summary
+        if: always()
+        run: |
+          {
+            echo "## Docker image build"
+            echo "Image: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`"
+            if [[ "${{ steps.build.outcome }}" == "success" ]]; then
+              echo ""
+              echo "Docker image built and pushed successfully."
+            else
+              echo ""
+              echo "Build or push did not succeed. Check the **Build and Push Docker Image** step logs."
+            fi
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/dockerfiles/rocm-spack-env/entrypoint.sh
+++ b/dockerfiles/rocm-spack-env/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Entrypoint: initialize Spack and activate the rocm environment before
+# running any command passed to the container.
+
+set -e
+
+. "${SPACK_ROOT}/share/spack/setup-env.sh"
+spack env activate "${SPACK_ENV_NAME}"
+
+exec "$@"

--- a/dockerfiles/rocm-spack-env/spack.yaml
+++ b/dockerfiles/rocm-spack-env/spack.yaml
@@ -1,0 +1,94 @@
+# Spack environment for ROCm
+# Packages are added dynamically at build time via: spack list -t rocm
+
+spack:
+  packages:
+    all:
+      require:
+        - "%gcc"
+      target: [x86_64]
+      prefer:
+        - ~cuda
+        - +rocm
+        - amdgpu_target=gfx90a
+    opengl:
+      buildable: false
+  compilers:
+    - compiler:
+        spec: gcc@13
+        paths:
+          cc: /usr/bin/gcc
+          cxx: /usr/bin/g++
+          f77: /usr/bin/gfortran
+          fc: /usr/bin/gfortran
+        flags: {}
+        operating_system: ubuntu24.04
+        target: x86_64
+        modules: []
+        environment: {}
+        extra_rpaths: []
+
+  concretizer:
+    reuse: true
+
+  mirrors:
+    spack-public:
+      url: https://binaries.spack.io/releases/latest
+      signed: false
+    spack-source:
+      url: https://mirror.spack.io/
+      binary: false
+
+  config:
+    install_tree:
+      root: /home/spack/spack-install
+    build_stage: /home/spack/spack-stage
+    source_cache: /home/spack/spack-cache
+
+
+  view:
+    default:
+      root: /home/spack/spack-view
+      link: roots
+
+  specs:
+  - amdsmi@develop
+  - comgr@develop
+  - composable-kernel@develop
+  - hip@develop
+  - hipblas@develop
+  - hipblas-common@develop
+  - hipblaslt@develop
+  - hipcub@develop
+  - hipdnn@develop
+  - hipfft@develop
+  - hipify-clang@develop
+  - hiprand@develop
+  - hipsolver@develop
+  - hipsparse@develop
+  - hipsparselt@develop
+  - hsa-rocr-dev@develop
+  - hsa-amd-aqlprofile@develop
+  - llvm-amdgpu@develop
+  - miopen-hip@develop
+  - rccl@develop
+  - rocblas@develop
+  - rocdecode@develop
+  - rocm-cmake@develop
+  - rocm-core@develop
+  - rocm-smi-lib@develop
+  - rocfft@develop
+  - rocminfo@develop
+  - rocmlir@develop
+  - rocprim@develop
+  - rocprofiler-compute@develop
+  - rocprofiler-dev@develop
+  - rocprofiler-register@develop
+  - rocprofiler-sdk@develop
+  - rocprofiler-systems@develop
+  - rocrand@develop
+  - rocsolver@develop
+  - rocsparse@develop
+  - rocthrust@develop
+  - roctracer-dev@develop
+  - roctracer-dev-api@develop

--- a/dockerfiles/rocm-spack-env/spack.yaml
+++ b/dockerfiles/rocm-spack-env/spack.yaml
@@ -45,50 +45,55 @@ spack:
     build_stage: /home/spack/spack-stage
     source_cache: /home/spack/spack-cache
 
-
   view:
     default:
       root: /home/spack/spack-view
       link: roots
 
+  definitions:
+  - rocm_specs:
+    - matrix:
+      - - amdsmi
+        - comgr
+        - composable-kernel
+        - hip
+        - hipblas
+        - hipblas-common
+        - hipblaslt
+        - hipcub
+        - hipdnn
+        - hipfft
+        - hipify-clang
+        - hiprand
+        - hipsolver
+        - hipsparse
+        - hipsparselt
+        - hsa-rocr-dev
+        - hsa-amd-aqlprofile
+        - llvm-amdgpu
+        - miopen-hip
+        - rccl
+        - rocblas
+        - rocdecode
+        - rocm-cmake
+        - rocm-core
+        - rocm-smi-lib
+        - rocfft
+        - rocminfo
+        - rocmlir
+        - rocprim
+        - rocprofiler-compute
+        - rocprofiler-dev
+        - rocprofiler-register
+        - rocprofiler-sdk
+        - rocprofiler-systems
+        - rocrand
+        - rocsolver
+        - rocsparse
+        - rocthrust
+        - roctracer-dev
+        - roctracer-dev-api
+      - - '@develop'
+
   specs:
-  - amdsmi@develop
-  - comgr@develop
-  - composable-kernel@develop
-  - hip@develop
-  - hipblas@develop
-  - hipblas-common@develop
-  - hipblaslt@develop
-  - hipcub@develop
-  - hipdnn@develop
-  - hipfft@develop
-  - hipify-clang@develop
-  - hiprand@develop
-  - hipsolver@develop
-  - hipsparse@develop
-  - hipsparselt@develop
-  - hsa-rocr-dev@develop
-  - hsa-amd-aqlprofile@develop
-  - llvm-amdgpu@develop
-  - miopen-hip@develop
-  - rccl@develop
-  - rocblas@develop
-  - rocdecode@develop
-  - rocm-cmake@develop
-  - rocm-core@develop
-  - rocm-smi-lib@develop
-  - rocfft@develop
-  - rocminfo@develop
-  - rocmlir@develop
-  - rocprim@develop
-  - rocprofiler-compute@develop
-  - rocprofiler-dev@develop
-  - rocprofiler-register@develop
-  - rocprofiler-sdk@develop
-  - rocprofiler-systems@develop
-  - rocrand@develop
-  - rocsolver@develop
-  - rocsparse@develop
-  - rocthrust@develop
-  - roctracer-dev@develop
-  - roctracer-dev-api@develop
+  - $rocm_specs

--- a/dockerfiles/spack_ubuntu24_04.Dockerfile
+++ b/dockerfiles/spack_ubuntu24_04.Dockerfile
@@ -54,7 +54,7 @@ RUN . ${SPACK_ROOT}/share/spack/setup-env.sh && \
     spack env activate ${SPACK_ENV_NAME} && \
     spack concretize -f && \
     spack clean -m && \
-    spack install --fail-fast
+    spack install --fail-fast --reuse --use-cache
 
 # Activate the environment for interactive sessions
 RUN echo ". ${SPACK_ROOT}/share/spack/setup-env.sh" >> /home/spack/.bashrc && \

--- a/dockerfiles/spack_ubuntu24_04.Dockerfile
+++ b/dockerfiles/spack_ubuntu24_04.Dockerfile
@@ -1,0 +1,69 @@
+# Dockerfile for Spack integration on Ubuntu 24.04
+# This image includes Spack for ROCm package management and builds
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install all system dependencies in one layer
+RUN apt-get update -y && apt-get install -y \
+    sudo \
+    curl \
+    wget \
+    git \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel \
+    build-essential \
+    ca-certificates \
+    gnupg \
+    lsb-release \
+    file \
+    unzip \
+    patch \
+    gfortran \
+    cmake \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create spack user with passwordless sudo
+RUN useradd -m -s /bin/bash -U -G sudo spack && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER spack
+WORKDIR /home/spack
+
+ENV SPACK_ROOT=/home/spack/spack \
+    SPACK_ENV_NAME=rocm
+ENV PATH="${SPACK_ROOT}/bin:${PATH}"
+
+# Clone Spack and the ROCm package repository
+RUN git clone --depth 1 https://github.com/spack/spack.git ${SPACK_ROOT} && \
+    git clone -b rocm-spack-ci-changes --depth 1 https://github.com/ROCm/rocm-spack-packages.git /home/spack/spack-packages
+
+# Bootstrap Spack: detect compilers and register the ROCm package repo
+RUN . ${SPACK_ROOT}/share/spack/setup-env.sh && \
+    spack compiler find && \
+    spack repo set --destination  /home/spack/spack-packages builtin
+
+# Create the named environment and install all ROCm-tagged packages
+COPY --chown=spack:spack rocm-spack-env/spack.yaml /home/spack/rocm-spack-env/spack.yaml
+RUN . ${SPACK_ROOT}/share/spack/setup-env.sh && \
+    spack clean -m && \
+    spack env create ${SPACK_ENV_NAME} /home/spack/rocm-spack-env/spack.yaml && \
+    spack env activate ${SPACK_ENV_NAME} && \
+    spack concretize -f && \
+    spack clean -m && \
+    spack install --fail-fast
+
+# Activate the environment for interactive sessions
+RUN echo ". ${SPACK_ROOT}/share/spack/setup-env.sh" >> /home/spack/.bashrc && \
+    echo "spack env activate ${SPACK_ENV_NAME}" >> /home/spack/.bashrc
+
+# Entrypoint activates the spack environment for all commands
+COPY --chown=spack:spack rocm-spack-env/entrypoint.sh /home/spack/entrypoint.sh
+RUN chmod +x /home/spack/entrypoint.sh
+
+ENTRYPOINT ["/home/spack/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/dockerfiles/spack_ubuntu24_04.Dockerfile
+++ b/dockerfiles/spack_ubuntu24_04.Dockerfile
@@ -1,5 +1,4 @@
 # Dockerfile for Spack integration on Ubuntu 24.04
-# This image includes Spack for ROCm package management and builds
 
 FROM ubuntu:24.04
 


### PR DESCRIPTION
Currently we maintain a branch with the changes required to build ROCm on spack using the latest TheRock commits here: https://github.com/ROCm/rocm-spack-packages/tree/rocm-spack-ci-changes. ROCm libraries and ROCm systems commit IDs in those Spack recipes are updated when TheRock’s submodule commits move.

This PR adds continuous validation of that stack: a Docker image on Ubuntu 24.04 that installs upstream Spack, points the builtin repo at rocm-spack-ci-changes, and runs spack concretize / spack install for the ROCm environment defined in-repo. The image is built in GitHub Actions and pushed to GHCR (ghcr.io/.../rocm/spack_ubuntu24_04).

This build is essential to making sure the latest Spack, rocm-spack-ci-changes, and TheRock-aligned recipes still work together, so ROCm Spack support does not silently break.
