### PR TITLE
[ci] Adding external repo support for rocm-libraries multi-arch

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -58,6 +58,10 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
+      external_repo_config:
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -82,6 +86,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -105,6 +110,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -138,6 +144,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -165,6 +172,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -188,6 +196,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -211,6 +220,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -234,6 +244,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -257,6 +268,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -287,6 +299,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -310,6 +323,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -58,10 +58,6 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
-      external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
-        type: string
-        default: ""
 
 permissions:
   contents: read
@@ -86,7 +82,6 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
-      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -110,7 +105,6 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
-      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -144,7 +138,6 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
-      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -172,7 +165,6 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
-      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -196,7 +188,6 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
-      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -220,7 +211,6 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
-      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -244,7 +234,6 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
-      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -268,7 +257,6 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
-      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -299,7 +287,6 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
-      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -323,7 +310,6 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
-      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -59,7 +59,7 @@ on:
         type: string
         default: ""
       external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package)"
         type: string
         default: ""
 

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -66,7 +66,7 @@ on:
         type: string
         default: ""
       external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package)"
         type: string
         default: ""
 
@@ -160,7 +160,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             ${{ inputs.build_variant_cmake_preset && format('--preset={0}', inputs.build_variant_cmake_preset) }} \
-            ${{ inputs.external_repo_config != '' && format('-D{0}={1}', fromJSON(inputs.external_repo_config).cmake_source_dir_var, fromJSON(inputs.external_repo_config).checkout_path) || '' }} \
+            ${{ inputs.external_repo_config != '' && format('-DTHEROCK_{0}_SOURCE_DIR={1}', fromJSON(inputs.external_repo_config).source_package, fromJSON(inputs.external_repo_config).checkout_path) || '' }} \
             ${{ steps.stage_config.outputs.cmake_args }}
 
       - name: Build stage

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -66,7 +66,7 @@ on:
         type: string
         default: ""
       external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package)"
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package, fetch_sources_args)"
         type: string
         default: ""
 
@@ -89,6 +89,7 @@ jobs:
       CACHE_DIR: ${{ github.workspace }}/.container-cache
       TEATIME_FORCE_INTERACTIVE: 0
       RELEASE_TYPE: ${{ inputs.release_type }}
+      EXTERNAL_FETCH_SOURCES_ARGS: ${{ inputs.external_repo_config != '' && fromJSON(inputs.external_repo_config).fetch_sources_args || '' }}
 
     steps:
       - name: Checkout Repository
@@ -137,7 +138,7 @@ jobs:
 
       - name: Fetch sources
         timeout-minutes: 30
-        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1
+        run: ./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1 ${EXTERNAL_FETCH_SOURCES_ARGS}
 
       - name: Get stage configuration
         id: stage_config

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -65,6 +65,10 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
+      external_repo_config:
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        type: string
+        default: ""
 
 jobs:
   build_stage:
@@ -87,11 +91,28 @@ jobs:
       RELEASE_TYPE: ${{ inputs.release_type }}
 
     steps:
