### PR TITLE
[WIP] [rocprofiler-systems] Build examples as standalone and have CTest as the test executor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 [submodule "rocm-systems"]
 	path = rocm-systems
 	url = https://github.com/ROCm/rocm-systems.git
-	branch = develop
+	branch = users/kcossett-amd/ctests-for-pytests
 [submodule "spirv-llvm-translator"]
 	path = compiler/spirv-llvm-translator
 	url = https://github.com/ROCm/SPIRV-LLVM-Translator.git

--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -724,6 +724,13 @@ feature_name = "ROCPROFSYS"
 feature_group = "PROFILER"
 disable_platforms = ["windows"]
 
+[artifacts.rocprofiler-systems-examples]
+artifact_group = "profiler-apps"
+type = "target-specific"
+artifact_deps = ["rocprofiler-systems"]
+feature_group = "PROFILER"
+disable_platforms = ["windows"]
+
 # --- Data Center Tools ---
 
 [artifacts.rdc]

--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -726,7 +726,9 @@ disable_platforms = ["windows"]
 
 [artifacts.rocprofiler-systems-examples]
 artifact_group = "profiler-apps"
-type = "target-specific"
+# target-neutral (rather than target-specific) so the kpack artifact splitter
+# does not strip per-arch HIP offload bundles out of the example binaries.
+type = "target-neutral"
 artifact_deps = ["rocprofiler-systems"]
 feature_group = "PROFILER"
 disable_platforms = ["windows"]

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -482,8 +482,8 @@ test_matrix = {
     },
     "rocprofiler-systems": {
         "job_name": "rocprofiler-systems",
-        "fetch_artifact_args": "--rocprofiler-systems --rocprofiler-sdk --tests",
-        "timeout_minutes": 15,
+        "fetch_artifact_args": "--rocprofiler-systems --rocprofiler-systems-examples --rocprofiler-sdk --tests",
+        "timeout_minutes": 60,  # TODO: REVERT, THIS IS TEMPORARY TO VERIFY TESTS
         "test_script": f"python {_get_script_path('test_rocprofiler_systems.py')}",
         "platform": ["linux"],
         "total_shards_dict": {

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -484,11 +484,13 @@ test_matrix = {
         "job_name": "rocprofiler-systems",
         "fetch_artifact_args": "--rocprofiler-systems --rocprofiler-systems-examples --rocprofiler-sdk --tests",
         "timeout_minutes": 60,  # TODO: REVERT, THIS IS TEMPORARY TO VERIFY TESTS
+        "additional_requirements_files": [
+            "share/rocprofiler-systems/tests/requirements.txt",
+        ],
         "test_script": f"python {_get_script_path('test_rocprofiler_systems.py')}",
         "platform": ["linux"],
         "total_shards_dict": {
             "linux": 1,
-            "windows": 1,
         },
     },
     # libhipcxx hipcc tests

--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
@@ -3,57 +3,91 @@
 
 import logging
 import os
+import shlex
 import subprocess
-import sys
 from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
-SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_BIN_PATH = Path(THEROCK_BIN_DIR).resolve()
+THEROCK_PATH = THEROCK_BIN_PATH.parent
+THEROCK_LIB_PATH = str(THEROCK_PATH / "lib")
+ROCPROFSYS_TEST_DIR = THEROCK_PATH / "share" / "rocprofiler-systems" / "tests"
+
+# TODO: Once the corresponding tests are fixed, remove from this list
+EXCLUDED_TESTS = [
+    "openmp-target",  # Validation test fails (__omp_dm_init_kernel.kd)
+    # "transpose-runtime-instrument",  # Requires runtime-instrument optimization PR
+    "transferbench-sys-run",  # Requires multi-gpu system
+    # "fork.*",  # Requires runtime-instrument optimization PR, or deadlocks because of logger
+    "scratch.*",  # Validation test fails (GPU events need to be reduced to 1 instead of 12)
+    # "roctx-sampling",  # Requires less strict sampling requirements
+    "roctx-runtime-instrument",  # Requires runtime-instrument optimization PR
+]
+
+EXCLUDED_LABELS = [
+    "mpi",  # Currently unsupported
+    "julia",  # Unsupported
+    "kfd",  # No SDK version can be found yet
+    "attach",  # Fails
+]
 
 logging.basicConfig(level=logging.INFO)
-rocm_base = Path(THEROCK_BIN_DIR).resolve().parent
 
-# Environment variables
 environ_vars = os.environ.copy()
-ld_paths = [
-    # Libraries used by examples
-    rocm_base
-    / "share"
-    / "rocprofiler-systems"
-    / "examples"
-    / "lib",
-]
-ld_paths_str = ":".join(str(p) for p in ld_paths)
 
-existing_ld_path = os.environ.get("LD_LIBRARY_PATH", "")
-existing_path = os.environ.get("PATH", "")
 
-environ_vars["PATH"] = (
-    f"{THEROCK_BIN_DIR}:{existing_path}" if existing_path else THEROCK_BIN_DIR
-)
-environ_vars["ROCM_PATH"] = str(rocm_base)
-environ_vars["LD_LIBRARY_PATH"] = (
-    f"{ld_paths_str}:{existing_ld_path}" if existing_ld_path else ld_paths_str
-)
-# Required to force the pytest package to use install mode
-environ_vars["ROCPROFSYS_INSTALL_DIR"] = str(rocm_base)
+def setup_env():
+    environ_vars["ROCM_PATH"] = str(THEROCK_PATH)
+    environ_vars["ROCPROFSYS_INSTALL_DIR"] = str(THEROCK_PATH)
 
-# Execute tests
-pytest_package_exec = (
-    rocm_base / "share" / "rocprofiler-systems" / "tests" / "rocprofsys-tests.pyz"
-)
+    old_path = os.getenv("PATH", "")
+    rocm_bin = str(THEROCK_BIN_PATH)
+    environ_vars["PATH"] = f"{rocm_bin}:{old_path}" if old_path else rocm_bin
 
-cmd = [
-    sys.executable,
-    str(pytest_package_exec),
-    # TODO: Once the corresponding tests are fixed, remove the lines below
-    "-k",
-    "not TestOpenMPTarget and not (TestTranspose and runtime_instrument) and not TestGPUConnect",
-    "--junit-xml=junit.xml",
-    "--ci-mode",
-    "--log-cli-level=info",
-]
+    ld_paths = [
+        str(THEROCK_PATH / "share" / "rocprofiler-systems" / "examples" / "lib"),
+    ]
+    ld_paths_str = ":".join(ld_paths)
+    old_ld_path = os.getenv("LD_LIBRARY_PATH", "")
+    environ_vars["LD_LIBRARY_PATH"] = (
+        f"{ld_paths_str}:{old_ld_path}" if old_ld_path else ld_paths_str
+    )
 
-logging.info(f"++ Exec: {' '.join(cmd)}")
-subprocess.run(cmd, cwd=THEROCK_DIR, check=True, env=environ_vars)
+
+def execute_tests():
+    shard_index = int(os.getenv("SHARD_INDEX", "1")) - 1
+    total_shards = int(os.getenv("TOTAL_SHARDS", "1"))
+
+    ctest_base = [
+        "ctest",
+        "--test-dir",
+        str(ROCPROFSYS_TEST_DIR),
+    ]
+
+    # Informational test
+    config_cmd = ctest_base + [
+        "--verbose",
+        "--tests-regex",
+        "rocprofiler-systems-pytest-config",
+    ]
+    logging.info(f"++ Exec [{THEROCK_PATH}]$ {shlex.join(config_cmd)}")
+    subprocess.run(config_cmd, cwd=THEROCK_PATH, check=False, env=environ_vars)
+
+    # Actual tests
+    cmd = ctest_base + [
+        "--output-on-failure",
+        "--exclude-regex",
+        f"{'|'.join(EXCLUDED_TESTS)}",
+        "--label-exclude",
+        f"{'|'.join(EXCLUDED_LABELS)}",
+        "--tests-information",
+        f"{shard_index},,{total_shards}",
+    ]
+
+    logging.info(f"++ Exec [{THEROCK_PATH}]$ {shlex.join(cmd)}")
+    subprocess.run(cmd, cwd=THEROCK_PATH, check=True, env=environ_vars)
+
+
+if __name__ == "__main__":
+    setup_env()
+    execute_tests()

--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
@@ -39,6 +39,7 @@ environ_vars = os.environ.copy()
 def setup_env():
     environ_vars["ROCM_PATH"] = str(THEROCK_PATH)
     environ_vars["ROCPROFSYS_INSTALL_DIR"] = str(THEROCK_PATH)
+    environ_vars["ROCPROFSYS_MAX_THREADS"] = "64"
 
     old_path = os.getenv("PATH", "")
     rocm_bin = str(THEROCK_BIN_PATH)

--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
@@ -78,8 +78,12 @@ def execute_tests():
     subprocess.run(config_cmd, cwd=THEROCK_PATH, check=False, env=environ_vars)
 
     # Actual tests
+    # NOTE: using --verbose (not --output-on-failure) so we always see the per-test
+    # output, including pytest SKIPPED reasons. This is intentionally noisy and
+    # should be reverted to --output-on-failure once the GPU-target skip issue
+    # in rocprofiler-systems-examples is fully resolved.
     cmd = ctest_base + [
-        "--output-on-failure",
+        "--verbose",
         "--exclude-regex",
         f"{'|'.join(EXCLUDED_TESTS)}",
         "--label-exclude",

--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
@@ -32,6 +32,8 @@ EXCLUDED_LABELS = [
     "lulesh",  # Target is not built
     "network",  # NIC unsupported
     "overflow",  # Requires CAPSYS_ADMIN/PERFMON or perf_event_paranoid <= 3
+    "fork",  # only the runtime instrument fails, but logs are VERY long
+    "pthreads",  # All fail
 ]
 
 logging.basicConfig(level=logging.INFO)
@@ -82,8 +84,18 @@ def execute_tests():
     # output, including pytest SKIPPED reasons. This is intentionally noisy and
     # should be reverted to --output-on-failure once the GPU-target skip issue
     # in rocprofiler-systems-examples is fully resolved.
+    #
+    # Cap per-test output: keep failed tests' full output (1 MiB) for debugging,
+    # but trim passed/skipped output to ~16 KiB (tail) so the SKIPPED reason and
+    # final lines survive without exploding CI log size.
     cmd = ctest_base + [
         "--verbose",
+        "--test-output-size-passed",
+        str(16 * 1024),
+        "--test-output-size-failed",
+        str(1024 * 1024),
+        "--test-output-truncation",
+        "tail",
         "--exclude-regex",
         f"{'|'.join(EXCLUDED_TESTS)}",
         "--label-exclude",

--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
@@ -28,7 +28,10 @@ EXCLUDED_LABELS = [
     "mpi",  # Currently unsupported
     "julia",  # Unsupported
     "kfd",  # No SDK version can be found yet
-    "attach",  # Fails
+    "attach",  # Fails - Under investigation
+    "lulesh",  # Target is not built
+    "network",  # NIC unsupported
+    "overflow",  # Requires CAPSYS_ADMIN/PERFMON or perf_event_paranoid <= 3
 ]
 
 logging.basicConfig(level=logging.INFO)

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -39,6 +39,7 @@ python build_tools/install_rocm_from_artifacts.py
     [--rocprofiler-compute | --no-rocprofiler-compute]
     [--rocprofiler-sdk | --no-rocprofiler-sdk ]
     [--rocprofiler-systems | --no-rocprofiler-systems]
+    [--rocprofiler-systems-examples | --no-rocprofiler-systems-examples]
     [--rocrtst | --no-rocrtst]
     [--rocwmma | --no-rocwmma]
     [--libhipcxx | --no-libhipcxx]
@@ -363,6 +364,7 @@ def retrieve_artifacts_by_run_id(args):
             args.rocprofiler_compute,
             args.rocprofiler_sdk,
             args.rocprofiler_systems,
+            args.rocprofiler_systems_examples,
             args.rocrtst,
             args.rocwmma,
             args.libhipcxx,
@@ -446,6 +448,9 @@ def retrieve_artifacts_by_run_id(args):
             extra_artifacts.append("rocprofiler-systems")
             # Contains executables (rocprof-sys-run, rocprof-sys-instrument, etc.)
             argv.append("rocprofiler-systems_run")
+        if args.rocprofiler_systems_examples:
+            # Only a _test artifact is published (no _lib); append directly.
+            argv.append("rocprofiler-systems-examples_test")
         if args.rocrtst:
             extra_artifacts.append("rocrtst")
             # rocrtst depends on sysdeps-hwloc (which depends on sysdeps-libpciaccess)
@@ -793,6 +798,13 @@ def main(argv):
         "--rocprofiler-systems",
         default=False,
         help="Include 'rocprofiler-systems' artifacts",
+        action=argparse.BooleanOptionalAction,
+    )
+
+    artifacts_group.add_argument(
+        "--rocprofiler-systems-examples",
+        default=False,
+        help="Include 'rocprofiler-systems-examples' artifacts",
         action=argparse.BooleanOptionalAction,
     )
 

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -348,7 +348,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
       )
 
       if(${THEROCK_BUILD_TESTING})
-
+        # comment to retrigger CI
         if(NOT THEROCK_DIST_AMDGPU_TARGETS
            OR THEROCK_DIST_AMDGPU_TARGETS MATCHES "-NOTFOUND$")
           message(FATAL_ERROR

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -348,19 +348,17 @@ if(THEROCK_ENABLE_ROCPROFV3)
       )
 
       if(${THEROCK_BUILD_TESTING})
-        # comment to retrigger CI
-        if(NOT THEROCK_DIST_AMDGPU_TARGETS
-           OR THEROCK_DIST_AMDGPU_TARGETS MATCHES "-NOTFOUND$")
+        if(NOT THEROCK_TEST_AMDGPU_TARGETS
+           OR THEROCK_TEST_AMDGPU_TARGETS MATCHES "-NOTFOUND$")
           message(FATAL_ERROR
-            "rocprofiler-systems-examples requires THEROCK_DIST_AMDGPU_TARGETS to be set "
-            "(set THEROCK_DIST_AMDGPU_FAMILIES or THEROCK_AMDGPU_FAMILIES).")
+            "THEROCK_TEST_AMDGPU_TARGETS is not set")
         endif()
 
         string(REPLACE ";" "\\;" _ROCPROFSYS_GFX_TARGETS_ESCAPED
-          "${THEROCK_DIST_AMDGPU_TARGETS}")
+          "${THEROCK_TEST_AMDGPU_TARGETS}")
 
         therock_cmake_subproject_declare(rocprofiler-systems-examples
-          USE_DIST_AMDGPU_TARGETS
+          USE_TEST_AMDGPU_TARGETS
           EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprofiler-systems/examples"
           BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprofiler-systems-examples"
           BACKGROUND_BUILD
@@ -381,6 +379,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
         therock_cmake_subproject_activate(rocprofiler-systems-examples)
 
         therock_provide_artifact(rocprofiler-systems-examples
+          TARGET_NEUTRAL
           DESCRIPTOR "${CMAKE_SOURCE_DIR}/profiler/artifact-rocprofiler-systems-examples.toml"
           COMPONENTS
             test

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -349,22 +349,23 @@ if(THEROCK_ENABLE_ROCPROFV3)
 
       if(${THEROCK_BUILD_TESTING})
 
-        if(NOT THEROCK_AMDGPU_TARGETS
-           OR THEROCK_AMDGPU_TARGETS MATCHES "-NOTFOUND$")
+        if(NOT THEROCK_DIST_AMDGPU_TARGETS
+           OR THEROCK_DIST_AMDGPU_TARGETS MATCHES "-NOTFOUND$")
           message(FATAL_ERROR
-            "rocprofiler-systems-examples requires THEROCK_AMDGPU_TARGETS to be set "
-            "(set THEROCK_AMDGPU_FAMILIES).")
+            "rocprofiler-systems-examples requires THEROCK_DIST_AMDGPU_TARGETS to be set "
+            "(set THEROCK_DIST_AMDGPU_FAMILIES or THEROCK_AMDGPU_FAMILIES).")
         endif()
 
         string(REPLACE ";" "\\;" _ROCPROFSYS_GFX_TARGETS_ESCAPED
-          "${THEROCK_AMDGPU_TARGETS}")
+          "${THEROCK_DIST_AMDGPU_TARGETS}")
 
         therock_cmake_subproject_declare(rocprofiler-systems-examples
+          USE_DIST_AMDGPU_TARGETS
           EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprofiler-systems/examples"
           BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprofiler-systems-examples"
           BACKGROUND_BUILD
           CMAKE_ARGS
-            "-DROCPROFSYS_GFX_TARGETS=${_ROCPROFSYS_GFX_TARGETS_ESCAPED}"
+            -DROCPROFSYS_GFX_TARGETS="${_ROCPROFSYS_GFX_TARGETS_ESCAPED}"
             -DROCPROFSYS_DISABLE_EXAMPLES=lulesh
           INSTALL_RPATH_DIRS
             "lib"

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -349,10 +349,13 @@ if(THEROCK_ENABLE_ROCPROFV3)
 
       if(${THEROCK_BUILD_TESTING})
 
-        if(THEROCK_DIST_AMDGPU_TARGETS STREQUAL "THEROCK_DIST_AMDGPU_TARGETS-NOTFOUND")
-          set(_ROCPROFSYS_GFX_TARGETS_ESCAPED "")
-        else()
-          string(REPLACE ";" "\\;" _ROCPROFSYS_GFX_TARGETS_ESCAPED "${THEROCK_DIST_AMDGPU_TARGETS}")
+        # Examples read ROCPROFSYS_GFX_TARGETS. Fail fast if it is
+        # unset so we don't silently build CPU-only example binaries.
+        if(NOT THEROCK_DIST_AMDGPU_TARGETS
+           OR THEROCK_DIST_AMDGPU_TARGETS MATCHES "-NOTFOUND$")
+          message(FATAL_ERROR
+            "rocprofiler-systems-examples requires THEROCK_DIST_AMDGPU_TARGETS to be set "
+            "(set THEROCK_DIST_AMDGPU_FAMILIES or THEROCK_AMDGPU_FAMILIES).")
         endif()
 
         therock_cmake_subproject_declare(rocprofiler-systems-examples
@@ -361,8 +364,8 @@ if(THEROCK_ENABLE_ROCPROFV3)
           BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprofiler-systems-examples"
           BACKGROUND_BUILD
           CMAKE_ARGS
-            -DROCPROFSYS_GFX_TARGETS="${_ROCPROFSYS_GFX_TARGETS_ESCAPED}"
-            -DROCPROFSYS_DISABLE_EXAMPLES="lulesh"
+            "-DROCPROFSYS_GFX_TARGETS=\"${THEROCK_DIST_AMDGPU_TARGETS}\""
+            -DROCPROFSYS_DISABLE_EXAMPLES=lulesh
           INSTALL_RPATH_DIRS
             "lib"
             "lib/rocprofiler-systems"

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -261,12 +261,6 @@ if(THEROCK_ENABLE_ROCPROFV3)
   # rocprofiler-systems requires GCC, but sanitizer builds use Clang.
   # Skip enabling rocprofiler-systems when building with sanitizers.
   if (THEROCK_ENABLE_ROCPROFSYS AND THEROCK_SANITIZER STREQUAL "")
-    # Escape semicolons in GPU targets list to prevent shell interpretation
-    if (THEROCK_TEST_AMDGPU_TARGETS STREQUAL "THEROCK_TEST_AMDGPU_TARGETS-NOTFOUND")
-      set(_ROCPROFSYS_GFX_TARGETS_ESCAPED "")
-    else()
-      string(REPLACE ";" "\\;" _ROCPROFSYS_GFX_TARGETS_ESCAPED "${THEROCK_TEST_AMDGPU_TARGETS}")
-    endif()
 
     therock_detect_python_versions(_rocprofsys_detected_python_executables _rocprofsys_detected_python_versions)
     if(NOT _rocprofsys_detected_python_versions OR NOT _rocprofsys_detected_python_executables)
@@ -301,10 +295,10 @@ if(THEROCK_ENABLE_ROCPROFV3)
         -DROCPROFSYS_BUILD_LIBIBERTY=ON
         -DROCPROFSYS_BUILD_BOOST=ON
         -DROCPROFSYS_BUILD_DYNINST=ON
-        -DROCPROFSYS_BUILD_FOR_THEROCK=ON # TODO: Will be deprecated
+        -DROCPROFSYS_BUILD_FOR_THEROCK=ON
+        -DROCPROFSYS_USE_PYTESTS=OFF
         -DROCPROFSYS_INSTALL_TESTING="${THEROCK_BUILD_TESTING}"
-        -DROCPROFSYS_INSTALL_EXAMPLES="${THEROCK_BUILD_TESTING}"
-        -DROCPROFSYS_GFX_TARGETS="${_ROCPROFSYS_GFX_TARGETS_ESCAPED}"
+        -DROCPROFSYS_BUILD_TESTING="${THEROCK_BUILD_TESTING}"
         -DROCPROFSYS_BUILD_SPDLOG=OFF
         -DROCPROFSYS_BUILD_SQLITE3=OFF
         -DROCPROFSYS_USE_PYTHON="${_ROCPROFSYS_USE_PYTHON}"
@@ -334,6 +328,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
       SUBDIRS .
     )
 
+    therock_cmake_subproject_provide_package(rocprofiler-systems rocprofiler-systems lib/cmake/rocprofiler-systems)
     therock_cmake_subproject_activate(rocprofiler-systems)
 
     therock_provide_artifact(rocprofiler-systems
@@ -351,5 +346,46 @@ if(THEROCK_ENABLE_ROCPROFV3)
         rocprofiler-sdk
         rocprofiler-systems
       )
+
+      if(${THEROCK_BUILD_TESTING})
+
+        if(THEROCK_DIST_AMDGPU_TARGETS STREQUAL "THEROCK_DIST_AMDGPU_TARGETS-NOTFOUND")
+          set(_ROCPROFSYS_GFX_TARGETS_ESCAPED "")
+        else()
+          string(REPLACE ";" "\\;" _ROCPROFSYS_GFX_TARGETS_ESCAPED "${THEROCK_DIST_AMDGPU_TARGETS}")
+        endif()
+
+        therock_cmake_subproject_declare(rocprofiler-systems-examples
+          USE_DIST_AMDGPU_TARGETS
+          EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprofiler-systems/examples"
+          BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprofiler-systems-examples"
+          BACKGROUND_BUILD
+          CMAKE_ARGS
+            -DROCPROFSYS_GFX_TARGETS="${_ROCPROFSYS_GFX_TARGETS_ESCAPED}"
+            -DROCPROFSYS_DISABLE_EXAMPLES="lulesh"
+          INSTALL_RPATH_DIRS
+            "lib"
+            "lib/rocprofiler-systems"
+            "llvm/lib"
+          RUNTIME_DEPS
+            rocprofiler-systems
+            ${_rocprofsys_examples_optional_deps}
+        )
+        therock_cmake_subproject_glob_c_sources(rocprofiler-systems-examples
+          SUBDIRS .
+        )
+        therock_cmake_subproject_activate(rocprofiler-systems-examples)
+
+        therock_provide_artifact(rocprofiler-systems-examples
+          DESCRIPTOR "${CMAKE_SOURCE_DIR}/profiler/artifact-rocprofiler-systems-examples.toml"
+          COMPONENTS
+            test
+          SUBPROJECT_DEPS
+            rocprofiler-systems
+            rocprofiler-systems-examples
+        )
+
+      endif()
+
   endif(THEROCK_ENABLE_ROCPROFSYS AND THEROCK_SANITIZER STREQUAL "")
 endif(THEROCK_ENABLE_ROCPROFV3)

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -349,22 +349,22 @@ if(THEROCK_ENABLE_ROCPROFV3)
 
       if(${THEROCK_BUILD_TESTING})
 
-        # Examples read ROCPROFSYS_GFX_TARGETS. Fail fast if it is
-        # unset so we don't silently build CPU-only example binaries.
-        if(NOT THEROCK_DIST_AMDGPU_TARGETS
-           OR THEROCK_DIST_AMDGPU_TARGETS MATCHES "-NOTFOUND$")
+        if(NOT THEROCK_AMDGPU_TARGETS
+           OR THEROCK_AMDGPU_TARGETS MATCHES "-NOTFOUND$")
           message(FATAL_ERROR
-            "rocprofiler-systems-examples requires THEROCK_DIST_AMDGPU_TARGETS to be set "
-            "(set THEROCK_DIST_AMDGPU_FAMILIES or THEROCK_AMDGPU_FAMILIES).")
+            "rocprofiler-systems-examples requires THEROCK_AMDGPU_TARGETS to be set "
+            "(set THEROCK_AMDGPU_FAMILIES).")
         endif()
 
