### PR TITLE
Restructure CMake presets and "build_variant"s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
   setup:
     uses: ./.github/workflows/setup.yml
     with:
-      build_variant: "release"
+      build_variant: "ci"
 
   linux_build_and_test:
     name: Linux::${{ matrix.variant.family }}::${{ matrix.variant.build_variant_label }}

--- a/.github/workflows/ci_asan.yml
+++ b/.github/workflows/ci_asan.yml
@@ -39,7 +39,7 @@ jobs:
   setup:
     uses: ./.github/workflows/setup.yml
     with:
-      build_variant: "asan"
+      build_variant: "ci_asan"
 
   linux_build_and_test:
     name: Linux::${{ matrix.variant.family }}::${{ matrix.variant.build_variant_label }}

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -62,7 +62,7 @@ jobs:
   setup:
     uses: ./.github/workflows/setup.yml
     with:
-      build_variant: "release"
+      build_variant: "ci"
 
   linux_build_and_test:
     name: Linux::${{ matrix.variant.family }}::${{ matrix.variant.build_variant_label }}

--- a/.github/workflows/ci_tsan.yml
+++ b/.github/workflows/ci_tsan.yml
@@ -40,7 +40,7 @@ jobs:
   setup:
     uses: ./.github/workflows/setup.yml
     with:
-      build_variant: "tsan"
+      build_variant: "ci_tsan"
 
   linux_build_and_test:
     name: Linux::${{ matrix.variant.family }}::${{ matrix.variant.build_variant_label }}

--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -67,7 +67,7 @@ jobs:
   setup:
     uses: ./.github/workflows/setup_multi_arch.yml
     with:
-      build_variant: "release"
+      build_variant: "ci"
       linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || '' }}
       windows_amdgpu_families: ${{ inputs.windows_amdgpu_families || '' }}
       linux_test_labels: ${{ inputs.linux_test_labels || '' }}

--- a/.github/workflows/multi_arch_ci_asan.yml
+++ b/.github/workflows/multi_arch_ci_asan.yml
@@ -50,7 +50,7 @@ jobs:
   setup:
     uses: ./.github/workflows/setup_multi_arch.yml
     with:
-      build_variant: "asan"
+      build_variant: "ci_asan"
       linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || '' }}
       linux_test_labels: ${{ inputs.linux_test_labels || '' }}
       prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -214,7 +214,7 @@ jobs:
         env:
           amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
           package_version: ${{ needs.setup_metadata.outputs.version }}
-          # TODO: Use cmake_preset: linux-release-package once this workflow is
+          # TODO: Use cmake_preset: linux-release once this workflow is
           # wired to the release preset.
           extra_cmake_options: '-DTHEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS=ON'
           cmake_preset: ''

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,8 +7,8 @@
   },
   "configurePresets": [
     {
-      "name": "linux-release-package",
-      "displayName": "Linux release packages",
+      "name": "linux-base",
+      "displayName": "Linux base preset",
       "description": "Ninja generator, default compiler, RelWithDebInfo for most subprojects",
       "generator": "Ninja",
       "cacheVariables": {
@@ -18,9 +18,27 @@
         "therock-SuiteSparse_BUILD_TYPE": "Release",
         "THEROCK_SPLIT_DEBUG_INFO": "ON",
         "THEROCK_MINIMAL_DEBUG_INFO": "ON",
-        "THEROCK_QUIET_INSTALL": "OFF",
-        "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
+        "THEROCK_QUIET_INSTALL": "OFF"
       }
+    },
+    {
+      "name": "linux-dev",
+      "displayName": "Linux CI/development builds",
+      "description": "For CI and development builds (no git version stamping for ccache friendliness)",
+      "inherits": [
+        "linux-base"
+      ]
+    },
+    {
+      "name": "linux-release",
+      "displayName": "Linux release packages",
+      "description": "Extends linux-base with release-only flags (git version stamping)",
+      "cacheVariables": {
+        "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
+      },
+      "inherits": [
+        "linux-base"
+      ]
     },
     {
       "name": "linux-release-asan",
@@ -127,6 +145,17 @@
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       }
+    },
+    {
+      "name": "windows-dev",
+      "displayName": "Windows CI/development builds",
+      "description": "For CI and development builds (no git version stamping for ccache friendliness)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      },
+      "inherits": [
+        "windows-base"
+      ]
     },
     {
       "name": "windows-release",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,16 +33,16 @@
       "name": "linux-release",
       "displayName": "Linux release packages",
       "description": "Extends linux-base with release-only flags (git version stamping)",
-      "cacheVariables": {
-        "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
-      },
       "inherits": [
         "linux-base"
-      ]
+      ],
+      "cacheVariables": {
+        "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
+      }
     },
     {
-      "name": "linux-release-asan",
-      "displayName": "Linux release asan build",
+      "name": "linux-dev-asan",
+      "displayName": "Linux CI asan build",
       "description": "Ninja generator, default compiler, RelWithDebInfo and ASAN for most runtime subprojects",
       "generator": "Ninja",
       "cacheVariables": {
@@ -65,13 +65,23 @@
         "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_CXX_FLAGS": "-g1",
         "CMAKE_C_FLAGS": "-g1",
-        "THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS": "OFF",
+        "THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS": "OFF"
+      }
+    },
+    {
+      "name": "linux-release-asan",
+      "displayName": "Linux release asan build",
+      "description": "Extends linux-dev-asan with release-only flags (git version stamping)",
+      "inherits": [
+        "linux-dev-asan"
+      ],
+      "cacheVariables": {
         "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
       }
     },
     {
-      "name": "linux-release-host-asan",
-      "displayName": "Linux release host-only asan build",
+      "name": "linux-dev-host-asan",
+      "displayName": "Linux CI host-only asan build",
       "description": "Ninja generator, default compiler, RelWithDebInfo with host-side ASAN only (no device-side instrumentation)",
       "generator": "Ninja",
       "cacheVariables": {
@@ -91,13 +101,23 @@
         "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_CXX_FLAGS": "-g1",
-        "CMAKE_C_FLAGS": "-g1",
+        "CMAKE_C_FLAGS": "-g1"
+      }
+    },
+    {
+      "name": "linux-release-host-asan",
+      "displayName": "Linux release host-only asan build",
+      "description": "Extends linux-dev-host-asan with release-only flags (git version stamping)",
+      "inherits": [
+        "linux-dev-host-asan"
+      ],
+      "cacheVariables": {
         "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
       }
     },
     {
-      "name": "linux-release-tsan",
-      "displayName": "Linux release tsan build",
+      "name": "linux-dev-tsan",
+      "displayName": "Linux CI tsan build",
       "description": "Ninja generator, default compiler, RelWithDebInfo and TSAN for most runtime subprojects",
       "generator": "Ninja",
       "cacheVariables": {
@@ -117,7 +137,17 @@
         "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_CXX_FLAGS": "-g1",
-        "CMAKE_C_FLAGS": "-g1",
+        "CMAKE_C_FLAGS": "-g1"
+      }
+    },
+    {
+      "name": "linux-release-tsan",
+      "displayName": "Linux release tsan build",
+      "description": "Extends linux-dev-tsan with release-only flags (git version stamping)",
+      "inherits": [
+        "linux-dev-tsan"
+      ],
+      "cacheVariables": {
         "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
       }
     },
