### PR TITLE
Remove Python index generation(manage.py) from CI as it is moved over to S3-triggered Lambda

### DIFF
--- a/.github/workflows/build_linux_jax_wheels.yml
+++ b/.github/workflows/build_linux_jax_wheels.yml
@@ -244,17 +244,6 @@ jobs:
             --python-version "${{ inputs.python_version }}" \
             --jax-git-ref "${{ inputs.jax_ref }}"
 
-      - name: (Re-)Generate Python package release index
-        if: ${{ github.repository_owner == 'ROCm' }}
-        env:
-          # Environment variables to be set for `manage.py`
-          CUSTOM_PREFIX: "${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}"
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip3 install boto3 packaging
-          python3 ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}
-
   generate_target_to_run:
     name: Generate target_to_run
     runs-on: ubuntu-24.04
@@ -352,12 +341,3 @@ jobs:
             ${JAXLIB_INCLUDE:+${JAXLIB_INCLUDE}} \
             --include "jax_rocm7_plugin-${JAX_PLUGIN_VERSION}-${CP_VERSION}-manylinux_2_28_x86_64.whl" \
             --include "jax_rocm7_pjrt-${JAX_PJRT_VERSION}-py3-none-manylinux_2_28_x86_64.whl"
-
-      - name: (Re-)Generate Python package release index
-        if: ${{ env.upload == 'true' }}
-        env:
-          # Environment variables to be set for `manage.py`
-          CUSTOM_PREFIX: "${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}"
-        run: |
-          pip install boto3 packaging
-          python ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -300,14 +300,6 @@ jobs:
             --python-version "${{ inputs.python_version }}" \
             --pytorch-git-ref "${{ inputs.pytorch_git_ref }}"
 
-      - name: (Re-)Generate Python package release index for staging
-        if: ${{ github.repository_owner == 'ROCm' }}
-        env:
-          # Environment variables to be set for `manage.py`
-          CUSTOM_PREFIX: "${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}"
-        run: |
-          python ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}
-
   generate_target_to_run:
     name: Generate target_to_run
     runs-on: ubuntu-24.04
@@ -405,11 +397,3 @@ jobs:
       - name: Install python deps for CI
         run: |
           pip install -r external-builds/pytorch/requirements-ci.txt
-
-      - name: (Re-)Generate Python package release index
-        if: ${{ env.upload == 'true' }}
-        env:
-          # Environment variables to be set for `manage.py`
-          CUSTOM_PREFIX: "${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}"
-        run: |
-          python ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -338,15 +338,6 @@ jobs:
             --python-version "${{ inputs.python_version }}" \
             --pytorch-git-ref "${{ inputs.pytorch_git_ref }}"
 
-      - name: (Re-)Generate Python package release index for staging
-        if: ${{ github.repository_owner == 'ROCm' }}
-        env:
-          # Environment variables to be set for `manage.py`
-          CUSTOM_PREFIX: "${{ inputs.s3_staging_subdir }}/${{ inputs.amdgpu_family }}"
-        shell: cmd
-        run: |
-          python ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}
-
   generate_target_to_run:
     name: Generate target_to_run
     runs-on: ubuntu-24.04
@@ -439,11 +430,3 @@ jobs:
       - name: Install python deps for CI
         run: |
           pip install -r external-builds/pytorch/requirements-ci.txt
-
-      - name: (Re-)Generate Python package release index
-        if: ${{ env.upload == 'true' }}
-        env:
-          # Environment variables to be set for `manage.py`
-          CUSTOM_PREFIX: "${{ inputs.s3_subdir }}/${{ inputs.amdgpu_family }}"
-        run: |
-          python ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}

--- a/.github/workflows/copy_release.yml
+++ b/.github/workflows/copy_release.yml
@@ -99,11 +99,3 @@ jobs:
             s3://therock-${{ inputs.sourcebucket }}-python/${{ inputs.sourcesubdir }}/${{ inputs.amdgpu_family }}/ \
             s3://therock-${{ inputs.destbucket }}-python/${{ inputs.destsubdir }}/${{ inputs.amdgpu_family }}/ \
             --recursive --exclude "*"  --include "*torch*${{ inputs.rocm_version }}*${{ env.cp_version }}*"
-
-      - name: (Re-)Generate Python package release index
-        env:
-          S3_BUCKET_PY: "therock-${{ inputs.destbucket }}-python"
-          CUSTOM_PREFIX: "${{ inputs.destsubdir }}/${{ inputs.amdgpu_family }}"
-        run: |
-          pip install boto3 packaging
-          python ./build_tools/third_party/s3_management/manage.py ${CUSTOM_PREFIX}

