### PR TITLE
[ci] Adopting `test_filtering.md` correctly in all test scripts and github actions scripts

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -614,7 +614,7 @@ def _determine_test_type(
     ):
         matching = set(git_context.submodule_paths) & set(git_context.changed_files)
         if matching:
-            return "full", f"submodule(s) changed: {sorted(matching)}"
+            return "standard", f"submodule(s) changed: {sorted(matching)}"
 
     # Default: quick tests for fast CI feedback.
     return "quick", "default"

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -673,7 +673,7 @@ def run():
     platform = os.getenv("RUNNER_OS").lower()
     projects_to_test = os.getenv("PROJECTS_TO_TEST", "*")
     amdgpu_families = os.getenv("AMDGPU_FAMILIES")
-    test_type = os.getenv("TEST_TYPE", "full")
+    test_type = os.getenv("TEST_TYPE", "standard")
     test_labels = ast.literal_eval(os.getenv("TEST_LABELS") or "[]")
     run_extended_tests = str2bool(os.getenv("RUN_EXTENDED_TESTS", "false"))
     windows_hip_rocr_tests = str2bool(os.getenv("WINDOWS_HIP_ROCR_TESTS", "false"))

--- a/build_tools/github_actions/test_executable_scripts/test_amdsmi.py
+++ b/build_tools/github_actions/test_executable_scripts/test_amdsmi.py
@@ -52,14 +52,14 @@ TOTAL_SHARDS = os.getenv("TOTAL_SHARDS", "1")
 environ_vars = os.environ.copy()
 environ_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
 environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
-test_type = os.getenv("TEST_TYPE", "full")
+test_type = os.getenv("TEST_TYPE", "standard")
 
 if test_type == "quick":
     logging.info("Running quick tests only for amdsmitst")
     test_filter = ["--gtest_filter=AmdSmiDynamicMetricTest.*"]
 
 else:
