### PR TITLE
Updated windows_support.md

### DIFF
--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -102,8 +102,16 @@ These instructions mostly mirror the instructions in the root
 Before diving into the full setup, you can run the environment validation script
 to check that all prerequisites are met:
 
-```powershell
-.\build_tools\validate_windows_install.ps1
+```bash
+powershell.exe .\build_tools\validate_windows_install.ps1
+```
+
+To get correct results you may need to set all Visual Studio specific paths and pre-configured Python's environment (see below), in such case you need to run few commands before:
+
+```bash
+vcvarsall.bat x64
+.venv\Scripts\Activate.bat
+powershell.exe .\build_tools\validate_windows_install.ps1
 ```
 
 The script checks RAM, disk space, long path support, symlink capability, MSVC,


### PR DESCRIPTION
Added information into docs for correct applying environment variables in a single command line session

## Motivation

Docs are not full at the moment. When you simply run validate_windows_install.ps1 it doesn't have an access to a current build environment, and it will always fail even all pre-requisites are resolved.

## Technical Details

We are talking about a single command line session, so it requires:
1. Set Visual Studio specific environment variables using vcvarsall.bat x64 (exact path depends on a used VS version)
2. Then need to initialize pre-configured Python's virtual environment (otherwise it will fail due to no requirements.txt installed globally)
3. And only after that need to run the script

## Test Plan

Manually verified

## Test Result

All necessary environment settings successfully verified

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
