### PR TITLE
Add baseline run selection helpers

### DIFF
--- a/build_tools/github_actions/baseline_runs.py
+++ b/build_tools/github_actions/baseline_runs.py
@@ -2,7 +2,22 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Helpers for selecting baseline workflow runs for prebuilt artifact reuse."""
+"""Helpers for selecting baseline workflow runs for prebuilt artifact reuse.
+
+Example:
+
+    baseline = select_baseline_run(
+        required_artifacts=[
+            RequiredArtifact("blas", "gfx94X-dcgpu"),
+            RequiredArtifact("base", "generic"),
+        ],
+        platform="linux",
+        exclude_run_ids=[os.environ["GITHUB_RUN_ID"]],
+    )
+    if baseline:
+        # Pass baseline.run_id as the multi-arch CI baseline_run_id.
+        ...
+"""
 
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
@@ -46,8 +61,22 @@ class ArtifactAvailability:
 
 
 @dataclass(frozen=True)
+class WorkflowJobHealth:
+    """Result of checking required workflow jobs in a candidate run."""
+
+    required_name_substrings: tuple[str, ...]
+    matched_job_names: tuple[str, ...]
+    failed_job_names: tuple[str, ...]
+    missing_name_substrings: tuple[str, ...]
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.failed_job_names and not self.missing_name_substrings
+
+
+@dataclass(frozen=True)
 class BaselineRun:
-    """Successful workflow run with artifacts suitable for reuse."""
+    """Workflow run with build jobs and artifacts suitable for reuse."""
 
     run_id: str
     html_url: str
@@ -55,10 +84,12 @@ class BaselineRun:
     branch: str
     workflow_name: str
     platform: str
+    job_health: WorkflowJobHealth
     artifact_availability: ArtifactAvailability
 
 
 ArtifactBackendFactory = Callable[[dict, str, str], ArtifactBackend]
+WorkflowJobsFetcher = Callable[[dict, str], Sequence[dict]]
 
 
 def _dedupe_required_artifacts(
@@ -84,12 +115,74 @@ def _dedupe_required_artifacts(
     return tuple(result)
 
 
+def _dedupe_nonempty_strings(
+    values: Iterable[str],
+    *,
+    field_name: str,
+) -> tuple[str, ...]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(f"{field_name} must contain non-empty values")
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return tuple(result)
+
+
+def is_completed_workflow_run(workflow_run: dict) -> bool:
+    """Return True when a workflow run has completed."""
+    return workflow_run.get("status") == "completed"
+
+
 def is_successful_workflow_run(workflow_run: dict) -> bool:
     """Return True when a workflow run completed successfully."""
     return (
         workflow_run.get("status") == "completed"
         and workflow_run.get("conclusion") == "success"
     )
+
+
+def is_successful_workflow_job(workflow_job: dict) -> bool:
+    """Return True when a workflow job completed successfully."""
+    return (
+        workflow_job.get("status") == "completed"
+        and workflow_job.get("conclusion") == "success"
+    )
+
+
+def query_completed_workflow_runs(
+    *,
+    github_repository: str = "ROCm/TheRock",
+    workflow_name: str = "multi_arch_ci.yml",
+    branch: str = "main",
+    max_runs: int = 20,
+) -> list[dict]:
+    """Query recent completed workflow runs for a workflow and branch."""
+    if max_runs < 1:
+        raise ValueError("max_runs must be at least 1")
+
+    per_page = min(max_runs, 100)
+    workflow_path = quote(workflow_name, safe="")
+    query = urlencode(
+        {
+            "status": "completed",
+            "branch": branch,
+            "per_page": per_page,
+            "sort": "created",
+            "direction": "desc",
+        }
+    )
+    url = (
+        f"https://api.github.com/repos/{github_repository}"
+        f"/actions/workflows/{workflow_path}/runs?{query}"
+    )
+    response = gha_send_request(url)
+    workflow_runs = response.get("workflow_runs", [])
+    return workflow_runs[:max_runs]
 
 
 def query_successful_workflow_runs(
@@ -121,6 +214,52 @@ def query_successful_workflow_runs(
     response = gha_send_request(url)
     workflow_runs = response.get("workflow_runs", [])
     return workflow_runs[:max_runs]
+
+
+def query_workflow_run_jobs(
+    *,
+    github_repository: str = "ROCm/TheRock",
+    run_id: str,
+    run_attempt: int | str | None = None,
+    max_pages: int = 10,
+) -> list[dict]:
+    """Query jobs for a workflow run or a specific run attempt."""
+    if max_pages < 1:
+        raise ValueError("max_pages must be at least 1")
+
+    all_jobs: list[dict] = []
+    for page in range(1, max_pages + 1):
+        if run_attempt is None:
+            url = (
+                f"https://api.github.com/repos/{github_repository}"
+                f"/actions/runs/{run_id}/jobs"
+                f"?filter=latest&per_page=100&page={page}"
+            )
+        else:
+            url = (
+                f"https://api.github.com/repos/{github_repository}"
+                f"/actions/runs/{run_id}/attempts/{run_attempt}/jobs"
+                f"?per_page=100&page={page}"
+            )
+        response = gha_send_request(url)
+        jobs = response.get("jobs", [])
+        all_jobs.extend(jobs)
+        if len(jobs) < 100:
+            break
+    return all_jobs
+
+
+def query_jobs_for_workflow_run(
+    workflow_run: dict,
+    github_repository: str,
+) -> list[dict]:
+    """Query jobs for a workflow run, preferring the run attempt when known."""
+    run_attempt = workflow_run.get("run_attempt")
+    return query_workflow_run_jobs(
+        github_repository=github_repository,
+        run_id=str(workflow_run["id"]),
+        run_attempt=run_attempt,
+    )
 
 
 def create_artifact_backend_for_workflow_run(
@@ -188,6 +327,66 @@ def validate_required_artifacts_available(
     )
 
 
+def _format_job_status(workflow_job: dict) -> str:
+    name = workflow_job.get("name", "unknown")
+    status = workflow_job.get("status", "unknown")
+    conclusion = workflow_job.get("conclusion", "unknown")
+    return f"{name} ({status}/{conclusion})"
+
+
+def validate_required_jobs_successful(
+    *,
+    workflow_jobs: Sequence[dict],
+    required_name_substrings: Iterable[str],
+) -> WorkflowJobHealth:
+    """Validate that matching workflow jobs completed successfully.
+
+    Candidate workflow runs can have failed test jobs while still containing
+    reusable build artifacts. This check lets callers require the relevant
+    build jobs to be healthy without requiring the whole workflow conclusion to
+    be successful.
+    """
+    requirements = _dedupe_nonempty_strings(
+        required_name_substrings,
+        field_name="required_name_substrings",
+    )
+
+    matched: list[str] = []
+    failed: list[str] = []
+    missing: list[str] = []
+    seen_matched: set[str] = set()
+    seen_failed: set[str] = set()
+
+    for requirement in requirements:
+        requirement_matches = [
+            job
+            for job in workflow_jobs
+            if requirement.casefold() in job.get("name", "").casefold()
+        ]
+        if not requirement_matches:
+            missing.append(requirement)
+            continue
+
+        for job in requirement_matches:
+            job_name = job.get("name", "unknown")
+            if job_name not in seen_matched:
+                seen_matched.add(job_name)
+                matched.append(job_name)
+            if is_successful_workflow_job(job):
+                continue
+            job_status = _format_job_status(job)
+            if job_status not in seen_failed:
+                seen_failed.add(job_status)
+                failed.append(job_status)
+
+    return WorkflowJobHealth(
+        required_name_substrings=requirements,
+        matched_job_names=tuple(matched),
+        failed_job_names=tuple(failed),
+        missing_name_substrings=tuple(missing),
+    )
+
+
 def select_baseline_run(
     *,
     required_artifacts: Iterable[RequiredArtifact],
@@ -197,10 +396,12 @@ def select_baseline_run(
     platform: str,
     max_runs: int = 20,
     exclude_run_ids: Iterable[str] = (),
+    required_successful_job_name_substrings: Iterable[str] = ("Build",),
     workflow_runs: Sequence[dict] | None = None,
     backend_factory: ArtifactBackendFactory = create_artifact_backend_for_workflow_run,
+    workflow_jobs_fetcher: WorkflowJobsFetcher = query_jobs_for_workflow_run,
 ) -> BaselineRun | None:
-    """Select the newest successful workflow run with required artifacts.
+    """Select the newest workflow run with healthy build jobs and artifacts.
 
     Args:
         required_artifacts: Artifact/family pairs that must be present in the
@@ -212,24 +413,35 @@ def select_baseline_run(
         max_runs: Maximum workflow runs to inspect.
         exclude_run_ids: Run IDs that must not be selected, such as the
             current workflow run.
+        required_successful_job_name_substrings: Job-name substrings that must
+            match at least one completed successful job in the candidate run.
+            Defaults to ``("Build",)`` so unrelated test failures do not
+            automatically disqualify otherwise reusable build artifacts.
         workflow_runs: Optional pre-fetched candidate runs for testing or for
             callers that already queried GitHub.
         backend_factory: Factory used to create an artifact backend for each
             candidate run.
+        workflow_jobs_fetcher: Factory used to query jobs for each candidate
+            run.
 
     Returns:
-        The first candidate run that completed successfully and has all required
-        artifact/family pairs, or ``None`` if no valid baseline is found.
+        The first completed candidate run that has healthy required jobs and
+        all required artifact/family pairs, or ``None`` if no valid baseline is
+        found.
     """
     # Validate these early so a missing requirement is a caller error instead of
     # being discovered only after GitHub/API work.
     requirements = _dedupe_required_artifacts(required_artifacts)
