### PR TITLE
Add new TheRock flag HIP_TESTS_MONITOR_OPS_ARE_ATOMIC

### DIFF
--- a/FLAGS.cmake
+++ b/FLAGS.cmake
@@ -32,11 +32,11 @@ therock_declare_flag(
 )
 
 therock_declare_flag(
-  NAME HIP_TESTS_MONITOR_LOAD_AS_AN_ATOMIC_OPERATION
+  NAME HIP_TESTS_MONITOR_OPS_ARE_ATOMIC
   DEFAULT_VALUE OFF
-  DESCRIPTION "Monitor loads are implemented as an atomic operation"
+  DESCRIPTION "Monitor builtins are implemented as an atomic operation"
   CMAKE_VARS
-    HIP_TESTS_MONITOR_LOAD_AS_AN_ATOMIC_OPERATION=ON
+    HIP_TESTS_MONITOR_OPS_ARE_ATOMIC=ON
   SUB_PROJECTS
     hip-tests
 )

--- a/FLAGS.cmake
+++ b/FLAGS.cmake
@@ -31,6 +31,16 @@ therock_declare_flag(
     hipkernelprovider
 )
 
+therock_declare_flag(
+  NAME HIP_TESTS_MONITOR_LOAD_AS_AN_ATOMIC_OPERATION
+  DEFAULT_VALUE OFF
+  DESCRIPTION "Monitor loads are implemented as an atomic operation"
+  CMAKE_VARS
+    HIP_TESTS_MONITOR_LOAD_AS_AN_ATOMIC_OPERATION=ON
+  SUB_PROJECTS
+    hip-tests
+)
+
 ###############################################################################
 # Branch-specific flag overrides.
 # BRANCH_FLAGS.cmake is .gitignored on main but can be committed on


### PR DESCRIPTION
  - If ON, then monitor builtins are implemented as atomic operations
  - If OFF, then monitor builtins are not an atomic operations
  - Defaults to OFF
  - Flag is used in hip-tests