### PR TITLE
Consolidate zstd/xz archive helpers into archive_util.py

### DIFF
--- a/build_tools/_therock_utils/archive_util.py
+++ b/build_tools/_therock_utils/archive_util.py
@@ -6,17 +6,8 @@
 from pathlib import Path
 import tarfile
 
-# Maps open_archive mode to the binary mode for ZstdFile and the tarfile mode
-# string for xz archives.
-_MODES = {
-    "r": {"zstd": "rb", "xz": "r:xz"},
-    "w": {"zstd": "wb", "xz": "x:xz"},
-}
 
-_DEFAULT_LEVELS = {"zstd": 3, "xz": 6}
-
-
-def get_pyzstd():
+def _get_pyzstd():
     """Lazy import pyzstd with helpful error message."""
     try:
         import pyzstd
@@ -38,65 +29,41 @@ class ZstdTarFile(tarfile.TarFile):
     """
 
     def __init__(self, path: Path, mode: str = "rb", **zstd_kwargs) -> None:
-        pyzstd = get_pyzstd()
+        pyzstd = _get_pyzstd()
         self._zstd_file = pyzstd.ZstdFile(path, mode=mode, **zstd_kwargs)
+
+        # Trim mode from ZstdFile format to TarFile format
+        #   * https://pyzstd.readthedocs.io/en/stable/pyzstd.html#open
+        #   * https://docs.python.org/3/library/tarfile.html#tarfile.open
         # "rb" -> "r", "wb" -> "w"
-        super().__init__(fileobj=self._zstd_file, mode=mode[0])
+        mode_tarfile = mode[0]
+
+        super().__init__(fileobj=self._zstd_file, mode=mode_tarfile)
 
     def close(self) -> None:
         super().close()
         self._zstd_file.close()
 
 
-def _infer_compression_type(path: Path) -> str:
-    name = path.name
-    if name.endswith(".tar.zst"):
-        return "zstd"
-    elif name.endswith(".tar.xz"):
-        return "xz"
-    raise ValueError(f"Cannot infer compression type from: {path}")
-
-
-def open_archive(
-    path: Path,
-    mode: str = "r",
-    *,
-    compression_type: str | None = None,
-    compression_level: int | None = None,
-) -> tarfile.TarFile:
-    """Open a tar archive for reading or writing.
-
-    Args:
-        path: Path to the archive file.
-        mode: "r" for reading, "w" for writing.
-        compression_type: "zstd" or "xz". Inferred from the file extension
-            if not provided.
-        compression_level: Compression level (write only). Defaults to 3 for
-            zstd, 6 for xz.
-    """
-    if compression_type is None:
-        compression_type = _infer_compression_type(path)
-
-    mode_map = _MODES.get(mode)
-    if mode_map is None:
-        raise ValueError(f"Unsupported mode: {mode!r} (expected 'r' or 'w')")
-    if compression_type not in mode_map:
-        raise ValueError(f"Unknown compression type: {compression_type!r}")
-
-    if compression_type == "zstd":
-        kwargs = {}
-        if compression_level is not None:
-            kwargs["level_or_option"] = compression_level
-        elif mode == "w":
-            kwargs["level_or_option"] = _DEFAULT_LEVELS["zstd"]
-        return ZstdTarFile(path, mode_map["zstd"], **kwargs)
+def open_archive_for_read(path: Path) -> tarfile.TarFile:
+    """Open a tar archive for reading, auto-detecting compression from extension."""
+    if path.name.endswith(".tar.zst"):
+        return ZstdTarFile(path, mode="rb")
+    elif path.name.endswith(".tar.xz"):
+        return tarfile.TarFile.open(path, mode="r:xz")
     else:
-        level = (
-            compression_level
-            if compression_level is not None
-            else _DEFAULT_LEVELS[compression_type]
-        )
-        if mode == "r":
-            return tarfile.TarFile.open(path, mode=mode_map["xz"])
-        else:
-            return tarfile.TarFile.open(path, mode=mode_map["xz"], preset=level)
+        raise ValueError(f"Unknown archive format: {path}")
+
+
+def open_archive_for_write(
+    path: Path, compression_type: str, compression_level: int | None = None
+) -> tarfile.TarFile:
+    """Open a tar archive for writing with the specified compression."""
+    if compression_type == "zstd":
+        level = compression_level if compression_level is not None else 3
+        return ZstdTarFile(path, "wb", level_or_option=level)
+    elif compression_type == "xz":
+        level = compression_level if compression_level is not None else 6
+        return tarfile.TarFile.open(path, mode="x:xz", preset=level)
+    else:
+        raise ValueError(f"Unknown compression type: {compression_type}")

--- a/build_tools/_therock_utils/archive_util.py
+++ b/build_tools/_therock_utils/archive_util.py
@@ -1,0 +1,102 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Utilities for reading and writing zstd/xz compressed tar archives."""
+
+from pathlib import Path
+import tarfile
+
+# Maps open_archive mode to the binary mode for ZstdFile and the tarfile mode
+# string for xz archives.
+_MODES = {
+    "r": {"zstd": "rb", "xz": "r:xz"},
+    "w": {"zstd": "wb", "xz": "x:xz"},
+}
+
+_DEFAULT_LEVELS = {"zstd": 3, "xz": 6}
+
+
+def get_pyzstd():
+    """Lazy import pyzstd with helpful error message."""
+    try:
+        import pyzstd
+
+        return pyzstd
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
+            "pyzstd is required for zstd artifact compression. "
+            "Install it with: pip install pyzstd"
+        )
+
+
+class ZstdTarFile(tarfile.TarFile):
+    """TarFile wrapper that manages the underlying ZstdFile lifetime.
+
+    When TarFile receives a fileobj it did not open, it does not close it.
+    This leaves the OS file handle open, which on Windows prevents subsequent
+    os.unlink() calls from succeeding.
+    """
+
+    def __init__(self, path: Path, mode: str = "rb", **zstd_kwargs) -> None:
+        pyzstd = get_pyzstd()
+        self._zstd_file = pyzstd.ZstdFile(path, mode=mode, **zstd_kwargs)
+        # "rb" -> "r", "wb" -> "w"
+        super().__init__(fileobj=self._zstd_file, mode=mode[0])
+
+    def close(self) -> None:
+        super().close()
+        self._zstd_file.close()
+
+
+def _infer_compression_type(path: Path) -> str:
+    name = path.name
+    if name.endswith(".tar.zst"):
+        return "zstd"
+    elif name.endswith(".tar.xz"):
+        return "xz"
+    raise ValueError(f"Cannot infer compression type from: {path}")
+
+
+def open_archive(
+    path: Path,
+    mode: str = "r",
+    *,
+    compression_type: str | None = None,
+    compression_level: int | None = None,
+) -> tarfile.TarFile:
+    """Open a tar archive for reading or writing.
+
+    Args:
+        path: Path to the archive file.
+        mode: "r" for reading, "w" for writing.
+        compression_type: "zstd" or "xz". Inferred from the file extension
+            if not provided.
+        compression_level: Compression level (write only). Defaults to 3 for
+            zstd, 6 for xz.
+    """
+    if compression_type is None:
+        compression_type = _infer_compression_type(path)
+
+    mode_map = _MODES.get(mode)
+    if mode_map is None:
+        raise ValueError(f"Unsupported mode: {mode!r} (expected 'r' or 'w')")
+    if compression_type not in mode_map:
+        raise ValueError(f"Unknown compression type: {compression_type!r}")
+
+    if compression_type == "zstd":
+        kwargs = {}
+        if compression_level is not None:
+            kwargs["level_or_option"] = compression_level
+        elif mode == "w":
+            kwargs["level_or_option"] = _DEFAULT_LEVELS["zstd"]
+        return ZstdTarFile(path, mode_map["zstd"], **kwargs)
+    else:
+        level = (
+            compression_level
+            if compression_level is not None
+            else _DEFAULT_LEVELS[compression_type]
+        )
+        if mode == "r":
+            return tarfile.TarFile.open(path, mode=mode_map["xz"])
+        else:
+            return tarfile.TarFile.open(path, mode=mode_map["xz"], preset=level)

