### PR TITLE
Explicitly set INSTALL_RPATH_DIRS for rocminfo

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -171,6 +171,8 @@ if(THEROCK_ENABLE_CORE_RUNTIME)
       "${_system_toolchain}"
     RUNTIME_DEPS
       ROCR-Runtime
+    INSTALL_RPATH_DIRS
+      lib
   )
   therock_cmake_subproject_glob_c_sources(rocminfo SUBDIRS .)
   therock_cmake_subproject_activate(rocminfo)


### PR DESCRIPTION
Configure rocminfo to explicitly use TheRock's RPATH infrastructure by specifying INSTALL_RPATH_DIRS. This ensures rocminfo binaries have RPATH set to find libraries relative to their installation location.

Without this explicit configuration, rocminfo (which has its own standalone CMakeLists.txt in rocm-systems submodule) doesn't participate in TheRock's automatic RPATH post-processing, potentially causing the binary to search for libraries in system paths instead of the artifact's lib/ directory.

This fix ensures that:
1. rocminfo has RPATH set to $ORIGIN/../lib and $ORIGIN/../lib/rocm_sysdeps/lib
2. The binary will find the correct libhsa-runtime64.so from the same artifact
3. CI tests use the newly built runtime with fixes, not system libraries
4. The solution doesn't rely on LD_LIBRARY_PATH environment configuration

Fixes: ROCM-23909
