### PR TITLE
Improve clang ccache hit rates on Windows

### DIFF
--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -76,7 +76,7 @@ jobs:
     env:
       STAGE_NAME: ${{ inputs.stage_name }}
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_family }}
-      BUILD_DIR: B:\build
+      BUILD_DIR: D:\build
       CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
       CACHE_DIR: ${{ github.workspace }}/.cache
       TEATIME_FORCE_INTERACTIVE: 0
@@ -84,6 +84,16 @@ jobs:
       EXTERNAL_FETCH_SOURCES_ARGS: ${{ inputs.external_repo_config != '' && fromJSON(inputs.external_repo_config).fetch_sources_args || '' }}
 
     steps:
+      # Map B:\build to a stable drive letter via subst. B:\ is a volume mount
+      # to C:\{GUID}\ where the GUID changes per runner VM. Clang resolves
+      # paths through the mount, embedding the GUID in include paths, which
+      # defeats ccache (entries become runner-specific). subst is transparent
+      # to path resolution, so D:\build paths stay as D:\build in ccache
+      # manifests regardless of which runner executes the job.
+      - name: Stabilize build drive path
+        shell: cmd
+        run: "subst D: B:\\"
+
       # Enable git longpaths before checkout (needed for external repos with long paths)
       - name: Enable git longpaths
         if: ${{ inputs.external_repo_config != '' }}

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -76,7 +76,7 @@ jobs:
     env:
       STAGE_NAME: ${{ inputs.stage_name }}
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_family }}
-      BUILD_DIR: D:\build
+      BUILD_DIR: B:\build
       CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
       CACHE_DIR: ${{ github.workspace }}/.cache
       TEATIME_FORCE_INTERACTIVE: 0
@@ -84,16 +84,6 @@ jobs:
       EXTERNAL_FETCH_SOURCES_ARGS: ${{ inputs.external_repo_config != '' && fromJSON(inputs.external_repo_config).fetch_sources_args || '' }}
 
     steps:
-      # Map B:\build to a stable drive letter via subst. B:\ is a volume mount
-      # to C:\{GUID}\ where the GUID changes per runner VM. Clang resolves
-      # paths through the mount, embedding the GUID in include paths, which
-      # defeats ccache (entries become runner-specific). subst is transparent
-      # to path resolution, so D:\build paths stay as D:\build in ccache
-      # manifests regardless of which runner executes the job.
-      - name: Stabilize build drive path
-        shell: cmd
-        run: "subst D: B:\\"
-
       # Enable git longpaths before checkout (needed for external repos with long paths)
       - name: Enable git longpaths
         if: ${{ inputs.external_repo_config != '' }}

--- a/build_tools/setup_ccache.py
+++ b/build_tools/setup_ccache.py
@@ -43,7 +43,7 @@ CACHE_SRV_REL = "http://bazelremote-svc-rel.bazelremote-ns.svc.cluster.local:808
 # Bump this version when making hash-affecting config changes (sloppiness,
 # compiler_check, etc.) to logically isolate new cache entries from stale
 # ones on the shared remote cache server.
-CCACHE_NAMESPACE_VERSION = "v1"
+CCACHE_NAMESPACE_VERSION = "v2"
 
 DEFAULT_LOG_DIR = REPO_ROOT / "build" / "logs" / "ccache"
 
@@ -71,11 +71,17 @@ CONFIG_PRESETS_MAP = {
 }
 
 
+def _log(msg: str):
+    print(f"[setup_ccache] {msg}", file=sys.stderr)
+
+
 def gen_config(dir: Path, compiler_check_file: Path, args: argparse.Namespace):
     lines = []
 
     config_preset: str = args.config_preset
     selected_config = CONFIG_PRESETS_MAP[config_preset]
+    _log(f"Config preset: {config_preset}")
+    _log(f"Platform: {'Windows' if IS_WINDOWS else 'POSIX'}")
     for k, v in selected_config.items():
         lines.append(f"{k} = {v}")
 
@@ -146,16 +152,18 @@ def run(args: argparse.Namespace):
 
     config_contents = gen_config(dir, compiler_check_file, args)
     if args.init or not config_file.exists():
-        print(f"Initializing ccache dir: {dir}", file=sys.stderr)
+        _log(f"Initializing ccache dir: {dir}")
         dir.mkdir(parents=True, exist_ok=True)
         config_file.write_text(config_contents)
+        _log(f"Wrote config: {config_file}")
         if not IS_WINDOWS:
             compiler_check_file.write_text(POSIX_COMPILER_CHECK_SCRIPT)
+            _log(f"Wrote compiler check script: {compiler_check_file}")
 
     else:
         # Check to see if updated.
         if config_file.read_text() != config_contents:
-            print(
+            _log(
                 f"NOTE: {config_file} does not match expected. Run with --init to regenerate",
                 file=sys.stderr,
             )
@@ -182,6 +190,12 @@ def run(args: argparse.Namespace):
                 f"ERROR! Zeroing statistic counters failed. Message: {proc_ccache.stderr}",
                 file=sys.stderr,
             )
