### PR TITLE
[ci] Removing memory monitor script

### DIFF
--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -126,8 +126,7 @@ jobs:
 
       - name: Build therock-archives and therock-dist
         run: |
-          python build_tools/memory_monitor.py --phase Build -- \
-            cmake --build build --target therock-archives therock-dist -- -k 0
+          cmake --build build --target therock-archives therock-dist -- -k 0
 
       - name: Test Packaging
         if: ${{ github.event.repository.name == 'TheRock' }}

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -140,8 +140,7 @@ jobs:
 
       - name: Build therock-archives and therock-dist
         run: |
-          python build_tools/memory_monitor.py --phase Build -- \
-            cmake --build "${{ env.BUILD_DIR }}" --target therock-archives therock-dist -- -k 0
+          cmake --build "${{ env.BUILD_DIR }}" --target therock-archives therock-dist -- -k 0
 
       - name: Report
         if: ${{ !cancelled() }}

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -152,8 +152,7 @@ jobs:
 
       - name: Build stage
         run: |
-          python build_tools/memory_monitor.py --phase Build -- \
-            cmake --build "${BUILD_DIR}" --target stage-${STAGE_NAME} therock-artifacts -- -k 0
+          cmake --build "${BUILD_DIR}" --target stage-${STAGE_NAME} therock-artifacts -- -k 0
 
       - name: Report
         if: ${{ !cancelled() }}

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -169,8 +169,7 @@ jobs:
 
       - name: Build stage
         run: |
-          python build_tools/memory_monitor.py --phase Build -- \
-            cmake --build "${BUILD_DIR}" --target stage-${STAGE_NAME} therock-artifacts -- -k 0
+          cmake --build "${BUILD_DIR}" --target stage-${STAGE_NAME} therock-artifacts -- -k 0
 
       - name: Report
         if: ${{ !cancelled() }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -183,8 +183,7 @@ jobs:
             (${{ inputs.amdgpu_families }})
             ${{ fromJSON(inputs.component).expect_failure == true && '(xfail)' || '' }}
         run: |
-          python ./build_tools/memory_monitor.py --phase "Test ${{ fromJSON(inputs.component).job_name }}" -- \
-            bash -c '${{ fromJSON(inputs.component).test_script }}'
+          ${{ fromJSON(inputs.component).test_script }}
 
       - name: Print test reproduction command
         if: ${{ failure() && steps.test.outcome == 'failure' }}


### PR DESCRIPTION
As the ASAN resource was resolved and with `actions-prolense` scaling onto GPU machines, we are removing the use of memory monitor script across the build step and test step to lessen logging bloat