### PR TITLE
Add gfx1250 to postsubmit CI matrix and adding pytorch vars

### DIFF
--- a/SUPPORTED_GPUS.md
+++ b/SUPPORTED_GPUS.md
@@ -35,7 +35,7 @@ See also the [ROCm Device Support Wishlist GitHub Discussion](https://github.com
 | Architecture | LLVM target | Build Passing | Sanity Tested | Release Ready |
 | ------------ | ----------- | ------------- | ------------- | ------------- |
 | **CDNA4**    | **gfx950**  | ✅            |               |               |
-| **CDNA3**    | **gfx942**  | ✅            | ✅            | ✅           |
+| **CDNA3**    | **gfx942**  | ✅            | ✅            | ✅            |
 | CDNA2        | gfx90a      | ✅            |               |               |
 | CDNA         | gfx908      | ✅            |               |               |
 | GCN5.1       | gfx906      | ✅            |               |               |

--- a/SUPPORTED_GPUS.md
+++ b/SUPPORTED_GPUS.md
@@ -34,6 +34,7 @@ See also the [ROCm Device Support Wishlist GitHub Discussion](https://github.com
 
 | Architecture | LLVM target | Build Passing | Sanity Tested | Release Ready |
 | ------------ | ----------- | ------------- | ------------- | ------------- |
+| **CDNA5**    | **gfx1250** |               |               |               |
 | **CDNA4**    | **gfx950**  | ✅            |               |               |
 | **CDNA3**    | **gfx942**  | ✅            | ✅            | ✅            |
 | CDNA2        | gfx90a      | ✅            |               |               |

--- a/SUPPORTED_GPUS.md
+++ b/SUPPORTED_GPUS.md
@@ -34,9 +34,8 @@ See also the [ROCm Device Support Wishlist GitHub Discussion](https://github.com
 
 | Architecture | LLVM target | Build Passing | Sanity Tested | Release Ready |
 | ------------ | ----------- | ------------- | ------------- | ------------- |
-| **CDNA5**    | **gfx1250** |               |               |               |
 | **CDNA4**    | **gfx950**  | ✅            |               |               |
-| **CDNA3**    | **gfx942**  | ✅            | ✅            | ✅            |
+| **CDNA3**    | **gfx942**  | ✅            | ✅            | ✅           |
 | CDNA2        | gfx90a      | ✅            |               |               |
 | CDNA         | gfx908      | ✅            |               |               |
 | GCN5.1       | gfx906      | ✅            |               |               |

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -259,6 +259,15 @@ amdgpu_family_info_matrix_postsubmit = {
             "build_variants": ["release", "asan", "tsan"],
         }
     },
+    "gfx125x": {
+        "linux": {
+            # No hardware available for testing yet; build-only.
+            "test-runs-on": "",
+            "family": "gfx125X-dcgpu",
+            "fetch-gfx-targets": [],
+            "build_variants": ["release"],
+        },
+    },
 }
 
 # The 'nightly' matrix runs on 'schedule' triggers.

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -245,6 +245,16 @@ amdgpu_family_info_matrix_presubmit = {
             "nightly_check_only_for_family": True,
         },
     },
+    "gfx125x": {
+        "linux": {
+            # No hardware available for testing yet; build-only nightly.
+            "test-runs-on": "",
+            "family": "gfx125X-dcgpu",
+            "fetch-gfx-targets": [],
+            "build_variants": ["release"],
+            "nightly_check_only_for_family": True,
+        },
+    },
 }
 
 # The 'postsubmit' matrix runs on 'push' triggers (for every commit to the default branch).

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -245,16 +245,8 @@ amdgpu_family_info_matrix_presubmit = {
             "nightly_check_only_for_family": True,
         },
     },
-    "gfx125x": {
-        "linux": {
-            # No hardware available for testing yet; build-only.
-            "test-runs-on": "",
-            "family": "gfx125X-dcgpu",
-            "fetch-gfx-targets": [],
-            "build_variants": ["release"],
-        },
-    },
 }
