### PR TITLE
workflow: shorten and reorder run names for multi-arch release (#4987)

### DIFF
--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -94,7 +94,7 @@ on:
           - ccache
         default: none
 
-run-name: Multi-Arch Release Linux PyTorch Wheels (${{ inputs.amdgpu_families }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
+run-name: Release PyTorch (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_families }})
 
 permissions:
   contents: read


### PR DESCRIPTION
The GPU targets list was placed at the front of the run name, causing overlap with the workflow name in GitHub UI. Move targets to the end and shorten the prefix.

Before: Multi-Arch Release Linux PyTorch Wheels (gfx94X-dcgpu;..., nightly, 7.x.x)
After:  Release PyTorch (nightly, 7.x.x, gfx94X-dcgpu;...)

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
