### PR TITLE
[ci] Register rocgdb as a multi-arch external repo

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -161,7 +161,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             ${{ inputs.build_variant_cmake_preset && format('--preset={0}', inputs.build_variant_cmake_preset) }} \
-            ${{ inputs.external_repo_config != '' && format('-DTHEROCK_{0}_SOURCE_DIR={1}', fromJSON(inputs.external_repo_config).source_package, fromJSON(inputs.external_repo_config).checkout_path) || '' }} \
+            ${{ inputs.external_repo_config != '' && format('-DTHEROCK_USE_EXTERNAL_{0}=ON -DTHEROCK_{0}_SOURCE_DIR={1}', fromJSON(inputs.external_repo_config).source_package, fromJSON(inputs.external_repo_config).checkout_path) || '' }} \
             ${{ steps.stage_config.outputs.cmake_args }}
 
       - name: Build stage

--- a/build_tools/github_actions/detect_external_repo_config.py
+++ b/build_tools/github_actions/detect_external_repo_config.py
@@ -52,10 +52,14 @@ REPO_CONFIGS: Dict[str, Dict[str, Any]] = {
         "submodule_path": "rocm-systems",
         "skip_submodules": ["rocm-systems"],
     },
+    "rocgdb": {
+        "cmake_source_var": "THEROCK_ROCGDB_SOURCE_DIR",
+        "submodule_path": "debug-tools/rocgdb/source",
+        "skip_submodules": ["rocgdb"],
+    },
     # Future repos can be added here:
     # "llvm-project": {...},
     # "hipify": {...},
-    # "rocgdb": {...},
     # "libhipcxx": {...},
 }
 

--- a/build_tools/github_actions/detect_external_repo_config.py
+++ b/build_tools/github_actions/detect_external_repo_config.py
@@ -381,11 +381,14 @@ def main(argv=None):
             external_repo = json.loads(args.external_repo_json)
             source_repository = external_repo.get("repository", "")
             source_ref = external_repo.get("ref", "")
-            # Extract repo name from full name (e.g., "rocm-libraries" from "ROCm/rocm-libraries")
+            # Extract repo name from full name (e.g., "rocm-libraries" from "ROCm/rocm-libraries").
+            # Lowercase to match REPO_CONFIGS keys, since GitHub preserves the
+            # canonical casing of the repo (e.g. "ROCm/ROCgdb").
             if "/" in source_repository:
                 repo_name = source_repository.split("/")[-1]
             else:
                 repo_name = source_repository
+            repo_name = repo_name.lower()
             args.repository = repo_name
             print(
                 f"Parsed external_repo: repository={source_repository}, ref={source_ref}",


### PR DESCRIPTION
Adds rocgdb to REPO_CONFIGS in detect_external_repo_config.py so the multi-arch CI pipeline can substitute an external rocgdb checkout into the debug-tools build stage via the external_repo mechanism.

Also fixes the CMake invocation in
multi_arch_build_portable_linux_artifacts.yml to emit -DTHEROCK_USE_EXTERNAL_<PKG>=ON alongside
-DTHEROCK_<PKG>_SOURCE_DIR=<path>. rocgdb's source is declared via therock_enable_external_source(... OFF) which uses CACHE STRING FORCE, so a SOURCE_DIR override is silently discarded unless USE_EXTERNAL is also turned on. The extra option is harmless for rocm-libraries / rocm-systems (no USE_EXTERNAL gate defined there).

The rocgdb counterpart, still very WIP:
- https://github.com/ROCm/ROCgdb/pull/130