### PR TITLE
[ci] Improving multi arch CI for external repos (re-land)

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -56,6 +56,14 @@ on:
         description: "'true' if this is a kpack-split flat build."
         type: string
         default: "false"
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+        default: ""
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       artifact_group:
@@ -113,6 +121,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
 
       - name: Configure Git Identity
         run: |

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -171,9 +171,8 @@ jobs:
           python build_tools/github_actions/determine_version.py \
             --rocm-version ${{ inputs.rocm_version }}
 
-      # Skip sccache for external repos - OIDC trust policy only covers TheRock.
       - name: Configure AWS Credentials for sccache
-        if: ${{ inputs.cache_type == 'sccache' && inputs.repository == '' }}
+        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-region: us-east-1
@@ -204,12 +203,10 @@ jobs:
       # TODO(#4687): Make --pytorch-rocm-arch required here once every
       # caller plumbs the value through and the fallback in
       # build_prod_wheels.py::get_rocm_sdk_targets is removed.
-      # External repos (inputs.repository != '') skip sccache since OIDC
-      # trust policy only covers TheRock repo.
       - name: Build PyTorch wheels
         run: |
           cache_flag=""
-          if [ "${{ inputs.cache_type }}" = "sccache" ] && [ -z "${{ inputs.repository }}" ]; then
+          if [ "${{ inputs.cache_type }}" = "sccache" ]; then
             cache_flag="--use-sccache"
           elif [ "${{ inputs.cache_type }}" = "ccache" ]; then
             cache_flag="--use-ccache"

--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -171,8 +171,9 @@ jobs:
           python build_tools/github_actions/determine_version.py \
             --rocm-version ${{ inputs.rocm_version }}
 
+      # Skip sccache for external repos - OIDC trust policy only covers TheRock.
       - name: Configure AWS Credentials for sccache
