### PR TITLE
Only allow dev release type for multi_arch_release workflow_dispatch

### DIFF
--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -46,12 +46,10 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease". All developer-triggered jobs should use "dev"!'
+        description: 'Release type. All developer-triggered jobs should use "dev"!'
         type: choice
         options:
           - dev
-          - nightly
-          - prerelease
         default: dev
       prerelease_version:
         description: Prerelease version number such as '2'. This gets appended to the computed version after 'rc', like '7.10.0rc2'


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/3334.

Developers apparently can't be trusted to read: https://github.com/ROCm/TheRock/actions/runs/24596714944. All non-dev releases will be triggered in https://github.com/ROCm/rockrel.

## Test Plan

Check workflow input options in my fork:
<img width="1348" height="609" alt="image" src="https://github.com/user-attachments/assets/19ab3456-fdbe-40f7-8a9e-b8f01350d70e" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
