### PR TITLE
Fix S3 copy failure for files larger than 5GB

### DIFF
--- a/build_tools/_therock_utils/storage_backend.py
+++ b/build_tools/_therock_utils/storage_backend.py
@@ -452,13 +452,15 @@ class S3StorageBackend(StorageBackend):
             return
 
         copy_source = {"Bucket": source.bucket, "Key": source.relative_path}
+        # Use the managed transfer copy() instead of copy_object() to
+        # support files larger than 5GB via automatic multipart copy.
         _s3_retry(
             "copy",
             f"{source.s3_uri} -> {dest.s3_uri}",
-            self.s3_client.copy_object,
-            Bucket=dest.bucket,
-            Key=dest.relative_path,
-            CopySource=copy_source,
+            self.s3_client.copy,
+            copy_source,
+            dest.bucket,
+            dest.relative_path,
         )
 
 

--- a/build_tools/tests/storage_backend_test.py
+++ b/build_tools/tests/storage_backend_test.py
@@ -478,7 +478,7 @@ class TestS3StorageBackendUploadFile(unittest.TestCase):
 
 
 class TestS3StorageBackendCopyFile(unittest.TestCase):
-    def test_calls_copy_object(self):
+    def test_calls_copy(self):
         backend = S3StorageBackend()
         mock_client = mock.MagicMock()
         backend._s3_client = mock_client
@@ -487,10 +487,10 @@ class TestS3StorageBackendCopyFile(unittest.TestCase):
         dest = StorageLocation("dest-bucket", "release/file.whl")
         backend.copy_file(source, dest)
 
