### PR TITLE
Switch find_*artifacts*.py scripts to multi_arch_ci.yml by default

### DIFF
--- a/build_tools/find_artifacts_for_commit.py
+++ b/build_tools/find_artifacts_for_commit.py
@@ -105,7 +105,9 @@ def check_if_artifacts_exist(info: ArtifactRunInfo) -> bool:
     exist. Artifacts could be partially uploaded.
 
     TODO(scotttodd): plumb through a list of artifact keys to check for, then
-       use `ArtifactBackend::artifact_exists(artifact_key)`
+       use `ArtifactBackend::artifact_exists(artifact_key)`. With multi-arch CI
+       workflows and server-side indexing of artifacts, this method returns
+       `True` even if only early build stages have completed so far.
 
     Args:
         info: ArtifactRunInfo with the S3 location to check
@@ -127,7 +129,7 @@ def find_artifacts_for_commit(
     commit: str,
     artifact_groups: list[str],
     github_repository_name: str = "ROCm/TheRock",
-    workflow_file_name: str = "ci.yml",
+    workflow_file_name: str = "multi_arch_ci.yml",
     platform: str = platform_module.system().lower(),
 ) -> list[ArtifactRunInfo]:
     """Find artifact info for one or more groups from a commit.

--- a/build_tools/find_latest_artifacts.py
+++ b/build_tools/find_latest_artifacts.py
@@ -44,7 +44,7 @@ from github_actions.github_actions_api import (
 def find_latest_artifacts(
     artifact_groups: list[str],
     github_repository_name: str = "ROCm/TheRock",
-    workflow_file_name: str = "ci.yml",
+    workflow_file_name: str = "multi_arch_ci.yml",
     platform: str = platform_module.system().lower(),
     branch: str = "main",
     max_commits: int = 50,
@@ -140,13 +140,13 @@ def main(argv: list[str] | None = None) -> int:
         "--repo",
         type=str,
         default="ROCm/TheRock",
-        help="Repository in 'owner/repo' format (default: detect from git remote)",
+        help="Repository in 'owner/repo' format",
     )
     parser.add_argument(
         "--workflow",
         type=str,
-        default="ci.yml",
-        help="Workflow filename that produces artifacts (default: infer from repo, e.g. ci.yml in TheRock)",
+        default="multi_arch_ci.yml",
+        help="Workflow filename that produces artifacts",
     )
     parser.add_argument(
         "--platform",

--- a/build_tools/tests/find_artifacts_for_commit_test.py
+++ b/build_tools/tests/find_artifacts_for_commit_test.py
@@ -56,6 +56,12 @@ TEST_THEROCK_MAIN_RUN_ID = "20083647898"
 TEST_THEROCK_FORK_COMMIT = "62bc1eaa02e6ad1b49a718eed111cf4c9f03593a"
 TEST_THEROCK_FORK_RUN_ID = "20384488184"
 
+# Known commit with multi_arch_ci.yml workflow run in ROCm/TheRock:
+#   https://github.com/ROCm/TheRock/commit/903ee444eb935adf456bf5df724e1b6f5c2ce962
+#   multi_arch_ci run: https://github.com/ROCm/TheRock/actions/runs/25267756727
+TEST_THEROCK_MULTI_ARCH_COMMIT = "903ee444eb935adf456bf5df724e1b6f5c2ce962"
+TEST_THEROCK_MULTI_ARCH_RUN_ID = "25267756727"
+
 # Known commit with CI workflow run in ROCm/rocm-libraries:
 #   https://github.com/ROCm/rocm-libraries/commit/ab692342ac4d00268ac8a5a4efbc144c194cb45a
 #   CI run: https://github.com/ROCm/rocm-libraries/actions/runs/21365647639
@@ -74,6 +80,7 @@ class FindArtifactsForCommitTest(unittest.TestCase):
             commit=TEST_THEROCK_MAIN_COMMIT,
             artifact_groups=["gfx110X-all"],
             github_repository_name="ROCm/TheRock",
+            workflow_file_name="ci.yml",
             platform="linux",
         )
 
@@ -99,6 +106,7 @@ class FindArtifactsForCommitTest(unittest.TestCase):
             commit=TEST_THEROCK_FORK_COMMIT,
             artifact_groups=["gfx110X-all"],
             github_repository_name="ROCm/TheRock",
+            workflow_file_name="ci.yml",
             platform="linux",
         )
 
@@ -118,6 +126,7 @@ class FindArtifactsForCommitTest(unittest.TestCase):
             commit=TEST_THEROCK_MAIN_COMMIT,
             artifact_groups=["gfx110X-all"],
             github_repository_name="ROCm/TheRock",
+            workflow_file_name="ci.yml",
             platform="linux",
         )
 
@@ -132,6 +141,7 @@ class FindArtifactsForCommitTest(unittest.TestCase):
             commit=TEST_THEROCK_MAIN_COMMIT,
             artifact_groups=["gfx110X-all"],
             github_repository_name="ROCm/TheRock",
+            workflow_file_name="ci.yml",
             platform="windows",
         )
 
@@ -166,6 +176,48 @@ class FindArtifactsForCommitTest(unittest.TestCase):
 
         mock_check.assert_called()
 
+    @_skip_unless_authenticated_github_api_is_available
+    @mock.patch("find_artifacts_for_commit.check_if_artifacts_exist", return_value=True)
+    def test_multi_arch_ci_commit(self, mock_check):
+        """multi_arch_ci.yml commit returns ArtifactRunInfo with correct metadata."""
+        results = find_artifacts_for_commit(
+            commit=TEST_THEROCK_MULTI_ARCH_COMMIT,
+            artifact_groups=["gfx110X-all"],
+            github_repository_name="ROCm/TheRock",
+            workflow_file_name="multi_arch_ci.yml",
+            platform="linux",
+        )
+
+        self.assertEqual(len(results), 1)
+        info = results[0]
+        self.assertIsInstance(info, ArtifactRunInfo)
+        self.assertEqual(info.git_commit_sha, TEST_THEROCK_MULTI_ARCH_COMMIT)
+        self.assertEqual(info.github_repository_name, "ROCm/TheRock")
+        self.assertEqual(info.workflow_file_name, "multi_arch_ci.yml")
+        self.assertEqual(info.workflow_run_id, TEST_THEROCK_MULTI_ARCH_RUN_ID)
+        self.assertEqual(info.s3_bucket, "therock-ci-artifacts")
+        self.assertEqual(info.external_repo, "")
+        self.assertEqual(info.platform, "linux")
+        self.assertEqual(info.artifact_group, "gfx110X-all")
+
+        mock_check.assert_called()
+
+    @_skip_unless_authenticated_github_api_is_available
+    @mock.patch("find_artifacts_for_commit.check_if_artifacts_exist", return_value=True)
+    def test_multi_arch_ci_default_workflow(self, mock_check):
+        """multi_arch_ci.yml is the default workflow_file_name."""
+        results = find_artifacts_for_commit(
+            commit=TEST_THEROCK_MULTI_ARCH_COMMIT,
+            artifact_groups=["gfx110X-all"],
+            github_repository_name="ROCm/TheRock",
+            platform="linux",
+        )
+
+        self.assertEqual(len(results), 1)
+        info = results[0]
+        self.assertEqual(info.workflow_file_name, "multi_arch_ci.yml")
+        self.assertEqual(info.workflow_run_id, TEST_THEROCK_MULTI_ARCH_RUN_ID)
+
     def test_rate_limit_error_raises_exception(self):
         """Rate limit errors raise GitHubAPIError (not silently return None)."""
         rate_limit_error = GitHubAPIError(
@@ -198,6 +250,7 @@ class FindArtifactsForCommitMultiGroupTest(unittest.TestCase):
             commit=TEST_THEROCK_MAIN_COMMIT,
             artifact_groups=["gfx110X-all", "gfx120X-all"],
             github_repository_name="ROCm/TheRock",
+            workflow_file_name="ci.yml",
             platform="linux",
         )
 
@@ -221,6 +274,7 @@ class FindArtifactsForCommitMultiGroupTest(unittest.TestCase):
             commit=TEST_THEROCK_MAIN_COMMIT,
             artifact_groups=["gfx110X-all", "gfx120X-all"],
             github_repository_name="ROCm/TheRock",
+            workflow_file_name="ci.yml",
             platform="linux",
         )
 
@@ -235,6 +289,7 @@ class FindArtifactsForCommitMultiGroupTest(unittest.TestCase):
             commit=TEST_THEROCK_MAIN_COMMIT,
             artifact_groups=["gfx120X-all", "gfx110X-all"],
             github_repository_name="ROCm/TheRock",
+            workflow_file_name="ci.yml",
             platform="linux",
         )
 

--- a/build_tools/tests/find_latest_artifacts_test.py
+++ b/build_tools/tests/find_latest_artifacts_test.py
@@ -70,6 +70,7 @@ class FindLatestArtifactsTest(unittest.TestCase):
         results = find_latest_artifacts(
             artifact_groups=["gfx110X-all"],
             github_repository_name="ROCm/TheRock",
+            workflow_file_name="ci.yml",
             platform="linux",
         )
 
@@ -96,6 +97,7 @@ class FindLatestArtifactsTest(unittest.TestCase):
         results = find_latest_artifacts(
             artifact_groups=["gfx110X-all"],
             github_repository_name="ROCm/TheRock",
+            workflow_file_name="ci.yml",
             platform="linux",
         )
 
@@ -118,6 +120,7 @@ class FindLatestArtifactsTest(unittest.TestCase):
         results = find_latest_artifacts(
             artifact_groups=["gfx110X-all"],
             github_repository_name="ROCm/TheRock",
+            workflow_file_name="ci.yml",
             platform="linux",
         )
 
@@ -159,6 +162,7 @@ class FindLatestArtifactsMultiGroupTest(unittest.TestCase):
         results = find_latest_artifacts(
             artifact_groups=["gfx110X-all", "gfx120X-all"],
             github_repository_name="ROCm/TheRock",
+            workflow_file_name="ci.yml",
             platform="linux",
         )
 
@@ -191,6 +195,7 @@ class FindLatestArtifactsMultiGroupTest(unittest.TestCase):
         results = find_latest_artifacts(
             artifact_groups=["gfx110X-all", "gfx120X-all"],
             github_repository_name="ROCm/TheRock",
+            workflow_file_name="ci.yml",
             platform="linux",
         )
 
@@ -221,6 +226,7 @@ class FindLatestArtifactsMultiGroupTest(unittest.TestCase):
         results = find_latest_artifacts(
             artifact_groups=["gfx110X-all", "gfx120X-all"],
             github_repository_name="ROCm/TheRock",
+            workflow_file_name="ci.yml",
             platform="linux",
         )
 


### PR DESCRIPTION
## Motivation

The default CI workflow in TheRock changed from ci.yml to multi_arch_ci.yml with https://github.com/ROCm/TheRock/pull/4204. This updates a few scripts to use the new workflow so commands like `python build_tools/find_latest_artifacts.py --artifact-group gfx110X-all --platform=windows` work again.

## Technical Details

Due to how multi-arch CI workflows now work with progressive uploads during build stages and server-side index generation, these scripts are currently unreliable in that they don't differentiate between "has some artifacts" and "has all expected artifacts". For example, "find latest artifacts" will find workflow runs that have only completed the "foundation" stage and not yet finished building all the math-libs stages. Updating to that behavior can be a separate PR.

## Test Plan

* Existing and new unit tests
* Manually ran `python build_tools/find_latest_artifacts.py --artifact-group gfx110X-all --platform=windows`
* Manually ran `python build_tools/fetch_artifacts.py --run-id 25234948859 --output-dir D:/scratch/therock/25234948859 --no-delete-after-extract` with https://github.com/ROCm/TheRock/pull/4294 cherry-picked

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
