### PR TITLE
Add precompile test option for rocfft/hipfft tests

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hipfft.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipfft.py
@@ -29,10 +29,13 @@ if test_type == "quick":
 else:
     # Standard/comprehensive: "--test_prob" is the probability that a given test will run.
     # Due to the large number of tests for hipFFT, we only run a subset.
+    # The option --precompile=precompiled.db reduces test time by more
+    # efficiently parallelizing runtime compilation.
     test_filter = [
         "--gtest_filter=-*multi_gpu*",
         "--test_prob",
         "0.01",
+        "--precompile=precompiled.db",
     ]
 
 cmd = [f"{THEROCK_BIN_DIR}/hipfft-test"] + test_filter

--- a/build_tools/github_actions/test_executable_scripts/test_rocfft.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocfft.py
@@ -29,10 +29,13 @@ if test_type == "quick":
 else:
     # Standard/comprehensive: "--test_prob" is the probability that a given test will run.
     # Due to the large number of tests for rocFFT, we only run a subset.
+    # The option --precompile=precompiled.db reduces test time by more
+    # efficiently parallelizing runtime compilation.
     test_filter = [
         "--gtest_filter=-*multi_gpu*",
         "--test_prob",
         "0.02",
+        "--precompile=precompiled.db",
     ]
 
 cmd = [f"{THEROCK_BIN_DIR}/rocfft-test"] + test_filter


### PR DESCRIPTION
## Objective

Reduce test execution time for rocfft and hipfft.

## Technical Details

The RTC kernel generation can be more efficiently parallelized when as a preliminary batch job.  This commit adds that command-line argument to the test.  Typically, we have about a 10% time reduction.

## Test Plan

Covered by normal tests.

## Test Result

Tests run.

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