-        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}
+        if: ${{ inputs.cache_type == 'sccache' && inputs.repository == '' }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-region: us-east-1
@@ -203,10 +204,12 @@ jobs:
       # TODO(#4687): Make --pytorch-rocm-arch required here once every
       # caller plumbs the value through and the fallback in
       # build_prod_wheels.py::get_rocm_sdk_targets is removed.
+      # External repos (inputs.repository != '') skip sccache since OIDC
+      # trust policy only covers TheRock repo.
       - name: Build PyTorch wheels
         run: |
           cache_flag=""
-          if [ "${{ inputs.cache_type }}" = "sccache" ]; then
+          if [ "${{ inputs.cache_type }}" = "sccache" ] && [ -z "${{ inputs.repository }}" ]; then
             cache_flag="--use-sccache"
           elif [ "${{ inputs.cache_type }}" = "ccache" ]; then
             cache_flag="--use-ccache"

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -55,6 +55,14 @@ on:
         description: "'true' if this is a kpack-split flat build."
         type: string
         default: "false"
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+        default: ""
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       artifact_group:
@@ -114,6 +122,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
 
       - name: Configure Git Identity
         run: |

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -188,9 +188,8 @@ jobs:
           python build_tools/github_actions/determine_version.py \
             --rocm-version ${{ inputs.rocm_version }}
 
-      # Skip sccache for external repos - OIDC trust policy only covers TheRock.
       - name: Configure AWS Credentials for sccache
-        if: ${{ inputs.cache_type == 'sccache' && inputs.repository == '' }}
+        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-region: us-east-1
@@ -225,14 +224,11 @@ jobs:
       # TODO(#4687): Make --pytorch-rocm-arch required here once every
       # caller plumbs the value through and the fallback in
       # build_prod_wheels.py::get_rocm_sdk_targets is removed.
-      #
-      # External repos (inputs.repository != '') skip sccache since OIDC
-      # trust policy only covers TheRock repo.
       - name: Build PyTorch wheels
         shell: cmd
         run: |
           set "CACHE_FLAG="
-          if "${{ inputs.cache_type }}"=="sccache" if "${{ inputs.repository }}"=="" set "CACHE_FLAG=--use-sccache"
+          if "${{ inputs.cache_type }}"=="sccache" set "CACHE_FLAG=--use-sccache"
           if "${{ inputs.cache_type }}"=="ccache" set "CACHE_FLAG=--use-ccache"
 
           set "PYTORCH_ROCM_ARCH_FLAG="

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -188,8 +188,9 @@ jobs:
           python build_tools/github_actions/determine_version.py \
             --rocm-version ${{ inputs.rocm_version }}
 
+      # Skip sccache for external repos - OIDC trust policy only covers TheRock.
       - name: Configure AWS Credentials for sccache
-        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}
+        if: ${{ inputs.cache_type == 'sccache' && inputs.repository == '' }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-region: us-east-1
@@ -224,11 +225,14 @@ jobs:
       # TODO(#4687): Make --pytorch-rocm-arch required here once every
       # caller plumbs the value through and the fallback in
       # build_prod_wheels.py::get_rocm_sdk_targets is removed.
+      #
+      # External repos (inputs.repository != '') skip sccache since OIDC
+      # trust policy only covers TheRock repo.
       - name: Build PyTorch wheels
         shell: cmd
         run: |
           set "CACHE_FLAG="
-          if "${{ inputs.cache_type }}"=="sccache" set "CACHE_FLAG=--use-sccache"
+          if "${{ inputs.cache_type }}"=="sccache" if "${{ inputs.repository }}"=="" set "CACHE_FLAG=--use-sccache"
           if "${{ inputs.cache_type }}"=="ccache" set "CACHE_FLAG=--use-ccache"
 
           set "PYTORCH_ROCM_ARCH_FLAG="

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -148,7 +148,7 @@ jobs:
     uses: ./.github/workflows/multi_arch_build_native_linux_packages.yml
     with:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
-      rocm_version: ${{ inputs.rocm_deb_package_version }}
+      rocm_version: ${{ inputs.rocm_deb_package_version || inputs.rocm_package_version }}
       native_package_type: deb
     permissions:
       contents: read
@@ -161,7 +161,7 @@ jobs:
     uses: ./.github/workflows/multi_arch_build_native_linux_packages.yml
     with:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
-      rocm_version: ${{ inputs.rocm_rpm_package_version }}
+      rocm_version: ${{ inputs.rocm_rpm_package_version || inputs.rocm_package_version }}
       native_package_type: rpm
     permissions:
       contents: read
@@ -284,6 +284,8 @@ jobs:
       kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
       rocm_package_find_links_url: ${{ needs.build_python_packages.outputs.package_find_links_url }}
       rocm_version: ${{ inputs.rocm_package_version }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -57,6 +57,9 @@ jobs:
     steps:
       - name: Checking out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -234,6 +234,8 @@ jobs:
       multiarch_index: true
       package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -187,6 +187,8 @@ jobs:
       os_profile: ubuntu2404
       artifact_group: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       test_type: sanity
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -202,6 +204,8 @@ jobs:
       os_profile: rhel10
       artifact_group: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       test_type: sanity
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -217,6 +221,8 @@ jobs:
       os_profile: sles16
       artifact_group: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       test_type: sanity
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -273,6 +279,8 @@ jobs:
       kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
       container_image_name: ${{ matrix.image.name }}
       container_image_url: ${{ matrix.image.url }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
 
   # Multi-arch PyTorch build: one fat wheel covering every target, then
   # split into a host wheel + per-gfx device wheels via rocm-kpack.

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -54,19 +54,17 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    container:
+      image: python:3.12-slim
+      options: -v /runner/config:/home/awsconfig/
     env:
-      AWS_SHARED_CREDENTIALS_FILE: /runner/config/credentials.ini
+      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
     steps:
       - name: Checking out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
 
       - name: Install artifact manager dependencies
         run: pip install boto3

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -122,6 +122,8 @@ jobs:
       amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       platform: linux
       release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
 
   test_artifacts_per_family:
     needs: [copy_prebuilt_stages, build_multi_arch_stages]

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -155,6 +155,8 @@ jobs:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       rocm_version: ${{ inputs.rocm_deb_package_version || inputs.rocm_package_version }}
       native_package_type: deb
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write
@@ -168,6 +170,8 @@ jobs:
       dist_amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       rocm_version: ${{ inputs.rocm_rpm_package_version || inputs.rocm_package_version }}
       native_package_type: rpm
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -54,6 +54,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      AWS_SHARED_CREDENTIALS_FILE: /runner/config/credentials.ini
     steps:
       - name: Checking out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -54,6 +54,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    # Run in container to access AWS credentials mounted from the host runner.
     container:
       image: python:3.12-slim
       options: -v /runner/config:/home/awsconfig/

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -207,6 +207,8 @@ jobs:
       kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
       rocm_package_find_links_url: ${{ needs.build_python_packages.outputs.package_find_links_url }}
       rocm_version: ${{ inputs.rocm_package_version }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -158,6 +158,8 @@ jobs:
       multiarch_index: true
       package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -119,6 +119,8 @@ jobs:
       amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
       platform: windows
       release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
 
   test_artifacts_per_family:
     needs: [copy_prebuilt_stages, build_multi_arch_stages]

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -56,6 +56,9 @@ jobs:
     steps:
       - name: Checking out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -192,6 +192,8 @@ jobs:
       # Windows runs natively without a container image.
       container_image_name: native
       container_image_url: ""
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
 
   # Multi-arch PyTorch build: one fat wheel covering every target, then
   # split into a host wheel + per-gfx device wheels via rocm-kpack.

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -94,6 +94,12 @@ on:
           and native Linux runners).
         required: true
         type: string
+      repository:
+        description: "Repository to checkout. Defaults to github.repository."
+        type: string
+      ref:
+        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        type: string
 
 permissions:
   contents: read
@@ -125,6 +131,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
 
       # actions/setup-python only has prebuilt binaries for Ubuntu
       - name: Set up Python

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -97,9 +97,11 @@ on:
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
+        default: ""
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
+        default: ""
 
 permissions:
   contents: read


### PR DESCRIPTION
Relanding #5698

As the multi arch CI fails in rocm-libraries from other workflows (such as validate package, python builds, etc), this PR addresses those errors. Also in order for `Copy prebuilt stage artifacts` to work for external, we require IAM role ([errors from sample run](https://github.com/ROCm/rocm-libraries/actions/runs/26469059871/job/77937255846#step:6:597))

external repo tested here: https://github.com/ROCm/rocm-libraries/actions/runs/27375104784
forked test here: https://github.com/ROCm/TheRock/actions/runs/27375409471?pr=5796
normal run working here: https://github.com/ROCm/TheRock/actions/runs/27382744190?pr=5799

This is another iteration as we continue to find and fix errors
