### PR TITLE
test(rocwmma): default CTest --parallel to 1 (ROCM-24171)

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
@@ -8,7 +8,6 @@ import subprocess
 from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
-platform = os.getenv("RUNNER_OS").lower()
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
@@ -8,7 +8,6 @@ import subprocess
 from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
-AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 platform = os.getenv("RUNNER_OS").lower()
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
@@ -49,10 +48,9 @@ elif test_type == "regression":
     test_subdir = "/regression"
     timeout = "720"
 
-# Make per-device adjustments
-ctest_parallelism = "2"
-if AMDGPU_FAMILIES == "gfx1153":
-    ctest_parallelism = "1"
+# ROCM-24171: Default CTest --parallel was 2; intermittent lockups / 60m timeouts on
+# gfx942 TheRock CI suggested avoiding concurrent GPU tests — use 1 until root cause is found.
+ctest_parallelism = "1"
 
 cmd = [
     "ctest",


### PR DESCRIPTION
## Summary
- Set rocWMMA TheRock CTest `--parallel` default from **2** to **1** in `build_tools/github_actions/test_executable_scripts/test_rocwmma.py`.
- Bump `rocm-libraries` submodule to include the matching `test/therock/test_rocwmma.py` change.

## Context
TheRock CI Nightly (Linux gfx94X-dcgpu) has seen intermittent **rocwmma** test steps hit the **60-minute** timeout (shard 4/5). Running CTest with a single parallel job avoids concurrent GPU test processes on single-GPU runners while the root cause is investigated.

## Related
- rocm-libraries: https://github.com/ROCm/rocm-libraries/pull/7075

Made with [Cursor](https://cursor.com)

ROCM-24171