### PR TITLE
[ci] Skip the PyTorch UT, test_is_pinned_no_context

### DIFF
--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -74,6 +74,9 @@ skip_tests = {
             # "test_hip_device_count"
             # "test_nvtx"
             # ----------------
+            #
+            # Multi-processing error in py3.14
+            "test_is_pinned_no_context",
         ],
         "nn": [
             # external-builds/pytorch/pytorch/test/test_nn.py::TestNN::test_RNN_dropout_state MIOpen(HIP): Error [Compile] 'hiprtcCompileProgram(prog.get(), c_options.size(), c_options.data())' MIOpenDropoutHIP.cpp: HIPRTC_ERROR_COMPILATION (6)


### PR DESCRIPTION
## Motivation

Skip `test/test_cuda.py::TestCuda::test_is_pinned_no_context` due to known failure (subprocess crash with CalledProcessError when using torch multiprocessing/CUDA context), tracked in issue #4197.
