### PR TITLE
Revert "Make CI release type explicit and limit workflow_dispatch inputs to [ci, dev]"

### DIFF
--- a/.github/actions/configure_aws_artifacts_credentials/action.yml
+++ b/.github/actions/configure_aws_artifacts_credentials/action.yml
@@ -12,8 +12,8 @@ description: >-
 
 inputs:
   release_type:
-    description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
-    default: ci
+    description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
+    default: ""
 
 runs:
   using: "composite"

--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -24,8 +24,8 @@ inputs:
   FETCH_ARTIFACT_ARGS:
     description: (string) Extra arguments to install_rocm_from_artifacts.py (e.g. `--blas --tests`)
   RELEASE_TYPE:
-    description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
-    default: ci
+    description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
+    default: ""
 
 runs:
   using: "composite"

--- a/.github/workflows/build_linux_jax_wheels.yml
+++ b/.github/workflows/build_linux_jax_wheels.yml
@@ -78,10 +78,12 @@ on:
         type: string
         default: "3.12"
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
         type: choice
+        description: Type of release to create. All developer-triggered jobs should use "dev"!
         options:
           - dev
+          - nightly
+          - prerelease
         default: dev
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family

--- a/.github/workflows/build_native_linux_packages.yml
+++ b/.github/workflows/build_native_linux_packages.yml
@@ -66,11 +66,9 @@ on:
         type: string
         required: false
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev".'
-        type: choice
-        options:
-          - dev
-        default: dev
+        description: The type of release to build ("dev", "nightly", or "prerelease"). All developer-triggered jobs should use "dev"!
+        type: string
+        default: "dev"
       skip_package_upload:
         description: Skip uploading packages to S3. Set to true when called from test workflows.
         type: boolean
@@ -100,7 +98,7 @@ jobs:
       OUTPUT_DIR: ${{ github.workspace }}/output
       ARTIFACTS_DIR: ${{ github.workspace }}/output/artifacts
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages
-      RELEASE_TYPE: ${{ inputs.release_type }}
+      RELEASE_TYPE: ${{ inputs.release_type || '' }}
       S3_BUCKET_NATIVE: "therock-${{ inputs.release_type }}-packages"
     steps:
       - name: "Checking out repository"

--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -37,12 +37,9 @@ on:
         description: "package_version to set on packages, e.g. '7.13.0.dev0+dbd7369489260265fc6ddfc9d0de1262a95fe974'"
         type: string
       release_type:
-        description: 'Release type: "ci" or "dev"'
-        type: choice
-        options:
-          - ci
-          - dev
-        default: ci
+        description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
+        type: string
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
@@ -76,7 +73,7 @@ on:
         type: string
       release_type:
         type: string
-        default: ci
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels.yml
@@ -75,11 +75,9 @@ on:
         type: string
         default: "3.12"
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
-        type: choice
-        options:
-          - dev
-        default: dev
+        description: The type of release to build ("dev", "nightly", or "prerelease"). All developer-triggered jobs should use "dev"!
+        type: string
+        default: "dev"
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family
         type: string

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -56,6 +56,13 @@ on:
         description: "'true' if this is a kpack-split flat build."
         type: string
         default: "false"
+      release_type:
+        description: >-
+          Release type used to pick the AWS role for S3 uploads
+          (forwarded to configure_aws_artifacts_credentials). Empty for
+          CI runs that should skip the upload.
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       artifact_group:
@@ -101,7 +108,6 @@ jobs:
     env:
       AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
-      RELEASE_TYPE: ci
       optional_build_prod_arguments: ""
       SCCACHE_BUCKET: therock-pytorch-sccache-ci
       SCCACHE_REGION: us-east-1
@@ -280,7 +286,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure_aws_artifacts_credentials
         with:
-          release_type: ci
+          release_type: ${{ inputs.release_type }}
 
       # Appends to the same therock-ci-artifacts/<run>-linux/python/ prefix
       # that the ROCm python job already populated — one find-links URL

--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -37,12 +37,9 @@ on:
         description: "package_version to set on packages, e.g. '7.13.0.dev0+dbd7369489260265fc6ddfc9d0de1262a95fe974'"
         type: string
       release_type:
-        description: 'Release type: "ci" or "dev"'
-        type: choice
-        options:
-          - ci
-          - dev
-        default: ci
+        description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
+        type: string
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
@@ -76,7 +73,7 @@ on:
         type: string
       release_type:
         type: string
