### PR TITLE
[ci] Increase AWS build runners to 50%

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -46,13 +46,13 @@ def select_weighted_label(labels_config: list[dict], context_name: str) -> str:
 
 
 # Build runner configuration for Linux builds
-# Uses weighted distribution: 80% Azure, 20% AWS
+# Uses weighted distribution: 50% Azure, 50% AWS
 # Sanitizer builds (asan/tsan) use ramdisk variants (100% Azure, no AWS yet)
 BUILD_RUNNER_LABELS = {
     "linux": {
         "default": [
-            {"label": "azure-linux-scale-rocm", "weight": 0.8},
-            {"label": "aws-linux-scale-rocm-prod", "weight": 0.2},
+            {"label": "azure-linux-scale-rocm", "weight": 0.5},
+            {"label": "aws-linux-scale-rocm-prod", "weight": 0.5},
         ],
         "sanitizer": [
             {"label": "azure-linux-scale-rocm-heavy-ramdisk", "weight": 1.0},

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1387,17 +1387,17 @@ class TestBuildRunnerSelection(unittest.TestCase):
     """Test weighted random selection of build runners (Azure vs AWS)."""
 
     def test_select_build_runner_weighted_selection(self):
-        """Test weighted selection: Azure (80%) vs AWS (20%) for default builds."""
+        """Test weighted selection: Azure (50%) vs AWS (50%) for default builds."""
         from amdgpu_family_matrix import select_build_runner
 
-        # Random < 0.8 should select Azure
-        with patch("random.random", return_value=0.5):
+        # Random < 0.5 should select Azure
+        with patch("random.random", return_value=0.3):
             self.assertEqual(
                 select_build_runner("linux", "release"), "azure-linux-scale-rocm"
             )
 
-        # Random >= 0.8 should select AWS
-        with patch("random.random", return_value=0.95):
+        # Random >= 0.5 should select AWS
+        with patch("random.random", return_value=0.75):
             self.assertEqual(
                 select_build_runner("linux", "release"), "aws-linux-scale-rocm-prod"
             )


### PR DESCRIPTION
## Summary

- Increases AWS prod runner weight from 20% → 50% (50% Azure / 50% AWS)
- Continues the gradual migration from Azure to AWS runners

## Prerequisites

- [x] Prod AZRebalance suspension applied (TheRock-Infra#301) — prevents mid-build node termination
- [x] AWS prod runners stable at 20% since TheRock#5706

## Test plan
- [ ] Verify CI jobs begin routing ~50% of Linux builds to `aws-linux-scale-rocm-prod`
- [ ] Monitor Grafana prod dashboard for runner pod pressure and co-location

🤖 Generated with [Claude Code](https://claude.com/claude-code)