### PR TITLE
Fix HOST_ASAN producing malformed HIP fat binaries on non-xnack targets

### DIFF
--- a/cmake/therock_sanitizers.cmake
+++ b/cmake/therock_sanitizers.cmake
@@ -55,6 +55,9 @@ function(therock_sanitizer_configure
       string(APPEND _stanza "set(AMDGPU_TARGETS \"\${GPU_TARGETS}\")\n")
       string(APPEND _stanza "message(STATUS \"Override ASAN GPU_TARGETS = \${GPU_TARGETS}\")\n")
     else()
+      # Explicitly disable ASAN for device compilation to prevent malformed
+      # HIP fat binaries on non-xnack GPU targets (e.g. gfx942).
+      string(APPEND _stanza "add_compile_options(\"SHELL:-Xarch_device -fno-sanitize=address\")\n")
       string(APPEND _stanza "message(STATUS \"HOST_ASAN enabled - GPU_TARGETS unchanged\")\n")
     endif()
     # Action at a distance: Signal that the sub-project should extend its build and install


### PR DESCRIPTION
## Summary

- In `HOST_ASAN` mode, `-fsanitize=address` is added globally via `CMAKE_CXX_FLAGS_INIT`, which reaches the HIP device compilation pass. For non-xnack GPU targets like `gfx942`, clang warns and silently ignores the flag, but this produces malformed fat binaries with corrupt magic bytes (`0x00000000` instead of `HIPF`/`0x48495046`) and misaligned `.hipFatBinSegment` sizes.
- Add `-Xarch_device -fno-sanitize=address` in the `HOST_ASAN` stanza to explicitly cancel ASAN for device compilation passes, so the device code compiles cleanly without any ASAN-related flags and produces valid fat binaries.
- This is consistent with existing patterns in `hipfile/cmake/AISSanitizers.cmake` and `rocFFT` that use `-Xarch_host`/`-Xarch_device` to scope flags to specific compilation passes.

## Background

When building with `--preset linux-release-host-asan` targeting `gfx942`:

1. `therock_sanitizers.cmake` injects `-fsanitize=address` into `CMAKE_CXX_FLAGS_INIT` (applies to both host and device compilation)
2. For `HOST_ASAN`, `GPU_TARGETS` is intentionally left unchanged (no `:xnack+` suffix)
3. Clang warns: `ignoring '-fsanitize=address' option for offload arch 'gfx942' as it is not currently supported there`
4. The resulting HIP fat binary is malformed — `split_artifacts.py` fails with `Unexpected magic 0x00000000` and segment size misalignment errors
5. The build fails during artifact packaging, ~38 minutes after compilation

The fix ensures the device compilation pass never sees `-fsanitize=address` in the first place, rather than relying on the compiler to gracefully ignore it.

## Test plan

- [ ] Verify `--preset linux-release-host-asan` build with `gfx942` target completes without fat binary corruption
- [ ] Verify `--preset linux-release-asan` (full ASAN) still correctly transforms targets to `gfx942:xnack+`
- [ ] Verify non-ASAN builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)