### PR TITLE
[ci] Add DNS fallback for rocm.nightlies.amd.com to S3 bucket

### DIFF
--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -50,10 +50,12 @@ from pathlib import Path
 import platform
 import shlex
 import shutil
+import socket
 import subprocess
 import sys
 import re
 import time
+from urllib.parse import urlparse
 
 from github_actions.github_actions_api import *
 
@@ -66,10 +68,90 @@ ROCM_INDEX_URLS_MAP = {
     "dev": "https://rocm.devreleases.amd.com/v2",
 }
 
+# Fallback mapping from CDN domains to direct S3 bucket URLs.
+# Used when DNS resolution fails for the CDN.
+CDN_TO_S3_FALLBACK_MAP = {
+    "rocm.devreleases.amd.com": "therock-dev-python.s3.amazonaws.com",
+    "rocm.nightlies.amd.com": "therock-nightly-python.s3.amazonaws.com",
+}
+
 
 def log(*args, **kwargs):
     print(*args, **kwargs)
     sys.stdout.flush()
+
+
+def check_dns_resolution(hostname: str, timeout: float = 5.0) -> bool:
+    """Check if a hostname can be resolved via DNS."""
+    try:
+        socket.setdefaulttimeout(timeout)
+        socket.gethostbyname(hostname)
+        return True
+    except (socket.gaierror, socket.timeout):
+        return False
+
+
+def apply_url_fallback(url: str) -> tuple[str, bool]:
+    """If DNS fails for the URL's domain, substitute a fallback domain if configured."""
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+
+    if not hostname:
+        return url, False
+
+    # Check if we have a fallback configured for this domain.
+    fallback_hostname = CDN_TO_S3_FALLBACK_MAP.get(hostname)
+    if not fallback_hostname:
+        return url, False
+
+    # Check if the original domain is reachable.
+    if check_dns_resolution(hostname):
+        return url, False
+
+    # DNS failed, check if fallback is reachable.
+    log(f"[WARNING] DNS resolution failed for '{hostname}', trying fallback...")
+    if not check_dns_resolution(fallback_hostname):
+        log(
+            f"[WARNING] Fallback '{fallback_hostname}' also unreachable, using original URL"
+        )
+        return url, False
+
+    # Replace the hostname with the fallback.
+    fallback_url = url.replace(f"://{hostname}", f"://{fallback_hostname}", 1)
+    log(f"[INFO] Using fallback URL: {fallback_url}")
+    return fallback_url, True
+
+
+def scrape_package_names_from_index(index_url: str) -> list[str]:
+    """Scrape package names from the index.html at the given URL.
+
+    This dynamically fetches the list of available packages from the S3 bucket
+    index page, avoiding the need for a hardcoded package list.
+    Uses urllib.request (stdlib) to avoid external dependencies.
+    """
+    import urllib.request
+    import urllib.error
+
+    # Ensure URL ends with index.html for S3 bucket listing
+    if not index_url.endswith("/"):
+        index_url = index_url + "/"
+    index_html_url = index_url + "index.html"
+
+    try:
+        with urllib.request.urlopen(index_html_url, timeout=30) as response:
+            html_content = response.read().decode("utf-8")
+    except (urllib.error.URLError, urllib.error.HTTPError) as e:
+        log(f"[WARNING] Failed to fetch package index from {index_html_url}: {e}")
+        return []
+
+    # Extract package names from <a> tags in the index HTML
+    # Typical format: <a href="package-name/">package-name</a>
+    package_pattern = r'<a[^>]*href="([^"/]+)/?">.*?</a>'
+    matches = re.findall(package_pattern, html_content, re.IGNORECASE)
+
+    # Filter out non-package entries (like parent directory links)
+    packages = [m for m in matches if m and not m.startswith(".")]
+    return packages
 
 
 def run_command(args: list[str | Path], cwd: Path = Path.cwd()):
