### PR TITLE
Add multi-arch PyTorch release workflows

### DIFF
--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -117,20 +117,16 @@ jobs:
   # TODO: dispatch test artifacts per family (add workflow_dispatch to
   #   test_artifacts.yml, then use benc-uk/workflow-dispatch here)
 
-  dispatch_pytorch_wheels:
+  # TODO: Consider switch pulling ROCm packages from the CDN instead of the artifact
+  #   bucket if the job order is not altered.
+  build_pytorch_wheels:
     needs: [build_artifacts, build_python_packages]
-    name: Dispatch PyTorch Wheels
+    name: Build PyTorch Wheel
     runs-on: ubuntu-24.04
     permissions:
       actions: write
     steps:
-      # benc-uk/workflow-dispatch dispatches via the GitHub API; no local
-      # checkout needed. ref: selects which version of the workflow YAML
-      # to run (branch or tag name; SHAs may be rejected). The "ref"
-      # input inside `inputs:` is plumbed through to the dispatched
-      # workflow's actions/checkout, which accepts branches, tags, or
-      # SHAs.
-      - name: Dispatch multi_arch_release_linux_pytorch_wheels.yml
+      - name: Trigger PyTorch Build
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:
           workflow: multi_arch_release_linux_pytorch_wheels.yml

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -117,6 +117,37 @@ jobs:
   # TODO: dispatch test artifacts per family (add workflow_dispatch to
   #   test_artifacts.yml, then use benc-uk/workflow-dispatch here)
 
-  # TODO: dispatch pytorch wheels (release_portable_linux_pytorch_wheels.yml)
+  dispatch_pytorch_wheels:
+    needs: [build_artifacts, build_python_packages]
+    name: Dispatch PyTorch Wheels
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      # gh workflow run --ref selects which version of the workflow YAML
+      # to execute and accepts a branch or tag name (commit SHAs may be
+      # rejected). github.ref_name is the short branch/tag name that
+      # triggered this workflow's run. The -f ref input is plumbed
+      # through to the dispatched workflow's actions/checkout, which
+      # accepts branches, tags, or SHAs.
+      - name: Dispatch multi_arch_release_linux_pytorch_wheels.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run multi_arch_release_linux_pytorch_wheels.yml \
+            --ref "${{ inputs.ref || github.ref_name }}" \
+            -f amdgpu_families="${{ fromJSON(inputs.build_config).dist_amdgpu_families }}" \
+            -f rocm_version="${{ inputs.rocm_package_version }}" \
+            -f rocm_package_find_links_url="${{ needs.build_python_packages.outputs.package_find_links_url }}" \
+            -f release_type="${{ inputs.release_type }}" \
+            -f repository="${{ inputs.repository || github.repository }}" \
+            -f ref="${{ inputs.ref }}"
 
   # TODO: dispatch jax wheels (release_portable_linux_jax_wheels.yml)

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -123,31 +123,25 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       actions: write
-      contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref }}
-
-      # gh workflow run --ref selects which version of the workflow YAML
-      # to execute and accepts a branch or tag name (commit SHAs may be
-      # rejected). github.ref_name is the short branch/tag name that
-      # triggered this workflow's run. The -f ref input is plumbed
-      # through to the dispatched workflow's actions/checkout, which
-      # accepts branches, tags, or SHAs.
+      # benc-uk/workflow-dispatch dispatches via the GitHub API; no local
+      # checkout needed. ref: selects which version of the workflow YAML
+      # to run (branch or tag name; SHAs may be rejected). The "ref"
+      # input inside `inputs:` is plumbed through to the dispatched
+      # workflow's actions/checkout, which accepts branches, tags, or
+      # SHAs.
       - name: Dispatch multi_arch_release_linux_pytorch_wheels.yml
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh workflow run multi_arch_release_linux_pytorch_wheels.yml \
-            --ref "${{ inputs.ref || github.ref_name }}" \
-            -f amdgpu_families="${{ fromJSON(inputs.build_config).dist_amdgpu_families }}" \
-            -f rocm_version="${{ inputs.rocm_package_version }}" \
-            -f rocm_package_find_links_url="${{ needs.build_python_packages.outputs.package_find_links_url }}" \
-            -f release_type="${{ inputs.release_type }}" \
-            -f repository="${{ inputs.repository || github.repository }}" \
-            -f ref="${{ inputs.ref }}"
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
+        with:
+          workflow: multi_arch_release_linux_pytorch_wheels.yml
+          ref: ${{ inputs.ref || github.ref_name }}
+          inputs: |
+            { "amdgpu_families": "${{ fromJSON(inputs.build_config).dist_amdgpu_families }}",
+              "rocm_version": "${{ inputs.rocm_package_version }}",
+              "rocm_package_find_links_url": "${{ needs.build_python_packages.outputs.package_find_links_url }}",
+              "release_type": "${{ inputs.release_type }}",
+              "repository": "${{ inputs.repository || github.repository }}",
+              "ref": "${{ inputs.ref || '' }}"
+            }
 
   # TODO: dispatch jax wheels (release_portable_linux_jax_wheels.yml)

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -13,7 +13,7 @@
 #     (server-side indexing handles the index page).
 #
 # Triggered exclusively via workflow_dispatch from
