### PR TITLE
[ROCM-20223] CV Integration - RPP inclusion (3/3)

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -726,6 +726,20 @@ test_matrix = {
             "linux": 1,
         },
     },
+    "rpp": {
+        "job_name": "rpp",
+        "fetch_artifact_args": "--rpp --tests",
+        # Sized for comprehensive/full, which runs the perf suites serially and
+        # upstream allows 4000s each. quick and standard are far under this.
+        # TODO(ROCm/rocm-libraries#10187): lower once perf tests are split out
+        # of the correctness suite.
+        "timeout_minutes": 60,
+        "test_script": f"python {_get_script_path('test_rpp.py')}",
+        "platform": ["linux"],
+        "total_shards_dict": {
+            "linux": 1,
+        },
+    },
     # aqlprofile tests
     "aqlprofile": {
         "job_name": "aqlprofile",

--- a/build_tools/github_actions/test_executable_scripts/test_rpp.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rpp.py
@@ -1,0 +1,115 @@
+import logging
+import os
+import re
+import shlex
+import subprocess
+from pathlib import Path
+import sys
+import platform
+
+logging.basicConfig(level=logging.INFO)
+THEROCK_BIN_DIR_STR = os.getenv("THEROCK_BIN_DIR")
+if THEROCK_BIN_DIR_STR is None:
+    logging.info(
+        "++ Error: env(THEROCK_BIN_DIR) is not set. Please set it before executing tests."
+    )
+    sys.exit(1)
+THEROCK_BIN_DIR = Path(THEROCK_BIN_DIR_STR)
+SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_TEST_DIR = Path(THEROCK_DIR) / "build"
+
+RPP_TEST_PATH = str(Path(THEROCK_BIN_DIR).resolve().parent / "share" / "rpp" / "test")
+if not os.path.isdir(RPP_TEST_PATH):
+    logging.info(f"++ Error: rpp tests not found in {RPP_TEST_PATH}")
+    sys.exit(1)
+else:
+    logging.info(f"++ INFO: rpp tests found in {RPP_TEST_PATH}")
+env = os.environ.copy()
+
+# GitHub Actions passes an empty string when a workflow input is left blank.
+TEST_TYPE = (os.getenv("TEST_TYPE") or "standard").lower()
+
+
+def test_filter_args():
+    """CTest filter for the requested category, per docs/development/test_filtering.md.
+
+    The two `test_type_1` entries are RPP's performance suites and take ~58% of
+    the total runtime, so they are reserved for comprehensive/full.
+    """
+    if TEST_TYPE == "quick":
+        return ["-R", "rpp_sanity_test"]
+    if TEST_TYPE == "standard":
+        return ["-E", "test_type_1"]
+    return []
+
+
+# set env variables required for tests
+def setup_env(env):
+    ROCM_PATH = Path(THEROCK_BIN_DIR).resolve().parent
+    env["ROCM_PATH"] = str(ROCM_PATH)
+    logging.info(f"++ rpp setting ROCM_PATH={ROCM_PATH}")
+    if platform.system() == "Linux":
+        HIP_LIB_PATH = Path(THEROCK_BIN_DIR).resolve().parent / "lib"
+        logging.info(f"++ rpp setting LD_LIBRARY_PATH={HIP_LIB_PATH}")
+        if "LD_LIBRARY_PATH" in env:
+            env["LD_LIBRARY_PATH"] = f"{HIP_LIB_PATH}:{env['LD_LIBRARY_PATH']}"
+        else:
+            env["LD_LIBRARY_PATH"] = str(HIP_LIB_PATH)
+    else:
+        logging.info("++ rpp tests only supported on Linux")
+        sys.exit(0)
+
+
+def execute_tests(env):
+    RPP_TEST_DIR = Path(THEROCK_TEST_DIR) / "rpp-test"
+    RPP_TEST_DIR.mkdir(parents=True, exist_ok=True)
+
+    # rpp ships its tests as CMake source, built here against the installed
+    # headers/libs because some test deps are only available from the system.
+    # TODO(ROCm/rocm-libraries#10187): drop once prebuilt test binaries ship.
+    cmd = [
+        "cmake",
+        "-GNinja",
+        RPP_TEST_PATH,
+    ]
+    logging.info(f"++ Exec [{RPP_TEST_DIR}]$ {shlex.join(cmd)}")
+    subprocess.run(cmd, cwd=RPP_TEST_DIR, check=True, env=env)
+
+    filter_args = test_filter_args()
+    logging.info(f"++ rpp test category TEST_TYPE={TEST_TYPE}")
+
+    cmd = [
+        "ctest",
+        "-N",
+    ] + filter_args
+    logging.info(f"++ Exec [{RPP_TEST_DIR}]$ {shlex.join(cmd)}")
+    ctest_list = subprocess.run(
+        cmd,
+        cwd=RPP_TEST_DIR,
+        check=True,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    logging.info(ctest_list.stdout)
+    match = re.search(r"Total Tests:\s*(\d+)", ctest_list.stdout)
+    if match is None:
+        raise RuntimeError(
+            "Failed to determine CTest test count from `ctest -N` output"
+        )
+    if int(match.group(1)) == 0:
+        raise RuntimeError(f"CTest discovered zero rpp tests for TEST_TYPE={TEST_TYPE}")
+
+    cmd = [
+        "ctest",
+        "--extra-verbose",
+        "--output-on-failure",
+    ] + filter_args
+    logging.info(f"++ Exec [{RPP_TEST_DIR}]$ {shlex.join(cmd)}")
+    subprocess.run(cmd, cwd=RPP_TEST_DIR, check=True, env=env)
+
+
+if __name__ == "__main__":
+    setup_env(env)
+    execute_tests(env)

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -562,13 +562,16 @@ def retrieve_artifacts_by_run_id(args):
             extra_artifacts.append("rpp")
             # test_rpp.py compiles the test suite against the installed tree,
             # so the _lib expansion below is not sufficient:
-            #   rpp_dev  - lib/cmake/rpp for find_package(rpp), plus headers.
-            #   base_dev - include/half/half.hpp, which api/rppdefs.h includes
-            #              to define Rpp16f.
-            # OpenMP needs nothing extra here: libomp.so and omp.h both ship
-            # in amd-llvm_lib, already fetched via base_artifact_patterns.
+            #   rpp_dev      - lib/cmake/rpp for find_package(rpp), plus headers.
+            #   base_dev     - include/half/half.hpp, which api/rppdefs.h
+            #                  includes to define Rpp16f.
+            #   amd-llvm_dev - lib/llvm/lib/cmake/AMDDeviceLibs. rpp-config.cmake
+            #                  calls find_dependency(HIP), and hip-config-amd.cmake
+            #                  in turn resolves AMDDeviceLibs through the
+            #                  lib/cmake/AMDDeviceLibs shim in base_lib.
             argv.append("rpp_dev")
             argv.append("base_dev")
+            argv.append("amd-llvm_dev")
         if args.libhipcxx:
             extra_artifacts.append("libhipcxx")
             argv.append("amd-llvm_dev")


### PR DESCRIPTION
## Motivation

Integrate RPP (ROCm Performance Primitives) into TheRock under a new cv-libs group

Track: Jira ID - ROCM-20223

## Technical Details

Integrates [RPP](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rpp) into TheRock under a new top-level `cv-libs/` (computer vision) group.

- **New `cv-libs/` component**: `CMakeLists.txt`, `artifact-rpp.toml`, and `README.md`. RPP builds from `rocm-libraries/projects/rpp` with the HIP backend (`-DBACKEND=HIP`, `-DRPP_AUDIO_SUPPORT=OFF`).
- **Minimal, audited dependency set** (verified against upstream RPP CMake): `RUNTIME_DEPS hip-clr`, `BUILD_DEPS rocm-half`, `COMPILER_TOOLCHAIN amd-hip`, and `therock_explicit_finders.cmake` for RPP's `find_path(half/half.hpp)`. 
- **Build topology**: new `cv-libs` build stage, artifact group, and `rpp` artifact (`feature_group = "CV_LIBS"`, `artifact_deps = ["core-runtime", "core-hip", "base", "sysdeps"]`).
- **Feature flags**: `THEROCK_ENABLE_CV_LIBS` (group) and `THEROCK_ENABLE_RPP`. On by default on Linux; experimental and **off by default on Windows** (opt-in via `-DTHEROCK_ENABLE_RPP=ON`).
- **CI**: new `cv-libs` stage in the Linux portable build workflow and an `rpp` CTest job (builds the installed test tree and runs `ctest`, 60 min timeout for RPP's long QA suites).
- **Packaging / install / dist**: `amdrocm-rpp`, `amdrocm-rpp-devel`, `amdrocm-rpp-test` Debian/RPM packages wired into the core metapackages; `--rpp` flag in `install_rocm_from_artifacts.py`; `librpp.so*` entry in `_dist_info.py` under the `libraries` package (no Windows DLL pattern, since RPP is not built on Windows in CI); `rpp` in the libraries wheel filter in `build_python_packages.py`, plus a `lib/llvm/lib` rpath on that wheel so `librpp.so` resolves libomp from core; coverage in `analyze_build_times.py` and the manylinux/container configure paths.
- **Docs**: README feature-flag tables, build_system, artifacts, installing_artifacts, ci_overview, ci_behavior_manipulation, and windows_support updated.
## Notes
- Windows support for RPP is experimental and not built in CI; upstream blockers (e.g. unconditional `stdc++fs` link) are tracked in [ROCm/rpp#729](https://github.com/ROCm/rpp/issues/729).

## Test Plan

- [x] `cv-libs` CI stage builds RPP green on Linux for the target families
- [x] `rpp` CTest job passes (installed test tree configures + `ctest` runs)
- [x] `python build_tools/topology_to_cmake.py --validate-only` passes (verified locally)
- [x] `pytest build_tools/tests/build_topology_test.py build_tools/tests/fetch_sources_mirror_test.py` passes (verified locally: 42 passed)
- [x] `install_rocm_from_artifacts.py --rpp --tests` fetches the expected artifacts
- [x] Packages build and the `amdrocm-rpp*` deps resolve

## Test Result

RPP artifacts built with TheRock

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
