### PR TITLE
[ci] Use ubuntu24.04 for configure_test_matrix job

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -98,31 +98,14 @@ run-name: Test Artifacts (${{ inputs.amdgpu_families }}, ${{ inputs.release_type
 jobs:
   configure_test_matrix:
     name: "Configure test matrix (${{ inputs.amdgpu_families }})"
-    # if there is a test machine available
     if: ${{ inputs.test_runs_on != '' }}
-    runs-on: ${{ inputs.test_runs_on }}
+    runs-on: ubuntu-24.04
     outputs:
       sanity_component: ${{ steps.configure.outputs.sanity_component }}
       components: ${{ steps.configure.outputs.components }}
       platform: ${{ steps.configure.outputs.platform }}
       shard_arr: ${{ steps.configure.outputs.shard_arr }}
     steps:
-      - name: "Fetch 'build_tools' from repository"
-        if: ${{ runner.os == 'Windows' }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref }}
-          sparse-checkout: build_tools
-          path: "prejob"
-
-      # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
-      # Post-job cleanup isn't necessary since no executables are launched in this job.
-      - name: Pre-job cleanup processes on Windows
-        if: ${{ runner.os == 'Windows' }}
-        shell: powershell
-        run: . '${{ github.workspace }}\prejob\build_tools\github_actions\cleanup_processes.ps1'
-
       - name: Checking out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -143,7 +126,9 @@ jobs:
           TEST_LABELS: ${{ inputs.test_labels }}
           RUN_EXTENDED_TESTS: ${{ inputs.run_extended_tests }}
           WINDOWS_HIP_ROCR_TESTS: ${{ inputs.windows_hip_rocr_tests }}
-        run: python ./build_tools/github_actions/fetch_test_configurations.py
+        run: |
+          python ./build_tools/github_actions/fetch_test_configurations.py \
+            --platform=${{ contains(inputs.test_runs_on, 'windows') && 'windows' || 'linux' }}
 
   test_sanity_check:
     name: 'Test Sanity Check'

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -848,6 +848,9 @@ def _expand_build_config_for_platform(
             test_runner_kernel = label.split(":")[1]
             break
 
+    # Select build runner using weighted distribution (same for all families)
+    build_runs_on = select_build_runner(platform, build_variant)
+
     per_family_info: list[dict] = []
     for family_name in families:
         # select_targets already validates family names and filters by
@@ -946,6 +949,7 @@ def _expand_build_config_for_platform(
                 "amdgpu_family": platform_info["family"],
                 "amdgpu_targets": ",".join(platform_info["fetch-gfx-targets"]),
                 "test-runs-on": test_runs_on,
+                "build-runs-on": build_runs_on,
                 "sanity_check_only_for_family": platform_info.get(
                     "sanity_check_only_for_family", False
                 ),
@@ -959,9 +963,6 @@ def _expand_build_config_for_platform(
     expect_failure = variant_config.get("expect_failure", False)
     expect_pytorch_failure = variant_config.get("expect_pytorch_failure", False)
     suffix = variant_config.get("build_variant_suffix", "")
-
-    # Select build runner using weighted distribution
-    build_runs_on = select_build_runner(platform, build_variant)
 
     return BuildConfig(
         per_family_info=per_family_info,

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -676,7 +676,17 @@ test_matrix = {
 
 
 def run():
-    platform = os.getenv("RUNNER_OS").lower()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--platform",
+        type=str,
+        default=os.getenv("RUNNER_OS", "linux").lower(),
+        help="Platform to configure tests for (linux or windows)",
+    )
+    args = parser.parse_args()
+    platform = args.platform
     projects_to_test = os.getenv("PROJECTS_TO_TEST", "*")
     amdgpu_families = os.getenv("AMDGPU_FAMILIES")
     test_type = os.getenv("TEST_TYPE", "standard")

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -832,6 +832,7 @@ class TestExpandBuildConfigs(unittest.TestCase):
             "amdgpu_family",
             "amdgpu_targets",
             "test-runs-on",
+            "build-runs-on",
             "sanity_check_only_for_family",
         }
         for config in [result.linux, result.windows]:


### PR DESCRIPTION
As configure test matrix step does not require a GPU, we are using our CPU builders to determine this

linux configure test matrix working: https://github.com/ROCm/TheRock/actions/runs/27442979100/job/81121623123#step:1:2

windows configure test matrix working: https://github.com/ROCm/TheRock/actions/runs/27442979100/job/81121781166#step:1:2