### PR TITLE
[hipdnn samples] Increase timeouts so we dont have test timeouts when a sample test takes > 1 min

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -403,7 +403,7 @@ test_matrix = {
     "hipdnn-samples": {
         "job_name": "hipdnn-samples",
         "fetch_artifact_args": "--blas --miopen --hipdnn --miopenprovider --hipdnn-samples --tests",
-        "timeout_minutes": 5,
+        "timeout_minutes": 30,
         "test_script": f"python {_get_script_path('test_hipdnn_samples.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {

--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn_samples.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn_samples.py
@@ -21,7 +21,7 @@ cmd = [
     "--parallel",
     "8",
     "--timeout",
-    "60",
+    "300",
 ]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 


### PR DESCRIPTION
## Motivation
Were seeing variations of test times from 1 to 5x.  See the following issue for more info: https://github.com/ROCm/rocm-libraries/issues/6864
