### PR TITLE
Updates to test_runner.py unit tests

### DIFF
--- a/build_tools/github_actions/tests/unit_test_runner.py
+++ b/build_tools/github_actions/tests/unit_test_runner.py
@@ -128,16 +128,20 @@ class BuildCtestCommandTest(unittest.TestCase):
     def test_category_exclude_label_applied(self):
         exclude_labels = {"quick_exclude", "standard_exclude"}
         cmd = self._build("quick", "", set(), exclude_labels)
+        # build_ctest_command emits a single -LE flag with all exclude
+        # patterns joined by "|" (ctest regex OR). Split the value back
+        # into its component patterns so the assertion matches logical
+        # excludes rather than the emitted -LE arg string.
         le_indices = [i for i, v in enumerate(cmd) if v == "-LE"]
-        le_values = [cmd[i + 1] for i in le_indices]
-        self.assertIn("quick_exclude", le_values)
+        le_patterns = [p for i in le_indices for p in cmd[i + 1].split("|")]
+        self.assertIn("quick_exclude", le_patterns)
 
     def test_category_exclude_label_not_applied_when_absent(self):
         exclude_labels = {"standard_exclude"}
         cmd = self._build("quick", "generic", set(), exclude_labels)
         le_indices = [i for i, v in enumerate(cmd) if v == "-LE"]
-        le_values = [cmd[i + 1] for i in le_indices]
-        self.assertNotIn("quick_exclude", le_values)
+        le_patterns = [p for i in le_indices for p in cmd[i + 1].split("|")]
+        self.assertNotIn("quick_exclude", le_patterns)
 
     def test_comprehensive_category(self):
         cmd = self._build("comprehensive", "", set())


### PR DESCRIPTION
## Summary

`unit_test_runner.py::BuildCtestCommandTest` has had a latent pair of broken assertions since commit `c53683d1` (PR #4011, *Changes to accomodate ctest based tests in test filters (rocprof-compute)*, 2026-04-29) — the same commit that introduced both the test and the implementation it tests. `build_ctest_command` emits a single `-LE` flag with all exclude patterns joined by `|` (ctest regex OR), so the `-LE` arg string is `"quick_exclude|ex_gpu"` rather than separate list elements, but the tests asserted against the raw arg strings.

- `test_category_exclude_label_applied` — **was failing** on a clean `main` checkout. `assertIn("quick_exclude", ["quick_exclude|ex_gpu"])` is False.
- `test_category_exclude_label_not_applied_when_absent` — **was passing by accident**. `assertNotIn("quick_exclude", ["ex_gpu"])` is trivially True, but a future refactor that puts new patterns into the same `-LE` arg could mask a real regression.

Switch both tests to split each `-LE` value on `|` and assert against the logical pattern list. They now operate on the same shape (`le_patterns = [p for i in le_indices for p in cmd[i + 1].split("|")]`), match the implementation's actual contract, and the positive/negative variants are mechanically symmetric.

## Test plan

- [x] `env -u TEST_TYPE -u TEST_COMPONENT -u THEROCK_BIN_DIR python3 build_tools/github_actions/tests/unit_test_runner.py -v` → **22/22 OK** (was 21/22).
- [x] Confirmed the same `BuildCtestCommandTest.test_category_exclude_label_applied` failure exists on unmodified `main` (so this PR is a true fix, not a no-op).
- [x] Re-ran across the `TEST_TYPE` input matrix (unset / valid / empty / invalid / regression) — all 22/22 in every scenario.

Made with [Cursor](https://cursor.com)