### PR TITLE
Skip generic artifacts when checking for gfx-specific packages

### DIFF
--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -840,6 +840,11 @@ def has_artifact_for_arch(pkg_name, artifacts_dir, gfx_arch):
         else:
             artifact_suffix = gfx_arch
 
+        # When checking for a specific gfx architecture (not generic),
+        # skip generic-only artifacts - they don't contribute to gfx-specific packages
+        if gfx_arch != GFX_GENERIC and artifact_suffix == "generic":
+            continue
+
         for subdir in artifact["Artifact_Subdir"]:
             component_list = subdir["Components"]
             for component in component_list:


### PR DESCRIPTION
When determining if artifacts exist for a specific GFX architecture,
generic-only artifacts should not be considered as they don't contribute to architecture-specific packages
This ensures metapackages only include dependencies for packages that will actually be built

