### PR TITLE
Adding script to compute affected stage changes

### DIFF
--- a/build_tools/github_actions/determine_stages.py
+++ b/build_tools/github_actions/determine_stages.py
@@ -12,43 +12,60 @@ from collections import defaultdict, deque
 TOPOLOGY_FILE = "BUILD_TOPOLOGY.toml"
 
 def git(*args: str) -> str:
-    return subprocess.check_output(
-        ["git", *args],
-        text=True,
-    ).strip()
+    return subprocess.check_output(["git", *args], text=True).strip()
 
 
 def changed_files(base: str, head: str) -> list[str]:
-    diff = git("diff", "--name-only", f"{base}...{head}")
-    return [x for x in diff.splitlines() if x.strip()]
-
+    out = git("diff", "--name-only", f"{base}...{head}")
+    return [x for x in out.splitlines() if x.strip()]
 
 def load_topology():
     with open(TOPOLOGY_FILE, "rb") as f:
         return tomllib.load(f)
 
+def build_source_set_index(topo):
+    """
+    submodule -> source_set mapping
+    """
+    index = {}
 
-def build_group_graph(topology):
-    groups = topology["artifact_groups"]
+    for set_name, meta in topo["source_sets"].items():
+        for sm in meta.get("submodules", []):
+            index[sm] = set_name
 
+    return index
+
+
+def build_source_set_to_groups(topo):
+    """
+    source_set -> artifact_groups
+    """
+    mapping = defaultdict(set)
+
+    for gname, gmeta in topo["artifact_groups"].items():
+        for ss in gmeta.get("source_sets", []):
+            mapping[ss].add(gname)
+
+    return mapping
+
+
+def build_group_deps(topo):
     deps = defaultdict(set)
     reverse = defaultdict(set)
 
-    for name, meta in groups.items():
+    for g, meta in topo["artifact_groups"].items():
         for d in meta.get("artifact_group_deps", []):
-            deps[name].add(d)
-            reverse[d].add(name)
+            deps[g].add(d)
+            reverse[d].add(g)
 
     return deps, reverse
 
 
-def build_stage_map(topology):
-    stages = topology["build_stages"]
-
+def build_stage_map(topo):
     group_to_stage = {}
     stage_to_groups = {}
 
-    for stage, meta in stages.items():
+    for stage, meta in topo["build_stages"].items():
         stage_to_groups[stage] = set(meta["artifact_groups"])
         for g in meta["artifact_groups"]:
             group_to_stage[g] = stage
@@ -56,90 +73,52 @@ def build_stage_map(topology):
     return group_to_stage, stage_to_groups
 
 
-# ----------------------------
-# naive path → group mapping
-# ----------------------------
-
-def map_path_to_groups(path: str) -> set[str]:
-    p = path.lower()
-
-    if "llvm-project" in p or "hipify" in p:
-        return {"compiler"}
-
-    if "rocm-libraries" in p:
-        return {"math-libs", "ml-libs"}
-
-    if "rocm-systems" in p:
-        # affects almost everything
-        return {
-            "base",
-            "core-runtime",
-            "hip-runtime",
-            "opencl-runtime",
-            "runtime-tests",
-            "profiler-core",
-            "comm-libs",
-            "storage-libs",
-            "debug-tools",
-            "dctools-core",
-            "profiler-apps",
-            "media-libs",
-            "rocjitsu",
-        }
-
-    return set()
-
-
-# ----------------------------
-# propagate dependencies
-# ----------------------------
+def extract_submodule(path: str) -> str | None:
+    parts = path.split("/")
+    return parts[0] if parts else None
 
 def closure(seed: set[str], reverse_deps: dict[str, set[str]]) -> set[str]:
     q = deque(seed)
     out = set(seed)
 
     while q:
-        g = q.popleft()
-        for dep in reverse_deps.get(g, []):
-            if dep not in out:
-                out.add(dep)
-                q.append(dep)
+        x = q.popleft()
+        for n in reverse_deps.get(x, []):
+            if n not in out:
+                out.add(n)
+                q.append(n)
 
     return out
 
-
-# ----------------------------
-# main
-# ----------------------------
-
 def main():
     ap = argparse.ArgumentParser()
-
     ap.add_argument("--base", required=True)
     ap.add_argument("--head", required=True)
-
     args = ap.parse_args()
 
     topo = load_topology()
 
