### PR TITLE
fix: make rocdxg an optional library 

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__init__.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__init__.py
@@ -61,6 +61,10 @@ def find_libraries(*shortnames: str) -> list[Path]:
             entry_pattern = lib_entry.so_pattern
         matching_paths = sorted(relpath.glob(entry_pattern))
         if len(matching_paths) == 0:
+            if lib_entry.optional:
+                # Optional libraries (e.g. WSL-only rocdxg) may be absent from
+                # the distribution. Skip rather than failing.
+                continue
             raise FileNotFoundError(
                 f"Could not find rocm library '{shortname}' at path '{relpath},' no match for pattern '{entry_pattern}'"
             )
@@ -97,12 +101,17 @@ def preload_libraries(*shortnames: str, rtld_global: bool = True):
     """
     import ctypes
 
-    paths = find_libraries(*shortnames)
     mode = ctypes.RTLD_GLOBAL if rtld_global is True else ctypes.RTLD_LOCAL
-    for shortname, path in zip(shortnames, paths):
+    for shortname in shortnames:
         if shortname in _ALL_CDLLS:
             continue
-        cdll = ctypes.CDLL(str(path), mode=mode)
+        # Resolve per shortname: find_libraries may skip entries (libraries
+        # absent on the current platform or optional ones not present in the
+        # distribution), so a positional zip against shortnames would mispair.
+        paths = find_libraries(shortname)
+        if not paths:
+            continue
+        cdll = ctypes.CDLL(str(paths[0]), mode=mode)
         _ALL_CDLLS[shortname] = cdll
 
 

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -32,6 +32,7 @@ class LibraryEntry:
         so_pattern: str,
         dll_pattern: str,
         posix_relpath="lib",
+        optional: bool = False,
     ):
         self.shortname = shortname
         self.package = ALL_PACKAGES[package_name]
@@ -39,6 +40,11 @@ class LibraryEntry:
         self.windows_relpath = "bin"
         self.so_pattern = so_pattern
         self.dll_pattern = dll_pattern
+        # Optional libraries may be absent from a built distribution (e.g.
+        # rocdxg only builds on a WSL host and is skipped on fork PRs and
+        # local single-command Linux builds). find_libraries skips these
+        # rather than raising when no file matches.
+        self.optional = optional
         assert shortname not in ALL_LIBRARIES
         ALL_LIBRARIES[shortname] = self
 
@@ -264,7 +270,7 @@ LibraryEntry("amd_comgr", "core", "libamd_comgr.so*", "amd_comgr*.dll")
 LibraryEntry("rocm_smi64", "core", "librocm_smi64.so*", "")
 LibraryEntry("rocdecode", "core", "librocdecode.so*", "")
 LibraryEntry("rocjpeg", "core", "librocjpeg.so*", "")
-LibraryEntry("rocdxg", "core", "librocdxg*.so*", "")
+LibraryEntry("rocdxg", "core", "librocdxg*.so*", "", optional=True)
 LibraryEntry("hipblas", "libraries", "libhipblas.so*", "*hipblas*.dll")
 LibraryEntry("hipblaslt", "libraries", "libhipblaslt.so*", "*hipblaslt*.dll")
 LibraryEntry("hipfft", "libraries", "libhipfft.so*", "hipfft*.dll")


### PR DESCRIPTION
 ## Summary

   - Adds an `optional` flag to `LibraryEntry` and marks `rocdxg` with `optional=True`.
   - `find_libraries` skips an optional library when no file matches its glob, instead of raising `FileNotFoundError`.
   - `preload_libraries` resolves each shortname individually rather than zipping `shortnames` against a possibly-shorter `paths` list.

 ## Motivation

The `rocdxg` library only builds on a WSL host, so it is absent from fork PRs (which don't upload the `wsl-rocdxg` artifact) and from local single-command Linux builds (which can't produce it without a WSL host).

Because `rocdxg` was declared as an unconditional `LibraryEntry` in the always-installed `core` package, `testPreloadLibraries` — which iterates every installed library — failed with `no match for pattern 'librocdxg*.so*'`.

This implements the fix suggested in the #5283 review thread: making the library entry optional. It is data-driven, so future conditional libraries only need to pass `optional=True`.

This addresses
ISSUE ID #6077.
   
## Technical Details

- **`_dist_info.py`** — `LibraryEntry.__init__` gains `optional: bool = False`, stored as `self.optional`. `rocdxg` is the only entry that sets it. No special-casing elsewhere — any future conditional library opts in the same way.
- **`find_libraries` (`__init__.py`)** — when `relpath.glob(entry_pattern)` returns no matches and `lib_entry.optional` is set, the loop `continue`s instead of raising. This mirrors the existing skip for Windows-absent libraries (`is_windows and not lib_entry.dll_pattern`) a few lines above. Required libraries are unaffected and still raise `FileNotFoundError`.
- **`preload_libraries` (`__init__.py`)** — previously did `paths = find_libraries(*shortnames)` then `zip(shortnames, paths)`. Once `find_libraries` can skip an entry, that `paths` list is shorter than `shortnames` and the `zip` silently mispairs names with the wrong libraries (and drops the tail). This was already latent for Windows-skipped libraries. The fix resolves one shortname at a time (`find_libraries(shortname)`), skipping when the result is empty, so each name maps to its own path. The `_ALL_CDLLS` dedup cache and `rtld_global` behavior are unchanged.

## Test Result

- `python -m py_compile build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py build_tools/packaging/python/templates/rocm/src/rocm_sdk/__init__.py`
- Verified by inspection: `testPreloadLibraries` skips `rocdxg` cleanly when the artifact is absent; required-library-missing still raises `FileNotFoundError` and missing-package still raises `ModuleNotFoundError`.

## Notes

CI should confirm the rocm-sdk core tests pass on a fork PR (where the `rocdxg` artifact is absent).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
