### PR TITLE
Improve pytorch repository checkout behavior

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -189,21 +189,21 @@ jobs:
       - name: Checkout PyTorch Source Repos from nightly branch
         if: ${{ inputs.pytorch_git_ref == 'nightly' }}
         run: |
-          ./external-builds/pytorch/pytorch_torch_repo.py checkout --repo-hashtag nightly
-          ./external-builds/pytorch/pytorch_audio_repo.py checkout --repo-hashtag nightly
-          ./external-builds/pytorch/pytorch_apex_repo.py checkout --repo-hashtag master
-          ./external-builds/pytorch/pytorch_vision_repo.py checkout --repo-hashtag nightly
-          ./external-builds/pytorch/pytorch_triton_repo.py checkout
+          ./external-builds/pytorch/pytorch_torch_repo.py checkout --repo-hashtag nightly --no-commit-hipify
+          ./external-builds/pytorch/pytorch_audio_repo.py checkout --repo-hashtag nightly --no-commit-hipify
+          ./external-builds/pytorch/pytorch_apex_repo.py checkout --repo-hashtag master --no-commit-hipify
+          ./external-builds/pytorch/pytorch_vision_repo.py checkout --repo-hashtag nightly --no-commit-hipify
+          ./external-builds/pytorch/pytorch_triton_repo.py checkout --no-commit-hipify
 
       # Checkout stable sources from https://github.com/ROCm/pytorch
       - name: Checkout PyTorch Source Repos from stable branch
         if: ${{ inputs.pytorch_git_ref != 'nightly' }}
         run: |
-          ./external-builds/pytorch/pytorch_torch_repo.py checkout --gitrepo-origin https://github.com/ROCm/pytorch.git --repo-hashtag ${{ inputs.pytorch_git_ref }}
-          ./external-builds/pytorch/pytorch_audio_repo.py checkout --require-related-commit
-          ./external-builds/pytorch/pytorch_apex_repo.py checkout --require-related-commit
-          ./external-builds/pytorch/pytorch_vision_repo.py checkout --require-related-commit
-          ./external-builds/pytorch/pytorch_triton_repo.py checkout
+          ./external-builds/pytorch/pytorch_torch_repo.py checkout --gitrepo-origin https://github.com/ROCm/pytorch.git --repo-hashtag ${{ inputs.pytorch_git_ref }} --no-commit-hipify
+          ./external-builds/pytorch/pytorch_audio_repo.py checkout --require-related-commit --no-commit-hipify
+          ./external-builds/pytorch/pytorch_apex_repo.py checkout --require-related-commit --no-commit-hipify
+          ./external-builds/pytorch/pytorch_vision_repo.py checkout --require-related-commit --no-commit-hipify
+          ./external-builds/pytorch/pytorch_triton_repo.py checkout --no-commit-hipify
 
       # Note: determine_version.py sets optional_build_prod_arguments in
       # GITHUB_ENV, which includes --rocm-sdk-version and --version-suffix.

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -147,14 +147,16 @@ jobs:
         if: ${{ inputs.pytorch_git_ref == 'nightly' }}
         run: |
           ./external-builds/pytorch/pytorch_torch_repo.py checkout \
-            --repo-hashtag nightly
+            --repo-hashtag nightly \
+            --no-commit-hipify
 
       - name: Checkout PyTorch source (stable)
         if: ${{ inputs.pytorch_git_ref != 'nightly' }}
         run: |
           ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --gitrepo-origin https://github.com/ROCm/pytorch.git \
-            --repo-hashtag ${{ inputs.pytorch_git_ref }}
+            --repo-hashtag ${{ inputs.pytorch_git_ref }} \
+            --no-commit-hipify
 
       # Note: determine_version.py sets optional_build_prod_arguments in
       # GITHUB_ENV, which includes --rocm-sdk-version and --version-suffix.

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -209,13 +209,16 @@ jobs:
           git config --global core.longpaths true
           python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --checkout-dir ${{ env.CHECKOUT_ROOT }}/torch \
-            --repo-hashtag nightly
+            --repo-hashtag nightly \
+            --no-commit-hipify
           python ./external-builds/pytorch/pytorch_audio_repo.py checkout \
             --checkout-dir ${{ env.CHECKOUT_ROOT }}/audio \
