### PR TITLE
feat: Add tarballs excluding tests

### DIFF
--- a/.github/workflows/multi_arch_build_tarballs.yml
+++ b/.github/workflows/multi_arch_build_tarballs.yml
@@ -34,6 +34,10 @@ on:
           - ci
           - dev
         default: ci
+      include_lite_tarballs:
+        description: "Also build lite tarballs that exclude test artifacts"
+        type: boolean
+        default: true
   workflow_call:
     inputs:
       artifact_run_id:
@@ -54,6 +58,9 @@ on:
       release_type:
         type: string
         default: ci
+      include_lite_tarballs:
+        type: boolean
+        default: true
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
@@ -101,13 +108,19 @@ jobs:
 
       - name: Build tarballs
         run: |
+          EXTRA_ARGS=()
+          if [[ "${{ inputs.include_lite_tarballs }}" == "true" ]]; then
+            EXTRA_ARGS+=(--include-lite-tarballs)
+          fi
+
           python build_tools/build_tarballs.py \
             --run-id="${{ env.ARTIFACT_RUN_ID }}" \
             --run-github-repo="${{ inputs.artifact_github_repo }}" \
             --dist-amdgpu-families="${{ inputs.dist_amdgpu_families }}" \
             --platform="${{ inputs.platform }}" \
             --package-version="${{ inputs.package_version }}" \
-            --output-dir="${{ github.workspace }}/tarballs"
+            --output-dir="${{ github.workspace }}/tarballs" \
+            "${EXTRA_ARGS[@]}"
 
       - name: Configure AWS Credentials
         uses: ./.github/actions/configure_aws_artifacts_credentials

--- a/.github/workflows/multi_arch_build_tarballs.yml
+++ b/.github/workflows/multi_arch_build_tarballs.yml
@@ -34,8 +34,8 @@ on:
           - ci
           - dev
         default: ci
-      include_lite_tarballs:
-        description: "Also build lite tarballs that exclude test artifacts"
+      include_test_tarballs:
+        description: "Also build -tests tarballs that include test artifacts"
         type: boolean
         default: true
   workflow_call:
@@ -58,7 +58,7 @@ on:
       release_type:
         type: string
         default: ci
-      include_lite_tarballs:
+      include_test_tarballs:
         type: boolean
         default: true
       repository:
@@ -109,8 +109,8 @@ jobs:
       - name: Build tarballs
         run: |
           EXTRA_ARGS=()
-          if [[ "${{ inputs.include_lite_tarballs }}" == "true" ]]; then
-            EXTRA_ARGS+=(--include-lite-tarballs)
+          if [[ "${{ inputs.include_test_tarballs }}" == "true" ]]; then
+            EXTRA_ARGS+=(--include-test-tarballs)
           fi
 
           python build_tools/build_tarballs.py \

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -136,26 +136,67 @@ def parse_target_families(args: argparse.Namespace) -> List[str]:
 
 
 def find_available_artifacts(
-    artifact_names: Set[str],
-    target_families: List[str],
-    available: Set[str],
-) -> List[str]:
+    artifact_names: set[str],
+    target_families: list[str],
+    available: set[str],
+    excluded_components: set[str] | None = None,
+) -> list[str]:
     """Find which artifacts exist in the available set.
 
     Iterates artifact_names × target_families × components × extensions,
     returning filenames that are present in `available`. Prefers .tar.zst
     over .tar.xz when both exist.
     """
+    excluded_components = excluded_components or set()
     matched = []
     for artifact_name in sorted(artifact_names):
         for tf in target_families:
             for comp in ARTIFACT_COMPONENTS:
+                if comp in excluded_components:
+                    continue
                 for ext in ARTIFACT_EXTENSIONS:
                     filename = f"{artifact_name}_{comp}_{tf}{ext}"
                     if filename in available:
                         matched.append(filename)
                         break  # Found this artifact, don't check other extensions
     return matched
+
+
+def parse_excluded_components(raw_components: str) -> set[str]:
+    """Parse and validate component names passed to --exclude-components."""
+    components = {
+        comp.strip()
+        for comp in raw_components.replace(";", ",").split(",")
+        if comp.strip()
+    }
+    invalid_components = components - set(ARTIFACT_COMPONENTS)
+    if invalid_components:
+        raise ValueError(
+            "Invalid artifact component(s): "
+            f"{', '.join(sorted(invalid_components))}. "
+            f"Valid components are: {', '.join(ARTIFACT_COMPONENTS)}"
+        )
+    return components
+
+
+def parse_excluded_artifacts(
+    raw_artifacts: str,
+    valid_artifacts: set[str],
+) -> set[str]:
+    """Parse and validate artifact names passed to --exclude-artifacts."""
+    artifacts = {
+        artifact.strip()
+        for artifact in raw_artifacts.replace(";", ",").split(",")
+        if artifact.strip()
+    }
+    invalid_artifacts = artifacts - valid_artifacts
+    if invalid_artifacts:
+        raise ValueError(
+            "Invalid artifact name(s): "
+            f"{', '.join(sorted(invalid_artifacts))}. "
+            f"Valid artifacts are: {', '.join(sorted(valid_artifacts))}"
+        )
+    return artifacts
 
 
 # =============================================================================
@@ -334,6 +375,16 @@ def do_fetch(args: argparse.Namespace):
         )
 
     target_families = parse_target_families(args)
+    excluded_artifacts = parse_excluded_artifacts(
+        args.exclude_artifacts,
+        set(topology.artifacts.keys()),
+    )
+    if excluded_artifacts:
+        log(f"Excluding artifacts: {', '.join(sorted(excluded_artifacts))}")
+        inbound -= excluded_artifacts
+        if not inbound:
+            log("No artifacts remain after exclusions")
+            return
 
     # Create backend
     backend = create_backend_from_env(
@@ -355,7 +406,16 @@ def do_fetch(args: argparse.Namespace):
     )
     download_dir.mkdir(parents=True, exist_ok=True)
 
