### PR TITLE
[CI] Raise rocsparse test step timeout to 30 minutes

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -336,7 +336,7 @@ test_matrix = {
     "rocsparse": {
         "job_name": "rocsparse",
         "fetch_artifact_args": "--blas --tests",
-        "timeout_minutes": 15,
+        "timeout_minutes": 30,
         "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {


### PR DESCRIPTION
The rocsparse Linux test job runs unsharded ("shard 1 of 1") and the suite takes ~19 minutes, exceeding the previous 15-minute per-step timeout, causing the Test action to be killed mid-run (observed on rocm-libraries PRs #8083 and #8084). Raise timeout_minutes from 15 to 30 to give the suite room to finish. Shard counts are left unchanged.