### PR TITLE
CI : Skip` amdsmitstReadWrite.FanReadWrite` in ROCm sanity checks for gfx130x, gfx120x

### DIFF
--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -208,6 +208,12 @@ class TestROCmSanity:
                     "amdsmitstReadWrite.FanReadWrite",
                 ]
             },
+            "gfx103x": {
+                # TODO(#2963): Re-enable once amdsmi tests are fixed for gfx103x
+                "linux": [
+                    "amdsmitstReadWrite.FanReadWrite",
+                ]
+            },
         }
 
         platform_key = "windows" if is_windows() else "linux"

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -219,7 +219,7 @@ class TestROCmSanity:
                 "linux": [
                     "amdsmitstReadWrite.FanReadWrite",
                 ]
-            }
+            },
         }
 
         platform_key = "windows" if is_windows() else "linux"

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -208,7 +208,7 @@ class TestROCmSanity:
                     "amdsmitstReadWrite.FanReadWrite",
                 ]
             },
-            "gfx103x": {
+            "gfx103X-all": {
                 # TODO(#2963): Re-enable once amdsmi tests are fixed for gfx103x
                 "linux": [
                     "amdsmitstReadWrite.FanReadWrite",

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -214,6 +214,12 @@ class TestROCmSanity:
                     "amdsmitstReadWrite.FanReadWrite",
                 ]
             },
+            "gfx120X-all": {
+                # TODO(#2963): Re-enable once amdsmi tests are fixed for gfx120X-all
+                "linux": [
+                    "amdsmitstReadWrite.FanReadWrite",
+                ]
+            }
         }
 
         platform_key = "windows" if is_windows() else "linux"


### PR DESCRIPTION
## Motivation
Skip `amdsmitstReadWrite.FanReadWrite` for `gfx103x` , `gfx120x` as part of the ROCm sanity checks so that CI continues to validate AMD SMI functionality without being blocked by a hardware/permission-specific fan write test.
more details: https://github.com/ROCm/TheRock/issues/2963

## Test Plan

CI Nightly : 
gfx103x: https://github.com/ROCm/TheRock/actions/runs/24773357242
gfx120x: https://github.com/ROCm/TheRock/actions/runs/24788962974 

## Test Result

Sanity Checks passed: 
gfx103x: https://github.com/ROCm/TheRock/actions/runs/24773357242/job/72485464964
gfx120x: https://github.com/ROCm/TheRock/actions/runs/24788962974/job/72546141455

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
