### PR TITLE
Update AWS credential configuration for multi arch native linux artifact upload

### DIFF
--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -93,26 +93,6 @@ jobs:
           apt-get install -y rpm debhelper-compat build-essential
           apt-get install -y dpkg-dev createrepo-c
 
-      - name: Determine IAM role
-        id: iam_role
-        run: |
-          # ================================================================
-          # IAM Role Selection Logic
-          # ================================================================
-          # CI builds (empty RELEASE_TYPE) use therock-ci role for the
-          # artifacts bucket. Release builds (dev/nightly/prerelease) use
-          # the matching therock-{type} role for the packages bucket.
-          # ================================================================
-          RELEASE_TYPE="${{ env.RELEASE_TYPE }}"
-          if [ -z "${RELEASE_TYPE}" ]; then
-            IAM_ROLE="arn:aws:iam::692859939525:role/therock-ci"
-            echo "✓ Using CI role: ${IAM_ROLE}"
-          else
-            IAM_ROLE="arn:aws:iam::692859939525:role/therock-${RELEASE_TYPE}"
-            echo "✓ Using release-type role: ${IAM_ROLE}"
-          fi
-          echo "iam_role=${IAM_ROLE}" >> $GITHUB_OUTPUT
-
       - name: Fetch Artifacts for all GPU families
         run: |
           # Use artifact_manager.py for consistent multi-arch artifact fetching
@@ -139,14 +119,10 @@ jobs:
             --pkg-type "${{ inputs.native_package_type }}" \
             --version-suffix "${{ env.ARTIFACT_RUN_ID }}"
 
-      - name: Configure AWS Credentials
-        # Only assume OIDC role for authorized repositories (ROCm/TheRock, ROCm/rockrel).
-        # Allowing both CI builds (TheRock) and release builds (rockrel) to upload packages.
-        if: ${{ (github.repository == 'ROCm/TheRock' || github.repository == 'ROCm/rockrel') && !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+      - name: Configure AWS credentials for artifact uploads
+        uses: ./.github/actions/configure_aws_artifacts_credentials
         with:
-          aws-region: us-east-2
-          role-to-assume: ${{ steps.iam_role.outputs.iam_role }}
+          release_type: ${{ inputs.release_type }}
 
       - name: Upload Package repo to S3
         id: upload-packages


### PR DESCRIPTION
## Motivation

This pull request simplifies the AWS credentials configuration process in the `multi_arch_build_native_linux_packages.yml` workflow. The main change is the removal of inline IAM role selection logic in favor of a reusable custom GitHub Action for configuring AWS credentials, streamlining artifact upload steps.

## Technical Details

* Replaced the inline IAM role determination step with usage of a custom action (`configure_aws_artifacts_credentials`) to handle AWS credentials setup for artifact uploads. This centralizes and simplifies credential management. [[1]](diffhunk://#diff-e6eaa029d920068b8aa38d789a13a36a7bf13b56fb9e664fe6ac9c38046a79a2L90-L112) [[2]](diffhunk://#diff-e6eaa029d920068b8aa38d789a13a36a7bf13b56fb9e664fe6ac9c38046a79a2L139-R119)

## Test Plan

- [ ] `workflow_dispatch` on **Multi-Arch CI** (branch: `users/acheruva/aws_cred_comments_apr26`)
  - `baseline_run_id`: `26183913175`
  - `prebuilt_stages`: `all`
  - `linux_amdgpu_families`: `gfx11x,gfx94x`
  - Windows fields: empty

## Test Result

https://github.com/ROCm/TheRock/actions/runs/26239866672

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
