### PR TITLE
Expand CI "skippable path patterns" to cover new files

### DIFF
--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -145,22 +145,28 @@ def is_ci_run_required(paths: Optional[Iterable[str]]) -> bool:
 # ============================================================================
 
 # File path patterns that don't trigger CI runs.
-# Changes to files matching these patterns are considered
-# documentation/configuration that don't affect build or test workflows.
+# Changes matching these patterns shouldn't affect CI build/test workflows.
 _SKIPPABLE_PATH_PATTERNS = [
     "docs/*",
     "*.gitignore",
     "*.md",
+    "*.mdc",
     "*.pre-commit-config.*",
     ".github/dependabot.yml",
     "*CODEOWNERS",
     "*LICENSE",
+    # Files used by gitleaks, no impact on CI.
+    "gitleaks.toml",
+    "build_tools/scan_tools/*",
     # Changes to dockerfiles do not currently affect CI workflows directly.
     # Docker images are built and published after commits are pushed, then
     # workflows can be updated to use the new image sha256 values.
     "dockerfiles/*",
     # Changes to experimental code do not run standard build/test workflows.
     "experimental/*",
+    # This directory contains a collection of AI skills and other developer
+    # utilities. It includes some Python scripts, none of which affect CI.
+    "skills/*",
 ]
 
 # GitHub workflow files that are used by CI workflows. Changes to any of

--- a/build_tools/github_actions/tests/configure_ci_path_filters_test.py
+++ b/build_tools/github_actions/tests/configure_ci_path_filters_test.py
@@ -29,6 +29,11 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
         run_ci = is_ci_run_required(paths)
         self.assertFalse(run_ci)
 
+    def test_dont_run_ci_if_only_skipped_files_edited(self):
+        paths = ["gitleaks.toml", "build_tools/scan_tools/script.py"]
+        run_ci = is_ci_run_required(paths)
+        self.assertFalse(run_ci)
+
     def test_run_ci_if_related_workflow_file_edited(self):
         paths = [".github/workflows/multi_arch_ci.yml"]
         run_ci = is_ci_run_required(paths)


### PR DESCRIPTION
## Motivation

These file paths can't affect CI and thus can skip it automatically.

Following up on a few PRs which used the `ci:skip` label recently where this automatic filtering could have worked too (diff highlighting showing the newly added files that will be excluded by these patterns now, note that markdown files are already excluded):
* https://github.com/ROCm/TheRock/pull/5994 --> https://github.com/ROCm/TheRock/actions/runs/27844082781/job/82409359223#step:3:30
    ```diff
     GitContext: 4 changed file(s)
       .github/therock_pr_bot/FAQ.md
       .github/therock_pr_bot/policy.yml
    +  .github/therock_pr_bot/policy_check.py  (this got moved to skills/)
       .github/workflows/therock-pr-bot.yml
    
    -Enabling build jobs since a non-skippable path was modified
    -  CI-relevant files changed, running CI
    ```
* https://github.com/ROCm/TheRock/pull/5734 --> https://github.com/ROCm/TheRock/actions/runs/27234509143/job/80422879255#step:3:30
    ```diff
     GitContext: 5 changed file(s)
    +  .cursor/rules/rocm-pr-quality.mdc
       CLAUDE.md
       skills/rocm-pr-quality/SKILL.md
       skills/rocm-pr-quality/reference.md
    +  skills/rocm-pr-quality/tools/pr_quality_check.py
    
    -Enabling build jobs since a non-skippable path was modified
    -  CI-relevant files changed, running CI
    ```
* https://github.com/ROCm/TheRock/pull/5367 --> https://github.com/ROCm/TheRock/actions/runs/26175015896/job/77002756090#step:3:30
    ```diff
     GitContext: 4 changed file(s)
       .github/workflows/gitleaks.yml
       .github/workflows/gitleaks_main.yml
       .github/workflows/pre-commit-security.yml
    +  scan_tools/github_actions/gitleaks.py
    
    -Enabling build jobs since a non-skippable path was modified
    -  CI-relevant files changed, running CI
    ```

## Technical Details

I'm also considering other ways to organize the `build_tools/` folder to avoid so many false positive triggers there. We have quite a few scripts that are only used for e.g. jax releases or package promotion that could skip CI automatically too.

## Test Plan

Adjusted unit tests.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
