### PR TITLE
Add AORTA triage smoke test + weekly CI workflow

### DIFF
--- a/.github/workflows/ci_aorta_triage_smoke.yml
+++ b/.github/workflows/ci_aorta_triage_smoke.yml
@@ -11,18 +11,32 @@
 #
 # Required repository secrets
 # ---------------------------
-#  * AORTA_INTERNAL_TOKEN   PAT with read access to ROCm/aorta-internal so the
-#                           runner can clone the recipe + workload plugin
-#                           package. If unset, the job logs a warning and skips
-#                           the pytest step (the test's own ``skipif`` then
-#                           reports SKIPPED rather than FAILED).
-#  * DOCKERHUB_USERNAME     (optional) Docker Hub user for pulling private
-#                           recipe images (e.g. rocm/pytorch-private:*).
-#  * DOCKERHUB_TOKEN        (optional) Docker Hub token paired with the above.
-#                           When either secret is unset the docker login step
-#                           is skipped; recipes that need private images will
-#                           then fail with a pull error and surface as an
-#                           error cell, which is the desired signal.
+#  * AORTA_INTERNAL_APP_ID          GitHub App ID for an org-managed App that
+#                                   has at minimum ``Contents: Read``
+#                                   permission on ``ROCm/aorta-internal`` and
+#                                   is installed on both ``ROCm/TheRock`` and
+#                                   ``ROCm/aorta-internal``.
+#  * AORTA_INTERNAL_APP_PRIVATE_KEY PEM-encoded private key for the same App.
+#                                   The workflow mints a short-lived
+#                                   installation token via
+#                                   ``actions/create-github-app-token`` -
+#                                   same pattern as ``bump_submodules.yml``
+#                                   so no personal PAT is involved.
+#                                   When either of these is unset the job
+#                                   logs a warning and skips the
+#                                   aorta-internal clone + pytest steps
+#                                   (the test's own ``skipif`` then reports
+#                                   SKIPPED rather than FAILED).
+#  * DOCKERHUB_USERNAME             (optional) Docker Hub user for pulling
+#                                   private recipe images (e.g.
+#                                   rocm/pytorch-private:*).
+#  * DOCKERHUB_TOKEN                (optional) Docker Hub token paired with
+#                                   the above. When either secret is unset
+#                                   the docker login step is skipped;
+#                                   recipes that need private images will
+#                                   then fail with a pull error and surface
+#                                   as an error cell, which is the desired
+#                                   signal.
 #
 # See ``test_aorta_triage.py`` for the env-var contract and pre-reqs.
 
@@ -131,14 +145,31 @@ jobs:
           echo "AORTA_SRC_DIR=${aorta_src}" >> "${GITHUB_ENV}"
           echo "AORTA_INTERNAL_SRC_DIR=${aorta_internal_src}" >> "${GITHUB_ENV}"
 
+      - name: Detect aorta-internal App credentials availability
+        id: app_creds
+        env:
+          APP_ID: ${{ secrets.AORTA_INTERNAL_APP_ID }}
+          APP_KEY: ${{ secrets.AORTA_INTERNAL_APP_PRIVATE_KEY }}
+        # Mirror the secret presence into a step output so the
+        # ``create-github-app-token`` action and the clone step can gate on
+        # it (the ``secrets`` context is not available in step ``if:``
+        # conditions). Both secrets must be set; either missing means we
+        # cannot mint an installation token, so we degrade to the
+        # graceful-skip path.
+        run: |
+          set -euo pipefail
+          if [ -n "${APP_ID:-}" ] && [ -n "${APP_KEY:-}" ]; then
+            echo "available=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "available=false" >> "${GITHUB_OUTPUT}"
+            echo "::warning::AORTA_INTERNAL_APP_ID/AORTA_INTERNAL_APP_PRIVATE_KEY secrets are not configured; skipping aorta-internal clone and pytest steps."
+          fi
+
       - name: Detect Docker Hub auth availability
         id: dh_auth
         env:
           DH_USER: ${{ secrets.DOCKERHUB_USERNAME }}
           DH_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        # Mirror the secret presence into a step output so other steps can
-        # gate on it without referencing the ``secrets`` context (which is
-        # not available in step ``if:`` conditions).
         run: |
           set -euo pipefail
           if [ -n "${DH_USER:-}" ] && [ -n "${DH_TOKEN:-}" ]; then
@@ -170,17 +201,25 @@ jobs:
             "git+https://github.com/${AORTA_REPO}.git@${AORTA_REF}#egg=aorta"
           aorta --version || aorta --help | head -1
 
+      - name: Generate aorta-internal App installation token
+        id: aorta_internal_token
+        if: steps.app_creds.outputs.available == 'true'
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.AORTA_INTERNAL_APP_ID }}
+          private-key: ${{ secrets.AORTA_INTERNAL_APP_PRIVATE_KEY }}
+          owner: "ROCm"
+          repositories: "aorta-internal"
+
       - name: Clone aorta-internal (private)
         id: clone_internal
+        if: steps.app_creds.outputs.available == 'true'
         env:
-          AORTA_INTERNAL_TOKEN: ${{ secrets.AORTA_INTERNAL_TOKEN }}
+          # Short-lived installation token (~1h TTL) minted above; not a
+          # personal PAT.
+          AORTA_INTERNAL_TOKEN: ${{ steps.aorta_internal_token.outputs.token }}
         run: |
           set -euo pipefail
