### PR TITLE
Add multi-arch (flat) upload mode for Python packages and tarballs

### DIFF
--- a/build_tools/packaging/upload_release_packages.py
+++ b/build_tools/packaging/upload_release_packages.py
@@ -35,6 +35,20 @@ TYPICAL USAGE (Command Line):
     --execute \
     --use-release-buckets
 
+  # Upload wheels only using multi-arch (flat layout)
+  python ./build_tools/packaging/upload_release_packages.py \
+    --input-dir=./downloads \
+    --multi-arch \
+    --execute
+
+  # Upload wheels and tarballs using multi-arch (flat layout, production buckets)
+  python ./build_tools/packaging/upload_release_packages.py \
+    --input-dir=./downloads \
+    --upload-tarballs \
+    --multi-arch \
+    --execute \
+    --use-release-buckets
+
 DIRECTORY STRUCTURE:
   Input directory structure (created by download_prerelease_packages.py):
     <input-dir>/
@@ -58,6 +72,16 @@ DIRECTORY STRUCTURE:
       therock-dist-linux-<arch1>-<version>.tar.gz
       therock-dist-windows-<arch2>-<version>.tar.gz
       ...
+
+  S3 bucket structure for mult-arch:
+    v4/whl/
+    package1.whl
+    package2.whl
+    package1.tar.gz
+
+  v4/tarball/
+    therock-dist-linux-<arch1>-<version>.tar.gz
+    therock-dist-windows-<arch2>-<version>.tar.gz
 
 NOTE:
   Index file generation is handled separately by manage.py.

--- a/build_tools/packaging/upload_release_packages.py
+++ b/build_tools/packaging/upload_release_packages.py
@@ -79,7 +79,11 @@ except ImportError:
 
 
 def upload_python_files(
-    input_dir: Path, bucket_name: str, bucket_prefix: str, execute: bool
+    input_dir: Path,
+    bucket_name: str,
+    bucket_prefix: str,
+    execute: bool,
+    multi_arch: bool = False,
 ) -> int:
     """Upload Python package files to S3 bucket.
 
@@ -125,7 +129,10 @@ def upload_python_files(
         print(f"  Found {len(files_to_upload)} file(s) to upload:")
 
         for file_path in sorted(files_to_upload):
-            s3_key = f"{bucket_prefix}{arch}/{file_path.name}"
+            if multi_arch:
+                s3_key = f"{bucket_prefix}{file_path.name}"
+            else:
+                s3_key = f"{bucket_prefix}{arch}/{file_path.name}"
 
             if execute:
                 try:
@@ -247,6 +254,13 @@ Safety Features:
     )
 
     parser.add_argument(
+        "--multi-arch",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Upload to multi-arch flat layout (no arch subdirectories)",
+    )
+
+    parser.add_argument(
         "--bucket",
         default="therock-testing-bucket",
         help="S3 bucket name for Python packages (default: therock-testing-bucket). You probably want to use therock-release-python",
@@ -295,9 +309,15 @@ Safety Features:
 
     if args.use_release_buckets:
         args.bucket = "therock-release-python"
-        args.bucket_prefix = "v3/rocm/whl/"
-        args.tarball_bucket = "therock-release-tarball"
-        args.tarball_bucket_prefix = "v3/rocm/tarball/"
+
+        if args.multi_arch:
+            args.bucket_prefix = "v3/whl-multi-arch/"
+            args.tarball_bucket = "therock-release-tarball"
+            args.tarball_bucket_prefix = "v3/tarball-multi-arch/"
+        else:
+            args.bucket_prefix = "v3/whl/"
+            args.tarball_bucket = "therock-release-tarball"
+            args.tarball_bucket_prefix = "v3/tarball/"
 
     # Validate input directory
     if not args.input_dir.exists():
@@ -384,12 +404,20 @@ def upload_release_packages(
     try:
         if upload_python:
             wheels_uploaded = upload_python_files(
-                input_dir, bucket_name, bucket_prefix, execute
+                input_dir,
+                bucket_name,
+                bucket_prefix,
+                execute,
+                multi_arch=args.multi_arch,
             )
 
         if upload_tarballs:
             tarballs_uploaded = upload_tarball_files(
-                input_dir, tarball_bucket_name, tarball_bucket_prefix, execute
+                input_dir,
+                tarball_bucket_name,
+                tarball_bucket_prefix,
+                execute,
+                multi_arch=args.multi_arch,
             )
 
     except NoCredentialsError:

--- a/build_tools/packaging/upload_release_packages.py
+++ b/build_tools/packaging/upload_release_packages.py
@@ -79,11 +79,7 @@ except ImportError:
 
 
 def upload_python_files(
-    input_dir: Path,
-    bucket_name: str,
-    bucket_prefix: str,
-    execute: bool,
-    multi_arch: bool = False,
+    input_dir: Path, bucket_name: str, bucket_prefix: str, execute: bool, multi_arch: bool = False
 ) -> int:
     """Upload Python package files to S3 bucket.
 