+
 
 # The 'postsubmit' matrix runs on 'push' triggers (for every commit to the default branch).
 amdgpu_family_info_matrix_postsubmit = {
@@ -407,6 +399,18 @@ amdgpu_family_info_matrix_nightly = {
         "windows": {
             "test-runs-on": "",
             "family": "gfx1153",
+            "fetch-gfx-targets": [],
+            "build_variants": ["release"],
+        },
+    },
+    "gfx125x": {
+        "linux": {
+            # No hardware available for testing yet; build-only.
+            # PyTorch builds are included — workflow_dispatch can be used
+            # to trigger manually; nightly schedule runs both ROCm stack
+            # and PyTorch builds.
+            "test-runs-on": "",
+            "family": "gfx125X-dcgpu",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
         },

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -247,12 +247,11 @@ amdgpu_family_info_matrix_presubmit = {
     },
     "gfx125x": {
         "linux": {
-            # No hardware available for testing yet; build-only nightly.
+            # No hardware available for testing yet; build-only.
             "test-runs-on": "",
             "family": "gfx125X-dcgpu",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
-            "nightly_check_only_for_family": True,
         },
     },
 }

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -72,6 +72,7 @@ amdgpu_family_predefined_groups = {
         "gfx1150",
         "gfx1152",
         "gfx1153",
+        "gfx125X-dcgpu",
     ],
 }
 
