### PR TITLE
exe_stub_gen: use /proc/self/exe instead of dladdr() to locate stub binary

### DIFF
--- a/build_tools/_therock_utils/exe_stub_gen.py
+++ b/build_tools/_therock_utils/exe_stub_gen.py
@@ -89,8 +89,9 @@ POSIX_EXE_STUB_TEMPLATE = r"""#define _GNU_SOURCE
 static const char EXEC_RELPATH[] = "@EXEC_RELPATH@";
 
 int main(int argc, char** argv) {
-    // Use the Dl_info of the main program to get the path. This is only valid
-    // because we linked as a PIE executable and the cwd has not been changed.
+    // Use the Dl_info of the main program to get the path. -fPIE is required
+    // so the dynamic linker loads the binary as a position-independent
+    // executable, which allows dladdr() to resolve dli_fname.
     Dl_info info;
     if (!dladdr(main, &info)) {
         fprintf(stderr, "could not get dl info for main: %s\n", dlerror());
@@ -139,6 +140,17 @@ def generate_exe_link_stub(output_file: Path, relative_link_to: str) -> None:
     if platform.system() == "Windows":
         raise NotImplementedError("generate_exe_link_stub NYI for Windows")
 
+    # Reject characters that would produce invalid C or enable injection
+    # when relative_link_to is interpolated into a C string literal.
+    if not relative_link_to or any(
+        c in relative_link_to for c in ('"', "\\", "\n", "\r", "\0")
+    ):
+        raise ValueError(
+            f"relative_link_to must be a non-empty path containing no "
+            f'characters invalid in a C string literal (no `"`, `\\`, '
+            f"or control characters): {relative_link_to!r}"
+        )
+
     with tempfile.TemporaryDirectory() as td:
         source_file = Path(td) / "stub.c"
         if platform.system() == "Linux":
@@ -148,9 +160,9 @@ def generate_exe_link_stub(output_file: Path, relative_link_to: str) -> None:
             template = LINUX_EXE_STUB_TEMPLATE
         else:
             # Generic POSIX impl (macOS, BSD, etc.): use dladdr(main) to locate
-            # the stub binary. Must link as PIE so that the main executable is
-            # dynamic (i.e. dladdr will work). dladdr is in the system library
-            # on macOS/BSD; no extra link flag needed.
+            # the stub binary. -fPIE is passed so the dynamic linker loads the
+            # binary as a position-independent executable, which allows
+            # dladdr() to resolve dli_fname.
             template = POSIX_EXE_STUB_TEMPLATE
         source_contents = template.replace("@EXEC_RELPATH@", relative_link_to)
         source_file.write_text(source_contents)

--- a/build_tools/_therock_utils/exe_stub_gen.py
+++ b/build_tools/_therock_utils/exe_stub_gen.py
@@ -20,7 +20,8 @@ import subprocess
 import sys
 import tempfile
 
-LINUX_EXE_STUB_TEMPLATE = r"""#include <stdio.h>
+LINUX_EXE_STUB_TEMPLATE = r"""#include <limits.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -31,7 +32,7 @@ int main(int argc, char** argv) {
     // Use /proc/self/exe instead of dladdr(main): dladdr() fails when argv[0]
     // has no '/' (e.g. MLIR's ROCDL target passes bare "ld.lld" as argv[0]),
     // causing dli_fname to have no path component and strrchr to return NULL.
-    char main_path[4096];
+    char main_path[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", main_path, sizeof(main_path));
     if (len == -1) {
         perror("could not readlink /proc/self/exe");
@@ -70,7 +71,7 @@ int main(int argc, char** argv) {
     int rc = execv(target, argv);
     if (rc == -1) {
         fprintf(stderr, "could not exec %s: ", target);
-        perror(0);
+        perror("");
         return 1;
     }
     return 0;
@@ -122,7 +123,7 @@ int main(int argc, char** argv) {
     int rc = execv(target, argv);
     if (rc == -1) {
         fprintf(stderr, "could not exec %s: ", target);
-        perror(0);
+        perror("");
         return 1;
     }
     return 0;

--- a/build_tools/_therock_utils/exe_stub_gen.py
+++ b/build_tools/_therock_utils/exe_stub_gen.py
@@ -20,7 +20,6 @@ import subprocess
 import sys
 import tempfile
 
-
 POSIX_EXE_STUB_TEMPLATE = r"""#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -81,9 +80,7 @@ def generate_exe_link_stub(output_file: Path, relative_link_to: str):
         )
         source_file.write_text(source_contents)
         cc = os.getenv("CC", "cc")
