### PR TITLE
[rocprofiler-compute] Disable flaky GPU performance metric tests

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_compute.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_compute.py
@@ -17,6 +17,8 @@ ROCPROFILER_COMPUTE_DIRECTORY = THEROCK_PATH / "libexec" / "rocprofiler-compute"
 # Set up excluded tests
 EXCLUDED_TESTS = [
     "test_profile_live_attach_detach",
+    "test_metric_validation",
+    "test_L1_cache_counters",
 ]
 
 # quick Tests
@@ -25,10 +27,8 @@ QUICK_TESTS = [
     "test_utils",
     "test_num_xcds_cli_output",
     "test_num_xcds_spec_class",
-    "test_L1_cache_counters",
     "test_analyze_workloads",
     "test_analyze_commands",
-    "test_metric_validation",
     "test_profile_iteration_multiplexing_1",
 ]
 


### PR DESCRIPTION
## Summary
- Add `test_metric_validation` and `test_L1_cache_counters` to `EXCLUDED_TESTS` in the rocprofiler-compute test runner.
- Remove the same two tests from the `QUICK_TESTS` allowlist so the two lists stay consistent.

These tests assert GPU performance metrics which are unstable on CI machines with heavy GPU load, causing intermittent failures unrelated to the changes under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)