### PR TITLE
Add artifacts for python build

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -299,6 +299,7 @@ def libraries_artifact_filter(target_family: str, an: ArtifactName) -> bool:
             "hipkernelprovider",
             "rand",
             "rccl",
+            "rocshmem",
         ]
         and an.component
         in [

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -147,6 +147,7 @@ def _run_kpack_split(
             "rocwmma",
             "flatbuffers",
             "nlohmann-json",
+            "rocshmem",
         ],
         exclude_components=["test"],
         tarball_compression=args.devel_tarball_compression,
@@ -299,7 +300,6 @@ def libraries_artifact_filter(target_family: str, an: ArtifactName) -> bool:
             "hipkernelprovider",
             "rand",
             "rccl",
-            "rocshmem",
         ]
         and an.component
         in [

--- a/comm-libs/artifact-rocshmem.toml
+++ b/comm-libs/artifact-rocshmem.toml
@@ -2,7 +2,6 @@
 [components.lib."comm-libs/rocshmem/stage"]
 include = [
   "share/rocshmem/**",
-  "lib/**",
 ]
 [components.run."comm-libs/rocshmem/stage"]
 include = [

--- a/comm-libs/artifact-rocshmem.toml
+++ b/comm-libs/artifact-rocshmem.toml
@@ -2,6 +2,7 @@
 [components.lib."comm-libs/rocshmem/stage"]
 include = [
   "share/rocshmem/**",
+  "lib/**",
 ]
 [components.run."comm-libs/rocshmem/stage"]
 include = [


### PR DESCRIPTION
## Motivation

See ticket AIROCSHMEM-317

We have a customer request that request that rocSHMEM can be installed via:

```
pip install --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ "rocm[libraries,devel]"
```

## Technical Details

We have added the following changes so that we can have it packaged in python, this similar to other libraries. However, rocSHMEM only creates a static library, `rocshmem.a` so the current python packaging scripts fail

Unclear, this PR was created so that we can get feedback on what needs to be done to provide the customer the integration work that is needed

## Test Plan

Check if shmem library is within the PIP package

## Test Result
```
(reverse-i-search)`find': pip install rocm[libraries,devel,device-gfx950] --pre     --^Cnd-links=https://therock-ci-artifacts.s3.amazonaws.com/24819356211-linux/python/index.html
(.venv) ytemucin@smci355-ccs-aus-m10-13:~/tmp$ rocm-sdk init
Devel contents expanded to '/home/ytemucin/tmp/.venv/lib/python3.10/site-packages/_rocm_sdk_devel'
(.venv) ytemucin@smci355-ccs-aus-m10-13:~/tmp$ find .venv/ -iname "*shmem*"
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/lib/cmake/rocshmem
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/lib/cmake/rocshmem/rocshmem-config-version.cmake
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/lib/cmake/rocshmem/rocshmem-targets.cmake
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/lib/cmake/rocshmem/rocshmem-config.cmake
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/lib/cmake/rocshmem/rocshmem-targets-release.cmake
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/lib/librocshmem.a
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/include/rocshmem
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/include/rocshmem/rocshmem_COLL.hpp
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/include/rocshmem/rocshmem_AMO.hpp
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/include/rocshmem/rocshmem_common.hpp
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/include/rocshmem/rocshmem_P2P_SYNC.hpp
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/include/rocshmem/rocshmem_config.h
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/include/rocshmem/rocshmem_SIG_OP.hpp
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/include/rocshmem/rocshmem_debug.hpp
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/include/rocshmem/rocshmem.hpp
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/include/rocshmem/rocshmem_RMA_X.hpp
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/include/rocshmem/rocshmem_RMA.hpp
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/include/rocshmem/rocshmem_mpi.hpp
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocshmem
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocshmem/rocshmem_functional_driver.sh
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/share/doc/rocshmem
.venv/lib/python3.10/site-packages/_rocm_sdk_devel/bin/rocshmem_info

```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
