### PR TITLE
feat(dockerfiles): add Debian 12/13 support and install core-sdk meta…

### DIFF
--- a/dockerfiles/install_rocm_deps.sh
+++ b/dockerfiles/install_rocm_deps.sh
@@ -9,6 +9,7 @@
 #
 # Supported distributions:
 #   - Ubuntu 22.04, 24.04 (apt)
+#   - Debian 12, 13 (apt)
 #   - AlmaLinux 8 (dnf)
 #   - Azure Linux 3 (tdnf)
 #   - RHEL 8.10, 9.7, 10.1 (dnf)
@@ -42,7 +43,7 @@ echo "Detected distribution: $DISTRO"
 echo "Detected version: $VERSION_ID"
 
 case "$DISTRO" in
-    ubuntu)
+    ubuntu|debian)
         echo "Installing dependencies using apt..."
         apt-get update
         apt-get install -y --no-install-recommends \
@@ -165,7 +166,7 @@ case "$DISTRO" in
 
     *)
         echo "Error: Unsupported distribution: $DISTRO"
-        echo "Supported distributions: ubuntu, almalinux, azurelinux, rhel, sles"
+        echo "Supported distributions: ubuntu, debian, almalinux, azurelinux, rhel, sles"
         exit 1
         ;;
 esac

--- a/dockerfiles/install_rocm_packages.sh
+++ b/dockerfiles/install_rocm_packages.sh
@@ -6,6 +6,8 @@
 #
 # Installs ROCm from deb/rpm packages via the system package manager.
 # Automatically detects the distribution and configures the appropriate repository.
+# Installs both the runtime meta-package (amdrocm*) and the core SDK meta-package
+# (amdrocm-core-sdk*) to provide a complete ROCm installation.
 #
 # Usage:
 #   ./install_rocm_packages.sh <VERSION> <AMDGPU_FAMILY> [RELEASE_TYPE]
@@ -98,6 +100,12 @@ map_distro_to_repo() {
             PKG_TYPE="deb"
             PKG_MGR="apt"
             ;;
+        debian)
+            # Debian VERSION_ID is major-only (e.g., 12, 13) → debian12, debian13
+            REPO_DISTRO="debian${major_ver}"
+            PKG_TYPE="deb"
+            PKG_MGR="apt"
+            ;;
         almalinux)
             # AlmaLinux uses RHEL repos
             REPO_DISTRO="rhel${major_ver}"
@@ -121,7 +129,7 @@ map_distro_to_repo() {
             ;;
         *)
             echo "Error: Unsupported distribution: $id"
-            echo "Supported: ubuntu, almalinux, azurelinux, rhel, sles"
+            echo "Supported: ubuntu, debian, almalinux, azurelinux, rhel, sles"
             exit 1
             ;;
     esac
