### PR TITLE
Fixing the duplicte index file generation which are handled in lamda fn

### DIFF
--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -739,13 +739,13 @@ def main():
         s3_client, bucket, prefix, args.pkg_type, uploaded_packages, job_type
     )
 
-    # Skip index.html generation for CI builds (handled by Lambda function)
-    if job_type != "ci":
+    # Skip index.html generation for run_id is not passed. (handled by Lambda function)
+    if not args.run_id:
         generate_index_from_s3(s3_client, bucket, prefix)
         top_prefix = prefix.split("/")[0]
         generate_top_index_from_s3(s3_client, bucket, top_prefix)
     else:
-        print("Skipping index.html generation for CI build")
+        print("Skipping index.html generation for cases Lamda fn is set")
 
     print(f"Package repository URL: {install_url}")
     _emit_github_output("package_repository_url", install_url)


### PR DESCRIPTION
Fixing the duplicte index file generation which are handled in lamda fn
## Motivation

The index files in the artifact were getting messed up due to duplicate upload to artifact buckets.
See for eg: https://therock-nightly-artifacts.s3.amazonaws.com/25355852546-linux/index.html
It should be ideally like https://therock-nightly-artifacts.s3.amazonaws.com/25355852546-windows/index.html

## Technical Details

Upload of index file is restricted to case of not multi arch builds

## Test Plan

The ci will test this