### PR TITLE
[ci] Adding more efficient distribution of test runners with arch containing `test-runs-on-label`

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -140,7 +140,7 @@ jobs:
       artifact_group: ${{ inputs.artifact_group }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
       amdgpu_targets: ${{ inputs.amdgpu_targets }}
-      test_runs_on: ${{ inputs.test_runs_on }}
+      test_runs_on: ${{ fromJSON(needs.configure_test_matrix.outputs.sanity_component).test_runner }}
       platform: ${{ needs.configure_test_matrix.outputs.platform }}
       component: ${{ needs.configure_test_matrix.outputs.sanity_component }}
       release_type: ${{ inputs.release_type }}
@@ -177,7 +177,7 @@ jobs:
       #   1. Benchmark components use the dedicated benchmark runner
       #   2. Multi-GPU components use the multi-GPU runner
       #   3. CPU-only components use standard GitHub runners (azure-linux-scale-rocm)
-      #   4. Everything else uses the standard test runner (GPU runners)
+      #   4. Per-component runner (set by fetch_test_configurations.py)
       test_runs_on: >-
         ${{
           (matrix.components.is_benchmark == true &&
@@ -187,7 +187,7 @@ jobs:
             matrix.components.multi_gpu_runner) ||
           (matrix.components.linux_cpu_runner == true &&
             'azure-linux-scale-rocm') ||
-          inputs.test_runs_on
+          matrix.components.test_runner
         }}
       platform: ${{ needs.configure_test_matrix.outputs.platform }}
       component: ${{ toJSON(matrix.components) }}

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -59,7 +59,6 @@ from amdgpu_family_matrix import (
     all_build_variants,
     get_all_families_for_trigger_types,
     select_build_runner,
-    select_weighted_label,
 )
 from configure_ci_path_filters import (
     get_git_modified_paths,
@@ -864,14 +863,10 @@ def _expand_build_config_for_platform(
             continue
 
         # Determine test runner label.
+        # Note: Per-component weighted runner selection is handled in
+        # fetch_test_configurations.py for better load distribution.
+        # Here we just use the default fallback label.
         test_runs_on = platform_info["test-runs-on"]
-
-        # Handle multi-label configuration with weighted random selection.
-        # Some families (e.g. gfx94x) have multiple runner labels available.
-        if "test-runs-on-labels" in platform_info:
-            test_runs_on = select_weighted_label(
-                platform_info["test-runs-on-labels"], family_name
-            )
 
         # TODO: use hard-coded label (vultr machines) as we try to determine core42 regression
         # This is a temporary measure to get good signal for submodule bumps while we determine core42 issues

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -698,6 +698,8 @@ def run():
     # This enables better load distribution across runner pools
     test_runs_on_labels = None
     test_runs_on_default = None
+    test_runs_on_multi_gpu_labels = None
+    test_runs_on_multi_gpu_default = None
     if amdgpu_families:
         shortened_family = amdgpu_families.split("-")[0].lower()
         all_families = get_all_families_for_trigger_types(
@@ -707,6 +709,12 @@ def run():
             platform_info = all_families[shortened_family].get(platform, {})
             test_runs_on_labels = platform_info.get("test-runs-on-labels")
             test_runs_on_default = platform_info.get("test-runs-on", "")
+            test_runs_on_multi_gpu_labels = platform_info.get(
+                "test-runs-on-multi-gpu-labels"
+            )
+            test_runs_on_multi_gpu_default = platform_info.get(
+                "test-runs-on-multi-gpu", ""
+            )
 
     logging.info(f"Selecting projects: {projects_to_test}")
 
@@ -868,8 +876,17 @@ def run():
     # Per-component runner selection for better load distribution
     # Each component gets its own independent random draw based on configured weights
     for component in all_components:
-        if "test_runner" not in component and "multi_gpu_runner" not in component:
-            job_name = component.get("job_name", "unknown")
+        job_name = component.get("job_name", "unknown")
+        if "multi_gpu_runner" in component:
+            # Multi-GPU components use multi-GPU runner labels
+            if test_runs_on_multi_gpu_labels:
+                component["multi_gpu_runner"] = select_weighted_label(
+                    test_runs_on_multi_gpu_labels, f"{job_name}-multi-gpu"
+                )
+            elif test_runs_on_multi_gpu_default:
+                component["multi_gpu_runner"] = test_runs_on_multi_gpu_default
+        else:
+            # Regular components use standard runner labels
             if test_runs_on_labels:
                 component["test_runner"] = select_weighted_label(
                     test_runs_on_labels, job_name

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -835,35 +835,16 @@ def run():
             # Inside the "multi_gpu" field, we have a mapping of amdgpu_family -> bool (if multi GPU testing is enabled for that family)
             # If the multi GPU test runner is not enabled, we will skip the test
             if "multi_gpu" in selected_matrix[key]:
-                amdgpu_families_matrix = get_all_families_for_trigger_types(
-                    ["presubmit", "postsubmit", "nightly"]
-                )
                 if (
                     platform in selected_matrix[key]["multi_gpu"]
                     and amdgpu_families in selected_matrix[key]["multi_gpu"][platform]
                 ):
-                    # If the architecture is available for multi GPU testing, we indicate that this specific test requires the multi GPU test runner
-                    shortened_amdgpu_families_name = amdgpu_families.split("-")[
-                        0
-                    ].lower()
-                    platform_info = amdgpu_families_matrix[
-                        shortened_amdgpu_families_name
-                    ][platform]
-
-                    # Use weighted random selection if test-runs-on-multi-gpu-labels is available
-                    # Each component gets its own independent random draw for better load distribution
-                    if "test-runs-on-multi-gpu-labels" in platform_info:
-                        multi_gpu_runner = select_weighted_label(
-                            platform_info["test-runs-on-multi-gpu-labels"],
-                            f"{job_name}-multi-gpu",
-                        )
-                    else:
-                        multi_gpu_runner = platform_info["test-runs-on-multi-gpu"]
-
+                    # Mark this component as needing a multi-GPU runner.
+                    # The actual runner selection is done in the per-component loop below.
+                    job_config_data["multi_gpu_runner"] = True
                     logging.info(
-                        f"Including job {job_name} since multi GPU testing is available for family {amdgpu_families} with runner {multi_gpu_runner}"
+                        f"Including job {job_name} for multi GPU testing with family {amdgpu_families}"
                     )
-                    job_config_data["multi_gpu_runner"] = multi_gpu_runner
                 else:
                     # If the architecture is not available for multi GPU testing, we skip the test requiring multi GPU
                     logging.info(

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -694,6 +694,20 @@ def run():
     run_extended_tests = str2bool(os.getenv("RUN_EXTENDED_TESTS", "false"))
     windows_hip_rocr_tests = str2bool(os.getenv("WINDOWS_HIP_ROCR_TESTS", "false"))
 
+    # Get runner config for per-component runner selection
+    # This enables better load distribution across runner pools
+    test_runs_on_labels = None
+    test_runs_on_default = None
+    if amdgpu_families:
+        shortened_family = amdgpu_families.split("-")[0].lower()
+        all_families = get_all_families_for_trigger_types(
+            ["presubmit", "postsubmit", "nightly"]
+        )
+        if shortened_family in all_families:
+            platform_info = all_families[shortened_family].get(platform, {})
+            test_runs_on_labels = platform_info.get("test-runs-on-labels")
+            test_runs_on_default = platform_info.get("test-runs-on", "")
+
     logging.info(f"Selecting projects: {projects_to_test}")
 
     # Build the selected test matrix:
@@ -759,6 +773,7 @@ def run():
                 total_shards = base.get("total_shards_dict", {}).get(platform, 1)
                 if test_type == "quick":
                     total_shards = 1
+
                 shard_arr = list(range(1, total_shards + 1))
 
                 pal_entry = {
@@ -828,10 +843,11 @@ def run():
                     ][platform]
 
                     # Use weighted random selection if test-runs-on-multi-gpu-labels is available
+                    # Each component gets its own independent random draw for better load distribution
                     if "test-runs-on-multi-gpu-labels" in platform_info:
                         multi_gpu_runner = select_weighted_label(
                             platform_info["test-runs-on-multi-gpu-labels"],
-                            f"{shortened_amdgpu_families_name}-multi-gpu",
+                            f"{job_name}-multi-gpu",
                         )
                     else:
                         multi_gpu_runner = platform_info["test-runs-on-multi-gpu"]
@@ -848,6 +864,18 @@ def run():
                     continue
 
             all_components.append(job_config_data)
+
+    # Per-component runner selection for better load distribution
+    # Each component gets its own independent random draw based on configured weights
+    for component in all_components:
+        if "test_runner" not in component and "multi_gpu_runner" not in component:
+            job_name = component.get("job_name", "unknown")
+            if test_runs_on_labels:
+                component["test_runner"] = select_weighted_label(
+                    test_runs_on_labels, job_name
+                )
+            elif test_runs_on_default:
+                component["test_runner"] = test_runs_on_default
 
     # Build container options for all components (concatenates base, GPU, and job-specific options)
     all_components = [_build_container_options(c, platform) for c in all_components]

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1311,8 +1311,12 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         total_weight = sum(l["weight"] for l in labels)
         self.assertAlmostEqual(total_weight, 1.0, places=1)
 
-    def test_first_label_selected_when_random_low(self):
-        """When random() < first weight, first label should be selected."""
+    def test_expand_build_configs_uses_default_runner(self):
+        """expand_build_configs uses the default test-runs-on label.
+
+        Note: Per-component weighted runner selection is handled in
+        fetch_test_configurations.py, not in expand_build_configs.
+        """
         ci_inputs = cm.CIInputs(
             run_id="12345",
             event_name="pull_request",
@@ -1322,63 +1326,16 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         )
         targets = cm.TargetSelection(linux_families=["gfx94x"])
 
-        # Mock random.random() to return 0.1 (< 0.369 first weight)
-        with patch("random.random", return_value=0.1):
-            builds = cm.expand_build_configs(
-                targets, ci_inputs, test_type="quick", git_context=cm.GitContext()
-            )
-
-        self.assertIsNotNone(builds.linux)
-        # Check that the first label was selected
-        gfx94x_info = builds.linux.per_family_info[0]
-        self.assertEqual(
-            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ccs-ossci-rocm"
+        builds = cm.expand_build_configs(
+            targets, ci_inputs, test_type="quick", git_context=cm.GitContext()
         )
 
-    def test_second_label_selected_when_random_medium(self):
-        """When random() is in second range, second label should be selected."""
-        ci_inputs = cm.CIInputs(
-            run_id="12345",
-            event_name="pull_request",
-            commit_ref="feature",
-            base_ref="HEAD^",
-            build_variant="release",
-        )
-        targets = cm.TargetSelection(linux_families=["gfx94x"])
-
-        # Mock random.random() to return 0.4 (>= 0.369, < 0.455)
-        with patch("random.random", return_value=0.4):
-            builds = cm.expand_build_configs(
-                targets, ci_inputs, test_type="quick", git_context=cm.GitContext()
-            )
-
         self.assertIsNotNone(builds.linux)
-        # Check that the second label was selected
         gfx94x_info = builds.linux.per_family_info[0]
+        # Should use the default test-runs-on label (core42)
         self.assertEqual(
             gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-core42-ossci-rocm"
         )
-
-    def test_third_label_selected_when_random_high(self):
-        """When random() >= first two weights, third label should be selected."""
-        ci_inputs = cm.CIInputs(
-            run_id="12345",
-            event_name="pull_request",
-            commit_ref="feature",
-            base_ref="HEAD^",
-            build_variant="release",
-        )
-        targets = cm.TargetSelection(linux_families=["gfx94x"])
-
-        with patch("random.random", return_value=0.9):
-            builds = cm.expand_build_configs(
-                targets, ci_inputs, test_type="quick", git_context=cm.GitContext()
-            )
-
-        self.assertIsNotNone(builds.linux)
-        # Check that the third label was selected
-        gfx94x_info = builds.linux.per_family_info[0]
-        self.assertEqual(gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ossci-rocm")
 
     def test_families_without_multi_label_use_primary_only(self):
         """Families without multi-label config should only use primary label."""

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -288,9 +288,9 @@ class FetchTestConfigurationsTest(unittest.TestCase):
 
             rccl = next(j for j in components if j["job_name"] == "rccl")
             self.assertEqual(rccl["multi_gpu_runner"], "linux-mi300-mgpu-a")
-            # Verify select_weighted_label was called
+            # Verify select_weighted_label was called with job-specific context
             self.assertEqual(len(selected_labels), 1)
-            self.assertEqual(selected_labels[0][1], "gfx94x-multi-gpu")
+            self.assertEqual(selected_labels[0][1], "rccl-multi-gpu")
         finally:
             fetch_test_configurations.select_weighted_label = (
                 original_select_weighted_label

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -259,6 +259,11 @@ class FetchTestConfigurationsTest(unittest.TestCase):
             return {
                 "gfx94x": {
                     "linux": {
+                        "test-runs-on": "linux-gfx942-default",
+                        "test-runs-on-labels": [
+                            {"label": "linux-gfx942-a", "weight": 0.5},
+                            {"label": "linux-gfx942-b", "weight": 0.5},
+                        ],
                         "test-runs-on-multi-gpu": "linux-mi300-mgpu-default",
                         "test-runs-on-multi-gpu-labels": [
                             {"label": "linux-mi300-mgpu-a", "weight": 0.5},
@@ -272,13 +277,16 @@ class FetchTestConfigurationsTest(unittest.TestCase):
             fake_get_all_families
         )
 
-        # Mock select_weighted_label to verify it's called and return a known label
+        # Mock select_weighted_label to verify it's called and return known labels
         original_select_weighted_label = fetch_test_configurations.select_weighted_label
         selected_labels = []
 
         def fake_select_weighted_label(labels_config, context_name):
             selected_labels.append((labels_config, context_name))
-            return "linux-mi300-mgpu-a"
+            # Return different labels based on whether it's multi-gpu
+            if "multi-gpu" in context_name:
+                return "linux-mi300-mgpu-a"
+            return "linux-gfx942-a"
 
         fetch_test_configurations.select_weighted_label = fake_select_weighted_label
 
@@ -288,9 +296,10 @@ class FetchTestConfigurationsTest(unittest.TestCase):
 
             rccl = next(j for j in components if j["job_name"] == "rccl")
             self.assertEqual(rccl["multi_gpu_runner"], "linux-mi300-mgpu-a")
-            # Verify select_weighted_label was called with job-specific context
-            self.assertEqual(len(selected_labels), 1)
-            self.assertEqual(selected_labels[0][1], "rccl-multi-gpu")
+            # Verify select_weighted_label was called for rccl multi-gpu
+            multi_gpu_calls = [c for c in selected_labels if "multi-gpu" in c[1]]
+            self.assertEqual(len(multi_gpu_calls), 1)
+            self.assertEqual(multi_gpu_calls[0][1], "rccl-multi-gpu")
         finally:
             fetch_test_configurations.select_weighted_label = (
                 original_select_weighted_label


### PR DESCRIPTION
Currently, label selection (for those labels with "test-runs-on-labels") were selected at `configure` and are responsible for ALL jobs afterwards.

However, this is an inefficient way of balancing resources and maximizing usage. Now, with this change, each individual job picks up a runner, making the distribution more efficient

Test runs in a workflow dispatch (random samples):
- https://github.com/ROCm/TheRock/actions/runs/27585251851
    - https://github.com/ROCm/TheRock/actions/runs/27585251851/job/81554474526#step:1:2
    - https://github.com/ROCm/TheRock/actions/runs/27585251851/job/81554679974#step:1:2
    - https://github.com/ROCm/TheRock/actions/runs/27585251851/job/81554680100#step:1:2
    - https://github.com/ROCm/TheRock/actions/runs/27585251851/job/81554680089#step:1:2
    - https://github.com/ROCm/TheRock/actions/runs/27585251851/job/81554679939#step:1:2

As test is completed, we are adding `ci:skip` label