### PR TITLE
Revert "Install test invocation added to multi arch Linux release/build workflow"

### DIFF
--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -119,14 +119,6 @@ jobs:
             --pkg-type "${{ inputs.native_package_type }}" \
             --version-suffix "${{ env.ARTIFACT_RUN_ID }}"
 
-      - name: Simulated install Test
-        id: test-packages
-        run: |
-          python ./build_tools/packaging/linux/native_linux_package_install_test.py \
-            --test-type simulate \
-            --packages-dir "${{ env.PACKAGE_DIST_DIR }}" \
-            --pkg-type ${{ inputs.native_package_type }}
-
       - name: Configure AWS credentials for artifact uploads
         uses: ./.github/actions/configure_aws_artifacts_credentials
         with:

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -155,6 +155,7 @@ jobs:
   trigger_test_artifacts_per_family:
     needs: [build_artifacts]
     name: Trigger Test Artifacts (${{ matrix.family_info.amdgpu_family }})
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-24.04
     permissions:
       actions: write
@@ -179,34 +180,6 @@ jobs:
               "repository": "${{ inputs.repository }}",
               "ref": "${{ inputs.ref }}"
             }
-
-  # Install tests are dispatched asynchronously (sanity) so publish
-  # is not blocked on GPU runner queues. See https://github.com/ROCm/TheRock/issues/5212
-  trigger_test_native_install:
-    needs: [build_native_deb_packages, build_native_rpm_packages]
-    name: Trigger Native Install Test - ${{ matrix.os_profile }}
-    runs-on: ubuntu-24.04
-    permissions:
-      actions: write
-    strategy:
-      fail-fast: false
-      matrix:
-        os_profile: [ubuntu2404, rhel10, sles16]
-    steps:
-      - name: Trigger test_native_linux_packages_install
-        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
-        with:
-          workflow: test_native_linux_packages_install.yml
-          inputs: |
-            { "package_install_url": "${{ matrix.os_profile == 'ubuntu2404' && needs.build_native_deb_packages.outputs.package_repository_url || needs.build_native_rpm_packages.outputs.package_repository_url }}",
-              "release_type": "${{ inputs.release_type }}",
-              "os_profile": "${{ matrix.os_profile }}",
-              "artifact_group": "${{ fromJSON(inputs.build_config).dist_amdgpu_families }}",
-              "test_type": "${{ inputs.test_type }}",
-              "repository": "${{ inputs.repository }}",
-              "ref": "${{ inputs.ref }}"
-            }
-
 
   # TODO: Consider switch pulling ROCm packages from the CDN instead of the artifact
   #   bucket if the job order is not altered.

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -34,7 +34,7 @@ on:
         type: string
         default: "/opt/rocm/core"
       test_type:
-        description: "Test type: quick, standard, comprehensive, full, install, or sanity. CI test types are mapped to native install test modes."
+        description: "Test type: sanity (install + basic verification), full (install + basic + rdhc). If not set, script default is used."
         required: false
         type: string
         default: ""
@@ -83,7 +83,7 @@ on:
         default: "/opt/rocm/core"
         required: false
       test_type:
-        description: "Test type: quick, standard, comprehensive, full, install, or sanity (optional; leave empty for sanity)"
+        description: "Test type: sanity or full (optional; leave empty for script default)"
         type: string
         default: ""
       repository:
@@ -145,7 +145,7 @@ jobs:
       RELEASE_TYPE: ${{ inputs.release_type }}
       GFX_ARCH: ${{ needs.prepare_install_context.outputs.gfx_arch }}
       INSTALL_PREFIX: ${{ inputs.install_prefix || '/opt/rocm/core' }}
-      TEST_TYPE: ${{ inputs.test_type }}
+      TEST_TYPE: ${{ inputs.test_type || 'sanity' }}
     steps:
       - name: Install System Prerequisites
         run: |
@@ -159,8 +159,8 @@ jobs:
               ca-certificates \
               gpg \
               lsb-release
