### PR TITLE
[feature] Integrating AMDMIGraphX into TheRock

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,7 @@
 	path = debug-tools/rocgdb/source
 	url = https://github.com/ROCm/rocgdb.git
 	branch = amd-staging-rocgdb-16
+[submodule "AMDMIGraphX"]
+	path = ml-frameworks/AMDMIGraphX
+	url = https://github.com/ROCm/AMDMIGraphX.git
+	branch = develop

--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -113,7 +113,7 @@ submodules = ["libhipcxx"]
 
 [source_sets.ml-frameworks]
 description = "ML framework submodules"
-submodules = []
+submodules = ["AMDMIGraphX"]
 
 [source_sets.comm-libs]
 description = "Communication library submodules"
@@ -617,6 +617,13 @@ artifact_group = "ml-libs"
 type = "target-specific"
 artifact_deps = ["core-runtime", "core-hip", "blas", "composable-kernel", "rand", "rocprofiler-sdk"]
 split_databases = ["miopen"]
+
+[artifacts.migraphx]
+artifact_group = "ml-libs"
+type = "target-specific"
+artifact_deps = ["core-runtime", "core-hip", "blas", "composable-kernel", "miopen", "rand", "rocprofiler-sdk"]
+feature_name = "MIGRAPHX"
+feature_group = "ML_LIBS"
 
 [artifacts.hipdnn]
 artifact_group = "ml-libs"

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -882,7 +882,7 @@ def main(argv):
         "--ml-framework-projects",
         nargs="+",
         type=str,
-        default=[],
+        default=["AMDMIGraphX"],
     )
     parser.add_argument(
         "--media-libs-projects",

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -148,6 +148,58 @@ if(THEROCK_ENABLE_MIOPEN)
   )
 endif(THEROCK_ENABLE_MIOPEN)
 
+if(THEROCK_ENABLE_MIGRAPHX)
+  ##############################################################################
+  # MIGraphX
+  ##############################################################################
+  therock_cmake_subproject_declare(MIGraphX
+    EXTERNAL_SOURCE_DIR "${THEROCK_SOURCE_DIR}/ml-frameworks/AMDMIGraphX"
+    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/MIGraphX"
+    BACKGROUND_BUILD
+    CMAKE_ARGS
+      -DHIP_PLATFORM=amd
+      -DROCM_PATH=
+      -DROCM_DIR=
+      "-DBUILD_TESTING=${THEROCK_BUILD_TESTING}"
+      "-DMIGRAPHX_ENABLE_PYTHON=OFF"
+      "-DMIGRAPHX_USE_COMPOSABLEKERNEL=OFF" # TODO: enable
+      "-DMIGRAPHX_ENABLE_MLIR=OFF" # TODO: enable
+    CMAKE_INCLUDES
+      therock_explicit_finders.cmake
+    COMPILER_TOOLCHAIN
+      amd-hip
+    BUILD_DEPS
+      rocm-cmake
+      therock-googletest
+      therock-nlohmann-json
+      therock-eigen
+      therock-msgpack-cxx
+      therock-grpc
+    RUNTIME_DEPS
+      hip-clr
+      rocm-half
+      rocBLAS
+      rocRAND
+      MIOpen
+      composable_kernel
+  )
+  therock_cmake_subproject_provide_package(MIGraphX migraphx lib/cmake/migraphx)
+  therock_cmake_subproject_activate(MIGraphX)
+
+  therock_provide_artifact(migraphx
+    DESCRIPTOR artifact-migraphx.toml
+    COMPONENTS
+      dbg
+      dev
+      doc
+      lib
+      run
+      test
+    SUBPROJECT_DEPS
+      MIGraphX
+  )
+endif(THEROCK_ENABLE_MIGRAPHX)
+
 if(THEROCK_ENABLE_HIPDNN)
   ##############################################################################
   # hipDNN

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -149,55 +149,60 @@ if(THEROCK_ENABLE_MIOPEN)
 endif(THEROCK_ENABLE_MIOPEN)
 
 if(THEROCK_ENABLE_MIGRAPHX)
