### PR TITLE
Set CMake presets explicitly in CI/CD workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,9 @@ jobs:
       test_runs_on: ${{ matrix.variant.test-runs-on }}
       build_variant_label: ${{ matrix.variant.build_variant_label }}
       build_variant_suffix: ${{ matrix.variant.build_variant_suffix }}
-      build_variant_cmake_preset: ${{ matrix.variant.build_variant_cmake_preset }}
+      # TODO: Use linux-dev once capacity and rccl link issues are
+      # resolved. https://github.com/ROCm/TheRock/issues/1781
+      build_variant_cmake_preset: ""
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
       expect_failure: ${{ matrix.variant.expect_failure == true }}
@@ -134,7 +136,7 @@ jobs:
       test_runs_on: ${{ matrix.variant.test-runs-on }}
       build_variant_label: ${{ matrix.variant.build_variant_label }}
       build_variant_suffix: ${{ matrix.variant.build_variant_suffix }}
-      build_variant_cmake_preset: ${{ matrix.variant.build_variant_cmake_preset }}
+      build_variant_cmake_preset: "windows-dev"
       test_labels: ${{ needs.setup.outputs.windows_test_labels }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
       expect_failure: ${{ matrix.variant.expect_failure == true }}

--- a/.github/workflows/ci_asan.yml
+++ b/.github/workflows/ci_asan.yml
@@ -61,7 +61,7 @@ jobs:
       test_runs_on: ${{ matrix.variant.test-runs-on }}
       build_variant_label: ${{ matrix.variant.build_variant_label }}
       build_variant_suffix: ${{ matrix.variant.build_variant_suffix }}
-      build_variant_cmake_preset: ${{ matrix.variant.build_variant_cmake_preset }}
+      build_variant_cmake_preset: "linux-dev-asan"
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
       expect_failure: ${{ matrix.variant.expect_failure == true }}

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -86,7 +86,9 @@ jobs:
       run_extended_tests: ${{ needs.setup.outputs.run_extended_tests }}
       build_variant_label: ${{ matrix.variant.build_variant_label }}
       build_variant_suffix: ${{ matrix.variant.build_variant_suffix }}
-      build_variant_cmake_preset: ${{ matrix.variant.build_variant_cmake_preset }}
+      # TODO: Use linux-dev once capacity and rccl link issues are
+      # resolved. https://github.com/ROCm/TheRock/issues/1781
+      build_variant_cmake_preset: ""
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
       expect_failure: ${{ matrix.variant.expect_failure == true }}
@@ -121,7 +123,7 @@ jobs:
       run_extended_tests: ${{ needs.setup.outputs.run_extended_tests }}
       build_variant_label: ${{ matrix.variant.build_variant_label }}
       build_variant_suffix: ${{ matrix.variant.build_variant_suffix }}
-      build_variant_cmake_preset: ${{ matrix.variant.build_variant_cmake_preset }}
+      build_variant_cmake_preset: "windows-dev"
       test_labels: ${{ needs.setup.outputs.windows_test_labels }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
       expect_failure: ${{ matrix.variant.expect_failure == true }}

--- a/.github/workflows/ci_tsan.yml
+++ b/.github/workflows/ci_tsan.yml
@@ -62,7 +62,7 @@ jobs:
       test_runs_on: ${{ matrix.variant.test-runs-on }}
       build_variant_label: ${{ matrix.variant.build_variant_label }}
       build_variant_suffix: ${{ matrix.variant.build_variant_suffix }}
-      build_variant_cmake_preset: ${{ matrix.variant.build_variant_cmake_preset }}
+      build_variant_cmake_preset: "linux-dev-tsan"
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
       expect_failure: ${{ matrix.variant.expect_failure == true }}

--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -87,6 +87,9 @@ jobs:
     secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
+      # TODO: Use linux-dev once capacity and rccl link issues are resolved.
+      # https://github.com/ROCm/TheRock/issues/1781
+      cmake_preset: ""
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       rocm_deb_package_version: ${{ needs.setup.outputs.rocm_deb_package_version }}
@@ -108,6 +111,7 @@ jobs:
     secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.windows_build_config }}
