### PR TITLE
Use a static seed for FFT randomized test selection

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hipfft.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipfft.py
@@ -29,11 +29,18 @@ if test_type == "quick":
 else:
     # Standard/comprehensive: "--test_prob" is the probability that a given test will run.
     # Due to the large number of tests for hipFFT, we only run a subset.
+    # On a standard workstation, --test_prob=0.01 takes about 1 minute.
+    # The option --precompile=precompiled.db reduces test time by more
+    # efficiently parallelizing runtime compilation.
     test_filter = [
         "--gtest_filter=-*multi_gpu*",
         "--test_prob",
         "0.01",
+        "--precompile=precompiled.db",
+        "--seed=0"
     ]
+    # Setting the static seed is a temporary measure to help the
+    # therock CI team understand the variation in test execution time.
 
 cmd = [f"{THEROCK_BIN_DIR}/hipfft-test"] + test_filter
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")

--- a/build_tools/github_actions/test_executable_scripts/test_hipfft.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipfft.py
@@ -32,15 +32,15 @@ else:
     # On a standard workstation, --test_prob=0.01 takes about 1 minute.
     # The option --precompile=precompiled.db reduces test time by more
     # efficiently parallelizing runtime compilation.
+    # Setting the static seed is a temporary measure to help the
+    # therock CI team understand the variation in test execution time.
     test_filter = [
         "--gtest_filter=-*multi_gpu*",
         "--test_prob",
         "0.01",
         "--precompile=precompiled.db",
-        "--seed=0"
+        "--seed=0",
     ]
-    # Setting the static seed is a temporary measure to help the
-    # therock CI team understand the variation in test execution time.
 
 cmd = [f"{THEROCK_BIN_DIR}/hipfft-test"] + test_filter
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")

--- a/build_tools/github_actions/test_executable_scripts/test_hipfft.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipfft.py
@@ -30,15 +30,12 @@ else:
     # Standard/comprehensive: "--test_prob" is the probability that a given test will run.
     # Due to the large number of tests for hipFFT, we only run a subset.
     # On a standard workstation, --test_prob=0.01 takes about 1 minute.
-    # The option --precompile=precompiled.db reduces test time by more
-    # efficiently parallelizing runtime compilation.
     # Setting the static seed is a temporary measure to help the
     # therock CI team understand the variation in test execution time.
     test_filter = [
         "--gtest_filter=-*multi_gpu*",
         "--test_prob",
         "0.01",
-        "--precompile=precompiled.db",
         "--seed=0",
     ]
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocfft.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocfft.py
@@ -30,15 +30,12 @@ else:
     # Standard/comprehensive: "--test_prob" is the probability that a given test will run.
     # Due to the large number of tests for rocFFT, we only run a subset.
     # On a standard workstation, --test_prob=0.02 takes about 20 minutes.
-    # The option --precompile=precompiled.db reduces test time by more
-    # efficiently parallelizing runtime compilation.
     # Setting the static seed is a temporary measure to help the
     # therock CI team understand the variation in test execution time.
     test_filter = [
         "--gtest_filter=-*multi_gpu*",
         "--test_prob",
         "0.02",
-        "--precompile=precompiled.db",
         "--seed=0",
     ]
 

--- a/build_tools/github_actions/test_executable_scripts/test_rocfft.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocfft.py
@@ -29,11 +29,18 @@ if test_type == "quick":
 else:
     # Standard/comprehensive: "--test_prob" is the probability that a given test will run.
     # Due to the large number of tests for rocFFT, we only run a subset.
+    # On a standard workstation, --test_prob=0.02 takes about 20 minutes.
+    # The option --precompile=precompiled.db reduces test time by more
+    # efficiently parallelizing runtime compilation.
     test_filter = [
         "--gtest_filter=-*multi_gpu*",
         "--test_prob",
         "0.02",
+        "--precompile=precompiled.db",
+        "--seed=0"
     ]
+    # Setting the static seed is a temporary measure to help the
+    # therock CI team understand the variation in test execution time.
 
 cmd = [f"{THEROCK_BIN_DIR}/rocfft-test"] + test_filter
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")

--- a/build_tools/github_actions/test_executable_scripts/test_rocfft.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocfft.py
@@ -32,15 +32,15 @@ else:
     # On a standard workstation, --test_prob=0.02 takes about 20 minutes.
     # The option --precompile=precompiled.db reduces test time by more
     # efficiently parallelizing runtime compilation.
+    # Setting the static seed is a temporary measure to help the
+    # therock CI team understand the variation in test execution time.
     test_filter = [
         "--gtest_filter=-*multi_gpu*",
         "--test_prob",
         "0.02",
         "--precompile=precompiled.db",
-        "--seed=0"
+        "--seed=0",
     ]
-    # Setting the static seed is a temporary measure to help the
-    # therock CI team understand the variation in test execution time.
 
 cmd = [f"{THEROCK_BIN_DIR}/rocfft-test"] + test_filter
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")


### PR DESCRIPTION
Add, as a temporary measure, a static seed for fft tests.

## Objective

The objective is to reduce test time variation for rocfft/hipfft tests as a temporary measure.

## Technical Details

This adds a static seed for randomized test selection, as a temporary measure, in order to aid the CI team in understanding test time variation.

## Test Plan

Normal CI tests should cover.

## Test Result

Tests will be run.

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