-    group_deps, reverse_deps = build_group_graph(topo)
+    submodule_to_source_set = build_source_set_index(topo)
+    source_set_to_groups = build_source_set_to_groups(topo)
+    _, group_reverse_deps = build_group_deps(topo)
     group_to_stage, stage_to_groups = build_stage_map(topo)
 
     files = changed_files(args.base, args.head)
 
-    if not files:
-        print(json.dumps({"stages": []}, indent=2))
-        return
-
     impacted_groups = set()
 
     for f in files:
-        impacted_groups |= map_path_to_groups(f)
+        sm = extract_submodule(f)
+        if not sm:
+            continue
 
-    # propagate group-level dependencies
-    impacted_groups = closure(impacted_groups, reverse_deps)
+        source_set = submodule_to_source_set.get(sm)
+        if not source_set:
+            continue
 
-    # map to stages
+        impacted_groups |= source_set_to_groups.get(source_set, set())
+
+    impacted_groups = closure(impacted_groups, group_reverse_deps)
     impacted_stages = set()
 
     for g in impacted_groups:

--- a/build_tools/github_actions/determine_stages.py
+++ b/build_tools/github_actions/determine_stages.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import tomllib
+from collections import defaultdict, deque
+
+
+TOPOLOGY_FILE = "BUILD_TOPOLOGY.toml"
+
+def git(*args: str) -> str:
+    return subprocess.check_output(
+        ["git", *args],
+        text=True,
+    ).strip()
+
+
+def changed_files(base: str, head: str) -> list[str]:
+    diff = git("diff", "--name-only", f"{base}...{head}")
+    return [x for x in diff.splitlines() if x.strip()]
+
+
+def load_topology():
+    with open(TOPOLOGY_FILE, "rb") as f:
+        return tomllib.load(f)
+
+
+def build_group_graph(topology):
+    groups = topology["artifact_groups"]
+
+    deps = defaultdict(set)
+    reverse = defaultdict(set)
+
+    for name, meta in groups.items():
+        for d in meta.get("artifact_group_deps", []):
+            deps[name].add(d)
+            reverse[d].add(name)
+
+    return deps, reverse
+
+
+def build_stage_map(topology):
+    stages = topology["build_stages"]
+
+    group_to_stage = {}
+    stage_to_groups = {}
+
+    for stage, meta in stages.items():
+        stage_to_groups[stage] = set(meta["artifact_groups"])
+        for g in meta["artifact_groups"]:
+            group_to_stage[g] = stage
+
+    return group_to_stage, stage_to_groups
+
+
+# ----------------------------
+# naive path → group mapping
+# ----------------------------
+
+def map_path_to_groups(path: str) -> set[str]:
+    p = path.lower()
+
+    if "llvm-project" in p or "hipify" in p:
+        return {"compiler"}
+
+    if "rocm-libraries" in p:
+        return {"math-libs", "ml-libs"}
+
+    if "rocm-systems" in p:
+        # affects almost everything
+        return {
+            "base",
+            "core-runtime",
+            "hip-runtime",
+            "opencl-runtime",
+            "runtime-tests",
+            "profiler-core",
+            "comm-libs",
+            "storage-libs",
+            "debug-tools",
+            "dctools-core",
+            "profiler-apps",
+            "media-libs",
+            "rocjitsu",
+        }
+
+    return set()
+
+
+# ----------------------------
+# propagate dependencies
+# ----------------------------
+
+def closure(seed: set[str], reverse_deps: dict[str, set[str]]) -> set[str]:
+    q = deque(seed)
+    out = set(seed)
+
+    while q:
+        g = q.popleft()
+        for dep in reverse_deps.get(g, []):
+            if dep not in out:
+                out.add(dep)
+                q.append(dep)
+
+    return out
+
+
+# ----------------------------
+# main
+# ----------------------------
+
+def main():
+    ap = argparse.ArgumentParser()
+
+    ap.add_argument("--base", required=True)
+    ap.add_argument("--head", required=True)
+
+    args = ap.parse_args()
+
+    topo = load_topology()
+
+    group_deps, reverse_deps = build_group_graph(topo)
+    group_to_stage, stage_to_groups = build_stage_map(topo)
+
+    files = changed_files(args.base, args.head)
+
+    if not files:
+        print(json.dumps({"stages": []}, indent=2))
+        return
+
+    impacted_groups = set()
+
+    for f in files:
+        impacted_groups |= map_path_to_groups(f)
+
+    # propagate group-level dependencies
+    impacted_groups = closure(impacted_groups, reverse_deps)
+
+    # map to stages
+    impacted_stages = set()
+
+    for g in impacted_groups:
+        if g in group_to_stage:
+            impacted_stages.add(group_to_stage[g])
+
+    if not impacted_stages:
+        impacted_stages = set(stage_to_groups.keys())
+
+    print(json.dumps({
+        "changed_files": files,
+        "impacted_groups": sorted(impacted_groups),
+        "impacted_stages": sorted(impacted_stages),
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Motivation

This script introduces a deterministic, topology-driven way to identify which CI build stages are impacted by a pull request.

The goal is to reduce unnecessary CI execution by analyzing changed files and mapping them through the build dependency graph defined in BUILD_TOPOLOGY.toml. This is the first step toward enabling efficient stage-level CI skipping and later artifact reuse.

Instead of relying on CI history or cached builds, this script computes impacted stages purely from source changes and the declared build topology, ensuring correctness and reproducibility.

## Technical Details

<p>
The script performs the following steps:
</p>
<ol>
  <li>
    <b>Compute changed files</b><br/>
    Uses <code>git diff --name-only &lt;base&gt;...&lt;head&gt;</code> to identify files modified in the pull request.
  </li>

  <li>
    <b>Load build topology</b><br/>
    Parses <code>BUILD_TOPOLOGY.toml</code> using Python's <code>tomllib</code>.<br/>
    Extracts:
    <ul>
      <li><code>artifact_groups</code></li>
      <li><code>artifact_group_deps</code></li>
      <li><code>build_stages</code></li>
    </ul>
  </li>

  <li>
    <b>Map file paths to artifact groups</b><br/>
    Uses a heuristic mapping layer  to associate changed paths with relevant artifact groups.<br/>
    Example mappings:
    <ul>
      <li><code>llvm-project/</code> → <code>compiler</code></li>
      <li><code>rocm-libraries/</code> → <code>math-libs</code>, <code>ml-libs</code></li>
      <li><code>rocm-systems/</code> → most core/runtime-related groups</li>
    </ul>
  </li>

  <li>
    <b>Propagate dependencies</b><br/>
    Builds a reverse dependency graph from <code>artifact_group_deps</code>.<br/>
    Computes transitive closure so that dependent groups are also marked impacted.
  </li>

  <li>
    <b>Map groups to build stages</b><br/>
    Uses <code>artifact_groups → build_stages</code> mapping.<br/>
    Produces the final set of impacted stages.
  </li>

  <li>
    <b>Fallback behavior</b><br/>
    If no mapping is found for changed files, the script conservatively marks all stages as impacted to avoid skipping required builds.
  </li>
</ol>

## Test Plan
(venv) amallya@build-hw-78:~/therock-demo/tiger-team/theROCK$ python3 build_tools/github_actions/determine_stages.py --base origin/main --head 32f51806a841552aa7d10828872cc33f537b15de
{
  "changed_files": [
    "compiler/CMakeLists.txt",
    "compiler/pre_hook_amd-llvm-static.cmake"
  ],
  "impacted_groups": [],
  "impacted_stages": [
    "comm-libs",
    "compiler-runtime",
    "dctools-core",
    "debug-tools",
    "math-libs",
    "media-libs",
    "profiler-apps",
    "runtime-tests",
    "storage-libs",
    "wsl-rocdxg"
  ]
}
(venv) amallya@build-hw-78:~/therock-demo/tiger-team/theROCK$ python3 build_tools/github_actions/determine_stages.py --base origin/main --head 2478dc3b5165939bb1ddc01b3b33228882ef7f27
{
  "changed_files": [
    "rocm-systems"
  ],
  "impacted_groups": [
    "base",
    "comm-libs",
    "core-amdsmi",
    "core-runtime",
    "dctools-core",
    "debug-tools",
    "hip-runtime",
    "math-libs",
    "media-libs",
    "ml-libs",
    "opencl-runtime",
    "profiler-apps",
    "profiler-core",
    "rocjitsu",
    "runtime-tests",
    "storage-libs",
    "wsl-rocdxg"
  ],
  "impacted_stages": [
    "comm-libs",
    "compiler-runtime",
    "dctools-core",
    "debug-tools",
    "math-libs",
    "media-libs",
    "profiler-apps",
    "runtime-tests",
    "storage-libs",
    "wsl-rocdxg"
  ]
}
