### PR TITLE
Disable PyTorch sccache on fork PRs via a computed cache_type

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_portable_linux_pytorch_wheels_ci.yml
@@ -160,8 +160,18 @@ jobs:
           python build_tools/github_actions/determine_version.py \
             --rocm-version ${{ inputs.rocm_version }}
 
+      # sccache uses an S3 bucket reached via an OIDC-assumed IAM role, which
+      # fork PRs / external repos cannot assume. Compute the effective cache
+      # type once (downgrading sccache -> none on forks) so every sccache step
+      # below keys off a single decision instead of repeating fork checks.
+      - name: Determine cache type
+        id: cache
+        run: |
+          python build_tools/github_actions/compute_pytorch_cache_type.py \
+            --cache-type "${{ inputs.cache_type }}"
+
       - name: Configure AWS Credentials for sccache
-        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}
+        if: ${{ steps.cache.outputs.cache_type == 'sccache' }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-region: us-east-1
@@ -171,7 +181,7 @@ jobs:
           role-duration-seconds: 21600
 
       - name: Verify sccache
-        if: ${{ inputs.cache_type == 'sccache' }}
+        if: ${{ steps.cache.outputs.cache_type == 'sccache' }}
         run: |
           echo "sccache version: $(sccache --version)"
           echo "SCCACHE_BUCKET=${SCCACHE_BUCKET}"
@@ -195,9 +205,9 @@ jobs:
       - name: Build PyTorch wheels
         run: |
           cache_flag=""
-          if [ "${{ inputs.cache_type }}" = "sccache" ]; then
+          if [ "${{ steps.cache.outputs.cache_type }}" = "sccache" ]; then
             cache_flag="--use-sccache"
-          elif [ "${{ inputs.cache_type }}" = "ccache" ]; then
+          elif [ "${{ steps.cache.outputs.cache_type }}" = "ccache" ]; then
             cache_flag="--use-ccache"
           fi
 
@@ -217,13 +227,13 @@ jobs:
             ${{ env.optional_build_prod_arguments }}
 
       - name: Report cache stats
-        if: ${{ !cancelled() && inputs.cache_type != 'none' }}
+        if: ${{ !cancelled() && steps.cache.outputs.cache_type != 'none' }}
         run: |
-          if [ "${{ inputs.cache_type }}" = "sccache" ]; then
+          if [ "${{ steps.cache.outputs.cache_type }}" = "sccache" ]; then
             echo "sccache stats:"
             echo "--------------"
             sccache --show-stats || true
-          elif [ "${{ inputs.cache_type }}" = "ccache" ]; then
+          elif [ "${{ steps.cache.outputs.cache_type }}" = "ccache" ]; then
             echo "ccache stats:"
             echo "-------------"
             ccache -s -v || true

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -129,6 +129,16 @@ jobs:
           python build_tools/github_actions/python_to_cp_version.py \
             --python-version ${{ inputs.python_version }}
 
+      # sccache uses an S3 bucket reached via an OIDC-assumed IAM role, which
+      # fork PRs / external repos cannot assume. Compute the effective cache
+      # type once (downgrading sccache -> none on forks) so every sccache step
+      # below keys off a single decision instead of repeating fork checks.
+      - name: Determine cache type
+        id: cache
+        run: |
+          python build_tools/github_actions/compute_pytorch_cache_type.py \
+            --cache-type "${{ inputs.cache_type }}"
+
       # TODO(amd-justchen): share with build_windows_artifacts.yml. Include in VM image? Dockerfile?
       - name: Install requirements
         run: |
@@ -137,7 +147,7 @@ jobs:
           choco install --no-progress -y ninja --version 1.13.1
 
       - name: Install sccache
-        if: ${{ inputs.cache_type == 'sccache' }}
+        if: ${{ steps.cache.outputs.cache_type == 'sccache' }}
         run: |
           choco install --no-progress -y sccache
           echo "sccache version: $(sccache --version)"
@@ -178,7 +188,7 @@ jobs:
             --rocm-version ${{ inputs.rocm_version }}
 
       - name: Configure AWS Credentials for sccache
-        if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}
+        if: ${{ steps.cache.outputs.cache_type == 'sccache' }}
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-region: us-east-1
@@ -189,7 +199,7 @@ jobs:
           special-characters-workaround: true
 
       - name: Verify sccache
-        if: ${{ inputs.cache_type == 'sccache' }}
+        if: ${{ steps.cache.outputs.cache_type == 'sccache' }}
         run: |
           echo "sccache version: $(sccache --version)"
           echo "SCCACHE_BUCKET=${SCCACHE_BUCKET}"
@@ -217,13 +227,13 @@ jobs:
         shell: cmd
         run: |
           set "CACHE_FLAG="
