### PR TITLE
Enable hotswap in theRock using THEROCK_BUILD_COMGR_HOTSWAP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ option(THEROCK_COMPOSABLE_KERNEL_FOR_MIOPEN_ONLY
 
 option(THEROCK_BUILD_LLVM_TOOLS "Enables building all LLVM tools (not just minimum required)" OFF)
 option(THEROCK_BUILD_LLVM_TESTS "Enables building LLVM LIT tests" OFF)
+option(THEROCK_BUILD_COMGR_HOTSWAP "Enables building the comgr hotswap transpiler and tool" ON)
 
 set(THEROCK_SANITIZER "" CACHE STRING "Enable project wide sanitizer build ('ASAN' for host+device, 'HOST_ASAN' for host-only)")
 

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -159,6 +159,16 @@ if(THEROCK_ENABLE_COMPILER)
   # version script, avoiding symbol interposition issues.
   ##############################################################################
 
+  set(_comgr_hotswap_cmake_args)
+  if(THEROCK_BUILD_COMGR_HOTSWAP)
+    list(APPEND _comgr_hotswap_cmake_args -DCOMGR_ENABLE_HOTSWAP_TRANSPILE=ON)
+    if(NOT WIN32)
+      list(APPEND _comgr_hotswap_cmake_args
+        -DHOTSWAP_BUILD_TOOL=ON
+        "-DHOTSWAP_TOOL_HSA_INCLUDE_ROOT=${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime/runtime/hsa-runtime")
+    endif()
+  endif()
+
   therock_cmake_subproject_declare(amd-comgr
     USE_DIST_AMDGPU_TARGETS
     NO_INSTALL_RPATH  # See manual handling in the pre_hook.
@@ -174,6 +184,7 @@ if(THEROCK_ENABLE_COMPILER)
       -DTHEROCK_BUILD_COMGR_TESTS=${THEROCK_BUILD_COMGR_TESTS}
       "-DLLVM_VERSION_SUFFIX=-rocm${ROCM_MAJOR_VERSION}"
       -DLLVM_ENABLE_SYMBOL_VERSIONING=ON
+      ${_comgr_hotswap_cmake_args}
     BUILD_DEPS
       rocm-cmake
     RUNTIME_DEPS


### PR DESCRIPTION
## Motivation

HotSwap is an AMDGPU binary-translation system in COMGR (Code Object Manager) that rewrites GPU kernel code objects at load time. Its B0→A0 patcher rewrites gfx1250 B0-stepping binaries to run on A0 hardware via in-place patches, trampolines, and VGPR/SGPR scratch allocation.

With the supporting pieces already landing in the build's submodules — the LLVM cherry-picks that add the COMGR transpiler scaffolding and runtime tool (PR #5989), and the rocm-systems bump that adds CLR hotswap routing (PR #5971) — TheRock still has no way to actually compile any of it. The hotswap transpiler entry point and the HSA_TOOLS_LIB tool are gated behind COMGR cmake options that TheRock never sets, so they are silently omitted from every build.

This PR is the final piece of that three-PR sequence. It adds a TheRock-level build option that turns hotswap on, so that:
- `libamd_comgr.so` is built with the hotswap transpiler entry point (`amd_comgr_hotswap_rewrite`), and
- `libamd_comgr_hotswap_tool.so` is produced as a new artifact (the HSA_TOOLS_LIB runtime tool, Linux only).

The patcher is inert on non-gfx1250 targets, so enabling it should be safe for existing gfx94X (MI300X) builds and does not change their runtime behavior — the goal is to ship hotswap with zero regressions on the existing CI matrix.

## Technical Details

This PR adds a single TheRock-level option, `THEROCK_BUILD_COMGR_HOTSWAP` (ON by default), and wires it into the `amd-comgr` subproject build. Two files change:

**`CMakeLists.txt`** — declare the new option alongside the other LLVM/COMGR build toggles:

```cmake
option(THEROCK_BUILD_COMGR_HOTSWAP "Enables building the comgr hotswap transpiler and tool" ON)
```

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
