### PR TITLE
Add Ruff PLW1514 (explicit encoding) to pre-commit and fix call sites

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,14 @@ repos:
     - id: actionlint
       args: [-shellcheck=, -ignore, 'label ".+" is unknown']
 
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.15.12
+  hooks:
+    - id: ruff
+      name: ruff (explicit text encoding, PLW1514)
+      args: [--select, PLW1514, --preview]
+      files: ^(build_tools|tests|external-builds)/
+
 - repo: local
   hooks:
   - id: test-file-naming

--- a/build_tools/_therock_utils/artifacts.py
+++ b/build_tools/_therock_utils/artifacts.py
@@ -193,7 +193,7 @@ class ArtifactPopulator:
                 # Process an exploded artifact dir.
                 self.on_artifact_dir(artifact_path)
                 manifest_path: Path = artifact_path / "artifact_manifest.txt"
-                relpaths = manifest_path.read_text().splitlines()
+                relpaths = manifest_path.read_text(encoding="utf-8").splitlines()
                 for relpath in relpaths:
                     if not relpath:
                         continue

--- a/build_tools/_therock_utils/cmake_amdgpu_targets.py
+++ b/build_tools/_therock_utils/cmake_amdgpu_targets.py
@@ -40,7 +40,7 @@ def parse_amdgpu_targets_cmake(cmake_path: Path) -> list[AmdgpuTargetInfo]:
             "Expected at cmake/therock_amdgpu_targets.cmake relative to repo root."
         )
 
-    content = cmake_path.read_text()
+    content = cmake_path.read_text(encoding="utf-8")
     results: list[AmdgpuTargetInfo] = []
 
     # Each therock_add_amdgpu_target() call has the form:

--- a/build_tools/_therock_utils/hash_util.py
+++ b/build_tools/_therock_utils/hash_util.py
@@ -22,6 +22,6 @@ def calculate_hash(file, hash_algorithm):
 
 
 def write_hash(hash_file, digest):
-    with open(hash_file, "wt") as f:
+    with open(hash_file, "wt", encoding="utf-8") as f:
         f.write(digest.hexdigest())
         f.write("\n")

--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -158,7 +158,7 @@ def _is_current_run_pr_from_fork() -> bool:
     if not event_path:
         return False
 
-    with open(event_path) as f:
+    with open(event_path, encoding="utf-8") as f:
         event = json.load(f)
 
     return bool(

--- a/build_tools/analyze_build_times.py
+++ b/build_tools/analyze_build_times.py
@@ -119,7 +119,7 @@ def parse_ninja_log(log_path: Path) -> List[Task]:
     """Parse .ninja_log and return list of Task objects."""
     tasks = []
     try:
-        with open(log_path, "r") as f:
+        with open(log_path, "r", encoding="utf-8") as f:
             f.readline()  # Skip header
             for line in f:
                 parts = line.strip().split("\t")
@@ -297,7 +297,7 @@ def get_system_info() -> Dict[str, str]:
 
     # Get CPU model from /proc/cpuinfo
     try:
-        with open("/proc/cpuinfo", "r") as f:
+        with open("/proc/cpuinfo", "r", encoding="utf-8") as f:
             for line in f:
                 if line.startswith("model name"):
                     info["cpu_model"] = line.split(":")[1].strip()
@@ -313,7 +313,7 @@ def get_system_info() -> Dict[str, str]:
 
     # Get memory from /proc/meminfo
     try:
-        with open("/proc/meminfo", "r") as f:
+        with open("/proc/meminfo", "r", encoding="utf-8") as f:
             for line in f:
                 if line.startswith("MemTotal"):
                     kb = int(line.split()[1])
@@ -462,7 +462,7 @@ def generate_report(
             .replace("{{DEP_TABLE}}", dep_html)
             .replace("{{COMP_SUMMARY}}", comp_summary_html)
         )
-        output_file.write_text(html)
+        output_file.write_text(html, encoding="utf-8")
         print(f"HTML report generated at: {output_file}")
     except FileNotFoundError:
         print(f"Error: Template file not found at {template_path}")

--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -68,7 +68,7 @@ def load_rocm_version() -> str:
     """Loads the rocm-version from the repository's version.json file."""
     version_file = THEROCK_DIR / "version.json"
     _log(f"Loading version from file '{version_file.resolve()}'")
-    with open(version_file, "rt") as f:
+    with open(version_file, "rt", encoding="utf-8") as f:
         loaded_file = json.load(f)
         return loaded_file["rocm-version"]
 

--- a/build_tools/export_source_archive.py
+++ b/build_tools/export_source_archive.py
@@ -106,7 +106,7 @@ class TarArchiveWriter(ArchiveWriter):
         self.archive.add(str(path), arcname, recursive=True)
 
     def add_text(self, text: str, arcname: str):
-        with tempfile.NamedTemporaryFile(mode="wt") as tf:
+        with tempfile.NamedTemporaryFile(encoding="utf-8", mode="wt") as tf:
             tf.write(text)
             self.archive.add(Path(tf.name), arcname)
 

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -89,7 +89,7 @@ def do_artifact_archive(args):
     ) as arc:
         for artifact_path in args.artifact:
             manifest_path: Path = artifact_path / "artifact_manifest.txt"
-            relpaths = manifest_path.read_text().splitlines()
+            relpaths = manifest_path.read_text(encoding="utf-8").splitlines()
             # Important: The manifest must be stored first.
             arc.add(manifest_path, arcname=manifest_path.name, recursive=False)
             for relpath in relpaths:

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -105,7 +105,7 @@ def update_ref_in_file(file_path, new_sha):
     Update all ROCm/TheRock refs in a YAML file.
     Replaces existing 'ref:' after 'repository: "ROCm/TheRock"'.
     """
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
     updated_lines = []
@@ -150,7 +150,7 @@ def update_ref_in_file(file_path, new_sha):
                 i = ref_line_index
         i += 1
 
-    with open(file_path, "w") as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         f.writelines(updated_lines)
 
     print(f"[INFO] Updated {file_path}")

--- a/build_tools/github_actions/compute_jax_package_version.py
+++ b/build_tools/github_actions/compute_jax_package_version.py
@@ -42,7 +42,7 @@ def extract_jax_version_from_requirements(requirements_path: str) -> str:
     """
     pattern = re.compile(r"^\s*(jax|jaxlib)\s*==\s*([^#\s]+)")
 
