### PR TITLE
Bump minimum MSVC version to 19.43 in docs and validate scripts

### DIFF
--- a/build_tools/hack/env_check/check_tools.py
+++ b/build_tools/hack/env_check/check_tools.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 from typing import Literal
 import os
+import re
 from pathlib import Path
 from abc import ABC
 from .utils import cstring, Emoji
@@ -657,6 +658,12 @@ class CheckLD(CheckProgram):
 
 
 class CheckMSVC(CheckProgram):
+    # Prebuilt libraries (e.g. wkmi.lib) may reference STL internals
+    # introduced in newer MSVC versions, causing LNK2019 errors on older
+    # toolchains.  Keep this in sync with validate_windows_install.ps1.
+    # See https://github.com/ROCm/TheRock/issues/5029
+    MIN_MSVC_VERSION = (19, 43)
+
     def __init__(self, required=True):
         super().__init__(required)
         self.program = FindMSVC()
@@ -718,9 +725,39 @@ class CheckMSVC(CheckProgram):
             _result = None
 
         else:
-            _stat = msg_stat("pass", self.name, f"Found MSVC {cl.version} at {cl.exe}")
-            _except = ""
-            _result = True
+            # Check minimum version. cl.version is e.g. "19.42.34436 (v143)".
+            _ver_match = re.match(r"(\d+)\.(\d+)", cl.version or "")
+            if (
+                _ver_match
+                and (
+                    int(_ver_match.group(1)),
+                    int(_ver_match.group(2)),
+                )
+                < self.MIN_MSVC_VERSION
+            ):
+                _min = ".".join(str(v) for v in self.MIN_MSVC_VERSION)
+                _stat = msg_stat(
+                    "err",
+                    self.name,
+                    f"MSVC {cl.version} is too old (>= {_min} required)",
+                )
+                _except = cstring(
+                    f"""
+    Prebuilt libraries require MSVC >= {_min} (Visual Studio 2022 17.13+).
+    Update Visual Studio or install a newer Build Tools version.
+
+        traceback: MSVC version too old
+            > expected >= {_min}, found {cl.version}
+    """,
+                    "err",
+                )
+                _result = None
+            else:
+                _stat = msg_stat(
+                    "pass", self.name, f"Found MSVC {cl.version} at {cl.exe}"
+                )
+                _except = ""
+                _result = True
 
         return _stat, _except, _result
 

--- a/build_tools/hack/env_check/check_tools.py
+++ b/build_tools/hack/env_check/check_tools.py
@@ -259,7 +259,6 @@ class CheckCMake(CheckProgram):
         self.name = "CMake"
 
     def check(self):
-        device = SystemInfo()
         if self.program.exe is None:
             _stat = msg_stat("err", "CMake", f"Cannot find CMake.")
             _except = cstring(
@@ -297,25 +296,6 @@ class CheckCMake(CheckProgram):
                 "warn",
             )
             _result = None
