### PR TITLE
[rocSHMEM] Add lib component to amdrocm-rocshmem package

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -2089,6 +2089,7 @@
             "Name": "rocshmem",
             "Components": [
               "run",
+              "lib",
               "doc"
             ]
           }


### PR DESCRIPTION
The lib component was missing in amdrocm-rocmshmem package.
Added the same to the package artifact compoents