### PR TITLE
Add rocprof trace decoder dev component

### DIFF
--- a/profiler/artifact-rocprofiler-sdk.toml
+++ b/profiler/artifact-rocprofiler-sdk.toml
@@ -38,3 +38,4 @@ include = [
 
 # rocprof-trace-decoder
 [components.lib."profiler/rocprof-trace-decoder/stage"]
+[components.dev."profiler/rocprof-trace-decoder/stage"]


### PR DESCRIPTION
## Motivation

rocprof-trace-decoder was missing it's dev component installation, meaning other projects couldn't find the decoder via cmake.
This is due to the original closed source decoder being a .so only, without dev components.

## Technical Details

Added the dev components such that the cmake target and include headers are part of the build.
Tested locally and it produces the cmake/ and include/ artifact

## JIRA ID

AIPROFSDK-894

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