-# multi_arch_release_linux.yml's dispatch_pytorch_wheels job (gh workflow run).
+# multi_arch_release_linux.yml's dispatch_pytorch_wheels job.
 #
 # Build phase only: testing and promotion are deferred follow-ups.
 # See https://github.com/ROCm/TheRock/issues/3291 for convergence plans.
@@ -247,9 +247,6 @@ jobs:
         with:
           release_type: ${{ inputs.release_type }}
 
-      # boto3 is already installed via external-builds/pytorch/requirements-ci.txt
-      # earlier in the job. The publish_pytorch_to_staging.py helper uses
-      # _therock_utils.storage_backend (boto3 + stdlib only).
       - name: Upload PyTorch wheels to release-bucket staging
         run: |
           python build_tools/github_actions/publish_pytorch_to_staging.py \

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -1,0 +1,257 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Multi-arch release variant of build_portable_linux_pytorch_wheels_ci.yml.
+#
+# Built shape:
+#   - One fat build_prod_wheels.py invocation per (python_version,
+#     pytorch_git_ref) matrix cell, covering all gfx targets expanded
+#     from the inputs.amdgpu_families set.
+#   - kpack-split the resulting fat torch wheel into a host wheel plus
+#     per-gfx amd-torch-device-* wheels.
+#   - Upload the result to s3://therock-{release_type}-python/v4/whl-staging/
+#     (server-side indexing handles the index page).
+#
+# Triggered exclusively via workflow_dispatch from
+# multi_arch_release_linux.yml's dispatch_pytorch_wheels job (gh workflow run).
+#
+# Build phase only: testing and promotion are deferred follow-ups.
+# See https://github.com/ROCm/TheRock/issues/3291 for convergence plans.
+
+name: Multi-Arch Release Linux PyTorch Wheels
+
+on:
+  workflow_dispatch:
+    inputs:
+      amdgpu_families:
+        description: >-
+          Semicolon-separated list of AMD GPU families to build PyTorch for
+          (e.g. 'gfx94X-dcgpu;gfx120X-all'). Expanded to gfx targets at
+          build time via cmake/therock_amdgpu_targets.cmake.
+        type: string
+        required: true
+      rocm_version:
+        description: ROCm package version to install and build against (e.g. 7.10.0.dev0)
+        type: string
+        required: true
+      rocm_package_find_links_url:
+        description: URL for pip --find-links to install ROCm packages
+        type: string
+        required: true
+      release_type:
+        description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
+        type: string
+        required: true
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+        default: ""
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
+      cache_type:
+        description: "Compiler cache type"
+        type: choice
+        options:
+          - none
+          - sccache
+          - ccache
+        default: none
+
+run-name: Multi-Arch Release Linux PyTorch Wheels (${{ inputs.amdgpu_families }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
+
+permissions:
+  contents: read
+
+jobs:
+  build_pytorch_wheels:
+    name: Build | py ${{ matrix.python_version }} | torch ${{ matrix.pytorch_git_ref }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        pytorch_git_ref: ["release/2.8", "release/2.9", "release/2.10", "release/2.11", "nightly"]
+        exclude:
+          # Python 3.14 support was added in PyTorch 2.9.
+          - pytorch_git_ref: "release/2.8"
+            python_version: "3.14"
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+    permissions:
+      id-token: write
+      contents: read
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
+    env:
+      PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
+      optional_build_prod_arguments: ""
+      SCCACHE_BUCKET: "therock-${{ inputs.release_type }}-pytorch-sccache"
+      SCCACHE_REGION: us-east-2
+      SCCACHE_S3_KEY_PREFIX: "linux/multiarch/"
+      SCCACHE_S3_USE_SSL: "true"
+      SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
+      SCCACHE_IDLE_TIMEOUT: "600"
+      SCCACHE_LOG: warn
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      - name: Configure Git Identity
+        run: |
+          git config --global user.name "therockbot"
+          git config --global user.email "therockbot@amd.com"
+
+      - name: Select Python version
+        run: |
+          python build_tools/github_actions/python_to_cp_version.py \
+            --python-version ${{ matrix.python_version }}
+
+      - name: Add selected Python version to PATH
+        run: |
+          python_dir="/opt/python/${{ env.cp_version }}"
+          if ! [ -x "${python_dir}/bin/python" ]; then
+            echo "ERROR: Could not find python: ${python_dir}"
+            exit 1
+          fi
+          echo "${python_dir}/bin" >> "$GITHUB_PATH"
+
+      - name: Install python deps for CI
+        run: |
+          pip install -r external-builds/pytorch/requirements-ci.txt
+
+      - name: Checkout PyTorch source (nightly)
+        if: ${{ matrix.pytorch_git_ref == 'nightly' }}
+        run: |
+          ./external-builds/pytorch/pytorch_torch_repo.py checkout \
+            --repo-hashtag nightly
+
+      - name: Checkout PyTorch source (stable)
+        if: ${{ matrix.pytorch_git_ref != 'nightly' }}
+        run: |
+          ./external-builds/pytorch/pytorch_torch_repo.py checkout \
+            --gitrepo-origin https://github.com/ROCm/pytorch.git \
+            --repo-hashtag ${{ matrix.pytorch_git_ref }}
+
+      # determine_version.py sets optional_build_prod_arguments in
+      # GITHUB_ENV (--rocm-sdk-version, --version-suffix).
+      - name: Determine optional arguments passed to `build_prod_wheels.py`
+        run: |
+          python build_tools/github_actions/determine_version.py \
+            --rocm-version ${{ inputs.rocm_version }}
+
+      - name: Configure AWS Credentials for sccache
+        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}
+
+      - name: Verify sccache
+        if: ${{ inputs.cache_type == 'sccache' }}
+        run: |
+          echo "sccache version: $(sccache --version)"
+          echo "SCCACHE_BUCKET=${SCCACHE_BUCKET}"
+          echo "SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX}"
+
+      - name: Expand amdgpu families to gfx targets
+        id: expand
+        run: |
+          targets=$(python build_tools/github_actions/expand_amdgpu_families.py \
+            --amdgpu-families "${{ inputs.amdgpu_families }}")
+          echo "Expanded families '${{ inputs.amdgpu_families }}' -> '${targets}'"
+          echo "targets=${targets}" >> "$GITHUB_OUTPUT"
+
+      - name: Build PyTorch wheels
+        run: |
+          cache_flag=""
+          if [ "${{ inputs.cache_type }}" = "sccache" ]; then
+            cache_flag="--use-sccache"
+          elif [ "${{ inputs.cache_type }}" = "ccache" ]; then
+            cache_flag="--use-ccache"
+          fi
+
+          ./external-builds/pytorch/build_prod_wheels.py \
+            build \
+            --install-rocm \
+            --find-links "${{ inputs.rocm_package_find_links_url }}" \
+            --clean \
+            --output-dir ${{ env.PACKAGE_DIST_DIR }} \
+            ${cache_flag} \
+            --pytorch-rocm-arch ${{ steps.expand.outputs.targets }} \
+            ${{ env.optional_build_prod_arguments }}
+
+      - name: Report cache stats
+        if: ${{ !cancelled() && inputs.cache_type != 'none' }}
+        run: |
+          if [ "${{ inputs.cache_type }}" = "sccache" ]; then
+            echo "sccache stats:"
+            echo "--------------"
+            sccache --show-stats || true
+          elif [ "${{ inputs.cache_type }}" = "ccache" ]; then
+            echo "ccache stats:"
+            echo "-------------"
+            ccache -s -v || true
+          fi
+
+      - name: Sanity check wheel
+        run: |
+          python external-builds/pytorch/sanity_check_wheel.py \
+            ${{ env.PACKAGE_DIST_DIR }}/
+
+      # The kpack wheel splitter takes the fat torch wheel and produces a
+      # smaller host wheel plus one device wheel per gfx target. Source-install
+      # from the TheRock checkout - kpack has no published wheel today.
+      # The outer actions/checkout skips submodules for speed, so pull in
+      # rocm-systems only when we actually need it.
+      - name: Init rocm-systems submodule
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git submodule update --init --depth=1 rocm-systems
+
+      - name: Install kpack tooling
+        run: |
+          pip install \
+            -e rocm-systems/python/rocm-bootstrap \
+            -e rocm-systems/shared/kpack
+
+      - name: Split PyTorch fat wheel
+        run: |
+          # The splitter writes the host wheel under the same filename as
+          # the input, so relocate the fat wheel out of PACKAGE_DIST_DIR
+          # first.
+          FAT_STAGE="${RUNNER_TEMP:-/tmp}/pytorch-fat"
+          mkdir -p "${FAT_STAGE}"
+          mv ${{ env.PACKAGE_DIST_DIR }}/torch-*.whl "${FAT_STAGE}/"
+
+          ROCM_SDK_VERSION="$(python -m rocm_sdk version)"
+
+          python -m rocm_kpack.tools.split_python_wheels \
+            --input "${FAT_STAGE}"/torch-*.whl \
+            --output-dir "${{ env.PACKAGE_DIST_DIR }}" \
+            --device-package-prefix amd-torch-device \
+            --overlay-root torch/ \
+            --wheel-type torch-fat \
+            --device-requires-dist "rocm-sdk-device-@GFXARCH@ == ${ROCM_SDK_VERSION}" \
+            --compression zstd \
+            -j "$(nproc)"
+
+          rm -rf "${FAT_STAGE}"
+          echo "Post-split contents of ${{ env.PACKAGE_DIST_DIR }}:"
+          ls -lh "${{ env.PACKAGE_DIST_DIR }}/"
+
+      - name: Configure AWS Credentials
+        uses: ./.github/actions/configure_aws_artifacts_credentials
+        with:
+          release_type: ${{ inputs.release_type }}
+
+      # boto3 is already installed via external-builds/pytorch/requirements-ci.txt
+      # earlier in the job. The publish_pytorch_to_staging.py helper uses
+      # _therock_utils.storage_backend (boto3 + stdlib only).
+      - name: Upload PyTorch wheels to release-bucket staging
+        run: |
+          python build_tools/github_actions/publish_pytorch_to_staging.py \
+            --source-dir="${{ env.PACKAGE_DIST_DIR }}" \
+            --release-type="${{ inputs.release_type }}"

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -114,20 +114,16 @@ jobs:
 
   # TODO: dispatch test artifacts per family
 
-  dispatch_pytorch_wheels:
+  # TODO: Consider switch pulling ROCm packages from the CDN instead of the artifact
+  #   bucket if the job order is not altered.
+  build_pytorch_wheels:
     needs: [build_artifacts, build_python_packages]
-    name: Dispatch PyTorch Wheels
+    name: Build PyTorch Wheels
     runs-on: ubuntu-24.04
     permissions:
       actions: write
     steps:
-      # benc-uk/workflow-dispatch dispatches via the GitHub API; no local
-      # checkout needed. ref: selects which version of the workflow YAML
-      # to run (branch or tag name; SHAs may be rejected). The "ref"
-      # input inside `inputs:` is plumbed through to the dispatched
-      # workflow's actions/checkout, which accepts branches, tags, or
-      # SHAs.
-      - name: Dispatch multi_arch_release_windows_pytorch_wheels.yml
+      - name: Trigger PyTorch Build
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:
           workflow: multi_arch_release_windows_pytorch_wheels.yml

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -120,29 +120,23 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       actions: write
-      contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref }}
-
-      # gh workflow run --ref selects which version of the workflow YAML
-      # to execute and accepts a branch or tag name (commit SHAs may be
-      # rejected). github.ref_name is the short branch/tag name that
-      # triggered this workflow's run. The -f ref input is plumbed
-      # through to the dispatched workflow's actions/checkout, which
-      # accepts branches, tags, or SHAs.
+      # benc-uk/workflow-dispatch dispatches via the GitHub API; no local
+      # checkout needed. ref: selects which version of the workflow YAML
+      # to run (branch or tag name; SHAs may be rejected). The "ref"
+      # input inside `inputs:` is plumbed through to the dispatched
+      # workflow's actions/checkout, which accepts branches, tags, or
+      # SHAs.
       - name: Dispatch multi_arch_release_windows_pytorch_wheels.yml
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh workflow run multi_arch_release_windows_pytorch_wheels.yml \
-            --ref "${{ inputs.ref || github.ref_name }}" \
-            -f amdgpu_families="${{ fromJSON(inputs.build_config).dist_amdgpu_families }}" \
-            -f rocm_version="${{ inputs.rocm_package_version }}" \
-            -f rocm_package_find_links_url="${{ needs.build_python_packages.outputs.package_find_links_url }}" \
-            -f release_type="${{ inputs.release_type }}" \
-            -f repository="${{ inputs.repository || github.repository }}" \
-            -f ref="${{ inputs.ref }}"
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
+        with:
+          workflow: multi_arch_release_windows_pytorch_wheels.yml
+          ref: ${{ inputs.ref || github.ref_name }}
+          inputs: |
+            { "amdgpu_families": "${{ fromJSON(inputs.build_config).dist_amdgpu_families }}",
+              "rocm_version": "${{ inputs.rocm_package_version }}",
+              "rocm_package_find_links_url": "${{ needs.build_python_packages.outputs.package_find_links_url }}",
+              "release_type": "${{ inputs.release_type }}",
+              "repository": "${{ inputs.repository || github.repository }}",
+              "ref": "${{ inputs.ref || '' }}"
+            }

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -113,4 +113,36 @@ jobs:
             --kpack-split="${{ needs.build_python_packages.outputs.kpack_split }}"
 
   # TODO: dispatch test artifacts per family
