### PR TITLE
 Adding Navi48 XLRC model to libdrm

### DIFF
--- a/third-party/sysdeps/linux/libdrm/patch_source.sh
+++ b/third-party/sysdeps/linux/libdrm/patch_source.sh
@@ -32,4 +32,6 @@ cat >> "$AMDGPU_IDS" << 'EOF'
 75B0,	00,	AMD Instinct MI350X VF
 75B3,	00,	AMD Instinct MI355X VF
 75A8,	00,	AMD Instinct MI350P
+7551,	C1,	AMD Radeon AI Pro R9700S
+7551,	C8,	AMD Radeon AI Pro R9600D
 EOF


### PR DESCRIPTION
 Adding Navi48 XLRC model to libdrm

## Motivation

rocminfo is not showing correct model without this 