### PR TITLE
Patch amdgpu.ids with missing device IDs in libdrm sysdep

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
   rev: v1.5.5
   hooks:
   - id: forbid-tabs
-    exclude: ".gitmodules|patches/.*|docs/development/git_chores.md|build_tools/packaging/linux/template/debian_rules.j2"
+    exclude: ".gitmodules|patches/.*|docs/development/git_chores.md|build_tools/packaging/linux/template/debian_rules.j2|third-party/sysdeps/linux/libdrm/patch_source.sh"
 
 - repo: https://github.com/rhysd/actionlint
   rev: v1.7.10

--- a/third-party/sysdeps/linux/libdrm/patch_source.sh
+++ b/third-party/sysdeps/linux/libdrm/patch_source.sh
@@ -21,3 +21,14 @@ sed -i -E "/libdrm_amdgpu[[:space:]]*=[[:space:]]*library\(/,/\)/ s/^([[:space:]
 sed -i "/pkg\.generate\s*(/,/)/ s/\blibdrm_amdgpu,\s*//" "$AMDGPU_MESON_BUILD"
 # Add libraries tag to pkg.generate block
 sed -i "/pkg\.generate\s*(/a\  libraries : ['-L\${libdir}', '-ldrm_amdgpu']," $AMDGPU_MESON_BUILD
+
+# Append missing device IDs to amdgpu.ids
+AMDGPU_IDS="$SOURCE_DIR/data/amdgpu.ids"
+cat >> "$AMDGPU_IDS" << 'EOF'
+7590,	C0,	AMD Radeon RX 9060 XT
+744B,	00,	AMD Radeon PRO W7900D
+75A0,	00,	AMD Instinct MI350X
+75A3,	00,	AMD Instinct MI355X
+75B0,	00,	AMD Instinct MI350X VF
+75B3,	00,	AMD Instinct MI355X VF
+EOF


### PR DESCRIPTION
Add missing device IDs to amdgpu.ids via patch_source.sh:
- AMD Radeon RX 9060 XT (7590, C0)
- AMD Radeon PRO W7900D (744B, 00)
- AMD Instinct MI350X (75A0, 00)
- AMD Instinct MI355X (75A3, 00)
- AMD Instinct MI350X VF (75B0, 00)
- AMD Instinct MI355X VF (75B3, 00)

Also exclude patch_source.sh from the forbid-tabs pre-commit hook since amdgpu.ids uses tabs as field separators (IFS=$',\t').

## Motivation

Marketing Names are getting wrong in amd-smi and rocmnfo output. 
Refer internal ticket for more details: Ticket: [[ROCM-21360] Linux- ASIC marketing name is missing and appears generic in rocminfo on Linux - Jira](https://amd-hub.atlassian.net/browse/ROCM-21360)

[ROCM-21360]: https://amd-hub.atlassian.net/browse/ROCM-21360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