### PR TITLE
Add known issue warning for missing device metadata

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -147,6 +147,17 @@ Select your GPU using the `[device-*]` extras from the
 > succeed, but device enumeration, kernel launch, or library loads may fail at
 > runtime. Please file an issue if you hit one.
 
+> [!WARNING]
+> Known issue ([#5347](https://github.com/ROCm/TheRock/issues/5347)): some
+> `rocm` meta-package device extras may be missing from the published `rocm`
+> package metadata. If a `rocm[device-*]` extra does not install the expected
+> device package, install the device package directly, for example:
+>
+> ```bash
+> pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+>     rocm-sdk-device-gfx942 rocm-sdk-device-gfx950
+> ```
+
 ```bash
 # Single device (replace device-gfx942 with your GPU):
 pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \


### PR DESCRIPTION
## Motivation

Workaround for https://github.com/ROCm/TheRock/issues/5347.

## Test Plan

```
pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ rocm[device-gfx950] --dry-run

Looking in indexes: https://rocm.nightlies.amd.com/whl-multi-arch/
Collecting rocm[device-gfx950]
  Using cached rocm-7.14.0a20260519.tar.gz (19 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
WARNING: rocm 7.14.0a20260519 does not provide the extra 'device-gfx950'
```

```
pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ rocm[device-gfx950] rocm-sdk-device-gfx950 --dry-run

Looking in indexes: https://rocm.nightlies.amd.com/whl-multi-arch/
Collecting rocm-sdk-device-gfx950
  Downloading rocm_sdk_device_gfx950-7.14.0a20260519-py3-none-linux_x86_64.whl (616.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 616.3/616.3 MB 33.9 MB/s  0:00:14
Collecting rocm[device-gfx950]
  Using cached rocm-7.14.0a20260519.tar.gz (19 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
WARNING: rocm 7.14.0a20260519 does not provide the extra 'device-gfx950'
Collecting rocm-sdk-core==7.14.0a20260519 (from rocm[device-gfx950])
  Using cached rocm_sdk_core-7.14.0a20260519-py3-none-linux_x86_64.whl (410.9 MB)
Collecting rocm-sdk-libraries==7.14.0a20260519 (from rocm-sdk-device-gfx950)
  Downloading rocm_sdk_libraries-7.14.0a20260519-py3-none-linux_x86_64.whl (136.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 136.2/136.2 MB 38.2 MB/s  0:00:03
Would install rocm-7.14.0a20260519 rocm-sdk-core-7.14.0a20260519 rocm-sdk-device-gfx950-7.14.0a20260519 rocm-sdk-libraries-7.14.0a20260519
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