+    # Print the generated config for visibility in CI logs.
+    _log("Generated ccache config:")
+    for line in config_contents.splitlines():
+        if line.strip():
+            _log(f"  {line}")
+
     # Output options.
     if IS_WINDOWS:
         print(f"set CCACHE_CONFIGPATH={config_file}")

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1701,6 +1701,15 @@ function(_therock_cmake_subproject_setup_toolchain
     string(APPEND _toolchain_contents "set(CMAKE_C_COMPILER \"@AMD_LLVM_C_COMPILER@\")\n")
     string(APPEND _toolchain_contents "set(CMAKE_CXX_COMPILER \"@AMD_LLVM_CXX_COMPILER@\")\n")
     string(APPEND _toolchain_contents "set(CMAKE_LINKER \"@AMD_LLVM_LINKER@\")\n")
+    # Explicitly set clang's resource directory using the toolchain path rather
+    # than letting clang auto-detect it. On Windows CI, B:\ is a volume mount
+    # to C:\{GUID}\ and clang resolves its binary path through the mount when
+    # computing the resource dir. This embeds the GUID in include paths, which
+    # defeats ccache. Passing -resource-dir with the unresolved path avoids this.
+    string(APPEND _toolchain_contents "file(GLOB _therock_clang_resource_dirs \"@_amd_llvm_dist_dir@/lib/llvm/lib/clang/*\")\n")
+    string(APPEND _toolchain_contents "list(GET _therock_clang_resource_dirs 0 _therock_clang_resource_dir)\n")
+    string(APPEND _toolchain_contents "string(APPEND CMAKE_C_FLAGS_INIT \" -resource-dir \${_therock_clang_resource_dir}\")\n")
+    string(APPEND _toolchain_contents "string(APPEND CMAKE_CXX_FLAGS_INIT \" -resource-dir \${_therock_clang_resource_dir}\")\n")
     string(APPEND _toolchain_contents "string(APPEND CMAKE_CXX_FLAGS_INIT \" ${_amd_llvm_cxx_flags_spaces}\")\n")
 
     therock_sanitizer_configure(


### PR DESCRIPTION
## Motivation

Tentatively fixes https://github.com/ROCm/TheRock/issues/4519.

This makes ccache functional for `clang` compile commands on our Windows CI runners that use `B:\` volume mounts. Previously even with a "warm" cache we would get cache misses for all clang commands resulting in 4+ hour build times. Now we can get ~95% cache hits for builds under 1 hour.

## Technical Details

Detailed analysis: https://github.com/ScottTodd/claude-rocm-workspace/blob/main/tasks/active/windows-ccache-hitrate.md.

* https://github.com/ROCm/TheRock/pull/4419 enabled reproducible build options, producing byte-identical amd-llvm compiler binaries
* Our Windows CI runners use `B:\` volume mounts that resolve to GUID-based workspace paths like `C:\B109CE3D-03D2-40EB-AD46-20E30992D028\build\`
* Setting ccache's `base_dir` was not sufficient to normalize this
* The GUID paths are embedded in CMake compile commands like `-DHIP_COMPILER_FLAGS` and by clang for resource directory headers

Two changes were needed to fully get cache hits (without editing the runner configuration itself):

1. ~~Stabilize filesystem paths used for the source checkout and entry point commands using [`subst`](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/subst) to "associate a path with a drive letter"~~ (reverted to keep workflows simpler strictly required)
2. Explicitly set clang's `-resource-dir` to the stable (unresolved) path to avoid LLVM's call to [`GetModuleFileNameW`](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamew) in [`llvm/lib/Support/Windows/Path.inc`](https://github.com/llvm/llvm-project/blob/7377bac59b4aea64da09873b44df1430571e93c3/llvm/lib/Support/Windows/Path.inc#L207-L212))

## Test Plan

Multiple rounds of Linux and Windows CI on this PR watching ccache statistics.

## Test Result

Pre-testing experiment results: https://github.com/ScottTodd/claude-rocm-workspace/blob/main/tasks/active/windows-ccache-hitrate.md#experiment-results

Baseline (https://github.com/ROCm/TheRock/actions/runs/25588131640):

Run description | Build time | Cache hitrate | Logs link 
-- | -- | -- | --
Linux gfx110X-all (warm postsubmit cache) | 0h26m | 96.20% | [logs here](https://github.com/ROCm/TheRock/actions/runs/25588131640/job/75123210201)
Windows gfx110X-all ("warm" postsubmit cache) | 4h04m | 1.59% ❌ | [logs here](https://github.com/ROCm/TheRock/actions/runs/25588131640/job/75124089768)

On this PR:

Run description | Build time | Cache hitrate | Logs link 
-- | -- | -- | --
Windows gfx110X-all attempt 1 (cold cache) | 5h13m | 11.60% | [logs here](https://github.com/ROCm/TheRock/actions/runs/25585430330/job/75117786398?pr=5141)
Windows gfx110X-all attempt 2 (warm cache) | 0h54m | 96.00% ✅ | [logs here](https://github.com/ROCm/TheRock/actions/runs/25585430330/job/75157312061?pr=5141)
Linux gfx110X-all attempt 1 (cold cache) | 6h03m | 20.65% | [logs here](https://github.com/ROCm/TheRock/actions/runs/25585430330/job/75117509858?pr=5141)
Linux gfx110X-all attempt 2 (warm cache) | 0h28m | 96.20% | [logs here](https://github.com/ROCm/TheRock/actions/runs/25585430330/job/75169390396?pr=5141)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
