### PR TITLE
Support testing multi-arch ROCm wheels using PEP 503 `--index-url` inputs

### DIFF
--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -256,7 +256,6 @@ jobs:
         }}
       python_version: "3.12"
       rocm_version: ${{ inputs.rocm_package_version }}
-      amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
       kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
       container_image_name: ${{ matrix.image.name }}
       container_image_url: ${{ matrix.image.url }}

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -178,7 +178,6 @@ jobs:
         }}
       python_version: "3.12"
       rocm_version: ${{ inputs.rocm_package_version }}
-      amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
       kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
       # Windows runs natively without a container image.
       container_image_name: native

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -17,7 +17,10 @@ on:
         type: string
         default: "linux-gfx942-1gpu-ossci-rocm"
       package_index_url_base:
-        description: Base Python package index URL (without GPU family subdir)
+        description: >-
+          Base Python package index URL. For legacy per-family builds, this is
+          without the GPU family subdir. For kpack-split builds, this is the
+          full flat index URL.
         type: string
         default: "https://rocm.nightlies.amd.com/v2"
       package_find_links_url:
@@ -31,13 +34,6 @@ on:
         description: ROCm version to pip install (e.g. "7.10.0a20251124")
         required: true
         type: string
-      amdgpu_targets:
-        description: >-
-          Comma-separated individual gfx targets for kpack-split builds
-          (e.g. 'gfx942' or 'gfx1200,gfx1201'). Used to install the correct
-          per-target device wheels. Leave empty for legacy per-family builds.
-        type: string
-        default: ""
       kpack_split:
         description: "'true' if this is a kpack-split flat build."
         type: string
@@ -66,6 +62,10 @@ on:
         required: true
         type: string
       package_index_url_base:
+        description: >-
+          Base Python package index URL. For legacy per-family builds, this is
+          without the GPU family subdir. For kpack-split builds, this is the
+          full flat index URL.
         type: string
       package_find_links_url:
         type: string
@@ -75,13 +75,6 @@ on:
       rocm_version:
         required: true
         type: string
-      amdgpu_targets:
-        description: >-
-          Comma-separated individual gfx targets for kpack-split builds
-          (e.g. 'gfx942' or 'gfx1200,gfx1201'). Used to install the correct
-          per-target device wheels. Leave empty for legacy per-family builds.
-        type: string
-        default: ""
       kpack_split:
         description: "'true' if this is a kpack-split flat build."
         type: string
@@ -141,30 +134,35 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - name: Compute ROCm device extras
+        if: ${{ inputs.kpack_split == 'true' }}
         id: device_extras
         run: |
-          if [ "${{ inputs.kpack_split }}" = "true" ] && [ -n "${{ inputs.amdgpu_targets }}" ]; then
-            # Prefix each comma-separated target with "device-": gfx942,gfx1201 -> device-gfx942,device-gfx1201
-            extras=$(echo "${{ inputs.amdgpu_targets }}" | sed 's/\(^\|,\)/\1device-/g')
-            echo "value=${extras}" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=" >> "$GITHUB_OUTPUT"
-          fi
+          python build_tools/github_actions/expand_amdgpu_families.py \
+            --amdgpu-families "${{ inputs.amdgpu_family }}" \
+            --output-mode=device-extras
 
       # Key off install_libraries success (not test_libraries) so devel install/test still run
       - name: Install rocm[libraries]
         id: install_libraries
         run: |
           pkg="rocm[libraries]"
-          if [ -n "${{ steps.device_extras.outputs.value }}" ]; then
-            pkg="${pkg%]},${{ steps.device_extras.outputs.value }}]"
+          if [ -n "${{ steps.device_extras.outputs.device_extras }}" ]; then
+            pkg="${pkg%]},${{ steps.device_extras.outputs.device_extras }}]"
           fi
-          python build_tools/setup_venv.py ${VENV_DIR} \
-            --packages "${pkg}==${{ inputs.rocm_version }}" \
-            --index-url=${{ inputs.package_index_url_base }} \
-            --index-subdir=${{ inputs.amdgpu_family }} \
-            --find-links=${{ inputs.package_find_links_url }} \
-            --activate-in-future-github-actions-steps
+          if [ "${{ inputs.kpack_split }}" = "true" ]; then
+            python build_tools/setup_venv.py ${VENV_DIR} \
+              --packages "${pkg}==${{ inputs.rocm_version }}" \
+              --index-url=${{ inputs.package_index_url_base }} \
+              --find-links=${{ inputs.package_find_links_url }} \
+              --activate-in-future-github-actions-steps
+          else
+            python build_tools/setup_venv.py ${VENV_DIR} \
+              --packages "${pkg}==${{ inputs.rocm_version }}" \
+              --index-url=${{ inputs.package_index_url_base }} \
+              --index-subdir=${{ inputs.amdgpu_family }} \
+              --find-links=${{ inputs.package_find_links_url }} \
+              --activate-in-future-github-actions-steps
+          fi
 
       - name: Show installed packages (libraries)
         if: ${{ !cancelled() && steps.install_libraries.outcome == 'success' }}
