### PR TITLE
Expose additional outputs in `build_tools/github_actions/determine_version.py`

### DIFF
--- a/build_tools/github_actions/determine_version.py
+++ b/build_tools/github_actions/determine_version.py
@@ -24,60 +24,42 @@ Writing the output to the "GITHUB_ENV" file can be suppressed by passing
 #       together and follow a similar style.
 # TODO: Or share with JAX builds? Could use a different name in that case too.
 
-from packaging.version import parse
-
 import argparse
 import sys
+from pathlib import Path
 
-from github_actions_api import *
+from packaging.version import parse
+
+_BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_BUILD_TOOLS_DIR))
+
+from github_actions.github_actions_api import gha_set_env
 
 
 def derive_version_suffix(rocm_version: str) -> str:
-    # Compute a version suffix to be used as a local version identifier:
-    # https://packaging.python.org/en/latest/specifications/version-specifiers/#local-version-identifiers
-    #
-    # For example, torch with base version `2.9.0` built with rocm `7.10.0`
-    # support can use this suffix in its version as `2.9.0+rocm7.10.0`.
-    #
-    # We take extra care here to sort final > nightly > dev and only include
-    # a single `+` in the suffix.
-    #
-    # For example:
-    #
-    # | description | rocm version       | suffix                     |
-    # | ----------- | ------------------ | -------------------------- |
-    # | final       | 7.10.0             | +rocm7.10.0                |
-    # | nightly     | 7.10.0a20251124    | +rocm7.10.0a20251124       |
-    # | dev         | 7.10.0.dev0+efed3c | +devrocm7.10.0.dev0-efed3c |
-    #                                       ^                 ^
-    #                                       |                 |-- no `+` here
-    #                                       |
-    #                                       |--- devrocm sorts older than rocm
+    """Compute a version suffix to be used as a local version identifier.
 
-    parsed_version = parse(rocm_version)
+    See https://packaging.python.org/en/latest/specifications/version-specifiers/#local-version-identifiers
+
+    For example, torch with base version ``2.9.0`` built with rocm ``7.10.0``
+    support uses this suffix in its version as ``2.9.0+rocm7.10.0``.
+
+    We take extra care to sort final > nightly > dev and only include
+    a single ``+`` in the suffix.
+
+    | description | rocm version       | suffix                     |
+    | ----------- | ------------------ | -------------------------- |
+    | final       | 7.10.0             | +rocm7.10.0                |
+    | nightly     | 7.10.0a20251124    | +rocm7.10.0a20251124       |
+    | dev         | 7.10.0.dev0+efed3c | +devrocm7.10.0.dev0-efed3c |
+                                            ^                 ^
+                                            |                 |-- no ``+`` here
+                                            |
+                                            |--- devrocm sorts older than rocm
+    """
+    parsed = parse(rocm_version)
     base_name = "devrocm" if "dev" in rocm_version else "rocm"
-    version_suffix = f"+{base_name}{str(parsed_version).replace('+','-')}"
-
-    return version_suffix
-
-
-def derive_versions(rocm_version: str, verbose_output: bool) -> str:
-    parsed_version = parse(rocm_version)
-    rocm_sdk_version = f"=={parsed_version}"
-
-    version_suffix = derive_version_suffix(rocm_version)
-
-    optional_build_prod_arguments = (
-        f"--rocm-sdk-version {rocm_sdk_version} --version-suffix {version_suffix}"
-    )
-
-    if verbose_output:
-        print(f"ROCm version: {parsed_version}")
-        print(f"`--rocm-sdk-version`\t: {rocm_sdk_version}")
-        print(f"`--version-suffix`\t: {version_suffix}")
-        print()
-
-    return optional_build_prod_arguments
+    return f"+{base_name}{str(parsed).replace('+', '-')}"
 
 
 def main(argv: list[str]):
@@ -102,11 +84,28 @@ def main(argv: list[str]):
     )
     args = p.parse_args(argv)
 
