### PR TITLE
[CI] Skip failing run_pytorch_tests_full.py UTs with release/2.11

### DIFF
--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -240,6 +240,11 @@ jobs:
           echo "CC=${ROCM_HOME}/lib/llvm/bin/clang" >> "${GITHUB_ENV}"
           echo "CXX=${ROCM_HOME}/lib/llvm/bin/clang++" >> "${GITHUB_ENV}"
 
+      - name: Install C++ build tools for PyTorch tests
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends build-essential
+
       # export_test_times.py must run from the PyTorch repo root with
       # PYTHONPATH=. because it imports internal PyTorch modules (e.g.
       # tools.stats.*) that expect the repo root on sys.path.

--- a/external-builds/pytorch/skip_tests/pytorch_2.11.py
+++ b/external-builds/pytorch/skip_tests/pytorch_2.11.py
@@ -67,6 +67,31 @@ skip_tests = {
         "torch": [
             "test_cpp_warnings_have_python_context_cuda",
         ],
+        "utils": [
+            # ROCm devel/runtime-dependent UT. Skip in the PyTorch full-suite lane;
+            # this is expected to run in the separate ROCm devel UT step.
+            "test_load_standalone",
+        ],
+        "multiprocessing": [
+            # ROCm devel/runtime-dependent UTs. Skip in the PyTorch full-suite
+            # lane; these are expected to run in the separate ROCm devel UT step.
+            "(test_fs and not test_fs_)",
+            "test_fs_is_shared",
+            "test_fs_pool",
+            "test_fs_preserve_sharing",
+            "test_fs_sharing",
+        ],
+        "serialization": [
+            # TestSerialization - NJT weights_only import check
+            # TestOldSerialization - CI env assertion
+            "test_debug_set_in_ci",
+        ],
+        "modules": [
+            # TestModuleCUDA - CTCLoss cpu/gpu parity scalar mismatch
+            "test_cpu_gpu_parity_nn_CTCLoss_cuda_float32",
+            # TestModuleCUDA - CTCLoss forward scalar mismatch
+            "test_forward_nn_CTCLoss_cuda_float32",
+        ],
     },
     "gfx942": {
         "cuda": [


### PR DESCRIPTION
## Motivation

- Add script to Install C++ build tools for PyTorch tests
- Skip the failing UTs when run PyTorch full tests

