### PR TITLE
ISSUE ID #5833 feat(pytorch): enable gfx125x for PyTorch release/2.11 builds

### DIFF
--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -40,9 +40,7 @@ PYTORCH_REFS_LINUX: list[dict] = [
     },
     {
         "pytorch_git_ref": "release/2.11",
-        # gfx125x not yet upstreamed to pytorch/pytorch.
-        # See https://github.com/ROCm/TheRock/issues/5833.
-        "exclude_amdgpu_families": {"gfx125x"},
+        # gfx125x upstreamed via https://github.com/ROCm/pytorch/pull/3346.
     },
     {
         "pytorch_git_ref": "release/2.12",


### PR DESCRIPTION
gfx125x support has been upstreamed via ROCm/pytorch#3346, so remove the exclusion from the release/2.11 matrix entry to enable multiarch builds for that branch.

## Motivation

- Removes the `gfx125x` exclusion from the `release/2.11` PyTorch matrix entry
  - gfx125x support has been upstreamed via ROCm/pytorch#3346
  - This enables multiarch PyTorch builds (including gfx125x) for nightly CI runs targeting the `release/2.11` branch

  Exclusions for `release/2.9`, `release/2.10`, `release/2.12`, and `nightly` remain in place as those branches do not have upstream support.

  Closes #5833 (partially — for release/2.11).

  ## Test plan
  - [ ] Verify nightly CI triggers a `release/2.11` PyTorch build that includes `gfx125x` in the matrix
  - [ ] Confirm other release branches still exclude `gfx125x`