### PR TITLE
[CI] Generalize full PyTorch test dispatch beyond Linux gfx942 (#5755)

### DIFF
--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -29,7 +29,7 @@ on:
         type: string
         required: true
       release_type:
-        description: 'Release type; selects the S3 bucket'
+        description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
         type: string
         required: true
       repository:
@@ -70,11 +70,9 @@ on:
         type: string
         required: true
       release_type:
-        description: 'Release type; developer-triggered jobs should use "dev"'
-        type: choice
-        options:
-          - dev
-        default: dev
+        description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
+        type: string
+        required: true
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
@@ -146,8 +144,41 @@ jobs:
       ref: ${{ inputs.ref }}
       cache_type: ${{ inputs.cache_type }}
 
+  setup_full_test_matrix:
+    name: Setup Full PyTorch Test Matrix
+    # Only relevant for scheduled nightly runs that opt into full tests. The
+    # matrix is derived from the requested AMDGPU families so coverage tracks
+    # what was built instead of a single hardcoded family (#5755).
+    if: >-
+      ${{
+        inputs.run_full_pytorch_tests &&
+        inputs.release_type == 'nightly'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      enabled: ${{ steps.matrix.outputs.enabled }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      - name: Generate full test matrix
+        id: matrix
+        run: |
+          python ./build_tools/github_actions/configure_pytorch_test_matrix.py \
+            --build-amdgpu-families "${{ inputs.amdgpu_families }}" \
+            --test-amdgpu-families auto \
+            --platform linux \
+            --include-multi-gpu \
+            --default-test-configs "default distributed inductor"
+
   dispatch_pytorch_wheels_full_test:
-    name: Dispatch PyTorch Full Test | gfx94X-dcgpu | torch ${{ matrix.pytorch_git_ref }}
+    name: Dispatch PyTorch Full Test | ${{ matrix.family.amdgpu_family }} | torch ${{ matrix.pytorch.pytorch_git_ref }}
     # Existing rockrel wrappers do not pass run_full_pytorch_tests, so this
     # remains a no-op until the companion rockrel wrapper PR enables the flag
     # and provides test_pytorch_wheels_full.yml in that repository.
@@ -155,9 +186,10 @@ jobs:
       ${{
         inputs.run_full_pytorch_tests &&
         inputs.release_type == 'nightly' &&
-        needs.build_pytorch_wheels.result == 'success'
+        needs.build_pytorch_wheels.result == 'success' &&
+        needs.setup_full_test_matrix.outputs.enabled == 'true'
       }}
-    needs: [build_pytorch_wheels]
+    needs: [build_pytorch_wheels, setup_full_test_matrix]
     runs-on: ubuntu-24.04
     permissions:
       actions: write
@@ -165,7 +197,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
+        # AMDGPU families resolved from the build inputs; each entry carries its
+        # single-GPU runner, optional multi-GPU runner, and the test configs it
+        # can run (families without a multi-GPU runner drop 'distributed').
+        family: ${{ fromJSON(needs.setup_full_test_matrix.outputs.matrix).include }}
+        pytorch:
           - pytorch_git_ref: release/2.9
             pytorch_git_repo: ROCm/pytorch
             torch_package: "torch==2.9.*"
@@ -185,12 +221,12 @@ jobs:
     env:
       PACKAGE_INDEX_URL: "https://rocm.nightlies.amd.com/whl-multi-arch/"
       PYTHON_VERSION: "3.12"
-      TORCH_PACKAGE: ${{ matrix.torch_package }}
+      TORCH_PACKAGE: ${{ matrix.pytorch.torch_package }}
     steps:
       - name: Check full test cadence
         id: cadence
         run: |
-          if [ "${{ matrix.dispatch_on }}" = "daily" ] || [ "$(date -u +%u)" = "7" ]; then
+          if [ "${{ matrix.pytorch.dispatch_on }}" = "daily" ] || [ "$(date -u +%u)" = "7" ]; then
             echo "dispatch=true" >> "$GITHUB_OUTPUT"
           else
             echo "dispatch=false" >> "$GITHUB_OUTPUT"
@@ -229,15 +265,15 @@ jobs:
         with:
           workflow: test_pytorch_wheels_full.yml
           inputs: |
-            { "amdgpu_family": "gfx94X-dcgpu",
-              "test_runs_on": "linux-gfx942-1gpu-ossci-rocm",
-              "test_runs_on_multi_gpu": "linux-gfx942-8gpu-ossci-rocm",
+            { "amdgpu_family": "${{ matrix.family.amdgpu_family }}",
+              "test_runs_on": "${{ matrix.family.test_runs_on }}",
+              "test_runs_on_multi_gpu": "${{ matrix.family.test_runs_on_multi_gpu }}",
               "package_index_url": "${{ env.PACKAGE_INDEX_URL }}",
               "python_version": "3.12",
               "torch_version": "${{ steps.resolve.outputs.torch_version }}",
-              "pytorch_git_ref": "${{ matrix.pytorch_git_ref }}",
-              "pytorch_git_repo": "${{ matrix.pytorch_git_repo }}",
-              "test_configs": "default distributed inductor",
+              "pytorch_git_ref": "${{ matrix.pytorch.pytorch_git_ref }}",
+              "pytorch_git_repo": "${{ matrix.pytorch.pytorch_git_repo }}",
+              "test_configs": "${{ matrix.family.test_configs }}",
               "tests_to_include": "",
               "multi_arch": true,
               "repository": "${{ inputs.repository || github.repository }}",

--- a/build_tools/github_actions/configure_pytorch_test_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_test_matrix.py
@@ -29,7 +29,7 @@ def split_families(value: str) -> list[str]:
     return list(dict.fromkeys(f.strip() for f in value.split(";") if f.strip()))
 
 
-def find_test_runs_on(*, amdgpu_family: str, platform: str) -> str:
+def _find_platform_info(*, amdgpu_family: str, platform: str) -> dict[str, object]:
     matrix = get_all_families_for_trigger_types(["presubmit", "postsubmit", "nightly"])
     for info_for_key in matrix.values():
         platform_info = info_for_key.get(platform)
@@ -38,15 +38,44 @@ def find_test_runs_on(*, amdgpu_family: str, platform: str) -> str:
 
         family = platform_info["family"]
         if amdgpu_family.lower() == family.lower():
-            return platform_info["test-runs-on"]
+            return platform_info
 
     raise ValueError(f"No {platform} AMDGPU family entry found for {amdgpu_family!r}")
+
+
+def find_test_runs_on(*, amdgpu_family: str, platform: str) -> str:
+    platform_info = _find_platform_info(amdgpu_family=amdgpu_family, platform=platform)
+    return platform_info["test-runs-on"]
+
+
+def find_multi_gpu_runs_on(*, amdgpu_family: str, platform: str) -> str:
+    """Return the multi-GPU runner label for a family, or "" if none exists.
+
+    Only data-center families (e.g. gfx942, gfx950) currently have multi-GPU
+    runner pools; consumer families have single-GPU runners only.
+    """
+    platform_info = _find_platform_info(amdgpu_family=amdgpu_family, platform=platform)
+    return str(platform_info.get("test-runs-on-multi-gpu") or "")
+
+
+def select_test_configs(*, default_test_configs: str, has_multi_gpu: bool) -> str:
+    """Drop multi-GPU-only configs when a family has no multi-GPU runner.
+
+    `distributed` requires more than one GPU, so families without a multi-GPU
+    runner can only run the single-GPU configs.
+    """
+    configs = [c for c in default_test_configs.split() if c]
+    if not has_multi_gpu:
+        configs = [c for c in configs if c != "distributed"]
+    return " ".join(configs)
 
 
 def build_test_matrix(
     *,
     amdgpu_families: list[str],
     platform: str,
+    include_multi_gpu: bool = False,
+    default_test_configs: str = "",
 ) -> dict[str, list[dict[str, str]]]:
     print(f"Requested {platform} AMDGPU families: {amdgpu_families}")
     include: list[dict[str, str]] = []
@@ -62,13 +91,32 @@ def build_test_matrix(
             )
             continue
 
-        print(f"Including {requested_family}: testing on {test_runs_on}")
-        include.append(
-            {
-                "amdgpu_family": requested_family,
-                "test_runs_on": test_runs_on,
-            }
+        entry: dict[str, str] = {
+            "amdgpu_family": requested_family,
+            "test_runs_on": test_runs_on,
+        }
+
+        if include_multi_gpu:
+            multi_gpu_runs_on = find_multi_gpu_runs_on(
+                amdgpu_family=requested_family,
+                platform=platform,
+            )
+            entry["test_runs_on_multi_gpu"] = multi_gpu_runs_on
+            entry["test_configs"] = select_test_configs(
+                default_test_configs=default_test_configs,
+                has_multi_gpu=bool(multi_gpu_runs_on),
+            )
+
+        print(
+            f"Including {requested_family}: testing on {test_runs_on}"
+            + (
+                f" (multi-GPU: {entry['test_runs_on_multi_gpu'] or 'none'}, "
+                f"configs: {entry['test_configs'] or 'none'})"
+                if include_multi_gpu
+                else ""
+            )
         )
+        include.append(entry)
 
     return {"include": include}
 
@@ -103,6 +151,23 @@ def main(argv: list[str]) -> None:
         default=platform_module.system().lower(),
         help="Test platform (default: current system).",
     )
+    parser.add_argument(
+        "--include-multi-gpu",
+        action="store_true",
+        help=(
+            "Also emit 'test_runs_on_multi_gpu' and 'test_configs' per family. "
+            "Families without a multi-GPU runner drop multi-GPU-only configs "
+            "(e.g. 'distributed')."
+        ),
+    )
+    parser.add_argument(
+        "--default-test-configs",
+        default="",
+        help=(
+            "Space-separated test configs to request when --include-multi-gpu "
+            "is set (e.g. 'default distributed inductor')."
+        ),
+    )
     args = parser.parse_args(argv)
 
     built_families = split_families(args.build_amdgpu_families)
@@ -123,6 +188,8 @@ def main(argv: list[str]) -> None:
     matrix = build_test_matrix(
         amdgpu_families=test_amdgpu_families,
         platform=args.platform,
+        include_multi_gpu=args.include_multi_gpu,
+        default_test_configs=args.default_test_configs,
     )
     emit_outputs(matrix)
 

--- a/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_test_matrix_test.py
@@ -35,6 +35,13 @@ FAKE_FAMILY_MATRIX: FamilyMatrix = {
             "test-runs-on": "",
         }
     },
+    "gfxmulti": {
+        "linux": {
+            "family": "gfxmulti-dcgpu",
+            "test-runs-on": "linux-multi-1gpu",
+            "test-runs-on-multi-gpu": "linux-multi-8gpu",
+        },
+    },
 }
 
 
@@ -159,6 +166,84 @@ class ConfigurePyTorchTestMatrixTest(unittest.TestCase):
         outputs = gha_set_output.call_args.args[0]
         self.assertEqual(outputs["enabled"], "false")
         self.assertEqual(json.loads(outputs["matrix"]), {"include": []})
+
+    def test_include_multi_gpu_keeps_distributed_for_multi_gpu_family(self) -> None:
+        with mock.patch.object(
+            m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
+        ):
+            matrix = m.build_test_matrix(
+                amdgpu_families=["gfxmulti-dcgpu"],
+                platform="linux",
+                include_multi_gpu=True,
+                default_test_configs="default distributed inductor",
+            )
+        self.assertEqual(
+            matrix["include"],
+            [
+                {
+                    "amdgpu_family": "gfxmulti-dcgpu",
+                    "test_runs_on": "linux-multi-1gpu",
+                    "test_runs_on_multi_gpu": "linux-multi-8gpu",
+                    "test_configs": "default distributed inductor",
+                }
+            ],
+        )
+
+    def test_include_multi_gpu_drops_distributed_without_multi_gpu(self) -> None:
+        with mock.patch.object(
+            m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
+        ):
+            matrix = m.build_test_matrix(
+                amdgpu_families=["gfxalpha-all"],
+                platform="linux",
+                include_multi_gpu=True,
+                default_test_configs="default distributed inductor",
+            )
+        self.assertEqual(
+            matrix["include"],
+            [
+                {
+                    "amdgpu_family": "gfxalpha-all",
+                    "test_runs_on": "linux-alpha",
+                    "test_runs_on_multi_gpu": "",
+                    "test_configs": "default inductor",
+                }
+            ],
+        )
+
+    def test_select_test_configs_drops_distributed_only(self) -> None:
+        self.assertEqual(
+            m.select_test_configs(
+                default_test_configs="default distributed inductor",
+                has_multi_gpu=False,
+            ),
+            "default inductor",
+        )
+        self.assertEqual(
+            m.select_test_configs(
+                default_test_configs="default distributed inductor",
+                has_multi_gpu=True,
+            ),
+            "default distributed inductor",
+        )
+
+    def test_default_matrix_omits_multi_gpu_fields(self) -> None:
+        with mock.patch.object(
+            m, "get_all_families_for_trigger_types", side_effect=_fake_family_matrix
+        ):
+            matrix = m.build_test_matrix(
+                amdgpu_families=["gfxmulti-dcgpu"],
+                platform="linux",
+            )
+        self.assertEqual(
+            matrix["include"],
+            [
+                {
+                    "amdgpu_family": "gfxmulti-dcgpu",
+                    "test_runs_on": "linux-multi-1gpu",
+                }
+            ],
+        )
 
     def test_real_family_matrix_finds_gfx950_runner(self) -> None:
         matrix = m.build_test_matrix(


### PR DESCRIPTION
## Summary
Generalizes the full PyTorch test dispatch in `multi_arch_release_linux_pytorch_wheels.yml` so it tests every built AMDGPU family that has a runner, instead of the single hardcoded `gfx94X-dcgpu` / `linux-gfx942` configuration.

Closes #5755.

## What changed
- **`build_tools/github_actions/configure_pytorch_test_matrix.py`**: added an opt-in `--include-multi-gpu` mode (with `--default-test-configs`) that, for each requested family, resolves its single-GPU runner and optional multi-GPU runner from `amdgpu_family_matrix`, and emits the `test_configs` that family can run. Families without a multi-GPU runner drop multi-GPU-only configs (`distributed`). The existing output schema used by the per-build test workflows is unchanged — the new fields only appear behind the flag.
- **`.github/workflows/multi_arch_release_linux_pytorch_wheels.yml`**: added a `setup_full_test_matrix` job that generates the family matrix from the `amdgpu_families` input, and reworked `dispatch_pytorch_wheels_full_test` into a **families × pytorch-refs** matrix, passing per-family `amdgpu_family` / `test_runs_on` / `test_runs_on_multi_gpu` / `test_configs`.

## Effect
A nightly run that previously only tested gfx942 now fans out to every built family with a runner (e.g. gfx950, gfx110X, gfx1151, gfx120X, gfx90a, gfx1030, gfx1150), with `distributed` automatically limited to the data-center parts (gfx942/gfx950) that have multi-GPU pools. Families without a runner are skipped, so coverage grows automatically as runners are added to the family matrix.

## Out of scope
- Does not change the aggregate `build_pytorch_wheels.result == 'success'` gate (per-ref status is tracked in #5777).

## Test plan
- `configure_pytorch_test_matrix_test.py` (incl. new multi-GPU / drop-distributed / schema-unchanged cases)
- `workflow_dispatch_inputs_test.py`
- Workflow YAML parses.
