### PR TITLE
Add flag THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS (default OFF) and propagate to sub projects.

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -214,7 +214,9 @@ jobs:
         env:
           amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
           package_version: ${{ needs.setup_metadata.outputs.version }}
-          extra_cmake_options: ''
+          # TODO: Use cmake_preset: linux-release-package once this workflow is
+          # wired to the release preset.
+          extra_cmake_options: '-DTHEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS=ON'
           cmake_preset: ''
         run: |
           python3 ./build_tools/github_actions/build_configure.py \

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,7 +18,8 @@
         "therock-SuiteSparse_BUILD_TYPE": "Release",
         "THEROCK_SPLIT_DEBUG_INFO": "ON",
         "THEROCK_MINIMAL_DEBUG_INFO": "ON",
-        "THEROCK_QUIET_INSTALL": "OFF"
+        "THEROCK_QUIET_INSTALL": "OFF",
+        "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
       }
     },
     {
@@ -46,7 +47,8 @@
         "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_CXX_FLAGS": "-g1",
         "CMAKE_C_FLAGS": "-g1",
-        "THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS": "OFF"
+        "THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS": "OFF",
+        "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
       }
     },
     {
@@ -71,7 +73,8 @@
         "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_CXX_FLAGS": "-g1",
-        "CMAKE_C_FLAGS": "-g1"
+        "CMAKE_C_FLAGS": "-g1",
+        "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
       }
     },
     {
@@ -96,7 +99,8 @@
         "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_CXX_FLAGS": "-g1",
-        "CMAKE_C_FLAGS": "-g1"
+        "CMAKE_C_FLAGS": "-g1",
+        "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
       }
     },
     {
@@ -129,7 +133,8 @@
       "displayName": "Windows release builds preset",
       "description": "Ninja generator, MSVC (cl.exe), x64 architecture, Release",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
+        "CMAKE_BUILD_TYPE": "Release",
+        "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
       },
       "inherits": [
         "windows-base"

--- a/FLAGS.cmake
+++ b/FLAGS.cmake
@@ -32,6 +32,14 @@ therock_declare_flag(
 )
 
 therock_declare_flag(
+  NAME STAMP_LIBRARY_GIT_VERSIONS
+  DEFAULT_VALUE OFF
+  DESCRIPTION "Stamp library git revisions into generated version metadata"
+  ISSUE https://github.com/ROCm/TheRock/issues/5009
+  GLOBAL_PROPAGATE_FLAG
+)
+
+therock_declare_flag(
   NAME INCLUDE_HRX
   DEFAULT_VALUE OFF
   DESCRIPTION "Include experimental HRX runtime in core-runtime"

--- a/cmake/therock_flag_utils.cmake
+++ b/cmake/therock_flag_utils.cmake
@@ -27,6 +27,9 @@ set_property(GLOBAL PROPERTY THEROCK_ALL_FLAGS)
 #   DEFAULT_VALUE  - ON or OFF
 #   DESCRIPTION    - Short description for the cache variable
 #   ISSUE          - (Optional) Tracking issue URL
+#   GLOBAL_PROPAGATE_FLAG
+#                  - Propagate THEROCK_FLAG_${NAME} to all sub-projects
+#                    regardless of whether the flag is enabled or disabled.
 #   GLOBAL_CMAKE_VARS   - (Optional) VAR=VALUE pairs set in super-project and
 #                          all sub-projects when the flag is enabled
 #   GLOBAL_CPP_DEFINES  - (Optional) Preprocessor defines for all sub-projects
@@ -39,7 +42,7 @@ set_property(GLOBAL PROPERTY THEROCK_ALL_FLAGS)
 #                          CMAKE_VARS and CPP_DEFINES
 function(therock_declare_flag)
   cmake_parse_arguments(PARSE_ARGV 0 ARG
-    ""
+    "GLOBAL_PROPAGATE_FLAG"
     "NAME;DEFAULT_VALUE;DESCRIPTION;ISSUE"
     "GLOBAL_CMAKE_VARS;GLOBAL_CPP_DEFINES;CMAKE_VARS;CPP_DEFINES;SUB_PROJECTS"
   )
@@ -77,6 +80,7 @@ function(therock_declare_flag)
   # Store flag metadata in global properties for later retrieval.
   set_property(GLOBAL PROPERTY _THEROCK_FLAG_${ARG_NAME}_DEFAULT_VALUE "${ARG_DEFAULT_VALUE}")
   set_property(GLOBAL PROPERTY _THEROCK_FLAG_${ARG_NAME}_DESCRIPTION "${ARG_DESCRIPTION}")
+  set_property(GLOBAL PROPERTY _THEROCK_FLAG_${ARG_NAME}_GLOBAL_PROPAGATE_FLAG "${ARG_GLOBAL_PROPAGATE_FLAG}")
   set_property(GLOBAL PROPERTY _THEROCK_FLAG_${ARG_NAME}_GLOBAL_CMAKE_VARS "${ARG_GLOBAL_CMAKE_VARS}")
   set_property(GLOBAL PROPERTY _THEROCK_FLAG_${ARG_NAME}_GLOBAL_CPP_DEFINES "${ARG_GLOBAL_CPP_DEFINES}")
   set_property(GLOBAL PROPERTY _THEROCK_FLAG_${ARG_NAME}_CMAKE_VARS "${ARG_CMAKE_VARS}")
@@ -134,8 +138,13 @@ function(therock_finalize_flags)
       list(APPEND _json_entries "\"${_flag_name}\": false")
     endif()
 
+    get_property(_global_propagate_flag GLOBAL PROPERTY _THEROCK_FLAG_${_flag_name}_GLOBAL_PROPAGATE_FLAG)
+    if(_global_propagate_flag)
+      set_property(GLOBAL APPEND PROPERTY THEROCK_DEFAULT_CMAKE_VARS THEROCK_FLAG_${_flag_name})
+    endif()
+
     if(NOT THEROCK_FLAG_${_flag_name})
-      continue()  # Flag is OFF, skip propagation processing.
+      continue()  # Flag is OFF, skip enabled-only propagation processing.
     endif()
 
     # Process GLOBAL_CMAKE_VARS: set in super-project and add to default vars list.

--- a/docs/development/flags.md
+++ b/docs/development/flags.md
@@ -31,18 +31,20 @@ cmake/therock_subproject.cmake   Injection via project_init.cmake
 
 ### Propagation Mechanism
 
-When a flag is enabled, its effects are injected into subprojects via the
-generated `project_init.cmake` files (the same mechanism used for
+Flag effects are injected into subprojects via the generated
+`project_init.cmake` files (the same mechanism used for
 `THEROCK_DEFAULT_CMAKE_VARS`):
 
+- **GLOBAL_PROPAGATE_FLAG**: Mirrors `THEROCK_FLAG_{NAME}` to **all**
+  subprojects, regardless of whether the flag is enabled or disabled.
 - **GLOBAL_CMAKE_VARS**: `VAR=VALUE` pairs set in the super-project and
-  propagated to **all** subprojects via `THEROCK_DEFAULT_CMAKE_VARS`.
+  propagated to **all** subprojects when the flag is enabled.
 - **GLOBAL_CPP_DEFINES**: Preprocessor defines added to **all** subprojects
-  via `add_compile_definitions()` in project_init.cmake.
+  when the flag is enabled via `add_compile_definitions()` in project_init.cmake.
 - **CMAKE_VARS**: `VAR=VALUE` pairs injected only into the listed
-  **SUB_PROJECTS** via `set(VAR VALUE CACHE STRING "" FORCE)`.
+  **SUB_PROJECTS** when the flag is enabled.
 - **CPP_DEFINES**: Preprocessor defines added only to the listed
-  **SUB_PROJECTS** via `add_compile_definitions()`.
+  **SUB_PROJECTS** when the flag is enabled via `add_compile_definitions()`.
 
 Structural concerns (conditional subproject inclusion, runtime dependency
 wiring) remain as explicit conditionals in the consuming CMakeLists.txt files.
@@ -67,17 +69,18 @@ therock_declare_flag(
 
 ### Parameters
 
-| Parameter            | Required | Description                                                                      |
-| -------------------- | -------- | -------------------------------------------------------------------------------- |
-| `NAME`               | Yes      | Unique identifier. Creates `THEROCK_FLAG_{NAME}` cache variable.                 |
-| `DEFAULT_VALUE`      | Yes      | `ON` or `OFF`.                                                                   |
-| `DESCRIPTION`        | Yes      | Short description shown in CMake cache UI.                                       |
-| `ISSUE`              | No       | Tracking issue URL.                                                              |
-| `GLOBAL_CMAKE_VARS`  | No       | `VAR=VALUE` pairs for all subprojects.                                           |
-| `GLOBAL_CPP_DEFINES` | No       | Preprocessor defines for all subprojects.                                        |
-| `CMAKE_VARS`         | No       | `VAR=VALUE` pairs for listed `SUB_PROJECTS` only.                                |
-| `CPP_DEFINES`        | No       | Preprocessor defines for listed `SUB_PROJECTS` only.                             |
-| `SUB_PROJECTS`       | No\*     | Target names for scoped `CMAKE_VARS`/`CPP_DEFINES`. \*Required if either is set. |
+| Parameter               | Required | Description                                                                      |
+| ----------------------- | -------- | -------------------------------------------------------------------------------- |
+| `NAME`                  | Yes      | Unique identifier. Creates `THEROCK_FLAG_{NAME}` cache variable.                 |
+| `DEFAULT_VALUE`         | Yes      | `ON` or `OFF`.                                                                   |
+| `DESCRIPTION`           | Yes      | Short description shown in CMake cache UI.                                       |
+| `ISSUE`                 | No       | Tracking issue URL.                                                              |
+| `GLOBAL_PROPAGATE_FLAG` | No       | Mirror `THEROCK_FLAG_{NAME}` to all subprojects whether enabled or disabled.     |
+| `GLOBAL_CMAKE_VARS`     | No       | `VAR=VALUE` pairs for all subprojects when enabled.                              |
+| `GLOBAL_CPP_DEFINES`    | No       | Preprocessor defines for all subprojects when enabled.                           |
+| `CMAKE_VARS`            | No       | `VAR=VALUE` pairs for listed `SUB_PROJECTS` only when enabled.                   |
+| `CPP_DEFINES`           | No       | Preprocessor defines for listed `SUB_PROJECTS` when enabled.                     |
+| `SUB_PROJECTS`          | No\*     | Target names for scoped `CMAKE_VARS`/`CPP_DEFINES`. \*Required if either is set. |
 
 ### Using a Flag in CMakeLists.txt
 
@@ -180,9 +183,10 @@ This is generated automatically: `therock_finalize_flags()` writes
 1. Add a `therock_declare_flag()` call in `FLAGS.cmake`.
 1. Use `THEROCK_FLAG_{NAME}` in the relevant CMakeLists.txt files for
    structural decisions (conditional subproject inclusion, dependency wiring).
-1. If the flag needs to set variables or defines in subprojects, use the
+1. If subprojects need the flag value itself, use `GLOBAL_PROPAGATE_FLAG`.
+   If the flag needs to set variables or defines only when enabled, use the
    `CMAKE_VARS`, `CPP_DEFINES`, `GLOBAL_CMAKE_VARS`, or `GLOBAL_CPP_DEFINES`
-   parameters to automate propagation.
+   parameters.
 1. Run cmake configure and verify the flag report output and, if applicable,
    inspect the generated `project_init.cmake` files.
 


### PR DESCRIPTION
* Adds THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS=OFF
* Configures release presets to enable it (manually for the linux workflow since it is not yet using the preset)
* Will mate with a corresponding change to clr to redact the git version when the flag is off.
* End result should be that developer builds, presubmits, and postsubmit workflows will cache correctly when HIP headers are included. Release behavior remains unchanged.

Progress on #5009
