### PR TITLE
[CI] Support dev releases + derive index URL in full PyTorch test dispatch (#5781)

### DIFF
--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -146,13 +146,13 @@ jobs:
 
   setup_full_test_matrix:
     name: Setup Full PyTorch Test Matrix
-    # Only relevant for scheduled nightly runs that opt into full tests. The
-    # matrix is derived from the requested AMDGPU families so coverage tracks
-    # what was built instead of a single hardcoded family (#5755).
+    # Only relevant for scheduled runs that opt into full tests. The matrix is
+    # derived from the requested AMDGPU families so coverage tracks what was
+    # built instead of a single hardcoded family (#5755).
     if: >-
       ${{
         inputs.run_full_pytorch_tests &&
-        inputs.release_type == 'nightly'
+        (inputs.release_type == 'nightly' || inputs.release_type == 'dev')
       }}
     runs-on: ubuntu-24.04
     permissions:
@@ -160,6 +160,7 @@ jobs:
     outputs:
       enabled: ${{ steps.matrix.outputs.enabled }}
       matrix: ${{ steps.matrix.outputs.matrix }}
+      package_index_url: ${{ steps.index_url.outputs.package_index_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -177,6 +178,12 @@ jobs:
             --include-multi-gpu \
             --default-test-configs "default distributed inductor"
 
+      - name: Resolve package index URL
+        id: index_url
+        run: |
+          python ./build_tools/github_actions/multi_arch_release_urls.py \
+            --release-type "${{ inputs.release_type }}"
+
   dispatch_pytorch_wheels_full_test:
     name: Dispatch PyTorch Full Test | ${{ matrix.family.amdgpu_family }} | torch ${{ matrix.pytorch.pytorch_git_ref }}
     # Existing rockrel wrappers do not pass run_full_pytorch_tests, so this
@@ -185,7 +192,7 @@ jobs:
     if: >-
       ${{
         inputs.run_full_pytorch_tests &&
-        inputs.release_type == 'nightly' &&
+        (inputs.release_type == 'nightly' || inputs.release_type == 'dev') &&
         needs.build_pytorch_wheels.result == 'success' &&
         needs.setup_full_test_matrix.outputs.enabled == 'true'
       }}
@@ -219,7 +226,7 @@ jobs:
             torch_package: "torch"
             dispatch_on: sunday
     env:
-      PACKAGE_INDEX_URL: "https://rocm.nightlies.amd.com/whl-multi-arch/"
+      PACKAGE_INDEX_URL: ${{ needs.setup_full_test_matrix.outputs.package_index_url }}
       PYTHON_VERSION: "3.12"
       TORCH_PACKAGE: ${{ matrix.pytorch.torch_package }}
     steps:

--- a/build_tools/github_actions/multi_arch_release_urls.py
+++ b/build_tools/github_actions/multi_arch_release_urls.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Single source of truth for multi-arch release package index URLs.
+
+Maps a release type to the public pip index that serves its multi-arch
+PyTorch wheels. Used both when publishing wheels and when dispatching the
+full test suite so tests install from the same index the wheels were
+published to.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_BUILD_TOOLS_DIR))
+
+from github_actions.github_actions_api import gha_set_output
+
+MULTI_ARCH_INDEX_URLS = {
+    # TODO: Move this release bucket to CDN/index URL mapping into
+    # build_tools/_therock_utils/s3_buckets.py.
+    "dev": "https://rocm.devreleases.amd.com/whl-multi-arch/",
+    "nightly": "https://rocm.nightlies.amd.com/whl-multi-arch/",
+    "prerelease": "https://rocm.prereleases.amd.com/whl-multi-arch/",
+}
+
+
+def get_index_url(release_type: str) -> str:
+    try:
+        return MULTI_ARCH_INDEX_URLS[release_type]
+    except KeyError:
+        raise ValueError(
+            f"Unknown release_type {release_type!r}; expected one of "
+            f"{sorted(MULTI_ARCH_INDEX_URLS)}"
+        )
+
+
+def main(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--release-type",
+        required=True,
+        choices=sorted(MULTI_ARCH_INDEX_URLS),
+        help="Release type whose multi-arch index URL to resolve.",
+    )
+    args = parser.parse_args(argv)
+    url = get_index_url(args.release_type)
+    gha_set_output({"package_index_url": url})
+    print(url)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/build_tools/github_actions/publish_pytorch_to_release_bucket.py
+++ b/build_tools/github_actions/publish_pytorch_to_release_bucket.py
@@ -33,17 +33,9 @@ from _therock_utils.s3_buckets import get_release_bucket_config
 from _therock_utils.storage_backend import create_storage_backend
 from _therock_utils.storage_location import StorageLocation
 from github_actions.github_actions_api import gha_set_output
+from github_actions.multi_arch_release_urls import MULTI_ARCH_INDEX_URLS
 
 logger = logging.getLogger(__name__)
-
-
-MULTI_ARCH_INDEX_URLS = {
-    # TODO: Move this release bucket to CDN/index URL mapping into
-    # build_tools/_therock_utils/s3_buckets.py.
-    "dev": "https://rocm.devreleases.amd.com/whl-multi-arch/",
-    "nightly": "https://rocm.nightlies.amd.com/whl-multi-arch/",
-    "prerelease": "https://rocm.prereleases.amd.com/whl-multi-arch/",
-}
 
 
 def main(argv: list[str]) -> None:

--- a/build_tools/github_actions/tests/multi_arch_release_urls_test.py
+++ b/build_tools/github_actions/tests/multi_arch_release_urls_test.py
@@ -1,0 +1,52 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, os.fspath(THIS_DIR.parent))
+sys.path.insert(0, os.fspath(THIS_DIR.parent.parent))
+
+import multi_arch_release_urls as m
+
+
+class MultiArchReleaseUrlsTest(unittest.TestCase):
+    def test_known_release_types(self) -> None:
+        self.assertEqual(
+            m.get_index_url("dev"),
+            "https://rocm.devreleases.amd.com/whl-multi-arch/",
+        )
+        self.assertEqual(
+            m.get_index_url("nightly"),
+            "https://rocm.nightlies.amd.com/whl-multi-arch/",
+        )
+        self.assertEqual(
+            m.get_index_url("prerelease"),
+            "https://rocm.prereleases.amd.com/whl-multi-arch/",
+        )
+
+    def test_unknown_release_type_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Unknown release_type"):
+            m.get_index_url("bogus")
+
+    def test_main_sets_output(self) -> None:
+        with mock.patch.object(m, "gha_set_output") as gha_set_output:
+            m.main(["--release-type", "dev"])
+        outputs = gha_set_output.call_args.args[0]
+        self.assertEqual(
+            outputs["package_index_url"],
+            "https://rocm.devreleases.amd.com/whl-multi-arch/",
+        )
+
+    def test_publish_script_shares_mapping(self) -> None:
+        import publish_pytorch_to_release_bucket as publish
+
+        self.assertEqual(publish.MULTI_ARCH_INDEX_URLS, m.MULTI_ARCH_INDEX_URLS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Lets `dev` releases dispatch the full PyTorch test suite (in addition to `nightly`) and stops hardcoding the nightly package index URL, so dev runs test against the dev index rather than nightly wheels.

Closes #5781.

> **Stacked on #5813** (#5755). Base will be retargeted to `main` once #5813 merges; review the last commit only.

## What changed
- **`build_tools/github_actions/multi_arch_release_urls.py`** (new): single source of truth for the `release_type -> multi-arch index URL` mapping, with a small CLI that emits the `package_index_url` GitHub Actions output.
- **`build_tools/github_actions/publish_pytorch_to_release_bucket.py`**: imports `MULTI_ARCH_INDEX_URLS` from the shared helper instead of defining its own copy (no behavior change).
- **`.github/workflows/multi_arch_release_linux_pytorch_wheels.yml`**:
  - `setup_full_test_matrix` now resolves `package_index_url` from `release_type` and exposes it as an output.
  - The dispatch job reads `PACKAGE_INDEX_URL` from that output instead of a hardcoded nightly literal.
  - Both the setup and dispatch gates accept `release_type == 'nightly'` **or** `'dev'`.

## Cadence / safety
This is a safe no-op for dev until a scheduled wrapper passes `run_full_pytorch_tests=true` for dev releases — the dispatch only fires when that flag is set, so frequent on-demand dev builds will not trigger a full-test storm. Adding the dev schedule itself is a rockrel-side change (mirrors the existing nightly schedule).

## Test plan
- `multi_arch_release_urls_test.py` (new)
- `publish_pytorch_to_release_bucket_test.py` (unchanged, still passes after refactor)
- `configure_pytorch_test_matrix_test.py`, `workflow_dispatch_inputs_test.py`
- Workflow YAML parses.
