### PR TITLE
Add public is_current_run_pr_from_fork() wrapper for cache-type gating

### DIFF
--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -170,6 +170,15 @@ def _is_current_run_pr_from_fork() -> bool:
     )
 
 
+def is_current_run_pr_from_fork() -> bool:
+    """Whether the current workflow run is a pull request from a fork.
+
+    Public wrapper around the module-internal implementation, for reuse by
+    other build scripts.
+    """
+    return _is_current_run_pr_from_fork()
+
+
 def get_artifacts_bucket_config_for_workflow_run(
     github_repository: str,
     release_type: str | None = None,

--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -142,43 +142,6 @@ def get_release_bucket_config(
     return _BUCKET_CONFIGS_BY_NAME[bucket_name]
 
 
-def _is_current_run_pr_from_fork() -> bool:
-    """Check if the current workflow run is a pull request from a fork.
-
-    Reads the GitHub event payload to check the .fork property on the
-    head repo, matching the behavior of the GitHub Actions expression
-    ``github.event.pull_request.head.repo.fork``.
-
-    Returns False for non-pull_request events or if the event payload
-    is not available (e.g. local development).
-    """
-    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
-    if event_name != "pull_request":
-        return False
-
-    if not os.environ.get("GITHUB_EVENT_PATH"):
-        return False
-
-    # Deferred import: github_actions is optional in some environments; only
-    # needed when resolving fork state from the on-disk event payload.
-    from github_actions.github_actions_api import gha_load_github_event
-
-    event = gha_load_github_event()
-
-    return bool(
-        event.get("pull_request", {}).get("head", {}).get("repo", {}).get("fork", False)
-    )
-
-
-def is_current_run_pr_from_fork() -> bool:
-    """Whether the current workflow run is a pull request from a fork.
-
-    Public wrapper around the module-internal implementation, for reuse by
-    other build scripts.
-    """
-    return _is_current_run_pr_from_fork()
-
-
 def get_artifacts_bucket_config_for_workflow_run(
     github_repository: str,
     release_type: str | None = None,
@@ -240,7 +203,11 @@ def get_artifacts_bucket_config_for_workflow_run(
         _log(f"  head_github_repository: {head_github_repository}")
         _log(f"  is_pr_from_fork: {is_pr_from_fork}")
     else:
-        is_pr_from_fork = _is_current_run_pr_from_fork()
+        # Deferred import: github_actions is optional in some environments;
+        # only needed when resolving fork state from the on-disk event payload.
+        from github_actions.github_actions_api import is_current_run_pr_from_fork
+
+        is_pr_from_fork = is_current_run_pr_from_fork()
         _log(f"  is_pr_from_fork: {is_pr_from_fork}")
 
     config = get_artifacts_bucket_config(

--- a/build_tools/github_actions/compute_pytorch_cache_type.py
+++ b/build_tools/github_actions/compute_pytorch_cache_type.py
@@ -26,8 +26,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from _therock_utils.s3_buckets import is_current_run_pr_from_fork
-from github_actions_api import gha_set_output
+from github_actions_api import gha_set_output, is_current_run_pr_from_fork
 
 
 def compute_cache_type(cache_type: str, github_repository: str) -> str:

--- a/build_tools/github_actions/compute_pytorch_cache_type.py
+++ b/build_tools/github_actions/compute_pytorch_cache_type.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from _therock_utils.s3_buckets import _is_current_run_pr_from_fork
+from _therock_utils.s3_buckets import is_current_run_pr_from_fork
 from github_actions_api import gha_set_output
 
 
@@ -40,7 +40,7 @@ def compute_cache_type(cache_type: str, github_repository: str) -> str:
     if cache_type != "sccache":
         return cache_type
 
-    if _is_current_run_pr_from_fork() or github_repository != "ROCm/TheRock":
+    if is_current_run_pr_from_fork() or github_repository != "ROCm/TheRock":
         print(
             "sccache is unavailable for fork PRs / external repositories "
             "(no OIDC access to the sccache IAM role); using cache_type=none."

--- a/build_tools/github_actions/github_actions_api.py
+++ b/build_tools/github_actions/github_actions_api.py
@@ -431,6 +431,26 @@ def gha_load_github_event() -> dict[str, Any]:
     return data
 
 
+def is_current_run_pr_from_fork() -> bool:
+    """Whether the current workflow run is a pull request from a fork.
+
+    Reads the GitHub event payload to check the ``.fork`` property on the head
+    repo, matching the GitHub Actions expression
+    ``github.event.pull_request.head.repo.fork``.
+
+    Returns False for non-pull_request events or if the event payload is not
+    available (e.g. local development).
+    """
+    if os.environ.get("GITHUB_EVENT_NAME", "") != "pull_request":
+        return False
+    if not os.environ.get("GITHUB_EVENT_PATH"):
+        return False
+    event = gha_load_github_event()
+    return bool(
+        event.get("pull_request", {}).get("head", {}).get("repo", {}).get("fork", False)
+    )
+
+
 def gha_send_request(url: str, timeout_seconds: int = 300) -> object:
     """Sends a request to the given GitHub REST API URL and returns the response.
 

--- a/build_tools/github_actions/tests/compute_pytorch_cache_type_test.py
+++ b/build_tools/github_actions/tests/compute_pytorch_cache_type_test.py
@@ -23,7 +23,7 @@ class TestComputeCacheType(unittest.TestCase):
     def _run(self, cache_type, repo="ROCm/TheRock", is_fork=False):
         with mock.patch.object(
             compute_pytorch_cache_type,
-            "_is_current_run_pr_from_fork",
+            "is_current_run_pr_from_fork",
             return_value=is_fork,
         ):
             return compute_cache_type(cache_type, repo)
@@ -47,10 +47,10 @@ class TestComputeCacheType(unittest.TestCase):
         self.assertEqual(self._run("none", is_fork=True), "none")
 
     def test_fork_check_skipped_when_not_sccache(self):
-        # _is_current_run_pr_from_fork must not even be consulted for ccache/none.
+        # is_current_run_pr_from_fork must not even be consulted for ccache/none.
         with mock.patch.object(
             compute_pytorch_cache_type,
-            "_is_current_run_pr_from_fork",
+            "is_current_run_pr_from_fork",
             side_effect=AssertionError("should not be called"),
         ):
             self.assertEqual(compute_cache_type("ccache", "ROCm/TheRock"), "ccache")
@@ -66,7 +66,7 @@ class TestMain(unittest.TestCase):
             env = {"GITHUB_REPOSITORY": repo, "GITHUB_OUTPUT": str(out)}
             with mock.patch.dict(os.environ, env), mock.patch.object(
                 compute_pytorch_cache_type,
-                "_is_current_run_pr_from_fork",
+                "is_current_run_pr_from_fork",
                 return_value=is_fork,
             ):
                 main(["--cache-type", cache_type])


### PR DESCRIPTION
Follow-up to #5816, addressing the review nit at https://github.com/ROCm/TheRock/pull/5816#discussion_r3405042032 (importing the private `_is_current_run_pr_from_fork` across files).

Adds a public `is_current_run_pr_from_fork()` wrapper in `s3_buckets.py` and repoints `compute_pytorch_cache_type.py` (and its test mocks) to it. No behavior change.

## Test plan
- [x] `compute_pytorch_cache_type_test.py` (8 cases) pass
- [x] Real fork-event smoke test: fork+sccache -> none

## Submission Checklist
 Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.