-            if [ "$TEST_TYPE" = "full" ] || [ "$TEST_TYPE" = "comprehensive" ]; then
-              echo "Extra OS packages for --test-type full/comprehensive (e.g. rdhc): pciutils, kmod, apt-utils"
+            if [ "$TEST_TYPE" = "full" ]; then
+              echo "Extra OS packages for --test-type full (e.g. rdhc): pciutils, kmod, apt-utils"
               apt install -y pciutils kmod apt-utils
             fi
           elif [[ "${{ inputs.os_profile }}" == sles* ]]; then
@@ -173,8 +173,8 @@ jobs:
               gpg2 \
               lsb-release \
               update-alternatives
-            if [ "$TEST_TYPE" = "full" ] || [ "$TEST_TYPE" = "comprehensive" ]; then
-              echo "Extra OS packages for --test-type full/comprehensive on SLES (e.g. rdhc): pciutils, kmod"
+            if [ "$TEST_TYPE" = "full" ]; then
+              echo "Extra OS packages for --test-type full on SLES (e.g. rdhc): pciutils, kmod"
               zypper install -y pciutils kmod
             fi
           else
@@ -185,8 +185,8 @@ jobs:
               ca-certificates \
               gnupg2 \
               dnf-plugins-core
-            if [ "$TEST_TYPE" = "full" ] || [ "$TEST_TYPE" = "comprehensive" ]; then
-              echo "Extra OS packages for --test-type full/comprehensive (e.g. rdhc): pciutils, kmod"
+            if [ "$TEST_TYPE" = "full" ]; then
+              echo "Extra OS packages for --test-type full (e.g. rdhc): pciutils, kmod"
               dnf install -y --allowerasing pciutils kmod
             fi
           fi

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -8,7 +8,6 @@ Full installation and simulate-install test script for ROCm native packages.
 Test modes (--test-type):
 - sanity: Basic test. Repo-based install plus basic verification only
   (steps 1 and 2).
-- quick / standard: CI aliases for sanity.
 - full: Full test. Repo-based install plus basic verification plus full
   verification (steps 1, 2, and 3).
   Steps (invoked one by one from main):
@@ -17,9 +16,6 @@ Test modes (--test-type):
   2. Basic verification: install prefix, key components, installed packages
      list, rocminfo. (Run for both sanity and full.)
   3. Full verification: rdhc.py / RDHC test. (Run only for full.)
-- comprehensive: CI alias for full.
-- install: Repo-based install only (step 1). No rocminfo or component checks.
-  Used by release workflows that dispatch install tests off the critical path.
 - simulate: Dry-run only. Simulated install of local .deb or .rpm files
   (apt install --simulate or rpm -Uvh --test --nodeps). No repo setup or
   actual install. Requires --packages-dir.
@@ -55,49 +51,43 @@ Example invocations:
 
  # Nightly DEB (Ubuntu 24.04) - run inside ubuntu:24.04 container or VM
  python3 native_linux_package_install_test.py \\
-         --os-profile ubuntu2404 \\
-         --repo-url https://rocm.nightlies.amd.com/deb/20260204-21658678136/ \\
-         --gfx-arch gfx94x \\
-         --release-type nightly
+ --os-profile ubuntu2404 \\
+ --repo-url https://rocm.nightlies.amd.com/deb/20260204-21658678136/ \\
+ --gfx-arch gfx94x \\
+ --release-type nightly
 
  # Prerelease DEB with GPG verification
  python3 native_linux_package_install_test.py \\
-         --os-profile ubuntu2404 \\
-         --repo-url https://rocm.prereleases.amd.com/packages/ubuntu2404 \\
-         --release-type prerelease \\
-         --gpg-key-url https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
+ --os-profile ubuntu2404 \\
+ --repo-url https://rocm.prereleases.amd.com/packages/ubuntu2404 \\
+ --release-type prerelease \\
+ --gpg-key-url https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
 
  # Nightly RPM (RHEL 8) - run inside rhel8/almalinux container or VM
  python3 native_linux_package_install_test.py \\
