### PR TITLE
[ci] Removing WSL build stage from multi_arch pipeline

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -116,28 +116,29 @@ jobs:
       contents: read
       id-token: write
 
-  # ==========================================================================
-  # STAGE: wsl-rocdxg (generic)
-  # ==========================================================================
-  wsl-rocdxg:
-    needs: compiler-runtime
-    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'wsl-rocdxg') }}
-    uses: ./.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
-    secrets: inherit
-    with:
-      stage_name: wsl-rocdxg
-      stage_display_name: "Stage - WSL ROCDXG"
-      timeout_minutes: 120  # 2 hours
-      dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
-      rocm_package_version: ${{ inputs.rocm_package_version }}
-      build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
-      release_type: ${{ inputs.release_type }}
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
-      external_repo_config: ${{ inputs.external_repo_config }}
-    permissions:
-      contents: read
-      id-token: write
+  # TODO: bring back runner ROCR-Runtime-libhsakmt-WSL to re-enable workflow
+  # # ==========================================================================
+  # # STAGE: wsl-rocdxg (generic)
+  # # ==========================================================================
+  # wsl-rocdxg:
+  #   needs: compiler-runtime
+  #   if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'wsl-rocdxg') }}
+  #   uses: ./.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+  #   secrets: inherit
+  #   with:
+  #     stage_name: wsl-rocdxg
+  #     stage_display_name: "Stage - WSL ROCDXG"
+  #     timeout_minutes: 120  # 2 hours
+  #     dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
+  #     rocm_package_version: ${{ inputs.rocm_package_version }}
+  #     build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+  #     release_type: ${{ inputs.release_type }}
+  #     repository: ${{ inputs.repository }}
+  #     ref: ${{ inputs.ref }}
+  #     external_repo_config: ${{ inputs.external_repo_config }}
+  #   permissions:
+  #     contents: read
+  #     id-token: write
 
   # ==========================================================================
   # STAGE: math-libs (per-arch)

--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -191,7 +191,6 @@ _GITHUB_WORKFLOWS_CI_FILENAMES = {
     "multi_arch_build_portable_linux_artifacts.yml",
     "multi_arch_build_windows.yml",
     "multi_arch_build_windows_artifacts.yml",
-    "multi_arch_build_wsl_rocdxg_artifacts.yml",
     "setup_multi_arch.yml",
     "test_artifacts_structure.yml",
     "test_native_linux_packages_install.yml",


### PR DESCRIPTION
The runners for WSL `ROCR-Runtime-libhsakmt-WSL` is not available, causing jobs to timeout after 24h. 

Tried to revert #4541, but changes have already been made. Technically, the workflow does work, just runner is not available. I am temporarily removing this stage until @jayhawk-commits  is back to bring back runners