### PR TITLE
[sysdeps][linux][amd-mesa] - Update amd-mesa branch to main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,7 +29,7 @@
 [submodule "amd-mesa"]
 	path = third-party/sysdeps/linux/amd-mesa/mesa-fork
 	url = https://github.com/ROCm/mesa-fork.git
-	branch = amd-decode-only
+	branch = main
 [submodule "libhipcxx"]
 	path = math-libs/libhipcxx
 	url = https://github.com/ROCm/libhipcxx.git

--- a/third-party/sysdeps/linux/amd-mesa/CMakeLists.txt
+++ b/third-party/sysdeps/linux/amd-mesa/CMakeLists.txt
@@ -78,7 +78,29 @@ add_custom_target(
         -Dallow-fallback-for=libva # NOTE: Use local build of VA library
         -Dforce_fallback_for=libva # NOTE: Enforce local build, if public VA found
         -Dpkg_config_path="${CMAKE_CURRENT_BINARY_DIR}"/../../../libdrm/build/dist/lib/rocm_sysdeps/lib/pkgconfig
-        -Damd-decode-only=true # NOTE: enable decode only for TheRock
+        -Degl=disabled
+        -Dgallium-drivers=radeonsi
+        -Dgallium-rusticl=false
+        -Dgallium-va=enabled
+        -Dgbm=disabled
+        -Dgles1=disabled
+        -Dgles2=disabled
+        -Dglvnd=disabled
+        -Dglx=disabled
+        -Dllvm=disabled
+        -Dopengl=false
+        -Dvideo-codecs=h264dec,h265dec,av1dec,vp9dec,jpegdec
+        -Dvulkan-drivers=
+        -Dplatforms=
+        -Dlibva:with_glx=no
+        -Dlibva:with_wayland=no
+        -Dlibva:with_x11=no
+        -Dvalgrind=disabled
+        -Dspirv-tools=disabled
+        -Dzlib=disabled
+        -Dzstd=disabled
+        -Dshader-cache=disabled
+        -Dexpat=disabled
         "${CMAKE_CURRENT_BINARY_DIR}"
         "${PATCH_SOURCE_DIR}"
   COMMAND
@@ -102,7 +124,29 @@ add_custom_target(
         -Dallow-fallback-for=libva # NOTE: Use local build of VA library
         -Dforce_fallback_for=libva # NOTE: Enforce local build, if public VA found
         -Dpkg_config_path="${CMAKE_CURRENT_BINARY_DIR}"/../../../libdrm/build/dist/lib/rocm_sysdeps/lib/pkgconfig
-        -Damd-decode-only=true # NOTE: enable decode only for TheRock
+        -Degl=disabled
+        -Dgallium-drivers=radeonsi
+        -Dgallium-rusticl=false
+        -Dgallium-va=enabled
+        -Dgbm=disabled
+        -Dgles1=disabled
+        -Dgles2=disabled
+        -Dglvnd=disabled
+        -Dglx=disabled
+        -Dllvm=disabled
+        -Dopengl=false
+        -Dvideo-codecs=h264dec,h265dec,av1dec,vp9dec,jpegdec
+        -Dvulkan-drivers=
+        -Dplatforms=
+        -Dlibva:with_glx=no
+        -Dlibva:with_wayland=no
+        -Dlibva:with_x11=no
+        -Dvalgrind=disabled
+        -Dspirv-tools=disabled
+        -Dzlib=disabled
+        -Dzstd=disabled
+        -Dshader-cache=disabled
+        -Dexpat=disabled
         "${CMAKE_CURRENT_BINARY_DIR}"
         "${PATCH_SOURCE_DIR}"
   COMMAND


### PR DESCRIPTION
## Motivation

This PR updates the amd-mesa branch from amd-decode-only to the main branch of mesa-fork. The main branch of mesa-fork now tracks upstream Mesa. All changes required for building the decode-only version of Mesa have already been upstreamed.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
