### PR TITLE
sysdeps/elfutils: disable warnings as errors

### DIFF
--- a/third-party/sysdeps/linux/elfutils/CMakeLists.txt
+++ b/third-party/sysdeps/linux/elfutils/CMakeLists.txt
@@ -76,6 +76,9 @@ string(APPEND EXTRA_CPPFLAGS " -I${THEROCK_BINARY_DIR}/third-party/sysdeps/linux
 string(APPEND EXTRA_CPPFLAGS " -fPIC")
 message(STATUS "EXTRA_CPPFLAGS=${EXTRA_CPPFLAGS}")
 
+# Disable "treat compiler warnings as errors" in elfutils by adding `-Wno-error`
+set(ELFUTILS_CFLAGS "-O2 -g -Wno-error")
+
 add_custom_target(
   build ALL
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
@@ -101,6 +104,8 @@ add_custom_target(
       # then escaped single quotes to make it to the linker command line.
       "LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath=\\'\\$$\\$$ORIGIN\\'"
       "CPPFLAGS=${EXTRA_CPPFLAGS}"
+      "CFLAGS=${ELFUTILS_CFLAGS}"
+      "CXXFLAGS=${ELFUTILS_CFLAGS}"
       --
     "${CMAKE_CURRENT_BINARY_DIR}/s/configure"
       --prefix "${CMAKE_INSTALL_PREFIX}"


### PR DESCRIPTION
## Motivation

elfuitils makefiles treats compiler warnings as errors by default even in their release tarballs. Experience has shown this often break as compilers and C standard library implementations are updated on Linux.

The last break was around Jan 2026 when glibc-2.43 was updated to align with the ISO C23 standard which made `bsearch` return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

See https://github.com/ROCm/TheRock/issues/5120a and https://bugzilla.mozilla.org/show_bug.cgi?id=2012313

## Technical Details

This patch disables "warnings as errors" by passing `-Wno-error` through CFLAGS and CXXFLAGS explicitly, thus making the build break less often.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
