### PR TITLE
[math-libs] Skip rocPRIM benchmark build when amdsmi target is unavailable

### DIFF
--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -122,8 +122,11 @@ if(THEROCK_ENABLE_PRIM)
     # rocPRIM_tests declared as a separate target to stop the tests from clogging up the critical build path for libs
     # that depend on rocPRIM
     # passing BACKGROUND_BUILD ensures that the tests aren't built (too) concurrently with other projects that are demanding
-    # amdsmi is Linux-only; benchmarks depend on primbench which requires amd_smi
-    if(WIN32)
+    # amdsmi is Linux-only and only declared when THEROCK_ENABLE_CORE_AMDSMI is ON
+    # (see core/CMakeLists.txt). Benchmarks depend on primbench which requires
+    # amd_smi, so they must be disabled when amdsmi is unavailable (e.g., the
+    # prim-isolated CI group THEROCK_ENABLE_ALL=OFF / THEROCK_ENABLE_PRIM=ON).
+    if(WIN32 OR NOT TARGET amdsmi)
       set(_rocprim_benchmark_enable "OFF")
       set(_rocprim_benchmark_deps)
       set(_rocprim_benchmark_includes)


### PR DESCRIPTION
## Summary

- Guard `_rocprim_benchmark_enable` on `TARGET amdsmi` so the prim-isolated CI build (`-DTHEROCK_ENABLE_ALL=OFF -DTHEROCK_ENABLE_PRIM=ON`) no longer fails configure with `get_target_property() called with non-existent target "amdsmi"`.
- Full SDK builds are unaffected — `amdsmi` is declared (via `THEROCK_ENABLE_CORE_AMDSMI`), so the target is present, and benchmarks build exactly as before.
- Mirrors the existing precedent at `core/CMakeLists.txt:589` for `rocrtst`.

## Background

#4334 added `amdsmi` to `rocPRIM_tests` `BUILD_DEPS` unconditionally for non-Windows, but `amdsmi` is only declared as a TheRock subproject when `THEROCK_ENABLE_CORE_AMDSMI` is ON. The prim-isolated CI group doesn't enable CORE, so `_therock_cmake_subproject_collect_build_deps` blows up before configure completes.

This is breaking the rocm-libraries TheRock-pin bump in [ROCm/rocm-libraries#7979](https://github.com/ROCm/rocm-libraries/pull/7979) (e.g. `Linux (rocthrust,rocprim,hipcub | gfx94X-dcgpu) / Build`).

Related upstream tracking: #4651 (rocPRIM should also gracefully skip `find_package(amd_smi)` when not requested — once that lands, the `therock_rocprim_benchmark_deps.cmake` workaround can be dropped, but this guard is still the right shape regardless).

## Test plan

- [x] TheRock CI green on full SDK (benchmarks still built — confirm `benchmark_*` binaries under `dist/rocm/`)
- [x] TheRock CI green on any prim-isolated job (configure no longer errors)
- [ ] After merge, repoint rocm-libraries#7979's `therock-ref` to the merge SHA and re-run its failing build jobs