### PR TITLE
Skip client-side flat index in kpack-split upload

### DIFF
--- a/build_tools/github_actions/tests/upload_python_packages_test.py
+++ b/build_tools/github_actions/tests/upload_python_packages_test.py
@@ -140,8 +140,11 @@ class TestMultiArchUploadPath(unittest.TestCase):
 class TestGenerateIndex(unittest.TestCase):
     """Tests for generate_index() flat vs per-family auto-detection."""
 
-    def test_flat_layout_creates_top_level_index(self):
-        """Flat dist/ (no subdirs) creates index.html at top level."""
+    def test_flat_layout_skips_client_side_index(self):
+        """Flat dist/ (no subdirs) skips client index generation — the
+        therock-ci-artifacts bucket serves index.html from its own side,
+        and a client-generated index would race with the server view
+        when multiple jobs append to the same prefix."""
         with tempfile.TemporaryDirectory() as tmp:
             dist_dir = Path(tmp)
             (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
@@ -149,20 +152,7 @@ class TestGenerateIndex(unittest.TestCase):
 
             upload_python_packages.generate_index(dist_dir, multiarch=True)
 
-            index = dist_dir / "index.html"
-            self.assertTrue(index.is_file())
-            content = index.read_text()
-            self.assertIn("rocm_sdk_core-1.0.whl", content)
-            self.assertIn("rocm_sdk_device_gfx942-1.0.whl", content)
-
-    def test_flat_layout_no_subdir_indexes_created(self):
-        """Flat dist/ does not create any subdirectory index files."""
-        with tempfile.TemporaryDirectory() as tmp:
-            dist_dir = Path(tmp)
-            (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
-
-            upload_python_packages.generate_index(dist_dir, multiarch=True)
-
+            self.assertFalse((dist_dir / "index.html").exists())
             self.assertFalse(any(d.is_dir() for d in dist_dir.iterdir()))
 
     def test_per_family_layout_creates_family_indexes(self):

--- a/build_tools/github_actions/upload_python_packages.py
+++ b/build_tools/github_actions/upload_python_packages.py
@@ -101,8 +101,14 @@ def generate_index(dist_dir: Path, multiarch: bool = False, dry_run: bool = Fals
             log("[INFO] Multi-arch legacy mode: generating per-family indexes")
             generate_multiarch_indexes(dist_dir)
         else:
-            log("[INFO] kpack-split flat mode: generating single top-level index")
-            generate_flat_index(dist_dir)
+            # kpack-split flat mode: multiple jobs may append to the same
+            # prefix (ROCm wheels + pytorch wheels). therock-ci-artifacts
+            # generates index.html server-side, so a client-side flat index
+            # would just race with (and briefly shadow) the server view.
+            log(
+                "[INFO] kpack-split flat mode: skipping client-side index "
+                "generation (server-side indexing handles it)"
+            )
     else:
         # Single-arch mode: use existing indexer.py for top-level
         log("[INFO] Single-arch mode: using indexer.py")


### PR DESCRIPTION
The therock-ci-artifacts bucket serves `index.html` from its own side, so `upload_python_packages.py` emitting a client-generated flat index in the kpack-split branch is redundant — and, once multiple jobs append to the same prefix, briefly wrong until the server refreshes. Drop the `generate_flat_index()` call in that one branch; legacy per-family and single-arch paths stay as-is.

The associated unit test is rewritten to assert the new behaviour: no client `index.html`, no subdir indexes.
