### PR TITLE
[ci] Add 2-hour timeout to PyTorch test steps

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -229,6 +229,7 @@ jobs:
             -v
 
       - name: Run PyTorch tests
+        timeout-minutes: 120
         run: |
           python ./external-builds/pytorch/run_pytorch_tests.py \
             --device-query "${{ inputs.device_query }}" \


### PR DESCRIPTION
Prevents tests from hanging for 6 hours when GPU gets stuck on certain test failures (e.g., test_cross_entropy_loss_2d_out_of_bounds). This helps free up CI runners faster when issues occur.

Progress on #5565
