### PR TITLE
build(cmake): remove rocprofiler-systems GCC and sanitizer guards

### DIFF
--- a/cmake/therock_compiler_config.cmake
+++ b/cmake/therock_compiler_config.cmake
@@ -46,25 +46,6 @@ if(MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 4)
     "  Detected CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")
 endif()
 
-
-if(UNIX AND NOT APPLE AND NOT THEROCK_DISABLE_GNU_CHECK)
-  # Linux-specific check.
-  if(THEROCK_ENABLE_ROCPROFSYS AND (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT CMAKE_C_COMPILER_ID STREQUAL "GNU"))
-   # Currently, the Dyninst dependency in rocprofiler-systems requires GNU compilers (gcc/g++).
-    message(FATAL_ERROR
-        "Currently, rocprofiler-systems requires GNU compilers (gcc/g++).\n"
-        "  Detected CMAKE_C_COMPILER_ID: ${CMAKE_C_COMPILER_ID}\n"
-        "  Detected CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}\n"
-        "  Detected CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}\n"
-        "  Detected CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}\n"
-        "To use GNU compilers, set:\n"
-        "  -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++\n"
-        "To disable rocprofiler-systems, set:\n"
-        "  -DTHEROCK_ENABLE_ROCPROFSYS=OFF\n"
-        "Set THEROCK_DISABLE_GNU_CHECK to bypass this check.")
-  endif()
-endif()
-
 # macOS-specific compiler checks
 if(APPLE)
   # Verify we're using AppleClang or Clang on macOS

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -271,9 +271,13 @@ endif(THEROCK_ENABLE_ROCPROFILER_COMPUTE)
 ##############################################################################
 # rocprofiler-systems
 ##############################################################################
-# rocprofiler-systems requires GCC, but sanitizer builds use Clang.
-# Skip enabling rocprofiler-systems when building with sanitizers.
-if (THEROCK_ENABLE_ROCPROFSYS AND THEROCK_SANITIZER STREQUAL "")
+if(THEROCK_ENABLE_ROCPROFSYS)
+  # Escape semicolons in GPU targets list to prevent shell interpretation
+  if (THEROCK_TEST_AMDGPU_TARGETS STREQUAL "THEROCK_TEST_AMDGPU_TARGETS-NOTFOUND")
+    set(_ROCPROFSYS_GFX_TARGETS_ESCAPED "")
+  else()
+    string(REPLACE ";" "\\;" _ROCPROFSYS_GFX_TARGETS_ESCAPED "${THEROCK_TEST_AMDGPU_TARGETS}")
+  endif()
 
   therock_detect_python_versions(_rocprofsys_detected_python_executables _rocprofsys_detected_python_versions)
   if(NOT _rocprofsys_detected_python_versions OR NOT _rocprofsys_detected_python_executables)
@@ -317,6 +321,8 @@ if (THEROCK_ENABLE_ROCPROFSYS AND THEROCK_SANITIZER STREQUAL "")
       -DROCPROFSYS_PYTHON_VERSIONS:STRING="${_ROCPROFSYS_PYTHON_VERSIONS_STR}"
       -DROCPROFSYS_PYTHON_ROOT_DIRS:STRING="${_ROCPROFSYS_PYTHON_ROOT_DIRS_STR}"
       "-DROCPROFSYS_USE_MPI=${THEROCK_ENABLE_MPI}"
+    COMPILER_TOOLCHAIN
+      amd-hip
     INSTALL_RPATH_DIRS
       "lib"
       "lib/rocprofiler-systems"
@@ -405,4 +411,4 @@ if (THEROCK_ENABLE_ROCPROFSYS AND THEROCK_SANITIZER STREQUAL "")
         rocprofiler-systems-examples
     )
   endif()
-endif(THEROCK_ENABLE_ROCPROFSYS AND THEROCK_SANITIZER STREQUAL "")
+endif(THEROCK_ENABLE_ROCPROFSYS)

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -272,12 +272,6 @@ endif(THEROCK_ENABLE_ROCPROFILER_COMPUTE)
 # rocprofiler-systems
 ##############################################################################
 if(THEROCK_ENABLE_ROCPROFSYS)
-  # Escape semicolons in GPU targets list to prevent shell interpretation
-  if (THEROCK_TEST_AMDGPU_TARGETS STREQUAL "THEROCK_TEST_AMDGPU_TARGETS-NOTFOUND")
-    set(_ROCPROFSYS_GFX_TARGETS_ESCAPED "")
-  else()
-    string(REPLACE ";" "\\;" _ROCPROFSYS_GFX_TARGETS_ESCAPED "${THEROCK_TEST_AMDGPU_TARGETS}")
-  endif()
 
   therock_detect_python_versions(_rocprofsys_detected_python_executables _rocprofsys_detected_python_versions)
   if(NOT _rocprofsys_detected_python_versions OR NOT _rocprofsys_detected_python_executables)


### PR DESCRIPTION
## Motivation

rocprofiler-systems can be built with Clang and alongside sanitizer configurations. Drop the Linux bootstrap check that required GCC when ROCPROFSYS was enabled and stop skipping the subproject when THEROCK_SANITIZER is set.

- Relates to AIPROFSYST-478

## Technical Details

- Set `COMPILER_TOOLCHAIN` to amd-hip
- Remove the Linux bootstrap hard-failure that required GNU compilers when `THEROCK_ENABLE_ROCPROFSYS=ON`.
- Stop skipping `rocprofiler-systems` configuration/activation when `THEROCK_SANITIZER` is set.
- This depends on some changes in rocm-system (https://github.com/ROCm/rocm-systems/pull/6295), which should have already been promoted in the latest submodule bump.

## Test Plan

Locally, test builds with the `amd-hip` toolchain and with ASAN enabled

## Test Result

- Local build of therock complete

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
