### PR TITLE
workflows: shorten and reorder run_name format for (#4987)

### DIFF
--- a/.github/workflows/build_linux_jax_wheels.yml
+++ b/.github/workflows/build_linux_jax_wheels.yml
@@ -124,7 +124,7 @@ permissions:
   id-token: write
   contents: read
 
-run-name: Build Linux JAX Wheels (${{ inputs.amdgpu_family }}, ${{ inputs.python_version }}, ${{ inputs.release_type }})
+run-name: Build Linux JAX Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.amdgpu_family }})
 
 jobs:
   build_jax_wheels:

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -111,7 +111,7 @@ on:
           - ccache
         default: none
 
-run-name: Build portable Linux PyTorch Wheels (${{ inputs.amdgpu_family }}, ${{ inputs.python_version }}, ${{ inputs.release_type }})
+run-name: Build portable Linux PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.amdgpu_family }})
 
 jobs:
   build_pytorch_wheels:

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -111,6 +111,8 @@ on:
           - ccache
         default: none
 
+run-name: Build Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.amdgpu_family }})
+
 jobs:
   build_pytorch_wheels:
     name: Build | ${{ inputs.amdgpu_family }} | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_git_ref }}

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -94,7 +94,7 @@ on:
           - ccache
         default: none
 
-run-name: Multi-Arch Release Linux PyTorch Wheels (${{ inputs.amdgpu_families }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
+run-name: Release Linux PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_families }})
 
 permissions:
   contents: read

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -96,7 +96,7 @@ on:
           - ccache
         default: none
 
-run-name: Multi-Arch Release Windows PyTorch Wheels (${{ inputs.amdgpu_families }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
+run-name: Release Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_families }})
 
 permissions:
   contents: read

--- a/.github/workflows/release_portable_linux_jax_wheels.yml
+++ b/.github/workflows/release_portable_linux_jax_wheels.yml
@@ -94,7 +94,7 @@ permissions:
   contents: read
   packages: read
 
-run-name: Release portable Linux JAX Wheels (${{ inputs.amdgpu_family }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
+run-name: Release portable Linux JAX Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_family }})
 
 jobs:
   release:

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -65,7 +65,7 @@ on:
 permissions:
   contents: read
 
-run-name: Release portable Linux packages (${{ inputs.families || 'default' }}, ${{ inputs.release_type || 'nightly' }})
+run-name: Release portable Linux packages (${{ inputs.release_type || 'nightly' }}, ${{ inputs.families || 'default' }})
 
 jobs:
   setup_metadata:

--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -87,7 +87,7 @@ permissions:
   id-token: write
   contents: read
 
-run-name: Release portable Linux PyTorch Wheels (${{ inputs.amdgpu_family }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
+run-name: Release portable Linux PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_family }})
 
 jobs:
   release:

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -72,7 +72,7 @@ on:
 permissions:
   contents: read
 
-run-name: Release Windows packages (${{ inputs.families || 'default' }}, ${{ inputs.release_type || 'nightly' }})
+run-name: Release Windows packages (${{ inputs.release_type || 'nightly' }}, ${{ inputs.families || 'default' }})
 
 jobs:
   setup_metadata:

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -87,7 +87,7 @@ permissions:
   id-token: write
   contents: read
 
-run-name: Release Windows PyTorch Wheels (${{ inputs.amdgpu_family }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
+run-name: Release Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_family }})
 
 jobs:
   release:


### PR DESCRIPTION
The GPU targets list was placed at the front of the run name, causing overlap with the workflow name in GitHub UI. 

Move targets to the end and shorten the prefix.

Before: Multi-Arch Release Linux PyTorch Wheels (gfx94X-dcgpu;..., nightly, 7.x.x)
After: Release Linux PyTorch Wheels (nightly, 7.x.x, gfx94X-dcgpu;...)
