### PR TITLE
fix(rocwmma): disable tests when targets are excluded

### DIFF
--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -375,13 +375,32 @@ if(THEROCK_ENABLE_BLAS)
 endif()
 
 if(THEROCK_ENABLE_ROCWMMA)
+  set(_rocwmma_build_samples ON)
+  set(_rocwmma_build_tests ${THEROCK_BUILD_TESTING})
+  set(_rocwmma_enable_benchmarks ${THEROCK_ROCWMMA_ENABLE_BENCHMARKS})
+  set(_rocwmma_artifact_components dbg dev lib test)
+  if(THEROCK_AMDGPU_TARGETS AND NOT "${THEROCK_AMDGPU_TARGETS}" MATCHES "-NOTFOUND$")
+    therock_filter_amdgpu_targets(
+      _rocwmma_gpu_targets rocWMMA ${THEROCK_AMDGPU_TARGETS})
+    if(NOT _rocwmma_gpu_targets)
+      string(JOIN " " _rocwmma_requested_targets ${THEROCK_AMDGPU_TARGETS})
+      message(STATUS
+        "rocWMMA: no supported GPU targets remain after filtering "
+        "(${_rocwmma_requested_targets}); disabling samples and tests.")
+      set(_rocwmma_build_samples OFF)
+      set(_rocwmma_build_tests OFF)
+      set(_rocwmma_enable_benchmarks OFF)
+      list(REMOVE_ITEM _rocwmma_artifact_components test)
+    endif()
+  endif()
+
   ##############################################################################
   # rocWMMA
   ##############################################################################
 
   # Configure optional dependencies
   set(_rocwmma_optional_deps)
-  if(THEROCK_ROCWMMA_ENABLE_BENCHMARKS)
+  if(_rocwmma_enable_benchmarks)
     list(APPEND _rocwmma_optional_deps rocm_smi_lib)
   endif()
 
@@ -393,10 +412,11 @@ if(THEROCK_ENABLE_ROCWMMA)
       -DHIP_PLATFORM=amd
       -DROCM_PATH=
       -DROCM_DIR=
-      "-DROCWMMA_BUILD_TESTS=$<BOOL:${THEROCK_BUILD_TESTING}>"
+      "-DROCWMMA_BUILD_SAMPLES=$<BOOL:${_rocwmma_build_samples}>"
+      "-DROCWMMA_BUILD_TESTS=$<BOOL:${_rocwmma_build_tests}>"
       "-DROCWMMA_VALIDATE_WITH_ROCBLAS=ON"
-      "-DROCWMMA_BENCHMARK_WITH_ROCBLAS=$<BOOL:${THEROCK_ROCWMMA_ENABLE_BENCHMARKS}>"
-      "-DROCWMMA_BUILD_BENCHMARK_TESTS=$<BOOL:${THEROCK_ROCWMMA_ENABLE_BENCHMARKS}>"
+      "-DROCWMMA_BENCHMARK_WITH_ROCBLAS=$<BOOL:${_rocwmma_enable_benchmarks}>"
+      "-DROCWMMA_BUILD_BENCHMARK_TESTS=$<BOOL:${_rocwmma_enable_benchmarks}>"
       -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON # Needed for Ninja build
       -DROCWMMA_USE_SYSTEM_GOOGLETEST=ON # Use therock-googletest
     CMAKE_INCLUDES
@@ -422,10 +442,7 @@ if(THEROCK_ENABLE_ROCWMMA)
   therock_provide_artifact(rocwmma
     DESCRIPTOR artifact-rocwmma.toml
     COMPONENTS
-      dbg
-      dev
-      lib
-      test
+      ${_rocwmma_artifact_components}
     SUBPROJECT_DEPS
       rocWMMA
   )

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -379,6 +379,12 @@ if(THEROCK_ENABLE_ROCWMMA)
   set(_rocwmma_build_tests ${THEROCK_BUILD_TESTING})
   set(_rocwmma_enable_benchmarks ${THEROCK_ROCWMMA_ENABLE_BENCHMARKS})
   set(_rocwmma_artifact_components dbg dev lib test)
+
+  # rocWMMA intentionally supports only targets with MFMA/WMMA instructions.
+  # Use the same target filtering metadata as CK to recognize all-filtered
+  # shards, but keep the host/API subproject declared for downstream users.
+  # For those shards, omit only target-dependent samples/tests/benchmarks so
+  # they do not publish an untransformed rocwmma_test_generic artifact.
   if(THEROCK_AMDGPU_TARGETS AND NOT "${THEROCK_AMDGPU_TARGETS}" MATCHES "-NOTFOUND$")
     therock_filter_amdgpu_targets(
       _rocwmma_gpu_targets rocWMMA ${THEROCK_AMDGPU_TARGETS})
@@ -386,7 +392,8 @@ if(THEROCK_ENABLE_ROCWMMA)
       string(JOIN " " _rocwmma_requested_targets ${THEROCK_AMDGPU_TARGETS})
       message(STATUS
         "rocWMMA: no supported GPU targets remain after filtering "
-        "(${_rocwmma_requested_targets}); disabling samples and tests.")
+        "(${_rocwmma_requested_targets}); disabling samples, tests, "
+        "and benchmarks.")
       set(_rocwmma_build_samples OFF)
       set(_rocwmma_build_tests OFF)
       set(_rocwmma_enable_benchmarks OFF)


### PR DESCRIPTION
## Summary
- keep rocWMMA declared in the build graph even when all selected per-arch targets are filtered out
- use the same AMDGPU target filtering metadata as CK to detect all-filtered rocWMMA shards
- when no rocWMMA-supported targets remain, disable rocWMMA samples, tests, and benchmarks, and omit only the rocwmma test artifact component
- avoids unsupported target-family jobs producing and uploading raw rocwmma_test_generic artifacts while preserving the rocWMMA host API for downstream dependencies
- supported rocWMMA target shards still build samples/tests and include the rocwmma test artifact

## Dependency
None. This PR no longer changes the rocm-systems submodule after ROCm/rocm-systems#7633 was reverted.

## Validation
- `git diff --check origin/main...HEAD`
- Rebased on current `origin/main`; final diff is only `math-libs/CMakeLists.txt`
- Configure-only math-libs stage checks using a temporary uv-provided cmake/ninja/lit tool environment:
  - `gfx101X-dgpu`: configure completed; emitted the all-filtered rocWMMA message; generated `ROCWMMA_BUILD_SAMPLES=0`, `ROCWMMA_BUILD_TESTS=0`, `ROCWMMA_BENCHMARK_WITH_ROCBLAS=0`, `ROCWMMA_BUILD_BENCHMARK_TESTS=0`; no `rocwmma_test` artifact rule
  - `gfx103X-all`: same disabled rocWMMA samples/tests/benchmarks result; no `rocwmma_test` artifact rule
  - `gfx900`: same disabled rocWMMA samples/tests/benchmarks result; no `rocwmma_test` artifact rule
  - `gfx906`: same disabled rocWMMA samples/tests/benchmarks result; no `rocwmma_test` artifact rule
  - `gfx94X-dcgpu`: configure completed without the all-filtered message; generated `ROCWMMA_BUILD_SAMPLES=1` and `ROCWMMA_BUILD_TESTS=1`; `rocwmma_test` artifact rule remains present

ISSUE ID: https://github.com/ROCm/rocm-libraries/issues/8660
