### PR TITLE
fix(ci): Fix upload_tarballs.py for single-family builds like ASAN

### DIFF
--- a/build_tools/github_actions/upload_tarballs.py
+++ b/build_tools/github_actions/upload_tarballs.py
@@ -60,16 +60,30 @@ def _select_shared_tarball_url(
     output_root: WorkflowOutputRoot,
     platform: str,
 ) -> str | None:
+    """Select the shared tarball URL for the tarball_urls output.
+
+    Priority:
+    1. Multiarch tarball (if exists)
+    2. Single shared tarball (if only one non-test tarball exists)
+    3. Family name without hyphen (legacy single-family builds)
+
+    Returns None if multiple families exist without a multiarch tarball,
+    which is an error condition.
+    """
     shared_tarball_files = [f for f in tarball_files if not _is_test_tarball(f.name)]
 
+    # Priority 1: Look for multiarch tarball
     for f in shared_tarball_files:
         name = f.name
         if name.startswith(f"therock-dist-{platform}-multiarch-"):
             return _tarball_url(output_root, name)
 
+    # Priority 2: If only one shared tarball, use it (handles single-family
+    # builds like ASAN with gfx94X-dcgpu)
     if len(shared_tarball_files) == 1:
         return _tarball_url(output_root, shared_tarball_files[0].name)
 
+    # Priority 3: Legacy - family name without hyphen (e.g., gfx900)
     prefix = f"therock-dist-{platform}-"
     suffix = ".tar.gz"
 
@@ -81,6 +95,7 @@ def _select_shared_tarball_url(
             if "-" not in stem:
                 return _tarball_url(output_root, name)
 
+    # Multiple families without multiarch - caller should handle this error
     return None
 
 


### PR DESCRIPTION
The script was failing for ASAN builds because the tarball naming logic expected either a multiarch tarball or a family name without hyphens. ASAN builds produce single-family tarballs like gfx94X-dcgpu which contain a hyphen in the family name.

Changes:
- Parse family name by finding where the version starts (first digit)
- Build a dict of all family tarball URLs
- Fall back to the first family tarball as "multiarch" for single-family builds to maintain backwards compatibility

working here: https://github.com/ROCm/TheRock/actions/runs/28115137163/job/83315737020

broken here: https://github.com/ROCm/TheRock/actions/runs/28049441058/job/83112141566