### PR TITLE
[ci] Fix nightly Multi-Arch Release: declare build_pytorch/python_version under workflow_call

### DIFF
--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -43,6 +43,14 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
+      build_pytorch:
+        description: "Build PyTorch wheels"
+        type: boolean
+        default: true
+      python_version:
+        description: "Single Python version for wheel builds (empty for full matrix)"
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       release_type:


### PR DESCRIPTION
## Motivation

This pull request makes a small update to the `.github/workflows/multi_arch_release.yml` workflow configuration. It adds two new workflow dispatch inputs to control whether PyTorch wheels are built and to specify a single Python version for wheel builds.

On the workflow_call (scheduled nightly) path those inputs are undefined and resolve to an empty string '', which is then passed to the boolean-typed build_pytorch input of multi_arch_release_linux.yml / multi_arch_release_windows.yml — an invalid boolean, hence "Unexpected value ''".

## Technical Details

- Added build_pytorch and python_version to the on.workflow_call.inputs block of multi_arch_release.yml, mirroring the existing workflow_dispatch declarations.



## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

https://github.com/ROCm/rockrel/actions/runs/27181867499

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
