### PR TITLE
[rocprofiler-compute] Include lib/rocprofiler-compute in rocprofiler-compute artifact

### DIFF
--- a/profiler/artifact-rocprofiler-compute.toml
+++ b/profiler/artifact-rocprofiler-compute.toml
@@ -1,6 +1,7 @@
 # rocprofiler-compute
 [components.lib."profiler/rocprofiler-compute/stage"]
 include = [
+  "lib/rocprofiler-compute/**",
   "libexec/rocprofiler-compute/**",
 ]
 [components.run."profiler/rocprofiler-compute/stage"]


### PR DESCRIPTION
## Summary
- The upstream rocprofiler-compute CMake installs `librocprofiler-compute-tool.so` to `${CMAKE_INSTALL_LIBDIR}/rocprofiler-compute/` (i.e. `lib/rocprofiler-compute/`).
- TheRock's artifact descriptor for rocprofiler-compute only included `libexec/rocprofiler-compute/**`, `bin/**`, `share/rocprofiler-compute/**`, and `share/doc/rocprofiler-compute/**` — `lib/rocprofiler-compute/**` was missing.
- Result: the native tool .so was staged but never hard-linked into `dist/` or the unified `build/dist/rocm/` tree, leaving the runtime library out of distributed artifacts.
- Fix: add `lib/rocprofiler-compute/**` to the `lib` component glob.

## Test plan
- [x] `ninja -C build rocprofiler-compute+dist`
- [x] `ls build/dist/rocm/lib/rocprofiler-compute/` shows `librocprofiler-compute-tool.so`
- [x] Inspect the produced rocprofiler-compute artifact tarball and confirm the .so is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)