### PR TITLE
Fix release dev version commit ref in cross-repo workflow_call

### DIFF
--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -140,4 +140,5 @@ jobs:
         run: |
           python ./build_tools/compute_rocm_package_version.py \
             --release-type=${{ inputs.release_type || 'dev' }} \
-            --prerelease-version=${{ inputs.prerelease_version }}
+            --prerelease-version=${{ inputs.prerelease_version }} \
+            --git-sha=${{ steps.checkout.outputs.commit }}

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -141,4 +141,4 @@ jobs:
           python ./build_tools/compute_rocm_package_version.py \
             --release-type=${{ inputs.release_type || 'dev' }} \
             --prerelease-version=${{ inputs.prerelease_version }} \
-            --git-sha=${{ steps.checkout.outputs.commit }}
+            --override-git-sha=${{ steps.checkout.outputs.commit }}

--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -73,21 +73,34 @@ def load_rocm_version() -> str:
         return loaded_file["rocm-version"]
 
 
-def get_git_sha(short: bool = False):
-    """Gets the current git SHA, either from GITHUB_SHA or running git commands."""
+def get_git_sha(short: bool = False, override_git_sha: str | None = None):
+    """Gets the git SHA to embed in version strings.
 
-    # Default GitHub environment variable, info:
-    # https://docs.github.com/en/actions/reference/workflows-and-actions/variables
-    github_sha = os.getenv("GITHUB_SHA")
+    Resolution order:
+      1. ``override_git_sha`` (explicit caller override)
+      2. ``GITHUB_SHA`` environment variable
+      3. ``git rev-parse HEAD`` in the repo checkout
 
-    if github_sha:
-        git_sha = github_sha
+    When the workflow is triggered cross-repo (e.g. rockrel calling TheRock),
+    GITHUB_SHA refers to the *caller's* commit.  Pass ``override_git_sha``
+    from the checkout step to get the correct TheRock SHA.
+    """
+
+    if override_git_sha:
+        git_sha = override_git_sha
     else:
-        git_sha = subprocess.check_output(
-            ["git", "rev-parse", "--verify", "HEAD"],
-            cwd=THEROCK_DIR,
-            text=True,
-        ).strip()
+        # Default GitHub environment variable, info:
+        # https://docs.github.com/en/actions/reference/workflows-and-actions/variables
+        github_sha = os.getenv("GITHUB_SHA")
+
+        if github_sha:
+            git_sha = github_sha
+        else:
+            git_sha = subprocess.check_output(
+                ["git", "rev-parse", "--verify", "HEAD"],
+                cwd=THEROCK_DIR,
+                text=True,
+            ).strip()
 
     # Shorten the sha to 8 characters if requested
     if short:
