### PR TITLE
[ci] Removing vultr mi325 pool and bringing core42 mi325 replacements

### DIFF
--- a/.github/workflows/ci_nightly_pytorch_full_test.yml
+++ b/.github/workflows/ci_nightly_pytorch_full_test.yml
@@ -32,7 +32,7 @@ on:
       test_runs_on:
         description: Runner label for single-GPU test configs
         type: string
-        default: "linux-gfx942-1gpu-ossci-rocm"
+        default: "linux-gfx942-1gpu-core42-ossci-rocm"
       test_runs_on_multi_gpu:
         description: Runner label for multi-GPU test configs (e.g. distributed)
         type: string
@@ -72,7 +72,7 @@ run-name: >-
 
 env:
   AMDGPU_FAMILY: ${{ inputs.amdgpu_family || 'gfx94X-dcgpu' }}
-  TEST_RUNS_ON: ${{ inputs.test_runs_on || 'linux-gfx942-1gpu-ossci-rocm' }}
+  TEST_RUNS_ON: ${{ inputs.test_runs_on || 'linux-gfx942-1gpu-core42-ossci-rocm' }}
   TEST_RUNS_ON_MULTI_GPU: ${{ inputs.test_runs_on_multi_gpu || 'linux-gfx942-8gpu-ossci-rocm' }}
   PACKAGE_INDEX_URL: ${{ inputs.package_index_url || 'https://rocm.nightlies.amd.com/v2-staging' }}
   TORCH_VERSION_INPUT: ${{ inputs.torch_version || '' }}
@@ -125,7 +125,7 @@ jobs:
     uses: ./.github/workflows/test_pytorch_wheels_full.yml
     with:
       amdgpu_family: ${{ inputs.amdgpu_family || 'gfx94X-dcgpu' }}
-      test_runs_on: ${{ inputs.test_runs_on || 'linux-gfx942-1gpu-ossci-rocm' }}
+      test_runs_on: ${{ inputs.test_runs_on || 'linux-gfx942-1gpu-core42-ossci-rocm' }}
       test_runs_on_multi_gpu: ${{ inputs.test_runs_on_multi_gpu || 'linux-gfx942-8gpu-ossci-rocm' }}
       package_index_url: ${{ inputs.package_index_url || 'https://rocm.nightlies.amd.com/v2-staging' }}
       python_version: ${{ inputs.python_version || '3.12' }}

--- a/.github/workflows/test_jax_dockerfile.yml
+++ b/.github/workflows/test_jax_dockerfile.yml
@@ -9,7 +9,7 @@ on:
       test_runs_on:
         required: true
         type: string
-        default: "linux-gfx942-1gpu-ossci-rocm"
+        default: "linux-gfx942-1gpu-core42-ossci-rocm"
       image_name:
         required: true
         description: JAX docker image to run tests with

--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -127,7 +127,7 @@ on:
         description: Runner label to use. The selected runner should have a GPU supported by amdgpu_family
         required: true
         type: string
-        default: "linux-gfx942-1gpu-ossci-rocm"
+        default: "linux-gfx942-1gpu-core42-ossci-rocm"
       ref:
         description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow."
         type: string

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -132,7 +132,7 @@ jobs:
     needs: [prepare_install_context]
     strategy:
       fail-fast: false
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'linux-gfx942-1gpu-ossci-rocm' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'linux-gfx942-1gpu-core42-ossci-rocm' || 'ubuntu-24.04' }}
     container:
       image: ${{ needs.prepare_install_context.outputs.container_image }}
       options: --ipc host

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -15,7 +15,7 @@ on:
         description: Runner label to use. The selected runner should have a GPU supported by amdgpu_family
         required: true
         type: string
-        default: "linux-gfx942-1gpu-ossci-rocm"
+        default: "linux-gfx942-1gpu-core42-ossci-rocm"
       package_index_url:
         description: >-
           Base Python package index URL to test.

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -15,7 +15,7 @@ on:
         description: Runner label to use. The selected runner should have a GPU supported by amdgpu_family
         required: true
         type: string
-        default: "linux-gfx942-1gpu-ossci-rocm"
+        default: "linux-gfx942-1gpu-core42-ossci-rocm"
       test_runs_on_multi_gpu:
         description: Runner label for multi-GPU test configs (e.g. distributed). Corresponds to test-runs-on-multi-gpu in amdgpu_family_matrix.py
         type: string
@@ -64,7 +64,7 @@ on:
       test_runs_on:
         required: false
         type: string
