### PR TITLE
Build fat PyTorch wheel and kpack-split in multi-arch CI

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -233,3 +233,35 @@ jobs:
         run: |
           python external-builds/pytorch/sanity_check_wheel.py \
             ${{ env.PACKAGE_DIST_DIR }}/
+
+      # The kpack wheel splitter takes the fat torch wheel and produces a
+      # smaller host wheel plus one device wheel per gfx target. Source-install
+      # from the TheRock checkout — kpack has no published wheel today.
+      - name: Install kpack tooling
+        if: ${{ inputs.kpack_split == 'true' }}
+        run: |
+          pip install \
+            rocm-systems/python/rocm-bootstrap \
+            rocm-systems/shared/kpack
+
+      - name: Split PyTorch fat wheel
+        if: ${{ inputs.kpack_split == 'true' }}
+        run: |
+          # The splitter writes the host wheel under the same filename as the
+          # input, so relocate the fat wheel out of PACKAGE_DIST_DIR first.
+          FAT_STAGE="${RUNNER_TEMP:-/tmp}/pytorch-fat"
+          mkdir -p "${FAT_STAGE}"
+          mv ${{ env.PACKAGE_DIST_DIR }}/torch-*.whl "${FAT_STAGE}/"
+
+          python -m rocm_kpack.tools.split_python_wheels \
+            --input "${FAT_STAGE}"/torch-*.whl \
+            --output-dir "${{ env.PACKAGE_DIST_DIR }}" \
+            --device-package-prefix amd-torch-device \
+            --overlay-root torch/ \
+            --wheel-type torch-fat \
+            --compression zstd \
+            -j "$(nproc)"
+
+          rm -rf "${FAT_STAGE}"
+          echo "Post-split contents of ${{ env.PACKAGE_DIST_DIR }}:"
+          ls -lh "${{ env.PACKAGE_DIST_DIR }}/"

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -230,6 +230,13 @@ jobs:
       # The kpack wheel splitter takes the fat torch wheel and produces a
       # smaller host wheel plus one device wheel per gfx target. Source-install
       # from the TheRock checkout — kpack has no published wheel today.
+      # The outer actions/checkout skips submodules for speed, so pull in
+      # rocm-systems only when we actually need it.
+      - name: Init rocm-systems submodule
+        if: ${{ inputs.kpack_split == 'true' }}
+        run: |
+          git submodule update --init --depth=1 rocm-systems
+
       - name: Install kpack tooling
         if: ${{ inputs.kpack_split == 'true' }}
         run: |

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -242,6 +242,7 @@ jobs:
       - name: Init rocm-systems submodule
         if: ${{ inputs.kpack_split == 'true' }}
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git submodule update --init --depth=1 rocm-systems
 
       - name: Install kpack tooling

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -193,6 +193,18 @@ jobs:
             rocm_extras_flag="--rocm-extras ${{ steps.device_extras.outputs.value }}"
           fi
 
+          # Only multi-arch callers (multi_arch_ci_linux.yml) populate
+          # inputs.amdgpu_targets today. Legacy single-family CI (ci_linux.yml)
+          # leaves it empty and falls back to `rocm-sdk targets` inside
+          # build_prod_wheels.py.
+          # TODO(#4687): Make --pytorch-rocm-arch required here once every
+          # caller plumbs the value through and the fallback in
+          # build_prod_wheels.py::get_rocm_sdk_targets is removed.
+          pytorch_rocm_arch_flag=""
+          if [ -n "${{ inputs.amdgpu_targets }}" ]; then
+            pytorch_rocm_arch_flag="--pytorch-rocm-arch ${{ inputs.amdgpu_targets }}"
+          fi
+
           ./external-builds/pytorch/build_prod_wheels.py \
             build \
             --install-rocm \
@@ -201,6 +213,7 @@ jobs:
             --output-dir ${{ env.PACKAGE_DIST_DIR }} \
             ${cache_flag} \
             ${rocm_extras_flag} \
+            ${pytorch_rocm_arch_flag} \
             ${{ env.optional_build_prod_arguments }}
 
       - name: Report cache stats

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -44,11 +44,13 @@ on:
         required: false
         type: string
         default: "none"
-      amdgpu_targets:
+      amdgpu_families:
         description: >-
-          Comma-separated individual gfx targets for kpack-split builds
-          (e.g. 'gfx942' or 'gfx1200,gfx1201'). Used to install the correct
-          per-target device wheels. Leave empty for legacy per-family builds.
+          Semicolon-separated list of AMD GPU families to build PyTorch for
+          (e.g. 'gfx94X-dcgpu;gfx120X-all'). Expanded to gfx targets at
+          build time via cmake/therock_amdgpu_targets.cmake. Leave empty
+          for legacy callers that rely on build_prod_wheels.py's
+          `rocm-sdk targets` fallback.
         type: string
         default: ""
       kpack_split:
@@ -168,16 +170,14 @@ jobs:
           echo "SCCACHE_BUCKET=${SCCACHE_BUCKET}"
           echo "SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX}"
 
-      - name: Compute ROCm device extras
-        id: device_extras
+      - name: Expand amdgpu families to gfx targets
+        if: ${{ inputs.amdgpu_families != '' }}
+        id: expand
         run: |
-          if [ "${{ inputs.kpack_split }}" = "true" ] && [ -n "${{ inputs.amdgpu_targets }}" ]; then
-            # Prefix each comma-separated target with "device-": gfx942,gfx1201 -> device-gfx942,device-gfx1201
-            extras=$(echo "${{ inputs.amdgpu_targets }}" | sed 's/\(^\|,\)/\1device-/g')
-            echo "value=${extras}" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=" >> "$GITHUB_OUTPUT"
-          fi
+          targets=$(python build_tools/github_actions/expand_amdgpu_families.py \
+            --amdgpu-families "${{ inputs.amdgpu_families }}")
+          echo "Expanded families '${{ inputs.amdgpu_families }}' -> '${targets}'"
+          echo "targets=${targets}" >> "$GITHUB_OUTPUT"
 
       - name: Build PyTorch wheels
         run: |
@@ -188,21 +188,15 @@ jobs:
             cache_flag="--use-ccache"
           fi
 
-          rocm_extras_flag=""
-          if [ -n "${{ steps.device_extras.outputs.value }}" ]; then
-            rocm_extras_flag="--rocm-extras ${{ steps.device_extras.outputs.value }}"
-          fi
-
-          # Only multi-arch callers (multi_arch_ci_linux.yml) populate
-          # inputs.amdgpu_targets today. Legacy single-family CI (ci_linux.yml)
-          # leaves it empty and falls back to `rocm-sdk targets` inside
-          # build_prod_wheels.py.
+          # inputs.amdgpu_families is only populated by the multi-arch caller
+          # today. Legacy single-family CI (ci_linux.yml) leaves it empty and
+          # falls back to `rocm-sdk targets` inside build_prod_wheels.py.
           # TODO(#4687): Make --pytorch-rocm-arch required here once every
           # caller plumbs the value through and the fallback in
           # build_prod_wheels.py::get_rocm_sdk_targets is removed.
           pytorch_rocm_arch_flag=""
