### PR TITLE
[ci] Add optional PyTorch build toggle for workflow_dispatch (re-land)

### DIFF
--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -43,6 +43,14 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
+      build_pytorch:
+        description: "Build PyTorch wheels"
+        type: boolean
+        default: true
+      python_version:
+        description: "Single Python version for wheel builds (empty for full matrix)"
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       release_type:

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -65,6 +65,14 @@ on:
         description: 'Comma-separated list of Windows GPU families. "all" = all, "none" = skip platform.'
         type: string
         default: "gfx110x"
+      build_pytorch:
+        description: "Build PyTorch wheels"
+        type: boolean
+        default: false
+      python_version:
+        description: "Single Python version for wheel builds (empty for full matrix)"
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -101,6 +109,8 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ needs.setup.outputs.ref }}
+      build_pytorch: ${{ inputs.build_pytorch }}
+      python_version: ${{ inputs.python_version }}
     permissions:
       contents: read
       actions: write  # Added permission to trigger workflows
@@ -119,6 +129,8 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ needs.setup.outputs.ref }}
+      build_pytorch: ${{ inputs.build_pytorch }}
+      python_version: ${{ inputs.python_version }}
     permissions:
       contents: read
       actions: write  # Added permission to trigger workflows

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -29,6 +29,14 @@ on:
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
+      build_pytorch:
+        description: "Build PyTorch wheels (defaults to true for workflow_call)"
+        type: boolean
+        default: true
+      python_version:
+        description: "Single Python version for wheel builds (empty for full matrix)"
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -186,6 +194,7 @@ jobs:
   trigger_release_pytorch_wheels:
     needs: [build_artifacts, build_python_packages]
     name: Trigger Release PyTorch Wheels
+    if: ${{ inputs.build_pytorch != false }}
     runs-on: ubuntu-24.04
     permissions:
       actions: write
@@ -199,7 +208,8 @@ jobs:
               "rocm_version": "${{ inputs.rocm_package_version }}",
               "rocm_package_find_links_url": "${{ needs.build_python_packages.outputs.package_find_links_url }}",
               "release_type": "${{ inputs.release_type }}",
-              "ref": "${{ inputs.ref || '' }}"
+              "ref": "${{ inputs.ref || '' }}",
+              "python_version": "${{ inputs.python_version }}"
             }
 
   # TODO: trigger_build_jax_wheels (release_portable_linux_jax_wheels.yml or equivalent)

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -44,6 +44,10 @@ on:
         description: "Compiler cache type ('none', 'sccache', or 'ccache')"
         type: string
         default: "none"
+      python_version:
+        description: "Single Python version to build (empty for full matrix)"
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -81,6 +85,10 @@ on:
           - sccache
           - ccache
         default: none
+      python_version:
+        description: "Single Python version to build (empty for full matrix)"
+        type: string
+        default: ""
 
 run-name: Release Linux PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_families }})
 
@@ -88,13 +96,31 @@ permissions:
   contents: read
 
 jobs:
+  setup_matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      pytorch_matrix: ${{ steps.matrix.outputs.pytorch_matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      - name: Generate PyTorch matrix
+        id: matrix
+        run: |
+          python ./build_tools/github_actions/configure_pytorch_release_matrix.py \
+            --python-versions="${{ inputs.python_version }}" \
+            --platform=linux
+
   build_pytorch_wheels:
-    name: Release | py ${{ matrix.python_version }} | torch ${{ matrix.pytorch_git_ref }}
+    needs: setup_matrix
+    name: Build | py ${{ matrix.python_version }} | torch ${{ matrix.pytorch_git_ref }}
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        pytorch_git_ref: ["release/2.9", "release/2.10", "release/2.11", "release/2.12", "nightly"]
+        include: ${{ fromJSON(needs.setup_matrix.outputs.pytorch_matrix) }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -23,6 +23,14 @@ on:
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
+      build_pytorch:
+        description: "Build PyTorch wheels (defaults to true for workflow_call)"
+        type: boolean
+        default: true
+      python_version:
+        description: "Single Python version for wheel builds (empty for full matrix)"
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -148,6 +156,7 @@ jobs:
   trigger_release_pytorch_wheels:
     needs: [build_artifacts, build_python_packages]
     name: Trigger Release PyTorch Wheels
+    if: ${{ inputs.build_pytorch != false }}
     runs-on: ubuntu-24.04
     permissions:
       actions: write
@@ -161,5 +170,6 @@ jobs:
               "rocm_version": "${{ inputs.rocm_package_version }}",
               "rocm_package_find_links_url": "${{ needs.build_python_packages.outputs.package_find_links_url }}",
               "release_type": "${{ inputs.release_type }}",
-              "ref": "${{ inputs.ref || '' }}"
+              "ref": "${{ inputs.ref || '' }}",
+              "python_version": "${{ inputs.python_version }}"
             }

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -44,6 +44,10 @@ on:
         description: "Compiler cache type ('none', 'sccache', or 'ccache')"
         type: string
         default: "none"
+      python_version:
+        description: "Single Python version to build (empty for full matrix)"
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -81,6 +85,10 @@ on:
           - sccache
           - ccache
         default: none
+      python_version:
+        description: "Single Python version to build (empty for full matrix)"
+        type: string
+        default: ""
 
 run-name: Release Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, ${{ inputs.amdgpu_families }})
 
@@ -88,13 +96,31 @@ permissions:
   contents: read
 
 jobs:
+  setup_matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      pytorch_matrix: ${{ steps.matrix.outputs.pytorch_matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      - name: Generate PyTorch matrix
+        id: matrix
+        run: |
+          python ./build_tools/github_actions/configure_pytorch_release_matrix.py \
+            --python-versions="${{ inputs.python_version }}" \
+            --platform=windows
+
   build_pytorch_wheels:
-    name: Release | py ${{ matrix.python_version }} | torch ${{ matrix.pytorch_git_ref }}
+    needs: setup_matrix
+    name: Build | py ${{ matrix.python_version }} | torch ${{ matrix.pytorch_git_ref }}
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        pytorch_git_ref: ["release/2.9", "release/2.10", "release/2.11", "release/2.12", "nightly"]
+        include: ${{ fromJSON(needs.setup_matrix.outputs.pytorch_matrix) }}
     permissions:
       id-token: write
       contents: read

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Generate PyTorch release build matrix for workflows."""
+
+import argparse
+import json
+import platform as platform_module
+import sys
+from pathlib import Path
+
+_BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_BUILD_TOOLS_DIR))
+
+from github_actions.github_actions_api import gha_set_output
+
+PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+PYTORCH_REFS_LINUX = [
+    "release/2.9",
+    "release/2.10",
+    "release/2.11",
+    "release/2.12",
+    "nightly",
+]
+
+PYTORCH_REFS_WINDOWS = [
+    "release/2.9",
+    "release/2.10",
+    "release/2.11",
+    "release/2.12",
+    "nightly",
+]
+
+
+def generate_pytorch_matrix(
+    python_versions: list[str] | None,
+    platform: str = "linux",
+) -> list[dict]:
+    versions = python_versions if python_versions else PYTHON_VERSIONS
+    pytorch_refs = PYTORCH_REFS_WINDOWS if platform == "windows" else PYTORCH_REFS_LINUX
+    matrix = []
+    for py in versions:
+        for ref in pytorch_refs:
+            matrix.append({"python_version": py, "pytorch_git_ref": ref})
+    return matrix
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate PyTorch release build matrix"
+    )
+    parser.add_argument(
+        "--python-versions",
+        type=str,
+        default="",
+        help="Comma or semicolon separated list of Python versions (default: all)",
+    )
+    parser.add_argument(
+        "--platform",
+        type=str,
+        default=platform_module.system().lower(),
+        choices=["linux", "windows"],
+        help="Platform to generate matrix for (default: current system)",
+    )
+    args = parser.parse_args(argv)
+
+    python_versions = None
+    if args.python_versions:
+        sep = ";" if ";" in args.python_versions else ","
+        python_versions = [
+            v.strip() for v in args.python_versions.split(sep) if v.strip()
+        ]
+
+    matrix = generate_pytorch_matrix(python_versions, args.platform)
+    gha_set_output({"pytorch_matrix": json.dumps(matrix)})
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Relanding after revert #5710, test working here: https://github.com/ROCm/rockrel/actions/runs/27224507676/job/80387970559 (cancelled to save resources)

As discussed in standup, `workflow_dispatch` release jobs take up lots of capacity, even if not intended (most jobs don't require pytorch builds). Now, the workflow dispatch trigger will have additional options to prevent unnecessary builds and if pytorch is needed, specific python versions to limit.

Changes:
- Adding build_pytorch check mark to build pytorch for workflow dispatch (default off)
- If above option is enabled, specify the python version to build for pytorch
- Creating `build_tools/github_actions/fetch_pytorch_matrix.py` script as logic is introduced in matrix selection

Tested (but cancelled to save resources) here: https://github.com/ROCm/TheRock/actions/runs/26059852448 / https://github.com/ROCm/TheRock/actions/runs/26065169000/job/76634242693 to ensure no syntax issues

Adding `ci:skip` as this only impacts release workflows

In order to avoid logic in YML, we are converting version selection /ignore via python files