--- a/build_tools/_therock_utils/artifacts.py
+++ b/build_tools/_therock_utils/artifacts.py
@@ -28,34 +28,9 @@ from typing import Callable, Optional, Sequence
 import os
 import re
 from pathlib import Path, PurePosixPath
-import tarfile
 
+from .archive_util import open_archive
 from .pattern_match import PatternMatcher, MatchPredicate
-
-
-def _get_pyzstd():
-    """Lazy import pyzstd with helpful error message."""
-    try:
-        import pyzstd
-
-        return pyzstd
-    except ModuleNotFoundError:
-        raise ModuleNotFoundError(
-            "pyzstd is required for zstd artifact decompression. "
-            "Install it with: pip install pyzstd"
-        )
-
-
-def _open_archive_for_read(path: Path) -> tarfile.TarFile:
-    """Open a tar archive for reading, auto-detecting compression type."""
-    if path.name.endswith(".tar.zst"):
-        pyzstd = _get_pyzstd()
-        zstd_file = pyzstd.ZstdFile(path, mode="rb")
-        return tarfile.TarFile(fileobj=zstd_file, mode="r")
-    elif path.name.endswith(".tar.xz"):
-        return tarfile.TarFile.open(path, mode="r:xz")
-    else:
-        raise ValueError(f"Unknown archive format: {path}")
 
 
 class ArtifactName:
