### PR TITLE
Collapse foundation and split runtime tests

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -4,8 +4,8 @@
 # Multi-Arch Build - Sharded Pipeline for Linux
 #
 # This workflow builds TheRock in stages:
-# 1. foundation (generic) - sysdeps, base
-# 2. compiler-runtime (generic) - compiler, runtimes, profiler-core
+# 1. compiler-runtime (generic) - sysdeps, base, compiler, runtimes, profiler-core
+# 2. runtime-tests (generic) - hip-tests, rocrtst (parallel to math-libs)
 # 3. wsl-rocdxg (generic) - WSL-only ROCDXG bridge library (after compiler-runtime)
 # 4. math-libs (per-arch) - BLAS, FFT, etc.
 # 5. comm-libs (per-arch) - RCCL, rocshmem (parallel to math-libs)
@@ -68,16 +68,16 @@ permissions:
 
 jobs:
   # ==========================================================================
-  # STAGE: foundation (generic)
+  # STAGE: compiler-runtime (generic)
   # ==========================================================================
-  foundation:
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'foundation') }}
+  compiler-runtime:
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'compiler-runtime') }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
-      stage_name: foundation
-      stage_display_name: "Stage - Foundation"
-      timeout_minutes: 180  # 3 hours
+      stage_name: compiler-runtime
+      stage_display_name: "Stage - Compiler Runtime"
+      timeout_minutes: 480  # 8 hours (compiler is big)
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
@@ -91,17 +91,17 @@ jobs:
       id-token: write
 
   # ==========================================================================
-  # STAGE: compiler-runtime (generic)
+  # STAGE: runtime-tests (generic, parallel to math-libs)
   # ==========================================================================
-  compiler-runtime:
-    needs: foundation
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'compiler-runtime') }}
+  runtime-tests:
+    needs: compiler-runtime
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'runtime-tests') }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_artifacts.yml
     secrets: inherit
     with:
-      stage_name: compiler-runtime
-      stage_display_name: "Stage - Compiler Runtime"
-      timeout_minutes: 480  # 8 hours (compiler is big)
+      stage_name: runtime-tests
+      stage_display_name: "Stage - Runtime Tests"
+      timeout_minutes: 120  # 2 hours
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -4,7 +4,7 @@
 # Reusable Workflow: Build Stage Artifacts
 #
 # This workflow builds TheRock stage artifacts for all stages.
-# Handles both generic stages (foundation, compiler-runtime, etc.) and
+# Handles both generic stages (compiler-runtime, profiler-apps, etc.) and
 # per-arch stages (math-libs, comm-libs) using conditional logic.
 #
 # Artifacts flow between stages via S3 using the artifact_manager.py tool.
@@ -22,7 +22,7 @@ on:
       stage_name:
         type: string
         required: true
-        description: "Stage name (e.g., foundation, math-libs, compiler-runtime)"
+        description: "Stage name (e.g., compiler-runtime, math-libs)"
       stage_display_name:
         type: string
         required: true

--- a/.github/workflows/multi_arch_build_windows.yml
+++ b/.github/workflows/multi_arch_build_windows.yml
@@ -4,8 +4,8 @@
 # Multi-Arch Build - Sharded Pipeline for Windows
 #
 # This workflow builds TheRock in stages:
-# 1. foundation (generic) - sysdeps, base
-# 2. compiler-runtime (generic) - compiler, runtimes
+# 1. compiler-runtime (generic) - sysdeps, base, compiler, runtimes
+# 2. runtime-tests (generic) - hip-tests (parallel to math-libs)
 # 3. math-libs (per-arch) - BLAS, FFT, etc.
 # 4. debug-tools (generic) - amd-dbgapi (rocgdb eventually).
 #
@@ -67,16 +67,16 @@ permissions:
 
 jobs:
   # ==========================================================================
-  # STAGE: foundation (generic)
+  # STAGE: compiler-runtime (generic)
   # ==========================================================================
-  foundation:
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'foundation') }}
+  compiler-runtime:
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'compiler-runtime') }}
     uses: ./.github/workflows/multi_arch_build_windows_artifacts.yml
     secrets: inherit
     with:
-      stage_name: foundation
-      stage_display_name: "Stage - Foundation"
-      timeout_minutes: 180  # 3 hours
+      stage_name: compiler-runtime
+      stage_display_name: "Stage - Compiler Runtime"
+      timeout_minutes: 480  # 8 hours (compiler is big)
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
@@ -89,17 +89,17 @@ jobs:
       id-token: write
 
   # ==========================================================================
-  # STAGE: compiler-runtime (generic)
+  # STAGE: runtime-tests (generic, parallel to math-libs)
   # ==========================================================================
-  compiler-runtime:
-    needs: foundation
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'compiler-runtime') }}
+  runtime-tests:
+    needs: compiler-runtime
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'runtime-tests') }}
     uses: ./.github/workflows/multi_arch_build_windows_artifacts.yml
     secrets: inherit
     with:
-      stage_name: compiler-runtime
-      stage_display_name: "Stage - Compiler Runtime"
-      timeout_minutes: 480  # 8 hours (compiler is big)
+      stage_name: runtime-tests
+      stage_display_name: "Stage - Runtime Tests"
+      timeout_minutes: 120  # 2 hours
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
       rocm_package_version: ${{ inputs.rocm_package_version }}

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -4,7 +4,7 @@
 # Reusable Workflow: Build Stage Artifacts
 #
 # This workflow builds TheRock stage artifacts for all stages.
-# Handles both generic stages (foundation, compiler-runtime, etc.) and
+# Handles both generic stages (compiler-runtime, etc.) and
 # per-arch stages (math-libs) using conditional logic.
 #
 # Artifacts flow between stages via S3 using the artifact_manager.py tool.
@@ -22,7 +22,7 @@ on:
       stage_name:
         type: string
         required: true
-        description: "Stage name (e.g., foundation, math-libs, compiler-runtime)"
+        description: "Stage name (e.g., compiler-runtime, math-libs)"
       stage_display_name:
         type: string
         required: true

--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -135,13 +135,11 @@ disable_platforms = ["windows"]
 # These represent actual CI/CD pipeline jobs optimized for parallel execution
 # Note: Stage names are identifiers, not sequence indicators - many can run in parallel
 
