### PR TITLE
Fix jax dispatch when passing a ref for TheRock checkout

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -332,7 +332,6 @@ jobs:
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:
           workflow: release_portable_linux_jax_wheels.yml
-          ref: ${{ inputs.ref || github.ref_name }}
           inputs: |
             { "amdgpu_family": "${{ matrix.target_bundle.amdgpu_family }}",
               "release_type": "${{ env.RELEASE_TYPE }}",


### PR DESCRIPTION
For jax dispatch the ref must be past as a inputs parameter, not as part of `with:`