### PR TITLE
[ci] Skip native packages and PyTorch builds for ASAN variant

### DIFF
--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -143,11 +143,7 @@ jobs:
   build_native_deb_packages:
     needs: [build_multi_arch_stages]
     name: Build DEB Packages
-    if: >-
-      ${{
-        !failure() && !cancelled() &&
-        fromJSON(inputs.build_config).build_native_linux == true
-      }}
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_native_linux == true }}
     uses: ./.github/workflows/multi_arch_build_native_linux_packages.yml
     with:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
@@ -160,11 +156,7 @@ jobs:
   build_native_rpm_packages:
     needs: [build_multi_arch_stages]
     name: Build RPM Packages
-    if: >-
-      ${{
-        !failure() && !cancelled() &&
-        fromJSON(inputs.build_config).build_native_linux == true
-      }}
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_native_linux == true }}
     uses: ./.github/workflows/multi_arch_build_native_linux_packages.yml
     with:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
@@ -177,11 +169,7 @@ jobs:
   test_native_packages_ubuntu2404:
     needs: [build_native_deb_packages]
     name: Test DEB Install - ubuntu2404
-    if: >-
-      ${{
-        !failure() && !cancelled() &&
-        fromJSON(inputs.build_config).build_native_linux == true
-      }}
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_native_linux == true }}
     uses: ./.github/workflows/test_native_linux_packages_install.yml
     with:
       package_install_url: ${{ needs.build_native_deb_packages.outputs.package_repository_url }}
@@ -196,11 +184,7 @@ jobs:
   test_native_packages_rhel10:
     needs: [build_native_rpm_packages]
     name: Test RPM Install - rhel10
-    if: >-
-      ${{
-        !failure() && !cancelled() &&
-        fromJSON(inputs.build_config).build_native_linux == true
-      }}
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_native_linux == true }}
     uses: ./.github/workflows/test_native_linux_packages_install.yml
     with:
       package_install_url: ${{ needs.build_native_rpm_packages.outputs.package_repository_url }}
@@ -215,11 +199,7 @@ jobs:
   test_native_packages_sles16:
     needs: [build_native_rpm_packages]
     name: Test RPM Install - sles16
-    if: >-
-      ${{
-        !failure() && !cancelled() &&
-        fromJSON(inputs.build_config).build_native_linux == true
-      }}
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_native_linux == true }}
     uses: ./.github/workflows/test_native_linux_packages_install.yml
     with:
       package_install_url: ${{ needs.build_native_rpm_packages.outputs.package_repository_url }}
@@ -290,11 +270,7 @@ jobs:
   build_pytorch_wheel_fat:
     needs: [build_python_packages]
     name: Build PyTorch (fat + split)
-    if: >-
-      ${{
-        !failure() && !cancelled() &&
-        fromJSON(inputs.build_config).build_pytorch == true
-      }}
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_pytorch == true }}
     uses: ./.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
     with:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -140,10 +140,16 @@ jobs:
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
 
+  # TODO: Re-enable for ASAN builds once fixed and passing.
   build_native_deb_packages:
     needs: [build_multi_arch_stages]
     name: Build DEB Packages
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    if: >-
+      ${{
+        !failure() && !cancelled() &&
+        fromJSON(inputs.build_config).expect_failure == false &&
+        fromJSON(inputs.build_config).build_variant_suffix != 'asan'
+      }}
     uses: ./.github/workflows/multi_arch_build_native_linux_packages.yml
     with:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
@@ -153,10 +159,16 @@ jobs:
       contents: read
       id-token: write
 
+  # TODO: Re-enable for ASAN builds once fixed and passing.
   build_native_rpm_packages:
     needs: [build_multi_arch_stages]
     name: Build RPM Packages
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    if: >-
+      ${{
+        !failure() && !cancelled() &&
+        fromJSON(inputs.build_config).expect_failure == false &&
+        fromJSON(inputs.build_config).build_variant_suffix != 'asan'
+      }}
     uses: ./.github/workflows/multi_arch_build_native_linux_packages.yml
     with:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
@@ -166,10 +178,16 @@ jobs:
       contents: read
       id-token: write
 
