### PR TITLE
Fix rocprofiler-sdk build by ordering it after ROCm dist artifacts

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -94,6 +94,11 @@ if(THEROCK_ENABLE_ROCPROFV3)
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprofiler-sdk"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprofiler-sdk"
     BACKGROUND_BUILD
+    EXTRA_DEPENDS
+      artifact-base
+      artifact-sysdeps
+      artifact-amd-llvm
+      artifact-core-hip
     CMAKE_ARGS
       -DHIP_PLATFORM=amd
       -DROCPROFILER_BUILD_CI=ON


### PR DESCRIPTION
rocprofiler-sdk has a test case where it builds a piece of HIP code, `syncthreads_kernel.hip`, then
extracts the DWARF from the resulting binary to test debug info parsing.
The current cmake code looks for the the `amdclang++` compiler in a way
that could either find:

`build/compiler/amd-llvm/dist/lib/llvm/bin/amdclang++`

or

`build/dist/rocm/bin/amdclang++`

depending on a race condition between the `rocprofiler-sdk+configure` step and
the ROCm artifact installation under `build/dist/rocm`.

Relevant code is in `rocm-systems/projects/rocmprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt`:

```
find_program(
    CODEOBJ_AMDCLANGPP REQUIRED
    NAMES amdclang++
    HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
    PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
    PATH_SUFFIXES bin llvm/bin NO_CACHE)
    
(...)

add_custom_command(
    OUTPUT "${_SYNCKERNEL_BIN}"
    COMMAND
        ${CODEOBJ_AMDCLANGPP} -x hip -ggdb --offload-arch=${_SYNCKERNEL_ARCH}
        --offload-device-only -c -fno-gpu-rdc --no-offload-new-driver -o
        "${_SYNCKERNEL_BUNDLE}" "${_SYNCKERNEL_SRC}"
    COMMAND
        ${CODEOBJ_OFFLOAD_BUNDLER} --type=o --input=${_SYNCKERNEL_BUNDLE}
        --output=${_SYNCKERNEL_BIN} --unbundle
        --targets=hipv4-amdgcn-amd-amdhsa--${_SYNCKERNEL_ARCH}
    DEPENDS "${_SYNCKERNEL_SRC}"
    COMMENT
        "Compiling syncthreads_kernel.hip -> syncthreads_kernel.bin (${_SYNCKERNEL_ARCH})"
    VERBATIM)
```


If `rocprofiler-sdk+configure` finds the amdclang++ under
`build/compiler/amd-llvm/dist/...` the build fails since the HIP source uses
`<hip/hip_runtime.h>` and the location of the HIP runtime header can't be
inferred from that directory layout.

Log snippet:

```
FAILED: source/lib/tests/codeobj/syncthreads_kernel.bin /home/scottt/o/r-gfx1151/build/profiler/rocprofiler-sdk/build/source/lib/tests/codeobj/syncthreads_kernel.bin
cd /home/scottt/o/r-gfx1151/build/profiler/rocprofiler-sdk/build/source/lib/tests/codeobj && /home/scottt/o/r-gfx1151/build/compiler/amd-llvm/dist/lib/llvm/bin/amdclang++ -x hip -ggdb --offload-arch=gfx90a --offload-device-only -c -fno-gpu-rdc --no-offload-new-driver -o /home/scottt/o/r-gfx1151/build/profiler/rocprofiler-sdk/build/source/lib/tests/codeobj/syncthreads_kernel_bundle.o /home/scottt/w/r/rocm-systems/projects/rocprofiler-sdk/source/lib/tests/codeobj/syncthreads_kernel.hip && /home/scottt/o/r-gfx1151/build/compiler/amd-llvm/dist/lib/llvm/bin/clang-offload-bundler --type=o --input=/home/scottt/o/r-gfx1151/build/profiler/rocprofiler-sdk/build/source/lib/tests/codeobj/syncthreads_kernel_bundle.o --output=/home/scottt/o/r-gfx1151/build/profiler/rocprofiler-sdk/build/source/lib/tests/codeobj/syncthreads_kernel.bin --unbundle --targets=hipv4-amdgcn-amd-amdhsa--gfx90a
clang++: error: cannot find HIP runtime; provide its path via '--rocm-path', or pass '-nogpuinc' to build without HIP runtime
```

where `syncthreads_kernel.hip` contains:

```
#include <hip/hip_runtime.h>
__device__ void
barrier_wrapper(int* data)
{
        __syncthreads();
        data[threadIdx.x] += data[threadIdx.x ^ 1];
}

__global__ void
syncthreads_kernel(int* data)
{
        data[threadIdx.x] = threadIdx.x;

}
```

The patch makes the rocprofiler-sdk subproject configure step wait for the artifacts that
populate the merged dist before CMake tries to resolve `amdclang++`.
Thus making `amdclang++` come from the merged ROCm dist artifact passed as `ROCM_PATH`,
not from an internal compiler artifact path.

rocprofiler-sdk now EXTRA_DEPENDS on:

* `artifact-amd-llvm` provides the LLVM compiler payload under
  `dist/rocm/lib/llvm`.
* `artifact-core-hip` provides the HIP runtime/header pieces used by HIP
  compilation.
* `artifact-base` provides the `dist/rocm/bin/amdclang++` wrapper/symlink.
* `artifact-sysdeps` provides the sysdeps runtime libraries required by the
  compiler tools under `dist/rocm/lib/rocm_sysdeps`.

This lets `ROCPROFILER_BUILD_TESTS` follow `THEROCK_BUILD_TESTING` instead of
being forced off as a workaround for the missing HIP runtime error.
