### PR TITLE
[ci] Enable OIDC for external repos, skip for fork PRs

### DIFF
--- a/build_tools/_therock_utils/s3_buckets.py
+++ b/build_tools/_therock_utils/s3_buckets.py
@@ -46,9 +46,9 @@ class S3BucketConfig:
 
 
 s3_bucket_configs = [
-    # CI (self-hosted runners include credentials for therock-ci-artifacts-external)
+    # CI (external repos use OIDC with therock-ci-external; fork PRs use runner base credentials)
     S3BucketConfig("therock-ci-artifacts", iam_role="therock-ci"),
-    S3BucketConfig("therock-ci-artifacts-external", iam_role=None),
+    S3BucketConfig("therock-ci-artifacts-external", iam_role="therock-ci-external"),
     # Release type "dev"
     S3BucketConfig("therock-dev-artifacts", iam_role="therock-dev"),
     S3BucketConfig("therock-dev-packages", iam_role="therock-dev"),
@@ -216,4 +216,18 @@ def get_artifacts_bucket_config_for_workflow_run(
         is_pr_from_fork=is_pr_from_fork,
     )
     _log(f"  bucket: {config.name}")
+
+    # For fork PRs, skip OIDC and use runner base credentials instead.
+    # Fork PRs cannot assume IAM roles via OIDC because they don't have
+    # the required trust relationship. Return a config without an IAM role
+    # so the configure-aws-credentials step is skipped.
+    if is_pr_from_fork and config.iam_role is not None:
+        _log("  Fork PR detected, skipping OIDC (using runner base credentials)")
+        config = S3BucketConfig(
+            name=config.name,
+            region=config.region,
+            iam_account=config.iam_account,
+            iam_role=None,
+        )
+
     return config

--- a/build_tools/tests/s3_buckets_test.py
+++ b/build_tools/tests/s3_buckets_test.py
@@ -39,12 +39,16 @@ class TestGetArtifactsBucketConfig(unittest.TestCase):
             release_type="ci", repository="ROCm/TheRock", is_pr_from_fork=True
         )
         self.assertEqual(config.name, "therock-ci-artifacts-external")
+        # The raw lookup returns the external role for forks; the OIDC skip for
+        # forks happens in get_artifacts_bucket_config_for_workflow_run, not here.
+        self.assertEqual(config.iam_role, "therock-ci-external")
 
     def test_ci_external_repo(self):
         config = get_artifacts_bucket_config(
             release_type="ci", repository="ROCm/rocm-libraries", is_pr_from_fork=False
         )
         self.assertEqual(config.name, "therock-ci-artifacts-external")
+        self.assertEqual(config.iam_role, "therock-ci-external")
 
     def test_release_type_dev(self):
         config = get_artifacts_bucket_config(
@@ -199,6 +203,37 @@ class TestGetArtifactsBucketConfigForWorkflowRun(unittest.TestCase):
             github_repository="ROCm/TheRock", workflow_run=fake_run
         )
         self.assertEqual(config.name, "therock-ci-artifacts-external")
+        # Fork PRs cannot assume an IAM role via OIDC (no trust relationship),
+        # so the wrapper must strip the role and fall back to runner base
+        # credentials. Regression coverage for #5654.
+        self.assertIsNone(config.iam_role)
+        self.assertIsNone(config.write_access_iam_role)
+
+    def test_workflow_run_external_repo_uses_oidc(self):
+        # An external (non-fork) repo such as rocm-libraries keeps the
+        # therock-ci-external role so it can authenticate via OIDC.
+        fake_run = {
+            "id": 12345,
+            "head_repository": {"full_name": "ROCm/rocm-libraries"},
+        }
+        config = get_artifacts_bucket_config_for_workflow_run(
+            github_repository="ROCm/rocm-libraries", workflow_run=fake_run
+        )
+        self.assertEqual(config.name, "therock-ci-artifacts-external")
+        self.assertEqual(config.iam_role, "therock-ci-external")
+
+    def test_workflow_run_same_repo_keeps_internal_role(self):
+        # A same-repo (non-fork) ROCm/TheRock PR is unaffected by the fork skip
+        # and keeps the internal therock-ci role.
+        fake_run = {
+            "id": 12345,
+            "head_repository": {"full_name": "ROCm/TheRock"},
+        }
+        config = get_artifacts_bucket_config_for_workflow_run(
+            github_repository="ROCm/TheRock", workflow_run=fake_run
+        )
+        self.assertEqual(config.name, "therock-ci-artifacts")
+        self.assertEqual(config.iam_role, "therock-ci")
 
     def test_workflow_run_id_triggers_api_call(self):
         self.mock_api.return_value = {

--- a/docs/development/s3_buckets.md
+++ b/docs/development/s3_buckets.md
@@ -64,6 +64,13 @@ jobs:
   `configure_aws_artifacts_credentials` composite action mentioned above
   handles this automatically)
 
+**External repos and forks:**
+
+- **External repos** (e.g., `rocm-libraries`) use OIDC with the
+  `therock-ci-external` role to upload to `therock-ci-artifacts-external`.
+- **Fork PRs** cannot use OIDC (no trust relationship). They fall back to
+  runner base credentials.
+
 ## Bucket inventory
 
 ### CI buckets


### PR DESCRIPTION
Add iam_role="therock-ci-external" back to therock-ci-artifacts-external bucket config to enable OIDC authentication for external repos like rocm-libraries.

An error was occuring for WSL ROCDXG as this is a github hosted runner and had no way to provide credentials for external repos

For fork PRs, the iam_role is set to None in
get_artifacts_bucket_config_for_workflow_run() so that OIDC is skipped and runner base credentials are used instead. This fixes issue #5654 where fork PRs failed with "Could not assume role" because they don't have the required OIDC trust relationship.

Summary:
- External repos (non-fork): Use OIDC with therock-ci-external role
- Fork PRs: Skip OIDC, use runner base credentials (Linux only)

Working in test fork PR: https://github.com/ROCm/TheRock/actions/runs/27710372755/job/81975007386?pr=5923
Working in external repo: https://github.com/ROCm/rocm-libraries/actions/runs/27709741844/job/81971020614

Truly resolves #5654 with proper external role plugged in now

Resolves errors found in https://github.com/ROCm/rocm-libraries/pull/8297