### PR TITLE
Pin ROCm devel packages for full PyTorch tests

### DIFF
--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -225,14 +225,21 @@ jobs:
               --activate-in-future-github-actions-steps
           fi
 
+      - name: Resolve ROCm package version
+        id: rocm_package
+        run: |
+          ROCM_PACKAGE_VERSION="$(python -c 'import importlib.metadata; print(importlib.metadata.version("rocm"))')"
+          echo "rocm_package_version=${ROCM_PACKAGE_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved ROCm package version: ${ROCM_PACKAGE_VERSION}"
+
       - name: Install ROCm devel packages
         timeout-minutes: 15
         run: |
           if [ "${{ inputs.multi_arch }}" = "true" ]; then
-            pip install "rocm[devel,${{ steps.expand.outputs.device_extras }}]" \
+            python -m pip install "rocm[devel,${{ steps.expand.outputs.device_extras }}]==${{ steps.rocm_package.outputs.rocm_package_version }}" \
               --index-url=${{ inputs.package_index_url }}
           else
-            pip install "rocm[devel]" \
+            python -m pip install "rocm[devel]==${{ steps.rocm_package.outputs.rocm_package_version }}" \
               --index-url=${{ inputs.package_index_url }}/${{ inputs.amdgpu_family }}
           fi
 

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -214,33 +214,15 @@ jobs:
         run: |
           if [ "${{ inputs.multi_arch }}" = "true" ]; then
             python build_tools/setup_venv.py ${VENV_DIR} \
-              --packages "torch[${{ steps.expand.outputs.device_extras }}]==${{ inputs.torch_version }}" \
+              --packages "torch[${{ steps.expand.outputs.device_extras }}]==${{ inputs.torch_version }} rocm[devel,${{ steps.expand.outputs.device_extras }}]" \
               --index-url=${{ inputs.package_index_url }} \
               --activate-in-future-github-actions-steps
           else
             python build_tools/setup_venv.py ${VENV_DIR} \
-              --packages torch==${{ inputs.torch_version }} \
+              --packages "torch==${{ inputs.torch_version }} rocm[devel]" \
               --index-url=${{ inputs.package_index_url }} \
               --index-subdir=${{ inputs.amdgpu_family }} \
               --activate-in-future-github-actions-steps
-          fi
-
-      - name: Resolve ROCm package version
-        id: rocm_package
-        run: |
-          ROCM_PACKAGE_VERSION="$(python -c 'import importlib.metadata; print(importlib.metadata.version("rocm"))')"
-          echo "rocm_package_version=${ROCM_PACKAGE_VERSION}" >> "${GITHUB_OUTPUT}"
-          echo "Resolved ROCm package version: ${ROCM_PACKAGE_VERSION}"
-
-      - name: Install ROCm devel packages
-        timeout-minutes: 15
-        run: |
-          if [ "${{ inputs.multi_arch }}" = "true" ]; then
-            python -m pip install "rocm[devel,${{ steps.expand.outputs.device_extras }}]==${{ steps.rocm_package.outputs.rocm_package_version }}" \
-              --index-url=${{ inputs.package_index_url }}
-          else
-            python -m pip install "rocm[devel]==${{ steps.rocm_package.outputs.rocm_package_version }}" \
-              --index-url=${{ inputs.package_index_url }}/${{ inputs.amdgpu_family }}
           fi
 
       - name: Initialize ROCm SDK and configure environment


### PR DESCRIPTION
Test run: https://github.com/ROCm/TheRock/actions/runs/26044789530

Result: failed. Several gfx94X shards were blocked while installing packages because `rocm.nightlies.amd.com` could not be resolved (`Temporary failure in name resolution`). The install command shape is correct, and later shards that reached the package index got past virtualenv setup.

Likely blocker/fix: https://github.com/ROCm/TheRock/pull/5324 adds a DNS fallback for `rocm.nightlies.amd.com` to the S3 bucket and appears to target the same runner/index failure mode.

Old-version validation run: https://github.com/ROCm/TheRock/actions/runs/27284482421

Dispatched with `torch_version=2.13.0a0+rocm7.14.0a20260518` to validate that `rocm[devel]` does not float to the latest nightly. Cancelled after the relevant setup validation completed. Evidence from https://github.com/ROCm/TheRock/actions/runs/27284482421/job/80588048888:

```text
pip install --index-url=https://rocm.nightlies.amd.com/v2-staging/gfx94X-dcgpu torch==2.13.0a0+rocm7.14.0a20260518 'rocm[devel]'
Collecting rocm==7.14.0a20260518 (from rocm[libraries]==7.14.0a20260518->torch==2.13.0a0+rocm7.14.0a20260518)
Collecting rocm-sdk-devel==7.14.0a20260518 (from rocm[devel])
Successfully installed ... rocm-7.14.0a20260518 rocm-sdk-core-7.14.0a20260518 rocm-sdk-devel-7.14.0a20260518 rocm-sdk-libraries-gfx94X-dcgpu-7.14.0a20260518 ... torch-2.13.0a0+rocm7.14.0a20260518
```
