### PR TITLE
[rocgdb] XFAIL multi-inferior tests on mixed-GPU hosts with gfx1036

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocgdb.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocgdb.py
@@ -41,6 +41,10 @@ XFAILED_TESTS = {
         "gdb.rocm/corefile.exp",
         "gdb.rocm/device-interrupt.exp",
         "gdb.rocm/load-core-remote-system.exp",
+        # Fails when executed on a machine hosting mixed GPU's with one
+        # of those being the unsupported gfx1036.
+        "gdb.rocm/multi-inferior-fork.exp",
+        "gdb.rocm/multi-inferior-gpu.exp",
     ],
     "GCC": [],
     "LLVM": [


### PR DESCRIPTION
These tests fail when run on machines hosting mixed GPUs where one of them is the unsupported gfx1036.