### PR TITLE
Add versioned OpenCL configuration files for multi-version ROCm support

### DIFF
--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -447,7 +447,8 @@ def rename_etc_files_with_version(etc_dir, version, version_suffix):
             f.write("/opt/rocm/core/lib/opencl\n")
 
         # Rename with version
-        new_name = f"10-rocm{version}-opencl-{version_suffix}.conf"
+        version_str = version_to_str(version)
+        new_name = f"10-rocm{version_str}-{version_suffix}-opencl.conf"
         new_path = ldso_conf.parent / new_name
         ldso_conf.rename(new_path)
         print(f"Renamed: {ldso_conf.name} -> {new_name}")
@@ -456,7 +457,8 @@ def rename_etc_files_with_version(etc_dir, version, version_suffix):
     # Rename OpenCL ICD file
     icd_file = etc_path / "OpenCL" / "vendors" / "amdocl64.icd"
     if icd_file.exists():
-        new_name = f"amdocl64_{version}_{version_suffix}.icd"
+        version_str = version_to_str(version)
+        new_name = f"amdocl64_{version_str}_{version_suffix}.icd"
         new_path = icd_file.parent / new_name
         icd_file.rename(new_path)
         print(f"Renamed: {icd_file.name} -> {new_name}")
@@ -682,6 +684,7 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
     context = {
         "pkg_name": pkg_name,
         "version": version,
+        "version_str": version_to_str(version),
         "release": config.version_suffix,
         "build_arch": pkg_info.get("BuildArch"),
         "description_short": pkg_info.get("Description_Short"),

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -167,6 +167,18 @@ def create_versioned_deb_package(pkg_name, config: PackageConfig):
         if build_config.enable_rpath:
             convert_runpath_to_rpath(package_dir)
 
+        # Move etc files to system /etc location
+        etc_source = dest_dir / "etc"
+        if etc_source.exists() and etc_source.is_dir():
+            etc_dest = package_dir / "etc"
+            etc_dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(etc_source), str(etc_dest))
+
+            # Rename OpenCL configuration files with version
+            rename_etc_files_with_version(
+                etc_dest, build_config.rocm_version, build_config.version_suffix
+            )
+
         # Generate install file after copying, so we can check for hidden files
         generate_install_file(pkg_info, deb_dir, build_config, dest_dir)
 
@@ -249,6 +261,10 @@ def generate_install_file(pkg_info, deb_dir, config: PackageConfig, dest_dir=Non
             else:
                 has_regular_files = True
 
+    # Check if etc files exist at the package root (moved from install_prefix/etc)
+    package_dir = Path(deb_dir).parent
+    has_etc_files = (package_dir / "etc").exists()
+
     env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
     template = env.get_template("template/debian_install.j2")
     # Prepare your context dictionary
@@ -256,6 +272,7 @@ def generate_install_file(pkg_info, deb_dir, config: PackageConfig, dest_dir=Non
         "path": config.install_prefix,
         "has_hidden_files": has_hidden_files,
         "has_regular_files": has_regular_files,
+        "has_etc_files": has_etc_files,
     }
 
     with install_file.open("w", encoding="utf-8") as f:
@@ -404,6 +421,45 @@ def generate_debian_postscripts(pkg_info, deb_dir, config: PackageConfig):
             with script_file.open("w", encoding="utf-8") as f:
                 f.write(template.render(context))
             os.chmod(script_file, 0o755)
+
+
+def rename_etc_files_with_version(etc_dir, version, version_suffix):
+    """Rename OpenCL configuration files to include ROCm version and version suffix.
+
+    Parameters:
+    etc_dir : Path to the etc directory
+    version : ROCm version string
+    version_suffix : Version suffix string
+
+    Returns: None
+    """
+    print_function_name()
+
+    etc_path = Path(etc_dir)
+    if not etc_path.exists():
+        return
+
+    # Rename and edit ld.so.conf.d file
+    ldso_conf = etc_path / "ld.so.conf.d" / "10-rocm-opencl.conf"
+    if ldso_conf.exists():
+        # Update content to use /opt/rocm/core/lib/opencl
+        with ldso_conf.open("w", encoding="utf-8") as f:
+            f.write("/opt/rocm/core/lib/opencl\n")
+
+        # Rename with version
+        new_name = f"10-rocm{version}-opencl-{version_suffix}.conf"
+        new_path = ldso_conf.parent / new_name
+        ldso_conf.rename(new_path)
+        print(f"Renamed: {ldso_conf.name} -> {new_name}")
+        print(f"Updated content to: /opt/rocm/core/lib/opencl")
+
+    # Rename OpenCL ICD file
+    icd_file = etc_path / "OpenCL" / "vendors" / "amdocl64.icd"
+    if icd_file.exists():
+        new_name = f"amdocl64_{version}_{version_suffix}.icd"
+        new_path = icd_file.parent / new_name
+        icd_file.rename(new_path)
+        print(f"Renamed: {icd_file.name} -> {new_name}")
 
 
 def copy_package_contents(source_dir, destination_dir):
@@ -618,6 +674,9 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
 
     pkg_name = update_package_name(pkg_name, config)
 
+    # Check if any source directories contain etc files
+    has_etc_files = any((Path(src_dir) / "etc").exists() for src_dir in sourcedir_list)
+
     env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
     template = env.get_template("template/rpm_specfile.j2")
     context = {
@@ -642,6 +701,7 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
         "sourcedir_list": sourcedir_list,
         "rpm_scripts": rpm_scripts,
         "exclude_libpython_requires": exclude_libpython_requires,
+        "has_etc_files": has_etc_files,
     }
 
     with open(specfile, "w", encoding="utf-8") as f:

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1502,6 +1502,7 @@
         ]
       }
     ],
