### PR TITLE
Revert "Disable Gfxarch for amdrocm-ck package"

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -2053,7 +2053,7 @@
         ]
       }
     ],
-    "Gfxarch": "False"
+    "Gfxarch": "True"
   },
   {
     "Package": "amdrocm-ck-devel",


### PR DESCRIPTION
Reverts ROCm/TheRock#5462

Breaking the native packaging CI runs in all gfx archs where CK was enblaed.
related Issue: https://github.com/ROCm/TheRock/issues/5486