### PR TITLE
fix(cmake): pin HIP compiler variables in amd-hip toolchain file

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1819,9 +1819,14 @@ function(_therock_cmake_subproject_setup_toolchain
     # CMakeDetermineHIPCompiler, which scans the system and silently picks up
     # /opt/rocm-*/bin/* when present. See ROCm/TheRock#102 and the matching
     # pattern in examples/CMakeLists.txt.
+    # CACHE ... FORCE is required because CMakeDetermineHIPCompiler runs after
+    # the toolchain file is processed and would override plain set() calls.
+    # Forcing into the cache makes the values visible to the determine module
+    # so it skips detection entirely.
     string(APPEND _toolchain_contents "set(CMAKE_HIP_PLATFORM \"amd\" CACHE STRING \"\" FORCE)\n")
     string(APPEND _toolchain_contents "set(CMAKE_HIP_COMPILER_ROCM_ROOT \"@_hip_dist_dir@\" CACHE PATH \"\" FORCE)\n")
     string(APPEND _toolchain_contents "set(CMAKE_HIP_COMPILER \"@AMD_LLVM_CXX_COMPILER@\" CACHE FILEPATH \"\" FORCE)\n")
+    string(APPEND _toolchain_contents "set(CMAKE_HIP_COMPILER_LAUNCHER \"@CMAKE_CXX_COMPILER_LAUNCHER@\" CACHE STRING \"\" FORCE)\n")
 
     if(THEROCK_VERBOSE)
       message(STATUS "HIP_DIR = ${_hip_dist_dir}")

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1830,7 +1830,7 @@ function(_therock_cmake_subproject_setup_toolchain
 
     if(THEROCK_VERBOSE)
       message(STATUS "HIP_DIR = ${_hip_dist_dir}")
-      message(STATUS "CMAKE_HIP_COMPILER = ${AMD_LLVM_CXX_COMPILER}")
+      message(STATUS "CMAKE_HIP_COMPILER = ${CMAKE_HIP_COMPILER}")
     endif()
   endif()
 

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1813,8 +1813,19 @@ function(_therock_cmake_subproject_setup_toolchain
     list(APPEND _compiler_toolchain_addl_depends "${_hip_stamp_dir}/stage.stamp")
     string(APPEND _toolchain_contents "string(APPEND CMAKE_CXX_FLAGS_INIT \" --hip-path=@_hip_dist_dir@\")\n")
     string(APPEND _toolchain_contents "string(APPEND CMAKE_CXX_FLAGS_INIT \" --hip-device-lib-path=@_amd_llvm_device_lib_path@\")\n")
+
+    # Pin the HIP language to TheRock's toolchain. Without these, any subproject
+    # that does `project(... LANGUAGES HIP)` or `enable_language(HIP)` triggers
+    # CMakeDetermineHIPCompiler, which scans the system and silently picks up
+    # /opt/rocm-*/bin/* when present. See ROCm/TheRock#102 and the matching
+    # pattern in examples/CMakeLists.txt.
+    string(APPEND _toolchain_contents "set(CMAKE_HIP_PLATFORM \"amd\" CACHE STRING \"\" FORCE)\n")
+    string(APPEND _toolchain_contents "set(CMAKE_HIP_COMPILER_ROCM_ROOT \"@_hip_dist_dir@\" CACHE PATH \"\" FORCE)\n")
+    string(APPEND _toolchain_contents "set(CMAKE_HIP_COMPILER \"@AMD_LLVM_CXX_COMPILER@\" CACHE FILEPATH \"\" FORCE)\n")
+
     if(THEROCK_VERBOSE)
       message(STATUS "HIP_DIR = ${_hip_dist_dir}")
+      message(STATUS "CMAKE_HIP_COMPILER = ${AMD_LLVM_CXX_COMPILER}")
     endif()
   endif()
 


### PR DESCRIPTION
## Motivation

Guarantee that subprojects using `COMPILER_TOOLCHAIN amd-hip` always build
with TheRock's own HIP compiler rather than a system-discovered one.

## Technical Details

Subprojects that call `project(... LANGUAGES HIP)` or `enable_language(HIP)`
trigger `CMakeDetermineHIPCompiler`, which scans the system and silently picks
up `/opt/rocm-*/bin/*` when a system ROCm install is present. Inside the
manylinux build container this was latent; on a developer machine with
`/opt/rocm-7.3` installed it caused `rocr-debug-agent-tests` and `libhipcxx`
to compile against the wrong toolchain.

Emit `CMAKE_HIP_PLATFORM`, `CMAKE_HIP_COMPILER_ROCM_ROOT`, `CMAKE_HIP_COMPILER`,
and `CMAKE_HIP_COMPILER_LAUNCHER` into the generated toolchain file using
`CACHE ... FORCE`. The `FORCE` is required because `CMakeDetermineHIPCompiler`
runs *after* the toolchain file is processed and would override plain `set()`
calls — forcing into the cache makes the values visible to the determine module
so it skips detection entirely. This mirrors the pattern in
`examples/CMakeLists.txt` (ROCm/TheRock#102).

`CMAKE_HIP_COMPILER_LAUNCHER` is propagated from `CMAKE_CXX_COMPILER_LAUNCHER`
so that HIP compilation benefits from ccache, consistent with C/CXX targets.

## Test Plan

Tested by observing the HIP compiler used to build the mentioned subprojects.
Also validated with a local script that confirms the CMake variables point at
TheRock's compiler.

## Test Result

Confirmed the correct compiler is being used.

ISSUE ID : #102