### PR TITLE
Re-enable WSL ROCDXG multi-arch CI

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -116,29 +116,28 @@ jobs:
       contents: read
       id-token: write
 
-  # TODO: bring back runner ROCR-Runtime-libhsakmt-WSL to re-enable workflow
-  # # ==========================================================================
-  # # STAGE: wsl-rocdxg (generic)
-  # # ==========================================================================
-  # wsl-rocdxg:
-  #   needs: compiler-runtime
-  #   if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'wsl-rocdxg') }}
-  #   uses: ./.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
-  #   secrets: inherit
-  #   with:
-  #     stage_name: wsl-rocdxg
-  #     stage_display_name: "Stage - WSL ROCDXG"
-  #     timeout_minutes: 120  # 2 hours
-  #     dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
-  #     rocm_package_version: ${{ inputs.rocm_package_version }}
-  #     build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
-  #     release_type: ${{ inputs.release_type }}
-  #     repository: ${{ inputs.repository }}
-  #     ref: ${{ inputs.ref }}
-  #     external_repo_config: ${{ inputs.external_repo_config }}
-  #   permissions:
-  #     contents: read
-  #     id-token: write
+  # ==========================================================================
+  # STAGE: wsl-rocdxg (generic)
+  # ==========================================================================
+  wsl-rocdxg:
+    needs: compiler-runtime
+    if: ${{ !cancelled() && !failure() && !contains(inputs.prebuilt_stages, 'wsl-rocdxg') }}
+    uses: ./.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+    secrets: inherit
+    with:
+      stage_name: wsl-rocdxg
+      stage_display_name: "Stage - WSL ROCDXG"
+      timeout_minutes: 120  # 2 hours
+      dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
+      rocm_package_version: ${{ inputs.rocm_package_version }}
+      build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
+    permissions:
+      contents: read
+      id-token: write
 
   # ==========================================================================
   # STAGE: math-libs (per-arch)

--- a/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+++ b/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
@@ -65,10 +65,15 @@ jobs:
       RELEASE_TYPE: ${{ inputs.release_type }}
       THEROCK_HOST_WORKSPACE: ${{ github.workspace }}
       THEROCK_HOST_BUILD_DIR: ${{ github.workspace }}\build-wsl-rocdxg
-      WSLENV: THEROCK_HOST_WORKSPACE/p:THEROCK_HOST_BUILD_DIR/p
+      WSLENV: THEROCK_HOST_WORKSPACE/p:THEROCK_HOST_BUILD_DIR/p:GITHUB_REPOSITORY:GITHUB_EVENT_NAME:GITHUB_EVENT_PATH/p:RELEASE_TYPE
       EXTERNAL_FETCH_SOURCES_ARGS: ${{ inputs.external_repo_config != '' && fromJSON(inputs.external_repo_config).fetch_sources_args || '' }}
 
     steps:
+      # Enable git longpaths before checkout (needed for external repos with long paths)
+      - name: Enable git longpaths
+        if: ${{ inputs.external_repo_config != '' }}
+        run: git config --system core.longpaths true
+
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -190,6 +195,7 @@ jobs:
           mkdir -p "${THEROCK_HOST_BUILD_DIR}"
           "${wsl_venv_dir}/bin/python" "${THEROCK_HOST_WORKSPACE}/build_tools/artifact_manager.py" fetch \
             --run-id="${{ github.run_id }}" \
+            --run-github-repo="${{ github.repository }}" \
             --platform=linux \
             --stage="${stage_name}" \
             --output-dir="${THEROCK_HOST_BUILD_DIR}" \
@@ -233,11 +239,12 @@ jobs:
       - name: Push stage artifacts
         shell: wsl-bash {0}
         env:
-          WSLENV: THEROCK_HOST_WORKSPACE/p:THEROCK_HOST_BUILD_DIR/p:AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN:AWS_DEFAULT_REGION:AWS_REGION
+          WSLENV: THEROCK_HOST_WORKSPACE/p:THEROCK_HOST_BUILD_DIR/p:GITHUB_REPOSITORY:GITHUB_EVENT_NAME:GITHUB_EVENT_PATH/p:RELEASE_TYPE:AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN:AWS_DEFAULT_REGION:AWS_REGION
         run: |
           stage_name="${{ inputs.stage_name }}"
           wsl_venv_dir="/tmp/therock-wsl-rocdxg/.venv"
           "${wsl_venv_dir}/bin/python" "${THEROCK_HOST_WORKSPACE}/build_tools/artifact_manager.py" push --run-id ${{ github.run_id }} \
+            --run-github-repo="${{ github.repository }}" \
             --platform linux \
             --stage="${stage_name}" \
             --build-dir="${THEROCK_HOST_BUILD_DIR}"

--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -191,6 +191,7 @@ _GITHUB_WORKFLOWS_CI_FILENAMES = {
     "multi_arch_build_portable_linux_artifacts.yml",
     "multi_arch_build_windows.yml",
     "multi_arch_build_windows_artifacts.yml",
+    "multi_arch_build_wsl_rocdxg_artifacts.yml",
     "setup_multi_arch.yml",
     "test_artifacts_structure.yml",
     "test_native_linux_packages_install.yml",


### PR DESCRIPTION
## Summary

- Re-enables the `wsl-rocdxg` multi-arch Linux stage that was temporarily disabled in #5317.
- Restores path-filter coverage for the WSL ROCDXG workflow.
- Fixes the WSL artifact fetch/push path so WSL receives the release type and GitHub run context used by the other multi-arch stages.
- Enables Git long-path support before checkout when building from an external repository.

## Motivation

- #5317 temporarily disabled the WSL ROCDXG stage after follow-on CI issues were found.
- The failing WSL run fetched `0` inbound artifacts because the WSL shell did not receive enough context to select the correct artifact backend.
- External repository checkout can also hit Windows path-length limits, so long paths need to be enabled before checkout begins.

## Details

- Re-enables the `wsl-rocdxg` job in `multi_arch_build_portable_linux.yml`.
- Adds `multi_arch_build_wsl_rocdxg_artifacts.yml` back to CI path filtering.
- Propagates `RELEASE_TYPE` and GitHub event context through `WSLENV` for WSL-side artifact fetch and upload.
- Passes `--run-github-repo` to WSL-side artifact fetch and upload.
- Moves `core.longpaths` setup before repository checkout for external-repo WSL jobs.