### PR TITLE
Add --include-intermediate-dirs flag to S3 index generator

### DIFF
--- a/build_tools/generate_s3_index.py
+++ b/build_tools/generate_s3_index.py
@@ -200,6 +200,24 @@ def _discover_dirs_with_files_s3(s3_client, bucket: str, run_prefix: str) -> lis
     return sorted(dirs)
 
 
+def _expand_with_intermediate_dirs(dirs: list[str], run_prefix: str) -> list[str]:
+    """Add every ancestor directory of each entry, up to and including run_prefix.
+
+    Without this, intermediate directories that contain only subdirectories
+    (e.g. ``<run>/logs/`` when only ``<run>/logs/<component>/`` has files)
+    have no index.html generated, so links from a parent index 404.
+    """
+    all_dirs: set[str] = set(dirs)
+    all_dirs.add(run_prefix)
+    for d in dirs:
+        while "/" in d and d != run_prefix:
+            d = d.rsplit("/", 1)[0]
+            all_dirs.add(d)
+            if d == run_prefix:
+                break
+    return sorted(all_dirs)
+
+
 # ---------------------------------------------------------------------------
 # Local listing helpers (for --output-dir mode)
 # ---------------------------------------------------------------------------
@@ -343,6 +361,14 @@ def run(args) -> None:
         log("[WARN] No directories with files found. Nothing to index.")
         return
 
+    if args.include_intermediate_dirs:
+        before = len(dirs)
+        dirs = _expand_with_intermediate_dirs(dirs, prefix)
+        log(
+            f"[INFO] Expanded {before} dirs with files to {len(dirs)} dirs "
+            f"including intermediate ancestors."
+        )
+
     log(f"[INFO] Found directories: {dirs}")
     for dir_prefix in dirs:
         log(f"\n[INFO] Generating index for: {dir_prefix}")
@@ -385,6 +411,15 @@ if __name__ == "__main__":
         "--dry-run",
         action="store_true",
         help="Print what would be uploaded without actually uploading",
+    )
+    parser.add_argument(
+        "--include-intermediate-dirs",
+        action="store_true",
+        help=(
+            "Also generate index.html for directories whose contents are "
+            "only subdirectories (no direct files). Without this, links to "
+            "such directories from a parent index 404."
+        ),
     )
     args = parser.parse_args()
     run(args)

--- a/build_tools/tests/generate_s3_index_test.py
+++ b/build_tools/tests/generate_s3_index_test.py
@@ -124,6 +124,65 @@ class TestDiscoverDirsWithFilesLocal(unittest.TestCase):
             self.assertEqual(dirs, [])
 
 
+class TestExpandWithIntermediateDirs(unittest.TestCase):
+    """Tests for _expand_with_intermediate_dirs()."""
+
+    def test_adds_intermediate_ancestors(self):
+        """Each ancestor of a deep dir is added, up to and including run_prefix."""
+        dirs = ["12345-linux/logs/math-libs/gfx908"]
+        expanded = generate_s3_index._expand_with_intermediate_dirs(dirs, "12345-linux")
+        self.assertEqual(
+            expanded,
+            [
+                "12345-linux",
+                "12345-linux/logs",
+                "12345-linux/logs/math-libs",
+                "12345-linux/logs/math-libs/gfx908",
+            ],
+        )
+
+    def test_dedupes_shared_ancestors(self):
+        """Sibling leaves share ancestors; expansion does not duplicate them."""
+        dirs = [
+            "12345-linux/logs/math-libs/gfx908",
+            "12345-linux/logs/math-libs/gfx90a",
+        ]
+        expanded = generate_s3_index._expand_with_intermediate_dirs(dirs, "12345-linux")
+        self.assertEqual(
+            expanded,
+            [
+                "12345-linux",
+                "12345-linux/logs",
+                "12345-linux/logs/math-libs",
+                "12345-linux/logs/math-libs/gfx908",
+                "12345-linux/logs/math-libs/gfx90a",
+            ],
+        )
+
+    def test_input_already_contains_ancestors(self):
+        """Already-present ancestors are not duplicated."""
+        dirs = [
+            "12345-linux",
+            "12345-linux/logs/math-libs/gfx908",
+        ]
+        expanded = generate_s3_index._expand_with_intermediate_dirs(dirs, "12345-linux")
+        self.assertEqual(len(expanded), len(set(expanded)))
+        self.assertIn("12345-linux/logs", expanded)
+        self.assertIn("12345-linux/logs/math-libs", expanded)
+
+    def test_run_prefix_always_included(self):
+        """The run_prefix itself is in the result even when no input contains files."""
+        expanded = generate_s3_index._expand_with_intermediate_dirs([], "12345-linux")
+        self.assertEqual(expanded, ["12345-linux"])
+
+    def test_dir_equal_to_run_prefix(self):
+        """A dir equal to run_prefix yields just the run_prefix (no spurious ancestors)."""
+        expanded = generate_s3_index._expand_with_intermediate_dirs(
+            ["12345-linux"], "12345-linux"
+        )
+        self.assertEqual(expanded, ["12345-linux"])
+
+
 class TestGenerateIndexHtml(unittest.TestCase):
     """Tests for _generate_index_html()."""
 


### PR DESCRIPTION
## Motivation

generate_s3_index.py only discovered directories that directly contain files. Directories whose contents were exclusively subdirectories (e.g. `<run>/logs/`, `<run>/logs/math-libs/`, `<run>/packages/deb/dists/`) had no index.html generated, so clicking through from a parent index 404s on the static-hosted bucket. While this is not an issue on server-side (as the lambda handler takes care), this is hit when executing the script manually.

## Technical Details

Add an opt-in `--include-intermediate-dirs` flag that expands the discovered set with all ancestors up to the run root. The existing `_list_files_s3` already lists` CommonPrefixes` correctly, so no listing-side change is needed.

## Test Plan and Results

Default behavior is unchanged. Verified against run 25528390694 (28 dirs without the flag, 36 with the flag, adding the 8 intermediate-only directories).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
