### PR TITLE
Install generic amdrocm packages instead of gfx-specific

### DIFF
--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -835,11 +835,8 @@ gpgcheck=0
 
         print(f"\n[PASS] rdhc.py found at: {rdhc_script}")
 
-        # Check if script is executable or can be run with python
-        if os.access(rdhc_script, os.X_OK):
-            cmd = [str(rdhc_script)]
-        else:
-            cmd = [sys.executable, str(rdhc_script)]
+        # Always run rdhc with this process's interpreter.
+        cmd = [sys.executable, str(rdhc_script)]
 
         # Set RDHC arguments for full test
         test_args = ["--rocm-install-prefix", rocm_install_prefix_arg, "--all"]

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -285,8 +285,8 @@ class NativeLinuxPackageInstallTest:
 
         # Packages to install, in order
         self.package_names = [
-            f"amdrocm",
-            f"amdrocm-core-sdk",
+            "amdrocm",
+            "amdrocm-core-sdk",
         ]
 
     def setup_gpg_key(self) -> bool:

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -285,8 +285,8 @@ class NativeLinuxPackageInstallTest:
 
         # Packages to install, in order
         self.package_names = [
-            f"amdrocm-{self.gfx_arch}",
-            f"amdrocm-core-sdk-{self.gfx_arch}",
+            f"amdrocm",
+            f"amdrocm-core-sdk",
         ]
 
     def setup_gpg_key(self) -> bool:
@@ -835,8 +835,11 @@ gpgcheck=0
 
         print(f"\n[PASS] rdhc.py found at: {rdhc_script}")
 
-        # Always run rdhc with this process's interpreter.
-        cmd = [sys.executable, str(rdhc_script)]
+        # Check if script is executable or can be run with python
+        if os.access(rdhc_script, os.X_OK):
+            cmd = [str(rdhc_script)]
+        else:
+            cmd = [sys.executable, str(rdhc_script)]
 
         # Set RDHC arguments for full test
         test_args = ["--rocm-install-prefix", rocm_install_prefix_arg, "--all"]


### PR DESCRIPTION
- Change package names from amdrocm-{gfx_arch}/amdrocm-core-sdk-{gfx_arch} to generic amdrocm/amdrocm-core-sdk for multi-arch kpack builds
- Check if rdhc.py is executable before deciding how to invoke it


