### PR TITLE
Patch test_components fromJSON error when test_runs_on is empty

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -167,13 +167,14 @@ jobs:
       ${{
         !failure() &&
         !cancelled() &&
+        needs.configure_test_matrix.outputs.components != '' &&
         needs.configure_test_matrix.outputs.components != '[]' &&
         !inputs.sanity_check_only_for_family
       }}
     strategy:
       fail-fast: false
       matrix:
-        components: ${{ fromJSON(needs.configure_test_matrix.outputs.components) }}
+        components: ${{ fromJSON(needs.configure_test_matrix.outputs.components || '[]') }}
     uses: './.github/workflows/test_component.yml'
     secrets: inherit
     with:


### PR DESCRIPTION
## Motivation

This dev release in rockrel: https://github.com/ROCm/rockrel/actions/runs/25100364100/attempts/1 hit errors
`Multi-Arch Release
Error when evaluating 'strategy' for job 'test_components'. ROCm/TheRock/.github/workflows/test_artifacts.yml@30fc752307885b3099b9a25b2fde039928d8a651 (Line: 176, Col: 21): Error from function 'fromJSON': empty input, ROCm/TheRock/.github/workflows/test_artifacts.yml@30fc752307885b3099b9a25b2fde039928d8a651 (Line: 176, Col: 21): Unexpected value ''`

## Technical Details

I think we missed this in CI workflows since multi_arch_ci_linux.yml has a `expect_failure` condition: https://github.com/ROCm/TheRock/blob/88425ee26eb1259292089c723432e4594e3bbb20/.github/workflows/multi_arch_ci_linux.yml#L99-L103

I did not add that condition to multi_arch_release_linux.yml: https://github.com/ROCm/TheRock/blob/7161bc7968a7bae56be9ea4658b6261831d14d8e/.github/workflows/multi_arch_release_linux.yml#L117-L120

I'd like to remove that `expect_failure` entirely since it isn't actually working right now in multi-arch CI, see https://github.com/ROCm/TheRock/pull/4500

## Test Plan

We'll need to run a release workflow until it reaches the test step, which takes hours. Might as well merge and test via an actual dev release.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