@@ -209,7 +184,7 @@ class ArtifactPopulator:
                     pm.copy_to(destdir=destdir, verbose=self.verbose, remove_dest=False)
             else:
                 # Process as an archive file.
-                with _open_archive_for_read(artifact_path) as tf:
+                with open_archive(artifact_path) as tf:
                     self.on_artifact_archive(artifact_path)
                     # Read manifest first.
                     manifest_member = tf.next()

--- a/build_tools/_therock_utils/artifacts.py
+++ b/build_tools/_therock_utils/artifacts.py
@@ -29,7 +29,7 @@ import os
 import re
 from pathlib import Path, PurePosixPath
 
-from .archive_util import open_archive
+from .archive_util import open_archive_for_read
 from .pattern_match import PatternMatcher, MatchPredicate
 
 
@@ -184,7 +184,7 @@ class ArtifactPopulator:
                     pm.copy_to(destdir=destdir, verbose=self.verbose, remove_dest=False)
             else:
                 # Process as an archive file.
-                with open_archive(artifact_path) as tf:
+                with open_archive_for_read(artifact_path) as tf:
                     self.on_artifact_archive(artifact_path)
                     # Read manifest first.
                     manifest_member = tf.next()

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -54,7 +54,7 @@ import time
 from pathlib import Path
 from typing import List, Optional, Set
 