-        default: ci
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/build_windows_pytorch_wheels.yml
+++ b/.github/workflows/build_windows_pytorch_wheels.yml
@@ -75,11 +75,9 @@ on:
         type: string
         default: "3.12"
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
-        type: choice
-        options:
-          - dev
-        default: dev
+        description: The type of release to build ("dev", "nightly", or "prerelease"). All developer-triggered jobs should use "dev"!
+        type: string
+        default: "dev"
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family
         type: string

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -55,6 +55,13 @@ on:
         description: "'true' if this is a kpack-split flat build."
         type: string
         default: "false"
+      release_type:
+        description: >-
+          Release type used to pick the AWS role for S3 uploads
+          (forwarded to configure_aws_artifacts_credentials). Empty for
+          CI runs that should skip the upload.
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       artifact_group:
@@ -98,7 +105,6 @@ jobs:
       CHECKOUT_ROOT: B:/src
       # Note the \ here instead of /. This should be used from 'cmd' not 'bash'!
       PACKAGE_DIST_DIR: ${{ github.workspace }}\output\packages\dist
-      RELEASE_TYPE: ci
       optional_build_prod_arguments: ""
       SCCACHE_BUCKET: therock-pytorch-sccache-ci
       SCCACHE_REGION: us-east-1
@@ -325,7 +331,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure_aws_artifacts_credentials
         with:
-          release_type: ci
+          release_type: ${{ inputs.release_type }}
 
       # Appends to the same therock-ci-artifacts/<run>-windows/python/ prefix
       # that the ROCm python job already populated — one find-links URL

--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -26,10 +26,10 @@ on:
         type: string
         default: ""
       release_type:
-        description: "Release type: 'ci', 'dev', 'nightly', or 'prerelease'"
+        description: "The type of release to build ('dev', 'nightly', or 'release'). Empty string for CI builds."
         required: false
         type: string
-        default: ci
+        default: ""
       repository:
         description: "Repository to checkout. Otherwise, defaults to `github.repository`"
         type: string

--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -46,9 +46,9 @@ on:
         default: "azure-linux-scale-rocm"
         description: "Build runner label (selected by configure script with weighted distribution)"
       release_type:
-        description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
+        description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
-        default: ci
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -50,9 +50,9 @@ on:
         default: ""
         description: "CMake preset name for this build variant (optional)"
       release_type:
-        description: 'Release type; controls artifact bucket and IAM role'
+        description: 'Release type: "" for CI, or "dev", "nightly", "prerelease". Controls artifact bucket and IAM role.'
         type: string
-        default: ci
+        default: ""
       build_runs_on:
         description: "Build runner label (selected by configure script with weighted distribution)"
         type: string

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -54,7 +54,7 @@ on:
         type: string
         required: true
       release_type:
-        description: 'Release type; selects the S3 bucket.'
+        description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
         type: string
         required: true
       repository:
@@ -102,11 +102,9 @@ on:
         type: string
         required: true
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev".'
-        type: choice
-        options:
-          - dev
-        default: dev
+        description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
+        type: string
+        required: true
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/multi_arch_build_tarballs.yml
+++ b/.github/workflows/multi_arch_build_tarballs.yml
@@ -28,12 +28,9 @@ on:
         description: "ROCm package version string (e.g. '7.13.0.dev0+abc123')"
         type: string
       release_type:
-        description: 'Release type: "ci" or "dev"'
-        type: choice
-        options:
-          - ci
-          - dev
-        default: ci
+        description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
+        type: string
+        default: ""
   workflow_call:
     inputs:
       artifact_run_id:
@@ -53,7 +50,7 @@ on:
         required: true
       release_type:
         type: string
-        default: ci
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/multi_arch_build_windows.yml
+++ b/.github/workflows/multi_arch_build_windows.yml
@@ -46,9 +46,9 @@ on:
       rocm_package_version:
         type: string
       release_type:
-        description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
+        description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
-        default: ci
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -47,9 +47,9 @@ on:
         required: true
         description: "ROCm package version string"
       release_type:
-        description: 'Release type; controls artifact bucket and IAM role'
+        description: 'Release type: "" for CI, or "dev", "nightly", "prerelease". Controls artifact bucket and IAM role.'
         type: string
-        default: ci
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -56,7 +56,7 @@ on:
         type: string
         required: true
       release_type:
-        description: 'Release type; selects the S3 bucket.'
+        description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
         type: string
         required: true
       repository:
