### PR TITLE
Add native Linux package builds to multi-arch release workflow

### DIFF
--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -11,6 +11,12 @@ on:
         description: JSON object with build configuration for this platform.
       rocm_package_version:
         type: string
+      rocm_deb_package_version:
+        type: string
+        description: ROCm DEB package version for native packages (e.g., 8.0.0).
+      rocm_rpm_package_version:
+        type: string
+        description: ROCm RPM package version for native packages (e.g., 8.0.0).
       test_type:
         type: string
       release_type:
@@ -78,10 +84,40 @@ jobs:
       contents: read
       id-token: write
 
-  # TODO(#3334): build native packages (build_native_linux_packages.yml)
+  build_native_deb_packages:
+    needs: [build_artifacts]
+    name: Build DEB Packages
+    uses: ./.github/workflows/multi_arch_build_native_linux_packages.yml
+    with:
+      dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
+      artifact_run_id: ${{ github.run_id }}
+      rocm_version: ${{ inputs.rocm_deb_package_version }}
+      native_package_type: deb
+      release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
+    permissions:
+      contents: read
+      id-token: write
+
+  build_native_rpm_packages:
+    needs: [build_artifacts]
+    name: Build RPM Packages
+    uses: ./.github/workflows/multi_arch_build_native_linux_packages.yml
+    with:
+      dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
+      artifact_run_id: ${{ github.run_id }}
+      rocm_version: ${{ inputs.rocm_rpm_package_version }}
+      native_package_type: rpm
+      release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
+    permissions:
+      contents: read
+      id-token: write
 
   publish_to_release_buckets:
