### PR TITLE
build: Add hipfile and util-linux artifacts to rocm-sdk-core wheel.

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -378,6 +378,7 @@ def core_artifact_filter(an: ArtifactName) -> bool:
         "core-ocl",
         "core-hipinfo",
         "core-runtime",
+        "hipfile",
         "hipify",
         "host-blas",
         "host-suite-sparse",
@@ -392,6 +393,7 @@ def core_artifact_filter(an: ArtifactName) -> bool:
         "sysdeps-gmp",
         "sysdeps-mpfr",
         "sysdeps-ncurses",
+        "sysdeps-util-linux",
         "wsl-rocdxg",
     ] and an.component in [
         "lib",

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -240,6 +240,7 @@ PackageEntry(
 LibraryEntry("amdhip64", "core", "libamdhip64.so*", "amdhip64*.dll")
 # The DLL glob here uses '0' from the version to avoid matching 'hiprtc-builtins'.
 # If DLLs with no version suffix are later added we will need a different pattern.
+LibraryEntry("hipfile", "core", "libhipfile.so*", "")
 LibraryEntry("hiprtc", "core", "libhiprtc.so*", "hiprtc0*.dll")
 LibraryEntry("roctx64", "core", "libroctx64.so*", "")
 LibraryEntry("rocprofiler-sdk", "core", "librocprofiler-sdk.so*", "")


### PR DESCRIPTION
## Motivation

Enable packaging hipfile in the Python rocm-sdk-core wheel.

JIRA ID: AIHIPFILE-27
JIRA ID: AIHIPFILE-170

## Technical Details

Adds hipfile and the util-linux sysdep to core_artifact_filter.

## Test Plan

Verify libhipfile and librocm_sysdeps_mount are packaged in wheel.

## Test Result

Downloaded the rocm-sdk-core wheel from CI and verified that libhipfile and librocm_sysdeps_mount are in the archive.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
