### PR TITLE
Stop packaging ocl artifacts on windows

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -465,17 +465,19 @@ if(THEROCK_ENABLE_OCL_ICD)
   INTERFACE_INSTALL_RPATH_DIRS
     "lib"
   )
-
   therock_cmake_subproject_activate(ocl-icd)
 
-  therock_provide_artifact(core-ocl-icd
-    TARGET_NEUTRAL
-    DESCRIPTOR artifact-core-ocl-icd.toml
-    COMPONENTS
-      lib
-    SUBPROJECT_DEPS
-      ocl-icd
-  )
+  # ocl-icd will be packaged in windows drivers
+  if(NOT WIN32)
+    therock_provide_artifact(core-ocl-icd
+      TARGET_NEUTRAL
+      DESCRIPTOR artifact-core-ocl-icd.toml
+      COMPONENTS
+        lib
+      SUBPROJECT_DEPS
+        ocl-icd
+    )
+  endif()
 endif(THEROCK_ENABLE_OCL_ICD)
 
 if(THEROCK_ENABLE_OCL_RUNTIME)
@@ -542,19 +544,22 @@ if(THEROCK_ENABLE_OCL_RUNTIME)
   therock_cmake_subproject_provide_package(ocl-clr ocl-icd lib/cmake/ocl-icd)
   therock_cmake_subproject_activate(ocl-clr)
 
-  therock_provide_artifact(core-ocl
-    TARGET_NEUTRAL
-    DESCRIPTOR artifact-core-ocl.toml
-    COMPONENTS
-      dbg
-      dev
-      doc
-      lib
-      run
-      test
-    SUBPROJECT_DEPS
-      ocl-clr
-  )
+  # ocl runtime will be packaged in windows drivers
+  if(NOT WIN32)
+    therock_provide_artifact(core-ocl
+      TARGET_NEUTRAL
+      DESCRIPTOR artifact-core-ocl.toml
+      COMPONENTS
+        dbg
+        dev
+        doc
+        lib
+        run
+        test
+      SUBPROJECT_DEPS
+        ocl-clr
+    )
+  endif()
 
   therock_test_validate_shared_lib(
     PATH ocl-clr/dist/lib/opencl

--- a/core/artifact-core-ocl-icd.toml
+++ b/core/artifact-core-ocl-icd.toml
@@ -1,7 +1,7 @@
 # opencl
 [components.lib."core/ocl-icd/stage"]
 # Linux implicitly includes lib/libOpenCL.so
-# Windows needs to explicitly include bin/OpenCL.dll
+# Windows will be packaged in drivers
 include = [
   "bin/**",
 ]


### PR DESCRIPTION
## Motivation
ocl artifacts will be packaged in windows drivers

## Technical Details
Aligned with windows MSI design -https://github.com/ROCm/TheRock/pull/3973#discussion_r3237895440

## Test Plan
Ensure rock build passes on linux and windows

## Test Result
Ensure rock build passes on linux and windows

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