-         --os-profile rhel8 \\
-         --repo-url https://rocm.nightlies.amd.com/rpm/20260204-21658678136/x86_64/ \\
-         --gfx-arch gfx94x \\
-         --release-type nightly
+ --os-profile rhel8 \\
+ --repo-url https://rocm.nightlies.amd.com/rpm/20260204-21658678136/x86_64/ \\
+ --gfx-arch gfx94x \\
+ --release-type nightly
 
  # Prerelease RPM (SLES 16)
  python3 native_linux_package_install_test.py \\
-         --os-profile sles16 \\
-         --repo-url https://rocm.prereleases.amd.com/packages/sles16/x86_64/ \\
-         --release-type prerelease \\
-         --gpg-key-url https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
+ --os-profile sles16 \\
+ --repo-url https://rocm.prereleases.amd.com/packages/sles16/x86_64/ \\
+ --release-type prerelease \\
+ --gpg-key-url https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
 
  # --test-type sanity (default): repo install + basic verification only (steps 1-2)
  python3 native_linux_package_install_test.py --test-type sanity \\
-         --os-profile ubuntu2404 \\
-         --repo-url https://rocm.nightlies.amd.com/deb/20260204-21658678136/ \\
-         --gfx-arch gfx94x --release-type nightly --install-prefix /opt/rocm/core
+ --os-profile ubuntu2404 \\
+ --repo-url https://rocm.nightlies.amd.com/deb/20260204-21658678136/ \\
+ --gfx-arch gfx94x --release-type nightly --install-prefix /opt/rocm/core
 
  # --test-type full: same as sanity plus rdhc full verification (steps 1-3)
  python3 native_linux_package_install_test.py --test-type full \\
-         --os-profile ubuntu2404 \\
-         --repo-url https://rocm.nightlies.amd.com/deb/20260204-21658678136/ \\
-         --gfx-arch gfx94x --release-type nightly --install-prefix /opt/rocm/core
-
- # --test-type install: repo install only (no verification)
- python3 native_linux_package_install_test.py --test-type install \\
-         --os-profile ubuntu2404 \\
-         --repo-url https://rocm.nightlies.amd.com/deb/20260204-21658678136/ \\
-         --gfx-arch gfx94x --release-type nightly
+ --os-profile ubuntu2404 \\
+ --repo-url https://rocm.nightlies.amd.com/deb/20260204-21658678136/ \\
+ --gfx-arch gfx94x --release-type nightly --install-prefix /opt/rocm/core
 
  # Simulate install (dry-run) from local .deb or .rpm directory
  python3 native_linux_package_install_test.py --test-type simulate --packages-dir /path/to/pkgs --os-profile ubuntu2404
@@ -151,32 +141,6 @@ INSTALL_TIMEOUT_SEC = 1800  # 30 minutes
 ROCMINFO_TIMEOUT_SEC = 30
 RDHC_TIMEOUT_SEC = 30
 VERIFY_MIN_COMPONENTS = 2
-_TEST_TYPE_MAP = {
-    "": "sanity",
-    "quick": "sanity",
-    "standard": "sanity",
-    "comprehensive": "full",
-    "full": "full",
-    "install": "install",
-    "sanity": "sanity",
-    "simulate": "simulate",
-}
-
-
-def _normalize_test_type(test_type: str | None) -> str:
-    """Map shared CI test types to native package install test modes.
-
-    quick/standard/empty -> sanity, comprehensive/full -> full.
-    Native modes (install/sanity/full/simulate) are also accepted directly.
-    """
-    normalized = (test_type or "").strip().lower()
-    try:
-        return _TEST_TYPE_MAP[normalized]
-    except KeyError as e:
-        valid = ", ".join(sorted(k or "<empty>" for k in _TEST_TYPE_MAP))
-        raise ValueError(
-            f"Unsupported test_type {test_type!r}. Expected one of: {valid}."
-        ) from e
 
 
 def run_simulate_install_test(pkg_type: str, packages_dir: str) -> bool:
@@ -952,11 +916,6 @@ Examples:
  --repo-url https://rocm.nightlies.amd.com/deb/20260204-21658678136/ \\
  --gfx-arch gfx94x --release-type nightly --install-prefix /opt/rocm/core
 
