### PR TITLE
[ci] Adding AWS production label

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -51,8 +51,8 @@ def select_weighted_label(labels_config: list[dict], context_name: str) -> str:
 BUILD_RUNNER_LABELS = {
     "linux": {
         "default": [
-            {"label": "azure-linux-scale-rocm", "weight": 1.0},
-            {"label": "aws-linux-scale-rocm", "weight": 0.0},
+            {"label": "azure-linux-scale-rocm", "weight": 0.9},
+            {"label": "aws-linux-scale-rocm-prod", "weight": 0.1},
         ],
         "sanitizer": [
             {"label": "azure-linux-scale-rocm-heavy-ramdisk", "weight": 1.0},

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1236,10 +1236,10 @@ class TestBuildRunnerSelection(unittest.TestCase):
         # Random >= 0.9 should select Azure
         with patch("random.random", return_value=0.95):
             self.assertEqual(
-                select_build_runner("linux", "release"), "azure-linux-scale-rocm"
+                select_build_runner("linux", "release"), "aws-linux-scale-rocm-prod"
             )
 
-        # Random >= 0.9 should select AWS
+        # Random >= 0.9 should select Azure
         with patch("random.random", return_value=0.95):
             self.assertEqual(
                 select_build_runner("windows", "release"), "azure-windows-scale-rocm"


### PR DESCRIPTION
From run here: https://github.com/ROCm/TheRock/actions/runs/25691136973/job/75427662531, the AWS label is working properly. 

We are going to implement the 10% label for AWS CPU build runners as we observe and continue to watch for errors / issues.
