### PR TITLE
Add ocl-icd as part of python core artifacts

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -322,6 +322,7 @@ def core_artifact_filter(an: ArtifactName) -> bool:
         "core-hip",
         "core-kpack",
         "core-ocl",
+        "core-ocl-icd",
         "core-hipinfo",
         "core-runtime",
         "hipify",


### PR DESCRIPTION
## Motivation
ocltst and ocl-cts depends on ocl-icd. This PR installs the ocl-icd as part of python wheels since we package it already.

## Technical Details
have  ocl-icd as part of python wheels

## Test Plan
Python wheels should have the ocl-icd installed to bin(windows) and lib(linux)

## Test Result
Python wheels should have the ocl-icd installed to bin(windows) and lib(linux)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
