### PR TITLE
[CI] Skip failing pyt UTs with release/2.11

### DIFF
--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -75,7 +75,7 @@ skip_tests = {
             # "test_nvtx"
             # ----------------
             #
-            # Multi-processing error in py3.14
+            # Multi-processing error in py3.14 - https://github.com/ROCm/TheRock/issues/4197
             "test_is_pinned_no_context",
         ],
         "nn": [

--- a/external-builds/pytorch/skip_tests/pytorch_2.11.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.11.py
@@ -61,7 +61,7 @@ skip_tests = {
             "test_resnet",
             # RuntimeError: miopenStatusUnknownError
             "test_graph_cudnn_dropout",
-            #Fatal Python error: Segmentation fault - https://github.com/ROCm/TheRock/issues/4745
+            # Fatal Python error: Segmentation fault - https://github.com/ROCm/TheRock/issues/4745
             "test_snapshot_include_traces",
         ],
         "nn": [
@@ -75,7 +75,7 @@ skip_tests = {
     },
     "gfx1151": {
         "nn": [
-            #AssertionError: Tensor-likes are not close! - https://github.com/ROCm/TheRock/issues/4744
+            # AssertionError: Tensor-likes are not close! - https://github.com/ROCm/TheRock/issues/4744
             "test_Embedding_discontiguous_cuda",
         ],
     },

--- a/external-builds/pytorch/skip_tests/pytorch_2.11.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.11.py
@@ -68,11 +68,15 @@ skip_tests = {
             # new in 2.11
             # AssertionError: Scalars are not close!
             "test_CTCLoss_cudnn_cuda",
-            #AssertionError: Tensor-likes are not close! - https://github.com/ROCm/TheRock/issues/4744
-            "test_Embedding_discontiguous_cuda",
         ],
         "torch": [
             "test_cpp_warnings_have_python_context_cuda",
+        ],
+    },
+    "gfx1151": {
+        "nn": [
+            #AssertionError: Tensor-likes are not close! - https://github.com/ROCm/TheRock/issues/4744
+            "test_Embedding_discontiguous_cuda",
         ],
     },
     # "gfx120": {

--- a/external-builds/pytorch/skip_tests/pytorch_2.11.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.11.py
@@ -61,11 +61,15 @@ skip_tests = {
             "test_resnet",
             # RuntimeError: miopenStatusUnknownError
             "test_graph_cudnn_dropout",
+            #Fatal Python error: Segmentation fault - https://github.com/ROCm/TheRock/issues/4745
+            "test_snapshot_include_traces",
         ],
         "nn": [
             # new in 2.11
             # AssertionError: Scalars are not close!
             "test_CTCLoss_cudnn_cuda",
+            #AssertionError: Tensor-likes are not close! - https://github.com/ROCm/TheRock/issues/4744
+            "test_Embedding_discontiguous_cuda",
         ],
         "torch": [
             "test_cpp_warnings_have_python_context_cuda",


### PR DESCRIPTION
Skip the below UTs that are failing with PyTorch version 2.11 

```
external-builds/pytorch/pytorch/test/test_cuda.py::TestMemPool::test_snapshot_include_traces 
external-builds/pytorch/pytorch/test/test_nn.py::TestNN::test_Embedding_discontiguous_cuda 
```

Tracked in issues:
https://github.com/ROCm/TheRock/issues/4745
https://github.com/ROCm/TheRock/issues/4744