### PR TITLE
Upload TheRock Manifest from stage post-build step

### DIFF
--- a/build_tools/_therock_utils/workflow_outputs.py
+++ b/build_tools/_therock_utils/workflow_outputs.py
@@ -53,6 +53,7 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 from _therock_utils.storage_location import StorageLocation
 from _therock_utils.s3_buckets import get_artifacts_bucket_config_for_workflow_run
 
+
 # ---------------------------------------------------------------------------
 # WorkflowOutputRoot
 # ---------------------------------------------------------------------------

--- a/build_tools/_therock_utils/workflow_outputs.py
+++ b/build_tools/_therock_utils/workflow_outputs.py
@@ -203,6 +203,13 @@ class WorkflowOutputRoot:
             f"{self.prefix}/manifests/therock_manifest.json",
         )
 
+    def manifests_index(self) -> StorageLocation:
+        """Location for the workflow-level manifests index."""
+        return StorageLocation(
+            self.bucket,
+            f"{self.prefix}/manifests/index.html",
+        )
+
     # -- Native packages --------------------------------------------------------
 
     def native_linux_packages(self, pkg_type: str) -> StorageLocation:

--- a/build_tools/_therock_utils/workflow_outputs.py
+++ b/build_tools/_therock_utils/workflow_outputs.py
@@ -53,7 +53,6 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 from _therock_utils.storage_location import StorageLocation
 from _therock_utils.s3_buckets import get_artifacts_bucket_config_for_workflow_run
 
-
 # ---------------------------------------------------------------------------
 # WorkflowOutputRoot
 # ---------------------------------------------------------------------------
@@ -194,6 +193,13 @@ class WorkflowOutputRoot:
         return StorageLocation(
             self.bucket,
             f"{self.prefix}/manifests/{artifact_group}/therock_manifest.json",
+        )
+
+    def manifest_root(self) -> StorageLocation:
+        """Location for the workflow-level therock_manifest.json."""
+        return StorageLocation(
+            self.bucket,
+            f"{self.prefix}/manifests/therock_manifest.json",
         )
 
     # -- Native packages --------------------------------------------------------

--- a/build_tools/github_actions/configure_multi_arch_ci_summary.py
+++ b/build_tools/github_actions/configure_multi_arch_ci_summary.py
@@ -180,13 +180,13 @@ def _append_build_rocm(
             lines.append(f"| {platform} | {families} | `{config.artifact_group}` |")
     lines.append("")
 
-    # Link to log and artifact index pages
+    # Link to log, artifact, and manifest index pages
     lines.extend(
         [
             "## Build outputs",
             "",
-            "Platform | 📋 Logs | 📦 Artifacts",
-            "-- | -- | --",
+            "Platform | 📋 Logs | 📦 Artifacts | 📄 Manifests",
+            "-- | -- | -- | --",
         ]
     )
     for platform_name in ["linux", "windows"]:
@@ -195,7 +195,10 @@ def _append_build_rocm(
         )
         log_url = output_root.log_root_index().https_url
         artifact_url = output_root.artifact_index().https_url
-        lines.append(f"{platform_name.capitalize()} | {log_url} | {artifact_url}")
+        manifest_url = output_root.manifests_index().https_url
+        lines.append(
+            f"{platform_name.capitalize()} | {log_url} | {artifact_url} | {manifest_url}"
+        )
 
 
 def _append_test_rocm(lines: list[str], outputs: CIOutputs) -> None:

--- a/build_tools/github_actions/post_stage_upload.py
+++ b/build_tools/github_actions/post_stage_upload.py
@@ -191,6 +191,9 @@ def run(args: argparse.Namespace):
         stage_name=args.stage,
         amdgpu_family=args.amdgpu_family,
     )
+    if args.stage != "foundation":
+        log("[INFO] Manifest upload is only performed by foundation stage. Skipping.")
+        return
 
     log("Upload manifest")
     log("---------------")

--- a/build_tools/github_actions/post_stage_upload.py
+++ b/build_tools/github_actions/post_stage_upload.py
@@ -14,7 +14,7 @@ to S3, organized by stage name and (optionally) GPU family:
 This is the multi-arch counterpart to post_build_upload.py, which handles
 single-stage (monolithic) CI builds. Key differences:
 
