### PR TITLE
[ml-libs] Remove all-or-nothing CK disable logic; let MIOpen self-filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,10 +268,6 @@ include("${CMAKE_CURRENT_BINARY_DIR}/cmake/therock_topology.cmake")
 # which filters out CORE_RUNTIME dependency for HIP_RUNTIME on Windows.
 
 # Optional sub-features that control behavior within artifacts
-cmake_dependent_option(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL
-  "Enables composable kernel in MIOpen" ON
-  "THEROCK_ENABLE_COMPOSABLE_KERNEL" OFF)
-
 cmake_dependent_option(THEROCK_ROCWMMA_ENABLE_BENCHMARKS
   "Enables building rocWMMA benchmarks" OFF
   "THEROCK_ENABLE_ROCWMMA;THEROCK_BUILD_TESTING" OFF)

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -8,20 +8,6 @@ if(THEROCK_FLAG_INCLUDE_PROFILER)
   list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
 endif()
 
-# limit use of composable kernel to the GPU families it is valid for
-if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
-  set(_ck_supported_gfx_targets gfx908 gfx90a gfx942 gfx950 gfx1150 gfx1151 gfx1152 gfx1153 gfx1200 gfx1201)
-  foreach(_gfx_target ${THEROCK_AMDGPU_TARGETS})
-    if(NOT ${_gfx_target} IN_LIST _ck_supported_gfx_targets)
-      message(WARNING
-        "${_gfx_target} (included in THEROCK_AMDGPU_TARGETS) is not supported by composable kernel. "
-        "Disabling composable kernel and it's use in MIOpen.")
-      set(THEROCK_ENABLE_COMPOSABLE_KERNEL OFF)
-      set(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL OFF)
-    endif()
-  endforeach()
-endif()
-
 if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
   ##############################################################################
   # Composable_kernel
@@ -69,9 +55,11 @@ if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
 endif()
 
 if(THEROCK_ENABLE_MIOPEN)
-  # If composable kernel is enabled, add it as an MIOpen dep.
+  # If composable kernel is enabled, add it as an MIOpen build dep.
+  # MIOpen's ck_impl self-filters GPU_TARGETS against arches it has CK grouped
+  # conv kernels for, so no need to gate on specific arch families here.
   set(optional_miopen_build_deps)
-  if(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL)
+  if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
     list(APPEND optional_miopen_build_deps composable_kernel)
   endif()
 
@@ -90,7 +78,7 @@ if(THEROCK_ENABLE_MIOPEN)
       -DROCM_PATH=
       -DROCM_DIR=
       "-DBUILD_TESTING=${_THEROCK_MIOPEN_ENABLE_TESTING}"
-      "-DMIOPEN_USE_COMPOSABLEKERNEL=${THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL}"
+      "-DMIOPEN_USE_COMPOSABLEKERNEL=${THEROCK_ENABLE_COMPOSABLE_KERNEL}"
       -DMIOPEN_USE_MLIR=OFF # TODO: enable
       -DMIOPEN_TEST_DISCRETE=OFF
       "-DMIOPEN_INSTALL_GPU_DATABASES=\"${THEROCK_AMDGPU_TARGETS}\""


### PR DESCRIPTION
## Summary

Cleans up the TheRock-side CK/MIOpen wiring now that MIOpen self-filters `GPU_TARGETS` per-arch (see ROCm/rocm-libraries#6839).

Previously, if any GPU target in the build lacked CK grouped conv support, TheRock disabled composable kernel entirely for the whole MIOpen build. This silently lost CK kernels on supported arches in mixed multi-arch builds.

**Changes:**
- Remove the all-or-nothing arch validation block that set `THEROCK_ENABLE_COMPOSABLE_KERNEL=OFF` when any target was unsupported
- Remove the now-redundant `THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL` dependent option
- Replace `THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL` refs with `THEROCK_ENABLE_COMPOSABLE_KERNEL` in the MIOpen build dep and cmake args
- Pass `-DMIOPEN_USE_COMPOSABLEKERNEL=THEROCK_ENABLE_COMPOSABLE_KERNEL` so MIOpen matches what we've setup in TheRock for CK
- Bump `rocm-libraries` submodule to ROCm/rocm-libraries#6839 branch tip so CI validates both changes together

## Dependency

> [!IMPORTANT]
> This PR depends on ROCm/rocm-libraries#6839 landing first. The submodule will be bumped to the merged SHA before this is merged.

## Test plan

- [ ] `THEROCK_AMDGPU_FAMILIES=gfx942` — `MIOpenCKGroupedConv_gfx942.so` built as before
- [ ] Mixed build with unsupported arch (e.g. `gfx942;gfx1100`) — `MIOpenCKGroupedConv_gfx942.so` built, `gfx1100` skipped with status message, no build failure
- [ ] `THEROCK_ENABLE_COMPOSABLE_KERNEL=OFF` — `-DMIOPEN_USE_COMPOSABLEKERNEL=OFF` forwarded, no CK libs built

🤖 Generated with [Claude Code](https://claude.com/claude-code)