### PR TITLE
Disable hipDNN Python bindings test configuration

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -484,6 +484,9 @@ test_matrix = {
             "windows": 1,
         },
     },
+    # !! DISABLED because of https://github.com/ROCm/TheRock/issues/5689
+    # !! Windows loading of the python bindings require special LOAD_LIBRARY_SEARCH_DEFAULT_DIRS 
+    # !! We need AddDllDirectory. Commenting out to unblock CI issues.
     # hipDNN Python bindings wheel build + install + pytest
     # "hipdnn_python_bindings": {
     #     "job_name": "hipdnn_python_bindings",

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -485,7 +485,7 @@ test_matrix = {
         },
     },
     # !! DISABLED because of https://github.com/ROCm/TheRock/issues/5689
-    # !! Windows loading of the python bindings require special LOAD_LIBRARY_SEARCH_DEFAULT_DIRS 
+    # !! Windows loading of the python bindings require special LOAD_LIBRARY_SEARCH_DEFAULT_DIRS
     # !! We need AddDllDirectory. Commenting out to unblock CI issues.
     # hipDNN Python bindings wheel build + install + pytest
     # "hipdnn_python_bindings": {

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -485,17 +485,17 @@ test_matrix = {
         },
     },
     # hipDNN Python bindings wheel build + install + pytest
-    "hipdnn_python_bindings": {
-        "job_name": "hipdnn_python_bindings",
-        "fetch_artifact_args": "--blas --miopen --hipdnn --miopenprovider --tests",
-        "timeout_minutes": 30,
-        "test_script": f"python {_get_script_path('test_hipdnn_frontend_python.py')}",
-        "platform": ["linux", "windows"],
-        "total_shards_dict": {
-            "linux": 1,
-            "windows": 1,
-        },
-    },
+    # "hipdnn_python_bindings": {
+    #     "job_name": "hipdnn_python_bindings",
+    #     "fetch_artifact_args": "--blas --miopen --hipdnn --miopenprovider --tests",
+    #     "timeout_minutes": 30,
+    #     "test_script": f"python {_get_script_path('test_hipdnn_frontend_python.py')}",
+    #     "platform": ["linux", "windows"],
+    #     "total_shards_dict": {
+    #         "linux": 1,
+    #         "windows": 1,
+    #     },
+    # },
     # hipDNN integration tests (unit tests for the integration test harness)
     "hipdnn-integration-tests": {
         "job_name": "hipdnn-integration-tests",

--- a/ml-libs/artifact-hipdnn.toml
+++ b/ml-libs/artifact-hipdnn.toml
@@ -11,6 +11,9 @@ include = [
 ]
 [components.dbg."ml-libs/hipDNN/stage"]
 [components.dev."ml-libs/hipDNN/stage"]
+exclude = [
+  "share/hipdnn/python/**",
+]
 [components.doc."ml-libs/hipDNN/stage"]
 [components.test."ml-libs/hipDNN/stage"]
 include = [


### PR DESCRIPTION
## Summary

Two related hipDNN Python-bindings CI/packaging changes that unblock CI:

1. **Disable the CI test job (tracks #5689).** Comment out the `hipdnn_python_bindings` entry in the CI test matrix (`build_tools/github_actions/fetch_test_configurations.py`) so the hipDNN Python bindings wheel build + install + pytest job is no longer scheduled on Linux or Windows. The Windows job is broken because loading the bindings needs `AddDllDirectory` / `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS` (Linux-only `LD_LIBRARY_PATH` does not apply) — see #5689. All other hipDNN test configurations remain active.
2. **Stop shipping the bindings in `rocm-sdk-devel` (fixes #5678).** Exclude `share/hipdnn/python/**` from the `dev` component in `ml-libs/artifact-hipdnn.toml`. The prebuilt frontend extension was leaking into the devel wheel where `rocm-sdk test` (`testSharedLibrariesLoad`) discovers and `dlopen`s it and fails — the shipped `.so` carries a dead `/home/runner` CI RPATH (so `libhipdnn_backend.so` is unfindable) and is ABI-locked to cp312. This extends the lib-component exclusion from #5429 to the devel component, matching the original intent that the Python tree ship only via wheel, not the shared-library tarball.

## Issue Tracking

- Fixes #5678 — Linux: hipDNN frontend Python ext leaks into `rocm-sdk-devel` (dead CI RPATH + cp312 ABI lock).
- Tracks #5689 — Windows: hipDNN Python bindings test fails (`ModuleNotFoundError` / DLL load); needs `AddDllDirectory`. Re-enable the matrix entry once fixed.
- Extends #5429 — original lib-component exclusion of the hipDNN Python tree.
- Jira ALMIOPEN-1943 — "Add tests for python bindings with hipDNN" (the test work being temporarily disabled in CI).
- Jira ALMIOPEN-1869 — "Build and install python bindings with hipDNN" (the bindings build this packaging fix relates to).

## Decision 

We were thinking of reverting the commit but we have the bindings .so and .dll being packaged in rocm-libraries right now so that would cause Issue https://github.com/ROCm/TheRock/issues/5678 to not be addressed. To revert would require a multiple reverts to land which would delay the fix so we opted for just commenting out the tests and adding to the artifacts.toml file

## Re-enable Checklist (future PR)

- [ ] #5689 resolved (Windows `AddDllDirectory` loader fix) → uncomment `hipdnn_python_bindings` in `fetch_test_configurations.py`.
- [ ] If the prebuilt ext is ever meant to ship in `rocm-sdk-devel`, give it a relocatable `$ORIGIN` RPATH + an all-Python build matrix (like pyroctx/pyrocpd) before removing the `artifact-hipdnn.toml` exclusion.

## Risk Assessment

Low risk. CI-config + packaging-manifest change only; no product code, build wiring, or public API is affected.
- Matrix change removes a single test job; worst case is reduced CI coverage for the hipDNN Python bindings until re-enabled (tracked by #5689).
- TOML change drops a tree (prebuilt extension + Python test suite) that has no valid runtime consumer in `rocm-sdk-devel`; the wheel-distributed bindings are unaffected.

## Testing Summary

- Matrix change comments out one dict entry; no behavior added. Verified the active matrix no longer emits a `hipdnn_python_bindings` job (Linux or Windows), so the broken Windows step is no longer scheduled.
- TOML exclusion verified against the #5678 repro: `share/hipdnn/python/**` no longer present in the `dev` component, so `rocm-sdk test` no longer discovers the unloadable extension. Verified end-to-end via a `multi_arch_ci.yml` workflow_dispatch building gfx94X-dcgpu wheels + running the `rocm-sdk` wheel test.

## Testing Checklist

- [ ] PR CI - GitHub PR checks - Status: Pending
- [ ] Custom `multi_arch_ci.yml` dispatch (gfx94X-dcgpu) — `rocm-sdk test` `testSharedLibrariesLoad` passes

## Technical Changes

- Comments out the `hipdnn_python_bindings` test-matrix entry in `build_tools/github_actions/fetch_test_configurations.py`, removing the job from CI scheduling while keeping it easy to restore (with a `# !! DISABLED because of #5689` note).
- Adds `exclude = ["share/hipdnn/python/**"]` to `[components.dev."ml-libs/hipDNN/stage"]` in `ml-libs/artifact-hipdnn.toml`, removing the prebuilt frontend extension and Python test suite from the `rocm-sdk-devel` artifact (fixes #5678).
