### PR TITLE
fix: Fix LLVM wrappers in pip whl by correcting symlink

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -432,8 +432,26 @@ def _lock_and_expand(
                             parent_path.mkdir(parents=True, exist_ok=True)
                             symlink_target = ti.linkname
                             hardlink_target = dest_path.parent / symlink_target
+                            # On Linux, preserve symlinks in top-level bin/ directory
+                            # top-level bin/ so $ORIGIN in RPATH resolves correctly.
+                            PRESERVE_SYMLINKS = [
+                                "amdclang",
+                                "amdclang++",
+                                "amdclang-cl",
+                                "amdclang-cpp",
+                                "amdflang",
+                                "amdlld",
+                                "amdllvm",
+                            ]
+                            if (
+                                not _is_windows()
+                                and dest_path.name in PRESERVE_SYMLINKS
+                                and dest_path.parent.name == "bin"
+                                and dest_path.parent.parent.name.startswith("_rocm_sdk_devel")
+                            ):
+                                dest_path.symlink_to(symlink_target)
                             # Only create hardlinks for files, not directories
-                            if hardlink_target.is_file():
+                            elif hardlink_target.is_file():
                                 dest_path.hardlink_to(hardlink_target)
                             else:
                                 # For directory symlinks, extract as normal

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -433,7 +433,6 @@ def _lock_and_expand(
                             symlink_target = ti.linkname
                             hardlink_target = dest_path.parent / symlink_target
                             # On Linux, preserve symlinks in top-level bin/ directory
-                            # top-level bin/ so $ORIGIN in RPATH resolves correctly.
                             PRESERVE_SYMLINKS = [
                                 "amdclang",
                                 "amdclang++",

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_devel.py
@@ -447,7 +447,9 @@ def _lock_and_expand(
                                 not _is_windows()
                                 and dest_path.name in PRESERVE_SYMLINKS
                                 and dest_path.parent.name == "bin"
-                                and dest_path.parent.parent.name.startswith("_rocm_sdk_devel")
+                                and dest_path.parent.parent.name.startswith(
+                                    "_rocm_sdk_devel"
+                                )
                             ):
                                 dest_path.symlink_to(symlink_target)
                             # Only create hardlinks for files, not directories


### PR DESCRIPTION
After installing the multi-arch ROCm pip SDK, 
the LLVM toolchain wrappers in _rocm_sdk_devel/bin are non-functional:
- amdclang
- amdclang++
- amdflang
- amdlld
- amdclang-cl
- amdclang-cpp

Fix symlink to resolve 

JIRA ID : ROCM-26126

**Test Results:**
**Top level bin directory need symlink**
/python3.12/site-packages/_rocm_sdk_devel/bin# ls -l amd*
-rwxr-xr-x 2 root root 10427 Jun 24 08:15 amd-smi
lrwxrwxrwx 1 root root    24 Jun 24 08:16 amdclang -> ../lib/llvm/bin/amdclang
lrwxrwxrwx 1 root root    26 Jun 24 08:16 amdclang++ -> ../lib/llvm/bin/amdclang++
lrwxrwxrwx 1 root root    27 Jun 24 08:16 amdclang-cl -> ../lib/llvm/bin/amdclang-cl
lrwxrwxrwx 1 root root    28 Jun 24 08:16 amdclang-cpp -> ../lib/llvm/bin/amdclang-cpp
lrwxrwxrwx 1 root root    24 Jun 24 08:16 amdflang -> ../lib/llvm/bin/amdflang
lrwxrwxrwx 1 root root    22 Jun 24 08:16 amdlld -> ../lib/llvm/bin/amdlld
lrwxrwxrwx 1 root root    23 Jun 24 08:16 amdllvm -> ../lib/llvm/bin/amdllvm

**No symlink required in internal bin folder**
python3.12/site-packages/_rocm_sdk_devel/lib/llvm/bin# ls -l amd*
-rwxr-xr-x 2 root root 4770488 Jun 24 08:15 amd-llvm-spirv
-rwxr-xr-x 2 root root   26168 Jun 24 08:15 amdclang
-rwxr-xr-x 2 root root   26168 Jun 24 08:15 amdclang++
-rwxr-xr-x 2 root root   26168 Jun 24 08:15 amdclang-23
-rwxr-xr-x 2 root root   26168 Jun 24 08:15 amdclang-cl
-rwxr-xr-x 2 root root   26168 Jun 24 08:15 amdclang-cpp
-rwxr-xr-x 2 root root   26168 Jun 24 08:15 amdflang
-rwxr-xr-x 2 root root   26168 Jun 24 08:15 amdgpu-arch
-rwxr-xr-x 2 root root   26168 Jun 24 08:15 amdlld
-rwxr-xr-x 2 root root   27912 Jun 24 08:15 amdllvm

amdclang --help output(pasted only a small snippet)
python3.12/site-packages/_rocm_sdk_devel/bin# ./amdclang --help
OVERVIEW: clang LLVM compiler

USAGE: clang-23 [options] file...

OPTIONS:
  -###                    Print (but do not run) the commands to run for this compilation
  --analyzer-output <value>
                          Static analyzer report output format (html|plist|plist-multi-file|plist-html|sarif|sarif-html|text).
  --analyze               Run the static analyzer
  -B <prefix>             Search $prefix$file for executables, libraries, and data files. If $prefix is a directory, search $prefix/$file
  -b <arg>                Pass -b <arg> to the linker on AIX
  -CC                     Include comments from within macros in preprocessed output