### PR TITLE
Add placeholder multi-arch JAX build workflow

### DIFF
--- a/.github/workflows/multi_arch_build_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Determine build arguments
         run: |
           if [ "${{ inputs.build_jaxlib }}" = "true" ]; then
-            echo "SOURCE_ARG=--jax-source-dir=${{ github.workspace }}/jax" >> "$GITHUB_ENV"
+            echo "SOURCE_ARG=--jax-source-dir=$GITHUB_WORKSPACE/jax" >> "$GITHUB_ENV"
           else
             echo "SOURCE_ARG=" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/multi_arch_build_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels.yml
@@ -109,10 +109,11 @@ jobs:
         working-directory: rocm-jax
         env:
           ROCM_VERSION: ${{ inputs.rocm_version }}
+          PYTHON_VERSION: ${{ inputs.python_version }}
         run: |
           python3 build/ci_build \
             --compiler=clang \
-            --python-versions="${{ inputs.python_version }}" \
+            --python-versions="${PYTHON_VERSION}" \
             --rocm-version="${ROCM_VERSION}" \
             --therock-path="${{ inputs.tar_url }}" \
             ${SOURCE_ARG} \

--- a/.github/workflows/multi_arch_build_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels.yml
@@ -1,0 +1,119 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Placeholder reusable build workflow.
+# Artifact upload and release/test plumbing will be added in a follow-up PR.
+
+# Reusable multi-arch build variant of the Linux JAX wheel flow.
+#
+# Built shape:
+#   - One build/ci_build invocation for one python_version and jax_ref
+#     matrix cell.
+#   - Builds directly against the shared TheRock multiarch tarball
+#     passed in via inputs.tar_url.
+#
+# Legacy rocm-jax release branches
+# (rocm-jaxlib-v0.8.2, rocm-jaxlib-v0.9.0, rocm-jaxlib-v0.9.1, and
+# rocm-jaxlib-v0.9.2) produce architecture-agnostic wheels.
+
+name: Multi-Arch Build Linux JAX Wheels
+
+on:
+  workflow_call:
+    inputs:
+      python_version:
+        description: Python version to build wheels for.
+        type: string
+        required: true
+      jax_ref:
+        description: JAX / rocm-jax release ref.
+        type: string
+        required: true
+      build_jaxlib:
+        description: Whether this matrix cell should build jaxlib from JAX source.
+        type: boolean
+        required: true
+      rocm_version:
+        description: ROCm package version to install and build against.
+        type: string
+        required: true
+      tar_url:
+        description: URL to the TheRock tarball used for the build.
+        type: string
+        required: true
+      release_type:
+        description: Release type.
+        type: string
+        required: true
+      repository:
+        description: Repository to checkout. Defaults to github.repository.
+        type: string
+        default: ""
+      ref:
+        description: Branch, tag, or SHA to checkout. Defaults to the triggering ref.
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  build_jax_wheels:
+    name: Build | py ${{ inputs.python_version }} | jax ${{ inputs.jax_ref }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+
+    env:
+      PACKAGE_DIST_DIR: ${{ github.workspace }}/rocm-jax/jax_rocm_plugin/wheelhouse
+
+    steps:
+      - name: Checkout TheRock
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref_name }}
+
+      - name: Checkout rocm-jax
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: rocm-jax
+          repository: ROCm/rocm-jax
+          ref: ${{ inputs.jax_ref }}
+
+      - name: Checkout JAX
+        if: ${{ inputs.build_jaxlib }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: jax
+          repository: ROCm/jax
+          ref: ${{ inputs.jax_ref }}
+
+      - name: Configure Git Identity
+        run: |
+          git config --global user.name "therockbot"
+          git config --global user.email "therockbot@amd.com"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Determine build arguments
+        run: |
+          if [ "${{ inputs.build_jaxlib }}" = "true" ]; then
+            echo "SOURCE_ARG=--jax-source-dir=${{ github.workspace }}/jax" >> "$GITHUB_ENV"
+          else
+            echo "SOURCE_ARG=" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build JAX wheels
+        working-directory: rocm-jax
+        env:
+          ROCM_VERSION: ${{ inputs.rocm_version }}
+        run: |
+          python3 build/ci_build \
+            --compiler=clang \
+            --python-versions="${{ inputs.python_version }}" \
+            --rocm-version="${ROCM_VERSION}" \
+            --therock-path="${{ inputs.tar_url }}" \
+            ${SOURCE_ARG} \
+            dist_wheels

--- a/.github/workflows/multi_arch_build_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels.yml
@@ -98,8 +98,10 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - name: Determine build arguments
+        env:
+          BUILD_JAXLIB: ${{ inputs.build_jaxlib }}
         run: |
-          if [ "${{ inputs.build_jaxlib }}" = "true" ]; then
+          if [ "$BUILD_JAXLIB" = "true" ]; then
             echo "SOURCE_ARG=--jax-source-dir=$GITHUB_WORKSPACE/jax" >> "$GITHUB_ENV"
           else
             echo "SOURCE_ARG=" >> "$GITHUB_ENV"


### PR DESCRIPTION
Follow up https://github.com/ROCm/TheRock/pull/4366
Add an initial reusable multi-arch JAX build workflow.

This change establishes the workflow structure used by the multi-arch JAX release flow and mirrors the PyTorch workflow layout.