@@ -387,6 +388,25 @@ amdgpu_family_info_matrix_all = {
                 },
                 "release": {
                     "push_on_success": True,
+                    "bypass_tests_for_releases": True,
+                },
+            },
+        }
+    },
+    "gfx125X": {
+        "dcgpu": {
+            "linux": {
+                "build": {
+                    "build_variants": ["release"],
+                },
+                "test": {
+                    # No gfx1250 hardware available for testing yet.
+                    "run_tests": False,
+                    "runs_on": {},
+                    "fetch-gfx-targets": [],
+                },
+                "release": {
+                    "push_on_success": False,
                     "bypass_tests_for_releases": True,
                 },
             },

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -63,7 +63,7 @@ amdgpu_family_predefined_groups = {
     # The 'presubmit' matrix runs on 'pull_request' triggers (on all PRs).
     "amdgpu_presubmit": ["gfx94X-dcgpu", "gfx110X-all", "gfx1151", "gfx120X-all"],
     # The 'postsubmit' matrix runs on 'push' triggers (for every commit to the default branch).
-    "amdgpu_postsubmit": ["gfx950-dcgpu"],
+    "amdgpu_postsubmit": ["gfx950-dcgpu", "gfx125X-dcgpu"],
     # The 'nightly' matrix runs on 'schedule' triggers.
     "amdgpu_nightly": [
         "gfx90X-dcgpu",

--- a/build_tools/hack/env_check/AMDGPU_LLVM_TARGET.py
+++ b/build_tools/hack/env_check/AMDGPU_LLVM_TARGET.py
@@ -53,6 +53,12 @@ _amdgpu = {
     "gfx1153": [
         "AMD Radeon 820M",
     ],
+    # CDNA 5 / gfx125X
+    "gfx1250": [
+        "AMD Instinct MI450",
+        "AMD Instinct MI450X",
+        "AMD Instinct MI455X",
+    ],
     # RDNA 4
     "gfx1201": [
         "AMD Radeon RX 9070 XT",

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -242,6 +242,9 @@ therock_add_amdgpu_target(gfx1201 "AMD RX 9070 / XT" FAMILY dgpu-all gfx120X-all
     rocprofiler-compute # https://github.com/ROCm/TheRock/issues/2892
 )
 
+# gfx125X family
+therock_add_amdgpu_target(gfx1250 "AMD Instinct MI450/MI450X/MI455X CDNA" FAMILY dcgpu-all gfx125X-all gfx125X-dcgpu)
+
 # Optional extension targets (used for out of tree target development).
 include(therock_custom_amdgpu_targets OPTIONAL)
 

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -243,7 +243,10 @@ therock_add_amdgpu_target(gfx1201 "AMD RX 9070 / XT" FAMILY dgpu-all gfx120X-all
 )
 
 # gfx125X family
-therock_add_amdgpu_target(gfx1250 "AMD Instinct MI450/MI450X/MI455X CDNA" FAMILY dcgpu-all gfx125X-all gfx125X-dcgpu)
+therock_add_amdgpu_target(gfx1250 "AMD Instinct MI450/MI450X/MI455X CDNA" FAMILY dcgpu-all gfx125X-all gfx125X-dcgpu
+  EXCLUDE_TARGET_PROJECTS
+    rocWMMA # https://github.com/ROCm/TheRock/issues/1944
+)
 
 # Optional extension targets (used for out of tree target development).
 include(therock_custom_amdgpu_targets OPTIONAL)

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -245,7 +245,7 @@ therock_add_amdgpu_target(gfx1201 "AMD RX 9070 / XT" FAMILY dgpu-all gfx120X-all
 # gfx125X family
 therock_add_amdgpu_target(gfx1250 "AMD Instinct MI450/MI450X/MI455X CDNA" FAMILY dcgpu-all gfx125X-all gfx125X-dcgpu
   EXCLUDE_TARGET_PROJECTS
-    rocWMMA # https://github.com/ROCm/TheRock/issues/1944
+    rocWMMA # https://amd-hub.atlassian.net/browse/LCOMPILER-2316
 )
 
 # Optional extension targets (used for out of tree target development).

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -949,13 +949,27 @@ def do_build_pytorch(
     AOTRITON_SUPPORTED_ARCH_PREFIXES = ("gfx90a", "gfx942", "gfx950", "gfx11", "gfx12")
     # gfx1152/53: supported in aotriton 0.11.2b+ (https://github.com/ROCm/aotriton/pull/142),
     #   which is pinned by pytorch >= 2.11. Older versions don't include it.
-    aotriton_unsupported_archs_for_version = []
+    # gfx1250: not yet supported by aotriton.
+    #   See: https://github.com/ROCm/TheRock/issues/5833
+    aotriton_unsupported_archs_for_version = ["gfx1250"]
     if not is_pytorch_2_11_or_later:
-        aotriton_unsupported_archs_for_version = ["gfx1152", "gfx1153"]
+        aotriton_unsupported_archs_for_version += ["gfx1152", "gfx1153"]
     rocm_arch_list = env.get("PYTORCH_ROCM_ARCH", "").split(";")
     has_aotriton_supported_arch = any(
         arch.startswith(AOTRITON_SUPPORTED_ARCH_PREFIXES)
         and arch not in aotriton_unsupported_archs_for_version
+        for arch in rocm_arch_list
+    )
+
+    # PyTorch's CK-based SDPA and GEMM kernels (USE_ROCM_CK_SDPA,
+    # USE_ROCM_CK_GEMM) are not yet supported for gfx1250. Disable them when
+    # the build targets only gfx1250 so that PyTorch falls back to other
+    # backends. In multi-arch builds that include other supported arches, CK
+    # SDPA/GEMM remain enabled.
+    # See: https://github.com/ROCm/TheRock/issues/5833
+    CK_SDPA_GEMM_UNSUPPORTED_ARCHS = ("gfx1250",)
+    has_ck_sdpa_gemm_supported_arch = any(
+        arch and not arch.startswith(CK_SDPA_GEMM_UNSUPPORTED_ARCHS)
         for arch in rocm_arch_list
     )
 
@@ -1023,6 +1037,18 @@ def do_build_pytorch(
         )
         print(
             f"Flash Attention and Memory efficiency enabled: {env['USE_FLASH_ATTENTION'] == 'ON'}"
+        )
+
+        use_ck_sdpa_gemm = "ON" if has_ck_sdpa_gemm_supported_arch else "OFF"
+        env.update(
+            {
+                "USE_ROCM_CK_SDPA": use_ck_sdpa_gemm,
+                "USE_ROCM_CK_GEMM": use_ck_sdpa_gemm,
+            }
+        )
+        print(
+            f"CK SDPA and GEMM enabled: {env['USE_ROCM_CK_SDPA'] == 'ON'}"
+            f" (archs: {rocm_arch_list})"
         )
 
     env["USE_ROCM"] = "ON"


### PR DESCRIPTION
Add gfx125x to amdgpu_family_info_matrix_postsubmit in amdgpu_family_matrix.py and amdgpu_postsubmit group in new_amdgpu_family_matrix.py so that the ROCm stack and PyTorch builds also run on every push to main.

Depends on rocm-systems bump (PR #5787 or higher) for builds to pass.

## Motivation

Enable Post-commit CI after rocm-system bump adds copilation fix for gfx1250

