### PR TITLE
Replace configure check `_GITHUB_WORKFLOWS_CI_PATTERNS` with an explicit list

### DIFF
--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -16,7 +16,7 @@ Public API:
 """
 
 import fnmatch
-import os
+from pathlib import Path
 import subprocess
 import sys
 from typing import Iterable, Optional
@@ -227,7 +227,7 @@ def _check_for_non_skippable_path(paths: Optional[Iterable[str]]) -> bool:
 
 def _is_path_workflow_file_related_to_ci(path: str) -> bool:
     """Checks if a single path is a CI-related workflow file."""
-    return os.path.basename(path) in _GITHUB_WORKFLOWS_CI_FILENAMES
+    return Path(path).name in _GITHUB_WORKFLOWS_CI_FILENAMES
 
 
 def _check_for_workflow_file_related_to_ci(paths: Optional[Iterable[str]]) -> bool:

--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -145,8 +145,8 @@ def is_ci_run_required(paths: Optional[Iterable[str]]) -> bool:
 # ============================================================================
 
 # File path patterns that don't trigger CI runs.
-# Changes to files matching these patterns are considered documentation/configuration
-# that don't affect build or test workflows.
+# Changes to files matching these patterns are considered
+# documentation/configuration that don't affect build or test workflows.
 _SKIPPABLE_PATH_PATTERNS = [
     "docs/*",
     "*.gitignore",
@@ -163,13 +163,16 @@ _SKIPPABLE_PATH_PATTERNS = [
     "experimental/*",
 ]
 
-# GitHub workflow files that are considered CI-related.  Changes to any of
-# these trigger CI runs.  This is an explicit list (not glob patterns) so that
+# GitHub workflow files that are used by CI workflows. Changes to any of
+# these trigger CI runs. This is an explicit list (not glob patterns) so that
 # unrelated workflows are never accidentally included.
 #
-# Maintained manually — the unit test
-# ``test_ci_workflow_filenames_cover_all_transitive_uses`` verifies that every
+# This list is maintained manually and a unit test verifies that every
 # workflow transitively called by ci.yml / multi_arch_ci.yml is listed here.
+#
+# TODO: Compute this set dynamically by scanning workflow files for
+# ``uses: ./.github/workflows/...`` references instead of maintaining it
+# by hand.
 _GITHUB_WORKFLOWS_CI_FILENAMES = {
     # ci.yml only
     "ci.yml",

--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -16,6 +16,7 @@ Public API:
 """
 
 import fnmatch
+import os
 import subprocess
 import sys
 from typing import Iterable, Optional
@@ -162,21 +163,43 @@ _SKIPPABLE_PATH_PATTERNS = [
     "experimental/*",
 ]
 
-# GitHub workflow file patterns that are considered CI-related.
-# Changes to workflow files matching these patterns will trigger CI runs,
-# as they may affect the CI pipeline itself.
-_GITHUB_WORKFLOWS_CI_PATTERNS = [
+# GitHub workflow files that are considered CI-related.  Changes to any of
+# these trigger CI runs.  This is an explicit list (not glob patterns) so that
+# unrelated workflows are never accidentally included.
+#
+# Maintained manually — the unit test
+# ``test_ci_workflow_filenames_cover_all_transitive_uses`` verifies that every
+# workflow transitively called by ci.yml / multi_arch_ci.yml is listed here.
+_GITHUB_WORKFLOWS_CI_FILENAMES = {
+    # ci.yml only
+    "ci.yml",
     "setup.yml",
-    "ci*.yml",
-    "multi_arch*.yml",
-    "build*artifact*.yml",
-    "build*ci.yml",
-    "build*python_packages.yml",
-    "test*artifacts.yml",
-    "test_rocm_wheels.yml",
-    "test_sanity_check.yml",
+    "ci_linux.yml",
+    "ci_windows.yml",
+    "build_native_linux_packages.yml",
+    "build_portable_linux_artifacts.yml",
+    "build_windows_artifacts.yml",
+    # multi_arch_ci.yml only
+    "multi_arch_ci.yml",
+    "multi_arch_ci_linux.yml",
+    "multi_arch_ci_windows.yml",
+    "multi_arch_build_native_linux_packages.yml",
+    "multi_arch_build_portable_linux.yml",
+    "multi_arch_build_portable_linux_artifacts.yml",
+    "multi_arch_build_windows.yml",
+    "multi_arch_build_windows_artifacts.yml",
+    "setup_multi_arch.yml",
+    "test_artifacts_structure.yml",
+    "test_native_linux_packages_install.yml",
+    # both
+    "build_portable_linux_python_packages.yml",
+    "build_portable_linux_pytorch_wheels_ci.yml",
+    "build_windows_python_packages.yml",
+    "build_windows_pytorch_wheels_ci.yml",
+    "test_artifacts.yml",
     "test_component.yml",
-]
+    "test_rocm_wheels.yml",
+}
 
 
 # ============================================================================
