### PR TITLE
Enable comgr hotswap via THEROCK_ENABLE_HOTSWAP

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -154,23 +154,6 @@ jobs:
           echo "HSA_XNACK=1" >> $GITHUB_ENV
           echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
 
-      # Hotswap smoke test: hotswap is built by default (THEROCK_ENABLE_HOTSWAP=ON), so the
-      # tool must be present in the artifacts. Load it via HSA_TOOLS_LIB so ROCr/CLR exercise
-      # the tool-load path during hip-tests (which load code objects on the GPU). The tool is
-      # inert on non-gfx1250 targets, so this is a regression guard that enabling it does not
-      # perturb existing results. A missing tool means a broken/misconfigured build, so fail
-      # loudly rather than silently skipping.
-      - name: Enable hotswap tool loading
-        if: ${{ runner.os == 'Linux' && fromJSON(inputs.component).job_name == 'hip-tests' }}
-        run: |
-          hotswap_tool="${{ env.OUTPUT_ARTIFACTS_DIR }}/lib/libamd_comgr_hotswap_tool.so"
-          if [ ! -f "$hotswap_tool" ]; then
-            echo "::error::Hotswap tool not found at $hotswap_tool. THEROCK_ENABLE_HOTSWAP is on by default, so it should be present in the artifacts."
-            exit 1
-          fi
-          echo "Loading hotswap tool via HSA_TOOLS_LIB: $hotswap_tool"
-          echo "HSA_TOOLS_LIB=$hotswap_tool" >> $GITHUB_ENV
-
       - name: Test
         id: test
         timeout-minutes: ${{ fromJSON(inputs.component).timeout_minutes }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -154,6 +154,23 @@ jobs:
           echo "HSA_XNACK=1" >> $GITHUB_ENV
           echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
 
+      # Hotswap smoke test: hotswap is built by default (THEROCK_ENABLE_HOTSWAP=ON), so the
+      # tool must be present in the artifacts. Load it via HSA_TOOLS_LIB so ROCr/CLR exercise
+      # the tool-load path during hip-tests (which load code objects on the GPU). The tool is
+      # inert on non-gfx1250 targets, so this is a regression guard that enabling it does not
+      # perturb existing results. A missing tool means a broken/misconfigured build, so fail
+      # loudly rather than silently skipping.
+      - name: Enable hotswap tool loading
+        if: ${{ runner.os == 'Linux' && fromJSON(inputs.component).job_name == 'hip-tests' }}
+        run: |
+          hotswap_tool="${{ env.OUTPUT_ARTIFACTS_DIR }}/lib/libamd_comgr_hotswap_tool.so"
+          if [ ! -f "$hotswap_tool" ]; then
+            echo "::error::Hotswap tool not found at $hotswap_tool. THEROCK_ENABLE_HOTSWAP is on by default, so it should be present in the artifacts."
+            exit 1
+          fi
+          echo "Loading hotswap tool via HSA_TOOLS_LIB: $hotswap_tool"
+          echo "HSA_TOOLS_LIB=$hotswap_tool" >> $GITHUB_ENV
+
       - name: Test
         id: test
         timeout-minutes: ${{ fromJSON(inputs.component).timeout_minutes }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ option(THEROCK_COMPOSABLE_KERNEL_FOR_MIOPEN_ONLY
 
 option(THEROCK_BUILD_LLVM_TOOLS "Enables building all LLVM tools (not just minimum required)" OFF)
 option(THEROCK_BUILD_LLVM_TESTS "Enables building LLVM LIT tests" OFF)
+option(THEROCK_ENABLE_HOTSWAP "Enables the comgr hotswap transpiler/tool and loads it in the runtime via HSA_TOOLS_LIB" ON)
 
 set(THEROCK_SANITIZER "" CACHE STRING "Enable project wide sanitizer build ('ASAN' for host+device, 'HOST_ASAN' for host-only)")
 

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -159,6 +159,16 @@ if(THEROCK_ENABLE_COMPILER)
   # version script, avoiding symbol interposition issues.
   ##############################################################################
 
+  set(_comgr_hotswap_cmake_args)
+  if(THEROCK_ENABLE_HOTSWAP)
+    list(APPEND _comgr_hotswap_cmake_args -DCOMGR_ENABLE_HOTSWAP_TRANSPILE=ON)
+    if(NOT WIN32)
+      list(APPEND _comgr_hotswap_cmake_args
+        -DHOTSWAP_BUILD_TOOL=ON
+        "-DHOTSWAP_TOOL_HSA_INCLUDE_ROOT=${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime/runtime/hsa-runtime")
+    endif()
+  endif()
+
   therock_cmake_subproject_declare(amd-comgr
     USE_DIST_AMDGPU_TARGETS
     NO_INSTALL_RPATH  # See manual handling in the pre_hook.
@@ -174,6 +184,7 @@ if(THEROCK_ENABLE_COMPILER)
       -DTHEROCK_BUILD_COMGR_TESTS=${THEROCK_BUILD_COMGR_TESTS}
       "-DLLVM_VERSION_SUFFIX=-rocm${ROCM_MAJOR_VERSION}"
       -DLLVM_ENABLE_SYMBOL_VERSIONING=ON
+      ${_comgr_hotswap_cmake_args}
     BUILD_DEPS
       rocm-cmake
     RUNTIME_DEPS


### PR DESCRIPTION
## Summary

Adds a single `THEROCK_ENABLE_HOTSWAP` option (ON) that enables the comgr hotswap transpiler and runtime tool, and bumps `compiler/amd-llvm` to a commit that includes the LLD link-order fix so enabling hotswap does not break the build.

Also bump amd-llvm to contain the needed HOTSWAP changes

## What it does

- **`CMakeLists.txt`**: add `THEROCK_ENABLE_HOTSWAP` option (ON by default).
- **`compiler/CMakeLists.txt`**: wire it into the `amd-comgr` subproject — passing `-DCOMGR_ENABLE_HOTSWAP_TRANSPILE=ON` and, on Linux, `-DHOTSWAP_BUILD_TOOL=ON` plus the HSA include root. This builds `libamd_comgr.so` with the `amd_comgr_hotswap_rewrite` entry point and produces `libamd_comgr_hotswap_tool.so`.
- **`compiler/amd-llvm`**: bump to `46fcb339` (tip of `users/lambj/therock-hotswap-cherrypick-v3`), which includes the link-order fix (ROCm/llvm-project#2987).


## Runtime loading (HSA_TOOLS_LIB) — not in this PR

A build option cannot by itself make the runtime load the tool: ROCr reads `HSA_TOOLS_LIB` only from the process environment (no config-file fallback). Making the runtime actually load `libamd_comgr_hotswap_tool.so` requires setting `HSA_TOOLS_LIB` in the runtime/test environment.

An initial attempt to wire this into the Linux hip-tests stage (set `HSA_TOOLS_LIB=<artifacts>/lib/libamd_comgr_hotswap_tool.so`) was **reverted**: ROCr reported `Tool lib "..." failed to load` and ~450/1048 hip-tests failed (vs all-green without it). The tool is not as harmless-when-failed as assumed — a failed `dlopen` (likely the relative artifact path not resolving from the test CWD, and/or `libamd_comgr.so` not on the loader path) cascaded into widespread test failures. To be investigated separately, ideally once the CLR/ROCr gating changes (rocm-systems #7234) are in the build.

**No gfx1250 runtime coverage either:** there is no gfx1250 test runner in CI yet (`run_tests: False` for gfx125X), so the tool's actual B0→A0 transpile cannot be exercised in CI regardless.

## Test plan

- [ ] CI `compiler-runtime` stage builds successfully
- [ ] gfx125X-dcgpu math-libs (rocFFT) builds successfully (the regression the fix targets)
- [ ] gfx94X-dcgpu hip-tests pass with no regressions
- [ ] Windows build not broken (hotswap tool is Linux-only; only the transpile entry point is compiled in)


