### PR TITLE
build: enable EMULATION in ALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ option(THEROCK_ENABLE_ML_LIBS "Enable building of ML libraries" "${THEROCK_ENABL
 option(THEROCK_ENABLE_PROFILER "Enable building the profiler libraries" "${THEROCK_ENABLE_ALL}")
 option(THEROCK_ENABLE_DC_TOOLS "Enable building of data center tools" "${THEROCK_ENABLE_ALL}")
 option(THEROCK_ENABLE_MEDIA_LIBS "Enable building of Media libraries" "${THEROCK_ENABLE_ALL}")
-option(THEROCK_ENABLE_EMULATION "Enable building of emulation tools" OFF)
+option(THEROCK_ENABLE_EMULATION "Enable building of emulation tools" "${THEROCK_ENABLE_ALL}")
 option(THEROCK_ENABLE_HOST_MATH "Build all bundled host math libraries by default" OFF)
 option(THEROCK_ENABLE_WSL "Enable building WSL-specific artifacts" OFF)
 option(THEROCK_RESET_FEATURES "One-shot flag which forces all feature flags to their default state for this configuration run" OFF)

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -262,6 +262,7 @@ def _run_kpack_split(
             "flatbuffers",
             "nlohmann-json",
             "rocshmem",
+            "rocjitsu",
         ],
         exclude_components=["test"],
         tarball_compression=args.devel_tarball_compression,
@@ -349,6 +350,8 @@ def _run_legacy(
                 # Third party dependencies needed by hipDNN consumers.
                 "flatbuffers",
                 "nlohmann-json",
+                # rocjitsu emulation suite.
+                "rocjitsu",
             ],
             tarball_compression=args.devel_tarball_compression,
         )

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -3134,6 +3134,45 @@
     "Gfxarch": "True"
   },
   {
+    "Package": "amdrocm-emulation",
+    "Version": "",
+    "Architecture": "amd64",
+    "BuildArch": "x86_64",
+    "DEBDepends": [
+      "libc6",
+      "amdrocm-runtime",
+      "amdrocm-sysdeps"
+    ],
+    "RPMRequires": [
+      "amdrocm-runtime",
+      "amdrocm-sysdeps"
+    ],
+    "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
+    "Description_Short": "ROCm emulation tools",
+    "Description_Long": "emulation, virtualization, and instrumentation tools for AMD GPU applications",
+    "Section": "devel",
+    "Priority": "optional",
+    "Group": "unknown",
+    "License": "MIT",
+    "Vendor": "Advanced Micro Devices, Inc",
+    "Homepage": "https://github.com/ROCm/rocm-systems",
+    "Artifactory": [
+      {
+        "Artifact": "rocjitsu",
+        "Artifact_Subdir": [
+          {
+            "Name": "rocjitsu",
+            "Components": [
+              "lib",
+              "run"
+            ]
+          }
+        ]
+      }
+    ],
+    "Gfxarch": "False"
+  },
+  {
     "Package": "amdrocm-developer-tools",
     "Version": "",
     "Architecture": "amd64",
@@ -3142,13 +3181,15 @@
       "amdrocm-base",
       "amdrocm-amdsmi",
       "amdrocm-profiler-base",
-      "amdrocm-profiler"
+      "amdrocm-profiler",
+      "amdrocm-emulation"
     ],
     "RPMRequires": [
       "amdrocm-base",
       "amdrocm-amdsmi",
       "amdrocm-profiler-base",
-      "amdrocm-profiler"
+      "amdrocm-profiler",
+      "amdrocm-emulation"
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
     "Description_Short": "AMD ROCm development tools metapackage",

--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -15,7 +15,7 @@ if(THEROCK_ENABLE_ROCJITSU)
 
   therock_cmake_subproject_declare(rocjitsu
     USE_DIST_AMDGPU_TARGETS
-    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/emulation/rocjitsu/CMakeLists.txt"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/emulation/rocjitsu"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocjitsu"
     CMAKE_ARGS
       -DBUILD_TESTING=${THEROCK_BUILD_TESTING}

--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # ROCm Emulation Tools
 
-if(THEROCK_ENABLE_ROCJITSU AND THEROCK_ENABLE_EMULATION)
+if(THEROCK_ENABLE_ROCJITSU)
   ##############################################################################
   # rocjitsu
   #
@@ -13,20 +13,11 @@ if(THEROCK_ENABLE_ROCJITSU AND THEROCK_ENABLE_EMULATION)
   # hardware.
   ##############################################################################
 
-  if(EXISTS "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/emulation/rocjitsu/CMakeLists.txt")
-    set(_rocjitsu_source_dir "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/emulation/rocjitsu")
-  elseif(EXISTS "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/experimental/rocjitsu/CMakeLists.txt")
-    set(_rocjitsu_source_dir "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/experimental/rocjitsu")
-  else()
-    message(FATAL_ERROR "rocjitsu source directory not found under rocm-systems/emulation or rocm-systems/experimental")
-  endif()
-
   therock_cmake_subproject_declare(rocjitsu
     USE_DIST_AMDGPU_TARGETS
-    EXTERNAL_SOURCE_DIR "${_rocjitsu_source_dir}"
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/emulation/rocjitsu/CMakeLists.txt"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocjitsu"
     CMAKE_ARGS
-      -DRJ_BUILD_GUI=OFF
       -DBUILD_TESTING=${THEROCK_BUILD_TESTING}
   )
 

--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -36,7 +36,7 @@ if(THEROCK_ENABLE_ROCJITSU)
 
   therock_test_validate_shared_lib(PATH rocjitsu/dist/lib
     LIB_NAMES
-      librocjitsu.so
+      librocjitsu_kmd.so
   )
 
   therock_provide_artifact(rocjitsu

--- a/emulation/artifact-rocjitsu.toml
+++ b/emulation/artifact-rocjitsu.toml
@@ -1,5 +1,9 @@
 # rocjitsu
 [components.lib."emulation/rocjitsu/stage"]
+default_patterns = false
+include = [
+  "lib/librocjitsu_kmd.so",
+]
 [components.dbg."emulation/rocjitsu/stage"]
 [components.dev."emulation/rocjitsu/stage"]
 [components.run."emulation/rocjitsu/stage"]


### PR DESCRIPTION
make emulation be included in nightly build

## Motivation
emulation is included in nightly builds

## Technical Details

`option(THEROCK_ENABLE_EMULATION "Enable building of emulation tools" "${THEROCK_ENABLE_ALL}")`

make it no longer require `THEROCK_ENABLE_EMULATION` to be set

## Test Plan

run the ci and checked the produced artifacts

## Test Result

passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
