### PR TITLE
Bump pytest to 9.0.3

### DIFF
--- a/external-builds/jax/requirements-jax.txt
+++ b/external-builds/jax/requirements-jax.txt
@@ -5,7 +5,7 @@ wheel>=0.46.2
 six==1.17.0
 auditwheel==6.5.0
 scipy==1.16.3
-pytest==9.0.1
+pytest==9.0.3
 pytest-html==4.1.1
 pytest_html_merger==0.1.0
 pytest-reportlog==1.0.0

--- a/external-builds/pytorch/requirements-test.txt
+++ b/external-builds/pytorch/requirements-test.txt
@@ -1,6 +1,6 @@
 # Partially retrieved from https://github.com/pytorch/pytorch/blob/main/requirements.txt
 # and https://github.com/pytorch/pytorch/blob/main/requirements-build.txt
-pytest==8.3.5
+pytest==9.0.3
 pytest-timeout
 pytest-xdist>=3.5.0
 expecttest>=0.3.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 boto3==1.39.15
-pytest==9.0.0 # This versions has subtests built-in.
+pytest==9.0.3 # This versions has subtests built-in.
 pytest-check==2.5.3
 pytest-cov==6.0.0
 pytest-timeout==2.4.0


### PR DESCRIPTION
Fixed use of insecure temporary directory (CVE-2025-71176).