-  ##############################################################################
-  # MIGraphX
-  ##############################################################################
-  therock_cmake_subproject_declare(MIGraphX
-    EXTERNAL_SOURCE_DIR "${THEROCK_SOURCE_DIR}/ml-frameworks/AMDMIGraphX"
-    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/MIGraphX"
-    BACKGROUND_BUILD
-    CMAKE_ARGS
-      -DHIP_PLATFORM=amd
-      -DROCM_PATH=
-      -DROCM_DIR=
-      "-DBUILD_TESTING=${THEROCK_BUILD_TESTING}"
-      "-DMIGRAPHX_ENABLE_PYTHON=OFF"
-      "-DMIGRAPHX_USE_COMPOSABLEKERNEL=OFF" # TODO: enable
-      "-DMIGRAPHX_ENABLE_MLIR=OFF" # TODO: enable
-    CMAKE_INCLUDES
-      therock_explicit_finders.cmake
-    COMPILER_TOOLCHAIN
-      amd-hip
-    BUILD_DEPS
-      rocm-cmake
-      therock-googletest
-      therock-nlohmann-json
-      therock-eigen
-      therock-msgpack-cxx
-      therock-grpc
-    RUNTIME_DEPS
-      hip-clr
-      rocm-half
-      rocBLAS
-      rocRAND
-      MIOpen
-      composable_kernel
-  )
-  therock_cmake_subproject_provide_package(MIGraphX migraphx lib/cmake/migraphx)
-  therock_cmake_subproject_activate(MIGraphX)
+  if(NOT EXISTS "${THEROCK_SOURCE_DIR}/ml-frameworks/AMDMIGraphX/CMakeLists.txt")
+    message(STATUS "MIGraphX source not found. Disabling MIGraphX. If you want to enable MIGraphX run: python3 ./build_tools/fetch_sources.py --source-sets ml-frameworks")
+    set(THEROCK_ENABLE_MIGRAPHX OFF)
+  else()
+    ##############################################################################
+    # MIGraphX
+    ##############################################################################
+    therock_cmake_subproject_declare(MIGraphX
+      EXTERNAL_SOURCE_DIR "${THEROCK_SOURCE_DIR}/ml-frameworks/AMDMIGraphX"
+      BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/MIGraphX"
+      BACKGROUND_BUILD
+      CMAKE_ARGS
+        -DHIP_PLATFORM=amd
+        -DROCM_PATH=
+        -DROCM_DIR=
+        "-DBUILD_TESTING=${THEROCK_BUILD_TESTING}"
+        "-DMIGRAPHX_ENABLE_PYTHON=OFF"
+        "-DMIGRAPHX_USE_COMPOSABLEKERNEL=OFF" # TODO: enable
+        "-DMIGRAPHX_ENABLE_MLIR=OFF" # TODO: enable
+      CMAKE_INCLUDES
+        therock_explicit_finders.cmake
+      COMPILER_TOOLCHAIN
+        amd-hip
+      BUILD_DEPS
+        rocm-cmake
+        therock-googletest
+        therock-nlohmann-json
+        therock-eigen
+        therock-msgpack-cxx
+        therock-grpc
+      RUNTIME_DEPS
+        hip-clr
+        rocm-half
+        rocBLAS
+        rocRAND
+        MIOpen
+        composable_kernel
+    )
+    therock_cmake_subproject_provide_package(MIGraphX migraphx lib/cmake/migraphx)
+    therock_cmake_subproject_activate(MIGraphX)
 
-  therock_provide_artifact(migraphx
-    DESCRIPTOR artifact-migraphx.toml
-    COMPONENTS
-      dbg
-      dev
-      doc
-      lib
-      run
-      test
-    SUBPROJECT_DEPS
-      MIGraphX
-  )
+    therock_provide_artifact(migraphx
+      DESCRIPTOR artifact-migraphx.toml
+      COMPONENTS
+        dbg
+        dev
+        doc
+        lib
+        run
+        test
+      SUBPROJECT_DEPS
+        MIGraphX
+    )
+  endif()
 endif(THEROCK_ENABLE_MIGRAPHX)
 
 if(THEROCK_ENABLE_HIPDNN)

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -185,7 +185,6 @@ if(THEROCK_ENABLE_MIGRAPHX)
         rocBLAS
         rocRAND
         MIOpen
-        composable_kernel
     )
     therock_cmake_subproject_provide_package(MIGraphX migraphx lib/cmake/migraphx)
     therock_cmake_subproject_activate(MIGraphX)

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -165,7 +165,7 @@ if(THEROCK_ENABLE_MIGRAPHX)
         -DROCM_PATH=
         -DROCM_DIR=
         "-DBUILD_TESTING=${THEROCK_BUILD_TESTING}"