- # --test-type install: install only
- python native_linux_package_install_test.py --test-type install --os-profile ubuntu2404 \\
- --repo-url https://therock-dev-artifacts.s3.amazonaws.com/26299074718-linux/packages/deb \\
- --gfx-arch gfx94x --release-type dev --install-prefix /opt/rocm/core
-
  # Simulate install (dry-run) from local packages
  python native_linux_package_install_test.py --test-type simulate --packages-dir /path/to/pkgs --os-profile ubuntu2404
  python native_linux_package_install_test.py --test-type simulate --packages-dir /path/to/rpms --pkg-type rpm
@@ -1008,8 +967,9 @@ def _build_argument_parser(*, exit_on_error: bool = True) -> ArgumentParser:
     parser.add_argument(
         "--test-type",
         type=str,
+        choices=["sanity", "full", "simulate"],
         default="sanity",
-        help="Test type: 'install' = repo install only; 'sanity' = install + basic verification; 'full' = sanity + rdhc; 'simulate' = dry-run local packages (requires --packages-dir). Also accepts CI test types: quick, standard, comprehensive.",
+        help="Test type: 'sanity' = basic test only; 'full' = basic + full test; 'simulate' = simulated install only (requires --packages-dir).",
     )
     parser.add_argument(
         "--packages-dir",
@@ -1041,17 +1001,11 @@ def _validate_cli_args(parser: ArgumentParser, args: Namespace) -> None:
                 parser.error(str(e))
         return
     if not args.os_profile:
-        parser.error(
-            "--os-profile is required when --test-type is 'install', 'sanity', or 'full'"
-        )
+        parser.error("--os-profile is required when --test-type is 'sanity' or 'full'")
     if not args.repo_url:
-        parser.error(
-            "--repo-url is required when --test-type is 'install', 'sanity', or 'full'"
-        )
+        parser.error("--repo-url is required when --test-type is 'sanity' or 'full'")
     if not args.gfx_arch:
-        parser.error(
-            "--gfx-arch is required when --test-type is 'install', 'sanity', or 'full'"
-        )
+        parser.error("--gfx-arch is required when --test-type is 'sanity' or 'full'")
 
 
 def parse_cli_arguments(
@@ -1072,10 +1026,6 @@ def parse_cli_arguments(
 
         parser.error = _raise  # type: ignore[method-assign]
     args = parser.parse_args(argv)
-    try:
-        args.test_type = _normalize_test_type(args.test_type)
-    except ValueError as e:
-        parser.error(str(e))
     _validate_cli_args(parser, args)
     return args
 
@@ -1137,12 +1087,6 @@ def run_tests(args: Namespace) -> int:
         if not test_runner.run_repo_setup_and_install():
             print("\n[FAIL] Step 1 (repo setup and install) failed.")
             return 1
-        if args.test_type == "install":
-            print("\n" + "=" * 80)
-            print("[PASS] INSTALLATION TEST PASSED")
-            print("(install: repo setup and package install completed)")
-            print("=" * 80 + "\n")
-            return 0
         if not test_runner.run_basic_verification():
             print("\n[FAIL] Step 2 (basic verification) failed.")
             return 1

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, mock_open
 
 # Load the module: look in same dir as this file, then parent (covers linux/ or linux/tests/ layout).
 _this_file = Path(__file__).resolve()
@@ -95,45 +95,6 @@ class EnvHelperTest(unittest.TestCase):
                 native_linux_package_install_test._env("ROCM_TEST_KEY", "default"),
                 "value",
             )
-
-
-class NormalizeTestTypeTest(unittest.TestCase):
-    """Tests for _normalize_test_type()."""
-
-    def test_empty_quick_and_standard_map_to_sanity(self):
-        for test_type in ("", None, "quick", "standard"):
-            with self.subTest(test_type=test_type):
-                self.assertEqual(
-                    native_linux_package_install_test._normalize_test_type(test_type),
-                    "sanity",
-                )
-
-    def test_comprehensive_and_full_map_to_full(self):
-        for test_type in ("comprehensive", "full"):
-            with self.subTest(test_type=test_type):
-                self.assertEqual(
-                    native_linux_package_install_test._normalize_test_type(test_type),
-                    "full",
-                )
-
-    def test_native_modes_are_accepted(self):
-        for test_type in ("install", "sanity", "full", "simulate"):
-            with self.subTest(test_type=test_type):
-                self.assertEqual(
-                    native_linux_package_install_test._normalize_test_type(test_type),
-                    test_type,
-                )
-
-    def test_strips_whitespace_and_lowercases(self):
-        self.assertEqual(
-            native_linux_package_install_test._normalize_test_type("  Quick  "),
-            "sanity",
-        )
-
-    def test_invalid_test_type_raises(self):
-        with self.assertRaises(ValueError) as ctx:
-            native_linux_package_install_test._normalize_test_type("standrd")
-        self.assertIn("Unsupported test_type", str(ctx.exception))
 
 
 class DerivePackageTypeTest(unittest.TestCase):
@@ -266,7 +227,7 @@ class NativeLinuxPackageInstallTestInitTest(unittest.TestCase):
         self.assertEqual(t.gfx_arch, "gfx94x")
         self.assertEqual(
             t.package_names,
-            ["amdrocm", "amdrocm-core-sdk"],
+            ["amdrocm-gfx94x", "amdrocm-core-sdk-gfx94x"],
         )
 
     def test_gfx_arch_string_normalized_to_list(self):
@@ -279,7 +240,7 @@ class NativeLinuxPackageInstallTestInitTest(unittest.TestCase):
         self.assertEqual(t.gfx_arch, "gfx110x")
         self.assertEqual(
             t.package_names,
-            ["amdrocm", "amdrocm-core-sdk"],
+            ["amdrocm-gfx110x", "amdrocm-core-sdk-gfx110x"],
         )
 
     def test_gfx_arch_list_uses_first_element(self):
@@ -292,7 +253,7 @@ class NativeLinuxPackageInstallTestInitTest(unittest.TestCase):
         self.assertEqual(t.gfx_arch, "gfx1151")
         self.assertEqual(
             t.package_names,
-            ["amdrocm", "amdrocm-core-sdk"],
+            ["amdrocm-gfx1151", "amdrocm-core-sdk-gfx1151"],
         )
 
     def test_gfx_arch_empty_string_falls_back_to_default(self):
@@ -452,7 +413,7 @@ class MainValidationTest(unittest.TestCase):
                 "--test-type",
                 "sanity",
                 "--repo-url",
-                "https://repo_url.com",
+                "https://x.com",
                 "--gfx-arch",
                 "gfx94x",
             ],
@@ -490,161 +451,12 @@ class MainValidationTest(unittest.TestCase):
                 "--os-profile",
                 "ubuntu2404",
                 "--repo-url",
-                "https://repo_url.com",
+                "https://x.com",
             ],
         ):
             with self.assertRaises(SystemExit) as cm:
                 native_linux_package_install_test.main()
             self.assertEqual(cm.exception.code, 2)
