### PR TITLE
Stage-impact: formalize StageImpactResult contract

### DIFF
--- a/build_tools/github_actions/stage_impact.py
+++ b/build_tools/github_actions/stage_impact.py
@@ -45,7 +45,18 @@ class StageImpactRuleSet:
 
 @dataclass(frozen=True)
 class StageImpactResult:
-    """Result of stage-impact analysis."""
+    """Stable result of stage-impact analysis.
+
+    Fields:
+        changed_inputs: Normalized changed paths or submodule names.
+        matched_source_sets: Source sets matched from the changed inputs.
+        impacted_artifact_groups: Artifact groups directly impacted.
+        rebuild_stages: Stages that must rebuild.
+        copy_stages: Stages that can be reused/copied.
+        full_rebuild_required: Whether conservative fallback was triggered.
+        reasons: Why full CI or a broader rebuild was selected.
+        unmatched_inputs: Inputs that could not be mapped to a source set.
+    """
 
     changed_inputs: Tuple[str, ...]
     matched_source_sets: Tuple[str, ...]
@@ -55,6 +66,18 @@ class StageImpactResult:
     full_rebuild_required: bool
     reasons: Tuple[str, ...] = ()
     unmatched_inputs: Tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "changed_inputs": self.changed_inputs,
+            "matched_source_sets": self.matched_source_sets,
+            "impacted_artifact_groups": self.impacted_artifact_groups,
+            "rebuild_stages": self.rebuild_stages,
+            "copy_stages": self.copy_stages,
+            "full_rebuild_required": self.full_rebuild_required,
+            "reasons": self.reasons,
+            "unmatched_inputs": self.unmatched_inputs,
+        }
 
 
 class StageImpactAnalyzer:

--- a/build_tools/github_actions/stage_impact.py
+++ b/build_tools/github_actions/stage_impact.py
@@ -45,7 +45,7 @@ class StageImpactRuleSet:
 
 @dataclass(frozen=True)
 class StageImpactResult:
-    """Stable result of stage-impact analysis.
+    """Result of stage-impact analysis.
 
     Fields:
         changed_inputs: Normalized changed paths or submodule names.

--- a/build_tools/github_actions/tests/stage_impact_test.py
+++ b/build_tools/github_actions/tests/stage_impact_test.py
@@ -500,6 +500,8 @@ class StageImpactTest(unittest.TestCase):
             },
         )
         self.assertEqual(payload["changed_inputs"], ("rocm-libraries",))
+        self.assertEqual(payload["reasons"], ())
+        self.assertEqual(payload["unmatched_inputs"], ())
         self.assertEqual(payload["matched_source_sets"], ("rocm-libraries",))
         self.assertFalse(payload["full_rebuild_required"])
 

--- a/build_tools/github_actions/tests/stage_impact_test.py
+++ b/build_tools/github_actions/tests/stage_impact_test.py
@@ -459,6 +459,49 @@ class StageImpactTest(unittest.TestCase):
         self.assertIn("compiler", result.impacted_artifact_groups)
         self.assertIn("compiler-runtime", result.rebuild_stages)
 
+    def test_stage_impact_result_shape(self):
+        self.write_topology(
+            """
+            [source_sets.rocm-libraries]
+            description = "ROCm libraries"
+            submodules = ["rocm-libraries"]
+
+            [artifact_groups.math-libs]
+            description = "Math libs"
+            type = "per-arch"
+            source_sets = ["rocm-libraries"]
+
+            [build_stages.math-libs]
+            description = "Math libs stage"
+            artifact_groups = ["math-libs"]
+            type = "per-arch"
+
+            [artifacts.prim]
+            artifact_group = "math-libs"
+            type = "target-specific"
+            """
+        )
+
+        topology = BuildTopology(self.topology_path)
+        result = analyze_stage_impact(["rocm-libraries"], topology=topology)
+
+        payload = result.to_dict()
+        self.assertEqual(
+            set(payload.keys()),
+            {
+                "changed_inputs",
+                "matched_source_sets",
+                "impacted_artifact_groups",
+                "rebuild_stages",
+                "copy_stages",
+                "full_rebuild_required",
+                "reasons",
+                "unmatched_inputs",
+            },
+        )
+        self.assertEqual(payload["changed_inputs"], ("rocm-libraries",))
+        self.assertEqual(payload["matched_source_sets"], ("rocm-libraries",))
+        self.assertFalse(payload["full_rebuild_required"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/build_tools/github_actions/tests/stage_impact_test.py
+++ b/build_tools/github_actions/tests/stage_impact_test.py
@@ -503,5 +503,6 @@ class StageImpactTest(unittest.TestCase):
         self.assertEqual(payload["matched_source_sets"], ("rocm-libraries",))
         self.assertFalse(payload["full_rebuild_required"])
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

This PR stabilizes the stage-impact analysis interface and documents the result contract that downstream targeted-CI components will consume.

The implementation does not change stage-impact behavior. Instead, it formalizes the analyzer output through a documented `StageImpactResult` contract and adds a stable serialization helper for programmatic consumers.

## Motivation

Follow-on targeted-CI work (baseline selection, reuse planning, dry-run reporting, and workflow integration) needs a stable interface for consuming stage-impact results.

This PR establishes that contract and adds tests to ensure the result shape remains consistent as the implementation evolves.

## Changes

### Stage Impact Result Contract

Updated `StageImpactResult` documentation to define the supported output fields:

* `changed_inputs`
* `matched_source_sets`
* `impacted_artifact_groups`
* `rebuild_stages`
* `copy_stages`
* `full_rebuild_required`
* `reasons`
* `unmatched_inputs`

### Stable Serialization

Added:

* `StageImpactResult.to_dict()`

This provides a stable serialized representation for downstream consumers.

### Test Coverage

Added a contract test to verify:

* the expected result keys are present
* serialized output remains stable
* representative field values are returned correctly

## Test Results

```bash
python -m unittest build_tools.github_actions.tests.stage_impact_test -v
```

All tests pass.

The new test added
`test_stage_impact_result_shape (build_tools.github_actions.tests.stage_impact_test.StageImpactTest.test_stage_impact_result_shape) ... ok`

## Future Work

This PR only standardizes the stage-impact output interface.

Follow-on work can build on this contract to:

* generate reusable baseline plans
* support dry-run impact reporting
* produce source/ref summaries for baseline selection
* integrate targeted CI decision making into workflow automation
