### PR TITLE
[PyTorch] move UTs requiring hipblas headers to generic.py

### DIFF
--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -48,6 +48,13 @@ skip_tests = {
             # NEW ERROR
             # RuntimeError: Error building extension 'dummy_allocator'
             "test_mempool_with_allocator",
+            # RuntimeError: Error building extension 'dummy_allocator_v3'
+            "test_tensor_delete_after_allocator_delete",
+            # RuntimeError: Error building extension 'dummy_allocator'
+            "test_deleted_mempool_not_used_on_oom",
+            # Same hipblas.h compilation error as test_mempool_with_allocator.
+            # See https://github.com/pytorch/pytorch/pull/173330
+            "test_mempool_expandable",
             # Change detector test (Cublaslt vs Cublas depending on gcn_arch and torch version)
             # Always skip as this test is very basic and needs manual intervention for new architectures
             # See

--- a/external-builds/pytorch/skip_tests/pytorch_2.11.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.11.py
@@ -49,14 +49,6 @@ skip_tests = {
             "test_mempool_empty_cache_inactive",
             # RuntimeError: Error building extension 'dummy_allocator_v1'
             "test_mempool_limited_memory_with_allocator",
-            # new for pytorch 2.11
-            # RuntimeError: Error building extension 'dummy_allocator_v3'
-            "test_tensor_delete_after_allocator_delete",
-            # RuntimeError: Error building extension 'dummy_allocator'
-            "test_deleted_mempool_not_used_on_oom",
-            # Same hipblas.h compilation error as test_mempool_with_allocator.
-            # See https://github.com/pytorch/pytorch/pull/173330
-            "test_mempool_expandable",
             # ModuleNotFoundError: No module named 'torchvision'
             "test_resnet",
             # RuntimeError: miopenStatusUnknownError

--- a/external-builds/pytorch/skip_tests/pytorch_2.12.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.12.py
@@ -6,15 +6,8 @@ skip_tests = {
         "cuda": [
             # RuntimeError: Error building extension 'dummy_allocator_v1'
             "test_mempool_limited_memory_with_allocator",
-            # RuntimeError: Error building extension 'dummy_allocator_v3'
-            "test_tensor_delete_after_allocator_delete",
-            # RuntimeError: Error building extension 'dummy_allocator'
-            "test_deleted_mempool_not_used_on_oom",
             # AssertionError: Scalars are not equal!
             "test_mempool_ctx_multithread",
-            # Same hipblas.h compilation error as test_mempool_with_allocator.
-            # See https://github.com/pytorch/pytorch/pull/173330
-            "test_mempool_expandable",
             # torch.AcceleratorError: HIP error: operation not permitted when
             # stream is capturing
             "test_cuda_graph_tensor_item_not_allowed",


### PR DESCRIPTION
## Motivation
Expandable Segments feature got backported to 2.9 and 2.10 release branches as well due to a customer ask. Therefore, moving the associated UTs to generic.py to get skipped across all release branches. These UTs require devel package to be installed at runtime. We will do a thorough analysis and try to run UTs that require devel package in "core" UTs as a separate step/job in our nightly builds

UTs impacted:
            "test_tensor_delete_after_allocator_delete",
            "test_deleted_mempool_not_used_on_oom",
            "test_mempool_expandable",
            
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
