### PR TITLE
Add libuv build step to multi-arch Windows PyTorch workflows

### DIFF
--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -157,6 +157,14 @@ jobs:
           choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
           choco install --no-progress -y ninja --version 1.13.1
 
+      - name: Build libuv from source for GLOO
+        run: |
+          git clone https://github.com/libuv/libuv.git -b v1.47.0 --depth 1
+          cmake -S libuv -B libuv/build -DBUILD_TESTING=OFF
+          cmake --build libuv/build --config Release
+          cmake --install libuv/build --prefix "${{ github.workspace }}/libuv-install"
+          echo "libuv_ROOT=${{ github.workspace }}/libuv-install" >> $GITHUB_ENV
+
       - name: Install sccache
         if: ${{ steps.cache.outputs.cache_type == 'sccache' }}
         run: |

--- a/.github/workflows/build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/build_windows_pytorch_wheels_ci.yml
@@ -157,6 +157,9 @@ jobs:
           choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
           choco install --no-progress -y ninja --version 1.13.1
 
+      # Build a fixed version of libuv from source, no matter the pytorch ref.
+      # gloo requires >= 1.26; v1.47.0 matches upstream's source build.
+      # https://github.com/pytorch/pytorch/blob/main/.ci/pytorch/windows/arm64/bootstrap_libuv.bat
       - name: Build libuv from source for GLOO
         run: |
           git clone https://github.com/libuv/libuv.git -b v1.47.0 --depth 1

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -187,6 +187,9 @@ jobs:
           choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
           choco install --no-progress -y ninja --version 1.13.1
 
+      # Build a fixed version of libuv from source, no matter the pytorch ref.
+      # gloo requires >= 1.26; v1.47.0 matches upstream's source build.
+      # https://github.com/pytorch/pytorch/blob/main/.ci/pytorch/windows/arm64/bootstrap_libuv.bat
       - name: Build libuv from source for GLOO
         run: |
           git clone https://github.com/libuv/libuv.git -b v1.47.0 --depth 1

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -187,6 +187,14 @@ jobs:
           choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
           choco install --no-progress -y ninja --version 1.13.1
 
+      - name: Build libuv from source for GLOO
+        run: |
+          git clone https://github.com/libuv/libuv.git -b v1.47.0 --depth 1
+          cmake -S libuv -B libuv/build -DBUILD_TESTING=OFF
+          cmake --build libuv/build --config Release
+          cmake --install libuv/build --prefix "${{ github.workspace }}/libuv-install"
+          echo "libuv_ROOT=${{ github.workspace }}/libuv-install" >> $GITHUB_ENV
+
       - name: Install sccache
         if: ${{ inputs.cache_type == 'sccache' }}
         run: |


### PR DESCRIPTION
## Motivation

Follow up to https://github.com/ROCm/TheRock/pull/5694 and https://github.com/ROCm/TheRock/issues/3284.

## Technical Details

GLOO is working as a backend for torch.distributed on Windows through the above PR. libuv is needed on our Windows build machines for GLOO to be enabled - adding the install step into workflow files that are currently in use.

## Test Plan

Run both
- `.github/workflows/build_windows_pytorch_wheels_ci.yml` 
- `.github/workflows/multi_arch_build_windows_pytorch_wheels.yml` - https://github.com/ROCm/TheRock/actions/runs/27699570196

Then with generated wheels, run 
```
python -c "import torch; print(f'torch={torch.__version__}, hip={torch.version.hip}, cuda={torch.cuda.is_available()}, distributed={torch.distributed.is_available()}, gloo={torch.distributed.is_gloo_available() if torch.distributed.is_available()else False}')"
```
Both workflows should pass and command output should show torch.distributed and gloo working.
## Test Result

In progress

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
