### PR TITLE
Fix PR test:* labels not threading to test_labels output

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -137,8 +137,8 @@ class CIInputs:
     # Per-platform workflow_dispatch overrides (parsed from comma-separated input)
     linux_amdgpu_families: list[str] = field(default_factory=list)
     windows_amdgpu_families: list[str] = field(default_factory=list)
-    linux_test_labels: str = ""
-    windows_test_labels: str = ""
+    linux_test_labels: list[str] = field(default_factory=list)
+    windows_test_labels: list[str] = field(default_factory=list)
 
     # Prebuilt configuration (from workflow_dispatch)
     prebuilt_stages: str = ""
@@ -196,6 +196,18 @@ class CIInputs:
         elif event_name == "push":
             base_ref = event.get("before", "HEAD^1")
 
+        # Test labels come from two sources:
+        # 1. LINUX/WINDOWS_TEST_LABELS env vars (workflow_dispatch inputs)
+        # 2. PR test:* labels (apply to both platforms)
+        pr_test_labels = [label for label in pr_labels if label.startswith("test:")]
+        linux_test_labels = (
+            _parse_comma_list(os.environ.get("LINUX_TEST_LABELS", "")) + pr_test_labels
+        )
+        windows_test_labels = (
+            _parse_comma_list(os.environ.get("WINDOWS_TEST_LABELS", ""))
+            + pr_test_labels
+        )
+
         return CIInputs(
             run_id=run_id,
             event_name=event_name,
@@ -210,12 +222,8 @@ class CIInputs:
             windows_amdgpu_families=_parse_comma_list(
                 os.environ.get("WINDOWS_AMDGPU_FAMILIES", "")
             ),
-            linux_test_labels=_parse_comma_list(
-                os.environ.get("LINUX_TEST_LABELS", "")
-            ),
-            windows_test_labels=_parse_comma_list(
-                os.environ.get("WINDOWS_TEST_LABELS", "")
-            ),
+            linux_test_labels=linux_test_labels,
+            windows_test_labels=windows_test_labels,
             prebuilt_stages=os.environ.get("PREBUILT_STAGES", ""),
             baseline_run_id=os.environ.get("BASELINE_RUN_ID", ""),
         )
@@ -462,9 +470,10 @@ class CIOutputs:
     is_ci_enabled: bool = True
     builds: BuildConfigs = field(default_factory=BuildConfigs)
     jobs: JobDecisions | None = None
-    # Test labels pass through from inputs to outputs for downstream workflows.
-    linux_test_labels: str = ""
-    windows_test_labels: str = ""
+    # Test labels for downstream workflows. Merged from workflow_dispatch inputs
+    # and PR test:* labels.
+    linux_test_labels: list[str] = field(default_factory=list)
+    windows_test_labels: list[str] = field(default_factory=list)
 
     @staticmethod
     def skipped() -> "CIOutputs":

--- a/build_tools/github_actions/configure_multi_arch_ci_summary.py
+++ b/build_tools/github_actions/configure_multi_arch_ci_summary.py
@@ -110,8 +110,9 @@ def _non_default_highlights(ci_inputs: CIInputs) -> list[str]:
                 f"(not in default presubmit set)"
             )
         elif label.startswith("test_filter:"):
+            filter_type = label.split(":")[1]
             highlights.append(
-                f"Label `{label}`: overrode test level (default would be `quick`)"
+                f"Label `{label}`: overrode test level to `{filter_type}`"
             )
         elif label.startswith("test_runner:"):
             kernel = label.split(":")[1]

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -153,6 +153,23 @@ class TestCIInputsFromEnviron(unittest.TestCase):
         self.assertEqual(inputs.pr_labels, ["gfx950", "test:rocprim"])
         self.assertEqual(inputs.base_ref, "HEAD^")
 
