### PR TITLE
Revert "Generate and checkout from manifests in PyTorch build workflows"

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -42,17 +42,9 @@ on:
         type: string
         required: true
       pytorch_git_ref:
-        description: >-
-          PyTorch ref to checkout and build. Typically "nightly" or
-          "release/X.Y". Required unless manifest_url is set.
+        description: PyTorch ref to checkout. Typically "nightly" or "release/X.Y".
         type: string
-        default: ""
-      manifest_url:
-        description: >-
-          Optional explicit URL to a pre-generated PyTorch manifest. If empty,
-          this workflow generates and uploads one for pytorch_git_ref.
-        type: string
-        default: ""
+        required: true
       rocm_version:
         description: ROCm package version to install and build against (e.g. 7.10.0.dev0)
         type: string
@@ -98,17 +90,9 @@ on:
         type: string
         default: "3.12"
       pytorch_git_ref:
-        description: >-
-          PyTorch ref to checkout and build. Typically "nightly" or
-          "release/X.Y". Required unless manifest_url is set.
+        description: PyTorch ref to checkout (for example, "release/2.12").
         type: string
-        default: ""
-      manifest_url:
-        description: >-
-          Optional explicit URL to a pre-generated PyTorch manifest. If empty,
-          this workflow generates and uploads one for pytorch_git_ref.
-        type: string
-        default: ""
+        default: "release/2.12"
       rocm_version:
         description: ROCm package version to install and build against (e.g. 7.10.0.dev0)
         type: string
@@ -140,64 +124,14 @@ on:
           - ccache
         default: sccache
 
-run-name: "Build Multi-Arch Linux PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref || 'manifest URL' }})"
+run-name: Build Multi-Arch Linux PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref }})
 
 permissions:
   contents: read
 
 jobs:
-  # Generate and upload a manifest only when the caller did not provide one.
-  # Manifest URL pass-through skips this job and is handled by the build job.
-  prepare_pytorch_manifest:
-    name: "Generate Manifest | torch ${{ inputs.pytorch_git_ref }}"
-    if: ${{ inputs.manifest_url == '' }}
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
-    permissions:
-      id-token: write
-      contents: read
-    outputs:
-      manifest_url: ${{ steps.generate.outputs.manifest_url }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref || '' }}
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-
-      - name: Install Python requirements
-        run: |
-          pip install packaging boto3
-
-      - name: Configure AWS Credentials for artifacts
-        uses: ./.github/actions/configure_aws_artifacts_credentials
-        with:
-          release_type: ${{ inputs.release_type }}
-
-      - name: Generate PyTorch manifest
-        id: generate
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          python build_tools/github_actions/generate_pytorch_source_manifest.py \
-            --upload \
-            --rocm-version "${{ inputs.rocm_version }}" \
-            --run-id "${{ github.run_id }}" \
-            --release-type "${{ inputs.release_type }}" \
-            --platform linux \
-            --output "${{ github.workspace }}/output/manifests/pytorch_manifest.json" \
-            --pytorch-git-refs "${{ inputs.pytorch_git_ref }}" \
-            --therock-repo "https://github.com/${{ inputs.repository || github.repository }}" \
-            --therock-branch "${{ inputs.ref || github.ref_name }}"
-
   build_pytorch_wheels:
-    name: "Build | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_git_ref || 'manifest URL' }}"
-    needs: [prepare_pytorch_manifest]
-    if: ${{ always() && (inputs.manifest_url != '' || needs.prepare_pytorch_manifest.result == 'success') }}
+    name: Build | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_git_ref }}
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
@@ -208,7 +142,6 @@ jobs:
     env:
       AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
       PACKAGE_DIST_DIR: ${{ github.workspace }}/output/packages/dist
-      PYTORCH_MANIFEST_URL: ${{ inputs.manifest_url || needs.prepare_pytorch_manifest.outputs.manifest_url }}
       optional_build_prod_arguments: ""
       SCCACHE_BUCKET: "therock-pytorch-sccache-${{ inputs.release_type }}"
       SCCACHE_REGION: us-east-1
