### PR TITLE
workflow: shorten and reorder run names for multi-arch release (#4987)

### DIFF
--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -94,7 +94,7 @@ on:
           - ccache
         default: none
 
-run-name: Multi-Arch Release Linux PyTorch Wheels (${{ inputs.amdgpu_families }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
+run-name: Release PyTorch (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_families }})
 
 permissions:
   contents: read


### PR DESCRIPTION
The GPU targets list was placed at the front of the run name, causing overlap with the workflow name in GitHub UI. Move targets to the end and shorten the prefix.

Before: Multi-Arch Release Linux PyTorch Wheels (gfx94X-dcgpu;..., nightly, 7.x.x)
After:  Release PyTorch (nightly, 7.x.x, gfx94X-dcgpu;...)
