### PR TITLE
Fix print/log function usage in setup_ccache.py

### DIFF
--- a/build_tools/setup_ccache.py
+++ b/build_tools/setup_ccache.py
@@ -165,15 +165,13 @@ def run(args: argparse.Namespace):
         if config_file.read_text() != config_contents:
             _log(
                 f"NOTE: {config_file} does not match expected. Run with --init to regenerate",
-                file=sys.stderr,
             )
         if not IS_WINDOWS and (
             not compiler_check_file.exists()
             or compiler_check_file.read_text() != POSIX_COMPILER_CHECK_SCRIPT
         ):
-            print(
+            _log(
                 f"NOTE: {compiler_check_file} does not match expected. Run with --init to regenerate it",
-                file=sys.stderr,
             )
 
     # Reset statistic counters
@@ -186,9 +184,8 @@ def run(args: argparse.Namespace):
             print(proc_ccache.stdout, end="", file=sys.stderr)
 
         except subprocess.CalledProcessError:
-            print(
+            _log(
                 f"ERROR! Zeroing statistic counters failed. Message: {proc_ccache.stderr}",
-                file=sys.stderr,
             )
     # Print the generated config for visibility in CI logs.
     _log("Generated ccache config:")
@@ -197,6 +194,8 @@ def run(args: argparse.Namespace):
             _log(f"  {line}")
 
     # Output options.
+    # Note: these print to stdout, while _log prints to stderr.
+    # This allows the script output (stdout) to be run through eval().
     if IS_WINDOWS:
         print(f"set CCACHE_CONFIGPATH={config_file}")
     else:


### PR DESCRIPTION
## Motivation

This should fix crashes that occur on these error handling paths since the `_log` helper function does not accept a `file` argument.

## Technical Details

Back on https://github.com/ROCm/TheRock/pull/5141, I added additional logging as part of debugging https://github.com/ROCm/TheRock/issues/4519. For the logging to not interfere with the suggested `eval "$(./build_tools/setup_ccache.py)"` usage of this script it was sent to `stderr` instead of `stdout` via this helper function.

## Test Plan

* CI should still configure and use ccache
  * ... on Windows. On Linux we're using new runners on AWS that don't have access to the ccache bucket
* Error paths are not exercised right now, either on CI or via unit tests, but I think this is safe enough to trust without that

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
