### PR TITLE
Include rccl in device wheel artifact filter

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -408,6 +408,7 @@ def device_artifact_filter(target: str, an: ArtifactName) -> bool:
             "miopenprovider",
             "hipblasltprovider",
             "rand",
+            "rccl",
         ]
         and an.component == "lib"
         and an.target_family == target

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -550,6 +550,12 @@ class DevicePackagingTest(TmpDirTestCase):
         an_gfx942 = ArtifactName("blas", "lib", "gfx942")
         self.assertTrue(device_artifact_filter("gfx942", an_gfx942))
 
+        # rccl is built TARGET_NEUTRAL but BUILD_TOPOLOGY marks it
+        # target-specific so kpack splits produce per-arch rccl_lib_<arch>
+        # artifacts that must land in the device wheel.
+        an_rccl = ArtifactName("rccl", "lib", "gfx942")
+        self.assertTrue(device_artifact_filter("gfx942", an_rccl))
+
         # Should NOT match generic.
         an_generic = ArtifactName("blas", "lib", "generic")
         self.assertFalse(device_artifact_filter("gfx942", an_generic))


### PR DESCRIPTION
As rccl was moved to an "always a generic (non-per-ISA) artifact", it was removed from the device_artifact_filter. This assumption holds true for the CMake build (target neutral) but `artifacts.rccl` in `BUILD_TOPOLOGY.toml` stays `target-specific`. The latter drives kpack splitting. This readds rccl to the device_artifact_filter so per-arch rccl_lib_<arch> artifacts land in the rocm-sdk-device-wheel.

Further adds a positive assertion for ("rccl", "lib", "gfx942") to test_device_artifact_filter so a future removal regresses CI rather than silently dropping kpacks from the wheel again.