### PR TITLE
Updating the GitHub Actions outputs using gha_set_output

### DIFF
--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -14,6 +14,7 @@ Subcommands (get operations):
   get-repo-sub-folder  Get repo_sub_folder from an S3 prefix (last segment if YYYYMMDD-<id>, else empty). Prints repo_sub_folder=<value>.
   get-repo-url         Get full repo URL from components(release_type, native_package_type, repo_base_url, os_profile, repo_sub_folder). Prints repo_url=<value>.
   extract-gfx-arch     Extract and normalize GPU architecture from artifact group. Prints gfx_arch=<value>.
+  get-container-image  Get container image for a given OS profile. Prints container_image=<value>.
 
 Usage:
   python build_tools/packaging/linux/get_url_repo_params.py get-base-url --from-url <url>
@@ -21,6 +22,7 @@ Usage:
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix <prefix>
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url ...
   python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch --artifact-group <group>
+  python build_tools/packaging/linux/get_url_repo_params.py get-container-image --os-profile <profile>
 
 Examples:
   python build_tools/packaging/linux/get_url_repo_params.py get-base-url --from-url https://example.com/v2/whl
@@ -28,12 +30,18 @@ Examples:
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix v3/packages/deb/20260204-12345
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --release-type prerelease --native-package-type deb --repo-base-url https://x.com --os-profile ubuntu2404 --repo-sub-folder ''
   python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch --artifact-group gfx94X-dcgpu
