### PR TITLE
Add multi-arch GPU family support to rocm_runtime.Dockerfile

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -124,6 +124,17 @@ The installation method is selected via the `INSTALL_METHOD` build argument:
 - `packages`: Configures the AMD package repository and installs ROCm via
   apt/dnf/tdnf/zypper.
 
+By default each image targets a single GPU family (e.g.,
+`AMDGPU_FAMILY=gfx110X-all`). To build one image that supports all GPU
+families, set `AMDGPU_FAMILY=multi-arch` (works with both `INSTALL_METHOD`
+options):
+
+- With `INSTALL_METHOD=packages`: pulls the all-GPU meta-package from AMD's
+  `packages-multi-arch/` repository.
+- With `INSTALL_METHOD=tarball`: downloads AMD's bundled `multiarch`
+  tarball from the `tarball-multi-arch/` path (contains per-family `.kpack/`
+  files for every supported GPU target).
+
 Supporting scripts:
 
 - [`install_rocm_deps.sh`](install_rocm_deps.sh): Auto-detects the distribution
@@ -144,6 +155,10 @@ Supporting scripts:
   # Example: Install ROCm 7.13.0a20260322 for gfx110x (nightly)
   curl -sSL https://raw.githubusercontent.com/ROCm/TheRock/main/dockerfiles/install_rocm_packages.sh | \
     sudo bash -s -- 7.13.0a20260322 gfx110x nightlies
