### PR TITLE
Revert "[ci] Improving multi arch CI for external repos "

### DIFF
--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -57,9 +57,6 @@ jobs:
     steps:
       - name: Checking out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -119,8 +116,6 @@ jobs:
       amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       platform: linux
       release_type: ${{ inputs.release_type }}
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
 
   test_artifacts_per_family:
     needs: [copy_prebuilt_stages, build_multi_arch_stages]
@@ -154,8 +149,6 @@ jobs:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       rocm_version: ${{ inputs.rocm_deb_package_version }}
       native_package_type: deb
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -169,8 +162,6 @@ jobs:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       rocm_version: ${{ inputs.rocm_rpm_package_version }}
       native_package_type: rpm
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -186,8 +177,6 @@ jobs:
       os_profile: ubuntu2404
       artifact_group: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       test_type: sanity
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -203,8 +192,6 @@ jobs:
       os_profile: rhel10
       artifact_group: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       test_type: sanity
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -220,8 +207,6 @@ jobs:
       os_profile: sles16
       artifact_group: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       test_type: sanity
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -239,8 +224,6 @@ jobs:
       multiarch_index: true
       package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -278,8 +261,6 @@ jobs:
       kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
       container_image_name: ${{ matrix.image.name }}
       container_image_url: ${{ matrix.image.url }}
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
 
   # Multi-arch PyTorch build: one fat wheel covering every target, then
   # split into a host wheel + per-gfx device wheels via rocm-kpack.

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -56,9 +56,6 @@ jobs:
     steps:
       - name: Checking out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -118,8 +115,6 @@ jobs:
       amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       platform: windows
       release_type: ${{ inputs.release_type }}
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
 
   test_artifacts_per_family:
     needs: [copy_prebuilt_stages, build_multi_arch_stages]
@@ -157,8 +152,6 @@ jobs:
       multiarch_index: true
       package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -191,8 +184,6 @@ jobs:
       # Windows runs natively without a container image.
       container_image_name: native
       container_image_url: ""
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
 
   # Multi-arch PyTorch build: one fat wheel covering every target, then
   # split into a host wheel + per-gfx device wheels via rocm-kpack.

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -52,14 +52,6 @@ on:
           on the runner (required for Windows and native Linux runners).
         type: string
         default: "ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26"
-      repository:
-        description: "Repository to checkout. Defaults to github.repository."
-        type: string
-        default: ""
-      ref:
-        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
-        type: string
-        default: ""
 
   workflow_call:
     inputs:
@@ -102,14 +94,6 @@ on:
           and native Linux runners).
         required: true
         type: string
-      repository:
-        description: "Repository to checkout. Defaults to github.repository."
-        type: string
-        default: ""
-      ref:
-        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
-        type: string
-        default: ""
 
 permissions:
   contents: read
@@ -141,9 +125,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref }}
 
       # actions/setup-python only has prebuilt binaries for Ubuntu
       - name: Set up Python

--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -46,9 +46,9 @@ class S3BucketConfig:
 
 
 s3_bucket_configs = [
-    # CI
+    # CI (self-hosted runners include credentials for therock-ci-artifacts-external)
     S3BucketConfig("therock-ci-artifacts", iam_role="therock-ci"),
-    S3BucketConfig("therock-ci-artifacts-external", iam_role="therock-ci-external"),
+    S3BucketConfig("therock-ci-artifacts-external", iam_role=None),
     # Release type "dev"
     S3BucketConfig("therock-dev-artifacts", iam_role="therock-dev"),
     S3BucketConfig("therock-dev-packages", iam_role="therock-dev"),


### PR DESCRIPTION
Reverts ROCm/TheRock#5450 to fix https://github.com/ROCm/TheRock/issues/5654

This broke CI on PRs from forks, e.g. https://github.com/ROCm/TheRock/actions/runs/26984086713?pr=5531:
```
Error: Could not assume role with user credentials: User: arn:aws:sts::324352301041:assumed-role/therock-runners-prod-runner-s3-external/aws-sdk-js-session-1780614257367 is not authorized to perform: sts:TagSession on resource: arn:aws:iam::692859939525:role/therock-ci-external
```