### PR TITLE
[multi-arch ci] Fix case-insensitive external repo name lookup in detect_external_repo_config.py

### DIFF
--- a/build_tools/github_actions/detect_external_repo_config.py
+++ b/build_tools/github_actions/detect_external_repo_config.py
@@ -377,11 +377,12 @@ def main(argv=None):
             external_repo = json.loads(args.external_repo_json)
             source_repository = external_repo.get("repository", "")
             source_ref = external_repo.get("ref", "")
-            # Extract repo name from full name (e.g., "rocm-libraries" from "ROCm/rocm-libraries")
+            # Extract repo name from full name (e.g., "rocm-libraries" from "ROCm/rocm-libraries").
+            # Lowercase so REPO_CONFIGS lookup is case-insensitive (e.g. "ROCgdb" -> "rocgdb").
             if "/" in source_repository:
-                repo_name = source_repository.split("/")[-1]
+                repo_name = source_repository.split("/")[-1].lower()
             else:
-                repo_name = source_repository
+                repo_name = source_repository.lower()
             args.repository = repo_name
             print(
                 f"Parsed external_repo: repository={source_repository}, ref={source_ref}",

--- a/build_tools/github_actions/tests/detect_external_repo_config_test.py
+++ b/build_tools/github_actions/tests/detect_external_repo_config_test.py
@@ -26,6 +26,49 @@ from detect_external_repo_config import (
 )
 
 
+class TestExternalRepoJsonCasing(unittest.TestCase):
+    """Tests that repo name extraction from external_repo JSON is case-insensitive."""
+
+    def setUp(self):
+        with tempfile.NamedTemporaryFile(mode="w+", delete=False) as f:
+            self.temp_file = f.name
+        os.environ["GITHUB_OUTPUT"] = self.temp_file
+
+    def tearDown(self):
+        if "GITHUB_OUTPUT" in os.environ:
+            del os.environ["GITHUB_OUTPUT"]
+        if hasattr(self, "temp_file") and os.path.exists(self.temp_file):
+            os.unlink(self.temp_file)
+
+    def _run_with_json(self, repository: str) -> int:
+        return detect_external_repo_config_main(
+            [
+                "--external-repo-json",
+                f'{{"repository": "{repository}", "ref": "abc123"}}',
+            ]
+        )
+
+    def test_mixed_case_repo_name(self):
+        """ROCm/Rocm-Libraries (mixed case) should resolve to rocm-libraries config."""
+        rc = self._run_with_json("ROCm/Rocm-Libraries")
+        self.assertEqual(rc, 0)
+
+    def test_uppercase_repo_name(self):
+        """ROCm/ROCM-LIBRARIES (all caps) should still resolve to rocm-libraries config."""
+        rc = self._run_with_json("ROCm/ROCM-LIBRARIES")
+        self.assertEqual(rc, 0)
+
+    def test_lowercase_repo_name(self):
+        """ROCm/rocm-libraries (already lowercase) should resolve to rocm-libraries config."""
+        rc = self._run_with_json("ROCm/rocm-libraries")
+        self.assertEqual(rc, 0)
+
+    def test_unknown_repo_returns_nonzero(self):
+        """An unregistered repo should return a non-zero exit code."""
+        rc = self._run_with_json("ROCm/SomeUnknownRepo")
+        self.assertNotEqual(rc, 0)
+
+
 class TestGetRepoConfig(unittest.TestCase):
     """Tests for get_repo_config function"""
 


### PR DESCRIPTION
## Motivation

When an external repository is passed via the `external_repo` JSON input (e.g. `{"repository": "ROCm/ROCgdb", "ref": "..."}`), the repo name is extracted by splitting on `/` and looking up the result in `REPO_CONFIGS`. That dictionary uses lowercase keys (`rocm-libraries`, `rocm-systems`, `rocgdb`), but the extracted name preserves the original casing (`ROCgdb`), causing lookup failures for any repo whose name uses mixed or upper case.

## Technical Details

- `detect_external_repo_config.py`: lowercase the extracted repo name before the `REPO_CONFIGS` lookup so the comparison is case-insensitive.
- `detect_external_repo_config_test.py`: add `TestExternalRepoJsonCasing` with four cases — mixed case, all-caps, already-lowercase, and unknown repo — to confirm the fix holds for any casing variant.

## Test Plan

Run the updated unit tests:
```
python -m pytest build_tools/github_actions/tests/detect_external_repo_config_test.py -v
```

## Test Result

All 23 tests pass, including the 4 new casing cases.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.