-from _therock_utils.archive_util import open_archive
+from _therock_utils.archive_util import open_archive_for_read
 from _therock_utils.cmake_amdgpu_targets import (
     amdgpu_family_map,
     expand_families,
@@ -294,7 +294,7 @@ def extract_artifact(request: ExtractRequest) -> Optional[Path]:
             if output_dir.exists():
                 shutil.rmtree(output_dir)
             log(f"  ++ Extracting {archive_path.name}")
-            with open_archive(archive_path) as tf:
+            with open_archive_for_read(archive_path) as tf:
                 tf.extractall(output_dir, filter="tar")
 
         if request.delete_archive:

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -49,12 +49,12 @@ import os
 import platform as platform_module
 import shutil
 import sys
-import tarfile
 import threading
 import time
 from pathlib import Path
 from typing import List, Optional, Set
 
+from _therock_utils.archive_util import open_archive
 from _therock_utils.cmake_amdgpu_targets import (
     amdgpu_family_map,
     expand_families,
@@ -82,31 +82,6 @@ def log(msg: str):
 def _delay_for_retry(seconds: float):
     """Sleep for retry delay. Mockable for testing."""
     time.sleep(seconds)
-
-
-def _get_pyzstd():
-    """Lazy import pyzstd with helpful error message."""
-    try:
-        import pyzstd
-
-        return pyzstd
-    except ModuleNotFoundError:
-        raise ModuleNotFoundError(
-            "pyzstd is required for zstd artifact decompression. "
-            "Install it with: pip install pyzstd"
-        )
-
-
-def _open_archive_for_read(path: Path) -> tarfile.TarFile:
-    """Open a tar archive for reading, auto-detecting compression type."""
-    if path.name.endswith(".tar.zst"):
-        pyzstd = _get_pyzstd()
-        zstd_file = pyzstd.ZstdFile(path, mode="rb")
-        return tarfile.TarFile(fileobj=zstd_file, mode="r")
-    elif path.name.endswith(".tar.xz"):
-        return tarfile.TarFile.open(path, mode="r:xz")
-    else:
-        raise ValueError(f"Unknown archive format: {path}")
 
 
 def get_default_topology_path() -> Path:
@@ -319,7 +294,7 @@ def extract_artifact(request: ExtractRequest) -> Optional[Path]:
             if output_dir.exists():
                 shutil.rmtree(output_dir)
             log(f"  ++ Extracting {archive_path.name}")
-            with _open_archive_for_read(archive_path) as tf:
+            with open_archive(archive_path) as tf:
                 tf.extractall(output_dir, filter="tar")
 
         if request.delete_archive:

--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -38,7 +38,7 @@ import re
 import shutil
 import sys
 
-from _therock_utils.archive_util import open_archive
+from _therock_utils.archive_util import open_archive_for_read
 from _therock_utils.artifact_backend import ArtifactBackend, S3Backend
 from _therock_utils.artifacts import (
     ArtifactName,
@@ -165,7 +165,7 @@ def extract_artifact(
         output_dir = archive_file.parent / artifact_name
         if output_dir.exists():
             shutil.rmtree(output_dir)
-        with open_archive(archive_file) as tf:
+        with open_archive_for_read(archive_file) as tf:
             log(f"++ Extracting '{archive_file.name}' to '{artifact_name}'")
             tf.extractall(archive_file.parent / artifact_name, filter="tar")
     elif postprocess_mode == "flatten":

--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -38,11 +38,11 @@ import re
 import shutil
 import sys
 
+from _therock_utils.archive_util import open_archive
 from _therock_utils.artifact_backend import ArtifactBackend, S3Backend
 from _therock_utils.artifacts import (
     ArtifactName,
     ArtifactPopulator,
-    _open_archive_for_read,
 )
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 from artifact_manager import DownloadRequest, download_artifact
@@ -165,7 +165,7 @@ def extract_artifact(
         output_dir = archive_file.parent / artifact_name
         if output_dir.exists():
             shutil.rmtree(output_dir)
-        with _open_archive_for_read(archive_file) as tf:
+        with open_archive(archive_file) as tf:
             log(f"++ Extracting '{archive_file.name}' to '{artifact_name}'")
             tf.extractall(archive_file.parent / artifact_name, filter="tar")
     elif postprocess_mode == "flatten":

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import sys
 import shutil
 
-from _therock_utils.archive_util import open_archive
+from _therock_utils.archive_util import open_archive_for_write
 from _therock_utils.artifacts import ArtifactPopulator
 import _therock_utils.artifact_builder as artifact_builder
 from _therock_utils.hash_util import calculate_hash, write_hash
@@ -84,11 +84,8 @@ def do_artifact_archive(args):
         output_path.unlink()
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with open_archive(
-        output_path,
-        "w",
-        compression_type=args.compression_type,
-        compression_level=args.compression_level,
+    with open_archive_for_write(
+        output_path, args.compression_type, args.compression_level
     ) as arc:
         for artifact_path in args.artifact:
             manifest_path: Path = artifact_path / "artifact_manifest.txt"

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -21,8 +21,8 @@ import argparse
 from pathlib import Path
 import sys
 import shutil
-import tarfile
 
+from _therock_utils.archive_util import open_archive
 from _therock_utils.artifacts import ArtifactPopulator
 import _therock_utils.artifact_builder as artifact_builder
 from _therock_utils.hash_util import calculate_hash, write_hash
@@ -84,8 +84,11 @@ def do_artifact_archive(args):
         output_path.unlink()
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with _open_archive(
-        output_path, args.compression_type, args.compression_level
+    with open_archive(
+        output_path,
+        "w",
+        compression_type=args.compression_type,
+        compression_level=args.compression_level,
     ) as arc:
         for artifact_path in args.artifact:
             manifest_path: Path = artifact_path / "artifact_manifest.txt"
@@ -107,47 +110,6 @@ def do_artifact_archive(args):
     if args.hash_file:
         digest = calculate_hash(output_path, args.hash_algorithm)
         write_hash(args.hash_file, digest)
-
-
-def _get_pyzstd():
-    """Lazy import pyzstd with helpful error message."""
-    try:
-        import pyzstd
-
-        return pyzstd
-    except ModuleNotFoundError:
-        raise ModuleNotFoundError(
-            "pyzstd is required for zstd compression. "
-            "Install it with: pip install pyzstd"
-        )
-
-
-class _ZstdTarFile(tarfile.TarFile):
-    """TarFile wrapper that writes to a zstd-compressed file."""
-
-    def __init__(self, path: Path, compression_level: int) -> None:
-        pyzstd = _get_pyzstd()
-        self._zstd_file = pyzstd.ZstdFile(
-            path, mode="wb", level_or_option=compression_level
-        )
-        super().__init__(fileobj=self._zstd_file, mode="w")
-
-    def close(self) -> None:
-        super().close()
-        self._zstd_file.close()
-
-
-def _open_archive(
-    p: Path, compression_type: str, compression_level: int | None
-) -> tarfile.TarFile:
-    if compression_type == "zstd":
-        level = compression_level if compression_level is not None else 3
-        return _ZstdTarFile(p, level)
-    elif compression_type == "xz":
-        level = compression_level if compression_level is not None else 6
-        return tarfile.TarFile.open(p, mode="x:xz", preset=level)
-    else:
-        raise ValueError(f"Unknown compression type: {compression_type}")
 
 
 def _do_artifact_flatten(args):

--- a/build_tools/tests/archive_util_test.py
+++ b/build_tools/tests/archive_util_test.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import os
+import platform
+import tempfile
+import unittest
+from pathlib import Path
+
+from _therock_utils.archive_util import (
+    open_archive_for_read,
+    open_archive_for_write,
+)
+
+IS_WINDOWS = platform.system() == "Windows"
+
+
+class ArchiveRoundtripTest(unittest.TestCase):
+    """Test writing and reading archives for each compression type."""
+
+    def _roundtrip(self, suffix: str, compression_type: str):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+
+            # Create a source file to archive.
+            src = tmp / "hello.txt"
+            src.write_text("hello world")
+
+            # Write archive.
+            archive = tmp / f"test.tar.{suffix}"
+            with open_archive_for_write(archive, compression_type) as arc:
+                arc.add(str(src), arcname="hello.txt")
+
+            self.assertTrue(archive.exists())
+
+            # Read archive and verify contents.
+            with open_archive_for_read(archive) as arc:
+                members = arc.getnames()
+                self.assertIn("hello.txt", members)
+
+    def test_roundtrip_zstd(self):
+        self._roundtrip("zst", "zstd")
+
+    def test_roundtrip_xz(self):
+        self._roundtrip("xz", "xz")
+
+    def test_roundtrip_zstd_custom_level(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            src = tmp / "hello.txt"
+            src.write_text("hello world")
+
+            archive = tmp / "test.tar.zst"
+            with open_archive_for_write(archive, "zstd", compression_level=1) as arc:
+                arc.add(str(src), arcname="hello.txt")
+
+            with open_archive_for_read(archive) as arc:
+                self.assertIn("hello.txt", arc.getnames())
+
+
+class HandleLeakTest(unittest.TestCase):
+    """Verify that closing a ZstdTarFile releases the OS file handle."""
+
+    @unittest.skipUnless(IS_WINDOWS, "Handle leak only blocks deletion on Windows")
+    def test_zstd_read_close_releases_handle(self):
+        """After closing a zstd archive opened for read, the file can be deleted."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            src = tmp / "hello.txt"
+            src.write_text("hello world")
+
+            archive = tmp / "test.tar.zst"
+            with open_archive_for_write(archive, "zstd") as arc:
+                arc.add(str(src), arcname="hello.txt")
+
+            # Open for read, close, then delete.
+            tf = open_archive_for_read(archive)
+            tf.getnames()
+            tf.close()
+
+            # This would raise PermissionError if the handle leaked.
+            os.unlink(archive)
+            self.assertFalse(archive.exists())
+
+    @unittest.skipUnless(IS_WINDOWS, "Handle leak only blocks deletion on Windows")
+    def test_zstd_write_close_releases_handle(self):
+        """After closing a zstd archive opened for write, the file can be deleted."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            src = tmp / "hello.txt"
+            src.write_text("hello world")
+
+            archive = tmp / "test.tar.zst"
+            tf = open_archive_for_write(archive, "zstd")
+            tf.add(str(src), arcname="hello.txt")
+            tf.close()
+
+            os.unlink(archive)
+            self.assertFalse(archive.exists())
+
+
+class ErrorHandlingTest(unittest.TestCase):
+    def test_read_unknown_extension(self):
+        with self.assertRaises(ValueError):
+            open_archive_for_read(Path("test.tar.gz"))
+
+    def test_write_unknown_compression(self):
+        with self.assertRaises(ValueError):
+            open_archive_for_write(Path("test.tar.gz"), "gzip")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_artifact_structure.py
+++ b/tests/test_artifact_structure.py
@@ -38,7 +38,8 @@ import pytest
 THIS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(THIS_DIR.parent / "build_tools"))
 
-from _therock_utils.artifacts import ArtifactName, _open_archive_for_read
+from _therock_utils.artifacts import ArtifactName
+from _therock_utils.archive_util import open_archive_for_read
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +69,7 @@ def list_archive_files(archive_path: Path) -> tuple[list[str], list[str]]:
     prefixes: list[str] = []
     flattened: list[str] = []
 
-    with _open_archive_for_read(archive_path) as tf:
+    with open_archive_for_read(archive_path) as tf:
         # Extract prefixes from the artifact manifest.
         manifest_member = tf.next()
         if manifest_member is None or manifest_member.name != "artifact_manifest.txt":


### PR DESCRIPTION
## Motivation

This fixes an archive extraction race on Windows.

## Technical Details

On https://github.com/ROCm/TheRock/pull/4771, I found a consistently triggered race condition in archive extraction of `.tar.zst` files using `fetch_artifacts.py` on non-multi-arch CI that is not present in our usage from `artifact_manager.py` in multi-arch CI: https://github.com/ROCm/TheRock/actions/runs/25123843788/job/73676411055?pr=4771#step:5:357

```
++ Extracting 'prim_test_gfx120X-all.tar.zst' to 'prim_test_gfx120X-all'
++ Extracting 'amd-llvm_run_generic.tar.zst' to 'amd-llvm_run_generic'
Traceback (most recent call last):
  File "C:\home\runner\_work\TheRock\TheRock\build_tools\fetch_artifacts.py", line 386, in <module>
    main(sys.argv[1:])
  File "C:\home\runner\_work\TheRock\TheRock\build_tools\fetch_artifacts.py", line 382, in main
    run(args)
  File "C:\home\runner\_work\TheRock\TheRock\build_tools\fetch_artifacts.py", line 280, in run
    [f.result() for f in extract_futures]
     ^^^^^^^^^^
  File "C:\home\runner\_work\_tool\Python\3.12.10\x64\Lib\concurrent\futures\_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "C:\home\runner\_work\_tool\Python\3.12.10\x64\Lib\concurrent\futures\_base.py", line 401, in __get_result
    raise self._exception
  File "C:\home\runner\_work\_tool\Python\3.12.10\x64\Lib\concurrent\futures\thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\home\runner\_work\TheRock\TheRock\build_tools\fetch_artifacts.py", line 182, in extract_artifact
    archive_file.unlink()
  File "C:\home\runner\_work\_tool\Python\3.12.10\x64\Lib\pathlib.py", line 1342, in unlink
    os.unlink(self)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\home\\runner\\_work\\TheRock\\TheRock\\artifacts\\base_run_generic.tar.zst'
Error: Process completed with exit code 1.
```

I trace this to the Zstdfile remaining open when the Tarfile is closed. We already had code for this in `fileset_tool.py`, but not in other files.

This was not seen before since:
* Non-multi-arch CI has been using `fetch_artifacts.py` for `.tar.xz` files and not `.tar.zst` files, with `--delete-after-extract` (my other PR changes this)
* Multi-arch CI has been using `artifact_manager.py`  for `.tar.zst` files with `delete_archive=False` (avoiding the race)

## Test Plan

* New unit tests should pass as-is
* New unit tests should fail if `self._zstd_file.close()` is removed:
    ```
                for name in filenames:
                    fullname = os.path.join(dirpath, name)
                    try:
    >                   os.unlink(fullname)
    E                   PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\NOD-SH~1\\AppData\\Local\\Temp\\tmpnpflkt9b\\test.tar.zst'
    
    C:\Users\Nod-Shark16\AppData\Local\Programs\Python\Python313\Lib\shutil.py:625: PermissionError
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
