### PR TITLE
Move aux-overlay compiler symlinks and cmake configs to amd-llvm_dev

### DIFF
--- a/base/artifact.toml
+++ b/base/artifact.toml
@@ -55,8 +55,16 @@ include = [
 ]
 
 # therock-aux-overlay
+# Only share/therock stays in base (dist_info.json, therock_manifest.json).
+# bin/, lib/cmake/, llvm, and amdgcn are compiler-related and assigned to amd-llvm_dev.
 [components.lib."base/aux-overlay/stage"]
 default_patterns = false
 include = [
   "**/*",
+]
+exclude = [
+  "bin/**",
+  "lib/cmake/**",
+  "llvm",
+  "amdgcn",
 ]

--- a/compiler/artifact-amd-llvm.toml
+++ b/compiler/artifact-amd-llvm.toml
@@ -58,3 +58,13 @@ exclude = [
 [components.dbg."compiler/hipcc/stage"]
 [components.dev."compiler/hipcc/stage"]
 [components.doc."compiler/hipcc/stage"]
+
+# aux-overlay symlinks and cmake redirects for LLVM toolchain
+[components.dev."base/aux-overlay/stage"]
+default_patterns = false
+include = [
+  "bin/**",
+  "lib/cmake/**",
+  "llvm",
+  "amdgcn",
+]


### PR DESCRIPTION
  The aux-overlay stage contains symlinks and cmake redirect files that
  are part of the LLVM toolchain. Move these from base_lib to amd-llvm_dev:
  - bin/ (amdclang, amdflang, amdlld, offload-arch symlinks)
  - lib/cmake/ (AMDDeviceLibs, clang, lld, llvm config files)
  - llvm and amdgcn symlinks

  Only share/therock/ (dist_info.json, therock_manifest.json) remains in base_lib