### PR TITLE
[torch] Disable `test_cross_entropy_loss_2d_out_of_bounds_class_index_cuda_float16` on Windows 

### DIFF
--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -257,6 +257,9 @@ skip_tests = {
             "test_streams",
         ],
         "nn": [
+            # Hangs on some Windows ROCm runners until the job hits the 6h limit.
+            # https://github.com/ROCm/TheRock/issues/5565
+            "test_cross_entropy_loss_2d_out_of_bounds_class_index",
             # RuntimeError: miopenStatusUnknownError
             "test_cudnn_weight_format",
             "test_rnn_retain_variables_cuda_float16",


### PR DESCRIPTION
## Motivation

Disable `test_cross_entropy_loss_2d_out_of_bounds_class_index_cuda_float16` as it is hanging on Windows runners, see https://github.com/ROCm/TheRock/issues/5565. 

## Technical Details

`test_cross_entropy_loss_2d_out_of_bounds_class_index_cuda_float16` spawns a kernel and gives an out of bounds class index to `F.cross_entropy(reduction="none")`. It expects that the kernel call will fail and abort and waits on it with `torch.cuda.synchronize()`. The abort wedges the queue but never propagates, so synchronize() blocks forever on a queue that will never complete
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Verify that the test is skipped
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Verified locally that the test is skipped
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
