### PR TITLE
fix(matrix): remove gfx125x exclusion from release/2.11

### DIFF
--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -40,9 +40,8 @@ PYTORCH_REFS_LINUX: list[dict] = [
     },
     {
         "pytorch_git_ref": "release/2.11",
-        # gfx125x not yet upstreamed to pytorch/pytorch.
+        # No exclusion — gfx1250 supported via release/2.11_gfx1250 branch.
         # See https://github.com/ROCm/TheRock/issues/5833.
-        "exclude_amdgpu_families": {"gfx125x"},
     },
     {
         "pytorch_git_ref": "release/2.12",


### PR DESCRIPTION
## Summary

Removes the `exclude_amdgpu_families: gfx125x` from the `release/2.11` matrix entry, mirroring what was done for `release/2.12` in #5889.

`ROCm/pytorch:release/2.11_gfx1250` exists with gfx1250 support. Removing the exclusion allows builds to target gfx1250 when dispatched with `pytorch_git_ref=release/2.11_gfx1250`.

## Change

```python
# Before
{
    "pytorch_git_ref": "release/2.11",
    # gfx125x not yet upstreamed to pytorch/pytorch.
    # See https://github.com/ROCm/TheRock/issues/5833.
    "exclude_amdgpu_families": {"gfx125x"},
},

# After
{
    "pytorch_git_ref": "release/2.11",
    # No exclusion — gfx1250 supported via release/2.11_gfx1250 branch.
    # See https://github.com/ROCm/TheRock/issues/5833.
},
```

## Related
- #5889 — same change for release/2.12
- Issue #5833 — gfx1250 upstreaming tracking