-    matched_filenames = find_available_artifacts(inbound, target_families, available)
+    excluded_components = parse_excluded_components(args.exclude_components)
+    if excluded_components:
+        log(f"Excluding artifact components: {', '.join(sorted(excluded_components))}")
+
+    matched_filenames = find_available_artifacts(
+        inbound,
+        target_families,
+        available,
+        excluded_components=excluded_components,
+    )
 
     download_requests = [
         DownloadRequest(
@@ -1082,6 +1142,19 @@ def main(argv: Optional[List[str]] = None):
         type=int,
         default=None,
         help="Number of concurrent extractions (default: auto)",
+    )
+    fetch_parser.add_argument(
+        "--exclude-components",
+        type=str,
+        default="",
+        help="Comma- or semicolon-separated artifact components to exclude "
+        f"when fetching. Valid components: {', '.join(ARTIFACT_COMPONENTS)}",
+    )
+    fetch_parser.add_argument(
+        "--exclude-artifacts",
+        type=str,
+        default="",
+        help="Comma- or semicolon-separated artifact names to exclude when fetching",
     )
     fetch_parser.set_defaults(func=do_fetch)
 

--- a/build_tools/build_tarballs.py
+++ b/build_tools/build_tarballs.py
@@ -55,12 +55,15 @@ import subprocess
 import sys
 from pathlib import Path
 
+LITE_EXCLUDED_ARTIFACTS: list[str] = ["fftw3"]
+LITE_EXCLUDED_COMPONENTS: list[str] = ["test"]
 
-def log(msg: str):
+
+def log(msg: str) -> None:
     print(msg, flush=True)
 
 
-def run_command(args: list[str | Path], cwd: Path | None = None):
+def run_command(args: list[str | Path], cwd: Path | None = None) -> None:
     args = [str(arg) for arg in args]
     log(f"++ Exec{f' [{cwd}]' if cwd else ''}$ {shlex.join(args)}")
     subprocess.check_call(args, cwd=str(cwd) if cwd else None, stdin=subprocess.DEVNULL)
@@ -74,11 +77,17 @@ def fetch_and_flatten(
     output_dir: Path,
     download_cache_dir: Path,
     run_github_repo: str | None = None,
-):
+    exclude_components: list[str] | None = None,
+    exclude_artifacts: list[str] | None = None,
+) -> None:
     """Fetch artifacts for one or more families and flatten into output_dir."""
     families_str = ";".join(amdgpu_families)
     log(f"\n{'='*60}")
     log(f"Fetching artifacts for {families_str}")
