### PR TITLE
Include `rocprofiler-compute` payload and fix `rocprof-compute` imports

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -120,7 +120,6 @@ def run(args: argparse.Namespace):
                 "libexec/rocprofiler-compute/**",
                 "lib/rocprofiler-compute/**",
                 "share/**/rocprofiler-compute/**",
-
             ],
         ),
     )

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -118,6 +118,9 @@ def run(args: argparse.Namespace):
                 # rocprofiler-compute
                 "bin/rocprof-*",
                 "libexec/rocprofiler-compute/**",
+                "lib/rocprofiler-compute/**",
+                "share/**/rocprofiler-compute/**",
+
             ],
         ),
     )

--- a/build_tools/packaging/python/templates/rocm-profiler/src/rocm_profiler/_cli.py
+++ b/build_tools/packaging/python/templates/rocm-profiler/src/rocm_profiler/_cli.py
@@ -41,6 +41,25 @@ def _extend_ld_library_path() -> None:
         os.environ["LD_LIBRARY_PATH"] = ":".join([sysdeps_str, *existing_parts])
 
 
+def _extend_pythonpath_for_compute() -> None:
+    if platform.system() == "Windows":
+        return
+
+    profiler_root = _get_profiler_module_path()
+    compute_path = profiler_root / "libexec" / "rocprofiler-compute"
+
+    if not compute_path.exists():
+        return
+
+    existing = os.environ.get("PYTHONPATH", "")
+    parts = [p for p in existing.split(":") if p]
+
+    compute_str = str(compute_path)
+
+    if compute_str not in parts:
+        os.environ["PYTHONPATH"] = ":".join([compute_str, *parts])
+
+
 def _get_profiler_module_path() -> Path:
     profiler_module = importlib.import_module(PROFILER_PY_PACKAGE_NAME)
     return Path(profiler_module.__file__).parent
@@ -51,6 +70,7 @@ def _exec(relpath: str) -> None:
         raise RuntimeError("rocm-profiler is not supported on Windows.")
 
     _extend_ld_library_path()
+    _extend_pythonpath_for_compute()
 
     full_path = _get_profiler_module_path() / relpath
     if not full_path.exists():


### PR DESCRIPTION
## Motivation

This PR fixes gaps in the `rocm-profiler` Python wheel packaging for `rocprofiler-compute`.

Previously:
- The wheel included the `rocprof-compute` launcher and `libexec/rocprofiler-compute`, but **missed the full compute payload** under:
  - `lib/rocprofiler-compute`
  - `share/rocprofiler-compute`
- As a result, the installed layout did not match a native installation, and some functionality was incomplete.
- Additionally, the `rocprof-compute` CLI could print an initial Python import error (`No module named 'rocprof_compute_base'`) due to missing `PYTHONPATH` setup.

This PR ensures the compute payload is fully packaged and the CLI runs cleanly from the installed wheel.

---

## Technical Details

### Packaging fixes

Updated `build_tools/build_python_packages.py` to include missing compute components:

- Added:
  - `lib/rocprofiler-compute/**`
  - `share/**/rocprofiler-compute/**`

This ensures the wheel now includes:
- `_rocm_profiler/share/rocprofiler-compute/{modulefiles,sample}`
- `_rocm_profiler/lib/rocprofiler-compute/librocprofiler-compute-tool.so`

This matches the structure of a native prefix install, but rooted under `site-packages/_rocm_profiler`.

### CLI import path fix

Updated `_cli.py` to add:

```python
_extend_pythonpath_for_compute()
```

## Testing 
``` Bash
ls $VIRTUAL_ENV/lib/python3.12/site-packages/_rocm_profiler/share
modulefiles  rocprofiler-compute  rocprofiler-systems

ls $VIRTUAL_ENV/lib/python3.12/site-packages/_rocm_profiler/share/rocprofiler-compute
modulefiles  sample

ls $VIRTUAL_ENV/lib/python3.12/site-packages/_rocm_profiler/lib
librocprof-sys-dl.so  librocprof-sys-dl.so.1  librocprof-sys-rt.so  librocprof-sys-rt.so.1  librocprof-sys.so  librocprof-sys.so.1  librocprof-sys-user.so  librocprof-sys-user.so.1  python  rocprofiler-compute  rocprofiler-systems

ls $VIRTUAL_ENV/lib/python3.12/site-packages/_rocm_profiler/lib/rocprofiler-compute
librocprofiler-compute-tool.so
```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
