### PR TITLE
[ci] Allow rocBLAS to keep its 6 shards on quick test runs

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -89,6 +89,13 @@ test_matrix = {
             "linux": 6,
             "windows": 6,
         },
+        # rocBLAS's "quick" suite is a single CTest target (rocblas-test_quick_suite)
+        # with a 600s CTest TIMEOUT. The unsharded gtest invocation runs every
+        # *quick* test case in one process and now exceeds 600s on CI, so the
+        # one-shard default for test_type=quick must be overridden here. With
+        # 6 shards, each gtest invocation handles ~1/6 of the cases via
+        # GTEST_TOTAL_SHARDS/GTEST_SHARD_INDEX and finishes well under 600s.
+        "shard_quick_tests": True,
     },
     "rocroller": {
         "job_name": "rocroller",
@@ -677,8 +684,13 @@ def run():
             job_config_data["total_shards"] = total_shards
 
             # If the test type is quick tests, we only need one shard for the test job
+            # unless the component opts in to shard its quick tests too. Components
+            # whose quick suite has grown beyond a single CTest TIMEOUT budget set
+            # "shard_quick_tests": True and keep their total_shards_dict value.
             # Note: Benchmarks always use test_type="full" but have total_shards=1 anyway
-            if test_type == "quick":
+            if test_type == "quick" and not job_config_data.get(
+                "shard_quick_tests", False
+            ):
                 job_config_data["total_shards"] = 1
                 job_config_data["shard_arr"] = [1]
 

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -125,9 +125,27 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         fetch_test_configurations.run()
         components = self._get_components()
 
+        # Components without the shard_quick_tests opt-in collapse to a single
+        # shard on quick runs; opted-in components keep their full shard count.
         for job in components:
+            if job.get("shard_quick_tests"):
+                continue
             self.assertEqual(job["total_shards"], 1)
             self.assertEqual(job["shard_arr"], [1])
+
+    def test_quick_test_respects_shard_quick_tests_opt_in(self):
+        """Components with shard_quick_tests=True keep their full shard count on quick runs."""
+        os.environ["TEST_TYPE"] = "quick"
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        # rocBLAS opts in (its quick suite is one CTest target that exceeds
+        # the CTest TIMEOUT budget when unsharded). It must keep linux: 6.
+        rocblas = next(j for j in components if j["job_name"] == "rocblas")
+        self.assertTrue(rocblas.get("shard_quick_tests"))
+        self.assertEqual(rocblas["total_shards"], 6)
+        self.assertEqual(rocblas["shard_arr"], [1, 2, 3, 4, 5, 6])
 
     def test_platform_specific_shards(self):
         os.environ["PROJECTS_TO_TEST"] = "hipblaslt"


### PR DESCRIPTION
## Summary

`fetch_test_configurations.py` unconditionally collapses `total_shards` to 1 when `test_type == "quick"`. The override is right for most components — their quick suites are quick — but it's incorrect for rocBLAS, where the "quick" CTest entry (`rocblas-test_quick_suite`) is a single non-shardable target whose gtest filter (`*quick*`) now matches enough cases to exceed the 600s CTest TIMEOUT budget when run unsharded.

Evidence: https://github.com/ROCm/TheRock/actions/runs/25753877460/job/75666293964 — `0% tests passed, 1 tests failed out of 1: rocblas-test_quick_suite (Timeout)` at exactly `600.29 sec`, on a job named `(shard 1/1)`. The rocBLAS config (line 83-84) already documents an assumption of 6-way sharding (`24h / 6 shards = 4h per shard`), so the override silently breaks that intent for the quick path.

## Fix

Add an opt-in flag `shard_quick_tests: True` to the component config. When set, the component keeps its `total_shards_dict` value even for `test_type=quick`; when unset (the existing default), behavior is unchanged. rocBLAS opts in.

## Why opt-in rather than removing the override

The override was added deliberately in 2025-10 (then for "smoke" tests, renamed when test types were unified) to save CI machine time on fast suites. That assumption is still correct for most components; only rocBLAS has outgrown a single-shard budget so far. An opt-in keeps everyone else's behavior identical and minimizes blast radius.

## Changes

| File | Edit |
|---|---|
| `fetch_test_configurations.py` | `shard_quick_tests: True` on rocblas; gate override on the flag |
| `tests/fetch_test_configurations_test.py` | existing `test_quick_test_forces_single_shard` skips opted-in components; new `test_quick_test_respects_shard_quick_tests_opt_in` asserts rocblas keeps its 6 shards |

## Test plan

- [x] `python -m unittest build_tools.github_actions.tests.fetch_test_configurations_test -v` — 21/21 pass
- [x] `pre-commit run` clean (black formatted)
- [ ] CI on this PR exercises `quick` test_type on rocBLAS; expected outcome is six parallel `Test rocblas (shard N/6)` jobs each finishing well under 600s, where the previous behavior had one `(shard 1/1)` job hitting the 600s timeout

Generated using Claude Code.