### PR TITLE
test: add rocjitsu emulator target

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -185,11 +185,14 @@ jobs:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       amdgpu_targets: ${{ inputs.amdgpu_targets }}
       # Route to the appropriate runner:
-      #   1. Benchmark components use the dedicated benchmark runner
-      #   2. Multi-GPU components use the multi-GPU runner
-      #   3. Everything else uses the standard test runner
+      #   1. Emulator components use CPU runners
+      #   2. Benchmark components use the dedicated benchmark runner
+      #   3. Multi-GPU components use the multi-GPU runner
+      #   4. Everything else uses the standard test runner
       test_runs_on: >-
         ${{
+          (matrix.components.emulator_runs_on != '' &&
+            matrix.components.emulator_runs_on) ||
           (matrix.components.is_benchmark == true &&
             inputs.benchmark_runs_on != '' &&
             inputs.benchmark_runs_on) ||

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -45,6 +45,7 @@ jobs:
       Test ${{ fromJSON(inputs.component).job_name }}
       (shard ${{ matrix.shard }}/${{ fromJSON(inputs.component).total_shards }})
       (${{ inputs.amdgpu_families }})
+      ${{ fromJSON(inputs.component).emulator == 'rocjitsu' && '(rocjitsu)' || '' }}
       ${{ fromJSON(inputs.component).expect_failure == true && '(xfail)' || '' }}
     runs-on: ${{ inputs.test_runs_on }}
     continue-on-error: ${{ fromJSON(inputs.component).expect_failure == true }}
@@ -61,16 +62,9 @@ jobs:
       # --security-opt seccomp=unconfined - enables memory mapping, and is recommended for containers running in HPC environments
       # --env-file /etc/podinfo/gha-gpu-isolation-settings - Required for GPU isolation on OSSCI MIXXX runners
       # --user 0:0 - Running as root, by recommendation of GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/dockerfile-support#user
-      options: --ipc host
-        --group-add video
-        --device /dev/kfd
-        --device /dev/dri
-        --group-add 993
-        --group-add 992
-        --group-add 110
-        --ulimit memlock=-1:-1
-        --security-opt seccomp=unconfined
-        --env-file /etc/podinfo/gha-gpu-isolation-settings
+      options: >-
+        --ipc host
+        ${{ fromJSON(inputs.component).emulator != 'rocjitsu' && '--group-add video --device /dev/kfd --device /dev/dri --group-add 993 --group-add 992 --group-add 110 --ulimit memlock=-1:-1 --security-opt seccomp=unconfined --env-file /etc/podinfo/gha-gpu-isolation-settings' || '' }}
         --user 0:0
         ${{ fromJSON(inputs.component).container_options }}
     strategy:
@@ -143,6 +137,7 @@ jobs:
           python ./build_tools/health_status.py
 
       - name: Driver / GPU sanity check
+        if: ${{ fromJSON(inputs.component).emulator != 'rocjitsu' }}
         timeout-minutes: 3
         run: |
           python ./build_tools/print_driver_gpu_info.py
@@ -170,6 +165,10 @@ jobs:
           TEST_TYPE: ${{ fromJSON(inputs.component).test_type }}
           TEST_COMPONENT: ${{ fromJSON(inputs.component).job_name }}
           ROCM_KPACK_DEBUG: "1"
+          ROCM_TESTS_RUN_ON_EMULATOR: ${{ fromJSON(inputs.component).emulator }}
+          LD_PRELOAD: ${{ fromJSON(inputs.component).emulator == 'rocjitsu' && format('{0}/lib/librocjitsu_kmd.so', env.OUTPUT_ARTIFACTS_DIR) || '' }}
+          RJ_CONFIG: ${{ fromJSON(inputs.component).emulator == 'rocjitsu' && format('{0}/{1}', env.OUTPUT_ARTIFACTS_DIR, fromJSON(inputs.component).rocjitsu_config) || '' }}
+          RJ_SCHEMA: ${{ fromJSON(inputs.component).emulator == 'rocjitsu' && format('{0}/{1}', env.OUTPUT_ARTIFACTS_DIR, fromJSON(inputs.component).rocjitsu_schema) || '' }}
           # Windows hip-tests (PAL=1, ROCR=0) set this via matrix; other components
           # leave it empty. #3587
           GPU_ENABLE_PAL: ${{ fromJSON(inputs.component).gpu_enable_pal }}
@@ -181,6 +180,7 @@ jobs:
             Test ${{ fromJSON(inputs.component).job_name }}
             (shard ${{ matrix.shard }}/${{ fromJSON(inputs.component).total_shards }})
             (${{ inputs.amdgpu_families }})
+            ${{ fromJSON(inputs.component).emulator == 'rocjitsu' && '(rocjitsu)' || '' }}
             ${{ fromJSON(inputs.component).expect_failure == true && '(xfail)' || '' }}
         run: |
           ${{ fromJSON(inputs.component).test_script }}

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -125,6 +125,8 @@ amdgpu_family_info_matrix dictionary fields:
 - test-runs-on-multi-gpu: (optional) GitHub runner label for multi-GPU tests for this architecture
 - test-runs-on-multi-gpu-labels: (optional) List of runner label configs for multi-GPU load balancing.
     Same format as test-runs-on-labels.
+- test-runs-on-emulator: (optional) CPU runner label for rocJITsu emulator tests for this architecture
+- rocjitsu-config: (optional) rocJITsu config file under share/rocjitsu/configs for emulator tests
 - benchmark-runs-on: (optional) GitHub runner label for benchmarks for this architecture
 - test-runs-on-kernel: (optional) dict of kernel-specific runner labels, keyed by kernel type (e.g. "oem")
 - family: (required) AMD GPU family name, used for test selection and artifact fetching
@@ -169,6 +171,8 @@ amdgpu_family_info_matrix_presubmit = {
                     "weight": 0.21,
                 },  # core42 (3/14)
             ],
+            "test-runs-on-emulator": "azure-linux-scale-rocm",
+            "rocjitsu-config": "amdgpu_cdna3_kmd.json",
             # TODO(#2754): Add new benchmark-runs-on runner for benchmarks
             "benchmark-runs-on": "linux-gfx942-8gpu-ossci-rocm",
             "family": "gfx94X-dcgpu",
@@ -244,6 +248,8 @@ amdgpu_family_info_matrix_postsubmit = {
         "linux": {
             "test-runs-on": "linux-gfx950-1gpu-ccs-ossci-rocm",
             "test-runs-on-multi-gpu": "linux-gfx950-8gpu-ccs-ossci-rocm",
+            "test-runs-on-emulator": "azure-linux-scale-rocm",
+            "rocjitsu-config": "amdgpu_cdna4_kmd.json",
             "family": "gfx950-dcgpu",
             "fetch-gfx-targets": ["gfx950"],
             "build_variants": ["release", "asan", "tsan"],

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -171,7 +171,7 @@ amdgpu_family_info_matrix_presubmit = {
                     "weight": 0.21,
                 },  # core42 (3/14)
             ],
-            "test-runs-on-emulator": "azure-linux-scale-rocm",
+            "test-runs-on-emulator": "rocjitsu-cpu",
             "rocjitsu-config": "amdgpu_cdna3_kmd.json",
             # TODO(#2754): Add new benchmark-runs-on runner for benchmarks
             "benchmark-runs-on": "linux-gfx942-8gpu-ossci-rocm",
@@ -248,7 +248,7 @@ amdgpu_family_info_matrix_postsubmit = {
         "linux": {
             "test-runs-on": "linux-gfx950-1gpu-ccs-ossci-rocm",
             "test-runs-on-multi-gpu": "linux-gfx950-8gpu-ccs-ossci-rocm",
-            "test-runs-on-emulator": "azure-linux-scale-rocm",
+            "test-runs-on-emulator": "rocjitsu-cpu",
             "rocjitsu-config": "amdgpu_cdna4_kmd.json",
             "family": "gfx950-dcgpu",
             "fetch-gfx-targets": ["gfx950"],

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -101,12 +101,8 @@ def _make_rocjitsu_component(
     )
     emulator_component["emulator"] = ROCJITSU_EMULATOR
     emulator_component["emulator_runs_on"] = emulator_runs_on
-    emulator_component["rocjitsu_config"] = (
-        f"share/rocjitsu/configs/{rocjitsu_config}"
-    )
-    emulator_component["rocjitsu_schema"] = (
-        f"share/rocjitsu/schemas/{ROCJITSU_SCHEMA}"
-    )
+    emulator_component["rocjitsu_config"] = f"share/rocjitsu/configs/{rocjitsu_config}"
+    emulator_component["rocjitsu_schema"] = f"share/rocjitsu/schemas/{ROCJITSU_SCHEMA}"
     emulator_component.pop("multi_gpu_runner", None)
     return emulator_component
 

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -38,6 +38,9 @@ logging.basicConfig(level=logging.INFO)
 # Note: these paths are relative to the repository root. We could make that
 # more explicit, or use absolute paths.
 SCRIPT_DIR = Path("./build_tools/github_actions/test_executable_scripts")
+ROCJITSU_EMULATOR = "rocjitsu"
+ROCJITSU_FETCH_ARTIFACT_ARG = "--rocjitsu"
+ROCJITSU_SCHEMA = "simulation_config.fbs"
 
 
 def _get_script_path(script_name: str) -> str:
@@ -46,6 +49,66 @@ def _get_script_path(script_name: str) -> str:
     # 'bash' as the shell on Linux and Windows.
     posix_path = platform_path.as_posix()
     return str(posix_path)
+
+
+def _append_fetch_artifact_arg(fetch_artifact_args: str, arg: str) -> str:
+    args = fetch_artifact_args.split()
+    if arg not in args:
+        args.append(arg)
+    return " ".join(args)
+
+
+def _get_family_platform_info(
+    amdgpu_families_matrix: dict,
+    platform: str,
+    amdgpu_families: str | None,
+) -> tuple[str | None, dict | None]:
+    if not amdgpu_families:
+        return None, None
+
+    requested_family = amdgpu_families.lower()
+    for family_name, family_info in amdgpu_families_matrix.items():
+        platform_info = family_info.get(platform)
+        if not platform_info:
+            continue
+
+        candidate_names = {
+            family_name.lower(),
+            platform_info.get("family", "").lower(),
+        }
+        candidate_names.update(
+            target.lower() for target in platform_info.get("fetch-gfx-targets", [])
+        )
+        if requested_family in candidate_names:
+            return family_name, platform_info
+
+    return None, None
+
+
+def _make_rocjitsu_component(
+    job_config_data: dict,
+    platform_info: dict,
+) -> dict | None:
+    emulator_runs_on = platform_info.get("test-runs-on-emulator")
+    rocjitsu_config = platform_info.get("rocjitsu-config")
+    if not emulator_runs_on or not rocjitsu_config:
+        return None
+
+    emulator_component = deepcopy(job_config_data)
+    emulator_component["job_name"] = f'{job_config_data["job_name"]} (rocjitsu)'
+    emulator_component["fetch_artifact_args"] = _append_fetch_artifact_arg(
+        emulator_component.get("fetch_artifact_args", ""), ROCJITSU_FETCH_ARTIFACT_ARG
+    )
+    emulator_component["emulator"] = ROCJITSU_EMULATOR
+    emulator_component["emulator_runs_on"] = emulator_runs_on
+    emulator_component["rocjitsu_config"] = (
+        f"share/rocjitsu/configs/{rocjitsu_config}"
+    )
+    emulator_component["rocjitsu_schema"] = (
+        f"share/rocjitsu/schemas/{ROCJITSU_SCHEMA}"
+    )
+    emulator_component.pop("multi_gpu_runner", None)
+    return emulator_component
 
 
 test_matrix = {
@@ -454,6 +517,7 @@ test_matrix = {
     "rocwmma": {
         "job_name": "rocwmma",
         "fetch_artifact_args": "--rocwmma --tests --blas",
+        "run_on_emulator": True,
         # Headroom above typical shard runtime; per-test CTest timeouts fail fast on hangs (ROCM-24171).
         "timeout_minutes": 90,
         "test_script": f"python {_get_script_path('test_rocwmma.py')}",
@@ -563,9 +627,9 @@ test_matrix = {
 
 
 def run():
-    platform = os.getenv("RUNNER_OS").lower()
+    platform = os.environ["RUNNER_OS"].lower()
     projects_to_test = os.getenv("PROJECTS_TO_TEST", "*")
-    amdgpu_families = os.getenv("AMDGPU_FAMILIES")
+    amdgpu_families = os.getenv("AMDGPU_FAMILIES", "")
     test_type = os.getenv("TEST_TYPE", "full")
     test_labels = ast.literal_eval(os.getenv("TEST_LABELS") or "[]")
     run_extended_tests = str2bool(os.getenv("RUN_EXTENDED_TESTS", "false"))
@@ -597,6 +661,13 @@ def run():
 
     # This string -> array conversion ensures no partial strings are detected during test selection (ex: "hipblas" in ["hipblaslt", "rocblas"] = false)
     project_array = [item.strip() for item in projects_to_test.split(",")]
+
+    amdgpu_families_matrix = get_all_families_for_trigger_types(
+        ["presubmit", "postsubmit", "nightly"]
+    )
+    _, amdgpu_family_platform_info = _get_family_platform_info(
+        amdgpu_families_matrix, platform, amdgpu_families
+    )
 
     all_components = []
     for key in selected_matrix:
@@ -667,7 +738,7 @@ def run():
                     all_components.append(rocr_entry)
                 continue
 
-            job_config_data = selected_matrix[key]
+            job_config_data = deepcopy(selected_matrix[key])
             job_config_data["test_type"] = test_type
             # For CI testing, we construct a shard array based on "total_shards" from "fetch_test_configurations.py"
             # This way, the test jobs will be split up into X shards. (ex: [1, 2, 3, 4] = 4 test shards)
@@ -687,9 +758,6 @@ def run():
             # Inside the "multi_gpu" field, we have a mapping of amdgpu_family -> bool (if multi GPU testing is enabled for that family)
             # If the multi GPU test runner is not enabled, we will skip the test
             if "multi_gpu" in selected_matrix[key]:
-                amdgpu_families_matrix = get_all_families_for_trigger_types(
-                    ["presubmit", "postsubmit", "nightly"]
-                )
                 if (
                     platform in selected_matrix[key]["multi_gpu"]
                     and amdgpu_families in selected_matrix[key]["multi_gpu"][platform]
@@ -723,6 +791,19 @@ def run():
                     continue
 
             all_components.append(job_config_data)
+
+            if selected_matrix[key].get("run_on_emulator"):
+                emulator_component = None
+                if amdgpu_family_platform_info:
+                    emulator_component = _make_rocjitsu_component(
+                        job_config_data, amdgpu_family_platform_info
+                    )
+                if emulator_component:
+                    logging.info(
+                        f"Including job {emulator_component['job_name']} on "
+                        f"{emulator_component['emulator_runs_on']}"
+                    )
+                    all_components.append(emulator_component)
 
     # Separate sanity (always a prerequisite) from the regular component matrix.
     sanity_component = next(

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -22,6 +22,7 @@ amdgpu_family_info_matrix_all {
               "runs_on": {                      #         dict: Host names of compute nodes
                   "test":                       #             string: test runner (optional)
                   "test-multi-gpu":             #             string: multi-gpu test runner (optional)
+                  "emulator":                   #             string: emulator test runner (optional)
                   "benchmark":                  #             string: benchmark runner (optional)
               }
             }
@@ -114,10 +115,12 @@ amdgpu_family_info_matrix_all = {
                     "runs_on": {
                         "test": "linux-mi325-1gpu-ossci-rocm-frac",
                         "test-multi-gpu": "linux-mi325-8gpu-ossci-rocm",
+                        "emulator": "azure-linux-scale-rocm",
                         # TODO(#2754): Add new benchmark-runs-on runner for benchmarks
                         "benchmark": "linux-mi325-8gpu-ossci-rocm",
                     },
                     "fetch-gfx-targets": ["gfx942"],
+                    "rocjitsu-config": "amdgpu_cdna3_kmd.json",
                 },
                 "release": {
                     "push_on_success": True,
@@ -330,8 +333,12 @@ amdgpu_family_info_matrix_all = {
                 },
                 "test": {
                     "run_tests": True,
-                    "runs_on": {"test": "linux-mi355-1gpu-ossci-rocm"},
+                    "runs_on": {
+                        "test": "linux-mi355-1gpu-ossci-rocm",
+                        "emulator": "azure-linux-scale-rocm",
+                    },
                     "fetch-gfx-targets": ["gfx950"],
+                    "rocjitsu-config": "amdgpu_cdna4_kmd.json",
                 },
                 "release": {
                     "push_on_success": False,

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -158,6 +158,52 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         self.assertNotIn("rocroller", names)
 
     # -----------------------
+    # rocJITsu emulator tests
+    # -----------------------
+
+    def test_emulator_job_emitted_for_opted_in_test_on_supported_family(self):
+        os.environ["PROJECTS_TO_TEST"] = "rocwmma"
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        names = {job["job_name"] for job in components}
+        self.assertEqual(names, {"rocwmma", "rocwmma (rocjitsu)"})
+
+        emulator = next(j for j in components if j["job_name"] == "rocwmma (rocjitsu)")
+        self.assertEqual(emulator["emulator"], "rocjitsu")
+        self.assertEqual(emulator["emulator_runs_on"], "azure-linux-scale-rocm")
+        self.assertIn("--rocjitsu", emulator["fetch_artifact_args"].split())
+        self.assertEqual(
+            emulator["rocjitsu_config"],
+            "share/rocjitsu/configs/amdgpu_cdna3_kmd.json",
+        )
+        self.assertEqual(
+            emulator["rocjitsu_schema"],
+            "share/rocjitsu/schemas/simulation_config.fbs",
+        )
+
+    def test_emulator_job_not_emitted_for_unsupported_family(self):
+        os.environ["PROJECTS_TO_TEST"] = "rocwmma"
+        os.environ["AMDGPU_FAMILIES"] = "gfx110X-all"
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        names = {job["job_name"] for job in components}
+        self.assertEqual(names, {"rocwmma"})
+
+    def test_emulator_job_not_emitted_on_windows(self):
+        os.environ["PROJECTS_TO_TEST"] = "rocwmma"
+        os.environ["RUNNER_OS"] = "Windows"
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        names = {job["job_name"] for job in components}
+        self.assertEqual(names, {"rocwmma"})
+
+    # -----------------------
     # Functional test merging via run_extended_tests
     # -----------------------
 


### PR DESCRIPTION
## Motivation

we constantly have shortages during NPI.
rocjitsu allows emulating new gpus either on cpu or  old gpu.
This will give us much better coverage.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
