### PR TITLE
Extend Dependabot to cover composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
 
   # Check for updates to GitHub Actions
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
Dependabot's github-actions ecosystem with directory `/` only scans `.github/workflows/` in practice, missing composite actions defined under `.github/actions/`. As an examplem, PR #5338 updates `configure-aws-credentials` pin in workflows but misses to bump the action in `actions/configure_aws_artifacts_credentials/`.

This adds an explicit entry for the composite action directory so pinned dependencies in those get bumped by dependabot as well.