-
-    def test_install_requires_os_profile(self):
-        # install uses the same required args as sanity (no verification step).
-        with patch(
-            "sys.argv",
-            [
-                "prog",
-                "--test-type",
-                "install",
-                "--repo-url",
-                "https://repo_url.com",
-                "--gfx-arch",
-                "gfx94x",
-            ],
-        ):
-            with self.assertRaises(SystemExit) as cm:
-                native_linux_package_install_test.main()
-            self.assertEqual(cm.exception.code, 2)
-
-    def test_parse_cli_maps_quick_to_sanity(self):
-        args = native_linux_package_install_test.parse_cli_arguments(
-            [
-                "--test-type",
-                "quick",
-                "--os-profile",
-                "ubuntu2404",
-                "--repo-url",
-                "https://repo_url.com",
-                "--gfx-arch",
-                "gfx94x",
-            ],
-            raise_instead_of_exit=True,
-        )
-        self.assertEqual(args.test_type, "sanity")
-
-    def test_parse_cli_maps_comprehensive_to_full(self):
-        args = native_linux_package_install_test.parse_cli_arguments(
-            [
-                "--test-type",
-                "comprehensive",
-                "--os-profile",
-                "ubuntu2404",
-                "--repo-url",
-                "https://repo_url.com",
-                "--gfx-arch",
-                "gfx94x",
-            ],
-            raise_instead_of_exit=True,
-        )
-        self.assertEqual(args.test_type, "full")
-
-    def test_parse_cli_rejects_invalid_test_type(self):
-        with self.assertRaises(ValueError) as ctx:
-            native_linux_package_install_test.parse_cli_arguments(
-                ["--test-type", "standrd"],
-                raise_instead_of_exit=True,
-            )
-        self.assertIn("Unsupported test_type", str(ctx.exception))
-
-
-class ArgvFromCiEnvTest(unittest.TestCase):
-    """Tests for _argv_from_ci_env() (CI workflow env → CLI argv)."""
-
-    def test_builds_argv_for_install_test_type(self):
-        env = {
-            "TEST_TYPE": "install",
-            "OS_PROFILE": "ubuntu2404",
-            "REPO_URL": "https://example.com/deb",
-            "GFX_ARCH": "gfx94x",
-            "RELEASE_TYPE": "dev",
-            "INSTALL_PREFIX": "/opt/rocm/core",
-        }
-        with patch.dict(os.environ, env, clear=False):
-            argv = native_linux_package_install_test._argv_from_ci_env()
-        self.assertIsNotNone(argv)
-        self.assertIn("--test-type", argv)
-        self.assertEqual(argv[argv.index("--test-type") + 1], "install")
-        self.assertEqual(argv[argv.index("--os-profile") + 1], "ubuntu2404")
-        self.assertEqual(argv[argv.index("--repo-url") + 1], "https://example.com/deb")
-
-    def test_ci_env_passes_shared_test_type_to_parser(self):
-        env = {
-            "TEST_TYPE": "comprehensive",
-            "OS_PROFILE": "ubuntu2404",
-            "REPO_URL": "https://example.com/deb",
-            "GFX_ARCH": "gfx94x",
-            "RELEASE_TYPE": "dev",
-            "INSTALL_PREFIX": "/opt/rocm/core",
-        }
-        with patch.dict(os.environ, env, clear=False):
-            argv = native_linux_package_install_test._argv_from_ci_env()
-        self.assertIsNotNone(argv)
-        self.assertEqual(argv[argv.index("--test-type") + 1], "comprehensive")
-        args = native_linux_package_install_test.parse_cli_arguments(
-            argv,
-            raise_instead_of_exit=True,
-        )
-        self.assertEqual(args.test_type, "full")
-
-    def test_returns_none_when_required_env_missing(self):
-        with patch.dict(os.environ, {"TEST_TYPE": "install"}, clear=True):
-            self.assertIsNone(native_linux_package_install_test._argv_from_ci_env())
-
-
-class RunTestsTestTypeTest(unittest.TestCase):
-    """Tests for run_tests() early exit paths for install."""
-
-    def _base_args(self, test_type: str):
-        from argparse import Namespace
-
-        return Namespace(
-            test_type=test_type,
-            os_profile="ubuntu2404",
-            repo_url="https://example.com",
-            release_type="dev",
-            install_prefix="/opt/rocm/core",
-            gfx_arch=["gfx94x"],
-            gpg_key_url=None,
-            packages_dir=None,
-            pkg_type=None,
-        )
-
-    @patch.object(
-        native_linux_package_install_test.NativeLinuxPackageInstallTest,
-        "run_repo_setup_and_install",
-        return_value=True,
-    )
-    @patch.object(
-        native_linux_package_install_test.NativeLinuxPackageInstallTest,
-        "run_basic_verification",
-    )
-    def test_install_skips_basic_verification(self, mock_basic, mock_repo_setup):
-        args = self._base_args("install")
-        with _suppress_script_output():
-            rc = native_linux_package_install_test.run_tests(args)
-        self.assertEqual(rc, 0)
-        mock_repo_setup.assert_called_once()
-        mock_basic.assert_not_called()
-
-    @patch.object(
-        native_linux_package_install_test.NativeLinuxPackageInstallTest,
-        "run_repo_setup_and_install",
-        return_value=False,
-    )
-    def test_install_fails_when_repo_setup_fails(self, mock_repo_setup):
-        args = self._base_args("install")
-        with _suppress_script_output():
-            rc = native_linux_package_install_test.run_tests(args)
-        self.assertEqual(rc, 1)
 
 
 class RunBasicVerificationTest(unittest.TestCase):
