### PR TITLE
Bump Boost to 1.91.0 for Visual Studio 2026 support #5146

### DIFF
--- a/third-party/boost/CMakeLists.txt
+++ b/third-party/boost/CMakeLists.txt
@@ -18,8 +18,8 @@ therock_subproject_fetch(boost-sources
   SOURCE_DIR "${_source_dir}"
   # Originally mirrored from: "https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2"
   # with `libs\wave\test\testwave\testfiles\utf8-test*` removed.
-  URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/boost_1_87_0-1.tar.bz2"
-  URL_HASH "SHA256=0ba4085a0beb3b9c57fa617d09110c79e977a9944750cd93fb17d82807a8c64c"
+  URL "https://archives.boost.io/release/1.91.0/source/boost_1_91_0.tar.bz2"
+  URL_HASH "SHA256=de5e6b0e4913395c6bdfa90537febd9028ea4c0735d2cdb0cd9b45d5f51264f5"
   TOUCH "${_download_stamp}"
 )
 
@@ -32,14 +32,14 @@ therock_cmake_subproject_declare(therock-boost
   OUTPUT_ON_FAILURE
   CMAKE_ARGS
     "-DBOOST_SOURCE_DIR=${_source_dir}"
-    "-DTHEROCK_BOOST_LIBRARIES=atomic,filesystem,multi_index,system"
+    "-DTHEROCK_BOOST_LIBRARIES=atomic,filesystem"
   EXTRA_DEPENDS
     "${_download_stamp}"
 )
 # Important: Version number here must match the version downloaded above.
 # Check the install directory if in doubt (i.e. run `ninja therock-boost` and
 # see what the install layout is).
-set(_boost_version 1.87.0)
+set(_boost_version 1.91.0)
 # Advertise the Boost meta package and each supported sub-library. Must be
 # kept in sync with above library list.
 therock_cmake_subproject_provide_package(therock-boost Boost "lib/cmake/Boost-${_boost_version}")


### PR DESCRIPTION
## Motivation

Attempting to build `TheRock` with the Visual Studio 2026 Build Tools installed will fail due to a lack of support in the Boost build system. Fixes #5146.

## Technical Details

Bumping the version of Boost to 1.91.0 where Visual Studio Build Tools 2026 is supported. Additionally the `multi_index` and `system` libraries have been removed from `THEROCK_BOOST_LIBRARIES` because they are header only libraries and the `--with-<library>` option with header only libraries is treated as an error.

## Test Plan

Built locally on Windows using the Visual Studio 2026 Build Tools. Build and test in TheRock ci for Windows and Linux to ensure no regressions occur.

## Test Result

Local build on Windows using the Visual Studio 2026 Build Tools was successful. Waiting for TheRock ci run approval and then TBD for the results.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
