### PR TITLE
CI: gate Windows hip-tests (ROCR) matrix entry behind WINDOWS_HIP_ROCR_TESTS flag

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -31,6 +31,9 @@ on:
       run_extended_tests:
         type: string
         default: 'false'
+      windows_hip_rocr_tests:
+        type: string
+        default: 'false'
       release_type:
         description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
@@ -60,6 +63,9 @@ on:
       test_labels:
         type: string
       run_extended_tests:
+        type: string
+        default: 'false'
+      windows_hip_rocr_tests:
         type: string
         default: 'false'
       release_type:
@@ -114,6 +120,7 @@ jobs:
           TEST_TYPE: ${{ inputs.test_type }}
           TEST_LABELS: ${{ inputs.test_labels }}
           RUN_EXTENDED_TESTS: ${{ inputs.run_extended_tests }}
+          WINDOWS_HIP_ROCR_TESTS: ${{ inputs.windows_hip_rocr_tests }}
         run: python ./build_tools/github_actions/fetch_test_configurations.py
 
   test_sanity_check:

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -573,6 +573,7 @@ def run():
     test_type = os.getenv("TEST_TYPE", "full")
     test_labels = ast.literal_eval(os.getenv("TEST_LABELS") or "[]")
     run_extended_tests = str2bool(os.getenv("RUN_EXTENDED_TESTS", "false"))
+    windows_hip_rocr_tests = str2bool(os.getenv("WINDOWS_HIP_ROCR_TESTS", "false"))
 
     logging.info(f"Selecting projects: {projects_to_test}")
 
@@ -631,9 +632,9 @@ def run():
         ):
             logging.info(f"Including job {job_name} with test_type {test_type}")
 
-            # Hip-tests on Windows run twice: PAL (pass/fail) and ROCR (informational)
-            # for parity tracking until ROCR is the pass/fail path. See:
-            # https://github.com/ROCm/TheRock/issues/3587
+            # Hip-tests on Windows: always run PAL (pass/fail). Optionally also run
+            # ROCR (informational) for parity tracking when WINDOWS_HIP_ROCR_TESTS=true.
+            # See: https://github.com/ROCm/TheRock/issues/3587
             if key == "hip-tests" and platform == "windows":
                 base = selected_matrix[key]
                 total_shards = base.get("total_shards_dict", {}).get(platform, 1)
@@ -654,19 +655,20 @@ def run():
                 }
                 all_components.append(pal_entry)
 
-                rocr_entry = {
-                    "job_name": "hip-tests (ROCR)",
-                    "fetch_artifact_args": base["fetch_artifact_args"],
-                    "timeout_minutes": base["timeout_minutes"],
-                    "test_script": base["test_script"],
-                    "platform": base["platform"],
-                    "total_shards": total_shards,
-                    "test_type": test_type,
-                    "shard_arr": shard_arr,
-                    "expect_failure": True,
-                    "gpu_enable_pal": "0",
-                }
-                all_components.append(rocr_entry)
+                if windows_hip_rocr_tests:
+                    rocr_entry = {
+                        "job_name": "hip-tests (ROCR)",
+                        "fetch_artifact_args": base["fetch_artifact_args"],
+                        "timeout_minutes": base["timeout_minutes"],
+                        "test_script": base["test_script"],
+                        "platform": base["platform"],
+                        "total_shards": total_shards,
+                        "test_type": test_type,
+                        "shard_arr": shard_arr,
+                        "expect_failure": True,
+                        "gpu_enable_pal": "0",
+                    }
+                    all_components.append(rocr_entry)
                 continue
 
             job_config_data = selected_matrix[key]

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -267,10 +267,26 @@ class FetchTestConfigurationsTest(unittest.TestCase):
     # Output contract
     # -----------------------
 
-    def test_windows_hip_tests_emits_pal_and_rocr_entries(self):
-        """On Windows, hip-tests run twice: PAL (pass/fail) and ROCR (informational)."""
+    def test_windows_hip_tests_default_emits_pal_only(self):
+        """On Windows, hip-tests emits only PAL by default (WINDOWS_HIP_ROCR_TESTS off)."""
         os.environ["RUNNER_OS"] = "Windows"
         os.environ["TEST_LABELS"] = json.dumps(["hip-tests"])
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        hip_jobs = [j for j in components if "hip-tests" in j["job_name"]]
+        self.assertEqual(len(hip_jobs), 1, "Expected only hip-tests (PAL)")
+        self.assertEqual(hip_jobs[0]["job_name"], "hip-tests (PAL)")
+        self.assertNotIn("expect_failure", hip_jobs[0])
+        self.assertEqual(hip_jobs[0]["total_shards"], 4)
+        self.assertEqual(hip_jobs[0]["shard_arr"], [1, 2, 3, 4])
+
+    def test_windows_hip_tests_emits_pal_and_rocr_entries(self):
+        """On Windows with WINDOWS_HIP_ROCR_TESTS=true, hip-tests runs PAL and ROCR."""
+        os.environ["RUNNER_OS"] = "Windows"
+        os.environ["TEST_LABELS"] = json.dumps(["hip-tests"])
+        os.environ["WINDOWS_HIP_ROCR_TESTS"] = "true"
 
         fetch_test_configurations.run()
         components = self._get_components()
@@ -293,10 +309,11 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         self.assertEqual(rocr["shard_arr"], [1, 2, 3, 4])
 
     def test_windows_hip_tests_quick_uses_single_shard(self):
-        """On Windows with test_type=quick, hip-tests PAL/ROCR each use 1 shard."""
+        """On Windows with test_type=quick and ROCR enabled, PAL/ROCR each use 1 shard."""
         os.environ["RUNNER_OS"] = "Windows"
         os.environ["TEST_LABELS"] = json.dumps(["hip-tests"])
         os.environ["TEST_TYPE"] = "quick"
+        os.environ["WINDOWS_HIP_ROCR_TESTS"] = "true"
 
         fetch_test_configurations.run()
         components = self._get_components()


### PR DESCRIPTION
Adds a CI-only feature flag (`WINDOWS_HIP_ROCR_TESTS` env var) that gates the
informational `hip-tests (ROCR)` matrix entry on Windows. Previously the ROCR
entry was emitted unconditionally alongside the PAL entry; now PAL is always
emitted and ROCR is opt-in via the flag.

Changes:
- `fetch_test_configurations.py`: reads `WINDOWS_HIP_ROCR_TESTS` via `str2bool`
  and wraps the ROCR dict literal in an `if` guard (consistent with how
  `run_extended_tests` is handled nearby)
- `test_artifacts.yml`: exposes `windows_hip_rocr_tests` as a `workflow_input`
  (default `'false'`) in both `workflow_dispatch` and `workflow_call` blocks,
  wired through `${{ inputs.windows_hip_rocr_tests }}`
- Tests: adds `test_windows_hip_tests_default_emits_pal_only` to cover the
  gate-off path (previously untested); updates the two existing ROCR tests to
  set `WINDOWS_HIP_ROCR_TESTS=true` explicitly

All callers of `test_artifacts.yml` (`ci_windows.yml`, `multi_arch_ci_windows.yml`,
and the Linux variants) are unaffected — the input is optional and the `'false'`
default reproduces the intended suppressed-ROCR behavior with no changes required
at call sites.

The flag is expected to be temporary. When ROCR becomes the primary pass/fail
path (tracked in issue #3587), the flag, the PAL-specific entry, and the
`expect_failure: True` ROCR path can all be cleaned up in a single follow-up
commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
