### PR TITLE
Add rmtree_with_retry to more functions to help Windows build flakes

### DIFF
--- a/build_tools/_therock_utils/os_util.py
+++ b/build_tools/_therock_utils/os_util.py
@@ -3,7 +3,8 @@
 
 """OS-level utility functions.
 
-Workarounds for platform-specific quirks, particularly Windows file locking.
+These include workarounds for platform-specific quirks, particularly Windows
+file locking.
 """
 
 from pathlib import Path
@@ -11,7 +12,7 @@ import shutil
 import sys
 import time
 
-# Maximum number of attempts to retry removing a directory on Windows.
+# Maximum number of attempts to retry removing a directory.
 RMTREE_MAX_ATTEMPTS: int = 10
 # Base delay between retry attempts in seconds (multiplied by attempt + 2).
 RMTREE_RETRY_DELAY_SECONDS: float = 0.5
@@ -24,10 +25,10 @@ def rmtree_with_retry(
     max_attempts: int = RMTREE_MAX_ATTEMPTS,
     retry_delay_seconds: float = RMTREE_RETRY_DELAY_SECONDS,
 ) -> None:
-    """Remove a directory tree, retrying on PermissionError (Windows file locks).
+    """Remove a directory tree, retrying on PermissionError (e.g. Windows locks).
 
     On Windows, files may be temporarily locked by antivirus scanners, search
-    indexers, or other processes.  A short retry loop avoids flaky failures in
+    indexers, or other processes. A short retry loop avoids flaky failures in
     CI builds where parallel jobs can hold transient file handles.
     """
     for attempt in range(max_attempts):

--- a/build_tools/_therock_utils/os_util.py
+++ b/build_tools/_therock_utils/os_util.py
@@ -1,0 +1,54 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""OS-level utility functions.
+
+Workarounds for platform-specific quirks, particularly Windows file locking.
+"""
+
+from pathlib import Path
+import shutil
+import sys
+import time
+
+# Maximum number of attempts to retry removing a directory on Windows.
+RMTREE_MAX_ATTEMPTS: int = 10
+# Base delay between retry attempts in seconds (multiplied by attempt + 2).
+RMTREE_RETRY_DELAY_SECONDS: float = 0.5
+
+
+def rmtree_with_retry(
+    path: Path,
+    *,
+    verbose: bool = False,
+    max_attempts: int = RMTREE_MAX_ATTEMPTS,
+    retry_delay_seconds: float = RMTREE_RETRY_DELAY_SECONDS,
+) -> None:
+    """Remove a directory tree, retrying on PermissionError (Windows file locks).
+
+    On Windows, files may be temporarily locked by antivirus scanners, search
+    indexers, or other processes.  A short retry loop avoids flaky failures in
+    CI builds where parallel jobs can hold transient file handles.
+    """
+    for attempt in range(max_attempts):
+        try:
+            shutil.rmtree(path)
+            if verbose:
+                print(f"rmtree {path}", file=sys.stderr)
+            return
+        except PermissionError:
+            wait_time = retry_delay_seconds * (attempt + 2)
+            if verbose:
+                print(
+                    f"PermissionError calling shutil.rmtree('{path}') "
+                    f"retrying after {wait_time}s",
+                    file=sys.stderr,
+                )
+            time.sleep(wait_time)
+            if attempt == max_attempts - 1:
+                if verbose:
+                    print(
+                        f"rmtree failed after {max_attempts} attempts, failing",
+                        file=sys.stderr,
+                    )
+                raise

--- a/build_tools/_therock_utils/pattern_match.py
+++ b/build_tools/_therock_utils/pattern_match.py
@@ -9,7 +9,8 @@ import platform
 import re
 import shutil
 import sys
-import time
+
+from .os_util import rmtree_with_retry
 
 _IS_WINDOWS = platform.system() == "Windows"
 
@@ -137,10 +138,6 @@ class MatchPredicate:
 
 
 class PatternMatcher:
