### PR TITLE
[debug-tools] Install rocgdb CI test script from component source

### DIFF
--- a/debug-tools/rocgdb/CMakeLists.txt
+++ b/debug-tools/rocgdb/CMakeLists.txt
@@ -705,6 +705,14 @@ if(BUILD_TESTING)
       COMPONENT tests
       USE_SOURCE_PERMISSIONS)
   endforeach()
+
+  # Also install the CI wrapper script to invoke rocgdb tests.
+  # This is used in the context of TheRock CI.
+  install(
+    PROGRAMS ${ROCGDB_SOURCE_DIR}/.github/scripts/test_rocgdb.py
+    DESTINATION tests/rocgdb
+    COMPONENT tests
+  )
 else()
   message(STATUS "rocgdb tests: BUILD_TESTING not set. Skipping installation integrity tests.")
 endif()


### PR DESCRIPTION
Installs test_rocgdb.py from the rocgdb component's .github/scripts/
directory into tests/rocgdb so it can be invoked by TheRock CI. This
aligns test script management with component ownership.

We don't need extra changes for rocr-debug-agent because its build system was already modified in https://github.com/ROCm/rocm-systems/pull/5651, such that test_rocr-debug-agent.py is sourced from rocm-systems/projects/rocr-debug-agent/.github/scripts and installed into tests/rocm-debug-agent.