### PR TITLE
Add LSAN suppressions for Python, bash, and rpds false positives

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -151,6 +151,7 @@ jobs:
         if: ${{ contains(inputs.artifact_group, 'asan') }}
         run: |
           echo "ASAN_OPTIONS=detect_odr_violation=0:quarantine_size_mb=600" >> $GITHUB_ENV
+          echo "LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/build_tools/github_actions/lsan_suppressions.txt" >> $GITHUB_ENV
           echo "HSA_XNACK=1" >> $GITHUB_ENV
           echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
 

--- a/build_tools/github_actions/lsan_suppressions.txt
+++ b/build_tools/github_actions/lsan_suppressions.txt
@@ -1,0 +1,26 @@
+# LSAN suppressions for known false positives in test environments.
+# These are not actual memory leaks - they are artifacts of internal
+# memory management that do not fully cooperate with LeakSanitizer's expectations.
+
+# Bash shell internal allocations
+# Bash intentionally does not free all memory before exit since the OS reclaims
+# it anyway. This is standard behavior for shells and not a real leak.
+leak:make_if_command
+leak:make_simple_command
+leak:command_connect
+leak:yyparse
+leak:/usr/bin/bash
+
+# Python's internal memory allocator (pymalloc)
+leak:_PyMem_RawMalloc
+leak:PyObject_Malloc
+leak:PyMem_Malloc
+leak:_PyObject_Malloc
+leak:_PyBytes_Resize
+leak:PyMem_RawMalloc
+leak:PyMem_Realloc
+leak:_PyObject_Realloc
+
+# rpds (Rust-based persistent data structures library, pytest dependency)
+leak:rpds::HashTrieMapPy
+leak:rpds::HashTrieSetPy


### PR DESCRIPTION
  When running ASAN CI tests, LeakSanitizer reports false positive memory
  leaks from third-party components:

  - Bash shell internal allocations (make_if_command, yyparse, etc.)
  - Python's internal memory allocator (pymalloc)
  - rpds library (Rust-based pytest dependency)

  These are not actual leaks - they are artifacts of internal memory
  management that do not fully cooperate with LeakSanitizer's expectations.

  This change adds a suppressions file to filter out these false positives,
  allowing CI to focus on real memory leaks in ROCm components
  
  Fixed : https://github.com/ROCm/TheRock/issues/5951

