### PR TITLE
hipcc: prefer install layout over stale ROCM_PATH (llvm 0007).

### DIFF
--- a/patches/amd-mainline/llvm-project/0007-Rework-constructRoccmPath-so-ROCM_PATH-env-var-is-lower.patch
+++ b/patches/amd-mainline/llvm-project/0007-Rework-constructRoccmPath-so-ROCM_PATH-env-var-is-lower.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TheRock <therock@amd.com>
+Date: Wed, 3 Jun 2026 00:00:00 +0000
+Subject: [PATCH 7/8] Rework constructRoccmPath so ROCM_PATH env var is lower
+ priority.
+
+Mirror constructHipPath (PATCH 6/8): prefer the install layout next to
+hipcc over a stale ROCM_PATH from the host environment.
+---
+ amd/hipcc/src/hipBin_base.h | 27 +++++++++++++++++++++------
+ 1 file changed, 21 insertions(+), 6 deletions(-)
+
+diff --git a/amd/hipcc/src/hipBin_base.h b/amd/hipcc/src/hipBin_base.h
+index 1d2f043e9558..65699bb05f71 100644
+--- a/amd/hipcc/src/hipBin_base.h
++++ b/amd/hipcc/src/hipBin_base.h
+@@ -358,16 +358,33 @@ void HipBinBase::constructHipPath() {
+ 
+ // constructs the ROCM path
+ void HipBinBase::constructRoccmPath() {
+-  // we need to use --rocm-path option
++  // The --rocm-path argument option takes precedence over all other settings.
+   string rocm_path_name = getrocm_pathOption();
+-
+-  // chose the --rocm-path option first, if specified.
+-  if (!rocm_path_name.empty())
++  if (!rocm_path_name.empty()) {
+     variables_.roccmPathEnv_ = rocm_path_name;
+-  else if (envVariables_.roccmPathEnv_.empty()) {
+-    variables_.roccmPathEnv_ = getHipPath();
+-  } else {
+-    variables_.roccmPathEnv_ = envVariables_.roccmPathEnv_;}
++    return;
++  }
++
++  fs::path full_path(hipcc::utils::getSelfPath());
++  fs::path parent_path = full_path.parent_path();
++
++  // Next, check for `../lib/llvm/bin/`, the standard ROCm install structure.
++  fs::path llvm_path = parent_path / "lib" / "llvm" / "bin";
++  if (fs::exists(llvm_path)) {
++    variables_.roccmPathEnv_ = parent_path.string();
++    return;
++  }
++
++  // Otherwise, check the ROCM_PATH environment variable from the HIP SDK.
++  // Self-contained builds/installs should not read stale global state when
++  // the install layout is detectable (same rationale as constructHipPath).
++  if (!envVariables_.roccmPathEnv_.empty()) {
++    variables_.roccmPathEnv_ = envVariables_.roccmPathEnv_;
++    return;
++  }
++
++  // Finally, fallback to the HIP path.
++  variables_.roccmPathEnv_ = getHipPath();
+ }
+ 
+ // reads the Hip Version

--- a/patches/amd-mainline/llvm-project/0007-Rework-constructRoccmPath-so-ROCM_PATH-env-var-is-lower.patch
+++ b/patches/amd-mainline/llvm-project/0007-Rework-constructRoccmPath-so-ROCM_PATH-env-var-is-lower.patch
@@ -1,14 +1,12 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: TheRock <therock@amd.com>
-Date: Wed, 3 Jun 2026 00:00:00 +0000
+From 4ecdaa8f6513c69c91441f0906314b75fb2f1bdb Mon Sep 17 00:00:00 2001
+From: Tijana Vukovic <tvukovic@amd.com>
+Date: Wed, 10 Jun 2026 09:34:59 -0700
 Subject: [PATCH 7/8] Rework constructRoccmPath so ROCM_PATH env var is lower
  priority.
 
-Mirror constructHipPath (PATCH 6/8): prefer the install layout next to
-hipcc over a stale ROCM_PATH from the host environment.
 ---
- amd/hipcc/src/hipBin_base.h | 27 +++++++++++++++++++++------
- 1 file changed, 21 insertions(+), 6 deletions(-)
+ amd/hipcc/src/hipBin_base.h | 33 +++++++++++++++++++++++++--------
+ 1 file changed, 25 insertions(+), 8 deletions(-)
 
 diff --git a/amd/hipcc/src/hipBin_base.h b/amd/hipcc/src/hipBin_base.h
 index 1d2f043e9558..65699bb05f71 100644
@@ -56,3 +54,6 @@ index 1d2f043e9558..65699bb05f71 100644
  }
  
  // reads the Hip Version
+-- 
+2.51.1.windows.1
+


### PR DESCRIPTION
## Summary

Adds llvm patch `0007` to rework `HipBinBase::constructRoccmPath()` so a stale host `ROCM_PATH` does not override a self-contained `hipcc` install (e.g. Python wheels).

This mirrors the existing `0006` patch for `constructHipPath()` / `HIP_PATH`, which is already on `main`. Path resolution order becomes:

- `--rocm-path` CLI flag (highest)
- Install layout next to `hipcc` (`../lib/llvm/bin/` exists)
- `ROCM_PATH` environment variable (host HIP SDK)
- HIP path fallback

Without this change, `hipcc.exe` invoked directly (not via the Python launcher) can pick up `ROCM_PATH` from a system-wide HIP SDK install and fail or mis-resolve on self-hosted Windows runners and other self-contained installs.

## Changes

- `patches/amd-mainline/llvm-project/0007-Rework-constructRoccmPath-so-ROCM_PATH-env-var-is-lower.patch` — updates `amd/hipcc/src/hipBin_base.h`

## Validation

### Before (fails on `main` — `hipcc` / `rocm-sdk test`)

**Build Windows PyTorch Wheels on `main` (gfx1151, published wheels, stale runner `ROCM_PATH`):**

- Workflow run: https://github.com/ROCm/TheRock/actions/runs/26882526084
- Failing job: https://github.com/ROCm/TheRock/actions/runs/26882526084/job/79297304052
- Failing step: `Run rocm-sdk sanity tests` → `rocm-sdk test` → `core_test.testConsoleScripts` → `hipcc --help`
- In the log, search for: `testConsoleScripts`, `hipcc`, `CalledProcessError`, or `exit status 1`

### After (passes with this patch — Multi-Arch CI, freshly built wheels)

**Multi-Arch CI on `users/tvukovic-amd/hipcc-constructRoccmPath-0007` (`compiler-runtime` rebuilt with patch `0007`):**

- Workflow run: https://github.com/ROCm/TheRock/actions/runs/27130253660
- Passing job: https://github.com/ROCm/TheRock/actions/runs/27130253660/job/80306302745 (`Windows::release / Test Python gfx110X-all / Test ROCm wheels | gfx110X-all | native`)
- Passing steps:
  - `Test rocm[libraries]` → `rocm-sdk test` (includes `testConsoleScripts` / `hipcc --help`)
  - `Test rocm[libraries,devel]` → `rocm-sdk test`
- In the log for `Test rocm[libraries]`, search for: `testConsoleScripts`, `Check console-script hipcc`, or `ok`