### PR TITLE
Add ROCm PR Quality agent skills (base + TheRock overlay)

### DIFF
--- a/.cursor/rules/rocm-pr-quality.mdc
+++ b/.cursor/rules/rocm-pr-quality.mdc
@@ -1,0 +1,18 @@
+---
+description: Use the rocm-pr-quality skill when authoring, reviewing, or pre-merge-gating a pull request in this repo
+alwaysApply: false
+---
+
+# ROCm PR Quality
+
+When the user is authoring, reviewing, or deciding whether it is safe to merge a pull request,
+read and apply [`skills/rocm-pr-quality/SKILL.md`](../../skills/rocm-pr-quality/SKILL.md) and its
+`reference.md` before proceeding. It is the library-agnostic base skill; component repositories
+layer thin overlays on top that may tighten but never weaken its MUST rules.
+
+Key behaviors the skill enforces:
+
+- One entry point, three actions: author assist, review assist, pre-merge gate.
+- Advisory and paved-road, not a compliance cop.
+- Never post PR descriptions, review comments, labels, or merges to GitHub/Jira without explicit
+  human approval — draft the text and wait.

--- a/.cursor/rules/rocm-pr-quality.mdc
+++ b/.cursor/rules/rocm-pr-quality.mdc
@@ -10,6 +10,11 @@ read and apply [`skills/rocm-pr-quality/SKILL.md`](../../skills/rocm-pr-quality/
 `reference.md` before proceeding. It is the library-agnostic base skill; component repositories
 layer thin overlays on top that may tighten but never weaken its MUST rules.
 
+For PRs touching TheRock's build itself — the superbuild/CMake, submodules and patches,
+`artifact-*.toml` / `BUILD_TOPOLOGY.toml`, or reusable CI workflows — also read and apply the
+TheRock overlay [`skills/therock-pr-quality/SKILL.md`](../../skills/therock-pr-quality/SKILL.md),
+which extends the base and defers to the canonical `docs/development/style_guides/`.
+
 Key behaviors the skill enforces:
 
 - One entry point, three actions: author assist, review assist, pre-merge gate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,15 @@ directory for each style guide:
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
+## PR Quality Skill
+
+A composable, ROCm-wide PR-quality agent skill lives at
+[skills/rocm-pr-quality/](skills/rocm-pr-quality/). When authoring, reviewing, or
+pre-merge-gating a pull request, read and apply
+[skills/rocm-pr-quality/SKILL.md](skills/rocm-pr-quality/SKILL.md) (and its `reference.md`).
+It is the library-agnostic base; component repositories add thin overlays on top. The skill is
+advisory and never posts to GitHub/Jira without explicit human approval.
+
 ## Project Structure
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,12 +181,20 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## PR Quality Skill
 
-A composable, ROCm-wide PR-quality agent skill lives at
-[skills/rocm-pr-quality/](skills/rocm-pr-quality/). When authoring, reviewing, or
-pre-merge-gating a pull request, read and apply
-[skills/rocm-pr-quality/SKILL.md](skills/rocm-pr-quality/SKILL.md) (and its `reference.md`).
-It is the library-agnostic base; component repositories add thin overlays on top. The skill is
-advisory and never posts to GitHub/Jira without explicit human approval.
+Composable, ROCm-wide PR-quality agent skills live under [skills/](skills/). When authoring,
+reviewing, or pre-merge-gating a pull request, read and apply the base skill, plus the TheRock
+overlay when the change touches the build:
+
+- **Base — [skills/rocm-pr-quality/SKILL.md](skills/rocm-pr-quality/SKILL.md)** (and its
+  `reference.md`): the library-agnostic floor. Always read this first.
+- **TheRock overlay — [skills/therock-pr-quality/SKILL.md](skills/therock-pr-quality/SKILL.md)**:
+  add this for PRs touching the superbuild, submodules/patches, `artifact-*.toml` /
+  `BUILD_TOPOLOGY.toml`, or reusable CI workflows. It extends the base and defers to the canonical
+  `docs/development/style_guides/`.
+
+Component repositories add their own thin overlays on top (e.g. `hipblaslt-pr-quality` in
+`rocm-libraries`). Overlays may tighten but never weaken the base MUST rules. The skills are
+advisory and never post to GitHub/Jira without explicit human approval.
 
 ## Project Structure
 

--- a/skills/rocm-pr-quality/SKILL.md
+++ b/skills/rocm-pr-quality/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rocm-pr-quality
-description: Help an engineer author, review, or pre-merge-gate a pull request to a ROCm library so it is traceable, tested, and safe to merge. Use when preparing a PR, reviewing a PR, or deciding whether an approved PR is safe to merge right now, or when the user provides a GitHub PR URL or branch and asks for help with PR quality, description, testing, review, or merge-readiness. Library-agnostic base; component overlays extend it.
-argument-hint: '[author | review | pre-merge] [PR URL | branch:<name> | local] [base:<branch>]'
+description: "Help an engineer author, review, or pre-merge-gate a pull request to a ROCm library so it is traceable, tested, and safe to merge. Use when preparing a PR, reviewing a PR, or deciding whether an approved PR is safe to merge right now, or when the user provides a GitHub PR URL or branch and asks for help with PR quality, description, testing, review, or merge-readiness. Library-agnostic base; component overlays extend it."
+argument-hint: "[author | review | pre-merge] [PR URL | branch:<name> | local] [base:<branch>]"
 allowed-tools: Bash, Read, Grep, Glob, Task, WebFetch
 ---
 
@@ -85,8 +85,8 @@ reviewer adjudicates. M1 is waiver-able only via the tracked two-PR plan. M3 has
 ### Waivers (author-declared, reviewer-adjudicated)
 
 An exception is never a silent self-override. The author declares a waiver code + a one-to-
-two-sentence reason (and any required approver); the reviewer accepts (verdict WAIVER) or
-rejects a weak one (verdict BLOCKER). A bare "N/A" is not a waiver — "why" is mandatory even
+two-sentence reason (and any required approver); the reviewer accepts (`APPROVED`, with the waiver
+recorded) or rejects a weak one (`CHANGES REQUESTED`). A bare "N/A" is not a waiver — "why" is mandatory even
 when the rule is waived. Higher-risk waivers need a named approver. Waiver codes are in
 `reference.md`.
 
@@ -195,18 +195,33 @@ web diff alone has lower confidence). Do not modify files during review.
    (waiver?), (4) what adjacent tests should have been considered.
 1. Adjudicate any author-declared waiver: accept a well-justified one, reject a weak one.
 
-**Severity** for individual findings: Critical / Major / Minor / Suggestion (see `reference.md`).
+**Evidence-based review (CI validation).** Treat CI as data, not a binary. Look at *all* CI runs on
+the PR, not only the one linked in the description — a green rollup can hide a skipped lane, a flaky
+retry that masked a real failure, or a required check that never ran. Where a baseline exists (the
+target branch's latest run, or the PR's own earlier run), compare against it: new failures,
+newly-skipped tests, and large step-timing deltas (a job that suddenly runs much longer or shorter)
+are signals worth a finding. Calibrate severity against this data instead of asserting risk — "this
+lane was green on the base and now fails here" is `BLOCKING`; "the build step is 3× slower" is at
+least `IMPORTANT` to ask about. Ground each finding in the specific run/step link.
 
-**Verdict** for the PR overall: `STANDARD` (policy met), `WAIVER` (valid documented exception),
-or `BLOCKER` (missing tests/flags/waiver, bad tracking, defect without regression plan,
-unresolved Critical finding, etc.).
+**Finding tiers** (severity-ordered): `BLOCKING` / `IMPORTANT` / `SUGGESTION` / `FUTURE WORK`
+(see `reference.md`). Quick decision framework: correctness / security / incomplete cleanup of
+code being modified → `BLOCKING`; will bite users or developers soon → `IMPORTANT`; nice-to-have
+on code already being touched → `SUGGESTION`; genuinely out of scope for this PR → `FUTURE WORK`.
+
+**Overall assessment** for the PR: `APPROVED` (policy met — may still carry documented,
+reviewer-accepted waivers and optional recommendations), `CHANGES REQUESTED` (one or more
+`BLOCKING` items: missing tests/flags/waiver, bad/absent tracking, a defect without a regression
+plan, or an unresolved correctness/security finding), or `REJECTED` (fundamental problem with the
+approach that needs rework). A valid, documented waiver does not block: that is `APPROVED` with the
+waiver recorded.
 
 **Optional delegation:** for broad PRs, you may split the review by scope bucket via subagents
 and add cross-cutting testing/reuse passes; otherwise do a single-pass review.
 
-**Output:** verdict + the four answers + a severity-ordered findings list + a blocking-items
-list. Only on request, and only after the user approves the wording, produce a draft
-request-changes comment. Never post it yourself.
+**Output:** the overall assessment + the four answers + a severity-ordered findings list + a
+`BLOCKING`-items list. Only on request, and only after the user approves the wording, produce a
+draft request-changes comment. Never post it yourself.
 
 ______________________________________________________________________
 
@@ -229,7 +244,9 @@ merge queue, and it does not force a CI rerun by default.
 - **CI currency.** An approved green can be hours or days old. Report when this PR's CI last
   completed against a freshness policy (default SHOULD: flag beyond ~3 days). Whether a rebase +
   re-run is *required* vs *recommended* is a component SHOULD (overlays set it); the base does not
-  force a rerun.
+  force a rerun. Also confirm the green is *real*, not just a passing rollup summary (see
+  "Evidence-based review" under Action 2): every required lane actually ran and passed, with no
+  skipped/cancelled required check hiding under the green.
 - **Adjacent-file / stale-base check on develop.** Compare the PR's changed files against the
   files the base branch changed since the PR diverged. No overlap → do not tax velocity, merge is
   fine. Overlap on high-coupling files (shared generators, register/lifetime code, shared
@@ -259,3 +276,11 @@ ______________________________________________________________________
   heuristic, CI currency, adjacent-file overlap). It is advisory today and is the same logic a
   future CI status check could call. Semantic judgments (test substance, M3) stay with the agent
   and the human.
+
+## Attribution
+
+The finding/assessment vocabulary, the agent-change anti-patterns, the PR-hygiene checklist, and
+the self-evident-change exemptions draw on Scott Todd's ROCm code-review guidelines
+(`ScottTodd/rocm-workspace`), toward one shared review vocabulary across ROCm. This base defers to
+canonical, in-repo style guides and lint/pre-commit config rather than duplicating them; see
+`reference.md` ("Attribution & deferral").

