### PR TITLE
[rocprofiler-systems] Disable flaky `openmplu-duration-sampling` test

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
@@ -18,6 +18,7 @@ EXCLUDED_TESTS = [
     "transferbench-sys-run",
     "fork.*",
     "openmp-target.*",
+    "openmplu-sampling-duration",
     "roctx-sampling",
     "roctx-runtime-instrument",
     "jacobi-usm-sys-run",


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

The `openmplu-duration-sampling` test can fail if the program finalizes before the sampling duration deadline is reached. This requires a fix to go on the `rocm-systems` side. To prevent this failure from blocking PRs here, the test will be disabled.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Add `openmplu-duration-sampling` to `EXCLUDED_TESTS`

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Workflows

## Test Result

<!-- Briefly summarize test outcomes. -->

Workflows

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
