### PR TITLE
Add new PyTorch manifest generation and checkout scripts

### DIFF
--- a/build_tools/github_actions/generate_pytorch_source_manifest.py
+++ b/build_tools/github_actions/generate_pytorch_source_manifest.py
@@ -45,6 +45,7 @@ DEFAULT_PYTORCH_GIT_REFS = [
     "release/2.12",
     "nightly",
 ]
+SCHEMA_VERSION = 1
 
 THEROCK_DIR = Path(__file__).resolve().parents[2]
 TRITON_WINDOWS_REPO = "triton-lang/triton-windows"
@@ -92,6 +93,8 @@ REPOS: dict[str, RepoConfig] = {
     "triton": RepoConfig(
         stable_repo="ROCm/triton",
         nightly_repo="ROCm/triton",
+        # Triton does not use a floating nightly branch. PyTorch's pin files
+        # resolve the exact commit and the base package version.
         # Windows release Triton is not enabled by default until PyTorch repos
         # publish a shared pin format for release branches.
         exclude_platforms=("windows",),
@@ -130,7 +133,10 @@ def manifest_filename(*, platform: str, pytorch_git_ref: str) -> str:
 
 
 def write_manifest_file(path: Path, manifest: Manifest) -> None:
-    serialized_manifest = {name: entry.to_dict() for name, entry in manifest.items()}
+    serialized_manifest: dict[str, object] = {"schema_version": SCHEMA_VERSION}
+    serialized_manifest.update(
+        {name: entry.to_dict() for name, entry in manifest.items()}
+    )
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(serialized_manifest, indent=2, sort_keys=False) + "\n",
@@ -229,7 +235,9 @@ def _resolve_triton(
         )
 
     config = REPOS["triton"]
-    triton_repo = config.stable_repo
+    triton_repo = (
+        config.nightly_repo if pytorch_ref == "nightly" else config.stable_repo
+    )
     pin_file = ".ci/docker/ci_commit_pins/triton.txt"
 
     # Use PyTorch's explicit Triton pin. triton_version.txt only provides the
@@ -256,15 +264,16 @@ def default_projects_for_pytorch_ref(platform: str, pytorch_ref: str) -> list[st
     """Return default projects for a platform and PyTorch ref."""
     projects = default_projects_for_platform(platform)
 
-    # TODO: Flip this once Windows Triton nightly builds are ready by default.
-    # Release branches still need a shared PyTorch-hosted pin format.
-    if (
-        False
-        and platform == "windows"
-        and pytorch_ref == "nightly"
-        and "triton" not in projects
-    ):
-        projects.append("triton")
+    if False:
+        # TODO: Flip this once Windows Triton nightly builds are ready by
+        # default. Release branches still need a shared PyTorch-hosted pin
+        # format.
+        if (
+            platform == "windows"
+            and pytorch_ref == "nightly"
+            and "triton" not in projects
+        ):
+            projects.append("triton")
     return projects
 
 

--- a/build_tools/github_actions/generate_pytorch_source_manifest.py
+++ b/build_tools/github_actions/generate_pytorch_source_manifest.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Generate PyTorch source manifests.
+
+Resolves PyTorch ecosystem refs and pin files to exact commit SHAs and records
+expected package versions in manifest JSON files.
+
+Usage::
+
+    python generate_pytorch_source_manifest.py \
+        --rocm-version 7.13.0a20260501 \
+        --version-suffix "+rocm7.13.0a20260501" \
+        --manifest-dir /tmp/manifests \
+        --pytorch-git-refs "release/2.11"
+"""
+
+import argparse
+import json
+import platform as platform_module
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_BUILD_TOOLS_DIR))
+
+from github_actions.github_actions_api import (
+    gha_fetch_text_file_contents,
+    gha_resolve_git_ref,
+)
+from github_actions.determine_version import derive_version_suffix
+from github_actions.manifest_utils import (
+    GitSourceInfo,
+    detect_therock_source_info,
+    log,
+    normalize_ref_for_filename,
+)
+
+DEFAULT_PYTORCH_GIT_REFS = [
+    "release/2.9",
+    "release/2.10",
+    "release/2.11",
+    "release/2.12",
+    "nightly",
+]
+
+THEROCK_DIR = Path(__file__).resolve().parents[2]
+TRITON_WINDOWS_REPO = "triton-lang/triton-windows"
+
+Manifest = dict[str, GitSourceInfo]
+
+
+@dataclass(frozen=True)
+class RepoConfig:
+    """Configuration for a pytorch ecosystem repository."""
+
+    stable_repo: str
+    nightly_repo: str
+    nightly_branch: str | None = None
+    version_file: str | None = None
+    # Key in ROCm/pytorch's ``related_commits`` file (e.g. "torchaudio").
+    # When set, stable builds resolve from related_commits; when None,
+    # the repo uses custom resolution logic (pytorch itself, triton).
+    related_commits_key: str | None = None
+    # Platforms this repo is excluded from. Empty means all platforms.
+    exclude_platforms: tuple[str, ...] = ()
+
+
+REPOS: dict[str, RepoConfig] = {
+    "pytorch": RepoConfig(
+        stable_repo="ROCm/pytorch",
+        nightly_repo="pytorch/pytorch",
+        nightly_branch="nightly",
+        version_file="version.txt",
+    ),
+    "pytorch_audio": RepoConfig(
+        stable_repo="pytorch/audio",
+        nightly_repo="pytorch/audio",
+        nightly_branch="nightly",
+        version_file="version.txt",
+        related_commits_key="torchaudio",
+    ),
+    "pytorch_vision": RepoConfig(
+        stable_repo="pytorch/vision",
+        nightly_repo="pytorch/vision",
+        nightly_branch="nightly",
+        version_file="version.txt",
+        related_commits_key="torchvision",
+    ),
+    "triton": RepoConfig(
+        stable_repo="ROCm/triton",
+        nightly_repo="ROCm/triton",
+        # Windows release Triton is not enabled by default until PyTorch repos
+        # publish a shared pin format for release branches.
+        exclude_platforms=("windows",),
+    ),
+    "apex": RepoConfig(
+        stable_repo="ROCm/apex",
+        nightly_repo="ROCm/apex",
+        nightly_branch="master",
+        version_file="version.txt",
+        related_commits_key="apex",
+        exclude_platforms=("windows",),
+    ),
+}
+
+
+def _split_words(value: str) -> list[str]:
+    return value.replace(";", " ").split() if value else []
+
+
+def validate_projects(projects: list[str]) -> None:
+    """Validate requested project names before resolving refs."""
+    unknown = sorted(set(projects) - set(REPOS))
+    if unknown:
+        available = ", ".join(REPOS)
+        raise ValueError(
+            f"Unknown PyTorch manifest project(s): {', '.join(unknown)}. "
+            f"Available projects: {available}"
+        )
+    if "pytorch" not in projects:
+        raise ValueError("pytorch must be in the projects list")
+
+
+def manifest_filename(*, platform: str, pytorch_git_ref: str) -> str:
+    ref = normalize_ref_for_filename(pytorch_git_ref)
+    return f"therock-manifest_torch_{platform}_{ref}.json"
+
+
+def write_manifest_file(path: Path, manifest: Manifest) -> None:
+    serialized_manifest = {name: entry.to_dict() for name, entry in manifest.items()}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(serialized_manifest, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+    if not path.is_file() or path.stat().st_size == 0:
+        raise RuntimeError(f"Failed to write manifest: {path}")
+
+
+def _parse_related_commits(content: str) -> dict[str, dict[str, str]]:
+    """Parse ROCm/pytorch's ``related_commits`` file.
+
+    Returns a dict keyed by project name (e.g. "torchaudio") with
+    "origin" and "commit" fields. Some release branches list both
+    ``ubuntu`` and ``centos`` entries with the same pin, while others only
+    list one platform. Since the manifest needs one commit per project, reject
+    duplicate project rows that disagree.
+    """
+    pins: dict[str, dict[str, str]] = {}
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Example:
+        # ubuntu|pytorch|torchaudio|release/2.10|<commit>|https://github.com/pytorch/audio
+        parts = line.split("|")
+        if len(parts) != 6:
+            raise ValueError(f"Malformed related_commits line: {line!r}")
+        rec_os, _source, rec_project, _branch, rec_commit, rec_origin = parts
+        pin = {"origin": rec_origin, "commit": rec_commit}
+        previous = pins.get(rec_project)
+        if previous is not None and previous != pin:
+            raise ValueError(
+                f"Conflicting related_commits entries for {rec_project!r}: "
+                f"{previous!r} vs {pin!r} on {rec_os!r}"
+            )
+        pins[rec_project] = pin
+    return pins
+
+
+def read_triton_windows_pin() -> str:
+    """Read TheRock's current Windows Triton commit pin."""
+    pin_file = (
+        THEROCK_DIR
+        / "external-builds"
+        / "pytorch"
+        / "ci_commit_pins"
+        / "triton-windows.txt"
+    )
+    if not pin_file.is_file():
+        raise FileNotFoundError(f"Windows Triton pin file does not exist: {pin_file}")
+    pin = pin_file.read_text(encoding="utf-8").strip()
+    if not pin:
+        raise ValueError(f"Windows Triton pin file is empty: {pin_file}")
+    return pin
+
+
+def _resolve_triton(
+    pytorch_repo: str,
+    pytorch_ref: str,
+    pytorch_sha: str,
+    *,
+    version_suffix: str,
+    platform: str,
+) -> GitSourceInfo:
+    """Resolve triton commit and version from pytorch's pin files.
+
+    The triton base version lives in pytorch's ``.ci/docker/triton_version.txt``.
+    On Linux the commit comes from ``ci_commit_pins/triton.txt``.
+    See:
+    https://github.com/pytorch/pytorch/blob/main/.ci/docker/triton_version.txt
+    https://github.com/pytorch/pytorch/blob/main/.ci/docker/ci_commit_pins/triton.txt
+    """
+    is_windows = platform == "windows"
+
+    if is_windows and pytorch_ref != "nightly":
+        raise ValueError(
+            "Windows Triton manifest generation currently supports only "
+            "PyTorch nightly"
+        )
+
+    # Base version is always in pytorch's triton_version.txt.
+    base_version = gha_fetch_text_file_contents(
+        pytorch_repo, ".ci/docker/triton_version.txt", pytorch_sha
+    ).strip()
+    version = f"{base_version}{version_suffix}"
+    log(f"  triton: {base_version} -> {version}")
+
+    if is_windows:
+        pin = read_triton_windows_pin()
+        log(f"  triton-windows pin: {pin[:12]}")
+        return GitSourceInfo(
+            commit=pin,
+            repo=f"https://github.com/{TRITON_WINDOWS_REPO}",
+            version=version,
+        )
+
+    config = REPOS["triton"]
+    triton_repo = config.stable_repo
+    pin_file = ".ci/docker/ci_commit_pins/triton.txt"
+
+    # Use PyTorch's explicit Triton pin. triton_version.txt only provides the
+    # package version; the matching release branch can move independently.
+    pin = gha_fetch_text_file_contents(pytorch_repo, pin_file, pytorch_sha).strip()
+    log(f"  triton pin: {pin[:12]}")
+    return GitSourceInfo(
+        commit=pin,
+        repo=f"https://github.com/{triton_repo}",
+        version=version,
+    )
+
+
+def default_projects_for_platform(platform: str) -> list[str]:
+    """Return the default project list for a platform."""
+    return [
+        name
+        for name, config in REPOS.items()
+        if platform not in config.exclude_platforms
+    ]
+
+
+def default_projects_for_pytorch_ref(platform: str, pytorch_ref: str) -> list[str]:
+    """Return default projects for a platform and PyTorch ref."""
+    projects = default_projects_for_platform(platform)
+
+    # TODO: Flip this once Windows Triton nightly builds are ready by default.
+    # Release branches still need a shared PyTorch-hosted pin format.
+    if (
+        False
+        and platform == "windows"
+        and pytorch_ref == "nightly"
+        and "triton" not in projects
+    ):
+        projects.append("triton")
+    return projects
+
+
+def resolve_sources(
+    pytorch_ref: str,
+    version_suffix: str,
+    platform: str,
+    projects: list[str],
+) -> dict[str, GitSourceInfo]:
+    """Resolve source commits for the requested projects."""
+    validate_projects(projects)
+
+    nightly = pytorch_ref == "nightly"
+    sources: dict[str, GitSourceInfo] = {}
+
+    # Resolve pytorch first — other repos depend on it for pin files.
+    pytorch_config = REPOS["pytorch"]
+    pytorch_repo = (
+        pytorch_config.nightly_repo if nightly else pytorch_config.stable_repo
+    )
+    pytorch_sha = gha_resolve_git_ref(pytorch_repo, pytorch_ref)
+    log(f"  {pytorch_repo}@{pytorch_ref} -> {pytorch_sha[:12]}")
+    sources["pytorch"] = GitSourceInfo(
+        commit=pytorch_sha,
+        repo=f"https://github.com/{pytorch_repo}",
+        branch=pytorch_ref,
+    )
+
+    # For stable builds, load related_commits once (used by repos that have
+    # a related_commits_key).
+    pins: dict[str, dict[str, str]] = {}
+    needs_related_commits = any(
+        name != "pytorch"
+        and name in projects
+        and REPOS[name].related_commits_key is not None
+        for name in REPOS
+    )
+    if not nightly and needs_related_commits:
+        related_content = gha_fetch_text_file_contents(
+            pytorch_repo, "related_commits", pytorch_sha
+        )
+        pins = _parse_related_commits(related_content)
+
+    # Resolve remaining repos.
+    for name, config in REPOS.items():
+        if name == "pytorch" or name not in projects:
+            continue
+
+        # Triton has its own pin mechanism.
+        if name == "triton":
+            sources[name] = _resolve_triton(
+                pytorch_repo,
+                pytorch_ref,
+                pytorch_sha,
+                version_suffix=version_suffix,
+                platform=platform,
+            )
+            continue
+
+        if nightly:
+            sha = gha_resolve_git_ref(config.nightly_repo, config.nightly_branch)
+            log(f"  {config.nightly_repo}@{config.nightly_branch} -> {sha[:12]}")
+            sources[name] = GitSourceInfo(
+                commit=sha,
+                repo=f"https://github.com/{config.nightly_repo}",
+                branch=config.nightly_branch,
+            )
+        elif config.related_commits_key and config.related_commits_key in pins:
+            pin = pins[config.related_commits_key]
+            sources[name] = GitSourceInfo(commit=pin["commit"], repo=pin["origin"])
+        elif config.related_commits_key:
+            raise ValueError(
+                f"{pytorch_ref}: related_commits is missing "
+                f"{config.related_commits_key!r} for {name!r}"
+            )
+        else:
+            raise ValueError(
+                f"{name!r} does not have a stable PyTorch release pin policy"
+            )
+
+    return sources
+
+
+def fetch_versions(
+    sources: dict[str, GitSourceInfo], version_suffix: str
+) -> dict[str, GitSourceInfo]:
+    """Fetch version.txt for each repo and return updated GitSourceInfo entries.
+
+    PyTorch ecosystem projects store their base Python package versions in
+    plain text files such as ``version.txt``. For example:
+    https://github.com/pytorch/pytorch/blob/nightly/version.txt
+
+    This step reads those base versions at the already-resolved commits and
+    appends TheRock's ROCm version suffix. Projects without a version_file, such
+    as Triton, must have their version filled in by their custom resolver.
+    """
+    updated: dict[str, GitSourceInfo] = {}
+    for name, info in sources.items():
+        version_file = REPOS[name].version_file
+        if version_file is None:
+            updated[name] = info
+            continue
+
+        repo = (
+            info.repo.removeprefix("https://github.com/")
+            .removesuffix(".git")
+            .rstrip("/")
+        )
+        base_version = gha_fetch_text_file_contents(
+            repo, version_file, info.commit
+        ).strip()
+        full_version = f"{base_version}{version_suffix}"
+        log(f"  {name}: {base_version} -> {full_version}")
+        updated[name] = GitSourceInfo(
+            commit=info.commit, repo=info.repo, branch=info.branch, version=full_version
+        )
+    return updated
+
+
+def generate_manifest(
+    *,
+    pytorch_git_ref: str,
+    rocm_version: str,
+    version_suffix: str,
+    platform: str,
+    projects: list[str],
+    therock_commit: str,
+    therock_repo: str,
+    therock_branch: str,
+) -> Manifest:
+    """Generate a single manifest for one pytorch_git_ref."""
+    log(f"Generating manifest for {pytorch_git_ref} ({platform})")
+
+    sources = resolve_sources(pytorch_git_ref, version_suffix, platform, projects)
+    sources = fetch_versions(sources, version_suffix)
+    sources["therock"] = GitSourceInfo(
+        repo=therock_repo,
+        commit=therock_commit,
+        branch=therock_branch,
+        version=rocm_version,
+    )
+
+    return sources
+
+
+def main(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(description="Generate PyTorch source manifests")
+    parser.add_argument("--rocm-version", required=True, help="e.g. 7.13.0a20260501")
+    parser.add_argument(
+        "--version-suffix",
+        default="",
+        help="e.g. +rocm7.13.0a20260501 (default: derive from --rocm-version)",
+    )
+    parser.add_argument(
+        "--platform",
+        choices=["linux", "windows"],
+        default=platform_module.system().lower(),
+        help=(
+            "Target platform (affects repo selection and exclusions; "
+            "default: current system)"
+        ),
+    )
+    output_group = parser.add_mutually_exclusive_group(required=True)
+    output_group.add_argument(
+        "--output",
+        type=Path,
+        help="Write a single manifest to this exact path (requires one --pytorch-git-refs entry)",
+    )
+    output_group.add_argument(
+        "--manifest-dir",
+        type=Path,
+        help="Write manifests to this directory (filenames are computed from refs)",
+    )
+    parser.add_argument(
+        "--therock-commit", help="Override TheRock commit (default: detect from git)"
+    )
+    parser.add_argument(
+        "--therock-repo", help="Override TheRock repo URL (default: detect from git)"
+    )
+    parser.add_argument(
+        "--therock-branch", help="Override TheRock branch (default: detect from git)"
+    )
+    parser.add_argument(
+        "--projects",
+        default="",
+        help=(
+            "Semicolon- or space-separated list of projects to include in the "
+            "manifest (default: all projects for the platform)"
+        ),
+    )
+    parser.add_argument(
+        "--pytorch-git-refs",
+        default="",
+        help="Semicolon- or space-separated pytorch refs (empty = all defaults)",
+    )
+    args = parser.parse_args(argv)
+
+    refs = _split_words(args.pytorch_git_refs) or DEFAULT_PYTORCH_GIT_REFS
+
+    if args.output and len(refs) != 1:
+        parser.error("--output requires exactly one --pytorch-git-refs entry")
+    explicit_projects = _split_words(args.projects) or None
+    version_suffix = args.version_suffix or derive_version_suffix(args.rocm_version)
+
+    # Detect TheRock source info from the local repo, then apply CLI overrides.
+    therock_root = Path(__file__).resolve().parents[2]
+    therock_info = detect_therock_source_info(therock_root)
+    therock_commit = args.therock_commit or therock_info.commit
+    therock_repo = args.therock_repo or therock_info.repo
+    therock_branch = args.therock_branch or therock_info.branch
+
+    log(f"ROCm version: {args.rocm_version}, suffix: {version_suffix}")
+    log(
+        f"Platform: {args.platform}, projects: "
+        f"{explicit_projects or 'default per PyTorch ref'}"
+    )
+    log(f"TheRock: {therock_commit[:12]} ({therock_branch})")
+    log(f"PyTorch refs: {refs}")
+    log("")
+
+    for ref in refs:
+        projects = explicit_projects or default_projects_for_pytorch_ref(
+            args.platform, ref
+        )
+        log(f"Projects for {ref}: {projects}")
+        manifest = generate_manifest(
+            pytorch_git_ref=ref,
+            rocm_version=args.rocm_version,
+            version_suffix=version_suffix,
+            platform=args.platform,
+            projects=projects,
+            therock_commit=therock_commit,
+            therock_repo=therock_repo,
+            therock_branch=therock_branch,
+        )
+
+        if args.output:
+            out_path = args.output
+        else:
+            out_path = args.manifest_dir / manifest_filename(
+                platform=args.platform, pytorch_git_ref=ref
+            )
+
+        write_manifest_file(out_path, manifest)
+        log(f"Wrote {out_path}")
+        log(out_path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/build_tools/github_actions/github_actions_api.py
+++ b/build_tools/github_actions/github_actions_api.py
@@ -606,6 +606,19 @@ def gha_fetch_file_contents(github_repository: str, path: str, ref: str) -> byte
         raise GitHubAPIError(f"Failed to decode GitHub contents for {path!r}") from e
 
 
+def gha_fetch_text_file_contents(
+    github_repository: str, path: str, ref: str, *, encoding: str = "utf-8"
+) -> str:
+    """Fetch and decode a text file from a GitHub repo at a specific ref."""
+    contents = gha_fetch_file_contents(github_repository, path, ref)
+    try:
+        return contents.decode(encoding)
+    except UnicodeDecodeError as e:
+        raise GitHubAPIError(
+            f"Failed to decode GitHub contents for {path!r} as {encoding}"
+        ) from e
+
+
 # TODO: Consider moving str2bool to a general-purpose utils module. It's useful
 # for GitHub Actions (YAML has fuzzy boolean handling) but is also used broadly.
 def str2bool(value: str | None) -> bool:

--- a/build_tools/github_actions/manifest_utils.py
+++ b/build_tools/github_actions/manifest_utils.py
@@ -18,16 +18,19 @@ def log(*args, **kwargs) -> None:
 
 @dataclass(frozen=True)
 class GitSourceInfo:
-    """Git commit and origin repo for a source checkout."""
+    """Git source info for a repository checkout."""
 
-    commit: str
     repo: str
+    commit: str
     branch: str | None = None
+    version: str | None = None
 
     def to_dict(self) -> dict[str, str]:
-        d = {"commit": self.commit, "repo": self.repo}
+        d = {"repo": self.repo, "commit": self.commit}
         if self.branch is not None:
             d["branch"] = self.branch
+        if self.version is not None:
+            d["version"] = self.version
         return d
 
 
@@ -130,6 +133,22 @@ def resolve_branch(*, inferred: str | None, provided: str | None) -> str | None:
     if provided:
         return provided
     return None
+
+
+def detect_therock_source_info(repo_root: Path) -> GitSourceInfo:
+    """Detect TheRock commit, repo, and branch from a local git checkout.
+
+    Falls back to "unknown" for fields that cannot be determined (e.g. when
+    not inside a git worktree).
+    """
+    commit = capture_optional(["git", "rev-parse", "HEAD"], cwd=repo_root) or "unknown"
+    repo_url = (
+        capture_optional(["git", "remote", "get-url", "origin"], cwd=repo_root)
+        or "https://github.com/ROCm/TheRock"
+    )
+    repo_url = repo_url.removesuffix(".git")
+    branch = git_branch_best_effort(repo_root) or "unknown"
+    return GitSourceInfo(commit=commit, repo=repo_url, branch=branch)
 
 
 def normalize_python_version_for_filename(python_version: str) -> str:

--- a/build_tools/github_actions/manifest_utils.py
+++ b/build_tools/github_actions/manifest_utils.py
@@ -16,6 +16,12 @@ def log(*args, **kwargs) -> None:
     sys.stdout.flush()
 
 
+def warn(*args, **kwargs) -> None:
+    """Consistent warning helper for manifest generation scripts."""
+    print("WARNING:", *args, file=sys.stderr, **kwargs)
+    sys.stderr.flush()
+
+
 @dataclass(frozen=True)
 class GitSourceInfo:
     """Git source info for a repository checkout."""
@@ -141,13 +147,23 @@ def detect_therock_source_info(repo_root: Path) -> GitSourceInfo:
     Falls back to "unknown" for fields that cannot be determined (e.g. when
     not inside a git worktree).
     """
-    commit = capture_optional(["git", "rev-parse", "HEAD"], cwd=repo_root) or "unknown"
-    repo_url = (
-        capture_optional(["git", "remote", "get-url", "origin"], cwd=repo_root)
-        or "https://github.com/ROCm/TheRock"
-    )
+    commit = capture_optional(["git", "rev-parse", "HEAD"], cwd=repo_root)
+    if commit is None:
+        warn(f"Could not detect TheRock commit from {repo_root}; using 'unknown'")
+        commit = "unknown"
+
+    repo_url = capture_optional(["git", "remote", "get-url", "origin"], cwd=repo_root)
+    if repo_url is None:
+        warn(
+            f"Could not detect TheRock origin from {repo_root}; "
+            "using https://github.com/ROCm/TheRock"
+        )
+        repo_url = "https://github.com/ROCm/TheRock"
     repo_url = repo_url.removesuffix(".git")
-    branch = git_branch_best_effort(repo_root) or "unknown"
+    branch = git_branch_best_effort(repo_root)
+    if branch is None:
+        warn(f"Could not detect TheRock branch from {repo_root}; using 'unknown'")
+        branch = "unknown"
     return GitSourceInfo(commit=commit, repo=repo_url, branch=branch)
 
 

--- a/build_tools/github_actions/tests/generate_pytorch_source_manifest_test.py
+++ b/build_tools/github_actions/tests/generate_pytorch_source_manifest_test.py
@@ -500,6 +500,7 @@ class GeneratePyTorchSourceManifestTest(unittest.TestCase):
             # Expected output from the CLI after resolving refs, deriving the
             # version suffix, filtering projects, and writing the manifest.
             expected = {
+                "schema_version": 1,
                 "pytorch": {
                     "repo": "https://github.com/ROCm/pytorch",
                     "commit": pytorch_sha,

--- a/build_tools/github_actions/tests/generate_pytorch_source_manifest_test.py
+++ b/build_tools/github_actions/tests/generate_pytorch_source_manifest_test.py
@@ -1,0 +1,565 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, os.fspath(THIS_DIR.parent.parent))
+sys.path.insert(0, os.fspath(THIS_DIR.parent))
+
+import generate_pytorch_source_manifest as m
+
+
+class GeneratePyTorchSourceManifestTest(unittest.TestCase):
+    def _patch_github_api(self, *, resolves: dict, files: dict):
+        def fake_resolve(repo: str, ref: str) -> str:
+            return resolves[(repo, ref)]
+
+        def fake_fetch(repo: str, path: str, ref: str) -> str:
+            return files[(repo, path, ref)]
+
+        return mock.patch.multiple(
+            m,
+            gha_resolve_git_ref=mock.Mock(side_effect=fake_resolve),
+            gha_fetch_text_file_contents=mock.Mock(side_effect=fake_fetch),
+        )
+
+    def _stable_windows_github_data(self) -> tuple[dict[str, str], dict, dict]:
+        shas = {
+            "pytorch": "1" * 40,
+            "audio": "2" * 40,
+            "vision": "3" * 40,
+            "triton": "4" * 40,
+        }
+        related_commits = "\n".join(
+            [
+                "ubuntu|pytorch|torchaudio|release/2.10|"
+                f"{shas['audio']}|https://github.com/pytorch/audio",
+                "ubuntu|pytorch|torchvision|release/2.10|"
+                f"{shas['vision']}|https://github.com/pytorch/vision",
+            ]
+        )
+        resolves = {
+            ("ROCm/pytorch", "release/2.10"): shas["pytorch"],
+        }
+        files = {
+            ("ROCm/pytorch", "related_commits", shas["pytorch"]): related_commits,
+            ("ROCm/pytorch", "version.txt", shas["pytorch"]): "2.10.0\n",
+            ("pytorch/audio", "version.txt", shas["audio"]): "2.10.0\n",
+            ("pytorch/vision", "version.txt", shas["vision"]): "0.25.0\n",
+        }
+        return shas, resolves, files
+
+    def _assert_related_commits_error(
+        self, related_commits: str, projects: list[str], pattern: str
+    ) -> None:
+        pytorch_sha = "1" * 40
+        resolves = {
+            ("ROCm/pytorch", "release/2.10"): pytorch_sha,
+        }
+        files = {
+            ("ROCm/pytorch", "related_commits", pytorch_sha): related_commits,
+        }
+
+        with self._patch_github_api(resolves=resolves, files=files):
+            with self.assertRaisesRegex(ValueError, pattern):
+                m.generate_manifest(
+                    pytorch_git_ref="release/2.10",
+                    rocm_version="7.13.0a20260501",
+                    version_suffix="+rocm7.13.0a20260501",
+                    platform="linux",
+                    projects=projects,
+                    therock_commit="a" * 40,
+                    therock_repo="https://github.com/ROCm/TheRock",
+                    therock_branch="main",
+                )
+
+    def test_stable_linux_manifest_resolves_related_commits_and_versions(self) -> None:
+        shas = {
+            "pytorch": "1" * 40,
+            "audio": "2" * 40,
+            "vision": "3" * 40,
+            "triton": "4" * 40,
+            "apex": "5" * 40,
+        }
+        related_commits = "\n".join(
+            [
+                "ubuntu|pytorch|torchaudio|release/2.10|"
+                f"{shas['audio']}|https://github.com/pytorch/audio",
+                "centos|pytorch|torchaudio|release/2.10|"
+                f"{shas['audio']}|https://github.com/pytorch/audio",
+                "ubuntu|pytorch|torchvision|release/2.10|"
+                f"{shas['vision']}|https://github.com/pytorch/vision",
+                "centos|pytorch|torchvision|release/2.10|"
+                f"{shas['vision']}|https://github.com/pytorch/vision",
+                "ubuntu|pytorch|apex|release/2.10|"
+                f"{shas['apex']}|https://github.com/ROCm/apex",
+                "centos|pytorch|apex|release/2.10|"
+                f"{shas['apex']}|https://github.com/ROCm/apex",
+            ]
+        )
+        resolves = {
+            ("ROCm/pytorch", "release/2.10"): shas["pytorch"],
+        }
+        files = {
+            ("ROCm/pytorch", "related_commits", shas["pytorch"]): related_commits,
+            (
+                "ROCm/pytorch",
+                ".ci/docker/triton_version.txt",
+                shas["pytorch"],
+            ): "3.6.0\n",
+            (
+                "ROCm/pytorch",
+                ".ci/docker/ci_commit_pins/triton.txt",
+                shas["pytorch"],
+            ): shas["triton"],
+            ("ROCm/pytorch", "version.txt", shas["pytorch"]): "2.10.0\n",
+            ("pytorch/audio", "version.txt", shas["audio"]): "2.10.0\n",
+            ("pytorch/vision", "version.txt", shas["vision"]): "0.25.0\n",
+            ("ROCm/apex", "version.txt", shas["apex"]): "1.10.0\n",
+        }
+
+        with self._patch_github_api(resolves=resolves, files=files):
+            manifest = m.generate_manifest(
+                pytorch_git_ref="release/2.10",
+                rocm_version="7.13.0a20260501",
+                version_suffix="+rocm7.13.0a20260501",
+                platform="linux",
+                projects=[
+                    "pytorch",
+                    "pytorch_audio",
+                    "pytorch_vision",
+                    "triton",
+                    "apex",
+                ],
+                therock_commit="a" * 40,
+                therock_repo="https://github.com/ROCm/TheRock",
+                therock_branch="users/example/branch",
+            )
+
+        self.assertEqual(
+            manifest,
+            {
+                "pytorch": m.GitSourceInfo(
+                    repo="https://github.com/ROCm/pytorch",
+                    commit=shas["pytorch"],
+                    branch="release/2.10",
+                    version="2.10.0+rocm7.13.0a20260501",
+                ),
+                "pytorch_audio": m.GitSourceInfo(
+                    repo="https://github.com/pytorch/audio",
+                    commit=shas["audio"],
+                    version="2.10.0+rocm7.13.0a20260501",
+                ),
+                "pytorch_vision": m.GitSourceInfo(
+                    repo="https://github.com/pytorch/vision",
+                    commit=shas["vision"],
+                    version="0.25.0+rocm7.13.0a20260501",
+                ),
+                "triton": m.GitSourceInfo(
+                    repo="https://github.com/ROCm/triton",
+                    commit=shas["triton"],
+                    version="3.6.0+rocm7.13.0a20260501",
+                ),
+                "apex": m.GitSourceInfo(
+                    repo="https://github.com/ROCm/apex",
+                    commit=shas["apex"],
+                    version="1.10.0+rocm7.13.0a20260501",
+                ),
+                "therock": m.GitSourceInfo(
+                    repo="https://github.com/ROCm/TheRock",
+                    commit="a" * 40,
+                    branch="users/example/branch",
+                    version="7.13.0a20260501",
+                ),
+            },
+        )
+
+    def test_stable_manifest_requires_related_commit_pins(self) -> None:
+        pytorch_sha = "1" * 40
+        resolves = {
+            ("ROCm/pytorch", "release/2.10"): pytorch_sha,
+        }
+        files = {
+            ("ROCm/pytorch", "related_commits", pytorch_sha): "",
+        }
+
+        with self._patch_github_api(resolves=resolves, files=files):
+            with self.assertRaisesRegex(ValueError, "torchaudio"):
+                m.generate_manifest(
+                    pytorch_git_ref="release/2.10",
+                    rocm_version="7.13.0a20260501",
+                    version_suffix="+rocm7.13.0a20260501",
+                    platform="linux",
+                    projects=["pytorch", "pytorch_audio"],
+                    therock_commit="a" * 40,
+                    therock_repo="https://github.com/ROCm/TheRock",
+                    therock_branch="main",
+                )
+
+    def test_pytorch_only_manifest_does_not_fetch_related_commits(self) -> None:
+        pytorch_sha = "1" * 40
+        resolves = {
+            ("ROCm/pytorch", "release/2.10"): pytorch_sha,
+        }
+        files = {
+            ("ROCm/pytorch", "version.txt", pytorch_sha): "2.10.0\n",
+        }
+
+        with self._patch_github_api(resolves=resolves, files=files):
+            manifest = m.generate_manifest(
+                pytorch_git_ref="release/2.10",
+                rocm_version="7.13.0a20260501",
+                version_suffix="+rocm7.13.0a20260501",
+                platform="linux",
+                projects=["pytorch"],
+                therock_commit="a" * 40,
+                therock_repo="https://github.com/ROCm/TheRock",
+                therock_branch="main",
+            )
+
+        self.assertEqual(
+            manifest,
+            {
+                "pytorch": m.GitSourceInfo(
+                    repo="https://github.com/ROCm/pytorch",
+                    commit=pytorch_sha,
+                    branch="release/2.10",
+                    version="2.10.0+rocm7.13.0a20260501",
+                ),
+                "therock": m.GitSourceInfo(
+                    repo="https://github.com/ROCm/TheRock",
+                    commit="a" * 40,
+                    branch="main",
+                    version="7.13.0a20260501",
+                ),
+            },
+        )
+
+    def test_manifest_rejects_unknown_project_before_resolving_refs(self) -> None:
+        unknown_project = "pytorch_vison"  # Missing the second "i" in "vision".
+        with mock.patch.object(m, "gha_resolve_git_ref") as resolve_ref:
+            with self.assertRaisesRegex(ValueError, unknown_project):
+                m.generate_manifest(
+                    pytorch_git_ref="release/2.10",
+                    rocm_version="7.13.0a20260501",
+                    version_suffix="+rocm7.13.0a20260501",
+                    platform="linux",
+                    projects=["pytorch", unknown_project],
+                    therock_commit="a" * 40,
+                    therock_repo="https://github.com/ROCm/TheRock",
+                    therock_branch="main",
+                )
+
+        resolve_ref.assert_not_called()
+
+    def test_malformed_related_commits_error(self) -> None:
+        self._assert_related_commits_error(
+            "centos|src|torchaudio",
+            ["pytorch", "pytorch_audio"],
+            "Malformed related_commits",
+        )
+
+    def test_conflicting_related_commits_error(self) -> None:
+        self._assert_related_commits_error(
+            "\n".join(
+                [
+                    "ubuntu|pytorch|torchvision|release/0.27|"
+                    f"{'2' * 40}|https://github.com/pytorch/vision",
+                    "centos|pytorch|torchvision|release/0.27|"
+                    f"{'3' * 40}|https://github.com/pytorch/vision",
+                ]
+            ),
+            ["pytorch", "pytorch_vision"],
+            "Conflicting related_commits",
+        )
+
+    def test_nightly_linux_manifest_uses_triton_pin(self) -> None:
+        shas = {
+            "pytorch": "1" * 40,
+            "audio": "2" * 40,
+            "vision": "3" * 40,
+            "triton": "4" * 40,
+            "apex": "5" * 40,
+        }
+        resolves = {
+            ("pytorch/pytorch", "nightly"): shas["pytorch"],
+            ("pytorch/audio", "nightly"): shas["audio"],
+            ("pytorch/vision", "nightly"): shas["vision"],
+            ("ROCm/apex", "master"): shas["apex"],
+        }
+        files = {
+            (
+                "pytorch/pytorch",
+                ".ci/docker/triton_version.txt",
+                shas["pytorch"],
+            ): "3.6.0\n",
+            (
+                "pytorch/pytorch",
+                ".ci/docker/ci_commit_pins/triton.txt",
+                shas["pytorch"],
+            ): shas["triton"],
+            ("pytorch/pytorch", "version.txt", shas["pytorch"]): "2.11.0a0\n",
+            ("pytorch/audio", "version.txt", shas["audio"]): "2.11.0a0\n",
+            ("pytorch/vision", "version.txt", shas["vision"]): "0.26.0a0\n",
+            ("ROCm/apex", "version.txt", shas["apex"]): "1.11.0\n",
+        }
+
+        with self._patch_github_api(resolves=resolves, files=files):
+            manifest = m.generate_manifest(
+                pytorch_git_ref="nightly",
+                rocm_version="7.13.0.dev0+abc",
+                version_suffix="+devrocm7.13.0.dev0-abc",
+                platform="linux",
+                projects=[
+                    "pytorch",
+                    "pytorch_audio",
+                    "pytorch_vision",
+                    "triton",
+                    "apex",
+                ],
+                therock_commit="a" * 40,
+                therock_repo="https://github.com/ROCm/TheRock",
+                therock_branch="main",
+            )
+
+        self.assertEqual(
+            manifest,
+            {
+                "pytorch": m.GitSourceInfo(
+                    repo="https://github.com/pytorch/pytorch",
+                    commit=shas["pytorch"],
+                    branch="nightly",
+                    version="2.11.0a0+devrocm7.13.0.dev0-abc",
+                ),
+                "pytorch_audio": m.GitSourceInfo(
+                    repo="https://github.com/pytorch/audio",
+                    commit=shas["audio"],
+                    branch="nightly",
+                    version="2.11.0a0+devrocm7.13.0.dev0-abc",
+                ),
+                "pytorch_vision": m.GitSourceInfo(
+                    repo="https://github.com/pytorch/vision",
+                    commit=shas["vision"],
+                    branch="nightly",
+                    version="0.26.0a0+devrocm7.13.0.dev0-abc",
+                ),
+                "triton": m.GitSourceInfo(
+                    repo="https://github.com/ROCm/triton",
+                    commit=shas["triton"],
+                    version="3.6.0+devrocm7.13.0.dev0-abc",
+                ),
+                "apex": m.GitSourceInfo(
+                    repo="https://github.com/ROCm/apex",
+                    commit=shas["apex"],
+                    branch="master",
+                    version="1.11.0+devrocm7.13.0.dev0-abc",
+                ),
+                "therock": m.GitSourceInfo(
+                    repo="https://github.com/ROCm/TheRock",
+                    commit="a" * 40,
+                    branch="main",
+                    version="7.13.0.dev0+abc",
+                ),
+            },
+        )
+
+    def test_windows_release_manifest_excludes_triton_and_apex_by_default(self) -> None:
+        _shas, resolves, files = self._stable_windows_github_data()
+
+        with self._patch_github_api(resolves=resolves, files=files):
+            manifest = m.generate_manifest(
+                pytorch_git_ref="release/2.10",
+                rocm_version="7.13.0a20260501",
+                version_suffix="+rocm7.13.0a20260501",
+                platform="windows",
+                projects=["pytorch", "pytorch_audio", "pytorch_vision"],
+                therock_commit="a" * 40,
+                therock_repo="https://github.com/ROCm/TheRock",
+                therock_branch="main",
+            )
+
+        self.assertNotIn("apex", manifest)
+        self.assertNotIn("triton", manifest)
+
+    @unittest.skip("Enable when Windows Triton nightly builds are on by default")
+    def test_windows_nightly_default_projects_include_triton(self) -> None:
+        self.assertEqual(
+            m.default_projects_for_pytorch_ref("windows", "nightly"),
+            ["pytorch", "pytorch_audio", "pytorch_vision", "triton"],
+        )
+
+    def test_windows_nightly_manifest_uses_triton_windows_pin(self) -> None:
+        shas = {
+            "pytorch": "1" * 40,
+            "audio": "2" * 40,
+            "vision": "3" * 40,
+            "triton_windows": "4" * 40,
+        }
+        resolves = {
+            ("pytorch/pytorch", "nightly"): shas["pytorch"],
+            ("pytorch/audio", "nightly"): shas["audio"],
+            ("pytorch/vision", "nightly"): shas["vision"],
+        }
+        files = {
+            (
+                "pytorch/pytorch",
+                ".ci/docker/triton_version.txt",
+                shas["pytorch"],
+            ): "3.6.0\n",
+            ("pytorch/pytorch", "version.txt", shas["pytorch"]): "2.13.0a0\n",
+            ("pytorch/audio", "version.txt", shas["audio"]): "2.13.0a0\n",
+            ("pytorch/vision", "version.txt", shas["vision"]): "0.28.0a0\n",
+        }
+
+        with mock.patch.object(
+            m, "read_triton_windows_pin", return_value=shas["triton_windows"]
+        ), self._patch_github_api(resolves=resolves, files=files):
+            manifest = m.generate_manifest(
+                pytorch_git_ref="nightly",
+                rocm_version="7.13.0.dev0+abc",
+                version_suffix="+devrocm7.13.0.dev0-abc",
+                platform="windows",
+                projects=["pytorch", "pytorch_audio", "pytorch_vision", "triton"],
+                therock_commit="a" * 40,
+                therock_repo="https://github.com/ROCm/TheRock",
+                therock_branch="main",
+            )
+
+        self.assertEqual(
+            manifest["triton"],
+            m.GitSourceInfo(
+                repo="https://github.com/triton-lang/triton-windows",
+                commit=shas["triton_windows"],
+                version="3.6.0+devrocm7.13.0.dev0-abc",
+            ),
+        )
+        self.assertNotIn("apex", manifest)
+
+    def test_windows_release_manifest_triton_opt_in_errors(self) -> None:
+        pytorch_sha = "1" * 40
+        resolves = {
+            ("ROCm/pytorch", "release/2.10"): pytorch_sha,
+        }
+        files = {}
+
+        with self._patch_github_api(resolves=resolves, files=files):
+            with self.assertRaisesRegex(
+                ValueError,
+                "Windows Triton.*PyTorch nightly",
+            ):
+                m.generate_manifest(
+                    pytorch_git_ref="release/2.10",
+                    rocm_version="7.13.0a20260501",
+                    version_suffix="+rocm7.13.0a20260501",
+                    platform="windows",
+                    projects=[
+                        "pytorch",
+                        "triton",
+                    ],
+                    therock_commit="a" * 40,
+                    therock_repo="https://github.com/ROCm/TheRock",
+                    therock_branch="main",
+                )
+
+    def test_main_writes_single_output_manifest_with_project_filter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = Path(tmp) / "manifest.json"
+            pytorch_sha = "1" * 40
+            triton_sha = "2" * 40
+            pytorch_repo = "ROCm/pytorch"
+            pytorch_ref = "release/2.10"
+
+            # Mock GitHub ref resolution for the requested PyTorch ref.
+            resolves = {
+                (pytorch_repo, pytorch_ref): pytorch_sha,
+            }
+
+            # Mock files fetched from the resolved PyTorch commit. Triton gets
+            # both its package version and source commit from PyTorch pin files.
+            files = {
+                (
+                    pytorch_repo,
+                    ".ci/docker/triton_version.txt",
+                    pytorch_sha,
+                ): "3.6.0\n",
+                (
+                    pytorch_repo,
+                    ".ci/docker/ci_commit_pins/triton.txt",
+                    pytorch_sha,
+                ): triton_sha,
+                (pytorch_repo, "version.txt", pytorch_sha): "2.10.0\n",
+            }
+
+            # Expected output from the CLI after resolving refs, deriving the
+            # version suffix, filtering projects, and writing the manifest.
+            expected = {
+                "pytorch": {
+                    "repo": "https://github.com/ROCm/pytorch",
+                    "commit": pytorch_sha,
+                    "branch": pytorch_ref,
+                    "version": "2.10.0+rocm7.13.0",
+                },
+                "triton": {
+                    "repo": "https://github.com/ROCm/triton",
+                    "commit": triton_sha,
+                    "version": "3.6.0+rocm7.13.0",
+                },
+                "therock": {
+                    "repo": "https://github.com/ROCm/TheRock",
+                    "commit": "a" * 40,
+                    "branch": "main",
+                    "version": "7.13.0",
+                },
+            }
+            with mock.patch.object(
+                m,
+                "detect_therock_source_info",
+                return_value=m.GitSourceInfo(
+                    repo="https://github.com/ROCm/TheRock",
+                    commit="a" * 40,
+                    branch="main",
+                ),
+            ), self._patch_github_api(resolves=resolves, files=files):
+                m.main(
+                    [
+                        "--rocm-version",
+                        "7.13.0",
+                        "--platform",
+                        "linux",
+                        "--output",
+                        str(out_path),
+                        "--pytorch-git-refs",
+                        pytorch_ref,
+                        "--projects",
+                        "pytorch;triton",
+                    ]
+                )
+
+            self.assertEqual(json.loads(out_path.read_text(encoding="utf-8")), expected)
+
+    def test_output_requires_single_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(SystemExit):
+                m.main(
+                    [
+                        "--rocm-version",
+                        "7.13.0",
+                        "--version-suffix",
+                        "+rocm7.13.0",
+                        "--output",
+                        str(Path(tmp) / "manifest.json"),
+                        "--pytorch-git-refs",
+                        "release/2.10 nightly",
+                    ]
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/github_actions/tests/github_actions_api_test.py
+++ b/build_tools/github_actions/tests/github_actions_api_test.py
@@ -17,6 +17,7 @@ from github_actions_api import (
     GitHubAPI,
     GitHubAPIError,
     gha_fetch_file_contents,
+    gha_fetch_text_file_contents,
     gha_load_github_event,
     gha_query_last_successful_workflow_run,
     gha_query_recent_branch_commits,
@@ -497,6 +498,19 @@ class GitHubActionsUtilsTest(unittest.TestCase):
         gha_send_request.assert_called_once_with(
             "https://api.github.com/repos/ROCm/pytorch/contents/some%20path/version.txt?ref=release%2F2.12"
         )
+
+    def test_fetch_text_file_contents_decodes_text(self):
+        content = "2.13.0a0\n".encode("utf-8")
+        encoded = base64.b64encode(content).decode("ascii")
+        with mock.patch(
+            "github_actions_api.gha_send_request",
+            return_value={"type": "file", "encoding": "base64", "content": encoded},
+        ):
+            text = gha_fetch_text_file_contents(
+                "pytorch/pytorch", "version.txt", "nightly"
+            )
+
+        self.assertEqual(text, "2.13.0a0\n")
 
     def test_fetch_file_contents_rejects_non_file_response(self):
         with mock.patch("github_actions_api.gha_send_request", return_value=[]):

--- a/build_tools/github_actions/tests/pytorch_checkout_from_manifest_test.py
+++ b/build_tools/github_actions/tests/pytorch_checkout_from_manifest_test.py
@@ -82,10 +82,8 @@ class PyTorchCheckoutFromManifestTest(unittest.TestCase):
             str(resolved_checkout_root / "pytorch"),
         )
         self.assertNotIn("--torch-dir", pytorch_command)
-        self.assertEqual(
-            self._option_value(audio_command, "--torch-dir"),
-            str(resolved_checkout_root / "pytorch"),
-        )
+        self.assertNotIn("--torch-dir", audio_command)
+        self.assertNotIn("--torch-dir", triton_command)
         self.assertEqual(
             self._option_value(audio_command, "--checkout-dir"),
             str(resolved_checkout_root / "pytorch_audio"),
@@ -140,7 +138,6 @@ class PyTorchCheckoutFromManifestTest(unittest.TestCase):
             tmp_path = Path(tmp)
             manifest_path = self._write_manifest(tmp_path / "manifest.json", manifest)
             checkout_root = tmp_path / "checkouts"
-            resolved_checkout_root = checkout_root.resolve()
 
             checkout_from_manifest.main(
                 [
@@ -160,10 +157,7 @@ class PyTorchCheckoutFromManifestTest(unittest.TestCase):
         )
         for command in commands.values():
             self.assertIn("--no-hipify", command)
-        self.assertEqual(
-            self._option_value(commands["pytorch_vision_repo.py"], "--torch-dir"),
-            str(resolved_checkout_root / "pytorch"),
-        )
+            self.assertNotIn("--torch-dir", command)
 
     def test_unknown_requested_project_errors(self) -> None:
         manifest = {
@@ -201,6 +195,32 @@ class PyTorchCheckoutFromManifestTest(unittest.TestCase):
             manifest_path = self._write_manifest(tmp_path / "manifest.json", [])
 
             with self.assertRaisesRegex(ValueError, "Manifest root"):
+                checkout_from_manifest.main(
+                    [
+                        "--manifest",
+                        str(manifest_path),
+                        "--checkout-root",
+                        str(tmp_path / "checkouts"),
+                    ]
+                )
+
+        check_call.assert_not_called()
+
+    def test_unsupported_manifest_schema_version_errors_before_checkout(self) -> None:
+        manifest = {
+            "schema_version": 2,
+            "pytorch": {
+                "repo": "https://github.com/ROCm/pytorch",
+                "commit": "1" * 40,
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            checkout_from_manifest.subprocess, "check_call"
+        ) as check_call:
+            tmp_path = Path(tmp)
+            manifest_path = self._write_manifest(tmp_path / "manifest.json", manifest)
+
+            with self.assertRaisesRegex(ValueError, "schema_version"):
                 checkout_from_manifest.main(
                     [
                         "--manifest",

--- a/build_tools/github_actions/tests/pytorch_checkout_from_manifest_test.py
+++ b/build_tools/github_actions/tests/pytorch_checkout_from_manifest_test.py
@@ -1,0 +1,340 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+THIS_DIR = Path(__file__).resolve().parent
+PYTORCH_DIR = THIS_DIR.parents[2] / "external-builds" / "pytorch"
+EXAMPLE_MANIFEST = PYTORCH_DIR / "pytorch_manifest_nightly.example.json"
+sys.path.insert(0, os.fspath(PYTORCH_DIR))
+
+import checkout_from_manifest
+
+
+class PyTorchCheckoutFromManifestTest(unittest.TestCase):
+    def _write_manifest(self, path: Path, entries: object) -> Path:
+        path.write_text(json.dumps(entries), encoding="utf-8")
+        return path
+
+    def _commands_by_script(self, check_call: mock.Mock) -> dict[str, list[str]]:
+        return {
+            Path(call.args[0][1]).name: call.args[0]
+            for call in check_call.call_args_list
+        }
+
+    def _option_value(self, command: list[str], option: str) -> str:
+        return command[command.index(option) + 1]
+
+    def test_main_checks_out_manifest_projects(self) -> None:
+        manifest = {
+            "pytorch_audio": {
+                "repo": "https://github.com/pytorch/audio",
+                "commit": "2" * 40,
+            },
+            "pytorch": {
+                "repo": "https://github.com/ROCm/pytorch",
+                "commit": "1" * 40,
+            },
+            "triton": {
+                "repo": "https://github.com/ROCm/triton",
+                "commit": "4" * 40,
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            checkout_from_manifest.subprocess, "check_call"
+        ) as check_call:
+            tmp_path = Path(tmp)
+            manifest_path = self._write_manifest(tmp_path / "manifest.json", manifest)
+            checkout_root = tmp_path / "checkouts"
+            resolved_checkout_root = checkout_root.resolve()
+
+            checkout_from_manifest.main(
+                [
+                    "--manifest",
+                    str(manifest_path),
+                    "--checkout-root",
+                    str(checkout_root),
+                ]
+            )
+
+        commands = self._commands_by_script(check_call)
+        self.assertEqual(
+            set(commands),
+            {
+                "pytorch_torch_repo.py",
+                "pytorch_audio_repo.py",
+                "pytorch_triton_repo.py",
+            },
+        )
+
+        pytorch_command = commands["pytorch_torch_repo.py"]
+        audio_command = commands["pytorch_audio_repo.py"]
+        triton_command = commands["pytorch_triton_repo.py"]
+
+        self.assertEqual(
+            self._option_value(pytorch_command, "--checkout-dir"),
+            str(resolved_checkout_root / "pytorch"),
+        )
+        self.assertNotIn("--torch-dir", pytorch_command)
+        self.assertEqual(
+            self._option_value(audio_command, "--torch-dir"),
+            str(resolved_checkout_root / "pytorch"),
+        )
+        self.assertEqual(
+            self._option_value(audio_command, "--checkout-dir"),
+            str(resolved_checkout_root / "pytorch_audio"),
+        )
+        self.assertEqual(self._option_value(triton_command, "--repo-hashtag"), "4" * 40)
+
+    def test_checked_in_example_manifest_is_usable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            checkout_from_manifest.subprocess, "check_call"
+        ) as check_call:
+            checkout_root = Path(tmp) / "checkouts"
+
+            checkout_from_manifest.main(
+                [
+                    "--manifest",
+                    str(EXAMPLE_MANIFEST),
+                    "--checkout-root",
+                    str(checkout_root),
+                    "--projects",
+                    "pytorch",
+                    "--no-hipify",
+                ]
+            )
+
+        manifest = json.loads(EXAMPLE_MANIFEST.read_text(encoding="utf-8"))
+        command = self._commands_by_script(check_call)["pytorch_torch_repo.py"]
+        self.assertEqual(
+            self._option_value(command, "--gitrepo-origin"), manifest["pytorch"]["repo"]
+        )
+        self.assertEqual(
+            self._option_value(command, "--repo-hashtag"), manifest["pytorch"]["commit"]
+        )
+
+    def test_projects_filter_and_no_hipify(self) -> None:
+        manifest = {
+            "pytorch": {
+                "repo": "https://github.com/ROCm/pytorch",
+                "commit": "1" * 40,
+            },
+            "pytorch_audio": {
+                "repo": "https://github.com/pytorch/audio",
+                "commit": "2" * 40,
+            },
+            "pytorch_vision": {
+                "repo": "https://github.com/pytorch/vision",
+                "commit": "3" * 40,
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            checkout_from_manifest.subprocess, "check_call"
+        ) as check_call:
+            tmp_path = Path(tmp)
+            manifest_path = self._write_manifest(tmp_path / "manifest.json", manifest)
+            checkout_root = tmp_path / "checkouts"
+            resolved_checkout_root = checkout_root.resolve()
+
+            checkout_from_manifest.main(
+                [
+                    "--manifest",
+                    str(manifest_path),
+                    "--checkout-root",
+                    str(checkout_root),
+                    "--projects",
+                    "pytorch;pytorch_vision",
+                    "--no-hipify",
+                ]
+            )
+
+        commands = self._commands_by_script(check_call)
+        self.assertEqual(
+            set(commands), {"pytorch_torch_repo.py", "pytorch_vision_repo.py"}
+        )
+        for command in commands.values():
+            self.assertIn("--no-hipify", command)
+        self.assertEqual(
+            self._option_value(commands["pytorch_vision_repo.py"], "--torch-dir"),
+            str(resolved_checkout_root / "pytorch"),
+        )
+
+    def test_unknown_requested_project_errors(self) -> None:
+        manifest = {
+            "pytorch": {
+                "repo": "https://github.com/ROCm/pytorch",
+                "commit": "1" * 40,
+            }
+        }
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            checkout_from_manifest.subprocess, "check_call"
+        ) as check_call:
+            tmp_path = Path(tmp)
+            manifest_path = self._write_manifest(tmp_path / "manifest.json", manifest)
+            checkout_root = tmp_path / "checkouts"
+
+            with self.assertRaises(SystemExit):
+                checkout_from_manifest.main(
+                    [
+                        "--manifest",
+                        str(manifest_path),
+                        "--checkout-root",
+                        str(checkout_root),
+                        "--projects",
+                        "pytorch triton",
+                    ]
+                )
+
+        check_call.assert_not_called()
+
+    def test_manifest_root_must_be_object(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            checkout_from_manifest.subprocess, "check_call"
+        ) as check_call:
+            tmp_path = Path(tmp)
+            manifest_path = self._write_manifest(tmp_path / "manifest.json", [])
+
+            with self.assertRaisesRegex(ValueError, "Manifest root"):
+                checkout_from_manifest.main(
+                    [
+                        "--manifest",
+                        str(manifest_path),
+                        "--checkout-root",
+                        str(tmp_path / "checkouts"),
+                    ]
+                )
+
+        check_call.assert_not_called()
+
+    def test_manifest_with_no_supported_projects_errors(self) -> None:
+        manifest = {
+            "therock": {
+                "repo": "https://github.com/ROCm/TheRock",
+                "commit": "a" * 40,
+            }
+        }
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            checkout_from_manifest.subprocess, "check_call"
+        ) as check_call:
+            tmp_path = Path(tmp)
+            manifest_path = self._write_manifest(tmp_path / "manifest.json", manifest)
+
+            with self.assertRaisesRegex(ValueError, "no supported PyTorch projects"):
+                checkout_from_manifest.main(
+                    [
+                        "--manifest",
+                        str(manifest_path),
+                        "--checkout-root",
+                        str(tmp_path / "checkouts"),
+                    ]
+                )
+
+        check_call.assert_not_called()
+
+    def test_missing_required_manifest_fields_error_before_checkout(self) -> None:
+        required_fields = {
+            "repo": "https://github.com/ROCm/pytorch",
+            "commit": "1" * 40,
+        }
+        for missing_field in required_fields:
+            with self.subTest(missing_field=missing_field):
+                manifest = {"pytorch": dict(required_fields)}
+                manifest["pytorch"].pop(missing_field)
+
+                with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+                    checkout_from_manifest.subprocess, "check_call"
+                ) as check_call:
+                    tmp_path = Path(tmp)
+                    manifest_path = self._write_manifest(
+                        tmp_path / "manifest.json", manifest
+                    )
+
+                    with self.assertRaisesRegex(
+                        ValueError, f"pytorch.*{missing_field}"
+                    ):
+                        checkout_from_manifest.main(
+                            [
+                                "--manifest",
+                                str(manifest_path),
+                                "--checkout-root",
+                                str(tmp_path / "checkouts"),
+                            ]
+                        )
+
+                check_call.assert_not_called()
+
+    def test_downloads_manifest_url_and_validates_ref(self) -> None:
+        manifest = {
+            "pytorch": {
+                "repo": "https://github.com/ROCm/pytorch",
+                "commit": "1" * 40,
+                "branch": "release/2.12",
+            }
+        }
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            checkout_from_manifest.urllib.request, "urlretrieve"
+        ) as urlretrieve, mock.patch.object(
+            checkout_from_manifest.subprocess, "check_call"
+        ) as check_call:
+            tmp_path = Path(tmp)
+            checkout_root = tmp_path / "checkouts"
+            manifest_path = checkout_root.resolve() / "pytorch_manifest.json"
+
+            def fake_urlretrieve(_url, output_path):
+                Path(output_path).write_text(json.dumps(manifest), encoding="utf-8")
+
+            urlretrieve.side_effect = fake_urlretrieve
+
+            checkout_from_manifest.main(
+                [
+                    "--manifest-url",
+                    "https://example.com/manifest.json",
+                    "--checkout-root",
+                    str(checkout_root),
+                    "--expected-pytorch-git-ref",
+                    "release/2.12",
+                ]
+            )
+
+        urlretrieve.assert_called_once_with(
+            "https://example.com/manifest.json", manifest_path
+        )
+        self.assertEqual(len(check_call.call_args_list), 1)
+
+    def test_expected_ref_mismatch_errors_before_checkout(self) -> None:
+        manifest = {
+            "pytorch": {
+                "repo": "https://github.com/ROCm/pytorch",
+                "commit": "1" * 40,
+                "branch": "release/2.12",
+            }
+        }
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            checkout_from_manifest.subprocess, "check_call"
+        ) as check_call:
+            tmp_path = Path(tmp)
+            manifest_path = self._write_manifest(tmp_path / "manifest.json", manifest)
+
+            with self.assertRaisesRegex(ValueError, "release/2.11"):
+                checkout_from_manifest.main(
+                    [
+                        "--manifest",
+                        str(manifest_path),
+                        "--checkout-root",
+                        str(tmp_path / "checkouts"),
+                        "--expected-pytorch-git-ref",
+                        "release/2.11",
+                    ]
+                )
+
+        check_call.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -141,7 +141,13 @@ PyTorch packages versions are handled via scripts:
 - [`build_tools/github_actions/determine_version.py`](/build_tools/github_actions/determine_version.py) (this generates e.g. `--version-suffix +rocm7.10.0`)
   - [`build_tools/github_actions/tests/determine_version_test.py`](/build_tools/github_actions/tests/determine_version_test.py)
 - [`external-builds/pytorch/build_prod_wheels.py`](/external-builds/pytorch/build_prod_wheels.py) (this appends the version suffix to each build version)
-- [`build_tools/github_actions/write_torch_versions.py`](/build_tools/github_actions/write_torch_versions.py) (this finds the versions in built packages)
+- [`build_tools/github_actions/write_torch_versions.py`](/build_tools/github_actions/write_torch_versions.py)
+  (this finds the versions in built packages)
+- [`build_tools/github_actions/generate_pytorch_source_manifest.py`](/build_tools/github_actions/generate_pytorch_source_manifest.py)
+  (this computes expected PyTorch ecosystem package versions and records them
+  with pinned source commits for checkout/build jobs)
+- [`external-builds/pytorch/checkout_from_manifest.py`](/external-builds/pytorch/checkout_from_manifest.py)
+  (this checks out the exact source commits recorded in the manifest)
 
 The scripts produce these versions for each distribution channel:
 
@@ -188,6 +194,8 @@ When working with versions please use these tools and avoid custom parsing
   - [`build_tools/compute_rocm_package_version.py`](/build_tools/compute_rocm_package_version.py)
   - [`build_tools/github_actions/determine_version.py`](/build_tools/github_actions/determine_version.py)
   - [`build_tools/github_actions/write_torch_versions.py`](/build_tools/github_actions/write_torch_versions.py)
+  - [`build_tools/github_actions/generate_pytorch_source_manifest.py`](/build_tools/github_actions/generate_pytorch_source_manifest.py)
+  - [`external-builds/pytorch/checkout_from_manifest.py`](/external-builds/pytorch/checkout_from_manifest.py)
 
 #### Tip - installing prereleases
 

--- a/external-builds/pytorch/.gitignore
+++ b/external-builds/pytorch/.gitignore
@@ -4,3 +4,8 @@ src/
 /pytorch_vision
 /pytorch_audio
 /triton
+
+# Manifest files
+manifest.json
+pytorch_manifest.json
+manifests/

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -509,7 +509,8 @@ python build_tools/github_actions/generate_pytorch_source_manifest.py \
     --manifest-dir external-builds/pytorch/manifests/ \
     --pytorch-git-refs "release/2.10 release/2.11 nightly"
 
-# Explicit platform selection (Windows may include different packages):
+# The target platform defaults to the current host. Pass it explicitly when
+# generating a manifest for another platform:
 python build_tools/github_actions/generate_pytorch_source_manifest.py \
     --rocm-version 7.13.0a20260501 \
     --platform windows \

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -378,6 +378,11 @@ If you want to make changes to PyTorch source code, prefer in this order:
 
 ### Checking out PyTorch repositories
 
+For release-branch work, prefer the manifest-based flow in
+[Checking out using manifests](#checking-out-using-manifests). It records the
+exact torch, audio, vision, triton, and apex commits in one JSON file, then
+checks out all requested repositories from that file.
+
 Each `pytorch_*_repo.py` script handles checkout and preparation:
 
 1. Clone the repository as needed from `--gitrepo-origin` to the `--repo-name`
@@ -454,26 +459,90 @@ the fork at https://github.com/ROCm/pytorch.
 
 > [!TIP]
 > You are welcome to maintain your own branches that extend one of AMD's.
-> Change origins and tags as appropriate.
+> Fork these scripts and change origins/tags/commits/versions as appropriate.
 
-In order to check out and build one of these, use the following instructions:
+For most work, run these commands from the TheRock repository root to generate
+a manifest for the release branch and check out from that manifest:
 
 ```bash
-# Other common --repo-hashtag values:
-#   release/2.12
-#   release/2.11
-#   release/2.10
-#   release/2.9
-python pytorch_torch_repo.py checkout \
-  --gitrepo-origin https://github.com/ROCm/pytorch.git \
-  --repo-hashtag release/2.12
+python build_tools/github_actions/generate_pytorch_source_manifest.py \
+  --rocm-version 7.13.0a20260501 \
+  --output external-builds/pytorch/pytorch_manifest.json \
+  --pytorch-git-refs release/2.12
 
-# Backport branches have `related_commits` files that point to specific
-# sub-project commits, so the main torch repo must be checked out first to
-# have proper defaults.
-python pytorch_audio_repo.py checkout --require-related-commit
-python pytorch_vision_repo.py checkout --require-related-commit
+python external-builds/pytorch/checkout_from_manifest.py \
+  --manifest external-builds/pytorch/pytorch_manifest.json \
+  --checkout-root ./external-builds/pytorch
+```
 
-python pytorch_triton_repo.py checkout
-python pytorch_apex_repo.py checkout --require-related-commit
+The manifest generator creates files like
+[`pytorch_manifest_nightly.example.json`](pytorch_manifest_nightly.example.json)
+which can then be read by the checkout script.
+
+> [!TIP]
+> You can also use the lower-level checkout scripts that individually read the
+> `related_commit` pins from the torch repository by running these commands from
+> this `external-builds/pytorch/` directory:
+>
+> ```bash
+> python pytorch_torch_repo.py checkout \
+>   --gitrepo-origin https://github.com/ROCm/pytorch.git \
+>   --repo-hashtag release/2.12
+> python pytorch_audio_repo.py checkout --require-related-commit
+> python pytorch_vision_repo.py checkout --require-related-commit
+> python pytorch_triton_repo.py checkout
+> python pytorch_apex_repo.py checkout --require-related-commit
+> ```
+
+#### Generating a manifest
+
+```bash
+# Single version (writes to an explicit path):
+python build_tools/github_actions/generate_pytorch_source_manifest.py \
+    --rocm-version 7.13.0a20260501 \
+    --output external-builds/pytorch/pytorch_manifest.json \
+    --pytorch-git-refs "release/2.10"
+
+# Multiple versions (computed filenames in a directory):
+python build_tools/github_actions/generate_pytorch_source_manifest.py \
+    --rocm-version 7.13.0a20260501 \
+    --manifest-dir external-builds/pytorch/manifests/ \
+    --pytorch-git-refs "release/2.10 release/2.11 nightly"
+
+# Explicit platform selection (Windows may include different packages):
+python build_tools/github_actions/generate_pytorch_source_manifest.py \
+    --rocm-version 7.13.0a20260501 \
+    --platform windows \
+    --output manifest.json \
+    --pytorch-git-refs "release/2.10"
+
+# Only pytorch (skip audio/vision/triton/apex):
+python build_tools/github_actions/generate_pytorch_source_manifest.py \
+    --rocm-version 7.13.0a20260501 \
+    --output external-builds/pytorch/manifest.json \
+    --pytorch-git-refs "release/2.10" \
+    --projects pytorch
+```
+
+#### Checking out from a manifest
+
+```bash
+cd external-builds/pytorch
+
+# Check out all projects at pinned commits:
+python checkout_from_manifest.py \
+    --manifest manifest.json \
+    --checkout-root ./src
+
+# Check out only pytorch:
+python checkout_from_manifest.py \
+    --manifest manifest.json \
+    --checkout-root ./src \
+    --projects pytorch
+
+# Skip HIPIFY (e.g. for test-only runs):
+python checkout_from_manifest.py \
+    --manifest manifest.json \
+    --checkout-root ./src \
+    --no-hipify
 ```

--- a/external-builds/pytorch/checkout_from_manifest.py
+++ b/external-builds/pytorch/checkout_from_manifest.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Check out pytorch ecosystem repositories from a manifest file.
+
+Reads a manifest JSON (produced by ``generate_pytorch_source_manifest.py``)
+and calls the individual ``pytorch_*_repo.py checkout`` scripts with the
+exact commit SHAs and repo URLs from the manifest.
+
+This provides a single command to reproduce the same source tree that CI
+builds use, given only a manifest file.
+
+Usage::
+
+    # Check out all projects in the manifest under ./checkouts/:
+    python checkout_from_manifest.py \\
+        --manifest manifests/therock-manifest_torch_linux_release-2.10.json \\
+        --checkout-root ./checkouts
+
+    # Check out only pytorch (skip audio, vision, etc.):
+    python checkout_from_manifest.py \\
+        --manifest manifest.json \\
+        --checkout-root ./checkouts \\
+        --projects pytorch
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+
+# Maps manifest project names to their checkout scripts.
+CHECKOUT_SCRIPTS: dict[str, str] = {
+    "pytorch": "pytorch_torch_repo.py",
+    "pytorch_audio": "pytorch_audio_repo.py",
+    "pytorch_vision": "pytorch_vision_repo.py",
+    "triton": "pytorch_triton_repo.py",
+    "apex": "pytorch_apex_repo.py",
+}
+
+
+def _split_words(value: str) -> list[str]:
+    return value.replace(";", " ").split() if value else []
+
+
+def log(*args, **kwargs) -> None:
+    print(*args, **kwargs)
+    sys.stdout.flush()
+
+
+def checkout_project(
+    *,
+    name: str,
+    source_info: dict[str, str],
+    checkout_root: Path,
+    no_hipify: bool,
+) -> None:
+    """Check out a single project using its checkout script."""
+    script = THIS_DIR / CHECKOUT_SCRIPTS[name]
+    checkout_dir = checkout_root / name
+
+    commit = source_info["commit"]
+    repo = source_info["repo"]
+
+    log(f"  {name}: {repo} @ {commit[:12]}")
+
+    cmd: list[str] = [
+        sys.executable,
+        str(script),
+        "checkout",
+        "--gitrepo-origin",
+        repo,
+        "--repo-hashtag",
+        commit,
+        "--checkout-dir",
+        str(checkout_dir),
+    ]
+
+    # pytorch_torch_repo.py doesn't have --torch-dir, but the others do.
+    # When checking out from a manifest we pass explicit origin/hashtag,
+    # so related_commits is not needed. We still pass --torch-dir pointing
+    # to the pytorch checkout so the scripts can find it if needed.
+    if name != "pytorch":
+        cmd.extend(["--torch-dir", str(checkout_root / "pytorch")])
+
+    if no_hipify:
+        cmd.append("--no-hipify")
+
+    log(f"  Running: {' '.join(cmd)}")
+    subprocess.check_call(cmd)
+
+
+def download_manifest(*, manifest_url: str, output_path: Path) -> Path:
+    """Download a manifest URL to output_path."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    log(f"Downloading manifest: {manifest_url} -> {output_path}")
+    urllib.request.urlretrieve(manifest_url, output_path)
+    if not output_path.is_file() or output_path.stat().st_size == 0:
+        raise RuntimeError(f"Failed to download manifest: {manifest_url}")
+    return output_path
+
+
+def load_manifest(manifest_path: Path) -> dict[str, object]:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+        raise ValueError("Manifest root must be a JSON object")
+    return manifest
+
+
+def require_project_source_info(
+    manifest: dict[str, object], project: str
+) -> dict[str, str]:
+    source_info = manifest.get(project)
+    if not isinstance(source_info, dict):
+        raise ValueError(f"Manifest entry {project!r} must be a JSON object")
+
+    for field in ("repo", "commit"):
+        value = source_info.get(field)
+        if not isinstance(value, str) or not value:
+            raise ValueError(
+                f"Manifest entry {project!r} is missing required string "
+                f"field {field!r}"
+            )
+
+    return {
+        str(field): value
+        for field, value in source_info.items()
+        if isinstance(value, str)
+    }
+
+
+def validate_manifest(
+    manifest: dict[str, object], *, expected_pytorch_git_ref: str
+) -> None:
+    """Validate manifest contents against workflow expectations."""
+    if not expected_pytorch_git_ref:
+        return
+    pytorch = manifest.get("pytorch")
+    if not isinstance(pytorch, dict):
+        raise ValueError("Manifest is missing pytorch entry")
+    actual_ref = pytorch.get("branch")
+    if actual_ref != expected_pytorch_git_ref:
+        raise ValueError(
+            f"Manifest PyTorch ref {actual_ref!r} does not match "
+            f"{expected_pytorch_git_ref!r}"
+        )
+
+
+def main(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(
+        description="Check out pytorch repos from a manifest file"
+    )
+    manifest_input = parser.add_mutually_exclusive_group(required=True)
+    manifest_input.add_argument(
+        "--manifest",
+        type=Path,
+        help="Path to manifest JSON file",
+    )
+    manifest_input.add_argument(
+        "--manifest-url",
+        help="URL to a manifest JSON file to download before checkout",
+    )
+    parser.add_argument(
+        "--checkout-root",
+        type=Path,
+        required=True,
+        help="Root directory for checkouts (each project gets a subdirectory)",
+    )
+    parser.add_argument(
+        "--projects",
+        default="",
+        help=(
+            "Semicolon- or space-separated list of projects to check out "
+            "(default: all projects in the manifest)."
+        ),
+    )
+    parser.add_argument(
+        "--expected-pytorch-git-ref",
+        default="",
+        help="Validate manifest pytorch.branch against this ref before checkout",
+    )
+    parser.add_argument(
+        "--no-hipify",
+        action="store_true",
+        default=False,
+        help="Skip HIPIFY for all checkouts (e.g. for test-only runs)",
+    )
+    args = parser.parse_args(argv)
+
+    checkout_root = args.checkout_root.resolve()
+    manifest_path = args.manifest
+    if args.manifest_url:
+        manifest_path = checkout_root / "pytorch_manifest.json"
+        download_manifest(manifest_url=args.manifest_url, output_path=manifest_path)
+
+    manifest = load_manifest(manifest_path)
+    validate_manifest(manifest, expected_pytorch_git_ref=args.expected_pytorch_git_ref)
+
+    # Determine which projects to check out.
+    available = [name for name in CHECKOUT_SCRIPTS if name in manifest]
+    if args.projects:
+        projects = _split_words(args.projects)
+        unknown = set(projects) - set(available)
+        if unknown:
+            parser.error(
+                f"Projects not in manifest: {unknown}. " f"Available: {available}"
+            )
+    else:
+        projects = available
+    if not projects:
+        supported = ", ".join(CHECKOUT_SCRIPTS)
+        raise ValueError(
+            "Manifest contains no supported PyTorch projects. "
+            f"Supported projects: {supported}"
+        )
+
+    source_infos = {
+        name: require_project_source_info(manifest, name) for name in projects
+    }
+
+    log(f"Manifest: {manifest_path}")
+    log(f"Checkout root: {checkout_root}")
+    log(f"Projects: {projects}")
+    log("")
+
+    checkout_root.mkdir(parents=True, exist_ok=True)
+
+    # Always check out pytorch first (other scripts may reference --torch-dir).
+    if "pytorch" in projects:
+        projects = ["pytorch"] + [p for p in projects if p != "pytorch"]
+
+    for name in projects:
+        checkout_project(
+            name=name,
+            source_info=source_infos[name],
+            checkout_root=checkout_root,
+            no_hipify=args.no_hipify,
+        )
+        log("")
+
+    log("All checkouts complete.")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/external-builds/pytorch/checkout_from_manifest.py
+++ b/external-builds/pytorch/checkout_from_manifest.py
@@ -33,6 +33,7 @@ import urllib.request
 from pathlib import Path
 
 THIS_DIR = Path(__file__).resolve().parent
+SCHEMA_VERSION = 1
 
 # Maps manifest project names to their checkout scripts.
 CHECKOUT_SCRIPTS: dict[str, str] = {
@@ -81,13 +82,6 @@ def checkout_project(
         str(checkout_dir),
     ]
 
-    # pytorch_torch_repo.py doesn't have --torch-dir, but the others do.
-    # When checking out from a manifest we pass explicit origin/hashtag,
-    # so related_commits is not needed. We still pass --torch-dir pointing
-    # to the pytorch checkout so the scripts can find it if needed.
-    if name != "pytorch":
-        cmd.extend(["--torch-dir", str(checkout_root / "pytorch")])
-
     if no_hipify:
         cmd.append("--no-hipify")
 
@@ -109,6 +103,12 @@ def load_manifest(manifest_path: Path) -> dict[str, object]:
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     if not isinstance(manifest, dict):
         raise ValueError("Manifest root must be a JSON object")
+    schema_version = manifest.get("schema_version")
+    if schema_version is not None and schema_version != SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported manifest schema_version {schema_version!r}; "
+            f"expected {SCHEMA_VERSION}"
+        )
     return manifest
 
 
@@ -230,7 +230,7 @@ def main(argv: list[str]) -> None:
 
     checkout_root.mkdir(parents=True, exist_ok=True)
 
-    # Always check out pytorch first (other scripts may reference --torch-dir).
+    # Keep pytorch first so a full checkout tree is easy to inspect.
     if "pytorch" in projects:
         projects = ["pytorch"] + [p for p in projects if p != "pytorch"]
 

--- a/external-builds/pytorch/pytorch_manifest_nightly.example.json
+++ b/external-builds/pytorch/pytorch_manifest_nightly.example.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "pytorch": {
     "repo": "https://github.com/pytorch/pytorch",
     "commit": "cac8bcf1ca69bff4364b793b570f850cf9e1faa1",

--- a/external-builds/pytorch/pytorch_manifest_nightly.example.json
+++ b/external-builds/pytorch/pytorch_manifest_nightly.example.json
@@ -1,0 +1,37 @@
+{
+  "pytorch": {
+    "repo": "https://github.com/pytorch/pytorch",
+    "commit": "cac8bcf1ca69bff4364b793b570f850cf9e1faa1",
+    "branch": "nightly",
+    "version": "2.13.0a0+rocm7.14.0"
+  },
+  "pytorch_audio": {
+    "repo": "https://github.com/pytorch/audio",
+    "commit": "c6473ed0a5d5254cef30295c4b24019c539007b2",
+    "branch": "nightly",
+    "version": "2.11.0a0+rocm7.14.0"
+  },
+  "pytorch_vision": {
+    "repo": "https://github.com/pytorch/vision",
+    "commit": "97164178c67fc943ab7b3ecddd4454a3265b0f63",
+    "branch": "nightly",
+    "version": "0.28.0a0+rocm7.14.0"
+  },
+  "triton": {
+    "repo": "https://github.com/ROCm/triton",
+    "commit": "88b227e23f0445f3f695bad05bbf1a363b4f50e0",
+    "version": "3.7.0+rocm7.14.0"
+  },
+  "apex": {
+    "repo": "https://github.com/ROCm/apex",
+    "commit": "af25af4e26f0546d897c3e2ff31502ef50530ecc",
+    "branch": "master",
+    "version": "1.11.0+rocm7.14.0"
+  },
+  "therock": {
+    "repo": "https://github.com/ROCm/TheRock",
+    "commit": "2555d629204cb066d6668823ad6241d2fcf250e4",
+    "branch": "main",
+    "version": "7.14.0"
+  }
+}

--- a/external-builds/pytorch/pytorch_triton_repo.py
+++ b/external-builds/pytorch/pytorch_triton_repo.py
@@ -74,12 +74,13 @@ def do_checkout(args: argparse.Namespace):
     else:
         print("Using ROCm/triton repository (Linux build)")
 
-        if not torch_dir.exists():
-            raise ValueError(
-                f"Could not find torch dir: {torch_dir} (did you check out torch first)"
-            )
-
         if args.repo_hashtag is None:
+            if not torch_dir.exists():
+                raise ValueError(
+                    f"Could not find torch dir: {torch_dir} "
+                    "(did you check out torch first)"
+                )
+
             if args.release:
                 # Derive the commit pin based on --release.
                 pin_version = get_triton_version(torch_dir)


### PR DESCRIPTION
## Motivation

Progress on
* https://github.com/ROCm/TheRock/issues/5110 (These new scripts will be used for multi-arch instead of the existing scripts)
* https://github.com/ROCm/TheRock/issues/1236 (Generating manifests _before_ building will let us freeze commits for repeatable release workflows) 
* https://github.com/ROCm/TheRock/issues/5496 (Having these records of what packages were built will let us trigger torch tests from multi-arch releases)

## Overview

This adds two new scripts:

* `build_tools/github_actions/generate_pytorch_source_manifest.py`
  * replacement for [`generate_pytorch_manifest.py`](https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/generate_pytorch_manifest.py) (to be deleted as part of https://github.com/ROCm/TheRock/issues/3340)
* `external-builds/pytorch/checkout_from_manifest.py`
  * wrapper around [`pytorch_torch_repo.py`](https://github.com/ROCm/TheRock/blob/main/external-builds/pytorch/pytorch_torch_repo.py), [`pytorch_audio_repo.py`](https://github.com/ROCm/TheRock/blob/main/external-builds/pytorch/pytorch_audio_repo.py), etc.

This will change our torch checkout workflows like so:

```mermaid
  flowchart LR
      C1["Current: checkout PyTorch from floating pin"]
      C2["Checkout related projects from PyTorch pins"]
      C3["Build"]
      C4["Record versions after build"]
      C5["Upload/test"]

      N1["New: resolve commits and versions into manifest"]
      N2["Checkout using manifest"]
      N3["Build"]
      N4["Upload/test"]

      C1 --> C2 --> C3 --> C4 --> C5
      N1 --> N2 --> N3 --> N4
```

This PR is just the new scripts, future PRs will use them from [`multi_arch_build_portable_linux_pytorch_wheels.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml) and [`multi_arch_build_windows_pytorch_wheels.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml).

### Technical Details

Highlighted design decisions:
* Commit hash and version discovery fetches individual files using the GitHub API, rather than clone the repositories. This keeps manifest generation fast, but it does risk API-related failures (e.g. rate limits) earlier in jobs that might not appear with the more natural `git clone` code.
* Version fields in the generated manifests are _expected_ versions, and those versions can then be checked against the _actual_ versions later. There is a risk that these diverge if we don't check.
* There is special case handling for Triton across Linux and Windows since support is still pending on Windows.
* I considered adding more metadata to the manifest schema (e.g. generation date, schema version, etc.) but decided to defer that until later and to start simple.
* The generator lives in `build_tools/github_actions/` as it uses utils from TheRock and references ROCm/pytorch release branches. The checkout script lives in `external-builds/pytorch/` as it connects to the existing checkout scripts and _could_ be used standalone from hand crafted manifest files. If we later want to move more of this code to ROCm/pytorch or pytorch/pytorch we can revisit the split.

## Test Plan

* Added new unit tests
* Ran manifest generation and checkout scripts manually on Windows
  1. These files were generated: [torch_manifest_examples (gist)](https://gist.github.com/ScottTodd/e9e2f9f2622ecb526ec4de478fe32b12)
  2. Spot checked manifest contents for release branches, e.g. https://github.com/ROCm/pytorch/blob/release/2.10/related_commits --> https://github.com/pytorch/audio/blob/5047768f2447d963dffc250b64a5d6c01afc84fa/version.txt
* Tested on github actions as part of a larger feature branch. Sample run: https://github.com/ROCm/TheRock/actions/runs/26195227273
  1. Generated and uploaded https://therock-dev-artifacts.s3.amazonaws.com/26195227273-linux/manifests/pytorch/index.html
  2. Build jobs each receive a single manifest and use it to checkout: https://github.com/ROCm/TheRock/actions/runs/26195227273/job/77073137433#step:10:25
  3. Test jobs also checkout from the manifest: https://github.com/ROCm/TheRock/actions/runs/26195227273/job/77077733178#step:8:19

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Assisted-by: Codex