### PR TITLE
ci: update default Linux build runner from Azure to AWS

### DIFF
--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -99,7 +99,7 @@ jobs:
   build_rocm_wheels:
     name: Build Python | ${{ inputs.artifact_group }}
     # Note: GitHub-hosted runners run out of disk space for some gpu families
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
     container:

--- a/.github/workflows/manifest-diff.yml
+++ b/.github/workflows/manifest-diff.yml
@@ -77,7 +77,7 @@ permissions:
 jobs:
   generate-report:
     name: Generate Manifest Diff Report
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
     # Non-blocking under CI; strict on manual dispatch so regressions surface red.
     continue-on-error: ${{ github.event_name != 'workflow_dispatch' }}
     permissions:

--- a/.github/workflows/multi_arch_build_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels.yml
@@ -113,7 +113,7 @@ permissions:
 jobs:
   build_jax_wheels:
     name: Build | py ${{ inputs.python_version }} | jax ${{ inputs.jax_ref }}
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
     outputs:
       package_index_url: ${{ steps.publish_jax_wheels.outputs.package_index_url }}
       jax_version: ${{ steps.write_jax_versions.outputs.jax_version }}

--- a/.github/workflows/multi_arch_build_native_linux_packages.yml
+++ b/.github/workflows/multi_arch_build_native_linux_packages.yml
@@ -52,7 +52,7 @@ run-name: Build ${{ inputs.native_package_type }} packages (${{ inputs.rocm_vers
 jobs:
   build_native_packages:
     name: Build ${{ inputs.native_package_type }} packages
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
     container:
       image: ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
       options: -v /runner/config:/home/awsconfig/

--- a/.github/workflows/multi_arch_build_portable_linux.yml
+++ b/.github/workflows/multi_arch_build_portable_linux.yml
@@ -42,7 +42,7 @@ on:
         description: "Comma-separated build stages to skip (artifacts already copied by the orchestrator)"
       build_runs_on:
         type: string
-        default: "azure-linux-scale-rocm"
+        default: "aws-linux-scale-rocm-prod"
         description: "Build runner label (selected by configure script with weighted distribution)"
       release_type:
         description: 'Release type: "ci", "dev", "nightly", or "prerelease"'

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -56,7 +56,7 @@ on:
       build_runs_on:
         description: "Build runner label (selected by configure script with weighted distribution)"
         type: string
-        default: "azure-linux-scale-rocm"
+        default: "aws-linux-scale-rocm-prod"
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -145,7 +145,7 @@ permissions:
 jobs:
   build_pytorch_wheels:
     name: Build | py ${{ inputs.python_version }} | torch ${{ inputs.pytorch_git_ref }}
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
@@ -99,7 +99,7 @@ run-name: Build portable Linux PyTorch Wheels CI (${{ inputs.artifact_group }}, 
 jobs:
   build_pytorch_wheels:
     name: Build PyTorch | ${{ inputs.artifact_group }} | torch ${{ inputs.pytorch_git_ref }} | py${{ inputs.python_version }}
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/multi_arch_build_tarballs.yml
+++ b/.github/workflows/multi_arch_build_tarballs.yml
@@ -75,7 +75,7 @@ run-name: Build Multi-Arch Tarballs (${{ inputs.dist_amdgpu_families }}, ${{ inp
 jobs:
   build_tarballs:
     name: Build Tarballs
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
     outputs:

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -55,7 +55,7 @@ jobs:
   copy_prebuilt_stages:
     name: Copy Prebuilt Stages
     if: ${{ fromJSON(inputs.build_config).prebuilt_stages != '' && fromJSON(inputs.build_config).baseline_run_id != '' }}
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-prod
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/test_artifacts_structure.yml
+++ b/.github/workflows/test_artifacts_structure.yml
@@ -68,7 +68,7 @@ permissions:
 jobs:
   test_artifact_structure:
     name: "Validate artifact structure"
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
     env:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
       PLATFORM: ${{ inputs.platform }}


### PR DESCRIPTION
## Summary

Migrates all Linux workflow jobs from \`azure-linux-scale-rocm\` to \`aws-linux-scale-rocm-prod\`, following the [amdgpu_family_matrix.py](https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/amdgpu_family_matrix.py) update that routes 100% of regular Linux builds to AWS.

### Changes

**Input defaults** (stale fallbacks that would route ad-hoc dispatches to the wrong pool):
- \`.github/workflows/multi_arch_build_portable_linux.yml\` — \`build_runs_on\` default
- \`.github/workflows/multi_arch_build_portable_linux_artifacts.yml\` — \`build_runs_on\` default

**Hardcoded / conditional \`runs-on\` fields:**
- \`multi_arch_ci_linux.yml\` — \`copy_prebuilt_stages\` job (was hardcoded)
- \`multi_arch_build_native_linux_packages.yml\`
- \`multi_arch_build_tarballs.yml\`
- \`manifest-diff.yml\`
- \`build_portable_linux_python_packages.yml\`
- \`multi_arch_build_portable_linux_pytorch_wheels.yml\`
- \`multi_arch_build_portable_linux_pytorch_wheels_ci.yml\`
- \`test_artifacts_structure.yml\`
- \`multi_arch_build_linux_jax_wheels.yml\`

### Not changed

- \`azure-linux-scale-rocm-heavy-ramdisk\` — still used for sanitizer (asan/tsan) builds; no AWS ramdisk equivalent yet
- \`azure-windows-scale-rocm\` — Windows builds remain on Azure

## Test plan

- [ ] Verify standard release pipeline is unaffected (configure script already selects \`aws-linux-scale-rocm-prod\` at runtime)
- [ ] Verify direct \`workflow_dispatch\` on \`multi_arch_build_portable_linux.yml\` without \`build_runs_on\` now routes to \`aws-linux-scale-rocm-prod\`
- [ ] Verify \`copy_prebuilt_stages\` job in \`multi_arch_ci_linux.yml\` routes to AWS

🤖 Generated with [Claude Code](https://claude.com/claude-code)