### PR TITLE
Fix GPU_ENABLE_PAL breaking benchmarks on gfx1151 Windows nightly-ci (#3587)

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -152,6 +152,12 @@ jobs:
           echo "HSA_XNACK=1" >> $GITHUB_ENV
           echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
 
+      # Set GPU_ENABLE_PAL for Windows hip-tests (PAL=1, ROCR=0) (Issue #3587)
+      - name: Set GPU_ENABLE_PAL for Windows hip-tests
+        if: ${{ fromJSON(inputs.component).gpu_enable_pal != '' }}
+        shell: bash
+        run: echo "GPU_ENABLE_PAL=${{ fromJSON(inputs.component).gpu_enable_pal }}" >> $GITHUB_ENV
+
       - name: Test
         id: test
         timeout-minutes: ${{ fromJSON(inputs.component).timeout_minutes }}
@@ -161,9 +167,6 @@ jobs:
           TEST_TYPE: ${{ fromJSON(inputs.component).test_type }}
           TEST_COMPONENT: ${{ fromJSON(inputs.component).job_name }}
           ROCM_KPACK_DEBUG: "1"
-          # Windows hip-tests (PAL=1, ROCR=0) set this via matrix; other components
-          # leave it empty. #3587
-          GPU_ENABLE_PAL: ${{ fromJSON(inputs.component).gpu_enable_pal }}
           RETRY_THIS_STEP: "true"
           RETRY_COUNT: "1"
           RETRY_DELAY: "7"


### PR DESCRIPTION
## Summary

- PR #3593 added `GPU_ENABLE_PAL` to the Test step env block in `test_component.yml`. For non-hip-tests components, the field evaluates to `""`, causing gfx1151 (Strix Halo) Windows benchmarks to use the non-functional ROCR backend instead of PAL.
- Fix: move `GPU_ENABLE_PAL` to a conditional `$GITHUB_ENV` step (same pattern as the existing ASAN env var step) so the env var is only set when the component explicitly provides a value.

### Affected

- hipblaslt_bench: `error: invalid argument (1)`
- rocfft_bench: `hipMemGetInfo failed`
- rocrand_bench: `ROCRAND_STATUS_LAUNCH_FAILURE (107)`
- rocsolver_bench: `hipErrorInvalidKernelFile` / `missing TensileLibrary.dat`

Github-issue: https://github.com/ROCm/TheRock/issues/4558

## Test plan

- Verify gfx1151 Windows benchmarks pass in nightly-CI
- Verify hip-tests PAL/ROCR dual-run still works on Windows

## Test Result
- Without this PR - https://github.com/ROCm/TheRock/actions/runs/24830717391
- With this PR - https://github.com/ROCm/TheRock/actions/runs/24830703374