### PR TITLE
[debug-tools] Refactor container options and split rocgdb tests into CPU and GPU runners

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -187,7 +187,8 @@ jobs:
       # Route to the appropriate runner:
       #   1. Benchmark components use the dedicated benchmark runner
       #   2. Multi-GPU components use the multi-GPU runner
-      #   3. Everything else uses the standard test runner
+      #   3. CPU-only components use standard GitHub runners (azure-linux-scale-rocm)
+      #   4. Everything else uses the standard test runner (GPU runners)
       test_runs_on: >-
         ${{
           (matrix.components.is_benchmark == true &&
@@ -195,6 +196,8 @@ jobs:
             inputs.benchmark_runs_on) ||
           (matrix.components.multi_gpu_runner != '' &&
             matrix.components.multi_gpu_runner) ||
+          (matrix.components.linux_cpu_runner == true &&
+            'azure-linux-scale-rocm') ||
           inputs.test_runs_on
         }}
       platform: ${{ needs.configure_test_matrix.outputs.platform }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -57,22 +57,10 @@ jobs:
             (fromJSON(inputs.component).container_image || inputs.default_container_image)
             || null
         }}
-      # --ulimit memlock=-1:-1 - Prevents memory allocation issues with ROCm inside container
-      # --security-opt seccomp=unconfined - enables memory mapping, and is recommended for containers running in HPC environments
-      # --env-file /etc/podinfo/gha-gpu-isolation-settings - Required for GPU isolation on OSSCI MIXXX runners
-      # --user 0:0 - Running as root, by recommendation of GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/dockerfile-support#user
-      options: --ipc host
-        --group-add video
-        --device /dev/kfd
-        --device /dev/dri
-        --group-add 993
-        --group-add 992
-        --group-add 110
-        --ulimit memlock=-1:-1
-        --security-opt seccomp=unconfined
-        --env-file /etc/podinfo/gha-gpu-isolation-settings
-        --user 0:0
-        ${{ fromJSON(inputs.component).container_options }}
+      # Container options are configured in build_tools/github_actions/fetch_test_configurations.py
+      # and include base options (ipc, user, ulimit, seccomp), GPU options (devices, groups),
+      # and any job-specific options
+      options: ${{ fromJSON(inputs.component).container_options }}
     strategy:
       fail-fast: false
       matrix:

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -60,7 +60,7 @@ _BASE_CONTAINER_OPTIONS = [
     "--security-opt seccomp=unconfined",
 ]
 
-# GPU-specific container options (only applied when cpu_runner != True)
+# GPU-specific container options (only applied when linux_cpu_runner != True)
 # --group-add video - Grants access to GPU video group
 # --device /dev/kfd - AMD KFD device for GPU compute
 # --device /dev/dri - Direct Rendering Infrastructure devices
@@ -96,7 +96,7 @@ def _build_container_options(job_config: dict, platform: str) -> dict:
     options_parts = _BASE_CONTAINER_OPTIONS.copy()
 
     # Add GPU-specific options unless this is a CPU-only runner
-    if not job_config.get("cpu_runner", False):
+    if not job_config.get("linux_cpu_runner", False):
         options_parts.extend(_GPU_CONTAINER_OPTIONS)
 
     # Add any job-specific container options
@@ -108,6 +108,16 @@ def _build_container_options(job_config: dict, platform: str) -> dict:
 
     return job_config
 
+
+# Common settings for rocgdb jobs
+_rocgdb_common = {
+    "fetch_artifact_args": "--debug-tools --tests",
+    "timeout_minutes": 30,
+    "platform": ["linux"],
+    "total_shards": 1,
+    "container_image": "ghcr.io/rocm/no_rocm_image_ubuntu24_04_rocgdb@sha256:7063e922b4b9145c92f20011674571f1c97b8fad6faaeb0b7d2d165b0bd9ae8b",  # 2026-04-02T21:47:07.506375216Z
+    "container_options": ["--cap-add=SYS_PTRACE"],
+}
 
 test_matrix = {
     # Sanity tests - always run first as a prerequisite for other component tests
@@ -249,15 +259,16 @@ test_matrix = {
             "windows": 1,
         },
     },
