### PR TITLE
Auto-derive gfx targets from family in install_rocm_from_artifacts (ROCM-26102)

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -185,6 +185,7 @@ jobs:
             --run-id "${{ env.ARTIFACT_RUN_ID }}" \
             --repository "${{ github.repository }}" \
             --amdgpu-family "${{ inputs.amdgpu_families }}" \
+            --amdgpu-targets "${{ inputs.amdgpu_targets }}" \
             --test-script "${{ fromJSON(inputs.component).test_script }}" \
             --shard-index "${{ matrix.shard }}" \
             --total-shards "${{ fromJSON(inputs.component).total_shards }}" \

--- a/build_tools/github_actions/reproduce_test_failure.py
+++ b/build_tools/github_actions/reproduce_test_failure.py
@@ -77,6 +77,8 @@ def build_reproduction_command(args: argparse.Namespace) -> str:
         f"--amdgpu-family {args.amdgpu_family} "
         f'--test-script "{args.test_script}" '
     )
+    if args.amdgpu_targets:
+        cmd += f" --amdgpu-targets {args.amdgpu_targets}"
     if args.shard_index != "1":
         cmd += f" --shard-index {args.shard_index}"
     if args.total_shards != "1":
@@ -100,6 +102,8 @@ def run_linux(args: argparse.Namespace) -> int:
         f"--run-id {args.run_id} "
         f"--amdgpu-family {args.amdgpu_family}"
     )
+    if args.amdgpu_targets:
+        fetch_cmd += f" --amdgpu-targets {args.amdgpu_targets}"
     if args.fetch_artifact_args:
         fetch_cmd += f" {args.fetch_artifact_args}"
 
@@ -218,6 +222,8 @@ def run_windows(args: argparse.Namespace) -> int:
         f"--run-id {args.run_id} "
         f"--amdgpu-family {args.amdgpu_family}"
     )
+    if args.amdgpu_targets:
+        fetch_cmd += f" --amdgpu-targets {args.amdgpu_targets}"
     if args.fetch_artifact_args:
         fetch_cmd += f" {args.fetch_artifact_args}"
 
@@ -343,6 +349,12 @@ def main() -> int:
     parser.add_argument("--run-id", required=True, help="GitHub Actions run ID")
     parser.add_argument("--repository", required=True, help="GitHub repository")
     parser.add_argument("--amdgpu-family", required=True, help="AMDGPU family")
+    parser.add_argument(
+        "--amdgpu-targets",
+        default="",
+        help="Comma-separated gfx targets (e.g. gfx942). Needed to fetch "
+        "per-target kpack-split shards; optional for monolithic runs.",
+    )
     parser.add_argument("--test-script", required=True, help="Test script to run")
     parser.add_argument("--shard-index", default="1", help="Shard index")
     parser.add_argument("--total-shards", default="1", help="Total shards")

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -120,6 +120,7 @@ from botocore import UNSIGNED
 from botocore.config import Config
 from datetime import datetime
 from fetch_artifacts import main as fetch_artifacts_main
+from _therock_utils.cmake_amdgpu_targets import amdgpu_family_map, expand_families
 from pathlib import Path
 import platform
 import re
@@ -313,6 +314,21 @@ def retrieve_artifacts_by_run_id(args):
     ]
     if args.amdgpu_targets:
         argv.extend(["--amdgpu-targets", args.amdgpu_targets])
+    else:
+        # Auto-derive gfx targets from the family so a family-only install also
+        # fetches per-target (kpack-split) shards. In split runs the per-target
+        # shard carries data the family/'generic' shards lack (e.g. MIOpen
+        # tuning DBs under share/miopen/db); without these targets the fetch
+        # matches only the family literal and 'generic', silently dropping them.
+        derived_targets = expand_families(
+            [args.artifact_group], amdgpu_family_map(), strict=False
+        )
+        if derived_targets:
+            log(
+                f"Auto-deriving --amdgpu-targets from family "
+                f"'{args.artifact_group}': {','.join(derived_targets)}"
+            )
+            argv.extend(["--amdgpu-targets", ",".join(derived_targets)])
     if args.dry_run:
         argv.append("--dry-run")
     if args.run_github_repo:


