### PR TITLE
Check for tarball deletion

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -60,7 +60,7 @@ def get_devel_root() -> Path:
     site_lib_path = rocm_sdk_devel_path.parent
     devel_py_pkg_name = di.ALL_PACKAGES["devel"].get_py_package_name()
     devel_py_pkg_path = site_lib_path / devel_py_pkg_name
-  
+
     # Skip expanding if the devel package has already been expanded fully.
     # _expand_devel_contents deletes the tarball with tarfile_path.unlink()
     # as the last step of expansion, so presence of the tarball means
@@ -68,13 +68,14 @@ def get_devel_root() -> Path:
     tarfile_path, _ = _find_tarfile(rocm_sdk_devel_path)
     if (devel_py_pkg_path / "__init__.py").exists() and not tarfile_path:
         return devel_py_pkg_path
-      
+
     _expand_devel_contents(rocm_sdk_devel_path, site_lib_path)
     if not (devel_py_pkg_path / "__init__.py").exists():
         raise ImportError(
             f"Expanding {devel_py_pkg_name} did not produce a valid Python package"
         )
     return devel_py_pkg_path
+
 
 # Gets the path of a module presumed to be a package defined by an __init__.py
 # file. Returns None if it is a namespace package or another kind of module.
@@ -152,7 +153,7 @@ def _expand_devel_contents(rocm_sdk_devel_path: Path, site_lib_path: Path):
         raise ImportError(
             f"Expected to find _devel.tar or _devel.tar.xz in {rocm_sdk_devel_path}"
         )
-      
+
     dist_file_path_names = [str(df) for df in dist_files]
     _lock_and_expand(
         site_lib_path,
@@ -161,6 +162,7 @@ def _expand_devel_contents(rocm_sdk_devel_path: Path, site_lib_path: Path):
         record_path,
         dist_file_path_names,
     )
+
 
 def _find_tarfile(rocm_sdk_devel_path: Path):
     tarfile_path = rocm_sdk_devel_path / "_devel.tar.xz"
@@ -173,6 +175,7 @@ def _find_tarfile(rocm_sdk_devel_path: Path):
         else:
             return "", ""
     return tarfile_path, tarfile_mode
