### PR TITLE
ci: raise MIOpen GHA step timeout to 120 minutes (ALMIOPEN-1994)

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -400,7 +400,11 @@ test_matrix = {
     "miopen": {
         "job_name": "miopen",
         "fetch_artifact_args": "--blas --miopen --rand --tests",
-        "timeout_minutes": 60,
+        # GHA step timeout: sized to allow nightly comprehensive runs (~2 hr).
+        # Per-test CTest TIMEOUT in rocm-libraries/projects/miopen/test/gtest/
+        # test_categories.yaml bounds individual tests (quick: 10 min,
+        # standard: 60 min, etc).
+        "timeout_minutes": 120,
         "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {


### PR DESCRIPTION
## Summary
- Raise the MIOpen GHA step timeout from 60 → 120 minutes so nightly comprehensive runs (~2 hr target) complete without the wrapper killing the job.
- Per-test CTest `TIMEOUT` in `rocm-libraries/projects/miopen/test/gtest/test_categories.yaml` still bounds individual tests (quick: 10 min, standard: 60 min, etc.) — quick/standard PRs continue to fail fast.
- Comment added to the MIOpen entry pointing at the per-test source of truth so future readers don't conflate the wrapper with the per-test ceiling.

## Risk Assessment

Low.  This is a minor increase to the max MIOpen test timeout.  The timeouts in the MIOpen test categories yaml file still keep the _quick_ and _standard_ timeouts at their usual values.

## Test plan
- [x] CI: pass the relevant rock CI
- [x] Verified that test category timeouts are controlled by the test categories yaml file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)