+  # TODO: Re-enable for ASAN builds once fixed and passing.
   test_native_packages_ubuntu2404:
     needs: [build_native_deb_packages]
     name: Test DEB Install - ubuntu2404
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    if: >-
+      ${{
+        !failure() && !cancelled() &&
+        fromJSON(inputs.build_config).expect_failure == false &&
+        fromJSON(inputs.build_config).build_variant_suffix != 'asan'
+      }}
     uses: ./.github/workflows/test_native_linux_packages_install.yml
     with:
       package_install_url: ${{ needs.build_native_deb_packages.outputs.package_repository_url }}
@@ -181,10 +199,16 @@ jobs:
       contents: read
       id-token: write
 
+  # TODO: Re-enable for ASAN builds once fixed and passing.
   test_native_packages_rhel10:
     needs: [build_native_rpm_packages]
     name: Test RPM Install - rhel10
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    if: >-
+      ${{
+        !failure() && !cancelled() &&
+        fromJSON(inputs.build_config).expect_failure == false &&
+        fromJSON(inputs.build_config).build_variant_suffix != 'asan'
+      }}
     uses: ./.github/workflows/test_native_linux_packages_install.yml
     with:
       package_install_url: ${{ needs.build_native_rpm_packages.outputs.package_repository_url }}
@@ -196,10 +220,16 @@ jobs:
       contents: read
       id-token: write
 
+  # TODO: Re-enable for ASAN builds once fixed and passing.
   test_native_packages_sles16:
     needs: [build_native_rpm_packages]
     name: Test RPM Install - sles16
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    if: >-
+      ${{
+        !failure() && !cancelled() &&
+        fromJSON(inputs.build_config).expect_failure == false &&
+        fromJSON(inputs.build_config).build_variant_suffix != 'asan'
+      }}
     uses: ./.github/workflows/test_native_linux_packages_install.yml
     with:
       package_install_url: ${{ needs.build_native_rpm_packages.outputs.package_repository_url }}
@@ -267,10 +297,16 @@ jobs:
   # default; build_configure.py's opt-out only fires in single-arch CI),
   # so the split path is unconditional here. The split itself runs inline
   # in build_portable_linux_pytorch_wheels_ci.yml based on inputs.kpack_split.
+  # TODO: Re-enable for ASAN builds once fixed and passing.
   build_pytorch_wheel_fat:
     needs: [build_python_packages]
     name: Build PyTorch (fat + split)
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_pytorch == true }}
+    if: >-
+      ${{
+        !failure() && !cancelled() &&
+        fromJSON(inputs.build_config).build_pytorch == true &&
+        fromJSON(inputs.build_config).build_variant_suffix != 'asan'
+      }}
     uses: ./.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
     with:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -13,7 +13,7 @@ on:
           artifact_group, per_family_info, dist_amdgpu_families,
           build_variant_label, build_variant_cmake_preset,
           build_variant_suffix, expect_failure, build_pytorch,
-          prebuilt_stages, baseline_run_id.
+          build_native_linux, prebuilt_stages, baseline_run_id.
       test_labels:
         type: string
       rocm_package_version:
@@ -140,15 +140,13 @@ jobs:
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
 
-  # TODO: Re-enable for ASAN builds once fixed and passing.
   build_native_deb_packages:
     needs: [build_multi_arch_stages]
     name: Build DEB Packages
     if: >-
       ${{
         !failure() && !cancelled() &&
-        fromJSON(inputs.build_config).expect_failure == false &&
-        fromJSON(inputs.build_config).build_variant_suffix != 'asan'
+        fromJSON(inputs.build_config).build_native_linux == true
       }}
     uses: ./.github/workflows/multi_arch_build_native_linux_packages.yml
     with:
@@ -159,15 +157,13 @@ jobs:
       contents: read
       id-token: write
 
