### PR TITLE
Media Tests - Enable extended rocdecode tests

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocdecode.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocdecode.py
@@ -70,7 +70,7 @@ def execute_tests(env):
     cmd = [
         "cmake",
         "-GNinja",
-        "-DTHEROCK_TEST_ENABLE_EXTENDED=ON",
+        "-DENABLE_EXTENDED_TESTS=ON",
         ROCDECODE_TEST_PATH,
     ]
     logging.info(f"++ Exec [{ROCDECODE_TEST_DIR}]$ {shlex.join(cmd)}")

--- a/build_tools/github_actions/test_executable_scripts/test_rocdecode.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocdecode.py
@@ -50,9 +50,7 @@ def setup_env(env):
         LD_PRELOAD_VALUE = ":".join(LD_PRELOAD_LIBS)
         logging.info(f"++ rocdecode setting LD_PRELOAD={LD_PRELOAD_VALUE}")
         env["LD_PRELOAD"] = LD_PRELOAD_VALUE
-        logging.info(
-            f"++ rocdecode setting LIBVA_DRIVERS_PATH={ROCM_SYSDEPS_LIB_PATH}"
-        )
+        logging.info(f"++ rocdecode setting LIBVA_DRIVERS_PATH={ROCM_SYSDEPS_LIB_PATH}")
         env["LIBVA_DRIVERS_PATH"] = str(ROCM_SYSDEPS_LIB_PATH)
     else:
         logging.info(f"++ rocdecode tests only supported on Linux")

--- a/build_tools/github_actions/test_executable_scripts/test_rocdecode.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocdecode.py
@@ -42,6 +42,18 @@ def setup_env(env):
             env["LD_LIBRARY_PATH"] = f"{HIP_LIB_PATH}:{env['LD_LIBRARY_PATH']}"
         else:
             env["LD_LIBRARY_PATH"] = str(HIP_LIB_PATH)
+        ROCM_SYSDEPS_LIB_PATH = ROCM_PATH / "lib" / "rocm_sysdeps" / "lib"
+        LD_PRELOAD_LIBS = [
+            str(ROCM_SYSDEPS_LIB_PATH / "librocm_sysdeps_va.so.2"),
+            str(ROCM_SYSDEPS_LIB_PATH / "librocm_sysdeps_va-drm.so.2"),
+        ]
+        LD_PRELOAD_VALUE = ":".join(LD_PRELOAD_LIBS)
+        logging.info(f"++ rocdecode setting LD_PRELOAD={LD_PRELOAD_VALUE}")
+        env["LD_PRELOAD"] = LD_PRELOAD_VALUE
+        logging.info(
+            f"++ rocdecode setting LIBVA_DRIVERS_PATH={ROCM_SYSDEPS_LIB_PATH}"
+        )
+        env["LIBVA_DRIVERS_PATH"] = str(ROCM_SYSDEPS_LIB_PATH)
     else:
         logging.info(f"++ rocdecode tests only supported on Linux")
         sys.exit(0)
@@ -60,6 +72,7 @@ def execute_tests(env):
     cmd = [
         "cmake",
         "-GNinja",
+        "-DTHEROCK_TEST_ENABLE_EXTENDED=ON",
         ROCDECODE_TEST_PATH,
     ]
     logging.info(f"++ Exec [{ROCDECODE_TEST_DIR}]$ {shlex.join(cmd)}")


### PR DESCRIPTION
## Motivation

Enable rocdecode tests that require FFmpeg

Replaces: PR #4781

## Technical Details

Extended tests that require FFmpeg can now be enabled with FFmpeg support on media docker for test and adds two env variables to make libs available.
 * LIBVA_DRIVERS_PATH
 * LD_LIBRARY_PATH

## Test Plan

CTests will add tests that require FFmpeg

## Test Result

Current and extended tests should pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