@@ -117,10 +130,8 @@ def compute_version(
         custom_version_suffix: Custom suffix to override automatic suffix
         prerelease_version: Prerelease version number
         override_base_version: Override the base version from version.json
-        git_sha: Explicit git SHA to use instead of auto-detecting from
-            GITHUB_SHA or the local repo HEAD. Needed when the workflow is
-            triggered from a different repository (e.g. rockrel calling
-            TheRock), where GITHUB_SHA refers to the caller's commit.
+        git_sha: Explicit git SHA override, forwarded to get_git_sha().
+            See get_git_sha() for details on when this is needed.
 
     Returns:
         Computed version string appropriate for the package type
@@ -141,8 +152,7 @@ def compute_version(
         elif release_type == "dev":
             # Construct a dev release version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#developmental-releases
-            resolved_sha = git_sha or get_git_sha()
-            version_suffix = f".dev0+{resolved_sha}"
+            version_suffix = f".dev0+{get_git_sha(override_git_sha=git_sha)}"
         elif release_type == "nightly":
             # Construct a nightly (a / "alpha") version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases
@@ -180,10 +190,8 @@ def compute_version(
             if package_type == "deb":
                 version_suffix_str = f"~dev{current_date}"
             else:  # rpm
-                resolved_sha = git_sha or get_git_sha(short=True)
-                if len(resolved_sha) > 8:
-                    resolved_sha = resolved_sha[:8]
-                version_suffix_str = f"~{current_date}g{resolved_sha}"
+                short_sha = get_git_sha(short=True, override_git_sha=git_sha)
+                version_suffix_str = f"~{current_date}g{short_sha}"
         elif release_type == "nightly":
             # Construct a nightly version with date
             # Format: <rocm-version>~<YYYYMMDD>

--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -120,7 +120,7 @@ def compute_version(
     custom_version_suffix: str | None = None,
     prerelease_version: str | None = None,
     override_base_version: str | None = None,
-    git_sha: str | None = None,
+    override_git_sha: str | None = None,
 ) -> str:
     """Compute package version based on package type and release type.
 
@@ -130,7 +130,7 @@ def compute_version(
         custom_version_suffix: Custom suffix to override automatic suffix
         prerelease_version: Prerelease version number
         override_base_version: Override the base version from version.json
-        git_sha: Explicit git SHA override, forwarded to get_git_sha().
+        override_git_sha: Explicit git SHA override, forwarded to get_git_sha().
             See get_git_sha() for details on when this is needed.
 
     Returns:
@@ -152,7 +152,8 @@ def compute_version(
         elif release_type == "dev":
             # Construct a dev release version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#developmental-releases
-            version_suffix = f".dev0+{get_git_sha(override_git_sha=git_sha)}"
+            git_sha = get_git_sha(override_git_sha=override_git_sha)
+            version_suffix = f".dev0+{git_sha}"
         elif release_type == "nightly":
             # Construct a nightly (a / "alpha") version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases
@@ -190,8 +191,8 @@ def compute_version(
             if package_type == "deb":
                 version_suffix_str = f"~dev{current_date}"
             else:  # rpm
-                short_sha = get_git_sha(short=True, override_git_sha=git_sha)
-                version_suffix_str = f"~{current_date}g{short_sha}"
+                git_sha = get_git_sha(short=True, override_git_sha=override_git_sha)
+                version_suffix_str = f"~{current_date}g{git_sha}"
         elif release_type == "nightly":
             # Construct a nightly version with date
             # Format: <rocm-version>~<YYYYMMDD>
@@ -254,7 +255,7 @@ def main(argv):
     )
 
     parser.add_argument(
-        "--git-sha",
+        "--override-git-sha",
         type=str,
         help="Explicit git SHA to embed in the version instead of auto-detecting",
     )
@@ -278,7 +279,7 @@ def main(argv):
         args.custom_version_suffix,
         args.prerelease_version,
         args.override_base_version,
-        args.git_sha,
+        args.override_git_sha,
     )
 
     # Set appropriate output variable based on package type

--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -107,6 +107,7 @@ def compute_version(
     custom_version_suffix: str | None = None,
     prerelease_version: str | None = None,
     override_base_version: str | None = None,
+    git_sha: str | None = None,
 ) -> str:
     """Compute package version based on package type and release type.
 
@@ -116,6 +117,10 @@ def compute_version(
         custom_version_suffix: Custom suffix to override automatic suffix
         prerelease_version: Prerelease version number
         override_base_version: Override the base version from version.json
+        git_sha: Explicit git SHA to use instead of auto-detecting from
+            GITHUB_SHA or the local repo HEAD. Needed when the workflow is
+            triggered from a different repository (e.g. rockrel calling
+            TheRock), where GITHUB_SHA refers to the caller's commit.
 
     Returns:
         Computed version string appropriate for the package type
@@ -136,8 +141,8 @@ def compute_version(
         elif release_type == "dev":
             # Construct a dev release version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#developmental-releases
-            git_sha = get_git_sha()
-            version_suffix = f".dev0+{git_sha}"
+            resolved_sha = git_sha or get_git_sha()
+            version_suffix = f".dev0+{resolved_sha}"
         elif release_type == "nightly":
             # Construct a nightly (a / "alpha") version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases
@@ -175,8 +180,10 @@ def compute_version(
             if package_type == "deb":
                 version_suffix_str = f"~dev{current_date}"
             else:  # rpm
-                git_sha = get_git_sha(short=True)
-                version_suffix_str = f"~{current_date}g{git_sha}"
+                resolved_sha = git_sha or get_git_sha(short=True)
+                if len(resolved_sha) > 8:
+                    resolved_sha = resolved_sha[:8]
+                version_suffix_str = f"~{current_date}g{resolved_sha}"
         elif release_type == "nightly":
             # Construct a nightly version with date
             # Format: <rocm-version>~<YYYYMMDD>
@@ -238,6 +245,12 @@ def main(argv):
         help="Override the base version from version.json with this value",
     )
 
+    parser.add_argument(
+        "--git-sha",
+        type=str,
+        help="Explicit git SHA to embed in the version instead of auto-detecting",
+    )
+
     args = parser.parse_args(argv)
 
     # Validation
@@ -257,6 +270,7 @@ def main(argv):
         args.custom_version_suffix,
         args.prerelease_version,
         args.override_base_version,
+        args.git_sha,
     )
 
     # Set appropriate output variable based on package type

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -225,13 +225,13 @@ class RpmPackageVersionTest(unittest.TestCase):
 
 
 class GitShaOverrideTest(unittest.TestCase):
-    """Tests for explicit git_sha parameter."""
+    """Tests for explicit override_git_sha parameter."""
 
     def test_wheel_dev_uses_provided_git_sha(self):
         version = compute_rocm_package_version.compute_version(
             release_type="dev",
             override_base_version="8.1.0",
-            git_sha="abcdef1234567890abcdef1234567890abcdef12",
+            override_git_sha="abcdef1234567890abcdef1234567890abcdef12",
         )
         self.assertEqual(version, "8.1.0.dev0+abcdef1234567890abcdef1234567890abcdef12")
 
@@ -240,7 +240,7 @@ class GitShaOverrideTest(unittest.TestCase):
             package_type="rpm",
             release_type="dev",
             override_base_version="8.1.0",
-            git_sha="abcdef1234567890",
+            override_git_sha="abcdef1234567890",
         )
         # Should truncate to 8 chars
         self.assertRegex(version, r"^8\.1\.0~[0-9]{8}gabcdef12$")

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -224,6 +224,28 @@ class RpmPackageVersionTest(unittest.TestCase):
         self.assertEqual(version, "8.0.0~custom1")
 
 
+class GitShaOverrideTest(unittest.TestCase):
+    """Tests for explicit git_sha parameter."""
+
+    def test_wheel_dev_uses_provided_git_sha(self):
+        version = compute_rocm_package_version.compute_version(
+            release_type="dev",
+            override_base_version="8.1.0",
+            git_sha="abcdef1234567890abcdef1234567890abcdef12",
+        )
+        self.assertEqual(version, "8.1.0.dev0+abcdef1234567890abcdef1234567890abcdef12")
+
+    def test_rpm_dev_truncates_long_git_sha(self):
+        version = compute_rocm_package_version.compute_version(
+            package_type="rpm",
+            release_type="dev",
+            override_base_version="8.1.0",
+            git_sha="abcdef1234567890",
+        )
+        # Should truncate to 8 chars
+        self.assertRegex(version, r"^8\.1\.0~[0-9]{8}gabcdef12$")
+
+
 class BackwardsCompatibilityTest(unittest.TestCase):
     """Tests for backwards compatibility with old API."""
 


### PR DESCRIPTION
## Motivation

A dev release run in rockrel https://github.com/ROCm/rockrel/actions/runs/25100364100/job/73547700450 checked out commit `42e0a8bd7ddd664c7e600c854b4f6e8cd22ab220` from TheRock but computed version `7.13.0.dev0+b7df0b9cb7302534cb45e9614ba29962d4ec6c2c` using the commit ref from rockrel. The version should be the commit from TheRock, not rockrel.

## Test Plan

1. Attempted to test at https://github.com/ROCm/rockrel/actions/runs/25118876533/job/73613659899 but the workflow has `Uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@refs/heads/main`
2. Tested from a branch with a different pin: https://github.com/ROCm/rockrel/actions/runs/25119107861/job/73614526170
    
    ```diff
    Run actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
    Syncing repository: ROCm/TheRock
    Checking out the ref
    /usr/bin/git log -1 --format=%H
    +bce56b2318b2cb6ca35826faee750814d190702b
    ```
    
    ```diff
    Run python ./build_tools/compute_rocm_package_version.py \
      python ./build_tools/compute_rocm_package_version.py \
        --release-type=dev \
        --prerelease-version= \
    +   --git-sha=bce56b2318b2cb6ca35826faee750814d190702b
      shell: /usr/bin/bash -e {0}
    Loading version from file '/home/runner/work/rockrel/rockrel/version.json'
    Base version  : '7.13.0'
    Package type  : 'wheel'
    +Version suffix: '.dev0+bce56b2318b2cb6ca35826faee750814d190702b'
    Full version  : '7.13.0.dev0+bce56b2318b2cb6ca35826faee750814d190702b'
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
