### PR TITLE
[rocprim] change incorrect rocthrust -> rocprim in resource spec executable path

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocprim.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprim.py
@@ -125,7 +125,7 @@ env_vars["LD_LIBRARY_PATH"] = (
 
 is_windows = platform.system() == "Windows"
 exe_name = "generate_resource_spec.exe" if is_windows else "generate_resource_spec"
-exe_dir = rocm_base / "bin" / "rocthrust"
+exe_dir = rocm_base / "bin" / "rocprim"
 
 resource_spec_file = "resources.json"
 res_gen_cmd = [


### PR DESCRIPTION
## Motivation

The rocprim tests were looking in the rocthrust directory for the resource spec executable.

## Technical Details

Change incorrect rocthrust -> rocprim in resource spec executable path in test_rocprim.py.

## Test Plan

Verify the rocprim unit tests are running.

## Test Result

rocprim unit tests should run instead of silently failing.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
