### PR TITLE
[gfx1250] Move arch exclusion to release/2.11, remove from release/2.12 ahead of merge

### DIFF
--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -40,12 +40,14 @@ PYTORCH_REFS_LINUX: list[dict] = [
     },
     {
         "pytorch_git_ref": "release/2.11",
-    },
-    {
-        "pytorch_git_ref": "release/2.12",
         # gfx125x not yet upstreamed to pytorch/pytorch.
         # See https://github.com/ROCm/TheRock/issues/5833.
         "exclude_amdgpu_families": {"gfx125x"},
+    },
+    {
+        "pytorch_git_ref": "release/2.12",
+        # No exclusion — trigger manually with release/2.12_gfx1250 branch
+        # to include gfx1250 until upstreamed. See issue #5833.
     },
     {
         "pytorch_git_ref": "nightly",


### PR DESCRIPTION
## Summary

Repositions the gfx1250 exclusion in the PyTorch release matrix ahead of the `release/2.12_gfx1250` → `release/2.12` merge:

| Branch | Before | After |
|---|---|---|
| `release/2.11` | no exclusion | `exclude_amdgpu_families: {gfx125x}` |
| `release/2.12` | `exclude_amdgpu_families: {gfx125x}` | no exclusion |

## Why

- **`release/2.11`** — gfx1250 workarounds have not been backported here; exclusion is correct and necessary.
- **`release/2.12`** — `release/2.12_gfx1250` (which carries the gfx1250 workarounds) is being merged into `release/2.12` shortly. Removing the exclusion now means the nightly matrix will automatically pick up gfx1250 for `release/2.12` as soon as that merge lands — no follow-up PR needed.

## After the release/2.12_gfx1250 merge

Once `release/2.12_gfx1250` is merged into `release/2.12`:
- `release/2.12` nightly will build gfx1250 wheels automatically ✅
- The dedicated `release/2.12_gfx1250` entry in `GFX1250_PYTORCH_REFS` can be removed

See: https://github.com/ROCm/TheRock/issues/5833

## Test Result

https://github.com/ROCm/TheRock/actions/runs/27775758878 — `release/2.12_gfx1250` built successfully with gfx1250 ✅

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.