-          if [ -n "${{ inputs.amdgpu_targets }}" ]; then
-            pytorch_rocm_arch_flag="--pytorch-rocm-arch ${{ inputs.amdgpu_targets }}"
+          if [ -n "${{ steps.expand.outputs.targets }}" ]; then
+            pytorch_rocm_arch_flag="--pytorch-rocm-arch ${{ steps.expand.outputs.targets }}"
           fi
 
           ./external-builds/pytorch/build_prod_wheels.py \
@@ -212,7 +206,6 @@ jobs:
             --clean \
             --output-dir ${{ env.PACKAGE_DIST_DIR }} \
             ${cache_flag} \
-            ${rocm_extras_flag} \
             ${pytorch_rocm_arch_flag} \
             ${{ env.optional_build_prod_arguments }}
 
@@ -253,12 +246,15 @@ jobs:
           mkdir -p "${FAT_STAGE}"
           mv ${{ env.PACKAGE_DIST_DIR }}/torch-*.whl "${FAT_STAGE}/"
 
+          ROCM_SDK_VERSION="$(python -m rocm_sdk version)"
+
           python -m rocm_kpack.tools.split_python_wheels \
             --input "${FAT_STAGE}"/torch-*.whl \
             --output-dir "${{ env.PACKAGE_DIST_DIR }}" \
             --device-package-prefix amd-torch-device \
             --overlay-root torch/ \
             --wheel-type torch-fat \
+            --device-requires-dist "rocm-sdk-device-@GFXARCH@ == ${ROCM_SDK_VERSION}" \
             --compression zstd \
             -j "$(nproc)"
 

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -249,8 +249,8 @@ jobs:
         if: ${{ inputs.kpack_split == 'true' }}
         run: |
           pip install \
-            rocm-systems/python/rocm-bootstrap \
-            rocm-systems/shared/kpack
+            -e rocm-systems/python/rocm-bootstrap \
+            -e rocm-systems/shared/kpack
 
       - name: Split PyTorch fat wheel
         if: ${{ inputs.kpack_split == 'true' }}

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -11,7 +11,6 @@
 #   - Uses sccache with S3-backed storage (configurable via cache_type input)
 #
 # TODO(#3291): Build more packages (torchvision, torchaudio, triton, etc.)
-# TODO(#3291): Upload packages to S3 (via upload_python_packages.py?)
 #
 # Both workflows share build_prod_wheels.py for the actual build logic.
 # See https://github.com/ROCm/TheRock/issues/3291 for convergence plans.
@@ -186,6 +185,12 @@ jobs:
           echo "Expanded families '${{ inputs.amdgpu_families }}' -> '${targets}'"
           echo "targets=${targets}" >> "$GITHUB_OUTPUT"
 
+      # inputs.amdgpu_families is only populated by the multi-arch caller
+      # today. Legacy single-family CI (ci_linux.yml) leaves it empty and
+      # falls back to `rocm-sdk targets` inside build_prod_wheels.py.
+      # TODO(#4687): Make --pytorch-rocm-arch required here once every
+      # caller plumbs the value through and the fallback in
+      # build_prod_wheels.py::get_rocm_sdk_targets is removed.
       - name: Build PyTorch wheels
         run: |
           cache_flag=""
@@ -195,12 +200,6 @@ jobs:
             cache_flag="--use-ccache"
           fi
 
-          # inputs.amdgpu_families is only populated by the multi-arch caller
-          # today. Legacy single-family CI (ci_linux.yml) leaves it empty and
-          # falls back to `rocm-sdk targets` inside build_prod_wheels.py.
-          # TODO(#4687): Make --pytorch-rocm-arch required here once every
-          # caller plumbs the value through and the fallback in
-          # build_prod_wheels.py::get_rocm_sdk_targets is removed.
           pytorch_rocm_arch_flag=""
           if [ -n "${{ steps.expand.outputs.targets }}" ]; then
             pytorch_rocm_arch_flag="--pytorch-rocm-arch ${{ steps.expand.outputs.targets }}"

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -57,6 +57,13 @@ on:
         description: "'true' if this is a kpack-split flat build."
         type: string
         default: "false"
+      release_type:
+        description: >-
+          Release type used to pick the AWS role for S3 uploads
+          (forwarded to configure_aws_artifacts_credentials). Empty for
+          CI runs that should skip the upload.
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       artifact_group:
@@ -268,3 +275,19 @@ jobs:
           rm -rf "${FAT_STAGE}"
           echo "Post-split contents of ${{ env.PACKAGE_DIST_DIR }}:"
           ls -lh "${{ env.PACKAGE_DIST_DIR }}/"
+
+      - name: Configure AWS Credentials
+        uses: ./.github/actions/configure_aws_artifacts_credentials
+        with:
+          release_type: ${{ inputs.release_type }}
+
+      # Appends to the same therock-ci-artifacts/<run>-linux/python/ prefix
+      # that the ROCm python job already populated — one find-links URL
+      # covers the whole SDK + PyTorch stack.
+      - name: Upload PyTorch wheels
+        run: |
+          python build_tools/github_actions/upload_python_packages.py \
+            --input-packages-dir="${{ env.PACKAGE_DIST_DIR }}" \
+            --artifact-group="${{ inputs.artifact_group }}" \
+            --run-id="${{ github.run_id }}" \
+            --multiarch

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -263,6 +263,7 @@ jobs:
       - name: Init rocm-systems submodule
         if: ${{ inputs.kpack_split == 'true' }}
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git submodule update --init --depth=1 rocm-systems
 
       - name: Install kpack tooling

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -317,7 +317,7 @@ jobs:
             --wheel-type torch-fat \
             --device-requires-dist "rocm-sdk-device-@GFXARCH@ == ${ROCM_SDK_VERSION}" \
             --compression zstd \
-            -j "$(nproc)"
+            -j 32
 
           rm -rf "${FAT_STAGE}"
           echo "Post-split contents of ${DIST_DIR}:"

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -211,6 +211,16 @@ jobs:
           set "ROCM_EXTRAS_FLAG="
           if not "${{ steps.device_extras.outputs.value }}"=="" set "ROCM_EXTRAS_FLAG=--rocm-extras ${{ steps.device_extras.outputs.value }}"
 