+
 
 def _lock_and_expand(
     site_lib_path: Path,

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -60,16 +60,21 @@ def get_devel_root() -> Path:
     site_lib_path = rocm_sdk_devel_path.parent
     devel_py_pkg_name = di.ALL_PACKAGES["devel"].get_py_package_name()
     devel_py_pkg_path = site_lib_path / devel_py_pkg_name
-    tarball_present = (rocm_sdk_devel_path / "_devel.tar.xz").exists() or (rocm_sdk_devel_path / "_devel.tar").exists()
-    if (devel_py_pkg_path / "__init__.py").exists() and not tarball_present:
+  
+    # Skip expanding if the devel package has already been expanded fully.
+    # _expand_devel_contents deletes the tarball with tarfile_path.unlink()
+    # as the last step of expansion, so presence of the tarball means
+    # we haven't expanded yet or expansion failed and we need to retry
+    tarfile_path, _ = _find_tarfile(rocm_sdk_devel_path)
+    if (devel_py_pkg_path / "__init__.py").exists() and not tarfile_path:
         return devel_py_pkg_path
+      
     _expand_devel_contents(rocm_sdk_devel_path, site_lib_path)
     if not (devel_py_pkg_path / "__init__.py").exists():
         raise ImportError(
             f"Expanding {devel_py_pkg_name} did not produce a valid Python package"
         )
     return devel_py_pkg_path
-
 
 # Gets the path of a module presumed to be a package defined by an __init__.py
 # file. Returns None if it is a namespace package or another kind of module.
@@ -142,17 +147,12 @@ def _expand_devel_contents(rocm_sdk_devel_path: Path, site_lib_path: Path):
     record_path = record_pkg_file.locate()
 
     # Find the tarfile.
-    tarfile_path = rocm_sdk_devel_path / "_devel.tar.xz"
-    if tarfile_path.exists():
-        tarfile_mode = "r:xz"
-    else:
-        tarfile_path = rocm_sdk_devel_path / "_devel.tar"
-        if not tarfile_path.exists():
-            raise ImportError(
-                f"Expected to find _devel.tar or _devel.tar.xz in {rocm_sdk_devel_path}"
-            )
-        tarfile_mode = "r"
-
+    tarfile_path, tarfile_mode = find_tarfile(rocm_sdk_devel_path)
+    if not tarfile_path:
+        raise ImportError(
+            f"Expected to find _devel.tar or _devel.tar.xz in {rocm_sdk_devel_path}"
+        )
+      
     dist_file_path_names = [str(df) for df in dist_files]
     _lock_and_expand(
         site_lib_path,
@@ -162,6 +162,17 @@ def _expand_devel_contents(rocm_sdk_devel_path: Path, site_lib_path: Path):
         dist_file_path_names,
     )
 
+def _find_tarfile(rocm_sdk_devel_path: Path):
+    tarfile_path = rocm_sdk_devel_path / "_devel.tar.xz"
+    if tarfile_path.exists():
+        tarfile_mode = "r:xz"
+    else:
+        tarfile_path = rocm_sdk_devel_path / "_devel.tar"
+        if tarfile_path.exists():
+            tarfile_mode = "r"
+        else:
+            return "", ""
+    return tarfile_path, tarfile_mode
 
 def _lock_and_expand(
     site_lib_path: Path,

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -147,7 +147,7 @@ def _expand_devel_contents(rocm_sdk_devel_path: Path, site_lib_path: Path):
     record_path = record_pkg_file.locate()
 
     # Find the tarfile.
-    tarfile_path, tarfile_mode = find_tarfile(rocm_sdk_devel_path)
+    tarfile_path, tarfile_mode = _find_tarfile(rocm_sdk_devel_path)
     if not tarfile_path:
         raise ImportError(
             f"Expected to find _devel.tar or _devel.tar.xz in {rocm_sdk_devel_path}"

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -60,9 +60,9 @@ def get_devel_root() -> Path:
     site_lib_path = rocm_sdk_devel_path.parent
     devel_py_pkg_name = di.ALL_PACKAGES["devel"].get_py_package_name()
     devel_py_pkg_path = site_lib_path / devel_py_pkg_name
-    if (devel_py_pkg_path / "__init__.py").exists():
+    tarball_present = (rocm_sdk_devel_path / "_devel.tar.xz").exists() or (rocm_sdk_devel_path / "_devel.tar").exists()
+    if (devel_py_pkg_path / "__init__.py").exists() and not tarball_present:
         return devel_py_pkg_path
-
     _expand_devel_contents(rocm_sdk_devel_path, site_lib_path)
     if not (devel_py_pkg_path / "__init__.py").exists():
         raise ImportError(


### PR DESCRIPTION
Tarball is deleted as the final step of expansion, so check for this to determine whether expansion needs to be performed and not just the existence of \_\_init\_\_.py.

## Motivation

Sporadic issue observed on Windows where `rocm-sdk path --root` and `rocm-sdk init` will fail partway through the expansion, resulting in the _rocm_sdk_devel directory containing \_\_init\_\_.py while not being complete. Currently this can only be remedied by starting from scratch, deleting \_\_init\_\_.py in the devel path, or manually extracting the files, as re-running these commands currently detect \_\_init\_\_.py and stop early.

## Technical Details

Checks for _devel.tar or _devel.tar.xz in get_devel_root() to determine whether to return the path or expand the devel files. The nightly wheels have a .tar file but documentation in _devel.py states support for either format.

This does introduce a potential issue where if the tarball is not properly deleted after expanding the files then `rocm-sdk path --root` and `rocm-sdk init` will take additional time as they perform a redundant expansion of the files. An alternative design if this is undesirable is to add an option to these commands to force retrying the expansion and not do so by default.

## Test Plan

Used this change to fix an installation on a system I saw the issue on. Issue is sporadic and without clear cause so is hard to make a consistent test for, but could create a dummy tarball file in a working installation and observe the init script extract it.