### PR TITLE
Surface more useful URLs in bump PR bodies

### DIFF
--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -84,19 +84,13 @@ def latest_commit(repo, token):
 
 
 def generate_pr_body(repo, base, head):
-    compare = f"https://github.com/{repo}/compare/{base}...{head}"
+    base_url = f"https://github.com/{repo}/commit/{base}"
+    head_url = f"https://github.com/{repo}/commit/{head}"
+    compare_url = f"https://github.com/{repo}/compare/{base}...{head}"
     return f"""
-Bumps [{repo}](https://github.com/{repo}) from `{base[:7]}` to `{head[:7]}`.
+Bumps [{repo}](https://github.com/{repo}) from {base_url} to {head_url}.
 
-<details>
-<summary>Commits</summary>
-
-See full comparison here:
-
-{compare}
-
-</details>
-<br />
+See full comparison here: {compare_url}
 """
 
 


### PR DESCRIPTION
## Motivation

This changes the format from:

> Bumps [ROCm/rocm-systems](https://github.com/ROCm/rocm-systems) from `1b2a555` to `6e8a553`.
> 
> <details>
> <summary>Commits</summary>
> 
> See full comparison here:
> 
> https://github.com/ROCm/rocm-systems/compare/1b2a555677ae5ed2e859d22db97b12ff69b343bd...6e8a55387bfe8b7f41e7d445ee4a8c02005d56fb
> 
> </details>
> <br />

To:

> Bumps [ROCm/rocm-systems](https://github.com/ROCm/rocm-systems) from https://github.com/ROCm/rocm-systems/commit/1b2a555677ae5ed2e859d22db97b12ff69b343bd to https://github.com/ROCm/rocm-systems/commit/6e8a55387bfe8b7f41e7d445ee4a8c02005d56fb.
> 
> See full comparison here: https://github.com/ROCm/rocm-systems/compare/1b2a555677ae5ed2e859d22db97b12ff69b343bd...6e8a55387bfe8b7f41e7d445ee4a8c02005d56fb

Now the individual commits are clickable URLs and the comparison is not hidden under an expandable `<details><summary>` block. We could add back the block if we wanted to list all commits individually, as dependabot does on PRs like https://github.com/ROCm/TheRock/pull/5703:

<img width="508" height="190" alt="image" src="https://github.com/user-attachments/assets/7db8116a-3127-44ce-b060-e3da0383e443" />

## Test Plan

Untested but looks safe... this code doesn't look like it was designed to be tested. We can watch the next scheduled run?

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
