### PR TITLE
Add `--no-gpg-sign` to git patch commits in fetch_sources.py

### DIFF
--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -646,6 +646,7 @@ def apply_patches(args, projects):
                 "user.email=therockbot@amd.com",
                 "am",
                 "--whitespace=nowarn",
+                "--no-gpg-sign",
             ]
             + patch_files,
             cwd=project_dir,


### PR DESCRIPTION
## Motivation

When running fetch_sources.py we generate some patch commits for the files in [`patches/`](https://github.com/ROCm/TheRock/tree/main/patches), but it isn't necessarily useful for those patch commits to be signed since they will remain local.

This is the same fix that we applied to `external-builds/pytorch/` in https://github.com/ROCm/TheRock/pull/837.

## Technical Details

Docs: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---gpg-signkey-id

I'm using git commit signing for github commit signature verification (https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) with this in my global `~/.gitconfig`:
```gitconfig
[commit]
	gpgsign = true
[tag]
	gpgsign = true
```

I'm also using a hardware token to complete the signing, so each patch commit needs a physical tap and if I miss the tap I get a commit timeout error that leaves the submodule in a broken state until I go `git am --abort` in that directory.

## Test Plan

Ran fetch_sources with the change, no commit signing or hardware tap was required.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
