### PR TITLE
Adding the new mi350p model to libdrm

### DIFF
--- a/third-party/sysdeps/linux/libdrm/patch_source.sh
+++ b/third-party/sysdeps/linux/libdrm/patch_source.sh
@@ -31,4 +31,5 @@ cat >> "$AMDGPU_IDS" << 'EOF'
 75A3,	00,	AMD Instinct MI355X
 75B0,	00,	AMD Instinct MI350X VF
 75B3,	00,	AMD Instinct MI355X VF
+75A8,	00,	AMD Instinct MI350P
 EOF


### PR DESCRIPTION
## Motivation

MI350p is the model AMD announced today. This is needed to be supported in 7.13 release. 
Adding the model name in libdrm gpu ids file.

## Test Plan

Test the ci build