### PR TITLE
Patches to fix issues introduced by merge

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,5 +45,4 @@
 [submodule "rocgdb"]
 	path = debug-tools/rocgdb/source
 	url = https://github.com/ROCm/rocgdb.git
-    branch = amd-staging-rocgdb-16
-
+	branch = amd-staging-rocgdb-16

--- a/patches/amd-mainline/llvm-project/0007-AMDGPU-VOPD-fix-assembler-to-allow-same-VGPR-src0-o.patch
+++ b/patches/amd-mainline/llvm-project/0007-AMDGPU-VOPD-fix-assembler-to-allow-same-VGPR-src0-o.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrey Kasaurov <andrey.kasaurov@amd.com>
+Date: Wed, 14 May 2026 21:00:00 -0700
+Subject: [PATCH] [AMDGPU] VOPD: fix assembler to allow same-VGPR src0 on
+ GFX12
+
+Commit c510ee553e20 ("[AMDGPU] VOPD: AllowSameVGPR on GFX12") relaxed
+the codegen constraint to allow VOPD pairs where both halves share the
+same src0 VGPR on GFX12 targets, since the hardware supports this.
+However, the MC assembler validation was not updated to match.
+
+This mismatch causes build failures when the compiler generates valid
+VOPD pairs (e.g. v_dual_min_num_f32 + v_dual_max_num_f32 sharing src0)
+that the assembler then rejects with:
+  error: src0 operands must use different VGPR banks
+
+Align the assembler with codegen by changing AllowSameVGPR from
+isGFX1250Plus() to isGFX12Plus() in checkVOPDRegBankConstraints.
+
+This fixes RCCL gfx1200 build failures where the
+specialized_reduce_ring_simple_minmax kernel triggers this codepath.
+---
+ .../Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp   |  2 +-
+ .../test/MC/AMDGPU/gfx12_asm_vopd_features.s      |  8 ++++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+index cc8cea8f8411..60ad6b019080 100644
+--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
++++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+@@ -3994,7 +3994,7 @@ AMDGPUAsmParser::checkVOPDRegBankConstraints(const MCInst &Inst, bool AsVOPD3) {
+       Opcode == AMDGPU::V_DUAL_MOV_B32_e32_X_MOV_B32_e32_gfx13 ||
+       Opcode == AMDGPU::V_DUAL_MOV_B32_e32_X_MOV_B32_e32_e96_gfx1250 ||
+       Opcode == AMDGPU::V_DUAL_MOV_B32_e32_X_MOV_B32_e32_e96_gfx13;
+-  bool AllowSameVGPR = isGFX1250Plus();
++  bool AllowSameVGPR = isGFX12Plus();
+ 
+   if (AsVOPD3) { // Literal constants are not allowed with VOPD3.
+     for (auto OpName : {OpName::src0X, OpName::src0Y}) {
+diff --git a/llvm/test/MC/AMDGPU/gfx12_asm_vopd_features.s b/llvm/test/MC/AMDGPU/gfx12_asm_vopd_features.s
+index f42d54faff9a..f25cb6afe183 100644
+--- a/llvm/test/MC/AMDGPU/gfx12_asm_vopd_features.s
++++ b/llvm/test/MC/AMDGPU/gfx12_asm_vopd_features.s
+@@ -47,6 +47,14 @@
+ // A VOPD OpY mov_b32 instruction uses SRC2 source-cache if OpX is also mov_b32
+ //===----------------------------------------------------------------------===//
+ 
++//===----------------------------------------------------------------------===//
++// SRCX0 and SRCY0 may use the same bank if they are using the same VGPR; same for
++// VSRCX1 and VSRCY1.
++//===----------------------------------------------------------------------===//
++
++v_dual_add_f32 v2, v2, v5 :: v_dual_mul_f32 v3, v2, v5
++// GFX12: v_dual_add_f32 v2, v2, v5 :: v_dual_mul_f32 v3, v2, v5 ; encoding: [0x02,0x0b,0x06,0xc9,0x02,0x0b,0x02,0x02]
++
+ v_dual_add_f32      v255, s105, v2               ::  v_dual_cndmask_b32   v6, s105, v3
+ // GFX12: v_dual_add_f32 v255, s105, v2 :: v_dual_cndmask_b32 v6, s105, v3 ; encoding: [0x69,0x04,0x12,0xc9,0x69,0x06,0x06,0xff]
+ 
+-- 
+2.43.0
+

--- a/patches/amd-mainline/rocm-libraries/0001-CK-Suppress-Wlifetime-safety-lifetimebound-violation.patch
+++ b/patches/amd-mainline/rocm-libraries/0001-CK-Suppress-Wlifetime-safety-lifetimebound-violation.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrey Kasaurov <andrey.kasaurov@amd.com>
+Date: Wed, 14 May 2026 18:30:00 -0700
+Subject: [PATCH] CK: Suppress -Wlifetime-safety-lifetimebound-violation in
+ dtype_vector.hpp
+
+The upstream fix (10e9d70a) suppresses -Wlifetime-safety-intra-tu-suggestions
+but misses -Wlifetime-safety-lifetimebound-violation in dtype_vector.hpp,
+causing build failures with Clang 23+ when -Werror is enabled.
+
+---
+ .../include/ck/utility/dtype_vector.hpp          | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/projects/composablekernel/include/ck/utility/dtype_vector.hpp b/projects/composablekernel/include/ck/utility/dtype_vector.hpp
+index 2958cc2b864..4446cda58fe 100644
+--- a/projects/composablekernel/include/ck/utility/dtype_vector.hpp
++++ b/projects/composablekernel/include/ck/utility/dtype_vector.hpp
+@@ -8,6 +8,7 @@
+ #pragma clang diagnostic push
+ #pragma clang diagnostic ignored "-Wno-unknown-warning-option"
+ #pragma clang diagnostic ignored "-Wlifetime-safety-intra-tu-suggestions"
++#pragma clang diagnostic ignored "-Wlifetime-safety-lifetimebound-violation"
+ namespace ck {
+ 
+ __device__ int static err = 0;
+-- 
+2.49.0
+


### PR DESCRIPTION
## Motivation

Patches to fix several issues introduced my merge https://github.com/ROCm/TheRock/pull/5235 
* address `Math Libs` failures: suppress CK warnings related to `-Wlifetime-safety-lifetimebound-violation` flag
* address `Comm Libs` failures: fix in LLVM assembler for issue with `AllowSameVGPR()` on GFX12
* fix `.gitmodules` for an extra non-empty line

N.B. This PR is based on https://github.com/ROCm/TheRock/pull/5264 and https://github.com/ROCm/TheRock/pull/5268

## Technical Details

Issue with `AllowSameVGPR()` on GFX12 was introduced by commit https://github.com/llvm/llvm-project/commit/c510ee553e2057f94c2f023c72abb3c9afec0962 

Merge in `compiler/amd-staging` of the commit above introduced an LLVM assembler error in RCCL for the gfx1200 target (see e.g. https://github.com/ROCm/TheRock/actions/runs/25896035544/job/76113036390?pr=5264):
```
error: src0 operands must use different VGPR banks
v_dual_min_num_f32 v193, v20, v24 :: v_dual_max_num_f32 v20, v20, v24
```

The fix details:
* Verified hardware constraint -- Commit c510ee553e20 explicitly states "The hardware allows this" and deliberately relaxed codegen to use hasGFX12Insts() for AllowSameVGPR. The assembler was simply not updated to match.
* Patch introduce fix the LLVM assembler:
   * `llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp` line 3992: Change `isGFX1250Plus()` to `isGFX12Plus()` so the assembler accepts the same VOPD pairs that codegen creates for gfx1200.
   * `llvm/test/MC/AMDGPU/gfx12_asm_vopd_features.s`: Add a positive test case confirming that same-VGPR src0 in VOPD pairs is accepted for gfx12, matching the existing test in gfx1250_asm_vopd_features.s.

Related upstream PR: https://github.com/llvm/llvm-project/pull/198034

## Test Plan

CI Run

## Test Result

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
