### PR TITLE
Add repository and ref to release publish jobs

### DIFF
--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -20,7 +20,6 @@ on:
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
-        default: ""
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -91,6 +91,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
 
       - name: Setting up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -89,6 +89,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
 
       - name: Setting up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -20,7 +20,6 @@ on:
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
-        default: ""
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/3334.

This should fix publish errors for workflow runs in https://github.com/ROCm/rockrel: https://github.com/ROCm/rockrel/actions/runs/24859053365/job/72810680720
```
Run actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
Syncing repository: ROCm/rockrel
...
Run pip install -r requirements.txt
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'
Error: Process completed with exit code 1.
```

## Test Plan

Untested, the next dev or nightly release in rockrel will test this.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