-[build_stages.foundation]
-description = "Foundation - critical path dependencies"
-artifact_groups = ["third-party-sysdeps", "base"]
-
 [build_stages.compiler-runtime]
 description = "Compiler, runtimes, and core profiling"
 artifact_groups = [
+    "third-party-sysdeps",
+    "base",
     "compiler",
     "core-amdsmi",
     "core-runtime",
@@ -149,13 +147,16 @@ artifact_groups = [
     "hip-runtime",
     "opencl-runtime",
     "profiler-core",
-    "rocrtst",
     "rocjitsu"
 ]
 
 [build_stages.wsl-rocdxg]
 description = "WSL-only ROCDXG bridge library"
 artifact_groups = ["wsl-rocdxg"]
+
+[build_stages.runtime-tests]
+description = "Runtime tests (parallel to math-libs, not on critical path)"
+artifact_groups = ["runtime-tests"]
 
 [build_stages.math-libs]
 description = "Math and ML libraries per architecture"
@@ -254,10 +255,10 @@ type = "generic"
 artifact_group_deps = ["core-runtime", "compiler"]
 source_sets = ["rocm-systems"]  # clr is in rocm-systems
 
-[artifact_groups.rocrtst]
-description = "Core runtime tests (ROCR-Runtime, rocminfo)"
+[artifact_groups.runtime-tests]
+description = "Runtime tests (hip-tests, rocrtst)"
 type = "generic"
-artifact_group_deps = ["opencl-runtime", "core-runtime"]
+artifact_group_deps = ["hip-runtime", "opencl-runtime", "core-runtime"]
 source_sets = ["rocm-systems"]
 
 [artifact_groups.math-libs]
@@ -536,7 +537,7 @@ feature_name = "OCL_RUNTIME"
 feature_group = "CORE"  # Part of core, enabled by default
 
 [artifacts.rocrtst]
-artifact_group = "rocrtst"
+artifact_group = "runtime-tests"
 type = "target-neutral"
 artifact_deps = ["core-runtime", "core-ocl", "sysdeps-hwloc"]
 feature_name = "CORE_RUNTIME_TESTS"
@@ -550,10 +551,8 @@ platform = "windows"
 artifact_deps = ["core-hip"]
 feature_group = "CORE"  # Part of core, enabled by default
 
-# --- hip-tests ---
-
 [artifacts.core-hiptests]
-artifact_group = "hip-runtime"
+artifact_group = "runtime-tests"
 type = "target-neutral"
 artifact_deps = ["core-hip"]
 feature_group = "CORE"  # Part of core, enabled by default

--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -539,7 +539,7 @@ feature_group = "CORE"  # Part of core, enabled by default
 [artifacts.rocrtst]
 artifact_group = "runtime-tests"
 type = "target-neutral"
-artifact_deps = ["core-runtime", "core-ocl", "sysdeps-hwloc"]
+artifact_deps = ["core-runtime", "core-ocl", "core-amdsmi", "sysdeps-hwloc"]
 feature_name = "CORE_RUNTIME_TESTS"
 feature_group = "CORE"
 disable_platforms = ["windows"]

--- a/build_tools/_therock_utils/workflow_outputs.py
+++ b/build_tools/_therock_utils/workflow_outputs.py
@@ -138,7 +138,7 @@ class WorkflowOutputRoot:
         per-arch stages (e.g., math-libs) get a subdirectory per family.
 
         Args:
-            stage_name: Build stage (e.g., 'foundation', 'math-libs')
+            stage_name: Build stage (e.g., 'compiler-runtime', 'math-libs')
             amdgpu_family: GPU family (e.g., 'gfx1151'). Empty for generic stages.
         """
         if amdgpu_family:

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -1142,7 +1142,7 @@ def main(argv: Optional[List[str]] = None):
         "--stage",
         type=str,
         required=True,
-        help="Build stage name(s), comma-separated (e.g., 'foundation,compiler-runtime')",
+        help="Build stage name(s), comma-separated (e.g., 'compiler-runtime,runtime-tests,math-libs')",
     )
     _add_target_args(copy_parser)
     copy_parser.add_argument(

--- a/build_tools/configure_stage.py
+++ b/build_tools/configure_stage.py
@@ -174,7 +174,7 @@ def main(argv: List[str] = None):
         "--stage",
         type=str,
         default=None,
-        help="Build stage name (e.g., foundation, compiler-runtime, math-libs)",
+        help="Build stage name (e.g., compiler-runtime, math-libs)",
     )
     parser.add_argument(
         "--amdgpu-families",

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -101,8 +101,8 @@ def _parse_prebuilt_stages(raw: str) -> list[str]:
     Reads stage names from BUILD_TOPOLOGY.toml when 'all' is specified.
 
     Example:
-        "foundation,compiler-runtime" → ["foundation", "compiler-runtime"]
-        "all" → ["foundation", "compiler-runtime", "math-libs", ...]
+        "compiler-runtime,runtime-tests" → ["compiler-runtime", "runtime-tests"]
+        "all" → ["compiler-runtime", "runtime-tests", "math-libs", ...]
     """
     stages = _parse_comma_list(raw)
     if "all" in stages:

--- a/build_tools/github_actions/post_stage_upload.py
+++ b/build_tools/github_actions/post_stage_upload.py
@@ -128,7 +128,7 @@ def upload_stage_logs(
         build_dir: Build directory containing logs/.
         output_root: Workflow output root for path computation.
         backend: Storage backend (S3 or local) to upload through.
-        stage_name: Build stage (e.g., 'foundation', 'math-libs').
+        stage_name: Build stage (e.g., 'compiler-runtime', 'math-libs').
         amdgpu_family: GPU family (e.g., 'gfx1151'). Empty for generic stages.
     """
     log_dir = build_dir / "logs"
@@ -204,7 +204,7 @@ def main(argv: list[str] | None = None):
         "--stage",
         type=str,
         required=True,
-        help="Build stage name (e.g., 'foundation', 'math-libs')",
+        help="Build stage name (e.g., 'compiler-runtime', 'math-libs')",
     )
     parser.add_argument(
         "--build-dir",

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -127,13 +127,13 @@ class TestCIInputsFromEnviron(unittest.TestCase):
                 "LINUX_TEST_LABELS": "test:rocprim",
                 "WINDOWS_AMDGPU_FAMILIES": "",
                 "WINDOWS_TEST_LABELS": "",
-                "PREBUILT_STAGES": "foundation,compiler-runtime",
+                "PREBUILT_STAGES": "compiler-runtime,runtime-tests",
                 "BASELINE_RUN_ID": "12345",
             },
         )
         self.assertEqual(inputs.linux_amdgpu_families, ["gfx94x", "gfx120x"])
         self.assertEqual(inputs.linux_test_labels, ["test:rocprim"])
-        self.assertEqual(inputs.prebuilt_stages, "foundation,compiler-runtime")
+        self.assertEqual(inputs.prebuilt_stages, "compiler-runtime,runtime-tests")
         self.assertEqual(inputs.baseline_run_id, "12345")
 
     def test_pull_request_extracts_labels(self):
@@ -402,13 +402,13 @@ class TestDecideJobs(unittest.TestCase):
         result = cm.decide_jobs(
             self._inputs(
                 event_name="workflow_dispatch",
-                prebuilt_stages="foundation,compiler-runtime",
+                prebuilt_stages="compiler-runtime,runtime-tests",
             ),
             git_context=cm.GitContext(),
         )
         self.assertEqual(
             sorted(result.build_rocm.prebuilt_stages),
-            ["compiler-runtime", "foundation"],
+            ["compiler-runtime", "runtime-tests"],
         )
         self.assertEqual(result.build_rocm.rebuild_stages, [])
 
@@ -423,14 +423,14 @@ class TestDecideJobs(unittest.TestCase):
         decision = cm.BuildRocmDecision(
             action=cm.JobAction.RUN,
             stage_decisions={
-                "foundation": cm.JobAction.PREBUILT,
                 "compiler-runtime": cm.JobAction.PREBUILT,
                 "math-libs": cm.JobAction.RUN,
+                "profiler-apps": cm.JobAction.PREBUILT,
             },
         )
         self.assertEqual(
             sorted(decision.prebuilt_stages),
-            ["compiler-runtime", "foundation"],
+            ["compiler-runtime", "profiler-apps"],
         )
         self.assertEqual(decision.rebuild_stages, ["math-libs"])
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -400,49 +400,6 @@ if(THEROCK_ENABLE_WSL_ROCDXG)
   )
 endif()
 
-if(THEROCK_BUILD_TESTING)
-  if(THEROCK_ENABLE_CORE_HIPTESTS)
-    set(HIP_TESTS_CMAKE_ARGS)
-    set(_hip_tests_subproject_names)
-    therock_cmake_subproject_declare(hip-tests
-      USE_TEST_AMDGPU_TARGETS
-      EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/hip-tests/catch"
-      BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hip-tests"
-      BACKGROUND_BUILD
-      COMPILER_TOOLCHAIN
-        amd-hip
-      CMAKE_ARGS
-        -DHIP_PLATFORM="amd"
-        -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
-      BUILD_DEPS
-        rocm-cmake
-        therock-boost
-        therock-catch2
-      RUNTIME_DEPS
-        hip-clr
-        ${THEROCK_BUNDLED_NUMACTL}
-      INTERFACE_LINK_DIRS
-        lib
-        lib/rocm_sysdeps/lib
-      INTERFACE_INSTALL_RPATH_DIRS
-        lib
-        lib/rocm_sysdeps/lib
-    )
-    therock_cmake_subproject_glob_c_sources(hip-tests SUBDIRS .)
-    therock_cmake_subproject_activate(hip-tests)
-    # Provide it as an artifact:
-    therock_provide_artifact(core-hiptests
-      TARGET_NEUTRAL
-      DESCRIPTOR artifact-core-hiptests.toml
-      COMPONENTS
-        test
-      SUBPROJECT_DEPS
-        hip-tests
-    )
-    list(APPEND _hip_tests_subproject_names hip-tests)
-  endif(THEROCK_ENABLE_CORE_HIPTESTS)
-endif(THEROCK_BUILD_TESTING)
-
 ################################################################################
 # ocl-icd
 ################################################################################
@@ -577,63 +534,101 @@ if(THEROCK_ENABLE_OCL_RUNTIME)
 endif(THEROCK_ENABLE_OCL_RUNTIME)
 
 ##############################################################################
-# rocrtst for ROCR-Runtime
+# Runtime tests
+# These are in their own build stage (runtime-tests) so they don't block
+# downstream stages like math-libs, dctools-core, etc.
 ##############################################################################
 
-if(THEROCK_BUILD_TESTING)
-  if(THEROCK_ENABLE_CORE_RUNTIME_TESTS)
+if(THEROCK_BUILD_TESTING AND THEROCK_ENABLE_CORE_HIPTESTS)
+  set(HIP_TESTS_CMAKE_ARGS)
+  set(_hip_tests_subproject_names)
+  therock_cmake_subproject_declare(hip-tests
+    USE_TEST_AMDGPU_TARGETS
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/hip-tests/catch"
+    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hip-tests"
+    BACKGROUND_BUILD
+    COMPILER_TOOLCHAIN
+      amd-hip
+    CMAKE_ARGS
+      -DHIP_PLATFORM="amd"
+      -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
+    BUILD_DEPS
+      rocm-cmake
+      therock-boost
+      therock-catch2
+    RUNTIME_DEPS
+      hip-clr
+      ${THEROCK_BUNDLED_NUMACTL}
+    INTERFACE_LINK_DIRS
+      lib
+      lib/rocm_sysdeps/lib
+    INTERFACE_INSTALL_RPATH_DIRS
+      lib
+      lib/rocm_sysdeps/lib
+  )
+  therock_cmake_subproject_glob_c_sources(hip-tests SUBDIRS .)
+  therock_cmake_subproject_activate(hip-tests)
+  therock_provide_artifact(core-hiptests
+    TARGET_NEUTRAL
+    DESCRIPTOR artifact-core-hiptests.toml
+    COMPONENTS
+      test
+    SUBPROJECT_DEPS
+      hip-tests
+  )
+  list(APPEND _hip_tests_subproject_names hip-tests)
+endif(THEROCK_BUILD_TESTING AND THEROCK_ENABLE_CORE_HIPTESTS)
 
-    # rocrtst may optionally build against amdsmi when available (Linux).
-    set(_rocrtst_build_deps
-      amd-llvm
-      ocl-clr
-      therock-yaml-cpp
-    )
-    if(TARGET amdsmi)
-      list(APPEND _rocrtst_build_deps amdsmi)
-    endif()
+if(THEROCK_BUILD_TESTING AND THEROCK_ENABLE_CORE_RUNTIME_TESTS)
+  # rocrtst may optionally build against amdsmi when available (Linux).
+  set(_rocrtst_build_deps
+    amd-llvm
+    ocl-clr
+    therock-yaml-cpp
+  )
+  if(TARGET amdsmi)
+    list(APPEND _rocrtst_build_deps amdsmi)
+  endif()
 
-    therock_cmake_subproject_declare(rocrtst
-      USE_TEST_AMDGPU_TARGETS
-      EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime/rocrtst/suites/test_common"
-      BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocrtst"
-      BACKGROUND_BUILD
-      CMAKE_ARGS
-        "-DCMAKE_PREFIX_PATH="
-        "-DLLVM_DIR="
-        "-DROCM_DIR="
-      COMPILER_TOOLCHAIN
-        "${_system_toolchain}"
-      BUILD_DEPS
-        ${_rocrtst_build_deps}
-      RUNTIME_DEPS
-        ROCR-Runtime
-        rocprofiler-register
-        ${THEROCK_BUNDLED_ELFUTILS}
-        ${THEROCK_BUNDLED_HWLOC}
-        ${THEROCK_BUNDLED_LIBDRM}
-        ${THEROCK_BUNDLED_NUMACTL}
-      INTERFACE_LINK_DIRS
-        "lib/rocm_sysdeps/lib"
-      INTERFACE_INSTALL_RPATH_DIRS
-        "lib/rocm_sysdeps/lib"
-    )
-    therock_cmake_subproject_glob_c_sources(rocrtst SUBDIRS .)
-    therock_cmake_subproject_activate(rocrtst)
+  therock_cmake_subproject_declare(rocrtst
+    USE_TEST_AMDGPU_TARGETS
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime/rocrtst/suites/test_common"
+    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocrtst"
+    BACKGROUND_BUILD
+    CMAKE_ARGS
+      "-DCMAKE_PREFIX_PATH="
+      "-DLLVM_DIR="
+      "-DROCM_DIR="
+    COMPILER_TOOLCHAIN
+      "${_system_toolchain}"
+    BUILD_DEPS
+      ${_rocrtst_build_deps}
+    RUNTIME_DEPS
+      ROCR-Runtime
+      rocprofiler-register
+      ${THEROCK_BUNDLED_ELFUTILS}
+      ${THEROCK_BUNDLED_HWLOC}
+      ${THEROCK_BUNDLED_LIBDRM}
+      ${THEROCK_BUNDLED_NUMACTL}
+    INTERFACE_LINK_DIRS
+      "lib/rocm_sysdeps/lib"
+    INTERFACE_INSTALL_RPATH_DIRS
+      "lib/rocm_sysdeps/lib"
+  )
+  therock_cmake_subproject_glob_c_sources(rocrtst SUBDIRS .)
+  therock_cmake_subproject_activate(rocrtst)
 
-    therock_provide_artifact(rocrtst
-      TARGET_NEUTRAL
-      DESCRIPTOR artifact-core-rocrtst.toml
-      COMPONENTS
-        dbg
-        dev
-        doc
-        lib
-        run
-        test
-      SUBPROJECT_DEPS
-        rocrtst
-    )
-
-  endif(THEROCK_ENABLE_CORE_RUNTIME_TESTS)
-endif(THEROCK_BUILD_TESTING)
+  therock_provide_artifact(rocrtst
+    TARGET_NEUTRAL
+    DESCRIPTOR artifact-core-rocrtst.toml
+    COMPONENTS
+      dbg
+      dev
+      doc
+      lib
+      run
+      test
+    SUBPROJECT_DEPS
+      rocrtst
+  )
+endif(THEROCK_BUILD_TESTING AND THEROCK_ENABLE_CORE_RUNTIME_TESTS)

--- a/docs/development/ci_behavior_manipulation.md
+++ b/docs/development/ci_behavior_manipulation.md
@@ -78,14 +78,14 @@ workflow supports skipping individual build stages by copying their artifacts
 from a previous workflow run. This will be used in a few scenarios. For example:
 
 - Changes to the rocm-libraries project will use prebuilt artifacts for
-  `foundation,compiler-runtime`
+  `compiler-runtime`
 - Changes to just test scripts or python packages will use prebuilt artifacts for
   all stages
 
 Two workflow inputs control this:
 
 - **`prebuilt_stages`**: Comma-separated list of stage names to skip
-  (e.g. `foundation,compiler-runtime`). Artifacts for these stages are copied
+  (e.g. `compiler-runtime,runtime-tests,math-libs`). Artifacts for these stages are copied
   from the baseline run instead of being built. Applied to both Linux and
   Windows; stages not present on a platform are ignored.
 - **`baseline_run_id`**: The workflow run ID to copy prebuilt artifacts from.
@@ -113,6 +113,6 @@ be computed based on dependencies and a special "all" option may be available.
 For now, these are the common configurations used for testing:
 
 ```
-foundation,compiler-runtime
-foundation,compiler-runtime,math-libs,comm-libs,debug-tools,dctools-core,profiler-apps,media-libs
+compiler-runtime
+compiler-runtime,runtime-tests,math-libs,comm-libs,debug-tools,dctools-core,profiler-apps,media-libs
 ```

--- a/docs/development/ci_overview.md
+++ b/docs/development/ci_overview.md
@@ -14,7 +14,7 @@ Instead of Jenkins and Groovy pipelines, TheRock uses **GitHub Actions** workflo
 
 ## CI Architecture
 
-TheRock uses a multi-stage CI pipeline that splits the build into stages (foundation → compiler-runtime → math-libs, etc.) with dependency chaining. Below is a general diagram of the CI flow
+TheRock uses a multi-stage CI pipeline that splits the build into stages (compiler-runtime → runtime-tests/math-libs, etc.) with dependency chaining. Below is a general diagram of the CI flow
 
 ```mermaid
 graph TD

--- a/docs/development/github_actions_debugging.md
+++ b/docs/development/github_actions_debugging.md
@@ -199,4 +199,4 @@ the `artifact_github_repo` and `artifact_run_id` workflow inputs.
 Eventually we would like for all ROCm CI and CD workflow runs to produce and
 upload artifacts in a compatible schema so that more workflows (e.g. producing
 native Linux or Windows packages, running framework tests, etc.) can extend this
-foundation.
+work.

--- a/docs/development/workflow_outputs.md
+++ b/docs/development/workflow_outputs.md
@@ -47,7 +47,7 @@ There are two CI pipeline architectures with different log layouts:
 - **Single-stage CI** (`ci.yml`) — one monolithic build per artifact group.
   Logs from all subprojects land in a single flat directory.
 - **Multi-arch CI** (`multi_arch_ci.yml`) — the build is split into stages
-  (foundation, compiler-runtime, math-libs, etc.). Each stage runs as a
+  (compiler-runtime, runtime-tests, math-libs, etc.). Each stage runs as a
   separate job and uploads its own logs, organized by stage name and GPU family.
 
 `artifact_group` is the CI matrix variant, composed of a target family plus an
@@ -97,7 +97,7 @@ The `comp-summary.*` files appear both in the `therock-build-prof/` subdirectory
 #### Multi-arch CI layout
 
 Logs are organized by stage, with a subdirectory per GPU family for per-arch
-stages. Generic stages (foundation, compiler-runtime) have no family
+stages. Generic stages (compiler-runtime, runtime-tests, profiler-apps) have no family
 subdirectory. Per-arch stages (e.g., math-libs) fan out across GPU
 families in parallel, producing identically-named log files (e.g.,
 `rocBLAS_build.log`) that are kept separate by the family subdirectory.
@@ -148,20 +148,19 @@ families in parallel, producing identically-named log files (e.g.,
         therock-dist-{platform}-multiarch-{version}.tar.gz  (KPACK split only)
 ```
 
-Example for a run with foundation + math-libs stages:
+Example for a run with compiler-runtime + runtime-tests + math-libs stages:
 
 ```
 12345-linux/
-    logs/foundation/
-        rocm-cmake_build.log
-        rocm-cmake_configure.log
-        rocm-cmake_install.log
-        ninja_logs.tar.gz
-
     logs/compiler-runtime/
         amd-llvm_build.log
         amd-llvm_configure.log
         amd-llvm_install.log
+        ninja_logs.tar.gz
+
+    logs/runtime-tests/
+        hip-tests_build.log
+        rocrtst_build.log
         ninja_logs.tar.gz
 
     logs/math-libs/gfx1151/
@@ -242,7 +241,7 @@ root.artifact(filename="blas_lib_gfx94X.tar.xz")
 root.artifact_index()
 root.log_dir(artifact_group="gfx94X-dcgpu")
 root.log_stage_dir(stage_name="math-libs", amdgpu_family="gfx1151")
-root.log_stage_dir(stage_name="foundation")  # generic stage, no family
+root.log_stage_dir(stage_name="compiler-runtime")  # generic stage, no family
 root.log_file(artifact_group="gfx94X-dcgpu", filename="build.log")
 root.log_index(artifact_group="gfx94X-dcgpu")
 root.build_observability(artifact_group="gfx94X-dcgpu")


### PR DESCRIPTION
Partial landing split from #3928.

Changes:

- Remove the foundation stage and fold sysdeps/base into compiler-runtime.

- Add a runtime-tests stage for hip-tests and rocrtst so runtime test builds no longer sit on the compiler-runtime critical path.

- Update multi-stage workflow dependencies, helper text, docs, and CI unit-test expectations for the new stage layout.