+      cmake_preset: "windows-dev"
       test_labels: ${{ needs.setup.outputs.windows_test_labels }}
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}

--- a/.github/workflows/multi_arch_ci_asan.yml
+++ b/.github/workflows/multi_arch_ci_asan.yml
@@ -68,6 +68,7 @@ jobs:
     secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
+      cmake_preset: "linux-dev-asan"
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       rocm_deb_package_version: ${{ needs.setup.outputs.rocm_deb_package_version }}

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -14,6 +14,10 @@ on:
           build_variant_label, build_variant_cmake_preset,
           build_variant_suffix, expect_failure, build_pytorch,
           prebuilt_stages, baseline_run_id.
+      cmake_preset:
+        description: "CMake preset name (e.g. linux-dev, linux-release, linux-dev-asan)."
+        type: string
+        default: ""
       test_labels:
         type: string
       rocm_package_version:
@@ -92,7 +96,7 @@ jobs:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       build_variant_label: ${{ fromJSON(inputs.build_config).build_variant_label }}
-      build_variant_cmake_preset: ${{ fromJSON(inputs.build_config).build_variant_cmake_preset }}
+      build_variant_cmake_preset: ${{ inputs.cmake_preset }}
       build_variant_suffix: ${{ fromJSON(inputs.build_config).build_variant_suffix }}
       expect_failure: ${{ fromJSON(inputs.build_config).expect_failure }}
       prebuilt_stages: ${{ fromJSON(inputs.build_config).prebuilt_stages }}

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -11,8 +11,8 @@ on:
         description: >-
           JSON object with build configuration for this platform. Fields:
           artifact_group, per_family_info, dist_amdgpu_families,
-          build_variant_label, build_variant_cmake_preset,
-          build_variant_suffix, expect_failure, build_pytorch,
+          build_variant_label, build_variant_suffix,
+          expect_failure, build_pytorch,
           prebuilt_stages, baseline_run_id.
       cmake_preset:
         description: "CMake preset name (e.g. linux-dev, linux-release, linux-dev-asan)."

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -11,8 +11,8 @@ on:
         description: >-
           JSON object with build configuration for this platform. Fields:
           artifact_group, per_family_info, dist_amdgpu_families,
-          build_variant_label, build_variant_cmake_preset,
-          build_variant_suffix, expect_failure, build_pytorch,
+          build_variant_label, build_variant_suffix,
+          expect_failure, build_pytorch,
           prebuilt_stages, baseline_run_id.
       cmake_preset:
         description: "CMake preset name (e.g. windows-dev, windows-release)."

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -14,6 +14,10 @@ on:
           build_variant_label, build_variant_cmake_preset,
           build_variant_suffix, expect_failure, build_pytorch,
           prebuilt_stages, baseline_run_id.
+      cmake_preset:
+        description: "CMake preset name (e.g. windows-dev, windows-release)."
+        type: string
+        default: ""
       test_labels:
         type: string
       rocm_package_version:
@@ -91,7 +95,7 @@ jobs:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       build_variant_label: ${{ fromJSON(inputs.build_config).build_variant_label }}
-      build_variant_cmake_preset: ${{ fromJSON(inputs.build_config).build_variant_cmake_preset }}
+      build_variant_cmake_preset: ${{ inputs.cmake_preset }}
       build_variant_suffix: ${{ fromJSON(inputs.build_config).build_variant_suffix }}
       expect_failure: ${{ fromJSON(inputs.build_config).expect_failure }}
       prebuilt_stages: ${{ fromJSON(inputs.build_config).prebuilt_stages }}

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -94,7 +94,6 @@ jobs:
     secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
-      cmake_preset: "linux-release"
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       rocm_deb_package_version: ${{ needs.setup.outputs.rocm_deb_package_version }}
       rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
@@ -115,7 +114,6 @@ jobs:
     secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.windows_build_config }}
