### PR TITLE
Refactor baseline selection to reuse shared workflow run helpers

### DIFF
--- a/build_tools/github_actions/baseline_runs.py
+++ b/build_tools/github_actions/baseline_runs.py
@@ -23,7 +23,6 @@ from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 import sys
-from urllib.parse import urlencode, quote
 
 # Add parent directory to path for artifact and _therock_utils imports.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -36,7 +35,10 @@ from _therock_utils.artifact_backend import (
 )
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 
-from github_actions_api import gha_send_request
+from github_actions_api import (
+    gha_send_request,
+    gha_query_last_successful_workflow_runs,
+)
 
 
 @dataclass(frozen=True)
@@ -152,68 +154,6 @@ def is_successful_workflow_job(workflow_job: dict) -> bool:
         workflow_job.get("status") == "completed"
         and workflow_job.get("conclusion") == "success"
     )
-
-
-def query_completed_workflow_runs(
-    *,
-    github_repository: str = "ROCm/TheRock",
-    workflow_name: str = "multi_arch_ci.yml",
-    branch: str = "main",
-    max_runs: int = 20,
-) -> list[dict]:
-    """Query recent completed workflow runs for a workflow and branch."""
-    if max_runs < 1:
-        raise ValueError("max_runs must be at least 1")
-
-    per_page = min(max_runs, 100)
-    workflow_path = quote(workflow_name, safe="")
-    query = urlencode(
-        {
-            "status": "completed",
-            "branch": branch,
-            "per_page": per_page,
-            "sort": "created",
-            "direction": "desc",
-        }
-    )
-    url = (
-        f"https://api.github.com/repos/{github_repository}"
-        f"/actions/workflows/{workflow_path}/runs?{query}"
-    )
-    response = gha_send_request(url)
-    workflow_runs = response.get("workflow_runs", [])
-    return workflow_runs[:max_runs]
-
-
-def query_successful_workflow_runs(
-    *,
-    github_repository: str = "ROCm/TheRock",
-    workflow_name: str = "multi_arch_ci.yml",
-    branch: str = "main",
-    max_runs: int = 20,
-) -> list[dict]:
-    """Query recent successful workflow runs for a workflow and branch."""
-    if max_runs < 1:
-        raise ValueError("max_runs must be at least 1")
-
-    per_page = min(max_runs, 100)
-    workflow_path = quote(workflow_name, safe="")
-    query = urlencode(
-        {
-            "status": "success",
-            "branch": branch,
-            "per_page": per_page,
-            "sort": "created",
-            "direction": "desc",
-        }
-    )
-    url = (
-        f"https://api.github.com/repos/{github_repository}"
-        f"/actions/workflows/{workflow_path}/runs?{query}"
-    )
-    response = gha_send_request(url)
-    workflow_runs = response.get("workflow_runs", [])
-    return workflow_runs[:max_runs]
 
 
 def query_workflow_run_jobs(
@@ -441,7 +381,7 @@ def select_baseline_run(
     candidates = (
         list(workflow_runs)
         if workflow_runs is not None
-        else query_completed_workflow_runs(
+        else gha_query_last_successful_workflow_runs(
             github_repository=github_repository,
             workflow_name=workflow_name,
             branch=branch,

--- a/build_tools/github_actions/github_actions_api.py
+++ b/build_tools/github_actions/github_actions_api.py
@@ -480,30 +480,73 @@ def gha_query_workflow_runs_for_commit(
     return runs
 
 
+def gha_query_last_successful_workflow_runs(
+    github_repository: str = "ROCm/TheRock",
+    workflow_name: str = "multi_arch_ci.yml",
+    branch: str = "main",
+    max_runs: int = 20,
+) -> list[dict]:
+    """Gets recent successful workflow runs for a workflow on a branch.
+
+    Uses the GitHub REST API endpoint:
+    /actions/workflows/{workflow}/runs?status=success&branch={branch}
+
+    Results are returned most-recent-first.
+
+    Args:
+        github_repository: Repository in "owner/repo" format
+            (e.g. "ROCm/TheRock").
+        workflow_name: Workflow filename
+            (e.g. "multi_arch_ci.yml").
+        branch: Branch name to filter by.
+        max_runs: Maximum number of successful workflow runs to return.
+
+    Returns:
+        List of successful workflow run metadata dicts ordered most-recent-first.
+        Returns an empty list if no successful runs are found.
+    """
+    if max_runs < 1:
+        raise ValueError("max_runs must be at least 1")
+
+    url = (
+        f"https://api.github.com/repos/{github_repository}"
+        f"/actions/workflows/{workflow_name}/runs"
+        f"?status=success&branch={branch}&per_page={min(max_runs, 100)}"
+        f"&sort=created&direction=desc"
+    )
+    response = gha_send_request(url)
+    return (response.get("workflow_runs") or [])[:max_runs]
+
+
 def gha_query_last_successful_workflow_run(
     github_repository: str = "ROCm/TheRock",
     workflow_name: str = "multi_arch_ci.yml",
     branch: str = "main",
 ) -> dict | None:
-    """Find the last successful run of a specific workflow on the specified branch.
+    """Gets the most recent successful workflow run for a workflow on a branch.
+
+    This is a convenience wrapper around
+    ``gha_query_last_successful_workflow_runs()`` that returns only the newest
+    successful workflow run.
 
     Args:
-        github_repository: Repository in format "owner/repo"
-        workflow_name: Name of the workflow file (e.g., "ci_nightly.yml")
-        branch: Branch to filter by (defaults to "main")
+        github_repository: Repository in "owner/repo" format
+            (e.g. "ROCm/TheRock").
+        workflow_name: Workflow filename
+            (e.g. "multi_arch_ci.yml").
+        branch: Branch name to filter by.
 
     Returns:
-        The full workflow run object of the most recent successful run on the specified branch,
-        or None if no successful runs are found.
+        Workflow run metadata dict for the most recent successful workflow run,
+        or ``None`` if no successful runs are found.
     """
-    # Use GitHub API query parameters to pre-filter for successful runs on the specified branch
-    url = f"https://api.github.com/repos/{github_repository}/actions/workflows/{workflow_name}/runs?status=success&branch={branch}&per_page=100&sort=created&direction=desc"
-    response = gha_send_request(url)
-
-    # Return the first (most recent) successful run
-    if response and response.get("workflow_runs"):
-        return response["workflow_runs"][0]
-    return None
+    runs = gha_query_last_successful_workflow_runs(
+        github_repository=github_repository,
+        workflow_name=workflow_name,
+        branch=branch,
+        max_runs=1,
+    )
+    return runs[0] if runs else None
 
 
 def gha_query_recent_branch_commits(

--- a/build_tools/github_actions/tests/baseline_runs_test.py
+++ b/build_tools/github_actions/tests/baseline_runs_test.py
@@ -91,62 +91,6 @@ class BaselineRunsTest(unittest.TestCase):
             )
         )
 
-    def test_query_completed_workflow_runs(self):
-        with mock.patch.object(
-            baseline_runs,
-            "gha_send_request",
-            return_value={
-                "workflow_runs": [
-                    _workflow_run("1"),
-                    _workflow_run("2"),
-                    _workflow_run("3"),
-                ]
-            },
-        ) as mock_send_request:
-            runs = baseline_runs.query_completed_workflow_runs(
-                github_repository="ROCm/TheRock",
-                workflow_name="multi_arch_ci.yml",
-                branch="main",
-                max_runs=2,
-            )
-
-        self.assertEqual([run["id"] for run in runs], ["1", "2"])
-        url = mock_send_request.call_args.args[0]
-        self.assertIn(
-            "/repos/ROCm/TheRock/actions/workflows/multi_arch_ci.yml/runs", url
-        )
-        self.assertIn("status=completed", url)
-        self.assertIn("branch=main", url)
-        self.assertIn("per_page=2", url)
-
-    def test_query_successful_workflow_runs(self):
-        with mock.patch.object(
-            baseline_runs,
-            "gha_send_request",
-            return_value={
-                "workflow_runs": [
-                    _workflow_run("1"),
-                    _workflow_run("2"),
-                    _workflow_run("3"),
-                ]
-            },
-        ) as mock_send_request:
-            runs = baseline_runs.query_successful_workflow_runs(
-                github_repository="ROCm/TheRock",
-                workflow_name="multi_arch_ci.yml",
-                branch="main",
-                max_runs=2,
-            )
-
-        self.assertEqual([run["id"] for run in runs], ["1", "2"])
-        url = mock_send_request.call_args.args[0]
-        self.assertIn(
-            "/repos/ROCm/TheRock/actions/workflows/multi_arch_ci.yml/runs", url
-        )
-        self.assertIn("status=success", url)
-        self.assertIn("branch=main", url)
-        self.assertIn("per_page=2", url)
-
     def test_query_workflow_run_jobs_uses_run_attempt_when_provided(self):
         with mock.patch.object(
             baseline_runs,

--- a/build_tools/github_actions/tests/github_actions_api_test.py
+++ b/build_tools/github_actions/tests/github_actions_api_test.py
@@ -20,6 +20,7 @@ from github_actions_api import (
     gha_fetch_text_file_contents,
     gha_load_github_event,
     gha_query_last_successful_workflow_run,
+    gha_query_last_successful_workflow_runs,
     gha_query_recent_branch_commits,
     gha_query_workflow_run_by_id,
     gha_query_workflow_runs_for_commit,
@@ -636,6 +637,38 @@ class GitHubActionsUtilsTest(unittest.TestCase):
             gha_query_last_successful_workflow_run(
                 "ROCm/TheRock", "nonexistent_workflow_12345.yml", "main"
             )
+
+    def test_gha_query_last_successful_workflow_runs(self):
+        """Test querying recent successful workflow runs on a branch."""
+        with mock.patch(
+            "github_actions_api.gha_send_request",
+            return_value={
+                "workflow_runs": [
+                    {"id": 1, "conclusion": "success"},
+                    {"id": 2, "conclusion": "success"},
+                    {"id": 3, "conclusion": "success"},
+                ]
+            },
+        ) as mock_send_request:
+            runs = gha_query_last_successful_workflow_runs(
+                github_repository="ROCm/TheRock",
+                workflow_name="multi_arch_ci.yml",
+                branch="main",
+                max_runs=2,
+            )
+
+        self.assertEqual(len(runs), 2)
+        self.assertEqual(runs[0]["id"], 1)
+        self.assertEqual(runs[1]["id"], 2)
+
+        url = mock_send_request.call_args.args[0]
+        self.assertIn(
+            "/repos/ROCm/TheRock/actions/workflows/multi_arch_ci.yml/runs",
+            url,
+        )
+        self.assertIn("status=success", url)
+        self.assertIn("branch=main", url)
+        self.assertIn("per_page=2", url)
 
     @_skip_unless_authenticated_github_api_is_available
     def test_gha_query_recent_branch_commits(self):


### PR DESCRIPTION
## Summary

Refactor baseline workflow selection to reuse shared GitHub Actions workflow-run query utilities instead of maintaining duplicate query implementations in `baseline_runs.py`.

This change addresses review feedback on #5435 by expanding the existing helper infrastructure in `github_actions_api.py` and migrating baseline selection to consume the shared utility.

Particular comment addresed: https://github.com/ROCm/TheRock/pull/5435#discussion_r3305286417

## Changes

### GitHub Actions API Utilities

Added:

* `gha_query_last_successful_workflow_runs()`

Retained:

* `gha_query_last_successful_workflow_run()`

The existing singular helper is now implemented as a thin wrapper around the new plural helper to preserve backward compatibility.

### Baseline Selection

Removed duplicate workflow-run query implementations from:

* `query_completed_workflow_runs()`
* `query_successful_workflow_runs()`

Updated `select_baseline_run()` to use:

```python
gha_query_last_successful_workflow_runs(...)
```

instead of maintaining its own workflow discovery logic.

### Tests

Removed tests for deleted query helpers.

Added direct unit coverage for:

```python
gha_query_last_successful_workflow_runs()
```

Verified:

* `github_actions_api_test.py`
* `baseline_runs_test.py`
* `build_topology_test.py`

all pass.

## Motivation

`baseline_runs.py` previously duplicated GitHub workflow-run query logic that already existed in `github_actions_api.py`.

This refactor consolidates workflow discovery in a single location and keeps `baseline_runs.py` focused on:

* baseline selection
* job validation
* artifact validation

while reusing shared GitHub Actions utilities.

## Test Results

```text
github_actions_api_test.py: 39 passed
baseline_runs_test.py: 14 passed
build_topology_test.py: 19 passed
```