### PR TITLE
Fix multi-arch rocm sdist missing per-platform device extras

### DIFF
--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -21,6 +21,14 @@ on:
         description: "amdgpu_families for multi-arch builds as a semicolon-separated list (e.g. 'gfx94X-dcgpu;gfx120X-all'). Leave empty for single-family builds (those only use artifact_group)"
         type: string
         default: ""
+      linux_amdgpu_families:
+        description: "Linux side of the cross-platform family pair for multi-arch builds; used to advertise the union of device extras in the rocm sdist. Leave empty for single-platform builds."
+        type: string
+        default: ""
+      windows_amdgpu_families:
+        description: "Windows side of the cross-platform family pair. See linux_amdgpu_families."
+        type: string
+        default: ""
       multiarch_index:
         description: "Enable multi-arch indexing (generates per-family indexes)"
         type: boolean
@@ -50,6 +58,12 @@ on:
       artifact_group:
         type: string
       amdgpu_families:
+        type: string
+        default: ""
+      linux_amdgpu_families:
+        type: string
+        default: ""
+      windows_amdgpu_families:
         type: string
         default: ""
       multiarch_index:
@@ -141,7 +155,9 @@ jobs:
           python ./build_tools/build_python_packages.py \
             --artifact-dir="${{ env.ARTIFACTS_DIR }}" \
             --dest-dir="${{ env.PACKAGES_DIR }}" \
-            --version="${{ inputs.package_version }}"
+            --version="${{ inputs.package_version }}" \
+            --linux-amdgpu-families="${{ inputs.linux_amdgpu_families }}" \
+            --windows-amdgpu-families="${{ inputs.windows_amdgpu_families }}"
 
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure_aws_artifacts_credentials

--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -21,6 +21,14 @@ on:
         description: "amdgpu_families for multi-arch builds as a semicolon-separated list (e.g. 'gfx94X-dcgpu;gfx120X-all'). Leave empty for single-family builds (those only use artifact_group)"
         type: string
         default: ""
+      linux_amdgpu_families:
+        description: "Linux side of the cross-platform family pair for multi-arch builds; used to advertise the union of device extras in the rocm sdist. Leave empty for single-platform builds."
+        type: string
+        default: ""
+      windows_amdgpu_families:
+        description: "Windows side of the cross-platform family pair. See linux_amdgpu_families."
+        type: string
+        default: ""
       multiarch_index:
         description: "Enable multi-arch indexing (generates per-family indexes)"
         type: boolean
@@ -50,6 +58,12 @@ on:
       artifact_group:
         type: string
       amdgpu_families:
+        type: string
+        default: ""
+      linux_amdgpu_families:
+        type: string
+        default: ""
+      windows_amdgpu_families:
         type: string
         default: ""
       multiarch_index:
@@ -142,7 +156,9 @@ jobs:
           python ./build_tools/build_python_packages.py \
             --artifact-dir="${{ env.ARTIFACTS_DIR }}" \
             --dest-dir="${{ env.PACKAGES_DIR }}" \
-            --version="${{ inputs.package_version }}"
+            --version="${{ inputs.package_version }}" \
+            --linux-amdgpu-families="${{ inputs.linux_amdgpu_families }}" \
+            --windows-amdgpu-families="${{ inputs.windows_amdgpu_families }}"
 
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure_aws_artifacts_credentials

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -219,6 +219,8 @@ jobs:
     with:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
+      linux_amdgpu_families: ${{ fromJSON(inputs.build_config).linux_amdgpu_families }}
+      windows_amdgpu_families: ${{ fromJSON(inputs.build_config).windows_amdgpu_families }}
       multiarch_index: true
       package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -147,6 +147,8 @@ jobs:
     with:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
+      linux_amdgpu_families: ${{ fromJSON(inputs.build_config).linux_amdgpu_families }}
+      windows_amdgpu_families: ${{ fromJSON(inputs.build_config).windows_amdgpu_families }}
       multiarch_index: true
       package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -75,6 +75,8 @@ jobs:
     with:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
+      linux_amdgpu_families: ${{ fromJSON(inputs.build_config).linux_amdgpu_families }}
+      windows_amdgpu_families: ${{ fromJSON(inputs.build_config).windows_amdgpu_families }}
       multiarch_index: true
       package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -69,6 +69,8 @@ jobs:
     with:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
+      linux_amdgpu_families: ${{ fromJSON(inputs.build_config).linux_amdgpu_families }}
+      windows_amdgpu_families: ${{ fromJSON(inputs.build_config).windows_amdgpu_families }}
       multiarch_index: true
       package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -6,6 +6,7 @@
 from typing import Callable, Sequence
 
 import importlib.util
+import io
 import re
 import os
 from pathlib import Path
@@ -315,7 +316,7 @@ class PopulatedDistPackage:
         dist_info_path = package_dest_dir / dist_info_relpath
         log(f"  Writing dist info: {dist_info_path}")
         dist_info_path.parent.mkdir(parents=True, exist_ok=True)
-        dist_info_path.write_text(dist_info_contents)
+        dist_info_path.write_text(dist_info_contents, newline="\n")
 
         return package_dest_dir
 
@@ -796,3 +797,64 @@ def build_packages(
 
         log(f"::: Building python package {child_name}: {shlex.join(build_args)}")
         subprocess.check_call(build_args, cwd=child_path, stderr=subprocess.STDOUT)
+
+        if child_name == "rocm":
+            # setuptools writes PKG-INFO / setup.cfg / egg-info in platform
+            # text mode, which yields CRLF on Windows. Normalize so the
+            # rocm sdist is byte-identical across Linux and Windows builds.
+            sdists = list(effective_dist_dir.glob(f"{child_name}-*.tar.gz"))
+            if not sdists:
+                raise RuntimeError(
+                    f"No {child_name} sdist produced in {effective_dist_dir}"
+                )
+            for sdist in sdists:
+                _normalize_sdist_line_endings(sdist)
+
+
+_TEXT_SUFFIXES = frozenset({".py", ".md", ".toml", ".cfg", ".txt", ".rst", ".in"})
+
+
+def _is_text_member(name: str) -> bool:
+    base = name.rsplit("/", 1)[-1]
+    if base == "PKG-INFO":
+        return True
+    suffix = ("." + base.rsplit(".", 1)[-1].lower()) if "." in base else ""
+    return suffix in _TEXT_SUFFIXES
+
+
+def _normalize_sdist_line_endings(sdist_path: Path) -> None:
+    """Rewrite `sdist_path` in place with LF line endings on text members.
+
+    Preserves the original tar member order and per-file metadata
+    (mtime, mode, uid/gid) so the only delta vs. setuptools' output is
+    the byte content of text files.
+    """
+    with tarfile.open(sdist_path, "r:gz") as src:
+        members = src.getmembers()
+        payloads: dict[str, bytes] = {}
+        for member in members:
+            if not member.isfile():
+                continue
+            fp = src.extractfile(member)
+            if fp is None:
+                raise RuntimeError(
+                    f"Could not extract regular file {member.name} from {sdist_path}"
+                )
+            data = fp.read()
+            if _is_text_member(member.name):
+                data = data.replace(b"\r\n", b"\n")
+            payloads[member.name] = data
+
+    tmp_path = sdist_path.with_suffix(sdist_path.suffix + ".tmp")
+    with tarfile.open(tmp_path, "w:gz") as dst:
+        for member in members:
+            if member.isfile() and member.name in payloads:
+                data = payloads[member.name]
+                member.size = len(data)
+                dst.addfile(member, fileobj=io.BytesIO(data))
+            else:
+                dst.addfile(member)
+    tmp_path.replace(sdist_path)
+
+    if not sdist_path.exists() or sdist_path.stat().st_size == 0:
+        raise RuntimeError(f"Normalized sdist missing or empty: {sdist_path}")

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -75,6 +75,8 @@ class Parameters:
         version_suffix: str,
         artifacts: ArtifactCatalog,
         kpack_split: bool = False,
+        linux_target_families: list[str] | None = None,
+        windows_target_families: list[str] | None = None,
     ):
         self.dest_dir = dest_dir
         self.version = version