@@ -254,10 +250,10 @@ Safety Features:
     )
 
     parser.add_argument(
-        "--multi-arch",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Upload to multi-arch flat layout (no arch subdirectories)",
+    "--multi-arch",
+    action=argparse.BooleanOptionalAction,
+    default=False,
+    help="Upload to multi-arch flat layout (no arch subdirectories)",
     )
 
     parser.add_argument(
@@ -311,9 +307,9 @@ Safety Features:
         args.bucket = "therock-release-python"
 
         if args.multi_arch:
-            args.bucket_prefix = "v3/whl-multi-arch/"
+            args.bucket_prefix = "v4/whl/"
             args.tarball_bucket = "therock-release-tarball"
-            args.tarball_bucket_prefix = "v3/tarball-multi-arch/"
+            args.tarball_bucket_prefix = "v4/tarball/"
         else:
             args.bucket_prefix = "v3/whl/"
             args.tarball_bucket = "therock-release-tarball"
@@ -404,20 +400,12 @@ def upload_release_packages(
     try:
         if upload_python:
             wheels_uploaded = upload_python_files(
-                input_dir,
-                bucket_name,
-                bucket_prefix,
-                execute,
-                multi_arch=args.multi_arch,
+                input_dir, bucket_name, bucket_prefix, execute, multi_arch=args.multi_arch,
             )
 
         if upload_tarballs:
             tarballs_uploaded = upload_tarball_files(
-                input_dir,
-                tarball_bucket_name,
-                tarball_bucket_prefix,
-                execute,
-                multi_arch=args.multi_arch,
+                input_dir, tarball_bucket_name, tarball_bucket_prefix, execute, multi_arch=args.multi_arch,
             )
 
     except NoCredentialsError:

--- a/build_tools/packaging/upload_release_packages.py
+++ b/build_tools/packaging/upload_release_packages.py
@@ -79,7 +79,11 @@ except ImportError:
 
 
 def upload_python_files(
-    input_dir: Path, bucket_name: str, bucket_prefix: str, execute: bool, multi_arch: bool = False
+    input_dir: Path,
+    bucket_name: str,
+    bucket_prefix: str,
+    execute: bool,
+    multi_arch: bool = False,
 ) -> int:
     """Upload Python package files to S3 bucket.
 
@@ -250,10 +254,10 @@ Safety Features:
     )
 
     parser.add_argument(
-    "--multi-arch",
-    action=argparse.BooleanOptionalAction,
-    default=False,
-    help="Upload to multi-arch flat layout (no arch subdirectories)",
+        "--multi-arch",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Upload to multi-arch flat layout (no arch subdirectories)",
     )
 
     parser.add_argument(
@@ -400,12 +404,19 @@ def upload_release_packages(
     try:
         if upload_python:
             wheels_uploaded = upload_python_files(
-                input_dir, bucket_name, bucket_prefix, execute, multi_arch=args.multi_arch,
+                input_dir,
+                bucket_name,
+                bucket_prefix,
+                execute,
+                multi_arch=args.multi_arch,
             )
 
         if upload_tarballs:
             tarballs_uploaded = upload_tarball_files(
-                input_dir, tarball_bucket_name, tarball_bucket_prefix, execute, multi_arch=args.multi_arch,
+                input_dir,
+                tarball_bucket_name,
+                tarball_bucket_prefix,
+                execute,
             )
 
     except NoCredentialsError:

--- a/build_tools/packaging/upload_release_packages.py
+++ b/build_tools/packaging/upload_release_packages.py
@@ -130,24 +130,45 @@ def upload_python_files(
     s3_client = boto3.client("s3") if execute else None
     upload_count = 0
 
-    for arch_dir in input_dir.iterdir():
-        if not arch_dir.is_dir():
-            continue
+    if multi_arch:
+        wheels_dir = input_dir / "wheels"
 
-        # Skip tarball directory (handled separately)
-        if arch_dir.name == "tarball":
-            continue
+        if not wheels_dir.exists():
+            print(f"[ERROR]: Multi-arch wheels directory not found: {wheels_dir}")
+            return 0
 
-        arch = arch_dir.name
-        print(f"\nArchitecture: {arch}")
+        print("\nMulti-arch wheels")
 
-        # Find all wheel and tar.gz files (rocm sdist)
         files_to_upload = []
-        files_to_upload.extend(arch_dir.glob("*.whl"))
-        files_to_upload.extend(arch_dir.glob("*.tar.gz"))
+        files_to_upload.extend(wheels_dir.glob("*.whl"))
+        files_to_upload.extend(wheels_dir.glob("*.tar.gz"))
+
+        upload_dirs = [(None, files_to_upload)]
+
+    else:
+        upload_dirs = []
+
+        for arch_dir in input_dir.iterdir():
+            if not arch_dir.is_dir():
+                continue
+
+            if arch_dir.name in ["tarball", "tarball-multi-arch", "wheels"]:
+                continue
+
+            arch = arch_dir.name
+
+            files_to_upload = []
+            files_to_upload.extend(arch_dir.glob("*.whl"))
+            files_to_upload.extend(arch_dir.glob("*.tar.gz"))
+
+            upload_dirs.append((arch, files_to_upload))
+
+    for arch, files_to_upload in upload_dirs:
+        if arch:
+            print(f"\nArchitecture: {arch}")
 
         if not files_to_upload:
-            print(f"  No files to upload")
+            print("  No files to upload")
             continue
 
         print(f"  Found {len(files_to_upload)} file(s) to upload:")
@@ -178,7 +199,11 @@ def upload_python_files(
 
 
 def upload_tarball_files(
-    input_dir: Path, bucket_name: str, bucket_prefix: str, execute: bool
+    input_dir: Path,
+    bucket_name: str,
+    bucket_prefix: str,
+    execute: bool,
+    multi_arch: bool = False,
 ) -> int:
     """Upload tarball files to S3 bucket.
 
@@ -198,7 +223,10 @@ def upload_tarball_files(
         print("DRY-RUN MODE: No actual uploads will be performed")
         print("=" * 80)
 
-    tarball_dir = input_dir / "tarball"
+    if multi_arch:
+        tarball_dir = input_dir / "tarball-multi-arch"
+    else:
+        tarball_dir = input_dir / "tarball"
 
     if not tarball_dir.exists() or not tarball_dir.is_dir():
         print(f"  No tarball directory found at {tarball_dir}")
@@ -331,6 +359,10 @@ Safety Features:
 
     args = parser.parse_args(argv)
 
+    # Adjust testing tarball prefix for multi-arch uploads
+    if args.multi_arch and not args.use_release_buckets:
+        args.tarball_bucket_prefix = "release-upload-testing/tarball-multi-arch/"
+
     if args.use_release_buckets:
         args.bucket = "therock-release-python"
 
@@ -362,6 +394,7 @@ def upload_release_packages(
     tarball_bucket_name: str = "therock-testing-bucket",
     tarball_bucket_prefix: str = "release-upload-testing/tarball/",
     execute: bool = False,
+    multi_arch: bool = False,
 ) -> Tuple[int, int]:
     """Upload promoted packages to S3 release bucket.
 
@@ -404,13 +437,15 @@ def upload_release_packages(
 
     # Count architectures (exclude tarball directory)
     architectures = [
-        d for d in input_dir.iterdir() if d.is_dir() and d.name != "tarball"
+        d
+        for d in input_dir.iterdir()
+        if d.is_dir() and d.name not in ["tarball", "tarball-multi-arch", "wheels"]
     ]
     print(f"\nFound {len(architectures)} architecture(s):")
     for arch_dir in architectures:
         print(f"  - {arch_dir.name}")
 
-    if not architectures:
+    if not architectures and not multi_arch:
         print("\n[ERROR]: No architecture directories found in input directory")
         sys.exit(1)
 
@@ -432,7 +467,7 @@ def upload_release_packages(
                 bucket_name,
                 bucket_prefix,
                 execute,
-                multi_arch=args.multi_arch,
+                multi_arch=multi_arch,
             )
 
         if upload_tarballs:
@@ -441,6 +476,7 @@ def upload_release_packages(
                 tarball_bucket_name,
                 tarball_bucket_prefix,
                 execute,
+                multi_arch=multi_arch,
             )
 
     except NoCredentialsError:
@@ -500,4 +536,5 @@ if __name__ == "__main__":
         tarball_bucket_name=args.tarball_bucket,
         tarball_bucket_prefix=args.tarball_bucket_prefix,
         execute=args.execute,
+        multi_arch=args.multi_arch,
     )

--- a/build_tools/packaging/upload_release_packages.py
+++ b/build_tools/packaging/upload_release_packages.py
@@ -49,6 +49,13 @@ TYPICAL USAGE (Command Line):
     --execute \
     --use-release-buckets
 
+  # Upload single-arch wheels and tarballs to production release buckets
+  python ./build_tools/packaging/upload_release_packages.py \
+    --input-dir=./downloads \
+    --upload-tarballs \
+    --execute \
+    --use-release-buckets
+
 DIRECTORY STRUCTURE:
   Input directory structure (created by download_prerelease_packages.py):
     <input-dir>/


### PR DESCRIPTION
This PR mainly adds

- Add --multi-arch flag to support flat S3 upload layout
- Apply layout changes to both Python packages and tarballs via prefix selection
- Preserve existing arch-based behavior by default

1. Multi-arch upload mode (flat layout)

Introduced --multi-arch flag
Changes S3 key construction:

Default:

`<prefix>/<arch>/<package>`

Multi-arch:

`<prefix>/<package>`

2. Prefix selection for both wheels and tarballs

Updated --use-release-buckets handling:
Default → v3/whl/, v3/tarball/
Multi-arch → v4/whl/, v4/tarball/
Ensures both Python packages and tarballs are uploaded to the correct layout

3. Tarball uploads

Upload logic remains flat:

`<prefix>/<tarball>`

Destination changes based on selected prefix (standard vs multi-arch)

Testing:

https://gist.github.com/araravik-psd/904784e6f08af6c1fd79aab6b5d16da5