### PR TITLE
Refactor Linux packaging to support host-device split architecture

### DIFF
--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -26,18 +26,12 @@ create RPM and DEB packages and upload to artifactory server
 """
 
 import argparse
-import glob
 import json
 import os
-import shutil
-import subprocess
 import sys
 import traceback
 
 from dataclasses import replace
-from datetime import datetime, timezone
-from email.utils import format_datetime
-from jinja2 import Environment, FileSystemLoader, Template
 from pathlib import Path
 
 # Setup paths
@@ -55,11 +49,15 @@ from runpath_to_rpath import *
 
 from _therock_utils.artifacts import ArtifactCatalog
 
+from deb_package import *
+from rpm_package import *
+
+
 # Default install prefix
 DEFAULT_INSTALL_PREFIX = "/opt/rocm/core"
 
 
-def _load_kpack_from_manifest(artifacts_dir: Path) -> bool:
+def load_kpack_from_manifest(artifacts_dir: Path) -> bool:
     """Detect kpack mode by scanning therock_manifest.json files in artifact directory.
 
     Returns True if any manifest has KPACK_SPLIT_ARTIFACTS set to True.
@@ -100,683 +98,367 @@ def get_all_target_families(artifact_dir):
     return sorted(catalog.all_target_families)
 
 
-################### Debian package creation #######################
-def create_deb_package(pkg_name, config: PackageConfig):
-    """Create a Debian package.
+################### Package Variant Builders #######################
+def build_package_variants(pkg_name, config: PackageConfig) -> list:
+    """Build all required package variants based on package type and mode.
 
-    This function invokes the creation of versioned and non-versioned packages
-    and moves the resulting `.deb` files to the destination directory.
+    This is the main entry point for building packages. It determines which
+    variants to build based on:
+    - Whether the package is a gfxarch package (GfxArch=True/False)
+    - Whether kpack mode is enabled
+    - Package type (DEB/RPM)
 
     Parameters:
-    pkg_name : Name of the package to be created
-    config: Configuration object containing package metadata
+        pkg_name: Name of the package to build
+        config: Configuration object containing package metadata
 
     Returns:
-    output_list: List of packages created
+        List of built package filenames
+
+    Variants created:
+        For GfxArch=False (non-gfxarch packages):
+            - Versioned package (e.g., amdrocm-core8.2)
+            - Non-versioned package (e.g., amdrocm-core)
+
+        For GfxArch=True (gfxarch packages) in kpack mode (multi-arch):
+            - Host package (e.g., amdrocm-fft-host8.2)
+            - Device packages (e.g., amdrocm-fft8.2-gfx1100, amdrocm-fft8.2-gfx94x)
+            - Meta package (e.g., amdrocm-fft8.2)
+            - Non-versioned package (e.g., amdrocm-fft)
+
+        For GfxArch=True (gfxarch packages) in single-arch mode:
+            - Versioned package with arch suffix (e.g., amdrocm-fft8.2-gfx1100)
+            - Non-versioned package with arch suffix (e.g., amdrocm-fft-gfx1100)
     """
-    print_function_name()
-    print(f"Package Name: {pkg_name}")
+    pkg_info = get_package_info(pkg_name)  # Raises ValueError if not found
 
-    # Non-versioned packages are not required for RPATH packages
-    # In multi-arch mode, only create non-versioned packages for generic architecture
-    if not config.enable_rpath:
-        if not config.enable_kpack or config.gfx_arch == GFX_GENERIC:
-            create_nonversioned_deb_package(pkg_name, config)
-
-    create_versioned_deb_package(pkg_name, config)
-    output_list = move_packages_to_destination(pkg_name, config)
-    # Clean debian build directory
-    remove_dir(Path(config.dest_dir) / config.pkg_type)
-    return output_list
-
-
-def create_nonversioned_deb_package(pkg_name, config: PackageConfig):
-    """Create a non-versioned Debian meta package (.deb).
-
-    Builds a minimal Debian binary package whose payload is empty and whose primary
-    purpose is to express dependencies. The package name does not embed a version
-
-    Parameters:
-    pkg_name : Name of the package to be created
-    config: Configuration object containing package metadata
-
-    Returns: None
-    """
-    print_function_name()
-    # Create immutable config copy with versioned_pkg=False
-    build_config = replace(config, versioned_pkg=False)
-
-    package_dir = Path(build_config.dest_dir) / build_config.pkg_type / pkg_name
-    deb_dir = package_dir / "debian"
-    # Create package directory and debian directory
-    os.makedirs(deb_dir, exist_ok=True)
-
-    pkg_info = get_package_info(pkg_name)
-    generate_changelog_file(pkg_info, deb_dir, build_config)
-    generate_rules_file(pkg_info, deb_dir, build_config)
-    generate_control_file(pkg_info, deb_dir, build_config)
-
-    package_with_dpkg_build(package_dir)
-
-
-def create_versioned_deb_package(pkg_name, config: PackageConfig):
-    """Create a versioned Debian package (.deb).
-
-    This function automates the process of building a Debian package by:
-    1) Retrieving package metadata and validating required fields.
-    2) Generating the `DEBIAN/control` file with appropriate fields (Package,
-       Version, Architecture, Maintainer, Description, and dependencies).
-    3) Copying the required package contents from an Artifactory repository.
-    4) Invoking `dpkg-buildpackage` to assemble the final `.deb` file.
-
-    Parameters:
-    pkg_name : Name of the package to be created
-    config: Configuration object containing package metadata
-
-    Returns: None
-    """
-    print_function_name()
-    # Explicitly ensure versioned_pkg=True
-    build_config = replace(config, versioned_pkg=True)
-    package_dir = (
-        Path(build_config.dest_dir)
-        / build_config.pkg_type
-        / f"{pkg_name}{build_config.rocm_version}"
-    )
-    deb_dir = package_dir / "debian"
-    # Create package directory and debian directory
-    os.makedirs(deb_dir, exist_ok=True)
-
-    pkg_info = get_package_info(pkg_name)
-    is_meta = is_meta_package(pkg_info)
-    generate_changelog_file(pkg_info, deb_dir, build_config)
-    generate_rules_file(pkg_info, deb_dir, build_config)
-    generate_control_file(pkg_info, deb_dir, build_config)
-    if is_postinstallscripts_available(pkg_info):
-        generate_debian_postscripts(pkg_info, deb_dir, build_config)
-
-    sourcedir_list = []
-    dir_list = filter_components_fromartifactory(
-        pkg_name,
-        build_config.artifacts_dir,
-        build_config.gfx_arch,
-        build_config.enable_kpack,
-    )
-    sourcedir_list.extend(dir_list)
-
-    print(f"sourcedir_list:\n  {sourcedir_list}")
-    if not sourcedir_list and not is_meta:
-        if build_config.enable_kpack:
-            print(
-                f"ERROR: {pkg_name}: Empty sourcedir_list and not a meta package, skipping"
-            )
-            return []
-        else:
-            sys.exit(
-                f"{pkg_name}: Empty sourcedir_list and not a meta package, exiting"
-            )
-
-    if not sourcedir_list:
-        print(f"{pkg_name} is a Meta package")
-    else:
-        # Copy package contents first
-        dest_dir = package_dir / Path(build_config.install_prefix).relative_to("/")
-        for source_path in sourcedir_list:
-            copy_package_contents(source_path, dest_dir)
-
-        if build_config.enable_rpath:
-            convert_runpath_to_rpath(package_dir)
-
-        # Generate install file after copying, so we can check for hidden files
-        generate_install_file(pkg_info, deb_dir, build_config, dest_dir)
-
-    package_with_dpkg_build(package_dir)
-
-
-def generate_changelog_file(pkg_info, deb_dir, config: PackageConfig):
-    """Generate a Debian changelog entry in `debian/changelog`.
-
-    Parameters:
-    pkg_info : Package details from the Json file
-    deb_dir: Directory where debian package changelog file is saved
-    config: Configuration object containing package metadata
-
-    Returns: None
-    """
-    print_function_name()
-    changelog = Path(deb_dir) / "changelog"
-
-    pkg_name = update_package_name(pkg_info.get("Package"), config)
-    maintainer = pkg_info.get("Maintainer")
-    name_part, email_part = maintainer.split("<")
-    name = name_part.strip()
-    email = email_part.replace(">", "").strip()
-    # version is used along with package name
-    version = str(config.rocm_version)
-    if config.version_suffix:
-        version += f"-{str(config.version_suffix)}"
-
-    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
-    template = env.get_template("template/debian_changelog.j2")
-
-    # Prepare context dictionary
-    context = {
-        "package": pkg_name,
-        "version": version,
-        "distribution": "UNRELEASED",
-        "urgency": "medium",
-        "changes": ["Initial release"],  # TODO: Will get from package.json?
-        "maintainer_name": name,
-        "maintainer_email": email,
-        "date": format_datetime(
-            datetime.now(timezone.utc)
-        ),  # TODO. How to get the date info?
-    }
-
-    with changelog.open("w", encoding="utf-8") as f:
-        f.write(template.render(context))
-
-
-def generate_install_file(pkg_info, deb_dir, config: PackageConfig, dest_dir=None):
-    """Generate a Debian install entry in `debian/install`.
-
-    Parameters:
-    pkg_info : Package details from the Json file
-    deb_dir: Directory where debian package control file is saved
-    config: Configuration object containing package metadata
-    dest_dir: Optional path to check for hidden files
-
-    Returns: None
-    """
-    print_function_name()
-    # Note: pkg_info is not used currently:
-    # May be required in future to populate any context
-    install_file = Path(deb_dir) / "install"
-
-    # Check if hidden files and regular files exist in the destination directory
-    has_hidden_files = False
-    has_regular_files = False
-    if dest_dir and Path(dest_dir).exists():
-        for item in Path(dest_dir).iterdir():
-            name = item.name  # get the filename as a string
-            # Skip "." and ".."
-            if name in [".", ".."]:
-                continue
-
-            # Hidden entry
-            if name.startswith("."):
-                has_hidden_files = True
-            else:
-                has_regular_files = True
-
-    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
-    template = env.get_template("template/debian_install.j2")
-    # Prepare your context dictionary
-    context = {
-        "path": config.install_prefix,
-        "has_hidden_files": has_hidden_files,
-        "has_regular_files": has_regular_files,
-    }
-
-    with install_file.open("w", encoding="utf-8") as f:
-        f.write(template.render(context))
-
-
-def generate_rules_file(pkg_info, deb_dir, config: PackageConfig):
-    """Generate a Debian rules entry in `debian/rules`.
-
-    Parameters:
-    pkg_info : Package details from the Json file
-    deb_dir: Directory where debian package control file is saved
-    config: Configuration object containing package metadata
-
-    Returns: None
-    """
-    print_function_name()
-    rules_file = Path(deb_dir) / "rules"
-    disable_dh_strip = is_key_defined(pkg_info, "Disable_DEB_STRIP")
-    disable_dwz = is_key_defined(pkg_info, "Disable_DWZ")
-    # Get package name for changelog installation
-    pkg_name = update_package_name(pkg_info.get("Package"), config)
-
-    # Disable debian dh_strip for multi-arch builds
-    # WORKAROUND: dh_strip's debugedit incorrectly truncates ELF files with
-    # unconventional layouts (e.g., program headers at end of file).
-    # This causes "program header goes past the end of the file" errors.
-    # See: https://github.com/ROCm/TheRock/issues/4047
     if config.enable_kpack:
-        disable_dh_strip = True
-
-    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
-    template = env.get_template("template/debian_rules.j2")
-    # Prepare  context dictionary
-    context = {
-        "disable_dwz": disable_dwz,
-        "disable_dh_strip": disable_dh_strip,
-        "install_prefix": config.install_prefix,
-        "pkg_name": pkg_name,
-    }
-
-    with rules_file.open("w", encoding="utf-8") as f:
-        f.write(template.render(context))
-    # set executable permission for rules file
-    rules_file.chmod(0o755)
-
-
-def generate_control_file(pkg_info, deb_dir, config: PackageConfig):
-    """Generate a Debian control file entry in `debian/control`.
-
-    Parameters:
-    pkg_info: Package details parsed from a JSON file
-    deb_dir: Directory where the `debian/control` file will be created
-    config: Configuration object containing package metadata
-
-    Returns: None
-    """
-    print_function_name()
-    control_file = Path(deb_dir) / "control"
-    pkg_name = pkg_info.get("Package")
-    is_meta = is_meta_package(pkg_info)
-
-    # Initialize optional fields
-    provides = replaces = conflicts = ""
-    debrecommends = debsuggests = ""
-
-    if config.versioned_pkg:
-        # Get -> Filter -> Transform
-        debrecommends = process_dependency_field(pkg_info, "DEBRecommends", config)
-        debsuggests = process_dependency_field(pkg_info, "DEBSuggests", config)
-        depends = process_dependency_field(
-            pkg_info, "DEBDepends", config, use_multiarch=True
-        )
-    else:
-        # Get -> Transform -> Join
-        provides = process_name_field(pkg_info, "Provides", debian_replace_devel_name)
-        replaces = process_name_field(pkg_info, "Replaces", debian_replace_devel_name)
-        conflicts = process_name_field(pkg_info, "Conflicts", debian_replace_devel_name)
-        # Non-versioned package depends on versioned package itself
-        depends = resolve_versioned_dependencies([pkg_name], config, is_meta)
-
-    pkg_name = update_package_name(pkg_name, config)
-
-    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
-    template = env.get_template("template/debian_control.j2")
-    context = {
-        "source": pkg_name,
-        "depends": depends,
-        "pkg_name": pkg_name,
-        "arch": pkg_info.get("Architecture"),
-        "description_short": pkg_info.get("Description_Short"),
-        "description_long": pkg_info.get("Description_Long"),
-        "homepage": pkg_info.get("Homepage"),
-        "maintainer": pkg_info.get("Maintainer"),
-        "priority": pkg_info.get("Priority"),
-        "section": pkg_info.get("Section"),
-        "version": config.rocm_version,
-        "provides": provides,
-        "replaces": replaces,
-        "conflicts": conflicts,
-        "debrecommends": debrecommends,
-        "debsuggests": debsuggests,
-    }
-
-    with control_file.open("w", encoding="utf-8") as f:
-        f.write(template.render(context))
-        f.write("\n")  # Adds a blank line. For fixing missing final newline
-
-
-def generate_debian_postscripts(pkg_info, deb_dir, config: PackageConfig):
-    """Generate a Debian postinst/prerm file entry in `debian folder`.
-
-    Parameters:
-    pkg_info: Package details parsed from a JSON file
-    deb_dir: Directory where the `debian/control` file will be created
-    config: Configuration object containing package metadata
-
-    Returns: None
-    """
-    # Debian maintainer scripts that must be executable
-    EXEC_SCRIPTS = {"preinst", "postinst", "prerm", "postrm", "config"}
-    pkg_name = pkg_info.get("Package")
-    parts = config.rocm_version.split(".")
-    if len(parts) < 3:
-        raise ValueError(
-            f"Version string '{config.rocm_version}' does not have major.minor.patch versions"
-        )
-
-    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
-    # Prepare your context dictionary
-    context = {
-        "install_prefix": config.install_prefix,
-        "version_major": int(re.match(r"^\d+", parts[0]).group()),
-        "version_minor": int(re.match(r"^\d+", parts[1]).group()),
-        "version_patch": int(re.match(r"^\d+", parts[2]).group()),
-        "target": "deb",
-    }
-
-    templates_root = Path(SCRIPT_DIR) / "template" / "scripts"
-    # Collect all matching files
-    for script in EXEC_SCRIPTS:
-        pattern = f"{pkg_name}-{script}.j2"
-        for file in templates_root.glob(pattern):
-            script_file = Path(deb_dir) / script
-            template = env.get_template(str(file.relative_to(SCRIPT_DIR)))
-            with script_file.open("w", encoding="utf-8") as f:
-                f.write(template.render(context))
-            os.chmod(script_file, 0o755)
-
-
-def copy_package_contents(source_dir, destination_dir):
-    """Copy package contents from artfactory to package build directory
-
-    Parameters:
-    source_dir : Source directory
-    destination_dir: Local directory where the package contents should be copied
-
-    Returns: None
-    """
-    print_function_name()
-
-    source_dir = Path(source_dir)
-    destination_dir = Path(destination_dir)
-
-    if not source_dir.is_dir():
-        print(f"Directory does not exist: {source_dir}")
-        return
-
-    # Ensure destination directory exists
-    destination_dir.mkdir(parents=True, exist_ok=True)
-
-    # Copy each item from source to destination
-    for item in source_dir.iterdir():
-        src = item
-        dst = destination_dir / item.name
-
-        if src.is_dir() and not dst.is_symlink():
-            shutil.copytree(
-                src,
-                dst,
-                dirs_exist_ok=True,
-                symlinks=True,
-                ignore_dangling_symlinks=True,
-            )
-        elif src.is_symlink():
-            # Copy the symlink itself (even if dangling)
-            link_target = src.readlink()
-            dst.symlink_to(link_target)
+        if is_gfxarch_package(pkg_info, config.enable_kpack) or is_meta_package(
+            pkg_info
+        ):
+            # GfxArch=True: host + devices + meta + non-versioned
+            return build_gfxarch_package_variants(pkg_name, config)
         else:
-            shutil.copy2(src, dst)
+            # GfxArch=False: versioned + non-versioned
+            return build_simple_package_variants(pkg_name, config)
+    else:
+        # Single-arch mode
+        return build_singlearch_package_variants(pkg_name, config)
 
 
-def package_with_dpkg_build(pkg_dir):
-    """Generate a Debian package using `dpkg-buildpackage`
+def build_gfxarch_package_variants(pkg_name, config: PackageConfig) -> list:
+    """Build all variants for a gfxarch package in kpack mode (multi-arch).
 
-    Parameters:
-    pkg_dir: Path to the directory containing the package contents and the `debian/`
-        subdirectory (with `control`, `changelog`, `rules`, etc.).
+    Creates:
+    - Host package (e.g., amdrocm-fft-host8.2) - generic artifacts
+    - Device packages (e.g., amdrocm-fft8.2-gfx1100, amdrocm-fft8.2-gfx94x) - arch-specific artifacts
+    - Meta package (e.g., amdrocm-fft8.2) - depends on host + all devices
+    - Non-versioned package (e.g., amdrocm-fft) - user-facing, depends on meta
 
-    Returns: None
-    """
-    print_function_name()
-    # Build the command
-    cmd = ["dpkg-buildpackage", "-uc", "-us", "-b"]
-
-    # Execute the command
-    try:
-        subprocess.run(cmd, check=True, cwd=pkg_dir)
-        print(f"Deb Package built successfully: {os.path.basename(pkg_dir)}")
-    except subprocess.CalledProcessError as e:
-        print(f"Error building deb package: {os.path.basename(pkg_dir)}: {e}")
-        sys.exit(e.returncode)
-
-
-######################## RPM package creation ####################
-def create_rpm_package(pkg_name, config: PackageConfig):
-    """Create an RPM package.
-
-    This function invokes the creation of versioned and non-versioned packages
-    and moves the resulting `.rpm` files to the destination directory.
+    This function builds packages sequentially but is parallel-ready. Each variant
+    builder is independent (no shared state, no cleanup during build) and can be
+    run in parallel in the future. Cleanup is deferred until all variants complete.
 
     Parameters:
-    pkg_name : Name of the package to be created
-    config: Configuration object containing package metadata
+        pkg_name: Name of the package to build
+        config: Configuration object
 
     Returns:
-    output_list: List of packages created
+        List of built package filenames
     """
