### PR TITLE
[rocprofiler-systems] Patch library files to set the correct RPATH

### DIFF
--- a/profiler/post_hook_rocprofiler-systems.cmake
+++ b/profiler/post_hook_rocprofiler-systems.cmake
@@ -1,0 +1,29 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Dyninst and rocprofiler-systems internal libraries live in lib/rocprofiler-systems.
+# Set the RPATH origin per-target so that (for example) lib/rocm_sysdeps/lib resolves as
+# $ORIGIN/../rocm_sysdeps/lib rather than $ORIGIN/rocm_sysdeps/lib.
+set(_rocprofsys_lib_targets
+  common
+  dynElf
+  dynDwarf
+  dyninstAPI
+  dyninstAPI_RT
+  dynC_API
+  instructionAPI
+  parseAPI
+  patchAPI
+  pcontrol
+  stackwalk
+  symtabAPI
+  gotcha
+)
+
+foreach(_target ${_rocprofsys_lib_targets})
+  if(TARGET "${_target}")
+    set_target_properties("${_target}" PROPERTIES
+      THEROCK_INSTALL_RPATH_ORIGIN lib/rocprofiler-systems
+    )
+  endif()
+endforeach()


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Patching rocprofiler-systems libraries' RPATH.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
The issue in ROCM-24678 is that `rocprof-sys-instrument` cannot be run in the `dist` directory because the loader cannot find `libomp.so`.
- `rocprof-sys-instrument` depends on `libinstructionAPI.so`
- `libinstructionAPI.so` depends on `libomp.so`

The root cause is that RPATH in `rocprof-sys-instrument` is correctly pointing to
the location of `libinstructionAPI.so`, but RPATH in that library is wrong, so loader
can't find `libomp.so`.

This PR patches all libraries in `dist/rocm/lib/rocprofiler-systems` so that their RPATH
contains entries
`$ORIGIN/..:$ORIGIN:$ORIGIN/../llvm/lib:$ORIGIN/../rocm_sysdeps/lib`.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Build TheRock.
- In the directory `/therock/output/build/dist/rocm/lib/rocprofiler-systems` in the manylinux container, inspect each `.so` file with `patchelf`, for example:
  `patchelf --print-rpath libinstructionAPI.so`

## Test Result

<!-- Briefly summarize test outcomes. -->
- The output of the `patchelf` in the example above is:
  `$ORIGIN/..:$ORIGIN:$ORIGIN/../llvm/lib:$ORIGIN/../rocm_sysdeps/lib`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
