### PR TITLE
Set SCCACHE_IDLE_TIMEOUT=0 so PyTorch sccache stats reflect the full build

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -133,7 +133,10 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: "linux/${{ inputs.amdgpu_family }}/"
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
-      SCCACHE_IDLE_TIMEOUT: "600"
+      # 0 = no idle shutdown: keep the sccache server alive for the whole
+      # build so --show-stats reflects the full run (a >10min single compile
+      # would otherwise idle-out the server mid-build and reset the counters).
+      SCCACHE_IDLE_TIMEOUT: "0"
       SCCACHE_LOG: warn
     outputs:
       cp_version: ${{ env.cp_version }}

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -133,10 +133,7 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: "linux/${{ inputs.amdgpu_family }}/"
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
-      # 0 = no idle shutdown: keep the sccache server alive for the whole
-      # build so --show-stats reflects the full run (a >10min single compile
-      # would otherwise idle-out the server mid-build and reset the counters).
-      SCCACHE_IDLE_TIMEOUT: "0"
+      SCCACHE_IDLE_TIMEOUT: "0" # never idle-out; keeps stats accurate on long builds
       SCCACHE_LOG: warn
     outputs:
       cp_version: ${{ env.cp_version }}

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -114,7 +114,10 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: "linux/${{ inputs.artifact_group }}/"
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
-      SCCACHE_IDLE_TIMEOUT: "600"
+      # 0 = no idle shutdown: keep the sccache server alive for the whole
+      # build so --show-stats reflects the full run (a >10min single compile
+      # would otherwise idle-out the server mid-build and reset the counters).
+      SCCACHE_IDLE_TIMEOUT: "0"
       SCCACHE_LOG: warn
     steps:
       - name: Checkout

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -114,10 +114,7 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: "linux/${{ inputs.artifact_group }}/"
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
-      # 0 = no idle shutdown: keep the sccache server alive for the whole
-      # build so --show-stats reflects the full run (a >10min single compile
-      # would otherwise idle-out the server mid-build and reset the counters).
-      SCCACHE_IDLE_TIMEOUT: "0"
+      SCCACHE_IDLE_TIMEOUT: "0" # never idle-out; keeps stats accurate on long builds
       SCCACHE_LOG: warn
     steps:
       - name: Checkout

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -133,10 +133,7 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: "windows/${{ inputs.amdgpu_family }}/"
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
-      # 0 = no idle shutdown: keep the sccache server alive for the whole
-      # build so --show-stats reflects the full run (a >10min single compile
-      # would otherwise idle-out the server mid-build and reset the counters).
-      SCCACHE_IDLE_TIMEOUT: "0"
+      SCCACHE_IDLE_TIMEOUT: "0" # never idle-out; keeps stats accurate on long builds
       SCCACHE_LOG: warn
     outputs:
       cp_version: ${{ env.cp_version }}

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -133,7 +133,10 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: "windows/${{ inputs.amdgpu_family }}/"
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
-      SCCACHE_IDLE_TIMEOUT: "600"
+      # 0 = no idle shutdown: keep the sccache server alive for the whole
+      # build so --show-stats reflects the full run (a >10min single compile
+      # would otherwise idle-out the server mid-build and reset the counters).
+      SCCACHE_IDLE_TIMEOUT: "0"
       SCCACHE_LOG: warn
     outputs:
       cp_version: ${{ env.cp_version }}

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -111,7 +111,10 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: "windows/${{ inputs.artifact_group }}/"
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
-      SCCACHE_IDLE_TIMEOUT: "600"
+      # 0 = no idle shutdown: keep the sccache server alive for the whole
+      # build so --show-stats reflects the full run (a >10min single compile
+      # would otherwise idle-out the server mid-build and reset the counters).
+      SCCACHE_IDLE_TIMEOUT: "0"
       SCCACHE_LOG: warn
     defaults:
       run:

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -111,10 +111,7 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: "windows/${{ inputs.artifact_group }}/"
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
-      # 0 = no idle shutdown: keep the sccache server alive for the whole
-      # build so --show-stats reflects the full run (a >10min single compile
-      # would otherwise idle-out the server mid-build and reset the counters).
-      SCCACHE_IDLE_TIMEOUT: "0"
+      SCCACHE_IDLE_TIMEOUT: "0" # never idle-out; keeps stats accurate on long builds
       SCCACHE_LOG: warn
     defaults:
       run:

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -132,7 +132,10 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: "linux/multiarch/v1/"
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
-      SCCACHE_IDLE_TIMEOUT: "600"
+      # 0 = no idle shutdown: keep the sccache server alive for the whole
+      # build so --show-stats reflects the full run (a >10min single compile
+      # would otherwise idle-out the server mid-build and reset the counters).
+      SCCACHE_IDLE_TIMEOUT: "0"
       SCCACHE_LOG: warn
     steps:
       - name: Checkout

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -132,10 +132,7 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: "linux/multiarch/v1/"
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
-      # 0 = no idle shutdown: keep the sccache server alive for the whole
-      # build so --show-stats reflects the full run (a >10min single compile
-      # would otherwise idle-out the server mid-build and reset the counters).
-      SCCACHE_IDLE_TIMEOUT: "0"
+      SCCACHE_IDLE_TIMEOUT: "0" # never idle-out; keeps stats accurate on long builds
       SCCACHE_LOG: warn
     steps:
       - name: Checkout

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -132,7 +132,10 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: "windows/multiarch/v1/"
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
-      SCCACHE_IDLE_TIMEOUT: "600"
+      # 0 = no idle shutdown: keep the sccache server alive for the whole
+      # build so --show-stats reflects the full run (a >10min single compile
+      # would otherwise idle-out the server mid-build and reset the counters).
+      SCCACHE_IDLE_TIMEOUT: "0"
       SCCACHE_LOG: warn
     defaults:
       run:

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -132,10 +132,7 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: "windows/multiarch/v1/"
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_SERVER_SIDE_ENCRYPTION: "true"
-      # 0 = no idle shutdown: keep the sccache server alive for the whole
-      # build so --show-stats reflects the full run (a >10min single compile
-      # would otherwise idle-out the server mid-build and reset the counters).
-      SCCACHE_IDLE_TIMEOUT: "0"
+      SCCACHE_IDLE_TIMEOUT: "0" # never idle-out; keeps stats accurate on long builds
       SCCACHE_LOG: warn
     defaults:
       run:


### PR DESCRIPTION
## Summary

Follow-up to #5471 (raised in review there). The `Report cache stats` step on the PyTorch wheel builds showed `0/0/0` even though sccache was caching.

Root cause: `SCCACHE_IDLE_TIMEOUT=600` lets the sccache server idle-out and restart mid-build — a single HIP device translation unit can exceed 10 min — which resets its in-memory counters. The end-of-build `sccache --show-stats` then reads a fresh server, reporting `0/0/0`. (Same `0/0/0` appeared before #5471, so it predates the `HIP_CLANG_LAUNCHER` change.)

Fix: set `SCCACHE_IDLE_TIMEOUT=0` (no idle shutdown) in the 6 PyTorch wheel workflows so the server stays alive for the whole job and the stats reflect the full run. Linux jobs run in ephemeral containers, so the server is torn down with the container at job end.


## Validation (this PR's own CI — run 27105218441)

`Report cache stats` now reflects the full build instead of 0/0/0:

| Platform | Compile requests | Cache hits | Hit rate |
| --- | --- | --- | --- |
| Linux   | 1067  | 722 (HIP 303) | 99.86% |
| Windows | 20026 | 19881         | 99.42% |

- Linux:   https://github.com/ROCm/TheRock/actions/runs/27105218441/job/80001517765?pr=5672#step:15:1
- Windows: https://github.com/ROCm/TheRock/actions/runs/27105218441/job/80006008076?pr=5672#step:17:1