### PR TITLE
[wheel] [multi-arch]: fix rocBLAS kernel loading failure in whl-multi-arch 

### DIFF
--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -601,18 +601,27 @@ class PopulatedDistPackage:
             libraries_pkg_name = libraries_entry.get_py_package_name(target_family=None)
             libraries_platform_dir = package_path.parent / libraries_pkg_name
 
+            # Use relative symlinks so they survive tarball extraction at any
+            # install prefix. Both devel and libraries platform dirs are siblings
+            # under site-packages/, so "../<libraries_pkg_name>/..." is correct.
             kpack_link = package_path / ".kpack"
             if not kpack_link.exists():
-                kpack_link.symlink_to(libraries_platform_dir / ".kpack")
+                kpack_link.symlink_to(Path("..") / libraries_pkg_name / ".kpack")
                 log(
-                    f"::: Created .kpack symlink in devel: {kpack_link} -> {libraries_platform_dir / '.kpack'}"
+                    f"::: Created .kpack symlink in devel: {kpack_link} -> ../{libraries_pkg_name}/.kpack"
                 )
 
             rocblas_library_link = package_path / "lib" / "rocblas" / "library"
             if not rocblas_library_link.exists():
                 rocblas_library_link.parent.mkdir(parents=True, exist_ok=True)
                 rocblas_library_link.symlink_to(
-                    libraries_platform_dir / "lib" / "rocblas" / "library"
+                    Path("..")
+                    / ".."
+                    / ".."
+                    / libraries_pkg_name
+                    / "lib"
+                    / "rocblas"
+                    / "library"
                 )
                 log(
                     f"::: Created rocblas/library symlink in devel: {rocblas_library_link}"

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -578,6 +578,24 @@ class PopulatedDistPackage:
                 dir_entry,
             )
 
+        # In kpack-split mode, kpack-transformed libraries (e.g. librocblas.so.5.5)
+        # are loaded by the dynamic linker from _rocm_sdk_devel/lib/ because that
+        # package holds the versioned symlinks. Their embedded kpack search path
+        # resolves to ../.kpack/ relative to the loaded .so location, which lands
+        # in _rocm_sdk_devel/.kpack/ — but the actual .kpack archives live in
+        # _rocm_sdk_libraries/.kpack/. Without this symlink, kpack silently fails
+        # to find the archive and rocBLAS falls back to direct Tensile loading,
+        # which then fails with hipErrorInvalidImage on gfx942 (bare arch code
+        # objects rejected by CLR against gfx942:sramecc+:xnack- hardware ISA).
+        if self.params.kpack_split:
+            libraries_entry = self.params.dist_info.ALL_PACKAGES["libraries"]
+            libraries_pkg_name = libraries_entry.get_py_package_name(target_family=None)
+            libraries_platform_dir = package_path.parent / libraries_pkg_name
+            kpack_link = package_path / ".kpack"
+            if not kpack_link.exists():
+                kpack_link.symlink_to(libraries_platform_dir / ".kpack")
+                log(f"::: Created .kpack symlink in devel: {kpack_link} -> {libraries_platform_dir / '.kpack'}")
+
         # For packaging, the devel platform/ contents are not wheel safe, so we
         # store them into their own tarball and dynamically decompress at runtime.
         # The tarball will contain as its first path component the top level

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -580,21 +580,39 @@ class PopulatedDistPackage:
 
         # In kpack-split mode, kpack-transformed libraries (e.g. librocblas.so.5.5)
         # are loaded by the dynamic linker from _rocm_sdk_devel/lib/ because that
-        # package holds the versioned symlinks. Their embedded kpack search path
-        # resolves to ../.kpack/ relative to the loaded .so location, which lands
-        # in _rocm_sdk_devel/.kpack/ — but the actual .kpack archives live in
-        # _rocm_sdk_libraries/.kpack/. Without this symlink, kpack silently fails
-        # to find the archive and rocBLAS falls back to direct Tensile loading,
-        # which then fails with hipErrorInvalidImage on gfx942 (bare arch code
-        # objects rejected by CLR against gfx942:sramecc+:xnack- hardware ISA).
+        # package holds the versioned symlinks. Two symlinks are needed so that
+        # code loaded from _rocm_sdk_devel can find its GPU artifacts in
+        # _rocm_sdk_libraries:
+        #
+        # 1. .kpack symlink: the embedded kpack search path in librocblas.so
+        #    resolves to ../.kpack/ relative to the loaded .so, landing in
+        #    _rocm_sdk_devel/.kpack/ — but the actual kpack archives live in
+        #    _rocm_sdk_libraries/.kpack/. Without this, kpack silently fails.
+        #
+        # 2. lib/rocblas/library symlink: tensile_host.cpp initializes by
+        #    reading .dat manifest files from lib/rocblas/library/ relative to
+        #    its own .so location (_rocm_sdk_devel/lib/). The per-arch Tensile
+        #    files live in _rocm_sdk_libraries/lib/rocblas/library/. Without
+        #    this, Tensile host init fails with "Cannot read TensileLibrary.dat"
+        #    and rocBLAS falls back to direct kernel loading which then fails
+        #    with hipErrorInvalidImage on gfx942:sramecc+:xnack- hardware.
         if self.params.kpack_split:
             libraries_entry = self.params.dist_info.ALL_PACKAGES["libraries"]
             libraries_pkg_name = libraries_entry.get_py_package_name(target_family=None)
             libraries_platform_dir = package_path.parent / libraries_pkg_name
+
             kpack_link = package_path / ".kpack"
             if not kpack_link.exists():
                 kpack_link.symlink_to(libraries_platform_dir / ".kpack")
                 log(f"::: Created .kpack symlink in devel: {kpack_link} -> {libraries_platform_dir / '.kpack'}")
