### PR TITLE
Fix windows fetch-gfx-targets for gfx110X-all and gfx120X-all

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -192,7 +192,7 @@ amdgpu_family_info_matrix_presubmit = {
         "windows": {
             "test-runs-on": "windows-gfx110X-gpu-rocm",
             "family": "gfx110X-all",
-            "fetch-gfx-targets": ["gfx1100", "gfx1101"],
+            "fetch-gfx-targets": ["gfx1100", "gfx1101", "gfx1102"],
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
         },
@@ -232,7 +232,7 @@ amdgpu_family_info_matrix_presubmit = {
         "windows": {
             "test-runs-on": "windows-gfx120X-gpu-rocm",
             "family": "gfx120X-all",
-            "fetch-gfx-targets": [],
+            "fetch-gfx-targets": ["gfx1200", "gfx1201"],
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
             "nightly_check_only_for_family": True,

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -192,7 +192,7 @@ amdgpu_family_info_matrix_presubmit = {
         "windows": {
             "test-runs-on": "windows-gfx110X-gpu-rocm",
             "family": "gfx110X-all",
-            "fetch-gfx-targets": ["gfx1100", "gfx1101", "gfx1102"],
+            "fetch-gfx-targets": ["gfx1100", "gfx1101", "gfx1102", "gfx1103"],
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
         },

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -170,7 +170,7 @@ amdgpu_family_info_matrix_all = {
                     "runs_on": {
                         "test": "windows-gfx110X-gpu-rocm",
                     },
-                    "fetch-gfx-targets": ["gfx1100", "gfx1101"],
+                    "fetch-gfx-targets": ["gfx1100", "gfx1101", "gfx1102"],
                     "sanity_check_only_for_family": True,
                 },
                 "release": {
@@ -378,13 +378,12 @@ amdgpu_family_info_matrix_all = {
                     "build_variants": ["release"],
                 },
                 "test": {
-                    # TODO(#2962): Re-enable machine once sanity checks work with this architecture
-                    # fetch-gfx-targets should be ["gfx1200", "gfx1201"] when re-enabled
+                    # TODO(#2962): Re-enable run_tests once sanity checks work with this architecture.
                     "run_tests": False,
                     "runs_on": {
                         "test": "windows-gfx120X-gpu-rocm",
                     },
-                    "fetch-gfx-targets": [],
+                    "fetch-gfx-targets": ["gfx1200", "gfx1201"],
                 },
                 "release": {
                     "push_on_success": True,

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -170,7 +170,7 @@ amdgpu_family_info_matrix_all = {
                     "runs_on": {
                         "test": "windows-gfx110X-gpu-rocm",
                     },
-                    "fetch-gfx-targets": ["gfx1100", "gfx1101", "gfx1102"],
+                    "fetch-gfx-targets": ["gfx1100", "gfx1101", "gfx1102", "gfx1103"],
                     "sanity_check_only_for_family": True,
                 },
                 "release": {


### PR DESCRIPTION
## Summary

`fetch-gfx-targets` for the windows entries should match the arches the family
actually builds. The `cmake/therock_amdgpu_targets.cmake` `gfx110X-all` family
includes gfx1100/gfx1101/gfx1102, and `gfx120X-all` includes gfx1200/gfx1201,
so the build step is already producing split artifacts for all of them. The
windows test fetch lists were missing entries:

- `gfx110X-all` windows: `["gfx1100", "gfx1101"]` -> add `"gfx1102"`
- `gfx120X-all` windows: `[]` -> `["gfx1200", "gfx1201"]`

Mirrored in `new_amdgpu_family_matrix.py` per the in-file sync note.
`run_tests: False` on `gfx120X-all` windows stays -- `TODO(#2962)` is a
separate sanity-check issue.

## Test plan

- `cd build_tools && python -m pytest` -- 756 passed, 1 skipped, 2 subtests passed.
