### PR TITLE
fix: Set LD_PRELOAD for ASan runtime in test workflows

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -153,8 +153,6 @@ jobs:
           echo "ASAN_OPTIONS=detect_odr_violation=0:quarantine_size_mb=600" >> $GITHUB_ENV
           echo "HSA_XNACK=1" >> $GITHUB_ENV
           echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
-          ASAN_LIB=$(${{ env.OUTPUT_ARTIFACTS_DIR }}/lib/llvm/bin/clang++ --print-file-name=libclang_rt.asan-x86_64.so)
-          echo "LD_PRELOAD=${ASAN_LIB}" >> $GITHUB_ENV
 
       - name: Test
         id: test

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -153,6 +153,8 @@ jobs:
           echo "ASAN_OPTIONS=detect_odr_violation=0:quarantine_size_mb=600" >> $GITHUB_ENV
           echo "HSA_XNACK=1" >> $GITHUB_ENV
           echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
+          ASAN_LIB=$(${{ env.OUTPUT_ARTIFACTS_DIR }}/lib/llvm/bin/clang++ --print-file-name=libclang_rt.asan-x86_64.so)
+          echo "LD_PRELOAD=${ASAN_LIB}" >> $GITHUB_ENV
 
       - name: Test
         id: test

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -29,10 +29,37 @@ def is_windows():
     return "windows" == platform.system().lower()
 
 
-def run_command(command: list[str], cwd=None):
+def get_asan_preload_env():
+    """Returns env with LD_PRELOAD for ASAN builds, None otherwise."""
+    if not is_asan():
+        return None
+    machine = platform.machine()
+    if machine in ("x86_64", "AMD64"):
+        arch = "x86_64"
+    elif machine == "aarch64":
+        arch = "aarch64"
+    else:
+        return None
+    clangxx = THEROCK_BIN_DIR / ".." / "lib" / "llvm" / "bin" / "clang++"
+    if not clangxx.exists():
+        return None
+    result = subprocess.run(
+        [str(clangxx), f"--print-file-name=libclang_rt.asan-{arch}.so"],
+        capture_output=True,
+        text=True,
+    )
+    asan_lib = result.stdout.strip()
+    if not asan_lib or not Path(asan_lib).exists():
+        return None
+    env = os.environ.copy()
+    env["LD_PRELOAD"] = asan_lib
+    return env
+
+
+def run_command(command: list[str], cwd=None, env=None):
     logger.info(f"++ Run [{cwd}]$ {shlex.join(command)}")
     process = subprocess.run(
-        command, capture_output=True, cwd=cwd, shell=is_windows(), text=True
+        command, capture_output=True, cwd=cwd, shell=is_windows(), text=True, env=env
     )
     if process.returncode != 0:
         logger.error(f"Command failed!")
@@ -147,7 +174,11 @@ class TestROCmSanity:
         # Running and checking the executable
         platform_executable_prefix = "./" if not is_windows() else ""
         hipcc_check_executable = f"{platform_executable_prefix}hipcc_check"
-        process = run_command([hipcc_check_executable], cwd=str(THEROCK_BIN_DIR))
+        process = run_command(
+            [hipcc_check_executable],
+            cwd=str(THEROCK_BIN_DIR),
+            env=get_asan_preload_env(),
+        )
         check.equal(process.returncode, 0)
         check.greater(
             os.path.getsize(str(THEROCK_BIN_DIR / hipcc_check_executable_file)), 0


### PR DESCRIPTION
  The ASan runtime library must be loaded first in the library list,
  otherwise tests fail with:
  "ASan runtime does not come first in initial library list"

  Use clang++ --print-file-name to dynamically resolve the ASan library
  path and set LD_PRELOAD before test execution.

Jira ID: https://github.com/ROCm/TheRock/issues/5919