### PR TITLE
math-libs/BLAS: add xnack qualifiers to Tensile GPU targets for CDNA

### DIFF
--- a/math-libs/BLAS/pre_hook_hipBLASLt.cmake
+++ b/math-libs/BLAS/pre_hook_hipBLASLt.cmake
@@ -25,3 +25,25 @@ block(SCOPE_FOR VARIABLES)
   set(ENV{PATH} "${new_path}")
   message(STATUS "Augmented toolchain PATH=$ENV{PATH}")
 endblock()
+
+# Tensile source kernels require explicit xnack qualifiers for CDNA targets.
+# See pre_hook_rocBLAS.cmake for full explanation.
+# hipBLASLt's tensilelite_supported_architectures.cmake only accepts gfx942:xnack+
+# and gfx950:xnack+ (not xnack-); gfx90a accepts both variants.
+if(NOT THEROCK_SANITIZER)
+  set(_tensile_xnack_targets)
+  foreach(_t IN LISTS GPU_TARGETS)
+    if("${_t}" STREQUAL "gfx90a")
+      list(APPEND _tensile_xnack_targets "${_t}:xnack-" "${_t}:xnack+")
+    elseif("${_t}" STREQUAL "gfx942" OR "${_t}" STREQUAL "gfx950")
+      list(APPEND _tensile_xnack_targets "${_t}:xnack+")
+    else()
+      list(APPEND _tensile_xnack_targets "${_t}")
+    endif()
+  endforeach()
+  if(NOT "${_tensile_xnack_targets}" STREQUAL "${GPU_TARGETS}")
+    message(STATUS "hipBLASLt: expanding Tensile GPU targets with xnack variants: ${_tensile_xnack_targets}")
+    set(GPU_TARGETS "${_tensile_xnack_targets}" CACHE STRING "GPU targets" FORCE)
+    set(AMDGPU_TARGETS "${_tensile_xnack_targets}" CACHE STRING "AMDGPU targets" FORCE)
+  endif()
+endif()

--- a/math-libs/BLAS/pre_hook_hipSPARSELt.cmake
+++ b/math-libs/BLAS/pre_hook_hipSPARSELt.cmake
@@ -25,3 +25,25 @@ block(SCOPE_FOR VARIABLES)
   set(ENV{PATH} "${new_path}")
   message(STATUS "Augmented toolchain PATH=$ENV{PATH}")
 endblock()
+
+# Tensile source kernels require explicit xnack qualifiers for CDNA targets.
+# See pre_hook_rocBLAS.cmake for full explanation.
+# hipSPARSELt uses TensileLite with the same target restrictions as hipBLASLt:
+# gfx942:xnack+ and gfx950:xnack+ only; gfx90a accepts both xnack variants.
+if(NOT THEROCK_SANITIZER)
+  set(_tensile_xnack_targets)
+  foreach(_t IN LISTS GPU_TARGETS)
+    if("${_t}" STREQUAL "gfx90a")
+      list(APPEND _tensile_xnack_targets "${_t}:xnack-" "${_t}:xnack+")
+    elseif("${_t}" STREQUAL "gfx942" OR "${_t}" STREQUAL "gfx950")
+      list(APPEND _tensile_xnack_targets "${_t}:xnack+")
+    else()
+      list(APPEND _tensile_xnack_targets "${_t}")
+    endif()
+  endforeach()
+  if(NOT "${_tensile_xnack_targets}" STREQUAL "${GPU_TARGETS}")
+    message(STATUS "hipSPARSELt: expanding Tensile GPU targets with xnack variants: ${_tensile_xnack_targets}")
+    set(GPU_TARGETS "${_tensile_xnack_targets}" CACHE STRING "GPU targets" FORCE)
+    set(AMDGPU_TARGETS "${_tensile_xnack_targets}" CACHE STRING "AMDGPU targets" FORCE)
+  endif()
+endif()

--- a/math-libs/BLAS/pre_hook_rocBLAS.cmake
+++ b/math-libs/BLAS/pre_hook_rocBLAS.cmake
@@ -34,3 +34,30 @@ if(NOT WIN32)
   find_library(_therock_legacy_roctx64 roctx64 REQUIRED)
   cmake_language(DEFER CALL therock_patch_linked_lib OLD_LIBRARY "roctx64" NEW_TARGET "${_therock_legacy_roctx64}")
 endif()