-    needs: [build_tarballs, build_python_packages]
+    needs: [build_tarballs, build_python_packages, build_native_deb_packages, build_native_rpm_packages]
     name: Publish to Release Buckets
     runs-on: ubuntu-24.04
     permissions:

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -140,7 +140,7 @@ def publish_python_packages(
             raise FileNotFoundError(f"No python packages found at {source.s3_uri}")
 
 
-def publish_native_packages(
+def publish_native_linux_packages(
     artifacts_root: WorkflowOutputRoot,
     release_type: str,
     backend: StorageBackend,
@@ -174,7 +174,7 @@ def publish_native_packages(
     today = datetime.date.today().strftime("%Y%m%d")
 
     for pkg_type in ["deb", "rpm"]:
-        source = artifacts_root.native_packages(pkg_type)
+        source = artifacts_root.native_linux_packages(pkg_type)
 
         if release_type == "prerelease":
             dest_prefix = f"v4/packages/{pkg_type}"
@@ -233,7 +233,7 @@ def main(argv: list[str]) -> None:
     publish_tarballs(artifacts_root, args.release_type, backend)
     publish_python_packages(artifacts_root, args.release_type, backend, kpack_split)
     if not args.skip_native_packages:
-        publish_native_packages(artifacts_root, args.release_type, backend)
+        publish_native_linux_packages(artifacts_root, args.release_type, backend)
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -232,7 +232,7 @@ def main(argv: list[str]) -> None:
 
     publish_tarballs(artifacts_root, args.release_type, backend)
     publish_python_packages(artifacts_root, args.release_type, backend, kpack_split)
-    if not args.skip_native_packages:
+    if artifacts_root.platform == "linux" and not args.skip_native_packages:
         publish_native_linux_packages(artifacts_root, args.release_type, backend)
 
 

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -36,9 +36,9 @@ Example with ``--run-id 12345 --platform linux --release-type dev``:
     native linux packages (dev/nightly):
 
     s3://therock-dev-artifacts/12345-linux/packages/deb/
-      -> s3://therock-dev-packages/deb/20250101-12345/
+      -> s3://therock-dev-packages/v4/deb/20250101-12345/
     s3://therock-dev-artifacts/12345-linux/packages/rpm/
-      -> s3://therock-dev-packages/rpm/20250101-12345/
+      -> s3://therock-dev-packages/v4/rpm/20250101-12345/
 
     native linux packages (prerelease):
 
@@ -153,9 +153,9 @@ def publish_native_packages(
 
     dev/nightly example:
         s3://therock-dev-artifacts/12345-linux/packages/deb/
-          -> s3://therock-dev-packages/deb/20250101-12345/
+          -> s3://therock-dev-packages/v4/deb/20250101-12345/
         s3://therock-dev-artifacts/12345-linux/packages/rpm/
-          -> s3://therock-dev-packages/rpm/20250101-12345/
+          -> s3://therock-dev-packages/v4/rpm/20250101-12345/
 
     prerelease example:
         s3://therock-prerelease-artifacts/12345-linux/packages/deb/
@@ -179,7 +179,7 @@ def publish_native_packages(
         if release_type == "prerelease":
             dest_prefix = f"v4/packages/{pkg_type}"
         else:
-            dest_prefix = f"{pkg_type}/{today}-{artifacts_root.run_id}"
+            dest_prefix = f"v4/{pkg_type}/{today}-{artifacts_root.run_id}"
 
         dest = StorageLocation(dest_bucket.name, dest_prefix)
         logger.info(

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -8,7 +8,7 @@ These release file types are supported:
 
 - [x] tarballs
 - [x] python packages
-- [ ] native linux packages
+- [x] native linux packages
 - [ ] native windows packages
 
 Example with ``--run-id 12345 --platform linux --release-type dev``:
@@ -33,12 +33,27 @@ Example with ``--run-id 12345 --platform linux --release-type dev``:
       -> s3://therock-dev-python/v4/whl/rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl
       -> s3://therock-dev-python/v4/whl/rocm_sdk_libraries-7.13.0-py3-none-linux_x86_64.whl
 
+    native linux packages (dev/nightly):
+
+    s3://therock-dev-artifacts/12345-linux/packages/deb/
+      -> s3://therock-dev-packages/deb/20250101-12345/
+    s3://therock-dev-artifacts/12345-linux/packages/rpm/
+      -> s3://therock-dev-packages/rpm/20250101-12345/
+
+    native linux packages (prerelease):
+
+    s3://therock-prerelease-artifacts/12345-linux/packages/deb/
+      -> s3://therock-prerelease-packages/v3/packages/deb/
+    s3://therock-prerelease-artifacts/12345-linux/packages/rpm/
+      -> s3://therock-prerelease-packages/v3/packages/rpm/
+
 Test usage:
     python build_tools/github_actions/publish_rocm_to_release_buckets.py \\
         --run-id 12345 --platform linux --release-type dev --dry-run
 """
 
 import argparse
+import datetime
 import logging
 import platform as platform_module
 import sys
@@ -125,6 +140,57 @@ def publish_python_packages(
             raise FileNotFoundError(f"No python packages found at {source.s3_uri}")
 
 
+def publish_native_packages(
+    artifacts_root: WorkflowOutputRoot,
+    release_type: str,
+    backend: StorageBackend,
+) -> None:
+    """Copy native Linux packages from the artifacts bucket to the release packages bucket.
+
+    The source packages were uploaded by upload_package_repo.py (called from
+    multi_arch_build_native_linux_packages.yml) and already include repodata
+    (Packages/Release files for deb, repodata/ for rpm).
+
+    dev/nightly example:
+        s3://therock-dev-artifacts/12345-linux/packages/deb/
+          -> s3://therock-dev-packages/deb/20250101-12345/
+        s3://therock-dev-artifacts/12345-linux/packages/rpm/
+          -> s3://therock-dev-packages/rpm/20250101-12345/
+
+    prerelease example:
+        s3://therock-prerelease-artifacts/12345-linux/packages/deb/
+          -> s3://therock-prerelease-packages/v3/packages/deb/
+        s3://therock-prerelease-artifacts/12345-linux/packages/rpm/
+          -> s3://therock-prerelease-packages/v3/packages/rpm/
+
+    Note (prerelease): This is a plain copy — the repodata already present in the
+    packages bucket is overwritten with the repodata from this run. If multiple
+    prerelease runs upload packages to the same fixed prefix, earlier packages
+    will no longer be referenced by the repodata.
+    TODO: Implement a proper repodata merge for the prerelease case, similar to
+    the merge logic in upload_package_repo.py (regenerate_repo_metadata_from_s3).
+    """
+    dest_bucket = get_release_bucket_config(release_type, "packages")
+    today = datetime.date.today().strftime("%Y%m%d")
+
+    for pkg_type in ["deb", "rpm"]:
+        source = artifacts_root.native_packages(pkg_type)
+
+        if release_type == "prerelease":
+            dest_prefix = f"v3/packages/{pkg_type}"
+        else:
+            dest_prefix = f"{pkg_type}/{today}-{artifacts_root.run_id}"
+
+        dest = StorageLocation(dest_bucket.name, dest_prefix)
+        logger.info(
+            "Native %s packages: %s -> %s", pkg_type, source.s3_uri, dest.s3_uri
+        )
+        count = backend.copy_directory(source, dest)
+        logger.info("Copied %d files for %s packages", count, pkg_type)
+        if count == 0:
+            raise FileNotFoundError(f"No {pkg_type} packages found at {source.s3_uri}")
+
+
 def main(argv: list[str]) -> None:
     parser = argparse.ArgumentParser(
         description="Publish ROCm release files to release buckets"
@@ -149,6 +215,11 @@ def main(argv: list[str]) -> None:
         help='Whether kpack split is enabled ("true" or "false")',
     )
     parser.add_argument(
+        "--skip-native-packages",
+        action="store_true",
+        help="Skip publishing native Linux packages (deb/rpm)",
+    )
+    parser.add_argument(
         "--dry-run", action="store_true", help="Print plan without copying"
     )
     args = parser.parse_args(argv)
@@ -161,6 +232,8 @@ def main(argv: list[str]) -> None:
 
     publish_tarballs(artifacts_root, args.release_type, backend)
     publish_python_packages(artifacts_root, args.release_type, backend, kpack_split)
+    if not args.skip_native_packages:
+        publish_native_packages(artifacts_root, args.release_type, backend)
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -43,9 +43,9 @@ Example with ``--run-id 12345 --platform linux --release-type dev``:
     native linux packages (prerelease):
 
     s3://therock-prerelease-artifacts/12345-linux/packages/deb/
-      -> s3://therock-prerelease-packages/v3/packages/deb/
+      -> s3://therock-prerelease-packages/v4/packages/deb/
     s3://therock-prerelease-artifacts/12345-linux/packages/rpm/
-      -> s3://therock-prerelease-packages/v3/packages/rpm/
+      -> s3://therock-prerelease-packages/v4/packages/rpm/
 
 Test usage:
     python build_tools/github_actions/publish_rocm_to_release_buckets.py \\
@@ -159,9 +159,9 @@ def publish_native_packages(
 
     prerelease example:
         s3://therock-prerelease-artifacts/12345-linux/packages/deb/
-          -> s3://therock-prerelease-packages/v3/packages/deb/
+          -> s3://therock-prerelease-packages/v4/packages/deb/
         s3://therock-prerelease-artifacts/12345-linux/packages/rpm/
-          -> s3://therock-prerelease-packages/v3/packages/rpm/
+          -> s3://therock-prerelease-packages/v4/packages/rpm/
 
     Note (prerelease): This is a plain copy — the repodata already present in the
     packages bucket is overwritten with the repodata from this run. If multiple
@@ -177,7 +177,7 @@ def publish_native_packages(
         source = artifacts_root.native_packages(pkg_type)
 
         if release_type == "prerelease":
-            dest_prefix = f"v3/packages/{pkg_type}"
+            dest_prefix = f"v4/packages/{pkg_type}"
         else:
             dest_prefix = f"{pkg_type}/{today}-{artifacts_root.run_id}"
 

--- a/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
+++ b/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
@@ -26,6 +26,7 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
                 "linux",
                 "--release-type",
                 "dev",
+                "--skip-native-packages",
                 "--dry-run",
             ]
         )
@@ -85,6 +86,7 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
                 "dev",
                 "--kpack-split",
                 "true",
+                "--skip-native-packages",
                 "--dry-run",
             ]
         )
@@ -95,6 +97,53 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
         self.assertEqual(python_dest_staging.relative_path, "v4/whl-staging")
         _, python_dest_release = mock_copy.call_args_list[2].args
         self.assertEqual(python_dest_release.relative_path, "v4/whl")
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
+    def test_dev_linux_copies_native_packages(self, mock_copy):
+        mock_copy.return_value = 2
+        main(
+            [
+                "--run-id",
+                "123",
+                "--platform",
+                "linux",
+                "--release-type",
+                "dev",
+                "--dry-run",
+            ]
+        )
+
+        # Calls: tarballs, python -> v3/whl-staging, python -> v3/whl, deb, rpm
+        self.assertEqual(mock_copy.call_count, 5)
+        # deb packages
+        deb_source, deb_dest = mock_copy.call_args_list[3].args
+        self.assertEqual(deb_source.bucket, "therock-dev-artifacts")
+        self.assertEqual(deb_source.relative_path, "123-linux/packages/deb")
+        self.assertEqual(deb_dest.bucket, "therock-dev-packages")
+        self.assertRegex(deb_dest.relative_path, r"^v4/deb/\d{8}-123$")
+        # rpm packages
+        rpm_source, rpm_dest = mock_copy.call_args_list[4].args
+        self.assertEqual(rpm_source.bucket, "therock-dev-artifacts")
+        self.assertEqual(rpm_source.relative_path, "123-linux/packages/rpm")
+        self.assertEqual(rpm_dest.bucket, "therock-dev-packages")
+        self.assertRegex(rpm_dest.relative_path, r"^v4/rpm/\d{8}-123$")
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
+    def test_windows_skips_native_packages(self, mock_copy):
+        mock_copy.return_value = 1
+        main(
+            [
+                "--run-id",
+                "99",
+                "--platform",
+                "windows",
+                "--release-type",
+                "nightly",
+                "--dry-run",
+            ]
+        )
+        # Only tarballs + python x2 (3 calls) — native packages skipped for windows
+        self.assertEqual(mock_copy.call_count, 3)
 
     @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
     def test_raises_when_no_tarballs_found(self, mock_copy):


### PR DESCRIPTION
## Motivation

Native Linux packages (DEB and RPM) are built as part of the multi-arch CI pipeline but were not being published to release buckets during release workflows. This PR resolves the TODO(#3334) placeholder in `multi_arch_release_linux.yml` by wiring native package builds and publishing into the release flow.

## Technical Details

### `multi_arch_release_linux.yml`
- Added `rocm_deb_package_version` and `rocm_rpm_package_version` inputs (passed through from `setup_multi_arch.yml` outputs via `multi_arch_release.yml` on the `users/nunnikri/multi_arch_ci_enable` branch)
- Added `build_native_deb_packages` and `build_native_rpm_packages` jobs that run in parallel with `build_tarballs` and `build_python_packages` after `build_artifacts` completes
- Updated `publish_to_release_buckets` to depend on both native package build jobs

### `publish_rocm_to_release_buckets.py`
- Added `publish_native_packages()` function that copies DEB and RPM packages from the artifacts bucket (`therock-{type}-artifacts/{run_id}-linux/packages/{pkg_type}/`) to the release packages bucket (`therock-{type}-packages`)
- Destination prefix strategy:
  - **dev/nightly:** `{pkg_type}/{YYYYMMDD}-{run_id}/` (dated, per-run)
  - **prerelease:** `v3/packages/{pkg_type}/` (fixed prefix, plain copy)
- Added `--skip-native-packages` flag to allow bypassing native package publishing if needed
- Added a TODO note on the prerelease repodata overwrite limitation — proper repodata merge (similar to `regenerate_repo_metadata_from_s3` in `upload_package_repo.py`) is left for a follow-up

**Note:** This PR and [ `users/nunnikri/multi_arch_ci_enable` for the `rocm_deb/rpm_package_version` pass-through in `multi_arch_release.yml`.](https://github.com/ROCm/TheRock/pull/4359) needs to merged together

## Test Plan

- [ ] Dry-run verification:
  ```bash
  python build_tools/github_actions/publish_rocm_to_release_buckets.py \
      --run-id <run_id> --platform linux --release-type dev --dry-run

## Test Results
- Dev Release job with this PR https://github.com/ROCm/TheRock/actions/runs/25019825963
- Packages created
    RPM: https://[therock-dev-artifacts.s3.amazonaws.com/25019825963-linux/packages/rpm/x86_64/index.html](https://therock-dev-artifacts.s3.amazonaws.com/25019825963-linux/packages/rpm/x86_64/index.html)
    Debian : https://[therock-dev-artifacts.s3.amazonaws.com/25019825963-linux/packages/deb/index.html](https://therock-dev-artifacts.s3.amazonaws.com/25019825963-linux/packages/deb/index.html)
