### PR TITLE
Remove unnecessary package permissions from JAX workflows

### DIFF
--- a/.github/workflows/multi_arch_build_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels.yml
@@ -109,7 +109,6 @@ run-name: Build Multi-Arch Linux JAX Wheels (${{ inputs.release_type }}, ${{ inp
 permissions:
   contents: read
   id-token: write
-  packages: read
 
 jobs:
   build_jax_wheels:
@@ -214,6 +213,9 @@ jobs:
     steps:
       - name: Checking out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref_name }}
 
       - name: Generating target to run
         id: configure
@@ -228,7 +230,6 @@ jobs:
     name: Test JAX wheels | py ${{ inputs.python_version }} | jax ${{ inputs.jax_ref }}
     permissions:
       contents: read
-      packages: read
       id-token: write
     uses: ./.github/workflows/test_linux_jax_wheels_partial.yml
     with:

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -86,7 +86,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      packages: read
     uses: ./.github/workflows/multi_arch_build_linux_jax_wheels.yml
     with:
       test_amdgpu_family: ${{ inputs.test_amdgpu_family }}

--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -124,7 +124,6 @@ on:
         default: "linux-gfx942-1gpu-core42-ossci-rocm"
 permissions:
   contents: read
-  packages: read
   id-token: write
 
 jobs:


### PR DESCRIPTION
## Summary

1) Remove unnecessary `packages: read` permissions from the JAX multi-arch release workflow chain and 
2) Fix repository checkout in `generate_target_to_run`.

## Changes

### Permission cleanup

Removed `packages: read` from:

* `.github/workflows/multi_arch_release_linux_jax_wheels.yml`
* `.github/workflows/multi_arch_build_linux_jax_wheels.yml`
* `.github/workflows/test_linux_jax_wheels_partial.yml`

The JAX build and test workflows do not publish GitHub packages and the GHCR container image used by the test workflow is public, so package read permissions are not required.

### Checkout fix

The error happened at rockrel side. Updated the `generate_target_to_run` job in:

* `.github/workflows/multi_arch_build_linux_jax_wheels.yml`

to explicitly checkout the requested repository and ref:

```yaml
with:
  repository: ${{ inputs.repository || github.repository }}
  ref: ${{ inputs.ref || github.ref_name }}
```

This fixes execution when the workflow is invoked from external repositories such as RockRel.

## Test:

https://github.com/ROCm/rockrel/actions/runs/27837042307/job/82425429242
https://github.com/ROCm/rockrel/actions/runs/27849442639