### PR TITLE
Add amdllvm to `rocm-sdk path --bin` dir.

### DIFF
--- a/base/aux-overlay/CMakeLists.txt
+++ b/base/aux-overlay/CMakeLists.txt
@@ -26,6 +26,7 @@ if(NOT WIN32)
     COMMAND "${CMAKE_COMMAND}" -E create_symlink "../lib/llvm/bin/amdclang-cl" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang-cl"
     COMMAND "${CMAKE_COMMAND}" -E create_symlink "../lib/llvm/bin/amdclang-cpp" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang-cpp"
     COMMAND "${CMAKE_COMMAND}" -E create_symlink "../lib/llvm/bin/amdlld" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdlld"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "../lib/llvm/bin/amdllvm" "${CMAKE_CURRENT_BINARY_DIR}/bin/amdllvm"
     COMMAND "${CMAKE_COMMAND}" -E create_symlink "../lib/llvm/bin/offload-arch" "${CMAKE_CURRENT_BINARY_DIR}/bin/offload-arch"
   )
   # llvm and amdgcn are symlinks to directories; install(FILES) rejects
@@ -46,6 +47,7 @@ if(NOT WIN32)
     "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang-cl"
     "${CMAKE_CURRENT_BINARY_DIR}/bin/amdclang-cpp"
     "${CMAKE_CURRENT_BINARY_DIR}/bin/amdlld"
+    "${CMAKE_CURRENT_BINARY_DIR}/bin/amdllvm"
     "${CMAKE_CURRENT_BINARY_DIR}/bin/offload-arch"
     DESTINATION bin
   )


### PR DESCRIPTION
In pip installed packages, amdllvm was missing from `rocm-sdk path --bin`. amdclang and amdclang++ expected amdllvm to be in the same directory.

Fixes #5726

## Motivation

amdclang when called from `rocm-sdk path --bin` now succeeds.

## Technical Details

Adds missing amdllvm to `rocm-sdk path --bin`.

## Test Plan

I built TheRock pip packaged and installed locally and saw the symlink. Furthermore on #5726 I also provided the following minimal error:

```
$ `rocm-sdk path --bin`/amdclang --version
could not exec path/to/env/lib/python3.12/site-packages/_rocm_sdk_devel/bin/amdllvm: No such file or directory
```

## Test Result

It now succeeds with the locally built and pip installed package:

```
$  `rocm-sdk path --bin`/amdclang --version
AMD clang version 23.0.0git (https://github.com/ROCm/llvm-project.git 52226beb248fcdd136d084307a12207d2fc00220)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /home/eochoalo/code/TheRock/env/lib/python3.12/site-packages/_rocm_sdk_devel/lib/llvm/bin
```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
