### PR TITLE
Bump configure-aws-credentials action to v6.1.1

### DIFF
--- a/.github/actions/configure_aws_artifacts_credentials/action.yml
+++ b/.github/actions/configure_aws_artifacts_credentials/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Configure AWS Credentials
       if: ${{ always() && steps.iam.outputs.iam_role != '' }}
-      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
       with:
         aws-region: ${{ steps.iam.outputs.aws_region }}
         role-to-assume: ${{ steps.iam.outputs.iam_role }}


### PR DESCRIPTION
Bumps aws-actions/configure-aws-credentials to v6.1.1, missed by the automation in #5151.