### PR TITLE
feat(build): forward top-level includes and fix packaging perms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,12 @@ therock_enable_external_source("rocr-debug-agent" "${THEROCK_ROCM_SYSTEMS_SOURCE
 # Overall build settings.
 option(THEROCK_VERBOSE "Enables verbose CMake statuses" OFF)
 set(THEROCK_DEV_PROJECTS "" CACHE STRING "Semicolon-separated list of subprojects that opt in to source globbing even when otherwise skipped (e.g. amd-llvm).")
+set(THEROCK_SUBPROJECT_CMAKE_INCLUDES "" CACHE STRING
+  "Semicolon-separated list of absolute CMake file paths included at the top of \
+every subproject's first project() call (via CMAKE_PROJECT_TOP_LEVEL_INCLUDES). \
+Use this to inject hooks into all subproject configures without editing TheRock. \
+CMAKE_PROJECT_TOP_LEVEL_INCLUDES itself is not forwarded; it only affects the \
+TheRock super-project configure.")
 
 # Initialize the install directory.
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -13,6 +13,7 @@ import os
 from pathlib import Path
 import platform
 import shlex
+import stat
 import subprocess
 import shutil
 import sys
@@ -490,6 +491,10 @@ class PopulatedDistPackage:
         # We have to patch many files, so we do not hard-link: always copy.
         log(f"  MATERIALIZE: {relpath} (from {src_path})", vlog=2)
         shutil.copy2(src_path, dest_path)
+        # copy2 preserves source mode bits. Some upstream files (e.g. LLVM's
+        # OMPD gdb module) are installed read-only, and patchelf below opens the
+        # file for writing, so guarantee the owner-write bit first.
+        os.chmod(dest_path, os.stat(dest_path).st_mode | stat.S_IWUSR)
         if self.files.has(relpath):
             log(f"WARNING: Path already materialized: {relpath}")
         else:

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -1782,7 +1782,9 @@ class MaterializeReadOnlySourceTest(TmpDirTestCase):
         # Use a .txt source so get_file_type() returns "text" and the ELF
         # rpath path (patchelf) is skipped — we only exercise the copy+chmod.
         src = self.write_file("readonly.txt", "payload")
-        os.chmod(src, 0o444)
+        # Owner read-only (no write bit); this is the exact condition the fix
+        # handles. 0o400 rather than 0o444 keeps the temp file non-world-readable.
+        os.chmod(src, 0o400)
 
         dest_path = self.temp_dir / "dest" / "readonly.txt"
         pkg._populate_file(

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -11,6 +11,7 @@ These tests cover:
 
 import json
 import os
+import stat
 import subprocess
 import tempfile
 import unittest
@@ -1747,6 +1748,56 @@ class EnsureProfilerLibrarySymlinksTest(unittest.TestCase):
 
         link = self.lib_dir / "libprofiler-hub.so"
         self.assertEqual(os.readlink(link), "libprofiler-hub.so.99")
+
+
+# ---------------------------------------------------------------------------
+# Tests for materialize permission handling
+# ---------------------------------------------------------------------------
+
+
+def _scandir_entry(path: Path) -> os.DirEntry:
+    with os.scandir(path.parent) as it:
+        for entry in it:
+            if entry.name == path.name:
+                return entry
+    raise FileNotFoundError(path)
+
+
+class MaterializeReadOnlySourceTest(TmpDirTestCase):
+    """Regression test for materializing a read-only upstream file.
+
+    shutil.copy2 preserves the source mode bits, so a read-only source (e.g.
+    LLVM's OMPD gdb module, or any file owned by another user in a shared
+    build tree) was copied read-only. The subsequent patchelf pass then could
+    not open the file for writing. _populate_file must restore the owner-write
+    bit on the materialized file regardless of the source permissions.
+    """
+
+    def test_readonly_source_becomes_owner_writable(self):
+        # Build a package instance without running __init__ (which needs a full
+        # dist_info catalog); _populate_file only touches self.files.
+        pkg = PopulatedDistPackage.__new__(PopulatedDistPackage)
+        pkg.files = PopulatedFiles()
+
+        # Use a .txt source so get_file_type() returns "text" and the ELF
+        # rpath path (patchelf) is skipped — we only exercise the copy+chmod.
+        src = self.write_file("readonly.txt", "payload")
+        os.chmod(src, 0o444)
+
+        dest_path = self.temp_dir / "dest" / "readonly.txt"
+        pkg._populate_file(
+            "readonly.txt",
+            dest_path,
+            _scandir_entry(src),
+            resolve_src=False,
+        )
+
+        mode = stat.S_IMODE(os.stat(dest_path).st_mode)
+        self.assertEqual(dest_path.read_text(), "payload")
+        self.assertTrue(
+            mode & stat.S_IWUSR,
+            f"expected owner-write bit to be set, got mode {oct(mode)}",
+        )
 
 
 if __name__ == "__main__":

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -714,6 +714,14 @@ function(therock_cmake_subproject_activate target_name)
 
   # Compose CMAKE_PROJECT_TOP_LEVEL_INCLUDES for the subproject: its generated
   # init file first, then any files listed in THEROCK_SUBPROJECT_CMAKE_INCLUDES.
+  foreach(_hook IN LISTS THEROCK_SUBPROJECT_CMAKE_INCLUDES)
+    if(NOT IS_ABSOLUTE "${_hook}")
+      message(FATAL_ERROR "THEROCK_SUBPROJECT_CMAKE_INCLUDES: '${_hook}' must be an absolute path")
+    endif()
+    if(NOT EXISTS "${_hook}")
+      message(FATAL_ERROR "THEROCK_SUBPROJECT_CMAKE_INCLUDES: '${_hook}' does not exist")
+    endif()
+  endforeach()
   set(_subproject_top_level_includes "${_cmake_project_init_file}" ${THEROCK_SUBPROJECT_CMAKE_INCLUDES})
 
   # Handle compiler toolchain.
@@ -723,6 +731,7 @@ function(therock_cmake_subproject_activate target_name)
     "${_compiler_toolchain}" "${_cmake_project_toolchain_file}"
     "${_subproject_top_level_includes}")
   list(APPEND _fprint_files "${_cmake_project_toolchain_file}")
+  list(APPEND _fprint_files ${THEROCK_SUBPROJECT_CMAKE_INCLUDES})
 
   # Customize any other super-project CMake variables that are captured by
   # _init.cmake.

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -712,11 +712,16 @@ function(therock_cmake_subproject_activate target_name)
   # TODO: split into 'build' and 'configure'? Keeping them in sync seems useful.
   _therock_cmake_subproject_build_env_pairs(_build_env_pairs)
 
+  # Compose CMAKE_PROJECT_TOP_LEVEL_INCLUDES for the subproject: its generated
+  # init file first, then any files listed in THEROCK_SUBPROJECT_CMAKE_INCLUDES.
+  set(_subproject_top_level_includes "${_cmake_project_init_file}" ${THEROCK_SUBPROJECT_CMAKE_INCLUDES})
+
   # Handle compiler toolchain.
   set(_compiler_toolchain_addl_depends)
   set(_compiler_toolchain_init_contents)
   _therock_cmake_subproject_setup_toolchain("${target_name}"
-    "${_compiler_toolchain}" "${_cmake_project_toolchain_file}")
+    "${_compiler_toolchain}" "${_cmake_project_toolchain_file}"
+    "${_subproject_top_level_includes}")
   list(APPEND _fprint_files "${_cmake_project_toolchain_file}")
 
   # Customize any other super-project CMake variables that are captured by
