### PR TITLE
Re-add `pytorch-triton-rocm`

### DIFF
--- a/build_tools/third_party/s3_management/manage.py
+++ b/build_tools/third_party/s3_management/manage.py
@@ -111,6 +111,7 @@ PACKAGE_ALLOW_LIST = {x.lower() for x in [
     "rocm_sdk_libraries",
     # ---- triton ----
     "triton",
+    "pytorch_triton_rocm",
     # ---- triton additional packages ----
     "Arpeggio",
     "caliper_reader",


### PR DESCRIPTION
With newer releases we only build `triton` but with earlier releases `pytorch-triton-rocm` was pushed as a pre-release but was missed to index.