### PR TITLE
Skip S3 credential test when the endpoint is unavailable

### DIFF
--- a/build_tools/tests/artifact_backend_test.py
+++ b/build_tools/tests/artifact_backend_test.py
@@ -5,6 +5,7 @@
 """Unit tests for artifact_backend.py."""
 
 import os
+import socket
 import sys
 import tempfile
 import unittest
@@ -39,6 +40,16 @@ def _make_s3_root(
         run_id=run_id,
         platform=platform,
     )
+
+
+def _is_public_s3_available():
+    try:
+        with socket.create_connection(
+            ("therock-ci-artifacts.s3.amazonaws.com", 443), timeout=5
+        ):
+            return True
+    except OSError:
+        return False
 
 
 class TestLocalDirectoryBackend(unittest.TestCase):
@@ -545,6 +556,10 @@ class TestS3BackendCredentials(unittest.TestCase):
         )
         return S3Backend(output_root=output_root)
 
+    @unittest.skipUnless(
+        _is_public_s3_available(),
+        "Public S3 endpoint is not reachable",
+    )
     def test_list_objects_unsigned(self):
         """Listing objects in a public bucket must succeed without credentials."""
         # Point config/credentials files at nonexistent paths so that

--- a/build_tools/tests/artifact_backend_test.py
+++ b/build_tools/tests/artifact_backend_test.py
@@ -558,7 +558,7 @@ class TestS3BackendCredentials(unittest.TestCase):
 
     @unittest.skipUnless(
         _is_public_s3_available(),
-        "Public S3 endpoint is not reachable",
+        "Public S3 endpoint is not reachable (sandbox with no network access?)",
     )
     def test_list_objects_unsigned(self):
         """Listing objects in a public bucket must succeed without credentials."""


### PR DESCRIPTION
## Motivation

I'm experimenting with Codex, and this test was failing under the Windows sandbox (https://developers.openai.com/codex/windows#windows-sandbox) where network access is blocked by default. Skipping the test is fine in that case, similar to how we skip tests that need authenticated access to the GitHub API: https://github.com/ROCm/TheRock/blob/a898cf24215b305808cab40b46e0abbce84065a7/build_tools/github_actions/tests/github_actions_api_test.py#L489-L493

## Test Plan

`pytest build_tools/tests/artifact_backend_test.py` inside and outside of the sandbox (passed outside, skipped inside)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
