### PR TITLE
CI: install Python deps with uv --no-cache to avoid corrupted wheel cache

### DIFF
--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -56,7 +56,7 @@ runs:
     - name: Install test requirements
       shell: bash
       run: |
-        uv pip install -r requirements-test.txt
+        uv pip install -r requirements-test.txt --no-cache
         uv pip freeze
 
     - name: Install Choco tools


### PR DESCRIPTION
## Motivation
The Multi-Arch CI job failed during dependency install with:
- `Failed to install: requests-2.33.0...`
- `The wheel is invalid: Metadata field Name not found`
This error is consistent with a corrupted/partial wheel being reused from cache. Passing --no-cache forces uv to install fresh artifacts.

## Test Plan

CI checks running.

## Test Result

TBD

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
