### PR TITLE
[ci] Guard downstream consumers on empty upstream output URLs

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -132,6 +132,8 @@ jobs:
     # - Build succeeded (or using prebuilt artifacts)
     # - Not expecting failure
     # - Test runner is available (test_runs_on is set)
+    # - The build produced a find-links URL (empty on forks where the S3
+    #   upload step is skipped for lack of AWS credentials)
     if: >-
       ${{
         !failure() &&
@@ -141,7 +143,8 @@ jobs:
           inputs.use_prebuilt_artifacts == 'true'
         ) &&
         inputs.expect_failure == false &&
-        inputs.test_runs_on != ''
+        inputs.test_runs_on != '' &&
+        needs.build_portable_linux_python_packages.outputs.package_find_links_url != ''
       }}
     uses: ./.github/workflows/test_rocm_wheels.yml
     with:
@@ -157,6 +160,9 @@ jobs:
   build_portable_linux_pytorch_wheels_ci:
     needs: [build_portable_linux_python_packages]
     name: Build PyTorch
+    # PyTorch builds pip-install ROCm wheels via rocm_package_find_links_url;
+    # an empty URL (fork PRs, where the S3 upload step is skipped) means
+    # pip cannot resolve them, so we skip the build.
     if: >-
       ${{
         !failure() &&
@@ -165,7 +171,8 @@ jobs:
           inputs.use_prebuilt_artifacts == 'false' ||
           inputs.use_prebuilt_artifacts == 'true'
         ) &&
-        inputs.build_pytorch == true
+        inputs.build_pytorch == true &&
+        needs.build_portable_linux_python_packages.outputs.package_find_links_url != ''
       }}
     uses: ./.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
     with:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -132,6 +132,8 @@ jobs:
     # - Build succeeded (or using prebuilt artifacts)
     # - Not expecting failure
     # - Test runner is available (test_runs_on is set)
+    # - The build produced a find-links URL (empty on forks where the S3
+    #   upload step is skipped for lack of AWS credentials)
     if: >-
       ${{
         !failure() &&
@@ -141,7 +143,8 @@ jobs:
           inputs.use_prebuilt_artifacts == 'true'
         ) &&
         inputs.expect_failure == false &&
-        inputs.test_runs_on != ''
+        inputs.test_runs_on != '' &&
+        needs.build_windows_python_packages.outputs.package_find_links_url != ''
       }}
     uses: ./.github/workflows/test_rocm_wheels.yml
     with:
@@ -157,6 +160,9 @@ jobs:
   build_windows_pytorch_wheels_ci:
     needs: [build_windows_python_packages]
     name: Build PyTorch
+    # PyTorch builds pip-install ROCm wheels via rocm_package_find_links_url;
+    # an empty URL (fork PRs, where the S3 upload step is skipped) means
+    # pip cannot resolve them, so we skip the build.
     if: >-
       ${{
         !failure() &&
@@ -165,7 +171,8 @@ jobs:
           inputs.use_prebuilt_artifacts == 'false' ||
           inputs.use_prebuilt_artifacts == 'true'
         ) &&
-        inputs.build_pytorch == true
+        inputs.build_pytorch == true &&
+        needs.build_windows_python_packages.outputs.package_find_links_url != ''
       }}
     uses: ./.github/workflows/build_windows_pytorch_wheels_ci.yml
     with:

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -169,7 +169,10 @@ jobs:
   test_native_packages_ubuntu2404:
     needs: [build_native_deb_packages]
     name: Test DEB Install - ubuntu2404
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    # The package_repository_url is empty on forks because the build job
+    # skips the S3 upload step (it has no AWS credentials). Skip install
+    # tests when there's no repository URL to install from.
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false && needs.build_native_deb_packages.outputs.package_repository_url != '' }}
     uses: ./.github/workflows/test_native_linux_packages_install.yml
     with:
       package_install_url: ${{ needs.build_native_deb_packages.outputs.package_repository_url }}
@@ -184,7 +187,8 @@ jobs:
   test_native_packages_rhel10:
     needs: [build_native_rpm_packages]
     name: Test RPM Install - rhel10
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    # See note on test_native_packages_ubuntu2404 about the empty-URL guard.
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false && needs.build_native_rpm_packages.outputs.package_repository_url != '' }}
     uses: ./.github/workflows/test_native_linux_packages_install.yml
     with:
       package_install_url: ${{ needs.build_native_rpm_packages.outputs.package_repository_url }}
