### PR TITLE
feat(CI): Add submodule selection option to manual `workflow_dispatch` trigger

### DIFF
--- a/.github/workflows/bump_submodules.yml
+++ b/.github/workflows/bump_submodules.yml
@@ -5,6 +5,16 @@ name: Bump Submodule automation
 
 on:
   workflow_dispatch:
+    inputs:
+      submodule:
+        description: 'Submodule to bump (default: all)'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - rocm-systems
+          - rocm-libraries
   schedule:
     - cron: "0 */12 * * *" # Runs every 12 hrs at 12AM and 12PM
   push:
@@ -55,6 +65,7 @@ jobs:
         run: |
           python3 build_tools/github_actions/bump_automation.py \
             --event_type "schedule" \
+            --submodule "${{ github.event.inputs.submodule || 'all' }}" \
             --systems_token "${{ steps.systems-token.outputs.token }}" \
             --libraries_token "${{ steps.librarian-token.outputs.token }}"
 

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -288,10 +288,12 @@ def create_therock_bump(submodule, token):
         os.chdir(original_cwd)
 
 
-def handle_schedule(systems_token, libraries_token):
-    """Create bump PRs for both submodules"""
-    create_therock_bump("rocm-systems", systems_token)
-    create_therock_bump("rocm-libraries", libraries_token)
+def handle_schedule(systems_token, libraries_token, submodule="all"):
+    """Create bump PRs for the specified submodule(s)"""
+    if submodule in ("all", "rocm-systems"):
+        create_therock_bump("rocm-systems", systems_token)
+    if submodule in ("all", "rocm-libraries"):
+        create_therock_bump("rocm-libraries", libraries_token)
 
 
 def handle_push(before, after, systems_token, libraries_token):
@@ -358,6 +360,7 @@ def handle_push(before, after, systems_token, libraries_token):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--event_type", required=True, choices=["schedule", "push"])
+    parser.add_argument("--submodule", default="all", choices=["all", "rocm-systems", "rocm-libraries"])
     parser.add_argument("--before")
     parser.add_argument("--after")
     parser.add_argument("--systems_token", required=True)
@@ -368,7 +371,7 @@ def main():
     run(["git", "config", "--global", "user.email", "therockbot@amd.com"])
 
     if args.event_type == "schedule":
-        handle_schedule(args.systems_token, args.libraries_token)
+        handle_schedule(args.systems_token, args.libraries_token, args.submodule)
     elif args.event_type == "push":
         handle_push(
             args.before,

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -360,7 +360,9 @@ def handle_push(before, after, systems_token, libraries_token):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--event_type", required=True, choices=["schedule", "push"])
-    parser.add_argument("--submodule", default="all", choices=["all", "rocm-systems", "rocm-libraries"])
+    parser.add_argument(
+        "--submodule", default="all", choices=["all", "rocm-systems", "rocm-libraries"]
+    )
     parser.add_argument("--before")
     parser.add_argument("--after")
     parser.add_argument("--systems_token", required=True)


### PR DESCRIPTION
## Motivation

  Currently, triggering `bump_submodules.yml` via `workflow_dispatch` always bumps both submodules (rocm-systems and rocm-libraries). This PR adds an optional input so a single submodule can be targeted when triggering manually — useful for debugging, retrying a failed bump, or bumping independently without touching the other.

- ISSUE ID : https://github.com/ROCm/TheRock/issues/6330

## Changes:
  - `.github/workflows/bump_submodules.yml`  - adds a submodule choice input (all / rocm-systems / rocm-libraries, default: all) to the `workflow_dispatch` trigger; passes it to the script via `--submodule`
  - `build_tools/github_actions/bump_automation.py` - adds `--submodule` CLI argument; `handle_schedule` conditionally bumps only the selected submodule(s)
  ---
##   Test Plan
  
  - [X] Trigger workflow_dispatch with submodule: all — verify PRs are created for both rocm-systems and rocm-libraries
  - [X] Trigger workflow_dispatch with submodule: rocm-systems — verify only a rocm-systems bump PR is created, no rocm-libraries 
   - [X] Trigger workflow_dispatch with submodule: rocm-libraries — verify only a rocm-libraries bump PR is created, no rocm-systems 
---
##  Test Results
- created r-s bump , not r-l bump, [Run](https://github.com/ROCm/TheRock/actions/runs/28038949699)  and bumpPR (https://github.com/ROCm/TheRock/pull/6064)
- created r-l bump, not r-s bump [Run](https://github.com/ROCm/TheRock/actions/runs/28640874345/job/84936566713)  and bump Pr https://github.com/ROCm/TheRock/pull/6328
- created both bumps with all option [Run](https://github.com/ROCm/TheRock/actions/runs/28501167345)  and bumps https://github.com/ROCm/TheRock/pull/6288 , https://github.com/ROCm/TheRock/pull/6289

---
- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