-    print_function_name()
-    print(f"Package Name: {pkg_name}")
+    built_packages = []
 
-    # Non-versioned packages are not required for RPATH packages
-    # In multi-arch mode, only create non-versioned packages for generic architecture
+    # Host package (contains generic artifacts)
+    print(f"\n=== Building host variant for {pkg_name} ===")
+    pkg = build_host_package(pkg_name, config)
+    if pkg:
+        built_packages.extend(pkg)
+
+    # Device packages (one per architecture)
+    for device_arch in config.gfxarch_list:
+        print(f"\n=== Building device variant for {pkg_name} ({device_arch}) ===")
+        pkg = build_device_package(pkg_name, config, device_arch)
+        if pkg:
+            built_packages.extend(pkg)
+
+    # Meta package (depends on host + all devices)
+    print(f"\n=== Building meta variant for {pkg_name} ===")
+    pkg = build_meta_package(pkg_name, config)
+    if pkg:
+        built_packages.extend(pkg)
+
+    # Non-versioned package (user-facing, depends on meta)
     if not config.enable_rpath:
-        if not config.enable_kpack or config.gfx_arch == GFX_GENERIC:
-            create_nonversioned_rpm_package(pkg_name, config)
+        print(f"\n=== Building non-versioned variant for {pkg_name} ===")
+        # For gfxarch packages in kpack mode, non-versioned has no arch suffix (e.g., amdrocm-fft)
+        # It depends on the meta package which pulls in host + all devices
+        meta_config = replace(config, gfx_arch=GFX_META)
+        pkg = build_nonversioned_package(pkg_name, meta_config)
+        if pkg:
+            built_packages.extend(pkg)
 
-    create_versioned_rpm_package(pkg_name, config)
-    output_list = move_packages_to_destination(pkg_name, config)
-    # Clean rpm build directory
-    remove_dir(Path(config.dest_dir) / config.pkg_type)
-    return output_list
-
-
-def create_nonversioned_rpm_package(pkg_name, config: PackageConfig):
-    """Create a non-versioned RPM meta package (.rpm).
-
-    Builds a minimal RPM binary package whose payload is empty and whose primary
-    purpose is to express dependencies. The package name does not embed a version
-
-    Parameters:
-    pkg_name : Name of the package to be created
-    config: Configuration object containing package metadata
-
-    Returns: None
-    """
-    print_function_name()
-    # Create immutable config copy with versioned_pkg=False
-    build_config = replace(config, versioned_pkg=False)
-    package_dir = Path(build_config.dest_dir) / build_config.pkg_type / pkg_name
-    specfile = package_dir / "specfile"
-    generate_spec_file(pkg_name, specfile, build_config)
-    package_with_rpmbuild(specfile)
+    cleanup_build_directory(config)
+    return built_packages
 
 
-def create_versioned_rpm_package(pkg_name, config: PackageConfig):
-    """Create a versioned RPM package (.rpm).
+def build_simple_package_variants(pkg_name, config: PackageConfig) -> list:
+    """Build variants for a non-gfxarch package in kpack mode.
 
-    This function automates the process of building a RPM package by:
-    1) Generating the spec file with appropriate fields (Package,
-       Version, Architecture, Maintainer, Description, and dependencies).
-    2) Invoking `rpmbuild` to assemble the final `.rpm` file.
+    Creates:
+    - Versioned package (e.g., amdrocm-core8.2)
+    - Non-versioned package with no arch suffix (e.g., amdrocm-core)
 
     Parameters:
-    pkg_name : Name of the package to be created
-    config: Configuration object containing package metadata
+        pkg_name: Name of the package to build
+        config: Configuration object
 
-    Returns: None
+    Returns:
+        List of built package filenames
     """
-    print_function_name()
-    # Explicitly ensure versioned_pkg=True
-    build_config = replace(config, versioned_pkg=True)
-    package_dir = (
-        Path(build_config.dest_dir)
-        / build_config.pkg_type
-        / f"{pkg_name}{build_config.rocm_version}"
-    )
-    specfile = package_dir / "specfile"
-    generate_spec_file(pkg_name, specfile, build_config)
-    package_with_rpmbuild(specfile)
+    built_packages = []
+
+    # Versioned package
+    print(f"\n=== Building versioned variant for {pkg_name} ===")
+    pkg = build_versioned_package(pkg_name, config)
+    if pkg:
+        built_packages.extend(pkg)
+
+    # Non-versioned package
+    if not config.enable_rpath:
+        print(f"\n=== Building non-versioned variant for {pkg_name} ===")
+        # For non-gfxarch packages, non-versioned has no arch suffix (e.g., amdrocm-core)
+        simple_config = replace(config, gfx_arch="")
+        pkg = build_nonversioned_package(pkg_name, simple_config)
+        if pkg:
+            built_packages.extend(pkg)
+
+    cleanup_build_directory(config)
+    return built_packages
 
 
-def generate_spec_file(pkg_name, specfile, config: PackageConfig):
-    """Generate an RPM spec file.
+def build_singlearch_package_variants(pkg_name, config: PackageConfig) -> list:
+    """Build package variants in single-arch mode (non-kpack).
+
+    Creates:
+    - Versioned package (e.g., amdrocm-core8.2 or amdrocm-fft8.2-gfx1100 for gfxarch packages)
+    - Non-versioned package (e.g., amdrocm-core or amdrocm-fft-gfx1100 for gfxarch packages)
+
+    In single-arch mode, gfxarch packages include the arch suffix in both variants
+    because they're specific to that architecture.
 
     Parameters:
-    pkg_name : Package name
-    specfile: Path where the generated spec file should be saved
-    config: Configuration object containing package metadata
+        pkg_name: Name of the package to build
+        config: Configuration object
 
-    Returns: None
+    Returns:
+        List of built package filenames
     """
-    print_function_name()
-    os.makedirs(os.path.dirname(specfile), exist_ok=True)
+    built_packages = []
 
