### PR TITLE
Disable pytorch sccache for PRs from forks

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -216,7 +216,7 @@ jobs:
             --rocm-version ${{ inputs.rocm_version }}
 
       - name: Configure AWS Credentials for sccache
-        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}
+        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'ROCm') }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-region: us-east-1

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -161,7 +161,7 @@ jobs:
             --rocm-version ${{ inputs.rocm_version }}
 
       - name: Configure AWS Credentials for sccache
-        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}
+        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'ROCm') }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-region: us-east-1

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -252,7 +252,7 @@ jobs:
             --rocm-version ${{ inputs.rocm_version }}
 
       - name: Configure AWS Credentials for sccache
-        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}
+        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'ROCm') }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-region: us-east-1

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -178,7 +178,7 @@ jobs:
             --rocm-version ${{ inputs.rocm_version }}
 
       - name: Configure AWS Credentials for sccache
-        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}
+        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'ROCm') }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-region: us-east-1

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -211,7 +211,7 @@ jobs:
             --rocm-version ${{ inputs.rocm_version }}
 
       - name: Configure AWS Credentials for sccache
-        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}
+        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'ROCm') }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-region: us-east-1

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -227,7 +227,7 @@ jobs:
             --rocm-version ${{ inputs.rocm_version }}
 
       - name: Configure AWS Credentials for sccache
-        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}
+        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'ROCm') }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-region: us-east-1

--- a/docs/development/s3_buckets.md
+++ b/docs/development/s3_buckets.md
@@ -128,6 +128,51 @@ ID; the corresponding role ARNs are
 for `therock-{dev,nightly}` also covers `repo:ROCm/rockrel:*` so reusable
 workflow invocations from `rockrel` can assume the role.
 
+Workflow steps that assume these roles must skip runs from contexts that are not
+authorized for the PyTorch sccache roles. Typically this means using a pattern
+like:
+
+```yaml
+- name: Configure AWS Credentials for sccache
+  if: >-
+    ${{
+      inputs.cache_type == 'sccache' &&
+      github.repository_owner == 'ROCm' &&
+      (
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.owner.login == 'ROCm'
+      )
+    }}
+  uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+  with:
+    aws-region: us-east-1
+    role-to-assume: arn:aws:iam::324352301041:role/therock-${{ inputs.release_type }}
+```
+
+TODO: this should be moved into a script like
+[`build_tools/_therock_utils/s3_buckets.py`](build_tools/_therock_utils/s3_buckets.py),
+as has already been done for artifact access (see above).
+
+> [!WARNING]
+> Just checking `pull_request.head.repo.fork` would exclude ROCm organization
+> repositories which are themselves forks of upstream repositories, like
+> https://github.com/ROCm/llvm-project/ (fork of
+> https://github.com/llvm/llvm-project).
+>
+> ```yaml
+> - name: Configure AWS Credentials for sccache
+>   # Don't use this code pattern! Use the previous pattern instead.
+>   if: >-
+>     ${{
+>       inputs.cache_type == 'sccache' &&
+>       github.repository_owner == 'ROCm' &&
+>       (
+>         github.event_name != 'pull_request' ||
+>         !github.event.pull_request.head.repo.fork
+>       )
+>     }}
+> ```
+
 | Bucket                               | Contents                   | IAM role             |
 | ------------------------------------ | -------------------------- | -------------------- |
 | `therock-pytorch-sccache-ci`         | PyTorch CI sccache         | `therock-ci`         |


### PR DESCRIPTION
## Motivation

Tentative fix for https://github.com/ROCm/TheRock/issues/5737, to unblock https://github.com/ROCm/TheRock/pull/5729.

Workflow runs from fork PRs outside of the ROCm organization are not authorized to assume the `therock-ci` AWS IAM role, so PyTorch builds are failing on fork PRs with errors like
```
It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission? If you are not trying to authenticate with OIDC and the action is working successfully, you can ignore this message.
Assuming role with user credentials
Retry AssumeRole: attempt 1 of 12 failed: Could not assume role with user credentials: User: arn:aws:iam::692859939525:user/therock-external-upload is not authorized to perform: sts:TagSession on resource: arn:aws:iam::324352301041:role/therock-ci. Retrying after 43ms.
Assuming role with user credentials
Retry AssumeRole: attempt 2 of 12 failed: Could not assume role with user credentials: User: arn:aws:iam::692859939525:user/therock-external-upload is not authorized to perform: sts:TagSession on resource: arn:aws:iam::324352301041:role/therock-ci. Retrying after 79ms.
Assuming role with user credentials
Retry AssumeRole: attempt 3 of 12 failed: Could not assume role with user credentials: User: arn:aws:iam::692859939525:user/therock-external-upload is not authorized to perform: sts:TagSession on resource: arn:aws:iam::324352301041:role/therock-ci. Retrying after 110ms.
Assuming role with user credentials
Retry AssumeRole: attempt 4 of 12 failed: Could not assume role with user credentials: User: arn:aws:iam::692859939525:user/therock-external-upload is not authorized to perform: sts:TagSession on resource: arn:aws:iam::324352301041:role/therock-ci. Retrying after 10ms.
Assuming role with user credentials
Retry AssumeRole: attempt 5 of 12 failed: Could not assume role with user credentials: User: arn:aws:iam::692859939525:user/therock-external-upload is not authorized to perform: sts:TagSession on resource: arn:aws:iam::324352301041:role/therock-ci. Retrying after 270ms.
```

## Technical Details

I guess `github.repository_owner == 'ROCm'` is true for PRs from forks. I think `github.event.pull_request.head.repo.owner.login == 'ROCm'` should be a more precise check.

We should add base credentials to these runners that can access some cache like how artifacts can upload to `therock-ci-artifacts-external` (see https://github.com/ROCm/TheRock/blob/main/docs/development/s3_buckets.md#ci-buckets).

## Test Plan

Watch to see if workflow runs on this PR successfully skip sccache setup and build pytorch.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
