### PR TITLE
fix(rocprofiler-sdk): enable rocprofv3 mpi-ranks tests in CI

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -487,6 +487,11 @@ test_matrix = {
         "total_shards_dict": {
             "linux": 1,
         },
+        # rocprofv3 mpi-ranks tests gate on find_package(MPI) and launch under
+        # mpiexec. OpenMPI is not bundled in TheRock artifacts and is provided via
+        # the specialized openmpi image.
+        # TODO: pin to a published @sha256 digest once the image exists.
+        "container_image": "ghcr.io/rocm/no_rocm_image_ubuntu24_04_openmpi:latest",
     },
     # hipDNN tests
     "hipdnn": {

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -490,8 +490,7 @@ test_matrix = {
         # rocprofv3 mpi-ranks tests gate on find_package(MPI) and launch under
         # mpiexec. OpenMPI is not bundled in TheRock artifacts and is provided via
         # the specialized openmpi image.
-        # TODO: pin to a published @sha256 digest once the image exists.
-        "container_image": "ghcr.io/rocm/no_rocm_image_ubuntu24_04_openmpi:latest",
+        "container_image": "ghcr.io/rocm/no_rocm_image_ubuntu24_04_openmpi@sha256:f67d0b02cae8faf0d2f3e4a1de38a01af6bad2eb27f10a5e07bf19748a84d1e6",
     },
     # hipDNN tests
     "hipdnn": {


### PR DESCRIPTION
## Motivation

rocprofiler-sdk's `rocprofv3` **mpi-ranks** tests are silently **disabled** unless `find_package(MPI)` succeeds at test-configure time. The shared `no_rocm` test image doesn't include an MPI implementation, so these tests never run in CI. This PR points the rocprofiler-sdk test job at the dedicated OpenMPI test image so the tests find MPI and run.

## Technical Details

- Points the `rocprofiler-sdk` test job at `ghcr.io/rocm/no_rocm_image_ubuntu24_04_openmpi` via `container_image` in `build_tools/github_actions/fetch_test_configurations.py`.

Depends on #6610, which adds and publishes that image. `test_rocprofiler_sdk.py` configures and builds the tests at test time inside the container, so `find_package(MPI)` resolves the system OpenMPI and `mpiexec` is on `PATH`, enabling the mpi-ranks tests. `rocprofv3` itself does not link MPI, so no build-time MPI is required and OpenMPI stays out of the shipped ROCm artifacts.

The image is referenced by tag pending publish; it will be pinned to an `@sha256` digest once #<image PR> lands and the image is published (see `dockerfiles/README.md`).

## Test Plan

Run the `rocprofiler-sdk` test job in CI on the OpenMPI image and confirm the mpi-ranks tests are selected and executed (not `DISABLED`) and pass.

## Test Result

_CI run on this branch: the rocprofiler-sdk job runs on the OpenMPI test image and the mpi-ranks tests run + pass 

## JIRA ID

JIRA ID : AIROCVAL-45

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.