### PR TITLE
[ci] Adding fix for hipSPARSELt compress fails on multiarch gfx950

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -566,7 +566,7 @@ feature_group = "CORE"  # Part of core, enabled by default
 artifact_group = "math-libs"
 type = "target-specific"
 artifact_deps = ["core-runtime", "core-hip", "core-amdsmi", "host-blas", "host-suite-sparse", "rocprofiler-sdk", "spdlog"]
-split_databases = ["rocblas", "hipblaslt"]
+split_databases = ["rocblas", "hipblaslt", "hipsparselt"]
 
 [artifacts.rand]
 artifact_group = "math-libs"


### PR DESCRIPTION
Users noticed a gfx950 hipsparselt bug during multi-arch tests, but this change properly loads hipsparselt
Old results:
```
tester@f6fafc2816fb:~/test-old/bin$ ROCR_VISIBLE_DEVICES=0 ./hipsparselt-test   --data hipsparselt_gtest.data   --gtest_filter='*quick_compress_small_f16*'   --gtest_repeat=1
hipSPARSELt version: 207 revision: 3036f7ea

Query device success: there are 1 devices
-------------------------------------------------------------------------------
Device ID 0 : AMD Radeon Graphics gfx950:sramecc+:xnack-
with 38.7 GB memory, max. SCLK 2400 MHz, max. MCLK 2000 MHz, compute capability 9.5
maxGridDimX 2147483647, sharedMemPerBlock 163.8 KB, maxThreadsPerBlock 1024, warpSize 64
-------------------------------------------------------------------------------
info: parsing of test data may take a couple minutes before any test output appears...

Note: Google Test filter = *quick_compress_small_f16*
[==========] Running 72 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 72 tests from _/compress_test
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_8_8_8_8_CCCC

hipsparselt_error: Cannot read /home/tester/test-old/bin/../lib/hipsparselt/library/TensileLibrary_lazy_gfx950.dat: No such file or directory

hipsparselt_error: Could not load /home/tester/test-old/bin/../lib/hipsparselt/library/TensileLibrary_lazy_gfx950.dat
hipModuleLoad failed: /home/tester/test-old/bin/../lib/hipsparselt/library/Kernels.so-000-gfx950.hsaco
 error: file not found
hipModuleLoad failed: /home/tester/test-old/bin/../lib/hipsparselt/library/Kernels.so-000-gfx950-xnack-.hsaco
 error: file not found
hipModuleLoad failed: /home/tester/test-old/bin/../lib/hipsparselt/library/Kernels.so-000-gfx950-xnack+.hsaco
 error: file not found

hipsparselt_error: Could not initialize Tensile library
There are no solutions for this problem size
/__w/rockrel/rockrel/rocm-libraries/projects/hipsparselt/clients/include/spmm/testing_compress.hpp:658: Failure
Expected equality of these values:
  status_
    Which is: 3
  HIPSPARSE_STATUS_SUCCESS
    Which is: 0

[  FAILED  ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_8_8_8_8_CCCC, where GetParam() = { function: "compress", name: "compress_small", category: "quick", known_bug_platforms: "", alpha: 1, beta: 0, stride_a: 64, stride_b: 64, stride_c: 64, stride_d: 64, user_allocated_workspace: 0, M: 8, N: 8, K: 8, lda: 8, ldb: 8, ldc: 8, ldd: 8, batch_count: 1, iters: 10, cold_iters: 2, algo: 0, solution_index: 0, prune_algo: 1, a_type: f16_r, b_type: f16_r, c_type: f16_r, d_type: f16_r, compute_type: f32_r, initialization: "rand_int", gpu_arch: "", pad: 4096, threads: 0, streams: 0, devices:  (35 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_8_8_8_8_CCCC
There are no solutions for this problem size
/__w/rockrel/rockrel/rocm-libraries/projects/hipsparselt/clients/include/spmm/testing_compress.hpp:658: Failure
Expected equality of these values:
  status_
    Which is: 3
  HIPSPARSE_STATUS_SUCCESS
    Which is: 0

[  FAILED  ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_8_8_8_8_CCCC, where GetParam() = { function: "compress", name: "compress_small", category: "quick", known_bug_platforms: "", alpha: 1, beta: 0, stride_a: 64, stride_b: 64, stride_c: 64, stride_d: 64, user_allocated_workspace: 0, M: 8, N: 8, K: 8, lda: 8, ldb: 8, ldc: 8, ldd: 8, batch_count: 1, iters: 10, cold_iters: 2, algo: 0, solution_index: 0, prune_algo: 1, a_type: f16_r, b_type: f16_r, c_type: f16_r, d_type: f16_r, compute_type: f32_r, initialization: "rand_int", gpu_arch: "", pad: 4096, threads: 0, streams: 0, devices:  (1 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_16_16_16_16_CCCC
There are no solutions for this problem size
/__w/rockrel/rockrel/rocm-libraries/projects/hipsparselt/clients/include/spmm/testing_compress.hpp:658: Failure
Expected equality of these values:
  status_
    Which is: 3
  HIPSPARSE_STATUS_SUCCESS
    Which is: 0
```
<br/>
<br/>

