### PR TITLE
Baseline-runs: add workflow run summary contract

### DIFF
--- a/build_tools/github_actions/baseline_runs.py
+++ b/build_tools/github_actions/baseline_runs.py
@@ -73,20 +73,69 @@ class WorkflowJobHealth:
     def is_valid(self) -> bool:
         return not self.failed_job_names and not self.missing_name_substrings
 
+@dataclass(frozen=True)
+class WorkflowRunSummary:
+    """Compact source/ref summary for a workflow run."""
+
+    repository: str
+    branch: str
+    commit: str
+    workflow: str
+    run_id: str
+    status: str
+    conclusion: str | None
+    timestamp: str | None
+    html_url: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "repository": self.repository,
+            "branch": self.branch,
+            "commit": self.commit,
+            "workflow": self.workflow,
+            "run_id": self.run_id,
+            "status": self.status,
+            "conclusion": self.conclusion,
+            "timestamp": self.timestamp,
+            "html_url": self.html_url,
+        }
 
 @dataclass(frozen=True)
 class BaselineRun:
     """Workflow run with build jobs and artifacts suitable for reuse."""
 
-    run_id: str
-    html_url: str
-    head_sha: str
-    branch: str
-    workflow_name: str
+    source_ref: WorkflowRunSummary
     platform: str
     job_health: WorkflowJobHealth
     artifact_availability: ArtifactAvailability
 
+    @property
+    def run_id(self) -> str:
+        return self.source_ref.run_id
+
+    @property
+    def html_url(self) -> str:
+        return self.source_ref.html_url
+
+    @property
+    def head_sha(self) -> str:
+        return self.source_ref.commit
+
+    @property
+    def branch(self) -> str:
+        return self.source_ref.branch
+
+    @property
+    def workflow_name(self) -> str:
+        return self.source_ref.workflow
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "source_ref": self.source_ref.to_dict(),
+            "platform": self.platform,
+            "job_health": self.job_health,
+            "artifact_availability": self.artifact_availability,
+        }
 
 ArtifactBackendFactory = Callable[[dict, str, str], ArtifactBackend]
 WorkflowJobsFetcher = Callable[[dict, str], Sequence[dict]]
@@ -261,6 +310,24 @@ def query_jobs_for_workflow_run(
         run_attempt=run_attempt,
     )
 