-      cmake_preset: "windows-release"
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
       release_type: ${{ inputs.release_type }}

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -94,6 +94,7 @@ jobs:
     secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
+      cmake_preset: "linux-release"
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       rocm_deb_package_version: ${{ needs.setup.outputs.rocm_deb_package_version }}
       rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
@@ -114,6 +115,7 @@ jobs:
     secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.windows_build_config }}
+      cmake_preset: "windows-release"
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
       release_type: ${{ inputs.release_type }}

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -9,6 +9,10 @@ on:
       build_config:
         type: string
         description: JSON object with build configuration for this platform.
+      cmake_preset:
+        description: "CMake preset name (e.g. linux-dev, linux-release)."
+        type: string
+        default: ""
       rocm_package_version:
         type: string
       rocm_deb_package_version:
@@ -43,7 +47,7 @@ jobs:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       build_variant_label: ${{ fromJSON(inputs.build_config).build_variant_label }}
-      build_variant_cmake_preset: ${{ fromJSON(inputs.build_config).build_variant_cmake_preset }}
+      build_variant_cmake_preset: ${{ inputs.cmake_preset }}
       build_variant_suffix: ${{ fromJSON(inputs.build_config).build_variant_suffix }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -9,10 +9,6 @@ on:
       build_config:
         type: string
         description: JSON object with build configuration for this platform.
-      cmake_preset:
-        description: "CMake preset name (e.g. linux-dev, linux-release)."
-        type: string
-        default: ""
       rocm_package_version:
         type: string
       rocm_deb_package_version:
@@ -47,7 +43,7 @@ jobs:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       build_variant_label: ${{ fromJSON(inputs.build_config).build_variant_label }}
-      build_variant_cmake_preset: ${{ inputs.cmake_preset }}
+      build_variant_cmake_preset: "linux-release"
       build_variant_suffix: ${{ fromJSON(inputs.build_config).build_variant_suffix }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -9,6 +9,10 @@ on:
       build_config:
         type: string
         description: JSON object with build configuration for this platform.
+      cmake_preset:
+        description: "CMake preset name (e.g. windows-dev, windows-release)."
+        type: string
+        default: ""
       rocm_package_version:
         type: string
       test_type:
@@ -37,7 +41,7 @@ jobs:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       build_variant_label: ${{ fromJSON(inputs.build_config).build_variant_label }}
-      build_variant_cmake_preset: ${{ fromJSON(inputs.build_config).build_variant_cmake_preset }}
+      build_variant_cmake_preset: ${{ inputs.cmake_preset }}
       build_variant_suffix: ${{ fromJSON(inputs.build_config).build_variant_suffix }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -9,10 +9,6 @@ on:
       build_config:
         type: string
         description: JSON object with build configuration for this platform.
-      cmake_preset:
-        description: "CMake preset name (e.g. windows-dev, windows-release)."
-        type: string
-        default: ""
       rocm_package_version:
         type: string
       test_type:
@@ -41,7 +37,7 @@ jobs:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       build_variant_label: ${{ fromJSON(inputs.build_config).build_variant_label }}
-      build_variant_cmake_preset: ${{ inputs.cmake_preset }}
+      build_variant_cmake_preset: "windows-release"
       build_variant_suffix: ${{ fromJSON(inputs.build_config).build_variant_suffix }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -214,7 +214,7 @@ jobs:
         env:
           amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
           package_version: ${{ needs.setup_metadata.outputs.version }}
-          # TODO: Use cmake_preset: linux-release-package once this workflow is
+          # TODO: Use cmake_preset: linux-release once this workflow is
           # wired to the release preset.
           extra_cmake_options: '-DTHEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS=ON'
           cmake_preset: ''

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,8 +7,8 @@
   },
   "configurePresets": [
     {
-      "name": "linux-release-package",
-      "displayName": "Linux release packages",
+      "name": "linux-base",
+      "displayName": "Linux base preset",
       "description": "Ninja generator, default compiler, RelWithDebInfo for most subprojects",
       "generator": "Ninja",
       "cacheVariables": {
@@ -18,9 +18,27 @@
         "therock-SuiteSparse_BUILD_TYPE": "Release",
         "THEROCK_SPLIT_DEBUG_INFO": "ON",
         "THEROCK_MINIMAL_DEBUG_INFO": "ON",
-        "THEROCK_QUIET_INSTALL": "OFF",
-        "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
+        "THEROCK_QUIET_INSTALL": "OFF"
       }
+    },
+    {
+      "name": "linux-dev",
+      "displayName": "Linux CI/development builds",
+      "description": "For CI and development builds (no git version stamping for ccache friendliness)",
+      "inherits": [
+        "linux-base"
+      ]
+    },
+    {
+      "name": "linux-release",
+      "displayName": "Linux release packages",
+      "description": "Extends linux-base with release-only flags (git version stamping)",
+      "cacheVariables": {
+        "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
+      },
+      "inherits": [
+        "linux-base"
+      ]
     },
     {
       "name": "linux-release-asan",
@@ -127,6 +145,17 @@
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       }
+    },
+    {
+      "name": "windows-dev",
+      "displayName": "Windows CI/development builds",
+      "description": "For CI and development builds (no git version stamping for ccache friendliness)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      },
+      "inherits": [
+        "windows-base"
+      ]
     },
     {
       "name": "windows-release",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,16 +33,16 @@
       "name": "linux-release",
       "displayName": "Linux release packages",
       "description": "Extends linux-base with release-only flags (git version stamping)",
-      "cacheVariables": {
-        "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
-      },
       "inherits": [
         "linux-base"
-      ]
+      ],
+      "cacheVariables": {
+        "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
+      }
     },
     {
-      "name": "linux-release-asan",
-      "displayName": "Linux release asan build",
+      "name": "linux-dev-asan",
+      "displayName": "Linux CI asan build",
       "description": "Ninja generator, default compiler, RelWithDebInfo and ASAN for most runtime subprojects",
       "generator": "Ninja",
       "cacheVariables": {
@@ -65,13 +65,23 @@
         "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_CXX_FLAGS": "-g1",
         "CMAKE_C_FLAGS": "-g1",
-        "THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS": "OFF",
+        "THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS": "OFF"
+      }
+    },
+    {
+      "name": "linux-release-asan",
+      "displayName": "Linux release asan build",
+      "description": "Extends linux-dev-asan with release-only flags (git version stamping)",
+      "inherits": [
+        "linux-dev-asan"
+      ],
+      "cacheVariables": {
         "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
       }
     },
     {
-      "name": "linux-release-host-asan",
-      "displayName": "Linux release host-only asan build",
+      "name": "linux-dev-host-asan",
+      "displayName": "Linux CI host-only asan build",
       "description": "Ninja generator, default compiler, RelWithDebInfo with host-side ASAN only (no device-side instrumentation)",
       "generator": "Ninja",
       "cacheVariables": {
@@ -91,13 +101,23 @@
         "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_CXX_FLAGS": "-g1",
-        "CMAKE_C_FLAGS": "-g1",
+        "CMAKE_C_FLAGS": "-g1"
+      }
+    },
+    {
+      "name": "linux-release-host-asan",
+      "displayName": "Linux release host-only asan build",
+      "description": "Extends linux-dev-host-asan with release-only flags (git version stamping)",
+      "inherits": [
+        "linux-dev-host-asan"
+      ],
+      "cacheVariables": {
         "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
       }
     },
     {
-      "name": "linux-release-tsan",
-      "displayName": "Linux release tsan build",
+      "name": "linux-dev-tsan",
+      "displayName": "Linux CI tsan build",
       "description": "Ninja generator, default compiler, RelWithDebInfo and TSAN for most runtime subprojects",
       "generator": "Ninja",
       "cacheVariables": {
@@ -117,7 +137,17 @@
         "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_CXX_FLAGS": "-g1",
-        "CMAKE_C_FLAGS": "-g1",
+        "CMAKE_C_FLAGS": "-g1"
+      }
+    },
+    {
+      "name": "linux-release-tsan",
+      "displayName": "Linux release tsan build",
+      "description": "Extends linux-dev-tsan with release-only flags (git version stamping)",
+      "inherits": [
+        "linux-dev-tsan"
+      ],
+      "cacheVariables": {
         "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
       }
     },
@@ -150,24 +180,24 @@
       "name": "windows-dev",
       "displayName": "Windows CI/development builds",
       "description": "For CI and development builds (no git version stamping for ccache friendliness)",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
-      },
       "inherits": [
         "windows-base"
-      ]
+      ],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
     },
     {
       "name": "windows-release",
       "displayName": "Windows release builds preset",
       "description": "Ninja generator, MSVC (cl.exe), x64 architecture, Release",
+      "inherits": [
+        "windows-base"
+      ],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
-      },
-      "inherits": [
-        "windows-base"
-      ]
+      }
     }
   ]
 }

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -91,27 +91,20 @@ all_build_variants = {
         "release": {
             "build_variant_label": "release",
             "build_variant_suffix": "",
-            # TODO: Enable linux-release-package once capacity and rccl link
-            # issues are resolved. https://github.com/ROCm/TheRock/issues/1781
-            # "build_variant_cmake_preset": "linux-release-package",
-            "build_variant_cmake_preset": "",
         },
         "asan": {
             "build_variant_label": "asan",
             "build_variant_suffix": "asan",
-            "build_variant_cmake_preset": "linux-release-asan",
         },
         "tsan": {
             "build_variant_label": "tsan",
             "build_variant_suffix": "tsan",
-            "build_variant_cmake_preset": "linux-release-tsan",
         },
     },
     "windows": {
         "release": {
             "build_variant_label": "release",
             "build_variant_suffix": "",
-            "build_variant_cmake_preset": "windows-release",
         },
     },
 }

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -425,7 +425,6 @@ class BuildConfig:
     artifact_group: str
     build_variant_label: str
     build_variant_suffix: str
