### PR TITLE
[profiler] Declare rocprof-trace-decoder as a provided package

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -11,7 +11,6 @@ if(THEROCK_ENABLE_ROCPROFV3)
   # rocprof-trace-decoder
   # The trace decoder is responsible for decoding advanced thread traces from the
   # GPU and is used at runtime by `rocprofv3 --att`.
-  # See: https://github.com/ROCm/rocprof-trace-decoder/
   ##############################################################################
   therock_cmake_subproject_declare(rocprof-trace-decoder
     # The build infrastructure requires generic stages to pass through

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -24,6 +24,11 @@ if(THEROCK_ENABLE_ROCPROFV3)
   therock_cmake_subproject_provide_package(rocprof-trace-decoder rocprof-trace-decoder lib/cmake/rocprof-trace-decoder)
   therock_cmake_subproject_activate(rocprof-trace-decoder)
 
+  therock_test_validate_shared_lib(PATH ${CMAKE_CURRENT_BINARY_DIR}/rocprof-trace-decoder/dist/lib
+    LIB_NAMES
+      librocprof-trace-decoder.so
+  )
+
   ##############################################################################
   # aqlprofile
   ##############################################################################

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -21,6 +21,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprof-trace-decoder"
     BACKGROUND_BUILD
   )
+  therock_cmake_subproject_provide_package(rocprof-trace-decoder rocprof-trace-decoder lib/cmake/rocprof-trace-decoder)
   therock_cmake_subproject_activate(rocprof-trace-decoder)
 
   ##############################################################################


### PR DESCRIPTION
  rocprofiler-sdk's cmake/rocprofiler_config_interfaces.cmake calls
  find_package(rocprof-trace-decoder REQUIRED CONFIG). Without a
  matching therock_cmake_subproject_provide_package declaration,
  THEROCK_PACKAGE_DIR_rocprof-trace-decoder is never set and the
  dep_provider falls through to a system search (line 73), which fails
  in CI:

    Could not find a package configuration file provided by
    "rocprof-trace-decoder" with any of the following names:
        rocprof-trace-decoderConfig.cmake
        rocprof-trace-decoder-config.cmake

  The relpath lib/cmake/rocprof-trace-decoder matches what the
  trace-decoder project installs (TTD_CONFIG_INSTALL_DIR =
  ${CMAKE_INSTALL_LIBDIR}/cmake/rocprof-trace-decoder, with
  CMAKE_INSTALL_LIBDIR forced to "lib"). Same shape as the existing
  declarations for rocdecode, rocjpeg, rdc, etc.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
