### PR TITLE
Add multi-arch support to PyTorch test workflows

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -132,7 +132,8 @@ jobs:
             --torch-version=${{ inputs.torch_version }} \
             --pytorch-git-ref=${{ inputs.pytorch_git_ref }} \
             --index-url=${{ inputs.package_index_url }} \
-            ${{ inputs.multi_arch && format('--device-extras={0}', steps.expand.outputs.device_extras) || format('--index-subdir={0}', inputs.amdgpu_family) }}
+            --index-subdir=${{ inputs.amdgpu_family }} \
+            --device-extras="${{ steps.expand.outputs.device_extras }}"
 
       - name: Set git options
         run: |

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -121,11 +121,9 @@ jobs:
         if: ${{ inputs.multi_arch }}
         id: expand
         run: |
-          device_extras=$(python build_tools/github_actions/expand_amdgpu_families.py \
+          python build_tools/github_actions/expand_amdgpu_families.py \
             --amdgpu-families "${{ inputs.amdgpu_family }}" \
-            --prefix "device-")
-          echo "Expanded '${{ inputs.amdgpu_family }}' -> device extras '${device_extras}'"
-          echo "device_extras=${device_extras}" >> "$GITHUB_OUTPUT"
+            --output-mode=device-extras
 
       # TODO: also upload and reference test report together with this logging?
       - name: Summarize workflow inputs

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -17,7 +17,10 @@ on:
         type: string
         default: "linux-mi325-1gpu-ossci-rocm"
       package_index_url:
-        description: Base Python package index URL to test, typically nightly/dev URL with a "v2" or "v2-staging" subdir (without a GPU family subdir)
+        description: >-
+          Base Python package index URL to test.
+          Per-family: nightly/dev URL with a "v2" or "v2-staging" subdir (without a GPU family subdir).
+          Multi-arch: unified index URL (e.g. "https://rocm.nightlies.amd.com/whl-staging-multi-arch/").
         required: true
         type: string
         default: "https://rocm.nightlies.amd.com/v2"
@@ -33,6 +36,12 @@ on:
         description: PyTorch ref to checkout test sources from. (e.g. "nightly", or "release/2.7")
         type: string
         default: "release/2.7"
+      multi_arch:
+        description: >-
+          Install from a multi-arch index using device extras
+          (e.g. torch[device-gfx942]) instead of per-family index subdirs.
+        type: boolean
+        default: false
 
   workflow_call:
     inputs:
@@ -54,6 +63,12 @@ on:
       pytorch_git_ref:
         type: string
         default: "release/2.7"
+      multi_arch:
+        description: >-
+          Install from a multi-arch index using device extras
+          (e.g. torch[device-gfx942]) instead of per-family index subdirs.
+        type: boolean
+        default: false
       repository:
         description: "Repository to checkout. Otherwise, defaults to `github.repository`."
         type: string
@@ -99,6 +114,19 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
+      # Multi-arch packages use pip extras (e.g. torch[device-gfx942]) to
+      # select GPU-specific device packages. Expand the family to get the
+      # comma-separated device extras string for pip install.
+      - name: Expand GPU family to device extras
+        if: ${{ inputs.multi_arch }}
+        id: expand
+        run: |
+          device_extras=$(python build_tools/github_actions/expand_amdgpu_families.py \
+            --amdgpu-families "${{ inputs.amdgpu_family }}" \
+            --prefix "device-")
+          echo "Expanded '${{ inputs.amdgpu_family }}' -> device extras '${device_extras}'"
+          echo "device_extras=${device_extras}" >> "$GITHUB_OUTPUT"
+
       # TODO: also upload and reference test report together with this logging?
       - name: Summarize workflow inputs
         run: |
@@ -106,7 +134,7 @@ jobs:
             --torch-version=${{ inputs.torch_version }} \
             --pytorch-git-ref=${{ inputs.pytorch_git_ref }} \
             --index-url=${{ inputs.package_index_url }} \
-            --index-subdir=${{ inputs.amdgpu_family }}
+            ${{ inputs.multi_arch && format('--device-extras={0}', steps.expand.outputs.device_extras) || format('--index-subdir={0}', inputs.amdgpu_family) }}
 
       - name: Set git options
         run: |
@@ -133,11 +161,18 @@ jobs:
 
       - name: Set up virtual environment
         run: |
