### PR TITLE
[RFC0010] Add shared ROCm test runner utilities

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -48,6 +48,12 @@ jobs:
         python -m pytest -vv \
           --cov --cov-report=term-missing --cov-report=html
 
+    - name: Test test_tools
+      working-directory: test_tools
+      run: |
+        python -m pytest -vv \
+          --cov --cov-report=term-missing --cov-report=html
+
     # TODO: upload to AWS S3 instead (so reports are hosted and don't require
     #       a download step to view).
     #       We could also use https://about.codecov.io/ instead of custom infra.

--- a/build_tools/github_actions/tests/unit_test_runner.py
+++ b/build_tools/github_actions/tests/unit_test_runner.py
@@ -130,7 +130,7 @@ class BuildCtestCommandTest(unittest.TestCase):
         cmd = self._build("quick", "", set(), exclude_labels)
         le_indices = [i for i, v in enumerate(cmd) if v == "-LE"]
         le_values = [cmd[i + 1] for i in le_indices]
-        self.assertIn("quick_exclude", le_values)
+        self.assertIn("quick_exclude|ex_gpu", le_values)
 
     def test_category_exclude_label_not_applied_when_absent(self):
         exclude_labels = {"standard_exclude"}

--- a/build_tools/github_actions/tests/unit_test_runner.py
+++ b/build_tools/github_actions/tests/unit_test_runner.py
@@ -130,7 +130,7 @@ class BuildCtestCommandTest(unittest.TestCase):
         cmd = self._build("quick", "", set(), exclude_labels)
         le_indices = [i for i, v in enumerate(cmd) if v == "-LE"]
         le_values = [cmd[i + 1] for i in le_indices]
-        self.assertIn("quick_exclude|ex_gpu", le_values)
+        self.assertIn("quick_exclude", le_values)
 
     def test_category_exclude_label_not_applied_when_absent(self):
         exclude_labels = {"standard_exclude"}

--- a/test_tools/pyproject.toml
+++ b/test_tools/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
+]
+python_files = ["*_test.py"]
+addopts = "-ra"
+
+[tool.coverage.run]
+data_file = "../build/.coverage-test-tools"
+source = ["."]
+omit = [
+    "tests/*",
+    "*/__pycache__/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+precision = 2
+sort = "Cover"
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+]
+
+[tool.coverage.html]
+directory = "../build/coverage-html/test_tools"

--- a/test_tools/test_utils.py
+++ b/test_tools/test_utils.py
@@ -19,9 +19,7 @@ from typing import Iterable, Mapping
 VALID_TEST_CATEGORIES = {"quick", "standard", "comprehensive", "full"}
 
 _GPU_ARCH_PATTERN = re.compile(r"gfx[0-9a-zA-Z]+", re.IGNORECASE)
