### PR TITLE
Disable Unit_hiprtcCombiComplrOptnTst for gfx1250

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -87,6 +87,15 @@ TEST_TO_IGNORE = {
             "Unit_hipStreamValue_Wait_Blocking - uint32_t",
         ]
     },
+    "gfx125X-dcgpu": {
+        "linux": [
+            # Runtime-compiles and launches kernels from combinatorial compiler
+            # option sets; on gfx1250 bringup this triggers an unrecoverable GPU
+            # fault/hang that escalates to a full node reboot. Disable until the
+            # backend/firmware mature.
+            "Unit_hiprtcCombiComplrOptnTst",
+        ]
+    },
 }
 
 


### PR DESCRIPTION
## Motivation

`Unit_hiprtcCombiComplrOptnTst` (hip-tests `catch/unit/rtc`) **causes a full system reboot on gfx1250 (CDNA5 / MI455X)** during bringup.

Unlike most catch tests, this one is not compile-only: for each block in `RtcConfig.json` it runtime-compiles kernels via `hiprtcCompileProgram` using large *combinations* of compiler/codegen flags (denormal flush, fast-math, signed-zeros, fp-contract, SLP-vectorize, unsafe FP atomics, `-mllvm ...` backend knobs) and then loads + launches the resulting code objects on the GPU.

On pre-production gfx1250 silicon, some of those combinatorial code objects trigger an unrecoverable GPU memory fault / shader hang. Because hang recovery (GPU reset / RAS) is not yet robust on this part, it escalates to a full **node reboot** instead of a contained test failure.

## Changes

- Add `gfx125X-dcgpu` → `linux` → `Unit_hiprtcCombiComplrOptnTst` to `TEST_TO_IGNORE` in `build_tools/github_actions/test_executable_scripts/test_hiptests.py`, which excludes it via `ctest --exclude-regex`.

This is stacked on top of #5789 (gfx1250 build support).

## Follow-up

- [ ] Re-enable once the gfx1250 compiler backend + firmware mature and the offending compiler-option combination is identified/fixed.

Made with [Cursor](https://cursor.com)