### PR TITLE
[ci] Use `ubuntu24.04` for `configure_test_matrix` job

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -100,29 +100,13 @@ jobs:
     name: "Configure test matrix (${{ inputs.amdgpu_families }})"
     # if there is a test machine available
     if: ${{ inputs.test_runs_on != '' }}
-    runs-on: ${{ inputs.test_runs_on }}
+    runs-on: ubuntu-24.04
     outputs:
       sanity_component: ${{ steps.configure.outputs.sanity_component }}
       components: ${{ steps.configure.outputs.components }}
       platform: ${{ steps.configure.outputs.platform }}
       shard_arr: ${{ steps.configure.outputs.shard_arr }}
     steps:
-      - name: "Fetch 'build_tools' from repository"
-        if: ${{ runner.os == 'Windows' }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref }}
-          sparse-checkout: build_tools
-          path: "prejob"
-
-      # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
-      # Post-job cleanup isn't necessary since no executables are launched in this job.
-      - name: Pre-job cleanup processes on Windows
-        if: ${{ runner.os == 'Windows' }}
-        shell: powershell
-        run: . '${{ github.workspace }}\prejob\build_tools\github_actions\cleanup_processes.ps1'
-
       - name: Checking out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -143,7 +127,9 @@ jobs:
           TEST_LABELS: ${{ inputs.test_labels }}
           RUN_EXTENDED_TESTS: ${{ inputs.run_extended_tests }}
           WINDOWS_HIP_ROCR_TESTS: ${{ inputs.windows_hip_rocr_tests }}
-        run: python ./build_tools/github_actions/fetch_test_configurations.py
+        run: |
+          python ./build_tools/github_actions/fetch_test_configurations.py \
+            --platform=${{ contains(inputs.test_runs_on, 'windows') && 'windows' || 'linux' }}
 
   test_sanity_check:
     name: 'Test Sanity Check'

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -15,13 +15,15 @@ Required environment variables:
   - RUNNER_OS (https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#detecting-the-operating-system)
 """
 
+import argparse
 import ast
 import json
 import logging
 import os
+import platform as platform_module
 import sys
-from pathlib import Path
 from copy import deepcopy
+from pathlib import Path
 
 # Add tests directory to path for extended_tests imports
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tests"))
@@ -676,7 +678,15 @@ test_matrix = {
 
 
 def run():
-    platform = os.getenv("RUNNER_OS").lower()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--platform",
+        type=str,
+        default=platform_module.system().lower(),
+        help="Platform to configure tests for (linux or windows)",
+    )
+    args, _ = parser.parse_known_args()
+    platform = args.platform
     projects_to_test = os.getenv("PROJECTS_TO_TEST", "*")
     amdgpu_families = os.getenv("AMDGPU_FAMILIES")
     test_type = os.getenv("TEST_TYPE", "standard")

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -17,6 +17,8 @@ class FetchTestConfigurationsTest(unittest.TestCase):
     def setUp(self):
         # Save environment so tests don't leak state
         self._orig_env = os.environ.copy()
+        # Save sys.argv so tests don't leak state
+        self._orig_argv = sys.argv.copy()
         # Save module-level attributes that tests may change
         self._orig_functional_matrix = fetch_test_configurations.functional_matrix
         self._orig_benchmark_matrix = fetch_test_configurations.benchmark_matrix
@@ -24,11 +26,13 @@ class FetchTestConfigurationsTest(unittest.TestCase):
             fetch_test_configurations.get_all_families_for_trigger_types
         )
 
-        os.environ["RUNNER_OS"] = "Linux"
         os.environ["AMDGPU_FAMILIES"] = "gfx94X-dcgpu"
         os.environ["TEST_TYPE"] = "full"
         os.environ["TEST_LABELS"] = "[]"
         os.environ["PROJECTS_TO_TEST"] = "*"
+
+        # Default to linux platform
+        sys.argv = ["fetch_test_configurations.py", "--platform=linux"]
 
         # Capture gha_set_output instead of writing to GitHub
         self.gha_output = {}
@@ -41,6 +45,7 @@ class FetchTestConfigurationsTest(unittest.TestCase):
     def tearDown(self):
         os.environ.clear()
         os.environ.update(self._orig_env)
+        sys.argv = self._orig_argv
         # Restore module-level attributes
         fetch_test_configurations.functional_matrix = self._orig_functional_matrix
         fetch_test_configurations.benchmark_matrix = self._orig_benchmark_matrix
@@ -135,7 +140,7 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         components = self._get_components()
         hipblaslt_linux = components[0]
 
-        os.environ["RUNNER_OS"] = "Windows"
+        sys.argv = ["fetch_test_configurations.py", "--platform=windows"]
         fetch_test_configurations.run()
         components = self._get_components()
         hipblaslt_windows = components[0]
@@ -313,7 +318,7 @@ class FetchTestConfigurationsTest(unittest.TestCase):
 
     def test_windows_hip_tests_default_emits_pal_only(self):
         """On Windows, hip-tests emits only PAL by default (WINDOWS_HIP_ROCR_TESTS off)."""
-        os.environ["RUNNER_OS"] = "Windows"
+        sys.argv = ["fetch_test_configurations.py", "--platform=windows"]
         os.environ["TEST_LABELS"] = json.dumps(["hip-tests"])
 
         fetch_test_configurations.run()
@@ -328,7 +333,7 @@ class FetchTestConfigurationsTest(unittest.TestCase):
 
     def test_windows_hip_tests_emits_pal_and_rocr_entries(self):
         """On Windows with WINDOWS_HIP_ROCR_TESTS=true, hip-tests runs PAL and ROCR."""
-        os.environ["RUNNER_OS"] = "Windows"
+        sys.argv = ["fetch_test_configurations.py", "--platform=windows"]
         os.environ["TEST_LABELS"] = json.dumps(["hip-tests"])
         os.environ["WINDOWS_HIP_ROCR_TESTS"] = "true"
 
@@ -354,7 +359,7 @@ class FetchTestConfigurationsTest(unittest.TestCase):
 
     def test_windows_hip_tests_quick_uses_single_shard(self):
         """On Windows with test_type=quick and ROCR enabled, PAL/ROCR each use 1 shard."""
-        os.environ["RUNNER_OS"] = "Windows"
+        sys.argv = ["fetch_test_configurations.py", "--platform=windows"]
         os.environ["TEST_LABELS"] = json.dumps(["hip-tests"])
         os.environ["TEST_TYPE"] = "quick"
         os.environ["WINDOWS_HIP_ROCR_TESTS"] = "true"


### PR DESCRIPTION
As configure test matrix step does not require a GPU, we are using ubuntu24 to determine this

linux configure test matrix working: https://github.com/ROCm/TheRock/actions/runs/27445401758/job/81129474031

windows configure test matrix working: https://github.com/ROCm/TheRock/actions/runs/27445401758/job/81130272475

tried to reopen #5832 but it was force-pushed :( 