### PR TITLE
Add a Nix flake defining devShells

### DIFF
--- a/build_tools/posix_ccache_compiler_check.py
+++ b/build_tools/posix_ccache_compiler_check.py
@@ -61,6 +61,10 @@ import subprocess
 
 
 def compute_compiler_fingerprint():
+    # A Nix derivation output is already named with a hash of all the inputs we
+    # care about, so use it verbatim.
+    if compiler_exe.is_relative_to("/nix/store"):
+        return str(compiler_exe)
     ldd_lines = (
         subprocess.check_output(["ldd", str(compiler_exe)]).decode().splitlines()
     )

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,74 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-root": {
+      "locked": {
+        "lastModified": 1723604017,
+        "narHash": "sha256-rBtQ8gg+Dn4Sx/s+pvjdq3CB2wQNzx9XGFq/JVGCB6k=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "b759a56851e10cb13f6b8e5698af7b59c44be26e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780336545,
+        "narHash": "sha256-bWVU1JP9hCYZzQjMLdMzr/FINF+UvpZGvCJcnNY616k=",
+        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1008784.4df1b885d76a/nixexprs.tar.xz?lastModified=1780336545&rev=4df1b885d76a54e1aa1a318f8d16fd6005b6401f"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "flake-root": "flake-root",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,140 @@
+{
+  description = "TheRock (The HIP Environment and ROCm Kit)";
+
+  inputs = {
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-root.url = "github:srid/flake-root";
+  };
+
+  outputs =
+    inputs@{ flake-parts, flake-root, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } rec {
+      imports = [
+        flake-root.flakeModule
+      ];
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      flake = rec {
+        # TODO: currently we assume "nightly" releases for venv rocm packages,
+        # but we could expose every "channel"
+        families = [
+          "gfx101X-dgpu"
+          "gfx103X-all"
+          "gfx103X-dgpu"
+          "gfx110X-all"
+          "gfx110X-dgpu"
+          "gfx1150"
+          "gfx1151"
+          "gfx1152"
+          "gfx1153"
+          "gfx900"
+          "gfx906"
+          "gfx908"
+          "gfx90a"
+          "gfx120X-all"
+          "gfx90X-dcgpu"
+          "gfx94X-dcgpu"
+          "gfx950-dcgpu"
+        ];
+        forAllFamilies = f: inputs.nixpkgs.lib.genAttrs families (family: f family);
+      };
+      perSystem =
+        { config, pkgs, ... }:
+        let
+          mkFamilyShell =
+            family:
+            let
+              venvPath = if family == "" then ".venv" else ".venv.${family}";
+              ifFamily = s: if family == "" then "" else s;
+            in
+            pkgs.mkShellNoCC {
+              inputsFrom = [ config.flake-root.devShell ];
+              packages = with pkgs; [
+                autoconf
+                automake
+                bison
+                ccache
+                cmake
+                dvc
+                flex
+                gfortran # also includes g++, etc.
+                git
+                libtool
+                ncurses # just for libtinfo, since therock builds its own ncurses
+                ninja
+                pkg-config
+                python3
+                texinfo
+                (stdenv.mkDerivation rec {
+                  pname = "patchelf-rocm";
+                  version = "d0f70eea5397606c486857e0a105e53ec123904a";
+
+                  src = fetchGit {
+                    url = "https://github.com/NixOS/${pname}";
+                    rev = "${version}";
+                  };
+
+                  patchPhase = ''
+                    PATCHELF_GIT_REF="${version}"
+                    SHORT_GIT_REF="''${PATCHELF_GIT_REF:0:12}"
+                    BASE_VERSION="$(cat version)"
+                    LOCAL_VERSION="''${BASE_VERSION}+therock.''${SHORT_GIT_REF}"
+                    printf "%s\n" "''${LOCAL_VERSION}" > version
+                  '';
+
+                  nativeBuildInputs = [ autoreconfHook ];
+                })
+                (pkgs.writeShellApplication {
+                  name = "therock-update-python";
+                  text = ''
+                    set -x
+                    cd "$FLAKE_ROOT"
+                    pip install --upgrade pip
+                    pip install --upgrade -r requirements.txt
+                    ${ifFamily "pip install --upgrade 'rocm[libraries,devel]' --index-url=https://rocm.nightlies.amd.com/v2/${family}"}
+                  '';
+                })
+                (pkgs.writeShellApplication {
+                  name = "therock-fetch-sources";
+                  text = ''
+                    set -x
+                    cd "$FLAKE_ROOT"
+                    python3 ./build_tools/fetch_sources.py
+                  '';
+                })
+              ];
+              shellHook = ''
+                cd "$FLAKE_ROOT"
+                if [ ! -d ${venvPath} ]; then
+                  printf "[shell_hook] Creating ${venvPath}\n"
+                  python3 ./build_tools/setup_venv.py ${venvPath} \
+                  ${ifFamily "--packages 'rocm[libraries,devel]' --index-name nightly --index-subdir ${family}"}
+                fi
+                printf "[shell_hook] Activating ${venvPath}\n"
+                source ${venvPath}/bin/activate
+                if [ ! -d .ccache ]; then
+                  printf "[shell_hook] Creating .ccache\n"
+                  eval "$(python3 ./build_tools/setup_ccache.py)"
+                fi
+                printf "[shell_hook] Helper commands available:\n"
+                compgen -c therock- | sed 's/^/\t/'
+              '';
+            };
+        in
+        {
+          # This flake just defines devShells, so that `nix develop .` and `nix
+          # develop .#<family>` work, but we could also expose package(s).
+          # Upstream nixpkgs already maintains rocm-modules, so we would be
+          # duplicating much of that.
+          devShells = flake.forAllFamilies (family: mkFamilyShell family) // {
+            default = mkFamilyShell "";
+          };
+          formatter = pkgs.nixfmt-tree;
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -120,6 +120,9 @@
                 if [ ! -d .ccache ]; then
                   printf "[shell_hook] Creating .ccache\n"
                   eval "$(python3 ./build_tools/setup_ccache.py)"
+                else
+                  printf "[shell_hook] Activating .ccache\n"
+                  export CCACHE_CONFIGPATH="$PWD"/.ccache/ccache.conf
                 fi
                 printf "[shell_hook] Helper commands available:\n"
                 compgen -c therock- | sed 's/^/\t/'


### PR DESCRIPTION
This would otherwise live in my own nix configs, but it could be useful generally for anyone already using nix as a package manager. I have not tested on NixOS, so there may be some impurities that would need to be addressed before it worked there.

This assumes the "nix-command" and "flakes" experimental features are enabled in nix/lix, as I didn't factor things out into `default.nix` or `shell.nix`: everything is defined in the flake. This has the side-effect of ensuring inputs are pinned via `flake.lock`, which should mean less surface area for "works on my machine" type impurity bugs.

I hard-coded the supported families and didn't confirm the supported systems is accurate for TheRock. I assume "nightly" for the venv rocm packages, but that could be changed or made configurable too.

## Motivation

Actually developing out of a docker container is clunky, and nix can achieve much of the isolation and reproducibility docker offers. There doesn't need to be a commitment to maintaining the flake, but it would be nice to have as an option.

## Technical Details

See https://github.com/NixOS/nix for the package manager itself.

## Test Plan

I ran the non-family and a couple family configurations through with `--ignore-environment` to try to ensure there are no impurity bugs, but I don't have a grasp on how best to rigorously test the flake automatically. My intention is to support this provisionally (since I am using it myself) and if it benefits others it can be supported more comprehensively.

## Test Result

No issues in the cases I tested. I was able to build a subset of TheRock, the `venv` and `ccache` setup seemed right, and the helper scripts worked.

I also ran `flake-checker` and it doesn't flag any issues:

```
$ nix run nixpkgs#flake-checker
Flake checker results:

The flake checker scanned your flake.lock and didn't identify any issues. All
Nixpkgs inputs:

> Use supported branches
> Are less than 30 days old
> Use upstream Nixpkgs

```

And with the change in `posix_ccache_compiler_check.py` the smoke test in `build_tools/hack/ccache/test_ccache_sanity.sh` shows a cache hit:

```
❄️ nix-shell-env $ build_tools/hack/ccache/test_ccache_sanity.sh 
Cacheable calls:     1 /    1 (100.0%)
  Hits:              1 /    1 (100.0%)
    Direct:          1 /    1 (100.0%)
    Preprocessed:    0 /    1 ( 0.00%)
  Misses:            0 /    1 ( 0.00%)
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