+          REM Only multi-arch callers (multi_arch_ci_windows.yml) populate
+          REM inputs.amdgpu_targets today. Legacy single-family CI
+          REM (ci_windows.yml) leaves it empty and falls back to
+          REM `rocm-sdk targets` inside build_prod_wheels.py.
+          REM TODO(#4687): Make --pytorch-rocm-arch required here once every
+          REM caller plumbs the value through and the fallback in
+          REM build_prod_wheels.py::get_rocm_sdk_targets is removed.
+          set "PYTORCH_ROCM_ARCH_FLAG="
+          if not "${{ inputs.amdgpu_targets }}"=="" set "PYTORCH_ROCM_ARCH_FLAG=--pytorch-rocm-arch ${{ inputs.amdgpu_targets }}"
+
           echo "Building PyTorch wheels for ${{ inputs.artifact_group }} (cache: ${{ inputs.cache_type }})"
           python ./external-builds/pytorch/build_prod_wheels.py ^
             build ^
@@ -222,6 +232,7 @@ jobs:
             --output-dir ${{ env.PACKAGE_DIST_DIR }} ^
             %CACHE_FLAG% ^
             %ROCM_EXTRAS_FLAG% ^
+            %PYTORCH_ROCM_ARCH_FLAG% ^
             ${{ env.optional_build_prod_arguments }}
 
       - name: Report cache stats

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -251,6 +251,13 @@ jobs:
       # The kpack wheel splitter takes the fat torch wheel and produces a
       # smaller host wheel plus one device wheel per gfx target. Source-install
       # from the TheRock checkout — kpack has no published wheel today.
+      # The outer actions/checkout skips submodules for speed, so pull in
+      # rocm-systems only when we actually need it.
+      - name: Init rocm-systems submodule
+        if: ${{ inputs.kpack_split == 'true' }}
+        run: |
+          git submodule update --init --depth=1 rocm-systems
+
       - name: Install kpack tooling
         if: ${{ inputs.kpack_split == 'true' }}
         run: |

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -56,6 +56,13 @@ on:
         description: "'true' if this is a kpack-split flat build."
         type: string
         default: "false"
+      release_type:
+        description: >-
+          Release type used to pick the AWS role for S3 uploads
+          (forwarded to configure_aws_artifacts_credentials). Empty for
+          CI runs that should skip the upload.
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       artifact_group:
@@ -314,3 +321,19 @@ jobs:
           rm -rf "${FAT_STAGE}"
           echo "Post-split contents of ${DIST_DIR}:"
           ls -lh "${DIST_DIR}/"
+
+      - name: Configure AWS Credentials
+        uses: ./.github/actions/configure_aws_artifacts_credentials
+        with:
+          release_type: ${{ inputs.release_type }}
+
+      # Appends to the same therock-ci-artifacts/<run>-windows/python/ prefix
+      # that the ROCm python job already populated — one find-links URL
+      # covers the whole SDK + PyTorch stack.
+      - name: Upload PyTorch wheels
+        run: |
+          python build_tools/github_actions/upload_python_packages.py \
+            --input-packages-dir="${{ env.PACKAGE_DIST_DIR }}" \
+            --artifact-group="${{ inputs.artifact_group }}" \
+            --run-id="${{ github.run_id }}" \
+            --multiarch

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -252,3 +252,60 @@ jobs:
         shell: cmd
         run: |
           python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}
+
+      # The kpack wheel splitter takes the fat torch wheel and produces a
+      # smaller host wheel plus one device wheel per gfx target. Source-install
+      # from the TheRock checkout — kpack has no published wheel today.
+      - name: Install kpack tooling
+        if: ${{ inputs.kpack_split == 'true' }}
+        run: |
+          pip install \
+            rocm-systems/python/rocm-bootstrap \
+            rocm-systems/shared/kpack
+
+      - name: Split PyTorch fat wheel
+        if: ${{ inputs.kpack_split == 'true' }}
+        run: |
+          DIST_DIR="$(cygpath -u "${{ env.PACKAGE_DIST_DIR }}")"
+
+          # LLVM binaries ship inside the already-installed rocm-sdk-devel.
+          ROCM_SDK_ROOT="$(cygpath -u "$(python -m rocm_sdk path --root)")"
+          LLVM_BIN="${ROCM_SDK_ROOT}/lib/llvm/bin"
+          if [ ! -d "${LLVM_BIN}" ]; then
+            echo "ERROR: LLVM bin dir not found: ${LLVM_BIN}" >&2
+            exit 1
+          fi
+
+          # The kpack Toolchain strictly looks up "objcopy" and "readelf" on
+          # PATH. On Windows, ROCm ships only llvm-objcopy.exe /
+          # llvm-readelf.exe, so stage copies under the unprefixed names.
+          # TODO: drop this shim once rocm-kpack's Toolchain adds llvm-*
+          # fallbacks for objcopy/readelf (parallels its existing objdump
+          # pattern). See tasks/active/kpack-binutils-llvm-fallback.md.
+          SHIMS="$(cygpath -u "${RUNNER_TEMP}")/kpack-shims"
+          mkdir -p "${SHIMS}"
+          cp "${LLVM_BIN}/llvm-objcopy.exe" "${SHIMS}/objcopy.exe"
+          cp "${LLVM_BIN}/llvm-readelf.exe" "${SHIMS}/readelf.exe"
+
+          # Prepend shims + LLVM bin so clang-offload-bundler.exe and the
+          # llvm-objdump fallback are also resolvable.
+          export PATH="${SHIMS}:${LLVM_BIN}:${PATH}"
+
+          # The splitter writes the host wheel under the same filename as the
+          # input, so relocate the fat wheel out of PACKAGE_DIST_DIR first.
+          FAT_STAGE="$(cygpath -u "${RUNNER_TEMP}")/pytorch-fat"
+          mkdir -p "${FAT_STAGE}"
+          mv "${DIST_DIR}"/torch-*.whl "${FAT_STAGE}/"
+
+          python -m rocm_kpack.tools.split_python_wheels \
+            --input "${FAT_STAGE}"/torch-*.whl \
+            --output-dir "${DIST_DIR}" \
+            --device-package-prefix amd-torch-device \
+            --overlay-root torch/ \
+            --wheel-type torch-fat \
+            --compression zstd \
+            -j "$(nproc)"
+
+          rm -rf "${FAT_STAGE}"
+          echo "Post-split contents of ${DIST_DIR}:"
+          ls -lh "${DIST_DIR}/"

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -10,7 +10,6 @@
 #   - No S3 upload, staging, testing, or promotion — just build + sanity check
 #
 # TODO(#3291): Build more packages (torchvision, torchaudio, etc.)
-# TODO(#3291): Upload packages to S3 (via upload_python_packages.py?)
 #
 # Both workflows share build_prod_wheels.py for the actual build logic.
 # See https://github.com/ROCm/TheRock/issues/3291 for convergence plans.
@@ -208,6 +207,13 @@ jobs:
 
       # Using 'cmd' here is load bearing! There are configuration issues when
       # run under 'bash': https://github.com/ROCm/TheRock/issues/827#issuecomment-3025858800
+      #
+      # inputs.amdgpu_families is only populated by the multi-arch caller
+      # today. Legacy single-family CI (ci_linux.yml) leaves it empty and
+      # falls back to `rocm-sdk targets` inside build_prod_wheels.py.
+      # TODO(#4687): Make --pytorch-rocm-arch required here once every
+      # caller plumbs the value through and the fallback in
+      # build_prod_wheels.py::get_rocm_sdk_targets is removed.
       - name: Build PyTorch wheels
         shell: cmd
         run: |
@@ -215,12 +221,6 @@ jobs:
           if "${{ inputs.cache_type }}"=="sccache" set "CACHE_FLAG=--use-sccache"
           if "${{ inputs.cache_type }}"=="ccache" set "CACHE_FLAG=--use-ccache"
 
