### PR TITLE
[CI] Dispatch full PyTorch tests per-ref via build manifests (follow-up to #4499)

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -77,6 +77,12 @@ on:
         description: "Compiler cache type ('none', 'sccache', or 'ccache')"
         type: string
         default: "sccache"
+      run_full_pytorch_tests:
+        description: >-
+          Dispatch the full PyTorch test suite after a successful build.
+          Only takes effect for nightly gfx94X-dcgpu Python 3.12 builds.
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -139,6 +145,12 @@ on:
           - sccache
           - ccache
         default: sccache
+      run_full_pytorch_tests:
+        description: >-
+          Dispatch the full PyTorch test suite after a successful build.
+          Only takes effect for nightly gfx94X-dcgpu Python 3.12 builds.
+        type: boolean
+        default: false
 
 run-name: "Build Multi-Arch Linux PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref || 'manifest URL' }})"
 
@@ -453,3 +465,56 @@ jobs:
       multi_arch: true
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref }}
+
+  # Dispatch the full PyTorch test suite for this exact build. Because this
+  # workflow builds a single (python_version, pytorch_git_ref), the build job's
+  # torch_version output is unambiguous and only this build's success gates the
+  # dispatch -- a failure for one ref no longer skips testing the others (#5777).
+  # Scoped to nightly gfx94X-dcgpu Python 3.12 builds for now.
+  dispatch_pytorch_wheels_full_test:
+    name: Dispatch PyTorch Full Test | torch ${{ inputs.pytorch_git_ref }}
+    if: >-
+      ${{
+        inputs.run_full_pytorch_tests &&
+        inputs.release_type == 'nightly' &&
+        inputs.python_version == '3.12' &&
+        contains(inputs.amdgpu_families, 'gfx94X-dcgpu')
+      }}
+    needs: [build_pytorch_wheels]
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
+    env:
+      PYTORCH_GIT_REF: ${{ inputs.pytorch_git_ref }}
+    steps:
+      - name: Check full test cadence
+        id: cadence
+        # Release branches test daily; the nightly branch tests weekly (Sunday).
+        run: |
+          if [ "${PYTORCH_GIT_REF}" != "nightly" ] || [ "$(date -u +%u)" = "7" ]; then
+            echo "dispatch=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dispatch=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Dispatch full PyTorch test workflow
+        if: ${{ steps.cadence.outputs.dispatch == 'true' }}
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
+        with:
+          workflow: test_pytorch_wheels_full.yml
+          inputs: |
+            { "amdgpu_family": "gfx94X-dcgpu",
+              "test_runs_on": "linux-gfx942-1gpu-ossci-rocm",
+              "test_runs_on_multi_gpu": "linux-gfx942-8gpu-ossci-rocm",
+              "package_index_url": "${{ needs.build_pytorch_wheels.outputs.package_index_url }}",
+              "python_version": "${{ inputs.python_version }}",
+              "torch_version": "${{ needs.build_pytorch_wheels.outputs.torch_version }}",
+              "pytorch_git_ref": "${{ inputs.pytorch_git_ref }}",
+              "pytorch_git_repo": "${{ inputs.pytorch_git_ref == 'nightly' && 'pytorch/pytorch' || 'ROCm/pytorch' }}",
+              "test_configs": "default distributed inductor",
+              "tests_to_include": "",
+              "multi_arch": true,
+              "repository": "${{ inputs.repository || github.repository }}",
+              "ref": "${{ inputs.ref }}"
+            }

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -134,6 +134,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Granted so the reusable build workflow's dispatch_pytorch_wheels_full_test
+      # job can trigger the full test workflow (a reusable workflow's job cannot
+      # request more permissions than its caller grants).
+      actions: write
     uses: ./.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
@@ -145,101 +149,7 @@ jobs:
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref }}
       cache_type: ${{ inputs.cache_type }}
