### PR TITLE
rccl: skip BUILD_ADDRESS_SANITIZER when GPU_TARGETS has multiple entries

### DIFF
--- a/comm-libs/pre_hook_rccl.cmake
+++ b/comm-libs/pre_hook_rccl.cmake
@@ -12,10 +12,35 @@ if(NOT WIN32)
   cmake_language(DEFER CALL therock_patch_linked_lib OLD_LIBRARY "roctx64" NEW_TARGET "${_therock_legacy_roctx64}")
 endif()
 
-# Enable BUILD_ADDRESS_SANITIZER when THEROCK_SANITIZER is ASAN
-# This enables RCCL's LTO optimization bypass for faster ASAN link times
+# Enable BUILD_ADDRESS_SANITIZER when THEROCK_SANITIZER is ASAN.
+# This enables RCCL's LTO optimization bypass for faster ASAN link times and
+# turns on device-side ASAN instrumentation (xnack+).
+#
+# Caveat: RCCL hard-fails if BUILD_ADDRESS_SANITIZER is set together with
+# more than one entry in GPU_TARGETS, because ASAN-instrumented device code
+# combined with -fgpu-rdc exceeds the clang-offload-bundler v2 size limits.
+# In multi-arch ASAN builds (e.g. the multi_arch_ci_asan workflow), the
+# super-project passes the full family list (gfx906;gfx908;gfx90a;
+# gfx942:xnack+;gfx950:xnack+) which would trip that check and break the
+# whole build at the RCCL configure step. See:
+#   https://github.com/ROCm/TheRock/issues/4770
+#
+# Detect that case and skip BUILD_ADDRESS_SANITIZER for RCCL only. Host-side
+# ASAN flags (-fsanitize=address) are still injected globally by
+# therock_sanitizers.cmake, so the host parts of librccl remain instrumented.
 if(THEROCK_SANITIZER STREQUAL "ASAN")
-  set(BUILD_ADDRESS_SANITIZER ON)
-  message(STATUS "Enabling BUILD_ADDRESS_SANITIZER for RCCL
-(THEROCK_SANITIZER=${THEROCK_SANITIZER})")
+  list(LENGTH GPU_TARGETS _therock_rccl_num_gpu_targets)
+  if(_therock_rccl_num_gpu_targets GREATER 1)
+    message(WARNING
+      "Skipping BUILD_ADDRESS_SANITIZER for RCCL because GPU_TARGETS contains "
+      "${_therock_rccl_num_gpu_targets} entries (${GPU_TARGETS}). "
+      "RCCL's ASAN device-code path only supports a single GPU_TARGET due to "
+      "clang-offload-bundler size limits. Host-side ASAN instrumentation is "
+      "still applied via global compiler flags. To enable full device-side "
+      "ASAN for RCCL, configure the build with a single GPU target.")
+  else()
+    set(BUILD_ADDRESS_SANITIZER ON)
+    message(STATUS "Enabling BUILD_ADDRESS_SANITIZER for RCCL "
+      "(THEROCK_SANITIZER=${THEROCK_SANITIZER}, GPU_TARGETS=${GPU_TARGETS})")
+  endif()
 endif()


### PR DESCRIPTION
The Multi-Arch ASAN CI (multi_arch_ci_asan.yml) passes the full Linux GPU family list (gfx906;gfx908;gfx90a;gfx942:xnack+;gfx950:xnack+) to the super-project. The previous pre_hook_rccl.cmake unconditionally turned on BUILD_ADDRESS_SANITIZER for RCCL whenever THEROCK_SANITIZER was ASAN, which trips RCCL's hard FATAL_ERROR check that requires a single GPU_TARGET when device-side ASAN is enabled (the combination of -fsanitize=address device code and -fgpu-rdc exceeds clang-offload- bundler v2 size limits).

Detect the multi-target case in the hook and leave BUILD_ADDRESS_SANITIZER unset, emitting a WARNING that explains the trade-off. Host-side ASAN instrumentation is still applied to RCCL because therock_sanitizers.cmake injects -fsanitize=address into the global CMAKE_*_FLAGS independently. Single-target ASAN builds preserve the original behavior and still get full device-side ASAN.

Verified:
  * Multi-arch RCCL configure (gfx906;gfx908;gfx90a;gfx942:xnack+; gfx950:xnack+) with host -fsanitize=address now succeeds.
  * Single-arch path (gfx942:xnack+) still sets BUILD_ADDRESS_SANITIZER=ON.

Fixes: https://github.com/ROCm/TheRock/issues/4770

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
