### PR TITLE
Add release prebuilt artifact reuse mode

### DIFF
--- a/.github/workflows/copy_prebuilt_artifacts.yml
+++ b/.github/workflows/copy_prebuilt_artifacts.yml
@@ -91,6 +91,10 @@ on:
 permissions:
   contents: read
 
+run-name: >-
+  Copy Prebuilt Artifacts
+  (${{ inputs.platform }}, ${{ inputs.release_type }}) | prebuilt: ${{ inputs.prebuilt_prefix }}
+
 jobs:
   copy:
     name: Copy Prebuilt Artifacts

--- a/.github/workflows/copy_prebuilt_artifacts.yml
+++ b/.github/workflows/copy_prebuilt_artifacts.yml
@@ -1,0 +1,142 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Reusable workflow that materializes a release run's artifact prefix from a
+# fixed "prebuilt" prefix in the active artifact namespace.
+#
+# Behavior:
+# - If `prebuilt_prefix` is empty, the job runs but is a successful no-op.
+#   Downstream jobs can keep `needs:` on this workflow without conditional
+#   plumbing for normal source-build runs.
+# - If `prebuilt_prefix` is non-empty, the job copies all stage artifacts
+#   from that prefix into the active run's prefix using
+#   `artifact_manager.py copy --source-prefix-only --stage=all
+#   --require-matches`.
+#
+# This workflow is also exposed as `workflow_dispatch` for manual reruns,
+# e.g. when re-staging a patched prebuilt prefix.
+
+name: Copy Prebuilt Artifacts
+
+on:
+  workflow_call:
+    inputs:
+      prebuilt_prefix:
+        description: >-
+          Source prefix component (the part before "-linux"/"-windows") to
+          copy artifacts from. Empty means no-op (source-build mode).
+        type: string
+        default: ""
+      platform:
+        description: 'Platform: "linux" or "windows".'
+        type: string
+        required: true
+      amdgpu_families:
+        description: "Semicolon-separated GPU families to copy."
+        type: string
+        required: true
+      expand_family_to_targets:
+        description: >-
+          Pass --expand-family-to-targets to artifact_manager copy. Required
+          for kpack-split (multi-arch) prefixes; should be false for
+          single-family release builds.
+        type: boolean
+        default: false
+      release_type:
+        description: 'Release type: "dev", "nightly", or "prerelease".'
+        type: string
+        required: true
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+        default: ""
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      prebuilt_prefix:
+        description: 'Source prefix (e.g. "rerun-2026-04-30").'
+        type: string
+        required: true
+      platform:
+        description: 'Platform: "linux" or "windows".'
+        type: choice
+        options:
+          - linux
+          - windows
+        default: linux
+      amdgpu_families:
+        description: "Semicolon-separated GPU families to copy."
+        type: string
+        required: true
+      expand_family_to_targets:
+        description: "Pass --expand-family-to-targets to artifact_manager copy."
+        type: boolean
+        default: false
+      release_type:
+        description: 'Release type: "dev", "nightly", or "prerelease".'
+        type: choice
+        options:
+          - dev
+          - nightly
+          - prerelease
+        default: dev
+      ref:
+        description: "Branch, tag, or SHA to checkout."
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  copy:
+    name: Copy Prebuilt Artifacts
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: No-op when prebuilt_prefix is empty
+        if: ${{ inputs.prebuilt_prefix == '' }}
+        run: echo "prebuilt_prefix is empty; skipping copy (source-build mode)."
+
+      - name: Checkout
+        if: ${{ inputs.prebuilt_prefix != '' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Python
+        if: ${{ inputs.prebuilt_prefix != '' }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install artifact manager dependencies
+        if: ${{ inputs.prebuilt_prefix != '' }}
+        run: pip install boto3
+
+      - name: Configure AWS credentials
+        if: ${{ inputs.prebuilt_prefix != '' }}
+        uses: ./.github/actions/configure_aws_artifacts_credentials
+        with:
+          release_type: ${{ inputs.release_type }}
+
+      - name: Copy prebuilt artifacts
+        if: ${{ inputs.prebuilt_prefix != '' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
+        run: |
+          python build_tools/artifact_manager.py copy \
+            --source-run-id="${{ inputs.prebuilt_prefix }}" \
+            --source-prefix-only \
+            --stage=all \
+            --platform="${{ inputs.platform }}" \
+            --amdgpu-families="${{ inputs.amdgpu_families }}" \
+            ${{ inputs.expand_family_to_targets && '--expand-family-to-targets' || '' }} \
+            --require-matches

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -43,6 +43,13 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
+      prebuilt_prefix:
+        description: >-
+          Optional fixed prefix component (the part before "-linux"/
+          "-windows") to copy artifacts from instead of building from
+          source. Empty (the default) selects normal source-build mode.
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       release_type:
@@ -65,6 +72,12 @@ on:
         description: 'Comma-separated list of Windows GPU families. "all" = all, "none" = skip platform.'
         type: string
         default: "gfx110x"
+      prebuilt_prefix:
+        description: >-
+          Optional fixed prefix component to copy artifacts from instead of
+          building from source. Empty selects normal source-build mode.
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -72,7 +85,7 @@ permissions:
 run-name: >-
   Multi-Arch Release (${{ inputs.release_type }})
   | Linux: ${{ inputs.linux_amdgpu_families || 'none' }}
-  | Windows: ${{ inputs.windows_amdgpu_families || 'none' }}
+  | Windows: ${{ inputs.windows_amdgpu_families || 'none' }}${{ inputs.prebuilt_prefix && format(' | prebuilt: {0}', inputs.prebuilt_prefix) || '' }}
 
 jobs:
   setup:
@@ -101,6 +114,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ needs.setup.outputs.ref }}
+      prebuilt_prefix: ${{ inputs.prebuilt_prefix }}
     permissions:
       contents: read
       actions: write  # Added permission to trigger workflows
@@ -119,6 +133,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ needs.setup.outputs.ref }}
+      prebuilt_prefix: ${{ inputs.prebuilt_prefix }}
     permissions:
       contents: read
       actions: write  # Added permission to trigger workflows

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -29,13 +29,20 @@ on:
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
+      prebuilt_prefix:
+        description: >-
+          Optional fixed prefix to copy artifacts from instead of building
+          from source. Empty selects normal source-build mode.
+        type: string
+        default: ""
 
 permissions:
   contents: read
 
 jobs:
-  build_artifacts:
-    name: Build Artifacts
+  build_source:
+    name: Build Artifacts (source)
+    if: ${{ inputs.prebuilt_prefix == '' }}
     uses: ./.github/workflows/multi_arch_build_portable_linux.yml
     secrets: inherit
     with:
@@ -52,6 +59,41 @@ jobs:
     permissions:
       contents: read
       id-token: write
+
+  copy_prebuilt:
+    name: Copy Prebuilt Artifacts
+    uses: ./.github/workflows/copy_prebuilt_artifacts.yml
+    secrets: inherit
+    with:
+      prebuilt_prefix: ${{ inputs.prebuilt_prefix }}
+      platform: linux
+      amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
+      expand_family_to_targets: true
+      release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
+    permissions:
+      contents: read
+      id-token: write
+
+  build_artifacts:
+    name: Build Artifacts
+    needs: [build_source, copy_prebuilt]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      - name: Verify active producer succeeded
+        run: |
+          python build_tools/github_actions/verify_artifacts_ready.py \
+            --prebuilt-prefix="${{ inputs.prebuilt_prefix }}" \
+            --build-source-result="${{ needs.build_source.result }}" \
+            --copy-prebuilt-result="${{ needs.copy_prebuilt.result }}"
 
   build_tarballs:
     needs: [build_artifacts]
@@ -169,11 +211,15 @@ jobs:
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
 
+  # PyTorch wheels are built from source. The prebuilt path only re-stages
+  # ROCm artifacts; it does not carry PyTorch wheels, so skip the dispatch
+  # in prebuilt mode.
   # TODO: Consider switch pulling ROCm packages from the CDN instead of the artifact
   #   bucket if the job order is not altered.
   build_pytorch_wheels:
     needs: [build_artifacts, build_python_packages]
     name: Build PyTorch Wheels
+    if: ${{ inputs.prebuilt_prefix == '' }}
     runs-on: ubuntu-24.04
     permissions:
       actions: write

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -23,13 +23,20 @@ on:
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
+      prebuilt_prefix:
+        description: >-
+          Optional fixed prefix to copy artifacts from instead of building
+          from source. Empty selects normal source-build mode.
+        type: string
+        default: ""
 
 permissions:
   contents: read
 
 jobs:
-  build_artifacts:
-    name: Build Artifacts
+  build_source:
+    name: Build Artifacts (source)
+    if: ${{ inputs.prebuilt_prefix == '' }}
     uses: ./.github/workflows/multi_arch_build_windows.yml
     secrets: inherit
     with:
@@ -46,6 +53,41 @@ jobs:
     permissions:
       contents: read
       id-token: write
+
+  copy_prebuilt:
+    name: Copy Prebuilt Artifacts
+    uses: ./.github/workflows/copy_prebuilt_artifacts.yml
+    secrets: inherit
+    with:
+      prebuilt_prefix: ${{ inputs.prebuilt_prefix }}
+      platform: windows
+      amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
+      expand_family_to_targets: true
+      release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
+    permissions:
+      contents: read
+      id-token: write
+
+  build_artifacts:
+    name: Build Artifacts
+    needs: [build_source, copy_prebuilt]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      - name: Verify active producer succeeded
+        run: |
+          python build_tools/github_actions/verify_artifacts_ready.py \
+            --prebuilt-prefix="${{ inputs.prebuilt_prefix }}" \
+            --build-source-result="${{ needs.build_source.result }}" \
+            --copy-prebuilt-result="${{ needs.copy_prebuilt.result }}"
 
   build_tarballs:
     needs: [build_artifacts]
@@ -131,11 +173,15 @@ jobs:
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
 
+  # PyTorch wheels are built from source. The prebuilt path only re-stages
+  # ROCm artifacts; it does not carry PyTorch wheels, so skip the dispatch
+  # in prebuilt mode.
   # TODO: Consider switch pulling ROCm packages from the CDN instead of the artifact
   #   bucket if the job order is not altered.
   build_pytorch_wheels:
     needs: [build_artifacts, build_python_packages]
     name: Build PyTorch Wheels
+    if: ${{ inputs.prebuilt_prefix == '' }}
     runs-on: ubuntu-24.04
     permissions:
       actions: write

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -77,7 +77,9 @@ on:
 permissions:
   contents: read
 
-run-name: Release portable Linux packages (${{ inputs.families || 'default' }}, ${{ inputs.release_type || 'nightly' }})
+run-name: >-
+  Release portable Linux packages
+  (${{ inputs.families || 'default' }}, ${{ inputs.release_type || 'nightly' }})${{ inputs.prebuilt_prefix && format(' | prebuilt: {0}', inputs.prebuilt_prefix) || '' }}
 
 jobs:
   setup_metadata:

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -156,11 +156,9 @@ jobs:
   # prebuilt_prefix is empty so the downstream `needs:` graph stays stable
   # in source-build mode.
   #
-  # TODO: when `inputs.families` is empty (caller relies on the defaults
-  # computed by fetch_package_targets.py), this passes an empty
-  # amdgpu_families and copy --require-matches exits 1 in prebuilt mode.
-  # Resolve the family list in setup_metadata and feed both the matrix and
-  # copy_prebuilt from it so empty `families` works in prebuilt mode too.
+  # The family list is derived from the resolved package_targets matrix
+  # (not inputs.families) so an empty inputs.families - which expands via
+  # fetch_package_targets.py defaults - works correctly in prebuilt mode.
   copy_prebuilt:
     needs: [setup_metadata]
     name: Copy Prebuilt Artifacts
@@ -169,7 +167,7 @@ jobs:
     with:
       prebuilt_prefix: ${{ inputs.prebuilt_prefix }}
       platform: linux
-      amdgpu_families: ${{ inputs.families }}
+      amdgpu_families: ${{ join(fromJSON(needs.setup_metadata.outputs.package_targets).*.amdgpu_family, ';') }}
       expand_family_to_targets: false
       release_type: ${{ needs.setup_metadata.outputs.release_type }}
       repository: ${{ inputs.repository || github.repository }}

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -383,9 +383,8 @@ jobs:
           pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py  ${{ env.CUSTOM_PREFIX }}
 
-      # PyTorch/JAX wheels and native packages are built from source. The
-      # prebuilt path only re-stages ROCm artifacts; skip these dispatches
-      # in prebuilt mode.
+      # The prebuilt path only re-stages ROCm artifacts; it does not carry PyTorch wheels,
+      # so skip the dispatch in prebuilt mode.
       - name: Trigger building PyTorch wheels
         if: ${{ inputs.prebuilt_prefix == '' && github.repository_owner == 'ROCm' && matrix.target_bundle.expect_pytorch_failure == false }}
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
@@ -406,6 +405,8 @@ jobs:
         id: url-encode-tar
         run: python -c "from urllib.parse import quote; print('tar_url=${{ needs.setup_metadata.outputs.cloudfront_base_url }}/tarball/' + quote('${{ env.FILE_NAME }}'))" >> ${GITHUB_OUTPUT}
 
+      # The prebuilt path only re-stages ROCm artifacts; it does not carry JAX wheels,
+      # so skip the dispatch in prebuilt mode.
       - name: Trigger release JAX wheels
         if: ${{ inputs.prebuilt_prefix == '' && github.repository_owner == 'ROCm' }}
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -277,7 +277,7 @@ jobs:
       #                                build_python_packages.py
       #   OUTPUT_DIR/build/dist/rocm - flat merged tree for the dist tarball
       - name: Fetch prebuilt artifacts
-        if: ${{ inputs.prebuilt_prefix != '' && github.repository_owner == 'ROCm' }}
+        if: ${{ inputs.prebuilt_prefix != '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PREBUILT_FETCH_CACHE: ${{ github.workspace }}/output/prebuilt-fetch-cache
@@ -297,7 +297,7 @@ jobs:
             --download-cache-dir="${PREBUILT_FETCH_CACHE}"
 
       - name: Build dist tarball from prebuilt artifacts
-        if: ${{ inputs.prebuilt_prefix != '' && github.repository_owner == 'ROCm' }}
+        if: ${{ inputs.prebuilt_prefix != '' }}
         run: |
           cd ${{ env.OUTPUT_DIR }}/build/dist/rocm
           echo "Building ${{ env.DIST_ARCHIVE }}"

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -33,6 +33,12 @@ on:
       ref:
         description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow."
         type: string
+      prebuilt_prefix:
+        description: >-
+          Optional fixed prefix to copy artifacts from instead of building
+          from source. Empty selects normal source-build mode.
+        type: string
+        default: ""
   # Trigger manually (typically to test the workflow or manually build a release [candidate])
   workflow_dispatch:
     inputs:
@@ -57,6 +63,12 @@ on:
       prerelease_version:
         description: "(Optional) Number of the prerelease"
         type: string
+      prebuilt_prefix:
+        description: >-
+          Optional fixed prefix to copy artifacts from instead of building
+          from source. Empty selects normal source-build mode.
+        type: string
+        default: ""
   # Trigger on a schedule to build nightly release candidates.
   schedule:
     # Runs at 02:00 AM UTC, which is 7:00 PM PST (UTC-8)
@@ -140,6 +152,32 @@ jobs:
           THEROCK_PACKAGE_PLATFORM: "linux"
         run: python ./build_tools/github_actions/fetch_package_targets.py
 
+  # Top-level copy job. Always runs; the reusable workflow no-ops when
+  # prebuilt_prefix is empty so the downstream `needs:` graph stays stable
+  # in source-build mode.
+  #
+  # TODO: when `inputs.families` is empty (caller relies on the defaults
+  # computed by fetch_package_targets.py), this passes an empty
+  # amdgpu_families and copy --require-matches exits 1 in prebuilt mode.
+  # Resolve the family list in setup_metadata and feed both the matrix and
+  # copy_prebuilt from it so empty `families` works in prebuilt mode too.
+  copy_prebuilt:
+    needs: [setup_metadata]
+    name: Copy Prebuilt Artifacts
+    uses: ./.github/workflows/copy_prebuilt_artifacts.yml
+    secrets: inherit
+    with:
+      prebuilt_prefix: ${{ inputs.prebuilt_prefix }}
+      platform: linux
+      amdgpu_families: ${{ inputs.families }}
+      expand_family_to_targets: false
+      release_type: ${{ needs.setup_metadata.outputs.release_type }}
+      repository: ${{ inputs.repository || github.repository }}
+      ref: ${{ inputs.ref }}
+    permissions:
+      contents: read
+      id-token: write
+
   portable_linux_packages:
     name: ${{ matrix.target_bundle.amdgpu_family }}::Build Portable Linux
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
@@ -148,7 +186,7 @@ jobs:
       options: -v /runner/config:/home/awsconfig/
     continue-on-error: ${{ matrix.target_bundle.expect_failure == true }} # for GPU families that are flaky, we mark as xfail
     timeout-minutes: 720 # 12 hour timeout
-    needs: [setup_metadata]
+    needs: [setup_metadata, copy_prebuilt]
     permissions:
       contents: write
       actions: write # Added permission to trigger workflows
@@ -192,6 +230,7 @@ jobs:
           git config fetch.parallel 10
 
       - name: Setup ccache
+        if: ${{ inputs.prebuilt_prefix == '' }}
         run: |
           ./build_tools/setup_ccache.py \
             --release-type "${{ env.RELEASE_TYPE }}" \
@@ -199,6 +238,7 @@ jobs:
             --local-path "$CCACHE_DIR"
 
       - name: Runner health status
+        if: ${{ inputs.prebuilt_prefix == '' }}
         run: |
           ./build_tools/health_status.py
 
@@ -206,11 +246,13 @@ jobs:
         run: ./dockerfiles/install_awscli.sh
 
       - name: Fetch sources
+        if: ${{ inputs.prebuilt_prefix == '' }}
         timeout-minutes: 30
         run: |
           ./build_tools/fetch_sources.py --jobs 10
 
       - name: Configure Projects
+        if: ${{ inputs.prebuilt_prefix == '' }}
         env:
           amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
           package_version: ${{ needs.setup_metadata.outputs.version }}
@@ -222,12 +264,46 @@ jobs:
             --manylinux
 
       - name: Build Projects
+        if: ${{ inputs.prebuilt_prefix == '' }}
         run: |
           cmake --build ${{ env.OUTPUT_DIR }}/build --target therock-archives therock-dist
           cd ${{ env.OUTPUT_DIR }}/build/dist/rocm
           echo "Building ${{ env.DIST_ARCHIVE }}"
           tar cfz "${{ env.DIST_ARCHIVE }}" .
           ccache -s
+
+      # Prebuilt mode: the artifacts were copied into this run's prefix by
+      # the top-level copy_prebuilt job. Materialize them in two layouts
+      # using a shared download cache to avoid double-downloading:
+      #   BUILD_DIR/artifacts        - per-artifact subdirs for
+      #                                build_python_packages.py
+      #   OUTPUT_DIR/build/dist/rocm - flat merged tree for the dist tarball
+      - name: Fetch prebuilt artifacts
+        if: ${{ inputs.prebuilt_prefix != '' && github.repository_owner == 'ROCm' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PREBUILT_FETCH_CACHE: ${{ github.workspace }}/output/prebuilt-fetch-cache
+        run: |
+          mkdir -p ${{ env.BUILD_DIR }}/artifacts
+          mkdir -p ${{ env.OUTPUT_DIR }}/build/dist/rocm
+          python ./build_tools/artifact_manager.py fetch \
+            --stage=all \
+            --amdgpu-families="${{ matrix.target_bundle.amdgpu_family }}" \
+            --output-dir=${{ env.BUILD_DIR }}/artifacts \
+            --download-cache-dir="${PREBUILT_FETCH_CACHE}"
+          python ./build_tools/artifact_manager.py fetch \
+            --stage=all \
+            --amdgpu-families="${{ matrix.target_bundle.amdgpu_family }}" \
+            --output-dir=${{ env.OUTPUT_DIR }}/build/dist/rocm \
+            --flatten \
+            --download-cache-dir="${PREBUILT_FETCH_CACHE}"
+
+      - name: Build dist tarball from prebuilt artifacts
+        if: ${{ inputs.prebuilt_prefix != '' && github.repository_owner == 'ROCm' }}
+        run: |
+          cd ${{ env.OUTPUT_DIR }}/build/dist/rocm
+          echo "Building ${{ env.DIST_ARCHIVE }}"
+          tar cfz "${{ env.DIST_ARCHIVE }}" .
 
       - name: Build Python Packages
         run: |
@@ -237,7 +313,7 @@ jobs:
             "--version=${{ needs.setup_metadata.outputs.version }}"
 
       - name: Build Report
-        if: ${{ !cancelled() }}
+        if: ${{ inputs.prebuilt_prefix == '' && !cancelled() }}
         run: |
           echo "Full SDK du:"
           echo "------------"
@@ -245,7 +321,7 @@ jobs:
 
       # Analyze ninja build log to generate per-component timing report
       - name: Analyze Build Times
-        if: ${{ !cancelled() }}
+        if: ${{ inputs.prebuilt_prefix == '' && !cancelled() }}
         env:
           THEROCK_BUILD_PROF_LOG_DIR: ${{ env.OUTPUT_DIR }}/build/logs/therock-build-prof
         run: |
@@ -260,7 +336,7 @@ jobs:
           role-to-assume: arn:aws:iam::692859939525:role/therock-${{ env.RELEASE_TYPE }}
 
       - name: Post Build Upload
-        if: ${{ github.repository_owner == 'ROCm' && !cancelled() }}
+        if: ${{ inputs.prebuilt_prefix == '' && github.repository_owner == 'ROCm' && !cancelled() }}
         run: |
           python3 build_tools/github_actions/post_build_upload.py \
             --run-id ${{ github.run_id }} \
@@ -307,8 +383,11 @@ jobs:
           pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py  ${{ env.CUSTOM_PREFIX }}
 
+      # PyTorch/JAX wheels and native packages are built from source. The
+      # prebuilt path only re-stages ROCm artifacts; skip these dispatches
+      # in prebuilt mode.
       - name: Trigger building PyTorch wheels
-        if: ${{ github.repository_owner == 'ROCm' && matrix.target_bundle.expect_pytorch_failure == false }}
+        if: ${{ inputs.prebuilt_prefix == '' && github.repository_owner == 'ROCm' && matrix.target_bundle.expect_pytorch_failure == false }}
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:
           workflow: release_portable_linux_pytorch_wheels.yml
@@ -328,7 +407,7 @@ jobs:
         run: python -c "from urllib.parse import quote; print('tar_url=${{ needs.setup_metadata.outputs.cloudfront_base_url }}/tarball/' + quote('${{ env.FILE_NAME }}'))" >> ${GITHUB_OUTPUT}
 
       - name: Trigger release JAX wheels
-        if: ${{ github.repository_owner == 'ROCm' }}
+        if: ${{ inputs.prebuilt_prefix == '' && github.repository_owner == 'ROCm' }}
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:
           workflow: release_portable_linux_jax_wheels.yml

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -84,7 +84,9 @@ on:
 permissions:
   contents: read
 
-run-name: Release Windows packages (${{ inputs.families || 'default' }}, ${{ inputs.release_type || 'nightly' }})
+run-name: >-
+  Release Windows packages
+  (${{ inputs.families || 'default' }}, ${{ inputs.release_type || 'nightly' }})${{ inputs.prebuilt_prefix && format(' | prebuilt: {0}', inputs.prebuilt_prefix) || '' }}
 
 jobs:
   setup_metadata:

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -301,7 +301,7 @@ jobs:
       #                                build_python_packages.py
       #   BUILD_DIR/dist/rocm        - flat merged tree for the dist tarball
       - name: Fetch prebuilt artifacts
-        if: ${{ inputs.prebuilt_prefix != '' && github.repository_owner == 'ROCm' }}
+        if: ${{ inputs.prebuilt_prefix != '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PREBUILT_FETCH_CACHE: ${{ env.BUILD_DIR }}/prebuilt-fetch-cache
@@ -321,7 +321,7 @@ jobs:
             --download-cache-dir="${PREBUILT_FETCH_CACHE}"
 
       - name: Build dist tarball from prebuilt artifacts
-        if: ${{ inputs.prebuilt_prefix != '' && github.repository_owner == 'ROCm' }}
+        if: ${{ inputs.prebuilt_prefix != '' }}
         run: |
           cd ${{ env.BUILD_DIR }}/dist/rocm
           echo "Compressing ${{ env.DIST_ARCHIVE }}"

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -409,6 +409,8 @@ jobs:
           pip install boto3 packaging
           python ./build_tools/third_party/s3_management/manage.py  ${{ env.CUSTOM_PREFIX }}
 
+      # The prebuilt path only re-stages ROCm artifacts; it does not carry PyTorch wheels,
+      # so skip the dispatch in prebuilt mode.
       - name: Trigger building PyTorch wheels
         if: ${{ inputs.prebuilt_prefix == '' && github.repository_owner == 'ROCm' && matrix.target_bundle.expect_pytorch_failure == false }}
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -36,6 +36,12 @@ on:
       ref:
         description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow."
         type: string
+      prebuilt_prefix:
+        description: >-
+          Optional fixed prefix to copy artifacts from instead of building
+          from source. Empty selects normal source-build mode.
+        type: string
+        default: ""
   # Trigger manually (typically to test the workflow or manually build a release [candidate])
   workflow_dispatch:
     inputs:
@@ -63,6 +69,12 @@ on:
       extra_cmake_options:
         description: "Extra options to pass to the CMake configure command"
         type: string
+      prebuilt_prefix:
+        description: >-
+          Optional fixed prefix to copy artifacts from instead of building
+          from source. Empty selects normal source-build mode.
+        type: string
+        default: ""
 
   # Trigger on a schedule to build nightly release candidates.
   schedule:
@@ -141,12 +153,38 @@ jobs:
           THEROCK_PACKAGE_PLATFORM: "windows"
         run: python ./build_tools/github_actions/fetch_package_targets.py
 
+  # Top-level copy job. Always runs; the reusable workflow no-ops when
+  # prebuilt_prefix is empty so the downstream `needs:` graph stays stable
+  # in source-build mode.
+  #
+  # TODO: when `inputs.families` is empty (caller relies on the defaults
+  # computed by fetch_package_targets.py), this passes an empty
+  # amdgpu_families and copy --require-matches exits 1 in prebuilt mode.
+  # Resolve the family list in setup_metadata and feed both the matrix and
+  # copy_prebuilt from it so empty `families` works in prebuilt mode too.
+  copy_prebuilt:
+    needs: [setup_metadata]
+    name: Copy Prebuilt Artifacts
+    uses: ./.github/workflows/copy_prebuilt_artifacts.yml
+    secrets: inherit
+    with:
+      prebuilt_prefix: ${{ inputs.prebuilt_prefix }}
+      platform: windows
+      amdgpu_families: ${{ inputs.families }}
+      expand_family_to_targets: false
+      release_type: ${{ needs.setup_metadata.outputs.release_type }}
+      repository: ${{ inputs.repository || github.repository }}
+      ref: ${{ inputs.ref }}
+    permissions:
+      contents: read
+      id-token: write
+
   windows_packages:
     name: ${{ matrix.target_bundle.amdgpu_family }}::Build Windows
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-windows-scale-rocm' || 'windows-2022' }}
     continue-on-error: ${{ matrix.target_bundle.expect_failure == true }} # for GPU families that are flaky, we mark as xfail
     timeout-minutes: 720 # 12 hour timeout
-    needs: [setup_metadata]
+    needs: [setup_metadata, copy_prebuilt]
     permissions:
       contents: write
       actions: write # Added permission to trigger workflows
@@ -207,13 +245,16 @@ jobs:
 
       # After other installs, so MSVC get priority in the PATH.
       - name: Configure MSVC
+        if: ${{ inputs.prebuilt_prefix == '' }}
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Runner health status
+        if: ${{ inputs.prebuilt_prefix == '' }}
         run: |
           python ./build_tools/health_status.py
 
       - name: Setup ccache
+        if: ${{ inputs.prebuilt_prefix == '' }}
         run: |
           python ./build_tools/setup_ccache.py \
             --release-type "${{ env.RELEASE_TYPE }}" \
@@ -222,6 +263,7 @@ jobs:
             --log-dir "${BUILD_DIR}/logs/ccache"
 
       - name: Fetch sources
+        if: ${{ inputs.prebuilt_prefix == '' }}
         timeout-minutes: 30
         run: |
           git config fetch.parallel 10
@@ -230,6 +272,7 @@ jobs:
           python ./build_tools/fetch_sources.py --jobs 12
 
       - name: Configure Projects
+        if: ${{ inputs.prebuilt_prefix == '' }}
         env:
           cmake_preset: windows-release
           amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
@@ -239,12 +282,48 @@ jobs:
           python3 build_tools/github_actions/build_configure.py
 
       - name: Build therock-dist
+        if: ${{ inputs.prebuilt_prefix == '' }}
         run: cmake --build "${{ env.BUILD_DIR }}" --target therock-dist
 
       - name: Build therock-archives
+        if: ${{ inputs.prebuilt_prefix == '' }}
         run: cmake --build "${{ env.BUILD_DIR }}" --target therock-archives
 
       - name: Compress dist folder
+        if: ${{ inputs.prebuilt_prefix == '' }}
+        run: |
+          cd ${{ env.BUILD_DIR }}/dist/rocm
+          echo "Compressing ${{ env.DIST_ARCHIVE }}"
+          tar cfz "${{ env.DIST_ARCHIVE }}" --force-local .
+
+      # Prebuilt mode: the artifacts were copied into this run's prefix by
+      # the top-level copy_prebuilt job. Materialize them in two layouts
+      # using a shared download cache to avoid double-downloading:
+      #   BUILD_DIR/artifacts        - per-artifact subdirs for
+      #                                build_python_packages.py
+      #   BUILD_DIR/dist/rocm        - flat merged tree for the dist tarball
+      - name: Fetch prebuilt artifacts
+        if: ${{ inputs.prebuilt_prefix != '' && github.repository_owner == 'ROCm' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PREBUILT_FETCH_CACHE: ${{ env.BUILD_DIR }}/prebuilt-fetch-cache
+        run: |
+          mkdir -p "${{ env.BUILD_DIR }}/artifacts"
+          mkdir -p "${{ env.BUILD_DIR }}/dist/rocm"
+          python ./build_tools/artifact_manager.py fetch \
+            --stage=all \
+            --amdgpu-families="${{ matrix.target_bundle.amdgpu_family }}" \
+            --output-dir="${{ env.BUILD_DIR }}/artifacts" \
+            --download-cache-dir="${PREBUILT_FETCH_CACHE}"
+          python ./build_tools/artifact_manager.py fetch \
+            --stage=all \
+            --amdgpu-families="${{ matrix.target_bundle.amdgpu_family }}" \
+            --output-dir="${{ env.BUILD_DIR }}/dist/rocm" \
+            --flatten \
+            --download-cache-dir="${PREBUILT_FETCH_CACHE}"
+
+      - name: Build dist tarball from prebuilt artifacts
+        if: ${{ inputs.prebuilt_prefix != '' && github.repository_owner == 'ROCm' }}
         run: |
           cd ${{ env.BUILD_DIR }}/dist/rocm
           echo "Compressing ${{ env.DIST_ARCHIVE }}"
@@ -258,7 +337,7 @@ jobs:
             --version=${{ needs.setup_metadata.outputs.version }}
 
       - name: Build report
-        if: ${{ !cancelled() }}
+        if: ${{ inputs.prebuilt_prefix == '' && !cancelled() }}
         shell: bash
         run: |
           if [ -d "${{ env.BUILD_DIR }}" ]; then
@@ -283,7 +362,7 @@ jobs:
           special-characters-workaround: true
 
       - name: Post Build Upload
-        if: ${{ github.repository_owner == 'ROCm' && !cancelled() }}
+        if: ${{ inputs.prebuilt_prefix == '' && github.repository_owner == 'ROCm' && !cancelled() }}
         run: |
           python3 build_tools/github_actions/post_build_upload.py \
             --run-id ${{ github.run_id }} \

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -408,7 +408,7 @@ jobs:
           python ./build_tools/third_party/s3_management/manage.py  ${{ env.CUSTOM_PREFIX }}
 
       - name: Trigger building PyTorch wheels
-        if: ${{ github.repository_owner == 'ROCm' && matrix.target_bundle.expect_pytorch_failure == false }}
+        if: ${{ inputs.prebuilt_prefix == '' && github.repository_owner == 'ROCm' && matrix.target_bundle.expect_pytorch_failure == false }}
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:
           workflow: release_windows_pytorch_wheels.yml

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -157,11 +157,9 @@ jobs:
   # prebuilt_prefix is empty so the downstream `needs:` graph stays stable
   # in source-build mode.
   #
-  # TODO: when `inputs.families` is empty (caller relies on the defaults
-  # computed by fetch_package_targets.py), this passes an empty
-  # amdgpu_families and copy --require-matches exits 1 in prebuilt mode.
-  # Resolve the family list in setup_metadata and feed both the matrix and
-  # copy_prebuilt from it so empty `families` works in prebuilt mode too.
+  # The family list is derived from the resolved package_targets matrix
+  # (not inputs.families) so an empty inputs.families - which expands via
+  # fetch_package_targets.py defaults - works correctly in prebuilt mode.
   copy_prebuilt:
     needs: [setup_metadata]
     name: Copy Prebuilt Artifacts
@@ -170,7 +168,7 @@ jobs:
     with:
       prebuilt_prefix: ${{ inputs.prebuilt_prefix }}
       platform: windows
-      amdgpu_families: ${{ inputs.families }}
+      amdgpu_families: ${{ join(fromJSON(needs.setup_metadata.outputs.package_targets).*.amdgpu_family, ';') }}
       expand_family_to_targets: false
       release_type: ${{ needs.setup_metadata.outputs.release_type }}
       repository: ${{ inputs.repository || github.repository }}

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -135,6 +135,20 @@ def get_topology(topology_path: Optional[Path] = None) -> BuildTopology:
 # =============================================================================
 
 
+def parse_input_families(args: argparse.Namespace) -> List[str]:
+    """Return the user-specified input families (no generic, no expansions).
+
+    Accepts either ';' (canonical) or ',' as a separator so callers that
+    receive a CSV family list (e.g. workflow inputs whose docs say
+    comma-separated) can pass it through unchanged. Returns an empty list
+    if --generic-only was passed or no families were specified.
+    """
+    if args.generic_only or not args.amdgpu_families:
+        return []
+    raw = args.amdgpu_families.replace(",", ";")
+    return [f.strip() for f in raw.split(";") if f.strip()]
+
+
 def parse_target_families(args: argparse.Namespace) -> List[str]:
     """Parse target families from argparse args.
 
@@ -145,8 +159,8 @@ def parse_target_families(args: argparse.Namespace) -> List[str]:
     if args.generic_only:
         log("Using generic (host) artifacts only")
     else:
-        if args.amdgpu_families:
-            input_families = args.amdgpu_families.split(";")
+        input_families = parse_input_families(args)
+        if input_families:
             output_families.extend(input_families)
             if args.expand_family_to_targets:
                 family_map = amdgpu_family_map()
@@ -780,12 +794,23 @@ def copy_single_artifact(request: CopyRequest) -> bool:
 
 
 def _create_source_backend(
-    source_run_id: str, platform: str, local_staging_dir: Optional[Path] = None
+    source_run_id: str,
+    platform: str,
+    local_staging_dir: Optional[Path] = None,
+    prefix_only: bool = False,
 ) -> ArtifactBackend:
     """Create a backend for the source run ID.
 
-    For S3, uses WorkflowOutputRoot.from_workflow_run(lookup_workflow_run=True)
-    to resolve the correct bucket (which may differ from the current run's bucket).
+    For S3 with prefix_only=False (default), uses
+    WorkflowOutputRoot.from_workflow_run(lookup_workflow_run=True) to resolve
+    the correct bucket via a GitHub API call (which may differ from the
+    current run's bucket - e.g. fork or post-cutover).
+
+    For S3 with prefix_only=True, derives the bucket from the same env-based
+    rules used for the dest backend (no API call). The source's prefix is
+    formed from `source_run_id`-`platform` within that bucket. Use this when
+    the source artifacts live under a fixed prefix in the active run's
+    artifact namespace (e.g. a manually populated "prebuilt" prefix).
 
     For local backends, creates a LocalDirectoryBackend in the same staging dir.
     """
@@ -800,25 +825,53 @@ def _create_source_backend(
         )
 
     output_root = WorkflowOutputRoot.from_workflow_run(
-        run_id=source_run_id, platform=platform, lookup_workflow_run=True
+        run_id=source_run_id,
+        platform=platform,
+        lookup_workflow_run=not prefix_only,
     )
     return S3Backend(output_root=output_root)
+
+
+def _families_satisfied_by_matches(
+    artifact_names: Set[str],
+    matched_filenames: List[str],
+) -> Set[str]:
+    """Return the set of target_family tokens present in matched filenames."""
+    satisfied: Set[str] = set()
+    for filename in matched_filenames:
+        stem = filename
+        for ext in ARTIFACT_EXTENSIONS:
+            if stem.endswith(ext):
+                stem = stem[: -len(ext)]
+                break
+        for an in artifact_names:
+            for comp in ARTIFACT_COMPONENTS:
+                prefix = f"{an}_{comp}_"
+                if stem.startswith(prefix):
+                    satisfied.add(stem[len(prefix) :])
+                    break
+    return satisfied
 
 
 def do_copy(args: argparse.Namespace):
     """Copy produced artifacts for one or more stages from one run to another."""
     topology = get_topology(args.topology)
 
-    # Parse and validate stages (comma-separated). Unlike fetch/push which
-    # operate on a single stage, copy accepts multiple stages at once so that
-    # a single setup job can copy all prebuilt stages in one invocation.
-    stage_names = [s.strip() for s in args.stage.split(",") if s.strip()]
-    available_stages = topology.build_stages.keys()
-    for stage_name in stage_names:
-        if stage_name not in available_stages:
-            log(f"ERROR: Stage '{stage_name}' not found")
-            log(f"Available stages: {', '.join(available_stages)}")
-            sys.exit(1)
+    # Parse and validate stages. The literal token "all" expands to every
+    # build stage in the topology; otherwise comma-separated stage names are
+    # parsed. Unlike fetch/push which operate on a single stage, copy accepts
+    # multiple stages at once so that a single setup job can copy all
+    # prebuilt stages in one invocation.
+    available_stages = list(topology.build_stages.keys())
+    if args.stage.strip() == "all":
+        stage_names = available_stages
+    else:
+        stage_names = [s.strip() for s in args.stage.split(",") if s.strip()]
+        for stage_name in stage_names:
+            if stage_name not in available_stages:
+                log(f"ERROR: Stage '{stage_name}' not found")
+                log(f"Available stages: {', '.join(available_stages)}")
+                sys.exit(1)
 
     # Union produced artifacts across all specified stages
     produced: Set[str] = set()
@@ -834,12 +887,14 @@ def do_copy(args: argparse.Namespace):
         return
 
     target_families = parse_target_families(args)
+    input_families = parse_input_families(args)
 
     # Create source and dest backends
     source_backend = _create_source_backend(
         source_run_id=args.source_run_id,
         platform=args.platform,
         local_staging_dir=args.local_staging_dir,
+        prefix_only=args.source_prefix_only,
     )
     dest_backend = create_backend_from_env(
         run_id=args.run_id,
@@ -855,6 +910,28 @@ def do_copy(args: argparse.Namespace):
 
     # Build copy requests from matched artifacts
     matched_filenames = find_available_artifacts(produced, target_families, available)
+
+    if args.require_matches and input_families:
+        # With --expand-family-to-targets, an input family is satisfied by
+        # either a family-named artifact or any of its expanded targets.
+        family_map = (
+            amdgpu_family_map() if args.expand_family_to_targets else {}
+        )
+        satisfied_families = _families_satisfied_by_matches(produced, matched_filenames)
+        unsatisfied = []
+        for family in input_families:
+            candidates = {family}
+            if args.expand_family_to_targets:
+                candidates.update(family_map.get(family, []))
+            if not (candidates & satisfied_families):
+                unsatisfied.append(family)
+        if unsatisfied:
+            log(
+                f"ERROR: --require-matches: no source artifacts found for "
+                f"families: {', '.join(unsatisfied)}"
+            )
+            sys.exit(1)
+
     copy_requests = [
         CopyRequest(
             artifact_key=filename,
@@ -937,9 +1014,13 @@ def do_info(args: argparse.Namespace):
         else:
             log(f"  - {name}")
 
-    # Show target families if provided
+    # Show target families if provided. Accept comma or semicolon.
     if args.amdgpu_families:
-        families = args.amdgpu_families.split(";")
+        families = [
+            f.strip()
+            for f in args.amdgpu_families.replace(",", ";").split(";")
+            if f.strip()
+        ]
         target_families = ["generic"] + families
         log(f"\nTarget families: {', '.join(target_families)}")
 
@@ -1151,15 +1232,45 @@ def main(argv: Optional[List[str]] = None):
         "--source-run-id",
         type=str,
         required=True,
-        help="Run ID to copy artifacts from (bucket resolved via GitHub API)",
+        help=(
+            "Source run ID (or fixed prefix component) to copy artifacts "
+            "from. By default the source bucket is resolved via the GitHub "
+            "API; pass --source-prefix-only to skip the lookup and reuse the "
+            "active run's bucket selection."
+        ),
+    )
+    copy_parser.add_argument(
+        "--source-prefix-only",
+        action="store_true",
+        help=(
+            "Treat --source-run-id as a fixed prefix component and skip the "
+            "GitHub workflow run lookup. The source bucket is derived from "
+            "the same env-based rules as the dest bucket. Use when the "
+            "source artifacts live under a manually populated prefix in the "
+            "active run's artifact namespace."
+        ),
     )
     copy_parser.add_argument(
         "--stage",
         type=str,
         required=True,
-        help="Build stage name(s), comma-separated (e.g., 'foundation,compiler-runtime')",
+        help=(
+            "Build stage name(s), comma-separated (e.g., "
+            "'foundation,compiler-runtime'). Pass 'all' to union every "
+            "build stage in the topology."
+        ),
     )
     _add_target_args(copy_parser)
+    copy_parser.add_argument(
+        "--require-matches",
+        action="store_true",
+        help=(
+            "Fail with non-zero exit if any requested family yields no "
+            "matching source artifact. With --expand-family-to-targets, a "
+            "family is satisfied by either a family-named artifact or any "
+            "of its expanded target-named artifacts."
+        ),
+    )
     copy_parser.add_argument(
         "--concurrency",
         type=int,

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -1276,8 +1276,8 @@ def main(argv: Optional[List[str]] = None):
         required=True,
         help=(
             "Build stage name(s), comma-separated (e.g., "
-            "'foundation,compiler-runtime'). Pass 'all' to union every "
-            "build stage in the topology."
+            "'foundation,compiler-runtime'). Pass 'all' to copy every "
+            "artifact in the topology (matching `fetch --stage=all`)."
         ),
     )
     _add_target_args(copy_parser)

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -943,6 +943,8 @@ def do_copy(args: argparse.Namespace):
 
     if not copy_requests:
         log("No matching artifacts found to copy")
+        if args.require_matches:
+            sys.exit(1)
         return
 
     if args.dry_run:

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -857,30 +857,33 @@ def do_copy(args: argparse.Namespace):
     """Copy produced artifacts for one or more stages from one run to another."""
     topology = get_topology(args.topology)
 
-    # Parse and validate stages. The literal token "all" expands to every
-    # build stage in the topology; otherwise comma-separated stage names are
-    # parsed. Unlike fetch/push which operate on a single stage, copy accepts
-    # multiple stages at once so that a single setup job can copy all
-    # prebuilt stages in one invocation.
-    available_stages = list(topology.build_stages.keys())
+    # Parse and validate stages. The literal token "all" matches every
+    # artifact in the topology, mirroring `fetch --stage=all` semantics
+    # so an artifact present in topology but not produced by any stage is
+    # still copied. Otherwise comma-separated stage names are parsed and
+    # their produced artifacts are unioned. Unlike fetch/push which
+    # operate on a single stage, copy accepts multiple stages at once so
+    # that a single setup job can copy all prebuilt stages in one
+    # invocation.
+    produced: Set[str] = set()
     if args.stage.strip() == "all":
-        stage_names = available_stages
+        produced = set(topology.artifacts.keys())
+        log(f"Copying all {len(produced)} artifacts from topology")
     else:
         stage_names = [s.strip() for s in args.stage.split(",") if s.strip()]
         for stage_name in stage_names:
-            if stage_name not in available_stages:
+            if stage_name not in topology.build_stages:
                 log(f"ERROR: Stage '{stage_name}' not found")
-                log(f"Available stages: {', '.join(available_stages)}")
+                log(
+                    f"Available stages: {', '.join(topology.build_stages.keys())}"
+                )
                 sys.exit(1)
-
-    # Union produced artifacts across all specified stages
-    produced: Set[str] = set()
-    for stage_name in stage_names:
-        stage_produced = topology.get_produced_artifacts(stage_name)
-        log(
-            f"Stage '{stage_name}' produces {len(stage_produced)} artifacts: {', '.join(sorted(stage_produced))}"
-        )
-        produced.update(stage_produced)
+        for stage_name in stage_names:
+            stage_produced = topology.get_produced_artifacts(stage_name)
+            log(
+                f"Stage '{stage_name}' produces {len(stage_produced)} artifacts: {', '.join(sorted(stage_produced))}"
+            )
+            produced.update(stage_produced)
 
     if not produced:
         log("Specified stages produce no artifacts")

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -798,6 +798,7 @@ def _create_source_backend(
     platform: str,
     local_staging_dir: Optional[Path] = None,
     prefix_only: bool = False,
+    dest_output_root: Optional[WorkflowOutputRoot] = None,
 ) -> ArtifactBackend:
     """Create a backend for the source run ID.
 
@@ -806,11 +807,12 @@ def _create_source_backend(
     the correct bucket via a GitHub API call (which may differ from the
     current run's bucket - e.g. fork or post-cutover).
 
-    For S3 with prefix_only=True, derives the bucket from the same env-based
-    rules used for the dest backend (no API call). The source's prefix is
-    formed from `source_run_id`-`platform` within that bucket. Use this when
-    the source artifacts live under a fixed prefix in the active run's
-    artifact namespace (e.g. a manually populated "prebuilt" prefix).
+    For S3 with prefix_only=True, mirrors the dest backend's resolved
+    bucket and external_repo directly. Use this when the source artifacts
+    live under a fixed prefix in the active run's artifact namespace
+    (e.g. a manually populated "prebuilt" prefix). Mirroring dest avoids
+    silent divergence if dest's resolution accepts overrides (e.g. a
+    --run-github-repo flag) that the env-only path would not pick up.
 
     For local backends, creates a LocalDirectoryBackend in the same staging dir.
     """
@@ -824,10 +826,21 @@ def _create_source_backend(
             output_root=output_root,
         )
 
+    if prefix_only:
+        if dest_output_root is None:
+            raise ValueError("prefix_only requires dest_output_root")
+        output_root = WorkflowOutputRoot(
+            bucket=dest_output_root.bucket,
+            external_repo=dest_output_root.external_repo,
+            run_id=source_run_id,
+            platform=platform,
+        )
+        return S3Backend(output_root=output_root)
+
     output_root = WorkflowOutputRoot.from_workflow_run(
         run_id=source_run_id,
         platform=platform,
-        lookup_workflow_run=not prefix_only,
+        lookup_workflow_run=True,
     )
     return S3Backend(output_root=output_root)
 
@@ -892,16 +905,18 @@ def do_copy(args: argparse.Namespace):
     target_families = parse_target_families(args)
     input_families = parse_input_families(args)
 
-    # Create source and dest backends
+    # Create dest first; the source backend in prefix-only mode mirrors
+    # dest's resolved bucket/external_repo so the two cannot diverge.
+    dest_backend = create_backend_from_env(
+        run_id=args.run_id,
+        platform=args.platform,
+    )
     source_backend = _create_source_backend(
         source_run_id=args.source_run_id,
         platform=args.platform,
         local_staging_dir=args.local_staging_dir,
         prefix_only=args.source_prefix_only,
-    )
-    dest_backend = create_backend_from_env(
-        run_id=args.run_id,
-        platform=args.platform,
+        dest_output_root=dest_backend.output_root,
     )
 
     log(f"Source: {source_backend.base_uri}")

--- a/build_tools/github_actions/tests/verify_artifacts_ready_test.py
+++ b/build_tools/github_actions/tests/verify_artifacts_ready_test.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for verify_artifacts_ready.py."""
+
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+import verify_artifacts_ready as v
+
+
+class TestDecide(unittest.TestCase):
+    """Producer selection: prebuilt_prefix non-empty -> copy_prebuilt."""
+
+    def test_empty_prefix_selects_build_source(self):
+        producer, result = v.decide(
+            prebuilt_prefix="",
+            build_source_result="success",
+            copy_prebuilt_result="failure",
+        )
+        self.assertEqual(producer, "build_source")
+        self.assertEqual(result, "success")
+
+    def test_non_empty_prefix_selects_copy_prebuilt(self):
+        producer, result = v.decide(
+            prebuilt_prefix="rerun-2026-04-30",
+            build_source_result="failure",
+            copy_prebuilt_result="success",
+        )
+        self.assertEqual(producer, "copy_prebuilt")
+        self.assertEqual(result, "success")
+
+
+class TestMain(unittest.TestCase):
+    """End-to-end exit-code behavior."""
+
+    def _run(self, argv):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = v.main(argv)
+        return code, buf.getvalue()
+
+    def test_source_mode_success_exits_zero(self):
+        code, out = self._run(
+            [
+                "--prebuilt-prefix",
+                "",
+                "--build-source-result",
+                "success",
+                "--copy-prebuilt-result",
+                "skipped",
+            ]
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("build_source", out)
+
+    def test_source_mode_failure_exits_one(self):
+        code, out = self._run(
+            [
+                "--prebuilt-prefix",
+                "",
+                "--build-source-result",
+                "failure",
+                "--copy-prebuilt-result",
+                "success",
+            ]
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("build_source", out)
+        self.assertIn("failure", out)
+
+    def test_source_mode_ignores_copy_result(self):
+        # Copy result should not affect source mode.
+        code, _ = self._run(
+            [
+                "--prebuilt-prefix",
+                "",
+                "--build-source-result",
+                "success",
+                "--copy-prebuilt-result",
+                "failure",
+            ]
+        )
+        self.assertEqual(code, 0)
+
+    def test_prebuilt_mode_success_exits_zero(self):
+        code, out = self._run(
+            [
+                "--prebuilt-prefix",
+                "rerun-foo",
+                "--build-source-result",
+                "skipped",
+                "--copy-prebuilt-result",
+                "success",
+            ]
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("copy_prebuilt", out)
+
+    def test_prebuilt_mode_failure_exits_one(self):
+        code, out = self._run(
+            [
+                "--prebuilt-prefix",
+                "rerun-foo",
+                "--build-source-result",
+                "success",
+                "--copy-prebuilt-result",
+                "failure",
+            ]
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("copy_prebuilt", out)
+        self.assertIn("failure", out)
+
+    def test_prebuilt_mode_ignores_source_result(self):
+        # Source result should not affect prebuilt mode.
+        code, _ = self._run(
+            [
+                "--prebuilt-prefix",
+                "rerun-foo",
+                "--build-source-result",
+                "failure",
+                "--copy-prebuilt-result",
+                "success",
+            ]
+        )
+        self.assertEqual(code, 0)
+
+    def test_cancelled_active_producer_exits_one(self):
+        code, _ = self._run(
+            [
+                "--prebuilt-prefix",
+                "",
+                "--build-source-result",
+                "cancelled",
+                "--copy-prebuilt-result",
+                "success",
+            ]
+        )
+        self.assertEqual(code, 1)
+
+    def test_skipped_active_producer_exits_one(self):
+        # In source-build mode, a `skipped` source job is a failure: nothing
+        # produced the artifacts.
+        code, _ = self._run(
+            [
+                "--prebuilt-prefix",
+                "",
+                "--build-source-result",
+                "skipped",
+                "--copy-prebuilt-result",
+                "success",
+            ]
+        )
+        self.assertEqual(code, 1)
+
+    def test_whitespace_prefix_is_treated_as_empty(self):
+        # Defensive: leading/trailing whitespace in inputs shouldn't flip mode.
+        code, _ = self._run(
+            [
+                "--prebuilt-prefix",
+                "   ",
+                "--build-source-result",
+                "success",
+                "--copy-prebuilt-result",
+                "failure",
+            ]
+        )
+        self.assertEqual(code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/github_actions/verify_artifacts_ready.py
+++ b/build_tools/github_actions/verify_artifacts_ready.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Multi-arch release artifact-ready gate.
+
+Used by the multi-arch release workflows as a small synthetic
+`build_artifacts` job that gates downstream package/test jobs on whichever
+producer (source build or prebuilt copy) is active for this run.
+
+The job graph looks like this::
+
+    build_source         copy_prebuilt
+            \\           /
+             verify_artifacts_ready    <- this script
+                       |
+        +--------+-----+-----+----------+
+        |        |           |          |
+    tarballs  python    native      tests
+              packages  packages
+
+Mode selection:
+
+- If `--prebuilt-prefix` is empty, the active producer is `build_source`
+  and the script ignores `--copy-prebuilt-result`.
+- If `--prebuilt-prefix` is non-empty, the active producer is
+  `copy_prebuilt` and the script ignores `--build-source-result`.
+
+Exit code:
+
+- 0 if the active producer's GitHub Actions job result is `success`.
+- 1 otherwise (failure, cancelled, or skipped).
+
+Skipping the script entirely (e.g. `if: !always()`) would mask producer
+failures. Always run it and let it gate explicitly.
+"""
+
+import argparse
+import sys
+
+
+# GitHub Actions job result strings.
+RESULT_SUCCESS = "success"
+
+
+def decide(
+    prebuilt_prefix: str,
+    build_source_result: str,
+    copy_prebuilt_result: str,
+) -> tuple[str, str]:
+    """Return (producer_name, producer_result) for the active producer."""
+    if prebuilt_prefix:
+        return ("copy_prebuilt", copy_prebuilt_result)
+    return ("build_source", build_source_result)
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(prog="verify_artifacts_ready.py")
+    p.add_argument(
+        "--prebuilt-prefix",
+        default="",
+        help=(
+            "Value of the workflow's prebuilt_prefix input. Empty selects "
+            "source-build mode; non-empty selects prebuilt-copy mode."
+        ),
+    )
+    p.add_argument(
+        "--build-source-result",
+        default="",
+        help="GitHub Actions result of the source-build job (success|failure|cancelled|skipped).",
+    )
+    p.add_argument(
+        "--copy-prebuilt-result",
+        default="",
+        help="GitHub Actions result of the prebuilt-copy job (success|failure|cancelled|skipped).",
+    )
+    args = p.parse_args(argv)
+
+    producer, result = decide(
+        prebuilt_prefix=args.prebuilt_prefix.strip(),
+        build_source_result=args.build_source_result.strip(),
+        copy_prebuilt_result=args.copy_prebuilt_result.strip(),
+    )
+
+    if result == RESULT_SUCCESS:
+        print(f"Active producer '{producer}' succeeded; artifacts are ready.")
+        return 0
+
+    print(
+        f"ERROR: active producer '{producer}' has result '{result}' "
+        f"(expected '{RESULT_SUCCESS}')."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -114,13 +114,17 @@ class FailingBackend(ArtifactBackend):
         self.download_count = 0
         self.run_id = run_id
         self.platform = platform
+        # Always expose an output_root so callers (e.g. do_copy) that read
+        # backend.output_root succeed even when no staging_dir was given.
+        self.output_root = WorkflowOutputRoot.for_local(
+            run_id=run_id, platform=platform
+        )
 
         # Use a real backend for successful operations
         if staging_dir:
-            output_root = WorkflowOutputRoot.for_local(run_id=run_id, platform=platform)
             self._real_backend = LocalDirectoryBackend(
                 staging_dir=staging_dir,
-                output_root=output_root,
+                output_root=self.output_root,
             )
         else:
             self._real_backend = None
@@ -1241,8 +1245,11 @@ class TestCopyExtensions(ArtifactManagerTestBase):
         )
 
     @mock.patch("artifact_manager._delay_for_retry")
-    def test_copy_source_prefix_only_uses_lookup_free_factory(self, mock_delay):
-        """`--source-prefix-only` builds an S3 backend with lookup_workflow_run=False."""
+    def test_copy_source_prefix_only_mirrors_dest_bucket(self, mock_delay):
+        """`--source-prefix-only` source backend must mirror dest's bucket
+        and external_repo, not re-derive them from env. This guards against
+        silent divergence if dest's bucket resolution accepts overrides
+        (e.g. --run-github-repo) that the env-only path would not pick up."""
         import artifact_manager
 
         # Force the S3 path by clearing local-staging from argv.
@@ -1253,35 +1260,48 @@ class TestCopyExtensions(ArtifactManagerTestBase):
         ]
         argv.append("--source-prefix-only")
 
-        captured = {}
+        # Dest backend with a deliberately non-env bucket / external_repo
+        # so we can prove the source mirrors dest rather than env.
+        dest_root = WorkflowOutputRoot(
+            bucket="custom-dest-bucket",
+            external_repo="custom-owner-repo/",
+            run_id="dest-run",
+            platform=TEST_PLATFORM,
+        )
+        dest_backend = LocalDirectoryBackend(
+            staging_dir=self.staging_dir,
+            output_root=dest_root,
+        )
 
-        def fake_from_workflow_run(run_id, platform, **kwargs):
-            captured["run_id"] = run_id
-            captured["lookup_workflow_run"] = kwargs.get("lookup_workflow_run", False)
-            return WorkflowOutputRoot.for_local(run_id=run_id, platform=platform)
+        captured_source_root = {}
+
+        def fake_s3_backend(output_root):
+            captured_source_root["root"] = output_root
+            mock_inst = mock.MagicMock()
+            mock_inst.output_root = output_root
+            mock_inst.base_uri = f"mock://{output_root.bucket}/{output_root.prefix}"
+            mock_inst.list_artifacts.return_value = []
+            return mock_inst
 
         with (
-            mock.patch.object(
-                artifact_manager.WorkflowOutputRoot,
-                "from_workflow_run",
-                side_effect=fake_from_workflow_run,
-            ),
-            mock.patch("artifact_manager.S3Backend") as mock_s3_cls,
+            mock.patch("artifact_manager.S3Backend", side_effect=fake_s3_backend),
             mock.patch(
                 "artifact_manager.create_backend_from_env",
-                return_value=LocalDirectoryBackend(
-                    staging_dir=self.staging_dir,
-                    output_root=WorkflowOutputRoot.for_local(
-                        run_id="dest-run", platform=TEST_PLATFORM
-                    ),
-                ),
+                return_value=dest_backend,
             ),
+            mock.patch(
+                "_therock_utils.workflow_outputs._retrieve_bucket_info"
+            ) as mock_lookup,
         ):
-            mock_s3_cls.return_value.list_artifacts.return_value = []
             artifact_manager.main(argv)
+            mock_lookup.assert_not_called()
 
-        self.assertEqual(captured.get("run_id"), "source-run")
-        self.assertFalse(captured.get("lookup_workflow_run"))
+        source_root = captured_source_root.get("root")
+        self.assertIsNotNone(source_root, "S3Backend should be constructed for source")
+        self.assertEqual(source_root.bucket, "custom-dest-bucket")
+        self.assertEqual(source_root.external_repo, "custom-owner-repo/")
+        self.assertEqual(source_root.run_id, "source-run")
+        self.assertEqual(source_root.platform, TEST_PLATFORM)
 
     @mock.patch("artifact_manager._delay_for_retry")
     def test_copy_require_matches_passes_when_family_matched(self, mock_delay):

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -1136,6 +1136,235 @@ class TestCopy(ArtifactManagerTestBase):
         )
 
 
+class TestCopyExtensions(ArtifactManagerTestBase):
+    """Tests for copy --stage=all, --source-prefix-only, --require-matches."""
+
+    def _create_source_artifact(
+        self,
+        name: str,
+        component: str,
+        target_family: str,
+        run_id: str = "source-run",
+    ) -> str:
+        return self._create_staged_artifact(name, component, target_family, run_id)
+
+    def _base_argv(
+        self,
+        stage: str = "upstream-stage",
+        source_run_id: str = "source-run",
+        dest_run_id: str = "dest-run",
+    ):
+        return [
+            "copy",
+            "--source-run-id",
+            source_run_id,
+            "--stage",
+            stage,
+            "--topology",
+            str(self.topology_path),
+            "--local-staging-dir",
+            str(self.staging_dir),
+            "--platform",
+            TEST_PLATFORM,
+            "--run-id",
+            dest_run_id,
+        ]
+
+    @mock.patch("artifact_manager._delay_for_retry")
+    def test_copy_stage_all_unions_every_stage(self, mock_delay):
+        """`--stage=all` should copy artifacts from every build stage."""
+        import artifact_manager
+
+        self._create_source_artifact("test-artifact", "lib", "generic")
+        self._create_source_artifact("second-artifact", "lib", "generic")
+        self._create_source_artifact("downstream-artifact", "lib", "generic")
+
+        artifact_manager.main(self._base_argv(stage="all"))
+
+        dest_backend = LocalDirectoryBackend(
+            staging_dir=self.staging_dir,
+            output_root=WorkflowOutputRoot.for_local(
+                run_id="dest-run", platform=TEST_PLATFORM
+            ),
+        )
+        for name in ("test-artifact", "second-artifact", "downstream-artifact"):
+            self.assertTrue(
+                dest_backend.artifact_exists(f"{name}_lib_generic.tar.zst"),
+                f"{name} should be copied under --stage=all",
+            )
+
+    @mock.patch("artifact_manager._delay_for_retry")
+    def test_copy_source_prefix_only_skips_workflow_run_lookup(self, mock_delay):
+        """`--source-prefix-only` must not call the GitHub API to resolve the bucket."""
+        import artifact_manager
+
+        self._create_source_artifact("test-artifact", "lib", "generic")
+
+        with mock.patch(
+            "_therock_utils.workflow_outputs._retrieve_bucket_info"
+        ) as mock_lookup:
+            # Local staging is set, so the S3 path (and the bucket lookup) should
+            # never be invoked. This guards against accidental regressions where
+            # the prefix-only branch accidentally goes through the API path.
+            artifact_manager.main(
+                self._base_argv() + ["--source-prefix-only"]
+            )
+            mock_lookup.assert_not_called()
+
+        dest_backend = LocalDirectoryBackend(
+            staging_dir=self.staging_dir,
+            output_root=WorkflowOutputRoot.for_local(
+                run_id="dest-run", platform=TEST_PLATFORM
+            ),
+        )
+        self.assertTrue(
+            dest_backend.artifact_exists("test-artifact_lib_generic.tar.zst")
+        )
+
+    @mock.patch("artifact_manager._delay_for_retry")
+    def test_copy_source_prefix_only_uses_lookup_free_factory(self, mock_delay):
+        """`--source-prefix-only` builds an S3 backend with lookup_workflow_run=False."""
+        import artifact_manager
+
+        # Force the S3 path by clearing local-staging from argv.
+        argv = [
+            arg
+            for arg in self._base_argv()
+            if arg not in ("--local-staging-dir", str(self.staging_dir))
+        ]
+        argv.append("--source-prefix-only")
+
+        captured = {}
+
+        def fake_from_workflow_run(run_id, platform, **kwargs):
+            captured["run_id"] = run_id
+            captured["lookup_workflow_run"] = kwargs.get("lookup_workflow_run", False)
+            return WorkflowOutputRoot.for_local(run_id=run_id, platform=platform)
+
+        with (
+            mock.patch.object(
+                artifact_manager.WorkflowOutputRoot,
+                "from_workflow_run",
+                side_effect=fake_from_workflow_run,
+            ),
+            mock.patch("artifact_manager.S3Backend") as mock_s3_cls,
+            mock.patch(
+                "artifact_manager.create_backend_from_env",
+                return_value=LocalDirectoryBackend(
+                    staging_dir=self.staging_dir,
+                    output_root=WorkflowOutputRoot.for_local(
+                        run_id="dest-run", platform=TEST_PLATFORM
+                    ),
+                ),
+            ),
+        ):
+            mock_s3_cls.return_value.list_artifacts.return_value = []
+            artifact_manager.main(argv)
+
+        self.assertEqual(captured.get("run_id"), "source-run")
+        self.assertFalse(captured.get("lookup_workflow_run"))
+
+    @mock.patch("artifact_manager._delay_for_retry")
+    def test_copy_require_matches_passes_when_family_matched(self, mock_delay):
+        """--require-matches succeeds when the input family has a match."""
+        import artifact_manager
+
+        self._create_source_artifact("test-artifact", "lib", "gfx94X-dcgpu")
+
+        artifact_manager.main(
+            self._base_argv()
+            + ["--amdgpu-families", "gfx94X-dcgpu", "--require-matches"]
+        )
+
+        dest_backend = LocalDirectoryBackend(
+            staging_dir=self.staging_dir,
+            output_root=WorkflowOutputRoot.for_local(
+                run_id="dest-run", platform=TEST_PLATFORM
+            ),
+        )
+        self.assertTrue(
+            dest_backend.artifact_exists("test-artifact_lib_gfx94X-dcgpu.tar.zst")
+        )
+
+    @mock.patch("artifact_manager._delay_for_retry")
+    def test_copy_require_matches_fails_when_family_missing(self, mock_delay):
+        """--require-matches exits non-zero when no source artifact for a family."""
+        import artifact_manager
+
+        # Source has only a generic artifact; the requested gfx94X-dcgpu has
+        # no match.
+        self._create_source_artifact("test-artifact", "lib", "generic")
+
+        with self.assertRaises(SystemExit) as ctx:
+            artifact_manager.main(
+                self._base_argv()
+                + ["--amdgpu-families", "gfx94X-dcgpu", "--require-matches"]
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+
+    @mock.patch("artifact_manager._delay_for_retry")
+    def test_copy_require_matches_satisfied_by_expanded_target(self, mock_delay):
+        """A family is satisfied if any of its expanded targets is matched."""
+        import artifact_manager
+
+        # Source only has the per-target artifact (kpack-split layout).
+        self._create_source_artifact("test-artifact", "lib", "gfx942")
+
+        fake_map = {"gfx94X-dcgpu": ["gfx942"]}
+        with mock.patch.object(
+            artifact_manager, "amdgpu_family_map", return_value=fake_map
+        ):
+            artifact_manager.main(
+                self._base_argv()
+                + [
+                    "--amdgpu-families",
+                    "gfx94X-dcgpu",
+                    "--expand-family-to-targets",
+                    "--require-matches",
+                ]
+            )
+
+        dest_backend = LocalDirectoryBackend(
+            staging_dir=self.staging_dir,
+            output_root=WorkflowOutputRoot.for_local(
+                run_id="dest-run", platform=TEST_PLATFORM
+            ),
+        )
+        self.assertTrue(
+            dest_backend.artifact_exists("test-artifact_lib_gfx942.tar.zst")
+        )
+
+    @mock.patch("artifact_manager._delay_for_retry")
+    def test_copy_require_matches_fails_with_expand_when_neither_match(
+        self, mock_delay
+    ):
+        """With --expand-family-to-targets, fail when neither family nor any
+        expanded target produced a match."""
+        import artifact_manager
+
+        # Source only has a generic artifact; the requested family expands
+        # to gfx942 but neither gfx94X-dcgpu nor gfx942 has a match.
+        self._create_source_artifact("test-artifact", "lib", "generic")
+
+        fake_map = {"gfx94X-dcgpu": ["gfx942"]}
+        with mock.patch.object(
+            artifact_manager, "amdgpu_family_map", return_value=fake_map
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                artifact_manager.main(
+                    self._base_argv()
+                    + [
+                        "--amdgpu-families",
+                        "gfx94X-dcgpu",
+                        "--expand-family-to-targets",
+                        "--require-matches",
+                    ]
+                )
+
+        self.assertEqual(ctx.exception.code, 1)
+
+
 class ParseTargetFamiliesTest(unittest.TestCase):
     """Unit tests for artifact_manager.parse_target_families."""
 
@@ -1215,6 +1444,19 @@ class ParseTargetFamiliesTest(unittest.TestCase):
         self.assertIn("gfx110X-all", result)
         self.assertIn("gfx1100", result)
         self.assertIn("gfx1101", result)
+
+    def test_comma_separated_families_accepted(self):
+        # Workflow inputs that document `families` as comma-separated should
+        # pass through unchanged. Mixed separators are also tolerated.
+        args = self._make_args(amdgpu_families="gfx94X-dcgpu,gfx110X-all")
+        result = self.am.parse_target_families(args)
+        self.assertIn("gfx94X-dcgpu", result)
+        self.assertIn("gfx110X-all", result)
+
+        args = self._make_args(amdgpu_families="gfx94X-dcgpu;gfx110X-all,gfx120X-all")
+        result = self.am.parse_target_families(args)
+        for f in ("gfx94X-dcgpu", "gfx110X-all", "gfx120X-all"):
+            self.assertIn(f, result)
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -66,6 +66,17 @@ type = "target-neutral"
 artifact_group = "downstream-group"
 type = "target-neutral"
 artifact_deps = ["test-artifact", "second-artifact"]
+
+# Orphan group that no build stage produces. Used to verify that
+# `copy --stage=all` matches `fetch --stage=all` semantics: the union of
+# all topology artifacts, not just the union of per-stage produced sets.
+[artifact_groups.orphan-group]
+description = "Group not referenced by any build stage"
+type = "generic"
+
+[artifacts.orphan-artifact]
+artifact_group = "orphan-group"
+type = "target-neutral"
 """
 
 # Platform used consistently across all tests
@@ -1171,13 +1182,16 @@ class TestCopyExtensions(ArtifactManagerTestBase):
         ]
 
     @mock.patch("artifact_manager._delay_for_retry")
-    def test_copy_stage_all_unions_every_stage(self, mock_delay):
-        """`--stage=all` should copy artifacts from every build stage."""
+    def test_copy_stage_all_unions_every_topology_artifact(self, mock_delay):
+        """`--stage=all` should copy every topology artifact, including those
+        not produced by any build stage. Mirrors `fetch --stage=all`."""
         import artifact_manager
 
         self._create_source_artifact("test-artifact", "lib", "generic")
         self._create_source_artifact("second-artifact", "lib", "generic")
         self._create_source_artifact("downstream-artifact", "lib", "generic")
+        # orphan-artifact lives in orphan-group, which no build stage owns.
+        self._create_source_artifact("orphan-artifact", "lib", "generic")
 
         artifact_manager.main(self._base_argv(stage="all"))
 
@@ -1187,7 +1201,12 @@ class TestCopyExtensions(ArtifactManagerTestBase):
                 run_id="dest-run", platform=TEST_PLATFORM
             ),
         )
-        for name in ("test-artifact", "second-artifact", "downstream-artifact"):
+        for name in (
+            "test-artifact",
+            "second-artifact",
+            "downstream-artifact",
+            "orphan-artifact",
+        ):
             self.assertTrue(
                 dest_backend.artifact_exists(f"{name}_lib_generic.tar.zst"),
                 f"{name} should be copied under --stage=all",

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -1364,6 +1364,19 @@ class TestCopyExtensions(ArtifactManagerTestBase):
 
         self.assertEqual(ctx.exception.code, 1)
 
+    @mock.patch("artifact_manager._delay_for_retry")
+    def test_copy_require_matches_fails_when_no_artifacts_at_all(self, mock_delay):
+        """--require-matches must fail when nothing matches even without
+        --amdgpu-families. The empty-copy_requests path must honor the flag,
+        otherwise prebuilt copy jobs can succeed while delivering nothing."""
+        import artifact_manager
+
+        # Source has no artifacts at all (no _create_source_artifact call).
+        with self.assertRaises(SystemExit) as ctx:
+            artifact_manager.main(self._base_argv() + ["--require-matches"])
+
+        self.assertEqual(ctx.exception.code, 1)
+
 
 class ParseTargetFamiliesTest(unittest.TestCase):
     """Unit tests for artifact_manager.parse_target_families."""


### PR DESCRIPTION
## Motivation

In rare cases release re-runs need to reuse already-built artifacts. Those might be manually patched or we restrict the re-run to a subset of targets and solely use the release run to repackage for this limited subset. The release workflows will build tarballs, Python packages and native Linux packages without starting a source build.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