+
+  # Example: Install ROCm 7.13.0a20260322 with multi-arch (all GPU families)
+  curl -sSL https://raw.githubusercontent.com/ROCm/TheRock/main/dockerfiles/install_rocm_packages.sh | \
+    sudo bash -s -- 7.13.0a20260322 multi-arch nightlies
   ```
 
 - [`install_rocm_tarball.sh`](install_rocm_tarball.sh): Downloads ROCm tarball

--- a/dockerfiles/install_rocm_packages.sh
+++ b/dockerfiles/install_rocm_packages.sh
@@ -13,6 +13,9 @@
 # Arguments:
 #   VERSION          - Full version string (e.g., 7.13.0a20260322, 7.11.0)
 #   AMDGPU_FAMILY    - AMD GPU family (e.g., gfx110x, gfx94x, gfx110X-all)
+#                      Special value: 'multi-arch' installs the meta-package from
+#                      AMD's packages-multi-arch repository, which supports all
+#                      GPU families in a single image.
 #   RELEASE_TYPE     - Release type: nightlies (default), prereleases, stable
 #
 # Examples:
@@ -20,6 +23,7 @@
 #   ./install_rocm_packages.sh 7.13.0a20260322 gfx110x nightlies
 #   ./install_rocm_packages.sh 7.12.0 gfx94x prereleases
 #   ./install_rocm_packages.sh 7.11.0 gfx110x stable
+#   ./install_rocm_packages.sh 7.13.0a20260322 multi-arch nightlies   # multi-arch
 
 set -euo pipefail
 
@@ -27,6 +31,14 @@ set -euo pipefail
 VERSION="${1:?Error: VERSION is required}"
 AMDGPU_FAMILY="${2:?Error: AMDGPU_FAMILY is required}"
 RELEASE_TYPE="${3:-nightlies}"
+
+# Multi-arch mode: AMDGPU_FAMILY=multi-arch picks the meta-package that supports
+# all GPU families, sourced from AMD's packages-multi-arch repositories.
+if [ "$AMDGPU_FAMILY" = "multi-arch" ]; then
+    MULTI_ARCH=1
+else
+    MULTI_ARCH=0
+fi
 
 # ---------------------------------------------------------------------------
 # Helper: extract MAJOR.MINOR from VERSION (e.g., 7.13.0a20260322 → 7.13)
@@ -121,6 +133,7 @@ map_distro_to_repo() {
 resolve_nightly_build_dir() {
     local date_str="$1"
     local repo_type="$2"  # deb or rpm
+    local multi_arch="${3:-0}"
 
     if [ -z "$date_str" ]; then
         echo "Error: Cannot extract date from VERSION '$VERSION' for nightly builds" >&2
@@ -129,6 +142,7 @@ resolve_nightly_build_dir() {
     fi
 
     local listing_url="https://rocm.nightlies.amd.com/${repo_type}/"
+    [ "$multi_arch" = "1" ] && listing_url="https://rocm.nightlies.amd.com/packages-multi-arch/${repo_type}/"
     echo "Searching for nightly build directory matching date ${date_str}..." >&2
 
     local build_dir
@@ -148,33 +162,43 @@ resolve_nightly_build_dir() {
 
 # ---------------------------------------------------------------------------
 # Helper: build the repo base URL
+#
+# Multi-arch repos live under a 'packages-multi-arch/' path segment that:
+#   - PREFIXES the deb/rpm dir for nightlies (single-family has no such prefix)
+#   - REPLACES the 'packages/' segment for prereleases and stable
 # ---------------------------------------------------------------------------
 build_repo_url() {
     local release_type="$1"
     local pkg_type="$2"
     local repo_distro="$3"
     local nightly_build_dir="$4"
+    local multi_arch="${5:-0}"
+
+    local pkg_segment="packages"
+    [ "$multi_arch" = "1" ] && pkg_segment="packages-multi-arch"
 
     case "$release_type" in
         nightlies)
+            local nightly_root="https://rocm.nightlies.amd.com"
+            [ "$multi_arch" = "1" ] && nightly_root="${nightly_root}/${pkg_segment}"
             if [ "$pkg_type" = "deb" ]; then
-                echo "https://rocm.nightlies.amd.com/deb/${nightly_build_dir}"
+                echo "${nightly_root}/deb/${nightly_build_dir}"
             else
-                echo "https://rocm.nightlies.amd.com/rpm/${nightly_build_dir}/x86_64"
+                echo "${nightly_root}/rpm/${nightly_build_dir}/x86_64"
             fi
             ;;
         prereleases)
             if [ "$pkg_type" = "deb" ]; then
-                echo "https://rocm.prereleases.amd.com/packages/${repo_distro}"
+                echo "https://rocm.prereleases.amd.com/${pkg_segment}/${repo_distro}"
             else
-                echo "https://rocm.prereleases.amd.com/packages/${repo_distro}/x86_64"
+                echo "https://rocm.prereleases.amd.com/${pkg_segment}/${repo_distro}/x86_64"
             fi
             ;;
         stable)
             if [ "$pkg_type" = "deb" ]; then
-                echo "https://repo.amd.com/rocm/packages/${repo_distro}"
+                echo "https://repo.amd.com/rocm/${pkg_segment}/${repo_distro}"
             else
-                echo "https://repo.amd.com/rocm/packages/${repo_distro}/x86_64"
+                echo "https://repo.amd.com/rocm/${pkg_segment}/${repo_distro}/x86_64"
             fi
             ;;
         *)
@@ -187,9 +211,15 @@ build_repo_url() {
 
 # ---------------------------------------------------------------------------
 # Helper: get GPG key URL for signed repos
+#
+# The same AMD signing key is used for both `packages/` and
+# `packages-multi-arch/` repositories, so the key URL is always sourced from
+# `packages/gpg/` regardless of install mode. (The mirror file under
+# `packages-multi-arch/gpg/` currently returns 403 on direct GET.)
 # ---------------------------------------------------------------------------
 get_gpg_key_url() {
     local release_type="$1"
+
     case "$release_type" in
         prereleases)
             echo "https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg"
@@ -329,8 +359,13 @@ REPOEOF
 # ===========================================================================
 
 MAJOR_MINOR=$(extract_major_minor "$VERSION")
-GPU_TARGET=$(normalize_gpu_target "$AMDGPU_FAMILY")
-META_PACKAGE="amdrocm${MAJOR_MINOR}-${GPU_TARGET}"
+if [ "$MULTI_ARCH" = "1" ]; then
+    GPU_TARGET="multi-arch"
+    META_PACKAGE="amdrocm${MAJOR_MINOR}"
+else
+    GPU_TARGET=$(normalize_gpu_target "$AMDGPU_FAMILY")
+    META_PACKAGE="amdrocm${MAJOR_MINOR}-${GPU_TARGET}"
+fi
 
 echo "=============================================="
 echo "ROCm Package Installation"
@@ -341,6 +376,7 @@ echo "AMDGPU Family:   ${AMDGPU_FAMILY}"
 echo "GPU Target:      ${GPU_TARGET}"
 echo "Meta Package:    ${META_PACKAGE}"
 echo "Release Type:    ${RELEASE_TYPE}"
+echo "Install Mode:    $([ "$MULTI_ARCH" = "1" ] && echo "multi-arch" || echo "single-family")"
 echo "=============================================="
 
 # Detect distribution
@@ -357,11 +393,11 @@ echo "=============================================="
 NIGHTLY_BUILD_DIR=""
 if [ "$RELEASE_TYPE" = "nightlies" ]; then
     DATE_STR=$(extract_date_from_version "$VERSION")
-    NIGHTLY_BUILD_DIR=$(resolve_nightly_build_dir "$DATE_STR" "$PKG_TYPE")
+    NIGHTLY_BUILD_DIR=$(resolve_nightly_build_dir "$DATE_STR" "$PKG_TYPE" "$MULTI_ARCH")
 fi
 
 # Build repo URL
-REPO_URL=$(build_repo_url "$RELEASE_TYPE" "$PKG_TYPE" "$REPO_DISTRO" "$NIGHTLY_BUILD_DIR")
+REPO_URL=$(build_repo_url "$RELEASE_TYPE" "$PKG_TYPE" "$REPO_DISTRO" "$NIGHTLY_BUILD_DIR" "$MULTI_ARCH")
 GPG_KEY_URL=$(get_gpg_key_url "$RELEASE_TYPE")
 
 echo "Repo URL:        ${REPO_URL}"

--- a/dockerfiles/install_rocm_tarball.sh
+++ b/dockerfiles/install_rocm_tarball.sh
@@ -12,7 +12,10 @@
 #
 # Arguments:
 #   VERSION          - Full version string (e.g., 7.11.0a20251211, 7.10.0)
-#   AMDGPU_FAMILY    - AMD GPU family (e.g., gfx110X-all, gfx94X-dcgpu)
+#   AMDGPU_FAMILY    - AMD GPU family (e.g., gfx110X-all, gfx94X-dcgpu).
+#                      Special value: 'multi-arch' downloads AMD's bundled
+#                      tarball that contains kpack files for all GPU families
+#                      (from the tarball-multi-arch/ path).
 #   RELEASE_TYPE     - Release type: nightlies (default), prereleases, devreleases, stable
 #
 # Examples:
@@ -20,6 +23,7 @@
 #   ./install_rocm_tarball.sh 7.11.0a20251211 gfx94X-dcgpu nightlies
 #   ./install_rocm_tarball.sh 7.10.0rc2 gfx110X-all prereleases
 #   ./install_rocm_tarball.sh 7.10.0 gfx94X-dcgpu stable
+#   ./install_rocm_tarball.sh 7.13.0a20260515 multi-arch nightlies   # multi-arch
 
 set -eu
 
@@ -31,13 +35,25 @@ RELEASE_TYPE="${3:-nightlies}"
 # URL-encode '+' as '%2B' in VERSION (required for devreleases)
 VERSION_ENCODED="${VERSION//+/%2B}"
 
-# Build tarball URL based on release type
-# - stable releases use: https://repo.amd.com/rocm/tarball/
-# - other releases use: https://rocm.{RELEASE_TYPE}.amd.com/tarball/
-if [ "$RELEASE_TYPE" = "stable" ]; then
-    TARBALL_URL="https://repo.amd.com/rocm/tarball/therock-dist-linux-${AMDGPU_FAMILY}-${VERSION_ENCODED}.tar.gz"
+# AMDGPU_FAMILY=multi-arch selects AMD's bundled all-GPU tarball at the
+# tarball-multi-arch/ path. AMD's URL path uses "multi-arch" (with hyphen)
+# but the tarball filename slot uses "multiarch" (no hyphen) — handle both
+# conventions explicitly here.
+if [ "$AMDGPU_FAMILY" = "multi-arch" ]; then
+    TARBALL_DIR="tarball-multi-arch"
+    FAMILY_SLOT="multiarch"
 else
-    TARBALL_URL="https://rocm.${RELEASE_TYPE}.amd.com/tarball/therock-dist-linux-${AMDGPU_FAMILY}-${VERSION_ENCODED}.tar.gz"
+    TARBALL_DIR="tarball"
+    FAMILY_SLOT="$AMDGPU_FAMILY"
+fi
+
+# Build tarball URL based on release type
+# - stable releases use: https://repo.amd.com/rocm/${TARBALL_DIR}/
+# - other releases use: https://rocm.{RELEASE_TYPE}.amd.com/${TARBALL_DIR}/
+if [ "$RELEASE_TYPE" = "stable" ]; then
+    TARBALL_URL="https://repo.amd.com/rocm/${TARBALL_DIR}/therock-dist-linux-${FAMILY_SLOT}-${VERSION_ENCODED}.tar.gz"
+else
+    TARBALL_URL="https://rocm.${RELEASE_TYPE}.amd.com/${TARBALL_DIR}/therock-dist-linux-${FAMILY_SLOT}-${VERSION_ENCODED}.tar.gz"
 fi
 
 echo "=============================================="
@@ -58,16 +74,16 @@ echo "Downloading tarball..."
 if ! curl -fsSL -o "$TARBALL_FILE" "$TARBALL_URL" 2>/dev/null; then
     echo "Direct URL not found, searching for matching tarball..."
     if [ "$RELEASE_TYPE" = "stable" ]; then
-        LISTING_URL="https://repo.amd.com/rocm/tarball/"
+        LISTING_URL="https://repo.amd.com/rocm/${TARBALL_DIR}/"
     else
-        LISTING_URL="https://rocm.${RELEASE_TYPE}.amd.com/tarball/"
+        LISTING_URL="https://rocm.${RELEASE_TYPE}.amd.com/${TARBALL_DIR}/"
     fi
-    # Case-insensitive search for tarball matching AMDGPU_FAMILY and VERSION.
+    # Case-insensitive search for tarball matching FAMILY_SLOT and VERSION.
     # The HTML listing contains literal '+' (not URL-encoded), so use VERSION
     # with '+' escaped as '\+' for PCRE rather than VERSION_ENCODED.
     VERSION_REGEX="${VERSION//+/\\+}"
     MATCHED_FILE=$(curl -fsSL "$LISTING_URL" 2>/dev/null \
-        | grep -ioP "therock-dist-linux-[^\"]*${AMDGPU_FAMILY}[^\"]*-${VERSION_REGEX}\.tar\.gz" \
+        | grep -ioP "therock-dist-linux-[^\"]*${FAMILY_SLOT}[^\"]*-${VERSION_REGEX}\.tar\.gz" \
         | head -1) || true
     if [ -z "$MATCHED_FILE" ]; then
         echo "Error: No tarball found matching '${AMDGPU_FAMILY}' and version '${VERSION}'"

--- a/dockerfiles/rocm_runtime.Dockerfile
+++ b/dockerfiles/rocm_runtime.Dockerfile
@@ -38,7 +38,10 @@
 # Build arguments
 # - BASE_IMAGE       : Base Docker image (default: ubuntu:24.04)
 # - VERSION          : Full version string (e.g., 7.11.0a20251211, 7.10.0)
-# - AMDGPU_FAMILY    : AMD GPU family (e.g., gfx110X-all, gfx94X-dcgpu)
+# - AMDGPU_FAMILY    : AMD GPU family (e.g., gfx110X-all, gfx94X-dcgpu).
+#                      Use 'multi-arch' to install AMD's all-GPU artifact in
+#                      a single image (works with both INSTALL_METHOD=packages
+#                      and INSTALL_METHOD=tarball).
 # - RELEASE_TYPE     : Release type (default: nightlies). Options: prereleases, devreleases, stable
 #                      Note: devreleases is only supported with INSTALL_METHOD=tarball.
 # - INSTALL_METHOD   : Installation method (default: tarball). Options: tarball, packages
@@ -147,6 +150,26 @@
 #     --build-arg INSTALL_METHOD=packages \
 #     -f dockerfiles/rocm_runtime.Dockerfile \
 #     -t rocm-nightly-pkg:rhel9.7-gfx94x-7.13.0a20260322 \
+#     dockerfiles/
+#
+#   # Ubuntu 24.04 + all GPU families via multi-arch packages (nightly)
+#   docker build \
+#     --build-arg BASE_IMAGE=ubuntu:24.04 \
+#     --build-arg VERSION=7.13.0a20260322 \
+#     --build-arg AMDGPU_FAMILY=multi-arch \
+#     --build-arg INSTALL_METHOD=packages \
+#     -f dockerfiles/rocm_runtime.Dockerfile \
+#     -t rocm-nightly-pkg:ubuntu24.04-multi-arch-7.13.0a20260322 \
+#     dockerfiles/
+#
+#   # Ubuntu 24.04 + all GPU families via multi-arch tarball (nightly)
+#   docker build \
+#     --build-arg BASE_IMAGE=ubuntu:24.04 \
+#     --build-arg VERSION=7.13.0a20260515 \
+#     --build-arg AMDGPU_FAMILY=multi-arch \
+#     --build-arg INSTALL_METHOD=tarball \
+#     -f dockerfiles/rocm_runtime.Dockerfile \
+#     -t rocm-nightly-tar:ubuntu24.04-multi-arch-7.13.0a20260515 \
 #     dockerfiles/
 #
 # Run example:


### PR DESCRIPTION
## Motivation

Extend `rocm_runtime.Dockerfile` to support building a single image that includes ROCm support for **all GPU families** in one go, complementing the existing per-family workflow. Users can now pass `AMDGPU_FAMILY=multi-arch` with either install method:

- `INSTALL_METHOD=packages`: pulls AMD's multi-arch meta-package (`amdrocm{MAJOR.MINOR}`) from the [`packages-multi-arch/`](https://repo.amd.com/rocm/packages-multi-arch/) repository.
- `INSTALL_METHOD=tarball`: downloads AMD's bundled tarball (`therock-dist-linux-multiarch-{VERSION}.tar.gz`) from the [`tarball-multi-arch/`](https://repo.amd.com/rocm/tarball-multi-arch/) path.

This matches the multi-arch distribution channels AMD already publishes for nightlies, prereleases, and stable releases. Existing per-family invocations (`AMDGPU_FAMILY=gfx110X-all`, etc.) are fully backward-compatible — multi-arch is opt-in via the reserved value.

Issue: https://github.com/ROCm/TheRock/issues/2425

## Technical Details

This PR builds on #2572, #4067, and #4398.

**Reserved `AMDGPU_FAMILY=multi-arch` value** activates the multi-arch code paths in both installer scripts. Single magic value chosen to match AMD's URL-path naming (`packages-multi-arch/`, `tarball-multi-arch/`, `whl-multi-arch/`) for cross-channel discoverability. No new build args introduced.

**Enhanced [`install_rocm_packages.sh`](dockerfiles/install_rocm_packages.sh):**
- New `MULTI_ARCH` flag derived from `AMDGPU_FAMILY=multi-arch`.
- `build_repo_url()` switches the path segment to `packages-multi-arch/` for all three release types (nightlies, prereleases, stable).
- `resolve_nightly_build_dir()` lists from the matching multi-arch path for nightlies.
- Existing per-family path (`amdrocm{MAJOR_MINOR}-{GPU_TARGET}`) is unchanged.

**Enhanced [`install_rocm_tarball.sh`](dockerfiles/install_rocm_tarball.sh):**
- `AMDGPU_FAMILY=multi-arch` switches the URL path segment to `tarball-multi-arch/` and the filename family slot to `multiarch` (handles AMD's URL-vs-filename hyphen difference: path is `tarball-multi-arch/`, filename is `multiarch-{ver}.tar.gz`).
- Existing per-family fuzzy-match fallback continues to work for non-multi-arch invocations.

**Other changes:**
- [`rocm_runtime.Dockerfile`](dockerfiles/rocm_runtime.Dockerfile): Updated `AMDGPU_FAMILY` build-arg documentation; added two multi-arch build examples (packages + tarball).
- [`README.md`](dockerfiles/README.md): Documented `AMDGPU_FAMILY=multi-arch` semantics for both install methods + one-liner example.

## Test Plan

Full test matrix: 8 distros × 3 release types × multiple install methods on the May 15/19, 2026 nightly + 7.13.0 prereleases/stable.

- packages × multi-arch × {nightlies, prereleases, stable} × 8 distros = 24 builds (**new code path**)
- packages × single-family × {nightlies, prereleases, stable} × 8 distros = 24 builds (regression vs #4398)
- tarball × multi-arch × {nightlies, prereleases, stable} × 8 distros = 24 builds (**new code path**)
- tarball × single-family × nightlies × 8 distros = 8 builds (regression smoke)

Total: **80 builds across nightlies/prereleases/stable**.

Each build verified with `hipcc --version`. Every multi-arch build additionally verified to have **16 per-family kernel files** under `/opt/rocm/lib/rocblas/library/Kernels.so-*.hsaco` — confirming the multi-arch artifact pulled in support for the full GPU set rather than a single family.

## Test Result

**Multi-arch matrix (48 builds, 24 packages + 24 tarball):**

| Distro | packages × multi-arch |||| tarball × multi-arch ||||
|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
| | nightly | pre | stable | kernels | nightly | pre | stable | kernels |
| Ubuntu 24.04 | PASS | PASS | PASS | 16 | PASS | PASS | PASS | 16 |
| AlmaLinux 8 | PASS | PASS | PASS | 16 | PASS | PASS | PASS | 16 |
| Azure Linux 3 | PASS | PASS | PASS | 16 | PASS | PASS | PASS | 16 |
| RHEL 8.10 | PASS | PASS | PASS | 16 | PASS | PASS | PASS | 16 |
| RHEL 9.7 | PASS | PASS | PASS | 16 | PASS | PASS | PASS | 16 |
| RHEL 10.1 | PASS | PASS | PASS | 16 | PASS | PASS | PASS | 16 |
| SLES 15.7 | PASS | PASS | PASS | 16 | PASS | PASS | PASS | 16 |
| SLES 16.0 | PASS | PASS | PASS | 16 | PASS | PASS | PASS | 16 |

HIP versions detected:
- nightlies (multi-arch): `HIP version: 7.13.0-0000000`
- prereleases + stable (multi-arch): `HIP version: 7.13.99004-3309c611`

**Single-family regression (32 builds):**

| Configuration | Result |
|---|---|
| packages + single-family + nightlies (7.13.0a20260515, gfx110X-all) | 8/8 PASS |
| packages + single-family + prereleases (7.13.0, gfx110X-all) | 8/8 PASS |
| packages + single-family + stable (7.13.0, gfx110X-all) | 8/8 PASS |
| tarball + single-family + nightlies (7.13.0a20260515, gfx110X-all) | 8/8 PASS |

**80/80 PASSED**

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
