### PR TITLE
[rocWMMA CI] Per-test CTest timeout + job budget (revert parallel=1)

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -454,7 +454,8 @@ test_matrix = {
     "rocwmma": {
         "job_name": "rocwmma",
         "fetch_artifact_args": "--rocwmma --tests --blas",
-        "timeout_minutes": 60,
+        # Headroom above typical shard runtime; per-test CTest timeouts fail fast on hangs (ROCM-24171).
+        "timeout_minutes": 90,
         "test_script": f"python {_get_script_path('test_rocwmma.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {

--- a/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
@@ -37,15 +37,21 @@ test_type = os.getenv("TEST_TYPE", "full")
 TESTS_TO_IGNORE = ["unpack_util_test", "contamination_test", "map_util_test"]
 
 test_subdir = ""
-timeout = "3600"
+# CTest --timeout is per-test (seconds), not wall-clock for the whole shard.
+# A value near the GitHub step limit lets one hung test burn the entire job (ROCM-24171).
+# rocWMMA unit/gemm binaries should finish well under this on healthy runners; a stuck
+# test then fails with a clear CTest timeout instead of an opaque 60m workflow cancel.
+_PER_TEST_TIMEOUT_FULL_SEC = 1800
+_PER_TEST_TIMEOUT_QUICK_SEC = 720
+timeout = str(_PER_TEST_TIMEOUT_FULL_SEC)
 if test_type == "quick":
     # The emulator regression tests are very fast.
     # If we need something even faster we can use "/smoke" here.
     test_subdir = "/regression"
-    timeout = "720"
+    timeout = str(_PER_TEST_TIMEOUT_QUICK_SEC)
 elif test_type == "regression":
     test_subdir = "/regression"
-    timeout = "720"
+    timeout = str(_PER_TEST_TIMEOUT_QUICK_SEC)
 
 # ROCM-24171: Default CTest --parallel was 2; intermittent lockups / 60m timeouts on
 # gfx942 TheRock CI suggested avoiding concurrent GPU tests — use 1 until root cause is found.

--- a/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
@@ -8,6 +8,8 @@ import subprocess
 from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
+AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
+platform = os.getenv("RUNNER_OS").lower()
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
@@ -53,9 +55,10 @@ elif test_type == "regression":
     test_subdir = "/regression"
     timeout = str(_PER_TEST_TIMEOUT_QUICK_SEC)
 
-# ROCM-24171: Default CTest --parallel was 2; intermittent lockups / 60m timeouts on
-# gfx942 TheRock CI suggested avoiding concurrent GPU tests — use 1 until root cause is found.
-ctest_parallelism = "1"
+# Make per-device adjustments
+ctest_parallelism = "2"
+if AMDGPU_FAMILIES == "gfx1153":
+    ctest_parallelism = "1"
 
 cmd = [
     "ctest",

--- a/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
-platform = os.getenv("RUNNER_OS").lower()
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
@@ -42,7 +41,8 @@ test_subdir = ""
 # CTest --timeout is per-test (seconds), not wall-clock for the whole shard.
 # A value near the GitHub step limit lets one hung test burn the entire job (ROCM-24171).
 # rocWMMA unit/gemm binaries should finish well under this on healthy runners; a stuck
-# test then fails with a clear CTest timeout instead of an opaque 60m workflow cancel.
+# test then fails with a clear CTest timeout instead of an opaque workflow cancel at the
+# GitHub Actions step limit.
 _PER_TEST_TIMEOUT_FULL_SEC = 1800
 _PER_TEST_TIMEOUT_QUICK_SEC = 720
 timeout = str(_PER_TEST_TIMEOUT_FULL_SEC)


### PR DESCRIPTION
## Summary

Follow-up for the intermittent **TheRock / rocWMMA** Linux gfx94X CI issue tracked as **[ROCM-24171](https://amd-hub.atlassian.net/browse/ROCM-24171)**.

This PR is the **next step in that investigation**: we tighten **CTest per-test timeouts** and align the **GitHub Test step** budget so a single hung or pathological test is less likely to burn an entire opaque **60-minute** window. We are **not** claiming a full root-cause fix (see Jira — e.g. `parallel = 1` did not resolve the stalls).

## Changes

- `test_rocwmma.py`: document that `ctest --timeout` is **per-test**; cap full-suite per-test timeout to **1800s** (was **3600s**, effectively on par with the old **60m** step limit).
- `fetch_test_configurations.py`: raise rocWMMA `timeout_minutes` from **60** to **90** so healthy shards have headroom while hung tests fail earlier via CTest.

## Revert for controlled variables

- **Revert** [`96b977c`](https://github.com/ROCm/TheRock/commit/96b977c97007842536a8105a430bda8e5d39905d) (PR **#5063** — default CTest `--parallel` to **1** for rocWMMA) so this PR isolates **timeout / job budget** behavior from the parallel-1 experiment (per discussion on ROCM-24171).

## Testing

- [ ] CI / reviewer confirmation that rocWMMA shards still complete within budgets and no legitimate test exceeds the new per-test cap.

---

**Jira:** [ROCM-24171](https://amd-hub.atlassian.net/browse/ROCM-24171)

Made with [Cursor](https://cursor.com)

[ROCM-24171]: https://amd-hub.atlassian.net/browse/ROCM-24171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROCM-24171]: https://amd-hub.atlassian.net/browse/ROCM-24171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