-  # TODO: dispatch pytorch wheels
+
+  dispatch_pytorch_wheels:
+    needs: [build_artifacts, build_python_packages]
+    name: Dispatch PyTorch Wheels
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      # gh workflow run --ref selects which version of the workflow YAML
+      # to execute and accepts a branch or tag name (commit SHAs may be
+      # rejected). github.ref_name is the short branch/tag name that
+      # triggered this workflow's run. The -f ref input is plumbed
+      # through to the dispatched workflow's actions/checkout, which
+      # accepts branches, tags, or SHAs.
+      - name: Dispatch multi_arch_release_windows_pytorch_wheels.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run multi_arch_release_windows_pytorch_wheels.yml \
+            --ref "${{ inputs.ref || github.ref_name }}" \
+            -f amdgpu_families="${{ fromJSON(inputs.build_config).dist_amdgpu_families }}" \
+            -f rocm_version="${{ inputs.rocm_package_version }}" \
+            -f rocm_package_find_links_url="${{ needs.build_python_packages.outputs.package_find_links_url }}" \
+            -f release_type="${{ inputs.release_type }}" \
+            -f repository="${{ inputs.repository || github.repository }}" \
+            -f ref="${{ inputs.ref }}"

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -1,0 +1,303 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Multi-arch release variant of build_windows_pytorch_wheels_ci.yml.
+#
+# Built shape:
+#   - One fat build_prod_wheels.py invocation per (python_version,
+#     pytorch_git_ref) matrix cell, covering all gfx targets expanded
+#     from the inputs.amdgpu_families set.
+#   - kpack-split the resulting fat torch wheel into a host wheel plus
+#     per-gfx amd-torch-device-* wheels.
+#   - Upload the result to s3://therock-{release_type}-python/v4/whl-staging/
+#     (server-side indexing handles the index page) via
+#     publish_pytorch_to_staging.py.
+#
+# Triggered exclusively via workflow_dispatch from
+# multi_arch_release_windows.yml's dispatch_pytorch_wheels job
+# (gh workflow run).
+#
+# Build phase only: testing and promotion are deferred follow-ups.
+# See https://github.com/ROCm/TheRock/issues/3291 for convergence plans.
+
+name: Multi-Arch Release Windows PyTorch Wheels
+
+on:
+  workflow_dispatch:
+    inputs:
+      amdgpu_families:
+        description: >-
+          Semicolon-separated list of AMD GPU families to build PyTorch for
+          (e.g. 'gfx110X-all;gfx120X-all'). Expanded to gfx targets at
+          build time via cmake/therock_amdgpu_targets.cmake.
+        type: string
+        required: true
+      rocm_version:
+        description: ROCm package version to install and build against (e.g. 7.10.0.dev0)
+        type: string
+        required: true
+      rocm_package_find_links_url:
+        description: URL for pip --find-links to install ROCm packages
+        type: string
+        required: true
+      release_type:
+        description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
+        type: string
+        required: true
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+        default: ""
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
+      cache_type:
+        description: "Compiler cache type"
+        type: choice
+        options:
+          - none
+          - sccache
+          - ccache
+        default: none
+
+run-name: Multi-Arch Release Windows PyTorch Wheels (${{ inputs.amdgpu_families }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
+
+permissions:
+  contents: read
+
+jobs:
+  build_pytorch_wheels:
+    name: Build | py ${{ matrix.python_version }} | torch ${{ matrix.pytorch_git_ref }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        pytorch_git_ref: ["release/2.9", "release/2.10", "release/2.11", "nightly"]
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-windows-scale-rocm' || 'windows-2022' }}
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CHECKOUT_ROOT: B:/src
+      # Note the \ here instead of /. This should be used from 'cmd' not 'bash'!
+      PACKAGE_DIST_DIR: ${{ github.workspace }}\output\packages\dist
+      optional_build_prod_arguments: ""
+      SCCACHE_BUCKET: "therock-${{ inputs.release_type }}-pytorch-sccache"
+      SCCACHE_REGION: us-east-2
+      SCCACHE_S3_KEY_PREFIX: "windows/multiarch/"
+      SCCACHE_S3_USE_SSL: "true"
+      SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
+      SCCACHE_IDLE_TIMEOUT: "600"
+      SCCACHE_LOG: warn
+    defaults:
+      run:
+        # Note: there are mixed uses of 'bash' (this default) and 'cmd' below
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      - name: Configure Git Identity
+        run: |
+          git config --global user.name "therockbot"
+          git config --global user.email "therockbot@amd.com"
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - name: Select Python version
+        run: |
+          python build_tools/github_actions/python_to_cp_version.py \
+            --python-version ${{ matrix.python_version }}
+
+      # TODO(amd-justchen): share with build_windows_artifacts.yml. Include in VM image? Dockerfile?
+      - name: Install requirements
+        run: |
+          choco source disable -n=chocolatey
+          choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
+          choco install --no-progress -y ninja --version 1.13.1
+
+      - name: Install sccache
+        if: ${{ inputs.cache_type == 'sccache' }}
+        run: |
+          choco install --no-progress -y sccache
+          echo "sccache version: $(sccache --version)"
+
+      # After other installs, so MSVC gets priority in the PATH.
+      - name: Configure MSVC
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      - name: Install python deps for CI
+        run: |
+          pip install -r external-builds/pytorch/requirements-ci.txt
+
+      - name: Checkout PyTorch source (nightly)
+        if: ${{ matrix.pytorch_git_ref == 'nightly' }}
+        run: |
+          git config --global core.longpaths true
+          python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
+            --checkout-dir ${{ env.CHECKOUT_ROOT }}/torch \
+            --repo-hashtag nightly
+
+      - name: Checkout PyTorch source (stable)
+        if: ${{ matrix.pytorch_git_ref != 'nightly' }}
+        run: |
+          git config --global core.longpaths true
+          python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
+            --checkout-dir ${{ env.CHECKOUT_ROOT }}/torch \
+            --gitrepo-origin https://github.com/ROCm/pytorch.git \
+            --repo-hashtag ${{ matrix.pytorch_git_ref }}
+
+      # determine_version.py sets optional_build_prod_arguments in
+      # GITHUB_ENV (--rocm-sdk-version, --version-suffix).
+      - name: Determine optional arguments passed to `build_prod_wheels.py`
+        run: |
+          python build_tools/github_actions/determine_version.py \
+            --rocm-version ${{ inputs.rocm_version }}
+
+      - name: Configure AWS Credentials for sccache
+        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-${{ inputs.release_type }}
+          special-characters-workaround: true
+
+      - name: Verify sccache
+        if: ${{ inputs.cache_type == 'sccache' }}
+        run: |
+          echo "sccache version: $(sccache --version)"
+          echo "SCCACHE_BUCKET=${SCCACHE_BUCKET}"
+          echo "SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX}"
+
+      - name: Expand amdgpu families to gfx targets
+        id: expand
+        run: |
+          targets=$(python build_tools/github_actions/expand_amdgpu_families.py \
+            --amdgpu-families "${{ inputs.amdgpu_families }}")
+          echo "Expanded families '${{ inputs.amdgpu_families }}' -> '${targets}'"
+          echo "targets=${targets}" >> "$GITHUB_OUTPUT"
+
+      # Using 'cmd' here is load bearing! There are configuration issues when
+      # run under 'bash': https://github.com/ROCm/TheRock/issues/827#issuecomment-3025858800
+      - name: Build PyTorch wheels
+        shell: cmd
+        run: |
+          set "CACHE_FLAG="
+          if "${{ inputs.cache_type }}"=="sccache" set "CACHE_FLAG=--use-sccache"
+          if "${{ inputs.cache_type }}"=="ccache" set "CACHE_FLAG=--use-ccache"
+
+          echo "Building PyTorch wheels for ${{ inputs.amdgpu_families }} (cache: ${{ inputs.cache_type }})"
+          python ./external-builds/pytorch/build_prod_wheels.py ^
+            build ^
+            --install-rocm ^
+            --find-links "${{ inputs.rocm_package_find_links_url }}" ^
+            --pytorch-dir ${{ env.CHECKOUT_ROOT }}/torch ^
+            --enable-pytorch-flash-attention-windows ^
+            --clean ^
+            --output-dir ${{ env.PACKAGE_DIST_DIR }} ^
+            %CACHE_FLAG% ^
+            --pytorch-rocm-arch ${{ steps.expand.outputs.targets }} ^
+            ${{ env.optional_build_prod_arguments }}
+
+      - name: Report cache stats
+        if: ${{ !cancelled() && inputs.cache_type != 'none' }}
+        run: |
+          if [ "${{ inputs.cache_type }}" = "sccache" ]; then
+            echo "sccache stats:"
+            echo "--------------"
+            sccache --show-stats || true
+          elif [ "${{ inputs.cache_type }}" = "ccache" ]; then
+            echo "ccache stats:"
+            echo "-------------"
+            ccache -s -v || true
+          fi
+
+      - name: Sanity check wheel
+        shell: cmd
+        run: |
+          python external-builds/pytorch/sanity_check_wheel.py ${{ env.PACKAGE_DIST_DIR }}
+
+      # The kpack wheel splitter takes the fat torch wheel and produces a
+      # smaller host wheel plus one device wheel per gfx target. Source-install
+      # from the TheRock checkout - kpack has no published wheel today.
+      # The outer actions/checkout skips submodules for speed, so pull in
+      # rocm-systems only when we actually need it.
+      - name: Init rocm-systems submodule
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git submodule update --init --depth=1 rocm-systems
+
+      - name: Install kpack tooling
+        run: |
+          pip install \
+            -e rocm-systems/python/rocm-bootstrap \
+            -e rocm-systems/shared/kpack
+
+      - name: Split PyTorch fat wheel
+        run: |
+          DIST_DIR="$(cygpath -u "${{ env.PACKAGE_DIST_DIR }}")"
+
+          # LLVM binaries ship inside the already-installed rocm-sdk-devel.
+          ROCM_SDK_ROOT="$(cygpath -u "$(python -m rocm_sdk path --root)")"
+          LLVM_BIN="${ROCM_SDK_ROOT}/lib/llvm/bin"
+          if [ ! -d "${LLVM_BIN}" ]; then
+            echo "ERROR: LLVM bin dir not found: ${LLVM_BIN}" >&2
+            exit 1
+          fi
+
+          # The kpack Toolchain strictly looks up "objcopy" and "readelf" on
+          # PATH. On Windows, ROCm ships only llvm-objcopy.exe /
+          # llvm-readelf.exe, so stage copies under the unprefixed names.
+          # TODO: drop this shim once rocm-kpack's Toolchain adds llvm-*
+          # fallbacks for objcopy/readelf (parallels its existing objdump
+          # pattern). See https://github.com/ROCm/rocm-systems/issues/5506.
+          SHIMS="$(cygpath -u "${RUNNER_TEMP}")/kpack-shims"
+          mkdir -p "${SHIMS}"
+          cp "${LLVM_BIN}/llvm-objcopy.exe" "${SHIMS}/objcopy.exe"
+          cp "${LLVM_BIN}/llvm-readelf.exe" "${SHIMS}/readelf.exe"
+
+          # Prepend shims + LLVM bin so clang-offload-bundler.exe and the
+          # llvm-objdump fallback are also resolvable.
+          export PATH="${SHIMS}:${LLVM_BIN}:${PATH}"
+
+          # The splitter writes the host wheel under the same filename as the
+          # input, so relocate the fat wheel out of PACKAGE_DIST_DIR first.
+          FAT_STAGE="$(cygpath -u "${RUNNER_TEMP}")/pytorch-fat"
+          mkdir -p "${FAT_STAGE}"
+          mv "${DIST_DIR}"/torch-*.whl "${FAT_STAGE}/"
+
+          ROCM_SDK_VERSION="$(python -m rocm_sdk version)"
+
+          python -m rocm_kpack.tools.split_python_wheels \
+            --input "${FAT_STAGE}"/torch-*.whl \
+            --output-dir "${DIST_DIR}" \
+            --device-package-prefix amd-torch-device \
+            --overlay-root torch/ \
+            --wheel-type torch-fat \
+            --device-requires-dist "rocm-sdk-device-@GFXARCH@ == ${ROCM_SDK_VERSION}" \
+            --compression zstd \
+            -j 32
+
+          rm -rf "${FAT_STAGE}"
+          echo "Post-split contents of ${DIST_DIR}:"
+          ls -lh "${DIST_DIR}/"
+
+      - name: Configure AWS Credentials
+        uses: ./.github/actions/configure_aws_artifacts_credentials
+        with:
+          release_type: ${{ inputs.release_type }}
+
+      # boto3 is already installed via external-builds/pytorch/requirements-ci.txt
+      # earlier in the job. The publish_pytorch_to_staging.py helper uses
+      # _therock_utils.storage_backend (boto3 + stdlib only).
+      - name: Upload PyTorch wheels to release-bucket staging
+        run: |
+          python build_tools/github_actions/publish_pytorch_to_staging.py \
+            --source-dir="${{ env.PACKAGE_DIST_DIR }}" \
+            --release-type="${{ inputs.release_type }}"

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -14,8 +14,7 @@
 #     publish_pytorch_to_staging.py.
 #
 # Triggered exclusively via workflow_dispatch from
-# multi_arch_release_windows.yml's dispatch_pytorch_wheels job
-# (gh workflow run).
+# multi_arch_release_windows.yml's dispatch_pytorch_wheels job.
 #
 # Build phase only: testing and promotion are deferred follow-ups.
 # See https://github.com/ROCm/TheRock/issues/3291 for convergence plans.
@@ -293,9 +292,6 @@ jobs:
         with:
           release_type: ${{ inputs.release_type }}
 
-      # boto3 is already installed via external-builds/pytorch/requirements-ci.txt
-      # earlier in the job. The publish_pytorch_to_staging.py helper uses
-      # _therock_utils.storage_backend (boto3 + stdlib only).
       - name: Upload PyTorch wheels to release-bucket staging
         run: |
           python build_tools/github_actions/publish_pytorch_to_staging.py \

--- a/build_tools/github_actions/publish_pytorch_to_staging.py
+++ b/build_tools/github_actions/publish_pytorch_to_staging.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Upload PyTorch wheels from a local directory to release-bucket staging.
+
+Used by the multi-arch release Linux PyTorch wheels workflow to push the
+host wheel and per-gfx amd-torch-device-* wheels produced by the kpack
+splitter into the release bucket's staging path. A future test workflow
+consumes this path; a future promotion workflow copies it into v4/whl/.
+
+Example with ``--source-dir /tmp/dist --release-type dev``::
+
+    /tmp/dist/torch-2.10.0+rocm7.10.0-cp312-cp312-linux_x86_64.whl
+    /tmp/dist/amd-torch-device-gfx942-2.10.0+rocm7.10.0-py3-none-linux_x86_64.whl
+      -> s3://therock-dev-python/v4/whl-staging/torch-...whl
+      -> s3://therock-dev-python/v4/whl-staging/amd-torch-device-...whl
+
+Test usage::
+
+    python build_tools/github_actions/publish_pytorch_to_staging.py \\
+        --source-dir /tmp/dist --release-type dev --dry-run
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+_BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_BUILD_TOOLS_DIR))
+
+from _therock_utils.s3_buckets import get_release_bucket_config
+from _therock_utils.storage_backend import create_storage_backend
+from _therock_utils.storage_location import StorageLocation
+
+logger = logging.getLogger(__name__)
+
+_STAGING_SUBDIR = "v4/whl-staging"
+
+
+def main(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(
+        description="Upload PyTorch wheels to release-bucket staging"
+    )
+    parser.add_argument(
+        "--source-dir",
+        required=True,
+        type=Path,
+        help="Local directory containing the wheels to upload",
+    )
+    parser.add_argument(
+        "--release-type",
+        required=True,
+        choices=["dev", "nightly", "prerelease"],
+        help="Release type (selects therock-{release_type}-python bucket)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print plan without uploading"
+    )
+    args = parser.parse_args(argv)
+
+    if not args.source_dir.is_dir():
+        raise FileNotFoundError(f"Source directory not found: {args.source_dir}")
+
+    bucket = get_release_bucket_config(args.release_type, "python")
+    dest = StorageLocation(bucket.name, _STAGING_SUBDIR)
+    backend = create_storage_backend(dry_run=args.dry_run)
+
+    logger.info("PyTorch wheels: %s -> %s", args.source_dir, dest.s3_uri)
+    count = backend.upload_directory(args.source_dir, dest, include=["*.whl"])
+    logger.info("Uploaded %d wheel files", count)
+    if count == 0:
+        raise FileNotFoundError(f"No wheels found at {args.source_dir}")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main(sys.argv[1:])

--- a/build_tools/github_actions/tests/publish_pytorch_to_staging_test.py
+++ b/build_tools/github_actions/tests/publish_pytorch_to_staging_test.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+"""Unit tests for publish_pytorch_to_staging.py."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent))
+
+from github_actions.publish_pytorch_to_staging import main
+
+
+class TestPublishPytorchToStaging(unittest.TestCase):
+    """Tests for the main() CLI entry point."""
+
+    def setUp(self):
+        # Real directory so the script's existence check passes; the
+        # upload itself is mocked so no S3 contact happens.
+        self._tmp = tempfile.TemporaryDirectory()
+        self.source_dir = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_directory")
+    def test_dev_uploads_to_v4_whl_staging_in_dev_python(self, mock_upload):
+        mock_upload.return_value = 3
+        main(
+            [
+                "--source-dir",
+                os.fspath(self.source_dir),
+                "--release-type",
+                "dev",
+                "--dry-run",
+            ]
+        )
+
+        self.assertEqual(mock_upload.call_count, 1)
+        call_args = mock_upload.call_args
+        source, dest = call_args.args
+        self.assertEqual(source, self.source_dir)
+        self.assertEqual(dest.bucket, "therock-dev-python")
+        self.assertEqual(dest.relative_path, "v4/whl-staging")
+        self.assertEqual(call_args.kwargs.get("include"), ["*.whl"])
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_directory")
+    def test_nightly_selects_nightly_bucket(self, mock_upload):
+        mock_upload.return_value = 2
+        main(
+            [
+                "--source-dir",
+                os.fspath(self.source_dir),
+                "--release-type",
+                "nightly",
+                "--dry-run",
+            ]
+        )
+
+        _source, dest = mock_upload.call_args.args
+        self.assertEqual(dest.bucket, "therock-nightly-python")
+        self.assertEqual(dest.relative_path, "v4/whl-staging")
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_directory")
+    def test_prerelease_selects_prerelease_bucket(self, mock_upload):
+        mock_upload.return_value = 2
+        main(
+            [
+                "--source-dir",
+                os.fspath(self.source_dir),
+                "--release-type",
+                "prerelease",
+                "--dry-run",
+            ]
+        )
+
+        _source, dest = mock_upload.call_args.args
+        self.assertEqual(dest.bucket, "therock-prerelease-python")
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_directory")
+    def test_raises_when_no_wheels_uploaded(self, mock_upload):
+        mock_upload.return_value = 0
+        with self.assertRaises(FileNotFoundError):
+            main(
+                [
+                    "--source-dir",
+                    os.fspath(self.source_dir),
+                    "--release-type",
+                    "dev",
+                    "--dry-run",
+                ]
+            )
+
+    def test_raises_when_source_dir_missing(self):
+        missing = self.source_dir / "does-not-exist"
+        with self.assertRaises(FileNotFoundError):
+            main(
+                [
+                    "--source-dir",
+                    os.fspath(missing),
+                    "--release-type",
+                    "dev",
+                    "--dry-run",
+                ]
+            )
+
+    def test_invalid_release_type_rejected(self):
+        with self.assertRaises(SystemExit):
+            main(
+                [
+                    "--source-dir",
+                    os.fspath(self.source_dir),
+                    "--release-type",
+                    "release",
+                    "--dry-run",
+                ]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

This adds workflows dispatched from the multi-arch release workflows to build PyTorch wheels.

## Technical Details

Instead of using workflow calls this explicitly uses workflow dispatch. This tradeoff is chosen as only two runs will be triggered, one for Linux and one for Windows, whereas a workflow call would significantly blow up the workflow graph.

For now, the ROCm packages get pulled from the artifact bucket and not the CDN. This allows to re-order the workflow execution more easily but this might change in a follow up. The new workflows further mimic the current implementation in `.github/workflows/build_{linux_portable,windows}_pytorch_wheels_ci.yml`. The existing workflows are not re-used (yet!) as it is planned to extend the release workflows to build additional packages (torchaudio, torchvision, triton, apex) soon.

## Test Plan

tbd

## Test Result

tbd

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
