### PR TITLE
Document rocm-profiler package and integration with rocm meta package

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -249,6 +249,37 @@ We provide several Python packages which together form the complete ROCm SDK.
 | `rocm-sdk-devel`     | OS-specific development tools                                      |
 | `rocm-sdk-libraries` | OS-specific libraries                                              |
 
+### Optional Profiler Package
+
+A new optional package `rocm-profiler` is available, providing ROCm profiling tools:
+
+- `rocprof-compute`
+- `rocprof-sys-*` (run, attach, avail, causal, instrument, sample, python)
+
+#### Installation
+
+Install profiling tools via the meta package:
+
+```bash
+pip install "rocm[profiler]"
+```
+
+This will install:
+- `rocm-sdk-core` (required runtime + SDK)
+- `rocm-profiler` (profiling tools)
+
+> Note: Installation requires compatible ROCm SDK packages for the target platform.
+
+#### Notes
+
+- `rocm-profiler` does **not** declare `install_requires`
+- Dependencies are managed via the `rocm` meta package
+- Runtime dependencies are resolved via RPATH
+- Direct installation (`pip install rocm-profiler`) is not recommended for typical use
+- The `rocm` meta package requires device-family-specific components
+  (e.g. `gfx94X-dcgpu`). If these are not available in the selected
+  package index, installation may be incomplete.
+
 ##### rocm for gfx94X-dcgpu
 
 Supported devices in this family:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -265,6 +265,7 @@ pip install "rocm[profiler]"
 ```
 
 This will install:
+
 - `rocm-sdk-core` (required runtime + SDK)
 - `rocm-profiler` (profiling tools)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -253,8 +253,8 @@ We provide several Python packages which together form the complete ROCm SDK.
 
 A new optional package `rocm-profiler` is available, providing ROCm profiling tools:
 
-- `rocprof-compute`
-- `rocprof-sys-*` (see rocprofiler-systems documentation for full command list)
+- ROCm Systems Profiler (rocprofiler-systems)
+- ROCm Compute Profiler (rocprofiler-compute)
 
 ###### Installing the profiler package
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -249,14 +249,14 @@ We provide several Python packages which together form the complete ROCm SDK.
 | `rocm-sdk-devel`     | OS-specific development tools                                      |
 | `rocm-sdk-libraries` | OS-specific libraries                                              |
 
-### Optional Profiler Package
+##### Optional profiler package
 
 A new optional package `rocm-profiler` is available, providing ROCm profiling tools:
 
 - `rocprof-compute`
 - `rocprof-sys-*` (run, attach, avail, causal, instrument, sample, python)
 
-#### Installation
+###### Installing the profiler package
 
 Install profiling tools via the meta package:
 
@@ -268,18 +268,6 @@ This will install:
 
 - `rocm-sdk-core` (required runtime + SDK)
 - `rocm-profiler` (profiling tools)
-
-> Note: Installation requires compatible ROCm SDK packages for the target platform.
-
-#### Notes
-
-- `rocm-profiler` does **not** declare `install_requires`
-- Dependencies are managed via the `rocm` meta package
-- Runtime dependencies are resolved via RPATH
-- Direct installation (`pip install rocm-profiler`) is not recommended for typical use
-- The `rocm` meta package requires device-family-specific components
-  (e.g. `gfx94X-dcgpu`). If these are not available in the selected
-  package index, installation may be incomplete.
 
 ##### rocm for gfx94X-dcgpu
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -254,7 +254,7 @@ We provide several Python packages which together form the complete ROCm SDK.
 A new optional package `rocm-profiler` is available, providing ROCm profiling tools:
 
 - `rocprof-compute`
-- `rocprof-sys-*` (run, attach, avail, causal, instrument, sample, python)
+- `rocprof-sys-*` (see rocprofiler-systems documentation for full command list)
 
 ###### Installing the profiler package
 

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -218,7 +218,8 @@ The recommended way to install profiling tools is via the meta package:
 pip install "rocm[profiler]"
 ```
 
-This installs:
+This will install:
+
 - `rocm-sdk-core` (required runtime + SDK)
 - `rocm-profiler` (profiling tools)
 
@@ -229,11 +230,13 @@ This installs:
 ROCm Python packaging separates profiling functionality as follows:
 
 - `rocm-sdk-core`:
