### PR TITLE
Fix PyTorch dispatch

### DIFF
--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -146,7 +146,6 @@ jobs:
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:
           workflow: multi_arch_release_linux_pytorch_wheels.yml
-          ref: ${{ inputs.ref || github.ref_name }}
           inputs: |
             { "amdgpu_families": "${{ fromJSON(inputs.build_config).dist_amdgpu_families }}",
               "rocm_version": "${{ inputs.rocm_package_version }}",

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -144,7 +144,6 @@ jobs:
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:
           workflow: multi_arch_release_windows_pytorch_wheels.yml
-          ref: ${{ inputs.ref || github.ref_name }}
           inputs: |
             { "amdgpu_families": "${{ fromJSON(inputs.build_config).dist_amdgpu_families }}",
               "rocm_version": "${{ inputs.rocm_package_version }}",


### PR DESCRIPTION
This prevented dispatching the workflow in rockrel. Without `ref:`, the `benc-uk/workflow-dispatch` action defaults to the workflow run's `github.ref` (rockrel's branch when called via the rockrel orchestrator and TheRock's branch when called directly), so the workflow file lookup always points at the correct dispatching repo.