--- a/.github/workflows/copy_release.yml
+++ b/.github/workflows/copy_release.yml
@@ -99,4 +99,3 @@ jobs:
             s3://therock-${{ inputs.sourcebucket }}-python/${{ inputs.sourcesubdir }}/${{ inputs.amdgpu_family }}/ \
             s3://therock-${{ inputs.destbucket }}-python/${{ inputs.destsubdir }}/${{ inputs.amdgpu_family }}/ \
             --recursive --exclude "*"  --include "*torch*${{ inputs.rocm_version }}*${{ env.cp_version }}*"
-

--- a/.github/workflows/copy_release.yml
+++ b/.github/workflows/copy_release.yml
@@ -99,3 +99,4 @@ jobs:
             s3://therock-${{ inputs.sourcebucket }}-python/${{ inputs.sourcesubdir }}/${{ inputs.amdgpu_family }}/ \
             s3://therock-${{ inputs.destbucket }}-python/${{ inputs.destsubdir }}/${{ inputs.amdgpu_family }}/ \
             --recursive --exclude "*"  --include "*torch*${{ inputs.rocm_version }}*${{ env.cp_version }}*"
+

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -278,15 +278,6 @@ jobs:
           --include "*.whl" \
           --include "*.tar.gz"
 
-      - name: (Re-)Generate Python package release index for staging
-        if: ${{ github.repository_owner == 'ROCm' }}
-        env:
-          # Environment variable to be set for `manage.py`
-          CUSTOM_PREFIX: "${{ env.S3_STAGING_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}"
-        run: |
-          pip install boto3 packaging
-          python ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}
-
       ## TODO: Restrict uploading to the non-staging S3 directory until ROCm sanity checks and all validation tests have successfully passed.
       - name: Upload Releases to S3
         if: ${{ github.repository_owner == 'ROCm' }}
@@ -297,15 +288,6 @@ jobs:
           --exclude "*" \
           --include "*.whl" \
           --include "*.tar.gz"
-
-      - name: (Re-)Generate release index pages
-        if: ${{ github.repository_owner == 'ROCm' }}
-        env:
-          # Environment variable to be set for `manage.py`
-          CUSTOM_PREFIX: "${{ env.S3_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}"
-        run: |
-          pip install boto3 packaging
-          python ./build_tools/third_party/s3_management/manage.py  ${{ env.CUSTOM_PREFIX }}
 
       - name: Trigger building PyTorch wheels
         if: ${{ github.repository_owner == 'ROCm' && matrix.target_bundle.expect_pytorch_failure == false }}

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -301,15 +301,6 @@ jobs:
           --include "*.whl" \
           --include "*.tar.gz"
 
-      - name: (Re-)Generate Python package release index for staging
-        if: ${{ github.repository_owner == 'ROCm' }}
-        env:
-          # Environment variable to be set for `manage.py`
-          CUSTOM_PREFIX: "${{ env.S3_STAGING_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}"
-        run: |
-          pip install boto3 packaging
-          python ./build_tools/third_party/s3_management/manage.py ${{ env.CUSTOM_PREFIX }}
-
       ## TODO: Restrict uploading to the non-staging S3 directory until sanity checks and all validation tests have successfully passed.
       - name: Upload Releases to S3
         if: ${{ github.repository_owner == 'ROCm' }}
@@ -320,15 +311,6 @@ jobs:
           --exclude "*" \
           --include "*.whl" \
           --include "*.tar.gz"
-
-      - name: (Re-)Generate release index pages
-        if: ${{ github.repository_owner == 'ROCm' }}
-        env:
-          # Environment variable to be set for `manage.py`
-          CUSTOM_PREFIX: "${{ env.S3_SUBDIR }}/${{ matrix.target_bundle.amdgpu_family }}"
-        run: |
-          pip install boto3 packaging
-          python ./build_tools/third_party/s3_management/manage.py  ${{ env.CUSTOM_PREFIX }}
 
       - name: Trigger building PyTorch wheels
         if: ${{ github.repository_owner == 'ROCm' && matrix.target_bundle.expect_pytorch_failure == false }}


### PR DESCRIPTION
Removes manual index regeneration from CI workflows and shifts it to an S3 event-driven Lambda that invokes manage.py on object create/delete.

Key Changes:

- Eliminates duplicate index generation across workflows

- Avoids race conditions on shared prefixes

- Removes CI dependency setup (boto3, packaging)

- Centralizes and simplifies index updates

Scope

Covers both staging and release prefixes. Presently deployed in dev, nightly and prereleases for python buckets.

References
Resolves: https://github.com/ROCm/TheRock/issues/3321
Manage.py Refactor PR: https://github.com/ROCm/TheRock/pull/3737