### PR TITLE
Run PyTorch tests in multi-arch release workflows

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -64,9 +64,9 @@ on:
         default: "none"
       test_amdgpu_families:
         description: >-
-          Semicolon-separated AMD GPU families to run quick tests for after a
+          Semicolon-separated AMD GPU families to run tests for after a
           successful build. Use 'auto' to test built families, or 'none' to
-          skip quick tests.
+          skip tests.
         type: string
         default: "auto"
   workflow_dispatch:
@@ -116,9 +116,9 @@ on:
         default: none
       test_amdgpu_families:
         description: >-
-          Semicolon-separated AMD GPU families to run quick tests for after a
+          Semicolon-separated AMD GPU families to run tests for after a
           successful build. Use 'auto' to test built families, or 'none' to
-          skip quick tests.
+          skip tests.
         type: string
         default: "auto"
 
@@ -386,8 +386,7 @@ jobs:
           python build_tools/github_actions/configure_pytorch_test_matrix.py \
             --build-amdgpu-families "${{ inputs.amdgpu_families }}" \
             --test-amdgpu-families "${{ inputs.test_amdgpu_families }}" \
-            --platform linux \
-            --package-index-url "${{ needs.build_pytorch_wheels.outputs.package_index_url }}"
+            --platform linux
 
   test_pytorch_wheels:
     name: Test | ${{ matrix.amdgpu_family }} | ${{ matrix.test_runs_on }}
@@ -406,7 +405,7 @@ jobs:
     with:
       amdgpu_family: ${{ matrix.amdgpu_family }}
       test_runs_on: ${{ matrix.test_runs_on }}
-      package_index_url: ${{ matrix.package_index_url }}
+      package_index_url: ${{ needs.build_pytorch_wheels.outputs.package_index_url }}
       python_version: ${{ inputs.python_version }}
       torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}
       # TODO(#5110): pass manifest_url here and let test_pytorch_wheels.yml use

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -62,6 +62,13 @@ on:
         description: "Compiler cache type ('none', 'sccache', or 'ccache')"
         type: string
         default: "none"
+      test_amdgpu_families:
+        description: >-
+          Semicolon-separated AMD GPU families to run quick tests for after a
+          successful build. Use 'auto' to test built families, or 'none' to
+          skip quick tests.
+        type: string
+        default: "auto"
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -107,6 +114,13 @@ on:
           - sccache
           - ccache
         default: none
+      test_amdgpu_families:
+        description: >-
+          Semicolon-separated AMD GPU families to run quick tests for after a
+          successful build. Use 'auto' to test built families, or 'none' to
+          skip quick tests.
+        type: string
+        default: "auto"
 
 run-name: Build Multi-Arch Linux PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref }})
 
@@ -134,6 +148,13 @@ jobs:
       SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
       SCCACHE_IDLE_TIMEOUT: "600"
       SCCACHE_LOG: warn
+    outputs:
+      torch_version: ${{ steps.pytorch-versions.outputs.torch_version }}
+      torchaudio_version: ${{ steps.pytorch-versions.outputs.torchaudio_version }}
+      apex_version: ${{ steps.pytorch-versions.outputs.apex_version }}
+      torchvision_version: ${{ steps.pytorch-versions.outputs.torchvision_version }}
+      triton_version: ${{ steps.pytorch-versions.outputs.triton_version }}
+      package_index_url: ${{ steps.publish-pytorch-wheels.outputs.package_index_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -322,13 +343,76 @@ jobs:
           echo "Post-split contents of ${{ env.PACKAGE_DIST_DIR }}:"
           ls -lh "${{ env.PACKAGE_DIST_DIR }}/"
 
+      # TODO(#5110): Once manifest-driven builds land, write these outputs from
+      # the manifest and keep wheel scanning as a validation step that the build
+      # produced the requested package versions.
+      - name: Write PyTorch package version outputs
+        id: pytorch-versions
+        run: |
+          python build_tools/github_actions/write_torch_versions.py \
+            --dist-dir ${{ env.PACKAGE_DIST_DIR }}
+
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure_aws_artifacts_credentials
         with:
           release_type: ${{ inputs.release_type }}
 
       - name: Upload PyTorch wheels to release bucket
+        id: publish-pytorch-wheels
         run: |
           python build_tools/github_actions/publish_pytorch_to_release_bucket.py \
             --source-dir="${{ env.PACKAGE_DIST_DIR }}" \
             --release-type="${{ inputs.release_type }}"
+
+  configure_pytorch_tests:
+    name: Configure PyTorch Tests
+    needs: [build_pytorch_wheels]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      enabled: ${{ steps.configure.outputs.enabled }}
+      matrix: ${{ steps.configure.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      - name: Configure PyTorch test matrix
+        id: configure
+        run: |
+          python build_tools/github_actions/configure_pytorch_test_matrix.py \
+            --build-amdgpu-families "${{ inputs.amdgpu_families }}" \
+            --test-amdgpu-families "${{ inputs.test_amdgpu_families }}" \
+            --platform linux \
+            --package-index-url "${{ needs.build_pytorch_wheels.outputs.package_index_url }}"
+
+  test_pytorch_wheels:
+    name: Test | ${{ matrix.amdgpu_family }} | ${{ matrix.test_runs_on }}
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.configure_pytorch_tests.outputs.enabled == 'true'
+      }}
+    needs: [build_pytorch_wheels, configure_pytorch_tests]
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.configure_pytorch_tests.outputs.matrix) }}
+    uses: ./.github/workflows/test_pytorch_wheels.yml
+    with:
+      amdgpu_family: ${{ matrix.amdgpu_family }}
+      test_runs_on: ${{ matrix.test_runs_on }}
+      package_index_url: ${{ matrix.package_index_url }}
+      python_version: ${{ inputs.python_version }}
+      torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}
+      # TODO(#5110): pass manifest_url here and let test_pytorch_wheels.yml use
+      # checkout_from_manifest.py --no-hipify --no-submodules so tests use the
+      # exact source commit that produced the package under test.
+      pytorch_git_ref: ${{ inputs.pytorch_git_ref }}
+      multi_arch: true
+      repository: ${{ inputs.repository || github.repository }}
+      ref: ${{ inputs.ref }}

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -371,7 +371,6 @@ jobs:
     permissions:
       contents: read
     outputs:
-      enabled: ${{ steps.configure.outputs.enabled }}
       matrix: ${{ steps.configure.outputs.matrix }}
     steps:
       - name: Checkout
@@ -390,11 +389,6 @@ jobs:
 
   test_pytorch_wheels:
     name: Test | ${{ matrix.amdgpu_family }} | ${{ matrix.test_runs_on }}
-    if: >-
-      ${{
-        !cancelled() &&
-        needs.configure_pytorch_tests.outputs.enabled == 'true'
-      }}
     needs: [build_pytorch_wheels, configure_pytorch_tests]
     permissions:
       contents: read

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -370,6 +370,7 @@ jobs:
     permissions:
       contents: read
     outputs:
+      enabled: ${{ steps.configure.outputs.enabled }}
       matrix: ${{ steps.configure.outputs.matrix }}
     steps:
       - name: Checkout
@@ -388,6 +389,7 @@ jobs:
 
   test_pytorch_wheels:
     name: Test | ${{ matrix.amdgpu_family }} | ${{ matrix.test_runs_on }}
+    if: ${{ needs.configure_pytorch_tests.outputs.enabled == 'true' }}
     needs: [build_pytorch_wheels, configure_pytorch_tests]
     permissions:
       contents: read

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -30,6 +30,13 @@ on:
           build time via cmake/therock_amdgpu_targets.cmake.
         type: string
         required: true
+      test_amdgpu_families:
+        description: >-
+          Semicolon-separated AMD GPU families to run tests for (e.g.
+          'gfx94X-dcgpu'). Use 'auto' to test built families, or 'none' to skip
+          tests.
+        type: string
+        default: "auto"
       python_version:
         description: Python version to build wheels for.
         type: string
@@ -62,13 +69,6 @@ on:
         description: "Compiler cache type ('none', 'sccache', or 'ccache')"
         type: string
         default: "none"
-      test_amdgpu_families:
-        description: >-
-          Semicolon-separated AMD GPU families to run tests for after a
-          successful build. Use 'auto' to test built families, or 'none' to
-          skip tests.
-        type: string
-        default: "auto"
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -78,6 +78,13 @@ on:
           build time via cmake/therock_amdgpu_targets.cmake.
         type: string
         required: true
+      test_amdgpu_families:
+        description: >-
+          Semicolon-separated AMD GPU families to run tests for (e.g.
+          'gfx94X-dcgpu'). Use 'auto' to test built families, or 'none' to skip
+          tests.
+        type: string
+        default: "auto"
       python_version:
         description: Python version to build wheels for (for example, "3.12").
         type: string