+
+# Tensile's source-kernel compilation (which produces Kernels.so-000-{arch}.hsaco)
+# requires explicit xnack qualifiers for CDNA targets that support xnack variants.
+# Without them, Tensile compiles bare gfx942/gfx90a images that the HIP runtime
+# rejects with hipErrorInvalidImage on hardware that reports xnack feature flags
+# (e.g. MI300X reports gfx942:sramecc+:xnack-). Both xnack- and xnack+ variants
+# are needed: production CDNA systems run xnack- by default; some deployments and
+# ROCm tools (e.g. rocr page migration) require xnack+.
+# TheRock registers bare gfx942/gfx90a/gfx950 targets; we expand each bare CDNA
+# target into its two xnack variants here, matching the legacy build-infra behaviour.
+# ASAN builds are excluded: therock_sanitizers.cmake already forces xnack+ only.
+if(NOT THEROCK_SANITIZER)
+  set(_xnack_arches "gfx90a" "gfx942" "gfx950")
+  set(_tensile_xnack_targets)
+  foreach(_t IN LISTS GPU_TARGETS)
+    if("${_t}" IN_LIST _xnack_arches)
+      list(APPEND _tensile_xnack_targets "${_t}:xnack-" "${_t}:xnack+")
+    else()
+      list(APPEND _tensile_xnack_targets "${_t}")
+    endif()
+  endforeach()
+  if(NOT "${_tensile_xnack_targets}" STREQUAL "${GPU_TARGETS}")
+    message(STATUS "rocBLAS: expanding Tensile GPU targets with xnack variants: ${_tensile_xnack_targets}")
+    set(GPU_TARGETS "${_tensile_xnack_targets}" CACHE STRING "GPU targets" FORCE)
+    set(AMDGPU_TARGETS "${_tensile_xnack_targets}" CACHE STRING "AMDGPU targets" FORCE)
+  endif()
+endif()


### PR DESCRIPTION
Tensile's source-kernel compilation produces Kernels.so-000-{arch}.hsaco files that must be compiled with explicit xnack feature qualifiers for CDNA targets (gfx90a, gfx942, gfx950). Without them, Tensile compiles bare arch images that the HIP runtime rejects with hipErrorInvalidImage at load time because real CDNA hardware (e.g. MI300X) reports gfx942:sramecc+:xnack- while the compiled image only targets bare gfx942.

TheRock registers bare gfx942/gfx90a/gfx950 targets in therock_amdgpu_targets.cmake. The legacy build-infra explicitly passes both xnack- and xnack+ variants for these arches. Expand each bare CDNA target into both xnack variants in the pre_hook for rocBLAS, hipBLASLt, and hipSPARSELt to match this behaviour. Both variants are required: production systems default to xnack-; some deployments and ROCm tools require xnack+. ASAN builds are excluded since therock_sanitizers.cmake already forces xnack+ for those targets.

## Motivation

https://amd-hub.atlassian.net/browse/ROCM-24723 - rocHPL application is failing with hipErrorInvalidImage error. 

## Technical Details

TheRock registers CDNA targets (gfx90a, gfx942, gfx950) as bare arch names in therock_amdgpu_targets.cmake. Tensile's source-kernel compilation uses these directly, producing Kernels.so-000-gfx942.hsaco compiled for bare amdgcn-amd-amdhsa--gfx942.

At runtime, CDNA hardware reports full feature flags (e.g. MI300X reports gfx942:sramecc+:xnack-). The HIP runtime's image compatibility check requires the compiled target to match — bare gfx942 is rejected with hipErrorInvalidImage (error 200).

**Fix**
In the pre_hook cmake files for rocBLAS, hipBLASLt, and hipSPARSELt, expand each bare CDNA target into both xnack variants before Tensile configure runs:


gfx90a  →  gfx90a:xnack-  gfx90a:xnack+
gfx942  →  gfx942:xnack-  gfx942:xnack+
gfx950  →  gfx950:xnack-  gfx950:xnack+
Tensile then produces correctly qualified files (Kernels.so-000-gfx942-xnack-.hsaco, Kernels.so-000-gfx942-xnack+.hsaco) that the HIP runtime accepts. Both variants are needed: production CDNA systems run xnack- by default; some deployments and ROCm tools (e.g. page migration) require xnack+.

ASAN builds are excluded — therock_sanitizers.cmake already transforms these targets to xnack+.

**Alternates considered**
1. Relax the HIP/ROCr image compatibility check to accept bare arch

The check lives in rocr (hsa_executable_load_agent_code_object) and comgr (ELF note parsing). Relaxing it to accept bare gfx942 on gfx942:sramecc+:xnack- hardware would require changes to both, with wide blast radius across the entire ROCm stack.

More importantly, the strict check is correct by design. xnack changes the GPU memory model — with xnack+ the GPU supports page fault recovery and SVM, and the compiler emits xnack-aware instructions with different scratch buffer management. A kernel compiled without xnack awareness loaded on an xnack+ system can produce wrong results or fault silently on SVM pointers. The runtime cannot determine whether a binary uses xnack-sensitive instructions without disassembling it, so there is no safe way to relax the check. Rejected: correctness risk.

2. Register xnack variants in therock_amdgpu_targets.cmake

This would be the proper long-term fix — make the full build topology aware of gfx942:xnack- and gfx942:xnack+ as distinct targets. However it doubles the artifact set, build times, and wheel sizes for all CDNA targets and requires broader design discussion on how the kpack splitter, artifact topology, and CI matrix handle the expanded target list. Deferred: correct approach but longer build time, so differed as a long term solution.

3. Pass xnack variants directly via -DAMDGPU_TARGETS in CMakeLists.txt

Would work but bypasses the subproject GPU target filtering machinery (_therock_filter_project_gpu_targets), which handles per-project exclusions, default fallbacks, and dist/test target variants. The pre_hook approach keeps all that machinery intact and only widens the target list at the point Tensile sees it. Rejected in favour of pre_hook.


## Test Plan

Test ci artifacts and rocHPL with the change

## Test Result

