### PR TITLE
feat(rocgdb): add upstream build and download CI script flags

### DIFF
--- a/debug-tools/CMakeLists.txt
+++ b/debug-tools/CMakeLists.txt
@@ -281,18 +281,18 @@ if(THEROCK_ENABLE_ROCGDB)
   #   - roccoremerge man page
   # set: -DTHEROCK_ROCGDB_UPSTREAM_BUILD=ON
   # Note: upstream master will eventually include roccoremerge.
-  if(NOT DEFINED THEROCK_ROCGDB_UPSTREAM_BUILD)
-    set(THEROCK_ROCGDB_UPSTREAM_BUILD OFF)
-  endif()
+  option(THEROCK_ROCGDB_UPSTREAM_BUILD
+    "Build rocgdb against upstream GDB master (skips AMD-specific files like NOTICES.txt, roccoremerge)"
+    OFF)
 
   # When ON, download the test_rocgdb.py CI wrapper script from ROCm/ROCgdb
   # amd-staging if it is not already present in the rocgdb source tree, and
   # install it into tests/rocgdb. Required by TheRock CI when building a
   # rocgdb source tree that is not part of the branches exercised by CI.
   # Off by default to avoid a network fetch at configure time.
-  if(NOT DEFINED THEROCK_ROCGDB_DOWNLOAD_CI_SCRIPT)
-    set(THEROCK_ROCGDB_DOWNLOAD_CI_SCRIPT OFF)
-  endif()
+  option(THEROCK_ROCGDB_DOWNLOAD_CI_SCRIPT
+    "Download test_rocgdb.py from ROCm/ROCgdb amd-staging if missing in rocgdb source tree"
+    OFF)
 
   therock_cmake_subproject_declare(rocgdb
     USE_DIST_AMDGPU_TARGETS

--- a/debug-tools/CMakeLists.txt
+++ b/debug-tools/CMakeLists.txt
@@ -274,6 +274,26 @@ if(THEROCK_ENABLE_ROCGDB)
     message(WARNING "Configuring ROCgdb with modified source directory: ${THEROCK_ROCGDB_SOURCE_DIR}")
   endif()
 
+  # Default to building ROCm's rocgdb branch (with NOTICES.txt, roccoremerge, etc.).
+  # For upstream master builds, which currently lack AMD-specific files:
+  #   - NOTICES.txt file
+  #   - roccoremerge program
+  #   - roccoremerge man page
+  # set: -DTHEROCK_ROCGDB_UPSTREAM_BUILD=ON
+  # Note: upstream master will eventually include roccoremerge.
+  if(NOT DEFINED THEROCK_ROCGDB_UPSTREAM_BUILD)
+    set(THEROCK_ROCGDB_UPSTREAM_BUILD OFF)
+  endif()
+
+  # When ON, download the test_rocgdb.py CI wrapper script from ROCm/ROCgdb
+  # amd-staging if it is not already present in the rocgdb source tree, and
+  # install it into tests/rocgdb. Required by TheRock CI when building a
+  # rocgdb source tree that is not part of the branches exercised by CI.
+  # Off by default to avoid a network fetch at configure time.
+  if(NOT DEFINED THEROCK_ROCGDB_DOWNLOAD_CI_SCRIPT)
+    set(THEROCK_ROCGDB_DOWNLOAD_CI_SCRIPT OFF)
+  endif()
+
   therock_cmake_subproject_declare(rocgdb
     USE_DIST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "rocgdb"
@@ -285,6 +305,8 @@ if(THEROCK_ENABLE_ROCGDB)
       "-DSHARED_PYTHON_EXECUTABLES=${_rocgdb_python_executables_escaped}"
       "-DTHEROCK_BUNDLE_SYSDEPS=${THEROCK_BUNDLE_SYSDEPS}"
       "-DROCGDB_SOURCE_DIR=${THEROCK_ROCGDB_SOURCE_DIR}"
+      "-DROCGDB_UPSTREAM_BUILD=${THEROCK_ROCGDB_UPSTREAM_BUILD}"
+      "-DROCGDB_DOWNLOAD_CI_SCRIPT=${THEROCK_ROCGDB_DOWNLOAD_CI_SCRIPT}"
     COMPILER_TOOLCHAIN
       amd-llvm
     RUNTIME_DEPS

--- a/debug-tools/README.md
+++ b/debug-tools/README.md
@@ -507,3 +507,21 @@ terminal types as compiled-in fallbacks:
 If the user's system terminal type does not match any of these fallbacks, the
 user must install a terminfo dependency in one of the lookup paths listed
 above. Otherwise, the TUI mode in ROCgdb will remain unavailable.
+
+## Configuration Variables
+
+### THEROCK_ROCGDB_UPSTREAM_BUILD
+
+- **Default**: `OFF` - Build ROCm's rocgdb branch with AMD-specific files (NOTICES.txt, roccoremerge)
+- **Non-default**: `ON` - Build upstream GDB master, skip AMD-specific files not yet in upstream
+
+Usage: `-DTHEROCK_ROCGDB_UPSTREAM_BUILD=ON`
+
+### THEROCK_ROCGDB_DOWNLOAD_CI_SCRIPT
+
+- **Default**: `OFF` - Require `.github/scripts/test_rocgdb.py` to exist in the rocgdb source tree; configure fails if it is missing.
+- **Non-default**: `ON` - If `test_rocgdb.py` is missing from the source tree, download it from `ROCm/ROCgdb` `amd-staging` at configure time (with retries) and install it into `tests/rocgdb`.
+
+Use this when building a rocgdb source tree (e.g. upstream master) that is not part of the branches exercised by TheRock CI.
+
+Usage: `-DTHEROCK_ROCGDB_DOWNLOAD_CI_SCRIPT=ON`

--- a/debug-tools/README.md
+++ b/debug-tools/README.md
@@ -525,3 +525,7 @@ Usage: `-DTHEROCK_ROCGDB_UPSTREAM_BUILD=ON`
 Use this when building a rocgdb source tree (e.g. upstream master) that is not part of the branches exercised by TheRock CI.
 
 Usage: `-DTHEROCK_ROCGDB_DOWNLOAD_CI_SCRIPT=ON`
+
+**Note:** `curl` must be available on the system when this option is enabled, as
+it is used to download `test_rocgdb.py` at configure time. Most environments
+provide `curl` by default, but it may need to be installed otherwise.

--- a/debug-tools/rocgdb/CMakeLists.txt
+++ b/debug-tools/rocgdb/CMakeLists.txt
@@ -747,23 +747,30 @@ if(BUILD_TESTING)
       # The source of truth for the CI script is the one in amd-staging.
       set(TEST_ROCGDB_URL "https://raw.githubusercontent.com/ROCm/ROCgdb/amd-staging/.github/scripts/test_rocgdb.py")
 
+      # Use curl rather than file(DOWNLOAD): file(DOWNLOAD)'s STATUS is the
+      # libcurl transfer code, so HTTP 404/500 responses are reported as
+      # success and the error-page body is written to disk. curl --fail
+      # returns non-zero on HTTP >= 400, and verifies TLS by default.
+      find_program(CURL_EXECUTABLE curl REQUIRED)
       set(download_success FALSE)
       foreach(attempt RANGE 1 3)
         message(STATUS "Attempting to download test_rocgdb.py (attempt ${attempt}/3)")
-        file(DOWNLOAD
-          "${TEST_ROCGDB_URL}"
-          "${TEST_ROCGDB_SCRIPT}"
-          STATUS download_status
-          TIMEOUT 60
+        execute_process(
+          COMMAND "${CURL_EXECUTABLE}"
+            --fail --silent --show-error --location
+            --max-time 60
+            --output "${TEST_ROCGDB_SCRIPT}"
+            "${TEST_ROCGDB_URL}"
+          RESULT_VARIABLE curl_result
+          ERROR_VARIABLE  curl_error
         )
-        list(GET download_status 0 status_code)
-        if(status_code EQUAL 0)
+        if(curl_result EQUAL 0)
           set(download_success TRUE)
           message(STATUS "Successfully downloaded test_rocgdb.py to ${TEST_ROCGDB_SCRIPT}")
           break()
         else()
-          list(GET download_status 1 error_message)
-          message(WARNING "Download attempt ${attempt} failed: ${error_message}")
+          message(WARNING "Download attempt ${attempt} failed: ${curl_error}")
+          file(REMOVE "${TEST_ROCGDB_SCRIPT}")
         endif()
       endforeach()
 

--- a/debug-tools/rocgdb/CMakeLists.txt
+++ b/debug-tools/rocgdb/CMakeLists.txt
@@ -90,6 +90,15 @@ endfunction()
 # By default install the ROCgdb testsuite files.
 option(ENABLE_TESTS "Enable installation of ROCgdb testsuite files" OFF)
 
+# Upstream build mode: skips AMD-specific files not yet in upstream master
+# (NOTICES.txt, roccoremerge program/manpage).
+option(ROCGDB_UPSTREAM_BUILD "Building from upstream master (skips AMD-specific files)" OFF)
+
+# When the rocgdb source tree does not carry .github/scripts/test_rocgdb.py
+# (e.g. an upstream branch), fetch it from ROCm/ROCgdb amd-staging at configure
+# time so that it can be installed into tests/rocgdb for TheRock CI to invoke.
+option(ROCGDB_DOWNLOAD_CI_SCRIPT "Download test_rocgdb.py from amd-staging if missing in source tree" OFF)
+
 # Find standard build tools.
 find_program(MAKE_EXECUTABLE NAMES make REQUIRED)
 
@@ -284,6 +293,14 @@ macro(add_python_variant minor_version configure_flags libpython_dir)
   set(ROCGDB_PDF_DIR "${ROCGDB_INTERMEDIATE_INSTALL_DIR}/share/doc")
   set(ROCGDB_INFO_DIR "${ROCGDB_INTERMEDIATE_INSTALL_DIR}/share/info/rocgdb")
 
+  # Build AMD-specific install commands (conditionally included).
+  set(AMD_SPECIFIC_INSTALL_COMMANDS "")
+  if(NOT ROCGDB_UPSTREAM_BUILD)
+    list(APPEND AMD_SPECIFIC_INSTALL_COMMANDS
+      COMMAND ${CMAKE_COMMAND} -E copy ${ROCGDB_SOURCE_DIR}/gdb/NOTICES.txt ${ROCGDB_INTERMEDIATE_INSTALL_DIR}/share/doc/
+    )
+  endif()
+
   add_custom_target("${ROCGDB_TARGET_NAME}"
     ALL
     VERBATIM
@@ -360,11 +377,11 @@ macro(add_python_variant minor_version configure_flags libpython_dir)
     COMMAND
       ${CMAKE_COMMAND} -E chdir "${ROCGDB_BUILD_DIR}"
       ${MAKE_EXECUTABLE} -s -C binutils install
-    # Add in the AMD licences file.
+    # Create doc directory and add AMD-specific files (NOTICES.txt) if not building upstream.
     COMMAND
       ${CMAKE_COMMAND} -E make_directory ${ROCGDB_INTERMEDIATE_INSTALL_DIR}/share/doc
-    COMMAND
-      ${CMAKE_COMMAND} -E copy ${ROCGDB_SOURCE_DIR}/gdb/NOTICES.txt ${ROCGDB_INTERMEDIATE_INSTALL_DIR}/share/doc/
+    ${AMD_SPECIFIC_INSTALL_COMMANDS}
+
     # Rename rocgcore to rocgcore-py<python version>.
     COMMAND
       ${CMAKE_COMMAND} -E rename ${ROCGDB_INTERMEDIATE_INSTALL_DIR}/bin/rocgcore ${ROCGDB_INTERMEDIATE_INSTALL_DIR}/bin/rocgcore-py${minor_version}
@@ -387,7 +404,6 @@ macro(add_python_variant minor_version configure_flags libpython_dir)
 
   # Executable files.
   set(ROCGDB_EXEC_FILES_TO_INSTALL
-    "bin/roccoremerge"
     "bin/rocgcore-py${minor_version}"
     "bin/rocgdb-py${minor_version}"
   )
@@ -396,11 +412,16 @@ macro(add_python_variant minor_version configure_flags libpython_dir)
   set(ROCGDB_MISC_FILES_TO_INSTALL
     "share/info/rocgdb/annotate.info"
     "share/info/rocgdb/gdb.info"
-    "share/man/man1/roccoremerge.1"
     "share/man/man1/rocgdb.1"
     "share/man/man1/rocgcore.1"
     "share/man/man1/rocgdb-add-index.1"
   )
+
+  # AMD-specific files not yet in upstream master.
+  if(NOT ROCGDB_UPSTREAM_BUILD)
+    list(APPEND ROCGDB_EXEC_FILES_TO_INSTALL "bin/roccoremerge")
+    list(APPEND ROCGDB_MISC_FILES_TO_INSTALL "share/man/man1/roccoremerge.1")
+  endif()
 
   # Register the final installation step for this variant's files.
   # This basically moves the variant files from the intermediate install
@@ -527,9 +548,12 @@ endif()
 
 # List of all the files in bin we need to patch in RUNPATH's.
 # This excludes rocgdb executables as we patch those separately.
-set(ROCGDB_EXECS_TO_PATCH
-  "bin/roccoremerge"
-)
+set(ROCGDB_EXECS_TO_PATCH)
+
+# roccoremerge is only present in ROCm's branch (not yet in upstream master).
+if(NOT ROCGDB_UPSTREAM_BUILD)
+  list(APPEND ROCGDB_EXECS_TO_PATCH "bin/roccoremerge")
+endif()
 
 foreach(rocgdb_exec_filename ${ROCGDB_EXECS_TO_PATCH})
   set(rocgdb_exec_file "${CMAKE_INSTALL_PREFIX}/${rocgdb_exec_filename}")
@@ -637,8 +661,15 @@ if(BUILD_TESTING)
     "share/man/man1/rocgdb-add-index.1"
     "share/man/man1/rocgcore.1"
     "share/man/man1/rocgdb.1"
-    "share/man/man1/roccoremerge.1"
   )
+
+  # AMD-specific files not yet in upstream master.
+  if(NOT ROCGDB_UPSTREAM_BUILD)
+    list(APPEND ROCGDB_EXPECTED_FILES
+      "share/doc/NOTICES.txt"
+      "share/man/man1/roccoremerge.1"
+    )
+  endif()
 
   list(APPEND ROCGDB_BUILD_INTEGRITY_FILES ${ROCGDB_EXPECTED_FILES})
 
@@ -706,10 +737,46 @@ if(BUILD_TESTING)
       USE_SOURCE_PERMISSIONS)
   endforeach()
 
-  # Also install the CI wrapper script to invoke rocgdb tests.
-  # This is used in the context of TheRock CI.
+  # Install the CI wrapper script that invokes the rocgdb testsuite. This is
+  # used by TheRock CI. If the script is not in the source tree and
+  # ROCGDB_DOWNLOAD_CI_SCRIPT is enabled, fetch it from amd-staging.
+  set(TEST_ROCGDB_SCRIPT "${ROCGDB_SOURCE_DIR}/.github/scripts/test_rocgdb.py")
+  if(NOT EXISTS "${TEST_ROCGDB_SCRIPT}")
+    if(ROCGDB_DOWNLOAD_CI_SCRIPT)
+      set(TEST_ROCGDB_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/test_rocgdb.py")
+      # The source of truth for the CI script is the one in amd-staging.
+      set(TEST_ROCGDB_URL "https://raw.githubusercontent.com/ROCm/ROCgdb/amd-staging/.github/scripts/test_rocgdb.py")
+
+      set(download_success FALSE)
+      foreach(attempt RANGE 1 3)
+        message(STATUS "Attempting to download test_rocgdb.py (attempt ${attempt}/3)")
+        file(DOWNLOAD
+          "${TEST_ROCGDB_URL}"
+          "${TEST_ROCGDB_SCRIPT}"
+          STATUS download_status
+          TIMEOUT 60
+        )
+        list(GET download_status 0 status_code)
+        if(status_code EQUAL 0)
+          set(download_success TRUE)
+          message(STATUS "Successfully downloaded test_rocgdb.py to ${TEST_ROCGDB_SCRIPT}")
+          break()
+        else()
+          list(GET download_status 1 error_message)
+          message(WARNING "Download attempt ${attempt} failed: ${error_message}")
+        endif()
+      endforeach()
+
+      if(NOT download_success)
+        message(FATAL_ERROR "Failed to download test_rocgdb.py after 3 attempts")
+      endif()
+    else()
+      message(FATAL_ERROR "test_rocgdb.py not found at ${TEST_ROCGDB_SCRIPT} and ROCGDB_DOWNLOAD_CI_SCRIPT is OFF. Re-configure with -DTHEROCK_ROCGDB_DOWNLOAD_CI_SCRIPT=ON to fetch it from amd-staging.")
+    endif()
+  endif()
+
   install(
-    PROGRAMS ${ROCGDB_SOURCE_DIR}/.github/scripts/test_rocgdb.py
+    PROGRAMS ${TEST_ROCGDB_SCRIPT}
     DESTINATION tests/rocgdb
     COMPONENT tests
   )


### PR DESCRIPTION
Adds `THEROCK_ROCGDB_UPSTREAM_BUILD` and `THEROCK_ROCGDB_DOWNLOAD_CI_SCRIPT` flags (both default `OFF`) to support building rocgdb from upstream GDB master. When enabled, the build skips AMD-specific install artifacts (`NOTICES.txt`, `roccoremerge`) and optionally downloads `test_rocgdb.py` from `ROCm/ROCgdb` amd-staging when absent from the source tree.

Both flags are declared via `option()` so they get proper `BOOL` cache entries and help strings visible in `ccmake`/`cmake-gui`/`cmake -LH`.

The `test_rocgdb.py` download uses `execute_process(curl --fail ...)` rather than `file(DOWNLOAD)` so HTTP 4xx/5xx errors actually fail the retry loop instead of silently writing an error page to disk.

Depends on:

- [x] https://github.com/ROCm/TheRock/pull/4960
- [x] https://github.com/ROCm/TheRock/pull/5720
- [x] https://github.com/ROCm/ROCgdb/pull/117

Related: #4960