### PR TITLE
[DRAFT][rocgdb] Test filter standardization support (generic, component-agnostic)

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -307,16 +307,20 @@ test_matrix = {
             "windows": 1,
         },
     },
+    # rocgdb test-filter standardization (RFC0010): both jobs share one tier
+    # definition (ROCgdb's .github/test-runner/test_categories.yaml, installed
+    # next to the testsuite) and split it by --domain. --tier defaults to
+    # 'quick' here; nightly/extended pipelines can raise it later.
     "rocgdb-cpu": {
         **_rocgdb_common,
         "job_name": "rocgdb-cpu",
-        "test_script": "python ./build/tests/rocgdb/test_rocgdb.py --tests gdb.dwarf2",
+        "test_script": "python ./build/tests/rocgdb/test_rocgdb.py --tier quick --domain cpu",
         "linux_cpu_runner": True,
     },
     "rocgdb-gpu": {
         **_rocgdb_common,
         "job_name": "rocgdb-gpu",
-        "test_script": "python ./build/tests/rocgdb/test_rocgdb.py --tests gdb.rocm",
+        "test_script": "python ./build/tests/rocgdb/test_rocgdb.py --tier quick --domain gpu",
     },
     "rocr-debug-agent": {
         "job_name": "rocr-debug-agent",

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -307,10 +307,14 @@ test_matrix = {
             "windows": 1,
         },
     },
-    # rocgdb test-filter standardization (RFC0010): both jobs share one tier
-    # definition (ROCgdb's .github/test-runner/test_categories.yaml, installed
-    # next to the testsuite) and split it by --domain. --tier defaults to
-    # 'quick' here; nightly/extended pipelines can raise it later.
+    # rocgdb test-filter standardization (RFC0010): all three jobs share one
+    # tier definition (ROCgdb's .github/test-runner/test_categories.yaml,
+    # installed next to the testsuite) and split it into disjoint runner
+    # categories via --domain. --tier defaults to 'quick' here; nightly/extended
+    # pipelines can raise it later.
+    #   cpu      - non-GPU (gdb.dwarf2) tests on CPU-only runners
+    #   gpu      - gdb.rocm tests minus the corefile subset, on GPU runners
+    #   corefile - the gdb.rocm corefile tests (require allow_rocm_core_tests)
     "rocgdb-cpu": {
         **_rocgdb_common,
         "job_name": "rocgdb-cpu",
@@ -321,6 +325,16 @@ test_matrix = {
         **_rocgdb_common,
         "job_name": "rocgdb-gpu",
         "test_script": "python ./build/tests/rocgdb/test_rocgdb.py --tier quick --domain gpu",
+    },
+    # NOTE: the corefile tests exercise host core-dump handling and therefore
+    # need a GPU runner whose host kernel core_pattern / ulimit are provisioned
+    # to write plain core files (plus the coremerge tool). Until a dedicated
+    # core-dump runner pool/label exists it lands on the standard GPU runner;
+    # tests self-skip via `require allow_rocm_core_tests` when unsupported.
+    "rocgdb-corefile": {
+        **_rocgdb_common,
+        "job_name": "rocgdb-corefile",
+        "test_script": "python ./build/tests/rocgdb/test_rocgdb.py --tier quick --domain corefile",
     },
     "rocr-debug-agent": {
         "job_name": "rocr-debug-agent",

--- a/debug-tools/CMakeLists.txt
+++ b/debug-tools/CMakeLists.txt
@@ -92,6 +92,7 @@ if(THEROCK_ENABLE_AMD_DBGAPI)
     TEST_SUBPROJECTS
       rocgdb-cpu
       rocgdb-gpu
+      rocgdb-corefile
       rocr-debug-agent-tests
   )
 
@@ -327,6 +328,7 @@ if(THEROCK_ENABLE_ROCGDB)
     TEST_SUBPROJECTS
       rocgdb-cpu
       rocgdb-gpu
+      rocgdb-corefile
   )
 
   # We may want to adjust this to optimize rebuilds.

--- a/debug-tools/rocgdb/CMakeLists.txt
+++ b/debug-tools/rocgdb/CMakeLists.txt
@@ -799,6 +799,22 @@ if(BUILD_TESTING)
     message(WARNING "rocgdb tests: xfails ignore list not found at "
       "${ROCGDB_SOURCE_DIR}/.github/scripts/rocgdb_ignore_list.json; skipping installation.")
   endif()
+
+  # Install the optional test-filter (RFC0010) tier definition, if present in
+  # the sources. It is a non-upstream helper kept out of gdb's source tree
+  # (under .github/test-runner/), so the EXISTS guard keeps this wrapper
+  # compatible with upstream gdb. It installs next to the testsuite at
+  # tests/rocgdb/gdb/testsuite/, where test_rocgdb.py --tier looks for it.
+  if(EXISTS "${ROCGDB_SOURCE_DIR}/.github/test-runner/test_categories.yaml")
+    install(
+      FILES ${ROCGDB_SOURCE_DIR}/.github/test-runner/test_categories.yaml
+      DESTINATION tests/rocgdb/gdb/testsuite
+      COMPONENT tests
+    )
+  else()
+    message(WARNING "rocgdb tests: test-filter tier definition not found at "
+      "${ROCGDB_SOURCE_DIR}/.github/test-runner/test_categories.yaml; skipping installation.")
+  endif()
 else()
   message(STATUS "rocgdb tests: BUILD_TESTING not set. Skipping installation integrity tests.")
 endif()


### PR DESCRIPTION
## Summary

TheRock-side support for ROCgdb test-filter standardization (RFC0010). This
keeps TheRock fully generic — all rocgdb-specific test logic (the tiered
`test_categories.yaml`, the generated `CTestTestfile.cmake`, and the
`test_rocgdb.py` launcher) lives in the ROCgdb repo. TheRock only:

1. **`build_tools/.../test_runner.py`** — adds a generic `COMPONENT_OVERRIDES`
   entry for `rocgdb` pointing the ctest `--test-dir` at the installed
   testsuite (`tests/rocgdb/gdb/testsuite`). No rocgdb-specific behavior; just
   a directory override, consistent with other components.

2. **`debug-tools/rocgdb/CMakeLists.txt`** — adds `EXISTS`-guarded install
   rules that ship ROCgdb's `.github/test-runner/test_categories.yaml` and
   `CTestTestfile.cmake` into `tests/rocgdb/gdb/testsuite/` when the sources
   provide them. Absence is a no-op, so the wrapper still works with upstream
   gdb sources that don't carry these files (mirrors the optional-install
   pattern from #5720).

With these, `test_runner.py` can drive `ctest -L <tier>` against the rocgdb
testsuite, where each tier invokes `../../test_rocgdb.py --tier <name>`.

## Paired PR

Pairs with the ROCgdb PR: ROCm/ROCgdb#170 (`users/dravindr/tf_rocgdb`), which
owns all the rocgdb-specific files. Draft until that lands and the test-trigger
wiring is finalized alongside the multi-arch CI work.

## Test plan

- [x] `ctest -N` / `--print-labels` discover the four tiers and labels
- [x] `ctest -L quick` runs end-to-end in ROCgdb PR CI (paired branch), ~2 min
- [ ] Validate install rules are no-ops for upstream gdb sources
- [ ] Finalize how the test trigger is invoked from TheRock CI (multi-arch)

Made with [Cursor](https://cursor.com)