### PR TITLE
build: Add `run` to hipFile toml

### DIFF
--- a/storage-libs/CMakeLists.txt
+++ b/storage-libs/CMakeLists.txt
@@ -47,6 +47,7 @@ if(THEROCK_ENABLE_HIPFILE)
       dev
       doc
       lib
+      run
       test
     SUBPROJECT_DEPS
       ${_hipfile_subproject_names}

--- a/storage-libs/artifact-hipfile.toml
+++ b/storage-libs/artifact-hipfile.toml
@@ -3,6 +3,10 @@
 include = [
   "share/hipfile/**",
 ]
+[components.run."storage-libs/hipfile/stage"]
+include = [
+  "bin/**",
+]
 [components.dbg."storage-libs/hipfile/stage"]
 [components.dev."storage-libs/hipfile/stage"]
 [components.doc."storage-libs/hipfile/stage"]


### PR DESCRIPTION
## Motivation

hipFile needs to build and deploy ais-stats and ais-check (the latter is a Python program). They both deploy to the `bin` directory.

JIRA ID: ROCM-1261
JIRA ID: AIHIPFILE-27

## Technical Details

Adds `run` to the toml

## Test Plan

Verify ais-stats and ais-check are built and installed

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
