### PR TITLE
Add `--override-file` flag to `fetch_sources.py`

### DIFF
--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -17,8 +17,10 @@
 import argparse
 import concurrent.futures
 import hashlib
+import json
 from pathlib import Path
 import platform
+import re
 import shlex
 import shutil
 import subprocess
@@ -120,6 +122,90 @@ def _get_submodule_url_map() -> dict[str, str]:
         except subprocess.CalledProcessError:
             continue
     return path_to_url
+
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def load_submodule_overrides(
+    args: argparse.Namespace, projects: list[str]
+) -> dict[str, str]:
+    """Load --override-file into a project-name -> 40-char SHA dict.
+
+    Returns {} when --override-file is not set. Entries whose project is not in
+    the current run's projects (e.g. a stage that doesn't fetch that project)
+    are skipped.
+    """
+    if args.override_file is None:
+        return {}
+
+    path: Path = args.override_file
+    if not path.exists():
+        raise FileNotFoundError(f"--override-file not found: {path}")
+
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        raise ValueError(f"--override-file {path}: malformed JSON: {e}") from e
+
+    overrides = data.get("submodule_overrides")
+    if not isinstance(overrides, dict):
+        raise ValueError(
+            f"--override-file {path}: top-level 'submodule_overrides' must be an object"
+        )
+
+    projects_set = set(projects)
+    result: dict[str, str] = {}
+    for key, value in overrides.items():
+        if not isinstance(value, str) or not _SHA_RE.match(value):
+            raise ValueError(
+                f"--override-file {path}: invalid SHA for {key!r}: {value!r}. "
+                f"Expected 40-char lowercase hex."
+            )
+        if key not in projects_set:
+            log(f"Override skip: {key!r} not in this run's projects")
+            continue
+        result[key] = value
+
+    return result
+
+
+def apply_submodule_overrides(args: argparse.Namespace, projects: list[str]) -> None:
+    """Switch each in-scope submodule to its override SHA via fetch + checkout.
+
+    For each (project_name, sha) returned by load_submodule_overrides:
+      - skip if the submodule HEAD is already at the override SHA
+      - otherwise: git fetch --depth=1 origin <sha> (with full-fetch fallback)
+                   + git checkout --detach <sha>
+    """
+    overrides = load_submodule_overrides(args, projects)
+    if not overrides:
+        return
+
+    for project_name, sha in overrides.items():
+        sub_path = get_submodule_path(project_name)
+
+        orig_sha = (
+            subprocess.check_output(
+                ["git", "-C", sub_path, "rev-parse", "HEAD"],
+                cwd=str(THEROCK_DIR),
+            )
+            .decode()
+            .strip()
+        )
+        if orig_sha == sha:
+            log(f"Override no-op: {project_name} ({sub_path}) already at {sha[:7]}")
+            continue
+
+        log(f"Override: {project_name} ({sub_path}) {orig_sha[:7]} -> {sha[:7]}")
+        run_command(
+            ["git", "-C", sub_path, "fetch", "--depth=1", "origin", sha],
+            cwd=THEROCK_DIR,
+        )
+        run_command(
+            ["git", "-C", sub_path, "checkout", "--detach", sha],
+            cwd=THEROCK_DIR,
+        )
 
 
 def _submodule_is_initialized(submodule_path: str) -> bool:
@@ -553,6 +639,11 @@ def run(args):
     if args.dvc_projects:
         pull_large_files(args.dvc_projects, projects)
 
+    # Apply --override-file overrides BEFORE nested-submodule init,
+    # so nested submodules track the override SHA's .gitmodules.
+    if args.update_submodules:
+        apply_submodule_overrides(args, projects)
+
     # Fetch nested submodules
     if args.update_submodules:
         fetch_nested_submodules(args, projects)
@@ -782,6 +873,21 @@ def main(argv):
             "setup_git_mirrors.py). Submodule clones will use --reference "
             "to read objects locally instead of over the network. "
             f"Also reads from ${MIRROR_DIR_ENV} environment variable."
+        ),
+    )
+
+    # Submodule SHA overrides (e.g., for rocm-libraries CI to drive iree/fusilli pins)
+    parser.add_argument(
+        "--override-file",
+        type=Path,
+        default=None,
+        help=(
+            "Path to a JSON file with submodule SHA overrides. After the standard "
+            "submodule update, switches each listed submodule to the override SHA. "
+            'Schema: {"submodule_overrides": {"<project_name>": "<sha>", ...}} '
+            "where <project_name> is the submodule name from .gitmodules (e.g. "
+            '"fusilli", "iree"). Only applies to submodules already in this run\'s '
+            "project set; entries whose target isn't being fetched are skipped silently."
         ),
     )
 


### PR DESCRIPTION
## Motivation

### The problem: deadlocked CI

The dependency flow between TheRock submodules (`iree-libs/iree`, `iree-libs/fusilli`) and the `fusilli-provider` library inside `rocm-libraries` is deadlocked when fusilli ships a breaking API change:

- TheRock's fusilli pin can't move forward until rocm-libraries' fusilli-provider is updated.
- rocm-libraries' fusilli-provider can't be updated until TheRock provides the new fusilli, because rocm-libraries CI builds fusilli-provider against TheRock's pinned fusilli.

### Candidate solutions

####  Disable `THEROCK_ENABLE_FUSILLI_PLUGIN` during the rollover

1. **TheRock PR**: bump `iree-libs/fusilli` to the new (breaking) SHA and disable fusilli-provider build.
2. *Wait* for the next TheRock back-bump in rocm-libraries. This updates rocm-libraries' pinned TheRock ref to the SHA with the new fusilli (which won't actually build).
3. **rocm-libraries PR**: update fusilli-provider source for the new fusilli API.
4. *Wait* for the next TheRock auto-bump. TheRock's `rocm-libraries` pointer moves to 3's SHA.
8. **TheRock PR**: re-enable the plugin build. It _should_ be green at this point, but at the same time this is the first time it will actually be tested...

#### Ship breaking changes as fusilli patch in rocm-libraries

This approach relies on a change in TheRock to allow `fetch_sources.py` to apply a patch stored in `rocm-libraries` as well as in `patches/amd-mainline/`.

1. **rocm-libraries PR**: introduce the fusilli breaking changes in a _patch_ + update fusilli provider to use new API.
2. *Wait* for the rocm-libraries auto-bump to land in TheRock.
3.  **TheRock PR**: bump fusilli to the new SHA and adds a flag (env var, config option, sentinel) to make the build ignore the patch shipped from rocm-libraries.
4. *Wait* for the TheRock back-bump to land in rocm-libraries.
5. **rocm-libraries PR**: remove the patch.
6. **TheRock PR**: remove the temporary "ignore patch" flag added in step 3.

### This PR's solution:  `dep_overrides.json`

`rocm-libraries/dep_overrides.json` becomes the source of truth for the fusilli SHA used by rocm-libraries' CI.
The CI passes `--override-file dep_overrides.json` to TheRock's `fetch_sources.py`, which switches TheRock's `iree-libs/fusilli` and `iree-libs/iree` checkouts to the SHAs listed in that file.

TheRock's own CI uses the regular `.gitmodules` pins without overrides. To keep the two views in sync PRs that bump rocm-libraries in TheRock must *propagate* `dep_overrides.json` into TheRock's pointers each time it bumps the rocm-libraries pin; a follow on PR will update TheRock's auto-bump workflow to do this automatically.

Conceptually, this is very very close to the patch approach. We patch the submodules being used `rocm-libraries` CI, but unlike the patch approach the change is pushed forward rather than waiting for it to cycle back around.

#### To update IREE/fusilli (no breaking change)

1. Open a PR to rocm-libraries that bumps the `fusilli` and `iree` entry in `dep_overrides.json` to the new SHA. The IREE SHA should be the equivalent of the version number pinned in fusilli's [`version.json`](https://github.com/iree-org/fusilli/blob/main/version.json). Fusilli should work with a wide variety of IREE versions, but in practice it's best to use the version fusilli has already tested and verified against.
2. CI runs against the new fusilli/IREE. If green, merge.
3. Within ~12 h, TheRock's submodule-bump workflow opens a TheRock PR that propagates the override (single PR atomically updates the `rocm-libraries`, `iree-libs/fusilli`, and `iree-libs/iree` pointers).

#### To update IREE/fusilli with a breaking API change

Same process, but open a single rocm-libraries PR that simultaneously bumps the `fusilli`/`iree` entry in `dep_overrides.json`, **and** updates fusilli-provider source code for the new fusilli API.


## Technical Details

- Adds `--override-file <path>` to `fetch_sources.py` with JSON schema

  ```json 
  {"submodule_overrides": {"<project_name>": "<sha>", "<other_project_name>": "<sha>"}} 
  ```

  where `<project_name>` is the submodule short name from `.gitmodules` (e.g. `fusilli`, `iree`).

- `fetch_sources.py` switches any project in the override file to corresponding SHA via `git fetch --depth=1 origin <sha>` then `git checkout --detach <sha>`.


## Test Plan

- Manual rocm-libraries CI run using new override flag: no-op override same fusilli/IREE versions as already in TheRock
  - https://github.com/ROCm/rocm-libraries/compare/p054-dep-flow__ci-test-pr1
  - https://github.com/ROCm/rocm-libraries/actions/runs/25561325093/job/75033526603#step:11:46
- Manual rocm-libraries CI run using new override flag: real override updating fusilli/IREE versions in TheRock
   - https://github.com/ROCm/rocm-libraries/compare/p054-dep-flow__ci-test-active-override
   - https://github.com/ROCm/rocm-libraries/actions/runs/25565320640/job/75047292857#step:11:46

## Test Result

- Manual runs passed CI

## Related PRs
- https://github.com/ROCm/rocm-libraries/pull/7208
- https://github.com/ROCm/TheRock/pull/5135

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.