### PR TITLE
[ci] Skip already-exited processes in Windows runner prejob cleanup

### DIFF
--- a/build_tools/github_actions/cleanup_processes.ps1
+++ b/build_tools/github_actions/cleanup_processes.ps1
@@ -30,7 +30,14 @@
 #### Helper functions ####
 
 function Get-Process-Filter ([String]$RegexStr)  {
-    Get-Process | Where-Object { $_.MainModule.FileName -Match $RegexStr }
+    # Skip processes that have already exited: PowerShell's Get-Process can
+    # surface stale handles for processes that died naturally but whose
+    # process objects are still cached, and WMI Terminate is a silent no-op
+    # on them. Without this guard, Wait-Process-Filter loops forever on the
+    # zombie handle and the script reports "Failed to stop" on a process
+    # that already finished. The -and short-circuits the .MainModule access
+    # for exited processes, where that property is unreliable.
+    Get-Process | Where-Object { -not $_.HasExited -and $_.MainModule.FileName -Match $RegexStr }
 }
 function Get-Process-Info ($PSobj) {
     # Note in powershell this output gets buffered and returned from this function

--- a/build_tools/github_actions/cleanup_processes.ps1
+++ b/build_tools/github_actions/cleanup_processes.ps1
@@ -33,10 +33,11 @@ function Get-Process-Filter ([String]$RegexStr)  {
     # Skip processes that have already exited: PowerShell's Get-Process can
     # surface stale handles for processes that died naturally but whose
     # process objects are still cached, and WMI Terminate is a silent no-op
-    # on them. Without this guard, Wait-Process-Filter loops forever on the
-    # zombie handle and the script reports "Failed to stop" on a process
-    # that already finished. The -and short-circuits the .MainModule access
-    # for exited processes, where that property is unreliable.
+    # on them. Without this guard, Wait-Process-Filter exhausts all of its
+    # bounded retries on the zombie handle and the script then reports
+    # "Failed to stop" on a process that already finished. The -and
+    # short-circuits the .MainModule access for exited processes, where
+    # that property is unreliable.
     Get-Process | Where-Object { -not $_.HasExited -and $_.MainModule.FileName -Match $RegexStr }
 }
 function Get-Process-Info ($PSobj) {


### PR DESCRIPTION
## Summary

`cleanup_processes.ps1` runs as a Windows runner pre-job script that stops executables left over from previous jobs so that `actions/checkout` can delete the workspace. It loops on `Get-Process | Where-Object { $_.MainModule.FileName -Match $RegexStr }` and treats a non-empty list as "still running."

PowerShell's `Get-Process` can return stale objects for processes that already exited but whose `Process` objects are still cached (e.g. when something is still holding a handle to them). Those objects report `HasExited:True`, but the script counts them anyway. WMI `Terminate()` on an already-dead PID is a silent no-op, so the zombie handle survives every retry, and after five attempts the script exits 1 with "Failed to stop executable(s)" on a process that finished naturally minutes ago.

This bites the Windows test-matrix prejob step intermittently when `rocblas-test.exe` (or any `build\*.exe`) exits cleanly just before cleanup runs. Recent observation: https://github.com/ROCm/TheRock/actions/runs/25753877460/job/75686544203 — the log shows `[pid:11584][HasExited:True] rocblas-test.exe` printed inside the `Failed to stop executable(s)` block.

## Fix

Guard `Get-Process-Filter` against exited processes:

```powershell
Get-Process | Where-Object { -not $_.HasExited -and $_.MainModule.FileName -Match $RegexStr }
```

The `-and` short-circuits `.MainModule` access for exited processes, where that property can be unreliable. All four call sites in the script (initial check, wait loop, and the two post-attempt re-checks) flow through this function, so the single function-level fix covers everything.

## Test plan

- [x] `pre-commit run` clean
- [ ] No clean way to exercise locally (Windows-only, runs as a pre-job hook on non-ephemeral runners); validation will come from absence of intermittent "Configure test matrix" red Xs on subsequent runs that reuse the same Azure runner

Generated using Claude Code.