+
+            rocblas_library_link = package_path / "lib" / "rocblas" / "library"
+            if not rocblas_library_link.exists():
+                rocblas_library_link.parent.mkdir(parents=True, exist_ok=True)
+                rocblas_library_link.symlink_to(
+                    libraries_platform_dir / "lib" / "rocblas" / "library"
+                )
+                log(f"::: Created rocblas/library symlink in devel: {rocblas_library_link}")
 
         # For packaging, the devel platform/ contents are not wheel safe, so we
         # store them into their own tarball and dynamically decompress at runtime.

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -604,7 +604,9 @@ class PopulatedDistPackage:
             kpack_link = package_path / ".kpack"
             if not kpack_link.exists():
                 kpack_link.symlink_to(libraries_platform_dir / ".kpack")
-                log(f"::: Created .kpack symlink in devel: {kpack_link} -> {libraries_platform_dir / '.kpack'}")
+                log(
+                    f"::: Created .kpack symlink in devel: {kpack_link} -> {libraries_platform_dir / '.kpack'}"
+                )
 
             rocblas_library_link = package_path / "lib" / "rocblas" / "library"
             if not rocblas_library_link.exists():
@@ -612,7 +614,9 @@ class PopulatedDistPackage:
                 rocblas_library_link.symlink_to(
                     libraries_platform_dir / "lib" / "rocblas" / "library"
                 )
-                log(f"::: Created rocblas/library symlink in devel: {rocblas_library_link}")
+                log(
+                    f"::: Created rocblas/library symlink in devel: {rocblas_library_link}"
+                )
 
         # For packaging, the devel platform/ contents are not wheel safe, so we
         # store them into their own tarball and dynamically decompress at runtime.


### PR DESCRIPTION
## Motivation

In kpack-split wheel mode (`whl-multi-arch`), rocBLAS and other kpack-transformed libraries fail to load GPU kernels on gfx942 (MI300X) hardware with `hipErrorInvalidImage` or `Cannot read TensileLibrary.dat: Illegal seek for GPU arch: gfx942`. This blocks rocHPL and any other workload using rocBLAS on MI300X when installed from the multi-arch wheel index. The root cause is a cross-package path gap between `_rocm_sdk_devel` and `_rocm_sdk_libraries` that leaves the devel package unable to locate kpack archives or Tensile kernel manifests.

## Technical Details

In kpack-split mode the wheel install is split across two packages:
- `_rocm_sdk_devel` holds versioned shared library symlinks (e.g. `librocblas.so.5.5`)
- `_rocm_sdk_libraries` holds the kpack archives (`.kpack/`) and per-arch Tensile files (`lib/rocblas/library/gfx942/`)

The dynamic linker loads `librocblas.so.5.5` from `_rocm_sdk_devel/lib/` (only location with the versioned symlink). Two path lookups then fail:

**1. kpack search path:** the embedded path `../.kpack/blas_lib_@GFXARCH@.kpack` resolves to `_rocm_sdk_devel/.kpack/` — which does not exist. kpack silently fails and rocBLAS falls through to direct Tensile loading.

**2. Tensile host init:** `tensile_host.cpp` uses `dl_iterate_phdr` to find the loaded library's path, then looks for `lib/rocblas/library/` relative to it. This resolves to `_rocm_sdk_devel/lib/rocblas/library/` — which also does not exist. The per-arch Tensile files (`.dat` manifests, `Kernels.so-000-gfx942.hsaco`) live in `_rocm_sdk_libraries/lib/rocblas/library/gfx942/`.

**Fix:** In `build_tools/_therock_utils/py_packaging.py`, when assembling the devel package tarball in kpack-split mode, create two symlinks in the devel platform directory pointing into the libraries package:
- `.kpack` → `_rocm_sdk_libraries/.kpack/`
- `lib/rocblas/library` → `_rocm_sdk_libraries/lib/rocblas/library/`

This ensures both path lookups resolve correctly without modifying any library binary or packaging layout. This does not affect non-kpack-split (legacy) wheel builds or Debian/RPM packages, which use a single prefix layout where these paths are naturally co-located.

## Test Plan

Manual workaround verification (pre-fix) on rocm-sdk `7.14.0a20260608` on MI300X (8x gfx942):

    python3 -m venv .venv
    source .venv/bin/activate
    pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ "rocm[libraries,devel,device-all]"
    export ROCM=$(python3 -m rocm_sdk path --root)
    export ROCM_RT=$(dirname $ROCM)/_rocm_sdk_core
    export ROCM_LB=$(dirname $ROCM)/_rocm_sdk_libraries
    export ROCM_DEV=$(dirname $ROCM)/_rocm_sdk_devel
    export LD_LIBRARY_PATH=$ROCM_RT/lib:$ROCM_LB/lib:$ROCM_RT/lib/rocm_sysdeps/lib/:$LD_LIBRARY_PATH
    ln -sf $ROCM_LB/.kpack $ROCM_DEV/.kpack
    mkdir -p $ROCM_DEV/lib/rocblas/
    ln -s $ROCM_LB/lib/rocblas/library $ROCM_DEV/lib/rocblas/library
    git clone https://github.com/ROCm/rocHPL.git && cd rocHPL
    ./install.sh --with-rocm=$ROCM --with-rocblas=$ROCM_LB
    ./build/mpirun_rochpl -P 4 -Q 2 -N 256000 --NB 512

CI: Trigger the multi-arch wheel build with this change and run rocHPL on gfx942 (MI300X) hardware without any symlink workaround steps above

## Test Result

- Without fix: `rocBLAS error: Cannot read TensileLibrary.dat: Illegal seek for GPU arch: gfx942` → abort
- With symlinks applied: rocHPL completes successfully at ~355 TFLOPS, residual check PASSED