-    pkg_info = get_package_info(pkg_name)
-    version = f"{config.rocm_version}"
-    is_meta = is_meta_package(pkg_info)
-
-    # Initialize optional fields
-    provides = obsoletes = conflicts = ""
-    rpmrecommends = rpmsuggests = ""
-    sourcedir_list = []
-    rpm_scripts = []
-    # amdrocm-debugger: Exclude libpython requirements
-    # Multiple Python-version-specific binaries are included; the wrapper script
-    # automatically selects the binary matching the system's Python version
-    exclude_libpython_requires = pkg_name == "amdrocm-debugger"
-
-    if config.versioned_pkg:
-        # Get -> Filter -> Transform
-        rpmrecommends = process_dependency_field(pkg_info, "RPMRecommends", config)
-        rpmsuggests = process_dependency_field(pkg_info, "RPMSuggests", config)
-        requires = process_dependency_field(
-            pkg_info, "RPMRequires", config, use_multiarch=True
-        )
-
-        dir_list = filter_components_fromartifactory(
-            pkg_name, config.artifacts_dir, config.gfx_arch, config.enable_kpack
-        )
-        sourcedir_list.extend(dir_list)
-
-        # Filter out non-existing directories
-        sourcedir_list = [path for path in sourcedir_list if os.path.isdir(path)]
-
-        # Warn if we have no artifacts for non-meta packages
-        if not sourcedir_list and not is_meta:
-            if config.enable_kpack:
-                print(
-                    f"WARNING: {pkg_name}: Empty sourcedir_list and not a meta package, creating empty RPM"
-                )
-            else:
-                sys.exit(
-                    f"{pkg_name}: Empty sourcedir_list and not a meta package, exiting"
-                )
-
-        if is_postinstallscripts_available(pkg_info):
-            rpm_scripts = generate_rpm_postscripts(pkg_info, config)
-
-        if config.enable_rpath:
-            for path in sourcedir_list:
-                convert_runpath_to_rpath(path)
-    else:
-        # Get -> Transform -> Join (no transform needed for RPM)
-        provides = process_name_field(pkg_info, "Provides")
-        obsoletes = process_name_field(pkg_info, "Obsoletes")
-        conflicts = process_name_field(pkg_info, "Conflicts")
-        # Non-versioned package requires versioned package itself
-        requires = resolve_versioned_dependencies([pkg_name], config, is_meta)
-
-    pkg_name = update_package_name(pkg_name, config)
-
-    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
-    template = env.get_template("template/rpm_specfile.j2")
-    context = {
-        "pkg_name": pkg_name,
-        "version": version,
-        "release": config.version_suffix,
-        "build_arch": pkg_info.get("BuildArch"),
-        "description_short": pkg_info.get("Description_Short"),
-        "description_long": pkg_info.get("Description_Long"),
-        "group": pkg_info.get("Group"),
-        "pkg_license": pkg_info.get("License"),
-        "vendor": pkg_info.get("Vendor"),
-        "install_prefix": config.install_prefix,
-        "requires": requires,
-        "provides": provides,
-        "obsoletes": obsoletes,
-        "conflicts": conflicts,
-        "rpmrecommends": rpmrecommends,
-        "rpmsuggests": rpmsuggests,
-        "disable_rpm_strip": is_rpm_stripping_disabled(pkg_info),
-        "disable_debug_package": is_debug_package_disabled(pkg_info),
-        "sourcedir_list": sourcedir_list,
-        "rpm_scripts": rpm_scripts,
-        "exclude_libpython_requires": exclude_libpython_requires,
-    }
-
-    with open(specfile, "w", encoding="utf-8") as f:
-        f.write(template.render(context))
-
-
-def generate_rpm_postscripts(pkg_info, config: PackageConfig):
-    """Generate RPM postinst/prerm sections.
-
-    Parameters:
-    pkg_info: Package details parsed from a JSON file
-    config: Configuration object containing package metadata
-
-    Returns: rpm script sections for specfile
-    """
-    # RPM maintainer scripts
-    EXEC_SCRIPTS = {
-        "preinst": "%pre",
-        "postinst": "%post",
-        "prerm": "%preun",
-        "postrm": "%postun",
-    }
-    pkg_name = pkg_info.get("Package")
-    parts = config.rocm_version.split(".")
-    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
-    # Prepare your context dictionary
-    context = {
-        "install_prefix": config.install_prefix,
-        "version_major": int(re.match(r"^\d+", parts[0]).group()),
-        "version_minor": int(re.match(r"^\d+", parts[1]).group()),
-        "version_patch": int(re.match(r"^\d+", parts[2]).group()),
-        "target": "rpm",
-    }
-
-    templates_root = Path(SCRIPT_DIR) / "template" / "scripts"
-    # Collect all matching files
-    # This will hold rendered RPM script sections
-    rpm_script_sections = {}
-
-    for script, rpm_section in EXEC_SCRIPTS.items():
-        pattern = f"{pkg_name}-{script}.j2"
-
-        for file in templates_root.glob(pattern):
-            template = env.get_template(str(file.relative_to(SCRIPT_DIR)))
-            rendered = template.render(context)
-
-            # Store rendered script under its RPM section name
-            rpm_script_sections[rpm_section] = rendered
-
-    return rpm_script_sections
-
-
-def package_with_rpmbuild(spec_file):
-    """Generate a RPM package using `rpmbuild`
-
-    Parameters:
-    spec_file: Specfile for RPM package
-
-    Returns: None
-    """
-    print_function_name()
-    package_rpm = os.path.dirname(spec_file)
-
+    # Versioned package
+    print(f"\n=== Building versioned package for {pkg_name} (single-arch mode) ===")
     try:
