### PR TITLE
Build torchaudio, torchvision, and triton in multi-arch PyTorch release

### DIFF
--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -6,9 +6,11 @@
 # Built shape:
 #   - One fat build_prod_wheels.py invocation per (python_version,
 #     pytorch_git_ref) matrix cell, covering all gfx targets expanded
-#     from the inputs.amdgpu_families set.
-#   - kpack-split the resulting fat torch wheel into a host wheel plus
-#     per-gfx amd-torch-device-* wheels.
+#     from the inputs.amdgpu_families set. Builds torch, torchaudio,
+#     torchvision, and triton in a single invocation.
+#   - kpack-split the fat torch and torchvision wheels into host wheels
+#     plus per-gfx amd-torch-device-* / amd-torchvision-device-* wheels.
+#     torchaudio and triton ship as-is (no split).
 #   - Upload the result to s3://therock-{release_type}-python/v4/whl-staging/
 #     (server-side indexing handles the index page).
 #
@@ -122,18 +124,28 @@ jobs:
         run: |
           pip install -r external-builds/pytorch/requirements-ci.txt
 
-      - name: Checkout PyTorch source (nightly)
+      - name: Checkout PyTorch source repos (nightly)
         if: ${{ matrix.pytorch_git_ref == 'nightly' }}
         run: |
           ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --repo-hashtag nightly
+          ./external-builds/pytorch/pytorch_audio_repo.py checkout \
+            --repo-hashtag nightly
+          ./external-builds/pytorch/pytorch_vision_repo.py checkout \
+            --repo-hashtag nightly
+          ./external-builds/pytorch/pytorch_triton_repo.py checkout
 
-      - name: Checkout PyTorch source (stable)
+      - name: Checkout PyTorch source repos (stable)
         if: ${{ matrix.pytorch_git_ref != 'nightly' }}
         run: |
           ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --gitrepo-origin https://github.com/ROCm/pytorch.git \
             --repo-hashtag ${{ matrix.pytorch_git_ref }}
+          ./external-builds/pytorch/pytorch_audio_repo.py checkout \
+            --require-related-commit
+          ./external-builds/pytorch/pytorch_vision_repo.py checkout \
+            --require-related-commit
+          ./external-builds/pytorch/pytorch_triton_repo.py checkout
 
       # determine_version.py sets optional_build_prod_arguments in
       # GITHUB_ENV (--rocm-sdk-version, --version-suffix).
@@ -217,23 +229,34 @@ jobs:
             -e rocm-systems/python/rocm-bootstrap \
             -e rocm-systems/shared/kpack
 
-      - name: Split PyTorch fat wheel
+      - name: Split PyTorch fat wheels (torch + torchvision)
         run: |
           # The splitter writes the host wheel under the same filename as
-          # the input, so relocate the fat wheel out of PACKAGE_DIST_DIR
-          # first.
+          # the input, so relocate each fat wheel out of PACKAGE_DIST_DIR
+          # before invoking the splitter. torchaudio and triton ship as-is.
           FAT_STAGE="${RUNNER_TEMP:-/tmp}/pytorch-fat"
           mkdir -p "${FAT_STAGE}"
-          mv ${{ env.PACKAGE_DIST_DIR }}/torch-*.whl "${FAT_STAGE}/"
 
           ROCM_SDK_VERSION="$(python -m rocm_sdk version)"
 
+          mv ${{ env.PACKAGE_DIST_DIR }}/torch-*.whl "${FAT_STAGE}/"
           python -m rocm_kpack.tools.split_python_wheels \
             --input "${FAT_STAGE}"/torch-*.whl \
             --output-dir "${{ env.PACKAGE_DIST_DIR }}" \
             --device-package-prefix amd-torch-device \
             --overlay-root torch/ \
             --wheel-type torch-fat \
+            --device-requires-dist "rocm-sdk-device-@GFXARCH@ == ${ROCM_SDK_VERSION}" \
+            --compression zstd \
+            -j "$(nproc)"
+          rm -f "${FAT_STAGE}"/torch-*.whl
+
+          mv ${{ env.PACKAGE_DIST_DIR }}/torchvision-*.whl "${FAT_STAGE}/"
+          python -m rocm_kpack.tools.split_python_wheels \
+            --input "${FAT_STAGE}"/torchvision-*.whl \
+            --output-dir "${{ env.PACKAGE_DIST_DIR }}" \
+            --device-package-prefix amd-torchvision-device \
+            --overlay-root torchvision/ \
             --device-requires-dist "rocm-sdk-device-@GFXARCH@ == ${ROCM_SDK_VERSION}" \
             --compression zstd \
             -j "$(nproc)"

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -6,9 +6,12 @@
 # Built shape:
 #   - One fat build_prod_wheels.py invocation per (python_version,
 #     pytorch_git_ref) matrix cell, covering all gfx targets expanded
-#     from the inputs.amdgpu_families set.
-#   - kpack-split the resulting fat torch wheel into a host wheel plus
-#     per-gfx amd-torch-device-* wheels.
+#     from the inputs.amdgpu_families set. Builds torch, torchaudio,
+#     and torchvision in a single invocation. (No triton on Windows,
+#     matching the legacy release_windows_pytorch_wheels.yml shape.)
+#   - kpack-split the fat torch and torchvision wheels into host wheels
+#     plus per-gfx amd-torch-device-* / amd-torchvision-device-* wheels.
+#     torchaudio ships as-is (no split).
 #   - Upload the result to s3://therock-{release_type}-python/v4/whl-staging/
 #     (server-side indexing handles the index page) via
 #     publish_pytorch_to_staging.py.