@@ -150,24 +180,24 @@
       "name": "windows-dev",
       "displayName": "Windows CI/development builds",
       "description": "For CI and development builds (no git version stamping for ccache friendliness)",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
-      },
       "inherits": [
         "windows-base"
-      ]
+      ],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
     },
     {
       "name": "windows-release",
       "displayName": "Windows release builds preset",
       "description": "Ninja generator, MSVC (cl.exe), x64 architecture, Release",
+      "inherits": [
+        "windows-base"
+      ],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
-      },
-      "inherits": [
-        "windows-base"
-      ]
+      }
     }
   ]
 }

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -88,26 +88,38 @@ def select_build_runner(platform: str, build_variant: str) -> str:
 
 all_build_variants = {
     "linux": {
+        "ci": {
+            "build_variant_label": "ci",
+            "build_variant_suffix": "",
+            # TODO: Enable linux-dev once capacity and rccl link
+            # issues are resolved. https://github.com/ROCm/TheRock/issues/1781
+            # "build_variant_cmake_preset": "linux-dev",
+            "build_variant_cmake_preset": "",
+        },
         "release": {
             "build_variant_label": "release",
             "build_variant_suffix": "",
-            # TODO: Enable linux-release-package once capacity and rccl link
-            # issues are resolved. https://github.com/ROCm/TheRock/issues/1781
-            # "build_variant_cmake_preset": "linux-release-package",
-            "build_variant_cmake_preset": "",
+            "build_variant_cmake_preset": "linux-release",
         },
-        "asan": {
+        "ci_asan": {
             "build_variant_label": "asan",
             "build_variant_suffix": "asan",
-            "build_variant_cmake_preset": "linux-release-asan",
+            "build_variant_cmake_preset": "linux-dev-asan",
+            "families": ["gfx94x", "gfx950"],
         },
-        "tsan": {
+        "ci_tsan": {
             "build_variant_label": "tsan",
             "build_variant_suffix": "tsan",
-            "build_variant_cmake_preset": "linux-release-tsan",
+            "build_variant_cmake_preset": "linux-dev-tsan",
+            "families": ["gfx94x", "gfx950"],
         },
     },
     "windows": {
+        "ci": {
+            "build_variant_label": "ci",
+            "build_variant_suffix": "",
+            "build_variant_cmake_preset": "windows-dev",
+        },
         "release": {
             "build_variant_label": "release",
             "build_variant_suffix": "",
@@ -129,7 +141,6 @@ amdgpu_family_info_matrix dictionary fields:
 - test-runs-on-kernel: (optional) dict of kernel-specific runner labels, keyed by kernel type (e.g. "oem")
 - family: (required) AMD GPU family name, used for test selection and artifact fetching
 - fetch-gfx-targets: (required) list of gfx targets to fetch split test artifacts for (e.g. ["gfx942", "gfx942:xnack+"])
-- build_variants: (optional) list of build variants to test for this architecture (e.g. ["release", "asan"])
 - bypass_tests_for_releases: (optional) if enabled, bypass tests for release builds (e.g. by skipping test steps in the workflow, or by not running tests on release builds in test scripts)
 - sanity_check_only_for_family: (optional) if enabled, only run sanity check tests for this architecture
 - run-full-tests-only: (optional) if enabled, only run full tests for this architecture
@@ -177,7 +188,6 @@ amdgpu_family_info_matrix_presubmit = {
             # Individual GPU target(s) on the test runner, for fetching split artifacts.
             # TODO(#3444): ASAN variants may need xnack suffix expansion (e.g. gfx942:xnack+).
             "fetch-gfx-targets": ["gfx942"],
-            "build_variants": ["release", "asan", "tsan"],
         }
     },
     "gfx110x": {
@@ -186,7 +196,6 @@ amdgpu_family_info_matrix_presubmit = {
             "family": "gfx110X-all",
             "fetch-gfx-targets": [],
             "bypass_tests_for_releases": True,
-            "build_variants": ["release"],
             "nightly_check_only_for_family": True,
         },
         "windows": {
@@ -194,7 +203,6 @@ amdgpu_family_info_matrix_presubmit = {
             "family": "gfx110X-all",
             "fetch-gfx-targets": ["gfx1100", "gfx1101", "gfx1102", "gfx1103"],
             "bypass_tests_for_releases": True,
-            "build_variants": ["release"],
         },
     },
     "gfx1151": {
@@ -206,7 +214,6 @@ amdgpu_family_info_matrix_presubmit = {
             "family": "gfx1151",
             "fetch-gfx-targets": ["gfx1151"],
             "bypass_tests_for_releases": True,
-            "build_variants": ["release"],
             "nightly_check_only_for_family": True,
         },
         "windows": {
@@ -215,7 +222,6 @@ amdgpu_family_info_matrix_presubmit = {
             "benchmark-runs-on": "windows-gfx1151-gpu-rocm",
             "family": "gfx1151",
             "fetch-gfx-targets": ["gfx1151"],
-            "build_variants": ["release"],
             # TODO(#3299): Re-enable quick tests once capacity is available for Windows gfx1151
             "nightly_check_only_for_family": True,
         },
@@ -226,7 +232,6 @@ amdgpu_family_info_matrix_presubmit = {
             "family": "gfx120X-all",
             "fetch-gfx-targets": ["gfx1200", "gfx1201"],
             "bypass_tests_for_releases": True,
-            "build_variants": ["release"],
             "nightly_check_only_for_family": True,
         },
         "windows": {
@@ -234,7 +239,6 @@ amdgpu_family_info_matrix_presubmit = {
             "family": "gfx120X-all",
             "fetch-gfx-targets": ["gfx1200", "gfx1201"],
             "bypass_tests_for_releases": True,
-            "build_variants": ["release"],
             "nightly_check_only_for_family": True,
         },
     },
@@ -248,7 +252,6 @@ amdgpu_family_info_matrix_postsubmit = {
             "test-runs-on-multi-gpu": "linux-gfx950-8gpu-ccs-ossci-rocm",
             "family": "gfx950-dcgpu",
             "fetch-gfx-targets": ["gfx950"],
-            "build_variants": ["release", "asan", "tsan"],
         }
     },
 }
@@ -262,13 +265,11 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx900",
             "fetch-gfx-targets": [],
             "sanity_check_only_for_family": True,
-            "build_variants": ["release"],
         },
         "windows": {
             "test-runs-on": "",
             "family": "gfx900",
             "fetch-gfx-targets": [],
-            "build_variants": ["release"],
         },
     },
     # gfx906/908/90a split into separate families - each has different instruction
@@ -280,14 +281,12 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx906",
             "fetch-gfx-targets": [],
             "sanity_check_only_for_family": True,
-            "build_variants": ["release"],
         },
         # TODO(#1927): Resolve error generating file `torch_hip_generated_int4mm.hip.obj`, to enable PyTorch builds
         "windows": {
             "test-runs-on": "",
             "family": "gfx906",
             "fetch-gfx-targets": [],
-            "build_variants": ["release"],
         },
     },
     "gfx908": {
@@ -297,13 +296,11 @@ amdgpu_family_info_matrix_nightly = {
             "family": "gfx908",
             "fetch-gfx-targets": [],
             "sanity_check_only_for_family": True,
-            "build_variants": ["release"],
         },
         "windows": {
             "test-runs-on": "",
             "family": "gfx908",
             "fetch-gfx-targets": [],
-            "build_variants": ["release"],
         },
     },
     "gfx90a": {
@@ -311,14 +308,12 @@ amdgpu_family_info_matrix_nightly = {
             "test-runs-on": "linux-gfx90a-gpu-rocm",
             "family": "gfx90a",
             "fetch-gfx-targets": ["gfx90a"],
-            "build_variants": ["release"],
             "nightly_check_only_for_family": True,
         },
         "windows": {
             "test-runs-on": "",
             "family": "gfx90a",
             "fetch-gfx-targets": [],
-            "build_variants": ["release"],
         },
     },
     "gfx101x": {
@@ -326,13 +321,11 @@ amdgpu_family_info_matrix_nightly = {
             "test-runs-on": "",
             "family": "gfx101X-dgpu",
             "fetch-gfx-targets": [],
-            "build_variants": ["release"],
         },
         "windows": {
             "test-runs-on": "",
             "family": "gfx101X-dgpu",
             "fetch-gfx-targets": [],
-            "build_variants": ["release"],
         },
     },
     "gfx103x": {
@@ -340,14 +333,12 @@ amdgpu_family_info_matrix_nightly = {
             "test-runs-on": "linux-gfx1030-gpu-rocm",
             "family": "gfx103X-all",
             "fetch-gfx-targets": ["gfx1030"],
-            "build_variants": ["release"],
             "nightly_check_only_for_family": True,
         },
         "windows": {
             "test-runs-on": "windows-gfx1030-gpu-rocm",
             "family": "gfx103X-all",
             "fetch-gfx-targets": [],
-            "build_variants": ["release"],
             "nightly_check_only_for_family": True,
         },
     },
@@ -356,14 +347,12 @@ amdgpu_family_info_matrix_nightly = {
             "test-runs-on": "linux-gfx1150-gpu-rocm",
             "family": "gfx1150",
             "fetch-gfx-targets": [],
-            "build_variants": ["release"],
             "nightly_check_only_for_family": True,
         },
         "windows": {
             "test-runs-on": "",
             "family": "gfx1150",
             "fetch-gfx-targets": [],
-            "build_variants": ["release"],
         },
     },
     "gfx1152": {
@@ -371,13 +360,11 @@ amdgpu_family_info_matrix_nightly = {
             "test-runs-on": "",
             "family": "gfx1152",
             "fetch-gfx-targets": [],
-            "build_variants": ["release"],
         },
         "windows": {
             "test-runs-on": "",
             "family": "gfx1152",
             "fetch-gfx-targets": [],
-            "build_variants": ["release"],
         },
     },
     "gfx1153": {
@@ -385,14 +372,12 @@ amdgpu_family_info_matrix_nightly = {
             "test-runs-on": "linux-gfx1153-gpu-rocm",
             "family": "gfx1153",
             "fetch-gfx-targets": [],
-            "build_variants": ["release"],
             "nightly_check_only_for_family": True,
         },
         "windows": {
             "test-runs-on": "",
             "family": "gfx1153",
             "fetch-gfx-targets": [],
-            "build_variants": ["release"],
         },
     },
 }

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -363,104 +363,96 @@ def matrix_generator(
             platform_info = platform_set.get(platform)
             assert isinstance(platform_info, dict)
 
-            # Further expand it based on build_variant.
-            build_variant_names = platform_info.get("build_variants")
-            assert isinstance(
-                build_variant_names, list
-            ), f"Expected 'build_variant' in platform: {platform_info}"
-            for build_variant_name in build_variant_names:
-                # We have custom build variants for specific CI flows.
-                # For CI, we use the release build variant (for PRs, pushes to main, nightlies)
-                # For CI ASAN/TSAN, we use the ASAN/TSAN build variant (for pushes to main)
-                # In the case that the build variant is not requested, we skip it
-                if build_variant_name != base_args.get("build_variant"):
-                    continue
+            # Look up the requested build variant and check the family
+            # allow-list. Variants without a "families" key apply to all
+            # families; variants with one only apply to listed families.
+            build_variant_name = base_args.get("build_variant")
+            build_variant_info = platform_build_variants.get(build_variant_name)
+            if not build_variant_info:
+                continue
+            allowed_families = build_variant_info.get("families")
+            if allowed_families is not None and target_name not in allowed_families:
+                continue
 
-                # Merge platform_info and build_variant_info into a matrix_row.
-                matrix_row = dict(platform_info)
+            # Merge platform_info and build_variant_info into a matrix_row.
+            matrix_row = dict(platform_info)
 
-                build_variant_info = platform_build_variants.get(build_variant_name)
-                assert isinstance(
-                    build_variant_info, dict
-                ), f"Expected {build_variant_name} in {platform_build_variants} for {platform_info}"
+            # If the build variant level notes expect_failure, set it on the overall row.
+            # But if not, honor what is already there.
+            if build_variant_info.get("expect_failure", False):
+                matrix_row["expect_failure"] = True
 
-                # If the build variant level notes expect_failure, set it on the overall row.
-                # But if not, honor what is already there.
-                if build_variant_info.get("expect_failure", False):
-                    matrix_row["expect_failure"] = True
+            # Enable pytorch builds for families without known build failures.
+            # TODO(#3291): Add finer-grained controls over when pytorch is built
+            expect_failure = matrix_row.get("expect_failure", False)
+            expect_pytorch_failure = matrix_row.get("expect_pytorch_failure", False)
+            matrix_row["build_pytorch"] = (
+                not expect_failure and not expect_pytorch_failure
+            )
 
-                # Enable pytorch builds for families without known build failures.
-                # TODO(#3291): Add finer-grained controls over when pytorch is built
-                expect_failure = matrix_row.get("expect_failure", False)
-                expect_pytorch_failure = matrix_row.get("expect_pytorch_failure", False)
-                matrix_row["build_pytorch"] = (
-                    not expect_failure and not expect_pytorch_failure
+            matrix_row.update(build_variant_info)
+
+            # Assign a computed "artifact_group" combining the family and variant.
+            artifact_group = platform_info["family"]
+            build_variant_suffix = build_variant_info["build_variant_suffix"]
+            if build_variant_suffix:
+                artifact_group += f"-{build_variant_suffix}"
+            matrix_row["artifact_group"] = artifact_group
+
+            # Handle multi-label configuration with weighted random selection.
+            # Some families (e.g. gfx94x) have multiple runner labels available.
+            if "test-runs-on-labels" in platform_info:
+                matrix_row["test-runs-on"] = select_weighted_label(
+                    platform_info["test-runs-on-labels"], target_name
+                )
+            if "test-runs-on-multi-gpu-labels" in platform_info:
+                matrix_row["test-runs-on-multi-gpu"] = select_weighted_label(
+                    platform_info["test-runs-on-multi-gpu-labels"],
+                    f"{target_name} (multi-gpu)",
                 )
 
-                del matrix_row["build_variants"]
-                matrix_row.update(build_variant_info)
+            # We retrieve labels from both PR and workflow_dispatch to customize the build and test jobs
+            label_options = []
+            label_options.extend(get_pr_labels(base_args))
+            label_options.extend(
+                get_workflow_dispatch_additional_label_options(base_args)
+            )
+            for label in label_options:
+                # If a specific test kernel type was specified, we use that kernel-enabled test runners
+                # We disable the other machines that do not have the specified kernel type
+                # If a kernel test label was added, we set the test-runs-on accordingly to kernel-specific test machines
+                if "test_runner" in label:
+                    _, kernel_type = label.split(":")
+                    # If the architecture has a valid kernel machine, we set it here
+                    if (
+                        "test-runs-on-kernel" in platform_info
+                        and kernel_type in platform_info["test-runs-on-kernel"]
+                    ):
+                        matrix_row["test-runs-on"] = platform_info[
+                            "test-runs-on-kernel"
+                        ][kernel_type]
+                    # Otherwise, we disable the test runner for this architecture
+                    else:
+                        matrix_row["test-runs-on"] = ""
+                        if "test-runs-on-multi-gpu" in platform_info:
+                            matrix_row["test-runs-on-multi-gpu"] = ""
+                    break
 
-                # Assign a computed "artifact_group" combining the family and variant.
-                artifact_group = platform_info["family"]
-                build_variant_suffix = build_variant_info["build_variant_suffix"]
-                if build_variant_suffix:
-                    artifact_group += f"-{build_variant_suffix}"
-                matrix_row["artifact_group"] = artifact_group
+            # TODO(#3433): Remove sandbox logic once ASAN tests are passing and environment is no longer required
+            # To avoid impact on the production environment, we use the custom sandbox runners if this is an ASAN test run
+            if (
+                "asan" in base_args.get("build_variant")
+                and "test-runs-on-sandbox" in matrix_row
+            ):
+                matrix_row["test-runs-on"] = matrix_row["test-runs-on-sandbox"]
 
-                # Handle multi-label configuration with weighted random selection.
-                # Some families (e.g. gfx94x) have multiple runner labels available.
-                if "test-runs-on-labels" in platform_info:
-                    matrix_row["test-runs-on"] = select_weighted_label(
-                        platform_info["test-runs-on-labels"], target_name
-                    )
-                if "test-runs-on-multi-gpu-labels" in platform_info:
-                    matrix_row["test-runs-on-multi-gpu"] = select_weighted_label(
-                        platform_info["test-runs-on-multi-gpu-labels"],
-                        f"{target_name} (multi-gpu)",
-                    )
+            # Select build runner using weighted distribution (90% Azure, 10% AWS)
+            # Sanitizer builds use ramdisk variants
+            matrix_row["build-runs-on"] = select_build_runner(
+                platform, base_args.get("build_variant", "ci")
+            )
 
-                # We retrieve labels from both PR and workflow_dispatch to customize the build and test jobs
-                label_options = []
-                label_options.extend(get_pr_labels(base_args))
-                label_options.extend(
-                    get_workflow_dispatch_additional_label_options(base_args)
-                )
-                for label in label_options:
-                    # If a specific test kernel type was specified, we use that kernel-enabled test runners
-                    # We disable the other machines that do not have the specified kernel type
-                    # If a kernel test label was added, we set the test-runs-on accordingly to kernel-specific test machines
-                    if "test_runner" in label:
-                        _, kernel_type = label.split(":")
-                        # If the architecture has a valid kernel machine, we set it here
-                        if (
-                            "test-runs-on-kernel" in platform_info
-                            and kernel_type in platform_info["test-runs-on-kernel"]
-                        ):
-                            matrix_row["test-runs-on"] = platform_info[
-                                "test-runs-on-kernel"
-                            ][kernel_type]
-                        # Otherwise, we disable the test runner for this architecture
-                        else:
-                            matrix_row["test-runs-on"] = ""
-                            if "test-runs-on-multi-gpu" in platform_info:
-                                matrix_row["test-runs-on-multi-gpu"] = ""
-                        break
-
-                # TODO(#3433): Remove sandbox logic once ASAN tests are passing and environment is no longer required
-                # To avoid impact on the production environment, we use the custom sandbox runners if this is an ASAN test run
-                if (
-                    "asan" in base_args.get("build_variant")
-                    and "test-runs-on-sandbox" in matrix_row
-                ):
-                    matrix_row["test-runs-on"] = matrix_row["test-runs-on-sandbox"]
-
-                # Select build runner using weighted distribution (90% Azure, 10% AWS)
-                # Sanitizer builds use ramdisk variants
-                matrix_row["build-runs-on"] = select_build_runner(
-                    platform, base_args.get("build_variant", "release")
-                )
-
-                matrix_output.append(matrix_row)
+            matrix_output.append(matrix_row)
 
     print(f"Generated build matrix: {str(matrix_output)}")
     print(f"Generated test list: {str(unique_test_names)}")
@@ -697,6 +689,6 @@ if __name__ == "__main__":
     base_args["workflow_dispatch_additional_label_options"] = os.getenv(
         "ADDITIONAL_LABEL_OPTIONS", ""
     )
-    base_args["build_variant"] = os.getenv("BUILD_VARIANT", "release")
+    base_args["build_variant"] = os.getenv("BUILD_VARIANT", "ci")
 
     main(base_args, linux_families, windows_families)

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -128,7 +128,7 @@ class CIInputs:
     event_name: str  # GITHUB_EVENT_NAME value (e.g. "push", "pull_request", "schedule", "workflow_dispatch")
     commit_ref: str  # GITHUB_REF_NAME value
     base_ref: str  # Git ref for the workflow run (PR base or HEAD^1, used for diffing)
-    build_variant: str  # Build variant label, e.g. "release", "asan", "tsan"
+    build_variant: str  # Build variant key, e.g. "ci", "release", "ci_asan", "ci_tsan"
     release_type: str = ""  # "" for CI, or "dev", "nightly", "prerelease" for releases
 
     # PR labels (from event payload for pull_request events)
@@ -179,7 +179,7 @@ class CIInputs:
         # Workflow inputs are passed as environment variables by
         # setup_multi_arch.yml. GitHub-specific context (PR labels,
         # push before-commit) comes from the event payload.
-        build_variant = os.environ.get("BUILD_VARIANT", "release")
+        build_variant = os.environ.get("BUILD_VARIANT", "ci")
         release_type = os.environ.get("RELEASE_TYPE", "")
 
         pr_labels: list[str] = []
@@ -508,7 +508,7 @@ def should_skip_ci(
     #       If overly expensive, remove that option
     if (
         ci_inputs.is_pull_request
-        and ci_inputs.build_variant == "asan"
+        and ci_inputs.build_variant == "ci_asan"
         and git_context.changed_files is not None
         and git_context.submodule_paths is not None
     ):
@@ -828,11 +828,14 @@ def _expand_build_config_for_platform(
         # amdgpu_family_matrix_test.py. We can index directly here.
         platform_info = all_families[family_name][platform]
 
-        # Filter out families missing the build variant (e.g. 'asan').
-        if build_variant not in platform_info["build_variants"]:
+        # Filter families by the variant's allow-list. Variants without a
+        # "families" key apply to all families (e.g. ci, release). Variants
+        # with a "families" key only apply to listed families (e.g. ci_asan).
+        allowed_families = variant_config.get("families")
+        if allowed_families is not None and family_name not in allowed_families:
             print(
-                f"  Family {family_name} does not support variant "
-                f"{build_variant} on {platform}, skipping"
+                f"  Family {family_name} not in {build_variant} allow-list, "
+                f"skipping"
             )
             continue
 
@@ -866,7 +869,7 @@ def _expand_build_config_for_platform(
 
         # TODO(#3433): Remove sandbox logic once ASAN tests are passing
         # For ASAN builds, use sandbox runner to avoid impacting production
-        if build_variant == "asan":
+        if build_variant == "ci_asan":
             if "test-runs-on-sandbox" in platform_info:
                 test_runs_on = platform_info["test-runs-on-sandbox"]
                 print(f"  {family_name}: using ASAN sandbox runner: {test_runs_on}")

--- a/build_tools/github_actions/tests/amdgpu_family_matrix_test.py
+++ b/build_tools/github_actions/tests/amdgpu_family_matrix_test.py
@@ -42,7 +42,7 @@ class TestFamilyMatrixInvariants(unittest.TestCase):
 
     def test_required_fields_present(self):
         """Every platform entry must have the required fields."""
-        required = {"family", "fetch-gfx-targets", "test-runs-on", "build_variants"}
+        required = {"family", "fetch-gfx-targets", "test-runs-on"}
         for target_name, entry in ALL_FAMILIES.items():
             for platform in ("linux", "windows"):
                 if platform not in entry:
@@ -54,15 +54,22 @@ class TestFamilyMatrixInvariants(unittest.TestCase):
                         f"{target_name}/{platform} missing required fields: {missing}"
                     )
 
-    def test_build_variants_non_empty(self):
-        """Every platform entry must list at least one build variant."""
-        for target_name, entry in ALL_FAMILIES.items():
-            for platform in ("linux", "windows"):
-                if platform not in entry:
+    def test_variant_families_exist(self):
+        """Every family in a variant's allow-list must exist in the matrix."""
+        from amdgpu_family_matrix import all_build_variants
+
+        all_family_names = set(ALL_FAMILIES.keys())
+        for platform, variants in all_build_variants.items():
+            for variant_name, variant_config in variants.items():
+                allowed = variant_config.get("families")
+                if allowed is None:
                     continue
-                variants = entry[platform].get("build_variants", [])
-                if not variants:
-                    self.fail(f"{target_name}/{platform} has empty build_variants")
+                for family in allowed:
+                    if family not in all_family_names:
+                        self.fail(
+                            f"Variant {variant_name} on {platform} references "
+                            f"unknown family {family!r}"
+                        )
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -510,7 +510,7 @@ class ConfigureCITest(unittest.TestCase):
 
     # TODO(#3433): Remove sandbox logic once ASAN tests are passing and environment is no longer required
     def test_sandbox_test_runner_with_asan(self):
-        base_args = {"build_variant": "asan"}
+        base_args = {"build_variant": "ci_asan"}
         build_families = {"amdgpu_families": "gfx94X"}
         linux_target_output, linux_test_labels = configure_ci.matrix_generator(
             is_pull_request=True,

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -35,7 +35,7 @@ def _run_from_environ(
     event_payload: dict,
     *,
     commit_ref: str = "main",
-    build_variant: str = "release",
+    build_variant: str = "ci",
     extra_env: dict[str, str] | None = None,
 ) -> cm.CIInputs:
     """Call CIInputs.from_environ() with a synthetic event payload.
@@ -84,7 +84,7 @@ class TestCIInputs(unittest.TestCase):
             event_name="pull_request",
             commit_ref="feature",
             base_ref="HEAD^",
-            build_variant="release",
+            build_variant="ci",
         )
         self.assertTrue(inputs.is_pull_request)
         self.assertFalse(inputs.is_push)
@@ -98,7 +98,7 @@ class TestCIInputs(unittest.TestCase):
             event_name="push",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
         )
         self.assertEqual(inputs.pr_labels, [])
         self.assertEqual(inputs.linux_amdgpu_families, [])
@@ -198,7 +198,7 @@ class TestShouldSkipCI(unittest.TestCase):
             event_name="pull_request",
             commit_ref="feature",
             base_ref="HEAD^",
-            build_variant="release",
+            build_variant="ci",
         )
         defaults.update(kwargs)
         return cm.CIInputs(**defaults)
@@ -240,7 +240,7 @@ class TestShouldSkipCI(unittest.TestCase):
 
     def test_asan_pr_without_submodule_change_skips(self):
         """ASAN PR without submodule changes skips CI."""
-        inputs = self._inputs(build_variant="asan", pr_labels=[])
+        inputs = self._inputs(build_variant="ci_asan", pr_labels=[])
         git = cm.GitContext(
             changed_files=["CMakeLists.txt", "build_tools/script.py"],
             submodule_paths=["rocm-libraries", "rocm-systems"],
@@ -249,7 +249,7 @@ class TestShouldSkipCI(unittest.TestCase):
 
     def test_asan_pr_with_submodule_change_runs(self):
         """ASAN PR with submodule changes runs CI."""
-        inputs = self._inputs(build_variant="asan", pr_labels=[])
+        inputs = self._inputs(build_variant="ci_asan", pr_labels=[])
         git = cm.GitContext(
             changed_files=["rocm-libraries", "CMakeLists.txt"],
             submodule_paths=["rocm-libraries", "rocm-systems"],
@@ -258,7 +258,7 @@ class TestShouldSkipCI(unittest.TestCase):
 
     def test_asan_non_pr_runs_regardless_of_submodule(self):
         """ASAN on schedule/push runs regardless of submodule changes."""
-        inputs = self._inputs(event_name="schedule", build_variant="asan")
+        inputs = self._inputs(event_name="schedule", build_variant="ci_asan")
         git = cm.GitContext(
             changed_files=None,
             submodule_paths=["rocm-libraries"],
@@ -267,7 +267,7 @@ class TestShouldSkipCI(unittest.TestCase):
 
     def test_release_pr_without_submodule_change_runs(self):
         """Release variant PR without submodule changes still runs (not skipped)."""
-        inputs = self._inputs(build_variant="release", pr_labels=[])
+        inputs = self._inputs(build_variant="ci", pr_labels=[])
         git = cm.GitContext(
             changed_files=["CMakeLists.txt"],
             submodule_paths=["rocm-libraries"],
@@ -289,7 +289,7 @@ class TestDecideJobs(unittest.TestCase):
             event_name="pull_request",
             commit_ref="feature",
             base_ref="HEAD^",
-            build_variant="release",
+            build_variant="ci",
         )
         defaults.update(kwargs)
         return cm.CIInputs(**defaults)
@@ -434,7 +434,7 @@ class TestSelectTargets(unittest.TestCase):
             event_name="push",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
         )
         result = cm.select_targets(inputs)
         # gfx950 is postsubmit-only, should be present for push
@@ -447,7 +447,7 @@ class TestSelectTargets(unittest.TestCase):
             event_name="schedule",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
         )
         result = cm.select_targets(inputs)
         # Schedule should have more families than push (nightly families added)
@@ -456,7 +456,7 @@ class TestSelectTargets(unittest.TestCase):
             event_name="push",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
         )
         push_result = cm.select_targets(push_inputs)
         self.assertGreater(len(result.linux_families), len(push_result.linux_families))
@@ -468,7 +468,7 @@ class TestSelectTargets(unittest.TestCase):
             event_name="pull_request",
             commit_ref="feature",
             base_ref="HEAD^",
-            build_variant="release",
+            build_variant="ci",
         )
         result = cm.select_targets(inputs)
         self.assertGreater(len(result.linux_families), 0)
@@ -482,14 +482,14 @@ class TestSelectTargets(unittest.TestCase):
             event_name="pull_request",
             commit_ref="feature",
             base_ref="HEAD^",
-            build_variant="release",
+            build_variant="ci",
         )
         inputs_with = cm.CIInputs(
             run_id="12345",
             event_name="pull_request",
             commit_ref="feature",
             base_ref="HEAD^",
-            build_variant="release",
+            build_variant="ci",
             # gfx906 is nightly-only, not in presubmit+postsubmit defaults
             pr_labels=["gfx906"],
         )
@@ -505,7 +505,7 @@ class TestSelectTargets(unittest.TestCase):
             event_name="pull_request",
             commit_ref="feature",
             base_ref="HEAD^",
-            build_variant="release",
+            build_variant="ci",
             pr_labels=["ci:run-all-archs"],
         )
         result = cm.select_targets(inputs)
@@ -519,7 +519,7 @@ class TestSelectTargets(unittest.TestCase):
             event_name="pull_request",
             commit_ref="feature",
             base_ref="HEAD^",
-            build_variant="release",
+            build_variant="ci",
             pr_labels=["gfx9999"],
         )
         with self.assertRaises(ValueError, msg="Unknown GPU families"):
@@ -532,7 +532,7 @@ class TestSelectTargets(unittest.TestCase):
             event_name="workflow_dispatch",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
             linux_amdgpu_families=["gfx94x", "gfx110x"],
             windows_amdgpu_families=["gfx110x"],
         )
@@ -550,7 +550,7 @@ class TestSelectTargets(unittest.TestCase):
             event_name="workflow_dispatch",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
         )
         result = cm.select_targets(inputs)
         self.assertEqual(result.linux_families, [])
@@ -563,7 +563,7 @@ class TestSelectTargets(unittest.TestCase):
             event_name="workflow_dispatch",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
             linux_amdgpu_families=["gfx_bogus"],
         )
         with self.assertRaises(ValueError, msg="Unknown GPU families"):
@@ -579,7 +579,7 @@ class TestSelectTargets(unittest.TestCase):
             event_name="workflow_dispatch",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
             # gfx950 has no windows entry — this should be an error, not silently dropped
             windows_amdgpu_families=["gfx950"],
         )
@@ -655,7 +655,7 @@ class TestSelectTargets(unittest.TestCase):
             event_name="repository_dispatch",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
         )
         with self.assertRaises(ValueError, msg="Unsupported event type"):
             cm.select_targets(inputs)
@@ -667,7 +667,7 @@ class TestSelectTargets(unittest.TestCase):
             event_name="push",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
         )
         result = cm.select_targets(inputs)
         # gfx94x is linux-only (no windows entry in presubmit matrix)
@@ -694,7 +694,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             event_name="push",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
         )
         defaults.update(kwargs)
         return cm.CIInputs(**defaults)
@@ -705,7 +705,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             per_family_info=[],
             dist_amdgpu_families="",
             artifact_group="multi-arch-release",
-            build_variant_label="release",
+            build_variant_label="ci",
             build_variant_suffix="",
             build_variant_cmake_preset="",
             expect_failure=False,
@@ -732,7 +732,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             per_family_info=[{"amdgpu_family": "gfx110x"}],
             dist_amdgpu_families="gfx110x",
             artifact_group="multi-arch-release",
-            build_variant_label="release",
+            build_variant_label="ci",
             build_variant_suffix="",
             build_variant_cmake_preset="release",
             expect_failure=False,
@@ -756,7 +756,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             event_name="push",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
         )
         targets = cm.select_targets(inputs)
         result = cm.expand_build_configs(
@@ -840,7 +840,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
         )
         result = cm.expand_build_configs(
             targets=targets,
-            ci_inputs=self._inputs(build_variant="asan"),
+            ci_inputs=self._inputs(build_variant="ci_asan"),
             test_type="quick",
         )
         # Only gfx94x on linux survives.
@@ -890,7 +890,7 @@ class TestFormatSummary(unittest.TestCase):
             event_name="push",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
         )
         defaults.update(kwargs)
         return cm.CIInputs(**defaults)
@@ -948,7 +948,7 @@ class TestConfigurePipeline(unittest.TestCase):
             event_name="workflow_dispatch",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
         )
         outputs = cm.configure(inputs, cm.GitContext())
         self.assertFalse(outputs.is_ci_enabled)
@@ -961,7 +961,7 @@ class TestConfigurePipeline(unittest.TestCase):
             event_name="pull_request",
             commit_ref="feature",
             base_ref="HEAD^",
-            build_variant="release",
+            build_variant="ci",
             linux_test_labels=["test:rccl"],
             windows_test_labels=["test:rccl"],
         )
@@ -976,7 +976,7 @@ class TestConfigurePipeline(unittest.TestCase):
             event_name="pull_request",
             commit_ref="feature",
             base_ref="HEAD^",
-            build_variant="release",
+            build_variant="ci",
         )
         outputs = cm.configure(inputs, cm.GitContext.empty())
         self.assertEqual(outputs.linux_test_labels, [])
@@ -1057,7 +1057,7 @@ class TestFamilyTestFilters(unittest.TestCase):
             event_name="pull_request",  # Non-schedule run
             commit_ref="feature-branch",
             base_ref="HEAD^",
-            build_variant="release",
+            build_variant="ci",
             pr_labels=["ci:run-all-archs"],  # Include gfx90a from nightly matrix
         )
         targets = cm.select_targets(ci_inputs)
@@ -1137,7 +1137,7 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
             event_name="pull_request",
             commit_ref="feature",
             base_ref="HEAD^",
-            build_variant="release",
+            build_variant="ci",
         )
         targets = cm.TargetSelection(linux_families=["gfx94x"])
 
@@ -1157,7 +1157,7 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
             event_name="pull_request",
             commit_ref="feature",
             base_ref="HEAD^",
-            build_variant="release",
+            build_variant="ci",
         )
         targets = cm.TargetSelection(linux_families=["gfx94x"])
 
@@ -1179,7 +1179,7 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
             event_name="pull_request",
             commit_ref="feature",
             base_ref="HEAD^",
-            build_variant="release",
+            build_variant="ci",
         )
         targets = cm.TargetSelection(linux_families=["gfx94x"])
 
@@ -1201,7 +1201,7 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
             event_name="schedule",
             commit_ref="main",
             base_ref="HEAD^1",
-            build_variant="release",
+            build_variant="ci",
         )
         # gfx103x doesn't have multi-label config
         targets = cm.TargetSelection(linux_families=["gfx103x"])


### PR DESCRIPTION
> [!IMPORTANT]
> See also https://github.com/ROCm/TheRock/pull/5191 as an alternate approach.

## Motivation

Follow-up to https://github.com/ROCm/TheRock/pull/5153#discussion_r3220301745

This aims to set the `THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS` flag value more consistently in our CI/CD workflows:
* Enabled in `linux-release` / `windows-release` presets, used by release (CD) workflows
* Disabled in `linux-dev` / `windows-dev` presets, used by CI workflows

## Technical Details

These workflows have been using a top level "build_variant" setting like `build_variant: "release"` which traced through `build_tools/github_actions/configure_multi_arch_ci.py` and `build_tools/github_actions/amdgpu_family_matrix.py` to compute a "build config".

This splits the "release" build variants to include "ci" and "release" with different cmake presets for each.

## Test Plan

Check presets used by CI, trigger a dev release build?

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
