### PR TITLE
[ci] bumping rocsolver + rocwmma shard

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -161,12 +161,12 @@ test_matrix = {
         "fetch_artifact_args": "--blas --tests",
         # 68350(approx) tests needs 48 mins, so 48 mins / 2 shards = 24 mins per shard
         # 24 mins + 20% margin = 30 mins => ~40 mins (considering gpu delays and lags)
-        "timeout_minutes": 40,
+        "timeout_minutes": 60,
         "test_script": f"python {_get_script_path('test_rocsolver.py')}",
         # Issue for adding windows tests: https://github.com/ROCm/TheRock/issues/1770
         "platform": ["linux"],
         "total_shards_dict": {
-            "linux": 2,
+            "linux": 3,
             "windows": 2,
         },
     },
@@ -463,7 +463,7 @@ test_matrix = {
         "test_script": f"python {_get_script_path('test_rocwmma.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
-            "linux": 4,
+            "linux": 5,
             "windows": 2,
         },
     },


### PR DESCRIPTION
For 7.13 unblock, we are bumping rocsolver and rocwmma resources as it continues to timeout. Eventually, these components will be converted into test standarization work and will remove these timeouts and follow times here: https://github.com/ROCm/TheRock/blob/main/docs/development/test_filtering.md