-  # TODO: Re-enable for ASAN builds once fixed and passing.
   build_native_rpm_packages:
     needs: [build_multi_arch_stages]
     name: Build RPM Packages
     if: >-
       ${{
         !failure() && !cancelled() &&
-        fromJSON(inputs.build_config).expect_failure == false &&
-        fromJSON(inputs.build_config).build_variant_suffix != 'asan'
+        fromJSON(inputs.build_config).build_native_linux == true
       }}
     uses: ./.github/workflows/multi_arch_build_native_linux_packages.yml
     with:
@@ -178,15 +174,13 @@ jobs:
       contents: read
       id-token: write
 
-  # TODO: Re-enable for ASAN builds once fixed and passing.
   test_native_packages_ubuntu2404:
     needs: [build_native_deb_packages]
     name: Test DEB Install - ubuntu2404
     if: >-
       ${{
         !failure() && !cancelled() &&
-        fromJSON(inputs.build_config).expect_failure == false &&
-        fromJSON(inputs.build_config).build_variant_suffix != 'asan'
+        fromJSON(inputs.build_config).build_native_linux == true
       }}
     uses: ./.github/workflows/test_native_linux_packages_install.yml
     with:
@@ -199,15 +193,13 @@ jobs:
       contents: read
       id-token: write
 
-  # TODO: Re-enable for ASAN builds once fixed and passing.
   test_native_packages_rhel10:
     needs: [build_native_rpm_packages]
     name: Test RPM Install - rhel10
     if: >-
       ${{
         !failure() && !cancelled() &&
-        fromJSON(inputs.build_config).expect_failure == false &&
-        fromJSON(inputs.build_config).build_variant_suffix != 'asan'
+        fromJSON(inputs.build_config).build_native_linux == true
       }}
     uses: ./.github/workflows/test_native_linux_packages_install.yml
     with:
@@ -220,15 +212,13 @@ jobs:
       contents: read
       id-token: write
 
-  # TODO: Re-enable for ASAN builds once fixed and passing.
   test_native_packages_sles16:
     needs: [build_native_rpm_packages]
     name: Test RPM Install - sles16
     if: >-
       ${{
         !failure() && !cancelled() &&
-        fromJSON(inputs.build_config).expect_failure == false &&
-        fromJSON(inputs.build_config).build_variant_suffix != 'asan'
+        fromJSON(inputs.build_config).build_native_linux == true
       }}
     uses: ./.github/workflows/test_native_linux_packages_install.yml
     with:
@@ -297,15 +287,13 @@ jobs:
   # default; build_configure.py's opt-out only fires in single-arch CI),
   # so the split path is unconditional here. The split itself runs inline
   # in build_portable_linux_pytorch_wheels_ci.yml based on inputs.kpack_split.
-  # TODO: Re-enable for ASAN builds once fixed and passing.
   build_pytorch_wheel_fat:
     needs: [build_python_packages]
     name: Build PyTorch (fat + split)
     if: >-
       ${{
         !failure() && !cancelled() &&
-        fromJSON(inputs.build_config).build_pytorch == true &&
-        fromJSON(inputs.build_config).build_variant_suffix != 'asan'
+        fromJSON(inputs.build_config).build_pytorch == true
       }}
     uses: ./.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
     with:

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -13,7 +13,7 @@ on:
           artifact_group, per_family_info, dist_amdgpu_families,
           build_variant_label, build_variant_cmake_preset,
           build_variant_suffix, expect_failure, build_pytorch,