+
   - `rocprofiler-sdk` libraries
   - `rocprofv3`, `rocprof-attach`
   - `roctx` API (user-facing annotation library)
 
 - `rocm-profiler`:
+
   - `rocprof-compute`
   - `rocprof-sys-*`
   - profiler runtime libraries (from `rocprofiler-systems` and `rocprofiler-compute`)
@@ -245,6 +248,7 @@ This separation allows users to install profiling tools only when needed.
 The `rocm-profiler` package intentionally does **not** declare `install_requires`.
 
 Instead:
+
 - Dependencies are managed by the `rocm` meta package
 - Packages are co-installed into the same `site-packages`
 - Runtime dependencies are resolved using RPATH

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -206,7 +206,7 @@ The `rocm-profiler` package provides ROCm profiling tools and runtime components
 ### Contents
 
 - `rocprof-compute`
-- `rocprof-sys-*` (run, attach, avail, causal, instrument, sample, python)
+- `rocprof-sys-*` (see rocprofiler-systems documentation for full command list)
 - `rocprofiler-systems` runtime libraries
 - `rocprofiler-compute` runtime components
 

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -221,10 +221,6 @@ This will install:
 - `rocm-sdk-core` (required runtime + SDK)
 - `rocm-profiler` (profiling tools)
 
