### PR TITLE
fix(ci): Add BUILD_VARIANT env var for ASAN test skipping

### DIFF
--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -148,6 +148,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      build_variant: ${{ fromJSON(inputs.build_config).build_variant_label }}
 
   build_native_deb_packages:
     needs: [build_multi_arch_stages]

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -51,6 +51,13 @@ on:
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
+      build_variant:
+        description: "Build variant (e.g., release, asan)."
+        type: choice
+        options:
+          - release
+          - asan
+        default: release
   workflow_call:
     inputs:
       artifact_group:
@@ -94,6 +101,10 @@ on:
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
+      build_variant:
+        description: "Build variant (e.g., release, asan)."
+        type: string
+        default: "release"
   push:
     branches:
       - ADHOCBUILD
@@ -167,6 +178,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      build_variant: ${{ inputs.build_variant }}
 
   test_components:
     name: 'Test ${{ matrix.components.job_name }}'
@@ -219,3 +231,4 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      build_variant: ${{ inputs.build_variant }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -31,6 +31,10 @@ on:
       ref:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
+      build_variant:
+        description: "Build variant (e.g., release, asan). Used to skip tests incompatible with certain builds."
+        type: string
+        default: "release"
       default_container_image:
         type: string
         default: "ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98"
@@ -78,6 +82,7 @@ jobs:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       AMDGPU_TARGETS: ${{ inputs.amdgpu_targets }}
       ARTIFACT_GROUP: ${{ inputs.artifact_group }}
+      BUILD_VARIANT: ${{ inputs.build_variant }}
       # Benchmark results database API endpoints for performance metrics collection
       # NOTE: These secrets are only required for benchmark results submission in nightly CI runs.
       # For PR/push workflows, secret retrieval will fail gracefully and benchmarks will skip API submission.

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -21,7 +21,14 @@ TODO(#2200): clarify AMD GPU family selection
 # NOTE: when doing changes here, also check that they are done in new_amdgpu_family_matrix.py
 #############################################################################################
 
+import os
 import random
+
+
+def is_asan():
+    """Determines if this is an ASAN build using BUILD_VARIANT env var."""
+    BUILD_VARIANT = os.getenv("BUILD_VARIANT", "")
+    return BUILD_VARIANT == "asan"
 
 
 def select_weighted_label(labels_config: list[dict], context_name: str) -> str:

--- a/build_tools/github_actions/github_actions_api.py
+++ b/build_tools/github_actions/github_actions_api.py
@@ -773,6 +773,6 @@ def get_first_gpu_architecture(env=None, therock_bin_dir: str | None = None) -> 
 
 
 def is_asan():
-    """Using artifact_group, determines if this is an asan build"""
-    ARTIFACT_GROUP = os.getenv("ARTIFACT_GROUP", "")
-    return "asan" in ARTIFACT_GROUP
+    """Determines if this is an ASAN build using BUILD_VARIANT env var."""
+    BUILD_VARIANT = os.getenv("BUILD_VARIANT", "")
+    return BUILD_VARIANT == "asan"

--- a/build_tools/github_actions/github_actions_api.py
+++ b/build_tools/github_actions/github_actions_api.py
@@ -770,9 +770,3 @@ def get_first_gpu_architecture(env=None, therock_bin_dir: str | None = None) -> 
             logging.info(f"Detected GPU architecture: {gpu_arch}")
             return gpu_arch
     raise RuntimeError("No GPU architecture found in rocminfo output")
-
-
-def is_asan():
-    """Determines if this is an ASAN build using BUILD_VARIANT env var."""
-    BUILD_VARIANT = os.getenv("BUILD_VARIANT", "")
-    return BUILD_VARIANT == "asan"

--- a/build_tools/github_actions/test_executable_scripts/test_hipblas.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblas.py
@@ -12,9 +12,9 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
-# Importing is_asan from github_actions_api.py
+# Importing is_asan from amdgpu_family_matrix.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
-from github_actions_api import is_asan
+from amdgpu_family_matrix import is_asan
 
 # GTest sharding
 SHARD_INDEX = os.getenv("SHARD_INDEX", 1)

--- a/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipblaslt.py
@@ -14,9 +14,9 @@ platform = os.getenv("RUNNER_OS").lower()
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
-# Importing is_asan from github_actions_api.py
+# Importing is_asan from amdgpu_family_matrix.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
-from github_actions_api import is_asan
+from amdgpu_family_matrix import is_asan
 
 logging.basicConfig(level=logging.INFO)
 

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -24,9 +24,9 @@ TEST_TYPE = os.getenv("TEST_TYPE", "standard")
 os_type = platform.system().lower()
 CATCH_TESTS_PATH = str(Path(THEROCK_BIN_DIR).parent / "share" / "hip" / "catch_tests")
 
-# Importing is_asan from github_actions_api.py
+# Importing is_asan from amdgpu_family_matrix.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
-from github_actions_api import is_asan
+from amdgpu_family_matrix import is_asan
 
 env = os.environ.copy()
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocblas.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocblas.py
@@ -12,9 +12,9 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
-# Importing is_asan from github_actions_api.py
+# Importing is_asan from amdgpu_family_matrix.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
-from github_actions_api import is_asan
+from amdgpu_family_matrix import is_asan
 
 # GTest sharding
 SHARD_INDEX = os.getenv("SHARD_INDEX", 1)

--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_sdk.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_sdk.py
@@ -12,7 +12,7 @@ import sys
 SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))
-from github_actions_api import is_asan
+from amdgpu_family_matrix import is_asan
 
 # Base Paths
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")

--- a/tests/test_rocm_sanity.py
+++ b/tests/test_rocm_sanity.py
@@ -20,9 +20,9 @@ THEROCK_BIN_DIR = Path(os.getenv("THEROCK_BIN_DIR")).resolve()
 
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 
-# Importing is_asan from github_actions_api.py
+# Importing is_asan from amdgpu_family_matrix.py
 sys.path.append(str(THIS_DIR.parent / "build_tools" / "github_actions"))
-from github_actions_api import is_asan
+from amdgpu_family_matrix import is_asan
 
 
 def is_windows():


### PR DESCRIPTION
The is_asan() function was checking ARTIFACT_GROUP which doesn't contain "asan" for ASAN builds. Add BUILD_VARIANT input/env var through the workflow chain and update is_asan() to check it.

Fixes test skipping for ASAN builds (hipcc, rocminfo tests).