### PR TITLE
Revert "Add COMGR build-time unit tests to CI (#4881)"

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -154,14 +154,6 @@ jobs:
         run: |
           cmake --build "${BUILD_DIR}" --target stage-${STAGE_NAME} therock-artifacts -- -k 0
 
-      - name: Run build tests
-        if: ${{ !cancelled() && inputs.stage_name == 'compiler-runtime' }}
-        continue-on-error: true
-        env:
-          TEATIME_FORCE_INTERACTIVE: 1
-        run: |
-          cmake --build "${BUILD_DIR}" --target therock-build-tests -- -k 0
-
       - name: Report
         if: ${{ !cancelled() }}
         run: |

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -171,14 +171,6 @@ jobs:
         run: |
           cmake --build "${BUILD_DIR}" --target stage-${STAGE_NAME} therock-artifacts -- -k 0
 
-      - name: Run build tests
-        if: ${{ !cancelled() && inputs.stage_name == 'compiler-runtime' }}
-        continue-on-error: true
-        env:
-          TEATIME_FORCE_INTERACTIVE: 1
-        run: |
-          cmake --build "${BUILD_DIR}" --target therock-build-tests -- -k 0
-
       - name: Report
         if: ${{ !cancelled() }}
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ option(THEROCK_COMPOSABLE_KERNEL_FOR_MIOPEN_ONLY
 
 option(THEROCK_BUILD_LLVM_TOOLS "Enables building all LLVM tools (not just minimum required)" OFF)
 option(THEROCK_BUILD_LLVM_TESTS "Enables building LLVM LIT tests" OFF)
+option(THEROCK_BUILD_COMGR_TESTS "Enables building Comgr tests" OFF)
 
 set(THEROCK_SANITIZER "" CACHE STRING "Enable project wide sanitizer build ('ASAN' for host+device, 'HOST_ASAN' for host-only)")
 

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1146,7 +1146,6 @@ function(therock_cmake_subproject_build_test target_name)
 
   get_target_property(_binary_dir "${target_name}" THEROCK_BINARY_DIR)
   get_target_property(_output_on_failure "${target_name}" THEROCK_OUTPUT_ON_FAILURE)
-  get_target_property(_prefix_dir "${target_name}" THEROCK_PREFIX_DIR)
   get_target_property(_stamp_dir "${target_name}" THEROCK_STAMP_DIR)
   get_target_property(_stage_dir "${target_name}" THEROCK_STAGE_DIR)
 
@@ -1194,20 +1193,15 @@ function(therock_cmake_subproject_build_test target_name)
     message(FATAL_ERROR "Empty COMMAND in build tests for '${target_name}'")
   endif()
 
-  # Generate a runner script that executes all test commands independently,
-  # so a failure in one does not prevent the others from running.
+  set(_build_test_commands)
   _therock_cmake_subproject_build_env_pairs(_build_env_pairs)
-  set(_runner_script "${_prefix_dir}/build-test-runner.cmake")
-  set(_runner_content "set(_any_failed FALSE)\n\n")
-
   foreach(_command_index RANGE 1 ${_command_count})
-    # Use numbered labels/files only when there are multiple commands;
-    # a single command gets the plain name without a suffix.
     set(_log_file "${target_name}_build_test.log")
     set(_log_label "${target_name} build-test")
-    if(_command_count GREATER 1)
-      set(_log_file "${target_name}_build_test_${_command_index}.log")
-      set(_log_label "${target_name} build-test ${_command_index}")
+    if(_command_index GREATER 1)
+      math(EXPR _log_suffix "${_command_index} - 1")
+      set(_log_file "${target_name}_build_test_${_log_suffix}.log")
+      set(_log_label "${target_name} build-test ${_log_suffix}")
     endif()
     therock_subproject_log_command(_test_log_prefix
       LOG_FILE "${_log_file}"
@@ -1216,64 +1210,20 @@ function(therock_cmake_subproject_build_test target_name)
     )
 
     set(_test_command_var "_test_command_${_command_index}")
-    set(_full_cmd
-      ${_test_log_prefix}
-      "${CMAKE_COMMAND}" -E env ${_build_env_pairs} --
-      ${${_test_command_var}}
+    list(APPEND _build_test_commands
+      COMMAND
+        ${_test_log_prefix}
+        "${CMAKE_COMMAND}" -E env ${_build_env_pairs} --
+        ${${_test_command_var}}
     )
-
-    # Serialize the command list into a quoted string for the script.
-    set(_cmd_str "")
-    foreach(_arg IN LISTS _full_cmd)
-      string(APPEND _cmd_str " \"${_arg}\"")
-    endforeach()
-
-    if(_command_index GREATER 1)
-      string(APPEND _runner_content "message(STATUS \"\")\n")
-    endif()
-    string(APPEND _runner_content "message(STATUS \"----------------------------------------\")\n")
-    string(APPEND _runner_content "message(STATUS \"Running: ${_log_label}\")\n")
-    string(APPEND _runner_content "message(STATUS \"----------------------------------------\")\n")
-    string(APPEND _runner_content "execute_process(\n")
-    string(APPEND _runner_content "  COMMAND${_cmd_str}\n")
-    string(APPEND _runner_content "  WORKING_DIRECTORY \"${_binary_dir}\"\n")
-    string(APPEND _runner_content "  RESULT_VARIABLE _rc${_command_index}\n")
-    string(APPEND _runner_content ")\n")
-    string(APPEND _runner_content "if(_rc${_command_index})\n")
-    string(APPEND _runner_content "  set(_any_failed TRUE)\n")
-    string(APPEND _runner_content "endif()\n\n")
   endforeach()
-
-  string(APPEND _runner_content "message(STATUS \"\")\n")
-  string(APPEND _runner_content "message(STATUS \"========================================\")\n")
-  string(APPEND _runner_content "message(STATUS \"BUILD TEST SUMMARY for ${target_name}\")\n")
-  string(APPEND _runner_content "message(STATUS \"========================================\")\n")
-  foreach(_command_index RANGE 1 ${_command_count})
-    set(_log_label "${target_name} build-test")
-    if(_command_count GREATER 1)
-      set(_log_label "${target_name} build-test ${_command_index}")
-    endif()
-    string(APPEND _runner_content "if(_rc${_command_index})\n")
-    string(APPEND _runner_content "  message(STATUS \"  ${_log_label}: FAILED (exit code \${_rc${_command_index}})\")\n")
-    string(APPEND _runner_content "else()\n")
-    string(APPEND _runner_content "  message(STATUS \"  ${_log_label}: PASSED\")\n")
-    string(APPEND _runner_content "endif()\n")
-  endforeach()
-  string(APPEND _runner_content "message(STATUS \"========================================\")\n")
-  string(APPEND _runner_content "if(_any_failed)\n")
-  string(APPEND _runner_content "  message(FATAL_ERROR \"One or more build test commands failed for ${target_name}\")\n")
-  string(APPEND _runner_content "else()\n")
-  string(APPEND _runner_content "  message(STATUS \"All build tests passed for ${target_name}\")\n")
-  string(APPEND _runner_content "endif()\n")
-
-  file(GENERATE OUTPUT "${_runner_script}" CONTENT "${_runner_content}")
 
   set(_build_stamp_file "${_stamp_dir}/build.stamp")
   set(_build_test_stamp_file "${_stamp_dir}/build-test.stamp")
 
   add_custom_command(
     OUTPUT "${_build_test_stamp_file}"
-    COMMAND "${CMAKE_COMMAND}" -P "${_runner_script}"
+    ${_build_test_commands}
     COMMAND "${CMAKE_COMMAND}" -E touch "${_build_test_stamp_file}"
     WORKING_DIRECTORY "${_binary_dir}"
     COMMENT "Running build tests for sub-project ${target_name}"

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -2,10 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 if(THEROCK_ENABLE_COMPILER)
-  if(NOT DEFINED THEROCK_BUILD_COMGR_TESTS)
-    set(THEROCK_BUILD_COMGR_TESTS ${THEROCK_BUILD_TESTING})
-  endif()
-
   ##############################################################################
   # amd-llvm
   # Everything built as part of LLVM installs to lib/llvm
@@ -78,7 +74,6 @@ if(THEROCK_ENABLE_COMPILER)
 
       # Features
       -DLLVM_INCLUDE_TESTS=${THEROCK_ENABLE_LLVM_TESTS}
-      -DTHEROCK_BUILD_COMGR_TESTS=${THEROCK_BUILD_COMGR_TESTS}
       -DLLVM_ENABLE_ZLIB=FORCE_ON
       -DLLVM_ENABLE_Z3_SOLVER=OFF
       -DLLVM_ENABLE_LIBXML2=OFF
@@ -168,7 +163,6 @@ if(THEROCK_ENABLE_COMPILER)
       # symbols inside libamd_comgr.so, preventing symbol interposition without
       # requiring namespace isolation via dlmopen.
       -DCOMGR_STATIC_LLVM=ON
-      -DTHEROCK_BUILD_COMGR_TESTS=${THEROCK_BUILD_COMGR_TESTS}
       -DTHEROCK_HIP_MAJOR_VERSION=${THEROCK_HIP_MAJOR_VERSION}
       -DTHEROCK_HIP_MINOR_VERSION=${THEROCK_HIP_MINOR_VERSION}
       "-DLLVM_VERSION_SUFFIX=-rocm${ROCM_MAJOR_VERSION}"
@@ -185,23 +179,6 @@ if(THEROCK_ENABLE_COMPILER)
   )
   therock_cmake_subproject_provide_package(amd-comgr amd_comgr lib/cmake/amd_comgr)
   therock_cmake_subproject_activate(amd-comgr)
-
-  if(THEROCK_BUILD_COMGR_TESTS)
-    if(WIN32)
-      set(_llvm_lit_script "${CMAKE_BINARY_DIR}/compiler/amd-llvm/build/bin/llvm-lit.py")
-    else()
-      set(_llvm_lit_script "${CMAKE_BINARY_DIR}/compiler/amd-llvm/build/bin/llvm-lit")
-    endif()
-    therock_cmake_subproject_build_test(amd-comgr
-      COMMAND
-        "${Python3_EXECUTABLE}" "${_llvm_lit_script}"
-        "${CMAKE_BINARY_DIR}/compiler/amd-comgr/build/test-lit" -v
-      COMMAND
-        "${CMAKE_CTEST_COMMAND}"
-        --test-dir "${CMAKE_BINARY_DIR}/compiler/amd-comgr/build"
-        --output-on-failure
-    )
-  endif()
 
   therock_test_validate_shared_lib(
     PATH amd-comgr/dist/lib

--- a/compiler/pre_hook_amd-llvm.cmake
+++ b/compiler/pre_hook_amd-llvm.cmake
@@ -72,6 +72,37 @@ endif()
 if(THEROCK_BUILD_LLVM_TESTS OR THEROCK_BUILD_LLVM_TOOLS OR THEROCK_BUILD_COMGR_TESTS)
   set(LLVM_BUILD_TOOLS ON CACHE BOOL "Build LLVM tools required for tests" FORCE)
   set(LLVM_INSTALL_UTILS ON CACHE BOOL "Install LLVM utility binaries like FileCheck" FORCE)
+
+  # Install llvm-lit script and the lit Python module for running LIT tests.
+  # LLVM_INSTALL_UTILS only installs C++ utilities (FileCheck, not, etc.),
+  # but llvm-lit is a Python script that requires separate handling.
+  install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/bin/llvm-lit" DESTINATION bin)
+
+  # Install the lit Python module. This is needed for llvm-lit to function.
+  # We install it to a lib/python subdirectory and set PYTHONPATH in llvm-lit.
+  set(_lit_source_dir "${CMAKE_CURRENT_SOURCE_DIR}/../llvm/utils/lit")
+  install(DIRECTORY "${_lit_source_dir}/lit"
+    DESTINATION "lib/python"
+    PATTERN "__pycache__" EXCLUDE
+    PATTERN "*.pyc" EXCLUDE
+  )
+
+  # Create a wrapper script that sets PYTHONPATH before invoking the real llvm-lit
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/llvm-lit-wrapper" [=[#!/usr/bin/env bash
+# Wrapper script for llvm-lit that sets up PYTHONPATH
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export PYTHONPATH="${SCRIPT_DIR}/../lib/python:${PYTHONPATH}"
+exec "${SCRIPT_DIR}/llvm-lit.real" "$@"
+]=])
+  # Install the wrapper and rename the original
+  install(CODE "
+    # Rename the original llvm-lit to llvm-lit.real
+    file(RENAME \"\${CMAKE_INSTALL_PREFIX}/bin/llvm-lit\" \"\${CMAKE_INSTALL_PREFIX}/bin/llvm-lit.real\" )
+    # Install the wrapper script as llvm-lit
+    file(COPY \"${CMAKE_CURRENT_BINARY_DIR}/llvm-lit-wrapper\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}/bin\")
+    file(RENAME \"\${CMAKE_INSTALL_PREFIX}/bin/llvm-lit-wrapper\" \"\${CMAKE_INSTALL_PREFIX}/bin/llvm-lit\")
+    file(CHMOD \"\${CMAKE_INSTALL_PREFIX}/bin/llvm-lit\" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+  ")
 endif()
 # we have never enabled benchmarks,
 # disabling more explicitly after a bug fix enabled.


### PR DESCRIPTION
This reverts commit 54acd32c58aa0b5c2911b42b53bc23b0e0ddd6d6.

## Motivation

Fixes https://github.com/ROCm/TheRock/issues/5074. This commit inadvertently disabled building `offload-arch` on Windows, which caused sanity check tests to fail (among other downstream effects).

## Technical Details

See details at https://github.com/ROCm/TheRock/pull/4881#issuecomment-4390716989. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
