### PR TITLE
[ml-libs] Remove all-or-nothing CK disable logic; let MIOpen self-filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,10 +269,6 @@ include("${CMAKE_CURRENT_BINARY_DIR}/cmake/therock_topology.cmake")
 # which filters out CORE_RUNTIME dependency for HIP_RUNTIME on Windows.
 
 # Optional sub-features that control behavior within artifacts
-cmake_dependent_option(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL
-  "Enables composable kernel in MIOpen" ON
-  "THEROCK_ENABLE_COMPOSABLE_KERNEL" OFF)
-
 cmake_dependent_option(THEROCK_ROCWMMA_ENABLE_BENCHMARKS
   "Enables building rocWMMA benchmarks" OFF
   "THEROCK_ENABLE_ROCWMMA;THEROCK_BUILD_TESTING" OFF)

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -8,20 +8,6 @@ if(THEROCK_FLAG_INCLUDE_PROFILER)
   list(APPEND optional_profiler_deps roctracer rocprofiler-sdk)
 endif()
 
-# limit use of composable kernel to the GPU families it is valid for
-if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
-  set(_ck_supported_gfx_targets gfx908 gfx90a gfx942 gfx950 gfx1150 gfx1151 gfx1152 gfx1153 gfx1200 gfx1201)
-  foreach(_gfx_target ${THEROCK_AMDGPU_TARGETS})
-    if(NOT ${_gfx_target} IN_LIST _ck_supported_gfx_targets)
-      message(WARNING
-        "${_gfx_target} (included in THEROCK_AMDGPU_TARGETS) is not supported by composable kernel. "
-        "Disabling composable kernel and it's use in MIOpen.")
-      set(THEROCK_ENABLE_COMPOSABLE_KERNEL OFF)
-      set(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL OFF)
-    endif()
-  endforeach()
-endif()
-
 if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
   ##############################################################################
   # Composable_kernel
@@ -69,9 +55,11 @@ if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
 endif()
 
 if(THEROCK_ENABLE_MIOPEN)
-  # If composable kernel is enabled, add it as an MIOpen dep.
+  # If composable kernel is enabled, add it as an MIOpen build dep.
+  # MIOpen's ck_impl self-filters GPU_TARGETS against arches it has CK grouped
+  # conv kernels for, so no need to gate on specific arch families here.
   set(optional_miopen_build_deps)
-  if(THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL)
+  if(THEROCK_ENABLE_COMPOSABLE_KERNEL)
     list(APPEND optional_miopen_build_deps composable_kernel)
   endif()
 
@@ -90,7 +78,7 @@ if(THEROCK_ENABLE_MIOPEN)
       -DROCM_PATH=
       -DROCM_DIR=
       "-DBUILD_TESTING=${_THEROCK_MIOPEN_ENABLE_TESTING}"
-      "-DMIOPEN_USE_COMPOSABLEKERNEL=${THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL}"
+      "-DMIOPEN_USE_COMPOSABLEKERNEL=${THEROCK_ENABLE_COMPOSABLE_KERNEL}"
       -DMIOPEN_USE_MLIR=OFF # TODO: enable
       -DMIOPEN_TEST_DISCRETE=OFF
       "-DMIOPEN_INSTALL_GPU_DATABASES=\"${THEROCK_AMDGPU_TARGETS}\""


### PR DESCRIPTION
## Summary
- Reapplies #4838 which was reverted in #4923 due to CK failing when `GPU_TARGETS` was empty
- The root cause is now fixed in rocm-libraries: CK's CMakeLists.txt gracefully skips its build when `GPU_TARGETS` is explicitly empty (ROCm/rocm-libraries#6960)
- Removes the all-or-nothing `_ck_supported_gfx_targets` gate that disabled CK entirely when any unsupported arch was in the target list
- Removes `THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL` option — `THEROCK_ENABLE_COMPOSABLE_KERNEL` is sufficient since MIOpen's ck_impl self-filters GPU_TARGETS
- Updates rocm-libraries submodule to include the CK empty GPU_TARGETS fix

## Test plan
- [ ] Build with `THEROCK_AMDGPU_FAMILIES=gfx1100` — CK should configure with empty targets and skip gracefully, MIOpen should build with `MIOPEN_USE_COMPOSABLEKERNEL=ON` and its ck_impl should handle the unsupported arch
- [ ] Build with `THEROCK_AMDGPU_FAMILIES=gfx942` — CK and MIOpen should build normally with full CK support
- [ ] Build with mixed targets (e.g., `gfx942;gfx1100`) — CK should build for gfx942 only, MIOpen ck_impl should produce real library for gfx942 and skip gfx1100

🤖 Generated with [Claude Code](https://claude.com/claude-code)