### PR TITLE
Fix pip install failure for rocm metapackage

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -101,6 +101,7 @@ index at https://rocm.nightlies.amd.com/whl-multi-arch/.
 > ```bash
 > python -m venv .venv
 > source .venv/bin/activate
+> pip install --upgrade pip setuptools wheel
 > ```
 >
 > Multiple virtual environments can be present on a system at a time, allowing you to switch between them at will.
@@ -139,7 +140,7 @@ Install ROCm with device support for your GPU using the unified index:
 
 ```bash
 # Replace device-gfx942 with your GPU, see the section below for details
-pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ "rocm[libraries,device-gfx942]"
+pip install --no-build-isolation --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ "rocm[libraries,device-gfx942]"
 ```
 
 <!-- TODO: Advertise wheel variants / WheelNext once available  -->
@@ -215,7 +216,7 @@ Install PyTorch with ROCm support using the same unified index:
 # Replace device-gfx942 with your GPU, see the section above for details
 # Note: we'll recommend 'whl-multi-arch' instead of 'whl-staging-multi-arch'
 #       as soon as we test run automate tests on these packages
-pip install --index-url https://rocm.nightlies.amd.com/whl-staging-multi-arch/ \
+pip install --no-build-isolation --index-url https://rocm.nightlies.amd.com/whl-staging-multi-arch/ \
     "torch[device-gfx942]" "torchvision[device-gfx942]" torchaudio
 
 # Optional additional packages on Linux:
@@ -229,7 +230,7 @@ pip install --index-url https://rocm.nightlies.amd.com/whl-staging-multi-arch/ \
 > install ROCm separately:
 >
 > ```bash
-> pip install --index-url https://rocm.nightlies.amd.com/whl-staging-multi-arch/ \
+> pip install --no-build-isolation --index-url https://rocm.nightlies.amd.com/whl-staging-multi-arch/ \
 >     "torch[device-gfx1100]"
 >
 > pip freeze  # with approximate download sizes:
@@ -424,6 +425,7 @@ We currently support Python 3.10, 3.11, 3.12, 3.13, and 3.14 (PyTorch 2.9+ only)
 > ```bash
 > python -m venv .venv
 > source .venv/bin/activate
+> pip install --upgrade pip setuptools wheel
 > ```
 >
 > Multiple virtual environments can be present on a system at a time, allowing you to switch between them at will.
@@ -494,7 +496,7 @@ A new optional package `rocm-profiler` is available, providing ROCm profiling to
 Install profiling tools via the meta package:
 
 ```bash
-pip install "rocm[profiler]"
+pip install --no-build-isolation "rocm[profiler]"
 ```
 
 This will install:
@@ -513,7 +515,7 @@ Supported devices in this family:
 Install instructions:
 
 ```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ "rocm[libraries,devel]"
+pip install --no-build-isolation --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ "rocm[libraries,devel]"
 ```
 
 ##### rocm for gfx950-dcgpu
@@ -527,7 +529,7 @@ Supported devices in this family:
 Install instructions:
 
 ```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ "rocm[libraries,devel]"
+pip install --no-build-isolation --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ "rocm[libraries,devel]"
 ```
 
 ##### rocm for gfx110X-all
@@ -544,7 +546,7 @@ Supported devices in this family:
 Install instructions:
 
 ```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ "rocm[libraries,devel]"
+pip install --no-build-isolation --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ "rocm[libraries,devel]"
 ```
 
 ##### rocm for gfx1151
@@ -558,7 +560,7 @@ Supported devices in this family:
 Install instructions:
 
 ```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ "rocm[libraries,devel]"
+pip install --no-build-isolation --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ "rocm[libraries,devel]"
 ```
 
 ##### rocm for gfx120X-all
@@ -573,7 +575,7 @@ Supported devices in this family:
 Install instructions:
 
 ```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ "rocm[libraries,devel]"
+pip install --no-build-isolation --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ "rocm[libraries,devel]"
 ```
 
 #### Using ROCm Python packages

--- a/build_tools/github_actions/upload_python_packages.py
+++ b/build_tools/github_actions/upload_python_packages.py
@@ -35,7 +35,7 @@ Output Layout:
     *.whl, *.tar.gz
 
 Installation:
-  pip install rocm[libraries,devel] --pre \\
+  pip install --no-build-isolation rocm[libraries,devel] --pre \\
     --find-links=https://{bucket}.s3.amazonaws.com/{path}/index.html
 """
 
@@ -181,7 +181,7 @@ def write_gha_upload_summary(
             f"- [{family}]({base_url}/{family}/index.html)" for family in families
         )
         family_installs = "\n\n".join(
-            f"```bash\npip install rocm[libraries,devel] --pre {LINE_CONTINUATION_CHAR}\n"
+            f"```bash\npip install --no-build-isolation rocm[libraries,devel] --pre {LINE_CONTINUATION_CHAR}\n"
             f"    --find-links={base_url}/{family}/index.html\n```"
             for family in families
         )
@@ -198,7 +198,7 @@ Per-family indexes:
         install_instructions_markdown = f"""[ROCm Python packages (kpack-split)]({index_url})
 Replace `<YOUR_TARGET>` with your GPU target (e.g. `gfx942`, `gfx1201`):
 ```bash
-pip install rocm[libraries,devel,device-<YOUR_TARGET>] --pre {LINE_CONTINUATION_CHAR}
+pip install --no-build-isolation rocm[libraries,devel,device-<YOUR_TARGET>] --pre {LINE_CONTINUATION_CHAR}
     --find-links={index_url}
 ```
 """