-          if [ -z "${AORTA_INTERNAL_TOKEN:-}" ]; then
-            echo "::warning::AORTA_INTERNAL_TOKEN secret is not configured; skipping aorta-internal clone"
-            echo "internal_available=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
           rm -rf "${AORTA_INTERNAL_SRC_DIR}"
           git clone --depth 1 --branch "${AORTA_INTERNAL_REF}" \
             "https://x-access-token:${AORTA_INTERNAL_TOKEN}@github.com/${AORTA_INTERNAL_REPO}.git" \

--- a/.github/workflows/ci_aorta_triage_smoke.yml
+++ b/.github/workflows/ci_aorta_triage_smoke.yml
@@ -32,6 +32,17 @@ on:
   schedule:
     # Sunday 03:00 UTC. Pairs with the existing weekly slot in ci_weekly.yml.
     - cron: "0 3 * * 0"
+  # TEMPORARY (pre-merge testing only): trigger the workflow on every push to
+  # the development branch so we can validate end-to-end on a real GPU runner
+  # before this PR merges. Remove this `push:` block (and this comment)
+  # before final review / merge -- the merged version should rely on
+  # `schedule` + `workflow_dispatch` only.
+  push:
+    branches:
+      - aorta-triage-smoke-test
+    paths:
+      - .github/workflows/ci_aorta_triage_smoke.yml
+      - build_tools/github_actions/test_executable_scripts/test_aorta_triage.py
   workflow_dispatch:
     inputs:
       runner_label:

--- a/.github/workflows/ci_aorta_triage_smoke.yml
+++ b/.github/workflows/ci_aorta_triage_smoke.yml
@@ -1,0 +1,254 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Scheduled smoke test of the AORTA triage pipeline.
+#
+# Drives ``build_tools/github_actions/test_executable_scripts/test_aorta_triage.py``
+# from a GPU runner against a recipe checked out at job time. The test asserts
+# only milestone-1 plumbing (exit 0, ``matrix.md`` produced, no cell-level
+# ``error`` rows in ``matrix.json``); recipe-specific assertions (NaN bands,
+# confound flags, digest-pinned images) are deferred to follow-ups.
+#
+# Required repository secrets
+# ---------------------------
+#  * AORTA_INTERNAL_TOKEN   PAT with read access to ROCm/aorta-internal so the
+#                           runner can clone the recipe + workload plugin
+#                           package. If unset, the job logs a warning and skips
+#                           the pytest step (the test's own ``skipif`` then
+#                           reports SKIPPED rather than FAILED).
+#  * DOCKERHUB_USERNAME     (optional) Docker Hub user for pulling private
+#                           recipe images (e.g. rocm/pytorch-private:*).
+#  * DOCKERHUB_TOKEN        (optional) Docker Hub token paired with the above.
+#                           When either secret is unset the docker login step
+#                           is skipped; recipes that need private images will
+#                           then fail with a pull error and surface as an
+#                           error cell, which is the desired signal.
+#
+# See ``test_aorta_triage.py`` for the env-var contract and pre-reqs.
+
+name: CI Weekly AORTA Triage Smoke
+
+on:
+  schedule:
+    # Sunday 03:00 UTC. Pairs with the existing weekly slot in ci_weekly.yml.
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+    inputs:
+      runner_label:
+        description: "GPU runner label (must have docker + ROCm)."
+        type: string
+        default: "linux-gfx950-1gpu-ccs-ossci-rocm"
+      python_version:
+        description: "Python version to set up on the runner."
+        type: string
+        default: "3.12"
+      aorta_repo:
+        description: "Public aorta source repo (owner/name)."
+        type: string
+        default: "ROCm/aorta"
+      aorta_ref:
+        description: "Git ref of aorta to install (branch, tag, or SHA)."
+        type: string
+        default: "main"
+      aorta_internal_repo:
+        description: "Private aorta-internal source repo (owner/name)."
+        type: string
+        default: "ROCm/aorta-internal"
+      aorta_internal_ref:
+        description: "Git ref of aorta-internal to install (branch, tag, or SHA)."
+        type: string
+        default: "main"
+      recipe_relpath:
+        description: "Recipe YAML path relative to the aorta-internal checkout root."
+        type: string
+        default: "recipes/recom_repro_smoke.yaml"
+      mitigations_relpath:
+        description: "Optional mitigations sidecar path relative to aorta-internal root. Leave empty to skip --mitigations-file."
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  # Only one scheduled smoke at a time; serialize on workflow + ref.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: false
+
+run-name: >-
+  CI Weekly AORTA Triage Smoke
+  (${{ inputs.runner_label || 'linux-gfx950-1gpu-ccs-ossci-rocm' }},
+   recipe=${{ inputs.recipe_relpath || 'recipes/recom_repro_smoke.yaml' }})
+
+jobs:
+  aorta_triage_smoke:
+    name: AORTA triage smoke (${{ inputs.runner_label || 'linux-gfx950-1gpu-ccs-ossci-rocm' }})
+    runs-on: ${{ inputs.runner_label || 'linux-gfx950-1gpu-ccs-ossci-rocm' }}
+    timeout-minutes: 45
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      AORTA_REPO: ${{ inputs.aorta_repo || 'ROCm/aorta' }}
+      AORTA_REF: ${{ inputs.aorta_ref || 'main' }}
+      AORTA_INTERNAL_REPO: ${{ inputs.aorta_internal_repo || 'ROCm/aorta-internal' }}
+      AORTA_INTERNAL_REF: ${{ inputs.aorta_internal_ref || 'main' }}
+      RECIPE_RELPATH: ${{ inputs.recipe_relpath || 'recipes/recom_repro_smoke.yaml' }}
+      MITIGATIONS_RELPATH: ${{ inputs.mitigations_relpath || '' }}
+      TRIAGE_OUTPUT_DIR: ${{ github.workspace }}/triage-output
+
+    steps:
+      - name: Checkout TheRock
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ inputs.python_version || '3.12' }}
+
+      - name: Compute scratch directories
+        id: scratch
+        # ``runner.temp`` is only available inside steps, so derive the
+        # per-job scratch dirs here and persist them via GITHUB_ENV so
+        # subsequent steps can reference them as plain env vars.
+        run: |
+          set -euo pipefail
+          aorta_src="${RUNNER_TEMP}/aorta-src"
+          aorta_internal_src="${RUNNER_TEMP}/aorta-internal-src"
+          echo "AORTA_SRC_DIR=${aorta_src}" >> "${GITHUB_ENV}"
+          echo "AORTA_INTERNAL_SRC_DIR=${aorta_internal_src}" >> "${GITHUB_ENV}"
+
+      - name: Detect Docker Hub auth availability
+        id: dh_auth
+        env:
+          DH_USER: ${{ secrets.DOCKERHUB_USERNAME }}
+          DH_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        # Mirror the secret presence into a step output so other steps can
+        # gate on it without referencing the ``secrets`` context (which is
+        # not available in step ``if:`` conditions).
+        run: |
+          set -euo pipefail
+          if [ -n "${DH_USER:-}" ] && [ -n "${DH_TOKEN:-}" ]; then
+            echo "available=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "available=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Runner health check
+        run: |
+          set -euxo pipefail
+          uname -a
+          python --version
+          pip --version
+          docker --version || echo "::warning::docker CLI not found on runner"
+          if command -v rocm-smi >/dev/null 2>&1; then
+            rocm-smi --showproductname || true
+          else
+            echo "::warning::rocm-smi not found on runner"
+          fi
+
+      - name: Install public aorta package
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          # Public ROCm/aorta source install. The PyPI project named `aorta`
+          # is unrelated; we deliberately pin to the GitHub repo.
+          python -m pip install \
+            "git+https://github.com/${AORTA_REPO}.git@${AORTA_REF}#egg=aorta"
+          aorta --version || aorta --help | head -1
+
+      - name: Clone aorta-internal (private)
+        id: clone_internal
+        env:
+          AORTA_INTERNAL_TOKEN: ${{ secrets.AORTA_INTERNAL_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${AORTA_INTERNAL_TOKEN:-}" ]; then
+            echo "::warning::AORTA_INTERNAL_TOKEN secret is not configured; skipping aorta-internal clone"
+            echo "internal_available=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          rm -rf "${AORTA_INTERNAL_SRC_DIR}"
+          git clone --depth 1 --branch "${AORTA_INTERNAL_REF}" \
+            "https://x-access-token:${AORTA_INTERNAL_TOKEN}@github.com/${AORTA_INTERNAL_REPO}.git" \
+            "${AORTA_INTERNAL_SRC_DIR}"
+          echo "internal_available=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Install aorta-internal (editable)
+        if: steps.clone_internal.outputs.internal_available == 'true'
+        run: |
+          set -euxo pipefail
+          # Editable install so the recom_repro workload + mitigations
+          # entry-points register against the public aorta runtime.
+          python -m pip install -e "${AORTA_INTERNAL_SRC_DIR}"
+
+      - name: Resolve recipe + mitigations paths
+        if: steps.clone_internal.outputs.internal_available == 'true'
+        id: resolve_paths
+        run: |
+          set -euo pipefail
+          recipe_abs="${AORTA_INTERNAL_SRC_DIR}/${RECIPE_RELPATH}"
+          if [ ! -f "${recipe_abs}" ]; then
+            echo "::error::Recipe not found at ${recipe_abs}"
+            exit 1
+          fi
+          echo "recipe_abs=${recipe_abs}" >> "${GITHUB_OUTPUT}"
+          if [ -n "${MITIGATIONS_RELPATH}" ]; then
+            mitig_abs="${AORTA_INTERNAL_SRC_DIR}/${MITIGATIONS_RELPATH}"
+            if [ ! -f "${mitig_abs}" ]; then
+              echo "::error::Mitigations sidecar not found at ${mitig_abs}"
+              exit 1
+            fi
+            echo "mitigations_abs=${mitig_abs}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "mitigations_abs=" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Docker Hub login (optional)
+        id: docker_login
+        if: steps.dh_auth.outputs.available == 'true'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Warn when docker auth is not configured
+        if: steps.dh_auth.outputs.available != 'true'
+        run: |
+          echo "::warning::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN secrets not set; private images referenced by the recipe may fail to pull."
+
+      - name: Run AORTA triage smoke test
+        if: steps.clone_internal.outputs.internal_available == 'true'
+        env:
+          AORTA_RECIPE_PATH: ${{ steps.resolve_paths.outputs.recipe_abs }}
+          AORTA_MITIGATIONS_FILE: ${{ steps.resolve_paths.outputs.mitigations_abs }}
+        run: |
+          set -euxo pipefail
+          mkdir -p "${TRIAGE_OUTPUT_DIR}"
+          # --basetemp gives the dispatcher a predictable output path under
+          # the runner workspace so the upload-artifact step below can find
+          # matrix.md / matrix.json regardless of the recipe's ticket dir.
+          python -m pytest \
+            build_tools/github_actions/test_executable_scripts/test_aorta_triage.py \
+            -k test_aorta_triage_smoke \
+            --basetemp="${TRIAGE_OUTPUT_DIR}" \
+            -v -s --log-cli-level=INFO
+
+      - name: Upload triage matrix artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: aorta-triage-matrix-${{ github.run_id }}
+          path: |
+            ${{ env.TRIAGE_OUTPUT_DIR }}/**/matrix.md
+            ${{ env.TRIAGE_OUTPUT_DIR }}/**/matrix.json
+            ${{ env.TRIAGE_OUTPUT_DIR }}/**/cells/**/trial_*.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Docker Hub logout
+        if: always() && steps.docker_login.outcome == 'success'
+        run: |
+          docker logout || true

--- a/build_tools/github_actions/test_executable_scripts/test_aorta_triage.py
+++ b/build_tools/github_actions/test_executable_scripts/test_aorta_triage.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+===============================================================================
+AORTA Triage Smoke Test (Manual Execution Only)
+
+This script is NOT part of automated CI runs.
+
+Exercises ``aorta triage run`` end-to-end against the ``recom_repro`` smoke
+recipe from ``aorta-internal`` (``recipes/recom_repro_smoke.yaml``). Milestone
+1 pass criteria per ROCm/aorta-internal#26:
+
+* dispatcher exit code 0
+* ``matrix.md`` produced under ``--output-dir``
+* no matrix cells in the ``error`` state (cell-level failure)
+
+Pre-requisites
+--------------
+
+1. **Dual editable install** (``aorta-internal/docs/triage_matrix_quickstart.md``
+   section 1)::
+
+       pip install -e <path>/aorta -e <path>/aorta-internal
+
+   Per ``aorta-internal/CLAUDE.md`` rule #5: do **not** submodule public
+   ``aorta`` into ``aorta-internal``. Use a sibling clone (or a pinned
+   ``rocm-aorta`` PyPI package once published on internal PyPI).
+
+2. **``AORTA_INTERNAL_DIR``** must point at the ``aorta-internal`` checkout
+   so this test can resolve ``recipes/recom_repro_smoke.yaml``.
+
+3. **GPU + ROCm host** with docker available. The smoke recipe runs the
+   ``recom_repro`` workload inside docker (``nan-repro`` environment).
+
+4. **Private image auth.** Step A uses a known-good image already wired into
+   the recipe (``rocm/pytorch-private:nan-repro``). These are private AMD
+   images; TheRock CI will not pull them without explicit registry credentials.
+
+5. **Digest pinning (follow-up).** ``CLAUDE.md`` rule #7 requires digest-pinned
+   gate images. This milestone does not assert on image digests; that lands in
+   the follow-up ticket after milestone 1.
+
+Expected runtime: ~3-5 minutes on MI350X once ``nan-repro`` is pulled; first
+pull adds ~5-10 minutes.
+
+Manual validation (document in your PR / run notes, not in CI)
+---------------------------------------------------------------
+
+* **Step A** -- run against the recipe's known-good ``rocm/pytorch-private:nan-repro``.
+* **Step B** -- re-run against the latest ROCm image available in TheRock at run
+  time. A Step B failure where Step A passed is reportable data; do not "fix"
+  it inside this script.
+
+Usage (after temporarily removing ``pytestmark`` skip, or passing
+``--runxfail`` is insufficient -- un-skip locally only, do not commit)::
+
+    export AORTA_INTERNAL_DIR=/path/to/aorta-internal
+    pytest build_tools/github_actions/test_executable_scripts/test_aorta_triage.py \\
+        -k test_aorta_triage_smoke -s
+
+===============================================================================
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skip(
+    "Manual execution only - requires GPU, ROCm, private docker image auth, "
+    "AORTA_INTERNAL_DIR sibling install"
+)
+
+logging.basicConfig(level=logging.INFO)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+
+RECIPE_REL = Path("recipes") / "recom_repro_smoke.yaml"
+
+
+def _resolve_recipe() -> Path:
+    aorta_internal = os.getenv("AORTA_INTERNAL_DIR")
+    if not aorta_internal:
+        pytest.skip("AORTA_INTERNAL_DIR is not set (path to aorta-internal checkout)")
+    recipe = Path(aorta_internal) / RECIPE_REL
+    if not recipe.is_file():
+        pytest.fail(f"Smoke recipe not found: {recipe}")
+    return recipe
+
+
+def _assert_no_error_cells(run_dir: Path) -> None:
+    matrix_json_paths = sorted(run_dir.rglob("matrix.json"))
+    if len(matrix_json_paths) != 1:
+        pytest.fail(
+            f"Expected exactly one matrix.json under {run_dir}, "
+            f"found {len(matrix_json_paths)}: {matrix_json_paths}"
+        )
+    matrix_doc = json.loads(matrix_json_paths[0].read_text(encoding="utf-8"))
+    error_cells: list[str] = []
+    for cell in matrix_doc.get("cells", []):
+        if cell.get("error") is not None:
+            error_cells.append(f"{cell.get('name')}: {cell['error']}")
+        elif cell.get("confound") == "error":
+            error_cells.append(f"{cell.get('name')}: confound=error")
+    if error_cells:
+        pytest.fail("Matrix cells in error state:\n" + "\n".join(error_cells))
+
+    for trial_path in sorted(run_dir.rglob("trial_*.json")):
+        trial = json.loads(trial_path.read_text(encoding="utf-8"))
+        exit_status = trial.get("exit_status")
+        if exit_status in (None, "ok"):
+            continue
+        # Trial-level failures are acceptable for smoke (bug may not fire at
+        # 50 steps); only cell-level "could not start" counts as milestone error.
+        pass
+
+
+def test_aorta_triage_smoke(tmp_path: Path) -> None:
+    if shutil.which("aorta") is None:
+        pytest.skip("aorta CLI not on PATH (pip install -e aorta -e aorta-internal)")
+
+    recipe = _resolve_recipe()
+    cmd = [
+        "aorta",
+        "triage",
+        "run",
+        "--recipe",
+        str(recipe),
+        "--output-dir",
+        str(tmp_path),
+    ]
+
+    logging.info("++ Exec [%s]$ %s", THEROCK_DIR, shlex.join(cmd))
+    proc = subprocess.run(
+        cmd,
+        cwd=THEROCK_DIR,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        pytest.fail(
+            f"aorta triage run failed (exit {proc.returncode})\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+
+    matrix_md_paths = sorted(tmp_path.rglob("matrix.md"))
+    if len(matrix_md_paths) != 1:
+        pytest.fail(
+            f"Expected exactly one matrix.md under {tmp_path}, "
+            f"found {len(matrix_md_paths)}: {matrix_md_paths}"
+        )
+
+    run_dir = matrix_md_paths[0].parent
+    logging.info("matrix.md: %s", matrix_md_paths[0])
+    _assert_no_error_cells(run_dir)

--- a/build_tools/github_actions/test_executable_scripts/test_aorta_triage.py
+++ b/build_tools/github_actions/test_executable_scripts/test_aorta_triage.py
@@ -4,36 +4,54 @@
 
 """
 ===============================================================================
-AORTA triage smoke test (manual execution only)
-
-This script is NOT part of automated CI runs.
+AORTA triage smoke test
 
 Runs ``aorta triage run`` against a recipe file and checks milestone-style
 plumbing: dispatcher exit code 0, a single ``matrix.md`` under ``--output-dir``,
 and no cell-level ``error`` rows in ``matrix.json``.
 
+The test is **skipped by default**. It opts in only when the operator (or a
+scheduled CI job) sets ``AORTA_RECIPE_PATH``. That keeps the regular pytest
+collection on PRs and nightly runs a no-op while letting the dedicated
+``ci_aorta_triage_smoke.yml`` workflow exercise the full pipeline on a GPU
+host on a weekly cadence.
+
 Pre-requisites
 --------------
 
-1. ``aorta`` on ``PATH`` (``pip install`` of the public ``aorta`` package, or an
-   editable install from a local checkout).
+1. ``aorta`` on ``PATH``. Install the public ROCm/aorta package
+   (https://github.com/ROCm/aorta) either from a tagged release archive or
+   from source, e.g.::
+
+       pip install "git+https://github.com/ROCm/aorta.git@main"
+
+   The PyPI project named ``aorta`` is unrelated; do not install it.
 
 2. **``AORTA_RECIPE_PATH``** — absolute path to a triage recipe YAML.
+   This env var both enables the test and tells the dispatcher what to run.
 
-3. **``AORTA_MITIGATIONS_FILE``** (optional) — path to a mitigations/environments
-   sidecar JSON passed through to ``--mitigations-file`` when set.
+3. **``AORTA_MITIGATIONS_FILE``** (optional) — path to a mitigations /
+   environments sidecar JSON. Passed through to ``aorta triage run
+   --mitigations-file`` when set.
 
-4. **GPU + ROCm host** with docker if the recipe uses docker-backed environments.
-   Registry credentials for non-public images are out of band; TheRock CI does not
-   provide them today.
+4. **GPU + ROCm host** with docker available if the recipe uses
+   docker-backed environments. Private registry credentials must be
+   supplied out of band (e.g. via ``docker login`` in the calling CI job).
 
-Usage (remove ``pytestmark`` skip locally only; do not commit)::
+Manual usage::
 
     export AORTA_RECIPE_PATH=/path/to/smoke-recipe.yaml
-    export AORTA_MITIGATIONS_FILE=/path/to/sidecar.json   # if required by recipe
+    export AORTA_MITIGATIONS_FILE=/path/to/sidecar.json   # optional
     export HIP_VISIBLE_DEVICES=0
     pytest build_tools/github_actions/test_executable_scripts/test_aorta_triage.py \\
         -k test_aorta_triage_smoke -s
+
+CI usage:
+    See ``.github/workflows/ci_aorta_triage_smoke.yml`` for the scheduled
+    weekly invocation. The workflow installs ``aorta`` (and any private
+    workload plugin packages required by the recipe), configures docker
+    auth from secrets, exports ``AORTA_RECIPE_PATH`` /
+    ``AORTA_MITIGATIONS_FILE``, then invokes pytest on this file.
 
 ===============================================================================
 """
@@ -50,8 +68,12 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.skip(
-    "Manual execution only — requires GPU, ROCm, and AORTA_RECIPE_PATH"
+pytestmark = pytest.mark.skipif(
+    not os.getenv("AORTA_RECIPE_PATH"),
+    reason=(
+        "AORTA_RECIPE_PATH not set; smoke test only runs when an operator or "
+        "the scheduled ci_aorta_triage_smoke workflow points at a recipe."
+    ),
 )
 
 logging.basicConfig(level=logging.INFO)

--- a/build_tools/github_actions/test_executable_scripts/test_aorta_triage.py
+++ b/build_tools/github_actions/test_executable_scripts/test_aorta_triage.py
@@ -86,6 +86,8 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
 RECIPE_REL = Path("recipes") / "recom_repro_smoke.yaml"
+# nan-repro / fixed docker envs are defined in this sidecar until B3 entry-points land.
+SIDECAR_REL = Path("recipes") / "SHAMPOO-NAN-2026-042-sidecar.json"
 
 
 def _resolve_recipe() -> Path:
@@ -129,13 +131,20 @@ def test_aorta_triage_smoke(tmp_path: Path) -> None:
     if shutil.which("aorta") is None:
         pytest.skip("aorta CLI not on PATH (pip install -e aorta -e aorta-internal)")
 
+    aorta_internal = Path(os.environ["AORTA_INTERNAL_DIR"])
     recipe = _resolve_recipe()
+    sidecar = aorta_internal / SIDECAR_REL
+    if not sidecar.is_file():
+        pytest.fail(f"Mitigations sidecar not found: {sidecar}")
+
     cmd = [
         "aorta",
         "triage",
         "run",
         "--recipe",
         str(recipe),
+        "--mitigations-file",
+        str(sidecar),
         "--output-dir",
         str(tmp_path),
     ]

--- a/build_tools/github_actions/test_executable_scripts/test_aorta_triage.py
+++ b/build_tools/github_actions/test_executable_scripts/test_aorta_triage.py
@@ -51,7 +51,10 @@ CI usage:
     weekly invocation. The workflow installs ``aorta`` (and any private
     workload plugin packages required by the recipe), configures docker
     auth from secrets, exports ``AORTA_RECIPE_PATH`` /
-    ``AORTA_MITIGATIONS_FILE``, then invokes pytest on this file.
+    ``AORTA_MITIGATIONS_FILE``, then invokes pytest on this file. Access
+    to private workload-plugin repositories is brokered by an org-managed
+    GitHub App (``actions/create-github-app-token``), not a personal PAT,
+    so the same App pattern as ``bump_submodules.yml`` applies.
 
 ===============================================================================
 """

--- a/build_tools/github_actions/test_executable_scripts/test_aorta_triage.py
+++ b/build_tools/github_actions/test_executable_scripts/test_aorta_triage.py
@@ -4,59 +4,34 @@
 
 """
 ===============================================================================
-AORTA Triage Smoke Test (Manual Execution Only)
+AORTA triage smoke test (manual execution only)
 
 This script is NOT part of automated CI runs.
 
-Exercises ``aorta triage run`` end-to-end against the ``recom_repro`` smoke
-recipe from ``aorta-internal`` (``recipes/recom_repro_smoke.yaml``). Milestone
-1 pass criteria per ROCm/aorta-internal#26:
-
-* dispatcher exit code 0
-* ``matrix.md`` produced under ``--output-dir``
-* no matrix cells in the ``error`` state (cell-level failure)
+Runs ``aorta triage run`` against a recipe file and checks milestone-style
+plumbing: dispatcher exit code 0, a single ``matrix.md`` under ``--output-dir``,
+and no cell-level ``error`` rows in ``matrix.json``.
 
 Pre-requisites
 --------------
 
-1. **Dual editable install** (``aorta-internal/docs/triage_matrix_quickstart.md``
-   section 1)::
+1. ``aorta`` on ``PATH`` (``pip install`` of the public ``aorta`` package, or an
+   editable install from a local checkout).
 
-       pip install -e <path>/aorta -e <path>/aorta-internal
+2. **``AORTA_RECIPE_PATH``** — absolute path to a triage recipe YAML.
 
-   Per ``aorta-internal/CLAUDE.md`` rule #5: do **not** submodule public
-   ``aorta`` into ``aorta-internal``. Use a sibling clone (or a pinned
-   ``rocm-aorta`` PyPI package once published on internal PyPI).
+3. **``AORTA_MITIGATIONS_FILE``** (optional) — path to a mitigations/environments
+   sidecar JSON passed through to ``--mitigations-file`` when set.
 
-2. **``AORTA_INTERNAL_DIR``** must point at the ``aorta-internal`` checkout
-   so this test can resolve ``recipes/recom_repro_smoke.yaml``.
+4. **GPU + ROCm host** with docker if the recipe uses docker-backed environments.
+   Registry credentials for non-public images are out of band; TheRock CI does not
+   provide them today.
 
-3. **GPU + ROCm host** with docker available. The smoke recipe runs the
-   ``recom_repro`` workload inside docker (``nan-repro`` environment).
+Usage (remove ``pytestmark`` skip locally only; do not commit)::
 
-4. **Private image auth.** Step A uses a known-good image already wired into
-   the recipe (``rocm/pytorch-private:nan-repro``). These are private AMD
-   images; TheRock CI will not pull them without explicit registry credentials.
-
-5. **Digest pinning (follow-up).** ``CLAUDE.md`` rule #7 requires digest-pinned
-   gate images. This milestone does not assert on image digests; that lands in
-   the follow-up ticket after milestone 1.
-
-Expected runtime: ~3-5 minutes on MI350X once ``nan-repro`` is pulled; first
-pull adds ~5-10 minutes.
-
-Manual validation (document in your PR / run notes, not in CI)
----------------------------------------------------------------
-
-* **Step A** -- run against the recipe's known-good ``rocm/pytorch-private:nan-repro``.
-* **Step B** -- re-run against the latest ROCm image available in TheRock at run
-  time. A Step B failure where Step A passed is reportable data; do not "fix"
-  it inside this script.
-
-Usage (after temporarily removing ``pytestmark`` skip, or passing
-``--runxfail`` is insufficient -- un-skip locally only, do not commit)::
-
-    export AORTA_INTERNAL_DIR=/path/to/aorta-internal
+    export AORTA_RECIPE_PATH=/path/to/smoke-recipe.yaml
+    export AORTA_MITIGATIONS_FILE=/path/to/sidecar.json   # if required by recipe
+    export HIP_VISIBLE_DEVICES=0
     pytest build_tools/github_actions/test_executable_scripts/test_aorta_triage.py \\
         -k test_aorta_triage_smoke -s
 
@@ -76,8 +51,7 @@ from pathlib import Path
 import pytest
 
 pytestmark = pytest.mark.skip(
-    "Manual execution only - requires GPU, ROCm, private docker image auth, "
-    "AORTA_INTERNAL_DIR sibling install"
+    "Manual execution only — requires GPU, ROCm, and AORTA_RECIPE_PATH"
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -85,19 +59,25 @@ logging.basicConfig(level=logging.INFO)
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
-RECIPE_REL = Path("recipes") / "recom_repro_smoke.yaml"
-# nan-repro / fixed docker envs are defined in this sidecar until B3 entry-points land.
-SIDECAR_REL = Path("recipes") / "SHAMPOO-NAN-2026-042-sidecar.json"
 
-
-def _resolve_recipe() -> Path:
-    aorta_internal = os.getenv("AORTA_INTERNAL_DIR")
-    if not aorta_internal:
-        pytest.skip("AORTA_INTERNAL_DIR is not set (path to aorta-internal checkout)")
-    recipe = Path(aorta_internal) / RECIPE_REL
+def _recipe_path() -> Path:
+    raw = os.getenv("AORTA_RECIPE_PATH")
+    if not raw:
+        pytest.skip("AORTA_RECIPE_PATH is not set (path to triage recipe YAML)")
+    recipe = Path(raw)
     if not recipe.is_file():
-        pytest.fail(f"Smoke recipe not found: {recipe}")
+        pytest.fail(f"Recipe not found: {recipe}")
     return recipe
+
+
+def _mitigations_file() -> Path | None:
+    raw = os.getenv("AORTA_MITIGATIONS_FILE")
+    if not raw:
+        return None
+    sidecar = Path(raw)
+    if not sidecar.is_file():
+        pytest.fail(f"AORTA_MITIGATIONS_FILE not found: {sidecar}")
+    return sidecar
 
 
 def _assert_no_error_cells(run_dir: Path) -> None:
@@ -117,37 +97,24 @@ def _assert_no_error_cells(run_dir: Path) -> None:
     if error_cells:
         pytest.fail("Matrix cells in error state:\n" + "\n".join(error_cells))
 
-    for trial_path in sorted(run_dir.rglob("trial_*.json")):
-        trial = json.loads(trial_path.read_text(encoding="utf-8"))
-        exit_status = trial.get("exit_status")
-        if exit_status in (None, "ok"):
-            continue
-        # Trial-level failures are acceptable for smoke (bug may not fire at
-        # 50 steps); only cell-level "could not start" counts as milestone error.
-        pass
-
 
 def test_aorta_triage_smoke(tmp_path: Path) -> None:
     if shutil.which("aorta") is None:
-        pytest.skip("aorta CLI not on PATH (pip install -e aorta -e aorta-internal)")
+        pytest.skip("aorta CLI not on PATH")
 
-    aorta_internal = Path(os.environ["AORTA_INTERNAL_DIR"])
-    recipe = _resolve_recipe()
-    sidecar = aorta_internal / SIDECAR_REL
-    if not sidecar.is_file():
-        pytest.fail(f"Mitigations sidecar not found: {sidecar}")
-
+    recipe = _recipe_path()
     cmd = [
         "aorta",
         "triage",
         "run",
         "--recipe",
         str(recipe),
-        "--mitigations-file",
-        str(sidecar),
         "--output-dir",
         str(tmp_path),
     ]
+    sidecar = _mitigations_file()
+    if sidecar is not None:
+        cmd.extend(["--mitigations-file", str(sidecar)])
 
     logging.info("++ Exec [%s]$ %s", THEROCK_DIR, shlex.join(cmd))
     proc = subprocess.run(


### PR DESCRIPTION
## Summary

Adds a pytest harness for the public `aorta triage run` CLI **and** wires it
into TheRock CI as a weekly scheduled job.

The test asserts dispatcher exit code 0, production of `matrix.md`, and the
absence of cell-level `error` rows in `matrix.json`. Recipe content,
mitigations sidecars, and workload plugin packages are supplied at job time
via inputs/secrets, so no internal repos, workload names, docker image
references, or ticket identifiers appear in the tree.

## What is new in this revision

1. **`build_tools/github_actions/test_executable_scripts/test_aorta_triage.py`** -
   the unconditional `pytest.mark.skip` is replaced with
   `pytest.mark.skipif(not os.getenv("AORTA_RECIPE_PATH"))`. The default
   collection behaviour on PRs / unit-test workflows is unchanged (the test
   reports SKIPPED with a clear reason), and the same file is now reusable
   by the scheduled workflow without local edits. The docstring also
   clarifies that `aorta` should be installed from
   https://github.com/ROCm/aorta and **not** from the unrelated PyPI
   project of the same name (per review comment).

2. **`.github/workflows/ci_aorta_triage_smoke.yml`** - new workflow:
   - **Triggers:** `schedule: 0 3 * * 0` (Sunday 03:00 UTC, matching the
     weekly slot in `ci_weekly.yml`) and `workflow_dispatch` with
     overrides for runner label, Python version, aorta /
     aorta-internal refs, recipe path, and optional mitigations
     sidecar.
   - **Runner:** defaults to `linux-gfx950-1gpu-ccs-ossci-rocm`
     (MI350X) so it lines up with the smoke recipe the test exercises.
   - **Install steps:** installs the public `aorta` package from
     `ROCm/aorta`, then (if `AORTA_INTERNAL_TOKEN` is set) clones and
     editable-installs `ROCm/aorta-internal` so workload + mitigation
     plugin entry-points register. When the token is missing the
     workflow logs a warning and skips the pytest step instead of
     failing.
   - **Docker auth:** when `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`
     are configured, the workflow does a `docker/login-action` and a
     paired `docker logout` at the end. Missing secrets only emit a
     warning - recipes that need private images will then surface as
     error cells, which is the desired signal.
   - **Output:** runs pytest with `--basetemp=$GITHUB_WORKSPACE/triage-output`
     and uploads `matrix.md`, `matrix.json`, and `cells/*/trial_*.json`
     as a 30-day retention artifact named
     `aorta-triage-matrix-<run_id>`.

## Configuration

### Test env-var contract (unchanged)

| Variable                | Required | Purpose                                                |
|-------------------------|----------|--------------------------------------------------------|
| `AORTA_RECIPE_PATH`     | yes      | Path to triage recipe YAML; also enables the `skipif`. |
| `AORTA_MITIGATIONS_FILE`| no       | Passed to `--mitigations-file` when set.               |
| `HIP_VISIBLE_DEVICES`   | recommended | GPU selection for docker/host runs.                 |

### New repository secrets

| Secret                | Required | Purpose                                                                   |
|-----------------------|----------|---------------------------------------------------------------------------|
| `AORTA_INTERNAL_TOKEN`| recommended | PAT with read access to `ROCm/aorta-internal`. Without it the workflow logs a warning and skips the pytest step. |
| `DOCKERHUB_USERNAME`  | optional | Docker Hub user for pulling private recipe images.                        |
| `DOCKERHUB_TOKEN`     | optional | Docker Hub token paired with the above; login step is skipped if either is missing. |

### Workflow inputs (workflow_dispatch overrides)

`runner_label`, `python_version`, `aorta_repo`, `aorta_ref`,
`aorta_internal_repo`, `aorta_internal_ref`, `recipe_relpath`,
`mitigations_relpath` - see the workflow file for defaults.

## Manual validation

The test logic was validated manually on an AMD internal MI350X cluster
during the original revision of this PR (not recorded here to avoid
private infrastructure details). Both runs met the plumbing criteria
(exit 0, `matrix.md`, no error cells). The new workflow has been
syntax-validated locally with `actionlint` (clean) and the test still
collects and reports SKIPPED when `AORTA_RECIPE_PATH` is unset.

## Out of scope

* Recipe-specific assertions (NaN bands, confound flags, digest-pinned images).
* Wiring into `fetch_test_configurations.py` - the smoke job is a standalone
  scheduled workflow, not a per-architecture component of the regular CI
  matrix, so it does not need to participate in test sharding.

## Test plan

- [x] `pytest` collects `test_aorta_triage_smoke` as **skipped** without `AORTA_RECIPE_PATH` (verified locally with pytest 9.0.3).
- [x] `actionlint` reports no issues against `ci_aorta_triage_smoke.yml`.
- [ ] Reviewer: confirm runner label / cadence are appropriate for the team.
- [ ] Reviewer: confirm secret names (`AORTA_INTERNAL_TOKEN`, `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`) match any existing naming conventions.
- [ ] First scheduled run (or a manual `workflow_dispatch`) to verify end-to-end.