-        subprocess.run(
-            ["rpmbuild", "--define", f"_topdir {package_rpm}", "-ba", spec_file],
-            check=True,
+        versioned_config = replace(config, versioned_pkg=True)
+        if versioned_config.pkg_type == "rpm":
+            pkg = create_versioned_rpm_package(pkg_name, versioned_config)
+        else:
+            pkg = create_versioned_deb_package(pkg_name, versioned_config)
+        if pkg:
+            built_packages.extend(pkg)
+    except Exception as e:
+        print(f"ERROR: Failed to build versioned package for {pkg_name}: {e}")
+
+    # Non-versioned package
+    if not config.enable_rpath:
+        print(
+            f"\n=== Building non-versioned package for {pkg_name} (single-arch mode) ==="
         )
-        print(f"RPM build completed successfully: {os.path.basename(package_rpm)}")
-    except subprocess.CalledProcessError as e:
-        print(f"RPM build failed for {os.path.basename(package_rpm)}: {e}")
-        sys.exit(e.returncode)
+        try:
+            # In single-arch mode, non-versioned packages keep the arch suffix
+            # to indicate they're specific to that architecture (e.g., amdrocm-fft-gfx1100)
+            nonversioned_config = replace(config, versioned_pkg=False)
+            if nonversioned_config.pkg_type == "rpm":
+                pkg = create_nonversioned_rpm_package(pkg_name, nonversioned_config)
+            else:
+                pkg = create_nonversioned_deb_package(pkg_name, nonversioned_config)
+            if pkg:
+                built_packages.extend(pkg)
+        except Exception as e:
+            print(f"ERROR: Failed to build non-versioned package for {pkg_name}: {e}")
+
+    cleanup_build_directory(config)
+    return built_packages
 
 
-######################## Begin Packaging Process################################
+def build_host_package(pkg_name, config: PackageConfig) -> list:
+    """Build host package variant (contains generic artifacts).
+
+    The host package contains architecture-independent artifacts and is named
+    with a -host suffix (e.g., amdrocm-fft-host8.2).
+
+    Parameters:
+        pkg_name: Name of the package to build
+        config: Configuration object
+
+    Returns:
+        List of built package filenames
+    """
+    host_config = replace(config, gfx_arch=GFX_HOST, versioned_pkg=True)
+    try:
+        if host_config.pkg_type == "rpm":
+            return create_versioned_rpm_package(pkg_name, host_config)
+        else:
+            return create_versioned_deb_package(pkg_name, host_config)
+    except Exception as e:
+        print(f"ERROR: Failed to build host package for {pkg_name}: {e}")
+        return []
+
+
+def build_device_package(pkg_name, config: PackageConfig, device_arch: str) -> list:
+    """Build device-specific package variant.
+
+    Device packages contain architecture-specific artifacts and are named
+    with an architecture suffix (e.g., amdrocm-fft8.2-gfx1100).
+
+    Parameters:
+        pkg_name: Name of the package to build
+        config: Configuration object
+        device_arch: Device architecture (e.g., "gfx1100", "gfx94x")
+
+    Returns:
+        List of built package filenames
+    """
+    device_config = replace(config, gfx_arch=device_arch, versioned_pkg=True)
+    try:
+        if device_config.pkg_type == "rpm":
+            return create_versioned_rpm_package(pkg_name, device_config)
+        else:
+            return create_versioned_deb_package(pkg_name, device_config)
+    except Exception as e:
+        print(
+            f"ERROR: Failed to build device package for {pkg_name} ({device_arch}): {e}"
+        )
+        return []
+
+
+def build_meta_package(pkg_name, config: PackageConfig) -> list:
+    """Build meta package that depends on host + all devices.
+
+    The meta package is a versioned metapackage with no content, only dependencies.
+    It pulls in the host package and all device packages (e.g., amdrocm-fft8.2).
+
+    Parameters:
+        pkg_name: Name of the package to build
+        config: Configuration object
+
+    Returns:
+        List of built package filenames
+    """
+    meta_config = replace(config, gfx_arch=GFX_META, versioned_pkg=True)
+    try:
+        if meta_config.pkg_type == "rpm":
+            return create_versioned_rpm_package(pkg_name, meta_config)
+        else:
+            return create_versioned_deb_package(pkg_name, meta_config)
+    except Exception as e:
+        print(f"ERROR: Failed to build meta package for {pkg_name}: {e}")
+        return []
+
+
+def build_versioned_package(pkg_name, config: PackageConfig) -> list:
+    """Build versioned package (for non-gfxarch packages).
+
+    This creates a versioned package with no architecture suffix,
+    used for packages that don't have gfxarch variants (e.g., amdrocm-core8.2).
+
+    Parameters:
+        pkg_name: Name of the package to build
+        config: Configuration object
+
+    Returns:
+        List of built package filenames
+    """
+    versioned_config = replace(config, gfx_arch="", versioned_pkg=True)
+    try:
+        if versioned_config.pkg_type == "rpm":
+            return create_versioned_rpm_package(pkg_name, versioned_config)
+        else:
+            return create_versioned_deb_package(pkg_name, versioned_config)
+    except Exception as e:
+        print(f"ERROR: Failed to build versioned package for {pkg_name}: {e}")
+        return []
+
+
+def build_nonversioned_package(pkg_name, config: PackageConfig) -> list:
+    """Build non-versioned package (user-facing metapackage).
+
+    This creates a non-versioned metapackage that depends on the versioned variant.
+    For gfxarch packages, it depends on the meta package. For non-gfxarch packages,
+    it depends on the versioned package (e.g., amdrocm-fft -> amdrocm-fft8.2).
+
+    IMPORTANT: Caller must set config.gfx_arch appropriately before calling:
+    - GFX_META for gfxarch packages in kpack mode (e.g., "amdrocm-fft")
+    - "" (empty string) for non-gfxarch packages in any mode (e.g., "amdrocm-core")
+    - Actual arch (e.g., "gfx1100") for gfxarch packages in single-arch mode (e.g., "amdrocm-fft-gfx1100")
+
+    Parameters:
+        pkg_name: Name of the package to build
+        config: Configuration object with gfx_arch already set by caller
+
+    Returns:
+        List of built package filenames
+    """
+    nonversioned_config = replace(config, versioned_pkg=False)
+    try:
+        if nonversioned_config.pkg_type == "rpm":
+            return create_nonversioned_rpm_package(pkg_name, nonversioned_config)
+        else:
+            return create_nonversioned_deb_package(pkg_name, nonversioned_config)
+    except Exception as e:
+        print(f"ERROR: Failed to build non-versioned package for {pkg_name}: {e}")
+        return []
+
+
+def cleanup_build_directory(config: PackageConfig):
+    """Clean up build directory after all package variants are built.
+
+    This should only be called after all variants for a package are complete.
+    Defers cleanup to allow parallel builds of variants in the future.
+
+    Parameters:
+    config: Configuration object containing dest_dir and pkg_type
+    """
+    build_dir = Path(config.dest_dir) / config.pkg_type
+    if build_dir.exists():
+        remove_dir(build_dir)
+        print(f"Cleaned up build directory: {build_dir}")
+
+
+def cleanup_packaging_environment(config: PackageConfig):
+    """Clean the packaging environment (build directories and pycache).
+
+    This is called at the start and end of the packaging run to ensure
+    a clean environment. Unlike cleanup_build_directory(), this also
+    removes Python cache files.
+
+    Parameters:
+    config: Configuration object containing package metadata
+
+    Returns: None
+    """
+    print_function_name()
+    PYCACHE_DIR = Path(SCRIPT_DIR) / "__pycache__"
+    remove_dir(PYCACHE_DIR)
+
+    # NOTE: Remove only the build directory
+    # Make sure the destination directory is not removed
+    remove_dir(Path(config.dest_dir) / config.pkg_type)
+    # TBD:
+    # Currently RPATH packages are created by modifying the artifacts dir
+    # So artifacts dir clean up is required
+    # remove_dir(artifacts_dir)
+
+
 def parse_input_package_list(pkg_name, artifact_dir):
     """Populate the package list from the provided input arguments.
 
@@ -882,7 +564,7 @@ def create_package_config(args: argparse.Namespace) -> PackageConfig:
     # Auto-detect kpack from manifest if not explicitly requested via --enable-kpack
     artifacts_dir = Path(args.artifacts_dir).resolve()
     if not args.enable_kpack:
-        args.enable_kpack = _load_kpack_from_manifest(artifacts_dir)
+        args.enable_kpack = load_kpack_from_manifest(artifacts_dir)
         if args.enable_kpack:
             print(
                 "Detected KPACK_SPLIT_ARTIFACTS in manifest — producing host + device packages"
@@ -890,14 +572,16 @@ def create_package_config(args: argparse.Namespace) -> PackageConfig:
 
     # Configure architecture based on multi-arch mode
     if args.enable_kpack:
-        # Multi-arch: Build generic package + arch-specific packages for each target
-        # Example: amdrocm-runtime (generic) + amdrocm-runtime-gfx94x + amdrocm-runtime-gfx1100
-        default_gfx_arch = GFX_GENERIC
+        # Multi-arch: Build host + device + meta packages for each target
+        # Example: amdrocm-fft-host8.2 + amdrocm-fft8.2-gfx94x + amdrocm-fft8.2 (meta)
+        # For non-gfxarch packages: use empty string (no arch variants, just versioned + non-versioned)
+        # For gfxarch packages: variant builders will set GFX_HOST, GFX_META, or device arch
+        default_gfx_arch = ""  # Default used for non-gfxarch packages
         gfxarch_list = normalized_targets
     else:
         # Single-arch: Build only one package for the specified target
-        # Example: amdrocm-runtime-gfx94x (no generic, no other variants)
-        default_gfx_arch = normalized_targets[0]
+        # Example: amdrocm-fft8.2-gfx94x (no host, no other variants)
+        default_gfx_arch = normalized_targets[0] if normalized_targets else ""
         gfxarch_list = []
 
     # Parse version for install prefix (major.minor)
@@ -942,11 +626,15 @@ def run(args: argparse.Namespace):
     config = create_package_config(args)
 
     # Clean the packaging build directories
-    clean_package_build_dir(config)
+    cleanup_packaging_environment(config)
 
     pkg_list, skipped_list = parse_input_package_list(
         args.pkg_names, config.artifacts_dir
     )
+
+    if not pkg_list:
+        print("Error: No packages found to build. Package list is empty.")
+        sys.exit(1)
 
     current_pkg_idx = 0
     try:
@@ -954,43 +642,26 @@ def run(args: argparse.Namespace):
         failed_pkglist = []
 
         for current_pkg_idx, pkg_name in enumerate(pkg_list):
-            print(f"Create {config.pkg_type} package.")
+            print(f"Creating {config.pkg_type} package: {pkg_name}")
 
-            pkg_info = get_package_info(pkg_name)
-            # Check the package is marked as gfxarch package OR meta package
-            if is_gfxarch_package(pkg_info, config.enable_kpack) or is_meta_package(
-                pkg_info
-            ):
-                # Use all gfxarch values
-                loop_list = list(config.gfxarch_list) + [config.gfx_arch]
+            # Build all package variants for this package
+            output_list = build_package_variants(pkg_name, config)
+
+            if output_list:
+                built_pkglist.extend(output_list)
+                print(
+                    f"\n✓ Successfully built {len(output_list)} variant(s) for {pkg_name}"
+                )
             else:
-                # Only use default architecture
-                loop_list = [config.gfx_arch]
-
-            pkg_built = False
-            for gfxarch in loop_list:
-                # Create new config with updated gfx_arch (config is immutable)
-                build_config = replace(config, gfx_arch=gfxarch)
-                if config.pkg_type == "rpm":
-                    output_list = create_rpm_package(pkg_name, build_config)
-                else:
-                    output_list = create_deb_package(pkg_name, build_config)
-
-                if output_list:
-                    built_pkglist.extend(output_list)
-                    pkg_built = True
-                    print(f"Built package List: {built_pkglist}")
-                else:
-                    # Add failed architecture variant to failed list
-                    variant_name = (
-                        f"{pkg_name}-{gfxarch}"
-                        if gfxarch != config.gfx_arch
-                        else pkg_name
-                    )
-                    failed_pkglist.append(variant_name)
+                # Package failed to build
+                failed_pkglist.append(pkg_name)
+                print(f"\n✗ Failed to build any variants for {pkg_name}")
 
         # Clean the build directories
-        clean_package_build_dir(config)
+        cleanup_packaging_environment(config)
+
+        if built_pkglist:
+            print(f"\nBuilt packages: {built_pkglist}")
 
         pkglist_status = PackageList(
             total=pkg_list,

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -133,9 +133,7 @@ def build_package_variants(pkg_name, config: PackageConfig) -> list:
     pkg_info = get_package_info(pkg_name)  # Raises ValueError if not found
 
     if config.enable_kpack:
-        if is_gfxarch_package(pkg_info, config.enable_kpack) or is_meta_package(
-            pkg_info
-        ):
+        if is_gfxarch_package(pkg_info, config.enable_kpack):
             # GfxArch=True: host + devices + meta + non-versioned
             return build_gfxarch_package_variants(pkg_name, config)
         else:

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -149,11 +149,17 @@ def build_package_variants(pkg_name, config: PackageConfig) -> list:
 def build_gfxarch_package_variants(pkg_name, config: PackageConfig) -> list:
     """Build all variants for a gfxarch package in kpack mode (multi-arch).
 
-    Creates:
+    For regular gfxarch packages (Metapackage=False), creates:
     - Host package (e.g., amdrocm-fft-host8.2) - generic artifacts
     - Device packages (e.g., amdrocm-fft8.2-gfx1100, amdrocm-fft8.2-gfx94x) - arch-specific artifacts
     - Meta package (e.g., amdrocm-fft8.2) - depends on host + all devices
     - Non-versioned package (e.g., amdrocm-fft) - user-facing, depends on meta
+
+    For gfxarch metapackages (Metapackage=True + Gfxarch=True), creates:
+    - Arch-specific meta packages (e.g., amdrocm-core8.2-gfx1100) - depends on actual packages
+    - Generic meta package (e.g., amdrocm-core8.2) - depends on all arch-specific metas
+    - Non-versioned package (e.g., amdrocm-core) - user-facing, depends on generic meta
+    (No host package - metapackages have no artifacts to split)
 
     This function builds packages sequentially but is parallel-ready. Each variant
     builder is independent (no shared state, no cleanup during build) and can be
@@ -167,21 +173,27 @@ def build_gfxarch_package_variants(pkg_name, config: PackageConfig) -> list:
         List of built package filenames
     """
     built_packages = []
+    pkg_info = get_package_info(pkg_name)
+    is_meta = is_meta_package(pkg_info)
 
     # Host package (contains generic artifacts)
-    print(f"\n=== Building host variant for {pkg_name} ===")
-    pkg = build_host_package(pkg_name, config)
-    if pkg:
-        built_packages.extend(pkg)
+    # Skip for metapackages - they have no artifacts, only dependencies
+    if not is_meta:
+        print(f"\n=== Building host variant for {pkg_name} ===")
+        pkg = build_host_package(pkg_name, config)
+        if pkg:
+            built_packages.extend(pkg)
 
     # Device packages (one per architecture)
+    # For metapackages, these become arch-specific meta packages
     for device_arch in config.gfxarch_list:
         print(f"\n=== Building device variant for {pkg_name} ({device_arch}) ===")
         pkg = build_device_package(pkg_name, config, device_arch)
         if pkg:
             built_packages.extend(pkg)
 
-    # Meta package (depends on host + all devices)
+    # Meta package (depends on host + all devices for regular packages,
+    # or depends on all arch-specific metas for metapackages)
     print(f"\n=== Building meta variant for {pkg_name} ===")
     pkg = build_meta_package(pkg_name, config)
     if pkg:

--- a/build_tools/packaging/linux/deb_package.py
+++ b/build_tools/packaging/linux/deb_package.py
@@ -435,6 +435,3 @@ def package_with_dpkg_build(pkg_dir):
     except subprocess.CalledProcessError as e:
         print(f"Error building deb package: {os.path.basename(pkg_dir)}: {e}")
         sys.exit(e.returncode)
-
-
-######################## RPM package creation ####################

--- a/build_tools/packaging/linux/deb_package.py
+++ b/build_tools/packaging/linux/deb_package.py
@@ -13,7 +13,7 @@ import sys
 from dataclasses import replace
 from datetime import datetime, timezone
 from email.utils import format_datetime
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from pathlib import Path
 
 from packaging_utils import *
@@ -163,7 +163,14 @@ def generate_changelog_file(pkg_info, deb_dir, config: PackageConfig):
     if config.version_suffix:
         version += f"-{str(config.version_suffix)}"
 
-    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
+    env = Environment(
+        loader=FileSystemLoader(str(SCRIPT_DIR)),
+        autoescape=select_autoescape(
+            enabled_extensions=("html", "htm", "xml"),
+            default_for_string=True,
+            default=False,
+        ),
+    )
     template = env.get_template("template/debian_changelog.j2")
 
     # Prepare context dictionary
@@ -216,7 +223,14 @@ def generate_install_file(pkg_info, deb_dir, config: PackageConfig, dest_dir=Non
             else:
                 has_regular_files = True
 
-    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
+    env = Environment(
+        loader=FileSystemLoader(str(SCRIPT_DIR)),
+        autoescape=select_autoescape(
+            enabled_extensions=("html", "htm", "xml"),
+            default_for_string=True,
+            default=False,
+        ),
+    )
     template = env.get_template("template/debian_install.j2")
     # Prepare your context dictionary
     context = {
@@ -254,7 +268,14 @@ def generate_rules_file(pkg_info, deb_dir, config: PackageConfig):
     if config.enable_kpack:
         disable_dh_strip = True
 
-    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
+    env = Environment(
+        loader=FileSystemLoader(str(SCRIPT_DIR)),
+        autoescape=select_autoescape(
+            enabled_extensions=("html", "htm", "xml"),
+            default_for_string=True,
+            default=False,
+        ),
+    )
     template = env.get_template("template/debian_rules.j2")
     # Prepare  context dictionary
     context = {
@@ -306,7 +327,14 @@ def generate_control_file(pkg_info, deb_dir, config: PackageConfig):
 
     pkg_name = update_package_name(pkg_name, config)
 
-    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
+    env = Environment(
+        loader=FileSystemLoader(str(SCRIPT_DIR)),
+        autoescape=select_autoescape(
+            enabled_extensions=("html", "htm", "xml"),
+            default_for_string=True,
+            default=False,
+        ),
+    )
     template = env.get_template("template/debian_control.j2")
     context = {
         "source": pkg_name,
@@ -351,7 +379,14 @@ def generate_debian_postscripts(pkg_info, deb_dir, config: PackageConfig):
             f"Version string '{config.rocm_version}' does not have major.minor.patch versions"
         )
 
-    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
+    env = Environment(
+        loader=FileSystemLoader(str(SCRIPT_DIR)),
+        autoescape=select_autoescape(
+            enabled_extensions=("html", "htm", "xml"),
+            default_for_string=True,
+            default=False,
+        ),
+    )
     # Prepare your context dictionary
     context = {
         "install_prefix": config.install_prefix,

--- a/build_tools/packaging/linux/deb_package.py
+++ b/build_tools/packaging/linux/deb_package.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Debian package creation functions for ROCm packaging."""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import replace
+from datetime import datetime, timezone
+from email.utils import format_datetime
+from jinja2 import Environment, FileSystemLoader
+from pathlib import Path
+
+from packaging_utils import *
+
+# Setup paths
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def create_nonversioned_deb_package(pkg_name, config: PackageConfig):
+    """Create a non-versioned Debian meta package (.deb).
+
+    Builds a minimal Debian binary package whose payload is empty and whose primary
+    purpose is to express dependencies. The package name does not embed a version
+
+    Parameters:
+    pkg_name : Name of the package to be created
+    config: Configuration object containing package metadata
+
+    Returns:
+    output_list: List of packages created
+    """
+    print_function_name()
+    # Create immutable config copy with versioned_pkg=False
+    build_config = replace(config, versioned_pkg=False)
+
+    # Use updated package name for build directory to avoid collisions between variants
+    pkg_info = get_package_info(pkg_name)  # Needed for update_package_name
+    updated_pkg_name = update_package_name(pkg_info.get("Package"), build_config)
+    package_dir = Path(build_config.dest_dir) / build_config.pkg_type / updated_pkg_name
+    deb_dir = package_dir / "debian"
+    # Create package directory and debian directory
+    os.makedirs(deb_dir, exist_ok=True)
+    generate_changelog_file(pkg_info, deb_dir, build_config)
+    generate_rules_file(pkg_info, deb_dir, build_config)
+    generate_control_file(pkg_info, deb_dir, build_config)
+
+    package_with_dpkg_build(package_dir)
+
+    # Move packages to destination
+    updated_pkg_name = update_package_name(pkg_name, build_config)
+    output_list = move_packages_to_destination(updated_pkg_name, build_config)
+    return output_list
+
+
+def create_versioned_deb_package(pkg_name, config: PackageConfig):
+    """Create a versioned Debian package (.deb).
+
+    This function automates the process of building a Debian package by:
+    1) Retrieving package metadata and validating required fields.
+    2) Generating the `DEBIAN/control` file with appropriate fields (Package,
+       Version, Architecture, Maintainer, Description, and dependencies).
+    3) Copying the required package contents from an Artifactory repository.
+    4) Invoking `dpkg-buildpackage` to assemble the final `.deb` file.
+
+    Parameters:
+    pkg_name : Name of the package to be created
+    config: Configuration object containing package metadata
+
+    Returns:
+    output_list: List of packages created
+    """
+    print_function_name()
+    # Explicitly ensure versioned_pkg=True
+    build_config = replace(config, versioned_pkg=True)
+
+    # Use updated package name for build directory to avoid collisions between variants
+    # Each variant (host, device, meta) gets its own build directory
+    updated_pkg_name = update_package_name(pkg_name, build_config)
+    package_dir = Path(build_config.dest_dir) / build_config.pkg_type / updated_pkg_name
+    deb_dir = package_dir / "debian"
+    # Create package directory and debian directory
+    os.makedirs(deb_dir, exist_ok=True)
+
+    pkg_info = get_package_info(pkg_name)  # Raises ValueError if not found
+    is_meta = is_meta_package(pkg_info)
+    generate_changelog_file(pkg_info, deb_dir, build_config)
+    generate_rules_file(pkg_info, deb_dir, build_config)
+    generate_control_file(pkg_info, deb_dir, build_config)
+    if is_postinstallscripts_available(pkg_info):
+        generate_debian_postscripts(pkg_info, deb_dir, build_config)
+
+    sourcedir_list = []
+    dir_list = filter_components_fromartifactory(
+        pkg_name,
+        build_config.artifacts_dir,
+        build_config.gfx_arch,
+        build_config.enable_kpack,
+    )
+    sourcedir_list.extend(dir_list)
+
+    print(f"sourcedir_list:\n  {sourcedir_list}")
+    # GFX_META is a versioned meta package (empty content, just dependencies)
+    is_gfx_meta = build_config.enable_kpack and build_config.gfx_arch == GFX_META
+    if not sourcedir_list and not is_meta and not is_gfx_meta:
+        if build_config.enable_kpack:
+            print(
+                f"ERROR: {pkg_name}: Empty sourcedir_list and not a meta package, skipping"
+            )
+            return []
+        else:
+            sys.exit(
+                f"{pkg_name}: Empty sourcedir_list and not a meta package, exiting"
+            )
+
+    if not sourcedir_list:
+        print(f"{pkg_name} is a Meta package")
+    else:
+        # Copy package contents first
+        dest_dir = package_dir / Path(build_config.install_prefix).relative_to("/")
+        for source_path in sourcedir_list:
+            copy_package_contents(source_path, dest_dir)
+
+        if build_config.enable_rpath:
+            convert_runpath_to_rpath(package_dir)
+
+        # Generate install file after copying, so we can check for hidden files
+        generate_install_file(pkg_info, deb_dir, build_config, dest_dir)
+
+    package_with_dpkg_build(package_dir)
+
+    # Move packages to destination
+    updated_pkg_name = update_package_name(pkg_name, build_config)
+    output_list = move_packages_to_destination(updated_pkg_name, build_config)
+    return output_list
+
+
+def generate_changelog_file(pkg_info, deb_dir, config: PackageConfig):
+    """Generate a Debian changelog entry in `debian/changelog`.
+
+    Parameters:
+    pkg_info : Package details from the Json file
+    deb_dir: Directory where debian package changelog file is saved
+    config: Configuration object containing package metadata
+
+    Returns: None
+    """
+    print_function_name()
+    changelog = Path(deb_dir) / "changelog"
+
+    pkg_name = update_package_name(pkg_info.get("Package"), config)
+    maintainer = pkg_info.get("Maintainer")
+    name_part, email_part = maintainer.split("<")
+    name = name_part.strip()
+    email = email_part.replace(">", "").strip()
+    # version is used along with package name
+    version = str(config.rocm_version)
+    if config.version_suffix:
+        version += f"-{str(config.version_suffix)}"
+
+    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
+    template = env.get_template("template/debian_changelog.j2")
+
+    # Prepare context dictionary
+    context = {
+        "package": pkg_name,
+        "version": version,
+        "distribution": "UNRELEASED",
+        "urgency": "medium",
+        "changes": ["Initial release"],  # TODO: Will get from package.json?
+        "maintainer_name": name,
+        "maintainer_email": email,
+        "date": format_datetime(
+            datetime.now(timezone.utc)
+        ),  # TODO. How to get the date info?
+    }
+
+    with changelog.open("w", encoding="utf-8") as f:
+        f.write(template.render(context))
+
+
+def generate_install_file(pkg_info, deb_dir, config: PackageConfig, dest_dir=None):
+    """Generate a Debian install entry in `debian/install`.
+
+    Parameters:
+    pkg_info : Package details from the Json file
+    deb_dir: Directory where debian package control file is saved
+    config: Configuration object containing package metadata
+    dest_dir: Optional path to check for hidden files
+
+    Returns: None
+    """
+    print_function_name()
+    # Note: pkg_info is not used currently:
+    # May be required in future to populate any context
+    install_file = Path(deb_dir) / "install"
+
+    # Check if hidden files and regular files exist in the destination directory
+    has_hidden_files = False
+    has_regular_files = False
+    if dest_dir and Path(dest_dir).exists():
+        for item in Path(dest_dir).iterdir():
+            name = item.name  # get the filename as a string
+            # Skip "." and ".."
+            if name in [".", ".."]:
+                continue
+
+            # Hidden entry
+            if name.startswith("."):
+                has_hidden_files = True
+            else:
+                has_regular_files = True
+
+    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
+    template = env.get_template("template/debian_install.j2")
+    # Prepare your context dictionary
+    context = {
+        "path": config.install_prefix,
+        "has_hidden_files": has_hidden_files,
+        "has_regular_files": has_regular_files,
+    }
+
+    with install_file.open("w", encoding="utf-8") as f:
+        f.write(template.render(context))
+
+
+def generate_rules_file(pkg_info, deb_dir, config: PackageConfig):
+    """Generate a Debian rules entry in `debian/rules`.
+
+    Parameters:
+    pkg_info : Package details from the Json file
+    deb_dir: Directory where debian package control file is saved
+    config: Configuration object containing package metadata
+
+    Returns: None
+    """
+    print_function_name()
+    rules_file = Path(deb_dir) / "rules"
+    disable_dh_strip = is_key_defined(pkg_info, "Disable_DEB_STRIP")
+    disable_dwz = is_key_defined(pkg_info, "Disable_DWZ")
+    # Get package name for changelog installation
+    pkg_name = update_package_name(pkg_info.get("Package"), config)
+
+    # Disable debian dh_strip for multi-arch builds
+    # WORKAROUND: dh_strip's debugedit incorrectly truncates ELF files with
+    # unconventional layouts (e.g., program headers at end of file).
+    # This causes "program header goes past the end of the file" errors.
+    # See: https://github.com/ROCm/TheRock/issues/4047
+    if config.enable_kpack:
+        disable_dh_strip = True
+
+    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
+    template = env.get_template("template/debian_rules.j2")
+    # Prepare  context dictionary
+    context = {
+        "disable_dwz": disable_dwz,
+        "disable_dh_strip": disable_dh_strip,
+        "install_prefix": config.install_prefix,
+        "pkg_name": pkg_name,
+    }
+
+    with rules_file.open("w", encoding="utf-8") as f:
+        f.write(template.render(context))
+    # set executable permission for rules file
+    rules_file.chmod(0o755)
+
+
+def generate_control_file(pkg_info, deb_dir, config: PackageConfig):
+    """Generate a Debian control file entry in `debian/control`.
+
+    Parameters:
+    pkg_info: Package details parsed from a JSON file
+    deb_dir: Directory where the `debian/control` file will be created
+    config: Configuration object containing package metadata
+
+    Returns: None
+    """
+    print_function_name()
+    control_file = Path(deb_dir) / "control"
+    pkg_name = pkg_info.get("Package")
+    is_meta = is_meta_package(pkg_info)
+
+    # Initialize optional fields
+    provides = replaces = conflicts = ""
+    debrecommends = debsuggests = ""
+
+    if config.versioned_pkg:
+        # Get -> Filter -> Transform
+        debrecommends = process_secondary_dependencies(
+            pkg_info, "DEBRecommends", config
+        )
+        debsuggests = process_secondary_dependencies(pkg_info, "DEBSuggests", config)
+        depends = process_main_dependencies(pkg_info, "DEBDepends", config)
+    else:
+        # Get -> Transform -> Join
+        provides = process_name_field(pkg_info, "Provides", debian_replace_devel_name)
+        replaces = process_name_field(pkg_info, "Replaces", debian_replace_devel_name)
+        conflicts = process_name_field(pkg_info, "Conflicts", debian_replace_devel_name)
+        # Non-versioned package depends on versioned package itself
+        depends = resolve_versioned_dependencies([pkg_name], config, is_meta)
+
+    pkg_name = update_package_name(pkg_name, config)
+
+    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
+    template = env.get_template("template/debian_control.j2")
+    context = {
+        "source": pkg_name,
+        "depends": depends,
+        "pkg_name": pkg_name,
+        "arch": pkg_info.get("Architecture"),
+        "description_short": pkg_info.get("Description_Short"),
+        "description_long": pkg_info.get("Description_Long"),
+        "homepage": pkg_info.get("Homepage"),
+        "maintainer": pkg_info.get("Maintainer"),
+        "priority": pkg_info.get("Priority"),
+        "section": pkg_info.get("Section"),
+        "version": config.rocm_version,
+        "provides": provides,
+        "replaces": replaces,
+        "conflicts": conflicts,
+        "debrecommends": debrecommends,
+        "debsuggests": debsuggests,
+    }
+
+    with control_file.open("w", encoding="utf-8") as f:
+        f.write(template.render(context))
+        f.write("\n")  # Adds a blank line. For fixing missing final newline
+
+
+def generate_debian_postscripts(pkg_info, deb_dir, config: PackageConfig):
+    """Generate a Debian postinst/prerm file entry in `debian folder`.
+
+    Parameters:
+    pkg_info: Package details parsed from a JSON file
+    deb_dir: Directory where the `debian/control` file will be created
+    config: Configuration object containing package metadata
+
+    Returns: None
+    """
+    # Debian maintainer scripts that must be executable
+    EXEC_SCRIPTS = {"preinst", "postinst", "prerm", "postrm", "config"}
+    pkg_name = pkg_info.get("Package")
+    parts = config.rocm_version.split(".")
+    if len(parts) < 3:
+        raise ValueError(
+            f"Version string '{config.rocm_version}' does not have major.minor.patch versions"
+        )
+
+    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
+    # Prepare your context dictionary
+    context = {
+        "install_prefix": config.install_prefix,
+        "version_major": int(re.match(r"^\d+", parts[0]).group()),
+        "version_minor": int(re.match(r"^\d+", parts[1]).group()),
+        "version_patch": int(re.match(r"^\d+", parts[2]).group()),
+        "target": "deb",
+    }
+
+    templates_root = Path(SCRIPT_DIR) / "template" / "scripts"
+    # Collect all matching files
+    for script in EXEC_SCRIPTS:
+        pattern = f"{pkg_name}-{script}.j2"
+        for file in templates_root.glob(pattern):
+            script_file = Path(deb_dir) / script
+            template = env.get_template(str(file.relative_to(SCRIPT_DIR)))
+            with script_file.open("w", encoding="utf-8") as f:
+                f.write(template.render(context))
+            os.chmod(script_file, 0o755)
+
+
+def copy_package_contents(source_dir, destination_dir):
+    """Copy package contents from artfactory to package build directory
+
+    Parameters:
+    source_dir : Source directory
+    destination_dir: Local directory where the package contents should be copied
+
+    Returns: None
+    """
+    print_function_name()
+
+    source_dir = Path(source_dir)
+    destination_dir = Path(destination_dir)
+
+    if not source_dir.is_dir():
+        print(f"Directory does not exist: {source_dir}")
+        return
+
+    # Ensure destination directory exists
+    destination_dir.mkdir(parents=True, exist_ok=True)
+
+    # Copy each item from source to destination
+    for item in source_dir.iterdir():
+        src = item
+        dst = destination_dir / item.name
+
+        if src.is_dir() and not dst.is_symlink():
+            shutil.copytree(
+                src,
+                dst,
+                dirs_exist_ok=True,
+                symlinks=True,
+                ignore_dangling_symlinks=True,
+            )
+        elif src.is_symlink():
+            # Copy the symlink itself (even if dangling)
+            link_target = src.readlink()
+            dst.symlink_to(link_target)
+        else:
+            shutil.copy2(src, dst)
+
+
+def package_with_dpkg_build(pkg_dir):
+    """Generate a Debian package using `dpkg-buildpackage`
+
+    Parameters:
+    pkg_dir: Path to the directory containing the package contents and the `debian/`
+        subdirectory (with `control`, `changelog`, `rules`, etc.).
+
+    Returns: None
+    """
+    print_function_name()
+    # Build the command
+    cmd = ["dpkg-buildpackage", "-uc", "-us", "-b"]
+
+    # Execute the command
+    try:
+        subprocess.run(cmd, check=True, cwd=pkg_dir)
+        print(f"Deb Package built successfully: {os.path.basename(pkg_dir)}")
+    except subprocess.CalledProcessError as e:
+        print(f"Error building deb package: {os.path.basename(pkg_dir)}: {e}")
+        sys.exit(e.returncode)
+
+
+######################## RPM package creation ####################

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -94,36 +94,7 @@ def is_key_defined(pkg_info, key):
             value = pkg_info[k]
 
     value = value.strip().lower()
-    if value in (
-        "1",
-        "true",
-        "t",
-        "yes",
-        "y",
-        "on",
-        "enable",
-        "enabled",
-        "found",
-    ):
-        return True
-    if value in (
-        "",
-        "0",
-        "false",
-        "f",
-        "no",
-        "n",
-        "off",
-        "disable",
-        "disabled",
-        "notfound",
-        "none",
-        "null",
-        "nil",
-        "undefined",
-        "n/a",
-    ):
-        return False
+    return value in ("1", "true", "t", "yes", "y", "on", "enable", "enabled", "found")
 
 
 def is_postinstallscripts_available(pkg_info):
@@ -296,7 +267,7 @@ def get_package_list(artifact_dir):
         if is_packaging_disabled(pkg_info):
             continue
 
-        # Metapackages don't need artifact lookup
+        # Metapackages do not need artifact lookup
         if is_meta_package(pkg_info):
             pkg_list.append(pkg_name)
             continue
@@ -417,7 +388,12 @@ def expand_metapackage_to_all_archs(pkg_name, gfxarch_list, config: PackageConfi
     """
     arch_specific_packages = []
 
-    for gfx_arch in gfxarch_list:
+    # Filter archs to only those with artifacts
+    filtered_archs = filter_archs_with_artifacts(
+        pkg_name, gfxarch_list, config.artifacts_dir
+    )
+
+    for gfx_arch in filtered_archs:
         # Create new config for each arch with versioned_pkg=True
         local_config = replace(config, versioned_pkg=True, gfx_arch=gfx_arch)
         # update_package_name will append version and gfx_arch
@@ -447,8 +423,13 @@ def expand_kpack_meta_dependencies(pkg_name, gfxarch_list, config: PackageConfig
     host_pkg = update_package_name(pkg_name, host_config)
     packages.append(host_pkg)
 
-    # Add all arch-specific (device) packages
-    for gfx_arch in gfxarch_list:
+    # Filter archs to only those with artifacts
+    filtered_archs = filter_archs_with_artifacts(
+        pkg_name, gfxarch_list, config.artifacts_dir
+    )
+
+    # Add arch-specific (device) packages only for available architectures
+    for gfx_arch in filtered_archs:
         arch_config = replace(config, versioned_pkg=True, gfx_arch=gfx_arch)
         arch_pkg = update_package_name(pkg_name, arch_config)
         packages.append(arch_pkg)
@@ -547,13 +528,11 @@ def process_main_dependencies_kpack(
             )
         else:
             # Arch-specific metapackage: depend on actual runtime packages
-            # Filter out dependencies that don't have artifacts for this architecture
             dep_list = pkg_info.get(field_key, [])
-            dep_list = [
-                dep
-                for dep in dep_list
-                if has_artifact_for_arch(dep, config.artifacts_dir, config.gfx_arch)
-            ]
+            # Filter deps without artifacts
+            dep_list = filter_dependencies_by_artifacts(
+                dep_list, config.artifacts_dir, config.gfx_arch
+            )
     elif config.gfx_arch == GFX_META:
         # GFX_META for non-meta gfxarch packages: depend on host + all device packages
         dep_list = expand_kpack_meta_dependencies(pkg_name, config.gfxarch_list, config)
@@ -568,9 +547,12 @@ def process_main_dependencies_kpack(
                 get_package_info(dep, raise_if_missing=False) or {}, config.enable_kpack
             )
         ]
+        # Filter deps without artifacts
+        dep_list = filter_dependencies_by_artifacts(
+            dep_list, config.artifacts_dir, config.gfx_arch
+        )
     else:
         # Device package: depend on host package + gfxarch dependencies with arch suffix
-        # Filter out dependencies that don't have artifacts for this architecture
         dep_list = pkg_info.get(field_key, [])
         gfxarch_deps = [
             dep
@@ -578,8 +560,11 @@ def process_main_dependencies_kpack(
             if is_gfxarch_package(
                 get_package_info(dep, raise_if_missing=False) or {}, config.enable_kpack
             )
-            and has_artifact_for_arch(dep, config.artifacts_dir, config.gfx_arch)
         ]
+        # Filter deps without artifacts
+        gfxarch_deps = filter_dependencies_by_artifacts(
+            gfxarch_deps, config.artifacts_dir, config.gfx_arch
+        )
         dep_list = [pkg_name] + gfxarch_deps
 
     if not dep_list:
@@ -683,15 +668,15 @@ def convert_to_versiondependency(
 def append_version_suffix(dep_string, config: PackageConfig):
     """Append a ROCm version suffix to dependency names that match known ROCm packages.
 
-    This function takes a comma‑separated dependency string,
+    This function takes a comma-separated dependency string,
     identifies which dependencies correspond to packages listed in `pkg_list`,
     and appends the appropriate ROCm version suffix based on the provided configuration.
 
     Parameters:
-    dep_string : A comma‑separated list of dependency package names.
+    dep_string : A comma-separated list of dependency package names.
     config : Configuration object containing ROCm version, suffix, and packaging type.
 
-    Returns: A comma‑separated string where matching dependencies include the version suffix,
+    Returns: A comma-separated string where matching dependencies include the version suffix,
     while all others remain unchanged.
     """
     print_function_name()
@@ -954,11 +939,11 @@ def has_artifact_for_arch(pkg_name, artifacts_dir, gfx_arch):
     if pkg_info is None:
         return False
 
-    # Non-gfxarch packages don't need arch-specific artifacts
+    # Non-gfxarch packages do not need arch-specific artifacts
     if not is_gfxarch_package(pkg_info, enable_kpack=True):
         return True
 
-    # Meta packages don't have their own artifacts
+    # Meta packages do not have their own artifacts
     if is_meta_package(pkg_info):
         return True
 
@@ -977,7 +962,7 @@ def has_artifact_for_arch(pkg_name, artifacts_dir, gfx_arch):
             artifact_suffix = gfx_arch
 
         # When checking for a specific gfx architecture (not host/meta),
-        # skip generic-only artifacts - they don't contribute to gfx-specific packages
+        # skip generic-only artifacts - they do not contribute to gfx-specific packages
         if gfx_arch not in (GFX_HOST, GFX_META) and artifact_suffix == "generic":
             continue
 
@@ -1013,92 +998,83 @@ def has_artifact_for_arch(pkg_name, artifacts_dir, gfx_arch):
     return False
 
 
-def get_dependency_list_for_multiarch(pkg_info, dep_key, config: PackageConfig):
-    """Determine the appropriate dependency list for multi-arch mode.
+def filter_archs_with_artifacts(
+    pkg_name: str, gfxarch_list, artifacts_dir: Path
+) -> list:
+    """Filter architecture list to only those with available artifacts.
+
+    This function prevents meta packages from depending on device packages that
+    do not exist because their artifacts were not built.
 
     Parameters:
-    pkg_info: Package details from JSON
-    dep_key: Dependency key ("DEBDepends" or "RPMRequires")
-    config: Configuration object containing package metadata
+    pkg_name: Package name to check (e.g., "amdrocm-ck")
+    gfxarch_list: Full list of architecture targets to filter
+    artifacts_dir: Directory where artifacts are stored
 
-    Returns: List of dependency package names
+    Returns: Filtered list of architectures that have artifacts available
+
+    Example:
+        Input:  ["gfx1100", "gfx1101", "gfx942"], pkg_name="amdrocm-ck"
+        Output: ["gfx1100", "gfx942"]  # if gfx1101 has no artifacts for ck
     """
-    pkg_name = pkg_info.get("Package")
-    is_meta = is_meta_package(pkg_info)
+    pkg_info = get_package_info(pkg_name, raise_if_missing=False)
+    if pkg_info is None:
+        return list(gfxarch_list)
 
-    if (
-        config.enable_kpack
-        and is_meta
-        and is_gfxarch_package(pkg_info, config.enable_kpack)
-    ):
-        # For gfxarch metapackages in multi-arch mode:
-        # - Generic variant depends on all arch-specific variants
-        # - Arch-specific variants depend on actual runtime packages
-        # Non-gfxarch metapackages (e.g., developer-tools) fall through to generic handling
-        if config.gfx_arch == GFX_GENERIC:
-            # Generic metapackage: depend on all arch-specific metapackages
-            return expand_metapackage_to_all_archs(
-                pkg_name, config.gfxarch_list, config
-            )
+    # Non-gfxarch packages do not have arch-specific variants
+    if not is_gfxarch_package(pkg_info, enable_kpack=True):
+        return list(gfxarch_list)
+
+    # Meta packages inherit from their dependencies, return all archs
+    if is_meta_package(pkg_info):
+        return list(gfxarch_list)
+
+    # Filter to only architectures with available artifacts
+    available = [
+        arch
+        for arch in gfxarch_list
+        if has_artifact_for_arch(pkg_name, artifacts_dir, arch)
+    ]
+
+    if len(available) < len(list(gfxarch_list)):
+        missing = set(gfxarch_list) - set(available)
+        print(f"WORKAROUND: {pkg_name} missing artifacts for: {sorted(missing)}")
+
+    return available
+
+
+def filter_dependencies_by_artifacts(
+    dep_list: list, artifacts_dir: Path, gfx_arch: str
+) -> list:
+    """Filter dependency list to exclude packages without artifacts.
+
+    Removes dependencies that do not have artifacts available for the specified
+    architecture. This prevents installation failures due to missing packages.
+
+    Parameters:
+    dep_list: List of dependency package names
+    artifacts_dir: Directory where artifacts are stored
+    gfx_arch: Target architecture to check
+
+    Returns: Filtered dependency list
+    """
+    filtered = []
+    for dep in dep_list:
+        dep_info = get_package_info(dep, raise_if_missing=False)
+        if dep_info is None:
+            # Unknown package, keep it (might be system package)
+            filtered.append(dep)
+            continue
+
+        # Non-gfxarch packages are always available
+        if not is_gfxarch_package(dep_info, enable_kpack=True):
+            filtered.append(dep)
+            continue
+
+        # Check if gfxarch package has artifacts
+        if has_artifact_for_arch(dep, artifacts_dir, gfx_arch):
+            filtered.append(dep)
         else:
-            # Arch-specific metapackage: depend on actual runtime packages
-            dep_list = pkg_info.get(dep_key, [])
+            print(f"WORKAROUND: Excluding {dep} (no artifacts for {gfx_arch})")
 
-            # Check if this is a non-gfxarch metapackage or a -devel metapackage
-            is_pkg_gfxarch = is_gfxarch_package(pkg_info, config.enable_kpack)
-
-            if not is_pkg_gfxarch or pkg_name.endswith("-devel"):
-                # For non-gfxarch metapackages (e.g., developer-tools) and
-                # -devel metapackages (even if gfxarch):
-                # Include all dependencies that exist in pkg_list (no arch filtering)
-                pkg_list, _ = get_package_list(config.artifacts_dir)
-                return [
-                    dep
-                    for dep in dep_list
-                    if not dep.startswith("amdrocm") or dep in pkg_list
-                ]
-            else:
-                # Gfxarch metapackages (non-devel): filter by artifacts
-                return [
-                    dep
-                    for dep in dep_list
-                    if has_artifact_for_arch(dep, config.artifacts_dir, config.gfx_arch)
-                ]
-    elif config.enable_kpack and config.gfx_arch == GFX_GENERIC:
-        # Generic package in multi-arch mode:
-        # Only include non-gfxarch dependencies
-        # Gfxarch deps are pulled via the gfx-specific package
-        # Exception: non-gfxarch packages and -devel packages keep all dependencies
-        dep_list = pkg_info.get(dep_key, [])
-
-        # For non-gfxarch packages (e.g., developer-tools) and -devel packages,
-        # keep all dependencies but verify amdrocm* packages exist
-        is_pkg_gfxarch = is_gfxarch_package(pkg_info, config.enable_kpack)
-        if not is_pkg_gfxarch or pkg_name.endswith("-devel"):
-            pkg_list, _ = get_package_list(config.artifacts_dir)
-            return [
-                dep
-                for dep in dep_list
-                if not dep.startswith("amdrocm") or dep in pkg_list
-            ]
-
-        return [
-            dep
-            for dep in dep_list
-            if not is_gfxarch_package(get_package_info(dep) or {}, config.enable_kpack)
-        ]
-    elif config.enable_kpack and config.gfx_arch != GFX_GENERIC:
-        # Gfx-specific package in multi-arch mode:
-        # Depend on generic self + gfxarch dependencies with arch suffix
-        # Filter out dependencies that don't have artifacts for this architecture
-        dep_list = pkg_info.get(dep_key, [])
-        gfxarch_deps = [
-            dep
-            for dep in dep_list
-            if is_gfxarch_package(get_package_info(dep) or {}, config.enable_kpack)
-            and has_artifact_for_arch(dep, config.artifacts_dir, config.gfx_arch)
-        ]
-        return [pkg_name] + gfxarch_deps
-    else:
-        # Single-arch mode: use full dependencies
-        return pkg_info.get(dep_key, [])
+    return filtered

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -551,6 +551,14 @@ def process_main_dependencies_kpack(
         dep_list = filter_dependencies_by_artifacts(
             dep_list, config.artifacts_dir, config.gfx_arch
         )
+    elif not is_gfxarch_package(pkg_info, config.enable_kpack):
+        # Non-gfxarch versioned package: use all dependencies directly
+        # These packages don't have host/device split, so include everything
+        dep_list = pkg_info.get(field_key, [])
+        # Filter deps without artifacts
+        dep_list = filter_dependencies_by_artifacts(
+            dep_list, config.artifacts_dir, config.gfx_arch
+        )
     else:
         # Device package: depend on host package + gfxarch dependencies with arch suffix
         dep_list = pkg_info.get(field_key, [])
@@ -894,7 +902,8 @@ def resolve_versioned_dependencies(dep_list, config: PackageConfig, is_meta):
             versioned = convert_to_versiondependency(
                 [dep], config, preserve_arch=preserve
             )
-            result_deps.append(versioned)
+            if versioned:  # Filter out empty strings from missing packages
+                result_deps.append(versioned)
 
         deps = ", ".join(result_deps)
         deps = append_version_suffix(deps, config)

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 
-import copy
-import glob
 import json
 import os
 import platform
@@ -16,8 +14,10 @@ from pathlib import Path
 
 
 # Constants
-# Used for creating a generic package in Multi arch mode
-GFX_GENERIC = "gfx_generic"
+# Used for creating host package in kpack mode (contains generic content)
+GFX_HOST = "gfx_host"
+# Used for creating versioned meta package in kpack mode (depends on host + devices)
+GFX_META = "gfx_meta"
 
 
 # User inputs required for packaging
@@ -223,13 +223,18 @@ def is_gfxarch_package(pkg_info, enable_kpack=False):
     return is_key_defined(pkg_info, "Gfxarch")
 
 
-def get_package_info(pkgname):
+def get_package_info(pkgname, raise_if_missing=True):
     """Retrieves package details from a JSON file for the given package name
 
     Parameters:
     pkgname : Package Name
+    raise_if_missing : If True, raise ValueError when package not found.
+                       If False, return None (for backward compatibility)
 
-    Returns: Package metadata
+    Returns: Package metadata dictionary, or None if not found and raise_if_missing=False
+
+    Raises:
+    ValueError: If package not found and raise_if_missing=True
     """
 
     # Load JSON data from a file
@@ -239,6 +244,12 @@ def get_package_info(pkgname):
         if package.get("Package") == pkgname:
             return package
 
+    # Package not found
+    if raise_if_missing:
+        raise ValueError(
+            f"Package '{pkgname}' not found in package.json. "
+            f"Please verify the package name and ensure it's defined in the package configuration."
+        )
     return None
 
 
@@ -360,14 +371,31 @@ def update_package_name(pkg_name, config: PackageConfig):
     if config.pkg_type.lower() == "deb":
         updated_pkgname = debian_replace_devel_name(pkg_name)
 
+    # For GFX_HOST in kpack mode, add "-host" before version suffix
+    # Result: amdrocm-fft-host8.2 (not amdrocm-fft8.2-host)
+    if (
+        config.enable_kpack
+        and is_gfxarch_package(pkg_info, config.enable_kpack)
+        and config.gfx_arch == GFX_HOST
+    ):
+        updated_pkgname += "-host"
+
     updated_pkgname += pkg_suffix
 
     if is_gfxarch_package(pkg_info, config.enable_kpack):
-        # For multi-arch mode, skip appending gfx_generic
-        if config.enable_kpack and config.gfx_arch == GFX_GENERIC:
-            pass  # Don't append gfx_generic in multi-arch mode
+        if config.enable_kpack:
+            if config.gfx_arch == GFX_HOST:
+                # Host package: "-host" already added before version
+                pass
+            elif config.gfx_arch == GFX_META:
+                # Meta package: no arch suffix (e.g., amdrocm-fft8.2)
+                pass
+            else:
+                # Device package: add gfx arch suffix (e.g., amdrocm-fft8.2-gfx1100)
+                gfx_arch = config.gfx_arch.lower().split("-", 1)[0]
+                updated_pkgname += "-" + gfx_arch
         else:
-            # Remove -dcgpu from gfx_arch
+            # Single-arch mode: add gfx arch suffix
             gfx_arch = config.gfx_arch.lower().split("-", 1)[0]
             updated_pkgname += "-" + gfx_arch
 
@@ -397,6 +425,35 @@ def expand_metapackage_to_all_archs(pkg_name, gfxarch_list, config: PackageConfi
         arch_specific_packages.append(arch_pkg)
 
     return arch_specific_packages
+
+
+def expand_kpack_meta_dependencies(pkg_name, gfxarch_list, config: PackageConfig):
+    """Get dependencies for kpack versioned meta package: host + all device packages.
+
+    For example, if pkg_name is "amdrocm-fft" and gfxarch_list is ["gfx1100", "gfx1101"],
+    this returns a list: ["amdrocm-fft-host8.2", "amdrocm-fft8.2-gfx1100", "amdrocm-fft8.2-gfx1101"]
+
+    Parameters:
+    pkg_name: Base package name (e.g., "amdrocm-fft")
+    gfxarch_list: List of architecture targets
+    config: Configuration object containing package metadata
+
+    Returns: List of package names (host + all device packages)
+    """
+    packages = []
+
+    # Add host package (with -host suffix)
+    host_config = replace(config, versioned_pkg=True, gfx_arch=GFX_HOST)
+    host_pkg = update_package_name(pkg_name, host_config)
+    packages.append(host_pkg)
+
+    # Add all arch-specific (device) packages
+    for gfx_arch in gfxarch_list:
+        arch_config = replace(config, versioned_pkg=True, gfx_arch=gfx_arch)
+        arch_pkg = update_package_name(pkg_name, arch_config)
+        packages.append(arch_pkg)
+
+    return packages
 
 
 def debian_replace_devel_name(pkg_name):
@@ -441,37 +498,137 @@ def process_name_field(
     return ", ".join(name_list)
 
 
-def process_dependency_field(
-    pkg_info: dict,
-    field_key: str,
-    config: PackageConfig,
-    use_multiarch: bool = False,
+def process_main_dependencies(
+    pkg_info: dict, field_key: str, config: PackageConfig
 ) -> str:
-    """Process a dependency field with 3-step pattern.
+    """Process main dependency field (DEBDepends/RPMRequires).
 
-    Works for: DEBDepends, DEBRecommends, DEBSuggests,
-               RPMRequires, RPMRecommends, RPMSuggests
+    Delegates to kpack or single-arch handler based on build mode.
 
     Parameters:
     pkg_info: Package details from JSON
-    field_key: Key to extract (e.g., "DEBDepends", "RPMRecommends")
+    field_key: Key to extract ("DEBDepends" or "RPMRequires")
     config: Configuration object containing package metadata
-    use_multiarch: If True, apply multi-arch expansion for main dependencies
+
+    Returns: Comma-separated string of versioned dependencies
+    """
+    if config.enable_kpack:
+        return process_main_dependencies_kpack(pkg_info, field_key, config)
+    else:
+        return process_main_dependencies_single_arch(pkg_info, field_key, config)
+
+
+def process_main_dependencies_kpack(
+    pkg_info: dict, field_key: str, config: PackageConfig
+) -> str:
+    """Process main dependencies for kpack (multi-arch) mode.
+
+    Handles:
+    - Meta packages: depend on all arch-specific variants
+    - Host packages: depend on non-gfxarch packages only
+    - Device packages: depend on host + arch-specific gfxarch packages
+    - GFX_META packages: depend on host + all device variants
+
+    Parameters:
+    pkg_info: Package details from JSON
+    field_key: Key to extract ("DEBDepends" or "RPMRequires")
+    config: Configuration object containing package metadata
 
     Returns: Comma-separated string of versioned dependencies
     """
     is_meta = is_meta_package(pkg_info)
-    # Step 1 & 2: Get + Filter
-    if use_multiarch:
-        dep_list = get_dependency_list_for_multiarch(pkg_info, field_key, config)
-    else:
-        dep_list = pkg_info.get(field_key, []) or []
+    pkg_name = pkg_info.get("Package")
 
-    # Return empty string if no dependencies
+    if is_meta:
+        if config.gfx_arch == GFX_META:
+            # Meta package: depend on all arch-specific metapackages
+            dep_list = expand_metapackage_to_all_archs(
+                pkg_name, config.gfxarch_list, config
+            )
+        else:
+            # Arch-specific metapackage: depend on actual runtime packages
+            # Filter out dependencies that don't have artifacts for this architecture
+            dep_list = pkg_info.get(field_key, [])
+            dep_list = [
+                dep
+                for dep in dep_list
+                if has_artifact_for_arch(dep, config.artifacts_dir, config.gfx_arch)
+            ]
+    elif config.gfx_arch == GFX_META:
+        # GFX_META for non-meta gfxarch packages: depend on host + all device packages
+        dep_list = expand_kpack_meta_dependencies(pkg_name, config.gfxarch_list, config)
+    elif config.gfx_arch == GFX_HOST:
+        # Host package: only include non-gfxarch dependencies
+        # Gfxarch deps are pulled via the gfx-specific package
+        dep_list = pkg_info.get(field_key, [])
+        dep_list = [
+            dep
+            for dep in dep_list
+            if not is_gfxarch_package(
+                get_package_info(dep, raise_if_missing=False) or {}, config.enable_kpack
+            )
+        ]
+    else:
+        # Device package: depend on host package + gfxarch dependencies with arch suffix
+        # Filter out dependencies that don't have artifacts for this architecture
+        dep_list = pkg_info.get(field_key, [])
+        gfxarch_deps = [
+            dep
+            for dep in dep_list
+            if is_gfxarch_package(
+                get_package_info(dep, raise_if_missing=False) or {}, config.enable_kpack
+            )
+            and has_artifact_for_arch(dep, config.artifacts_dir, config.gfx_arch)
+        ]
+        dep_list = [pkg_name] + gfxarch_deps
+
     if not dep_list:
         return ""
+    return resolve_versioned_dependencies(dep_list, config, is_meta)
 
-    # Step 3: Transform
+
+def process_main_dependencies_single_arch(
+    pkg_info: dict, field_key: str, config: PackageConfig
+) -> str:
+    """Process main dependencies for single-arch mode.
+
+    Simple case: use full dependency list from package.json and add version suffixes.
+
+    Parameters:
+    pkg_info: Package details from JSON
+    field_key: Key to extract ("DEBDepends" or "RPMRequires")
+    config: Configuration object containing package metadata
+
+    Returns: Comma-separated string of versioned dependencies
+    """
+    is_meta = is_meta_package(pkg_info)
+    dep_list = pkg_info.get(field_key, []) or []
+
+    if not dep_list:
+        return ""
+    return resolve_versioned_dependencies(dep_list, config, is_meta)
+
+
+def process_secondary_dependencies(
+    pkg_info: dict, field_key: str, config: PackageConfig
+) -> str:
+    """Process secondary dependency fields (Recommends/Suggests).
+
+    Simple processing: get from JSON and add version suffixes.
+    Works the same for both kpack and single-arch modes.
+
+    Parameters:
+    pkg_info: Package details from JSON
+    field_key: Key to extract (e.g., "DEBRecommends", "RPMSuggests")
+    config: Configuration object containing package metadata
+
+    Returns: Comma-separated string of versioned dependencies
+    """
+    is_meta = is_meta_package(pkg_info)
+    dep_list = pkg_info.get(field_key, []) or []
+
+    if not dep_list:
+        return ""
     return resolve_versioned_dependencies(dep_list, config, is_meta)
 
 
@@ -496,9 +653,14 @@ def convert_to_versiondependency(
 
     # Create config with versioned_pkg=True and conditionally override gfx_arch
     if config.enable_kpack and not preserve_arch:
-        # In multi-arch mode, dependencies point to generic packages
-        # UNLESS preserve_arch is True (for arch-specific metapackages)
-        local_config = replace(config, versioned_pkg=True, gfx_arch=GFX_GENERIC)
+        if not config.versioned_pkg:
+            # Non-versioned package depends on versioned meta package
+            # e.g., amdrocm-fft -> amdrocm-fft8.2
+            local_config = replace(config, versioned_pkg=True, gfx_arch=GFX_META)
+        else:
+            # Versioned packages depend on host packages
+            # e.g., amdrocm-fft8.2-gfx1100 -> amdrocm-fft-host8.2
+            local_config = replace(config, versioned_pkg=True, gfx_arch=GFX_HOST)
     else:
         local_config = replace(config, versioned_pkg=True)
 
@@ -562,11 +724,15 @@ def append_version_suffix(dep_string, config: PackageConfig):
     return depends
 
 
-def move_packages_to_destination(pkg_name, config: PackageConfig):
-    """Move the generated Debian package from the build directory to the destination directory.
+def move_packages_to_destination(updated_pkg_name, config: PackageConfig):
+    """Move the generated package from the build directory to the destination directory.
+
+    This function is parallel-safe because it uses exact package name matching
+    rather than glob patterns that could match multiple variants.
 
     Parameters:
-    pkg_name : Package name
+    updated_pkg_name : Updated package name (e.g., "amdrocm-fft-host8.2", "amdrocm-fft8.2-gfx1100")
+                       Should be the result of update_package_name(pkg_name, config)
     config: Configuration object containing package metadata
 
     Returns:
@@ -576,21 +742,26 @@ def move_packages_to_destination(pkg_name, config: PackageConfig):
     output_packages = []
     # Create destination dir to move the packages created
     os.makedirs(config.dest_dir, exist_ok=True)
-    print(f"Package name: {pkg_name}")
+    print(f"Updated package name: {updated_pkg_name}")
     PKG_DIR = Path(config.dest_dir) / config.pkg_type
+
     if config.pkg_type.lower() == "deb":
         artifacts = list(PKG_DIR.glob("*.deb"))
-        # Replace -devel with -dev for debian packages
-        pkg_name = debian_replace_devel_name(pkg_name)
+        # DEB filename format: {updated_pkg_name}_{version}_{arch}.deb
+        # Example: amdrocm-fft-host8.2_8.2.0-12345_amd64.deb
+        prefix = f"{updated_pkg_name}_"
     else:
         artifacts = list(PKG_DIR.glob(f"*/RPMS/{platform.machine()}/*.rpm"))
+        # RPM filename format: {updated_pkg_name}-{version}-{release}.{arch}.rpm
+        # Example: amdrocm-fft-host8.2-8.2.0-12345.x86_64.rpm
+        prefix = f"{updated_pkg_name}-"
 
     # Move deb/rpm files to the destination directory
     for file_path in artifacts:
         file_path = Path(file_path)  # ensure it's a Path object
         file_name = file_path.name  # basename equivalent
 
-        if file_name.startswith(pkg_name):
+        if file_name.startswith(prefix):
             dest_file = Path(config.dest_dir) / file_name
 
             # if file exists, remove it first
@@ -624,11 +795,16 @@ def filter_components_fromartifactory(
     sourcedir_list = []
 
     if enable_kpack:
-        dir_suffix = (
-            gfx_arch
-            if (is_gfxarch_package(pkg_info, enable_kpack) and gfx_arch != GFX_GENERIC)
-            else "generic"
-        )
+        # GFX_META is a meta package with no artifacts
+        if gfx_arch == GFX_META:
+            return sourcedir_list  # Return empty list for meta package
+        # GFX_HOST uses "generic" artifacts
+        if gfx_arch == GFX_HOST:
+            dir_suffix = "generic"
+        elif is_gfxarch_package(pkg_info, enable_kpack):
+            dir_suffix = gfx_arch
+        else:
+            dir_suffix = "generic"
     else:
         dir_suffix = (
             gfx_arch if is_gfxarch_package(pkg_info, enable_kpack) else "generic"
@@ -653,7 +829,7 @@ def filter_components_fromartifactory(
 
             # In kpack mode, skip non-gfxarch artifacts when building gfx-specific packages
             # This prevents generic artifacts from being included in both base and arch-specific packages
-            if enable_kpack and gfx_arch != GFX_GENERIC and not is_gfxarch:
+            if enable_kpack and gfx_arch not in (GFX_HOST, GFX_META) and not is_gfxarch:
                 print(
                     f"{pkg_name} : Skipping artifact '{artifact_prefix}' for {gfx_arch} package "
                     f"(Artifact_Gfxarch=False, should only be in generic package)"
@@ -697,29 +873,6 @@ def filter_components_fromartifactory(
     return sourcedir_list
 
 
-def clean_package_build_dir(config: PackageConfig):
-    """Clean the package build directories
-
-    If artifactory directory is provided, clean the same as well
-
-    Parameters:
-    config: Configuration object containing package metadata
-
-    Returns: None
-    """
-    print_function_name()
-    PYCACHE_DIR = Path(SCRIPT_DIR) / "__pycache__"
-    remove_dir(PYCACHE_DIR)
-
-    # NOTE: Remove only the build directory
-    # Make sure the destination directory is not removed
-    remove_dir(Path(config.dest_dir) / config.pkg_type)
-    # TBD:
-    # Currently RPATH packages are created by modifying the artifacts dir
-    # So artifacts dir clean up is required
-    # remove_dir(artifacts_dir)
-
-
 def resolve_versioned_dependencies(dep_list, config: PackageConfig, is_meta):
     """Resolve a dependency list into a versioned dependency string.
 
@@ -738,16 +891,14 @@ def resolve_versioned_dependencies(dep_list, config: PackageConfig, is_meta):
 
     Returns: A comma-separated string of versioned dependencies
     """
-    if (
-        config.versioned_pkg
-        and config.enable_kpack
-        and is_meta
-        and config.gfx_arch == GFX_GENERIC
-    ):
+    if config.versioned_pkg and config.enable_kpack and config.gfx_arch == GFX_META:
+        # GFX_META: versioned meta package depends on host + all devices
         # dep_list already contains versioned arch-specific package names
         # Just add version suffix and join
         deps = append_version_suffix(", ".join(dep_list), config)
-    elif config.enable_kpack and is_meta and config.gfx_arch != GFX_GENERIC:
+    elif (
+        config.enable_kpack and is_meta and config.gfx_arch not in (GFX_HOST, GFX_META)
+    ):
         # Arch-specific metapackage: preserve architecture for gfxarch dependencies
         # For -devel metapackages: mix arch-specific (gfxarch) and generic (non-gfxarch)
         result_deps = []
@@ -762,7 +913,11 @@ def resolve_versioned_dependencies(dep_list, config: PackageConfig, is_meta):
 
         deps = ", ".join(result_deps)
         deps = append_version_suffix(deps, config)
-    elif config.enable_kpack and not is_meta and config.gfx_arch != GFX_GENERIC:
+    elif (
+        config.enable_kpack
+        and not is_meta
+        and config.gfx_arch not in (GFX_HOST, GFX_META)
+    ):
         # Gfx-specific non-meta package:
         # dep_list[0] is the versioned-dependency (resolved as generic)
         # dep_list[1:] are gfxarch dependencies (resolved with arch suffix)
@@ -821,9 +976,9 @@ def has_artifact_for_arch(pkg_name, artifacts_dir, gfx_arch):
         else:
             artifact_suffix = gfx_arch
 
-        # When checking for a specific gfx architecture (not generic),
+        # When checking for a specific gfx architecture (not host/meta),
         # skip generic-only artifacts - they don't contribute to gfx-specific packages
-        if gfx_arch != GFX_GENERIC and artifact_suffix == "generic":
+        if gfx_arch not in (GFX_HOST, GFX_META) and artifact_suffix == "generic":
             continue
 
         for subdir in artifact["Artifact_Subdir"]:

--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -10,7 +10,7 @@ import re
 import subprocess
 import sys
 from dataclasses import replace
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from pathlib import Path
 
 from packaging_utils import *
@@ -153,7 +153,14 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
 
     pkg_name = update_package_name(pkg_name, config)
 
-    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
+    env = Environment(
+        loader=FileSystemLoader(str(SCRIPT_DIR)),
+        autoescape=select_autoescape(
+            enabled_extensions=("html", "htm", "xml"),
+            default_for_string=True,
+            default=False,
+        ),
+    )
     template = env.get_template("template/rpm_specfile.j2")
     context = {
         "pkg_name": pkg_name,
@@ -201,7 +208,14 @@ def generate_rpm_postscripts(pkg_info, config: PackageConfig):
     }
     pkg_name = pkg_info.get("Package")
     parts = config.rocm_version.split(".")
-    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
+    env = Environment(
+        loader=FileSystemLoader(str(SCRIPT_DIR)),
+        autoescape=select_autoescape(
+            enabled_extensions=("html", "htm", "xml"),
+            default_for_string=True,
+            default=False,
+        ),
+    )
     # Prepare your context dictionary
     context = {
         "install_prefix": config.install_prefix,

--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""RPM package creation functions for ROCm packaging."""
+
+import os
+import re
+import subprocess
+import sys
+from dataclasses import replace
+from jinja2 import Environment, FileSystemLoader
+from pathlib import Path
+
+from packaging_utils import *
+
+# Setup paths
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def create_nonversioned_rpm_package(pkg_name, config: PackageConfig):
+    """Create a non-versioned RPM meta package (.rpm).
+
+    Builds a minimal RPM binary package whose payload is empty and whose primary
+    purpose is to express dependencies. The package name does not embed a version
+
+    Parameters:
+    pkg_name : Name of the package to be created
+    config: Configuration object containing package metadata
+
+    Returns:
+    output_list: List of packages created
+    """
+    print_function_name()
+    # Create immutable config copy with versioned_pkg=False
+    build_config = replace(config, versioned_pkg=False)
+
+    # Use updated package name for build directory to avoid collisions between variants
+    updated_pkg_name = update_package_name(pkg_name, build_config)
+    package_dir = Path(build_config.dest_dir) / build_config.pkg_type / updated_pkg_name
+    specfile = package_dir / "specfile"
+    generate_spec_file(pkg_name, specfile, build_config)
+    package_with_rpmbuild(specfile)
+
+    # Move packages to destination
+    output_list = move_packages_to_destination(updated_pkg_name, build_config)
+    return output_list
+
+
+def create_versioned_rpm_package(pkg_name, config: PackageConfig):
+    """Create a versioned RPM package (.rpm).
+
+    This function automates the process of building a RPM package by:
+    1) Generating the spec file with appropriate fields (Package,
+       Version, Architecture, Maintainer, Description, and dependencies).
+    2) Invoking `rpmbuild` to assemble the final `.rpm` file.
+
+    Parameters:
+    pkg_name : Name of the package to be created
+    config: Configuration object containing package metadata
+
+    Returns:
+    output_list: List of packages created
+    """
+    print_function_name()
+    # Explicitly ensure versioned_pkg=True
+    build_config = replace(config, versioned_pkg=True)
+
+    # Use updated package name for build directory to avoid collisions between variants
+    # Each variant (host, device, meta) gets its own build directory
+    updated_pkg_name = update_package_name(pkg_name, build_config)
+    package_dir = Path(build_config.dest_dir) / build_config.pkg_type / updated_pkg_name
+    specfile = package_dir / "specfile"
+    generate_spec_file(pkg_name, specfile, build_config)
+    package_with_rpmbuild(specfile)
+
+    # Move packages to destination
+    output_list = move_packages_to_destination(updated_pkg_name, build_config)
+    return output_list
+
+
+def generate_spec_file(pkg_name, specfile, config: PackageConfig):
+    """Generate an RPM spec file.
+
+    Parameters:
+    pkg_name : Package name
+    specfile: Path where the generated spec file should be saved
+    config: Configuration object containing package metadata
+
+    Returns: None
+    """
+    print_function_name()
+    os.makedirs(os.path.dirname(specfile), exist_ok=True)
+
+    pkg_info = get_package_info(pkg_name)  # Raises ValueError if not found
+    version = f"{config.rocm_version}"
+    is_meta = is_meta_package(pkg_info)
+
+    # Initialize optional fields
+    provides = obsoletes = conflicts = ""
+    rpmrecommends = rpmsuggests = ""
+    sourcedir_list = []
+    rpm_scripts = []
+    # amdrocm-debugger: Exclude libpython requirements
+    # Multiple Python-version-specific binaries are included; the wrapper script
+    # automatically selects the binary matching the system's Python version
+    exclude_libpython_requires = pkg_name == "amdrocm-debugger"
+
+    if config.versioned_pkg:
+        # Get -> Filter -> Transform
+        rpmrecommends = process_secondary_dependencies(
+            pkg_info, "RPMRecommends", config
+        )
+        rpmsuggests = process_secondary_dependencies(pkg_info, "RPMSuggests", config)
+        requires = process_main_dependencies(pkg_info, "RPMRequires", config)
+
+        dir_list = filter_components_fromartifactory(
+            pkg_name, config.artifacts_dir, config.gfx_arch, config.enable_kpack
+        )
+        sourcedir_list.extend(dir_list)
+
+        # Filter out non-existing directories
+        sourcedir_list = [path for path in sourcedir_list if os.path.isdir(path)]
+
+        # GFX_META is a versioned meta package (empty content, just dependencies)
+        is_gfx_meta = config.enable_kpack and config.gfx_arch == GFX_META
+
+        # Warn if we have no artifacts for non-meta packages
+        if not sourcedir_list and not is_meta and not is_gfx_meta:
+            if config.enable_kpack:
+                print(
+                    f"WARNING: {pkg_name}: Empty sourcedir_list and not a meta package, creating empty RPM"
+                )
+            else:
+                sys.exit(
+                    f"{pkg_name}: Empty sourcedir_list and not a meta package, exiting"
+                )
+
+        if is_postinstallscripts_available(pkg_info):
+            rpm_scripts = generate_rpm_postscripts(pkg_info, config)
+
+        if config.enable_rpath:
+            for path in sourcedir_list:
+                convert_runpath_to_rpath(path)
+    else:
+        # Get -> Transform -> Join (no transform needed for RPM)
+        provides = process_name_field(pkg_info, "Provides")
+        obsoletes = process_name_field(pkg_info, "Obsoletes")
+        conflicts = process_name_field(pkg_info, "Conflicts")
+        # Non-versioned package requires versioned package itself
+        requires = resolve_versioned_dependencies([pkg_name], config, is_meta)
+
+    pkg_name = update_package_name(pkg_name, config)
+
+    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
+    template = env.get_template("template/rpm_specfile.j2")
+    context = {
+        "pkg_name": pkg_name,
+        "version": version,
+        "release": config.version_suffix,
+        "build_arch": pkg_info.get("BuildArch"),
+        "description_short": pkg_info.get("Description_Short"),
+        "description_long": pkg_info.get("Description_Long"),
+        "group": pkg_info.get("Group"),
+        "pkg_license": pkg_info.get("License"),
+        "vendor": pkg_info.get("Vendor"),
+        "install_prefix": config.install_prefix,
+        "requires": requires,
+        "provides": provides,
+        "obsoletes": obsoletes,
+        "conflicts": conflicts,
+        "rpmrecommends": rpmrecommends,
+        "rpmsuggests": rpmsuggests,
+        "disable_rpm_strip": is_rpm_stripping_disabled(pkg_info),
+        "disable_debug_package": is_debug_package_disabled(pkg_info),
+        "sourcedir_list": sourcedir_list,
+        "rpm_scripts": rpm_scripts,
+        "exclude_libpython_requires": exclude_libpython_requires,
+    }
+
+    with open(specfile, "w", encoding="utf-8") as f:
+        f.write(template.render(context))
+
+
+def generate_rpm_postscripts(pkg_info, config: PackageConfig):
+    """Generate RPM postinst/prerm sections.
+
+    Parameters:
+    pkg_info: Package details parsed from a JSON file
+    config: Configuration object containing package metadata
+
+    Returns: rpm script sections for specfile
+    """
+    # RPM maintainer scripts
+    EXEC_SCRIPTS = {
+        "preinst": "%pre",
+        "postinst": "%post",
+        "prerm": "%preun",
+        "postrm": "%postun",
+    }
+    pkg_name = pkg_info.get("Package")
+    parts = config.rocm_version.split(".")
+    env = Environment(loader=FileSystemLoader(str(SCRIPT_DIR)))
+    # Prepare your context dictionary
+    context = {
+        "install_prefix": config.install_prefix,
+        "version_major": int(re.match(r"^\d+", parts[0]).group()),
+        "version_minor": int(re.match(r"^\d+", parts[1]).group()),
+        "version_patch": int(re.match(r"^\d+", parts[2]).group()),
+        "target": "rpm",
+    }
+
+    templates_root = Path(SCRIPT_DIR) / "template" / "scripts"
+    # Collect all matching files
+    # This will hold rendered RPM script sections
+    rpm_script_sections = {}
+
+    for script, rpm_section in EXEC_SCRIPTS.items():
+        pattern = f"{pkg_name}-{script}.j2"
+
+        for file in templates_root.glob(pattern):
+            template = env.get_template(str(file.relative_to(SCRIPT_DIR)))
+            rendered = template.render(context)
+
+            # Store rendered script under its RPM section name
+            rpm_script_sections[rpm_section] = rendered
+
+    return rpm_script_sections
+
+
+def package_with_rpmbuild(spec_file):
+    """Generate a RPM package using `rpmbuild`
+
+    Parameters:
+    spec_file: Path to the RPM spec file
+
+    Returns: None
+    """
+    print_function_name()
+    # Build the command
+    cmd = [
+        "rpmbuild",
+        "-bb",
+        spec_file,
+        "--define",
+        f"_topdir {spec_file.parent}",
+    ]
+
+    # Execute the command
+    try:
+        subprocess.run(cmd, check=True)
+        print(f"RPM Package built successfully: {spec_file.name}")
+    except subprocess.CalledProcessError as e:
+        print(f"Error building RPM package: {spec_file.name}: {e}")
+        sys.exit(e.returncode)


### PR DESCRIPTION


 Restructured packaging code to properly support host-device split packaging
   for multi-arch (kpack) builds. Extracted DEB and RPM logic into separate
   modules for better maintainability.

   Key improvements:
   - Implemented host-device package variant builder for gfxarch packages
     * Host packages contain generic/architecture-independent artifacts
     * Device packages contain architecture-specific artifacts per target * Meta packages depend on host + all device packages * Non-versioned packages provide user-facing entry point
   - Split DEB creation logic into deb_package.py (440 lines)
   - Split RPM creation logic into rpm_package.py (256 lines)
   - Refactored build_package.py to orchestrate package variants (929 lines reduced)
   - Enhanced packaging_utils.py with improved variant handling
   - Introduced build_package_variants() as unified entry point
   - Each package variant uses isolated build directory to prevent collisions

   This refactoring enables proper multi-arch packaging with clean separation
   between host and device components, improving package management for
   heterogeneous GPU environments.

**Test Results:**
[host-device-test.txt](https://github.com/user-attachments/files/28775900/host-device-test.txt)
[single-arch-test.txt](https://github.com/user-attachments/files/28783140/single-arch-test.txt)