### PR TITLE
[torch] Invert aotriton filtering to enable flash attention in multi-arch releases

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -952,13 +952,13 @@ def do_build_pytorch(
     AOTRITON_SUPPORTED_ARCH_PREFIXES = ("gfx90a", "gfx942", "gfx950", "gfx11", "gfx12")
     # gfx1152/53: supported in aotriton 0.11.2b+ (https://github.com/ROCm/aotriton/pull/142),
     #   which is pinned by pytorch >= 2.11. Older versions don't include it.
-    aotriton_unsupported_for_version = []
+    aotriton_unsupported_archs_for_version = []
     if not is_pytorch_2_11_or_later:
-        aotriton_unsupported_for_version = ["gfx1152", "gfx1153"]
+        aotriton_unsupported_archs_for_version = ["gfx1152", "gfx1153"]
     rocm_arch_list = env.get("PYTORCH_ROCM_ARCH", "").split(";")
     has_aotriton_supported_arch = any(
         arch.startswith(AOTRITON_SUPPORTED_ARCH_PREFIXES)
-        and arch not in aotriton_unsupported_for_version
+        and arch not in aotriton_unsupported_archs_for_version
         for arch in rocm_arch_list
     )
 

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -938,6 +938,23 @@ def do_build_pytorch(
 
     is_pytorch_2_9 = pytorch_build_version_parsed.release[:2] == (2, 9)
 
+    # aotriton supports a subset of GPU architectures. When at least one
+    # target arch is supported, we enable flash attention and let aotriton's
+    # build system (gpu_targets.py) filter to just the supported ones. The
+    # runtime (check_gpu in sdp_utils.cpp) gracefully falls back to math/CK
+    # backends on unsupported GPUs. We only disable flash attention when
+    # *no* target arch is supported — otherwise aotriton's configure step
+    # fails on the empty target list (see https://github.com/ROCm/aotriton/issues/XXX).
+    #
+    # These prefixes match what aotriton's gpu_targets.py recognizes.
+    # See also the image list in pytorch/cmake/External/aotriton.cmake.
+    AOTRITON_SUPPORTED_ARCH_PREFIXES = ["gfx90a", "gfx942", "gfx950", "gfx11", "gfx12"]
+    rocm_arch_list = env.get("PYTORCH_ROCM_ARCH", "").split(";")
+    has_aotriton_supported_arch = any(
+        arch.startswith(tuple(AOTRITON_SUPPORTED_ARCH_PREFIXES))
+        for arch in rocm_arch_list
+    )
+
     ## Enable FBGEMM_GENAI on Linux for PyTorch, as it is available only for 2.9 on rocm/pytorch
     ## and causes build failures for other PyTorch versions
     ## Warn user when enabling it manually.
@@ -972,14 +989,15 @@ def do_build_pytorch(
         print(f"FBGEMM_GENAI enabled: {env['USE_FBGEMM_GENAI'] == 'ON'}")
 
         if args.enable_pytorch_flash_attention_linux is None:
-            # Default behavior — determined by if triton is built.
-            # Arch filtering is intentionally NOT done here: aotriton's
-            # build system only downloads kernel images for supported
-            # architectures, and the runtime (check_gpu) gracefully falls
-            # back to math/CK backends on unsupported GPUs.
-            use_flash_attention = "ON" if triton_requirement else "OFF"
+            # Default: enable when triton is available AND at least one
+            # target arch is supported by aotriton. When all targets are
+            # unsupported, aotriton can't produce a valid library.
+            use_flash_attention = (
+                "ON" if triton_requirement and has_aotriton_supported_arch else "OFF"
+            )
             print(
-                f"Flash Attention default behavior (based on triton): {use_flash_attention}"
+                f"Flash Attention default behavior (triton={bool(triton_requirement)},"
+                f" aotriton_arch={has_aotriton_supported_arch}): {use_flash_attention}"
             )
         else:
             # Explicit override: user has set the flag to true/false
@@ -1028,12 +1046,11 @@ def do_build_pytorch(
     if is_windows:
         copy_msvc_libomp_to_torch_lib(pytorch_dir)
 
-        # Arch filtering is intentionally NOT done here: aotriton's
-        # build system filters unsupported architectures itself (via
-        # gpu_targets.py), and the runtime (check_gpu) gracefully falls
-        # back to math/CK backends on unsupported GPUs.
         use_flash_attention = (
-            "1" if args.enable_pytorch_flash_attention_windows else "0"
+            "1"
+            if args.enable_pytorch_flash_attention_windows
+            and has_aotriton_supported_arch
+            else "0"
         )
 
         env.update(

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -937,15 +937,6 @@ def do_build_pytorch(
     print(f"  Using PYTORCH_BUILD_VERSION: {pytorch_build_version}")
 
     is_pytorch_2_9 = pytorch_build_version_parsed.release[:2] == (2, 9)
-    is_pytorch_2_11_or_later = pytorch_build_version_parsed.release[:2] >= (2, 11)
-
-    # aotriton is not supported on certain architectures yet.
-    # gfx900/gfx906/gfx908/gfx101X/gfx103X: https://github.com/ROCm/TheRock/issues/1925
-    AOTRITON_UNSUPPORTED_ARCHS = ["gfx900", "gfx906", "gfx908", "gfx101", "gfx103"]
-    # gfx1152/53: supported in aotriton 0.11.2b+ (https://github.com/ROCm/aotriton/pull/142),
-    #   which is pinned by pytorch >= 2.11. Older versions don't include it.
-    if not is_pytorch_2_11_or_later:
-        AOTRITON_UNSUPPORTED_ARCHS += ["gfx1152", "gfx1153"]
 
     ## Enable FBGEMM_GENAI on Linux for PyTorch, as it is available only for 2.9 on rocm/pytorch
     ## and causes build failures for other PyTorch versions
@@ -981,15 +972,14 @@ def do_build_pytorch(
         print(f"FBGEMM_GENAI enabled: {env['USE_FBGEMM_GENAI'] == 'ON'}")
 
         if args.enable_pytorch_flash_attention_linux is None:
-            # Default behavior — determined by if triton is build
+            # Default behavior — determined by if triton is built.
+            # Arch filtering is intentionally NOT done here: aotriton's
+            # build system only downloads kernel images for supported
+            # architectures, and the runtime (check_gpu) gracefully falls
+            # back to math/CK backends on unsupported GPUs.
             use_flash_attention = "ON" if triton_requirement else "OFF"
-
-            if any(
-                arch in env["PYTORCH_ROCM_ARCH"] for arch in AOTRITON_UNSUPPORTED_ARCHS
-            ):
-                use_flash_attention = "OFF"
             print(
-                f"Flash Attention default behavior (based on triton and gpu): {use_flash_attention}"
+                f"Flash Attention default behavior (based on triton): {use_flash_attention}"
             )
         else:
             # Explicit override: user has set the flag to true/false
@@ -1038,12 +1028,13 @@ def do_build_pytorch(
     if is_windows:
         copy_msvc_libomp_to_torch_lib(pytorch_dir)
 
-        use_flash_attention = "0"
-
-        if args.enable_pytorch_flash_attention_windows and not any(
-            arch in env["PYTORCH_ROCM_ARCH"] for arch in AOTRITON_UNSUPPORTED_ARCHS
-        ):
-            use_flash_attention = "1"
+        # Arch filtering is intentionally NOT done here: aotriton's
+        # build system filters unsupported architectures itself (via
+        # gpu_targets.py), and the runtime (check_gpu) gracefully falls
+        # back to math/CK backends on unsupported GPUs.
+        use_flash_attention = (
+            "1" if args.enable_pytorch_flash_attention_windows else "0"
+        )
 
         env.update(
             {
@@ -1060,9 +1051,7 @@ def do_build_pytorch(
                 "BUILD_TEST": "0",
             }
         )
-        print(
-            f"  Flash attention enabled: {args.enable_pytorch_flash_attention_windows or not is_windows}"
-        )
+        print(f"  Flash attention enabled: {use_flash_attention == '1'}")
 
     if not is_windows:
         # Prepend the ROCm sysdeps dir so that we use bundled libraries.

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -945,7 +945,7 @@ def do_build_pytorch(
     # runtime (check_gpu in sdp_utils.cpp) gracefully falls back to math/CK
     # backends on unsupported GPUs. We only disable flash attention when
     # *no* target arch is supported — otherwise aotriton's configure step
-    # fails on the empty target list.
+    # fails on the empty target list (https://github.com/ROCm/aotriton/issues/169).
     #
     # These prefixes match what aotriton's gpu_targets.py recognizes.
     # See also the image list in pytorch/cmake/External/aotriton.cmake.

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -937,6 +937,7 @@ def do_build_pytorch(
     print(f"  Using PYTORCH_BUILD_VERSION: {pytorch_build_version}")
 
     is_pytorch_2_9 = pytorch_build_version_parsed.release[:2] == (2, 9)
+    is_pytorch_2_11_or_later = pytorch_build_version_parsed.release[:2] >= (2, 11)
 
     # aotriton supports a subset of GPU architectures. When at least one
     # target arch is supported, we enable flash attention and let aotriton's
@@ -944,14 +945,20 @@ def do_build_pytorch(
     # runtime (check_gpu in sdp_utils.cpp) gracefully falls back to math/CK
     # backends on unsupported GPUs. We only disable flash attention when
     # *no* target arch is supported — otherwise aotriton's configure step
-    # fails on the empty target list (see https://github.com/ROCm/aotriton/issues/XXX).
+    # fails on the empty target list.
     #
     # These prefixes match what aotriton's gpu_targets.py recognizes.
     # See also the image list in pytorch/cmake/External/aotriton.cmake.
-    AOTRITON_SUPPORTED_ARCH_PREFIXES = ["gfx90a", "gfx942", "gfx950", "gfx11", "gfx12"]
+    AOTRITON_SUPPORTED_ARCH_PREFIXES = ("gfx90a", "gfx942", "gfx950", "gfx11", "gfx12")
+    # gfx1152/53: supported in aotriton 0.11.2b+ (https://github.com/ROCm/aotriton/pull/142),
+    #   which is pinned by pytorch >= 2.11. Older versions don't include it.
+    aotriton_unsupported_for_version = []
+    if not is_pytorch_2_11_or_later:
+        aotriton_unsupported_for_version = ["gfx1152", "gfx1153"]
     rocm_arch_list = env.get("PYTORCH_ROCM_ARCH", "").split(";")
     has_aotriton_supported_arch = any(
-        arch.startswith(tuple(AOTRITON_SUPPORTED_ARCH_PREFIXES))
+        arch.startswith(AOTRITON_SUPPORTED_ARCH_PREFIXES)
+        and arch not in aotriton_unsupported_for_version
         for arch in rocm_arch_list
     )
 


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/4969 to enable flash attention and aotriton in multi-arch torch builds where we set e.g. `PYTORCH_ROCM_ARCH=gfx1100;gfx1101;gfx1102;gfx1103;gfx1151;gfx1200;gfx1201;gfx900;gfx906;gfx908;gfx90a;gfx1010;gfx1011;gfx1012;gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036;gfx1150;gfx1152;gfx1153`.

## Technical Details

We were disabling flash attention and aotriton if _any_ target in the list was unsupported, but aotriton and pytorch have their own filtering and fallback behavior. What's remaining is https://github.com/ROCm/aotriton/issues/169 - if building aotriton for _only unsupported architectures_ it fails to build. Inverting the logic should enable flash attention for our multi-arch builds while keeping our single-family release builds working too.

## Test Plan

* Manually triggered
    Run link | details | outcome
    -- | -- | --
    [run 25194709687](https://github.com/ROCm/TheRock/actions/runs/25194709687) | Linux `gfx908;gfx110X-all` - no filtering | Passed
    [run 25194723047](https://github.com/ROCm/TheRock/actions/runs/25194723047) | Windows `gfx908;gfx110X-all` - no filtering | Passed
    [run 25201744067](https://github.com/ROCm/TheRock/actions/runs/25201744067) | Linux `gfx900` - no filtering | Failed due to [ROCm/aotriton#169](https://github.com/ROCm/aotriton/issues/169)
    [run 25227195536](https://github.com/ROCm/TheRock/actions/runs/25227195536) | Linux `gfx900` - inverted filtering in this PR | Passed
* Multi-arch CI on this PR should build torch for supported targets, with flash attention enabled
* Multi-arch releases after merge should enable flash attention
* Single-family releases after merge should enable/disable flash attention as before

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
