### PR TITLE
[ci] Removing ctest timeout

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_fusilliprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_fusilliprovider.py
@@ -23,8 +23,6 @@ cmd = [
     "--output-on-failure",
     "--parallel",
     "8",
-    "--timeout",
-    "600",
 ]
 
 # Set up environment variables

--- a/build_tools/github_actions/test_executable_scripts/test_hipblasltprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblasltprovider.py
@@ -20,8 +20,6 @@ cmd = [
     "--output-on-failure",
     "--parallel",
     "8",
-    "--timeout",
-    "600",
 ]
 
 # Determine test filter based on TEST_TYPE environment variable

--- a/build_tools/github_actions/test_executable_scripts/test_hipcub.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipcub.py
@@ -103,8 +103,6 @@ cmd = [
     "8",
     "--resource-spec-file",
     resource_spec_file,
-    "--timeout",
-    "300",
 ]
 
 # If quick tests are enabled, we run quick tests only.

--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn.py
@@ -21,8 +21,6 @@ cmd = [
     "--output-on-failure",
     "--parallel",
     "8",
-    "--timeout",
-    "60",
 ]
 
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")

--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn_install.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn_install.py
@@ -96,8 +96,6 @@ def run_tests(build_dir: Path):
         "--output-on-failure",
         "--parallel",
         "8",
-        "--timeout",
-        "120",
     ]
     logging.info(f"++ Test: {shlex.join(test_cmd)}")
     subprocess.run(test_cmd, check=True, cwd=THEROCK_DIR, env=environ_vars)

--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn_integration_tests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn_integration_tests.py
@@ -20,8 +20,6 @@ cmd = [
     "--output-on-failure",
     "--parallel",
     "8",
-    "--timeout",
-    "600",
 ]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 

--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn_samples.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn_samples.py
@@ -20,8 +20,6 @@ cmd = [
     "--output-on-failure",
     "--parallel",
     "8",
-    "--timeout",
-    "300",
 ]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 

--- a/build_tools/github_actions/test_executable_scripts/test_hipkernelprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipkernelprovider.py
@@ -26,8 +26,6 @@ cmd = [
     "--output-on-failure",
     "--parallel",
     "8",
-    "--timeout",
-    "600",
 ]
 
 # Determine test filter based on TEST_TYPE environment variable

--- a/build_tools/github_actions/test_executable_scripts/test_hiprand.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiprand.py
@@ -20,8 +20,6 @@ cmd = [
     "--output-on-failure",
     "--parallel",
     "8",
-    "--timeout",
-    "60",
 ]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -151,8 +151,6 @@ def setup_env(env):
 
 
 def execute_tests(env):
-    # Allow for more time in ASAN mode to run the tests.
-    timeout = 1500 if is_asan() else 600
     cmd = [
         "ctest",
         "--tests-information",
@@ -160,8 +158,6 @@ def execute_tests(env):
         "--test-dir",
         CATCH_TESTS_PATH,
         "--output-on-failure",
-        "--timeout",
-        f"{timeout}",
     ]
 
     if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILIES]:

--- a/build_tools/github_actions/test_executable_scripts/test_miopenprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopenprovider.py
@@ -37,8 +37,6 @@ cmd = [
     "--output-on-failure",
     "--parallel",
     "8",
-    "--timeout",
-    "1200",
 ]
 
 if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILIES]:

--- a/build_tools/github_actions/test_executable_scripts/test_rocprim.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprim.py
@@ -109,8 +109,6 @@ cmd = [
     "--output-on-failure",
     "--parallel",
     "8",
-    "--timeout",
-    "900",
     "--repeat",
     "until-pass:6",
     # shards the tests by running a specific set of tests based on starting test (shard_index) and stride (total_shards)

--- a/build_tools/github_actions/test_executable_scripts/test_rocrand.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocrand.py
@@ -89,8 +89,6 @@ cmd = [
     "--output-on-failure",
     "--parallel",
     "8",
-    "--timeout",
-    "900",
     "--repeat",
     "until-pass:3",
 ]

--- a/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
@@ -134,8 +134,6 @@ cmd = [
     f"{ctest_parallel_count}",
     "--resource-spec-file",
     resource_spec_file,
-    "--timeout",
-    "300",
 ]
 
 # If quick tests are enabled, we run quick tests only.


### PR DESCRIPTION
After discussion with some math libs folks, we decided to remove the ctest subtest timeout, as these were hard-coded earlier and each test varies significantly in time.

The global timeout handles the timeout of the job: https://github.com/ROCm/TheRock/blob/e3bef8a43b95addccc3cd9490d5858de3d8ff050/.github/workflows/test_component.yml#L157

Changes:
- removing ctest timeout (per subtest level)