--- a/skills/rocm-pr-quality/SKILL.md
+++ b/skills/rocm-pr-quality/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: rocm-pr-quality
+description: "Help an engineer author, review, or pre-merge-gate a pull request to a ROCm library so it is traceable, tested, and safe to merge. Use when preparing a PR, reviewing a PR, or deciding whether an approved PR is safe to merge right now, or when the user provides a GitHub PR URL or branch and asks for help with PR quality, description, testing, review, or merge-readiness. Library-agnostic base; component overlays extend it."
+argument-hint: "[author | review | pre-merge] [PR URL | branch:<name> | local] [base:<branch>]"
+allowed-tools: Bash, Read, Grep, Glob, Task, WebFetch
+---
+
+# ROCm PR Quality (base)
+
+This is the library-agnostic base skill for PR quality across ROCm. It exposes three
+actions the user invokes with a single sentence; the skill does the legwork through the
+tools already on the desk (`gh`, the repo, and Jira/GitHub MCPs when available).
+
+- **Author assist** — "help me write a PR worth reviewing."
+- **Review assist** — "help me review this PR well."
+- **Pre-merge gate** — "is it actually safe to press merge right now?"
+
+Pick the action from the user's request. If it is ambiguous, ask which one they want.
+
+Detailed rubric tables, the PR description template, change classes, the test-level map,
+waiver codes, and the MUST set live in `reference.md` in this directory. Read it before
+running an action.
+
+______________________________________________________________________
+
+## Operating principles
+
+1. **Paved road, not compliance cop.** The goal is to make the high-quality path the easy
+   path. Be the helpful senior reviewer, not the gate guard. "Easy = used" is the point.
+1. **Never write to external systems without explicit human approval.** Do not post PR
+   descriptions, review comments, issue/ticket comments, labels, or merges to GitHub or
+   Jira on your own. Draft the text, show it, and wait for the user to approve or edit.
+   This applies even when the user says "review the PR" — you produce the review, the human
+   posts it.
+1. **Advisory first.** This skill raises the floor; it does not approve and it does not
+   block a merge by itself. Hard enforcement (a required CI status check, a merge queue)
+   is a separate, DevOps-owned lane that may be added later. Do not assume it exists.
+1. **Defer to the repo.** When a component repo ships its own testing/contributing/standards
+   docs (e.g. `CONTRIBUTING.md`, a `docs/testing*.md`, a per-repo best-practices file), read
+   and apply them rather than inventing guidance. The skill checks that repo standards are
+   followed; it does not replace them.
+1. **Discover, do not hardcode.** Supported architectures, CI labels, test lanes, and
+   tracker prefixes drift. Discover them from the repo and CI config at run time.
+1. **Evidence over assertion.** Ground every finding in a `file:line`, a CI link, a diff
+   hunk, or a resolved tracker. Do not invent test results or completed runs.
+
+______________________________________________________________________
+
+## How overlays extend this base
+
+Each ROCm library may publish a thin overlay skill (e.g. `hipblaslt-pr-quality`) that
+depends on this base. Overlays may **add** rules, **tighten** thresholds, and bind rules to
+component paths. Overlays may **not** weaken a base MUST-rule. On any conflict, the base
+MUST-rule wins.
+
+When invoked through an overlay, read this base first, then apply the overlay's supplements
+on top.
+
+______________________________________________________________________
+
+## Shared concepts (used by all three actions)
+
+### Change classification (extensible; multiple tags allowed)
+
+Map touched paths + intent to one or more change classes. A PR may carry more than one tag
+(e.g. `defect-fix` + `kernel/tuning`). When ambiguous, pick the **stricter** class.
+
+Base classes: `new-public-api`, `new-op/dtype/path`, `heuristic/default-selection`,
+`kernel/tuning`, `build/ci`, `docs`, `revert`, `defect-fix`, `regression-test-only`, `other`.
+Overlays may add component-specific classes. The class drives the test/flag bar (see
+`reference.md`).
+
+### The MUST set (M1–M5, non-overridable by overlays)
+
+- **M1** Defect-fix PRs include a regression test, or a tracked two-PR known-bug plan.
+- **M2** Product-code changes carry tests, a safe-default flag, or a written waiver.
+- **M3** Never disable, skip, or weaken tests solely to green CI. *(hard MUST — no waiver.)*
+- **M4** Non-trivial PRs carry work tracking (ticket, public issue, or credible no-tracker reason).
+- **M5** PRs link the artifacts they relate to (work-tracking item, the defect they fix,
+  directly related PRs), and those links must resolve.
+
+M2, M4, M5 are **escape-hatch MUSTs**: waiver-able with an explicit written reason that a
+reviewer adjudicates. M1 is waiver-able only via the tracked two-PR plan. M3 has no waiver.
+
+### Waivers (author-declared, reviewer-adjudicated)
+
+An exception is never a silent self-override. The author declares a waiver code + a one-to-
+two-sentence reason (and any required approver); the reviewer accepts (verdict WAIVER) or
+rejects a weak one (verdict BLOCKER). A bare "N/A" is not a waiver — "why" is mandatory even
+when the rule is waived. Higher-risk waivers need a named approver. Waiver codes are in
+`reference.md`.
+
+### Test substance — the mutation question (and the "why")
+
+Presence of tests is not enough. For 2–3 sampled tests ask: *what specific change to the
+source would make this test fail?* If the answer is hand-wavy, it is coverage padding — a
+blocker, not a nit. Smell scan: assert-callable-only, `hasattr`-guarded bodies, lone
+`is not None`/`.called` assertions, copy-paste that should be parametrized, mock-only
+assertions that pass against a no-op, and phantom methods that do not exist in the source.
+
+Also ask for the **rationale** behind non-obvious test choices: where did this tolerance
+value come from, why this parameter combination and not another? A short paper trail prevents
+the "author is long gone, nobody knows why this test exists" problem. Prompt the author to
+record it; flag its absence on non-obvious numeric tolerances or parameter sets.
+
+### Blast radius & device/architecture coverage
+
+Judge from what the diff actually changes, not the file's path. Decide whether the change is
+architecture-independent (wiring/plumbing with no kernel-selection/default/support-surface
+change → standard CI is enough), behavior-shifting (defaults/dispatch → multi-arch run
+warranted), arch-scoped (only the affected devices), or support-surface-expanding (full
+sweep). Kernel/device code generally needs cross-device coverage; host-only code often does
+not. Discover the supported architecture/label set from the repo's CI config; do not hardcode
+it. Do not over-escalate: an arch-independent change covered by passing CI needs no sweep, and
+saying so is a valid outcome.
+
+### Risk level (1–5)
+
+Take any user-provided hint, then independently evaluate the diff. 1 = docs/comments/metadata
+only; 2 = narrow low-blast-radius change, good coverage; 3 = core subsystem / new feature path
+/ schema-API addition / dispatch-build-test infra; 4 = broad behavior change, compat-sensitive
+public API, perf-critical path, incomplete coverage; 5 = cross-project/architectural, default
+behavior change in a critical path, ABI break, large unproven refactor, known unresolved
+failures. Residual coverage gaps (a required sweep that has not passed) raise the level.
+
+### Interlinking — every PR is an entry point
+
+A PR should never be a dead end. From any artifact a reader should follow links outward to the
+why, the fix, the dependencies, and the predecessors. Forward links should resolve into
+reverse edges (GitHub back-references; Jira dev-panel auto-linking when the issue key is in the
+branch/PR title). M5 makes the core links mandatory; broader context (design docs, loosely
+related PRs) is a SHOULD.
+
+______________________________________________________________________
+
+## Action 1 — Author assist
+
+Goal: the author pushes a PR a reviewer can evaluate without archaeology, that already passes
+the obvious quality bar.
+
+**Required inputs** (ask only for what cannot be discovered from the PR/branch/diff/repo):
+work-tracking reference (ticket / issue / prior PR / RFC / credible none), a risk hint, testing
+performed (groups, exact commands when known, status, devices for hardware tests, run/CI links),
+and the blast-radius/device-coverage picture. Accept `N/A`/`none`/`not run` as answers, but do
+not render empty `N/A` fields in the body.
+
+**Workflow:**
+
+1. Inspect the diff: `gh pr view`, `gh pr diff`, `git diff --stat`, targeted file reads.
+1. Classify the change (one or more classes; stricter when unsure).
+1. Scan branch name, commit messages, and diff for tracker keys, issue numbers, and referenced
+   PRs; pre-fill the Related section; prompt for anything obviously missing (e.g. "this fixes a
+   defect — link the defect ticket").
+1. Check the test/flag/waiver obligation for the class (see `reference.md`). If product code
+   changed, require at least one of: tests exercising the change, a safe-default flag guard plus
+   a follow-up tracker, or a documented waiver. "Disable/skip/weaken tests to green CI" is never
+   valid.
+1. Draft a complete PR description from the template in `reference.md`. New PRs are **draft by
+   default**; open ready-for-review only when the user explicitly asks.
+1. Prompt for the things authors skip: work tracking, flags for default-path/experimental
+   behavior, and adjacent tests ("what else exercises this code path that you should run?").
+
+**Output:** a suggested PR title + body (Markdown), a per-step checklist (pass / warn / fail),
+CI labels to consider, and open questions for the author — all before the push. Do not create
+or edit the PR on GitHub unless the user explicitly approves the exact text.
+
+______________________________________________________________________
+
+## Action 2 — Review assist
+
+Goal: a consistent, substance-focused review floor, so every reviewer checks the same
+fundamentals. Lead with findings ordered by severity, each grounded in `file:line`.
+
+**Setup:** determine the repo root (`git rev-parse --show-toplevel`); inspect changed files
+(`gh pr view --json ...`, `gh pr diff --name-only`); save the full diff to a temp file rather
+than pasting it into the conversation; prefer local source for cross-reference (a review from a
+web diff alone has lower confidence). Do not modify files during review.
+
+**Workflow:**
+
+1. Classify changed files into scope buckets (overlays define component buckets; generic buckets:
+   public API, core/runtime, build/CI, tests, docs/tooling).
+1. Run the rubric (`reference.md`): scope, change class, work tracking, test/flag obligation,
+   work type, and any defect-specific extras (regression test + evidence, or a documented two-PR
+   plan).
+1. Review for correctness, resource/memory ownership (leaks, RAII, lifetime on failure paths),
+   code reuse (flag copy-paste where a helper exists), and build/packaging where touched.
+1. Testing review is required every time, even when no test files changed. Do not equate "tests
+   added" with "behavior covered" — read assertions, run the mutation question, run the smell
+   scan, and check the test "why" for non-obvious choices.
+1. Assess blast radius and device/arch coverage; reconcile what the content warrants against what
+   the PR actually tested/claimed. Flag gaps; do not over-escalate.
+1. Answer the four review questions explicitly: (1) what new/changed functionality lands,
+   (2) what test level is appropriate, (3) if tests/flags are omitted, is that acceptable
+   (waiver?), (4) what adjacent tests should have been considered.
+1. Adjudicate any author-declared waiver: accept a well-justified one, reject a weak one.
+
+**Severity** for individual findings: Critical / Major / Minor / Suggestion (see `reference.md`).
+
+**Verdict** for the PR overall: `STANDARD` (policy met), `WAIVER` (valid documented exception),
+or `BLOCKER` (missing tests/flags/waiver, bad tracking, defect without regression plan,
+unresolved Critical finding, etc.).
+
+**Optional delegation:** for broad PRs, you may split the review by scope bucket via subagents
+and add cross-cutting testing/reuse passes; otherwise do a single-pass review.
+
+**Output:** verdict + the four answers + a severity-ordered findings list + a blocking-items
+list. Only on request, and only after the user approves the wording, produce a draft
+request-changes comment. Never post it yourself.
+
+______________________________________________________________________
+
+## Action 3 — Pre-merge gate
+
+This is genuinely different from review: a PR can be approved and green and still be the wrong
+thing to merge *at this moment*. Run against an already-approved PR, immediately before merge.
+This is a final red/green sanity check the dev (or a team's merge group) can lean on — **not** a
+merge queue, and it does not force a CI rerun by default.
+
+**Criteria:**
+
+- **Timing / risky moment.** Discourage merging large or default-path changes when nobody is
+  around to babysit fallout — end of week, right before a holiday or freeze. This is
+  timezone/region-aware: use the owning team's region (overlays configure it, e.g. a Calgary-based
+  team) to decide "going into the weekend / end of day." Optionally, when calendar/Teams
+  availability is reachable, check that a minimal set of people are online with enough hours left
+  in the day. Advisory-with-teeth: a configurable "are you sure?", except where a freeze is in
+  effect. Small/low-risk/revert PRs can be exempted.
+- **CI currency.** An approved green can be hours or days old. Report when this PR's CI last
+  completed against a freshness policy (default SHOULD: flag beyond ~3 days). Whether a rebase +
+  re-run is *required* vs *recommended* is a component SHOULD (overlays set it); the base does not
+  force a rerun.
+- **Adjacent-file / stale-base check on develop.** Compare the PR's changed files against the
+  files the base branch changed since the PR diverged. No overlap → do not tax velocity, merge is
+  fine. Overlap on high-coupling files (shared generators, register/lifetime code, shared
+  components — overlays name them) → strong-recommend rebase + re-run. This catches the
+  "both PRs individually green, the bug only exists combined" class that nothing compiled until
+  after merge.
+- **Impacted open PRs (advisory).** Optionally identify other open PRs that touch the same
+  high-coupling files and would be affected by this merge. You may *draft* a courtesy
+  "consider rebasing" comment for those PRs — but never post it without explicit human approval.
+
+**Output:** a go / caution / hold summary with the specific reason and the recommended action
+(e.g. "overlap on a high-coupling file — rebase + re-run before merge"). The decision stays with
+the human.
+
+The durable fix for CI-currency and stale-base is a real merge queue; until that exists the
+pre-merge gate is the manual stand-in, and a strong argument for funding one.
+
+______________________________________________________________________
+
+## Operational notes
+
+- Use `gh` for PR data, diffs, files, and CI status. Use the Jira/GitHub MCPs to look up and
+  validate tickets, issues, and related PRs.
+- Save large diffs to a temp file; read focused sections rather than pasting everything.
+- The optional shared checker `tools/pr_quality_check.py` performs the deterministic subset of
+  the MUST checks (description sections, work-tracking presence, link resolution, test-file-touched
+  heuristic, CI currency, adjacent-file overlap). It is advisory today and is the same logic a
+  future CI status check could call. Semantic judgments (test substance, M3) stay with the agent
+  and the human.

--- a/skills/rocm-pr-quality/SKILL.md
+++ b/skills/rocm-pr-quality/SKILL.md
@@ -33,12 +33,12 @@ ______________________________________________________________________
    This applies even when the user says "review the PR" — you produce the review, the human
    posts it.
 1. **Advisory first.** This skill raises the floor; it does not approve and it does not
-   block a merge by itself. Hard enforcement (a required CI status check, a merge queue)
-   is a separate, DevOps-owned lane that may be added later. Do not assume it exists.
-1. **Defer to the repo.** When a component repo ships its own testing/contributing/standards
-   docs (e.g. `CONTRIBUTING.md`, a `docs/testing*.md`, a per-repo best-practices file), read
-   and apply them rather than inventing guidance. The skill checks that repo standards are
-   followed; it does not replace them.
+   block a merge by itself. Hard enforcement (a required CI status check, a merge queue) is a
+   separate, DevOps-owned lane. Do not assume it exists.
+1. **Follow the repo's own standards.** When a component repo ships its own
+   testing/contributing/standards docs (e.g. `CONTRIBUTING.md`, a `docs/testing*.md`, a per-repo
+   best-practices file), read and apply them rather than inventing guidance. The skill checks that
+   repo standards are followed; it does not replace them.
 1. **Discover, do not hardcode.** Supported architectures, CI labels, test lanes, and
    tracker prefixes drift. Discover them from the repo and CI config at run time.
 1. **Evidence over assertion.** Ground every finding in a `file:line`, a CI link, a diff
@@ -261,9 +261,6 @@ merge queue, and it does not force a CI rerun by default.
 (e.g. "overlap on a high-coupling file — rebase + re-run before merge"). The decision stays with
 the human.
 
-The durable fix for CI-currency and stale-base is a real merge queue; until that exists the
-pre-merge gate is the manual stand-in, and a strong argument for funding one.
-
 ______________________________________________________________________
 
 ## Operational notes
@@ -273,14 +270,5 @@ ______________________________________________________________________
 - Save large diffs to a temp file; read focused sections rather than pasting everything.
 - The optional shared checker `tools/pr_quality_check.py` performs the deterministic subset of
   the MUST checks (description sections, work-tracking presence, link resolution, test-file-touched
-  heuristic, CI currency, adjacent-file overlap). It is advisory today and is the same logic a
-  future CI status check could call. Semantic judgments (test substance, M3) stay with the agent
-  and the human.
-
-## Attribution
-
-The finding/assessment vocabulary, the agent-change anti-patterns, the PR-hygiene checklist, and
-the self-evident-change exemptions draw on Scott Todd's ROCm code-review guidelines
-(`ScottTodd/rocm-workspace`), toward one shared review vocabulary across ROCm. This base defers to
-canonical, in-repo style guides and lint/pre-commit config rather than duplicating them; see
-`reference.md` ("Attribution & deferral").
+  heuristic, CI currency, adjacent-file overlap). It is advisory; semantic judgments (test
+  substance, M3) stay with the agent and the human.

