### PR TITLE
fix: use BooleanOptionalAction for --include-intermediate-dirs

### DIFF
--- a/build_tools/generate_s3_index.py
+++ b/build_tools/generate_s3_index.py
@@ -414,7 +414,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--include-intermediate-dirs",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         help=(
             "Also generate index.html for directories whose contents are "
             "only subdirectories (no direct files). Without this, links to "


### PR DESCRIPTION
## Motivation

Use `argparse.BooleanOptionalAction` for `--include-intermediate-dirs`
to automatically provide a `--no-include-intermediate-dirs` flag.

## Technical Details

Replaced `action="store_true"` with `action=argparse.BooleanOptionalAction`
for the `--include-intermediate-dirs` argument in `build_tools/generate_s3_index.py`.
This is the recommended pattern per the project's Python style guide.

## Test Plan

Verified that `--help` now shows both `--include-intermediate-dirs` and
`--no-include-intermediate-dirs` flags. pre-commit checks pass.

## Test Result

python build_tools/generate_s3_index.py --help                   
usage: generate_s3_index.py [-h] --run-id RUN_ID [--output-dir OUTPUT_DIR] [--bucket BUCKET] [--dry-run] [--include-intermediate-dirs | --no-include-intermediate-dirs]

Generate S3 index files after uploads

options:
  -h, --help            show this help message and exit
  --run-id RUN_ID       GitHub run ID of the workflow run
  --output-dir OUTPUT_DIR
                        Local staging directory instead of S3 (for testing)
  --bucket BUCKET       Override the S3 bucket (default: resolved from GHA environment)
  --dry-run             Print what would be uploaded without actually uploading
  --include-intermediate-dirs, --no-include-intermediate-dirs
                        Also generate index.html for directories whose contents are only subdirectories (no direct files). Without this, links to such directories from a parent index 404.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Closes #5237