### PR TITLE
[hipdnn] Remove stale spdlog from artifact_deps (ALMIOPEN-1796)

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -615,7 +615,7 @@ split_databases = ["miopen"]
 [artifacts.hipdnn]
 artifact_group = "ml-libs"
 type = "target-neutral"
-artifact_deps = ["core-runtime", "core-hip", "spdlog"]
+artifact_deps = ["core-runtime", "core-hip"]
 
 [artifacts.hipdnn-integration-tests]
 artifact_group = "ml-libs"


### PR DESCRIPTION
## Summary

PR #3609 already moved `spdlog`/`fmt` to BUILD_DEPS in hipdnn and removed the artifact exports, but `BUILD_TOPOLOGY.toml` still declared `"spdlog"` as a hipdnn `artifact_dep`. This drops the stale entry so the artifact graph reflects reality.

One-line config change. The `flatbuffers` runtime export stays — samples/tests still need flatc.

## Test plan

- [x] TOML syntax validates (`python3 -c "import tomllib; tomllib.load(open('BUILD_TOPOLOGY.toml','rb'))"`)
- [x] No other stale `spdlog` references in `[artifacts.hipdnn]` (other matches in file are unrelated artifacts that legitimately depend on spdlog)
- [ ] CI green on this branch

[ALMIOPEN-1796]: https://amd-hub.atlassian.net/browse/ALMIOPEN-1796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