### PR TITLE
[ASAN] Avoid Clang -shared-libsan on global CMAKE_*_LINKER_FLAGS

### DIFF
--- a/cmake/therock_sanitizers.cmake
+++ b/cmake/therock_sanitizers.cmake
@@ -59,10 +59,12 @@ function(therock_sanitizer_configure
     string(APPEND _stanza "  $<$<AND:$<LINK_LANGUAGE:C,CXX>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>>:-shared-libsan>)\n")
 
     # For autotools-based builds (like rocgdb) that use CMAKE_*_LINKER_FLAGS directly,
-    # always include -fsanitize=<sanitizer> for linking. Also add -shared-libsan since
-    # we know we are dealing with a non-system compiler.
-    string(APPEND _stanza "string(APPEND CMAKE_EXE_LINKER_FLAGS \" -fsanitize=${_sanitizer_string} -shared-libsan\")\n")
-    string(APPEND _stanza "string(APPEND CMAKE_SHARED_LINKER_FLAGS \" -fsanitize=${_sanitizer_string} -shared-libsan\")\n")
+    # include -fsanitize=<sanitizer> for linking. Do not append -shared-libsan here: those
+    # flags apply to every link (including CMake's Fortran compiler probe with gfortran),
+    # and -shared-libsan is Clang-only (ROCM-24371). C/C++ still get -shared-libsan from
+    # add_link_options() above when using Clang.
+    string(APPEND _stanza "string(APPEND CMAKE_EXE_LINKER_FLAGS \" -fsanitize=${_sanitizer_string}\")\n")
+    string(APPEND _stanza "string(APPEND CMAKE_SHARED_LINKER_FLAGS \" -fsanitize=${_sanitizer_string}\")\n")
 
     # Device-side ASAN: Only for full ASAN mode, not HOST_ASAN.
     # Filter GPU_TARGETS to enable xnack+ mode only for gfx targets that support it.


### PR DESCRIPTION
## What broke
Scheduled **Multi-Arch CI ASAN** started failing when CMake ran the **Fortran** compiler check for **hipBLASLt**: **gfortran** was invoked with **`-fsanitize=address`**, **`-shared-libsan`**, and the usual rpath flags. **`-shared-libsan`** is a **Clang driver** option; **gfortran** errors with `unrecognized command-line option '-shared-libsan'`, so configure fails.

## Regression (original change)
This behavior came from [#4674](https://github.com/ROCm/TheRock/pull/4674) — **[cmake] Handle sanitizers for autotools projects**. That PR correctly scoped **`-shared-libsan`** to **C/C++** via **`add_link_options()`** with **`$<LINK_LANGUAGE:C,CXX>`** and a Clang-only generator expression, but also appended **`-fsanitize=…` _and_ `-shared-libsan`** to **`CMAKE_EXE_LINKER_FLAGS`** / **`CMAKE_SHARED_LINKER_FLAGS`** so autotools-based projects (e.g. ROCgdb) that mirror those variables into **`LDFLAGS`** still saw sanitizer link flags.

The problem is that **global** **`CMAKE_*_LINKER_FLAGS`** are applied to **all** languages, including CMake’s **Fortran** try-compile/link, not only Clang-driven C/C++ or autotools wrappers.

## Fix (reasoning)
- Keep appending only **`-fsanitize=<sanitizer>`** to the global **`CMAKE_EXE_LINKER_FLAGS`** / **`CMAKE_SHARED_LINKER_FLAGS`** in the generated toolchain stanza so autotools continue to get a sanitizer on the link line.
- **Stop** appending **`-shared-libsan`** to those globals so **gfortran** (and any non-Clang link) is not fed a Clang-only flag.
- **C/C++** links with **Clang** still receive **`-shared-libsan`** from the existing **`add_link_options()`** block in **`cmake/therock_sanitizers.cmake`**, preserving the intent of [#4674](https://github.com/ROCm/TheRock/pull/4674) for the main compiler toolchain.

## Follow-up
- [ ] Confirm **Multi-Arch CI ASAN** (or equivalent) passes **math-libs / hipBLASLt** and **debug-tools** (autotools + **`LDFLAGS`**), in case any edge case still needs **`-shared-libsan`** only on the autotools path.

**ROCM-24371** 
Made with [Cursor](https://cursor.com)