### PR TITLE
[ci] Update workflow to use internal ubuntu container instead of public

### DIFF
--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -54,7 +54,7 @@ jobs:
     name: Build ${{ inputs.native_package_type }} packages
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
     container:
-      image: ubuntu:24.04
+      image: ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
       options: -v /runner/config:/home/awsconfig/
     outputs:
       package_repository_url: ${{ steps.upload-packages.outputs.package_repository_url }}

--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -88,10 +88,10 @@ jobs:
         run: |
           # Install the needed tools for creating rpm / deb packages
           # Also install tools for creating repo files
-          apt-get update
-          apt-get install -y llvm-20
-          apt-get install -y rpm debhelper-compat build-essential
-          apt-get install -y dpkg-dev createrepo-c
+          sudo apt-get update
+          sudo apt-get install -y llvm-20
+          sudo apt-get install -y rpm debhelper-compat build-essential
+          sudo apt-get install -y dpkg-dev createrepo-c
 
       - name: Fetch Artifacts for all GPU families
         run: |

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -150,8 +150,8 @@ jobs:
           echo "Installing prerequisites for ${{ env.PKG_TYPE }} on container"
 
           if [ "${{ env.PKG_TYPE }}" = "deb" ]; then
-            apt update
-            apt install -y \
+            sudo apt update
+            sudo apt install -y \
               wget \
               curl \
               ca-certificates \
@@ -159,7 +159,7 @@ jobs:
               lsb-release
             if [ "$TEST_TYPE" = "full" ] || [ "$TEST_TYPE" = "comprehensive" ]; then
               echo "Extra OS packages for --test-type full/comprehensive (e.g. rdhc): pciutils, kmod, apt-utils"
-              apt install -y pciutils kmod apt-utils
+              sudo apt install -y pciutils kmod apt-utils
             fi
           elif [[ "${{ inputs.os_profile }}" == sles* ]]; then
             # SLES prerequisites (uses BCI base - zypper)

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -225,7 +225,7 @@ def cmd_extract_gfx_arch(args: argparse.Namespace) -> int:
 # Maps OS profile prefixes to container images (checked in order).
 _OS_PROFILE_TO_IMAGE: list[tuple[tuple[str, ...], str]] = [
     (("sles",), "registry.suse.com/bci/bci-base:16.0"),
-    (("ubuntu", "debian"), "ubuntu:24.04"),
+    (("ubuntu", "debian"), "ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest"),
     ((), "registry.access.redhat.com/ubi10/ubi:10.1"),  # default (e.g. rhel*)
 ]
 
