### PR TITLE
Keep unversioned libhsa-runtime64.so symlink in core wheel to fix rccl dlopen bug

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -79,13 +79,18 @@ def ensure_profiler_library_symlinks(profiler: PopulatedDistPackage) -> None:
 
 
 def ensure_core_library_symlinks(core: PopulatedDistPackage) -> None:
-    """Recreate unversioned core library symlinks expected by dlopen()."""
+    """Recreate unversioned core library symlinks expected by dlopen().
+
+    TODO(#5562): Remove this function and its call site ensure_core_library_symlinks(core) in run()
+    once upstream RCCL stops using the unversioned libhsa-runtime64.so name in its dlopen() calls.
+    """
     core_lib_dir = core.platform_dir / "lib"
 
     target = core_lib_dir / "libhsa-runtime64.so.1"
     link = core_lib_dir / "libhsa-runtime64.so"
     if target.exists() and not link.exists():
         link.symlink_to(target.name)
+
 
 def run(args: argparse.Namespace):
     manifest = load_therock_manifest(args.artifact_dir)

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -78,6 +78,15 @@ def ensure_profiler_library_symlinks(profiler: PopulatedDistPackage) -> None:
             link.symlink_to(target.name)
 
 
+def ensure_core_library_symlinks(core: PopulatedDistPackage) -> None:
+    """Recreate unversioned core library symlinks expected by dlopen()."""
+    core_lib_dir = core.platform_dir / "lib"
+
+    target = core_lib_dir / "libhsa-runtime64.so.1"
+    link = core_lib_dir / "libhsa-runtime64.so"
+    if target.exists() and not link.exists():
+        link.symlink_to(target.name)
+
 def run(args: argparse.Namespace):
     manifest = load_therock_manifest(args.artifact_dir)
     kpack_split = manifest.get("flags", {}).get("KPACK_SPLIT_ARTIFACTS", False)
@@ -137,6 +146,7 @@ def run(args: argparse.Namespace):
             ],
         ),
     )
+    ensure_core_library_symlinks(core)
 
     profiler_artifacts = params.filter_artifacts(
         profiler_artifact_filter,


### PR DESCRIPTION
## Motivation

Closes: #5562 

Currently, rocm-sdk-core Python wheel strips out the unversioned libhsa-runtime64.so symlink. However, librccl has a bug where it [explicitly calls `dlopen("libhsa-runtime64.so")`](https://github.com/ROCm/TheRock/issues/5562#:~:text=calls%20dlopen(%22libhsa%2Druntime64.so%22)%20(unversioned).) at runtime instead of using the properly versioned .so.1 SONAME.

As noted by the issue reporter: "[RCCL's unversioned dlopen is its own bug, but the packaging asymmetry is independently fixable and unblocks /opt/rocm-less deployment without waiting on librccl.](https://github.com/ROCm/TheRock/issues/5562#:~:text=RCCL%27s%20unversioned%20dlopen%20is%20its%20own%20bug%2C%20but%20the%20packaging%20asymmetry%20is%20independently%20fixable%20and%20unblocks%20/opt/rocm%2Dless%20deployment%20without%20waiting%20on%20librccl.)"
This PR implements an exception to the packaging rule to resolve this asymmetry, immediately unblocking the dependent community while we wait for the upstream fix in RCCL.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Added `ensure_core_library_symlinks()` inside `build_tools/build_python_packages.py` and invoked it immediately after `core.populate_runtime_files()`. Because `populate_runtime_files()` has a hardcoded rule to drop unversioned .so aliases from runtime packages. This new function manually adds the libhsa-runtime64.so symlink into core wheel. 
This mirrors the exact pattern already established in the script for profiler libraries (`ensure_profiler_library_symlinks()` function).

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
1. Generated wheels using `build_python_packages.py` on existing C++ artifacts from my older local build.
2. In clean virtual env I `pip install` this newly generated `rocm-sdk-core` wheel.
3.  Run reporter's verification code inside the venv.

## Test Result

<!-- Briefly summarize test outcomes. -->
After I run reporter's verification code
```
  PURELIB=$(python3 -c "import sysconfig; print(sysconfig.get_paths()[\"purelib\"])")
  for tree in _rocm_sdk_core _rocm_sdk_libraries _rocm_sdk_devel; do
    echo "--- $tree/lib ---"
    out=$(ls "$PURELIB/$tree/lib"/libhsa-runtime64* 2>/dev/null | sed "s|$PURELIB/||")
    [ -z "$out" ] && echo "(empty)" || echo "$out"
  done
```
 inside my venv, I get the following result:
```
--- _rocm_sdk_core/lib ---
_rocm_sdk_core/lib/libhsa-runtime64.so
_rocm_sdk_core/lib/libhsa-runtime64.so.1
...
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
