### PR TITLE
Do not merge: Bump rocm-libraries to users/dahawkin/hipdnn-sdpa-feature-flag-2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 [submodule "rocm-libraries"]
 	path = rocm-libraries
 	url = https://github.com/ROCm/rocm-libraries
-	branch = develop
+	branch = users/dahawkin/hipdnn-sdpa-feature-flag-2
 [submodule "rocm-systems"]
 	path = rocm-systems
 	url = https://github.com/ROCm/rocm-systems.git


### PR DESCRIPTION
This is intended for end-to-end testing of the hipDNN SDPA feature flag with Fusilli in TheRock. This PR is never intended to be merged.

Updates the rocm-libraries submodule pointer to 0fed4746bc19c60de50f7ffa37544dd264fc1d01, the current tip of branch users/dahawkin/hipdnn-sdpa-feature-flag-2 on github.com/ROCm/rocm-libraries. Also updates .gitmodules so this submodule tracks that branch for future `git submodule update --remote` runs.