### PR TITLE
[CI] Run CTest with --parallel 1 for library test drivers

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_fusilliprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_fusilliprovider.py
@@ -22,7 +22,7 @@ cmd = [
     str(fusilli_test_dir),
     "--output-on-failure",
     "--parallel",
-    "8",
+    "1",
 ]
 
 # Set up environment variables

--- a/build_tools/github_actions/test_executable_scripts/test_hipblasltprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblasltprovider.py
@@ -19,7 +19,7 @@ cmd = [
     f"{THEROCK_BIN_DIR}/hipblaslt_plugin",
     "--output-on-failure",
     "--parallel",
-    "8",
+    "1",
 ]
 
 # Determine test filter based on TEST_TYPE environment variable

--- a/build_tools/github_actions/test_executable_scripts/test_hipcub.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipcub.py
@@ -100,7 +100,7 @@ cmd = [
     f"{THEROCK_BIN_DIR}/hipcub",
     "--output-on-failure",
     "--parallel",
-    "8",
+    "1",
     "--resource-spec-file",
     resource_spec_file,
 ]

--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn.py
@@ -20,7 +20,7 @@ cmd = [
     f"{THEROCK_BIN_DIR}/hipdnn",
     "--output-on-failure",
     "--parallel",
-    "8",
+    "1",
 ]
 
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")

--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn_install.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn_install.py
@@ -95,7 +95,7 @@ def run_tests(build_dir: Path):
         str(build_dir),
         "--output-on-failure",
         "--parallel",
-        "8",
+        "1",
     ]
     logging.info(f"++ Test: {shlex.join(test_cmd)}")
     subprocess.run(test_cmd, check=True, cwd=THEROCK_DIR, env=environ_vars)

--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn_integration_tests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn_integration_tests.py
@@ -19,7 +19,7 @@ cmd = [
     f"{THEROCK_BIN_DIR}/hipdnn_integration_tests_ctest",
     "--output-on-failure",
     "--parallel",
-    "8",
+    "1",
 ]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 

--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn_samples.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn_samples.py
@@ -19,7 +19,7 @@ cmd = [
     f"{THEROCK_BIN_DIR}/hipdnn_samples",
     "--output-on-failure",
     "--parallel",
-    "8",
+    "1",
 ]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 

--- a/build_tools/github_actions/test_executable_scripts/test_hipkernelprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipkernelprovider.py
@@ -25,7 +25,7 @@ cmd = [
     f"{THEROCK_BIN_DIR}/hip_kernel_provider",
     "--output-on-failure",
     "--parallel",
-    "8",
+    "1",
 ]
 
 # Determine test filter based on TEST_TYPE environment variable

--- a/build_tools/github_actions/test_executable_scripts/test_hiprand.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiprand.py
@@ -19,7 +19,7 @@ cmd = [
     f"{THEROCK_BIN_DIR}/hipRAND",
     "--output-on-failure",
     "--parallel",
-    "8",
+    "1",
 ]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 

--- a/build_tools/github_actions/test_executable_scripts/test_miopenprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopenprovider.py
@@ -36,7 +36,7 @@ cmd = [
     f"{THEROCK_BIN_DIR}/miopen_plugin",
     "--output-on-failure",
     "--parallel",
-    "8",
+    "1",
 ]
 
 if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILIES]:

--- a/build_tools/github_actions/test_executable_scripts/test_rocprim.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprim.py
@@ -108,7 +108,7 @@ cmd = [
     f"{THEROCK_BIN_DIR}/rocprim",
     "--output-on-failure",
     "--parallel",
-    "8",
+    "1",
     "--repeat",
     "until-pass:6",
     # shards the tests by running a specific set of tests based on starting test (shard_index) and stride (total_shards)

--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_sdk.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_sdk.py
@@ -97,7 +97,7 @@ def execute_tests():
         "--test-dir",
         "build",
         "--parallel",
-        "8",
+        "1",
         "--output-on-failure",
     ]
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocrand.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocrand.py
@@ -88,7 +88,7 @@ cmd = [
     f"{THEROCK_BIN_DIR}/rocRAND",
     "--output-on-failure",
     "--parallel",
-    "8",
+    "1",
     "--repeat",
     "until-pass:3",
 ]

--- a/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
@@ -84,12 +84,8 @@ QUICK_TESTS = [
     "ZipIterator*",
 ]
 
-# Some platforms are less capable than others.
-ctest_parallel_count = 8
-if AMDGPU_FAMILIES == "gfx1152":
-    ctest_parallel_count = 4
-elif AMDGPU_FAMILIES == "gfx1153":
-    ctest_parallel_count = 4
+# Serial CTest for CI stability on shared GPU runners.
+ctest_parallel_count = 1
 
 # Generate the resource spec file for ctest
 rocm_base = Path(THEROCK_BIN_DIR).resolve().parent

--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -67,12 +67,8 @@ TEST_COMPONENT = COMPONENT_DIR_MAPPING.get(
 SHARD_INDEX = os.getenv("SHARD_INDEX", 1)
 TOTAL_SHARDS = os.getenv("TOTAL_SHARDS", 1)
 
-# CTest parallel jobs (use fewer in less capable platforms)
-ctest_parallel_count = 8
-if AMDGPU_FAMILIES and "gfx1152" in AMDGPU_FAMILIES:
-    ctest_parallel_count = 4
-elif AMDGPU_FAMILIES and "gfx1153" in AMDGPU_FAMILIES:
-    ctest_parallel_count = 4
+# CTest parallel jobs: serial (1) for CI stability on shared GPU runners.
+ctest_parallel_count = 1
 
 # CTest per-test timeout (default 2 hours, in seconds)
 # There should be a timeout set from component level, but this can be used as an override


### PR DESCRIPTION
## Summary
Sets CTest job parallelism to **1** (serial test processes) across TheRock GitHub Actions test drivers in `build_tools/github_actions/test_executable_scripts/`, to reduce GPU/driver contention and improve stability on shared CI runners.

## Changes
- **`test_runner.py`**: single parallel count `1` (replaces 8 and gfx1152/gfx1153 → 4). Affects rocBLAS, MIOpen, hipSPARSELt, rocprofiler-compute jobs that use this runner.
- **`test_rocthrust.py`**: same.
- **Per-component scripts** that hardcoded `--parallel` `8` → `1` (rocRAND, rocPRIM, MIOpen provider, hipCUB, hipDNN family, hipRAND, Fusilli, hipBLASLt provider, hipkernel provider).
- **`test_rocprofiler_sdk.py`**: `ctest --parallel` set to `1`; `cmake --build --parallel 8` unchanged.

`test_rocwmma.py` was already parallel 1; no edit.

## Out of scope
- No updates to `rocm-libraries/test/therock/` mirrors (TheRock-only for this pass).

## Follow-up
If step durations approach timeouts, consider raising per-component `timeout_minutes` in `fetch_test_configurations.py` or additional sharding rather than restoring CTest parallelism.

Made with [Cursor](https://cursor.com)