### PR TITLE
Add PKG Dependency Check Tests to install test

### DIFF
--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -36,6 +36,8 @@ closure for DEB; ``rpm -qR`` / ``rpm -q --whatprovides`` closure for RPM) unless
 ``NATIVE_LINUX_SKIP_DEP_VERIFY=1``. The resolved dependency closure is rendered as an indented
 tree with summary counts (packages in closure / dependency edges / roots), printed to the
 console and written to ``NATIVE_LINUX_DEP_REPORT_FILE`` (default ``rocm_dependency_report.txt``).
+A flat JSON summary (status, roots, closure/edge counts, and a flat errors list) is written
+alongside it to ``NATIVE_LINUX_DEP_REPORT_JSON_FILE`` (default ``rocm_dependency_report.json``).
 
 Prerequisites:
 - This script does NOT start Docker or a VM. You must run it inside an existing
@@ -137,6 +139,7 @@ Example invocations:
 """
 
 import argparse
+import json
 import os
 import re
 import subprocess
@@ -190,6 +193,12 @@ ENV_NATIVE_LINUX_SKIP_DEP_VERIFY = "NATIVE_LINUX_SKIP_DEP_VERIFY"
 # Path of the transitive-dependency report written after verification; overridable.
 ENV_NATIVE_LINUX_DEP_REPORT_FILE = "NATIVE_LINUX_DEP_REPORT_FILE"
 DEFAULT_DEP_REPORT_FILE = "rocm_dependency_report.txt"
+
+# Path of a flat, machine-readable JSON summary written alongside the text report;
+# overridable. Shallow on purpose (status + counts + flat errors list) so CI gating
+# can parse it without walking a nested tree.
+ENV_NATIVE_LINUX_DEP_REPORT_JSON_FILE = "NATIVE_LINUX_DEP_REPORT_JSON_FILE"
+DEFAULT_DEP_REPORT_JSON_FILE = "rocm_dependency_report.json"
 
 # Timeouts (seconds) and verification threshold
 GPG_MKDIR_TIMEOUT_SEC = 10
@@ -251,12 +260,31 @@ class DependencyReport:
     roots: list[str] = field(default_factory=list)
     edges: dict[str, list[str]] = field(default_factory=dict)
     closure: list[str] = field(default_factory=list)
+    # Verification errors captured for the walk (empty => OK). Populated from the
+    # verifier's returned error list; surfaced flat in the JSON summary.
+    errors: list[str] = field(default_factory=list)
 
     def package_count(self) -> int:
         return len(self.closure)
 
     def edge_count(self) -> int:
         return sum(len(deps) for deps in self.edges.values())
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a flat, JSON-serializable summary of the report.
+
+        Intentionally shallow (no nested dependency tree): overall ``status``, the
+        ``roots``, closure/edge counts, and a flat list of verification ``errors``.
+        ``status`` is ``"BROKEN"`` when any error was captured, else ``"OK"``.
+        """
+        return {
+            "package_type": self.package_type,
+            "status": "BROKEN" if self.errors else "OK",
+            "roots": list(self.roots),
+            "packages": self.package_count(),
+            "edges": self.edge_count(),
+            "errors": list(self.errors),
+        }
 
     def _render_node(
         self,
@@ -1281,15 +1309,22 @@ gpgcheck=0
         report = DependencyReport(package_type=self.package_type)
         self.last_dependency_report = report
         if self.package_type == "deb":
-            return verify_debian_transitive_dependencies(
+            ok, errors = verify_debian_transitive_dependencies(
                 self.package_names, report=report
             )
-        return verify_rpm_transitive_dependencies(self.package_names, report=report)
+        else:
+            ok, errors = verify_rpm_transitive_dependencies(
+                self.package_names, report=report
+            )
+        report.errors = list(errors)
+        return ok, errors
 
     def _write_dependency_report(self, report: "DependencyReport") -> str | None:
-        """Render the dependency report to console and write it to the report file.
+        """Render the dependency report to console and write the text + JSON report files.
 
-        Returns the path written, or None if writing failed (a warning is printed).
+        Writes the human-readable text report and a flat JSON summary alongside it.
+        Returns the text report path written, or None if writing the text report failed
+        (a warning is printed). A JSON write failure is non-fatal (warning only).
         """
         rendered = report.render()
         print("\n" + rendered)
@@ -1303,6 +1338,20 @@ gpgcheck=0
             print(f" [WARN] Could not write dependency report file: {e}")
             return None
         print(f"\nDependency report written to: {report_path}")
+
+        json_path = Path(
+            _env(ENV_NATIVE_LINUX_DEP_REPORT_JSON_FILE, DEFAULT_DEP_REPORT_JSON_FILE)
+        )
+        try:
+            json_path.parent.mkdir(parents=True, exist_ok=True)
+            json_path.write_text(
+                json.dumps(report.to_dict(), indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            print(f"JSON summary written to: {json_path}")
+        except OSError as e:
+            print(f" [WARN] Could not write JSON dependency report file: {e}")
+
         return str(report_path)
 
     def run_repo_setup_and_install(self) -> bool:

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -33,7 +33,9 @@ ROCM_APT_KEYRING_FILE, ROCM_ZYPP_REPOS_DIR, ROCM_YUM_REPOS_DIR,
 ROCM_RDHC_REL_PATH (relative path from install prefix to rdhc binary).
 After install, Step 2 verifies transitive dependencies (``apt-get check`` + Depends/Pre-Depends
 closure for DEB; ``rpm -qR`` / ``rpm -q --whatprovides`` closure for RPM) unless
-``NATIVE_LINUX_SKIP_DEP_VERIFY=1``.
+``NATIVE_LINUX_SKIP_DEP_VERIFY=1``. The resolved dependency closure is rendered as an indented
+tree with summary counts (packages in closure / dependency edges / roots), printed to the
+console and written to ``NATIVE_LINUX_DEP_REPORT_FILE`` (default ``rocm_dependency_report.txt``).
 
 Prerequisites:
 - This script does NOT start Docker or a VM. You must run it inside an existing
@@ -142,6 +144,7 @@ import sys
 import traceback
 from argparse import ArgumentParser, Namespace
 from collections import deque
+from dataclasses import dataclass, field
 from pathlib import Path
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
@@ -184,6 +187,10 @@ ENV_NATIVE_LINUX_INSTALL_ROCM_VERSION = "NATIVE_LINUX_INSTALL_ROCM_VERSION"
 # Set to ``1`` to skip transitive dependency verification after install (faster / edge cases).
 ENV_NATIVE_LINUX_SKIP_DEP_VERIFY = "NATIVE_LINUX_SKIP_DEP_VERIFY"
 
+# Path of the transitive-dependency report written after verification; overridable.
+ENV_NATIVE_LINUX_DEP_REPORT_FILE = "NATIVE_LINUX_DEP_REPORT_FILE"
+DEFAULT_DEP_REPORT_FILE = "rocm_dependency_report.txt"
+
 # Timeouts (seconds) and verification threshold
 GPG_MKDIR_TIMEOUT_SEC = 10
 GPG_KEY_TIMEOUT_SEC = 60
@@ -225,9 +232,77 @@ def _normalize_test_type(test_type: str | None) -> str:
             f"Unsupported test_type {test_type!r}. Expected one of: {valid}."
         ) from e
 
+
 # Transitive dependency walk limits (avoid pathological cycles / huge trees).
 DEP_VERIFY_MAX_CLOSURE = 8000
 DEP_VERIFY_SUBPROCESS_TIMEOUT = 90
+
+
+@dataclass
+class DependencyReport:
+    """Captured transitive-dependency closure for human-readable reporting.
+
+    ``edges`` maps each visited package to the ordered list of resolved dependency
+    packages (DEB: chosen alternative/provider per Depends/Pre-Depends group; RPM:
+    providers of each non-file requirement). ``closure`` is every visited package.
+    """
+
+    package_type: str = ""
+    roots: list[str] = field(default_factory=list)
+    edges: dict[str, list[str]] = field(default_factory=dict)
+    closure: list[str] = field(default_factory=list)
+
+    def package_count(self) -> int:
+        return len(self.closure)
+
+    def edge_count(self) -> int:
+        return sum(len(deps) for deps in self.edges.values())
+
+    def _render_node(
+        self,
+        node: str,
+        lines: list[str],
+        prefix: str,
+        shown: set[str],
+        path: tuple[str, ...],
+    ) -> None:
+        if node in path:
+            lines.append(f"{prefix}{node} (cycle)")
+            return
+        if node in shown:
+            # Already expanded fully elsewhere; collapse to keep output bounded.
+            suffix = " (see above)" if self.edges.get(node) else ""
+            lines.append(f"{prefix}{node}{suffix}")
+            return
+        shown.add(node)
+        lines.append(f"{prefix}{node}")
+        for child in self.edges.get(node, []):
+            self._render_node(child, lines, prefix + "    ", shown, path + (node,))
+
+    def render(self) -> str:
+        """Render an indented dependency tree (per root) followed by summary counts."""
+        pt = self.package_type.upper() or "PKG"
+        lines: list[str] = []
+        lines.append("=" * 80)
+        lines.append(f"TRANSITIVE DEPENDENCY REPORT ({pt})")
+        lines.append("=" * 80)
+        lines.append(
+            f"Root packages: {', '.join(self.roots) if self.roots else '(none)'}"
+        )
+        lines.append("")
+        lines.append("Dependency tree:")
+        if self.roots:
+            shown: set[str] = set()
+            for root in self.roots:
+                self._render_node(root, lines, "  ", shown, ())
+        else:
+            lines.append("  (no packages walked)")
+        lines.append("")
+        lines.append(
+            f"Summary: {self.package_count()} package(s) in closure, "
+            f"{self.edge_count()} dependency edge(s), {len(self.roots)} root package(s)."
+        )
+        return "\n".join(lines)
 
 
 def _deb_pkg_name_from_dep_token(token: str) -> str | None:
@@ -385,13 +460,18 @@ def verify_debian_transitive_dependencies(
     root_packages: list[str],
     *,
     max_closure: int = DEP_VERIFY_MAX_CLOSURE,
+    report: "DependencyReport | None" = None,
 ) -> tuple[bool, list[str]]:
     """Verify dpkg database consistency and full Depends/Pre-Depends closure for roots.
 
     Confirms each AND-of-OR dependency group is satisfied (including virtual names via
-    Reverse Provides) and walks the chosen installed packages transitively.
+    Reverse Provides) and walks the chosen installed packages transitively. When
+    ``report`` is provided, its ``roots``/``edges``/``closure`` are populated for
+    human-readable reporting.
     """
     errors: list[str] = []
+    if report is not None:
+        report.roots = list(root_packages)
     chk = subprocess.run(
         ["apt-get", "check"],
         capture_output=True,
@@ -411,6 +491,9 @@ def verify_debian_transitive_dependencies(
         if pkg in expanded:
             continue
         expanded.add(pkg)
+        if report is not None:
+            report.closure.append(pkg)
+            report.edges.setdefault(pkg, [])
         steps += 1
         if steps > max_closure:
             errors.append(
@@ -435,6 +518,8 @@ def verify_debian_transitive_dependencies(
                         "none of the alternatives are installed (including providers)"
                     )
                     return False, errors
+                if report is not None and rep not in report.edges.get(pkg, []):
+                    report.edges.setdefault(pkg, []).append(rep)
                 if rep not in expanded:
                     queue.append(rep)
     return True, []
@@ -500,15 +585,19 @@ def verify_rpm_transitive_dependencies(
     root_packages: list[str],
     *,
     max_closure: int = DEP_VERIFY_MAX_CLOSURE,
+    report: "DependencyReport | None" = None,
 ) -> tuple[bool, list[str]]:
     """Walk ``rpm -qR`` requires for installed roots; each require must be provided by some RPM.
 
     Uses ``rpm -q --whatprovides`` so file sonames and virtual provides resolve to installed
-    packages; then recurses on provider package names for multi-level closure.
+    packages; then recurses on provider package names for multi-level closure. When
+    ``report`` is provided, its ``roots``/``edges``/``closure`` are populated (keyed by
+    package name) for human-readable reporting.
     """
     errors: list[str] = []
     expanded: set[str] = set()
     queue: deque[str] = deque()
+    root_names: list[str] = []
     for root in root_packages:
         rq = subprocess.run(
             ["rpm", "-q", root],
@@ -524,6 +613,11 @@ def verify_rpm_transitive_dependencies(
         first = (rq.stdout or "").strip().split("\n")[0].strip()
         if first:
             queue.append(first)
+            root_name = _rpm_name_from_installed_nevra(first)
+            if root_name not in root_names:
+                root_names.append(root_name)
+    if report is not None:
+        report.roots = root_names
 
     steps = 0
     while queue:
@@ -532,6 +626,9 @@ def verify_rpm_transitive_dependencies(
         if name in expanded:
             continue
         expanded.add(name)
+        if report is not None:
+            report.closure.append(name)
+            report.edges.setdefault(name, [])
         steps += 1
         if steps > max_closure:
             errors.append(
@@ -548,6 +645,12 @@ def verify_rpm_transitive_dependencies(
                 return False, errors
             for prov in providers:
                 pn = _rpm_name_from_installed_nevra(prov)
+                if (
+                    report is not None
+                    and pn != name
+                    and pn not in report.edges.get(name, [])
+                ):
+                    report.edges.setdefault(name, []).append(pn)
                 if pn not in expanded:
                     queue.append(prov)
     return True, []
@@ -733,6 +836,8 @@ class NativeLinuxPackageInstallTest:
             self.gfx_arch_list[0] if self.gfx_arch_list else None
         )
         self.gpg_key_url = gpg_key_url
+        # Populated by _verify_transitive_dependencies_installed() on a non-skipped run.
+        self.last_dependency_report: "DependencyReport | None" = None
 
         # Metapackage install targets (four combinations of optional inputs):
         #   gfx_arch + rocm_version -> amdrocm{major.minor}-{arch} per arch
@@ -1168,12 +1273,37 @@ gpgcheck=0
         """Verify full dependency closure for ``self.package_names`` (post-install).
 
         Skipped when ``NATIVE_LINUX_SKIP_DEP_VERIFY`` is ``1``/``true``/``yes``.
+        On a non-skipped run the captured closure is stored on
+        ``self.last_dependency_report`` for reporting.
         """
         if _env(ENV_NATIVE_LINUX_SKIP_DEP_VERIFY, "").lower() in ("1", "true", "yes"):
             return True, []
+        report = DependencyReport(package_type=self.package_type)
+        self.last_dependency_report = report
         if self.package_type == "deb":
-            return verify_debian_transitive_dependencies(self.package_names)
-        return verify_rpm_transitive_dependencies(self.package_names)
+            return verify_debian_transitive_dependencies(
+                self.package_names, report=report
+            )
+        return verify_rpm_transitive_dependencies(self.package_names, report=report)
+
+    def _write_dependency_report(self, report: "DependencyReport") -> str | None:
+        """Render the dependency report to console and write it to the report file.
+
+        Returns the path written, or None if writing failed (a warning is printed).
+        """
+        rendered = report.render()
+        print("\n" + rendered)
+        report_path = Path(
+            _env(ENV_NATIVE_LINUX_DEP_REPORT_FILE, DEFAULT_DEP_REPORT_FILE)
+        )
+        try:
+            report_path.parent.mkdir(parents=True, exist_ok=True)
+            report_path.write_text(rendered + "\n", encoding="utf-8")
+        except OSError as e:
+            print(f" [WARN] Could not write dependency report file: {e}")
+            return None
+        print(f"\nDependency report written to: {report_path}")
+        return str(report_path)
 
     def run_repo_setup_and_install(self) -> bool:
         """Step 1: Repo setup and install. Run for both sanity (basic) and full test.
@@ -1265,9 +1395,13 @@ gpgcheck=0
             if not ok_dep:
                 for e in dep_errs:
                     print(f" [FAIL] {e}", file=sys.stderr)
+                if self.last_dependency_report is not None:
+                    self._write_dependency_report(self.last_dependency_report)
                 print("\n[FAIL] Transitive dependency verification FAILED")
                 return False
             print(" [PASS] Transitive dependency verification passed")
+            if self.last_dependency_report is not None:
+                self._write_dependency_report(self.last_dependency_report)
 
         # Check installed packages
         print("\nChecking installed packages:")

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -31,6 +31,9 @@ Path and repo name are overridable via environment variables: ROCM_REPO_NAME (re
 APT list, Zypper/Yum repo file and section), ROCM_APT_KEYRING_DIR, ROCM_APT_SOURCES_LIST,
 ROCM_APT_KEYRING_FILE, ROCM_ZYPP_REPOS_DIR, ROCM_YUM_REPOS_DIR,
 ROCM_RDHC_REL_PATH (relative path from install prefix to rdhc binary).
+After install, Step 2 verifies transitive dependencies (``apt-get check`` + Depends/Pre-Depends
+closure for DEB; ``rpm -qR`` / ``rpm -q --whatprovides`` closure for RPM) unless
+``NATIVE_LINUX_SKIP_DEP_VERIFY=1``.
 
 Prerequisites:
 - This script does NOT start Docker or a VM. You must run it inside an existing
@@ -138,6 +141,7 @@ import subprocess
 import sys
 import traceback
 from argparse import ArgumentParser, Namespace
+from collections import deque
 from pathlib import Path
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
@@ -176,6 +180,9 @@ RDHC_REL_PATH = _env("ROCM_RDHC_REL_PATH", "libexec/rocm-core/rdhc.py")
 
 # Pytest/CI only: becomes ``--rocm-version``.
 ENV_NATIVE_LINUX_INSTALL_ROCM_VERSION = "NATIVE_LINUX_INSTALL_ROCM_VERSION"
+
+# Set to ``1`` to skip transitive dependency verification after install (faster / edge cases).
+ENV_NATIVE_LINUX_SKIP_DEP_VERIFY = "NATIVE_LINUX_SKIP_DEP_VERIFY"
 
 # Timeouts (seconds) and verification threshold
 GPG_MKDIR_TIMEOUT_SEC = 10
@@ -217,6 +224,333 @@ def _normalize_test_type(test_type: str | None) -> str:
         raise ValueError(
             f"Unsupported test_type {test_type!r}. Expected one of: {valid}."
         ) from e
+
+# Transitive dependency walk limits (avoid pathological cycles / huge trees).
+DEP_VERIFY_MAX_CLOSURE = 8000
+DEP_VERIFY_SUBPROCESS_TIMEOUT = 90
+
+
+def _deb_pkg_name_from_dep_token(token: str) -> str | None:
+    """Extract a binary package name from one Depends/Pre-Depends token, or None if not applicable."""
+    t = token.strip()
+    if not t or t.startswith("/"):
+        return None
+    if t.startswith("${") and t.endswith("}"):
+        return None
+    if (t.startswith('"') and t.endswith('"')) or (
+        t.startswith("'") and t.endswith("'")
+    ):
+        t = t[1:-1].strip()
+    if "(" in t:
+        t = t[: t.index("(")].strip()
+    if not t:
+        return None
+    if ":" in t:
+        base, _, qual = t.rpartition(":")
+        if qual in (
+            "amd64",
+            "arm64",
+            "i386",
+            "all",
+            "ppc64el",
+            "riscv64",
+            "s390x",
+        ) or (len(qual) <= 8 and "_" in qual):
+            t = base or t
+    return t if t else None
+
+
+def _parse_debian_dep_field(field_value: str) -> list[frozenset[str]]:
+    """Split a Depends / Pre-Depends field into AND-of-OR groups (Debian policy grammar).
+
+    Comma separates AND; ``|`` separates OR within one AND term. Parentheses group
+    nested alternatives. Returns a list of frozensets; each frozenset is one OR-group
+    (at least one package must be installed).
+    """
+    field_value = field_value.strip()
+    if not field_value:
+        return []
+
+    def split_top_level(s: str, sep: str) -> list[str]:
+        parts: list[str] = []
+        depth = 0
+        cur: list[str] = []
+        for ch in s:
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+            if ch == sep and depth == 0:
+                parts.append("".join(cur).strip())
+                cur = []
+                continue
+            cur.append(ch)
+        parts.append("".join(cur).strip())
+        return [p for p in parts if p]
+
+    and_groups: list[frozenset[str]] = []
+    for and_segment in split_top_level(field_value, ","):
+        or_names: set[str] = set()
+        for or_segment in split_top_level(and_segment, "|"):
+            inner = or_segment.strip()
+            if inner.startswith("(") and inner.endswith(")"):
+                inner = inner[1:-1].strip()
+            name = _deb_pkg_name_from_dep_token(inner)
+            if name:
+                or_names.add(name)
+        if or_names:
+            and_groups.append(frozenset(or_names))
+    return and_groups
+
+
+def _apt_cache_show_first_stanza(pkg: str) -> dict[str, str]:
+    """First stanza of ``apt-cache show`` as field name (lower) -> value (merged)."""
+    r = subprocess.run(
+        ["apt-cache", "show", pkg],
+        capture_output=True,
+        text=True,
+        timeout=DEP_VERIFY_SUBPROCESS_TIMEOUT,
+    )
+    if r.returncode != 0 or not (r.stdout or "").strip():
+        return {}
+    lines: list[str] = []
+    for line in r.stdout.split("\n"):
+        if line.strip() == "":
+            break
+        lines.append(line)
+    fields: dict[str, list[str]] = {}
+    cur_key: str | None = None
+    for line in lines:
+        if line.startswith(" ") and cur_key is not None:
+            fields[cur_key][-1] += line.strip()
+            continue
+        if ":" in line:
+            k, _, v = line.partition(":")
+            cur_key = k.strip().lower()
+            fields.setdefault(cur_key, []).append(v.strip())
+    return {k: " ".join(v) for k, v in fields.items()}
+
+
+def _deb_is_pkg_installed(name: str) -> bool:
+    r = subprocess.run(
+        ["dpkg-query", "-W", "-f=${db:Status-Status}", name],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if r.returncode != 0:
+        return False
+    return (r.stdout or "").strip() == "installed"
+
+
+def _deb_showpkg_reverse_provides(name: str) -> list[str]:
+    """Binary package names listed under Reverse Provides for a (possibly virtual) name."""
+    r = subprocess.run(
+        ["apt-cache", "showpkg", name],
+        capture_output=True,
+        text=True,
+        timeout=DEP_VERIFY_SUBPROCESS_TIMEOUT,
+    )
+    if r.returncode != 0:
+        return []
+    lines = r.stdout.split("\n")
+    in_section = False
+    providers: list[str] = []
+    for line in lines:
+        ls = line.strip()
+        if ls == "Reverse Provides:":
+            in_section = True
+            continue
+        if in_section:
+            if line and not line.startswith((" ", "\t")):
+                break
+            parts = line.split()
+            if parts and parts[0][0].isalnum():
+                providers.append(parts[0])
+    return providers
+
+
+def _deb_pick_installed_rep(or_group: frozenset[str]) -> str | None:
+    """Return one installed concrete package satisfying this OR-group (direct or provider)."""
+    for name in or_group:
+        if _deb_is_pkg_installed(name):
+            return name
+        for prov in _deb_showpkg_reverse_provides(name):
+            if _deb_is_pkg_installed(prov):
+                return prov
+    return None
+
+
+def verify_debian_transitive_dependencies(
+    root_packages: list[str],
+    *,
+    max_closure: int = DEP_VERIFY_MAX_CLOSURE,
+) -> tuple[bool, list[str]]:
+    """Verify dpkg database consistency and full Depends/Pre-Depends closure for roots.
+
+    Confirms each AND-of-OR dependency group is satisfied (including virtual names via
+    Reverse Provides) and walks the chosen installed packages transitively.
+    """
+    errors: list[str] = []
+    chk = subprocess.run(
+        ["apt-get", "check"],
+        capture_output=True,
+        text=True,
+        timeout=DEP_VERIFY_SUBPROCESS_TIMEOUT,
+    )
+    if chk.returncode != 0:
+        msg = (chk.stderr or chk.stdout or "").strip() or "(no output)"
+        errors.append(f"apt-get check failed (exit {chk.returncode}): {msg}")
+        return False, errors
+
+    expanded: set[str] = set()
+    queue: deque[str] = deque(root_packages)
+    steps = 0
+    while queue:
+        pkg = queue.popleft()
+        if pkg in expanded:
+            continue
+        expanded.add(pkg)
+        steps += 1
+        if steps > max_closure:
+            errors.append(
+                f"dependency walk exceeded max steps ({max_closure}); possible cycle or huge tree"
+            )
+            return False, errors
+        if not _deb_is_pkg_installed(pkg):
+            errors.append(f"package not installed (missing from dpkg): {pkg}")
+            return False, errors
+
+        stanza = _apt_cache_show_first_stanza(pkg)
+        for field_key in ("depends", "pre-depends"):
+            raw = stanza.get(field_key)
+            if not raw:
+                continue
+            for or_group in _parse_debian_dep_field(raw):
+                rep = _deb_pick_installed_rep(or_group)
+                if rep is None:
+                    alts = " | ".join(sorted(or_group))
+                    errors.append(
+                        f"{pkg}: unsatisfied dependency group ({alts}) — "
+                        "none of the alternatives are installed (including providers)"
+                    )
+                    return False, errors
+                if rep not in expanded:
+                    queue.append(rep)
+    return True, []
+
+
+def _rpm_require_token_is_file_or_rpmlib(req: str) -> bool:
+    r = req.strip()
+    if not r:
+        return True
+    if r.startswith("/"):
+        return True
+    if r.startswith("rpmlib(") or r.startswith("config("):
+        return True
+    return False
+
+
+def _rpm_requires_tokens(nevra: str) -> list[str]:
+    r = subprocess.run(
+        ["rpm", "-qR", nevra],
+        capture_output=True,
+        text=True,
+        timeout=DEP_VERIFY_SUBPROCESS_TIMEOUT,
+    )
+    if r.returncode != 0:
+        return []
+    return [ln.strip() for ln in (r.stdout or "").splitlines() if ln.strip()]
+
+
+def _rpm_whatprovides_nevras(req: str) -> list[str]:
+    r = subprocess.run(
+        ["rpm", "-q", "--whatprovides", req],
+        capture_output=True,
+        text=True,
+        timeout=DEP_VERIFY_SUBPROCESS_TIMEOUT,
+    )
+    if r.returncode != 0:
+        return []
+    out: list[str] = []
+    for line in (r.stdout or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        low = line.lower()
+        if "no package provides" in low or "no package matches" in low:
+            continue
+        out.append(line)
+    return out
+
+
+def _rpm_name_from_installed_nevra(nevra: str) -> str:
+    pr = subprocess.run(
+        ["rpm", "-q", "--qf", "%{NAME}", nevra],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if pr.returncode == 0 and (pr.stdout or "").strip():
+        return (pr.stdout or "").strip()
+    return nevra.split("-")[0]
+
+
+def verify_rpm_transitive_dependencies(
+    root_packages: list[str],
+    *,
+    max_closure: int = DEP_VERIFY_MAX_CLOSURE,
+) -> tuple[bool, list[str]]:
+    """Walk ``rpm -qR`` requires for installed roots; each require must be provided by some RPM.
+
+    Uses ``rpm -q --whatprovides`` so file sonames and virtual provides resolve to installed
+    packages; then recurses on provider package names for multi-level closure.
+    """
+    errors: list[str] = []
+    expanded: set[str] = set()
+    queue: deque[str] = deque()
+    for root in root_packages:
+        rq = subprocess.run(
+            ["rpm", "-q", root],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if rq.returncode != 0:
+            errors.append(
+                f"root package not installed: {root}: {(rq.stderr or '').strip()}"
+            )
+            return False, errors
+        first = (rq.stdout or "").strip().split("\n")[0].strip()
+        if first:
+            queue.append(first)
+
+    steps = 0
+    while queue:
+        nevra = queue.popleft()
+        name = _rpm_name_from_installed_nevra(nevra)
+        if name in expanded:
+            continue
+        expanded.add(name)
+        steps += 1
+        if steps > max_closure:
+            errors.append(
+                f"RPM dependency walk exceeded max steps ({max_closure}); possible cycle or huge tree"
+            )
+            return False, errors
+
+        for req in _rpm_requires_tokens(nevra):
+            if _rpm_require_token_is_file_or_rpmlib(req):
+                continue
+            providers = _rpm_whatprovides_nevras(req)
+            if not providers:
+                errors.append(f"{nevra}: no installed package provides {req!r}")
+                return False, errors
+            for prov in providers:
+                pn = _rpm_name_from_installed_nevra(prov)
+                if pn not in expanded:
+                    queue.append(prov)
+    return True, []
 
 
 def run_simulate_install_test(pkg_type: str, packages_dir: str) -> bool:
@@ -830,6 +1164,17 @@ gpgcheck=0
             print(f"\n[FAIL] Error during installation: {e}")
             return False
 
+    def _verify_transitive_dependencies_installed(self) -> tuple[bool, list[str]]:
+        """Verify full dependency closure for ``self.package_names`` (post-install).
+
+        Skipped when ``NATIVE_LINUX_SKIP_DEP_VERIFY`` is ``1``/``true``/``yes``.
+        """
+        if _env(ENV_NATIVE_LINUX_SKIP_DEP_VERIFY, "").lower() in ("1", "true", "yes"):
+            return True, []
+        if self.package_type == "deb":
+            return verify_debian_transitive_dependencies(self.package_names)
+        return verify_rpm_transitive_dependencies(self.package_names)
+
     def run_repo_setup_and_install(self) -> bool:
         """Step 1: Repo setup and install. Run for both sanity (basic) and full test.
 
@@ -905,6 +1250,24 @@ gpgcheck=0
                 print(f" [WARN] {component} (not found)")
 
         print(f"\nComponents found: {found_count}/{len(key_components)}")
+
+        skip_dep = _env(ENV_NATIVE_LINUX_SKIP_DEP_VERIFY, "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        if not skip_dep:
+            print(
+                "\nVerifying transitive dependencies "
+                "(Depends / Pre-Depends for DEB; RPM Requires + providers)..."
+            )
+            ok_dep, dep_errs = self._verify_transitive_dependencies_installed()
+            if not ok_dep:
+                for e in dep_errs:
+                    print(f" [FAIL] {e}", file=sys.stderr)
+                print("\n[FAIL] Transitive dependency verification FAILED")
+                return False
+            print(" [PASS] Transitive dependency verification passed")
 
         # Check installed packages
         print("\nChecking installed packages:")

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -978,7 +978,24 @@ class RunTestsTestTypeTest(unittest.TestCase):
 
 
 class RunBasicVerificationTest(unittest.TestCase):
-    """Tests for NativeLinuxPackageInstallTest.run_basic_verification()."""
+    """Tests for NativeLinuxPackageInstallTest.run_basic_verification().
+
+    run_basic_verification() now invokes the post-install transitive dependency
+    check (Step 2). These tests target component/rocminfo verification only, so the
+    dependency walk is disabled via NATIVE_LINUX_SKIP_DEP_VERIFY to avoid consuming
+    the mocked subprocess side effects.
+    """
+
+    def setUp(self):
+        self._dep_env = patch.dict(
+            os.environ,
+            {native_linux_package_install_test.ENV_NATIVE_LINUX_SKIP_DEP_VERIFY: "1"},
+            clear=False,
+        )
+        self._dep_env.start()
+
+    def tearDown(self):
+        self._dep_env.stop()
 
     def test_returns_false_when_install_prefix_does_not_exist(self):
         # Test that run_basic_verification returns False when install_prefix path does not exist.
@@ -1554,6 +1571,376 @@ class RunStreamingTest(unittest.TestCase):
         with self.assertRaises(sp.TimeoutExpired):
             native_linux_package_install_test._run_streaming(["slow-cmd"], 30)
         mock_proc.kill.assert_called_once()
+
+
+class DebPkgNameFromDepTokenTest(unittest.TestCase):
+    """Tests for _deb_pkg_name_from_dep_token()."""
+
+    def test_plain_name_returned_as_is(self):
+        # Test that a plain package name is returned unchanged.
+        self.assertEqual(
+            native_linux_package_install_test._deb_pkg_name_from_dep_token("libfoo"),
+            "libfoo",
+        )
+
+    def test_strips_version_constraint(self):
+        # Test that a trailing version constraint in parentheses is stripped.
+        self.assertEqual(
+            native_linux_package_install_test._deb_pkg_name_from_dep_token(
+                "libfoo (>= 1.2.3)"
+            ),
+            "libfoo",
+        )
+
+    def test_strips_known_arch_qualifier(self):
+        # Test that a known architecture qualifier (e.g. :amd64) is stripped.
+        self.assertEqual(
+            native_linux_package_install_test._deb_pkg_name_from_dep_token(
+                "libfoo:amd64"
+            ),
+            "libfoo",
+        )
+
+    def test_strips_surrounding_quotes(self):
+        # Test that surrounding single or double quotes are stripped.
+        self.assertEqual(
+            native_linux_package_install_test._deb_pkg_name_from_dep_token('"libfoo"'),
+            "libfoo",
+        )
+
+    def test_substvar_returns_none(self):
+        # Test that a dpkg substvar token (e.g. ${shlibs:Depends}) returns None.
+        self.assertIsNone(
+            native_linux_package_install_test._deb_pkg_name_from_dep_token(
+                "${shlibs:Depends}"
+            )
+        )
+
+    def test_file_path_returns_none(self):
+        # Test that a token starting with '/' (file path) returns None.
+        self.assertIsNone(
+            native_linux_package_install_test._deb_pkg_name_from_dep_token(
+                "/usr/bin/foo"
+            )
+        )
+
+    def test_empty_token_returns_none(self):
+        # Test that an empty or whitespace-only token returns None.
+        self.assertIsNone(
+            native_linux_package_install_test._deb_pkg_name_from_dep_token("   ")
+        )
+
+    def test_unknown_qualifier_kept(self):
+        # Test that an unknown qualifier (e.g. :any) is not treated as an arch and is kept.
+        self.assertEqual(
+            native_linux_package_install_test._deb_pkg_name_from_dep_token(
+                "libfoo:any"
+            ),
+            "libfoo:any",
+        )
+
+
+class ParseDebianDepFieldTest(unittest.TestCase):
+    """Tests for _parse_debian_dep_field()."""
+
+    def test_empty_field_returns_empty_list(self):
+        # Test that an empty Depends field parses to an empty list of groups.
+        self.assertEqual(
+            native_linux_package_install_test._parse_debian_dep_field(""), []
+        )
+
+    def test_comma_separates_and_groups(self):
+        # Test that commas split into separate AND groups (each a single-name frozenset).
+        result = native_linux_package_install_test._parse_debian_dep_field(
+            "liba, libb (>= 1.0), libc"
+        )
+        self.assertEqual(
+            result,
+            [frozenset({"liba"}), frozenset({"libb"}), frozenset({"libc"})],
+        )
+
+    def test_pipe_creates_or_group(self):
+        # Test that '|' within one AND term produces a single OR-group frozenset.
+        result = native_linux_package_install_test._parse_debian_dep_field(
+            "liba | libb"
+        )
+        self.assertEqual(result, [frozenset({"liba", "libb"})])
+
+    def test_mixed_and_or(self):
+        # Test a mixed expression: comma-separated AND groups, one containing an OR alternative.
+        result = native_linux_package_install_test._parse_debian_dep_field(
+            "liba, libb | libc (>= 2.0)"
+        )
+        self.assertEqual(
+            result,
+            [frozenset({"liba"}), frozenset({"libb", "libc"})],
+        )
+
+    def test_substvars_dropped(self):
+        # Test that substvar-only OR-groups are dropped (no resolvable package names).
+        result = native_linux_package_install_test._parse_debian_dep_field(
+            "liba, ${shlibs:Depends}"
+        )
+        self.assertEqual(result, [frozenset({"liba"})])
+
+
+class AptCacheShowFirstStanzaTest(unittest.TestCase):
+    """Tests for _apt_cache_show_first_stanza()."""
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_parses_first_stanza_and_merges_continuations(self, mock_run):
+        # Test that only the first stanza is parsed and folded continuation lines are merged.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "Package: libfoo\n"
+                "Depends: liba,\n"
+                " libb\n"
+                "\n"
+                "Package: other\n"
+                "Depends: zzz\n"
+            ),
+        )
+        stanza = native_linux_package_install_test._apt_cache_show_first_stanza(
+            "libfoo"
+        )
+        self.assertEqual(stanza.get("package"), "libfoo")
+        # Folded continuation lines are concatenated verbatim (no inserted space);
+        # the dependency-field parser later splits on commas regardless of spacing.
+        self.assertEqual(stanza.get("depends"), "liba,libb")
+        self.assertNotIn("zzz", stanza.get("depends", ""))
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_returns_empty_when_command_fails(self, mock_run):
+        # Test that a non-zero apt-cache return code yields an empty dict.
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        self.assertEqual(
+            native_linux_package_install_test._apt_cache_show_first_stanza("libfoo"),
+            {},
+        )
+
+
+class VerifyDebianTransitiveDependenciesTest(unittest.TestCase):
+    """Tests for verify_debian_transitive_dependencies()."""
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_apt_get_check_failure_returns_false(self, mock_run):
+        # Test that a failing 'apt-get check' short-circuits to a failure result.
+        mock_run.return_value = MagicMock(
+            returncode=100, stdout="", stderr="broken deps"
+        )
+        ok, errs = native_linux_package_install_test.verify_debian_transitive_dependencies(
+            ["amdrocm-gfx94x"]
+        )
+        self.assertFalse(ok)
+        self.assertTrue(any("apt-get check failed" in e for e in errs))
+
+    @patch("native_linux_package_install_test._apt_cache_show_first_stanza")
+    @patch("native_linux_package_install_test._deb_is_pkg_installed")
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_happy_path_no_dependencies(self, mock_run, mock_installed, mock_stanza):
+        # Test that an installed root with no Depends/Pre-Depends passes.
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        mock_installed.return_value = True
+        mock_stanza.return_value = {}  # no depends fields
+        ok, errs = native_linux_package_install_test.verify_debian_transitive_dependencies(
+            ["amdrocm-gfx94x"]
+        )
+        self.assertTrue(ok)
+        self.assertEqual(errs, [])
+
+    @patch("native_linux_package_install_test._deb_is_pkg_installed")
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_root_not_installed_returns_false(self, mock_run, mock_installed):
+        # Test that a root package missing from dpkg yields a failure.
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        mock_installed.return_value = False
+        ok, errs = native_linux_package_install_test.verify_debian_transitive_dependencies(
+            ["amdrocm-gfx94x"]
+        )
+        self.assertFalse(ok)
+        self.assertTrue(any("not installed" in e for e in errs))
+
+    @patch("native_linux_package_install_test._deb_pick_installed_rep")
+    @patch("native_linux_package_install_test._apt_cache_show_first_stanza")
+    @patch("native_linux_package_install_test._deb_is_pkg_installed")
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_unsatisfied_dependency_group_returns_false(
+        self, mock_run, mock_installed, mock_stanza, mock_pick
+    ):
+        # Test that an unsatisfied Depends OR-group (no installed alternative) fails.
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        mock_installed.return_value = True
+        mock_stanza.return_value = {"depends": "libmissing"}
+        mock_pick.return_value = None
+        ok, errs = native_linux_package_install_test.verify_debian_transitive_dependencies(
+            ["amdrocm-gfx94x"]
+        )
+        self.assertFalse(ok)
+        self.assertTrue(any("unsatisfied dependency group" in e for e in errs))
+
+    @patch("native_linux_package_install_test._deb_is_pkg_installed")
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_max_closure_exceeded_returns_false(self, mock_run, mock_installed):
+        # Test that exceeding max_closure aborts the walk with an error.
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        mock_installed.return_value = True
+        ok, errs = native_linux_package_install_test.verify_debian_transitive_dependencies(
+            ["amdrocm-gfx94x"], max_closure=0
+        )
+        self.assertFalse(ok)
+        self.assertTrue(any("exceeded max steps" in e for e in errs))
+
+
+class RpmRequireTokenClassificationTest(unittest.TestCase):
+    """Tests for _rpm_require_token_is_file_or_rpmlib()."""
+
+    def test_file_path_is_skipped(self):
+        # Test that an absolute file-path requirement is classified as skippable.
+        self.assertTrue(
+            native_linux_package_install_test._rpm_require_token_is_file_or_rpmlib(
+                "/usr/lib/libc.so.6"
+            )
+        )
+
+    def test_rpmlib_is_skipped(self):
+        # Test that an rpmlib(...) requirement is classified as skippable.
+        self.assertTrue(
+            native_linux_package_install_test._rpm_require_token_is_file_or_rpmlib(
+                "rpmlib(CompressedFileNames)"
+            )
+        )
+
+    def test_config_is_skipped(self):
+        # Test that a config(...) requirement is classified as skippable.
+        self.assertTrue(
+            native_linux_package_install_test._rpm_require_token_is_file_or_rpmlib(
+                "config(foo)"
+            )
+        )
+
+    def test_empty_is_skipped(self):
+        # Test that an empty requirement token is classified as skippable.
+        self.assertTrue(
+            native_linux_package_install_test._rpm_require_token_is_file_or_rpmlib("")
+        )
+
+    def test_normal_name_not_skipped(self):
+        # Test that a normal capability/package name is not skippable.
+        self.assertFalse(
+            native_linux_package_install_test._rpm_require_token_is_file_or_rpmlib(
+                "libstdc++"
+            )
+        )
+
+
+class VerifyRpmTransitiveDependenciesTest(unittest.TestCase):
+    """Tests for verify_rpm_transitive_dependencies()."""
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_root_not_installed_returns_false(self, mock_run):
+        # Test that a root package not installed (rpm -q non-zero) yields a failure.
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="package amdrocm-gfx94x is not installed"
+        )
+        ok, errs = native_linux_package_install_test.verify_rpm_transitive_dependencies(
+            ["amdrocm-gfx94x"]
+        )
+        self.assertFalse(ok)
+        self.assertTrue(any("root package not installed" in e for e in errs))
+
+    @patch("native_linux_package_install_test._rpm_requires_tokens")
+    @patch("native_linux_package_install_test._rpm_name_from_installed_nevra")
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_happy_path_no_requires(self, mock_run, mock_name, mock_requires):
+        # Test that an installed root with no (non-file) requires passes.
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="amdrocm-gfx94x-1.0-1.x86_64\n", stderr=""
+        )
+        mock_name.return_value = "amdrocm-gfx94x"
+        mock_requires.return_value = []
+        ok, errs = native_linux_package_install_test.verify_rpm_transitive_dependencies(
+            ["amdrocm-gfx94x"]
+        )
+        self.assertTrue(ok)
+        self.assertEqual(errs, [])
+
+    @patch("native_linux_package_install_test._rpm_whatprovides_nevras")
+    @patch("native_linux_package_install_test._rpm_requires_tokens")
+    @patch("native_linux_package_install_test._rpm_name_from_installed_nevra")
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_unprovided_requirement_returns_false(
+        self, mock_run, mock_name, mock_requires, mock_provides
+    ):
+        # Test that a requirement with no providing package yields a failure.
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="amdrocm-gfx94x-1.0-1.x86_64\n", stderr=""
+        )
+        mock_name.return_value = "amdrocm-gfx94x"
+        mock_requires.return_value = ["libmissing.so.1"]
+        mock_provides.return_value = []
+        ok, errs = native_linux_package_install_test.verify_rpm_transitive_dependencies(
+            ["amdrocm-gfx94x"]
+        )
+        self.assertFalse(ok)
+        self.assertTrue(any("no installed package provides" in e for e in errs))
+
+
+class VerifyTransitiveDependenciesInstalledTest(unittest.TestCase):
+    """Tests for NativeLinuxPackageInstallTest._verify_transitive_dependencies_installed()."""
+
+    def test_skipped_when_env_set(self):
+        # Test that the skip env var short-circuits to success without invoking verifiers.
+        t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="ubuntu2404",
+        )
+        with patch.dict(
+            os.environ,
+            {native_linux_package_install_test.ENV_NATIVE_LINUX_SKIP_DEP_VERIFY: "1"},
+            clear=False,
+        ):
+            ok, errs = t._verify_transitive_dependencies_installed()
+        self.assertTrue(ok)
+        self.assertEqual(errs, [])
+
+    @patch(
+        "native_linux_package_install_test.verify_debian_transitive_dependencies",
+        return_value=(True, []),
+    )
+    def test_routes_to_debian_for_deb(self, mock_deb):
+        # Test that a deb profile routes to the Debian verifier with the package names.
+        t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="ubuntu2404",
+        )
+        with patch.dict(
+            os.environ,
+            {native_linux_package_install_test.ENV_NATIVE_LINUX_SKIP_DEP_VERIFY: ""},
+            clear=False,
+        ):
+            ok, _ = t._verify_transitive_dependencies_installed()
+        self.assertTrue(ok)
+        mock_deb.assert_called_once_with(t.package_names)
+
+    @patch(
+        "native_linux_package_install_test.verify_rpm_transitive_dependencies",
+        return_value=(True, []),
+    )
+    def test_routes_to_rpm_for_rpm(self, mock_rpm):
+        # Test that an rpm profile routes to the RPM verifier with the package names.
+        t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="rhel8",
+        )
+        with patch.dict(
+            os.environ,
+            {native_linux_package_install_test.ENV_NATIVE_LINUX_SKIP_DEP_VERIFY: ""},
+            clear=False,
+        ):
+            ok, _ = t._verify_transitive_dependencies_installed()
+        self.assertTrue(ok)
+        mock_rpm.assert_called_once_with(t.package_names)
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -7,6 +7,7 @@
 
 import contextlib
 import importlib.util
+import json
 import os
 import sys
 import tempfile
@@ -875,6 +876,7 @@ class RunTestsTestTypeTest(unittest.TestCase):
             release_type="dev",
             install_prefix="/opt/rocm/core",
             gfx_arch=["gfx94x"],
+            rocm_version=None,
             gpg_key_url=None,
             packages_dir=None,
             pkg_type=None,
@@ -1951,6 +1953,116 @@ class VerifyTransitiveDependenciesInstalledTest(unittest.TestCase):
             ok, _ = t._verify_transitive_dependencies_installed()
         self.assertTrue(ok)
         mock_rpm.assert_called_once_with(t.package_names, report=ANY)
+
+
+class DependencyReportToDictTest(unittest.TestCase):
+    """Tests for DependencyReport.to_dict() (flat JSON summary)."""
+
+    def test_ok_status_and_counts(self):
+        # Test that a clean report serializes status OK with flat counts and empty errors.
+        report = native_linux_package_install_test.DependencyReport(
+            package_type="deb",
+            roots=["amdrocm-gfx94x"],
+            closure=["amdrocm-gfx94x", "rocm-core"],
+            edges={"amdrocm-gfx94x": ["rocm-core"], "rocm-core": []},
+        )
+        self.assertEqual(
+            report.to_dict(),
+            {
+                "package_type": "deb",
+                "status": "OK",
+                "roots": ["amdrocm-gfx94x"],
+                "packages": 2,
+                "edges": 1,
+                "errors": [],
+            },
+        )
+
+    def test_broken_status_when_errors_present(self):
+        # Test that captured errors flip status to BROKEN and are surfaced flat.
+        report = native_linux_package_install_test.DependencyReport(
+            package_type="rpm",
+            roots=["amdrocm-gfx94x"],
+            closure=["amdrocm-gfx94x"],
+            errors=["no installed package provides 'libfoo'"],
+        )
+        d = report.to_dict()
+        self.assertEqual(d["status"], "BROKEN")
+        self.assertEqual(d["errors"], ["no installed package provides 'libfoo'"])
+
+    def test_to_dict_is_json_serializable(self):
+        # Test that the summary round-trips through json without error.
+        report = native_linux_package_install_test.DependencyReport(
+            package_type="deb",
+            roots=["amdrocm-gfx94x"],
+            closure=["amdrocm-gfx94x"],
+            edges={"amdrocm-gfx94x": []},
+        )
+        encoded = json.dumps(report.to_dict())
+        self.assertEqual(json.loads(encoded)["status"], "OK")
+
+
+class WriteDependencyReportTest(unittest.TestCase):
+    """Tests for NativeLinuxPackageInstallTest._write_dependency_report()."""
+
+    def _make_tester(self):
+        return native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="ubuntu2404",
+        )
+
+    def test_writes_text_and_json_reports(self):
+        # Test that both the text and JSON files are written with matching flat data.
+        report = native_linux_package_install_test.DependencyReport(
+            package_type="deb",
+            roots=["amdrocm-gfx94x"],
+            closure=["amdrocm-gfx94x", "rocm-core"],
+            edges={"amdrocm-gfx94x": ["rocm-core"], "rocm-core": []},
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            txt_path = Path(tmp) / "report.txt"
+            json_path = Path(tmp) / "report.json"
+            env = {
+                native_linux_package_install_test.ENV_NATIVE_LINUX_DEP_REPORT_FILE: str(
+                    txt_path
+                ),
+                native_linux_package_install_test.ENV_NATIVE_LINUX_DEP_REPORT_JSON_FILE: str(
+                    json_path
+                ),
+            }
+            with patch.dict(os.environ, env, clear=False), _suppress_script_output():
+                returned = self._make_tester()._write_dependency_report(report)
+
+            self.assertEqual(returned, str(txt_path))
+            self.assertTrue(txt_path.is_file())
+            self.assertTrue(json_path.is_file())
+            data = json.loads(json_path.read_text(encoding="utf-8"))
+            self.assertEqual(data["status"], "OK")
+            self.assertEqual(data["package_type"], "deb")
+            self.assertEqual(data["packages"], 2)
+            self.assertEqual(data["edges"], 1)
+
+    def test_json_write_failure_is_non_fatal(self):
+        # Test that a JSON write error still returns the text report path (warning only).
+        report = native_linux_package_install_test.DependencyReport(package_type="deb")
+        with tempfile.TemporaryDirectory() as tmp:
+            txt_path = Path(tmp) / "report.txt"
+            env = {
+                native_linux_package_install_test.ENV_NATIVE_LINUX_DEP_REPORT_FILE: str(
+                    txt_path
+                ),
+                native_linux_package_install_test.ENV_NATIVE_LINUX_DEP_REPORT_JSON_FILE: str(
+                    Path(tmp) / "report.json"
+                ),
+            }
+            with patch.dict(os.environ, env, clear=False), _suppress_script_output():
+                with patch.object(
+                    native_linux_package_install_test.Path,
+                    "write_text",
+                    side_effect=[None, OSError("disk full")],
+                ):
+                    returned = self._make_tester()._write_dependency_report(report)
+            self.assertEqual(returned, str(txt_path))
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import ANY, patch, MagicMock
 
 # Load the module: look in same dir as this file, then parent (covers linux/ or linux/tests/ layout).
 _this_file = Path(__file__).resolve()
@@ -1931,7 +1931,7 @@ class VerifyTransitiveDependenciesInstalledTest(unittest.TestCase):
         ):
             ok, _ = t._verify_transitive_dependencies_installed()
         self.assertTrue(ok)
-        mock_deb.assert_called_once_with(t.package_names)
+        mock_deb.assert_called_once_with(t.package_names, report=ANY)
 
     @patch(
         "native_linux_package_install_test.verify_rpm_transitive_dependencies",
@@ -1950,7 +1950,7 @@ class VerifyTransitiveDependenciesInstalledTest(unittest.TestCase):
         ):
             ok, _ = t._verify_transitive_dependencies_installed()
         self.assertTrue(ok)
-        mock_rpm.assert_called_once_with(t.package_names)
+        mock_rpm.assert_called_once_with(t.package_names, report=ANY)
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -1729,8 +1729,10 @@ class VerifyDebianTransitiveDependenciesTest(unittest.TestCase):
         mock_run.return_value = MagicMock(
             returncode=100, stdout="", stderr="broken deps"
         )
-        ok, errs = native_linux_package_install_test.verify_debian_transitive_dependencies(
-            ["amdrocm-gfx94x"]
+        ok, errs = (
+            native_linux_package_install_test.verify_debian_transitive_dependencies(
+                ["amdrocm-gfx94x"]
+            )
         )
         self.assertFalse(ok)
         self.assertTrue(any("apt-get check failed" in e for e in errs))
@@ -1743,8 +1745,10 @@ class VerifyDebianTransitiveDependenciesTest(unittest.TestCase):
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         mock_installed.return_value = True
         mock_stanza.return_value = {}  # no depends fields
-        ok, errs = native_linux_package_install_test.verify_debian_transitive_dependencies(
-            ["amdrocm-gfx94x"]
+        ok, errs = (
+            native_linux_package_install_test.verify_debian_transitive_dependencies(
+                ["amdrocm-gfx94x"]
+            )
         )
         self.assertTrue(ok)
         self.assertEqual(errs, [])
@@ -1755,8 +1759,10 @@ class VerifyDebianTransitiveDependenciesTest(unittest.TestCase):
         # Test that a root package missing from dpkg yields a failure.
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         mock_installed.return_value = False
-        ok, errs = native_linux_package_install_test.verify_debian_transitive_dependencies(
-            ["amdrocm-gfx94x"]
+        ok, errs = (
+            native_linux_package_install_test.verify_debian_transitive_dependencies(
+                ["amdrocm-gfx94x"]
+            )
         )
         self.assertFalse(ok)
         self.assertTrue(any("not installed" in e for e in errs))
@@ -1773,8 +1779,10 @@ class VerifyDebianTransitiveDependenciesTest(unittest.TestCase):
         mock_installed.return_value = True
         mock_stanza.return_value = {"depends": "libmissing"}
         mock_pick.return_value = None
-        ok, errs = native_linux_package_install_test.verify_debian_transitive_dependencies(
-            ["amdrocm-gfx94x"]
+        ok, errs = (
+            native_linux_package_install_test.verify_debian_transitive_dependencies(
+                ["amdrocm-gfx94x"]
+            )
         )
         self.assertFalse(ok)
         self.assertTrue(any("unsatisfied dependency group" in e for e in errs))
@@ -1785,8 +1793,10 @@ class VerifyDebianTransitiveDependenciesTest(unittest.TestCase):
         # Test that exceeding max_closure aborts the walk with an error.
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         mock_installed.return_value = True
-        ok, errs = native_linux_package_install_test.verify_debian_transitive_dependencies(
-            ["amdrocm-gfx94x"], max_closure=0
+        ok, errs = (
+            native_linux_package_install_test.verify_debian_transitive_dependencies(
+                ["amdrocm-gfx94x"], max_closure=0
+            )
         )
         self.assertFalse(ok)
         self.assertTrue(any("exceeded max steps" in e for e in errs))


### PR DESCRIPTION
## Motivation

This pull request enhances the Linux native package installation test script by adding an automated, post-install transitive dependency verification step for both DEB and RPM packages. This ensures that all dependencies (including virtual and alternative dependencies) are correctly installed after the main package installation, improving test coverage and reliability. The dependency check can be skipped via an environment variable for faster or targeted testing, and the test suite has been updated to accommodate this new behavior.

## Technical Details

**Dependency Verification Enhancements:**

* Added post-install transitive dependency verification for DEB (using `apt-get check` and dependency closure) and RPM (using `rpm -qR` and provider closure) packages, ensuring all package dependencies are satisfied after installation. [[1]](diffhunk://#diff-79959fbf42afa5c33796b97c10d2634bdf16eb7ec4c0b530bd922c466fddeed0R188-R514) [[2]](diffhunk://#diff-79959fbf42afa5c33796b97c10d2634bdf16eb7ec4c0b530bd922c466fddeed0R1063-R1073) [[3]](diffhunk://#diff-79959fbf42afa5c33796b97c10d2634bdf16eb7ec4c0b530bd922c466fddeed0R1130-R1147)
* Introduced the `NATIVE_LINUX_SKIP_DEP_VERIFY` environment variable to allow skipping the dependency verification step when desired, improving test flexibility and performance in edge cases. [[1]](diffhunk://#diff-79959fbf42afa5c33796b97c10d2634bdf16eb7ec4c0b530bd922c466fddeed0R31-R33) [[2]](diffhunk://#diff-79959fbf42afa5c33796b97c10d2634bdf16eb7ec4c0b530bd922c466fddeed0R147-R149) [[3]](diffhunk://#diff-79959fbf42afa5c33796b97c10d2634bdf16eb7ec4c0b530bd922c466fddeed0R1130-R1147)


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
