### PR TITLE
fix(ci): add container spec to AWS kube-mode runner jobs, revert JAX to Azure

### DIFF
--- a/.github/workflows/multi_arch_build_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels.yml
@@ -113,7 +113,7 @@ permissions:
 jobs:
   build_jax_wheels:
     name: Build | py ${{ inputs.python_version }} | jax ${{ inputs.jax_ref }}
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'azure-linux-scale-rocm' || 'ubuntu-24.04' }}
     outputs:
       package_index_url: ${{ steps.publish_jax_wheels.outputs.package_index_url }}
       jax_version: ${{ steps.write_jax_versions.outputs.jax_version }}

--- a/.github/workflows/multi_arch_build_tarballs.yml
+++ b/.github/workflows/multi_arch_build_tarballs.yml
@@ -76,6 +76,8 @@ jobs:
   build_tarballs:
     name: Build Tarballs
     runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    container:
+      image: python:3.12-slim
     permissions:
       id-token: write
     outputs:

--- a/.github/workflows/multi_arch_build_tarballs.yml
+++ b/.github/workflows/multi_arch_build_tarballs.yml
@@ -93,11 +93,6 @@ jobs:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref_name }}
 
-      - name: Setting up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-
       - name: Install Python requirements
         run: pip install -r requirements.txt
 

--- a/.github/workflows/test_artifacts_structure.yml
+++ b/.github/workflows/test_artifacts_structure.yml
@@ -83,11 +83,6 @@ jobs:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
 
-      - name: Setting up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-
       - name: Install test requirements
         run: |
           pip install -r requirements-test.txt

--- a/.github/workflows/test_artifacts_structure.yml
+++ b/.github/workflows/test_artifacts_structure.yml
@@ -69,6 +69,8 @@ jobs:
   test_artifact_structure:
     name: "Validate artifact structure"
     runs-on: ${{ github.repository_owner == 'ROCm' && 'aws-linux-scale-rocm-prod' || 'ubuntu-24.04' }}
+    container:
+      image: python:3.12-slim
     env:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}"
       PLATFORM: ${{ inputs.platform }}


### PR DESCRIPTION
## Summary

ISSUE ID https://github.com/ROCm/TheRock/issues/6061

Fixes a regression introduced by #6037 where jobs migrated to \`aws-linux-scale-rocm-prod\` failed because AWS runners operate in Kubernetes mode and enforce that every job has a \`container:\` block.

### Root cause

Azure self-hosted runners are VMs — jobs run directly on the host with a full shell and a GitHub tool cache available. AWS runners are Kubernetes-mode: each job runs inside an ephemeral pod and a \`container:\` image is required.

Two separate issues had to be fixed:

**1. Missing \`container:\` block**
Jobs without a container spec fail immediately with:
> \`Jobs without a job container are forbidden on this runner\`

Fixed by adding \`container: python:3.12-slim\` to the affected jobs.

**2. \`actions/setup-python\` incompatible inside a container**
After adding the container spec, \`actions/setup-python\` failed with:
> \`The version '3.12' with architecture 'x64' was not found for this operating system.\`

On Azure VM runners, \`actions/setup-python\` downloads Python into the host's tool cache (\`$RUNNER_TOOL_CACHE\`). Inside a kube-mode container, that tool cache is not mounted — so the action has nothing to work with. Since \`python:3.12-slim\` already ships Python 3.12, the \`actions/setup-python\` step is both redundant and broken inside the container. Removed it from both affected jobs.

**3. \`build_jax_wheels\` cannot run on kube-mode runners**
This job calls \`docker buildx build\` + \`docker run\` internally via \`ci_build dist_wheels\`. Kube-mode runners have no Docker daemon, so this cannot be fixed with a \`container:\` block. Reverted to \`azure-linux-scale-rocm\` until a Docker-in-Docker or native build solution is in place.

### Changes

- **\`test_artifacts_structure.yml\`** — add \`container: python:3.12-slim\`, remove \`actions/setup-python\`
- **\`multi_arch_build_tarballs.yml\`** — add \`container: python:3.12-slim\`, remove \`actions/setup-python\`
- **\`multi_arch_build_linux_jax_wheels.yml\`** — revert \`build_jax_wheels\` back to \`azure-linux-scale-rocm\`

## Test plan

- [ ] Verify \`test_artifact_structure\` (Linux + Windows) passes on AWS runner
- [ ] Verify \`build_tarballs\` passes on AWS runner
- [ ] Verify \`build_jax_wheels\` continues to pass on Azure runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)