### PR TITLE
Patch upload_jax_manifest_test to pass when run from a fork.

### DIFF
--- a/build_tools/github_actions/tests/upload_jax_manifest_test.py
+++ b/build_tools/github_actions/tests/upload_jax_manifest_test.py
@@ -104,6 +104,8 @@ class TestMain(unittest.TestCase):
                     "nightly",
                     "--output-dir",
                     str(staging_dir),
+                    "--bucket",
+                    "test",
                 ]
             )
 
@@ -141,6 +143,8 @@ class TestMain(unittest.TestCase):
                     "release/0.4.28",
                     "--output-dir",
                     str(staging_dir),
+                    "--bucket",
+                    "test",
                 ]
             )
 
@@ -174,6 +178,8 @@ class TestMain(unittest.TestCase):
                         "nightly",
                         "--output-dir",
                         str(staging),
+                        "--bucket",
+                        "test",
                     ]
                 )
 


### PR DESCRIPTION
## Motivation

Same fix as https://github.com/ROCm/TheRock/pull/3864 for the jax test (which was merged _after_ the fix: https://github.com/ROCm/TheRock/pull/2866)

## Technical Details

The underlying code uses `GITHUB_REPOSITORY` to choose a subpath in a bucket like `"ForkName-TheRock/"` instead of `""`. The test expects path `{staging_dir}/12345-linux/manifests/...` but on the fork it becomes `{staging_dir}/ForkName-TheRock/12345-linux/manifests/....`.

## Test Plan

* Failed before: https://github.com/ScottTodd/TheRock/actions/runs/25447477273/job/74655441638?pr=7#step:5:787
* Passed after: https://github.com/ScottTodd/TheRock/actions/runs/25448564237

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
