### PR TITLE
  Fix kpack dependency check to verify manifest contents

### DIFF
--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -846,14 +846,33 @@ def has_artifact_for_arch(pkg_name, artifacts_dir, gfx_arch):
             continue
 
         for subdir in artifact["Artifact_Subdir"]:
+            artifact_subdir = subdir["Name"]
             component_list = subdir["Components"]
             for component in component_list:
                 source_dir = (
                     Path(artifacts_dir)
                     / f"{artifact_prefix}_{component}_{artifact_suffix}"
                 )
-                if source_dir.exists():
-                    return True
+                if not source_dir.exists():
+                    continue
+
+                # Check if the required subdirectory exists in the manifest
+                manifest_file = source_dir / "artifact_manifest.txt"
+                if not manifest_file.exists():
+                    continue
+
+                try:
+                    with manifest_file.open("r", encoding="utf-8") as file:
+                        for line in file:
+                            match_found = (
+                                isinstance(artifact_subdir, str)
+                                and (artifact_subdir.lower() + "/") in line.lower()
+                            )
+                            if match_found and line.strip():
+                                # Found at least one required subdirectory in the manifest
+                                return True
+                except OSError:
+                    continue
 
     return False
 


### PR DESCRIPTION
  When --enable-kpack is enabled, has_artifact_for_arch() was only checking
  if artifact directories existed, not whether they contained the required
  subdirectories listed in artifact_manifest.txt.

  This caused meta packages like amdrocm-core7.13-gfx906 to add dependencies
  (e.g., amdrocm-solver7.13-gfx906) even when the required subdirectories
  (rocSOLVER, hipSOLVER) were missing from the artifact, resulting in unmet
  dependency errors for empty or non-existent packages.

  Fix: Modified has_artifact_for_arch() to read artifact_manifest.txt and
  verify that at least one required subdirectory exists in the manifest
  before declaring the artifact as available for that architecture.

  This prevents empty packages from being added as dependencies in kpack mode.