### PR TITLE
fix rccl ASAN build due to missing hip flags in device ASAN compilation

### DIFF
--- a/cmake/therock_sanitizers.cmake
+++ b/cmake/therock_sanitizers.cmake
@@ -36,8 +36,8 @@ function(therock_sanitizer_configure
     string(APPEND _stanza "set(THEROCK_SANITIZER \"${_sanitizer}\")\n")
     # TODO: Support ASAN_STATIC to use static ASAN linkage. Shared is almost always the right thing,
     # so make "ASAN" imply shared linkage.
-    string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS \" -fsanitize=address -fno-omit-frame-pointer -g\")\n")
-    string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS \" -fsanitize=address -fno-omit-frame-pointer -g\")\n")
+    string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS_INIT \" -fsanitize=address -fno-omit-frame-pointer -g\")\n")
+    string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS_INIT \" -fsanitize=address -fno-omit-frame-pointer -g\")\n")
     # Sharp edge: The -shared-libsan flag is compiler frontend specific:
     #   gcc (and gfortran): defaults to shared sanitizer linkage
     #   clang: defaults to static linkage and requires -shared-libsan to link shared
@@ -64,8 +64,8 @@ function(therock_sanitizer_configure
     string(APPEND _stanza "set(THEROCK_SANITIZER \"TSAN\")\n")
     # TODO: Support TSAN_STATIC to use static TSAN linkage. Shared is almost always the right thing,
     # so make "TSAN" imply shared linkage.
-    string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS \" -fsanitize=thread -fno-omit-frame-pointer -g\")\n")
-    string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS \" -fsanitize=thread -fno-omit-frame-pointer -g\")\n")
+    string(APPEND _stanza "string(APPEND CMAKE_CXX_FLAGS_INIT \" -fsanitize=thread -fno-omit-frame-pointer -g\")\n")
+    string(APPEND _stanza "string(APPEND CMAKE_C_FLAGS_INIT \" -fsanitize=thread -fno-omit-frame-pointer -g\")\n")
     # Sharp edge: The -shared-libsan flag is compiler frontend specific:
     #   gcc (and gfortran): defaults to shared sanitizer linkage
     #   clang: defaults to static linkage and requires -shared-libsan to link shared