-    with open(requirements_path, "r") as f:
+    with open(requirements_path, "r", encoding="utf-8") as f:
         for line in f:
             match = pattern.match(line.strip())
             if match:

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -171,7 +171,7 @@ class CIInputs:
 
         # Read the full event webhook payload (common to all event triggers).
         event_path = os.environ["GITHUB_EVENT_PATH"]
-        with open(event_path) as f:
+        with open(event_path, encoding="utf-8") as f:
             event = json.load(f)
 
         # Workflow inputs are passed as environment variables by

--- a/build_tools/github_actions/github_actions_api.py
+++ b/build_tools/github_actions/github_actions_api.py
@@ -313,7 +313,7 @@ def gha_add_to_path(new_path: str | Path):
         _log("  Warning: GITHUB_PATH env var not set, can't add to path")
         return
 
-    with open(path_file, "a") as f:
+    with open(path_file, "a", encoding="utf-8") as f:
         f.write(str(new_path))
 
 
@@ -332,7 +332,7 @@ def gha_set_env(vars: Mapping[str, str | Path]):
         _log("  Warning: GITHUB_ENV env var not set, can't set environment variable")
         return
 
-    with open(env_file, "a") as f:
+    with open(env_file, "a", encoding="utf-8") as f:
         f.writelines(f"{k}={str(v)}" + "\n" for k, v in vars.items())
 
 
@@ -352,7 +352,7 @@ def gha_set_output(vars: Mapping[str, str | Path]):
         _log("  Warning: GITHUB_OUTPUT env var not set, can't set github outputs")
         return
 
-    with open(step_output_file, "a") as f:
+    with open(step_output_file, "a", encoding="utf-8") as f:
         for k, v in vars.items():
             print(f"OUTPUT {k}={str(v)}")
             f.write(f"{k}={str(v)}\n")
@@ -374,7 +374,7 @@ def gha_append_step_summary(summary: str):
         _log("  Warning: GITHUB_STEP_SUMMARY env var not set, can't write job summary")
         return
 
-    with open(step_summary_file, "a") as f:
+    with open(step_summary_file, "a", encoding="utf-8") as f:
         # Use double newlines to split sections in markdown.
         f.write(summary + "\n\n")
 

--- a/build_tools/github_actions/hip_tagging_helper.py
+++ b/build_tools/github_actions/hip_tagging_helper.py
@@ -38,7 +38,7 @@ def get_rocm_version():
     Reads version.json from repo root.
     Returns major.minor
     """
-    with open("version.json", "r") as f:
+    with open("version.json", "r", encoding="utf-8") as f:
         data = json.load(f)
 
     full_version = data["rocm-version"]

--- a/build_tools/github_actions/reproduce_test_failure.py
+++ b/build_tools/github_actions/reproduce_test_failure.py
@@ -310,7 +310,9 @@ def run_windows(args: argparse.Namespace) -> int:
     script_content = "\n".join(lines)
 
     # Write to temp file and execute
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".ps1", delete=False) as f:
+    with tempfile.NamedTemporaryFile(
+        encoding="utf-8", mode="w", suffix=".ps1", delete=False
+    ) as f:
         f.write(script_content)
         script_path = f.name
 

--- a/build_tools/github_actions/test_executable_scripts/test_libhipcxx_hipcc.py
+++ b/build_tools/github_actions/test_executable_scripts/test_libhipcxx_hipcc.py
@@ -31,7 +31,7 @@ def load_rocm_version() -> str:
     """Loads the rocm-version from the repository's version.json file."""
     version_file = THEROCK_DIR / "version.json"
     logging.info(f"Loading ROCm version from: {version_file}")
-    with open(version_file, "rt") as f:
+    with open(version_file, "rt", encoding="utf-8") as f:
         loaded_file = json.load(f)
         return loaded_file["rocm-version"]
 

--- a/build_tools/github_actions/test_executable_scripts/test_libhipcxx_hiprtc.py
+++ b/build_tools/github_actions/test_executable_scripts/test_libhipcxx_hiprtc.py
@@ -31,7 +31,7 @@ def load_rocm_version() -> str:
     """Loads the rocm-version from the repository's version.json file."""
     version_file = THEROCK_DIR / "version.json"
     logging.info(f"Loading ROCm version from: {version_file}")
-    with open(version_file, "rt") as f:
+    with open(version_file, "rt", encoding="utf-8") as f:
         loaded_file = json.load(f)
         return loaded_file["rocm-version"]
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocgdb.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocgdb.py
@@ -902,7 +902,7 @@ def setup_core_file_info() -> bool:
     core_pattern_file = Path("/proc/sys/kernel/core_pattern")
     try:
         if core_pattern_file.exists():
-            core_pattern = core_pattern_file.read_text().strip()
+            core_pattern = core_pattern_file.read_text(encoding="utf-8").strip()
             logger.info(f"System core file pattern: {core_pattern}")
         else:
             logger.info("System core file pattern: N/A (file not found)")
