### PR TITLE
Delete "conventional commits" policy requirement from PR bot

### DIFF
--- a/skills/therock_pr_bot/FAQ.md
+++ b/skills/therock_pr_bot/FAQ.md
@@ -37,31 +37,8 @@ ______________________________________________________________________
 ## 📝 PR Title
 
 **What does it check?**
-The PR title must follow **Conventional Commits** style so the changelog and release notes can be generated automatically.
 
 > **Note:** In the results table, the title and description checks are reported together as a single **PR Title/Description** row. Any title *or* description failure shows up there.
-
-**Required format**
-
-```
-type(optional-scope): short description
-```
-
-**Allowed types**
-
-| Type       | When to use                              |
-| ---------- | ---------------------------------------- |
-| `feat`     | A new feature                            |
-| `fix`      | A bug fix                                |
-| `docs`     | Documentation only changes               |
-| `style`    | Formatting, whitespace — no logic change |
-| `refactor` | Code restructure — no feature or fix     |
-| `perf`     | Performance improvement                  |
-| `test`     | Adding or fixing tests                   |
-| `build`    | Build system or dependency changes       |
-| `ci`       | CI / workflow changes                    |
-| `chore`    | Maintenance tasks                        |
-| `revert`   | Reverting a previous commit              |
 
 **Length rules**
 
@@ -74,8 +51,8 @@ type(optional-scope): short description
 Edit the PR title on GitHub (top of the PR page → pencil icon) to match the format, e.g.:
 
 ```
-feat(auth): add token refresh support
-fix(ci): correct codeql workflow trigger
+Add token refresh support
+Correct codeql workflow trigger
 ```
 
 ______________________________________________________________________

--- a/skills/therock_pr_bot/policy.yml
+++ b/skills/therock_pr_bot/policy.yml
@@ -21,12 +21,8 @@ pr:
     # GitHub auto-revert branches, e.g. revert-5217-users/derobins/add_hipfile_support
     - '^revert-[0-9]+-[a-z0-9][a-z0-9\-_\/]*$'
 
-  # PR title rules (Conventional Commits style):
-  #   type(optional-scope): short description
-  # Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+  # PR title rules
   title:
-    pattern:
-      - '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9\-]+\))?(!)?: .+'
     title_min_length: 10
     title_max_length: 80
 

--- a/skills/therock_pr_bot/policy_check.py
+++ b/skills/therock_pr_bot/policy_check.py
@@ -295,11 +295,7 @@ def ensure_pr_title(policy: Policy, title: str, errors: List[str]) -> None:
     if policy.title_patterns and not any(
         p.search(title) for p in policy.title_patterns
     ):
-        errors.append(
-            "**Error:** Title does not follow Conventional Commits style.\n"
-            "**Expected:** start with a valid type (feat, fix, docs, …).\n"
-            f"{fmt}"
-        )
+        errors.append("**Error:** Title does not follow policy patterns.\n" f"{fmt}")
 
     if policy.forbidden_title_patterns:
         matched = [


### PR DESCRIPTION
## Motivation

Related to https://github.com/ROCm/TheRock/issues/5998. Follow-up to https://github.com/ROCm/TheRock/pull/5994#discussion_r3453865409, removing the Conventional Commits (https://www.conventionalcommits.org/en/v1.0.0/) requirement.

This sort of policy change needs to start with a discussion and inclusion in https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.

I'm being picky here because
* I'm seeing lots of wasted energy being spent across the project to satisfy this check when it has not been sufficiently reviewed and implemented.
* Conventional commits will not work in https://github.com/ROCm/rocm-libraries and https://github.com/ROCm/rocm-systems where there are already established subproject tag styles used for commits with `[component-name]` syntax. We could aim to standardize across related ROCm projects, so we could formalize and adopt _that_ style here.
* See recent arguments against conventional commits at https://sumnerevans.com/posts/software-engineering/stop-using-conventional-commits/ and https://news.ycombinator.com/item?id=48414027

## Test Plan

Watch the PR bot run on this PR. It doesn't have unit tests yet so I can't test these changes effectively otherwise.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.