### PR TITLE
users/torrezuk/rocm 23617 test revert

### DIFF
--- a/FLAGS.cmake
+++ b/FLAGS.cmake
@@ -17,7 +17,7 @@ include(therock_flag_utils)
 
 therock_declare_flag(
   NAME KPACK_SPLIT_ARTIFACTS
-  DEFAULT_VALUE ON
+  DEFAULT_VALUE OFF
   DESCRIPTION "Split target-specific artifacts into generic and arch-specific components"
 )
 

--- a/build_tools/github_actions/build_configure.py
+++ b/build_tools/github_actions/build_configure.py
@@ -108,13 +108,6 @@ def build_configure(build_dir, manylinux=False):
             f"-DCMAKE_C_COMPILER_LAUNCHER={c_launcher}",
             f"-DCMAKE_CXX_COMPILER_LAUNCHER={cxx_launcher}",
             "-DBUILD_TESTING=ON",
-            # Opt-out of KPACK_SPLIT_ARTIFACTS for non-multi-arch CI/CD.
-            # * Multi-arch CI/CD uses configure_stage.py instead of this script
-            # * Local developer builds will use the flag default value
-            # Related issues:
-            # * multi-arch kpack parent: https://github.com/ROCm/TheRock/issues/3323
-            # * multi-arch opt-in: https://github.com/ROCm/TheRock/issues/3338
-            "-DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=OFF",
         ]
     )
 


### PR DESCRIPTION
You can review this PR test results with submodule bump, but the pure revert is in the linked new PR https://github.com/ROCm/TheRock/pull/4835 so would be mergable without this submodule bump.  Preferred approach, so don't merge this PR unless that submodule commit is needed today.

This pull request updates the default behavior for splitting KPACK artifacts and removes explicit overrides in the build configuration script. It also updates the `rocm-libraries` submodule to a new commit.

**Build configuration and flag management:**

* Changed the default value of the `KPACK_SPLIT_ARTIFACTS` flag from `ON` to `OFF` in `FLAGS.cmake`, meaning artifact splitting is now opt-in by default.
* Removed the explicit `-DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=OFF` setting from the `build_configure.py` script, as the new default makes this unnecessary.

**Submodule updates:**

* Updated the `rocm-libraries` submodule to a newer commit (`56eee18bfefd703751b5c0371b942c2e00e2dfd6`).