-            --repo-hashtag nightly
+            --repo-hashtag nightly \
+            --no-commit-hipify
           python ./external-builds/pytorch/pytorch_vision_repo.py checkout \
             --checkout-dir ${{ env.CHECKOUT_ROOT }}/vision \
-            --repo-hashtag nightly
+            --repo-hashtag nightly \
+            --no-commit-hipify
 
       # Checkout stable sources from https://github.com/ROCm/pytorch
       - name: Checkout PyTorch Source Repos from stable branch
@@ -225,15 +228,18 @@ jobs:
           python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
               --checkout-dir ${{ env.CHECKOUT_ROOT }}/torch \
               --gitrepo-origin https://github.com/ROCm/pytorch.git \
-              --repo-hashtag ${{ inputs.pytorch_git_ref }}
+              --repo-hashtag ${{ inputs.pytorch_git_ref }} \
+              --no-commit-hipify
           python ./external-builds/pytorch/pytorch_audio_repo.py checkout \
               --checkout-dir ${{ env.CHECKOUT_ROOT }}/audio \
               --torch-dir ${{ env.CHECKOUT_ROOT }}/torch \
-              --require-related-commit
+              --require-related-commit \
+              --no-commit-hipify
           python ./external-builds/pytorch/pytorch_vision_repo.py checkout \
               --checkout-dir ${{ env.CHECKOUT_ROOT }}/vision \
               --torch-dir ${{ env.CHECKOUT_ROOT }}/torch \
-              --require-related-commit
+              --require-related-commit \
+              --no-commit-hipify
 
       # Note: determine_version.py sets optional_build_prod_arguments in
       # GITHUB_ENV, which includes --rocm-sdk-version and --version-suffix.

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -162,7 +162,8 @@ jobs:
           git config --global core.longpaths true
           python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --checkout-dir ${{ env.CHECKOUT_ROOT }}/torch \
-            --repo-hashtag nightly
+            --repo-hashtag nightly \
+            --no-commit-hipify
 
       - name: Checkout PyTorch source (stable)
         if: ${{ inputs.pytorch_git_ref != 'nightly' }}
@@ -171,7 +172,8 @@ jobs:
           python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --checkout-dir ${{ env.CHECKOUT_ROOT }}/torch \
             --gitrepo-origin https://github.com/ROCm/pytorch.git \
-            --repo-hashtag ${{ inputs.pytorch_git_ref }}
+            --repo-hashtag ${{ inputs.pytorch_git_ref }} \
+            --no-commit-hipify
 
       # Note: determine_version.py sets optional_build_prod_arguments in
       # GITHUB_ENV, which includes --rocm-sdk-version and --version-suffix.

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -168,28 +168,38 @@ jobs:
         if: ${{ inputs.pytorch_git_ref == 'nightly' }}
         run: |
           ./external-builds/pytorch/pytorch_torch_repo.py checkout \
-            --repo-hashtag nightly
+            --repo-hashtag nightly \
+            --no-commit-hipify
           ./external-builds/pytorch/pytorch_audio_repo.py checkout \
-            --repo-hashtag nightly
+            --repo-hashtag nightly \
+            --no-commit-hipify
           ./external-builds/pytorch/pytorch_vision_repo.py checkout \
-            --repo-hashtag nightly
-          ./external-builds/pytorch/pytorch_triton_repo.py checkout
+            --repo-hashtag nightly \
+            --no-commit-hipify
+          ./external-builds/pytorch/pytorch_triton_repo.py checkout \
+            --no-commit-hipify
           ./external-builds/pytorch/pytorch_apex_repo.py checkout \
-            --repo-hashtag master
+            --repo-hashtag master \
+            --no-commit-hipify
 
       - name: Checkout PyTorch source repos (stable)
         if: ${{ inputs.pytorch_git_ref != 'nightly' }}
         run: |
           ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --gitrepo-origin https://github.com/ROCm/pytorch.git \
-            --repo-hashtag ${{ inputs.pytorch_git_ref }}
+            --repo-hashtag ${{ inputs.pytorch_git_ref }} \
+            --no-commit-hipify
           ./external-builds/pytorch/pytorch_audio_repo.py checkout \
-            --require-related-commit
+            --require-related-commit \
+            --no-commit-hipify
           ./external-builds/pytorch/pytorch_vision_repo.py checkout \
