### PR TITLE
fix(ci): use $GITHUB_WORKSPACE in artifact fetch output-dir for kube-mode runners

### DIFF
--- a/.github/workflows/test_artifacts_structure.yml
+++ b/.github/workflows/test_artifacts_structure.yml
@@ -97,7 +97,7 @@ jobs:
             --stage=all \
             --amdgpu-families="${{ inputs.amdgpu_families }}" \
             --platform="${{ env.PLATFORM }}" \
-            --output-dir="${{ github.workspace }}" \
+            --output-dir="${GITHUB_WORKSPACE}" \
             --no-extract
           # NOTE: artifact_manager.py appends /.download_cache to --output-dir
           # in --no-extract mode, so pass workspace root here so that


### PR DESCRIPTION
ISSUE ID #6061

## Problem

`Validate artifact structure` was failing on AWS kube-mode runners but passing on Azure.

On kube-mode runners, each step without a job-level `container:` block runs in its own short-lived container. The work PVC is mounted at `/__w/` inside step containers.

The fetch step used `--output-dir="${{ github.workspace }}"`. This is a GHA template expression evaluated by the runner pod at **template expansion time** — before any shell runs in a container. The runner substitutes its own view of the path (`/home/runner/_work/TheRock/TheRock`), baking that literal string into the script.

Inside the step container, `/home/runner/_work/` is not on the shared PVC. `artifact_manager.py` creates `.download_cache` there on ephemeral local storage that disappears when the step container exits.

The next step (validate) runs in a new container. `THEROCK_ARTIFACTS_DIR` is a job-level env var — the ARC runner translates it to `/__w/TheRock/TheRock/.download_cache` when injecting it into the container. The test checks that path on the PVC, which was never written to.

On Azure, `${{ github.workspace }}` and `$GITHUB_WORKSPACE` resolve to the same path — no translation happens and the test passes.

## Fix

Changed `--output-dir="${{ github.workspace }}"` to `--output-dir="${GITHUB_WORKSPACE}"`.

`$GITHUB_WORKSPACE` is a shell env var evaluated at **shell execution time** inside the container. The ARC runner injects it with the container-translated value (`/__w/TheRock/TheRock`), so `artifact_manager.py` downloads to `/__w/TheRock/TheRock/.download_cache` on the shared PVC — the same path the validate step checks.

## Verified

Dispatched `test_artifacts_structure.yml` from this branch with the inputs from the original failing run (`artifact_run_id=28036338651`, `platform=windows`, `amdgpu_families=gfx110X-all;gfx1151;gfx120X-all`) — [run passed](https://github.com/ROCm/TheRock/actions/runs/28121123281).

Closes #6061