@@ -183,14 +181,21 @@ jobs:
         if: ${{ !cancelled() && steps.install_libraries.outcome == 'success' }}
         run: |
           pkg="rocm[libraries,devel]"
-          if [ -n "${{ steps.device_extras.outputs.value }}" ]; then
-            pkg="${pkg%]},${{ steps.device_extras.outputs.value }}]"
+          if [ -n "${{ steps.device_extras.outputs.device_extras }}" ]; then
+            pkg="${pkg%]},${{ steps.device_extras.outputs.device_extras }}]"
           fi
-          python build_tools/setup_venv.py ${VENV_DIR} \
-            --packages "${pkg}==${{ inputs.rocm_version }}" \
-            --index-url=${{ inputs.package_index_url_base }} \
-            --index-subdir=${{ inputs.amdgpu_family }} \
-            --find-links=${{ inputs.package_find_links_url }}
+          if [ "${{ inputs.kpack_split }}" = "true" ]; then
+            python build_tools/setup_venv.py ${VENV_DIR} \
+              --packages "${pkg}==${{ inputs.rocm_version }}" \
+              --index-url=${{ inputs.package_index_url_base }} \
+              --find-links=${{ inputs.package_find_links_url }}
+          else
+            python build_tools/setup_venv.py ${VENV_DIR} \
+              --packages "${pkg}==${{ inputs.rocm_version }}" \
+              --index-url=${{ inputs.package_index_url_base }} \
+              --index-subdir=${{ inputs.amdgpu_family }} \
+              --find-links=${{ inputs.package_find_links_url }}
+          fi
 
       - name: Show installed packages (libraries,devel)
         if: ${{ !cancelled() && steps.install_devel.outcome == 'success' }}


### PR DESCRIPTION
## Motivation

Expanding our ability to test for https://github.com/ROCm/TheRock/issues/5347.

The `.github/workflows/test_rocm_wheels.yml` workflow was not compatible with `--index-url https://rocm.nightlies.amd.com/whl-multi-arch/`, only CI uploads like `--find-links https://therock-ci-artifacts.s3.amazonaws.com/26115600835-linux/python/index.html`. Now it supports both modes.

## Technical Details

The main fix here is to omit `--index-subdir=${{ inputs.amdgpu_family }}` when `${{ inputs.kpack_split == 'true' }}`, similar to https://github.com/ROCm/TheRock/blob/48e5305a977d3b598af3113ff259f1f088e82248/.github/workflows/test_pytorch_wheels.yml#L161-L175

## Test Plan

* Manually triggered https://github.com/ROCm/TheRock/actions/runs/26132646536/job/76860876521
    ```
      kpack_split: true
      package_index_url_base: https://rocm.nightlies.amd.com/whl-multi-arch/
      package_find_links_url:
      amdgpu_family: gfx950-dcgpu
      rocm_version: 7.14.0a20260519
      test_runs_on: linux-gfx950-1gpu-ccs-ossci-rocm
    ```
* Watch CI on this PR to check that `--find-links` path still works
  * Linux gfx942: https://github.com/ROCm/TheRock/actions/runs/26133134983/job/76877270781?pr=5352 success,
      ```
      Run pip freeze
      rocm==7.14.0.dev0+03fb5824e759640bf4f8e9b4e3c842561d1befd7
      rocm-sdk-core==7.14.0.dev0+03fb5824e759640bf4f8e9b4e3c842561d1befd7
      rocm-sdk-device-gfx942==7.14.0.dev0+03fb5824e759640bf4f8e9b4e3c842561d1befd7
      rocm-sdk-libraries==7.14.0.dev0+03fb5824e759640bf4f8e9b4e3c842561d1befd7
      ```
  * Windows gfx110X: https://github.com/ROCm/TheRock/actions/runs/26133134983/job/76879169824?pr=5352 known timeout,
      ```
      Run pip freeze
      rocm==7.14.0.dev0+03fb5824e759640bf4f8e9b4e3c842561d1befd7
      rocm-sdk-core==7.14.0.dev0+03fb5824e759640bf4f8e9b4e3c842561d1befd7
      rocm-sdk-device-gfx1100==7.14.0.dev0+03fb5824e759640bf4f8e9b4e3c842561d1befd7
      rocm-sdk-device-gfx1101==7.14.0.dev0+03fb5824e759640bf4f8e9b4e3c842561d1befd7
      rocm-sdk-device-gfx1102==7.14.0.dev0+03fb5824e759640bf4f8e9b4e3c842561d1befd7
      rocm-sdk-device-gfx1103==7.14.0.dev0+03fb5824e759640bf4f8e9b4e3c842561d1befd7
      rocm-sdk-libraries==7.14.0.dev0+03fb5824e759640bf4f8e9b4e3c842561d1befd7
      ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