-    build_variant_cmake_preset: str
     expect_failure: bool
     build_pytorch: bool
     # Build runner label for this platform/variant combination
@@ -924,7 +923,6 @@ def _expand_build_config_for_platform(
         artifact_group=f"multi-arch-{suffix or 'release'}",
         build_variant_label=variant_config["build_variant_label"],
         build_variant_suffix=suffix,
-        build_variant_cmake_preset=variant_config["build_variant_cmake_preset"],
         expect_failure=expect_failure,
         build_pytorch=not expect_failure and not expect_pytorch_failure,
         build_runs_on=build_runs_on,

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -707,7 +707,6 @@ class TestExpandBuildConfigs(unittest.TestCase):
             artifact_group="multi-arch-release",
             build_variant_label="release",
             build_variant_suffix="",
-            build_variant_cmake_preset="",
             expect_failure=False,
             build_pytorch=True,
         )
@@ -734,7 +733,6 @@ class TestExpandBuildConfigs(unittest.TestCase):
             artifact_group="multi-arch-release",
             build_variant_label="release",
             build_variant_suffix="",
-            build_variant_cmake_preset="release",
             expect_failure=False,
             build_pytorch=True,
         )


### PR DESCRIPTION
> [!IMPORTANT]
> See also https://github.com/ROCm/TheRock/pull/5192 as an alternate approach.

## Motivation

Follow-up to https://github.com/ROCm/TheRock/pull/5153#discussion_r3220301745

This aims to set the `THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS` flag value more consistently in our CI/CD workflows:
* Enabled in `linux-release` / `windows-release` presets, used by release (CD) workflows
* Disabled in `linux-dev` / `windows-dev` presets, used by CI workflows

## Technical Details

These workflows have been using a top level "build_variant" setting like `build_variant: "release"` which traced through `build_tools/github_actions/configure_multi_arch_ci.py` and `build_tools/github_actions/amdgpu_family_matrix.py` to compute a "build config".

The choice of cmake preset is fixed for a given workflow entry point, so we can instead be explicit upfront.

## Test Plan

Check presets used by CI, trigger a dev release build?

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
