### PR TITLE
adding test pkg for hipdnn, rocrtst, debug-agent, roc-gdb

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -328,6 +328,41 @@
     "Gfxarch": "False"
   },
   {
+    "Package": "amdrocm-hip-test",
+    "Version": "",
+    "Architecture": "amd64",
+    "BuildArch": "x86_64",
+    "DEBDepends": [
+      "amdrocm-runtime-devel"
+    ],
+    "RPMRequires": [
+      "amdrocm-runtime-devel"
+    ],
+    "Maintainer": "AMD HSA Support <dl.HSA-Runtime-Support@amd.com>",
+    "Description_Short": "AMD HIP test files for ROCm platforms",
+    "Description_Long": "AMD HIP test files for ROCm platforms",
+    "Section": "devel",
+    "Priority": "optional",
+    "Group": "unknown",
+    "License": "MIT",
+    "Vendor": "Advanced Micro Devices, Inc",
+    "Homepage": "https://github.com/ROCm/rocm-systems",
+    "Artifactory": [
+      {
+        "Artifact": "core-hiptests",
+        "Artifact_Subdir": [
+          {
+            "Name": "hip-tests",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
+      }
+    ],
+    "Gfxarch": "False"
+  },
+  {
     "Package": "amdrocm-fft-test",
     "Version": "",
     "Architecture": "amd64",
@@ -2326,79 +2361,6 @@
 
   },
   {
-    "Package": "rocr-debug-agent-test",
-    "Version": "",
-    "Architecture": "amd64",
-    "BuildArch": "x86_64",
-    "DEBDepends": [
-      "amdrocm-sysdeps"
-    ],
-    "RPMRequires": [
-      "amdrocm-sysdeps"
-    ],
-    "Maintainer": "ROCm Debugger Support <rocm-gdb.support@amd.com>",
-    "Description_Short": "ROCm debugger tests",
-    "Description_Long": "Tests for AMD ROCm source-level debugger for Linux,based on GDB, the GNU source-level debugger",
-    "Section": "devel",
-    "Priority": "optional",
-    "Group": "unknown",
-    "License": "MIT AND GPL AND NCSA",
-    "Vendor": "Advanced Micro Devices, Inc",
-    "Homepage": "https://github.com/ROCm/rocGdb",
-    "Artifactory": [
-      {
-        "Artifact": "rocr-debug-agent-tests",
-        "Artifact_Subdir": [
-          {
-            "Name": "rocr-debug-agent-tests",
-            "Components": [
-              "test"
-            ]
-          }
-        ]
-      }
-    ],
-    "Disable_DWZ": "True",
-    "Gfxarch": "False"
-  },
-
-  {
-    "Package": "rocgdb-test",
-    "Version": "",
-    "Architecture": "amd64",
-    "BuildArch": "x86_64",
-    "DEBDepends": [
-      "amdrocm-sysdeps"
-    ],
-    "RPMRequires": [
-      "amdrocm-sysdeps"
-    ],
-    "Maintainer": "ROCm Debugger Support <rocm-gdb.support@amd.com>",
-    "Description_Short": "ROCm debugger tests",
-    "Description_Long": "AMD ROCm source-level debugger tests",
-    "Section": "devel",
-    "Priority": "optional",
-    "Group": "unknown",
-    "License": "MIT AND GPL AND NCSA",
-    "Vendor": "Advanced Micro Devices, Inc",
-    "Homepage": "https://github.com/ROCm/rocGdb",
-    "Artifactory": [
-      {
-        "Artifact": "rocgdb",
-        "Artifact_Subdir": [
-          {
-            "Name": "rocgdb",
-            "Components": [
-              "test"
-            ]
-          }
-        ]
-      }
-    ],
-    "Gfxarch": "False"
-  },
-
-  {
     "Package": "amdrocm-debugger",
     "Version": "",
     "Architecture": "amd64",
@@ -2462,6 +2424,93 @@
       }
 
     ],
+    "Gfxarch": "False"
+  },
+  {
+    "Package": "amdrocm-debugger-test",
+    "Version": "",
+    "Architecture": "amd64",
+    "BuildArch": "x86_64",
+    "DEBDepends": [
+      "amdrocm-sysdeps"
+    ],
+    "RPMRequires": [
+      "amdrocm-sysdeps"
+    ],
+    "Maintainer": "ROCm Debugger Support <rocm-gdb.support@amd.com>",
+    "Description_Short": "ROCm debugger test files",
+    "Description_Long": "Test files for AMD ROCm debugger including rocr-debug-agent-tests and rocgdb-test",
+    "Section": "devel",
+    "Priority": "optional",
+    "Group": "unknown",
+    "License": "MIT AND GPL AND NCSA",
+    "Vendor": "Advanced Micro Devices, Inc",
+    "Homepage": "https://github.com/ROCm/rocGdb",
+    "Artifactory": [
+      {
+        "Artifact": "rocr-debug-agent-tests",
+        "Artifact_Subdir": [
+          {
+            "Name": "rocr-debug-agent-tests",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
+      },
+      {
+        "Artifact": "rocgdb",
+        "Artifact_Subdir": [
+          {
+            "Name": "rocgdb",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
+      }
+    ],
+    "Disable_DWZ": "True",
+    "Gfxarch": "False"
+  },
+  {
+    "Package": "amdrocm-rocrtst",
+    "Version": "",
+    "Architecture": "amd64",
+    "BuildArch": "x86_64",
+    "DEBDepends": [
+      "amdrocm-sysdeps",
+      "amdrocm-base",
+      "amdrocm-llvm"
+    ],
+    "RPMRequires": [
+      "amdrocm-sysdeps",
+      "amdrocm-base",
+      "amdrocm-llvm"
+    ],
+    "Maintainer": "AMD HSA Support <dl.HSA-Runtime-Support@amd.com>",
+    "Description_Short": "ROCm runtime test files",
+    "Description_Long": "Test files for AMD HIP Runtime for ROCm platforms",
+    "Section": "devel",
+    "Priority": "optional",
+    "Group": "unknown",
+    "License": "MIT",
+    "Vendor": "Advanced Micro Devices, Inc",
+    "Homepage": "https://github.com/ROCm/rocm-libraries",
+    "Artifactory": [
+      {
+        "Artifact": "rocrtst",
+        "Artifact_Subdir": [
+          {
+            "Name": "rocrtst",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
+      }
+    ],
+    "Disable_DWZ": "True",
     "Gfxarch": "False"
   },
   {
@@ -2954,46 +3003,6 @@
     "Homepage": "https://github.com/ROCm/rocm-libraries",
     "Metapackage": "True",
     "Gfxarch": "True"
-  },
-  {
-    "Package": "rocrtst-test",
-    "Version": "",
-    "Architecture": "amd64",
-    "BuildArch": "x86_64",
-    "DEBDepends": [
-      "amdrocm-sysdeps",
-      "amdrocm-base",
-      "amdrocm-llvm"
-    ],
-    "RPMRequires": [
-      "amdrocm-sysdeps",
-      "amdrocm-base",
-      "amdrocm-llvm"
-    ],
-    "Maintainer": "AMD HSA Support <dl.HSA-Runtime-Support@amd.com>",
-    "Description_Short": "AMD HIP Runtime for ROCm platforms",
-    "Description_Long": "AMD HIP Runtime for ROCm platforms",
-    "Section": "devel",
-    "Priority": "optional",
-    "Group": "unknown",
-    "License": "MIT",
-    "Vendor": "Advanced Micro Devices, Inc",
-    "Homepage": "https://github.com/ROCm/rocm-libraries",
-    "Artifactory": [
-      {
-        "Artifact": "rocrtst",
-        "Artifact_Subdir": [
-          {
-            "Name": "rocrtst",
-            "Components": [
-              "test"
-            ]
-          }
-        ]
-      }
-    ],
-    "Disable_DWZ": "True",
-    "Gfxarch": "False"
   }
 
 ]

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -328,15 +328,21 @@
     "Gfxarch": "False"
   },
   {
-    "Package": "amdrocm-hip-test",
+    "Package": "amdrocm-runtime-test",
     "Version": "",
     "Architecture": "amd64",
     "BuildArch": "x86_64",
     "DEBDepends": [
-      "amdrocm-runtime-devel"
+      "amdrocm-runtime-devel",
+      "amdrocm-sysdeps",
+      "amdrocm-base",
+      "amdrocm-llvm"
     ],
     "RPMRequires": [
-      "amdrocm-runtime-devel"
+      "amdrocm-runtime-devel",
+      "amdrocm-sysdeps",
+      "amdrocm-base",
+      "amdrocm-llvm"
     ],
     "Maintainer": "AMD HSA Support <dl.HSA-Runtime-Support@amd.com>",
     "Description_Short": "AMD HIP test files for ROCm platforms",
@@ -358,9 +364,21 @@
             ]
           }
         ]
+      },
+      {
+        "Artifact": "rocrtst",
+        "Artifact_Subdir": [
+          {
+            "Name": "rocrtst",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
       }
     ],
-    "Gfxarch": "False"
+    "Gfxarch": "False",
+    "Disable_DWZ": "True"
   },
   {
     "Package": "amdrocm-fft-test",

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -2492,46 +2492,6 @@
     "Gfxarch": "False"
   },
   {
-    "Package": "amdrocm-rocrtst",
-    "Version": "",
-    "Architecture": "amd64",
-    "BuildArch": "x86_64",
-    "DEBDepends": [
-      "amdrocm-sysdeps",
-      "amdrocm-base",
-      "amdrocm-llvm"
-    ],
-    "RPMRequires": [
-      "amdrocm-sysdeps",
-      "amdrocm-base",
-      "amdrocm-llvm"
-    ],
-    "Maintainer": "AMD HSA Support <dl.HSA-Runtime-Support@amd.com>",
-    "Description_Short": "ROCm runtime test files",
-    "Description_Long": "Test files for AMD HIP Runtime for ROCm platforms",
-    "Section": "devel",
-    "Priority": "optional",
-    "Group": "unknown",
-    "License": "MIT",
-    "Vendor": "Advanced Micro Devices, Inc",
-    "Homepage": "https://github.com/ROCm/rocm-libraries",
-    "Artifactory": [
-      {
-        "Artifact": "rocrtst",
-        "Artifact_Subdir": [
-          {
-            "Name": "rocrtst",
-            "Components": [
-              "test"
-            ]
-          }
-        ]
-      }
-    ],
-    "Disable_DWZ": "True",
-    "Gfxarch": "False"
-  },
-  {
     "Package": "amdrocm-decode-test",
     "Version": "",
     "Architecture": "amd64",

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -579,7 +579,13 @@
               "doc"
             ]
           },