@@ -114,13 +121,6 @@ on:
           - sccache
           - ccache
         default: none
-      test_amdgpu_families:
-        description: >-
-          Semicolon-separated AMD GPU families to run tests for after a
-          successful build. Use 'auto' to test built families, or 'none' to
-          skip tests.
-        type: string
-        default: "auto"
 
 run-name: Build Multi-Arch Linux PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref }})
 
@@ -366,7 +366,6 @@ jobs:
 
   configure_pytorch_tests:
     name: Configure PyTorch Tests
-    needs: [build_pytorch_wheels]
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -413,7 +413,6 @@ jobs:
     permissions:
       contents: read
     outputs:
-      enabled: ${{ steps.configure.outputs.enabled }}
       matrix: ${{ steps.configure.outputs.matrix }}
     steps:
       - name: Checkout
@@ -432,11 +431,6 @@ jobs:
 
   test_pytorch_wheels:
     name: Test | ${{ matrix.amdgpu_family }} | ${{ matrix.test_runs_on }}
-    if: >-
-      ${{
-        !cancelled() &&
-        needs.configure_pytorch_tests.outputs.enabled == 'true'
-      }}
     needs: [build_pytorch_wheels, configure_pytorch_tests]
     permissions:
       contents: read

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -412,6 +412,7 @@ jobs:
     permissions:
       contents: read
     outputs:
+      enabled: ${{ steps.configure.outputs.enabled }}
       matrix: ${{ steps.configure.outputs.matrix }}
     steps:
       - name: Checkout
@@ -430,6 +431,7 @@ jobs:
 
   test_pytorch_wheels:
     name: Test | ${{ matrix.amdgpu_family }} | ${{ matrix.test_runs_on }}
+    if: ${{ needs.configure_pytorch_tests.outputs.enabled == 'true' }}
     needs: [build_pytorch_wheels, configure_pytorch_tests]
     permissions:
       contents: read

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -32,6 +32,13 @@ on:
           build time via cmake/therock_amdgpu_targets.cmake.
         type: string
         required: true
+      test_amdgpu_families:
+        description: >-
+          Semicolon-separated AMD GPU families to run tests for (e.g.
+          'gfx120X-all'). Use 'auto' to test built families, or 'none' to skip
+          tests.
+        type: string
+        default: "auto"
       python_version:
         description: Python version to build wheels for.
         type: string
@@ -64,13 +71,6 @@ on:
         description: "Compiler cache type ('none', 'sccache', or 'ccache')"
         type: string
         default: "none"
-      test_amdgpu_families:
-        description: >-
-          Semicolon-separated AMD GPU families to run tests for after a
-          successful build. Use 'auto' to test built families, or 'none' to
-          skip tests.
-        type: string
-        default: "auto"
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -80,6 +80,13 @@ on:
           build time via cmake/therock_amdgpu_targets.cmake.
         type: string
         required: true
+      test_amdgpu_families:
+        description: >-
+          Semicolon-separated AMD GPU families to run tests for (e.g.
+          'gfx120X-all'). Use 'auto' to test built families, or 'none' to skip
+          tests.
+        type: string
+        default: "auto"
       python_version:
         description: Python version to build wheels for (for example, "3.12").
         type: string
@@ -116,13 +123,6 @@ on:
           - sccache
           - ccache
         default: none
-      test_amdgpu_families:
-        description: >-
-          Semicolon-separated AMD GPU families to run tests for after a
-          successful build. Use 'auto' to test built families, or 'none' to
-          skip tests.
-        type: string
-        default: "auto"
 
 run-name: Build Multi-Arch Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref }})
 
@@ -408,7 +408,6 @@ jobs:
 
   configure_pytorch_tests:
     name: Configure PyTorch Tests
-    needs: [build_pytorch_wheels]
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -66,9 +66,9 @@ on:
         default: "none"
       test_amdgpu_families:
         description: >-
-          Semicolon-separated AMD GPU families to run quick tests for after a
+          Semicolon-separated AMD GPU families to run tests for after a
           successful build. Use 'auto' to test built families, or 'none' to
-          skip quick tests.
+          skip tests.
         type: string
         default: "auto"
   workflow_dispatch:
@@ -118,9 +118,9 @@ on:
         default: none
       test_amdgpu_families:
         description: >-
-          Semicolon-separated AMD GPU families to run quick tests for after a
+          Semicolon-separated AMD GPU families to run tests for after a
           successful build. Use 'auto' to test built families, or 'none' to
-          skip quick tests.
+          skip tests.
         type: string
         default: "auto"
 
@@ -428,8 +428,7 @@ jobs:
           python build_tools/github_actions/configure_pytorch_test_matrix.py \
             --build-amdgpu-families "${{ inputs.amdgpu_families }}" \
             --test-amdgpu-families "${{ inputs.test_amdgpu_families }}" \
-            --platform windows \
-            --package-index-url "${{ needs.build_pytorch_wheels.outputs.package_index_url }}"
+            --platform windows
 
   test_pytorch_wheels:
     name: Test | ${{ matrix.amdgpu_family }} | ${{ matrix.test_runs_on }}
@@ -448,7 +447,7 @@ jobs:
     with:
       amdgpu_family: ${{ matrix.amdgpu_family }}
       test_runs_on: ${{ matrix.test_runs_on }}
-      package_index_url: ${{ matrix.package_index_url }}
+      package_index_url: ${{ needs.build_pytorch_wheels.outputs.package_index_url }}
       python_version: ${{ inputs.python_version }}
       torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}
       # TODO(#5110): pass manifest_url here and let test_pytorch_wheels.yml use

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -64,6 +64,13 @@ on:
         description: "Compiler cache type ('none', 'sccache', or 'ccache')"
         type: string
         default: "none"
+      test_amdgpu_families:
+        description: >-
+          Semicolon-separated AMD GPU families to run quick tests for after a
+          successful build. Use 'auto' to test built families, or 'none' to
+          skip quick tests.
+        type: string
+        default: "auto"
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -109,6 +116,13 @@ on:
           - sccache
           - ccache
         default: none
+      test_amdgpu_families:
+        description: >-
+          Semicolon-separated AMD GPU families to run quick tests for after a
+          successful build. Use 'auto' to test built families, or 'none' to
+          skip quick tests.
+        type: string
+        default: "auto"
 
 run-name: Build Multi-Arch Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref }})
 
@@ -134,6 +148,11 @@ jobs:
       SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
       SCCACHE_IDLE_TIMEOUT: "600"
       SCCACHE_LOG: warn
+    outputs:
+      torch_version: ${{ steps.pytorch-versions.outputs.torch_version }}
+      torchaudio_version: ${{ steps.pytorch-versions.outputs.torchaudio_version }}
+      torchvision_version: ${{ steps.pytorch-versions.outputs.torchvision_version }}
+      package_index_url: ${{ steps.publish-pytorch-wheels.outputs.package_index_url }}
     defaults:
       run:
         # Note: there are mixed uses of 'bash' (this default) and 'cmd' below
@@ -366,13 +385,76 @@ jobs:
           echo "Post-split contents of ${DIST_DIR}:"
           ls -lh "${DIST_DIR}/"
 
+      # TODO(#5110): Once manifest-driven builds land, write these outputs from
+      # the manifest and keep wheel scanning as a validation step that the build
+      # produced the requested package versions.
+      - name: Write PyTorch package version outputs
+        id: pytorch-versions
+        shell: cmd
+        run: |
+          python build_tools/github_actions/write_torch_versions.py --dist-dir ${{ env.PACKAGE_DIST_DIR }}
+
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure_aws_artifacts_credentials
         with:
           release_type: ${{ inputs.release_type }}
 
       - name: Upload PyTorch wheels to release bucket
+        id: publish-pytorch-wheels
         run: |
           python build_tools/github_actions/publish_pytorch_to_release_bucket.py \
             --source-dir="${{ env.PACKAGE_DIST_DIR }}" \
             --release-type="${{ inputs.release_type }}"
