### PR TITLE
ci: map rocgdb subproject to rocgdb-cpu/rocgdb-gpu test jobs

### DIFF
--- a/debug-tools/CMakeLists.txt
+++ b/debug-tools/CMakeLists.txt
@@ -90,7 +90,8 @@ if(THEROCK_ENABLE_AMD_DBGAPI)
     INTERFACE_PKG_CONFIG_DIRS
       "share/pkgconfig"
     TEST_SUBPROJECTS
-      rocgdb
+      rocgdb-cpu
+      rocgdb-gpu
       rocr-debug-agent-tests
   )
 
@@ -302,6 +303,8 @@ if(THEROCK_ENABLE_ROCGDB)
     INTERFACE_LINK_DIRS
       "lib"
     TEST_SUBPROJECTS
+      rocgdb-cpu
+      rocgdb-gpu
   )
 
   # We may want to adjust this to optimize rebuilds.


### PR DESCRIPTION
Maps the rocgdb subproject in `debug-tools/CMakeLists.txt` to the `rocgdb-cpu` and `rocgdb-gpu` test job keys, enabling the CI pipeline to correctly identify and trigger the appropriate test jobs for rocgdb changes.

ISSUE ID: N/A

## Motivation

The rocgdb subproject was listed as a single `rocgdb` test subproject, but the CI pipeline splits rocgdb testing into two separate job keys: `rocgdb-cpu` and `rocgdb-gpu`. This mismatch caused the pipeline to not trigger the correct test jobs when rocgdb-related changes were detected.

## Technical Details

- In `THEROCK_ENABLE_AMD_DBGAPI` block: replace `rocgdb` with `rocgdb-cpu` and `rocgdb-gpu`
- In `THEROCK_ENABLE_ROCGDB` block: add `rocgdb-cpu` and `rocgdb-gpu`

## Test Plan

CI pipeline correctly maps rocgdb changes to the `rocgdb-cpu` and `rocgdb-gpu` test jobs.

## Test Result

Verified via ROCgdb multi-arch CI runs.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.