### PR TITLE
Pin rocm/rocm-sdk-* deps with PEP 440 === instead of ==

### DIFF
--- a/build_tools/github_actions/determine_version.py
+++ b/build_tools/github_actions/determine_version.py
@@ -86,7 +86,11 @@ def main(argv: list[str]):
 
     parsed_version = parse(args.rocm_version)
     version_suffix = derive_version_suffix(args.rocm_version)
-    rocm_sdk_version = f"=={parsed_version}"
+    # PEP 440 arbitrary equality (===) so an index publishing both X and
+    # X+<local> silicon-rev variants of rocm cannot have == silently resolve
+    # to the local-segmented candidate during the SDK install in the build
+    # environment.
+    rocm_sdk_version = f"==={parsed_version}"
     optional_build_prod_arguments = (
         f"--rocm-sdk-version {rocm_sdk_version} --version-suffix {version_suffix}"
     )

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -94,7 +94,13 @@ class PackageEntry:
         return self.dist_package_template.format(**kwargs)
 
     def get_dist_package_require(self, target_family: str | None = None) -> str:
-        return self.get_dist_package_name(target_family) + f"=={__version__}"
+        # Use PEP 440 arbitrary equality (===) so a Python index that publishes
+        # both X and X+<local> silicon-rev variants of the same rocm-sdk-* package
+        # cannot satisfy this strict intra-package pin with a different local
+        # segment than the one that produced this metapackage. == would match
+        # both X and X+<local> candidates and pip prefers the local-segmented
+        # one, silently cross-stamping the install.
+        return self.get_dist_package_name(target_family) + f"==={__version__}"
 
     def get_py_package_name(self, target_family: str | None = None) -> str:
         dist_name = self.get_dist_package_name(target_family)

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -1039,9 +1039,13 @@ def do_build_pytorch(
     env["PYTORCH_BUILD_VERSION"] = pytorch_build_version
     env["PYTORCH_BUILD_NUMBER"] = args.pytorch_build_number
 
-    # Determine which install requirements to add.
+    # Determine which install requirements to add. Use PEP 440 arbitrary equality
+    # (===) on the rocm pin so that an index publishing both X and X+<local>
+    # silicon-rev variants of the rocm metapackage cannot silently substitute the
+    # local-segmented one at consumer install time (== matches both candidates
+    # and pip prefers the local-segmented one).
     install_requirements = [
-        f"rocm[libraries]=={get_rocm_sdk_version()}",
+        f"rocm[libraries]==={get_rocm_sdk_version()}",
     ]
     if triton_requirement:
         install_requirements.append(triton_requirement)


### PR DESCRIPTION
Switches the three rocm-sdk-* version pins in `_dist_info.py`, `external-builds/pytorch/build_prod_wheels.py`, and `build_tools/github_actions/determine_version.py` from PEP 440 `==` to `===` (arbitrary equality / literal-string match) so an index that publishes both bare `X` and local-segmented `X+<local>` silicon-rev variants of the same rocm-sdk wheel cannot satisfy these pins with a different rev than the one that produced the metapackage / torch wheel (`==X` matches both candidates and pip's resolver prefers the local-segmented one, silently cross-stamping the install). Single-rev indices remain unaffected. Currently mirrored as a sed-patch step in [rocm-npi-dev#785](https://github.com/AMD-ROCm-Internal/rocm-npi-dev/pull/785) which can be dropped once this lands and TheRock is bumped there.

Made with [Cursor](https://cursor.com)