-> [!NOTE]
-> Installation requires compatible ROCm SDK packages for the target platform.
-> See the [ROCm Compatibility Matrix](https://rocm.docs.amd.com/en/latest/compatibility/compatibility-matrix.html).
-
 #### Direct installation
 
 Direct installation is not recommended for typical use:

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -223,7 +223,8 @@ This will install:
 - `rocm-sdk-core` (required runtime + SDK)
 - `rocm-profiler` (profiling tools)
 
-> Note: Installation requires compatible ROCm SDK packages for the target platform.
+> [!NOTE]
+> Installation requires compatible ROCm SDK packages for the target platform.
 
 ### Package Layout
 
@@ -253,7 +254,7 @@ Instead:
 - Packages are co-installed into the same `site-packages`
 - Runtime dependencies are resolved using RPATH
 
-> Note:
+> [!NOTE]
 > The `rocm` meta package requires device-family-specific components
 > (e.g. `gfx94X-dcgpu`). If these are not available in the selected
 > package index, installation may be incomplete.

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -207,6 +207,7 @@ The `rocm-profiler` package provides ROCm profiling tools and runtime components
 - ROCm Compute Profiler (rocprofiler-compute)
 
 ### Installation
+
 #### Using meta package
 
 The recommended way to install profiling tools is via the meta package:
@@ -272,7 +273,6 @@ Instead:
 > The `rocm` meta package requires device-family-specific components
 > (e.g. `gfx94X-dcgpu`). If these are not available in the selected
 > package index, installation may be incomplete.
-
 
 ## Using Packages from Frameworks
 

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -201,14 +201,13 @@ pip install rocm[libraries,devel] --pre \
 
 ## rocm-profiler
 
-The `rocm-profiler` package provides ROCm profiling tools and runtime components.
-
-### Contents
+The `rocm-profiler` package provides ROCm profiling tools and runtime components. It contains:
 
 - ROCm Systems Profiler (rocprofiler-systems)
 - ROCm Compute Profiler (rocprofiler-compute)
 
 ### Installation
+#### Using meta package
 
 The recommended way to install profiling tools is via the meta package:
 
@@ -223,6 +222,23 @@ This will install:
 
 > [!NOTE]
 > Installation requires compatible ROCm SDK packages for the target platform.
+> See the [ROCm Compatibility Matrix](https://rocm.docs.amd.com/en/latest/compatibility/compatibility-matrix.html).
+
+#### Direct installation
+
+Direct installation is not recommended for typical use:
+
+```bash
+pip install rocm-profiler
+```
+
+This may result in missing dependencies unless `rocm-sdk-core` is also installed.
+
+Always prefer:
+
+```bash
+pip install "rocm[profiler]"
+```
 
 ### Package Layout
 
@@ -257,21 +273,6 @@ Instead:
 > (e.g. `gfx94X-dcgpu`). If these are not available in the selected
 > package index, installation may be incomplete.
 
-### Direct Installation
-
-Direct installation is not recommended for typical use:
-
-```bash
-pip install rocm-profiler
-```
-
-This may result in missing dependencies unless `rocm-sdk-core` is also installed.
-
-Always prefer:
-
-```bash
-pip install "rocm[profiler]"
-```
 
 ## Using Packages from Frameworks
 

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -240,7 +240,7 @@ ROCm Python packaging separates profiling functionality as follows:
   - `rocprof-sys-*`
   - profiler runtime libraries (from `rocprofiler-systems` and `rocprofiler-compute`)
 
-This separation allows users to install profiling tools only when needed.
+This separation allows you to install profiling tools only when needed.
 
 ### Dependency Model
 
@@ -248,9 +248,9 @@ The `rocm-profiler` package intentionally does **not** declare `install_requires
 
 Instead:
 
-- Dependencies are managed by the `rocm` meta package
-- Packages are co-installed into the same `site-packages`
-- Runtime dependencies are resolved using RPATH
+- Dependencies are managed by the `rocm` meta package.
+- Packages are co-installed into the same `site-packages`.
+- Runtime dependencies are resolved using RPATH.
 
 > [!NOTE]
 > The `rocm` meta package requires device-family-specific components

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -199,6 +199,77 @@ pip install rocm[libraries,devel] --pre \
 > the index and organizes files into the `{run_id}-{platform}/python/{artifact_group}/`
 > structure used by CI uploads.
 
+## rocm-profiler
+
+The `rocm-profiler` package provides ROCm profiling tools and runtime components.
+
+### Contents
+
+- `rocprof-compute`
+- `rocprof-sys-*` (run, attach, avail, causal, instrument, sample, python)
+- `rocprofiler-systems` runtime libraries
+- `rocprofiler-compute` runtime components
+
+### Installation
+
+The recommended way to install profiling tools is via the meta package:
+
+```bash
+pip install "rocm[profiler]"
+```
+
+This installs:
+- `rocm-sdk-core` (required runtime + SDK)
+- `rocm-profiler` (profiling tools)
+
+> Note: Installation requires compatible ROCm SDK packages for the target platform.
+
+### Package Layout
+
+ROCm Python packaging separates profiling functionality as follows:
+
+- `rocm-sdk-core`:
+  - `rocprofiler-sdk` libraries
+  - `rocprofv3`, `rocprof-attach`
+  - `roctx` API (user-facing annotation library)
+
+- `rocm-profiler`:
+  - `rocprof-compute`
+  - `rocprof-sys-*`
+  - profiler runtime libraries (from `rocprofiler-systems` and `rocprofiler-compute`)
+
+This separation allows users to install profiling tools only when needed.
+
+### Dependency Model
+
+The `rocm-profiler` package intentionally does **not** declare `install_requires`.
+
+Instead:
+- Dependencies are managed by the `rocm` meta package
+- Packages are co-installed into the same `site-packages`
+- Runtime dependencies are resolved using RPATH
+
+> Note:
+> The `rocm` meta package requires device-family-specific components
+> (e.g. `gfx94X-dcgpu`). If these are not available in the selected
+> package index, installation may be incomplete.
+
+### Direct Installation
+
+Direct installation is not recommended for typical use:
+
+```bash
+pip install rocm-profiler
+```
+
+This may result in missing dependencies unless `rocm-sdk-core` is also installed.
+
+Always prefer:
+
+```bash
+pip install "rocm[profiler]"
+```
+
 ## Using Packages from Frameworks
 
 ### Building Python Based Projects

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -205,10 +205,8 @@ The `rocm-profiler` package provides ROCm profiling tools and runtime components
 
 ### Contents
 
-- `rocprof-compute`
-- `rocprof-sys-*` (see rocprofiler-systems documentation for full command list)
-- `rocprofiler-systems` runtime libraries
-- `rocprofiler-compute` runtime components
+- ROCm Systems Profiler (rocprofiler-systems)
+- ROCm Compute Profiler (rocprofiler-compute)
 
 ### Installation
 


### PR DESCRIPTION
## Motivation

This change introduces documentation for the new optional rocm-profiler Python package and its integration with the rocm meta package.

## Technical Details

ROCm Python packaging now includes a separate rocm-profiler package providing profiling tools such as:

rocprof-compute
rocprof-sys-* utilities
associated profiling runtime components

Users need clear guidance on:

How to install profiling tools how rocm-profiler relates to rocm-sdk-core why installation is recommended via the rocm meta package

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
