### PR TITLE
[ci] excluding hipcc test for windows due to `offload-arch.exe` error

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -208,7 +208,7 @@ amdgpu_family_info_matrix_presubmit = {
             "nightly_check_only_for_family": True,
         },
         "windows": {
-            "test-runs-on": "test-windows-strix-halo-gpu-rocm",
+            "test-runs-on": "windows-gfx1151-gpu-rocm",
             # TODO(#2754): Add new benchmark-runs-on runner for benchmarks
             "benchmark-runs-on": "windows-gfx1151-gpu-rocm",
             "family": "gfx1151",

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -208,7 +208,7 @@ amdgpu_family_info_matrix_presubmit = {
             "nightly_check_only_for_family": True,
         },
         "windows": {
-            "test-runs-on": "windows-gfx1151-gpu-rocm",
+            "test-runs-on": "test-windows-strix-halo-gpu-rocm",
             # TODO(#2754): Add new benchmark-runs-on runner for benchmarks
             "benchmark-runs-on": "windows-gfx1151-gpu-rocm",
             "family": "gfx1151",

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -86,6 +86,11 @@ class TestROCmSanity:
     @pytest.mark.skipif(
         is_asan(), reason="hipcc test fails with ASAN build, see TheRock#3313"
     )
+    # TODO(#4755): Re-enable test for windows once offload-arch.exe is fixed
+    @pytest.mark.skipif(
+        is_windows(),
+        reason="Windows offload-arch.exe is not retrieving correct data, ignoring test",
+    )
     def test_hip_printf(self):
         platform_executable_suffix = ".exe" if is_windows() else ""
 


### PR DESCRIPTION
Due to #4755, I am excluding the hipcc test specifically for windows. The fix will be landed soon, but this known error is blocking rocm-systems

Working here: https://github.com/ROCm/TheRock/actions/runs/26112850729/job/76794731609#step:11:57, so disabling CI