@@ -104,11 +104,9 @@ on:
         type: string
         required: true
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev".'
-        type: choice
-        options:
-          - dev
-        default: dev
+        description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
+        type: string
+        required: true
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+++ b/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
@@ -32,9 +32,9 @@ on:
         default: ""
         description: "CMake preset name for this build variant (optional)"
       release_type:
-        description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
+        description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
-        default: ci
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -27,9 +27,9 @@ on:
       test_type:
         type: string
       release_type:
-        description: 'Release type: "ci", "dev", "nightly", or "prerelease"'
+        description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
-        default: ci
+        default: ""
       external_repo_config:
         description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package, fetch_sources_args)"
         type: string
@@ -284,6 +284,7 @@ jobs:
       kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
       rocm_package_find_links_url: ${{ needs.build_python_packages.outputs.package_find_links_url }}
       rocm_version: ${{ inputs.rocm_package_version }}
+      release_type: ${{ inputs.release_type }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -21,9 +21,9 @@ on:
       test_type:
         type: string
       release_type:
-        description: 'Release type: "ci", "dev", "nightly", or "prerelease".'
+        description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
-        default: ci
+        default: ""
       external_repo_config:
         description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package)"
         type: string
@@ -207,6 +207,7 @@ jobs:
       kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
       rocm_package_find_links_url: ${{ needs.build_python_packages.outputs.package_find_links_url }}
       rocm_version: ${{ inputs.rocm_package_version }}
