### PR TITLE
install test support functions - gpg url, repo url update

### DIFF
--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -26,7 +26,7 @@ Usage:
 
 Examples:
   python build_tools/packaging/linux/get_url_repo_params.py get-base-url --from-url https://example.com/v2/whl
-  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url --release-type prerelease --from-url https://rocm.prereleases.amd.com/packages/ubuntu2404
+  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url --release-type prerelease --from-url https://rocm.prereleases.amd.com/packages/ubuntu2404  # → .../packages/gpg/rocm.gpg
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix v3/packages/deb/20260204-12345
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --release-type prerelease --native-package-type deb --repo-base-url https://x.com --os-profile ubuntu2404 --repo-sub-folder ''
   python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch --artifact-group gfx94X-dcgpu
@@ -72,14 +72,28 @@ def get_gpg_key_url(package_url: str) -> str:
     """
     Get GPG key URL from package repository URL.
 
-    Extracts base URL and appends /gpg/rocm.gpg path.
+    ROCm hosts publish the key under .../packages/gpg/rocm.gpg (same tree as the repo),
+    not at the origin root. See dockerfiles/install_rocm_packages.sh get_gpg_key_url.
 
     Examples:
-        https://rocm.prereleases.amd.com/packages/ubuntu2404 -> https://rocm.prereleases.amd.com/gpg/rocm.gpg
-        https://repo.amd.com/rocm/packages/rhel10/x86_64/ -> https://repo.amd.com/gpg/rocm.gpg
+        https://rocm.prereleases.amd.com/packages/ubuntu2404
+            -> https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
+        https://repo.amd.com/rocm/packages/rhel10/x86_64/
+            -> https://repo.amd.com/rocm/packages/gpg/rocm.gpg
     """
-    base_url = get_base_url(package_url)
-    return f"{base_url}/gpg/rocm.gpg"
+    parsed = urlparse(package_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError(f"Invalid URL: {package_url!r}")
+    segments = [p for p in parsed.path.split("/") if p]
+    try:
+        idx = segments.index("packages")
+    except ValueError:
+        # No .../packages/... segment (e.g. bare base URL): match AMD defaults.
+        if parsed.netloc.lower() == "repo.amd.com":
+            return f"{parsed.scheme}://{parsed.netloc}/rocm/packages/gpg/rocm.gpg"
+        return f"{parsed.scheme}://{parsed.netloc}/packages/gpg/rocm.gpg"
+    prefix = "/" + "/".join(segments[: idx + 1])
+    return f"{parsed.scheme}://{parsed.netloc}{prefix}/gpg/rocm.gpg"
 
 
 def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
@@ -286,7 +300,7 @@ def main(argv: list[str] | None = None) -> int:
         type=str,
         required=True,
         metavar="URL",
-        help="Package repository URL to derive GPG key URL from when needed (e.g. https://rocm.prereleases.amd.com/packages/ubuntu2404 → https://rocm.prereleases.amd.com/gpg/rocm.gpg)",
+        help="Package repository URL to derive GPG key URL from when needed (e.g. .../packages/ubuntu2404 → .../packages/gpg/rocm.gpg)",
     )
     p_gpg.add_argument(
         "--release-type",

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -11,7 +11,7 @@ Subcommands (get operations):
 
   get-base-url         Get base URL (scheme + netloc) from --from-url or from --release-type. Prints repo_base_url=<value>.
   get-repo-sub-folder  Get repo_sub_folder from an S3 prefix (last segment if YYYYMMDD-<id>, else empty). Prints repo_sub_folder=<value>.
-  get-repo-url         Native install repo URL and gpg_key_url (see docs/packaging/native_packaging.md). Required: --release-type, --os-profile. Optional: --repo-sub-folder, --repo-base-url, --native-package-type, --from-url (optional override for GPG derivation on signed repos). Prints repo_url=<value> and gpg_key_url=<value>.
+  get-repo-url         Native install repo URL and gpg_key_url. Required: --release-type, --os-profile. Optional: --layout per_family|multi_arch (default per_family), --repo-sub-folder, --repo-base-url, --native-package-type, --from-url. Prints repo_url=<value> and gpg_key_url=<value>.
   extract-gfx-arch     Extract and normalize GPU architecture from artifact group. Prints gfx_arch=<value>.
   get-container-image  Get container image for a given OS profile. Prints container_image=<value>.
 
@@ -27,6 +27,7 @@ Examples:
   python build_tools/packaging/linux/get_url_repo_params.py get-base-url --release-type prerelease
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix v3/packages/deb/20260204-12345
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --release-type prerelease --os-profile ubuntu2404
+  python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --layout multi_arch --release-type nightly --os-profile ubuntu2404 --repo-sub-folder 20260501-25200531110
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --release-type prerelease --native-package-type deb --repo-base-url https://x.com --os-profile ubuntu2404 --repo-sub-folder ''
   python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch --artifact-group gfx94X-dcgpu
   python build_tools/packaging/linux/get_url_repo_params.py get-container-image --os-profile ubuntu2404
@@ -41,6 +42,25 @@ from urllib.parse import urlparse
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent))
 from github_actions.github_actions_api import gha_set_output
+
+# Repo URL layout selectors (get-repo-url --layout).
+LAYOUT_PER_FAMILY = "per_family"
+LAYOUT_MULTI_ARCH = "multi_arch"
+_PACKAGES_MULTI_ARCH = "packages-multi-arch"
+_VALID_LAYOUTS = (LAYOUT_PER_FAMILY, LAYOUT_MULTI_ARCH, "legacy", "gfx", "multiarch")
+
+
+def normalize_layout(layout: str | None) -> str:
+    """Normalize --layout values to LAYOUT_PER_FAMILY or LAYOUT_MULTI_ARCH."""
+    if not (layout or "").strip():
+        return LAYOUT_PER_FAMILY
+    key = layout.strip().lower().replace("-", "_")
+    if key in (LAYOUT_PER_FAMILY, "legacy", "gfx"):
+        return LAYOUT_PER_FAMILY
+    if key in (LAYOUT_MULTI_ARCH, "multiarch"):
+        return LAYOUT_MULTI_ARCH
+    supported = ", ".join(_VALID_LAYOUTS)
+    raise ValueError(f"Unknown layout {layout!r}; use one of: {supported}")
 
 
 # --- base_url ---
@@ -103,12 +123,15 @@ def get_gpg_key_url(package_url: str) -> str:
     """
     Get GPG key URL from package repository URL.
 
-    ROCm hosts publish the key under .../packages/gpg/rocm.gpg (same tree as the repo),
-    not at the origin root. See dockerfiles/install_rocm_packages.sh get_gpg_key_url.
+    ROCm hosts publish the key next to the package tree (…/gpg/rocm.gpg), not at the
+    origin root. Supports per-family (…/packages/…) and multi-arch
+    (…/packages-multi-arch/…) paths. See dockerfiles/install_rocm_packages.sh.
 
     Examples:
         https://rocm.prereleases.amd.com/packages/ubuntu2404
             -> https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
+        https://rocm.nightlies.amd.com/packages-multi-arch/deb/20260501-123
+            -> https://rocm.nightlies.amd.com/packages-multi-arch/gpg/rocm.gpg
         https://repo.amd.com/rocm/packages/rhel10/x86_64/
             -> https://repo.amd.com/rocm/packages/gpg/rocm.gpg
     """
@@ -116,15 +139,17 @@ def get_gpg_key_url(package_url: str) -> str:
     if not parsed.scheme or not parsed.netloc:
         raise ValueError(f"Invalid URL: {package_url!r}")
     segments = [p for p in parsed.path.split("/") if p]
-    try:
-        idx = segments.index("packages")
-    except ValueError:
-        # No .../packages/... segment (e.g. bare base URL): match AMD defaults.
-        if parsed.netloc.lower() == "repo.amd.com":
-            return f"{parsed.scheme}://{parsed.netloc}/rocm/packages/gpg/rocm.gpg"
-        return f"{parsed.scheme}://{parsed.netloc}/packages/gpg/rocm.gpg"
-    prefix = "/" + "/".join(segments[: idx + 1])
-    return f"{parsed.scheme}://{parsed.netloc}{prefix}/gpg/rocm.gpg"
+    for segment_name in (_PACKAGES_MULTI_ARCH, "packages"):
+        try:
+            idx = segments.index(segment_name)
+        except ValueError:
+            continue
+        prefix = "/" + "/".join(segments[: idx + 1])
+        return f"{parsed.scheme}://{parsed.netloc}{prefix}/gpg/rocm.gpg"
+    # No known package-tree segment (e.g. bare base URL): match AMD defaults.
+    if parsed.netloc.lower() == "repo.amd.com":
+        return f"{parsed.scheme}://{parsed.netloc}/rocm/packages/gpg/rocm.gpg"
+    return f"{parsed.scheme}://{parsed.netloc}/packages/gpg/rocm.gpg"
 
 
 # Minimal package-repo URLs (path through …/packages/) so get_gpg_key_url() resolves the
@@ -139,28 +164,51 @@ _RELEASE_TYPE_TO_MINIMAL_PACKAGE_URL_FOR_GPG: dict[str, str] = {
     "dev": "https://rocm.devreleases.amd.com/packages/",
 }
 
+_RELEASE_TYPE_TO_MINIMAL_MULTI_ARCH_URL_FOR_GPG: dict[str, str] = {
+    "prerelease": "https://rocm.prereleases.amd.com/packages-multi-arch/",
+    "prereleases": "https://rocm.prereleases.amd.com/packages-multi-arch/",
+    "release": "https://repo.amd.com/packages-multi-arch/",
+    "stable": "https://repo.amd.com/packages-multi-arch/",
+    "nightly": "https://rocm.nightlies.amd.com/packages-multi-arch/",
+    "nightlies": "https://rocm.nightlies.amd.com/packages-multi-arch/",
+    "dev": "https://rocm.devreleases.amd.com/packages-multi-arch/",
+    "ci": "https://rocm.nightlies.amd.com/packages-multi-arch/",
+}
 
-def get_gpg_key_url_from_release_type(release_type: str) -> str:
+
+def get_gpg_key_url_from_release_type(
+    release_type: str, layout: str = LAYOUT_PER_FAMILY
+) -> str:
     """Return GPG key URL using only release line (no user-supplied package URL)."""
     if not (release_type or "").strip():
         raise ValueError("release_type cannot be empty")
     rt = release_type.strip().lower()
-    minimal = _RELEASE_TYPE_TO_MINIMAL_PACKAGE_URL_FOR_GPG.get(rt)
+    normalized_layout = normalize_layout(layout)
+    url_map = (
+        _RELEASE_TYPE_TO_MINIMAL_MULTI_ARCH_URL_FOR_GPG
+        if normalized_layout == LAYOUT_MULTI_ARCH
+        else _RELEASE_TYPE_TO_MINIMAL_PACKAGE_URL_FOR_GPG
+    )
+    minimal = url_map.get(rt)
     if minimal is None:
-        supported = ", ".join(sorted(set(_RELEASE_TYPE_TO_MINIMAL_PACKAGE_URL_FOR_GPG)))
+        supported = ", ".join(sorted(set(url_map)))
         raise ValueError(
             f"Unknown release_type {release_type!r}; use one of: {supported}"
         )
     return get_gpg_key_url(minimal)
 
 
-def derive_gpg_key_url_for_repo_outputs(release_type: str, from_url: str | None) -> str:
+def derive_gpg_key_url_for_repo_outputs(
+    release_type: str,
+    from_url: str | None,
+    layout: str = LAYOUT_PER_FAMILY,
+) -> str:
     """Return gpg_key_url string for get-repo-url (empty when unsigned release lines)."""
     if not gpg_key_url_needed_for_release_type(release_type):
         return ""
     if from_url is not None:
         return get_gpg_key_url(from_url)
-    return get_gpg_key_url_from_release_type(release_type)
+    return get_gpg_key_url_from_release_type(release_type, layout=layout)
 
 
 def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
