### PR TITLE
Initial documentation for multi-arch nightly releases

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,11 +3,11 @@
 This page describes how to install and use our release artifacts for ROCm and
 external builds like PyTorch and JAX. We produce build artifacts as part of our
 Continuous Integration (CI) build/test workflows as well as release artifacts as
-part of Continuous Delivery (CD) nightly releases. For the development-status of GPU architecture support in TheRock, please see the [SUPPORTED_GPUS.md](./SUPPORTED_GPUS.md) document, which tracks readiness and onboarding progress for each AMD GPU architecture.
+part of Continuous Delivery (CD) nightly releases.
 
-See also the
-[Roadmap for support](ROADMAP.md) and
-[Build artifacts overview](docs/development/artifacts.md) pages.
+For the development status of GPU architecture support in TheRock, please see
+[SUPPORTED_GPUS.md](./SUPPORTED_GPUS.md) which tracks release readiness for each
+AMD GPU architecture.
 
 > [!IMPORTANT]
 > These instructions assume familiarity with how to use ROCm.
@@ -21,26 +21,122 @@ See also the
 
 Table of contents:
 
-- [Installing releases using pip](#installing-releases-using-pip)
-  - [Python packages release status](#python-packages-release-status)
-  - [Installing ROCm Python packages](#installing-rocm-python-packages)
-  - [Using ROCm Python packages](#using-rocm-python-packages)
-  - [Installing PyTorch Python packages](#installing-pytorch-python-packages)
-  - [Using PyTorch Python packages](#using-pytorch-python-packages)
-  - [Installing JAX Python packages](#installing-jax-python-packages)
-  - [Using JAX Python packages](#using-jax-python-packages)
-- [Installing from native packages](#installing-from-native-packages)
-  - [Native packages release status](#native-packages-release-status)
-  - [Installing on Debian-based systems](#installing-on-debian-based-systems-ubuntu-debian-etc)
-  - [Installing on RPM-based systems](#installing-on-rpm-based-systems-rhel-sles-almalinux-etc)
-- [Installing from tarballs](#installing-from-tarballs)
-  - [Browsing release tarballs](#browsing-release-tarballs)
-  - [Manual tarball extraction](#manual-tarball-extraction)
-  - [Automated tarball extraction](#automated-tarball-extraction)
-  - [Using installed tarballs](#using-installed-tarballs)
+- [Multi-arch releases](#multi-arch-releases)
+  - [Multi-arch release status](#multi-arch-release-status)
+  - [Installing multi-arch ROCm Python packages](#installing-multi-arch-rocm-python-packages)
+  <!-- - [Installing multi-arch PyTorch Python packages](#installing-multi-arch-pytorch-python-packages) -->
+- [Per-family releases](#per-family-releases)
+  - [Installing per-family releases using pip](#installing-per-family-releases-using-pip)
+    - [Python packages release status](#python-packages-release-status)
+    - [Installing ROCm Python packages](#installing-rocm-python-packages)
+    - [Using ROCm Python packages](#using-rocm-python-packages)
+    - [Installing PyTorch Python packages](#installing-pytorch-python-packages)
+    - [Using PyTorch Python packages](#using-pytorch-python-packages)
+    - [Installing JAX Python packages](#installing-jax-python-packages)
+    - [Using JAX Python packages](#using-jax-python-packages)
+  - [Installing from tarballs](#installing-from-tarballs)
+    - [Browsing release tarballs](#browsing-release-tarballs)
+    - [Manual tarball extraction](#manual-tarball-extraction)
+    - [Automated tarball extraction](#automated-tarball-extraction)
+    - [Using installed tarballs](#using-installed-tarballs)
+  - [Installing from native packages](#installing-from-native-packages)
+    - [Native packages release status](#native-packages-release-status)
+    - [Installing on Debian-based systems](#installing-on-debian-based-systems-ubuntu-debian-etc)
+    - [Installing on RPM-based systems](#installing-on-rpm-based-systems-rhel-sles-almalinux-etc)
 - [Verifying your installation](#verifying-your-installation)
 
-## Installing releases using pip
+## Multi-arch releases
+
+Multi-arch releases use a unified package index that serves all GPU architectures.
+
+Benefits over [per-family releases](#per-family-releases):
+
+- **One index URL** for all GPUs - no need to find the right per-family URL
+- **Smaller downloads** - GPU-specific code is split into separate device
+  packages, so you only download what you need
+- **Mix GPU targets** - install device packages for multiple GPUs in the same
+  environment
+
+### Multi-arch release status
+
+[![Multi-arch release](https://github.com/ROCm/rockrel/actions/workflows/multi_arch_release.yml/badge.svg)](https://github.com/ROCm/rockrel/actions/workflows/multi_arch_release.yml)
+
+**Package availability:**
+
+| Package type            | Linux                                                                 | Windows                                                               |
+| ----------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| ROCm Python packages    | ✅ Available                                                          | ✅ Available                                                          |
+| PyTorch Python packages | 🟡 In progress ([#3332](https://github.com/ROCm/TheRock/issues/3332)) | 🟡 In progress ([#3332](https://github.com/ROCm/TheRock/issues/3332)) |
+| JAX Python packages     | 🟠 Planned                                                            | -                                                                     |
+| ROCm tarballs           | 🟡 In progress (missing index)                                        | 🟡 In progress (missing index)                                        |
+| Native Linux packages   | 🟡 In progress ([#3333](https://github.com/ROCm/TheRock/issues/3333)) | 🟠 Planned ([#1987](https://github.com/ROCm/TheRock/issues/1987))     |
+
+### Installing multi-arch ROCm Python packages
+
+> [!TIP]
+> We highly recommend working within a [Python virtual environment](https://docs.python.org/3/library/venv.html):
+>
+> ```bash
+> python -m venv .venv
+> source .venv/bin/activate
+> ```
+
+Install ROCm with device support for your GPU using the unified index and one or
+more `device-gfx*` pip extras:
+
+```bash
+pip install --extra-index-url https://rocm.nightlies.amd.com/v4/whl/ --pre "rocm[devel,device-gfx####]"
+```
+
+Where `####` is the GFX target taken from the following table:
+
+| Product Name                       | GFX Target | Device Extra     |
+| ---------------------------------- | ---------- | ---------------- |
+| MI300A/MI300X                      | gfx942     | `device-gfx942`  |
+| MI350X/MI355X                      | gfx950     | `device-gfx950`  |
+| AMD RX 7900 XTX                    | gfx1100    | `device-gfx1100` |
+| AMD RX 7800 XT                     | gfx1101    | `device-gfx1101` |
+| AMD RX 7700S / Framework Laptop 16 | gfx1102    | `device-gfx1102` |
+| AMD Radeon 780M Laptop iGPU        | gfx1103    | `device-gfx1103` |
+| AMD Strix Halo iGPU                | gfx1151    | `device-gfx1151` |
+| AMD RX 9060 / XT                   | gfx1200    | `device-gfx1200` |
+| AMD RX 9070 / XT                   | gfx1201    | `device-gfx1201` |
+
+For example, install the gfx1100 device code like so:
+
+```bash
+pip install --extra-index-url https://rocm.nightlies.amd.com/v4/whl/ --pre "rocm[devel,device-gfx1100]"
+```
+
+<!-- TODO: Once dependencies are uploaded to the multi-arch index, replace
+     --extra-index-url with --index-url throughout this section. -->
+
+<!-- TODO: Update URL once the top-level CloudFront path is finalized
+     (e.g. https://rocm.nightlies.amd.com/whl-multi-arch/). -->
+
+<!-- TODO: Advertise wheel variants / WheelNext once available  -->
+
+After installing, verify your installation:
+
+```bash
+rocm-sdk test
+```
+
+<!-- ### Installing multi-arch PyTorch Python packages -->
+
+<!-- TODO(#3332): Document torch packages once they are available in nightly releases -->
+
+## Per-family releases
+
+Per-family releases use **GPU-family-specific index URLs** — you choose the
+index URL that matches your GPU family, and all packages for that family are
+served from that URL.
+
+> [!NOTE]
+> Multi-arch releases (above) are the newer approach and will soon replace
+> per-family releases. Both are available during the transition.
+
+### Installing per-family releases using pip
 
 We recommend installing ROCm and projects like PyTorch and JAX via `pip`, the
 [Python package installer](https://packaging.python.org/en/latest/guides/tool-recommendations/).
@@ -61,7 +157,7 @@ We currently support Python 3.10, 3.11, 3.12, 3.13, and 3.14 (PyTorch 2.9+ only)
 > If you _really_ want a system-wide install, you can pass `--break-system-packages` to `pip` outside a virtual enivornment.
 > In this case, commandline interface shims for executables are installed to `/usr/local/bin`, which normally has precedence over `/usr/bin` and might therefore conflict with a previous installation of ROCm.
 
-### Python packages release status
+#### Python packages release status
 
 > [!IMPORTANT]
 > Known issues with the Python wheels are tracked at
@@ -74,7 +170,7 @@ We currently support Python 3.10, 3.11, 3.12, 3.13, and 3.14 (PyTorch 2.9+ only)
 | Linux    | [![Release portable Linux packages](https://github.com/ROCm/TheRock/actions/workflows/release_portable_linux_packages.yml/badge.svg?branch=main)](https://github.com/ROCm/TheRock/actions/workflows/release_portable_linux_packages.yml?query=branch%3Amain) | [![Release Linux PyTorch Wheels](https://github.com/ROCm/TheRock/actions/workflows/release_portable_linux_pytorch_wheels.yml/badge.svg?branch=main)](https://github.com/ROCm/TheRock/actions/workflows/release_portable_linux_pytorch_wheels.yml?query=branch%3Amain) | [![Release Linux JAX Wheels](https://github.com/ROCm/TheRock/actions/workflows/release_portable_linux_jax_wheels.yml/badge.svg?branch=main)](https://github.com/ROCm/TheRock/actions/workflows/release_portable_linux_jax_wheels.yml?query=branch%3Amain) |
 | Windows  |                      [![Release Windows packages](https://github.com/ROCm/TheRock/actions/workflows/release_windows_packages.yml/badge.svg?branch=main)](https://github.com/ROCm/TheRock/actions/workflows/release_windows_packages.yml?query=branch%3Amain) |             [![Release Windows PyTorch Wheels](https://github.com/ROCm/TheRock/actions/workflows/release_windows_pytorch_wheels.yml/badge.svg?branch=main)](https://github.com/ROCm/TheRock/actions/workflows/release_windows_pytorch_wheels.yml?query=branch%3Amain) |                                                                                                                                                                                                                                                         — |
 
-### Index page listing
+#### Index page listing
 
 For now, `rocm`, `torch`, and `jax` packages are published to GPU-architecture-specific index
 pages and must be installed using an appropriate `--find-links` argument to `pip`.
@@ -96,7 +192,7 @@ project layouts.**
 | AMD RX 9060 / XT                   | gfx1200    | gfx120X-all  | [rocm](#rocm-for-gfx120X-all) // [torch](#torch-for-gfx120X-all) // [jax](#jax-for-gfx120X-all)    |
 | AMD RX 9070 / XT                   | gfx1201    | gfx120X-all  | [rocm](#rocm-for-gfx120X-all) // [torch](#torch-for-gfx120X-all) // [jax](#jax-for-gfx120X-all)    |
 
-### Installing ROCm Python packages
+#### Installing ROCm Python packages
 
 We provide several Python packages which together form the complete ROCm SDK.
 
@@ -113,7 +209,7 @@ We provide several Python packages which together form the complete ROCm SDK.
 | `rocm-sdk-devel`     | OS-specific development tools                                      |
 | `rocm-sdk-libraries` | OS-specific libraries                                              |
 
-#### rocm for gfx94X-dcgpu
+##### rocm for gfx94X-dcgpu
 
 Supported devices in this family:
 
@@ -127,7 +223,7 @@ Install instructions:
 pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ "rocm[libraries,devel]"
 ```
 
-#### rocm for gfx950-dcgpu
+##### rocm for gfx950-dcgpu
 
 Supported devices in this family:
 
@@ -141,7 +237,7 @@ Install instructions:
 pip install --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ "rocm[libraries,devel]"
 ```
 
-#### rocm for gfx110X-all
+##### rocm for gfx110X-all
 
 Supported devices in this family:
 
@@ -158,7 +254,7 @@ Install instructions:
 pip install --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ "rocm[libraries,devel]"
 ```
 
-#### rocm for gfx1151
+##### rocm for gfx1151
 
 Supported devices in this family:
 
@@ -172,7 +268,7 @@ Install instructions:
 pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ "rocm[libraries,devel]"
 ```
 
-#### rocm for gfx120X-all
+##### rocm for gfx120X-all
 
 Supported devices in this family:
 
@@ -187,7 +283,7 @@ Install instructions:
 pip install --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ "rocm[libraries,devel]"
 ```
 
-### Using ROCm Python packages
+#### Using ROCm Python packages
 
 After installing the ROCm Python packages, you should see them in your
 environment:
@@ -254,7 +350,7 @@ Once you have verified your installation, you can continue to use it for
 standard ROCm development or install PyTorch, JAX, or another supported Python ML
 framework.
 
-### Installing PyTorch Python packages
+#### Installing PyTorch Python packages
 
 Using the index pages [listed above](#installing-rocm-python-packages), you can
 also install `torch`, `torchaudio`, `torchvision`, and `apex`.
@@ -303,7 +399,7 @@ also install `torch`, `torchaudio`, `torchvision`, and `apex`.
 >
 > The triton package is now named `triton`.
 
-#### torch for gfx94X-dcgpu
+##### torch for gfx94X-dcgpu
 
 Supported devices in this family:
 
@@ -317,7 +413,7 @@ pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ torch to
 #   apex
 ```
 
-#### torch for gfx950-dcgpu
+##### torch for gfx950-dcgpu
 
 Supported devices in this family:
 
@@ -331,7 +427,7 @@ pip install --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ torch to
 #   apex
 ```
 
-#### torch for gfx110X-all
+##### torch for gfx110X-all
 
 Supported devices in this family:
 
@@ -348,7 +444,7 @@ pip install --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ torch tor
 #   apex
 ```
 
-#### torch for gfx1151
+##### torch for gfx1151
 
 Supported devices in this family:
 
@@ -362,7 +458,7 @@ pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ torch torchau
 #   apex
 ```
 
-#### torch for gfx120X-all
+##### torch for gfx120X-all
 
 Supported devices in this family:
 
@@ -377,7 +473,7 @@ pip install --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ torch tor
 #   apex
 ```
 
-### Using PyTorch Python packages
+#### Using PyTorch Python packages
 
 After installing the `torch` package with ROCm support, PyTorch can be used
 normally:
@@ -395,7 +491,7 @@ See also the
 [Testing the PyTorch installation](https://rocm.docs.amd.com/projects/install-on-linux/en/develop/install/3rd-party/pytorch-install.html#testing-the-pytorch-installation)
 instructions in the AMD ROCm documentation.
 
-### Installing JAX Python packages
+#### Installing JAX Python packages
 
 Using the index pages [listed above](#installing-rocm-python-packages), you can
 also install `jaxlib`, `jax_rocm7_plugin`, and `jax_rocm7_pjrt`.
@@ -429,7 +525,7 @@ also install `jaxlib`, `jax_rocm7_plugin`, and `jax_rocm7_pjrt`.
 > pip install jax
 > ```
 
-#### jax for gfx94X-dcgpu
+##### jax for gfx94X-dcgpu
 
 Supported devices in this family:
 
@@ -443,7 +539,7 @@ pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ jaxlib j
 pip install jax
 ```
 
-#### jax for gfx950-dcgpu
+##### jax for gfx950-dcgpu
 
 Supported devices in this family:
 
@@ -457,7 +553,7 @@ pip install --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ jaxlib j
 pip install jax
 ```
 
-#### jax for gfx110X-all
+##### jax for gfx110X-all
 
 Supported devices in this family:
 
@@ -474,7 +570,7 @@ pip install --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ jaxlib ja
 pip install jax
 ```
 
-#### jax for gfx1151
+##### jax for gfx1151
 
 Supported devices in this family:
 
@@ -488,7 +584,7 @@ pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ jaxlib jax_ro
 pip install jax
 ```
 
-#### jax for gfx120X-all
+##### jax for gfx120X-all
 
 Supported devices in this family:
 
@@ -503,7 +599,7 @@ pip install --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ jaxlib ja
 pip install jax
 ```
 
-### Using JAX Python packages
+#### Using JAX Python packages
 
 After installing the JAX packages with ROCm support, JAX can be used normally:
 
@@ -517,7 +613,7 @@ print(jax.devices())
 For building JAX from source or running the full JAX test suite, see the
 [external-builds/jax README](/external-builds/jax/README.md).
 
-## Installing from tarballs
+### Installing from tarballs
 
 Standalone "ROCm SDK tarballs" are a flattened view of ROCm
 [artifacts](docs/development/artifacts.md) matching the familiar folder
@@ -544,10 +640,11 @@ such as setting environment variables.
 >
 > For most users, we recommend installing via package managers:
 >
-> - [Installing releases using pip](#installing-releases-using-pip)
+> - [Installing multi-arch releases using pip](#installing-multi-arch-rocm-python-packages)
+> - [Installing per-family releases using pip](#installing-per-family-releases-using-pip)
 > - [Installing from native packages](#installing-from-native-packages)
 
-### Browsing release tarballs
+#### Browsing release tarballs
 
 Release tarballs are uploaded to the following locations:
 
@@ -558,7 +655,7 @@ Release tarballs are uploaded to the following locations:
 | https://rocm.prereleases.amd.com/tarball/ | (not publicly accessible)                                                                | ⚠️ Prerelease builds for QA testing ⚠️             |
 | https://rocm.devreleases.amd.com/tarball/ | [`therock-dev-tarball`](https://therock-dev-tarball.s3.amazonaws.com/index.html)         | ⚠️ Development builds from project maintainers ⚠️  |
 
-### Manual tarball extraction
+#### Manual tarball extraction
 
 To download a tarball and extract it into place manually:
 
@@ -569,7 +666,7 @@ wget https://rocm.nightlies.amd.com/tarball/therock-dist-linux-gfx110X-all-7.12.
 mkdir install && tar -xf *.tar.gz -C install
 ```
 
-### Automated tarball extraction
+#### Automated tarball extraction
 
 For more control over artifact installation—including per-commit CI builds,
 specific release versions, the latest nightly release, and component
@@ -579,7 +676,7 @@ documentation. The
 [`install_rocm_from_artifacts.py`](build_tools/install_rocm_from_artifacts.py)
 script can be used to install artifacts from a variety of sources.
 
-### Using installed tarballs
+#### Using installed tarballs
 
 After installing (downloading and extracting) a tarball, you can test it by
 running programs from the `bin/` directory:
@@ -619,7 +716,7 @@ ls install
 > #     ...
 > ```
 
-## Installing from native packages
+### Installing from native packages
 
 In addition to Python wheels and tarballs, ROCm native Linux packages are
 published for Debian-based and RPM-based distributions.
@@ -627,14 +724,14 @@ published for Debian-based and RPM-based distributions.
 > [!WARNING]
 > These builds are primarily intended for development and testing and are currently **unsigned**.
 
-### Native packages release status
+#### Native packages release status
 
 | Platform |                                                                                                                                                                                                                                  Native packages |
 | -------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | Linux    | [![Build Native Linux Packages](https://github.com/ROCm/TheRock/actions/workflows/build_native_linux_packages.yml/badge.svg?branch=main)](https://github.com/ROCm/TheRock/actions/workflows/build_native_linux_packages.yml?query=branch%3Amain) |
 | Windows  |                                                                                                                                                                                                                                    (Coming soon) |
 
-### GPU family and package mapping
+#### GPU family and package mapping
 
 | Product Name                       | GFX Target | GFX Family | Runtime Package | Development Package      |
 | ---------------------------------- | ---------- | ---------- | --------------- | ------------------------ |
@@ -666,7 +763,7 @@ published for Debian-based and RPM-based distributions.
 > - **Step 2**: Look for directories in the format `YYYYMMDD-<action-run-id>` (e.g., `20260310-12345678`)
 > - **Step 3**: Use the latest date in the installation commands below
 
-### Installing on Debian-based systems (Ubuntu, Debian, etc.)
+#### Installing on Debian-based systems (Ubuntu, Debian, etc.)
 
 ```bash
 # Step 1: Find the latest release from https://rocm.nightlies.amd.com/deb/
@@ -688,7 +785,7 @@ sudo apt install amdrocm-core-sdk-${GFX_ARCH}
 # If only runtime is needed, install amdrocm-${GFX_ARCH} instead
 ```
 
-### Installing on RPM-based systems (RHEL, SLES, AlmaLinux etc.)
+#### Installing on RPM-based systems (RHEL, SLES, AlmaLinux etc.)
 
 > [!NOTE]
 > The following instructions are for RHEL-based operating systems.
@@ -719,13 +816,12 @@ sudo dnf install amdrocm-core-sdk-${GFX_ARCH}
 
 ## Verifying your installation
 
-After installing ROCm via either pip packages, tarballs or native packages, you can verify that
-your GPU is properly recognized.
+After installing ROCm via any of the methods above, you can verify that your
+GPU is properly recognized.
 
-### Linux
+### Verifying installation on Linux
 
-Run one of the following commands to verify that your GPU is detected and properly
-initialized by the ROCm stack:
+GPU status on Linux can be checked via either:
 
 ```bash
 rocminfo
@@ -733,15 +829,15 @@ rocminfo
 amd-smi
 ```
 
-### Windows
+### Verifying installation on Windows
 
-Run the following command to verify GPU detection:
+GPU status on Windows can be checked via
 
 ```bash
 hipInfo.exe
 ```
 
-### Additional troubleshooting
+### Additional installation troubleshooting
 
 If your GPU is not recognized or you encounter issues:
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -25,6 +25,7 @@ Table of contents:
   - [Multi-arch release status](#multi-arch-release-status)
   - [Installing multi-arch ROCm Python packages](#installing-multi-arch-rocm-python-packages)
   <!-- - [Installing multi-arch PyTorch Python packages](#installing-multi-arch-pytorch-python-packages) -->
+  - [Installing multi-arch tarballs](#installing-multi-arch-tarballs)
 - [Per-family releases](#per-family-releases)
   - [Installing per-family releases using pip](#installing-per-family-releases-using-pip)
     - [Python packages release status](#python-packages-release-status)
@@ -47,15 +48,25 @@ Table of contents:
 
 ## Multi-arch releases
 
-Multi-arch releases use a unified package index that serves all GPU architectures.
+> [!IMPORTANT]
+> We are introducing multi-arch releases with
+> [#3323](https://github.com/ROCm/TheRock/issues/3323). Rather than build
+> ROCm for GPU family subsets like the [per-family releases](#per-family-releases),
+> these multi-arch releases build all GPU architectures together and split
+> GPU-specific code (kernel packs) from architecture-neutral host code as a
+> packaging step.
+>
+> This new setup will streamline package installation, so please note the
+> differences in the install instructions.
 
-Benefits over [per-family releases](#per-family-releases):
+See this table for key differences between release types:
 
-- **One index URL** for all GPUs - no need to find the right per-family URL
-- **Smaller downloads** - GPU-specific code is split into separate device
-  packages, so you only download what you need
-- **Mix GPU targets** - install device packages for multiple GPUs in the same
-  environment
+|                      | Multi-arch releases                    | Per-family releases                    |
+| -------------------- | -------------------------------------- | -------------------------------------- |
+| GPU code separation  | Split into device packages / `.kpack`  | Bundled into each artifact             |
+| GPU selection        | Package extras/variants                | Chosen by index URL or tarball name    |
+| Multiple GPU targets | Install extras / use multiarch tarball | Separate venvs or tarballs per family  |
+| Download size        | Smaller per target                     | Larger (all targets in family bundled) |
 
 ### Multi-arch release status
 
@@ -85,8 +96,17 @@ Install ROCm with device support for your GPU using the unified index and one or
 more `device-gfx*` pip extras:
 
 ```bash
+# Note: this URL is expected to change soon
 pip install --extra-index-url https://rocm.nightlies.amd.com/v4/whl/ --pre "rocm[devel,device-gfx####]"
 ```
+
+<!-- TODO: Once dependencies are uploaded to the multi-arch index, replace
+     --extra-index-url with --index-url throughout this section. -->
+
+<!-- TODO: Update URL once the top-level CloudFront path is finalized
+     (e.g. https://rocm.nightlies.amd.com/whl-multi-arch/). -->
+
+<!-- TODO: Advertise wheel variants / WheelNext once available  -->
 
 Where `####` is the GFX target taken from the following table:
 
@@ -108,14 +128,6 @@ For example, install the gfx1100 device code like so:
 pip install --extra-index-url https://rocm.nightlies.amd.com/v4/whl/ --pre "rocm[devel,device-gfx1100]"
 ```
 
-<!-- TODO: Once dependencies are uploaded to the multi-arch index, replace
-     --extra-index-url with --index-url throughout this section. -->
-
-<!-- TODO: Update URL once the top-level CloudFront path is finalized
-     (e.g. https://rocm.nightlies.amd.com/whl-multi-arch/). -->
-
-<!-- TODO: Advertise wheel variants / WheelNext once available  -->
-
 After installing, verify your installation:
 
 ```bash
@@ -125,6 +137,41 @@ rocm-sdk test
 <!-- ### Installing multi-arch PyTorch Python packages -->
 
 <!-- TODO(#3332): Document torch packages once they are available in nightly releases -->
+
+### Installing multi-arch tarballs
+
+Standalone "ROCm SDK tarballs" are a flattened view of ROCm
+[artifacts](docs/development/artifacts.md) matching the familiar folder
+structure seen with system installs on Linux to `/opt/rocm/` or on Windows via
+the HIP SDK:
+
+```
+install/
+  .kpack/     # GPU-specific kernel packs (multi-arch only)
+  bin/
+  clients/
+  include/
+  lib/
+  libexec/
+  share/
+```
+
+Tarballs are _just_ these raw files. They do not come with "install" steps
+such as setting environment variables.
+
+Multi-arch tarballs separate GPU-specific kernel code into a `.kpack/`
+directory. Two variants are available:
+
+- **Per-family tarballs** (e.g. `therock-dist-linux-gfx110X-all-7.13.0a20260427.tar.gz`)
+  that include `.kpack` files only for one family.
+- **Multiarch tarball** (e.g. `therock-dist-linux-multiarch-7.13.0a20260427.tar.gz`)
+  that include `.kpack` files for all supported targets.
+
+> [!NOTE]
+> Multi-arch tarball releases are coming soon (index pages are not yet generated).
+
+<!-- TODO: Document tarball download/install once index pages are generated
+           and the CloudFront path is finalized. -->
 
 ## Per-family releases
 


### PR DESCRIPTION
Progress on https://github.com/ROCm/TheRock/issues/3323.

This documents what currently exists in nightly releases generated by https://github.com/ROCm/rockrel/actions/workflows/multi_arch_release.yml. Notably, what's missing is:
* ROCm tarballs do not yet have index pages generated so they are difficult to discover and download
* Torch python packages are not yet integrated into nightly release workflows
* Native ROCm linux packages are not yet integrated into nightly release workflows

I opted to put the new documentation at the top of RELEASES.md. We could instead put it at the bottom or interleave section by section.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
