### PR TITLE
fetch_test_configurations: coerce container_options to string on non-linux

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -88,8 +88,12 @@ def _build_container_options(job_config: dict, platform: str) -> dict:
     Returns:
         The modified job_config with updated container_options
     """
-    # Only apply container options for Linux platforms
+    # Containers are Linux-only (test_component.yml gates container.image on
+    # platform == 'linux'). On other platforms, collapse container_options to an
+    # empty string so `options: ${{ fromJSON(...).container_options }}` doesn't
+    # evaluate to a YAML sequence and fail template parsing.
     if platform != "linux":
+        job_config["container_options"] = ""
         return job_config
 
     # Start with base options (always applied on Linux)

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -371,6 +371,25 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         fetch_test_configurations.run()
         self.assertEqual(self.gha_output["platform"], "linux")
 
+    def test_container_options_on_windows_is_string_not_list(self):
+        # Regression: a list value here caused
+        # `options: ${{ fromJSON(...).container_options }}` in test_component.yml
+        # to evaluate to a YAML sequence, failing template parsing.
+        job = {
+            "container_options": [
+                "--cap-add SYS_MODULE",
+                "-v /lib/modules:/lib/modules",
+            ]
+        }
+        out = fetch_test_configurations._build_container_options(job, "windows")
+        self.assertIsInstance(out["container_options"], str)
+
+    def test_container_options_on_linux_is_joined_string(self):
+        job = {"container_options": ["--cap-add=SYS_PTRACE"]}
+        out = fetch_test_configurations._build_container_options(job, "linux")
+        self.assertIsInstance(out["container_options"], str)
+        self.assertIn("--cap-add=SYS_PTRACE", out["container_options"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Introduced in https://github.com/ROCm/TheRock/pull/5132:

_build_container_options early-returned on non-Linux platforms without collapsing the list-form container_options from test_matrix entries (e.g. sanity's ["--cap-add SYS_MODULE", "-v /lib/modules:/lib/modules"]). The raw list survived JSON serialization into the workflow matrix, and test_component.yml's `options: ${{ fromJSON(...).container_options }}` then evaluated to a YAML sequence, failing template parsing:

  test_component.yml (Line: 63, Col: 16): A sequence was not expected

Containers are Linux-only (container.image is already gated on platform == 'linux'), so on Windows the field is dead weight. Collapse it to an empty string so the workflow expression yields a harmless empty options value.

Fixes the following error on the Windows sanity test job:

Error: The template is not valid. ROCm/TheRock/.github/workflows/test_component.yml@ref (Line: 63, Col: 16): A sequence was not expected