### PR TITLE
Update fetch_test_configurations.py for hipblas

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -209,13 +209,12 @@ test_matrix = {
     "hipblas": {
         "job_name": "hipblas",
         "fetch_artifact_args": "--blas --tests",
-        "timeout_minutes": 30,
+        "timeout_minutes": 60,
         "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
-        # TODO(#2616): Enable full tests once known machine issues are resolved
         "total_shards_dict": {
-            "linux": 1,
-            "windows": 1,
+            "linux": 2,
+            "windows": 2,
         },
     },
     "amdsmi": {


### PR DESCRIPTION
## Motivation

This pull request increases the test coverage and reliability for the `hipblas` job by extending its timeout and enabling test sharding for both Linux and Windows platforms.  The TODO issue was closed so clearing that out.   Comprehensive hits time limits for tests so 2 shards and 1 hour required.

Test configuration improvements for `hipblas`:

* Increased the `timeout_minutes` for the `hipblas` job from 30 to 60 to allow more time for tests to complete.
* Updated `total_shards_dict` for `hipblas` to run tests in 2 shards on both Linux and Windows, improving parallelism and coverage.