### PR TITLE
Fix RCCL to generate arch-specific artifacts in kpack mode

### DIFF
--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -226,6 +226,12 @@ def is_gfxarch_package(pkg_info, enable_kpack=False):
         if pkgname.endswith("-devel"):
             return False
 
+        # Override RCCL Gfxarch behavior in kpack mode
+        # When --enable-kpack is used, RCCL should look for architecture-specific artifacts
+        # instead of generic artifacts to ensure GPU-specific kernel support (e.g., gfx1201)
+        if pkgname in ["amdrocm-rccl", "amdrocm-rccl-test"]:
+            return True
+
     return is_key_defined(pkg_info, "Gfxarch")
 
 


### PR DESCRIPTION
 Fix RCCL packaging to match artifact generation in kpack mode

  RCCL has "Gfxarch": "False" in package.json, causing the packaging
  system to always look for generic artifacts. However, the build system
  generates:
  - Single-arch build: Generic artifacts (rccl_lib_generic)
  - Multi-arch build (--enable-kpack): Arch-specific artifacts (rccl_lib_gfx1201)

  This mismatch causes packaging to fail in kpack mode because it looks
  for "generic" artifacts that don't exist, while arch-specific artifacts
  (containing GPU kernels like gfx1201) are ignored. This results in
  packages without GPU-specific kernels, leading to "invalid device
  function" errors during multi-rank RCCL operations.

  The fix overrides RCCL's Gfxarch setting to True when enable_kpack is
  used, aligning the packaging logic with the artifact generation behavior.

  Fixes: ROCM-24110