-          if "${{ inputs.cache_type }}"=="sccache" set "CACHE_FLAG=--use-sccache"
-          if "${{ inputs.cache_type }}"=="ccache" set "CACHE_FLAG=--use-ccache"
+          if "${{ steps.cache.outputs.cache_type }}"=="sccache" set "CACHE_FLAG=--use-sccache"
+          if "${{ steps.cache.outputs.cache_type }}"=="ccache" set "CACHE_FLAG=--use-ccache"
 
           set "PYTORCH_ROCM_ARCH_FLAG="
           if not "${{ steps.expand.outputs.targets }}"=="" set "PYTORCH_ROCM_ARCH_FLAG=--pytorch-rocm-arch ${{ steps.expand.outputs.targets }}"
 
-          echo "Building PyTorch wheels for ${{ inputs.artifact_group }} (cache: ${{ inputs.cache_type }})"
+          echo "Building PyTorch wheels for ${{ inputs.artifact_group }} (cache: ${{ steps.cache.outputs.cache_type }})"
           python ./external-builds/pytorch/build_prod_wheels.py ^
             build ^
             --install-rocm ^
@@ -237,13 +247,13 @@ jobs:
             ${{ env.optional_build_prod_arguments }}
 
       - name: Report cache stats
-        if: ${{ !cancelled() && inputs.cache_type != 'none' }}
+        if: ${{ !cancelled() && steps.cache.outputs.cache_type != 'none' }}
         run: |
-          if [ "${{ inputs.cache_type }}" = "sccache" ]; then
+          if [ "${{ steps.cache.outputs.cache_type }}" = "sccache" ]; then
             echo "sccache stats:"
             echo "--------------"
             sccache --show-stats || true
-          elif [ "${{ inputs.cache_type }}" = "ccache" ]; then
+          elif [ "${{ steps.cache.outputs.cache_type }}" = "ccache" ]; then
             echo "ccache stats:"
             echo "-------------"
             ccache -s -v || true

