### PR TITLE
build(emulation): librocjitsu.so is the interesting artifact

### DIFF
--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -37,7 +37,6 @@ if(THEROCK_ENABLE_ROCJITSU)
   therock_test_validate_shared_lib(PATH rocjitsu/dist/lib
     LIB_NAMES
       librocjitsu.so
-      librocjitsu_kmd.so
   )
 
   therock_provide_artifact(rocjitsu

--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -36,6 +36,7 @@ if(THEROCK_ENABLE_ROCJITSU)
 
   therock_test_validate_shared_lib(PATH rocjitsu/dist/lib
     LIB_NAMES
+      librocjitsu.so
       librocjitsu_kmd.so
   )
 

--- a/emulation/artifact-rocjitsu.toml
+++ b/emulation/artifact-rocjitsu.toml
@@ -1,5 +1,9 @@
 # rocjitsu
 [components.lib."emulation/rocjitsu/stage"]
+default_patterns = false
+include = [
+  "lib/librocjitsu.so",
+]
 [components.dbg."emulation/rocjitsu/stage"]
 [components.dev."emulation/rocjitsu/stage"]
 [components.run."emulation/rocjitsu/stage"]

--- a/emulation/artifact-rocjitsu.toml
+++ b/emulation/artifact-rocjitsu.toml
@@ -1,9 +1,5 @@
 # rocjitsu
 [components.lib."emulation/rocjitsu/stage"]
-default_patterns = false
-include = [
-  "lib/librocjitsu_kmd.so",
-]
 [components.dbg."emulation/rocjitsu/stage"]
 [components.dev."emulation/rocjitsu/stage"]
 [components.run."emulation/rocjitsu/stage"]


### PR DESCRIPTION
## Motivation
librocjitsu_kmd.so will depend on librocjitsu.so

## Technical Details

include librocjitsu.so in artifact

## Test Plan

- check the ci builds
- check artifacts

## Test Result

ci failures were unrelated.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
