### PR TITLE
ci(torch): Skip Windows device side assert tests that hang CI

### DIFF
--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -235,6 +235,21 @@ skip_tests = {
             "test_idiv_and_ifloordiv_vs_python_cuda",
         ],
         "cuda": [
+            # Device-side assert() does not propagate to the host on Windows ROCm:
+            # the KMD has no trap handler, so the faulted queue never reports an
+            # error and torch.cuda.synchronize() hangs until the CI job timeout.
+            # These tests deliberately trigger a device-side assert and await it
+            # with no subprocess timeout, so they hang rather than fail.
+            # Re-enable once the Windows ROCm driver propagates device-side
+            # faults to the runtime.
+            "test_fixed_cuda_assert_async",
+            "test_index_out_of_bounds_exception_cuda",
+            # Same device-side-assert-propagation issue as the two tests above:
+            # spawns a subprocess that feeds invalid probabilities (negative,
+            # inf, nan) to torch.multinomial, calls torch.cuda.synchronize(), and
+            # asserts the device-side assert surfaces in stderr. On Windows ROCm
+            # the fault never propagates, so it hangs/fails instead.
+            "test_multinomial_invalid_probs_cuda",
             # RuntimeError: miopenStatusUnknownError
             "test_autocast_rnn",
             # On some test runners

--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -235,21 +235,6 @@ skip_tests = {
             "test_idiv_and_ifloordiv_vs_python_cuda",
         ],
         "cuda": [
-            # Device-side assert() does not propagate to the host on Windows ROCm:
-            # the KMD has no trap handler, so the faulted queue never reports an
-            # error and torch.cuda.synchronize() hangs until the CI job timeout.
-            # These tests deliberately trigger a device-side assert and await it
-            # with no subprocess timeout, so they hang rather than fail.
-            # Re-enable once the Windows ROCm driver propagates device-side
-            # faults to the runtime.
-            "test_fixed_cuda_assert_async",
-            "test_index_out_of_bounds_exception_cuda",
-            # Same device-side-assert-propagation issue as the two tests above:
-            # spawns a subprocess that feeds invalid probabilities (negative,
-            # inf, nan) to torch.multinomial, calls torch.cuda.synchronize(), and
-            # asserts the device-side assert surfaces in stderr. On Windows ROCm
-            # the fault never propagates, so it hangs/fails instead.
-            "test_multinomial_invalid_probs_cuda",
             # RuntimeError: miopenStatusUnknownError
             "test_autocast_rnn",
             # On some test runners
@@ -270,6 +255,23 @@ skip_tests = {
             #   AssertionError: Scalars are not equal!
             #   Expected 0 but got 2173342911312.
             "test_streams",
+            # Device-side assert() does not propagate to the host on Windows ROCm:
+            # the KMD has no trap handler, so the faulted queue never reports an
+            # error and torch.cuda.synchronize() hangs until the CI job timeout.
+            # These tests deliberately trigger a device-side assert and await it
+            # with no subprocess timeout, so they hang rather than fail.
+            # Re-enable once the Windows ROCm driver propagates device-side
+            # faults to the runtime.
+            # See https://github.com/ROCm/TheRock/issues/5565
+            "test_fixed_cuda_assert_async",
+            "test_index_out_of_bounds_exception_cuda",
+            # Same device-side-assert-propagation issue as the two tests above:
+            # spawns a subprocess that feeds invalid probabilities (negative,
+            # inf, nan) to torch.multinomial, calls torch.cuda.synchronize(), and
+            # asserts the device-side assert surfaces in stderr. On Windows ROCm
+            # the fault never propagates, so it hangs/fails instead.
+            # See https://github.com/ROCm/TheRock/issues/5565
+            "test_multinomial_invalid_probs_cuda",
         ],
         "nn": [
             # Hangs on some Windows ROCm runners until the job hits the 6h limit.


### PR DESCRIPTION
## Motivation

ISSUE ID: https://github.com/ROCm/TheRock/issues/5565

Several PyTorch unit tests deliberately trigger a device-side assert and then wait for it to surface back on the host. On Windows ROCm the KMD has no trap-handler support, so the device fault is never reported to the runtime and the host blocks on `torch.cuda.synchronize()` indefinitely until the CI job hits its timeout.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Adds three tests to the `windows.cuda` skip section in `external-builds/pytorch/skip_tests/generic.py`:

- `test_fixed_cuda_assert_async` - `torch._assert_async(torch.tensor(0, device='cuda'))` then `synchronize()`
- `test_index_out_of_bounds_exception_cuda` - out-of-bounds index read on device then device to host copy
- `test_multinomial_invalid_probs_cuda` - invalid (negative/inf/nan) probabilities then `synchronize()`

On Linux the fault surfaces as `hipErrorLaunchFailure`/`HSA_STATUS_ERROR_EXCEPTION`, so this is a Windows-ROCm-specific skip.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Ran locally and made sure that the tests were skipped, will monitor latest Windows torch runs to make sure we unblock the test hangs.

## Test Result

<!-- Briefly summarize test outcomes. -->

Locally tests are skipped, will monitor CI runs in the future.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.