### PR TITLE
[ci] excluding crashing gfx110X windows tests for hipsparse

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
@@ -30,7 +30,7 @@ TEST_TO_IGNORE = {
         # TODO(#3621): Include test once out of resource errors are resolved
         "windows": ["*spmm*"]
     },
-    "gfx110X-all": {"windows": ["*csr2csr_compress*", "*prune_csr2csr.conversion*"]},
+    "gfx110X-all": {"windows": ["*csr2csr_compress*", "*prune_csr2csr.conversion*", "*prune_csr2csr_by_percentage.conversion*"]},
 }
 
 environ_vars["HIPSPARSE_CLIENTS_MATRICES_DIR"] = (

--- a/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
@@ -30,7 +30,13 @@ TEST_TO_IGNORE = {
         # TODO(#3621): Include test once out of resource errors are resolved
         "windows": ["*spmm*"]
     },
-    "gfx110X-all": {"windows": ["*csr2csr_compress*", "*prune_csr2csr.conversion*", "*prune_csr2csr_by_percentage.conversion*"]},
+    "gfx110X-all": {
+        "windows": [
+            "*csr2csr_compress*",
+            "*prune_csr2csr.conversion*",
+            "*prune_csr2csr_by_percentage.conversion*",
+        ]
+    },
 }
 
 environ_vars["HIPSPARSE_CLIENTS_MATRICES_DIR"] = (


### PR DESCRIPTION
This PR excludes `*prune_csr2csr_by_percentage.conversion*` tests on gfx110X with windows as they can fail as follows during CI:
```
2026-06-01T04:25:10.5273058Z [ RUN      ] quick/prune_csr2csr_by_percentage.conversion/f64_r_10_623_0_0b_0b
2026-06-01T04:25:11.5423830Z unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
2026-06-01T04:25:11.5424776Z Stack trace:
2026-06-01T04:25:11.5424873Z 
2026-06-01T04:25:11.5424889Z 
2026-06-01T04:25:11.5427411Z [  FAILED  ] quick/prune_csr2csr_by_percentage.conversion/f64_r_10_623_0_0b_0b, where GetParam() = { filename: "*", function: "prune_csr2csr_by_percentage", category: "quick", M: 10, N: 623, K: -1, nnz: -1, block_dim: 2, row_block_dimA: 2, col_block_dimA: 2, row_block_dimB: 2, col_block_dimB: 2, lda: 1, ldb: 1, ldc: 1, batch_count: -1, index_type_I: "i32", index_type_J: "i32", a_type: "f64_r", x_type: "f64_r", y_type: "f64_r", compute_type: "f64_r", alpha: 1.0, alphai: 0.0, beta: 0.0, betai: 0.0, threshold: 1.0, percentage: 0.0, c: 1.0, s: 1.0, transA: "NT", transB: "NT", baseA: "0b", baseB: "0b", baseC: "0b", baseD: "0b", action: "num", part: "auto", diag_type: "ND", fill_mode: "L", solve_policy: "use_level", dirA: "row", orderA: "col", orderB: "col", orderC: "col", formatA: "csr", formatB: "csr", csr2csc_alg: "default", dense2sparse_alg: "default", sparse2dense_alg: "default", sddmm_alg: "default", spgemm_alg: "default", spmm_alg: "default", spmv_alg: "default", spsm_alg: "default", spsv_alg: "default", csr2csc_alg: 0, dense2sparse_alg: 0, sparse2dense_alg: 0, sddmm_alg: 0, spgemm_alg: 0, spmm_alg: 0, spmv_alg: 0, spsm_alg: 0, spsv_alg: 0, numeric_boost: 0, boosttol: 0.0, boostval: 1.0, boostvali: 0.0, slice_size: 2, ell_width: 0, permute: 0, gtsv_alg: 0, gpsv_alg: 0, unit_check: 1, timing: 0, iters: 10, graph_test: false }
2026-06-01T04:25:11.5430108Z  (1015 ms)
```

This is a temporary work around as #4609 and it is related to both https://github.com/ROCm/TheRock/issues/4533 and https://github.com/ROCm/rocm-libraries/issues/7713 .