+    def test_pull_request_test_labels_extracted_to_test_labels(self):
+        """PR test:* labels are merged into linux/windows_test_labels."""
+        inputs = _run_from_environ(
+            event_name="pull_request",
+            event_payload={
+                "pull_request": {
+                    "labels": [
+                        {"name": "test:rccl", "id": 1},
+                        {"name": "test:rocprim", "id": 2},
+                        {"name": "gfx950", "id": 3},
+                    ]
+                }
+            },
+        )
+        self.assertEqual(inputs.linux_test_labels, ["test:rccl", "test:rocprim"])
+        self.assertEqual(inputs.windows_test_labels, ["test:rccl", "test:rocprim"])
+
     def test_push_reads_before_sha(self):
         """Push events use event.before as the diff base."""
         inputs = _run_from_environ(
@@ -296,7 +313,7 @@ class TestDecideJobs(unittest.TestCase):
         result = cm.decide_jobs(
             self._inputs(
                 event_name="workflow_dispatch",
-                linux_test_labels="test:rocprim",
+                linux_test_labels=["test:rocprim"],
             ),
             git_context=cm.GitContext(),
         )
@@ -900,6 +917,34 @@ class TestConfigurePipeline(unittest.TestCase):
         outputs = cm.configure(inputs, cm.GitContext())
         self.assertFalse(outputs.is_ci_enabled)
         self.assertIsNone(outputs.builds.linux)
+
+    def test_test_labels_thread_to_outputs(self):
+        """test_labels on CIInputs pass through to CIOutputs."""
+        inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="pull_request",
+            commit_ref="feature",
+            base_ref="HEAD^",
+            build_variant="release",
+            linux_test_labels=["test:rccl"],
+            windows_test_labels=["test:rccl"],
+        )
+        outputs = cm.configure(inputs, cm.GitContext.empty())
+        self.assertEqual(outputs.linux_test_labels, ["test:rccl"])
+        self.assertEqual(outputs.windows_test_labels, ["test:rccl"])
+
+    def test_no_test_labels_has_empty_outputs(self):
+        """Without test labels, outputs are empty lists."""
+        inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="pull_request",
+            commit_ref="feature",
+            base_ref="HEAD^",
+            build_variant="release",
+        )
+        outputs = cm.configure(inputs, cm.GitContext.empty())
+        self.assertEqual(outputs.linux_test_labels, [])
+        self.assertEqual(outputs.windows_test_labels, [])
 
 
 # ---------------------------------------------------------------------------

