### PR TITLE
packaging: Fix file conflicts in kpack mode

### DIFF
--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -680,6 +680,16 @@ def filter_components_fromartifactory(
         if "Artifact_Gfxarch" in artifact:
             print(f"{pkg_name} : Artifact_Gfxarch key exists for artifacts {artifact}")
             is_gfxarch = str(artifact["Artifact_Gfxarch"]).lower() == "true"
+
+            # In kpack mode, skip non-gfxarch artifacts when building gfx-specific packages
+            # This prevents generic artifacts from being included in both base and arch-specific packages
+            if enable_kpack and gfx_arch != GFX_GENERIC and not is_gfxarch:
+                print(
+                    f"{pkg_name} : Skipping artifact '{artifact_prefix}' for {gfx_arch} package "
+                    f"(Artifact_Gfxarch=False, should only be in generic package)"
+                )
+                continue
+
             artifact_suffix = gfx_arch if is_gfxarch else "generic"
         else:
             artifact_suffix = dir_suffix


### PR DESCRIPTION
When building with --enable-kpack, artifacts marked with
  "Artifact_Gfxarch": "False" were incorrectly included in both
  generic and gfx-specific packages, causing installation conflicts.

  Example: amdrocm-dnn's hipdnn artifact (Artifact_Gfxarch=False)
  was packaged in both amdrocm-dnn7.13 and amdrocm-dnn7.13-gfx110x,
  resulting in dpkg error for libhipdnn_backend.so.

  Fix: Skip non-gfxarch artifacts when building gfx-specific packages
  in kpack mode. These artifacts should only be in the generic package.

  No impact on builds without --enable-kpack.