### PR TITLE
fix flaky DVC fetch on Windows workflows

### DIFF
--- a/build_tools/fetch_dvc_artifacts.py
+++ b/build_tools/fetch_dvc_artifacts.py
@@ -259,7 +259,16 @@ def _store_in_cache(src: Path, cache_file: Path) -> None:
             os.link(src, tmp)
         except OSError:
             shutil.copy2(src, tmp)
-        os.replace(tmp, cache_file)
+        try:
+            os.replace(tmp, cache_file)
+        except PermissionError:
+            # Windows raises PermissionError when two workers race to os.replace
+            # the same cache_file simultaneously (POSIX permits this silently).
+            # If the winner already wrote the correct content, treat as success.
+            if cache_file.exists() and src.stat().st_size == cache_file.stat().st_size:
+                if _md5_of(src) == _md5_of(cache_file):
+                    return
+            raise
     finally:
         if tmp.exists():
             try:

--- a/build_tools/tests/fetch_dvc_artifacts_test.py
+++ b/build_tools/tests/fetch_dvc_artifacts_test.py
@@ -15,6 +15,7 @@ import io
 import os
 import sys
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -401,6 +402,81 @@ class TestDownloadBlob(unittest.TestCase):
             with self.assertRaisesRegex(fda.FetchError, "size mismatch"):
                 fda._download_blob(s3, remote, md5, dest, expected_size=len(data) + 100)
             self.assertFalse(dest.exists())
+
+
+class TestStoreInCacheConcurrency(unittest.TestCase):
+    """Regression test for #5943.
+
+    Multiple .dvc pointer files can reference files with the same content hash
+    (e.g. identical small tensors in different subdirectories). When fetched
+    concurrently, all workers call _store_in_cache with the same cache_file
+    path. Each uses a unique temp name, but the final os.replace races on
+    Windows and raises PermissionError. The fix catches PermissionError and
+    verifies the winner wrote the correct content before treating it as success.
+    """
+
+    def test_concurrent_calls_with_same_cache_file_do_not_raise(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            data = b"shared content"
+            md5 = _md5_hex(data)
+            cache_file = fda._cache_path(tmp / "cache", md5)
+
+            # Simulate the Windows race: both workers arrive at os.replace
+            # concurrently. Caller 1 writes cache_file; caller 2 then gets
+            # PermissionError because Windows won't replace a file another
+            # handle still has open. We model this with a two-phase barrier:
+            # both workers reach the gate, then caller 1 does the real replace
+            # and only after that does caller 2 raise PermissionError, so
+            # cache_file already exists when the exception handler checks it.
+            original_replace = os.replace
+            call_count = [0]
+            lock = threading.Lock()
+            gate = threading.Barrier(2)
+            done = threading.Event()
+
+            def patched_replace(src, dst):
+                with lock:
+                    call_count[0] += 1
+                    n = call_count[0]
+                gate.wait(timeout=5)
+                if n == 1:
+                    original_replace(src, dst)
+                    done.set()
+                else:
+                    done.wait(timeout=5)
+                    raise PermissionError("[WinError 5] Access is denied")
+
+            src1 = tmp / "src1.bin"
+            src2 = tmp / "src2.bin"
+            src1.write_bytes(data)
+            src2.write_bytes(data)
+
+            errors = []
+
+            def worker(src):
+                try:
+                    fda._store_in_cache(src, cache_file)
+                except Exception as e:
+                    errors.append(e)
+
+            # Patch fda's reference to os.replace (not the os module itself)
+            # so both threads see the same controlled replacement.
+            with mock.patch.object(fda.os, "replace", side_effect=patched_replace):
+                threads = [
+                    threading.Thread(target=worker, args=(src1,)),
+                    threading.Thread(target=worker, args=(src2,)),
+                ]
+                for th in threads:
+                    th.start()
+                for th in threads:
+                    th.join()
+
+            self.assertEqual(errors, [], f"unexpected errors: {errors}")
+            self.assertTrue(cache_file.exists())
+            self.assertEqual(cache_file.read_bytes(), data)
+            leftover = list(cache_file.parent.glob("*.tmp"))
+            self.assertEqual(leftover, [], f"leftover temp files: {leftover}")
 
 
 class TestMaterializeFile(unittest.TestCase):


### PR DESCRIPTION

## Motivation

Fixes #5943. CI on Windows Azure runners intermittently fails with [WinError 5] Access is denied during
  fetch_sources.py DVC pulls.

## Technical Details


  When pull() processes multiple .dvc pointer files concurrently, each worker calls _materialize_file, which downloads
  the blob and then stores it in the local cache via _store_in_cache(dest, _cache_path(cache_dir, md5)).

  The cache path is derived solely from the file's md5 hash. If two .dvc pointer files reference files with identical
  content — as is common with small repeated tensors like fp16/Small/Small.tensor1.bin and fp32/Small/Small.tensor1.bin,
  both with the same md5 — both workers will call _store_in_cache with the same cache_file destination.

  _store_in_cache uses a uuid4()-suffixed temp file per worker, so the downloads land in separate paths without
  collision. However, both workers then call os.replace(tmp, cache_file) concurrently. On Windows, os.replace raises
  PermissionError if the target is held open by another handle — so whichever worker calls it second will fail. On POSIX
  this is a silent atomic swap, which is why the error is Windows-only.

  The fix wraps os.replace in a try/except PermissionError. On failure, it checks whether cache_file already exists with
  the correct size and md5. If it does, the losing worker returns silently — the file is already correctly written by
  the winner. If the content does not match, the error is re-raised to surface genuine corruption.

Note: #5948 identified a similar-sounding race in _download_blob, but as @ScottTodd confirmed in his review, the
  failures traced to _store_in_cache. This PR implements the fix @ScottTodd recommended in that review ("approach 1").
  The _download_blob change from #5948 is not needed and is not included here.

## Test Plan

Added TestStoreInCacheConcurrency in build_tools/tests/fetch_dvc_artifacts_test.py: two threads call _store_in_cache
  with the same cache_file. A barrier synchronizes both threads to arrive at os.replace simultaneously; a patched
  os.replace lets caller 1 write the file first and raises PermissionError for caller 2. This deterministically
  reproduces the race without requiring real S3 access.

## Test Result

 All 40 tests pass locally on Windows (Python 3.13). The new test fails without the fix and passes with it.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
