### PR TITLE
Drop `generate_flat_index`

### DIFF
--- a/build_tools/github_actions/upload_python_packages.py
+++ b/build_tools/github_actions/upload_python_packages.py
@@ -52,7 +52,7 @@ sys.path.insert(0, str(_BUILD_TOOLS_DIR / "packaging" / "python"))
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 from _therock_utils.storage_location import StorageLocation
 from _therock_utils.storage_backend import StorageBackend, create_storage_backend
-from generate_local_index import generate_flat_index, generate_multiarch_indexes
+from generate_local_index import generate_multiarch_indexes
 from github_actions_api import (
     gha_append_step_summary,
     gha_set_output,

--- a/build_tools/packaging/python/generate_local_index.py
+++ b/build_tools/packaging/python/generate_local_index.py
@@ -101,39 +101,6 @@ def generate_simple_index(
     )
 
 
-def generate_flat_index(dist_dir: Path, patterns: list[str] | None = None) -> None:
-    """Generate a single flat index.html for kpack-split builds.
-
-    In kpack-split mode all packages (core, libraries, device-per-target, devel,
-    meta) are placed directly in dist/ at the top level — there are no family
-    subdirectories. This function generates a single index.html covering all
-    top-level files so that pip --find-links can discover all wheels.
-
-    Only top-level files are scanned; subdirectories are ignored.
-
-    Args:
-        dist_dir: dist/ directory containing packages at the top level
-        patterns: File patterns to include (default: ["*.whl", "*.tar.gz"])
-    """
-    if patterns is None:
-        patterns = ["*.whl", "*.tar.gz"]
-
-    local_files = []
-    for pattern in patterns:
-        local_files.extend([f for f in dist_dir.glob(pattern) if f.is_file()])
-
-    print(
-        f"Generating flat index for kpack-split build: {len(local_files)} files in {dist_dir}"
-    )
-
-    generate_simple_index(
-        output_path=dist_dir / "index.html",
-        local_files=local_files,
-        parent_files=None,
-        title="ROCm Python Packages",
-    )
-
-
 def generate_multiarch_indexes(
     dist_dir: Path, patterns: list[str] | None = None
 ) -> None:

--- a/build_tools/packaging/tests/generate_local_index_test.py
+++ b/build_tools/packaging/tests/generate_local_index_test.py
@@ -19,7 +19,6 @@ from pathlib import Path
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent / "python"))
 
 from generate_local_index import (
-    generate_flat_index,
     generate_multiarch_indexes,
     generate_simple_index,
 )

--- a/build_tools/packaging/tests/generate_local_index_test.py
+++ b/build_tools/packaging/tests/generate_local_index_test.py
@@ -175,68 +175,6 @@ class TestGenerateSimpleIndex(unittest.TestCase):
             )
 
 
-class TestGenerateFlatIndex(unittest.TestCase):
-    """Tests for generate_flat_index()."""
-
-    def test_generates_top_level_index(self):
-        """Top-level wheels and sdists appear in index.html at dist/ root."""
-        with tempfile.TemporaryDirectory() as tmp:
-            dist_dir = Path(tmp)
-            (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
-            (dist_dir / "rocm_sdk_device_gfx942-1.0.whl").write_bytes(b"device")
-
-            generate_flat_index(dist_dir)
-
-            index = dist_dir / "index.html"
-            self.assertTrue(index.is_file())
-            content = index.read_text()
-            self.assertIn('<a href="./rocm_sdk_core-1.0.whl">', content)
-            self.assertIn('<a href="./rocm_sdk_device_gfx942-1.0.whl">', content)
-
-    def test_excludes_subdir_contents(self):
-        """Files inside subdirectories are not included in the flat index."""
-        with tempfile.TemporaryDirectory() as tmp:
-            dist_dir = Path(tmp)
-            (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
-            subdir = dist_dir / "gfx94X-dcgpu"
-            subdir.mkdir()
-            (subdir / "rocm_sdk_libraries_gfx94x_dcgpu-1.0.whl").write_bytes(b"libs")
-
-            generate_flat_index(dist_dir)
-
-            content = (dist_dir / "index.html").read_text()
-            self.assertIn("rocm_sdk_core-1.0.whl", content)
-            self.assertNotIn("rocm_sdk_libraries_gfx94x_dcgpu", content)
-
-    def test_custom_patterns(self):
-        """Only files matching the specified patterns are included."""
-        with tempfile.TemporaryDirectory() as tmp:
-            dist_dir = Path(tmp)
-            (dist_dir / "package.whl").write_bytes(b"whl")
-            (dist_dir / "package.tar.gz").write_bytes(b"sdist")
-            (dist_dir / "README.md").write_bytes(b"readme")
-
-            generate_flat_index(dist_dir, patterns=["*.whl"])
-
-            content = (dist_dir / "index.html").read_text()
-            self.assertIn("package.whl", content)
-            self.assertNotIn("package.tar.gz", content)
-            self.assertNotIn("README.md", content)
-
-    def test_empty_dist(self):
-        """Empty dist/ produces a valid index.html with no package links."""
-        with tempfile.TemporaryDirectory() as tmp:
-            dist_dir = Path(tmp)
-
-            generate_flat_index(dist_dir)
-
-            index = dist_dir / "index.html"
-            self.assertTrue(index.is_file())
-            content = index.read_text()
-            self.assertIn("<!DOCTYPE html>", content)
-            self.assertNotIn("<a href", content)
-
-
 class TestGenerateMultiarchIndexes(unittest.TestCase):
     """Tests for generate_multiarch_indexes()."""
 


### PR DESCRIPTION
Flat indexes for multi-arch, kpack-split enabled packages are generated server side via `generate_s3_index.py`. The function is no longer needed and can be dropped.