-- Uploads the stage manifest alongside logs
+- Uploads the stage manifest alongside logs when present
 - No artifact upload (artifact_manager.py push handles that)
 - No index generation (server-side Lambda handles that, see #3331)
 - Logs are scoped to one stage, not the entire build
@@ -147,12 +147,28 @@ def upload_manifest(
     output_root: WorkflowOutputRoot,
     backend: StorageBackend,
 ):
-    """Upload therock_manifest.json."""
-    manifest_path = (
-        build_dir / "base" / "aux-overlay" / "build" / "therock_manifest.json"
+    """Upload therock_manifest.json when present."""
+
+    manifest_paths = [
+        build_dir / "base" / "aux-overlay" / "build" / "therock_manifest.json",
+        build_dir
+        / "base"
+        / "aux-overlay"
+        / "stage"
+        / "share"
+        / "therock"
+        / "therock_manifest.json",
+        build_dir / "dist" / "rocm" / "share" / "therock" / "therock_manifest.json",
+    ]
+
+    manifest_path = next(
+        (path for path in manifest_paths if path.is_file()),
+        None,
     )
-    if not manifest_path.is_file():
-        raise FileNotFoundError(f"therock_manifest.json not found at {manifest_path}")
+
+    if manifest_path is None:
+        log("[INFO] No therock_manifest.json found. Skipping upload.")
+        return
 
     log(f"[INFO] Uploading manifest {manifest_path}")
     backend.upload_file(manifest_path, output_root.manifest(artifact_group))

--- a/build_tools/github_actions/post_stage_upload.py
+++ b/build_tools/github_actions/post_stage_upload.py
@@ -14,8 +14,8 @@ to S3, organized by stage name and (optionally) GPU family:
 This is the multi-arch counterpart to post_build_upload.py, which handles
 single-stage (monolithic) CI builds. Key differences:
 
+- Uploads the stage manifest alongside logs
 - No artifact upload (artifact_manager.py push handles that)
-- No manifest upload (deferred to workflow-level, see #1236)
 - No index generation (server-side Lambda handles that, see #3331)
 - Logs are scoped to one stage, not the entire build
 
@@ -141,6 +141,23 @@ def upload_stage_logs(
     backend.upload_directory(log_dir, dest, exclude=["ccache/**/*"])
 
 
+def upload_manifest(
+    artifact_group: str,
+    build_dir: Path,
+    output_root: WorkflowOutputRoot,
+    backend: StorageBackend,
+):
+    """Upload therock_manifest.json."""
+    manifest_path = (
+        build_dir / "base" / "aux-overlay" / "build" / "therock_manifest.json"
+    )
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"therock_manifest.json not found at {manifest_path}")
+
+    log(f"[INFO] Uploading manifest {manifest_path}")
+    backend.upload_file(manifest_path, output_root.manifest(artifact_group))
+
+
 def run(args: argparse.Namespace):
     log(f"Creating log archives for stage '{args.stage}'")
     create_ninja_log_archive(args.build_dir)
@@ -158,6 +175,17 @@ def run(args: argparse.Namespace):
         backend=backend,
         stage_name=args.stage,
         amdgpu_family=args.amdgpu_family,
+    )
+
+    artifact_group = args.amdgpu_family or args.stage
+
+    log("Upload manifest")
+    log("---------------")
+    upload_manifest(
+        artifact_group=artifact_group,
+        build_dir=args.build_dir,
+        output_root=output_root,
+        backend=backend,
     )
 
 

--- a/build_tools/github_actions/post_stage_upload.py
+++ b/build_tools/github_actions/post_stage_upload.py
@@ -142,7 +142,7 @@ def upload_stage_logs(
 
 
 def upload_manifest(
-    artifact_group: str,
+    amdgpu_family: str,
     build_dir: Path,
     output_root: WorkflowOutputRoot,
     backend: StorageBackend,
@@ -171,7 +171,7 @@ def upload_manifest(
         return
 
     log(f"[INFO] Uploading manifest {manifest_path}")
-    backend.upload_file(manifest_path, output_root.manifest(artifact_group))
+    backend.upload_file(manifest_path, output_root.manifest(amdgpu_family))
 
 
 def run(args: argparse.Namespace):
@@ -193,16 +193,16 @@ def run(args: argparse.Namespace):
         amdgpu_family=args.amdgpu_family,
     )
 
-    artifact_group = args.artifact_group or args.amdgpu_family
+    amdgpu_family = args.amdgpu_family
 
-    if not artifact_group:
-        log("[INFO] No artifact group specified. Skipping manifest upload.")
+    if not amdgpu_family:
+        log("[INFO] No AMDGPU family specified. Skipping manifest upload.")
         return
 
     log("Upload manifest")
     log("---------------")
     upload_manifest(
-        artifact_group=artifact_group,
+        amdgpu_family=amdgpu_family,
         build_dir=args.build_dir,
         output_root=output_root,
         backend=backend,
@@ -241,13 +241,6 @@ def main(argv: list[str] | None = None):
         default="",
         help="GPU family for per-arch stages (e.g., 'gfx1151'). "
         "Empty for generic stages.",
-    )
-    parser.add_argument(
-        "--artifact-group",
-        type=str,
-        default="",
-        help="Artifact group for manifest upload "
-        "(e.g., 'gfx94X-dcgpu', 'gfx110X-all')",
     )
     parser.add_argument(
         "--compression-level",

--- a/build_tools/github_actions/post_stage_upload.py
+++ b/build_tools/github_actions/post_stage_upload.py
@@ -193,7 +193,11 @@ def run(args: argparse.Namespace):
         amdgpu_family=args.amdgpu_family,
     )
 
-    artifact_group = args.amdgpu_family or args.stage
+    artifact_group = args.artifact_group or args.amdgpu_family
+
+    if not artifact_group:
+        log("[INFO] No artifact group specified. Skipping manifest upload.")
+        return
 
     log("Upload manifest")
     log("---------------")
@@ -237,6 +241,13 @@ def main(argv: list[str] | None = None):
         default="",
         help="GPU family for per-arch stages (e.g., 'gfx1151'). "
         "Empty for generic stages.",
+    )
+    parser.add_argument(
+        "--artifact-group",
+        type=str,
+        default="",
+        help="Artifact group for manifest upload "
+        "(e.g., 'gfx94X-dcgpu', 'gfx110X-all')",
     )
     parser.add_argument(
         "--compression-level",

--- a/build_tools/github_actions/post_stage_upload.py
+++ b/build_tools/github_actions/post_stage_upload.py
@@ -148,24 +148,11 @@ def upload_manifest(
 ):
     """Upload therock_manifest.json when present."""
 
-    manifest_paths = [
-        build_dir / "base" / "aux-overlay" / "build" / "therock_manifest.json",
-        build_dir
-        / "base"
-        / "aux-overlay"
-        / "stage"
-        / "share"
-        / "therock"
-        / "therock_manifest.json",
-        build_dir / "dist" / "rocm" / "share" / "therock" / "therock_manifest.json",
-    ]
-
-    manifest_path = next(
-        (path for path in manifest_paths if path.is_file()),
-        None,
+    manifest_path = (
+        build_dir / "base" / "aux-overlay" / "build" / "therock_manifest.json"
     )
 
-    if manifest_path is None:
+    if not manifest_path.is_file():
         log("[INFO] No therock_manifest.json found. Skipping upload.")
         return
 
@@ -191,17 +178,12 @@ def run(args: argparse.Namespace):
         stage_name=args.stage,
         amdgpu_family=args.amdgpu_family,
     )
-    if args.stage != "foundation":
-        log("[INFO] Manifest upload is only performed by foundation stage. Skipping.")
-        return
-
-    log("Upload manifest")
-    log("---------------")
-    upload_manifest(
-        build_dir=args.build_dir,
-        output_root=output_root,
-        backend=backend,
-    )
+    if args.stage == "foundation":
+        upload_manifest(
+            build_dir=args.build_dir,
+            output_root=output_root,
+            backend=backend,
+        )
 
 
 def main(argv: list[str] | None = None):

--- a/build_tools/github_actions/post_stage_upload.py
+++ b/build_tools/github_actions/post_stage_upload.py
@@ -142,7 +142,6 @@ def upload_stage_logs(
 
 
 def upload_manifest(
-    amdgpu_family: str,
     build_dir: Path,
     output_root: WorkflowOutputRoot,
     backend: StorageBackend,
@@ -171,7 +170,7 @@ def upload_manifest(
         return
 
     log(f"[INFO] Uploading manifest {manifest_path}")
-    backend.upload_file(manifest_path, output_root.manifest(amdgpu_family))
+    backend.upload_file(manifest_path, output_root.manifest_root())
 
 
 def run(args: argparse.Namespace):
@@ -193,16 +192,9 @@ def run(args: argparse.Namespace):
         amdgpu_family=args.amdgpu_family,
     )
 
-    amdgpu_family = args.amdgpu_family
-
-    if not amdgpu_family:
-        log("[INFO] No AMDGPU family specified. Skipping manifest upload.")
-        return
-
     log("Upload manifest")
     log("---------------")
     upload_manifest(
-        amdgpu_family=amdgpu_family,
         build_dir=args.build_dir,
         output_root=output_root,
         backend=backend,


### PR DESCRIPTION
## Motivation

`post_stage_upload.py` previously only uploaded stage logs. Manifest uploads were deferred to workflow-level handling, which caused per-arch multi-stage CI jobs to miss `therock_manifest.json` uploads.

This change adds workflow-level manifest uploads directly to `post_stage_upload.py`.

## Technical Details

- Upload a single workflow-level therock_manifest.json from post_stage_upload.py when present
- Upload manifest to: `{run_id}-{platform}/manifests/therock_manifest.json`

The manifest path

```python
build/base/aux-overlay/build/therock_manifest.json
```

## Validation

Validated in multi-arch CI:

* Verified resulting S3 layout contains a single workflow-level manifest
https://therock-ci-artifacts.s3.amazonaws.com/26595281971-linux/manifests/index.html
https://therock-ci-artifacts.s3.amazonaws.com/26595281971-linux/manifests/therock_manifest.json

