### PR TITLE
enable codeql for python and gh actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/**"
+      - "build_tools/**"
+      - "scan_tools/**"
+      - "tests/**"
+  # Run every Saturday at 10:00 UTC.
+  schedule:
+    - cron: "0 10 * * 6"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, actions]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,16 +4,10 @@
 name: CodeQL
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - ".github/**"
-      - "build_tools/**"
-      - "scan_tools/**"
-      - "tests/**"
-  # Run every Saturday at 10:00 UTC.
-  schedule:
-    - cron: "0 10 * * 6"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,7 @@ on:
     branches: [main]
   pull_request:  
     branches: [main]  
-    paths:  
+    paths:
       - '**.py'
       - '.github/workflows/**'
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,8 +6,11 @@ name: CodeQL
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  pull_request:  
+    branches: [main]  
+    paths:  
+      - '**.py'
+      - '.github/workflows/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,11 +6,14 @@ name: CodeQL
 on:
   push:
     branches: [main]
+    paths:
+      - '**/*.py'
+      - '.github/**'
   pull_request:
     branches: [main]
     paths:
-      - '**.py'
-      - '.github/workflows/**'
+      - '**/*.py'
+      - '.github/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,8 +6,8 @@ name: CodeQL
 on:
   push:
     branches: [main]
-  pull_request:  
-    branches: [main]  
+  pull_request:
+    branches: [main]
     paths:
       - '**.py'
       - '.github/workflows/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,8 +16,10 @@ concurrency:
 
 jobs:
   analyze:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
## Motivation

Minimal implementation of codeql for python and github actions. First step in enabling codeql. Second step should compile the rock with ccache off and with codeql flags. 

## Technical Details
Runs on each pull request and on each post merge for security tab update. Pull requests are limited only to paths containing python scripts and gh actions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
