### PR TITLE
[ci] Add more test dependency for test subprojects

### DIFF
--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -153,6 +153,9 @@ therock_cmake_subproject_declare(hipBLASLt
     ${hipBLASLt_rocRoller_runtime_deps}
     ${hipBLASLt_runtime_deps}
     ${optional_profiler_deps}
+  TEST_SUBPROJECTS
+    hipSPARSELt
+    MIOpen
 )
 therock_cmake_subproject_glob_c_sources(hipBLASLt
   SUBDIRS
@@ -272,8 +275,9 @@ if(THEROCK_ENABLE_SPARSE)
       hip-clr
       ${optional_profiler_deps}
     TEST_SUBPROJECTS
-      rocSPARSE
       hipSPARSE
+      rocSOLVER
+      hipSOLVER
   )
   therock_cmake_subproject_glob_c_sources(rocSPARSE
     SUBDIRS

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -366,6 +366,8 @@ if(THEROCK_ENABLE_ROCWMMA)
       hip-clr
       rocBLAS
       ${_rocwmma_optional_deps}
+    TEST_SUBPROJECTS
+      rocWMMA
   )
   therock_cmake_subproject_glob_c_sources(rocWMMA
     SUBDIRS

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -56,6 +56,7 @@ if(THEROCK_ENABLE_RAND)
     RUNTIME_DEPS
       hip-clr
       rocRAND
+    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_glob_c_sources(hipRAND
     SUBDIRS
@@ -299,6 +300,7 @@ if(THEROCK_ENABLE_FFT)
     RUNTIME_DEPS
       hip-clr
       rocFFT
+    TEST_SUBPROJECTS
   )
   therock_cmake_subproject_glob_c_sources(hipFFT
     SUBDIRS
@@ -367,7 +369,6 @@ if(THEROCK_ENABLE_ROCWMMA)
       rocBLAS
       ${_rocwmma_optional_deps}
     TEST_SUBPROJECTS
-      rocWMMA
   )
   therock_cmake_subproject_glob_c_sources(rocWMMA
     SUBDIRS

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -24,6 +24,8 @@ if(THEROCK_ENABLE_RAND)
       therock-googletest
     RUNTIME_DEPS
       hip-clr
+    TEST_SUBPROJECTS
+      hipRAND
   )
   therock_cmake_subproject_glob_c_sources(rocRAND
     SUBDIRS
@@ -99,6 +101,10 @@ if(THEROCK_ENABLE_PRIM)
       rocm-cmake
     RUNTIME_DEPS
       hip-clr
+    TEST_SUBPROJECTS
+      hipCUB
+      rocThrust
+      rocSPARSE
   )
   therock_cmake_subproject_glob_c_sources(rocPRIM
     SUBDIRS
@@ -257,6 +263,8 @@ if(THEROCK_ENABLE_FFT)
     RUNTIME_DEPS
       hip-clr
       hipRAND
+    TEST_SUBPROJECTS
+      hipFFT
   )
   therock_cmake_subproject_glob_c_sources(rocFFT
     SUBDIRS

--- a/test_tools/determine_rocm_test_dependencies.py
+++ b/test_tools/determine_rocm_test_dependencies.py
@@ -34,7 +34,7 @@ def parse_cmake_test_subprojects(therock_dir):
             subproject_name = match.group(1).lower()
             block_content = match.group(2)
 
-                # Look for TEST_SUBPROJECTS within this block
+            # Look for TEST_SUBPROJECTS within this block
             # Match TEST_SUBPROJECTS with optional list of dependencies
             # Empty TEST_SUBPROJECTS is valid (only tests itself)
             test_subprojects_match = re.search(

--- a/test_tools/determine_rocm_test_dependencies.py
+++ b/test_tools/determine_rocm_test_dependencies.py
@@ -34,13 +34,15 @@ def parse_cmake_test_subprojects(therock_dir):
             subproject_name = match.group(1).lower()
             block_content = match.group(2)
 
-            # Look for TEST_SUBPROJECTS within this block
+                # Look for TEST_SUBPROJECTS within this block
+            # Match TEST_SUBPROJECTS with optional list of dependencies
+            # Empty TEST_SUBPROJECTS is valid (only tests itself)
             test_subprojects_match = re.search(
-                r"TEST_SUBPROJECTS\s+((?:\s+\w+)+)", block_content
+                r"TEST_SUBPROJECTS(?:\s+((?:\w+\s*)+))?", block_content
             )
 
             if test_subprojects_match:
-                deps_str = test_subprojects_match.group(1).strip()
+                deps_str = (test_subprojects_match.group(1) or "").strip()
                 deps = [d.strip().lower() for d in deps_str.split() if d.strip()]
                 test_deps[subproject_name] = deps
 
@@ -72,12 +74,26 @@ def get_rocm_test_dependencies(changed_subprojects, therock_dir=None):
     return get_subprojects_to_test(changed_subprojects, therock_dir)
 
 
-def list_subprojects(therock_dir=None):
-    """List all subprojects with TEST_SUBPROJECTS."""
+def list_subprojects(therock_dir=None, show_deps=False):
+    """List all subprojects with TEST_SUBPROJECTS.
+
+    Args:
+        therock_dir: Path to TheRock directory
+        show_deps: If True, return dict with deps; if False, return list of names
+    """
     if therock_dir is None:
         therock_dir = Path.cwd()
 
     test_deps = parse_cmake_test_subprojects(therock_dir)
+
+    if show_deps:
+        # Return dict with "empty" indicator for subprojects with no test deps
+        result = {}
+        for name in sorted(test_deps.keys()):
+            deps = test_deps[name]
+            result[name] = deps if deps else "empty"
+        return result
+
     return sorted(test_deps.keys())
 
 
@@ -106,6 +122,11 @@ def main():
         "--list-subprojects", action="store_true", help="List all subprojects"
     )
     parser.add_argument(
+        "--show-deps",
+        action="store_true",
+        help="With --list-subprojects, show dependencies (or 'empty' if none)",
+    )
+    parser.add_argument(
         "--format",
         choices=["json", "list"],
         default="json",
@@ -117,7 +138,7 @@ def main():
     therock_dir = Path(args.therock_dir).resolve()
 
     if args.list_subprojects:
-        result = list_subprojects(therock_dir)
+        result = list_subprojects(therock_dir, show_deps=args.show_deps)
         print(json.dumps(result, indent=2))
         return
 

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -11,6 +11,7 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 from determine_rocm_test_dependencies import (
     parse_cmake_test_subprojects,
     get_subprojects_to_test,
+    list_subprojects,
 )
 
 
@@ -26,7 +27,7 @@ class CMakeParserTest(unittest.TestCase):
 
         # Verify rocSPARSE test dependencies
         self.assertIn("rocsparse", test_deps)
-        self.assertEqual(set(test_deps["rocsparse"]), {"rocsparse", "hipsparse"})
+        self.assertEqual(set(test_deps["rocsparse"]), {"hipsparse", "rocsolver", "hipsolver"})
 
         # Verify hipSPARSE test dependencies
         self.assertIn("hipsparse", test_deps)
@@ -48,6 +49,18 @@ class CMakeParserTest(unittest.TestCase):
         self.assertIn("rocfft", test_deps)
         self.assertEqual(set(test_deps["rocfft"]), {"hipfft"})
 
+        # Verify rocWMMA has empty TEST_SUBPROJECTS (tests only itself)
+        self.assertIn("rocwmma", test_deps)
+        self.assertEqual(test_deps["rocwmma"], [])
+
+        # Verify hipRAND has empty TEST_SUBPROJECTS (tests only itself)
+        self.assertIn("hiprand", test_deps)
+        self.assertEqual(test_deps["hiprand"], [])
+
+        # Verify hipFFT has empty TEST_SUBPROJECTS (tests only itself)
+        self.assertIn("hipfft", test_deps)
+        self.assertEqual(test_deps["hipfft"], [])
+
     def test_get_subprojects_to_test(self):
         """Test get_subprojects_to_test with real CMake files."""
         therock_dir = Path(__file__).parent.parent.parent
@@ -58,7 +71,41 @@ class CMakeParserTest(unittest.TestCase):
 
         # Test rocSPARSE
         result = get_subprojects_to_test(["ROCSPARSE"], therock_dir)
-        self.assertEqual(result, {"rocsparse", "hipsparse"})
+        self.assertEqual(result, {"rocsparse", "hipsparse", "rocsolver", "hipsolver"})
+
+    def test_empty_test_subprojects(self):
+        """Test that empty TEST_SUBPROJECTS works correctly."""
+        therock_dir = Path(__file__).parent.parent.parent
+
+        # rocWMMA has empty TEST_SUBPROJECTS, should only return itself
+        result = get_subprojects_to_test(["rocWMMA"], therock_dir)
+        self.assertEqual(result, {"rocwmma"})
+
+        # hipRAND has empty TEST_SUBPROJECTS, should only return itself
+        result = get_subprojects_to_test(["hipRAND"], therock_dir)
+        self.assertEqual(result, {"hiprand"})
+
+        # hipFFT has empty TEST_SUBPROJECTS, should only return itself
+        result = get_subprojects_to_test(["hipFFT"], therock_dir)
+        self.assertEqual(result, {"hipfft"})
+
+    def test_list_subprojects_with_show_deps(self):
+        """Test list_subprojects with show_deps option."""
+        therock_dir = Path(__file__).parent.parent.parent
+
+        # Without show_deps, should return list
+        result = list_subprojects(therock_dir, show_deps=False)
+        self.assertIsInstance(result, list)
+        self.assertIn("rocblas", result)
+        self.assertIn("rocwmma", result)
+
+        # With show_deps, should return dict with "empty" for empty deps
+        result = list_subprojects(therock_dir, show_deps=True)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["rocblas"], ["hipblas", "rocsolver"])
+        self.assertEqual(result["rocwmma"], "empty")
+        self.assertEqual(result["hiprand"], "empty")
+        self.assertEqual(result["hipfft"], "empty")
 
 
 if __name__ == "__main__":

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -42,7 +42,9 @@ class CMakeParserTest(unittest.TestCase):
 
         # Verify rocPRIM test dependencies
         self.assertIn("rocprim", test_deps)
-        self.assertEqual(set(test_deps["rocprim"]), {"hipcub", "rocthrust", "rocsparse"})
+        self.assertEqual(
+            set(test_deps["rocprim"]), {"hipcub", "rocthrust", "rocsparse"}
+        )
 
         # Verify rocFFT test dependencies
         self.assertIn("rocfft", test_deps)

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -27,7 +27,9 @@ class CMakeParserTest(unittest.TestCase):
 
         # Verify rocSPARSE test dependencies
         self.assertIn("rocsparse", test_deps)
-        self.assertEqual(set(test_deps["rocsparse"]), {"hipsparse", "rocsolver", "hipsolver"})
+        self.assertEqual(
+            set(test_deps["rocsparse"]), {"hipsparse", "rocsolver", "hipsolver"}
+        )
 
         # Verify hipSPARSE test dependencies
         self.assertIn("hipsparse", test_deps)

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -36,6 +36,18 @@ class CMakeParserTest(unittest.TestCase):
         self.assertIn("hipsparselt", test_deps)
         self.assertEqual(set(test_deps["hipsparselt"]), {"hipsparselt"})
 
+        # Verify rocRAND test dependencies
+        self.assertIn("rocrand", test_deps)
+        self.assertEqual(set(test_deps["rocrand"]), {"hiprand"})
+
+        # Verify rocPRIM test dependencies
+        self.assertIn("rocprim", test_deps)
+        self.assertEqual(set(test_deps["rocprim"]), {"hipcub", "rocthrust", "rocsparse"})
+
+        # Verify rocFFT test dependencies
+        self.assertIn("rocfft", test_deps)
+        self.assertEqual(set(test_deps["rocfft"]), {"hipfft"})
+
     def test_get_subprojects_to_test(self):
         """Test get_subprojects_to_test with real CMake files."""
         therock_dir = Path(__file__).parent.parent.parent


### PR DESCRIPTION
After reaching out to component teams in regards to what components are dependent, we have determined the best subcomponents to test for each project.

Projects with `TEST_SUBPROJECTS` only need to test itself