### PR TITLE
test(ci): default ctest runners to serial execution

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/README.md
+++ b/build_tools/github_actions/test_executable_scripts/README.md
@@ -57,7 +57,7 @@ ______________________________________________________________________
 
 - `ctest -L <category>` (and optionally `-L ex_gpu_<arch>` or `-LE ex_gpu`).
 - Common options: `--output-on-failure`, `--parallel <N>`, `--test-dir`, `-V`, `--tests-information <SHARD_INDEX>,<TOTAL_SHARDS>`.
-- Parallelism: default 8; can be adjusted according to `AMDGPU_FAMILIES`
+- Parallelism: default 1 (serial); can be adjusted according to `AMDGPU_FAMILIES`
 
 7. **Run ctest**
    Execute the command in `THEROCK_DIR` with the environment that includes `ROCM_PATH`, `GTEST_SHARD_INDEX`, and `GTEST_TOTAL_SHARDS`.

--- a/build_tools/github_actions/test_executable_scripts/test_hipcub.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipcub.py
@@ -99,8 +99,6 @@ cmd = [
     "--test-dir",
     f"{THEROCK_BIN_DIR}/hipcub",
     "--output-on-failure",
-    "--parallel",
-    "8",
     "--resource-spec-file",
     resource_spec_file,
 ]

--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn.py
@@ -19,8 +19,6 @@ cmd = [
     "--test-dir",
     f"{THEROCK_BIN_DIR}/hipdnn",
     "--output-on-failure",
-    "--parallel",
-    "8",
 ]
 
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")

--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn_install.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn_install.py
@@ -94,8 +94,6 @@ def run_tests(build_dir: Path):
         "--test-dir",
         str(build_dir),
         "--output-on-failure",
-        "--parallel",
-        "8",
     ]
     logging.info(f"++ Test: {shlex.join(test_cmd)}")
     subprocess.run(test_cmd, check=True, cwd=THEROCK_DIR, env=environ_vars)

--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn_integration_tests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn_integration_tests.py
@@ -18,8 +18,6 @@ cmd = [
     "--test-dir",
     f"{THEROCK_BIN_DIR}/hipdnn_integration_tests_ctest",
     "--output-on-failure",
-    "--parallel",
-    "8",
 ]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 

--- a/build_tools/github_actions/test_executable_scripts/test_hipdnn_samples.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipdnn_samples.py
@@ -18,8 +18,6 @@ cmd = [
     "--test-dir",
     f"{THEROCK_BIN_DIR}/hipdnn_samples",
     "--output-on-failure",
-    "--parallel",
-    "8",
 ]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 

--- a/build_tools/github_actions/test_executable_scripts/test_hiprand.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiprand.py
@@ -18,8 +18,6 @@ cmd = [
     "--test-dir",
     f"{THEROCK_BIN_DIR}/hipRAND",
     "--output-on-failure",
-    "--parallel",
-    "8",
 ]
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocprim.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprim.py
@@ -141,8 +141,6 @@ cmd = [
     "--test-dir",
     f"{THEROCK_BIN_DIR}/rocprim",
     "--output-on-failure",
-    "--parallel",
-    "8",
     "--resource-spec-file",
     resource_spec_file,
     # shards the tests by running a specific set of tests based on starting test (shard_index) and stride (total_shards)

--- a/build_tools/github_actions/test_executable_scripts/test_rocrand.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocrand.py
@@ -87,8 +87,6 @@ cmd = [
     "--test-dir",
     f"{THEROCK_BIN_DIR}/rocRAND",
     "--output-on-failure",
-    "--parallel",
-    "8",
     "--repeat",
     "until-pass:3",
 ]

--- a/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocthrust.py
@@ -85,7 +85,7 @@ QUICK_TESTS = [
 ]
 
 # Some platforms are less capable than others.
-ctest_parallel_count = 8
+ctest_parallel_count = 1
 if AMDGPU_FAMILIES == "gfx1152":
     ctest_parallel_count = 4
 elif AMDGPU_FAMILIES == "gfx1153":

--- a/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocwmma.py
@@ -56,7 +56,7 @@ elif test_type == "regression":
     timeout = str(_PER_TEST_TIMEOUT_QUICK_SEC)
 
 # Make per-device adjustments
-ctest_parallelism = "2"
+ctest_parallelism = "1"
 if AMDGPU_FAMILIES == "gfx1153":
     ctest_parallelism = "1"
 

--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -99,7 +99,7 @@ SHARD_INDEX = os.getenv("SHARD_INDEX", 1)
 TOTAL_SHARDS = os.getenv("TOTAL_SHARDS", 1)
 
 # CTest parallel jobs (use fewer in less capable platforms)
-ctest_parallel_count = 8
+ctest_parallel_count = 1
 if AMDGPU_FAMILIES and "gfx1152" in AMDGPU_FAMILIES:
     ctest_parallel_count = 4
 elif AMDGPU_FAMILIES and "gfx1153" in AMDGPU_FAMILIES:


### PR DESCRIPTION
## Summary

Run the component test suites serially by defaulting the
`build_tools/github_actions/test_executable_scripts/` runners (the copies CI
invokes today via `fetch_test_configurations.py`) to a single ctest job. Parallel
ctest runs have caused flaky failures and GPU contention/OOM; serial execution
favors deterministic, triage-friendly runs. Where a parallelism knob already
exists it is preserved (initial value set to 1), so a parallel value can still be
specified.

## Risk Assessment

Risk 2. Reusable CI/test-orchestration only; no product or API change. Every test
still runs - only concurrency drops to serial. Trade-off: longer test wall-clock
time.

## Related

- Work tracking: none yet (W-NOTICKET) - no tracker filed at author time.
- Related PR: rocm-libraries PR removing the same flags from the migrated `test/therock/` copies - https://github.com/ROCm/rocm-libraries/pull/8607
- Design / docs: `docs/rfcs/RFC0010-Test-Scripts-Migration.md` (why these scripts exist in both repos).

## Testing Summary

- TheRock runner unit tests (`unit_test_runner.py`); py_compile of changed runners;
  black (pinned 25.11.0) clean. Runners still emit a valid ctest invocation
  (hardcoded runners now serial; variable-driven runners default to `--parallel 1`).

## Testing Checklist

- [x] `python -m unittest build_tools/github_actions/tests/unit_test_runner.py` - Status: Passed
- [x] py_compile changed scripts - Status: Passed
- [x] black (pinned 25.11.0) on changed files - Status: Passed (no changes)
- [ ] PR CI - GitHub PR checks - Status: Pending

## Flags / Guardrails

None. Hardcoded runners omit `--parallel` (ctest defaults to serial); variable-driven
runners keep the knob with a default of 1.

## Risk Acceptance / Waivers

- W-BUILD: reusable-CI/build-only change, no product behavior change.
- W-NOTICKET: no tracker at author time.

## Technical Changes

- Variable-driven runners default to serial: `ctest_parallel_count` 8->1
  (`test_runner`, `test_rocthrust`), `ctest_parallelism` "2"->"1" (`test_rocwmma`).
  The `--parallel` flag and per-GPU branches are kept so a parallel value can still
  be set.
- Removed the hardcoded `--parallel 8` pair from the rocm-libraries component
  runners under `test_executable_scripts/` (`test_rocrand`, `test_hiprand`,
  `test_rocprim`, `test_hipcub`, `test_hipdnn`, `test_hipdnn_install`,
  `test_hipdnn_samples`, `test_hipdnn_integration_tests`).
- README: parallelism default note updated 8 -> 1 (serial). `unit_test_runner.py`
  unchanged (test_runner.py still passes `--parallel`).
