### PR TITLE
Proposal for Build and Release of user application/libraries of ROCm 

### DIFF
--- a/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
+++ b/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
@@ -5,17 +5,17 @@ modified: 2026-04-14
 status: draft
 ---
 
-# ROCm End-User Projects With Independent Release Lifecycle 
+# ROCm End-User Projects With Independent Release Lifecycle
 
 ## 1. Overview
 
 ROCm ships a core SDK through TheRock build system. In addition to the core
 SDK, AMD and the broader community maintain a set of **extras** — tools,
 validation suites, and utility projects — that are compiled *on top of* a
-released ROCm installation but follow their own development and release
-timelines. These extras are not part of the ROCm Core SDK; they consume
-ROCm as a build dependency and are delivered as independently versioned
-packages.
+released ROCm Core SDK installation but follow their own development and
+release timelines. These extras are not part of the ROCm Core SDK; they
+consume ROCm as a build dependency and are delivered as independently
+versioned packages.
 
 The ROCm Validation Suite (RVS) is the canonical example of such a project.
 RVS exercises GPU hardware and the ROCm software stack through a collection
@@ -31,16 +31,16 @@ release cadence.
 1. **Decouple extras from the ROCm release train** so that bug fixes,
    new test modules, and feature enhancements can ship without waiting for
    the next ROCm Core SDK release.
-2. **Guarantee backward compatibility within a ROCm major version** so
-   that a single extras build works across every minor and patch release
+2. **Guarantee backward compatibility within a ROCm major version release stream**
+   so that a single extras build works across every minor and patch release
    of that major version.
 3. **Provide a clear installation layout** that coexists with the ROCm
    Core SDK directory structure defined in
    [RFC0009](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md) without
    creating conflicts or ambiguity.
 4. **Enable community and partner contributions** by keeping the extras
-   repositories buildable against any compatible, publicly released ROCm
-   installation.
+   repositories buildable against any compatible, publicly released
+   ROCm Core SDK installation.
 
 ### Scope
 
@@ -63,12 +63,16 @@ release cadence.
 Extras projects follow an **independent release cadence** that is not tied
 to the ROCm Core SDK release schedule.
 
+Each extras project may set an appropriate release cadence for the project in
+conjunction with its stakeholders.
+
 ### Versioning Scheme
 
-Each end-user project adopts its own semantic version:
+Each end-user project adopts its own semantic version which results in
+following filename template:
 
 ```
-<project>-<major>.<minor>.<patch>
+<projectname>-<major>.<minor>.<patch>
 ```
 
 For example:
@@ -121,21 +125,21 @@ compatible ROCm version family is always unambiguous.
 The following table illustrates how project versions map to ROCm
 compatibility:
 
-| Project version | ROCm target | Package release tag | Install path |
-| :--- | :--- | :--- | :--- |
-| rvs-1.0.0 | ROCm 7.x | `rvs-1.0.0-rocm7` | `/opt/rocm/extras-7/` |
-| rvs-1.1.0 | ROCm 7.x | `rvs-1.1.0-rocm7` | `/opt/rocm/extras-7/` |
-| rvs-1.2.0 | ROCm 7.x | `rvs-1.2.0-rocm7` | `/opt/rocm/extras-7/` |
-| rvs-2.0.0 | ROCm 8.x | `rvs-2.0.0-rocm8` | `/opt/rocm/extras-8/` |
+| Project version | ROCm target | Package release tag | Install path          |
+| :-------------- | :---------- | :------------------ | :-------------------- |
+| rvs-1.0.0       | ROCm 7.x    | `rvs-1.0.0-rocm7`   | `/opt/rocm/extras-7/` |
+| rvs-1.1.0       | ROCm 7.x    | `rvs-1.1.0-rocm7`   | `/opt/rocm/extras-7/` |
+| rvs-1.2.0       | ROCm 7.x    | `rvs-1.2.0-rocm7`   | `/opt/rocm/extras-7/` |
+| rvs-2.0.0       | ROCm 8.x    | `rvs-2.0.0-rocm8`   | `/opt/rocm/extras-8/` |
 
 ### Release Principles
 
-| Principle | Description |
-| :--- | :--- |
-| Independent scheduling | Extras may release at any time — weekly, monthly, or on-demand — without coordinating with upcoming ROCm Core SDK milestones. |
-| ROCm version binding | Each release of an extras project declares the ROCm major version it targets (e.g., ROCm 7). A new ROCm major version requires a corresponding new release of the extras project. |
-| Hotfix freedom | Critical bug fixes in an extras tool can ship immediately as a patch release without waiting for a ROCm point release. |
-| Nightly / pre-release builds | Extras projects may publish nightly or pre-release packages to a staging repository for early validation. |
+| Principle                    | Description                                                                                                                                                                       |
+| :--------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Independent scheduling       | Extras may release at any time — weekly, monthly, or on-demand — without coordinating with upcoming ROCm Core SDK milestones.                                                     |
+| ROCm version binding         | Each release of an extras project declares the ROCm major version it targets (e.g., ROCm 7). A new ROCm major version requires a corresponding new release of the extras project. |
+| Hotfix freedom               | Critical bug fixes in an extras tool can ship immediately as a patch release without waiting for a ROCm point release.                                                             |
+| Nightly / pre-release builds | Extras projects may publish nightly or pre-release packages to a staging repository for early validation.                                                                          |
 
 ### Example Timeline
 
@@ -170,19 +174,18 @@ whether the ROCm release is older or newer than the one used at build time.
 
 Concretely for RVS:
 
-| RVS version | Built against | Must work on |
-| :--- | :--- | :--- |
-| rvs-1.0.0 | ROCm 7.0 | ROCm 7.0, 7.1, 7.2, … |
-| rvs-1.1.0 | ROCm 7.1 | ROCm 7.0, 7.1, 7.2, … |
-| rvs-1.2.0 | ROCm 7.2 | ROCm 7.0, 7.1, 7.2, … |
-| rvs-2.0.0 | ROCm 8.0 | ROCm 8.0, 8.1, … |
+| RVS version | Built against | Must work on           |
+| :---------- | :------------ | :--------------------- |
+| rvs-1.0.0   | ROCm 7.0      | ROCm 7.0, 7.1, 7.2, … |
+| rvs-1.1.0   | ROCm 7.1      | ROCm 7.0, 7.1, 7.2, … |
+| rvs-1.2.0   | ROCm 7.2      | ROCm 7.0, 7.1, 7.2, … |
+| rvs-2.0.0   | ROCm 8.0      | ROCm 8.0, 8.1, …      |
 
 This means an operator who upgrades their cluster from ROCm 7.0 to ROCm 7.2
 does **not** need to reinstall or upgrade RVS — the existing RVS binary
 continues to function. Conversely, an operator running ROCm 7.0 can install a
 newer RVS release (e.g., rvs-1.2.0, originally built against ROCm 7.2) and it
 will work correctly.
-
 
 ### How Compatibility Is Achieved
 
@@ -411,12 +414,12 @@ applicable and when to use each.
 
 ### Format Overview
 
-| Format | Applicable | Primary use case |
-| :--- | :--- | :--- |
-| **DEB** (`.deb`) | Yes | Installation on Debian-based distributions (Ubuntu, Debian) via `apt` / `dpkg`. |
-| **RPM** (`.rpm`) | Yes | Installation on RPM-based distributions (RHEL, SLES, AlmaLinux, CentOS, Rocky, Oracle Linux) via `dnf` / `yum` / `zypper`. |
-| **Tarball** (`.tar.xz`) | Yes | Portable, package-manager-independent installation. Useful for container images, HPC environments without root access, and CI/CD pipelines that consume pre-built artifacts. |
-| **Python wheel** (`.whl`) | Conditional | Only applicable when the extras project ships a Python interface or CLI tool written in Python. Native-only projects (e.g., RVS) do not produce wheels. |
+| Format                    | Applicable  | Primary use case                                                                                                                                                             |
+| :------------------------ | :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **DEB** (`.deb`)          | Yes         | Installation on Debian-based distributions (Ubuntu, Debian) via `apt` / `dpkg`.                                                                                              |
+| **RPM** (`.rpm`)          | Yes         | Installation on RPM-based distributions (RHEL, SLES, AlmaLinux, CentOS, Rocky, Oracle Linux) via `dnf` / `yum` / `zypper`.                                                  |
+| **Tarball** (`.tar.xz`)   | Yes         | Portable, package-manager-independent installation. Useful for container images, HPC environments without root access, and CI/CD pipelines that consume pre-built artifacts. |
+| **Python wheel** (`.whl`) | Conditional | Only applicable when the extras project ships a Python interface or CLI tool written in Python. Native-only projects (e.g., RVS) do not produce wheels.                      |
 
 ### DEB and RPM Packages
 
@@ -429,32 +432,41 @@ non-versioned packages.
 
 Key conventions:
 
-- **Naming**: Packages use the `amdrocm-<project>` prefix for AMD
-  repository distribution, matching the convention in RFC0009. Distro-native
-  packages (e.g., those maintained by Ubuntu or Red Hat) use
-  `rocm-<project>` without the `amd` prefix.
+- **Naming**: Packages embed the target ROCm major version in the name
+  using the `amdrocm<major>-<project>` convention. This enables
+  side-by-side installation of the same project across different ROCm
+  major versions, since `amdrocm7-rvs` and `amdrocm8-rvs` are distinct
+  packages to the package manager. Distro-native packages use the
+  corresponding `rocm<major>-<project>` convention.
 
-  | AMD repository package | Distro-native equivalent | Contents |
-  | :--- | :--- | :--- |
-  | `amdrocm-rvs` | `rocm-rvs` | RVS runtime — binaries, modules, and configs |
-  | `amdrocm-rvs-devel` | `rocm-rvs-dev` | RVS development headers and CMake files |
+  | AMD repository package | Distro-native equivalent | Contents                                                   |
+  | :--------------------- | :----------------------- | :--------------------------------------------------------- |
+  | `amdrocm7-rvs`         | `rocm7-rvs`              | RVS runtime for ROCm 7.x — binaries, modules, and configs |
+  | `amdrocm7-rvs-devel`   | `rocm7-rvs-dev`          | RVS development headers and CMake files for ROCm 7.x      |
+  | `amdrocm8-rvs`         | `rocm8-rvs`              | RVS runtime for ROCm 8.x                                  |
 - **Runtime vs. development split (optional)**: Projects that expose a
   public API with headers and CMake config files may choose to produce a
   separate `-devel` / `-dev` package. Most extras projects are end-user
   tools built on top of the SDK and ship a single runtime package only.
 
-Example (RVS on Ubuntu):
+Example (RVS for ROCm 7 on Ubuntu):
 
 ```
-amdrocm-rvs_1.2.0-7_amd64.deb
-amdrocm-rvs-dev_1.2.0-7_amd64.deb
+amdrocm7-rvs_1.2.0_amd64.deb
+amdrocm7-rvs-dev_1.2.0_amd64.deb
 ```
 
-Example (RVS on RHEL):
+Example (RVS for ROCm 7 on RHEL):
 
 ```
-amdrocm-rvs-1.2.0-7.x86_64.rpm
-amdrocm-rvs-devel-1.2.0-7.x86_64.rpm
+amdrocm7-rvs-1.2.0.x86_64.rpm
+amdrocm7-rvs-devel-1.2.0.x86_64.rpm
+```
+
+Side-by-side install of RVS across ROCm 7 and ROCm 8:
+
+```bash
+apt install amdrocm7-rvs amdrocm8-rvs
 ```
 
 #### Dependency Resolution
@@ -477,7 +489,7 @@ The following rules apply to all end-user project packages:
    are resolved automatically by the package manager through the ROCm
    packages' own dependency chains.
 
-2. **Use version ranges, not exact versions.** Pin dependencies to the
+1. **Use version ranges, not exact versions.** Pin dependencies to the
    ROCm major version to honor the compatibility contract from Section 3.
    Avoid pinning to a specific minor or patch release unless a known
    minimum is required.
@@ -495,7 +507,7 @@ The following rules apply to all end-user project packages:
    Requires: amdrocm-runtimes < 8.0
    ```
 
-3. **Separate build-time and install-time dependencies.** Build
+1. **Separate build-time and install-time dependencies.** Build
    dependencies (`Build-Depends` / `BuildRequires`) may reference
    development packages such as `amdrocm-core-devel`. Runtime packages
    should only depend on the runtime counterparts.
@@ -505,11 +517,11 @@ The following rules apply to all end-user project packages:
 ROCm packages in TheRock are organized into three categories. End-user
 projects must understand this structure to declare the right dependencies.
 
-| Category | Description | Example packages |
-| :--- | :--- | :--- |
-| **Host packages** | Architecture-independent runtime and libraries — the host-side binaries that work regardless of which GPU is installed. Not all host packages have corresponding device packages; some (e.g., `amdrocm-runtimes`) are purely host-side. | `amdrocm-runtimes`, `amdrocm-core`, `amdrocm-base` |
-| **Device packages** | GPU-architecture-specific binaries containing device code for a particular `gfx` target. Only ROCm library packages that ship pre-compiled GPU kernels produce device variants. These are suffixed with the architecture name. | `amdrocm-blas-gfx942`, `amdrocm-blas-gfx1100` |
-| **Meta packages** | Convenience packages that pull in a set of host + device packages for a given architecture family or the full SDK. | `amdrocm`, `amdrocm-core-sdk`, `rocm-gfx90X` |
+| Category            | Description                                                                                                                                                                                                                             | Example packages                                    |
+| :------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------- |
+| **Host packages**   | Architecture-independent runtime and libraries — the host-side binaries that work regardless of which GPU is installed. Not all host packages have corresponding device packages; some (e.g., `amdrocm-runtimes`) are purely host-side. | `amdrocm-runtimes`, `amdrocm-core`, `amdrocm-base` |
+| **Device packages** | GPU-architecture-specific binaries containing device code for a particular `gfx` target. Only ROCm library packages that ship pre-compiled GPU kernels produce device variants. These are suffixed with the architecture name.          | `amdrocm-blas-gfx942`, `amdrocm-blas-gfx1100`      |
+| **Meta packages**   | Convenience packages that pull in a set of host + device packages for a given architecture family or the full SDK.                                                                                                                      | `amdrocm`, `amdrocm-core-sdk`, `rocm-gfx90X`       |
 
 #### Mapping End-User Project Dependencies to ROCm
 
@@ -570,7 +582,7 @@ variants and declare dependencies on the matching ROCm library device
 packages:
 
 ```
-Package: amdrocm-mytool-gfx942
+Package: amdrocm7-mytool-gfx942
 Depends: amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0),
          amdrocm-blas-gfx942 (>= 7.0), amdrocm-blas-gfx942 (<< 8.0)
 ```
@@ -608,35 +620,35 @@ End-user projects should be prepared for this model:
    host-only dependency pattern (the typical case above) are
    automatically compatible — no changes needed.
 
-2. **Do not assume fat binaries.** End-user projects must not assume
+1. **Do not assume fat binaries.** End-user projects must not assume
    that ROCm libraries contain embedded device code for all
    architectures. The device code may reside in separate architecture
    packages or kpack archives loaded at runtime.
 
-3. **Let the user choose architectures.** The end-user project package
+1. **Let the user choose architectures.** The end-user project package
    should never force-install a specific GPU architecture. Architecture
    selection is the user's responsibility through device meta-packages:
 
    ```bash
    # User installs the end-user project + their architecture
-   apt install amdrocm-rvs
+   apt install amdrocm7-rvs
    apt install rocm-gfx90X        # User's architecture choice
    ```
 
-4. **Test against both fat and split layouts.** During the transition
+1. **Test against both fat and split layouts.** During the transition
    period, CI should verify that the end-user project works correctly
    whether ROCm is installed from fat-binary packages or multi-arch
    split packages.
 
 #### Dependency Declaration Summary
 
-| Scenario | DEB `Depends` | RPM `Requires` |
-| :--- | :--- | :--- |
-| Uses HIP runtime | `amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0)` | `amdrocm-runtimes >= 7.0, amdrocm-runtimes < 8.0` |
-| Uses a ROCm library (e.g., rocBLAS) | `amdrocm-blas (>= 7.0), amdrocm-blas (<< 8.0)` | `amdrocm-blas >= 7.0, amdrocm-blas < 8.0` |
-| Uses ROCm SMI | `amdrocm-amdsmi (>= 7.0), amdrocm-amdsmi (<< 8.0)` | `amdrocm-amdsmi >= 7.0, amdrocm-amdsmi < 8.0` |
-| Needs full Core SDK runtime | `amdrocm-core (>= 7.0), amdrocm-core (<< 8.0)` | `amdrocm-core >= 7.0, amdrocm-core < 8.0` |
-| Ships own device kernels for a library | `amdrocm-<library>-<gfxarch> (>= 7.0)` | `amdrocm-<library>-<gfxarch> >= 7.0` |
+| Scenario                               | DEB `Depends`                                            | RPM `Requires`                                     |
+| :------------------------------------- | :------------------------------------------------------- | :------------------------------------------------- |
+| Uses HIP runtime                       | `amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0)` | `amdrocm-runtimes >= 7.0, amdrocm-runtimes < 8.0` |
+| Uses a ROCm library (e.g., rocBLAS)    | `amdrocm-blas (>= 7.0), amdrocm-blas (<< 8.0)`         | `amdrocm-blas >= 7.0, amdrocm-blas < 8.0`         |
+| Uses ROCm SMI                          | `amdrocm-amdsmi (>= 7.0), amdrocm-amdsmi (<< 8.0)`     | `amdrocm-amdsmi >= 7.0, amdrocm-amdsmi < 8.0`     |
+| Needs full Core SDK runtime            | `amdrocm-core (>= 7.0), amdrocm-core (<< 8.0)`         | `amdrocm-core >= 7.0, amdrocm-core < 8.0`         |
+| Ships own device kernels for a library | `amdrocm-<library>-<gfxarch> (>= 7.0)`                  | `amdrocm-<library>-<gfxarch> >= 7.0`              |
 
 ### Tarball Packages
 
@@ -655,14 +667,14 @@ a `.tar.xz` file with a corresponding `sha256sum`. The archive extracts
 into the flat FHS layout described in Section 4:
 
 ```bash
-tar -xf amdrocm-rvs-1.2.0-rocm7-linux-x86_64.tar.xz \
+tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
     -C /opt/rocm/extras-7/
 ```
 
 Tarball naming follows the pattern:
 
 ```
-amdrocm-<project>-<version>-rocm<major>-<os>-<arch>.tar.xz
+amdrocm<rocm-major>-<project>-<version>-<os>-<arch>.tar.xz
 ```
 
 #### Installing ROCm Dependencies for Tarball-Based Deployments
@@ -683,7 +695,7 @@ the installed ROCm major version matches:
 amd-smi version
 
 # Extract the end-user project into the extras tree
-tar -xf amdrocm-rvs-1.2.0-rocm7-linux-x86_64.tar.xz \
+tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
     -C /opt/rocm/extras-7/
 ```
 
@@ -698,7 +710,7 @@ tar -xf amdrocm-core-7.1.0-linux-x86_64.tar.xz \
     -C /opt/rocm/core-7/
 
 # Extract the end-user project
-tar -xf amdrocm-rvs-1.2.0-rocm7-linux-x86_64.tar.xz \
+tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
     -C /opt/rocm/extras-7/
 ```
 
@@ -711,7 +723,7 @@ libraries reside inside the Python site-packages directory. Use
 ```bash
 ROCM_ROOT=$(rocm-sdk path --root)
 
-tar -xf amdrocm-rvs-1.2.0-rocm7-linux-x86_64.tar.xz \
+tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
     -C /opt/rocm/extras-7/
 ```
 
@@ -801,7 +813,7 @@ projects like RVS do not produce wheels.
 When applicable, extras wheels follow the conventions described in the
 [Python packaging documentation](/docs/packaging/python_packaging.md):
 
-- **Selector package**: A source distribution (`rocm-<project>`)
+- **Selector package**: A source distribution (`rocm<major>-<project>`)
   that evaluates install-time constraints and pulls the correct runtime
   wheels.
 - **Runtime wheels**: Contain the minimal set of files needed to run,
@@ -827,7 +839,7 @@ build_tools/build_python_packages.py \
 Example install:
 
 ```bash
