### PR TITLE
Revert "[ml-libs] Remove all-or-nothing CK disable logic; let MIOpen …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,10 @@ include("${CMAKE_CURRENT_BINARY_DIR}/cmake/therock_topology.cmake")
 # which filters out CORE_RUNTIME dependency for HIP_RUNTIME on Windows.
 
 # Optional sub-features that control behavior within artifacts
+cmake_dependent_option(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL
+  "Enables composable kernel in MIOpen" ON
+  "THEROCK_ENABLE_COMPOSABLE_KERNEL" OFF)
+
 cmake_dependent_option(THEROCK_ROCWMMA_ENABLE_BENCHMARKS
   "Enables building rocWMMA benchmarks" OFF
   "THEROCK_ENABLE_ROCWMMA;THEROCK_BUILD_TESTING" OFF)

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -8,6 +8,20 @@ if(THEROCK_FLAG_INCLUDE_PROFILER)
   list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
 endif()
 
+# limit use of composable kernel to the GPU families it is valid for
+if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
+  set(_ck_supported_gfx_targets gfx908 gfx90a gfx942 gfx950 gfx1150 gfx1151 gfx1152 gfx1153 gfx1200 gfx1201)
+  foreach(_gfx_target ${THEROCK_AMDGPU_TARGETS})
+    if(NOT ${_gfx_target} IN_LIST _ck_supported_gfx_targets)
+      message(WARNING
+        "${_gfx_target} (included in THEROCK_AMDGPU_TARGETS) is not supported by composable kernel. "
+        "Disabling composable kernel and it's use in MIOpen.")
+      set(THEROCK_ENABLE_COMPOSABLE_KERNEL OFF)
+      set(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL OFF)
+    endif()
+  endforeach()
+endif()
+
 if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
   ##############################################################################
   # Composable_kernel
@@ -55,11 +69,9 @@ if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
 endif()
 
 if(THEROCK_ENABLE_MIOPEN)
-  # If composable kernel is enabled, add it as an MIOpen build dep.
-  # MIOpen's ck_impl self-filters GPU_TARGETS against arches it has CK grouped
-  # conv kernels for, so no need to gate on specific arch families here.
+  # If composable kernel is enabled, add it as an MIOpen dep.
   set(optional_miopen_build_deps)
-  if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
+  if(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL)
     list(APPEND optional_miopen_build_deps composable_kernel)
   endif()
 
@@ -78,7 +90,7 @@ if(THEROCK_ENABLE_MIOPEN)
       -DROCM_PATH=
       -DROCM_DIR=
       "-DBUILD_TESTING=${_THEROCK_MIOPEN_ENABLE_TESTING}"
-      "-DMIOPEN_USE_COMPOSABLEKERNEL=${THEROCK_ENABLE_COMPOSABLE_KERNEL}"
+      "-DMIOPEN_USE_COMPOSABLEKERNEL=${THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL}"
       -DMIOPEN_USE_MLIR=OFF # TODO: enable
       -DMIOPEN_TEST_DISCRETE=OFF
       "-DMIOPEN_INSTALL_GPU_DATABASES=\"${THEROCK_AMDGPU_TARGETS}\""


### PR DESCRIPTION
Reverts ROCm/TheRock#4838
Breaking Linux & Windows package runs on `gfx900, gfx906,gfx101x-dpgu` which are not part CK supported list.
more details:https://github.com/ROCm/TheRock/issues/4918