-
-  dispatch_pytorch_wheels_full_test:
-    name: Dispatch PyTorch Full Test | gfx94X-dcgpu | torch ${{ matrix.pytorch_git_ref }}
-    # Existing rockrel wrappers do not pass run_full_pytorch_tests, so this
-    # remains a no-op until the companion rockrel wrapper PR enables the flag
-    # and provides test_pytorch_wheels_full.yml in that repository.
-    if: >-
-      ${{
-        inputs.run_full_pytorch_tests &&
-        inputs.release_type == 'nightly' &&
-        needs.build_pytorch_wheels.result == 'success'
-      }}
-    needs: [build_pytorch_wheels]
-    runs-on: ubuntu-24.04
-    permissions:
-      actions: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - pytorch_git_ref: release/2.9
-            pytorch_git_repo: ROCm/pytorch
-            torch_package: "torch==2.9.*"
-            dispatch_on: daily
-          - pytorch_git_ref: release/2.10
-            pytorch_git_repo: ROCm/pytorch
-            torch_package: "torch==2.10.*"
-            dispatch_on: daily
-          - pytorch_git_ref: release/2.11
-            pytorch_git_repo: ROCm/pytorch
-            torch_package: "torch==2.11.*"
-            dispatch_on: daily
-          - pytorch_git_ref: nightly
-            pytorch_git_repo: pytorch/pytorch
-            torch_package: "torch"
-            dispatch_on: sunday
-    env:
-      PACKAGE_INDEX_URL: "https://rocm.nightlies.amd.com/whl-multi-arch/"
-      PYTHON_VERSION: "3.12"
-      TORCH_PACKAGE: ${{ matrix.torch_package }}
-    steps:
-      - name: Check full test cadence
-        id: cadence
-        run: |
-          if [ "${{ matrix.dispatch_on }}" = "daily" ] || [ "$(date -u +%u)" = "7" ]; then
-            echo "dispatch=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "dispatch=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Resolve torch version
-        if: ${{ steps.cadence.outputs.dispatch == 'true' }}
-        id: resolve
-        run: |
-          REPORT_PATH="${RUNNER_TEMP}/torch-install-report.json"
-
-          python -m pip install "${TORCH_PACKAGE}" \
-            --dry-run \
-            --ignore-installed \
-            --no-deps \
-            --only-binary=:all: \
-            --pre \
-            --index-url "${PACKAGE_INDEX_URL}" \
-            --python-version "${PYTHON_VERSION}" \
-            --platform linux_x86_64 \
-            --report "${REPORT_PATH}"
-
-          TORCH_VERSION=$(python -c 'import json, sys; print(json.load(open(sys.argv[1]))["install"][0]["metadata"]["version"])' "${REPORT_PATH}")
-
-          if [ -z "${TORCH_VERSION}" ]; then
-            echo "::error::Failed to resolve ${TORCH_PACKAGE} from ${PACKAGE_INDEX_URL}"
-            exit 1
-          fi
-
-          echo "torch_version=${TORCH_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Resolved torch_version: ${TORCH_VERSION}"
-
-      - name: Dispatch full PyTorch test workflow
-        if: ${{ steps.cadence.outputs.dispatch == 'true' }}
-        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
-        with:
-          workflow: test_pytorch_wheels_full.yml
-          inputs: |
-            { "amdgpu_family": "gfx94X-dcgpu",
-              "test_runs_on": "linux-gfx942-1gpu-ossci-rocm",
-              "test_runs_on_multi_gpu": "linux-gfx942-8gpu-ossci-rocm",
-              "package_index_url": "${{ env.PACKAGE_INDEX_URL }}",
-              "python_version": "3.12",
-              "torch_version": "${{ steps.resolve.outputs.torch_version }}",
-              "pytorch_git_ref": "${{ matrix.pytorch_git_ref }}",
-              "pytorch_git_repo": "${{ matrix.pytorch_git_repo }}",
-              "test_configs": "default distributed inductor",
-              "tests_to_include": "",
-              "multi_arch": true,
-              "repository": "${{ inputs.repository || github.repository }}",
-              "ref": "${{ inputs.ref }}"
-            }
+      # The reusable build workflow dispatches the full PyTorch test suite for
+      # each successfully built (nightly, gfx94X-dcgpu, py3.12) ref using that
+      # build's own torch_version output (#5777).
+      run_full_pytorch_tests: ${{ inputs.run_full_pytorch_tests }}


### PR DESCRIPTION
## Summary
Dispatches the full PyTorch test suite from the **per-ref build workflow** (`multi_arch_build_portable_linux_pytorch_wheels.yml`), next to the existing `test_pytorch_wheels` job, using that build's own `torch_version` output.

Refs #5777. Tracked under #5110.

## Problem
The previous dispatch lived in the orchestrator and:
- Gated on the **aggregate** matrix result, so a single failed build leg skipped the dispatch for **all** refs.
- Re-resolved the version with a loose `torch==X.Y.*` `pip --dry-run`, which can pick up a **stale** wheel from a prior run.

GitHub merges matrix-job outputs across cells (last-cell-wins), so per-ref status/version could not be read from the orchestrator's `build_pytorch_wheels.outputs.*` directly — hence the workarounds above.

## Approach
Per @ScottTodd's review, move the dispatch into the reusable build workflow, which builds a **single `(python_version, pytorch_git_ref)`**:
- New `dispatch_pytorch_wheels_full_test` job runs after `build_pytorch_wheels`, reading `needs.build_pytorch_wheels.outputs.torch_version` / `package_index_url` directly — **no re-resolution**.
- Because the job depends on a single-config build, it only runs when **that** build succeeds, so a failed ref skips **only its own** dispatch.
- Scoped to `run_full_pytorch_tests` + `release_type == 'nightly'` + `python_version == '3.12'` + `gfx94X-dcgpu` built, keeping the daily (release branches) / Sunday (nightly) cadence.
- The orchestrator just forwards `run_full_pytorch_tests` down to the build workflow.

This removes the orchestrator-side aggregate setup job and `collect_pytorch_manifest_versions.py`.

## TODO / follow-ups (tracked in #5857)
- [ ] Teach `configure_pytorch_test_matrix.py` about a **test-type axis (short vs full)** and emit matrix entries along it, instead of the hardcoded `gfx94X` / `py3.12` `if` conditions. This generalizes as full tests expand to e.g. Windows gfx1151 and opt-in Linux gfx950 (@ScottTodd suggestion).
- [ ] Source `test_runs_on` / `test_runs_on_multi_gpu` dynamically from `configure_pytorch_test_matrix.py` (`${{ matrix.test_runs_on }}`) instead of hardcoding `linux-gfx942-*-ossci-rocm`, so the dispatch doesn't go stale if runners migrate away from those labels (@ScottTodd).

## Test plan
- `workflow_dispatch_inputs_test.py`
- Both workflow YAMLs parse.
