### PR TITLE
fix: resolve libnuma load failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,3 +361,4 @@ separately.
 - [Build Artifacts](docs/development/artifacts.md): Documentation about the outputs of the build system.
 - [Releases Page](RELEASES.md): Documentation for how to leverage our build artifacts.
 - [Supported GPUs](SUPPORTED_GPUS.md): Current support status and prioritized roadmap for each AMD GPU architecture.
+// Fix libnuma path


### PR DESCRIPTION
Addressing the issue where rocSHMEM fails to open libnuma on Linux gfx950.