### PR TITLE
Add install retries to setup_venv.py to de-flake python test jobs

### DIFF
--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -31,6 +31,18 @@ There are a few modes this can be used in:
     python -m pip install rocm[libraries,devel] --index-url=https://.../gfx110X-all
     deactivate
     ```
+
+Some automated workflows using this script to install packages can run shortly
+after other workflows uploads those packages. In these cases server-side index
+generation may not have completed yet and installs can fail for 1-3 minutes.
+Package installs are retried by default to cover that transient window. This
+behavior can be adjusted with the `--install-retry-seconds` and
+`--install-retry-delay-seconds` arguments.
+See https://github.com/ROCm/TheRock/issues/5455 for more details.
+
+TODO: update docs and args for multi-arch
+   * --index-url https://rocm.nightlies.amd.com/whl-multi-arch/
+   * refresh ROCM_INDEX_URLS_MAP
 """
 
 import argparse

--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -36,8 +36,8 @@ Some automated workflows using this script to install packages can run shortly
 after other workflows uploads those packages. In these cases server-side index
 generation may not have completed yet and installs can fail for 1-3 minutes.
 Package installs are retried by default to cover that transient window. This
-behavior can be adjusted with the `--install-retry-seconds` and
-`--install-retry-delay-seconds` arguments.
+behavior can be adjusted with the `--install-retry-timeout-seconds` and
+`--install-retry-wait-between-seconds` arguments.
 See https://github.com/ROCm/TheRock/issues/5455 for more details.
 
 TODO: update docs and args for multi-arch
@@ -82,17 +82,20 @@ def run_command_with_retries(
     args: list[str | Path],
     cwd: Path = Path.cwd(),
     *,
-    retry_seconds: int,
-    retry_delay_seconds: int,
+    retry_timeout_seconds: int,
+    retry_wait_between_seconds: int,
 ):
-    deadline = time.monotonic() + retry_seconds
+    deadline = time.monotonic() + retry_timeout_seconds
     attempt = 1
     while True:
         try:
             run_command(args, cwd)
             return
         except subprocess.CalledProcessError as e:
-            if retry_seconds == 0 or time.monotonic() + retry_delay_seconds > deadline:
+            if (
+                retry_timeout_seconds == 0
+                or time.monotonic() + retry_wait_between_seconds > deadline
+            ):
                 log(
                     "Command failed after "
                     f"{attempt} attempt(s); no retry time remains"
@@ -101,9 +104,9 @@ def run_command_with_retries(
             log(
                 "Command failed "
                 f"(attempt {attempt}, exit code {e.returncode}); "
-                f"retrying in {retry_delay_seconds}s..."
+                f"retrying in {retry_wait_between_seconds}s..."
             )
-            time.sleep(retry_delay_seconds)
+            time.sleep(retry_wait_between_seconds)
             attempt += 1
 
 
@@ -200,8 +203,8 @@ def install_packages_into_venv(
     pre: bool = False,
     disable_cache: bool = False,
     *,
-    install_retry_seconds: int,
-    install_retry_delay_seconds: int,
+    install_retry_timeout_seconds: int,
+    install_retry_wait_between_seconds: int,
 ):
     """Installs packages into venv_dir using the provided options.
 
@@ -215,8 +218,8 @@ def install_packages_into_venv(
         find_links: URL for '--find-links' command argument
         pre: Allow pre-release packages (pip: --pre, uv: --prerelease=allow)
         disable_cache: Disable package cache (pip: --no-cache-dir, uv: --no-cache)
-        install_retry_seconds: Maximum retry window for the package install command
-        install_retry_delay_seconds: Delay between package install retries
+        install_retry_timeout_seconds: Maximum retry window for the install command
+        install_retry_wait_between_seconds: Delay between package install retries
     """
     log("")
 
@@ -255,8 +258,8 @@ def install_packages_into_venv(
 
     run_command_with_retries(
         pip_install_cmd,
-        retry_seconds=install_retry_seconds,
-        retry_delay_seconds=install_retry_delay_seconds,
+        retry_timeout_seconds=install_retry_timeout_seconds,
+        retry_wait_between_seconds=install_retry_wait_between_seconds,
     )
 
 
@@ -292,8 +295,8 @@ def run(args: argparse.Namespace):
             find_links=args.find_links,
             pre=args.pre,
             disable_cache=args.disable_cache,
-            install_retry_seconds=args.install_retry_seconds,
-            install_retry_delay_seconds=args.install_retry_delay_seconds,
+            install_retry_timeout_seconds=args.install_retry_timeout_seconds,
+            install_retry_wait_between_seconds=args.install_retry_wait_between_seconds,
         )
 
     if args.activate_in_future_github_actions_steps:
@@ -365,19 +368,20 @@ def main(argv: list[str]):
         help="Uses uv instead of pip/venv, see more at: https://docs.astral.sh/uv/",
     )
     general_options.add_argument(
-        "--install-retry-seconds",
+        "--install-retry-timeout-seconds",
         type=int,
         default=180,
         help=(
-            "Maximum retry window for package install failures in seconds "
-            "(default: 180; 0 disables retries)"
+            "Maximum wall-clock time to keep retrying failed package install "
+            "commands in seconds. This does not timeout an in-progress pip "
+            "command. (default: 180; 0 disables retries)"
         ),
     )
     general_options.add_argument(
-        "--install-retry-delay-seconds",
+        "--install-retry-wait-between-seconds",
         type=int,
         default=15,
-        help=("Seconds to wait between package install retries " "(default: 15)"),
+        help="Seconds to wait between failed package install attempts (default: 15)",
     )
 
     install_options = p.add_argument_group("Install options")
@@ -425,11 +429,14 @@ def main(argv: list[str]):
         p.error(f"venv_dir '{args.venv_dir}' exists and is not a directory")
     if args.index_name and not args.index_subdir:
         p.error("--index-subdir must be set when using --index-name")
-    if args.install_retry_seconds < 0:
-        p.error("--install-retry-seconds must be non-negative")
-    if args.install_retry_seconds > 0 and args.install_retry_delay_seconds <= 0:
+    if args.install_retry_timeout_seconds < 0:
+        p.error("--install-retry-timeout-seconds must be non-negative")
+    if (
+        args.install_retry_timeout_seconds > 0
+        and args.install_retry_wait_between_seconds <= 0
+    ):
         p.error(
-            "--install-retry-delay-seconds must be positive when retries are enabled"
+            "--install-retry-wait-between-seconds must be positive when retries are enabled"
         )
 
     run(args)

--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -81,9 +81,8 @@ def run_command(args: list[str | Path], cwd: Path = Path.cwd()):
 def run_command_with_retries(
     args: list[str | Path],
     cwd: Path = Path.cwd(),
-    *,
-    retry_timeout_seconds: int,
-    retry_wait_between_seconds: int,
+    retry_timeout_seconds: int = 0,
+    retry_wait_between_seconds: int = 0,
 ):
     deadline = time.monotonic() + retry_timeout_seconds
     attempt = 1
@@ -202,9 +201,8 @@ def install_packages_into_venv(
     find_links: str | None = None,
     pre: bool = False,
     disable_cache: bool = False,
-    *,
-    install_retry_timeout_seconds: int,
-    install_retry_wait_between_seconds: int,
+    install_retry_timeout_seconds: int = 0,
+    install_retry_wait_between_seconds: int = 0,
 ):
     """Installs packages into venv_dir using the provided options.
 

--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -41,6 +41,7 @@ import shutil
 import subprocess
 import sys
 import re
+import time
 
 from github_actions.github_actions_api import *
 
@@ -63,6 +64,35 @@ def run_command(args: list[str | Path], cwd: Path = Path.cwd()):
     args = [str(arg) for arg in args]
     log(f"++ Exec [{cwd}]$ {shlex.join(args)}")
     subprocess.check_call(args, cwd=str(cwd), stdin=subprocess.DEVNULL)
+
+
+def run_command_with_retries(
+    args: list[str | Path],
+    cwd: Path = Path.cwd(),
+    *,
+    retry_seconds: int,
+    retry_delay_seconds: int,
+):
+    deadline = time.monotonic() + retry_seconds
+    attempt = 1
+    while True:
+        try:
+            run_command(args, cwd)
+            return
+        except subprocess.CalledProcessError as e:
+            if retry_seconds == 0 or time.monotonic() + retry_delay_seconds > deadline:
+                log(
+                    "Command failed after "
+                    f"{attempt} attempt(s); no retry time remains"
+                )
+                raise
+            log(
+                "Command failed "
+                f"(attempt {attempt}, exit code {e.returncode}); "
+                f"retrying in {retry_delay_seconds}s..."
+            )
+            time.sleep(retry_delay_seconds)
+            attempt += 1
 
 
 def find_venv_python_exe(venv_path: Path) -> Path | None:
@@ -157,6 +187,9 @@ def install_packages_into_venv(
     find_links: str | None = None,
     pre: bool = False,
     disable_cache: bool = False,
+    *,
+    install_retry_seconds: int,
+    install_retry_delay_seconds: int,
 ):
     """Installs packages into venv_dir using the provided options.
 
@@ -170,6 +203,8 @@ def install_packages_into_venv(
         find_links: URL for '--find-links' command argument
         pre: Allow pre-release packages (pip: --pre, uv: --prerelease=allow)
         disable_cache: Disable package cache (pip: --no-cache-dir, uv: --no-cache)
+        install_retry_seconds: Maximum retry window for the package install command
+        install_retry_delay_seconds: Delay between package install retries
     """
     log("")
 
@@ -206,7 +241,11 @@ def install_packages_into_venv(
 
     pip_install_cmd.extend(packages)
 
-    run_command(pip_install_cmd)
+    run_command_with_retries(
+        pip_install_cmd,
+        retry_seconds=install_retry_seconds,
+        retry_delay_seconds=install_retry_delay_seconds,
+    )
 
 
 def log_venv_activate_instructions(venv_dir: Path):
@@ -241,6 +280,8 @@ def run(args: argparse.Namespace):
             find_links=args.find_links,
             pre=args.pre,
             disable_cache=args.disable_cache,
+            install_retry_seconds=args.install_retry_seconds,
+            install_retry_delay_seconds=args.install_retry_delay_seconds,
         )
 
     if args.activate_in_future_github_actions_steps:
@@ -311,6 +352,21 @@ def main(argv: list[str]):
         action=argparse.BooleanOptionalAction,
         help="Uses uv instead of pip/venv, see more at: https://docs.astral.sh/uv/",
     )
+    general_options.add_argument(
+        "--install-retry-seconds",
+        type=int,
+        default=180,
+        help=(
+            "Maximum retry window for package install failures in seconds "
+            "(default: 180; 0 disables retries)"
+        ),
+    )
+    general_options.add_argument(
+        "--install-retry-delay-seconds",
+        type=int,
+        default=15,
+        help=("Seconds to wait between package install retries " "(default: 15)"),
+    )
 
     install_options = p.add_argument_group("Install options")
 
@@ -357,6 +413,12 @@ def main(argv: list[str]):
         p.error(f"venv_dir '{args.venv_dir}' exists and is not a directory")
     if args.index_name and not args.index_subdir:
         p.error("--index-subdir must be set when using --index-name")
+    if args.install_retry_seconds < 0:
+        p.error("--install-retry-seconds must be non-negative")
+    if args.install_retry_seconds > 0 and args.install_retry_delay_seconds <= 0:
+        p.error(
+            "--install-retry-delay-seconds must be positive when retries are enabled"
+        )
 
     run(args)
 

--- a/build_tools/tests/setup_venv_test.py
+++ b/build_tools/tests/setup_venv_test.py
@@ -28,19 +28,12 @@ class InstallPackagesTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.venv_dir, ignore_errors=True)
 
-    def install_packages(self, **kwargs):
-        install_packages_into_venv(
-            venv_dir=self.venv_dir,
-            install_retry_timeout_seconds=0,
-            install_retry_wait_between_seconds=30,
-            **kwargs,
-        )
-
     @patch("setup_venv.find_venv_python_exe", return_value="python")
     @patch("setup_venv.run_command")
     def test_basic_pip_usage(self, mock_run, mock_find_python):
         """The most basic usage should run `python -m pip install [packages]`"""
-        self.install_packages(
+        install_packages_into_venv(
+            venv_dir=self.venv_dir,
             packages=["rocm"],
         )
 
@@ -55,7 +48,8 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_basic_uv_usage(self, mock_run, mock_find_python):
         """Using uv generates a different command structure."""
-        self.install_packages(
+        install_packages_into_venv(
+            venv_dir=self.venv_dir,
             packages=["rocm"],
             use_uv=True,
         )
@@ -71,7 +65,8 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_multiple_packages(self, mock_run, mock_find_python):
         """Multiple packages can be installed at once."""
-        self.install_packages(
+        install_packages_into_venv(
+            venv_dir=self.venv_dir,
             packages=["torch", "torchaudio"],
         )
 
@@ -83,7 +78,8 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_pre_flag_pip(self, mock_run, mock_find_python):
         """--pre flag uses pip syntax."""
-        self.install_packages(
+        install_packages_into_venv(
+            venv_dir=self.venv_dir,
             packages=["rocm"],
             pre=True,
         )
@@ -95,7 +91,8 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_pre_flag_uv(self, mock_run, mock_find_python):
         """--pre flag uses uv syntax when use_uv=True."""
-        self.install_packages(
+        install_packages_into_venv(
+            venv_dir=self.venv_dir,
             packages=["rocm"],
             use_uv=True,
             pre=True,
@@ -108,7 +105,8 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_index_url_complete(self, mock_run, mock_find_python):
         """Passing index_url without index_subdir uses the URL as-is."""
-        self.install_packages(
+        install_packages_into_venv(
+            venv_dir=self.venv_dir,
             packages=["rocm"],
             index_url="https://example.com/full/path/",
         )
@@ -120,7 +118,8 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_index_name_with_subdir(self, mock_run, mock_find_python):
         """Passing index_name with index_subdir constructs full URL."""
-        self.install_packages(
+        install_packages_into_venv(
+            venv_dir=self.venv_dir,
             packages=["rocm"],
             index_name="stable",
             index_subdir="gfx110X-all",
@@ -133,7 +132,8 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_index_url_with_subdir(self, mock_run, mock_find_python):
         """Passing index_url with index_subdir constructs full URL."""
-        self.install_packages(
+        install_packages_into_venv(
+            venv_dir=self.venv_dir,
             packages=["rocm"],
             index_url="https://example.com/base",
             index_subdir="gfx94X-dcgpu",
@@ -146,7 +146,8 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_find_links_only(self, mock_run, mock_find_python):
         """Passing just find_links uses it."""
-        self.install_packages(
+        install_packages_into_venv(
+            venv_dir=self.venv_dir,
             packages=["rocm"],
             find_links="https://bucket/run-123/index.html",
         )
@@ -159,7 +160,8 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_index_url_and_find_links(self, mock_run, mock_find_python):
         """Both index_url and find_links can be used together."""
-        self.install_packages(
+        install_packages_into_venv(
+            venv_dir=self.venv_dir,
             packages=["rocm"],
             index_url="https://deps/simple/",
             find_links="https://bucket/run-123/index.html",

--- a/build_tools/tests/setup_venv_test.py
+++ b/build_tools/tests/setup_venv_test.py
@@ -31,8 +31,8 @@ class InstallPackagesTest(unittest.TestCase):
     def install_packages(self, **kwargs):
         install_packages_into_venv(
             venv_dir=self.venv_dir,
-            install_retry_seconds=0,
-            install_retry_delay_seconds=30,
+            install_retry_timeout_seconds=0,
+            install_retry_wait_between_seconds=30,
             **kwargs,
         )
 
@@ -184,8 +184,8 @@ class InstallPackagesTest(unittest.TestCase):
         install_packages_into_venv(
             venv_dir=self.venv_dir,
             packages=["rocm"],
-            install_retry_seconds=60,
-            install_retry_delay_seconds=30,
+            install_retry_timeout_seconds=60,
+            install_retry_wait_between_seconds=30,
         )
 
         self.assertEqual(mock_run.call_count, 2)
@@ -204,8 +204,8 @@ class InstallPackagesTest(unittest.TestCase):
             install_packages_into_venv(
                 venv_dir=self.venv_dir,
                 packages=["rocm"],
-                install_retry_seconds=0,
-                install_retry_delay_seconds=30,
+                install_retry_timeout_seconds=0,
+                install_retry_wait_between_seconds=30,
             )
 
         self.assertEqual(mock_run.call_count, 1)

--- a/build_tools/tests/setup_venv_test.py
+++ b/build_tools/tests/setup_venv_test.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -27,12 +28,19 @@ class InstallPackagesTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.venv_dir, ignore_errors=True)
 
+    def install_packages(self, **kwargs):
+        install_packages_into_venv(
+            venv_dir=self.venv_dir,
+            install_retry_seconds=0,
+            install_retry_delay_seconds=30,
+            **kwargs,
+        )
+
     @patch("setup_venv.find_venv_python_exe", return_value="python")
     @patch("setup_venv.run_command")
     def test_basic_pip_usage(self, mock_run, mock_find_python):
         """The most basic usage should run `python -m pip install [packages]`"""
-        install_packages_into_venv(
-            venv_dir=self.venv_dir,
+        self.install_packages(
             packages=["rocm"],
         )
 
@@ -47,8 +55,7 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_basic_uv_usage(self, mock_run, mock_find_python):
         """Using uv generates a different command structure."""
-        install_packages_into_venv(
-            venv_dir=self.venv_dir,
+        self.install_packages(
             packages=["rocm"],
             use_uv=True,
         )
@@ -64,8 +71,7 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_multiple_packages(self, mock_run, mock_find_python):
         """Multiple packages can be installed at once."""
-        install_packages_into_venv(
-            venv_dir=self.venv_dir,
+        self.install_packages(
             packages=["torch", "torchaudio"],
         )
 
@@ -77,8 +83,7 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_pre_flag_pip(self, mock_run, mock_find_python):
         """--pre flag uses pip syntax."""
-        install_packages_into_venv(
-            venv_dir=self.venv_dir,
+        self.install_packages(
             packages=["rocm"],
             pre=True,
         )
@@ -90,8 +95,7 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_pre_flag_uv(self, mock_run, mock_find_python):
         """--pre flag uses uv syntax when use_uv=True."""
-        install_packages_into_venv(
-            venv_dir=self.venv_dir,
+        self.install_packages(
             packages=["rocm"],
             use_uv=True,
             pre=True,
@@ -104,8 +108,7 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_index_url_complete(self, mock_run, mock_find_python):
         """Passing index_url without index_subdir uses the URL as-is."""
-        install_packages_into_venv(
-            venv_dir=self.venv_dir,
+        self.install_packages(
             packages=["rocm"],
             index_url="https://example.com/full/path/",
         )
@@ -117,8 +120,7 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_index_name_with_subdir(self, mock_run, mock_find_python):
         """Passing index_name with index_subdir constructs full URL."""
-        install_packages_into_venv(
-            venv_dir=self.venv_dir,
+        self.install_packages(
             packages=["rocm"],
             index_name="stable",
             index_subdir="gfx110X-all",
@@ -131,8 +133,7 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_index_url_with_subdir(self, mock_run, mock_find_python):
         """Passing index_url with index_subdir constructs full URL."""
-        install_packages_into_venv(
-            venv_dir=self.venv_dir,
+        self.install_packages(
             packages=["rocm"],
             index_url="https://example.com/base",
             index_subdir="gfx94X-dcgpu",
@@ -145,8 +146,7 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_find_links_only(self, mock_run, mock_find_python):
         """Passing just find_links uses it."""
-        install_packages_into_venv(
-            venv_dir=self.venv_dir,
+        self.install_packages(
             packages=["rocm"],
             find_links="https://bucket/run-123/index.html",
         )
@@ -159,8 +159,7 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.run_command")
     def test_index_url_and_find_links(self, mock_run, mock_find_python):
         """Both index_url and find_links can be used together."""
-        install_packages_into_venv(
-            venv_dir=self.venv_dir,
+        self.install_packages(
             packages=["rocm"],
             index_url="https://deps/simple/",
             find_links="https://bucket/run-123/index.html",
@@ -169,6 +168,48 @@ class InstallPackagesTest(unittest.TestCase):
         cmd = mock_run.call_args[0][0]
         self.assertIn("--index-url=https://deps/simple/", cmd)
         self.assertIn("--find-links=https://bucket/run-123/index.html", cmd)
+
+    @patch("setup_venv.time.sleep")
+    @patch("setup_venv.find_venv_python_exe", return_value="python")
+    @patch("setup_venv.run_command")
+    def test_package_install_retries_then_succeeds(
+        self, mock_run, mock_find_python, mock_sleep
+    ):
+        """Transient package install failures are retried."""
+        mock_run.side_effect = [
+            subprocess.CalledProcessError(1, ["pip"]),
+            None,
+        ]
+
+        install_packages_into_venv(
+            venv_dir=self.venv_dir,
+            packages=["rocm"],
+            install_retry_seconds=60,
+            install_retry_delay_seconds=30,
+        )
+
+        self.assertEqual(mock_run.call_count, 2)
+        mock_sleep.assert_called_once_with(30)
+
+    @patch("setup_venv.time.sleep")
+    @patch("setup_venv.find_venv_python_exe", return_value="python")
+    @patch("setup_venv.run_command")
+    def test_package_install_retries_can_be_disabled(
+        self, mock_run, mock_find_python, mock_sleep
+    ):
+        """Setting the retry window to zero preserves fail-fast behavior."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, ["pip"])
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            install_packages_into_venv(
+                venv_dir=self.venv_dir,
+                packages=["rocm"],
+                install_retry_seconds=0,
+                install_retry_delay_seconds=30,
+            )
+
+        self.assertEqual(mock_run.call_count, 1)
+        mock_sleep.assert_not_called()
 
 
 class GfxRegexPatternTest(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Tentative fix for https://github.com/ROCm/TheRock/issues/5455. Our build jobs produce and upload packages and then server-side code regenerates index pages to include those packages. Queue time on the server-side functions is set to 60 seconds to debounce similar requests. If a test job is scheduled before the server-side code finishes running then tests fail with errors like
```
++ Exec [B:\runner\_work\rockrel\rockrel]$ 'B:\runner\_work\rockrel\rockrel\.venv\Scripts\python.exe' -m pip install --index-url=https://rocm.nightlies.amd.com/whl-multi-arch/ 'torch[device-gfx1100,device-gfx1101,device-gfx1102,device-gfx1103]==2.9.1+rocm7.14.0a20260612'
Looking in indexes: https://rocm.nightlies.amd.com/whl-multi-arch/
ERROR: Could not find a version that satisfies the requirement torch==2.9.1+rocm7.14.0a20260612 (from versions: 2.9.1+rocm7.14.0a20260521, 2.9.1+rocm7.14.0a20260522, 2.9.1+rocm7.14.0a20260524, 2.9.1+rocm7.14.0a20260525, 2.9.1+rocm7.14.0a20260526, 2.9.1+rocm7.14.0a20260527, 2.9.1+rocm7.14.0a20260528, 2.9.1+rocm7.14.0a20260529, 2.9.1+rocm7.14.0a20260531, 2.9.1+rocm7.14.0a20260601, 2.9.1+rocm7.14.0a20260602, 2.9.1+rocm7.14.0a20260603, 2.9.1+rocm7.14.0a20260604, 2.9.1+rocm7.14.0a20260605, 2.9.1+rocm7.14.0a20260606, 2.9.1+rocm7.14.0a20260607, 2.9.1+rocm7.14.0a20260611, 2.10.0+rocm7.14.0a20260521, 2.10.0+rocm7.14.0a20260522, 2.10.0+rocm7.14.0a20260524, 2.10.0+rocm7.14.0a20260525, 2.10.0+rocm7.14.0a20260526, 2.10.0+rocm7.14.0a20260527, 2.10.0+rocm7.14.0a20260528, 2.10.0+rocm7.14.0a20260529, 2.10.0+rocm7.14.0a20260601, 2.10.0+rocm7.14.0a20260602, 2.10.0+rocm7.14.0a20260603, 2.10.0+rocm7.14.0a20260604, 2.10.0+rocm7.14.0a20260605, 2.10.0+rocm7.14.0a20260606, 2.10.0+rocm7.14.0a20260607, 2.10.0+rocm7.14.0a20260608, 2.10.0+rocm7.14.0a20260611, 2.11.0+rocm7.14.0a20260521, 2.11.0+rocm7.14.0a20260522, 2.11.0+rocm7.14.0a20260524, 2.11.0+rocm7.14.0a20260525, 2.11.0+rocm7.14.0a20260526, 2.11.0+rocm7.14.0a20260527, 2.11.0+rocm7.14.0a20260528, 2.11.0+rocm7.14.0a20260529, 2.11.0+rocm7.14.0a20260531, 2.11.0+rocm7.14.0a20260601, 2.11.0+rocm7.14.0a20260602, 2.11.0+rocm7.14.0a20260603, 2.11.0+rocm7.14.0a20260604, 2.11.0+rocm7.14.0a20260605, 2.11.0+rocm7.14.0a20260606, 2.11.0+rocm7.14.0a20260607, 2.11.0+rocm7.14.0a20260611, 2.12.0+rocm7.14.0a20260521, 2.12.0+rocm7.14.0a20260522, 2.12.0+rocm7.14.0a20260524, 2.12.0+rocm7.14.0a20260525, 2.12.0+rocm7.14.0a20260526, 2.12.0+rocm7.14.0a20260527, 2.12.0+rocm7.14.0a20260528, 2.12.0+rocm7.14.0a20260529, 2.12.0+rocm7.14.0a20260531, 2.12.0+rocm7.14.0a20260601, 2.12.0+rocm7.14.0a20260602, 2.12.0+rocm7.14.0a20260603, 2.12.0+rocm7.14.0a20260604, 2.12.0+rocm7.14.0a20260605, 2.12.0+rocm7.14.0a20260606, 2.12.0+rocm7.14.0a20260607, 2.12.0+rocm7.14.0a20260608, 2.12.0+rocm7.14.0a20260611, 2.13.0a0+rocm7.14.0a20260521, 2.13.0a0+rocm7.14.0a20260527)
ERROR: No matching distribution found for torch==2.9.1+rocm7.14.0a20260612
```

> [!NOTE]
> This mostly affects our automated CI/CD systems. Individual users/developers who run install commands are not often running these commands within 1-2 minutes of the build jobs completing. Users/developers also typically don't pin an exact version like CI/CD workflows do, so they just install slightly older packages in the common case.

## Technical Details

This adds retry with timeout behavior _to each GPU test runner_ during python package installs to account for the delay in server-side index generation from running. I considered a few other options:

1. Add a fixed wait between 30 seconds and 2 minutes after the upload jobs.
    * This would save GPU runner time but would be unreliable if generation is slower than usual. It could also waste CPU runner time if the generation is faster than usual.
    * This could also help with native Linux/Windows packages, tarballs, and other workflows that involve asynchronous index generation and other post-upload-processing steps.
    * This could compose with the retries added here, providing two ways to mitigate the race condition.
2. After uploading, query the remote server index pages and check for the recently uploaded files
    * I can't think of a robust (and _simple_) way to do this. For Python packages we could use https://pip.pypa.io/en/latest/cli/pip_index/ but we'd realistically have to check "is torch-2.10.0+rocm7.14.0a20260522-cp311-cp311-linux_x86_64.whl there?", "is torch-2.10.0+rocm7.14.0a20260522-cp310-cp310-linux_x86_64.whl there?", etc. for all the packages that each job uploads. At that point we might as well parse the HTML pages themselves... ick
3. Wait for some "index generation complete" signal from the server
    * I think RPC calls would be the most robust solution here. Define some API endpoint that build jobs can post to with "upload these packages: <files>", then have the server mediate the upload and index generation then send back a "upload complete" response. Right now we just push raw files to S3 and let an AWS lambda function independently run whatever code it wants, without keeping that connection or signalling back to the uploading code that all operations are complete.

## Test Plan

Watch CI/CD workflow runs to see if the retry code is being used, is sufficient, and works.

Tested the retry behavior locally:

```
λ python D:\projects\TheRock\build_tools/setup_venv.py test_pip.venv --packages rocm[libraries]==1.2.3 --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ --install-retry-delay-seconds=2 --install-retry-seconds=20
Creating venv at 'test_pip.venv'
  Dir relative to CWD: 'test_pip.venv'
  Dir fully resolved : 'D:\scratch\therock\test_pip.venv'

  Found existing python executable at 'D:\scratch\therock\test_pip.venv\Scripts\python.exe', skipping creation
  Run again with --clean to clear the existing directory instead