@@ -239,7 +247,7 @@ get_gpg_key_url() {
 install_deb() {
     local repo_url="$1"
     local gpg_key_url="$2"
-    local meta_package="$3"
+    local meta_packages="$3"  # space-separated list
     local release_type="$4"
 
     echo "Configuring APT repository..."
@@ -260,8 +268,9 @@ install_deb() {
     echo "Repository configured: $(cat /etc/apt/sources.list.d/rocm.list)"
     apt-get update
 
-    echo "Installing ${meta_package}..."
-    apt-get install -y --no-install-recommends "$meta_package"
+    echo "Installing ${meta_packages}..."
+    # shellcheck disable=SC2086  # intentional word-splitting of package list
+    apt-get install -y --no-install-recommends ${meta_packages}
     rm -rf /var/lib/apt/lists/*
 }
 
@@ -271,7 +280,7 @@ install_deb() {
 install_rpm_dnf() {
     local repo_url="$1"
     local gpg_key_url="$2"
-    local meta_package="$3"
+    local meta_packages="$3"  # space-separated list
     local release_type="$4"
     local pkg_mgr="$5"
 
@@ -306,13 +315,15 @@ REPOEOF
             rm -f /tmp/rocm.gpg
         fi
         tdnf clean all
-        echo "Installing ${meta_package}..."
-        tdnf install -y "$meta_package"
+        echo "Installing ${meta_packages}..."
+        # shellcheck disable=SC2086  # intentional word-splitting of package list
+        tdnf install -y ${meta_packages}
     else
         # dnf: --allowerasing needed for RHEL UBI images where curl-minimal conflicts with curl
         dnf clean all
-        echo "Installing ${meta_package}..."
-        dnf install -y --allowerasing "$meta_package"
+        echo "Installing ${meta_packages}..."
+        # shellcheck disable=SC2086  # intentional word-splitting of package list
+        dnf install -y --allowerasing ${meta_packages}
         dnf clean all
     fi
 }
@@ -323,7 +334,7 @@ REPOEOF
 install_rpm_zypper() {
     local repo_url="$1"
     local gpg_key_url="$2"
-    local meta_package="$3"
+    local meta_packages="$3"  # space-separated list
     local release_type="$4"
 
     echo "Configuring Zypper repository..."
@@ -349,8 +360,9 @@ REPOEOF
     cat /etc/zypp/repos.d/rocm.repo
 
     zypper --non-interactive --gpg-auto-import-keys refresh
-    echo "Installing ${meta_package}..."
-    zypper --non-interactive install --no-recommends "$meta_package"
+    echo "Installing ${meta_packages}..."
+    # shellcheck disable=SC2086  # intentional word-splitting of package list
+    zypper --non-interactive install --no-recommends ${meta_packages}
     zypper clean --all
 }
 
@@ -359,12 +371,14 @@ REPOEOF
 # ===========================================================================
 
 MAJOR_MINOR=$(extract_major_minor "$VERSION")
+# Install both the runtime meta-package (amdrocm*) and the core SDK meta-package
+# (amdrocm-core-sdk*) so the image gets a complete ROCm installation.
 if [ "$MULTI_ARCH" = "1" ]; then
     GPU_TARGET="multi-arch"
-    META_PACKAGE="amdrocm${MAJOR_MINOR}"
+    META_PACKAGES="amdrocm${MAJOR_MINOR} amdrocm-core-sdk${MAJOR_MINOR}"
 else
     GPU_TARGET=$(normalize_gpu_target "$AMDGPU_FAMILY")
-    META_PACKAGE="amdrocm${MAJOR_MINOR}-${GPU_TARGET}"
+    META_PACKAGES="amdrocm${MAJOR_MINOR}-${GPU_TARGET} amdrocm-core-sdk${MAJOR_MINOR}-${GPU_TARGET}"
 fi
 
 echo "=============================================="
@@ -374,7 +388,7 @@ echo "Version:         ${VERSION}"
 echo "Major.Minor:     ${MAJOR_MINOR}"
 echo "AMDGPU Family:   ${AMDGPU_FAMILY}"
 echo "GPU Target:      ${GPU_TARGET}"
-echo "Meta Package:    ${META_PACKAGE}"
+echo "Meta Packages:   ${META_PACKAGES}"
 echo "Release Type:    ${RELEASE_TYPE}"
 echo "Install Mode:    $([ "$MULTI_ARCH" = "1" ] && echo "multi-arch" || echo "single-family")"
 echo "=============================================="
@@ -407,13 +421,13 @@ echo "=============================================="
 # Install based on package type
 case "$PKG_MGR" in
     apt)
-        install_deb "$REPO_URL" "$GPG_KEY_URL" "$META_PACKAGE" "$RELEASE_TYPE"
+        install_deb "$REPO_URL" "$GPG_KEY_URL" "$META_PACKAGES" "$RELEASE_TYPE"
         ;;
     dnf|tdnf)
-        install_rpm_dnf "$REPO_URL" "$GPG_KEY_URL" "$META_PACKAGE" "$RELEASE_TYPE" "$PKG_MGR"
+        install_rpm_dnf "$REPO_URL" "$GPG_KEY_URL" "$META_PACKAGES" "$RELEASE_TYPE" "$PKG_MGR"
         ;;
     zypper)
-        install_rpm_zypper "$REPO_URL" "$GPG_KEY_URL" "$META_PACKAGE" "$RELEASE_TYPE"
+        install_rpm_zypper "$REPO_URL" "$GPG_KEY_URL" "$META_PACKAGES" "$RELEASE_TYPE"
         ;;
 esac
 

--- a/dockerfiles/rocm_runtime.Dockerfile
+++ b/dockerfiles/rocm_runtime.Dockerfile
@@ -27,6 +27,8 @@
 #
 # Supported base images (examples)
 # - ubuntu:24.04
+# - debian:12 (Bookworm)
+# - debian:13 (Trixie)
 # - almalinux:8
 # - mcr.microsoft.com/azurelinux/base/core:3.0
 # - registry.access.redhat.com/ubi8/ubi:8.10 (RHEL 8.10)
@@ -83,6 +85,28 @@
 #     --build-arg RELEASE_TYPE=stable \
 #     -f dockerfiles/rocm_runtime.Dockerfile \
 #     -t rocm:ubuntu22.04-gfx94X-7.10.0 \
+#     dockerfiles/
+#
+#   # Debian 12 + gfx110x via packages (stable)
+#   docker build \
+#     --build-arg BASE_IMAGE=debian:12 \
+#     --build-arg VERSION=7.13.0 \
+#     --build-arg AMDGPU_FAMILY=gfx110x \
+#     --build-arg RELEASE_TYPE=stable \
+#     --build-arg INSTALL_METHOD=packages \
+#     -f dockerfiles/rocm_runtime.Dockerfile \
+#     -t rocm:debian12-gfx110x-7.13.0 \
+#     dockerfiles/
+#
+#   # Debian 13 + multi-arch via packages (stable)
+#   docker build \
+#     --build-arg BASE_IMAGE=debian:13 \
+#     --build-arg VERSION=7.13.0 \
+#     --build-arg AMDGPU_FAMILY=multi-arch \
+#     --build-arg RELEASE_TYPE=stable \
+#     --build-arg INSTALL_METHOD=packages \
+#     -f dockerfiles/rocm_runtime.Dockerfile \
+#     -t rocm:debian13-multi-arch-7.13.0 \
 #     dockerfiles/
 #
 #   # RHEL 8.10 UBI + gfx94X (nightly)


### PR DESCRIPTION
  ## Motivation

The ROCm runtime Dockerfile (`dockerfiles/rocm_runtime.Dockerfile`) did not support Debian as a base image, and the package-based install only installed the runtime meta package, leaving the image without a complete ROCm installation (no core SDK components).

This PR adds Debian 12/13 support and installs the core SDK meta package alongside the runtime meta package so package-based images provide a complete ROCm installation across all supported distros.

## Technical Details

  - **`dockerfiles/install_rocm_deps.sh`**: handle the `debian` distro id through the existing apt branch (`ubuntu|debian`); update the supported-distro doc comment and the unsupported-distro error message.
  - **`dockerfiles/install_rocm_packages.sh`**:
    - Map `debian` to the `debian12`/`debian13` repositories (deb/apt). Debian `VERSION_ID` is major-only (e.g. `12`, `13`), matching the repo layout under `repo.amd.com/rocm/packages/debian12|debian13`.
    - Install **both** the runtime meta package (`amdrocm*`) and the core SDK meta package (`amdrocm-core-sdk*`) — for both single-family (`amdrocm<MM>-<gpu>` + `amdrocm-core-sdk<MM>-<gpu>`) and multi-arch (`amdrocm<MM>` + `amdrocm-core-sdk<MM>`) modes.
    - Pass the meta packages as a space-separated list and install them across all package managers (apt / dnf / tdnf / zypper).
  - **`dockerfiles/rocm_runtime.Dockerfile`**: add `debian:12` / `debian:13` to the supported base image list and add stable package-install build examples.

## Test Plan

Real `docker build` runs on an x86_64 build host (Docker 24.0.7), covering every supported distro across both release channels (`INSTALL_METHOD=packages`, `AMDGPU_FAMILY=gfx110x`, parallel builds):

  - Distros: ubuntu 22.04 / 24.04, debian 12 / 13, almalinux 8, RHEL UBI 9.7 / 10.1, azurelinux 3.0, SLES BCI 15.7 / 16.0.
  - Channels: `stable` (7.13.0) and `nightlies` (7.14.0a*).
  - Per-image verification inside the container: both `amdrocm` and `amdrocm-core-sdk` meta packages installed, `/opt/rocm/bin/hipcc --version` works, `rocminfo` present.
  - Debian validated end-to-end (stable + nightly), confirming the new `debian` branch resolves packages from the correct `debian12`/`debian13` (deb) repos.

## Test Result

All distros install both `amdrocm` and `amdrocm-core-sdk` correctly with `hipcc` available; the change itself passes on every distro × channel.

One unrelated, non-blocking note: **SLES 15.7 stable** fails due to an upstream packaging bug where `librocprof-sys` linked the public `libdw`/`libelf` (needs `ELFUTILS_0.186`, unsatisfiable on SLES), which pulled in conflicting 7.11 packages. This is fixed upstream in rocm-systems PR #6445 (already in TheRock via the rocm-systems bump commit) and verified resolved on a SLES 15.7 post-fix nightly (no 7.11 packages pulled; `librocprof-sys` links the vendored `librocm_sysdeps_dw/elf`). Only the pre-fix stable 7.13.0-2 release is affected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
