### PR TITLE
Fix fetch_sources when patch directory is empty

### DIFF
--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -640,9 +640,11 @@ def remove_smrev_files(args, projects):
 def apply_patches(args, projects):
     if not args.patch_tag:
         log("Not patching (no --patch-tag specified)")
+        return
     patch_version_dir: Path = PATCHES_DIR / args.patch_tag
     if not patch_version_dir.exists():
-        log(f"ERROR: Patch directory {patch_version_dir} does not exist")
+        log(f"No patch directory {patch_version_dir} exists. Skipping patches.")
+        return
     for patch_project_dir in patch_version_dir.iterdir():
         log(f"* Processing project patch directory {patch_project_dir}:")
         # Check that project patch directory was included


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/5391

If there are no patches in the patch directory, then `fetch_sources.py` should treat that as no patches to apply instead of failing while trying to iterate over a missing directory.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

`fetch_sources.py` now returns early when no patch tag is configured, or when the patch folder doesn't exist
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Verify `fetch_sources.py` works locally.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
 
It works
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
