### PR TITLE
[ci] Adding `expand-family-to-targets` for `Copy prebuilt stages` to correctly copy artifacts

### DIFF
--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -79,7 +79,8 @@ jobs:
           python build_tools/artifact_manager.py copy \
             --source-run-id=${{ fromJSON(inputs.build_config).baseline_run_id }} \
             --stage="${{ fromJSON(inputs.build_config).prebuilt_stages }}" \
-            --amdgpu-families="${{ fromJSON(inputs.build_config).dist_amdgpu_families }}"
+            --amdgpu-families="${{ fromJSON(inputs.build_config).dist_amdgpu_families }}" \
+            --expand-family-to-targets
 
   build_multi_arch_stages:
     name: Build Multi-Arch Stages

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -78,7 +78,8 @@ jobs:
           python build_tools/artifact_manager.py copy \
             --source-run-id=${{ fromJSON(inputs.build_config).baseline_run_id }} \
             --stage="${{ fromJSON(inputs.build_config).prebuilt_stages }}" \
-            --amdgpu-families="${{ fromJSON(inputs.build_config).dist_amdgpu_families }}"
+            --amdgpu-families="${{ fromJSON(inputs.build_config).dist_amdgpu_families }}" \
+            --expand-family-to-targets
 
   build_multi_arch_stages:
     name: Build Multi-Arch Stages


### PR DESCRIPTION
During CSP comparison testing, I noticed that when using `Copy prebuilt stages`, it only copied over `generic` and not the specific target

The changes below correctly copy the artifacts for testing

[failing log](https://github.com/ROCm/TheRock/actions/runs/27174398928/job/80220654041#step:7:396)
(this is testing rocwmma)
```
++ Flattening 'core-amdsmi_run_generic.tar.zst' to 'core-amdsmi_run_generic'
++ Flattening 'core-amdsmi_lib_generic.tar.zst' to 'core-amdsmi_lib_generic'
++ Flattening 'sysdeps_lib_generic.tar.zst' to 'sysdeps_lib_generic'
++ Flattening 'host-blas_lib_generic.tar.zst' to 'host-blas_lib_generic'
++ Flattening 'core-hip_lib_generic.tar.zst' to 'core-hip_lib_generic'
++ Flattening 'blas_lib_generic.tar.zst' to 'blas_lib_generic'
++ Flattening 'amd-llvm_run_generic.tar.zst' to 'amd-llvm_run_generic'
++ Flattening 'rocprofiler-sdk_lib_generic.tar.zst' to 'rocprofiler-sdk_lib_generic'
++ Flattening 'rocwmma_test_generic.tar.zst' to 'rocwmma_test_generic'
++ Flattening 'amd-llvm_lib_generic.tar.zst' to 'amd-llvm_lib_generic'
++ Flattening 'blas_test_generic.tar.zst' to 'blas_test_generic'
Retrieved artifacts for run ID 27174398928
```

[passing log](https://github.com/ROCm/TheRock/actions/runs/27218639549/job/80368160396#step:7:405)
(this is testing rocwmma)
```
++ Flattening 'core-hip_lib_generic.tar.zst' to 'core-hip_lib_generic'
++ Flattening 'sysdeps_lib_generic.tar.zst' to 'sysdeps_lib_generic'
++ Flattening 'blas_lib_generic.tar.zst' to 'blas_lib_generic'
++ Flattening 'host-blas_lib_generic.tar.zst' to 'host-blas_lib_generic'
++ Flattening 'rocprofiler-sdk_lib_generic.tar.zst' to 'rocprofiler-sdk_lib_generic'
++ Flattening 'rocwmma_test_generic.tar.zst' to 'rocwmma_test_generic'
++ Flattening 'rocwmma_test_gfx942.tar.zst' to 'rocwmma_test_gfx942'
++ Flattening 'amd-llvm_lib_generic.tar.zst' to 'amd-llvm_lib_generic'
++ Flattening 'blas_test_generic.tar.zst' to 'blas_test_generic'
++ Flattening 'blas_lib_gfx942.tar.zst' to 'blas_lib_gfx942'
Retrieved artifacts for run ID 27218639549
```

Works as logs above prove it works so adding `ci:skip`