### PR DESCRIPTION
# Auto-derive gfx targets from family in install_rocm_from_artifacts

## Motivation

`Smoke/GPU_ConvNDKernelTuningAI_*` MIOpen tests (ROCM-26102) failed when run
against a family-only artifact install, but passed in CI. The root cause was a
fetch gap specific to **kpack-split** runs.

In a split run the per-target shard (e.g. `_gfx942`) carries the MIOpen tuning
databases under `share/miopen/db/` (`.tn.model`, `.ktn.model`, `.kdb`), while
the `_generic` shard holds only `libMIOpen.so*`. A family-only install
(`--amdgpu-family gfx94X-dcgpu` with no `--amdgpu-targets`) matched only the
family literal and `generic` shards, **silently dropping the per-target shard**
— so the tuning DBs were never installed and the AI-tuning tests failed.

CI never hit this because `.github/actions/setup_test_environment` always passes
`--amdgpu-targets` explicitly. The gap only affected manual installs and the
repro commands CI generates for failed tests (which omitted `--amdgpu-targets`,
reproducing the broken install rather than the one that actually ran).

## Technical Details

- **`build_tools/install_rocm_from_artifacts.py`**: When `--amdgpu-targets` is
  omitted, expand the family to its gfx targets via the CMake source of truth
  (`_therock_utils.cmake_amdgpu_targets.expand_families` /
  `amdgpu_family_map`) and pass them through to the fetch. `strict=False` so an
  unknown/non-expandable family group (no derived targets) leaves behavior
  unchanged rather than erroring. This reuses the same utility already wrapped
  by `build_tools/github_actions/expand_amdgpu_families.py`. The import resolves
  via `build_tools/` on `sys.path[0]`, matching the existing
  `from fetch_artifacts import main`.
- **`build_tools/github_actions/reproduce_test_failure.py`**: Add an optional
  `--amdgpu-targets` argument and thread it into the printed reproduction
  command and into both the Linux and Windows `install_rocm_from_artifacts.py`
  fetch invocations, so generated repro commands faithfully target the split
  shard that ran.
- **`.github/workflows/test_component.yml`**: Pass the existing
  `inputs.amdgpu_targets` to the `reproduce_test_failure.py` invocation so CI
  emits correct repro commands for split runs.

## Risk Assessment

**Risk Level: 🟢 Low**

29-line additive change across 3 files. The behavioral change is gated on
`--amdgpu-targets` being absent — callers that already pass targets (all of CI)
are unaffected. No dependencies added; the only new import is an in-repo utility
already used elsewhere.

### Impacted Components

- `build_tools/install_rocm_from_artifacts.py` (manual/repro artifact installs)
- `build_tools/github_actions/reproduce_test_failure.py` (CI repro-command generator)
- `.github/workflows/test_component.yml` (test workflow that invokes the generator)

### Potential Side Effects

- A family-only install now fetches additional per-target shards, so it
  downloads more data than before (this is the intended fix). Monolithic runs
  have no per-target shards, so the wider matcher is a no-op for them.
- If a family group cannot be expanded to targets, `expand_families` returns
  empty and the install behaves exactly as before.

### Mitigation Steps

- Change is opt-out by passing `--amdgpu-targets` explicitly.
- Verified via dry-run that the derived matcher only adds the expected target.
- Revert is a single-commit revert with no migration concerns.

## Test Plan

- Dry-run `install_rocm_from_artifacts.py` with `--amdgpu-family gfx94X-dcgpu`
  and no `--amdgpu-targets`; confirm derivation and the widened shard matcher.
- Real (non-dry-run) family-only download against a split run, then run the
  previously-failing `Smoke/GPU_ConvNDKernelTuningAI_*` tests.

## Test Result

- Dry-run confirmed `gfx94X-dcgpu` derives `--amdgpu-targets gfx942` and the
  shard matcher widened to `['generic', 'gfx942', 'gfx94X-dcgpu']`.
- Real family-only download pulled the MIOpen DB shard and the previously
  failing AI-tuning unit tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