+def create_workflow_run_summary(
+    workflow_run: dict,
+    *,
+    github_repository: str,
+    workflow_name: str,
+) -> WorkflowRunSummary:
+    """Create a compact source/ref summary for a workflow run."""
+    return WorkflowRunSummary(
+        repository=github_repository,
+        branch=workflow_run.get("head_branch", ""),
+        commit=workflow_run.get("head_sha", ""),
+        workflow=workflow_name,
+        run_id=str(workflow_run["id"]),
+        status=workflow_run.get("status", ""),
+        conclusion=workflow_run.get("conclusion"),
+        timestamp=workflow_run.get("created_at"),
+        html_url=workflow_run.get("html_url", ""),
+    )
 
 def create_artifact_backend_for_workflow_run(
     workflow_run: dict,
@@ -471,12 +538,14 @@ def select_baseline_run(
         if not availability.is_valid:
             continue
 
-        return BaselineRun(
-            run_id=run_id,
-            html_url=workflow_run.get("html_url", ""),
-            head_sha=workflow_run.get("head_sha", ""),
-            branch=workflow_run.get("head_branch", branch),
+        source_ref = create_workflow_run_summary(
+            workflow_run,
+            github_repository=github_repository,
             workflow_name=workflow_name,
+        )
+
+        return BaselineRun(
+            source_ref=source_ref,
             platform=platform,
             job_health=job_health,
             artifact_availability=availability,

--- a/build_tools/github_actions/baseline_runs.py
+++ b/build_tools/github_actions/baseline_runs.py
@@ -73,6 +73,7 @@ class WorkflowJobHealth:
     def is_valid(self) -> bool:
         return not self.failed_job_names and not self.missing_name_substrings
 
+
 @dataclass(frozen=True)
 class WorkflowRunSummary:
     """Compact source/ref summary for a workflow run."""
@@ -99,6 +100,7 @@ class WorkflowRunSummary:
             "timestamp": self.timestamp,
             "html_url": self.html_url,
         }
+
 
 @dataclass(frozen=True)
 class BaselineRun:
@@ -136,6 +138,7 @@ class BaselineRun:
             "job_health": self.job_health,
             "artifact_availability": self.artifact_availability,
         }
+
 
 ArtifactBackendFactory = Callable[[dict, str, str], ArtifactBackend]
 WorkflowJobsFetcher = Callable[[dict, str], Sequence[dict]]
@@ -310,6 +313,7 @@ def query_jobs_for_workflow_run(
         run_attempt=run_attempt,
     )
 
+
 def create_workflow_run_summary(
     workflow_run: dict,
     *,
@@ -328,6 +332,7 @@ def create_workflow_run_summary(
         timestamp=workflow_run.get("created_at"),
         html_url=workflow_run.get("html_url", ""),
     )
+
 
 def create_artifact_backend_for_workflow_run(
     workflow_run: dict,

--- a/build_tools/github_actions/tests/baseline_runs_test.py
+++ b/build_tools/github_actions/tests/baseline_runs_test.py
@@ -193,6 +193,74 @@ class BaselineRunsTest(unittest.TestCase):
         self.assertIn("page=1", first_url)
         self.assertIn("page=2", second_url)
 
+    def test_create_workflow_run_summary(self):
+        run = _workflow_run("123")
+        summary = baseline_runs.create_workflow_run_summary(
+            run,
+            github_repository="ROCm/TheRock",
+            workflow_name="multi_arch_ci.yml",
+        )
+
+        self.assertEqual(summary.repository, "ROCm/TheRock")
+        self.assertEqual(summary.branch, "main")
+        self.assertEqual(summary.commit, "sha-123")
+        self.assertEqual(summary.workflow, "multi_arch_ci.yml")
+        self.assertEqual(summary.run_id, "123")
+        self.assertEqual(summary.status, "completed")
+        self.assertEqual(summary.conclusion, "success")
+        self.assertEqual(summary.timestamp, None)
+
+    def test_workflow_run_summary_to_dict(self):
+        run = _workflow_run("123")
+        summary = baseline_runs.create_workflow_run_summary(
+            run,
+            github_repository="ROCm/TheRock",
+            workflow_name="multi_arch_ci.yml",
+        )
+
+        payload = summary.to_dict()
+        self.assertEqual(
+            set(payload.keys()),
+            {
+                "repository",
+                "branch",
+                "commit",
+                "workflow",
+                "run_id",
+                "status",
+                "conclusion",
+                "timestamp",
+                "html_url",
+            },
+        )
+        self.assertEqual(payload["run_id"], "123")
+        self.assertEqual(payload["workflow"], "multi_arch_ci.yml")
+
+    def test_baseline_run_to_dict(self):
+        source_ref = baseline_runs.WorkflowRunSummary(
+            repository="ROCm/TheRock",
+            branch="main",
+            commit="sha-123",
+            workflow="multi_arch_ci.yml",
+            run_id="123",
+            status="completed",
+            conclusion="success",
+            timestamp=None,
+        )
+
+        baseline = baseline_runs.BaselineRun(
+            source_ref=source_ref,
+            platform="linux",
+            job_health=mock.Mock(),
+            artifact_availability=mock.Mock(),
+        )
+
+        payload = baseline.to_dict()
+
+        self.assertIn("source_ref", payload)
+        self.assertEqual(payload["platform"], "linux")
+        self.assertEqual(payload["source_ref"]["run_id"], "123")
+
     def test_validate_required_artifacts_available(self):
         backend = FakeBackend(
             [
@@ -375,6 +443,8 @@ class BaselineRunsTest(unittest.TestCase):
         self.assertEqual(baseline.run_id, "failed")
         self.assertEqual(baseline.head_sha, "sha-failed")
         self.assertEqual(baseline.platform, "linux")
+        self.assertEqual(baseline.source_ref.workflow, "multi_arch_ci.yml")
+        self.assertEqual(baseline.source_ref.repository, "ROCm/TheRock")
         self.assertEqual(baseline.job_health.failed_job_names, ())
         self.assertEqual(baseline.artifact_availability.missing_artifacts, ())
 


### PR DESCRIPTION
## Summary

This PR introduces a stable workflow run summary contract for baseline selection.

The implementation adds `WorkflowRunSummary` as a compact source/ref representation of a workflow run and attaches it to `BaselineRun` via `source_ref`. This provides a consistent interface for downstream consumers while preserving existing baseline selection behavior.

## Motivation

Baseline selection currently returns workflow metadata through several individual fields. As targeted CI work expands, downstream consumers need a stable representation of repository, branch, commit, workflow, and run information that can be reused across reporting, baseline planning, and future CI decision logic.

This PR establishes that contract.

## Changes

### Workflow Run Summary

Added:

* `WorkflowRunSummary`
* `WorkflowRunSummary.to_dict()`

Fields include:

* repository
* branch
* commit
* workflow
* run_id
* status
* conclusion
* timestamp
* html_url

### Baseline Selection

Updated:

* `BaselineRun` now contains `source_ref: WorkflowRunSummary`
* `select_baseline_run()` populates `source_ref` for selected baselines

Existing convenience properties (`run_id`, `head_sha`, `branch`, `workflow_name`, etc.) remain available.

### Test Coverage

Added:

* `test_create_workflow_run_summary`
* `test_workflow_run_summary_to_dict`
* `test_baseline_run_to_dict`

### Test Results

```bash
python -m unittest build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest -v
test_baseline_run_to_dict (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_baseline_run_to_dict) ... ok
test_create_workflow_run_summary (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_create_workflow_run_summary) ... ok
test_is_completed_workflow_run (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_is_completed_workflow_run) ... ok
test_is_successful_workflow_job (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_is_successful_workflow_job) ... ok
test_is_successful_workflow_run (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_is_successful_workflow_run) ... ok
test_query_completed_workflow_runs (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_query_completed_workflow_runs) ... ok
test_query_successful_workflow_runs (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_query_successful_workflow_runs) ... ok
test_query_workflow_run_jobs_paginates_latest_jobs (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_query_workflow_run_jobs_paginates_latest_jobs) ... ok
test_query_workflow_run_jobs_uses_run_attempt_when_provided (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_query_workflow_run_jobs_uses_run_attempt_when_provided) ... ok
test_select_baseline_run_returns_none_when_no_candidate_is_valid (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_select_baseline_run_returns_none_when_no_candidate_is_valid) ... ok
test_select_baseline_run_skips_run_when_required_build_job_failed (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_select_baseline_run_skips_run_when_required_build_job_failed) ... ok
test_select_baseline_run_uses_failed_workflow_with_healthy_build_jobs (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_select_baseline_run_uses_failed_workflow_with_healthy_build_jobs) ... ok
test_validate_required_artifacts_available (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_validate_required_artifacts_available) ... ok
test_validate_required_artifacts_available_reports_missing_names (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_validate_required_artifacts_available_reports_missing_names) ... ok
test_validate_required_artifacts_checks_each_target_family (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_validate_required_artifacts_checks_each_target_family) ... ok
test_validate_required_artifacts_requires_nonempty_requirements (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_validate_required_artifacts_requires_nonempty_requirements) ... ok
test_validate_required_jobs_successful (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_validate_required_jobs_successful) ... ok
test_validate_required_jobs_successful_reports_failed_and_missing_jobs (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_validate_required_jobs_successful_reports_failed_and_missing_jobs) ... ok
test_workflow_run_summary_to_dict (build_tools.github_actions.tests.baseline_runs_test.BaselineRunsTest.test_workflow_run_summary_to_dict) ... ok

----------------------------------------------------------------------
Ran 19 tests in 0.001s

OK
```

Updated baseline selection tests to validate the populated `source_ref` fields.

## Behavior Changes

None.

Baseline selection logic, artifact validation, job-health validation, and candidate selection behavior are unchanged.

## Future Work

This PR provides the source/ref summary layer needed for future baseline-planning work.

Follow-on work can use this contract to:

* generate baseline reuse plans
* support dry-run reporting
* track baseline provenance
* integrate targeted CI reuse decisions into workflow automation