### PR TITLE
[ci] Improve error message when run ID is from different repo

### DIFF
--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -202,9 +202,26 @@ def get_artifacts_bucket_config_for_workflow_run(
     # Deferred import: github_actions is an optional dependency not available in
     # all environments (e.g. local dev without the GHA support package installed).
     if workflow_run is None and workflow_run_id is not None:
-        from github_actions.github_actions_api import gha_query_workflow_run_by_id
+        from github_actions.github_actions_api import (
+            GitHubAPIError,
+            gha_query_workflow_run_by_id,
+        )
 
-        workflow_run = gha_query_workflow_run_by_id(github_repository, workflow_run_id)
+        try:
+            workflow_run = gha_query_workflow_run_by_id(
+                github_repository, workflow_run_id
+            )
+        except GitHubAPIError as e:
+            run_url = (
+                f"https://github.com/{github_repository}/actions/runs/{workflow_run_id}"
+            )
+            raise GitHubAPIError(
+                f"Failed to query workflow run {workflow_run_id} in repository "
+                f"{github_repository}: {run_url}\n"
+                f"  {e}\n"
+                f"Hint: Did you mean to specify a different repository with "
+                f"--run-github-repo?"
+            ) from e
 
     # Extract metadata from workflow_run if available
     if workflow_run is not None:

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -120,7 +120,6 @@ from botocore import UNSIGNED
 from botocore.config import Config
 from datetime import datetime
 from fetch_artifacts import main as fetch_artifacts_main
-from github_actions.github_actions_api import GitHubAPIError
 from pathlib import Path
 import platform
 import re
@@ -495,17 +494,7 @@ def retrieve_artifacts_by_run_id(args):
         pass
 
     log(f"\nCalling fetch_artifacts_main with args:\n  {' '.join(argv)}\n")
-    try:
-        fetch_artifacts_main(argv)
-    except GitHubAPIError as e:
-        log(f"\nError: Failed to retrieve artifacts for workflow run {run_id}")
-        log(f"  {e}")
-        log(
-            "\nHint: If this run ID is from a different repository, "
-            "specify --run-github-repo=<owner/repo>"
-        )
-        log("  Example: --run-github-repo=ROCm/rocm-libraries")
-        sys.exit(1)
+    fetch_artifacts_main(argv)
 
     log(f"Retrieved artifacts for run ID {run_id}")
 

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -120,6 +120,7 @@ from botocore import UNSIGNED
 from botocore.config import Config
 from datetime import datetime
 from fetch_artifacts import main as fetch_artifacts_main
+from github_actions.github_actions_api import GitHubAPIError
 from pathlib import Path
 import platform
 import re
@@ -494,7 +495,17 @@ def retrieve_artifacts_by_run_id(args):
         pass
 
     log(f"\nCalling fetch_artifacts_main with args:\n  {' '.join(argv)}\n")
-    fetch_artifacts_main(argv)
+    try:
+        fetch_artifacts_main(argv)
+    except GitHubAPIError as e:
+        log(f"\nError: Failed to retrieve artifacts for workflow run {run_id}")
+        log(f"  {e}")
+        log(
+            "\nHint: If this run ID is from a different repository, "
+            "specify --run-github-repo=<owner/repo>"
+        )
+        log("  Example: --run-github-repo=ROCm/rocm-libraries")
+        sys.exit(1)
 
     log(f"Retrieved artifacts for run ID {run_id}")
 


### PR DESCRIPTION
When fetching artifacts fails with a 404 error, we now provide a clear message suggesting the user may need to specify --run-github-repo=<owner/repo> if the run ID is from a different repository.

Working locally:
```
Retrieving bucket info for workflow run...
       github_repository: ROCm/TheRock
       release_type: ci
     Traceback (most recent call last):
...
       File "/home/geomin12/Code/TheRock/build_tools/fetch_artifacts.py", line 397, in <module>
         main(sys.argv[1:])
       File "/home/geomin12/Code/TheRock/build_tools/fetch_artifacts.py", line 393, in main
         run(args)
       File "/home/geomin12/Code/TheRock/build_tools/fetch_artifacts.py", line 203, in run
         output_root = WorkflowOutputRoot.from_workflow_run(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       File "/home/geomin12/Code/TheRock/build_tools/_therock_utils/workflow_outputs.py", line 288, in
     from_workflow_run
         external_repo, bucket = _retrieve_bucket_info(
                                 ^^^^^^^^^^^^^^^^^^^^^^
       File "/home/geomin12/Code/TheRock/build_tools/_therock_utils/workflow_outputs.py", line 344, in
     _retrieve_bucket_info
         artifact_bucket_config = get_artifacts_bucket_config_for_workflow_run(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       File "/home/geomin12/Code/TheRock/build_tools/_therock_utils/s3_buckets.py", line 218, in
     get_artifacts_bucket_config_for_workflow_run
         raise GitHubAPIError(
     github_actions.github_actions_api.GitHubAPIError: Failed to query workflow run 27221109515 in
     repository ROCm/TheRock: https://github.com/ROCm/TheRock/actions/runs/27221109515
       gh api request failed: gh: Not Found (HTTP 404)

     Hint: Did you mean to specify a different repository with --run-github-repo?
```