+      # Always checkout TheRock first. When called from an external repo,
+      # github.repository points to that repo, so we must be explicit.
+      - name: Checkout TheRock
+        if: ${{ inputs.external_repo_config != '' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/TheRock
+
       - name: Checkout Repository
+        if: ${{ inputs.external_repo_config == '' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
+
+      - name: Checkout external repository
+        if: ${{ inputs.external_repo_config != '' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ fromJSON(inputs.external_repo_config).repository }}
+          ref: ${{ fromJSON(inputs.external_repo_config).ref }}
+          path: ${{ fromJSON(inputs.external_repo_config).checkout_path }}
 
       - name: Install python deps
         run: pip install -r requirements.txt
@@ -148,6 +169,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             ${{ inputs.build_variant_cmake_preset && format('--preset={0}', inputs.build_variant_cmake_preset) }} \
+            ${{ inputs.external_repo_config != '' && format('-D{0}={1}', fromJSON(inputs.external_repo_config).cmake_source_dir_var, fromJSON(inputs.external_repo_config).checkout_path) || '' }} \
             ${{ steps.stage_config.outputs.cmake_args }}
 
       - name: Build stage

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -65,6 +65,10 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
+      external_repo_config:
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        type: string
+        default: ""
 
 jobs:
   build_stage:
@@ -92,6 +96,14 @@ jobs:
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
+
+      - name: Checkout external repository
+        if: ${{ inputs.external_repo_config != '' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ fromJSON(inputs.external_repo_config).repository }}
+          ref: ${{ fromJSON(inputs.external_repo_config).ref }}
+          path: ${{ fromJSON(inputs.external_repo_config).checkout_path }}
 
       - name: Install python deps
         run: pip install -r requirements.txt
@@ -148,6 +160,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             ${{ inputs.build_variant_cmake_preset && format('--preset={0}', inputs.build_variant_cmake_preset) }} \
+            ${{ inputs.external_repo_config != '' && format('-D{0}={1}', fromJSON(inputs.external_repo_config).cmake_source_dir_var, fromJSON(inputs.external_repo_config).checkout_path) || '' }} \
             ${{ steps.stage_config.outputs.cmake_args }}
 
       - name: Build stage

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -65,10 +65,6 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
-      external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
-        type: string
-        default: ""
 
 jobs:
   build_stage:
@@ -96,14 +92,6 @@ jobs:
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
-
-      - name: Checkout external repository
-        if: ${{ inputs.external_repo_config != '' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ${{ fromJSON(inputs.external_repo_config).repository }}
-          ref: ${{ fromJSON(inputs.external_repo_config).ref }}
-          path: ${{ fromJSON(inputs.external_repo_config).checkout_path }}
 
       - name: Install python deps
         run: pip install -r requirements.txt
@@ -160,7 +148,6 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             ${{ inputs.build_variant_cmake_preset && format('--preset={0}', inputs.build_variant_cmake_preset) }} \
-            ${{ inputs.external_repo_config != '' && format('-D{0}={1}', fromJSON(inputs.external_repo_config).cmake_source_dir_var, fromJSON(inputs.external_repo_config).checkout_path) || '' }} \
             ${{ steps.stage_config.outputs.cmake_args }}
 
       - name: Build stage

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -91,16 +91,7 @@ jobs:
       RELEASE_TYPE: ${{ inputs.release_type }}
 
     steps:
-      # Always checkout TheRock first. When called from an external repo,
-      # github.repository points to that repo, so we must be explicit.
-      - name: Checkout TheRock
-        if: ${{ inputs.external_repo_config != '' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ROCm/TheRock
-
       - name: Checkout Repository
-        if: ${{ inputs.external_repo_config == '' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository || github.repository }}

--- a/.github/workflows/multi_arch_build_windows.yml
+++ b/.github/workflows/multi_arch_build_windows.yml
@@ -56,6 +56,10 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
+      external_repo_config:
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -78,6 +82,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -100,6 +105,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write
@@ -132,6 +138,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_build_windows.yml
+++ b/.github/workflows/multi_arch_build_windows.yml
@@ -57,7 +57,7 @@ on:
         type: string
         default: ""
       external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package)"
         type: string
         default: ""
 

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -59,7 +59,7 @@ on:
         type: string
         default: ""
       external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package)"
         type: string
         default: ""
 
@@ -182,7 +182,7 @@ jobs:
             -DTHEROCK_PACKAGE_VERSION=${{ inputs.rocm_package_version }} \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            ${{ inputs.external_repo_config != '' && format('-D{0}={1}', fromJSON(inputs.external_repo_config).cmake_source_dir_var, fromJSON(inputs.external_repo_config).checkout_path) || '' }} \
+            ${{ inputs.external_repo_config != '' && format('-DTHEROCK_{0}_SOURCE_DIR={1}', fromJSON(inputs.external_repo_config).source_package, fromJSON(inputs.external_repo_config).checkout_path) || '' }} \
             ${{ steps.stage_config.outputs.cmake_args }}
 
       - name: Build stage

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -58,6 +58,10 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
+      external_repo_config:
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        type: string
+        default: ""
 
 jobs:
   build_stage:
@@ -79,11 +83,33 @@ jobs:
       RELEASE_TYPE: ${{ inputs.release_type }}
 
     steps:
+      # Enable git longpaths before checkout (needed for external repos with long paths)
+      - name: Enable git longpaths
+        if: ${{ inputs.external_repo_config != '' }}
+        run: git config --system core.longpaths true
+
+      # Always checkout TheRock first. When called from an external repo,
+      # github.repository points to that repo, so we must be explicit.
+      - name: Checkout TheRock
+        if: ${{ inputs.external_repo_config != '' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/TheRock
+
       - name: Checkout Repository
+        if: ${{ inputs.external_repo_config == '' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
+
+      - name: Checkout external repository
+        if: ${{ inputs.external_repo_config != '' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ fromJSON(inputs.external_repo_config).repository }}
+          ref: ${{ fromJSON(inputs.external_repo_config).ref }}
+          path: ${{ fromJSON(inputs.external_repo_config).checkout_path }}
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -165,6 +191,7 @@ jobs:
             -DTHEROCK_PACKAGE_VERSION=${{ inputs.rocm_package_version }} \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            ${{ inputs.external_repo_config != '' && format('-D{0}={1}', fromJSON(inputs.external_repo_config).cmake_source_dir_var, fromJSON(inputs.external_repo_config).checkout_path) || '' }} \
             ${{ steps.stage_config.outputs.cmake_args }}
 
       - name: Build stage

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -59,7 +59,7 @@ on:
         type: string
         default: ""
       external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package)"
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package, fetch_sources_args)"
         type: string
         default: ""
 
@@ -81,6 +81,7 @@ jobs:
       CACHE_DIR: ${{ github.workspace }}/.cache
       TEATIME_FORCE_INTERACTIVE: 0
       RELEASE_TYPE: ${{ inputs.release_type }}
+      EXTERNAL_FETCH_SOURCES_ARGS: ${{ inputs.external_repo_config != '' && fromJSON(inputs.external_repo_config).fetch_sources_args || '' }}
 
     steps:
       # Enable git longpaths before checkout (needed for external repos with long paths)
@@ -160,7 +161,7 @@ jobs:
 
       - name: Fetch sources
         timeout-minutes: 30
-        run: python build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1
+        run: python build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1 ${EXTERNAL_FETCH_SOURCES_ARGS}
 
       - name: Get stage configuration
         id: stage_config

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -88,16 +88,7 @@ jobs:
         if: ${{ inputs.external_repo_config != '' }}
         run: git config --system core.longpaths true
 
-      # Always checkout TheRock first. When called from an external repo,
-      # github.repository points to that repo, so we must be explicit.
-      - name: Checkout TheRock
-        if: ${{ inputs.external_repo_config != '' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ROCm/TheRock
-
       - name: Checkout Repository
-        if: ${{ inputs.external_repo_config == '' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository || github.repository }}

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -137,7 +137,6 @@ jobs:
       test_labels: ${{ inputs.test_labels }}
       sanity_check_only_for_family: ${{ matrix.family_info.sanity_check_only_for_family }}
       release_type: ${{ inputs.release_type }}
-      external_repo_config: ${{ inputs.external_repo_config }}
 
   build_native_deb_packages:
     needs: [build_multi_arch_stages]

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -30,10 +30,6 @@ on:
         description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
         default: ""
-      external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
-        type: string
-        default: ""
 
 permissions:
   contents: read
@@ -91,7 +87,6 @@ jobs:
       build_runs_on: ${{ fromJSON(inputs.build_config).build_runs_on }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
-      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -30,6 +30,18 @@ on:
         description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
         default: ""
+      external_repo_config:
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        type: string
+        default: ""
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+        default: ""
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -87,6 +99,9 @@ jobs:
       build_runs_on: ${{ fromJSON(inputs.build_config).build_runs_on }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
+      external_repo_config: ${{ inputs.external_repo_config }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -122,6 +137,7 @@ jobs:
       test_labels: ${{ inputs.test_labels }}
       sanity_check_only_for_family: ${{ matrix.family_info.sanity_check_only_for_family }}
       release_type: ${{ inputs.release_type }}
+      external_repo_config: ${{ inputs.external_repo_config }}
 
   build_native_deb_packages:
     needs: [build_multi_arch_stages]

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -30,6 +30,10 @@ on:
         description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
         default: ""
+      external_repo_config:
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -87,6 +91,7 @@ jobs:
       build_runs_on: ${{ fromJSON(inputs.build_config).build_runs_on }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -137,6 +137,8 @@ jobs:
       test_labels: ${{ inputs.test_labels }}
       sanity_check_only_for_family: ${{ matrix.family_info.sanity_check_only_for_family }}
       release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
 
   build_native_deb_packages:
     needs: [build_multi_arch_stages]

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -31,7 +31,7 @@ on:
         type: string
         default: ""
       external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package)"
         type: string
         default: ""
       repository:

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -136,6 +136,8 @@ jobs:
       test_labels: ${{ inputs.test_labels }}
       sanity_check_only_for_family: ${{ matrix.family_info.sanity_check_only_for_family }}
       release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
 
   build_python_packages:
     needs: [build_multi_arch_stages]

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -25,7 +25,7 @@ on:
         type: string
         default: ""
       external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package)"
         type: string
         default: ""
       repository:

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -24,6 +24,18 @@ on:
         description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
         default: ""
+      external_repo_config:
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        type: string
+        default: ""
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+        default: ""
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -86,6 +98,9 @@ jobs:
       build_runs_on: ${{ fromJSON(inputs.build_config).build_runs_on }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
+      external_repo_config: ${{ inputs.external_repo_config }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -52,6 +52,10 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
+      external_repo_config:
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        type: string
+        default: ""
     outputs:
       enable_build_jobs:
         description: Whether to enable build jobs.
@@ -86,6 +90,9 @@ on:
           to ensure all downstream jobs use the same commit, even if the branch
           HEAD moves during the workflow run.
         value: ${{ jobs.setup.outputs.ref }}
+      external_repo_config:
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        value: ${{ jobs.setup.outputs.external_repo_config }}
 
 permissions:
   contents: read
@@ -104,6 +111,7 @@ jobs:
       rocm_deb_package_version: ${{ steps.rocm_package_version.outputs.rocm_deb_package_version }}
       rocm_rpm_package_version: ${{ steps.rocm_package_version.outputs.rocm_rpm_package_version }}
       ref: ${{ steps.checkout.outputs.commit }}
+      external_repo_config: ${{ steps.external_repo.outputs.config }}
     steps:
       - name: Checking out repository
         id: checkout
@@ -113,6 +121,12 @@ jobs:
           ref: ${{ inputs.ref }}
           # We need the parent commit to do a diff
           fetch-depth: 2
+
+      # Pass through external repo config if provided
+      - name: Set external repo config
+        id: external_repo
+        run: |
+          echo "config=${{ inputs.external_repo_config }}" >> $GITHUB_OUTPUT
 
       # Note: the script reads PR labels, the base ref, etc. from the event
       # payload (GITHUB_EVENT_PATH). That is the original event that started

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -53,7 +53,7 @@ on:
         type: string
         default: ""
       external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package)"
         type: string
         default: ""
     outputs:
@@ -91,7 +91,7 @@ on:
           HEAD moves during the workflow run.
         value: ${{ jobs.setup.outputs.ref }}
       external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package)"
         value: ${{ inputs.external_repo_config }}
 
 permissions:

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -52,10 +52,6 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
-      external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
-        type: string
-        default: ""
     outputs:
       enable_build_jobs:
         description: Whether to enable build jobs.
@@ -90,9 +86,6 @@ on:
           to ensure all downstream jobs use the same commit, even if the branch
           HEAD moves during the workflow run.
         value: ${{ jobs.setup.outputs.ref }}
-      external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
-        value: ${{ jobs.setup.outputs.external_repo_config }}
 
 permissions:
   contents: read
@@ -111,7 +104,6 @@ jobs:
       rocm_deb_package_version: ${{ steps.rocm_package_version.outputs.rocm_deb_package_version }}
       rocm_rpm_package_version: ${{ steps.rocm_package_version.outputs.rocm_rpm_package_version }}
       ref: ${{ steps.checkout.outputs.commit }}
-      external_repo_config: ${{ steps.external_repo.outputs.config }}
     steps:
       - name: Checking out repository
         id: checkout
@@ -121,12 +113,6 @@ jobs:
           ref: ${{ inputs.ref }}
           # We need the parent commit to do a diff
           fetch-depth: 2
-
-      # Pass through external repo config if provided
-      - name: Set external repo config
-        id: external_repo
-        run: |
-          echo "config=${{ inputs.external_repo_config }}" >> $GITHUB_OUTPUT
 
       # Note: the script reads PR labels, the base ref, etc. from the event
       # payload (GITHUB_EVENT_PATH). That is the original event that started

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -52,6 +52,10 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
+      external_repo_config:
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        type: string
+        default: ""
     outputs:
       enable_build_jobs:
         description: Whether to enable build jobs.
@@ -86,6 +90,9 @@ on:
           to ensure all downstream jobs use the same commit, even if the branch
           HEAD moves during the workflow run.
         value: ${{ jobs.setup.outputs.ref }}
+      external_repo_config:
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        value: ${{ inputs.external_repo_config }}
 
 permissions:
   contents: read
@@ -129,6 +136,8 @@ jobs:
           WINDOWS_TEST_LABELS: ${{ inputs.windows_test_labels }}
           PREBUILT_STAGES: ${{ inputs.prebuilt_stages }}
           BASELINE_RUN_ID: ${{ inputs.baseline_run_id }}
+          # Skip path filtering for external repos (git sha won't exist in TheRock)
+          SKIP_PATH_FILTERS: ${{ inputs.external_repo_config != '' && 'true' || '' }}
         run: python ./build_tools/github_actions/configure_multi_arch_ci.py
 
       # Note: Other scripts treat "dev releases" and "CI builds" differently.

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -83,6 +83,10 @@ on:
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
+      external_repo_config:
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        type: string
+        default: ""
   push:
     branches:
       - ADHOCBUILD
@@ -106,8 +110,8 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.external_repo_config != '' && 'ROCm/TheRock' || inputs.repository || github.repository }}
+          ref: ${{ inputs.external_repo_config == '' && inputs.ref || '' }}
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -118,7 +122,15 @@ jobs:
         shell: powershell
         run: . '${{ github.workspace }}\prejob\build_tools\github_actions\cleanup_processes.ps1'
 
+      # Always checkout TheRock first when called from external repo
+      - name: "Checkout TheRock"
+        if: ${{ inputs.external_repo_config != '' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/TheRock
+
       - name: "Checking out repository"
+        if: ${{ inputs.external_repo_config == '' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository || github.repository }}
@@ -155,6 +167,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
 
   test_components:
     name: 'Test ${{ matrix.components.job_name }}'
@@ -200,3 +213,4 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -83,10 +83,6 @@ on:
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
-      external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
-        type: string
-        default: ""
   push:
     branches:
       - ADHOCBUILD
@@ -110,8 +106,8 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: ${{ inputs.external_repo_config != '' && 'ROCm/TheRock' || inputs.repository || github.repository }}
-          ref: ${{ inputs.external_repo_config == '' && inputs.ref || '' }}
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -122,15 +118,7 @@ jobs:
         shell: powershell
         run: . '${{ github.workspace }}\prejob\build_tools\github_actions\cleanup_processes.ps1'
 
-      # Always checkout TheRock first when called from external repo
-      - name: "Checkout TheRock"
-        if: ${{ inputs.external_repo_config != '' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ROCm/TheRock
-
-      - name: "Checking out repository"
-        if: ${{ inputs.external_repo_config == '' }}
+      - name: Checking out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository || github.repository }}
@@ -167,7 +155,6 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
-      external_repo_config: ${{ inputs.external_repo_config }}
 
   test_components:
     name: 'Test ${{ matrix.components.job_name }}'
@@ -213,4 +200,3 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
-      external_repo_config: ${{ inputs.external_repo_config }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -31,6 +31,10 @@ on:
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
+      external_repo_config:
+        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
+        type: string
+        default: ""
       default_container_image:
         type: string
         default: "ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98"
@@ -110,7 +114,15 @@ jobs:
         shell: powershell
         run: . '${{ github.workspace }}\prejob\build_tools\github_actions\cleanup_processes.ps1'
 
+      # Always checkout TheRock first when called from external repo
+      - name: Checkout TheRock
+        if: ${{ inputs.external_repo_config != '' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/TheRock
+
       - name: Checkout Repository
+        if: ${{ inputs.external_repo_config == '' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository || github.repository }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -31,10 +31,6 @@ on:
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
-      external_repo_config:
-        description: "JSON config for external repo checkout (repository, ref, checkout_path, cmake_source_dir_var)"
-        type: string
-        default: ""
       default_container_image:
         type: string
         default: "ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98"
@@ -114,15 +110,7 @@ jobs:
         shell: powershell
         run: . '${{ github.workspace }}\prejob\build_tools\github_actions\cleanup_processes.ps1'
 
-      # Always checkout TheRock first when called from external repo
-      - name: Checkout TheRock
-        if: ${{ inputs.external_repo_config != '' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ROCm/TheRock
-
-      - name: Checkout Repository
-        if: ${{ inputs.external_repo_config == '' }}
+      - name: Checking repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository || github.repository }}

--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -48,7 +48,7 @@ class S3BucketConfig:
 s3_bucket_configs = [
     # CI (self-hosted runners include credentials for therock-ci-artifacts-external)
     S3BucketConfig("therock-ci-artifacts", iam_role="therock-ci"),
-    S3BucketConfig("therock-ci-artifacts-external", iam_role=""),
+    S3BucketConfig("therock-ci-artifacts-external", iam_role=None),
     # Release type "dev"
     S3BucketConfig("therock-dev-artifacts", iam_role="therock-dev"),
     S3BucketConfig("therock-dev-packages", iam_role="therock-dev"),

--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -48,7 +48,7 @@ class S3BucketConfig:
 s3_bucket_configs = [
     # CI (self-hosted runners include credentials for therock-ci-artifacts-external)
     S3BucketConfig("therock-ci-artifacts", iam_role="therock-ci"),
-    S3BucketConfig("therock-ci-artifacts-external", iam_role=None),
+    S3BucketConfig("therock-ci-artifacts-external", iam_role="therock-ci-external"),
     # Release type "dev"
     S3BucketConfig("therock-dev-artifacts", iam_role="therock-dev"),
     S3BucketConfig("therock-dev-packages", iam_role="therock-dev"),

--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -48,7 +48,7 @@ class S3BucketConfig:
 s3_bucket_configs = [
     # CI (self-hosted runners include credentials for therock-ci-artifacts-external)
     S3BucketConfig("therock-ci-artifacts", iam_role="therock-ci"),
-    S3BucketConfig("therock-ci-artifacts-external", iam_role="therock-ci-external"),
+    S3BucketConfig("therock-ci-artifacts-external", iam_role=""),
     # Release type "dev"
     S3BucketConfig("therock-dev-artifacts", iam_role="therock-dev"),
     S3BucketConfig("therock-dev-packages", iam_role="therock-dev"),

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1055,7 +1055,13 @@ def configure(ci_inputs: CIInputs, git_context: GitContext) -> CIOutputs:
 def main():
     ci_inputs = CIInputs.from_environ()
 
-    if ci_inputs.is_pull_request or ci_inputs.is_push:
+    # Skip path filtering for external repos (e.g., rocm-libraries calling TheRock workflows)
+    skip_path_filters = os.environ.get("SKIP_PATH_FILTERS", "").lower() == "true"
+
+    if skip_path_filters:
+        # External repo: skip path filtering, run everything
+        git_context = GitContext.empty()
+    elif ci_inputs.is_pull_request or ci_inputs.is_push:
         # 'pull_request' and 'push' events can use the list of changed files
         # compared to the "prior commit" to affect job selections/options.
         git_context = GitContext.from_repo(base_ref=ci_inputs.base_ref)

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1056,6 +1056,9 @@ def main():
     ci_inputs = CIInputs.from_environ()
 
     # Skip path filtering for external repos (e.g., rocm-libraries calling TheRock workflows)
+    # The "run everything" is initial state for superrepo multi-arch CI migration.
+    # We will eventually support path filtering and component selection.
+    # TODO: Provide custom decision logic to run specific components and paths
     skip_path_filters = os.environ.get("SKIP_PATH_FILTERS", "").lower() == "true"
 
     if skip_path_filters:


### PR DESCRIPTION
Got a request to enable multi-arch CI workflow_dispatch in rocm-libraries. They were looking to test everything and build everything to make sure it works (with kpack)

I am running test here: https://github.com/ROCm/rocm-libraries/actions/runs/25452223287/job/74672238697   with branch changes here: https://github.com/ROCm/rocm-libraries/compare/develop...users/geomin12/multi-arch-ci

This is a good v1, where we can iterate as we migrate to multi-arch CI. somewhat relevant to de-dup work but fulfilling this request as developers want to get kpack tests ASAP