### PR TITLE
Fix RPM symbol version dependency resolution for sysdeps libraries

### DIFF
--- a/build_tools/patch_linux_so.py
+++ b/build_tools/patch_linux_so.py
@@ -8,6 +8,7 @@ import argparse
 import glob
 from pathlib import Path
 import shlex
+import shutil
 import subprocess
 import sys
 
@@ -30,6 +31,131 @@ def resolve_symlinks(lib_path: Path):
     all_paths: list[Path] = [lib_path]
     all_paths.extend([Path(p) for p in glob.glob(f"{str(lib_path)}.*")])
     return all_paths
+
+
+def update_library_links(
+    libfile: Path, linker_name: str, patchelf: str = "patchelf"
+) -> None:
+    """
+    Normalize a shared library so that its real file is named exactly as its ELF SONAME,
+    and ensure a canonical linker-visible symlink exists.
+
+    This function is used when a library has been installed under a prefixed or
+    non-standard filename (e.g., librocm_sysdeps_elf.so).
+    It performs the following operations:
+    - Extracts the library's SONAME using `patchelf --print-soname`.
+    - Resolves the underlying real file (following symlinks).
+    - Renames the real file to match its SONAME if it does not already.
+    - Creates or updates a symlink named `linker_name` pointing to the SONAME file.
+    - Removes or renames the original file or symlink as appropriate.
+
+    Final layout example:
+    - libhwloc.so → librocm_sysdeps_hwloc.so.5
+    - librocm_sysdeps_hwloc.so.5 (real file)
+
+    Parameters
+    ----------
+    libfile : Path
+        Path to the library file or symlink to normalize.
+        Example: /prefix/lib/librocm_sysdeps_elf.so
+
+    linker_name : str
+        The desired linker-visible filename to create in the same directory.
+        Example: libelf.so
+
+    patchelf : str, optional
+        Path to the `patchelf` executable used to extract the SONAME.
+        Defaults to "patchelf".
+    """
+    if not libfile.exists():
+        raise FileNotFoundError(f"File '{libfile}' not found")
+
+    dir_path = libfile.parent
+
+    # Get SONAME
+    try:
+        lib_soname = subprocess.check_output(
+            [patchelf, "--print-soname", str(libfile)],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError:
+        print(f"Error: No SONAME found in '{libfile}'", flush=True)
+        return
+
+    if not lib_soname:
+        print(f"Error: Empty SONAME for '{libfile}'", flush=True)
+        return
+
+    # Resolve real file path
+    try:
+        realname = libfile.resolve(strict=True)
+    except FileNotFoundError:
+        print(f"Error: resolve() failed for '{libfile}'", flush=True)
+        return
+
+    target_real = dir_path / lib_soname
+    symlink_path = dir_path / linker_name
+
+    if realname != target_real:
+        # Move real file to $dir/$soname
+        shutil.move(str(realname), str(target_real))
+
+        # Create/update linker symlink
+        if symlink_path.exists() or symlink_path.is_symlink():
+            symlink_path.unlink()
+        symlink_path.symlink_to(lib_soname)
+
+        # Remove the original symlink or file
+        if libfile.is_symlink() or libfile.exists():
+            libfile.unlink()
+    else:
+        # Rename symlink in the same directory
+        if symlink_path.exists():
+            symlink_path.unlink()
+        libfile.rename(symlink_path)
+
+
+def relativize_pc_file(pc_file: Path) -> None:
+    """Make a .pc file relocatable by using pcfiledir-relative paths.
+
+    Replaces the absolute prefix= line with a pcfiledir-relative path,
+    then replaces all other occurrences of the absolute prefix with ${prefix}.
+    Also removes absolute -L flags from Libs.private that may have leaked from
+    build-time LDFLAGS.
+    Assumes the .pc file is located at $PREFIX/lib/pkgconfig/.
+
+    Parameters
+    ----------
+    pc_file : Path
+        Path to the .pc file to make relocatable.
+    """
+    import re
+
+    content = pc_file.read_text()
+
+    # Find the original absolute prefix value.
+    original_prefix = None
+    for line in content.splitlines():
+        if line.startswith("prefix="):
+            original_prefix = line[len("prefix=") :]
+            break
+
+    if not original_prefix:
+        return
+
+    # Replace the prefix line with pcfiledir-relative path.
+    # .pc files are in $PREFIX/lib/pkgconfig, so go up 2 levels.
+    content = content.replace(f"prefix={original_prefix}", "prefix=${pcfiledir}/../..")
+    # Replace all other occurrences of the absolute path with ${prefix}.
+    # Use trailing / to avoid partial matches.
+    content = content.replace(f"{original_prefix}/", "${prefix}/")
+
+    # Remove absolute -L paths from Libs.private (these leak from build-time LDFLAGS)
+    # Match patterns like: -L/absolute/path/to/lib
+    content = re.sub(r"-L/[^\s]+", "", content)
+
+    pc_file.write_text(content)
 
 
 def add_prefix(args: argparse.Namespace):

--- a/build_tools/patch_linux_so.py
+++ b/build_tools/patch_linux_so.py
@@ -7,6 +7,7 @@
 import argparse
 import glob
 from pathlib import Path
+import re
 import shlex
 import shutil
 import subprocess
@@ -79,13 +80,11 @@ def update_library_links(
             stderr=subprocess.DEVNULL,
             text=True,
         ).strip()
-    except subprocess.CalledProcessError:
-        print(f"Error: No SONAME found in '{libfile}'", flush=True)
-        return
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"patchelf --print-soname failed for '{libfile}'") from e
 
     if not lib_soname:
