### PR TITLE
[ci] Removing gfx950 from pool

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -246,8 +246,8 @@ amdgpu_family_info_matrix_postsubmit = {
         "linux": {
             # Disabled on 5/1/2026 due to power failures in CCS cluster
             # Expected to be restored 5/8/2026
-            "test-runs-on": "", # label is linux-gfx950-1gpu-ccs-ossci-rocm
-            "test-runs-on-multi-gpu": "", # label is linux-gfx950-8gpu-ccs-ossci-rocm
+            "test-runs-on": "",  # label is linux-gfx950-1gpu-ccs-ossci-rocm
+            "test-runs-on-multi-gpu": "",  # label is linux-gfx950-8gpu-ccs-ossci-rocm
             "family": "gfx950-dcgpu",
             "fetch-gfx-targets": ["gfx950"],
             "build_variants": ["release", "asan", "tsan"],

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -246,7 +246,7 @@ amdgpu_family_info_matrix_postsubmit = {
         "linux": {
             # Disabled on 5/1/2026 due to power failures in CCS cluster
             # Expected to be restored 5/8/2026
-            "test-runs-on": "",  # label is linux-gfx950-1gpu-ccs-ossci-rocm
+            "test-runs-on": "linux-mi355-1gpu-ossci-rocm",  # label is linux-gfx950-1gpu-ccs-ossci-rocm
             "test-runs-on-multi-gpu": "",  # label is linux-gfx950-8gpu-ccs-ossci-rocm
             "family": "gfx950-dcgpu",
             "fetch-gfx-targets": ["gfx950"],

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -244,8 +244,10 @@ amdgpu_family_info_matrix_presubmit = {
 amdgpu_family_info_matrix_postsubmit = {
     "gfx950": {
         "linux": {
-            "test-runs-on": "linux-gfx950-1gpu-ccs-ossci-rocm",
-            "test-runs-on-multi-gpu": "linux-gfx950-8gpu-ccs-ossci-rocm",
+            # Disabled on 5/1/2026 due to power failures in CCS cluster
+            # Expected to be restored 5/8/2026
+            "test-runs-on": "", # label is linux-gfx950-1gpu-ccs-ossci-rocm
+            "test-runs-on-multi-gpu": "", # label is linux-gfx950-8gpu-ccs-ossci-rocm
             "family": "gfx950-dcgpu",
             "fetch-gfx-targets": ["gfx950"],
             "build_variants": ["release", "asan", "tsan"],


### PR DESCRIPTION
Due to a partial power failure for CCS cluster, these machines are down for maintenance until May 8th. 

We are disabling machines until back as no gfx950 machines are available