### PR TITLE
Enable rccl and rccl-tests for more amdgpu targets

### DIFF
--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -190,6 +190,8 @@ therock_add_amdgpu_target(gfx1102 "AMD RX 7700S/Framework Laptop 16" FAMILY dgpu
 therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all gfx110X-all gfx110X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
+    rccl # https://github.com/ROCm/TheRock/issues/150
+    rccl-tests
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 
@@ -197,6 +199,8 @@ therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all 
 therock_add_amdgpu_target(gfx1150 "AMD Strix Point iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
+    rccl # https://github.com/ROCm/TheRock/issues/150
+    rccl-tests
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 therock_add_amdgpu_target(gfx1151 "AMD Strix Halo iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
@@ -207,11 +211,15 @@ therock_add_amdgpu_target(gfx1151 "AMD Strix Halo iGPU" FAMILY igpu-all gfx115X-
 therock_add_amdgpu_target(gfx1152 "AMD Krackan 1 iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
+    rccl # https://github.com/ROCm/TheRock/issues/150
+    rccl-tests
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 therock_add_amdgpu_target(gfx1153 "AMD Radeon 820M iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
+    rccl # https://github.com/ROCm/TheRock/issues/150
+    rccl-tests
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -52,8 +52,6 @@ therock_add_amdgpu_target(gfx900 "Vega 10 / MI25" FAMILY dgpu-all gfx900-dgpu
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 
 # gfx90c
@@ -64,8 +62,6 @@ therock_add_amdgpu_target(gfx90c "AMD Renoir/Lucienne/Cezanne iGPU" FAMILY igpu-
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 
 # gfx906 (separate family - different instruction support from gfx908/gfx90a)
@@ -104,8 +100,6 @@ therock_add_amdgpu_target(gfx1010 "AMD RX 5700" FAMILY dgpu-all gfx101X-all gfx1
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 therock_add_amdgpu_target(gfx1011 "AMD Radeon Pro V520" FAMILY dgpu-all gfx101X-all gfx101X-dgpu
   EXCLUDE_TARGET_PROJECTS
@@ -114,8 +108,6 @@ therock_add_amdgpu_target(gfx1011 "AMD Radeon Pro V520" FAMILY dgpu-all gfx101X-
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 
 therock_add_amdgpu_target(gfx1012 "AMD RX 5500" FAMILY dgpu-all gfx101X-all gfx101X-dgpu
@@ -125,8 +117,6 @@ therock_add_amdgpu_target(gfx1012 "AMD RX 5500" FAMILY dgpu-all gfx101X-all gfx1
     composable_kernel # https://github.com/ROCm/TheRock/issues/1245
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 
 # gfx103X family
@@ -136,8 +126,6 @@ therock_add_amdgpu_target(gfx1030 "AMD RX 6800 / XT" FAMILY dgpu-all gfx103X-all
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 therock_add_amdgpu_target(gfx1031 "AMD RX 6700 / XT" FAMILY dgpu-all gfx103X-all gfx103X-dgpu
   EXCLUDE_TARGET_PROJECTS
@@ -145,8 +133,6 @@ therock_add_amdgpu_target(gfx1031 "AMD RX 6700 / XT" FAMILY dgpu-all gfx103X-all
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 therock_add_amdgpu_target(gfx1032 "AMD RX 6600" FAMILY dgpu-all gfx103X-all gfx103X-dgpu
   EXCLUDE_TARGET_PROJECTS
@@ -154,8 +140,6 @@ therock_add_amdgpu_target(gfx1032 "AMD RX 6600" FAMILY dgpu-all gfx103X-all gfx1
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 therock_add_amdgpu_target(gfx1033 "AMD Van Gogh iGPU" FAMILY igpu-all gfx103X-all gfx103X-igpu
   EXCLUDE_TARGET_PROJECTS
@@ -164,8 +148,6 @@ therock_add_amdgpu_target(gfx1033 "AMD Van Gogh iGPU" FAMILY igpu-all gfx103X-al
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
     composable_kernel
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 therock_add_amdgpu_target(gfx1034 "AMD RX 6500 XT" FAMILY dgpu-all gfx103X-all gfx103X-dgpu
   EXCLUDE_TARGET_PROJECTS
@@ -173,8 +155,6 @@ therock_add_amdgpu_target(gfx1034 "AMD RX 6500 XT" FAMILY dgpu-all gfx103X-all g
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 therock_add_amdgpu_target(gfx1035 "AMD Radeon 680M Laptop iGPU" FAMILY igpu-all gfx103X-all gfx103X-igpu
   EXCLUDE_TARGET_PROJECTS
@@ -182,8 +162,6 @@ therock_add_amdgpu_target(gfx1035 "AMD Radeon 680M Laptop iGPU" FAMILY igpu-all 
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 therock_add_amdgpu_target(gfx1036 "AMD Raphael iGPU" FAMILY igpu-all gfx103X-all gfx103X-igpu
   EXCLUDE_TARGET_PROJECTS
@@ -191,8 +169,6 @@ therock_add_amdgpu_target(gfx1036 "AMD Raphael iGPU" FAMILY igpu-all gfx103X-all
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocWMMA # https://github.com/ROCm/TheRock/issues/1944
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 
 # gfx110X family
@@ -200,28 +176,20 @@ therock_add_amdgpu_target(gfx1100 "AMD RX 7900 XTX" FAMILY dgpu-all gfx110X-all 
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 therock_add_amdgpu_target(gfx1101 "AMD RX 7800 XT" FAMILY dgpu-all gfx110X-all gfx110X-dgpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 therock_add_amdgpu_target(gfx1102 "AMD RX 7700S/Framework Laptop 16" FAMILY dgpu-all gfx110X-all gfx110X-dgpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all gfx110X-all gfx110X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
-    rccl # https://github.com/ROCm/TheRock/issues/150
-    rccl-tests
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 
@@ -229,29 +197,21 @@ therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all 
 therock_add_amdgpu_target(gfx1150 "AMD Strix Point iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
-    rccl # https://github.com/ROCm/TheRock/issues/150
-    rccl-tests
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 therock_add_amdgpu_target(gfx1151 "AMD Strix Halo iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
-    rccl # https://github.com/ROCm/TheRock/issues/150
-    rccl-tests
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 therock_add_amdgpu_target(gfx1152 "AMD Krackan 1 iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
-    rccl # https://github.com/ROCm/TheRock/issues/150
-    rccl-tests
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 therock_add_amdgpu_target(gfx1153 "AMD Radeon 820M iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
-    rccl # https://github.com/ROCm/TheRock/issues/150
-    rccl-tests
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 
@@ -260,15 +220,11 @@ therock_add_amdgpu_target(gfx1200 "AMD RX 9060 / XT" FAMILY dgpu-all gfx120X-all
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 therock_add_amdgpu_target(gfx1201 "AMD RX 9070 / XT" FAMILY dgpu-all gfx120X-all
   EXCLUDE_TARGET_PROJECTS
     hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
-    rccl # Disable on all but CDNA, see https://github.com/ROCm/TheRock/issues/2130
-    rccl-tests
 )
 
 # Optional extension targets (used for out of tree target development).


### PR DESCRIPTION
## Motivation

RCCL builds have historically been too slow to support for all targets, see
* https://github.com/ROCm/TheRock/issues/2130
* https://github.com/ROCm/rocm-systems/pull/4795
* https://github.com/ROCm/TheRock/pull/4661

Build time has improved recently. Let's see if it's improved enough to re-enable these targets.

## Test Plan

Multi-arch CI on this PR, watch comm-libs stage
* Build should succeed
* Build time should be reasonable (not a bottleneck compared to other stages)
* Tests should run (and probably pass?)
* Inspect the configure/build logs and uploaded artifacts (look for what was actually enabled, what kpack files are included, etc.)

## Test Result

* comm-libs build stage succeeded ([logs here](https://github.com/ROCm/TheRock/actions/runs/25134138451/job/73674820623?pr=4935))
* comm-libs build time: 1h43m, math-libs gfx94X build time: 1h41m
* RCCL tests passed on Linux gfx942 ([logs here](https://github.com/ROCm/TheRock/actions/runs/25134138451/job/73686990909?pr=4935))
* RCCL tests passed on Linux gfx950 ([logs here](https://github.com/ROCm/TheRock/actions/runs/25134138451/job/73686961882?pr=4935))
* RCCL artifacts were split for each architecture, e.g. `rccl_lib_gfx1151.tar.zst` which includes `.kpack/rccl_lib_gfx1151.kpack`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
