### PR TITLE
Enable `--include-iree-libs` fetch and `-DTHEROCK_ENABLE_IREE_LIBS` build by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,10 +248,9 @@ option(THEROCK_ENABLE_ML_LIBS "Enable building of ML libraries" "${THEROCK_ENABL
 option(THEROCK_ENABLE_PROFILER "Enable building the profiler libraries" "${THEROCK_ENABLE_ALL}")
 option(THEROCK_ENABLE_DC_TOOLS "Enable building of data center tools" "${THEROCK_ENABLE_ALL}")
 option(THEROCK_ENABLE_MEDIA_LIBS "Enable building of Media libraries" "${THEROCK_ENABLE_ALL}")
+option(THEROCK_ENABLE_IREE_LIBS "Enable building of IREE libraries" "${THEROCK_ENABLE_ALL}")
 option(THEROCK_ENABLE_HOST_MATH "Build all bundled host math libraries by default" OFF)
 option(THEROCK_RESET_FEATURES "One-shot flag which forces all feature flags to their default state for this configuration run" OFF)
-# TODO(iree-org/fusilli/issues/57): Enable fusilli build once multi-arch support lands.
-option(THEROCK_ENABLE_IREE_LIBS "Enable building of IREE libraries" OFF)
 
 ################################################################################
 # Artifact-based features are auto-generated from BUILD_TOPOLOGY.toml

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -885,7 +885,7 @@ def main(argv):
     )
     parser.add_argument(
         "--include-iree-libs",
-        default=False,
+        default=True,
         action=argparse.BooleanOptionalAction,
         help="Include IREE and related libraries",
     )


### PR DESCRIPTION
## Motivation

Multi-arch CI is now enabled by default in TheRock, so we should make the default for developers match what CI is doing.

See:
* https://github.com/ROCm/TheRock/issues/3337
* https://github.com/iree-org/fusilli/issues/57
* https://github.com/ROCm/rocm-libraries/pull/6903

## Technical Details

* This will add 45s+ to initial clone time when using the legacy fetch options.
  * Repositories that have not yet migrated to the `--stage` mode of fetching sources will pay this extra cost if they don't explicitly opt-out of the new setting.
* This will enable a few new subproject builds (IREE's LLVM, fusilli, etc.) by default which are already enabled for multi-arch CI.
  * Repositories that have not yet migrated to multi-arch CI may want to opt-out with `-DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_*=ON` for some subset (as rocm-libraries already does) or `-DTHEROCK_ENABLE_IREE_LIBS=OFF`
  * The `iree-compiler` artifact is still annotated with `disable_platforms = ["windows"]` in `BUILD_TOPOLOGY.toml`, so the builds remain disabled there

## Test Plan

* Multi-arch CI on this PR
* Non-multi-arch CI on this PR (watch fetch time and build time, see how non-multi-arch CI in other repositories may want to adapt)
  * https://github.com/ROCm/TheRock/actions/runs/25464273855?pr=5093
  * https://therock-ci-artifacts-external.s3.amazonaws.com/ROCm-TheRock/25464273855-linux/logs/gfx94X-dcgpu/index.html
  * https://therock-ci-artifacts-external.s3.amazonaws.com/ROCm-TheRock/25464273855-linux/logs/gfx94X-dcgpu/iree-compiler_build.log (~5 minutes to build iree-compiler)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