++ Exec [D:\scratch\therock]$ 'test_pip.venv\Scripts\python.exe' -m pip install --upgrade pip
Requirement already satisfied: pip in .\test_pip.venv\Lib\site-packages (26.1.2)

++ Exec [D:\scratch\therock]$ 'test_pip.venv\Scripts\python.exe' -m pip install --index-url=https://rocm.nightlies.amd.com/whl-multi-arch/ 'rocm[libraries]==1.2.3'
Looking in indexes: https://rocm.nightlies.amd.com/whl-multi-arch/
ERROR: Could not find a version that satisfies the requirement rocm==1.2.3 (from versions: 7.13.0a20260425, 7.13.0a20260426, 7.13.0a20260427, 7.13.0a20260428, 7.13.0a20260430, 7.13.0a20260501, 7.13.0a20260502, 7.13.0a20260503, 7.13.0a20260504, 7.13.0a20260505, 7.13.0a20260506, 7.13.0a20260507, 7.13.0a20260508, 7.13.0a20260509, 7.13.0a20260510, 7.13.0a20260511, 7.13.0a20260512, 7.13.0a20260513, 7.13.0a20260514, 7.13.0a20260515, 7.14.0a20260518, 7.14.0a20260519, 7.14.0a20260520, 7.14.0a20260521, 7.14.0a20260522, 7.14.0a20260523, 7.14.0a20260524, 7.14.0a20260525, 7.14.0a20260526, 7.14.0a20260527, 7.14.0a20260528, 7.14.0a20260529, 7.14.0a20260531, 7.14.0a20260601, 7.14.0a20260602, 7.14.0a20260603, 7.14.0a20260604, 7.14.0a20260605, 7.14.0a20260606, 7.14.0a20260607, 7.14.0a20260608, 7.14.0a20260611, 7.14.0a20260612)
ERROR: No matching distribution found for rocm==1.2.3
Command failed (attempt 1, exit code 1); retrying in 2s...
++ Exec [D:\scratch\therock]$ 'test_pip.venv\Scripts\python.exe' -m pip install --index-url=https://rocm.nightlies.amd.com/whl-multi-arch/ 'rocm[libraries]==1.2.3'
Looking in indexes: https://rocm.nightlies.amd.com/whl-multi-arch/
ERROR: Could not find a version that satisfies the requirement rocm==1.2.3 (from versions: 7.13.0a20260425, 7.13.0a20260426, 7.13.0a20260427, 7.13.0a20260428, 7.13.0a20260430, 7.13.0a20260501, 7.13.0a20260502, 7.13.0a20260503, 7.13.0a20260504, 7.13.0a20260505, 7.13.0a20260506, 7.13.0a20260507, 7.13.0a20260508, 7.13.0a20260509, 7.13.0a20260510, 7.13.0a20260511, 7.13.0a20260512, 7.13.0a20260513, 7.13.0a20260514, 7.13.0a20260515, 7.14.0a20260518, 7.14.0a20260519, 7.14.0a20260520, 7.14.0a20260521, 7.14.0a20260522, 7.14.0a20260523, 7.14.0a20260524, 7.14.0a20260525, 7.14.0a20260526, 7.14.0a20260527, 7.14.0a20260528, 7.14.0a20260529, 7.14.0a20260531, 7.14.0a20260601, 7.14.0a20260602, 7.14.0a20260603, 7.14.0a20260604, 7.14.0a20260605, 7.14.0a20260606, 7.14.0a20260607, 7.14.0a20260608, 7.14.0a20260611, 7.14.0a20260612)
ERROR: No matching distribution found for rocm==1.2.3
Command failed (attempt 2, exit code 1); retrying in 2s...
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
