### PR TITLE
Override CK GfxArch behavior in kpack mode

### DIFF
--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -230,6 +230,12 @@ def is_gfxarch_package(pkg_info, enable_kpack=False):
         if pkgname in ["amdrocm-rccl", "amdrocm-rccl-test"]:
             return True
 
+        # Override CK Gfxarch behavior in kpack mode
+        # When --enable-kpack is used, CK should look for generic artifacts
+        # Root Cause: CK provides generic artifacts only
+        if pkgname in ["amdrocm-ck"]:
+            return False
+
     return is_key_defined(pkg_info, "Gfxarch")
 
 


### PR DESCRIPTION
## Motivation

This pull request updates `packaging_utils.py` to handle a special case for the `amdrocm-ck` package when kpack mode is enabled. The change ensures that, when `--enable-kpack` is used, CK packages are treated as generic artifacts rather than being tied to a specific Gfxarch.

## Technical Details

Behavioral change for CK packages in kpack mode:
* Updated for the `amdrocm-ck` package when kpack mode is enabled, ensuring CK is treated as providing generic artifacts.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
