### PR TITLE
dockerfiles: use NINJA_VERSION instead of CMAKE_VERSION for ./install_ninja.sh

### DIFF
--- a/dockerfiles/build_manylinux_rccl_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_rccl_x86_64.Dockerfile
@@ -37,9 +37,9 @@ RUN ./install_cmake.sh "${CMAKE_VERSION}" && rm -rf /install-cmake
 
 ######## Ninja ########
 WORKDIR /install-ninja
-ENV CMAKE_VERSION="1.12.1"
+ENV NINJA_VERSION="1.12.1"
 COPY install_ninja.sh ./
-RUN ./install_ninja.sh "${CMAKE_VERSION}" && rm -rf /install-ninja
+RUN ./install_ninja.sh "${NINJA_VERSION}" && rm -rf /install-ninja
 
 ######## AWS CLI ######
 WORKDIR /install-awscli

--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -42,9 +42,9 @@ RUN ./install_cmake.sh "${CMAKE_VERSION}" && rm -rf /install-cmake
 
 ######## Ninja ########
 WORKDIR /install-ninja
-ENV CMAKE_VERSION="1.12.1"
+ENV NINJA_VERSION="1.12.1"
 COPY install_ninja.sh ./
-RUN ./install_ninja.sh "${CMAKE_VERSION}" && rm -rf /install-ninja
+RUN ./install_ninja.sh "${NINJA_VERSION}" && rm -rf /install-ninja
 
 ######## AWS CLI ######
 WORKDIR /install-awscli


### PR DESCRIPTION
This trivial patch changes the Ninja version string in `build_manylinux_x86_64.Dockerfile` from the currently misnamed `CMAKE_VERSION` to `NINJA_VERSION`.

@stellaraccident  reused  `CMAKE_VERSION` as the name for the variable passed to `./install_ninja.sh` in 02db71e648 for `build_manylinux_x86_64.Dockerfile`. `build_manylinux_rccl_x86_64.Dockerfile` then inherited that when it was created in cd0270b8be

# Motivation

I create Dockerfiles for more recent Linux distro releases and build TheRock in them to stay one step ahead of breakage from e.g. newer toolchains. Having the CMAKE_VERSION and NINJA_VERSION be distinctly named makes my scripts to sync up the build dependencies easier.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
