### PR TITLE
Enable GLOO backend for torch.distributed on Windows

### DIFF
--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -187,6 +187,11 @@ jobs:
           choco install --no-progress -y awscli
           echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
 
+      - name: Install libuv for GLOO
+        run: |
+          vcpkg install libuv:x64-windows
+          echo "libuv_ROOT=C:/vcpkg/installed/x64-windows" >> $GITHUB_ENV
+
       - name: Install sccache
         if: ${{ inputs.cache_type == 'sccache' }}
         run: |

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -187,10 +187,13 @@ jobs:
           choco install --no-progress -y awscli
           echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
 
-      - name: Install libuv for GLOO
+      - name: Build libuv from source for GLOO
         run: |
-          vcpkg install libuv:x64-windows
-          echo "libuv_ROOT=C:/vcpkg/installed/x64-windows" >> $GITHUB_ENV
+          git clone https://github.com/libuv/libuv.git -b v1.47.0 --depth 1
+          cmake -S libuv -B libuv/build -DBUILD_TESTING=OFF
+          cmake --build libuv/build --config Release
+          cmake --install libuv/build --prefix "${{ github.workspace }}/libuv-install"
+          echo "libuv_ROOT=${{ github.workspace }}/libuv-install" >> $GITHUB_ENV
 
       - name: Install sccache
         if: ${{ inputs.cache_type == 'sccache' }}

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -187,6 +187,9 @@ jobs:
           choco install --no-progress -y awscli
           echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
 
+      # Build a fixed version of libuv from source, no matter the pytorch ref.
+      # gloo requires >= 1.26; v1.47.0 matches upstream's source build.
+      # https://github.com/pytorch/pytorch/blob/main/.ci/pytorch/windows/arm64/bootstrap_libuv.bat
       - name: Build libuv from source for GLOO
         run: |
           git clone https://github.com/libuv/libuv.git -b v1.47.0 --depth 1

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -475,9 +475,7 @@ def _setup_common_build_env(
         "USE_KINETO": os.environ.get("USE_KINETO", "ON" if not is_windows else "OFF"),
     }
 
-    # GLOO enabled for only Linux
-    if not is_windows:
-        env["USE_GLOO"] = "ON"
+    env["USE_GLOO"] = "ON"
 
     # At checkout, we compute some additional env vars that influence the way that
     # the wheel is named/versioned.

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -925,6 +925,18 @@ def copy_msvc_libomp_to_torch_lib(pytorch_dir: Path):
     shutil.copy2(omp_path, target_lib)
 
 
+def copy_libuv_to_torch_lib(pytorch_dir: Path):
+    libuv_root = os.environ.get("libuv_ROOT", "")
+    if not libuv_root:
+        return
+    uv_dll = Path(libuv_root) / "bin" / "uv.dll"
+    if not uv_dll.exists():
+        raise RuntimeError(f"Did not find uv.dll at '{uv_dll}'")
+    target_lib = pytorch_dir / "torch" / "lib"
+    print(f"Copying libuv from '{uv_dll}' to '{target_lib}'")
+    shutil.copy2(uv_dll, target_lib)
+
+
 def do_build_pytorch(
     args: argparse.Namespace,
     pytorch_dir: Path,
@@ -1054,6 +1066,7 @@ def do_build_pytorch(
     # Windows-specific settings.
     if is_windows:
         copy_msvc_libomp_to_torch_lib(pytorch_dir)
+        copy_libuv_to_torch_lib(pytorch_dir)
 
         use_flash_attention = (
             "1"


### PR DESCRIPTION
## Motivation

Resolves https://github.com/ROCm/TheRock/issues/3284

Our Windows PyTorch wheels have been shipping without torch.distributed support causing third party apps to fail with errors such as 
```
File "D:\languages\python\Lib\site-packages\torch\distributed\distributed_c10d.py", line 23, in
from torch._C._distributed_c10d import (
ModuleNotFoundError: No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
```
Examples

- https://github.com/ROCm/TheRock/issues/1179
- https://github.com/ROCm/TheRock/issues/4102
- https://github.com/ROCm/TheRock/issues/2008

These issues are seen on single GPU systems where there's no actual distributed work being done. We've been mitigating these issues by patching the upstream libraries to have fallback support when torch.distributed isn't available but the longterm solution is to enable the GLOO backend.

## Technical Details

In `build_windows_pytorch_wheels.yml`
- Add vcpkg libuv install step and set libuv_ROOT so PyTorch's CMake finds it

In `external-builds/pytorch/build_prod_wheels.py`
- Set USE_GLOO=ON unconditionally (was Linux-only)
- Add copy_libuv_to_torch_lib() to bundle uv.dll into torch/lib/, following the same pattern as copy_msvc_libomp_to_torch_lib()

## Test Plan

- Run `Build Windows Pytorch Wheels` workflow to generate wheels
- Test that both the GLOO backend and torch.distributed are available.

## Test Result
Using the wheels built from https://github.com/ROCm/TheRock/actions/runs/27149444602 on gfx1151,

```
python -c "import torch.distributed; print('torch.distributed available:', torch.distributed.is_available()); print('GLOO available:', torch.distributed.is_gloo_available())"
torch.distributed available: True
GLOO available: True
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