-            --require-related-commit
-          ./external-builds/pytorch/pytorch_triton_repo.py checkout
+            --require-related-commit \
+            --no-commit-hipify
+          ./external-builds/pytorch/pytorch_triton_repo.py checkout \
+            --no-commit-hipify
           ./external-builds/pytorch/pytorch_apex_repo.py checkout \
-            --require-related-commit
+            --require-related-commit \
+            --no-commit-hipify
 
       # determine_version.py sets optional_build_prod_arguments in
       # GITHUB_ENV (--rocm-sdk-version, --version-suffix).

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -186,13 +186,16 @@ jobs:
           git config --global core.longpaths true
           python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --checkout-dir ${{ env.CHECKOUT_ROOT }}/torch \
-            --repo-hashtag nightly
+            --repo-hashtag nightly \
+            --no-commit-hipify
           python ./external-builds/pytorch/pytorch_audio_repo.py checkout \
             --checkout-dir ${{ env.CHECKOUT_ROOT }}/audio \
-            --repo-hashtag nightly
+            --repo-hashtag nightly \
+            --no-commit-hipify
           python ./external-builds/pytorch/pytorch_vision_repo.py checkout \
             --checkout-dir ${{ env.CHECKOUT_ROOT }}/vision \
-            --repo-hashtag nightly
+            --repo-hashtag nightly \
+            --no-commit-hipify
 
       - name: Checkout PyTorch source repos (stable)
         if: ${{ inputs.pytorch_git_ref != 'nightly' }}
@@ -201,15 +204,18 @@ jobs:
           python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --checkout-dir ${{ env.CHECKOUT_ROOT }}/torch \
             --gitrepo-origin https://github.com/ROCm/pytorch.git \
-            --repo-hashtag ${{ inputs.pytorch_git_ref }}
+            --repo-hashtag ${{ inputs.pytorch_git_ref }} \
+            --no-commit-hipify
           python ./external-builds/pytorch/pytorch_audio_repo.py checkout \
             --checkout-dir ${{ env.CHECKOUT_ROOT }}/audio \
             --torch-dir ${{ env.CHECKOUT_ROOT }}/torch \
-            --require-related-commit
+            --require-related-commit \
+            --no-commit-hipify
           python ./external-builds/pytorch/pytorch_vision_repo.py checkout \
             --checkout-dir ${{ env.CHECKOUT_ROOT }}/vision \
             --torch-dir ${{ env.CHECKOUT_ROOT }}/torch \
-            --require-related-commit
+            --require-related-commit \
+            --no-commit-hipify
 
       # determine_version.py sets optional_build_prod_arguments in
       # GITHUB_ENV (--rocm-sdk-version, --version-suffix).

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -141,14 +141,16 @@ jobs:
 
       # Here we checkout the same version of PyTorch that wheels were built from
       # so we have the right set of test source files. We _probably_ don't need
-      # to run HIPIFY or apply any patches, so we skip those steps to save time.
+      # to run HIPIFY, apply patches, or fetch submodules, so we skip those
+      # steps to save time.
       - name: Checkout PyTorch Source Repos from nightly branch
         if: ${{ (inputs.pytorch_git_ref == 'nightly') }}
         run: |
           python external-builds/pytorch/pytorch_torch_repo.py checkout \
             --gitrepo-origin https://github.com/pytorch/pytorch.git \
             --repo-hashtag nightly \
-            --no-hipify
+            --no-hipify \
+            --no-submodules
 
       - name: Checkout PyTorch Source Repos from stable branch
         if: ${{ (inputs.pytorch_git_ref != 'nightly') }}
@@ -156,7 +158,8 @@ jobs:
           python external-builds/pytorch/pytorch_torch_repo.py checkout \
             --gitrepo-origin https://github.com/ROCm/pytorch.git \
             --repo-hashtag ${{ inputs.pytorch_git_ref }} \
-            --no-hipify
+            --no-hipify \
+            --no-submodules
 
       - name: Set up virtual environment
         timeout-minutes: 15

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -201,13 +201,15 @@ jobs:
 
       # Here we checkout the same version of PyTorch that wheels were built from
       # so we have the right set of test source files. We _probably_ don't need
