### PR TITLE
Pin commit SHA in setup so all release jobs use the same commit

### DIFF
--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -100,7 +100,7 @@ jobs:
       test_type: ${{ needs.setup.outputs.test_type }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository || github.repository }}
-      ref: ${{ inputs.ref }}
+      ref: ${{ needs.setup.outputs.ref }}
     permissions:
       contents: read
       actions: write  # Added permission to trigger workflows
@@ -118,7 +118,7 @@ jobs:
       test_type: ${{ needs.setup.outputs.test_type }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository || github.repository }}
-      ref: ${{ inputs.ref }}
+      ref: ${{ needs.setup.outputs.ref }}
     permissions:
       contents: read
       actions: write  # Added permission to trigger workflows

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -23,7 +23,6 @@ on:
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
-        default: ""
 
 permissions:
   contents: read

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -23,7 +23,6 @@ on:
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
-        default: ""
 
 permissions:
   contents: read

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -74,6 +74,12 @@ on:
       rocm_package_version:
         description: ROCm package version (primarily for Python packages).
         value: ${{ jobs.setup.outputs.rocm_package_version }}
+      ref:
+        description: >-
+          Resolved commit SHA from checkout. Use this instead of the input ref
+          to ensure all downstream jobs use the same commit, even if the branch
+          HEAD moves during the workflow run.
+        value: ${{ jobs.setup.outputs.ref }}
 
 permissions:
   contents: read
@@ -89,8 +95,10 @@ jobs:
       linux_test_labels: ${{ steps.configure.outputs.linux_test_labels }}
       windows_test_labels: ${{ steps.configure.outputs.windows_test_labels }}
       rocm_package_version: ${{ steps.rocm_package_version.outputs.rocm_package_version }}
+      ref: ${{ steps.checkout.outputs.commit }}
     steps:
       - name: Checking out repository
+        id: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository || github.repository }}


### PR DESCRIPTION
## Motivation

As reported at https://github.com/ROCm/rockrel/pull/35#discussion_r3135281106, the new https://github.com/ROCm/rockrel/blob/main/.github/workflows/multi_arch_release.yml workflow (in rockrel, not TheRock) uses a floating ref when triggered by `workflow_dispatch` or `schedule` events. This has the expected behavior for the first job triggered, but sub-jobs _also_ use a floating ref, and if they run hours later this is likely to be a different commit (across artifact build stages, across packaging jobs, etc.).

Progress on:
* https://github.com/ROCm/TheRock/issues/1236
* https://github.com/ROCm/TheRock/issues/3334

## Technical Details

For https://github.com/ROCm/TheRock/issues/1236, we can extend the setup job to also choose commits for PyTorch release branches, JAX release branches, etc.

## Test Plan

Test run in my fork: https://github.com/ScottTodd/TheRock/actions/runs/24906712749
1. Setup:
    ```
    Run actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
      with:
        repository: ScottTodd/TheRock
    ```
2. Build job:
    ```
    Run actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
      with:
        repository: ScottTodd/TheRock
        ref: 260481ba880ed2dd8135410e5c8b31365a6475ee
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
