### PR TITLE
fix(ci): Fix fetch_artifacts to match xnack-suffixed artifact variants

### DIFF
--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -59,6 +59,31 @@ def log(*args, **kwargs):
     sys.stdout.flush()
 
 
+def _get_base_arch(target: str) -> str:
+    """Strip xnack/other suffixes: 'gfx942:xnack+' -> 'gfx942'."""
+    return target.split(":")[0]
+
+
+def _matches_target(artifact_target: str, requested_targets: set[str]) -> bool:
+    """Check if artifact target matches requested targets (base arch matches variants)."""
+    # Direct match
+    if artifact_target in requested_targets:
+        return True
+
+    # Check if the artifact's base arch matches any requested target
+    artifact_base = _get_base_arch(artifact_target)
+    if artifact_base in requested_targets:
+        return True
+
+    # Check if any requested target's base arch matches the artifact's base arch
+    # (handles case where user requests "gfx942:xnack+" explicitly)
+    for requested in requested_targets:
+        if _get_base_arch(requested) == artifact_base:
+            return True
+
+    return False
+
+
 def list_artifacts_for_group(
     backend: ArtifactBackend,
     artifact_group: str | None,
@@ -69,6 +94,9 @@ def list_artifacts_for_group(
     Inclusive matching: accepts both family-named archives (mono-arch pipeline)
     and individual-target archives (split/kpack pipeline). Whichever naming
     convention is present in the bucket will be matched.
+
+    Base architecture matching: requesting a base arch (e.g., "gfx942") will
+    also match variants with suffixes (e.g., "gfx942:xnack+", "gfx942:xnack-").
 
     Args:
         backend: ArtifactBackend instance configured for the target run
@@ -103,7 +131,7 @@ def list_artifacts_for_group(
     data = set()
     for filename in all_artifacts:
         an = ArtifactName.from_filename(filename)
-        if an and an.target_family in targets_to_match:
+        if an and _matches_target(an.target_family, targets_to_match):
             data.add(filename)
 
     if not data:

--- a/build_tools/fetch_artifacts.py
+++ b/build_tools/fetch_artifacts.py
@@ -61,27 +61,18 @@ def log(*args, **kwargs):
 
 def _get_base_arch(target: str) -> str:
     """Strip xnack/other suffixes: 'gfx942:xnack+' -> 'gfx942'."""
-    return target.split(":")[0]
+    if not target:
+        return ""
+    base = target.split(":")[0]
+    return base if base else target
 
 
 def _matches_target(artifact_target: str, requested_targets: set[str]) -> bool:
-    """Check if artifact target matches requested targets (base arch matches variants)."""
-    # Direct match
-    if artifact_target in requested_targets:
-        return True
-
-    # Check if the artifact's base arch matches any requested target
-    artifact_base = _get_base_arch(artifact_target)
-    if artifact_base in requested_targets:
-        return True
-
-    # Check if any requested target's base arch matches the artifact's base arch
-    # (handles case where user requests "gfx942:xnack+" explicitly)
-    for requested in requested_targets:
-        if _get_base_arch(requested) == artifact_base:
-            return True
-
-    return False
+    """Match if the artifact's base arch equals any requested target's base arch."""
+    if not artifact_target:
+        return False
+    requested_bases = {_get_base_arch(t) for t in requested_targets}
+    return _get_base_arch(artifact_target) in requested_bases
 
 
 def list_artifacts_for_group(

--- a/build_tools/tests/fetch_artifacts_test.py
+++ b/build_tools/tests/fetch_artifacts_test.py
@@ -13,6 +13,8 @@ from _therock_utils.artifact_backend import ArtifactBackend
 from fetch_artifacts import (
     list_artifacts_for_group,
     filter_artifacts,
+    _get_base_arch,
+    _matches_target,
 )
 
 THIS_DIR = Path(__file__).resolve().parent
@@ -182,6 +184,22 @@ class ArtifactsIndexPageTest(unittest.TestCase):
         self.assertIn("blas_lib_generic.tar.zst", result)
         self.assertIn("blas_lib_gfx942.tar.zst", result)
         self.assertIn("rccl_test_gfx942:xnack+.tar.zst", result)
+
+    def testGetBaseArch_HandlesEdgeCases(self):
+        """Test _get_base_arch with empty and garbage inputs."""
+        self.assertEqual(_get_base_arch(""), "")
+        self.assertEqual(_get_base_arch(":xnack+"), ":xnack+")
+        self.assertEqual(_get_base_arch("gfx942"), "gfx942")
+        self.assertEqual(_get_base_arch("gfx942:xnack+"), "gfx942")
+        self.assertEqual(_get_base_arch("garbage-*&%^$"), "garbage-*&%^$")
+
+    def testMatchesTarget_HandlesEdgeCases(self):
+        """Test _matches_target with empty and garbage inputs."""
+        requested = {"generic", "gfx942"}
+        self.assertFalse(_matches_target("", requested))
+        self.assertFalse(_matches_target("garbage-*&%^$", requested))
+        self.assertTrue(_matches_target("gfx942", requested))
+        self.assertTrue(_matches_target("gfx942:xnack+", requested))
 
     def testFilterArtifacts_NoIncludesOrExcludes(self):
         artifacts = {"foo_test", "foo_run", "bar_test", "bar_run"}

--- a/build_tools/tests/fetch_artifacts_test.py
+++ b/build_tools/tests/fetch_artifacts_test.py
@@ -139,6 +139,50 @@ class ArtifactsIndexPageTest(unittest.TestCase):
         self.assertIn("blas_lib_generic.tar.zst", result)
         self.assertIn("blas_lib_gfx942.tar.zst", result)
 
+    def testListArtifactsForGroup_MatchesXnackVariants(self):
+        """Test that requesting base arch also matches xnack-suffixed variants."""
+        backend = MagicMock(spec=ArtifactBackend)
+        backend.base_uri = "s3://therock-ci-artifacts/123-linux"
+        backend.list_artifacts.return_value = [
+            "blas_lib_generic.tar.zst",
+            "blas_lib_gfx942.tar.zst",
+            "blas_test_gfx942.tar.zst",
+            "rccl_test_gfx942:xnack+.tar.zst",  # xnack+ variant
+            "rccl_lib_gfx942:xnack-.tar.zst",  # xnack- variant
+            "blas_lib_gfx1100.tar.zst",  # different arch, should not match
+        ]
+
+        # Request base arch gfx942 - should also pull xnack variants
+        result = list_artifacts_for_group(
+            backend, artifact_group=None, amdgpu_targets=["gfx942"]
+        )
+
+        self.assertIn("blas_lib_generic.tar.zst", result)
+        self.assertIn("blas_lib_gfx942.tar.zst", result)
+        self.assertIn("blas_test_gfx942.tar.zst", result)
+        self.assertIn("rccl_test_gfx942:xnack+.tar.zst", result)
+        self.assertIn("rccl_lib_gfx942:xnack-.tar.zst", result)
+        self.assertNotIn("blas_lib_gfx1100.tar.zst", result)
+
+    def testListArtifactsForGroup_ExplicitXnackTargetMatchesBase(self):
+        """Test that requesting xnack variant explicitly also matches base arch."""
+        backend = MagicMock(spec=ArtifactBackend)
+        backend.base_uri = "s3://therock-ci-artifacts/123-linux"
+        backend.list_artifacts.return_value = [
+            "blas_lib_generic.tar.zst",
+            "blas_lib_gfx942.tar.zst",
+            "rccl_test_gfx942:xnack+.tar.zst",
+        ]
+
+        # Request xnack+ variant explicitly - should also pull base arch
+        result = list_artifacts_for_group(
+            backend, artifact_group=None, amdgpu_targets=["gfx942:xnack+"]
+        )
+
+        self.assertIn("blas_lib_generic.tar.zst", result)
+        self.assertIn("blas_lib_gfx942.tar.zst", result)
+        self.assertIn("rccl_test_gfx942:xnack+.tar.zst", result)
+
     def testFilterArtifacts_NoIncludesOrExcludes(self):
         artifacts = {"foo_test", "foo_run", "bar_test", "bar_run"}
 


### PR DESCRIPTION
When requesting a base arch (e.g., gfx942), also match variants with xnack suffixes (e.g., gfx942:xnack+, gfx942:xnack-). This fixes ASAN test runs which emit artifacts with :xnack+ suffixes that were being silently dropped.

Fixes #6038
ISSUE ID https://github.com/ROCm/TheRock/issues/6038

test logs locally:
```
$ python3 build_tools/fetch_artifacts.py --run-id 27891627402 --amdgpu-targets gfx942  --dry-run
Retrieving bucket info for workflow run...
  github_repository: ROCm/TheRock
  release_type: ci
  workflow_run_id: 27891627402
  head_github_repository: ROCm/TheRock
  is_pr_from_fork: False
  bucket: therock-ci-artifacts
Retrieving artifacts from 's3://therock-ci-artifacts/27891627402-linux'
Matching artifact target families: ['generic', 'gfx942']

Filtered artifacts to download:
  s3://therock-ci-artifacts/27891627402-linux/amd-dbgapi_dbg_generic.tar.zst
  s3://therock-ci-artifacts/27891627402-linux/amd-dbgapi_dev_generic.tar.zst
...
  s3://therock-ci-artifacts/27891627402-linux/rccl_doc_generic.tar.zst
  s3://therock-ci-artifacts/27891627402-linux/rccl_lib_generic.tar.zst
  s3://therock-ci-artifacts/27891627402-linux/rccl_lib_gfx942.tar.zst
  s3://therock-ci-artifacts/27891627402-linux/rccl_run_generic.tar.zst
  s3://therock-ci-artifacts/27891627402-linux/rccl_test_generic.tar.zst
  s3://therock-ci-artifacts/27891627402-linux/rccl_test_gfx942:xnack+.tar.zst <----- this one is here now!!
  s3://therock-ci-artifacts/27891627402-linux/rdc_dbg_generic.tar.zst
  s3://therock-ci-artifacts/27891627402-linux/rdc_dev_generic.tar.zst
  s3://therock-ci-artifacts/27891627402-linux/rdc_doc_generic.tar.zst
  s3://therock-ci-artifacts/27891627402-linux/rdc_lib_generic.tar.zst
...
  s3://therock-ci-artifacts/27891627402-linux/wsl-rocdxg_lib_generic.tar.zst

Skipping downloads since --dry-run was set
```