### PR TITLE
Re-land (#5515) Include ROCm base version in TheRock manifest

### DIFF
--- a/build_tools/generate_therock_manifest.py
+++ b/build_tools/generate_therock_manifest.py
@@ -172,12 +172,20 @@ def patches_for_submodule_by_name(repo_dir: Path, sub_name: str):
     return [str(p.relative_to(repo_dir)) for p in sorted(base.glob("*.patch"))]
 
 
+def rocm_version_from_package_version(rocm_package_version: str) -> str | None:
+    match = re.match(r"^(\d+\.\d+\.\d+)", rocm_package_version)
+    if not match:
+        return None
+    return match.group(1)
+
+
 def build_manifest_schema(
     repo_root: Path,
     the_rock_commit: str,
     github_job: str | None = None,
     github_run_id: str | None = None,
     rocm_package_version: str | None = None,
+    rocm_version: str | None = None,
 ) -> dict:
     # Enumerate submodules from .gitmodules at the specified commit.
     entries = list_submodules_from_gitmodules_at_commit(repo_root, the_rock_commit)
@@ -209,6 +217,9 @@ def build_manifest_schema(
     if rocm_package_version:
         manifest["rocm_package_version"] = rocm_package_version
 
+    if rocm_version:
+        manifest["rocm_version"] = rocm_version
+
     manifest["submodules"] = rows
     return manifest
 
@@ -218,6 +229,7 @@ def build_partial_manifest_schema(
     github_job: str | None = None,
     github_run_id: str | None = None,
     rocm_package_version: str | None = None,
+    rocm_version: str | None = None,
 ) -> dict:
     # Enumerate submodules from the filesystem .gitmodules file when git metadata
     # is unavailable (for example, source trees with .git removed).
@@ -248,6 +260,9 @@ def build_partial_manifest_schema(
 
     if rocm_package_version:
         manifest["rocm_package_version"] = rocm_package_version
+
+    if rocm_version:
+        manifest["rocm_version"] = rocm_version
 
     manifest["submodules"] = rows
     return manifest
@@ -290,6 +305,12 @@ def main():
     github_run_id = os.getenv("GITHUB_RUN_ID")
     git_available = has_git_metadata(repo_root)
 
+    rocm_version = (
+        rocm_version_from_package_version(args.rocm_package_version)
+        if args.rocm_package_version
+        else None
+    )
+
     if git_available:
         the_rock_commit = capture(["git", "rev-parse", args.commit], cwd=repo_root)
         manifest = build_manifest_schema(
@@ -298,6 +319,7 @@ def main():
             github_job,
             github_run_id,
             args.rocm_package_version,
+            rocm_version,
         )
     else:
         manifest = build_partial_manifest_schema(
@@ -305,6 +327,7 @@ def main():
             github_job,
             github_run_id,
             args.rocm_package_version,
+            rocm_version,
         )
 
     # Merge flag settings into the manifest if provided.


### PR DESCRIPTION
Reland #5515
Reverted at #5527

Include ROCm base version in TheRock manifest

Add an optional `rocm_version` field to generated manifests by
deriving the base semantic version from `rocm_package_version`.

Examples:

* `7.14.0a20260526+a0` -> `7.14.0`
* `git` -> no `rocm_version` field emitted

This keeps manifest generation self-contained while providing
normalized version metadata for downstream CI/CD consumers.

Validated:

* direct manifest generation
* `THEROCK_PACKAGE_VERSION=git`
* versioned package builds
* therock-aux-overlay CMake integration path

### Local Validation

Validated both manifest generation paths locally:

#### 1. Direct manifest generation

Verified that:

```bash
python build_tools/generate_therock_manifest.py \
  --rocm-package-version git
```

correctly emits:

```json
"rocm_package_version": "git"
```

without generating `rocm_version`.

Also verified that:

```bash
python build_tools/generate_therock_manifest.py \
  --rocm-package-version 7.14.0a20260526+a0
```

correctly emits:

```json
"rocm_package_version": "7.14.0a20260526+a0",
"rocm_version": "7.14.0"
```

#### 2. CMake integration path

Validated the actual `therock-aux-overlay` manifest generation path with:

```bash
cmake -S . -B build-min -GNinja \
  -DTHEROCK_PACKAGE_VERSION=git \
  -DTHEROCK_AMDGPU_FAMILIES=gfx94X-dcgpu

cmake --build build-min --target therock-aux-overlay

```

Result:
```TheRock/build-min/base/aux-overlay/build/therock_manifest.json```

```
{
  "the_rock_commit": "1e2662a33dc2a7cbec82f72de285fe00c823c5f0",
  "rocm_package_version": "git",
  "submodules": [
    {
      "submodule_name": "half",
      "submodule_path": "base/half",
      "submodule_url": "https://github.com/ROCm/half.git",
      "pin_sha": "207ee58595a64b5c4a70df221f1e6e704b807811",
      "patches": []
    },
 ...   
```

and:


```bash
cmake -S . -B build-min-version -GNinja \
  -DTHEROCK_PACKAGE_VERSION=7.14.0a20260526+a0 \
  -DTHEROCK_AMDGPU_FAMILIES=gfx94X-dcgpu

cmake --build build-min-version --target therock-aux-overlay
```

Result:
```TheRock/build-min-version/base/aux-overlay/build/therock_manifest.json```
```
{
  "the_rock_commit": "1e2662a33dc2a7cbec82f72de285fe00c823c5f0",
  "rocm_package_version": "7.14.0a20260526+a0",
  "rocm_version": "7.14.0",
  "submodules": [
    {
      "submodule_name": "half",
      "submodule_path": "base/half",
      "submodule_url": "https://github.com/ROCm/half.git",
      "pin_sha": "207ee58595a64b5c4a70df221f1e6e704b807811",
      "patches": []
    },
...
```
Both builds completed successfully and generated the manifest correctly.

#### 3. CI Result:
https://therock-ci-artifacts.s3.amazonaws.com/26666604312-linux/manifests/therock_manifest.json