### PR TITLE
ISSUE ID #5833 - ci(torch): exclude gfx125x from release/2.12 pytorch nightly matrix

### DIFF
--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -46,8 +46,10 @@ PYTORCH_REFS_LINUX: list[dict] = [
     },
     {
         "pytorch_git_ref": "release/2.12",
-        # No exclusion — trigger manually with release/2.12_gfx1250 branch
-        # to include gfx1250 until upstreamed. See issue #5833.
+        # gfx125x not yet upstreamed to pytorch/pytorch. Upstream expected
+        # 2026-06-26, but the ROCm 7.14 release is cut before that date.
+        # See https://github.com/ROCm/TheRock/issues/5833.
+        "exclude_amdgpu_families": {"gfx125x"},
     },
     {
         "pytorch_git_ref": "nightly",


### PR DESCRIPTION
## Summary

gfx125x upstream support in pytorch/pytorch is expected 2026-06-26, but the ROCm 7.14 release will be cut before that date. Without this exclusion the multi-arch nightly PyTorch builds for other GPU families fail when gfx125x is included in the matrix for release/2.12.

Add `exclude_amdgpu_families: {gfx125x}` to the release/2.12 entry in `PYTORCH_REFS_LINUX`, consistent with how release/2.9, 2.10, 2.11, and nightly already handle the missing upstream support.

See https://github.com/ROCm/TheRock/issues/5833.

## Motivation

  gfx125x upstream support in `pytorch/pytorch` is expected on 2026-06-26, but
  the ROCm 7.14 release will be cut before that date. Without this exclusion,
  multi-arch nightly PyTorch builds for other GPU families fail when `gfx125x`
  is included in the `release/2.12` matrix entry. This PR adds
  `exclude_amdgpu_families: {gfx125x}` to `release/2.12` in `PYTORCH_REFS_LINUX`,
  consistent with how `release/2.9`, `2.10`, `2.11`, and `nightly` already
  handle the missing upstream support.

  ## Risk Assessment

  Risk level **2** — narrow, low blast-radius change confined to the CI matrix
  configuration script. No build logic is altered; only a filter set is
  populated for one additional ref entry. Incorrect filtering would cause
  `gfx125x` jobs to be skipped (intended), not broken, for other families.

  ## Related

  - Work tracking: https://github.com/ROCm/TheRock/issues/5833
  - Related PRs: see prior exclusions for release/2.9, 2.10, 2.11 in same file

  ## Device / Architecture Coverage

  `build/ci` change only. This removes `gfx125x` from the `release/2.12`
  nightly matrix so that other GPU families (e.g. `gfx90a`, `gfx942`,
  `gfx110x`) can build successfully. No device-level testing is required;
  passing PR CI on the unaffected families is sufficient.

  ## Testing Summary

  - Matrix generation logic is exercised by existing unit tests for
    `configure_pytorch_release_matrix.py`.
  - The `_filter_families` path for `exclude_amdgpu_families` is already
    covered by prior entries (2.9, 2.10, 2.11, nightly); this entry follows
    the identical pattern.

  ## Testing Checklist

  - [ ] PR CI - GitHub PR checks - Status: Pending

  ## Flags / Guardrails

  None. The exclusion will be lifted once gfx125x support lands upstream
  (expected 2026-06-26) by removing `exclude_amdgpu_families` from the
  `release/2.12` entry. Tracked in issue #5833.

  ## Adjacent Tests Considered

  `test_configure_pytorch_release_matrix.py` (if present) covers the filter
  logic; no new tests needed for a pattern-consistent config-only change.

  ## Risk Acceptance / Waivers

  `W-BUILD`: CI-config-only change with no product behavior change. The
  exclusion is intentional and time-bounded; the upstream arrival date and
  tracking issue are documented in both the code comment and this description.

  ## Technical Changes

  - `PYTORCH_REFS_LINUX[release/2.12]`: added `"exclude_amdgpu_families": {"gfx125x"}`.
    Matches the pattern already used by release/2.9, 2.10, 2.11, and nightly.
  - Updated inline comment to document the upstream ETA and the release cut
    timing that necessitates this exclusion.