-    "rocgdb": {
-        "job_name": "rocgdb",
-        "fetch_artifact_args": "--debug-tools --tests",
-        "timeout_minutes": 45,
-        "test_script": f"python {_get_script_path('test_rocgdb.py')}",
-        "platform": ["linux"],
-        "total_shards": 1,
-        "container_image": "ghcr.io/rocm/no_rocm_image_ubuntu24_04_rocgdb@sha256:7063e922b4b9145c92f20011674571f1c97b8fad6faaeb0b7d2d165b0bd9ae8b",  # 2026-04-02T21:47:07.506375216Z
-        "container_options": "--cap-add=SYS_PTRACE",
+    "rocgdb-cpu": {
+        **_rocgdb_common,
+        "job_name": "rocgdb-cpu",
+        "test_script": f"python {_get_script_path('test_rocgdb.py')} --tests gdb.dwarf2",
+        "linux_cpu_runner": True,
+    },
+    "rocgdb-gpu": {
+        **_rocgdb_common,
+        "job_name": "rocgdb-gpu",
+        "test_script": f"python {_get_script_path('test_rocgdb.py')} --tests gdb.rocm",
     },
     "rocr-debug-agent": {
         "job_name": "rocr-debug-agent",

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -48,6 +48,67 @@ def _get_script_path(script_name: str) -> str:
     return str(posix_path)
 
 
+# Base container options applied to all Linux containers
+# --ipc host - Allows shared memory between host and container
+# --user 0:0 - Running as root, by recommendation of GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/dockerfile-support#user
+# --ulimit memlock=-1:-1 - Prevents memory allocation issues with ROCm inside container
+# --security-opt seccomp=unconfined - enables memory mapping, and is recommended for containers running in HPC environments
+_BASE_CONTAINER_OPTIONS = [
+    "--ipc host",
+    "--user 0:0",
+    "--ulimit memlock=-1:-1",
+    "--security-opt seccomp=unconfined",
+]
+
+# GPU-specific container options (only applied when cpu_runner != True)
+# --group-add video - Grants access to GPU video group
+# --device /dev/kfd - AMD KFD device for GPU compute
+# --device /dev/dri - Direct Rendering Infrastructure devices
+# --group-add 993,992,110 - Additional GPU-related groups
+# --env-file /etc/podinfo/gha-gpu-isolation-settings - Required for GPU isolation on OSSCI MIXXX runners
+_GPU_CONTAINER_OPTIONS = [
+    "--group-add video",
+    "--device /dev/kfd",
+    "--device /dev/dri",
+    "--group-add 993",
+    "--group-add 992",
+    "--group-add 110",
+    "--env-file /etc/podinfo/gha-gpu-isolation-settings",
+]
+
+
+def _build_container_options(job_config: dict, platform: str) -> dict:
+    """
+    Build the final container_options string by concatenating base, GPU, and job-specific options.
+
+    Args:
+        job_config: The job configuration dictionary
+        platform: The platform (e.g., "linux", "windows")
+
+    Returns:
+        The modified job_config with updated container_options
+    """
+    # Only apply container options for Linux platforms
+    if platform != "linux":
+        return job_config
+
+    # Start with base options (always applied on Linux)
+    options_parts = _BASE_CONTAINER_OPTIONS.copy()
+
+    # Add GPU-specific options unless this is a CPU-only runner
+    if not job_config.get("cpu_runner", False):
+        options_parts.extend(_GPU_CONTAINER_OPTIONS)
+
+    # Add any job-specific container options
+    if "container_options" in job_config:
+        options_parts.extend(job_config["container_options"])
+
+    # Concatenate all parts with a space separator
+    job_config["container_options"] = " ".join(options_parts)
+
+    return job_config
+
+
 test_matrix = {
     # Sanity tests - always run first as a prerequisite for other component tests
     "sanity": {
@@ -62,7 +123,7 @@ test_matrix = {
         },
         # Running docker with cap-add and -v /lib/modules, by recommendation of GitHub:
         # https://rocm.docs.amd.com/projects/amdsmi/en/amd-staging/how-to/setup-docker-container.html
-        "container_options": "--cap-add SYS_MODULE -v /lib/modules:/lib/modules",
+        "container_options": ["--cap-add SYS_MODULE", "-v /lib/modules:/lib/modules"],
     },
     # hip-tests
     "hip-tests": {
@@ -354,7 +415,7 @@ test_matrix = {
         ],
         "test_script": f"python {_get_script_path('test_rocprofiler_sdk.py')}",
         "platform": ["linux"],
-        "container_options": "--cap-add=SYS_PTRACE",
+        "container_options": ["--cap-add=SYS_PTRACE"],
         "total_shards_dict": {
             "linux": 1,
         },
@@ -723,6 +784,9 @@ def run():
                     continue
 
             all_components.append(job_config_data)
+
+    # Build container options for all components (concatenates base, GPU, and job-specific options)
+    all_components = [_build_container_options(c, platform) for c in all_components]
 
     # Separate sanity (always a prerequisite) from the regular component matrix.
     sanity_component = next(

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -109,6 +109,9 @@ def _build_container_options(job_config: dict, platform: str) -> dict:
     return job_config
 
 
+# Common settings applied to all jobs
+_common_settings = {}
+
 # Common settings for rocgdb jobs
 _rocgdb_common = {
     "fetch_artifact_args": "--debug-tools --tests",
@@ -711,6 +714,7 @@ def run():
                 shard_arr = list(range(1, total_shards + 1))
 
                 pal_entry = {
+                    **_common_settings,
                     "job_name": "hip-tests (PAL)",
                     "fetch_artifact_args": base["fetch_artifact_args"],
                     "timeout_minutes": base["timeout_minutes"],
@@ -725,6 +729,7 @@ def run():
 
                 if windows_hip_rocr_tests:
                     rocr_entry = {
+                        **_common_settings,
                         "job_name": "hip-tests (ROCR)",
                         "fetch_artifact_args": base["fetch_artifact_args"],
                         "timeout_minutes": base["timeout_minutes"],
@@ -739,7 +744,7 @@ def run():
                     all_components.append(rocr_entry)
                 continue
 
-            job_config_data = selected_matrix[key]
+            job_config_data = {**_common_settings, **selected_matrix[key]}
             job_config_data["test_type"] = test_type
             # For CI testing, we construct a shard array based on "total_shards" from "fetch_test_configurations.py"
             # This way, the test jobs will be split up into X shards. (ex: [1, 2, 3, 4] = 4 test shards)


### PR DESCRIPTION
[Refactor container options to use arrays in Python](https://github.com/ROCm/TheRock/pull/5132/commits/6e286f40b97c3662e188c53e16fd3c1a33c976b0) 
[6e286f4](https://github.com/ROCm/TheRock/pull/5132/commits/6e286f40b97c3662e188c53e16fd3c1a33c976b0)
Moves hardcoded docker container flags from the GitHub Actions workflow
YAML to the Python configuration script (fetch_test_configurations.py),
using arrays instead of concatenated strings for better maintainability.

This centralized approach:
- Simplifies workflow maintenance by keeping all container configuration
  in one place
- Makes it easier to update flags globally by managing them as arrays
- Reduces YAML complexity
- Enables conditional container options (e.g., CPU vs GPU runners)

Container options are now built in three layers using array operations:
1. Base options (--ipc, --user, --ulimit, --seccomp) - always applied
2. GPU options (--device, --group-add) - applied unless cpu_runner=True
3. Job-specific options - from individual test configurations

Arrays are joined with spaces to produce the final container_options
string passed to the workflow.

[Split rocgdb tests into CPU and GPU runners](https://github.com/ROCm/TheRock/pull/5132/commits/5169ce35a23581a87752f324dfbe79542561adde) 
[5169ce3](https://github.com/ROCm/TheRock/pull/5132/commits/5169ce35a23581a87752f324dfbe79542561adde)
Separates rocgdb test suite into two jobs:
- rocgdb-cpu: runs gdb.dwarf2 tests on standard ubuntu-24.04 runners
- rocgdb-gpu: runs gdb.rocm tests on GPU runners

CPU tests no longer require GPU runners, improving CI resource utilization.
The cpu_runner flag triggers runner selection and container option handling
(via the refactored _build_container_options function).

[Add common_settings for all test jobs](https://github.com/ROCm/TheRock/pull/5132/commits/5de9b6e3589ac2497d6a31f10b7cebde8992ccba) 
[5de9b6e](https://github.com/ROCm/TheRock/pull/5132/commits/5de9b6e3589ac2497d6a31f10b7cebde8992ccba)
Introduces _common_settings dictionary that is applied to all jobs in
the test matrix. This provides a central location for settings that
should be shared across all test configurations.

Currently initialized as empty after analysis showed no settings are
truly common across all jobs. Each job has unique timeout, script,
and artifact requirements. This structure is ready for future common
defaults if needed (e.g., retry policies, common environment variables).