### PR TITLE
Add build topology reverse index helpers

### DIFF
--- a/build_tools/_therock_utils/build_topology.py
+++ b/build_tools/_therock_utils/build_topology.py
@@ -686,6 +686,120 @@ class BuildTopology:
 
         return order
 
+    def get_source_set_to_artifact_groups(self) -> Dict[str, List[str]]:
+        """
+        Get a reverse index from source set names to artifact group names.
+
+        Returns:
+            Dictionary mapping source set names to artifact group names that
+            reference them. Known source sets with no artifact group references
+            are included with an empty list.
+        """
+        artifact_groups_by_source_set = {
+            source_set_name: [] for source_set_name in self.source_sets
+        }
+        for group in self.artifact_groups.values():
+            for source_set_name in group.source_sets:
+                artifact_groups_by_source_set.setdefault(source_set_name, []).append(
+                    group.name
+                )
+        return artifact_groups_by_source_set
+
+    def get_artifact_group_to_artifacts(self) -> Dict[str, List[str]]:
+        """
+        Get an index from artifact group names to artifact names.
+
+        Returns:
+            Dictionary mapping artifact group names to artifact names in that
+            group. Known artifact groups with no artifacts are included with an
+            empty list.
+        """
+        artifacts_by_group = {group_name: [] for group_name in self.artifact_groups}
+        for artifact in self.artifacts.values():
+            artifacts_by_group.setdefault(artifact.artifact_group, []).append(
+                artifact.name
+            )
+        return artifacts_by_group
+
+    def get_artifact_group_to_build_stages(self) -> Dict[str, List[str]]:
+        """
+        Get a reverse index from artifact group names to producer build stages.
+
+        Returns:
+            Dictionary mapping artifact group names to build stage names that
+            list the group. Known artifact groups with no producing stage are
+            included with an empty list.
+        """
+        stages_by_group = {group_name: [] for group_name in self.artifact_groups}
+        for stage in self.build_stages.values():
+            for group_name in stage.artifact_groups:
+                stages_by_group.setdefault(group_name, []).append(stage.name)
+        return stages_by_group
+
+    def get_artifact_to_producer_stages(self) -> Dict[str, List[str]]:
+        """
+        Get an index from artifact names to producer build stages.
+
+        Returns:
+            Dictionary mapping artifact names to build stage names that produce
+            their artifact group. Artifacts in unmapped groups are included with
+            an empty list.
+        """
+        stages_by_group = self.get_artifact_group_to_build_stages()
+        return {
+            artifact.name: list(stages_by_group.get(artifact.artifact_group, []))
+            for artifact in self.artifacts.values()
+        }
+
+    def get_stage_to_source_sets(
+        self, platform: Optional[str] = None
+    ) -> Dict[str, List[str]]:
+        """
+        Get an index from build stages to source set names.
+
+        Args:
+            platform: Current platform (e.g., "linux", "windows"). If provided,
+                source_sets with this platform in disable_platforms are skipped.
+
+        Returns:
+            Dictionary mapping build stage names to source set names used by the
+            stage's artifact groups.
+        """
+        return {
+            stage_name: [
+                source_set.name
+                for source_set in self.get_source_sets_for_stage(
+                    stage_name, platform=platform
+                )
+            ]
+            for stage_name in self.build_stages
+        }
+
+    def get_source_set_to_stages(
+        self, platform: Optional[str] = None
+    ) -> Dict[str, List[str]]:
+        """
+        Get a reverse index from source set names to build stages.
+
+        Args:
+            platform: Current platform (e.g., "linux", "windows"). If provided,
+                source_sets with this platform in disable_platforms are skipped.
+
+        Returns:
+            Dictionary mapping source set names to build stage names that use
+            them through artifact groups. Known source sets with no build stage
+            usage are included with an empty list.
+        """
+        stages_by_source_set = {
+            source_set_name: [] for source_set_name in self.source_sets
+        }
+        for stage_name, source_set_names in self.get_stage_to_source_sets(
+            platform=platform
+        ).items():
+            for source_set_name in source_set_names:
+                stages_by_source_set.setdefault(source_set_name, []).append(stage_name)
+        return stages_by_source_set
+
     def get_source_sets(self) -> List[SourceSet]:
         """Get all source sets."""
         return list(self.source_sets.values())

--- a/build_tools/tests/build_topology_test.py
+++ b/build_tools/tests/build_topology_test.py
@@ -405,6 +405,173 @@ class BuildTopologyTest(unittest.TestCase):
         runtime_idx = build_order.index("runtime")
         self.assertLess(compiler_idx, runtime_idx)
 
