### PR TITLE
[debug-tools] rocgdb test script improvement

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocgdb.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocgdb.py
@@ -889,14 +889,25 @@ def check_executables(executables: List[str]) -> None:
         _log_error_and_exit(f"Missing {len(missing)} executables required for testing.")
 
 
-def set_core_file_limit() -> bool:
+def setup_core_file_info() -> bool:
     """
-    Set system core file size limit to unlimited.
+    Set system core file size limit to unlimited and display core file pattern.
 
     Returns:
         True if successfully set to unlimited, False otherwise.
     """
-    print_section("Core file size")
+    print_section("Core file information")
+
+    # Display current core file pattern.
+    core_pattern_file = Path("/proc/sys/kernel/core_pattern")
+    try:
+        if core_pattern_file.exists():
+            core_pattern = core_pattern_file.read_text().strip()
+            logger.info(f"System core file pattern: {core_pattern}")
+        else:
+            logger.info("System core file pattern: N/A (file not found)")
+    except (PermissionError, IOError) as e:
+        logger.info(f"System core file pattern: N/A (unable to read: {e})")
 
     try:
         resource.setrlimit(
@@ -1351,8 +1362,8 @@ def main() -> None:
     )
 
     if platform.system() == "Linux":
-        # Set core dump file limit.
-        set_core_file_limit()
+        # Set core dump file limit and display info.
+        setup_core_file_info()
 
     # Prepare environment for tests.
     env_vars = setup_environment(artifacts_dir)

--- a/build_tools/github_actions/test_executable_scripts/test_rocgdb.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocgdb.py
@@ -271,6 +271,18 @@ def parse_arguments() -> argparse.Namespace:
         default=100,
         help="Timeout value in seconds for individual tests (max: 600). Default is 100.",
     )
+    parser.add_argument(
+        "--check-type",
+        type=str,
+        choices=["check", "check-read1", "check-readmore"],
+        default="check",
+        help="Which GDB testsuite target to invoke. 'check' is the normal run."
+        "'check-read1' runs under an LD_PRELOAD shim that forces read(2) to"
+        "return 1 byte at a time (stress-tests GDB's incremental I/O parsing)."
+        "'check-readmore' forces large reads (the opposite extreme). These"
+        "are upstream GDB testsuite modes and can surface real GDB bugs that"
+        "'check' alone misses. Default: 'check'.",
+    )
 
     args = parser.parse_args()
 
@@ -1228,7 +1240,7 @@ def run_tests(
 
         cmd = [
             "make",
-            "check",
+            args.check_type,
             f"RUNTESTFLAGS={runtestflags_str}",
             f"TESTS={current_tests}",
         ]
@@ -1529,6 +1541,7 @@ def print_configuration(
     logger.info(f"  Testsuite Directory:  {testsuite_dir}")
     logger.info(f"  Configure Script:     {configure_script}")
     logger.info(f"  Tests:                {' '.join(args.tests)}")
+    logger.info(f"  Check Type:           {args.check_type}")
     logger.info(f"  Parallel Execution:   {'Enabled' if args.parallel else 'Disabled'}")
     logger.info(f"  Use FAIL ignore list: {'Not using' if args.no_xfail else 'Using'}")
     logger.info(


### PR DESCRIPTION
A couple improvements to the rocgdb testing script, which we might use in the future for TheRock CI.

[Add --check-type option to test_rocgdb.py script](https://github.com/ROCm/TheRock/commit/d3133b0f355b06f40f74a48b4c4cd089f3cfab29) 

Adds a new --check-type command-line argument to support different test
execution modes. The option accepts three choices:
- check: regular test execution (default)
- check-read1: reads 1 character at a time
- check-readmore: reads a lot of characters at a time

The selected check type is passed to the make command and displayed in
the configuration summary.

[Display core file pattern in test_rocgdb.py](https://github.com/ROCm/TheRock/commit/57cb49ccbcc524da895bc1a30797a091e7e94e4f) 

Enhances the core file information section to display the current system
core file pattern from /proc/sys/kernel/core_pattern alongside the ulimit
information. This helps diagnose core dump configuration issues.

Changes:
- Rename set_core_file_limit() to setup_core_file_info()
- Rename section from "Core file size" to "Core file information"
- Add display of system core file pattern before setting ulimit
- Handle cases where the pattern file is missing or unreadable