-          REM inputs.amdgpu_families is only populated by the multi-arch caller
-          REM today. Legacy single-family CI (ci_windows.yml) leaves it empty
-          REM and falls back to `rocm-sdk targets` inside build_prod_wheels.py.
-          REM TODO(#4687): Make --pytorch-rocm-arch required here once every
-          REM caller plumbs the value through and the fallback in
-          REM build_prod_wheels.py::get_rocm_sdk_targets is removed.
           set "PYTORCH_ROCM_ARCH_FLAG="
           if not "${{ steps.expand.outputs.targets }}"=="" set "PYTORCH_ROCM_ARCH_FLAG=--pytorch-rocm-arch ${{ steps.expand.outputs.targets }}"
 
@@ -291,7 +291,7 @@ jobs:
           # llvm-readelf.exe, so stage copies under the unprefixed names.
           # TODO: drop this shim once rocm-kpack's Toolchain adds llvm-*
           # fallbacks for objcopy/readelf (parallels its existing objdump
-          # pattern). See tasks/active/kpack-binutils-llvm-fallback.md.
+          # pattern). See https://github.com/ROCm/rocm-systems/issues/5506.
           SHIMS="$(cygpath -u "${RUNNER_TEMP}")/kpack-shims"
           mkdir -p "${SHIMS}"
           cp "${LLVM_BIN}/llvm-objcopy.exe" "${SHIMS}/objcopy.exe"

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -43,11 +43,13 @@ on:
         required: false
         type: string
         default: "none"
-      amdgpu_targets:
+      amdgpu_families:
         description: >-
-          Comma-separated individual gfx targets for kpack-split builds
-          (e.g. 'gfx1151' or 'gfx1200,gfx1201'). Used to install the correct
-          per-target device wheels. Leave empty for legacy per-family builds.
+          Semicolon-separated list of AMD GPU families to build PyTorch for
+          (e.g. 'gfx110X-all;gfx120X-all'). Expanded to gfx targets at
+          build time via cmake/therock_amdgpu_targets.cmake. Leave empty
+          for legacy callers that rely on build_prod_wheels.py's
+          `rocm-sdk targets` fallback.
         type: string
         default: ""
       kpack_split:
@@ -188,16 +190,14 @@ jobs:
           echo "SCCACHE_BUCKET=${SCCACHE_BUCKET}"
           echo "SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX}"
 
-      - name: Compute ROCm device extras
-        id: device_extras
+      - name: Expand amdgpu families to gfx targets
+        if: ${{ inputs.amdgpu_families != '' }}
+        id: expand
         run: |
-          if [ "${{ inputs.kpack_split }}" = "true" ] && [ -n "${{ inputs.amdgpu_targets }}" ]; then
-            # Prefix each comma-separated target with "device-": gfx1151,gfx1201 -> device-gfx1151,device-gfx1201
-            extras=$(echo "${{ inputs.amdgpu_targets }}" | sed 's/\(^\|,\)/\1device-/g')
-            echo "value=${extras}" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=" >> "$GITHUB_OUTPUT"
-          fi
+          targets=$(python build_tools/github_actions/expand_amdgpu_families.py \
+            --amdgpu-families "${{ inputs.amdgpu_families }}")
+          echo "Expanded families '${{ inputs.amdgpu_families }}' -> '${targets}'"
+          echo "targets=${targets}" >> "$GITHUB_OUTPUT"
 
       # Using 'cmd' here is load bearing! There are configuration issues when
       # run under 'bash': https://github.com/ROCm/TheRock/issues/827#issuecomment-3025858800
@@ -208,18 +208,14 @@ jobs:
           if "${{ inputs.cache_type }}"=="sccache" set "CACHE_FLAG=--use-sccache"
           if "${{ inputs.cache_type }}"=="ccache" set "CACHE_FLAG=--use-ccache"
 
-          set "ROCM_EXTRAS_FLAG="
-          if not "${{ steps.device_extras.outputs.value }}"=="" set "ROCM_EXTRAS_FLAG=--rocm-extras ${{ steps.device_extras.outputs.value }}"
-
-          REM Only multi-arch callers (multi_arch_ci_windows.yml) populate
-          REM inputs.amdgpu_targets today. Legacy single-family CI
-          REM (ci_windows.yml) leaves it empty and falls back to
-          REM `rocm-sdk targets` inside build_prod_wheels.py.
+          REM inputs.amdgpu_families is only populated by the multi-arch caller
+          REM today. Legacy single-family CI (ci_windows.yml) leaves it empty
+          REM and falls back to `rocm-sdk targets` inside build_prod_wheels.py.
           REM TODO(#4687): Make --pytorch-rocm-arch required here once every
           REM caller plumbs the value through and the fallback in
           REM build_prod_wheels.py::get_rocm_sdk_targets is removed.
           set "PYTORCH_ROCM_ARCH_FLAG="
-          if not "${{ inputs.amdgpu_targets }}"=="" set "PYTORCH_ROCM_ARCH_FLAG=--pytorch-rocm-arch ${{ inputs.amdgpu_targets }}"
+          if not "${{ steps.expand.outputs.targets }}"=="" set "PYTORCH_ROCM_ARCH_FLAG=--pytorch-rocm-arch ${{ steps.expand.outputs.targets }}"
 
           echo "Building PyTorch wheels for ${{ inputs.artifact_group }} (cache: ${{ inputs.cache_type }})"
           python ./external-builds/pytorch/build_prod_wheels.py ^
@@ -231,7 +227,6 @@ jobs:
             --clean ^
             --output-dir ${{ env.PACKAGE_DIST_DIR }} ^
             %CACHE_FLAG% ^
-            %ROCM_EXTRAS_FLAG% ^
             %PYTORCH_ROCM_ARCH_FLAG% ^
             ${{ env.optional_build_prod_arguments }}
 
@@ -297,12 +292,15 @@ jobs:
           mkdir -p "${FAT_STAGE}"
           mv "${DIST_DIR}"/torch-*.whl "${FAT_STAGE}/"
 
+          ROCM_SDK_VERSION="$(python -m rocm_sdk version)"
+
           python -m rocm_kpack.tools.split_python_wheels \
             --input "${FAT_STAGE}"/torch-*.whl \
             --output-dir "${DIST_DIR}" \
             --device-package-prefix amd-torch-device \
             --overlay-root torch/ \
             --wheel-type torch-fat \
+            --device-requires-dist "rocm-sdk-device-@GFXARCH@ == ${ROCM_SDK_VERSION}" \
             --compression zstd \
             -j "$(nproc)"
 

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -270,8 +270,8 @@ jobs:
         if: ${{ inputs.kpack_split == 'true' }}
         run: |
           pip install \
-            rocm-systems/python/rocm-bootstrap \
-            rocm-systems/shared/kpack
+            -e rocm-systems/python/rocm-bootstrap \
+            -e rocm-systems/shared/kpack
 
       - name: Split PyTorch fat wheel
         if: ${{ inputs.kpack_split == 'true' }}

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -166,33 +166,25 @@ jobs:
       container_image_name: ${{ matrix.image.name }}
       container_image_url: ${{ matrix.image.url }}
 
-  # NOTE: Per-family PyTorch builds — each family gets its own wheel built
-  # against that family's ROCm package index slice.
-  # TODO(future): Consider adding a combined multi-arch pytorch build job
-  # that builds once against the full multi-arch index (amdgpu_families=all).
-  build_pytorch_wheels_per_family:
+  # Multi-arch PyTorch build: one fat wheel covering every target, then
+  # split into a host wheel + per-gfx device wheels via rocm-kpack.
+  # KPACK_SPLIT_ARTIFACTS is always ON in multi-arch CI (FLAGS.cmake
+  # default; build_configure.py's opt-out only fires in single-arch CI),
+  # so the split path is unconditional here. The split itself runs inline
+  # in build_portable_linux_pytorch_wheels_ci.yml based on inputs.kpack_split.
+  build_pytorch_wheel_fat:
     needs: [build_python_packages]
-    name: Build PyTorch | ${{ matrix.family_info.amdgpu_family }}
+    name: Build PyTorch (fat + split)
     if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_pytorch == true }}