-    optional_build_prod_arguments = derive_versions(args.rocm_version, args.verbose)
+    parsed_version = parse(args.rocm_version)
+    version_suffix = derive_version_suffix(args.rocm_version)
+    rocm_sdk_version = f"=={parsed_version}"
+    optional_build_prod_arguments = (
+        f"--rocm-sdk-version {rocm_sdk_version} --version-suffix {version_suffix}"
+    )
+
+    if args.verbose:
+        print(f"ROCm version: {parsed_version}")
+        print(f"`--rocm-sdk-version`\t: {rocm_sdk_version}")
+        print(f"`--version-suffix`\t: {version_suffix}")
+        print()
+
     print(f"{optional_build_prod_arguments}")
 
     if args.write_env_file:
-        gha_set_env({"optional_build_prod_arguments": optional_build_prod_arguments})
+        gha_set_env(
+            {
+                "optional_build_prod_arguments": optional_build_prod_arguments,
+                "version_suffix": version_suffix,
+            }
+        )
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/tests/determine_version_test.py
+++ b/build_tools/github_actions/tests/determine_version_test.py
@@ -12,27 +12,18 @@ import determine_version
 
 
 class DetermineVersionTest(unittest.TestCase):
-    def test_dev_version(self):
+    def test_dev_version_suffix(self):
         rocm_version = "7.0.0.dev0+515115ea2cb85a0b71b5507ce56a627d14c7ae73"
-        optional_build_prod_arguments = determine_version.derive_versions(
-            rocm_version=rocm_version, verbose_output=True
-        )
-
+        suffix = determine_version.derive_version_suffix(rocm_version)
         self.assertEqual(
-            optional_build_prod_arguments,
-            "--rocm-sdk-version ==7.0.0.dev0+515115ea2cb85a0b71b5507ce56a627d14c7ae73 --version-suffix +devrocm7.0.0.dev0-515115ea2cb85a0b71b5507ce56a627d14c7ae73",
+            suffix,
+            "+devrocm7.0.0.dev0-515115ea2cb85a0b71b5507ce56a627d14c7ae73",
         )
 
-    def test_nightly_version(self):
+    def test_nightly_version_suffix(self):
         rocm_version = "7.0.0rc20250707"
-        optional_build_prod_arguments = determine_version.derive_versions(
-            rocm_version=rocm_version, verbose_output=True
-        )
-
-        self.assertEqual(
-            optional_build_prod_arguments,
-            "--rocm-sdk-version ==7.0.0rc20250707 --version-suffix +rocm7.0.0rc20250707",
-        )
+        suffix = determine_version.derive_version_suffix(rocm_version)
+        self.assertEqual(suffix, "+rocm7.0.0rc20250707")
 
     def test_version_suffix_sorting(self):
         # This tests that version suffixes follow this ordering:

--- a/build_tools/github_actions/tests/determine_version_test.py
+++ b/build_tools/github_actions/tests/determine_version_test.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import os
 import sys
 import unittest
+from unittest import mock
+
 from packaging.version import Version
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
@@ -48,6 +50,20 @@ class DetermineVersionTest(unittest.TestCase):
         self.assertGreater(version_final, version_prerelease)
         self.assertGreater(version_prerelease, version_alpha)
         self.assertGreater(version_alpha, version_dev)
+
+    def test_write_env_file_sets_build_arguments_and_suffix(self):
+        rocm_version = "7.0.0"
+        with mock.patch.object(determine_version, "gha_set_env") as gha_set_env:
+            determine_version.main(["--rocm-version", rocm_version, "--write-env-file"])
+
+        gha_set_env.assert_called_once_with(
+            {
+                "optional_build_prod_arguments": (
+                    "--rocm-sdk-version ==7.0.0 --version-suffix +rocm7.0.0"
+                ),
+                "version_suffix": "+rocm7.0.0",
+            }
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

I want to use this data from some new pytorch manifest generation code in multi-arch CI/CD as part of https://github.com/ROCm/TheRock/issues/5110, so exposing the underlying `version_suffix` in addition to `optional_build_prod_arguments`.

## Test Plan

* New and existing unit tests
* Python package builds/tests on this PR should continue to pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