--- a/build_tools/github_actions/compute_pytorch_cache_type.py
+++ b/build_tools/github_actions/compute_pytorch_cache_type.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Computes the effective compiler cache type for a PyTorch wheel build and
+writes it to GITHUB_OUTPUT as `cache_type`.
+
+sccache for PyTorch uses an S3 bucket reached via an OIDC-assumed IAM role
+(`therock-ci`). Pull requests from forks (and runs in repositories other than
+ROCm/TheRock) cannot assume that role -- GitHub does not grant OIDC tokens to
+fork workflows -- so any attempt to use sccache there fails with an AWS
+AccessDenied / could-not-assume-role error (see ROCm/TheRock#5737).
+
+To keep a single, consistent decision instead of scattering fork checks across
+several workflow `if:` conditions, this script downgrades `sccache` to `none`
+for fork PRs / non-ROCm repositories. `ccache` and `none` pass through
+unchanged.
+
+Used by the `*_pytorch_wheels_ci.yml` workflows.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _therock_utils.s3_buckets import _is_current_run_pr_from_fork
+from github_actions_api import gha_set_output
+
+
+def compute_cache_type(cache_type: str, github_repository: str) -> str:
+    """Return the effective cache type, downgrading sccache to none on forks.
+
+    Args:
+        cache_type: Requested cache type ("sccache", "ccache", or "none").
+        github_repository: e.g. "ROCm/TheRock".
+    """
+    if cache_type != "sccache":
+        return cache_type
+
+    if _is_current_run_pr_from_fork() or github_repository != "ROCm/TheRock":
+        print(
+            "sccache is unavailable for fork PRs / external repositories "
+            "(no OIDC access to the sccache IAM role); using cache_type=none."
+        )
+        return "none"
+
+    return "sccache"
+
+
+def main(argv: list[str] | None = None):
+    parser = argparse.ArgumentParser(
+        description="Compute the effective PyTorch build cache type."
+    )
+    parser.add_argument(
+        "--cache-type",
+        type=str,
+        default=os.environ.get("CACHE_TYPE", "sccache"),
+        help='Requested cache type: "sccache", "ccache", or "none".',
+    )
+    args = parser.parse_args(argv)
+
+    github_repository = os.environ.get("GITHUB_REPOSITORY", "ROCm/TheRock")
+    effective = compute_cache_type(args.cache_type, github_repository)
+    print(f"Requested cache_type={args.cache_type!r} -> effective={effective!r}")
+    gha_set_output({"cache_type": effective})
+
+
+if __name__ == "__main__":
+    main()

--- a/build_tools/github_actions/tests/compute_pytorch_cache_type_test.py
+++ b/build_tools/github_actions/tests/compute_pytorch_cache_type_test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for compute_pytorch_cache_type.py"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import compute_pytorch_cache_type
+from compute_pytorch_cache_type import compute_cache_type, main
+
+
+class TestComputeCacheType(unittest.TestCase):
+    """Tests for the compute_cache_type decision function."""
+
+    def _run(self, cache_type, repo="ROCm/TheRock", is_fork=False):
+        with mock.patch.object(
+            compute_pytorch_cache_type,
+            "_is_current_run_pr_from_fork",
+            return_value=is_fork,
+        ):
+            return compute_cache_type(cache_type, repo)
+
+    def test_sccache_in_org_pr_stays_sccache(self):
+        self.assertEqual(self._run("sccache", is_fork=False), "sccache")
+
+    def test_sccache_fork_pr_downgrades_to_none(self):
+        self.assertEqual(self._run("sccache", is_fork=True), "none")
+
+    def test_sccache_non_rocm_repo_downgrades_to_none(self):
+        self.assertEqual(
+            self._run("sccache", repo="someone/TheRock", is_fork=False), "none"
+        )
+
+    def test_ccache_passes_through_even_on_fork(self):
+        # Only sccache depends on the OIDC role; ccache is local.
+        self.assertEqual(self._run("ccache", is_fork=True), "ccache")
+
+    def test_none_passes_through(self):
+        self.assertEqual(self._run("none", is_fork=True), "none")
+
+    def test_fork_check_skipped_when_not_sccache(self):
+        # _is_current_run_pr_from_fork must not even be consulted for ccache/none.
+        with mock.patch.object(
+            compute_pytorch_cache_type,
+            "_is_current_run_pr_from_fork",
+            side_effect=AssertionError("should not be called"),
+        ):
+            self.assertEqual(compute_cache_type("ccache", "ROCm/TheRock"), "ccache")
+            self.assertEqual(compute_cache_type("none", "ROCm/TheRock"), "none")
+
+
+class TestMain(unittest.TestCase):
+    """Tests for main() writing the effective cache_type to GITHUB_OUTPUT."""
+
+    def _main_with_output(self, cache_type, repo, is_fork):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "gh_output.txt"
+            env = {"GITHUB_REPOSITORY": repo, "GITHUB_OUTPUT": str(out)}
+            with mock.patch.dict(os.environ, env), mock.patch.object(
+                compute_pytorch_cache_type,
+                "_is_current_run_pr_from_fork",
+                return_value=is_fork,
+            ):
+                main(["--cache-type", cache_type])
+            return out.read_text()
+
+    def test_main_in_org_writes_sccache(self):
+        self.assertIn(
+            "cache_type=sccache",
+            self._main_with_output("sccache", "ROCm/TheRock", is_fork=False),
+        )
+
+    def test_main_fork_writes_none(self):
+        self.assertIn(
+            "cache_type=none",
+            self._main_with_output("sccache", "ROCm/TheRock", is_fork=True),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #5737 (supersedes the Draft #5738). PyTorch CI jobs fail on PRs from forks at the sccache steps:

```
User: arn:aws:iam::692859939525:user/therock-external-upload is not authorized to perform:
sts:TagSession on resource: arn:aws:iam::324352301041:role/therock-ci
... AccessDenied ... s3:GetObject on therock-pytorch-sccache-ci/.../.sccache_check
```

### Root cause

sccache uses an S3 bucket reached via an OIDC-assumed IAM role (`therock-ci`). Fork PRs don't get OIDC tokens, so the role can't be assumed. The gate `github.repository_owner == 'ROCm'` is **always true** on fork PRs (it's the base repo), and it only guarded the credentials step — `Verify sccache` and the build still passed `--use-sccache`, so sccache started and failed on S3 access.

### Fix

Compute the effective cache type **once**, in [build_tools/github_actions/compute_pytorch_cache_type.py](https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/compute_pytorch_cache_type.py) (reusing `_is_current_run_pr_from_fork()` from `s3_buckets.py`), downgrading `sccache` -> `none` on fork PRs / non-ROCm repos. Every sccache step in the two `*_pytorch_wheels_ci.yml` workflows now keys off that single `steps.cache.outputs.cache_type` instead of repeating fork checks. `ccache`/`none` pass through unchanged; in-org runs keep sccache and its hard-fail semantics.

This follows the review direction on #5738 ("compute earlier… this all needs to go through scripts, not yml code") and limits changes to the `_ci.yml` workflows (the release / `multi_arch_build_*` workflows are never fork-triggered).

## Files

- `build_tools/github_actions/compute_pytorch_cache_type.py` (new)
- `build_tools/github_actions/tests/compute_pytorch_cache_type_test.py` (new, 8 cases)
- `build_portable_linux_pytorch_wheels_ci.yml`, `build_windows_pytorch_wheels_ci.yml` — add "Determine cache type" step; gate all sccache steps on its output.

## Test plan

- [x] Unit tests (fork / in-org / non-PR / non-ROCm / none / ccache).
- [x] Real-script test against fork-shaped event payloads: fork+sccache->none, in-org+sccache->sccache, fork+ccache->ccache.
- [x] In-org CI run on this PR: sccache still active + cache hits (no regression).
- [x] Fork PR (#5729) after merge: sccache skipped, build succeeds with cache_type=none.
