### PR TITLE
[ci] Clear stale  git submodule trees in Windows runner cleanup

### DIFF
--- a/build_tools/github_actions/cleanup_processes.ps1
+++ b/build_tools/github_actions/cleanup_processes.ps1
@@ -180,6 +180,27 @@ if ($currentUser -match "NT AUTHORITY") {
     echo "[*] Not Running as a Windows Service (NT AUTHORITY\*) - skipping system environment cleanup"
 }
 
+#### Cleanup stale git submodule working trees ####
+# These runners are non-ephemeral and shared across super-repos whose checkouts
+# pin DIFFERENT submodule commits. `actions/checkout` runs
+# `git submodule foreach --recursive` during its auth setup/teardown, descending
+# into leftover submodule working trees from a prior job.
+# `git reset --hard` does not clear nested submodule working trees, so a newer
+# nested submodule left on disk can remain under an older superproject whose
+# .gitmodules lacks that URL. The recursive foreach then aborts with
+# `fatal: No url found for submodule path ...` (exit 128) and the job dies
+# before its own checkout begins. Deiniting empties those working trees (deinit
+# is non-recursive, so it won't trip on the missing URL itself) leaving nothing
+# stale for the recursive foreach to enter.
+$workspaceRepo = $env:GITHUB_WORKSPACE
+if ($workspaceRepo -and (Test-Path (Join-Path $workspaceRepo ".git"))) {
+    echo "[*] Deiniting stale git submodules in workspace: $workspaceRepo"
+    git -C $workspaceRepo submodule deinit -f --all 2>&1 | ForEach-Object { echo "      $_" }
+    echo "[*] >> Submodule deinit finished (git exit code: $LASTEXITCODE)"
+} else {
+    echo "[*] No git repo at workspace root, skipping submodule deinit"
+}
+
 #### Cleanup Processes ####
 echo "[*] Cleaning up processes..."
 

--- a/build_tools/github_actions/cleanup_processes.ps1
+++ b/build_tools/github_actions/cleanup_processes.ps1
@@ -189,16 +189,38 @@ if ($currentUser -match "NT AUTHORITY") {
 # nested submodule left on disk can remain under an older superproject whose
 # .gitmodules lacks that URL. The recursive foreach then aborts with
 # `fatal: No url found for submodule path ...` (exit 128) and the job dies
-# before its own checkout begins. Deiniting empties those working trees (deinit
-# is non-recursive, so it won't trip on the missing URL itself) leaving nothing
-# stale for the recursive foreach to enter.
+# before its own checkout begins.
+#
+# We cannot rely on `git submodule deinit`: a prior job can leave the workspace
+# partially corrupted (e.g. submodule.<name>.url registered in .git/config while
+# .git/modules/<name> is missing), which makes deinit abort with
+# `could not lock config file .git/modules/<name>/config`. Instead we physically
+# empty the top-level submodule working trees listed in .gitmodules. The
+# recursive foreach only descends into populated submodule dirs, so emptying them
+# leaves nothing for it to enter, independent of .git/modules health. We keep
+# .git/modules objects (repopulation stays a local checkout, no network re-clone)
+# and never touch ccache/deps (those are not submodule paths).
 $workspaceRepo = $env:GITHUB_WORKSPACE
-if ($workspaceRepo -and (Test-Path (Join-Path $workspaceRepo ".git"))) {
-    echo "[*] Deiniting stale git submodules in workspace: $workspaceRepo"
-    git -C $workspaceRepo submodule deinit -f --all 2>&1 | ForEach-Object { echo "      $_" }
-    echo "[*] >> Submodule deinit finished (git exit code: $LASTEXITCODE)"
+$gitmodulesPath = if ($workspaceRepo) { Join-Path $workspaceRepo ".gitmodules" } else { $null }
+if ($workspaceRepo -and (Test-Path (Join-Path $workspaceRepo ".git")) -and $gitmodulesPath -and (Test-Path $gitmodulesPath)) {
+    echo "[*] Clearing stale git submodule working trees in workspace: $workspaceRepo"
+    # Parse submodule paths directly from .gitmodules (no git state required).
+    $submodulePaths = Select-String -Path $gitmodulesPath -Pattern '^\s*path\s*=\s*(.+)$' |
+        ForEach-Object { $_.Matches[0].Groups[1].Value.Trim() }
+    foreach ($subPath in $submodulePaths) {
+        $fullSubPath = Join-Path $workspaceRepo $subPath
+        if (Test-Path $fullSubPath) {
+            echo "      removing $subPath"
+            try {
+                Remove-Item -Recurse -Force -LiteralPath $fullSubPath -ErrorAction Stop
+            } catch {
+                echo "      WARNING: could not fully remove ${subPath}: $_"
+            }
+        }
+    }
+    echo "[*] >> Submodule working-tree cleanup finished"
 } else {
-    echo "[*] No git repo at workspace root, skipping submodule deinit"
+    echo "[*] No git repo / .gitmodules at workspace root, skipping submodule cleanup"
 }
 
 #### Cleanup Processes ####

--- a/build_tools/github_actions/cleanup_processes.ps1
+++ b/build_tools/github_actions/cleanup_processes.ps1
@@ -204,9 +204,11 @@ $workspaceRepo = $env:GITHUB_WORKSPACE
 $gitmodulesPath = if ($workspaceRepo) { Join-Path $workspaceRepo ".gitmodules" } else { $null }
 if ($workspaceRepo -and (Test-Path (Join-Path $workspaceRepo ".git")) -and $gitmodulesPath -and (Test-Path $gitmodulesPath)) {
     echo "[*] Clearing stale git submodule working trees in workspace: $workspaceRepo"
-    # Parse submodule paths directly from .gitmodules (no git state required).
-    $submodulePaths = Select-String -Path $gitmodulesPath -Pattern '^\s*path\s*=\s*(.+)$' |
-        ForEach-Object { $_.Matches[0].Groups[1].Value.Trim() }
+    # Read submodule paths via `git config -f`, which parses .gitmodules as a
+    # standalone config file without touching repo state (no index, no
+    # .git/modules), so it cannot trip on the corruption we are cleaning up.
+    $submodulePaths = git config -f $gitmodulesPath --get-regexp '^submodule\..*\.path$' |
+        ForEach-Object { ($_ -split '\s+', 2)[1].Trim() }
     foreach ($subPath in $submodulePaths) {
         $fullSubPath = Join-Path $workspaceRepo $subPath
         if (Test-Path $fullSubPath) {


### PR DESCRIPTION
Non-ephemeral Windows GPU runners are shared across super-repos whose checkouts pin different submodule commits. `git reset --hard` (run by `actions/checkout`) does not clear nested submodule working trees, so a newer nested submodule left on disk by a prior job can remain under an older superproject whose `.gitmodules` lacks its URL.

`actions/checkout` then runs `git submodule foreach --recursive` during its auth setup/teardown, descends into that stale tree, and aborts.

To fix this:
Add a step to the shared pre-job cleanup script that empties the top-level submodule working trees left by the prior job. Submodule paths are read with `git config -f .gitmodules` and the dirs removed with `Remove-Item`. `git submodule deinit` is unusable here: a prior job can leave the workspace partially corrupted (submodule URL in `.git/config` but `.git/modules/<name>` missing), making deinit abort with `could not lock config file ...`. Physical removal is independent of `.git/modules` health. Runs before `actions/checkout`.

Cache-safe: keeps `.git/modules` objects and touches no untracked or ignored files, so ccache and downloaded deps are preserved.

Fixes #5742