-        print(f"Error: Empty SONAME for '{libfile}'", flush=True)
-        return
+        raise RuntimeError(f"Empty SONAME returned by patchelf for '{libfile}'")
 
     # Resolve real file path
     try:
@@ -130,7 +129,6 @@ def relativize_pc_file(pc_file: Path) -> None:
     pc_file : Path
         Path to the .pc file to make relocatable.
     """
-    import re
 
     content = pc_file.read_text()
 

--- a/third-party/sysdeps/common/hwloc/CMakeLists.txt
+++ b/third-party/sysdeps/common/hwloc/CMakeLists.txt
@@ -69,6 +69,13 @@ if(NOT PATCHELF)
   message(FATAL_ERROR "Missing PATCHELF from super-project")
 endif()
 
+# Apply patch source only on Linux
+set(patch_source_commands)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  list(APPEND patch_source_commands   COMMAND
+    bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${SOURCE_DIR}")
+endif()
+
 # Helper function to extract dependency prefixes from CMAKE_PREFIX_PATH.
 # Needed for autotools-based builds that require --with-* configure flags.
 # (Autotools doesn't use CMAKE_PREFIX_PATH directly, so we must extract and pass explicitly.)
@@ -94,6 +101,8 @@ add_custom_target(
   #
   # OPTIONAL: Patching of the sources should happen here.
   #
+  COMMAND
+    ${patch_source_commands}
   COMMAND
     "${CMAKE_COMMAND}" -E env
       "PKG_CONFIG_PATH=${PCIACCESS_PREFIX}/lib/pkgconfig:${NUMA_PREFIX}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}"

--- a/third-party/sysdeps/common/hwloc/patch_install.py
+++ b/third-party/sysdeps/common/hwloc/patch_install.py
@@ -4,37 +4,8 @@
 from pathlib import Path
 import os
 import platform
-import shutil
 import subprocess
 import sys
-
-
-def relativize_pc_file(pc_file: Path) -> None:
-    """Make a .pc file relocatable by using pcfiledir-relative paths.
-
-    Replaces the absolute prefix= line with a pcfiledir-relative path,
-    then replaces all other occurrences of the absolute prefix with ${prefix}.
-    Assumes the .pc file is located at $PREFIX/lib/pkgconfig/.
-    """
-    content = pc_file.read_text()
-
-    # Find the original absolute prefix value.
-    original_prefix = None
-    for line in content.splitlines():
-        if line.startswith("prefix="):
-            original_prefix = line[len("prefix=") :]
-            break
-
-    if not original_prefix:
-        return
-
-    # Replace the prefix line with pcfiledir-relative path.
-    # .pc files are in $PREFIX/lib/pkgconfig, so go up 2 levels.
-    content = content.replace(f"prefix={original_prefix}", "prefix=${pcfiledir}/../..")
-    # Replace all other occurrences of the absolute path with ${prefix}.
-    # Use trailing / to avoid partial matches.
-    content = content.replace(f"{original_prefix}/", "${prefix}/")
-    pc_file.write_text(content)
 
 
 # Fetch an environment variable or exit if it is not found.
@@ -60,6 +31,11 @@ therock_source_dir = Path(get_env_or_exit("THEROCK_SOURCE_DIR"))
 python_exe = get_env_or_exit("Python3_EXECUTABLE")
 patchelf_exe = get_env_or_exit("PATCHELF")
 
+# Import common utilities from build_tools using THEROCK_SOURCE_DIR
+script_path = therock_source_dir / "build_tools" / "patch_linux_so.py"
+sys.path.insert(0, str(script_path.parent))
+from patch_linux_so import update_library_links, relativize_pc_file
+
 if platform.system() == "Linux":
     # Specify the directory containing the libraries.
     lib_dir = Path(install_prefix) / "lib"
@@ -69,29 +45,7 @@ if platform.system() == "Linux":
         if file_path.suffix in (".a", ".la"):
             file_path.unlink(missing_ok=True)
 
-    # Now adjust the shared libraries according to our sysdeps rules.
-    script_path = therock_source_dir / "build_tools" / "patch_linux_so.py"
-
-    # Iterate over all shared libraries.
-    for lib_path in lib_dir.glob("*.so"):
-        # Patch the shared library and add our sysdeps prefix.
-        patch_cmd = [
-            python_exe,
-            str(script_path),
-            "--patchelf",
-            patchelf_exe,
-            "--add-prefix",
-            "rocm_sysdeps_",
-            str(lib_path),
-        ]
-
-        try:
-            subprocess.run(patch_cmd, check=True)
-        except subprocess.CalledProcessError as e:
-            print(f"Error: Failed to patch {lib_path.name} (Exit: {e.returncode})")
-            sys.exit(e.returncode)
-
-    # Set RPATH on all prefixed shared libraries.
+    # Set RPATH on all prefixed shared libraries (already named correctly from build).
     for lib_path in lib_dir.glob("librocm_sysdeps_*.so*"):
         if lib_path.is_symlink():
             continue
@@ -111,7 +65,13 @@ if platform.system() == "Linux":
             )
             sys.exit(e.returncode)
 
-    # Fix .pc files to use relocatable paths.
+    # Create linker symlink libhwloc.so -> librocm_sysdeps_hwloc.so.5
+    # using the common update_library_links function
+    hwloc_lib = lib_dir / "librocm_sysdeps_hwloc.so"
+    if hwloc_lib.exists():
+        update_library_links(hwloc_lib, "libhwloc.so", patchelf_exe)
+
+    # Fix .pc files to use relocatable paths using the common function
     pkgconfig_dir = lib_dir / "pkgconfig"
     if pkgconfig_dir.exists():
         for pc_file in pkgconfig_dir.glob("*.pc"):

--- a/third-party/sysdeps/common/hwloc/patch_source.sh
+++ b/third-party/sysdeps/common/hwloc/patch_source.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+set -e
+
+SOURCE_DIR="${1:?Source directory must be given}"
+
+echo "Patching hwloc sources to rename main library..."
+
+# Patch the src/Makefile.in to change library name from libhwloc to librocm_sysdeps_hwloc
+HWLOC_MAKEFILE="$SOURCE_DIR/src/Makefile.in"
+
+if [ -f "$HWLOC_MAKEFILE" ]; then
+  echo "Patching $HWLOC_MAKEFILE..."
+  sed -i 's/libhwloc\.la/librocm_sysdeps_hwloc.la/g' "$HWLOC_MAKEFILE"
+  sed -i 's/libhwloc_la_SOURCES/librocm_sysdeps_hwloc_la_SOURCES/g' "$HWLOC_MAKEFILE"
+  sed -i 's/libhwloc_la_LDFLAGS/librocm_sysdeps_hwloc_la_LDFLAGS/g' "$HWLOC_MAKEFILE"
+  sed -i 's/libhwloc_la_LIBADD/librocm_sysdeps_hwloc_la_LIBADD/g' "$HWLOC_MAKEFILE"
+  sed -i 's/libhwloc_la_DEPENDENCIES/librocm_sysdeps_hwloc_la_DEPENDENCIES/g' "$HWLOC_MAKEFILE"
+fi
+
+# Patch all Makefile.in files that reference libhwloc.la
+echo "Patching all Makefile.in files that reference libhwloc.la..."
+find "$SOURCE_DIR" -name "Makefile.in" -type f -exec grep -l "libhwloc\.la" {} \; | while read -r makefile; do
+  echo "  Patching $makefile..."
+  sed -i 's|/src/libhwloc\.la|/src/librocm_sysdeps_hwloc.la|g' "$makefile"
+done
+
+echo "hwloc patching completed."

--- a/third-party/sysdeps/linux/libpciaccess/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libpciaccess/CMakeLists.txt
@@ -60,9 +60,19 @@ endif()
 include("${THEROCK_SOURCE_DIR}/cmake/therock_meson_env.cmake")
 therock_get_meson_compiler_env(_meson_cc _meson_cxx)
 
+# Apply patch source only on Linux
+set(patch_source_commands)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  list(APPEND patch_source_commands COMMAND
+    bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${SOURCE_DIR}")
+endif()
+
 add_custom_target(
   meson_build ALL
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+
+  COMMAND
+    ${patch_source_commands}
   COMMAND
     "${CMAKE_COMMAND}" -E rm -rf -- "${CMAKE_INSTALL_PREFIX}"
   COMMAND

--- a/third-party/sysdeps/linux/libpciaccess/patch_install.py
+++ b/third-party/sysdeps/linux/libpciaccess/patch_install.py
@@ -4,37 +4,8 @@
 from pathlib import Path
 import os
 import platform
-import shutil
 import subprocess
 import sys
-
-
-def relativize_pc_file(pc_file: Path) -> None:
-    """Make a .pc file relocatable by using pcfiledir-relative paths.
-
-    Replaces the absolute prefix= line with a pcfiledir-relative path,
-    then replaces all other occurrences of the absolute prefix with ${prefix}.
-    Assumes the .pc file is located at $PREFIX/lib/pkgconfig/.
-    """
-    content = pc_file.read_text()
-
-    # Find the original absolute prefix value.
-    original_prefix = None
-    for line in content.splitlines():
-        if line.startswith("prefix="):
-            original_prefix = line[len("prefix=") :]
-            break
-
-    if not original_prefix:
-        return
-
-    # Replace the prefix line with pcfiledir-relative path.
-    # .pc files are in $PREFIX/lib/pkgconfig, so go up 2 levels.
-    content = content.replace(f"prefix={original_prefix}", "prefix=${pcfiledir}/../..")
-    # Replace all other occurrences of the absolute path with ${prefix}.
-    # Use trailing / to avoid partial matches.
-    content = content.replace(f"{original_prefix}/", "${prefix}/")
-    pc_file.write_text(content)
 
 
 # Fetch an environment variable or exit if it is not found.
@@ -60,6 +31,11 @@ therock_source_dir = Path(get_env_or_exit("THEROCK_SOURCE_DIR"))
 python_exe = get_env_or_exit("Python3_EXECUTABLE")
 patchelf_exe = get_env_or_exit("PATCHELF")
 
+# Import common utilities from build_tools using THEROCK_SOURCE_DIR
+script_path = therock_source_dir / "build_tools" / "patch_linux_so.py"
+sys.path.insert(0, str(script_path.parent))
+from patch_linux_so import update_library_links, relativize_pc_file
+
 if platform.system() == "Linux":
     # Specify the directory containing the libraries.
     lib_dir = Path(install_prefix) / "lib"
@@ -69,29 +45,7 @@ if platform.system() == "Linux":
         if file_path.suffix in (".a", ".la"):
             file_path.unlink(missing_ok=True)
 
-    # Now adjust the shared libraries according to our sysdeps rules.
-    script_path = therock_source_dir / "build_tools" / "patch_linux_so.py"
-
-    # Iterate over all shared libraries.
-    for lib_path in lib_dir.glob("*.so"):
-        # Patch the shared library and add our sysdeps prefix.
-        patch_cmd = [
-            python_exe,
-            str(script_path),
-            "--patchelf",
-            patchelf_exe,
-            "--add-prefix",
-            "rocm_sysdeps_",
-            str(lib_path),
-        ]
-
-        try:
-            subprocess.run(patch_cmd, check=True)
-        except subprocess.CalledProcessError as e:
-            print(f"Error: Failed to patch {lib_path.name} (Exit: {e.returncode})")
-            sys.exit(e.returncode)
-
-    # Set RPATH on all prefixed shared libraries.
+    # Set RPATH on all prefixed shared libraries (already named correctly from build).
     for lib_path in lib_dir.glob("librocm_sysdeps_*.so*"):
         if lib_path.is_symlink():
             continue
@@ -111,7 +65,13 @@ if platform.system() == "Linux":
             )
             sys.exit(e.returncode)
 
-    # Fix .pc files to use relocatable paths.
+    # Create linker symlink libpciaccess.so -> librocm_sysdeps_pciaccess.so
+    # using the common update_library_links function
+    pciaccess_lib = lib_dir / "librocm_sysdeps_pciaccess.so"
+    if pciaccess_lib.exists():
+        update_library_links(pciaccess_lib, "libpciaccess.so", patchelf_exe)
+
+    # Fix .pc files to use relocatable paths using the common function
     pkgconfig_dir = lib_dir / "pkgconfig"
     if pkgconfig_dir.exists():
         for pc_file in pkgconfig_dir.glob("*.pc"):

--- a/third-party/sysdeps/linux/libpciaccess/patch_source.sh
+++ b/third-party/sysdeps/linux/libpciaccess/patch_source.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+set -e
+
+SOURCE_DIR="${1:?Source directory must be given}"
+
+echo "Patching libpciaccess sources to rename main library..."
+
+# Patch the src/meson.build to change library name from pciaccess to rocm_sysdeps_pciaccess
+SRC_MESON_BUILD="$SOURCE_DIR/src/meson.build"
+
+if [ -f "$SRC_MESON_BUILD" ]; then
+  echo "Patching $SRC_MESON_BUILD..."
+  # Change the variable name and the library name parameter
+  # Original: libpciaccess = library('pciaccess', ...)
+  # Result:   librocm_sysdeps_pciaccess = library('rocm_sysdeps_pciaccess', ...)
+  sed -i "s/^libpciaccess = library($/librocm_sysdeps_pciaccess = library(/g" "$SRC_MESON_BUILD"
+  sed -i "s/^  'pciaccess',$/  'rocm_sysdeps_pciaccess',/g" "$SRC_MESON_BUILD"
+  # Update dependency declaration
+  sed -i 's/link_with : libpciaccess/link_with : librocm_sysdeps_pciaccess/g' "$SRC_MESON_BUILD"
+fi
+
+# Patch the root meson.build pkg.generate reference
+ROOT_MESON_BUILD="$SOURCE_DIR/meson.build"
+if [ -f "$ROOT_MESON_BUILD" ]; then
+  echo "Patching $ROOT_MESON_BUILD..."
+  # Update pkg.generate to NOT pass the library object, use libraries parameter instead
+  # This way meson won't auto-generate -lrocm_sysdeps_pciaccess
+  # Original:
+  #   pkg.generate(
+  #     libpciaccess,
+  #     description : '...',
+  #   )
+  # Result:
+  #   pkg.generate(
+  #     name : 'pciaccess',
+  #     libraries : ['-L${libdir}', '-lpciaccess'],
+  #     description : '...',
+  #   )
+  sed -i '/^pkg\.generate($/,/^)$/ {
+    s/^  libpciaccess,$/  name : '\''pciaccess'\'',\n  libraries : ['\''-L${libdir}'\'', '\''-lpciaccess'\''],/
+  }' "$ROOT_MESON_BUILD"
+fi
+
+echo "libpciaccess patching completed."


### PR DESCRIPTION
   Fix issue where RPM dependency resolution failed because elfdeps was
   reporting symbol versions using the wrong library name.

   Problem:
     Post-install renaming created symlinks like libhwloc.so -> librocm_sysdeps_hwloc.so.5
     RPM elfdeps used the symlink name for symbol versions:
       libhwloc.so.5(AMDROCM_SYSDEPS_1.0)(64bit)  [WRONG]
     But packages required:
       librocm_sysdeps_hwloc.so.5(AMDROCM_SYSDEPS_1.0)(64bit)  [CORRECT]

   Solution:
     Rename libraries at build-time by patching Makefile.in/meson.build before build.
     Libraries are now built with rocm_sysdeps_ prefix from the start.
     RPM elfdeps now correctly reports:
       librocm_sysdeps_hwloc.so.5(AMDROCM_SYSDEPS_1.0)(64bit)

   Changes:
   - Add patch_source.sh scripts for hwloc and libpciaccess to rename at source level
   - Update CMakeLists.txt to apply source patches before build
   - Extract common utilities to build_tools/patch_linux_so.py
   - Simplify patch_install.py to use shared functions
   
Test Results:
[TestOutput.txt](https://github.com/user-attachments/files/27183341/TestOutput.txt)
