### PR TITLE
Fetch transitive artifacts for stage dependencies

### DIFF
--- a/build_tools/_therock_utils/build_topology.py
+++ b/build_tools/_therock_utils/build_topology.py
@@ -280,7 +280,11 @@ class BuildTopology:
             # Get all artifacts from dependent groups (transitively)
             for dep_group_name in group.artifact_group_deps:
                 dep_artifacts = self.get_artifacts_in_group(dep_group_name)
-                inbound_artifacts.update(a.name for a in dep_artifacts)
+                for artifact in dep_artifacts:
+                    inbound_artifacts.add(artifact.name)
+                    self._collect_transitive_artifact_deps(
+                        artifact.name, inbound_artifacts
+                    )
 
         # Also collect direct artifact dependencies from artifacts in this stage
         # This includes transitive artifact dependencies

--- a/build_tools/tests/build_topology_test.py
+++ b/build_tools/tests/build_topology_test.py
@@ -521,6 +521,54 @@ class BuildTopologyTest(unittest.TestCase):
         self.assertIn("C", stage2_inbound)
         self.assertIn("D", stage2_inbound)
 
+    def test_group_dependencies_include_transitive_artifact_dependencies(self):
+        """Test group deps include the artifact deps of artifacts they pull in."""
+        self.write_topology(
+            """
+            [build_stages.producer]
+            description = "Producer"
+            artifact_groups = ["base"]
+
+            [build_stages.consumer]
+            description = "Consumer"
+            artifact_groups = ["leaf"]
+
+            [artifact_groups.base]
+            description = "Base"
+            type = "generic"
+
+            [artifact_groups.leaf]
+            description = "Leaf"
+            type = "generic"
+            artifact_group_deps = ["base"]
+
+            [artifacts.toolchain-runtime]
+            artifact_group = "base"
+            type = "target-neutral"
+            artifact_deps = ["toolchain-frontend"]
+
+            [artifacts.toolchain-frontend]
+            artifact_group = "base"
+            type = "target-neutral"
+            artifact_deps = ["toolchain-base"]
+
+            [artifacts.toolchain-base]
+            artifact_group = "base"
+            type = "target-neutral"
+
+            [artifacts.leaf-artifact]
+            artifact_group = "leaf"
+            type = "target-neutral"
+        """
+        )
+
+        topology = BuildTopology(self.topology_path)
+
+        consumer_inbound = topology.get_inbound_artifacts("consumer")
+        self.assertIn("toolchain-runtime", consumer_inbound)
+        self.assertIn("toolchain-frontend", consumer_inbound)
+        self.assertIn("toolchain-base", consumer_inbound)
+
     def test_complex_dependency_chain(self):
         """Test complex dependency chain resolution."""
         self.write_topology(


### PR DESCRIPTION
Partial landing split from #3928.

Changes:

- When a stage depends on an artifact group, include not only the artifacts produced by that group but also each artifact's transitive artifact dependencies.

- Add topology regression coverage for a group dependency where a pulled-in artifact depends on additional toolchain artifacts from the same producer group.

Rationale:

- Multi-stage CI fetches stage inputs from get_inbound_artifacts(). Without this closure, a downstream stage can fetch a higher-level artifact while missing lower-level artifacts that it needs at configure/build time.

- This is a standalone topology correctness fix that derisks the split compiler artifacts from #3928.

Validation:

- python -m unittest build_tools.tests.build_topology_test

- python build_tools/topology_to_cmake.py --validate-only

- git diff --cached --check

Generated with Codex
