### PR TITLE
fix(ci): Pass build_runs_on to multi_arch_build_portable_linux.yml

### DIFF
--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -61,6 +61,7 @@ jobs:
       build_variant_label: ${{ fromJSON(inputs.build_config).build_variant_label }}
       build_variant_cmake_preset: ${{ fromJSON(inputs.build_config).build_variant_cmake_preset }}
       build_variant_suffix: ${{ fromJSON(inputs.build_config).build_variant_suffix }}
+      build_runs_on: ${{ fromJSON(inputs.build_config).build_runs_on }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}


### PR DESCRIPTION
The multi_arch_release_linux.yml workflow was missing the build_runs_on parameter when calling multi_arch_build_portable_linux.yml, causing ASAN builds to use the default runner (azure-linux-scale-rocm) instead of the sanitizer runner (azure-linux-scale-rocm-heavy-ramdisk) selected by configure_multi_arch_ci.py.

This resulted in AWS IAM permission errors since the AWS runner role lacks permissions to the therock-dev-artifacts bucket.

Tested here: https://github.com/ROCm/TheRock/actions/runs/28047796953/job/83030388981#step:1:2 and properly passing it in

Tested here too: https://github.com/ROCm/TheRock/actions/runs/28039559307/job/83001994909#step:3:51

ISSUE ID #5937