### PR TITLE
Add `rocprof-sys-attach` CLI entrypoint to `rocm-profiler` wheel

### DIFF
--- a/build_tools/packaging/python/templates/rocm-profiler/setup.py
+++ b/build_tools/packaging/python/templates/rocm-profiler/setup.py
@@ -68,6 +68,7 @@ setup(
         "console_scripts": (
             [
                 "rocprof-compute=rocm_profiler._cli:rocprof_compute",
+                "rocprof-sys-attach=rocm_profiler._cli:rocprof_sys_attach",
                 "rocprof-sys-avail=rocm_profiler._cli:rocprof_sys_avail",
                 "rocprof-sys-causal=rocm_profiler._cli:rocprof_sys_causal",
                 "rocprof-sys-instrument=rocm_profiler._cli:rocprof_sys_instrument",

--- a/build_tools/packaging/python/templates/rocm-profiler/src/rocm_profiler/_cli.py
+++ b/build_tools/packaging/python/templates/rocm-profiler/src/rocm_profiler/_cli.py
@@ -104,3 +104,7 @@ def rocprof_sys_sample() -> None:
 
 def rocprof_sys_python() -> None:
     _exec("bin/rocprof-sys-python")
+
+
+def rocprof_sys_attach() -> None:
+    _exec("bin/rocprof-sys-attach")


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/3573
## Motivation

This PR exposes the `rocprof-sys-attach` CLI in the `rocm-profiler` Python wheel by adding the missing console entry point and trampoline wrapper.

Based on discussion in here: https://github.com/ROCm/TheRock/pull/4518,
https://github.com/ROCm/TheRock/pull/4518#issuecomment-4290747420 

## Test Plan and Result

```python
python build_tools/build_python_packages.py \
  --artifact-dir ~/therock-multiarch-root \
  --dest-dir /tmp/therock-profiler-test \
  --build-packages

python -m pip install --force-reinstall \
  /tmp/therock-profiler-test/dist/rocm_sdk_core-*.whl

python -m pip install --force-reinstall \
  /tmp/therock-profiler-test/dist/rocm_profiler-*.whl
```
```bash
rocprof-sys-attach --help
Usage: /home/nod/ergurses/TheRock/.venv-build-therock/lib/python3.12/site-packages/_rocm_profiler/bin/rocprof-sys-attach -p <pid> [OPTIONS]

Attach to a running process for profiling.

Options:
  -p <pid>             Process ID to attach to (required)
  -o, --output PATH    Output path for profiling results
  -F, --format FORMAT[,FORMAT,...]
                       Output format(s): perfetto, rocpd
  -h, --help           Show this help message

Environment variables:
  ROCPROFSYS_OUTPUT_PATH       Output directory for profiling data
  ROCPROFSYS_TRACE             Enable perfetto trace output
  ROCPROFSYS_USE_ROCPD         Enable rocpd database output
  ROCPROF_ATTACH_TOOL_LIBRARY  Path to the tool library

Once attached, press ENTER to detach from the process.
```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
