### PR TITLE
Fix Python 3.10 compatibility for invalidate_caches() in ROCm devel package

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -29,6 +29,7 @@ it, as the alternative is to increase the package size by 2-5x and break
 symlink relationships.
 """
 
+import importlib
 import importlib.metadata as md
 import io
 import json
@@ -229,7 +230,8 @@ def _discover_device_link_plans(site_lib_path: Path, expected_version: str):
     # importlib.metadata caches path scans by directory mtime. On filesystems with
     # coarse mtime resolution, a device wheel installed immediately after a prior
     # scan may otherwise be missed.
-    md.MetadataPathFinder.invalidate_caches()
+    importlib.invalidate_caches()
+
     plans = []
     for dist in md.distributions(path=[str(site_lib_path)]):
         name = dist.metadata["Name"]


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/TheRock/issues/5814

This internal function has a different call signature across Python 3.10 and 3.11+, leading to errors on Python 3.10 during `rocm-sdk init`: https://github.com/ROCm/rockrel/actions/runs/27422263294/job/81050704163#step:14:2746
```
  File "/opt/python/cp310-cp310/lib/python3.10/site-packages/rocm_sdk/_devel.py", line 76, in get_devel_root
    _reconcile_device_links(site_lib_path, devel_py_pkg_path, di.__version__)
  File "/opt/python/cp310-cp310/lib/python3.10/site-packages/rocm_sdk/_devel.py", line 326, in _reconcile_device_links
    plans = _discover_device_link_plans(site_lib_path, expected_version)
  File "/opt/python/cp310-cp310/lib/python3.10/site-packages/rocm_sdk/_devel.py", line 232, in _discover_device_link_plans
    md.MetadataPathFinder.invalidate_caches()
TypeError: MetadataPathFinder.invalidate_caches() missing 1 required positional argument: 'cls'
```

## Technical Details

See the docs:
* https://docs.python.org/3/library/importlib.metadata.html
* (what the code used before) https://docs.python.org/3/library/importlib.html#importlib.abc.MetaPathFinder 
    > An optional method which, when called, should invalidate any internal cache used by the finder. Used by [importlib.invalidate_caches()](https://docs.python.org/3/library/importlib.html#importlib.invalidate_caches) when invalidating the caches of all finders on [sys.meta_path](https://docs.python.org/3/library/sys.html#sys.meta_path).
* (what it uses now) https://docs.python.org/3/library/importlib.html#importlib.invalidate_caches
    > Invalidate the internal caches of finders stored at [sys.meta_path](https://docs.python.org/3/library/sys.html#sys.meta_path). If a finder implements invalidate_caches() then it will be called to perform the invalidation. This function should be called if any modules are created/installed while your program is running to guarantee all finders will notice the new module’s existence.

## Test Plan

CI coverage for Python 3.10 will be added in https://github.com/ROCm/TheRock/pull/5731.

Tested locally by installing latest nightly packages with the issue then running `rocm-sdk init` on Python 3.10 and Python 3.11 with and without the fix:
```bash
py -V:3.10 -m venv 3.10.venv && .\3.10.venv\Scripts\activate.bat
pip install rocm[libraries,devel,device-gfx1100] --pre --index-url https://rocm.nightlies.amd.com/whl-multi-arch/
rocm-sdk init

# edit 3.10.venv\Lib\site-packages\rocm_sdk\_devel.py
rocm-sdk init
```

Validated that the test added in https://github.com/ROCm/TheRock/pull/5798 to `pytest -vv build_tools/tests/devel_reconcile_test.py` fails if I remove the `invalidate_caches()` code entirely (either the old version or the new version).

## Test Result

Able to reproduce the error without the fix. The fix worked for 3.10 and did not regress 3.11.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