-        elif self.program.MAJOR_VERSION == 4 and device.is_windows:
-            _stat = msg_stat(
-                "warn",
-                "CMake",
-                f"Found CMake version {self.program.version} at {self.program.exe}",
-            )
-            _except = cstring(
-                f"""
-    The support of CMake 4 is still under development, and the different CMake version behavior may effect TheRock build.
-    If your build requires stable build, please downgrade it and re-try again.
-    You can find ROCm/TheRock latest required CMake here:
-        https://github.com/ROCm/TheRock/blob/main/docs/environment_setup_guide.md#common-issues
-
-        traceback: CMake program too new may cause unstable
-            expected: 3.25.X ≤ cmake ≤ 3.31.X, found {self.program.version}
-    """,
-                "warn",
-            )
-            _result = False
 
         else:
             _stat = msg_stat(

--- a/build_tools/validate_windows_install.ps1
+++ b/build_tools/validate_windows_install.ps1
@@ -219,12 +219,34 @@ try {
 # ============================================================================
 Write-Section "3. MSVC Compiler"
 
+$MinMsvcVersion = [Version]"19.43"
+
 $clCmd = Get-Command cl.exe -ErrorAction SilentlyContinue
 if ($clCmd) {
-    # cl.exe prints its version banner to stderr
-    $clBanner = (& cl.exe 2>&1 | Select-Object -First 1).ToString().Trim()
+    # cl.exe prints its version banner to stderr; capture it with
+    # ErrorAction Continue so SilentlyContinue doesn't swallow error records.
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    $clOutput = (& cl.exe 2>&1) | ForEach-Object { $_.ToString().Trim() }
+    $ErrorActionPreference = $prevEAP
+    $clBanner = ($clOutput | Select-Object -First 1)
     Write-Pass "cl.exe in PATH: $($clCmd.Source)"
     Write-Info $clBanner
+
+    # Check MSVC version meets minimum requirement.
+    # Prebuilt libraries (e.g. wkmi.lib) may reference STL internals introduced
+    # in newer MSVC versions, causing LNK2019 errors on older toolchains.
+    # See https://github.com/ROCm/TheRock/issues/5029
+    $clVersionLine = $clOutput | Where-Object { $_ -match "Version \d+\.\d+" } | Select-Object -First 1
+    if ($clVersionLine -match "Version (\d+\.\d+)") {
+        $msvcVer = [Version]$matches[1]
+        if ($msvcVer -ge $MinMsvcVersion) {
+            Write-Pass "MSVC version $msvcVer (>= $MinMsvcVersion)"
+        } else {
+            Write-Fail "MSVC version $msvcVer is too old (>= $MinMsvcVersion required)" `
+                -Detail "Update Visual Studio 2022 to version 17.13+ or install a newer Build Tools"
+        }
+    }
 } else {
     Write-Warn "cl.exe not in PATH - checking for VS installation..."
 

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -179,7 +179,7 @@ configuration. It is safe to re-run at any time.
 > Microsoft.VisualStudio.Component.VC.CMake.Project --add Microsoft.VisualStudio.Component.VC.ATL --add
 > Microsoft.VisualStudio.Component.Windows11SDK.22621"
 > winget install --id Git.Git -e --source winget --custom "/o:PathOption=CmdTools"
-> winget install cmake -v 3.31.0
+> winget install cmake
 > winget install ninja-build.ninja ccache python strawberryperl bloodrock.pkg-config-lite
 > winget install --id Iterative.DVC --silent --accept-source-agreements
 > ```
@@ -190,7 +190,10 @@ If you prefer to install tools manually, you will need:
   (Using either "Visual Studio" or "Build Tools for Visual Studio"),
   including these components:
 
-  - MSVC
+  - MSVC **version 19.43+** (Visual Studio 2022 **17.13+**). Older versions
+    will fail at link time because prebuilt libraries reference STL internals
+    introduced in 19.43.
+    See [Issue#5029](https://github.com/ROCm/TheRock/issues/5029).
   - C++ CMake tools for Windows
   - C++ ATL
   - C++ AddressSanitizer (optional)
@@ -199,8 +202,7 @@ If you prefer to install tools manually, you will need:
 
   - With "Use Git and optional Unix tools from the Windows Command Prompt" as certain build scripts use Bash.
 
-- CMake: https://cmake.org/download/, version < 4.0.0
-  (see [Issue#318](https://github.com/ROCm/TheRock/issues/318))
+- CMake: https://cmake.org/download/
 
 - Ninja: https://ninja-build.org/
 


### PR DESCRIPTION
## Motivation

Patch for https://github.com/ROCm/TheRock/issues/5029 . Source builds since ~April 7 have required version 19.43+, so my builds using 19.42 were failing.

I also removed checks for CMake <4.0 given that https://github.com/ROCm/TheRock/issues/318 has been marked fixed for months.

## Test Plan

* Source builds of `hip-clr` failed with the older version installed
* Source builds of `hip-clr` succeeded with the newer version installed
* Both validate scripts produced errors with an older version installed
* Both validate scripts passed with a newer version installed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
