### PR TITLE
Revert /Z7 flags to reduce amd-llvm dev package size

### DIFF
--- a/cmake/therock_compiler_config.cmake
+++ b/cmake/therock_compiler_config.cmake
@@ -7,7 +7,7 @@
 # This improves compatibility with ccache and sccache:
 # https://github.com/ccache/ccache/issues/1040
 if(WIN32 AND NOT DEFINED CMAKE_MSVC_DEBUG_INFORMATION_FORMAT)
-  set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded")
+  set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
 endif()
 
 if(WIN32 AND NOT MSVC AND NOT THEROCK_DISABLE_MSVC_CHECK)


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/5341.

The always on /Z7 flag makes the dev package size increase significantly due to llvm libs containing debug symbols. Disable it for now.

Cache rate is expected to decrease before these PRs are merged:
* host-blas: https://github.com/ROCm/TheRock/pull/5370
* CLR: https://github.com/ROCm/rocm-systems/pull/6239

## Technical Details

Revert back to only using /Z7 for RelWitDebInfo / Debug.

## Test Plan

Build passes with reduced package size

## Test Result

Build passes with reduced package size

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