-        subprocess.check_call(
-            [cc, "-fPIE", "-o", str(output_file), str(source_file)]
-        )
+        subprocess.check_call([cc, "-fPIE", "-o", str(output_file), str(source_file)])
 
 
 if __name__ == "__main__":

--- a/build_tools/_therock_utils/exe_stub_gen.py
+++ b/build_tools/_therock_utils/exe_stub_gen.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 import tempfile
 
-POSIX_EXE_STUB_TEMPLATE = r"""#include <stdio.h>
+LINUX_EXE_STUB_TEMPLATE = r"""#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -37,8 +37,62 @@ int main(int argc, char** argv) {
         perror("could not readlink /proc/self/exe");
         return 1;
     }
+    if (len == (ssize_t)(sizeof(main_path) - 1)) {
+        fprintf(stderr,
+                "path to main program may have been truncated reading "
+                "/proc/self/exe (buffer too small)\n");
+        return 1;
+    }
     main_path[len] = '\0';
 
+    char* last_slash = strrchr(main_path, '/');
+    if (!last_slash) {
+        fprintf(stderr, "could not find path component of main program: '%s'\n",
+                main_path);
+        return 1;
+    }
+    *last_slash = 0;
+
+    // Compute the new target relative to the containing directory.
+    char* target = malloc(
+        strlen(main_path) + 1 /* slash */ + strlen(EXEC_RELPATH) + 1 /* nul */);
+    strcpy(target, main_path);
+    strcat(target, "/");
+    strcat(target, EXEC_RELPATH);
+
+    // Exec with altered target executable but preserving argv[0] as pointing
+    // to the current program. This emulates how invocation via a symlink
+    // works.
+    int rc = execv(target, argv);
+    if (rc == -1) {
+        fprintf(stderr, "could not exec %s: ", target);
+        perror(0);
+        return 1;
+    }
+    return 0;
+}
+"""
+
+POSIX_EXE_STUB_TEMPLATE = r"""#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char EXEC_RELPATH[] = "@EXEC_RELPATH@";
+
+int main(int argc, char** argv) {
+    // Use the Dl_info of the main program to get the path. This is only valid
+    // because we linked as a PIE executable and the cwd has not been changed.
+    Dl_info info;
+    if (!dladdr(main, &info)) {
+        fprintf(stderr, "could not get dl info for main: %s\n", dlerror());
+        return 1;
+    }
+
+    // Get the path of the main program object.
+    char* main_path = strdup(info.dli_fname);
     char* last_slash = strrchr(main_path, '/');
     if (!last_slash) {
         fprintf(stderr, "could not find path component of main program: '%s'\n",
@@ -72,15 +126,26 @@ def generate_exe_link_stub(output_file: Path, relative_link_to: str):
     if platform.system() == "Windows":
         raise NotImplementedError("generate_exe_link_stub NYI for Windows")
 
-    # Generic Posix impl.
     with tempfile.TemporaryDirectory() as td:
         source_file = Path(td) / "stub.c"
-        source_contents = POSIX_EXE_STUB_TEMPLATE.replace(
-            "@EXEC_RELPATH@", relative_link_to
-        )
+        if platform.system() == "Linux":
+            # Linux impl: use /proc/self/exe to locate the stub binary.
+            # dladdr() is unreliable when argv[0] has no '/' (e.g. MLIR's ROCDL
+            # target passes bare "ld.lld" as argv[0]).
+            template = LINUX_EXE_STUB_TEMPLATE
+            link_args: list[str] = []
+        else:
+            # Generic POSIX impl (macOS, BSD, etc.): use dladdr(main) to locate
+            # the stub binary. Must link as PIE so that the main executable is
+            # dynamic (i.e. dladdr will work).
+            template = POSIX_EXE_STUB_TEMPLATE
+            link_args = ["-ldl"]
+        source_contents = template.replace("@EXEC_RELPATH@", relative_link_to)
         source_file.write_text(source_contents)
         cc = os.getenv("CC", "cc")
-        subprocess.check_call([cc, "-fPIE", "-o", str(output_file), str(source_file)])
+        subprocess.check_call(
+            [cc, "-fPIE", "-o", str(output_file), str(source_file)] + link_args
+        )
 
 
 if __name__ == "__main__":

--- a/build_tools/_therock_utils/exe_stub_gen.py
+++ b/build_tools/_therock_utils/exe_stub_gen.py
@@ -21,9 +21,7 @@ import sys
 import tempfile
 
 
-POSIX_EXE_STUB_TEMPLATE = r"""#define _GNU_SOURCE
-#include <dlfcn.h>
-#include <stdio.h>
+POSIX_EXE_STUB_TEMPLATE = r"""#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -31,16 +29,17 @@ POSIX_EXE_STUB_TEMPLATE = r"""#define _GNU_SOURCE
 static const char EXEC_RELPATH[] = "@EXEC_RELPATH@";
 
 int main(int argc, char** argv) {
-    // Use the Dl_info of the main program to get the path. This is only valid
-    // because we linked as a PIE executable and the cwd has not been changed.
-    Dl_info info;
-    if (!dladdr(main, &info)) {
-        fprintf(stderr, "could not get dl info for main: %s\n", dlerror());
+    // Use /proc/self/exe instead of dladdr(main): dladdr() fails when argv[0]
+    // has no '/' (e.g. MLIR's ROCDL target passes bare "ld.lld" as argv[0]),
+    // causing dli_fname to have no path component and strrchr to return NULL.
+    char main_path[4096];
+    ssize_t len = readlink("/proc/self/exe", main_path, sizeof(main_path) - 1);
+    if (len == -1) {
+        perror("could not readlink /proc/self/exe");
         return 1;
     }
+    main_path[len] = '\0';
 
-    // Get the path of the main program object.
-    char* main_path = strdup(info.dli_fname);
     char* last_slash = strrchr(main_path, '/');
     if (!last_slash) {
         fprintf(stderr, "could not find path component of main program: '%s'\n",
@@ -82,10 +81,8 @@ def generate_exe_link_stub(output_file: Path, relative_link_to: str):
         )
         source_file.write_text(source_contents)
         cc = os.getenv("CC", "cc")
-        # Must link as PIE so that the main executable is dynamic (i.e. dladdr
-        # will work).
         subprocess.check_call(
-            [cc, "-fPIE", "-o", str(output_file), str(source_file), "-ldl"]
+            [cc, "-fPIE", "-o", str(output_file), str(source_file)]
         )
 
 

--- a/build_tools/_therock_utils/exe_stub_gen.py
+++ b/build_tools/_therock_utils/exe_stub_gen.py
@@ -16,6 +16,7 @@ Example usage (creates a stub that invokes /bin/ls):
 from pathlib import Path
 import os
 import platform
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -166,8 +167,10 @@ def generate_exe_link_stub(output_file: Path, relative_link_to: str) -> None:
             template = POSIX_EXE_STUB_TEMPLATE
         source_contents = template.replace("@EXEC_RELPATH@", relative_link_to)
         source_file.write_text(source_contents)
-        cc = os.getenv("CC", "cc")
-        subprocess.check_call([cc, "-fPIE", "-o", str(output_file), str(source_file)])
+        cc_cmd = shlex.split(os.getenv("CC", "cc"))
+        subprocess.check_call(
+            [*cc_cmd, "-fPIE", "-o", str(output_file), str(source_file)]
+        )
 
 
 if __name__ == "__main__":

--- a/build_tools/_therock_utils/exe_stub_gen.py
+++ b/build_tools/_therock_utils/exe_stub_gen.py
@@ -20,7 +20,8 @@ import subprocess
 import sys
 import tempfile
 
-LINUX_EXE_STUB_TEMPLATE = r"""#include <limits.h>
+LINUX_EXE_STUB_TEMPLATE = r"""#include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -70,8 +71,7 @@ int main(int argc, char** argv) {
     // works.
     int rc = execv(target, argv);
     if (rc == -1) {
-        fprintf(stderr, "could not exec %s: ", target);
-        perror("");
+        fprintf(stderr, "could not exec %s: %s\n", target, strerror(errno));
         return 1;
     }
     return 0;
@@ -80,6 +80,7 @@ int main(int argc, char** argv) {
 
 POSIX_EXE_STUB_TEMPLATE = r"""#define _GNU_SOURCE
 #include <dlfcn.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -98,6 +99,10 @@ int main(int argc, char** argv) {
 
     // Get the path of the main program object.
     char* main_path = strdup(info.dli_fname);
+    if (!main_path) {
+        fprintf(stderr, "out of memory\n");
+        return 1;
+    }
     char* last_slash = strrchr(main_path, '/');
     if (!last_slash) {
         fprintf(stderr, "could not find path component of main program: '%s'\n",
@@ -122,8 +127,7 @@ int main(int argc, char** argv) {
     // works.
     int rc = execv(target, argv);
     if (rc == -1) {
-        fprintf(stderr, "could not exec %s: ", target);
-        perror("");
+        fprintf(stderr, "could not exec %s: %s\n", target, strerror(errno));
         return 1;
     }
     return 0;
@@ -131,7 +135,7 @@ int main(int argc, char** argv) {
 """
 
 
-def generate_exe_link_stub(output_file: Path, relative_link_to: str):
+def generate_exe_link_stub(output_file: Path, relative_link_to: str) -> None:
     if platform.system() == "Windows":
         raise NotImplementedError("generate_exe_link_stub NYI for Windows")
 
@@ -158,4 +162,4 @@ if __name__ == "__main__":
     if len(sys.argv) != 3:
         print("ERROR: Expected {out_file} {relative_link_to}")
         sys.exit(1)
-    generate_exe_link_stub(sys.argv[1], sys.argv[2])
+    generate_exe_link_stub(Path(sys.argv[1]), sys.argv[2])

--- a/build_tools/_therock_utils/exe_stub_gen.py
+++ b/build_tools/_therock_utils/exe_stub_gen.py
@@ -148,7 +148,7 @@ def generate_exe_link_stub(output_file: Path, relative_link_to: str) -> None:
         raise ValueError(
             f"relative_link_to must be a non-empty path containing no "
             f'characters invalid in a C string literal (no `"`, `\\`, '
-            f"or control characters): {relative_link_to!r}"
+            f"newlines, or null bytes): {relative_link_to!r}"
         )
 
     with tempfile.TemporaryDirectory() as td:

--- a/build_tools/_therock_utils/exe_stub_gen.py
+++ b/build_tools/_therock_utils/exe_stub_gen.py
@@ -141,20 +141,16 @@ def generate_exe_link_stub(output_file: Path, relative_link_to: str):
             # dladdr() is unreliable when argv[0] has no '/' (e.g. MLIR's ROCDL
             # target passes bare "ld.lld" as argv[0]).
             template = LINUX_EXE_STUB_TEMPLATE
-            link_args: list[str] = []
         else:
             # Generic POSIX impl (macOS, BSD, etc.): use dladdr(main) to locate
             # the stub binary. Must link as PIE so that the main executable is
             # dynamic (i.e. dladdr will work). dladdr is in the system library
             # on macOS/BSD; no extra link flag needed.
             template = POSIX_EXE_STUB_TEMPLATE
-            link_args: list[str] = []
         source_contents = template.replace("@EXEC_RELPATH@", relative_link_to)
         source_file.write_text(source_contents)
         cc = os.getenv("CC", "cc")
-        subprocess.check_call(
-            [cc, "-fPIE", "-o", str(output_file), str(source_file)] + link_args
-        )
+        subprocess.check_call([cc, "-fPIE", "-o", str(output_file), str(source_file)])
 
 
 if __name__ == "__main__":

--- a/build_tools/_therock_utils/exe_stub_gen.py
+++ b/build_tools/_therock_utils/exe_stub_gen.py
@@ -32,14 +32,14 @@ int main(int argc, char** argv) {
     // has no '/' (e.g. MLIR's ROCDL target passes bare "ld.lld" as argv[0]),
     // causing dli_fname to have no path component and strrchr to return NULL.
     char main_path[4096];
-    ssize_t len = readlink("/proc/self/exe", main_path, sizeof(main_path) - 1);
+    ssize_t len = readlink("/proc/self/exe", main_path, sizeof(main_path));
     if (len == -1) {
         perror("could not readlink /proc/self/exe");
         return 1;
     }
-    if (len == (ssize_t)(sizeof(main_path) - 1)) {
+    if (len == (ssize_t)sizeof(main_path)) {
         fprintf(stderr,
-                "path to main program may have been truncated reading "
+                "path to main program truncated reading "
                 "/proc/self/exe (buffer too small)\n");
         return 1;
     }
@@ -56,6 +56,10 @@ int main(int argc, char** argv) {
     // Compute the new target relative to the containing directory.
     char* target = malloc(
         strlen(main_path) + 1 /* slash */ + strlen(EXEC_RELPATH) + 1 /* nul */);
+    if (!target) {
+        fprintf(stderr, "out of memory\n");
+        return 1;
+    }
     strcpy(target, main_path);
     strcat(target, "/");
     strcat(target, EXEC_RELPATH);
@@ -104,6 +108,10 @@ int main(int argc, char** argv) {
     // Compute the new target relative to the containing directory.
     char* target = malloc(
         strlen(main_path) + 1 /* slash */ + strlen(EXEC_RELPATH) + 1 /* nul */);
+    if (!target) {
+        fprintf(stderr, "out of memory\n");
+        return 1;
+    }
     strcpy(target, main_path);
     strcat(target, "/");
     strcat(target, EXEC_RELPATH);
@@ -137,9 +145,10 @@ def generate_exe_link_stub(output_file: Path, relative_link_to: str):
         else:
             # Generic POSIX impl (macOS, BSD, etc.): use dladdr(main) to locate
             # the stub binary. Must link as PIE so that the main executable is
-            # dynamic (i.e. dladdr will work).
+            # dynamic (i.e. dladdr will work). dladdr is in the system library
+            # on macOS/BSD; no extra link flag needed.
             template = POSIX_EXE_STUB_TEMPLATE
-            link_args = ["-ldl"]
+            link_args: list[str] = []
         source_contents = template.replace("@EXEC_RELPATH@", relative_link_to)
         source_file.write_text(source_contents)
         cc = os.getenv("CC", "cc")

--- a/build_tools/tests/exe_stub_gen_test.py
+++ b/build_tools/tests/exe_stub_gen_test.py
@@ -4,6 +4,7 @@
 """Tests for exe_stub_gen — platform-specific stub executable generation."""
 
 import contextlib
+import os
 import platform
 import shutil
 import subprocess
@@ -16,7 +17,7 @@ from _therock_utils.exe_stub_gen import generate_exe_link_stub
 
 IS_WINDOWS = platform.system() == "Windows"
 IS_LINUX = platform.system() == "Linux"
-_CC_AVAILABLE = shutil.which("cc") is not None
+_CC_AVAILABLE = shutil.which(os.getenv("CC", "cc")) is not None
 
 
 class GenerateExeLinkStubTest(unittest.TestCase):

--- a/build_tools/tests/exe_stub_gen_test.py
+++ b/build_tools/tests/exe_stub_gen_test.py
@@ -71,6 +71,32 @@ class GenerateExeLinkStubTest(unittest.TestCase):
                     generate_exe_link_stub(Path("/tmp/stub"), bad)
 
     @unittest.skipIf(IS_WINDOWS, "POSIX only")
+    def test_multi_word_cc_is_split(self):
+        """A multi-word CC value (e.g. 'ccache cc') is tokenized so each word
+        is a separate argv element in the compiler invocation."""
+        captured_args: list[list[str]] = []
+
+        def _fake_check_call(args, **kwargs):
+            captured_args.append(list(args))
+
+        def _fake_getenv(key, default=None):
+            return "ccache cc" if key == "CC" else os.getenv(key, default)
+
+        with mock.patch(
+            "_therock_utils.exe_stub_gen.subprocess.check_call",
+            side_effect=_fake_check_call,
+        ), mock.patch(
+            "_therock_utils.exe_stub_gen.os.getenv",
+            side_effect=_fake_getenv,
+        ), tempfile.TemporaryDirectory() as tmp:
+            generate_exe_link_stub(Path(tmp) / "stub", "target")
+
+        self.assertGreater(
+            len(captured_args), 0, "subprocess.check_call was not invoked"
+        )
+        self.assertEqual(captured_args[0][:2], ["ccache", "cc"])
+
+    @unittest.skipIf(IS_WINDOWS, "POSIX only")
     def test_exec_relpath_placeholder_substituted(self):
         """@EXEC_RELPATH@ is replaced with the supplied relative path in the
         generated C source."""

--- a/build_tools/tests/exe_stub_gen_test.py
+++ b/build_tools/tests/exe_stub_gen_test.py
@@ -6,6 +6,7 @@
 import contextlib
 import os
 import platform
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -17,7 +18,7 @@ from _therock_utils.exe_stub_gen import generate_exe_link_stub
 
 IS_WINDOWS = platform.system() == "Windows"
 IS_LINUX = platform.system() == "Linux"
-_CC_AVAILABLE = shutil.which(os.getenv("CC", "cc")) is not None
+_CC_AVAILABLE = shutil.which(shlex.split(os.getenv("CC", "cc"))[0]) is not None
 
 
 class GenerateExeLinkStubTest(unittest.TestCase):

--- a/build_tools/tests/exe_stub_gen_test.py
+++ b/build_tools/tests/exe_stub_gen_test.py
@@ -1,0 +1,117 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for exe_stub_gen — platform-specific stub executable generation."""
+
+import contextlib
+import platform
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from _therock_utils.exe_stub_gen import generate_exe_link_stub
+
+IS_WINDOWS = platform.system() == "Windows"
+IS_LINUX = platform.system() == "Linux"
+_CC_AVAILABLE = shutil.which("cc") is not None
+
+
+class GenerateExeLinkStubTest(unittest.TestCase):
+    def _capture_generated_source(
+        self, relative_link_to: str, *, system: str | None = None
+    ) -> str:
+        """Invoke generate_exe_link_stub with a no-op compiler and return the
+        C source that would have been compiled."""
+        captured: dict[str, str] = {}
+
+        def _fake_check_call(args, **kwargs):
+            captured["source"] = Path(args[-1]).read_text()
+
+        patches = [
+            mock.patch(
+                "_therock_utils.exe_stub_gen.subprocess.check_call",
+                side_effect=_fake_check_call,
+            )
+        ]
+        if system is not None:
+            patches.append(
+                mock.patch(
+                    "_therock_utils.exe_stub_gen.platform.system",
+                    return_value=system,
+                )
+            )
+
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            with tempfile.TemporaryDirectory() as tmp:
+                generate_exe_link_stub(Path(tmp) / "stub", relative_link_to)
+
+        return captured["source"]
+
+    def test_windows_raises_not_implemented(self):
+        """NotImplementedError is raised on Windows."""
+        with mock.patch(
+            "_therock_utils.exe_stub_gen.platform.system", return_value="Windows"
+        ):
+            with self.assertRaises(NotImplementedError):
+                generate_exe_link_stub(Path("/tmp/stub"), "target")
+
+    @unittest.skipIf(IS_WINDOWS, "POSIX only")
+    def test_exec_relpath_placeholder_substituted(self):
+        """@EXEC_RELPATH@ is replaced with the supplied relative path in the
+        generated C source."""
+        source = self._capture_generated_source("my_target_binary")
+        self.assertIn("my_target_binary", source)
+        self.assertNotIn("@EXEC_RELPATH@", source)
+
+    def test_linux_template_uses_proc_self_exe(self):
+        """On Linux the generated source uses /proc/self/exe for path resolution."""
+        source = self._capture_generated_source("target", system="Linux")
+        self.assertIn("/proc/self/exe", source)
+        self.assertNotIn("#include <dlfcn.h>", source)
+
+    def test_posix_template_uses_dladdr(self):
+        """On non-Linux POSIX (e.g. macOS) the generated source uses dladdr()."""
+        source = self._capture_generated_source("target", system="Darwin")
+        self.assertIn("#include <dlfcn.h>", source)
+        self.assertNotIn("/proc/self/exe", source)
+
+    @unittest.skipUnless(IS_LINUX, "Linux /proc/self/exe path only")
+    @unittest.skipUnless(_CC_AVAILABLE, "C compiler (cc) required")
+    def test_stub_works_with_bare_argv0(self):
+        """Compiled stub resolves and execs its target when invoked with a bare
+        argv[0] (no '/' separator) — the failure mode triggered by MLIR's ROCDL
+        target which passes "ld.lld" as argv[0] to llvm::sys::ExecuteAndWait."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            # Minimal target script that exits 0.
+            target = tmp_path / "target"
+            target.write_text("#!/bin/sh\nexit 0\n")
+            target.chmod(0o755)
+
+            stub = tmp_path / "stub"
+            generate_exe_link_stub(stub, "target")
+
+            # argv[0] = "stub" (bare name, no '/'), while the OS executes the
+            # stub via its absolute path. This mirrors how MLIR's ROCDL target
+            # invokes ld.lld: absolute executable path, bare string as argv[0].
+            result = subprocess.run(
+                ["stub"],
+                executable=str(stub),
+                capture_output=True,
+            )
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"Stub failed when invoked with bare argv[0]: "
+                f"{result.stderr.decode()!r}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/tests/exe_stub_gen_test.py
+++ b/build_tools/tests/exe_stub_gen_test.py
@@ -61,6 +61,14 @@ class GenerateExeLinkStubTest(unittest.TestCase):
                 generate_exe_link_stub(Path("/tmp/stub"), "target")
 
     @unittest.skipIf(IS_WINDOWS, "POSIX only")
+    def test_invalid_relative_link_to_raises_value_error(self):
+        """Characters invalid in a C string literal are rejected before compilation."""
+        for bad in ('has"quote', "has\\backslash", "has\nnewline", "has\x00null", ""):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    generate_exe_link_stub(Path("/tmp/stub"), bad)
+
+    @unittest.skipIf(IS_WINDOWS, "POSIX only")
     def test_exec_relpath_placeholder_substituted(self):
         """@EXEC_RELPATH@ is replaced with the supplied relative path in the
         generated C source."""


### PR DESCRIPTION
## Problem

The POSIX exe stub uses `dladdr(main)` to locate its own path, then resolves the real target binary at a relative path from that directory. This fails when the stub is invoked with a bare filename as argv[0] (no '/' separator): `dladdr()` returns `dli_fname` without a path component, `strrchr` returns NULL, and the stub exits 1:

  could not find path component of main program: 'ld.lld'

The concrete trigger is MLIR's ROCDL `gpu-module-to-binary` pass, which invokes `ld.lld` via `llvm::sys::ExecuteAndWait()` with the absolute path as the executable but hardcodes the bare string `"ld.lld"` as argv[0]: https://github.com/llvm/llvm-project/blob/e4716e0c1155/mlir/lib/Target/LLVM/ROCDL/Target.cpp#L364-L366

This causes every FlyDSL AOT kernel compilation to fail during `setup.py` when building AITER v0.1.14 from source against TheRock wheels, blocking the wheel build entirely with 400+ failed kernels.

## Fix

The fix splits the stub into two platform-specific templates. On Linux, `dladdr(main)` is replaced with `readlink("/proc/self/exe")`, which always returns an absolute path regardless of how the process was invoked. On other POSIX platforms (macOS, BSD), the original `dladdr(main)` path is preserved unchanged, as `/proc/self/exe` is Linux-specific and TheRock supports macOS. Neither branch requires `-ldl`: the Linux template does not use `dladdr`, and macOS/BSD expose `dladdr` in the system library. A truncation check (`len == (ssize_t)sizeof(main_path)`) is added to the Linux path.

## Companion fix

The root cause in MLIR should also be fixed in llvm/llvm-project: passing `lldPath` (already computed as an absolute path at line 393) as argv[0] instead of the bare `"ld.lld"` literal. This PR makes the stub robust against that class of caller regardless of whether the MLIR fix lands first.
