### PR TITLE
Revert "[ci] Fixing dep rpm packages for forked upload (#5066)"

### DIFF
--- a/.github/workflows/build_native_linux_packages.yml
+++ b/.github/workflows/build_native_linux_packages.yml
@@ -89,13 +89,10 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
-    container:
-      image: ubuntu:24.04
-      options: -v /runner/config:/home/awsconfig/
     outputs:
       package_install_url: ${{ steps.upload-packages.outputs.package_repository_url }}
     env:
-      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
+      BUILD_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
       ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id || github.run_id }}
       PACKAGE_SUFFIX: ${{ inputs.package_suffix != '' && inputs.package_suffix || '' }}
       OUTPUT_DIR: ${{ github.workspace }}/output
@@ -123,10 +120,10 @@ jobs:
         run: |
           # Install the needed tools for creating rpm / deb packages
           # Also install tools for creating repo files
-          apt-get update
-          apt-get install -y llvm-20
-          apt-get install -y rpm debhelper-compat build-essential
-          apt-get install -y dpkg-dev createrepo-c
+          sudo apt update
+          sudo apt install -y llvm-20
+          sudo apt install -y rpm debhelper-compat build-essential
+          sudo apt install -y dpkg-dev createrepo-c
 
       - name: Fetch Artifacts
         run: |

--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -53,21 +53,15 @@ jobs:
   build_native_packages:
     name: Build ${{ inputs.native_package_type }} packages
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
-    container:
-      image: ubuntu:24.04
-      options: -v /runner/config:/home/awsconfig/
     outputs:
       package_repository_url: ${{ steps.upload-packages.outputs.package_repository_url }}
     env:
-      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
       DIST_AMDGPU_FAMILIES: ${{ inputs.dist_amdgpu_families }}
       PACKAGE_SUFFIX: ${{ inputs.package_suffix }}
-      # Use relative paths to avoid host/container path mismatch
-      # (github.workspace resolves to host path, but container mounts at /__w/)
-      OUTPUT_DIR: output
-      ARTIFACTS_DIR: output/artifacts
-      PACKAGE_DIST_DIR: output/packages
+      OUTPUT_DIR: ${{ github.workspace }}/output
+      ARTIFACTS_DIR: ${{ github.workspace }}/output/artifacts
+      PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages
       RELEASE_TYPE: ${{ inputs.release_type }}
     steps:
       - name: Checking out repository
@@ -89,10 +83,10 @@ jobs:
         run: |
           # Install the needed tools for creating rpm / deb packages
           # Also install tools for creating repo files
-          apt-get update
-          apt-get install -y llvm-20
-          apt-get install -y rpm debhelper-compat build-essential
-          apt-get install -y dpkg-dev createrepo-c
+          sudo apt update
+          sudo apt install -y llvm-20
+          sudo apt install -y rpm debhelper-compat build-essential
+          sudo apt install -y dpkg-dev createrepo-c
 
       - name: Determine IAM role
         id: iam_role


### PR DESCRIPTION
This reverts commit fc4e6be70f49f6de3d562f71899314fbe2709d7d. Starting from that commit, the `Configure AWS Credentials` steps in the native Linux packages build jobs (deb and rpm) fail with

```
Error: Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentit
```

due to assuming a non-existing role `*:role/therock-` (missing release type):
https://github.com/ROCm/TheRock/actions/runs/25931650380/job/76257228730