### PR TITLE
[ml-libs] Exclude hipDNN python from test artifact

### DIFF
--- a/ml-libs/artifact-hipdnn.toml
+++ b/ml-libs/artifact-hipdnn.toml
@@ -20,8 +20,7 @@ include = [
   "bin/*hipdnn_*_test*",
   "bin/hipdnn/CTestTestfile.cmake",
   "lib/test_plugins/**",
-  "share/hipdnn/python/**/*.py",
-  "share/hipdnn/python/**/*.so",
-  "share/hipdnn/python/**/*.pyd",
-  "share/hipdnn/tests/python/**/*.py",
+]
+exclude = [
+  "share/hipdnn/python/**",
 ]

--- a/ml-libs/artifact-hipdnn.toml
+++ b/ml-libs/artifact-hipdnn.toml
@@ -23,6 +23,8 @@ include = [
 ]
 # Exclude python frontend from the test artifact; ships with a dead CI RPATH
 # and is ABI-locked to cp312. See https://github.com/ROCm/TheRock/issues/5678
+# Needed because single-arch builds don't exclude test artifacts (multi-arch
+# does); remove this once single-arch is removed.
 exclude = [
   "share/hipdnn/python/**",
 ]

--- a/ml-libs/artifact-hipdnn.toml
+++ b/ml-libs/artifact-hipdnn.toml
@@ -21,6 +21,8 @@ include = [
   "bin/hipdnn/CTestTestfile.cmake",
   "lib/test_plugins/**",
 ]
+# Exclude python frontend from the test artifact; ships with a dead CI RPATH
+# and is ABI-locked to cp312. See https://github.com/ROCm/TheRock/issues/5678
 exclude = [
   "share/hipdnn/python/**",
 ]


### PR DESCRIPTION
## Summary
Nightly single-arch is broken because it uses the test artifacts for sharedlib testing

Replace the per-extension python includes in the hipDNN `test` component with a single `exclude = ["share/hipdnn/python/**"]`. The previous include list pulled python artifacts into the test component, which broke the single-arch nightly; excluding the python tree mirrors the `dev` and `lib` components and unblocks the nightly.

## Risk Assessment

Low risk. Artifact-manifest-only change scoped to the hipDNN test component; no product code, build logic, or public API affected.

## Testing Summary

- Manifest change validated by inspection against the existing `dev`/`lib` component exclude patterns.

## Testing Checklist

- [x] Single-arch nightly - Status: Pending
- [x] PR CI - GitHub PR checks - Status: Pending

## Technical Changes

- Removes the `share/hipdnn/python/**/*.{py,so,pyd}` and `share/hipdnn/tests/python/**/*.py` includes from `[components.test."ml-libs/hipDNN/stage"]`.
- Adds `exclude = ["share/hipdnn/python/**"]` to the test component, matching the `dev` and `lib` components.