@@ -201,10 +224,7 @@ def _check_for_non_skippable_path(paths: Optional[Iterable[str]]) -> bool:
 
 def _is_path_workflow_file_related_to_ci(path: str) -> bool:
     """Checks if a single path is a CI-related workflow file."""
-    return any(
-        fnmatch.fnmatch(path, ".github/workflows/" + pattern)
-        for pattern in _GITHUB_WORKFLOWS_CI_PATTERNS
-    )
+    return os.path.basename(path) in _GITHUB_WORKFLOWS_CI_FILENAMES
 
 
 def _check_for_workflow_file_related_to_ci(paths: Optional[Iterable[str]]) -> bool:

--- a/build_tools/github_actions/tests/configure_ci_path_filters_test.py
+++ b/build_tools/github_actions/tests/configure_ci_path_filters_test.py
@@ -60,9 +60,12 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
         """_GITHUB_WORKFLOWS_CI_FILENAMES must exactly match the set of
         workflows transitively called by ci.yml and multi_arch_ci.yml.
 
+        This is a change-detector test that can be removed if
+        _GITHUB_WORKFLOWS_CI_FILENAMES is computed dynamically instead of
+        maintained by hand.
+
         If this test fails, update _GITHUB_WORKFLOWS_CI_FILENAMES in
         configure_ci_path_filters.py to match the actual workflow tree.
-        See https://github.com/ROCm/TheRock/pull/5066#issuecomment-4384099586
         """
         all_used = get_transitive_workflow_uses(["ci.yml", "multi_arch_ci.yml"])
         missing = all_used - _GITHUB_WORKFLOWS_CI_FILENAMES

--- a/build_tools/github_actions/tests/configure_ci_path_filters_test.py
+++ b/build_tools/github_actions/tests/configure_ci_path_filters_test.py
@@ -9,7 +9,8 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
-from configure_ci_path_filters import is_ci_run_required
+from configure_ci_path_filters import is_ci_run_required, _GITHUB_WORKFLOWS_CI_FILENAMES
+from workflow_utils import get_transitive_workflow_uses
 
 
 class ConfigureCIPathFiltersTest(unittest.TestCase):
@@ -37,7 +38,7 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
         run_ci = is_ci_run_required(paths)
         self.assertTrue(run_ci)
 
-        paths = [".github/workflows/build_artifact.yml"]
+        paths = [".github/workflows/build_native_linux_packages.yml"]
         run_ci = is_ci_run_required(paths)
         self.assertTrue(run_ci)
 
@@ -54,6 +55,31 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
         paths = ["source_file.h", ".github/workflows/pre-commit.yml"]
         run_ci = is_ci_run_required(paths)
         self.assertTrue(run_ci)
+
+    def test_ci_workflow_filenames_cover_all_transitive_uses(self):
+        """_GITHUB_WORKFLOWS_CI_FILENAMES must exactly match the set of
+        workflows transitively called by ci.yml and multi_arch_ci.yml.
+
+        If this test fails, update _GITHUB_WORKFLOWS_CI_FILENAMES in
+        configure_ci_path_filters.py to match the actual workflow tree.
+        See https://github.com/ROCm/TheRock/pull/5066#issuecomment-4384099586
+        """
+        all_used = get_transitive_workflow_uses(["ci.yml", "multi_arch_ci.yml"])
+        missing = all_used - _GITHUB_WORKFLOWS_CI_FILENAMES
+        stale = _GITHUB_WORKFLOWS_CI_FILENAMES - all_used
+        errors = []
+        if missing:
+            errors.append(
+                "Missing (add to _GITHUB_WORKFLOWS_CI_FILENAMES):\n"
+                + "\n".join(f"  - {f}" for f in sorted(missing))
+            )
+        if stale:
+            errors.append(
+                "Stale (remove from _GITHUB_WORKFLOWS_CI_FILENAMES):\n"
+                + "\n".join(f"  - {f}" for f in sorted(stale))
+            )
+        if errors:
+            self.fail("\n".join(errors))
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/tests/workflow_utils.py
+++ b/build_tools/github_actions/tests/workflow_utils.py
@@ -77,6 +77,39 @@ def get_required_workflow_dispatch_inputs(workflow: dict) -> set:
     return required
 
 
