### PR TITLE
[CI] Skip failing test_nn UTs with release/2.11 on gfx950

### DIFF
--- a/external-builds/pytorch/skip_tests/pytorch_2.11.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.11.py
@@ -79,6 +79,18 @@ skip_tests = {
             "test_Embedding_discontiguous_cuda",
         ],
     },
+    "gfx950": {
+        "nn": [
+            # AssertionError: Scalars are not close! - Failed with python 3.10
+            "test_CTCLoss_no_batch_dim_reduction_mean_use_module_form_True_cuda",
+            # AssertionError: Tensor-likes are not close! - Failed with python 3.10
+            "test_CTCLoss_no_batch_dim_reduction_none_use_module_form_False_cuda",
+            # AssertionError: Tensor-likes are not close! - Failed with python 3.10
+            "test_CTCLoss_no_batch_dim_reduction_none_use_module_form_True_cuda",
+            # AssertionError: Tensor-likes are not close! - Failed with python 3.10, python 3.11 and python 3.12
+            "test_ctc_loss_cudnn_tensor_cuda_cuda",
+        ],
+    },
     # "gfx120": {
     #     "unary_ufuncs": [
     #         # this failed only once. maybe python version dependent? probably the run was python 3.13


### PR DESCRIPTION
Skip 4 UTs that are failing with PyTorch version 2.11 on gfx950 based on the below mentioned runs

```
FAILED [0.0034s] external-builds/pytorch/pytorch/test/test_nn.py::TestNNDeviceTypeCUDA::test_CTCLoss_no_batch_dim_reduction_mean_use_module_form_True_cuda - AssertionError: Scalars are not close!
FAILED [0.0027s] external-builds/pytorch/pytorch/test/test_nn.py::TestNNDeviceTypeCUDA::test_CTCLoss_no_batch_dim_reduction_none_use_module_form_False_cuda - AssertionError: Tensor-likes are not close!
FAILED [0.0023s] external-builds/pytorch/pytorch/test/test_nn.py::TestNNDeviceTypeCUDA::test_CTCLoss_no_batch_dim_reduction_none_use_module_form_True_cuda - AssertionError: Tensor-likes are not close!
FAILED [0.0049s] external-builds/pytorch/pytorch/test/test_nn.py::TestNNDeviceTypeCUDA::test_ctc_loss_cudnn_tensor_cuda_cuda - AssertionError: Tensor-likes are not close!

```



[Release | gfx950-dcgpu | py 3.10 | torch release/2.11 / Test | gfx950-dcgpu | linux-mi355-1gpu-ossci-rocm / Test PyTorch | gfx950-dcgpu](https://github.com/ROCm/TheRock/actions/runs/24874715080/job/72837703762#logs)
```
FAILED [0.0034s] external-builds/pytorch/pytorch/test/test_nn.py::TestNNDeviceTypeCUDA::test_CTCLoss_no_batch_dim_reduction_mean_use_module_form_True_cuda - AssertionError: Scalars are not close!
FAILED [0.0027s] external-builds/pytorch/pytorch/test/test_nn.py::TestNNDeviceTypeCUDA::test_CTCLoss_no_batch_dim_reduction_none_use_module_form_False_cuda - AssertionError: Tensor-likes are not close!
FAILED [0.0023s] external-builds/pytorch/pytorch/test/test_nn.py::TestNNDeviceTypeCUDA::test_CTCLoss_no_batch_dim_reduction_none_use_module_form_True_cuda - AssertionError: Tensor-likes are not close!
FAILED [0.0049s] external-builds/pytorch/pytorch/test/test_nn.py::TestNNDeviceTypeCUDA::test_ctc_loss_cudnn_tensor_cuda_cuda - AssertionError: Tensor-likes are not close!
= 4 failed, 39611 passed, 1973 skipped, 151 deselected, 48 xfailed in 1118.53s (0:18:38) =
```

[Release | gfx950-dcgpu | py 3.11 | torch release/2.11 / Test | gfx950-dcgpu | linux-mi355-1gpu-ossci-rocm / Test PyTorch | gfx950-dcgpu](https://github.com/ROCm/TheRock/actions/runs/24874715080/job/72838565272#logs)
```
FAILED [0.0045s] external-builds/pytorch/pytorch/test/test_nn.py::TestNNDeviceTypeCUDA::test_ctc_loss_cudnn_tensor_cuda_cuda - AssertionError: Tensor-likes are not close!
= 1 failed, 39614 passed, 1973 skipped, 151 deselected, 48 xfailed in 1140.05s (0:19:00) =

```

[Release | gfx950-dcgpu | py 3.12 | torch release/2.11 / Test | gfx950-dcgpu | linux-mi355-1gpu-ossci-rocm / Test PyTorch | gfx950-dcgpu](https://github.com/ROCm/TheRock/actions/runs/24874715080/job/72839088019#logs)
```
FAILED [0.0052s] external-builds/pytorch/pytorch/test/test_nn.py::TestNNDeviceTypeCUDA::test_ctc_loss_cudnn_tensor_cuda_cuda - AssertionError: Tensor-likes are not close!
= 1 failed, 39611 passed, 1976 skipped, 151 deselected, 48 xfailed in 1073.89s (0:17:53) =
```