### PR TITLE
Revert "build(cmake): remove rocprofiler-systems GCC and sanitizer guards"

### DIFF
--- a/cmake/therock_compiler_config.cmake
+++ b/cmake/therock_compiler_config.cmake
@@ -46,6 +46,25 @@ if(MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 4)
     "  Detected CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")
 endif()
 
+
+if(UNIX AND NOT APPLE AND NOT THEROCK_DISABLE_GNU_CHECK)
+  # Linux-specific check.
+  if(THEROCK_ENABLE_ROCPROFSYS AND (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT CMAKE_C_COMPILER_ID STREQUAL "GNU"))
+   # Currently, the Dyninst dependency in rocprofiler-systems requires GNU compilers (gcc/g++).
+    message(FATAL_ERROR
+        "Currently, rocprofiler-systems requires GNU compilers (gcc/g++).\n"
+        "  Detected CMAKE_C_COMPILER_ID: ${CMAKE_C_COMPILER_ID}\n"
+        "  Detected CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}\n"
+        "  Detected CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}\n"
+        "  Detected CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}\n"
+        "To use GNU compilers, set:\n"
+        "  -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++\n"
+        "To disable rocprofiler-systems, set:\n"
+        "  -DTHEROCK_ENABLE_ROCPROFSYS=OFF\n"
+        "Set THEROCK_DISABLE_GNU_CHECK to bypass this check.")
+  endif()
+endif()
+
 # macOS-specific compiler checks
 if(APPLE)
   # Verify we're using AppleClang or Clang on macOS

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -271,7 +271,9 @@ endif(THEROCK_ENABLE_ROCPROFILER_COMPUTE)
 ##############################################################################
 # rocprofiler-systems
 ##############################################################################
-if(THEROCK_ENABLE_ROCPROFSYS)
+# rocprofiler-systems requires GCC, but sanitizer builds use Clang.
+# Skip enabling rocprofiler-systems when building with sanitizers.
+if (THEROCK_ENABLE_ROCPROFSYS AND THEROCK_SANITIZER STREQUAL "")
 
   therock_detect_python_versions(_rocprofsys_detected_python_executables _rocprofsys_detected_python_versions)
   if(NOT _rocprofsys_detected_python_versions OR NOT _rocprofsys_detected_python_executables)
@@ -315,8 +317,6 @@ if(THEROCK_ENABLE_ROCPROFSYS)
       -DROCPROFSYS_PYTHON_VERSIONS:STRING="${_ROCPROFSYS_PYTHON_VERSIONS_STR}"
       -DROCPROFSYS_PYTHON_ROOT_DIRS:STRING="${_ROCPROFSYS_PYTHON_ROOT_DIRS_STR}"
       "-DROCPROFSYS_USE_MPI=${THEROCK_ENABLE_MPI}"
-    COMPILER_TOOLCHAIN
-      amd-hip
     INSTALL_RPATH_DIRS
       "lib"
       "lib/rocprofiler-systems"
@@ -405,4 +405,4 @@ if(THEROCK_ENABLE_ROCPROFSYS)
         rocprofiler-systems-examples
     )
   endif()
-endif(THEROCK_ENABLE_ROCPROFSYS)
+endif(THEROCK_ENABLE_ROCPROFSYS AND THEROCK_SANITIZER STREQUAL "")


### PR DESCRIPTION
Reverts ROCm/TheRock#5196
Breaking the multi arch ci asan jobs. #5196 was not tested against the Multi arch ci asan(checks were skipped).
related issue: https://github.com/ROCm/TheRock/issues/5593