### PR TITLE
[do not merge] Testing miopen provider build with new bundle changes in rocm-libraries

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_miopenprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_miopenprovider.py
@@ -35,6 +35,7 @@ cmd = [
     "--test-dir",
     f"{THEROCK_BIN_DIR}/miopen_plugin",
     "--output-on-failure",
+    "--verbose",
     "--parallel",
     "8",
 ]


### PR DESCRIPTION
Bump rocm-libraries submodule to 25332099a818ba5266745fb202a1399303c3d482. Add --verbose to the miopenprovider ctest command so test output is always logged, not only on failure.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