+  python build_tools/packaging/linux/get_url_repo_params.py get-container-image --os-profile ubuntu2404
 """
 
 import argparse
+import os
 import re
 import sys
+from pathlib import Path
 from urllib.parse import urlparse
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent))
+from github_actions.github_actions_api import gha_set_output
 
 
 # --- base_url ---
@@ -53,7 +61,7 @@ def cmd_base_url(args: argparse.Namespace) -> int:
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    print(f"repo_base_url={base_url}")
+    gha_set_output({"repo_base_url": base_url})
     return 0
 
 
@@ -92,14 +100,14 @@ def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
 
 def cmd_gpg_key_url(args: argparse.Namespace) -> int:
     if not gpg_key_url_needed_for_release_type(args.release_type):
-        print("gpg_key_url=")
+        gha_set_output({"gpg_key_url": ""})
         return 0
     try:
         gpg_url = get_gpg_key_url(args.from_url)
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    print(f"gpg_key_url={gpg_url}")
+    gha_set_output({"gpg_key_url": gpg_url})
     return 0
 
 
@@ -121,7 +129,7 @@ def get_repo_sub_folder(s3_prefix: str) -> str:
 
 def cmd_repo_sub_folder(args: argparse.Namespace) -> int:
     repo_sub_folder = get_repo_sub_folder(args.from_s3_prefix)
-    print(f"repo_sub_folder={repo_sub_folder}")
+    gha_set_output({"repo_sub_folder": repo_sub_folder})
     return 0
 
 
@@ -164,7 +172,7 @@ def cmd_repo_url(args: argparse.Namespace) -> int:
     except (ValueError, TypeError) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    print(f"repo_url={url}")
+    gha_set_output({"repo_url": url})
     return 0
 
 
@@ -208,7 +216,38 @@ def cmd_extract_gfx_arch(args: argparse.Namespace) -> int:
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    print(f"gfx_arch={gfx_arch}")
+    gha_set_output({"gfx_arch": gfx_arch})
+    return 0
+
+
+# --- get-container-image ---
+
+# Maps OS profile prefixes to container images (checked in order).
+_OS_PROFILE_TO_IMAGE: list[tuple[tuple[str, ...], str]] = [
+    (("sles",), "registry.suse.com/bci/bci-base:16.0"),
+    (("ubuntu", "debian"), "ubuntu:24.04"),
+    ((), "registry.access.redhat.com/ubi10/ubi:10.1"),  # default (e.g. rhel*)
+]
+
+
+def get_container_image(os_profile: str) -> str:
+    """Return the container image for a given OS profile.
+
+    Examples:
+        ubuntu2404  -> ubuntu:24.04
+        debian12    -> ubuntu:24.04
+        sles16      -> registry.suse.com/bci/bci-base:16.0
+        rhel10      -> registry.access.redhat.com/ubi10/ubi:10.1
+    """
+    for prefixes, image in _OS_PROFILE_TO_IMAGE:
+        if not prefixes or any(os_profile.startswith(p) for p in prefixes):
+            return image
+    return _OS_PROFILE_TO_IMAGE[-1][1]  # unreachable but satisfies type checker
+
+
+def cmd_container_image(args: argparse.Namespace) -> int:
+    image = get_container_image(args.os_profile)
+    gha_set_output({"container_image": image})
     return 0
 
 
@@ -320,6 +359,19 @@ def main(argv: list[str] | None = None) -> int:
         help="Artifact group to extract gfx_arch from (e.g. gfx94X-dcgpu, gfx1100-consumer)",
     )
     p_gfx.set_defaults(func=cmd_extract_gfx_arch)
+
+    # get-container-image: get container image for an OS profile
+    p_img = subparsers.add_parser(
+        "get-container-image",
+        help="Get container image for a given OS profile (e.g. ubuntu2404 -> ubuntu:24.04).",
+    )
+    p_img.add_argument(
+        "--os-profile",
+        type=str,
+        required=True,
+        help="OS profile (e.g. ubuntu2404, sles16, rhel10)",
+    )
+    p_img.set_defaults(func=cmd_container_image)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/build_tools/packaging/linux/setup_python_cmd.sh
+++ b/build_tools/packaging/linux/setup_python_cmd.sh
@@ -23,10 +23,10 @@
 # Sample usage
 # ------------
 #
-# CI (install + append PYTHON_CMD to GITHUB_ENV):
+# CI (install + append PYTHON_CMD to GITHUB_ENV directly):
 #
 #     bash build_tools/packaging/linux/setup_python_cmd.sh \
-#         --os-profile ubuntu2404 --install-runtime >> "$GITHUB_ENV"
+#         --os-profile ubuntu2404 --install-runtime
 #
 # UBI 9 / older RHEL-like: pin 3.12 from AppStream / repos:
 #
@@ -146,7 +146,7 @@ case "$OUTPUT_FORMAT" in
         echo "{\"python_cmd\": \"$PYTHON_CMD\"}"
         ;;
     github)
-        echo "PYTHON_CMD=$PYTHON_CMD"
+        echo "PYTHON_CMD=$PYTHON_CMD" >> "$GITHUB_ENV"
         ;;
     env)
         echo "export PYTHON_CMD=$PYTHON_CMD"

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -8,12 +8,27 @@
 
 import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent.parent))
 import get_url_repo_params
+
+
+def _run_main_with_output(argv: list[str]) -> tuple[int, str]:
+    """Run main() with a temp GITHUB_OUTPUT file; return (exit_code, file_contents)."""
+    with tempfile.NamedTemporaryFile(mode="r", suffix=".txt", delete=False) as f:
+        tmp_path = f.name
+    try:
+        with patch.dict(os.environ, {"GITHUB_OUTPUT": tmp_path}):
+            code = get_url_repo_params.main(argv)
+        contents = Path(tmp_path).read_text()
+    finally:
+        os.unlink(tmp_path)
+    return code, contents
 
 
 class GetBaseUrlTest(unittest.TestCase):
@@ -289,14 +304,11 @@ class MainSubcommandsTest(unittest.TestCase):
     """Tests for main() subcommands (get-base-url, get-repo-sub-folder, get-repo-url)."""
 
     def test_get_base_url_success(self):
-        # Test that get-base-url subcommand prints repo_base_url= and returns 0.
-        with patch("sys.stdout") as mock_stdout:
-            code = get_url_repo_params.main(
-                ["get-base-url", "--from-url", "https://example.com/v2/whl"]
-            )
+        # Test that get-base-url subcommand writes repo_base_url= to GITHUB_OUTPUT.
+        code, output = _run_main_with_output(
+            ["get-base-url", "--from-url", "https://example.com/v2/whl"]
+        )
         self.assertEqual(code, 0)
-        mock_stdout.write.assert_called()
-        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
         self.assertIn("repo_base_url=https://example.com", output)
 
     def test_get_base_url_invalid_returns_one(self):
@@ -306,35 +318,31 @@ class MainSubcommandsTest(unittest.TestCase):
         self.assertEqual(code, 1)
 
     def test_get_repo_sub_folder_success(self):
-        # Test that get-repo-sub-folder prints repo_sub_folder= and returns 0.
-        with patch("sys.stdout") as mock_stdout:
-            code = get_url_repo_params.main(
-                ["get-repo-sub-folder", "--from-s3-prefix", "v3/deb/20260204-12345"]
-            )
+        # Test that get-repo-sub-folder writes repo_sub_folder= to GITHUB_OUTPUT.
+        code, output = _run_main_with_output(
+            ["get-repo-sub-folder", "--from-s3-prefix", "v3/deb/20260204-12345"]
+        )
         self.assertEqual(code, 0)
-        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
         self.assertIn("repo_sub_folder=20260204-12345", output)
 
     def test_get_repo_url_success(self):
-        # Test that get-repo-url prints repo_url= and returns 0.
-        with patch("sys.stdout") as mock_stdout:
-            code = get_url_repo_params.main(
-                [
-                    "get-repo-url",
-                    "--release-type",
-                    "prerelease",
-                    "--native-package-type",
-                    "deb",
-                    "--repo-base-url",
-                    "https://x.com",
-                    "--os-profile",
-                    "ubuntu2404",
-                    "--repo-sub-folder",
-                    "",
-                ]
-            )
+        # Test that get-repo-url writes repo_url= to GITHUB_OUTPUT.
+        code, output = _run_main_with_output(
+            [
+                "get-repo-url",
+                "--release-type",
+                "prerelease",
+                "--native-package-type",
+                "deb",
+                "--repo-base-url",
+                "https://x.com",
+                "--os-profile",
+                "ubuntu2404",
+                "--repo-sub-folder",
+                "",
+            ]
+        )
         self.assertEqual(code, 0)
-        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
         self.assertIn("repo_url=https://x.com/ubuntu2404", output)
 
     def test_get_repo_url_error_returns_one(self):
@@ -361,23 +369,19 @@ class MainSubcommandsTest(unittest.TestCase):
         self.assertEqual(code, 1)
 
     def test_extract_gfx_arch_success(self):
-        # Test that extract-gfx-arch subcommand prints gfx_arch= and returns 0.
-        with patch("sys.stdout") as mock_stdout:
-            code = get_url_repo_params.main(
-                ["extract-gfx-arch", "--artifact-group", "gfx94X-dcgpu"]
-            )
+        # Test that extract-gfx-arch writes gfx_arch= to GITHUB_OUTPUT.
+        code, output = _run_main_with_output(
+            ["extract-gfx-arch", "--artifact-group", "gfx94X-dcgpu"]
+        )
         self.assertEqual(code, 0)
-        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
         self.assertIn("gfx_arch=gfx94x", output)
 
     def test_extract_gfx_arch_lowercase(self):
         # Test that extract-gfx-arch handles already-lowercase input.
-        with patch("sys.stdout") as mock_stdout:
-            code = get_url_repo_params.main(
-                ["extract-gfx-arch", "--artifact-group", "gfx1100-consumer"]
-            )
+        code, output = _run_main_with_output(
+            ["extract-gfx-arch", "--artifact-group", "gfx1100-consumer"]
+        )
         self.assertEqual(code, 0)
-        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
         self.assertIn("gfx_arch=gfx1100", output)
 
     def test_extract_gfx_arch_empty_returns_one(self):
@@ -390,110 +394,124 @@ class MainSubcommandsTest(unittest.TestCase):
 
     def test_extract_gfx_arch_comma_list(self):
         # Test that extract-gfx-arch handles comma-separated list.
-        with patch("sys.stdout") as mock_stdout:
-            code = get_url_repo_params.main(
-                [
-                    "extract-gfx-arch",
-                    "--artifact-group",
-                    "gfx94X-dcgpu,gfx1100-consumer",
-                ]
-            )
+        code, output = _run_main_with_output(
+            ["extract-gfx-arch", "--artifact-group", "gfx94X-dcgpu,gfx1100-consumer"]
+        )
         self.assertEqual(code, 0)
-        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
         self.assertIn("gfx_arch=gfx94x,gfx1100", output)
 
     def test_extract_gfx_arch_semicolon_list(self):
         # Test that extract-gfx-arch handles semicolon-separated list.
-        with patch("sys.stdout") as mock_stdout:
-            code = get_url_repo_params.main(
-                [
-                    "extract-gfx-arch",
-                    "--artifact-group",
-                    "gfx94X-dcgpu;gfx1100-consumer",
-                ]
-            )
+        code, output = _run_main_with_output(
+            ["extract-gfx-arch", "--artifact-group", "gfx94X-dcgpu;gfx1100-consumer"]
+        )
         self.assertEqual(code, 0)
-        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
         self.assertIn("gfx_arch=gfx94x,gfx1100", output)
 
     def test_get_gpg_url_success(self):
-        # Test that get-gpg-url subcommand prints gpg_key_url= and returns 0.
-        with patch("sys.stdout") as mock_stdout:
-            code = get_url_repo_params.main(
-                [
-                    "get-gpg-url",
-                    "--from-url",
-                    "https://rocm.prereleases.amd.com/packages/ubuntu2404",
-                ]
-            )
+        # Test that get-gpg-url writes gpg_key_url= to GITHUB_OUTPUT.
+        code, output = _run_main_with_output(
+            [
+                "get-gpg-url",
+                "--from-url",
+                "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+            ]
+        )
         self.assertEqual(code, 0)
-        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
         self.assertIn(
             "gpg_key_url=https://rocm.prereleases.amd.com/gpg/rocm.gpg", output
         )
 
     def test_get_gpg_url_with_release_type_dev_emits_empty(self):
-        with patch("sys.stdout") as mock_stdout:
-            code = get_url_repo_params.main(
-                [
-                    "get-gpg-url",
-                    "--release-type",
-                    "dev",
-                    "--from-url",
-                    "https://rocm.prereleases.amd.com/packages/ubuntu2404",
-                ]
-            )
+        code, output = _run_main_with_output(
+            [
+                "get-gpg-url",
+                "--release-type",
+                "dev",
+                "--from-url",
+                "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+            ]
+        )
         self.assertEqual(code, 0)
-        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
         self.assertIn("gpg_key_url=", output)
         self.assertNotIn("rocm.gpg", output)
 
     def test_get_gpg_url_with_release_type_dev_ignores_invalid_url(self):
-        with patch("sys.stdout") as mock_stdout:
-            code = get_url_repo_params.main(
-                [
-                    "get-gpg-url",
-                    "--release-type",
-                    "nightly",
-                    "--from-url",
-                    "not-a-valid-url",
-                ]
-            )
+        code, output = _run_main_with_output(
+            [
+                "get-gpg-url",
+                "--release-type",
+                "nightly",
+                "--from-url",
+                "not-a-valid-url",
+            ]
+        )
         self.assertEqual(code, 0)
-        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
         self.assertEqual(output.strip(), "gpg_key_url=")
 
     def test_get_gpg_url_with_release_type_prerelease(self):
-        with patch("sys.stdout") as mock_stdout:
-            code = get_url_repo_params.main(
-                [
-                    "get-gpg-url",
-                    "--release-type",
-                    "prerelease",
-                    "--from-url",
-                    "https://rocm.prereleases.amd.com/packages/ubuntu2404",
-                ]
-            )
+        code, output = _run_main_with_output(
+            [
+                "get-gpg-url",
+                "--release-type",
+                "prerelease",
+                "--from-url",
+                "https://rocm.prereleases.amd.com/packages/ubuntu2404",
+            ]
+        )
         self.assertEqual(code, 0)
-        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
         self.assertIn(
             "gpg_key_url=https://rocm.prereleases.amd.com/gpg/rocm.gpg", output
         )
 
     def test_get_gpg_url_with_release_type_release(self):
-        with patch("sys.stdout") as mock_stdout:
-            code = get_url_repo_params.main(
-                [
-                    "get-gpg-url",
-                    "--release-type",
-                    "release",
-                    "--from-url",
-                    "https://repo.amd.com/rocm/packages/rhel10/x86_64/",
-                ]
-            )
+        code, output = _run_main_with_output(
+            [
+                "get-gpg-url",
+                "--release-type",
+                "release",
+                "--from-url",
+                "https://repo.amd.com/rocm/packages/rhel10/x86_64/",
+            ]
+        )
         self.assertEqual(code, 0)
-        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
         self.assertIn("gpg_key_url=https://repo.amd.com/gpg/rocm.gpg", output)
+
+
+class GetContainerImageTest(unittest.TestCase):
+    """Tests for get_container_image()."""
+
+    def test_ubuntu_returns_ubuntu_image(self):
+        self.assertEqual(
+            get_url_repo_params.get_container_image("ubuntu2404"),
+            "ubuntu:24.04",
+        )
+
+    def test_debian_returns_ubuntu_image(self):
+        self.assertEqual(
+            get_url_repo_params.get_container_image("debian12"),
+            "ubuntu:24.04",
+        )
+
+    def test_sles_returns_bci_image(self):
+        self.assertEqual(
+            get_url_repo_params.get_container_image("sles16"),
+            "registry.suse.com/bci/bci-base:16.0",
+        )
+
+    def test_rhel_returns_ubi_image(self):
+        self.assertEqual(
+            get_url_repo_params.get_container_image("rhel10"),
+            "registry.access.redhat.com/ubi10/ubi:10.1",
+        )
+
+    def test_get_container_image_subcommand(self):
+        # Test that get-container-image writes container_image= to GITHUB_OUTPUT.
+        code, output = _run_main_with_output(
+            ["get-container-image", "--os-profile", "ubuntu2404"]
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("container_image=ubuntu:24.04", output)
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/tests/setup_python_cmd_test.sh
+++ b/build_tools/packaging/linux/tests/setup_python_cmd_test.sh
@@ -57,44 +57,61 @@ assert_contains() {
     fi
 }
 
+# Helper: run script with --output-format github using a temp GITHUB_ENV file.
+# Returns the content written to GITHUB_ENV.
+run_github_format() {
+    local tmp_env
+    tmp_env=$(mktemp)
+    GITHUB_ENV="$tmp_env" bash "$SETUP_SCRIPT" "$@" --output-format github
+    local result
+    result=$(cat "$tmp_env")
+    rm -f "$tmp_env"
+    echo "$result"
+}
+
 # Test resolve_python_cmd logic (output format tests)
 test_ubuntu_profiles() {
-    local output=$(bash "$SETUP_SCRIPT" --os-profile ubuntu2404 --output-format github)
+    local output
+    output=$(run_github_format --os-profile ubuntu2404)
     assert_equals "PYTHON_CMD=python3.12" "$output" "Ubuntu 24.04 resolves to python3.12"
 
-    output=$(bash "$SETUP_SCRIPT" --os-profile ubuntu2204 --output-format github)
+    output=$(run_github_format --os-profile ubuntu2204)
     assert_equals "PYTHON_CMD=python3.12" "$output" "Ubuntu 22.04 resolves to python3.12"
 
-    output=$(bash "$SETUP_SCRIPT" --os-profile ubuntu2004 --output-format github)
+    output=$(run_github_format --os-profile ubuntu2004)
     assert_equals "PYTHON_CMD=python3.12" "$output" "Ubuntu 20.04 resolves to python3.12"
 }
 
 test_debian_profiles() {
-    local output=$(bash "$SETUP_SCRIPT" --os-profile debian12 --output-format github)
+    local output
+    output=$(run_github_format --os-profile debian12)
     assert_equals "PYTHON_CMD=python3.12" "$output" "Debian 12 resolves to python3.12"
 
-    output=$(bash "$SETUP_SCRIPT" --os-profile debian11 --output-format github)
+    output=$(run_github_format --os-profile debian11)
     assert_equals "PYTHON_CMD=python3.12" "$output" "Debian 11 resolves to python3.12"
 }
 
 test_sles_profiles() {
-    local output=$(bash "$SETUP_SCRIPT" --os-profile sles16 --output-format github)
+    local output
+    output=$(run_github_format --os-profile sles16)
     assert_equals "PYTHON_CMD=python3.13" "$output" "SLES 16 resolves to python3.13"
 
-    output=$(bash "$SETUP_SCRIPT" --os-profile sles15 --output-format github)
+    output=$(run_github_format --os-profile sles15)
     assert_equals "PYTHON_CMD=python3.13" "$output" "SLES 15 resolves to python3.13"
 }
 
 test_rhel_profiles() {
-    local output=$(bash "$SETUP_SCRIPT" --os-profile rhel10 --output-format github)
+    local output
+    output=$(run_github_format --os-profile rhel10)
     assert_equals "PYTHON_CMD=python3.12" "$output" "RHEL 10 resolves to python3.12"
 
-    output=$(bash "$SETUP_SCRIPT" --os-profile rhel9 --output-format github)
+    output=$(run_github_format --os-profile rhel9)
     assert_equals "PYTHON_CMD=python3.12" "$output" "RHEL 9 resolves to python3.12"
 }
 
 test_centos_profiles() {
-    local output=$(bash "$SETUP_SCRIPT" --os-profile centos9 --output-format github)
+    local output
+    output=$(run_github_format --os-profile centos9)
     assert_equals "PYTHON_CMD=python3.12" "$output" "CentOS 9 resolves to python3.12 (default case)"
 }
 
@@ -108,8 +125,9 @@ test_json_output() {
 }
 
 test_github_output() {
-    local output=$(bash "$SETUP_SCRIPT" --os-profile rhel10 --output-format github)
-    assert_equals "PYTHON_CMD=python3.12" "$output" "GitHub output format for RHEL"
+    local output
+    output=$(run_github_format --os-profile rhel10)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "GitHub output format writes to GITHUB_ENV"
 }
 
 test_env_output() {


### PR DESCRIPTION
## Motivation

Scripts in `build_tools/packaging/linux/` were writing GitHub Actions outputs by printing `key=value` to stdout and relying on callers to redirect with `>> $GITHUB_OUTPUT` or `>> $GITHUB_ENV`. Any unexpected print statement in the call chain can silently corrupt these files, causing hard-to-debug CI failures.

## Technical Details

**`get_url_repo_params.py`**
- Switch `sys.path.insert` to point to `build_tools/` and use `from github_actions.github_actions_api import gha_set_output` — consistent with other `build_tools/` scripts (e.g. `configure_stage.py`).
- Replace all `print(f"key=value")` calls in every `cmd_*` function with `gha_set_output({...})`, which writes directly to the `$GITHUB_OUTPUT` file.
- Add `get-container-image` subcommand with an `_OS_PROFILE_TO_IMAGE` table mapping OS profile prefixes to container images (`sles` → SUSE BCI 16, `ubuntu`/`debian` → `ubuntu:24.04`, default → RHEL UBI 10).

**`setup_python_cmd.sh`**
- In the `github` output format case, write `PYTHON_CMD=...` directly to `$GITHUB_ENV` instead of printing to stdout. Callers no longer need `>> $GITHUB_ENV`.

**Tests**
- `get_url_repo_params_test.py`: Replace `patch("sys.stdout")` in all `MainSubcommandsTest` cases with a `_run_main_with_output()` helper that uses a temp `$GITHUB_OUTPUT` file. Add `GetContainerImageTest` covering `get_container_image()` for all OS profile families and the new subcommand.
- `setup_python_cmd_test.sh`: Add `run_github_format()` helper that sets a temp `$GITHUB_ENV` file and reads from it, replacing direct stdout capture for all `--output-format github` test cases.

## Test Plan

- Run `get_url_repo_params_test.py` unit tests locally.
- Run `setup_python_cmd_test.sh` locally.

## Test Result

All 50 `get_url_repo_params_test.py` tests pass.
`setup_python_cmd_test.sh` github-format mechanism tests pass 