### PR TITLE
Fix kpack libraries pure package name

### DIFF
--- a/build_tools/packaging/python/templates/rocm-sdk-libraries/setup.py
+++ b/build_tools/packaging/python/templates/rocm-sdk-libraries/setup.py
@@ -31,7 +31,12 @@ def import_dist_info():
 dist_info = import_dist_info()
 my_package = dist_info.ALL_PACKAGES["libraries"]
 print(f"Loaded dist_info package: {my_package}")
-pure_py_package = f"rocm_sdk_libraries_{dist_info.THIS_TARGET_FAMILY}"
+if dist_info.THIS_TARGET_FAMILY is None:
+    pure_py_package = my_package.pure_py_package_name
+else:
+    pure_py_package = (
+        f"{my_package.pure_py_package_name}_{dist_info.THIS_TARGET_FAMILY}"
+    )
 packages = [pure_py_package]
 platform_py_package = my_package.get_py_package_name(
     target_family=dist_info.THIS_TARGET_FAMILY

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -11,6 +11,7 @@ These tests cover:
 
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -442,12 +443,17 @@ class DevicePackagingTest(TmpDirTestCase):
             f.write_text(content)
         (subdir / "artifact_manifest.txt").write_text("stage\n")
 
-    def _make_params(self, artifact_dir: Path, kpack_split: bool = False) -> Parameters:
+    def _make_params(
+        self,
+        artifact_dir: Path,
+        kpack_split: bool = False,
+        version: str = "0.0.1.test",
+    ) -> Parameters:
         dest_dir = self.temp_dir / "packages"
         dest_dir.mkdir(parents=True, exist_ok=True)
         return Parameters(
             dest_dir=dest_dir,
-            version="0.0.1.test",
+            version=version,
             version_suffix="",
             artifacts=ArtifactCatalog(artifact_dir),
             kpack_split=kpack_split,
@@ -498,6 +504,31 @@ class DevicePackagingTest(TmpDirTestCase):
         # Should not raise.
         lib = PopulatedDistPackage(params, logical_name="libraries", target_family=None)
         self.assertIsNotNone(lib.path)
+
+    def test_kpack_split_libraries_setup_uses_unsuffixed_pure_package(self):
+        """setup.py must not turn target_family=None into a package name suffix."""
+        artifact_dir = self._setup_kpack_split_artifacts()
+        params = self._make_params(
+            artifact_dir,
+            kpack_split=True,
+            version="0.0.1.dev0",
+        )
+
+        lib = PopulatedDistPackage(params, logical_name="libraries", target_family=None)
+        result = subprocess.run(
+            [sys.executable, "setup.py", "--name"],
+            cwd=lib.path,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        self.assertIn(
+            "Found packages: ['rocm_sdk_libraries', '_rocm_sdk_libraries']",
+            result.stdout,
+        )
+        self.assertNotIn("rocm_sdk_libraries_None", result.stdout)
 
     def test_populate_device_files_copies_all_files(self):
         """populate_device_files() should copy .kpack and kernel DB files."""

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,6 +10,7 @@ prettytable==3.12.0
 requests==2.33.0
 jsonschema==4.23.0
 packaging==25.0
+setuptools>=80.9.0,<82.0.0
 python-magic==0.4.27; sys_platform != "win32"
 
 # tensilelite/rocisa test requirements


### PR DESCRIPTION
The kpack-split libraries package has `THIS_TARGET_FAMILY` set to `None`. The setup script was interpolating that value into the pure Python package name, emitting `rocm_sdk_libraries_None` in wheels and installs instead of `rocm_sdk_libraries`.

With this patch, the base pure Python package name is used for target-neutral libraries while keeping target-specific names for legacy (rocm-sdk-libraries-gfx*) wheels.

Fixes #5048.

Assisted-by: Codex <codex@openai.com>