### PR TITLE
Disable rocWMMA for gfx1250 target

### DIFF
--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -243,7 +243,10 @@ therock_add_amdgpu_target(gfx1201 "AMD RX 9070 / XT" FAMILY dgpu-all gfx120X-all
 )
 
 # gfx125X family
-therock_add_amdgpu_target(gfx1250 "AMD Instinct MI450/MI450X/MI455X CDNA" FAMILY dcgpu-all gfx125X-all gfx125X-dcgpu)
+therock_add_amdgpu_target(gfx1250 "AMD Instinct MI450/MI450X/MI455X CDNA" FAMILY dcgpu-all gfx125X-all gfx125X-dcgpu
+  EXCLUDE_TARGET_PROJECTS
+    rocWMMA # https://github.com/ROCm/TheRock/issues/1944
+)
 
 # Optional extension targets (used for out of tree target development).
 include(therock_custom_amdgpu_targets OPTIONAL)

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -350,7 +350,18 @@ if(THEROCK_ENABLE_BLAS)
   add_subdirectory(BLAS)
 endif()
 
-if(THEROCK_ENABLE_ROCWMMA)
+set(_rocwmma_enabled ${THEROCK_ENABLE_ROCWMMA})
+if(_rocwmma_enabled)
+  therock_filter_amdgpu_targets(_rocwmma_targets rocWMMA ${THEROCK_AMDGPU_TARGETS})
+  if(NOT _rocwmma_targets)
+    message(STATUS
+      "rocWMMA: no supported gfx targets remain after filtering "
+      "(THEROCK_AMDGPU_TARGETS='${THEROCK_AMDGPU_TARGETS}'); skipping subproject.")
+    set(_rocwmma_enabled OFF)
+  endif()
+endif()
+
+if(_rocwmma_enabled)
   ##############################################################################
   # rocWMMA
   ##############################################################################
@@ -405,7 +416,7 @@ if(THEROCK_ENABLE_ROCWMMA)
     SUBPROJECT_DEPS
       rocWMMA
   )
-endif(THEROCK_ENABLE_ROCWMMA)
+endif()
 
 if(THEROCK_ENABLE_LIBHIPCXX)
   ##############################################################################


### PR DESCRIPTION
Stacked on #5744. Extracts the rocWMMA target exclusion from #5789 so gfx1250 is not passed to rocWMMA until support exists. Tracking: #1944.