### PR TITLE
[Defect] Revert "Flip `KPACK_SPLIT_ARTIFACTS` to `ON` (#4652)"

### DIFF
--- a/FLAGS.cmake
+++ b/FLAGS.cmake
@@ -17,7 +17,7 @@ include(therock_flag_utils)
 
 therock_declare_flag(
   NAME KPACK_SPLIT_ARTIFACTS
-  DEFAULT_VALUE ON
+  DEFAULT_VALUE OFF
   DESCRIPTION "Split target-specific artifacts into generic and arch-specific components"
 )
 

--- a/build_tools/github_actions/build_configure.py
+++ b/build_tools/github_actions/build_configure.py
@@ -108,13 +108,6 @@ def build_configure(build_dir, manylinux=False):
             f"-DCMAKE_C_COMPILER_LAUNCHER={c_launcher}",
             f"-DCMAKE_CXX_COMPILER_LAUNCHER={cxx_launcher}",
             "-DBUILD_TESTING=ON",
-            # Opt-out of KPACK_SPLIT_ARTIFACTS for non-multi-arch CI/CD.
-            # * Multi-arch CI/CD uses configure_stage.py instead of this script
-            # * Local developer builds will use the flag default value
-            # Related issues:
-            # * multi-arch kpack parent: https://github.com/ROCm/TheRock/issues/3323
-            # * multi-arch opt-in: https://github.com/ROCm/TheRock/issues/3338
-            "-DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=OFF",
         ]
     )
 


### PR DESCRIPTION
This pull request updates the default behavior of the `KPACK_SPLIT_ARTIFACTS` flag and removes an explicit override from the CI/CD build configuration script. The main effect is that builds will now use the new default value for this flag unless explicitly set elsewhere.  The original merge clearly showed a large number of new failing tests on windows gfx110X related to GEMM kernel using code objects for solutions

Flag configuration changes:

* Changed the default value of the `KPACK_SPLIT_ARTIFACTS` flag from `ON` to `OFF` in `FLAGS.cmake`, meaning target-specific artifacts will not be split by default.

Build script adjustments:

* Removed the explicit setting of `-DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=OFF` from the `build_configure.py` script, allowing builds to use the flag's default value instead.

ROCM-23699