### PR TITLE
[CI] Pin distributed jobs to 4 GPUs and disable stepcurrent retries

### DIFF
--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -277,6 +277,17 @@ jobs:
           echo "CC=${ROCM_HOME}/lib/llvm/bin/clang" >> "${GITHUB_ENV}"
           echo "CXX=${ROCM_HOME}/lib/llvm/bin/clang++" >> "${GITHUB_ENV}"
 
+      # Restrict distributed jobs to 4 GPUs (0,1,2,3) on the 8-GPU runner.
+      # Several FSDP / DTensor / pipelining suites assume world_size <= 4 or
+      # are flaky/slow at world_size=8 on gfx94X; pinning to 4 GPUs gives
+      # more deterministic, faster runs. set_gpu_execution_policy() in
+      # run_pytorch_tests_full.py respects a pre-set HIP_VISIBLE_DEVICES,
+      # so policy="all" will only pick from the 4 we expose here.
+      - name: Restrict distributed jobs to 4 GPUs
+        if: matrix.test_config == 'distributed'
+        run: |
+          echo "HIP_VISIBLE_DEVICES=0,1,2,3" >> "${GITHUB_ENV}"
+
       # export_test_times.py must run from the PyTorch repo root with
       # PYTHONPATH=. because it imports internal PyTorch modules (e.g.
       # tools.stats.*) that expect the repo root on sys.path.

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -277,12 +277,6 @@ jobs:
           echo "CC=${ROCM_HOME}/lib/llvm/bin/clang" >> "${GITHUB_ENV}"
           echo "CXX=${ROCM_HOME}/lib/llvm/bin/clang++" >> "${GITHUB_ENV}"
 
-      # Restrict distributed jobs to 4 GPUs (0,1,2,3) on the 8-GPU runner.
-      # Several FSDP / DTensor / pipelining suites assume world_size <= 4 or
-      # are flaky/slow at world_size=8 on gfx94X; pinning to 4 GPUs gives
-      # more deterministic, faster runs. set_gpu_execution_policy() in
-      # run_pytorch_tests_full.py respects a pre-set HIP_VISIBLE_DEVICES,
-      # so policy="all" will only pick from the 4 we expose here.
       - name: Restrict distributed jobs to 4 GPUs
         if: matrix.test_config == 'distributed'
         run: |

--- a/external-builds/pytorch/run_pytorch_tests_full.py
+++ b/external-builds/pytorch/run_pytorch_tests_full.py
@@ -122,6 +122,18 @@ EXCLUDED_TEST_MODULES: list[str] = [
     "functorch/test_control_flow",
 ]
 
+
+def disable_distributed_stepcurrent_retries(pytorch_dir: Path) -> None:
+    run_test_path = pytorch_dir / "test" / "run_test.py"
+    text = run_test_path.read_text()
+    old = '        and not is_cpp_test\n        and "-n" not in command\n'
+    new = '        and not is_cpp_test\n        and not is_distributed_test\n        and "-n" not in command\n'
+    if new in text:
+        return
+    if old not in text:
+        raise RuntimeError("Could not disable distributed stepcurrent retries")
+    run_test_path.write_text(text.replace(old, new, 1))
+
 # Inductor config: mirrors upstream test_inductor_shard() in .ci/pytorch/test.sh.
 # The inductor config requires TWO separate run_test.py invocations:
 #   1. Generic tests run with --inductor (sets PYTORCH_TEST_WITH_INDUCTOR=1)
@@ -484,6 +496,8 @@ def main(argv: list[str]) -> int:
     check_pytorch_source_version(
         pytorch_dir=args.pytorch_dir, allow_mismatch=args.allow_version_mismatch
     )
+    if args.test_config == "distributed":
+        disable_distributed_stepcurrent_retries(args.pytorch_dir)
 
     # Determine AMDGPU family and set HIP_VISIBLE_DEVICES BEFORE importing
     # torch or running pytest.  Once torch.cuda is initialized, changing

--- a/external-builds/pytorch/run_pytorch_tests_full.py
+++ b/external-builds/pytorch/run_pytorch_tests_full.py
@@ -134,6 +134,7 @@ def disable_distributed_stepcurrent_retries(pytorch_dir: Path) -> None:
         raise RuntimeError("Could not disable distributed stepcurrent retries")
     run_test_path.write_text(text.replace(old, new, 1))
 
+
 # Inductor config: mirrors upstream test_inductor_shard() in .ci/pytorch/test.sh.
 # The inductor config requires TWO separate run_test.py invocations:
 #   1. Generic tests run with --inductor (sets PYTORCH_TEST_WITH_INDUCTOR=1)


### PR DESCRIPTION
Pin `HIP_VISIBLE_DEVICES=0,1,2,3` for `test_config == 'distributed'` jobs. Distributed tests assume a fixed world size, and the 8-GPU runner was giving each shard a different rank count, surfacing as flaky multi-rank failures.

Disable PyTorch's stepcurrent retry for distributed tests in the wrapper. `pytest-rerunfailures` is already off here, but stepcurrent still relaunches each failed distributed test in a fresh subprocess. Most distributed failures are deterministic multi-rank timeouts, so retrying just wastes 5+ minutes per rank and clutters `--keep-going` output during triage.