### PR TITLE
fix: Add xnack variant support to Linux native packaging

### DIFF
--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -95,7 +95,9 @@ def get_all_target_families(artifact_dir):
 
     # Use ArtifactCatalog from _therock_utils to get all target families
     catalog = ArtifactCatalog(artifact_dir)
-    return sorted(catalog.all_target_families)
+    # Strip xnack suffixes (e.g., gfx942:xnack+ -> gfx942)
+    targets = {t.split(":", 1)[0] for t in catalog.all_target_families}
+    return sorted(targets)
 
 
 ################### Package Variant Builders #######################

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -51,7 +51,7 @@ def normalize_target_list(
         raw = [str(a) for a in value]
 
     tokens = [
-        tok.lower() if lowercase else tok
+        (tok.split(":", 1)[0].lower() if lowercase else tok.split(":", 1)[0])
         for item in raw
         for tok in _GFX_ARCH_SPLIT_RE.split(item)
         if tok
@@ -927,30 +927,32 @@ def filter_components_fromartifactory(
             component_list = subdir["Components"]
 
             for component in component_list:
-                source_dir = (
-                    Path(artifacts_dir)
-                    / f"{artifact_prefix}_{component}_{artifact_suffix}"
-                )
-                filename = source_dir / "artifact_manifest.txt"
-                if not filename.exists():
-                    print(f"{pkg_name} : Missing {filename}")
-                    continue
-                try:
-                    with filename.open("r", encoding="utf-8") as file:
-                        for line in file:
+                # Find base artifact and all xnack variants (e.g., :xnack+, :xnack-)
+                base_pattern = f"{artifact_prefix}_{component}_{artifact_suffix}"
+                artifact_dirs = [Path(artifacts_dir) / base_pattern]
+                artifact_dirs.extend(Path(artifacts_dir).glob(f"{base_pattern}:*"))
 
-                            match_found = (
-                                isinstance(artifact_subdir, str)
-                                and (artifact_subdir.lower() + "/") in line.lower()
-                            )
+                for source_dir in artifact_dirs:
+                    filename = source_dir / "artifact_manifest.txt"
+                    if not filename.exists():
+                        print(f"{pkg_name} : Missing {filename}")
+                        continue
+                    try:
+                        with filename.open("r", encoding="utf-8") as file:
+                            for line in file:
 
-                            if match_found and line.strip():
-                                print("Matching line:", line.strip())
-                                source_path = source_dir / line.strip()
-                                sourcedir_list.append(source_path)
-                except OSError as e:
-                    print(f"Could not read manifest {filename}: {e}")
-                    continue
+                                match_found = (
+                                    isinstance(artifact_subdir, str)
+                                    and (artifact_subdir.lower() + "/") in line.lower()
+                                )
+
+                                if match_found and line.strip():
+                                    print("Matching line:", line.strip())
+                                    source_path = source_dir / line.strip()
+                                    sourcedir_list.append(source_path)
+                    except OSError as e:
+                        print(f"Could not read manifest {filename}: {e}")
+                        continue
 
     return sourcedir_list
 


### PR DESCRIPTION
ROCm builds for certain GPUs (e.g., gfx942) produce separate artifact
  directories for each xnack variant (:xnack+, :xnack-). Previously,
  packaging would only collect from one directory, missing variant artifacts.

  Unify all xnack variants into a single package per GPU target by:
  - Stripping xnack suffixes from target names for package naming
    (gfx942:xnack+ -> gfx942)
  - Globbing all variant directories during artifact collection

  This gives users one package that works regardless of xnack configuration

  Changes:
  - build_package.py: Strip xnack suffixes from discovered target families
  - packaging_utils.py: Strip xnack suffixes in target list normalization
  - packaging_utils.py: Glob for xnack variant artifact directories (:xnack+, :xnack-)

Jira ID: https://github.com/ROCm/TheRock/issues/6099