-          python build_tools/setup_venv.py ${VENV_DIR} \
-            --packages torch==${{ inputs.torch_version }} \
-            --index-url=${{ inputs.package_index_url }} \
-            --index-subdir=${{ inputs.amdgpu_family }} \
-            --activate-in-future-github-actions-steps
+          if [ "${{ inputs.multi_arch }}" = "true" ]; then
+            python build_tools/setup_venv.py ${VENV_DIR} \
+              --packages "torch[${{ steps.expand.outputs.device_extras }}]==${{ inputs.torch_version }}" \
+              --index-url=${{ inputs.package_index_url }} \
+              --activate-in-future-github-actions-steps
+          else
+            python build_tools/setup_venv.py ${VENV_DIR} \
+              --packages torch==${{ inputs.torch_version }} \
+              --index-url=${{ inputs.package_index_url }} \
+              --index-subdir=${{ inputs.amdgpu_family }} \
+              --activate-in-future-github-actions-steps
+          fi
 
       - name: Install test requirements
         run: |

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -188,11 +188,9 @@ jobs:
         if: ${{ inputs.multi_arch }}
         id: expand
         run: |
-          device_extras=$(python build_tools/github_actions/expand_amdgpu_families.py \
+          python build_tools/github_actions/expand_amdgpu_families.py \
             --amdgpu-families "${{ inputs.amdgpu_family }}" \
-            --prefix "device-")
-          echo "Expanded '${{ inputs.amdgpu_family }}' -> device extras '${device_extras}'"
-          echo "device_extras=${device_extras}" >> "$GITHUB_OUTPUT"
+            --output-mode=device-extras
 
       # safe.directory must be set before Runner Health Status
       - name: Adjust git config

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -49,6 +49,12 @@ on:
         description: Space-separated list of test modules to run (passed as TESTS_TO_INCLUDE to run_test.py). Leave empty to run all tests.
         type: string
         default: ""
+      multi_arch:
+        description: >-
+          Install from a multi-arch index using device extras
+          (e.g. torch[device-gfx942]) instead of per-family index subdirs.
+        type: boolean
+        default: false
 
   workflow_call:
     inputs:
@@ -77,6 +83,12 @@ on:
       pytorch_git_repo:
         type: string
         default: "pytorch/pytorch"
+      multi_arch:
+        description: >-
+          Install from a multi-arch index using device extras
+          (e.g. torch[device-gfx942]) instead of per-family index subdirs.
+        type: boolean
+        default: false
       repository:
         description: "Repository to checkout. Otherwise, defaults to `github.repository`."
         type: string
@@ -169,6 +181,19 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
+      # Multi-arch packages use pip extras (e.g. torch[device-gfx942]) to
+      # select GPU-specific device packages. Expand the family to get the
+      # comma-separated device extras string for pip install.
+      - name: Expand GPU family to device extras
+        if: ${{ inputs.multi_arch }}
+        id: expand
+        run: |
+          device_extras=$(python build_tools/github_actions/expand_amdgpu_families.py \
+            --amdgpu-families "${{ inputs.amdgpu_family }}" \
+            --prefix "device-")
+          echo "Expanded '${{ inputs.amdgpu_family }}' -> device extras '${device_extras}'"
+          echo "device_extras=${device_extras}" >> "$GITHUB_OUTPUT"
+
       # safe.directory must be set before Runner Health Status
       - name: Adjust git config
         run: |
@@ -188,16 +213,28 @@ jobs:
 
       - name: Set up virtual environment
         run: |
-          python build_tools/setup_venv.py ${VENV_DIR} \
-            --packages torch==${{ inputs.torch_version }} \
-            --index-url=${{ inputs.package_index_url }} \
-            --index-subdir=${{ inputs.amdgpu_family }} \
-            --activate-in-future-github-actions-steps
+          if [ "${{ inputs.multi_arch }}" = "true" ]; then
+            python build_tools/setup_venv.py ${VENV_DIR} \
+              --packages "torch[${{ steps.expand.outputs.device_extras }}]==${{ inputs.torch_version }}" \
+              --index-url=${{ inputs.package_index_url }} \
+              --activate-in-future-github-actions-steps
+          else
+            python build_tools/setup_venv.py ${VENV_DIR} \
+              --packages torch==${{ inputs.torch_version }} \
+              --index-url=${{ inputs.package_index_url }} \
+              --index-subdir=${{ inputs.amdgpu_family }} \
+              --activate-in-future-github-actions-steps
+          fi
 
       - name: Install ROCm devel packages
         run: |
