### PR TITLE
[stinkytofu] Add stinkytofu as independent TheRock subproject

### DIFF
--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -42,6 +42,34 @@ list(APPEND _blas_subproject_names hipBLAS-common)
 
 
 ##############################################################################
+# stinkytofu
+##############################################################################
+
+therock_cmake_subproject_declare(stinkytofu
+  EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_LIBRARIES_SOURCE_DIR}/shared/stinkytofu"
+  BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/stinkytofu"
+  BACKGROUND_BUILD
+  CMAKE_ARGS
+    -DSTINKYTOFU_BUILD_TESTS=${THEROCK_BUILD_TESTING}
+    -DSTINKYTOFU_BUILD_PYTHON=OFF
+    -DBUILD_SHARED_LIBS=ON
+  BUILD_DEPS
+    rocm-cmake
+    therock-googletest
+)
+therock_cmake_subproject_glob_c_sources(stinkytofu
+  SUBDIRS
+    .
+)
+therock_cmake_subproject_provide_package(stinkytofu stinkytofu lib/cmake/stinkytofu)
+therock_cmake_subproject_build_test(stinkytofu
+  COMMAND "${CMAKE_CTEST_COMMAND}" --output-on-failure --no-tests=error
+)
+therock_cmake_subproject_activate(stinkytofu)
+list(APPEND _blas_subproject_names stinkytofu)
+
+
+##############################################################################
 # rocRoller
 ##############################################################################
 
@@ -144,6 +172,7 @@ therock_cmake_subproject_declare(hipBLASLt
   BUILD_DEPS
     hipBLAS-common
     rocm-cmake
+    stinkytofu
     therock-googletest
     therock-msgpack-cxx
     ${hipBLASLt_rocRoller_build_deps}


### PR DESCRIPTION
## Summary
- Declare stinkytofu as a standalone subproject in the BLAS group
- Pure C++20 library — no HIP toolchain, no GPU targets
- Build-time test gating via `therock_cmake_subproject_build_test` (ctest)
- Added as `BUILD_DEP` for hipBLASLt (rocisa links against libstinkytofu.so)

## Companion PR
- rocm-libraries: https://github.com/ROCm/rocm-libraries/pull/7556
  - Adds `find_package(stinkytofu)` support so rocisa uses the pre-installed package
  - Switches stinkytofu install rules to `rocm_install` / `rocm_export_targets`

## Test plan
- [ ] TheRock BLAS build with stinkytofu subproject
- [ ] stinkytofu ctest passes as build-time gate
- [ ] hipBLASLt finds pre-installed stinkytofu via `find_package`