### PR TITLE
Forward checkout inputs to Windows debug-tools stage

### DIFF
--- a/.github/workflows/multi_arch_build_windows.yml
+++ b/.github/workflows/multi_arch_build_windows.yml
@@ -160,6 +160,9 @@ jobs:
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
       release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
+      external_repo_config: ${{ inputs.external_repo_config }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
The debug-tools stage in multi_arch_build_windows.yml was added in 41b84b35 without forwarding the repository, ref, and external_repo_config inputs to the reusable multi_arch_build_windows_artifacts.yml workflow. The other three stages (foundation, compiler-runtime, math-libs) all forward those inputs. This broke multi-arch nightly releases triggered in rockrel, which failed during the checkout step.

This adds the missing inputs. Superseds the revert #5360.