-          pip install "rocm[devel]" \
-            --index-url=${{ inputs.package_index_url }}/${{ inputs.amdgpu_family }}
+          if [ "${{ inputs.multi_arch }}" = "true" ]; then
+            pip install "rocm[devel,${{ steps.expand.outputs.device_extras }}]" \
+              --index-url=${{ inputs.package_index_url }}
+          else
+            pip install "rocm[devel]" \
+              --index-url=${{ inputs.package_index_url }}/${{ inputs.amdgpu_family }}
+          fi
 
       - name: Initialize ROCm SDK and configure environment
         run: |

--- a/build_tools/github_actions/expand_amdgpu_families.py
+++ b/build_tools/github_actions/expand_amdgpu_families.py
@@ -12,13 +12,20 @@ Used by CI workflows that need build-side gfx targets (e.g.
 `--pytorch-rocm-arch`) from a family list. Mirrors the pattern used by
 `artifact_manager.py --expand-family-to-targets`.
 
-Example usage:
+Output modes:
 
-    python expand_amdgpu_families.py --amdgpu-families "gfx94X-dcgpu;gfx120X-all"
-    -> gfx942,gfx1200,gfx1201
+* ``targets`` (default) — bare gfx targets, comma-separated:
 
-    python expand_amdgpu_families.py --amdgpu-families "gfx94X-dcgpu" --prefix "device-"
-    -> device-gfx942
+      python expand_amdgpu_families.py --amdgpu-families "gfx94X-dcgpu;gfx120X-all"
+      -> gfx942,gfx1200,gfx1201
+
+* ``device-extras`` — pip device extras, comma-separated, and also
+  written to ``$GITHUB_OUTPUT`` as ``device_extras=...``:
+
+      python expand_amdgpu_families.py --amdgpu-families "gfx94X-dcgpu" \
+        --output-mode=device-extras
+      -> device-gfx942  (stdout)
+      -> device_extras=device-gfx942  (GITHUB_OUTPUT)
 
 Fails with a non-zero exit code and a clear message if any requested
 family is not present in the CMake source — silent drops were the bug
@@ -36,6 +43,8 @@ from _therock_utils.cmake_amdgpu_targets import (
     expand_families,
 )
 
+from github_actions.github_actions_api import gha_set_output
+
 
 def main(argv: list[str]) -> int:
     p = argparse.ArgumentParser(prog="expand_amdgpu_families.py")
@@ -49,12 +58,13 @@ def main(argv: list[str]) -> int:
         ),
     )
     p.add_argument(
-        "--prefix",
-        type=str,
-        default="",
+        "--output-mode",
+        choices=["targets", "device-extras"],
+        default="targets",
         help=(
-            "Prefix to prepend to each target in the output "
-            "(e.g. 'device-' to produce 'device-gfx942')."
+            "'targets' prints bare gfx targets (default). "
+            "'device-extras' prints pip device extras (device-gfxNNN) "
+            "and writes them to GITHUB_OUTPUT as device_extras=..."
         ),
     )
     args = p.parse_args(argv)
@@ -65,7 +75,14 @@ def main(argv: list[str]) -> int:
         return 0
 
     targets = expand_families(families, amdgpu_family_map())
-    print(",".join(f"{args.prefix}{t}" for t in targets))
+
+    if args.output_mode == "device-extras":
+        result = ",".join(f"device-{t}" for t in targets)
+        print(result)
+        gha_set_output({"device_extras": result})
+    else:
+        print(",".join(targets))
+
     return 0
 
 

--- a/build_tools/github_actions/expand_amdgpu_families.py
+++ b/build_tools/github_actions/expand_amdgpu_families.py
@@ -17,6 +17,9 @@ Example usage:
     python expand_amdgpu_families.py --amdgpu-families "gfx94X-dcgpu;gfx120X-all"
     -> gfx942,gfx1200,gfx1201
 
+    python expand_amdgpu_families.py --amdgpu-families "gfx94X-dcgpu" --prefix "device-"
+    -> device-gfx942
+
 Fails with a non-zero exit code and a clear message if any requested
 family is not present in the CMake source — silent drops were the bug
 this helper exists to prevent.
@@ -45,6 +48,15 @@ def main(argv: list[str]) -> int:
             "(e.g. 'gfx94X-dcgpu;gfx120X-all')."
         ),
     )
