### PR TITLE
fix: Split WSL DXG library into separate amdrocm-wsl package

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -447,6 +447,17 @@ sudo dnf install amdrocm-core-sdk
 ROCm supports WSL via the DXG kernel interface. DXG detection is enabled by
 default as of rocm-systems@901f9a5 — no environment variable setup is required.
 
+To use ROCm on WSL, install the optional `amdrocm-wsl` package which provides
+the DXG support library:
+
+```bash
+# For Debian/Ubuntu:
+sudo apt install amdrocm-wsl
+
+# For RHEL/CentOS/Fedora:
+sudo dnf install amdrocm-wsl
+```
+
 To explicitly disable DXG detection, set:
 
 ```bash

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -291,6 +291,41 @@
     "Gfxarch": "False"
   },
   {
+    "Package": "amdrocm-wsl-devel",
+    "Version": "",
+    "Architecture": "amd64",
+    "BuildArch": "x86_64",
+    "DEBDepends": [
+      "amdrocm-wsl"
+    ],
+    "RPMRequires": [
+      "amdrocm-wsl"
+    ],
+    "Maintainer": "AMD HSA Support <dl.HSA-Runtime-Support@amd.com>",
+    "Description_Short": "AMD ROCm WSL support library development files",
+    "Description_Long": "Development files for AMD ROCm DXG support library for Windows Subsystem for Linux (WSL)",
+    "Section": "devel",
+    "Priority": "optional",
+    "Group": "unknown",
+    "License": "MIT",
+    "Vendor": "Advanced Micro Devices, Inc",
+    "Homepage": "https://github.com/ROCm/rocm-systems",
+    "Artifactory": [
+      {
+        "Artifact": "wsl-rocdxg",
+        "Artifact_Subdir": [
+          {
+            "Name": "wsl-rocdxg",
+            "Components": [
+              "dev"
+            ]
+          }
+        ]
+      }
+    ],
+    "Gfxarch": "False"
+  },
+  {
     "Package": "amdrocm-runtime-devel",
     "Version": "",
     "Architecture": "amd64",
@@ -323,17 +358,6 @@
             "Components": [
               "dev",
               "run"
-            ]
-          }
-        ]
-      },
-      {
-        "Artifact": "wsl-rocdxg",
-        "Artifact_Subdir": [
-          {
-            "Name": "wsl-rocdxg",
-            "Components": [
-              "dev"
             ]
           }
         ]

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -215,18 +215,6 @@
         ]
       },
       {
-        "Artifact": "wsl-rocdxg",
-        "Artifact_Subdir": [
-          {
-            "Name": "wsl-rocdxg",
-            "Components": [
-              "lib",
-              "doc"
-            ]
-          }
-        ]
-      },
-      {
         "Artifact": "core-hip",
         "Artifact_Subdir": [
           {
@@ -258,6 +246,42 @@
             "Components": [
               "lib",
               "run",
+              "doc"
+            ]
+          }
+        ]
+      }
+    ],
+    "Gfxarch": "False"
+  },
+  {
+    "Package": "amdrocm-wsl",
+    "Version": "",
+    "Architecture": "amd64",
+    "BuildArch": "x86_64",
+    "DEBDepends": [
+      "amdrocm-runtime"
+    ],
+    "RPMRequires": [
+      "amdrocm-runtime"
+    ],
+    "Maintainer": "AMD HSA Support <dl.HSA-Runtime-Support@amd.com>",
+    "Description_Short": "AMD ROCm WSL support library",
+    "Description_Long": "AMD ROCm DXG support library for Windows Subsystem for Linux (WSL)",
+    "Section": "devel",
+    "Priority": "optional",
+    "Group": "unknown",
+    "License": "MIT",
+    "Vendor": "Advanced Micro Devices, Inc",
+    "Homepage": "https://github.com/ROCm/rocm-systems",
+    "Artifactory": [
+      {
+        "Artifact": "wsl-rocdxg",
+        "Artifact_Subdir": [
+          {
+            "Name": "wsl-rocdxg",
+            "Components": [
+              "lib",
               "doc"
             ]
           }


### PR DESCRIPTION
  The librocdxg.so library requires GLIBC_2.38 and GLIBCXX_3.4.30+
  which are not available on RHEL/CentOS 9 (glibc 2.34). This was
  causing amdrocm-runtime installation to fail on EL9 systems with:
    nothing provides libc.so.6(GLIBC_2.38)(64bit)
    nothing provides libstdc++.so.6(GLIBCXX_3.4.30)(64bit)

  Since librocdxg.so is only needed for Windows Subsystem for Linux
  (WSL) environments, move it to separate optional packages so that
  native Linux users are not affected by its build dependencies.

  Changes:
  - Remove wsl-rocdxg artifact from amdrocm-runtime package
  - Remove wsl-rocdxg artifact from amdrocm-runtime-devel package
  - Create new amdrocm-wsl package containing wsl-rocdxg lib and doc
  - Create new amdrocm-wsl-devel package containing wsl-rocdxg dev
  - Update RELEASES.md with WSL package installation instructions

  Fixes: ROCm runtime installation failure on CentOS Stream 9

JIRA ID: https://amd-hub.atlassian.net/browse/ROCM-27077