@@ -971,19 +976,6 @@ function(therock_cmake_subproject_activate target_name)
       "STAGE_DESTINATION_DIR=${_rel_stage_destination_dir}"
     )
 
-    # Forward the superproject's CMAKE_PROJECT_TOP_LEVEL_INCLUDES (if any) to the
-    # subproject, alongside its generated init file, so a top-level
-    # -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=... reaches every subproject configure.
-    set(_subproject_top_level_includes "${_cmake_project_init_file}")
-    if(CMAKE_PROJECT_TOP_LEVEL_INCLUDES)
-      list(APPEND _subproject_top_level_includes ${CMAKE_PROJECT_TOP_LEVEL_INCLUDES})
-    endif()
-    # Escape the ';' list separator so the multi-file value reaches cmake as a
-    # single argument. Unescaped, the ';' is emitted verbatim into the generator's
-    # '/bin/sh -c' rule as a shell command separator, which then tries to execute
-    # the trailing include file as a program.
-    string(REPLACE ";" "\\;" _subproject_top_level_includes "${_subproject_top_level_includes}")
-
     # Configure command.
     add_custom_command(
       OUTPUT "${_configure_stamp_file}"
@@ -998,7 +990,6 @@ function(therock_cmake_subproject_activate target_name)
         "-DCMAKE_INSTALL_PREFIX=${_stage_destination_dir}"
         "-DTHEROCK_STAGE_INSTALL_ROOT=${_stage_dir}"
         "-DCMAKE_TOOLCHAIN_FILE=${_cmake_project_toolchain_file}"
-        "-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=${_subproject_top_level_includes}"
         ${_cmake_args}
       # CMake doesn't always generate a compile_commands.json so touch one to keep
       # the build graph sane.
@@ -1642,7 +1633,7 @@ endfunction()
 #   * amd-hip: Extends the amd-llvm toolchain to also depend on HIP, making
 #     it ready to use to compile HIP code.
 function(_therock_cmake_subproject_setup_toolchain
-    target_name compiler_toolchain toolchain_file)
+    target_name compiler_toolchain toolchain_file top_level_includes)
   string(APPEND CMAKE_MESSAGE_INDENT "  ")
   set(_build_env_pairs "${_build_env_pairs}")
   set(_toolchain_contents)
