### PR TITLE
[MIOpen] Use SYSTEM includes in pre_hook_MIOpen.cmake for third-party deps

### DIFF
--- a/ml-libs/pre_hook_MIOpen.cmake
+++ b/ml-libs/pre_hook_MIOpen.cmake
@@ -5,10 +5,8 @@
 # in an isolated directory via find_package (this has probably been masked when
 # in a directory with everything else). So we just include it here.
 # Fix upstream and remove this.
-include_directories("${THEROCK_BINARY_DIR}/math-libs/BLAS/hipBLAS/stage/include")
-
-# TODO: Ditto for hipBLAS-common
-include_directories("${THEROCK_BINARY_DIR}/math-libs/BLAS/hipBLAS-common/stage/include")
-
-# TODO: Ditto for rocrand
-include_directories("${THEROCK_BINARY_DIR}/math-libs/rocRAND/stage/include")
+# Use SYSTEM so these third-party headers are treated as system includes and do
+# not trigger warnings from MIOpen's own -Wall/-Wextra/-Werror flags.
+include_directories(SYSTEM "${THEROCK_BINARY_DIR}/math-libs/BLAS/hipBLAS/stage/include")
+include_directories(SYSTEM "${THEROCK_BINARY_DIR}/math-libs/BLAS/hipBLAS-common/stage/include")
+include_directories(SYSTEM "${THEROCK_BINARY_DIR}/math-libs/rocRAND/stage/include")


### PR DESCRIPTION
## Summary

- `pre_hook_MIOpen.cmake` was injecting hipBLAS, hipBLAS-common, and rocRAND include paths via `include_directories()`, which produces `-I` flags
- This causes headers from those libraries to be treated as project headers rather than system headers
- Warnings within them (e.g. `-Wold-style-cast`, `-Wundef` in rocRAND) then trigger MIOpen's own `-Werror` build
- Adding `SYSTEM` makes CMake emit `-isystem` instead, suppressing third-party warnings as intended

This fix removes the need for `#pragma clang diagnostic` workarounds that were added to MIOpen's source in ROCm/rocm-libraries#7257. Once this lands, those workarounds can be removed from the MIOpen PR.

**Root cause analysis:** The `include_directories()` calls in the pre-hook fire during MIOpen's CMake configure step before MIOpen's own `target_include_directories(MIOpen SYSTEM PRIVATE ${ROCRAND_INCLUDE_DIR})` can take effect. Since the same path gets added first as `-I`, the compiler treats rocRAND headers as non-system regardless of MIOpen's own target declarations.

**Risk analysis:** The risk on this is low since it just changes includes to be system level to stop the warning cascade.

**Note:** hipBLASLt and other `RUNTIME_DEP`s injected transitively via `therock_subproject.cmake` are not addressed here — that is a broader separate change.

## Test plan

- [x] MIOpen builds cleanly via TheRock with `-Werror` enabled (ROCm/rocm-libraries#7257) without `#pragma diagnostic` workarounds for rocRAND headers
- [x] Verify `-isystem` appears instead of `-I` for rocRAND/hipBLAS paths in verbose build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)