### PR TITLE
build: add rust 1.95 to the build images

### DIFF
--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -57,6 +57,14 @@ ENV GOOGLE_TEST_VERSION="1.16.0"
 COPY install_googletest.sh ./
 RUN ./install_googletest.sh "${GOOGLE_TEST_VERSION}" && rm -rf /install-googletest
 
+######## Rust (rustup) ########
+ENV RUSTUP_HOME="/usr/local/rustup"
+ENV CARGO_HOME="/usr/local/cargo"
+WORKDIR /install-rust
+ENV RUST_VERSION="1.95.0"
+COPY install_rust.sh ./
+RUN ./install_rust.sh "${RUST_VERSION}" && rm -rf /install-rust
+
 ######## Yum Packages #######
 # We are pinning to gcc-toolset-12 until it is safe to upgrade. The latest
 # manylinux containers use gcc-toolset-14 or later, which is not yet compatible

--- a/dockerfiles/install_rust.sh
+++ b/dockerfiles/install_rust.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Install the Rust toolchain via rustup.
+#
+# Usage: ./install_rust.sh <TOOLCHAIN_VERSION>
+# Example: ./install_rust.sh "1.88.0"
+#          ./install_rust.sh "stable"
+#
+# Installs rustup/cargo to a shared location (RUSTUP_HOME/CARGO_HOME) and
+# symlinks the toolchain binaries into /usr/local/bin so they are on PATH
+# for all users.
+
+set -euo pipefail
+
+RUST_VERSION="${1:-stable}"
+
+export RUSTUP_HOME="/usr/local/rustup"
+export CARGO_HOME="/usr/local/cargo"
+
+echo "Installing Rust toolchain '${RUST_VERSION}' via rustup..."
+curl --silent --fail --show-error --location \
+    "https://sh.rustup.rs" \
+    --output rustup-init.sh
+
+sh rustup-init.sh -y \
+    --no-modify-path \
+    --profile minimal \
+    --default-toolchain "${RUST_VERSION}"
+
+rm -f rustup-init.sh
+
+# Make the toolchain available system-wide.
+chmod -R a+rwX "${RUSTUP_HOME}" "${CARGO_HOME}"
+for bin in "${CARGO_HOME}/bin/"*; do
+    ln -sf "${bin}" "/usr/local/bin/$(basename "${bin}")"
+done
+
+echo "rust installed successfully:"
+rustc --version
+cargo --version


### PR DESCRIPTION
## Motivation

Mirage needs Rust to build the UX for our emulators.

## Technical Details

- Add `dockerfiles/install_rust.sh`: installs the Rust toolchain via `rustup` (currently `1.95.0`).

## Test Plan

Ran both scripts inside the actual pinned manylinux build image and verified:
1. Both toolchains install and the binaries resolve on `PATH` from a fresh login shell.
2. The installs do not make the builds non-portable.

## Test Result

- Toolchains install cleanly: `rustc 1.95.0` / `cargo 1.95.0
- Portability preserved:
  - No new files in `/usr/lib`, `/usr/lib64`, `/usr/local/lib(64)`, or
    `/etc/ld.so.conf.d`.
  - `ld.so.cache` unchanged (no new libs registered with the dynamic linker).
  - No Rust`pkg-config` `.pc` files added.
  - `/usr/local/bin` contains only binary symlinks, no `.so` files.
  - All toolchain shared libraries are confined to `RUSTUP_HOME`/`CARGO_HOME`, which are not on the default linker path; `LIBRARY_PATH` is unset
    and `LD_LIBRARY_PATH` references only the gcc-toolset.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.