+    p.add_argument(
+        "--prefix",
+        type=str,
+        default="",
+        help=(
+            "Prefix to prepend to each target in the output "
+            "(e.g. 'device-' to produce 'device-gfx942')."
+        ),
+    )
     args = p.parse_args(argv)
 
     families = [f.strip() for f in args.amdgpu_families.split(";") if f.strip()]
@@ -52,7 +64,8 @@ def main(argv: list[str]) -> int:
         print("")
         return 0
 
-    print(",".join(expand_families(families, amdgpu_family_map())))
+    targets = expand_families(families, amdgpu_family_map())
+    print(",".join(f"{args.prefix}{t}" for t in targets))
     return 0
 
 

--- a/build_tools/github_actions/summarize_test_pytorch_workflow.py
+++ b/build_tools/github_actions/summarize_test_pytorch_workflow.py
@@ -11,16 +11,24 @@ GITHUB_STEP_SUMMARY file.
 
 The script can be tested locally with inputs like this:
 
+    # Per-family mode:
     python ./build_tools/github_actions/summarize_test_pytorch_workflow.py \
       --pytorch-git-ref=release/2.7 \
       --index-url=https://rocm.nightlies.amd.com/v2-staging \
       --index-subdir=gfx110X-dgpu \
       --torch-version=2.7.1+rocm7.10.0a20251120
