### PR TITLE
[rocprofiler-compute] Fix RPATH for rocprofiler-compute test binary in non-default install location

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -233,6 +233,8 @@ if(THEROCK_ENABLE_ROCPROFILER_COMPUTE)
       therock_explicit_finders.cmake
     COMPILER_TOOLCHAIN
       amd-hip
+    INSTALL_RPATH_DIRS
+      "lib/rocprofiler-compute"
     RUNTIME_DEPS
       rocprofiler-sdk
       aqlprofile

--- a/profiler/post_hook_rocprofiler-compute.cmake
+++ b/profiler/post_hook_rocprofiler-compute.cmake
@@ -1,0 +1,11 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# test-rocprofiler-compute-tool installs to libexec/rocprofiler-compute/tests/
+# instead of the default bin/. Tell TheRock the actual origin so it can compute
+# correct relative RPATH entries.
+if(TARGET test-rocprofiler-compute-tool)
+  set_target_properties(test-rocprofiler-compute-tool PROPERTIES
+    THEROCK_INSTALL_RPATH_ORIGIN libexec/rocprofiler-compute/tests
+  )
+endif()


### PR DESCRIPTION
## Motivation

The C++ unit test binary `test-rocprofiler-compute-tool` (registered with CTest via `TEST_FROM_INSTALL=ON`) fails on TheRock builds with:

```
test-rocprofiler-compute-tool: error while loading shared libraries:
librocprofiler-compute-tool.so: cannot open shared object file
```

The library is installed to `lib/rocprofiler-compute/` and the binary to `libexec/rocprofiler-compute/tests/`. The per-target `INSTALL_RPATH` set upstream resolves correctly in standalone CMake builds, but TheRock's global post-subproject hook overwrites it with paths computed relative to the default executable origin (`bin/`), producing an RPATH that does not reach `lib/rocprofiler-compute/`.

This unblocks the upstream rocprofiler-compute PR https://github.com/ROCm/rocm-systems/pull/5721, which adds CTest registration of the native tool test and surfaces the failure on TheRock CI.

## Technical Details

Two changes:

1. `profiler/CMakeLists.txt`: add `INSTALL_RPATH_DIRS "lib/rocprofiler-compute"` to the rocprofiler-compute subproject declaration so the project's own lib subdir is part of the RPATH set TheRock plumbs into every binary in the subproject.

2. `profiler/post_hook_rocprofiler-compute.cmake` (new): annotate `test-rocprofiler-compute-tool` with `THEROCK_INSTALL_RPATH_ORIGIN libexec/rocprofiler-compute/tests` so TheRock computes RPATH relative to the actual install location. Auto-discovered via the `post_hook_<name>.cmake` naming convention. Mirrors the pattern in the adjacent `profiler/post_hook_rocprofiler-sdk.cmake`. Guarded with `if(TARGET ...)` so it is a no-op when `THEROCK_BUILD_TESTING=OFF`.

No upstream changes required. The existing `INSTALL_RPATH` in the rocprofiler-compute project continues to handle standalone builds.

## Test Plan

* TheRock build with `THEROCK_BUILD_TESTING=ON`: confirm `readelf -d` on the installed `test-rocprofiler-compute-tool` shows RUNPATH containing a relative path that resolves to `lib/rocprofiler-compute/` from `libexec/rocprofiler-compute/tests/`.
* CTest runs `test-rocprofiler-compute-tool` end-to-end without setting `LD_LIBRARY_PATH`.
* TheRock build with `THEROCK_BUILD_TESTING=OFF`: build still configures cleanly (post-hook guard prevents touching the missing target).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.