### PR TITLE
Add ffm-specific test categories to test_runner.py

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -28,7 +28,17 @@ from pathlib import Path
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
-VALID_TEST_CATEGORIES = {"quick", "standard", "comprehensive", "full"}
+VALID_TEST_CATEGORIES = {
+    "quick",
+    "standard",
+    "comprehensive",
+    "full",
+    # ffm-specific categories
+    "ffm-quick",
+    "ffm-standard",
+    "ffm-comprehensive",
+    "ffm-full",
+}
 # Normalize + validate TEST_TYPE once at module load so all downstream
 # consumers (apply_component_overrides at import time, main() at run
 # time) see the same lower-cased, validated value. `or "quick"` covers

--- a/build_tools/github_actions/tests/unit_test_runner.py
+++ b/build_tools/github_actions/tests/unit_test_runner.py
@@ -160,7 +160,16 @@ class ValidTestCategoriesTest(unittest.TestCase):
     def test_all_expected_categories_present(self):
         self.assertEqual(
             test_runner.VALID_TEST_CATEGORIES,
-            {"quick", "standard", "comprehensive", "full"},
+            {
+                "quick",
+                "standard",
+                "comprehensive",
+                "full",
+                "ffm-quick",
+                "ffm-standard",
+                "ffm-comprehensive",
+                "ffm-full",
+            },
         )
 
     def test_valid_category_accepted(self):


### PR DESCRIPTION
## Summary
- Add `ffm-quick`, `ffm-standard`, `ffm-comprehensive`, and `ffm-full` to the `VALID_TEST_CATEGORIES` allowed list in `test_runner.py`.
- Update the `test_all_expected_categories_present` unit test to include the new categories.

## Test plan
- [x] `env -u TEST_TYPE -u TEST_COMPONENT -u THEROCK_BIN_DIR python3 build_tools/github_actions/tests/unit_test_runner.py` — 21/22 pass; the single failure is the pre-existing, unrelated `test_category_exclude_label_applied` (matches `origin/main` baseline).

Made with [Cursor](https://cursor.com)