### PR TITLE
[CI][hipfile] Don't trigger CI on hipFile changes

### DIFF
--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -160,6 +160,9 @@ _SKIPPABLE_PATH_PATTERNS = [
     "dockerfiles/*",
     # Changes to experimental code do not run standard build/test workflows.
     "experimental/*",
+    # Changes to hipFile do not need to trigger TheRock CI at this time.
+    ".github/workflows/hipfile-*.yml",
+    "projects/hipfile/*",
 ]
 
 # GitHub workflow file patterns that are considered CI-related.


### PR DESCRIPTION
## Motivation

TheRock CI doesn't run any hipFile tests, so there's no need to trigger it and waste time when hipFile code changes.

## Technical Details

Adds hipFile code and actions to `_SKIPPABLE_PATH_PATTERNS`

## Test Plan

TheRock CI runs normally

## Test Result

TheRock CI passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
