### PR TITLE
Plumb repository and ref inputs through test workflows

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -35,6 +35,12 @@ on:
         description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
         default: ""
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
   workflow_call:
     inputs:
       artifact_group:
@@ -65,6 +71,12 @@ on:
       release_type:
         type: string
         default: ""
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
   push:
     branches:
       - ADHOCBUILD
@@ -88,6 +100,8 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -100,6 +114,9 @@ jobs:
 
       - name: "Checking out repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
 
       - name: Setting up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -129,6 +146,8 @@ jobs:
       platform: ${{ needs.configure_test_matrix.outputs.platform }}
       component: ${{ needs.configure_test_matrix.outputs.sanity_component }}
       release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
 
   test_components:
     name: 'Test ${{ matrix.components.job_name }}'
@@ -171,3 +190,5 @@ jobs:
       platform: ${{ needs.configure_test_matrix.outputs.platform }}
       component: ${{ toJSON(matrix.components) }}
       release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}

--- a/.github/workflows/test_artifacts_structure.yml
+++ b/.github/workflows/test_artifacts_structure.yml
@@ -29,6 +29,12 @@ on:
         description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
         default: ""
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
   workflow_call:
     inputs:
       artifact_run_id:
@@ -46,6 +52,12 @@ on:
       release_type:
         type: string
         default: ""
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
 
 permissions:
   contents: read
@@ -62,6 +74,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
 
       - name: Setting up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -25,6 +25,12 @@ on:
       release_type:
         type: string
         default: ""
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
       default_container_image:
         type: string
         default: "ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98"
@@ -93,6 +99,8 @@ jobs:
       - name: "Fetch 'build_tools' from repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -105,7 +113,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: "ROCm/TheRock"
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
 
       - name: Run setup test environment workflow
         timeout-minutes: 15


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/2281. This will let us trigger tests from release workflows running in https://github.com/ROCm/rockrel.

## Technical Details

1. I'm considering either `workflow_call` or `workflow_dispatch` triggering for test workflows, see https://github.com/ROCm/TheRock/issues/2281#issuecomment-4317109968
3. There is an extra checkout step in `.github/workflows/test_component.yml` to run https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/cleanup_processes.ps1. This does not belong in workflows - it should be a pre-job or post-job script (https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts). This repository **and rocm-libraries/rocm-systems** have been using **unpinned** checkouts of ROCm/TheRock for this script, so we can't safely rename the script without breaking all CI runs.
    * https://github.com/ROCm/rocm-libraries/blob/a2bb3b16c9eea059d5655ef19ee814b4f327af9c/.github/workflows/therock-test-component.yml#L55-L67
    * https://github.com/ROCm/rocm-systems/blob/affce09c9b740db4535bcebd0d9814e3b800cd10/.github/workflows/therock-test-component.yml#L64-L76

## Test Plan

Dev release run at https://github.com/ROCm/TheRock/actions/runs/24917079667, which ran all expected tests. Note that this used test type "quick" due to the `workflow_dispatch` trigger. We should probably add a dedicated code path in `_determine_test_type()` in [`build_tools/github_actions/configure_multi_arch_ci.py`](https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/configure_multi_arch_ci.py) for `if ci_inputs.release_type`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