-        mock_client.copy_object.assert_called_once_with(
-            Bucket="dest-bucket",
-            Key="release/file.whl",
-            CopySource={"Bucket": "src-bucket", "Key": "run-1/file.whl"},
+        mock_client.copy.assert_called_once_with(
+            {"Bucket": "src-bucket", "Key": "run-1/file.whl"},
+            "dest-bucket",
+            "release/file.whl",
         )
 
     def test_same_bucket_copy(self):
@@ -502,16 +502,16 @@ class TestS3StorageBackendCopyFile(unittest.TestCase):
         dest = StorageLocation("bucket", "release/file.whl")
         backend.copy_file(source, dest)
 
-        mock_client.copy_object.assert_called_once_with(
-            Bucket="bucket",
-            Key="release/file.whl",
-            CopySource={"Bucket": "bucket", "Key": "staging/file.whl"},
+        mock_client.copy.assert_called_once_with(
+            {"Bucket": "bucket", "Key": "staging/file.whl"},
+            "bucket",
+            "release/file.whl",
         )
 
     def test_retries_on_failure(self):
         backend = S3StorageBackend()
         mock_client = mock.MagicMock()
-        mock_client.copy_object.side_effect = [
+        mock_client.copy.side_effect = [
             Exception("transient"),
             None,
         ]
@@ -523,7 +523,7 @@ class TestS3StorageBackendCopyFile(unittest.TestCase):
         with mock.patch("_therock_utils.storage_backend.time.sleep"):
             backend.copy_file(source, dest)
 
-        self.assertEqual(mock_client.copy_object.call_count, 2)
+        self.assertEqual(mock_client.copy.call_count, 2)
 
     def test_dry_run_does_not_call_boto3(self):
         backend = S3StorageBackend(dry_run=True)
@@ -534,7 +534,7 @@ class TestS3StorageBackendCopyFile(unittest.TestCase):
         dest = StorageLocation("dst", "b.whl")
         backend.copy_file(source, dest)
 
-        mock_client.copy_object.assert_not_called()
+        mock_client.copy.assert_not_called()
 
 
 class TestLocalStorageBackendUploadFiles(unittest.TestCase):
@@ -998,7 +998,7 @@ class TestS3StorageBackendCopyFiles(unittest.TestCase):
         count = backend.copy_files(files)
 
         self.assertEqual(count, 3)
-        self.assertEqual(mock_client.copy_object.call_count, 3)
+        self.assertEqual(mock_client.copy.call_count, 3)
 
     def test_empty_list_returns_zero(self):
         backend = S3StorageBackend()
@@ -1007,7 +1007,7 @@ class TestS3StorageBackendCopyFiles(unittest.TestCase):
 
         count = backend.copy_files([])
         self.assertEqual(count, 0)
-        mock_client.copy_object.assert_not_called()
+        mock_client.copy.assert_not_called()
 
     def test_single_file_skips_thread_pool(self):
         backend = S3StorageBackend()
@@ -1028,7 +1028,7 @@ class TestS3StorageBackendCopyFiles(unittest.TestCase):
 
         self.assertEqual(count, 1)
         mock_pool.assert_not_called()
-        mock_client.copy_object.assert_called_once()
+        mock_client.copy.assert_called_once()
 
     def test_dry_run_does_not_call_boto3(self):
         backend = S3StorageBackend(dry_run=True)
@@ -1048,17 +1048,17 @@ class TestS3StorageBackendCopyFiles(unittest.TestCase):
         count = backend.copy_files(files)
 
         self.assertEqual(count, 2)
-        mock_client.copy_object.assert_not_called()
+        mock_client.copy.assert_not_called()
 
     def test_error_propagation(self):
         backend = S3StorageBackend()
         mock_client = mock.MagicMock()
 
-        def copy_side_effect(**kwargs):
-            if "bad" in kwargs["Key"]:
+        def copy_side_effect(copy_source, bucket, key):
+            if "bad" in key:
                 raise Exception("persistent failure")
 
-        mock_client.copy_object.side_effect = copy_side_effect
+        mock_client.copy.side_effect = copy_side_effect
         backend._s3_client = mock_client
 
         files = [


### PR DESCRIPTION
## Motivation

Progress on:
* https://github.com/ROCm/TheRock/issues/3334
* https://github.com/ROCm/TheRock/issues/4441

This fixes copy failures initially observed at https://github.com/ROCm/TheRock/actions/runs/24540020624/job/71767315808 `An error occurred (InvalidRequest) when calling the CopyObject operation: The specified copy source is larger than the maximum allowable size for a copy source: 5368709120`:
```
INFO:_therock_utils.storage_backend:copy_directory: s3://therock-dev-artifacts/24540020624-linux/tarballs -> therock-dev-tarball/v3/tarball (15 files)
INFO:_therock_utils.storage_backend:  therock-dist-linux-gfx101X-dgpu-7.13.0.dev0+94696237b7f5a5c44ec2d3e367dae21483ec4e87.tar.gz -> s3://therock-dev-tarball/v3/tarball/therock-dist-linux-gfx101X-dgpu-7.13.0.dev0+94696237b7f5a5c44ec2d3e367dae21483ec4e87.tar.gz
...
INFO:_therock_utils.storage_backend:  therock-dist-linux-gfx950-dcgpu-7.13.0.dev0+94696237b7f5a5c44ec2d3e367dae21483ec4e87.tar.gz -> s3://therock-dev-tarball/v3/tarball/therock-dist-linux-gfx950-dcgpu-7.13.0.dev0+94696237b7f5a5c44ec2d3e367dae21483ec4e87.tar.gz
INFO:_therock_utils.storage_backend:  therock-dist-linux-multiarch-7.13.0.dev0+94696237b7f5a5c44ec2d3e367dae21483ec4e87.tar.gz -> s3://therock-dev-tarball/v3/tarball/therock-dist-linux-multiarch-7.13.0.dev0+94696237b7f5a5c44ec2d3e367dae21483ec4e87.tar.gz
WARNING:_therock_utils.storage_backend:S3 copy attempt 1/3 failed for s3://therock-dev-artifacts/24540020624-linux/tarballs/therock-dist-linux-multiarch-7.13.0.dev0+94696237b7f5a5c44ec2d3e367dae21483ec4e87.tar.gz -> s3://therock-dev-tarball/v3/tarball/therock-dist-linux-multiarch-7.13.0.dev0+94696237b7f5a5c44ec2d3e367dae21483ec4e87.tar.gz: An error occurred (InvalidRequest) when calling the CopyObject operation: The specified copy source is larger than the maximum allowable size for a copy source: 5368709120. Retrying in 1.0s...
WARNING:_therock_utils.storage_backend:S3 copy attempt 2/3 failed for s3://therock-dev-artifacts/24540020624-linux/tarballs/therock-dist-linux-multiarch-7.13.0.dev0+94696237b7f5a5c44ec2d3e367dae21483ec4e87.tar.gz -> s3://therock-dev-tarball/v3/tarball/therock-dist-linux-
```

## Technical Details

The `copy_object()` API has a 5GB limit while the `copy()` API performs multipart, multithreaded copies internally.

Docs:
* https://docs.aws.amazon.com/boto3/latest/reference/services/s3/client/copy_object.html
    > You create a copy of your object up to 5 GB in size in a single atomic action using this API. However, to copy an object greater than 5 GB, you must use the multipart upload 
* https://docs.aws.amazon.com/boto3/latest/reference/services/s3/client/copy.html
    > This is a managed transfer which will perform a multipart copy in multiple threads if necessary.
* https://docs.aws.amazon.com/boto3/latest/reference/customizations/s3.html#boto3.s3.transfer.TransferConfig
    > `DEFAULTS = {'io_chunksize': 262144, 'max_bandwidth': None, 'max_concurrency': 10, 'max_io_queue': 100, 'max_io_queue_size': 100, 'max_request_concurrency': 10, 'multipart_chunksize': 8388608, 'multipart_threshold': 8388608, 'num_download_attempts': 5, 'preferred_transfer_client': 'auto', 'use_threads': True}`

## Test Plan

* Unit tests for the call sequence
* Manual testing with this script https://gist.github.com/ScottTodd/196df5598d8f27c903fc23155c7888e8

## Test Result

* Large file copy is now successful:
    ```
    (.venv) λ python D:\scratch\claude\test_s3_copy.py
    Source object size: 10,590,178,555 bytes (9.86 GB)
    
    --- Test 1: copy_object (low-level, 5GB limit) ---
    FAILED in 0.4s (expected for >5GB)
    Error: An error occurred (InvalidRequest) when calling the CopyObject operation: The specified copy source is larger than the maximum allowable size for a copy source: 5368709120
    
    --- Test 2: copy (managed transfer, multipart) ---
    SUCCESS in 33.2s
    Destination size: 10,590,178,555 bytes
    ```
* Small file copy is now faster:
    ```
    (.venv) λ python D:\scratch\claude\test_s3_copy.py
    Source object size: 2,933,613,000 bytes (2.73 GB)
    
    --- Test 1: copy_object (low-level, 5GB limit) ---
    SUCCESS in 54.2s (unexpected for >5GB)
    
    --- Test 2: copy (managed transfer, multipart) ---
    SUCCESS in 10.4s
    Destination size: 2,933,613,000 bytes
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
