### PR TITLE
[ci] adding three test runner label solution for `gfx94X`

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -53,7 +53,12 @@ all_build_variants = {
 """
 amdgpu_family_info_matrix dictionary fields:
 - test-runs-on: (required) GitHub runner label for this architecture
+- test-runs-on-labels: (optional) List of runner label configs for load balancing across pools.
+    Each entry is a dict with "label" and "weight" (probability 0.0-1.0). Weights must sum to 1.0.
+    When present, overrides test-runs-on for runner selection.
 - test-runs-on-multi-gpu: (optional) GitHub runner label for multi-GPU tests for this architecture
+- test-runs-on-multi-gpu-labels: (optional) List of runner label configs for multi-GPU load balancing.
+    Same format as test-runs-on-labels.
 - benchmark-runs-on: (optional) GitHub runner label for benchmarks for this architecture
 - test-runs-on-kernel: (optional) dict of kernel-specific runner labels, keyed by kernel type (e.g. "oem")
 - family: (required) AMD GPU family name, used for test selection and artifact fetching
@@ -68,12 +73,38 @@ amdgpu_family_info_matrix dictionary fields:
 amdgpu_family_info_matrix_presubmit = {
     "gfx94x": {
         "linux": {
-            # TODO: Remove alternative weight once we get dedicated set of machines
-            # As we are bringing back up mi325, we are using a dual-label configuration to distribute load
+            # TODO: Remove multi-label config once we get dedicated set of machines
+            # As we are bringing up mi325, we are using a multi-label configuration to distribute load
+            # 1-GPU distribution: 17N (vultr) + 4N (cirrascale) + 8N (core42)
             "test-runs-on": "linux-gfx942-1gpu-ossci-rocm",
+            "test-runs-on-labels": [
+                {
+                    "label": "linux-gfx942-1gpu-ossci-rocm",
+                    "weight": 0.59,
+                },  # vultr (17/29)
+                {
+                    "label": "linux-gfx942-1gpu-ccs-ossci-rocm",
+                    "weight": 0.14,
+                },  # cirrascale (4/29)
+                {
+                    "label": "linux-gfx942-1gpu-core42-ossci-rocm",
+                    "weight": 0.27,
+                },  # core42 (8/29)
+            ],
             # TODO(#3433): Remove sandbox label once ASAN tests are passing
             "test-runs-on-sandbox": "rocm-asan-mi325-sandbox",
+            # 8-GPU distribution: 11N (cirrascale) + 7N (core42)
             "test-runs-on-multi-gpu": "linux-gfx942-8gpu-ossci-rocm",
+            "test-runs-on-multi-gpu-labels": [
+                {
+                    "label": "linux-gfx942-8gpu-ossci-rocm",
+                    "weight": 0.61,
+                },  # cirrascale (11/18)
+                {
+                    "label": "linux-gfx942-8gpu-core42-ossci-rocm",
+                    "weight": 0.39,
+                },  # core42 (7/18)
+            ],
             # TODO(#2754): Add new benchmark-runs-on runner for benchmarks
             "benchmark-runs-on": "linux-gfx942-8gpu-ossci-rocm",
             "family": "gfx94X-dcgpu",

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -25,16 +25,7 @@ import random
 
 
 def select_weighted_label(labels_config: list[dict], context_name: str) -> str:
-    """Select a runner label based on weighted random selection.
-
-    Args:
-        labels_config: List of dicts with "label" and "weight" keys.
-                       Weights should sum to 1.0.
-        context_name: Name for logging context (e.g. family name).
-
-    Returns:
-        Selected label string.
-    """
+    """Select a runner label based on weighted random selection."""
     rand_val = random.random()
     cumulative = 0.0
     for config in labels_config:

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -3,6 +3,7 @@
 
 """
 This AMD GPU Family Matrix is the "source of truth" for GitHub workflows.
+Also provides the select_weighted_label utility for weighted runner selection.
 
 * Each entry determines which families and test runners are available to use
 * Each group determines which entries run by default on workflow triggers
@@ -19,6 +20,39 @@ TODO(#2200): clarify AMD GPU family selection
 #############################################################################################
 # NOTE: when doing changes here, also check that they are done in new_amdgpu_family_matrix.py
 #############################################################################################
+
+import random
+
+
+def select_weighted_label(labels_config: list[dict], context_name: str) -> str:
+    """Select a runner label based on weighted random selection.
+
+    Args:
+        labels_config: List of dicts with "label" and "weight" keys.
+                       Weights should sum to 1.0.
+        context_name: Name for logging context (e.g. family name).
+
+    Returns:
+        Selected label string.
+    """
+    rand_val = random.random()
+    cumulative = 0.0
+    for config in labels_config:
+        cumulative += config["weight"]
+        if rand_val < cumulative:
+            print(
+                f"  {context_name}: selected runner (weight={config['weight']}): "
+                f"{config['label']}"
+            )
+            return config["label"]
+    # Fallback to last label if rounding errors
+    selected = labels_config[-1]
+    print(
+        f"  {context_name}: selected runner (weight={selected['weight']}): "
+        f"{selected['label']}"
+    )
+    return selected["label"]
+
 
 all_build_variants = {
     "linux": {

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -51,6 +51,7 @@
 import json
 import os
 from pathlib import Path
+import random
 import sys
 from typing import Iterable, List, Optional
 import string
@@ -73,6 +74,36 @@ THEROCK_DIR = THIS_SCRIPT_DIR.parent.parent
 # --------------------------------------------------------------------------- #
 # Matrix creation logic based on PR, push, or workflow_dispatch
 # --------------------------------------------------------------------------- #
+
+
+def _select_weighted_label(labels_config: list[dict], context_name: str) -> str:
+    """Select a runner label based on weighted random selection.
+
+    Args:
+        labels_config: List of dicts with "label" and "weight" keys.
+                       Weights should sum to 1.0.
+        context_name: Name for logging context (e.g. target name).
+
+    Returns:
+        Selected label string.
+    """
+    rand_val = random.random()
+    cumulative = 0.0
+    for config in labels_config:
+        cumulative += config["weight"]
+        if rand_val < cumulative:
+            print(
+                f"  {context_name}: selected runner (weight={config['weight']}): "
+                f"{config['label']}"
+            )
+            return config["label"]
+    # Fallback to last label if rounding errors
+    selected = labels_config[-1]
+    print(
+        f"  {context_name}: selected runner (weight={selected['weight']}): "
+        f"{selected['label']}"
+    )
+    return selected["label"]
 
 
 def get_pr_labels(args) -> List[str]:
@@ -404,6 +435,18 @@ def matrix_generator(
                 if build_variant_suffix:
                     artifact_group += f"-{build_variant_suffix}"
                 matrix_row["artifact_group"] = artifact_group
+
+                # Handle multi-label configuration with weighted random selection.
+                # Some families (e.g. gfx94x) have multiple runner labels available.
+                if "test-runs-on-labels" in platform_info:
+                    matrix_row["test-runs-on"] = _select_weighted_label(
+                        platform_info["test-runs-on-labels"], target_name
+                    )
+                if "test-runs-on-multi-gpu-labels" in platform_info:
+                    matrix_row["test-runs-on-multi-gpu"] = _select_weighted_label(
+                        platform_info["test-runs-on-multi-gpu-labels"],
+                        f"{target_name} (multi-gpu)",
+                    )
 
                 # We retrieve labels from both PR and workflow_dispatch to customize the build and test jobs
                 label_options = []

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -51,13 +51,13 @@
 import json
 import os
 from pathlib import Path
-import random
 import sys
 from typing import Iterable, List, Optional
 import string
 from amdgpu_family_matrix import (
     all_build_variants,
     get_all_families_for_trigger_types,
+    select_weighted_label,
 )
 from fetch_test_configurations import test_matrix, functional_matrix
 
@@ -74,36 +74,6 @@ THEROCK_DIR = THIS_SCRIPT_DIR.parent.parent
 # --------------------------------------------------------------------------- #
 # Matrix creation logic based on PR, push, or workflow_dispatch
 # --------------------------------------------------------------------------- #
-
-
-def _select_weighted_label(labels_config: list[dict], context_name: str) -> str:
-    """Select a runner label based on weighted random selection.
-
-    Args:
-        labels_config: List of dicts with "label" and "weight" keys.
-                       Weights should sum to 1.0.
-        context_name: Name for logging context (e.g. target name).
-
-    Returns:
-        Selected label string.
-    """
-    rand_val = random.random()
-    cumulative = 0.0
-    for config in labels_config:
-        cumulative += config["weight"]
-        if rand_val < cumulative:
-            print(
-                f"  {context_name}: selected runner (weight={config['weight']}): "
-                f"{config['label']}"
-            )
-            return config["label"]
-    # Fallback to last label if rounding errors
-    selected = labels_config[-1]
-    print(
-        f"  {context_name}: selected runner (weight={selected['weight']}): "
-        f"{selected['label']}"
-    )
-    return selected["label"]
 
 
 def get_pr_labels(args) -> List[str]:
@@ -439,11 +409,11 @@ def matrix_generator(
                 # Handle multi-label configuration with weighted random selection.
                 # Some families (e.g. gfx94x) have multiple runner labels available.
                 if "test-runs-on-labels" in platform_info:
-                    matrix_row["test-runs-on"] = _select_weighted_label(
+                    matrix_row["test-runs-on"] = select_weighted_label(
                         platform_info["test-runs-on-labels"], target_name
                     )
                 if "test-runs-on-multi-gpu-labels" in platform_info:
-                    matrix_row["test-runs-on-multi-gpu"] = _select_weighted_label(
+                    matrix_row["test-runs-on-multi-gpu"] = select_weighted_label(
                         platform_info["test-runs-on-multi-gpu-labels"],
                         f"{target_name} (multi-gpu)",
                     )

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -47,7 +47,6 @@ Outputs (written to GITHUB_OUTPUT):
 import enum
 import json
 import os
-import random
 import sys
 from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
@@ -56,7 +55,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from _therock_utils.build_topology import get_topology
 
-from amdgpu_family_matrix import all_build_variants, get_all_families_for_trigger_types
+from amdgpu_family_matrix import (
+    all_build_variants,
+    get_all_families_for_trigger_types,
+    select_weighted_label,
+)
 from configure_ci_path_filters import (
     get_git_modified_paths,
     get_git_submodule_paths,
@@ -759,36 +762,6 @@ def select_targets(ci_inputs: CIInputs) -> TargetSelection:
 # ---------------------------------------------------------------------------
 
 
-def _select_weighted_label(labels_config: list[dict], context_name: str) -> str:
-    """Select a runner label based on weighted random selection.
-
-    Args:
-        labels_config: List of dicts with "label" and "weight" keys.
-                       Weights should sum to 1.0.
-        context_name: Name for logging context (e.g. family name).
-
-    Returns:
-        Selected label string.
-    """
-    rand_val = random.random()
-    cumulative = 0.0
-    for config in labels_config:
-        cumulative += config["weight"]
-        if rand_val < cumulative:
-            print(
-                f"  {context_name}: selected runner (weight={config['weight']}): "
-                f"{config['label']}"
-            )
-            return config["label"]
-    # Fallback to last label if rounding errors
-    selected = labels_config[-1]
-    print(
-        f"  {context_name}: selected runner (weight={selected['weight']}): "
-        f"{selected['label']}"
-    )
-    return selected["label"]
-
-
 def _expand_build_config_for_platform(
     families: list[str],
     platform: str,
@@ -841,7 +814,7 @@ def _expand_build_config_for_platform(
         # Handle multi-label configuration with weighted random selection.
         # Some families (e.g. gfx94x) have multiple runner labels available.
         if "test-runs-on-labels" in platform_info:
-            test_runs_on = _select_weighted_label(
+            test_runs_on = select_weighted_label(
                 platform_info["test-runs-on-labels"], family_name
             )
 

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -47,6 +47,7 @@ Outputs (written to GITHUB_OUTPUT):
 import enum
 import json
 import os
+import random
 import sys
 from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
@@ -758,6 +759,36 @@ def select_targets(ci_inputs: CIInputs) -> TargetSelection:
 # ---------------------------------------------------------------------------
 
 
+def _select_weighted_label(labels_config: list[dict], context_name: str) -> str:
+    """Select a runner label based on weighted random selection.
+
+    Args:
+        labels_config: List of dicts with "label" and "weight" keys.
+                       Weights should sum to 1.0.
+        context_name: Name for logging context (e.g. family name).
+
+    Returns:
+        Selected label string.
+    """
+    rand_val = random.random()
+    cumulative = 0.0
+    for config in labels_config:
+        cumulative += config["weight"]
+        if rand_val < cumulative:
+            print(
+                f"  {context_name}: selected runner (weight={config['weight']}): "
+                f"{config['label']}"
+            )
+            return config["label"]
+    # Fallback to last label if rounding errors
+    selected = labels_config[-1]
+    print(
+        f"  {context_name}: selected runner (weight={selected['weight']}): "
+        f"{selected['label']}"
+    )
+    return selected["label"]
+
+
 def _expand_build_config_for_platform(
     families: list[str],
     platform: str,
@@ -806,6 +837,13 @@ def _expand_build_config_for_platform(
 
         # Determine test runner label.
         test_runs_on = platform_info["test-runs-on"]
+
+        # Handle multi-label configuration with weighted random selection.
+        # Some families (e.g. gfx94x) have multiple runner labels available.
+        if "test-runs-on-labels" in platform_info:
+            test_runs_on = _select_weighted_label(
+                platform_info["test-runs-on-labels"], family_name
+            )
 
         # When a test_runner:<kernel> label is set, use the
         # kernel-specific runner if available, otherwise disable testing for

--- a/build_tools/github_actions/fetch_package_targets.py
+++ b/build_tools/github_actions/fetch_package_targets.py
@@ -54,12 +54,43 @@ jobs:
 
 import os
 import json
+import random
 from amdgpu_family_matrix import (
     get_all_families_for_trigger_types,
 )
 import string
 
 from github_actions_api import *
+
+
+def _select_weighted_label(labels_config: list[dict], context_name: str) -> str:
+    """Select a runner label based on weighted random selection.
+
+    Args:
+        labels_config: List of dicts with "label" and "weight" keys.
+                       Weights should sum to 1.0.
+        context_name: Name for logging context (e.g. family name).
+
+    Returns:
+        Selected label string.
+    """
+    rand_val = random.random()
+    cumulative = 0.0
+    for config in labels_config:
+        cumulative += config["weight"]
+        if rand_val < cumulative:
+            print(
+                f"  {context_name}: selected runner (weight={config['weight']}): "
+                f"{config['label']}"
+            )
+            return config["label"]
+    # Fallback to last label if rounding errors
+    selected = labels_config[-1]
+    print(
+        f"  {context_name}: selected runner (weight={selected['weight']}): "
+        f"{selected['label']}"
+    )
+    return selected["label"]
 
 
 def determine_package_targets(args):
@@ -99,6 +130,13 @@ def determine_package_targets(args):
 
         family = platform_for_key.get("family")
         test_machine = platform_for_key.get("test-runs-on")
+
+        # Handle multi-label configuration with weighted random selection.
+        if "test-runs-on-labels" in platform_for_key:
+            test_machine = _select_weighted_label(
+                platform_for_key["test-runs-on-labels"], family
+            )
+
         sanity_check_only_for_family = platform_for_key.get(
             "sanity_check_only_for_family", False
         )

--- a/build_tools/github_actions/fetch_package_targets.py
+++ b/build_tools/github_actions/fetch_package_targets.py
@@ -54,43 +54,13 @@ jobs:
 
 import os
 import json
-import random
 from amdgpu_family_matrix import (
     get_all_families_for_trigger_types,
+    select_weighted_label,
 )
 import string
 
 from github_actions_api import *
-
-
-def _select_weighted_label(labels_config: list[dict], context_name: str) -> str:
-    """Select a runner label based on weighted random selection.
-
-    Args:
-        labels_config: List of dicts with "label" and "weight" keys.
-                       Weights should sum to 1.0.
-        context_name: Name for logging context (e.g. family name).
-
-    Returns:
-        Selected label string.
-    """
-    rand_val = random.random()
-    cumulative = 0.0
-    for config in labels_config:
-        cumulative += config["weight"]
-        if rand_val < cumulative:
-            print(
-                f"  {context_name}: selected runner (weight={config['weight']}): "
-                f"{config['label']}"
-            )
-            return config["label"]
-    # Fallback to last label if rounding errors
-    selected = labels_config[-1]
-    print(
-        f"  {context_name}: selected runner (weight={selected['weight']}): "
-        f"{selected['label']}"
-    )
-    return selected["label"]
 
 
 def determine_package_targets(args):
@@ -133,7 +103,7 @@ def determine_package_targets(args):
 
         # Handle multi-label configuration with weighted random selection.
         if "test-runs-on-labels" in platform_for_key:
-            test_machine = _select_weighted_label(
+            test_machine = select_weighted_label(
                 platform_for_key["test-runs-on-labels"], family
             )
 

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -524,6 +524,169 @@ class ConfigureCITest(unittest.TestCase):
         entry = linux_target_output[0]
         self.assertEqual(entry["test-runs-on"], "rocm-asan-mi325-sandbox")
 
+    ###########################################################################
+    # Tests for multi-label runner selection
+
+    def test_gfx94x_multi_label_selects_first_when_random_low(self):
+        """When random() is very low, first label should be selected."""
+        base_args = {"build_variant": "release"}
+        build_families = {"amdgpu_families": "gfx94X"}
+
+        # Mock random.random() to return 0.1 (< 0.59 first weight)
+        with patch("random.random", return_value=0.1):
+            linux_target_output, _ = configure_ci.matrix_generator(
+                is_pull_request=True,
+                is_workflow_dispatch=False,
+                is_push=False,
+                is_schedule=False,
+                base_args=base_args,
+                families=build_families,
+                platform="linux",
+            )
+
+        # Find the gfx94X entry
+        gfx94x_entries = [
+            e for e in linux_target_output if e["family"] == "gfx94X-dcgpu"
+        ]
+        self.assertEqual(len(gfx94x_entries), 1, "Expected exactly one gfx94X entry")
+        entry = gfx94x_entries[0]
+        # Should select the first (vultr) label
+        self.assertEqual(entry["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm")
+
+    def test_gfx94x_multi_label_selects_second_when_random_medium(self):
+        """When random() is in middle range, second label should be selected."""
+        base_args = {"build_variant": "release"}
+        build_families = {"amdgpu_families": "gfx94X"}
+
+        # Mock random.random() to return 0.65 (>= 0.59, < 0.59+0.14=0.73)
+        with patch("random.random", return_value=0.65):
+            linux_target_output, _ = configure_ci.matrix_generator(
+                is_pull_request=True,
+                is_workflow_dispatch=False,
+                is_push=False,
+                is_schedule=False,
+                base_args=base_args,
+                families=build_families,
+                platform="linux",
+            )
+
+        # Find the gfx94X entry
+        gfx94x_entries = [
+            e for e in linux_target_output if e["family"] == "gfx94X-dcgpu"
+        ]
+        self.assertEqual(len(gfx94x_entries), 1, "Expected exactly one gfx94X entry")
+        entry = gfx94x_entries[0]
+        # Should select the second (cirrascale) label
+        self.assertEqual(entry["test-runs-on"], "linux-gfx942-1gpu-ccs-ossci-rocm")
+
+    def test_gfx94x_multi_label_selects_third_when_random_high(self):
+        """When random() is high, third label should be selected."""
+        base_args = {"build_variant": "release"}
+        build_families = {"amdgpu_families": "gfx94X"}
+
+        # Mock random.random() to return 0.8 (>= 0.59+0.14=0.73)
+        with patch("random.random", return_value=0.8):
+            linux_target_output, _ = configure_ci.matrix_generator(
+                is_pull_request=True,
+                is_workflow_dispatch=False,
+                is_push=False,
+                is_schedule=False,
+                base_args=base_args,
+                families=build_families,
+                platform="linux",
+            )
+
+        # Find the gfx94X entry
+        gfx94x_entries = [
+            e for e in linux_target_output if e["family"] == "gfx94X-dcgpu"
+        ]
+        self.assertEqual(len(gfx94x_entries), 1, "Expected exactly one gfx94X entry")
+        entry = gfx94x_entries[0]
+        # Should select the third (core42) label
+        self.assertEqual(entry["test-runs-on"], "linux-gfx942-1gpu-core42-ossci-rocm")
+
+    def test_gfx94x_multi_gpu_label_selects_first_when_random_low(self):
+        """When random() is low, first multi-gpu label should be selected."""
+        base_args = {"build_variant": "release"}
+        build_families = {"amdgpu_families": "gfx94X"}
+
+        # Mock random.random() to return 0.3 (< 0.61 first weight)
+        with patch("random.random", return_value=0.3):
+            linux_target_output, _ = configure_ci.matrix_generator(
+                is_pull_request=True,
+                is_workflow_dispatch=False,
+                is_push=False,
+                is_schedule=False,
+                base_args=base_args,
+                families=build_families,
+                platform="linux",
+            )
+
+        # Find the gfx94X entry
+        gfx94x_entries = [
+            e for e in linux_target_output if e["family"] == "gfx94X-dcgpu"
+        ]
+        self.assertEqual(len(gfx94x_entries), 1, "Expected exactly one gfx94X entry")
+        entry = gfx94x_entries[0]
+        # Should select the first (cirrascale) multi-gpu label
+        self.assertEqual(
+            entry["test-runs-on-multi-gpu"], "linux-gfx942-8gpu-ossci-rocm"
+        )
+
+    def test_gfx94x_multi_gpu_label_selects_second_when_random_high(self):
+        """When random() is high, second multi-gpu label should be selected."""
+        base_args = {"build_variant": "release"}
+        build_families = {"amdgpu_families": "gfx94X"}
+
+        # Mock random.random() to return 0.7 (>= 0.61)
+        with patch("random.random", return_value=0.7):
+            linux_target_output, _ = configure_ci.matrix_generator(
+                is_pull_request=True,
+                is_workflow_dispatch=False,
+                is_push=False,
+                is_schedule=False,
+                base_args=base_args,
+                families=build_families,
+                platform="linux",
+            )
+
+        # Find the gfx94X entry
+        gfx94x_entries = [
+            e for e in linux_target_output if e["family"] == "gfx94X-dcgpu"
+        ]
+        self.assertEqual(len(gfx94x_entries), 1, "Expected exactly one gfx94X entry")
+        entry = gfx94x_entries[0]
+        # Should select the second (core42) multi-gpu label
+        self.assertEqual(
+            entry["test-runs-on-multi-gpu"], "linux-gfx942-8gpu-core42-ossci-rocm"
+        )
+
+    def test_families_without_multi_label_always_use_primary(self):
+        """Families without multi-label config should always use primary label."""
+        base_args = {"build_variant": "release"}
+        build_families = {"amdgpu_families": "gfx103X"}
+
+        # Run multiple times to ensure consistency (no multi-label config exists)
+        for _ in range(5):
+            linux_target_output, _ = configure_ci.matrix_generator(
+                is_pull_request=False,
+                is_workflow_dispatch=False,
+                is_push=False,
+                is_schedule=True,
+                base_args=base_args,
+                families=build_families,
+                platform="linux",
+            )
+
+            # Find the gfx103X entry
+            gfx103x_entries = [
+                e for e in linux_target_output if e["family"] == "gfx103X-all"
+            ]
+            if gfx103x_entries:
+                entry = gfx103x_entries[0]
+                # Should always use the same primary label
+                self.assertEqual(entry["test-runs-on"], "linux-gfx1030-gpu-rocm")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -968,5 +968,144 @@ class TestFamilyTestFilters(unittest.TestCase):
         self.assertEqual(gfx90a_info["test-runs-on"], "")
 
 
+# ---------------------------------------------------------------------------
+# Multi-label runner selection
+# ---------------------------------------------------------------------------
+
+
+class TestMultiLabelRunnerSelection(unittest.TestCase):
+    """Test weighted random selection of multi-label runner configurations."""
+
+    def test_gfx94x_has_multi_label_config(self):
+        """Verify gfx94x has the multi-label configuration."""
+        from amdgpu_family_matrix import get_all_families_for_trigger_types
+
+        all_families = get_all_families_for_trigger_types(["presubmit"])
+        self.assertIn("gfx94x", all_families)
+
+        gfx94x_linux = all_families["gfx94x"].get("linux", {})
+        self.assertIn("test-runs-on", gfx94x_linux)
+        self.assertIn("test-runs-on-labels", gfx94x_linux)
+        self.assertIn("test-runs-on-multi-gpu-labels", gfx94x_linux)
+
+        # Verify we have 3 labels for 1-gpu
+        labels = gfx94x_linux["test-runs-on-labels"]
+        self.assertEqual(len(labels), 3)
+
+        # Verify label names
+        label_names = [l["label"] for l in labels]
+        self.assertIn("linux-gfx942-1gpu-ossci-rocm", label_names)
+        self.assertIn("linux-gfx942-1gpu-ccs-ossci-rocm", label_names)
+        self.assertIn("linux-gfx942-1gpu-core42-ossci-rocm", label_names)
+
+        # Verify weights sum to ~1.0
+        total_weight = sum(l["weight"] for l in labels)
+        self.assertAlmostEqual(total_weight, 1.0, places=1)
+
+    def test_gfx94x_multi_gpu_has_dual_label_config(self):
+        """Verify gfx94x has the multi-gpu dual-label configuration."""
+        from amdgpu_family_matrix import get_all_families_for_trigger_types
+
+        all_families = get_all_families_for_trigger_types(["presubmit"])
+        gfx94x_linux = all_families["gfx94x"].get("linux", {})
+
+        # Verify we have 2 labels for 8-gpu
+        labels = gfx94x_linux["test-runs-on-multi-gpu-labels"]
+        self.assertEqual(len(labels), 2)
+
+        # Verify label names
+        label_names = [l["label"] for l in labels]
+        self.assertIn("linux-gfx942-8gpu-ossci-rocm", label_names)
+        self.assertIn("linux-gfx942-8gpu-core42-ossci-rocm", label_names)
+
+        # Verify weights sum to 1.0
+        total_weight = sum(l["weight"] for l in labels)
+        self.assertAlmostEqual(total_weight, 1.0, places=1)
+
+    def test_first_label_selected_when_random_low(self):
+        """When random() < first weight, first label should be selected."""
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="pull_request",
+            commit_ref="feature",
+            base_ref="HEAD^",
+            build_variant="release",
+        )
+        targets = cm.TargetSelection(linux_families=["gfx94x"])
+
+        # Mock random.random() to return 0.1 (< 0.59 first weight)
+        with patch("random.random", return_value=0.1):
+            builds = cm.expand_build_configs(targets, ci_inputs, test_type="quick")
+
+        self.assertIsNotNone(builds.linux)
+        # Check that the first label was selected
+        gfx94x_info = builds.linux.per_family_info[0]
+        self.assertEqual(gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm")
+
+    def test_second_label_selected_when_random_medium(self):
+        """When random() is in second range, second label should be selected."""
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="pull_request",
+            commit_ref="feature",
+            base_ref="HEAD^",
+            build_variant="release",
+        )
+        targets = cm.TargetSelection(linux_families=["gfx94x"])
+
+        # Mock random.random() to return 0.65 (>= 0.59, < 0.73)
+        with patch("random.random", return_value=0.65):
+            builds = cm.expand_build_configs(targets, ci_inputs, test_type="quick")
+
+        self.assertIsNotNone(builds.linux)
+        # Check that the second label was selected
+        gfx94x_info = builds.linux.per_family_info[0]
+        self.assertEqual(
+            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ccs-ossci-rocm"
+        )
+
+    def test_third_label_selected_when_random_high(self):
+        """When random() >= first two weights, third label should be selected."""
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="pull_request",
+            commit_ref="feature",
+            base_ref="HEAD^",
+            build_variant="release",
+        )
+        targets = cm.TargetSelection(linux_families=["gfx94x"])
+
+        # Mock random.random() to return 0.8 (>= 0.59+0.14=0.73)
+        with patch("random.random", return_value=0.8):
+            builds = cm.expand_build_configs(targets, ci_inputs, test_type="quick")
+
+        self.assertIsNotNone(builds.linux)
+        # Check that the third label was selected
+        gfx94x_info = builds.linux.per_family_info[0]
+        self.assertEqual(
+            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-core42-ossci-rocm"
+        )
+
+    def test_families_without_multi_label_use_primary_only(self):
+        """Families without multi-label config should only use primary label."""
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="schedule",
+            commit_ref="main",
+            base_ref="HEAD^1",
+            build_variant="release",
+        )
+        # gfx103x doesn't have multi-label config
+        targets = cm.TargetSelection(linux_families=["gfx103x"])
+
+        # Run multiple times to ensure consistency
+        for _ in range(10):
+            builds = cm.expand_build_configs(targets, ci_inputs, test_type="full")
+            if builds.linux and builds.linux.per_family_info:
+                gfx103x_info = builds.linux.per_family_info[0]
+                # Should always use the primary label
+                self.assertEqual(gfx103x_info["test-runs-on"], "linux-gfx1030-gpu-rocm")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/build_tools/github_actions/tests/fetch_package_targets_test.py
+++ b/build_tools/github_actions/tests/fetch_package_targets_test.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import os
 import sys
 import unittest
+from unittest.mock import patch
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import fetch_package_targets
@@ -129,6 +130,63 @@ class FetchPackageTargetsTest(unittest.TestCase):
         self.assertFalse(any("gfx94X-dcgpu" == t["amdgpu_family"] for t in targets))
         self.assertTrue(any("gfx110X-all" == t["amdgpu_family"] for t in targets))
         self.assertTrue(any("gfx120X-all" == t["amdgpu_family"] for t in targets))
+
+    def test_gfx94x_multi_label_selects_first_when_random_low(self):
+        """When random() is low, first label should be selected."""
+        args = {
+            "AMDGPU_FAMILIES": "gfx94x",
+            "THEROCK_PACKAGE_PLATFORM": "linux",
+        }
+
+        # Mock random.random() to return 0.1 (< 0.59 first weight)
+        with patch("random.random", return_value=0.1):
+            targets = fetch_package_targets.determine_package_targets(args)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0]["test_machine"], "linux-gfx942-1gpu-ossci-rocm")
+
+    def test_gfx94x_multi_label_selects_second_when_random_medium(self):
+        """When random() is in second range, second label should be selected."""
+        args = {
+            "AMDGPU_FAMILIES": "gfx94x",
+            "THEROCK_PACKAGE_PLATFORM": "linux",
+        }
+
+        # Mock random.random() to return 0.65 (>= 0.59, < 0.73)
+        with patch("random.random", return_value=0.65):
+            targets = fetch_package_targets.determine_package_targets(args)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0]["test_machine"], "linux-gfx942-1gpu-ccs-ossci-rocm")
+
+    def test_gfx94x_multi_label_selects_third_when_random_high(self):
+        """When random() is high, third label should be selected."""
+        args = {
+            "AMDGPU_FAMILIES": "gfx94x",
+            "THEROCK_PACKAGE_PLATFORM": "linux",
+        }
+
+        # Mock random.random() to return 0.8 (>= 0.73)
+        with patch("random.random", return_value=0.8):
+            targets = fetch_package_targets.determine_package_targets(args)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(
+            targets[0]["test_machine"], "linux-gfx942-1gpu-core42-ossci-rocm"
+        )
+
+    def test_families_without_multi_label_use_primary(self):
+        """Families without multi-label config should use primary label."""
+        args = {
+            "AMDGPU_FAMILIES": "gfx110x",
+            "THEROCK_PACKAGE_PLATFORM": "linux",
+        }
+
+        # Run multiple times to ensure consistency
+        for _ in range(5):
+            targets = fetch_package_targets.determine_package_targets(args)
+            self.assertEqual(len(targets), 1)
+            self.assertEqual(targets[0]["test_machine"], "linux-gfx110X-gpu-rocm")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Revert of #4714 , the same label for clusters did not work :( 

We now have to do weight distribution accordingly for single and multi gpu. With `fetch_package_targets.py`, this will also work for superrepos.

Based on count of GPU, I have added the weight distribution!