### PR TITLE
[ci] Add vultr runner for submodule changes 

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -154,12 +154,16 @@ amdgpu_family_info_matrix_presubmit = {
             "test-runs-on-labels": [
                 {
                     "label": "linux-gfx942-1gpu-ccs-ossci-rocm",
-                    "weight": 0.138,
-                },  # cirrascale (4/29)
+                    "weight": 0.117,
+                },  # cirrascale (4/34)
                 {
                     "label": "linux-gfx942-1gpu-core42-ossci-rocm",
-                    "weight": 0.862,
-                },  # core42 (25/29)
+                    "weight": 0.736,
+                },  # core42 (25/34)
+                {
+                    "label": "linux-gfx942-1gpu-ossci-rocm",
+                    "weight": 0.147,
+                },  # vultr (5/34)
             ],
             # TODO(#3433): Remove sandbox label once ASAN tests are passing
             "test-runs-on-sandbox": "linux-mi325-gpu-rocm-cpu-sandbox",

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -823,6 +823,7 @@ def _expand_build_config_for_platform(
     pr_labels: list[str],
     is_schedule: bool,
     is_workflow_dispatch: bool,
+    git_context: GitContext,
     prebuilt_stages: list[str] | None = None,
     baseline_run_id: str = "",
 ) -> BuildConfig | None:
@@ -871,6 +872,18 @@ def _expand_build_config_for_platform(
             test_runs_on = select_weighted_label(
                 platform_info["test-runs-on-labels"], family_name
             )
+
+        # TODO: use hard-coded label (vultr machines) as we try to determine core42 regression
+        # This is a temporary measure to get good signal for submodule bumps while we determine core42 issues
+        if (
+            platform == "linux"
+            and family_name == "gfx94x"
+            and git_context.changed_files is not None
+            and git_context.submodule_paths is not None
+        ):
+            matching = set(git_context.submodule_paths) & set(git_context.changed_files)
+            if matching:
+                test_runs_on = "linux-gfx942-1gpu-ossci-rocm"
 
         # When a test_runner:<kernel> label is set, use the
         # kernel-specific runner if available, otherwise disable testing for
@@ -972,6 +985,7 @@ def expand_build_configs(
     targets: TargetSelection,
     ci_inputs: CIInputs,
     test_type: str,
+    git_context: GitContext,
     prebuilt_stages: list[str] | None = None,
     baseline_run_id: str = "",
 ) -> BuildConfigs:
@@ -1014,6 +1028,7 @@ def expand_build_configs(
             is_workflow_dispatch=ci_inputs.is_workflow_dispatch,
             prebuilt_stages=prebuilt_stages,
             baseline_run_id=baseline_run_id,
+            git_context=git_context,
         )
         if platform == "linux":
             linux_config = config
@@ -1119,6 +1134,7 @@ def configure(ci_inputs: CIInputs, git_context: GitContext) -> CIOutputs:
         test_type=jobs.test_rocm.test_type,
         prebuilt_stages=jobs.build_rocm.prebuilt_stages,
         baseline_run_id=jobs.build_rocm.baseline_run_id,
+        git_context=git_context,
     )
     builds.log()
 

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1378,9 +1378,7 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         self.assertIsNotNone(builds.linux)
         # Check that the third label was selected
         gfx94x_info = builds.linux.per_family_info[0]
-        self.assertEqual(
-            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm"
-        )
+        self.assertEqual(gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm")
 
     def test_families_without_multi_label_use_primary_only(self):
         """Families without multi-label config should only use primary label."""

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -779,7 +779,10 @@ class TestExpandBuildConfigs(unittest.TestCase):
         """Empty targets on both platforms → both None."""
         targets = cm.TargetSelection()
         result = cm.expand_build_configs(
-            targets=targets, ci_inputs=self._inputs(), test_type="quick"
+            targets=targets,
+            ci_inputs=self._inputs(),
+            test_type="quick",
+            git_context=cm.GitContext(),
         )
         self.assertIsNone(result.linux)
         self.assertIsNone(result.windows)
@@ -820,7 +823,10 @@ class TestExpandBuildConfigs(unittest.TestCase):
         )
         targets = cm.select_targets(inputs)
         result = cm.expand_build_configs(
-            targets=targets, ci_inputs=inputs, test_type="quick"
+            targets=targets,
+            ci_inputs=inputs,
+            test_type="quick",
+            git_context=cm.GitContext(),
         )
         required_keys = {
             "amdgpu_family",
@@ -870,7 +876,10 @@ class TestExpandBuildConfigs(unittest.TestCase):
             windows_families=["gfx110x"],
         )
         result = cm.expand_build_configs(
-            targets=targets, ci_inputs=self._inputs(), test_type="quick"
+            targets=targets,
+            ci_inputs=self._inputs(),
+            test_type="quick",
+            git_context=cm.GitContext(),
         )
 
         # All target families that support the variant appear in output.
@@ -902,6 +911,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             targets=targets,
             ci_inputs=self._inputs(build_variant="asan"),
             test_type="quick",
+            git_context=cm.GitContext(),
         )
         # Only gfx94x on linux survives.
         self.assertIsNotNone(result.linux)
@@ -934,6 +944,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
                     targets=targets,
                     ci_inputs=ci_inputs,
                     test_type="quick",
+                    git_context=cm.GitContext(),
                 )
                 # Only gfx94x on linux survives.
                 self.assertIsNotNone(result.linux)