@@ -784,9 +596,9 @@ class SetupDebRepositoryTest(unittest.TestCase):
     """Tests for NativeLinuxPackageInstallTest.setup_deb_repository()."""
 
     @patch("native_linux_package_install_test._run_streaming")
-    @patch("native_linux_package_install_test.Path.write_text")
+    @patch("builtins.open", new_callable=mock_open)
     def test_returns_true_when_apt_update_succeeds_no_gpg(
-        self, mock_write_text, mock_streaming
+        self, mock_file, mock_streaming
     ):
         # Test that setup_deb_repository writes repo entry (trusted=yes) and returns True when apt update returns 0.
         mock_streaming.return_value = 0
@@ -796,8 +608,8 @@ class SetupDebRepositoryTest(unittest.TestCase):
             gpg_key_url=None,
         )
         self.assertTrue(t.setup_deb_repository())
-        mock_write_text.assert_called_once()
-        written = mock_write_text.call_args[0][0]
+        mock_file().write.assert_called_once()
+        written = mock_file().write.call_args[0][0]
         self.assertIn("trusted=yes", written)
         self.assertIn("https://repo.example.com", written)
 
@@ -807,9 +619,9 @@ class SetupDebRepositoryTest(unittest.TestCase):
         "setup_gpg_key",
         return_value=True,
     )
