### PR TITLE
Pair kpack test binaries with per-ISA artifacts

### DIFF
--- a/build_tools/pair_kpack_test_binaries.py
+++ b/build_tools/pair_kpack_test_binaries.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Keep kpacked test host binaries paired with their device artifacts.
+
+Kpack splitting normally puts transformed host binaries in
+`<artifact>_<component>_generic` and puts `.kpack` files in per-ISA artifacts.
+That is correct for runtime libraries, but unsafe for test executables in
+multi-arch CI: multiple architecture jobs upload the same `_generic` artifact
+name, and the last upload can be paired with a different architecture job's
+`.kpack` shard. Some HIP test executables embed host-side kernel symbol names,
+so a cross-job host/kpack pair can fail at runtime with missing symbols.
+
+This post-process runs only for `test` components. It copies transformed host
+binaries that contain a kpack reference marker into every per-ISA artifact from
+the same split, then removes those binaries from the shared generic artifact.
+Non-device test data remains in the generic artifact.
+"""
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+from rocm_kpack.format_detect import UnsupportedBinaryFormat
+from rocm_kpack.kpack_transform import read_kpack_ref_marker
+
+
+def _read_manifest(artifact_dir: Path) -> list[str]:
+    manifest_path = artifact_dir / "artifact_manifest.txt"
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Missing artifact manifest: {manifest_path}")
+    return [line.strip() for line in manifest_path.read_text().splitlines() if line.strip()]
+
+
+def _write_manifest(artifact_dir: Path, prefixes: list[str]) -> None:
+    manifest_path = artifact_dir / "artifact_manifest.txt"
+    manifest_path.write_text("".join(f"{prefix}\n" for prefix in sorted(set(prefixes))))
+
+
+def _has_kpack_ref(path: Path) -> bool:
+    try:
+        return read_kpack_ref_marker(path) is not None
+    except UnsupportedBinaryFormat:
+        return False
+
+
+def _find_kpacked_files(generic_dir: Path, prefixes: list[str]) -> list[tuple[str, Path]]:
+    found: list[tuple[str, Path]] = []
+    for prefix in prefixes:
+        prefix_dir = generic_dir / prefix
+        if not prefix_dir.exists():
+            continue
+        for path in prefix_dir.rglob("*"):
+            if path.is_file() and _has_kpack_ref(path):
+                found.append((prefix, path))
+    return found
+
+
+def run(args: argparse.Namespace) -> None:
+    artifacts_dir = args.artifacts_dir
+    artifact_prefix = args.artifact_prefix
+    generic_dir = artifacts_dir / f"{artifact_prefix}_generic"
+    if not generic_dir.exists():
+        raise FileNotFoundError(f"Missing generic split artifact: {generic_dir}")
+
+    prefixes = _read_manifest(generic_dir)
+    kpacked_files = _find_kpacked_files(generic_dir, prefixes)
+    if not kpacked_files:
+        print(f"No kpacked test host binaries found in {generic_dir}")
+        return
+
+    arch_dirs = [
+        path
+        for path in sorted(artifacts_dir.glob(f"{artifact_prefix}_*"))
+        if path.is_dir()
+        and path.name != f"{artifact_prefix}_generic"
+        and (path / "artifact_manifest.txt").exists()
+    ]
+    if not arch_dirs:
+        raise FileNotFoundError(
+            f"Found kpacked host binaries in {generic_dir}, but no per-arch artifacts"
+        )
+
+    copied = 0
+    for arch_dir in arch_dirs:
+        arch_prefixes = _read_manifest(arch_dir)
+        for prefix, source_path in kpacked_files:
+            rel_path = source_path.relative_to(generic_dir / prefix)
+            dest_path = arch_dir / prefix / rel_path
+            dest_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_path, dest_path)
+            copied += 1
+            if prefix not in arch_prefixes:
+                arch_prefixes.append(prefix)
+        _write_manifest(arch_dir, arch_prefixes)
+
+    for _, source_path in kpacked_files:
+        source_path.unlink()
+
+    print(
+        f"Moved {len(kpacked_files)} kpacked test host binaries from "
+        f"{generic_dir.name} into {len(arch_dirs)} per-arch artifacts "
+        f"({copied} copies)"
+    )
+
+
+def main(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--artifacts-dir",
+        type=Path,
+        required=True,
+        help="Directory containing split artifact directories",
+    )
+    parser.add_argument(
+        "--artifact-prefix",
+        required=True,
+        help="Artifact prefix such as fft_test or blas_test",
+    )
+    args = parser.parse_args(argv)
+    run(args)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/build_tools/tests/pair_kpack_test_binaries_test.py
+++ b/build_tools/tests/pair_kpack_test_binaries_test.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+sys.path.insert(
+    0,
+    os.fspath(Path(__file__).parents[2] / "rocm-systems" / "shared" / "kpack" / "python"),
+)
+
+import pair_kpack_test_binaries
+
+
+class PairKpackTestBinariesTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = Path(tempfile.mkdtemp())
+        self.artifacts_dir = self.tmp_dir / "artifacts"
+        self.artifacts_dir.mkdir()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def write_manifest(self, artifact_dir: Path, entries: list[str]):
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        (artifact_dir / "artifact_manifest.txt").write_text(
+            "".join(f"{entry}\n" for entry in entries)
+        )
+
+    def test_kpacked_host_binaries_move_to_arch_artifacts(self):
+        generic_dir = self.artifacts_dir / "fft_test_generic"
+        self.write_manifest(generic_dir, ["bin", "share"])
+        (generic_dir / "bin").mkdir()
+        (generic_dir / "bin" / "fft_test").write_text("kpacked host binary")
+        (generic_dir / "bin" / "host_only").write_text("regular host binary")
+        (generic_dir / "share").mkdir()
+        (generic_dir / "share" / "data.txt").write_text("test data")
+
+        gfx1100_dir = self.artifacts_dir / "fft_test_gfx1100"
+        gfx1201_dir = self.artifacts_dir / "fft_test_gfx1201"
+        self.write_manifest(gfx1100_dir, ["lib"])
+        self.write_manifest(gfx1201_dir, ["lib"])
+
+        def read_marker(path: Path):
+            if path.name == "fft_test":
+                return {"kpack_search_paths": ["lib"], "kernel_name": "fft_test"}
+            return None
+
+        with mock.patch.object(
+            pair_kpack_test_binaries,
+            "read_kpack_ref_marker",
+            side_effect=read_marker,
+        ):
+            pair_kpack_test_binaries.run(
+                argparse.Namespace(
+                    artifacts_dir=self.artifacts_dir,
+                    artifact_prefix="fft_test",
+                )
+            )
+
+        self.assertFalse((generic_dir / "bin" / "fft_test").exists())
+        self.assertTrue((generic_dir / "bin" / "host_only").exists())
+        self.assertTrue((generic_dir / "share" / "data.txt").exists())
+
+        for arch_dir in [gfx1100_dir, gfx1201_dir]:
+            copied_binary = arch_dir / "bin" / "fft_test"
+            self.assertEqual(copied_binary.read_text(), "kpacked host binary")
+            manifest_entries = (arch_dir / "artifact_manifest.txt").read_text().splitlines()
+            self.assertIn("bin", manifest_entries)
+            self.assertIn("lib", manifest_entries)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cmake/therock_artifacts.cmake
+++ b/cmake/therock_artifacts.cmake
@@ -246,15 +246,29 @@ function(therock_provide_artifact slice_name)
       if(THEROCK_AMDGPU_TARGETS AND NOT "${THEROCK_AMDGPU_TARGETS}" STREQUAL "THEROCK_AMDGPU_TARGETS-NOTFOUND")
         list(APPEND _split_command_args --gpu-targets ${THEROCK_AMDGPU_TARGETS})
       endif()
+      if("${_component}" STREQUAL "test")
+        set(_pair_test_binaries_tool "${THEROCK_SOURCE_DIR}/build_tools/pair_kpack_test_binaries.py")
+        set(_pair_test_binaries_command
+          COMMAND "${CMAKE_COMMAND}" -E env "PYTHONPATH=${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/shared/kpack/python"
+            "${Python3_EXECUTABLE}" "${_pair_test_binaries_tool}"
+              --artifacts-dir "${THEROCK_BINARY_DIR}/artifacts/"
+              --artifact-prefix "${_artifact_prefix}"
+        )
+      else()
+        set(_pair_test_binaries_tool)
+        set(_pair_test_binaries_command)
+      endif()
 
       add_custom_command(
         OUTPUT "${_split_manifest}"
         COMMENT "Splitting ${_artifact_prefix} into generic and arch-specific artifacts"
         COMMAND "${CMAKE_COMMAND}" -E env "PYTHONPATH=${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/shared/kpack/python"
           "${Python3_EXECUTABLE}" "${_split_tool}" ${_split_command_args}
+        ${_pair_test_binaries_command}
         DEPENDS
           "${_unsplit_manifest}"
           "${_split_tool}"
+          ${_pair_test_binaries_tool}
         VERBATIM
       )
     endforeach()


### PR DESCRIPTION
(do not submit: this patch is not necessarily sound but is verifying some fft_test flakiness observed)

Partial landing split from #3928.

Changes:

- Add a post-split helper that finds kpacked test host binaries in the generic test artifact, copies them into each per-ISA artifact from the same split, and removes them from the shared generic artifact.

- Run that helper only for kpack-split test components so runtime library artifacts keep their existing generic/per-ISA shape.

- Add focused unit coverage for moving a kpacked host test binary while preserving regular generic test files.

Rationale:

- Multi-arch CI can otherwise upload the same generic test artifact name from multiple architecture jobs while the matching .kpack files remain per-ISA. That can pair a host executable from one job with device code from another.

Validation:

- python -m unittest build_tools.tests.pair_kpack_test_binaries_test

- python build_tools/topology_to_cmake.py --validate-only

- git diff --cached --check

Generated with Codex
