### PR TITLE
Wire multi-arch PyTorch wheel dispatch into release orchestrators

### DIFF
--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -133,6 +133,27 @@ jobs:
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
 
-  # TODO: dispatch pytorch wheels (release_portable_linux_pytorch_wheels.yml)
+  # TODO: Consider switch pulling ROCm packages from the CDN instead of the artifact
+  #   bucket if the job order is not altered.
+  build_pytorch_wheels:
+    needs: [build_artifacts, build_python_packages]
+    name: Build PyTorch Wheels
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+    steps:
+      - name: Trigger PyTorch Build
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
+        with:
+          workflow: multi_arch_release_linux_pytorch_wheels.yml
+          ref: ${{ inputs.ref || github.ref_name }}
+          inputs: |
+            { "amdgpu_families": "${{ fromJSON(inputs.build_config).dist_amdgpu_families }}",
+              "rocm_version": "${{ inputs.rocm_package_version }}",
+              "rocm_package_find_links_url": "${{ needs.build_python_packages.outputs.package_find_links_url }}",
+              "release_type": "${{ inputs.release_type }}",
+              "repository": "${{ inputs.repository || github.repository }}",
+              "ref": "${{ inputs.ref || '' }}"
+            }
 
   # TODO: dispatch jax wheels (release_portable_linux_jax_wheels.yml)

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -131,4 +131,25 @@ jobs:
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
 
-  # TODO: dispatch pytorch wheels
+  # TODO: Consider switch pulling ROCm packages from the CDN instead of the artifact
+  #   bucket if the job order is not altered.
+  build_pytorch_wheels:
+    needs: [build_artifacts, build_python_packages]
+    name: Build PyTorch Wheels
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+    steps:
+      - name: Trigger PyTorch Build
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
+        with:
+          workflow: multi_arch_release_windows_pytorch_wheels.yml
+          ref: ${{ inputs.ref || github.ref_name }}
+          inputs: |
+            { "amdgpu_families": "${{ fromJSON(inputs.build_config).dist_amdgpu_families }}",
+              "rocm_version": "${{ inputs.rocm_package_version }}",
+              "rocm_package_find_links_url": "${{ needs.build_python_packages.outputs.package_find_links_url }}",
+              "release_type": "${{ inputs.release_type }}",
+              "repository": "${{ inputs.repository || github.repository }}",
+              "ref": "${{ inputs.ref || '' }}"
+            }


### PR DESCRIPTION
## Motivation

With this the PyTorch build jobs get dispatched from the multi-arch release workflows. Both dispatched workflows have been landed to main with #4877 and #4895, respectively.

## Technical Details
The new job is gated on build_artifacts + build_python_packages and runs in parallel with publish_to_release_buckets; the required ROCm wheels get pulled from the release bucket and not the final index.

## Test Plan

A previous test run (https://github.com/ROCm/TheRock/actions/runs/25023992397) failed due to not having the dispatched workfkows in main yet but validates the inputs, then used in manually dispatched runs:

* https://github.com/ROCm/TheRock/actions/workflows/multi_arch_release_linux_pytorch_wheels.yml
* https://github.com/ROCm/TheRock/actions/workflows/multi_arch_release_windows_pytorch_wheels.yml

## Test Result

tbd

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
