### PR TITLE
[ci] Increase AWS build runners to 100%

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -46,13 +46,12 @@ def select_weighted_label(labels_config: list[dict], context_name: str) -> str:
 
 
 # Build runner configuration for Linux builds
-# Uses weighted distribution: 50% Azure, 50% AWS
+# Uses weighted distribution: 100% AWS
 # Sanitizer builds (asan/tsan) use ramdisk variants (100% Azure, no AWS yet)
 BUILD_RUNNER_LABELS = {
     "linux": {
         "default": [
-            {"label": "azure-linux-scale-rocm", "weight": 0.5},
-            {"label": "aws-linux-scale-rocm-prod", "weight": 0.5},
+            {"label": "aws-linux-scale-rocm-prod", "weight": 1.0},
         ],
         "sanitizer": [
             {"label": "azure-linux-scale-rocm-heavy-ramdisk", "weight": 1.0},

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1369,22 +1369,22 @@ class TestBuildRunnerSelection(unittest.TestCase):
     """Test weighted random selection of build runners (Azure vs AWS)."""
 
     def test_select_build_runner_weighted_selection(self):
-        """Test weighted selection: Azure (50%) vs AWS (50%) for default builds."""
+        """Test weighted selection: 100% AWS for default Linux builds."""
         from amdgpu_family_matrix import select_build_runner
 
-        # Random < 0.5 should select Azure
+        # Any random value should select AWS for Linux
         with patch("random.random", return_value=0.3):
             self.assertEqual(
-                select_build_runner("linux", "release"), "azure-linux-scale-rocm"
+                select_build_runner("linux", "release"), "aws-linux-scale-rocm-prod"
             )
 
-        # Random >= 0.5 should select AWS
+        # Any random value should select AWS for Linux
         with patch("random.random", return_value=0.75):
             self.assertEqual(
                 select_build_runner("linux", "release"), "aws-linux-scale-rocm-prod"
             )
 
-        # Random >= 0.9 should select Azure
+        # Windows still uses Azure
         with patch("random.random", return_value=0.95):
             self.assertEqual(
                 select_build_runner("windows", "release"), "azure-windows-scale-rocm"


### PR DESCRIPTION
## Summary

- Increases AWS prod runner weight from 50% → 100% (0% Azure / 100% AWS)
- Completes the migration of Linux builds from Azure to AWS runners
- Sanitizer builds (asan/tsan) remain on Azure ramdisk variants

## Prerequisites

- [x] AWS prod runners stable at 50% since TheRock#5831
- [x] Prod AZRebalance suspension in place (TheRock-Infra#301)

## Test plan
- [ ] Verify all Linux CI builds route to `aws-linux-scale-rocm-prod`
- [ ] Monitor Grafana prod dashboard for runner pod pressure
- [ ] Confirm sanitizer builds still use Azure ramdisk runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)