### PR TITLE
[ci] Add thread limit env vars to test component workflow

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -163,6 +163,7 @@ jobs:
           TEST_TYPE: ${{ fromJSON(inputs.component).test_type }}
           TEST_COMPONENT: ${{ fromJSON(inputs.component).job_name }}
           ROCM_KPACK_DEBUG: "1"
+          # Limit thread count to prevent CPU over-subscription during tests
           OPENBLAS_NUM_THREADS: "4"
           OMP_NUM_THREADS: "4"
           # Windows hip-tests (PAL=1, ROCR=0) set this via matrix; other components

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -163,6 +163,8 @@ jobs:
           TEST_TYPE: ${{ fromJSON(inputs.component).test_type }}
           TEST_COMPONENT: ${{ fromJSON(inputs.component).job_name }}
           ROCM_KPACK_DEBUG: "1"
+          OPENBLAS_NUM_THREADS: "4"
+          OMP_NUM_THREADS: "4"
           # Windows hip-tests (PAL=1, ROCR=0) set this via matrix; other components
           # leave it empty. #3587
           GPU_ENABLE_PAL: ${{ fromJSON(inputs.component).gpu_enable_pal }}


### PR DESCRIPTION
set OPENBLAS_NUM_THREADS and OMP_NUM_THREADS to 4 in the Test step to limit thread usage during test execution.

Test ran here: https://github.com/ROCm/TheRock/actions/runs/27778144650