### PR TITLE
[ci] Increase AWS runner weight from 20% to 50%

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -46,13 +46,13 @@ def select_weighted_label(labels_config: list[dict], context_name: str) -> str:
 
 
 # Build runner configuration for Linux builds
-# Uses weighted distribution: 80% Azure, 20% AWS
+# Uses weighted distribution: 50% Azure, 50% AWS
 # Sanitizer builds (asan/tsan) use ramdisk variants (100% Azure, no AWS yet)
 BUILD_RUNNER_LABELS = {
     "linux": {
         "default": [
-            {"label": "azure-linux-scale-rocm", "weight": 0.8},
-            {"label": "aws-linux-scale-rocm-prod", "weight": 0.2},
+            {"label": "azure-linux-scale-rocm", "weight": 0.5},
+            {"label": "aws-linux-scale-rocm-prod", "weight": 0.5},
         ],
         "sanitizer": [
             {"label": "azure-linux-scale-rocm-heavy-ramdisk", "weight": 1.0},

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1250,17 +1250,17 @@ class TestBuildRunnerSelection(unittest.TestCase):
     """Test weighted random selection of build runners (Azure vs AWS)."""
 
     def test_select_build_runner_weighted_selection(self):
-        """Test weighted selection: Azure (80%) vs AWS (20%) for default builds."""
+        """Test weighted selection: Azure (50%) vs AWS (50%) for default builds."""
         from amdgpu_family_matrix import select_build_runner
 
-        # Random < 0.8 should select Azure
-        with patch("random.random", return_value=0.5):
+        # Random < 0.5 should select Azure
+        with patch("random.random", return_value=0.3):
             self.assertEqual(
                 select_build_runner("linux", "release"), "azure-linux-scale-rocm"
             )
 
-        # Random >= 0.8 should select AWS
-        with patch("random.random", return_value=0.95):
+        # Random >= 0.5 should select AWS
+        with patch("random.random", return_value=0.75):
             self.assertEqual(
                 select_build_runner("linux", "release"), "aws-linux-scale-rocm-prod"
             )


### PR DESCRIPTION
## Summary

- Increases `aws-linux-scale-rocm-prod` runner weight from 20% → 50%
- Decreases `azure-linux-scale-rocm` weight from 80% → 50%
- Updates test comments and thresholds to reflect new distribution

Following the successful rollout at 20% (#5318), AWS runners have been stable and healthy. This bumps the traffic share to continue the gradual migration to AWS.

## Test plan

- [x] Existing weighted selection unit tests pass (thresholds updated to match new 50/50 distribution)
- [ ] Monitor AWS runner jobs after merge for errors/failures