+
+    # Multi-arch mode:
+    python ./build_tools/github_actions/summarize_test_pytorch_workflow.py \
+      --pytorch-git-ref=release/2.10 \
+      --index-url=https://rocm.nightlies.amd.com/whl-staging-multi-arch/ \
+      --device-extras=device-gfx942 \
+      --torch-version=2.10.0+rocm7.12.0a20260501
 """
 
 import argparse
-import os
 import platform
+import sys
 
 from github_actions_api import *
 
@@ -34,12 +42,26 @@ LINE_CONTINUATION = f" {LINE_CONTINUATION_CHAR}\n  "
 
 
 def run(args: argparse.Namespace):
-    index_url = f"{args.index_url}/{args.index_subdir}/"
     pytorch_repo_org = "pytorch" if args.pytorch_git_ref == "nightly" else "ROCm"
     pytorch_origin_args = "" if args.pytorch_git_ref == "nightly" else "--origin rocm"
     pytorch_remote_url = f"https://github.com/{pytorch_repo_org}/pytorch.git"
     pytorch_web_url = f"https://github.com/{pytorch_repo_org}/pytorch"
     pytorch_web_url_with_branch = f"{pytorch_web_url}/tree/{args.pytorch_git_ref}"
+
+    # Determine install mode based on provided arguments.
+    if args.device_extras:
+        # Multi-arch mode: single index URL, device selected via pip extras.
+        index_url = args.index_url.rstrip("/") + "/"
+        package_spec = f'"torch[{args.device_extras}]'
+        package_spec += f"=={args.torch_version}" if args.torch_version else ""
+        package_spec += '"'
+        gpu_label = args.device_extras
+    else:
+        # Per-family mode: index URL includes the family subdir.
+        index_url = f"{args.index_url}/{args.index_subdir}/"
+        package_spec = "torch"
+        package_spec += f"=={args.torch_version}" if args.torch_version else ""
+        gpu_label = args.index_subdir
 
     # This report should be as brief as possible while still conveying what
     # is unique to the given arguments.
@@ -50,8 +72,8 @@ def run(args: argparse.Namespace):
     # Summary information.
     summary += f"* Torch version: `{args.torch_version}`\n"
     summary += f"* Python version: `{args.python_version}`\n"
-    summary += f"* GPU family: `{args.index_subdir}`\n"
-    summary += f"* Package index: {index_url}/\n"
+    summary += f"* GPU target: `{gpu_label}`\n"
+    summary += f"* Package index: {index_url}\n"
     summary += f"* PyTorch source code: {pytorch_web_url_with_branch}\n"
 
     # Link to detailed documentation.
@@ -67,8 +89,7 @@ def run(args: argparse.Namespace):
     summary += "# Install torch and test requirements\n"
     summary += "pip install" + LINE_CONTINUATION
     summary += f"--index-url={index_url}" + LINE_CONTINUATION
-    summary += "torch"
-    summary += f"=={args.torch_version}" if args.torch_version else ""
+    summary += package_spec
     summary += "\n"
     summary += "pip install -r pytorch/.ci/docker/requirements-ci.txt\n"
     summary += "```\n\n"
@@ -101,14 +122,21 @@ if __name__ == "__main__":
         default="https://rocm.nightlies.amd.com/v2-staging",
         help="Full URL for a release index to use with 'pip install --index-url='",
     )
-    # TODO: default the index subdir based on the current GPU somehow?
-    #       (share that logic with setup_venv.py if so)
+    # Per-family mode: --index-subdir selects the GPU family subdirectory.
     parser.add_argument(
         "--index-subdir",
         type=str,
-        required=True,
-        help="Index subdirectory (e.g. gfx110X-dgpu)",
+        help="Index subdirectory (e.g. gfx110X-dgpu). Used for per-family installs.",
+    )
+    # Multi-arch mode: --device-extras selects GPU-specific device packages.
+    parser.add_argument(
+        "--device-extras",
+        type=str,
+        help="Comma-separated device extras (e.g. 'device-gfx942'). Used for multi-arch installs.",
     )
     args = parser.parse_args()
+
+    if not args.index_subdir and not args.device_extras:
+        parser.error("one of --index-subdir or --device-extras is required")
 
     run(args)

--- a/build_tools/github_actions/summarize_test_pytorch_workflow.py
+++ b/build_tools/github_actions/summarize_test_pytorch_workflow.py
@@ -48,20 +48,21 @@ def run(args: argparse.Namespace):
     pytorch_web_url = f"https://github.com/{pytorch_repo_org}/pytorch"
     pytorch_web_url_with_branch = f"{pytorch_web_url}/tree/{args.pytorch_git_ref}"
 
-    # Determine install mode based on provided arguments.
+    # Build index URL — append family subdir when provided.
+    index_url = args.index_url.rstrip("/")
+    if args.index_subdir:
+        index_url += f"/{args.index_subdir.strip('/')}"
+    index_url += "/"
+
+    # Build package spec — add device extras and/or version when provided.
+    package_spec = "torch"
     if args.device_extras:
-        # Multi-arch mode: single index URL, device selected via pip extras.
-        index_url = args.index_url.rstrip("/") + "/"
-        package_spec = f'"torch[{args.device_extras}]'
-        package_spec += f"=={args.torch_version}" if args.torch_version else ""
-        package_spec += '"'
-        gpu_label = args.device_extras
-    else:
-        # Per-family mode: index URL includes the family subdir.
-        index_url = f"{args.index_url}/{args.index_subdir}/"
-        package_spec = "torch"
-        package_spec += f"=={args.torch_version}" if args.torch_version else ""
-        gpu_label = args.index_subdir
+        package_spec += f"[{args.device_extras}]"
+    if args.torch_version:
+        package_spec += f"=={args.torch_version}"
+
+    # Label for the summary display.
+    gpu_label = " / ".join(filter(None, [args.index_subdir, args.device_extras]))
 
     # This report should be as brief as possible while still conveying what
     # is unique to the given arguments.
@@ -89,7 +90,7 @@ def run(args: argparse.Namespace):
     summary += "# Install torch and test requirements\n"
     summary += "pip install" + LINE_CONTINUATION
     summary += f"--index-url={index_url}" + LINE_CONTINUATION
-    summary += package_spec
+    summary += f'"{package_spec}"'
     summary += "\n"
     summary += "pip install -r pytorch/.ci/docker/requirements-ci.txt\n"
     summary += "```\n\n"
@@ -126,17 +127,16 @@ if __name__ == "__main__":
     parser.add_argument(
         "--index-subdir",
         type=str,
+        default="",
         help="Index subdirectory (e.g. gfx110X-dgpu). Used for per-family installs.",
     )
     # Multi-arch mode: --device-extras selects GPU-specific device packages.
     parser.add_argument(
         "--device-extras",
         type=str,
+        default="",
         help="Comma-separated device extras (e.g. 'device-gfx942'). Used for multi-arch installs.",
     )
     args = parser.parse_args()
-
-    if not args.index_subdir and not args.device_extras:
-        parser.error("one of --index-subdir or --device-extras is required")
 
     run(args)

--- a/build_tools/github_actions/tests/expand_amdgpu_families_test.py
+++ b/build_tools/github_actions/tests/expand_amdgpu_families_test.py
@@ -83,17 +83,17 @@ class ExpandAmdgpuFamiliesMainTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             expand_amdgpu_families.main(["--amdgpu-families", "gfxNOPE"])
 
-    def test_main_prefix_prepends_to_each_target(self):
+    def test_main_device_extras_mode(self):
         out = self._run_and_capture(
-            "--amdgpu-families", "gfx94X-dcgpu", "--prefix", "device-"
+            "--amdgpu-families", "gfx94X-dcgpu", "--output-mode", "device-extras"
         )
-        self.assertIn("device-gfx942", out.split(","))
-        # No bare target without the prefix.
-        for token in out.split(","):
+        # gha_set_output logs extra lines to stdout; the result is the first line.
+        first_line = out.split("\n")[0]
+        self.assertIn("device-gfx942", first_line.split(","))
+        for token in first_line.split(","):
             self.assertTrue(token.startswith("device-"), token)
 
-    def test_main_prefix_default_is_empty(self):
-        # Without --prefix the output should not have a prefix.
+    def test_main_targets_mode_is_default(self):
         out = self._run_and_capture("--amdgpu-families", "gfx94X-dcgpu")
         self.assertIn("gfx942", out.split(","))
         self.assertNotIn("device-", out)

--- a/build_tools/github_actions/tests/expand_amdgpu_families_test.py
+++ b/build_tools/github_actions/tests/expand_amdgpu_families_test.py
@@ -83,6 +83,21 @@ class ExpandAmdgpuFamiliesMainTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             expand_amdgpu_families.main(["--amdgpu-families", "gfxNOPE"])
 
+    def test_main_prefix_prepends_to_each_target(self):
+        out = self._run_and_capture(
+            "--amdgpu-families", "gfx94X-dcgpu", "--prefix", "device-"
+        )
+        self.assertIn("device-gfx942", out.split(","))
+        # No bare target without the prefix.
+        for token in out.split(","):
+            self.assertTrue(token.startswith("device-"), token)
+
+    def test_main_prefix_default_is_empty(self):
+        # Without --prefix the output should not have a prefix.
+        out = self._run_and_capture("--amdgpu-families", "gfx94X-dcgpu")
+        self.assertIn("gfx942", out.split(","))
+        self.assertNotIn("device-", out)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

This lets our test workflows install multi-arch packages to make progress on
* https://github.com/ROCm/TheRock/issues/3332
* https://github.com/ROCm/TheRock/issues/3334

The next step will be to connect trigger these tests as part of the new multi-arch releases here: https://github.com/ROCm/TheRock/blob/6d964adcf0b9194349a4c435f780dfa27130192f/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml#L313-L317

similar to https://github.com/ROCm/TheRock/blob/6d964adcf0b9194349a4c435f780dfa27130192f/.github/workflows/build_portable_linux_pytorch_wheels.yml#L311-L348

## Technical Details

Package install steps differ between single-family and multi-arch packages. Rather than use a separate _index_ per GPU family they use a _device extra_ in a shared index:

Package type | Install command
-- | --
Single family | `pip install --index-url=https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu torch==2.11.0+rocm7.13.0a20260501`
Multi-arch | `pip install --index-url=https://rocm.nightlies.amd.com/whl-staging-multi-arch/ 'torch[device-gfx942]==2.11.0+rocm7.13.0a20260501'`

I'm not thrilled about the bash branches in this code (https://github.com/ROCm/TheRock/blob/main/docs/development/style_guides/github_actions_style_guide.md#prefer-python-scripts-over-inline-bash), but we have worse offenders where we need to support both single-family and multi-arch (or kpack disabled/enabled) paths. Once we fully complete the migration to multi-arch we can go through and prune those branches down to just the new code.

## Test Plan

Triggered a few test jobs that show no obvious regressions between single-family and multi-arch torch packages:

Job description | Link | Results
-- | -- | --
Linux gfx942 | [run-25233709159](https://github.com/ROCm/TheRock/actions/runs/25233709159) | `= 39604 passed, 1986 skipped, 151 deselected, 48 xfailed, 6 subtests passed in 1052.95s (0:17:32) =`
Windows gfx1151 | [run-25232905677](https://github.com/ROCm/TheRock/actions/runs/25232905677) | segfault (matches https://github.com/ROCm/TheRock/issues/3987)
Windows gfx110X | [run-25234965314](https://github.com/ROCm/TheRock/actions/runs/25234965314) | pending

I did **not** trigger `test_pytorch_wheels_full.yml`.

We'll get more complete signal once these test jobs are integrated into the multi-arch release workflows.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