@@ -1019,7 +1019,7 @@ def set_test_timeout(test_suite_dir: Path, timeout_value: int) -> None:
     """
     site_exp_file = test_suite_dir / "site.exp"
     try:
-        with open(site_exp_file, "a") as f:
+        with open(site_exp_file, "a", encoding="utf-8") as f:
             f.write(f"\nset gdb_test_timeout {timeout_value}\n")
         logger.info(
             f"{STATUS_PASS} Successfully set gdb_test_timeout to {timeout_value} in {site_exp_file}"

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -49,7 +49,9 @@ def _run_from_environ(
 
     See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-environment-variables#default-environment-variables
     """
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+    with tempfile.NamedTemporaryFile(
+        encoding="utf-8", mode="w", suffix=".json", delete=False
+    ) as f:
         json.dump(event_payload, f)
         event_path = f.name
 

--- a/build_tools/github_actions/tests/detect_external_repo_config_test.py
+++ b/build_tools/github_actions/tests/detect_external_repo_config_test.py
@@ -73,7 +73,9 @@ class TestOutputGithubActionsVars(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures"""
         # Create temporary file for GITHUB_OUTPUT
-        with tempfile.NamedTemporaryFile(mode="w+", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            encoding="utf-8", mode="w+", delete=False
+        ) as f:
             self.temp_file = f.name
         os.environ["GITHUB_OUTPUT"] = self.temp_file
 
@@ -97,7 +99,7 @@ class TestOutputGithubActionsVars(unittest.TestCase):
         output_github_actions_vars(config)
 
         # Read the output file
-        with open(self.temp_file, "r") as f:
+        with open(self.temp_file, "r", encoding="utf-8") as f:
             output = f.read()
 
         # Verify output format
@@ -114,7 +116,7 @@ class TestOutputGithubActionsVars(unittest.TestCase):
 
         output_github_actions_vars(config)
 
-        with open(self.temp_file, "r") as f:
+        with open(self.temp_file, "r", encoding="utf-8") as f:
             output = f.read()
 
         # Verify lowercase (important for bash conditionals)
@@ -135,7 +137,7 @@ class TestOutputGithubActionsVars(unittest.TestCase):
         )
         self.assertEqual(rc, 0)
 
-        with open(self.temp_file, "r") as f:
+        with open(self.temp_file, "r", encoding="utf-8") as f:
             output = f.read()
 
         # Verify extra_cmake_options is included

--- a/build_tools/github_actions/tests/workflow_utils.py
+++ b/build_tools/github_actions/tests/workflow_utils.py
@@ -12,7 +12,7 @@ WORKFLOWS_DIR = Path(__file__).resolve().parents[3] / ".github" / "workflows"
 
 def load_workflow(path: Path) -> dict:
     """Loads a YAML workflow file from the given Path as a JSON dictionary."""
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 

--- a/build_tools/hack/env_check/device.py
+++ b/build_tools/hack/env_check/device.py
@@ -108,7 +108,7 @@ class SystemInfo:
 
         @property
         def is_WSL2(self):
-            with open("/proc/version", "r") as f:
+            with open("/proc/version", "r", encoding="utf-8") as f:
                 _f = f.read()
             return True if "microsoft-standard-WSL2" in _f else False
 
@@ -139,7 +139,7 @@ class SystemInfo:
             kernel = subprocess.check_output(["uname", "-r"], text=True).strip()
             kernel_version = kernel.split("-")[0]
 
-            with open("/etc/os-release") as f:
+            with open("/etc/os-release", encoding="utf-8") as f:
                 _f = f.read().splitlines()
                 for _line in _f:
                     _name_match = re.match(r'^NAME="?(.*?)"?$', _line)
@@ -314,7 +314,7 @@ class SystemInfo:
         elif self.is_linux:
             import re
 
-            with open("/proc/meminfo", "r") as f:
+            with open("/proc/meminfo", "r", encoding="utf-8") as f:
                 _f = f.read().splitlines()
                 for line in _f:
                     mem_tol = re.search(r"^MemTotal:\s+(\d+)\s+kB$", line)

--- a/build_tools/hack/env_check/find_tools.py
+++ b/build_tools/hack/env_check/find_tools.py
@@ -137,7 +137,9 @@ class FindPython(FindProgram):
         elif sys.prefix == sys.base_prefix:
             return False, "Global ENV"
         elif os.getenv("VIRTUAL_ENV") is not None:
-            with open(Path(f"{sys.prefix}/pyvenv.cfg").resolve(), "r") as file:
+            with open(
+                Path(f"{sys.prefix}/pyvenv.cfg").resolve(), "r", encoding="utf-8"
+            ) as file:
                 _conf = file.read()
             _env_type = "uv VENV" if "uv" in _conf else "Python VENV"
             return True, _env_type

--- a/build_tools/merge_compile_commands.py
+++ b/build_tools/merge_compile_commands.py
@@ -29,5 +29,5 @@ for input_file in input_files:
         this_records = json.load(f)
     records.extend(this_records)
 
-with open(output_file, "wt") as f:
+with open(output_file, "wt", encoding="utf-8") as f:
     json.dump(records, f, check_circular=False, indent="  ")

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -20,12 +20,14 @@ import get_url_repo_params
 
 def _run_main_with_output(argv: list[str]) -> tuple[int, str]:
     """Run main() with a temp GITHUB_OUTPUT file; return (exit_code, file_contents)."""
-    with tempfile.NamedTemporaryFile(mode="r", suffix=".txt", delete=False) as f:
+    with tempfile.NamedTemporaryFile(
+        encoding="utf-8", mode="r", suffix=".txt", delete=False
+    ) as f:
         tmp_path = f.name
     try:
         with patch.dict(os.environ, {"GITHUB_OUTPUT": tmp_path}):
             code = get_url_repo_params.main(argv)
-        contents = Path(tmp_path).read_text()
+        contents = Path(tmp_path).read_text(encoding="utf-8")
     finally:
         os.unlink(tmp_path)
     return code, contents

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -219,7 +219,7 @@ def generate_release_file_with_checksums(release_file, job_type, dists_dir):
         sha256_entries.append(f" {sha256_hash.hexdigest()} {file_size:16d} {rel_path}")
 
     # Write Release file
-    with open(release_file, "w") as f:
+    with open(release_file, "w", encoding="utf-8") as f:
         # Header fields
         f.write(
             f"""Origin: AMD ROCm
@@ -326,7 +326,7 @@ def regenerate_deb_metadata_from_s3(
                 f"Downloading existing Packages file from S3: s3://{bucket}/{packages_s3_key}"
             )
             s3.download_file(bucket, packages_s3_key, str(existing_packages))
-            with open(existing_packages, "r") as f:
+            with open(existing_packages, "r", encoding="utf-8") as f:
                 content = f.read()
                 pkg_count = content.count("\nPackage: ")
             print(f"✅ Downloaded existing Packages file ({pkg_count} packages)")
@@ -378,7 +378,7 @@ def regenerate_deb_metadata_from_s3(
             def parse_packages_file(filepath):
                 """Parse Packages file into dict keyed by Filename"""
                 packages = {}
-                with open(filepath, "r") as f:
+                with open(filepath, "r", encoding="utf-8") as f:
                     current_entry = []
                     current_filename = None
 
@@ -409,7 +409,7 @@ def regenerate_deb_metadata_from_s3(
             merged = old_packages.copy()
             merged.update(new_packages_dict)
 
-            with open(merged_packages, "w") as outfile:
+            with open(merged_packages, "w", encoding="utf-8") as outfile:
                 for filename in sorted(merged.keys()):
                     outfile.write(merged[filename])
                     outfile.write("\n")
@@ -503,7 +503,7 @@ def create_deb_repo(package_dir, job_type):
     run_command("gzip -9c Packages > Packages.gz", cwd=dists)
 
     release = os.path.join(package_dir, "dists", "stable", "Release")
-    with open(release, "w") as f:
+    with open(release, "w", encoding="utf-8") as f:
         f.write(
             f"""Origin: AMD ROCm
 Label: ROCm {job_type} Packages

--- a/build_tools/packaging/promote_from_rc_to_final.py
+++ b/build_tools/packaging/promote_from_rc_to_final.py
@@ -269,7 +269,9 @@ def promote_targz_sdist(filename: pathlib.Path, prerelease_type: str) -> bool:
         targz.close()
         print(" ...done")
 
-        with open(tmp_path / f"{package_name}" / "PKG-INFO", "r") as info:
+        with open(
+            tmp_path / f"{package_name}" / "PKG-INFO", "r", encoding="utf-8"
+        ) as info:
             for line in info.readlines():
                 if line.startswith("Version"):
                     version = Version(line.removeprefix("Version:").strip())

--- a/build_tools/packaging/python/generate_s3_index.py
+++ b/build_tools/packaging/python/generate_s3_index.py
@@ -91,7 +91,9 @@ def main(args):
     objects = get_objects(args.bucket, args.subdir)
     url = f"https://{args.bucket}.{args.endpoint}/{args.subdir}"
 
-    with sys.stdout if args.output == "-" else open(args.output, "w") as f:
+    with (
+        sys.stdout if args.output == "-" else open(args.output, "w", encoding="utf-8")
+    ) as f:
         f.write(
             textwrap.dedent(
                 """\

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -182,7 +182,7 @@ def _lock_and_expand(
         if dir.exists():
             shutil.rmtree(dir, ignore_errors=False)
 
-    with open(record_path, "at") as record_file:
+    with open(record_path, "at", encoding="utf-8") as record_file:
         file_lock = FileLock(record_file)
         try:
             with tarfile.open(tarfile_path, tarfile_mode) as tf:

--- a/build_tools/patch_third_party_source.py
+++ b/build_tools/patch_third_party_source.py
@@ -38,7 +38,7 @@ def run_command(cmd_list, cwd=None):
 
 
 def create_stamp_file(filename):
-    with open(filename, "w") as f:
+    with open(filename, "w", encoding="utf-8") as f:
         pass
 
 

--- a/build_tools/posix_ccache_compiler_check.py
+++ b/build_tools/posix_ccache_compiler_check.py
@@ -104,7 +104,7 @@ compiler_fingerprint = compute_compiler_fingerprint()
 hash_commit_file = Path(f"{compiler_exe_path_hash_file}.tmp{os.getpid()}")
 hash_commit_file.parent.mkdir(parents=True, exist_ok=True)
 try:
-    hash_commit_file.write_text(compiler_fingerprint)
+    hash_commit_file.write_text(compiler_fingerprint, encoding="utf-8")
     os.rename(hash_commit_file, compiler_exe_path_hash_file)
 except OSError:
     # Ignore.

--- a/build_tools/setup_sccache_rocm.py
+++ b/build_tools/setup_sccache_rocm.py
@@ -165,7 +165,7 @@ def create_sccache_wrapper(compiler_path: Path, sccache_path: Path) -> None:
                 f"  Created sccache wrapper: {compiler_path} -> sccache {real_compiler}"
             )
         else:
-            compiler_path.write_text(wrapper_content)
+            compiler_path.write_text(wrapper_content, encoding="utf-8")
             compiler_path.chmod(
                 stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
             )

--- a/build_tools/tests/artifact_backend_test.py
+++ b/build_tools/tests/artifact_backend_test.py
@@ -586,7 +586,7 @@ class TestS3BackendCredentials(unittest.TestCase):
         # Write a minimal credentials file. Values are intentionally not
         # real AWS keys — boto3 loads any syntactically valid values.
         with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".ini", delete=False
+            encoding="utf-8", mode="w", suffix=".ini", delete=False
         ) as creds_file:
             creds_file.write(
                 "[default]\n"

--- a/build_tools/tests/build_topology_test.py
+++ b/build_tools/tests/build_topology_test.py
@@ -30,7 +30,7 @@ class BuildTopologyTest(unittest.TestCase):
         """Set up test fixtures."""
         # Create a temporary file and close it immediately to avoid file locking on Windows
         with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".toml", delete=False
+            encoding="utf-8", mode="w", suffix=".toml", delete=False
         ) as temp_file:
             self.topology_path = temp_file.name
 
@@ -41,7 +41,7 @@ class BuildTopologyTest(unittest.TestCase):
 
     def write_topology(self, content: str):
         """Write topology content to temp file."""
-        with open(self.topology_path, "w") as f:
+        with open(self.topology_path, "w", encoding="utf-8") as f:
             f.write(textwrap.dedent(content))
 
     def test_empty_topology(self):

--- a/build_tools/tests/cmake_amdgpu_targets_test.py
+++ b/build_tools/tests/cmake_amdgpu_targets_test.py
@@ -20,7 +20,9 @@ class ParseAmdgpuTargetsCmakeTest(unittest.TestCase):
     def _parse(self, cmake_text: str) -> list[AmdgpuTargetInfo]:
         import tempfile
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".cmake", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            encoding="utf-8", mode="w", suffix=".cmake", delete=False
+        ) as f:
             f.write(textwrap.dedent(cmake_text))
             tmp_path = Path(f.name)
         try:

--- a/build_tools/tests/fileset_tool_test.py
+++ b/build_tools/tests/fileset_tool_test.py
@@ -46,7 +46,7 @@ def run_command(args: list[str | Path], cwd: Path = FILESET_TOOL.parent):
 
 def write_text(p: Path, text: str):
     p.parent.mkdir(exist_ok=True, parents=True)
-    p.write_text(text)
+    p.write_text(text, encoding="utf-8")
 
 
 def is_windows():

--- a/build_tools/tests/s3_buckets_test.py
+++ b/build_tools/tests/s3_buckets_test.py
@@ -206,7 +206,9 @@ class TestGetArtifactsBucketConfigForWorkflowRun(unittest.TestCase):
         Uses delete=False because NamedTemporaryFile(delete=True) holds an
         exclusive lock on Windows, preventing the code under test from reading.
         """
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            encoding="utf-8", mode="w", suffix=".json", delete=False
+        ) as f:
             json.dump(event, f)
             return f.name
 

--- a/build_tools/third_party/implib/implib-gen.py
+++ b/build_tools/third_party/implib/implib-gen.py
@@ -133,7 +133,7 @@ def collect_def_exports(filename):
 
   syms = []
 
-  with open(filename, 'r') as f:
+  with open(filename, 'r', encoding='utf-8') as f:
     lines = f.readlines()
   lines.reverse()
 
@@ -392,7 +392,7 @@ def read_soname(f):
 def read_library_name(filename):
   """Read library name from .def file."""
 
-  with open(filename, 'r') as f:
+  with open(filename, 'r', encoding='utf-8') as f:
     for line in f.readlines():
       line = line.strip()
       m = re.match(r'^(?:LIBRARY|NAME)\s+([A-Za-z0-9_.\-]+)$', line)
@@ -511,7 +511,7 @@ Examples:
   if args.symbol_list is None:
     funs = None
   else:
-    with open(args.symbol_list, 'r') as f:
+    with open(args.symbol_list, 'r', encoding='utf-8') as f:
       funs = []
       for line in re.split(r'\r?\n', f.read()):
         line = re.sub(r'#.*', '', line)
@@ -669,16 +669,16 @@ Examples:
   lib_suffix = re.sub(r'[^a-zA-Z_0-9]+', '_', suffix)
 
   tramp_file = f'{suffix}.tramp.S'
-  with open(os.path.join(outdir, tramp_file), 'w') as f:
+  with open(os.path.join(outdir, tramp_file), 'w', encoding='utf-8') as f:
     if not quiet:
       print(f"Generating {tramp_file}...")
-    with open(target_dir + '/table.S.tpl', 'r') as t:
+    with open(target_dir + '/table.S.tpl', 'r', encoding='utf-8') as t:
       table_text = string.Template(t.read()).substitute(
         lib_suffix=lib_suffix,
         table_size=ptr_size*(len(funs) + 1))
     f.write(table_text)
 
-    with open(target_dir + '/trampoline.S.tpl', 'r') as t:
+    with open(target_dir + '/trampoline.S.tpl', 'r', encoding='utf-8') as t:
       tramp_tpl = string.Template(t.read())
 
     for i, name in enumerate(funs):
@@ -692,10 +692,10 @@ Examples:
   # Generate C code
 
   init_file = f'{suffix}.init.c'
-  with open(os.path.join(outdir, init_file), 'w') as f:
+  with open(os.path.join(outdir, init_file), 'w', encoding='utf-8') as f:
     if not quiet:
       print(f"Generating {init_file}...")
-    with open(os.path.join(root, 'arch/common/init.c.tpl'), 'r') as t:
+    with open(os.path.join(root, 'arch/common/init.c.tpl'), 'r', encoding='utf-8') as t:
       if funs:
         sym_names = ',\n  '.join(f'"{name}"' for name in funs) + ','
       else:

--- a/build_tools/topology_to_cmake.py
+++ b/build_tools/topology_to_cmake.py
@@ -347,7 +347,7 @@ def main():
     # Create parent directory if needed
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         write_cmake_header(f)
         generate_validation_metadata(topology, f)
         generate_feature_declarations(topology, f)

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -484,7 +484,7 @@ def _setup_common_build_env(
     if triton_dir:
         triton_env_file = triton_dir / "build_env.json"
         if triton_env_file.exists():
-            with open(triton_env_file, "r") as f:
+            with open(triton_env_file, "r", encoding="utf-8") as f:
                 addl_triton_env = json.load(f)
                 print(f"-- Additional triton build env vars: {addl_triton_env}")
             env.update(addl_triton_env)

--- a/external-builds/pytorch/generate_test_sharding_matrix.py
+++ b/external-builds/pytorch/generate_test_sharding_matrix.py
@@ -112,7 +112,7 @@ def main() -> None:
 
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
-        with open(github_output, "a") as f:
+        with open(github_output, "a", encoding="utf-8") as f:
             f.write(f"matrix={matrix_json}\n")
     else:
         print(f"\nmatrix={matrix_json}")

--- a/external-builds/pytorch/pytorch_triton_repo.py
+++ b/external-builds/pytorch/pytorch_triton_repo.py
@@ -99,7 +99,7 @@ def do_checkout(args: argparse.Namespace):
 
     def _do_hipify(args: argparse.Namespace):
         print("Applying local modifications...")
-        with open(repo_dir / "build_env.json", "w") as f:
+        with open(repo_dir / "build_env.json", "w", encoding="utf-8") as f:
             json.dump(build_env, f, indent=2)
 
     repo_management.do_checkout(args, custom_hipify=_do_hipify)

--- a/external-builds/pytorch/windows_patch_fat_wheel.py
+++ b/external-builds/pytorch/windows_patch_fat_wheel.py
@@ -79,8 +79,8 @@ def process_wheel(
 
 
 def patch_init_py(init_py_path: Path):
-    lines = init_py_path.read_text().splitlines(keepends=True)
-    with open(init_py_path, "w") as out:
+    lines = init_py_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    with open(init_py_path, "w", encoding="utf-8") as out:
         for line in lines:
             if "for dll_path in dll_paths:" in line:
                 indent_count = len(line) - len(line.lstrip())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+# Ruff configuration for first-party TheRock Python (not submodules).
+# https://docs.astral.sh/ruff/
+
+[tool.ruff]
+extend-exclude = [
+    "base",
+    "comm-libs",
+    "compiler",
+    "core",
+    "dctools",
+    "debug-tools",
+    "examples",
+    "iree-libs",
+    "math-libs",
+    "media-libs",
+    "ml-libs",
+    "patches",
+    "profiler",
+    "rocm-libraries",
+    "rocm-systems",
+    "third-party",
+    "dockerfiles",
+]
+
+[tool.ruff.lint]
+# PLW1514: require explicit encoding for open() and pathlib text helpers.
+# Preview until the rule is stabilized; see https://docs.astral.sh/ruff/rules/unspecified-encoding/
+preview = true
+extend-select = ["PLW1514"]

--- a/tests/extended_tests/benchmark/scripts/test_hipblaslt_benchmark.py
+++ b/tests/extended_tests/benchmark/scripts/test_hipblaslt_benchmark.py
@@ -40,7 +40,7 @@ class HipblasltBenchmark(BenchmarkBase):
 
         # Load benchmark configuration
         config_file = self.script_dir.parent / "configs" / "hipblaslt.json"
-        with open(config_file, "r") as f:
+        with open(config_file, "r", encoding="utf-8") as f:
             config_data = json.load(f)
 
         # Combine test configurations: (shapes_list, transB_value)
@@ -51,7 +51,7 @@ class HipblasltBenchmark(BenchmarkBase):
 
         log.info("Running hipBLASLt Benchmarks")
 
-        with open(self.log_file, "w+") as f:
+        with open(self.log_file, "w+", encoding="utf-8") as f:
             for shapes_list, transB in test_configs:
                 for input_shape in shapes_list:
                     M, N, K, B = input_shape.split()
@@ -181,7 +181,7 @@ class HipblasltBenchmark(BenchmarkBase):
             )
 
         try:
-            with open(self.log_file, "r") as log_fp:
+            with open(self.log_file, "r", encoding="utf-8") as log_fp:
                 data = log_fp.readlines()
 
             # Find CSV header line

--- a/tests/extended_tests/benchmark/scripts/test_rccl_benchmark.py
+++ b/tests/extended_tests/benchmark/scripts/test_rccl_benchmark.py
@@ -36,7 +36,7 @@ class RCCLBenchmark(BenchmarkBase):
         """Run RCCL benchmarks and save output to log file."""
         # Load benchmark configuration
         config_file = self.script_dir.parent / "configs" / "rccl.json"
-        with open(config_file, "r") as f:
+        with open(config_file, "r", encoding="utf-8") as f:
             config_data = json.load(f)
 
         # Get configuration
@@ -58,7 +58,7 @@ class RCCLBenchmark(BenchmarkBase):
 
         log.info("Running RCCL Benchmarks")
 
-        with open(self.log_file, "w+") as f:
+        with open(self.log_file, "w+", encoding="utf-8") as f:
             for benchmark in benchmarks:
                 bench_binary = Path(self.therock_bin_dir) / benchmark
 
@@ -132,7 +132,7 @@ class RCCLBenchmark(BenchmarkBase):
         test_results = []
 
         try:
-            with open(self.log_file, "r") as log_fp:
+            with open(self.log_file, "r", encoding="utf-8") as log_fp:
                 content = log_fp.read()
             # Split by benchmark sections
             sections = content.split("=" * 80)

--- a/tests/extended_tests/benchmark/scripts/test_rocblas_benchmark.py
+++ b/tests/extended_tests/benchmark/scripts/test_rocblas_benchmark.py
@@ -28,7 +28,7 @@ class ROCblasBenchmark(BenchmarkBase):
     def run_benchmarks(self) -> None:
         """Run ROCblas benchmarks and save output to log files."""
         config_file = self.script_dir.parent / "configs" / "rocblas.json"
-        with open(config_file) as f:
+        with open(config_file, encoding="utf-8") as f:
             config_data = json.load(f)
 
         benchmark_config = config_data.get("benchmark_config", {})
@@ -89,7 +89,7 @@ class ROCblasBenchmark(BenchmarkBase):
                 )
                 bench_config.update(overrides)
 
-            with open(log_file, "w+") as f:
+            with open(log_file, "w+", encoding="utf-8") as f:
                 precision_values = bench_config.get("precision", ["s"])
                 if not isinstance(precision_values, list):
                     precision_values = [precision_values]
@@ -315,7 +315,7 @@ class ROCblasBenchmark(BenchmarkBase):
             suite_table.title = f"ROCblas {suite_name} Benchmark Results"
 
             try:
-                with open(log_file, "r") as log_fp:
+                with open(log_file, "r", encoding="utf-8") as log_fp:
                     lines = log_fp.readlines()
 
                 # Parse line by line, looking for CSV header followed by data

--- a/tests/extended_tests/benchmark/scripts/test_rocfft_benchmark.py
+++ b/tests/extended_tests/benchmark/scripts/test_rocfft_benchmark.py
@@ -36,7 +36,7 @@ class ROCfftBenchmark(BenchmarkBase):
 
         # Load benchmark configuration
         config_file = self.script_dir.parent / "configs" / "rocfft.json"
-        with open(config_file, "r") as f:
+        with open(config_file, "r", encoding="utf-8") as f:
             data = json.load(f)
 
         test_cases = data.get("generic", [])
@@ -45,7 +45,7 @@ class ROCfftBenchmark(BenchmarkBase):
 
         log.info("Running ROCfft Benchmarks")
 
-        with open(self.log_file, "w+") as f:
+        with open(self.log_file, "w+", encoding="utf-8") as f:
             for test_case in test_cases:
                 # Extract batch size from test case string (if specified)
                 pattern_batch_size = re.compile(r"-b\s+(\d+)")
@@ -122,7 +122,7 @@ class ROCfftBenchmark(BenchmarkBase):
         batch_size = default_batch_size
 
         try:
-            with open(self.log_file, "r") as log_fp:
+            with open(self.log_file, "r", encoding="utf-8") as log_fp:
 
                 for line in log_fp:
                     # Extract batch size from command line

--- a/tests/extended_tests/benchmark/scripts/test_rocrand_benchmark.py
+++ b/tests/extended_tests/benchmark/scripts/test_rocrand_benchmark.py
@@ -47,7 +47,7 @@ class ROCrandBenchmark(BenchmarkBase):
             log_file = self.script_dir / f"{bench_type}_bench.log"
 
             # Run benchmark
-            with open(log_file, "w+") as f:
+            with open(log_file, "w+", encoding="utf-8") as f:
                 cmd = [
                     f"{self.therock_bin_dir}/{bench_bin}",
                     "--trials",
@@ -117,7 +117,7 @@ class ROCrandBenchmark(BenchmarkBase):
             log.info(f"Parsing {bench_type} results")
 
             try:
-                with open(log_file, "r") as f:
+                with open(log_file, "r", encoding="utf-8") as f:
                     data = f.read()
 
                 # Find the CSV data in the file

--- a/tests/extended_tests/benchmark/scripts/test_rocsolver_benchmark.py
+++ b/tests/extended_tests/benchmark/scripts/test_rocsolver_benchmark.py
@@ -33,7 +33,7 @@ class ROCsolverBenchmark(BenchmarkBase):
         """Run ROCsolver benchmarks and save output to log file."""
         log.info("Running ROCsolver Benchmarks")
 
-        with open(self.log_file, "w+") as f:
+        with open(self.log_file, "w+", encoding="utf-8") as f:
             cmd = [
                 f"{self.therock_bin_dir}/rocsolver-bench",
                 "-f",
@@ -103,7 +103,7 @@ class ROCsolverBenchmark(BenchmarkBase):
         subtest_name = "rocsolver_gesvd_d_S_S_250_250"
 
         try:
-            with open(self.log_file, "r") as fp:
+            with open(self.log_file, "r", encoding="utf-8") as fp:
                 for line in fp:
                     # Check for GPU device lines
                     if re.search(device_pattern, line):

--- a/tests/extended_tests/functional/scripts/test_miopendriver_conv.py
+++ b/tests/extended_tests/functional/scripts/test_miopendriver_conv.py
@@ -121,7 +121,7 @@ class MIOpenDriverConvTest(FunctionalBase):
                 log.info(f"[{current_test}/{total_tests}] {test_case_name}: {status}")
 
         # Write all results to JSON file
-        with open(self.results_json, "w") as f:
+        with open(self.results_json, "w", encoding="utf-8") as f:
             json.dump(all_results, f, indent=2)
 
         log.info(f"{self.display_name} results saved to {self.results_json}")
@@ -136,7 +136,7 @@ class MIOpenDriverConvTest(FunctionalBase):
         log.info(f"Parsing {self.display_name} Results")
 
         try:
-            with open(self.results_json, "r") as f:
+            with open(self.results_json, "r", encoding="utf-8") as f:
                 json_results = json.load(f)
         except FileNotFoundError:
             raise TestExecutionError(

--- a/tests/extended_tests/utils/config/config_parser.py
+++ b/tests/extended_tests/utils/config/config_parser.py
@@ -45,7 +45,7 @@ class ConfigParser:
     def _load(self):
         """Load configuration from file with environment variable expansion and validation."""
         try:
-            with open(self.config_file, "r") as f:
+            with open(self.config_file, "r", encoding="utf-8") as f:
                 raw_config = yaml.safe_load(f)
 
             # Check if config is empty

--- a/tests/extended_tests/utils/extended_test_base.py
+++ b/tests/extended_tests/utils/extended_test_base.py
@@ -66,7 +66,7 @@ class ExtendedTestBase:
         config_file = self.script_dir.parent / "configs" / config_filename
 
         try:
-            with open(config_file, "r") as f:
+            with open(config_file, "r", encoding="utf-8") as f:
                 return json.load(f)
         except FileNotFoundError:
             raise TestExecutionError(

--- a/tests/extended_tests/utils/results/results_api.py
+++ b/tests/extended_tests/utils/results/results_api.py
@@ -333,7 +333,7 @@ def _load_schema() -> Dict[str, Any]:
         Dict containing the JSON schema
     """
     schema_path = Path(__file__).parent / "schemas" / "payload_schema.json"
-    with open(schema_path, "r") as f:
+    with open(schema_path, "r", encoding="utf-8") as f:
         return json.load(f)
 
 

--- a/tests/extended_tests/utils/results/results_handler.py
+++ b/tests/extended_tests/utils/results/results_handler.py
@@ -125,7 +125,7 @@ class ResultsHandler:
                 timestamp = time.strftime("%Y%m%d_%H%M%S")
 
             output_file = results_dir / f"results_{timestamp}.json"
-            with open(output_file, "w") as f:
+            with open(output_file, "w", encoding="utf-8") as f:
                 json.dump(results_data, f, indent=2)
 
             log.info(f"Results saved: {output_file}")

--- a/tests/extended_tests/utils/system/hardware.py
+++ b/tests/extended_tests/utils/system/hardware.py
@@ -139,7 +139,7 @@ class HardwareDetector:
         """
         try:
             # Read /proc/cpuinfo
-            with open("/proc/cpuinfo", "r") as f:
+            with open("/proc/cpuinfo", "r", encoding="utf-8") as f:
                 cpuinfo = f.read()
 
             # Extract model name
@@ -233,7 +233,7 @@ class HardwareDetector:
             # Get RAM size from /proc/meminfo
             ram_size_gb = 0
             try:
-                with open("/proc/meminfo", "r") as f:
+                with open("/proc/meminfo", "r", encoding="utf-8") as f:
                     meminfo = f.read()
                 mem_match = re.search(r"MemTotal:\s*(\d+)\s*kB", meminfo)
                 if mem_match:

--- a/tests/extended_tests/utils/system/platform.py
+++ b/tests/extended_tests/utils/system/platform.py
@@ -121,7 +121,7 @@ class PlatformDetector:
             # Method 2: /sys/class/dmi/id/bios_version
             try:
                 logger.debug("Trying /sys/class/dmi/id/bios_version...")
-                with open("/sys/class/dmi/id/bios_version", "r") as f:
+                with open("/sys/class/dmi/id/bios_version", "r", encoding="utf-8") as f:
                     bios_content = f.read().strip()
                     if bios_content:
                         logger.debug(f"SBIOS from sysfs: {bios_content}")
@@ -136,7 +136,9 @@ class PlatformDetector:
             # Method 3: /sys/devices/virtual/dmi/id/bios_version
             try:
                 logger.debug("Trying /sys/devices/virtual/dmi/id/bios_version...")
-                with open("/sys/devices/virtual/dmi/id/bios_version", "r") as f:
+                with open(
+                    "/sys/devices/virtual/dmi/id/bios_version", "r", encoding="utf-8"
+                ) as f:
                     bios_content = f.read().strip()
                     if bios_content:
                         logger.debug(f"SBIOS from alternate sysfs: {bios_content}")
@@ -233,7 +235,7 @@ class PlatformDetector:
         try:
             if os_name == "Linux":
                 try:
-                    with open("/etc/os-release", "r") as f:
+                    with open("/etc/os-release", "r", encoding="utf-8") as f:
                         os_release = f.read()
 
                     # Extract NAME and VERSION_ID

--- a/tests/extended_tests/utils/system/rocm_detector.py
+++ b/tests/extended_tests/utils/system/rocm_detector.py
@@ -110,7 +110,7 @@ class ROCmDetector:
             version_rocm_file = os.path.join(rocm_path, ".info", "version-rocm")
             logger.debug(f"Trying {version_rocm_file} file...")
             if os.path.exists(version_rocm_file):
-                with open(version_rocm_file, "r") as f:
+                with open(version_rocm_file, "r", encoding="utf-8") as f:
                     rocm_ver = f.read().strip()
                     if rocm_ver:
                         logger.debug(f"ROCm version from version-rocm file: {rocm_ver}")
@@ -126,7 +126,7 @@ class ROCmDetector:
             version_file = os.path.join(rocm_path, ".info", "version")
             logger.debug(f"Trying {version_file} file...")
             if os.path.exists(version_file):
-                with open(version_file, "r") as f:
+                with open(version_file, "r", encoding="utf-8") as f:
                     rocm_ver = f.read().strip()
                     if rocm_ver:
                         logger.debug(f"ROCm version from version file: {rocm_ver}")
@@ -141,7 +141,9 @@ class ROCmDetector:
                             )
                             if os.path.exists(version_rocm_file):
                                 try:
-                                    with open(version_rocm_file, "r") as f2:
+                                    with open(
+                                        version_rocm_file, "r", encoding="utf-8"
+                                    ) as f2:
                                         full_ver = f2.read().strip()
                                         if full_ver and "-" in full_ver:
                                             logger.debug(


### PR DESCRIPTION
## Summary

This implements the follow-up suggested on [#4695](https://github.com/ROCm/TheRock/pull/4695): enable Ruff rule **PLW1514** (explicit `encoding` for text-mode `open()` and pathlib text helpers) via `pyproject.toml` and a scoped **ruff-pre-commit** hook, then fix existing call sites under `build_tools/`, `tests/`, and `external-builds/` so checks pass.

## Commits

1. **Add Ruff PLW1514 check to pre-commit and pyproject** — root `pyproject.toml` (`preview` + `extend-select`) and `.pre-commit-config.yaml` hook (`--select PLW1514 --preview`, limited to first-party Python paths).
2. **Apply explicit UTF-8 encoding for text I/O (PLW1514)** — bulk `encoding="utf-8"` (and related) plus Black line wraps where the formatter touched the same files.

## Related

- Discussion and request to use Ruff for this: [#4695](https://github.com/ROCm/TheRock/pull/4695) (split from the UTF-8 GitHub event JSON change as agreed in that thread).


Made with [Cursor](https://cursor.com)