-    @patch("native_linux_package_install_test.Path.write_text")
+    @patch("builtins.open", new_callable=mock_open)
     def test_returns_true_with_gpg_when_apt_update_succeeds(
-        self, mock_write_text, mock_gpg, mock_streaming
+        self, mock_file, mock_gpg, mock_streaming
     ):
         # Test that with gpg_key_url, setup_gpg_key is called and repo entry uses signed-by.
         mock_streaming.return_value = 0
@@ -820,7 +632,7 @@ class SetupDebRepositoryTest(unittest.TestCase):
         )
         self.assertTrue(t.setup_deb_repository())
         mock_gpg.assert_called_once()
-        written = mock_write_text.call_args[0][0]
+        written = mock_file().write.call_args[0][0]
         self.assertIn("signed-by", written)
 
     @patch.object(
@@ -838,11 +650,8 @@ class SetupDebRepositoryTest(unittest.TestCase):
         self.assertFalse(t.setup_deb_repository())
 
     @patch("native_linux_package_install_test._run_streaming")
-    @patch(
-        "native_linux_package_install_test.Path.write_text",
-        side_effect=OSError("Permission denied"),
-    )
-    def test_returns_false_when_open_raises(self, mock_write_text, mock_streaming):
+    @patch("builtins.open", side_effect=OSError("Permission denied"))
+    def test_returns_false_when_open_raises(self, mock_file, mock_streaming):
         # Test that setup_deb_repository returns False when writing sources list raises OSError.
         t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
             repo_url="https://repo.example.com",
@@ -852,8 +661,8 @@ class SetupDebRepositoryTest(unittest.TestCase):
         self.assertFalse(t.setup_deb_repository())
 
     @patch("native_linux_package_install_test._run_streaming")
-    @patch("native_linux_package_install_test.Path.write_text")
-    def test_returns_false_when_apt_update_fails(self, mock_write_text, mock_streaming):
+    @patch("builtins.open", new_callable=mock_open)
+    def test_returns_false_when_apt_update_fails(self, mock_file, mock_streaming):
         # Test that setup_deb_repository returns False when apt update returns non-zero.
         mock_streaming.return_value = 1
         t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
@@ -864,10 +673,8 @@ class SetupDebRepositoryTest(unittest.TestCase):
         self.assertFalse(t.setup_deb_repository())
 
     @patch("native_linux_package_install_test._run_streaming")
-    @patch("native_linux_package_install_test.Path.write_text")
-    def test_returns_false_when_apt_update_times_out(
-        self, mock_write_text, mock_streaming
-    ):
+    @patch("builtins.open", new_callable=mock_open)
+    def test_returns_false_when_apt_update_times_out(self, mock_file, mock_streaming):
         # Test that setup_deb_repository returns False when _run_streaming raises TimeoutExpired.
         import subprocess
 
@@ -885,9 +692,9 @@ class SetupSlesRepositoryTest(unittest.TestCase):
 
     @patch("native_linux_package_install_test._run_streaming")
     @patch("native_linux_package_install_test.subprocess.run")
-    @patch("native_linux_package_install_test.Path.write_text")
+    @patch("builtins.open", new_callable=mock_open)
     def test_returns_true_when_refresh_succeeds(
-        self, mock_write_text, mock_run, mock_streaming
+        self, mock_file, mock_run, mock_streaming
     ):
         # Test that _setup_sles_repository writes repo file and returns True when zypper refresh returns 0.
         mock_streaming.return_value = 0
@@ -896,7 +703,7 @@ class SetupSlesRepositoryTest(unittest.TestCase):
             os_profile="sles16",
         )
         self.assertTrue(t._setup_sles_repository())
