### PR TITLE
[hip-tests] increase clr stack size in ASAN runs

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -145,6 +145,8 @@ def setup_env(env):
         if is_asan():
             env["LD_PRELOAD"] = get_asan_lib_path()
             env["HSA_XNACK"] = "1"
+            # Increase stack size of clr threads
+            env["CQ_THREAD_STACK_SIZE"] = "8388608"
             # TODO: enable this when we have symbolizer patch in
             # env["ASAN_SYMBOLIZER_PATH"] = str(Path(THEROCK_BIN_DIR).parent / "lib" / "llvm" / "bin" / "llvm-symbolizer")
     else:


### PR DESCRIPTION
## Motivation

Increase the stack size of clr threads

## Technical Details

Some tests tend to use extra tls space, this increases with ASAN. This helps those test finish to completion without error.

## Test Plan

Existing ASAN test should run fine.

## Test Result

It fixes some tests in hip-tests.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