@@ -234,8 +234,8 @@ def get_container_image(os_profile: str) -> str:
     """Return the container image for a given OS profile.
 
     Examples:
-        ubuntu2404  -> ubuntu:24.04
-        debian12    -> ubuntu:24.04
+        ubuntu2404  -> ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
+        debian12    -> ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
         sles16      -> registry.suse.com/bci/bci-base:16.0
         rhel10      -> registry.access.redhat.com/ubi10/ubi:10.1
     """

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -356,7 +356,7 @@ class NativeLinuxPackageInstallTest:
                 # Create keyring directory
                 print(f"\nCreating keyring directory: {keyring_dir}...")
                 subprocess.run(
-                    ["mkdir", "--parents", "--mode=0755", str(keyring_dir)],
+                    ["sudo", "mkdir", "--parents", "--mode=0755", str(keyring_dir)],
                     check=True,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
@@ -365,12 +365,12 @@ class NativeLinuxPackageInstallTest:
                 print(f"[PASS] Created keyring directory: {keyring_dir}")
 
                 # Download, dearmor, and write GPG key using pipeline
-                # wget URL -O - | gpg --dearmor | tee keyring_file > /dev/null
+                # wget URL -O - | gpg --dearmor | sudo tee keyring_file > /dev/null
                 print(f"\nDownloading and importing GPG key from {self.gpg_key_url}...")
                 pipeline_cmd = (
                     f"wget -q -O - {self.gpg_key_url} | "
                     f"gpg --dearmor | "
-                    f"tee {keyring_file} > /dev/null"
+                    f"sudo tee {keyring_file} > /dev/null"
                 )
 
                 subprocess.run(
@@ -383,7 +383,12 @@ class NativeLinuxPackageInstallTest:
                 )
 
                 # Set proper permissions on the keyring file
-                keyring_file.chmod(0o644)
+                subprocess.run(
+                    ["sudo", "chmod", "0644", str(keyring_file)],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
                 print(f"[PASS] GPG key imported to {keyring_file}")
                 return True
 
@@ -432,10 +437,16 @@ class NativeLinuxPackageInstallTest:
             repo_entry = f"deb [arch=amd64 trusted=yes] {self.repo_url} stable main\n"
 
         try:
-            sources_list.write_text(repo_entry, encoding="utf-8")
+            subprocess.run(
+                ["sudo", "tee", str(sources_list)],
+                input=repo_entry.encode(),
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
             print(f"[PASS] Repository added to {sources_list}")
             print(f" {repo_entry.strip()}")
-        except OSError as e:
+        except (OSError, subprocess.CalledProcessError) as e:
             print(f"[FAIL] Failed to add repository: {e}")
             return False
 
@@ -443,7 +454,9 @@ class NativeLinuxPackageInstallTest:
         print("\nUpdating package lists...")
         print("=" * 80)
         try:
-            return_code = _run_streaming(["apt", "update"], APT_UPDATE_TIMEOUT_SEC)
+            return_code = _run_streaming(
+                ["sudo", "apt", "update"], APT_UPDATE_TIMEOUT_SEC
+            )
             if return_code == 0:
                 print("\n[PASS] Package lists updated")
                 return True
@@ -648,7 +661,7 @@ gpgcheck=0
         print(f"\nPackages to install (in order): {self.package_names}")
 
         # Install using apt (packages in list order)
-        cmd = ["apt", "install", "-y"] + self.package_names
+        cmd = ["sudo", "apt", "install", "-y"] + self.package_names
         print(f"\nRunning: {' '.join(cmd)}")
         print("=" * 80)
         print("Installation progress (streaming output):\n")

--- a/build_tools/packaging/linux/setup_python_cmd.sh
+++ b/build_tools/packaging/linux/setup_python_cmd.sh
@@ -101,14 +101,14 @@ install_python_runtime() {
 
     if [[ "$os_profile" == ubuntu* ]] || [[ "$os_profile" == debian* ]]; then
         export DEBIAN_FRONTEND=noninteractive
-        apt-get update -qq >&2
+        sudo apt-get update -qq >&2
         if [[ -n "$PY_MM" ]]; then
-            apt-get install -y --no-install-recommends \
+            sudo apt-get install -y --no-install-recommends \
                 "python${PY_MM}" \
                 "python${PY_MM}-venv" \
                 "python${PY_MM}-pip" >&2
         else
-            apt-get install -y --no-install-recommends \
+            sudo apt-get install -y --no-install-recommends \
                 python3 \
                 python3-venv \
                 python3-pip >&2


### PR DESCRIPTION
Replace ubuntu:24.04 with ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest in the multi-arch build native packages workflow and the container image lookup used by the test native packages install workflow.

## Motivation

We're hitting Docker rate limits o.O [Link per-ISA device files into rocm-sdk-devel by marbre · Pull Request #5778 · ROCm/TheRock](https://github.com/ROCm/TheRock/pull/5778)
```
Starting job container
/usr/bin/docker pull ubuntu:24.04
Error response from daemon: toomanyrequests: You have reached your unauthenticated pull rate limit. [Docker Hub usage and limits](https://www.docker.com/increase-rate-limit)
Warning: Docker pull failed with exit code 1, back off 7.153 seconds before retry.
/usr/bin/docker pull ubuntu:24.04
Error response from daemon: toomanyrequests: You have reached your unauthenticated pull rate limit. [Docker Hub usage and limits](https://www.docker.com/increase-rate-limit)
Warning: Docker pull failed with exit code 1, back off 9.266 seconds before retry.
/usr/bin/docker pull ubuntu:24.04
Error response from daemon: toomanyrequests: You have reached your unauthenticated pull rate limit. [Docker Hub usage and limits](https://www.docker.com/increase-rate-limit)
Error: Docker pull failed with exit code 1

```
## Test Plan

CI testing pass can be treated as pass

