### PR TITLE
Skip flaky test_Embedding_discontiguous_cuda on gfx1151

### DIFF
--- a/external-builds/pytorch/skip_tests/pytorch_2.11.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.11.py
@@ -49,6 +49,20 @@ skip_tests = {
             "test_cpp_warnings_have_python_context_cuda",
         ],
     },
+    "gfx1151": {
+        "nn": [
+            # Flaky tolerance failure (fp32) caused by non-deterministic atomic
+            # accumulation in Embedding backward on GPU. test_noncontig in
+            # torch/testing/_internal/common_nn.py runs the same backward 4
+            # times with different contig/noncontig input/grad combinations and
+            # compares the resulting parameter gradients with default fp32
+            # tolerance (atol=1e-5, rtol=1.3e-6). Differences of ~1.3e-5
+            # occasionally exceed it (failure rate ~30% locally on gfx1151).
+            # See https://github.com/ROCm/TheRock/issues/4744
+            # AssertionError: Tensor-likes are not close!
+            "test_Embedding_discontiguous_cuda",
+        ],
+    },
     # "gfx120": {
     #     "unary_ufuncs": [
     #         # this failed only once. maybe python version dependent? probably the run was python 3.13


### PR DESCRIPTION
Skip `test_Embedding_discontiguous_cuda` on gfx1151 due to flaky fp32 tolerance failure.

**Root cause:** Non-deterministic atomic accumulation in Embedding backward produces gradients that intermittently exceed the default fp32 tolerance (atol=1e-5). Failure rate ~30% on gfx1151.

**Fix:** Added gfx1151 skip entry in `pytorch_2.11.py` following the existing per-arch skip pattern.

Fixes #4744