### PR TITLE
Restore rocm/ release bucket prefixes in upload_release_packages.py

### DIFF
--- a/build_tools/packaging/upload_release_packages.py
+++ b/build_tools/packaging/upload_release_packages.py
@@ -374,13 +374,13 @@ Safety Features:
         args.bucket = "therock-release-python"
 
         if args.multi_arch:
-            args.bucket_prefix = "v4/whl/"
+            args.bucket_prefix = "v4/rocm/whl/"
             args.tarball_bucket = "therock-release-tarball"
-            args.tarball_bucket_prefix = "v4/tarball/"
+            args.tarball_bucket_prefix = "v4/rocm/tarball/"
         else:
-            args.bucket_prefix = "v3/whl/"
+            args.bucket_prefix = "v3/rocm/whl/"
             args.tarball_bucket = "therock-release-tarball"
-            args.tarball_bucket_prefix = "v3/tarball/"
+            args.tarball_bucket_prefix = "v3/rocm/tarball/"
 
     # Validate input directory
     if not args.input_dir.exists():


### PR DESCRIPTION
This PR, Restores the original `rocm/` release bucket prefix structure in `upload_release_packages.py`.

The multi-arch refactor unintentionally changed production release upload paths from:

* `v3/rocm/whl/`
* `v3/rocm/tarball/`

to:

* `v3/whl/`
* `v3/tarball/`

This PR restores the original single-arch layout and keeps the same structure for multi-arch uploads.

## Changes

### Single-arch release uploads

Restore:

* `v3/rocm/whl/<arch>/`
* `v3/rocm/tarball/`

### Multi-arch release uploads

Use:

* `v4/rocm/whl/`
* `v4/rocm/tarball/`

## Resulting upload locations

### Single-arch

* `s3://therock-release-python/v3/rocm/whl/<arch>/`
* `s3://therock-release-tarball/v3/rocm/tarball/`

### Multi-arch

* `s3://therock-release-python/v4/rocm/whl/`
* `s3://therock-release-tarball/v4/rocm/tarball/`

Testing:

https://gist.github.com/araravik-psd/533ae49d5312e2d689ad96ad4253cb53