+    def test_topology_reverse_indexes(self):
+        """Test reverse indexes across source sets, groups, artifacts, and stages."""
+        self.write_topology(
+            """
+            [source_sets.base]
+            description = "Base"
+            submodules = ["base"]
+
+            [source_sets.runtime]
+            description = "Runtime"
+            submodules = ["runtime"]
+
+            [source_sets.tests]
+            description = "Tests"
+            submodules = ["tests"]
+
+            [source_sets.unused]
+            description = "Unused"
+            submodules = ["unused"]
+
+            [build_stages.foundation]
+            description = "Foundation"
+            artifact_groups = ["base"]
+
+            [build_stages.runtime]
+            description = "Runtime"
+            artifact_groups = ["hip", "rocrtst"]
+
+            [artifact_groups.base]
+            description = "Base"
+            type = "generic"
+            source_sets = ["base"]
+
+            [artifact_groups.hip]
+            description = "HIP"
+            type = "generic"
+            source_sets = ["runtime"]
+
+            [artifact_groups.rocrtst]
+            description = "Runtime tests"
+            type = "generic"
+            source_sets = ["runtime", "tests"]
+
+            [artifact_groups.future]
+            description = "Future group"
+            type = "generic"
+            source_sets = ["base"]
+
+            [artifacts.base-artifact]
+            artifact_group = "base"
+            type = "target-neutral"
+
+            [artifacts.hip-artifact]
+            artifact_group = "hip"
+            type = "target-neutral"
+
+            [artifacts.rocrtst-artifact]
+            artifact_group = "rocrtst"
+            type = "target-neutral"
+
+            [artifacts.future-artifact]
+            artifact_group = "future"
+            type = "target-neutral"
+        """
+        )
+
+        topology = BuildTopology(self.topology_path)
+
+        self.assertEqual(
+            topology.get_source_set_to_artifact_groups(),
+            {
+                "base": ["base", "future"],
+                "runtime": ["hip", "rocrtst"],
+                "tests": ["rocrtst"],
+                "unused": [],
+            },
+        )
+        self.assertEqual(
+            topology.get_artifact_group_to_artifacts(),
+            {
+                "base": ["base-artifact"],
+                "hip": ["hip-artifact"],
+                "rocrtst": ["rocrtst-artifact"],
+                "future": ["future-artifact"],
+            },
+        )
+        self.assertEqual(
+            topology.get_artifact_group_to_build_stages(),
+            {
+                "base": ["foundation"],
+                "hip": ["runtime"],
+                "rocrtst": ["runtime"],
+                "future": [],
+            },
+        )
+        self.assertEqual(
+            topology.get_artifact_to_producer_stages(),
+            {
+                "base-artifact": ["foundation"],
+                "hip-artifact": ["runtime"],
+                "rocrtst-artifact": ["runtime"],
+                "future-artifact": [],
+            },
+        )
+        self.assertEqual(
+            topology.get_stage_to_source_sets(),
+            {
+                "foundation": ["base"],
+                "runtime": ["runtime", "tests"],
+            },
+        )
+        self.assertEqual(
+            topology.get_source_set_to_stages(),
+            {
+                "base": ["foundation"],
+                "runtime": ["runtime"],
+                "tests": ["runtime"],
+                "unused": [],
+            },
+        )
+
+    def test_stage_source_set_indexes_filter_disabled_platforms(self):
+        """Test stage/source set indexes respect platform disabled source sets."""
+        self.write_topology(
+            """
+            [source_sets.common]
+            description = "Common"
+            submodules = ["common"]
+
+            [source_sets.windows-only]
+            description = "Windows-only"
+            submodules = ["windows-only"]
+            disable_platforms = ["linux"]
+
+            [build_stages.runtime]
+            description = "Runtime"
+            artifact_groups = ["runtime"]
+
+            [artifact_groups.runtime]
+            description = "Runtime"
+            type = "generic"
+            source_sets = ["common", "windows-only"]
+
+            [artifacts.runtime-artifact]
+            artifact_group = "runtime"
+            type = "target-neutral"
+        """
+        )
+
+        topology = BuildTopology(self.topology_path)
+
+        self.assertEqual(
+            topology.get_stage_to_source_sets(),
+            {"runtime": ["common", "windows-only"]},
+        )
+        self.assertEqual(
+            topology.get_stage_to_source_sets(platform="linux"),
+            {"runtime": ["common"]},
+        )
+        self.assertEqual(
+            topology.get_source_set_to_stages(platform="linux"),
+            {
+                "common": ["runtime"],
+                "windows-only": [],
+            },
+        )
+
     def test_get_dependency_graph(self):
         """Test generating dependency graph."""
         self.write_topology(


### PR DESCRIPTION
## Summary

Add behavior-neutral helper methods to `BuildTopology` for querying reverse and batch mappings from `BUILD_TOPOLOGY.toml`.

This is initial plumbing for the targeted CI work tracked in #5433, where later changes will use topology relationships to reason about affected stages for submodule bump PRs.

## Changes

- Add source set -> artifact groups mapping.
- Add artifact group -> artifacts mapping.
- Add artifact group -> build stages mapping.
- Add artifact -> producer build stages mapping.
- Add build stage -> source sets mapping.
- Add source set -> build stages mapping.
- Add unit coverage for the new helpers, including platform-filtered source set mappings.

## Testing

- `python -B build_tools/tests/build_topology_test.py`
- `pre-commit run --files build_tools/_therock_utils/build_topology.py build_tools/tests/build_topology_test.py`