-      # to run HIPIFY or apply any patches, so we skip those steps to save time.
+      # to run HIPIFY, apply patches, or fetch submodules, so we skip those
+      # steps to save time.
       - name: Checkout PyTorch Source
         run: |
           python external-builds/pytorch/pytorch_torch_repo.py checkout \
             --gitrepo-origin https://github.com/${{ inputs.pytorch_git_repo }}.git \
             --repo-hashtag ${{ inputs.pytorch_git_ref }} \
-            --no-hipify
+            --no-hipify \
+            --no-submodules
 
       - name: Set up virtual environment
         timeout-minutes: 15

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -406,6 +406,14 @@ Note the sequence of commits and tags that were created:
 - `main` is checked out initially and is tagged `THEROCK_UPSTREAM_DIFFBASE`
 - hipify is run and its changes are tagged `THEROCK_HIPIFY_DIFFBASE`
 
+For build workflows that need package metadata such as
+`torch.version.git_version` to identify the fetched upstream PyTorch commit,
+pass `--no-commit-hipify`. That still runs HIPIFY, but leaves the source tree
+dirty instead of creating a local `DO NOT SUBMIT: HIPIFY` commit.
+
+For test-only source checkouts, pass `--no-hipify --no-submodules` to fetch the
+PyTorch test files without HIPIFY preprocessing or submodule checkout.
+
 ### Alternative branches and versions
 
 #### PyTorch main branches

--- a/external-builds/pytorch/pytorch_apex_repo.py
+++ b/external-builds/pytorch/pytorch_apex_repo.py
@@ -82,14 +82,7 @@ def main(cl_args: list[str]):
     sub_p = p.add_subparsers(required=True)
     checkout_p = sub_p.add_parser("checkout", help="Clone Apex locally and checkout")
     add_common(checkout_p)
-    checkout_p.add_argument("--depth", type=int, help="Fetch depth")
-    checkout_p.add_argument("--jobs", type=int, help="Number of fetch jobs")
-    checkout_p.add_argument(
-        "--hipify",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Run hipify",
-    )
+    repo_management.add_checkout_options(checkout_p, default_hipify=False)
     checkout_p.set_defaults(func=repo_management.do_checkout)
 
     hipify_p = sub_p.add_parser("hipify", help="Run HIPIFY on the project")

--- a/external-builds/pytorch/pytorch_audio_repo.py
+++ b/external-builds/pytorch/pytorch_audio_repo.py
@@ -82,14 +82,7 @@ def main(cl_args: list[str]):
         "checkout", help="Clone PyTorch Audio locally and checkout"
     )
     add_common(checkout_p)
-    checkout_p.add_argument("--depth", type=int, help="Fetch depth")
-    checkout_p.add_argument("--jobs", type=int, help="Number of fetch jobs")
-    checkout_p.add_argument(
-        "--hipify",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Run hipify",
-    )
+    repo_management.add_checkout_options(checkout_p, default_hipify=True)
     checkout_p.set_defaults(func=repo_management.do_checkout)
 
     hipify_p = sub_p.add_parser("hipify", help="Run HIPIFY on the project")

--- a/external-builds/pytorch/pytorch_torch_repo.py
+++ b/external-builds/pytorch/pytorch_torch_repo.py
@@ -67,14 +67,8 @@ def main(cl_args: list[str]):
         default=DEFAULT_ORIGIN,
         help="git repository url",
     )
-    checkout_p.add_argument("--depth", type=int, help="Fetch depth")
-    checkout_p.add_argument("--jobs", default=10, type=int, help="Number of fetch jobs")
-    checkout_p.add_argument(
-        "--hipify",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Run hipify",
-    )
+    repo_management.add_checkout_options(checkout_p, default_hipify=True)
+    checkout_p.set_defaults(jobs=10)
     checkout_p.set_defaults(func=repo_management.do_checkout)
 
     hipify_p = sub_p.add_parser("hipify", help="Run HIPIFY on the project")

--- a/external-builds/pytorch/pytorch_triton_repo.py
+++ b/external-builds/pytorch/pytorch_triton_repo.py
@@ -152,14 +152,7 @@ def main(cl_args: list[str]):
         action=argparse.BooleanOptionalAction,
         help="Build a release Triton (vs nightly pin)",
     )
