### PR TITLE
CI: skip hipBLASLt tests on Windows gfx110X-all

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -143,7 +143,7 @@ test_matrix = {
             "linux": 6,
             "windows": 1,
         },
-        # Short-term: Windows gfx110X hipBLASLt CI is flaky; re-enable when stable.
+        # Short-term: Windows gfx110X hipBLASLt CI is flaky (tracked in ROCM-23611); re-enable when stable.
         "exclude_family": {
             "windows": ["gfx110X-all"],
         },

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -143,6 +143,10 @@ test_matrix = {
             "linux": 6,
             "windows": 1,
         },
+        # Short-term: Windows gfx110X hipBLASLt CI is flaky; re-enable when stable.
+        "exclude_family": {
+            "windows": ["gfx110X-all"],
+        },
     },
     # SOLVER tests
     "hipsolver": {


### PR DESCRIPTION
## Summary

Temporarily exclude the **hipblaslt** component test job on **Windows** when the artifact family is **gfx110X-all** (gfx1100/gfx1101 split artifacts), using the existing `exclude_family` mechanism in `fetch_test_configurations.py`.

## Motivation

Windows gfx110X hipBLASLt CI has been failing; this unblocks Multi-Arch CI while issues are investigated.

## Scope

- **Changed:** hipblaslt test matrix entry only; Windows gfx110X builds and other component tests are unchanged.
- **Not changed:** Linux hipBLASLt, or hipblaslt on other Windows families.

## Follow-up

Remove the `exclude_family` block once Windows gfx110X hipBLASLt is stable. If failures are in **build** rather than tests, a different matrix or runner change may be needed.

ROCM-23611
Made with [Cursor](https://cursor.com)