### PR TITLE
[CI] Fix linux fetch-gfx-targets for gfx110X-all

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -184,7 +184,7 @@ amdgpu_family_info_matrix_presubmit = {
         "linux": {
             "test-runs-on": "linux-gfx110X-gpu-rocm",
             "family": "gfx110X-all",
-            "fetch-gfx-targets": [],
+            "fetch-gfx-targets": ["gfx1100", "gfx1101", "gfx1102", "gfx1103"],
             "bypass_tests_for_releases": True,
             "build_variants": ["release"],
             "nightly_check_only_for_family": True,

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -147,13 +147,12 @@ amdgpu_family_info_matrix_all = {
                     "build_variants": ["release"],
                 },
                 "test": {
-                    # TODO(#2740): Re-enable machine once `amdsmi` test is fixed
-                    # fetch-gfx-targets should be ["gfx1100"] when re-enabled
+                    # TODO(#2740): Re-enable run_tests once `amdsmi` test is fixed.
                     "run_tests": False,
                     "runs_on": {
                         "test": "linux-gfx110X-gpu-rocm",
                     },
-                    "fetch-gfx-targets": [],
+                    "fetch-gfx-targets": ["gfx1100", "gfx1101", "gfx1102", "gfx1103"],
                     "sanity_check_only_for_family": True,
                 },
                 "release": {


### PR DESCRIPTION
## Summary

Mirror of #5036 (windows half) for the linux side of the `gfx110X-all`
family.

`fetch-gfx-targets` should match the arches the family actually builds.
Per [`cmake/therock_amdgpu_targets.cmake`](https://github.com/ROCm/TheRock/blob/main/cmake/therock_amdgpu_targets.cmake),
`gfx110X-all` covers:

| target  | board / SKU                                       |
|---------|---------------------------------------------------|
| gfx1100 | AMD RX 7900 XTX (Navi 31 dGPU)                    |
| gfx1101 | AMD RX 7800 XT (Navi 32 dGPU)                     |
| gfx1102 | AMD RX 7700S / Framework Laptop 16 (Navi 33 dGPU) |
| gfx1103 | AMD Radeon 780M Laptop iGPU (Phoenix iGPU)        |

Required for the new OrchestrAI linux runners coming online — the fleet
now carries gfx1101 and gfx1102 hosts behind `linux-gfx110X-gpu-rocm`,
so the test job needs the per-target split artifacts to be fetchable.

## Test plan

- [ ] Linux `gfx110X-all` build stage green (no new build target, just fetch-list)
- [ ] Linux `gfx110X-all` test stage runs (presubmit nightly path) and downloads the four split artifacts
- [ ] No regression on windows `gfx110X-all` (file is shared, but only `linux` sub-dict touched)


Made with [Cursor](https://cursor.com)