### PR TITLE
Update test_runs_on defaults to new runner label for gfx942

### DIFF
--- a/.github/workflows/test_jax_dockerfile.yml
+++ b/.github/workflows/test_jax_dockerfile.yml
@@ -9,7 +9,7 @@ on:
       test_runs_on:
         required: true
         type: string
-        default: "linux-mi325-1gpu-ossci-rocm"
+        default: "linux-gfx942-1gpu-ossci-rocm"
       image_name:
         required: true
         description: JAX docker image to run tests with

--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -127,7 +127,7 @@ on:
         description: Runner label to use. The selected runner should have a GPU supported by amdgpu_family
         required: true
         type: string
-        default: "linux-mi325-1gpu-ossci-rocm"
+        default: "linux-gfx942-1gpu-ossci-rocm"
       ref:
         description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow."
         type: string

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -15,7 +15,7 @@ on:
         description: Runner label to use. The selected runner should have a GPU supported by amdgpu_family
         required: true
         type: string
-        default: "linux-mi325-1gpu-ossci-rocm"
+        default: "linux-gfx942-1gpu-ossci-rocm"
       package_index_url:
         description: Base Python package index URL to test, typically nightly/dev URL with a "v2" or "v2-staging" subdir (without a GPU family subdir)
         required: true

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -15,7 +15,7 @@ on:
         description: Runner label to use. The selected runner should have a GPU supported by amdgpu_family
         required: true
         type: string
-        default: "linux-mi325-1gpu-ossci-rocm-frac"
+        default: "linux-gfx942-1gpu-ossci-rocm"
       package_index_url_base:
         description: Base Python package index URL (without GPU family subdir)
         type: string

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -739,7 +739,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
                 {
                     "amdgpu_family": "gfx94X-dcgpu",
                     "amdgpu_targets": "gfx942",
-                    "test-runs-on": "linux-mi325-1gpu-ossci-rocm",
+                    "test-runs-on": "linux-gfx942-1gpu-ossci-rocm",
                     "sanity_check_only_for_family": false
                 },
                 ...

--- a/docs/development/style_guides/github_actions_style_guide.md
+++ b/docs/development/style_guides/github_actions_style_guide.md
@@ -197,7 +197,7 @@ jobs:
   test_artifacts:
     name: Test Artifacts
     needs: build_artifacts
-    runs-on: linux-mi325-1gpu-ossci-rocm  # Expensive GPU runner only for tests
+    runs-on: linux-gfx942-1gpu-ossci-rocm  # Expensive GPU runner only for tests
     steps:
       # ... Download artifacts, setup test environment, etc.
 
@@ -211,7 +211,7 @@ jobs:
 jobs:
   build_and_test:
     name: Build and Test
-    runs-on: linux-mi325-1gpu-ossci-rocm  # Expensive GPU runner
+    runs-on: linux-gfx942-1gpu-ossci-rocm  # Expensive GPU runner
     steps:
       # ...
 


### PR DESCRIPTION
## Motivation

The label used here has no runners, so workflow_dispatch of these workflows with default inputs results in stalled jobs.

## Technical Details

See https://github.com/ROCm/TheRock/pull/4023 for context where we lost capacity for `linux-mi325-1gpu-ossci-rocm` and added back runners under `linux-gfx942-1gpu-ossci-rocm`. A few other labels are also available, see https://github.com/ROCm/TheRock/blob/51f806b3a709c424c4ff2091c6291974f0f642b3/build_tools/github_actions/amdgpu_family_matrix.py#L142-L159

## Test Plan

* Run with default is stuck queued: https://github.com/ROCm/TheRock/actions/runs/25232679673/job/73991726504
    ```
    Test PyTorch | gfx94X-dcgpu
    Started 35m 32s ago
    Requested labels: linux-mi325-1gpu-ossci-rocm
    Waiting for a runner to pick up this job...
    ```
* Run with new label is running: https://github.com/ROCm/TheRock/actions/runs/25233709159
    ```
    Runner name: 'linux-gfx942-1gpu-ossci-rocm-69plq-runner-vdf7s'
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
