### PR TITLE
[debug-tools] Fix test_rocgdb.py optimization flag parsing with spaces

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocgdb.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocgdb.py
@@ -1466,7 +1466,7 @@ def _build_runtestflags(
         f"F90_FOR_TARGET={fc}",
     ]
     if optimization:
-        parts.append(f"CFLAGS_FOR_TARGET={optimization}")
+        parts.append(f"CFLAGS_FOR_TARGET={shlex.quote(optimization)}")
     if runtestflags:
         parts.append(runtestflags)
 


### PR DESCRIPTION
Quote optimization flags in CFLAGS_FOR_TARGET to prevent shell argument splitting when values contain spaces (e.g., "--optimization=-O3 -g").