### PR TITLE
Add gfx1154 custom AMDGPU target

### DIFF
--- a/cmake/therock_custom_amdgpu_targets.cmake
+++ b/cmake/therock_custom_amdgpu_targets.cmake
@@ -1,0 +1,8 @@
+# gfx115X family
+therock_add_amdgpu_target(gfx1154 "AMD gfx1154 IGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu
+  EXCLUDE_TARGET_PROJECTS
+    hipSPARSELt # https://github.com/ROCm/TheRock/issues/2042
+    rccl # https://github.com/ROCm/TheRock/issues/150
+    rccl-tests
+    rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
+)


### PR DESCRIPTION
Add gfx1154 (AMD Radeon 8060S) as a custom IGPU target in the gfx115X family. Exclude hipSPARSELt, rccl, rccl-tests, and rocprofiler-compute which are not yet supported.

Depends on rocm-systems gfx1154 runtime support being merged and submodule bumped separately.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