-    logging.info("Running full amdsmitst test suite (include + exclude filter)")
+    logging.info("Running standard amdsmitst test suite (include + exclude filter)")
 
     include_tests = [
         "amdsmitstReadOnly.*",

--- a/build_tools/github_actions/test_executable_scripts/test_hipblas.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblas.py
@@ -43,8 +43,8 @@ cmd = [
 ]
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the normal test suite
-test_type = os.getenv("TEST_TYPE", "full")
+# Otherwise, we run the standard test suite.
+test_type = os.getenv("TEST_TYPE", "standard")
 if test_type == "quick":
     cmd += [
         "--yaml",

--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
@@ -33,8 +33,8 @@ if is_asan():
     environ_vars["OMP_NUM_THREADS"] = "1"
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the normal test suite
-test_type = os.getenv("TEST_TYPE", "full")
+# Otherwise, we run the standard test suite.
+test_type = os.getenv("TEST_TYPE", "standard")
 
 # Only run quick tests (less memory intensive) for Windows strix-halo, issue: https://github.com/ROCm/TheRock/issues/1750
 if AMDGPU_FAMILIES == "gfx1151" and platform == "windows":
@@ -43,8 +43,6 @@ if AMDGPU_FAMILIES == "gfx1151" and platform == "windows":
 test_filter = []
 if test_type == "quick":
     test_filter.append("--gtest_filter=*smoke*")
-elif test_type == "quick":
-    test_filter.append("--gtest_filter=*quick*")
 
 cmd = [f"{THEROCK_BIN_DIR}/hipblaslt-test"] + test_filter
 

--- a/build_tools/github_actions/test_executable_scripts/test_hipblasltprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblasltprovider.py
@@ -24,7 +24,7 @@ cmd = [
 
 # Determine test filter based on TEST_TYPE environment variable
 environ_vars = os.environ.copy()
-test_type = os.getenv("TEST_TYPE", "full")
+test_type = os.getenv("TEST_TYPE", "standard")
 
 if test_type == "quick":
     # Exclude tests that start with "Full" during quick tests

--- a/build_tools/github_actions/test_executable_scripts/test_hipcub.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipcub.py
@@ -106,9 +106,9 @@ cmd = [
 ]
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the normal test suite
+# Otherwise, we run the standard test suite.
 environ_vars = os.environ.copy()
-test_type = os.getenv("TEST_TYPE", "full")
+test_type = os.getenv("TEST_TYPE", "standard")
 if test_type == "quick":
     environ_vars["GTEST_FILTER"] = ":".join(QUICK_TESTS)
 

--- a/build_tools/github_actions/test_executable_scripts/test_hipfft.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipfft.py
@@ -22,12 +22,12 @@ environ_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
 environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the normal test suite
-test_type = os.getenv("TEST_TYPE", "full")
+# Otherwise, we run the standard test suite.
+test_type = os.getenv("TEST_TYPE", "standard")
 if test_type == "quick":
     test_filter = ["--smoketest"]
 else:
-    # "--test_prob" is the probability that a given test will run.
+    # Standard/comprehensive: "--test_prob" is the probability that a given test will run.
     # Due to the large number of tests for hipFFT, we only run a subset.
     test_filter = [
         "--gtest_filter=-*multi_gpu*",

--- a/build_tools/github_actions/test_executable_scripts/test_hipkernelprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipkernelprovider.py
@@ -29,10 +29,10 @@ cmd = [
 ]
 
 # Determine test filter based on TEST_TYPE environment variable
-test_type = os.getenv("TEST_TYPE", "full")
+test_type = os.getenv("TEST_TYPE", "standard")
 
-if test_type == "smoke":
-    # Exclude tests that start with "Full" during smoke tests
+if test_type == "quick":
+    # Exclude tests that start with "Full" during quick tests
     environ_vars["GTEST_FILTER"] = "-Full*"
 
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")

--- a/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsparse.py
@@ -47,7 +47,7 @@ cmd = [f"{THEROCK_BIN_DIR}/hipsparse-test"]
 
 gtest_filter = "--gtest_filter="
 
-test_type = os.getenv("TEST_TYPE", "full")
+test_type = os.getenv("TEST_TYPE", "standard")
 if test_type == "quick":
     gtest_filter += "*spmv*:*spsv*:*spsm*:*spmm*:*csric0*:*csrilu0*:-known_bug*"
 else:

--- a/build_tools/github_actions/test_executable_scripts/test_hipsparselt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipsparselt.py
@@ -23,8 +23,8 @@ environ_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
 environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the normal test suite
-test_type = os.getenv("TEST_TYPE", "full")
+# Otherwise, we run the standard test suite.
+test_type = os.getenv("TEST_TYPE", "standard")
 
 test_filter = []
 if test_type == "quick":

--- a/build_tools/github_actions/test_executable_scripts/test_miopen.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopen.py
@@ -273,8 +273,8 @@ if AMDGPU_FAMILIES != "gfx950-dcgpu":
 ####################################################
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the normal test suite
-test_type = os.getenv("TEST_TYPE", "full")
+# Otherwise, we run the standard test suite.
+test_type = os.getenv("TEST_TYPE", "standard")
 if test_type == "quick":
     test_filter = "--gtest_filter=" + ":".join(quick_filter)
 else:

--- a/build_tools/github_actions/test_executable_scripts/test_miopenprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopenprovider.py
@@ -45,7 +45,7 @@ if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILI
 
 # Determine test filter based on TEST_TYPE environment variable
 environ_vars = os.environ.copy()
-test_type = os.getenv("TEST_TYPE", "full")
+test_type = os.getenv("TEST_TYPE", "standard")
 
 if test_type == "quick":
     # Exclude tests that start with "Full" during quick tests

--- a/build_tools/github_actions/test_executable_scripts/test_rocblas.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocblas.py
@@ -30,8 +30,8 @@ if is_asan():
 logging.basicConfig(level=logging.INFO)
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the normal test suite
-test_type = os.getenv("TEST_TYPE", "full")
+# Otherwise, we run the standard test suite.
+test_type = os.getenv("TEST_TYPE", "standard")
 if test_type == "quick":
     test_filter = ["--yaml", f"{THEROCK_BIN_DIR}/rocblas_smoke.yaml"]
 else:

--- a/build_tools/github_actions/test_executable_scripts/test_rocfft.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocfft.py
@@ -22,12 +22,12 @@ environ_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
 environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the normal test suite
-test_type = os.getenv("TEST_TYPE", "full")
+# Otherwise, we run the standard test suite.
+test_type = os.getenv("TEST_TYPE", "standard")
 if test_type == "quick":
     test_filter = ["--smoketest"]
 else:
-    # "--test_prob" is the probability that a given test will run.
+    # Standard/comprehensive: "--test_prob" is the probability that a given test will run.
     # Due to the large number of tests for rocFFT, we only run a subset.
     test_filter = [
         "--gtest_filter=-*multi_gpu*",

--- a/build_tools/github_actions/test_executable_scripts/test_rocprim.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprim.py
@@ -155,9 +155,9 @@ if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILI
     cmd.extend(["--exclude-regex", "|".join(ignored_tests)])
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the normal test suite
+# Otherwise, we run the standard test suite.
 environ_vars = os.environ.copy()
-test_type = os.getenv("TEST_TYPE", "full")
+test_type = os.getenv("TEST_TYPE", "standard")
 if test_type == "quick":
     environ_vars["GTEST_FILTER"] = ":".join(QUICK_TESTS)
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_compute.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_compute.py
@@ -77,8 +77,8 @@ def execute_tests():
     ]
 
     # If quick tests are enabled, we run quick tests only.
-    # Otherwise, we run the normal test suite
-    test_type = os.getenv("TEST_TYPE", "full")
+    # Otherwise, we run the standard test suite.
+    test_type = os.getenv("TEST_TYPE", "standard")
     if test_type == "quick":
         cmd.append("--tests-regex")
         cmd.append("|".join(QUICK_TESTS))

--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
@@ -82,7 +82,7 @@ def execute_tests():
     # TODO: Sharding cannot be used as certain of our tests depend on the output of other tests
     # shard_index = int(os.getenv("SHARD_INDEX", "1")) - 1
     # total_shards = int(os.getenv("TOTAL_SHARDS", "1"))
-    test_type = os.getenv("TEST_TYPE", "full").lower()
+    test_type = os.getenv("TEST_TYPE", "standard").lower()
 
     ctest_base = [
         "ctest",

--- a/build_tools/github_actions/test_executable_scripts/test_rocrand.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocrand.py
@@ -94,9 +94,9 @@ cmd = [
 ]
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the normal test suite
+# Otherwise, we run the standard test suite.
 environ_vars = os.environ.copy()
-test_type = os.getenv("TEST_TYPE", "full")
+test_type = os.getenv("TEST_TYPE", "standard")
 if test_type == "quick":
     environ_vars["GTEST_FILTER"] = ":".join(QUICK_TESTS)
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocroller.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocroller.py
@@ -68,7 +68,7 @@ if platform == "linux":
     env["HIP_PATH"] = str(THEROCK_DIST_DIR)
 
 # TEST_TYPE → gtest filter
-TEST_TYPE = os.getenv("TEST_TYPE", "full").lower()
+TEST_TYPE = os.getenv("TEST_TYPE", "standard").lower()
 test_filter_arg = None
 if TEST_TYPE == "quick":
     # keep this subset (TODO: add more tests)
@@ -81,8 +81,6 @@ if TEST_TYPE == "quick":
         "ComponentTest.*",
     ]
     test_filter_arg = "--gtest_filter=" + ":".join(quick_tests)
-elif TEST_TYPE == "quick":
-    test_filter_arg = "--gtest_filter=*quick*"
 
 # Append to the existing filter or start a negative-only filter
 # TODO(#2030): re-enable these tests once compatible with TheRock

--- a/build_tools/github_actions/test_executable_scripts/test_rocrtst.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocrtst.py
@@ -80,7 +80,7 @@ if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILI
     ignored_tests = TEST_TO_IGNORE[AMDGPU_FAMILIES][os_type]
     exclude_filter += ":".join(ignored_tests)
 
-test_type = os.getenv("TEST_TYPE", "full")
+test_type = os.getenv("TEST_TYPE", "standard")
 
 if test_type == "quick":
     environ_vars["GTEST_FILTER"] = ":".join(QUICK_TESTS) + ":" + exclude_filter

--- a/build_tools/github_actions/test_executable_scripts/test_rocsolver.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocsolver.py
@@ -27,9 +27,9 @@ cmd = [
 ]
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the normal test suite
+# Otherwise, we run the standard test suite.
 # Test filter patterns retrieved from https://github.com/ROCm/rocm-libraries/blob/a18b17eef6c24bcd4bcf8dd6a0e36325cbcd11a7/projects/rocsolver/rtest.xml
-test_type = os.getenv("TEST_TYPE", "full")
+test_type = os.getenv("TEST_TYPE", "standard")
 if test_type == "quick":
     quick_tests = [
         "checkin*BDSQR*",

--- a/build_tools/github_actions/test_executable_scripts/test_rocsparse.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocsparse.py
@@ -23,8 +23,8 @@ environ_vars["GTEST_SHARD_INDEX"] = str(int(SHARD_INDEX) - 1)
 environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the normal test suite
-test_type = os.getenv("TEST_TYPE", "full")
+# Otherwise, we run the standard test suite.
+test_type = os.getenv("TEST_TYPE", "standard")
 if test_type == "quick":
     test_filter = [
         "--yaml",

--- a/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
@@ -137,9 +137,9 @@ cmd = [
 ]
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the normal test suite
+# Otherwise, we run the standard test suite.
 environ_vars = os.environ.copy()
-test_type = os.getenv("TEST_TYPE", "full")
+test_type = os.getenv("TEST_TYPE", "standard")
 if test_type == "quick":
     environ_vars["GTEST_FILTER"] = ":".join(QUICK_TESTS)
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
@@ -31,8 +31,8 @@ environ_vars["ROCM_PATH"] = str(ROCM_PATH)
 logging.basicConfig(level=logging.INFO)
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the normal test suite
-test_type = os.getenv("TEST_TYPE", "full")
+# Otherwise, we run the standard test suite.
+test_type = os.getenv("TEST_TYPE", "standard")
 
 # TODO(#2823): Re-enable test once flaky issue is resolved
 TESTS_TO_IGNORE = ["unpack_util_test", "contamination_test", "map_util_test"]

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -324,7 +324,7 @@ class TestDecideJobs(unittest.TestCase):
             submodule_paths=["rocm-libraries", "rocm-systems"],
         )
         result = cm.decide_jobs(self._inputs(), git_context=git)
-        self.assertEqual(result.test_rocm.test_type, "full")
+        self.assertEqual(result.test_rocm.test_type, "standard")
         self.assertIn("submodule", result.test_rocm.test_type_reason)
 
     def test_no_submodule_change_stays_quick(self):


### PR DESCRIPTION
As test standarization work is set in and to match behavior in https://github.com/ROCm/TheRock/blob/main/docs/development/test_filtering.md, we are converting the default to standard for all scripts / workflows

Previously, the default was full which is inaccurate