--- a/skills/rocm-pr-quality/SKILL.md
+++ b/skills/rocm-pr-quality/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rocm-pr-quality
-description: "Help an engineer author, review, or pre-merge-gate a pull request to a ROCm library so it is traceable, tested, and safe to merge. Use when preparing a PR, reviewing a PR, or deciding whether an approved PR is safe to merge right now, or when the user provides a GitHub PR URL or branch and asks for help with PR quality, description, testing, review, or merge-readiness. Library-agnostic base; component overlays extend it."
-argument-hint: "[author | review | pre-merge] [PR URL | branch:<name> | local] [base:<branch>]"
+description: Help an engineer author, review, or pre-merge-gate a pull request to a ROCm library so it is traceable, tested, and safe to merge. Use when preparing a PR, reviewing a PR, or deciding whether an approved PR is safe to merge right now, or when the user provides a GitHub PR URL or branch and asks for help with PR quality, description, testing, review, or merge-readiness. Library-agnostic base; component overlays extend it.
+argument-hint: '[author | review | pre-merge] [PR URL | branch:<name> | local] [base:<branch>]'
 allowed-tools: Bash, Read, Grep, Glob, Task, WebFetch
 ---
 

--- a/skills/rocm-pr-quality/reference.md
+++ b/skills/rocm-pr-quality/reference.md
@@ -42,18 +42,18 @@ ______________________________________________________________________
 A PR may carry more than one class. When ambiguous, pick the stricter one. Overlays may add
 component-specific classes (and bind them to paths).
 
-| Class                         | Typical test/flag bar                                                            |
-| ----------------------------- | -------------------------------------------------------------------------------- |
-| `new-public-api`              | Functional/API tests; compatibility check; likely flag if behavior-changing      |
-| `new-op/dtype/path`           | Tests exercising the new path across applicable devices                          |
-| `heuristic/default-selection` | Tests + safe-default flag for the new default                                    |
-| `kernel/tuning`               | Device/arch coverage appropriate to the kernel; perf evidence if perf-sensitive  |
-| `build/ci`                    | Build/CI green on supported lanes; no behavior change expected                   |
-| `docs`                        | Doc/link validation only                                                         |
-| `revert`                      | Links the PR it reverts (self-evident "why"); regression test if reverting a fix |
+| Class                         | Typical test/flag bar                                                                                                                                                                                                     |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `new-public-api`              | Functional/API tests; compatibility check; likely flag if behavior-changing                                                                                                                                               |
+| `new-op/dtype/path`           | Tests exercising the new path across applicable devices                                                                                                                                                                   |
+| `heuristic/default-selection` | Tests + safe-default flag for the new default                                                                                                                                                                             |
+| `kernel/tuning`               | Device/arch coverage appropriate to the kernel; perf evidence if perf-sensitive                                                                                                                                           |
+| `build/ci`                    | Build/CI green on supported lanes; no behavior change expected                                                                                                                                                            |
+| `docs`                        | Doc/link validation only                                                                                                                                                                                                  |
+| `revert`                      | Links the PR it reverts (self-evident "why"); regression test if reverting a fix                                                                                                                                          |
 | `defect-fix`                  | M1: regression test or tracked two-PR plan, **plus reproduction evidence** — the new test is shown to **fail on the unpatched build (reproducing the cited defect) and pass with the fix**, with the run linked in the PR |
-| `regression-test-only`        | The test is the deliverable; must fail before / pass after the fix               |
-| `other`                       | Judgment call; default to stricter                                               |
+| `regression-test-only`        | The test is the deliverable; must fail before / pass after the fix                                                                                                                                                        |
+| `other`                       | Judgment call; default to stricter                                                                                                                                                                                        |
 
 ______________________________________________________________________
 

--- a/skills/rocm-pr-quality/reference.md
+++ b/skills/rocm-pr-quality/reference.md
@@ -51,7 +51,7 @@ component-specific classes (and bind them to paths).
 | `build/ci`                    | Build/CI green on supported lanes; no behavior change expected                   |
 | `docs`                        | Doc/link validation only                                                         |
 | `revert`                      | Links the PR it reverts (self-evident "why"); regression test if reverting a fix |
-| `defect-fix`                  | M1: regression test or tracked two-PR plan + evidence                            |
+| `defect-fix`                  | M1: regression test or tracked two-PR plan, **plus reproduction evidence** — the new test is shown to **fail on the unpatched build (reproducing the cited defect) and pass with the fix**, with the run linked in the PR |
 | `regression-test-only`        | The test is the deliverable; must fail before / pass after the fix               |
 | `other`                       | Judgment call; default to stricter                                               |
 

--- a/skills/rocm-pr-quality/reference.md
+++ b/skills/rocm-pr-quality/reference.md
@@ -57,12 +57,9 @@ component-specific classes (and bind them to paths).
 
 ______________________________________________________________________
 
-## Test-level mapping (SHOULD — starter, extensible)
+## Test-level mapping (SHOULD)
 
-This is a **starter** map and a deliberate follow-on hook: the test-level → change-class mapping
-is expected to grow, and per-repo testing docs may override it. Keep it here as the central place
-so two reviewers do not disagree on "is the test good enough." Overlays map these levels to real
-paths/lanes.
+Per-repo testing docs may override this mapping. Overlays map these levels to real paths/lanes.
 
 | Change class                  | Default minimum test level                                    |
 | ----------------------------- | ------------------------------------------------------------- |
@@ -103,8 +100,7 @@ Mutation question: *what single change to the source would make this test fail?*
 
 ### Agent / AI-generated change anti-patterns (a hit warrants a closer read)
 
-These recur in AI-assisted PRs and frequently hide a thin or wrong change. Adapted from Scott
-Todd's review guidelines (see Attribution).
+These recur in AI-assisted PRs and frequently hide a thin or wrong change.
 
 - **Test sprawl** — many new test files / a large patch count for a small behavioral change; new
   tests that restate the implementation rather than lock behavior. Prefer parametrizing one test
@@ -126,8 +122,7 @@ ______________________________________________________________________
 
 ## PR-hygiene checklist (author & reviewer)
 
-Quick, mostly mechanical checks that make a PR reviewable. Adapted from Scott Todd's review
-guidelines (see Attribution).
+Quick, mostly mechanical checks that make a PR reviewable.
 
 - **Title** — concise, follows the repo convention (and carries the tracker key if the repo
   requires it for dev-panel auto-linking).
@@ -291,17 +286,3 @@ When a defect is known but the fix is not ready, M1 may be met by a tracked two-
 
 The quarantine must be tracked, time-boxed, and removed by the fix — not left in place. Overlays
 define the concrete mechanism (e.g. a `known_bugs` data file).