@@ -254,20 +187,49 @@ jobs:
         run: |
           pip install -r external-builds/pytorch/requirements-ci.txt
 
+      - name: Checkout PyTorch source repos (nightly)
+        if: ${{ inputs.pytorch_git_ref == 'nightly' }}
+        run: |
+          ./external-builds/pytorch/pytorch_torch_repo.py checkout \
+            --repo-hashtag nightly \
+            --no-commit-hipify
+          ./external-builds/pytorch/pytorch_audio_repo.py checkout \
+            --repo-hashtag nightly \
+            --no-commit-hipify
+          ./external-builds/pytorch/pytorch_vision_repo.py checkout \
+            --repo-hashtag nightly \
+            --no-commit-hipify
+          ./external-builds/pytorch/pytorch_triton_repo.py checkout \
+            --no-commit-hipify
+          ./external-builds/pytorch/pytorch_apex_repo.py checkout \
+            --repo-hashtag master \
+            --no-commit-hipify
+
+      - name: Checkout PyTorch source repos (stable)
+        if: ${{ inputs.pytorch_git_ref != 'nightly' }}
+        run: |
+          ./external-builds/pytorch/pytorch_torch_repo.py checkout \
+            --gitrepo-origin https://github.com/ROCm/pytorch.git \
+            --repo-hashtag ${{ inputs.pytorch_git_ref }} \
+            --no-commit-hipify
+          ./external-builds/pytorch/pytorch_audio_repo.py checkout \
+            --require-related-commit \
+            --no-commit-hipify
+          ./external-builds/pytorch/pytorch_vision_repo.py checkout \
+            --require-related-commit \
+            --no-commit-hipify
+          ./external-builds/pytorch/pytorch_triton_repo.py checkout \
+            --no-commit-hipify
+          ./external-builds/pytorch/pytorch_apex_repo.py checkout \
+            --require-related-commit \
+            --no-commit-hipify
+
       # determine_version.py sets optional_build_prod_arguments in
       # GITHUB_ENV (--rocm-sdk-version, --version-suffix).
       - name: Determine optional arguments passed to `build_prod_wheels.py`
         run: |
           python build_tools/github_actions/determine_version.py \
             --rocm-version ${{ inputs.rocm_version }}
-
-      - name: Checkout PyTorch source repos from manifest
-        run: |
-          python external-builds/pytorch/checkout_from_manifest.py \
-            --manifest-url "${PYTORCH_MANIFEST_URL}" \
-            --checkout-root ./external-builds/pytorch \
-            --expected-pytorch-git-ref "${{ inputs.pytorch_git_ref }}" \
-            --no-commit-hipify
 
       - name: Configure AWS Credentials for sccache
         if: ${{ inputs.cache_type == 'sccache' && github.repository_owner == 'ROCm' }}

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -44,17 +44,9 @@ on:
         type: string
         required: true
       pytorch_git_ref:
-        description: >-
-          PyTorch ref to checkout and build. Typically "nightly" or
-          "release/X.Y". Required unless manifest_url is set.
+        description: PyTorch ref to checkout. Typically "nightly" or "release/X.Y".
         type: string
-        default: ""
-      manifest_url:
-        description: >-
-          Optional explicit URL to a pre-generated PyTorch manifest. If empty,
-          this workflow generates and uploads one for pytorch_git_ref.
-        type: string
-        default: ""
+        required: true
       rocm_version:
         description: ROCm package version to install and build against (e.g. 7.10.0.dev0)
         type: string
@@ -100,17 +92,9 @@ on:
         type: string
         default: "3.12"
       pytorch_git_ref:
-        description: >-
-          PyTorch ref to checkout and build. Typically "nightly" or
-          "release/X.Y". Required unless manifest_url is set.
+        description: PyTorch ref to checkout (for example, "release/2.12").
         type: string
-        default: ""
-      manifest_url:
-        description: >-
-          Optional explicit URL to a pre-generated PyTorch manifest. If empty,
-          this workflow generates and uploads one for pytorch_git_ref.
-        type: string
-        default: ""
+        default: "release/2.12"
       rocm_version:
         description: ROCm package version to install and build against (e.g. 7.10.0.dev0)
         type: string
