### PR TITLE
Revert "[ci] Adding fix for hipSPARSELt compress fails on multiarch gfx950 (#5065)"

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -566,7 +566,7 @@ feature_group = "CORE"  # Part of core, enabled by default
 artifact_group = "math-libs"
 type = "target-specific"
 artifact_deps = ["core-runtime", "core-hip", "core-amdsmi", "host-blas", "host-suite-sparse", "rocprofiler-sdk", "spdlog"]
-split_databases = ["rocblas", "hipblaslt", "hipsparselt"]
+split_databases = ["rocblas", "hipblaslt"]
 
 [artifacts.rand]
 artifact_group = "math-libs"


### PR DESCRIPTION
Reverts 2ad0cc0a69605ce8640aa89b17ff2e33cd6bbdd2 from \`main\`.

This change restores the prior \`BUILD_TOPOLOGY.toml\` state.