@@ -186,13 +234,15 @@ DATE_ARTIFACT_PATTERN = re.compile(r"^\d{8}-\d+$")
 
 
 def get_repo_sub_folder(s3_prefix: str) -> str:
-    """Return last path segment if it matches YYYYMMDD-<id>, else empty."""
+    """Return YYYYMMDD-<id> release folder from an S3 prefix, if present.
+
+    Scans all path segments (newest last) so multi-arch prefixes such as
+    ``{run_id}-linux/packages/deb/20260204-12345`` are handled.
+    """
     segments = [p for p in s3_prefix.strip("/").split("/") if p]
-    if not segments:
-        return ""
-    last = segments[-1]
-    if DATE_ARTIFACT_PATTERN.fullmatch(last):
-        return last
+    for seg in reversed(segments):
+        if DATE_ARTIFACT_PATTERN.fullmatch(seg):
+            return seg
     return ""
 
 
@@ -223,7 +273,7 @@ def get_native_package_type_from_os_profile(os_profile: str) -> str:
     return "rpm"
 
 
-def get_repo_url(
+def get_repo_url_per_family(
     release_type: str,
     native_package_type: str,
     repo_base_url: str,
@@ -231,12 +281,12 @@ def get_repo_url(
     repo_sub_folder: str,
 ) -> str:
     """
-    Return the full native-package install repo URL.
+    Per-family native-package install repo URL (legacy layout).
 
-    Layout matches docs/packaging/native_packaging.md (DEB/RPM install URL columns):
+    Matches docs/packaging/native_packaging.md (DEB/RPM install URL columns):
     - prerelease: .../packages/{os_profile} (deb) or .../packages/{os_profile}/x86_64/ (rpm)
     - release, stable: .../rocm/packages/{os_profile} (deb) or .../rocm/packages/{os_profile}/x86_64/ (rpm)
-    - dev, nightly, ci, etc.: .../deb/{YYYYMMDD-id}/ or .../rpm/{id}/x86_64/ (empty id omits duplicate slashes)
+    - dev, nightly, ci, etc.: .../deb/{YYYYMMDD-id}/ or .../rpm/{id}/x86_64/
     """
     base = repo_base_url.rstrip("/")
     rt = _normalized_release_type_for_repo_url(release_type)
@@ -258,6 +308,54 @@ def get_repo_url(
     return f"{base}/rpm/x86_64/"
 
 
+def get_repo_url_multi_arch(
+    repo_base_url: str,
+    native_package_type: str,
+    repo_sub_folder: str,
+) -> str:
+    """
+    Multi-arch native-package install repo URL.
+
+    Matches RELEASES.md — Installing multi-arch native Linux packages:
+    - deb: {base}/packages-multi-arch/deb/{RELEASE_ID}
+    - rpm: {base}/packages-multi-arch/rpm/{RELEASE_ID}/x86_64
+    """
+    base = repo_base_url.rstrip("/")
+    sub = (repo_sub_folder or "").strip().strip("/")
+    if native_package_type == "deb":
+        if sub:
+            return f"{base}/{_PACKAGES_MULTI_ARCH}/deb/{sub}"
+        return f"{base}/{_PACKAGES_MULTI_ARCH}/deb"
+    if sub:
+        return f"{base}/{_PACKAGES_MULTI_ARCH}/rpm/{sub}/x86_64"
+    return f"{base}/{_PACKAGES_MULTI_ARCH}/rpm/x86_64"
+
+
+def get_repo_url(
+    release_type: str,
+    native_package_type: str,
+    repo_base_url: str,
+    os_profile: str,
+    repo_sub_folder: str,
+    layout: str = LAYOUT_PER_FAMILY,
+) -> str:
+    """Return the full native-package install repo URL for the requested layout."""
+    normalized_layout = normalize_layout(layout)
+    if normalized_layout == LAYOUT_MULTI_ARCH:
+        return get_repo_url_multi_arch(
+            repo_base_url=repo_base_url,
+            native_package_type=native_package_type,
+            repo_sub_folder=repo_sub_folder,
+        )
+    return get_repo_url_per_family(
+        release_type=release_type,
+        native_package_type=native_package_type,
+        repo_base_url=repo_base_url,
+        os_profile=os_profile,
+        repo_sub_folder=repo_sub_folder,
+    )
+
+
 def cmd_repo_url(args: argparse.Namespace) -> int:
     try:
         native = args.native_package_type
@@ -266,15 +364,19 @@ def cmd_repo_url(args: argparse.Namespace) -> int:
         repo_base = args.repo_base_url
         if repo_base is None:
             repo_base = get_base_url_from_release_type(args.release_type)
+        layout = normalize_layout(getattr(args, "layout", None))
         url = get_repo_url(
             release_type=args.release_type,
             native_package_type=native,
             repo_base_url=repo_base,
             os_profile=args.os_profile,
             repo_sub_folder=args.repo_sub_folder or "",
+            layout=layout,
         )
         gpg_url = derive_gpg_key_url_for_repo_outputs(
-            args.release_type, getattr(args, "from_url", None)
+            args.release_type,
+            getattr(args, "from_url", None),
+            layout=layout,
         )
     except (ValueError, TypeError) as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -408,7 +510,14 @@ def main(argv: list[str] | None = None) -> int:
     # get-repo-url: full repo URL from components (replaces inline logic in workflows)
     p_url = subparsers.add_parser(
         "get-repo-url",
-        help="Native repo URL and gpg_key_url (docs/packaging/native_packaging.md). Requires --release-type and --os-profile; optional --repo-sub-folder, --repo-base-url, --native-package-type, --from-url (GPG override).",
+        help="Native repo URL and gpg_key_url. Requires --release-type and --os-profile; optional --layout, --repo-sub-folder, --repo-base-url, --native-package-type, --from-url.",
+    )
+    p_url.add_argument(
+        "--layout",
+        type=str,
+        default=LAYOUT_PER_FAMILY,
+        choices=list(_VALID_LAYOUTS),
+        help="Repo URL layout: per_family (default, native_packaging.md) or multi_arch (RELEASES.md packages-multi-arch/…).",
     )
     p_url.add_argument(
         "--release-type", type=str, required=True, help="e.g. prerelease, dev, nightly"
@@ -444,7 +553,7 @@ def main(argv: list[str] | None = None) -> int:
         "--repo-sub-folder",
         type=str,
         default="",
-        help="YYYYMMDD-<id> for dev/nightly/ci deb|rpm layout; ignored for prerelease/release/stable (URL uses /packages/ or /rocm/packages/ + os-profile)",
+        help="YYYYMMDD-<run-id> (RELEASE_ID): per_family dev/nightly path, or multi_arch packages-multi-arch/{deb|rpm}/… segment.",
     )
     p_url.set_defaults(func=cmd_repo_url)
 

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -28,7 +28,7 @@ Examples:
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix v3/packages/deb/20260204-12345
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --release-type prerelease --os-profile ubuntu2404
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --layout multi_arch --release-type nightly --os-profile ubuntu2404 --repo-sub-folder 20260501-25200531110
-  python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --release-type prerelease --native-package-type deb --repo-base-url https://x.com --os-profile ubuntu2404 --repo-sub-folder ''
+  python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --release-type prerelease --native-package-type deb --repo-base-url https://repo_url.com --os-profile ubuntu2404 --repo-sub-folder ''
   python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch --artifact-group gfx94X-dcgpu
   python build_tools/packaging/linux/get_url_repo_params.py get-container-image --os-profile ubuntu2404
 """

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -12,7 +12,7 @@ Subcommands (get operations):
   get-base-url         Get base URL (scheme + netloc) from --from-url or from --release-type. Prints repo_base_url=<value>.
   get-gpg-url          Get GPG key URL for GITHUB_OUTPUT. Provide --from-url and/or --release-type (at least one). With --release-type only, uses canonical package hosts. With --release-type, emits a non-empty URL only for signed-repo lines (prerelease/release/stable); otherwise gpg_key_url=. Legacy: --from-url only always derives.
   get-repo-sub-folder  Get repo_sub_folder from an S3 prefix (last segment if YYYYMMDD-<id>, else empty). Prints repo_sub_folder=<value>.
-  get-repo-url         Get full repo URL. Required: --release-type, --os-profile. Optional: --repo-sub-folder, --repo-base-url, --native-package-type (repo base and package type default from release line and OS profile). Prints repo_url=<value>.
+  get-repo-url         Full native install repo URL (see docs/packaging/native_packaging.md). Required: --release-type, --os-profile. Optional: --repo-sub-folder, --repo-base-url, --native-package-type. Prints repo_url=<value>.
   extract-gfx-arch     Extract and normalize GPU architecture from artifact group. Prints gfx_arch=<value>.
   get-container-image  Get container image for a given OS profile. Prints container_image=<value>.
 
@@ -248,18 +248,23 @@ def get_repo_url(
     repo_sub_folder: str,
 ) -> str:
     """
-    Return the full repo URL for install tests.
-    - prerelease (+ prereleases alias) + deb: repo_base_url / os_profile
-    - prerelease + rpm: repo_base_url / os_profile / x86_64/
-    - non-prerelease + deb: repo_base_url / deb / repo_sub_folder / (or .../deb/ if subfolder empty)
-    - non-prerelease + rpm: repo_base_url / rpm / repo_sub_folder / x86_64/ (or .../rpm/x86_64/ if empty)
+    Return the full native-package install repo URL.
+
+    Layout matches docs/packaging/native_packaging.md (DEB/RPM install URL columns):
+    - prerelease: .../packages/{os_profile} (deb) or .../packages/{os_profile}/x86_64/ (rpm)
+    - release, stable: .../rocm/packages/{os_profile} (deb) or .../rocm/packages/{os_profile}/x86_64/ (rpm)
+    - dev, nightly, ci, etc.: .../deb/{YYYYMMDD-id}/ or .../rpm/{id}/x86_64/ (empty id omits duplicate slashes)
     """
     base = repo_base_url.rstrip("/")
     rt = _normalized_release_type_for_repo_url(release_type)
     if rt == "prerelease":
         if native_package_type == "deb":
-            return f"{base}/{os_profile}"
-        return f"{base}/{os_profile}/x86_64/"
+            return f"{base}/packages/{os_profile}"
+        return f"{base}/packages/{os_profile}/x86_64/"
+    if rt in ("release", "stable"):
+        if native_package_type == "deb":
+            return f"{base}/rocm/packages/{os_profile}"
+        return f"{base}/rocm/packages/{os_profile}/x86_64/"
     sub = (repo_sub_folder or "").strip().strip("/")
     if native_package_type == "deb":
         if sub:
@@ -437,7 +442,7 @@ def main(argv: list[str] | None = None) -> int:
     # get-repo-url: full repo URL from components (replaces inline logic in workflows)
     p_url = subparsers.add_parser(
         "get-repo-url",
-        help="Get full repo URL. Requires --release-type and --os-profile; optional --repo-sub-folder; --repo-base-url and --native-package-type default from release line and OS profile.",
+        help="Get full native install repo URL (docs/packaging/native_packaging.md). Requires --release-type and --os-profile; optional --repo-sub-folder; --repo-base-url and --native-package-type default from release line and OS profile.",
     )
     p_url.add_argument(
         "--release-type", type=str, required=True, help="e.g. prerelease, dev, nightly"
@@ -466,7 +471,7 @@ def main(argv: list[str] | None = None) -> int:
         "--repo-sub-folder",
         type=str,
         default="",
-        help="Repo subfolder (e.g. YYYYMMDD-<id> for dev/nightly; empty for prerelease)",
+        help="YYYYMMDD-<id> for dev/nightly/ci deb|rpm layout; ignored for prerelease/release/stable (URL uses /packages/ or /rocm/packages/ + os-profile)",
     )
     p_url.set_defaults(func=cmd_repo_url)
 

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -251,8 +251,8 @@ def get_repo_url(
     Return the full repo URL for install tests.
     - prerelease (+ prereleases alias) + deb: repo_base_url / os_profile
     - prerelease + rpm: repo_base_url / os_profile / x86_64/
-    - non-prerelease + deb: repo_base_url / deb / repo_sub_folder /
-    - non-prerelease + rpm: repo_base_url / rpm / repo_sub_folder / x86_64/
+    - non-prerelease + deb: repo_base_url / deb / repo_sub_folder / (or .../deb/ if subfolder empty)
+    - non-prerelease + rpm: repo_base_url / rpm / repo_sub_folder / x86_64/ (or .../rpm/x86_64/ if empty)
     """
     base = repo_base_url.rstrip("/")
     rt = _normalized_release_type_for_repo_url(release_type)
@@ -260,9 +260,14 @@ def get_repo_url(
         if native_package_type == "deb":
             return f"{base}/{os_profile}"
         return f"{base}/{os_profile}/x86_64/"
+    sub = (repo_sub_folder or "").strip().strip("/")
     if native_package_type == "deb":
-        return f"{base}/deb/{repo_sub_folder}/"
-    return f"{base}/rpm/{repo_sub_folder}/x86_64/"
+        if sub:
+            return f"{base}/deb/{sub}/"
+        return f"{base}/deb/"
+    if sub:
+        return f"{base}/rpm/{sub}/x86_64/"
+    return f"{base}/rpm/x86_64/"
 
 
 def cmd_repo_url(args: argparse.Namespace) -> int:

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -154,9 +154,7 @@ def get_gpg_key_url_from_release_type(release_type: str) -> str:
     return get_gpg_key_url(minimal)
 
 
-def derive_gpg_key_url_for_repo_outputs(
-    release_type: str, from_url: str | None
-) -> str:
+def derive_gpg_key_url_for_repo_outputs(release_type: str, from_url: str | None) -> str:
     """Return gpg_key_url string for get-repo-url (empty when unsigned release lines)."""
     if not gpg_key_url_needed_for_release_type(release_type):
         return ""

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -9,16 +9,16 @@ Output is always KEY=value (suitable for GITHUB_OUTPUT).
 
 Subcommands (get operations):
 
-  get-base-url         Get base URL (scheme + netloc) from an input URL. Prints repo_base_url=<value>.
-  get-gpg-url          Get GPG key URL for GITHUB_OUTPUT. With --release-type, emits a non-empty URL only for prerelease/release; otherwise gpg_key_url=. Without --release-type, always derives from --from-url (legacy).
+  get-base-url         Get base URL (scheme + netloc) from --from-url or from --release-type. Prints repo_base_url=<value>.
+  get-gpg-url          Get GPG key URL for GITHUB_OUTPUT. Provide --from-url and/or --release-type (at least one). With --release-type only, uses canonical package hosts. With --release-type, emits a non-empty URL only for signed-repo lines (prerelease/release/stable); otherwise gpg_key_url=. Legacy: --from-url only always derives.
   get-repo-sub-folder  Get repo_sub_folder from an S3 prefix (last segment if YYYYMMDD-<id>, else empty). Prints repo_sub_folder=<value>.
-  get-repo-url         Get full repo URL from components(release_type, native_package_type, repo_base_url, os_profile, repo_sub_folder). Prints repo_url=<value>.
+  get-repo-url         Get full repo URL. Required: --release-type, --os-profile. Optional: --repo-sub-folder, --repo-base-url, --native-package-type (repo base and package type default from release line and OS profile). Prints repo_url=<value>.
   extract-gfx-arch     Extract and normalize GPU architecture from artifact group. Prints gfx_arch=<value>.
   get-container-image  Get container image for a given OS profile. Prints container_image=<value>.
 
 Usage:
-  python build_tools/packaging/linux/get_url_repo_params.py get-base-url --from-url <url>
-  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url --from-url <url> [--release-type <type>]
+  python build_tools/packaging/linux/get_url_repo_params.py get-base-url (--from-url <url> | --release-type <type>)
+  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url (--from-url <url> | --release-type <type> | both)
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix <prefix>
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url ...
   python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch --artifact-group <group>
@@ -26,8 +26,11 @@ Usage:
 
 Examples:
   python build_tools/packaging/linux/get_url_repo_params.py get-base-url --from-url https://example.com/v2/whl
+  python build_tools/packaging/linux/get_url_repo_params.py get-base-url --release-type prerelease
   python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url --release-type prerelease --from-url https://rocm.prereleases.amd.com/packages/ubuntu2404  # → .../packages/gpg/rocm.gpg
+  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url --release-type prerelease  # same GPG URL without --from-url
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix v3/packages/deb/20260204-12345
+  python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --release-type prerelease --os-profile ubuntu2404
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --release-type prerelease --native-package-type deb --repo-base-url https://x.com --os-profile ubuntu2404 --repo-sub-folder ''
   python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch --artifact-group gfx94X-dcgpu
   python build_tools/packaging/linux/get_url_repo_params.py get-container-image --os-profile ubuntu2404
@@ -46,6 +49,35 @@ from github_actions.github_actions_api import gha_set_output
 
 # --- base_url ---
 
+# Canonical scheme+netloc for native-package distribution channels.
+# See docs/packaging/versioning.md (Distribution channel / Base URL).
+_RELEASE_TYPE_TO_REPO_BASE_URL: dict[str, str] = {
+    "prerelease": "https://rocm.prereleases.amd.com",
+    "prereleases": "https://rocm.prereleases.amd.com",
+    "release": "https://repo.amd.com",
+    "stable": "https://repo.amd.com",
+    "nightly": "https://rocm.nightlies.amd.com",
+    "nightlies": "https://rocm.nightlies.amd.com",
+    "dev": "https://rocm.devreleases.amd.com",
+}
+
+
+def get_base_url_from_release_type(release_type: str) -> str:
+    """Return repo base URL (scheme + netloc) for a known release line.
+
+    Does not require a sample URL; aligns with public ROCm distribution endpoints.
+    """
+    if not (release_type or "").strip():
+        raise ValueError("release_type cannot be empty")
+    rt = release_type.strip().lower()
+    base = _RELEASE_TYPE_TO_REPO_BASE_URL.get(rt)
+    if base is None:
+        supported = ", ".join(sorted(set(_RELEASE_TYPE_TO_REPO_BASE_URL)))
+        raise ValueError(
+            f"Unknown release_type {release_type!r}; use one of: {supported}"
+        )
+    return base
+
 
 def get_base_url(url: str) -> str:
     """Return base URL (scheme + netloc only). No path, query, or fragment."""
@@ -57,7 +89,10 @@ def get_base_url(url: str) -> str:
 
 def cmd_base_url(args: argparse.Namespace) -> int:
     try:
-        base_url = get_base_url(args.from_url)
+        if args.release_type is not None:
+            base_url = get_base_url_from_release_type(args.release_type)
+        else:
+            base_url = get_base_url(args.from_url)
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
@@ -96,6 +131,33 @@ def get_gpg_key_url(package_url: str) -> str:
     return f"{parsed.scheme}://{parsed.netloc}{prefix}/gpg/rocm.gpg"
 
 
+# Minimal package-repo URLs (path through …/packages/) so get_gpg_key_url() resolves the
+# correct …/packages/gpg/rocm.gpg per channel; keys match _RELEASE_TYPE_TO_REPO_BASE_URL.
+_RELEASE_TYPE_TO_MINIMAL_PACKAGE_URL_FOR_GPG: dict[str, str] = {
+    "prerelease": "https://rocm.prereleases.amd.com/packages/",
+    "prereleases": "https://rocm.prereleases.amd.com/packages/",
+    "release": "https://repo.amd.com/rocm/packages/",
+    "stable": "https://repo.amd.com/rocm/packages/",
+    "nightly": "https://rocm.nightlies.amd.com/packages/",
+    "nightlies": "https://rocm.nightlies.amd.com/packages/",
+    "dev": "https://rocm.devreleases.amd.com/packages/",
+}
+
+
+def get_gpg_key_url_from_release_type(release_type: str) -> str:
+    """Return GPG key URL using only release line (no user-supplied package URL)."""
+    if not (release_type or "").strip():
+        raise ValueError("release_type cannot be empty")
+    rt = release_type.strip().lower()
+    minimal = _RELEASE_TYPE_TO_MINIMAL_PACKAGE_URL_FOR_GPG.get(rt)
+    if minimal is None:
+        supported = ", ".join(sorted(set(_RELEASE_TYPE_TO_MINIMAL_PACKAGE_URL_FOR_GPG)))
+        raise ValueError(
+            f"Unknown release_type {release_type!r}; use one of: {supported}"
+        )
+    return get_gpg_key_url(minimal)
+
+
 def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
     """
     Whether install workflows should use a repo GPG key URL for this release line.
@@ -103,21 +165,31 @@ def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
     When release_type is None, callers treat this as "legacy / unspecified" and always
     derive the GPG URL from the package URL.
 
-    When release_type is set (e.g. from GitHub Actions), only prerelease and release
-    lines use signed-repo GPG keys; dev/nightly/ci/etc. omit it (empty gpg_key_url).
+    When release_type is set (e.g. from GitHub Actions), only prerelease/prereleases,
+    release, and stable lines use signed-repo GPG keys; dev/nightly/ci/etc. omit it
+    (empty gpg_key_url).
     """
     if release_type is None:
         return True
     rt = release_type.strip().lower()
-    return rt in ("prerelease", "release")
+    return rt in ("prerelease", "prereleases", "release", "stable")
 
 
 def cmd_gpg_key_url(args: argparse.Namespace) -> int:
+    if args.from_url is None and args.release_type is None:
+        print(
+            "Error: get-gpg-url requires --from-url and/or --release-type",
+            file=sys.stderr,
+        )
+        return 1
     if not gpg_key_url_needed_for_release_type(args.release_type):
         gha_set_output({"gpg_key_url": ""})
         return 0
     try:
-        gpg_url = get_gpg_key_url(args.from_url)
+        if args.from_url is not None:
+            gpg_url = get_gpg_key_url(args.from_url)
+        else:
+            gpg_url = get_gpg_key_url_from_release_type(args.release_type)
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
@@ -150,6 +222,24 @@ def cmd_repo_sub_folder(args: argparse.Namespace) -> int:
 # --- repo_url ---
 
 
+def _normalized_release_type_for_repo_url(release_type: str) -> str:
+    """Map aliases so path rules match (e.g. prereleases → prerelease layout)."""
+    rt = release_type.strip().lower()
+    if rt == "prereleases":
+        return "prerelease"
+    return rt
+
+
+def get_native_package_type_from_os_profile(os_profile: str) -> str:
+    """Return deb or rpm from OS profile prefix (ubuntu/debian → deb; else rpm)."""
+    if not (os_profile or "").strip():
+        raise ValueError("os_profile cannot be empty")
+    op = os_profile.strip().lower()
+    if op.startswith("ubuntu") or op.startswith("debian"):
+        return "deb"
+    return "rpm"
+
+
 def get_repo_url(
     release_type: str,
     native_package_type: str,
@@ -159,13 +249,14 @@ def get_repo_url(
 ) -> str:
     """
     Return the full repo URL for install tests.
-    - prerelease + deb: repo_base_url / os_profile
+    - prerelease (+ prereleases alias) + deb: repo_base_url / os_profile
     - prerelease + rpm: repo_base_url / os_profile / x86_64/
     - non-prerelease + deb: repo_base_url / deb / repo_sub_folder /
     - non-prerelease + rpm: repo_base_url / rpm / repo_sub_folder / x86_64/
     """
     base = repo_base_url.rstrip("/")
-    if release_type == "prerelease":
+    rt = _normalized_release_type_for_repo_url(release_type)
+    if rt == "prerelease":
         if native_package_type == "deb":
             return f"{base}/{os_profile}"
         return f"{base}/{os_profile}/x86_64/"
@@ -176,10 +267,16 @@ def get_repo_url(
 
 def cmd_repo_url(args: argparse.Namespace) -> int:
     try:
+        native = args.native_package_type
+        if native is None:
+            native = get_native_package_type_from_os_profile(args.os_profile)
+        repo_base = args.repo_base_url
+        if repo_base is None:
+            repo_base = get_base_url_from_release_type(args.release_type)
         url = get_repo_url(
             release_type=args.release_type,
-            native_package_type=args.native_package_type,
-            repo_base_url=args.repo_base_url,
+            native_package_type=native,
+            repo_base_url=repo_base,
             os_profile=args.os_profile,
             repo_sub_folder=args.repo_sub_folder or "",
         )
@@ -279,34 +376,42 @@ def main(argv: list[str] | None = None) -> int:
     # get-base-url: get base URL from any input URL
     p_base = subparsers.add_parser(
         "get-base-url",
-        help="Get base URL (scheme + netloc) from an input URL; path/query/fragment are stripped.",
+        help="Get base URL (scheme + netloc): from --from-url, or from --release-type using canonical ROCm hosts.",
     )
-    p_base.add_argument(
+    g_base = p_base.add_mutually_exclusive_group(required=True)
+    g_base.add_argument(
         "--from-url",
         type=str,
-        required=True,
+        default=None,
         metavar="URL",
-        help="Any URL to derive base URL from (scheme + netloc only; e.g. https://example.com/v2/whl → https://example.com)",
+        help="Any URL to derive base URL from (scheme + netloc only; path/query/fragment stripped).",
+    )
+    g_base.add_argument(
+        "--release-type",
+        type=str,
+        default=None,
+        metavar="TYPE",
+        help="Release line only (no URL): prerelease, release, nightly, dev, stable; also prereleases, nightlies.",
     )
     p_base.set_defaults(func=cmd_base_url)
 
     # get-gpg-url: get GPG key URL from package repository URL
     p_gpg = subparsers.add_parser(
         "get-gpg-url",
-        help="Print gpg_key_url= for GITHUB_OUTPUT. With --release-type, only prerelease/release get a non-empty URL; otherwise gpg_key_url=. Omit --release-type to always derive from --from-url.",
+        help="Print gpg_key_url= for GITHUB_OUTPUT. At least one of --from-url or --release-type. If only --release-type, use canonical hosts.",
     )
     p_gpg.add_argument(
         "--from-url",
         type=str,
-        required=True,
+        default=None,
         metavar="URL",
-        help="Package repository URL to derive GPG key URL from when needed (e.g. .../packages/ubuntu2404 → .../packages/gpg/rocm.gpg)",
+        help="Package repository URL for GPG derivation when provided (wins over release-type-only path). With --release-type, signed-repo lines only.",
     )
     p_gpg.add_argument(
         "--release-type",
         type=str,
         default=None,
-        help="If set, emit non-empty GPG URL only for 'prerelease' or 'release'; for dev/nightly/etc. print gpg_key_url=. If omitted, always derive from --from-url.",
+        help="Release line: with --from-url, gates non-empty GPG to prerelease/prereleases/release/stable. Alone (no --from-url), derive GPG URL from canonical ROCm hosts.",
     )
     p_gpg.set_defaults(func=cmd_gpg_key_url)
 
@@ -327,7 +432,7 @@ def main(argv: list[str] | None = None) -> int:
     # get-repo-url: full repo URL from components (replaces inline logic in workflows)
     p_url = subparsers.add_parser(
         "get-repo-url",
-        help="Get full repo URL from release_type, native_package_type, repo_base_url, os_profile, repo_sub_folder.",
+        help="Get full repo URL. Requires --release-type and --os-profile; optional --repo-sub-folder; --repo-base-url and --native-package-type default from release line and OS profile.",
     )
     p_url.add_argument(
         "--release-type", type=str, required=True, help="e.g. prerelease, dev, nightly"
@@ -335,16 +440,16 @@ def main(argv: list[str] | None = None) -> int:
     p_url.add_argument(
         "--native-package-type",
         type=str,
-        required=True,
+        default=None,
         choices=["deb", "rpm"],
-        help="Package type (deb or rpm)",
+        help="deb or rpm; if omitted, inferred from --os-profile (ubuntu/debian → deb, else rpm)",
     )
     p_url.add_argument(
         "--repo-base-url",
         type=str,
-        required=True,
+        default=None,
         metavar="URL",
-        help="Base URL (scheme + netloc, no trailing slash)",
+        help="Base URL (scheme + netloc); if omitted, use canonical host for --release-type",
     )
     p_url.add_argument(
         "--os-profile",

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -10,15 +10,13 @@ Output is always KEY=value (suitable for GITHUB_OUTPUT).
 Subcommands (get operations):
 
   get-base-url         Get base URL (scheme + netloc) from --from-url or from --release-type. Prints repo_base_url=<value>.
-  get-gpg-url          Get GPG key URL for GITHUB_OUTPUT. Provide --from-url and/or --release-type (at least one). With --release-type only, uses canonical package hosts. With --release-type, emits a non-empty URL only for signed-repo lines (prerelease/release/stable); otherwise gpg_key_url=. Legacy: --from-url only always derives.
   get-repo-sub-folder  Get repo_sub_folder from an S3 prefix (last segment if YYYYMMDD-<id>, else empty). Prints repo_sub_folder=<value>.
-  get-repo-url         Full native install repo URL (see docs/packaging/native_packaging.md). Required: --release-type, --os-profile. Optional: --repo-sub-folder, --repo-base-url, --native-package-type. Prints repo_url=<value>.
+  get-repo-url         Native install repo URL and gpg_key_url (see docs/packaging/native_packaging.md). Required: --release-type, --os-profile. Optional: --repo-sub-folder, --repo-base-url, --native-package-type, --from-url (optional override for GPG derivation on signed repos). Prints repo_url=<value> and gpg_key_url=<value>.
   extract-gfx-arch     Extract and normalize GPU architecture from artifact group. Prints gfx_arch=<value>.
   get-container-image  Get container image for a given OS profile. Prints container_image=<value>.
 
 Usage:
   python build_tools/packaging/linux/get_url_repo_params.py get-base-url (--from-url <url> | --release-type <type>)
-  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url (--from-url <url> | --release-type <type> | both)
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix <prefix>
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url ...
   python build_tools/packaging/linux/get_url_repo_params.py extract-gfx-arch --artifact-group <group>
@@ -27,8 +25,6 @@ Usage:
 Examples:
   python build_tools/packaging/linux/get_url_repo_params.py get-base-url --from-url https://example.com/v2/whl
   python build_tools/packaging/linux/get_url_repo_params.py get-base-url --release-type prerelease
-  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url --release-type prerelease --from-url https://rocm.prereleases.amd.com/packages/ubuntu2404  # → .../packages/gpg/rocm.gpg
-  python build_tools/packaging/linux/get_url_repo_params.py get-gpg-url --release-type prerelease  # same GPG URL without --from-url
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-sub-folder --from-s3-prefix v3/packages/deb/20260204-12345
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --release-type prerelease --os-profile ubuntu2404
   python build_tools/packaging/linux/get_url_repo_params.py get-repo-url --release-type prerelease --native-package-type deb --repo-base-url https://x.com --os-profile ubuntu2404 --repo-sub-folder ''
@@ -158,6 +154,17 @@ def get_gpg_key_url_from_release_type(release_type: str) -> str:
     return get_gpg_key_url(minimal)
 
 
+def derive_gpg_key_url_for_repo_outputs(
+    release_type: str, from_url: str | None
+) -> str:
+    """Return gpg_key_url string for get-repo-url (empty when unsigned release lines)."""
+    if not gpg_key_url_needed_for_release_type(release_type):
+        return ""
+    if from_url is not None:
+        return get_gpg_key_url(from_url)
+    return get_gpg_key_url_from_release_type(release_type)
+
+
 def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
     """
     Whether install workflows should use a repo GPG key URL for this release line.
@@ -173,28 +180,6 @@ def gpg_key_url_needed_for_release_type(release_type: str | None) -> bool:
         return True
     rt = release_type.strip().lower()
     return rt in ("prerelease", "prereleases", "release", "stable")
-
-
-def cmd_gpg_key_url(args: argparse.Namespace) -> int:
-    if args.from_url is None and args.release_type is None:
-        print(
-            "Error: get-gpg-url requires --from-url and/or --release-type",
-            file=sys.stderr,
-        )
-        return 1
-    if not gpg_key_url_needed_for_release_type(args.release_type):
-        gha_set_output({"gpg_key_url": ""})
-        return 0
-    try:
-        if args.from_url is not None:
-            gpg_url = get_gpg_key_url(args.from_url)
-        else:
-            gpg_url = get_gpg_key_url_from_release_type(args.release_type)
-    except ValueError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
-    gha_set_output({"gpg_key_url": gpg_url})
-    return 0
 
 
 # --- repo_sub_folder ---
@@ -290,10 +275,13 @@ def cmd_repo_url(args: argparse.Namespace) -> int:
             os_profile=args.os_profile,
             repo_sub_folder=args.repo_sub_folder or "",
         )
+        gpg_url = derive_gpg_key_url_for_repo_outputs(
+            args.release_type, getattr(args, "from_url", None)
+        )
     except (ValueError, TypeError) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    gha_set_output({"repo_url": url})
+    gha_set_output({"repo_url": url, "gpg_key_url": gpg_url})
     return 0
 
 
@@ -405,26 +393,6 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_base.set_defaults(func=cmd_base_url)
 
-    # get-gpg-url: get GPG key URL from package repository URL
-    p_gpg = subparsers.add_parser(
-        "get-gpg-url",
-        help="Print gpg_key_url= for GITHUB_OUTPUT. At least one of --from-url or --release-type. If only --release-type, use canonical hosts.",
-    )
-    p_gpg.add_argument(
-        "--from-url",
-        type=str,
-        default=None,
-        metavar="URL",
-        help="Package repository URL for GPG derivation when provided (wins over release-type-only path). With --release-type, signed-repo lines only.",
-    )
-    p_gpg.add_argument(
-        "--release-type",
-        type=str,
-        default=None,
-        help="Release line: with --from-url, gates non-empty GPG to prerelease/prereleases/release/stable. Alone (no --from-url), derive GPG URL from canonical ROCm hosts.",
-    )
-    p_gpg.set_defaults(func=cmd_gpg_key_url)
-
     # get-repo-sub-folder: get repo_sub_folder from S3 prefix
     p_repo = subparsers.add_parser(
         "get-repo-sub-folder",
@@ -442,10 +410,17 @@ def main(argv: list[str] | None = None) -> int:
     # get-repo-url: full repo URL from components (replaces inline logic in workflows)
     p_url = subparsers.add_parser(
         "get-repo-url",
-        help="Get full native install repo URL (docs/packaging/native_packaging.md). Requires --release-type and --os-profile; optional --repo-sub-folder; --repo-base-url and --native-package-type default from release line and OS profile.",
+        help="Native repo URL and gpg_key_url (docs/packaging/native_packaging.md). Requires --release-type and --os-profile; optional --repo-sub-folder, --repo-base-url, --native-package-type, --from-url (GPG override).",
     )
     p_url.add_argument(
         "--release-type", type=str, required=True, help="e.g. prerelease, dev, nightly"
+    )
+    p_url.add_argument(
+        "--from-url",
+        type=str,
+        default=None,
+        metavar="URL",
+        help="Optional package repo URL to derive gpg_key_url when signed-repo applies; overrides canonical host from --release-type",
     )
     p_url.add_argument(
         "--native-package-type",

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -170,7 +170,9 @@ class GpgKeyUrlNeededForReleaseTypeTest(unittest.TestCase):
         self.assertTrue(
             get_url_repo_params.gpg_key_url_needed_for_release_type("release")
         )
-        self.assertTrue(get_url_repo_params.gpg_key_url_needed_for_release_type("stable"))
+        self.assertTrue(
+            get_url_repo_params.gpg_key_url_needed_for_release_type("stable")
+        )
         self.assertTrue(
             get_url_repo_params.gpg_key_url_needed_for_release_type("  Prerelease  ")
         )
@@ -663,7 +665,9 @@ class MainSubcommandsTest(unittest.TestCase):
             ]
         )
         self.assertEqual(code, 0)
-        self.assertIn("gpg_key_url=https://repo.amd.com/rocm/packages/gpg/rocm.gpg", output)
+        self.assertIn(
+            "gpg_key_url=https://repo.amd.com/rocm/packages/gpg/rocm.gpg", output
+        )
 
     def test_get_repo_url_release_minimal_gpg_only_release_host(self):
         code, output = _run_main_with_output(
@@ -753,7 +757,9 @@ class ContractLegacyAndDerivedTest(unittest.TestCase):
             native_package_type=get_url_repo_params.get_native_package_type_from_os_profile(
                 "ubuntu2404"
             ),
-            repo_base_url=get_url_repo_params.get_base_url_from_release_type("prerelease"),
+            repo_base_url=get_url_repo_params.get_base_url_from_release_type(
+                "prerelease"
+            ),
             os_profile="ubuntu2404",
             repo_sub_folder="",
         )

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -277,11 +277,11 @@ class GetRepoUrlTest(unittest.TestCase):
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
             ),
-            "https://x.com/ubuntu2404",
+            "https://x.com/packages/ubuntu2404",
         )
 
     def test_prerelease_deb(self):
-        # Test that prerelease + deb yields base/os_profile.
+        # native_packaging.md: .../packages/ubuntu2404
         self.assertEqual(
             get_url_repo_params.get_repo_url(
                 release_type="prerelease",
@@ -290,11 +290,10 @@ class GetRepoUrlTest(unittest.TestCase):
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
             ),
-            "https://x.com/ubuntu2404",
+            "https://x.com/packages/ubuntu2404",
         )
 
     def test_prerelease_rpm(self):
-        # Test that prerelease + rpm yields base/os_profile/x86_64/
         self.assertEqual(
             get_url_repo_params.get_repo_url(
                 release_type="prerelease",
@@ -303,7 +302,31 @@ class GetRepoUrlTest(unittest.TestCase):
                 os_profile="rhel8",
                 repo_sub_folder="",
             ),
-            "https://x.com/rhel8/x86_64/",
+            "https://x.com/packages/rhel8/x86_64/",
+        )
+
+    def test_release_deb_matches_native_packaging_doc(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="release",
+                native_package_type="deb",
+                repo_base_url="https://repo.amd.com",
+                os_profile="ubuntu2404",
+                repo_sub_folder="",
+            ),
+            "https://repo.amd.com/rocm/packages/ubuntu2404",
+        )
+
+    def test_stable_rpm_matches_native_packaging_doc(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="stable",
+                native_package_type="rpm",
+                repo_base_url="https://repo.amd.com",
+                os_profile="rhel10",
+                repo_sub_folder="",
+            ),
+            "https://repo.amd.com/rocm/packages/rhel10/x86_64/",
         )
 
     def test_nightly_deb(self):
@@ -341,7 +364,7 @@ class GetRepoUrlTest(unittest.TestCase):
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
             ),
-            "https://repo.amd.com/deb/",
+            "https://repo.amd.com/rocm/packages/ubuntu2404",
         )
 
     def test_non_prerelease_empty_repo_subfolder_no_double_slash_rpm(self):
@@ -366,7 +389,7 @@ class GetRepoUrlTest(unittest.TestCase):
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
             ),
-            "https://x.com/ubuntu2404",
+            "https://x.com/packages/ubuntu2404",
         )
 
 
@@ -500,7 +523,7 @@ class MainSubcommandsTest(unittest.TestCase):
             ]
         )
         self.assertEqual(code, 0)
-        self.assertIn("repo_url=https://x.com/ubuntu2404", output)
+        self.assertIn("repo_url=https://x.com/packages/ubuntu2404", output)
 
     def test_get_repo_url_minimal_prerelease_ubuntu(self):
         code, output = _run_main_with_output(
@@ -514,7 +537,7 @@ class MainSubcommandsTest(unittest.TestCase):
         )
         self.assertEqual(code, 0)
         self.assertIn(
-            "repo_url=https://rocm.prereleases.amd.com/ubuntu2404",
+            "repo_url=https://rocm.prereleases.amd.com/packages/ubuntu2404",
             output,
         )
 
@@ -834,6 +857,7 @@ class ContractLegacyAndDerivedTest(unittest.TestCase):
         )
         self.assertIn("rocm.prereleases.amd.com", out_derived)
         self.assertIn("internal.example.com", out_custom)
+        self.assertIn("/packages/ubuntu2404", out_custom)
         self.assertNotEqual(out_derived, out_custom)
 
 

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -4,7 +4,8 @@
 
 # Unit test coverage for get_url_repo_params.py:
 #   get_base_url, get_base_url_from_release_type, get_gpg_key_url,
-#   get_gpg_key_url_from_release_type, gpg_key_url_needed_for_release_type,
+#   get_gpg_key_url_from_release_type, derive_gpg_key_url_for_repo_outputs,
+#   gpg_key_url_needed_for_release_type,
 #   get_repo_sub_folder,
 #   get_repo_url, get_native_package_type_from_os_profile, extract_gfx_arch,
 #   ContractLegacyAndDerivedTest (explicit vs derived/minimal parity),
@@ -169,9 +170,7 @@ class GpgKeyUrlNeededForReleaseTypeTest(unittest.TestCase):
         self.assertTrue(
             get_url_repo_params.gpg_key_url_needed_for_release_type("release")
         )
-        self.assertTrue(
-            get_url_repo_params.gpg_key_url_needed_for_release_type("stable")
-        )
+        self.assertTrue(get_url_repo_params.gpg_key_url_needed_for_release_type("stable"))
         self.assertTrue(
             get_url_repo_params.gpg_key_url_needed_for_release_type("  Prerelease  ")
         )
@@ -524,6 +523,10 @@ class MainSubcommandsTest(unittest.TestCase):
         )
         self.assertEqual(code, 0)
         self.assertIn("repo_url=https://x.com/packages/ubuntu2404", output)
+        self.assertIn(
+            "gpg_key_url=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg",
+            output,
+        )
 
     def test_get_repo_url_minimal_prerelease_ubuntu(self):
         code, output = _run_main_with_output(
@@ -538,6 +541,10 @@ class MainSubcommandsTest(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn(
             "repo_url=https://rocm.prereleases.amd.com/packages/ubuntu2404",
+            output,
+        )
+        self.assertIn(
+            "gpg_key_url=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg",
             output,
         )
 
@@ -558,6 +565,8 @@ class MainSubcommandsTest(unittest.TestCase):
             "repo_url=https://rocm.nightlies.amd.com/deb/20260204-12345/",
             output,
         )
+        self.assertIn("gpg_key_url=", output)
+        self.assertNotIn("rocm.gpg", output)
 
     def test_get_repo_url_error_returns_one(self):
         # Test that get-repo-url returns 1 and prints error when get_repo_url raises.
@@ -622,11 +631,14 @@ class MainSubcommandsTest(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn("gfx_arch=gfx94x,gfx1100", output)
 
-    def test_get_gpg_url_success(self):
-        # Test that get-gpg-url writes gpg_key_url= to GITHUB_OUTPUT.
+    def test_get_repo_url_with_from_url_override_prerelease_gpg(self):
         code, output = _run_main_with_output(
             [
-                "get-gpg-url",
+                "get-repo-url",
+                "--release-type",
+                "prerelease",
+                "--os-profile",
+                "ubuntu2404",
                 "--from-url",
                 "https://rocm.prereleases.amd.com/packages/ubuntu2404",
             ]
@@ -636,42 +648,46 @@ class MainSubcommandsTest(unittest.TestCase):
             "gpg_key_url=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg", output
         )
 
-    def test_get_gpg_url_release_type_only_prerelease(self):
+    def test_get_repo_url_release_with_from_url_gpg(self):
         code, output = _run_main_with_output(
-            ["get-gpg-url", "--release-type", "prerelease"]
+            [
+                "get-repo-url",
+                "--release-type",
+                "release",
+                "--os-profile",
+                "rhel10",
+                "--native-package-type",
+                "rpm",
+                "--from-url",
+                "https://repo.amd.com/rocm/packages/rhel10/x86_64/",
+            ]
         )
         self.assertEqual(code, 0)
-        self.assertIn(
-            "gpg_key_url=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg", output
-        )
+        self.assertIn("gpg_key_url=https://repo.amd.com/rocm/packages/gpg/rocm.gpg", output)
 
-    def test_get_gpg_url_release_type_only_release(self):
+    def test_get_repo_url_release_minimal_gpg_only_release_host(self):
         code, output = _run_main_with_output(
-            ["get-gpg-url", "--release-type", "release"]
+            [
+                "get-repo-url",
+                "--release-type",
+                "release",
+                "--os-profile",
+                "ubuntu2404",
+            ]
         )
         self.assertEqual(code, 0)
         self.assertIn(
             "gpg_key_url=https://repo.amd.com/rocm/packages/gpg/rocm.gpg", output
         )
 
-    def test_get_gpg_url_release_type_only_nightly_emits_empty(self):
-        code, output = _run_main_with_output(
-            ["get-gpg-url", "--release-type", "nightly"]
-        )
-        self.assertEqual(code, 0)
-        self.assertEqual(output.strip(), "gpg_key_url=")
-
-    def test_get_gpg_url_no_inputs_returns_one(self):
-        with patch("sys.stderr"):
-            code = get_url_repo_params.main(["get-gpg-url"])
-        self.assertEqual(code, 1)
-
-    def test_get_gpg_url_with_release_type_dev_emits_empty(self):
+    def test_get_repo_url_dev_unsigned_empty_gpg(self):
         code, output = _run_main_with_output(
             [
-                "get-gpg-url",
+                "get-repo-url",
                 "--release-type",
                 "dev",
+                "--os-profile",
+                "ubuntu2404",
                 "--from-url",
                 "https://rocm.prereleases.amd.com/packages/ubuntu2404",
             ]
@@ -680,48 +696,21 @@ class MainSubcommandsTest(unittest.TestCase):
         self.assertIn("gpg_key_url=", output)
         self.assertNotIn("rocm.gpg", output)
 
-    def test_get_gpg_url_with_release_type_dev_ignores_invalid_url(self):
+    def test_get_repo_url_nightly_invalid_from_url_still_unsigned(self):
         code, output = _run_main_with_output(
             [
-                "get-gpg-url",
+                "get-repo-url",
                 "--release-type",
                 "nightly",
+                "--os-profile",
+                "ubuntu2404",
                 "--from-url",
                 "not-a-valid-url",
             ]
         )
         self.assertEqual(code, 0)
-        self.assertEqual(output.strip(), "gpg_key_url=")
-
-    def test_get_gpg_url_with_release_type_prerelease(self):
-        code, output = _run_main_with_output(
-            [
-                "get-gpg-url",
-                "--release-type",
-                "prerelease",
-                "--from-url",
-                "https://rocm.prereleases.amd.com/packages/ubuntu2404",
-            ]
-        )
-        self.assertEqual(code, 0)
-        self.assertIn(
-            "gpg_key_url=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg", output
-        )
-
-    def test_get_gpg_url_with_release_type_release(self):
-        code, output = _run_main_with_output(
-            [
-                "get-gpg-url",
-                "--release-type",
-                "release",
-                "--from-url",
-                "https://repo.amd.com/rocm/packages/rhel10/x86_64/",
-            ]
-        )
-        self.assertEqual(code, 0)
-        self.assertIn(
-            "gpg_key_url=https://repo.amd.com/rocm/packages/gpg/rocm.gpg", output
-        )
+        self.assertIn("gpg_key_url=", output)
+        self.assertNotIn("rocm.gpg", output)
 
 
 class ContractLegacyAndDerivedTest(unittest.TestCase):
@@ -764,9 +753,7 @@ class ContractLegacyAndDerivedTest(unittest.TestCase):
             native_package_type=get_url_repo_params.get_native_package_type_from_os_profile(
                 "ubuntu2404"
             ),
-            repo_base_url=get_url_repo_params.get_base_url_from_release_type(
-                "prerelease"
-            ),
+            repo_base_url=get_url_repo_params.get_base_url_from_release_type("prerelease"),
             os_profile="ubuntu2404",
             repo_sub_folder="",
         )

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -7,7 +7,8 @@
 #   get_gpg_key_url_from_release_type, derive_gpg_key_url_for_repo_outputs,
 #   gpg_key_url_needed_for_release_type,
 #   get_repo_sub_folder,
-#   get_repo_url, get_native_package_type_from_os_profile, extract_gfx_arch,
+#   get_repo_url, get_repo_url_per_family, get_repo_url_multi_arch, normalize_layout,
+#   get_native_package_type_from_os_profile, extract_gfx_arch,
 #   ContractLegacyAndDerivedTest (explicit vs derived/minimal parity),
 #   and main() subcommands.
 
@@ -147,6 +148,14 @@ class GetGpgKeyUrlTest(unittest.TestCase):
             "https://rocm.nightlies.amd.com/packages/gpg/rocm.gpg",
         )
 
+    def test_handles_multi_arch_repo_url(self):
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url(
+                "https://rocm.nightlies.amd.com/packages-multi-arch/deb/20260204-12345/"
+            ),
+            "https://rocm.nightlies.amd.com/packages-multi-arch/gpg/rocm.gpg",
+        )
+
     def test_repo_amd_com_without_packages_segment(self):
         self.assertEqual(
             get_url_repo_params.get_gpg_key_url("https://repo.amd.com/"),
@@ -199,6 +208,20 @@ class GetGpgKeyUrlFromReleaseTypeTest(unittest.TestCase):
             "https://repo.amd.com/rocm/packages/gpg/rocm.gpg",
         )
 
+    def test_multi_arch_layout_hosts(self):
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url_from_release_type(
+                "prerelease", layout="multi_arch"
+            ),
+            "https://rocm.prereleases.amd.com/packages-multi-arch/gpg/rocm.gpg",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url_from_release_type(
+                "stable", layout="multiarch"
+            ),
+            "https://repo.amd.com/packages-multi-arch/gpg/rocm.gpg",
+        )
+
     def test_unknown_raises(self):
         with self.assertRaises(ValueError):
             get_url_repo_params.get_gpg_key_url_from_release_type("ci")
@@ -237,6 +260,42 @@ class GetRepoSubFolderTest(unittest.TestCase):
         self.assertEqual(get_url_repo_params.get_repo_sub_folder(""), "")
         self.assertEqual(get_url_repo_params.get_repo_sub_folder("/"), "")
 
+    def test_finds_release_id_in_multi_arch_s3_prefix(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_sub_folder(
+                "12345678-linux/packages/deb/20260204-12345"
+            ),
+            "20260204-12345",
+        )
+
+
+class NormalizeLayoutTest(unittest.TestCase):
+    """Tests for normalize_layout()."""
+
+    def test_defaults_to_per_family(self):
+        self.assertEqual(
+            get_url_repo_params.normalize_layout(None),
+            get_url_repo_params.LAYOUT_PER_FAMILY,
+        )
+        self.assertEqual(
+            get_url_repo_params.normalize_layout(""),
+            get_url_repo_params.LAYOUT_PER_FAMILY,
+        )
+
+    def test_aliases(self):
+        self.assertEqual(
+            get_url_repo_params.normalize_layout("legacy"),
+            get_url_repo_params.LAYOUT_PER_FAMILY,
+        )
+        self.assertEqual(
+            get_url_repo_params.normalize_layout("multiarch"),
+            get_url_repo_params.LAYOUT_MULTI_ARCH,
+        )
+
+    def test_unknown_raises(self):
+        with self.assertRaises(ValueError):
+            get_url_repo_params.normalize_layout("unknown")
+
 
 class GetNativePackageTypeFromOsProfileTest(unittest.TestCase):
     """Tests for get_native_package_type_from_os_profile()."""
@@ -267,7 +326,7 @@ class GetNativePackageTypeFromOsProfileTest(unittest.TestCase):
 
 
 class GetRepoUrlTest(unittest.TestCase):
-    """Tests for get_repo_url()."""
+    """Tests for get_repo_url() default (per_family) layout."""
 
     def test_prereleases_alias_matches_prerelease(self):
         self.assertEqual(
@@ -391,6 +450,87 @@ class GetRepoUrlTest(unittest.TestCase):
                 repo_sub_folder="",
             ),
             "https://x.com/packages/ubuntu2404",
+        )
+
+    def test_explicit_per_family_layout_matches_default(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="nightly",
+                native_package_type="deb",
+                repo_base_url="https://x.com",
+                os_profile="ubuntu2404",
+                repo_sub_folder="20260204-12345",
+                layout="per_family",
+            ),
+            get_url_repo_params.get_repo_url(
+                release_type="nightly",
+                native_package_type="deb",
+                repo_base_url="https://x.com",
+                os_profile="ubuntu2404",
+                repo_sub_folder="20260204-12345",
+            ),
+        )
+
+
+class GetRepoUrlMultiArchTest(unittest.TestCase):
+    """Tests for get_repo_url(..., layout=multi_arch)."""
+
+    def test_nightly_deb_matches_releases_doc(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="nightly",
+                native_package_type="deb",
+                repo_base_url="https://rocm.nightlies.amd.com",
+                os_profile="ubuntu2404",
+                repo_sub_folder="20260501-25200531110",
+                layout="multi_arch",
+            ),
+            "https://rocm.nightlies.amd.com/packages-multi-arch/deb/20260501-25200531110",
+        )
+
+    def test_nightly_rpm_matches_releases_doc(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="nightly",
+                native_package_type="rpm",
+                repo_base_url="https://rocm.nightlies.amd.com",
+                os_profile="rhel10",
+                repo_sub_folder="20260501-25200531110",
+                layout="multi_arch",
+            ),
+            "https://rocm.nightlies.amd.com/packages-multi-arch/rpm/20260501-25200531110/x86_64",
+        )
+
+    def test_os_profile_ignored_for_multi_arch(self):
+        deb_url = get_url_repo_params.get_repo_url_multi_arch(
+            repo_base_url="https://x.com",
+            native_package_type="deb",
+            repo_sub_folder="20260204-1",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="nightly",
+                native_package_type="deb",
+                repo_base_url="https://x.com",
+                os_profile="rhel10",
+                repo_sub_folder="20260204-1",
+                layout="multi_arch",
+            ),
+            deb_url,
+        )
+
+    def test_empty_release_id_index_urls(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url_multi_arch(
+                "https://x.com", "deb", ""
+            ),
+            "https://x.com/packages-multi-arch/deb",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_repo_url_multi_arch(
+                "https://x.com/", "rpm", ""
+            ),
+            "https://x.com/packages-multi-arch/rpm/x86_64",
         )
 
 
@@ -716,6 +856,52 @@ class MainSubcommandsTest(unittest.TestCase):
         self.assertIn("gpg_key_url=", output)
         self.assertNotIn("rocm.gpg", output)
 
+    def test_get_repo_url_multi_arch_layout_cli(self):
+        code, output = _run_main_with_output(
+            [
+                "get-repo-url",
+                "--layout",
+                "multi_arch",
+                "--release-type",
+                "nightly",
+                "--os-profile",
+                "ubuntu2404",
+                "--repo-sub-folder",
+                "20260501-25200531110",
+            ]
+        )
+        self.assertEqual(code, 0)
+        self.assertIn(
+            "repo_url=https://rocm.nightlies.amd.com/packages-multi-arch/deb/20260501-25200531110",
+            output,
+        )
+        self.assertIn("gpg_key_url=", output)
+        self.assertNotIn("rocm.gpg", output)
+
+    def test_get_repo_url_multi_arch_prerelease_signed_gpg(self):
+        code, output = _run_main_with_output(
+            [
+                "get-repo-url",
+                "--layout",
+                "multi_arch",
+                "--release-type",
+                "prerelease",
+                "--os-profile",
+                "ubuntu2404",
+                "--repo-sub-folder",
+                "20260204-12345",
+            ]
+        )
+        self.assertEqual(code, 0)
+        self.assertIn(
+            "repo_url=https://rocm.prereleases.amd.com/packages-multi-arch/deb/20260204-12345",
+            output,
+        )
+        self.assertIn(
+            "gpg_key_url=https://rocm.prereleases.amd.com/packages-multi-arch/gpg/rocm.gpg",
+            output,
+        )
+
 
 class ContractLegacyAndDerivedTest(unittest.TestCase):
     """Explicit-input ('legacy') paths vs derived defaults must agree where intended."""
@@ -745,7 +931,7 @@ class ContractLegacyAndDerivedTest(unittest.TestCase):
         )
 
     def test_get_repo_url_derived_components_equals_explicit_prerelease_ubuntu(self):
-        explicit = get_url_repo_params.get_repo_url(
+        explicit = get_url_repo_params.get_repo_url_per_family(
             release_type="prerelease",
             native_package_type="deb",
             repo_base_url="https://rocm.prereleases.amd.com",

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -521,15 +521,11 @@ class GetRepoUrlMultiArchTest(unittest.TestCase):
 
     def test_empty_release_id_index_urls(self):
         self.assertEqual(
-            get_url_repo_params.get_repo_url_multi_arch(
-                "https://x.com", "deb", ""
-            ),
+            get_url_repo_params.get_repo_url_multi_arch("https://x.com", "deb", ""),
             "https://x.com/packages-multi-arch/deb",
         )
         self.assertEqual(
-            get_url_repo_params.get_repo_url_multi_arch(
-                "https://x.com/", "rpm", ""
-            ),
+            get_url_repo_params.get_repo_url_multi_arch("https://x.com/", "rpm", ""),
             "https://x.com/packages-multi-arch/rpm/x86_64",
         )
 

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -71,30 +71,36 @@ class GetGpgKeyUrlTest(unittest.TestCase):
     """Tests for get_gpg_key_url()."""
 
     def test_extracts_base_and_adds_gpg_path(self):
-        # Test that get_gpg_key_url extracts base URL and appends /gpg/rocm.gpg.
+        # Test that get_gpg_key_url keeps the /packages prefix and appends gpg/rocm.gpg.
         self.assertEqual(
             get_url_repo_params.get_gpg_key_url(
                 "https://rocm.prereleases.amd.com/packages/ubuntu2404"
             ),
-            "https://rocm.prereleases.amd.com/gpg/rocm.gpg",
+            "https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg",
         )
 
     def test_strips_path_from_url(self):
-        # Test that get_gpg_key_url strips path and query from URL.
+        # Test that get_gpg_key_url keeps /rocm/packages and appends gpg/rocm.gpg.
         self.assertEqual(
             get_url_repo_params.get_gpg_key_url(
                 "https://repo.amd.com/rocm/packages/rhel10/x86_64/"
             ),
-            "https://repo.amd.com/gpg/rocm.gpg",
+            "https://repo.amd.com/rocm/packages/gpg/rocm.gpg",
         )
 
     def test_handles_nightly_url(self):
-        # Test that get_gpg_key_url works with nightly URLs.
+        # No /packages/ in path: fall back to .../packages/gpg/rocm.gpg on the host.
         self.assertEqual(
             get_url_repo_params.get_gpg_key_url(
                 "https://rocm.nightlies.amd.com/deb/20260204-12345/"
             ),
-            "https://rocm.nightlies.amd.com/gpg/rocm.gpg",
+            "https://rocm.nightlies.amd.com/packages/gpg/rocm.gpg",
+        )
+
+    def test_repo_amd_com_without_packages_segment(self):
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url("https://repo.amd.com/"),
+            "https://repo.amd.com/rocm/packages/gpg/rocm.gpg",
         )
 
 
@@ -419,7 +425,7 @@ class MainSubcommandsTest(unittest.TestCase):
         )
         self.assertEqual(code, 0)
         self.assertIn(
-            "gpg_key_url=https://rocm.prereleases.amd.com/gpg/rocm.gpg", output
+            "gpg_key_url=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg", output
         )
 
     def test_get_gpg_url_with_release_type_dev_emits_empty(self):
@@ -461,7 +467,7 @@ class MainSubcommandsTest(unittest.TestCase):
         )
         self.assertEqual(code, 0)
         self.assertIn(
-            "gpg_key_url=https://rocm.prereleases.amd.com/gpg/rocm.gpg", output
+            "gpg_key_url=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg", output
         )
 
     def test_get_gpg_url_with_release_type_release(self):
@@ -475,7 +481,9 @@ class MainSubcommandsTest(unittest.TestCase):
             ]
         )
         self.assertEqual(code, 0)
-        self.assertIn("gpg_key_url=https://repo.amd.com/gpg/rocm.gpg", output)
+        self.assertIn(
+            "gpg_key_url=https://repo.amd.com/rocm/packages/gpg/rocm.gpg", output
+        )
 
 
 class GetContainerImageTest(unittest.TestCase):

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -333,11 +333,11 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="prereleases",
                 native_package_type="deb",
-                repo_base_url="https://x.com",
+                repo_base_url="https://repo_url.com",
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
             ),
-            "https://x.com/packages/ubuntu2404",
+            "https://repo_url.com/packages/ubuntu2404",
         )
 
     def test_prerelease_deb(self):
@@ -346,11 +346,11 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="prerelease",
                 native_package_type="deb",
-                repo_base_url="https://x.com",
+                repo_base_url="https://repo_url.com",
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
             ),
-            "https://x.com/packages/ubuntu2404",
+            "https://repo_url.com/packages/ubuntu2404",
         )
 
     def test_prerelease_rpm(self):
@@ -358,11 +358,11 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="prerelease",
                 native_package_type="rpm",
-                repo_base_url="https://x.com",
+                repo_base_url="https://repo_url.com",
                 os_profile="rhel8",
                 repo_sub_folder="",
             ),
-            "https://x.com/packages/rhel8/x86_64/",
+            "https://repo_url.com/packages/rhel8/x86_64/",
         )
 
     def test_release_deb_matches_native_packaging_doc(self):
@@ -395,11 +395,11 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="nightly",
                 native_package_type="deb",
-                repo_base_url="https://x.com",
+                repo_base_url="https://repo_url.com",
                 os_profile="ubuntu2404",
                 repo_sub_folder="20260204-12345",
             ),
-            "https://x.com/deb/20260204-12345/",
+            "https://repo_url.com/deb/20260204-12345/",
         )
 
     def test_nightly_rpm(self):
@@ -408,11 +408,11 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="nightly",
                 native_package_type="rpm",
-                repo_base_url="https://x.com",
+                repo_base_url="https://repo_url.com",
                 os_profile="rhel8",
                 repo_sub_folder="20260204-12345",
             ),
-            "https://x.com/rpm/20260204-12345/x86_64/",
+            "https://repo_url.com/rpm/20260204-12345/x86_64/",
         )
 
     def test_non_prerelease_empty_repo_subfolder_no_double_slash_deb(self):
@@ -445,11 +445,11 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="prerelease",
                 native_package_type="deb",
-                repo_base_url="https://x.com/",
+                repo_base_url="https://repo_url.com/",
                 os_profile="ubuntu2404",
                 repo_sub_folder="",
             ),
-            "https://x.com/packages/ubuntu2404",
+            "https://repo_url.com/packages/ubuntu2404",
         )
 
     def test_explicit_per_family_layout_matches_default(self):
@@ -457,7 +457,7 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="nightly",
                 native_package_type="deb",
-                repo_base_url="https://x.com",
+                repo_base_url="https://repo_url.com",
                 os_profile="ubuntu2404",
                 repo_sub_folder="20260204-12345",
                 layout="per_family",
@@ -465,7 +465,7 @@ class GetRepoUrlTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="nightly",
                 native_package_type="deb",
-                repo_base_url="https://x.com",
+                repo_base_url="https://repo_url.com",
                 os_profile="ubuntu2404",
                 repo_sub_folder="20260204-12345",
             ),
@@ -503,7 +503,7 @@ class GetRepoUrlMultiArchTest(unittest.TestCase):
 
     def test_os_profile_ignored_for_multi_arch(self):
         deb_url = get_url_repo_params.get_repo_url_multi_arch(
-            repo_base_url="https://x.com",
+            repo_base_url="https://repo_url.com",
             native_package_type="deb",
             repo_sub_folder="20260204-1",
         )
@@ -511,7 +511,7 @@ class GetRepoUrlMultiArchTest(unittest.TestCase):
             get_url_repo_params.get_repo_url(
                 release_type="nightly",
                 native_package_type="deb",
-                repo_base_url="https://x.com",
+                repo_base_url="https://repo_url.com",
                 os_profile="rhel10",
                 repo_sub_folder="20260204-1",
                 layout="multi_arch",
@@ -521,12 +521,12 @@ class GetRepoUrlMultiArchTest(unittest.TestCase):
 
     def test_empty_release_id_index_urls(self):
         self.assertEqual(
-            get_url_repo_params.get_repo_url_multi_arch("https://x.com", "deb", ""),
-            "https://x.com/packages-multi-arch/deb",
+            get_url_repo_params.get_repo_url_multi_arch("https://repo_url.com", "deb", ""),
+            "https://repo_url.com/packages-multi-arch/deb",
         )
         self.assertEqual(
-            get_url_repo_params.get_repo_url_multi_arch("https://x.com/", "rpm", ""),
-            "https://x.com/packages-multi-arch/rpm/x86_64",
+            get_url_repo_params.get_repo_url_multi_arch("https://repo_url.com/", "rpm", ""),
+            "https://repo_url.com/packages-multi-arch/rpm/x86_64",
         )
 
 
@@ -652,7 +652,7 @@ class MainSubcommandsTest(unittest.TestCase):
                 "--native-package-type",
                 "deb",
                 "--repo-base-url",
-                "https://x.com",
+                "https://repo_url.com",
                 "--os-profile",
                 "ubuntu2404",
                 "--repo-sub-folder",
@@ -660,7 +660,7 @@ class MainSubcommandsTest(unittest.TestCase):
             ]
         )
         self.assertEqual(code, 0)
-        self.assertIn("repo_url=https://x.com/packages/ubuntu2404", output)
+        self.assertIn("repo_url=https://repo_url.com/packages/ubuntu2404", output)
         self.assertIn(
             "gpg_key_url=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg",
             output,
@@ -720,7 +720,7 @@ class MainSubcommandsTest(unittest.TestCase):
                         "--native-package-type",
                         "deb",
                         "--repo-base-url",
-                        "https://x.com",
+                        "https://repo_url.com",
                         "--os-profile",
                         "ubuntu2404",
                         "--repo-sub-folder",

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -332,6 +332,30 @@ class GetRepoUrlTest(unittest.TestCase):
             "https://x.com/rpm/20260204-12345/x86_64/",
         )
 
+    def test_non_prerelease_empty_repo_subfolder_no_double_slash_deb(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="release",
+                native_package_type="deb",
+                repo_base_url="https://repo.amd.com",
+                os_profile="ubuntu2404",
+                repo_sub_folder="",
+            ),
+            "https://repo.amd.com/deb/",
+        )
+
+    def test_non_prerelease_empty_repo_subfolder_no_double_slash_rpm(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="nightly",
+                native_package_type="rpm",
+                repo_base_url="https://repo.amd.com",
+                os_profile="rhel10",
+                repo_sub_folder="",
+            ),
+            "https://repo.amd.com/rpm/x86_64/",
+        )
+
     def test_strips_trailing_slash_from_base(self):
         # Test that repo_base_url trailing slash is stripped.
         self.assertEqual(

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -3,8 +3,12 @@
 # SPDX-License-Identifier: MIT
 
 # Unit test coverage for get_url_repo_params.py:
-#   get_base_url, get_gpg_key_url, gpg_key_url_needed_for_release_type, get_repo_sub_folder,
-#   get_repo_url, extract_gfx_arch, and main() subcommands.
+#   get_base_url, get_base_url_from_release_type, get_gpg_key_url,
+#   get_gpg_key_url_from_release_type, gpg_key_url_needed_for_release_type,
+#   get_repo_sub_folder,
+#   get_repo_url, get_native_package_type_from_os_profile, extract_gfx_arch,
+#   ContractLegacyAndDerivedTest (explicit vs derived/minimal parity),
+#   and main() subcommands.
 
 import os
 import sys
@@ -67,6 +71,51 @@ class GetBaseUrlTest(unittest.TestCase):
             get_url_repo_params.get_base_url("")
 
 
+class GetBaseUrlFromReleaseTypeTest(unittest.TestCase):
+    """Tests for get_base_url_from_release_type()."""
+
+    def test_known_release_lines(self):
+        self.assertEqual(
+            get_url_repo_params.get_base_url_from_release_type("prerelease"),
+            "https://rocm.prereleases.amd.com",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_base_url_from_release_type("Prereleases"),
+            "https://rocm.prereleases.amd.com",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_base_url_from_release_type("release"),
+            "https://repo.amd.com",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_base_url_from_release_type("stable"),
+            "https://repo.amd.com",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_base_url_from_release_type("nightly"),
+            "https://rocm.nightlies.amd.com",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_base_url_from_release_type("nightlies"),
+            "https://rocm.nightlies.amd.com",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_base_url_from_release_type("dev"),
+            "https://rocm.devreleases.amd.com",
+        )
+
+    def test_unknown_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            get_url_repo_params.get_base_url_from_release_type("ci")
+        self.assertIn("Unknown release_type", str(ctx.exception))
+
+    def test_empty_raises(self):
+        with self.assertRaises(ValueError):
+            get_url_repo_params.get_base_url_from_release_type("")
+        with self.assertRaises(ValueError):
+            get_url_repo_params.get_base_url_from_release_type("   ")
+
+
 class GetGpgKeyUrlTest(unittest.TestCase):
     """Tests for get_gpg_key_url()."""
 
@@ -115,7 +164,13 @@ class GpgKeyUrlNeededForReleaseTypeTest(unittest.TestCase):
             get_url_repo_params.gpg_key_url_needed_for_release_type("prerelease")
         )
         self.assertTrue(
+            get_url_repo_params.gpg_key_url_needed_for_release_type("prereleases")
+        )
+        self.assertTrue(
             get_url_repo_params.gpg_key_url_needed_for_release_type("release")
+        )
+        self.assertTrue(
+            get_url_repo_params.gpg_key_url_needed_for_release_type("stable")
         )
         self.assertTrue(
             get_url_repo_params.gpg_key_url_needed_for_release_type("  Prerelease  ")
@@ -128,6 +183,24 @@ class GpgKeyUrlNeededForReleaseTypeTest(unittest.TestCase):
         )
         self.assertFalse(get_url_repo_params.gpg_key_url_needed_for_release_type("ci"))
         self.assertFalse(get_url_repo_params.gpg_key_url_needed_for_release_type(""))
+
+
+class GetGpgKeyUrlFromReleaseTypeTest(unittest.TestCase):
+    """Tests for get_gpg_key_url_from_release_type()."""
+
+    def test_prerelease_and_release_hosts(self):
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url_from_release_type("prerelease"),
+            "https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url_from_release_type("stable"),
+            "https://repo.amd.com/rocm/packages/gpg/rocm.gpg",
+        )
+
+    def test_unknown_raises(self):
+        with self.assertRaises(ValueError):
+            get_url_repo_params.get_gpg_key_url_from_release_type("ci")
 
 
 class GetRepoSubFolderTest(unittest.TestCase):
@@ -164,8 +237,48 @@ class GetRepoSubFolderTest(unittest.TestCase):
         self.assertEqual(get_url_repo_params.get_repo_sub_folder("/"), "")
 
 
+class GetNativePackageTypeFromOsProfileTest(unittest.TestCase):
+    """Tests for get_native_package_type_from_os_profile()."""
+
+    def test_ubuntu_debian_deb(self):
+        self.assertEqual(
+            get_url_repo_params.get_native_package_type_from_os_profile("ubuntu2404"),
+            "deb",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_native_package_type_from_os_profile("debian12"),
+            "deb",
+        )
+
+    def test_rhel_sles_rpm(self):
+        self.assertEqual(
+            get_url_repo_params.get_native_package_type_from_os_profile("rhel10"),
+            "rpm",
+        )
+        self.assertEqual(
+            get_url_repo_params.get_native_package_type_from_os_profile("sles16"),
+            "rpm",
+        )
+
+    def test_empty_raises(self):
+        with self.assertRaises(ValueError):
+            get_url_repo_params.get_native_package_type_from_os_profile("")
+
+
 class GetRepoUrlTest(unittest.TestCase):
     """Tests for get_repo_url()."""
+
+    def test_prereleases_alias_matches_prerelease(self):
+        self.assertEqual(
+            get_url_repo_params.get_repo_url(
+                release_type="prereleases",
+                native_package_type="deb",
+                repo_base_url="https://x.com",
+                os_profile="ubuntu2404",
+                repo_sub_folder="",
+            ),
+            "https://x.com/ubuntu2404",
+        )
 
     def test_prerelease_deb(self):
         # Test that prerelease + deb yields base/os_profile.
@@ -317,10 +430,24 @@ class MainSubcommandsTest(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn("repo_base_url=https://example.com", output)
 
+    def test_get_base_url_from_release_type_success(self):
+        code, output = _run_main_with_output(
+            ["get-base-url", "--release-type", "nightly"]
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("repo_base_url=https://rocm.nightlies.amd.com", output)
+
     def test_get_base_url_invalid_returns_one(self):
         # Test that get-base-url with invalid URL returns 1 and prints error.
         with patch("sys.stderr"):
             code = get_url_repo_params.main(["get-base-url", "--from-url", "not-a-url"])
+        self.assertEqual(code, 1)
+
+    def test_get_base_url_unknown_release_type_returns_one(self):
+        with patch("sys.stderr"):
+            code = get_url_repo_params.main(
+                ["get-base-url", "--release-type", "unknown-channel"]
+            )
         self.assertEqual(code, 1)
 
     def test_get_repo_sub_folder_success(self):
@@ -350,6 +477,40 @@ class MainSubcommandsTest(unittest.TestCase):
         )
         self.assertEqual(code, 0)
         self.assertIn("repo_url=https://x.com/ubuntu2404", output)
+
+    def test_get_repo_url_minimal_prerelease_ubuntu(self):
+        code, output = _run_main_with_output(
+            [
+                "get-repo-url",
+                "--release-type",
+                "prerelease",
+                "--os-profile",
+                "ubuntu2404",
+            ]
+        )
+        self.assertEqual(code, 0)
+        self.assertIn(
+            "repo_url=https://rocm.prereleases.amd.com/ubuntu2404",
+            output,
+        )
+
+    def test_get_repo_url_minimal_nightly_with_subfolder(self):
+        code, output = _run_main_with_output(
+            [
+                "get-repo-url",
+                "--release-type",
+                "nightly",
+                "--os-profile",
+                "ubuntu2404",
+                "--repo-sub-folder",
+                "20260204-12345",
+            ]
+        )
+        self.assertEqual(code, 0)
+        self.assertIn(
+            "repo_url=https://rocm.nightlies.amd.com/deb/20260204-12345/",
+            output,
+        )
 
     def test_get_repo_url_error_returns_one(self):
         # Test that get-repo-url returns 1 and prints error when get_repo_url raises.
@@ -428,6 +589,36 @@ class MainSubcommandsTest(unittest.TestCase):
             "gpg_key_url=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg", output
         )
 
+    def test_get_gpg_url_release_type_only_prerelease(self):
+        code, output = _run_main_with_output(
+            ["get-gpg-url", "--release-type", "prerelease"]
+        )
+        self.assertEqual(code, 0)
+        self.assertIn(
+            "gpg_key_url=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg", output
+        )
+
+    def test_get_gpg_url_release_type_only_release(self):
+        code, output = _run_main_with_output(
+            ["get-gpg-url", "--release-type", "release"]
+        )
+        self.assertEqual(code, 0)
+        self.assertIn(
+            "gpg_key_url=https://repo.amd.com/rocm/packages/gpg/rocm.gpg", output
+        )
+
+    def test_get_gpg_url_release_type_only_nightly_emits_empty(self):
+        code, output = _run_main_with_output(
+            ["get-gpg-url", "--release-type", "nightly"]
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(output.strip(), "gpg_key_url=")
+
+    def test_get_gpg_url_no_inputs_returns_one(self):
+        with patch("sys.stderr"):
+            code = get_url_repo_params.main(["get-gpg-url"])
+        self.assertEqual(code, 1)
+
     def test_get_gpg_url_with_release_type_dev_emits_empty(self):
         code, output = _run_main_with_output(
             [
@@ -484,6 +675,142 @@ class MainSubcommandsTest(unittest.TestCase):
         self.assertIn(
             "gpg_key_url=https://repo.amd.com/rocm/packages/gpg/rocm.gpg", output
         )
+
+
+class ContractLegacyAndDerivedTest(unittest.TestCase):
+    """Explicit-input ('legacy') paths vs derived defaults must agree where intended."""
+
+    def test_get_base_url_from_url_same_host_as_release_type_prerelease(self):
+        self.assertEqual(
+            get_url_repo_params.get_base_url(
+                "https://rocm.prereleases.amd.com/packages/ubuntu2404"
+            ),
+            get_url_repo_params.get_base_url_from_release_type("prerelease"),
+        )
+
+    def test_get_gpg_key_url_from_sample_url_matches_release_type_only_prerelease(self):
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url(
+                "https://rocm.prereleases.amd.com/packages/ubuntu2404"
+            ),
+            get_url_repo_params.get_gpg_key_url_from_release_type("prerelease"),
+        )
+
+    def test_get_gpg_key_url_sample_url_matches_release_type_release(self):
+        self.assertEqual(
+            get_url_repo_params.get_gpg_key_url(
+                "https://repo.amd.com/rocm/packages/rhel10/x86_64/"
+            ),
+            get_url_repo_params.get_gpg_key_url_from_release_type("release"),
+        )
+
+    def test_get_repo_url_derived_components_equals_explicit_prerelease_ubuntu(self):
+        explicit = get_url_repo_params.get_repo_url(
+            release_type="prerelease",
+            native_package_type="deb",
+            repo_base_url="https://rocm.prereleases.amd.com",
+            os_profile="ubuntu2404",
+            repo_sub_folder="",
+        )
+        derived = get_url_repo_params.get_repo_url(
+            release_type="prerelease",
+            native_package_type=get_url_repo_params.get_native_package_type_from_os_profile(
+                "ubuntu2404"
+            ),
+            repo_base_url=get_url_repo_params.get_base_url_from_release_type(
+                "prerelease"
+            ),
+            os_profile="ubuntu2404",
+            repo_sub_folder="",
+        )
+        self.assertEqual(explicit, derived)
+
+    def test_cli_get_repo_url_minimal_matches_explicit_canonical_host(self):
+        code_m, out_m = _run_main_with_output(
+            [
+                "get-repo-url",
+                "--release-type",
+                "prerelease",
+                "--os-profile",
+                "ubuntu2404",
+            ]
+        )
+        code_x, out_x = _run_main_with_output(
+            [
+                "get-repo-url",
+                "--release-type",
+                "prerelease",
+                "--native-package-type",
+                "deb",
+                "--repo-base-url",
+                "https://rocm.prereleases.amd.com",
+                "--os-profile",
+                "ubuntu2404",
+                "--repo-sub-folder",
+                "",
+            ]
+        )
+        self.assertEqual(code_m, 0)
+        self.assertEqual(code_x, 0)
+        self.assertEqual(out_m, out_x)
+
+    def test_cli_get_repo_url_minimal_nightly_matches_explicit_same_parts(self):
+        code_m, out_m = _run_main_with_output(
+            [
+                "get-repo-url",
+                "--release-type",
+                "nightly",
+                "--os-profile",
+                "rhel10",
+                "--repo-sub-folder",
+                "20260204-9",
+            ]
+        )
+        code_x, out_x = _run_main_with_output(
+            [
+                "get-repo-url",
+                "--release-type",
+                "nightly",
+                "--native-package-type",
+                "rpm",
+                "--repo-base-url",
+                "https://rocm.nightlies.amd.com",
+                "--os-profile",
+                "rhel10",
+                "--repo-sub-folder",
+                "20260204-9",
+            ]
+        )
+        self.assertEqual(out_m, out_x)
+
+    def test_cli_get_repo_url_explicit_custom_base_differs_from_derived_minimal(self):
+        _, out_derived = _run_main_with_output(
+            [
+                "get-repo-url",
+                "--release-type",
+                "prerelease",
+                "--os-profile",
+                "ubuntu2404",
+            ]
+        )
+        _, out_custom = _run_main_with_output(
+            [
+                "get-repo-url",
+                "--release-type",
+                "prerelease",
+                "--native-package-type",
+                "deb",
+                "--repo-base-url",
+                "https://internal.example.com",
+                "--os-profile",
+                "ubuntu2404",
+                "--repo-sub-folder",
+                "",
+            ]
+        )
+        self.assertIn("rocm.prereleases.amd.com", out_derived)
+        self.assertIn("internal.example.com", out_custom)
+        self.assertNotEqual(out_derived, out_custom)
 
 
 class GetContainerImageTest(unittest.TestCase):


### PR DESCRIPTION
## Motivation

This pull request significantly enhances the flexibility and clarity of the `get_url_repo_params.py` tool for Linux packaging, especially around how repository URLs and GPG key URLs are derived and output. The changes introduce support for multiple repository layouts, improve argument handling, and make the code more robust and user-friendly for automation scenarios.

These changes make the tool more powerful, easier to use in CI/CD workflows, and better aligned with the evolving ROCm packaging infrastructure.

## Technical Details

Key improvements and new features include:

**Repository URL and Layout Handling:**
- Added support for both "per_family" and "multi_arch" repository layouts, with normalization logic and new helper functions to generate URLs according to the selected layout. This enables the tool to generate URLs compatible with both legacy and new multi-architecture packaging schemes. [[1]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0R46-R96) [[2]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0L139-R384)
- Improved logic for inferring the native package type (`deb` or `rpm`) from the OS profile if not explicitly provided, reducing manual input requirements.

**GPG Key URL Derivation:**
- Enhanced GPG key URL derivation to support both per-family and multi-arch layouts, with new mapping tables and logic to generate correct URLs based on release type and layout.
- Refined which release types require signed GPG key URLs, now including "stable" and "prereleases" in addition to "prerelease" and "release".

**Command-line Interface and Usability:**
- Updated CLI usage and help text to reflect new argument options, including mutually exclusive arguments for `get-base-url`, and new options for `get-repo-url` such as `--layout`, `--from-url`, and optional `--native-package-type`. [[1]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0L12-R30) [[2]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0L268-R494) [[3]](diffhunk://#diff-103884a38a5e372dab0d2471e73262aad4da14d0fd85ff8541f93067fbe281a0L316-R544)
- The `get-repo-url` command now outputs both `repo_url` and `gpg_key_url` in a single call, streamlining automation and reducing the number of required invocations.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

https://github.com/arvindcheru/TheRock/actions/runs/25092190403


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