@@ -199,7 +203,8 @@ jobs:
   test_native_packages_sles16:
     needs: [build_native_rpm_packages]
     name: Test RPM Install - sles16
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    # See note on test_native_packages_ubuntu2404 about the empty-URL guard.
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false && needs.build_native_rpm_packages.outputs.package_repository_url != '' }}
     uses: ./.github/workflows/test_native_linux_packages_install.yml
     with:
       package_install_url: ${{ needs.build_native_rpm_packages.outputs.package_repository_url }}
@@ -229,7 +234,9 @@ jobs:
   test_python_packages_per_family:
     needs: [build_python_packages]
     name: Test Python ${{ matrix.family_info.amdgpu_family }} | ${{ matrix.image.name }}
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    # package_find_links_url is empty on forks (S3 upload skipped, no AWS
+    # credentials). Skip wheel tests when there's no find-links URL.
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false && needs.build_python_packages.outputs.package_find_links_url != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -270,7 +277,9 @@ jobs:
   build_pytorch_wheel_fat:
     needs: [build_python_packages]
     name: Build PyTorch (fat + split)
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_pytorch == true }}
+    # PyTorch builds pip-install ROCm wheels via rocm_package_find_links_url;
+    # without it (forks have no S3 upload) the build can't resolve them.
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_pytorch == true && needs.build_python_packages.outputs.package_find_links_url != '' }}
     uses: ./.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
     with:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -157,7 +157,9 @@ jobs:
   test_python_packages_per_family:
     needs: [build_python_packages]
     name: Test Python ${{ matrix.family_info.amdgpu_family }}
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false }}
+    # package_find_links_url is empty on forks (S3 upload skipped, no AWS
+    # credentials). Skip wheel tests when there's no find-links URL.
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).expect_failure == false && needs.build_python_packages.outputs.package_find_links_url != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -193,7 +195,9 @@ jobs:
   build_pytorch_wheel_fat:
     needs: [build_python_packages]
     name: Build PyTorch (fat + split)
-    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_pytorch == true }}
+    # PyTorch builds pip-install ROCm wheels via rocm_package_find_links_url;
+    # without it (forks have no S3 upload) the build can't resolve them.
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_pytorch == true && needs.build_python_packages.outputs.package_find_links_url != '' }}
     uses: ./.github/workflows/build_windows_pytorch_wheels_ci.yml
     with:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}


### PR DESCRIPTION
## Summary

When upstream upload steps (S3 wheel/package uploads) produce no URL
output — e.g. fork PRs without credentials, or transient upload
failures — downstream consumer jobs (install tests, wheel tests,
PyTorch builds) still run and then fail at the install step with
"no such package" errors. This PR adds `&& steps.X.outputs.Y != ''`
to each consumer's `if:` condition so they skip cleanly when the
upstream URL is empty, rather than starting and erroring.

The guard is robust to any cause of a missing upload URL, not only
forks. It is purely a consumer-side defensive check; the upstream
auth gap that produces empty URLs on fork PRs is being addressed
separately at the credential layer in #5066.

## Changes

| File | Edit |
|---|---|
| `ci_linux.yml` | 2 consumer empty-output guards |
| `ci_windows.yml` | 2 consumer empty-output guards |
| `multi_arch_ci_linux.yml` | 5 consumer empty-output guards |
| `multi_arch_ci_windows.yml` | 2 consumer empty-output guards |

## Out of scope

- Fork upload auth (`NoCredentialsError` on fork PRs against AWS
  uploads) is being fixed at the credential layer in #5066. This PR
  does not skip any upload step.
- `build_portable_linux_pytorch_wheels.yml` /
  `build_windows_pytorch_wheels.yml` use direct
  `aws-actions/configure-aws-credentials` without a fork-guard, so
  on forks they fail at Configure, not Upload — different signature,
  separate work.
- The Windows test-matrix prejob's stale-process cleanup is filed
  separately in #5228.

## Test plan

- [x] `pre-commit run` clean on all 4 files (including actionlint)
- [ ] CI exercises the multi-arch path; consumer jobs should now
      skip cleanly when upstream outputs are empty rather than
      erroring during install

Generated using Claude Code.