### PR TITLE
[hipBLAS][rocBLAS][hipblaslt] correct subprocess coding to capture stderr in logs

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hipblas.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblas.py
@@ -57,4 +57,4 @@ else:
 
 
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
-subprocess.check_call(cmd, cwd=THEROCK_DIR, env=environ_vars)
+subprocess.check_call(cmd, cwd=THEROCK_DIR, env=environ_vars, stderr=subprocess.STDOUT)

--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
@@ -49,4 +49,4 @@ elif test_type == "quick":
 cmd = [f"{THEROCK_BIN_DIR}/hipblaslt-test"] + test_filter
 
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
-subprocess.run(cmd, cwd=THEROCK_DIR, check=True, env=environ_vars)
+subprocess.run(cmd, cwd=THEROCK_DIR, check=True, env=environ_vars, stderr=subprocess.STDOUT)

--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
@@ -49,4 +49,6 @@ elif test_type == "quick":
 cmd = [f"{THEROCK_BIN_DIR}/hipblaslt-test"] + test_filter
 
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
-subprocess.run(cmd, cwd=THEROCK_DIR, check=True, env=environ_vars, stderr=subprocess.STDOUT)
+subprocess.run(
+    cmd, cwd=THEROCK_DIR, check=True, env=environ_vars, stderr=subprocess.STDOUT
+)

--- a/build_tools/github_actions/test_executable_scripts/test_hipblasltprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblasltprovider.py
@@ -39,4 +39,5 @@ subprocess.run(
     cwd=THEROCK_DIR,
     check=True,
     env=environ_vars,
+    stderr=subprocess.STDOUT,
 )

--- a/build_tools/github_actions/test_executable_scripts/test_rocblas.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocblas.py
@@ -45,4 +45,6 @@ subprocess.run(
     cmd,
     cwd=THEROCK_DIR,
     check=True,
+    env=environ_vars,
+    stderr=subprocess.STDOUT,
 )


### PR DESCRIPTION
This pull request updates the test scripts for several HIP/ROCm-related executable tests to improve error logging. The main change is to redirect standard error output (`stderr`) to standard output (`STDOUT`) in all subprocess calls, making debugging easier by ensuring all output is captured together.

**Improvements to subprocess error logging:**

* Updated `subprocess.check_call` and `subprocess.run` calls in `test_hipblas.py`, `test_hipblaslt.py`, `test_hipblasltprovider.py`, and `test_rocblas.py` to include `stderr=subprocess.STDOUT`, so that error messages are included in the standard output logs. 

Could be a major flaw in entire theRock infrastructure but only fixing subset in this PR which would need to be replicated across the board if exists everywhere.

[issue-6620] 
ROCM-23617