-    # Maximum number of attempts to retry removing the destination directory
-    max_attempts: int = 5
-    # Delay between retry attempts in seconds
-    retry_delay_seconds: float = 0.2
 
     def __init__(
         self,
@@ -193,7 +190,7 @@ class PatternMatcher:
         remove_dest: bool = True,
     ):
         if remove_dest and destdir.exists():
-            self._rmtree_with_retry(destdir, verbose)
+            rmtree_with_retry(destdir, verbose=verbose)
         destdir.mkdir(parents=True, exist_ok=True)
 
         # Inode tracking for _copy_preserving_hardlink_groups.
@@ -220,31 +217,6 @@ class PatternMatcher:
             finally:
                 if verbose:
                     print("", file=sys.stderr)
-
-    def _rmtree_with_retry(self, path: Path, verbose: bool) -> None:
-        for attempt in range(self.max_attempts):
-            try:
-                shutil.rmtree(path)
-                if verbose:
-                    print(f"rmtree {path}", file=sys.stderr)
-                return
-            except PermissionError:
-                wait_time = self.retry_delay_seconds * (attempt + 2)
-                if verbose:
-                    print(
-                        f"PermissionError calling shutil.rmtree('{path}') "
-                        f"retrying after {wait_time}s",
-                        file=sys.stderr,
-                    )
-                time.sleep(wait_time)
-                if attempt == self.max_attempts - 1:
-                    if verbose:
-                        print(
-                            f"rmtree failed after {self.max_attempts} "
-                            f"attempts, failing",
-                            file=sys.stderr,
-                        )
-                    raise
 
     @staticmethod
     def _copy_symlink(

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -55,6 +55,7 @@ import time
 from pathlib import Path
 from typing import List, Optional, Set
 
+from _therock_utils.os_util import rmtree_with_retry
 from _therock_utils.cmake_amdgpu_targets import (
     amdgpu_family_map,
     expand_families,
@@ -282,7 +283,7 @@ class BootstrappingPopulator(ArtifactPopulator):
 
             # Do cleanup while holding lock to prevent race with extraction
             if full_path.exists():
-                shutil.rmtree(full_path)
+                rmtree_with_retry(full_path)
             # Write the ".prebuilt" marker file
             prebuilt_path = full_path.with_name(full_path.name + ".prebuilt")
             prebuilt_path.parent.mkdir(parents=True, exist_ok=True)
@@ -317,7 +318,7 @@ def extract_artifact(request: ExtractRequest) -> Optional[Path]:
         else:
             output_dir = request.output_dir / artifact_name
             if output_dir.exists():
-                shutil.rmtree(output_dir)
+                rmtree_with_retry(output_dir)
             log(f"  ++ Extracting {archive_path.name}")
             with _open_archive_for_read(archive_path) as tf:
                 tf.extractall(output_dir, filter="tar")
@@ -467,7 +468,7 @@ def do_fetch(args: argparse.Namespace):
 
     # Cleanup download cache (skip when using a shared cache dir)
     if download_dir.exists() and not args.no_extract and not shared_cache:
-        shutil.rmtree(download_dir)
+        rmtree_with_retry(download_dir)
 
     # Fail if any downloads failed
     total_requested = len(download_requests)
@@ -728,7 +729,7 @@ def do_push(args: argparse.Namespace):
 
     # Cleanup upload cache
     if upload_dir.exists():
-        shutil.rmtree(upload_dir)
+        rmtree_with_retry(upload_dir)
 
     # Fail if any artifacts failed to upload
     if uploaded_count < total_artifacts:

--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -39,6 +39,7 @@ import shutil
 import sys
 
 from _therock_utils.artifact_backend import ArtifactBackend, S3Backend
+from _therock_utils.os_util import rmtree_with_retry
 from _therock_utils.artifacts import (
     ArtifactName,
     ArtifactPopulator,
@@ -164,7 +165,7 @@ def extract_artifact(
     if postprocess_mode == "extract":
         output_dir = archive_file.parent / artifact_name
         if output_dir.exists():
-            shutil.rmtree(output_dir)
+            rmtree_with_retry(output_dir)
         with _open_archive_for_read(archive_file) as tf:
             log(f"++ Extracting '{archive_file.name}' to '{artifact_name}'")
             tf.extractall(archive_file.parent / artifact_name, filter="tar")

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -20,12 +20,12 @@ from typing import Callable
 import argparse
 from pathlib import Path
 import sys
-import shutil
 import tarfile
 
 from _therock_utils.artifacts import ArtifactPopulator
 import _therock_utils.artifact_builder as artifact_builder
 from _therock_utils.hash_util import calculate_hash, write_hash
+from _therock_utils.os_util import rmtree_with_retry
 from _therock_utils.pattern_match import PatternMatcher
 
 
@@ -68,7 +68,7 @@ def do_artifact(args):
 
         # Setup output dir.
         if output_dir.exists():
-            shutil.rmtree(output_dir)
+            rmtree_with_retry(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
 
         try:

--- a/build_tools/tests/os_util_test.py
+++ b/build_tools/tests/os_util_test.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from _therock_utils.os_util import rmtree_with_retry
+
+IS_WINDOWS = platform.system() == "Windows"
+
+# Script that holds a file open WITHOUT FILE_SHARE_DELETE, preventing deletion.
+# This simulates how antivirus scanners, search indexers, or loaded DLLs hold
+# files on Windows.
+_HOLD_FILE_SCRIPT = textwrap.dedent(
+    """\
+    import ctypes
+    import sys
+    import time
+    from ctypes import wintypes
+
+    CreateFileW = ctypes.windll.kernel32.CreateFileW
+    CreateFileW.restype = wintypes.HANDLE
+    CloseHandle = ctypes.windll.kernel32.CloseHandle
+
+    GENERIC_READ = 0x80000000
+    FILE_SHARE_READ = 0x00000001
+    # No FILE_SHARE_DELETE - prevents deletion while handle is open
+    OPEN_EXISTING = 3
+    INVALID_HANDLE_VALUE = wintypes.HANDLE(-1).value
+
+    path = sys.argv[1]
+    hold_seconds = float(sys.argv[2])
+
+    handle = CreateFileW(path, GENERIC_READ, FILE_SHARE_READ, None, OPEN_EXISTING, 0, None)
+    if handle == INVALID_HANDLE_VALUE:
+        sys.exit(f"CreateFileW failed for {path}")
+
+    # Signal readiness
+    print("READY", flush=True)
+    time.sleep(hold_seconds)
+    CloseHandle(handle)
+"""
+)
+
+
+def _start_holder(file_path: Path, hold_seconds: float) -> subprocess.Popen:
+    """Start a subprocess that holds *file_path* open without FILE_SHARE_DELETE."""
+    holder = subprocess.Popen(
+        [sys.executable, "-c", _HOLD_FILE_SCRIPT, str(file_path), str(hold_seconds)],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    line = holder.stdout.readline().strip()
+    assert line == "READY", f"holder subprocess failed to start: {line!r}"
+    return holder
+
+
+class RmtreeWithRetryTest(unittest.TestCase):
+    def test_removes_directory(self):
+        """Basic case: removes a directory with no locks."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "subdir"
+            target.mkdir()
+            (target / "file.txt").write_text("hello")
+            rmtree_with_retry(target)
+            self.assertFalse(target.exists())
+
+    def test_raises_on_nonexistent(self):
+        """Raises FileNotFoundError for a path that doesn't exist."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "does_not_exist"
+            with self.assertRaises(FileNotFoundError):
+                rmtree_with_retry(target)
+
+    @unittest.skipUnless(IS_WINDOWS, "Windows file locking behavior")
+    def test_retries_on_locked_file(self):
+        """rmtree_with_retry succeeds after a transient file lock is released."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "subdir"
+            target.mkdir()
+            locked_file = target / "locked.txt"
+            locked_file.write_text("data")
+
+            holder = _start_holder(locked_file, hold_seconds=1)
+            try:
+                # Bare shutil.rmtree should fail while the file is locked.
+                with self.assertRaises(PermissionError):
+                    shutil.rmtree(target)
+
+                # rmtree_with_retry should succeed after the subprocess releases.
+                rmtree_with_retry(target, max_attempts=10, retry_delay_seconds=0.2)
+                self.assertFalse(target.exists())
+            finally:
+                holder.wait()
+
+    @unittest.skipUnless(IS_WINDOWS, "Windows file locking behavior")
+    def test_gives_up_after_max_attempts(self):
+        """Raises PermissionError if the lock outlasts the retry window."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "subdir"
+            target.mkdir()
+            locked_file = target / "locked.txt"
+            locked_file.write_text("data")
+
+            holder = _start_holder(locked_file, hold_seconds=10)
+            try:
+                with self.assertRaises(PermissionError):
+                    rmtree_with_retry(target, max_attempts=2, retry_delay_seconds=0.1)
+            finally:
+                holder.terminate()
+                holder.wait()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

We've had a few flaky builds and adding retries to some of these known-brittle code paths _might_ help, see
* https://github.com/ROCm/TheRock/issues/481
* https://github.com/ROCm/TheRock/issues/5024

This expands the retry code added in https://github.com/ROCm/TheRock/pull/1631 to a few more call sites and adds a new unit test that demonstrates the operating system issue.

## Technical Details

I'm not confident that retries will be sufficient here, and they may mask actual build errors. We'll have add more complete logging and then monitor those logs.

## Test Plan

* Check that the new unit tests pass with the retry behavior
* Check that the new unit tests fail without the retry behavior:
    ```
    build_tools\tests\os_util_test.py:96:
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ build_tools\_therock_utils\os_util.py:33: in rmtree_with_retry
        shutil.rmtree(path)
    C:\Users\Nod-Shark16\AppData\Local\Programs\Python\Python313\Lib\shutil.py:790: in rmtree
        return _rmtree_unsafe(path, onexc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    C:\Users\Nod-Shark16\AppData\Local\Programs\Python\Python313\Lib\shutil.py:629: in _rmtree_unsafe
        onexc(os.unlink, fullname, err)
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
    
    path = WindowsPath('C:/Users/NOD-SH~1/AppData/Local/Temp/tmpxst6f026/subdir')
    onexc = <function rmtree.<locals>.onexc at 0x0000022B8FA291C0>
    
        def _rmtree_unsafe(path, onexc):
            def onerror(err):
                if not isinstance(err, FileNotFoundError):
                    onexc(os.scandir, err.filename, err)
            results = os.walk(path, topdown=False, onerror=onerror, followlinks=os._walk_symlinks_as_files)
            for dirpath, dirnames, filenames in results:
                for name in dirnames:
                    fullname = os.path.join(dirpath, name)
                    try:
                        os.rmdir(fullname)
                    except FileNotFoundError:
                        continue
                    except OSError as err:
                        onexc(os.rmdir, fullname, err)
                for name in filenames:
                    fullname = os.path.join(dirpath, name)
                    try:
    >                   os.unlink(fullname)
    E                   PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\NOD-SH~1\\AppData\\Local\\Temp\\tmpxst6f026\\subdir\\locked.txt'
    
    C:\Users\Nod-Shark16\AppData\Local\Programs\Python\Python313\Lib\shutil.py:625: PermissionError
    =============================================== short test summary info =============================================== FAILED build_tools\tests\os_util_test.py::RmtreeWithRetryTest::test_retries_on_locked_file - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\...
    ============================================= 1 failed, 3 passed in 1.37s =============================================
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
