### PR TITLE
test: Add test filter standardisation for hipdnn-samples

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -528,7 +528,7 @@ test_matrix = {
         "job_name": "hipdnn-samples",
         "fetch_artifact_args": "--blas --miopen --hipdnn --miopenprovider --hipdnn-samples --tests",
         "timeout_minutes": 30,
-        "test_script": f"python {_get_script_path('test_hipdnn_samples.py')}",
+        "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
             "linux": 1,


### PR DESCRIPTION
## Summary

Paired TheRock-side change for **hipdnn-samples** test-filter standardization. Switches the `hipdnn-samples` test job to the generic `test_runner.py` so it runs `ctest -L <tier>` from the installed `bin/hipdnn_samples/` tree instead of the legacy unfiltered `test_hipdnn_samples.py`.

### Changes
- `build_tools/github_actions/fetch_test_configurations.py` — `hipdnn-samples` `test_script`: `test_hipdnn_samples.py` → `test_runner.py`.

No other TheRock-side changes are needed:
- `COMPONENT_DIR_MAPPING` already maps `hipdnn-samples → hipdnn_samples` in `test_runner.py`.
- `ml-libs/artifact-hipdnn-samples.toml` already includes `bin/**` (and `bin/hipdnn_samples/CTestTestfile.cmake`), so the labeled install-tree `CTestTestfile.cmake` is bundled.

The legacy `test_hipdnn_samples.py` is intentionally retained for one release as a fallback.

JIRA ID ROCM-20736

### Verification
- `build_tools/github_actions/tests/unit_test_runner.py`: 22/22 pass.

## Paired PR
- rocm-libraries side (adds `test_categories.yaml` + CMake wiring): ROCm/rocm-libraries#8712

## Test plan
- [ ] hipdnn-samples test job green via `test_runner.py` once paired rocm-libraries PR is in the submodule pin