### PR TITLE
Move rocshmem numactl from BUILD_DEPS to RUNTIME_DEPS

### DIFF
--- a/comm-libs/CMakeLists.txt
+++ b/comm-libs/CMakeLists.txt
@@ -164,9 +164,9 @@ if(THEROCK_ENABLE_ROCSHMEM)
       rocm-cmake
       therock-fmt
       therock-googletest
-      ${THEROCK_BUNDLED_NUMACTL}
     RUNTIME_DEPS
       hip-clr
+      ${THEROCK_BUNDLED_NUMACTL}
   )
   therock_cmake_subproject_glob_c_sources(rocshmem
     SUBDIRS


### PR DESCRIPTION
## Motivation

1/2 fix for https://github.com/ROCm/TheRock/issues/5459. 

libnuma should be bundled in the dist artifact so rocSHMEM can find it at runtime via rpath, preventing the below error on systems that don't have system installed numa 
```
E-001h rocSHMEM Could not open libnuma. Returning       NUMAWrapper@src/gda/numa_wrapper.cpp:48
```

## Technical Details

Move rocshmem numactl from BUILD_DEPS to RUNTIME_DEPS so it's shipped and found correctly.

## Test Plan

- Copy libnuma.so.1 into torch/lib/ and create the unversioned libnuma.so symlink, mimicking how `RUNTIME_DEP` shipped numa would exist 
- Confirm dlopen("libnuma.so") then succeeds and the E-001h error disappears

## Test Result

- Error is no longer seen as libnuma is found correctly.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