@@ -963,6 +974,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             targets=targets,
             ci_inputs=ci_inputs,
             test_type="quick",
+            git_context=cm.GitContext(),
         )
         self.assertIsNotNone(result.linux)
         # Verify it's a host-asan build
@@ -982,6 +994,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             targets=targets,
             ci_inputs=self._inputs(pr_labels=["test_runner:oem"]),
             test_type="quick",
+            git_context=cm.GitContext(),
         )
         self.assertIsNotNone(result.linux)
         entry = result.linux.per_family_info[0]
@@ -995,6 +1008,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             targets=targets,
             ci_inputs=self._inputs(pr_labels=["test_runner:oem"]),
             test_type="quick",
+            git_context=cm.GitContext(),
         )
         self.assertIsNotNone(result.linux)
         entry = result.linux.per_family_info[0]
@@ -1004,7 +1018,10 @@ class TestExpandBuildConfigs(unittest.TestCase):
         """Without test_runner: label, default runner labels are used."""
         targets = cm.TargetSelection(linux_families=["gfx908"])
         result = cm.expand_build_configs(
-            targets=targets, ci_inputs=self._inputs(), test_type="quick"
+            targets=targets,
+            ci_inputs=self._inputs(),
+            test_type="quick",
+            git_context=cm.GitContext(),
         )
         self.assertIsNotNone(result.linux)
         entry = result.linux.per_family_info[0]
@@ -1022,6 +1039,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             targets=targets,
             ci_inputs=self._inputs(event_name="schedule", build_variant="asan"),
             test_type="quick",
+            git_context=cm.GitContext(),
         )
         entry = result.linux.per_family_info[0]
         self.assertIn("sandbox", entry["test-runs-on"])
@@ -1031,6 +1049,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             targets=targets,
             ci_inputs=self._inputs(event_name="pull_request", build_variant="asan"),
             test_type="quick",
+            git_context=cm.GitContext(),
         )
         entry = result.linux.per_family_info[0]
         self.assertEqual(entry["test-runs-on"], "")
@@ -1260,12 +1279,13 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
 
         # Verify we have 3 labels for 1-gpu
         labels = gfx94x_linux["test-runs-on-labels"]
-        self.assertEqual(len(labels), 2)
+        self.assertEqual(len(labels), 3)
 
         # Verify label names
         label_names = [l["label"] for l in labels]
         self.assertIn("linux-gfx942-1gpu-ccs-ossci-rocm", label_names)
         self.assertIn("linux-gfx942-1gpu-core42-ossci-rocm", label_names)
+        self.assertIn("linux-gfx942-1gpu-ossci-rocm", label_names)
 
         # Verify weights sum to ~1.0
         total_weight = sum(l["weight"] for l in labels)
@@ -1304,7 +1324,9 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
 
         # Mock random.random() to return 0.1 (< 0.369 first weight)
         with patch("random.random", return_value=0.1):
-            builds = cm.expand_build_configs(targets, ci_inputs, test_type="quick")
+            builds = cm.expand_build_configs(
+                targets, ci_inputs, test_type="quick", git_context=cm.GitContext()
+            )
 
         self.assertIsNotNone(builds.linux)
         # Check that the first label was selected
@@ -1326,7 +1348,9 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
 
         # Mock random.random() to return 0.4 (>= 0.369, < 0.455)
         with patch("random.random", return_value=0.4):
-            builds = cm.expand_build_configs(targets, ci_inputs, test_type="quick")
+            builds = cm.expand_build_configs(
+                targets, ci_inputs, test_type="quick", git_context=cm.GitContext()
+            )
 
         self.assertIsNotNone(builds.linux)
         # Check that the second label was selected
@@ -1348,7 +1372,9 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
 
         # Mock random.random() to return 0.5 (>= 0.369+0.086=0.455)
         with patch("random.random", return_value=0.5):
-            builds = cm.expand_build_configs(targets, ci_inputs, test_type="quick")
+            builds = cm.expand_build_configs(
+                targets, ci_inputs, test_type="quick", git_context=cm.GitContext()
+            )
 
         self.assertIsNotNone(builds.linux)
         # Check that the third label was selected
@@ -1371,7 +1397,9 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
 
         # Run multiple times to ensure consistency
         for _ in range(10):
-            builds = cm.expand_build_configs(targets, ci_inputs, test_type="full")
+            builds = cm.expand_build_configs(
+                targets, ci_inputs, test_type="full", git_context=cm.GitContext()
+            )
             if builds.linux and builds.linux.per_family_info:
                 gfx103x_info = builds.linux.per_family_info[0]
                 # Should always use the primary label

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1370,8 +1370,7 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         )
         targets = cm.TargetSelection(linux_families=["gfx94x"])
 
-        # Mock random.random() to return 0.5 (>= 0.369+0.086=0.455)
-        with patch("random.random", return_value=0.5):
+        with patch("random.random", return_value=0.9):
             builds = cm.expand_build_configs(
                 targets, ci_inputs, test_type="quick", git_context=cm.GitContext()
             )
@@ -1380,7 +1379,7 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         # Check that the third label was selected
         gfx94x_info = builds.linux.per_family_info[0]
         self.assertEqual(
-            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-core42-ossci-rocm"
+            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm"
         )
 
     def test_families_without_multi_label_use_primary_only(self):


### PR DESCRIPTION
As we are determining core42 regression issues, we want to make the vultr runner run for submodule updates (to provide stability)

This is temporary until we resolve core42 issues