New working results with this change from [multi-arch release dev build](https://github.com/ROCm/TheRock/actions/runs/25389408573/job/74484831495):
```
tester@f6fafc2816fb:~/test-new/bin$ ROCR_VISIBLE_DEVICES=0 ./hipsparselt-test   --data hipsparselt_gtest.data   --gtest_filter='*quick_compress_small_f16*'   --gtest_repeat=1
hipSPARSELt version: 208 revision: 89b3fc4c

Query device success: there are 1 devices
-------------------------------------------------------------------------------
Device ID 0 : AMD Instinct MI355X gfx950:sramecc+:xnack-
with 38.7 GB memory, max. SCLK 2400 MHz, max. MCLK 2000 MHz, compute capability 9.5
maxGridDimX 2147483647, sharedMemPerBlock 163.8 KB, maxThreadsPerBlock 1024, warpSize 64
-------------------------------------------------------------------------------
info: parsing of test data may take a couple minutes before any test output appears...

Note: Google Test filter = *quick_compress_small_f16*
[==========] Running 72 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 72 tests from _/compress_test
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_8_8_8_8_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_8_8_8_8_CCCC (72 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_8_8_8_8_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_8_8_8_8_CCCC (5 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_16_16_16_16_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_16_16_16_16_CCCC (2 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_16_16_16_16_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_16_16_16_16_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_24_24_24_24_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_24_24_24_24_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_24_24_24_24_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_24_24_24_24_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_32_32_32_32_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_32_32_32_32_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_32_32_32_32_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_32_32_32_32_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_40_40_40_40_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_40_40_40_40_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_40_40_40_40_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_40_40_40_40_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_48_48_48_48_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_48_48_48_48_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_48_48_48_48_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_48_48_48_48_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_56_56_56_56_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_56_56_56_56_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_56_56_56_56_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_56_56_56_56_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_64_64_64_64_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_64_64_64_64_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_64_64_64_64_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_64_64_64_64_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_72_72_72_72_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_72_72_72_72_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_72_72_72_72_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_72_72_72_72_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_8_8_8_8_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_8_8_8_8_CCCC (3 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_8_8_8_8_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_8_8_8_8_CCCC (4 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_16_16_16_16_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_16_16_16_16_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_16_16_16_16_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_16_16_16_16_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_24_24_24_24_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_24_24_24_24_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_24_24_24_24_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_24_24_24_24_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_32_32_32_32_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_32_32_32_32_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_32_32_32_32_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_32_32_32_32_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_40_40_40_40_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_40_40_40_40_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_40_40_40_40_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_40_40_40_40_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_48_48_48_48_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_48_48_48_48_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_48_48_48_48_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_48_48_48_48_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_56_56_56_56_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_56_56_56_56_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_56_56_56_56_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_56_56_56_56_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_64_64_64_64_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_64_64_64_64_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_64_64_64_64_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_64_64_64_64_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_72_72_72_72_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_72_72_72_72_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_72_72_72_72_CCCC
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_72_72_72_72_CCCC (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_8_8_8_8_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_8_8_8_8_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_8_8_8_8_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_8_8_8_8_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_16_16_16_16_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_16_16_16_16_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_16_16_16_16_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_16_16_16_16_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_24_24_24_24_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_24_24_24_24_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_24_24_24_24_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_24_24_24_24_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_32_32_32_32_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_32_32_32_32_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_32_32_32_32_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_32_32_32_32_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_40_40_40_40_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_40_40_40_40_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_40_40_40_40_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_40_40_40_40_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_48_48_48_48_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_48_48_48_48_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_48_48_48_48_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_48_48_48_48_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_56_56_56_56_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_56_56_56_56_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_56_56_56_56_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_56_56_56_56_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_64_64_64_64_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_64_64_64_64_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_64_64_64_64_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_64_64_64_64_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_72_72_72_72_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_NN_72_72_72_72_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_72_72_72_72_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_NN_72_72_72_72_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_8_8_8_8_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_8_8_8_8_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_8_8_8_8_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_8_8_8_8_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_16_16_16_16_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_16_16_16_16_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_16_16_16_16_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_16_16_16_16_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_24_24_24_24_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_24_24_24_24_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_24_24_24_24_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_24_24_24_24_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_32_32_32_32_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_32_32_32_32_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_32_32_32_32_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_32_32_32_32_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_40_40_40_40_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_40_40_40_40_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_40_40_40_40_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_40_40_40_40_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_48_48_48_48_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_48_48_48_48_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_48_48_48_48_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_48_48_48_48_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_56_56_56_56_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_56_56_56_56_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_56_56_56_56_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_56_56_56_56_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_64_64_64_64_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_64_64_64_64_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_64_64_64_64_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_64_64_64_64_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_72_72_72_72_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SB_TT_72_72_72_72_RRRR (0 ms)
[ RUN      ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_72_72_72_72_RRRR
[       OK ] _/compress_test.conversion/quick_compress_small_f16_r_SA_TT_72_72_72_72_RRRR (0 ms)
[----------] 72 tests from _/compress_test (147 ms total)

[----------] Global test environment tear-down
[==========] 72 tests from 1 test suite ran. (151 ms total)
[  PASSED  ] 72 tests.
hipSPARSELt version: 208 revision: 89b3fc4c

command line: ./hipsparselt-test --data hipsparselt_gtest.data --gtest_filter=*quick_compress_small_f16* --gtest_repeat=1
tester@f6fafc2816fb:~/test-new/bin$
```

For installation above: `wget  https://therock-dev-artifacts.s3.amazonaws.com/25389408573-linux/tarballs/therock-dist-linux-gfx950-dcgpu-7.13.0.dev0%2B8b3dda968d8546c8cb780dd5beb95c7ccc341a62.tar.gz`

ROCM-23979
