### PR TITLE
PR rocrtst issue - bump rocrtst's timeout_minutes in TheRock

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -632,7 +632,8 @@ test_matrix = {
     "rocrtst": {
         "job_name": "rocrtst",
         "fetch_artifact_args": "--rocrtst --tests",
-        "timeout_minutes": 15,
+        # rocrtst HSA stress + queue scenarios on single-GPU runners exceed 15
+        "timeout_minutes": 30,
         "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux"],
         "total_shards_dict": {


### PR DESCRIPTION
## Motivation

The `Test rocrtst (shard 1 of 1)` matrix entry consistently hits the
15-minute Test step timeout on the linux-gfx942-1gpu-ossci-rocm runner,
failing every rocm-systems PR that runs the Linux test matrix.
Recently observed:

  - rocm-systems#6336 (docs preview pipeline): timeout, 15m 0s
  - rocm-systems#5758 (clr OpenCL CTS fixes):  timeout, 16m 3s
  - rocm-systems#5638 (kfdtest APU skip):      timeout, 15m 46s

None of the three PRs touch rocrtst, the runtime, or anything in the
rocrtst execution path. The failure is a budget issue, not a regression
introduced by any of those PRs.

rocrtst executes the full HSA + multi-GPU/multi-queue/profiling CTest
set; 15 minutes is well below what neighbouring suites get
(rocprofiler-compute 60, rocprofiler-systems 60, rocfft/hipfft 60,
rocwmma 90, hip-tests 120). 

If/when rocrtst's wall-clock grows enough to justify it, this should be
sharded the same way hip-tests is, but raising the cap unblocks PR CI
immediately and is the lower-risk change.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
