### PR TITLE
[ci] Turning off AWS CPU builders

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -51,8 +51,8 @@ def select_weighted_label(labels_config: list[dict], context_name: str) -> str:
 BUILD_RUNNER_LABELS = {
     "linux": {
         "default": [
-            {"label": "azure-linux-scale-rocm", "weight": 0.90},
-            {"label": "aws-linux-scale-rocm", "weight": 0.10},
+            {"label": "azure-linux-scale-rocm", "weight": 1.0},
+            {"label": "aws-linux-scale-rocm", "weight": 0.0},
         ],
         "sanitizer": [
             {"label": "azure-linux-scale-rocm-heavy-ramdisk", "weight": 1.0},

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1152,10 +1152,10 @@ class TestBuildRunnerSelection(unittest.TestCase):
                 select_build_runner("linux", "release"), "azure-linux-scale-rocm"
             )
 
-        # Random >= 0.9 should select AWS
+        # Random >= 0.9 should select Azure
         with patch("random.random", return_value=0.95):
             self.assertEqual(
-                select_build_runner("linux", "release"), "aws-linux-scale-rocm"
+                select_build_runner("linux", "release"), "azure-linux-scale-rocm"
             )
 
         # Random >= 0.9 should select AWS


### PR DESCRIPTION
As a PAT issue is being diagnosed, we are turning off AWS CPU builders

CI checks below prove that Azure runners are selected correctly (As well as unit tests)