@@ -1682,6 +1673,10 @@ function(_therock_cmake_subproject_setup_toolchain
   endif()
 
   # General settings applicable to all toolchains.
+  # Register the subproject's generated init file plus any THEROCK_SUBPROJECT_CMAKE_INCLUDES
+  # files. The toolchain is read during system determination, before project() consults
+  # CMAKE_PROJECT_TOP_LEVEL_INCLUDES.
+  string(APPEND _toolchain_contents "set(CMAKE_PROJECT_TOP_LEVEL_INCLUDES \"@top_level_includes@\")\n")
   string(APPEND _toolchain_contents "set(CMAKE_EXPORT_COMPILE_COMMANDS ON)\n")
   string(APPEND _toolchain_contents "set(CMAKE_INSTALL_LIBDIR @CMAKE_INSTALL_LIBDIR@)\n")
   string(APPEND _toolchain_contents "set(CMAKE_PLATFORM_NO_VERSIONED_SONAME @CMAKE_PLATFORM_NO_VERSIONED_SONAME@)\n")

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -867,13 +867,15 @@ function(therock_cmake_subproject_activate target_name)
     string(APPEND _init_contents "set(THEROCK_USER_POST_HOOK \"@_post_hook_path@\")\n")
   endif()
   set(_global_post_include "${THEROCK_SOURCE_DIR}/cmake/therock_global_post_subproject.cmake")
-  # The subproject toolchain sets CMAKE_PROJECT_TOP_LEVEL_INCLUDES, which try_compile
-  # re-reads during compiler detection, so this init file also runs inside the scratch
-  # project. Do not schedule the global post hook there: it references targets that only
-  # exist in the real subproject (aborting the compiler check) and its rpath/debug-split
-  # fixups are meaningless for a throwaway project. The scratch project is named
-  # CMAKE_TRY_COMPILE.
-  string(APPEND _init_contents "if(NOT CMAKE_PROJECT_NAME STREQUAL \"CMAKE_TRY_COMPILE\")\n")
+  # The subproject toolchain sets CMAKE_PROJECT_TOP_LEVEL_INCLUDES, so the
+  # generated init file is also replayed inside nested try_compile()/try_run()
+  # scratch-project configures, not just the real subproject configure.
+  #
+  # Do not schedule the global post hook there: it may reference targets that
+  # only exist in the real subproject, and its rpath/debug-split/stamp-touch
+  # side effects are meaningless for throwaway probe builds.
+  string(APPEND _init_contents "get_property(_therock_in_try_compile GLOBAL PROPERTY IN_TRY_COMPILE)\n")
+  string(APPEND _init_contents "if(NOT _therock_in_try_compile)\n")
   string(APPEND _init_contents "  cmake_language(DEFER CALL include \"@_global_post_include@\")\n")
   string(APPEND _init_contents "endif()\n")
   foreach(_addl_cmake_include ${_cmake_includes})

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -971,6 +971,19 @@ function(therock_cmake_subproject_activate target_name)
       "STAGE_DESTINATION_DIR=${_rel_stage_destination_dir}"
     )
 