+      release_type: ${{ inputs.release_type }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -54,7 +54,7 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev".'
+        description: 'Release type. All developer-triggered jobs should use "dev"!'
         type: choice
         options:
           - dev

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -32,7 +32,7 @@ on:
         type: string
         default: "gfx94X-dcgpu"
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev".'
+        description: 'Release type. All developer-triggered jobs should use "dev"!'
         type: choice
         options:
           - dev

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -29,7 +29,7 @@ on:
         type: string
         required: true
       release_type:
-        description: 'Release type; selects the S3 bucket'
+        description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
         type: string
         required: true
       repository:
@@ -66,11 +66,9 @@ on:
         type: string
         required: true
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
-        type: choice
-        options:
-          - dev
-        default: dev
+        description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
+        type: string
+        required: true
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -29,7 +29,7 @@ on:
         type: string
         required: true
       release_type:
-        description: 'Release type; selects the S3 bucket'
+        description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
         type: string
         required: true
       repository:
@@ -66,11 +66,9 @@ on:
         type: string
         required: true
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
-        type: choice
-        options:
-          - dev
-        default: dev
+        description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
+        type: string
+        required: true
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/release_portable_linux_jax_wheels.yml
+++ b/.github/workflows/release_portable_linux_jax_wheels.yml
@@ -59,11 +59,9 @@ on:
           - gfx950-dcgpu
         default: gfx94X-dcgpu
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
-        type: choice
-        options:
-          - dev
-        default: dev
+        description: The type of release to build ("dev", "nightly", or "prerelease"). All developer-triggered jobs should use "dev"!
+        type: string
+        default: "dev"
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family
         type: string

--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -37,11 +37,9 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
-        type: choice
-        options:
-          - dev
-        default: dev
+        description: The type of release to build ("dev", "nightly", or "prerelease"). All developer-triggered jobs should use "dev"!
+        type: string
+        default: "dev"
       package_suffix:
         type: string
       s3_subdir:
@@ -67,14 +65,14 @@ on:
 permissions:
   contents: read
 
-run-name: Release portable Linux packages (${{ github.event_name == 'schedule' && 'nightly' || inputs.release_type }}, ${{ inputs.families || 'default' }})
+run-name: Release portable Linux packages (${{ inputs.release_type || 'nightly' }}, ${{ inputs.families || 'default' }})
 
 jobs:
   setup_metadata:
     if: ${{ github.repository_owner == 'ROCm' || github.event_name != 'schedule' }}
     runs-on: ubuntu-24.04
     env:
-      release_type: ${{ github.event_name == 'schedule' && 'nightly' || inputs.release_type }}
+      release_type: ${{ inputs.release_type || 'nightly' }}
     outputs:
       version: ${{ steps.rocm_package_version.outputs.rocm_package_version }}
       rpm_version: ${{ steps.rocm_package_version.outputs.rocm_rpm_package_version }}

--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -56,11 +56,9 @@ on:
           - gfx950-dcgpu
         default: gfx94X-dcgpu
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
-        type: choice
-        options:
-          - dev
-        default: dev
+        description: The type of release to build ("dev", "nightly", or "prerelease"). All developer-triggered jobs should use "dev"!
+        type: string
+        default: "dev"
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family
         type: string

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -40,11 +40,9 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
-        type: choice
-        options:
-          - dev
-        default: dev
+        description: The type of release to build ("dev", "nightly", or "prerelease"). All developer-triggered jobs should use "dev"!
+        type: string
+        default: "dev"
       package_suffix:
         type: string
       s3_subdir:
@@ -74,14 +72,14 @@ on:
 permissions:
   contents: read
 
-run-name: Release Windows packages (${{ github.event_name == 'schedule' && 'nightly' || inputs.release_type }}, ${{ inputs.families || 'default' }})
+run-name: Release Windows packages (${{ inputs.release_type || 'nightly' }}, ${{ inputs.families || 'default' }})
 
 jobs:
   setup_metadata:
     if: ${{ github.repository_owner == 'ROCm' || github.event_name != 'schedule' }}
     runs-on: ubuntu-24.04
     env:
-      release_type: ${{ github.event_name == 'schedule' && 'nightly' || inputs.release_type }}
+      release_type: ${{ inputs.release_type || 'nightly' }}
     outputs:
       version: ${{ steps.rocm_package_version.outputs.rocm_package_version }}
       release_type: ${{ env.release_type }}

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -56,11 +56,9 @@ on:
           - gfx950-dcgpu
         default: gfx1151
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
-        type: choice
-        options:
-          - dev
-        default: dev
+        description: The type of release to build ("dev", "nightly", or "prerelease"). All developer-triggered jobs should use "dev"!
+        type: string
+        default: "dev"
       s3_subdir:
         description: S3 subdirectory, not including the GPU-family
         type: string

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -11,10 +11,11 @@ on:
         default: "release"
       release_type:
         description: >-
-          Release type: "ci", "dev", "nightly", or "prerelease"; controls
-          artifact bucket selection, IAM role, and package versioning.
+          Release type: "" for CI builds, or "dev", "nightly", "prerelease"
+          for release builds. Controls artifact bucket selection, IAM role,
+          and package versioning.
         type: string
-        default: ci
+        default: ""
       prerelease_version:
         description: Prerelease version number such as '2'. This gets appended to the computed version after 'rc', like '7.10.0rc2'
         type: string
@@ -143,12 +144,12 @@ jobs:
       # Note: Other scripts treat "dev releases" and "CI builds" differently.
       # Here we set to a "dev" package version even for CI builds:
       #
-      # release_type | package version | version example
-      # ------------ | --------------- | ------------------
-      # ci           | dev             | 7.10.0.dev0+f689a8
-      # dev          | dev             | 7.10.0.dev0+f689a8
-      # nightly      | nightly         | 7.10.0a20251021
-      # prerelease   | prerelease      | 7.10.0rc2
+      # type of build                         | package version | version example
+      # ------------------------------------- | --------------- | ------------------
+      # ci ("" empty string for release_type) | dev             | 7.10.0.dev0+f689a8
+      # dev                                   | dev             | 7.10.0.dev0+f689a8
+      # nightly                               | nightly         | 7.10.0a20251021
+      # prerelease                            | prerelease      | 7.10.0rc2
       #
       # Other scripts upload "ci" and "dev release" packages to different
       # buckets, use different ccache namespaces, etc.
@@ -156,7 +157,7 @@ jobs:
         id: rocm_package_version
         run: |
           python ./build_tools/compute_rocm_package_version.py \
-            --release-type=${{ inputs.release_type }} \
+            --release-type=${{ inputs.release_type || 'dev' }} \
             --prerelease-version=${{ inputs.prerelease_version }} \
             --override-git-sha=${{ steps.checkout.outputs.commit }}
 

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -35,12 +35,9 @@ on:
         type: string
         default: 'false'
       release_type:
-        description: 'Release type: "ci" or "dev".'
-        type: choice
-        options:
-          - ci
-          - dev
-        default: ci
+        description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
+        type: string
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
@@ -79,7 +76,7 @@ on:
         default: 'false'
       release_type:
         type: string
-        default: ci
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
@@ -93,7 +90,7 @@ on:
 permissions:
   contents: read
 
-run-name: Test Artifacts (${{ inputs.amdgpu_families }}, ${{ inputs.release_type }}, ${{ inputs.test_type }}, ${{ inputs.test_runs_on }})
+run-name: Test Artifacts (${{ inputs.amdgpu_families }}, ${{ inputs.release_type || 'ci' }}, ${{ inputs.test_type }}, ${{ inputs.test_runs_on }})
 
 jobs:
   configure_test_matrix:

--- a/.github/workflows/test_artifacts_structure.yml
+++ b/.github/workflows/test_artifacts_structure.yml
@@ -26,12 +26,9 @@ on:
           - windows
         default: "linux"
       release_type:
-        description: 'Release type: "ci" or "dev"'
-        type: choice
-        options:
-          - ci
-          - dev
-        default: ci
+        description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
+        type: string
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
@@ -54,7 +51,7 @@ on:
         default: "linux"
       release_type:
         type: string
-        default: ci
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -24,7 +24,7 @@ on:
         type: string
       release_type:
         type: string
-        default: ci
+        default: ""
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -80,10 +80,9 @@ on:
           - gfx950-dcgpu
         default: gfx94X-dcgpu
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
-        type: choice
-        options:
-          - dev
+        description: The type of release ("nightly" or "dev")
+        required: true
+        type: string
         default: dev
       package_index_url:
         description: Base CloudFront URL for the Python package index

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -53,12 +53,14 @@ on:
         required: true
         type: string
       release_type:
-        description: 'Release type: "ci" or "dev"'
+        description: "Release line (ci, dev, nightly, or prerelease)"
         required: true
         type: choice
         options:
           - ci
           - dev
+          - nightly
+          - prerelease
       gpg_key_url:
         description: "GPG key URL for signed repos"
         type: string

--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -74,8 +74,6 @@ s3_bucket_configs = [
 
 _BUCKET_CONFIGS_BY_NAME = {c.name: c for c in s3_bucket_configs}
 
-_ALLOWED_ARTIFACT_RELEASE_TYPES = {"ci", "dev", "nightly", "prerelease"}
-
 _ALLOWED_RELEASE_TYPES = {"dev", "nightly", "prerelease"}
 
 _ALLOWED_RELEASE_BUCKET_TYPES = {"tarball", "python", "packages"}
@@ -89,26 +87,25 @@ def get_artifacts_bucket_config(
     """Look up the artifacts bucket config for a repository.
 
     Args:
-        release_type: "ci", "dev", "nightly", or "prerelease".
+        release_type: "" for CI builds, or "dev", "nightly", "prerelease".
         repository: GitHub repository (e.g. "ROCm/TheRock").
         is_pr_from_fork: Whether this is a PR from a fork.
 
     Raises:
         ValueError: If release_type is invalid.
     """
-    if release_type not in _ALLOWED_ARTIFACT_RELEASE_TYPES:
-        raise ValueError(
-            f"release_type={release_type!r} is invalid, "
-            f"expected one of {_ALLOWED_ARTIFACT_RELEASE_TYPES}"
-        )
-
-    if release_type == "ci":
+    if release_type:
+        if release_type not in _ALLOWED_RELEASE_TYPES:
+            raise ValueError(
+                f"release_type={release_type!r} is invalid, "
+                f"expected empty string or one of {_ALLOWED_RELEASE_TYPES}"
+            )
+        bucket_name = f"therock-{release_type}-artifacts"
+    else:
         if is_pr_from_fork or repository != "ROCm/TheRock":
             bucket_name = "therock-ci-artifacts-external"
         else:
             bucket_name = "therock-ci-artifacts"
-    else:
-        bucket_name = f"therock-{release_type}-artifacts"
     return _BUCKET_CONFIGS_BY_NAME[bucket_name]
 
 
@@ -185,7 +182,7 @@ def get_artifacts_bucket_config_for_workflow_run(
     Args:
         github_repository: GitHub repository (e.g. "ROCm/TheRock").
         release_type: Release type override. If None, reads RELEASE_TYPE
-            from the environment (default: "ci").
+            from the environment (default: empty string = CI build).
         workflow_run_id: If set and ``workflow_run`` is None, fetches the
             workflow run from the GitHub API for fork detection.
         workflow_run: Optional workflow run dict from GitHub API. If
@@ -195,8 +192,9 @@ def get_artifacts_bucket_config_for_workflow_run(
     _log(f"  github_repository: {github_repository}")
 
     if release_type is None:
-        release_type = os.environ.get("RELEASE_TYPE", "ci")
-    _log(f"  release_type: {release_type}")
+        release_type = os.environ.get("RELEASE_TYPE", "")
+    if release_type:
+        _log(f"  release_type: {release_type}")
 
     # Fetch workflow_run from API if not provided but workflow_run_id is set.
     # Deferred import: github_actions is an optional dependency not available in

--- a/build_tools/_therock_utils/workflow_outputs.py
+++ b/build_tools/_therock_utils/workflow_outputs.py
@@ -279,7 +279,7 @@ class WorkflowOutputRoot:
                 Most callers running inside their own CI workflow do not need
                 this — environment variables suffice. Set this when looking up
                 another repository's workflow run (e.g. fetching artifacts).
-            release_type: Release type override (e.g. "ci", "dev", "nightly"). If
+            release_type: Release type override (e.g. "dev", "nightly"). If
                 None, falls back to the RELEASE_TYPE environment variable.
         """
         workflow_run_id = (

--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -117,7 +117,7 @@ def compute_version(
 
     Args:
         package_type: Type of package ("wheel", "deb", or "rpm")
-        release_type: Release type ("ci", "dev", "nightly", "prerelease", or "release")
+        release_type: Release type ("dev", "nightly", "prerelease", or "release")
         custom_version_suffix: Custom suffix to override automatic suffix
         prerelease_version: Prerelease version number
         override_base_version: Override the base version from version.json
@@ -140,7 +140,7 @@ def compute_version(
             # Trust the custom suffix to satisfy the general rules:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/
             version_suffix = custom_version_suffix
-        elif release_type in ("ci", "dev"):
+        elif release_type == "dev":
             # Construct a dev release version:
             # https://packaging.python.org/en/latest/specifications/version-specifiers/#developmental-releases
             git_sha = get_git_sha(override_git_sha=override_git_sha)
@@ -174,7 +174,7 @@ def compute_version(
             # Final release version - no suffix
             # Format: <rocm-version>
             version_suffix_str = ""
-        elif release_type in ("ci", "dev"):
+        elif release_type == "dev":
             # Construct a dev release version with date and optionally git SHA
             # deb format: <rocm-version>~dev<YYYYMMDD>
             # rpm format: <rocm-version>~<YYYYMMDD>g<short-git-sha>
@@ -216,11 +216,8 @@ def main(argv):
     release_type_group.add_argument(
         "--release-type",
         type=str,
-        choices=["ci", "dev", "nightly", "prerelease", "release"],
-        help=(
-            "The type of package version to produce. "
-            "'ci' uses dev-style versions; 'release' is only valid for deb/rpm."
-        ),
+        choices=["dev", "nightly", "prerelease", "release"],
+        help="The type of package version to produce (note: 'release' only valid for deb/rpm)",
     )
     release_type_group.add_argument(
         "--custom-version-suffix",

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -129,7 +129,7 @@ class CIInputs:
     commit_ref: str  # GITHUB_REF_NAME value
     base_ref: str  # Git ref for the workflow run (PR base or HEAD^1, used for diffing)
     build_variant: str  # Build variant label, e.g. "release", "asan", "tsan"
-    release_type: str = "ci"  # "ci", or "dev", "nightly", "prerelease" for releases
+    release_type: str = ""  # "" for CI, or "dev", "nightly", "prerelease" for releases
 
     # PR labels (from event payload for pull_request events)
     pr_labels: list[str] = field(default_factory=list)
@@ -180,7 +180,7 @@ class CIInputs:
         # setup_multi_arch.yml. GitHub-specific context (PR labels,
         # push before-commit) comes from the event payload.
         build_variant = os.environ.get("BUILD_VARIANT", "release")
-        release_type = os.environ.get("RELEASE_TYPE", "ci")
+        release_type = os.environ.get("RELEASE_TYPE", "")
 
         pr_labels: list[str] = []
         base_ref = "HEAD^1"

--- a/build_tools/github_actions/upload_tarballs.py
+++ b/build_tools/github_actions/upload_tarballs.py
@@ -60,8 +60,8 @@ def main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--release-type",
-        default="ci",
-        help='Release type: "ci", "dev", "nightly", or "prerelease"',
+        default="",
+        help='Release type: "" for CI, or "dev", "nightly", "prerelease"',
     )
     parser.add_argument(
         "--output-dir",
@@ -90,7 +90,7 @@ def main(argv: list[str]) -> int:
     output_root = WorkflowOutputRoot.from_workflow_run(
         run_id=args.run_id,
         platform=args.platform,
-        release_type=args.release_type,
+        release_type=args.release_type or None,
     )
     dest = output_root.tarballs()
     logger.info("Destination: %s", dest.s3_uri)

--- a/build_tools/github_actions/write_artifacts_bucket_info.py
+++ b/build_tools/github_actions/write_artifacts_bucket_info.py
@@ -25,8 +25,8 @@ def main(argv: list[str] | None = None):
     parser.add_argument(
         "--release-type",
         type=str,
-        default="ci",
-        help='Release type: "ci", "dev", "nightly", or "prerelease".',
+        default="",
+        help='Release type: "" for CI, or "dev", "nightly", "prerelease".',
     )
     args = parser.parse_args(argv)
 

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -640,7 +640,7 @@ def _resolve_upload_target(
             run_id=args.run_id, platform="linux"
         )
         loc = root.native_linux_packages(pkg_type)
-        job_type = os.environ.get("RELEASE_TYPE", "ci")
+        job_type = os.environ.get("RELEASE_TYPE", "") or "ci"
         install_url = _package_install_url(loc.bucket, loc.relative_path, pkg_type)
         return loc.bucket, loc.relative_path, install_url, True, job_type
 

--- a/build_tools/setup_ccache.py
+++ b/build_tools/setup_ccache.py
@@ -256,14 +256,14 @@ def main(argv: list[str]):
     preset_group.add_argument(
         "--release-type",
         type=str,
-        choices=["ci", "dev", "nightly", "prerelease"],
-        help='Shorthand for --config-preset: "ci" and "dev" map to github-oss-dev, '
+        choices=["", "dev", "nightly", "prerelease"],
+        help='Shorthand for --config-preset: "" and "dev" map to github-oss-dev, '
         "others map to github-oss-release.",
     )
 
     args = p.parse_args(argv)
     if args.release_type is not None:
-        if args.release_type in ("ci", "dev"):
+        if args.release_type in ("", "dev"):
             args.config_preset = "github-oss-dev"
         else:
             args.config_preset = "github-oss-release"

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -17,15 +17,6 @@ import compute_rocm_package_version
 
 
 class DetermineVersionTest(unittest.TestCase):
-    def test_ci_version_uses_dev_version_shape(self):
-        version = compute_rocm_package_version.compute_version(
-            release_type="ci",
-            custom_version_suffix=None,
-            prerelease_version=None,
-            override_base_version=None,
-        )
-        self.assertRegex(version, r"^[0-9]+[0-9\.]*\.dev0\+[0-9a-z]+$")
-
     def test_dev_version(self):
         version = compute_rocm_package_version.compute_version(
             release_type="dev",
@@ -103,16 +94,6 @@ class DetermineVersionTest(unittest.TestCase):
 class DebPackageVersionTest(unittest.TestCase):
     """Tests for Debian package version computation."""
 
-    def test_ci_version_uses_dev_version_shape(self):
-        version = compute_rocm_package_version.compute_version(
-            package_type="deb",
-            release_type="ci",
-            custom_version_suffix=None,
-            prerelease_version=None,
-            override_base_version=None,
-        )
-        self.assertRegex(version, r"^[0-9]+[0-9\.]*~dev[0-9]{8}$")
-
     def test_dev_version(self):
         version = compute_rocm_package_version.compute_version(
             package_type="deb",
@@ -182,16 +163,6 @@ class DebPackageVersionTest(unittest.TestCase):
 
 class RpmPackageVersionTest(unittest.TestCase):
     """Tests for RPM package version computation."""
-
-    def test_ci_version_uses_dev_version_shape(self):
-        version = compute_rocm_package_version.compute_version(
-            package_type="rpm",
-            release_type="ci",
-            custom_version_suffix=None,
-            prerelease_version=None,
-            override_base_version=None,
-        )
-        self.assertRegex(version, r"^[0-9]+[0-9\.]*~[0-9]{8}g[0-9a-z]{8}$")
 
     def test_dev_version(self):
         version = compute_rocm_package_version.compute_version(

--- a/build_tools/tests/s3_buckets_test.py
+++ b/build_tools/tests/s3_buckets_test.py
@@ -26,7 +26,7 @@ from _therock_utils.s3_buckets import (
 class TestGetArtifactsBucketConfig(unittest.TestCase):
     def test_ci_rocm_therock(self):
         config = get_artifacts_bucket_config(
-            release_type="ci", repository="ROCm/TheRock", is_pr_from_fork=False
+            release_type="", repository="ROCm/TheRock", is_pr_from_fork=False
         )
         self.assertEqual(config.name, "therock-ci-artifacts")
         self.assertEqual(
@@ -36,13 +36,13 @@ class TestGetArtifactsBucketConfig(unittest.TestCase):
 
     def test_ci_fork_pr(self):
         config = get_artifacts_bucket_config(
-            release_type="ci", repository="ROCm/TheRock", is_pr_from_fork=True
+            release_type="", repository="ROCm/TheRock", is_pr_from_fork=True
         )
         self.assertEqual(config.name, "therock-ci-artifacts-external")
 
     def test_ci_external_repo(self):
         config = get_artifacts_bucket_config(
-            release_type="ci", repository="ROCm/rocm-libraries", is_pr_from_fork=False
+            release_type="", repository="ROCm/rocm-libraries", is_pr_from_fork=False
         )
         self.assertEqual(config.name, "therock-ci-artifacts-external")
 
@@ -67,14 +67,6 @@ class TestGetArtifactsBucketConfig(unittest.TestCase):
                 is_pr_from_fork=False,
             )
         self.assertIn("bogus", str(cm.exception))
-
-    def test_empty_release_type_raises(self):
-        with self.assertRaises(ValueError):
-            get_artifacts_bucket_config(
-                release_type="",
-                repository="ROCm/TheRock",
-                is_pr_from_fork=False,
-            )
 
 
 # ---------------------------------------------------------------------------
@@ -118,10 +110,6 @@ class TestGetReleaseBucketConfig(unittest.TestCase):
     def test_empty_release_type_raises(self):
         with self.assertRaises(ValueError):
             get_release_bucket_config(release_type="", bucket_type="tarball")
-
-    def test_ci_release_type_raises(self):
-        with self.assertRaises(ValueError):
-            get_release_bucket_config(release_type="ci", bucket_type="tarball")
 
     def test_invalid_bucket_type_raises(self):
         with self.assertRaises(ValueError) as cm:

--- a/docs/development/style_guides/github_actions_style_guide.md
+++ b/docs/development/style_guides/github_actions_style_guide.md
@@ -125,9 +125,9 @@ Benefits:
 - **Developer-friendly:** Easy to use for common cases
 
 > [!NOTE]
-> Release workflows in TheRock should only offer "dev" for manual dispatch.
-> CI-oriented build/test helpers may offer "ci" and "dev"; rockrel-owned
-> callers can pass "nightly" and "prerelease" through `workflow_call`.
+> Some workflows may be configured to have stricter security boundaries, such
+> as only accepting "nightly" release types from certain branches or from
+> certain repositories.
 
 ✅ **Preferred:**
 
@@ -140,6 +140,8 @@ on:
         description: Type of release to create. All developer-triggered jobs should use "dev"!
         options:
           - dev
+          - nightly
+          - prerelease
         default: dev  # Safe: development releases don't affect production
 
       amdgpu_families:

--- a/docs/development/workflow_outputs.md
+++ b/docs/development/workflow_outputs.md
@@ -185,19 +185,18 @@ See [S3 Buckets](s3_buckets.md) for the full list of buckets and authentication
 details.
 
 ```
-RELEASE_TYPE=dev/nightly/prerelease? ──Yes──> therock-{RELEASE_TYPE}-artifacts
-       │
-       No (RELEASE_TYPE=ci)
-       │
-ROCm/TheRock (not fork)? ─────────────Yes──> therock-ci-artifacts
+RELEASE_TYPE set? ──Yes──> therock-{RELEASE_TYPE}-artifacts
        │
        No
        │
-       └──────────────────────────────────> therock-ci-artifacts-external
+ROCm/TheRock (not fork)? ──Yes──> therock-ci-artifacts
+       │
+       No
+       │
+       └──> therock-ci-artifacts-external
 ```
 
-Valid artifact `RELEASE_TYPE` values are `ci`, `dev`, `nightly`, and
-`prerelease`.
+Valid `RELEASE_TYPE` values are `dev`, `nightly`, and `prerelease`.
 
 ## Python API
 


### PR DESCRIPTION
Reverts ROCm/TheRock#5481

`release_type` in the `workflow_dispatch` trigger of `release_portable_linux_pytorch_wheels.yml`, `release_portable_linux_jax_wheels.yml`, and `build_native_linux_packages.yml` from `type: string` to `type: choice` with only `- dev`.

This is causing `workflow_dispatch`  failures in `nightly`

```
🔎 Found workflow, id: 174743032, name: Release portable Linux PyTorch Wheels, path: .github/workflows/release_portable_linux_pytorch_wheels.yml
🚀 Calling GitHub API to dispatch workflow...
##[error]Provided value 'nightly' for input 'release_type' not in the list of allowed values - https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event
```

related issue: https://github.com/ROCm/TheRock/issues/5749