### PR TITLE
[ci] Add TEST_SUBPROJECTS to debug-tools components

### DIFF
--- a/debug-tools/CMakeLists.txt
+++ b/debug-tools/CMakeLists.txt
@@ -89,6 +89,9 @@ if(THEROCK_ENABLE_AMD_DBGAPI)
       "lib"
     INTERFACE_PKG_CONFIG_DIRS
       "share/pkgconfig"
+    TEST_SUBPROJECTS
+      rocgdb
+      rocr-debug-agent-tests
   )
 
   therock_cmake_subproject_glob_c_sources(amd-dbgapi SUBDIRS
@@ -156,6 +159,8 @@ if(THEROCK_ENABLE_ROCR_DEBUG_AGENT)
       "lib"
     INTERFACE_INSTALL_RPATH_DIRS
       "lib"
+    TEST_SUBPROJECTS
+      rocr-debug-agent-tests
   )
 
   therock_cmake_subproject_glob_c_sources(rocr-debug-agent SUBDIRS
@@ -296,6 +301,7 @@ if(THEROCK_ENABLE_ROCGDB)
       "bin"
     INTERFACE_LINK_DIRS
       "lib"
+    TEST_SUBPROJECTS
   )
 
   # We may want to adjust this to optimize rebuilds.


### PR DESCRIPTION
## Motivation

Declare test-selection mappings so determine_rocm_test_dependencies.py can pick the right tests when a debug-tools subproject changes:
  - amd-dbgapi       -> rocgdb, rocr-debug-agent-tests (both depend on it)
  - rocr-debug-agent -> rocr-debug-agent-tests
  - rocgdb           -> empty (tests only itself)

rocr-debug-agent-tests gets no TEST_SUBPROJECTS entry: its sources live inside the rocr-debug-agent tree (EXTERNAL_SOURCE_DIR .../rocr-debug-agent/test), so the manifest diff never reports it as a changed project and the key would never be looked up. The tests are still selected via the rocr-debug-agent and amd-dbgapi mappings above.

Empty TEST_SUBPROJECTS entries are placed last in the declare so the parser's greedy dependency-list match does not consume a later keyword.

Requires the hyphen-aware parser fix to be effective for these hyphenated subproject names.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Validated during multi-arch CI execution.

## Test Result

To be confirmed once multi-arch CI cross-triggers work.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