+def get_transitive_workflow_uses(root_filenames: list[str]) -> set[str]:
+    """Returns all workflow filenames transitively referenced via reusable workflow calls.
+
+    Starting from the given root workflow filenames, follows all
+    ``uses: ./.github/workflows/<name>.yml`` references in job definitions
+    and returns the complete set of workflow filenames (including the roots).
+    """
+    visited: set[str] = set()
+    queue = list(root_filenames)
+    while queue:
+        filename = queue.pop()
+        if filename in visited:
+            continue
+        visited.add(filename)
+        workflow_path = WORKFLOWS_DIR / filename
+        if not workflow_path.exists():
+            continue
+        workflow = load_workflow(workflow_path)
+        if not isinstance(workflow, dict):
+            continue
+        jobs = workflow.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        for job_def in jobs.values():
+            if not isinstance(job_def, dict):
+                continue
+            uses = job_def.get("uses")
+            if isinstance(uses, str) and uses.startswith("./.github/workflows/"):
+                ref_filename = uses.removeprefix("./.github/workflows/")
+                queue.append(ref_filename)
+    return visited
+
+
 def get_choice_options(workflow: dict, input_name: str) -> list | None:
     """Extracts the options list for a type: choice workflow_dispatch input.
 


### PR DESCRIPTION
## Motivation

This list is used to check whether a given set of changes should run CI workflows, so changes to just e.g. release or nightly test workflows would not run CI jobs. The curated list of patterns could have false negatives and false positives and would often go out of sync with workflows. Now there is an explicit list which is checked by a change detector unit test.

## Technical Details

We could also switch to computing dynamically, but I'm cautious about the CI workflows doing too much introspection (slow, more risk of bugs).

## Test Plan

New unit test passes on current code and can catch changes:
```diff
(.venv) λ git diff
diff --git a/.github/workflows/multi_arch_ci_linux.yml b/.github/workflows/multi_arch_ci_linux.yml
index db3f0973b..5c4c56661 100644
--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -73,7 +73,7 @@ jobs:
     name: Build Multi-Arch Stages
     needs: copy_prebuilt_stages
     if: ${{ !cancelled() && !failure() }}
-    uses: ./.github/workflows/multi_arch_build_portable_linux.yml
+    uses: ./.github/workflows/multi_arch_build_portable_linux_2.yml
     secrets: inherit
```

```
pytest build_tools/github_actions/tests/configure_ci_path_filters_test.py -vv
...

        if stale:
            errors.append(
                "Stale (remove from _GITHUB_WORKFLOWS_CI_FILENAMES):\n"
                + "\n".join(f"  - {f}" for f in sorted(stale))
            )
        if errors:
>           self.fail("\n".join(errors))
E           AssertionError: Missing (add to _GITHUB_WORKFLOWS_CI_FILENAMES):
E             - multi_arch_build_portable_linux_2.yml
E           Stale (remove from _GITHUB_WORKFLOWS_CI_FILENAMES):
E             - multi_arch_build_portable_linux.yml
E             - multi_arch_build_portable_linux_artifacts.yml

build_tools\github_actions\tests\configure_ci_path_filters_test.py:85: AssertionError
=============================================== short test summary info ===============================================
FAILED build_tools\github_actions\tests\configure_ci_path_filters_test.py::ConfigureCIPathFiltersTest::test_ci_workflow_filenames_cover_all_transitive_uses
- AssertionError:
Missing (add to _GITHUB_WORKFLOWS_CI_FILENAMES):
  - multi_arch_build_portable_linux_2.yml
Stale (remove from _GITHUB_WORKFLOWS_CI_FILENAMES):
  - multi_arch_build_portable_linux.yml
  - multi_arch_build_portable_linux_artifacts.yml
============================================= 1 failed, 6 passed in 0.23s =============================================
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
