### PR TITLE
Auto-detect kpack and GFX archs in multi-arch native builds

### DIFF
--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -120,18 +120,18 @@ jobs:
             --run-id="${{ env.ARTIFACT_RUN_ID }}" \
             --stage=all \
             --amdgpu-families="${{ env.DIST_AMDGPU_FAMILIES }}" \
+            --expand-family-to-targets \
             --output-dir="${{ env.OUTPUT_DIR }}"
 
       - name: Build Packages
         id: build-packages
         run: |
-          # Pass the target families as-is (semicolon-separated)
-          # build_package.py's normalize_target_list() handles all separators
-          # KPACK_SPLIT_ARTIFACTS is auto-detected from therock_manifest.json
+          # GFX architectures are auto-detected from the artifact directory
+          # (populated by --expand-family-to-targets in the fetch step).
+          # KPACK_SPLIT_ARTIFACTS is auto-detected from therock_manifest.json.
           python ./build_tools/packaging/linux/build_package.py \
             --dest-dir "${{ env.PACKAGE_DIST_DIR }}" \
-            --rocm-version  "${{ inputs.rocm_version }}" \
-            --target "${{ env.DIST_AMDGPU_FAMILIES }}" \
+            --rocm-version "${{ inputs.rocm_version }}" \
             --artifacts-dir "${{ env.ARTIFACTS_DIR }}" \
             --pkg-type "${{ inputs.native_package_type }}" \
             --version-suffix "${{ env.ARTIFACT_RUN_ID }}"

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -27,6 +27,7 @@ create RPM and DEB packages and upload to artifactory server
 
 import argparse
 import glob
+import json
 import os
 import shutil
 import subprocess
@@ -56,6 +57,21 @@ from _therock_utils.artifacts import ArtifactCatalog
 
 # Default install prefix
 DEFAULT_INSTALL_PREFIX = "/opt/rocm/core"
+
+
+def _load_kpack_from_manifest(artifacts_dir: Path) -> bool:
+    """Detect kpack mode by scanning therock_manifest.json files in artifact directory.
+
+    Returns True if any manifest has KPACK_SPLIT_ARTIFACTS set to True.
+    """
+    for manifest_path in artifacts_dir.rglob("therock_manifest.json"):
+        try:
+            manifest = json.loads(manifest_path.read_text())
+            if manifest.get("flags", {}).get("KPACK_SPLIT_ARTIFACTS", False):
+                return True
+        except (json.JSONDecodeError, OSError):
+            pass
+    return False
 
 
 def get_all_target_families(artifact_dir):
@@ -862,6 +878,15 @@ def create_package_config(args: argparse.Namespace) -> PackageConfig:
         with open(github_output, "a", encoding="utf-8") as f:
             targets_str = ",".join(normalized_targets)
             f.write(f"PACKAGING_ARCH_LIST={targets_str}\n")
+
+    # Auto-detect kpack from manifest if not explicitly requested via --enable-kpack
+    artifacts_dir = Path(args.artifacts_dir).resolve()
+    if not args.enable_kpack:
+        args.enable_kpack = _load_kpack_from_manifest(artifacts_dir)
+        if args.enable_kpack:
+            print(
+                "Detected KPACK_SPLIT_ARTIFACTS in manifest — producing host + device packages"
+            )
 
     # Configure architecture based on multi-arch mode
     if args.enable_kpack:


### PR DESCRIPTION
- Add _load_kpack_from_manifest() to build_package.py to auto-detect KPACK_SPLIT_ARTIFACTS from therock_manifest.json, eliminating the need to pass --enable-kpack explicitly in the workflow
- Add --expand-family-to-targets to artifact_manager.py fetch step so individual GFX targets are reflected in the artifact directory structure
- Remove --target from build_package.py invocation so GFX architectures are auto-detected from the artifact directory via get_all_target_families()

