### PR TITLE
[ci] Fix gitleaks workflow to use merge commit ref

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -63,7 +63,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: ${{ steps.depth.outputs.value }}
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5


### PR DESCRIPTION
The workflow was explicitly checking out the PR head SHA, which fails when the PR branch predates the gitleaks.py file addition. By using the default ref (merge commit for PRs), we ensure workflow files from main are available even when the PR branch was created before them.

Noticing error: https://github.com/ROCm/TheRock/actions/runs/27437653806/job/81103567501?pr=5799