-pip install rocm-mytool --pre \
+pip install rocm7-mytool --pre \
     --find-links=./OUTPUT_PKG/dist
 ```
 
@@ -836,9 +848,9 @@ pip install rocm-mytool --pre \
 The following table summarizes which format to produce based on the
 project characteristics:
 
-| Project type | DEB/RPM | Tarball | Wheel |
-| :--- | :---: | :---: | :---: |
-| Native C/C++ tool (e.g., RVS) | Yes | Yes | No |
-| Pure Python tool/test harness | No | No | Yes |
-| Mixed native + Python library | Yes | Yes | Yes |
+| Project type                  | DEB/RPM | Tarball | Wheel |
+| :---------------------------- | :-----: | :-----: | :---: |
+| Native C/C++ tool (e.g., RVS) |   Yes   |   Yes   |  No   |
+| Pure Python tool/test harness |   No    |   No    |  Yes  |
+| Mixed native + Python library |   Yes   |   Yes   |  Yes  |
 

--- a/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
+++ b/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
@@ -442,9 +442,6 @@ Key conventions:
   public API with headers and CMake config files may choose to produce a
   separate `-devel` / `-dev` package. Most extras projects are end-user
   tools built on top of the SDK and ship a single runtime package only.
-- **RPATH**: Packages are built with `$ORIGIN`-based RPATH. The
-  `--rpath-pkg` option produces versioned-only packages when relocatable
-  installs are required.
 
 Example (RVS on Ubuntu):
 

--- a/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
+++ b/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
@@ -1,0 +1,561 @@
+---
+author: Freddy Paul
+created: 2026-04-14
+modified: 2026-04-14
+status: draft
+---
+
+# ROCm End-User Projects With Independent Release Lifecycle for 
+
+## 1. Overview
+
+ROCm ships a core SDK through TheRock build system. In addition to the core
+SDK, AMD and the broader community maintain a set of **extras** — tools,
+validation suites, and utility projects — that are compiled *on top of* a
+released ROCm installation but follow their own development and release
+timelines. These extras are not part of the ROCm Core SDK; they consume
+ROCm as a build dependency and are delivered as independently versioned
+packages.
+
+The ROCm Validation Suite (RVS) is the canonical example of such a project.
+RVS exercises GPU hardware and the ROCm software stack through a collection
+of test modules (GPU Properties, PCI-Express Bandwidth, GPU Stress Test,
+Memory Test, etc.) and is used by datacenter operators, OEMs, and developers
+to qualify ROCm deployments. RVS depends on the ROCm runtime, HIP, and
+several ROCm libraries, yet its feature roadmap and release schedule are
+driven by validation requirements that are independent of the ROCm Core SDK
+release cadence.
+
+### Goals
+
+1. **Decouple extras from the ROCm release train** so that bug fixes,
+   new test modules, and feature enhancements can ship without waiting for
+   the next ROCm Core SDK release.
+2. **Guarantee backward compatibility within a ROCm major version** so
+   that a single extras build works across every minor and patch release
+   of that major version.
+3. **Provide a clear installation layout** that coexists with the ROCm
+   Core SDK directory structure defined in
+   [RFC0009](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md) without
+   creating conflicts or ambiguity.
+4. **Enable community and partner contributions** by keeping the extras
+   repositories buildable against any compatible, publicly released ROCm
+   installation.
+
+### Scope
+
+#### In Scope
+
+- Release cadence and versioning for extras/tools projects
+- ROCm major-version compatibility contract
+- Directory layout and packaging conventions for installed extras
+- ROCm Validation Suite (RVS) as the reference implementation
+
+#### Out of Scope
+
+- ROCm Core SDK packaging (covered by RFC0009)
+- GPU driver packaging
+- Python / pip / wheel packaging for extras
+- Internal CI/CD pipeline specifics of individual extras projects
+
+## 2. Release Cadence
+
+Extras projects follow an **independent release cadence** that is not tied
+to the ROCm Core SDK release schedule.
+
+### Versioning Scheme
+
+Each end-user project adopts its own semantic version:
+
+```
+<project>-<major>.<minor>.<patch>
+```
+
+For example:
+
+```
+rvs-1.0.0
+rvs-1.1.0
+rvs-1.1.1
+```
+
+The project version is entirely independent of the ROCm version it was
+built against. The relationship to the ROCm platform is encoded in two
+ways:
+
+1. **Extras tree version (installation path).** All end-user projects
+   compiled against a given ROCm major version are installed into a
+   single shared prefix whose name carries the ROCm major version:
+
+   ```
+   /opt/rocm/extras-<rocm-major>/
+   ```
+
+   For example, `extras-7` contains every end-user project built for the
+   ROCm 7.x family. This makes compatibility immediately visible from
+   the filesystem path — no additional metadata lookup is required.
+
+2. **Package version string.** Each package embeds the target ROCm major
+   version in its release tag so that the compatibility scope is apparent
+   even outside the filesystem context (e.g., in repository listings,
+   download pages, and CI logs):
+
+   ```
+   <project>-<major>.<minor>.<patch>-rocm<rocm-major>
+   ```
+
+   Examples:
+
+   ```
+   rvs-1.0.0-rocm7      # RVS 1.0.0 compatible with ROCm 7.x
+   rvs-1.2.0-rocm7      # RVS 1.2.0 compatible with ROCm 7.x
+   rvs-2.0.0-rocm8      # RVS 2.0.0 compatible with ROCm 8.x
+   ```
+
+The combination of both signals ensures that whether a user is looking at
+an installed directory, a package filename, or a repository index, the
+compatible ROCm version family is always unambiguous.
+
+### ROCm Compatibility Matrix
+
+The following table illustrates how project versions map to ROCm
+compatibility:
+
+| Project version | ROCm target | Package release tag | Install path |
+| :--- | :--- | :--- | :--- |
+| rvs-1.0.0 | ROCm 7.x | `rvs-1.0.0-rocm7` | `/opt/rocm/extras-7/` |
+| rvs-1.1.0 | ROCm 7.x | `rvs-1.1.0-rocm7` | `/opt/rocm/extras-7/` |
+| rvs-1.2.0 | ROCm 7.x | `rvs-1.2.0-rocm7` | `/opt/rocm/extras-7/` |
+| rvs-2.0.0 | ROCm 8.x | `rvs-2.0.0-rocm8` | `/opt/rocm/extras-8/` |
+
+### Release Principles
+
+| Principle | Description |
+| :--- | :--- |
+| Independent scheduling | Extras may release at any time — weekly, monthly, or on-demand — without coordinating with upcoming ROCm Core SDK milestones. |
+| ROCm version binding | Each release of an extras project declares the ROCm major version it targets (e.g., ROCm 7). A new ROCm major version requires a corresponding new release of the extras project. |
+| Hotfix freedom | Critical bug fixes in an extras tool can ship immediately as a patch release without waiting for a ROCm point release. |
+| Nightly / pre-release builds | Extras projects may publish nightly or pre-release packages to a staging repository for early validation. |
+
+### Example Timeline
+
+```
+ROCm 7.0  ─────── ROCm 7.1 ─────── ROCm 7.2 ──────── ROCm 8.0
+  │                  │                  │                  │
+  ├─ rvs-1.0.0       │                  │                  │
+  │  (extras-7)      ├─ rvs-1.1.0       │                  │
+  │                  │  (extras-7)       │                  │
+  │                  │    ├─ rvs-1.1.1   │                  │
+  │                  │    (extras-7)     ├─ rvs-1.2.0       │
+  │                  │                  │  (extras-7)       │
+  │                  │                  │                  ├─ rvs-2.0.0
+  │                  │                  │                  │  (extras-8)
+```
+
+In this timeline, all RVS 1.x releases land in `extras-7` and work with
+any ROCm 7.x release. When ROCm 8.0 introduces breaking ABI changes, RVS
+publishes a new major version (2.0.0) that installs into `extras-8`.
+
+## 3. Compatibility with ROCm Releases
+
+### Major-Version Compatibility Contract
+
+All extras packages compiled against a given ROCm **major** version must
+continue to work with any ROCm release that shares that major version,
+whether the ROCm release is older or newer than the one used at build time.
+
+> **Rule:** An extras package built on ROCm **X.a** must function correctly
+> on ROCm **X.b** for all supported values of **a** and **b** within major
+> version **X**.
+
+Concretely for RVS:
+
+| RVS version | Built against | Must work on |
+| :--- | :--- | :--- |
+| rvs-1.0.0 | ROCm 7.0 | ROCm 7.0, 7.1, 7.2, … |
+| rvs-1.1.0 | ROCm 7.1 | ROCm 7.0, 7.1, 7.2, … |
+| rvs-1.2.0 | ROCm 7.2 | ROCm 7.0, 7.1, 7.2, … |
+| rvs-2.0.0 | ROCm 8.0 | ROCm 8.0, 8.1, … |
+
+This means an operator who upgrades their cluster from ROCm 7.0 to ROCm 7.2
+does **not** need to reinstall or upgrade RVS — the existing RVS binary
+continues to function. Conversely, an operator running ROCm 7.0 can install a
+newer RVS release (e.g., rvs-1.2.0, originally built against ROCm 7.2) and it
+will work correctly.
+
+
+### How Compatibility Is Achieved
+
+1. **Stable ABI within a ROCm major version.** The ROCm Core SDK maintains
+   backward-compatible shared-library ABIs across all minor and patch releases
+   within the same major version. Extras projects link against these stable
+   interfaces.
+
+2. **`$ORIGIN`-based RPATH.** Extras packages are built with `$ORIGIN`-relative
+   RPATH entries so that they resolve their own bundled dependencies first,
+   falling back to the ROCm installation only for ROCm-provided libraries.
+
+3. **Minimum-version symbol binding.** Extras projects build against the
+   **lowest** minor release in the target major family (e.g., ROCm 7.0) to
+   ensure no dependency on symbols introduced in a later minor release. If a
+   feature from a newer minor release is required, it is accessed through
+   runtime detection or optional weak linking.
+
+4. **CI validation matrix.** Each extras release is tested against the full
+   set of supported ROCm minor releases within its target major version
+   before publication.
+
+### Breaking Changes Across Major Versions
+
+When ROCm increments its major version (e.g., 7.x to 8.0), ABI stability
+is **not** guaranteed. Extras projects must publish a corresponding new
+major version compiled against the new ROCm major release. Packages from
+different ROCm major families must not be mixed.
+
+## 4. Installed Package Directory Structure
+
+Extras packages install under `/opt/rocm/extras-<rocm-major>/` following
+the
+[ROCm Linux Filesystem Hierarchy Standard](https://rocm.docs.amd.com/en/latest/conceptual/file-reorg.html)
+and the conventions established in
+[RFC0009](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md). The extras
+tree version matches the ROCm major version it targets, so `extras-7`
+contains all extras built for ROCm 7.x. The layout is **flat** — all
+binaries, libraries, and headers from every extras project are merged into
+this single prefix, with project-specific subfolders under `include/` and
+`share/` for namespace isolation.
+
+### Layout
+
+```
+/opt/rocm/extras-<rocm-major>/
+    | -- bin
+    |      | -- all public binaries across extras projects
+    | -- lib
+    |      | -- lib<soname>.so -> lib<soname>.so.major -> lib<soname>.so.major.minor.patch
+    |      |      (public libraries to link with applications)
+    |      | -- <component>
+    |      |      | -- architecture dependent libraries and binaries used internally
+    |      | -- cmake
+    |             | -- <component>
+    |                    | -- <component>-config.cmake
+    | -- libexec
+    |      | -- <component>
+    |             | -- non-ISA/architecture independent executables used internally
+    | -- include
+    |      | -- <component>
+    |             | -- public header files
+    | -- share
+           | -- html
+           |      | -- <component>
+           |             | -- html documentation
+           | -- info
+           |      | -- <component>
+           |             | -- info files
+           | -- man
+           |      | -- <component>
+           |             | -- man pages
+           | -- doc
+           |      | -- <component>
+           |             | -- license files
+           | -- <component>
+                  | -- samples
+                  | -- architecture independent misc files (configs, test assets)
+```
+
+Where `<rocm-major>` is the ROCm major version the extras target (e.g.,
+`7` for ROCm 7.x), and `<component>` is the individual project name
+(e.g., `rvs`).
+
+### Symlinks
+
+A soft link provides a stable unversioned path that resolves to the latest
+installed extras tree:
+
+```
+/opt/rocm/extras/         -> /opt/rocm/extras-7
+```
+
+### RVS Example
+
+A concrete installation of the `extras-7` tree containing RVS 1.2.0:
+
+```
+/opt/rocm/extras-7/
+    | -- bin
+    |      | -- rvs                            # Main RVS executable
+    | -- lib
+    |      | -- librvs.so -> librvs.so.1 -> librvs.so.1.2.0
+    |      | -- rvs
+    |      |      | -- libgst.so               # GPU Stress Test module
+    |      |      | -- libiet.so               # Input EDPp Test module
+    |      |      | -- libpeqt.so              # PCI-Express Qualification Test module
+    |      |      | -- libpebb.so              # PCI-Express Bandwidth Benchmark module
+    |      |      | -- libmem.so               # Memory Test module
+    |      |      | -- librvs_internal.so      # Internal helpers
+    |      | -- cmake
+    |             | -- rvs
+    |                    | -- rvs-config.cmake
+    |                    | -- rvs-targets.cmake
+    | -- libexec
+    |      | -- rvs
+    |             | -- rvs_worker               # Internal worker process
+    | -- include
+    |      | -- rvs
+    |             | -- rvs.h
+    |             | -- rvs_module.h
+    | -- share
+           | -- doc
+           |      | -- rvs
+           |             | -- LICENSE
+           |             | -- CHANGELOG.md
+           | -- man
+           |      | -- rvs
+           |             | -- rvs.1
+           | -- rvs
+                  | -- conf
+                  |      | -- gpup_1.conf      # GPU Properties module config
+                  |      | -- gst_1.conf       # GPU Stress Test config
+                  |      | -- pebb_1.conf      # PCIe Bandwidth Benchmark config
+                  |      | -- rvs.conf         # Global RVS configuration
+                  | -- samples
+                         | -- gpu_stress.py
+```
+
+When RVS releases a new version (e.g., rvs-1.3.0) while still targeting
+ROCm 7, the updated files are installed in-place into the same `extras-7`
+tree. The extras tree version does not change — only the individual project
+binaries and libraries within it are upgraded.
+
+Symlink:
+
+```
+/opt/rocm/extras/         -> /opt/rocm/extras-7
+```
+
+### Multiple Extras Projects
+
+When more than one extras project is installed, all projects merge into the
+same flat prefix. The project-specific subfolders under `include/` and
+`share/` prevent namespace collisions:
+
+```
+/opt/rocm/extras-7/
+    | -- bin
+    |      | -- rvs
+    |      | -- rocm-bench
+    | -- lib
+    |      | -- librvs.so
+    |      | -- librocmbench.so
+    |      | -- cmake
+    |             | -- rvs
+    |             |      | -- rvs-config.cmake
+    |             | -- rocm-bench
+    |                    | -- rocm-bench-config.cmake
+    | -- include
+    |      | -- rvs
+    |      |      | -- rvs.h
+    |      | -- rocm-bench
+    |             | -- rocm_bench.h
+    | -- share
+           | -- doc
+           |      | -- rvs
+           |      |      | -- LICENSE
+           |      | -- rocm-bench
+           |             | -- LICENSE
+           | -- rvs
+           |      | -- conf
+           |      | -- samples
+           | -- rocm-bench
+                  | -- samples
+```
+
+### Side-by-Side Installation
+
+When multiple ROCm major versions are installed on the same system, a
+separate extras tree exists for each. This allows side-by-side operation
+without conflicts:
+
+```
+/opt/rocm/extras-7/
+/opt/rocm/extras-8/
+/opt/rocm/extras/         -> /opt/rocm/extras-8
+```
+
+Within a single extras tree (e.g., `extras-7`), project upgrades are
+installed in-place — there is no side-by-side at the individual project
+level. The ROCm major version is the only axis of side-by-side support.
+
+### Environment Integration
+
+To make extras tools discoverable, packages install a modulefile or profile
+snippet:
+
+```
+/etc/profile.d/amdrocm-extras.sh
+```
+
+This adds `/opt/rocm/extras/bin` to `$PATH` and `/opt/rocm/extras/lib` to
+`$LD_LIBRARY_PATH` (or the equivalent `ld.so.conf.d` drop-in). Because the
+layout is flat, a single profile snippet covers all extras projects. Users
+can target a specific ROCm major version by pointing directly at
+`/opt/rocm/extras-7/bin` instead of the symlink, or by using environment
+modules.
+
+## 5. Packaging Formats
+
+Extras projects must produce packaging formats that align with the formats
+supported by the ROCm Core SDK in TheRock. Not every format applies to
+every extras project — the table below identifies which formats are
+applicable and when to use each.
+
+### Format Overview
+
+| Format | Applicable | Primary use case |
+| :--- | :--- | :--- |
+| **DEB** (`.deb`) | Yes | Installation on Debian-based distributions (Ubuntu, Debian) via `apt` / `dpkg`. |
+| **RPM** (`.rpm`) | Yes | Installation on RPM-based distributions (RHEL, SLES, AlmaLinux, CentOS, Rocky, Oracle Linux) via `dnf` / `yum` / `zypper`. |
+| **Tarball** (`.tar.xz`) | Yes | Portable, package-manager-independent installation. Useful for container images, HPC environments without root access, and CI/CD pipelines that consume pre-built artifacts. |
+| **Python wheel** (`.whl`) | Conditional | Only applicable when the extras project ships a Python interface or CLI tool written in Python. Native-only projects (e.g., RVS) do not produce wheels. |
+
+### DEB and RPM Packages
+
+Extras projects follow the same native packaging workflow as the ROCm Core
+SDK, as described in the
+[native packaging documentation](/docs/packaging/native_packaging.md).
+Each extras project provides a `package.json` that defines its package
+entries, and TheRock's packaging tooling generates both versioned and
+non-versioned packages.
+
+Key conventions:
+
+- **Naming**: Packages use the `amdrocm-<project>` prefix for AMD
+  repository distribution, matching the convention in RFC0009. Distro-native
+  packages (e.g., those maintained by Ubuntu or Red Hat) use
+  `rocm-<project>` without the `amd` prefix.
+
+  | AMD repository package | Distro-native equivalent | Contents |
+  | :--- | :--- | :--- |
+  | `amdrocm-rvs` | `rocm-rvs` | RVS runtime — binaries, modules, and configs |
+  | `amdrocm-rvs-devel` | `rocm-rvs-dev` | RVS development headers and CMake files |
+- **Runtime vs. development split (optional)**: Projects that expose a
+  public API with headers and CMake config files may choose to produce a
+  separate `-devel` / `-dev` package. Most extras projects are end-user
+  tools built on top of the SDK and ship a single runtime package only.
+- **RPATH**: Packages are built with `$ORIGIN`-based RPATH. The
+  `--rpath-pkg` option produces versioned-only packages when relocatable
+  installs are required.
+
+Example (RVS on Ubuntu):
+
+```bash
+build_tools/packaging/linux/build_package.py \
+    --artifacts-dir ./ARTIFACTS_DIR \
+    --target gfx94X-dcgpu \
+    --dest-dir ./OUTPUT_PKG \
+    --rocm-version 7.1.0 \
+    --pkg-type deb
+```
+
+This produces packages such as:
+
+```
+amdrocm-rvs_1.2.0-7_amd64.deb
+amdrocm-rvs-dev_1.2.0-7_amd64.deb
+```
+
+Example (RVS on RHEL):
+
+```bash
+build_tools/packaging/linux/build_package.py \
+    --artifacts-dir ./ARTIFACTS_DIR \
+    --target gfx94X-dcgpu \
+    --dest-dir ./OUTPUT_PKG \
+    --rocm-version 7.1.0 \
+    --pkg-type rpm
+```
+
+This produces packages such as:
+
+```
+amdrocm-rvs-1.2.0-7.x86_64.rpm
+amdrocm-rvs-devel-1.2.0-7.x86_64.rpm
+```
+
+### Tarball Packages
+
+Tarball archives provide a package-manager-independent distribution
+channel. They are the preferred format for:
+
+- Container images where native package managers add unnecessary layer
+  complexity.
+- HPC clusters with shared filesystems and no per-node root access.
+- CI/CD pipelines that need to extract pre-built extras into an arbitrary
+  prefix.
+- Environments where `apt` / `dnf` repositories are not configured.
+
+Tarballs follow the same artifact archive conventions as TheRock, producing
+a `.tar.xz` file with a corresponding `sha256sum`. The archive extracts
+into the flat FHS layout described in Section 4:
+
+```bash
+tar -xf amdrocm-rvs-1.2.0-rocm7-linux-x86_64.tar.xz \
+    -C /opt/rocm/extras-7/
+```
+
+Tarball naming follows the pattern:
+
+```
+amdrocm-<project>-<version>-rocm<major>-<os>-<arch>.tar.xz
+```
+
+### Python Wheel Packages
+
+Wheels are applicable **only** when an extras project provides a Python
+API, CLI tool, or test harness written in Python. Native-only extras
+projects like RVS do not produce wheels.
+
+When applicable, extras wheels follow the conventions described in the
+[Python packaging documentation](/docs/packaging/python_packaging.md):
+
+- **Selector package**: A source distribution (`rocm-<project>`)
+  that evaluates install-time constraints and pulls the correct runtime
+  wheels.
+- **Runtime wheels**: Contain the minimal set of files needed to run,
+  with no symlinks. SONAME libraries are included directly.
+- **Devel wheels**: Catch-all for headers, CMake files, and symlinks
+  stored in a `_devel.tar` inside the wheel.
+
+Wheels declare a dependency on the ROCm SDK Python packages for the
+matching major version:
+
+```
+Requires-Dist: rocm[core] >=7.0, <8.0
+```
+
+Example build:
+
+```bash
+build_tools/build_python_packages.py \
+    --artifact-dir ./ARTIFACTS_DIR \
+    --dest-dir ./OUTPUT_PKG
+```
+
+Example install:
+
+```bash
+pip install rocm-mytool --pre \
+    --find-links=./OUTPUT_PKG/dist
+```
+
+### Format Selection Guide
+
+The following table summarizes which format to produce based on the
+project characteristics:
+
+| Project type | DEB/RPM | Tarball | Wheel |
+| :--- | :---: | :---: | :---: |
+| Native C/C++ tool (e.g., RVS) | Yes | Yes | No |
+| Native tool with Python CLI wrapper | Yes | Yes | Yes |
+| Pure Python tool/test harness | No | No | Yes |
+| Mixed native + Python library | Yes | Yes | Yes |

--- a/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
+++ b/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
@@ -5,7 +5,7 @@ modified: 2026-04-14
 status: draft
 ---
 
-# ROCm End-User Projects With Independent Release Lifecycle for 
+# ROCm End-User Projects With Independent Release Lifecycle 
 
 ## 1. Overview
 
@@ -144,10 +144,10 @@ ROCm 7.0  ─────── ROCm 7.1 ─────── ROCm 7.2 ──�
   │                  │                  │                  │
   ├─ rvs-1.0.0       │                  │                  │
   │  (extras-7)      ├─ rvs-1.1.0       │                  │
-  │                  │  (extras-7)       │                  │
-  │                  │    ├─ rvs-1.1.1   │                  │
-  │                  │    (extras-7)     ├─ rvs-1.2.0       │
-  │                  │                  │  (extras-7)       │
+  │                  │  (extras-7)      │                  │
+  │                  │    ├─ rvs-1.1.1  │                  │
+  │                  │    (extras-7)    ├─ rvs-1.2.0       │
+  │                  │                  │  (extras-7)      │
   │                  │                  │                  ├─ rvs-2.0.0
   │                  │                  │                  │  (extras-8)
 ```
@@ -448,34 +448,12 @@ Key conventions:
 
 Example (RVS on Ubuntu):
 
-```bash
-build_tools/packaging/linux/build_package.py \
-    --artifacts-dir ./ARTIFACTS_DIR \
-    --target gfx94X-dcgpu \
-    --dest-dir ./OUTPUT_PKG \
-    --rocm-version 7.1.0 \
-    --pkg-type deb
-```
-
-This produces packages such as:
-
 ```
 amdrocm-rvs_1.2.0-7_amd64.deb
 amdrocm-rvs-dev_1.2.0-7_amd64.deb
 ```
 
 Example (RVS on RHEL):
-
-```bash
-build_tools/packaging/linux/build_package.py \
-    --artifacts-dir ./ARTIFACTS_DIR \
-    --target gfx94X-dcgpu \
-    --dest-dir ./OUTPUT_PKG \
-    --rocm-version 7.1.0 \
-    --pkg-type rpm
-```
-
-This produces packages such as:
 
 ```
 amdrocm-rvs-1.2.0-7.x86_64.rpm
@@ -556,6 +534,5 @@ project characteristics:
 | Project type | DEB/RPM | Tarball | Wheel |
 | :--- | :---: | :---: | :---: |
 | Native C/C++ tool (e.g., RVS) | Yes | Yes | No |
-| Native tool with Python CLI wrapper | Yes | Yes | Yes |
 | Pure Python tool/test harness | No | No | Yes |
 | Mixed native + Python library | Yes | Yes | Yes |

--- a/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
+++ b/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
@@ -457,6 +457,187 @@ amdrocm-rvs-1.2.0-7.x86_64.rpm
 amdrocm-rvs-devel-1.2.0-7.x86_64.rpm
 ```
 
+#### Dependency Resolution
+
+End-user projects built on top of ROCm must declare their ROCm
+dependencies correctly so that package managers can resolve and install
+the required ROCm components automatically. The following covers the
+general principles for DEB and RPM dependency resolution and how to map
+them to ROCm's host, architecture-specific, and multi-arch package
+structure.
+
+#### General Principles
+
+DEB and RPM package managers resolve dependencies using metadata declared
+in the package control file (`Depends` for DEB, `Requires` for RPM).
+The following rules apply to all end-user project packages:
+
+1. **Declare only direct dependencies.** List only the ROCm packages
+   the project links against or invokes directly. Transitive dependencies
+   are resolved automatically by the package manager through the ROCm
+   packages' own dependency chains.
+
+2. **Use version ranges, not exact versions.** Pin dependencies to the
+   ROCm major version to honor the compatibility contract from Section 3.
+   Avoid pinning to a specific minor or patch release unless a known
+   minimum is required.
+
+   DEB example (`debian/control`):
+
+   ```
+   Depends: amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0)
+   ```
+
+   RPM example (`.spec`):
+
+   ```
+   Requires: amdrocm-runtimes >= 7.0
+   Requires: amdrocm-runtimes < 8.0
+   ```
+
+3. **Separate build-time and install-time dependencies.** Build
+   dependencies (`Build-Depends` / `BuildRequires`) may reference
+   development packages such as `amdrocm-core-devel`. Runtime packages
+   should only depend on the runtime counterparts.
+
+#### ROCm Dependency Categories
+
+ROCm packages in TheRock are organized into three categories. End-user
+projects must understand this structure to declare the right dependencies.
+
+| Category | Description | Example packages |
+| :--- | :--- | :--- |
+| **Host packages** | Architecture-independent runtime and libraries — the host-side binaries that work regardless of which GPU is installed. Not all host packages have corresponding device packages; some (e.g., `amdrocm-runtimes`) are purely host-side. | `amdrocm-runtimes`, `amdrocm-core`, `amdrocm-base` |
+| **Device packages** | GPU-architecture-specific binaries containing device code for a particular `gfx` target. Only ROCm library packages that ship pre-compiled GPU kernels produce device variants. These are suffixed with the architecture name. | `amdrocm-blas-gfx942`, `amdrocm-blas-gfx1100` |
+| **Meta packages** | Convenience packages that pull in a set of host + device packages for a given architecture family or the full SDK. | `amdrocm`, `amdrocm-core-sdk`, `rocm-gfx90X` |
+
+#### Mapping End-User Project Dependencies to ROCm
+
+Most end-user projects depend only on **host packages** because they call
+ROCm APIs (HIP, ROCm libraries) and do not ship their own GPU device
+code. The device packages are an end-user installation choice that
+determines which GPUs are supported at runtime — the end-user project
+itself is agnostic to this selection.
+
+**Host-only dependency (typical case)**
+
+An end-user project like RVS links against HIP, ROCm SMI, rocBLAS, and
+the ROCm runtime. Its package declares dependencies on the host packages
+for each component it uses:
+
+DEB:
+
+```
+Depends: amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0),
+         amdrocm-amdsmi (>= 7.0), amdrocm-amdsmi (<< 8.0),
+         amdrocm-blas (>= 7.0), amdrocm-blas (<< 8.0)
+```
+
+RPM:
+
+```
+Requires: amdrocm-runtimes >= 7.0, amdrocm-runtimes < 8.0
+Requires: amdrocm-amdsmi >= 7.0, amdrocm-amdsmi < 8.0
+Requires: amdrocm-blas >= 7.0, amdrocm-blas < 8.0
+```
+
+Note that `amdrocm-runtimes` is a host-only package and does not have
+architecture-specific variants. Libraries like `amdrocm-blas`, however,
+have corresponding device packages (`amdrocm-blas-gfx942`, etc.) that
+contain pre-compiled GPU kernels for specific architectures.
+
+The end-user project depends only on the host packages. The user is
+responsible for installing the device packages for their GPU, either
+individually or through an architecture family meta-package:
+
+```bash
+# Option 1: Install device packages for a specific architecture
+apt install amdrocm-blas-gfx942
+
+# Option 2: Install an architecture family meta-package (pulls in all
+#            device packages for the gfx94X family)
+apt install rocm-gfx94X
+```
+
+The end-user project does not need to know or declare which GPU
+architectures are present.
+
+**Architecture-specific dependency (rare case)**
+
+If an end-user project ships its own pre-compiled GPU kernels for
+specific architectures, it must produce architecture-specific package
+variants and declare dependencies on the matching ROCm library device
+packages:
+
+```
+Package: amdrocm-mytool-gfx942
+Depends: amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0),
+         amdrocm-blas-gfx942 (>= 7.0), amdrocm-blas-gfx942 (<< 8.0)
+```
+
+Each architecture variant must:
+
+- Not conflict with other architecture variants of the same project.
+- Be independently installable.
+- Follow the `<package>-<gfxarch>` naming convention from
+  [RFC0009](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md).
+
+**Meta-package dependency**
+
+If an end-user project needs the full ROCm runtime stack (not just
+individual libraries), it may depend on a meta-package instead of
+listing each component:
+
+```
+Depends: amdrocm-core (>= 7.0), amdrocm-core (<< 8.0)
+```
+
+This pulls in the complete ROCm Core runtime. Use this approach
+sparingly — prefer fine-grained dependencies to avoid installing
+unnecessary components.
+
+#### Multi-Arch Considerations
+
+ROCm is transitioning to a multi-arch packaging model through
+[RFC0008](/docs/rfcs/RFC0008-Multi-Arch-Packaging.md), where host code
+and device code are split into separate packages using `rocm-kpack`.
+End-user projects should be prepared for this model:
+
+1. **Depend on host packages only.** As ROCm splits host and device
+   code into separate packages, end-user projects that follow the
+   host-only dependency pattern (the typical case above) are
+   automatically compatible — no changes needed.
+
+2. **Do not assume fat binaries.** End-user projects must not assume
+   that ROCm libraries contain embedded device code for all
+   architectures. The device code may reside in separate architecture
+   packages or kpack archives loaded at runtime.
+
+3. **Let the user choose architectures.** The end-user project package
+   should never force-install a specific GPU architecture. Architecture
+   selection is the user's responsibility through device meta-packages:
+
+   ```bash
+   # User installs the end-user project + their architecture
+   apt install amdrocm-rvs
+   apt install rocm-gfx90X        # User's architecture choice
+   ```
+
+4. **Test against both fat and split layouts.** During the transition
+   period, CI should verify that the end-user project works correctly
+   whether ROCm is installed from fat-binary packages or multi-arch
+   split packages.
+
+#### Dependency Declaration Summary
+
+| Scenario | DEB `Depends` | RPM `Requires` |
+| :--- | :--- | :--- |
+| Uses HIP runtime | `amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0)` | `amdrocm-runtimes >= 7.0, amdrocm-runtimes < 8.0` |
+| Uses a ROCm library (e.g., rocBLAS) | `amdrocm-blas (>= 7.0), amdrocm-blas (<< 8.0)` | `amdrocm-blas >= 7.0, amdrocm-blas < 8.0` |
+| Uses ROCm SMI | `amdrocm-amdsmi (>= 7.0), amdrocm-amdsmi (<< 8.0)` | `amdrocm-amdsmi >= 7.0, amdrocm-amdsmi < 8.0` |
+| Needs full Core SDK runtime | `amdrocm-core (>= 7.0), amdrocm-core (<< 8.0)` | `amdrocm-core >= 7.0, amdrocm-core < 8.0` |
+| Ships own device kernels for a library | `amdrocm-<library>-<gfxarch> (>= 7.0)` | `amdrocm-<library>-<gfxarch> >= 7.0` |
+
 ### Tarball Packages
 
 Tarball archives provide a package-manager-independent distribution
@@ -483,6 +664,133 @@ Tarball naming follows the pattern:
 ```
 amdrocm-<project>-<version>-rocm<major>-<os>-<arch>.tar.xz
 ```
