### PR TITLE
debug-tools/rocgdb: install rocgdb_ignore_list.json when present

### DIFF
--- a/debug-tools/rocgdb/CMakeLists.txt
+++ b/debug-tools/rocgdb/CMakeLists.txt
@@ -713,6 +713,18 @@ if(BUILD_TESTING)
     DESTINATION tests/rocgdb
     COMPONENT tests
   )
+
+  # Install the optional xfails ignore list, if present in the sources.
+  if(EXISTS "${ROCGDB_SOURCE_DIR}/.github/scripts/rocgdb_ignore_list.json")
+    install(
+      FILES ${ROCGDB_SOURCE_DIR}/.github/scripts/rocgdb_ignore_list.json
+      DESTINATION tests/rocgdb
+      COMPONENT tests
+    )
+  else()
+    message(WARNING "rocgdb tests: xfails ignore list not found at "
+      "${ROCGDB_SOURCE_DIR}/.github/scripts/rocgdb_ignore_list.json; skipping installation.")
+  endif()
 else()
   message(STATUS "rocgdb tests: BUILD_TESTING not set. Skipping installation integrity tests.")
 endif()


### PR DESCRIPTION
Add an optional install rule next to the existing test_rocgdb.py rule so the xfails ignore list is shipped with the testsuite when the ROCgdb sources provide it. Guarded by EXISTS so absence is a no-op.

The xfails file is used by CI.