### PR TITLE
[Testing] Pin shipped hipDNN product version via -DHIPDNN_VERSION

### DIFF
--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -160,6 +160,9 @@ if(THEROCK_ENABLE_HIPDNN)
     BACKGROUND_BUILD
     CMAKE_ARGS
       -DHIP_PLATFORM=amd
+      # Pin the shipped hipDNN product version. TheRock is the source of truth
+      # for release builds; the in-repo HIPDNN_VERSION is only a local default.
+      -DHIPDNN_VERSION=0.2.0
       -DROCM_PATH=
       -DROCM_DIR=
       "-DHIP_DNN_SKIP_TESTS=$<NOT:$<BOOL:${THEROCK_BUILD_TESTING}>>"


### PR DESCRIPTION
## Summary

Makes TheRock the source of truth for the shipped hipDNN product version by passing `-DHIPDNN_VERSION` explicitly to the hipDNN subproject. The in-repo hipDNN default is then only used for local/standalone builds. Pairs with [rocm-libraries PR #8330](https://github.com/ROCm/rocm-libraries/pull/8330), which makes hipDNN's `HIPDNN_VERSION` an overridable cache variable.

## Risk Assessment

Low risk. Single-line CMake argument addition to the hipDNN subproject declaration; no other components affected and no behavior change unless hipDNN consumes the variable.

## Testing Summary

- Verified on the rocm-libraries side that hipDNN honors `-DHIPDNN_VERSION` and propagates it to backend/frontend/Python.

## Testing Checklist

- [x] hipDNN override propagation (rocm-libraries) - `cmake -DHIPDNN_VERSION=...` - Status: Passed
- [ ] TheRock build with hipDNN enabled - Status: Not run
- [ ] PR CI - GitHub PR checks - Status: Pending

## Technical Changes

- Adds `-DHIPDNN_VERSION=0.2.0` to the hipDNN subproject `CMAKE_ARGS` in `ml-libs/CMakeLists.txt`, pinning the shipped version at the integration point.