### PR TITLE
Adding msgpack and zstandard to requirements-test.txt

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-boto3==1.39.15
+botocore==1.42.84
 pytest==9.0.3 # This versions has subtests built-in.
 pytest-check==2.5.3
 pytest-cov==6.0.0
@@ -12,6 +12,8 @@ requests==2.33.0
 jsonschema==4.23.0
 packaging==25.0
 python-magic==0.4.27; sys_platform != "win32"
+msgpack==1.1.2
+zstandard==0.25.0
 
 # libhipcxx test requirement
 lit==18.1.8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-botocore==1.42.84
+boto3==1.39.15
 pytest==9.0.3 # This versions has subtests built-in.
 pytest-check==2.5.3
 pytest-cov==6.0.0


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Adding missing pip modules.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
The `cmake --build /therock/output/build` step fails because modules `msgpack` and `zstandard` are not installed.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Go through the steps of building TheRock.
- Before executing `cmake --build /therock/output/build`, run `pip install -r /therock/src/requirements-test.txt`.
- `cmake --build /therock/output/build` must succeed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