+    required_jobs = _dedupe_nonempty_strings(
+        required_successful_job_name_substrings,
+        field_name="required_successful_job_name_substrings",
+    )
     excluded = {str(run_id) for run_id in exclude_run_ids}
 
     candidates = (
         list(workflow_runs)
         if workflow_runs is not None
-        else query_successful_workflow_runs(
+        else query_completed_workflow_runs(
             github_repository=github_repository,
             workflow_name=workflow_name,
             branch=branch,
@@ -241,7 +453,14 @@ def select_baseline_run(
         run_id = str(workflow_run["id"])
         if run_id in excluded:
             continue
-        if not is_successful_workflow_run(workflow_run):
+        if not is_completed_workflow_run(workflow_run):
+            continue
+
+        job_health = validate_required_jobs_successful(
+            workflow_jobs=workflow_jobs_fetcher(workflow_run, github_repository),
+            required_name_substrings=required_jobs,
+        )
+        if not job_health.is_valid:
             continue
 
         backend = backend_factory(workflow_run, github_repository, platform)
@@ -259,6 +478,7 @@ def select_baseline_run(
             branch=workflow_run.get("head_branch", branch),
             workflow_name=workflow_name,
             platform=platform,
+            job_health=job_health,
             artifact_availability=availability,
         )
 

--- a/build_tools/github_actions/baseline_runs.py
+++ b/build_tools/github_actions/baseline_runs.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Helpers for selecting baseline workflow runs for prebuilt artifact reuse."""
+
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+from urllib.parse import urlencode, quote
+
+# Add parent directory to path for artifact and _therock_utils imports.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from artifact_manager import ARTIFACT_COMPONENTS
+from _therock_utils.artifact_backend import (
+    ARTIFACT_EXTENSIONS,
+    ArtifactBackend,
+    S3Backend,
+)
+from _therock_utils.workflow_outputs import WorkflowOutputRoot
+
+from github_actions_api import gha_send_request
+
+
+@dataclass(frozen=True)
+class RequiredArtifact:
+    """Artifact archive requirement for one target family."""
+
+    name: str
+    target_family: str
+
+
+@dataclass(frozen=True)
+class ArtifactAvailability:
+    """Result of checking a backend for required artifact archives."""
+
+    required_artifacts: tuple[RequiredArtifact, ...]
+    matched_filenames: tuple[str, ...]
+    missing_artifacts: tuple[RequiredArtifact, ...]
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.missing_artifacts
+
+
+@dataclass(frozen=True)
+class BaselineRun:
+    """Successful workflow run with artifacts suitable for reuse."""
+
+    run_id: str
+    html_url: str
+    head_sha: str
+    branch: str
+    workflow_name: str
+    platform: str
+    artifact_availability: ArtifactAvailability
+
+
+ArtifactBackendFactory = Callable[[dict, str, str], ArtifactBackend]
+
+
+def _dedupe_required_artifacts(
+    required_artifacts: Iterable[RequiredArtifact],
+) -> tuple[RequiredArtifact, ...]:
+    result: list[RequiredArtifact] = []
+    seen: set[RequiredArtifact] = set()
+    for artifact in required_artifacts:
+        normalized = RequiredArtifact(
+            name=artifact.name.strip(),
+            target_family=artifact.target_family.strip(),
+        )
+        if not normalized.name or not normalized.target_family:
+            raise ValueError(
+                "required_artifacts must have non-empty names and target families"
+            )
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    if not result:
+        raise ValueError("required_artifacts must contain at least one value")
+    return tuple(result)
+
+
+def is_successful_workflow_run(workflow_run: dict) -> bool:
+    """Return True when a workflow run completed successfully."""
+    return (
+        workflow_run.get("status") == "completed"
+        and workflow_run.get("conclusion") == "success"
+    )
+
+
+def query_successful_workflow_runs(
+    *,
+    github_repository: str = "ROCm/TheRock",
+    workflow_name: str = "multi_arch_ci.yml",
+    branch: str = "main",
+    max_runs: int = 20,
+) -> list[dict]:
+    """Query recent successful workflow runs for a workflow and branch."""
+    if max_runs < 1:
+        raise ValueError("max_runs must be at least 1")
+
+    per_page = min(max_runs, 100)
+    workflow_path = quote(workflow_name, safe="")
+    query = urlencode(
+        {
+            "status": "success",
+            "branch": branch,
+            "per_page": per_page,
+            "sort": "created",
+            "direction": "desc",
+        }
+    )
+    url = (
+        f"https://api.github.com/repos/{github_repository}"
+        f"/actions/workflows/{workflow_path}/runs?{query}"
+    )
+    response = gha_send_request(url)
+    workflow_runs = response.get("workflow_runs", [])
+    return workflow_runs[:max_runs]
+
+
+def create_artifact_backend_for_workflow_run(
+    workflow_run: dict,
+    github_repository: str,
+    platform: str,
+) -> ArtifactBackend:
+    """Create an artifact backend rooted at a workflow run's output prefix."""
+    run_id = str(workflow_run["id"])
+    output_root = WorkflowOutputRoot.from_workflow_run(
+        run_id=run_id,
+        platform=platform,
+        github_repository=github_repository,
+        workflow_run=workflow_run,
+    )
+    return S3Backend(output_root=output_root)
+
+
+def _find_matching_artifact_archives(
+    required_artifact: RequiredArtifact,
+    available: set[str],
+) -> list[str]:
+    matches: list[str] = []
+    for component in ARTIFACT_COMPONENTS:
+        for extension in ARTIFACT_EXTENSIONS:
+            filename = (
+                f"{required_artifact.name}_{component}_"
+                f"{required_artifact.target_family}{extension}"
+            )
+            if filename in available:
+                matches.append(filename)
+                break
+    return matches
+
+
+def validate_required_artifacts_available(
+    *,
+    backend: ArtifactBackend,
+    required_artifacts: Iterable[RequiredArtifact],
+) -> ArtifactAvailability:
+    """Validate that a backend has archives for each artifact/family pair.
+
+    This mirrors the artifact filename matching used by ``artifact_manager.py``
+    copy/fetch operations. It validates artifact/family presence, not a
+    complete per-component manifest.
+    """
+    requirements = _dedupe_required_artifacts(required_artifacts)
+
+    available = set(backend.list_artifacts())
+    matched: list[str] = []
+    missing: list[RequiredArtifact] = []
+    for required_artifact in requirements:
+        artifact_matches = _find_matching_artifact_archives(
+            required_artifact, available
+        )
+        if artifact_matches:
+            matched.extend(artifact_matches)
+        else:
+            missing.append(required_artifact)
+
+    return ArtifactAvailability(
+        required_artifacts=requirements,
+        matched_filenames=tuple(matched),
+        missing_artifacts=tuple(missing),
+    )
+
+
+def select_baseline_run(
+    *,
+    required_artifacts: Iterable[RequiredArtifact],
+    github_repository: str = "ROCm/TheRock",
+    workflow_name: str = "multi_arch_ci.yml",
+    branch: str = "main",
+    platform: str,
+    max_runs: int = 20,
+    exclude_run_ids: Iterable[str] = (),
+    workflow_runs: Sequence[dict] | None = None,
+    backend_factory: ArtifactBackendFactory = create_artifact_backend_for_workflow_run,
+) -> BaselineRun | None:
+    """Select the newest successful workflow run with required artifacts.
+
+    Args:
+        required_artifacts: Artifact/family pairs that must be present in the
+            baseline run output.
+        github_repository: Repository in ``owner/repo`` format.
+        workflow_name: Workflow filename to search.
+        branch: Branch to search.
+        platform: Artifact platform, e.g. ``linux`` or ``windows``.
+        max_runs: Maximum workflow runs to inspect.
+        exclude_run_ids: Run IDs that must not be selected, such as the
+            current workflow run.
+        workflow_runs: Optional pre-fetched candidate runs for testing or for
+            callers that already queried GitHub.
+        backend_factory: Factory used to create an artifact backend for each
+            candidate run.
+
+    Returns:
+        The first candidate run that completed successfully and has all required
+        artifact/family pairs, or ``None`` if no valid baseline is found.
+    """
+    # Validate these early so a missing requirement is a caller error instead of
+    # being discovered only after GitHub/API work.
+    requirements = _dedupe_required_artifacts(required_artifacts)
+    excluded = {str(run_id) for run_id in exclude_run_ids}
+
+    candidates = (
+        list(workflow_runs)
+        if workflow_runs is not None
+        else query_successful_workflow_runs(
+            github_repository=github_repository,
+            workflow_name=workflow_name,
+            branch=branch,
+            max_runs=max_runs,
+        )
+    )
+
+    for workflow_run in candidates[:max_runs]:
+        run_id = str(workflow_run["id"])
+        if run_id in excluded:
+            continue
+        if not is_successful_workflow_run(workflow_run):
+            continue
+
+        backend = backend_factory(workflow_run, github_repository, platform)
+        availability = validate_required_artifacts_available(
+            backend=backend,
+            required_artifacts=requirements,
+        )
+        if not availability.is_valid:
+            continue
+
+        return BaselineRun(
+            run_id=run_id,
+            html_url=workflow_run.get("html_url", ""),
+            head_sha=workflow_run.get("head_sha", ""),
+            branch=workflow_run.get("head_branch", branch),
+            workflow_name=workflow_name,
+            platform=platform,
+            artifact_availability=availability,
+        )
+
+    return None

--- a/build_tools/github_actions/tests/baseline_runs_test.py
+++ b/build_tools/github_actions/tests/baseline_runs_test.py
@@ -20,6 +20,7 @@ def _workflow_run(
     status: str = "completed",
     conclusion: str | None = "success",
     head_sha: str | None = None,
+    run_attempt: int = 1,
 ) -> dict:
     return {
         "id": run_id,
@@ -28,6 +29,20 @@ def _workflow_run(
         "html_url": f"https://github.com/ROCm/TheRock/actions/runs/{run_id}",
         "head_sha": head_sha or f"sha-{run_id}",
         "head_branch": "main",
+        "run_attempt": run_attempt,
+    }
+
+
+def _workflow_job(
+    name: str,
+    *,
+    status: str = "completed",
+    conclusion: str | None = "success",
+) -> dict:
+    return {
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
     }
 
 
@@ -40,6 +55,14 @@ class FakeBackend:
 
 
 class BaselineRunsTest(unittest.TestCase):
+    def test_is_completed_workflow_run(self):
+        self.assertTrue(baseline_runs.is_completed_workflow_run(_workflow_run("1")))
+        self.assertFalse(
+            baseline_runs.is_completed_workflow_run(
+                _workflow_run("1", status="in_progress", conclusion=None)
+            )
+        )
+
     def test_is_successful_workflow_run(self):
         self.assertTrue(baseline_runs.is_successful_workflow_run(_workflow_run("1")))
         self.assertFalse(
@@ -52,6 +75,49 @@ class BaselineRunsTest(unittest.TestCase):
                 _workflow_run("1", status="in_progress", conclusion=None)
             )
         )
+
+    def test_is_successful_workflow_job(self):
+        self.assertTrue(
+            baseline_runs.is_successful_workflow_job(_workflow_job("Build"))
+        )
+        self.assertFalse(
+            baseline_runs.is_successful_workflow_job(
+                _workflow_job("Build", conclusion="failure")
+            )
+        )
+        self.assertFalse(
+            baseline_runs.is_successful_workflow_job(
+                _workflow_job("Build", status="in_progress", conclusion=None)
+            )
+        )
+
+    def test_query_completed_workflow_runs(self):
+        with mock.patch.object(
+            baseline_runs,
+            "gha_send_request",
+            return_value={
+                "workflow_runs": [
+                    _workflow_run("1"),
+                    _workflow_run("2"),
+                    _workflow_run("3"),
+                ]
+            },
+        ) as mock_send_request:
+            runs = baseline_runs.query_completed_workflow_runs(
+                github_repository="ROCm/TheRock",
+                workflow_name="multi_arch_ci.yml",
+                branch="main",
+                max_runs=2,
+            )
+
+        self.assertEqual([run["id"] for run in runs], ["1", "2"])
+        url = mock_send_request.call_args.args[0]
+        self.assertIn(
+            "/repos/ROCm/TheRock/actions/workflows/multi_arch_ci.yml/runs", url
+        )
+        self.assertIn("status=completed", url)
+        self.assertIn("branch=main", url)
+        self.assertIn("per_page=2", url)
 
     def test_query_successful_workflow_runs(self):
         with mock.patch.object(
@@ -80,6 +146,52 @@ class BaselineRunsTest(unittest.TestCase):
         self.assertIn("status=success", url)
         self.assertIn("branch=main", url)
         self.assertIn("per_page=2", url)
+
+    def test_query_workflow_run_jobs_uses_run_attempt_when_provided(self):
+        with mock.patch.object(
+            baseline_runs,
+            "gha_send_request",
+            return_value={
+                "jobs": [
+                    _workflow_job("Build Multi-Arch Stages"),
+                    _workflow_job("Test hip-tests", conclusion="failure"),
+                ]
+            },
+        ) as mock_send_request:
+            jobs = baseline_runs.query_workflow_run_jobs(
+                github_repository="ROCm/TheRock",
+                run_id="123",
+                run_attempt=4,
+            )
+
+        self.assertEqual(
+            [job["name"] for job in jobs],
+            ["Build Multi-Arch Stages", "Test hip-tests"],
+        )
+        url = mock_send_request.call_args.args[0]
+        self.assertIn("/actions/runs/123/attempts/4/jobs", url)
+
+    def test_query_workflow_run_jobs_paginates_latest_jobs(self):
+        with mock.patch.object(
+            baseline_runs,
+            "gha_send_request",
+            side_effect=[
+                {"jobs": [_workflow_job(f"Build {i}") for i in range(100)]},
+                {"jobs": [_workflow_job("Build final")]},
+            ],
+        ) as mock_send_request:
+            jobs = baseline_runs.query_workflow_run_jobs(
+                github_repository="ROCm/TheRock",
+                run_id="123",
+            )
+
+        self.assertEqual(len(jobs), 101)
+        first_url = mock_send_request.call_args_list[0].args[0]
+        second_url = mock_send_request.call_args_list[1].args[0]
+        self.assertIn("/actions/runs/123/jobs", first_url)
+        self.assertIn("filter=latest", first_url)
+        self.assertIn("page=1", first_url)
+        self.assertIn("page=2", second_url)
 
     def test_validate_required_artifacts_available(self):
         backend = FakeBackend(
@@ -163,7 +275,53 @@ class BaselineRunsTest(unittest.TestCase):
             (RequiredArtifact("blas", "gfx120X-all"),),
         )
 
-    def test_select_baseline_run_uses_first_successful_run_with_artifacts(self):
+    def test_validate_required_jobs_successful(self):
+        job_health = baseline_runs.validate_required_jobs_successful(
+            workflow_jobs=[
+                _workflow_job("Build Multi-Arch Stages / linux"),
+                _workflow_job("Build Multi-Arch Stages / windows"),
+                _workflow_job("Test hip-tests", conclusion="failure"),
+            ],
+            required_name_substrings=["Build Multi-Arch Stages"],
+        )
+
+        self.assertTrue(job_health.is_valid)
+        self.assertEqual(
+            job_health.matched_job_names,
+            (
+                "Build Multi-Arch Stages / linux",
+                "Build Multi-Arch Stages / windows",
+            ),
+        )
+        self.assertEqual(job_health.failed_job_names, ())
+        self.assertEqual(job_health.missing_name_substrings, ())
+
+    def test_validate_required_jobs_successful_reports_failed_and_missing_jobs(self):
+        job_health = baseline_runs.validate_required_jobs_successful(
+            workflow_jobs=[
+                _workflow_job(
+                    "Build Multi-Arch Stages / linux",
+                    conclusion="failure",
+                ),
+                _workflow_job("Test hip-tests"),
+            ],
+            required_name_substrings=[
+                "Build Multi-Arch Stages",
+                "Build Python Packages",
+            ],
+        )
+
+        self.assertFalse(job_health.is_valid)
+        self.assertEqual(
+            job_health.failed_job_names,
+            ("Build Multi-Arch Stages / linux (completed/failure)",),
+        )
+        self.assertEqual(
+            job_health.missing_name_substrings,
+            ("Build Python Packages",),
+        )
+
+    def test_select_baseline_run_uses_failed_workflow_with_healthy_build_jobs(self):
         runs = [
             _workflow_run("current"),
             _workflow_run("missing-artifacts"),
@@ -181,9 +339,20 @@ class BaselineRunsTest(unittest.TestCase):
                 "blas_lib_gfx94X-dcgpu.tar.zst",
             ],
         }
+        jobs_by_run_id = {
+            "missing-artifacts": [_workflow_job("Build Multi-Arch Stages")],
+            "failed": [
+                _workflow_job("Build Multi-Arch Stages"),
+                _workflow_job("Test hip-tests", conclusion="failure"),
+            ],
+            "usable": [_workflow_job("Build Multi-Arch Stages")],
+        }
 
         def backend_factory(workflow_run, github_repository, platform):
             return FakeBackend(artifacts_by_run_id.get(workflow_run["id"], []))
+
+        def workflow_jobs_fetcher(workflow_run, github_repository):
+            return jobs_by_run_id.get(workflow_run["id"], [])
 
         baseline = baseline_runs.select_baseline_run(
             required_artifacts=[
@@ -195,16 +364,63 @@ class BaselineRunsTest(unittest.TestCase):
             branch="main",
             platform="linux",
             exclude_run_ids=["current"],
+            required_successful_job_name_substrings=["Build Multi-Arch Stages"],
             workflow_runs=runs,
             backend_factory=backend_factory,
+            workflow_jobs_fetcher=workflow_jobs_fetcher,
+        )
+
+        self.assertIsNotNone(baseline)
+        assert baseline is not None
+        self.assertEqual(baseline.run_id, "failed")
+        self.assertEqual(baseline.head_sha, "sha-failed")
+        self.assertEqual(baseline.platform, "linux")
+        self.assertEqual(baseline.job_health.failed_job_names, ())
+        self.assertEqual(baseline.artifact_availability.missing_artifacts, ())
+
+    def test_select_baseline_run_skips_run_when_required_build_job_failed(self):
+        runs = [
+            _workflow_run("failed-build", conclusion="failure"),
+            _workflow_run("usable"),
+        ]
+        artifacts_by_run_id = {
+            "failed-build": [
+                "base_lib_generic.tar.zst",
+                "blas_lib_gfx94X-dcgpu.tar.zst",
+            ],
+            "usable": [
+                "base_lib_generic.tar.zst",
+                "blas_lib_gfx94X-dcgpu.tar.zst",
+            ],
+        }
+        jobs_by_run_id = {
+            "failed-build": [
+                _workflow_job("Build Multi-Arch Stages", conclusion="failure")
+            ],
+            "usable": [_workflow_job("Build Multi-Arch Stages")],
+        }
+
+        def backend_factory(workflow_run, github_repository, platform):
+            return FakeBackend(artifacts_by_run_id.get(workflow_run["id"], []))
+
+        def workflow_jobs_fetcher(workflow_run, github_repository):
+            return jobs_by_run_id.get(workflow_run["id"], [])
+
+        baseline = baseline_runs.select_baseline_run(
+            required_artifacts=[
+                RequiredArtifact("base", "generic"),
+                RequiredArtifact("blas", "gfx94X-dcgpu"),
+            ],
+            platform="linux",
+            required_successful_job_name_substrings=["Build Multi-Arch Stages"],
+            workflow_runs=runs,
+            backend_factory=backend_factory,
+            workflow_jobs_fetcher=workflow_jobs_fetcher,
         )
 
         self.assertIsNotNone(baseline)
         assert baseline is not None
         self.assertEqual(baseline.run_id, "usable")
-        self.assertEqual(baseline.head_sha, "sha-usable")
-        self.assertEqual(baseline.platform, "linux")
-        self.assertEqual(baseline.artifact_availability.missing_artifacts, ())
 
     def test_select_baseline_run_returns_none_when_no_candidate_is_valid(self):
         runs = [
@@ -215,11 +431,15 @@ class BaselineRunsTest(unittest.TestCase):
         def backend_factory(workflow_run, github_repository, platform):
             return FakeBackend([])
 
+        def workflow_jobs_fetcher(workflow_run, github_repository):
+            return []
+
         baseline = baseline_runs.select_baseline_run(
             required_artifacts=[RequiredArtifact("base", "generic")],
             platform="linux",
             workflow_runs=runs,
             backend_factory=backend_factory,
+            workflow_jobs_fetcher=workflow_jobs_fetcher,
         )
 
         self.assertIsNone(baseline)

--- a/build_tools/github_actions/tests/baseline_runs_test.py
+++ b/build_tools/github_actions/tests/baseline_runs_test.py
@@ -1,0 +1,229 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+import baseline_runs
+
+RequiredArtifact = baseline_runs.RequiredArtifact
+
+
+def _workflow_run(
+    run_id: str,
+    *,
+    status: str = "completed",
+    conclusion: str | None = "success",
+    head_sha: str | None = None,
+) -> dict:
+    return {
+        "id": run_id,
+        "status": status,
+        "conclusion": conclusion,
+        "html_url": f"https://github.com/ROCm/TheRock/actions/runs/{run_id}",
+        "head_sha": head_sha or f"sha-{run_id}",
+        "head_branch": "main",
+    }
+
+
+class FakeBackend:
+    def __init__(self, artifacts: list[str]):
+        self._artifacts = artifacts
+
+    def list_artifacts(self):
+        return list(self._artifacts)
+
+
+class BaselineRunsTest(unittest.TestCase):
+    def test_is_successful_workflow_run(self):
+        self.assertTrue(baseline_runs.is_successful_workflow_run(_workflow_run("1")))
+        self.assertFalse(
+            baseline_runs.is_successful_workflow_run(
+                _workflow_run("1", conclusion="failure")
+            )
+        )
+        self.assertFalse(
+            baseline_runs.is_successful_workflow_run(
+                _workflow_run("1", status="in_progress", conclusion=None)
+            )
+        )
+
+    def test_query_successful_workflow_runs(self):
+        with mock.patch.object(
+            baseline_runs,
+            "gha_send_request",
+            return_value={
+                "workflow_runs": [
+                    _workflow_run("1"),
+                    _workflow_run("2"),
+                    _workflow_run("3"),
+                ]
+            },
+        ) as mock_send_request:
+            runs = baseline_runs.query_successful_workflow_runs(
+                github_repository="ROCm/TheRock",
+                workflow_name="multi_arch_ci.yml",
+                branch="main",
+                max_runs=2,
+            )
+
+        self.assertEqual([run["id"] for run in runs], ["1", "2"])
+        url = mock_send_request.call_args.args[0]
+        self.assertIn(
+            "/repos/ROCm/TheRock/actions/workflows/multi_arch_ci.yml/runs", url
+        )
+        self.assertIn("status=success", url)
+        self.assertIn("branch=main", url)
+        self.assertIn("per_page=2", url)
+
+    def test_validate_required_artifacts_available(self):
+        backend = FakeBackend(
+            [
+                "base_lib_generic.tar.zst",
+                "blas_lib_gfx94X-dcgpu.tar.zst",
+                "blas_dev_gfx94X-dcgpu.tar.xz",
+                "unrelated_lib_generic.tar.zst",
+            ]
+        )
+
+        availability = baseline_runs.validate_required_artifacts_available(
+            backend=backend,
+            required_artifacts=[
+                RequiredArtifact("base", "generic"),
+                RequiredArtifact("blas", "gfx94X-dcgpu"),
+            ],
+        )
+
+        self.assertTrue(availability.is_valid)
+        self.assertEqual(availability.missing_artifacts, ())
+        self.assertEqual(
+            availability.matched_filenames,
+            (
+                "base_lib_generic.tar.zst",
+                "blas_lib_gfx94X-dcgpu.tar.zst",
+                "blas_dev_gfx94X-dcgpu.tar.xz",
+            ),
+        )
+
+    def test_validate_required_artifacts_available_reports_missing_names(self):
+        backend = FakeBackend(["blas_lib_gfx94X-dcgpu.tar.zst"])
+
+        availability = baseline_runs.validate_required_artifacts_available(
+            backend=backend,
+            required_artifacts=[
+                RequiredArtifact("blas", "gfx94X-dcgpu"),
+                RequiredArtifact("rand", "gfx94X-dcgpu"),
+            ],
+        )
+
+        self.assertFalse(availability.is_valid)
+        self.assertEqual(
+            availability.missing_artifacts,
+            (RequiredArtifact("rand", "gfx94X-dcgpu"),),
+        )
+        self.assertEqual(
+            availability.matched_filenames,
+            ("blas_lib_gfx94X-dcgpu.tar.zst",),
+        )
+
+    def test_validate_required_artifacts_requires_nonempty_requirements(self):
+        backend = FakeBackend(["blas_lib_gfx94X-dcgpu.tar.zst"])
+
+        with self.assertRaisesRegex(ValueError, "required_artifacts"):
+            baseline_runs.validate_required_artifacts_available(
+                backend=backend,
+                required_artifacts=[],
+            )
+
+        with self.assertRaisesRegex(ValueError, "non-empty"):
+            baseline_runs.validate_required_artifacts_available(
+                backend=backend,
+                required_artifacts=[RequiredArtifact("blas", "")],
+            )
+
+    def test_validate_required_artifacts_checks_each_target_family(self):
+        backend = FakeBackend(["blas_lib_gfx94X-dcgpu.tar.zst"])
+
+        availability = baseline_runs.validate_required_artifacts_available(
+            backend=backend,
+            required_artifacts=[
+                RequiredArtifact("blas", "gfx94X-dcgpu"),
+                RequiredArtifact("blas", "gfx120X-all"),
+            ],
+        )
+
+        self.assertFalse(availability.is_valid)
+        self.assertEqual(
+            availability.missing_artifacts,
+            (RequiredArtifact("blas", "gfx120X-all"),),
+        )
+
+    def test_select_baseline_run_uses_first_successful_run_with_artifacts(self):
+        runs = [
+            _workflow_run("current"),
+            _workflow_run("missing-artifacts"),
+            _workflow_run("failed", conclusion="failure"),
+            _workflow_run("usable"),
+        ]
+        artifacts_by_run_id = {
+            "missing-artifacts": ["base_lib_generic.tar.zst"],
+            "failed": [
+                "base_lib_generic.tar.zst",
+                "blas_lib_gfx94X-dcgpu.tar.zst",
+            ],
+            "usable": [
+                "base_lib_generic.tar.zst",
+                "blas_lib_gfx94X-dcgpu.tar.zst",
+            ],
+        }
+
+        def backend_factory(workflow_run, github_repository, platform):
+            return FakeBackend(artifacts_by_run_id.get(workflow_run["id"], []))
+
+        baseline = baseline_runs.select_baseline_run(
+            required_artifacts=[
+                RequiredArtifact("base", "generic"),
+                RequiredArtifact("blas", "gfx94X-dcgpu"),
+            ],
+            github_repository="ROCm/TheRock",
+            workflow_name="multi_arch_ci.yml",
+            branch="main",
+            platform="linux",
+            exclude_run_ids=["current"],
+            workflow_runs=runs,
+            backend_factory=backend_factory,
+        )
+
+        self.assertIsNotNone(baseline)
+        assert baseline is not None
+        self.assertEqual(baseline.run_id, "usable")
+        self.assertEqual(baseline.head_sha, "sha-usable")
+        self.assertEqual(baseline.platform, "linux")
+        self.assertEqual(baseline.artifact_availability.missing_artifacts, ())
+
+    def test_select_baseline_run_returns_none_when_no_candidate_is_valid(self):
+        runs = [
+            _workflow_run("failed", conclusion="failure"),
+            _workflow_run("missing-artifacts"),
+        ]
+
+        def backend_factory(workflow_run, github_repository, platform):
+            return FakeBackend([])
+
+        baseline = baseline_runs.select_baseline_run(
+            required_artifacts=[RequiredArtifact("base", "generic")],
+            platform="linux",
+            workflow_runs=runs,
+            backend_factory=backend_factory,
+        )
+
+        self.assertIsNone(baseline)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add behavior-neutral helpers for selecting a successful baseline workflow run with reusable artifacts.

This is groundwork for the targeted CI work tracked in #5433. No workflow behavior changes in this PR.

## Flow

```mermaid
flowchart TD
    A[Required artifact/family pairs] --> B[Query successful workflow runs]
    B --> C[Skip excluded runs]
    C --> D[Create artifact backend for candidate run]
    D --> E[List available artifacts]
    E --> F{All required pairs present?}
    F -- No --> B
    F -- Yes --> G[Return BaselineRun]
    B --> H[No valid candidate]
    H --> I[Return None]
```

## Changes

- Add `RequiredArtifact`, `ArtifactAvailability`, and `BaselineRun` data structures.
- Add helper to query recent successful workflow runs for a workflow and branch.
- Add artifact availability validation for required artifact/family pairs.
- Add baseline selection that skips excluded runs and returns the newest successful run with all required artifacts.
- Add mocked unit tests for run filtering, artifact availability, missing families, and baseline selection.

## Testing

- `python -B build_tools/github_actions/tests/baseline_runs_test.py`
- `pre-commit run --files build_tools/github_actions/baseline_runs.py build_tools/github_actions/tests/baseline_runs_test.py`