### PR TITLE
Keep WSL ROCDXG venv outside /tmp and skip fork uploads

### DIFF
--- a/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+++ b/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
@@ -234,12 +234,13 @@ jobs:
           ls -lh "${THEROCK_HOST_BUILD_DIR}"/artifacts/*.tar.xz 2>/dev/null || echo "No artifacts found"
 
       - name: Configure AWS credentials for artifact uploads
-        if: ${{ always() }}
+        if: ${{ always() && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
         uses: ./.github/actions/configure_aws_artifacts_credentials
         with:
           release_type: ${{ inputs.release_type }}
 
       - name: Push stage artifacts
+        if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
         shell: wsl-bash {0}
         env:
           WSLENV: THEROCK_HOST_WORKSPACE/p:THEROCK_HOST_BUILD_DIR/p:GITHUB_REPOSITORY:GITHUB_EVENT_NAME:GITHUB_EVENT_PATH/p:RELEASE_TYPE:AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN:AWS_DEFAULT_REGION:AWS_REGION
@@ -253,7 +254,7 @@ jobs:
             --build-dir="${THEROCK_HOST_BUILD_DIR}"
 
       - name: Upload stage logs
-        if: ${{ always() }}
+        if: ${{ always() && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
         run: |
           python build_tools/github_actions/post_stage_upload.py \
             --run-id=${{ github.run_id }} \

--- a/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+++ b/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
@@ -144,9 +144,10 @@ jobs:
         run: |
           # setup-wsl's default wsl-bash wrapper runs `bash --noprofile --norc -euo pipefail`.
           # Explicitly bridged path vars from the Windows host are available in wsl-bash via
-          # WSLENV. Keep WSL-local state such as the venv itself under /tmp.
-          wsl_venv_dir="/tmp/therock-wsl-rocdxg/.venv"
-          python3 "${THEROCK_HOST_WORKSPACE}/build_tools/setup_venv.py" "${wsl_venv_dir}"
+          # WSLENV. Keep this path WSL-local.
+          wsl_work_dir="${HOME}/therock-wsl-rocdxg"
+          wsl_venv_dir="${wsl_work_dir}/.venv"
+          python3 "${THEROCK_HOST_WORKSPACE}/build_tools/setup_venv.py" --clean "${wsl_venv_dir}"
           "${wsl_venv_dir}/bin/python" -m pip install -r "${THEROCK_HOST_WORKSPACE}/requirements.txt"
 
       - name: Get stage configuration
@@ -165,7 +166,7 @@ jobs:
         if: ${{ steps.stage_config.outputs.pip_install_cmd }}
         shell: wsl-bash {0}
         run: |
-          wsl_venv_dir="/tmp/therock-wsl-rocdxg/.venv"
+          wsl_venv_dir="${HOME}/therock-wsl-rocdxg/.venv"
           "${wsl_venv_dir}/bin/python" -m pip install ${{ steps.stage_config.outputs.pip_install_cmd }}
 
       - name: Prepare WSL paths
@@ -181,17 +182,18 @@ jobs:
             exit 1
           fi
           mkdir -p "${THEROCK_HOST_BUILD_DIR}"
+          wsl_work_dir="${HOME}/therock-wsl-rocdxg"
           # Route the mounted SDK path through a stable symlink without spaces or
           # parentheses because nested subproject configure invocations are
           # shell-escaped and /bin/sh will misparse the raw "(x86)" segment.
-          win_sdk="/tmp/therock-wsl-rocdxg/windows-sdk-shared"
+          win_sdk="${wsl_work_dir}/windows-sdk-shared"
           ln -sfn "${THEROCK_WIN_SDK_SHARED}" "$win_sdk"
 
       - name: Fetch inbound artifacts
         shell: wsl-bash {0}
         run: |
           stage_name="${{ inputs.stage_name }}"
-          wsl_venv_dir="/tmp/therock-wsl-rocdxg/.venv"
+          wsl_venv_dir="${HOME}/therock-wsl-rocdxg/.venv"
           mkdir -p "${THEROCK_HOST_BUILD_DIR}"
           "${wsl_venv_dir}/bin/python" "${THEROCK_HOST_WORKSPACE}/build_tools/artifact_manager.py" fetch \
             --run-id="${{ github.run_id }}" \
@@ -204,8 +206,9 @@ jobs:
       - name: Configure
         shell: wsl-bash {0}
         run: |
-          wsl_venv_dir="/tmp/therock-wsl-rocdxg/.venv"
-          win_sdk="/tmp/therock-wsl-rocdxg/windows-sdk-shared"
+          wsl_work_dir="${HOME}/therock-wsl-rocdxg"
+          wsl_venv_dir="${wsl_work_dir}/.venv"
+          win_sdk="${wsl_work_dir}/windows-sdk-shared"
           source "${wsl_venv_dir}/bin/activate"
           cd "$THEROCK_HOST_WORKSPACE"
           cmake -B "${THEROCK_HOST_BUILD_DIR}" -S . -G Ninja \
@@ -220,7 +223,7 @@ jobs:
         shell: wsl-bash {0}
         run: |
           stage_name="${{ inputs.stage_name }}"
-          wsl_venv_dir="/tmp/therock-wsl-rocdxg/.venv"
+          wsl_venv_dir="${HOME}/therock-wsl-rocdxg/.venv"
           source "${wsl_venv_dir}/bin/activate"
           cmake --build "${THEROCK_HOST_BUILD_DIR}" --target "stage-${stage_name}" -- -k 0
 
@@ -242,7 +245,7 @@ jobs:
           WSLENV: THEROCK_HOST_WORKSPACE/p:THEROCK_HOST_BUILD_DIR/p:GITHUB_REPOSITORY:GITHUB_EVENT_NAME:GITHUB_EVENT_PATH/p:RELEASE_TYPE:AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN:AWS_DEFAULT_REGION:AWS_REGION
         run: |
           stage_name="${{ inputs.stage_name }}"
-          wsl_venv_dir="/tmp/therock-wsl-rocdxg/.venv"
+          wsl_venv_dir="${HOME}/therock-wsl-rocdxg/.venv"
           "${wsl_venv_dir}/bin/python" "${THEROCK_HOST_WORKSPACE}/build_tools/artifact_manager.py" push --run-id ${{ github.run_id }} \
             --run-github-repo="${{ github.repository }}" \
             --platform linux \


### PR DESCRIPTION
## Summary

- Moves the WSL ROCDXG workflow venv and Windows SDK symlink state from `/tmp/therock-wsl-rocdxg` to `${HOME}/therock-wsl-rocdxg`.
- Recreates the WSL venv with `setup_venv.py --clean` at job start.
- Keeps WSL ROCDXG build validation running for fork PRs, but skips S3 artifact/log uploads for fork PRs.

## Motivation

The ASAN WSL ROCDXG job created and used `/tmp/therock-wsl-rocdxg/.venv` during earlier steps, but artifact upload later failed because `/tmp/therock-wsl-rocdxg/.venv/bin/python` was no longer present.

Fork PR WSL jobs also lack the Linux runner baseline credentials used for `therock-ci-artifacts-external`, so upload steps fail after the build succeeds. The existing Linux credential path is documented in `docs/development/s3_buckets.md`: Linux containers mount runner credentials at `/home/awsconfig/credentials.ini` and set `AWS_SHARED_CREDENTIALS_FILE`.

## Testing

- `pre-commit run --files .github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml`
- `git diff --check`