+    if exclude_components:
+        log(f"Excluding components: {', '.join(exclude_components)}")
+    if exclude_artifacts:
+        log(f"Excluding artifacts: {', '.join(exclude_artifacts)}")
     log(f"{'='*60}")
 
     cmd = [
@@ -94,6 +103,10 @@ def fetch_and_flatten(
         "--flatten",
         f"--download-cache-dir={download_cache_dir}",
     ]
+    if exclude_components:
+        cmd.append(f"--exclude-components={','.join(exclude_components)}")
+    if exclude_artifacts:
+        cmd.append(f"--exclude-artifacts={','.join(exclude_artifacts)}")
     if run_github_repo:
         cmd.append(f"--run-github-repo={run_github_repo}")
     run_command(cmd)
@@ -108,7 +121,7 @@ def is_kpack_split(flatten_dir: Path) -> bool:
     return manifest.get("flags", {}).get("KPACK_SPLIT_ARTIFACTS", False)
 
 
-def compress_tarball(*, source_dir: Path, tarball_path: Path):
+def compress_tarball(*, source_dir: Path, tarball_path: Path) -> None:
     """Compress a directory into a .tar.gz tarball.
 
     Uses subprocess ``tar cfz`` rather than Python's ``tarfile`` module
@@ -126,7 +139,7 @@ def compress_tarball(*, source_dir: Path, tarball_path: Path):
     log(f"  Created {tarball_path.name} ({size_mb:.1f} MB)")
 
 
-def main(argv=None):
+def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
         description="Fetch multi-arch artifacts and package into per-family tarballs"
     )
@@ -160,6 +173,11 @@ def main(argv=None):
         required=True,
         help="Output directory for tarballs",
     )
+    parser.add_argument(
+        "--include-lite-tarballs",
+        action="store_true",
+        help="Also produce lite tarballs that exclude test artifacts",
+    )
     args = parser.parse_args(argv)
     # Normalize empty string to None (workflow inputs default to "")
     args.run_github_repo = args.run_github_repo or None
@@ -176,6 +194,7 @@ def main(argv=None):
     log(f"  Platform: {args.platform}")
     log(f"  Version: {args.package_version}")
     log(f"  Output: {args.output_dir}")
+    log(f"  Include lite tarballs: {args.include_lite_tarballs}")
 
     # Phase 1: Fetch and flatten sequentially.
     # Sequential so the shared download cache avoids re-downloading generic
@@ -197,6 +216,20 @@ def main(argv=None):
             f"therock-dist-{args.platform}-{family}-{args.package_version}.tar.gz"
         )
         compress_tasks.append((flatten_dir, args.output_dir / tarball_name))
+        if args.include_lite_tarballs:
+            lite_dir = work_dir / "lite" / family
+            fetch_and_flatten(
+                run_id=args.run_id,
+                amdgpu_families=[family],
+                platform=args.platform,
+                output_dir=lite_dir,
+                download_cache_dir=download_cache_dir,
+                run_github_repo=args.run_github_repo,
+                exclude_components=LITE_EXCLUDED_COMPONENTS,
+                exclude_artifacts=LITE_EXCLUDED_ARTIFACTS,
+            )
+            lite_tarball_name = f"therock-dist-{args.platform}-{family}-lite-{args.package_version}.tar.gz"
+            compress_tasks.append((lite_dir, args.output_dir / lite_tarball_name))
 
     # Phase 1.5: If KPACK_SPLIT_ARTIFACTS is enabled, fetch all families
     # into a single combined directory. With KPACK split, device-specific
@@ -218,6 +251,25 @@ def main(argv=None):
             f"therock-dist-{args.platform}-multiarch-{args.package_version}.tar.gz"
         )
         compress_tasks.append((multiarch_dir, args.output_dir / tarball_name))
+        if args.include_lite_tarballs:
+            lite_multiarch_dir = work_dir / "lite" / "multiarch"
+            fetch_and_flatten(
+                run_id=args.run_id,
+                amdgpu_families=families,
+                platform=args.platform,
+                output_dir=lite_multiarch_dir,
+                download_cache_dir=download_cache_dir,
+                run_github_repo=args.run_github_repo,
+                exclude_components=LITE_EXCLUDED_COMPONENTS,
+                exclude_artifacts=LITE_EXCLUDED_ARTIFACTS,
+            )
+            lite_tarball_name = (
+                f"therock-dist-{args.platform}-multiarch-lite-"
+                f"{args.package_version}.tar.gz"
+            )
+            compress_tasks.append(
+                (lite_multiarch_dir, args.output_dir / lite_tarball_name)
+            )
 
     # Phase 2: Compress all tarballs in parallel.
     # Each tar cfz is single-threaded, so running N families concurrently

--- a/build_tools/build_tarballs.py
+++ b/build_tools/build_tarballs.py
@@ -17,6 +17,10 @@ containing all targets in a single install prefix.
 A shared download cache avoids re-downloading generic (host) artifacts
 when processing multiple families.
 
+By default, generated tarballs exclude test artifacts and fftw3. Pass
+``--include-test-tarballs`` to also generate full tarballs, named with a
+``-tests`` suffix, that include test artifacts.
+
 Tarball naming follows the existing release convention:
     therock-dist-{platform}-{family}-{version}.tar.gz
     therock-dist-{platform}-multiarch-{version}.tar.gz  (KPACK split only)
@@ -55,8 +59,8 @@ import subprocess
 import sys
 from pathlib import Path
 
-LITE_EXCLUDED_ARTIFACTS: list[str] = ["fftw3"]
-LITE_EXCLUDED_COMPONENTS: list[str] = ["test"]
+DEFAULT_EXCLUDED_ARTIFACTS: list[str] = ["fftw3"]
+DEFAULT_EXCLUDED_COMPONENTS: list[str] = ["test"]
 
 
 def log(msg: str) -> None:
@@ -174,9 +178,9 @@ def main(argv: list[str] | None = None) -> None:
         help="Output directory for tarballs",
     )
     parser.add_argument(
-        "--include-lite-tarballs",
+        "--include-test-tarballs",
         action="store_true",
-        help="Also produce lite tarballs that exclude test artifacts",
+        help="Also produce -tests tarballs that include test artifacts",
     )
     args = parser.parse_args(argv)
     # Normalize empty string to None (workflow inputs default to "")
@@ -194,7 +198,7 @@ def main(argv: list[str] | None = None) -> None:
     log(f"  Platform: {args.platform}")
     log(f"  Version: {args.package_version}")
     log(f"  Output: {args.output_dir}")
-    log(f"  Include lite tarballs: {args.include_lite_tarballs}")
+    log(f"  Include test tarballs: {args.include_test_tarballs}")
 
     # Phase 1: Fetch and flatten sequentially.
     # Sequential so the shared download cache avoids re-downloading generic
@@ -210,26 +214,29 @@ def main(argv: list[str] | None = None) -> None:
             output_dir=flatten_dir,
             download_cache_dir=download_cache_dir,
             run_github_repo=args.run_github_repo,
+            exclude_components=DEFAULT_EXCLUDED_COMPONENTS,
+            exclude_artifacts=DEFAULT_EXCLUDED_ARTIFACTS,
         )
         family_dirs.append(flatten_dir)
         tarball_name = (
             f"therock-dist-{args.platform}-{family}-{args.package_version}.tar.gz"
         )
         compress_tasks.append((flatten_dir, args.output_dir / tarball_name))
-        if args.include_lite_tarballs:
-            lite_dir = work_dir / "lite" / family
+        if args.include_test_tarballs:
+            tests_dir = work_dir / "tests" / family
             fetch_and_flatten(
                 run_id=args.run_id,
                 amdgpu_families=[family],
                 platform=args.platform,
-                output_dir=lite_dir,
+                output_dir=tests_dir,
                 download_cache_dir=download_cache_dir,
                 run_github_repo=args.run_github_repo,
-                exclude_components=LITE_EXCLUDED_COMPONENTS,
-                exclude_artifacts=LITE_EXCLUDED_ARTIFACTS,
             )
-            lite_tarball_name = f"therock-dist-{args.platform}-{family}-lite-{args.package_version}.tar.gz"
-            compress_tasks.append((lite_dir, args.output_dir / lite_tarball_name))
+            tests_tarball_name = (
+                f"therock-dist-{args.platform}-{family}-tests-"
+                f"{args.package_version}.tar.gz"
+            )
+            compress_tasks.append((tests_dir, args.output_dir / tests_tarball_name))
 
     # Phase 1.5: If KPACK_SPLIT_ARTIFACTS is enabled, fetch all families
     # into a single combined directory. With KPACK split, device-specific
@@ -246,29 +253,29 @@ def main(argv: list[str] | None = None) -> None:
             output_dir=multiarch_dir,
             download_cache_dir=download_cache_dir,
             run_github_repo=args.run_github_repo,
+            exclude_components=DEFAULT_EXCLUDED_COMPONENTS,
+            exclude_artifacts=DEFAULT_EXCLUDED_ARTIFACTS,
         )
         tarball_name = (
             f"therock-dist-{args.platform}-multiarch-{args.package_version}.tar.gz"
         )
         compress_tasks.append((multiarch_dir, args.output_dir / tarball_name))
-        if args.include_lite_tarballs:
-            lite_multiarch_dir = work_dir / "lite" / "multiarch"
+        if args.include_test_tarballs:
+            tests_multiarch_dir = work_dir / "tests" / "multiarch"
             fetch_and_flatten(
                 run_id=args.run_id,
                 amdgpu_families=families,
                 platform=args.platform,
-                output_dir=lite_multiarch_dir,
+                output_dir=tests_multiarch_dir,
                 download_cache_dir=download_cache_dir,
                 run_github_repo=args.run_github_repo,
-                exclude_components=LITE_EXCLUDED_COMPONENTS,
-                exclude_artifacts=LITE_EXCLUDED_ARTIFACTS,
             )
-            lite_tarball_name = (
-                f"therock-dist-{args.platform}-multiarch-lite-"
+            tests_tarball_name = (
+                f"therock-dist-{args.platform}-multiarch-tests-"
                 f"{args.package_version}.tar.gz"
             )
             compress_tasks.append(
-                (lite_multiarch_dir, args.output_dir / lite_tarball_name)
+                (tests_multiarch_dir, args.output_dir / tests_tarball_name)
             )
 
     # Phase 2: Compress all tarballs in parallel.

--- a/build_tools/github_actions/tests/upload_tarballs_test.py
+++ b/build_tools/github_actions/tests/upload_tarballs_test.py
@@ -128,6 +128,76 @@ class TestUploadTarballsRun(unittest.TestCase):
                 "25834210506-linux/tarballs/therock-dist-linux-multiarch-7.13.0.tar.gz",
             )
 
+    @patch("upload_tarballs.gha_set_output")
+    def test_run_exports_single_full_family_url_when_lite_tarball_exists(
+        self,
+        mock_gha_set_output,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tarballs_dir = Path(tmpdir)
+            full_tarball = (
+                tarballs_dir
+                / "therock-dist-linux-gfx94X-dcgpu-7.14.0.dev0+13caf791.tar.gz"
+            )
+            full_tarball.write_text("x")
+            lite_tarball = (
+                tarballs_dir
+                / "therock-dist-linux-gfx94X-dcgpu-lite-7.14.0.dev0+13caf791.tar.gz"
+            )
+            lite_tarball.write_text("x")
+
+            staging_dir = tarballs_dir / "staging"
+            staging_dir.mkdir()
+            rc = mod.run(
+                input_tarballs_dir=tarballs_dir,
+                run_id="27993936036",
+                platform="linux",
+                release_type="dev",
+                output_dir=staging_dir,
+            )
+
+            self.assertEqual(rc, 0)
+            mock_gha_set_output.assert_called_once()
+
+            payload = mock_gha_set_output.call_args.args[0]
+            urls = json.loads(payload["tarball_urls"])
+
+            self.assertEqual(
+                urls["multiarch"],
+                "https://therock-dev-artifacts.s3.amazonaws.com/"
+                "27993936036-linux/tarballs/"
+                "therock-dist-linux-gfx94X-dcgpu-7.14.0.dev0%2B13caf791.tar.gz",
+            )
+
+    @patch("upload_tarballs.gha_set_output")
+    def test_run_rejects_multiple_full_family_urls_without_multiarch(
+        self,
+        mock_gha_set_output,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tarballs_dir = Path(tmpdir)
+            gfx94x_tarball = (
+                tarballs_dir / "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz"
+            )
+            gfx94x_tarball.write_text("x")
+            gfx110x_tarball = (
+                tarballs_dir / "therock-dist-linux-gfx110X-all-7.13.0.tar.gz"
+            )
+            gfx110x_tarball.write_text("x")
+
+            staging_dir = tarballs_dir / "staging"
+            staging_dir.mkdir()
+            with self.assertRaisesRegex(ValueError, "No shared tarball URL"):
+                mod.run(
+                    input_tarballs_dir=tarballs_dir,
+                    run_id="25834210506",
+                    platform="linux",
+                    release_type="dev",
+                    output_dir=staging_dir,
+                )
+
+            mock_gha_set_output.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/build_tools/github_actions/tests/upload_tarballs_test.py
+++ b/build_tools/github_actions/tests/upload_tarballs_test.py
@@ -93,18 +93,18 @@ class TestUploadTarballsRun(unittest.TestCase):
             )
 
     @patch("upload_tarballs.gha_set_output")
-    def test_run_exports_full_multiarch_url_when_lite_tarball_exists(
+    def test_run_exports_base_multiarch_url_when_test_tarball_exists(
         self,
         mock_gha_set_output,
     ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tarballs_dir = Path(tmpdir)
-            full_tarball = tarballs_dir / "therock-dist-linux-multiarch-7.13.0.tar.gz"
-            full_tarball.write_text("x")
-            lite_tarball = (
-                tarballs_dir / "therock-dist-linux-multiarch-lite-7.13.0.tar.gz"
+            base_tarball = tarballs_dir / "therock-dist-linux-multiarch-7.13.0.tar.gz"
+            base_tarball.write_text("x")
+            test_tarball = (
+                tarballs_dir / "therock-dist-linux-multiarch-tests-7.13.0.tar.gz"
             )
-            lite_tarball.write_text("x")
+            test_tarball.write_text("x")
 
             staging_dir = tarballs_dir / "staging"
             staging_dir.mkdir()
@@ -129,22 +129,22 @@ class TestUploadTarballsRun(unittest.TestCase):
             )
 
     @patch("upload_tarballs.gha_set_output")
-    def test_run_exports_single_full_family_url_when_lite_tarball_exists(
+    def test_run_exports_single_base_family_url_when_test_tarball_exists(
         self,
         mock_gha_set_output,
     ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tarballs_dir = Path(tmpdir)
-            full_tarball = (
+            base_tarball = (
                 tarballs_dir
                 / "therock-dist-linux-gfx94X-dcgpu-7.14.0.dev0+13caf791.tar.gz"
             )
-            full_tarball.write_text("x")
-            lite_tarball = (
+            base_tarball.write_text("x")
+            test_tarball = (
                 tarballs_dir
-                / "therock-dist-linux-gfx94X-dcgpu-lite-7.14.0.dev0+13caf791.tar.gz"
+                / "therock-dist-linux-gfx94X-dcgpu-tests-7.14.0.dev0+13caf791.tar.gz"
             )
-            lite_tarball.write_text("x")
+            test_tarball.write_text("x")
 
             staging_dir = tarballs_dir / "staging"
             staging_dir.mkdir()
@@ -170,7 +170,7 @@ class TestUploadTarballsRun(unittest.TestCase):
             )
 
     @patch("upload_tarballs.gha_set_output")
-    def test_run_rejects_multiple_full_family_urls_without_multiarch(
+    def test_run_rejects_multiple_base_family_urls_without_multiarch(
         self,
         mock_gha_set_output,
     ) -> None:

--- a/build_tools/github_actions/tests/upload_tarballs_test.py
+++ b/build_tools/github_actions/tests/upload_tarballs_test.py
@@ -92,6 +92,42 @@ class TestUploadTarballsRun(unittest.TestCase):
                 "25834210506-linux/tarballs/therock-dist-linux-7.13.0.tar.gz",
             )
 
+    @patch("upload_tarballs.gha_set_output")
+    def test_run_exports_full_multiarch_url_when_lite_tarball_exists(
+        self,
+        mock_gha_set_output,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tarballs_dir = Path(tmpdir)
+            full_tarball = tarballs_dir / "therock-dist-linux-multiarch-7.13.0.tar.gz"
+            full_tarball.write_text("x")
+            lite_tarball = (
+                tarballs_dir / "therock-dist-linux-multiarch-lite-7.13.0.tar.gz"
+            )
+            lite_tarball.write_text("x")
+
+            staging_dir = tarballs_dir / "staging"
+            staging_dir.mkdir()
+            rc = mod.run(
+                input_tarballs_dir=tarballs_dir,
+                run_id="25834210506",
+                platform="linux",
+                release_type="dev",
+                output_dir=staging_dir,
+            )
+
+            self.assertEqual(rc, 0)
+            mock_gha_set_output.assert_called_once()
+
+            payload = mock_gha_set_output.call_args.args[0]
+            urls = json.loads(payload["tarball_urls"])
+
+            self.assertEqual(
+                urls["multiarch"],
+                "https://therock-dev-artifacts.s3.amazonaws.com/"
+                "25834210506-linux/tarballs/therock-dist-linux-multiarch-7.13.0.tar.gz",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/build_tools/github_actions/upload_tarballs.py
+++ b/build_tools/github_actions/upload_tarballs.py
@@ -93,6 +93,8 @@ def run(
     for f in tarball_files:
         name = f.name
         encoded_name = quote(name, safe="")
+        if "-lite-" in name:
+            continue
 
         if name.startswith(f"therock-dist-{platform}-multiarch-"):
             shared_tarball_url = output_root.tarball(encoded_name).https_url

--- a/build_tools/github_actions/upload_tarballs.py
+++ b/build_tools/github_actions/upload_tarballs.py
@@ -46,6 +46,44 @@ from github_actions_api import gha_set_output
 logger = logging.getLogger(__name__)
 
 
+def _tarball_url(output_root: WorkflowOutputRoot, name: str) -> str:
+    return output_root.tarball(quote(name, safe="")).https_url
+
+
+def _is_lite_tarball(name: str) -> bool:
+    return "-lite-" in name
+
+
+def _select_shared_tarball_url(
+    *,
+    tarball_files: list[Path],
+    output_root: WorkflowOutputRoot,
+    platform: str,
+) -> str | None:
+    full_tarball_files = [f for f in tarball_files if not _is_lite_tarball(f.name)]
+
+    for f in full_tarball_files:
+        name = f.name
+        if name.startswith(f"therock-dist-{platform}-multiarch-"):
+            return _tarball_url(output_root, name)
+
+    if len(full_tarball_files) == 1:
+        return _tarball_url(output_root, full_tarball_files[0].name)
+
+    prefix = f"therock-dist-{platform}-"
+    suffix = ".tar.gz"
+
+    for f in full_tarball_files:
+        name = f.name
+        if name.startswith(prefix) and name.endswith(suffix):
+            stem = name[len(prefix) : -len(suffix)]
+
+            if "-" not in stem:
+                return _tarball_url(output_root, name)
+
+    return None
+
+
 def run(
     input_tarballs_dir: Path,
     run_id: str,
@@ -88,27 +126,11 @@ def run(
 
     logger.info("Uploaded %d files", count)
 
-    shared_tarball_url: str | None = None
-
-    for f in tarball_files:
-        name = f.name
-        encoded_name = quote(name, safe="")
-        if "-lite-" in name:
-            continue
-
-        if name.startswith(f"therock-dist-{platform}-multiarch-"):
-            shared_tarball_url = output_root.tarball(encoded_name).https_url
-            break
-
-        prefix = f"therock-dist-{platform}-"
-        suffix = ".tar.gz"
-
-        if name.startswith(prefix) and name.endswith(suffix):
-            stem = name[len(prefix) : -len(suffix)]
-
-            if "-" not in stem:
-                shared_tarball_url = output_root.tarball(encoded_name).https_url
-                break
+    shared_tarball_url = _select_shared_tarball_url(
+        tarball_files=tarball_files,
+        output_root=output_root,
+        platform=platform,
+    )
 
     if not shared_tarball_url:
         raise ValueError(

--- a/build_tools/github_actions/upload_tarballs.py
+++ b/build_tools/github_actions/upload_tarballs.py
@@ -50,8 +50,8 @@ def _tarball_url(output_root: WorkflowOutputRoot, name: str) -> str:
     return output_root.tarball(quote(name, safe="")).https_url
 
 
-def _is_lite_tarball(name: str) -> bool:
-    return "-lite-" in name
+def _is_test_tarball(name: str) -> bool:
+    return "-tests-" in name
 
 
 def _select_shared_tarball_url(
@@ -60,20 +60,20 @@ def _select_shared_tarball_url(
     output_root: WorkflowOutputRoot,
     platform: str,
 ) -> str | None:
-    full_tarball_files = [f for f in tarball_files if not _is_lite_tarball(f.name)]
+    shared_tarball_files = [f for f in tarball_files if not _is_test_tarball(f.name)]
 
-    for f in full_tarball_files:
+    for f in shared_tarball_files:
         name = f.name
         if name.startswith(f"therock-dist-{platform}-multiarch-"):
             return _tarball_url(output_root, name)
 
-    if len(full_tarball_files) == 1:
-        return _tarball_url(output_root, full_tarball_files[0].name)
+    if len(shared_tarball_files) == 1:
+        return _tarball_url(output_root, shared_tarball_files[0].name)
 
     prefix = f"therock-dist-{platform}-"
     suffix = ".tar.gz"
 
-    for f in full_tarball_files:
+    for f in shared_tarball_files:
         name = f.name
         if name.startswith(prefix) and name.endswith(suffix):
             stem = name[len(prefix) : -len(suffix)]

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -167,7 +167,7 @@ def extract_version_from_asset_name(
     suffix = ".tar.gz"
     if asset_name.startswith(prefix) and asset_name.endswith(suffix):
         version = asset_name[len(prefix) : -len(suffix)]
-        if version.startswith("lite-"):
+        if version.startswith("tests-"):
             return None
         return version
     return None
@@ -185,7 +185,7 @@ def list_available_nightly_gpu_families(platform_str: str = PLATFORM) -> set[str
 
     for page in paginator.paginate(Bucket=NIGHTLY_BUCKET_NAME, Prefix=prefix):
         for obj in page.get("Contents", []):
-            if "-lite-" in obj["Key"]:
+            if "-tests-" in obj["Key"]:
                 continue
             # Extract family from: therock-dist-linux-{family}-{version}.tar.gz
             match = re.match(rf"{prefix}([\w-]+)-", obj["Key"])
@@ -216,7 +216,7 @@ def _fetch_and_sort_nightly_releases(
             key = obj["Key"]
             if not key.endswith(".tar.gz"):
                 continue
-            if "-lite-" in key:
+            if "-tests-" in key:
                 continue
             version = extract_version_from_asset_name(key, artifact_group, platform_str)
             if version:

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -166,7 +166,10 @@ def extract_version_from_asset_name(
     prefix = f"therock-dist-{platform_str}-{artifact_group}-"
     suffix = ".tar.gz"
     if asset_name.startswith(prefix) and asset_name.endswith(suffix):
-        return asset_name[len(prefix) : -len(suffix)]
+        version = asset_name[len(prefix) : -len(suffix)]
+        if version.startswith("lite-"):
+            return None
+        return version
     return None
 
 
@@ -182,6 +185,8 @@ def list_available_nightly_gpu_families(platform_str: str = PLATFORM) -> set[str
 
     for page in paginator.paginate(Bucket=NIGHTLY_BUCKET_NAME, Prefix=prefix):
         for obj in page.get("Contents", []):
+            if "-lite-" in obj["Key"]:
+                continue
             # Extract family from: therock-dist-linux-{family}-{version}.tar.gz
             match = re.match(rf"{prefix}([\w-]+)-", obj["Key"])
             if match:
@@ -210,6 +215,8 @@ def _fetch_and_sort_nightly_releases(
         for obj in page.get("Contents", []):
             key = obj["Key"]
             if not key.endswith(".tar.gz"):
+                continue
+            if "-lite-" in key:
                 continue
             version = extract_version_from_asset_name(key, artifact_group, platform_str)
             if version:

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -546,6 +546,143 @@ class TestFetchStageAll(ArtifactManagerTestBase):
                 f"{name} should be fetched with --stage all",
             )
 
+    def test_fetch_exclude_components_skips_test_artifacts(self) -> None:
+        """Test that --exclude-components filters artifact components."""
+        import artifact_manager
+
+        self._create_staged_artifact("test-artifact", "lib", "generic")
+        self._create_staged_artifact("test-artifact", "test", "generic")
+        self._create_staged_artifact("test-artifact", "test", "gfx942")
+        self._create_staged_artifact("second-artifact", "run", "generic")
+        self._create_staged_artifact("second-artifact", "test", "generic")
+
+        extract_calls: list[artifact_manager.ExtractRequest] = []
+
+        def mock_extract(request: artifact_manager.ExtractRequest) -> Path:
+            extract_calls.append(request)
+            return request.output_dir
+
+        with mock.patch("artifact_manager.extract_artifact", mock_extract):
+            argv = [
+                "fetch",
+                "--stage",
+                "all",
+                "--output-dir",
+                str(self.output_dir),
+                "--topology",
+                str(self.topology_path),
+                "--local-staging-dir",
+                str(self.staging_dir),
+                "--platform",
+                TEST_PLATFORM,
+                "--run-id",
+                "local",
+                "--amdgpu-targets",
+                "gfx942",
+                "--exclude-components",
+                "test",
+            ]
+
+            artifact_manager.main(argv)
+
+        fetched_keys = [c.archive_path.name for c in extract_calls]
+        self.assertIn("test-artifact_lib_generic.tar.zst", fetched_keys)
+        self.assertIn("second-artifact_run_generic.tar.zst", fetched_keys)
+        self.assertFalse(
+            any("_test_" in key for key in fetched_keys),
+            f"Should not fetch test artifacts, got: {fetched_keys}",
+        )
+
+    def test_fetch_exclude_components_rejects_unknown_component(self) -> None:
+        """Test that --exclude-components validates component names."""
+        import artifact_manager
+
+        self._create_staged_artifact("test-artifact", "lib", "generic")
+
+        argv = [
+            "fetch",
+            "--stage",
+            "all",
+            "--output-dir",
+            str(self.output_dir),
+            "--topology",
+            str(self.topology_path),
+            "--local-staging-dir",
+            str(self.staging_dir),
+            "--platform",
+            TEST_PLATFORM,
+            "--run-id",
+            "local",
+            "--exclude-components",
+            "unknown",
+        ]
+
+        with self.assertRaises(ValueError):
+            artifact_manager.main(argv)
+
+    def test_fetch_exclude_artifacts_skips_named_artifacts(self) -> None:
+        """Test that --exclude-artifacts filters whole artifacts."""
+        import artifact_manager
+
+        self._create_staged_artifact("test-artifact", "lib", "generic")
+        self._create_staged_artifact("second-artifact", "lib", "generic")
+
+        extract_calls: list[artifact_manager.ExtractRequest] = []
+
+        def mock_extract(request: artifact_manager.ExtractRequest) -> Path:
+            extract_calls.append(request)
+            return request.output_dir
+
+        with mock.patch("artifact_manager.extract_artifact", mock_extract):
+            argv = [
+                "fetch",
+                "--stage",
+                "all",
+                "--output-dir",
+                str(self.output_dir),
+                "--topology",
+                str(self.topology_path),
+                "--local-staging-dir",
+                str(self.staging_dir),
+                "--platform",
+                TEST_PLATFORM,
+                "--run-id",
+                "local",
+                "--exclude-artifacts",
+                "second-artifact",
+            ]
+
+            artifact_manager.main(argv)
+
+        fetched_keys = [c.archive_path.name for c in extract_calls]
+        self.assertIn("test-artifact_lib_generic.tar.zst", fetched_keys)
+        self.assertNotIn("second-artifact_lib_generic.tar.zst", fetched_keys)
+
+    def test_fetch_exclude_artifacts_rejects_unknown_artifact(self) -> None:
+        """Test that --exclude-artifacts validates artifact names."""
+        import artifact_manager
+
+        argv = [
+            "fetch",
+            "--stage",
+            "all",
+            "--output-dir",
+            str(self.output_dir),
+            "--topology",
+            str(self.topology_path),
+            "--local-staging-dir",
+            str(self.staging_dir),
+            "--platform",
+            TEST_PLATFORM,
+            "--run-id",
+            "local",
+            "--exclude-artifacts",
+            "unknown-artifact",
+        ]
+
+        with self.assertRaises(ValueError):
+            artifact_manager.main(argv)
+
 
 class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
     """Tests that fetch command correctly handles --amdgpu-targets for split artifacts."""

--- a/build_tools/tests/build_tarballs_test.py
+++ b/build_tools/tests/build_tarballs_test.py
@@ -118,7 +118,7 @@ class TestMain(unittest.TestCase):
                         main(argv)
         return MainMocks(fetch_mock, compress_mock, kpack_mock)
 
-    def test_default_builds_full_tarballs_only(self) -> None:
+    def test_default_builds_tarballs_without_tests_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "tarballs"
             fetch_mock, compress_mock, _ = self._run_main_with_mocks(
@@ -132,7 +132,8 @@ class TestMain(unittest.TestCase):
             )
 
         self.assertEqual(fetch_mock.call_count, 1)
-        self.assertNotIn("exclude_components", fetch_mock.call_args.kwargs)
+        self.assertEqual(fetch_mock.call_args.kwargs["exclude_components"], ["test"])
+        self.assertEqual(fetch_mock.call_args.kwargs["exclude_artifacts"], ["fftw3"])
 
         compressed_names = [
             call.kwargs["tarball_path"].name for call in compress_mock.call_args_list
@@ -142,7 +143,7 @@ class TestMain(unittest.TestCase):
             ["therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz"],
         )
 
-    def test_include_lite_tarballs_builds_both_sets(self) -> None:
+    def test_include_test_tarballs_builds_both_sets(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "tarballs"
             fetch_mock, compress_mock, _ = self._run_main_with_mocks(
@@ -152,19 +153,19 @@ class TestMain(unittest.TestCase):
                     "--platform=linux",
                     "--package-version=7.13.0",
                     f"--output-dir={output_dir}",
-                    "--include-lite-tarballs",
+                    "--include-test-tarballs",
                 ]
             )
 
         self.assertEqual(fetch_mock.call_count, 2)
-        self.assertNotIn("exclude_components", fetch_mock.call_args_list[0].kwargs)
-        self.assertNotIn("exclude_artifacts", fetch_mock.call_args_list[0].kwargs)
         self.assertEqual(
-            fetch_mock.call_args_list[1].kwargs["exclude_components"], ["test"]
+            fetch_mock.call_args_list[0].kwargs["exclude_components"], ["test"]
         )
         self.assertEqual(
-            fetch_mock.call_args_list[1].kwargs["exclude_artifacts"], ["fftw3"]
+            fetch_mock.call_args_list[0].kwargs["exclude_artifacts"], ["fftw3"]
         )
+        self.assertNotIn("exclude_components", fetch_mock.call_args_list[1].kwargs)
+        self.assertNotIn("exclude_artifacts", fetch_mock.call_args_list[1].kwargs)
 
         compressed_names = [
             call.kwargs["tarball_path"].name for call in compress_mock.call_args_list
@@ -173,11 +174,11 @@ class TestMain(unittest.TestCase):
             compressed_names,
             [
                 "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz",
-                "therock-dist-linux-gfx94X-dcgpu-lite-7.13.0.tar.gz",
+                "therock-dist-linux-gfx94X-dcgpu-tests-7.13.0.tar.gz",
             ],
         )
 
-    def test_include_lite_tarballs_builds_kpack_multiarch_variant(self) -> None:
+    def test_include_test_tarballs_builds_kpack_multiarch_variant(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "tarballs"
             fetch_mock, compress_mock, _ = self._run_main_with_mocks(
@@ -187,18 +188,20 @@ class TestMain(unittest.TestCase):
                     "--platform=linux",
                     "--package-version=7.13.0",
                     f"--output-dir={output_dir}",
-                    "--include-lite-tarballs",
+                    "--include-test-tarballs",
                 ],
                 kpack_split=True,
             )
 
         self.assertEqual(fetch_mock.call_count, 6)
         self.assertEqual(
-            fetch_mock.call_args_list[-1].kwargs["exclude_components"], ["test"]
+            fetch_mock.call_args_list[-2].kwargs["exclude_components"], ["test"]
         )
         self.assertEqual(
-            fetch_mock.call_args_list[-1].kwargs["exclude_artifacts"], ["fftw3"]
+            fetch_mock.call_args_list[-2].kwargs["exclude_artifacts"], ["fftw3"]
         )
+        self.assertNotIn("exclude_components", fetch_mock.call_args_list[-1].kwargs)
+        self.assertNotIn("exclude_artifacts", fetch_mock.call_args_list[-1].kwargs)
 
         compressed_names = [
             call.kwargs["tarball_path"].name for call in compress_mock.call_args_list
@@ -207,11 +210,11 @@ class TestMain(unittest.TestCase):
             compressed_names,
             [
                 "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz",
-                "therock-dist-linux-gfx94X-dcgpu-lite-7.13.0.tar.gz",
+                "therock-dist-linux-gfx94X-dcgpu-tests-7.13.0.tar.gz",
                 "therock-dist-linux-gfx110X-all-7.13.0.tar.gz",
-                "therock-dist-linux-gfx110X-all-lite-7.13.0.tar.gz",
+                "therock-dist-linux-gfx110X-all-tests-7.13.0.tar.gz",
                 "therock-dist-linux-multiarch-7.13.0.tar.gz",
-                "therock-dist-linux-multiarch-lite-7.13.0.tar.gz",
+                "therock-dist-linux-multiarch-tests-7.13.0.tar.gz",
             ],
         )
 

--- a/build_tools/tests/build_tarballs_test.py
+++ b/build_tools/tests/build_tarballs_test.py
@@ -7,11 +7,48 @@ import sys
 import tarfile
 import tempfile
 import unittest
+from collections.abc import Callable
+from concurrent.futures import Future
 from pathlib import Path
+from types import TracebackType
+from typing import NamedTuple
+from unittest import mock
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
-from build_tarballs import compress_tarball, is_kpack_split
+from build_tarballs import compress_tarball, is_kpack_split, main
+
+
+class MainMocks(NamedTuple):
+    fetch: mock.Mock
+    compress: mock.Mock
+    kpack: mock.Mock
+
+
+class InlineProcessPoolExecutor:
+    def __init__(self, max_workers: int | None = None) -> None:
+        self.max_workers = max_workers
+
+    def __enter__(self) -> "InlineProcessPoolExecutor":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
+        return False
+
+    def submit(
+        self,
+        fn: Callable[..., object],
+        *args: object,
+        **kwargs: object,
+    ) -> Future[object]:
+        future: Future[object] = Future()
+        future.set_result(fn(*args, **kwargs))
+        return future
 
 
 class TestIsKpackSplit(unittest.TestCase):
@@ -59,6 +96,124 @@ class TestCompressTarball(unittest.TestCase):
                 names = tf.getnames()
                 self.assertIn("./bin/hello", names)
                 self.assertIn("./lib/libfoo.so", names)
+
+
+class TestMain(unittest.TestCase):
+    def _run_main_with_mocks(
+        self,
+        argv: list[str],
+        *,
+        kpack_split: bool = False,
+    ) -> MainMocks:
+        patches = [
+            mock.patch("build_tarballs.fetch_and_flatten"),
+            mock.patch("build_tarballs.compress_tarball"),
+            mock.patch("build_tarballs.is_kpack_split", return_value=kpack_split),
+            mock.patch("build_tarballs.ProcessPoolExecutor", InlineProcessPoolExecutor),
+        ]
+        with patches[0] as fetch_mock:
+            with patches[1] as compress_mock:
+                with patches[2] as kpack_mock:
+                    with patches[3]:
+                        main(argv)
+        return MainMocks(fetch_mock, compress_mock, kpack_mock)
+
+    def test_default_builds_full_tarballs_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "tarballs"
+            fetch_mock, compress_mock, _ = self._run_main_with_mocks(
+                [
+                    "--run-id=123",
+                    "--dist-amdgpu-families=gfx94X-dcgpu",
+                    "--platform=linux",
+                    "--package-version=7.13.0",
+                    f"--output-dir={output_dir}",
+                ]
+            )
+
+        self.assertEqual(fetch_mock.call_count, 1)
+        self.assertNotIn("exclude_components", fetch_mock.call_args.kwargs)
+
+        compressed_names = [
+            call.kwargs["tarball_path"].name for call in compress_mock.call_args_list
+        ]
+        self.assertEqual(
+            compressed_names,
+            ["therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz"],
+        )
+
+    def test_include_lite_tarballs_builds_both_sets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "tarballs"
+            fetch_mock, compress_mock, _ = self._run_main_with_mocks(
+                [
+                    "--run-id=123",
+                    "--dist-amdgpu-families=gfx94X-dcgpu",
+                    "--platform=linux",
+                    "--package-version=7.13.0",
+                    f"--output-dir={output_dir}",
+                    "--include-lite-tarballs",
+                ]
+            )
+
+        self.assertEqual(fetch_mock.call_count, 2)
+        self.assertNotIn("exclude_components", fetch_mock.call_args_list[0].kwargs)
+        self.assertNotIn("exclude_artifacts", fetch_mock.call_args_list[0].kwargs)
+        self.assertEqual(
+            fetch_mock.call_args_list[1].kwargs["exclude_components"], ["test"]
+        )
+        self.assertEqual(
+            fetch_mock.call_args_list[1].kwargs["exclude_artifacts"], ["fftw3"]
+        )
+
+        compressed_names = [
+            call.kwargs["tarball_path"].name for call in compress_mock.call_args_list
+        ]
+        self.assertEqual(
+            compressed_names,
+            [
+                "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz",
+                "therock-dist-linux-gfx94X-dcgpu-lite-7.13.0.tar.gz",
+            ],
+        )
+
+    def test_include_lite_tarballs_builds_kpack_multiarch_variant(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "tarballs"
+            fetch_mock, compress_mock, _ = self._run_main_with_mocks(
+                [
+                    "--run-id=123",
+                    "--dist-amdgpu-families=gfx94X-dcgpu;gfx110X-all",
+                    "--platform=linux",
+                    "--package-version=7.13.0",
+                    f"--output-dir={output_dir}",
+                    "--include-lite-tarballs",
+                ],
+                kpack_split=True,
+            )
+
+        self.assertEqual(fetch_mock.call_count, 6)
+        self.assertEqual(
+            fetch_mock.call_args_list[-1].kwargs["exclude_components"], ["test"]
+        )
+        self.assertEqual(
+            fetch_mock.call_args_list[-1].kwargs["exclude_artifacts"], ["fftw3"]
+        )
+
+        compressed_names = [
+            call.kwargs["tarball_path"].name for call in compress_mock.call_args_list
+        ]
+        self.assertEqual(
+            compressed_names,
+            [
+                "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz",
+                "therock-dist-linux-gfx94X-dcgpu-lite-7.13.0.tar.gz",
+                "therock-dist-linux-gfx110X-all-7.13.0.tar.gz",
+                "therock-dist-linux-gfx110X-all-lite-7.13.0.tar.gz",
+                "therock-dist-linux-multiarch-7.13.0.tar.gz",
+                "therock-dist-linux-multiarch-lite-7.13.0.tar.gz",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/install_rocm_from_artifacts_test.py
+++ b/build_tools/tests/install_rocm_from_artifacts_test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for install_rocm_from_artifacts.py."""
+
+from datetime import datetime
+from pathlib import Path
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+import install_rocm_from_artifacts as mod
+
+
+class TestReleaseDiscovery(unittest.TestCase):
+    def test_extract_version_ignores_lite_tarball(self) -> None:
+        self.assertIsNone(
+            mod.extract_version_from_asset_name(
+                "therock-dist-linux-gfx94X-dcgpu-lite-7.13.0.tar.gz",
+                "gfx94X-dcgpu",
+                "linux",
+            )
+        )
+
+    def test_fetch_and_sort_nightly_releases_ignores_lite_tarballs(self) -> None:
+        paginator = mock.Mock()
+        paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {
+                        "Key": (
+                            "therock-dist-linux-gfx94X-dcgpu-lite-"
+                            "7.13.0a20260102.tar.gz"
+                        ),
+                        "LastModified": datetime(2026, 1, 2),
+                        "Size": 20,
+                    },
+                    {
+                        "Key": "therock-dist-linux-gfx94X-dcgpu-7.13.0a20260101.tar.gz",
+                        "LastModified": datetime(2026, 1, 1),
+                        "Size": 10,
+                    },
+                ]
+            }
+        ]
+        s3_client = mock.Mock()
+        s3_client.get_paginator.return_value = paginator
+
+        with mock.patch.object(mod, "s3_client", s3_client):
+            releases = mod._fetch_and_sort_nightly_releases("gfx94X-dcgpu", "linux")
+
+        self.assertEqual(
+            [release["asset_name"] for release in releases],
+            ["therock-dist-linux-gfx94X-dcgpu-7.13.0a20260101.tar.gz"],
+        )
+
+    def test_list_available_nightly_gpu_families_ignores_lite_tarballs(self) -> None:
+        paginator = mock.Mock()
+        paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz"},
+                    {"Key": ("therock-dist-linux-gfx94X-dcgpu-lite-" "7.13.0.tar.gz")},
+                ]
+            }
+        ]
+        s3_client = mock.Mock()
+        s3_client.get_paginator.return_value = paginator
+
+        with mock.patch.object(mod, "s3_client", s3_client):
+            families = mod.list_available_nightly_gpu_families("linux")
+
+        self.assertEqual(families, {"gfx94X-dcgpu"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/tests/install_rocm_from_artifacts_test.py
+++ b/build_tools/tests/install_rocm_from_artifacts_test.py
@@ -17,23 +17,23 @@ import install_rocm_from_artifacts as mod
 
 
 class TestReleaseDiscovery(unittest.TestCase):
-    def test_extract_version_ignores_lite_tarball(self) -> None:
+    def test_extract_version_ignores_test_tarball(self) -> None:
         self.assertIsNone(
             mod.extract_version_from_asset_name(
-                "therock-dist-linux-gfx94X-dcgpu-lite-7.13.0.tar.gz",
+                "therock-dist-linux-gfx94X-dcgpu-tests-7.13.0.tar.gz",
                 "gfx94X-dcgpu",
                 "linux",
             )
         )
 
-    def test_fetch_and_sort_nightly_releases_ignores_lite_tarballs(self) -> None:
+    def test_fetch_and_sort_nightly_releases_ignores_test_tarballs(self) -> None:
         paginator = mock.Mock()
         paginator.paginate.return_value = [
             {
                 "Contents": [
                     {
                         "Key": (
-                            "therock-dist-linux-gfx94X-dcgpu-lite-"
+                            "therock-dist-linux-gfx94X-dcgpu-tests-"
                             "7.13.0a20260102.tar.gz"
                         ),
                         "LastModified": datetime(2026, 1, 2),
@@ -58,13 +58,13 @@ class TestReleaseDiscovery(unittest.TestCase):
             ["therock-dist-linux-gfx94X-dcgpu-7.13.0a20260101.tar.gz"],
         )
 
-    def test_list_available_nightly_gpu_families_ignores_lite_tarballs(self) -> None:
+    def test_list_available_nightly_gpu_families_ignores_test_tarballs(self) -> None:
         paginator = mock.Mock()
         paginator.paginate.return_value = [
             {
                 "Contents": [
                     {"Key": "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz"},
-                    {"Key": ("therock-dist-linux-gfx94X-dcgpu-lite-" "7.13.0.tar.gz")},
+                    {"Key": ("therock-dist-linux-gfx94X-dcgpu-tests-" "7.13.0.tar.gz")},
                 ]
             }
         ]


### PR DESCRIPTION
## Motivation

This teaches the stage-aware artifact fetch path to exclude selected
artifact components and whole artifacts. This is used to generate
tarballs which do not contain test artifacts and fftw3. Tarballs with
tests are generated in addition to those.

JIRA ID: ROCM-26486

## Technical Details

The script now creates test-less tarballs by default, whereas the reusable
workflow enables test tarballs by default in release automation.

Right now this excludes `_test` artifacts but some test files seem to
come in via other artifacts which needs to be addressed in a follow
up.

The naming explicitly not follow the draft RFC #4438, which was not
landed yet, after an internal discussion.

## Test Plan

* https://github.com/ROCm/TheRock/actions/runs/28102279885

## Test Result

* https://therock-dev-artifacts.s3.amazonaws.com/28102279885-linux/tarballs/index.html

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