@@ -250,6 +332,7 @@ def install_packages_into_venv(
         # Look up known index name.
         index_url = ROCM_INDEX_URLS_MAP[index_name]
 
+    using_s3_fallback = False
     if index_url == "":
         pip_install_cmd.append("--no-index")
         pip_install_cmd.append("--no-build-isolation")
@@ -258,10 +341,33 @@ def install_packages_into_venv(
         if index_subdir:
             index_url = f"{index_url.rstrip('/')}/{index_subdir.strip('/')}"
 
-        pip_install_cmd.append(f"--index-url={index_url}")
+        # Apply DNS fallback if needed (e.g., CDN domain unreachable).
+        index_url, using_s3_fallback = apply_url_fallback(index_url)
+
+        if using_s3_fallback:
+            # TODO(#5285): remove fallback once DNS issues on test machine are resolved
+            # Use --find-links with explicit index.html paths. S3 doesn't auto-serve
+            # index.html for directory URLs, so --index-url won't work.
+            # Dynamically scrape available packages from the fallback index.
+            pkg_names = scrape_package_names_from_index(index_url)
+            if not pkg_names:
+                log("[WARNING] No packages found in fallback index, install may fail")
+            for pkg_name in pkg_names:
+                pkg_find_links = f"{index_url.rstrip('/')}/{pkg_name}/index.html"
+                pip_install_cmd.append(f"--find-links={pkg_find_links}")
+        else:
+            pip_install_cmd.append(f"--index-url={index_url}")
 
     if find_links:
         pip_install_cmd.append(f"--find-links={find_links}")
+
+    # When using find-links without a valid index-url, prevent fallback to PyPI.
+    # This applies when:
+    # - find_links is provided without index_url (artifact-only installs)
+    # - S3 fallback is used (we switched from --index-url to --find-links)
+    if using_s3_fallback or (find_links and not index_url):
+        pip_install_cmd.append("--no-index")
+        pip_install_cmd.append("--no-build-isolation")
 
     if pre:
         pip_install_cmd.append("--prerelease=allow" if use_uv else "--pre")

--- a/build_tools/tests/setup_venv_test.py
+++ b/build_tools/tests/setup_venv_test.py
@@ -16,6 +16,9 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 from setup_venv import (
     GFX_TARGET_REGEX,
     install_packages_into_venv,
+    check_dns_resolution,
+    apply_url_fallback,
+    scrape_package_names_from_index,
 )
 
 
@@ -145,7 +148,7 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.find_venv_python_exe", return_value="python")
     @patch("setup_venv.run_command")
     def test_find_links_only(self, mock_run, mock_find_python):
-        """Passing just find_links uses it."""
+        """Passing just find_links uses --no-index to prevent PyPI fallback."""
         install_packages_into_venv(
             venv_dir=self.venv_dir,
             packages=["rocm"],
@@ -154,6 +157,8 @@ class InstallPackagesTest(unittest.TestCase):
 
         cmd = mock_run.call_args[0][0]
         self.assertIn("--find-links=https://bucket/run-123/index.html", cmd)
+        self.assertIn("--no-index", cmd)
+        self.assertIn("--no-build-isolation", cmd)
         self.assertFalse(any("--index-url" in str(a) for a in cmd))
 
     @patch("setup_venv.find_venv_python_exe", return_value="python")
@@ -229,6 +234,88 @@ class InstallPackagesTest(unittest.TestCase):
 
         self.assertEqual(mock_run.call_count, 1)
         mock_sleep.assert_not_called()
+
+
+class DnsFallbackTest(unittest.TestCase):
+    """Tests for DNS fallback functionality."""
+
+    def setUp(self):
+        self.venv_dir = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.venv_dir, ignore_errors=True)
+
+    @patch("setup_venv.check_dns_resolution")
+    def test_apply_url_fallback_when_cdn_unreachable(self, mock_dns):
+        """When CDN DNS fails but S3 is reachable, URL is substituted."""
+        # CDN fails, S3 succeeds
+        mock_dns.side_effect = lambda host: host.endswith("s3.amazonaws.com")
+
+        url = "https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu"
+        fallback_url, used_fallback = apply_url_fallback(url)
+
+        self.assertTrue(used_fallback)
+        self.assertEqual(
+            fallback_url,
+            "https://therock-nightly-python.s3.amazonaws.com/v2/gfx94X-dcgpu",
+        )
+
+    @patch("setup_venv.check_dns_resolution", return_value=True)
+    def test_apply_url_fallback_when_cdn_reachable(self, mock_dns):
+        """When CDN DNS succeeds, no fallback is used."""
+        url = "https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu"
+        fallback_url, used_fallback = apply_url_fallback(url)
+
+        self.assertFalse(used_fallback)
+        self.assertEqual(fallback_url, url)
+
+    @patch("setup_venv.check_dns_resolution", return_value=True)
+    def test_apply_url_fallback_unknown_domain(self, mock_dns):
+        """URLs without configured fallbacks are returned unchanged."""
+        url = "https://example.com/packages"
+        fallback_url, used_fallback = apply_url_fallback(url)
+
+        self.assertFalse(used_fallback)
+        self.assertEqual(fallback_url, url)
+
+    @patch("setup_venv.scrape_package_names_from_index")
+    @patch("setup_venv.apply_url_fallback")
+    @patch("setup_venv.find_venv_python_exe", return_value="python")
+    @patch("setup_venv.run_command")
+    def test_s3_fallback_uses_find_links_with_no_index(
+        self, mock_run, mock_find_python, mock_fallback, mock_scrape
+    ):
+        """When S3 fallback is used, --find-links and --no-index are added."""
+        mock_fallback.return_value = (
+            "https://therock-nightly-python.s3.amazonaws.com/v2/gfx94X-dcgpu",
+            True,  # using_s3_fallback=True
+        )
+        mock_scrape.return_value = ["rocm", "torch"]
+
+        install_packages_into_venv(
+            venv_dir=self.venv_dir,
+            packages=["rocm"],
+            index_name="nightly",
+            index_subdir="gfx94X-dcgpu",
+        )
+
+        cmd = mock_run.call_args[0][0]
+        # Should have --find-links for each scraped package
+        find_links = [arg for arg in cmd if "--find-links=" in arg]
+        self.assertEqual(len(find_links), 2)
+        self.assertIn(
+            "--find-links=https://therock-nightly-python.s3.amazonaws.com/v2/gfx94X-dcgpu/rocm/index.html",
+            cmd,
+        )
+        self.assertIn(
+            "--find-links=https://therock-nightly-python.s3.amazonaws.com/v2/gfx94X-dcgpu/torch/index.html",
+            cmd,
+        )
+        # Should have --no-index to prevent PyPI fallback
+        self.assertIn("--no-index", cmd)
+        self.assertIn("--no-build-isolation", cmd)
+        # Should NOT have --index-url
+        self.assertFalse(any("--index-url" in str(a) for a in cmd))
 
 
 class GfxRegexPatternTest(unittest.TestCase):


### PR DESCRIPTION
When DNS resolution fails for rocm.nightlies.amd.com, automatically fall back to therock-nightly-python.s3.amazonaws.com. This mitigates DNS issues seen on gfx94X runners where the CDN domain is unreachable but direct S3 access works.

Progress on #5285, as this is a temporary workaround

Tested here with same error scenario: https://github.com/ROCm/TheRock/actions/runs/27578771062/job/81533725193 (cancelled to save resources)