### PR TITLE
Fallback libhipcxx tests to AMDGPU_TARGETS

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/libhipcxx_utils.py
+++ b/build_tools/github_actions/test_executable_scripts/libhipcxx_utils.py
@@ -3,6 +3,7 @@ import platform
 import subprocess
 import sys
 import logging
+import re
 
 
 def prepend_env_path(env: dict, var_name: str, new_path: str):
@@ -25,6 +26,23 @@ def get_gpu_architecture_portable(therock_build_dir):
     """
     therock_build_dir = str(therock_build_dir)
     file_ending = ".exe" if platform.system() == "Windows" else ""
+
+    def get_architectures_from_targets() -> str | None:
+        amdgpu_targets = os.getenv("AMDGPU_TARGETS", "")
+        targets = [
+            target.strip()
+            for target in re.split(r"[,;]", amdgpu_targets)
+            if target.strip()
+        ]
+        if targets:
+            fallback_archs = ";".join(targets)
+            logging.info(
+                "Falling back to AMDGPU_TARGETS for HIP architectures: %s",
+                fallback_archs,
+            )
+            return fallback_archs
+        return None
+
     try:
         executable = therock_build_dir + f"/lib/llvm/bin/offload-arch{file_ending}"
         result = subprocess.run(
@@ -32,12 +50,14 @@ def get_gpu_architecture_portable(therock_build_dir):
         )
         lines = result.stdout.strip().split("\n")
         logging.info(f"DEBUG:{lines}")
-        return lines[-1]
+        if lines and lines[-1]:
+            return lines[-1]
+        return get_architectures_from_targets()
 
     except subprocess.CalledProcessError as e:
         print(f"Error executing offload-arch: {e}", file=sys.stderr)
         print(f"stderr: {e.stderr}", file=sys.stderr)
-        return None
+        return get_architectures_from_targets()
     except FileNotFoundError:
         print("Error: offload-arch command not found", file=sys.stderr)
-        return None
+        return get_architectures_from_targets()

--- a/build_tools/github_actions/test_executable_scripts/test_libhipcxx_hipcc.py
+++ b/build_tools/github_actions/test_executable_scripts/test_libhipcxx_hipcc.py
@@ -23,6 +23,8 @@ THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 gpu_arch = get_gpu_architecture_portable(OUTPUT_ARTIFACTS_DIR)
+if not gpu_arch:
+    raise RuntimeError("Could not determine HIP architecture for libhipcxx test")
 logging.info(f"++ Detected GPU architecture: {gpu_arch}")
 
 

--- a/build_tools/github_actions/test_executable_scripts/test_libhipcxx_hiprtc.py
+++ b/build_tools/github_actions/test_executable_scripts/test_libhipcxx_hiprtc.py
@@ -23,6 +23,8 @@ THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 gpu_arch = get_gpu_architecture_portable(OUTPUT_ARTIFACTS_DIR)
+if not gpu_arch:
+    raise RuntimeError("Could not determine HIP architecture for libhipcxx test")
 logging.info(f"++ Detected GPU architecture: {gpu_arch}")
 
 

--- a/build_tools/github_actions/tests/libhipcxx_utils_test.py
+++ b/build_tools/github_actions/tests/libhipcxx_utils_test.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(
+    0,
+    os.fspath(Path(__file__).parents[1] / "test_executable_scripts"),
+)
+
+import libhipcxx_utils
+
+
+class GetGpuArchitecturePortableTest(unittest.TestCase):
+    @mock.patch.dict(os.environ, {"AMDGPU_TARGETS": "gfx1100,gfx1201"}, clear=True)
+    @mock.patch("libhipcxx_utils.subprocess.run")
+    def test_falls_back_to_amdgpu_targets_when_offload_arch_missing(self, mock_run):
+        mock_run.side_effect = FileNotFoundError()
+
+        self.assertEqual(
+            libhipcxx_utils.get_gpu_architecture_portable("/tmp/rocm"),
+            "gfx1100;gfx1201",
+        )
+
+    @mock.patch.dict(os.environ, {"AMDGPU_TARGETS": "gfx1100; gfx1201"}, clear=True)
+    @mock.patch("libhipcxx_utils.subprocess.run")
+    def test_falls_back_to_amdgpu_targets_when_offload_arch_empty(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["offload-arch"],
+            returncode=0,
+            stdout="\n",
+            stderr="",
+        )
+
+        self.assertEqual(
+            libhipcxx_utils.get_gpu_architecture_portable("/tmp/rocm"),
+            "gfx1100;gfx1201",
+        )
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    @mock.patch("libhipcxx_utils.subprocess.run")
+    def test_returns_none_without_offload_arch_or_targets(self, mock_run):
+        mock_run.side_effect = FileNotFoundError()
+
+        self.assertIsNone(libhipcxx_utils.get_gpu_architecture_portable("/tmp/rocm"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Partial landing split from #3928.

Changes:

- Make the libhipcxx test helper fall back to AMDGPU_TARGETS when offload-arch is missing, fails, or reports no architecture.

- Normalize comma and semicolon separated AMDGPU_TARGETS values to the semicolon-separated form expected by the test scripts.

- Fail early in the hipcc and hiprtc libhipcxx tests when no architecture can be determined instead of continuing with an empty arch.

- Add unit coverage for missing offload-arch (as that will soon come from its own artifact), empty offload-arch output, and no fallback targets.

Rationale:

- Artifact-based CI jobs may not always have a usable offload-arch in the output tree, while the job already knows the intended GPU targets through AMDGPU_TARGETS.

Validation:

- python -m unittest build_tools.github_actions.tests.libhipcxx_utils_test

- python -m py_compile build_tools/github_actions/test_executable_scripts/libhipcxx_utils.py build_tools/github_actions/test_executable_scripts/test_libhipcxx_hipcc.py build_tools/github_actions/test_executable_scripts/test_libhipcxx_hiprtc.py build_tools/github_actions/tests/libhipcxx_utils_test.py

- git diff --cached --check

Generated with Codex
