### PR TITLE
[sysdeps][linux] - Update libdrm to version 2.4.134

### DIFF
--- a/third-party/sysdeps/linux/libdrm/CMakeLists.txt
+++ b/third-party/sysdeps/linux/libdrm/CMakeLists.txt
@@ -8,9 +8,9 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 
     therock_subproject_fetch(therock-libdrm-sources
       SOURCE_DIR "${_source_dir}"
-      # Originally mirrored from: "https://gitlab.freedesktop.org/mesa/libdrm/-/archive/libdrm-2.4.127/libdrm-libdrm-2.4.127.tar.bz2"
-      URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/libdrm-libdrm-2.4.127.tar.bz2"
-      URL_HASH "SHA256=3A11654905C595FCA2825D6E259A8086D04A448DCE215B4CB03A49320D9259EC"
+      # Originally mirrored from: "https://gitlab.freedesktop.org/mesa/libdrm/-/archive/libdrm-2.4.134/libdrm-libdrm-2.4.134.tar.bz2"
+      URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/libdrm-libdrm-2.4.134.tar.bz2"
+      URL_HASH "SHA256=D77E5AF336B6491F9E2427378244912EF5295C3C034AF76846C0FCFFE2EB869C"
       TOUCH "${_download_stamp}"
     )
 

--- a/third-party/sysdeps/linux/libdrm/inline_amdgpu_ids.sh
+++ b/third-party/sysdeps/linux/libdrm/inline_amdgpu_ids.sh
@@ -39,7 +39,9 @@ struct inline_amdgpu_id {
       # the file version leading line.
       continue
     fi
-    echo "  {0x${parts[0]}, 0x${parts[1]}, \"${parts[2]}\"},"
+    did="${parts[0]// /}"
+    rid="${parts[1]// /}"
+    echo "  {0x${did}, 0x${rid}, \"${parts[2]}\"},"
   done < "${SOURCE_DIR}/data/amdgpu.ids"
   echo '};'
 


### PR DESCRIPTION
## Motivation

Update libdrm to version from 2.4.127 to 2.4.134.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
