### PR TITLE
Add run-name to test_artifacts.yml

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -90,6 +90,8 @@ on:
 permissions:
   contents: read
 
+run-name: Test Artifacts (${{ inputs.amdgpu_families }}, ${{ inputs.release_type || 'ci' }}, ${{ inputs.test_type }}, ${{ inputs.test_runs_on }})
+
 jobs:
   configure_test_matrix:
     name: "Configure test matrix (${{ inputs.amdgpu_families }})"


### PR DESCRIPTION
## Motivation

This will show details about the run in the history at https://github.com/ROCm/TheRock/actions/workflows/test_artifacts.yml.

As part of https://github.com/ROCm/TheRock/issues/2281 I also want to switch multi-arch releases to trigger/dispatch separate jobs for artifact testing (one workflow run per GPU target), at which point we'll want the runs to be easy to categorize like runs of https://github.com/ROCm/TheRock/actions/workflows/release_portable_linux_pytorch_wheels.yml already are.

## Technical Details

I chose to start with `amdgpu_families`, `release_type`, `test_type` and `test_runs_on` in the name. There are 14 inputs total that could be included in the name. We may want to output a markdown summary in the "Configure test matrix" job that includes details like repro steps akin to https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/summarize_test_pytorch_workflow.py with a reference to https://github.com/ROCm/TheRock/blob/main/docs/development/test_environment_reproduction.md

## Test Plan

Triggered at https://github.com/ROCm/TheRock/actions/runs/25751957307, run name `Test Artifacts (gfx94X-dcgpu, dev, quick, linux-gfx942-1gpu-ossci-rocm)`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
