### PR TITLE
Fix device-link discovery against stale importlib.metadata cache

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -226,6 +226,10 @@ def _discover_device_link_plans(site_lib_path: Path, expected_version: str):
     record_path is that wheel's RECORD (so newly materialized devel links can be
     recorded against the wheel that owns the underlying device files).
     """
+    # importlib.metadata caches path scans by directory mtime. On filesystems with
+    # coarse mtime resolution, a device wheel installed immediately after a prior
+    # scan may otherwise be missed.
+    md.MetadataPathFinder.invalidate_caches()
     plans = []
     for dist in md.distributions(path=[str(site_lib_path)]):
         name = dist.metadata["Name"]

--- a/build_tools/tests/devel_reconcile_test.py
+++ b/build_tools/tests/devel_reconcile_test.py
@@ -163,12 +163,16 @@ class ReconcileDeviceLinksTest(unittest.TestCase):
         self._add_device_wheel(
             "gfx950", {".kpack/blas_lib_gfx950.kpack": "gfx950 kpack"}
         )
+        cached_site_mtime = self.site.stat().st_mtime
         self.assertEqual(self._reconcile(), 1)
 
         # gfx942 installed afterwards: re-running reconcile links only gfx942.
         self._add_device_wheel(
             "gfx942", {".kpack/blas_lib_gfx942.kpack": "gfx942 kpack"}
         )
+        # Simulate a filesystem with coarse directory mtime resolution, where
+        # importlib.metadata's path cache would not otherwise notice the new dist.
+        os.utime(self.site, (cached_site_mtime, cached_site_mtime))
         self.assertEqual(self._reconcile(), 1)
 
         self.assertTrue((self.devel_dir / ".kpack/blas_lib_gfx950.kpack").is_file())


### PR DESCRIPTION
## Motivation

importlib.metadata caches site-packages path scans by directory mtime. On filesystems with coarse mtime resolution (seen on Windows CI), a device wheel installed immediately after a prior scan could be missed, so the reconcile would not link the newly added arch into the devel tree.

## Technical Details

Invalidate the metadata path cache in _discover_device_link_plans before enumerating installed rocm-sdk-device-* wheels. The test now forces the coarse-mtime condition with os.utime so it reproduces the failure on all platforms rather than depending on Windows timing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
