### PR TITLE
build(hipdnn): disable hipkernelprovider by default (ALMIOPEN-2210)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,9 @@ option(THEROCK_ENABLE_MEDIA_LIBS "Enable building of Media libraries" "${THEROCK
 option(THEROCK_ENABLE_EMULATION "Enable building of emulation tools" "${THEROCK_ENABLE_ALL}")
 option(THEROCK_ENABLE_HOST_MATH "Build all bundled host math libraries by default" OFF)
 option(THEROCK_ENABLE_WSL "Enable building WSL-specific artifacts" OFF)
+# hip-kernel-provider is not packaged by default yet.
+option(THEROCK_ENABLE_HIPKERNELPROVIDER "Enables hipDNN hip kernel provider plugin" OFF)
+
 option(THEROCK_RESET_FEATURES "One-shot flag which forces all feature flags to their default state for this configuration run" OFF)
 
 ################################################################################
@@ -255,6 +258,15 @@ option(THEROCK_RESET_FEATURES "One-shot flag which forces all feature flags to t
 
 # Include generated topology (contains feature definitions)
 include("${CMAKE_CURRENT_BINARY_DIR}/cmake/therock_topology.cmake")
+
+# The generated HIPKERNELPROVIDER feature belongs to ML_LIBS, which resets to ON
+# because THEROCK_ENABLE_ML_LIBS defaults to ON. Keep this packaging exception
+# immediately after generated feature declarations so THEROCK_RESET_FEATURES
+# restores the explicit OFF default above.
+if(THEROCK_RESET_FEATURES)
+  set(THEROCK_ENABLE_HIPKERNELPROVIDER OFF CACHE BOOL "Enables hipDNN hip kernel provider plugin" FORCE)
+  set(THEROCK_ENABLE_HIPKERNELPROVIDER OFF)
+endif()
 
 ################################################################################
 # Manual features that don't map to artifacts

--- a/README.md
+++ b/README.md
@@ -214,11 +214,11 @@ minimal build):
 
 hipDNN provider plugins:
 
-| Provider flag                           | Description                               |
-| --------------------------------------- | ----------------------------------------- |
-| `-DTHEROCK_ENABLE_MIOPENPROVIDER=ON`    | Enables hipDNN MIOpen-provider plugin     |
-| `-DTHEROCK_ENABLE_HIPBLASLTPROVIDER=ON` | Enables hipDNN hipBLASLt-provider plugin  |
-| `-DTHEROCK_ENABLE_HIPKERNELPROVIDER=ON` | Enables hipDNN hip kernel provider plugin |
+| Provider flag                            | Description                                                                                                                   |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `-DTHEROCK_ENABLE_MIOPENPROVIDER=ON`     | Enables hipDNN MIOpen-provider plugin                                                                                         |
+| `-DTHEROCK_ENABLE_HIPBLASLTPROVIDER=ON`  | Enables hipDNN hipBLASLt-provider plugin                                                                                      |
+| `-DTHEROCK_ENABLE_HIPKERNELPROVIDER=OFF` | Default: disables hipDNN hip-kernel-provider plugin because it is not packaged by default yet; set to `ON` to opt in manually |
 
 > [!TIP]
 > Enabling any features will implicitly enable their *minimum* dependencies. Some


### PR DESCRIPTION
JIRA ID : ALMIOPEN-2210

## Summary

Disable the hipDNN hip-kernel-provider artifact by default because it is not needed for the release. The provider remains available as an explicit opt-in with `-DTHEROCK_ENABLE_HIPKERNELPROVIDER=ON`.

## Risk Assessment

Medium risk. This changes default build feature selection for one hipDNN provider artifact, but the change is isolated to the generated feature cache default and preserves the explicit opt-in path.

## Testing Summary

- CMake feature default checks covered generated topology behavior for the default, explicit opt-in, and reset paths.
- Pre-commit ran across the repository.

## Testing Checklist

- [x] CMake feature default check - `cmake -S build/hipkernelprovider-default-check -B build/hipkernelprovider-default-check/default && cmake -S build/hipkernelprovider-default-check -B build/hipkernelprovider-default-check/explicit-on -DTHEROCK_ENABLE_HIPKERNELPROVIDER=ON -DEXPECT_HIPKERNELPROVIDER_ON=ON && cmake -S build/hipkernelprovider-default-check -B build/hipkernelprovider-default-check/reset -DTHEROCK_ENABLE_HIPKERNELPROVIDER=ON -DTHEROCK_RESET_FEATURES=ON` - Status: Passed
- [x] Pre-commit - `pre-commit run --all-files` - Status: Passed
- [ ] PR CI - GitHub PR checks - Status: Pending

## Technical Changes

- Adds `THEROCK_ENABLE_HIPKERNELPROVIDER` to the existing feature-selection option block with a default of `OFF`.
- Preserves reset behavior so `THEROCK_RESET_FEATURES=ON` restores the hip-kernel-provider default to `OFF`.
- Updates the README provider table to show the hip-kernel-provider `OFF` default and explain that it is not packaged by default yet.
