### PR TITLE
[ci] Re-enable KPACK for ASAN

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -47,7 +47,6 @@
         "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O2 -g1",
         "CMAKE_CXX_FLAGS": "-g1",
         "CMAKE_C_FLAGS": "-g1",
-        "THEROCK_FLAG_KPACK_SPLIT_ARTIFACTS": "OFF",
         "THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS": "ON"
       }
     },


### PR DESCRIPTION
After https://github.com/ROCm/TheRock/commit/8f2ca6e9586bd785d0e824242a4ba5598e6ef7b9 has landed, KPACK now works for Multi Arch CI ASAN, with test running here https://github.com/ROCm/TheRock/actions/runs/26178511910/job/77020694871

Adding ci:skip label as tests ran

Closes #4680 