+    # Forward the superproject's CMAKE_PROJECT_TOP_LEVEL_INCLUDES (if any) to the
+    # subproject, alongside its generated init file, so a top-level
+    # -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=... reaches every subproject configure.
+    set(_subproject_top_level_includes "${_cmake_project_init_file}")
+    if(CMAKE_PROJECT_TOP_LEVEL_INCLUDES)
+      list(APPEND _subproject_top_level_includes ${CMAKE_PROJECT_TOP_LEVEL_INCLUDES})
+    endif()
+    # Escape the ';' list separator so the multi-file value reaches cmake as a
+    # single argument. Unescaped, the ';' is emitted verbatim into the generator's
+    # '/bin/sh -c' rule as a shell command separator, which then tries to execute
+    # the trailing include file as a program.
+    string(REPLACE ";" "\\;" _subproject_top_level_includes "${_subproject_top_level_includes}")
+
     # Configure command.
     add_custom_command(
       OUTPUT "${_configure_stamp_file}"
@@ -985,7 +998,7 @@ function(therock_cmake_subproject_activate target_name)
         "-DCMAKE_INSTALL_PREFIX=${_stage_destination_dir}"
         "-DTHEROCK_STAGE_INSTALL_ROOT=${_stage_dir}"
         "-DCMAKE_TOOLCHAIN_FILE=${_cmake_project_toolchain_file}"
-        "-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=${_cmake_project_init_file}"
+        "-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=${_subproject_top_level_includes}"
         ${_cmake_args}
       # CMake doesn't always generate a compile_commands.json so touch one to keep
       # the build graph sane.

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -867,7 +867,15 @@ function(therock_cmake_subproject_activate target_name)
     string(APPEND _init_contents "set(THEROCK_USER_POST_HOOK \"@_post_hook_path@\")\n")
   endif()
   set(_global_post_include "${THEROCK_SOURCE_DIR}/cmake/therock_global_post_subproject.cmake")
-  string(APPEND _init_contents "cmake_language(DEFER CALL include \"@_global_post_include@\")\n")
+  # The subproject toolchain sets CMAKE_PROJECT_TOP_LEVEL_INCLUDES, which try_compile
+  # re-reads during compiler detection, so this init file also runs inside the scratch
+  # project. Do not schedule the global post hook there: it references targets that only
+  # exist in the real subproject (aborting the compiler check) and its rpath/debug-split
+  # fixups are meaningless for a throwaway project. The scratch project is named
+  # CMAKE_TRY_COMPILE.
+  string(APPEND _init_contents "if(NOT CMAKE_PROJECT_NAME STREQUAL \"CMAKE_TRY_COMPILE\")\n")
+  string(APPEND _init_contents "  cmake_language(DEFER CALL include \"@_global_post_include@\")\n")
+  string(APPEND _init_contents "endif()\n")
   foreach(_addl_cmake_include ${_cmake_includes})
     if(NOT IS_ABSOLUTE)
       find_path(_addl_cmake_include_path "${addl_cmake_include}" NO_CACHE NO_DEFAULT_PATH PATHS ${CMAKE_MODULE_PATH} REQUIRED)

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1027,6 +1027,7 @@ function(therock_cmake_subproject_activate target_name)
         "${_cmake_project_toolchain_file}"
         "${_cmake_project_init_file}"
         "${_global_post_include}"
+        ${THEROCK_SUBPROJECT_CMAKE_INCLUDES}
         ${_extra_depends}
         ${_dep_provider_file}
         ${_configure_dep_stamps}

--- a/docs/development/build_system.md
+++ b/docs/development/build_system.md
@@ -313,3 +313,29 @@ therock_cmake_subproject_provide_package(ROCR-Runtime hsa-runtime64 lib/cmake/hs
 # to `FetchContent_MakeAvailable()` for that facility.
 therock_cmake_subproject_activate(ROCR-Runtime)
 ```
+
+## Forwarding `CMAKE_PROJECT_TOP_LEVEL_INCLUDES` to Sub-Projects
+
+Each sub-project is configured by its own nested `cmake` invocation, separate
+from the super-project's configure. The super-project always injects a generated
+`_init.cmake` for every sub-project via
+[`CMAKE_PROJECT_TOP_LEVEL_INCLUDES`](https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_TOP_LEVEL_INCLUDES.html),
+which CMake reads at the top of the sub-project's first `project()` call.
+
+If you pass `-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=<file>` to the super-project, that
+file is appended to each sub-project's list and forwarded to every sub-project
+configure as well. This lets an external hook customize CMake behavior across the
+entire build - the super-project and all sub-projects - without editing TheRock:
+
+```bash
+cmake -B build -GNinja \
+  -DTHEROCK_AMDGPU_FAMILIES=gfx1100 \
+  -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=/abs/path/my_hook.cmake
+```
+
+- **Ordering**: a sub-project's own generated `_init.cmake` is included first,
+  then your forwarded file(s). Your hook can therefore observe/override what the
+  generated init established.
+- **Multiple files**: use a standard CMake `;`-separated list.
+- **Absolute paths**: forwarded include files should be absolute, since each
+  sub-project configures from a different working directory.

--- a/docs/development/build_system.md
+++ b/docs/development/build_system.md
@@ -314,7 +314,7 @@ therock_cmake_subproject_provide_package(ROCR-Runtime hsa-runtime64 lib/cmake/hs
 therock_cmake_subproject_activate(ROCR-Runtime)
 ```
 
-## Forwarding `CMAKE_PROJECT_TOP_LEVEL_INCLUDES` to Sub-Projects
+## Injecting CMake Hooks into Sub-Projects
 
 Each sub-project is configured by its own nested `cmake` invocation, separate
 from the super-project's configure. The super-project always injects a generated
@@ -322,20 +322,24 @@ from the super-project's configure. The super-project always injects a generated
 [`CMAKE_PROJECT_TOP_LEVEL_INCLUDES`](https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_TOP_LEVEL_INCLUDES.html),
 which CMake reads at the top of the sub-project's first `project()` call.
 
-If you pass `-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=<file>` to the super-project, that
-file is appended to each sub-project's list and forwarded to every sub-project
-configure as well. This lets an external hook customize CMake behavior across the
-entire build - the super-project and all sub-projects - without editing TheRock:
+To inject an additional hook into every sub-project configure, set
+`THEROCK_SUBPROJECT_CMAKE_INCLUDES`. Files listed there are appended to each
+sub-project's `CMAKE_PROJECT_TOP_LEVEL_INCLUDES` (after the generated `_init.cmake`)
+and processed at the start of the sub-project's `project()` call:
 
 ```bash
 cmake -B build -GNinja \
   -DTHEROCK_AMDGPU_FAMILIES=gfx1100 \
-  -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=/abs/path/my_hook.cmake
+  -DTHEROCK_SUBPROJECT_CMAKE_INCLUDES=/abs/path/my_hook.cmake
 ```
 
+`CMAKE_PROJECT_TOP_LEVEL_INCLUDES` is **not** forwarded to sub-projects. CMake
+uses it automatically for the TheRock super-project configure; if you also want
+the hook to run there, pass it via `-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=` as well.
+
 - **Ordering**: a sub-project's own generated `_init.cmake` is included first,
-  then your forwarded file(s). Your hook can therefore observe/override what the
+  then your hook file(s). Your hook can therefore observe/override what the
   generated init established.
 - **Multiple files**: use a standard CMake `;`-separated list.
-- **Absolute paths**: forwarded include files should be absolute, since each
-  sub-project configures from a different working directory.
+- **Absolute paths**: hook files must be absolute, since each sub-project
+  configures from a different working directory.


### PR DESCRIPTION
Closes #6396

## Motivation

Configure, build and install from an existing source / build / install in a container where the file / dir owner is different, but all files / dirs have write permissions for all users.

## Technical Details

1. To enable external cmake super-project hooks to reach subprojects, propagate `CMAKE_PROJECT_TOP_LEVEL_INCLUDES` to all subprojects.
2. `py_packaging.py` performs a `copy2` before modifying. However, if the source file owner is not the same as the destination some permission bits are not set properly, and the subsequent `patchelf` pass cannot open the file for writing. The owner-write bit is now restored after materialization.

## Test Plan

- Built locally with other owner and `o+w` on all files.
- Added unit test `MaterializeReadOnlySourceTest` in `build_tools/tests/py_packaging_test.py` verifying a read-only source is materialized owner-writable.

## Test Result

Proper cross-owner build with no errors (using an external hook to modify TheRock cmake behavior). New unit test passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.