### PR TITLE
fix(packaging): preserve Gfxarch behavior for metapackages in kpack mode

### DIFF
--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -265,6 +265,9 @@ def is_gfxarch_package(
 
     # In kpack mode, verify arch-specific artifacts exist
     if enable_kpack:
+        # Metapackages don't have artifacts but should still respect Gfxarch metadata
+        if is_meta_package(pkg_info):
+            return is_key_defined(pkg_info, "Gfxarch")
         if artifacts_dir:
             return _has_arch_specific_artifacts(pkg_info, artifacts_dir)
         # Do not fall through to Gfxarch metadata: without artifacts we cannot treat


### PR DESCRIPTION
  Metapackages (like amdrocm-core-sdk) have no artifacts of their own,
  so artifact-based gfxarch detection returns False for them. This
  causes metapackage dependency expansion to fail - instead of depending
  on gfx-specific variants (amdrocm-core-sdk7.14-gfx1100, etc.), the
  metapackage only depends on the raw DEBDepends list.

  Fix by checking is_meta_package() before artifact verification and
  using Gfxarch metadata directly for metapackages.

Jira ID: https://github.com/ROCm/TheRock/issues/6093
