### PR TITLE
Disable Gfxarch for amdrocm-ck package

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -2053,7 +2053,7 @@
         ]
       }
     ],
-    "Gfxarch": "True"
+    "Gfxarch": "False"
   },
   {
     "Package": "amdrocm-ck-devel",


### PR DESCRIPTION
Set Gfxarch to False in the composable kernel package configuration to build architecture-independent packages
Currently all CK artifacts are part of dev components. NOTE: In future if any gfxarch specific binaries/libraries are getting added, will enable Gfxarch

