### PR TITLE
Switch multi-arch releases to dispatch test_artifacts.yml

### DIFF
--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -150,9 +150,9 @@ jobs:
             --release-type="${{ inputs.release_type }}" \
             --kpack-split="${{ needs.build_python_packages.outputs.kpack_split }}"
 
-  dispatch_tests_per_family:
+  trigger_test_artifacts_per_family:
     needs: [build_artifacts]
-    name: Dispatch Tests ${{ matrix.family_info.amdgpu_family }}
+    name: Trigger Test Artifacts (${{ matrix.family_info.amdgpu_family }})
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-24.04
     permissions:
@@ -162,7 +162,7 @@ jobs:
       matrix:
         family_info: ${{ fromJSON(inputs.build_config).per_family_info }}
     steps:
-      - name: Dispatch test_artifacts
+      - name: Trigger test_artifacts
         if: ${{ matrix.family_info.test-runs-on != '' }}
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:
@@ -182,9 +182,9 @@ jobs:
 
   # TODO: Consider switch pulling ROCm packages from the CDN instead of the artifact
   #   bucket if the job order is not altered.
-  build_pytorch_wheels:
+  trigger_release_pytorch_wheels:
     needs: [build_artifacts, build_python_packages]
-    name: Build PyTorch Wheels
+    name: Trigger Release PyTorch Wheels
     runs-on: ubuntu-24.04
     permissions:
       actions: write
@@ -201,4 +201,4 @@ jobs:
               "ref": "${{ inputs.ref || '' }}"
             }
 
-  # TODO: dispatch jax wheels (release_portable_linux_jax_wheels.yml)
+  # TODO: trigger_build_jax_wheels (release_portable_linux_jax_wheels.yml or equivalent)

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -167,7 +167,6 @@ jobs:
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:
           workflow: test_artifacts.yml