-        default: "linux-gfx942-1gpu-ossci-rocm"
+        default: "linux-gfx942-1gpu-core42-ossci-rocm"
       test_runs_on_multi_gpu:
         type: string
         default: "linux-gfx942-8gpu-ossci-rocm"

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -15,7 +15,7 @@ on:
         description: Runner label to use. The selected runner should have a GPU supported by amdgpu_family
         required: true
         type: string
-        default: "linux-gfx942-1gpu-ossci-rocm"
+        default: "linux-gfx942-1gpu-core42-ossci-rocm"
       package_index_url_base:
         description: >-
           Base Python package index URL. For legacy per-family builds, this is

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -150,21 +150,16 @@ amdgpu_family_info_matrix_presubmit = {
         "linux": {
             # TODO: Remove multi-label config once we get dedicated set of machines
             # As we are bringing up mi325, we are using a multi-label configuration to distribute load
-            "test-runs-on": "linux-gfx942-1gpu-ossci-rocm",
+            "test-runs-on": "linux-gfx942-1gpu-core42-ossci-rocm",
             "test-runs-on-labels": [
                 {
-                    "label": "linux-gfx942-1gpu-ossci-rocm",
-                    "weight": 0.81,
-                },  # vultr (17/21)
-                {
                     "label": "linux-gfx942-1gpu-ccs-ossci-rocm",
-                    "weight": 0.19,
-                },  # cirrascale (4/21)
-                # Temporarily removed due to cluster issues
+                    "weight": 0.138,
+                },  # cirrascale (4/29)
                 {
                     "label": "linux-gfx942-1gpu-core42-ossci-rocm",
-                    "weight": 0.0,
-                },  # core42 (25/46)
+                    "weight": 0.862,
+                },  # core42 (25/29)
             ],
             # TODO(#3433): Remove sandbox label once ASAN tests are passing
             "test-runs-on-sandbox": "linux-mi325-gpu-rocm-cpu-sandbox",

--- a/build_tools/github_actions/tests/configure_ci_test.py
+++ b/build_tools/github_actions/tests/configure_ci_test.py
@@ -550,8 +550,7 @@ class ConfigureCITest(unittest.TestCase):
         ]
         self.assertEqual(len(gfx94x_entries), 1, "Expected exactly one gfx94X entry")
         entry = gfx94x_entries[0]
-        # Should select the first (vultr) label
-        self.assertEqual(entry["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm")
+        self.assertEqual(entry["test-runs-on"], "linux-gfx942-1gpu-ccs-ossci-rocm")
 
     def test_gfx94x_multi_label_selects_second_when_random_medium(self):
         """When random() is in middle range, second label should be selected."""
@@ -576,8 +575,7 @@ class ConfigureCITest(unittest.TestCase):
         ]
         self.assertEqual(len(gfx94x_entries), 1, "Expected exactly one gfx94X entry")
         entry = gfx94x_entries[0]
-        # Should select the second (cirrascale) label
-        self.assertEqual(entry["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm")
+        self.assertEqual(entry["test-runs-on"], "linux-gfx942-1gpu-core42-ossci-rocm")
 
     def test_gfx94x_multi_label_selects_third_when_random_high(self):
         """When random() is high, third label should be selected."""
@@ -602,8 +600,7 @@ class ConfigureCITest(unittest.TestCase):
         ]
         self.assertEqual(len(gfx94x_entries), 1, "Expected exactly one gfx94X entry")
         entry = gfx94x_entries[0]
