### PR TITLE
Add SPIRV Target

### DIFF
--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -242,6 +242,24 @@ therock_add_amdgpu_target(gfx1201 "AMD RX 9070 / XT" FAMILY dgpu-all gfx120X-all
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 
+# SPIRV Target - Experimental
+# Most projects are disabled for it, they can be enabled when we know they work
+therock_add_amdgpu_target(amdgcnspirv "SPIRV Target for AMDGPUs" FAMILY amdgcnspirv
+  EXCLUDE_TARGET_PROJECTS
+    rocRAND hipRAND
+    rocPRIM rocPRIM_tests hipCUB rocThrust
+    rocFFT hipFFT
+    rocBLAS hipBLAS hipBLAS-common rocRoller hipBLASLt
+    rocSPARSE hipSPARSE hipSPARSELt
+    rocSOLVER hipSOLVER
+    rocWMMA libhipcxx
+    composable_kernel MIOpen hipDNN hipdnn_integration_tests
+    miopenprovider hipblasltprovider hipkernelprovider hipDNN_samples
+    rccl rccl-tests rocshmem
+    fusilli fusilliprovider
+    rocprofiler-compute
+)
+
 # Optional extension targets (used for out of tree target development).
 include(therock_custom_amdgpu_targets OPTIONAL)
 


### PR DESCRIPTION
## Motivation

Compiler supports SPIRV as a generic offload target, which can run on any GPU. This patch allows folks to use TheRock to build ROCm libraries/tests with SPIRV offload arch.

## Technical Details

Passing `-DTHEROCK_AMDGPU_FAMILIES=amdgcnspirv -DTHEROCK_TEST_AMDGPU_FAMILIES=amdgcnspirv` will allow users to build with SPIRV target. Disable all other non-tested projects for now, and enable them one by one when folks are confident with their support of SPIRV.

## Test Plan

Test locally, build binaries and check for spirv offload arch in binaries built.

## Test Result

hip-tests binaries had spirv offload bundle

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