@@ -142,64 +126,14 @@ on:
           - ccache
         default: sccache
 
-run-name: "Build Multi-Arch Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref || 'manifest URL' }})"
+run-name: Build Multi-Arch Windows PyTorch Wheels (${{ inputs.release_type }}, ${{ inputs.python_version }}, ${{ inputs.pytorch_git_ref }})
 
 permissions:
   contents: read
 
 jobs:
-  # Generate and upload a manifest only when the caller did not provide one.
-  # Manifest URL pass-through skips this job and is handled by the build job.
-  prepare_pytorch_manifest:
-    name: "Generate Manifest | torch ${{ inputs.pytorch_git_ref }}"
-    if: ${{ inputs.manifest_url == '' }}
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
-    permissions:
-      id-token: write
-      contents: read
-    outputs:
-      manifest_url: ${{ steps.generate.outputs.manifest_url }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref || '' }}
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-
-      - name: Install Python requirements
-        run: |
-          pip install packaging boto3
-
-      - name: Configure AWS Credentials for artifacts
-        uses: ./.github/actions/configure_aws_artifacts_credentials
-        with:
-          release_type: ${{ inputs.release_type }}
-
-      - name: Generate PyTorch manifest
-        id: generate
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          python build_tools/github_actions/generate_pytorch_source_manifest.py \
-            --upload \
-            --rocm-version "${{ inputs.rocm_version }}" \
-            --run-id "${{ github.run_id }}" \
-            --release-type "${{ inputs.release_type }}" \
-            --platform windows \
-            --output "${{ github.workspace }}/output/manifests/pytorch_manifest.json" \
-            --pytorch-git-refs "${{ inputs.pytorch_git_ref }}" \
-            --therock-repo "https://github.com/${{ inputs.repository || github.repository }}" \
-            --therock-branch "${{ inputs.ref || github.ref_name }}"
-
   build_pytorch_wheels:
-    name: "Build | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_git_ref || 'manifest URL' }}"
-    needs: [prepare_pytorch_manifest]
-    if: ${{ always() && (inputs.manifest_url != '' || needs.prepare_pytorch_manifest.result == 'success') }}
+    name: Build | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_git_ref }}
     runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-windows-scale-rocm' || 'windows-2022' }}
     permissions:
       id-token: write
@@ -208,7 +142,6 @@ jobs:
       CHECKOUT_ROOT: B:/src
       # Note the \ here instead of /. This should be used from 'cmd' not 'bash'!
       PACKAGE_DIST_DIR: ${{ github.workspace }}\output\packages\dist
-      PYTORCH_MANIFEST_URL: ${{ inputs.manifest_url || needs.prepare_pytorch_manifest.outputs.manifest_url }}
       optional_build_prod_arguments: ""
       SCCACHE_BUCKET: "therock-pytorch-sccache-${{ inputs.release_type }}"
       SCCACHE_REGION: us-east-1
@@ -268,13 +201,41 @@ jobs:
         run: |
           pip install -r external-builds/pytorch/requirements-ci.txt
 
-      - name: Checkout PyTorch source repos from manifest
+      - name: Checkout PyTorch source repos (nightly)
+        if: ${{ inputs.pytorch_git_ref == 'nightly' }}
         run: |
           git config --global core.longpaths true