-        # Should select the third (core42) label
-        self.assertEqual(entry["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm")
+        self.assertEqual(entry["test-runs-on"], "linux-gfx942-1gpu-core42-ossci-rocm")
 
     def test_gfx94x_multi_gpu_label_selects_first_when_random_low(self):
         """When random() is low, first multi-gpu label should be selected."""

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1260,11 +1260,10 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
 
         # Verify we have 3 labels for 1-gpu
         labels = gfx94x_linux["test-runs-on-labels"]
-        self.assertEqual(len(labels), 3)
+        self.assertEqual(len(labels), 2)
 
         # Verify label names
         label_names = [l["label"] for l in labels]
-        self.assertIn("linux-gfx942-1gpu-ossci-rocm", label_names)
         self.assertIn("linux-gfx942-1gpu-ccs-ossci-rocm", label_names)
         self.assertIn("linux-gfx942-1gpu-core42-ossci-rocm", label_names)
 
@@ -1310,7 +1309,9 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         self.assertIsNotNone(builds.linux)
         # Check that the first label was selected
         gfx94x_info = builds.linux.per_family_info[0]
-        self.assertEqual(gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm")
+        self.assertEqual(
+            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ccs-ossci-rocm"
+        )
 
     def test_second_label_selected_when_random_medium(self):
         """When random() is in second range, second label should be selected."""
@@ -1330,7 +1331,9 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         self.assertIsNotNone(builds.linux)
         # Check that the second label was selected
         gfx94x_info = builds.linux.per_family_info[0]
-        self.assertEqual(gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm")
+        self.assertEqual(
+            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-core42-ossci-rocm"
+        )
 
     def test_third_label_selected_when_random_high(self):
         """When random() >= first two weights, third label should be selected."""
@@ -1350,7 +1353,9 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         self.assertIsNotNone(builds.linux)
         # Check that the third label was selected
         gfx94x_info = builds.linux.per_family_info[0]
-        self.assertEqual(gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm")
+        self.assertEqual(
+            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-core42-ossci-rocm"
+        )
 
     def test_families_without_multi_label_use_primary_only(self):
         """Families without multi-label config should only use primary label."""

--- a/build_tools/github_actions/tests/configure_target_run_test.py
+++ b/build_tools/github_actions/tests/configure_target_run_test.py
@@ -23,7 +23,7 @@ class ConfigureTargetRunTest(unittest.TestCase):
         # gfx94X-dcgpu is the inner key, which we use for package names. When
         # run from a workflow, we expect to only work on the inner keys.
         runner_label = configure_target_run.get_runner_label("gfx94X-dcgpu", "linux")
-        self.assertEqual(runner_label, "linux-gfx942-1gpu-ossci-rocm")
+        self.assertEqual(runner_label, "linux-gfx942-1gpu-core42-ossci-rocm")
 
     def test_windows_gfx115x(self):
         runner_label = configure_target_run.get_runner_label("gfx1151", "windows")

--- a/build_tools/github_actions/tests/configure_target_run_test.py
+++ b/build_tools/github_actions/tests/configure_target_run_test.py
@@ -16,7 +16,7 @@ class ConfigureTargetRunTest(unittest.TestCase):
         # gfx94X-dcgpu is the inner key, which we use for package names. When
         # run from a workflow, we expect to only work on the inner keys.
         runner_label = configure_target_run.get_runner_label("gfx94x", "linux")
-        self.assertEqual(runner_label, "linux-gfx942-1gpu-ossci-rocm")
+        self.assertEqual(runner_label, "linux-gfx942-1gpu-core42-ossci-rocm")
 
     def test_linux_gfx94X_dcgpu(self):
         # gfx94x is the outer key used to construct workflow pipelines, while

--- a/build_tools/github_actions/tests/fetch_package_targets_test.py
+++ b/build_tools/github_actions/tests/fetch_package_targets_test.py
@@ -143,7 +143,7 @@ class FetchPackageTargetsTest(unittest.TestCase):
             targets = fetch_package_targets.determine_package_targets(args)
 
         self.assertEqual(len(targets), 1)
-        self.assertEqual(targets[0]["test_machine"], "linux-gfx942-1gpu-ossci-rocm")
+        self.assertEqual(targets[0]["test_machine"], "linux-gfx942-1gpu-ccs-ossci-rocm")
 
     def test_gfx94x_multi_label_selects_second_when_random_medium(self):
         """When random() is in second range, second label should be selected."""
@@ -157,7 +157,9 @@ class FetchPackageTargetsTest(unittest.TestCase):
             targets = fetch_package_targets.determine_package_targets(args)
 
         self.assertEqual(len(targets), 1)
-        self.assertEqual(targets[0]["test_machine"], "linux-gfx942-1gpu-ossci-rocm")
+        self.assertEqual(
+            targets[0]["test_machine"], "linux-gfx942-1gpu-core42-ossci-rocm"
+        )
 
     def test_gfx94x_multi_label_selects_third_when_random_high(self):
         """When random() is high, third label should be selected."""
@@ -171,7 +173,9 @@ class FetchPackageTargetsTest(unittest.TestCase):
             targets = fetch_package_targets.determine_package_targets(args)
 
         self.assertEqual(len(targets), 1)
-        self.assertEqual(targets[0]["test_machine"], "linux-gfx942-1gpu-ossci-rocm")
+        self.assertEqual(
+            targets[0]["test_machine"], "linux-gfx942-1gpu-core42-ossci-rocm"
+        )
 
     def test_families_without_multi_label_use_primary(self):
         """Families without multi-label config should use primary label."""


### PR DESCRIPTION
As vultr capacity is reduced (contract ended), we are bringing capacity in from core42. shortly, we will also have more ccs

Test works here: https://github.com/ROCm/TheRock/actions/runs/26647582217, so adding `ci:skip` label is not needed