### PR TITLE
[CI][Pytorch ut] unskip deepseek error tests

### DIFF
--- a/external-builds/pytorch/skip_tests/pytorch_2.12.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.12.py
@@ -219,10 +219,6 @@ skip_tests = {
             # TestLinalgCUDA - tunableop_rocm addmm relu
             "test_addmm_relu_tunableop_rocm_cuda_float32",
         ],
-        "scaled_matmul": [
-            # TestFP8MatmulCUDA - deepseek error messages
-            "test_scaled_mm_deepseek_error_messages_bfloat16_lhs_block_128_rhs_block_1_M_256_N_256_K_256_cuda",
-        ],
         "modules": [
             # TestModuleCUDA - CTCLoss cpu/gpu parity scalar mismatch
             "test_cpu_gpu_parity_nn_CTCLoss_cuda_float32",


### PR DESCRIPTION
Deepseek tests are skipped on gfx942, and on gfx950 expected exceptions are raised.
Recent fixes on upstream 
https://github.com/pytorch/pytorch/pull/180384
https://github.com/pytorch/pytorch/pull/180731

Fixes the issue mentioned here https://github.com/ROCm/frameworks-internal/issues/16162
Relevant logs from https://github.com/ROCm/TheRock/actions/runs/24805069144
test_scaled_matmul_cuda.py::TestFP8MatmulCUDA::test_scaled_mm_deepseek_error_messages_bfloat16_lhs_block_128_rhs_block_1_M_256_N_256_K_256_cuda SKIPPED [0.0011s] (skipIfRocm: test only runs on ('gfx950',)) [ 95%]
test_scaled_matmul_cuda.py::TestFP8MatmulCUDA::test_scaled_mm_deepseek_error_messages_bfloat16_lhs_block_128_rhs_block_1_M_256_N_256_K_512_cuda SKIPPED [0.0010s] (skipIfRocm: test only runs on ('gfx950',)) [ 95%]
test_scaled_matmul_cuda.py::TestFP8MatmulCUDA::test_scaled_mm_deepseek_error_messages_bfloat16_lhs_block_1_rhs_block_128_M_256_N_256_K_256_cuda SKIPPED [0.0011s] (skipIfRocm: test only runs on ('gfx950',)) [ 95%]
test_scaled_matmul_cuda.py::TestFP8MatmulCUDA::test_scaled_mm_deepseek_error_messages_bfloat16_lhs_block_1_rhs_block_128_M_256_N_256_K_512_cuda SKIPPED [0.0010s] (skipIfRocm: test only runs on ('gfx950',)) [ 96%]
test_scaled_matmul_cuda.py::TestFP8MatmulCUDA::test_scaled_mm_deepseek_error_messages_bfloat16_lhs_block_1_rhs_block_1_M_256_N_256_K_256_cuda SKIPPED [0.0012s] (skipIfRocm: test only runs on ('gfx950',)) [ 96%]
test_scaled_matmul_cuda.py::TestFP8MatmulCUDA::test_scaled_mm_deepseek_error_messages_bfloat16_lhs_block_1_rhs_block_1_M_256_N_256_K_512_cuda SKIPPED [0.0010s] (skipIfRocm: test only runs on ('gfx950',)) [ 96%]