### PR TITLE
[Media][Dependency] - add versioned symlinks for va libraries

### DIFF
--- a/third-party/sysdeps/linux/amd-mesa/patch_install.sh
+++ b/third-party/sysdeps/linux/amd-mesa/patch_install.sh
@@ -23,6 +23,7 @@ if [ -n "$VA_LIB" ]; then
     # Keep the meson-created symlinks, just add the additional symlink we need
     pushd "$PREFIX/lib" > /dev/null
     ln -sf "$(basename "$VA_LIB")" "libva.so"
+    ln -sf "$(basename "$VA_LIB")" "libva.so.2"
     popd > /dev/null
 else
     echo "Warning: Could not find librocm_sysdeps_va.so.2 symlink"
@@ -33,6 +34,7 @@ if [ -n "$VA_DRM_LIB" ]; then
     # Keep the meson-created symlinks, just add the additional symlink we need
     pushd "$PREFIX/lib" > /dev/null
     ln -sf "$(basename "$VA_DRM_LIB")" "libva-drm.so"
+    ln -sf "$(basename "$VA_DRM_LIB")" "libva-drm.so.2"
     popd > /dev/null
 else
     echo "Warning: Could not find librocm_sysdeps_va-drm.so.2 symlink"


### PR DESCRIPTION
## Motivation

This PR adds the necessary versioned symlinks for VA libraries required by certain applications. It introduces the following symlinks:

```
libva.so.2 → librocm_sysdeps_va.so.2
libva-drm.so.2 → librocm_sysdeps_va-drm.so.2
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