-    strategy:
-      fail-fast: false
-      matrix:
-        family_info: ${{ fromJSON(inputs.build_config).per_family_info }}
     uses: ./.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
     with:
-      artifact_group: ${{ matrix.family_info.amdgpu_family }}
+      artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       python_version: "3.12"
       pytorch_git_ref: "release/2.10"
-      amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
-      kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
-      rocm_package_find_links_url: >-
-        ${{
-          needs.build_python_packages.outputs.kpack_split == 'true'
-          && needs.build_python_packages.outputs.package_find_links_url
-          || format('{0}/{1}/index.html',
-              needs.build_python_packages.outputs.package_find_links_url,
-              matrix.family_info.amdgpu_family)
-        }}
+      # Combined targets across every family, e.g. "gfx942,gfx1200,gfx1201".
+      amdgpu_targets: ${{ join(fromJSON(inputs.build_config).per_family_info.*.amdgpu_targets, ',') }}
+      kpack_split: "true"
+      rocm_package_find_links_url: ${{ needs.build_python_packages.outputs.package_find_links_url }}
       rocm_version: ${{ inputs.rocm_package_version }}
     permissions:
       contents: read

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -187,6 +187,7 @@ jobs:
       kpack_split: "true"
       rocm_package_find_links_url: ${{ needs.build_python_packages.outputs.package_find_links_url }}
       rocm_version: ${{ inputs.rocm_package_version }}
+      release_type: ${{ inputs.release_type }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -184,7 +184,7 @@ jobs:
       # The reusable workflow expands this to gfx targets via
       # cmake/therock_amdgpu_targets.cmake.
       amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
-      kpack_split: "true"
+      kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
       rocm_package_find_links_url: ${{ needs.build_python_packages.outputs.package_find_links_url }}
       rocm_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -181,8 +181,9 @@ jobs:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       python_version: "3.12"
       pytorch_git_ref: "release/2.10"
-      # Combined targets across every family, e.g. "gfx942,gfx1200,gfx1201".
-      amdgpu_targets: ${{ join(fromJSON(inputs.build_config).per_family_info.*.amdgpu_targets, ',') }}
+      # The reusable workflow expands this to gfx targets via
+      # cmake/therock_amdgpu_targets.cmake.
+      amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       kpack_split: "true"
       rocm_package_find_links_url: ${{ needs.build_python_packages.outputs.package_find_links_url }}
       rocm_version: ${{ inputs.rocm_package_version }}

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -187,6 +187,7 @@ jobs:
       kpack_split: "true"
       rocm_package_find_links_url: ${{ needs.build_python_packages.outputs.package_find_links_url }}
       rocm_version: ${{ inputs.rocm_package_version }}
+      release_type: ${{ inputs.release_type }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -184,7 +184,7 @@ jobs:
       # The reusable workflow expands this to gfx targets via
       # cmake/therock_amdgpu_targets.cmake.
       amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
-      kpack_split: "true"
+      kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
       rocm_package_find_links_url: ${{ needs.build_python_packages.outputs.package_find_links_url }}
       rocm_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -166,16 +166,15 @@ jobs:
       container_image_name: native
       container_image_url: ""
 
-  # Multi-arch PyTorch build: one fat wheel covering every target.
+  # Multi-arch PyTorch build: one fat wheel covering every target, then
+  # split into a host wheel + per-gfx device wheels via rocm-kpack.
   # KPACK_SPLIT_ARTIFACTS is always ON in multi-arch CI (FLAGS.cmake
   # default; build_configure.py's opt-out only fires in single-arch CI),
-  # so kpack_split is hard-coded to "true" here.
-  # TODO(#4687): Wire the kpack split step into
-  # build_windows_pytorch_wheels_ci.yml once the splitter is validated on
-  # Windows (mirrors the Linux path in build_portable_linux_pytorch_wheels_ci.yml).
+  # so the split path is unconditional here. The split itself runs inline
+  # in build_windows_pytorch_wheels_ci.yml based on inputs.kpack_split.
   build_pytorch_wheel_fat:
     needs: [build_python_packages]
-    name: Build PyTorch (fat)
+    name: Build PyTorch (fat + split)
     if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_pytorch == true }}
     uses: ./.github/workflows/build_windows_pytorch_wheels_ci.yml
     with:

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -166,33 +166,26 @@ jobs:
       container_image_name: native
       container_image_url: ""
 
-  # NOTE: Per-family PyTorch builds — each family gets its own wheel built
-  # against that family's ROCm package index slice.
-  # TODO(future): Consider adding a combined multi-arch pytorch build job
-  # that builds once against the full multi-arch index (amdgpu_families=all).
-  build_pytorch_wheels_per_family:
+  # Multi-arch PyTorch build: one fat wheel covering every target.
+  # KPACK_SPLIT_ARTIFACTS is always ON in multi-arch CI (FLAGS.cmake
+  # default; build_configure.py's opt-out only fires in single-arch CI),
+  # so kpack_split is hard-coded to "true" here.
+  # TODO(#4687): Wire the kpack split step into
+  # build_windows_pytorch_wheels_ci.yml once the splitter is validated on
+  # Windows (mirrors the Linux path in build_portable_linux_pytorch_wheels_ci.yml).
+  build_pytorch_wheel_fat:
     needs: [build_python_packages]
-    name: Build PyTorch | ${{ matrix.family_info.amdgpu_family }}
+    name: Build PyTorch (fat)
     if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_pytorch == true }}
-    strategy:
-      fail-fast: false
-      matrix:
-        family_info: ${{ fromJSON(inputs.build_config).per_family_info }}
     uses: ./.github/workflows/build_windows_pytorch_wheels_ci.yml
     with:
-      artifact_group: ${{ matrix.family_info.amdgpu_family }}
+      artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       python_version: "3.12"
       pytorch_git_ref: "release/2.10"
-      amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
-      kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
-      rocm_package_find_links_url: >-
-        ${{
-          needs.build_python_packages.outputs.kpack_split == 'true'
-          && needs.build_python_packages.outputs.package_find_links_url
-          || format('{0}/{1}/index.html',
-              needs.build_python_packages.outputs.package_find_links_url,
-              matrix.family_info.amdgpu_family)
-        }}
+      # Combined targets across every family, e.g. "gfx1100,gfx1151,gfx1201".
+      amdgpu_targets: ${{ join(fromJSON(inputs.build_config).per_family_info.*.amdgpu_targets, ',') }}
+      kpack_split: "true"
+      rocm_package_find_links_url: ${{ needs.build_python_packages.outputs.package_find_links_url }}
       rocm_version: ${{ inputs.rocm_package_version }}
     permissions:
       contents: read

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -181,8 +181,9 @@ jobs:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       python_version: "3.12"
       pytorch_git_ref: "release/2.10"
-      # Combined targets across every family, e.g. "gfx1100,gfx1151,gfx1201".
-      amdgpu_targets: ${{ join(fromJSON(inputs.build_config).per_family_info.*.amdgpu_targets, ',') }}
+      # The reusable workflow expands this to gfx targets via
+      # cmake/therock_amdgpu_targets.cmake.
+      amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       kpack_split: "true"
       rocm_package_find_links_url: ${{ needs.build_python_packages.outputs.package_find_links_url }}
       rocm_version: ${{ inputs.rocm_package_version }}