+        string(REPLACE ";" "\\;" _ROCPROFSYS_GFX_TARGETS_ESCAPED
+          "${THEROCK_AMDGPU_TARGETS}")
+
         therock_cmake_subproject_declare(rocprofiler-systems-examples
-          USE_DIST_AMDGPU_TARGETS
           EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprofiler-systems/examples"
           BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprofiler-systems-examples"
           BACKGROUND_BUILD
           CMAKE_ARGS
-            "-DROCPROFSYS_GFX_TARGETS=\"${THEROCK_DIST_AMDGPU_TARGETS}\""
+            "-DROCPROFSYS_GFX_TARGETS=${_ROCPROFSYS_GFX_TARGETS_ESCAPED}"
             -DROCPROFSYS_DISABLE_EXAMPLES=lulesh
           INSTALL_RPATH_DIRS
             "lib"

--- a/profiler/artifact-rocprofiler-systems-examples.toml
+++ b/profiler/artifact-rocprofiler-systems-examples.toml
@@ -1,0 +1,5 @@
+# rocprofiler-systems-examples
+[components.test."examples/rocprofiler-systems-examples/stage"]
+include = [
+  "share/rocprofiler-systems/examples/**",
+]

--- a/profiler/artifact-rocprofiler-systems-examples.toml
+++ b/profiler/artifact-rocprofiler-systems-examples.toml
@@ -1,5 +1,5 @@
 # rocprofiler-systems-examples
-[components.test."examples/rocprofiler-systems-examples/stage"]
+[components.test."profiler/rocprofiler-systems-examples/stage"]
 include = [
   "share/rocprofiler-systems/examples/**",
 ]

--- a/profiler/artifact-rocprofiler-systems.toml
+++ b/profiler/artifact-rocprofiler-systems.toml
@@ -24,8 +24,8 @@ exclude = [
 include = [
   "share/doc/rocprofiler-systems/**"
 ]
+# Test binaries lie under rocprofiler-systems-examples artifact
 [components.test."profiler/rocprofiler-systems/stage"]
 include = [
   "share/rocprofiler-systems/tests/**",
-  "share/rocprofiler-systems/examples/**",
 ]


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

We are moving to using CTest as the test executor instead of pytest. 
We also need to build examples as a standalone to ensure it can be architecture specific (this will dratically reduce the build time)

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

WIP

TODO:
 - [x] Follow HIPDNN integration test example for `rocprofiler-systems-examples`
 - [ ] Remove submodule update once PR in rocm-systems is merged and bumped to here
 - [ ] Ensure CTests work

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Workflows

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.