@@ -207,7 +207,7 @@ pip install rocm[libraries,devel,device-<YOUR_TARGET>] --pre {LINE_CONTINUATION_
         index_url = f"{packages_loc.https_url}/index.html"
         install_instructions_markdown = f"""[ROCm Python packages]({index_url})
 ```bash
-pip install rocm[libraries,devel] --pre {LINE_CONTINUATION_CHAR}
+pip install --no-build-isolation rocm[libraries,devel] --pre {LINE_CONTINUATION_CHAR}
     --find-links={index_url}
 ```
 """

--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -28,7 +28,7 @@ There are a few modes this can be used in:
     python -m venv .venv
     source .venv/bin/activate
     python -m pip install --upgrade pip
-    python -m pip install rocm[libraries,devel] --index-url=https://.../gfx110X-all
+    python -m pip install rocm[libraries,devel] --no-build-isolation --index-url=https://.../gfx110X-all
     deactivate
     ```
 """
@@ -112,7 +112,18 @@ def update_venv(venv_dir: Path, use_uv: bool = False):
     # pip logs warnings about wanting to update, so we'll do that for it.
     log("")
     python_exe = find_venv_python_exe(venv_dir)
-    run_command([str(python_exe), "-m", "pip", "install", "--upgrade", "pip"])
+    run_command(
+        [
+            str(python_exe),
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "pip",
+            "setuptools",
+            "wheel",
+        ]
+    )
 
 
 def activate_venv_in_gha(venv_dir: Path):
@@ -194,6 +205,9 @@ def install_packages_into_venv(
             index_url = f"{index_url.rstrip('/')}/{index_subdir.strip('/')}"
 
         pip_install_cmd.append(f"--index-url={index_url}")
+
+    if any(pkg.startswith("rocm") for pkg in packages):
+        pip_install_cmd.append("--no-build-isolation")
 
     if find_links:
         pip_install_cmd.append(f"--find-links={find_links}")


### PR DESCRIPTION
## Motivation

Fixes: #5396 

When users follow the official installation instructions to install `rocm` metapackages using `pip install --index-url https://repo.amd.com/rocm/whl/gfx103X-all/ "rocm[libraries,devel]"` the installation fails with an error stating that `setuptools>=70.2.0` can't be found. This happends because pip creates a temporary virtual environment and attempts to download setuptools from the configured index. However since `--index-url` restricts pip to only search AMD's package index (which does not host standard PyPI build tools like setuptools) the build fails before installation even begins.

**EDIT:** Upon further investigation I noticed that this only affects certain GPU families. For example, installing from gfx90a index succeeds while gfx103X-all fails. The root cause is that for example enterprise gfx90a index mirrors standard PyPI dependencies, allowing pip to download them during build, while the consumer gfx103X-all index strictly hosts AMD pacakges and omits PyPI dependencies.

## Technical Details

This fix ensures that build dependencies are available locally, and tell pip to use those instead of trying to download them.

In `RELEASES.md` the virtual environment setup instructions now include `pip install --upgrade pip setuptools wheel` immediatelly after  creating and activating venv, because [python 3.12+ no longer bundles setuptools](https://docs.python.org/3/whatsnew/3.12.html#:~:text=gh%2D95299%3A%20Do%20not%20pre%2Dinstall%20setuptools%20in%20virtual%20environments%20created%20with%20venv.%20This%20means%20that%20distutils%2C%20setuptools%2C%20pkg_resources%2C%20and%20easy_install%20will%20no%20longer%20available%20by%20default%3B%20to%20access%20these%20run%20pip%20install%20setuptools%20in%20the%20activated%20virtual%20environment.) in newly created venv. Additionally, all `pip install` commands for `rocm` metapackages now include `--no-build-isolation` flag, which instructs pip to use locally installed `setuptools` rather than attempting to fetch it from AMD index.

In `build_tools/setup_venv.py` the `update_venv` function now installs setuptools and wheel alongside the existing pip upgrade. `install_packages_into_venv` function was updated to automatically append `--no-build-isolation` to the pip command whenever a package name statring with `rocm` is detected.

In `build_tools/github_actions/upload_python_packages.py` the string templates that generate GitHub Actions step summaries were updated to include `--no-build-isolation` in all generated `pip install` snippets.

## Test Plan

I set up clean Ubuntu DOcker container and ran the installation. The test was performed in fresh venv with no pre-existing packages (except for those that `python3 -m venv` provides).

## Test Result

Without the fix we get immediate error: `ERROR: Could not find a version that satisfies the requirement setuptools>=70.2.0`. With the fix applied, running the updated sequence (`pip install --upgrade pip setuptools wheel` followed by `pip install --no-build-isolation --index-url https://repo.amd.com/rocm/whl/gfx103X-all/ "rocm[libraries,devel]"`) completes successfully, with the following result: `Successfully installed rocm-7.13.0 rocm-sdk-core-7.13.0 rocm-sdk-devel-7.13.0 rocm-sdk-libraries-gfx103X-all-7.13.0`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
