### PR TITLE
Pin rocm/rocm-sdk-* deps with PEP 440 === instead of ==

### DIFF
--- a/build_tools/github_actions/determine_version.py
+++ b/build_tools/github_actions/determine_version.py
@@ -12,7 +12,7 @@ Example usage:
   The following string is appended to the file specified in the "GITHUB_ENV"
   environment variable:
 
-    optional_build_prod_arguments=--rocm-sdk-version ==7.0.0 --version-suffix +rocm7.0.0
+    optional_build_prod_arguments=--rocm-sdk-version ===7.0.0 --version-suffix +rocm7.0.0
 
 Writing the output to the "GITHUB_ENV" file can be suppressed by passing
 `--no-write-env-file`.

--- a/build_tools/github_actions/determine_version.py
+++ b/build_tools/github_actions/determine_version.py
@@ -86,7 +86,7 @@ def main(argv: list[str]):
 
     parsed_version = parse(args.rocm_version)
     version_suffix = derive_version_suffix(args.rocm_version)
-    rocm_sdk_version = f"=={parsed_version}"
+    rocm_sdk_version = f"==={parsed_version}"
     optional_build_prod_arguments = (
         f"--rocm-sdk-version {rocm_sdk_version} --version-suffix {version_suffix}"
     )

--- a/build_tools/github_actions/tests/determine_version_test.py
+++ b/build_tools/github_actions/tests/determine_version_test.py
@@ -59,7 +59,7 @@ class DetermineVersionTest(unittest.TestCase):
         gha_set_env.assert_called_once_with(
             {
                 "optional_build_prod_arguments": (
-                    "--rocm-sdk-version ==7.0.0 --version-suffix +rocm7.0.0"
+                    "--rocm-sdk-version ===7.0.0 --version-suffix +rocm7.0.0"
                 ),
                 "version_suffix": "+rocm7.0.0",
             }

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -94,7 +94,7 @@ class PackageEntry:
         return self.dist_package_template.format(**kwargs)
 
     def get_dist_package_require(self, target_family: str | None = None) -> str:
-        return self.get_dist_package_name(target_family) + f"=={__version__}"
+        return self.get_dist_package_name(target_family) + f"==={__version__}"
 
     def get_py_package_name(self, target_family: str | None = None) -> str:
         dist_name = self.get_dist_package_name(target_family)

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -1216,7 +1216,7 @@ class PerTargetExtrasTest(TmpDirTestCase):
                 )
 
     def test_requires_dist_pins_version_and_uses_target_in_name(self):
-        """Requires-Dist strings start with 'rocm-sdk-device-{target}==<ver>',
+        """Requires-Dist strings start with 'rocm-sdk-device-{target}===<ver>',
         matching the canonical PackageEntry.get_dist_package_require() shape.
         """
         dist_info = self._make_dist_info(

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -1226,7 +1226,7 @@ class PerTargetExtrasTest(TmpDirTestCase):
         extras = dist_info.build_per_target_extras()
         req = extras["device-gfx942"][0]
         self.assertTrue(
-            req.startswith("rocm-sdk-device-gfx942==0.0.1.test"),
+            req.startswith("rocm-sdk-device-gfx942===0.0.1.test"),
             f"Unexpected Requires-Dist shape: {req}",
         )
 

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -1041,7 +1041,7 @@ def do_build_pytorch(
 
     # Determine which install requirements to add.
     install_requirements = [
-        f"rocm[libraries]=={get_rocm_sdk_version()}",
+        f"rocm[libraries]==={get_rocm_sdk_version()}",
     ]
     if triton_requirement:
         install_requirements.append(triton_requirement)


### PR DESCRIPTION
## Motivation

Multi-rev indices (publishing both `X` and `X+<local>` for the same rocm-sdk wheel) silently cross-stamp installs because PEP 440 `==X` matches both bare and local-segmented variants and pip prefers the local-segmented one. Currently mirrored as a sed-patch step in [rocm-npi-dev#785](https://github.com/AMD-ROCm-Internal/rocm-npi-dev/pull/785), which can be dropped once this lands and TheRock is bumped there.

## Technical Details

Switches the three rocm-sdk-* version pins from PEP 440 `==` (version-equal, ignores local segment) to `===` (arbitrary equality / literal-string match) in:

- `_dist_info.py`
- `external-builds/pytorch/build_prod_wheels.py`
- `build_tools/github_actions/determine_version.py`

And bumps the two unit tests that hardcoded the old `==` pin in their expected-output strings:

- `build_tools/tests/py_packaging_test.py`
- `build_tools/github_actions/tests/determine_version_test.py`

Single-rev indices remain unaffected because `===X` and `==X` agree when only one candidate exists.

## Test Plan

Triggered the [`Build Portable Linux PyTorch Wheels`](https://github.com/ROCm/TheRock/actions/workflows/build_portable_linux_pytorch_wheels.yml) workflow against this branch, py 3.12, torch `release/2.10`, for each `rocm_version` format the strict-pin needs to keep working:

- **Nightlies format**  — `gfx110X-all`, `release_type=nightly`, `rocm_version=7.13.0a20260401`: [run 26928211954](https://github.com/ROCm/TheRock/actions/runs/26928211954).
- **Dev format**  — `gfx94X-dcgpu`, `release_type=dev`, `rocm_version=7.14.0.dev0+fe638f5f44e487ffb6dbf0e7f212b1b82e39ab73` (latest dev wheel on `rocm.devreleases.amd.com`): [run 26927718226](https://github.com/ROCm/TheRock/actions/runs/26927718226).

Each run should successfully resolve the metapackage and torch wheel against the expected exact rev (no silent cross-stamping).

## Test Result

- Nightlies format: [run 26928211954](https://github.com/ROCm/TheRock/actions/runs/26928211954) 
- Dev format: [run 26927718226](https://github.com/ROCm/TheRock/actions/runs/26927718226) 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