-
-______________________________________________________________________
-
-## Attribution & deferral
-
-- The finding tiers / overall-assessment vocabulary, the agent-change anti-patterns, the
-  PR-hygiene checklist, and the self-evident-change exemptions draw on Scott Todd's ROCm code
-  review guidelines (`ScottTodd/rocm-workspace`). Credit to him; the goal is one shared vocabulary
-  across ROCm reviews.
-- This base skill **defers to canonical, in-repo style guides** (e.g. each repo's `CONTRIBUTING`,
-  `docs/.../style_guides/`, pre-commit/lint config) rather than duplicating them. Where a rule is
-  already mechanically enforced (pre-commit, CI lint) the skill assumes it and does not restate it;
-  where a canonical guide exists, the skill links and defers instead of copying. Overlays name the
-  specific guides for their repo.

--- a/skills/rocm-pr-quality/reference.md
+++ b/skills/rocm-pr-quality/reference.md
@@ -88,7 +88,7 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
-## Test-substance smell scan (a hit is a blocker, not a nit)
+## Test-substance smell scan (a hit is `BLOCKING`, not a nit)
 
 - assert-callable only / asserts only that a mock was called
 - `hasattr`-guarded test bodies that silently skip
@@ -101,24 +101,86 @@ ______________________________________________________________________
 Mutation question: *what single change to the source would make this test fail?* No clear answer
 → coverage padding.
 
