### PR TITLE
Add encoding to github event file read

### DIFF
--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -158,7 +158,7 @@ def _is_current_run_pr_from_fork() -> bool:
     if not event_path:
         return False
 
-    with open(event_path) as f:
+    with open(event_path, encoding="utf-8") as f:
         event = json.load(f)
 
     return bool(


### PR DESCRIPTION
## Motivation
There is a minor bug, which will fail the post-upload step on windows builds if github event contains Unicode symbols. This PR fixes that
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
The github event file is currently reading without explicit encoding setting, which leads python to pick up OS default encoding. On Windows, this is cp1251, which will break script if PR title or description contains non-Unicode symbol. This was encountered on https://github.com/ROCm/rocm-systems/pull/4638 PR, see example run: https://github.com/ROCm/rocm-systems/actions/runs/24986998666/job/73162778037. 
The issue was caused by `“` symbol in the original PR description, unable to parse under windows.
This PR sets explicit "utf-8" to `open` call. 
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
1. Should not break any existing builds.
2. Should successfully build PRs with unicode description 
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
1. Waiting for CI to pass
2. This PR's description already contains non-unicode symbols “”, so also will be covered by its own CI.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
