### PR TITLE
[ci] Removing scheduled CI ASAN

### DIFF
--- a/.github/workflows/ci_asan.yml
+++ b/.github/workflows/ci_asan.yml
@@ -6,9 +6,6 @@
 name: CI ASAN
 
 on:
-  schedule:
-    # Runs at 02:00 AM UTC, which is 7:00 PM PST (UTC-8)
-    - cron: '0 02 * * *'
   workflow_dispatch:
     inputs:
       linux_amdgpu_families:


### PR DESCRIPTION
As multi arch CI ASAN is green, we are turning off CI ASAN scheduled. workflow dispatch is still available

No workflow errors here: https://github.com/ROCm/TheRock/actions/runs/25390129298 (but cancelled to save resources)