-          python external-builds/pytorch/checkout_from_manifest.py \
-            --manifest-url "${PYTORCH_MANIFEST_URL}" \
-            --checkout-root "${{ env.CHECKOUT_ROOT }}" \
-            --expected-pytorch-git-ref "${{ inputs.pytorch_git_ref }}" \
+          python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
+            --checkout-dir ${{ env.CHECKOUT_ROOT }}/torch \
+            --repo-hashtag nightly \
+            --no-commit-hipify
+          python ./external-builds/pytorch/pytorch_audio_repo.py checkout \
+            --checkout-dir ${{ env.CHECKOUT_ROOT }}/audio \
+            --repo-hashtag nightly \
+            --no-commit-hipify
+          python ./external-builds/pytorch/pytorch_vision_repo.py checkout \
+            --checkout-dir ${{ env.CHECKOUT_ROOT }}/vision \
+            --repo-hashtag nightly \
+            --no-commit-hipify
+
+      - name: Checkout PyTorch source repos (stable)
+        if: ${{ inputs.pytorch_git_ref != 'nightly' }}
+        run: |
+          git config --global core.longpaths true
+          python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
+            --checkout-dir ${{ env.CHECKOUT_ROOT }}/torch \
+            --gitrepo-origin https://github.com/ROCm/pytorch.git \
+            --repo-hashtag ${{ inputs.pytorch_git_ref }} \
+            --no-commit-hipify
+          python ./external-builds/pytorch/pytorch_audio_repo.py checkout \
+            --checkout-dir ${{ env.CHECKOUT_ROOT }}/audio \
+            --torch-dir ${{ env.CHECKOUT_ROOT }}/torch \
+            --require-related-commit \
+            --no-commit-hipify
+          python ./external-builds/pytorch/pytorch_vision_repo.py checkout \
+            --checkout-dir ${{ env.CHECKOUT_ROOT }}/vision \
+            --torch-dir ${{ env.CHECKOUT_ROOT }}/torch \
+            --require-related-commit \
             --no-commit-hipify
 
       # determine_version.py sets optional_build_prod_arguments in
@@ -324,9 +285,9 @@ jobs:
             build ^
             --install-rocm ^
             --find-links "${{ inputs.rocm_package_find_links_url }}" ^
-            --pytorch-dir ${{ env.CHECKOUT_ROOT }}/pytorch ^
-            --pytorch-audio-dir ${{ env.CHECKOUT_ROOT }}/pytorch_audio ^
-            --pytorch-vision-dir ${{ env.CHECKOUT_ROOT }}/pytorch_vision ^
+            --pytorch-dir ${{ env.CHECKOUT_ROOT }}/torch ^
+            --pytorch-audio-dir ${{ env.CHECKOUT_ROOT }}/audio ^
+            --pytorch-vision-dir ${{ env.CHECKOUT_ROOT }}/vision ^
             --enable-pytorch-flash-attention-windows ^
             --clean ^
             --output-dir ${{ env.PACKAGE_DIST_DIR }} ^

--- a/build_tools/_therock_utils/workflow_outputs.py
+++ b/build_tools/_therock_utils/workflow_outputs.py
@@ -210,10 +210,6 @@ class WorkflowOutputRoot:
             f"{self.prefix}/manifests/index.html",
         )
 
-    def pytorch_manifest_dir(self) -> StorageLocation:
-        """Location for multi-arch PyTorch source manifests."""
-        return StorageLocation(self.bucket, f"{self.prefix}/manifests/pytorch")
-
     # -- Native packages --------------------------------------------------------
 
     def native_linux_packages(self, pkg_type: str) -> StorageLocation:

--- a/build_tools/github_actions/generate_pytorch_source_manifest.py
+++ b/build_tools/github_actions/generate_pytorch_source_manifest.py
@@ -5,9 +5,7 @@
 """Generate PyTorch source manifests.
 
 Resolves PyTorch ecosystem refs and pin files to exact commit SHAs and records
-expected package versions in manifest JSON files. With ``--upload``, uploads
-the generated manifests to the workflow output location and emits GitHub Actions
-outputs with their URLs.
+expected package versions in manifest JSON files.
 
 Usage::
 
@@ -28,14 +26,9 @@ from pathlib import Path
 _BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
-from _therock_utils.storage_backend import StorageBackend, create_storage_backend
-from _therock_utils.storage_location import StorageLocation
-from _therock_utils.workflow_outputs import WorkflowOutputRoot
 from github_actions.github_actions_api import (
-    gha_append_step_summary,
     gha_fetch_text_file_contents,
     gha_resolve_git_ref,
-    gha_set_output,
 )
 from github_actions.determine_version import derive_version_suffix
 from github_actions.manifest_utils import (
@@ -151,60 +144,6 @@ def write_manifest_file(path: Path, manifest: Manifest) -> None:
     )
     if not path.is_file() or path.stat().st_size == 0:
         raise RuntimeError(f"Failed to write manifest: {path}")
-
-
-def make_output_root(
-    *,
-    run_id: str,
-    platform: str,
-    release_type: str,
-    bucket_override: str | None,
-) -> WorkflowOutputRoot:
-    if bucket_override:
-        return WorkflowOutputRoot(
-            bucket=bucket_override,
-            external_repo="",
-            run_id=run_id,
-            platform=platform,
-        )
-    return WorkflowOutputRoot.from_workflow_run(
-        run_id=run_id,
-        platform=platform,
-        release_type=release_type or None,
-    )
-
-
-def upload_manifest_file(
-    *,
-    manifest_path: Path,
-    output_root: WorkflowOutputRoot,
-    backend: StorageBackend,
-) -> str:
-    if not manifest_path.is_file():
-        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
-
-    manifest_dir = output_root.pytorch_manifest_dir()
-    manifest_location = StorageLocation(
-        manifest_dir.bucket,
-        f"{manifest_dir.relative_path}/{manifest_path.name}",
-    )
-
-    backend.upload_file(manifest_path, manifest_location)
-    return manifest_location.https_url
-
-
-def append_upload_summary(*, manifest_urls: dict[str, str], rocm_version: str) -> None:
-    lines = [
-        "## PyTorch Manifests",
-        "",
-        f"* ROCm version: `{rocm_version}`",
-        "",
-        "| PyTorch ref | Manifest |",
-        "| --- | --- |",
-    ]
-    for pytorch_ref, manifest_url in manifest_urls.items():
-        lines.append(f"| `{pytorch_ref}` | {manifest_url} |")
-    gha_append_step_summary("\n".join(lines) + "\n")
 
 
 def _parse_related_commits(content: str) -> dict[str, dict[str, str]]:
@@ -352,8 +291,6 @@ def resolve_sources(
 
     # Resolve pytorch first — other repos depend on it for pin files.
     pytorch_config = REPOS["pytorch"]
-    # TODO: Add an explicit PyTorch repo selector so direct workflow dispatch
-    # can resolve non-nightly refs from either ROCm/pytorch or pytorch/pytorch.
     pytorch_repo = (
         pytorch_config.nightly_repo if nightly else pytorch_config.stable_repo
     )
@@ -532,41 +469,12 @@ def main(argv: list[str]) -> None:
         default="",
         help="Semicolon- or space-separated pytorch refs (empty = all defaults)",
     )
-    parser.add_argument(
-        "--upload",
-        action="store_true",
-        help="Upload generated manifests to the workflow output location.",
-    )
-    parser.add_argument(
-        "--run-id",
-        default="",
-        help="GitHub Actions run ID used for uploaded manifest layout.",
-    )
-    parser.add_argument(
-        "--release-type",
-        default="",
-        help='Release type ("dev", "nightly", or "prerelease") for artifact bucket selection.',
-    )
-    parser.add_argument("--bucket", default=None, help="Override artifact bucket.")
-    parser.add_argument(
-        "--output-dir",
-        type=Path,
-        default=None,
-        help="Output uploaded files to a local directory instead of S3.",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Print upload plan without actually uploading.",
-    )
     args = parser.parse_args(argv)
 
     refs = _split_words(args.pytorch_git_refs) or DEFAULT_PYTORCH_GIT_REFS
 
     if args.output and len(refs) != 1:
         parser.error("--output requires exactly one --pytorch-git-refs entry")
-    if args.upload and not args.run_id:
-        parser.error("--run-id is required with --upload")
     explicit_projects = _split_words(args.projects) or None
     version_suffix = args.version_suffix or derive_version_suffix(args.rocm_version)
 
@@ -585,22 +493,6 @@ def main(argv: list[str]) -> None:
     log(f"TheRock: {therock_commit[:12]} ({therock_branch})")
     log(f"PyTorch refs: {refs}")
     log("")
-
-    upload_context: tuple[WorkflowOutputRoot, StorageBackend] | None = None
-    uploaded_manifest_urls: dict[str, str] = {}
-    if args.upload:
-        upload_context = (
-            make_output_root(
-                run_id=args.run_id,
-                platform=args.platform,
-                release_type=args.release_type,
-                bucket_override=args.bucket,
-            ),
-            create_storage_backend(
-                staging_dir=args.output_dir,
-                dry_run=args.dry_run,
-            ),
-        )
 
     for ref in refs:
         projects = explicit_projects or default_projects_for_pytorch_ref(
@@ -628,23 +520,6 @@ def main(argv: list[str]) -> None:
         write_manifest_file(out_path, manifest)
         log(f"Wrote {out_path}")
         log(out_path.read_text(encoding="utf-8"))
-        if upload_context:
-            output_root, backend = upload_context
-            uploaded_manifest_urls[ref] = upload_manifest_file(
-                manifest_path=out_path,
-                output_root=output_root,
-                backend=backend,
-            )
-
-    if uploaded_manifest_urls:
-        outputs = {"manifest_urls": json.dumps(uploaded_manifest_urls)}
-        if len(uploaded_manifest_urls) == 1:
-            outputs["manifest_url"] = next(iter(uploaded_manifest_urls.values()))
-        gha_set_output(outputs)
-        append_upload_summary(
-            manifest_urls=uploaded_manifest_urls,
-            rocm_version=args.rocm_version,
-        )
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/tests/generate_pytorch_source_manifest_test.py
+++ b/build_tools/github_actions/tests/generate_pytorch_source_manifest_test.py
@@ -468,8 +468,8 @@ class GeneratePyTorchSourceManifestTest(unittest.TestCase):
                     therock_branch="main",
                 )
 
-    def test_main_writes_uploads_and_outputs_manifest_url(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as staging:
+    def test_main_writes_single_output_manifest_with_project_filter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "manifest.json"
             pytorch_sha = "1" * 40
             triton_sha = "2" * 40
@@ -527,13 +527,7 @@ class GeneratePyTorchSourceManifestTest(unittest.TestCase):
                     commit="a" * 40,
                     branch="main",
                 ),
-            ), mock.patch.object(
-                m, "gha_set_output"
-            ) as gha_set_output, mock.patch.object(
-                m, "gha_append_step_summary"
-            ) as gha_append_step_summary, self._patch_github_api(
-                resolves=resolves, files=files
-            ):
+            ), self._patch_github_api(resolves=resolves, files=files):
                 m.main(
                     [
                         "--rocm-version",
@@ -546,33 +540,10 @@ class GeneratePyTorchSourceManifestTest(unittest.TestCase):
                         pytorch_ref,
                         "--projects",
                         "pytorch;triton",
-                        "--upload",
-                        "--run-id",
-                        "99999",
-                        "--bucket",
-                        "test",
-                        "--output-dir",
-                        staging,
                     ]
                 )
 
             self.assertEqual(json.loads(out_path.read_text(encoding="utf-8")), expected)
-            uploaded_manifest = (
-                Path(staging) / "99999-linux/manifests/pytorch/manifest.json"
-            )
-            self.assertTrue(uploaded_manifest.is_file())
-
-            manifest_url = (
-                "https://test.s3.amazonaws.com/99999-linux/manifests/pytorch/"
-                "manifest.json"
-            )
-            gha_set_output.assert_called_once_with(
-                {
-                    "manifest_urls": json.dumps({pytorch_ref: manifest_url}),
-                    "manifest_url": manifest_url,
-                }
-            )
-            gha_append_step_summary.assert_called_once()
 
     def test_output_requires_single_ref(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -587,21 +558,6 @@ class GeneratePyTorchSourceManifestTest(unittest.TestCase):
                         str(Path(tmp) / "manifest.json"),
                         "--pytorch-git-refs",
                         "release/2.10 nightly",
-                    ]
-                )
-
-    def test_upload_requires_run_id(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            with self.assertRaises(SystemExit):
-                m.main(
-                    [
-                        "--rocm-version",
-                        "7.13.0",
-                        "--output",
-                        str(Path(tmp) / "manifest.json"),
-                        "--pytorch-git-refs",
-                        "release/2.10",
-                        "--upload",
                     ]
                 )
 

--- a/build_tools/github_actions/tests/pytorch_checkout_from_manifest_test.py
+++ b/build_tools/github_actions/tests/pytorch_checkout_from_manifest_test.py
@@ -117,7 +117,7 @@ class PyTorchCheckoutFromManifestTest(unittest.TestCase):
             self._option_value(command, "--repo-hashtag"), manifest["pytorch"]["commit"]
         )
 
-    def test_projects_filter_and_checkout_options(self) -> None:
+    def test_projects_filter_and_no_hipify(self) -> None:
         manifest = {
             "pytorch": {
                 "repo": "https://github.com/ROCm/pytorch",
@@ -148,8 +148,6 @@ class PyTorchCheckoutFromManifestTest(unittest.TestCase):
                     "--projects",
                     "pytorch;pytorch_vision",
                     "--no-hipify",
-                    "--no-submodules",
-                    "--no-commit-hipify",
                 ]
             )
 
@@ -159,8 +157,6 @@ class PyTorchCheckoutFromManifestTest(unittest.TestCase):
         )
         for command in commands.values():
             self.assertIn("--no-hipify", command)
-            self.assertIn("--no-submodules", command)
-            self.assertIn("--no-commit-hipify", command)
             self.assertNotIn("--torch-dir", command)
 
     def test_unknown_requested_project_errors(self) -> None:

--- a/build_tools/tests/workflow_outputs_test.py
+++ b/build_tools/tests/workflow_outputs_test.py
@@ -164,10 +164,6 @@ class TestWorkflowOutputRootLocations(unittest.TestCase):
             "99999-linux/manifests/gfx94X-dcgpu/therock_manifest.json",
         )
 
-    def test_pytorch_manifest_dir(self):
-        loc = self.root.pytorch_manifest_dir()
-        self._assert_relative_path(loc, "99999-linux/manifests/pytorch")
-
     # -- Python packages --
 
     def test_python_packages(self):

--- a/external-builds/pytorch/checkout_from_manifest.py
+++ b/external-builds/pytorch/checkout_from_manifest.py
@@ -59,9 +59,7 @@ def checkout_project(
     name: str,
     source_info: dict[str, str],
     checkout_root: Path,
-    submodules: bool,
     no_hipify: bool,
-    commit_hipify: bool,
 ) -> None:
     """Check out a single project using its checkout script."""
     script = THIS_DIR / CHECKOUT_SCRIPTS[name]
@@ -86,10 +84,6 @@ def checkout_project(
 
     if no_hipify:
         cmd.append("--no-hipify")
-    if not submodules:
-        cmd.append("--no-submodules")
-    if not commit_hipify:
-        cmd.append("--no-commit-hipify")
 
     log(f"  Running: {' '.join(cmd)}")
     subprocess.check_call(cmd)
@@ -196,18 +190,6 @@ def main(argv: list[str]) -> None:
         default=False,
         help="Skip HIPIFY for all checkouts (e.g. for test-only runs)",
     )
-    parser.add_argument(
-        "--submodules",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Checkout git submodules",
-    )
-    parser.add_argument(
-        "--commit-hipify",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Commit HIPIFY changes after running HIPIFY",
-    )
     args = parser.parse_args(argv)
 
     checkout_root = args.checkout_root.resolve()
@@ -257,9 +239,7 @@ def main(argv: list[str]) -> None:
             name=name,
             source_info=source_infos[name],
             checkout_root=checkout_root,
-            submodules=args.submodules,
             no_hipify=args.no_hipify,
-            commit_hipify=args.commit_hipify,
         )
         log("")
 


### PR DESCRIPTION
Reverts ROCm/TheRock#5633
fixes https://github.com/ROCm/TheRock/issues/5880

The hardcoded `--output`  [multi_arch_build_windows_pytorch_wheels.yml#L194](https://github.com/ROCm/TheRock/blob/5ae92984cb9312d9551e34c8e4c218ed383af0ef/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml#L194) a single filename per job rather than using the ref-named filename, creating the collision.
```
ValueError: Manifest PyTorch ref 'release/2.9' does not match 'release/2.10'
```