### PR TITLE
[ci] Increase timeouts for PRIM tests because of expanded test suites (added quick_suite and standard_suite)

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -266,7 +266,7 @@ test_matrix = {
     "rocprim": {
         "job_name": "rocprim",
         "fetch_artifact_args": "--prim --tests",
-        "timeout_minutes": 30,
+        "timeout_minutes": 45,
         "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
@@ -277,7 +277,7 @@ test_matrix = {
     "hipcub": {
         "job_name": "hipcub",
         "fetch_artifact_args": "--prim --tests",
-        "timeout_minutes": 15,
+        "timeout_minutes": 45,
         "test_script": f"python {_get_script_path('test_hipcub.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
@@ -310,7 +310,7 @@ test_matrix = {
     "rocthrust": {
         "job_name": "rocthrust",
         "fetch_artifact_args": "--prim --tests",
-        "timeout_minutes": 15,
+        "timeout_minutes": 45,
         "test_script": f"python {_get_script_path('test_rocthrust.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
With the introduction of the new test categories, original run time budget for running all tests on the PRIM components is no longer enough.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
This PR increases the timeouts for rocprim, rocthrust, and hipcub tests.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
CI passing.

## Test Result

<!-- Briefly summarize test outcomes. -->
No test results will be affected but this change will allow blocked PRs (such as [PR 8188](https://github.com/ROCm/rocm-libraries/pull/8188)) to pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