-        written = mock_write_text.call_args[0][0]
+        written = mock_file().write.call_args[0][0]
         self.assertIn("baseurl=https://repo.example.com", written)
         self.assertIn("sles16", t.os_profile)
 
@@ -905,8 +712,8 @@ class SetupDnfRepositoryTest(unittest.TestCase):
     """Tests for NativeLinuxPackageInstallTest._setup_dnf_repository()."""
 
     @patch("native_linux_package_install_test.subprocess.run")
-    @patch("native_linux_package_install_test.Path.write_text")
-    def test_returns_true_after_writing_repo_file(self, mock_write_text, mock_run):
+    @patch("builtins.open", new_callable=mock_open)
+    def test_returns_true_after_writing_repo_file(self, mock_file, mock_run):
         # Test that _setup_dnf_repository writes repo file and returns True (dnf clean may be mocked).
         mock_run.side_effect = None
         mock_run.return_value = MagicMock(returncode=0)
@@ -915,7 +722,7 @@ class SetupDnfRepositoryTest(unittest.TestCase):
             os_profile="rhel8",
         )
         self.assertTrue(t._setup_dnf_repository())
-        written = mock_write_text.call_args[0][0]
+        written = mock_file().write.call_args[0][0]
         self.assertIn("baseurl=https://repo.example.com", written)
 
 
@@ -966,7 +773,7 @@ class InstallDebPackagesTest(unittest.TestCase):
         self.assertTrue(t.install_deb_packages())
         call_args = mock_streaming.call_args[0][0]
         self.assertEqual(call_args[0], "apt")
-        self.assertIn("amdrocm", call_args)
+        self.assertIn("amdrocm-gfx94x", call_args)
 
     @patch("native_linux_package_install_test._run_streaming")
     def test_returns_false_when_apt_install_fails(self, mock_streaming):
@@ -1132,7 +939,7 @@ class TestRdhcTest(unittest.TestCase):
             )
             self.assertTrue(t.test_rdhc())
             call_args = mock_run.call_args[0][0]
-            self.assertIn("rdhc.py", str(call_args[1]))
+            self.assertIn("rdhc.py", str(call_args[0]))
             self.assertIn("--rocm-install-prefix", call_args)
 
     @patch("native_linux_package_install_test.subprocess.run")


### PR DESCRIPTION
Reverts ROCm/TheRock#5398
Breaking Multi Arch Release workflows runs
related Issue: https://github.com/ROCm/TheRock/issues/5647