-
+          {
+            "Name": "origami",
+            "Components": [
+              "lib",
+              "run"
+            ]
+          },
           {
             "Name": "hipBLASLt",
             "Components": [
@@ -1726,7 +1732,6 @@
           }
         ]
       },
-
       {
         "Artifact": "sysdeps-expat",
         "Artifact_Subdir": [
@@ -1740,7 +1745,36 @@
             ]
           }
         ]
+      },
+      {
+        "Artifact": "sysdeps-hwloc",
+        "Artifact_Subdir": [
+          {
+            "Name": "hwloc",
+            "Components": [
+              "lib",
+              "dev",
+              "doc",
+              "run"
+            ]
+          }
+        ]
+      },
+      {
+        "Artifact": "sysdeps-libpciaccess",
+        "Artifact_Subdir": [
+          {
+            "Name": "libpciaccess",
+            "Components": [
+              "lib",
+              "dev",
+              "doc",
+              "run"
+            ]
+          }
+        ]
       }
+
     ],
 
     "Gfxarch": "False",
@@ -2250,6 +2284,18 @@
         "Artifact_Subdir": [
           {
             "Name": "hipdnn_samples",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
+      },
+      {
+        "Artifact": "hipdnn-integration-tests",
+        "Artifact_Gfxarch": "False",
+        "Artifact_Subdir": [
+          {
+            "Name": "hipdnn_integration_tests",
             "Components": [
               "test"
             ]

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -2326,6 +2326,79 @@
 
   },
   {
+    "Package": "rocr-debug-agent-test",
+    "Version": "",
+    "Architecture": "amd64",
+    "BuildArch": "x86_64",
+    "DEBDepends": [
+      "amdrocm-sysdeps"
+    ],
+    "RPMRequires": [
+      "amdrocm-sysdeps"
+    ],
+    "Maintainer": "ROCm Debugger Support <rocm-gdb.support@amd.com>",
+    "Description_Short": "ROCm debugger tests",
+    "Description_Long": "Tests for AMD ROCm source-level debugger for Linux,based on GDB, the GNU source-level debugger",
+    "Section": "devel",
+    "Priority": "optional",
+    "Group": "unknown",
+    "License": "MIT AND GPL AND NCSA",
+    "Vendor": "Advanced Micro Devices, Inc",
+    "Homepage": "https://github.com/ROCm/rocGdb",
+    "Artifactory": [
+      {
+        "Artifact": "rocr-debug-agent-tests",
+        "Artifact_Subdir": [
+          {
+            "Name": "rocr-debug-agent-tests",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
+      }
+    ],
+    "Disable_DWZ": "True",
+    "Gfxarch": "False"
+  },
+
+  {
+    "Package": "rocgdb-test",
+    "Version": "",
+    "Architecture": "amd64",
+    "BuildArch": "x86_64",
+    "DEBDepends": [
+      "amdrocm-sysdeps"
+    ],
+    "RPMRequires": [
+      "amdrocm-sysdeps"
+    ],
+    "Maintainer": "ROCm Debugger Support <rocm-gdb.support@amd.com>",
+    "Description_Short": "ROCm debugger tests",
+    "Description_Long": "AMD ROCm source-level debugger tests",
+    "Section": "devel",
+    "Priority": "optional",
+    "Group": "unknown",
+    "License": "MIT AND GPL AND NCSA",
+    "Vendor": "Advanced Micro Devices, Inc",
+    "Homepage": "https://github.com/ROCm/rocGdb",
+    "Artifactory": [
+      {
+        "Artifact": "rocgdb",
+        "Artifact_Subdir": [
+          {
+            "Name": "rocgdb",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
+      }
+    ],
+    "Gfxarch": "False"
+  },
+
+  {
     "Package": "amdrocm-debugger",
     "Version": "",
     "Architecture": "amd64",
@@ -2881,6 +2954,46 @@
     "Homepage": "https://github.com/ROCm/rocm-libraries",
     "Metapackage": "True",
     "Gfxarch": "True"
+  },
+  {
+    "Package": "rocrtst-test",
+    "Version": "",
+    "Architecture": "amd64",
+    "BuildArch": "x86_64",
+    "DEBDepends": [
+      "amdrocm-sysdeps",
+      "amdrocm-base",
+      "amdrocm-llvm"
+    ],
+    "RPMRequires": [
+      "amdrocm-sysdeps",
+      "amdrocm-base",
+      "amdrocm-llvm"
+    ],
+    "Maintainer": "AMD HSA Support <dl.HSA-Runtime-Support@amd.com>",
+    "Description_Short": "AMD HIP Runtime for ROCm platforms",
+    "Description_Long": "AMD HIP Runtime for ROCm platforms",
+    "Section": "devel",
+    "Priority": "optional",
+    "Group": "unknown",
+    "License": "MIT",
+    "Vendor": "Advanced Micro Devices, Inc",
+    "Homepage": "https://github.com/ROCm/rocm-libraries",
+    "Artifactory": [
+      {
+        "Artifact": "rocrtst",
+        "Artifact_Subdir": [
+          {
+            "Name": "rocrtst",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
+      }
+    ],
+    "Disable_DWZ": "True",
+    "Gfxarch": "False"
   }
 
 ]

--- a/core/artifact-core-rocrtst.toml
+++ b/core/artifact-core-rocrtst.toml
@@ -8,6 +8,7 @@ exclude = [
 [components.dev."core/rocrtst/stage"]
 [components.doc."core/rocrtst/stage"]
 [components.test."core/rocrtst/stage"]
-include = [
-   "bin/**",
+exclude = [
+    "lib/rocrtst/lib/libhwloc.so*",
+    "lib/rocrtst/lib/LICENSE",
 ]

--- a/core/artifact-core-rocrtst.toml
+++ b/core/artifact-core-rocrtst.toml
@@ -8,7 +8,6 @@ exclude = [
 [components.dev."core/rocrtst/stage"]
 [components.doc."core/rocrtst/stage"]
 [components.test."core/rocrtst/stage"]
-exclude = [
-    "lib/rocrtst/lib/libhwloc.so*",
-    "lib/rocrtst/lib/LICENSE",
+include = [
+   "bin/**",
 ]


### PR DESCRIPTION
## Motivation

 - Add test packages for  rocrtst, debug-agent, and roc-gdb                                                                                           
  - Reorganize and rename test packages with amdrocm prefix                                                                                                       
  - Combine amdrocm-rocrtst and amdrocm-hip-test into amdrocm-runtime-test                                                                                        
  - Add origami artifact with lib and run components                                                                                                              
  - Add sysdeps-hwloc and sysdeps-libpciaccess system dependencies                                                                                                
  - Add hipdnn-integration-tests artifact  

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
