### PR TITLE
Set test_type based on release_type in workflow runs

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -588,14 +588,13 @@ def _determine_test_type(
         return "full", "test labels specified"
 
     # Priority 3: release builds run deeper test suites than regular CI.
-    # Prerelease gets full (exhaustive pre-release validation), nightly
-    # gets comprehensive (deeper than standard, on a daily cadence).
-    # Dev releases fall through to later priorities so developers can
-    # iterate fast on release workflow changes.
-    if ci_inputs.release_type == "prerelease":
-        return "full", "release build (prerelease)"
+    # * 'nightly' gets comprehensive (deeper than standard, on a daily cadence)
+    # * 'prerelease' gets full (exhaustive pre-release validation)
+    # * 'dev' falls through to later priorities so changes can be tested quickly
     if ci_inputs.release_type == "nightly":
         return "comprehensive", "release build (nightly)"
+    if ci_inputs.release_type == "prerelease":
+        return "full", "release build (prerelease)"
 
     # Priority 4: schedule runs the full nightly suite — comprehensive
     # coverage on a cadence, catching regressions that quick tests miss.

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -587,12 +587,22 @@ def _determine_test_type(
     if _has_test_labels(ci_inputs):
         return "full", "test labels specified"
 
-    # Priority 3: schedule runs the full nightly suite — comprehensive
+    # Priority 3: release builds run deeper test suites than regular CI.
+    # Prerelease gets full (exhaustive pre-release validation), nightly
+    # gets comprehensive (deeper than standard, on a daily cadence).
+    # Dev releases fall through to later priorities so developers can
+    # iterate fast on release workflow changes.
+    if ci_inputs.release_type == "prerelease":
+        return "full", "release build (prerelease)"
+    if ci_inputs.release_type == "nightly":
+        return "comprehensive", "release build (nightly)"
+
+    # Priority 4: schedule runs the full nightly suite — comprehensive
     # coverage on a cadence, catching regressions that quick tests miss.
     if ci_inputs.is_schedule:
         return "comprehensive", "scheduled run"
 
-    # Priority 4: a submodule change means actual library code changed
+    # Priority 5: a submodule change means actual library code changed
     # (e.g. rocBLAS, MIOpen). These need full testing since the change
     # could affect any downstream consumer.
     if (

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -355,6 +355,28 @@ class TestDecideJobs(unittest.TestCase):
         )
         self.assertEqual(result.test_rocm.test_type, "full")
 
+    def test_nightly_release_is_comprehensive(self):
+        """Nightly release → comprehensive tests."""
+        result = cm.decide_jobs(
+            self._inputs(release_type="nightly"), git_context=cm.GitContext()
+        )
+        self.assertEqual(result.test_rocm.test_type, "comprehensive")
+        self.assertIn("release", result.test_rocm.test_type_reason)
+
+    def test_prerelease_is_full(self):
+        """Prerelease → full tests."""
+        result = cm.decide_jobs(
+            self._inputs(release_type="prerelease"), git_context=cm.GitContext()
+        )
+        self.assertEqual(result.test_rocm.test_type, "full")
+        self.assertIn("release", result.test_rocm.test_type_reason)
+
+    def test_dev_release_falls_through_to_default(self):
+        """Dev release without other signals → quick (falls through)."""
+        git = cm.GitContext(changed_files=["CMakeLists.txt"])
+        result = cm.decide_jobs(self._inputs(release_type="dev"), git_context=git)
+        self.assertEqual(result.test_rocm.test_type, "quick")
+
     def test_test_filter_label_overrides(self):
         """test_filter: PR label overrides the computed test_type."""
         # Even though schedule would set comprehensive, test_filter overrides.

--- a/docs/development/test_filtering.md
+++ b/docs/development/test_filtering.md
@@ -6,7 +6,7 @@
 
 - <b>quick</b>: A "sanity check" to ensure the system is fundamentally working
 
-  - Runs on: pull requests (if ROCm non-component related change), push to main branch
+  - Runs on: pull requests (non-component changes), push to main branch, dev releases
   - Characteristics: Shallow validation, focus on critical paths, component runs properly
   - Execution time: < 5 min
   - Target: build system updates, CI system updates, non-component specific updates
@@ -16,7 +16,7 @@
 <br/>
 
 - <b>standard</b>: The core baseline tests that ensures the most important and most commonly used functionality of the system are working
-  - Runs on: pull requests, workflow dispatch, push to main branch (if ROCm component related change)
+  - Runs on: pull requests (component changes), push to main branch (component changes)
   - Characteristics: business-critical logic, covers functionality that would block users or cause major regressions, high signal-to-noise ratio
   - Execution time: < 30 min
   - Target: component-specific core updates, submodule bumps
@@ -24,18 +24,18 @@
 <br/>
 
 - <b>comprehensive</b>: Test set that builds on top of standard tests, extending deeper test coverage
-  - Runs on: nightly
+  - Runs on: nightly releases, scheduled CI
   - Characteristics: deeper validation of edge cases, more expensive scenarios, more combinations of tests
   - Execution time: < 2 hours
-  - Target: daily scheduled run, on-demand PR label
+  - Target: nightly release validation, daily scheduled run, on-demand PR label
 
 <br/>
 
 - <b>full</b>: Test set that provides the highest level of confidence, validating a system under all conditions and edge cases
-  - Runs on: weekly, pre-major release
+  - Runs on: prerelease builds, submodule updates, on-demand
   - Characteristics: exhaustive scenarios, extreme edge cases, aim to eliminate unknown risks
   - Execution time: 2+ hours
-  - Target: pre-release testing, weekly scheduled run, on-demand PR label
+  - Target: pre-release testing, submodule bumps, on-demand PR label (`test_filter:full`)
 
 ## Test filter implementation
 


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/2281.

Previously, release workflow runs would choose the test type (e.g. "quick") based on the logic used for CI workflows. This adds new branches based on the `release_type` input set by CD workflows.

## Technical Details


Trigger | Release type | Test type before | Test type after
-- | -- | -- | --
`workflow_dispatch` | dev | quick | quick
`workflow_dispatch` | nightly | quick | comprehensive
`workflow_dispatch` | prerelease | quick | full
`schedule` | nightly | comprehensive | comprehensive

## Test Plan

I could trigger a "nightly" release, watch that the code does what we expect, then immediately cancel it... but I think this is safe to rely on just the unit tests. We can watch release runs after this change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
