### PR TITLE
[ci] Support hyphenated subproject names in test-deps parser

### DIFF
--- a/test_tools/determine_rocm_test_dependencies.py
+++ b/test_tools/determine_rocm_test_dependencies.py
@@ -33,7 +33,7 @@ def parse_cmake_test_subprojects(therock_dir):
         content = cmake_file.read_text()
 
         # Find all therock_cmake_subproject_declare blocks
-        pattern = r"therock_cmake_subproject_declare\s*\(\s*(\w+)(.*?)\)"
+        pattern = r"therock_cmake_subproject_declare\s*\(\s*([\w-]+)(.*?)\)"
 
         for match in re.finditer(pattern, content, re.DOTALL):
             subproject_name = match.group(1).lower()
@@ -43,7 +43,7 @@ def parse_cmake_test_subprojects(therock_dir):
             # Match TEST_SUBPROJECTS with optional list of dependencies
             # Empty TEST_SUBPROJECTS is valid (only tests itself)
             test_subprojects_match = re.search(
-                r"TEST_SUBPROJECTS(?:\s+((?:\w+\s*)+))?", block_content
+                r"TEST_SUBPROJECTS(?:\s+((?:[\w-]+\s*)+))?", block_content
             )
 
             if test_subprojects_match:

--- a/test_tools/tests/determine_rocm_test_dependencies_test.py
+++ b/test_tools/tests/determine_rocm_test_dependencies_test.py
@@ -3,6 +3,7 @@
 
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -46,6 +47,41 @@ class TestDetermineRocmTestDependencies(unittest.TestCase):
         # Verify rocWMMA has empty TEST_SUBPROJECTS (tests only itself)
         self.assertIn("rocwmma", test_deps)
         self.assertEqual(test_deps["rocwmma"], [])
+
+    def test_parse_hyphenated_subproject_names(self):
+        """Subproject names and TEST_SUBPROJECTS deps may contain hyphens."""
+        cmake = """\
+therock_cmake_subproject_declare(amd-dbgapi
+  RUNTIME_DEPS
+    amd-comgr
+  TEST_SUBPROJECTS
+    rocgdb
+    rocr-debug-agent-tests
+)
+
+therock_cmake_subproject_declare(rocr-debug-agent
+  RUNTIME_DEPS
+    amd-dbgapi
+  TEST_SUBPROJECTS
+    rocr-debug-agent-tests
+)
+
+therock_cmake_subproject_declare(rocr-debug-agent-tests
+  RUNTIME_DEPS
+    rocr-debug-agent
+  TEST_SUBPROJECTS
+)
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "CMakeLists.txt").write_text(cmake)
+            test_deps = parse_cmake_test_subprojects(tmp)
+
+        self.assertEqual(
+            set(test_deps["amd-dbgapi"]), {"rocgdb", "rocr-debug-agent-tests"}
+        )
+        self.assertEqual(test_deps["rocr-debug-agent"], ["rocr-debug-agent-tests"])
+        # Empty TEST_SUBPROJECTS placed last: tests only itself.
+        self.assertEqual(test_deps["rocr-debug-agent-tests"], [])
 
     def test_get_subprojects_to_test(self):
         """Test dependency resolution with case-insensitive input."""


### PR DESCRIPTION
## Motivation

determine_rocm_test_dependencies.py matched subproject names and TEST_SUBPROJECTS entries with \w+, which stops at hyphens. Names like rocr-debug-agent and amd-dbgapi were truncated to rocr / amd, breaking test selection for hyphenated components. Allow hyphens in both the declare-name and the dependency-list patterns, and add a self-contained test covering hyphenated names and empty TEST_SUBPROJECTS.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

New unit test to validate the problematic scenario

## Test Result

Validated the hyphenated subproject entries get handled correctly.