### PR TITLE
[ci] Fix MIOpen build failure on gfx110X by disabling CK-dependent tests

### DIFF
--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -75,10 +75,18 @@ if(THEROCK_ENABLE_MIOPEN)
     list(APPEND optional_miopen_build_deps composable_kernel)
   endif()
 
-  if(MSVC)
-    set(_THEROCK_MIOPEN_ENABLE_TESTING ON)
+  # MIOpen tests require composable kernel. When CK is disabled (e.g., for
+  # gfx110X which is not in _ck_supported_gfx_targets), we must also disable
+  # MIOpen tests to avoid compilation errors in CK-dependent test code.
+  if(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL)
+    if(MSVC)
+      set(_THEROCK_MIOPEN_ENABLE_TESTING ON)
+    else()
+      set(_THEROCK_MIOPEN_ENABLE_TESTING ${THEROCK_BUILD_TESTING})
+    endif()
   else()
-    set(_THEROCK_MIOPEN_ENABLE_TESTING ${THEROCK_BUILD_TESTING})
+    message(STATUS "Disabling MIOpen tests because composable kernel is disabled")
+    set(_THEROCK_MIOPEN_ENABLE_TESTING OFF)
   endif()
 
   therock_cmake_subproject_declare(MIOpen


### PR DESCRIPTION
## Motivation

miopen tests were failing [here](https://github.com/ROCm/TheRock/actions/runs/24944514058/job/73089055608)
with error: use of undeclared identifier 'ck'

## Technical Details

miopen tests are depend on Composable Kernel (CK) headers, but CK only supports certain GPU architectures. When building for unsupported targets like gfx110X (RDNA3/Navi3), the build system correctly disables CK but MIOpen tests were
  still being compiled, causing compilation errors

## changes
This change disables MIOpen tests when THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL is OFF, preventing the CK-dependent test code from being compiled on unsupported architectures.

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
