### PR TITLE
Install aux-overlay directory symlinks with CMake code

### DIFF
--- a/base/aux-overlay/CMakeLists.txt
+++ b/base/aux-overlay/CMakeLists.txt
@@ -28,12 +28,17 @@ if(NOT WIN32)
     COMMAND "${CMAKE_COMMAND}" -E create_symlink "../lib/llvm/bin/amdlld" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdlld"
     COMMAND "${CMAKE_COMMAND}" -E create_symlink "../lib/llvm/bin/offload-arch" "${CMAKE_CURRENT_BINARY_DIR}/bin/offload-arch"
   )
-  install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/bin"
-    "${CMAKE_CURRENT_BINARY_DIR}/llvm"
-    "${CMAKE_CURRENT_BINARY_DIR}/amdgcn"
-    DESTINATION .
-  )
+  # llvm and amdgcn are symlinks to directories; install(FILES) rejects
+  # directories, so create the symlinks directly at install time.
+  # Targets must match those created by the symlinks target above.
+  # See https://github.com/ROCm/TheRock/issues/3714
+  install(CODE "
+    file(MAKE_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}\")
+    file(CREATE_LINK \"lib/llvm\"
+      \"\${CMAKE_INSTALL_PREFIX}/llvm\" SYMBOLIC)
+    file(CREATE_LINK \"lib/llvm/amdgcn\"
+      \"\${CMAKE_INSTALL_PREFIX}/amdgcn\" SYMBOLIC)
+  ")
   install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang"
     "${CMAKE_CURRENT_BINARY_DIR}/bin/amdflang"


### PR DESCRIPTION
Partial landing split from #3928.

Changes:

- Replace install(FILES) for the root llvm and amdgcn directory symlinks with install(CODE) that creates the symlinks at install time.

- Create the install prefix inside the install code before creating root-level symlinks; local validation showed the closed #4301 form failed when the prefix did not exist yet.

- Leave the existing amdflang symlink behavior unchanged; conditional Fortran symlink handling remains with the split compiler work.

Rationale:

- CMake install(FILES) rejects directory symlinks, which breaks aux-overlay installation for the SDK layout symlinks tracked by #3714.

Validation:

- cmake -S base/aux-overlay -B /tmp/therock-aux-overlay-test-build -GNinja -DTHEROCK_SOURCE_DIR=/srv/vm-shared/projects/therock-workspace1/worktrees/TheRock -DTHEROCK_PACKAGE_VERSION=0.0.0 -DGPU_TARGETS=gfx1100

- cmake --build /tmp/therock-aux-overlay-test-build

- cmake --install /tmp/therock-aux-overlay-test-build --prefix /tmp/therock-aux-overlay-test-install

- verified llvm, amdgcn, and bin/amdclang are symlinks in /tmp/therock-aux-overlay-test-install

- git diff --cached --check

Generated with Codex
