### PR TITLE
Add PR-aware checkout fetch-depth action and script

### DIFF
--- a/.github/actions/compute_pr_fetch_depth/action.yml
+++ b/.github/actions/compute_pr_fetch_depth/action.yml
@@ -1,0 +1,29 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+name: "Compute PR-aware fetch-depth"
+
+description: >-
+  Returns the smallest `actions/checkout` fetch-depth that covers all
+  commits this workflow needs to walk.
+
+  * pull_request events: `commits + 1` (PR commits + merge-base).
+  * any other event (push, schedule, workflow_dispatch, ...): `0`
+    (full history). Use this when downstream tooling walks commit
+    history
+
+outputs:
+  value:
+    description: >-
+      String value to pass to actions/checkout fetch-depth. Already
+      coerced to a string so it composes cleanly with checkout's
+      input parser.
+    value: ${{ steps.compute.outputs.value }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Compute fetch-depth
+      id: compute
+      shell: bash
+      run: python build_tools/github_actions/compute_pr_depth.py

--- a/build_tools/github_actions/compute_pr_depth.py
+++ b/build_tools/github_actions/compute_pr_depth.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Compute the smallest `actions/checkout` fetch-depth for the current event."""
+
+import sys
+from typing import Any
+
+from github_actions_api import gha_load_github_event, gha_set_output
+
+
+def compute_fetch_depth(payload: dict[str, Any]) -> str:
+    pr = payload.get("pull_request")
+    if not isinstance(pr, dict):
+        return "0"
+
+    commits = pr.get("commits")
+    if not isinstance(commits, int) or commits <= 0:
+        return "0"
+
+    return str(commits + 1)
+
+
+def main(argv: list[str]) -> int:
+    value = compute_fetch_depth(gha_load_github_event())
+    print(f"fetch-depth = {value}")
+    gha_set_output({"value": value})
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/build_tools/github_actions/tests/compute_pr_depth_test.py
+++ b/build_tools/github_actions/tests/compute_pr_depth_test.py
@@ -14,8 +14,6 @@ class ComputeFetchDepthTest(unittest.TestCase):
     """Tests for compute_pr_depth.compute_fetch_depth."""
 
     def test_pull_request_returns_commits_plus_one(self):
-        # +1 covers the PR merge-base so downstream tooling can diff against
-        # the base commit, not just the PR's own commits.
         self.assertEqual(
             compute_pr_depth.compute_fetch_depth({"pull_request": {"commits": 3}}),
             "4",

--- a/build_tools/github_actions/tests/compute_pr_depth_test.py
+++ b/build_tools/github_actions/tests/compute_pr_depth_test.py
@@ -1,0 +1,72 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+import compute_pr_depth
+
+
+class ComputeFetchDepthTest(unittest.TestCase):
+    """Tests for compute_pr_depth.compute_fetch_depth."""
+
+    def test_pull_request_returns_commits_plus_one(self):
+        # +1 covers the PR merge-base so downstream tooling can diff against
+        # the base commit, not just the PR's own commits.
+        self.assertEqual(
+            compute_pr_depth.compute_fetch_depth({"pull_request": {"commits": 3}}),
+            "4",
+        )
+
+    def test_single_commit_pull_request(self):
+        self.assertEqual(
+            compute_pr_depth.compute_fetch_depth({"pull_request": {"commits": 1}}),
+            "2",
+        )
+
+    def test_empty_payload_returns_full_history(self):
+        self.assertEqual(compute_pr_depth.compute_fetch_depth({}), "0")
+
+    def test_push_payload_returns_full_history(self):
+        self.assertEqual(
+            compute_pr_depth.compute_fetch_depth({"before": "abc123"}), "0"
+        )
+
+    def test_non_dict_pull_request_returns_full_history(self):
+        self.assertEqual(
+            compute_pr_depth.compute_fetch_depth({"pull_request": None}), "0"
+        )
+
+    def test_missing_commits_returns_full_history(self):
+        self.assertEqual(
+            compute_pr_depth.compute_fetch_depth({"pull_request": {}}), "0"
+        )
+
+    def test_zero_commits_returns_full_history(self):
+        self.assertEqual(
+            compute_pr_depth.compute_fetch_depth({"pull_request": {"commits": 0}}),
+            "0",
+        )
+
+    def test_negative_commits_returns_full_history(self):
+        self.assertEqual(
+            compute_pr_depth.compute_fetch_depth({"pull_request": {"commits": -5}}),
+            "0",
+        )
+
+    def test_non_int_commits_returns_full_history(self):
+        self.assertEqual(
+            compute_pr_depth.compute_fetch_depth({"pull_request": {"commits": "3"}}),
+            "0",
+        )
+
+    def test_returns_string(self):
+        result = compute_pr_depth.compute_fetch_depth({"pull_request": {"commits": 2}})
+        self.assertIsInstance(result, str)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

For different security scanners we will need to calculate the commit depth of each PR. 

## Technical Details
Computes the minimal actions/checkout fetch-depth for the current event so workflows fetch just enough git history instead of cloning everything: for pull_request events it returns commits + 1.

## Test Plan
Unit-tested via compute_pr_depth_test.py (run by the existing unit_tests.yml job as part of pytest build_tools)

## Test Result



## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
