### PR TITLE
[AMD-SMI] Register amd_smi in rocm_sdk find_libraries

### DIFF
--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/_dist_info.py
@@ -262,6 +262,7 @@ LibraryEntry(
 )
 LibraryEntry("amd_comgr", "core", "libamd_comgr.so*", "amd_comgr*.dll")
 LibraryEntry("rocm_smi64", "core", "librocm_smi64.so*", "")
+LibraryEntry("amd_smi", "core", "libamd_smi.so*", "")
 LibraryEntry("rocdecode", "core", "librocdecode.so*", "")
 LibraryEntry("rocjpeg", "core", "librocjpeg.so*", "")
 LibraryEntry("rocdxg", "core", "librocdxg*.so*", "")


### PR DESCRIPTION
So find_libraries("amd_smi") resolves the shortname instead of raising; the .so already ships in rocm-sdk-core.

Will be useful in combination with https://github.com/ROCm/rocm-systems/pull/7091