--- a/comm-libs/pre_hook_rccl.cmake
+++ b/comm-libs/pre_hook_rccl.cmake
@@ -18,4 +18,19 @@ if(THEROCK_SANITIZER STREQUAL "ASAN")
   set(BUILD_ADDRESS_SANITIZER ON)
   message(STATUS "Enabling BUILD_ADDRESS_SANITIZER for RCCL
 (THEROCK_SANITIZER=${THEROCK_SANITIZER})")
+
+  # Work around a variable-shadowing issue: the sanitizer stanza in the
+  # generated toolchain uses string(APPEND CMAKE_CXX_FLAGS ...) which creates
+  # a normal variable that shadows the cache variable.  The cache variable
+  # (populated from CMAKE_CXX_FLAGS_INIT) contains --hip-path and
+  # --hip-device-lib-path, but the normal variable does not.  RCCL's
+  # DeviceLinker.cmake reads CMAKE_CXX_FLAGS at configure time to extract
+  # these flags, so we must ensure they are present in the normal variable.
+  string(REGEX MATCHALL "--hip-path=[^ ]+" _hip_path "${CMAKE_CXX_FLAGS_INIT}")
+  string(REGEX MATCHALL "--hip-device-lib-path=[^ ]+" _hip_devlib "${CMAKE_CXX_FLAGS_INIT}")
+  foreach(_flag IN LISTS _hip_path _hip_devlib)
+    if(NOT "${CMAKE_CXX_FLAGS}" MATCHES "${_flag}")
+      string(APPEND CMAKE_CXX_FLAGS " ${_flag}")
+    endif()
+  endforeach()
 endif()

--- a/comm-libs/pre_hook_rccl.cmake
+++ b/comm-libs/pre_hook_rccl.cmake
@@ -18,19 +18,4 @@ if(THEROCK_SANITIZER STREQUAL "ASAN")
   set(BUILD_ADDRESS_SANITIZER ON)
   message(STATUS "Enabling BUILD_ADDRESS_SANITIZER for RCCL
 (THEROCK_SANITIZER=${THEROCK_SANITIZER})")
-
-  # Work around a variable-shadowing issue: the sanitizer stanza in the
-  # generated toolchain uses string(APPEND CMAKE_CXX_FLAGS ...) which creates
-  # a normal variable that shadows the cache variable.  The cache variable
-  # (populated from CMAKE_CXX_FLAGS_INIT) contains --hip-path and
-  # --hip-device-lib-path, but the normal variable does not.  RCCL's
-  # DeviceLinker.cmake reads CMAKE_CXX_FLAGS at configure time to extract
-  # these flags, so we must ensure they are present in the normal variable.
-  string(REGEX MATCHALL "--hip-path=[^ ]+" _hip_path "${CMAKE_CXX_FLAGS_INIT}")
-  string(REGEX MATCHALL "--hip-device-lib-path=[^ ]+" _hip_devlib "${CMAKE_CXX_FLAGS_INIT}")
-  foreach(_flag IN LISTS _hip_path _hip_devlib)
-    if(NOT "${CMAKE_CXX_FLAGS}" MATCHES "${_flag}")
-      string(APPEND CMAKE_CXX_FLAGS " ${_flag}")
-    endif()
-  endforeach()
 endif()


### PR DESCRIPTION
## Motivation

Fix rccl build failure in TheRock ASAN CI pipeline

## Technical Details

* Summary

The ASAN CI build for TheRock (gfx94X-dcgpu) fails during RCCL device
compilation with:

#+begin_example
clang++: error: cannot find HIP runtime; provide its path via '--rocm-path',
or pass '-nogpuinc' to build without HIP runtime
#+end_example

PR #5569 (rocm-systems) successfully removed the single-GPU-target
restriction for ASAN builds, but exposed a latent variable-shadowing
bug in TheRock's sanitizer toolchain integration.

The ASAN sanitizer stanza in the generated toolchain file
(=cmake/therock_sanitizers.cmake= line 39-40) uses:

#+begin_src cmake
string(APPEND CMAKE_CXX_FLAGS " -fsanitize=address -fno-omit-frame-pointer -g")
string(APPEND CMAKE_C_FLAGS " -fsanitize=address -fno-omit-frame-pointer -g")
#+end_src

Meanwhile, the HIP path flags are set correctly via the =_INIT= mechanism
(=cmake/therock_subproject.cmake= line 1727-1728):

#+begin_src cmake
string(APPEND CMAKE_CXX_FLAGS_INIT " --hip-path=@_hip_dist_dir@")
string(APPEND CMAKE_CXX_FLAGS_INIT " --hip-device-lib-path=@_amd_llvm_device_lib_path@")
#+end_src

** Why this causes the failure

1. The toolchain file runs *before* =project()=.
2. =CMAKE_CXX_FLAGS_INIT= is set with =--hip-path=...= -- this is correct.
3. =string(APPEND CMAKE_CXX_FLAGS ...)= creates a *normal (non-cache) variable*
   containing only =-fsanitize=address ...= (no =--hip-path=).
4. =project()= initializes the *cache variable* =CMAKE_CXX_FLAGS= from
   =CMAKE_CXX_FLAGS_INIT= (which has =--hip-path=).
5. But the normal variable from step 3 *shadows* the cache variable at
   configure time.
6. When =DeviceLinker.cmake= reads =${CMAKE_CXX_FLAGS}= to extract
   =--hip-path=, it gets the normal variable -- which lacks the flag.
7. =rccl-device-compile= is invoked without =--hip-path=, so =amdclang++=
   cannot find HIP runtime headers in TheRock's split directory layout.

** Why non-ASAN builds are unaffected

No sanitizer stanza means no normal variable is created. The cache variable
(with =--hip-path=) is the only =CMAKE_CXX_FLAGS=, and =DeviceLinker.cmake=
reads it correctly.

** Why host compilation works even with ASAN

CMake's built-in compile rules use the *cache variable* for build-system
generation, not the normal variable. The shadowing only affects configure-time
CMake code that reads =${CMAKE_CXX_FLAGS}= directly -- which is exactly what
=DeviceLinker.cmake= does.

** Why this was never caught before

The old RCCL code had a =FATAL_ERROR= guard that rejected multi-target ASAN
builds at configure time. The DeviceLinker pipeline was never reached in ASAN
CI. PR #5569 removed the guard, allowing configure to pass, but exposing the
latent =--hip-path= issue in device compilation.



## Test Plan

Run TheRock CI ASAN

## Test Result

testing-in-progress