### PR TITLE
Fix the PyTorch workflow dispatch

### DIFF
--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -187,7 +187,6 @@ jobs:
               "rocm_version": "${{ inputs.rocm_package_version }}",
               "rocm_package_find_links_url": "${{ needs.build_python_packages.outputs.package_find_links_url }}",
               "release_type": "${{ inputs.release_type }}",
-              "repository": "${{ inputs.repository || github.repository }}",
               "ref": "${{ inputs.ref || '' }}"
             }
 

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -149,6 +149,5 @@ jobs:
               "rocm_version": "${{ inputs.rocm_package_version }}",
               "rocm_package_find_links_url": "${{ needs.build_python_packages.outputs.package_find_links_url }}",
               "release_type": "${{ inputs.release_type }}",
-              "repository": "${{ inputs.repository || github.repository }}",
               "ref": "${{ inputs.ref || '' }}"
             }


### PR DESCRIPTION
`repository` is an unknown argument. The workflow will always dispatched in the repo where the triggering workflow runs.