### PR TITLE
Replace manual `rocprof-sys` symlink map with pattern-based generation

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -54,18 +54,12 @@ def ensure_profiler_library_symlinks(profiler: PopulatedDistPackage) -> None:
     """Recreate unversioned profiler library symlinks expected by dlopen()."""
     profiler_lib_dir = profiler.platform_dir / "lib"
 
-    symlink_pairs = [
-        ("librocprof-sys.so", "librocprof-sys.so.1"),
-        ("librocprof-sys-dl.so", "librocprof-sys-dl.so.1"),
-        ("librocprof-sys-rt.so", "librocprof-sys-rt.so.1"),
-        ("librocprof-sys-user.so", "librocprof-sys-user.so.1"),
-    ]
-
-    for link_name, target_name in symlink_pairs:
-        target = profiler_lib_dir / target_name
-        link = profiler_lib_dir / link_name
-        if target.exists() and not link.exists():
-            link.symlink_to(target_name)
+    for target in profiler_lib_dir.glob("librocprof-sys*.so.*"):
+        if target.is_symlink():
+            continue
+        link = target.with_suffix("")
+        if not link.exists():
+            link.symlink_to(target.name)
 
 
 def run(args: argparse.Namespace):


### PR DESCRIPTION
Follow-up for https://github.com/ROCm/TheRock/pull/4518

Replace manual rocprof-sys symlink map with pattern-based generation

- generate unversioned librocprof-sys*.so symlinks from versioned .so.* files
- removes need for manual maintenance of symlink list
- preserves dlopen compatibility for rocprof-sys runtime

Validated:
- `_rocm_profiler` no longer bundles duplicate `rocm_sysdeps`
- `_rocm_sdk_core/lib/rocm_sysdeps/lib` contains the sysdeps payload
- unversioned `librocprof-sys*.so` symlinks are present after pip install
- `ldd` shows `rocprof-sys-run` resolving `librocm_sysdeps_*` from `_rocm_sdk_core/lib/rocm_sysdeps/lib`
- `ldd` shows `rocprof-sys-instrument` resolving `libomp.so` from `_rocm_sdk_core/lib/llvm/lib`
- no unresolved shared-library dependencies for the tested `rocprof-sys-*` binaries
- direct `dlopen()` of `librocprof-sys-dl.so` succeeds
- end-to-end runtime test `rocprof-sys-sample -- ls -al` succeeds

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
