### PR TITLE
Add more step timeouts to torch test workflows

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -159,6 +159,7 @@ jobs:
             --no-hipify
 
       - name: Set up virtual environment
+        timeout-minutes: 15
         run: |
           if [ "${{ inputs.multi_arch }}" = "true" ]; then
             python build_tools/setup_venv.py ${VENV_DIR} \
@@ -179,10 +180,12 @@ jobs:
           pip freeze
 
       - name: Run rocm-sdk sanity tests
+        timeout-minutes: 5
         run: |
           rocm-sdk test
 
       - name: Run PyTorch smoketests
+        timeout-minutes: 10
         run: |
           python ./external-builds/pytorch/run_pytorch_smoke_tests.py -- \
             --log-cli-level=INFO \

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -210,6 +210,7 @@ jobs:
             --no-hipify
 
       - name: Set up virtual environment
+        timeout-minutes: 15
         run: |
           if [ "${{ inputs.multi_arch }}" = "true" ]; then
             python build_tools/setup_venv.py ${VENV_DIR} \
@@ -225,6 +226,7 @@ jobs:
           fi
 
       - name: Install ROCm devel packages
+        timeout-minutes: 15
         run: |
           if [ "${{ inputs.multi_arch }}" = "true" ]; then
             pip install "rocm[devel,${{ steps.expand.outputs.device_extras }}]" \
@@ -295,10 +297,12 @@ jobs:
           ./build_tools/health_status.py
 
       - name: Run rocm-sdk sanity tests
+        timeout-minutes: 5
         run: |
           rocm-sdk test
 
       - name: Run PyTorch smoketests
+        timeout-minutes: 10
         run: |
           python ./external-builds/pytorch/run_pytorch_smoke_tests.py -- \
             --log-cli-level=INFO \


### PR DESCRIPTION
## Motivation

Observed default timeout of 6 hours (!) running `rocm-sdk test` on `azure-windows-11-gfx1101-gpu-rocm-runner-16` runner at https://github.com/ROCm/TheRock/actions/runs/25669102923/job/75367650240#step:11:1

Related to other timeouts on these runners:

* https://github.com/ROCm/TheRock/issues/5169
* https://github.com/ROCm/TheRock/issues/5172

## Test Plan

Trigger `.github/workflows/test_pytorch_wheels.yml`, workflows should be valid (timeout durations were selected based on prior runs and should be sufficiently high to avoid false timeouts):

* Windows: https://github.com/ROCm/TheRock/actions/runs/25743052151/job/75598606833 (queued)
* Linux: https://github.com/ROCm/TheRock/actions/runs/25743070432/job/75598672199 (failed during name resolution?)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
