### PR TITLE
[rocwmma] default CTest --parallel to 1

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
@@ -8,7 +8,6 @@ import subprocess
 from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
-platform = os.getenv("RUNNER_OS").lower()
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
@@ -8,7 +8,6 @@ import subprocess
 from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
-AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 platform = os.getenv("RUNNER_OS").lower()
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
@@ -49,10 +48,9 @@ elif test_type == "regression":
     test_subdir = "/regression"
     timeout = "720"
 
-# Make per-device adjustments
-ctest_parallelism = "2"
-if AMDGPU_FAMILIES == "gfx1153":
-    ctest_parallelism = "1"
+# ROCM-24171: Default CTest --parallel was 2; intermittent lockups / 60m timeouts on
+# gfx942 TheRock CI suggested avoiding concurrent GPU tests — use 1 until root cause is found.
+ctest_parallelism = "1"
 
 cmd = [
     "ctest",


### PR DESCRIPTION
## Summary
Set rocWMMA TheRock CTest `--parallel` default from **2** to **1** in `build_tools/github_actions/test_executable_scripts/test_rocwmma.py` only (no rocm-libraries submodule change on this branch).

## Context
Mitigate intermittent 60m test-step stalls on Linux gfx94X-dcgpu rocWMMA CI by avoiding two concurrent CTest jobs on single-GPU runners. Prior discussion: TheRock#2823 (flaky gfx94X / `unpack_util_test`); nightly already skips those tests via `TESTS_TO_IGNORE` in this script.

## Related
- rocm-libraries (mirrored `test/therock` script only): https://github.com/ROCm/rocm-libraries/pull/7075

## Follow-up
After merge, rocm-libraries picks up behavior on the **next pinned TheRock SHA bump** in its TheRock workflows (this PR does not advance the submodule).

Made with [Cursor](https://cursor.com)

ROCM-24171