### PR TITLE
Add inline test jobs to multi-arch release workflows

### DIFF
--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -114,8 +114,24 @@ jobs:
             --release-type="${{ inputs.release_type }}" \
             --kpack-split="${{ needs.build_python_packages.outputs.kpack_split }}"
 
-  # TODO: dispatch test artifacts per family (add workflow_dispatch to
-  #   test_artifacts.yml, then use benc-uk/workflow-dispatch here)
+  test_artifacts_per_family:
+    needs: [build_artifacts]
+    name: Test ${{ matrix.family_info.amdgpu_family }}
+    if: ${{ !failure() && !cancelled() }}
+    strategy:
+      fail-fast: false
+      matrix:
+        family_info: ${{ fromJSON(inputs.build_config).per_family_info }}
+    uses: ./.github/workflows/test_artifacts.yml
+    with:
+      artifact_group: ${{ matrix.family_info.amdgpu_family }}
+      amdgpu_families: ${{ matrix.family_info.amdgpu_family }}
+      amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
+      test_runs_on: ${{ matrix.family_info.test-runs-on }}
+      test_type: ${{ inputs.test_type }}
+      release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
 
   # TODO: dispatch pytorch wheels (release_portable_linux_pytorch_wheels.yml)
 

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -112,5 +112,23 @@ jobs:
             --release-type="${{ inputs.release_type }}" \
             --kpack-split="${{ needs.build_python_packages.outputs.kpack_split }}"
 
-  # TODO: dispatch test artifacts per family
+  test_artifacts_per_family:
+    needs: [build_artifacts]
+    name: Test ${{ matrix.family_info.amdgpu_family }}
+    if: ${{ !failure() && !cancelled() }}
+    strategy:
+      fail-fast: false
+      matrix:
+        family_info: ${{ fromJSON(inputs.build_config).per_family_info }}
+    uses: ./.github/workflows/test_artifacts.yml
+    with:
+      artifact_group: ${{ matrix.family_info.amdgpu_family }}
+      amdgpu_families: ${{ matrix.family_info.amdgpu_family }}
+      amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
+      test_runs_on: ${{ matrix.family_info.test-runs-on }}
+      test_type: ${{ inputs.test_type }}
+      release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
+
   # TODO: dispatch pytorch wheels


### PR DESCRIPTION
## Motivation

This builds on https://github.com/ROCm/TheRock/pull/4862 to run rocm tests as part of the new multi-arch release workflows.

Progress on:
* https://github.com/ROCm/TheRock/issues/2281
* https://github.com/ROCm/TheRock/issues/3334

## Technical Details

The call structure here matches what we do in multi-arch CI workflows with `workflow_call`. I also considered forking into new workflow runs using `workflow_dispatch`, which would let us view tests for each GPU target/family independently and cancel/retrigger jobs with finer granularity.

This will use the current `_determine_test_type()` code in [`build_tools/github_actions/configure_multi_arch_ci.py`](https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/configure_multi_arch_ci.py), e.g. "quick" for `workflow_dispatch` and "comprehensive" for `schedule` events. We should probably add a dedicated code path in  for `if ci_inputs.release_type`.

## Test Plan

Dev release: https://github.com/ROCm/TheRock/actions/runs/24917079667

## Test Result

Tests ran (with some known failures)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