+    "Postinstall": "True",
     "Gfxarch": "False"
   },
   {

--- a/build_tools/packaging/linux/template/debian_install.j2
+++ b/build_tools/packaging/linux/template/debian_install.j2
@@ -1,3 +1,6 @@
+{%- if has_etc_files %}
+./etc  /
+{%- endif %}
 {%- if has_regular_files %}
 .{{path}}/*  {{path}}
 {%- endif %}

--- a/build_tools/packaging/linux/template/rpm_specfile.j2
+++ b/build_tools/packaging/linux/template/rpm_specfile.j2
@@ -73,11 +73,11 @@ if [ -d "$RPM_BUILD_ROOT{{ install_prefix }}/etc" ]; then
         echo "/opt/rocm/core/lib/opencl" > "$RPM_BUILD_ROOT/etc/ld.so.conf.d/10-rocm-opencl.conf"
         # Rename with version
         mv "$RPM_BUILD_ROOT/etc/ld.so.conf.d/10-rocm-opencl.conf" \
-           "$RPM_BUILD_ROOT/etc/ld.so.conf.d/10-rocm{{ version }}-opencl-{{ release }}.conf"
+           "$RPM_BUILD_ROOT/etc/ld.so.conf.d/10-rocm{{ version_str }}-{{ release }}-opencl.conf"
     fi
     if [ -f "$RPM_BUILD_ROOT/etc/OpenCL/vendors/amdocl64.icd" ]; then
         mv "$RPM_BUILD_ROOT/etc/OpenCL/vendors/amdocl64.icd" \
-           "$RPM_BUILD_ROOT/etc/OpenCL/vendors/amdocl64_{{ version }}_{{ release }}.icd"
+           "$RPM_BUILD_ROOT/etc/OpenCL/vendors/amdocl64_{{ version_str }}_{{ release }}.icd"
     fi
 fi
 

--- a/build_tools/packaging/linux/template/rpm_specfile.j2
+++ b/build_tools/packaging/linux/template/rpm_specfile.j2
@@ -61,7 +61,30 @@ mkdir -p $RPM_BUILD_ROOT{{ install_prefix }}
 }
 {% endfor %}
 
+# Move etc files to system /etc directory
+if [ -d "$RPM_BUILD_ROOT{{ install_prefix }}/etc" ]; then
+    mkdir -p $RPM_BUILD_ROOT/etc
+    cp -R "$RPM_BUILD_ROOT{{ install_prefix }}/etc"/* $RPM_BUILD_ROOT/etc/
+    rm -rf "$RPM_BUILD_ROOT{{ install_prefix }}/etc"
+
+    # Rename and edit OpenCL configuration files with version
+    if [ -f "$RPM_BUILD_ROOT/etc/ld.so.conf.d/10-rocm-opencl.conf" ]; then
+        # Update content to use /opt/rocm/core/lib/opencl
+        echo "/opt/rocm/core/lib/opencl" > "$RPM_BUILD_ROOT/etc/ld.so.conf.d/10-rocm-opencl.conf"
+        # Rename with version
+        mv "$RPM_BUILD_ROOT/etc/ld.so.conf.d/10-rocm-opencl.conf" \
+           "$RPM_BUILD_ROOT/etc/ld.so.conf.d/10-rocm{{ version }}-opencl-{{ release }}.conf"
+    fi
+    if [ -f "$RPM_BUILD_ROOT/etc/OpenCL/vendors/amdocl64.icd" ]; then
+        mv "$RPM_BUILD_ROOT/etc/OpenCL/vendors/amdocl64.icd" \
+           "$RPM_BUILD_ROOT/etc/OpenCL/vendors/amdocl64_{{ version }}_{{ release }}.icd"
+    fi
+fi
+
 %files
+{%- if has_etc_files %}
+/etc
+{%- endif %}
 {{ install_prefix }}
 
 %clean

--- a/build_tools/packaging/linux/template/scripts/amdrocm-opencl-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-opencl-postinst.j2
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+{% if target == "deb" %}
+do_ldconfig() {
+  ldconfig
+}
+
+case "$1" in
+  abort-deconfigure|abort-remove|abort-upgrade)
+    echo "$1"
+  ;;
+  configure)
+    do_ldconfig
+  ;;
+  *)
+    exit 0
+  ;;
+esac
+{% else %}
+# RPM post-install
+ldconfig
+{% endif %}

--- a/build_tools/packaging/linux/template/scripts/amdrocm-opencl-postrm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-opencl-postrm.j2
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+{% if target == "deb" %}
+rm_ldconfig() {
+  ldconfig
+}
+
+case "$1" in
+  purge)
+  ;;
+  remove | upgrade )
+    rm_ldconfig
+  ;;
+  *)
+    exit 0
+  ;;
+esac
+{% else %}
+# RPM post-uninstall
+if [ $1 -eq 0 ]; then
+  # ldconfig during remove/uninstall operation. No ldconfig during upgrade
+  ldconfig
+fi
+{% endif %}


### PR DESCRIPTION
  Move OpenCL configuration files from ROCm install prefix to system /etc
  directory with version-specific naming to allow multiple ROCm versions to
  coexist on the same system.

  Changes:
  - Rename amdocl64.icd to amdocl64_{version}_{suffix}.icd format
  - Rename 10-rocm-opencl.conf to 10-rocm{version}-opencl-{suffix}.conf format
  - Update ld.so.conf.d content to reference /opt/rocm/core/lib/opencl
  - Add post-install/removal scripts to run ldconfig for both DEB and RPM packages
  - Enable Postinstall flag for amdrocm-opencl package in package.json

