### PR TITLE
[rocSOLVER] Increase test timeout

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -154,9 +154,8 @@ test_matrix = {
     "rocsolver": {
         "job_name": "rocsolver",
         "fetch_artifact_args": "--blas --tests",
-        # 68350(approx) tests needs 48 mins, so 48 mins / 2 shards = 24 mins per shard
-        # 24 mins + 20% margin = 30 mins => ~40 mins (considering gpu delays and lags)
-        "timeout_minutes": 60,
+        # Extended tests on math-ci take approx 5 hrs (as of May 5, 2026)
+        "timeout_minutes": 120,
         "test_script": f"python {_get_script_path('test_rocsolver.py')}",
         # Issue for adding windows tests: https://github.com/ROCm/TheRock/issues/1770
         "platform": ["linux"],


### PR DESCRIPTION
## Motivation

Nightly rocSOLVER tests intermittently time out on theRock CI. The variance in test time will need to be investigated, but increasing the time out value was suggested as a short-term solution.

## Technical Details

Increased test time out for rocSOLVER from 60 mins to 120 mins.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
