### PR TITLE
Document triton_windows for nightly PyTorch

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -279,10 +279,6 @@ print(torch.cuda.get_device_name(0))
 See [external-builds/pytorch/README.md](/external-builds/pytorch/README.md) for
 more details on supported PyTorch versions and building from source.
 
-On Windows, multi-arch nightly builds also publish **`triton_windows`** to
-`https://rocm.nightlies.amd.com/v4/whl/triton_windows/`. Install it explicitly if
-you are not using a `torch` wheel that already declares the dependency.
-
 ### Installing multi-arch tarballs
 
 Standalone "ROCm SDK tarballs" are a flattened view of ROCm
@@ -715,23 +711,7 @@ also install `torch`, `torchaudio`, `torchvision`, and `apex`.
 > pip uninstall pytorch-triton-rocm
 > ```
 >
-> The triton package is now named `triton` on Linux.
-
-> [!NOTE]
-> **Triton on Windows:** Nightly `torch` wheels from TheRock declare a dependency
-> on **`triton_windows`** (not `triton`). `pip install torch ...` from a Windows
-> per-family index installs both packages. The distribution name differs from Linux
-> because Windows builds use [triton-windows](https://github.com/triton-lang/triton-windows);
-> the Python import name is still `triton`, which enables `torch.compile`.
-> Triton is included on **nightly** Windows builds only; stable `release/*` wheels
-> may not publish `triton_windows` yet. See
-> [external-builds/pytorch/README.md](/external-builds/pytorch/README.md#triton-on-windows).
->
-> TheRock wheels add `triton` (Linux) or `triton_windows` (Windows) to the
-> `torch` package install requirements so one `pip install torch …` pulls the
-> matching Triton build. Upstream PyTorch ROCm wheels do not do this. To install
-> Triton separately, use the same index URL and package name, for example
-> `pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ triton_windows`.
+> The triton package is now named `triton`.
 
 ##### torch for gfx94X-dcgpu
 
@@ -790,7 +770,6 @@ Supported devices in this family:
 pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ torch torchaudio torchvision
 # Optional additional packages on Linux:
 #   apex
-# On Windows nightly indices, triton_windows is installed automatically with torch.
 ```
 
 ##### torch for gfx120X-all

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -279,6 +279,10 @@ print(torch.cuda.get_device_name(0))
 See [external-builds/pytorch/README.md](/external-builds/pytorch/README.md) for
 more details on supported PyTorch versions and building from source.
 
+On Windows, multi-arch nightly builds also publish **`triton_windows`** to
+`https://rocm.nightlies.amd.com/v4/whl/triton_windows/`. Install it explicitly if
+you are not using a `torch` wheel that already declares the dependency.
+
 ### Installing multi-arch tarballs
 
 Standalone "ROCm SDK tarballs" are a flattened view of ROCm
@@ -711,7 +715,23 @@ also install `torch`, `torchaudio`, `torchvision`, and `apex`.
 > pip uninstall pytorch-triton-rocm
 > ```
 >
-> The triton package is now named `triton`.
+> The triton package is now named `triton` on Linux.
+
+> [!NOTE]
+> **Triton on Windows:** Nightly `torch` wheels from TheRock declare a dependency
+> on **`triton_windows`** (not `triton`). `pip install torch ...` from a Windows
+> per-family index installs both packages. The distribution name differs from Linux
+> because Windows builds use [triton-windows](https://github.com/triton-lang/triton-windows);
+> the Python import name is still `triton`, which enables `torch.compile`.
+> Triton is included on **nightly** Windows builds only; stable `release/*` wheels
+> may not publish `triton_windows` yet. See
+> [external-builds/pytorch/README.md](/external-builds/pytorch/README.md#triton-on-windows).
+>
+> TheRock wheels add `triton` (Linux) or `triton_windows` (Windows) to the
+> `torch` package install requirements so one `pip install torch …` pulls the
+> matching Triton build. Upstream PyTorch ROCm wheels do not do this. To install
+> Triton separately, use the same index URL and package name, for example
+> `pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ triton_windows`.
 
 ##### torch for gfx94X-dcgpu
 
@@ -770,6 +790,7 @@ Supported devices in this family:
 pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ torch torchaudio torchvision
 # Optional additional packages on Linux:
 #   apex
+# On Windows nightly indices, triton_windows is installed automatically with torch.
 ```
 
 ##### torch for gfx120X-all

--- a/docs/development/github_actions_debugging.md
+++ b/docs/development/github_actions_debugging.md
@@ -68,6 +68,76 @@ to the dev bucket. You might also need to upload dependent packages or
 [re]generate release index pages, for which you can see the documentation at
 [`build_tools/third_party/s3_management/README.md`](/build_tools/third_party/s3_management/README.md).
 
+### Testing Windows PyTorch release workflows
+
+The Windows counterpart is
+[`.github/workflows/build_windows_pytorch_wheels.yml`](/.github/workflows/build_windows_pytorch_wheels.yml).
+It follows the same staging → test → promote pattern as the Linux workflow:
+
+1. Installs ROCm packages that have already been built
+2. Checks out PyTorch sources (`nightly` from upstream, or `release/*` from
+   [ROCm/pytorch](https://github.com/ROCm/pytorch))
+3. Builds `torch`, `torchaudio`, and `torchvision`; for **`pytorch_git_ref: nightly`**
+   also builds **`triton_windows`** via [triton-windows](https://github.com/triton-lang/triton-windows)
+4. Uploads wheels to a staging directory in the release index
+5. Runs [`test_pytorch_wheels.yml`](/.github/workflows/test_pytorch_wheels.yml)
+6. Copies the tested wheels from staging to the final per-family index
+
+This should be performed using a **"dev"** release with the
+`therock-dev-python` bucket and https://rocm.devreleases.amd.com/ index, same as
+the [Linux PyTorch workflow](#testing-pytorch-release-workflows) above.
+
+Follow these steps:
+
+1. Identify the ROCm package version to build against. You can find recent versions in a nightly release index
+   such as https://rocm.nightlies.amd.com/v2/gfx1151/rocm/ (match
+   `amdgpu_family` to the family you will build for).
+
+2. Copy that version from the nightly bucket to the dev bucket by triggering
+   [copy_release.yml](https://github.com/ROCm/TheRock/actions/workflows/copy_release.yml)
+   twice: once with `destsubdir` `v2` and again with `v2-staging`.
+
+3. Trigger
+   [build_windows_pytorch_wheels.yml](https://github.com/ROCm/TheRock/actions/workflows/build_windows_pytorch_wheels.yml)
+   from the branch you want. Keep the default **dev** release type, enter your
+   ROCm version and `amdgpu_family`, and set `pytorch_git_ref` to `nightly` if
+   you need a `triton_windows` wheel (stable `release/*` refs do not build
+   Triton in this workflow today).
+
+#### Windows workflow details (Triton)
+
+When `pytorch_git_ref` is `nightly`, the build job also:
+
+1. Runs `pytorch_triton_repo.py checkout` into `CHECKOUT_ROOT/triton`.
+1. Passes `--triton-dir … --build-triton` to `build_prod_wheels.py` (via
+   `TRITON_BUILD_ARGS`).
+
+After the wheel build, these steps must see a `triton_windows-*.whl` in the dist
+directory:
+
+| Step | Script / action | Triton-related expectation |
+| ---- | ----------------- | -------------------------- |
+| Record versions | [`write_torch_versions.py`](/build_tools/github_actions/write_torch_versions.py) | Finds `triton_windows-*.whl` and sets `triton_version` (required for Windows when `PYTORCH_GIT_REF=nightly`) |
+| Manifest | [`generate_pytorch_manifest.py`](/build_tools/github_actions/generate_pytorch_manifest.py) | Pass `--triton-dir ${CHECKOUT_ROOT}/triton` so `sources.triton` is recorded |
+| Staging upload | `aws s3 cp … --include "*.whl"` | Uploads all built wheels including `triton_windows` |
+| Promote to release index | Copy step in same workflow | Copies `triton_windows-${TRITON_VERSION}-…whl` with `torch` / `torchaudio` / `torchvision` |
+
+Browse staged or released wheels under paths like
+`https://rocm.nightlies.amd.com/v2/gfx1151/triton_windows/` (per-family) or
+`https://rocm.nightlies.amd.com/v4/whl/triton_windows/` (multi-arch).
+
+> [!NOTE]
+> [`build_windows_pytorch_wheels_ci.yml`](/.github/workflows/build_windows_pytorch_wheels_ci.yml)
+> (per-commit CI) still builds `torch` only, not `triton_windows`. See
+> [Issue #3291](https://github.com/ROCm/TheRock/issues/3291).
+>
+> [`test_pytorch_wheels.yml`](/.github/workflows/test_pytorch_wheels.yml) runs
+> general PyTorch tests, not a dedicated Triton test suite.
+
+Multi-arch Windows PyTorch releases use
+[`.github/workflows/multi_arch_release_windows_pytorch_wheels.yml`](/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml)
+and publish to `v4/whl/` (including `triton_windows` for nightly refs).
+
 ## Connecting to Kubernetes runners for interactive debugging
 
 While we don't have anything as sophisticated as
@@ -176,6 +246,12 @@ cmake --build "B:\build" --target MIOpen+dist
 
 - https://github.com/ROCm/TheRock/issues/840: Builds hitting 6 hour timeouts
 - https://github.com/ROCm/TheRock/issues/1407: Flaky compiler crashes during builds
+- https://github.com/ROCm/TheRock/issues/827: Windows PyTorch wheel builds use
+  MSVC (`ilammy/msvc-dev-cmd`) during the build step; the Triton build must run
+  under `cmd`, not `bash`. The workflow enables Windows long paths before tests.
+- Windows wheel install failures with `WinError 206` (path too long): enable long
+  paths on the runner; see
+  [Windows support — long paths](./windows_support.md#important-tool-settings).
 
 ## Working effectively from forks
 

--- a/docs/development/github_actions_debugging.md
+++ b/docs/development/github_actions_debugging.md
@@ -68,63 +68,12 @@ to the dev bucket. You might also need to upload dependent packages or
 [re]generate release index pages, for which you can see the documentation at
 [`build_tools/third_party/s3_management/README.md`](/build_tools/third_party/s3_management/README.md).
 
-### Testing Windows PyTorch release workflows
-
-The Windows counterpart is
-[`.github/workflows/build_windows_pytorch_wheels.yml`](/.github/workflows/build_windows_pytorch_wheels.yml).
-It follows the same staging → test → promote pattern as the Linux workflow:
-
-1. Installs ROCm packages that have already been built
-2. Checks out PyTorch sources (`nightly` from upstream, or `release/*` from
-   [ROCm/pytorch](https://github.com/ROCm/pytorch))
-3. Builds `torch`, `torchaudio`, and `torchvision`; for **`pytorch_git_ref: nightly`**
-   also builds **`triton_windows`** via [triton-windows](https://github.com/triton-lang/triton-windows)
-4. Uploads wheels to a staging directory in the release index
-5. Runs [`test_pytorch_wheels.yml`](/.github/workflows/test_pytorch_wheels.yml)
-6. Copies the tested wheels from staging to the final per-family index
-
-This should be performed using a **"dev"** release with the
-`therock-dev-python` bucket and https://rocm.devreleases.amd.com/ index, same as
-the [Linux PyTorch workflow](#testing-pytorch-release-workflows) above.
-
-Follow these steps:
-
-1. Identify the ROCm package version to build against. You can find recent versions in a nightly release index
-   such as https://rocm.nightlies.amd.com/v2/gfx1151/rocm/ (match
-   `amdgpu_family` to the family you will build for).
-
-2. Copy that version from the nightly bucket to the dev bucket by triggering
-   [copy_release.yml](https://github.com/ROCm/TheRock/actions/workflows/copy_release.yml)
-   twice: once with `destsubdir` `v2` and again with `v2-staging`.
-
-3. Trigger
-   [build_windows_pytorch_wheels.yml](https://github.com/ROCm/TheRock/actions/workflows/build_windows_pytorch_wheels.yml)
-   from the branch you want. Keep the default **dev** release type, enter your
-   ROCm version and `amdgpu_family`, and set `pytorch_git_ref` to `nightly` if
-   you need a `triton_windows` wheel (stable `release/*` refs do not build
-   Triton in this workflow today).
-
-#### Windows workflow details (Triton)
-
-When `pytorch_git_ref` is `nightly`, the build job also:
-
-1. Runs `pytorch_triton_repo.py checkout` into `CHECKOUT_ROOT/triton`.
-1. Passes `--triton-dir … --build-triton` to `build_prod_wheels.py` (via
-   `TRITON_BUILD_ARGS`).
-
-After the wheel build, these steps must see a `triton_windows-*.whl` in the dist
-directory:
-
-| Step | Script / action | Triton-related expectation |
-| ---- | ----------------- | -------------------------- |
-| Record versions | [`write_torch_versions.py`](/build_tools/github_actions/write_torch_versions.py) | Finds `triton_windows-*.whl` and sets `triton_version` (required for Windows when `PYTORCH_GIT_REF=nightly`) |
-| Manifest | [`generate_pytorch_manifest.py`](/build_tools/github_actions/generate_pytorch_manifest.py) | Pass `--triton-dir ${CHECKOUT_ROOT}/triton` so `sources.triton` is recorded |
-| Staging upload | `aws s3 cp … --include "*.whl"` | Uploads all built wheels including `triton_windows` |
-| Promote to release index | Copy step in same workflow | Copies `triton_windows-${TRITON_VERSION}-…whl` with `torch` / `torchaudio` / `torchvision` |
-
-Browse staged or released wheels under paths like
-`https://rocm.nightlies.amd.com/v2/gfx1151/triton_windows/` (per-family) or
-`https://rocm.nightlies.amd.com/v4/whl/triton_windows/` (multi-arch).
+For Windows, use the same flow with
+[`.github/workflows/build_windows_pytorch_wheels.yml`](/.github/workflows/build_windows_pytorch_wheels.yml)
+instead of the Linux workflow linked above. Use a "dev" release, set
+`amdgpu_family` for your target family, and set `pytorch_git_ref: nightly` if
+you need `triton_windows` (stable `release/*` refs currently build
+`torch`/`torchaudio`/`torchvision` without Triton).
 
 > [!NOTE]
 > [`build_windows_pytorch_wheels_ci.yml`](/.github/workflows/build_windows_pytorch_wheels_ci.yml)
@@ -136,7 +85,8 @@ Browse staged or released wheels under paths like
 
 Multi-arch Windows PyTorch releases use
 [`.github/workflows/multi_arch_release_windows_pytorch_wheels.yml`](/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml)
-and publish to `v4/whl/` (including `triton_windows` for nightly refs).
+and publish to https://rocm.nightlies.amd.com/whl-multi-arch/ (including
+`triton_windows` for nightly refs).
 
 ## Connecting to Kubernetes runners for interactive debugging
 

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -339,13 +339,13 @@ and require MSVC (Developer Command Prompt) plus a one-time download of a pinned
 LLVM toolchain; see
 [Triton on Windows](../../external-builds/pytorch/README.md#triton-on-windows).
 
-**Installing nightly wheels:** Use a per-family index at
-`https://rocm.nightlies.amd.com/v2/<amdgpu-family>/` (for example `gfx1151` for
-Strix Halo). Example:
+**Installing nightly wheels:** Use the unified multi-arch index at
+`https://rocm.nightlies.amd.com/whl-multi-arch/` and select your GPU target
+with device extras (for example `gfx1151` for Strix Halo). Example:
 
 ```powershell
-pip install --pre --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ `
-  torch torchaudio torchvision
+pip install --pre --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ `
+  "torch[device-gfx1151]" "torchvision[device-gfx1151]" torchaudio
 # triton_windows is pulled in automatically for nightly torch wheels
 ```
 

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -333,10 +333,10 @@ or by downloading from one of TheRock's release indices. See the instructions at
 [external-builds/pytorch](../../external-builds/pytorch/README.md).
 
 **Triton (`triton_windows`) on Windows:** Nightly PyTorch wheels built by TheRock
-include Triton for `torch.compile`. The wheel is published as **`triton_windows`**
+include Triton for `torch.compile` and sage-attention v1. The wheel is published as **`triton_windows`**
 (import `triton`). Local builds use [triton-windows](https://github.com/triton-lang/triton-windows)
-and require MSVC (Developer Command Prompt) plus a one-time download of a pinned
-LLVM toolchain; see
+and a one-time download of a pinned LLVM toolchain (see [Install tools](#install-tools)
+for MSVC); see
 [Triton on Windows](../../external-builds/pytorch/README.md#triton-on-windows).
 
 **Installing nightly wheels:** Use the unified multi-arch index at

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -332,6 +332,23 @@ PyTorch builds require Python wheels, either by building from source (see above)
 or by downloading from one of TheRock's release indices. See the instructions at
 [external-builds/pytorch](../../external-builds/pytorch/README.md).
 
+**Triton (`triton_windows`) on Windows:** Nightly PyTorch wheels built by TheRock
+include Triton for `torch.compile`. The wheel is published as **`triton_windows`**
+(import `triton`). Local builds use [triton-windows](https://github.com/triton-lang/triton-windows)
+and require MSVC (Developer Command Prompt) plus a one-time download of a pinned
+LLVM toolchain; see
+[Triton on Windows](../../external-builds/pytorch/README.md#triton-on-windows).
+
+**Installing nightly wheels:** Use a per-family index at
+`https://rocm.nightlies.amd.com/v2/<amdgpu-family>/` (for example `gfx1151` for
+Strix Halo). Example:
+
+```powershell
+pip install --pre --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ `
+  torch torchaudio torchvision
+# triton_windows is pulled in automatically for nightly torch wheels
+```
+
 ### Run tests
 
 Test builds can be enabled with `-DBUILD_TESTING=ON` (the default).

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -161,9 +161,8 @@ checkout (pin in
 extra local segments use `-` after the single `+` (see comments in
 `build_triton_linux()`). CI builds `triton_windows` only for
 `pytorch_git_ref: nightly`.
-Per-family CI uploads to `v2-staging/<family>/triton_windows/` for testing, then
-promotes to `v2/<family>/triton_windows/` on the release index. Multi-arch
-releases use `v4/whl/triton_windows/`.
+Windows `triton_windows` wheels are published on the multi-arch index at
+`https://rocm.nightlies.amd.com/whl-multi-arch/`.
 
 #### JAX versions
 

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -151,6 +151,19 @@ The scripts produce these versions for each distribution channel:
 | torchaudio   | `2.9.0+rocm7.10.0`                        | `2.10.0a0+rocm7.10.0a20251024`              |
 | torchvision  | `0.24.0+rocm7.10.0`                       | `0.24.0+rocm7.11.0a20251124`                |
 | triton       | `3.3.1+rocm7.10.0`                        | `3.5.1+rocm7.11.0a20251124`                 |
+| triton_windows | — (not built for stable `release/*` on Windows yet) | `3.6.0+git6fe895f6-rocm7.13.0a20260424` |
+
+On Windows, [`build_prod_wheels.py`](/external-builds/pytorch/build_prod_wheels.py)
+appends the same `--version-suffix` / `TRITON_WHEEL_VERSION_SUFFIX` used for Linux
+`triton` wheels. Nightly builds add `+git<githash>` from the triton-windows
+checkout (pin in
+[`ci_commit_pins/triton-windows.txt`](/external-builds/pytorch/ci_commit_pins/triton-windows.txt));
+extra local segments use `-` after the single `+` (see comments in
+`build_triton_linux()`). CI builds `triton_windows` only for
+`pytorch_git_ref: nightly`.
+Per-family CI uploads to `v2-staging/<family>/triton_windows/` for testing, then
+promotes to `v2/<family>/triton_windows/` on the release index. Multi-arch
+releases use `v4/whl/triton_windows/`.
 
 #### JAX versions
 

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -145,13 +145,13 @@ PyTorch packages versions are handled via scripts:
 
 The scripts produce these versions for each distribution channel:
 
-| Package name | Example release version (stable x stable) | Example nightly version (nightly x nightly) |
-| ------------ | ----------------------------------------- | ------------------------------------------- |
-| torch        | `2.9.1+rocm7.10.0`                        | `2.10.0a0+rocm7.10.0a20251024`              |
-| torchaudio   | `2.9.0+rocm7.10.0`                        | `2.10.0a0+rocm7.10.0a20251024`              |
-| torchvision  | `0.24.0+rocm7.10.0`                       | `0.24.0+rocm7.11.0a20251124`                |
-| triton       | `3.3.1+rocm7.10.0`                        | `3.5.1+rocm7.11.0a20251124`                 |
-| triton_windows | — (not built for stable `release/*` on Windows yet) | `3.6.0+git6fe895f6-rocm7.13.0a20260424` |
+| Package name   | Example release version (stable x stable)           | Example nightly version (nightly x nightly) |
+| -------------- | --------------------------------------------------- | ------------------------------------------- |
+| torch          | `2.9.1+rocm7.10.0`                                  | `2.10.0a0+rocm7.10.0a20251024`              |
+| torchaudio     | `2.9.0+rocm7.10.0`                                  | `2.10.0a0+rocm7.10.0a20251024`              |
+| torchvision    | `0.24.0+rocm7.10.0`                                 | `0.24.0+rocm7.11.0a20251124`                |
+| triton         | `3.3.1+rocm7.10.0`                                  | `3.5.1+rocm7.11.0a20251124`                 |
+| triton_windows | — (not built for stable `release/*` on Windows yet) | `3.6.0+git6fe895f6-rocm7.13.0a20260424`     |
 
 On Windows, [`build_prod_wheels.py`](/external-builds/pytorch/build_prod_wheels.py)
 appends the same `--version-suffix` / `TRITON_WHEEL_VERSION_SUFFIX` used for Linux

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -35,7 +35,7 @@ stable, nightly, and dev release channels.
 | ----------------- | ------------- | ------------------------------------------------------------------------------------------- |
 | torch             | ✅ Supported  | ✅ Supported                                                                                |
 | ↳ aotriton        | ✅ Supported  | ✅ Supported                                                                                |
-| ↳ triton          | ✅ Supported  | 🚧 In progress - [triton-windows#2](https://github.com/triton-lang/triton-windows/issues/2) |
+| ↳ triton          | ✅ Supported  | ✅ Supported (nightly only — see [Triton on Windows](#triton-on-windows)) |
 | ↳ FBGEMM GenAI    | ✅ Supported  | ❌ Not supported                                                                            |
 | torchaudio        | ✅ Supported  | ✅ Supported                                                                                |
 | torchvision       | ✅ Supported  | ✅ Supported                                                                                |
@@ -190,6 +190,59 @@ mix/match build steps.
     --output-dir %HOME%/tmp/pyout
   ```
 
+### Triton on Windows
+
+Windows nightly builds use the community
+[triton-windows](https://github.com/triton-lang/triton-windows) fork instead of
+[ROCm/triton](https://github.com/ROCm/triton). The resulting wheel is published
+as the **`triton_windows`** PyPI distribution (the import name remains `triton`).
+
+When building from source, check out triton after torch and pass `--build-triton`:
+
+```batch
+python pytorch_triton_repo.py checkout --checkout-dir C:/b/triton --torch-dir C:/b/pytorch
+python build_prod_wheels.py build ^
+    --install-rocm --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ ^
+    --pytorch-dir C:/b/pytorch ^
+    --pytorch-audio-dir C:/b/audio ^
+    --pytorch-vision-dir C:/b/vision ^
+    --triton-dir C:/b/triton ^
+    --build-triton ^
+    --output-dir %HOME%/tmp/pyout
+```
+
+Additional requirements for local Triton builds:
+
+- Run from a **Visual Studio Developer Command Prompt** (or after `vcvars64.bat`)
+  so MSVC is on `PATH`.
+- The build downloads a pinned LLVM toolchain (~500 MB) from
+  `oaitriton.blob.core.windows.net`, keyed by `cmake/llvm-hash.txt` in the
+  triton-windows checkout. The tree is cached next to the triton checkout as
+  `llvm-<hash>-windows-x64`.
+- Version suffixes follow the same ROCm composite scheme as other external Python
+  packages; see [Python package versioning](../../docs/packaging/versioning.md#pytorch-versions).
+
+AMD is contributing to upstream production readiness; see
+[triton-windows#2](https://github.com/triton-lang/triton-windows/issues/2).
+
+> [!NOTE]
+> On Linux, `build_prod_wheels.py` adds `triton==...` to the `torch` wheel's
+> install requirements so `pip install torch` pulls Triton automatically. On
+> Windows the same mechanism uses `triton_windows==...`. Upstream PyTorch wheels
+> do not declare these dependencies; TheRock adds them so `pip install torch`
+> from our indices pulls the matching Triton build.
+
+#### Commit pins
+
+Windows nightly builds pin [triton-windows](https://github.com/triton-lang/triton-windows)
+via [`ci_commit_pins/triton-windows.txt`](ci_commit_pins/triton-windows.txt)
+(instead of Linux [ROCm/triton](https://github.com/ROCm/triton) and
+[`.ci/docker/ci_commit_pins/triton.txt`](https://github.com/pytorch/pytorch/blob/nightly/.ci/docker/ci_commit_pins/triton.txt)).
+
+Stable `release/*` Windows wheels do not build Triton in CI today. The
+[supported PyTorch versions](#supported-pytorch-versions) table lists
+triton-windows only on the **nightly** row for that reason.
+
 ## Running/testing PyTorch
 
 ### Prerequisites
@@ -268,6 +321,16 @@ PYTORCH_TEST_WITH_ROCM=1 python pytorch/test/run_test.py --include test_torch
 ```
 
 ## Nightly releases
+
+Per-family Windows nightly workflows build `triton_windows` only for
+`pytorch_git_ref: nightly` (upstream `pytorch/pytorch` nightlies). Stable
+`release/*` branches from [ROCm/pytorch](https://github.com/ROCm/pytorch) currently
+build `torch`, `torchaudio`, and `torchvision` without Triton. Built wheels are
+uploaded alongside the other PyTorch packages on each family's index (for example
+`https://rocm.nightlies.amd.com/v2/gfx1151/triton_windows/`).
+
+Multi-arch Windows releases publish `triton_windows` to the unified index at
+`https://rocm.nightlies.amd.com/v4/whl/triton_windows/`.
 
 ### Gating releases with Pytorch tests
 

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -322,15 +322,12 @@ PYTORCH_TEST_WITH_ROCM=1 python pytorch/test/run_test.py --include test_torch
 
 ## Nightly releases
 
-Per-family Windows nightly workflows build `triton_windows` only for
-`pytorch_git_ref: nightly` (upstream `pytorch/pytorch` nightlies). Stable
-`release/*` branches from [ROCm/pytorch](https://github.com/ROCm/pytorch) currently
-build `torch`, `torchaudio`, and `torchvision` without Triton. Built wheels are
-uploaded alongside the other PyTorch packages on each family's index (for example
-`https://rocm.nightlies.amd.com/v2/gfx1151/triton_windows/`).
-
-Multi-arch Windows releases publish `triton_windows` to the unified index at
-`https://rocm.nightlies.amd.com/whl-multi-arch/`.
+For Windows workflows, `triton_windows` is built only when
+`pytorch_git_ref` is `nightly` (upstream `pytorch/pytorch` nightlies). For
+stable `release/*` refs from [ROCm/pytorch](https://github.com/ROCm/pytorch),
+the build currently produces `torch`, `torchaudio`, and `torchvision` without
+Triton. Windows nightly releases publish `triton_windows` to the unified
+multi-arch index at `https://rocm.nightlies.amd.com/whl-multi-arch/`.
 
 ### Gating releases with Pytorch tests
 

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -31,15 +31,15 @@ This incorporates advice from:
 The following projects and features are packaged and released through TheRock's
 stable, nightly, and dev release channels.
 
-| Project / feature | Linux support | Windows support                                                                             |
-| ----------------- | ------------- | ------------------------------------------------------------------------------------------- |
-| torch             | ✅ Supported  | ✅ Supported                                                                                |
-| ↳ aotriton        | ✅ Supported  | ✅ Supported                                                                                |
+| Project / feature | Linux support | Windows support                                                           |
+| ----------------- | ------------- | ------------------------------------------------------------------------- |
+| torch             | ✅ Supported  | ✅ Supported                                                              |
+| ↳ aotriton        | ✅ Supported  | ✅ Supported                                                              |
 | ↳ triton          | ✅ Supported  | ✅ Supported (nightly only — see [Triton on Windows](#triton-on-windows)) |
-| ↳ FBGEMM GenAI    | ✅ Supported  | ❌ Not supported                                                                            |
-| torchaudio        | ✅ Supported  | ✅ Supported                                                                                |
-| torchvision       | ✅ Supported  | ✅ Supported                                                                                |
-| apex              | ✅ Supported  | ❌ Not supported                                                                            |
+| ↳ FBGEMM GenAI    | ✅ Supported  | ❌ Not supported                                                          |
+| torchaudio        | ✅ Supported  | ✅ Supported                                                              |
+| torchvision       | ✅ Supported  | ✅ Supported                                                              |
+| apex              | ✅ Supported  | ❌ Not supported                                                          |
 
 The following projects are not currently packaged and released by TheRock, functionality may vary.
 

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -195,7 +195,7 @@ mix/match build steps.
 Windows nightly builds use the community
 [triton-windows](https://github.com/triton-lang/triton-windows) fork instead of
 [ROCm/triton](https://github.com/ROCm/triton). The resulting wheel is published
-as the **`triton_windows`** PyPI distribution (the import name remains `triton`).
+as **`triton_windows`** (the import name remains `triton`).
 
 When building from source, check out triton after torch and pass `--build-triton`:
 
@@ -330,7 +330,7 @@ uploaded alongside the other PyTorch packages on each family's index (for exampl
 `https://rocm.nightlies.amd.com/v2/gfx1151/triton_windows/`).
 
 Multi-arch Windows releases publish `triton_windows` to the unified index at
-`https://rocm.nightlies.amd.com/v4/whl/triton_windows/`.
+`https://rocm.nightlies.amd.com/whl-multi-arch/`.
 
 ### Gating releases with Pytorch tests
 


### PR DESCRIPTION
## Summary

Documents Windows Triton support for TheRock PyTorch wheels. This follows the build integration in PR #4006 and documents the nightly Windows CI wiring in PR #4205, which enables `triton_windows` in `build_windows_pytorch_wheels.yml` when `pytorch_git_ref` is `nightly`.

**Related PRs**
- #4006 — build integration for triton-windows (`build_prod_wheels.py`, `pytorch_triton_repo.py`)
- #4205 — nightly Windows PyTorch CI: Triton checkout/build, `write_torch_versions.py`, manifest, S3 staging/promote for `triton_windows`

This PR is **documentation only**. It does not change `build_prod_wheels.py`, CI workflows, or build scripts; those belong in #4006 and #4205.

## Scope

- `triton_windows` is only built and documented when the workflow uses `pytorch_git_ref: nightly`. For stable Windows refs such as `release/2.9`, CI still builds `torch`, `torchaudio`, and `torchvision`, but not Triton.

- `github_actions_debugging.md` is for maintainers who want to try that pipeline on **dev** infrastructure: copy a ROCm build from the nightly index into `therock-dev-python`, run `build_windows_pytorch_wheels.yml` with `release_type: dev`, and set `pytorch_git_ref: nightly` if you need a `triton_windows` wheel. It is not a guide for testing stable-release PyTorch with Triton.

## Changes

**external-builds/pytorch/README.md**
- Support table: Triton on Windows (nightly only)
- Triton on Windows: triton-windows repo, `triton_windows` package name, commit pin, local build steps, how `torch` pulls in Triton on install, and nightly wheel index URLs

**RELEASES.md**
- Note for installing nightly Windows `torch` / `triton_windows`

**docs/development/github_actions_debugging.md**
- Dev workflow for `build_windows_pytorch_wheels.yml` (parallel to Linux)
- Nightly Triton maintainer steps aligned with #4205 (`TRITON_BUILD_ARGS`, `write_torch_versions.py`, manifest, staging/promote)
- MSVC / long-path / `cmd` vs `bash` notes moved under “Issues with debugging notes”

**docs/development/windows_support.md**
- Nightly install pointers

**docs/packaging/versioning.md**
- `triton_windows` versioning examples; where wheels land on per-family indices (`v2-staging` → `v2`) vs multi-arch (`v4/whl/`)