-    checkout_p.add_argument("--depth", type=int, help="Fetch depth")
-    checkout_p.add_argument("--jobs", type=int, help="Number of fetch jobs")
-    checkout_p.add_argument(
-        "--hipify",
-        action=argparse.BooleanOptionalAction,
-        default=default_hipify,
-        help="Run hipify",
-    )
+    repo_management.add_checkout_options(checkout_p, default_hipify=default_hipify)
     checkout_p.set_defaults(func=do_checkout)
 
     args = p.parse_args(cl_args)

--- a/external-builds/pytorch/pytorch_vision_repo.py
+++ b/external-builds/pytorch/pytorch_vision_repo.py
@@ -82,14 +82,7 @@ def main(cl_args: list[str]):
         "checkout", help="Clone PyTorch Vision locally and checkout"
     )
     add_common(checkout_p)
-    checkout_p.add_argument("--depth", type=int, help="Fetch depth")
-    checkout_p.add_argument("--jobs", type=int, help="Number of fetch jobs")
-    checkout_p.add_argument(
-        "--hipify",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Run hipify",
-    )
+    repo_management.add_checkout_options(checkout_p, default_hipify=True)
     checkout_p.set_defaults(func=repo_management.do_checkout)
 
     hipify_p = sub_p.add_parser("hipify", help="Run HIPIFY on the project")

--- a/external-builds/pytorch/repo_management.py
+++ b/external-builds/pytorch/repo_management.py
@@ -232,6 +232,8 @@ def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
         fetch_args.extend(["--depth", str(args.depth)])
     if args.jobs:
         fetch_args.extend(["-j", str(args.jobs)])
+    if not args.submodules:
+        fetch_args.extend(["--no-recurse-submodules"])
     run_command(
         ["git", "fetch"] + fetch_args + ["origin", args.repo_hashtag], cwd=repo_dir
     )

--- a/external-builds/pytorch/repo_management.py
+++ b/external-builds/pytorch/repo_management.py
@@ -13,6 +13,31 @@ TAG_HIPIFY_DIFFBASE = "THEROCK_HIPIFY_DIFFBASE"
 HIPIFY_COMMIT_MESSAGE = "DO NOT SUBMIT: HIPIFY"
 
 
+def add_checkout_options(
+    command_parser: argparse.ArgumentParser, *, default_hipify: bool
+) -> None:
+    command_parser.add_argument("--depth", type=int, help="Fetch depth")
+    command_parser.add_argument("--jobs", type=int, help="Number of fetch jobs")
+    command_parser.add_argument(
+        "--submodules",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Checkout git submodules",
+    )
+    command_parser.add_argument(
+        "--hipify",
+        action=argparse.BooleanOptionalAction,
+        default=default_hipify,
+        help="Run hipify",
+    )
+    command_parser.add_argument(
+        "--commit-hipify",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Commit HIPIFY changes after running hipify",
+    )
+
+
 def run_command(args: list[str | Path], cwd: Path, *, stdout_devnull: bool = False):
     args = [str(arg) for arg in args]
     print(f"++ Exec [{cwd}]$ {shlex.join(args)}")
@@ -179,7 +204,7 @@ def commit_hipify_module(module_path: Path):
 
 def commit_hipify(args: argparse.Namespace):
     repo_dir: Path = args.checkout_dir
-    all_paths = get_all_repositories(repo_dir)
+    all_paths = get_all_repositories(repo_dir) if args.submodules else [repo_dir]
     for module_path in all_paths:
         commit_hipify_module(module_path)
 
@@ -212,31 +237,33 @@ def do_checkout(args: argparse.Namespace, custom_hipify=do_hipify):
     )
     run_command(["git", "checkout", "FETCH_HEAD"], cwd=repo_dir)
     run_command(["git", "tag", "-f", TAG_UPSTREAM_DIFFBASE, "--no-sign"], cwd=repo_dir)
-    try:
+    if args.submodules:
+        try:
+            run_command(
+                ["git", "submodule", "update", "--init", "--recursive"] + fetch_args,
+                cwd=repo_dir,
+            )
+        except subprocess.CalledProcessError:
+            print("Failed to fetch git submodules")
+            sys.exit(1)
         run_command(
-            ["git", "submodule", "update", "--init", "--recursive"] + fetch_args,
+            [
+                "git",
+                "submodule",
+                "foreach",
+                "--recursive",
+                f"git tag -f {TAG_UPSTREAM_DIFFBASE} --no-sign",
+            ],
             cwd=repo_dir,
+            stdout_devnull=True,
         )