-          prebuilt_stages, baseline_run_id.
+          build_native_linux, prebuilt_stages, baseline_run_id.
       test_labels:
         type: string
       rocm_package_version:

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -927,10 +927,10 @@ def _expand_build_config_for_platform(
         build_variant_suffix=suffix,
         build_variant_cmake_preset=variant_config["build_variant_cmake_preset"],
         expect_failure=expect_failure,
-        build_pytorch=not expect_failure
-        and not expect_pytorch_failure
-        and suffix != "asan",
-        build_native_linux=not expect_failure and suffix != "asan",
+        build_pytorch=(
+            not expect_failure and not expect_pytorch_failure and suffix != "asan"
+        ),
+        build_native_linux=(not expect_failure and suffix != "asan"),
         build_runs_on=build_runs_on,
         prebuilt_stages=prebuilt_stages or [],
         baseline_run_id=baseline_run_id,

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -428,6 +428,7 @@ class BuildConfig:
     build_variant_cmake_preset: str
     expect_failure: bool
     build_pytorch: bool
+    build_native_linux: bool
     # Build runner label for this platform/variant combination
     build_runs_on: str = ""
     # Prebuilt stage configuration — set by configure() from JobDecisions.
@@ -926,7 +927,10 @@ def _expand_build_config_for_platform(
         build_variant_suffix=suffix,
         build_variant_cmake_preset=variant_config["build_variant_cmake_preset"],
         expect_failure=expect_failure,
-        build_pytorch=not expect_failure and not expect_pytorch_failure,
+        build_pytorch=not expect_failure
+        and not expect_pytorch_failure
+        and suffix != "asan",
+        build_native_linux=not expect_failure and suffix != "asan",
         build_runs_on=build_runs_on,
         prebuilt_stages=prebuilt_stages or [],
         baseline_run_id=baseline_run_id,

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -21,7 +21,7 @@ The CI pipeline is a DAG of job groups:
     build-rocm → test-rocm
                → build-rocm-python → build-pytorch → test-pytorch
                                    → build-jax     → test-jax (future)
-               → build-native-linux   → test-native-linux   (future)
+               → build-native-linux   → test-native-linux
                → build-native-windows → test-native-windows (future)
 
 Step 4 determines which job groups to run, skip, or satisfy with prebuilt
@@ -427,8 +427,8 @@ class BuildConfig:
     build_variant_suffix: str
     build_variant_cmake_preset: str
     expect_failure: bool
-    build_pytorch: bool
     build_native_linux: bool
+    build_pytorch: bool
     # Build runner label for this platform/variant combination
     build_runs_on: str = ""
     # Prebuilt stage configuration — set by configure() from JobDecisions.
@@ -927,10 +927,10 @@ def _expand_build_config_for_platform(
         build_variant_suffix=suffix,
         build_variant_cmake_preset=variant_config["build_variant_cmake_preset"],
         expect_failure=expect_failure,
+        build_native_linux=(not expect_failure and suffix != "asan"),
         build_pytorch=(
             not expect_failure and not expect_pytorch_failure and suffix != "asan"
         ),
-        build_native_linux=(not expect_failure and suffix != "asan"),
         build_runs_on=build_runs_on,
         prebuilt_stages=prebuilt_stages or [],
         baseline_run_id=baseline_run_id,

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -710,6 +710,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             build_variant_cmake_preset="",
             expect_failure=False,
             build_pytorch=True,
+            build_native_linux=True,
         )
         d = config.to_dict()
         # to_dict keys should match dataclass fields.
@@ -737,6 +738,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             build_variant_cmake_preset="release",
             expect_failure=False,
             build_pytorch=True,
+            build_native_linux=True,
         )
         # Present config → valid JSON
         serialized = json.dumps(config.to_dict())

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1039,12 +1039,14 @@ class TestBuildConfigWorkflowContract(unittest.TestCase):
         workflow_path = WORKFLOWS_DIR / "multi_arch_ci_windows.yml"
         yaml_fields = self._extract_build_config_fields(workflow_path)
         python_fields = {f.name for f in fields(cm.BuildConfig)}
+        # build_native_linux is Linux-only, not used in Windows workflow
+        linux_only_fields = {"build_native_linux"}
         self.assertEqual(
             yaml_fields,
-            python_fields,
+            python_fields - linux_only_fields,
             f"BuildConfig fields mismatch with {workflow_path.name}.\n"
             f"  In YAML but not Python: {yaml_fields - python_fields}\n"
-            f"  In Python but not YAML: {python_fields - yaml_fields}",
+            f"  In Python but not YAML: {python_fields - yaml_fields - linux_only_fields}",
         )
 
 


### PR DESCRIPTION
Previously in Multi Arch CI ASAN (https://github.com/ROCm/TheRock/actions/runs/25710576013), pytorch and package builds fail as we have not worked on support for those. To keep green signal, we are removing those jobs until we provide support and have a green signal

working here on test: https://github.com/ROCm/TheRock/actions/runs/25811658440