### PR TITLE
[ci] Restore AWS build runners to 20%

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -51,8 +51,8 @@ def select_weighted_label(labels_config: list[dict], context_name: str) -> str:
 BUILD_RUNNER_LABELS = {
     "linux": {
         "default": [
-            {"label": "azure-linux-scale-rocm", "weight": 1.0},
-            {"label": "aws-linux-scale-rocm-prod", "weight": 0.0},
+            {"label": "azure-linux-scale-rocm", "weight": 0.8},
+            {"label": "aws-linux-scale-rocm-prod", "weight": 0.2},
         ],
         "sanitizer": [
             {"label": "azure-linux-scale-rocm-heavy-ramdisk", "weight": 1.0},

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1421,10 +1421,10 @@ class TestBuildRunnerSelection(unittest.TestCase):
                 select_build_runner("linux", "release"), "azure-linux-scale-rocm"
             )
 
-        # Random >= 0.8 should select Azure
+        # Random >= 0.8 should select AWS
         with patch("random.random", return_value=0.95):
             self.assertEqual(
-                select_build_runner("linux", "release"), "azure-linux-scale-rocm"
+                select_build_runner("linux", "release"), "aws-linux-scale-rocm-prod"
             )
 
         # Random >= 0.9 should select Azure


### PR DESCRIPTION
## Summary

- Restores AWS prod runner weight from 0% → 20% (80% Azure / 20% AWS)
- Reverts the drain change from #5700
- Prod cluster ARC upgrade to 0.13.1 is complete

## Test plan
- [ ] Verify CI jobs begin routing ~20% of Linux builds to `aws-linux-scale-rocm-prod`
- [ ] Monitor Grafana prod dashboard for runner pod pressure and co-location

🤖 Generated with [Claude Code](https://claude.com/claude-code)