### PR TITLE
Link per-ISA device files into rocm-sdk-devel

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -660,6 +660,16 @@ Devel contents expanded to '.venv/lib/python3.12/site-packages/_rocm_sdk_devel'
 These contents are useful for using the package outside of Python and _lazily_ expanded on the
 first use when used from Python.
 
+> [!NOTE]
+> The devel tree is expanded (and its device files linked) only once - on the
+> first `rocm-sdk init` or the first use of a devel tool such as `hipcc`. If you
+> install or remove a `rocm-sdk-device-*` wheel (for example, adding a second GPU
+> target) **after** that first expansion, re-run `rocm-sdk init` to link the new
+> device files into the devel tree. The compiler tools do not re-scan on their
+> own, so a device wheel added later is not picked up until you run
+> `rocm-sdk init` (or any `rocm-sdk path`) again. Uninstalling a `rocm-sdk-device-*`
+> wheel removes its devel files automatically via `pip`.
+
 Once you have verified your installation, you can continue to use it for
 standard ROCm development or install PyTorch, JAX, or another supported Python ML
 framework.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -180,6 +180,22 @@ After installing, verify your installation:
 rocm-sdk test
 ```
 
+The `rocm-sdk-devel` development files (headers, CMake config, and the device
+`.kpack`/kernel files from your `rocm-sdk-device-*` wheels) are expanded on first
+use. To expand them eagerly, run `rocm-sdk init`.
+
+> [!NOTE]
+> The devel tree is expanded - and its device files linked from the installed
+> `rocm-sdk-device-*` wheels - only once: on the first `rocm-sdk init` /
+> `rocm-sdk test`, or the first use of a devel tool such as `hipcc`. If you
+> install or remove a `rocm-sdk-device-*` wheel (for example, adding a second GPU
+> target) **after** that first expansion, re-run `rocm-sdk init` or `rocm-sdk test`
+> to link the new device files. The compiler tools do not re-scan on their own,
+> so a device wheel added later is not picked up until you run one of those again.
+> Uninstalling a `rocm-sdk-device-*` wheel removes its devel files automatically
+> via `pip`. If the devel tree ever ends up in a bad state, recreate the virtual
+> environment.
+
 #### Supported Python `[device-*]` install extras
 
 For packages which include device-specific code (such as `rocm`, `torch`, and
@@ -659,16 +675,6 @@ Devel contents expanded to '.venv/lib/python3.12/site-packages/_rocm_sdk_devel'
 
 These contents are useful for using the package outside of Python and _lazily_ expanded on the
 first use when used from Python.
-
-> [!NOTE]
-> The devel tree is expanded (and its device files linked) only once - on the
-> first `rocm-sdk init` or the first use of a devel tool such as `hipcc`. If you
-> install or remove a `rocm-sdk-device-*` wheel (for example, adding a second GPU
-> target) **after** that first expansion, re-run `rocm-sdk init` to link the new
-> device files into the devel tree. The compiler tools do not re-scan on their
-> own, so a device wheel added later is not picked up until you run
-> `rocm-sdk init` (or any `rocm-sdk path`) again. Uninstalling a `rocm-sdk-device-*`
-> wheel removes its devel files automatically via `pip`.
 
 Once you have verified your installation, you can continue to use it for
 standard ROCm development or install PyTorch, JAX, or another supported Python ML

--- a/build_tools/_therock_utils/py_packaging.py
+++ b/build_tools/_therock_utils/py_packaging.py
@@ -7,6 +7,7 @@ from typing import Callable, Sequence
 
 import importlib.util
 import io
+import json
 import re
 import os
 from pathlib import Path
@@ -390,13 +391,47 @@ class PopulatedDistPackage:
             log(f"  + {an}: {an_path}")
 
         package_dest_dir = self.platform_dir
+        libraries_py_package_name = package_dest_dir.name
+        devel_links: list[dict[str, str]] = []
         for relpath, dir_entry in artifacts.pm.matches():
             if self.files.has(relpath):
                 continue
             dest_path = package_dest_dir / relpath
             self._populate_file(relpath, dest_path, dir_entry, resolve_src=True)
+            if not dir_entry.is_dir():
+                # Record the relative hardlink target into the libraries overlay
+                # so that `rocm-sdk init` can mirror this per-ISA device file into
+                # the generic rocm-sdk-devel tree. The backtrack count and target
+                # layout mirror _populate_devel_file()'s symlink computation.
+                backtrack = len(Path(relpath).parts)
+                target = "/".join(
+                    [".."] * backtrack + [libraries_py_package_name, relpath]
+                )
+                devel_links.append({"relpath": relpath, "target": target})
+        self._emit_devel_links_manifest(devel_links)
         self.params.populated_packages.append(self)
         return self
+
+    def _emit_devel_links_manifest(self, devel_links: list[dict[str, str]]):
+        """Writes the `_devel_links` manifest consumed by `rocm-sdk init`.
+
+        Each device wheel ships this manifest so that, at devel expansion time,
+        its per-ISA files are hardlinked from the rocm-sdk-libraries overlay into
+        the generic rocm-sdk-devel tree (and recorded in this wheel's RECORD so
+        that `pip uninstall` prunes them). Named per target family so that
+        multiple device wheels overlay the shared libraries dir without
+        colliding.
+        """
+        manifest_dir = self.platform_dir / ".devel_links"
+        manifest_dir.mkdir(parents=True, exist_ok=True)
+        manifest_path = manifest_dir / f"{self.target_family}.json"
+        manifest_path.write_text(
+            json.dumps(
+                {"version": self.params.version, "links": devel_links},
+                indent=2,
+            ),
+            newline="\n",
+        )
 
     def _populate_runtime_symlink(
         self, relpath: str, dest_path: Path, src_entry: os.DirEntry[str]

--- a/build_tools/packaging/python/templates/rocm-sdk-core/src/rocm_sdk_core/_cli.py
+++ b/build_tools/packaging/python/templates/rocm-sdk-core/src/rocm_sdk_core/_cli.py
@@ -79,9 +79,20 @@ def _get_module_path(expand_devel: bool) -> Path:
          These tools should pass `expand_devel=False`.
       B) Other tools that benefit from the extra files in the 'devel' package
          will expand expand it by passing `expand_devel=True`.
+
+    NOTE: the "already expanded" check is one-shot. Once the devel tree exists
+    it is returned directly, WITHOUT re-running the device-link reconcile in
+    `rocm_sdk._devel._reconcile_device_links` (only `_expand_devel_module()` /
+    `rocm-sdk init` does that). So a `rocm-sdk-device-*` wheel installed or
+    removed after the first expansion is NOT picked up by these trampolines
+    (e.g. hipcc); refresh it with an explicit `rocm-sdk init` / `rocm-sdk path`.
+    This is intentional: reconciling on every compiler invocation would add a
+    subprocess + metadata scan to a build hot path.
     """
     if _has_devel_module():
         if _is_devel_module_expanded():
+            # One-shot: returns the existing tree without re-reconciling device
+            # links (see NOTE above).
             return _get_devel_module_path()
         elif expand_devel:
             _expand_devel_module()

--- a/build_tools/packaging/python/templates/rocm-sdk-core/src/rocm_sdk_core/_cli.py
+++ b/build_tools/packaging/python/templates/rocm-sdk-core/src/rocm_sdk_core/_cli.py
@@ -85,7 +85,8 @@ def _get_module_path(expand_devel: bool) -> Path:
     `rocm_sdk._devel._reconcile_device_links` (only `_expand_devel_module()` /
     `rocm-sdk init` does that). So a `rocm-sdk-device-*` wheel installed or
     removed after the first expansion is NOT picked up by these trampolines
-    (e.g. hipcc); refresh it with an explicit `rocm-sdk init` / `rocm-sdk path`.
+    (e.g. hipcc); refresh it with an explicit
+    `rocm-sdk init` / `rocm-sdk path` / `rocm-sdk test`.
     This is intentional: reconciling on every compiler invocation would add a
     subprocess + metadata scan to a build hot path.
     """

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
@@ -146,7 +146,12 @@ def main(argv: list[str] | None = None):
 
     # 'init' subcommand.
     init_p = sub_p.add_parser(
-        "init", help="Expand devel contents to initialize rocm[devel]"
+        "init",
+        help=(
+            "Expand devel contents to initialize rocm[devel] and link device "
+            "files from installed rocm-sdk-device-* wheels into the devel tree "
+            "(re-run after installing or removing a device wheel to refresh)"
+        ),
     )
     init_p.add_argument(
         "--quiet",

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -313,6 +313,11 @@ def _reconcile_device_links(
     Idempotent and safe to call on every `get_devel_root()`: links already in
     place are left untouched and add nothing to RECORD. Returns the number of
     links created during this call.
+
+    Note: the core CLI trampolines (hipcc etc., see rocm_sdk_core._cli) only
+    reach `get_devel_root()` on the FIRST devel expansion, so a device wheel
+    installed after that is linked by an explicit `rocm-sdk init` / `rocm-sdk
+    path`, not by subsequent compiler invocations.
     """
     plans = _discover_device_link_plans(site_lib_path, expected_version)
     if not plans:

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -450,7 +450,12 @@ class FileLock:
 
     def __init__(self, file: io.TextIOWrapper):
         self.file = file
-        self.original_file_size = os.path.getsize(file.name)
+        # Lock at least one byte. On Windows, msvcrt.locking treats a zero-length
+        # range as a no-op (a lock on an empty file does not block), so a lock
+        # file that starts empty - like the reconcile sentinel - would not
+        # actually serialize callers. Locking one byte at offset 0 is valid even
+        # when the file is empty.
+        self.lock_size = max(os.path.getsize(file.name), 1)
 
         if _is_windows():
             # The Windows APIs for file locking apply to only a given range
@@ -462,7 +467,7 @@ class FileLock:
 
             original_position = self.file.tell()
             self.file.seek(0)
-            msvcrt.locking(self.file.fileno(), msvcrt.LK_NBLCK, self.original_file_size)
+            msvcrt.locking(self.file.fileno(), msvcrt.LK_NBLCK, self.lock_size)
             self.file.seek(original_position)
         else:
             # The Unix APIs for file locking apply to the entire file descriptor.
@@ -476,7 +481,7 @@ class FileLock:
 
             original_position = self.file.tell()
             self.file.seek(0)
-            msvcrt.locking(self.file.fileno(), msvcrt.LK_UNLCK, self.original_file_size)
+            msvcrt.locking(self.file.fileno(), msvcrt.LK_UNLCK, self.lock_size)
             self.file.seek(original_position)
         else:
             import fcntl

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -31,10 +31,12 @@ symlink relationships.
 
 import importlib.metadata as md
 import io
+import json
 import os
 from pathlib import Path
 import platform
 import shutil
+import sys
 import tarfile
 
 from . import _dist_info as di
@@ -67,6 +69,11 @@ def get_devel_root() -> Path:
     # we haven't expanded yet or expansion failed and we need to retry
     tarfile_path, _ = _find_tarfile(rocm_sdk_devel_path)
     if (devel_py_pkg_path / "__init__.py").exists() and not tarfile_path:
+        # The generic devel content is expanded one-shot, but per-ISA device
+        # files are owned by independently-installed rocm-sdk-device-* wheels.
+        # Reconcile their links on every call so a device wheel installed after
+        # the first expansion is picked up on the next `rocm-sdk init`.
+        _reconcile_device_links(site_lib_path, devel_py_pkg_path, di.__version__)
         return devel_py_pkg_path
 
     _expand_devel_contents(rocm_sdk_devel_path, site_lib_path)
@@ -74,6 +81,7 @@ def get_devel_root() -> Path:
         raise ImportError(
             f"Expanding {devel_py_pkg_name} did not produce a valid Python package"
         )
+    _reconcile_device_links(site_lib_path, devel_py_pkg_path, di.__version__)
     return devel_py_pkg_path
 
 
@@ -175,6 +183,194 @@ def _find_tarfile(rocm_sdk_devel_path: Path):
         else:
             return "", ""
     return tarfile_path, tarfile_mode
+
+
+def _devel_link_ok(dest_path: Path, target: str) -> bool:
+    """True if dest_path already exists as a hardlink to its manifest target.
+
+    A symlink that happens to resolve to the right inode is rejected: the
+    reconciler must guarantee hardlinks, so the slow path replaces it.
+    """
+    if dest_path.is_symlink() or not dest_path.is_file():
+        return False
+    try:
+        return dest_path.samefile(dest_path.parent / target)
+    except OSError:
+        return False
+
+
+def _record_has_entries(record_path: Path, names: list[str]) -> bool:
+    """True if RECORD exists, has no duplicate rows, and lists every name.
+
+    Returning False on a duplicate row makes the fast path fall through so
+    `_ensure_record_entries` can rewrite RECORD and drop the duplicates.
+    """
+    if not record_path.exists():
+        return False
+    existing = set()
+    for line in record_path.read_text().splitlines():
+        if not line.strip():
+            continue
+        name = line.split(",", 1)[0]
+        if name in existing:
+            return False
+        existing.add(name)
+    return all(n in existing for n in names)
+
+
+def _discover_device_link_plans(site_lib_path: Path, expected_version: str):
+    """Find installed rocm-sdk-device-* wheels and their devel-link manifests.
+
+    Returns a list of (record_path, links) where links is the list of
+    {"relpath", "target"} entries from that wheel's `_devel_links` manifest and
+    record_path is that wheel's RECORD (so newly materialized devel links can be
+    recorded against the wheel that owns the underlying device files).
+    """
+    plans = []
+    for dist in md.distributions(path=[str(site_lib_path)]):
+        name = dist.metadata["Name"]
+        if not name:
+            continue
+        if name != "rocm-sdk-device" and not name.startswith("rocm-sdk-device-"):
+            continue
+        # The device wheel and the SDK are version-locked. A mismatched wheel's
+        # link targets may not line up with this devel tree, so skip it loudly.
+        if dist.version != expected_version:
+            print(
+                f"WARNING: skipping {name} {dist.version}: does not match "
+                f"rocm-sdk {expected_version}",
+                file=sys.stderr,
+            )
+            continue
+        files = dist.files
+        if not files:
+            continue
+        manifest_file = None
+        record_file = None
+        for f in files:
+            if f.name == "RECORD" and f.parent.name.endswith(".dist-info"):
+                record_file = f
+            elif f.suffix == ".json" and f.parent.name == ".devel_links":
+                manifest_file = f
+        if manifest_file is None or record_file is None:
+            continue
+        manifest_path = Path(manifest_file.locate())
+        if not manifest_path.is_file():
+            continue
+        links = json.loads(manifest_path.read_text()).get("links", [])
+        if not links:
+            continue
+        plans.append((Path(record_file.locate()), links))
+    return plans
+
+
+def _ensure_record_entries(record_path: Path, names: list[str]):
+    """Append RECORD entries for materialized devel links, de-duplicated.
+
+    Reads the existing RECORD, drops any duplicate paths, appends the new
+    site-packages-relative paths (with empty hash/size, per the PyPA spec), and
+    rewrites the file. Writes only when there is something to add or a duplicate
+    row to remove.
+    """
+    lines = []
+    seen = set()
+    changed = False
+    if record_path.exists():
+        for line in record_path.read_text().splitlines():
+            if not line.strip():
+                continue
+            path0 = line.split(",", 1)[0]
+            if path0 in seen:
+                # Drop a duplicate row; rewriting the file removes it.
+                changed = True
+                continue
+            seen.add(path0)
+            lines.append(line)
+    additions = [n for n in names if n not in seen]
+    if not additions and not changed:
+        return
+    for n in additions:
+        lines.append(f"{n},,")
+    record_path.write_text("\n".join(lines) + "\n", newline="\n")
+
+
+def _record_name(site_lib_path: Path, devel_py_pkg_path: Path, relpath: str) -> str:
+    """Site-packages-relative RECORD path for a materialized devel link."""
+    return (devel_py_pkg_path / relpath).relative_to(site_lib_path).as_posix()
+
+
+def _reconcile_device_links(
+    site_lib_path: Path, devel_py_pkg_path: Path, expected_version: str
+) -> int:
+    """Mirror per-ISA device files into the expanded devel tree.
+
+    Each installed `rocm-sdk-device-*` wheel ships a `.devel_links/<arch>.json`
+    manifest listing (relpath, target) pairs. For each entry we hardlink the
+    device file from the rocm-sdk-libraries overlay into the devel platform dir
+    and record the new path in that device wheel's RECORD so that
+    `pip uninstall rocm-sdk-device-<arch>` removes it.
+
+    Idempotent and safe to call on every `get_devel_root()`: links already in
+    place are left untouched and add nothing to RECORD. Returns the number of
+    links created during this call.
+    """
+    plans = _discover_device_link_plans(site_lib_path, expected_version)
+    if not plans:
+        return 0
+
+    # Fast path: skip the lock and any RECORD rewrite only when every device file
+    # is already a correct hardlink AND its wheel's RECORD cleanly owns every
+    # link (present, no duplicates). The RECORD check matters because a prior run
+    # can be interrupted after creating the hardlink but before writing RECORD;
+    # that must still be repaired (otherwise `pip uninstall` would not prune the
+    # orphaned link).
+    if all(
+        _devel_link_ok(devel_py_pkg_path / link["relpath"], link["target"])
+        for _record_path, links in plans
+        for link in links
+    ) and all(
+        _record_has_entries(
+            record_path,
+            [
+                _record_name(site_lib_path, devel_py_pkg_path, link["relpath"])
+                for link in links
+            ],
+        )
+        for record_path, links in plans
+    ):
+        return 0
+
+    lock_path = devel_py_pkg_path / ".devel_reconcile.lock"
+    with open(lock_path, "a") as lock_file:
+        file_lock = FileLock(lock_file)
+        try:
+            created = 0
+            for record_path, links in plans:
+                recorded_names = []
+                for link in links:
+                    relpath = link["relpath"]
+                    dest_path = devel_py_pkg_path / relpath
+                    recorded_names.append(
+                        _record_name(site_lib_path, devel_py_pkg_path, relpath)
+                    )
+                    if _devel_link_ok(dest_path, link["target"]):
+                        continue
+                    # Create the parent first so the relative ".." target can be
+                    # resolved through it (the OS cannot traverse a missing dir).
+                    dest_path.parent.mkdir(parents=True, exist_ok=True)
+                    hardlink_target = dest_path.parent / link["target"]
+                    if not hardlink_target.is_file():
+                        # The target ships in the same wheel as this manifest, so
+                        # it should exist; skip defensively if it somehow does not.
+                        continue
+                    if dest_path.exists() or dest_path.is_symlink():
+                        dest_path.unlink()
+                    dest_path.hardlink_to(hardlink_target)
+                    created += 1
+                _ensure_record_entries(record_path, recorded_names)
+            return created
+        finally:
+            file_lock.unlock()
 
 
 def _lock_and_expand(

--- a/build_tools/tests/devel_reconcile_test.py
+++ b/build_tools/tests/devel_reconcile_test.py
@@ -1,0 +1,280 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for rocm_sdk._devel._reconcile_device_links().
+
+These exercise the install-time reconcile that mirrors per-ISA device files
+(.kpack archives, kernel DBs, per-arch .so) from the rocm-sdk-libraries overlay
+into the expanded rocm-sdk-devel tree, driven by each installed
+`rocm-sdk-device-*` wheel's `_devel_links` manifest.
+
+The reconcile is unit-tested against a synthetic site-packages directory: fake
+`.dist-info` directories (METADATA + RECORD) are created so importlib.metadata
+discovers them via `distributions(path=[site])`, alongside a libraries overlay
+holding the real device files and the manifests.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path, PurePosixPath
+
+# Import the runtime module straight from the package template source tree.
+ROCM_SDK_SRC = (
+    Path(__file__).resolve().parent.parent
+    / "packaging"
+    / "python"
+    / "templates"
+    / "rocm"
+    / "src"
+)
+sys.path.insert(0, os.fspath(ROCM_SDK_SRC))
+
+from rocm_sdk import _devel  # noqa: E402
+
+
+VERSION = "0.0.1.test"
+LIBS_NAME = "_rocm_sdk_libraries_test"
+DEVEL_NAME = "_rocm_sdk_devel_test"
+
+
+def _target_for(relpath: str) -> str:
+    """Relative hardlink target from the devel tree into the libraries overlay."""
+    n = len(PurePosixPath(relpath).parts)
+    return "/".join([".."] * n + [LIBS_NAME, relpath])
+
+
+class ReconcileDeviceLinksTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.site = Path(self._tmp.name)
+        # The expanded (generic) devel platform dir must already exist.
+        self.devel_dir = self.site / DEVEL_NAME
+        self.devel_dir.mkdir(parents=True)
+        (self.devel_dir / "__init__.py").touch()
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    # ----- helpers --------------------------------------------------------
+
+    def _add_device_wheel(
+        self, target_family: str, files: dict[str, str], version: str = VERSION
+    ):
+        """Materialize an installed device wheel into the synthetic site-packages.
+
+        Writes the device files into the libraries overlay, a `_devel_links`
+        manifest, and a `.dist-info` with METADATA + RECORD listing all of them.
+        """
+        # Device files overlay into the libraries package dir.
+        for relpath, content in files.items():
+            p = self.site / LIBS_NAME / relpath
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content)
+
+        # Manifest, named per target so device wheels don't collide.
+        manifest_relpath = f"{LIBS_NAME}/.devel_links/{target_family}.json"
+        manifest = {
+            "version": version,
+            "links": [
+                {"relpath": relpath, "target": _target_for(relpath)}
+                for relpath in files
+            ],
+        }
+        manifest_path = self.site / manifest_relpath
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(manifest))
+
+        # .dist-info with METADATA and a RECORD listing the shipped files.
+        dist_info = self.site / f"rocm_sdk_device_{target_family}-{version}.dist-info"
+        dist_info.mkdir(parents=True, exist_ok=True)
+        (dist_info / "METADATA").write_text(
+            "Metadata-Version: 2.1\n"
+            f"Name: rocm-sdk-device-{target_family}\n"
+            f"Version: {version}\n"
+        )
+        record_lines = [f"{LIBS_NAME}/{r},," for r in files]
+        record_lines.append(f"{manifest_relpath},,")
+        record_lines.append(
+            f"rocm_sdk_device_{target_family}-{version}.dist-info/METADATA,,"
+        )
+        record_lines.append(
+            f"rocm_sdk_device_{target_family}-{version}.dist-info/RECORD,,"
+        )
+        (dist_info / "RECORD").write_text("\n".join(record_lines) + "\n")
+        return dist_info / "RECORD"
+
+    def _record_paths(self, record_path: Path) -> list[str]:
+        return [
+            line.split(",", 1)[0]
+            for line in record_path.read_text().splitlines()
+            if line.strip()
+        ]
+
+    def _reconcile(self) -> int:
+        return _devel._reconcile_device_links(self.site, self.devel_dir, VERSION)
+
+    # ----- tests ----------------------------------------------------------
+
+    def test_links_created_and_recorded(self):
+        record = self._add_device_wheel(
+            "gfx942",
+            {
+                ".kpack/blas_lib_gfx942.kpack": "kpack data",
+                "lib/rocblas/library/Foo_gfx942.co": "kernel object",
+            },
+        )
+
+        created = self._reconcile()
+        self.assertEqual(created, 2)
+
+        for relpath in (
+            ".kpack/blas_lib_gfx942.kpack",
+            "lib/rocblas/library/Foo_gfx942.co",
+        ):
+            devel_file = self.devel_dir / relpath
+            libs_file = self.site / LIBS_NAME / relpath
+            self.assertTrue(devel_file.is_file(), f"{relpath} not linked into devel")
+            self.assertTrue(
+                devel_file.samefile(libs_file),
+                f"{relpath} must be a hardlink to the libraries overlay file",
+            )
+            # The created devel path must be recorded in the device wheel RECORD
+            # so `pip uninstall` removes it.
+            self.assertIn(f"{DEVEL_NAME}/{relpath}", self._record_paths(record))
+
+    def test_idempotent_no_duplicate_records(self):
+        record = self._add_device_wheel(
+            "gfx942", {".kpack/blas_lib_gfx942.kpack": "kpack data"}
+        )
+
+        self.assertEqual(self._reconcile(), 1)
+        before = record.read_text()
+        # Second run creates nothing new and must not duplicate RECORD lines.
+        self.assertEqual(self._reconcile(), 0)
+        after = record.read_text()
+        self.assertEqual(before, after)
+        paths = self._record_paths(record)
+        self.assertEqual(len(paths), len(set(paths)), "duplicate RECORD entries")
+
+    def test_second_arch_added_later(self):
+        self._add_device_wheel(
+            "gfx950", {".kpack/blas_lib_gfx950.kpack": "gfx950 kpack"}
+        )
+        self.assertEqual(self._reconcile(), 1)
+
+        # gfx942 installed afterwards: re-running reconcile links only gfx942.
+        self._add_device_wheel(
+            "gfx942", {".kpack/blas_lib_gfx942.kpack": "gfx942 kpack"}
+        )
+        self.assertEqual(self._reconcile(), 1)
+
+        self.assertTrue((self.devel_dir / ".kpack/blas_lib_gfx950.kpack").is_file())
+        self.assertTrue((self.devel_dir / ".kpack/blas_lib_gfx942.kpack").is_file())
+
+    def test_version_mismatch_skipped(self):
+        self._add_device_wheel(
+            "gfx942",
+            {".kpack/blas_lib_gfx942.kpack": "kpack data"},
+            version="9.9.9",
+        )
+        # Device wheel version does not match the SDK version -> skip entirely.
+        self.assertEqual(self._reconcile(), 0)
+        self.assertFalse((self.devel_dir / ".kpack/blas_lib_gfx942.kpack").exists())
+
+    def test_prune_semantics_record_lists_links(self):
+        record = self._add_device_wheel(
+            "gfx942", {".kpack/blas_lib_gfx942.kpack": "kpack data"}
+        )
+        self._reconcile()
+
+        # Simulate `pip uninstall` by removing every path the RECORD owns.
+        for rel in self._record_paths(record):
+            p = self.site / rel
+            if p.is_file():
+                p.unlink()
+
+        self.assertFalse(
+            (self.devel_dir / ".kpack/blas_lib_gfx942.kpack").exists(),
+            "devel link must be RECORD-owned so pip uninstall removes it",
+        )
+
+    def test_record_repaired_when_link_exists_but_unrecorded(self):
+        # Simulate an interrupted prior run: the hardlink was created but RECORD
+        # was never updated. The fast path must not short-circuit on link
+        # presence alone - it must repair the missing RECORD entry.
+        record = self._add_device_wheel(
+            "gfx942", {".kpack/blas_lib_gfx942.kpack": "kpack data"}
+        )
+        relpath = ".kpack/blas_lib_gfx942.kpack"
+        rec_name = f"{DEVEL_NAME}/{relpath}"
+        dest = self.devel_dir / relpath
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        os.link(self.site / LIBS_NAME / relpath, dest)
+        self.assertNotIn(rec_name, self._record_paths(record))
+
+        self.assertEqual(self._reconcile(), 0)  # no new links, only RECORD repair
+        paths = self._record_paths(record)
+        self.assertIn(rec_name, paths)
+        self.assertEqual(len(paths), len(set(paths)), "duplicate RECORD entries")
+
+    def test_existing_duplicate_record_entry_is_removed(self):
+        # A duplicate RECORD row (e.g. from a botched prior write) must be
+        # repaired even when there is nothing new to link.
+        relpath = ".kpack/blas_lib_gfx942.kpack"
+        record = self._add_device_wheel("gfx942", {relpath: "kpack data"})
+        self.assertEqual(self._reconcile(), 1)
+
+        record_name = f"{DEVEL_NAME}/{relpath}"
+        with record.open("a") as f:
+            f.write(f"{record_name},,\n")
+        self.assertEqual(self._record_paths(record).count(record_name), 2)
+
+        self.assertEqual(self._reconcile(), 0)
+        self.assertEqual(self._record_paths(record).count(record_name), 1)
+
+    def test_symlink_dest_replaced_with_hardlink(self):
+        # A symlink that resolves to the right file must still be replaced by a
+        # true hardlink (the reconciler guarantees hardlinks).
+        record = self._add_device_wheel(
+            "gfx942", {".kpack/blas_lib_gfx942.kpack": "kpack data"}
+        )
+        relpath = ".kpack/blas_lib_gfx942.kpack"
+        dest = self.devel_dir / relpath
+        src = self.site / LIBS_NAME / relpath
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            dest.symlink_to(os.path.relpath(src, dest.parent))
+        except OSError as e:
+            self.skipTest(f"cannot create symlink on this platform: {e}")
+        self.assertTrue(dest.is_symlink())
+
+        self._reconcile()
+        self.assertFalse(dest.is_symlink(), "symlink dest must be replaced")
+        self.assertTrue(
+            dest.samefile(src), "dest must be a hardlink to the libraries file"
+        )
+        self.assertIn(f"{DEVEL_NAME}/{relpath}", self._record_paths(record))
+
+    def test_stale_file_at_dest_is_overwritten(self):
+        # Policy: manifest-driven device relpaths are authoritative, so a stale
+        # unrelated file at a device relpath is overwritten with the correct
+        # hardlink. (Device relpaths are arch-specific and assumed collision-free
+        # with generic devel content.)
+        self._add_device_wheel("gfx942", {".kpack/blas_lib_gfx942.kpack": "real kpack"})
+        relpath = ".kpack/blas_lib_gfx942.kpack"
+        dest = self.devel_dir / relpath
+        src = self.site / LIBS_NAME / relpath
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text("stale unrelated content")
+        self.assertFalse(dest.samefile(src))
+
+        self._reconcile()
+        self.assertTrue(dest.samefile(src))
+        self.assertEqual(dest.read_text(), "real kpack")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -9,6 +9,7 @@ These tests cover:
   - params.populated_packages: registration and cross-package search helpers
 """
 
+import json
 import os
 import tempfile
 import unittest
@@ -524,6 +525,52 @@ class DevicePackagingTest(TmpDirTestCase):
         self.assertTrue(
             (platform_dir / "lib" / "rocblas" / "library" / "Foo_gfx942.co").exists()
         )
+
+    def test_populate_device_files_emits_devel_links_manifest(self):
+        """Device wheel must ship a `_devel_links` manifest mapping each device
+        file to its relative hardlink target into the libraries overlay dir.
+
+        This manifest is what `rocm-sdk init` consumes to mirror per-ISA device
+        files (.kpack/.co/.dat/...) into the generic rocm-sdk-devel tree.
+        """
+        artifact_dir = self._setup_kpack_split_artifacts()
+        params = self._make_params(artifact_dir, kpack_split=True)
+
+        dev = PopulatedDistPackage(
+            params, logical_name="device", target_family="gfx942"
+        )
+        dev.populate_device_files(
+            params.filter_artifacts(
+                lambda an: an.name == "blas"
+                and an.component == "lib"
+                and an.target_family == "gfx942"
+            )
+        )
+
+        libs_name = dev._platform_dir.name
+        manifest_path = dev._platform_dir / ".devel_links" / "gfx942.json"
+        self.assertTrue(
+            manifest_path.is_file(),
+            "device wheel must emit a .devel_links/<target>.json manifest",
+        )
+
+        data = json.loads(manifest_path.read_text())
+        self.assertEqual(data["version"], "0.0.1.test")
+        links = {entry["relpath"]: entry["target"] for entry in data["links"]}
+
+        # Every device file must have an entry with a relative target that
+        # backtracks out of the devel tree and into the libraries overlay.
+        self.assertEqual(
+            links[".kpack/blas_lib_gfx942.kpack"],
+            f"../../{libs_name}/.kpack/blas_lib_gfx942.kpack",
+        )
+        self.assertEqual(
+            links["lib/rocblas/library/Foo_gfx942.co"],
+            f"../../../../{libs_name}/lib/rocblas/library/Foo_gfx942.co",
+        )
+
+        # The manifest must not list itself as a device file to link.
+        self.assertNotIn(".devel_links/gfx942.json", links)
 
     def test_device_platform_dir_overlays_libraries(self):
         """Device package platform dir must match libraries package platform dir name."""

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -14,18 +14,15 @@ We generate the following types of packages:
   evaluated at the point of install, allowing it to perform some selection logic
   to detect dependencies and needs. Most other packages are installed by
   asking to install extras of this one (i.e. `rocm[libraries]`, etc).
-
   - The `rocm` package provides the `rocm-sdk` tool.
   - The `rocm` package uses the `import rocm_sdk` Python namespace as we do
     not want a barename `rocm`.
-
 - Runtime packages: Most packages are runtime packages. These are wheel files
   that are ready to be expanded directly into a site-lib directory. They contain
   only the minimal set of files needed to run. Critically, they do not contain
   symlinks (instead, only SONAME libraries are included, and any executable
   symlinks are emitted by dynamically compiling an executable that can execle
   a relative binary).
-
 - Device packages: When kpack artifact splitting is enabled
   (`KPACK_SPLIT_ARTIFACTS` flag in `therock_manifest.json`), per-ISA device
   wheels (`rocm-sdk-device-{target}`) are produced alongside an arch-neutral
@@ -35,7 +32,6 @@ We generate the following types of packages:
   site-packages. Each device wheel declares `Requires-Dist` on the matching
   version of `rocm-sdk-libraries`. Users install only the device wheels for
   their GPU target(s).
-
 - Devel package: The `rocm-sdk-devel` package is the catch-all for everything.
   For any file already populated in a runtime package, it will include it as
   a relative symlink in the tarball. During extraction, file symlinks are
@@ -45,17 +41,6 @@ We generate the following types of packages:
   wheel file, the platform contents are stored in a `_devel.tar` or `_devel.tar.xz`
   file. The installed package is extended in response to requesting a path to it
   via the `rocm-sdk` tool.
-
-  In kpack-split mode the devel tree is arch-neutral and does not itself contain
-  per-ISA device files. Instead, each installed `rocm-sdk-device-{target}` wheel
-  carries a manifest, and `rocm-sdk init` (which also runs on the first use of a
-  devel tool such as `hipcc`) hardlinks that wheel's device files from
-  `rocm-sdk-libraries` into the devel tree, recording them in the device wheel's
-  `RECORD` so `pip uninstall` removes them. Because the compiler trampolines only
-  trigger this on the first expansion, **after installing or removing a
-  `rocm-sdk-device-*` wheel into an already-initialized environment, run
-  `rocm-sdk init` (or any `rocm-sdk path`) to refresh the device files in the
-  devel tree.**
 
 ### Legacy vs kpack-split packaging modes
 
@@ -71,6 +56,16 @@ The packaging pipeline supports two modes, selected automatically based on the
   via separate `rocm-sdk-device-{target}` wheels, one per GFX ISA target.
   The devel package is also arch-neutral and excludes test binaries (which
   require device code to run).
+
+In kpack-split mode the arch-neutral `rocm-sdk-devel` tree does not itself contain
+per-ISA device files. Each installed `rocm-sdk-device-{target}` wheel ships a
+manifest, and `rocm-sdk init` - which also runs on the first use of a devel tool
+such as `hipcc` - hardlinks that wheel's device files from `rocm-sdk-libraries`
+into the devel tree, recording them in the device wheel's `RECORD` so
+`pip uninstall` removes them. Because the compiler trampolines only trigger this
+on the first expansion, after installing or removing a `rocm-sdk-device-*` wheel
+in an already-initialized environment, re-run `rocm-sdk init` or `rocm-sdk test`
+to refresh the device files in the devel tree.
 
 It is expected that all packages are installed in the same site-lib, as they use
 relative symlinks and RPATHs that cross the top-level package boundary. The

--- a/docs/packaging/python_packaging.md
+++ b/docs/packaging/python_packaging.md
@@ -14,15 +14,18 @@ We generate the following types of packages:
   evaluated at the point of install, allowing it to perform some selection logic
   to detect dependencies and needs. Most other packages are installed by
   asking to install extras of this one (i.e. `rocm[libraries]`, etc).
+
   - The `rocm` package provides the `rocm-sdk` tool.
   - The `rocm` package uses the `import rocm_sdk` Python namespace as we do
     not want a barename `rocm`.
+
 - Runtime packages: Most packages are runtime packages. These are wheel files
   that are ready to be expanded directly into a site-lib directory. They contain
   only the minimal set of files needed to run. Critically, they do not contain
   symlinks (instead, only SONAME libraries are included, and any executable
   symlinks are emitted by dynamically compiling an executable that can execle
   a relative binary).
+
 - Device packages: When kpack artifact splitting is enabled
   (`KPACK_SPLIT_ARTIFACTS` flag in `therock_manifest.json`), per-ISA device
   wheels (`rocm-sdk-device-{target}`) are produced alongside an arch-neutral
@@ -32,6 +35,7 @@ We generate the following types of packages:
   site-packages. Each device wheel declares `Requires-Dist` on the matching
   version of `rocm-sdk-libraries`. Users install only the device wheels for
   their GPU target(s).
+
 - Devel package: The `rocm-sdk-devel` package is the catch-all for everything.
   For any file already populated in a runtime package, it will include it as
   a relative symlink in the tarball. During extraction, file symlinks are
@@ -41,6 +45,17 @@ We generate the following types of packages:
   wheel file, the platform contents are stored in a `_devel.tar` or `_devel.tar.xz`
   file. The installed package is extended in response to requesting a path to it
   via the `rocm-sdk` tool.
+
+  In kpack-split mode the devel tree is arch-neutral and does not itself contain
+  per-ISA device files. Instead, each installed `rocm-sdk-device-{target}` wheel
+  carries a manifest, and `rocm-sdk init` (which also runs on the first use of a
+  devel tool such as `hipcc`) hardlinks that wheel's device files from
+  `rocm-sdk-libraries` into the devel tree, recording them in the device wheel's
+  `RECORD` so `pip uninstall` removes them. Because the compiler trampolines only
+  trigger this on the first expansion, **after installing or removing a
+  `rocm-sdk-device-*` wheel into an already-initialized environment, run
+  `rocm-sdk init` (or any `rocm-sdk path`) to refresh the device files in the
+  devel tree.**
 
 ### Legacy vs kpack-split packaging modes
 


### PR DESCRIPTION
## Motivation
In kpack-split mode rocm-sdk-devel is a single generic wheel
(target_family=None), so _devel_artifact_filter dropped every per-ISA
artifact. The per-ISA device files (.kpack archives, .co/.dat/.hsaco
kernels, MIOpen DBs, per-arch .so) were therefore never linked into the
_rocm_sdk_devel tree, while host .so libraries (from generic artifacts)
were - an asymmetry that left devel incomplete for development against a
specific GPU.

## Technical Details
Each rocm-sdk-device-<arch> wheel now carries its own devel-link
manifest and devel expansion materializes it:

- populate_device_files emits .devel_links/<target_family>.json mapping
  each device file to its relative hardlink target into the
  rocm-sdk-libraries overlay. The device setup.py ships it unchanged
  (its package-data glob already covers the platform dir).
- _reconcile_device_links, run by get_devel_root on every call (so on
  rocm-sdk init / path), enumerates installed rocm-sdk-device-* wheels,
  hardlinks each manifest entry from the libraries overlay into
  _rocm_sdk_devel, and records the new path in that wheel's RECORD so
  pip uninstall prunes it. It is idempotent and version-locked.

Wheels have no install hook, so a newly installed device wheel is
linked on the next devel-root access; removal is automatic via pip.
Per-file hardlinks are used because a directory cannot be hardlinked
and a directory symlink would reintroduce the Windows privilege problem
that the symlink-to-hardlink conversion exists to avoid.

Reconcile is hardened against partial/duplicate state:

- _devel_link_ok rejects symlink destinations so they are always
  replaced with true hardlinks.
- The fast path short-circuits only when every link is a correct
  hardlink and cleanly recorded in its wheel's RECORD, repairing an
  interrupted prior run (hardlink created but RECORD write lost) that
  would otherwise leave a link pip uninstall cannot prune.
- _record_has_entries detects duplicate RECORD rows and
  _ensure_record_entries rewrites to drop them.

## Test Plan
- build_tools/tests: py_packaging_test.py (manifest emission) and new
  devel_reconcile_test.py (link, idempotent, add-arch, version-skip,
  prune, RECORD repair, duplicate-row removal, symlink replacement,
  stale-file overwrite).
- E2E: built nightly wheels (rockrel run 27109338630, gfx942+gfx950)
  and installed into a fresh venv.

## Test Result
- build_tools/tests: 537 passed, 4 skipped; pre-commit clean.
- E2E: device wheels ship the manifest (1631 gfx942 / 992 gfx950
  links); rocm-sdk init hardlinks all into _rocm_sdk_devel and records
  them; re-init idempotent; adding gfx950 links it without touching
  gfx942; pip uninstall removes exactly the arch's links; no
  device-reconcile dangling links.

Co-Authored-By: Claude <noreply@anthropic.com>
