### PR TITLE
Include ROCm base version in TheRock manifest

### DIFF
--- a/build_tools/generate_therock_manifest.py
+++ b/build_tools/generate_therock_manifest.py
@@ -172,12 +172,23 @@ def patches_for_submodule_by_name(repo_dir: Path, sub_name: str):
     return [str(p.relative_to(repo_dir)) for p in sorted(base.glob("*.patch"))]
 
 
+def rocm_version_from_package_version(rocm_package_version: str) -> str:
+    match = re.match(r"^(\d+\.\d+\.\d+)", rocm_package_version)
+    if not match:
+        raise ValueError(
+            f"Could not derive rocm_version from rocm_package_version: "
+            f"{rocm_package_version}"
+        )
+    return match.group(1)
+
+
 def build_manifest_schema(
     repo_root: Path,
     the_rock_commit: str,
     github_job: str | None = None,
     github_run_id: str | None = None,
     rocm_package_version: str | None = None,
+    rocm_version: str | None = None,
 ) -> dict:
     # Enumerate submodules from .gitmodules at the specified commit.
     entries = list_submodules_from_gitmodules_at_commit(repo_root, the_rock_commit)
@@ -209,6 +220,9 @@ def build_manifest_schema(
     if rocm_package_version:
         manifest["rocm_package_version"] = rocm_package_version
 
+    if rocm_version:
+        manifest["rocm_version"] = rocm_version
+
     manifest["submodules"] = rows
     return manifest
 
@@ -218,6 +232,7 @@ def build_partial_manifest_schema(
     github_job: str | None = None,
     github_run_id: str | None = None,
     rocm_package_version: str | None = None,
+    rocm_version: str | None = None,
 ) -> dict:
     # Enumerate submodules from the filesystem .gitmodules file when git metadata
     # is unavailable (for example, source trees with .git removed).
@@ -248,6 +263,9 @@ def build_partial_manifest_schema(
 
     if rocm_package_version:
         manifest["rocm_package_version"] = rocm_package_version
+
+    if rocm_version:
+        manifest["rocm_version"] = rocm_version
 
     manifest["submodules"] = rows
     return manifest
@@ -289,6 +307,11 @@ def main():
     github_job = os.getenv("GITHUB_JOB")
     github_run_id = os.getenv("GITHUB_RUN_ID")
     git_available = has_git_metadata(repo_root)
+    rocm_version = (
+        rocm_version_from_package_version(args.rocm_package_version)
+        if args.rocm_package_version
+        else None
+    )
 
     if git_available:
         the_rock_commit = capture(["git", "rev-parse", args.commit], cwd=repo_root)
@@ -298,6 +321,7 @@ def main():
             github_job,
             github_run_id,
             args.rocm_package_version,
+            rocm_version,
         )
     else:
         manifest = build_partial_manifest_schema(
@@ -305,6 +329,7 @@ def main():
             github_job,
             github_run_id,
             args.rocm_package_version,
+            rocm_version,
         )
 
     # Merge flag settings into the manifest if provided.


### PR DESCRIPTION
## Motivation

`therock_manifest.json` currently exposes only the full package version:

`rocm_package_version`: `7.14.0a20260526+a0`

Downstream CI/CD consumers currently need to parse this value to obtain the base ROCm SDK version (7.14.0).
Add an explicit rocm_version field to make the manifest a normalized and self-contained metadata source for downstream tooling.

## Technical Details

- Add rocm_version to generated TheRock manifests
- Derive the value from rocm_package_version

e.g:   `"rocm_version": "7.14.0",`

## Test Plan

Run on Local and CI

## Test Result
```
{
  "the_rock_commit": "a769a1f262a40f82f372a52448b846153065aeeb",
  "github_job": "build_stage",
  "github_run_id": "26641967117",
  "rocm_package_version": "7.14.0.dev0+a769a1f262a40f82f372a52448b846153065aeeb",
  "rocm_version": "7.14.0",
  "submodules": [
    {
      "submodule_name": "half",
      "submodule_path": "base/half",
      "submodule_url": "https://github.com/ROCm/half.git",
      "pin_sha": "207ee58595a64b5c4a70df221f1e6e704b807811",
      "patches": []
    },
...
```
https://therock-ci-artifacts.s3.amazonaws.com/26641967117-linux/manifests/therock_manifest.json
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
