### PR TITLE
test: Add test filter standardisation for hipdnn-integration-tests

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -516,7 +516,7 @@ test_matrix = {
         "job_name": "hipdnn-integration-tests",
         "fetch_artifact_args": "--hipdnn --hipdnn-integration-tests --tests",
         "timeout_minutes": 30,
-        "test_script": f"python {_get_script_path('test_hipdnn_integration_tests.py')}",
+        "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
             "linux": 1,

--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -72,6 +72,7 @@ COMPONENT_DIR_MAPPING = {
     "hipcub": "hipcub",
     "hipdnn": "hipdnn",
     "hipdnn-samples": "hipdnn_samples",
+    "hipdnn-integration-tests": "hipdnn_integration_tests_ctest",
     "miopen_plugin": "miopen_legacy_plugin",
     "miopenprovider": "miopen_plugin",
     "rocsparse": "rocsparse",


### PR DESCRIPTION
## Summary
Paired TheRock side of test-filter standardisation for the **hipdnn-integration-tests** component. Pairs with rocm-libraries branch `users/dravindr/tf_hipdnn_integration_tests`, which labels `bin/hipdnn_integration_tests_ctest/CTestTestfile.cmake` via `apply_ctest_category_labels()`.

- `fetch_test_configurations.py`: switch `hipdnn-integration-tests` `test_script` from `test_hipdnn_integration_tests.py` to the generic `test_runner.py`, so the runner drives `ctest -L {quick|standard|comprehensive|full}` from `THEROCK_BIN_DIR/hipdnn_integration_tests_ctest`.
- `test_runner.py`: map job name `hipdnn-integration-tests` → install dir `hipdnn_integration_tests_ctest` in `COMPONENT_DIR_MAPPING`.

`ml-libs/artifact-hipdnn-integration-tests.toml` already bundles `bin/hipdnn_integration_tests_ctest/CTestTestfile.cmake`, so no artifact change is required.

JIRA ID ROCM-20736

## Test plan
- [x] `build_tools/github_actions/tests/unit_test_runner.py` passes (22/22) after the `test_runner.py` edit.
- [x] CI: hipdnn-integration-tests test job runs `ctest -L quick` from the install tree and discovers labeled tests.

Paired PR: ROCm/rocm-libraries `users/dravindr/tf_hipdnn_integration_tests`.

Made with [Cursor](https://cursor.com)