+
+#### Installing ROCm Dependencies for Tarball-Based Deployments
+
+Unlike DEB/RPM packages, tarballs do not have a package manager to
+resolve and install ROCm dependencies automatically. The user must
+ensure a compatible ROCm installation is present before extracting
+the end-user project tarball. There are several options:
+
+**Option 1: ROCm installed via native packages (recommended)**
+
+If the host already has ROCm installed through `apt` or `dnf`, the
+tarball-based end-user project can link against it directly. Verify
+the installed ROCm major version matches:
+
+```bash
+# Check the installed ROCm version
+amd-smi version
+
+# Extract the end-user project into the extras tree
+tar -xf amdrocm-rvs-1.2.0-rocm7-linux-x86_64.tar.xz \
+    -C /opt/rocm/extras-7/
+```
+
+**Option 2: ROCm installed from tarball**
+
+ROCm itself can be deployed from a tarball into a custom prefix. In
+this case both ROCm and the end-user project are package-manager-free:
+
+```bash
+# Extract ROCm Core SDK tarball
+tar -xf amdrocm-core-7.1.0-linux-x86_64.tar.xz \
+    -C /opt/rocm/core-7/
+
+# Extract the end-user project
+tar -xf amdrocm-rvs-1.2.0-rocm7-linux-x86_64.tar.xz \
+    -C /opt/rocm/extras-7/
+```
+
+**Option 3: ROCm installed via Python packages**
+
+When ROCm is available through `pip install rocm[core]`, the SDK
+libraries reside inside the Python site-packages directory. Use
+`rocm-sdk path` to locate the installation:
+
+```bash
+ROCM_ROOT=$(rocm-sdk path --root)
+
+tar -xf amdrocm-rvs-1.2.0-rocm7-linux-x86_64.tar.xz \
+    -C /opt/rocm/extras-7/
+```
+
+#### Connecting Project Binaries with ROCm Libraries
+
+After extracting both ROCm and the end-user project, the project
+binaries must be able to locate ROCm shared libraries at runtime.
+The following options are available, listed from most to least
+preferred:
+
+**Option 1: `$ORIGIN`-based RPATH (built-in, no user action)**
+
+End-user project binaries are built with `$ORIGIN`-relative RPATH
+entries. If the end-user project and ROCm are installed under the
+same `/opt/rocm/` parent, the relative paths resolve automatically
+and no additional configuration is needed.
+
+**Option 2: `LD_LIBRARY_PATH` environment variable**
+
+Set `LD_LIBRARY_PATH` to include the ROCm library directory. This is
+the simplest option when ROCm is installed in a non-standard location
+or when `$ORIGIN` RPATH does not cover the layout:
+
+```bash
+export ROCM_PATH=/opt/rocm/core-7
+export LD_LIBRARY_PATH=${ROCM_PATH}/lib:${LD_LIBRARY_PATH}
+export PATH=/opt/rocm/extras-7/bin:${ROCM_PATH}/bin:${PATH}
+```
+
+**Option 3: `ld.so.conf.d` drop-in (system-wide, requires root)**
+
+Create a linker configuration file so the dynamic linker finds ROCm
+libraries without environment variables:
+
+```bash
+echo "/opt/rocm/core-7/lib" > /etc/ld.so.conf.d/rocm-7.conf
+ldconfig
+```
+
+**Option 4: Environment modules / Lmod**
+
+On HPC clusters, use environment modules to manage ROCm and extras
+paths per user or per job:
+
+```tcl
+# /opt/modulefiles/rocm-extras/7
+set     rocm_root    /opt/rocm/core-7
+set     extras_root  /opt/rocm/extras-7
+
+prepend-path  PATH             $extras_root/bin
+prepend-path  PATH             $rocm_root/bin
+prepend-path  LD_LIBRARY_PATH  $extras_root/lib
+prepend-path  LD_LIBRARY_PATH  $rocm_root/lib
+prepend-path  CMAKE_PREFIX_PATH $extras_root
+prepend-path  CMAKE_PREFIX_PATH $rocm_root
+```
+
+Usage:
+
+```bash
+module load rocm-extras/7
+rvs -d 1
+```
+
+#### Verifying the Setup
+
+After installation and environment configuration, verify that the
+end-user project binaries can find all required ROCm libraries:
+
+```bash
+# Check that all shared library dependencies resolve
+ldd /opt/rocm/extras-7/bin/rvs
+
+# Run the project's built-in sanity check (if available)
+rvs -d 1 -g
+```
+
+Any `not found` entries in the `ldd` output indicate a missing ROCm
+library or an incorrectly configured library search path.
 
 ### Python Wheel Packages
 
@@ -533,3 +841,4 @@ project characteristics:
 | Native C/C++ tool (e.g., RVS) | Yes | Yes | No |
 | Pure Python tool/test harness | No | No | Yes |
 | Mixed native + Python library | Yes | Yes | Yes |
+

--- a/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
+++ b/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
@@ -55,7 +55,6 @@ release cadence.
 
 - ROCm Core SDK packaging (covered by RFC0009)
 - GPU driver packaging
-- Python / pip / wheel packaging for extras
 - Internal CI/CD pipeline specifics of individual extras projects
 
 ## 2. Release Cadence

--- a/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
+++ b/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
@@ -99,38 +99,33 @@ ways:
    ROCm 7.x family. This makes compatibility immediately visible from
    the filesystem path — no additional metadata lookup is required.
 
-2. **Package version string.** Each package embeds the target ROCm major
-   version in its release tag so that the compatibility scope is apparent
-   even outside the filesystem context (e.g., in repository listings,
-   download pages, and CI logs):
+2. **Package name.** Each package embeds the target ROCm major version
+   in its name using the `amdrocm<major>-<project>` convention, so the
+   compatibility scope is apparent in repository listings, download
+   pages, and CI logs:
 
    ```
-   <project>-<major>.<minor>.<patch>-rocm<rocm-major>
+   amdrocm7-rvs-1.0.0       # RVS 1.0.0 for ROCm 7.x
+   amdrocm7-rvs-1.2.0       # RVS 1.2.0 for ROCm 7.x
+   amdrocm8-rvs-2.0.0       # RVS 2.0.0 for ROCm 8.x
    ```
 
-   Examples:
-
-   ```
-   rvs-1.0.0-rocm7      # RVS 1.0.0 compatible with ROCm 7.x
-   rvs-1.2.0-rocm7      # RVS 1.2.0 compatible with ROCm 7.x
-   rvs-2.0.0-rocm8      # RVS 2.0.0 compatible with ROCm 8.x
-   ```
-
-The combination of both signals ensures that whether a user is looking at
-an installed directory, a package filename, or a repository index, the
-compatible ROCm version family is always unambiguous.
+The combination of both signals — the install path and the package
+name — ensures that whether a user is looking at an installed directory,
+a package filename, or a repository index, the compatible ROCm version
+family is always unambiguous.
 
 ### ROCm Compatibility Matrix
 
 The following table illustrates how project versions map to ROCm
 compatibility:
 
-| Project version | ROCm target | Package release tag | Install path          |
-| :-------------- | :---------- | :------------------ | :-------------------- |
-| rvs-1.0.0       | ROCm 7.x    | `rvs-1.0.0-rocm7`   | `/opt/rocm/extras-7/` |
-| rvs-1.1.0       | ROCm 7.x    | `rvs-1.1.0-rocm7`   | `/opt/rocm/extras-7/` |
-| rvs-1.2.0       | ROCm 7.x    | `rvs-1.2.0-rocm7`   | `/opt/rocm/extras-7/` |
-| rvs-2.0.0       | ROCm 8.x    | `rvs-2.0.0-rocm8`   | `/opt/rocm/extras-8/` |
+| Project version | ROCm target | Package name    | Install path          |
+| :-------------- | :---------- | :-------------- | :-------------------- |
+| rvs-1.0.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
+| rvs-1.1.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
+| rvs-1.2.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
+| rvs-2.0.0       | ROCm 8.x    | `amdrocm8-rvs`  | `/opt/rocm/extras-8/` |
 
 ### Release Principles
 

--- a/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
+++ b/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
@@ -56,7 +56,8 @@ release cadence.
 - ROCm Core SDK packaging (covered by RFC0009)
 - GPU driver packaging
 - Internal CI/CD pipeline specifics of individual extras projects
-
+- ROCm Expansion SDK requirements need a parallel RFC to the requirements in this PR. 
+- These requirements is for software that releases individually and islimited to one version installed per major ROCm version.
 ## 2. Release Cadence
 
 Extras projects follow an **independent release cadence** that is not tied

--- a/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
+++ b/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
@@ -1,5 +1,5 @@
 ---
-author: Freddy Paul, Saad Rahim (saadrahim)
+author: Freddy Paul
 created: 2026-04-14
 modified: 2026-04-14
 status: draft
@@ -56,38 +56,8 @@ release cadence.
 - ROCm Core SDK packaging (covered by RFC0009)
 - GPU driver packaging
 - Internal CI/CD pipeline specifics of individual extras projects
