### PR TITLE
Revert "[ci] Removing gfx950 from pool (#4995)"

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -244,10 +244,8 @@ amdgpu_family_info_matrix_presubmit = {
 amdgpu_family_info_matrix_postsubmit = {
     "gfx950": {
         "linux": {
-            # Disabled on 5/1/2026 due to power failures in CCS cluster
-            # Expected to be restored 5/8/2026
-            "test-runs-on": "linux-mi355-1gpu-ossci-rocm",  # label is linux-gfx950-1gpu-ccs-ossci-rocm
-            "test-runs-on-multi-gpu": "",  # label is linux-gfx950-8gpu-ccs-ossci-rocm
+            "test-runs-on": "linux-gfx950-1gpu-ccs-ossci-rocm",
+            "test-runs-on-multi-gpu": "linux-gfx950-8gpu-ccs-ossci-rocm",
             "family": "gfx950-dcgpu",
             "fetch-gfx-targets": ["gfx950"],
             "build_variants": ["release", "asan", "tsan"],


### PR DESCRIPTION
gfx950 nodes restored to the pool.

This reverts commit 6d964adcf0b9194349a4c435f780dfa27130192f.
