### PR TITLE
[miopen-provider]: always print test output for miopen provider

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_miopenprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopenprovider.py
@@ -34,7 +34,7 @@ cmd = [
     "ctest",
     "--test-dir",
     f"{THEROCK_BIN_DIR}/miopen_plugin",
-    "--output-on-failure",
+    "-V",
     "--parallel",
     "8",
 ]


### PR DESCRIPTION
## Motivation

There appears to be a random issue where were timing out miopen tests on CI.  We want to always print the output so we can try and track this down as we cant reproduce locally.