+
+  configure_pytorch_tests:
+    name: Configure PyTorch Tests
+    needs: [build_pytorch_wheels]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      enabled: ${{ steps.configure.outputs.enabled }}
+      matrix: ${{ steps.configure.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      - name: Configure PyTorch test matrix
+        id: configure
+        run: |
+          python build_tools/github_actions/configure_pytorch_test_matrix.py \
+            --build-amdgpu-families "${{ inputs.amdgpu_families }}" \
+            --test-amdgpu-families "${{ inputs.test_amdgpu_families }}" \
+            --platform windows \
+            --package-index-url "${{ needs.build_pytorch_wheels.outputs.package_index_url }}"
+
+  test_pytorch_wheels:
+    name: Test | ${{ matrix.amdgpu_family }} | ${{ matrix.test_runs_on }}
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.configure_pytorch_tests.outputs.enabled == 'true'
+      }}
+    needs: [build_pytorch_wheels, configure_pytorch_tests]
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.configure_pytorch_tests.outputs.matrix) }}
+    uses: ./.github/workflows/test_pytorch_wheels.yml
+    with:
+      amdgpu_family: ${{ matrix.amdgpu_family }}
+      test_runs_on: ${{ matrix.test_runs_on }}
+      package_index_url: ${{ matrix.package_index_url }}
+      python_version: ${{ inputs.python_version }}
+      torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}
+      # TODO(#5110): pass manifest_url here and let test_pytorch_wheels.yml use
+      # checkout_from_manifest.py --no-hipify --no-submodules so tests use the
+      # exact source commit that produced the package under test.
+      pytorch_git_ref: ${{ inputs.pytorch_git_ref }}
+      multi_arch: true
+      repository: ${{ inputs.repository || github.repository }}
+      ref: ${{ inputs.ref }}

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -174,6 +174,9 @@ jobs:
       # so we have the right set of test source files. We _probably_ don't need
       # to run HIPIFY, apply patches, or fetch submodules, so we skip those
       # steps to save time.
+      # TODO(#5110): Accept manifest_url and use checkout_from_manifest.py
+      # --no-hipify --no-submodules so tests use the exact source commit and
+      # related repository pins that produced the package under test.
       - name: Checkout PyTorch Source Repos from nightly branch
         if: ${{ (inputs.pytorch_git_ref == 'nightly') }}
         run: |

--- a/build_tools/github_actions/configure_pytorch_test_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_test_matrix.py
@@ -25,12 +25,8 @@ from github_actions.amdgpu_family_matrix import get_all_families_for_trigger_typ
 from github_actions.github_actions_api import gha_set_output
 
 
-SKIP_TEST_VALUES = {"none", "skip", "false", "off", "0"}
-AUTO_TEST_VALUES = {"", "auto", "built"}
-
-
 def split_families(value: str) -> list[str]:
-    return [item.strip() for item in value.replace(";", " ").split() if item.strip()]
+    return [f.strip() for f in value.split(";") if f.strip()]
 
 
 def find_amdgpu_family(*, requested_family: str, platform: str) -> tuple[str, str, str]:
@@ -60,6 +56,7 @@ def build_test_matrix(
     amdgpu_families: list[str],
     platform: str,
 ) -> dict[str, list[dict[str, str]]]:
+    print(f"Requested {platform} AMDGPU families: {amdgpu_families}")
     include: list[dict[str, str]] = []
     seen_families: set[str] = set()
     for requested_family in amdgpu_families:
@@ -75,34 +72,15 @@ def build_test_matrix(
             print(f"Skipping {matrix_family}: no {platform} test runner is configured")
             continue
 
+        print(f"Including {test_family}: testing on {test_runs_on}")
         include.append({"amdgpu_family": test_family, "test_runs_on": test_runs_on})
 
     return {"include": include}
 
 
-def resolve_requested_test_families(
-    *, build_amdgpu_families: str, test_amdgpu_families: str
-) -> list[str]:
-    """Return the AMDGPU families to test.
-
-    Empty/auto/built test input means "test all built families". Explicit
-    none/skip disables tests.
-    """
-    build_families = split_families(build_amdgpu_families)
-    test_value = test_amdgpu_families.strip()
-    test_value_lower = test_value.lower()
-    if test_value_lower in SKIP_TEST_VALUES:
-        return []
-    if test_value_lower in AUTO_TEST_VALUES:
-        return build_families
-    return split_families(test_amdgpu_families)
-
-
 def emit_outputs(matrix: dict[str, list[dict[str, str]]]) -> None:
-    include = matrix["include"]
     gha_set_output(
         {
-            "enabled": str(bool(include)).lower(),
             "matrix": json.dumps(matrix, separators=(",", ":")),
         }
     )
@@ -113,15 +91,14 @@ def main(argv: list[str]) -> None:
     parser.add_argument(
         "--build-amdgpu-families",
         required=True,
-        help="Semicolon- or space-separated AMDGPU families that were built.",
+        help="Semicolon-separated AMDGPU families that were built.",
     )
     parser.add_argument(
         "--test-amdgpu-families",
         default="",
         help=(
-            "Semicolon- or space-separated AMDGPU families to test. "
-            "Use 'auto' or leave empty to test built families. Use 'none' "
-            "to skip tests."
+            "Semicolon-separated AMDGPU families to test. Use 'auto' or leave "
+            "empty to test built families. Use 'none' to skip tests."
         ),
     )
     parser.add_argument(
@@ -131,10 +108,16 @@ def main(argv: list[str]) -> None:
         help="Test platform (default: current system).",
     )
     args = parser.parse_args(argv)
-    test_amdgpu_families = resolve_requested_test_families(
-        build_amdgpu_families=args.build_amdgpu_families,
-        test_amdgpu_families=args.test_amdgpu_families,
-    )
+
+    built_families = split_families(args.build_amdgpu_families)
+    test_families_arg = args.test_amdgpu_families.strip().lower()
+    if test_families_arg in ("", "auto", "built"):
+        test_amdgpu_families = built_families
+    elif test_families_arg in ("none", "skip"):
+        test_amdgpu_families = []
+    else:
+        test_amdgpu_families = split_families(args.test_amdgpu_families)
+
     matrix = build_test_matrix(
         amdgpu_families=test_amdgpu_families,
         platform=args.platform,

--- a/build_tools/github_actions/configure_pytorch_test_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_test_matrix.py
@@ -81,6 +81,7 @@ def build_test_matrix(
 def emit_outputs(matrix: dict[str, list[dict[str, str]]]) -> None:
     gha_set_output(
         {
+            "enabled": str(bool(matrix["include"])).lower(),
             "matrix": json.dumps(matrix, separators=(",", ":")),
         }
     )

--- a/build_tools/github_actions/configure_pytorch_test_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_test_matrix.py
@@ -2,12 +2,20 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Configure quick PyTorch wheel test jobs for multi-arch build workflows."""
+"""Configure PyTorch wheel test jobs for multi-arch build workflows.
+
+TODO(#5110): Extract the AMDGPU family -> test runner policy once JAX needs
+the same flow. Standalone workflow_dispatch runs can keep using raw family
+inputs, while coordinated CI/release runs should be able to pass the
+per-family test policy produced by configure_multi_arch_ci.py. That shared
+policy should also support named defaults such as "release" and "presubmit",
+plus explicit opt-in/opt-out family lists.
+"""
 
 import argparse
 import json
+import platform as platform_module
 import sys
-from dataclasses import dataclass
 from pathlib import Path
 
 _BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
@@ -21,28 +29,12 @@ SKIP_TEST_VALUES = {"none", "skip", "false", "off", "0"}
 AUTO_TEST_VALUES = {"", "auto", "built"}
 
 
-@dataclass(frozen=True)
-class PyTorchTestMatrixEntry:
-    amdgpu_family: str
-    test_runs_on: str
-    package_index_url: str
-
-    def to_dict(self) -> dict[str, str]:
-        return {
-            "amdgpu_family": self.amdgpu_family,
-            "test_runs_on": self.test_runs_on,
-            "package_index_url": self.package_index_url,
-        }
-
-
 def split_families(value: str) -> list[str]:
     return [item.strip() for item in value.replace(";", " ").split() if item.strip()]
 
 
-def find_amdgpu_family(
-    *, requested_family: str, platform: str
-) -> tuple[str, str, dict[str, object]]:
-    """Return test family, canonical matrix family, and platform info."""
+def find_amdgpu_family(*, requested_family: str, platform: str) -> tuple[str, str, str]:
+    """Return test family, canonical matrix family, and runner label."""
     requested_lower = requested_family.lower()
     matrix = get_all_families_for_trigger_types(["presubmit", "postsubmit", "nightly"])
     for key, info_for_key in matrix.items():
@@ -50,18 +42,13 @@ def find_amdgpu_family(
         if not platform_info:
             continue
 
-        family = platform_info.get("family")
-        if not isinstance(family, str):
-            continue
-
+        family = platform_info["family"]
         fetch_targets = platform_info.get("fetch-gfx-targets", [])
-        if not isinstance(fetch_targets, list):
-            fetch_targets = []
 
         if requested_lower == key.lower() or requested_lower == family.lower():
-            return family, family, platform_info
+            return family, family, platform_info["test-runs-on"]
         if requested_family in fetch_targets:
-            return requested_family, family, platform_info
+            return requested_family, family, platform_info["test-runs-on"]
 
     raise ValueError(
         f"No {platform} AMDGPU family entry found for {requested_family!r}"
@@ -72,17 +59,11 @@ def build_test_matrix(
     *,
     amdgpu_families: list[str],
     platform: str,
-    package_index_url: str,
 ) -> dict[str, list[dict[str, str]]]:
-    if not amdgpu_families:
-        return {"include": []}
-    if not package_index_url:
-        raise ValueError("--package-index-url is required when tests are enabled")
-
     include: list[dict[str, str]] = []
     seen_families: set[str] = set()
     for requested_family in amdgpu_families:
-        test_family, matrix_family, platform_info = find_amdgpu_family(
+        test_family, matrix_family, test_runs_on = find_amdgpu_family(
             requested_family=requested_family,
             platform=platform,
         )
@@ -90,20 +71,11 @@ def build_test_matrix(
             continue
         seen_families.add(test_family)
 
-        test_runs_on = platform_info.get("test-runs-on")
         if not test_runs_on:
             print(f"Skipping {matrix_family}: no {platform} test runner is configured")
             continue
-        if not isinstance(test_runs_on, str):
-            raise ValueError(f"{matrix_family}: test-runs-on must be a string")
 
-        include.append(
-            PyTorchTestMatrixEntry(
-                amdgpu_family=test_family,
-                test_runs_on=test_runs_on,
-                package_index_url=package_index_url,
-            ).to_dict()
-        )
+        include.append({"amdgpu_family": test_family, "test_runs_on": test_runs_on})
 
     return {"include": include}
 
@@ -114,7 +86,7 @@ def resolve_requested_test_families(
     """Return the AMDGPU families to test.
 
     Empty/auto/built test input means "test all built families". Explicit
-    none/skip disables quick tests.
+    none/skip disables tests.
     """
     build_families = split_families(build_amdgpu_families)
     test_value = test_amdgpu_families.strip()
@@ -136,7 +108,7 @@ def emit_outputs(matrix: dict[str, list[dict[str, str]]]) -> None:
     )
 
 
-def create_parser() -> argparse.ArgumentParser:
+def main(argv: list[str]) -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--build-amdgpu-families",
@@ -147,40 +119,26 @@ def create_parser() -> argparse.ArgumentParser:
         "--test-amdgpu-families",
         default="",
         help=(
-            "Semicolon- or space-separated AMDGPU families to quick-test. "
+            "Semicolon- or space-separated AMDGPU families to test. "
             "Use 'auto' or leave empty to test built families. Use 'none' "
-            "to skip quick tests."
+            "to skip tests."
         ),
     )
     parser.add_argument(
         "--platform",
         choices=["linux", "windows"],
-        required=True,
-        help="Test platform.",
+        default=platform_module.system().lower(),
+        help="Test platform (default: current system).",
     )
-    parser.add_argument(
-        "--package-index-url",
-        default="",
-        help="Package index URL for tests.",
-    )
-    return parser
-
-
-def main(argv: list[str]) -> None:
-    parser = create_parser()
     args = parser.parse_args(argv)
     test_amdgpu_families = resolve_requested_test_families(
         build_amdgpu_families=args.build_amdgpu_families,
         test_amdgpu_families=args.test_amdgpu_families,
     )
-    try:
-        matrix = build_test_matrix(
-            amdgpu_families=test_amdgpu_families,
-            platform=args.platform,
-            package_index_url=args.package_index_url,
-        )
-    except ValueError as e:
-        parser.error(str(e))
+    matrix = build_test_matrix(
+        amdgpu_families=test_amdgpu_families,
+        platform=args.platform,
+    )
     emit_outputs(matrix)
 
 

--- a/build_tools/github_actions/configure_pytorch_test_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_test_matrix.py
@@ -13,7 +13,6 @@ plus explicit opt-in/opt-out family lists.
 """
 
 import argparse
-from dataclasses import dataclass
 import json
 import platform as platform_module
 import sys
@@ -27,46 +26,21 @@ from github_actions.github_actions_api import gha_set_output
 
 
 def split_families(value: str) -> list[str]:
-    return [f.strip() for f in value.split(";") if f.strip()]
+    return list(dict.fromkeys(f.strip() for f in value.split(";") if f.strip()))
 
 
-@dataclass(frozen=True)
-class AmdgpuFamilyMatch:
-    """AMDGPU test configuration resolved from a workflow family request."""
-
-    test_family: str
-    matrix_family: str
-    test_runs_on: str
-
-
-def find_amdgpu_family(*, requested_family: str, platform: str) -> AmdgpuFamilyMatch:
-    requested_lower = requested_family.lower()
+def find_test_runs_on(*, amdgpu_family: str, platform: str) -> str:
     matrix = get_all_families_for_trigger_types(["presubmit", "postsubmit", "nightly"])
-    for key, info_for_key in matrix.items():
+    for info_for_key in matrix.values():
         platform_info = info_for_key.get(platform)
         if not platform_info:
             continue
 
         family = platform_info["family"]
-        fetch_targets = platform_info.get("fetch-gfx-targets", [])
+        if amdgpu_family.lower() == family.lower():
+            return platform_info["test-runs-on"]
 
-        if requested_lower == key.lower() or requested_lower == family.lower():
-            return AmdgpuFamilyMatch(
-                test_family=family,
-                matrix_family=family,
-                test_runs_on=platform_info["test-runs-on"],
-            )
-        for fetch_target in fetch_targets:
-            if requested_lower == fetch_target.lower():
-                return AmdgpuFamilyMatch(
-                    test_family=fetch_target,
-                    matrix_family=family,
-                    test_runs_on=platform_info["test-runs-on"],
-                )
-
-    raise ValueError(
-        f"No {platform} AMDGPU family entry found for {requested_family!r}"
-    )
+    raise ValueError(f"No {platform} AMDGPU family entry found for {amdgpu_family!r}")
 
 
 def build_test_matrix(
@@ -76,30 +50,23 @@ def build_test_matrix(
 ) -> dict[str, list[dict[str, str]]]:
     print(f"Requested {platform} AMDGPU families: {amdgpu_families}")
     include: list[dict[str, str]] = []
-    seen_families: set[str] = set()
     for requested_family in amdgpu_families:
-        family_match = find_amdgpu_family(
-            requested_family=requested_family,
+        test_runs_on = find_test_runs_on(
+            amdgpu_family=requested_family,
             platform=platform,
         )
-        if family_match.test_family in seen_families:
-            continue
-        seen_families.add(family_match.test_family)
 
-        if not family_match.test_runs_on:
+        if not test_runs_on:
             print(
-                f"Skipping {family_match.matrix_family}: "
-                f"no {platform} test runner is configured"
+                f"Skipping {requested_family}: no {platform} test runner is configured"
             )
             continue
 
-        print(
-            f"Including {family_match.test_family}: testing on {family_match.test_runs_on}"
-        )
+        print(f"Including {requested_family}: testing on {test_runs_on}")
         include.append(
             {
-                "amdgpu_family": family_match.test_family,
-                "test_runs_on": family_match.test_runs_on,
+                "amdgpu_family": requested_family,
+                "test_runs_on": test_runs_on,
             }
         )
 

--- a/build_tools/github_actions/configure_pytorch_test_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_test_matrix.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Configure quick PyTorch wheel test jobs for multi-arch build workflows."""
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_BUILD_TOOLS_DIR))
+
+from github_actions.amdgpu_family_matrix import get_all_families_for_trigger_types
+from github_actions.github_actions_api import gha_set_output
+
+
+SKIP_TEST_VALUES = {"none", "skip", "false", "off", "0"}
+AUTO_TEST_VALUES = {"", "auto", "built"}
+
+
+@dataclass(frozen=True)
+class PyTorchTestMatrixEntry:
+    amdgpu_family: str
+    test_runs_on: str
+    package_index_url: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "amdgpu_family": self.amdgpu_family,
+            "test_runs_on": self.test_runs_on,
+            "package_index_url": self.package_index_url,
+        }
+
+
+def split_families(value: str) -> list[str]:
+    return [item.strip() for item in value.replace(";", " ").split() if item.strip()]
+
+
+def find_amdgpu_family(
+    *, requested_family: str, platform: str
+) -> tuple[str, str, dict[str, object]]:
+    """Return test family, canonical matrix family, and platform info."""
+    requested_lower = requested_family.lower()
+    matrix = get_all_families_for_trigger_types(["presubmit", "postsubmit", "nightly"])
+    for key, info_for_key in matrix.items():
+        platform_info = info_for_key.get(platform)
+        if not platform_info:
+            continue
+
+        family = platform_info.get("family")
+        if not isinstance(family, str):
+            continue
+
+        fetch_targets = platform_info.get("fetch-gfx-targets", [])
+        if not isinstance(fetch_targets, list):
+            fetch_targets = []
+
+        if requested_lower == key.lower() or requested_lower == family.lower():
+            return family, family, platform_info
+        if requested_family in fetch_targets:
+            return requested_family, family, platform_info
+
+    raise ValueError(
+        f"No {platform} AMDGPU family entry found for {requested_family!r}"
+    )
+
+
+def build_test_matrix(
+    *,
+    amdgpu_families: list[str],
+    platform: str,
+    package_index_url: str,
+) -> dict[str, list[dict[str, str]]]:
+    if not amdgpu_families:
+        return {"include": []}
+    if not package_index_url:
+        raise ValueError("--package-index-url is required when tests are enabled")
+
+    include: list[dict[str, str]] = []
+    seen_families: set[str] = set()
+    for requested_family in amdgpu_families:
+        test_family, matrix_family, platform_info = find_amdgpu_family(
+            requested_family=requested_family,
+            platform=platform,
+        )
+        if test_family in seen_families:
+            continue
+        seen_families.add(test_family)
+
+        test_runs_on = platform_info.get("test-runs-on")
+        if not test_runs_on:
+            print(f"Skipping {matrix_family}: no {platform} test runner is configured")
+            continue
+        if not isinstance(test_runs_on, str):
+            raise ValueError(f"{matrix_family}: test-runs-on must be a string")
+
+        include.append(
+            PyTorchTestMatrixEntry(
+                amdgpu_family=test_family,
+                test_runs_on=test_runs_on,
+                package_index_url=package_index_url,
+            ).to_dict()
+        )
+
+    return {"include": include}
+
+
+def resolve_requested_test_families(
+    *, build_amdgpu_families: str, test_amdgpu_families: str
+) -> list[str]:
+    """Return the AMDGPU families to test.
+
+    Empty/auto/built test input means "test all built families". Explicit
+    none/skip disables quick tests.
+    """
+    build_families = split_families(build_amdgpu_families)
+    test_value = test_amdgpu_families.strip()
+    test_value_lower = test_value.lower()
+    if test_value_lower in SKIP_TEST_VALUES:
+        return []
+    if test_value_lower in AUTO_TEST_VALUES:
+        return build_families
+    return split_families(test_amdgpu_families)
+
+
+def emit_outputs(matrix: dict[str, list[dict[str, str]]]) -> None:
+    include = matrix["include"]
+    gha_set_output(
+        {
+            "enabled": str(bool(include)).lower(),
+            "matrix": json.dumps(matrix, separators=(",", ":")),
+        }
+    )
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--build-amdgpu-families",
+        required=True,
+        help="Semicolon- or space-separated AMDGPU families that were built.",
+    )
+    parser.add_argument(
+        "--test-amdgpu-families",
+        default="",
+        help=(
+            "Semicolon- or space-separated AMDGPU families to quick-test. "
+            "Use 'auto' or leave empty to test built families. Use 'none' "
+            "to skip quick tests."
+        ),
+    )
+    parser.add_argument(
+        "--platform",
+        choices=["linux", "windows"],
+        required=True,
+        help="Test platform.",
+    )
+    parser.add_argument(
+        "--package-index-url",
+        default="",
+        help="Package index URL for tests.",
+    )
+    return parser
+
+
+def main(argv: list[str]) -> None:
+    parser = create_parser()
+    args = parser.parse_args(argv)
+    test_amdgpu_families = resolve_requested_test_families(
+        build_amdgpu_families=args.build_amdgpu_families,
+        test_amdgpu_families=args.test_amdgpu_families,
+    )
+    try:
+        matrix = build_test_matrix(
+            amdgpu_families=test_amdgpu_families,
+            platform=args.platform,
+            package_index_url=args.package_index_url,
+        )
+    except ValueError as e:
+        parser.error(str(e))
+    emit_outputs(matrix)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/build_tools/github_actions/configure_pytorch_test_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_test_matrix.py
@@ -13,6 +13,7 @@ plus explicit opt-in/opt-out family lists.
 """
 
 import argparse
+from dataclasses import dataclass
 import json
 import platform as platform_module
 import sys
@@ -29,8 +30,16 @@ def split_families(value: str) -> list[str]:
     return [f.strip() for f in value.split(";") if f.strip()]
 
 
-def find_amdgpu_family(*, requested_family: str, platform: str) -> tuple[str, str, str]:
-    """Return test family, canonical matrix family, and runner label."""
+@dataclass(frozen=True)
+class AmdgpuFamilyMatch:
+    """AMDGPU test configuration resolved from a workflow family request."""
+
+    test_family: str
+    matrix_family: str
+    test_runs_on: str
+
+
+def find_amdgpu_family(*, requested_family: str, platform: str) -> AmdgpuFamilyMatch:
     requested_lower = requested_family.lower()
     matrix = get_all_families_for_trigger_types(["presubmit", "postsubmit", "nightly"])
     for key, info_for_key in matrix.items():
@@ -42,9 +51,18 @@ def find_amdgpu_family(*, requested_family: str, platform: str) -> tuple[str, st
         fetch_targets = platform_info.get("fetch-gfx-targets", [])
 
         if requested_lower == key.lower() or requested_lower == family.lower():
-            return family, family, platform_info["test-runs-on"]
-        if requested_family in fetch_targets:
-            return requested_family, family, platform_info["test-runs-on"]
+            return AmdgpuFamilyMatch(
+                test_family=family,
+                matrix_family=family,
+                test_runs_on=platform_info["test-runs-on"],
+            )
+        for fetch_target in fetch_targets:
+            if requested_lower == fetch_target.lower():
+                return AmdgpuFamilyMatch(
+                    test_family=fetch_target,
+                    matrix_family=family,
+                    test_runs_on=platform_info["test-runs-on"],
+                )
 
     raise ValueError(
         f"No {platform} AMDGPU family entry found for {requested_family!r}"
@@ -60,20 +78,30 @@ def build_test_matrix(
     include: list[dict[str, str]] = []
     seen_families: set[str] = set()
     for requested_family in amdgpu_families:
-        test_family, matrix_family, test_runs_on = find_amdgpu_family(
+        family_match = find_amdgpu_family(
             requested_family=requested_family,
             platform=platform,
         )
-        if test_family in seen_families:
+        if family_match.test_family in seen_families:
             continue
-        seen_families.add(test_family)
+        seen_families.add(family_match.test_family)
 
-        if not test_runs_on:
-            print(f"Skipping {matrix_family}: no {platform} test runner is configured")
+        if not family_match.test_runs_on:
+            print(
+                f"Skipping {family_match.matrix_family}: "
+                f"no {platform} test runner is configured"
+            )
             continue
 
-        print(f"Including {test_family}: testing on {test_runs_on}")
-        include.append({"amdgpu_family": test_family, "test_runs_on": test_runs_on})
+        print(
+            f"Including {family_match.test_family}: testing on {family_match.test_runs_on}"
+        )
+        include.append(
+            {
+                "amdgpu_family": family_match.test_family,
+                "test_runs_on": family_match.test_runs_on,
+            }
+        )
 
     return {"include": include}
 
@@ -118,6 +146,12 @@ def main(argv: list[str]) -> None:
         test_amdgpu_families = []
     else:
         test_amdgpu_families = split_families(args.test_amdgpu_families)
+        for test_family in test_amdgpu_families:
+            if test_family.lower() in ("auto", "built", "none", "skip"):
+                raise ValueError(
+                    f"Test family control value {test_family!r} cannot be mixed "
+                    "with explicit AMDGPU families"
+                )
 
     matrix = build_test_matrix(
         amdgpu_families=test_amdgpu_families,

--- a/build_tools/github_actions/publish_pytorch_to_release_bucket.py
+++ b/build_tools/github_actions/publish_pytorch_to_release_bucket.py
@@ -32,8 +32,18 @@ sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 from _therock_utils.s3_buckets import get_release_bucket_config
 from _therock_utils.storage_backend import create_storage_backend
 from _therock_utils.storage_location import StorageLocation
+from github_actions.github_actions_api import gha_set_output
 
 logger = logging.getLogger(__name__)
+
+
+MULTI_ARCH_INDEX_URLS = {
+    # TODO: Move this release bucket to CDN/index URL mapping into
+    # build_tools/_therock_utils/s3_buckets.py.
+    "dev": "https://rocm.devreleases.amd.com/whl-multi-arch/",
+    "nightly": "https://rocm.nightlies.amd.com/whl-multi-arch/",
+    "prerelease": "https://rocm.prereleases.amd.com/whl-multi-arch/",
+}
 
 
 def main(argv: list[str]) -> None:
@@ -70,6 +80,7 @@ def main(argv: list[str]) -> None:
     logger.info("Uploaded %d wheel files", count)
     if count == 0:
         raise FileNotFoundError(f"No wheels found at {args.source_dir}")
+    gha_set_output({"package_index_url": MULTI_ARCH_INDEX_URLS[args.release_type]})
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
@@ -24,14 +24,12 @@ FAKE_FAMILY_MATRIX: FamilyMatrix = {
             "family": "gfxalpha-all",
             "fetch-gfx-targets": ["gfxalpha0"],
             "test-runs-on": "linux-alpha",
-        }
-    },
-    "gfxbeta": {
+        },
         "windows": {
-            "family": "gfxbeta-all",
-            "fetch-gfx-targets": ["gfxbeta0"],
-            "test-runs-on": "windows-beta",
-        }
+            "family": "gfxalpha-all",
+            "fetch-gfx-targets": ["gfxalpha0"],
+            "test-runs-on": "windows-alpha",
+        },
     },
     "gfxnorunner": {
         "linux": {
@@ -48,35 +46,24 @@ def _fake_family_matrix(_trigger_types: list[str]) -> FamilyMatrix:
 
 
 class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
-    def test_empty_family_list_disables_matrix(self) -> None:
+    def test_empty_family_list_returns_empty_matrix(self) -> None:
         matrix = m.build_test_matrix(
             amdgpu_families=[],
             platform="linux",
         )
         self.assertEqual(matrix, {"include": []})
 
-    def test_auto_uses_built_families(self) -> None:
-        test_families = m.resolve_requested_test_families(
-            build_amdgpu_families="gfx950",
-            test_amdgpu_families="auto",
-        )
-        self.assertEqual(test_families, ["gfx950"])
+    def test_known_family_without_runner_is_skipped(self) -> None:
+        with mock.patch.object(
+            m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
+        ):
+            matrix = m.build_test_matrix(
+                amdgpu_families=["gfxnorunner"],
+                platform="linux",
+            )
+        self.assertEqual(matrix, {"include": []})
 
-    def test_empty_test_families_uses_built_families(self) -> None:
-        test_families = m.resolve_requested_test_families(
-            build_amdgpu_families="gfx950",
-            test_amdgpu_families="",
-        )
-        self.assertEqual(test_families, ["gfx950"])
-
-    def test_none_skips_tests(self) -> None:
-        test_families = m.resolve_requested_test_families(
-            build_amdgpu_families="gfx950",
-            test_amdgpu_families="none",
-        )
-        self.assertEqual(test_families, [])
-
-    def test_gfx_target_builds_linux_test_matrix(self) -> None:
+    def test_gfx_target_builds_platform_test_matrix(self) -> None:
         with mock.patch.object(
             m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
         ):
@@ -84,6 +71,8 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
                 amdgpu_families=["gfxalpha0"],
                 platform="linux",
             )
+        # FAKE_FAMILY_MATRIX also has a windows-alpha runner. The Linux
+        # request should only use the Linux platform entry.
         self.assertEqual(
             matrix,
             {
@@ -95,36 +84,6 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
                 ]
             },
         )
-
-    def test_windows_target_builds_windows_test_matrix(self) -> None:
-        with mock.patch.object(
-            m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
-        ):
-            matrix = m.build_test_matrix(
-                amdgpu_families=["gfxbeta0"],
-                platform="windows",
-            )
-        self.assertEqual(
-            matrix,
-            {
-                "include": [
-                    {
-                        "amdgpu_family": "gfxbeta0",
-                        "test_runs_on": "windows-beta",
-                    }
-                ]
-            },
-        )
-
-    def test_known_family_without_runner_is_skipped(self) -> None:
-        with mock.patch.object(
-            m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
-        ):
-            matrix = m.build_test_matrix(
-                amdgpu_families=["gfxnorunner"],
-                platform="linux",
-            )
-        self.assertEqual(matrix, {"include": []})
 
     def test_unknown_family_errors(self) -> None:
         with mock.patch.object(
@@ -151,9 +110,43 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
             )
 
         outputs = gha_set_output.call_args.args[0]
-        self.assertEqual(outputs["enabled"], "true")
         matrix = json.loads(outputs["matrix"])
         self.assertEqual(matrix["include"][0]["amdgpu_family"], "gfxalpha0")
+
+    def test_main_auto_uses_built_families(self) -> None:
+        with mock.patch.object(
+            m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
+        ), mock.patch.object(m, "gha_set_output") as gha_set_output:
+            m.main(
+                [
+                    "--build-amdgpu-families",
+                    "gfxalpha0",
+                    "--test-amdgpu-families",
+                    "auto",
+                    "--platform",
+                    "linux",
+                ]
+            )
+
+        outputs = gha_set_output.call_args.args[0]
+        matrix = json.loads(outputs["matrix"])
+        self.assertEqual(matrix["include"][0]["amdgpu_family"], "gfxalpha0")
+
+    def test_main_none_skips_tests(self) -> None:
+        with mock.patch.object(m, "gha_set_output") as gha_set_output:
+            m.main(
+                [
+                    "--build-amdgpu-families",
+                    "gfxalpha0",
+                    "--test-amdgpu-families",
+                    "none",
+                    "--platform",
+                    "linux",
+                ]
+            )
+
+        outputs = gha_set_output.call_args.args[0]
+        self.assertEqual(json.loads(outputs["matrix"]), {"include": []})
 
     def test_real_family_matrix_resolves_gfx950(self) -> None:
         matrix = m.build_test_matrix(

--- a/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
@@ -1,0 +1,132 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, os.fspath(THIS_DIR.parent))
+sys.path.insert(0, os.fspath(THIS_DIR.parent.parent))
+
+import configure_pytorch_test_matrix as m
+
+
+class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
+    def test_empty_family_list_disables_matrix(self) -> None:
+        matrix = m.build_test_matrix(
+            amdgpu_families=[],
+            platform="linux",
+            package_index_url="https://example.com/whl-multi-arch/",
+        )
+        self.assertEqual(matrix, {"include": []})
+
+    def test_auto_uses_built_families(self) -> None:
+        test_families = m.resolve_requested_test_families(
+            build_amdgpu_families="gfx950",
+            test_amdgpu_families="auto",
+        )
+        self.assertEqual(test_families, ["gfx950"])
+
+    def test_empty_test_families_uses_built_families(self) -> None:
+        test_families = m.resolve_requested_test_families(
+            build_amdgpu_families="gfx950",
+            test_amdgpu_families="",
+        )
+        self.assertEqual(test_families, ["gfx950"])
+
+    def test_none_skips_quick_tests(self) -> None:
+        test_families = m.resolve_requested_test_families(
+            build_amdgpu_families="gfx950",
+            test_amdgpu_families="none",
+        )
+        self.assertEqual(test_families, [])
+
+    def test_gfx950_target_builds_linux_quick_test_matrix(self) -> None:
+        matrix = m.build_test_matrix(
+            amdgpu_families=["gfx950"],
+            platform="linux",
+            package_index_url="https://example.com/whl-multi-arch/",
+        )
+        self.assertEqual(
+            matrix,
+            {
+                "include": [
+                    {
+                        "amdgpu_family": "gfx950-dcgpu",
+                        "test_runs_on": "linux-gfx950-1gpu-ccs-ossci-rocm",
+                        "package_index_url": "https://example.com/whl-multi-arch/",
+                    }
+                ]
+            },
+        )
+
+    def test_windows_target_builds_windows_quick_test_matrix(self) -> None:
+        matrix = m.build_test_matrix(
+            amdgpu_families=["gfx1100"],
+            platform="windows",
+            package_index_url="https://example.com/whl-multi-arch/",
+        )
+        self.assertEqual(
+            matrix,
+            {
+                "include": [
+                    {
+                        "amdgpu_family": "gfx1100",
+                        "test_runs_on": "windows-gfx110X-gpu-rocm",
+                        "package_index_url": "https://example.com/whl-multi-arch/",
+                    }
+                ]
+            },
+        )
+
+    def test_known_family_without_runner_is_skipped(self) -> None:
+        matrix = m.build_test_matrix(
+            amdgpu_families=["gfx900"],
+            platform="linux",
+            package_index_url="https://example.com/whl-multi-arch/",
+        )
+        self.assertEqual(matrix, {"include": []})
+
+    def test_unknown_family_errors(self) -> None:
+        with self.assertRaisesRegex(ValueError, "not-a-family"):
+            m.build_test_matrix(
+                amdgpu_families=["not-a-family"],
+                platform="linux",
+                package_index_url="https://example.com/whl-multi-arch/",
+            )
+
+    def test_missing_package_index_url_errors_when_tests_enabled(self) -> None:
+        with self.assertRaisesRegex(ValueError, "--package-index-url"):
+            m.build_test_matrix(
+                amdgpu_families=["gfx950"],
+                platform="linux",
+                package_index_url="",
+            )
+
+    def test_main_writes_outputs(self) -> None:
+        with mock.patch.object(m, "gha_set_output") as gha_set_output:
+            m.main(
+                [
+                    "--build-amdgpu-families",
+                    "gfx950",
+                    "--test-amdgpu-families",
+                    "gfx950",
+                    "--platform",
+                    "linux",
+                    "--package-index-url",
+                    "https://example.com/whl-multi-arch/",
+                ]
+            )
+
+        outputs = gha_set_output.call_args.args[0]
+        self.assertEqual(outputs["enabled"], "true")
+        matrix = json.loads(outputs["matrix"])
+        self.assertEqual(matrix["include"][0]["amdgpu_family"], "gfx950-dcgpu")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
@@ -110,6 +110,7 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
             )
 
         outputs = gha_set_output.call_args.args[0]
+        self.assertEqual(outputs["enabled"], "true")
         matrix = json.loads(outputs["matrix"])
         self.assertEqual(matrix["include"][0]["amdgpu_family"], "gfxalpha0")
 
@@ -146,6 +147,7 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
             )
 
         outputs = gha_set_output.call_args.args[0]
+        self.assertEqual(outputs["enabled"], "false")
         self.assertEqual(json.loads(outputs["matrix"]), {"include": []})
 
     def test_real_family_matrix_resolves_gfx950(self) -> None:

--- a/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
@@ -22,19 +22,16 @@ FAKE_FAMILY_MATRIX: FamilyMatrix = {
     "gfxalpha": {
         "linux": {
             "family": "gfxalpha-all",
-            "fetch-gfx-targets": ["gfxalpha0"],
             "test-runs-on": "linux-alpha",
         },
         "windows": {
             "family": "gfxalpha-all",
-            "fetch-gfx-targets": ["gfxalpha0"],
             "test-runs-on": "windows-alpha",
         },
     },
     "gfxnorunner": {
         "linux": {
             "family": "gfxnorunner",
-            "fetch-gfx-targets": ["gfxnorunner0"],
             "test-runs-on": "",
         }
     },
@@ -63,22 +60,22 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
             )
         self.assertEqual(matrix, {"include": []})
 
-    def test_gfx_target_match_is_case_insensitive_and_platform_specific(self) -> None:
+    def test_family_match_is_platform_specific(self) -> None:
         with mock.patch.object(
             m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
         ):
             matrix = m.build_test_matrix(
-                amdgpu_families=["GFXALPHA0"],
+                amdgpu_families=["gfxalpha-all"],
                 platform="linux",
             )
         # FAKE_FAMILY_MATRIX also has a windows-alpha runner. The Linux
-        # request should only use the Linux platform entry and canonical target.
+        # request should only use the Linux platform entry and canonical family.
         self.assertEqual(
             matrix,
             {
                 "include": [
                     {
-                        "amdgpu_family": "gfxalpha0",
+                        "amdgpu_family": "gfxalpha-all",
                         "test_runs_on": "linux-alpha",
                     }
                 ]
@@ -101,9 +98,9 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
             m.main(
                 [
                     "--build-amdgpu-families",
-                    "gfxalpha0",
+                    "gfxalpha-all",
                     "--test-amdgpu-families",
-                    "gfxalpha0",
+                    "gfxalpha-all",
                     "--platform",
                     "linux",
                 ]
@@ -112,7 +109,7 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
         outputs = gha_set_output.call_args.args[0]
         self.assertEqual(outputs["enabled"], "true")
         matrix = json.loads(outputs["matrix"])
-        self.assertEqual(matrix["include"][0]["amdgpu_family"], "gfxalpha0")
+        self.assertEqual(matrix["include"][0]["amdgpu_family"], "gfxalpha-all")
 
     def test_main_auto_uses_built_families(self) -> None:
         with mock.patch.object(
@@ -121,7 +118,7 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
             m.main(
                 [
                     "--build-amdgpu-families",
-                    "gfxalpha0",
+                    "gfxalpha-all;gfxalpha-all",
                     "--test-amdgpu-families",
                     "auto",
                     "--platform",
@@ -131,16 +128,16 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
 
         outputs = gha_set_output.call_args.args[0]
         matrix = json.loads(outputs["matrix"])
-        self.assertEqual(matrix["include"][0]["amdgpu_family"], "gfxalpha0")
+        self.assertEqual(matrix["include"][0]["amdgpu_family"], "gfxalpha-all")
 
     def test_main_rejects_mixed_control_and_explicit_families(self) -> None:
         with self.assertRaisesRegex(ValueError, "cannot be mixed"):
             m.main(
                 [
                     "--build-amdgpu-families",
-                    "gfxalpha0",
+                    "gfxalpha-all",
                     "--test-amdgpu-families",
-                    "auto;gfxalpha0",
+                    "auto;gfxalpha-all",
                     "--platform",
                     "linux",
                 ]
@@ -151,7 +148,7 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
             m.main(
                 [
                     "--build-amdgpu-families",
-                    "gfxalpha0",
+                    "gfxalpha-all",
                     "--test-amdgpu-families",
                     "none",
                     "--platform",
@@ -163,9 +160,9 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
         self.assertEqual(outputs["enabled"], "false")
         self.assertEqual(json.loads(outputs["matrix"]), {"include": []})
 
-    def test_real_family_matrix_resolves_gfx950(self) -> None:
+    def test_real_family_matrix_finds_gfx950_runner(self) -> None:
         matrix = m.build_test_matrix(
-            amdgpu_families=["gfx950"],
+            amdgpu_families=["gfx950-dcgpu"],
             platform="linux",
         )
         include = matrix["include"]

--- a/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
@@ -15,12 +15,43 @@ sys.path.insert(0, os.fspath(THIS_DIR.parent.parent))
 import configure_pytorch_test_matrix as m
 
 
+FamilyMatrix = dict[str, dict[str, dict[str, object]]]
+
+
+FAKE_FAMILY_MATRIX: FamilyMatrix = {
+    "gfxalpha": {
+        "linux": {
+            "family": "gfxalpha-all",
+            "fetch-gfx-targets": ["gfxalpha0"],
+            "test-runs-on": "linux-alpha",
+        }
+    },
+    "gfxbeta": {
+        "windows": {
+            "family": "gfxbeta-all",
+            "fetch-gfx-targets": ["gfxbeta0"],
+            "test-runs-on": "windows-beta",
+        }
+    },
+    "gfxnorunner": {
+        "linux": {
+            "family": "gfxnorunner",
+            "fetch-gfx-targets": ["gfxnorunner0"],
+            "test-runs-on": "",
+        }
+    },
+}
+
+
+def _fake_family_matrix(_trigger_types: list[str]) -> FamilyMatrix:
+    return FAKE_FAMILY_MATRIX
+
+
 class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
     def test_empty_family_list_disables_matrix(self) -> None:
         matrix = m.build_test_matrix(
             amdgpu_families=[],
             platform="linux",
-            package_index_url="https://example.com/whl-multi-arch/",
         )
         self.assertEqual(matrix, {"include": []})
 
@@ -38,94 +69,101 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
         )
         self.assertEqual(test_families, ["gfx950"])
 
-    def test_none_skips_quick_tests(self) -> None:
+    def test_none_skips_tests(self) -> None:
         test_families = m.resolve_requested_test_families(
             build_amdgpu_families="gfx950",
             test_amdgpu_families="none",
         )
         self.assertEqual(test_families, [])
 
-    def test_gfx950_target_builds_linux_quick_test_matrix(self) -> None:
-        matrix = m.build_test_matrix(
-            amdgpu_families=["gfx950"],
-            platform="linux",
-            package_index_url="https://example.com/whl-multi-arch/",
-        )
+    def test_gfx_target_builds_linux_test_matrix(self) -> None:
+        with mock.patch.object(
+            m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
+        ):
+            matrix = m.build_test_matrix(
+                amdgpu_families=["gfxalpha0"],
+                platform="linux",
+            )
         self.assertEqual(
             matrix,
             {
                 "include": [
                     {
-                        "amdgpu_family": "gfx950-dcgpu",
-                        "test_runs_on": "linux-gfx950-1gpu-ccs-ossci-rocm",
-                        "package_index_url": "https://example.com/whl-multi-arch/",
+                        "amdgpu_family": "gfxalpha0",
+                        "test_runs_on": "linux-alpha",
                     }
                 ]
             },
         )
 
-    def test_windows_target_builds_windows_quick_test_matrix(self) -> None:
-        matrix = m.build_test_matrix(
-            amdgpu_families=["gfx1100"],
-            platform="windows",
-            package_index_url="https://example.com/whl-multi-arch/",
-        )
+    def test_windows_target_builds_windows_test_matrix(self) -> None:
+        with mock.patch.object(
+            m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
+        ):
+            matrix = m.build_test_matrix(
+                amdgpu_families=["gfxbeta0"],
+                platform="windows",
+            )
         self.assertEqual(
             matrix,
             {
                 "include": [
                     {
-                        "amdgpu_family": "gfx1100",
-                        "test_runs_on": "windows-gfx110X-gpu-rocm",
-                        "package_index_url": "https://example.com/whl-multi-arch/",
+                        "amdgpu_family": "gfxbeta0",
+                        "test_runs_on": "windows-beta",
                     }
                 ]
             },
         )
 
     def test_known_family_without_runner_is_skipped(self) -> None:
-        matrix = m.build_test_matrix(
-            amdgpu_families=["gfx900"],
-            platform="linux",
-            package_index_url="https://example.com/whl-multi-arch/",
-        )
+        with mock.patch.object(
+            m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
+        ):
+            matrix = m.build_test_matrix(
+                amdgpu_families=["gfxnorunner"],
+                platform="linux",
+            )
         self.assertEqual(matrix, {"include": []})
 
     def test_unknown_family_errors(self) -> None:
-        with self.assertRaisesRegex(ValueError, "not-a-family"):
+        with mock.patch.object(
+            m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
+        ), self.assertRaisesRegex(ValueError, "not-a-family"):
             m.build_test_matrix(
                 amdgpu_families=["not-a-family"],
                 platform="linux",
-                package_index_url="https://example.com/whl-multi-arch/",
-            )
-
-    def test_missing_package_index_url_errors_when_tests_enabled(self) -> None:
-        with self.assertRaisesRegex(ValueError, "--package-index-url"):
-            m.build_test_matrix(
-                amdgpu_families=["gfx950"],
-                platform="linux",
-                package_index_url="",
             )
 
     def test_main_writes_outputs(self) -> None:
-        with mock.patch.object(m, "gha_set_output") as gha_set_output:
+        with mock.patch.object(
+            m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
+        ), mock.patch.object(m, "gha_set_output") as gha_set_output:
             m.main(
                 [
                     "--build-amdgpu-families",
-                    "gfx950",
+                    "gfxalpha0",
                     "--test-amdgpu-families",
-                    "gfx950",
+                    "gfxalpha0",
                     "--platform",
                     "linux",
-                    "--package-index-url",
-                    "https://example.com/whl-multi-arch/",
                 ]
             )
 
         outputs = gha_set_output.call_args.args[0]
         self.assertEqual(outputs["enabled"], "true")
         matrix = json.loads(outputs["matrix"])
-        self.assertEqual(matrix["include"][0]["amdgpu_family"], "gfx950-dcgpu")
+        self.assertEqual(matrix["include"][0]["amdgpu_family"], "gfxalpha0")
+
+    def test_real_family_matrix_resolves_gfx950(self) -> None:
+        matrix = m.build_test_matrix(
+            amdgpu_families=["gfx950"],
+            platform="linux",
+        )
+        include = matrix["include"]
+        self.assertEqual(len(include), 1)
+        self.assertEqual(include[0]["amdgpu_family"], "gfx950-dcgpu")
+        self.assertTrue(include[0]["test_runs_on"])
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
@@ -63,16 +63,16 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
             )
         self.assertEqual(matrix, {"include": []})
 
-    def test_gfx_target_builds_platform_test_matrix(self) -> None:
+    def test_gfx_target_match_is_case_insensitive_and_platform_specific(self) -> None:
         with mock.patch.object(
             m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
         ):
             matrix = m.build_test_matrix(
-                amdgpu_families=["gfxalpha0"],
+                amdgpu_families=["GFXALPHA0"],
                 platform="linux",
             )
         # FAKE_FAMILY_MATRIX also has a windows-alpha runner. The Linux
-        # request should only use the Linux platform entry.
+        # request should only use the Linux platform entry and canonical target.
         self.assertEqual(
             matrix,
             {
@@ -132,6 +132,19 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
         outputs = gha_set_output.call_args.args[0]
         matrix = json.loads(outputs["matrix"])
         self.assertEqual(matrix["include"][0]["amdgpu_family"], "gfxalpha0")
+
+    def test_main_rejects_mixed_control_and_explicit_families(self) -> None:
+        with self.assertRaisesRegex(ValueError, "cannot be mixed"):
+            m.main(
+                [
+                    "--build-amdgpu-families",
+                    "gfxalpha0",
+                    "--test-amdgpu-families",
+                    "auto;gfxalpha0",
+                    "--platform",
+                    "linux",
+                ]
+            )
 
     def test_main_none_skips_tests(self) -> None:
         with mock.patch.object(m, "gha_set_output") as gha_set_output:

--- a/build_tools/github_actions/tests/publish_pytorch_to_release_bucket_test.py
+++ b/build_tools/github_actions/tests/publish_pytorch_to_release_bucket_test.py
@@ -26,7 +26,8 @@ class TestPublishPytorchToReleaseBucket(unittest.TestCase):
         self._tmp.cleanup()
 
     @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_directory")
-    def test_dev_uploads_to_v4_whl_in_dev_python(self, mock_upload):
+    @mock.patch("github_actions.publish_pytorch_to_release_bucket.gha_set_output")
+    def test_dev_uploads_to_v4_whl_in_dev_python(self, mock_set_output, mock_upload):
         mock_upload.return_value = 3
         main(
             [
@@ -45,6 +46,9 @@ class TestPublishPytorchToReleaseBucket(unittest.TestCase):
         self.assertEqual(dest.bucket, "therock-dev-python")
         self.assertEqual(dest.relative_path, "v4/whl")
         self.assertEqual(call_args.kwargs.get("include"), ["*.whl"])
+        mock_set_output.assert_called_once_with(
+            {"package_index_url": "https://rocm.devreleases.amd.com/whl-multi-arch/"}
+        )
 
     @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_directory")
     def test_nightly_selects_nightly_bucket(self, mock_upload):


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/5496. Now nightly releases of multi-arch PyTorch packages will run the standard set of PyTorch tests in [`test_pytorch_wheels.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/test_pytorch_wheels.yml). Note that https://github.com/ROCm/TheRock/pull/4499 will similarly trigger [`test_pytorch_wheels_full.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/test_pytorch_wheels_full.yml).

As advertised at https://github.com/ROCm/TheRock#nightly-release-status, see nightly workflow run history at:
* https://github.com/ROCm/rockrel/actions/workflows/multi_arch_release_linux_pytorch_wheels.yml
* https://github.com/ROCm/rockrel/actions/workflows/multi_arch_release_windows_pytorch_wheels.yml

that's where we'll start to see tests running with these changes.

## Technical Details

The "manifest" TODOs here relate to https://github.com/ROCm/TheRock/issues/5110 and https://github.com/ROCm/TheRock/pull/5633 - test jobs should use the same PyTorch commit as the build job, not just the same floating ref and hope that it resolves to the same commit when the tests run.

The matrix generation script could be shared with JAX for https://github.com/ROCm/TheRock/issues/5634, and maybe even ROCm artifact tests alongside [`build_tools/github_actions/fetch_test_configurations.py`](https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/fetch_test_configurations.py). The "test for what was built, or this subset" behavior is generic enough.

Note that unlike [`build_portable_linux_pytorch_wheels.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/build_portable_linux_pytorch_wheels.yml) the multi-arch release workflows have no concept of "upload to staging -> test -> promote", see https://github.com/ROCm/TheRock/pull/5107.

## Test Plan

1. Test workflow syntax with workflow_dispatch triggers of these `multi_arch_build_*pytorch_wheels.yml` workflows. Watch for the "configure pytorch tests" step to generate the expected matrix then the requested test runner labels to be used for test jobs that install and test the packages built by the build jobs:
    * Linux gfx94X;gfx950 with 'auto' testing, torch 2.11: https://github.com/ROCm/TheRock/actions/runs/27163214035
    * Windows gfx1151 with 'none' testing, torch 2.12: https://github.com/ROCm/TheRock/actions/runs/27045896457
2. After merge, watch nightly release runs for the full matrix of Python versions, PyTorch versions, AMDGPU targets, and platforms. Test results should be similar to those for the nightly single arch PyTorch releases currently running here in TheRock (e.g. https://github.com/ROCm/TheRock/actions/workflows/release_portable_linux_pytorch_wheels.yml?query=branch%3Amain)
3. If all goes well (or not worse than for single-arch releases), turn down the testing in single-arch release workflows like [`build_portable_linux_pytorch_wheels.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/build_portable_linux_pytorch_wheels.yml), see https://github.com/ROCm/TheRock/issues/3340

## Test Result

Linux https://github.com/ROCm/TheRock/actions/runs/27163214035/job/80192318135 configured
```
Requested linux AMDGPU families: ['gfx950-dcgpu', 'gfx94X-dcgpu']
Including gfx950-dcgpu: testing on linux-gfx950-1gpu-ccs-ossci-rocm
Including gfx94X-dcgpu: testing on linux-gfx942-1gpu-core42-ossci-rocm
```

then ran tests on those runners, e.g.
```
= 39637 passed, 1957 skipped, 41 deselected, 48 xfailed, 6 subtests passed in 1002.12s (0:16:42) =
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