--- a/docs/development/ci_behavior_manipulation.md
+++ b/docs/development/ci_behavior_manipulation.md
@@ -3,9 +3,7 @@
 TheRock has two CI pipelines:
 
 - **CI** ([`ci.yml`](https://github.com/ROCm/TheRock/actions/workflows/ci.yml)): single-arch builds, configured by [`configure_ci.py`](../../build_tools/github_actions/configure_ci.py)
-- **Multi-Arch CI** ([`multi_arch_ci.yml`](https://github.com/ROCm/TheRock/actions/workflows/multi_arch_ci.yml)): multi-arch builds, configured by [`configure_ci.py`](../../build_tools/github_actions/configure_ci.py)
-
-<!-- TODO(#3399): link to configure_multi_arch_ci.py when it lands -->
+- **Multi-Arch CI** ([`multi_arch_ci.yml`](https://github.com/ROCm/TheRock/actions/workflows/multi_arch_ci.yml)): multi-arch builds, configured by [`configure_multi_arch_ci.py`](../../build_tools/github_actions/configure_multi_arch_ci.py)
 
 Both read GPU family definitions from [`amdgpu_family_matrix.py`](../../build_tools/github_actions/amdgpu_family_matrix.py).
 
@@ -33,16 +31,16 @@ CI runs on pull requests if modified files pass the filters in
 
 The following labels may be added to a pull request to modify CI behavior:
 
-| Label or group          | Description                                                                                                                               |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `ci:skip`               | Skip all builds and tests                                                                                                                 |
-| `ci:run-all-archs`      | Build and test all possible architectures                                                                                                 |
-| `ci:run-multi-arch`     | (DEPRECATED) Opt in to running multi-arch CI on this PR                                                                                   |
-| `ci:run-non-multi-arch` | Opt in to running non-multi-arch CI on this PR                                                                                            |
-| `gfx...`                | Opt-in to building and testing the specified gfx family (e.g. `gfx120X`, `gfx950`)                                                        |
-| `test:...`              | Run full tests only for the specified projects (e.g. `test:rocthrust`, `test:hipblaslt`)                                                  |
-| `test_runner:...`       | Run tests on only custom test machines (e.g. `test_runner:oem`). Single-arch CI only.                                                     |
-| `test_filter:...`       | Set the test filter explicitly (e.g. `test_filter:comprehensive`). See [test_filtering.md](./test_filtering.md) for allowed test filters. |
+| Label or group          | Description                                                                                                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ci:skip`               | Skip all builds and tests                                                                                                                                                                         |
+| `ci:run-all-archs`      | Build and test all possible architectures                                                                                                                                                         |
+| `ci:run-multi-arch`     | (DEPRECATED) Opt in to running multi-arch CI on this PR                                                                                                                                           |
+| `ci:run-non-multi-arch` | Opt in to running non-multi-arch CI on this PR                                                                                                                                                    |
+| `gfx...`                | Opt-in to building and testing the specified gfx family (e.g. `gfx120X`, `gfx950`)                                                                                                                |
+| `test:...`              | Run tests only for the specified projects (e.g. `test:rocthrust`, `test:hipblaslt`). Sets test level to `full` unless overridden by `test_filter:`. Multiple `test:` labels can be combined.      |
+| `test_runner:...`       | Run tests on only custom test machines (e.g. `test_runner:oem`). Single-arch CI only.                                                                                                             |
+| `test_filter:...`       | Override the test level (e.g. `test_filter:comprehensive`, `test_filter:quick`). Takes priority over all other test level logic. See [test_filtering.md](./test_filtering.md) for allowed values. |
 
 ### Push
 


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/4948 so the documentation at https://github.com/ROCm/TheRock/blob/main/docs/development/ci_behavior_manipulation.md#pull-request is accurate. Previously adding a `test:*` label to a PR would run _all_ subproject tests with test type "full".

Labels | Previous behavior | Intended/fixed behavior
-- | -- | --
None | Quick tests for all subprojects | Quick tests for all subprojects
`test:hipfft` | Full tests for all subprojects | Full tests for just hipfft
`test:hipfft`, `test_filter:quick` | Quick tests for all subprojects | Quick tests for just hipfft

## Technical Details

This configure script was just reading test labels from environment variables that are set by `workflow_dispatch` inputs. Test labels coming from PR labels were not being processed.

## Test Plan

Add test labels to this PR, check that only those tests are selected in the configure output and in the actual run.

## Test Results

https://github.com/ROCm/TheRock/actions/runs/25237692770/job/74244691524?pr=4998

```diff
  python ./build_tools/github_actions/fetch_test_configurations.py
    python ./build_tools/github_actions/fetch_test_configurations.py
    shell: /usr/bin/bash -e {0}
    env:
      ARTIFACT_GROUP: gfx94X-dcgpu
      AMDGPU_FAMILIES: gfx94X-dcgpu
+     TEST_TYPE: quick
+     TEST_LABELS: ['test:hipblaslt', 'test:hipfft']
      RUN_EXTENDED_TESTS: false
      WINDOWS_HIP_ROCR_TESTS: false
  INFO:root:Selecting projects: *
  INFO:root:Using test_matrix (39 test(s))
  INFO:root:Including job sanity with test_type quick
  INFO:root:Excluding job hip-tests since it's not in the test labels
  INFO:root:Excluding job rocblas since it's not in the test labels
  INFO:root:Excluding job rocroller since it's not in the test labels
  INFO:root:Excluding job hipblas since it's not in the test labels
+ INFO:root:Including job hipblaslt with test_type quick
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
