### PR TITLE
[CI] Skip new failures on gfx94X with PyTorch release/2.11 

### DIFF
--- a/external-builds/pytorch/skip_tests/pytorch_2.11.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.11.py
@@ -60,15 +60,19 @@ skip_tests = {
             # new in 2.11
             # AssertionError: Scalars are not close!
             "test_CTCLoss_cudnn_cuda",
+            # AssertionError: Tensor-likes are not close! - https://github.com/ROCm/TheRock/issues/4744
+            # Failed on gfx1151 and gfx942 (only with python 3.13)
+            "test_Embedding_discontiguous_cuda",
         ],
         "torch": [
             "test_cpp_warnings_have_python_context_cuda",
         ],
     },
-    "gfx1151": {
-        "nn": [
-            # AssertionError: Tensor-likes are not close! - https://github.com/ROCm/TheRock/issues/4744
-            "test_Embedding_discontiguous_cuda",
+    "gfx942": {
+        "cuda": [
+            # new test
+            # AssertionError: Scalars are not equal!
+            "test_graph_capture_reclaim_shared_pool",
         ],
     },
     # "gfx120": {


### PR DESCRIPTION
Skip the below two UTs that are failing with PyTorch release/2.11 on gfx94X

```
#Failed with python 3.10, 3.11, 3.12  and 3.14 versions
builds/pytorch/pytorch/test/test_cuda.py::TestMemPool::test_graph_capture_reclaim_shared_pool - AssertionError: Scalars are not equal!

#Failed with python 3.13
external-builds/pytorch/pytorch/test/test_nn.py::TestNN::test_Embedding_discontiguous_cuda - AssertionError: Tensor-likes are not close!
```


Skips are base on the below runs:
- [Release | gfx94X-dcgpu | py 3.10 | torch release/2.11 / Test | gfx94X-dcgpu | linux-gfx942-1gpu-ossci-rocm / Test PyTorch |](https://github.com/ROCm/TheRock/actions/runs/25094124269/job/73531853673#logs)
`FAILED [0.0017s] external-builds/pytorch/pytorch/test/test_cuda.py::TestMemPool::test_graph_capture_reclaim_shared_pool - AssertionError: Scalars are not equal!`

- [Release | gfx94X-dcgpu | py 3.11 | torch release/2.11 / Test | gfx94X-dcgpu | linux-gfx942-1gpu-ossci-rocm / Test PyTorch | gfx94X-](https://github.com/ROCm/TheRock/actions/runs/25094124269/job/73530873341#logs)
`FAILED [0.0019s] external-builds/pytorch/pytorch/test/test_cuda.py::TestMemPool::test_graph_capture_reclaim_shared_pool - AssertionError: Scalars are not equal! `

- [Release | gfx94X-dcgpu | py 3.12 | torch release/2.11 / Test | gfx94X-dcgpu | linux-gfx942-1gpu-ossci-rocm / Test PyTorch |](https://github.com/ROCm/TheRock/actions/runs/25094124269/job/73531938890#logs)
```
FAILED [0.0021s] external-
builds/pytorch/pytorch/test/test_cuda.py::TestMemPool::test_graph_capture_reclaim_shared_pool - AssertionError: Scalars are not equal!
```

- [Release | gfx94X-dcgpu | py 3.13 | torch release/2.11 / Test | gfx94X-dcgpu | linux-gfx942-1gpu-ossci-rocm / Test PyTorch |](https://github.com/ROCm/TheRock/actions/runs/25094124269/job/73531804165#logs)
```
FAILED [0.0067s] external-builds/pytorch/pytorch/test/test_nn.py::TestNN::test_Embedding_discontiguous_cuda - AssertionError: 
Tensor-likes are not close! 
This test is passing in the other python versions
```

- [Release | gfx94X-dcgpu | py 3.14 | torch release/2.11 / Test | gfx94X-dcgpu | linux-gfx942-1gpu-ossci-rocm / Test PyTorch |](https://github.com/ROCm/TheRock/actions/runs/25094124269/job/73532062947#logs)
`FAILED [0.0025s] external-builds/pytorch/pytorch/test/test_cuda.py::TestMemPool::test_graph_capture_reclaim_shared_pool - AssertionError: Scalars are not equal!`