### PR TITLE
Remove client-side tarball index generation from release workflows

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -306,10 +306,6 @@ jobs:
         run: |
           pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py  ${{ env.CUSTOM_PREFIX }}
-          python ./build_tools/index_generation_s3_tar.py \
-            --bucket ${{ env.S3_BUCKET_TAR }} \
-            --directory ${{ env.S3_SUBDIR_TAR }} \
-            --upload
 
       - name: Trigger building PyTorch wheels
         if: ${{ github.repository_owner == 'ROCm' && matrix.target_bundle.expect_pytorch_failure == false }}

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -321,8 +321,6 @@ jobs:
           --include "*.whl" \
           --include "*.tar.gz"
 
-      # TODO(marbre): guard against race conditions where multiple workflows update the index at the same time?
-      #    Moving the index computation server-side could help
       - name: (Re-)Generate release index pages
         if: ${{ github.repository_owner == 'ROCm' }}
         env:
@@ -331,10 +329,6 @@ jobs:
         run: |
           pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py  ${{ env.CUSTOM_PREFIX }}
-          python ./build_tools/index_generation_s3_tar.py \
-            --bucket ${{ env.S3_BUCKET_TAR }} \
-            --directory ${{ env.S3_SUBDIR_TAR }} \
-            --upload
 
       - name: Trigger building PyTorch wheels
         if: ${{ github.repository_owner == 'ROCm' && matrix.target_bundle.expect_pytorch_failure == false }}


### PR DESCRIPTION
The index.html for the `therock-{nightly,dev,prerelease}-tarball` buckets is now regenerated server-side by a tarball-index AWS Lambda, triggered by S3 PutObject events with a `.tar.gz` suffix filter. Drop the `index_generation_s3_tar.py --upload` invocation from both the Linux and Windows release workflows.

Fixes #3326