-    except subprocess.CalledProcessError:
-        print("Failed to fetch git submodules")
-        sys.exit(1)
-    run_command(
-        [
-            "git",
-            "submodule",
-            "foreach",
-            "--recursive",
-            f"git tag -f {TAG_UPSTREAM_DIFFBASE} --no-sign",
-        ],
-        cwd=repo_dir,
-        stdout_devnull=True,
-    )
-    git_config_ignore_submodules(repo_dir)
+        git_config_ignore_submodules(repo_dir)
 
     # Hipify.
     if args.hipify:
         custom_hipify(args)
-        commit_hipify(args)
+        if args.commit_hipify:
+            commit_hipify(args)
 
 
 # Reads the ROCm maintained "related_commits" file from the given pytorch dir.


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/4987.

Two related improvements:
1. Skip committing HIPIFY changes to preserve accurate git_version metadata

    The torch package contains a `torch/version.py` file with contents like
    ```python
    from typing import Optional
    
    __all__ = ['__version__', 'debug', 'cuda', 'git_version', 'hip', 'rocm', 'xpu']
    __version__ = '2.13.0a0+rocm7.14.0a20260527'
    debug = False
    cuda: Optional[str] = None
    git_version = '98aad65aae973ef0bf0689a9254ec4d86eb84202'
    hip: Optional[str] = '7.13.60850'
    rocm: Optional[str] = '7.14.0'
    xpu: Optional[str] = None
    ```

    That is available for use from Python via e.g.:
    ```python
    >>> import torch
    >>> torch.version.git_version
    '98aad65aae973ef0bf0689a9254ec4d86eb84202'
    ```

    That `git_version` has been pointing to a HIPIFY commit, not any pushed commits from public repositories. Now the HIPIFY changes will remain uncommitted and the metadata will be accurate.
    
2. Skip submodule checkouts when running tests

    Tests don't need submodule files to run, so test jobs can save 1-2 minutes of time by skipping them.

## Test Plan

* Tested locally on Windows:
    ```bash
    # Test mode (no hipify/submodules)
    python pytorch_torch_repo.py checkout ^
      --checkout-dir D:/b/pytorch ^
      --gitrepo-origin https://github.com/rocm/pytorch.git ^
      --repo-hashtag release/2.12 ^
      --no-hipify ^
      --no-submodules
    
    # Build mode (no hipify commit)
    python pytorch_torch_repo.py checkout ^
      --checkout-dir D:/b/pytorch ^
      --gitrepo-origin https://github.com/rocm/pytorch.git ^
      --repo-hashtag release/2.12 ^
      --no-commit-hipify
    
    # Dev mode (full submodule checkout, hipify run, commits)
    python pytorch_torch_repo.py checkout ^
      --checkout-dir D:/b/pytorch ^
      --gitrepo-origin https://github.com/rocm/pytorch.git ^
      --repo-hashtag release/2.12
    ```

    Logs showed the expected commands running for each script call, repository state was as expected too.
* Tested on CI with `.github/workflows/build_portable_linux_pytorch_wheels.yml`: https://github.com/ROCm/TheRock/actions/runs/26658069438
    * ✅ check `torch/version.py` file
        * `git_version = '98563b80a0e35c3a50c789330d894198650d641b'` --> https://github.com/rocm/pytorch/commit/98563b80a0e35c3a50c789330d894198650d641b on https://github.com/ROCm/pytorch/tree/release/2.11, instead of `git_version = 'dd44a83cfac5129f5b3f1a9b919c3447af925290'` --> https://github.com/rocm/pytorch/commit/dd44a83cfac5129f5b3f1a9b919c3447af925290 (404)
    * ✅ check that tests run as expected, without new failures relating to the files that are now skipped
        * https://github.com/ROCm/TheRock/actions/runs/26658069438/job/78580000884 has `= 1 failed, 39637 passed, 1957 skipped, 41 deselected, 48 xfailed, 6 subtests passed` just like https://github.com/ROCm/TheRock/actions/runs/26623058753/job/78484073887, checkout took 27 seconds instead of 1m57s

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