-- **ROCm Expansion SDKs** (e.g., the HPC SDK proposed in
-  [PR #5613](https://github.com/ROCm/TheRock/pull/5613)). Expansions are a
-  distinct category and require a parallel RFC. The key difference is the
-  version model: an **expansion pins to and installs a single ROCm version**,
-  whereas the **extras** described here are explicitly designed to support
-  **multiple ROCm major versions side by side** within a single
-  `/opt/rocm/extras/` tree (e.g. the `rvs7` and `rvs8` binaries coexist).
-  The requirements in this RFC do not govern expansions.
-
-### Related RFCs
-
-This RFC defines the **build, release, versioning, and install layout** for
-extras. It is single-responsibility by design and relies on the following
-companion RFCs:
-
-- [**RFC0012 — ROCm Repository Structure** (PR #4414)](https://github.com/ROCm/TheRock/pull/4414):
-  defines the *distribution* layout on `repo.amd.com`, including the single
-  `extras/` folder with per-project subfolders that this RFC's packages are
-  published into.
-- [**RFC00XX — ROCm Repository Setup Packages**](RFC00XX-Repository-Package.md):
-  defines the native `amdrocm-repo-*` rpm/deb tier packages that configure the
-  AMD repositories from which these extras are installed.
-- [**RFC0009 — OS Packaging Requirements**](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md):
-  the native packaging conventions (FHS layout, `-gfxarch` naming) that extras
-  packages inherit.
-- [**RFC0008 — Multi-Arch Packaging**](/docs/rfcs/RFC0008-Multi-Arch-Packaging.md):
-  the host/device package split that extras dependency declarations must be
-  compatible with.
-- [**PR #5613 — ROCm Expansion SDK / HPC SDK**](https://github.com/ROCm/TheRock/pull/5613):
-  the separate expansions track (single ROCm version per install), which is
-  explicitly out of scope here (see Out of Scope above).
-
+- ROCm Expansion SDK requirements need a parallel RFC to the requirements in this PR. 
+- These requirements is for software that releases individually and islimited to one version installed per major ROCm version.
 ## 2. Release Cadence
 
 Extras projects follow an **independent release cadence** that is not tied
@@ -117,18 +87,17 @@ The project version is entirely independent of the ROCm version it was
 built against. The relationship to the ROCm platform is encoded in two
 ways:
 
-1. **Versioned binary within a single extras tree.** All end-user
-   projects install into one shared prefix — `/opt/rocm/extras/` — with
-   no per-major directory. The public executable is suffixed with the
-   ROCm major (`rvs7`, `rvs8`) and an unsuffixed symlink points at the
-   latest installed major (`rvs` → `rvs7`), so builds for different ROCm
-   majors coexist in the same tree. Shared libraries use **ordinary,
-   project-version-based SONAMEs** (`librvs.so` → `librvs.so.1` →
-   `librvs.so.1.2.0`) — the ROCm major is **not** encoded in the `.so`
-   version. Because an extra bumps its own major version when it retargets
-   a new ROCm major (RVS 1.x for ROCm 7.x, RVS 2.x for ROCm 8.x), the
-   library SONAMEs naturally differ across ROCm majors and coexist via
-   standard linker versioning.
+1. **Extras tree version (installation path).** All end-user projects
+   compiled against a given ROCm major version are installed into a
+   single shared prefix whose name carries the ROCm major version:
+
+   ```
+   /opt/rocm/extras-<rocm-major>/
+   ```
+
+   For example, `extras-7` contains every end-user project built for the
+   ROCm 7.x family. This makes compatibility immediately visible from
+   the filesystem path — no additional metadata lookup is required.
 
 2. **Package name.** Each package embeds the target ROCm major version
    in its name using the `amdrocm<major>-<project>` convention, so the
@@ -141,26 +110,22 @@ ways:
    amdrocm8-rvs-2.0.0       # RVS 2.0.0 for ROCm 8.x
    ```
 
-The combination of both signals — the versioned artifact names and the
-package name — ensures that whether a user is looking at an installed
-binary, a package filename, or a repository index, the compatible ROCm
-version family is always unambiguous.
+The combination of both signals — the install path and the package
+name — ensures that whether a user is looking at an installed directory,
+a package filename, or a repository index, the compatible ROCm version
+family is always unambiguous.
 
 ### ROCm Compatibility Matrix
 
 The following table illustrates how project versions map to ROCm
 compatibility:
 
-| Project version | ROCm target | Package name    | Installed binary               |
-| :-------------- | :---------- | :-------------- | :----------------------------- |
-| rvs-1.0.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras/bin/rvs7`    |
-| rvs-1.1.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras/bin/rvs7`    |
-| rvs-1.2.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras/bin/rvs7`    |
-| rvs-2.0.0       | ROCm 8.x    | `amdrocm8-rvs`  | `/opt/rocm/extras/bin/rvs8`    |
-
-All four install into the same `/opt/rocm/extras/` tree; the ROCm major
-is carried by the binary suffix (`rvs7` / `rvs8`), not a per-major
-directory.
+| Project version | ROCm target | Package name    | Install path          |
+| :-------------- | :---------- | :-------------- | :-------------------- |
+| rvs-1.0.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
+| rvs-1.1.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
+| rvs-1.2.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
+| rvs-2.0.0       | ROCm 8.x    | `amdrocm8-rvs`  | `/opt/rocm/extras-8/` |
 
 ### Release Principles
 
@@ -177,19 +142,18 @@ directory.
 ROCm 7.0  ─────── ROCm 7.1 ─────── ROCm 7.2 ──────── ROCm 8.0
   │                  │                  │                  │
   ├─ rvs-1.0.0       │                  │                  │
-  │  (bin/rvs7)      ├─ rvs-1.1.0       │                  │
-  │                  │  (bin/rvs7)      │                  │
+  │  (extras-7)      ├─ rvs-1.1.0       │                  │
+  │                  │  (extras-7)      │                  │
   │                  │    ├─ rvs-1.1.1  │                  │
-  │                  │    (bin/rvs7)    ├─ rvs-1.2.0       │
-  │                  │                  │  (bin/rvs7)      │
+  │                  │    (extras-7)    ├─ rvs-1.2.0       │
+  │                  │                  │  (extras-7)      │
   │                  │                  │                  ├─ rvs-2.0.0
-  │                  │                  │                  │  (bin/rvs8)
+  │                  │                  │                  │  (extras-8)
 ```
 
-In this timeline, all RVS 1.x releases install as `rvs7` and work with
+In this timeline, all RVS 1.x releases land in `extras-7` and work with
 any ROCm 7.x release. When ROCm 8.0 introduces breaking ABI changes, RVS
-publishes a new major version (2.0.0) that installs as `rvs8` alongside
-`rvs7` in the same `/opt/rocm/extras/` tree.
+publishes a new major version (2.0.0) that installs into `extras-8`.
 
 ## 3. Compatibility with ROCm Releases
 
@@ -248,52 +212,37 @@ different ROCm major families must not be mixed.
 
 ## 4. Installed Package Directory Structure
 
-Extras packages install under a single `/opt/rocm/extras/` prefix following
+Extras packages install under `/opt/rocm/extras-<rocm-major>/` following
 the
 [ROCm Linux Filesystem Hierarchy Standard](https://rocm.docs.amd.com/en/latest/conceptual/file-reorg.html)
 and the conventions established in
-[RFC0009](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md). There is **no
-per-major directory** — every extra, regardless of which ROCm major it
-targets, installs into this one tree. Side-by-side support across ROCm
-majors is provided by a **versioned binary name**: the public executable
-is suffixed with the ROCm major (`rvs7`, `rvs8`), and an unsuffixed
-symlink (`rvs` → `rvs7`) resolves to the latest installed major. Shared
-libraries use **ordinary project-version SONAMEs** (`librvs.so` →
-`librvs.so.1` → `librvs.so.1.2.0`); the ROCm major is **not** encoded in
-the `.so` version. The layout is otherwise **flat** — public binaries and
-libraries from every extras project share the common `bin/` and `lib/`,
-with project-specific subfolders under `include/`, `share/`, and the
-private `lib/`/`libexec/` component directories for namespace isolation.
-
-> **Distribution vs. install layout.** This section describes the *installed*
-> on-disk layout. The *distribution* layout on the AMD repository
-> (`repo.amd.com`) is a separate concern, defined in
-> [RFC0012 — Repository Structure (PR #4414)](https://github.com/ROCm/TheRock/pull/4414):
-> extras are distributed from a single `extras/` folder with per-project
-> subfolders, and the ROCm major version is carried in the *package name*
-> (`amdrocm<major>-<project>`) rather than the repository path. On the
-> installed side, the ROCm major is carried by the binary suffix
-> (`/opt/rocm/extras/bin/rvs7`) rather than a per-major install prefix;
-> libraries use ordinary project-version SONAMEs.
+[RFC0009](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md). The extras
+tree version matches the ROCm major version it targets, so `extras-7`
+contains all extras built for ROCm 7.x. The layout is **flat** — all
+binaries, libraries, and headers from every extras project are merged into
+this single prefix, with project-specific subfolders under `include/` and
+`share/` for namespace isolation.
 
 ### Layout
 
 ```
-/opt/rocm/extras/
+/opt/rocm/extras-<rocm-major>/
     | -- bin
-    |      | -- <component><rocm-major>          # versioned public binary (e.g. rvs7)
-    |      | -- <component> -> <component><rocm-major>   # symlink to the latest major
+    |      | -- all public binaries across extras projects
     | -- lib
-    |      | -- lib<soname>.so -> lib<soname>.so.<proj-major> -> lib<soname>.so.<proj-ver>   # ordinary project-version SONAME (no ROCm major)
-    |      | -- <component><rocm-major>          # private arch-dependent libs/modules, major-scoped so runtimes coexist
+    |      | -- lib<soname>.so -> lib<soname>.so.major -> lib<soname>.so.major.minor.patch
+    |      |      (public libraries to link with applications)
+    |      | -- <component>
+    |      |      | -- architecture dependent libraries and binaries used internally
     |      | -- cmake
     |             | -- <component>
-    |                    | -- <component>-config.cmake   # dev files (resolve to the latest major)
+    |                    | -- <component>-config.cmake
     | -- libexec
-    |      | -- <component><rocm-major>          # private executables used internally, major-scoped
+    |      | -- <component>
+    |             | -- non-ISA/architecture independent executables used internally
     | -- include
     |      | -- <component>
-    |             | -- public header files       # dev files (latest major)
+    |             | -- public header files
     | -- share
            | -- html
            |      | -- <component>
@@ -312,44 +261,30 @@ private `lib/`/`libexec/` component directories for namespace isolation.
                   | -- architecture independent misc files (configs, test assets)
 ```
 
-Where `<rocm-major>` is the ROCm major version the extra targets (e.g.,
-`7` for ROCm 7.x), `<component>` is the individual project name (e.g.,
-`rvs`), `<proj-major>` is the project's own SONAME major, and `<proj-ver>`
-is the project's full semantic version (e.g., `1.2.0`). Only the `bin/`
-executable and the private `lib/`/`libexec/` component directories carry
-the ROCm major (so multiple majors coexist); the public `lib*.so` uses an
-ordinary project-version SONAME with **no** ROCm major, and
-development-only files (`include/`, `lib/cmake/`) stay per-project and
-resolve to the latest installed major.
+Where `<rocm-major>` is the ROCm major version the extras target (e.g.,
+`7` for ROCm 7.x), and `<component>` is the individual project name
+(e.g., `rvs`).
 
 ### Symlinks
 
-Unversioned symlinks provide stable paths that resolve to the latest
-installed ROCm major:
+A soft link provides a stable unversioned path that resolves to the latest
+installed extras tree:
 
 ```
-/opt/rocm/extras/bin/rvs        -> rvs7
-```
-
-Shared libraries keep their conventional development symlink resolving to
-the project SONAME (not the ROCm major):
-
-```
-/opt/rocm/extras/lib/librvs.so  -> librvs.so.1 -> librvs.so.1.2.0
+/opt/rocm/extras/         -> /opt/rocm/extras-7
 ```
 
 ### RVS Example
 
-A concrete installation containing RVS 1.2.0 built for ROCm 7.x:
+A concrete installation of the `extras-7` tree containing RVS 1.2.0:
 
 ```
-/opt/rocm/extras/
+/opt/rocm/extras-7/
     | -- bin
-    |      | -- rvs7                           # Main RVS executable (ROCm 7.x)
-    |      | -- rvs -> rvs7                     # symlink to the latest major
+    |      | -- rvs                            # Main RVS executable
     | -- lib
-    |      | -- librvs.so -> librvs.so.1 -> librvs.so.1.2.0   # ordinary project SONAME (no ROCm major)
-    |      | -- rvs7                            # private RVS modules for ROCm 7.x
+    |      | -- librvs.so -> librvs.so.1 -> librvs.so.1.2.0
+    |      | -- rvs
     |      |      | -- libgst.so               # GPU Stress Test module
     |      |      | -- libiet.so               # Input EDPp Test module
     |      |      | -- libpeqt.so              # PCI-Express Qualification Test module
@@ -361,8 +296,8 @@ A concrete installation containing RVS 1.2.0 built for ROCm 7.x:
     |                    | -- rvs-config.cmake
     |                    | -- rvs-targets.cmake
     | -- libexec
-    |      | -- rvs7
-    |             | -- rvs_worker               # Internal worker process (ROCm 7.x)
+    |      | -- rvs
+    |             | -- rvs_worker               # Internal worker process
     | -- include
     |      | -- rvs
     |             | -- rvs.h
@@ -386,30 +321,30 @@ A concrete installation containing RVS 1.2.0 built for ROCm 7.x:
 ```
 
 When RVS releases a new version (e.g., rvs-1.3.0) while still targeting
-ROCm 7, the updated files replace the `rvs7` binary in-place — the
-ROCm-major suffix does not change — and the library advances its ordinary
-project SONAME (`librvs.so.1.3.0`). The `rvs` symlink continues to point
-at `rvs7` until a newer ROCm major is installed.
+ROCm 7, the updated files are installed in-place into the same `extras-7`
+tree. The extras tree version does not change — only the individual project
+binaries and libraries within it are upgraded.
+
+Symlink:
+
+```
+/opt/rocm/extras/         -> /opt/rocm/extras-7
+```
 
 ### Multiple Extras Projects
 
 When more than one extras project is installed, all projects merge into the
-same flat prefix. Each public binary keeps its ROCm-major suffix, and the
-project-specific subfolders under `include/` and `share/` prevent namespace
-collisions:
+same flat prefix. The project-specific subfolders under `include/` and
+`share/` prevent namespace collisions:
 
 ```
-/opt/rocm/extras/
+/opt/rocm/extras-7/
     | -- bin
-    |      | -- rvs7
-    |      | -- rvs -> rvs7
-    |      | -- rocm-bench7
-    |      | -- rocm-bench -> rocm-bench7
+    |      | -- rvs
+    |      | -- rocm-bench
     | -- lib
-    |      | -- librvs.so -> librvs.so.1 -> librvs.so.1.2.0
-    |      | -- librocmbench.so -> librocmbench.so.3 -> librocmbench.so.3.0.0
-    |      | -- rvs7
-    |      | -- rocm-bench7
+    |      | -- librvs.so
+    |      | -- librocmbench.so
     |      | -- cmake
     |             | -- rvs
     |             |      | -- rvs-config.cmake
@@ -435,35 +370,19 @@ collisions:
 
 ### Side-by-Side Installation
 
-When multiple ROCm major versions are installed on the same system, both
-sets of artifacts coexist within the **same** `/opt/rocm/extras/` tree —
-there is no per-major directory. The ROCm-major suffix on each binary
-(and on the private module directory) keeps the executables from
-colliding. The public libraries do **not** carry the ROCm major; they
-coexist through ordinary SONAME versioning because an extra bumps its own
-major when it retargets a new ROCm major (RVS 1.x → ROCm 7, RVS 2.x →
-ROCm 8):
+When multiple ROCm major versions are installed on the same system, a
+separate extras tree exists for each. This allows side-by-side operation
+without conflicts:
 
 ```
-/opt/rocm/extras/
-    | -- bin
-    |      | -- rvs7
-    |      | -- rvs8
-    |      | -- rvs -> rvs8                      # latest ROCm major wins
-    | -- lib
-           | -- librvs.so.1 -> librvs.so.1.2.0   # RVS 1.x (built for ROCm 7)
-           | -- librvs.so.2 -> librvs.so.2.0.0   # RVS 2.x (built for ROCm 8)
-           | -- librvs.so -> librvs.so.2         # newest project SONAME
-           | -- rvs7                             # ROCm 7 private modules
-           | -- rvs8                             # ROCm 8 private modules
+/opt/rocm/extras-7/
+/opt/rocm/extras-8/
+/opt/rocm/extras/         -> /opt/rocm/extras-8
 ```
 
-Within a single ROCm major (e.g. `rvs7`), project upgrades are installed
-in-place — there is no side-by-side at the individual project level. The
-ROCm major version is the only axis of side-by-side support. Development
-files (`include/`, `lib/cmake/`) are not major-suffixed and reflect the
-most recently installed major; consumers needing headers for a specific
-older major should install that major last or use a dedicated environment.
+Within a single extras tree (e.g., `extras-7`), project upgrades are
+installed in-place — there is no side-by-side at the individual project
+level. The ROCm major version is the only axis of side-by-side support.
 
 ### Environment Integration
 
@@ -475,11 +394,11 @@ snippet:
 ```
 
 This adds `/opt/rocm/extras/bin` to `$PATH` and `/opt/rocm/extras/lib` to
-`$LD_LIBRARY_PATH` (or the equivalent `ld.so.conf.d` drop-in). Because all
-majors share the one tree, a single profile snippet covers every extras
-project and every ROCm major. Invoking `rvs` runs the latest installed
-major (via the `rvs` → `rvs7` symlink); to target a specific major, call
-the suffixed binary directly (`rvs7`, `rvs8`).
+`$LD_LIBRARY_PATH` (or the equivalent `ld.so.conf.d` drop-in). Because the
+layout is flat, a single profile snippet covers all extras projects. Users
+can target a specific ROCm major version by pointing directly at
+`/opt/rocm/extras-7/bin` instead of the symlink, or by using environment
+modules.
 
 ## 5. Packaging Formats
 
@@ -744,7 +663,7 @@ into the flat FHS layout described in Section 4:
 
 ```bash
 tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
-    -C /opt/rocm/extras/
+    -C /opt/rocm/extras-7/
 ```
 
 Tarball naming follows the pattern:
@@ -772,7 +691,7 @@ amd-smi version
 
 # Extract the end-user project into the extras tree
 tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
-    -C /opt/rocm/extras/
+    -C /opt/rocm/extras-7/
 ```
 
 **Option 2: ROCm installed from tarball**
@@ -787,7 +706,7 @@ tar -xf amdrocm-core-7.1.0-linux-x86_64.tar.xz \
 
 # Extract the end-user project
 tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
-    -C /opt/rocm/extras/
+    -C /opt/rocm/extras-7/
 ```
 
 **Option 3: ROCm installed via Python packages**
@@ -800,7 +719,7 @@ libraries reside inside the Python site-packages directory. Use
 ROCM_ROOT=$(rocm-sdk path --root)
 
 tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
-    -C /opt/rocm/extras/
+    -C /opt/rocm/extras-7/
 ```
 
 #### Connecting Project Binaries with ROCm Libraries
@@ -826,7 +745,7 @@ or when `$ORIGIN` RPATH does not cover the layout:
 ```bash
 export ROCM_PATH=/opt/rocm/core-7
 export LD_LIBRARY_PATH=${ROCM_PATH}/lib:${LD_LIBRARY_PATH}
-export PATH=/opt/rocm/extras/bin:${ROCM_PATH}/bin:${PATH}
+export PATH=/opt/rocm/extras-7/bin:${ROCM_PATH}/bin:${PATH}
 ```
 
 **Option 3: `ld.so.conf.d` drop-in (system-wide, requires root)**
@@ -847,7 +766,7 @@ paths per user or per job:
 ```tcl
 # /opt/modulefiles/rocm-extras/7
 set     rocm_root    /opt/rocm/core-7
-set     extras_root  /opt/rocm/extras
+set     extras_root  /opt/rocm/extras-7
 
 prepend-path  PATH             $extras_root/bin
 prepend-path  PATH             $rocm_root/bin
@@ -871,7 +790,7 @@ end-user project binaries can find all required ROCm libraries:
 
 ```bash
 # Check that all shared library dependencies resolve
-ldd /opt/rocm/extras/bin/rvs7
+ldd /opt/rocm/extras-7/bin/rvs
 
 # Run the project's built-in sanity check (if available)
 rvs -d 1 -g
@@ -887,57 +806,21 @@ API, CLI tool, or test harness written in Python. Native-only extras
 projects like RVS do not produce wheels.
 
 When applicable, extras wheels follow the conventions described in the
-[Python packaging documentation](/docs/packaging/python_packaging.md).
+[Python packaging documentation](/docs/packaging/python_packaging.md):
 
-> **Wheel naming differs from native packages.** Unlike DEB/RPM packages,
-> a Python wheel **does not embed the ROCm major version in its distribution
-> name**. The wheel is named `rocm-<project>` (e.g., `rocm-rvs`), and the
-> ROCm major version is carried by metadata instead. This follows Python
-> packaging norms — PyPI treats `rocm7-rvs` and `rocm8-rvs` as unrelated
-> projects, which breaks `pip`'s upgrade and conflict resolution — and avoids
-> squatting a new PyPI name for every ROCm major.
-
-The target ROCm major version is encoded by **doing both** of the following,
-so the binding is visible to humans *and* enforced by the resolver:
-
-1. **PEP 440 local-version segment.** Each wheel carries a `+rocm<major>`
-   local-version tag, so the compatibility target is visible in the version
-   string and in `pip list`:
-
-   ```
-   rocm_rvs-1.2.0+rocm7-py3-none-linux_x86_64.whl   # RVS 1.2.0 for ROCm 7.x
-   rocm_rvs-2.0.0+rocm8-py3-none-linux_x86_64.whl   # RVS 2.0.0 for ROCm 8.x
-   ```
-
-2. **Non-overlapping `Requires-Dist` range.** The wheel declares a dependency
-   on the ROCm SDK Python packages pinned to a single major version. The
-   ranges across majors never overlap, so `pip` can only resolve a wheel
-   against a matching ROCm install:
-
-   ```
-   Requires-Dist: rocm[core] >=7.0, <8.0
-   ```
-
+- **Selector package**: A source distribution (`rocm<major>-<project>`)
+  that evaluates install-time constraints and pulls the correct runtime
+  wheels.
 - **Runtime wheels**: Contain the minimal set of files needed to run,
   with no symlinks. SONAME libraries are included directly.
 - **Devel wheels**: Catch-all for headers, CMake files, and symlinks
   stored in a `_devel.tar` inside the wheel.
 
-**PyPI name reservation.** To prevent dependency-confusion attacks, the
-`rocm-<project>` name should be reserved (registered) on public PyPI even if
-the wheels are primarily distributed through AMD's own index. This blocks a
-malicious actor from publishing a same-named package that `pip` might prefer.
-
-**Pinning across a fleet.** `pip` has no `apt-mark hold` equivalent, so
-fleet-wide version control is done with a constraints file:
+Wheels declare a dependency on the ROCm SDK Python packages for the
+matching major version:
 
 ```
-# rocm-constraints.txt
-rocm-rvs==1.2.0+rocm7
-```
-
-```bash
-pip install -c rocm-constraints.txt rocm-rvs
+Requires-Dist: rocm[core] >=7.0, <8.0
 ```
 
 Example build:
@@ -948,18 +831,10 @@ build_tools/build_python_packages.py \
     --dest-dir ./OUTPUT_PKG
 ```
 
-Example install (resolver selects the major via `Requires-Dist` against the
-installed ROCm):
+Example install:
 
 ```bash
-pip install rocm-rvs --pre \
-    --find-links=./OUTPUT_PKG/dist
-```
-
-Example install (explicitly pinned to a ROCm major):
-
-```bash
-pip install "rocm-rvs==1.2.0+rocm7" --pre \
+pip install rocm7-mytool --pre \
     --find-links=./OUTPUT_PKG/dist
 ```
 

--- a/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
+++ b/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
@@ -1,415 +1,850 @@
 ---
-author: Saad Rahim (saadrahim)
-created: 2026-04-08
-modified: 2026-05-28
+author: Freddy Paul
+created: 2026-04-14
+modified: 2026-04-14
 status: draft
 ---
 
-# ROCm software ecosystem package repository structure
+# ROCm End-User Projects With Independent Release Lifecycle
 
-## Related RFCs
+## 1. Overview
 
-- **RFC0008** — multi-arch Python wheels and device extras (source of the
-  `pyindex/multi-arch/` model used here).
-- **RFC0009** — native packaging conventions (source of the
-  `amdrocm<major>-<project>` package-naming family referenced for extras).
-- **RFC0012** — end-user projects independent release lifecycle (defines
-  the per-project release model for extras; this RFC defines where those
-  artifacts land on `repo.amd.com`).
+ROCm ships a core SDK through TheRock build system. In addition to the core
+SDK, AMD and the broader community maintain a set of **extras** — tools,
+validation suites, and utility projects — that are compiled *on top of* a
+released ROCm Core SDK installation but follow their own development and
+release timelines. These extras are not part of the ROCm Core SDK; they
+consume ROCm as a build dependency and are delivered as independently
+versioned packages.
 
-## Overview
+The ROCm Validation Suite (RVS) is the canonical example of such a project.
+RVS exercises GPU hardware and the ROCm software stack through a collection
+of test modules (GPU Properties, PCI-Express Bandwidth, GPU Stress Test,
+Memory Test, etc.) and is used by datacenter operators, OEMs, and developers
+to qualify ROCm deployments. RVS depends on the ROCm runtime, HIP, and
+several ROCm libraries, yet its feature roadmap and release schedule are
+driven by validation requirements that are independent of the ROCm Core SDK
+release cadence.
 
-repo.amd.com's open source software release publications need standardization. In scope is the ROCm software ecosystem which spans the ROCm Core SDK, expansions like ROCm-DS, and standalone projects like RVS. Software packaging for this ecosystem needs a well defined hierarchy reflected in the package distribution folder structure. As software is published on repo.amd.com, the planned hierarchy must be extensible by other software ecosystem published by AMD. As a result, this proposal includes the ability to add the AMD GPU driver to this structure in the future.
+### Goals
 
-## Definitions
+1. **Decouple extras from the ROCm release train** so that bug fixes,
+   new test modules, and feature enhancements can ship without waiting for
+   the next ROCm Core SDK release.
+2. **Guarantee backward compatibility within a ROCm major version release stream**
+   so that a single extras build works across every minor and patch release
+   of that major version.
+3. **Provide a clear installation layout** that coexists with the ROCm
+   Core SDK directory structure defined in
+   [RFC0009](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md) without
+   creating conflicts or ambiguity.
+4. **Enable community and partner contributions** by keeping the extras
+   repositories buildable against any compatible, publicly released
+   ROCm Core SDK installation.
 
-- Repository Streams
-  - nightly - nightly builds from the develop branch
-  - stablerc - release candidate builds for the next stable release
-  - stable - GA releases of ROCm with a short term support lifecycle, tagged as ROCm releases.
-  - ltsrc - *(future)* release candidate builds for the next LTS release
-  - lts - *(future)* long term stability (LTS) releases
+### Scope
 
-  > **Note on stream vocabulary:** RFC0012 does not define a strict
-  > stream taxonomy for extras — it only states that extras may publish
-  > "nightly / pre-release builds … to a staging repository for early
-  > validation" alongside ordinary releases. The canonical streams on
-  > `repo.amd.com` are the ones defined in this RFC
-  > (`nightly`/`stablerc`/`stable`, with `ltsrc`/`lts` reserved).
-  > Per-extra publishing maps into those streams as follows: nightly /
-  > staging builds → `nightly/`, pre-release builds intended for QA →
-  > `stablerc/`, GA releases → `stable/`. Each extra's release notes
-  > record which stream a given build landed in.
-- Products
-  - Core SDK
-  - expansions - SDK built with dependencies on the ROCm Core SDK
-    - HPC SDK - a ROCm expansion released on its own cadence, pinned to a single ROCm version per release
-  - extras - standalone components part of ROCm
-- pyindex - top-level folder for the ROCm Python package indices. Contains
-  two sibling indices (see "Python Indices" section):
-  - `pyindex/multi-arch/` — multi-arch index requiring explicit device
-    extras (e.g. `pip install rocm[device-gfx942]`)
-  - `pyindex/multi-arch-compat/` — backward-compatible multi-arch index
-    where `pip install rocm` pulls in all device extras automatically
+#### In Scope
 
-## Repository Structure
+- Release cadence and versioning for extras/tools projects
+- ROCm major-version compatibility contract
+- Directory layout and packaging conventions for installed extras
+- ROCm Validation Suite (RVS) as the reference implementation
 
-`repo.amd.com` will have the following folder structure:
+#### Out of Scope
 
-- **amdgpu** *(reserved for future use; follows the same stream structure as `rocm-platform`: **nightly**, **stablerc**, **stable**, **ltsrc**, **lts**)*
-- **amdrepos**
-  - packages
-    - **Linux Distros [a–z]**
-- **archives** *(unmaintained releasees, for reference only)*
-- **rocm** (current rocm folder with non production releases, move to archives in 6 months)
-- **rocm-platform**
+- ROCm Core SDK packaging (covered by RFC0009)
+- GPU driver packaging
+- Internal CI/CD pipeline specifics of individual extras projects
+- ROCm Expansion SDK requirements need a parallel RFC to the requirements in this PR. 
+- These requirements is for software that releases individually and islimited to one version installed per major ROCm version.
+## 2. Release Cadence
 
-  - **nightly** *(Retention policy: 30 dev, 120 nightly)*
-    - **pyindex** *(see Python Indices section)*
-      - **multi-arch** *(device extras specified manually)*
-      - **multi-arch-compat** *(backward-compatible; `pip install rocm` pulls in all device extras)*
-    - **core**
-      - tarball
-      - zip
-      - installers
-      - whl
-      - packages
-        - **Linux Distros [a–z]**
-    - **windows**
-      - MSI and EXE files for Windows
-    - **expansions [a–z]** *(e.g. **hpc-sdk** — see HPC SDK Release Model section)*
-      - tarball
-      - whl
-      - packages
-    - **extras-[ROCm-major]** #projects released independently for each ROCm major version
-      - **Decision:** per-project folder structure on `repo.amd.com` (each
-        extra gets its own folder; allows S3 bucket permission granularity
-        by group). A flat distribution structure was considered and rejected.
-      - **Distribution vs install layout — these are separate concerns
-        and do not conflict:**
-        - *Distribution layout* (this RFC, on `repo.amd.com`): **per
-          project**. Each extra has its own folder under
-          `extras-[ROCm-major]/` (e.g.
-          `rocm-platform/stable/extras-7/rvs/`,
-          `.../extras-7/rocoptiq/`). Chosen so S3 bucket permissions can
-          be granted per project/group.
-        - *Install layout* (RFC0012, on the user's disk): **flat**. After
-          install, all extras for a given ROCm major share a single
-          merged tree (e.g. `/opt/rocm/extras-7/bin/`,
-          `/opt/rocm/extras-7/lib/`, ...) — binaries and libraries from
-          different extras live side-by-side, not in per-project
-          subdirectories.
-        - The two layouts are independent: per-project folders on
-          `repo.amd.com` are how artifacts are *published and
-          permissioned*; the flat tree under `/opt/rocm/extras-7/` is how
-          they are *installed and consumed*. A reader should not infer
-          that the on-disk layout mirrors the publication folders, or
-          vice versa. RFC0012 is the source of truth for the install
-          layout.
-        - **Name-collision note:** the string `extras-7` appears in both
-          places (`rocm-platform/<stream>/extras-7/` here and
-          `/opt/rocm/extras-7/` in RFC0012) **because both are scoped to
-          the ROCm major version**, not because one mirrors the other.
-          The matching name is a coincidence of versioning, not a layout
-          guarantee — distribution folders and install prefixes remain
-          governed by their respective RFCs.
-      - **Package naming:** native packages for extras follow the
-        `amdrocm<major>-<project>` convention on `repo.amd.com` (e.g.
-        `amdrocm7-rvs`, `amdrocm7-rocoptiq`); the **distro-native**
-        equivalent shipped through distro repositories is
-        `rocm<major>-<project>` (e.g. `rocm7-rvs`). Optional `-devel` /
-        `-dev` sibling packages follow the same prefix when an extra
-        exposes a public API. See RFC0009 and RFC0012 §5 for the full
-        naming and split rules.
-      - **Versioning:** extras use **semver**
-        (`<project>-<major>.<minor>.<patch>`, e.g. `rvs-1.2.0`) per
-        RFC0012 §2. The date-based `YYYY.MM` scheme used elsewhere in
-        this RFC is **HPC-SDK-only** and must not be applied to extras.
-      - **Python wheels for extras:** when an extra ships a wheel, the
-        selector package is named `rocm<major>-<project>` (per RFC0012
-        §5) and declares `Requires-Dist: rocm[core] >=X.0, <(X+1).0`.
-        Wheels are published through `pyindex/multi-arch{,-compat}/`
-        like all other ROCm wheels.
-      - **Major-version compatibility:** each `extras-[ROCm-major]`
-        directory is the compatibility boundary. An extra published under
-        `extras-7` is guaranteed to install against any ROCm 7.x Core SDK
-        release; cross-major compatibility is not promised. See RFC0012
-        for the full compat contract.
-      - **rvs**
-        - tarball
-        - packages
-      - **rocoptiq**
-        - tarball
-        - whl
-        - packages
-      - **omnistat**
-        - whl
-    - **pytorch**
-      - **nightly**
-        - whl
-      - **stablerc**
-        - whl
-      - **stable**
-        - whl
-    - **jax** *(follows the same stream and artifact rules as **pytorch**)*
-    - **onnx-runtime** *(follows the same stream and artifact rules as **pytorch**)*
+Extras projects follow an **independent release cadence** that is not tied
+to the ROCm Core SDK release schedule.
 
-  - **stablerc** *(Retention policy: 2 years)*
+Each extras project may set an appropriate release cadence for the project in
+conjunction with its stakeholders.
 
-    - Release candidate builds for the next stable release
-    - Mirrors nightly folder structure
-    - Tested by QA
-    - Must match structure of `repo.amd.com`
+### Versioning Scheme
 
-  - **stable**
-
-    - Current ROCm Core release from TheRock
-    - **standard** (includes default build packages, asan build packages, default-debug symbol packages, and asan-debug system packages)
-    - **rpath** (includes rpath variant of standard packages)
-
-  - **ltsrc** — long term support release candidate *(future; Retention policy: 2 years)*
-
-    - Release candidate builds for the next LTS release
-    - Mirrors stable folder structure
-
-  - **lts** — long term support *(future)*
-
-    - `YYYYMM`
-      - Mirrors stable folder structure
-
-## Python Indices
-
-ROCm publishes wheels through two parallel multi-arch indices, per the
-direction in ROCm/TheRock#5289. Per-family indices were considered and
-rejected — only the two multi-arch flavors below are in scope.
-
-- **`pyindex/multi-arch/`** — multi-arch index where the user explicitly
-  picks the device extras they need. Smaller installs, but the user
-  must know their target architecture.
-  ```
-  pip install --index-url https://repo.amd.com/.../pyindex/multi-arch/ rocm[device-gfx942]
-  ```
-
-- **`pyindex/multi-arch-compat/`** — backward-compatible multi-arch
-  index. `pip install rocm` (or `pip install torch`) pulls in **all**
-  device extras automatically, matching the "it just works" behavior
-  users expect from `pip install torch --index-url
-  https://download.pytorch.org/whl/rocm7.2`. Larger download (~5.5 GB
-  for the torch case), but no architecture knowledge required.
-  ```
-  pip install --index-url https://repo.amd.com/.../pyindex/multi-arch-compat/ rocm
-  ```
-
-Both indices ship under every stream that publishes wheels (`nightly`,
-`stablerc`, `stable`; not `ltsrc`/`lts` until LTS exists), and both are
-built from the same underlying wheel set — `multi-arch-compat/` simply
-republishes the entry-point wheels (`rocm`, `torch`, `torchvision`, …)
-with `device-all` added as an automatic requirement, plus links to the
-unmodified device wheels in `multi-arch/` so storage is not duplicated.
-
-Future direction: WheelNext (`uv pip install` with a wheel-variant
-provider backed by `rocm-bootstrap`) is the long-term plan and will
-eventually make `multi-arch-compat/` unnecessary. Until that lands and
-is widely adopted, both indices must coexist.
-
-**Native multi-arch (parallel mechanism):** the `pyindex/` paths above
-cover the **wheel** side of multi-arch. The **native-package** side is
-covered by `rocm-kpack` per RFC0008 — host and device code are split
-into separate packages, with device code shipped either as
-per-architecture packages (`amdrocm-<library>-gfx<arch>`) or loaded at
-runtime from kpack archives. These device packages and the
-architecture-family meta-packages that group them
-(`rocm-gfx94X`, `rocm-gfx90X`, etc.) are published under
-`rocm-platform/<stream>/core/packages/<distro>/` alongside the host
-ROCm Core SDK packages — they are not a separate folder. Wheel
-multi-arch (`pyindex/`) and native multi-arch (`rocm-kpack`) are
-sibling mechanisms: wheel users go through `pyindex/`, native users
-install the matching device or `rocm-gfx<family>X` package from
-`core/packages/`. RFC0008 owns the full multi-arch contract for both
-sides.
-
-## Third Party AI Forks
-
-`pytorch`, `jax`, and `onnx-runtime` are **ROCm forks/builds of upstream
-third-party AI frameworks**, not first-party AMD projects. They are
-published on `repo.amd.com` so users can pick up ROCm-enabled wheels
-without having to build them locally, but the upstream project owns the
-source of truth and the release cadence for the framework itself.
-
-Rules that apply to all third-party AI forks:
-
-- **Upstream tracking:** each entry mirrors a specific upstream release
-  (or upstream nightly), with ROCm patches applied on top. Metadata in
-  every artifact records the upstream version and the ROCm version it
-  was built against.
-- **Streams:** published only under `nightly/`, `stablerc/`, and
-  `stable/`. Not published under `ltsrc/` or `lts/` — long-term-support
-  guarantees do not extend to third-party fork builds.
-- **Artifact format:** `whl` only. No tarballs, no native distro
-  packages — users install via `pip` from the matching ROCm wheel index.
-- **Dependency rule:** framework wheels must depend **only on Python
-  wheels of the ROCm Core SDK** (published under `core/whl/` and surfaced
-  through `pyindex/`). They must not depend on system packages, native
-  distro packages, or any non-wheel ROCm artifact. This keeps `pip
-  install` of a framework wheel fully self-contained and reproducible
-  across distros.
-- **Versioning:** uses the upstream framework's own version string
-  (e.g. PyTorch's `2.x.y+rocm<rocm-version>` convention), not the ROCm
-  `YYYYMM`/`YYYY.MM` scheme.
-- **Support model:** bug fixes for the ROCm-specific delta ship in the
-  next stream promotion; we do not back-patch older third-party fork
-  releases.
-- **Coverage list:** `pytorch`, `jax`, `onnx-runtime`. New third-party
-  forks added to `repo.amd.com` follow this same model by default.
-
-## Dependency Closure for Expansions and Extras
-
-Every package published under `expansions/` and `extras-[ROCm-major]/`
-must declare a **complete dependency chain**. The goal is that a single
-one-line install command for any expansion or extra pulls in every
-required component automatically, with no manual follow-up.
-
-Rules:
-
-- **Native packages (rpm/deb):** `Requires:` / `Depends:` must list every
-  ROCm Core SDK package, expansion, or extra the component needs at
-  runtime, at the exact (or minimum-compatible) versions. A `yum install
-  <pkg>` or `apt install <pkg>` must succeed without the user adding
-  ROCm Core SDK packages by hand.
-- **Python wheels:** `install_requires` / `Requires-Dist` must list every
-  ROCm Core SDK wheel (and any other expansion wheel) the component
-  needs. A `pip install <pkg> --index-url <pyindex>` must pull in the
-  full chain.
-- **Cross-format:** packages must not silently rely on a parallel
-  artifact in a different format (e.g. an rpm that quietly needs a wheel
-  to be installed, or vice versa). Each install path must be
-  self-sufficient.
-- **Host-only dependencies for extras (transitive chains stop at host
-  packages):** the **typical case** for extras (RFC0012 §5) is that
-  they call ROCm host APIs and do not ship their own GPU device code.
-  In that case, extras declare hard dependencies only on host-side ROCm
-  Core SDK packages (compilers, runtimes, host libraries). The
-  transitive dependency chain must terminate at host packages —
-  consuming-only extras must never pull in a specific GPU architecture
-  or any `amdrocm<major>-<library>-gfx*` device package as a hard
-  requirement, directly or transitively. Device coverage is the user's
-  choice at install time, selected via the multi-arch wheel index
-  (`pyindex/multi-arch/` with explicit `device-gfxNNNN` extras) or by
-  installing the matching device or architecture-family meta-packages
-  (e.g. `rocm-gfx94X`) alongside the extra. Recommended/suggested deps
-  (rpm `Recommends:`, deb `Recommends:`) are allowed for discoverability
-  but must remain non-hard.
-
-  - **Exception — extras that ship their own GPU kernels (RFC0012 §5,
-    "rare case"):** when an extra produces its own pre-compiled device
-    code, it must be split into per-architecture package variants named
-    `amdrocm<major>-<project>-gfx<arch>` (e.g.
-    `amdrocm7-mytool-gfx942`). Each architecture variant **may**
-    declare a hard dependency on the matching ROCm library device
-    package (e.g. `amdrocm-blas-gfx942`). The host-only rule applies
-    only to the consuming case; kernel-shipping extras are explicitly
-    exempt for their own device variants and only for them. The host
-    (non-`-gfx*`) package of such an extra still follows the host-only
-    rule.
-
-  - **CI enforcement:** the dependency-closure check runs in a
-    **host-only image** for every consuming extra; pulling in any
-    device package as a hard dep fails the publish. Kernel-shipping
-    `-gfx<arch>` variants are tested in an image with the matching
-    device packages installed.
-
-  This rule mirrors the device-extras model in RFC0008 and the
-  end-user-project dependency rules in RFC0012 §5, and applies to both
-  native packages and Python wheels.
-- **CI enforcement:** the publish pipeline runs a clean-environment
-  install test for every expansion and extra in each stream
-  (`nightly`/`stablerc`/`stable`) on every supported distro. Missing
-  transitive dependencies fail the publish.
-- **Meta-packages:** umbrella packages such as `amdrocm-hpc-YYYY.MM` (HPC
-  SDK) inherit this rule and additionally declare their hard dependency
-  on the pinned ROCm Core SDK version.
-
-## HPC SDK Release Model
-
-The HPC SDK is a ROCm expansion and is published under the `expansions [a–z]`
-folder of the matching `rocm-platform` stream (nightly, stablerc, stable,
-ltsrc, lts). Unlike other expansions, it is released on its own cadence — decoupled
-from ROCm release cadence — and uses date-based versioning. This mirrors the
-model used by NVIDIA's HPC SDK, which is published independently of CUDA
-releases.
-
-- **Cadence:** approximately 4 releases per year. Not every ROCm release will
-  have a corresponding HPC SDK release.
-- **Versioning:** date-based, `YYYY.MM` (e.g. `2026.06`). Versioning is
-  intentionally independent of ROCm version numbers to make the decoupling
-  explicit and avoid mix-and-match confusion.
-- **ROCm pinning:** each HPC SDK release is pinned to exactly one ROCm Core
-  SDK version. Pinning follows the stream:
-  - stable HPC SDK pins to a stable ROCm Core SDK release.
-  - LTS HPC SDK (when available) pins to an LTS ROCm Core SDK release.
-  Both streams coexist once LTS exists; a stable HPC SDK release is always
-  available regardless of LTS status.
-- **Patch releases:** bug fixes are delivered as patch releases (`YYYY.MM.N`)
-  against the pinned ROCm version, on the same model as LTS maintenance.
-- **Streams (required in v1):** `nightly/`, `stablerc/`, and `stable/` are
-  all required at launch. `ltsrc/` and `lts/` are reserved for future use,
-  aligned with ROCm LTS.
-  - `nightly/` — daily builds against the develop ROCm branch; retention
-    matches the `rocm-platform` nightly policy (30 dev / 120 nightly).
-  - `stablerc/` — release candidates for the next stable HPC SDK, tested
-    by QA, mirrors `stable/` layout. Retention: 2 years.
-  - `stable/` — GA HPC SDK releases, pinned to a stable ROCm version.
-    Retention: forever.
-  - `ltsrc/` *(future)* — release candidates for the next LTS HPC SDK.
-  - `lts/` *(future)* — long-term-support HPC SDK releases, pinned to an
-    LTS ROCm version.
-- **Layout:** published as `expansions/hpc-sdk/<YYYY.MM>/` under the
-  appropriate `rocm-platform` stream, with release metadata recording the
-  pinned ROCm version. Nightly builds use a date-stamped subfolder
-  (`expansions/hpc-sdk/nightly/<YYYYMMDD>/`).
-- **First target:** the first HPC SDK stable release is pinned to ROCm 7.14.
-- **Meta-package:** each release ships an installable umbrella package
-  `amdrocm-hpc-YYYY.MM` (rpm and deb) that depends on every HPC SDK component
-  at the versions in that release, plus a hard dependency on the pinned
-  ROCm Core SDK version. Patch releases update the component pins without
-  changing the meta-package name.
-- **Components:** first release includes rocHPCG, rocALUTION, hipFort,
-  rocHPL, and hipTensor. Second release adds miniHPL and miniHPCG.
-
-## Repository Package
-
-Allow users to install the all ROCm repositories via a convienient package. The package provides
-all the repository files. Example, the rpm repo file will add files to /etc/yum.repos.d/ and
-debian repo file will add to /etc/apt/sources.list.d/. The
-repo file will also install the gpg key, ideally prompting the user to accept the key. Updating
-the repo file will update the gpg key to the latest.
-
-- amdrocm-repo.rpm
-- amdrocm-repo-rpath.rpm # rpath is only available for rpm based releases today
-- amdrocm-repo.deb
-- amdrocm-repo-lts-YYYYMM.rpm #reserved for future LTS release streams
-
-Repository stream selection must be implemented per package manager.
-For rpm packages, install a package-manager variable file, for example
-/etc/yum/vars/amdrocm_release_stream or /etc/dnf/vars/amdrocm_release_stream,
-and use $amdrocm_release_stream in the repo baseurl.
-For Debian-based systems, the repository package must not rely on shell-style
-or yum-style variable expansion in APT source files. It should install explicit
-deb822 .sources stanzas, or separate .sources files, for each supported stream,
-using Enabled: yes/no to control which stream is active.
-
-The repository package is to include the latest amdgpu driver folder from repo.radeon.com.
-This is temporary until amdgpu is moved to repo.amd.com.
-
-This the repo packages are published in the amd-repos folder in the repo.amd.com hierarchy.
-The repo packages adds the amd-repos repository as well.
-
-It is designed to work with the following commands
+Each end-user project adopts its own semantic version which results in
+following filename template:
 
 ```
-wget https://repo.amd.com/amd-repos/$OS/rocm-repo.rpm
-rpm -ivh rocm-repo.rpm
-
-or directly via package manager
-yum install https://repo.amd.com/amd-repos/$OS/rocm-repo.rpm
+<projectname>-<major>.<minor>.<patch>
 ```
+
+For example:
+
+```
+rvs-1.0.0
+rvs-1.1.0
+rvs-1.1.1
+```
+
+The project version is entirely independent of the ROCm version it was
+built against. The relationship to the ROCm platform is encoded in two
+ways:
+
+1. **Extras tree version (installation path).** All end-user projects
+   compiled against a given ROCm major version are installed into a
+   single shared prefix whose name carries the ROCm major version:
+
+   ```
+   /opt/rocm/extras-<rocm-major>/
+   ```
+
+   For example, `extras-7` contains every end-user project built for the
+   ROCm 7.x family. This makes compatibility immediately visible from
+   the filesystem path — no additional metadata lookup is required.
+
+2. **Package name.** Each package embeds the target ROCm major version
+   in its name using the `amdrocm<major>-<project>` convention, so the
+   compatibility scope is apparent in repository listings, download
+   pages, and CI logs:
+
+   ```
+   amdrocm7-rvs-1.0.0       # RVS 1.0.0 for ROCm 7.x
+   amdrocm7-rvs-1.2.0       # RVS 1.2.0 for ROCm 7.x
+   amdrocm8-rvs-2.0.0       # RVS 2.0.0 for ROCm 8.x
+   ```
+
+The combination of both signals — the install path and the package
+name — ensures that whether a user is looking at an installed directory,
+a package filename, or a repository index, the compatible ROCm version
+family is always unambiguous.
+
+### ROCm Compatibility Matrix
+
+The following table illustrates how project versions map to ROCm
+compatibility:
+
+| Project version | ROCm target | Package name    | Install path          |
+| :-------------- | :---------- | :-------------- | :-------------------- |
+| rvs-1.0.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
+| rvs-1.1.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
+| rvs-1.2.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
+| rvs-2.0.0       | ROCm 8.x    | `amdrocm8-rvs`  | `/opt/rocm/extras-8/` |
+
+### Release Principles
+
+| Principle                    | Description                                                                                                                                                                       |
+| :--------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Independent scheduling       | Extras may release at any time — weekly, monthly, or on-demand — without coordinating with upcoming ROCm Core SDK milestones.                                                     |
+| ROCm version binding         | Each release of an extras project declares the ROCm major version it targets (e.g., ROCm 7). A new ROCm major version requires a corresponding new release of the extras project. |
+| Hotfix freedom               | Critical bug fixes in an extras tool can ship immediately as a patch release without waiting for a ROCm point release.                                                             |
+| Nightly / pre-release builds | Extras projects may publish nightly or pre-release packages to a staging repository for early validation.                                                                          |
+
+### Example Timeline
+
+```
+ROCm 7.0  ─────── ROCm 7.1 ─────── ROCm 7.2 ──────── ROCm 8.0
+  │                  │                  │                  │
+  ├─ rvs-1.0.0       │                  │                  │
+  │  (extras-7)      ├─ rvs-1.1.0       │                  │
+  │                  │  (extras-7)      │                  │
+  │                  │    ├─ rvs-1.1.1  │                  │
+  │                  │    (extras-7)    ├─ rvs-1.2.0       │
+  │                  │                  │  (extras-7)      │
+  │                  │                  │                  ├─ rvs-2.0.0
+  │                  │                  │                  │  (extras-8)
+```
+
+In this timeline, all RVS 1.x releases land in `extras-7` and work with
+any ROCm 7.x release. When ROCm 8.0 introduces breaking ABI changes, RVS
+publishes a new major version (2.0.0) that installs into `extras-8`.
+
+## 3. Compatibility with ROCm Releases
+
+### Major-Version Compatibility Contract
+
+All extras packages compiled against a given ROCm **major** version must
+continue to work with any ROCm release that shares that major version,
+whether the ROCm release is older or newer than the one used at build time.
+
+> **Rule:** An extras package built on ROCm **X.a** must function correctly
+> on ROCm **X.b** for all supported values of **a** and **b** within major
+> version **X**.
+
+Concretely for RVS:
+
+| RVS version | Built against | Must work on           |
+| :---------- | :------------ | :--------------------- |
+| rvs-1.0.0   | ROCm 7.0      | ROCm 7.0, 7.1, 7.2, … |
+| rvs-1.1.0   | ROCm 7.1      | ROCm 7.0, 7.1, 7.2, … |
+| rvs-1.2.0   | ROCm 7.2      | ROCm 7.0, 7.1, 7.2, … |
+| rvs-2.0.0   | ROCm 8.0      | ROCm 8.0, 8.1, …      |
+
+This means an operator who upgrades their cluster from ROCm 7.0 to ROCm 7.2
+does **not** need to reinstall or upgrade RVS — the existing RVS binary
+continues to function. Conversely, an operator running ROCm 7.0 can install a
+newer RVS release (e.g., rvs-1.2.0, originally built against ROCm 7.2) and it
+will work correctly.
+
+### How Compatibility Is Achieved
+
+1. **Stable ABI within a ROCm major version.** The ROCm Core SDK maintains
+   backward-compatible shared-library ABIs across all minor and patch releases
+   within the same major version. Extras projects link against these stable
+   interfaces.
+
+2. **`$ORIGIN`-based RPATH.** Extras packages are built with `$ORIGIN`-relative
+   RPATH entries so that they resolve their own bundled dependencies first,
+   falling back to the ROCm installation only for ROCm-provided libraries.
+
+3. **Minimum-version symbol binding.** Extras projects build against the
+   **lowest** minor release in the target major family (e.g., ROCm 7.0) to
+   ensure no dependency on symbols introduced in a later minor release. If a
+   feature from a newer minor release is required, it is accessed through
+   runtime detection or optional weak linking.
+
+4. **CI validation matrix.** Each extras release is tested against the full
+   set of supported ROCm minor releases within its target major version
+   before publication.
+
+### Breaking Changes Across Major Versions
+
+When ROCm increments its major version (e.g., 7.x to 8.0), ABI stability
+is **not** guaranteed. Extras projects must publish a corresponding new
+major version compiled against the new ROCm major release. Packages from
+different ROCm major families must not be mixed.
+
+## 4. Installed Package Directory Structure
+
+Extras packages install under `/opt/rocm/extras-<rocm-major>/` following
+the
+[ROCm Linux Filesystem Hierarchy Standard](https://rocm.docs.amd.com/en/latest/conceptual/file-reorg.html)
+and the conventions established in
+[RFC0009](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md). The extras
+tree version matches the ROCm major version it targets, so `extras-7`
+contains all extras built for ROCm 7.x. The layout is **flat** — all
+binaries, libraries, and headers from every extras project are merged into
+this single prefix, with project-specific subfolders under `include/` and
+`share/` for namespace isolation.
+
+### Layout
+
+```
+/opt/rocm/extras-<rocm-major>/
+    | -- bin
+    |      | -- all public binaries across extras projects
+    | -- lib
+    |      | -- lib<soname>.so -> lib<soname>.so.major -> lib<soname>.so.major.minor.patch
+    |      |      (public libraries to link with applications)
+    |      | -- <component>
+    |      |      | -- architecture dependent libraries and binaries used internally
+    |      | -- cmake
+    |             | -- <component>
+    |                    | -- <component>-config.cmake
+    | -- libexec
+    |      | -- <component>
+    |             | -- non-ISA/architecture independent executables used internally
+    | -- include
+    |      | -- <component>
+    |             | -- public header files
+    | -- share
+           | -- html
+           |      | -- <component>
+           |             | -- html documentation
+           | -- info
+           |      | -- <component>
+           |             | -- info files
+           | -- man
+           |      | -- <component>
+           |             | -- man pages
+           | -- doc
+           |      | -- <component>
+           |             | -- license files
+           | -- <component>
+                  | -- samples
+                  | -- architecture independent misc files (configs, test assets)
+```
+
+Where `<rocm-major>` is the ROCm major version the extras target (e.g.,
+`7` for ROCm 7.x), and `<component>` is the individual project name
+(e.g., `rvs`).
+
+### Symlinks
+
+A soft link provides a stable unversioned path that resolves to the latest
+installed extras tree:
+
+```
+/opt/rocm/extras/         -> /opt/rocm/extras-7
+```
+
+### RVS Example
+
+A concrete installation of the `extras-7` tree containing RVS 1.2.0:
+
+```
+/opt/rocm/extras-7/
+    | -- bin
+    |      | -- rvs                            # Main RVS executable
+    | -- lib
+    |      | -- librvs.so -> librvs.so.1 -> librvs.so.1.2.0
+    |      | -- rvs
+    |      |      | -- libgst.so               # GPU Stress Test module
+    |      |      | -- libiet.so               # Input EDPp Test module
+    |      |      | -- libpeqt.so              # PCI-Express Qualification Test module
+    |      |      | -- libpebb.so              # PCI-Express Bandwidth Benchmark module
+    |      |      | -- libmem.so               # Memory Test module
+    |      |      | -- librvs_internal.so      # Internal helpers
+    |      | -- cmake
+    |             | -- rvs
+    |                    | -- rvs-config.cmake
+    |                    | -- rvs-targets.cmake
+    | -- libexec
+    |      | -- rvs
+    |             | -- rvs_worker               # Internal worker process
+    | -- include
+    |      | -- rvs
+    |             | -- rvs.h
+    |             | -- rvs_module.h
+    | -- share
+           | -- doc
+           |      | -- rvs
+           |             | -- LICENSE
+           |             | -- CHANGELOG.md
+           | -- man
+           |      | -- rvs
+           |             | -- rvs.1
+           | -- rvs
+                  | -- conf
+                  |      | -- gpup_1.conf      # GPU Properties module config
+                  |      | -- gst_1.conf       # GPU Stress Test config
+                  |      | -- pebb_1.conf      # PCIe Bandwidth Benchmark config
+                  |      | -- rvs.conf         # Global RVS configuration
+                  | -- samples
+                         | -- gpu_stress.py
+```
+
+When RVS releases a new version (e.g., rvs-1.3.0) while still targeting
+ROCm 7, the updated files are installed in-place into the same `extras-7`
+tree. The extras tree version does not change — only the individual project
+binaries and libraries within it are upgraded.
+
+Symlink:
+
+```
+/opt/rocm/extras/         -> /opt/rocm/extras-7
+```
+
+### Multiple Extras Projects
+
+When more than one extras project is installed, all projects merge into the
+same flat prefix. The project-specific subfolders under `include/` and
+`share/` prevent namespace collisions:
+
+```
+/opt/rocm/extras-7/
+    | -- bin
+    |      | -- rvs
+    |      | -- rocm-bench
+    | -- lib
+    |      | -- librvs.so
+    |      | -- librocmbench.so
+    |      | -- cmake
+    |             | -- rvs
+    |             |      | -- rvs-config.cmake
+    |             | -- rocm-bench
+    |                    | -- rocm-bench-config.cmake
+    | -- include
+    |      | -- rvs
+    |      |      | -- rvs.h
+    |      | -- rocm-bench
+    |             | -- rocm_bench.h
+    | -- share
+           | -- doc
+           |      | -- rvs
+           |      |      | -- LICENSE
+           |      | -- rocm-bench
+           |             | -- LICENSE
+           | -- rvs
+           |      | -- conf
+           |      | -- samples
+           | -- rocm-bench
+                  | -- samples
+```
+
+### Side-by-Side Installation
+
+When multiple ROCm major versions are installed on the same system, a
+separate extras tree exists for each. This allows side-by-side operation
+without conflicts:
+
+```
+/opt/rocm/extras-7/
+/opt/rocm/extras-8/
+/opt/rocm/extras/         -> /opt/rocm/extras-8
+```
+
+Within a single extras tree (e.g., `extras-7`), project upgrades are
+installed in-place — there is no side-by-side at the individual project
+level. The ROCm major version is the only axis of side-by-side support.
+
+### Environment Integration
+
+To make extras tools discoverable, packages install a modulefile or profile
+snippet:
+
+```
+/etc/profile.d/amdrocm-extras.sh
+```
+
+This adds `/opt/rocm/extras/bin` to `$PATH` and `/opt/rocm/extras/lib` to
+`$LD_LIBRARY_PATH` (or the equivalent `ld.so.conf.d` drop-in). Because the
+layout is flat, a single profile snippet covers all extras projects. Users
+can target a specific ROCm major version by pointing directly at
+`/opt/rocm/extras-7/bin` instead of the symlink, or by using environment
+modules.
+
+## 5. Packaging Formats
+
+Extras projects must produce packaging formats that align with the formats
+supported by the ROCm Core SDK in TheRock. Not every format applies to
+every extras project — the table below identifies which formats are
+applicable and when to use each.
+
+### Format Overview
+
+| Format                    | Applicable  | Primary use case                                                                                                                                                             |
+| :------------------------ | :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **DEB** (`.deb`)          | Yes         | Installation on Debian-based distributions (Ubuntu, Debian) via `apt` / `dpkg`.                                                                                              |
+| **RPM** (`.rpm`)          | Yes         | Installation on RPM-based distributions (RHEL, SLES, AlmaLinux, CentOS, Rocky, Oracle Linux) via `dnf` / `yum` / `zypper`.                                                  |
+| **Tarball** (`.tar.xz`)   | Yes         | Portable, package-manager-independent installation. Useful for container images, HPC environments without root access, and CI/CD pipelines that consume pre-built artifacts. |
+| **Python wheel** (`.whl`) | Conditional | Only applicable when the extras project ships a Python interface or CLI tool written in Python. Native-only projects (e.g., RVS) do not produce wheels.                      |
+
+### DEB and RPM Packages
+
+Extras projects follow the same native packaging workflow as the ROCm Core
+SDK, as described in the
+[native packaging documentation](/docs/packaging/native_packaging.md).
+Each extras project provides a `package.json` that defines its package
+entries, and TheRock's packaging tooling generates both versioned and
+non-versioned packages.
+
+Key conventions:
+
+- **Naming**: Packages embed the target ROCm major version in the name
+  using the `amdrocm<major>-<project>` convention. This enables
+  side-by-side installation of the same project across different ROCm
+  major versions, since `amdrocm7-rvs` and `amdrocm8-rvs` are distinct
+  packages to the package manager. Distro-native packages use the
+  corresponding `rocm<major>-<project>` convention.
+
+  | AMD repository package | Distro-native equivalent | Contents                                                   |
+  | :--------------------- | :----------------------- | :--------------------------------------------------------- |
+  | `amdrocm7-rvs`         | `rocm7-rvs`              | RVS runtime for ROCm 7.x — binaries, modules, and configs |
+  | `amdrocm7-rvs-devel`   | `rocm7-rvs-dev`          | RVS development headers and CMake files for ROCm 7.x      |
+  | `amdrocm8-rvs`         | `rocm8-rvs`              | RVS runtime for ROCm 8.x                                  |
+- **Runtime vs. development split (optional)**: Projects that expose a
+  public API with headers and CMake config files may choose to produce a
+  separate `-devel` / `-dev` package. Most extras projects are end-user
+  tools built on top of the SDK and ship a single runtime package only.
+
+Example (RVS for ROCm 7 on Ubuntu):
+
+```
+amdrocm7-rvs_1.2.0_amd64.deb
+amdrocm7-rvs-dev_1.2.0_amd64.deb
+```
+
+Example (RVS for ROCm 7 on RHEL):
+
+```
+amdrocm7-rvs-1.2.0.x86_64.rpm
+amdrocm7-rvs-devel-1.2.0.x86_64.rpm
+```
+
+Side-by-side install of RVS across ROCm 7 and ROCm 8:
+
+```bash
+apt install amdrocm7-rvs amdrocm8-rvs
+```
+
+#### Dependency Resolution
+
+End-user projects built on top of ROCm must declare their ROCm
+dependencies correctly so that package managers can resolve and install
+the required ROCm components automatically. The following covers the
+general principles for DEB and RPM dependency resolution and how to map
+them to ROCm's host, architecture-specific, and multi-arch package
+structure.
+
+#### General Principles
+
+DEB and RPM package managers resolve dependencies using metadata declared
+in the package control file (`Depends` for DEB, `Requires` for RPM).
+The following rules apply to all end-user project packages:
+
+1. **Declare only direct dependencies.** List only the ROCm packages
+   the project links against or invokes directly. Transitive dependencies
+   are resolved automatically by the package manager through the ROCm
+   packages' own dependency chains.
+
+1. **Use version ranges, not exact versions.** Pin dependencies to the
+   ROCm major version to honor the compatibility contract from Section 3.
+   Avoid pinning to a specific minor or patch release unless a known
+   minimum is required.
+
+   DEB example (`debian/control`):
+
+   ```
+   Depends: amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0)
+   ```
+
+   RPM example (`.spec`):
+
+   ```
+   Requires: amdrocm-runtimes >= 7.0
+   Requires: amdrocm-runtimes < 8.0
+   ```
+
+1. **Separate build-time and install-time dependencies.** Build
+   dependencies (`Build-Depends` / `BuildRequires`) may reference
+   development packages such as `amdrocm-core-devel`. Runtime packages
+   should only depend on the runtime counterparts.
+
+#### ROCm Dependency Categories
+
+ROCm packages in TheRock are organized into three categories. End-user
+projects must understand this structure to declare the right dependencies.
+
+| Category            | Description                                                                                                                                                                                                                             | Example packages                                    |
+| :------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------- |
+| **Host packages**   | Architecture-independent runtime and libraries — the host-side binaries that work regardless of which GPU is installed. Not all host packages have corresponding device packages; some (e.g., `amdrocm-runtimes`) are purely host-side. | `amdrocm-runtimes`, `amdrocm-core`, `amdrocm-base` |
+| **Device packages** | GPU-architecture-specific binaries containing device code for a particular `gfx` target. Only ROCm library packages that ship pre-compiled GPU kernels produce device variants. These are suffixed with the architecture name.          | `amdrocm-blas-gfx942`, `amdrocm-blas-gfx1100`      |
+| **Meta packages**   | Convenience packages that pull in a set of host + device packages for a given architecture family or the full SDK.                                                                                                                      | `amdrocm`, `amdrocm-core-sdk`, `rocm-gfx90X`       |
+
+#### Mapping End-User Project Dependencies to ROCm
+
+Most end-user projects depend only on **host packages** because they call
+ROCm APIs (HIP, ROCm libraries) and do not ship their own GPU device
+code. The device packages are an end-user installation choice that
+determines which GPUs are supported at runtime — the end-user project
+itself is agnostic to this selection.
+
+**Host-only dependency (typical case)**
+
+An end-user project like RVS links against HIP, ROCm SMI, rocBLAS, and
+the ROCm runtime. Its package declares dependencies on the host packages
+for each component it uses:
+
+DEB:
+
+```
+Depends: amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0),
+         amdrocm-amdsmi (>= 7.0), amdrocm-amdsmi (<< 8.0),
+         amdrocm-blas (>= 7.0), amdrocm-blas (<< 8.0)
+```
+
+RPM:
+
+```
+Requires: amdrocm-runtimes >= 7.0, amdrocm-runtimes < 8.0
+Requires: amdrocm-amdsmi >= 7.0, amdrocm-amdsmi < 8.0
+Requires: amdrocm-blas >= 7.0, amdrocm-blas < 8.0
+```
+
+Note that `amdrocm-runtimes` is a host-only package and does not have
+architecture-specific variants. Libraries like `amdrocm-blas`, however,
+have corresponding device packages (`amdrocm-blas-gfx942`, etc.) that
+contain pre-compiled GPU kernels for specific architectures.
+
+The end-user project depends only on the host packages. The user is
+responsible for installing the device packages for their GPU, either
+individually or through an architecture family meta-package:
+
+```bash
+# Option 1: Install device packages for a specific architecture
+apt install amdrocm-blas-gfx942
+
+# Option 2: Install an architecture family meta-package (pulls in all
+#            device packages for the gfx94X family)
+apt install rocm-gfx94X
+```
+
+The end-user project does not need to know or declare which GPU
+architectures are present.
+
+**Architecture-specific dependency (rare case)**
+
+If an end-user project ships its own pre-compiled GPU kernels for
+specific architectures, it must produce architecture-specific package
+variants and declare dependencies on the matching ROCm library device
+packages:
+
+```
+Package: amdrocm7-mytool-gfx942
+Depends: amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0),
+         amdrocm-blas-gfx942 (>= 7.0), amdrocm-blas-gfx942 (<< 8.0)
+```
+
+Each architecture variant must:
+
+- Not conflict with other architecture variants of the same project.
+- Be independently installable.
+- Follow the `<package>-<gfxarch>` naming convention from
+  [RFC0009](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md).
+
+**Meta-package dependency**
+
+If an end-user project needs the full ROCm runtime stack (not just
+individual libraries), it may depend on a meta-package instead of
+listing each component:
+
+```
+Depends: amdrocm-core (>= 7.0), amdrocm-core (<< 8.0)
+```
+
+This pulls in the complete ROCm Core runtime. Use this approach
+sparingly — prefer fine-grained dependencies to avoid installing
+unnecessary components.
+
+#### Multi-Arch Considerations
+
+ROCm is transitioning to a multi-arch packaging model through
+[RFC0008](/docs/rfcs/RFC0008-Multi-Arch-Packaging.md), where host code
+and device code are split into separate packages using `rocm-kpack`.
+End-user projects should be prepared for this model:
+
+1. **Depend on host packages only.** As ROCm splits host and device
+   code into separate packages, end-user projects that follow the
+   host-only dependency pattern (the typical case above) are
+   automatically compatible — no changes needed.
+
+1. **Do not assume fat binaries.** End-user projects must not assume
+   that ROCm libraries contain embedded device code for all
+   architectures. The device code may reside in separate architecture
+   packages or kpack archives loaded at runtime.
+
+1. **Let the user choose architectures.** The end-user project package
+   should never force-install a specific GPU architecture. Architecture
+   selection is the user's responsibility through device meta-packages:
+
+   ```bash
+   # User installs the end-user project + their architecture
+   apt install amdrocm7-rvs
+   apt install rocm-gfx90X        # User's architecture choice
+   ```
+
+1. **Test against both fat and split layouts.** During the transition
+   period, CI should verify that the end-user project works correctly
+   whether ROCm is installed from fat-binary packages or multi-arch
+   split packages.
+
+#### Dependency Declaration Summary
+
+| Scenario                               | DEB `Depends`                                            | RPM `Requires`                                     |
+| :------------------------------------- | :------------------------------------------------------- | :------------------------------------------------- |
+| Uses HIP runtime                       | `amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0)` | `amdrocm-runtimes >= 7.0, amdrocm-runtimes < 8.0` |
+| Uses a ROCm library (e.g., rocBLAS)    | `amdrocm-blas (>= 7.0), amdrocm-blas (<< 8.0)`         | `amdrocm-blas >= 7.0, amdrocm-blas < 8.0`         |
+| Uses ROCm SMI                          | `amdrocm-amdsmi (>= 7.0), amdrocm-amdsmi (<< 8.0)`     | `amdrocm-amdsmi >= 7.0, amdrocm-amdsmi < 8.0`     |
+| Needs full Core SDK runtime            | `amdrocm-core (>= 7.0), amdrocm-core (<< 8.0)`         | `amdrocm-core >= 7.0, amdrocm-core < 8.0`         |
+| Ships own device kernels for a library | `amdrocm-<library>-<gfxarch> (>= 7.0)`                  | `amdrocm-<library>-<gfxarch> >= 7.0`              |
+
+### Tarball Packages
+
+Tarball archives provide a package-manager-independent distribution
+channel. They are the preferred format for:
+
+- Container images where native package managers add unnecessary layer
+  complexity.
+- HPC clusters with shared filesystems and no per-node root access.
+- CI/CD pipelines that need to extract pre-built extras into an arbitrary
+  prefix.
+- Environments where `apt` / `dnf` repositories are not configured.
+
+Tarballs follow the same artifact archive conventions as TheRock, producing
+a `.tar.xz` file with a corresponding `sha256sum`. The archive extracts
+into the flat FHS layout described in Section 4:
+
+```bash
+tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
+    -C /opt/rocm/extras-7/
+```
+
+Tarball naming follows the pattern:
+
+```
+amdrocm<rocm-major>-<project>-<version>-<os>-<arch>.tar.xz
+```
+
+#### Installing ROCm Dependencies for Tarball-Based Deployments
+
+Unlike DEB/RPM packages, tarballs do not have a package manager to
+resolve and install ROCm dependencies automatically. The user must
+ensure a compatible ROCm installation is present before extracting
+the end-user project tarball. There are several options:
+
+**Option 1: ROCm installed via native packages (recommended)**
+
+If the host already has ROCm installed through `apt` or `dnf`, the
+tarball-based end-user project can link against it directly. Verify
+the installed ROCm major version matches:
+
+```bash
+# Check the installed ROCm version
+amd-smi version
+
+# Extract the end-user project into the extras tree
+tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
+    -C /opt/rocm/extras-7/
+```
+
+**Option 2: ROCm installed from tarball**
+
+ROCm itself can be deployed from a tarball into a custom prefix. In
+this case both ROCm and the end-user project are package-manager-free:
+
+```bash
+# Extract ROCm Core SDK tarball
+tar -xf amdrocm-core-7.1.0-linux-x86_64.tar.xz \
+    -C /opt/rocm/core-7/
+
+# Extract the end-user project
+tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
+    -C /opt/rocm/extras-7/
+```
+
+**Option 3: ROCm installed via Python packages**
+
+When ROCm is available through `pip install rocm[core]`, the SDK
+libraries reside inside the Python site-packages directory. Use
+`rocm-sdk path` to locate the installation:
+
+```bash
+ROCM_ROOT=$(rocm-sdk path --root)
+
+tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
+    -C /opt/rocm/extras-7/
+```
+
+#### Connecting Project Binaries with ROCm Libraries
+
+After extracting both ROCm and the end-user project, the project
+binaries must be able to locate ROCm shared libraries at runtime.
+The following options are available, listed from most to least
+preferred:
+
+**Option 1: `$ORIGIN`-based RPATH (built-in, no user action)**
+
+End-user project binaries are built with `$ORIGIN`-relative RPATH
+entries. If the end-user project and ROCm are installed under the
+same `/opt/rocm/` parent, the relative paths resolve automatically
+and no additional configuration is needed.
+
+**Option 2: `LD_LIBRARY_PATH` environment variable**
+
+Set `LD_LIBRARY_PATH` to include the ROCm library directory. This is
+the simplest option when ROCm is installed in a non-standard location
+or when `$ORIGIN` RPATH does not cover the layout:
+
+```bash
+export ROCM_PATH=/opt/rocm/core-7
+export LD_LIBRARY_PATH=${ROCM_PATH}/lib:${LD_LIBRARY_PATH}
+export PATH=/opt/rocm/extras-7/bin:${ROCM_PATH}/bin:${PATH}
+```
+
+**Option 3: `ld.so.conf.d` drop-in (system-wide, requires root)**
+
+Create a linker configuration file so the dynamic linker finds ROCm
+libraries without environment variables:
+
+```bash
+echo "/opt/rocm/core-7/lib" > /etc/ld.so.conf.d/rocm-7.conf
+ldconfig
+```
+
+**Option 4: Environment modules / Lmod**
+
+On HPC clusters, use environment modules to manage ROCm and extras
+paths per user or per job:
+
+```tcl
+# /opt/modulefiles/rocm-extras/7
+set     rocm_root    /opt/rocm/core-7
+set     extras_root  /opt/rocm/extras-7
+
+prepend-path  PATH             $extras_root/bin
+prepend-path  PATH             $rocm_root/bin
+prepend-path  LD_LIBRARY_PATH  $extras_root/lib
+prepend-path  LD_LIBRARY_PATH  $rocm_root/lib
+prepend-path  CMAKE_PREFIX_PATH $extras_root
+prepend-path  CMAKE_PREFIX_PATH $rocm_root
+```
+
+Usage:
+
+```bash
+module load rocm-extras/7
+rvs -d 1
+```
+
+#### Verifying the Setup
+
+After installation and environment configuration, verify that the
+end-user project binaries can find all required ROCm libraries:
+
+```bash
+# Check that all shared library dependencies resolve
+ldd /opt/rocm/extras-7/bin/rvs
+
+# Run the project's built-in sanity check (if available)
+rvs -d 1 -g
+```
+
+Any `not found` entries in the `ldd` output indicate a missing ROCm
+library or an incorrectly configured library search path.
+
+### Python Wheel Packages
+
+Wheels are applicable **only** when an extras project provides a Python
+API, CLI tool, or test harness written in Python. Native-only extras
+projects like RVS do not produce wheels.
+
+When applicable, extras wheels follow the conventions described in the
+[Python packaging documentation](/docs/packaging/python_packaging.md):
+
+- **Selector package**: A source distribution (`rocm<major>-<project>`)
+  that evaluates install-time constraints and pulls the correct runtime
+  wheels.
+- **Runtime wheels**: Contain the minimal set of files needed to run,
+  with no symlinks. SONAME libraries are included directly.
+- **Devel wheels**: Catch-all for headers, CMake files, and symlinks
+  stored in a `_devel.tar` inside the wheel.
+
+Wheels declare a dependency on the ROCm SDK Python packages for the
+matching major version:
+
+```
+Requires-Dist: rocm[core] >=7.0, <8.0
+```
+
+Example build:
+
+```bash
+build_tools/build_python_packages.py \
+    --artifact-dir ./ARTIFACTS_DIR \
+    --dest-dir ./OUTPUT_PKG
+```
+
+Example install:
+
+```bash
+pip install rocm7-mytool --pre \
+    --find-links=./OUTPUT_PKG/dist
+```
+
+### Format Selection Guide
+
+The following table summarizes which format to produce based on the
+project characteristics:
+
+| Project type                  | DEB/RPM | Tarball | Wheel |
+| :---------------------------- | :-----: | :-----: | :---: |
+| Native C/C++ tool (e.g., RVS) |   Yes   |   Yes   |  No   |
+| Pure Python tool/test harness |   No    |   No    |  Yes  |
+| Mixed native + Python library |   Yes   |   Yes   |  Yes  |

--- a/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
+++ b/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
@@ -1,851 +1,415 @@
 ---
-author: Freddy Paul
-created: 2026-04-14
-modified: 2026-04-14
+author: Saad Rahim (saadrahim)
+created: 2026-04-08
+modified: 2026-05-28
 status: draft
 ---
 
-# ROCm End-User Projects With Independent Release Lifecycle
+# ROCm software ecosystem package repository structure
 
-## 1. Overview
+## Related RFCs
 
-ROCm ships a core SDK through TheRock build system. In addition to the core
-SDK, AMD and the broader community maintain a set of **extras** — tools,
-validation suites, and utility projects — that are compiled *on top of* a
-released ROCm Core SDK installation but follow their own development and
-release timelines. These extras are not part of the ROCm Core SDK; they
-consume ROCm as a build dependency and are delivered as independently
-versioned packages.
+- **RFC0008** — multi-arch Python wheels and device extras (source of the
+  `pyindex/multi-arch/` model used here).
+- **RFC0009** — native packaging conventions (source of the
+  `amdrocm<major>-<project>` package-naming family referenced for extras).
+- **RFC0012** — end-user projects independent release lifecycle (defines
+  the per-project release model for extras; this RFC defines where those
+  artifacts land on `repo.amd.com`).
 
-The ROCm Validation Suite (RVS) is the canonical example of such a project.
-RVS exercises GPU hardware and the ROCm software stack through a collection
-of test modules (GPU Properties, PCI-Express Bandwidth, GPU Stress Test,
-Memory Test, etc.) and is used by datacenter operators, OEMs, and developers
-to qualify ROCm deployments. RVS depends on the ROCm runtime, HIP, and
-several ROCm libraries, yet its feature roadmap and release schedule are
-driven by validation requirements that are independent of the ROCm Core SDK
-release cadence.
+## Overview
 
-### Goals
+repo.amd.com's open source software release publications need standardization. In scope is the ROCm software ecosystem which spans the ROCm Core SDK, expansions like ROCm-DS, and standalone projects like RVS. Software packaging for this ecosystem needs a well defined hierarchy reflected in the package distribution folder structure. As software is published on repo.amd.com, the planned hierarchy must be extensible by other software ecosystem published by AMD. As a result, this proposal includes the ability to add the AMD GPU driver to this structure in the future.
 
-1. **Decouple extras from the ROCm release train** so that bug fixes,
-   new test modules, and feature enhancements can ship without waiting for
-   the next ROCm Core SDK release.
-2. **Guarantee backward compatibility within a ROCm major version release stream**
-   so that a single extras build works across every minor and patch release
-   of that major version.
-3. **Provide a clear installation layout** that coexists with the ROCm
-   Core SDK directory structure defined in
-   [RFC0009](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md) without
-   creating conflicts or ambiguity.
-4. **Enable community and partner contributions** by keeping the extras
-   repositories buildable against any compatible, publicly released
-   ROCm Core SDK installation.
+## Definitions
 
-### Scope
+- Repository Streams
+  - nightly - nightly builds from the develop branch
+  - stablerc - release candidate builds for the next stable release
+  - stable - GA releases of ROCm with a short term support lifecycle, tagged as ROCm releases.
+  - ltsrc - *(future)* release candidate builds for the next LTS release
+  - lts - *(future)* long term stability (LTS) releases
 
-#### In Scope
+  > **Note on stream vocabulary:** RFC0012 does not define a strict
+  > stream taxonomy for extras — it only states that extras may publish
+  > "nightly / pre-release builds … to a staging repository for early
+  > validation" alongside ordinary releases. The canonical streams on
+  > `repo.amd.com` are the ones defined in this RFC
+  > (`nightly`/`stablerc`/`stable`, with `ltsrc`/`lts` reserved).
+  > Per-extra publishing maps into those streams as follows: nightly /
+  > staging builds → `nightly/`, pre-release builds intended for QA →
+  > `stablerc/`, GA releases → `stable/`. Each extra's release notes
+  > record which stream a given build landed in.
+- Products
+  - Core SDK
+  - expansions - SDK built with dependencies on the ROCm Core SDK
+    - HPC SDK - a ROCm expansion released on its own cadence, pinned to a single ROCm version per release
+  - extras - standalone components part of ROCm
+- pyindex - top-level folder for the ROCm Python package indices. Contains
+  two sibling indices (see "Python Indices" section):
+  - `pyindex/multi-arch/` — multi-arch index requiring explicit device
+    extras (e.g. `pip install rocm[device-gfx942]`)
+  - `pyindex/multi-arch-compat/` — backward-compatible multi-arch index
+    where `pip install rocm` pulls in all device extras automatically
 
-- Release cadence and versioning for extras/tools projects
-- ROCm major-version compatibility contract
-- Directory layout and packaging conventions for installed extras
-- ROCm Validation Suite (RVS) as the reference implementation
+## Repository Structure
 
-#### Out of Scope
+`repo.amd.com` will have the following folder structure:
 
-- ROCm Core SDK packaging (covered by RFC0009)
-- GPU driver packaging
-- Internal CI/CD pipeline specifics of individual extras projects
-- ROCm Expansion SDK requirements need a parallel RFC to the requirements in this PR. 
-- These requirements is for software that releases individually and islimited to one version installed per major ROCm version.
-## 2. Release Cadence
+- **amdgpu** *(reserved for future use; follows the same stream structure as `rocm-platform`: **nightly**, **stablerc**, **stable**, **ltsrc**, **lts**)*
+- **amdrepos**
+  - packages
+    - **Linux Distros [a–z]**
+- **archives** *(unmaintained releasees, for reference only)*
+- **rocm** (current rocm folder with non production releases, move to archives in 6 months)
+- **rocm-platform**
 
-Extras projects follow an **independent release cadence** that is not tied
-to the ROCm Core SDK release schedule.
+  - **nightly** *(Retention policy: 30 dev, 120 nightly)*
+    - **pyindex** *(see Python Indices section)*
+      - **multi-arch** *(device extras specified manually)*
+      - **multi-arch-compat** *(backward-compatible; `pip install rocm` pulls in all device extras)*
+    - **core**
+      - tarball
+      - zip
+      - installers
+      - whl
+      - packages
+        - **Linux Distros [a–z]**
+    - **windows**
+      - MSI and EXE files for Windows
+    - **expansions [a–z]** *(e.g. **hpc-sdk** — see HPC SDK Release Model section)*
+      - tarball
+      - whl
+      - packages
+    - **extras-[ROCm-major]** #projects released independently for each ROCm major version
+      - **Decision:** per-project folder structure on `repo.amd.com` (each
+        extra gets its own folder; allows S3 bucket permission granularity
+        by group). A flat distribution structure was considered and rejected.
+      - **Distribution vs install layout — these are separate concerns
+        and do not conflict:**
+        - *Distribution layout* (this RFC, on `repo.amd.com`): **per
+          project**. Each extra has its own folder under
+          `extras-[ROCm-major]/` (e.g.
+          `rocm-platform/stable/extras-7/rvs/`,
+          `.../extras-7/rocoptiq/`). Chosen so S3 bucket permissions can
+          be granted per project/group.
+        - *Install layout* (RFC0012, on the user's disk): **flat**. After
+          install, all extras for a given ROCm major share a single
+          merged tree (e.g. `/opt/rocm/extras-7/bin/`,
+          `/opt/rocm/extras-7/lib/`, ...) — binaries and libraries from
+          different extras live side-by-side, not in per-project
+          subdirectories.
+        - The two layouts are independent: per-project folders on
+          `repo.amd.com` are how artifacts are *published and
+          permissioned*; the flat tree under `/opt/rocm/extras-7/` is how
+          they are *installed and consumed*. A reader should not infer
+          that the on-disk layout mirrors the publication folders, or
+          vice versa. RFC0012 is the source of truth for the install
+          layout.
+        - **Name-collision note:** the string `extras-7` appears in both
+          places (`rocm-platform/<stream>/extras-7/` here and
+          `/opt/rocm/extras-7/` in RFC0012) **because both are scoped to
+          the ROCm major version**, not because one mirrors the other.
+          The matching name is a coincidence of versioning, not a layout
+          guarantee — distribution folders and install prefixes remain
+          governed by their respective RFCs.
+      - **Package naming:** native packages for extras follow the
+        `amdrocm<major>-<project>` convention on `repo.amd.com` (e.g.
+        `amdrocm7-rvs`, `amdrocm7-rocoptiq`); the **distro-native**
+        equivalent shipped through distro repositories is
+        `rocm<major>-<project>` (e.g. `rocm7-rvs`). Optional `-devel` /
+        `-dev` sibling packages follow the same prefix when an extra
+        exposes a public API. See RFC0009 and RFC0012 §5 for the full
+        naming and split rules.
+      - **Versioning:** extras use **semver**
+        (`<project>-<major>.<minor>.<patch>`, e.g. `rvs-1.2.0`) per
+        RFC0012 §2. The date-based `YYYY.MM` scheme used elsewhere in
+        this RFC is **HPC-SDK-only** and must not be applied to extras.
+      - **Python wheels for extras:** when an extra ships a wheel, the
+        selector package is named `rocm<major>-<project>` (per RFC0012
+        §5) and declares `Requires-Dist: rocm[core] >=X.0, <(X+1).0`.
+        Wheels are published through `pyindex/multi-arch{,-compat}/`
+        like all other ROCm wheels.
+      - **Major-version compatibility:** each `extras-[ROCm-major]`
+        directory is the compatibility boundary. An extra published under
+        `extras-7` is guaranteed to install against any ROCm 7.x Core SDK
+        release; cross-major compatibility is not promised. See RFC0012
+        for the full compat contract.
+      - **rvs**
+        - tarball
+        - packages
+      - **rocoptiq**
+        - tarball
+        - whl
+        - packages
+      - **omnistat**
+        - whl
+    - **pytorch**
+      - **nightly**
+        - whl
+      - **stablerc**
+        - whl
+      - **stable**
+        - whl
+    - **jax** *(follows the same stream and artifact rules as **pytorch**)*
+    - **onnx-runtime** *(follows the same stream and artifact rules as **pytorch**)*
 
-Each extras project may set an appropriate release cadence for the project in
-conjunction with its stakeholders.
+  - **stablerc** *(Retention policy: 2 years)*
 
-### Versioning Scheme
+    - Release candidate builds for the next stable release
+    - Mirrors nightly folder structure
+    - Tested by QA
+    - Must match structure of `repo.amd.com`
 
-Each end-user project adopts its own semantic version which results in
-following filename template:
+  - **stable**
+
+    - Current ROCm Core release from TheRock
+    - **standard** (includes default build packages, asan build packages, default-debug symbol packages, and asan-debug system packages)
+    - **rpath** (includes rpath variant of standard packages)
+
+  - **ltsrc** — long term support release candidate *(future; Retention policy: 2 years)*
+
+    - Release candidate builds for the next LTS release
+    - Mirrors stable folder structure
+
+  - **lts** — long term support *(future)*
+
+    - `YYYYMM`
+      - Mirrors stable folder structure
+
+## Python Indices
+
+ROCm publishes wheels through two parallel multi-arch indices, per the
+direction in ROCm/TheRock#5289. Per-family indices were considered and
+rejected — only the two multi-arch flavors below are in scope.
+
+- **`pyindex/multi-arch/`** — multi-arch index where the user explicitly
+  picks the device extras they need. Smaller installs, but the user
+  must know their target architecture.
+  ```
+  pip install --index-url https://repo.amd.com/.../pyindex/multi-arch/ rocm[device-gfx942]
+  ```
+
+- **`pyindex/multi-arch-compat/`** — backward-compatible multi-arch
+  index. `pip install rocm` (or `pip install torch`) pulls in **all**
+  device extras automatically, matching the "it just works" behavior
+  users expect from `pip install torch --index-url
+  https://download.pytorch.org/whl/rocm7.2`. Larger download (~5.5 GB
+  for the torch case), but no architecture knowledge required.
+  ```
+  pip install --index-url https://repo.amd.com/.../pyindex/multi-arch-compat/ rocm
+  ```
+
+Both indices ship under every stream that publishes wheels (`nightly`,
+`stablerc`, `stable`; not `ltsrc`/`lts` until LTS exists), and both are
+built from the same underlying wheel set — `multi-arch-compat/` simply
+republishes the entry-point wheels (`rocm`, `torch`, `torchvision`, …)
+with `device-all` added as an automatic requirement, plus links to the
+unmodified device wheels in `multi-arch/` so storage is not duplicated.
+
+Future direction: WheelNext (`uv pip install` with a wheel-variant
+provider backed by `rocm-bootstrap`) is the long-term plan and will
+eventually make `multi-arch-compat/` unnecessary. Until that lands and
+is widely adopted, both indices must coexist.
+
+**Native multi-arch (parallel mechanism):** the `pyindex/` paths above
+cover the **wheel** side of multi-arch. The **native-package** side is
+covered by `rocm-kpack` per RFC0008 — host and device code are split
+into separate packages, with device code shipped either as
+per-architecture packages (`amdrocm-<library>-gfx<arch>`) or loaded at
+runtime from kpack archives. These device packages and the
+architecture-family meta-packages that group them
+(`rocm-gfx94X`, `rocm-gfx90X`, etc.) are published under
+`rocm-platform/<stream>/core/packages/<distro>/` alongside the host
+ROCm Core SDK packages — they are not a separate folder. Wheel
+multi-arch (`pyindex/`) and native multi-arch (`rocm-kpack`) are
+sibling mechanisms: wheel users go through `pyindex/`, native users
+install the matching device or `rocm-gfx<family>X` package from
+`core/packages/`. RFC0008 owns the full multi-arch contract for both
+sides.
+
+## Third Party AI Forks
+
+`pytorch`, `jax`, and `onnx-runtime` are **ROCm forks/builds of upstream
+third-party AI frameworks**, not first-party AMD projects. They are
+published on `repo.amd.com` so users can pick up ROCm-enabled wheels
+without having to build them locally, but the upstream project owns the
+source of truth and the release cadence for the framework itself.
+
+Rules that apply to all third-party AI forks:
+
+- **Upstream tracking:** each entry mirrors a specific upstream release
+  (or upstream nightly), with ROCm patches applied on top. Metadata in
+  every artifact records the upstream version and the ROCm version it
+  was built against.
+- **Streams:** published only under `nightly/`, `stablerc/`, and
+  `stable/`. Not published under `ltsrc/` or `lts/` — long-term-support
+  guarantees do not extend to third-party fork builds.
+- **Artifact format:** `whl` only. No tarballs, no native distro
+  packages — users install via `pip` from the matching ROCm wheel index.
+- **Dependency rule:** framework wheels must depend **only on Python
+  wheels of the ROCm Core SDK** (published under `core/whl/` and surfaced
+  through `pyindex/`). They must not depend on system packages, native
+  distro packages, or any non-wheel ROCm artifact. This keeps `pip
+  install` of a framework wheel fully self-contained and reproducible
+  across distros.
+- **Versioning:** uses the upstream framework's own version string
+  (e.g. PyTorch's `2.x.y+rocm<rocm-version>` convention), not the ROCm
+  `YYYYMM`/`YYYY.MM` scheme.
+- **Support model:** bug fixes for the ROCm-specific delta ship in the
+  next stream promotion; we do not back-patch older third-party fork
+  releases.
+- **Coverage list:** `pytorch`, `jax`, `onnx-runtime`. New third-party
+  forks added to `repo.amd.com` follow this same model by default.
+
+## Dependency Closure for Expansions and Extras
+
+Every package published under `expansions/` and `extras-[ROCm-major]/`
+must declare a **complete dependency chain**. The goal is that a single
+one-line install command for any expansion or extra pulls in every
+required component automatically, with no manual follow-up.
+
+Rules:
+
+- **Native packages (rpm/deb):** `Requires:` / `Depends:` must list every
+  ROCm Core SDK package, expansion, or extra the component needs at
+  runtime, at the exact (or minimum-compatible) versions. A `yum install
+  <pkg>` or `apt install <pkg>` must succeed without the user adding
+  ROCm Core SDK packages by hand.
+- **Python wheels:** `install_requires` / `Requires-Dist` must list every
+  ROCm Core SDK wheel (and any other expansion wheel) the component
+  needs. A `pip install <pkg> --index-url <pyindex>` must pull in the
+  full chain.
+- **Cross-format:** packages must not silently rely on a parallel
+  artifact in a different format (e.g. an rpm that quietly needs a wheel
+  to be installed, or vice versa). Each install path must be
+  self-sufficient.
+- **Host-only dependencies for extras (transitive chains stop at host
+  packages):** the **typical case** for extras (RFC0012 §5) is that
+  they call ROCm host APIs and do not ship their own GPU device code.
+  In that case, extras declare hard dependencies only on host-side ROCm
+  Core SDK packages (compilers, runtimes, host libraries). The
+  transitive dependency chain must terminate at host packages —
+  consuming-only extras must never pull in a specific GPU architecture
+  or any `amdrocm<major>-<library>-gfx*` device package as a hard
+  requirement, directly or transitively. Device coverage is the user's
+  choice at install time, selected via the multi-arch wheel index
+  (`pyindex/multi-arch/` with explicit `device-gfxNNNN` extras) or by
+  installing the matching device or architecture-family meta-packages
+  (e.g. `rocm-gfx94X`) alongside the extra. Recommended/suggested deps
+  (rpm `Recommends:`, deb `Recommends:`) are allowed for discoverability
+  but must remain non-hard.
+
+  - **Exception — extras that ship their own GPU kernels (RFC0012 §5,
+    "rare case"):** when an extra produces its own pre-compiled device
+    code, it must be split into per-architecture package variants named
+    `amdrocm<major>-<project>-gfx<arch>` (e.g.
+    `amdrocm7-mytool-gfx942`). Each architecture variant **may**
+    declare a hard dependency on the matching ROCm library device
+    package (e.g. `amdrocm-blas-gfx942`). The host-only rule applies
+    only to the consuming case; kernel-shipping extras are explicitly
+    exempt for their own device variants and only for them. The host
+    (non-`-gfx*`) package of such an extra still follows the host-only
+    rule.
+
+  - **CI enforcement:** the dependency-closure check runs in a
+    **host-only image** for every consuming extra; pulling in any
+    device package as a hard dep fails the publish. Kernel-shipping
+    `-gfx<arch>` variants are tested in an image with the matching
+    device packages installed.
+
+  This rule mirrors the device-extras model in RFC0008 and the
+  end-user-project dependency rules in RFC0012 §5, and applies to both
+  native packages and Python wheels.
+- **CI enforcement:** the publish pipeline runs a clean-environment
+  install test for every expansion and extra in each stream
+  (`nightly`/`stablerc`/`stable`) on every supported distro. Missing
+  transitive dependencies fail the publish.
+- **Meta-packages:** umbrella packages such as `amdrocm-hpc-YYYY.MM` (HPC
+  SDK) inherit this rule and additionally declare their hard dependency
+  on the pinned ROCm Core SDK version.
+
+## HPC SDK Release Model
+
+The HPC SDK is a ROCm expansion and is published under the `expansions [a–z]`
+folder of the matching `rocm-platform` stream (nightly, stablerc, stable,
+ltsrc, lts). Unlike other expansions, it is released on its own cadence — decoupled
+from ROCm release cadence — and uses date-based versioning. This mirrors the
+model used by NVIDIA's HPC SDK, which is published independently of CUDA
+releases.
+
+- **Cadence:** approximately 4 releases per year. Not every ROCm release will
+  have a corresponding HPC SDK release.
+- **Versioning:** date-based, `YYYY.MM` (e.g. `2026.06`). Versioning is
+  intentionally independent of ROCm version numbers to make the decoupling
+  explicit and avoid mix-and-match confusion.
+- **ROCm pinning:** each HPC SDK release is pinned to exactly one ROCm Core
+  SDK version. Pinning follows the stream:
+  - stable HPC SDK pins to a stable ROCm Core SDK release.
+  - LTS HPC SDK (when available) pins to an LTS ROCm Core SDK release.
+  Both streams coexist once LTS exists; a stable HPC SDK release is always
+  available regardless of LTS status.
+- **Patch releases:** bug fixes are delivered as patch releases (`YYYY.MM.N`)
+  against the pinned ROCm version, on the same model as LTS maintenance.
+- **Streams (required in v1):** `nightly/`, `stablerc/`, and `stable/` are
+  all required at launch. `ltsrc/` and `lts/` are reserved for future use,
+  aligned with ROCm LTS.
+  - `nightly/` — daily builds against the develop ROCm branch; retention
+    matches the `rocm-platform` nightly policy (30 dev / 120 nightly).
+  - `stablerc/` — release candidates for the next stable HPC SDK, tested
+    by QA, mirrors `stable/` layout. Retention: 2 years.
+  - `stable/` — GA HPC SDK releases, pinned to a stable ROCm version.
+    Retention: forever.
+  - `ltsrc/` *(future)* — release candidates for the next LTS HPC SDK.
+  - `lts/` *(future)* — long-term-support HPC SDK releases, pinned to an
+    LTS ROCm version.
+- **Layout:** published as `expansions/hpc-sdk/<YYYY.MM>/` under the
+  appropriate `rocm-platform` stream, with release metadata recording the
+  pinned ROCm version. Nightly builds use a date-stamped subfolder
+  (`expansions/hpc-sdk/nightly/<YYYYMMDD>/`).
+- **First target:** the first HPC SDK stable release is pinned to ROCm 7.14.
+- **Meta-package:** each release ships an installable umbrella package
+  `amdrocm-hpc-YYYY.MM` (rpm and deb) that depends on every HPC SDK component
+  at the versions in that release, plus a hard dependency on the pinned
+  ROCm Core SDK version. Patch releases update the component pins without
+  changing the meta-package name.
+- **Components:** first release includes rocHPCG, rocALUTION, hipFort,
+  rocHPL, and hipTensor. Second release adds miniHPL and miniHPCG.
+
+## Repository Package
+
+Allow users to install the all ROCm repositories via a convienient package. The package provides
+all the repository files. Example, the rpm repo file will add files to /etc/yum.repos.d/ and
+debian repo file will add to /etc/apt/sources.list.d/. The
+repo file will also install the gpg key, ideally prompting the user to accept the key. Updating
+the repo file will update the gpg key to the latest.
+
+- amdrocm-repo.rpm
+- amdrocm-repo-rpath.rpm # rpath is only available for rpm based releases today
+- amdrocm-repo.deb
+- amdrocm-repo-lts-YYYYMM.rpm #reserved for future LTS release streams
+
+Repository stream selection must be implemented per package manager.
+For rpm packages, install a package-manager variable file, for example
+/etc/yum/vars/amdrocm_release_stream or /etc/dnf/vars/amdrocm_release_stream,
+and use $amdrocm_release_stream in the repo baseurl.
+For Debian-based systems, the repository package must not rely on shell-style
+or yum-style variable expansion in APT source files. It should install explicit
+deb822 .sources stanzas, or separate .sources files, for each supported stream,
+using Enabled: yes/no to control which stream is active.
+
+The repository package is to include the latest amdgpu driver folder from repo.radeon.com.
+This is temporary until amdgpu is moved to repo.amd.com.
+
+This the repo packages are published in the amd-repos folder in the repo.amd.com hierarchy.
+The repo packages adds the amd-repos repository as well.
+
+It is designed to work with the following commands
 
 ```
-<projectname>-<major>.<minor>.<patch>
+wget https://repo.amd.com/amd-repos/$OS/rocm-repo.rpm
+rpm -ivh rocm-repo.rpm
+
+or directly via package manager
+yum install https://repo.amd.com/amd-repos/$OS/rocm-repo.rpm
 ```
-
-For example:
-
-```
-rvs-1.0.0
-rvs-1.1.0
-rvs-1.1.1
-```
-
-The project version is entirely independent of the ROCm version it was
-built against. The relationship to the ROCm platform is encoded in two
-ways:
-
-1. **Extras tree version (installation path).** All end-user projects
-   compiled against a given ROCm major version are installed into a
-   single shared prefix whose name carries the ROCm major version:
-
-   ```
-   /opt/rocm/extras-<rocm-major>/
-   ```
-
-   For example, `extras-7` contains every end-user project built for the
-   ROCm 7.x family. This makes compatibility immediately visible from
-   the filesystem path — no additional metadata lookup is required.
-
-2. **Package name.** Each package embeds the target ROCm major version
-   in its name using the `amdrocm<major>-<project>` convention, so the
-   compatibility scope is apparent in repository listings, download
-   pages, and CI logs:
-
-   ```
-   amdrocm7-rvs-1.0.0       # RVS 1.0.0 for ROCm 7.x
-   amdrocm7-rvs-1.2.0       # RVS 1.2.0 for ROCm 7.x
-   amdrocm8-rvs-2.0.0       # RVS 2.0.0 for ROCm 8.x
-   ```
-
-The combination of both signals — the install path and the package
-name — ensures that whether a user is looking at an installed directory,
-a package filename, or a repository index, the compatible ROCm version
-family is always unambiguous.
-
-### ROCm Compatibility Matrix
-
-The following table illustrates how project versions map to ROCm
-compatibility:
-
-| Project version | ROCm target | Package name    | Install path          |
-| :-------------- | :---------- | :-------------- | :-------------------- |
-| rvs-1.0.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
-| rvs-1.1.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
-| rvs-1.2.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
-| rvs-2.0.0       | ROCm 8.x    | `amdrocm8-rvs`  | `/opt/rocm/extras-8/` |
-
-### Release Principles
-
-| Principle                    | Description                                                                                                                                                                       |
-| :--------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Independent scheduling       | Extras may release at any time — weekly, monthly, or on-demand — without coordinating with upcoming ROCm Core SDK milestones.                                                     |
-| ROCm version binding         | Each release of an extras project declares the ROCm major version it targets (e.g., ROCm 7). A new ROCm major version requires a corresponding new release of the extras project. |
-| Hotfix freedom               | Critical bug fixes in an extras tool can ship immediately as a patch release without waiting for a ROCm point release.                                                             |
-| Nightly / pre-release builds | Extras projects may publish nightly or pre-release packages to a staging repository for early validation.                                                                          |
-
-### Example Timeline
-
-```
-ROCm 7.0  ─────── ROCm 7.1 ─────── ROCm 7.2 ──────── ROCm 8.0
-  │                  │                  │                  │
-  ├─ rvs-1.0.0       │                  │                  │
-  │  (extras-7)      ├─ rvs-1.1.0       │                  │
-  │                  │  (extras-7)      │                  │
-  │                  │    ├─ rvs-1.1.1  │                  │
-  │                  │    (extras-7)    ├─ rvs-1.2.0       │
-  │                  │                  │  (extras-7)      │
-  │                  │                  │                  ├─ rvs-2.0.0
-  │                  │                  │                  │  (extras-8)
-```
-
-In this timeline, all RVS 1.x releases land in `extras-7` and work with
-any ROCm 7.x release. When ROCm 8.0 introduces breaking ABI changes, RVS
-publishes a new major version (2.0.0) that installs into `extras-8`.
-
-## 3. Compatibility with ROCm Releases
-
-### Major-Version Compatibility Contract
-
-All extras packages compiled against a given ROCm **major** version must
-continue to work with any ROCm release that shares that major version,
-whether the ROCm release is older or newer than the one used at build time.
-
-> **Rule:** An extras package built on ROCm **X.a** must function correctly
-> on ROCm **X.b** for all supported values of **a** and **b** within major
-> version **X**.
-
-Concretely for RVS:
-
-| RVS version | Built against | Must work on           |
-| :---------- | :------------ | :--------------------- |
-| rvs-1.0.0   | ROCm 7.0      | ROCm 7.0, 7.1, 7.2, … |
-| rvs-1.1.0   | ROCm 7.1      | ROCm 7.0, 7.1, 7.2, … |
-| rvs-1.2.0   | ROCm 7.2      | ROCm 7.0, 7.1, 7.2, … |
-| rvs-2.0.0   | ROCm 8.0      | ROCm 8.0, 8.1, …      |
-
-This means an operator who upgrades their cluster from ROCm 7.0 to ROCm 7.2
-does **not** need to reinstall or upgrade RVS — the existing RVS binary
-continues to function. Conversely, an operator running ROCm 7.0 can install a
-newer RVS release (e.g., rvs-1.2.0, originally built against ROCm 7.2) and it
-will work correctly.
-
-### How Compatibility Is Achieved
-
-1. **Stable ABI within a ROCm major version.** The ROCm Core SDK maintains
-   backward-compatible shared-library ABIs across all minor and patch releases
-   within the same major version. Extras projects link against these stable
-   interfaces.
-
-2. **`$ORIGIN`-based RPATH.** Extras packages are built with `$ORIGIN`-relative
-   RPATH entries so that they resolve their own bundled dependencies first,
-   falling back to the ROCm installation only for ROCm-provided libraries.
-
-3. **Minimum-version symbol binding.** Extras projects build against the
-   **lowest** minor release in the target major family (e.g., ROCm 7.0) to
-   ensure no dependency on symbols introduced in a later minor release. If a
-   feature from a newer minor release is required, it is accessed through
-   runtime detection or optional weak linking.
-
-4. **CI validation matrix.** Each extras release is tested against the full
-   set of supported ROCm minor releases within its target major version
-   before publication.
-
-### Breaking Changes Across Major Versions
-
-When ROCm increments its major version (e.g., 7.x to 8.0), ABI stability
-is **not** guaranteed. Extras projects must publish a corresponding new
-major version compiled against the new ROCm major release. Packages from
-different ROCm major families must not be mixed.
-
-## 4. Installed Package Directory Structure
-
-Extras packages install under `/opt/rocm/extras-<rocm-major>/` following
-the
-[ROCm Linux Filesystem Hierarchy Standard](https://rocm.docs.amd.com/en/latest/conceptual/file-reorg.html)
-and the conventions established in
-[RFC0009](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md). The extras
-tree version matches the ROCm major version it targets, so `extras-7`
-contains all extras built for ROCm 7.x. The layout is **flat** — all
-binaries, libraries, and headers from every extras project are merged into
-this single prefix, with project-specific subfolders under `include/` and
-`share/` for namespace isolation.
-
-### Layout
-
-```
-/opt/rocm/extras-<rocm-major>/
-    | -- bin
-    |      | -- all public binaries across extras projects
-    | -- lib
-    |      | -- lib<soname>.so -> lib<soname>.so.major -> lib<soname>.so.major.minor.patch
-    |      |      (public libraries to link with applications)
-    |      | -- <component>
-    |      |      | -- architecture dependent libraries and binaries used internally
-    |      | -- cmake
-    |             | -- <component>
-    |                    | -- <component>-config.cmake
-    | -- libexec
-    |      | -- <component>
-    |             | -- non-ISA/architecture independent executables used internally
-    | -- include
-    |      | -- <component>
-    |             | -- public header files
-    | -- share
-           | -- html
-           |      | -- <component>
-           |             | -- html documentation
-           | -- info
-           |      | -- <component>
-           |             | -- info files
-           | -- man
-           |      | -- <component>
-           |             | -- man pages
-           | -- doc
-           |      | -- <component>
-           |             | -- license files
-           | -- <component>
-                  | -- samples
-                  | -- architecture independent misc files (configs, test assets)
-```
-
-Where `<rocm-major>` is the ROCm major version the extras target (e.g.,
-`7` for ROCm 7.x), and `<component>` is the individual project name
-(e.g., `rvs`).
-
-### Symlinks
-
-A soft link provides a stable unversioned path that resolves to the latest
-installed extras tree:
-
-```
-/opt/rocm/extras/         -> /opt/rocm/extras-7
-```
-
-### RVS Example
-
-A concrete installation of the `extras-7` tree containing RVS 1.2.0:
-
-```
-/opt/rocm/extras-7/
-    | -- bin
-    |      | -- rvs                            # Main RVS executable
-    | -- lib
-    |      | -- librvs.so -> librvs.so.1 -> librvs.so.1.2.0
-    |      | -- rvs
-    |      |      | -- libgst.so               # GPU Stress Test module
-    |      |      | -- libiet.so               # Input EDPp Test module
-    |      |      | -- libpeqt.so              # PCI-Express Qualification Test module
-    |      |      | -- libpebb.so              # PCI-Express Bandwidth Benchmark module
-    |      |      | -- libmem.so               # Memory Test module
-    |      |      | -- librvs_internal.so      # Internal helpers
-    |      | -- cmake
-    |             | -- rvs
-    |                    | -- rvs-config.cmake
-    |                    | -- rvs-targets.cmake
-    | -- libexec
-    |      | -- rvs
-    |             | -- rvs_worker               # Internal worker process
-    | -- include
-    |      | -- rvs
-    |             | -- rvs.h
-    |             | -- rvs_module.h
-    | -- share
-           | -- doc
-           |      | -- rvs
-           |             | -- LICENSE
-           |             | -- CHANGELOG.md
-           | -- man
-           |      | -- rvs
-           |             | -- rvs.1
-           | -- rvs
-                  | -- conf
-                  |      | -- gpup_1.conf      # GPU Properties module config
-                  |      | -- gst_1.conf       # GPU Stress Test config
-                  |      | -- pebb_1.conf      # PCIe Bandwidth Benchmark config
-                  |      | -- rvs.conf         # Global RVS configuration
-                  | -- samples
-                         | -- gpu_stress.py
-```
-
-When RVS releases a new version (e.g., rvs-1.3.0) while still targeting
-ROCm 7, the updated files are installed in-place into the same `extras-7`
-tree. The extras tree version does not change — only the individual project
-binaries and libraries within it are upgraded.
-
-Symlink:
-
-```
-/opt/rocm/extras/         -> /opt/rocm/extras-7
-```
-
-### Multiple Extras Projects
-
-When more than one extras project is installed, all projects merge into the
-same flat prefix. The project-specific subfolders under `include/` and
-`share/` prevent namespace collisions:
-
-```
-/opt/rocm/extras-7/
-    | -- bin
-    |      | -- rvs
-    |      | -- rocm-bench
-    | -- lib
-    |      | -- librvs.so
-    |      | -- librocmbench.so
-    |      | -- cmake
-    |             | -- rvs
-    |             |      | -- rvs-config.cmake
-    |             | -- rocm-bench
-    |                    | -- rocm-bench-config.cmake
-    | -- include
-    |      | -- rvs
-    |      |      | -- rvs.h
-    |      | -- rocm-bench
-    |             | -- rocm_bench.h
-    | -- share
-           | -- doc
-           |      | -- rvs
-           |      |      | -- LICENSE
-           |      | -- rocm-bench
-           |             | -- LICENSE
-           | -- rvs
-           |      | -- conf
-           |      | -- samples
-           | -- rocm-bench
-                  | -- samples
-```
-
-### Side-by-Side Installation
-
-When multiple ROCm major versions are installed on the same system, a
-separate extras tree exists for each. This allows side-by-side operation
-without conflicts:
-
-```
-/opt/rocm/extras-7/
-/opt/rocm/extras-8/
-/opt/rocm/extras/         -> /opt/rocm/extras-8
-```
-
-Within a single extras tree (e.g., `extras-7`), project upgrades are
-installed in-place — there is no side-by-side at the individual project
-level. The ROCm major version is the only axis of side-by-side support.
-
-### Environment Integration
-
-To make extras tools discoverable, packages install a modulefile or profile
-snippet:
-
-```
-/etc/profile.d/amdrocm-extras.sh
-```
-
-This adds `/opt/rocm/extras/bin` to `$PATH` and `/opt/rocm/extras/lib` to
-`$LD_LIBRARY_PATH` (or the equivalent `ld.so.conf.d` drop-in). Because the
-layout is flat, a single profile snippet covers all extras projects. Users
-can target a specific ROCm major version by pointing directly at
-`/opt/rocm/extras-7/bin` instead of the symlink, or by using environment
-modules.
-
-## 5. Packaging Formats
-
-Extras projects must produce packaging formats that align with the formats
-supported by the ROCm Core SDK in TheRock. Not every format applies to
-every extras project — the table below identifies which formats are
-applicable and when to use each.
-
-### Format Overview
-
-| Format                    | Applicable  | Primary use case                                                                                                                                                             |
-| :------------------------ | :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **DEB** (`.deb`)          | Yes         | Installation on Debian-based distributions (Ubuntu, Debian) via `apt` / `dpkg`.                                                                                              |
-| **RPM** (`.rpm`)          | Yes         | Installation on RPM-based distributions (RHEL, SLES, AlmaLinux, CentOS, Rocky, Oracle Linux) via `dnf` / `yum` / `zypper`.                                                  |
-| **Tarball** (`.tar.xz`)   | Yes         | Portable, package-manager-independent installation. Useful for container images, HPC environments without root access, and CI/CD pipelines that consume pre-built artifacts. |
-| **Python wheel** (`.whl`) | Conditional | Only applicable when the extras project ships a Python interface or CLI tool written in Python. Native-only projects (e.g., RVS) do not produce wheels.                      |
-
-### DEB and RPM Packages
-
-Extras projects follow the same native packaging workflow as the ROCm Core
-SDK, as described in the
-[native packaging documentation](/docs/packaging/native_packaging.md).
-Each extras project provides a `package.json` that defines its package
-entries, and TheRock's packaging tooling generates both versioned and
-non-versioned packages.
-
-Key conventions:
-
-- **Naming**: Packages embed the target ROCm major version in the name
-  using the `amdrocm<major>-<project>` convention. This enables
-  side-by-side installation of the same project across different ROCm
-  major versions, since `amdrocm7-rvs` and `amdrocm8-rvs` are distinct
-  packages to the package manager. Distro-native packages use the
-  corresponding `rocm<major>-<project>` convention.
-
-  | AMD repository package | Distro-native equivalent | Contents                                                   |
-  | :--------------------- | :----------------------- | :--------------------------------------------------------- |
-  | `amdrocm7-rvs`         | `rocm7-rvs`              | RVS runtime for ROCm 7.x — binaries, modules, and configs |
-  | `amdrocm7-rvs-devel`   | `rocm7-rvs-dev`          | RVS development headers and CMake files for ROCm 7.x      |
-  | `amdrocm8-rvs`         | `rocm8-rvs`              | RVS runtime for ROCm 8.x                                  |
-- **Runtime vs. development split (optional)**: Projects that expose a
-  public API with headers and CMake config files may choose to produce a
-  separate `-devel` / `-dev` package. Most extras projects are end-user
-  tools built on top of the SDK and ship a single runtime package only.
-
-Example (RVS for ROCm 7 on Ubuntu):
-
-```
-amdrocm7-rvs_1.2.0_amd64.deb
-amdrocm7-rvs-dev_1.2.0_amd64.deb
-```
-
-Example (RVS for ROCm 7 on RHEL):
-
-```
-amdrocm7-rvs-1.2.0.x86_64.rpm
-amdrocm7-rvs-devel-1.2.0.x86_64.rpm
-```
-
-Side-by-side install of RVS across ROCm 7 and ROCm 8:
-
-```bash
-apt install amdrocm7-rvs amdrocm8-rvs
-```
-
-#### Dependency Resolution
-
-End-user projects built on top of ROCm must declare their ROCm
-dependencies correctly so that package managers can resolve and install
-the required ROCm components automatically. The following covers the
-general principles for DEB and RPM dependency resolution and how to map
-them to ROCm's host, architecture-specific, and multi-arch package
-structure.
-
-#### General Principles
-
-DEB and RPM package managers resolve dependencies using metadata declared
-in the package control file (`Depends` for DEB, `Requires` for RPM).
-The following rules apply to all end-user project packages:
-
-1. **Declare only direct dependencies.** List only the ROCm packages
-   the project links against or invokes directly. Transitive dependencies
-   are resolved automatically by the package manager through the ROCm
-   packages' own dependency chains.
-
-1. **Use version ranges, not exact versions.** Pin dependencies to the
-   ROCm major version to honor the compatibility contract from Section 3.
-   Avoid pinning to a specific minor or patch release unless a known
-   minimum is required.
-
-   DEB example (`debian/control`):
-
-   ```
-   Depends: amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0)
-   ```
-
-   RPM example (`.spec`):
-
-   ```
-   Requires: amdrocm-runtimes >= 7.0
-   Requires: amdrocm-runtimes < 8.0
-   ```
-
-1. **Separate build-time and install-time dependencies.** Build
-   dependencies (`Build-Depends` / `BuildRequires`) may reference
-   development packages such as `amdrocm-core-devel`. Runtime packages
-   should only depend on the runtime counterparts.
-
-#### ROCm Dependency Categories
-
-ROCm packages in TheRock are organized into three categories. End-user
-projects must understand this structure to declare the right dependencies.
-
-| Category            | Description                                                                                                                                                                                                                             | Example packages                                    |
-| :------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------- |
-| **Host packages**   | Architecture-independent runtime and libraries — the host-side binaries that work regardless of which GPU is installed. Not all host packages have corresponding device packages; some (e.g., `amdrocm-runtimes`) are purely host-side. | `amdrocm-runtimes`, `amdrocm-core`, `amdrocm-base` |
-| **Device packages** | GPU-architecture-specific binaries containing device code for a particular `gfx` target. Only ROCm library packages that ship pre-compiled GPU kernels produce device variants. These are suffixed with the architecture name.          | `amdrocm-blas-gfx942`, `amdrocm-blas-gfx1100`      |
-| **Meta packages**   | Convenience packages that pull in a set of host + device packages for a given architecture family or the full SDK.                                                                                                                      | `amdrocm`, `amdrocm-core-sdk`, `rocm-gfx90X`       |
-
-#### Mapping End-User Project Dependencies to ROCm
-
-Most end-user projects depend only on **host packages** because they call
-ROCm APIs (HIP, ROCm libraries) and do not ship their own GPU device
-code. The device packages are an end-user installation choice that
-determines which GPUs are supported at runtime — the end-user project
-itself is agnostic to this selection.
-
-**Host-only dependency (typical case)**
-
-An end-user project like RVS links against HIP, ROCm SMI, rocBLAS, and
-the ROCm runtime. Its package declares dependencies on the host packages
-for each component it uses:
-
-DEB:
-
-```
-Depends: amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0),
-         amdrocm-amdsmi (>= 7.0), amdrocm-amdsmi (<< 8.0),
-         amdrocm-blas (>= 7.0), amdrocm-blas (<< 8.0)
-```
-
-RPM:
-
-```
-Requires: amdrocm-runtimes >= 7.0, amdrocm-runtimes < 8.0
-Requires: amdrocm-amdsmi >= 7.0, amdrocm-amdsmi < 8.0
-Requires: amdrocm-blas >= 7.0, amdrocm-blas < 8.0
-```
-
-Note that `amdrocm-runtimes` is a host-only package and does not have
-architecture-specific variants. Libraries like `amdrocm-blas`, however,
-have corresponding device packages (`amdrocm-blas-gfx942`, etc.) that
-contain pre-compiled GPU kernels for specific architectures.
-
-The end-user project depends only on the host packages. The user is
-responsible for installing the device packages for their GPU, either
-individually or through an architecture family meta-package:
-
-```bash
-# Option 1: Install device packages for a specific architecture
-apt install amdrocm-blas-gfx942
-
-# Option 2: Install an architecture family meta-package (pulls in all
-#            device packages for the gfx94X family)
-apt install rocm-gfx94X
-```
-
-The end-user project does not need to know or declare which GPU
-architectures are present.
-
-**Architecture-specific dependency (rare case)**
-
-If an end-user project ships its own pre-compiled GPU kernels for
-specific architectures, it must produce architecture-specific package
-variants and declare dependencies on the matching ROCm library device
-packages:
-
-```
-Package: amdrocm7-mytool-gfx942
-Depends: amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0),
-         amdrocm-blas-gfx942 (>= 7.0), amdrocm-blas-gfx942 (<< 8.0)
-```
-
-Each architecture variant must:
-
-- Not conflict with other architecture variants of the same project.
-- Be independently installable.
-- Follow the `<package>-<gfxarch>` naming convention from
-  [RFC0009](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md).
-
-**Meta-package dependency**
-
-If an end-user project needs the full ROCm runtime stack (not just
-individual libraries), it may depend on a meta-package instead of
-listing each component:
-
-```
-Depends: amdrocm-core (>= 7.0), amdrocm-core (<< 8.0)
-```
-
-This pulls in the complete ROCm Core runtime. Use this approach
-sparingly — prefer fine-grained dependencies to avoid installing
-unnecessary components.
-
-#### Multi-Arch Considerations
-
-ROCm is transitioning to a multi-arch packaging model through
-[RFC0008](/docs/rfcs/RFC0008-Multi-Arch-Packaging.md), where host code
-and device code are split into separate packages using `rocm-kpack`.
-End-user projects should be prepared for this model:
-
-1. **Depend on host packages only.** As ROCm splits host and device
-   code into separate packages, end-user projects that follow the
-   host-only dependency pattern (the typical case above) are
-   automatically compatible — no changes needed.
-
-1. **Do not assume fat binaries.** End-user projects must not assume
-   that ROCm libraries contain embedded device code for all
-   architectures. The device code may reside in separate architecture
-   packages or kpack archives loaded at runtime.
-
-1. **Let the user choose architectures.** The end-user project package
-   should never force-install a specific GPU architecture. Architecture
-   selection is the user's responsibility through device meta-packages:
-
-   ```bash
-   # User installs the end-user project + their architecture
-   apt install amdrocm7-rvs
-   apt install rocm-gfx90X        # User's architecture choice
-   ```
-
-1. **Test against both fat and split layouts.** During the transition
-   period, CI should verify that the end-user project works correctly
-   whether ROCm is installed from fat-binary packages or multi-arch
-   split packages.
-
-#### Dependency Declaration Summary
-
-| Scenario                               | DEB `Depends`                                            | RPM `Requires`                                     |
-| :------------------------------------- | :------------------------------------------------------- | :------------------------------------------------- |
-| Uses HIP runtime                       | `amdrocm-runtimes (>= 7.0), amdrocm-runtimes (<< 8.0)` | `amdrocm-runtimes >= 7.0, amdrocm-runtimes < 8.0` |
-| Uses a ROCm library (e.g., rocBLAS)    | `amdrocm-blas (>= 7.0), amdrocm-blas (<< 8.0)`         | `amdrocm-blas >= 7.0, amdrocm-blas < 8.0`         |
-| Uses ROCm SMI                          | `amdrocm-amdsmi (>= 7.0), amdrocm-amdsmi (<< 8.0)`     | `amdrocm-amdsmi >= 7.0, amdrocm-amdsmi < 8.0`     |
-| Needs full Core SDK runtime            | `amdrocm-core (>= 7.0), amdrocm-core (<< 8.0)`         | `amdrocm-core >= 7.0, amdrocm-core < 8.0`         |
-| Ships own device kernels for a library | `amdrocm-<library>-<gfxarch> (>= 7.0)`                  | `amdrocm-<library>-<gfxarch> >= 7.0`              |
-
-### Tarball Packages
-
-Tarball archives provide a package-manager-independent distribution
-channel. They are the preferred format for:
-
-- Container images where native package managers add unnecessary layer
-  complexity.
-- HPC clusters with shared filesystems and no per-node root access.
-- CI/CD pipelines that need to extract pre-built extras into an arbitrary
-  prefix.
-- Environments where `apt` / `dnf` repositories are not configured.
-
-Tarballs follow the same artifact archive conventions as TheRock, producing
-a `.tar.xz` file with a corresponding `sha256sum`. The archive extracts
-into the flat FHS layout described in Section 4:
-
-```bash
-tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
-    -C /opt/rocm/extras-7/
-```
-
-Tarball naming follows the pattern:
-
-```
-amdrocm<rocm-major>-<project>-<version>-<os>-<arch>.tar.xz
-```
-
-#### Installing ROCm Dependencies for Tarball-Based Deployments
-
-Unlike DEB/RPM packages, tarballs do not have a package manager to
-resolve and install ROCm dependencies automatically. The user must
-ensure a compatible ROCm installation is present before extracting
-the end-user project tarball. There are several options:
-
-**Option 1: ROCm installed via native packages (recommended)**
-
-If the host already has ROCm installed through `apt` or `dnf`, the
-tarball-based end-user project can link against it directly. Verify
-the installed ROCm major version matches:
-
-```bash
-# Check the installed ROCm version
-amd-smi version
-
-# Extract the end-user project into the extras tree
-tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
-    -C /opt/rocm/extras-7/
-```
-
-**Option 2: ROCm installed from tarball**
-
-ROCm itself can be deployed from a tarball into a custom prefix. In
-this case both ROCm and the end-user project are package-manager-free:
-
-```bash
-# Extract ROCm Core SDK tarball
-tar -xf amdrocm-core-7.1.0-linux-x86_64.tar.xz \
-    -C /opt/rocm/core-7/
-
-# Extract the end-user project
-tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
-    -C /opt/rocm/extras-7/
-```
-
-**Option 3: ROCm installed via Python packages**
-
-When ROCm is available through `pip install rocm[core]`, the SDK
-libraries reside inside the Python site-packages directory. Use
-`rocm-sdk path` to locate the installation:
-
-```bash
-ROCM_ROOT=$(rocm-sdk path --root)
-
-tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
-    -C /opt/rocm/extras-7/
-```
-
-#### Connecting Project Binaries with ROCm Libraries
-
-After extracting both ROCm and the end-user project, the project
-binaries must be able to locate ROCm shared libraries at runtime.
-The following options are available, listed from most to least
-preferred:
-
-**Option 1: `$ORIGIN`-based RPATH (built-in, no user action)**
-
-End-user project binaries are built with `$ORIGIN`-relative RPATH
-entries. If the end-user project and ROCm are installed under the
-same `/opt/rocm/` parent, the relative paths resolve automatically
-and no additional configuration is needed.
-
-**Option 2: `LD_LIBRARY_PATH` environment variable**
-
-Set `LD_LIBRARY_PATH` to include the ROCm library directory. This is
-the simplest option when ROCm is installed in a non-standard location
-or when `$ORIGIN` RPATH does not cover the layout:
-
-```bash
-export ROCM_PATH=/opt/rocm/core-7
-export LD_LIBRARY_PATH=${ROCM_PATH}/lib:${LD_LIBRARY_PATH}
-export PATH=/opt/rocm/extras-7/bin:${ROCM_PATH}/bin:${PATH}
-```
-
-**Option 3: `ld.so.conf.d` drop-in (system-wide, requires root)**
-
-Create a linker configuration file so the dynamic linker finds ROCm
-libraries without environment variables:
-
-```bash
-echo "/opt/rocm/core-7/lib" > /etc/ld.so.conf.d/rocm-7.conf
-ldconfig
-```
-
-**Option 4: Environment modules / Lmod**
-
-On HPC clusters, use environment modules to manage ROCm and extras
-paths per user or per job:
-
-```tcl
-# /opt/modulefiles/rocm-extras/7
-set     rocm_root    /opt/rocm/core-7
-set     extras_root  /opt/rocm/extras-7
-
-prepend-path  PATH             $extras_root/bin
-prepend-path  PATH             $rocm_root/bin
-prepend-path  LD_LIBRARY_PATH  $extras_root/lib
-prepend-path  LD_LIBRARY_PATH  $rocm_root/lib
-prepend-path  CMAKE_PREFIX_PATH $extras_root
-prepend-path  CMAKE_PREFIX_PATH $rocm_root
-```
-
-Usage:
-
-```bash
-module load rocm-extras/7
-rvs -d 1
-```
-
-#### Verifying the Setup
-
-After installation and environment configuration, verify that the
-end-user project binaries can find all required ROCm libraries:
-
-```bash
-# Check that all shared library dependencies resolve
-ldd /opt/rocm/extras-7/bin/rvs
-
-# Run the project's built-in sanity check (if available)
-rvs -d 1 -g
-```
-
-Any `not found` entries in the `ldd` output indicate a missing ROCm
-library or an incorrectly configured library search path.
-
-### Python Wheel Packages
-
-Wheels are applicable **only** when an extras project provides a Python
-API, CLI tool, or test harness written in Python. Native-only extras
-projects like RVS do not produce wheels.
-
-When applicable, extras wheels follow the conventions described in the
-[Python packaging documentation](/docs/packaging/python_packaging.md):
-
-- **Selector package**: A source distribution (`rocm<major>-<project>`)
-  that evaluates install-time constraints and pulls the correct runtime
-  wheels.
-- **Runtime wheels**: Contain the minimal set of files needed to run,
-  with no symlinks. SONAME libraries are included directly.
-- **Devel wheels**: Catch-all for headers, CMake files, and symlinks
-  stored in a `_devel.tar` inside the wheel.
-
-Wheels declare a dependency on the ROCm SDK Python packages for the
-matching major version:
-
-```
-Requires-Dist: rocm[core] >=7.0, <8.0
-```
-
-Example build:
-
-```bash
-build_tools/build_python_packages.py \
-    --artifact-dir ./ARTIFACTS_DIR \
-    --dest-dir ./OUTPUT_PKG
-```
-
-Example install:
-
-```bash
-pip install rocm7-mytool --pre \
-    --find-links=./OUTPUT_PKG/dist
-```
-
-### Format Selection Guide
-
-The following table summarizes which format to produce based on the
-project characteristics:
-
-| Project type                  | DEB/RPM | Tarball | Wheel |
-| :---------------------------- | :-----: | :-----: | :---: |
-| Native C/C++ tool (e.g., RVS) |   Yes   |   Yes   |  No   |
-| Pure Python tool/test harness |   No    |   No    |  Yes  |
-| Mixed native + Python library |   Yes   |   Yes   |  Yes  |
-

--- a/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
+++ b/docs/rfcs/RFC0012-End-User-Projects-Independent-Release-Lifecycle.md
@@ -1,5 +1,5 @@
 ---
-author: Freddy Paul
+author: Freddy Paul, Saad Rahim (saadrahim)
 created: 2026-04-14
 modified: 2026-04-14
 status: draft
@@ -56,8 +56,38 @@ release cadence.
 - ROCm Core SDK packaging (covered by RFC0009)
 - GPU driver packaging
 - Internal CI/CD pipeline specifics of individual extras projects
-- ROCm Expansion SDK requirements need a parallel RFC to the requirements in this PR. 
-- These requirements is for software that releases individually and islimited to one version installed per major ROCm version.
+- **ROCm Expansion SDKs** (e.g., the HPC SDK proposed in
+  [PR #5613](https://github.com/ROCm/TheRock/pull/5613)). Expansions are a
+  distinct category and require a parallel RFC. The key difference is the
+  version model: an **expansion pins to and installs a single ROCm version**,
+  whereas the **extras** described here are explicitly designed to support
+  **multiple ROCm major versions side by side** within a single
+  `/opt/rocm/extras/` tree (e.g. the `rvs7` and `rvs8` binaries coexist).
+  The requirements in this RFC do not govern expansions.
+
+### Related RFCs
+
+This RFC defines the **build, release, versioning, and install layout** for
+extras. It is single-responsibility by design and relies on the following
+companion RFCs:
+
+- [**RFC0012 — ROCm Repository Structure** (PR #4414)](https://github.com/ROCm/TheRock/pull/4414):
+  defines the *distribution* layout on `repo.amd.com`, including the single
+  `extras/` folder with per-project subfolders that this RFC's packages are
+  published into.
+- [**RFC00XX — ROCm Repository Setup Packages**](RFC00XX-Repository-Package.md):
+  defines the native `amdrocm-repo-*` rpm/deb tier packages that configure the
+  AMD repositories from which these extras are installed.
+- [**RFC0009 — OS Packaging Requirements**](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md):
+  the native packaging conventions (FHS layout, `-gfxarch` naming) that extras
+  packages inherit.
+- [**RFC0008 — Multi-Arch Packaging**](/docs/rfcs/RFC0008-Multi-Arch-Packaging.md):
+  the host/device package split that extras dependency declarations must be
+  compatible with.
+- [**PR #5613 — ROCm Expansion SDK / HPC SDK**](https://github.com/ROCm/TheRock/pull/5613):
+  the separate expansions track (single ROCm version per install), which is
+  explicitly out of scope here (see Out of Scope above).
+
 ## 2. Release Cadence
 
 Extras projects follow an **independent release cadence** that is not tied
@@ -87,17 +117,18 @@ The project version is entirely independent of the ROCm version it was
 built against. The relationship to the ROCm platform is encoded in two
 ways:
 
-1. **Extras tree version (installation path).** All end-user projects
-   compiled against a given ROCm major version are installed into a
-   single shared prefix whose name carries the ROCm major version:
-
-   ```
-   /opt/rocm/extras-<rocm-major>/
-   ```
-
-   For example, `extras-7` contains every end-user project built for the
-   ROCm 7.x family. This makes compatibility immediately visible from
-   the filesystem path — no additional metadata lookup is required.
+1. **Versioned binary within a single extras tree.** All end-user
+   projects install into one shared prefix — `/opt/rocm/extras/` — with
+   no per-major directory. The public executable is suffixed with the
+   ROCm major (`rvs7`, `rvs8`) and an unsuffixed symlink points at the
+   latest installed major (`rvs` → `rvs7`), so builds for different ROCm
+   majors coexist in the same tree. Shared libraries use **ordinary,
+   project-version-based SONAMEs** (`librvs.so` → `librvs.so.1` →
+   `librvs.so.1.2.0`) — the ROCm major is **not** encoded in the `.so`
+   version. Because an extra bumps its own major version when it retargets
+   a new ROCm major (RVS 1.x for ROCm 7.x, RVS 2.x for ROCm 8.x), the
+   library SONAMEs naturally differ across ROCm majors and coexist via
+   standard linker versioning.
 
 2. **Package name.** Each package embeds the target ROCm major version
    in its name using the `amdrocm<major>-<project>` convention, so the
@@ -110,22 +141,26 @@ ways:
    amdrocm8-rvs-2.0.0       # RVS 2.0.0 for ROCm 8.x
    ```
 
-The combination of both signals — the install path and the package
-name — ensures that whether a user is looking at an installed directory,
-a package filename, or a repository index, the compatible ROCm version
-family is always unambiguous.
+The combination of both signals — the versioned artifact names and the
+package name — ensures that whether a user is looking at an installed
+binary, a package filename, or a repository index, the compatible ROCm
+version family is always unambiguous.
 
 ### ROCm Compatibility Matrix
 
 The following table illustrates how project versions map to ROCm
 compatibility:
 
-| Project version | ROCm target | Package name    | Install path          |
-| :-------------- | :---------- | :-------------- | :-------------------- |
-| rvs-1.0.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
-| rvs-1.1.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
-| rvs-1.2.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras-7/` |
-| rvs-2.0.0       | ROCm 8.x    | `amdrocm8-rvs`  | `/opt/rocm/extras-8/` |
+| Project version | ROCm target | Package name    | Installed binary               |
+| :-------------- | :---------- | :-------------- | :----------------------------- |
+| rvs-1.0.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras/bin/rvs7`    |
+| rvs-1.1.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras/bin/rvs7`    |
+| rvs-1.2.0       | ROCm 7.x    | `amdrocm7-rvs`  | `/opt/rocm/extras/bin/rvs7`    |
+| rvs-2.0.0       | ROCm 8.x    | `amdrocm8-rvs`  | `/opt/rocm/extras/bin/rvs8`    |
+
+All four install into the same `/opt/rocm/extras/` tree; the ROCm major
+is carried by the binary suffix (`rvs7` / `rvs8`), not a per-major
+directory.
 
 ### Release Principles
 
@@ -142,18 +177,19 @@ compatibility:
 ROCm 7.0  ─────── ROCm 7.1 ─────── ROCm 7.2 ──────── ROCm 8.0
   │                  │                  │                  │
   ├─ rvs-1.0.0       │                  │                  │
-  │  (extras-7)      ├─ rvs-1.1.0       │                  │
-  │                  │  (extras-7)      │                  │
+  │  (bin/rvs7)      ├─ rvs-1.1.0       │                  │
+  │                  │  (bin/rvs7)      │                  │
   │                  │    ├─ rvs-1.1.1  │                  │
-  │                  │    (extras-7)    ├─ rvs-1.2.0       │
-  │                  │                  │  (extras-7)      │
+  │                  │    (bin/rvs7)    ├─ rvs-1.2.0       │
+  │                  │                  │  (bin/rvs7)      │
   │                  │                  │                  ├─ rvs-2.0.0
-  │                  │                  │                  │  (extras-8)
+  │                  │                  │                  │  (bin/rvs8)
 ```
 
-In this timeline, all RVS 1.x releases land in `extras-7` and work with
+In this timeline, all RVS 1.x releases install as `rvs7` and work with
 any ROCm 7.x release. When ROCm 8.0 introduces breaking ABI changes, RVS
-publishes a new major version (2.0.0) that installs into `extras-8`.
+publishes a new major version (2.0.0) that installs as `rvs8` alongside
+`rvs7` in the same `/opt/rocm/extras/` tree.
 
 ## 3. Compatibility with ROCm Releases
 
@@ -212,37 +248,52 @@ different ROCm major families must not be mixed.
 
 ## 4. Installed Package Directory Structure
 
-Extras packages install under `/opt/rocm/extras-<rocm-major>/` following
+Extras packages install under a single `/opt/rocm/extras/` prefix following
 the
 [ROCm Linux Filesystem Hierarchy Standard](https://rocm.docs.amd.com/en/latest/conceptual/file-reorg.html)
 and the conventions established in
-[RFC0009](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md). The extras
-tree version matches the ROCm major version it targets, so `extras-7`
-contains all extras built for ROCm 7.x. The layout is **flat** — all
-binaries, libraries, and headers from every extras project are merged into
-this single prefix, with project-specific subfolders under `include/` and
-`share/` for namespace isolation.
+[RFC0009](/docs/rfcs/RFC0009-OS-Packaging-Requirements.md). There is **no
+per-major directory** — every extra, regardless of which ROCm major it
+targets, installs into this one tree. Side-by-side support across ROCm
+majors is provided by a **versioned binary name**: the public executable
+is suffixed with the ROCm major (`rvs7`, `rvs8`), and an unsuffixed
+symlink (`rvs` → `rvs7`) resolves to the latest installed major. Shared
+libraries use **ordinary project-version SONAMEs** (`librvs.so` →
+`librvs.so.1` → `librvs.so.1.2.0`); the ROCm major is **not** encoded in
+the `.so` version. The layout is otherwise **flat** — public binaries and
+libraries from every extras project share the common `bin/` and `lib/`,
+with project-specific subfolders under `include/`, `share/`, and the
+private `lib/`/`libexec/` component directories for namespace isolation.
+
+> **Distribution vs. install layout.** This section describes the *installed*
+> on-disk layout. The *distribution* layout on the AMD repository
+> (`repo.amd.com`) is a separate concern, defined in
+> [RFC0012 — Repository Structure (PR #4414)](https://github.com/ROCm/TheRock/pull/4414):
+> extras are distributed from a single `extras/` folder with per-project
+> subfolders, and the ROCm major version is carried in the *package name*
+> (`amdrocm<major>-<project>`) rather than the repository path. On the
+> installed side, the ROCm major is carried by the binary suffix
+> (`/opt/rocm/extras/bin/rvs7`) rather than a per-major install prefix;
+> libraries use ordinary project-version SONAMEs.
 
 ### Layout
 
 ```
-/opt/rocm/extras-<rocm-major>/
+/opt/rocm/extras/
     | -- bin
-    |      | -- all public binaries across extras projects
+    |      | -- <component><rocm-major>          # versioned public binary (e.g. rvs7)
+    |      | -- <component> -> <component><rocm-major>   # symlink to the latest major
     | -- lib
-    |      | -- lib<soname>.so -> lib<soname>.so.major -> lib<soname>.so.major.minor.patch
-    |      |      (public libraries to link with applications)
-    |      | -- <component>
-    |      |      | -- architecture dependent libraries and binaries used internally
+    |      | -- lib<soname>.so -> lib<soname>.so.<proj-major> -> lib<soname>.so.<proj-ver>   # ordinary project-version SONAME (no ROCm major)
+    |      | -- <component><rocm-major>          # private arch-dependent libs/modules, major-scoped so runtimes coexist
     |      | -- cmake
     |             | -- <component>
-    |                    | -- <component>-config.cmake
+    |                    | -- <component>-config.cmake   # dev files (resolve to the latest major)
     | -- libexec
-    |      | -- <component>
-    |             | -- non-ISA/architecture independent executables used internally
+    |      | -- <component><rocm-major>          # private executables used internally, major-scoped
     | -- include
     |      | -- <component>
-    |             | -- public header files
+    |             | -- public header files       # dev files (latest major)
     | -- share
            | -- html
            |      | -- <component>
@@ -261,30 +312,44 @@ this single prefix, with project-specific subfolders under `include/` and
                   | -- architecture independent misc files (configs, test assets)
 ```
 
-Where `<rocm-major>` is the ROCm major version the extras target (e.g.,
-`7` for ROCm 7.x), and `<component>` is the individual project name
-(e.g., `rvs`).
+Where `<rocm-major>` is the ROCm major version the extra targets (e.g.,
+`7` for ROCm 7.x), `<component>` is the individual project name (e.g.,
+`rvs`), `<proj-major>` is the project's own SONAME major, and `<proj-ver>`
+is the project's full semantic version (e.g., `1.2.0`). Only the `bin/`
+executable and the private `lib/`/`libexec/` component directories carry
+the ROCm major (so multiple majors coexist); the public `lib*.so` uses an
+ordinary project-version SONAME with **no** ROCm major, and
+development-only files (`include/`, `lib/cmake/`) stay per-project and
+resolve to the latest installed major.
 
 ### Symlinks
 
-A soft link provides a stable unversioned path that resolves to the latest
-installed extras tree:
+Unversioned symlinks provide stable paths that resolve to the latest
+installed ROCm major:
 
 ```
-/opt/rocm/extras/         -> /opt/rocm/extras-7
+/opt/rocm/extras/bin/rvs        -> rvs7
+```
+
+Shared libraries keep their conventional development symlink resolving to
+the project SONAME (not the ROCm major):
+
+```
+/opt/rocm/extras/lib/librvs.so  -> librvs.so.1 -> librvs.so.1.2.0
 ```
 
 ### RVS Example
 
-A concrete installation of the `extras-7` tree containing RVS 1.2.0:
+A concrete installation containing RVS 1.2.0 built for ROCm 7.x:
 
 ```
-/opt/rocm/extras-7/
+/opt/rocm/extras/
     | -- bin
-    |      | -- rvs                            # Main RVS executable
+    |      | -- rvs7                           # Main RVS executable (ROCm 7.x)
+    |      | -- rvs -> rvs7                     # symlink to the latest major
     | -- lib
-    |      | -- librvs.so -> librvs.so.1 -> librvs.so.1.2.0
-    |      | -- rvs
+    |      | -- librvs.so -> librvs.so.1 -> librvs.so.1.2.0   # ordinary project SONAME (no ROCm major)
+    |      | -- rvs7                            # private RVS modules for ROCm 7.x
     |      |      | -- libgst.so               # GPU Stress Test module
     |      |      | -- libiet.so               # Input EDPp Test module
     |      |      | -- libpeqt.so              # PCI-Express Qualification Test module
@@ -296,8 +361,8 @@ A concrete installation of the `extras-7` tree containing RVS 1.2.0:
     |                    | -- rvs-config.cmake
     |                    | -- rvs-targets.cmake
     | -- libexec
-    |      | -- rvs
-    |             | -- rvs_worker               # Internal worker process
+    |      | -- rvs7
+    |             | -- rvs_worker               # Internal worker process (ROCm 7.x)
     | -- include
     |      | -- rvs
     |             | -- rvs.h
@@ -321,30 +386,30 @@ A concrete installation of the `extras-7` tree containing RVS 1.2.0:
 ```
 
 When RVS releases a new version (e.g., rvs-1.3.0) while still targeting
-ROCm 7, the updated files are installed in-place into the same `extras-7`
-tree. The extras tree version does not change — only the individual project
-binaries and libraries within it are upgraded.
-
-Symlink:
-
-```
-/opt/rocm/extras/         -> /opt/rocm/extras-7
-```
+ROCm 7, the updated files replace the `rvs7` binary in-place — the
+ROCm-major suffix does not change — and the library advances its ordinary
+project SONAME (`librvs.so.1.3.0`). The `rvs` symlink continues to point
+at `rvs7` until a newer ROCm major is installed.
 
 ### Multiple Extras Projects
 
 When more than one extras project is installed, all projects merge into the
-same flat prefix. The project-specific subfolders under `include/` and
-`share/` prevent namespace collisions:
+same flat prefix. Each public binary keeps its ROCm-major suffix, and the
+project-specific subfolders under `include/` and `share/` prevent namespace
+collisions:
 
 ```
-/opt/rocm/extras-7/
+/opt/rocm/extras/
     | -- bin
-    |      | -- rvs
-    |      | -- rocm-bench
+    |      | -- rvs7
+    |      | -- rvs -> rvs7
+    |      | -- rocm-bench7
+    |      | -- rocm-bench -> rocm-bench7
     | -- lib
-    |      | -- librvs.so
-    |      | -- librocmbench.so
+    |      | -- librvs.so -> librvs.so.1 -> librvs.so.1.2.0
+    |      | -- librocmbench.so -> librocmbench.so.3 -> librocmbench.so.3.0.0
+    |      | -- rvs7
+    |      | -- rocm-bench7
     |      | -- cmake
     |             | -- rvs
     |             |      | -- rvs-config.cmake
@@ -370,19 +435,35 @@ same flat prefix. The project-specific subfolders under `include/` and
 
 ### Side-by-Side Installation
 
-When multiple ROCm major versions are installed on the same system, a
-separate extras tree exists for each. This allows side-by-side operation
-without conflicts:
+When multiple ROCm major versions are installed on the same system, both
+sets of artifacts coexist within the **same** `/opt/rocm/extras/` tree —
+there is no per-major directory. The ROCm-major suffix on each binary
+(and on the private module directory) keeps the executables from
+colliding. The public libraries do **not** carry the ROCm major; they
+coexist through ordinary SONAME versioning because an extra bumps its own
+major when it retargets a new ROCm major (RVS 1.x → ROCm 7, RVS 2.x →
+ROCm 8):
 
 ```
-/opt/rocm/extras-7/
-/opt/rocm/extras-8/
-/opt/rocm/extras/         -> /opt/rocm/extras-8
+/opt/rocm/extras/
+    | -- bin
+    |      | -- rvs7
+    |      | -- rvs8
+    |      | -- rvs -> rvs8                      # latest ROCm major wins
+    | -- lib
+           | -- librvs.so.1 -> librvs.so.1.2.0   # RVS 1.x (built for ROCm 7)
+           | -- librvs.so.2 -> librvs.so.2.0.0   # RVS 2.x (built for ROCm 8)
+           | -- librvs.so -> librvs.so.2         # newest project SONAME
+           | -- rvs7                             # ROCm 7 private modules
+           | -- rvs8                             # ROCm 8 private modules
 ```
 
-Within a single extras tree (e.g., `extras-7`), project upgrades are
-installed in-place — there is no side-by-side at the individual project
-level. The ROCm major version is the only axis of side-by-side support.
+Within a single ROCm major (e.g. `rvs7`), project upgrades are installed
+in-place — there is no side-by-side at the individual project level. The
+ROCm major version is the only axis of side-by-side support. Development
+files (`include/`, `lib/cmake/`) are not major-suffixed and reflect the
+most recently installed major; consumers needing headers for a specific
+older major should install that major last or use a dedicated environment.
 
 ### Environment Integration
 
@@ -394,11 +475,11 @@ snippet:
 ```
 
 This adds `/opt/rocm/extras/bin` to `$PATH` and `/opt/rocm/extras/lib` to
-`$LD_LIBRARY_PATH` (or the equivalent `ld.so.conf.d` drop-in). Because the
-layout is flat, a single profile snippet covers all extras projects. Users
-can target a specific ROCm major version by pointing directly at
-`/opt/rocm/extras-7/bin` instead of the symlink, or by using environment
-modules.
+`$LD_LIBRARY_PATH` (or the equivalent `ld.so.conf.d` drop-in). Because all
+majors share the one tree, a single profile snippet covers every extras
+project and every ROCm major. Invoking `rvs` runs the latest installed
+major (via the `rvs` → `rvs7` symlink); to target a specific major, call
+the suffixed binary directly (`rvs7`, `rvs8`).
 
 ## 5. Packaging Formats
 
@@ -663,7 +744,7 @@ into the flat FHS layout described in Section 4:
 
 ```bash
 tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
-    -C /opt/rocm/extras-7/
+    -C /opt/rocm/extras/
 ```
 
 Tarball naming follows the pattern:
@@ -691,7 +772,7 @@ amd-smi version
 
 # Extract the end-user project into the extras tree
 tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
-    -C /opt/rocm/extras-7/
+    -C /opt/rocm/extras/
 ```
 
 **Option 2: ROCm installed from tarball**
@@ -706,7 +787,7 @@ tar -xf amdrocm-core-7.1.0-linux-x86_64.tar.xz \
 
 # Extract the end-user project
 tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
-    -C /opt/rocm/extras-7/
+    -C /opt/rocm/extras/
 ```
 
 **Option 3: ROCm installed via Python packages**
@@ -719,7 +800,7 @@ libraries reside inside the Python site-packages directory. Use
 ROCM_ROOT=$(rocm-sdk path --root)
 
 tar -xf amdrocm7-rvs-1.2.0-linux-x86_64.tar.xz \
-    -C /opt/rocm/extras-7/
+    -C /opt/rocm/extras/
 ```
 
 #### Connecting Project Binaries with ROCm Libraries
@@ -745,7 +826,7 @@ or when `$ORIGIN` RPATH does not cover the layout:
 ```bash
 export ROCM_PATH=/opt/rocm/core-7
 export LD_LIBRARY_PATH=${ROCM_PATH}/lib:${LD_LIBRARY_PATH}
-export PATH=/opt/rocm/extras-7/bin:${ROCM_PATH}/bin:${PATH}
+export PATH=/opt/rocm/extras/bin:${ROCM_PATH}/bin:${PATH}
 ```
 
 **Option 3: `ld.so.conf.d` drop-in (system-wide, requires root)**
@@ -766,7 +847,7 @@ paths per user or per job:
 ```tcl
 # /opt/modulefiles/rocm-extras/7
 set     rocm_root    /opt/rocm/core-7
-set     extras_root  /opt/rocm/extras-7
+set     extras_root  /opt/rocm/extras
 
 prepend-path  PATH             $extras_root/bin
 prepend-path  PATH             $rocm_root/bin
@@ -790,7 +871,7 @@ end-user project binaries can find all required ROCm libraries:
 
 ```bash
 # Check that all shared library dependencies resolve
-ldd /opt/rocm/extras-7/bin/rvs
+ldd /opt/rocm/extras/bin/rvs7
 
 # Run the project's built-in sanity check (if available)
 rvs -d 1 -g
@@ -806,21 +887,57 @@ API, CLI tool, or test harness written in Python. Native-only extras
 projects like RVS do not produce wheels.
 
 When applicable, extras wheels follow the conventions described in the
-[Python packaging documentation](/docs/packaging/python_packaging.md):
+[Python packaging documentation](/docs/packaging/python_packaging.md).
 
-- **Selector package**: A source distribution (`rocm<major>-<project>`)
-  that evaluates install-time constraints and pulls the correct runtime
-  wheels.
+> **Wheel naming differs from native packages.** Unlike DEB/RPM packages,
+> a Python wheel **does not embed the ROCm major version in its distribution
+> name**. The wheel is named `rocm-<project>` (e.g., `rocm-rvs`), and the
+> ROCm major version is carried by metadata instead. This follows Python
+> packaging norms — PyPI treats `rocm7-rvs` and `rocm8-rvs` as unrelated
+> projects, which breaks `pip`'s upgrade and conflict resolution — and avoids
+> squatting a new PyPI name for every ROCm major.
+
+The target ROCm major version is encoded by **doing both** of the following,
+so the binding is visible to humans *and* enforced by the resolver:
+
+1. **PEP 440 local-version segment.** Each wheel carries a `+rocm<major>`
+   local-version tag, so the compatibility target is visible in the version
+   string and in `pip list`:
+
+   ```
+   rocm_rvs-1.2.0+rocm7-py3-none-linux_x86_64.whl   # RVS 1.2.0 for ROCm 7.x
+   rocm_rvs-2.0.0+rocm8-py3-none-linux_x86_64.whl   # RVS 2.0.0 for ROCm 8.x
+   ```
+
+2. **Non-overlapping `Requires-Dist` range.** The wheel declares a dependency
+   on the ROCm SDK Python packages pinned to a single major version. The
+   ranges across majors never overlap, so `pip` can only resolve a wheel
+   against a matching ROCm install:
+
+   ```
+   Requires-Dist: rocm[core] >=7.0, <8.0
+   ```
+
 - **Runtime wheels**: Contain the minimal set of files needed to run,
   with no symlinks. SONAME libraries are included directly.
 - **Devel wheels**: Catch-all for headers, CMake files, and symlinks
   stored in a `_devel.tar` inside the wheel.
 
-Wheels declare a dependency on the ROCm SDK Python packages for the
-matching major version:
+**PyPI name reservation.** To prevent dependency-confusion attacks, the
+`rocm-<project>` name should be reserved (registered) on public PyPI even if
+the wheels are primarily distributed through AMD's own index. This blocks a
+malicious actor from publishing a same-named package that `pip` might prefer.
+
+**Pinning across a fleet.** `pip` has no `apt-mark hold` equivalent, so
+fleet-wide version control is done with a constraints file:
 
 ```
-Requires-Dist: rocm[core] >=7.0, <8.0
+# rocm-constraints.txt
+rocm-rvs==1.2.0+rocm7
+```
+
+```bash
+pip install -c rocm-constraints.txt rocm-rvs
 ```
 
 Example build:
@@ -831,10 +948,18 @@ build_tools/build_python_packages.py \
     --dest-dir ./OUTPUT_PKG
 ```
 
-Example install:
+Example install (resolver selects the major via `Requires-Dist` against the
+installed ROCm):
 
 ```bash
-pip install rocm7-mytool --pre \
+pip install rocm-rvs --pre \
+    --find-links=./OUTPUT_PKG/dist
+```
+
+Example install (explicitly pinned to a ROCm major):
+
+```bash
+pip install "rocm-rvs==1.2.0+rocm7" --pre \
     --find-links=./OUTPUT_PKG/dist
 ```
 


### PR DESCRIPTION
## Motivation

A proposal on how to build and release tools/libraries on top of ROCm Core SDK

## Technical Details

With ROCm Core SDK delivered in different format(tar/rpm/deb/wheel) this proposal explains how each project can be build against a version of ROCm Core SDK and delivered with respective packaging format matching to ROCm Core.

Explains how the dependency of application/tools/libraries shall be established with ROCm core SDK.
This also  covers how versioning of projects can be established in relation to ROCm core to set the compatibility matrix with ROCm Core SDK.

Explains how user environments shall be configured to connect installed version of ROCm and tools/libraries with right compatibility.