--- a/build_tools/_therock_utils/cmake_amdgpu_targets.py
+++ b/build_tools/_therock_utils/cmake_amdgpu_targets.py
@@ -11,6 +11,14 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
+_DEFAULT_CMAKE_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "cmake"
+    / "therock_amdgpu_targets.cmake"
+)
+
+_family_to_targets_cache: dict[Path, dict[str, list[str]]] = {}
+
 
 @dataclass
 class AmdgpuTargetInfo:
@@ -80,6 +88,52 @@ def build_family_to_targets(infos: list[AmdgpuTargetInfo]) -> dict[str, list[str
             if info.gfx_target not in result[family]:
                 result[family].append(info.gfx_target)
     return result
+
+
+def amdgpu_family_map(
+    cmake_path: Path | None = None,
+) -> dict[str, list[str]]:
+    """Return the family → gfx targets map, parsing the CMake file once.
+
+    Uses `cmake/therock_amdgpu_targets.cmake` at the repo root by default.
+    Results are cached per resolved path so repeated calls are free.
+    """
+    resolved = (cmake_path or _DEFAULT_CMAKE_PATH).resolve()
+    cached = _family_to_targets_cache.get(resolved)
+    if cached is None:
+        cached = build_family_to_targets(parse_amdgpu_targets_cmake(resolved))
+        _family_to_targets_cache[resolved] = cached
+    return cached
+
+
+def expand_families(
+    families: list[str],
+    family_map: dict[str, list[str]],
+    *,
+    strict: bool = True,
+) -> list[str]:
+    """Expand a list of family names to the union of their gfx targets.
+
+    Preserves input order; de-duplicates. When `strict` (the default),
+    raises ValueError if any family is not present in `family_map`. With
+    `strict=False`, unknown families are silently skipped.
+    """
+    if strict:
+        unknown = [f for f in families if f not in family_map]
+        if unknown:
+            known = ", ".join(sorted(family_map.keys()))
+            raise ValueError(
+                f"Unknown AMD GPU families: {unknown}. Known families: {known}"
+            )
+
+    targets: list[str] = []
+    seen: set[str] = set()
+    for family in families:
+        for target in family_map.get(family, []):
+            if target not in seen:
+                seen.add(target)
+                targets.append(target)
+    return targets
 
 
 def _tokenize_cmake(text: str) -> list[str]:

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -73,6 +73,7 @@ from _therock_utils.workflow_outputs import WorkflowOutputRoot
 # Component types that artifacts are split into
 ARTIFACT_COMPONENTS = ["lib", "run", "dev", "dbg", "doc", "test"]
 
+
 def log(msg: str):
     """Print message and flush."""
     print(msg, flush=True)
@@ -148,9 +149,7 @@ def parse_target_families(args: argparse.Namespace) -> List[str]:
             output_families.extend(input_families)
             if args.expand_family_to_targets:
                 family_map = amdgpu_family_map()
-                for target in expand_families(
-                    input_families, family_map, strict=False
-                ):
+                for target in expand_families(input_families, family_map, strict=False):
                     if target not in output_families:
                         output_families.append(target)
         if args.amdgpu_targets:

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -56,8 +56,8 @@ from pathlib import Path
 from typing import List, Optional, Set
 
 from _therock_utils.cmake_amdgpu_targets import (
-    build_family_to_targets,
-    parse_amdgpu_targets_cmake,
+    amdgpu_family_map,
+    expand_families,
 )
 from _therock_utils.build_topology import BuildTopology
 from _therock_utils.artifact_backend import (
@@ -72,22 +72,6 @@ from _therock_utils.workflow_outputs import WorkflowOutputRoot
 
 # Component types that artifacts are split into
 ARTIFACT_COMPONENTS = ["lib", "run", "dev", "dbg", "doc", "test"]
-
-# Lazy-loaded cache for the family -> targets mapping parsed from CMake.
-_family_to_targets_cache: Optional[dict[str, list[str]]] = None
-
-
-def _get_family_to_targets() -> dict[str, list[str]]:
-    """Return the family -> gfx targets mapping, parsed once from CMake."""
-    global _family_to_targets_cache
-    if _family_to_targets_cache is None:
-        cmake_path = (
-            Path(__file__).parent.parent / "cmake" / "therock_amdgpu_targets.cmake"
-        )
-        infos = parse_amdgpu_targets_cmake(cmake_path)
-        _family_to_targets_cache = build_family_to_targets(infos)
-    return _family_to_targets_cache
-
 
 def log(msg: str):
     """Print message and flush."""
@@ -163,11 +147,12 @@ def parse_target_families(args: argparse.Namespace) -> List[str]:
             input_families = args.amdgpu_families.split(";")
             output_families.extend(input_families)
             if args.expand_family_to_targets:
-                family_map = _get_family_to_targets()
-                for input_family in input_families:
-                    for target in family_map.get(input_family, []):
-                        if target not in output_families:
-                            output_families.append(target)
+                family_map = amdgpu_family_map()
+                for target in expand_families(
+                    input_families, family_map, strict=False
+                ):
+                    if target not in output_families:
+                        output_families.append(target)
         if args.amdgpu_targets:
             output_families.extend(
                 t.strip() for t in args.amdgpu_targets.split(",") if t.strip()

--- a/build_tools/github_actions/expand_amdgpu_families.py
+++ b/build_tools/github_actions/expand_amdgpu_families.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Expand a list of AMD GPU families to their constituent gfx targets.
+
+Reads `cmake/therock_amdgpu_targets.cmake` (the authoritative source of
+truth) via `_therock_utils.cmake_amdgpu_targets` and prints the union
+of gfx targets for the requested families as a comma-separated string.
+
+Used by CI workflows that need build-side gfx targets (e.g.
+`--pytorch-rocm-arch`) from a family list. Mirrors the pattern used by
+`artifact_manager.py --expand-family-to-targets`.
+
+Example usage:
+
+    python expand_amdgpu_families.py --amdgpu-families "gfx94X-dcgpu;gfx120X-all"
+    -> gfx942,gfx1200,gfx1201
+
+Fails with a non-zero exit code and a clear message if any requested
+family is not present in the CMake source — silent drops were the bug
+this helper exists to prevent.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_BUILD_TOOLS_DIR))
+from _therock_utils.cmake_amdgpu_targets import (
+    amdgpu_family_map,
+    expand_families,
+)
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(prog="expand_amdgpu_families.py")
+    p.add_argument(
+        "--amdgpu-families",
+        required=True,
+        type=str,
+        help=(
+            "Semicolon-separated list of AMD GPU families to expand "
+            "(e.g. 'gfx94X-dcgpu;gfx120X-all')."
+        ),
+    )
+    args = p.parse_args(argv)
+
+    families = [f.strip() for f in args.amdgpu_families.split(";") if f.strip()]
+    if not families:
+        print("")
+        return 0
+
+    print(",".join(expand_families(families, amdgpu_family_map())))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/build_tools/github_actions/tests/expand_amdgpu_families_test.py
+++ b/build_tools/github_actions/tests/expand_amdgpu_families_test.py
@@ -26,9 +26,7 @@ _SAMPLE_MAP: dict[str, list[str]] = {
 
 class ExpandFamiliesTest(unittest.TestCase):
     def test_single_family_expands(self):
-        self.assertEqual(
-            expand_families(["gfx94X-dcgpu"], _SAMPLE_MAP), ["gfx942"]
-        )
+        self.assertEqual(expand_families(["gfx94X-dcgpu"], _SAMPLE_MAP), ["gfx942"])
 
     def test_multiple_families_preserve_order(self):
         self.assertEqual(

--- a/build_tools/github_actions/tests/expand_amdgpu_families_test.py
+++ b/build_tools/github_actions/tests/expand_amdgpu_families_test.py
@@ -1,0 +1,90 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent))
+import expand_amdgpu_families
+from _therock_utils.cmake_amdgpu_targets import expand_families
+
+
+_SAMPLE_MAP: dict[str, list[str]] = {
+    "gfx942": ["gfx942"],
+    "gfx1100": ["gfx1100"],
+    "gfx1101": ["gfx1101"],
+    "gfx94X-dcgpu": ["gfx942"],
+    "gfx110X-all": ["gfx1100", "gfx1101"],
+    "dcgpu-all": ["gfx942"],
+}
+
+
+class ExpandFamiliesTest(unittest.TestCase):
+    def test_single_family_expands(self):
+        self.assertEqual(
+            expand_families(["gfx94X-dcgpu"], _SAMPLE_MAP), ["gfx942"]
+        )
+
+    def test_multiple_families_preserve_order(self):
+        self.assertEqual(
+            expand_families(["gfx110X-all", "gfx94X-dcgpu"], _SAMPLE_MAP),
+            ["gfx1100", "gfx1101", "gfx942"],
+        )
+
+    def test_overlap_deduplicates_keeping_first_occurrence(self):
+        # Both dcgpu-all and gfx94X-dcgpu expand to gfx942; the second occurrence
+        # is dropped.
+        self.assertEqual(
+            expand_families(["dcgpu-all", "gfx94X-dcgpu"], _SAMPLE_MAP),
+            ["gfx942"],
+        )
+
+    def test_empty_input_returns_empty_list(self):
+        self.assertEqual(expand_families([], _SAMPLE_MAP), [])
+
+    def test_unknown_family_raises_by_default(self):
+        with self.assertRaisesRegex(ValueError, "Unknown AMD GPU families"):
+            expand_families(["gfx94X-dcgpu", "gfxNOPE"], _SAMPLE_MAP)
+
+    def test_unknown_family_silently_skipped_when_not_strict(self):
+        self.assertEqual(
+            expand_families(
+                ["gfx94X-dcgpu", "gfxNOPE", "gfx110X-all"],
+                _SAMPLE_MAP,
+                strict=False,
+            ),
+            ["gfx942", "gfx1100", "gfx1101"],
+        )
+
+
+class ExpandAmdgpuFamiliesMainTest(unittest.TestCase):
+    """End-to-end test of the script's main() against the real CMake file."""
+
+    def _run_and_capture(self, *argv: str) -> str:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = expand_amdgpu_families.main(list(argv))
+        self.assertEqual(rc, 0)
+        return buf.getvalue().strip()
+
+    def test_main_expands_single_known_family(self):
+        # gfx94X-dcgpu should always contain gfx942.
+        out = self._run_and_capture("--amdgpu-families", "gfx94X-dcgpu")
+        self.assertIn("gfx942", out.split(","))
+
+    def test_main_empty_input_prints_empty(self):
+        out = self._run_and_capture("--amdgpu-families", "")
+        self.assertEqual(out, "")
+
+    def test_main_unknown_family_raises(self):
+        with self.assertRaises(ValueError):
+            expand_amdgpu_families.main(["--amdgpu-families", "gfxNOPE"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/github_actions/upload_python_packages.py
+++ b/build_tools/github_actions/upload_python_packages.py
@@ -219,15 +219,17 @@ def run(args: argparse.Namespace):
     if not packages_dir.is_dir():
         raise FileNotFoundError(f"Packages root directory not found: {packages_dir}")
 
-    dist_dir = packages_dir / "dist"
-    if not dist_dir.is_dir():
-        raise FileNotFoundError(f"Packages dist/ subdirectory not found: {dist_dir}")
+    # Convention: build_python_packages.py writes into <packages_dir>/dist/,
+    # but build_prod_wheels.py (pytorch) writes directly into its output dir.
+    # Use the dist/ subdirectory when it exists, otherwise use the input dir.
+    dist_subdir = packages_dir / "dist"
+    dist_dir = dist_subdir if dist_subdir.is_dir() else packages_dir
 
-    log(f"[INFO] Packages directory: {packages_dir}")
-    log(f"[INFO] Dist subdirectory : {dist_dir}")
-    log(f"[INFO] Artifact group    : {args.artifact_group}")
-    log(f"[INFO] Run ID            : {args.run_id}")
-    log(f"[INFO] Platform          : {PLATFORM}")
+    log(f"[INFO] Packages directory  : {packages_dir}")
+    log(f"[INFO] Dist [sub]directory : {dist_dir}")
+    log(f"[INFO] Artifact group      : {args.artifact_group}")
+    log(f"[INFO] Run ID              : {args.run_id}")
+    log(f"[INFO] Platform            : {PLATFORM}")
     if args.dry_run:
         log(f"[INFO] Mode              : DRY RUN")
     elif args.output_dir:

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -1176,7 +1176,7 @@ class ParseTargetFamiliesTest(unittest.TestCase):
     def test_family_with_expansion_multi_target(self):
         fake_map = {"gfx110X-all": ["gfx1100", "gfx1101", "gfx1102", "gfx1103"]}
         with mock.patch.object(
-            self.am, "_get_family_to_targets", return_value=fake_map
+            self.am, "amdgpu_family_map", return_value=fake_map
         ):
             args = self._make_args(
                 amdgpu_families="gfx110X-all", expand_family_to_targets=True
@@ -1192,7 +1192,7 @@ class ParseTargetFamiliesTest(unittest.TestCase):
         # it also matches its own self-family name.
         fake_map = {"gfx942": ["gfx942"], "gfx94X-dcgpu": ["gfx942"]}
         with mock.patch.object(
-            self.am, "_get_family_to_targets", return_value=fake_map
+            self.am, "amdgpu_family_map", return_value=fake_map
         ):
             args = self._make_args(
                 amdgpu_families="gfx94X-dcgpu", expand_family_to_targets=True
@@ -1205,7 +1205,7 @@ class ParseTargetFamiliesTest(unittest.TestCase):
         # stays in the list.
         fake_map = {}
         with mock.patch.object(
-            self.am, "_get_family_to_targets", return_value=fake_map
+            self.am, "amdgpu_family_map", return_value=fake_map
         ):
             args = self._make_args(
                 amdgpu_families="custom-family", expand_family_to_targets=True

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -1175,9 +1175,7 @@ class ParseTargetFamiliesTest(unittest.TestCase):
 
     def test_family_with_expansion_multi_target(self):
         fake_map = {"gfx110X-all": ["gfx1100", "gfx1101", "gfx1102", "gfx1103"]}
-        with mock.patch.object(
-            self.am, "amdgpu_family_map", return_value=fake_map
-        ):
+        with mock.patch.object(self.am, "amdgpu_family_map", return_value=fake_map):
             args = self._make_args(
                 amdgpu_families="gfx110X-all", expand_family_to_targets=True
             )
@@ -1191,9 +1189,7 @@ class ParseTargetFamiliesTest(unittest.TestCase):
         # A single-target family: the target should appear once even though
         # it also matches its own self-family name.
         fake_map = {"gfx942": ["gfx942"], "gfx94X-dcgpu": ["gfx942"]}
-        with mock.patch.object(
-            self.am, "amdgpu_family_map", return_value=fake_map
-        ):
+        with mock.patch.object(self.am, "amdgpu_family_map", return_value=fake_map):
             args = self._make_args(
                 amdgpu_families="gfx94X-dcgpu", expand_family_to_targets=True
             )
@@ -1204,9 +1200,7 @@ class ParseTargetFamiliesTest(unittest.TestCase):
         # A family not in the cmake file should not crash; just the family name
         # stays in the list.
         fake_map = {}
-        with mock.patch.object(
-            self.am, "amdgpu_family_map", return_value=fake_map
-        ):
+        with mock.patch.object(self.am, "amdgpu_family_map", return_value=fake_map):
             args = self._make_args(
                 amdgpu_families="custom-family", expand_family_to_targets=True
             )

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -654,6 +654,11 @@ def do_build(args: argparse.Namespace):
             "Please specify --pytorch-rocm-arch (e.g., gfx942)."
         )
 
+    # PyTorch's CMake consumes PYTORCH_ROCM_ARCH as a CMake-style list, so any
+    # comma-separated input needs to be rewritten with semicolons before
+    # CMake runs — otherwise the whole string is treated as one arch.
+    pytorch_rocm_arch = pytorch_rocm_arch.replace(",", ";")
+
     env = _setup_common_build_env(
         cmake_prefix, rocm_dir, pytorch_rocm_arch, triton_dir, is_windows
     )

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -68,17 +68,22 @@ build_prod_wheels.py \
     --index-url https://rocm.devreleases.amd.com/v2/gfx110X-all/
 ```
 
-3. Build torch, torchaudio and torchvision for a single gfx architecture.
+3. Build torch, torchaudio and torchvision for one or more gfx architectures.
 
-Typical usage to build with default architecture from rocm-sdk targets:
+Target architectures are resolved in priority order from `--pytorch-rocm-arch`
+(comma-separated), the `PYTORCH_ROCM_ARCH` environment variable, and finally
+`rocm-sdk targets` from the installed rocm-sdk-core. Passing the flag or env
+var explicitly is preferred; see TODO on get_rocm_sdk_targets.
 
 ```
 # On Linux, using default paths for each repository:
 python build_prod_wheels.py build \
+    --pytorch-rocm-arch gfx942 \
     --output-dir $HOME/tmp/pyout
 
 # On Windows, using shorter custom paths:
 python build_prod_wheels.py build ^
+    --pytorch-rocm-arch gfx1201 ^
     --output-dir %HOME%/tmp/pyout ^
     --pytorch-dir C:/b/pytorch ^
     --pytorch-audio-dir C:/b/audio ^
@@ -227,6 +232,15 @@ def get_rocm_sdk_version() -> str:
     ).strip()
 
 
+# TODO(#4687): Remove this fallback once every caller passes --pytorch-rocm-arch
+# (or PYTORCH_ROCM_ARCH) explicitly. Reading dist_amdgpu_targets from the
+# installed rocm-sdk-core misreports targets in two known cases:
+#   1. Multi-arch kpack-split builds share one superset rocm-sdk-core, so every
+#      per-family job would compile torch for every arch in the superset.
+#   2. Prebuilt-reuse flows where the installed rocm-sdk-core's targets do not
+#      match the build intent (e.g. issue #4687).
+# This fallback is kept for legacy CI and release workflows that have not yet
+# been updated to plumb --pytorch-rocm-arch through from the caller.
 def get_rocm_sdk_targets() -> str:
     # Run `rocm-sdk targets` to get the default architecture
     targets = capture([sys.executable, "-m", "rocm_sdk", "targets"], cwd=Path.cwd())
@@ -622,18 +636,21 @@ def do_build(args: argparse.Namespace):
     system_path = str(bin_dir) + os.path.pathsep + os.environ.get("PATH", "")
     print(f"  PATH = {system_path}")
 
-    pytorch_rocm_arch = args.pytorch_rocm_arch
-    if pytorch_rocm_arch is None:
+    # Priority: --pytorch-rocm-arch > PYTORCH_ROCM_ARCH env > `rocm-sdk targets`
+    # fallback (legacy; see TODO on get_rocm_sdk_targets()).
+    pytorch_rocm_arch = args.pytorch_rocm_arch or os.environ.get("PYTORCH_ROCM_ARCH")
+    if pytorch_rocm_arch:
+        print(f"  Using provided PYTORCH_ROCM_ARCH: {pytorch_rocm_arch}")
+    else:
         pytorch_rocm_arch = get_rocm_sdk_targets()
         print(
             f"  Using default PYTORCH_ROCM_ARCH from rocm-sdk targets: {pytorch_rocm_arch}"
         )
-    else:
-        print(f"  Using provided PYTORCH_ROCM_ARCH: {pytorch_rocm_arch}")
 
     if not pytorch_rocm_arch:
         raise ValueError(
-            "No --pytorch-rocm-arch provided and rocm-sdk targets returned empty. "
+            "No --pytorch-rocm-arch provided, PYTORCH_ROCM_ARCH not set, and "
+            "rocm-sdk targets returned empty. "
             "Please specify --pytorch-rocm-arch (e.g., gfx942)."
         )
 
@@ -1340,7 +1357,10 @@ def main(argv: list[str]):
     )
     build_p.add_argument(
         "--pytorch-rocm-arch",
-        help="gfx arch to build pytorch with (defaults to rocm-sdk targets)",
+        help="Comma-separated gfx arches to build pytorch for (e.g. 'gfx942' or "
+        "'gfx942,gfx1201'). May also be supplied via the PYTORCH_ROCM_ARCH "
+        "environment variable. Falls back to `rocm-sdk targets` when unset "
+        "(legacy; see TODO on get_rocm_sdk_targets).",
     )
     build_p.add_argument(
         "--pytorch-build-number", default="1", help="Build number to append to version"


### PR DESCRIPTION
## Motivation

Multi-arch PyTorch CI has been running N per-family builds that produced N identical fat wheels. Every job saw the same superset rocm-sdk-core and build_prod_wheels.py silently fell back to rocm-sdk targets for PYTORCH_ROCM_ARCH. That fallback is also the root cause of #4687 - it misreports targets whenever the installed rocm-sdk diverges from build intent. The per-family matrix was never actually per-family.

This PR replaces the matrix with a single fat build followed by rocm-kpack wheel splitting, plumbs the target list explicitly end-to-end, and uploads the resulting host + per-arch device wheels alongside the ROCm wheels the build_python_packages job already writes, so one --find-links URL installs the whole SDK + PyTorch stack.


## Technical Details

This still makes use of GPU families which are converted into GPU targets. While this helper was previously limited to artifact_manager.py, this is now accessible via a helper script while the code is reused. We want to switch over from families to targets in the long run but the passed targets variables is currently restrict to _test_ targets and misses targets for which no test runner is available.

Intentionally out of scope:
* upstreaming the kpack objcopy/readelf fallback
* making --pytorch-rocm-arch strictly required after the legacy single-arch and release workflows plumb it through