### PR TITLE
WIP - FORKED TEST - DO NOT MERGE - Enable OIDC for external repos, skip for fork PRs

### DIFF
--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -46,9 +46,9 @@ class S3BucketConfig:
 
 
 s3_bucket_configs = [
-    # CI (self-hosted runners include credentials for therock-ci-artifacts-external)
+    # CI (external repos use OIDC with therock-ci-external; fork PRs use runner base credentials)
     S3BucketConfig("therock-ci-artifacts", iam_role="therock-ci"),
-    S3BucketConfig("therock-ci-artifacts-external", iam_role=None),
+    S3BucketConfig("therock-ci-artifacts-external", iam_role="therock-ci-external"),
     # Release type "dev"
     S3BucketConfig("therock-dev-artifacts", iam_role="therock-dev"),
     S3BucketConfig("therock-dev-packages", iam_role="therock-dev"),
@@ -216,4 +216,18 @@ def get_artifacts_bucket_config_for_workflow_run(
         is_pr_from_fork=is_pr_from_fork,
     )
     _log(f"  bucket: {config.name}")
+
+    # For fork PRs, skip OIDC and use runner base credentials instead.
+    # Fork PRs cannot assume IAM roles via OIDC because they don't have
+    # the required trust relationship. Return a config without an IAM role
+    # so the configure-aws-credentials step is skipped.
+    if is_pr_from_fork and config.iam_role is not None:
+        _log("  Fork PR detected, skipping OIDC (using runner base credentials)")
+        config = S3BucketConfig(
+            name=config.name,
+            region=config.region,
+            iam_account=config.iam_account,
+            iam_role=None,
+        )
+
     return config

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -2,6 +2,8 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+# Test: Verify fork PR skips OIDC and uses runner base credentials (issue #5654)
+
 """Configures CI matrix and job decisions for multi-arch workflows.
 
 This script is a pipeline of data transformations:

--- a/docs/development/s3_buckets.md
+++ b/docs/development/s3_buckets.md
@@ -64,6 +64,13 @@ jobs:
   `configure_aws_artifacts_credentials` composite action mentioned above
   handles this automatically)
 
+**External repos and forks:**
+
+- **External repos** (e.g., `rocm-libraries`) use OIDC with the
+  `therock-ci-external` role to upload to `therock-ci-artifacts-external`.
+- **Fork PRs** cannot use OIDC (no trust relationship). They fall back to
+  runner base credentials.
+
 ## Bucket inventory
 
 ### CI buckets


### PR DESCRIPTION
Add iam_role="therock-ci-external" back to therock-ci-artifacts-external bucket config to enable OIDC authentication for external repos like rocm-libraries.

For fork PRs, the iam_role is set to None in
get_artifacts_bucket_config_for_workflow_run() so that OIDC is skipped and runner base credentials are used instead. This fixes issue #5654 where fork PRs failed with "Could not assume role" because they don't have the required OIDC trust relationship.

Summary:
- External repos (non-fork): Use OIDC with therock-ci-external role
- Fork PRs: Skip OIDC, use runner base credentials (Linux only)

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
