### PR TITLE
[ci] Add test control file to artifact list for hipcub

### DIFF
--- a/math-libs/artifact-prim.toml
+++ b/math-libs/artifact-prim.toml
@@ -17,6 +17,7 @@ include = [
 include = [
   "bin/test_*",
   "bin/benchmark_*",
+  "bin/hipcub/control.txt",
   "bin/hipcub/CTestTestfile.cmake",
   "bin/hipcub/generate_resource_spec*",
 ]


### PR DESCRIPTION
## Motivation

rocm-libraries PR #7241 adds a "control.txt" test configuration file to hipcub. This file allows us to mark tests as disabled.

## Technical Details

 We need to pass this file through to the installation directory in TheRock CI.

## Test Plan

Tests using the PR pass locally. However, the control file can't be found in TheRock CI. We'll have to see if this change fixes the issue.

## Test Result

TBD

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