-_ROCMINFO_NAME_PATTERN = re.compile(
-    r"^\s*Name:\s+(gfx[0-9a-z]+)\s*$", re.IGNORECASE
-)
+_ROCMINFO_NAME_PATTERN = re.compile(r"^\s*Name:\s+(gfx[0-9a-z]+)\s*$", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -124,9 +122,7 @@ def build_ctest_label_args(
     if normalized_gpu_arch in ("", "generic", "none"):
         le_patterns.append("ex_gpu")
     else:
-        matching_arch = find_matching_gpu_arch(
-            normalized_gpu_arch, available_gpu_archs
-        )
+        matching_arch = find_matching_gpu_arch(normalized_gpu_arch, available_gpu_archs)
         if matching_arch:
             args.extend(["-L", f"ex_gpu_{matching_arch}"])
         else:
@@ -154,9 +150,7 @@ def count_ctest_tests(test_dir: str | Path, runner=subprocess.run) -> int:
         check=True,
     )
     return sum(
-        1
-        for line in result.stdout.splitlines()
-        if re.search(r"Test\s+#\d+:", line)
+        1 for line in result.stdout.splitlines() if re.search(r"Test\s+#\d+:", line)
     )
 
 

--- a/test_tools/test_utils.py
+++ b/test_tools/test_utils.py
@@ -8,13 +8,14 @@ CI environment variables, run subprocesses, or exit the process. Runner scripts
 own their project-specific paths, environment setup, timeouts, and dispatch.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 import logging
+import os
 from pathlib import Path
 import re
+import shlex
 import subprocess
 from typing import Iterable, Mapping
-
 
 VALID_TEST_CATEGORIES = {"quick", "standard", "comprehensive", "full"}
 
@@ -67,6 +68,128 @@ def _positive_int(name: str, value: str | int) -> int:
     if parsed < 1:
         raise ValueError(f"{name} must be >= 1, got {parsed}")
     return parsed
+
+
+@dataclass(frozen=True)
+class TestRunSettings:
+    """Common test runner settings parsed once and passed through helpers."""
+
+    test_dir: str | Path
+    rocm_path: str | Path | None = None
+    category: str | None = "quick"
+    gpu_arch: str | None = ""
+    shard_index: str | int = 1
+    total_shards: str | int = 1
+    available_gpu_archs: frozenset[str] = field(default_factory=frozenset)
+    exclude_labels: frozenset[str] = field(default_factory=frozenset)
+    ctest_parallel: str | int | None = None
+    ctest_timeout_seconds: str | int | None = None
+    ctest_output_on_failure: bool = True
+    ctest_verbose: bool = True
+    extra_ctest_args: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self):
+        object.__setattr__(self, "test_dir", Path(self.test_dir))
+        if self.rocm_path is not None:
+            object.__setattr__(self, "rocm_path", Path(self.rocm_path))
+        object.__setattr__(self, "category", normalize_test_category(self.category))
+        object.__setattr__(self, "gpu_arch", (self.gpu_arch or "").strip().lower())
+        parsed_shard_index = _positive_int("shard_index", self.shard_index)
+        parsed_total_shards = _positive_int("total_shards", self.total_shards)
+        if parsed_shard_index > parsed_total_shards:
+            raise ValueError(
+                "shard_index must be less than or equal to total_shards, "
+                f"got {parsed_shard_index} > {parsed_total_shards}"
+            )
+        object.__setattr__(self, "shard_index", parsed_shard_index)
+        object.__setattr__(self, "total_shards", parsed_total_shards)
+
+        if self.ctest_parallel is not None:
+            object.__setattr__(
+                self,
+                "ctest_parallel",
+                _positive_int("ctest_parallel", self.ctest_parallel),
+            )
+        if self.ctest_timeout_seconds is not None:
+            object.__setattr__(
+                self,
+                "ctest_timeout_seconds",
+                _positive_int("ctest_timeout_seconds", self.ctest_timeout_seconds),
+            )
+
+        object.__setattr__(
+            self,
+            "available_gpu_archs",
+            frozenset(str(v) for v in self.available_gpu_archs),
+        )
+        object.__setattr__(
+            self,
+            "exclude_labels",
+            frozenset(str(v) for v in self.exclude_labels),
+        )
+        object.__setattr__(
+            self,
+            "extra_ctest_args",
+            tuple(str(v) for v in self.extra_ctest_args),
+        )
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        test_dir: str | Path,
+        rocm_path: str | Path | None = None,
+        env: Mapping[str, str] | None = None,
+        **kwargs,
+    ) -> "TestRunSettings":
+        """Create settings from common CI environment variables."""
+        env = os.environ if env is None else env
+        return cls(
+            test_dir=test_dir,
+            rocm_path=rocm_path,
+            category=env.get("TEST_TYPE", "quick"),
+            gpu_arch=extract_gpu_arch(env.get("AMDGPU_FAMILIES")),
+            shard_index=env.get("SHARD_INDEX", 1),
+            total_shards=env.get("TOTAL_SHARDS", 1),
+            **kwargs,
+        )
+
+    def with_ctest(
+        self,
+        *,
+        available_gpu_archs: Iterable[str] | None = None,
+        exclude_labels: Iterable[str] | None = None,
+        parallel: str | int | None = None,
+        timeout_seconds: str | int | None = None,
+        output_on_failure: bool | None = None,
+        verbose: bool | None = None,
+        extra_args: Iterable[str] | None = None,
+    ) -> "TestRunSettings":
+        """Return settings with CTest-specific values replaced."""
+        updates = {}
+        if available_gpu_archs is not None:
+            updates["available_gpu_archs"] = frozenset(available_gpu_archs)
+        if exclude_labels is not None:
+            updates["exclude_labels"] = frozenset(exclude_labels)
+        if parallel is not None:
+            updates["ctest_parallel"] = parallel
+        if timeout_seconds is not None:
+            updates["ctest_timeout_seconds"] = timeout_seconds
+        if output_on_failure is not None:
+            updates["ctest_output_on_failure"] = output_on_failure
+        if verbose is not None:
+            updates["ctest_verbose"] = verbose
+        if extra_args is not None:
+            updates["extra_ctest_args"] = tuple(extra_args)
+        return replace(self, **updates)
+
+    def with_ctest_labels(self, labels: CTestLabels) -> "TestRunSettings":
+        """Return settings with discovered CTest labels applied."""
+        return replace(
+            self,
+            available_gpu_archs=frozenset(labels.gpu_archs),
+            exclude_labels=frozenset(labels.exclude_labels),
+        )
 
 
 def gtest_shard_env(
@@ -184,6 +307,100 @@ def parse_ctest_labels(labels: Iterable[str]) -> CTestLabels:
             exclude_labels.add(label)
 
     return CTestLabels(gpu_archs=gpu_archs, exclude_labels=exclude_labels)
+
+
+def discover_ctest_labels(
+    test_dir: str | Path,
+    runner=subprocess.run,
+    *,
+    require_tests: bool = True,
+) -> CTestLabels:
+    """Run CTest discovery and return parsed GPU/category-exclude labels."""
+    if require_tests and count_ctest_tests(test_dir, runner=runner) == 0:
+        raise RuntimeError(f"No CTest tests found in {Path(test_dir)}")
+    return parse_ctest_labels(read_ctest_labels(test_dir, runner=runner))
+
+
+def build_ctest_command(settings: TestRunSettings) -> list[str]:
+    """Build a CTest command from generic test run settings."""
+    cmd = ["ctest"]
+    cmd.extend(
+        build_ctest_label_args(
+            settings.category,
+            settings.gpu_arch,
+            set(settings.available_gpu_archs),
+            set(settings.exclude_labels),
+        )
+    )
+
+    if settings.ctest_output_on_failure:
+        cmd.append("--output-on-failure")
+    if settings.ctest_parallel is not None:
+        cmd.extend(["--parallel", str(settings.ctest_parallel)])
+    if settings.ctest_timeout_seconds is not None:
+        cmd.extend(["--timeout", str(settings.ctest_timeout_seconds)])
+    cmd.extend(["--test-dir", str(settings.test_dir)])
+    if settings.ctest_verbose:
+        cmd.append("-V")
+    cmd.extend(ctest_shard_args(settings.shard_index, settings.total_shards))
+    cmd.extend(settings.extra_ctest_args)
+    return cmd
+
+
+def _prepend_env_paths(
+    env: dict[str, str],
+    paths_by_var: Mapping[str, Iterable[str | Path]] | None,
+) -> None:
+    if not paths_by_var:
+        return
+    for env_key, paths in paths_by_var.items():
+        new_paths = [str(path) for path in paths]
+        existing_path = env.get(env_key, "")
+        env[env_key] = os.pathsep.join(filter(None, new_paths + [existing_path]))
+
+
+def build_test_env(
+    settings: TestRunSettings,
+    *,
+    base_env: Mapping[str, str] | None = None,
+    path_prepend: Mapping[str, Iterable[str | Path]] | None = None,
+    extra_env: Mapping[str, str | Path] | None = None,
+) -> dict[str, str]:
+    """Build a test environment with common ROCm and GTest settings."""
+    env = dict(base_env or {})
+    if settings.rocm_path is not None:
+        env["ROCM_PATH"] = str(settings.rocm_path)
+    env.update(gtest_shard_env(settings.shard_index, settings.total_shards))
+    _prepend_env_paths(env, path_prepend)
+    if extra_env:
+        env.update({key: str(value) for key, value in extra_env.items()})
+    return env
+
+
+def run_ctest(
+    settings: TestRunSettings,
+    *,
+    cwd: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+    runner=subprocess.run,
+    check: bool = False,
+    discover_labels: bool = False,
+    require_tests: bool = True,
+):
+    """Run CTest with settings-owned common mechanics and caller-owned env/cwd."""
+    if discover_labels:
+        settings = settings.with_ctest_labels(
+            discover_ctest_labels(
+                settings.test_dir,
+                runner=runner,
+                require_tests=require_tests,
+            )
+        )
+    cmd = build_ctest_command(settings)
+    if cwd is None:
+        cwd = settings.rocm_path
+    logging.info("++ Exec [%s]$ %s", cwd or Path.cwd(), shlex.join(cmd))
+    return runner(cmd, cwd=cwd, env=env, check=check)
 
 
 def _rocminfo_command(rocm_bin_dir: str | Path | None = None) -> str:

--- a/test_tools/test_utils.py
+++ b/test_tools/test_utils.py
@@ -1,0 +1,254 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Shared helpers for ROCm test runner scripts.
+
+This module is intentionally import-safe: importing it does not read required
+CI environment variables, run subprocesses, or exit the process. Runner scripts
+own their project-specific paths, environment setup, timeouts, and dispatch.
+"""
+
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+import re
+import subprocess
+from typing import Iterable, Mapping
+
+
+VALID_TEST_CATEGORIES = {"quick", "standard", "comprehensive", "full"}
+
+_GPU_ARCH_PATTERN = re.compile(r"gfx[0-9a-zA-Z]+", re.IGNORECASE)
+_ROCMINFO_NAME_PATTERN = re.compile(
+    r"^\s*Name:\s+(gfx[0-9a-z]+)\s*$", re.IGNORECASE
+)
+
+
+@dataclass(frozen=True)
+class CTestLabels:
+    gpu_archs: set[str]
+    exclude_labels: set[str]
+
+
+def normalize_test_category(test_type: str | None) -> str:
+    """Return a valid test category, defaulting invalid or empty values to quick."""
+    if not test_type:
+        return "quick"
+    category = test_type.strip().lower()
+    if category in VALID_TEST_CATEGORIES:
+        return category
+    return "quick"
+
+
+def extract_gpu_arch(amdgpu_families: str | None) -> str:
+    """Extract the first gfx architecture token from AMDGPU_FAMILIES-style text."""
+    if not amdgpu_families:
+        return ""
+    match = _GPU_ARCH_PATTERN.search(amdgpu_families)
+    return match.group(0).lower() if match else ""
+
+
+def find_matching_gpu_arch(gpu_arch: str, available_gpu_archs: set[str]) -> str | None:
+    """Find the most specific available GPU architecture label for gpu_arch."""
+    if gpu_arch in available_gpu_archs:
+        return gpu_arch
+
+    for i in range(len(gpu_arch) - 1, 4, -1):
+        pattern = gpu_arch[:i] + "X"
+        if pattern in available_gpu_archs:
+            return pattern
+
+    return None
+
+
+def _positive_int(name: str, value: str | int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as e:
+        raise ValueError(f"{name} must be an integer, got {value!r}") from e
+    if parsed < 1:
+        raise ValueError(f"{name} must be >= 1, got {parsed}")
+    return parsed
+
+
+def gtest_shard_env(
+    shard_index: str | int = 1, total_shards: str | int = 1
+) -> dict[str, str]:
+    """Translate 1-based CI shard values into GTest sharding environment vars."""
+    parsed_shard_index = _positive_int("shard_index", shard_index)
+    parsed_total_shards = _positive_int("total_shards", total_shards)
+    if parsed_shard_index > parsed_total_shards:
+        raise ValueError(
+            "shard_index must be less than or equal to total_shards, "
+            f"got {parsed_shard_index} > {parsed_total_shards}"
+        )
+    return {
+        "GTEST_SHARD_INDEX": str(parsed_shard_index - 1),
+        "GTEST_TOTAL_SHARDS": str(parsed_total_shards),
+    }
+
+
+def ctest_shard_args(
+    shard_index: str | int = 1, total_shards: str | int = 1
+) -> list[str]:
+    """Return CTest --tests-information args for 1-based CI shard values."""
+    parsed_shard_index = _positive_int("shard_index", shard_index)
+    parsed_total_shards = _positive_int("total_shards", total_shards)
+    if parsed_shard_index > parsed_total_shards:
+        raise ValueError(
+            "shard_index must be less than or equal to total_shards, "
+            f"got {parsed_shard_index} > {parsed_total_shards}"
+        )
+    return [
+        "--tests-information",
+        f"{parsed_shard_index},,{parsed_total_shards}",
+    ]
+
+
+def build_ctest_label_args(
+    category: str | None,
+    gpu_arch: str | None,
+    available_gpu_archs: set[str],
+    exclude_labels: set[str],
+) -> list[str]:
+    """Build CTest label include/exclude arguments for category and GPU labels."""
+    normalized_category = normalize_test_category(category)
+    normalized_gpu_arch = (gpu_arch or "").strip().lower()
+    args: list[str] = ["-L", normalized_category]
+    le_patterns: list[str] = []
+
+    category_exclude_label = f"{normalized_category}_exclude"
+    if category_exclude_label in exclude_labels:
+        le_patterns.append(category_exclude_label)
+
+    if normalized_gpu_arch in ("", "generic", "none"):
+        le_patterns.append("ex_gpu")
+    else:
+        matching_arch = find_matching_gpu_arch(
+            normalized_gpu_arch, available_gpu_archs
+        )
+        if matching_arch:
+            args.extend(["-L", f"ex_gpu_{matching_arch}"])
+        else:
+            le_patterns.append("ex_gpu")
+
+    if le_patterns:
+        args.extend(["-LE", "|".join(le_patterns)])
+
+    return args
+
+
+def _validate_test_dir(test_dir: Path) -> None:
+    if not test_dir.exists() or not test_dir.is_dir():
+        raise FileNotFoundError(f"CTest test directory does not exist: {test_dir}")
+
+
+def count_ctest_tests(test_dir: str | Path, runner=subprocess.run) -> int:
+    """Return the number of tests reported by ctest -N for test_dir."""
+    test_dir = Path(test_dir)
+    _validate_test_dir(test_dir)
+    result = runner(
+        ["ctest", "-N", "--test-dir", str(test_dir)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return sum(
+        1
+        for line in result.stdout.splitlines()
+        if re.search(r"Test\s+#\d+:", line)
+    )
+
+
+def read_ctest_labels(test_dir: str | Path, runner=subprocess.run) -> set[str]:
+    """Return labels printed by ctest --print-labels for test_dir."""
+    test_dir = Path(test_dir)
+    _validate_test_dir(test_dir)
+    result = runner(
+        ["ctest", "--print-labels", "--test-dir", str(test_dir)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def parse_ctest_labels(labels: Iterable[str]) -> CTestLabels:
+    """Parse CTest labels into GPU architecture and category-exclude sets."""
+    gpu_archs: set[str] = set()
+    exclude_labels: set[str] = set()
+    gpu_prefix = "ex_gpu_"
+    exclude_suffix = "_exclude"
+
+    for raw_label in labels:
+        label = raw_label.strip()
+        if label.startswith(gpu_prefix):
+            gpu_arch = label[len(gpu_prefix) :]
+            if gpu_arch.startswith("gfx"):
+                gpu_archs.add(gpu_arch)
+        elif label.endswith(exclude_suffix):
+            exclude_labels.add(label)
+
+    return CTestLabels(gpu_archs=gpu_archs, exclude_labels=exclude_labels)
+
+
+def _rocminfo_command(rocm_bin_dir: str | Path | None = None) -> str:
+    if rocm_bin_dir is not None:
+        rocminfo = Path(rocm_bin_dir) / "rocminfo"
+        if rocminfo.exists():
+            return str(rocminfo)
+    return "rocminfo"
+
+
+def parse_rocminfo_gpu_archs(output: str) -> list[str]:
+    """Return visible GPU architecture names from rocminfo output."""
+    gpu_archs: list[str] = []
+    for line in output.splitlines():
+        match = _ROCMINFO_NAME_PATTERN.match(line)
+        if match:
+            gpu_archs.append(match.group(1).lower())
+    return gpu_archs
+
+
+def get_visible_gpu_count(
+    env: Mapping[str, str] | None = None,
+    rocm_bin_dir: str | Path | None = None,
+    runner=subprocess.run,
+) -> int:
+    """Return the number of visible GPU architecture records in rocminfo output."""
+    result = runner(
+        [_rocminfo_command(rocm_bin_dir)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        check=False,
+    )
+    return len(parse_rocminfo_gpu_archs(result.stdout or ""))
+
+
+def get_first_gpu_architecture(
+    env: Mapping[str, str] | None = None,
+    rocm_bin_dir: str | Path | None = None,
+    runner=subprocess.run,
+) -> str:
+    """Return the first visible GPU architecture, such as gfx942."""
+    result = runner(
+        [_rocminfo_command(rocm_bin_dir)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        check=True,
+    )
+    gpu_archs = parse_rocminfo_gpu_archs(result.stdout or "")
+    if gpu_archs:
+        gpu_arch = gpu_archs[0]
+        logging.info("Detected GPU architecture: %s", gpu_arch)
+        return gpu_arch
+    raise RuntimeError("No GPU architecture found in rocminfo output")
+
+
+def is_asan_artifact_group(artifact_group: str | None) -> bool:
+    """Return whether an artifact group name describes an ASAN build."""
+    return "asan" in (artifact_group or "").lower()

--- a/test_tools/test_utils.py
+++ b/test_tools/test_utils.py
@@ -431,10 +431,10 @@ def get_visible_gpu_architectures(
         env=env,
         check=check,
     )
-    return parse_rocminfo_gpu_archs(result.stdout or "")
+    return _parse_rocminfo_gpu_archs(result.stdout or "")
 
 
-def parse_rocminfo_gpu_archs(output: str) -> list[str]:
+def _parse_rocminfo_gpu_archs(output: str) -> list[str]:
     """Return visible GPU architecture names from rocminfo output."""
     gpu_archs: list[str] = []
     for line in output.splitlines():

--- a/test_tools/test_utils.py
+++ b/test_tools/test_utils.py
@@ -238,6 +238,10 @@ def build_ctest_label_args(
     args: list[str] = ["-L", normalized_category]
     le_patterns: list[str] = []
 
+    # Category exclude labels, such as quick_exclude, always exclude tests from
+    # the selected category. GPU labels are additive: include the matching
+    # ex_gpu_gfxXXX label when one exists, otherwise exclude all ex_gpu tests so
+    # tests for other GPU targets do not run accidentally.
     category_exclude_label = f"{normalized_category}_exclude"
     if category_exclude_label in exclude_labels:
         le_patterns.append(category_exclude_label)
@@ -411,6 +415,25 @@ def _rocminfo_command(rocm_bin_dir: str | Path | None = None) -> str:
     return "rocminfo"
 
 
+def get_visible_gpu_architectures(
+    env: Mapping[str, str] | None = None,
+    rocm_bin_dir: str | Path | None = None,
+    runner=subprocess.run,
+    *,
+    check: bool = False,
+) -> list[str]:
+    """Return visible GPU architecture records reported by rocminfo."""
+    result = runner(
+        [_rocminfo_command(rocm_bin_dir)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        check=check,
+    )
+    return parse_rocminfo_gpu_archs(result.stdout or "")
+
+
 def parse_rocminfo_gpu_archs(output: str) -> list[str]:
     """Return visible GPU architecture names from rocminfo output."""
     gpu_archs: list[str] = []
@@ -427,15 +450,14 @@ def get_visible_gpu_count(
     runner=subprocess.run,
 ) -> int:
     """Return the number of visible GPU architecture records in rocminfo output."""
-    result = runner(
-        [_rocminfo_command(rocm_bin_dir)],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        env=env,
-        check=False,
+    return len(
+        get_visible_gpu_architectures(
+            env=env,
+            rocm_bin_dir=rocm_bin_dir,
+            runner=runner,
+            check=False,
+        )
     )
-    return len(parse_rocminfo_gpu_archs(result.stdout or ""))
 
 
 def get_first_gpu_architecture(
@@ -444,15 +466,12 @@ def get_first_gpu_architecture(
     runner=subprocess.run,
 ) -> str:
     """Return the first visible GPU architecture, such as gfx942."""
-    result = runner(
-        [_rocminfo_command(rocm_bin_dir)],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
+    gpu_archs = get_visible_gpu_architectures(
         env=env,
+        rocm_bin_dir=rocm_bin_dir,
+        runner=runner,
         check=True,
     )
-    gpu_archs = parse_rocminfo_gpu_archs(result.stdout or "")
     if gpu_archs:
         gpu_arch = gpu_archs[0]
         logging.info("Detected GPU architecture: %s", gpu_arch)
@@ -463,3 +482,8 @@ def get_first_gpu_architecture(
 def is_asan_artifact_group(artifact_group: str | None) -> bool:
     """Return whether an artifact group name describes an ASAN build."""
     return "asan" in (artifact_group or "").lower()
+
+
+def is_tsan_artifact_group(artifact_group: str | None) -> bool:
+    """Return whether an artifact group name describes a TSAN build."""
+    return "tsan" in (artifact_group or "").lower()

--- a/test_tools/test_utils.py
+++ b/test_tools/test_utils.py
@@ -19,7 +19,7 @@ from typing import Iterable, Mapping
 
 VALID_TEST_CATEGORIES = {"quick", "standard", "comprehensive", "full"}
 
-_GPU_ARCH_PATTERN = re.compile(r"gfx[0-9a-zA-Z]+", re.IGNORECASE)
+_GPU_ARCH_PATTERN = re.compile(r"gfx[0-9a-zA-Z]+")
 _ROCMINFO_NAME_PATTERN = re.compile(r"^\s*Name:\s+(gfx[0-9a-z]+)\s*$", re.IGNORECASE)
 
 
@@ -44,7 +44,7 @@ def extract_gpu_arch(amdgpu_families: str | None) -> str:
     if not amdgpu_families:
         return ""
     match = _GPU_ARCH_PATTERN.search(amdgpu_families)
-    return match.group(0).lower() if match else ""
+    return match.group(0) if match else ""
 
 
 def find_matching_gpu_arch(gpu_arch: str, available_gpu_archs: set[str]) -> str | None:

--- a/test_tools/tests/test_utils_test.py
+++ b/test_tools/tests/test_utils_test.py
@@ -33,9 +33,7 @@ class GpuArchTest(unittest.TestCase):
         self.assertEqual(test_utils.extract_gpu_arch(None), "")
         self.assertEqual(test_utils.extract_gpu_arch(""), "")
         self.assertEqual(test_utils.extract_gpu_arch("gfx1151"), "gfx1151")
-        self.assertEqual(
-            test_utils.extract_gpu_arch("family=gfx942,gfx90a"), "gfx942"
-        )
+        self.assertEqual(test_utils.extract_gpu_arch("family=gfx942,gfx90a"), "gfx942")
         self.assertEqual(test_utils.extract_gpu_arch("GFX90A"), "gfx90a")
         self.assertEqual(test_utils.extract_gpu_arch("generic"), "")
 
@@ -116,9 +114,7 @@ class CTestLabelArgsTest(unittest.TestCase):
         self.assertEqual(args, ["-L", "quick", "-L", "ex_gpu_gfx115X"])
 
     def test_no_matching_gpu_excludes_gpu_specific_tests(self):
-        args = test_utils.build_ctest_label_args(
-            "quick", "gfx1151", {"gfx94X"}, set()
-        )
+        args = test_utils.build_ctest_label_args("quick", "gfx1151", {"gfx94X"}, set())
         self.assertEqual(args, ["-L", "quick", "-LE", "ex_gpu"])
 
     def test_category_exclude_is_combined_with_gpu_exclude(self):
@@ -128,9 +124,7 @@ class CTestLabelArgsTest(unittest.TestCase):
         self.assertEqual(args, ["-L", "quick", "-LE", "quick_exclude|ex_gpu"])
 
     def test_invalid_category_uses_quick_policy(self):
-        args = test_utils.build_ctest_label_args(
-            "smoke", "", set(), {"quick_exclude"}
-        )
+        args = test_utils.build_ctest_label_args("smoke", "", set(), {"quick_exclude"})
         self.assertEqual(args, ["-L", "quick", "-LE", "quick_exclude|ex_gpu"])
 
 
@@ -227,9 +221,7 @@ class RocminfoTest(unittest.TestCase):
                 return SimpleNamespace(stdout=self.ROCMINFO_OUTPUT)
 
             self.assertEqual(
-                test_utils.get_visible_gpu_count(
-                    rocm_bin_dir=temp_dir, runner=runner
-                ),
+                test_utils.get_visible_gpu_count(rocm_bin_dir=temp_dir, runner=runner),
                 3,
             )
             self.assertEqual(calls[0][0], [os.fspath(rocminfo_path)])
@@ -238,9 +230,7 @@ class RocminfoTest(unittest.TestCase):
         def runner(cmd, **kwargs):
             return SimpleNamespace(stdout=self.ROCMINFO_OUTPUT)
 
-        self.assertEqual(
-            test_utils.get_first_gpu_architecture(runner=runner), "gfx942"
-        )
+        self.assertEqual(test_utils.get_first_gpu_architecture(runner=runner), "gfx942")
 
     def test_get_first_gpu_architecture_raises_without_visible_gpu(self):
         def runner(cmd, **kwargs):

--- a/test_tools/tests/test_utils_test.py
+++ b/test_tools/tests/test_utils_test.py
@@ -94,6 +94,82 @@ class ShardingTest(unittest.TestCase):
             test_utils.ctest_shard_args("5", "4")
 
 
+class TestRunSettingsTest(unittest.TestCase):
+    def test_from_env_parses_common_ci_settings(self):
+        settings = test_utils.TestRunSettings.from_env(
+            test_dir="tests",
+            rocm_path="install",
+            env={
+                "TEST_TYPE": "STANDARD",
+                "AMDGPU_FAMILIES": "family=gfx942",
+                "SHARD_INDEX": "2",
+                "TOTAL_SHARDS": "4",
+            },
+        )
+
+        self.assertEqual(settings.test_dir, Path("tests"))
+        self.assertEqual(settings.rocm_path, Path("install"))
+        self.assertEqual(settings.category, "standard")
+        self.assertEqual(settings.gpu_arch, "gfx942")
+        self.assertEqual(settings.shard_index, 2)
+        self.assertEqual(settings.total_shards, 4)
+
+    def test_invalid_env_category_falls_back_to_quick(self):
+        settings = test_utils.TestRunSettings.from_env(
+            test_dir="tests",
+            env={
+                "TEST_TYPE": "smoke",
+                "SHARD_INDEX": "1",
+                "TOTAL_SHARDS": "1",
+            },
+        )
+        self.assertEqual(settings.category, "quick")
+
+    def test_invalid_shards_raise(self):
+        with self.assertRaises(ValueError):
+            test_utils.TestRunSettings(
+                test_dir="tests", shard_index="3", total_shards="2"
+            )
+
+    def test_with_ctest_returns_updated_settings(self):
+        settings = test_utils.TestRunSettings(
+            test_dir="tests",
+            category="quick",
+            gpu_arch="gfx1151",
+        )
+
+        updated = settings.with_ctest(
+            available_gpu_archs={"gfx115X"},
+            exclude_labels={"quick_exclude"},
+            parallel="8",
+            timeout_seconds="7200",
+            output_on_failure=False,
+            verbose=False,
+            extra_args=["--tests-regex", "smoke"],
+        )
+
+        self.assertEqual(settings.available_gpu_archs, frozenset())
+        self.assertEqual(updated.available_gpu_archs, frozenset({"gfx115X"}))
+        self.assertEqual(updated.exclude_labels, frozenset({"quick_exclude"}))
+        self.assertEqual(updated.ctest_parallel, 8)
+        self.assertEqual(updated.ctest_timeout_seconds, 7200)
+        self.assertFalse(updated.ctest_output_on_failure)
+        self.assertFalse(updated.ctest_verbose)
+        self.assertEqual(updated.extra_ctest_args, ("--tests-regex", "smoke"))
+
+    def test_with_ctest_labels_applies_discovered_label_sets(self):
+        settings = test_utils.TestRunSettings(test_dir="tests")
+        updated = settings.with_ctest_labels(
+            test_utils.CTestLabels(
+                gpu_archs={"gfx942"},
+                exclude_labels={"quick_exclude"},
+            )
+        )
+
+        self.assertEqual(updated.available_gpu_archs, frozenset({"gfx942"}))
+        self.assertEqual(updated.exclude_labels, frozenset({"quick_exclude"}))
+
+
 class CTestLabelArgsTest(unittest.TestCase):
     def test_category_label_is_included(self):
         self.assertEqual(
@@ -176,6 +252,163 @@ class CTestDiscoveryTest(unittest.TestCase):
         )
         self.assertEqual(labels.gpu_archs, {"gfx115X", "gfx942"})
         self.assertEqual(labels.exclude_labels, {"standard_exclude"})
+
+    def test_discover_ctest_labels_requires_tests_by_default(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+
+            def runner(cmd, **kwargs):
+                if "-N" in cmd:
+                    return SimpleNamespace(stdout="Test project\n")
+                return SimpleNamespace(stdout="quick\n")
+
+            with self.assertRaises(RuntimeError):
+                test_utils.discover_ctest_labels(temp_dir, runner)
+
+    def test_discover_ctest_labels_can_skip_test_count_check(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            calls = []
+
+            def runner(cmd, **kwargs):
+                calls.append(cmd)
+                return SimpleNamespace(stdout="quick\nex_gpu_gfx115X\n")
+
+            labels = test_utils.discover_ctest_labels(
+                temp_dir, runner, require_tests=False
+            )
+
+            self.assertEqual(labels.gpu_archs, {"gfx115X"})
+            self.assertEqual(labels.exclude_labels, set())
+            self.assertEqual(
+                calls,
+                [["ctest", "--print-labels", "--test-dir", os.fspath(temp_dir)]],
+            )
+
+
+class CTestRunSettingsHelpersTest(unittest.TestCase):
+    def test_build_ctest_command_from_settings(self):
+        settings = test_utils.TestRunSettings(
+            test_dir="tests",
+            category="standard",
+            gpu_arch="gfx1151",
+            shard_index=2,
+            total_shards=4,
+        ).with_ctest(
+            available_gpu_archs={"gfx115X"},
+            exclude_labels={"standard_exclude"},
+            parallel=8,
+            timeout_seconds=7200,
+            extra_args=["--tests-regex", "smoke"],
+        )
+
+        self.assertEqual(
+            test_utils.build_ctest_command(settings),
+            [
+                "ctest",
+                "-L",
+                "standard",
+                "-L",
+                "ex_gpu_gfx115X",
+                "-LE",
+                "standard_exclude",
+                "--output-on-failure",
+                "--parallel",
+                "8",
+                "--timeout",
+                "7200",
+                "--test-dir",
+                "tests",
+                "-V",
+                "--tests-information",
+                "2,,4",
+                "--tests-regex",
+                "smoke",
+            ],
+        )
+
+    def test_build_test_env_applies_common_and_project_settings(self):
+        settings = test_utils.TestRunSettings(
+            test_dir="tests",
+            rocm_path="install",
+            shard_index=2,
+            total_shards=4,
+        )
+
+        env = test_utils.build_test_env(
+            settings,
+            base_env={"PATH": "base-bin", "LD_LIBRARY_PATH": "base-lib"},
+            path_prepend={
+                "PATH": [Path("install") / "bin"],
+                "LD_LIBRARY_PATH": [Path("install") / "lib"],
+            },
+            extra_env={"HIP_VISIBLE_DEVICES": "0"},
+        )
+
+        self.assertEqual(env["ROCM_PATH"], "install")
+        self.assertEqual(env["GTEST_SHARD_INDEX"], "1")
+        self.assertEqual(env["GTEST_TOTAL_SHARDS"], "4")
+        self.assertEqual(
+            env["PATH"],
+            os.pathsep.join([os.fspath(Path("install") / "bin"), "base-bin"]),
+        )
+        self.assertEqual(
+            env["LD_LIBRARY_PATH"],
+            os.pathsep.join([os.fspath(Path("install") / "lib"), "base-lib"]),
+        )
+        self.assertEqual(env["HIP_VISIBLE_DEVICES"], "0")
+
+    def test_run_ctest_uses_settings_command_and_default_cwd(self):
+        calls = []
+
+        def runner(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return SimpleNamespace(returncode=0)
+
+        settings = test_utils.TestRunSettings(
+            test_dir="tests",
+            rocm_path="install",
+            category="quick",
+            shard_index=1,
+            total_shards=2,
+        )
+        env = {"ROCM_PATH": "install"}
+
+        result = test_utils.run_ctest(settings, env=env, runner=runner, check=True)
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(calls[0][0][0], "ctest")
+        self.assertEqual(calls[0][1]["cwd"], Path("install"))
+        self.assertEqual(calls[0][1]["env"], env)
+        self.assertTrue(calls[0][1]["check"])
+
+    def test_run_ctest_can_discover_labels_before_running(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            calls = []
+
+            def runner(cmd, **kwargs):
+                calls.append((cmd, kwargs))
+                if "-N" in cmd:
+                    return SimpleNamespace(stdout="  Test #1: alpha\n")
+                if "--print-labels" in cmd:
+                    return SimpleNamespace(stdout="quick_exclude\nex_gpu_gfx115X\n")
+                return SimpleNamespace(returncode=0)
+
+            settings = test_utils.TestRunSettings(
+                test_dir=temp_dir,
+                category="quick",
+                gpu_arch="gfx1151",
+            )
+
+            result = test_utils.run_ctest(
+                settings,
+                runner=runner,
+                discover_labels=True,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            final_cmd = calls[-1][0]
+            self.assertIn("ex_gpu_gfx115X", final_cmd)
+            self.assertIn("quick_exclude", final_cmd)
+            self.assertEqual(len(calls), 3)
 
 
 class RocminfoTest(unittest.TestCase):

--- a/test_tools/tests/test_utils_test.py
+++ b/test_tools/tests/test_utils_test.py
@@ -1,0 +1,263 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+import test_utils
+
+
+class TestCategoryTest(unittest.TestCase):
+    def test_valid_categories_are_preserved(self):
+        self.assertEqual(
+            test_utils.VALID_TEST_CATEGORIES,
+            {"quick", "standard", "comprehensive", "full"},
+        )
+        self.assertEqual(test_utils.normalize_test_category("quick"), "quick")
+        self.assertEqual(test_utils.normalize_test_category(" STANDARD "), "standard")
+
+    def test_invalid_categories_fall_back_to_quick(self):
+        self.assertEqual(test_utils.normalize_test_category(None), "quick")
+        self.assertEqual(test_utils.normalize_test_category(""), "quick")
+        self.assertEqual(test_utils.normalize_test_category("smoke"), "quick")
+
+
+class GpuArchTest(unittest.TestCase):
+    def test_extract_gpu_arch(self):
+        self.assertEqual(test_utils.extract_gpu_arch(None), "")
+        self.assertEqual(test_utils.extract_gpu_arch(""), "")
+        self.assertEqual(test_utils.extract_gpu_arch("gfx1151"), "gfx1151")
+        self.assertEqual(
+            test_utils.extract_gpu_arch("family=gfx942,gfx90a"), "gfx942"
+        )
+        self.assertEqual(test_utils.extract_gpu_arch("GFX90A"), "gfx90a")
+        self.assertEqual(test_utils.extract_gpu_arch("generic"), "")
+
+    def test_find_matching_gpu_arch_exact_match(self):
+        available = {"gfx1151", "gfx115X", "gfx11X"}
+        self.assertEqual(
+            test_utils.find_matching_gpu_arch("gfx1151", available), "gfx1151"
+        )
+
+    def test_find_matching_gpu_arch_uses_most_specific_wildcard(self):
+        available = {"gfx115X", "gfx11X"}
+        self.assertEqual(
+            test_utils.find_matching_gpu_arch("gfx1151", available), "gfx115X"
+        )
+
+    def test_find_matching_gpu_arch_uses_less_specific_wildcard(self):
+        available = {"gfx1150", "gfx94X", "gfx11X"}
+        self.assertEqual(
+            test_utils.find_matching_gpu_arch("gfx1151", available), "gfx11X"
+        )
+
+    def test_find_matching_gpu_arch_returns_none_without_match(self):
+        self.assertIsNone(
+            test_utils.find_matching_gpu_arch("gfx1151", {"gfx94X", "gfx90a"})
+        )
+        self.assertIsNone(test_utils.find_matching_gpu_arch("gfx1151", set()))
+
+    def test_find_matching_gpu_arch_stops_before_too_broad_pattern(self):
+        self.assertEqual(
+            test_utils.find_matching_gpu_arch("gfx90a", {"gfx90X"}), "gfx90X"
+        )
+        self.assertIsNone(test_utils.find_matching_gpu_arch("gfx90a", {"gfx9X"}))
+
+
+class ShardingTest(unittest.TestCase):
+    def test_gtest_shard_env_converts_to_zero_based_index(self):
+        self.assertEqual(
+            test_utils.gtest_shard_env("2", "4"),
+            {"GTEST_SHARD_INDEX": "1", "GTEST_TOTAL_SHARDS": "4"},
+        )
+
+    def test_ctest_shard_args_keep_one_based_index(self):
+        self.assertEqual(
+            test_utils.ctest_shard_args("2", "4"),
+            ["--tests-information", "2,,4"],
+        )
+
+    def test_shard_values_must_be_positive(self):
+        with self.assertRaises(ValueError):
+            test_utils.gtest_shard_env("0", "4")
+        with self.assertRaises(ValueError):
+            test_utils.ctest_shard_args("1", "0")
+
+    def test_shard_index_must_not_exceed_total_shards(self):
+        with self.assertRaises(ValueError):
+            test_utils.gtest_shard_env("5", "4")
+        with self.assertRaises(ValueError):
+            test_utils.ctest_shard_args("5", "4")
+
+
+class CTestLabelArgsTest(unittest.TestCase):
+    def test_category_label_is_included(self):
+        self.assertEqual(
+            test_utils.build_ctest_label_args("quick", "", set(), set()),
+            ["-L", "quick", "-LE", "ex_gpu"],
+        )
+
+    def test_generic_gpu_excludes_gpu_specific_tests(self):
+        self.assertEqual(
+            test_utils.build_ctest_label_args("standard", "generic", set(), set()),
+            ["-L", "standard", "-LE", "ex_gpu"],
+        )
+
+    def test_matching_gpu_adds_gpu_label(self):
+        args = test_utils.build_ctest_label_args(
+            "quick", "gfx1151", {"gfx115X", "gfx11X"}, set()
+        )
+        self.assertEqual(args, ["-L", "quick", "-L", "ex_gpu_gfx115X"])
+
+    def test_no_matching_gpu_excludes_gpu_specific_tests(self):
+        args = test_utils.build_ctest_label_args(
+            "quick", "gfx1151", {"gfx94X"}, set()
+        )
+        self.assertEqual(args, ["-L", "quick", "-LE", "ex_gpu"])
+
+    def test_category_exclude_is_combined_with_gpu_exclude(self):
+        args = test_utils.build_ctest_label_args(
+            "quick", "", set(), {"quick_exclude", "standard_exclude"}
+        )
+        self.assertEqual(args, ["-L", "quick", "-LE", "quick_exclude|ex_gpu"])
+
+    def test_invalid_category_uses_quick_policy(self):
+        args = test_utils.build_ctest_label_args(
+            "smoke", "", set(), {"quick_exclude"}
+        )
+        self.assertEqual(args, ["-L", "quick", "-LE", "quick_exclude|ex_gpu"])
+
+
+class CTestDiscoveryTest(unittest.TestCase):
+    def test_count_ctest_tests(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            calls = []
+
+            def runner(cmd, **kwargs):
+                calls.append((cmd, kwargs))
+                return SimpleNamespace(
+                    stdout="Test project\n  Test #1: alpha\n  Test #2: beta\n"
+                )
+
+            self.assertEqual(test_utils.count_ctest_tests(temp_dir, runner), 2)
+            self.assertEqual(
+                calls[0][0], ["ctest", "-N", "--test-dir", os.fspath(temp_dir)]
+            )
+            self.assertTrue(calls[0][1]["capture_output"])
+            self.assertTrue(calls[0][1]["text"])
+            self.assertTrue(calls[0][1]["check"])
+
+    def test_read_ctest_labels(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+
+            def runner(cmd, **kwargs):
+                return SimpleNamespace(
+                    stdout="quick\nstandard\nex_gpu_gfx115X\nquick_exclude\n"
+                )
+
+            self.assertEqual(
+                test_utils.read_ctest_labels(temp_dir, runner),
+                {"quick", "standard", "ex_gpu_gfx115X", "quick_exclude"},
+            )
+
+    def test_missing_test_dir_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            test_utils.count_ctest_tests(Path("does-not-exist"))
+
+    def test_parse_ctest_labels(self):
+        labels = test_utils.parse_ctest_labels(
+            [
+                "quick",
+                " standard_exclude ",
+                "ex_gpu_gfx115X",
+                "ex_gpu_gfx942",
+                "ex_gpu_notgfx",
+            ]
+        )
+        self.assertEqual(labels.gpu_archs, {"gfx115X", "gfx942"})
+        self.assertEqual(labels.exclude_labels, {"standard_exclude"})
+
+
+class RocminfoTest(unittest.TestCase):
+    ROCMINFO_OUTPUT = """
+  Name:                    gfx942
+  Marketing Name:          AMD Instinct MI300X
+  Name:                    gfx942
+  Name:                    cpu
+  Name:                    GFX1100
+"""
+
+    def test_parse_rocminfo_gpu_archs_preserves_visible_gpu_records(self):
+        self.assertEqual(
+            test_utils.parse_rocminfo_gpu_archs(self.ROCMINFO_OUTPUT),
+            ["gfx942", "gfx942", "gfx1100"],
+        )
+
+    def test_get_visible_gpu_count_uses_runner(self):
+        calls = []
+
+        def runner(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return SimpleNamespace(stdout=self.ROCMINFO_OUTPUT)
+
+        self.assertEqual(
+            test_utils.get_visible_gpu_count(
+                env={"ROCR_VISIBLE_DEVICES": "0"}, runner=runner
+            ),
+            3,
+        )
+        self.assertEqual(calls[0][0], ["rocminfo"])
+        self.assertEqual(calls[0][1]["env"], {"ROCR_VISIBLE_DEVICES": "0"})
+        self.assertFalse(calls[0][1]["check"])
+
+    def test_get_visible_gpu_count_prefers_rocm_bin_dir_rocminfo(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            rocminfo_path = Path(temp_dir) / "rocminfo"
+            rocminfo_path.write_text("")
+            calls = []
+
+            def runner(cmd, **kwargs):
+                calls.append((cmd, kwargs))
+                return SimpleNamespace(stdout=self.ROCMINFO_OUTPUT)
+
+            self.assertEqual(
+                test_utils.get_visible_gpu_count(
+                    rocm_bin_dir=temp_dir, runner=runner
+                ),
+                3,
+            )
+            self.assertEqual(calls[0][0], [os.fspath(rocminfo_path)])
+
+    def test_get_first_gpu_architecture_returns_first_visible_gpu(self):
+        def runner(cmd, **kwargs):
+            return SimpleNamespace(stdout=self.ROCMINFO_OUTPUT)
+
+        self.assertEqual(
+            test_utils.get_first_gpu_architecture(runner=runner), "gfx942"
+        )
+
+    def test_get_first_gpu_architecture_raises_without_visible_gpu(self):
+        def runner(cmd, **kwargs):
+            return SimpleNamespace(stdout="Name: cpu\n")
+
+        with self.assertRaises(RuntimeError):
+            test_utils.get_first_gpu_architecture(runner=runner)
+
+
+class ArtifactGroupTest(unittest.TestCase):
+    def test_is_asan_artifact_group(self):
+        self.assertFalse(test_utils.is_asan_artifact_group(None))
+        self.assertFalse(test_utils.is_asan_artifact_group(""))
+        self.assertFalse(test_utils.is_asan_artifact_group("core-runtime"))
+        self.assertTrue(test_utils.is_asan_artifact_group("core-asan"))
+        self.assertTrue(test_utils.is_asan_artifact_group("CORE-ASAN"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_tools/tests/test_utils_test.py
+++ b/test_tools/tests/test_utils_test.py
@@ -457,7 +457,26 @@ class RocminfoTest(unittest.TestCase):
                 test_utils.get_visible_gpu_count(rocm_bin_dir=temp_dir, runner=runner),
                 3,
             )
-            self.assertEqual(calls[0][0], [os.fspath(rocminfo_path)])
+        self.assertEqual(calls[0][0], [os.fspath(rocminfo_path)])
+
+    def test_get_visible_gpu_architectures_uses_runner(self):
+        calls = []
+
+        def runner(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return SimpleNamespace(stdout=self.ROCMINFO_OUTPUT)
+
+        self.assertEqual(
+            test_utils.get_visible_gpu_architectures(
+                env={"ROCR_VISIBLE_DEVICES": "0"},
+                runner=runner,
+                check=True,
+            ),
+            ["gfx942", "gfx942", "gfx1100"],
+        )
+        self.assertEqual(calls[0][0], ["rocminfo"])
+        self.assertEqual(calls[0][1]["env"], {"ROCR_VISIBLE_DEVICES": "0"})
+        self.assertTrue(calls[0][1]["check"])
 
     def test_get_first_gpu_architecture_returns_first_visible_gpu(self):
         def runner(cmd, **kwargs):
@@ -480,6 +499,13 @@ class ArtifactGroupTest(unittest.TestCase):
         self.assertFalse(test_utils.is_asan_artifact_group("core-runtime"))
         self.assertTrue(test_utils.is_asan_artifact_group("core-asan"))
         self.assertTrue(test_utils.is_asan_artifact_group("CORE-ASAN"))
+
+    def test_is_tsan_artifact_group(self):
+        self.assertFalse(test_utils.is_tsan_artifact_group(None))
+        self.assertFalse(test_utils.is_tsan_artifact_group(""))
+        self.assertFalse(test_utils.is_tsan_artifact_group("core-runtime"))
+        self.assertTrue(test_utils.is_tsan_artifact_group("core-tsan"))
+        self.assertTrue(test_utils.is_tsan_artifact_group("CORE-TSAN"))
 
 
 if __name__ == "__main__":

--- a/test_tools/tests/test_utils_test.py
+++ b/test_tools/tests/test_utils_test.py
@@ -34,7 +34,7 @@ class GpuArchTest(unittest.TestCase):
         self.assertEqual(test_utils.extract_gpu_arch(""), "")
         self.assertEqual(test_utils.extract_gpu_arch("gfx1151"), "gfx1151")
         self.assertEqual(test_utils.extract_gpu_arch("family=gfx942,gfx90a"), "gfx942")
-        self.assertEqual(test_utils.extract_gpu_arch("GFX90A"), "gfx90a")
+        self.assertEqual(test_utils.extract_gpu_arch("GFX90A"), "")
         self.assertEqual(test_utils.extract_gpu_arch("generic"), "")
 
     def test_find_matching_gpu_arch_exact_match(self):

--- a/test_tools/tests/test_utils_test.py
+++ b/test_tools/tests/test_utils_test.py
@@ -422,7 +422,7 @@ class RocminfoTest(unittest.TestCase):
 
     def test_parse_rocminfo_gpu_archs_preserves_visible_gpu_records(self):
         self.assertEqual(
-            test_utils.parse_rocminfo_gpu_archs(self.ROCMINFO_OUTPUT),
+            test_utils._parse_rocminfo_gpu_archs(self.ROCMINFO_OUTPUT),
             ["gfx942", "gfx942", "gfx1100"],
         )
 


### PR DESCRIPTION
## Summary

Adds the first shared test utility module for RFC0010 runner cleanup.

This PR introduces `test_tools/test_utils.py`, a project-neutral helper module for common ROCm test runner mechanics:

- common test settings parsed from CI environment variables
- GTest and CTest sharding helpers
- CTest category/GPU-label command construction
- CTest label discovery
- shared test environment construction
- `rocminfo` helpers for visible GPU detection
- ASAN artifact-group detection

The module is intentionally import-safe: importing it does not read required CI variables, run subprocesses, or exit the process.

Project scripts still own project-specific behavior such as test directory selection, ROCm root discovery, cwd, timeout/parallel policy, env overrides, fallback behavior, and project-specific test filters.

Refs #3968.

## Validation Examples

This shared utility API has been exercised by two draft rocm-libraries proof-of-concept branches:

- FFT PoC: ROCm/rocm-libraries#7305
- MIOpen PoC: ROCm/rocm-libraries#7351

These are validation-only PRs, not intended to merge as-is. They show how installed project-owned runner scripts can consume the shared utilities when TheRock provides them, while keeping project-specific fallback behavior in the owning repository.

## CI

Adds `test_tools` to the explicit Unit Tests workflow with coverage:

    - name: Test test_tools
      working-directory: test_tools
      run: |
        python -m pytest -vv \
          --cov --cov-report=term-missing --cov-report=html

`test_tools/pyproject.toml` mirrors the `build_tools` pytest/coverage layout and writes HTML coverage under:

    build/coverage-html/test_tools

## Testing

- `python -m pytest -vv` from `test_tools`
- `python -m pytest -vv --cov --cov-report=term-missing --cov-report=html` from `test_tools`
- `python -m py_compile test_tools/test_utils.py test_tools/tests/test_utils_test.py`
- Unit Tests workflow on Ubuntu and Windows
- pre-commit