@@ -135,15 +138,21 @@ jobs:
         run: |
           pip install -r external-builds/pytorch/requirements-ci.txt
 
-      - name: Checkout PyTorch source (nightly)
+      - name: Checkout PyTorch source repos (nightly)
         if: ${{ matrix.pytorch_git_ref == 'nightly' }}
         run: |
           git config --global core.longpaths true
           python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --checkout-dir ${{ env.CHECKOUT_ROOT }}/torch \
             --repo-hashtag nightly
+          python ./external-builds/pytorch/pytorch_audio_repo.py checkout \
+            --checkout-dir ${{ env.CHECKOUT_ROOT }}/audio \
+            --repo-hashtag nightly
+          python ./external-builds/pytorch/pytorch_vision_repo.py checkout \
+            --checkout-dir ${{ env.CHECKOUT_ROOT }}/vision \
+            --repo-hashtag nightly
 
-      - name: Checkout PyTorch source (stable)
+      - name: Checkout PyTorch source repos (stable)
         if: ${{ matrix.pytorch_git_ref != 'nightly' }}
         run: |
           git config --global core.longpaths true
@@ -151,6 +160,14 @@ jobs:
             --checkout-dir ${{ env.CHECKOUT_ROOT }}/torch \
             --gitrepo-origin https://github.com/ROCm/pytorch.git \
             --repo-hashtag ${{ matrix.pytorch_git_ref }}
+          python ./external-builds/pytorch/pytorch_audio_repo.py checkout \
+            --checkout-dir ${{ env.CHECKOUT_ROOT }}/audio \
+            --torch-dir ${{ env.CHECKOUT_ROOT }}/torch \
+            --require-related-commit
+          python ./external-builds/pytorch/pytorch_vision_repo.py checkout \
+            --checkout-dir ${{ env.CHECKOUT_ROOT }}/vision \
+            --torch-dir ${{ env.CHECKOUT_ROOT }}/torch \
+            --require-related-commit
 
       # determine_version.py sets optional_build_prod_arguments in
       # GITHUB_ENV (--rocm-sdk-version, --version-suffix).
@@ -197,6 +214,8 @@ jobs:
             --install-rocm ^
             --find-links "${{ inputs.rocm_package_find_links_url }}" ^
             --pytorch-dir ${{ env.CHECKOUT_ROOT }}/torch ^
+            --pytorch-audio-dir ${{ env.CHECKOUT_ROOT }}/audio ^
+            --pytorch-vision-dir ${{ env.CHECKOUT_ROOT }}/vision ^
             --enable-pytorch-flash-attention-windows ^
             --clean ^
             --output-dir ${{ env.PACKAGE_DIST_DIR }} ^
@@ -238,7 +257,7 @@ jobs:
             -e rocm-systems/python/rocm-bootstrap \
             -e rocm-systems/shared/kpack
 
-      - name: Split PyTorch fat wheel
+      - name: Split PyTorch fat wheels (torch + torchvision)
         run: |
           DIST_DIR="$(cygpath -u "${{ env.PACKAGE_DIST_DIR }}")"
 
@@ -266,19 +285,31 @@ jobs:
           export PATH="${SHIMS}:${LLVM_BIN}:${PATH}"
 
           # The splitter writes the host wheel under the same filename as the
-          # input, so relocate the fat wheel out of PACKAGE_DIST_DIR first.
+          # input, so relocate each fat wheel out of PACKAGE_DIST_DIR before
+          # invoking the splitter. torchaudio ships as-is.
           FAT_STAGE="$(cygpath -u "${RUNNER_TEMP}")/pytorch-fat"
           mkdir -p "${FAT_STAGE}"
-          mv "${DIST_DIR}"/torch-*.whl "${FAT_STAGE}/"
 
           ROCM_SDK_VERSION="$(python -m rocm_sdk version)"
 
+          mv "${DIST_DIR}"/torch-*.whl "${FAT_STAGE}/"
           python -m rocm_kpack.tools.split_python_wheels \
             --input "${FAT_STAGE}"/torch-*.whl \
             --output-dir "${DIST_DIR}" \
             --device-package-prefix amd-torch-device \
             --overlay-root torch/ \
             --wheel-type torch-fat \
+            --device-requires-dist "rocm-sdk-device-@GFXARCH@ == ${ROCM_SDK_VERSION}" \
+            --compression zstd \
+            -j 32
+          rm -f "${FAT_STAGE}"/torch-*.whl
+
+          mv "${DIST_DIR}"/torchvision-*.whl "${FAT_STAGE}/"
+          python -m rocm_kpack.tools.split_python_wheels \
+            --input "${FAT_STAGE}"/torchvision-*.whl \
+            --output-dir "${DIST_DIR}" \
+            --device-package-prefix amd-torchvision-device \
+            --overlay-root torchvision/ \
             --device-requires-dist "rocm-sdk-device-@GFXARCH@ == ${ROCM_SDK_VERSION}" \
             --compression zstd \
             -j 32


### PR DESCRIPTION
## Motivation

Mirror the wheel set produced by the legacy single-arch release workflows (release_portable_linux_pytorch_wheels.yml and release_windows_pytorch_wheels.yml).

## Technical Details

Apex stays out of scope for now. Furthermore, the workflow is not yet wired into the release workflows and can only be triggered manually.

## Test Plan

Test run:
https://github.com/ROCm/TheRock/actions/runs/25051971912/job/73381868410

## Test Result

Packages pushed to index:
https://rocm.devreleases.amd.com/whl-staging-multi-arch/

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
