### PR TITLE
[Testing Only] Enable comgr hotswap in TheRock (with amd-llvm link-order fix)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ option(THEROCK_COMPOSABLE_KERNEL_FOR_MIOPEN_ONLY
 
 option(THEROCK_BUILD_LLVM_TOOLS "Enables building all LLVM tools (not just minimum required)" OFF)
 option(THEROCK_BUILD_LLVM_TESTS "Enables building LLVM LIT tests" OFF)
+option(THEROCK_BUILD_COMGR_HOTSWAP "Enables building the comgr hotswap transpiler and tool" ON)
 
 set(THEROCK_SANITIZER "" CACHE STRING "Enable project wide sanitizer build ('ASAN' for host+device, 'HOST_ASAN' for host-only)")
 

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -159,6 +159,16 @@ if(THEROCK_ENABLE_COMPILER)
   # version script, avoiding symbol interposition issues.
   ##############################################################################
 
+  set(_comgr_hotswap_cmake_args)
+  if(THEROCK_BUILD_COMGR_HOTSWAP)
+    list(APPEND _comgr_hotswap_cmake_args -DCOMGR_ENABLE_HOTSWAP_TRANSPILE=ON)
+    if(NOT WIN32)
+      list(APPEND _comgr_hotswap_cmake_args
+        -DHOTSWAP_BUILD_TOOL=ON
+        "-DHOTSWAP_TOOL_HSA_INCLUDE_ROOT=${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime/runtime/hsa-runtime")
+    endif()
+  endif()
+
   therock_cmake_subproject_declare(amd-comgr
     USE_DIST_AMDGPU_TARGETS
     NO_INSTALL_RPATH  # See manual handling in the pre_hook.
@@ -174,6 +184,7 @@ if(THEROCK_ENABLE_COMPILER)
       -DTHEROCK_BUILD_COMGR_TESTS=${THEROCK_BUILD_COMGR_TESTS}
       "-DLLVM_VERSION_SUFFIX=-rocm${ROCM_MAJOR_VERSION}"
       -DLLVM_ENABLE_SYMBOL_VERSIONING=ON
+      ${_comgr_hotswap_cmake_args}
     BUILD_DEPS
       rocm-cmake
     RUNTIME_DEPS


### PR DESCRIPTION
## Motivation

Self-contained variant of #5988 that turns on the comgr hotswap transpiler and tool in TheRock, **and** bumps `compiler/amd-llvm` to a commit that includes the link-order fix so enabling hotswap does not break the build.

Enabling `COMGR_ENABLE_HOTSWAP_TRANSPILE=ON` alone (as #5988 does on the prior amd-llvm pin) regresses build-time AOT compilation: comgr's in-process LLD rejects the forwarded `-plugin-opt=mcpu=<gpu>` with `Unknown command line argument '-mcpu='`, breaking e.g. rocFFT's `rocfft_aot_helper` on gfx1250. Root cause and fix are in ROCm/llvm-project#2987.

## What this PR does

- **`compiler/amd-llvm`**: bump to `46fcb339` (tip of `users/lambj/therock-hotswap-cherrypick-v3`), which adds the hotswap transpiler link edge **after** the curated LLVM/LLD link block so `LLVMCodeGen`'s `-mcpu` `cl::opt` registration is pulled in. This is the prior bump (`8887092`, #5989) plus the link-order fix.
- **`CMakeLists.txt`**: add `THEROCK_BUILD_COMGR_HOTSWAP` option (ON by default).
- **`compiler/CMakeLists.txt`**: wire the option into the `amd-comgr` subproject — passing `-DCOMGR_ENABLE_HOTSWAP_TRANSPILE=ON` and, on Linux, `-DHOTSWAP_BUILD_TOOL=ON` plus the HSA include root.

This produces `libamd_comgr.so` with the `amd_comgr_hotswap_rewrite` entry point and (Linux) the `libamd_comgr_hotswap_tool.so` HSA_TOOLS_LIB artifact.

## Relationship to existing PRs

- Supersedes the #5988 + #5989 stack by combining the option change and the amd-llvm bump into one PR off `main`, with the bump pointing at the fixed comgr.
- #5988 / #5989 are left untouched.
