### PR TITLE
[hotswap] Enable building the HSA HotSwap tool

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -159,14 +159,12 @@ if(THEROCK_ENABLE_COMPILER)
   # version script, avoiding symbol interposition issues.
   ##############################################################################
 
+  # A0 hotswap needs only the in-place rewrite (amd_comgr_hotswap_rewrite), which
+  # is compiled unconditionally. The cross-gen transpiler is NOT needed for A0 and
+  # is disabled (it also pulls dynamic libLLVM into comgr, defeating static link).
   set(_comgr_hotswap_cmake_args)
   if(THEROCK_ENABLE_HOTSWAP)
-    list(APPEND _comgr_hotswap_cmake_args -DCOMGR_ENABLE_HOTSWAP_TRANSPILE=ON)
-    if(NOT WIN32)
-      list(APPEND _comgr_hotswap_cmake_args
-        -DHOTSWAP_BUILD_TOOL=ON
-        "-DHOTSWAP_TOOL_HSA_INCLUDE_ROOT=${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime/runtime/hsa-runtime")
-    endif()
+    list(APPEND _comgr_hotswap_cmake_args -DCOMGR_ENABLE_HOTSWAP_TRANSPILE=OFF)
   endif()
 
   therock_cmake_subproject_declare(amd-comgr

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -143,6 +143,37 @@ if(THEROCK_ENABLE_CORE_RUNTIME)
     LIB_NAMES libhsa-runtime64.so
   )
 
+  set(_core_runtime_hotswap_subproject_deps)
+  if(THEROCK_ENABLE_HOTSWAP AND NOT WIN32)
+    ############################################################################
+    # HSA HotSwap tool
+    ############################################################################
+
+    therock_cmake_subproject_declare(hsa-hotswap
+      EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/hotswap"
+      BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hsa-hotswap"
+      BACKGROUND_BUILD
+      DISABLE_AMDGPU_TARGETS
+      COMPILER_TOOLCHAIN
+        "${_system_toolchain}"
+      RUNTIME_DEPS
+        ROCR-Runtime
+        amd-comgr
+      INTERFACE_LINK_DIRS
+        "lib"
+      INTERFACE_INSTALL_RPATH_DIRS
+        "lib"
+    )
+    therock_cmake_subproject_glob_c_sources(hsa-hotswap SUBDIRS .)
+    therock_cmake_subproject_activate(hsa-hotswap)
+    list(APPEND _core_runtime_hotswap_subproject_deps hsa-hotswap)
+
+    therock_test_validate_shared_lib(
+      PATH hsa-hotswap/dist/lib
+      LIB_NAMES libhsa-hotswap.so
+    )
+  endif()
+
   ##############################################################################
   # rocminfo
   ##############################################################################
@@ -165,6 +196,7 @@ if(THEROCK_ENABLE_CORE_RUNTIME)
   set(_core_runtime_subproject_deps
     ROCR-Runtime
     rocminfo
+    ${_core_runtime_hotswap_subproject_deps}
   )
   set(_core_runtime_artifact_components
     dbg

--- a/core/artifact-core-runtime.toml
+++ b/core/artifact-core-runtime.toml
@@ -33,3 +33,6 @@ optional = true
 include = [
   "lib/hrx/share/hrx-cts/**",
 ]
+
+#Hotswap HSA hookup
+[components.lib."core/hsa-hotswap/stage"]


### PR DESCRIPTION
## Summary
Enables building and packaging the rocm-systems HSA HotSwap tool
(`libhsa-hotswap.so`) and configures comgr for the in-place B0→A0 rewrite.
Gated on `THEROCK_ENABLE_HOTSWAP`.

- **core/CMakeLists.txt** — declare the `hsa-hotswap` subproject (built from
  `rocm-systems/projects/hotswap`); add it to the core-runtime deps + a
  shared-lib validation.
- **core/artifact-core-runtime.toml** — package `libhsa-hotswap.so` into the
  core-runtime lib artifact (so it lands in the dist/wheel).
- **compiler/CMakeLists.txt** — build comgr with
  `COMGR_ENABLE_HOTSWAP_TRANSPILE=OFF` so it links static (the transpiler pulls
  dynamic libLLVM into comgr, which breaks `hipMemcpy` on A0), and drop the
  now-removed in-tree comgr tool flags (`HOTSWAP_BUILD_TOOL`).

## Dependencies (coordinated multi-repo change)
- **llvm-project #3007** — remove the in-tree comgr HSA tool (comgr keeps the
  rewrite API). The amd-llvm pin advances to include it.
- **rocm-systems #7629** — the `libhsa-hotswap.so` tool + ROCr/CLR re-key +
  install. The rocm-systems pin advances to include it.

Draft until those land and the pins are bumped.

## Test plan
- [ ] Full build with `THEROCK_ENABLE_HOTSWAP=ON` produces `libhsa-hotswap.so`
      in `dist/rocm/lib` and the wheel.
- [ ] comgr links static (`ldd libamd_comgr.so` shows no `libLLVM.so`).
- [ ] A0: tool loads via `HSA_TOOLS_LIB` and rewrites gfx1250 B0 code objects.