### PR TITLE
ci: use test_runner.py for rocsparse and hipsparse

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -328,29 +328,18 @@ test_matrix = {
         "job_name": "hipsparse",
         "fetch_artifact_args": "--blas --tests",
         "timeout_minutes": 30,
-        # Temporary mitigation for ROCm/rocm-libraries#8592: the gfx110X
-        # Windows V710 MxGPU partition OOMs on the pre_checkin sparse configs
-        # that the test_runner.py (standard) path runs, cascading into mass
-        # hipErrorOutOfMemory failures. Route sparse back to the pre-#4490
-        # legacy script (the last green basis, which already carries the
-        # gfx110X ignore list) until the underlying OOM is fixed. Restore
-        # test_runner.py afterwards.
-        "test_script": f"python {_get_script_path('test_hipsparse.py')}",
+        "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
-            "linux": 1,
-            "windows": 1,
+            "linux": 3,
+            "windows": 3,
         },
     },
     "rocsparse": {
         "job_name": "rocsparse",
         "fetch_artifact_args": "--blas --tests",
-        "timeout_minutes": 30,
-        # Temporary mitigation for ROCm/rocm-libraries#8592 (see hipsparse
-        # above): route sparse back to the pre-#4490 legacy script until the
-        # underlying gfx110X Windows OOM is fixed. Restore test_runner.py
-        # afterwards.
-        "test_script": f"python {_get_script_path('test_rocsparse.py')}",
+        "timeout_minutes": 180,
+        "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
             "linux": 1,

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -338,7 +338,11 @@ test_matrix = {
     "rocsparse": {
         "job_name": "rocsparse",
         "fetch_artifact_args": "--blas --tests",
-        "timeout_minutes": 180,
+        # rocsparse runs as a single shard for now, so the full suite executes in
+        # one process and needs a generous timeout. This will be reduced soon once
+        # rocsparse moves to multi-shard gtest sharding (pending the tolerance fix
+        # in ROCm/rocm-libraries#8713).
+        "timeout_minutes": 240,
         "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {

--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -98,6 +98,18 @@ TEST_COMPONENT = COMPONENT_DIR_MAPPING.get(
 SHARD_INDEX = os.getenv("SHARD_INDEX", 1)
 TOTAL_SHARDS = os.getenv("TOTAL_SHARDS", 1)
 
+# Components whose category label matches MULTIPLE ctest entries (e.g. rocsparse
+# registers both *_full_suite and *_ffm-full_suite under the same label). For
+# these we must NOT combine the ctest `--tests-information` stride with the
+# gtest GTEST_TOTAL_SHARDS sharding: the two axes compound and silently drop
+# ~(1 - 1/N) of the suite (only one (entry x gtest-sub-shard) pair runs per
+# shard). Instead, shard purely at the gtest case level -- every shard runs all
+# ctest entries and gtest splits the cases -- which yields complete, disjoint
+# coverage for any number of (gtest-binary) entries. Single-entry components are
+# unaffected either way, so this is safe to keep narrowly scoped.
+GTEST_ONLY_SHARDING_COMPONENTS = {"rocsparse", "hipsparse"}
+use_gtest_only_sharding = test_component_job_name in GTEST_ONLY_SHARDING_COMPONENTS
+
 # CTest runs serially by default; per-GPU overrides can be added below.
 # Example: if AMDGPU_FAMILIES and "gfx1153" in AMDGPU_FAMILIES: ctest_parallel_count = 4
 ctest_parallel_count = 1
@@ -445,10 +457,15 @@ def build_ctest_command(
             "--test-dir",
             TEST_DIR,
             "-V",
-            "--tests-information",
-            f"{SHARD_INDEX},,{TOTAL_SHARDS}",
         ]
     )
+
+    # Shard via the ctest entry stride only when we are NOT relying on gtest
+    # case-level sharding. Applying both compounds and drops tests on multi-entry
+    # suites (see GTEST_ONLY_SHARDING_COMPONENTS). For gtest-only sharding, ctest
+    # runs every entry and GTEST_TOTAL_SHARDS splits the cases within each.
+    if not use_gtest_only_sharding:
+        cmd.extend(["--tests-information", f"{SHARD_INDEX},,{TOTAL_SHARDS}"])
 
     # Constrain GPU tests to the available GPU slots when the component
     # provides a resource spec. Without this, RESOURCE_GROUPS properties are


### PR DESCRIPTION
## Summary

Switch the `rocsparse` and `hipsparse` CI jobs back to the standard `test_runner.py` path so both run their full test suites again, and fix a gtest/ctest sharding interaction that was silently dropping tests on multi-entry suites.

## Background

Following the investigations on [#5960](https://github.com/ROCm/TheRock/pull/5960), and now that `ctest -j 1` is the default, the original reason for routing sparse through the legacy per-component scripts no longer applies. Those scripts were a temporary mitigation for [ROCm/rocm-libraries#8592](https://github.com/ROCm/rocm-libraries/issues/8592) (gfx110X Windows V710 MxGPU partition OOMing on the `pre_checkin` sparse configs, cascading into mass `hipErrorOutOfMemory` failures). We can now restore `test_runner.py` for both components and go back to running the full suite.

## Changes

- **`fetch_test_configurations.py`:** Route both `hipsparse` and `rocsparse` back to `test_runner.py` (dropping the temporary `test_hipsparse.py` / `test_rocsparse.py` legacy fallbacks and their mitigation comments). Set `hipsparse` to 3 shards on both Linux and Windows, and bump the `rocsparse` timeout to 180 minutes.
- **`test_runner.py`:** Add `GTEST_ONLY_SHARDING_COMPONENTS = {"rocsparse", "hipsparse"}` to fix a sharding bug. These components register multiple ctest entries under the same category label (e.g. rocsparse registers both `*_full_suite` and `*_ffm-full_suite`), so combining the ctest `--tests-information` stride with gtest `GTEST_TOTAL_SHARDS` compounds the two sharding axes and silently drops ~(1 − 1/N) of the suite. For these components we now shard purely at the gtest case level: every shard runs all ctest entries and gtest splits the cases, yielding complete, disjoint coverage. Single-entry components are unaffected.

## Follow-ups

- `rocsparse` is kept at 1 shard for now: sharding it currently makes two tests fail due to different random numbers producing results outside tolerance. Once [ROCm/rocm-libraries#8713](https://github.com/ROCm/rocm-libraries/pull/8713) is merged and picked up by a bump PR in TheRock, `rocsparse` can also move to 3 shards.

JIRA ID: AISPARSE-573