-          ref: ${{ inputs.ref }}
           inputs: |
             { "artifact_group": "${{ matrix.family_info.amdgpu_family }}",
               "artifact_run_id": "${{ github.run_id }}",

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -150,24 +150,35 @@ jobs:
             --release-type="${{ inputs.release_type }}" \
             --kpack-split="${{ needs.build_python_packages.outputs.kpack_split }}"
 
-  test_artifacts_per_family:
+  dispatch_tests_per_family:
     needs: [build_artifacts]
-    name: Test ${{ matrix.family_info.amdgpu_family }}
+    name: Dispatch Tests ${{ matrix.family_info.amdgpu_family }}
     if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
     strategy:
       fail-fast: false
       matrix:
         family_info: ${{ fromJSON(inputs.build_config).per_family_info }}
-    uses: ./.github/workflows/test_artifacts.yml
-    with:
-      artifact_group: ${{ matrix.family_info.amdgpu_family }}
-      amdgpu_families: ${{ matrix.family_info.amdgpu_family }}
-      amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
-      test_runs_on: ${{ matrix.family_info.test-runs-on }}
-      test_type: ${{ inputs.test_type }}
-      release_type: ${{ inputs.release_type }}
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
+    steps:
+      - name: Dispatch test_artifacts
+        if: ${{ matrix.family_info.test-runs-on != '' }}
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
+        with:
+          workflow: test_artifacts.yml
+          ref: ${{ inputs.ref }}
+          inputs: |
+            { "artifact_group": "${{ matrix.family_info.amdgpu_family }}",
+              "artifact_run_id": "${{ github.run_id }}",
+              "amdgpu_families": "${{ matrix.family_info.amdgpu_family }}",
+              "amdgpu_targets": "${{ matrix.family_info.amdgpu_targets }}",
+              "test_runs_on": "${{ matrix.family_info.test-runs-on }}",
+              "test_type": "${{ inputs.test_type }}",
+              "release_type": "${{ inputs.release_type }}",
+              "repository": "${{ inputs.repository }}",
+              "ref": "${{ inputs.ref }}"
+            }
 
   # TODO: Consider switch pulling ROCm packages from the CDN instead of the artifact
   #   bucket if the job order is not altered.

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -129,7 +129,6 @@ jobs:
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:
           workflow: test_artifacts.yml
-          ref: ${{ inputs.ref }}
           inputs: |
             { "artifact_group": "${{ matrix.family_info.amdgpu_family }}",
               "artifact_run_id": "${{ github.run_id }}",

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -112,9 +112,9 @@ jobs:
             --release-type="${{ inputs.release_type }}" \
             --kpack-split="${{ needs.build_python_packages.outputs.kpack_split }}"
 
-  dispatch_tests_per_family:
+  trigger_test_artifacts_per_family:
     needs: [build_artifacts]
-    name: Dispatch Tests ${{ matrix.family_info.amdgpu_family }}
+    name: Trigger Test Artifacts (${{ matrix.family_info.amdgpu_family }})
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-24.04
     permissions:
@@ -124,7 +124,7 @@ jobs:
       matrix:
         family_info: ${{ fromJSON(inputs.build_config).per_family_info }}
     steps:
-      - name: Dispatch test_artifacts
+      - name: Trigger test_artifacts
         if: ${{ matrix.family_info.test-runs-on != '' }}
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
         with:
@@ -144,9 +144,9 @@ jobs:
 
   # TODO: Consider switch pulling ROCm packages from the CDN instead of the artifact
   #   bucket if the job order is not altered.
-  build_pytorch_wheels:
+  trigger_release_pytorch_wheels:
     needs: [build_artifacts, build_python_packages]
-    name: Build PyTorch Wheels
+    name: Trigger Release PyTorch Wheels
     runs-on: ubuntu-24.04
     permissions:
       actions: write

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -112,24 +112,35 @@ jobs:
             --release-type="${{ inputs.release_type }}" \
             --kpack-split="${{ needs.build_python_packages.outputs.kpack_split }}"
 
-  test_artifacts_per_family:
+  dispatch_tests_per_family:
     needs: [build_artifacts]
-    name: Test ${{ matrix.family_info.amdgpu_family }}
+    name: Dispatch Tests ${{ matrix.family_info.amdgpu_family }}
     if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
     strategy:
       fail-fast: false
       matrix:
         family_info: ${{ fromJSON(inputs.build_config).per_family_info }}
-    uses: ./.github/workflows/test_artifacts.yml
-    with:
-      artifact_group: ${{ matrix.family_info.amdgpu_family }}
-      amdgpu_families: ${{ matrix.family_info.amdgpu_family }}
-      amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
-      test_runs_on: ${{ matrix.family_info.test-runs-on }}
-      test_type: ${{ inputs.test_type }}
-      release_type: ${{ inputs.release_type }}
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
+    steps:
+      - name: Dispatch test_artifacts
+        if: ${{ matrix.family_info.test-runs-on != '' }}
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
+        with:
+          workflow: test_artifacts.yml
+          ref: ${{ inputs.ref }}
+          inputs: |
+            { "artifact_group": "${{ matrix.family_info.amdgpu_family }}",
+              "artifact_run_id": "${{ github.run_id }}",
+              "amdgpu_families": "${{ matrix.family_info.amdgpu_family }}",
+              "amdgpu_targets": "${{ matrix.family_info.amdgpu_targets }}",
+              "test_runs_on": "${{ matrix.family_info.test-runs-on }}",
+              "test_type": "${{ inputs.test_type }}",
+              "release_type": "${{ inputs.release_type }}",
+              "repository": "${{ inputs.repository }}",
+              "ref": "${{ inputs.ref }}"
+            }
 
   # TODO: Consider switch pulling ROCm packages from the CDN instead of the artifact
   #   bucket if the job order is not altered.

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -90,6 +90,8 @@ on:
 permissions:
   contents: read
 
+run-name: Test Artifacts (${{ inputs.amdgpu_families }}, ${{ inputs.release_type || 'ci' }}, ${{ inputs.test_type }}, ${{ inputs.test_runs_on }})
+
 jobs:
   configure_test_matrix:
     name: "Configure test matrix (${{ inputs.amdgpu_families }})"

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -90,8 +90,6 @@ on:
 permissions:
   contents: read
 
-run-name: Test Artifacts (${{ inputs.amdgpu_families }}, ${{ inputs.release_type || 'ci' }}, ${{ inputs.test_type }}, ${{ inputs.test_runs_on }})
-
 jobs:
   configure_test_matrix:
     name: "Configure test matrix (${{ inputs.amdgpu_families }})"


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/2281. This switches release workflows from spawning "test artifacts" workflow jobs in _the current workflow_ to triggering _separate workflows_ using workflow dispatch, one per GPU target/family.

See https://github.com/ROCm/rockrel/actions/runs/25711105761 for an example of a recently nightly release run.

Arguments for keeping the jobs in the current workflow run (current baseline):
* A single workflow run includes all rocm build/test jobs
  * Framework builds (e.g. PyTorch) are still separate workflow runs
* Release workflows match CI workflows more closely (CI workflows that want to use a "required check" should use a single `pull_request` trigger for all jobs in a dependency set for predictable workflow behavior)
* No need for a wrapper workflow in rockrel like https://github.com/ROCm/rockrel/pull/44 that may get out of sync with the associated workflow in TheRock
  * I'm looking for more ideas for how to mitigate this... keeping multiple repositories in sync is a difficult problem

Arguments for splitting into separate workflow runs (this PR):
* The list of jobs in each workflow run will be more focused (build workflow run --> test workflow runs)
* Build and test status will be possible to monitor independently on different workflow history pages
* It will be easier to filter test status by GPU target/family (look across workflow runs for that GPU instead of needing to inspect more deeply within a combined build/test on all GPUs run)
* Test runner queues will not stall the entire release workflow (preventing clean cancel/retry loops if there are build issues)

## Technical Details

> [!IMPORTANT]
> For this to work with nightly releases running in https://github.com/ROCm/rockrel, a wrapper workflow is needed there: https://github.com/ROCm/rockrel/pull/44.
>
> Also note the workflow inputs must match (or be a compatible subset) across the repositories for nightly release to correctly trigger tests. This will be a moving target, so we may want to add additional structure (unit tests, documentation, etc.) to ensure that the wrapper workflow does not get too far out of sync.

Workflow graph before:
```mermaid
graph LR
    subgraph "Single workflow run"
        B[build_artifacts] --> T1[Test gfx94X]
        B --> T2[Test gfx110X]
        B --> P[publish_to_release_buckets]
        T1 --> S1[test_sanity_check]
        T1 --> S2[test_components x N]
        T2 --> S3[test_sanity_check]
        T2 --> S4[test_components x N]
    end
```

Workflow graph after:
```mermaid
  graph LR
      subgraph "Release workflow run"
          B[build_artifacts]
          subgraph "trigger_test_artifacts_per_family"
              D1[Trigger Test gfx94X]
              D2[Trigger Test gfx110X]
          end
          B --> D1
          B --> D2
          B --> P[publish_to_release_buckets]
      end
      subgraph "Test Artifacts run: gfx94X"
          D1 -.-> T1[test_sanity_check]
          T1 --> C1[test_components x N]
      end
      subgraph "Test Artifacts run: gfx110X"
          D2 -.-> T2[test_sanity_check]
          T2 --> C2[test_components x N]
      end
```

## Test Plan

Dev release: https://github.com/ROCm/TheRock/actions/runs/25761119152 triggered https://github.com/ROCm/TheRock/actions/runs/25767861598

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