@@ -82,10 +84,42 @@ class Parameters:
         self.artifacts = artifacts
         self.kpack_split = kpack_split
         self.all_target_families = artifacts.all_target_families
-        _sorted_families = sorted(self.all_target_families)
-        self.default_target_family: str | None = (
-            _sorted_families[0] if _sorted_families else None
+
+        # Cross-platform family view (#5347). When the multi-arch release
+        # pipeline passes per-platform family lists, the rocm sdist must
+        # advertise the union of both platforms' families and pick a
+        # DEFAULT_TARGET_FAMILY that resolves on either OS so a user
+        # without ROCM_SDK_TARGET_FAMILY / offload-arch lands on a family
+        # that has wheels for their platform — prefer the intersection.
+        # Without these kwargs the on-disk artifact view is used as
+        # before, preserving today's behavior for single-platform builds.
+        self.linux_target_families: list[str] = sorted(set(linux_target_families or []))
+        self.windows_target_families: list[str] = sorted(
+            set(windows_target_families or [])
         )
+        cross_platform_inputs = (
+            linux_target_families is not None or windows_target_families is not None
+        )
+        if cross_platform_inputs:
+            linux_set = set(self.linux_target_families)
+            windows_set = set(self.windows_target_families)
+            self.available_target_families: list[str] = sorted(linux_set | windows_set)
+            intersection = sorted(linux_set & windows_set)
+            if intersection:
+                self.default_target_family: str | None = intersection[0]
+            elif self.available_target_families:
+                self.default_target_family = self.available_target_families[0]
+            else:
+                self.default_target_family = None
+        else:
+            # Snapshot of the set; preserves prior set-iteration order so
+            # the generated _dist_info.py is byte-identical to before for
+            # single-platform builds.
+            self.available_target_families = list(self.all_target_families)
+            _sorted_families = sorted(self.all_target_families)
+            self.default_target_family = (
+                _sorted_families[0] if _sorted_families else None
+            )
         self.populated_packages: list["PopulatedDistPackage"] = []
         self.runtime_artifact_names: set[str] = set()
 
@@ -116,10 +150,14 @@ class Parameters:
             dist_info_contents += (
                 f"DEFAULT_TARGET_FAMILY = '{self.default_target_family}'\n"
             )
-        for target_family in self.all_target_families:
+        for target_family in self.available_target_families:
             dist_info_contents += (
                 f"AVAILABLE_TARGET_FAMILIES.append('{target_family}')\n"
             )
+        for target_family in self.linux_target_families:
+            dist_info_contents += f"LINUX_TARGET_FAMILIES.append('{target_family}')\n"
+        for target_family in self.windows_target_families:
+            dist_info_contents += f"WINDOWS_TARGET_FAMILIES.append('{target_family}')\n"
         self.dist_info_contents = dist_info_contents
 
         # And dynamically load it so that we have access to the same config during

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -86,12 +86,12 @@ class Parameters:
         self.kpack_split = kpack_split
         self.all_target_families = artifacts.all_target_families
 
-        # Cross-platform family view (#5347). When the multi-arch release
-        # pipeline passes per-platform family lists, the rocm sdist must
-        # advertise the union of both platforms' families and pick a
+        # Cross-platform family view. When the multi-arch release pipeline
+        # passes per-platform family lists, the rocm sdist must advertise
+        # the union of both platforms' families and pick a
         # DEFAULT_TARGET_FAMILY that resolves on either OS so a user
         # without ROCM_SDK_TARGET_FAMILY / offload-arch lands on a family
-        # that has wheels for their platform — prefer the intersection.
+        # that has wheels for their platform - prefer the intersection.
         # Without these kwargs the on-disk artifact view is used as
         # before, preserving today's behavior for single-platform builds.
         self.linux_target_families: list[str] = sorted(set(linux_target_families or []))
@@ -801,7 +801,9 @@ def build_packages(
         if child_name == "rocm":
             # setuptools writes PKG-INFO / setup.cfg / egg-info in platform
             # text mode, which yields CRLF on Windows. Normalize so the
-            # rocm sdist is byte-identical across Linux and Windows builds.
+            # rocm sdist's text members are content-identical across Linux
+            # and Windows builds (tar metadata such as mtime may still
+            # differ).
             sdists = list(effective_dist_dir.glob(f"{child_name}-*.tar.gz"))
             if not sdists:
                 raise RuntimeError(

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -84,16 +84,16 @@ def run(args: argparse.Namespace):
     if kpack_split:
         print("::: Detected KPACK_SPLIT_ARTIFACTS — producing host + device wheels")
 
-    # Cross-platform target view for the rocm sdist (#5347). Expand each
-    # platform's family list to the union of its gfx targets so the
+    # Cross-platform target view for the rocm sdist. Expand each platform's
+    # family list to the union of its gfx targets so the
     # AVAILABLE_TARGET_FAMILIES baked into the meta sdist matches what's
     # actually published as rocm-sdk-device-<target> wheels across both
     # platforms' builds.
-    # TODO(#5347): kwarg name `linux_target_families` in Parameters and
-    # the LINUX/WINDOWS_TARGET_FAMILIES constants in _dist_info.py predate
-    # the kpack-split semantics where the values are GPU targets. Rename
-    # to *_amdgpu_targets once the wider `target_family` terminology
-    # cleanup is in scope.
+    # TODO: kwarg name `linux_target_families` in Parameters and the
+    # LINUX/WINDOWS_TARGET_FAMILIES constants in _dist_info.py predate the
+    # kpack-split semantics where the values are GPU targets. Rename to
+    # *_amdgpu_targets once the wider `target_family` terminology cleanup
+    # is in scope.
     family_map = None
     linux_targets: list[str] | None = None
     windows_targets: list[str] | None = None
@@ -504,8 +504,8 @@ def main(argv: list[str]):
             "side of a multi-arch release (e.g. 'gfx94X-dcgpu,gfx110X-all'). "
             "Expanded to GPU targets via cmake/therock_amdgpu_targets.cmake "
             "and recorded in the rocm sdist so its device-gfx* extras "
-            "advertise the cross-platform union (#5347). Absent on "
-            "single-platform builds."
+            "advertise the cross-platform union. Absent on single-platform "
+            "builds."
         ),
     )
     p.add_argument(

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -27,7 +27,23 @@ from pathlib import Path
 import sys
 
 from _therock_utils.artifacts import ArtifactCatalog, ArtifactName
+from _therock_utils.cmake_amdgpu_targets import amdgpu_family_map, expand_families
 from _therock_utils.py_packaging import Parameters, PopulatedDistPackage, build_packages
+
+
+def _amdgpu_families_arg(value: str) -> list[str] | None:
+    """Argparse type for --linux/windows-amdgpu-families CLI flags.
+
+    Accepts both comma and semicolon separators so the same value shape
+    works from a shell prompt and from workflow YAML that passes
+    BuildConfig.dist_amdgpu_families (semicolon-separated) directly.
+
+    Returns None for empty/whitespace-only input so workflow YAML can
+    pass an empty string for "platform not participating" without
+    triggering cross-platform mode in Parameters.
+    """
+    parsed = [f.strip() for f in value.replace(";", ",").split(",") if f.strip()]
+    return parsed or None
 
 
 def load_therock_manifest(artifact_dir: Path) -> dict:
@@ -68,12 +84,35 @@ def run(args: argparse.Namespace):
     if kpack_split:
         print("::: Detected KPACK_SPLIT_ARTIFACTS — producing host + device wheels")
 
+    # Cross-platform target view for the rocm sdist (#5347). Expand each
+    # platform's family list to the union of its gfx targets so the
+    # AVAILABLE_TARGET_FAMILIES baked into the meta sdist matches what's
+    # actually published as rocm-sdk-device-<target> wheels across both
+    # platforms' builds.
+    # TODO(#5347): kwarg name `linux_target_families` in Parameters and
+    # the LINUX/WINDOWS_TARGET_FAMILIES constants in _dist_info.py predate
+    # the kpack-split semantics where the values are GPU targets. Rename
+    # to *_amdgpu_targets once the wider `target_family` terminology
+    # cleanup is in scope.
+    family_map = None
+    linux_targets: list[str] | None = None
+    windows_targets: list[str] | None = None
+    if args.linux_amdgpu_families is not None:
+        family_map = amdgpu_family_map()
+        linux_targets = expand_families(args.linux_amdgpu_families, family_map)
+    if args.windows_amdgpu_families is not None:
+        if family_map is None:
+            family_map = amdgpu_family_map()
+        windows_targets = expand_families(args.windows_amdgpu_families, family_map)
+
     params = Parameters(
         dest_dir=args.dest_dir,
         version=args.version,
         version_suffix=args.version_suffix,
         artifacts=ArtifactCatalog(args.artifact_dir),
         kpack_split=kpack_split,
+        linux_target_families=linux_targets,
+        windows_target_families=windows_targets,
     )
 
     # Populate each target neutral library package.
@@ -455,6 +494,28 @@ def main(argv: list[str]):
         default=True,
         action=argparse.BooleanOptionalAction,
         help="Apply compression when building wheels (disable for faster iteration or prior to recompression activities)",
+    )
+    p.add_argument(
+        "--linux-amdgpu-families",
+        type=_amdgpu_families_arg,
+        default=None,
+        help=(
+            "Comma- or semicolon-separated AMD GPU families for the Linux "
+            "side of a multi-arch release (e.g. 'gfx94X-dcgpu,gfx110X-all'). "
+            "Expanded to GPU targets via cmake/therock_amdgpu_targets.cmake "
+            "and recorded in the rocm sdist so its device-gfx* extras "
+            "advertise the cross-platform union (#5347). Absent on "
+            "single-platform builds."
+        ),
+    )
+    p.add_argument(
+        "--windows-amdgpu-families",
+        type=_amdgpu_families_arg,
+        default=None,
+        help=(
+            "Comma- or semicolon-separated AMD GPU families for the Windows "
+            "side of a multi-arch release. See --linux-amdgpu-families."
+        ),
     )
     args = p.parse_args(argv)
 

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -48,7 +48,7 @@ import enum
 import json
 import os
 import sys
-from dataclasses import asdict, dataclass, field, fields
+from dataclasses import asdict, dataclass, field, fields, replace
 from pathlib import Path
 
 # Add parent directory to path for _therock_utils imports
@@ -434,6 +434,9 @@ class BuildConfig:
     # Prebuilt stage configuration — set by configure() from JobDecisions.
     prebuilt_stages: list[str] = field(default_factory=list)
     baseline_run_id: str = ""
+    # Cross-platform pair, populated identically in linux and windows configs.
+    linux_amdgpu_families: str = ""  # Semicolon-separated
+    windows_amdgpu_families: str = ""  # Semicolon-separated
 
     def to_dict(self) -> dict:
         d = asdict(self)
@@ -991,6 +994,24 @@ def expand_build_configs(
             linux_config = config
         else:
             windows_config = config
+
+    # Stamp the cross-platform pair into both configs so each platform's
+    # build_python_packages step can produce a rocm sdist whose device
+    # extras advertise the union (and are byte-identical across platforms).
+    linux_families = linux_config.dist_amdgpu_families if linux_config else ""
+    windows_families = windows_config.dist_amdgpu_families if windows_config else ""
+    if linux_config is not None:
+        linux_config = replace(
+            linux_config,
+            linux_amdgpu_families=linux_families,
+            windows_amdgpu_families=windows_families,
+        )
+    if windows_config is not None:
+        windows_config = replace(
+            windows_config,
+            linux_amdgpu_families=linux_families,
+            windows_amdgpu_families=windows_families,
+        )
 
     return BuildConfigs(
         linux=linux_config,

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -997,7 +997,7 @@ def expand_build_configs(
 
     # Stamp the cross-platform pair into both configs so each platform's
     # build_python_packages step can produce a rocm sdist whose device
-    # extras advertise the union (and are byte-identical across platforms).
+    # extras advertise the union.
     linux_families = linux_config.dist_amdgpu_families if linux_config else ""
     windows_families = windows_config.dist_amdgpu_families if windows_config else ""
     if linux_config is not None:

--- a/build_tools/packaging/python/templates/rocm/setup.py
+++ b/build_tools/packaging/python/templates/rocm/setup.py
@@ -60,21 +60,13 @@ EXTRAS_REQUIRE = {
     for pkg in dist_info.ALL_PACKAGES.values()
     if not pkg.required
 }
-# For target-specific packages with multiple available targets (e.g. device
-# packages in kpack-split mode), generate per-target extras so users can
-# explicitly request a specific ISA: pip install rocm[device-gfx942]
-# Also generate a device-all extra that installs all available device shards.
-for pkg in dist_info.ALL_PACKAGES.values():
-    if not pkg.is_target_specific or pkg.required:
-        continue
-    if len(dist_info.AVAILABLE_TARGET_FAMILIES) > 1:
-        all_requires = []
-        for tf in sorted(dist_info.AVAILABLE_TARGET_FAMILIES):
-            extra_name = f"{pkg.logical_name}-{tf}"
-            req = pkg.get_dist_package_require(target_family=tf)
-            EXTRAS_REQUIRE[extra_name] = [req]
-            all_requires.append(req)
-        EXTRAS_REQUIRE[f"{pkg.logical_name}-all"] = all_requires
+# Per-target extras for target-specific packages with multiple available
+# targets (e.g. device wheels in kpack-split mode): explicit pip install
+# rocm[device-gfx942] plus a device-all aggregate. Cross-platform multi-arch
+# builds attach PEP 508 sys_platform markers to platform-exclusive targets
+# so `pip install rocm[device-all]` only pulls device wheels published for
+# the user's OS (#5347).
+EXTRAS_REQUIRE.update(dist_info.build_per_target_extras())
 
 # Drop the generic 'device' extra when target resolution would silently fall
 # back to DEFAULT_TARGET_FAMILY - e.g. kpack-split CI installs on GPU-less

--- a/build_tools/packaging/python/templates/rocm/setup.py
+++ b/build_tools/packaging/python/templates/rocm/setup.py
@@ -65,7 +65,7 @@ EXTRAS_REQUIRE = {
 # rocm[device-gfx942] plus a device-all aggregate. Cross-platform multi-arch
 # builds attach PEP 508 sys_platform markers to platform-exclusive targets
 # so `pip install rocm[device-all]` only pulls device wheels published for
-# the user's OS (#5347).
+# the user's OS.
 EXTRAS_REQUIRE.update(dist_info.build_per_target_extras())
 
 # Drop the generic 'device' extra when target resolution would silently fall

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -296,3 +296,63 @@ DEFAULT_TARGET_FAMILY: str = "DEFAULT"
 
 # All available target families that this distribution has available.
 AVAILABLE_TARGET_FAMILIES: list[str] = []
+
+# Per-platform target family lists. Populated by the build system when the
+# rocm sdist is produced from a multi-arch release that knows about both
+# platforms' family sets. Empty when unknown (single-platform builds, or
+# loading this module before the build system has rewritten it). Consumed
+# by setup.py at install time to attach PEP 508 sys_platform markers to
+# device extras for platform-exclusive families.
+LINUX_TARGET_FAMILIES: list[str] = []
+WINDOWS_TARGET_FAMILIES: list[str] = []
+
+
+def get_target_family_platform_marker(target_family: str) -> str:
+    """Returns a PEP 508 sys_platform marker for a target family, or "".
+
+    Used by the rocm setup.py to attach markers to device-gfx* Requires-Dist
+    entries when a family is published only for one platform. Returns "" if
+    either platform list is empty (single-platform build or only one
+    platform participating in a multi-arch release) since there is no
+    cross-platform variant to disambiguate from.
+    """
+    if not LINUX_TARGET_FAMILIES or not WINDOWS_TARGET_FAMILIES:
+        return ""
+    in_linux = target_family in LINUX_TARGET_FAMILIES
+    in_windows = target_family in WINDOWS_TARGET_FAMILIES
+    if in_linux and not in_windows:
+        return 'sys_platform == "linux"'
+    if in_windows and not in_linux:
+        return 'sys_platform == "win32"'
+    return ""
+
+
+def build_per_target_extras() -> "dict[str, list[str]]":
+    """Builds the device-gfx* and device-all entries for EXTRAS_REQUIRE.
+
+    Returns a dict mapping each per-target extra name to its list of
+    Requires-Dist strings. For platform-exclusive targets, attaches a
+    PEP 508 sys_platform marker so `pip install rocm[device-all]` only
+    pulls device wheels published for the user's OS (#5347).
+
+    Returns an empty dict when no target-specific package exists or the
+    distribution covers a single target (legacy single-arch behavior;
+    the generic extras already in setup.py's EXTRAS_REQUIRE suffice).
+    """
+    result: dict[str, list[str]] = {}
+    if len(AVAILABLE_TARGET_FAMILIES) <= 1:
+        return result
+    for pkg in ALL_PACKAGES.values():
+        if not pkg.is_target_specific or pkg.required:
+            continue
+        all_requires: list[str] = []
+        for tf in sorted(AVAILABLE_TARGET_FAMILIES):
+            extra_name = f"{pkg.logical_name}-{tf}"
+            req = pkg.get_dist_package_require(target_family=tf)
+            marker = get_target_family_platform_marker(tf)
+            if marker:
+                req = f"{req}; {marker}"
+            result[extra_name] = [req]
+            all_requires.append(req)
+        result[f"{pkg.logical_name}-all"] = all_requires
+    return result

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -333,7 +333,7 @@ def build_per_target_extras() -> "dict[str, list[str]]":
     Returns a dict mapping each per-target extra name to its list of
     Requires-Dist strings. For platform-exclusive targets, attaches a
     PEP 508 sys_platform marker so `pip install rocm[device-all]` only
-    pulls device wheels published for the user's OS (#5347).
+    pulls device wheels published for the user's OS.
 
     Returns an empty dict when no target-specific package exists or the
     distribution covers a single target (legacy single-arch behavior;

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -740,22 +740,21 @@ class RestrictFamiliesTest(TmpDirTestCase):
 
 
 # ---------------------------------------------------------------------------
-# Tests for cross-platform family awareness in the rocm sdist (#5347)
+# Tests for cross-platform family awareness in the rocm sdist
 # ---------------------------------------------------------------------------
 
 
 class CrossPlatformFamiliesTest(TmpDirTestCase):
     """Tests for linux_target_families / windows_target_families kwargs.
 
-    Covers the fix for ROCm/TheRock#5347: when a multi-arch release pipeline
-    knows the full union of GPU targets across both Linux and Windows
-    builds, the rocm sdist must (a) advertise that union in
-    AVAILABLE_TARGET_FAMILIES, (b) record each platform's contribution
-    separately so setup.py can attach sys_platform markers, (c) pick a
-    DEFAULT_TARGET_FAMILY that resolves on either OS, and (d) be
-    byte-identical across the two platforms' invocations so the
-    last-writer-wins S3 upload of `v4/whl/rocm-X.Y.Z.tar.gz` becomes
-    harmless.
+    When a multi-arch release pipeline knows the full union of GPU targets
+    across both Linux and Windows builds, the rocm sdist must (a) advertise
+    that union in AVAILABLE_TARGET_FAMILIES, (b) record each platform's
+    contribution separately so setup.py can attach sys_platform markers,
+    (c) pick a DEFAULT_TARGET_FAMILY that resolves on either OS, and
+    (d) produce identical dist_info_contents on both platforms so the
+    metadata that drives the published device extras matches regardless
+    of which platform's job uploaded the sdist last.
 
     Note on naming: the kwargs and the AVAILABLE_TARGET_FAMILIES constant
     use the historical "target_family" label, but in kpack-split mode
@@ -901,8 +900,8 @@ class CrossPlatformFamiliesTest(TmpDirTestCase):
         practice; the test puts gfx942 in the Windows list purely to
         construct a disagreement between sort-order and intersection.
         """
-        # Union sorted = [gfx900, gfx942] — alpha-first is gfx900 (Linux-only).
-        # Intersection = [gfx942] — DEFAULT must be gfx942.
+        # Union sorted = [gfx900, gfx942] - alpha-first is gfx900 (Linux-only).
+        # Intersection = [gfx942] - DEFAULT must be gfx942.
         params = self._make_params(
             linux_target_families=["gfx900", "gfx942"],
             windows_target_families=["gfx942"],
@@ -966,11 +965,11 @@ class CrossPlatformFamiliesTest(TmpDirTestCase):
         )
 
     def test_dist_info_identical_across_disjoint_artifact_sets(self):
-        """Core invariant of #5347: same cross-platform inputs produce
-        identical dist_info_contents on both Linux and Windows machines,
-        even when their on-disk artifact catalogs are disjoint. Without
-        this, the last-writer-wins upload of rocm-X.Y.Z.tar.gz silently
-        drops one platform's targets from the published device extras.
+        """Core invariant: same cross-platform inputs produce identical
+        dist_info_contents on both Linux and Windows machines, even when
+        their on-disk artifact catalogs are disjoint. Without this, the
+        last-writer-wins upload of rocm-X.Y.Z.tar.gz silently drops one
+        platform's targets from the published device extras.
         """
         # Linux machine has the full Linux target set on disk.
         linux_params = self._make_params(
@@ -991,7 +990,7 @@ class CrossPlatformFamiliesTest(TmpDirTestCase):
 
 
 # ---------------------------------------------------------------------------
-# Tests for platform marker helper (#5347)
+# Tests for platform marker helper
 # ---------------------------------------------------------------------------
 
 
@@ -1028,8 +1027,8 @@ class PlatformMarkerTest(TmpDirTestCase):
     def test_markers_in_mixed_platform_config(self):
         """In a realistic multi-arch config with Linux-only, cross-platform,
         and Windows-only targets, each category gets the right marker.
-        Mirrors the production case behind ROCm/TheRock#5347 where Linux
-        and Windows ship overlapping but unequal target sets.
+        Mirrors the production case where Linux and Windows ship
+        overlapping but unequal target sets.
         """
         dist_info = self._make_dist_info(
             linux_target_families=["gfx942", "gfx1100"],
@@ -1081,7 +1080,7 @@ class PlatformMarkerTest(TmpDirTestCase):
 
 
 # ---------------------------------------------------------------------------
-# Tests for per-target device extras builder (#5347)
+# Tests for per-target device extras builder
 # ---------------------------------------------------------------------------
 
 
@@ -1095,10 +1094,10 @@ class PerTargetExtrasTest(TmpDirTestCase):
     only to wheels actually published for the user's OS.
 
     All tests run with kpack_split=True to mirror the multi-arch release
-    pipeline (the only mode that exhibits #5347). In legacy mode the
-    libraries package is also target-specific and the helper would
-    additionally emit libraries-{target} extras; that path is not
-    exercised here.
+    pipeline (the only mode that exhibits the cross-platform divergence).
+    In legacy mode the libraries package is also target-specific and the
+    helper would additionally emit libraries-{target} extras; that path
+    is not exercised here.
     """
 
     def _make_dist_info(

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -739,5 +739,492 @@ class RestrictFamiliesTest(TmpDirTestCase):
         self.assertNotIn("gfx94X-dcgpu", content)
 
 
+# ---------------------------------------------------------------------------
+# Tests for cross-platform family awareness in the rocm sdist (#5347)
+# ---------------------------------------------------------------------------
+
+
+class CrossPlatformFamiliesTest(TmpDirTestCase):
+    """Tests for linux_target_families / windows_target_families kwargs.
+
+    Covers the fix for ROCm/TheRock#5347: when a multi-arch release pipeline
+    knows the full union of GPU targets across both Linux and Windows
+    builds, the rocm sdist must (a) advertise that union in
+    AVAILABLE_TARGET_FAMILIES, (b) record each platform's contribution
+    separately so setup.py can attach sys_platform markers, (c) pick a
+    DEFAULT_TARGET_FAMILY that resolves on either OS, and (d) be
+    byte-identical across the two platforms' invocations so the
+    last-writer-wins S3 upload of `v4/whl/rocm-X.Y.Z.tar.gz` becomes
+    harmless.
+
+    Note on naming: the kwargs and the AVAILABLE_TARGET_FAMILIES constant
+    use the historical "target_family" label, but in kpack-split mode
+    (the only mode that exhibits this bug) the values are GPU **targets**
+    like gfx942 / gfx1100, matching the device wheel suffixes the
+    artifact catalog produces and the `rocm-sdk-device-*` package names
+    published to the index. Tests use realistic target names accordingly.
+
+    The on-disk artifact catalog is irrelevant under these kwargs; tests
+    use an empty artifact tree except where the on-disk view is itself
+    under test (backward compat + identity-across-disjoint-artifacts).
+    """
+
+    def _add_minimal_artifact(self, artifact_dir: Path, target_family: str):
+        subdir = artifact_dir / f"base_lib_{target_family}"
+        (subdir / "stage").mkdir(parents=True, exist_ok=True)
+        (subdir / "artifact_manifest.txt").write_text("stage\n")
+
+    def _make_params(
+        self,
+        *,
+        on_disk_families: list[str] | None = None,
+        linux_target_families: list[str] | None = None,
+        windows_target_families: list[str] | None = None,
+    ) -> Parameters:
+        artifact_dir = self.temp_dir / "artifacts"
+        artifact_dir.mkdir(exist_ok=True)
+        for tf in on_disk_families or []:
+            self._add_minimal_artifact(artifact_dir, tf)
+        dest_dir = self.temp_dir / "packages"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        return Parameters(
+            dest_dir=dest_dir,
+            version="0.0.1.test",
+            version_suffix="",
+            artifacts=ArtifactCatalog(artifact_dir),
+            linux_target_families=linux_target_families,
+            windows_target_families=windows_target_families,
+        )
+
+    def _exec_dist_info(self, params: Parameters) -> dict:
+        ns: dict = {}
+        exec(params.dist_info_contents, ns)
+        return ns
+
+    # ----- Backward compat: no kwargs => on-disk artifact view ------------
+
+    def test_no_kwargs_uses_on_disk_artifact_view(self):
+        """Without the new kwargs, available_target_families reflects the
+        artifact catalog. Single-platform builds keep their existing
+        behavior unchanged.
+        """
+        params = self._make_params(on_disk_families=["gfx942", "gfx1100"])
+        self.assertEqual(
+            sorted(params.available_target_families),
+            ["gfx1100", "gfx942"],
+        )
+        self.assertEqual(params.linux_target_families, [])
+        self.assertEqual(params.windows_target_families, [])
+
+    def test_dist_info_omits_per_platform_appends_when_kwargs_omitted(self):
+        """No LINUX/WINDOWS_TARGET_FAMILIES.append() lines emitted when
+        neither kwarg is passed, so the generated _dist_info.py for
+        single-platform builds is byte-equivalent to today's.
+        """
+        params = self._make_params(on_disk_families=["gfx942"])
+        ns = self._exec_dist_info(params)
+        # Predeclared constants must load as empty lists.
+        self.assertEqual(ns["LINUX_TARGET_FAMILIES"], [])
+        self.assertEqual(ns["WINDOWS_TARGET_FAMILIES"], [])
+        self.assertNotIn("LINUX_TARGET_FAMILIES.append", params.dist_info_contents)
+        self.assertNotIn("WINDOWS_TARGET_FAMILIES.append", params.dist_info_contents)
+
+    # ----- Union semantics ------------------------------------------------
+
+    def test_available_target_families_is_sorted_union(self):
+        """available_target_families is the sorted union of linux + windows."""
+        params = self._make_params(
+            linux_target_families=["gfx942", "gfx950", "gfx1100"],
+            windows_target_families=["gfx1100", "gfx1102"],
+        )
+        self.assertEqual(
+            params.available_target_families,
+            ["gfx1100", "gfx1102", "gfx942", "gfx950"],
+        )
+
+    def test_kwargs_override_on_disk_view(self):
+        """When kwargs are passed, available_target_families ignores the
+        on-disk artifact list. The kwargs are the source of truth.
+        """
+        params = self._make_params(
+            on_disk_families=["gfx942"],
+            linux_target_families=["gfx1100"],
+            windows_target_families=["gfx1100"],
+        )
+        self.assertEqual(params.available_target_families, ["gfx1100"])
+
+    def test_per_platform_lists_sorted_and_deduped(self):
+        """Each platform's list is sorted and deduped on Parameters."""
+        params = self._make_params(
+            linux_target_families=["gfx950", "gfx942", "gfx942"],
+            windows_target_families=["gfx1100"],
+        )
+        self.assertEqual(params.linux_target_families, ["gfx942", "gfx950"])
+        self.assertEqual(params.windows_target_families, ["gfx1100"])
+
+    def test_only_linux_provided_union_equals_linux(self):
+        """When only linux is provided, union equals linux and windows is empty."""
+        params = self._make_params(
+            linux_target_families=["gfx942", "gfx950"],
+        )
+        self.assertEqual(params.available_target_families, ["gfx942", "gfx950"])
+        self.assertEqual(params.linux_target_families, ["gfx942", "gfx950"])
+        self.assertEqual(params.windows_target_families, [])
+
+    # ----- default_target_family must be cross-platform-safe --------------
+    # determine_target_family() in _dist_info.py falls back to
+    # DEFAULT_TARGET_FAMILY when neither ROCM_SDK_TARGET_FAMILY nor
+    # offload-arch resolves. setup.py then plugs that target into every
+    # target-specific extras Requires-Dist. If DEFAULT is Linux-only, a
+    # Windows user without env var or offload-arch fails to resolve
+    # `rocm-sdk-libraries-{DEFAULT}` because no win_amd64 wheel exists
+    # for that target. Hence: prefer the intersection.
+
+    def test_default_target_family_prefers_intersection(self):
+        """DEFAULT must come from the linux ∩ windows intersection when
+        non-empty, so a user without env var / offload-arch gets a target
+        that has wheels for their OS.
+        """
+        params = self._make_params(
+            linux_target_families=["gfx942", "gfx1100", "gfx950"],
+            windows_target_families=["gfx1100", "gfx1102"],
+        )
+        # Intersection = {gfx1100}; that must be the DEFAULT.
+        self.assertEqual(params.default_target_family, "gfx1100")
+
+    def test_default_target_family_avoids_linux_only_alpha_first(self):
+        """Discriminating case: alphabetical-first of the union is a
+        Linux-only target but the intersection points elsewhere. The
+        intersection must win, not the alphabetical-first.
+
+        Configuration is artificial: gfx900 / gfx942 are Linux-only in
+        practice; the test puts gfx942 in the Windows list purely to
+        construct a disagreement between sort-order and intersection.
+        """
+        # Union sorted = [gfx900, gfx942] — alpha-first is gfx900 (Linux-only).
+        # Intersection = [gfx942] — DEFAULT must be gfx942.
+        params = self._make_params(
+            linux_target_families=["gfx900", "gfx942"],
+            windows_target_families=["gfx942"],
+        )
+        self.assertEqual(params.default_target_family, "gfx942")
+
+    def test_default_target_family_intersection_is_sorted(self):
+        """When the intersection has multiple targets, DEFAULT is the
+        sorted-first of the intersection (deterministic).
+        """
+        params = self._make_params(
+            linux_target_families=["gfx942", "gfx1100", "gfx1200"],
+            windows_target_families=["gfx1200", "gfx1100"],
+        )
+        # Intersection sorted = [gfx1100, gfx1200] => gfx1100.
+        self.assertEqual(params.default_target_family, "gfx1100")
+
+    def test_default_target_family_falls_back_to_union_when_disjoint(self):
+        """When linux and windows lists are disjoint (no cross-platform
+        target possible), DEFAULT falls back to sorted-first-of-union as
+        a best-effort. Users on the "wrong" OS for that DEFAULT will need
+        ROCM_SDK_TARGET_FAMILY or offload-arch.
+        """
+        params = self._make_params(
+            linux_target_families=["gfx942"],
+            windows_target_families=["gfx1100"],
+        )
+        # No intersection => sorted-union[0] = gfx1100.
+        self.assertEqual(params.default_target_family, "gfx1100")
+
+    def test_default_target_family_from_only_linux(self):
+        """Only linux provided: DEFAULT is first of sorted linux list."""
+        params = self._make_params(
+            linux_target_families=["gfx950", "gfx942"],
+        )
+        self.assertEqual(params.default_target_family, "gfx942")
+
+    def test_default_target_family_from_only_windows(self):
+        """Only windows provided: DEFAULT is first of sorted windows list."""
+        params = self._make_params(
+            windows_target_families=["gfx1200", "gfx1100"],
+        )
+        self.assertEqual(params.default_target_family, "gfx1100")
+
+    # ----- Generated _dist_info.py shape ----------------------------------
+
+    def test_dist_info_exposes_per_platform_constants(self):
+        """LINUX_TARGET_FAMILIES / WINDOWS_TARGET_FAMILIES baked into
+        _dist_info.py so setup.py can inspect them at install time.
+        """
+        params = self._make_params(
+            linux_target_families=["gfx942", "gfx950"],
+            windows_target_families=["gfx1100"],
+        )
+        ns = self._exec_dist_info(params)
+        self.assertEqual(sorted(ns["LINUX_TARGET_FAMILIES"]), ["gfx942", "gfx950"])
+        self.assertEqual(ns["WINDOWS_TARGET_FAMILIES"], ["gfx1100"])
+        self.assertEqual(
+            sorted(ns["AVAILABLE_TARGET_FAMILIES"]),
+            ["gfx1100", "gfx942", "gfx950"],
+        )
+
+    def test_dist_info_identical_across_disjoint_artifact_sets(self):
+        """Core invariant of #5347: same cross-platform inputs produce
+        identical dist_info_contents on both Linux and Windows machines,
+        even when their on-disk artifact catalogs are disjoint. Without
+        this, the last-writer-wins upload of rocm-X.Y.Z.tar.gz silently
+        drops one platform's targets from the published device extras.
+        """
+        # Linux machine has the full Linux target set on disk.
+        linux_params = self._make_params(
+            on_disk_families=["gfx942", "gfx950", "gfx1100"],
+            linux_target_families=["gfx942", "gfx950", "gfx1100"],
+            windows_target_families=["gfx1100"],
+        )
+        # Windows machine only has Windows-supported targets on disk.
+        windows_params = self._make_params(
+            on_disk_families=["gfx1100"],
+            linux_target_families=["gfx942", "gfx950", "gfx1100"],
+            windows_target_families=["gfx1100"],
+        )
+        self.assertEqual(
+            linux_params.dist_info_contents,
+            windows_params.dist_info_contents,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests for platform marker helper (#5347)
+# ---------------------------------------------------------------------------
+
+
+class PlatformMarkerTest(TmpDirTestCase):
+    """Tests for get_target_family_platform_marker() in _dist_info.py.
+
+    Called by the rocm setup.py at install time to decide whether a
+    device-gfx* Requires-Dist needs a PEP 508 sys_platform marker.
+    Returns the marker string for platform-exclusive families, "" for
+    cross-platform families or when the per-platform breakdown is
+    unknown (single-platform builds).
+    """
+
+    def _make_dist_info(
+        self,
+        *,
+        linux_target_families: list[str] | None,
+        windows_target_families: list[str] | None,
+    ):
+        artifact_dir = self.temp_dir / "artifacts"
+        artifact_dir.mkdir(exist_ok=True)
+        dest_dir = self.temp_dir / "packages"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        params = Parameters(
+            dest_dir=dest_dir,
+            version="0.0.1.test",
+            version_suffix="",
+            artifacts=ArtifactCatalog(artifact_dir),
+            linux_target_families=linux_target_families,
+            windows_target_families=windows_target_families,
+        )
+        return params.dist_info
+
+    def test_markers_in_mixed_platform_config(self):
+        """In a realistic multi-arch config with Linux-only, cross-platform,
+        and Windows-only targets, each category gets the right marker.
+        Mirrors the production case behind ROCm/TheRock#5347 where Linux
+        and Windows ship overlapping but unequal target sets.
+        """
+        dist_info = self._make_dist_info(
+            linux_target_families=["gfx942", "gfx1100"],
+            windows_target_families=["gfx1100", "gfx1102"],
+        )
+        # Linux-only target gets a linux marker.
+        self.assertEqual(
+            dist_info.get_target_family_platform_marker("gfx942"),
+            'sys_platform == "linux"',
+        )
+        # Windows-only target gets a win32 marker.
+        self.assertEqual(
+            dist_info.get_target_family_platform_marker("gfx1102"),
+            'sys_platform == "win32"',
+        )
+        # Cross-platform target has no marker.
+        self.assertEqual(dist_info.get_target_family_platform_marker("gfx1100"), "")
+
+    def test_no_marker_when_per_platform_lists_unknown(self):
+        """Single-platform builds don't pass the new kwargs; no markers
+        are added, so existing (non-multi-arch) sdists are unchanged.
+        """
+        dist_info = self._make_dist_info(
+            linux_target_families=None, windows_target_families=None
+        )
+        self.assertEqual(dist_info.get_target_family_platform_marker("gfx942"), "")
+        self.assertEqual(dist_info.get_target_family_platform_marker("gfx1100"), "")
+
+    def test_no_marker_when_only_one_platform_participates(self):
+        """When only one platform's families are declared (the other side
+        is skipped in a multi-arch run, or a Linux-only build flows through
+        the cross-platform kwargs), markers are not attached: there is no
+        cross-platform variant to disambiguate from.
+        """
+        # Linux declared, Windows not.
+        dist_info = self._make_dist_info(
+            linux_target_families=["gfx942", "gfx1100"],
+            windows_target_families=None,
+        )
+        self.assertEqual(dist_info.get_target_family_platform_marker("gfx942"), "")
+        self.assertEqual(dist_info.get_target_family_platform_marker("gfx1100"), "")
+        # Windows declared, Linux not.
+        dist_info = self._make_dist_info(
+            linux_target_families=None,
+            windows_target_families=["gfx1100", "gfx1102"],
+        )
+        self.assertEqual(dist_info.get_target_family_platform_marker("gfx1100"), "")
+        self.assertEqual(dist_info.get_target_family_platform_marker("gfx1102"), "")
+
+
+# ---------------------------------------------------------------------------
+# Tests for per-target device extras builder (#5347)
+# ---------------------------------------------------------------------------
+
+
+class PerTargetExtrasTest(TmpDirTestCase):
+    """Tests for build_per_target_extras() in _dist_info.py.
+
+    The helper produces the device-gfx* and device-all entries for the
+    rocm meta sdist's EXTRAS_REQUIRE. Cross-platform-aware: targets
+    listed only in LINUX_TARGET_FAMILIES or only in WINDOWS_TARGET_FAMILIES
+    get a sys_platform marker so `pip install rocm[device-all]` resolves
+    only to wheels actually published for the user's OS.
+
+    All tests run with kpack_split=True to mirror the multi-arch release
+    pipeline (the only mode that exhibits #5347). In legacy mode the
+    libraries package is also target-specific and the helper would
+    additionally emit libraries-{target} extras; that path is not
+    exercised here.
+    """
+
+    def _make_dist_info(
+        self,
+        *,
+        linux_target_families: list[str] | None,
+        windows_target_families: list[str] | None,
+    ):
+        artifact_dir = self.temp_dir / "artifacts"
+        artifact_dir.mkdir(exist_ok=True)
+        dest_dir = self.temp_dir / "packages"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        params = Parameters(
+            dest_dir=dest_dir,
+            version="0.0.1.test",
+            version_suffix="",
+            artifacts=ArtifactCatalog(artifact_dir),
+            kpack_split=True,
+            linux_target_families=linux_target_families,
+            windows_target_families=windows_target_families,
+        )
+        return params.dist_info
+
+    def test_empty_when_single_target(self):
+        """No per-target extras for distributions with one target (legacy)."""
+        dist_info = self._make_dist_info(
+            linux_target_families=["gfx942"],
+            windows_target_families=["gfx942"],
+        )
+        self.assertEqual(dist_info.build_per_target_extras(), {})
+
+    def test_extras_emitted_for_mixed_platform_config(self):
+        """In a realistic multi-arch config, the helper emits one
+        device-{target} entry per available target, plus a device-all
+        aggregating them. Linux-only and Windows-only targets carry
+        sys_platform markers; cross-platform targets do not.
+        """
+        dist_info = self._make_dist_info(
+            linux_target_families=["gfx942", "gfx1100"],
+            windows_target_families=["gfx1100", "gfx1102"],
+        )
+        extras = dist_info.build_per_target_extras()
+
+        # One entry per target plus the aggregate.
+        self.assertEqual(
+            sorted(extras.keys()),
+            sorted(
+                [
+                    "device-gfx1100",
+                    "device-gfx1102",
+                    "device-gfx942",
+                    "device-all",
+                ]
+            ),
+        )
+
+        # Linux-only target carries the linux marker.
+        self.assertTrue(
+            extras["device-gfx942"][0].endswith('; sys_platform == "linux"'),
+            f"Expected linux marker on Linux-only target, got: "
+            f"{extras['device-gfx942'][0]}",
+        )
+        # Windows-only target carries the win32 marker.
+        self.assertTrue(
+            extras["device-gfx1102"][0].endswith('; sys_platform == "win32"'),
+            f"Expected win32 marker on Windows-only target, got: "
+            f"{extras['device-gfx1102'][0]}",
+        )
+        # Cross-platform target has no marker.
+        self.assertNotIn(";", extras["device-gfx1100"][0])
+        self.assertNotIn("sys_platform", extras["device-gfx1100"][0])
+
+        # device-all aggregates every per-target requirement verbatim.
+        self.assertEqual(
+            sorted(extras["device-all"]),
+            sorted(
+                extras["device-gfx942"]
+                + extras["device-gfx1100"]
+                + extras["device-gfx1102"]
+            ),
+        )
+
+    def test_no_markers_when_per_platform_lists_unknown(self):
+        """Without per-platform kwargs (single-platform builds), no markers
+        attach so existing single-platform sdists stay unchanged.
+        """
+        # Populate two targets via the artifact catalog so the helper
+        # actually emits per-target extras.
+        artifact_dir = self.temp_dir / "artifacts"
+        for t in ("gfx942", "gfx1100"):
+            subdir = artifact_dir / f"base_lib_{t}"
+            (subdir / "stage").mkdir(parents=True, exist_ok=True)
+            (subdir / "artifact_manifest.txt").write_text("stage\n")
+        dest_dir = self.temp_dir / "packages"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        params = Parameters(
+            dest_dir=dest_dir,
+            version="0.0.1.test",
+            version_suffix="",
+            artifacts=ArtifactCatalog(artifact_dir),
+            kpack_split=True,
+        )
+        extras = params.dist_info.build_per_target_extras()
+        for extra_name, requires in extras.items():
+            for req in requires:
+                self.assertNotIn(
+                    "sys_platform",
+                    req,
+                    f"Single-platform build leaked a marker into {extra_name}: {req}",
+                )
+
+    def test_requires_dist_pins_version_and_uses_target_in_name(self):
+        """Requires-Dist strings start with 'rocm-sdk-device-{target}==<ver>',
+        matching the canonical PackageEntry.get_dist_package_require() shape.
+        """
+        dist_info = self._make_dist_info(
+            linux_target_families=["gfx942", "gfx1100"],
+            windows_target_families=["gfx1100"],
+        )
+        extras = dist_info.build_per_target_extras()
+        req = extras["device-gfx942"][0]
+        self.assertTrue(
+            req.startswith("rocm-sdk-device-gfx942==0.0.1.test"),
+            f"Unexpected Requires-Dist shape: {req}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

The `rocm` meta sdist is generated independently by the Linux and Windows multi-arch release jobs and uploaded to the same location. Each job only knew its own platform's GPU families, so the published sdist silently dropped whichever platform's device extras lost the last-writer-wins race.

End users hit `pip install rocm[device-all]` missing families (for example gfx942/gfx950 absent on Linux after a Windows upload) or warnings like "does not provide the extra 'device-gfx950'". The bug surfaced any time the per-platform family lists diverged, which is the normal configuration since Windows does not support data-center GPUs.

Even with the metadata fix, the two tarballs still diverged byte-for-byte. The Windows runner's git checkout uses `core.autocrlf=true` by default, so template files arrive CRLF and flow into the sdist via `shutil.copytree`. setuptools also writes generated `PKG-INFO`, `setup.cfg`, and `egg-info/PKG-INFO` in platform text mode, which means CRLF on Windows. The s3 last-writer-wins upload might looked like a real content swap on every multi-arch release.

## Technical Details

Pass the cross-platform family pair into both platforms' python package builds so they produce a content-identical `rocm` sdist whose device-gfx* extras cover the union of both platforms' GPU targets. Platform-exclusive targets carry PEP 508 `sys_platform` markers so `pip install rocm[device-all]` resolves only to wheels actually published for the current OS. The `DEFAULT_TARGET_FAMILY` now prefers the cross-platform intersection so a user without `ROCM_SDK_TARGET_ FAMILY` or offload-arch resolves to a family that has wheels on their OS.

Neutralize the CRLF leak without altering repo-wide git checkout behavior: `Path.write_text` on the regenerated `_dist_info.py` now passes `newline="\n"` and the build pipeline rewrites the freshly-built `rocm-*.tar.gz` in place, normalizing CRLF->LF on text members (`PKG-INFO`, `*.py`, `*.toml`, `*.cfg`, `*.md`, `*.txt`, `*.rst`, `*.in`) while preserving the original tar member order, mtimes, modes, and owner metadata.

## Test Plan

- `pytest build_tools/tests/py_packaging_test.py`
- `pytest build_tools/github_actions/tests/configure_multi_arch_ci_test.py`
- Local end-to-end: built two `rocm` sdists with the same cross- platform kwargs but disjoint on-disk artifact sets (mimicking the Linux and Windows builds), confirmed PKG-INFO content is identical and device extras carry the expected sys_platform markers.
- Pulled both CI-built `rocm-*.tar.gz` artifacts from a multi-arch release run, ran a parity verifier script.

## Test Result

Unit tests pass; local end-to-end inspection confirms identical-content sdists across simulated Linux/Windows builds. Content-equality for CI-built artifacts verified after the normalization pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.