### PR TITLE
rocrtst: Added dependency yaml-cpp by rocrtst

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -478,7 +478,7 @@ if(THEROCK_BUILD_TESTING)
     set(_rocrtst_build_deps
       amd-llvm
       ocl-clr
-      yaml-cpp
+      therock-yaml-cpp
     )
     if(TARGET amdsmi)
       list(APPEND _rocrtst_build_deps amdsmi)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -478,6 +478,7 @@ if(THEROCK_BUILD_TESTING)
     set(_rocrtst_build_deps
       amd-llvm
       ocl-clr
+      yaml-cpp
     )
     if(TARGET amdsmi)
       list(APPEND _rocrtst_build_deps amdsmi)


### PR DESCRIPTION
## Motivation

rocrtst has been updated to use process a YAML file and now requires yaml-cpp to parse it.

## Technical Details

Added a dependency by  _rocrtst_build_deps in core/CMakeLists.txt on therock-yaml-cpp.