### PR TITLE
Fix typo in RELEASES.md

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,7 +16,7 @@ AMD GPU architecture.
 >
 > Prerequisites:
 >
-> - We recommend installing the latest [AMDGPU driver](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html#amdgpu-driver-installation) on Linux and [Adrenaline driver](https://www.amd.com/en/products/software/adrenalin.html) on Windows
+> - We recommend installing the latest [AMDGPU driver](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html#amdgpu-driver-installation) on Linux and [Adrenalin driver](https://www.amd.com/en/products/software/adrenalin.html) on Windows
 > - Linux users, please be aware of [Configuring permissions for GPU access](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/prerequisites.html#configuring-permissions-for-gpu-access) needed for ROCm
 
 Table of contents:
@@ -1161,7 +1161,7 @@ If your GPU is not recognized or you encounter issues:
 - Review memory allocation settings (see the [FAQ](https://github.com/ROCm/TheRock/blob/main/faq.md)
   for GTT configuration on unified memory systems)
 - Ensure you have the latest [AMDGPU driver](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html#amdgpu-driver-installation)
-  on Linux or [Adrenaline driver](https://www.amd.com/en/products/software/adrenalin.html) on Windows
+  on Linux or [Adrenalin driver](https://www.amd.com/en/products/software/adrenalin.html) on Windows
 - For platform-specific troubleshooting when using PyTorch or JAX, see:
   - [Using ROCm Python packages](#using-rocm-python-packages)
   - [Using PyTorch Python packages](#using-pytorch-python-packages)


### PR DESCRIPTION
I believe the official name is "Adrenalin" without the trailing "e": https://www.amd.com/en/products/software/adrenalin.html.

This PR fixes the typo in the documentation ("Adrenaline" -> "Adrenalin").