+### Agent / AI-generated change anti-patterns (a hit warrants a closer read)
+
+These recur in AI-assisted PRs and frequently hide a thin or wrong change. Adapted from Scott
+Todd's review guidelines (see Attribution).
+
+- **Test sprawl** — many new test files / a large patch count for a small behavioral change; new
+  tests that restate the implementation rather than lock behavior. Prefer parametrizing one test
+  over generating ten near-duplicates.
+- **Change-narrative comments** — comments that describe the *diff* ("renamed X to Y", "now also
+  handles Z", "previously this did…") instead of the code's intent. The diff already records the
+  change; such comments rot immediately. Flag them.
+- **"Backward-compat" framing for internal-only code** — keeping a deprecated alias / old code
+  path "for compatibility" when the symbol is internal and has no external users. That is
+  incomplete cleanup, not compatibility → `BLOCKING`.
+- **Over-mocking** — mocking the very thing under test, or so much that the test passes against a
+  no-op. The test must exercise real behavior.
+- **Excessive patch count / churn** — large reformat or rename noise mixed into a functional
+  change, making the real change hard to find. Ask for a split.
+- **File-naming / placement drift** — new files that do not follow the repo's existing test naming
+  and directory conventions; tests placed where the suite will not pick them up.
+
 ______________________________________________________________________
 
-## Severity (individual findings)
+## PR-hygiene checklist (author & reviewer)
 
-| Severity       | Meaning                                                                                                                                                                  |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Critical**   | Likely correctness failure, data corruption, leak/crash in normal use, ABI/API break, or an untested broad-blast-radius change to a default/shipping path. Blocks merge. |
-| **Major**      | Real behavioral risk, missing essential validation, meaningful test gap, missing required device/arch coverage, or a maintainability issue likely to cause defects.      |
-| **Minor**      | Localized quality issue, unclear docs, low-risk edge case, non-blocking cleanup.                                                                                         |
-| **Suggestion** | Optional improvement, refactor, or broader follow-up.                                                                                                                    |
+Quick, mostly mechanical checks that make a PR reviewable. Adapted from Scott Todd's review
+guidelines (see Attribution).
 
-## Verdict (PR overall)
+- **Title** — concise, follows the repo convention (and carries the tracker key if the repo
+  requires it for dev-panel auto-linking).
+- **Motivation answers "why"** — the description explains *why* the change is needed, not a
+  restatement of the title or a file-by-file list of *what* changed. A reviewer should understand
+  the problem before the diff.
+- **PR size** — scoped to one logical change. Large mechanical churn (reformat, rename, generated
+  code) is split from functional changes so the real change is reviewable. If it must be combined,
+  call it out and isolate it in its own commit.
+- **Revert vs roll-forward** — for a revert, link the PR being reverted (that is the "why"); for a
+  fix-forward, say why forward is safer than reverting.
+- **Reviewers / CODEOWNERS** — the right owners are requested; cross-component changes name each
+  affected area's owner.
+- **No leftover scaffolding** — no debug prints, commented-out code, TODOs without a tracker, or
+  generated/temporary files committed by accident.
 
-| Verdict    | When                                                                                                                                                |
-| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `STANDARD` | Policy met.                                                                                                                                         |
-| `WAIVER`   | A valid, documented, reviewer-accepted exception covers the gap.                                                                                    |
-| `BLOCKER`  | Missing tests/flags/waiver, bad/absent tracking, defect without a regression plan, an unresolved Critical finding, or a weak/again-rejected waiver. |
+## Self-evident changes (reduced-justification exemptions)
+
+Not every PR needs the full description, a tracker, or new tests. These classes are self-evident;
+do not manufacture process for them (but M3 still always applies — never weaken tests to green CI):
+
+- **Pure docs / comments / typo fixes** — link/metadata validation only; no tracker or tests
+  required.
+- **Mechanical, tool-driven changes** — auto-formatting, lint autofixes, generated-file
+  regeneration, dependency-pin bumps from a bot — where the tool and command are named.
+- **Reverts** — the linked reverted PR is the justification (add a regression test only if you are
+  reverting a fix).
+- **Trivial, obviously-correct edits** — a one-line constant/string fix, a version bump, fixing an
+  obvious typo in an identifier — where the diff is its own proof.
+
+For anything outside these classes, the normal MUST set (M1–M5) applies. When in doubt, treat the
+change as non-self-evident and ask for the missing justification.
+
+______________________________________________________________________
+
+## Finding tiers (individual findings)
+
+| Tier            | Meaning                                                                                                                                                                                                                                                                                                                                                        |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **BLOCKING**    | Must fix before merge: correctness/logic error, security issue, leak/crash in normal use, ABI/API break, breaking change without a migration path, missing required tests for new functionality, an untested broad-blast-radius change to a default/shipping path, or incomplete cleanup of code this PR modifies (dead params/constants/helpers left behind). |
+| **IMPORTANT**   | Should fix: real behavioral risk, missing validation for a likely edge case, meaningful test gap, missing required device/arch coverage, or a maintainability issue likely to cause defects soon.                                                                                                                                                              |
+| **SUGGESTION**  | Nice to have on code already being touched: clarity, naming, a small refactor, an extra test case.                                                                                                                                                                                                                                                             |
+| **FUTURE WORK** | Out of scope for this PR: improvements to code not being modified, larger refactors, follow-up features. Track separately; do not block this PR.                                                                                                                                                                                                               |
+
+Decision framework: correctness/security issue, or incomplete cleanup of code being modified → **BLOCKING**; will cause problems for users/developers soon → **IMPORTANT**; an improvement to code being modified → **SUGGESTION**; otherwise → **FUTURE WORK**. Do not mark unrelated improvements BLOCKING, and do not soften incomplete cleanup to SUGGESTION/FUTURE WORK.
+
+## Overall assessment (PR-level)
+
+| Status              | When                                                                                                                                                                                  |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `APPROVED`          | Policy met. May carry documented, reviewer-accepted waivers and optional recommendations. A valid waiver is recorded here, not treated as a block.                                    |
+| `CHANGES REQUESTED` | One or more `BLOCKING` items: missing tests/flags/waiver, bad/absent tracking, a defect without a regression plan, an unresolved `BLOCKING` finding, or a weak/again-rejected waiver. |
+| `REJECTED`          | Fundamental problem with the approach; needs rework or abandonment.                                                                                                                   |
 
 ______________________________________________________________________
 
@@ -229,3 +291,17 @@ When a defect is known but the fix is not ready, M1 may be met by a tracked two-
 
 The quarantine must be tracked, time-boxed, and removed by the fix — not left in place. Overlays
 define the concrete mechanism (e.g. a `known_bugs` data file).
+
+______________________________________________________________________
+
+## Attribution & deferral
+
+- The finding tiers / overall-assessment vocabulary, the agent-change anti-patterns, the
+  PR-hygiene checklist, and the self-evident-change exemptions draw on Scott Todd's ROCm code
+  review guidelines (`ScottTodd/rocm-workspace`). Credit to him; the goal is one shared vocabulary
+  across ROCm reviews.
+- This base skill **defers to canonical, in-repo style guides** (e.g. each repo's `CONTRIBUTING`,
+  `docs/.../style_guides/`, pre-commit/lint config) rather than duplicating them. Where a rule is
+  already mechanically enforced (pre-commit, CI lint) the skill assumes it and does not restate it;
+  where a canonical guide exists, the skill links and defers instead of copying. Overlays name the
+  specific guides for their repo.

--- a/skills/rocm-pr-quality/reference.md
+++ b/skills/rocm-pr-quality/reference.md
@@ -1,0 +1,231 @@
+# ROCm PR Quality — Reference
+
+Rubric tables, templates, and vocabularies for the `rocm-pr-quality` base skill. This is the
+single source of truth the author/review actions and the shared checker share. Overlays add to
+or tighten these; they never relax a MUST.
+
+______________________________________________________________________
+
+## MUST set (verbatim — non-overridable by overlays)
+
+- **M1** Defect-fix PRs include a regression test, or a tracked two-PR known-bug plan.
+- **M2** Product-code changes carry tests, a safe-default flag, or a written waiver.
+- **M3** Never disable, skip, or weaken tests solely to green CI.
+- **M4** Non-trivial PRs carry work tracking (ticket, public issue, or credible no-tracker reason).
+- **M5** PRs link the artifacts they relate to (work-tracking item, the defect they fix, directly
+  related PRs), and those links must resolve.
+
+Overlays may add rules and tighten thresholds; they may not weaken M1–M5.
+
+### Waiver-ability
+
+| Kind              | Rules      | Exception path                                                              |
+| ----------------- | ---------- | --------------------------------------------------------------------------- |
+| Escape-hatch MUST | M2, M4, M5 | Waiver-able with an explicit written reason; reviewer decides, can reject   |
+| Conditional MUST  | M1         | Satisfied by a regression test **or** a tracked two-PR plan; no bare waiver |
+| Hard MUST         | M3         | No waiver — there is no acceptable reason                                   |
+
+______________________________________________________________________
+
+## Rule strengths (how overlays may change a rule)
+
+| Strength   | Meaning         | Overlay MAY                                        | Overlay MUST NOT           |
+| ---------- | --------------- | -------------------------------------------------- | -------------------------- |
+| **MUST**   | ROCm-wide floor | Add new MUSTs; tighten; bind to component paths    | Remove, relax, or waive it |
+| **SHOULD** | Tunable default | Tighten or loosen with an owned, written rationale | Silently drop it           |
+| **MAY**    | Advisory nicety | Anything                                           | —                          |
+
+______________________________________________________________________
+
+## Change classes (extensible; multiple tags allowed)
+
+A PR may carry more than one class. When ambiguous, pick the stricter one. Overlays may add
+component-specific classes (and bind them to paths).
+
+| Class                         | Typical test/flag bar                                                            |
+| ----------------------------- | -------------------------------------------------------------------------------- |
+| `new-public-api`              | Functional/API tests; compatibility check; likely flag if behavior-changing      |
+| `new-op/dtype/path`           | Tests exercising the new path across applicable devices                          |
+| `heuristic/default-selection` | Tests + safe-default flag for the new default                                    |
+| `kernel/tuning`               | Device/arch coverage appropriate to the kernel; perf evidence if perf-sensitive  |
+| `build/ci`                    | Build/CI green on supported lanes; no behavior change expected                   |
+| `docs`                        | Doc/link validation only                                                         |
+| `revert`                      | Links the PR it reverts (self-evident "why"); regression test if reverting a fix |
+| `defect-fix`                  | M1: regression test or tracked two-PR plan + evidence                            |
+| `regression-test-only`        | The test is the deliverable; must fail before / pass after the fix               |
+| `other`                       | Judgment call; default to stricter                                               |
+
+______________________________________________________________________
+
+## Test-level mapping (SHOULD — starter, extensible)
+
+This is a **starter** map and a deliberate follow-on hook: the test-level → change-class mapping
+is expected to grow, and per-repo testing docs may override it. Keep it here as the central place
+so two reviewers do not disagree on "is the test good enough." Overlays map these levels to real
+paths/lanes.
+
+| Change class                  | Default minimum test level                                    |
+| ----------------------------- | ------------------------------------------------------------- |
+| `defect-fix`                  | Unit/lowest level that fails on the regression, plus evidence |
+| `new-public-api`              | Functional/API-level test                                     |
+| `new-op/dtype/path`           | Functional + device coverage for the path                     |
+| `heuristic/default-selection` | Functional test of the new default + flag                     |
+| `kernel/tuning`               | Integration / on-device test across affected archs            |
+| `build/ci`                    | CI lane green                                                 |
+| `docs`                        | Link/metadata validation                                      |
+
+Principle: pick the **lowest** test level that would actually fail on the regression or exercise
+the change; do not demand an integration test where a unit test locks the behavior.
+
+______________________________________________________________________
+
+## The four review questions
+
+1. What new or changed functionality lands in this PR?
+1. What test level is appropriate for it (and is it present)?
+1. If tests or flags are omitted, is that acceptable — i.e. is there a valid waiver?
+1. What adjacent tests should have been considered (second-order impact)?
+
+______________________________________________________________________
+
+## Test-substance smell scan (a hit is a blocker, not a nit)
+
+- assert-callable only / asserts only that a mock was called
+- `hasattr`-guarded test bodies that silently skip
+- lone `is not None` / `.called` assertions with no behavioral check
+- copy-paste tests that should be parametrized
+- mock-only assertions that pass against a no-op implementation
+- phantom methods / attributes that do not exist in the source (AI-slop tell)
+- non-obvious tolerance or parameter choices with no recorded rationale ("why")
+
+Mutation question: *what single change to the source would make this test fail?* No clear answer
+→ coverage padding.
+
+______________________________________________________________________
+
+## Severity (individual findings)
+
+| Severity       | Meaning                                                                                                                                                                  |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Critical**   | Likely correctness failure, data corruption, leak/crash in normal use, ABI/API break, or an untested broad-blast-radius change to a default/shipping path. Blocks merge. |
+| **Major**      | Real behavioral risk, missing essential validation, meaningful test gap, missing required device/arch coverage, or a maintainability issue likely to cause defects.      |
+| **Minor**      | Localized quality issue, unclear docs, low-risk edge case, non-blocking cleanup.                                                                                         |
+| **Suggestion** | Optional improvement, refactor, or broader follow-up.                                                                                                                    |
+
+## Verdict (PR overall)
+
+| Verdict    | When                                                                                                                                                |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `STANDARD` | Policy met.                                                                                                                                         |
+| `WAIVER`   | A valid, documented, reviewer-accepted exception covers the gap.                                                                                    |
+| `BLOCKER`  | Missing tests/flags/waiver, bad/absent tracking, defect without a regression plan, an unresolved Critical finding, or a weak/again-rejected waiver. |
+
+______________________________________________________________________
+
+## Risk levels (1–5)
+
+| Level | Meaning                                                                                                                                    |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1     | Docs-only, comments-only, metadata-only, or isolated non-shipping test changes.                                                            |
+| 2     | Narrow change, low blast radius, good coverage, no API/schema/build impact.                                                                |
+| 3     | Core subsystem, new feature path, schema/API addition, dispatch/build/test infra, or flagged change with real integration surface.         |
+| 4     | Broad behavior change, compat-sensitive public API, perf-critical path, complex migration, or incomplete coverage.                         |
+| 5     | Cross-project/architectural, default behavior change in a critical path, ABI break, large unproven refactor, or known unresolved failures. |
+
+A required-but-not-yet-passed device/arch run raises the residual risk.
+
+______________________________________________________________________
+
+## Waiver codes
+
+Base set (overlays may add component-specific codes and may tighten who can approve them):
+
+| Code         | Use                                                                                              |
+| ------------ | ------------------------------------------------------------------------------------------------ |
+| `W-DOC`      | Docs/comments-only change; no product behavior.                                                  |
+| `W-BUILD`    | Build/CI-only change with no behavior change.                                                    |
+| `W-REVERT`   | Revert; the "why" is the reverted PR, which is linked.                                           |
+| `W-HOTFIX`   | Emergency fix; regression test deferred to a linked follow-up (needs named approver).            |
+| `W-FLAG`     | New behavior landed dark behind a safe-default flag; tests/soak before enable, with a tracker.   |
+| `W-NOTICKET` | No tracker at author time; credible reason + a commitment to file & link within a stated window. |
+
+Every waiver needs a one-to-two-sentence "why." A bare "N/A" is not a waiver. Higher-risk waivers
+(e.g. `W-HOTFIX`) require a named approver / lead sign-off.
+
+______________________________________________________________________
+
+## PR description template
+
+```markdown
+## Summary
+
+<1-3 sentences: purpose, motivation, what this PR enables. Link named non-tracker references.>
+
+## Risk Assessment
+
+<Risk level 1-5 and a concise rationale (one short paragraph).>
+
+## Related
+
+- Work tracking: <ticket key and/or issue URL>
+- Fixes / defect: <tracker>
+- Related PRs: <#PR ...>  (dependency, two-PR flow, revert/cherry-pick source)
+- Design / docs: <links>
+
+## Device / Architecture Coverage
+
+<Blast radius and which devices/arches must be verified before merge. State whether passing PR
+CI is sufficient, a specific-arch run is required, or a full sweep is required, and why. Omit
+only for docs/comments/skill-only changes with no device impact.>
+
+## Testing Summary
+
+- <Testing category and what it covers.>
+
+## Testing Checklist
+
+- [x] <Test group> - `<command>` - Status: Passed
+- [x] <Hardware test group> - `<command>` - Devices: <list> - Status: Passed
+- [ ] <Sweep, only if blast radius requires it> - Devices: <families> - Status: Pending
+- [ ] PR CI - GitHub PR checks - Status: Pending
+
+## Flags / Guardrails
+
+<Any feature flag, default value, and the enable plan. "None" if not applicable.>
+
+## Adjacent Tests Considered
+
+<What else exercises this code path; what was run or why it was not needed.>
+
+## Risk Acceptance / Waivers
+
+<Any declared waiver: code + one-to-two-sentence reason + approver if required. Omit if none.>
+
+## Technical Changes
+
+- <Top-level technical what/why.>
+```
+
+### Checklist & body rules
+
+- `[x]` only for passed/completed validation; `[ ]` for pending/not-run/failed/unknown.
+- Include the command after the test group in backticks when known; omit if no useful command.
+- Include `Devices: ...` only for hardware tests; include `Link: ...` only when a real link exists.
+- Do **not** render empty placeholder fields (`Devices: N/A`, `Link: N/A`). Omit the field.
+- Do not include unverified testing claims or file-by-file changelogs for large PRs.
+- Tracker-key-in-title vs in-body is a per-repo convention; follow the repo's. Some repos
+  (e.g. Jira-linked) require the key in the title to trigger dev-panel auto-linking — overlays
+  state this.
+
+______________________________________________________________________
+
+## Two-PR known-bug flow (satisfies M1 without a same-PR fix)
+
+When a defect is known but the fix is not ready, M1 may be met by a tracked two-PR plan:
+
+1. **Test-only PR**: adds a regression test that documents the bug, quarantined/expected-fail and
+   **tracked** (a tracker id + a time-box), not silently skipped.
+1. **Fix PR**: lands the fix and removes the quarantine in the same PR.
+
+The quarantine must be tracked, time-boxed, and removed by the fix — not left in place. Overlays
+define the concrete mechanism (e.g. a `known_bugs` data file).

--- a/skills/rocm-pr-quality/tools/pr_quality_check.py
+++ b/skills/rocm-pr-quality/tools/pr_quality_check.py
@@ -68,7 +68,7 @@ CI_STALE_DAYS = 3
 class Finding:
     def __init__(self, rule: str, severity: str, message: str):
         self.rule = rule
-        self.severity = severity  # BLOCKER | WARN | INFO
+        self.severity = severity  # BLOCKING | IMPORTANT | INFO
         self.message = message
 
     def as_dict(self):
@@ -152,7 +152,9 @@ def check_description(body: str, findings: list[Finding]) -> None:
     if missing:
         findings.append(
             Finding(
-                "DESC", "WARN", f"PR body missing section(s): {', '.join(missing)}."
+                "DESC",
+                "IMPORTANT",
+                f"PR body missing section(s): {', '.join(missing)}.",
             )
         )
     for empty in re.findall(r"(Devices?|Link):\s*N/?A", body, re.IGNORECASE):
@@ -198,7 +200,7 @@ def check_tracking(
         findings.append(
             Finding(
                 "M4",
-                "WARN",
+                "IMPORTANT",
                 f"No work-tracking ticket, but cross-reference(s)/mention(s) found "
                 f"({shown}). A related PR or mention is not work tracking -- confirm "
                 "a ticket/issue or declare a credible no-tracker waiver.",
@@ -208,7 +210,7 @@ def check_tracking(
         findings.append(
             Finding(
                 "M4",
-                "BLOCKER",
+                "BLOCKING",
                 "No work-tracking reference and no cross-reference or declared "
                 "waiver. Add a tracker, or a credible no-tracker waiver.",
             )
@@ -225,7 +227,7 @@ def check_related_links(
         findings.append(
             Finding(
                 "M5",
-                "WARN",
+                "IMPORTANT",
                 "No related links found in the PR body. Link the work item, the "
                 "defect fixed, and directly related PRs.",
             )
@@ -247,7 +249,7 @@ def check_related_links(
                     findings.append(
                         Finding(
                             "M5",
-                            "WARN",
+                            "IMPORTANT",
                             f"Reference #{num} did not resolve to an issue or PR.",
                         )
                     )
@@ -263,7 +265,7 @@ def check_tests(data: dict, prof: dict, findings: list[Finding]) -> None:
         findings.append(
             Finding(
                 "M2",
-                "BLOCKER",
+                "BLOCKING",
                 f"{len(product)} product file(s) changed but no test files touched "
                 "and no waiver declared. Add tests, a safe-default flag + tracker, "
                 "or a written waiver. (Substance is judged separately by the agent.)",
@@ -294,7 +296,7 @@ def check_ci_currency(data: dict, findings: list[Finding]) -> None:
         findings.append(
             Finding(
                 "CI",
-                "WARN",
+                "IMPORTANT",
                 f"Newest CI result is ~{age_days:.1f} days old (> {CI_STALE_DAYS}). "
                 "Consider a rebase + re-run before merge.",
             )
@@ -326,7 +328,7 @@ def _report_overlap(
         findings.append(
             Finding(
                 "STALE-BASE",
-                "BLOCKER",
+                "BLOCKING",
                 "Overlap on high-coupling file(s) since divergence "
                 f"({how}): {', '.join(sorted(hot))}. Rebase + re-run before merge.",
             )
@@ -335,7 +337,7 @@ def _report_overlap(
         findings.append(
             Finding(
                 "STALE-BASE",
-                "WARN",
+                "IMPORTANT",
                 f"Overlap with base on {len(overlap)} file(s) ({how}); "
                 "consider rebase + re-run.",
             )
@@ -386,7 +388,7 @@ def check_stale_base_api(
         findings.append(
             Finding(
                 "STALE-BASE",
-                "WARN",
+                "IMPORTANT",
                 "Inconclusive: base advanced past the API's 300-file limit, so the "
                 "adjacent-file check is incomplete. Re-run nearer merge time, or use "
                 "--repo-path <clone> for an exact result.",
@@ -445,7 +447,7 @@ def main() -> None:
         "--check-links", action="store_true", help="resolve #refs via gh (network)"
     )
     ap.add_argument(
-        "--enforce", action="store_true", help="exit non-zero on BLOCKER findings"
+        "--enforce", action="store_true", help="exit non-zero on BLOCKING findings"
     )
     ap.add_argument("--json", action="store_true", help="emit JSON")
     args = ap.parse_args()
@@ -462,8 +464,8 @@ def main() -> None:
     check_ci_currency(data, findings)
     check_stale_base(data, prof, args.repo_path, args.repo, findings)
 
-    blockers = [f for f in findings if f.severity == "BLOCKER"]
-    warns = [f for f in findings if f.severity == "WARN"]
+    blockers = [f for f in findings if f.severity == "BLOCKING"]
+    warns = [f for f in findings if f.severity == "IMPORTANT"]
 
     if args.json:
         print(
@@ -481,11 +483,11 @@ def main() -> None:
         )
     else:
         print(f"PR #{data.get('number')} [{args.profile}] - {data.get('url')}")
-        order = {"BLOCKER": 0, "WARN": 1, "INFO": 2}
+        order = {"BLOCKING": 0, "IMPORTANT": 1, "INFO": 2}
         for f in sorted(findings, key=lambda x: order[x.severity]):
-            print(f"  [{f.severity:7}] {f.rule:11} {f.message}")
+            print(f"  [{f.severity:9}] {f.rule:11} {f.message}")
         print(
-            f"Summary: {len(blockers)} blocker(s), {len(warns)} warning(s). "
+            f"Summary: {len(blockers)} blocking, {len(warns)} important. "
             "Substance/M3 judged separately by the agent + human reviewer."
         )
 

--- a/skills/rocm-pr-quality/tools/pr_quality_check.py
+++ b/skills/rocm-pr-quality/tools/pr_quality_check.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Deterministic subset of the ROCm PR-quality MUST checks.
+
+One checker, two callers: the skill invokes it locally for fast feedback, and a future CI
+status check can run the exact same command. It covers only the *mechanical* checks --
+description completeness, work-tracking presence (M4), related-link presence/resolution (M5),
+a product-code-without-tests heuristic (M2), CI currency, and stale-base/adjacent-file overlap.
+Semantic judgments -- test substance, the mutation question, and M3 (never disable tests to
+green CI) -- stay with the agent and the human reviewer; they are intentionally NOT enforced here.
+
+Advisory by default (always exits 0). Pass --enforce to exit non-zero on blockers, matching the
+staged rollout: audit -> advisory -> enforced MUST.
+
+Usage:
+    python pr_quality_check.py --pr <number|url> [--repo owner/name] [--profile hipblaslt]
+                               [--repo-path .] [--check-links] [--enforce] [--json]
+
+Requires: gh (authenticated). The stale-base check uses local git when --repo-path is given
+(exact), otherwise falls back to the GitHub compare API (no clone needed; the API caps the file
+list at 300, so on a long-diverged base it reports "inconclusive" rather than a false "fine").
+M4 distinguishes a real work-tracking item (Jira key / closing-issue / issue link) from an
+incidental cross-reference or timeline mention, which it surfaces as a soft note, not a blocker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+# --- Profiles: generic defaults plus component overlays ------------------------------------
+
+PROFILES = {
+    "base": {
+        "product_globs": [r"src/", r"library/", r"include/"],
+        "test_globs": [r"test", r"clients/", r"/tests?/"],
+        "high_coupling": [],
+        # Strong work-tracking signals (a real ticket/issue), vs. incidental cross-references.
+        "tracker_regexes": [r"\b[A-Z][A-Z0-9]+-\d+\b"],
+        "issue_link_regexes": [r"https?://\S+/issues/\d+"],
+    },
+    "hipblaslt": {
+        "product_globs": [r"projects/hipblaslt/", r"tensilelite/"],
+        "test_globs": [r"clients/tests", r"test", r"/tests?/"],
+        "high_coupling": [
+            r"KernelWriter.*\.py",
+            r"KernelWriterAssembly\.py",
+            r"Components/",
+            r"sgpr",
+            r"register",
+        ],
+        "tracker_regexes": [r"\bAIHPBLAS-\d+\b", r"\bROCM-\d+\b"],
+        "issue_link_regexes": [r"https?://\S+/issues/\d+"],
+    },
+}
+
+REQUIRED_SECTIONS = ["Summary", "Risk", "Related", "Testing"]
+WAIVER_RE = re.compile(r"\bW-[A-Z\-]+\b")
+CI_STALE_DAYS = 3
+
+
+class Finding:
+    def __init__(self, rule: str, severity: str, message: str):
+        self.rule = rule
+        self.severity = severity  # BLOCKER | WARN | INFO
+        self.message = message
+
+    def as_dict(self):
+        return {"rule": self.rule, "severity": self.severity, "message": self.message}
+
+
+def run(cmd: list[str], cwd: str | None = None) -> tuple[int, str, str]:
+    # Force UTF-8 decoding; gh/git output is UTF-8 even on Windows (default cp1252 corrupts it).
+    p = subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, encoding="utf-8", errors="replace"
+    )
+    return p.returncode, (p.stdout or ""), (p.stderr or "")
+
+
+def gh_pr_json(pr: str, repo: str | None) -> dict:
+    fields = (
+        "title,body,files,baseRefName,headRefName,headRefOid,url,statusCheckRollup,"
+        "commits,number,closingIssuesReferences"
+    )
+    cmd = ["gh", "pr", "view", pr, "--json", fields]
+    if repo:
+        cmd += ["--repo", repo]
+    code, out, err = run(cmd)
+    if code != 0:
+        sys.stderr.write(f"ERROR: gh pr view failed: {err.strip()}\n")
+        sys.exit(3)
+    return json.loads(out)
+
+
+def gh_api_json(path: str):
+    code, out, err = run(["gh", "api", path])
+    if code != 0:
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return None
+
+
+def resolve_repo(repo: str | None) -> str | None:
+    if repo:
+        return repo
+    code, out, _ = run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]
+    )
+    return out.strip() if code == 0 and out.strip() else None
+
+
+def cross_reference_numbers(pr: str, repo: str | None) -> list[str]:
+    """Best-effort: PR/issue numbers that cross-reference this PR via the timeline.
+
+    A cross-reference (e.g. 'mentioned this pull request #7326') is NOT a work-tracking
+    item, but it is worth surfacing so M4 degrades to a soft note rather than a hard block.
+    """
+    repo = resolve_repo(repo)
+    if not repo:
+        return []
+    m = re.search(r"(\d+)$", pr)
+    num = m.group(1) if m else pr
+    data = gh_api_json(f"repos/{repo}/issues/{num}/timeline?per_page=100")
+    if not isinstance(data, list):
+        return []
+    refs = []
+    for ev in data:
+        if ev.get("event") == "cross-referenced":
+            src = (ev.get("source") or {}).get("issue") or {}
+            if src.get("number"):
+                refs.append(str(src["number"]))
+    return sorted(set(refs))
+
+
+def matches_any(path: str, patterns: list[str]) -> bool:
+    return any(re.search(p, path, re.IGNORECASE) for p in patterns)
+
+
+def check_description(body: str, findings: list[Finding]) -> None:
+    body = body or ""
+    missing = [
+        s for s in REQUIRED_SECTIONS if not re.search(rf"#+\s*{s}", body, re.IGNORECASE)
+    ]
+    if missing:
+        findings.append(
+            Finding(
+                "DESC", "WARN", f"PR body missing section(s): {', '.join(missing)}."
+            )
+        )
+    for empty in re.findall(r"(Devices?|Link):\s*N/?A", body, re.IGNORECASE):
+        findings.append(
+            Finding(
+                "DESC",
+                "INFO",
+                "Empty placeholder field present; omit it instead of 'N/A'.",
+            )
+        )
+        break
+
+
+def check_tracking(
+    data: dict, prof: dict, findings: list[Finding], cross_refs: list[str]
+) -> None:
+    haystack = " ".join(
+        [data.get("title", ""), data.get("body", ""), data.get("headRefName", "")]
+    )
+    body = data.get("body", "") or ""
+    has_jira = any(re.search(rx, haystack) for rx in prof["tracker_regexes"])
+    has_issue_link = any(
+        re.search(rx, body) for rx in prof.get("issue_link_regexes", [])
+    )
+    closing = data.get("closingIssuesReferences") or []
+    has_waiver = bool(WAIVER_RE.search(body))
+    body_refs = re.findall(r"(?<!\w)#(\d+)\b", body)
+    mentions = sorted(set(body_refs) | set(cross_refs))
+
+    if has_jira or has_issue_link or closing:
+        findings.append(Finding("M4", "INFO", "Work-tracking reference found."))
+    elif has_waiver:
+        findings.append(
+            Finding(
+                "M4",
+                "INFO",
+                "No tracker, but a waiver is declared; reviewer to adjudicate.",
+            )
+        )
+    elif mentions:
+        # A cross-reference / mention is not itself a tracker -- soft note, not a hard block.
+        shown = ", ".join("#" + m for m in mentions[:5])
+        findings.append(
+            Finding(
+                "M4",
+                "WARN",
+                f"No work-tracking ticket, but cross-reference(s)/mention(s) found "
+                f"({shown}). A related PR or mention is not work tracking -- confirm "
+                "a ticket/issue or declare a credible no-tracker waiver.",
+            )
+        )
+    else:
+        findings.append(
+            Finding(
+                "M4",
+                "BLOCKER",
+                "No work-tracking reference and no cross-reference or declared "
+                "waiver. Add a tracker, or a credible no-tracker waiver.",
+            )
+        )
+
+
+def check_related_links(
+    data: dict, findings: list[Finding], check_links: bool, repo: str | None
+) -> None:
+    body = data.get("body", "") or ""
+    urls = re.findall(r"https?://[^\s)]+", body)
+    issue_refs = re.findall(r"(?<!\w)#(\d+)\b", body)
+    if not urls and not issue_refs:
+        findings.append(
+            Finding(
+                "M5",
+                "WARN",
+                "No related links found in the PR body. Link the work item, the "
+                "defect fixed, and directly related PRs.",
+            )
+        )
+        return
+    if check_links:
+        for num in set(issue_refs):
+            cmd = ["gh", "issue", "view", num, "--json", "number"]
+            if repo:
+                cmd += ["--repo", repo]
+            code, _, _ = run(cmd)
+            if code != 0:
+                # could be a PR rather than an issue
+                cmd2 = ["gh", "pr", "view", num, "--json", "number"]
+                if repo:
+                    cmd2 += ["--repo", repo]
+                code2, _, _ = run(cmd2)
+                if code2 != 0:
+                    findings.append(
+                        Finding(
+                            "M5",
+                            "WARN",
+                            f"Reference #{num} did not resolve to an issue or PR.",
+                        )
+                    )
+
+
+def check_tests(data: dict, prof: dict, findings: list[Finding]) -> None:
+    files = [f.get("path", "") for f in data.get("files", [])]
+    product = [f for f in files if matches_any(f, prof["product_globs"])]
+    tests = [f for f in files if matches_any(f, prof["test_globs"])]
+    docs_only = files and all(f.endswith((".md", ".rst", ".txt")) for f in files)
+    has_waiver = bool(WAIVER_RE.search(data.get("body", "") or ""))
+    if product and not tests and not docs_only and not has_waiver:
+        findings.append(
+            Finding(
+                "M2",
+                "BLOCKER",
+                f"{len(product)} product file(s) changed but no test files touched "
+                "and no waiver declared. Add tests, a safe-default flag + tracker, "
+                "or a written waiver. (Substance is judged separately by the agent.)",
+            )
+        )
+
+
+def check_ci_currency(data: dict, findings: list[Finding]) -> None:
+    rollup = data.get("statusCheckRollup") or []
+    times = []
+    for c in rollup:
+        ts = c.get("completedAt") or c.get("startedAt")
+        if ts:
+            try:
+                times.append(datetime.fromisoformat(ts.replace("Z", "+00:00")))
+            except ValueError:
+                pass
+    if not times:
+        findings.append(
+            Finding(
+                "CI", "INFO", "No CI completion timestamps found to assess currency."
+            )
+        )
+        return
+    newest = max(times)
+    age_days = (datetime.now(timezone.utc) - newest).total_seconds() / 86400.0
+    if age_days > CI_STALE_DAYS:
+        findings.append(
+            Finding(
+                "CI",
+                "WARN",
+                f"Newest CI result is ~{age_days:.1f} days old (> {CI_STALE_DAYS}). "
+                "Consider a rebase + re-run before merge.",
+            )
+        )
+    else:
+        findings.append(
+            Finding("CI", "INFO", f"Newest CI result ~{age_days:.1f} days old.")
+        )
+
+
+def _report_overlap(
+    overlap: set[str], prof: dict, findings: list[Finding], how: str
+) -> None:
+    if not overlap:
+        findings.append(
+            Finding(
+                "STALE-BASE",
+                "INFO",
+                f"No adjacent-file overlap with base ({how}); merge is fine.",
+            )
+        )
+        return
+    hot = (
+        [f for f in overlap if matches_any(f, prof["high_coupling"])]
+        if prof["high_coupling"]
+        else []
+    )
+    if hot:
+        findings.append(
+            Finding(
+                "STALE-BASE",
+                "BLOCKER",
+                "Overlap on high-coupling file(s) since divergence "
+                f"({how}): {', '.join(sorted(hot))}. Rebase + re-run before merge.",
+            )
+        )
+    else:
+        findings.append(
+            Finding(
+                "STALE-BASE",
+                "WARN",
+                f"Overlap with base on {len(overlap)} file(s) ({how}); "
+                "consider rebase + re-run.",
+            )
+        )
+
+
+def check_stale_base_api(
+    data: dict, prof: dict, repo: str | None, findings: list[Finding]
+) -> None:
+    """No local clone: use the compare API to find the merge-base, then the files the base
+    branch advanced with since divergence, and intersect with the PR's files."""
+    repo = resolve_repo(repo)
+    base = data.get("baseRefName", "develop")
+    head = data.get("headRefOid")
+    pr_files = {f.get("path", "") for f in data.get("files", [])}
+    if not repo or not head:
+        findings.append(
+            Finding(
+                "STALE-BASE", "INFO", "Stale-base check skipped (need repo + head SHA)."
+            )
+        )
+        return
+    cmp1 = gh_api_json(f"repos/{repo}/compare/{base}...{head}")
+    if not cmp1 or not (cmp1.get("merge_base_commit") or {}).get("sha"):
+        findings.append(
+            Finding(
+                "STALE-BASE",
+                "INFO",
+                "Stale-base check skipped (merge-base not resolvable via API; "
+                "head may be from a deleted/fork branch -- use --repo-path).",
+            )
+        )
+        return
+    mb = cmp1["merge_base_commit"]["sha"]
+    cmp2 = gh_api_json(f"repos/{repo}/compare/{mb}...{base}")
+    if not cmp2:
+        findings.append(
+            Finding(
+                "STALE-BASE", "INFO", "Stale-base check skipped (base compare failed)."
+            )
+        )
+        return
+    base_changed = {f.get("filename", "") for f in (cmp2.get("files") or [])}
+    overlap = pr_files & base_changed
+    truncated = len(cmp2.get("files") or []) >= 300
+    if truncated and not overlap:
+        # The base advanced past the API's 300-file cap, so "no overlap" is not trustworthy.
+        findings.append(
+            Finding(
+                "STALE-BASE",
+                "WARN",
+                "Inconclusive: base advanced past the API's 300-file limit, so the "
+                "adjacent-file check is incomplete. Re-run nearer merge time, or use "
+                "--repo-path <clone> for an exact result.",
+            )
+        )
+        return
+    _report_overlap(overlap, prof, findings, "API (truncated)" if truncated else "API")
+
+
+def check_stale_base(
+    data: dict,
+    prof: dict,
+    repo_path: str | None,
+    repo: str | None,
+    findings: list[Finding],
+) -> None:
+    if not repo_path:
+        check_stale_base_api(data, prof, repo, findings)
+        return
+    base = data.get("baseRefName", "develop")
+    pr_files = {f.get("path", "") for f in data.get("files", [])}
+    code, mb, err = run(["git", "merge-base", f"origin/{base}", "HEAD"], cwd=repo_path)
+    if code != 0:
+        code, mb, err = run(["git", "merge-base", base, "HEAD"], cwd=repo_path)
+    if code != 0:
+        findings.append(
+            Finding(
+                "STALE-BASE", "INFO", f"Could not compute merge-base: {err.strip()}"
+            )
+        )
+        return
+    merge_base = mb.strip()
+    code, out, err = run(
+        ["git", "diff", "--name-only", f"{merge_base}..origin/{base}"], cwd=repo_path
+    )
+    if code != 0:
+        findings.append(
+            Finding("STALE-BASE", "INFO", f"Could not diff base: {err.strip()}")
+        )
+        return
+    base_changed = set(filter(None, out.splitlines()))
+    _report_overlap(pr_files & base_changed, prof, findings, "git")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="ROCm PR quality deterministic checks (advisory)."
+    )
+    ap.add_argument("--pr", required=True, help="PR number or URL")
+    ap.add_argument("--repo", help="owner/name (gh infers from cwd if omitted)")
+    ap.add_argument(
+        "--profile", default="base", choices=sorted(PROFILES), help="overlay profile"
+    )
+    ap.add_argument("--repo-path", help="local clone path for the stale-base check")
+    ap.add_argument(
+        "--check-links", action="store_true", help="resolve #refs via gh (network)"
+    )
+    ap.add_argument(
+        "--enforce", action="store_true", help="exit non-zero on BLOCKER findings"
+    )
+    ap.add_argument("--json", action="store_true", help="emit JSON")
+    args = ap.parse_args()
+
+    prof = PROFILES[args.profile]
+    data = gh_pr_json(args.pr, args.repo)
+    cross_refs = cross_reference_numbers(args.pr, args.repo)
+    findings: list[Finding] = []
+
+    check_description(data.get("body", ""), findings)
+    check_tracking(data, prof, findings, cross_refs)
+    check_related_links(data, findings, args.check_links, args.repo)
+    check_tests(data, prof, findings)
+    check_ci_currency(data, findings)
+    check_stale_base(data, prof, args.repo_path, args.repo, findings)
+
+    blockers = [f for f in findings if f.severity == "BLOCKER"]
+    warns = [f for f in findings if f.severity == "WARN"]
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "pr": data.get("number"),
+                    "url": data.get("url"),
+                    "profile": args.profile,
+                    "blockers": len(blockers),
+                    "warnings": len(warns),
+                    "findings": [f.as_dict() for f in findings],
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"PR #{data.get('number')} [{args.profile}] - {data.get('url')}")
+        order = {"BLOCKER": 0, "WARN": 1, "INFO": 2}
+        for f in sorted(findings, key=lambda x: order[x.severity]):
+            print(f"  [{f.severity:7}] {f.rule:11} {f.message}")
+        print(
+            f"Summary: {len(blockers)} blocker(s), {len(warns)} warning(s). "
+            "Substance/M3 judged separately by the agent + human reviewer."
+        )
+
+    sys.exit(2 if (args.enforce and blockers) else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/rocm-pr-quality/tools/pr_quality_check.py
+++ b/skills/rocm-pr-quality/tools/pr_quality_check.py
@@ -4,15 +4,13 @@
 
 """Deterministic subset of the ROCm PR-quality MUST checks.
 
-One checker, two callers: the skill invokes it locally for fast feedback, and a future CI
-status check can run the exact same command. It covers only the *mechanical* checks --
+The skill invokes it locally for fast feedback. It covers only the *mechanical* checks --
 description completeness, work-tracking presence (M4), related-link presence/resolution (M5),
 a product-code-without-tests heuristic (M2), CI currency, and stale-base/adjacent-file overlap.
 Semantic judgments -- test substance, the mutation question, and M3 (never disable tests to
 green CI) -- stay with the agent and the human reviewer; they are intentionally NOT enforced here.
 
-Advisory by default (always exits 0). Pass --enforce to exit non-zero on blockers, matching the
-staged rollout: audit -> advisory -> enforced MUST.
+Advisory by default (always exits 0). Pass --enforce to exit non-zero on blockers.
 
 Usage:
     python pr_quality_check.py --pr <number|url> [--repo owner/name] [--profile hipblaslt]

--- a/skills/therock-pr-quality/SKILL.md
+++ b/skills/therock-pr-quality/SKILL.md
@@ -37,21 +37,19 @@ Changes outside these areas follow the base bar only.
 
 ______________________________________________________________________
 
-## Defer to canonical TheRock guides (do not restate)
+## Canonical TheRock references
 
-These are canonical and in-repo; **link and defer** rather than duplicating. Assume their
-mechanically-enforced parts (pre-commit, lint) are already enforced and do not re-litigate style:
+Consult and cite these when reviewing build-repo PRs:
 
 - Build system overview: `docs/development/build_system.md`.
 - Style guides: `docs/development/style_guides/` —
-  [python](../../docs/development/style_guides/python_style_guide.md) (fail-fast / explicit),
+  [python](../../docs/development/style_guides/python_style_guide.md),
   [cmake](../../docs/development/style_guides/cmake_style_guide.md),
   [bash](../../docs/development/style_guides/bash_style_guide.md),
   [github_actions](../../docs/development/style_guides/github_actions_style_guide.md).
 - Formatting: `.pre-commit-config.yaml` (run `pre-commit run --all-files`).
 
-When a finding is "this violates the CMake/Bash/Actions/Python style guide," cite the specific guide
-section instead of re-explaining the rule.
+Cite the specific guide section for a style finding.
 
 ______________________________________________________________________
 
@@ -84,8 +82,8 @@ On top of the base classes, tag TheRock PRs with:
 - Distinguish superbuild-level changes (root `CMakeLists.txt`, `cmake/`, `THEROCK_ENABLE_*`) from
   sub-project CMake; a change in the wrong layer is a maintainability finding.
 - A new `THEROCK_ENABLE_*` (or similar) option needs a sane default, a help string, and a note on
-  how it interacts with existing components. Defer the conventions to
-  `docs/development/build_system.md` and the CMake style guide rather than restating them.
+  how it interacts with existing components. See `docs/development/build_system.md` and the CMake
+  style guide for conventions.
 - Enabling a component by default (or changing a default) is a behavior change → treat as the base
   `heuristic/default-selection` class (safe default + flag/tracker).
 

--- a/skills/therock-pr-quality/SKILL.md
+++ b/skills/therock-pr-quality/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: therock-pr-quality
+description: "TheRock build-repo supplements to the ROCm PR quality base skill. Use for TheRock PR author, review, or pre-merge gating where the change touches the superbuild, submodules/patches, artifact descriptors, or reusable CI workflows. Adds and tightens base rules; never relaxes a base MUST."
+argument-hint: "[author | review | pre-merge] [PR URL | branch:<name> | local]"
+extends: rocm-pr-quality
+allowed-tools: Bash, Read, Grep, Glob, Task, WebFetch
+---
+
+# TheRock PR Quality (overlay)
+
+## Dependency (mandatory — do this first)
+
+Read and apply the `rocm-pr-quality` base skill before anything below. It lives in this same repo at
+`skills/rocm-pr-quality/` (`SKILL.md` + `reference.md`). The supplements here only **ADD** rules or
+**TIGHTEN** thresholds; they never relax a base MUST-rule. On any conflict, the base MUST-rule wins.
+
+This overlay is for the *build-repo* concerns that the library overlays (e.g. `hipblaslt-pr-quality`)
+do not cover: the superbuild itself, submodules and patches, artifact descriptors, and the reusable
+CI workflows that every downstream build depends on.
+
+______________________________________________________________________
+
+## Scope
+
+Apply this overlay (in addition to the base) when a PR touches any of:
+
+- The superbuild / build system: root `CMakeLists.txt`, `cmake/`, `THEROCK_ENABLE_*` options,
+  component `CMakeLists.txt` under `math-libs/`, `ml-libs/`, `comm-libs/`, `compiler/`, etc.
+- Submodules and patches: `.gitmodules` (root and nested), `third-party/`, patch sets applied to
+  subprojects.
+- Artifact descriptors: `artifact-*.toml`, `BUILD_TOPOLOGY.toml`, and the artifact
+  fetch/install tooling (`build_tools/**`, `install_rocm_from_artifacts.py`).
+- Reusable CI: `.github/workflows/**` (especially reusable `workflow_call` workflows and their
+  callers) and `build_tools/github_actions/**`.
+
+Changes outside these areas follow the base bar only.
+
+______________________________________________________________________
+
+## Defer to canonical TheRock guides (do not restate)
+
+These are canonical and in-repo; **link and defer** rather than duplicating. Assume their
+mechanically-enforced parts (pre-commit, lint) are already enforced and do not re-litigate style:
+
+- Build system overview: `docs/development/build_system.md`.
+- Style guides: `docs/development/style_guides/` —
+  [python](../../docs/development/style_guides/python_style_guide.md) (fail-fast / explicit),
+  [cmake](../../docs/development/style_guides/cmake_style_guide.md),
+  [bash](../../docs/development/style_guides/bash_style_guide.md),
+  [github_actions](../../docs/development/style_guides/github_actions_style_guide.md).
+- Formatting: `.pre-commit-config.yaml` (run `pre-commit run --all-files`).
+
+When a finding is "this violates the CMake/Bash/Actions/Python style guide," cite the specific guide
+section instead of re-explaining the rule.
+
+______________________________________________________________________
+
+## Supplements
+
+### Adds — change classes (bind to TheRock paths)
+
+On top of the base classes, tag TheRock PRs with:
+
+- `submodule-bump` — advancing a submodule pointer (and/or its patch set).
+- `superbuild-cmake` — changes to superbuild options / component wiring.
+- `artifact-descriptor` — changes to `artifact-*.toml` / `BUILD_TOPOLOGY.toml`.
+- `reusable-ci` — changes to a reusable workflow or its callers.
+- `dependency-add` — adding a new third-party dependency or subproject.
+
+### Adds — submodules & patches review checks
+
+- A submodule pointer bump is a real change: the PR must say **what** moved and **why** (the target
+  commit/range and its purpose), and link the upstream PR/commit. An unexplained pointer move is an
+  M5 gap.
+- Pointer bumps and patch-set edits must be **intentional and isolated** — flag an incidental
+  pointer move bundled into an unrelated PR (the "undeclared submodule drift" smell).
+- Patches under a subproject must still apply cleanly against the new pointer; a patch that no longer
+  applies (or is now upstreamed and redundant) is `BLOCKING`.
+- New/changed patches need a one-line rationale and, where it exists, a link to the upstreaming
+  effort so the patch can later be dropped.
+
+### Adds — superbuild vs sub-project CMake
+
+- Distinguish superbuild-level changes (root `CMakeLists.txt`, `cmake/`, `THEROCK_ENABLE_*`) from
+  sub-project CMake; a change in the wrong layer is a maintainability finding.
+- A new `THEROCK_ENABLE_*` (or similar) option needs a sane default, a help string, and a note on
+  how it interacts with existing components. Defer the conventions to
+  `docs/development/build_system.md` and the CMake style guide rather than restating them.
+- Enabling a component by default (or changing a default) is a behavior change → treat as the base
+  `heuristic/default-selection` class (safe default + flag/tracker).
+
+### Adds — artifact descriptor checks
+
+- No **duplicate component ownership**: a given component/file should be claimed by exactly one
+  `artifact-*.toml`. Flag two descriptors claiming the same thing.
+- TOML components must match what the build actually provides — the components listed line up with
+  the `therock_provide_artifact()` (or equivalent) calls that produce them.
+- **Stale-descriptor-after-split**: when a component is split/moved, the old descriptor must be
+  updated, not left pointing at the pre-split layout.
+- `BUILD_TOPOLOGY.toml` stays consistent with the descriptors and component graph (no orphaned or
+  dangling entries).
+- Changes to artifact fetch/install flags (`install_rocm_from_artifacts.py` and friends) keep the
+  documented flags and defaults in sync.
+
+### Adds — reusable CI workflow wiring
+
+- When a reusable (`workflow_call`) workflow's interface changes, **all callers** are updated in the
+  same PR; a caller left on the old interface is `BLOCKING`.
+- Reusable-workflow inputs are read via `inputs.*`, not `github.event.inputs.*` (that only exists for
+  `workflow_dispatch`); flag the mismatch.
+- `runs-on` for self-hosted/specialized runners is pinned to the intended label set, not a generic
+  default that will mis-route the job.
+- Multi-checkout wiring (TheRock + a submodule/sibling repo) is correct: paths, fetch depth, and
+  submodule flags are set for what the job actually needs.
+- No complex inline `bash` embedded in YAML — non-trivial logic belongs in a script under
+  `build_tools/` (per the GitHub Actions style guide), where it is testable and lintable.
+- Any script a workflow calls has its runtime dependencies declared/available on the runner.
+
+### Adds — dependency / subproject additions
+
+A `dependency-add` PR must state: the **build-time and binary-size** impact (with a before/after
+metric where feasible), the **license** and its compatibility, and the **maintenance owner**. A new
+dependency with none of these is `IMPORTANT` at minimum, `BLOCKING` if it lands on a default/shipping
+path.
+
+### Tightens — stale-base on high-coupling build files
+
+Make the base pre-merge stale-base check concrete for TheRock. High-coupling files:
+root `CMakeLists.txt`, `cmake/**`, `.gitmodules`, `artifact-*.toml`, `BUILD_TOPOLOGY.toml`, and
+reusable workflows under `.github/workflows/`. Overlap with the base branch on any of these since the
+PR diverged → **mandatory** rebase + re-run (base default is strong-recommend), because these break
+combinations that neither PR's own CI can see.
+
+______________________________________________________________________
+
+## What the overlay cannot do
+
+Drop the regression/test obligations (M1/M2), allow disabling tests to green CI (M3), or skip work
+tracking/linking (M4/M5). Those are base MUSTs; this overlay can only make them stricter or bind them
+to TheRock build paths.

--- a/skills/therock-pr-quality/SKILL.md
+++ b/skills/therock-pr-quality/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: therock-pr-quality
-description: "TheRock build-repo supplements to the ROCm PR quality base skill. Use for TheRock PR author, review, or pre-merge gating where the change touches the superbuild, submodules/patches, artifact descriptors, or reusable CI workflows. Adds and tightens base rules; never relaxes a base MUST."
-argument-hint: "[author | review | pre-merge] [PR URL | branch:<name> | local]"
+description: TheRock build-repo supplements to the ROCm PR quality base skill. Use for TheRock PR author, review, or pre-merge gating where the change touches the superbuild, submodules/patches, artifact descriptors, or reusable CI workflows. Adds and tightens base rules; never relaxes a base MUST.
+argument-hint: '[author | review | pre-merge] [PR URL | branch:<name> | local]'
 extends: rocm-pr-quality
 allowed-tools: Bash, Read, Grep, Glob, Task, WebFetch
 ---


### PR DESCRIPTION
## Summary

Adds composable, ROCm-wide **PR Quality** agent skills under `skills/`. They give agents (Cursor, Claude Code) a consistent rubric for three jobs:

1. **Author assist** — help draft a complete, well-tested PR.
2. **Review assist** — talk through an open PR against the rubric.
3. **Pre-merge gate** — mechanical + judgment checks before merge.

The base is **library-agnostic**; repos add thin overlays that *tighten* (never weaken) the rules. The skills are repo-resident — anyone in a TheRock checkout already has them, auto-discovered via `.cursor/rules/rocm-pr-quality.mdc` and the `CLAUDE.md` pointer.

## What's included

- `skills/rocm-pr-quality/SKILL.md` — base skill: three actions, operating principles, MUST set (M1–M5), waiver semantics, and a shared review vocabulary (finding tiers `BLOCKING`/`IMPORTANT`/`SUGGESTION`/`FUTURE WORK`; overall `APPROVED`/`CHANGES REQUESTED`/`REJECTED`).
- `skills/rocm-pr-quality/reference.md` — rubric tables, PR description template, test-level mapping, waiver codes, a PR-hygiene checklist, self-evident-change exemptions, and an agent/AI-change anti-pattern catalog.
- `skills/rocm-pr-quality/tools/pr_quality_check.py` — deterministic checker for the mechanical subset (description completeness, work-tracking, related links, test heuristics, CI currency, stale-base overlap). Works against a local clone or via the GitHub API.
- `skills/therock-pr-quality/SKILL.md` — **TheRock overlay** for build-repo PRs (superbuild/CMake, submodules & patches, `artifact-*.toml`/`BUILD_TOPOLOGY.toml`, reusable CI workflows). Extends the base and defers to `docs/development/style_guides/`.
- `.cursor/rules/rocm-pr-quality.mdc` + `CLAUDE.md` — discovery hooks listing the base and the TheRock overlay.

## Attribution

The shared finding/assessment vocabulary, the agent-change anti-patterns, the PR-hygiene checklist, and the self-evident-change exemptions draw on Scott Todd's ROCm code-review guidelines (`ScottTodd/rocm-workspace`), toward one shared review vocabulary across ROCm. The base defers to canonical in-repo style guides and lint/pre-commit config rather than duplicating them.

## Safety

The skills are **advisory**. They never post comments or write to GitHub/Jira without explicit human approval.

## Test plan

- [ ] `pre-commit run --files ...` passes on all added/changed files
- [ ] `python skills/rocm-pr-quality/tools/pr_quality_check.py --help` runs
- [ ] Smoke-tested checker against a real PR (e.g. #7796)
