### PR TITLE
Revert "Revert "Use amd-llvm as the default toolchain for all RDC builds""

### DIFF
--- a/dctools/CMakeLists.txt
+++ b/dctools/CMakeLists.txt
@@ -18,6 +18,8 @@ if(THEROCK_ENABLE_RDC)
   therock_cmake_subproject_declare(rdc
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rdc"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rdc"
+    COMPILER_TOOLCHAIN
+      amd-llvm
     BACKGROUND_BUILD
     USE_DIST_AMDGPU_TARGETS
 


### PR DESCRIPTION
Reverts ROCm/TheRock#4648

Using amd-llvm to build RDC, after https://github.com/ROCm/rocm-systems/pull/5237 got merged, addressing the test failures seen earlier.