-        "-DMIGRAPHX_ENABLE_PYTHON=OFF"
+        "-DMIGRAPHX_ENABLE_PYTHON=OFF" # TODO: enable
         "-DMIGRAPHX_USE_COMPOSABLEKERNEL=OFF" # TODO: enable
         "-DMIGRAPHX_ENABLE_MLIR=OFF" # TODO: enable
       CMAKE_INCLUDES
@@ -180,7 +180,10 @@ if(THEROCK_ENABLE_MIGRAPHX)
         therock-msgpack-cxx
         therock-grpc
       RUNTIME_DEPS
+        hipBLAS-common
         hip-clr
+        hipBLAS
+        hipBLASLt
         rocm-half
         rocBLAS
         rocRAND

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -149,10 +149,6 @@ if(THEROCK_ENABLE_MIOPEN)
 endif(THEROCK_ENABLE_MIOPEN)
 
 if(THEROCK_ENABLE_MIGRAPHX)
-  if(NOT EXISTS "${THEROCK_SOURCE_DIR}/ml-frameworks/AMDMIGraphX/CMakeLists.txt")
-    message(STATUS "MIGraphX source not found. Disabling MIGraphX. If you want to enable MIGraphX run: python3 ./build_tools/fetch_sources.py --source-sets ml-frameworks")
-    set(THEROCK_ENABLE_MIGRAPHX OFF)
-  else()
     ##############################################################################
     # MIGraphX
     ##############################################################################

--- a/ml-libs/artifact-migraphx.toml
+++ b/ml-libs/artifact-migraphx.toml
@@ -1,0 +1,18 @@
+# MIGraphX
+[components.lib."ml-libs/MIGraphX/stage"]
+include = [
+  "include/migraphx/**",
+  "lib/libmigraphx*",
+  "share/migraphx/**"
+]
+[components.run."ml-libs/MIGraphX/stage"]
+include = [
+  "bin/migraphx-driver*"
+]
+[components.dev."ml-libs/MIGraphX/stage"]
+[components.dbg."ml-libs/MIGraphX/stage"]
+[components.doc."ml-libs/MIGraphX/stage"]
+[components.test."ml-libs/MIGraphX/stage"]
+include = [
+  "bin/test_*"
+]

--- a/third-party/grpc/CMakeLists.txt
+++ b/third-party/grpc/CMakeLists.txt
@@ -59,5 +59,7 @@ therock_cmake_subproject_declare(therock-grpc
 )
 therock_cmake_subproject_provide_package(therock-grpc gRPC lib/cmake/grpc)
 therock_cmake_subproject_provide_package(therock-grpc protobuf lib/cmake/protobuf)
+therock_cmake_subproject_provide_package(therock-grpc absl lib/cmake/absl)
+therock_cmake_subproject_provide_package(therock-grpc utf8_range lib/cmake/utf8_range)
 therock_cmake_subproject_activate(therock-grpc)
 add_dependencies(therock-third-party therock-grpc)


### PR DESCRIPTION
## Motivation

MIGraphX is currently missing from TheRock's build topology. This PR enables TheRock to build MIGraphX from source, ensuring access to the latest improvements in the underlying math libraries.

## Technical Details
- Added AMDMIGraphX as submodule under `ml-frameworks/` tracking the `develop` branch;
- Registered the project in `BUILD_TOPOLOGY.toml` and added `artifact-migraphx.toml` modelled after the existing MIOpen;
- Added the `therock_cmake_subproject_declare` block in `ml-libs/CMakeLists.txt`, with the required backedn dependencies.

**Small note:** There is small upstream bug in AMDMIGraphX code. To fix that bug (so that the build passes) go to `ml-frameworks/AMDMIGraphX/src/targets/gpu/mlir.cpp` and move `#include <mlir-c/Dialect/RockEnums.h>` line inside `#ifndef MIGRAPHX_MLIR` guard.

## Test Plan

1. Perform two builds: one default full build (without fetching MIGraphX sources), and one clean configure and build explicitly targeting MIGraphX.
2. Verify that both builds complete successfully.

## Test Results

1. Full default build (the one without MIGraphX) completes cleanly without errors. CMake detects the missing source folder and disables MIGraphX.
2. Targeted build (`cmake --build build --target MIGraphX`) completes cleanly.

 I performed all of the tests on Ubuntu 24.04 for gfx1100.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


*Note:* _The first 3 commits are logical split of the core implementation (since I forgot to commit earlier). The follow-up commits address issues I found while re-testing. I hope this helps with review._