### PR TITLE
Install rocm[devel] pkg during pytorch tests

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -144,6 +144,11 @@ jobs:
           python -m pip install -r external-builds/pytorch/requirements-test.txt
           pip freeze
 
+      - name: Install ROCm devel packages
+        run: |
+          pip install "rocm[devel]" \
+            --index-url=${{ inputs.package_index_url }}/${{ inputs.amdgpu_family }}
+
       - name: Run rocm-sdk sanity tests
         run: |
           rocm-sdk test


### PR DESCRIPTION
## Motivation

This is required  for some pytorch UTs to pass. 
```
external-builds/pytorch/pytorch/test/test_cuda.py::TestMemPool::test_mempool_expandable [1/2] c++ ...
FAILED: [code=1] main_hip.o
In file included from /github/home/.cache/torch_extensions/py314_cpu/dummy_allocator/main_hip.cpp:5:
/__w/TheRock/TheRock/.venv/lib/python3.14/site-packages/torch/include/ATen/hip/Exceptions.h:5:10: fatal error: 'hipblas/hipblas.h' file not found
    5 | #include <hipblas/hipblas.h>
      |          ^~~~~~~~~~~~~~~~~~~
1 error generated.
ninja: build stopped: subcommand failed.
...
subprocess.CalledProcessError: Command '['ninja', '-v']' returned non-zero exit status 1.
RuntimeError: Error building extension 'dummy_allocator'
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
