### PR TITLE
Add GitHub API 'resolve_git_ref' and 'fetch_file_contents' helpers

### DIFF
--- a/build_tools/github_actions/github_actions_api.py
+++ b/build_tools/github_actions/github_actions_api.py
@@ -435,6 +435,9 @@ def gha_query_workflow_run_by_id(github_repository: str, workflow_run_id: str) -
     return gha_send_request(url)
 
 
+# TODO: Consider accepting a git ref (branch/tag) here and resolving it
+# to a SHA via gha_resolve_git_ref, so callers don't need to do that
+# themselves. Same for other functions that take a commit SHA.
 def gha_query_workflow_runs_for_commit(
     github_repository: str,
     workflow_file_name: str,
@@ -529,6 +532,53 @@ def gha_query_recent_branch_commits(
     response = gha_send_request(url)
 
     return [commit["sha"] for commit in response]
+
+
+def gha_resolve_git_ref(github_repository: str, ref: str) -> str:
+    """Resolve a git ref (branch, tag, or SHA) to a full commit SHA.
+
+    Args:
+        github_repository: Repository in "owner/repo" format (e.g. "ROCm/pytorch").
+        ref: Git ref to resolve (branch name, tag, or commit SHA).
+
+    Returns:
+        The full 40-character commit SHA.
+
+    Raises:
+        GitHubAPIError: If the ref cannot be resolved.
+
+    See: https://docs.github.com/en/rest/commits/commits#get-a-commit
+    """
+    url = f"https://api.github.com/repos/{github_repository}/commits/{ref}"
+    response = gha_send_request(url)
+    return response["sha"]
+
+
+def gha_fetch_file_contents(github_repository: str, path: str, ref: str) -> str:
+    """Fetch a file's contents from a GitHub repo at a specific ref.
+
+    Uses the Contents API to retrieve and decode a single file. The file
+    must be small enough for the Contents API (< 1 MB); for larger files
+    use the Blobs API instead.
+
+    Args:
+        github_repository: Repository in "owner/repo" format (e.g. "ROCm/pytorch").
+        path: File path within the repo (e.g. "version.txt").
+        ref: Git ref (branch, tag, or commit SHA).
+
+    Returns:
+        The decoded file contents as a UTF-8 string.
+
+    Raises:
+        GitHubAPIError: If the file cannot be fetched (not found, API error, etc.).
+
+    See: https://docs.github.com/en/rest/repos/contents#get-repository-content
+    """
+    import base64
+
+    url = f"https://api.github.com/repos/{github_repository}/contents/{path}?ref={ref}"
+    response = gha_send_request(url)
+    return base64.b64decode(response["content"]).decode("utf-8")
 
 
 # TODO: Consider moving str2bool to a general-purpose utils module. It's useful

--- a/build_tools/github_actions/github_actions_api.py
+++ b/build_tools/github_actions/github_actions_api.py
@@ -11,6 +11,8 @@ This module provides:
 See also https://pypi.org/project/github-action-utils/.
 """
 
+import base64
+import binascii
 from enum import Enum, auto
 import json
 import logging
@@ -22,6 +24,7 @@ import subprocess
 import sys
 from typing import Any, Mapping
 from urllib.error import HTTPError, URLError
+from urllib.parse import quote
 from urllib.request import urlopen, Request
 
 
@@ -549,17 +552,18 @@ def gha_resolve_git_ref(github_repository: str, ref: str) -> str:
 
     See: https://docs.github.com/en/rest/commits/commits#get-a-commit
     """
-    url = f"https://api.github.com/repos/{github_repository}/commits/{ref}"
+    encoded_ref = quote(ref, safe="")
+    url = f"https://api.github.com/repos/{github_repository}/commits/{encoded_ref}"
     response = gha_send_request(url)
     return response["sha"]
 
 
-def gha_fetch_file_contents(github_repository: str, path: str, ref: str) -> str:
+def gha_fetch_file_contents(github_repository: str, path: str, ref: str) -> bytes:
     """Fetch a file's contents from a GitHub repo at a specific ref.
 
-    Uses the Contents API to retrieve and decode a single file. The file
-    must be small enough for the Contents API (< 1 MB); for larger files
-    use the Blobs API instead.
+    Uses the Contents API to retrieve and decode a single file. The file must
+    be small enough for the Contents API to return base64 content; for larger
+    files use the Blobs API instead.
 
     Args:
         github_repository: Repository in "owner/repo" format (e.g. "ROCm/pytorch").
@@ -567,18 +571,39 @@ def gha_fetch_file_contents(github_repository: str, path: str, ref: str) -> str:
         ref: Git ref (branch, tag, or commit SHA).
 
     Returns:
-        The decoded file contents as a UTF-8 string.
+        The decoded file contents.
 
     Raises:
         GitHubAPIError: If the file cannot be fetched (not found, API error, etc.).
 
     See: https://docs.github.com/en/rest/repos/contents#get-repository-content
     """
-    import base64
-
-    url = f"https://api.github.com/repos/{github_repository}/contents/{path}?ref={ref}"
+    encoded_path = quote(path, safe="/")
+    encoded_ref = quote(ref, safe="")
+    url = (
+        f"https://api.github.com/repos/{github_repository}/contents/"
+        f"{encoded_path}?ref={encoded_ref}"
+    )
     response = gha_send_request(url)
-    return base64.b64decode(response["content"]).decode("utf-8")
+    if not isinstance(response, dict) or response.get("type") != "file":
+        response_type = (
+            response.get("type") if isinstance(response, dict) else type(response)
+        )
+        raise GitHubAPIError(
+            f"Expected GitHub contents response for a file at {path!r}, "
+            f"got {response_type!r}"
+        )
+    if response.get("encoding") != "base64" or not isinstance(
+        response.get("content"), str
+    ):
+        raise GitHubAPIError(
+            f"Expected base64 GitHub contents response for {path!r}; "
+            "use the Git blobs API for larger files"
+        )
+    try:
+        return base64.b64decode(response["content"])
+    except binascii.Error as e:
+        raise GitHubAPIError(f"Failed to decode GitHub contents for {path!r}") from e
 
 
 # TODO: Consider moving str2bool to a general-purpose utils module. It's useful

--- a/build_tools/github_actions/tests/github_actions_api_test.py
+++ b/build_tools/github_actions/tests/github_actions_api_test.py
@@ -479,21 +479,37 @@ class GitHubActionsUtilsTest(unittest.TestCase):
 
         self.assertEqual(sha, "1" * 40)
         gha_send_request.assert_called_once_with(
-            "https://api.github.com/repos/ROCm/pytorch/commits/release/2.12"
+            "https://api.github.com/repos/ROCm/pytorch/commits/release%2F2.12"
         )
 
     def test_fetch_file_contents_decodes_contents_api_response(self):
-        encoded = base64.b64encode(b"2.12.0\n").decode("ascii")
+        content = b"\x89PNG\r\n\x1a\n"
+        encoded = base64.b64encode(content).decode("ascii")
         with mock.patch(
             "github_actions_api.gha_send_request",
-            return_value={"content": encoded},
+            return_value={"type": "file", "encoding": "base64", "content": encoded},
         ) as gha_send_request:
-            contents = gha_fetch_file_contents("ROCm/pytorch", "version.txt", "abc123")
+            contents = gha_fetch_file_contents(
+                "ROCm/pytorch", "some path/version.txt", "release/2.12"
+            )
 
-        self.assertEqual(contents, "2.12.0\n")
+        self.assertEqual(contents, content)
         gha_send_request.assert_called_once_with(
-            "https://api.github.com/repos/ROCm/pytorch/contents/version.txt?ref=abc123"
+            "https://api.github.com/repos/ROCm/pytorch/contents/some%20path/version.txt?ref=release%2F2.12"
         )
+
+    def test_fetch_file_contents_rejects_non_file_response(self):
+        with mock.patch("github_actions_api.gha_send_request", return_value=[]):
+            with self.assertRaisesRegex(GitHubAPIError, "Expected GitHub contents"):
+                gha_fetch_file_contents("ROCm/pytorch", "ci", "abc123")
+
+    def test_fetch_file_contents_rejects_non_base64_response(self):
+        with mock.patch(
+            "github_actions_api.gha_send_request",
+            return_value={"type": "file", "encoding": "none", "content": ""},
+        ):
+            with self.assertRaisesRegex(GitHubAPIError, "Expected base64"):
+                gha_fetch_file_contents("ROCm/pytorch", "large.bin", "abc123")
 
     def setUp(self):
         # Save environment state

--- a/build_tools/github_actions/tests/github_actions_api_test.py
+++ b/build_tools/github_actions/tests/github_actions_api_test.py
@@ -1,6 +1,7 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+import base64
 import json
 import os
 from pathlib import Path
@@ -15,11 +16,13 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 from github_actions_api import (
     GitHubAPI,
     GitHubAPIError,
+    gha_fetch_file_contents,
     gha_load_github_event,
     gha_query_last_successful_workflow_run,
     gha_query_recent_branch_commits,
     gha_query_workflow_run_by_id,
     gha_query_workflow_runs_for_commit,
+    gha_resolve_git_ref,
     is_authenticated_github_api_available,
 )
 
@@ -467,6 +470,31 @@ class GitHubAPITest(unittest.TestCase):
 
 
 class GitHubActionsUtilsTest(unittest.TestCase):
+    def test_resolve_git_ref_returns_sha_from_commit_api(self):
+        with mock.patch(
+            "github_actions_api.gha_send_request",
+            return_value={"sha": "1" * 40},
+        ) as gha_send_request:
+            sha = gha_resolve_git_ref("ROCm/pytorch", "release/2.12")
+
+        self.assertEqual(sha, "1" * 40)
+        gha_send_request.assert_called_once_with(
+            "https://api.github.com/repos/ROCm/pytorch/commits/release/2.12"
+        )
+
+    def test_fetch_file_contents_decodes_contents_api_response(self):
+        encoded = base64.b64encode(b"2.12.0\n").decode("ascii")
+        with mock.patch(
+            "github_actions_api.gha_send_request",
+            return_value={"content": encoded},
+        ) as gha_send_request:
+            contents = gha_fetch_file_contents("ROCm/pytorch", "version.txt", "abc123")
+
+        self.assertEqual(contents, "2.12.0\n")
+        gha_send_request.assert_called_once_with(
+            "https://api.github.com/repos/ROCm/pytorch/contents/version.txt?ref=abc123"
+        )
+
     def setUp(self):
         # Save environment state
         self._saved_env = {}


### PR DESCRIPTION
## Motivation

These helpers will be used for pytorch manifest generation in multi-arch CI/CD as part of https://github.com/ROCm/TheRock/issues/5110 by letting us
1. Resolve refs such as:
    * `release/2.10` https://github.com/ROCm/pytorch/tree/release/2.10 --> https://github.com/ROCm/pytorch/commit/3d3aa833db84eed6b7f5595cb5f162c2f78300a4
2. Fetch individual files such as:
    * https://github.com/ROCm/pytorch/blob/3d3aa833db84eed6b7f5595cb5f162c2f78300a4/related_commits
    * https://github.com/ROCm/pytorch/blob/3d3aa833db84eed6b7f5595cb5f162c2f78300a4/version.txt

These APIs are usable without needing to clone the repositories, so manifest generation remains fast (~10 seconds with ~30 API calls and some other overhead).

## Test Plan

* New unit tests
* Used as part of my larger feature branch, test workflow run that calls these new functions: https://github.com/ROCm/TheRock/actions/runs/26252181316/job/77265866122#step:6:32

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
