### PR TITLE
[ci] Disabling core42 pool

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -145,11 +145,11 @@ amdgpu_family_info_matrix_presubmit = {
             "test-runs-on-labels": [
                 {
                     "label": "linux-gfx942-1gpu-ossci-rocm",
-                    "weight": 0.8,
+                    "weight": 0.81,
                 },  # vultr (17/21)
                 {
                     "label": "linux-gfx942-1gpu-ccs-ossci-rocm",
-                    "weight": 0.2,
+                    "weight": 0.19,
                 },  # cirrascale (4/21)
                 # Temporarily removed due to cluster issues
                 {

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -145,15 +145,16 @@ amdgpu_family_info_matrix_presubmit = {
             "test-runs-on-labels": [
                 {
                     "label": "linux-gfx942-1gpu-ossci-rocm",
-                    "weight": 0.369,
-                },  # vultr (17/46)
+                    "weight": 0.8,
+                },  # vultr (17/21)
                 {
                     "label": "linux-gfx942-1gpu-ccs-ossci-rocm",
-                    "weight": 0.086,
-                },  # cirrascale (4/46)
+                    "weight": 0.2,
+                },  # cirrascale (4/21)
+                # Temporarily removed due to cluster issues
                 {
                     "label": "linux-gfx942-1gpu-core42-ossci-rocm",
-                    "weight": 0.543,
+                    "weight": 0.0,
                 },  # core42 (25/46)
             ],
             # TODO(#3433): Remove sandbox label once ASAN tests are passing

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -577,7 +577,7 @@ class ConfigureCITest(unittest.TestCase):
         self.assertEqual(len(gfx94x_entries), 1, "Expected exactly one gfx94X entry")
         entry = gfx94x_entries[0]
         # Should select the second (cirrascale) label
-        self.assertEqual(entry["test-runs-on"], "linux-gfx942-1gpu-ccs-ossci-rocm")
+        self.assertEqual(entry["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm")
 
     def test_gfx94x_multi_label_selects_third_when_random_high(self):
         """When random() is high, third label should be selected."""
@@ -603,7 +603,7 @@ class ConfigureCITest(unittest.TestCase):
         self.assertEqual(len(gfx94x_entries), 1, "Expected exactly one gfx94X entry")
         entry = gfx94x_entries[0]
         # Should select the third (core42) label
-        self.assertEqual(entry["test-runs-on"], "linux-gfx942-1gpu-core42-ossci-rocm")
+        self.assertEqual(entry["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm")
 
     def test_gfx94x_multi_gpu_label_selects_first_when_random_low(self):
         """When random() is low, first multi-gpu label should be selected."""

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1194,9 +1194,7 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         self.assertIsNotNone(builds.linux)
         # Check that the second label was selected
         gfx94x_info = builds.linux.per_family_info[0]
-        self.assertEqual(
-            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm"
-        )
+        self.assertEqual(gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm")
 
     def test_third_label_selected_when_random_high(self):
         """When random() >= first two weights, third label should be selected."""
@@ -1216,9 +1214,7 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         self.assertIsNotNone(builds.linux)
         # Check that the third label was selected
         gfx94x_info = builds.linux.per_family_info[0]
-        self.assertEqual(
-            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm"
-        )
+        self.assertEqual(gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm")
 
     def test_families_without_multi_label_use_primary_only(self):
         """Families without multi-label config should only use primary label."""

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1195,7 +1195,7 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         # Check that the second label was selected
         gfx94x_info = builds.linux.per_family_info[0]
         self.assertEqual(
-            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ccs-ossci-rocm"
+            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm"
         )
 
     def test_third_label_selected_when_random_high(self):
@@ -1217,7 +1217,7 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         # Check that the third label was selected
         gfx94x_info = builds.linux.per_family_info[0]
         self.assertEqual(
-            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-core42-ossci-rocm"
+            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm"
         )
 
     def test_families_without_multi_label_use_primary_only(self):

--- a/build_tools/github_actions/tests/fetch_package_targets_test.py
+++ b/build_tools/github_actions/tests/fetch_package_targets_test.py
@@ -157,7 +157,7 @@ class FetchPackageTargetsTest(unittest.TestCase):
             targets = fetch_package_targets.determine_package_targets(args)
 
         self.assertEqual(len(targets), 1)
-        self.assertEqual(targets[0]["test_machine"], "linux-gfx942-1gpu-ccs-ossci-rocm")
+        self.assertEqual(targets[0]["test_machine"], "linux-gfx942-1gpu-ossci-rocm")
 
     def test_gfx94x_multi_label_selects_third_when_random_high(self):
         """When random() is high, third label should be selected."""
@@ -172,7 +172,7 @@ class FetchPackageTargetsTest(unittest.TestCase):
 
         self.assertEqual(len(targets), 1)
         self.assertEqual(
-            targets[0]["test_machine"], "linux-gfx942-1gpu-core42-ossci-rocm"
+            targets[0]["test_machine"], "linux-gfx942-1gpu-ossci-rocm"
         )
 
     def test_families_without_multi_label_use_primary(self):

--- a/build_tools/github_actions/tests/fetch_package_targets_test.py
+++ b/build_tools/github_actions/tests/fetch_package_targets_test.py
@@ -171,9 +171,7 @@ class FetchPackageTargetsTest(unittest.TestCase):
             targets = fetch_package_targets.determine_package_targets(args)
 
         self.assertEqual(len(targets), 1)
-        self.assertEqual(
-            targets[0]["test_machine"], "linux-gfx942-1gpu-ossci-rocm"
-        )
+        self.assertEqual(targets[0]["test_machine"], "linux-gfx942-1gpu-ossci-rocm")
 
     def test_families_without_multi_label_use_primary(self):
         """Families without multi-label config should use primary label."""


### PR DESCRIPTION
Due to performance regression in core42 pool, we are disabling until issues are resolved

Test ran properly here: https://github.com/ROCm/TheRock/actions/runs/26526000279/job/78131197209, so  adding ci:skip