### PR TITLE
Adding kfdtest to The Rock CI.

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -151,6 +151,7 @@ artifact_groups = [
     "hip-runtime",
     "opencl-runtime",
     "profiler-core",
+    "kfdtest",
     "rocjitsu"
 ]
 
@@ -268,6 +269,12 @@ source_sets = ["rocm-systems"]  # clr is in rocm-systems
 description = "Runtime tests (hip-tests, rocrtst)"
 type = "generic"
 artifact_group_deps = ["hip-runtime", "opencl-runtime", "core-runtime"]
+source_sets = ["rocm-systems"]
+
+[artifact_groups.kfdtest]
+description = "KFD kernel driver tests"
+type = "generic"
+artifact_group_deps = ["core-runtime"]
 source_sets = ["rocm-systems"]
 
 [artifact_groups.math-libs]
@@ -563,6 +570,14 @@ artifact_group = "runtime-tests"
 type = "target-neutral"
 artifact_deps = ["core-runtime", "core-ocl", "core-amdsmi", "sysdeps-hwloc"]
 feature_name = "CORE_RUNTIME_TESTS"
+feature_group = "CORE"
+disable_platforms = ["windows"]
+
+[artifacts.kfdtest]
+artifact_group = "kfdtest"
+type = "target-neutral"
+artifact_deps = ["core-runtime", "amd-llvm", "sysdeps"]
+feature_name = "CORE_KFDTESTS"
 feature_group = "CORE"
 disable_platforms = ["windows"]
 

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -43,6 +43,7 @@ python build_tools/install_rocm_from_artifacts.py
     [--rocprofiler-systems-examples | --no-rocprofiler-systems-examples]
     [--rocrtst | --no-rocrtst]
     [--rocalution | --no-rocalution]
+    [--kfdtest | --no-kfdtest]
     [--rocwmma | --no-rocwmma]
     [--libhipcxx | --no-libhipcxx]
     [--tests | --no-tests]
@@ -386,6 +387,7 @@ def retrieve_artifacts_by_run_id(args):
             args.rocprofiler_systems_examples,
             args.rocrtst,
             args.rocalution,
+            args.kfdtest,
             args.rocwmma,
             args.libhipcxx,
         ]
@@ -497,6 +499,11 @@ def retrieve_artifacts_by_run_id(args):
         if args.rocalution:
             extra_artifacts.append("rocalution")
             argv.append("rocalution_dev")
+        if args.kfdtest:
+            extra_artifacts.append("kfdtest")
+            # kfdtest depends on llvm-dev
+            argv.append("amd-llvm_dev")
+            argv.append("amd-llvm_lib")
         if args.rocwmma:
             extra_artifacts.append("rocwmma")
             argv.append("rocwmma_dev")
@@ -867,6 +874,13 @@ def main(argv):
         "--rocalution",
         default=False,
         help="Include 'rocalution' artifacts",
+        action=argparse.BooleanOptionalAction,
+    )
+
+    artifacts_group.add_argument(
+        "--kfdtest",
+        default=False,
+        help="Include 'kfdtest' artifacts",
         action=argparse.BooleanOptionalAction,
     )
 

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -404,6 +404,17 @@
             ]
           }
         ]
+      },
+      {
+        "Artifact": "kfdtest",
+        "Artifact_Subdir": [
+          {
+            "Name": "kfdtest",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
       }
     ],
     "Gfxarch": "False",

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -632,3 +632,63 @@ if(THEROCK_BUILD_TESTING AND THEROCK_ENABLE_CORE_RUNTIME_TESTS)
       rocrtst
   )
 endif(THEROCK_BUILD_TESTING AND THEROCK_ENABLE_CORE_RUNTIME_TESTS)
+
+if(THEROCK_BUILD_TESTING AND THEROCK_ENABLE_CORE_KFDTESTS)
+
+    # kfdtest statically links libhsakmt and LLVM (AMDGPUAsmParser, Core, Support).
+    # It needs LLVM headers at build time and libhsakmt.a for linking.
+    set(_kfdtest_build_deps
+      amd-llvm
+      ROCR-Runtime
+      therock-yaml-cpp
+    )
+
+    # Get the ROCR-Runtime binary directory to locate libhsakmt
+    get_target_property(_rocr_binary_dir ROCR-Runtime THEROCK_BINARY_DIR)
+
+    therock_cmake_subproject_declare(kfdtest
+      USE_TEST_AMDGPU_TARGETS
+      EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime/libhsakmt/tests/kfdtest"
+      BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/kfdtest"
+      BACKGROUND_BUILD
+      CMAKE_ARGS
+        "-DCMAKE_PREFIX_PATH="
+        "-DLLVM_DIR="
+        "-DROCM_DIR="
+        "-DLIBHSAKMT_PATH=${_rocr_binary_dir}/libhsakmt"
+        "-DCMAKE_EXE_LINKER_FLAGS=-ldl"
+        "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
+      COMPILER_TOOLCHAIN
+        "${_system_toolchain}"
+      BUILD_DEPS
+        ${_kfdtest_build_deps}
+      RUNTIME_DEPS
+        amd-llvm
+        ${THEROCK_BUNDLED_LIBDRM}
+        ${THEROCK_BUNDLED_NUMACTL}
+        ${THEROCK_BUNDLED_ZLIB}
+        ${THEROCK_BUNDLED_ZSTD}
+      INTERFACE_LINK_DIRS
+        "lib"
+        "lib/rocm_sysdeps/lib"
+      INTERFACE_INSTALL_RPATH_DIRS
+        "lib"
+        "lib/rocm_sysdeps/lib"
+    )
+    therock_cmake_subproject_glob_c_sources(kfdtest SUBDIRS .)
+    therock_cmake_subproject_activate(kfdtest)
+
+    therock_provide_artifact(kfdtest
+      TARGET_NEUTRAL
+      DESCRIPTOR artifact-core-kfdtest.toml
+      COMPONENTS
+        dbg
+        dev
+        doc
+        lib
+        run
+        test
+      SUBPROJECT_DEPS
+        kfdtest
+    )
+endif(THEROCK_BUILD_TESTING AND THEROCK_ENABLE_CORE_KFDTESTS)

--- a/core/artifact-core-kfdtest.toml
+++ b/core/artifact-core-kfdtest.toml
@@ -1,0 +1,10 @@
+# kfdtest
+[components.run."core/kfdtest/stage"]
+exclude = [
+  "bin/**",
+  "share/kfdtest/**",
+]
+[components.dbg."core/kfdtest/stage"]
+[components.dev."core/kfdtest/stage"]
+[components.doc."core/kfdtest/stage"]
+[components.test."core/kfdtest/stage"]


### PR DESCRIPTION
Add kfdtest to TheRock CI
    
    - Add kfdtest subproject with correct dependencies (statically links libhsakmt and LLVM)
    - Use run_kfdtest.sh script which handles platform-specific test exclusions
    - Add --kfdtest flag to install_rocm_from_artifacts.py
    - Add kfdtest to BUILD_TOPOLOGY.toml (artifact group, build stage, and artifact)
    - Add sysdeps to kfdtest artifact dependencies for bundled libraries
    - Use get_target_property to dynamically locate ROCR-Runtime binary directory
    - Set RPATH to lib/rocm_sysdeps/lib only (kfdtest statically links main deps)
    - Support both standard and quick test modes via TEST_TYPE environment variable


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
