### PR TITLE
[compiler] Use AMDGPU.cmake for amdgcn runtimes cache

### DIFF
--- a/compiler/pre_hook_amd-llvm.cmake
+++ b/compiler/pre_hook_amd-llvm.cmake
@@ -47,7 +47,7 @@ else()
       set(RUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES "compiler-rt;libc;libcxx;libcxxabi;flang-rt;openmp")
       set(RUNTIMES_amdgcn-amd-amdhsa_FLANG_RT_LIBC_PROVIDER "llvm")
       set(RUNTIMES_amdgcn-amd-amdhsa_FLANG_RT_LIBCXX_PROVIDER "llvm")
-      set(RUNTIMES_amdgcn-amd-amdhsa_CACHE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/../compiler-rt/cmake/caches/GPU.cmake;${CMAKE_CURRENT_SOURCE_DIR}/../libcxx/cmake/caches/AMDGPU.cmake")
+      set(RUNTIMES_amdgcn-amd-amdhsa_CACHE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/../compiler-rt/cmake/caches/AMDGPU.cmake;${CMAKE_CURRENT_SOURCE_DIR}/../libcxx/cmake/caches/AMDGPU.cmake")
       set(FLANG_RUNTIME_F128_MATH_LIB "libquadmath")
       set(LIBOMPTARGET_BUILD_DEVICE_FORTRT ON)
       #TODO: Enable when HWLOC dependency is figured out


### PR DESCRIPTION
## Summary
Point the `amdgcn-amd-amdhsa` runtimes cache in `compiler/pre_hook_amd-llvm.cmake`
at `compiler-rt/cmake/caches/AMDGPU.cmake` instead of the legacy `GPU.cmake`.
`GPU.cmake` leaves `COMPILER_RT_BUILD_PROFILE=OFF`, so the device profile runtime
(`libclang_rt.profile.a` for amdgcn) was never built, breaking HIP device PGO.
`AMDGPU.cmake` builds it and is the upstream-maintained cache file.

## Co-dependency
Pairs with ROCm/llvm-project#3027, which removes the now-unused `GPU.cmake`.
That PR is marked draft, to be revived when the scripts finally quit using `GPU.cmake`.

## Test plan
- [ ] TheRock amdgcn runtimes build produces `libclang_rt.profile.a`.
- [ ] No sanitizer / other device runtime regressions.

Made with [Cursor](https://cursor.com)