### PR TITLE
[NFC] Refactor multi-arch build config inputs

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -819,13 +819,9 @@ def _expand_build_config_for_platform(
     platform: str,
     all_families: dict[str, dict],
     variant_config: dict,
-    test_type: str,
-    pr_labels: list[str],
-    is_schedule: bool,
-    is_workflow_dispatch: bool,
+    ci_inputs: CIInputs,
+    jobs: JobDecisions,
     git_context: GitContext,
-    prebuilt_stages: list[str] | None = None,
-    baseline_run_id: str = "",
 ) -> BuildConfig | None:
     """Build a BuildConfig for one platform, or None if no families match.
 
@@ -843,7 +839,7 @@ def _expand_build_config_for_platform(
     # Extract kernel type from test_runner:<kernel> PR label (e.g. "oem").
     # Selects kernel-specific test runners for families that support them.
     test_runner_kernel = ""
-    for label in pr_labels:
+    for label in ci_inputs.pr_labels:
         if label.startswith("test_runner:"):
             test_runner_kernel = label.split(":")[1]
             break
@@ -902,7 +898,7 @@ def _expand_build_config_for_platform(
         # TODO(#3433): Remove once ASAN tests pass and test_rocm.action is plumbed.
         if build_variant == "asan" or build_variant == "host-asan":
             # Only run ASAN tests on scheduled or workflow_dispatch runs
-            if not (is_schedule or is_workflow_dispatch):
+            if not (ci_inputs.is_schedule or ci_inputs.is_workflow_dispatch):
                 test_runs_on = ""
                 print(
                     f"  {family_name}: ASAN tests skipped for non-nightly trigger, "
@@ -919,7 +915,10 @@ def _expand_build_config_for_platform(
                 )
 
         # If run-full-tests-only is set and test_type is "quick", disable testing
-        if platform_info.get("run-full-tests-only", False) and test_type == "quick":
+        if (
+            platform_info.get("run-full-tests-only", False)
+            and jobs.test_rocm.test_type == "quick"
+        ):
             test_runs_on = ""
             print(
                 f"  {family_name}: run-full-tests-only flag set, "
@@ -929,7 +928,7 @@ def _expand_build_config_for_platform(
         # If nightly_check_only_for_family is set for schedule runs only
         if (
             platform_info.get("nightly_check_only_for_family", False)
-            and not is_schedule
+            and not ci_inputs.is_schedule
         ):
             test_runs_on = ""
             print(
@@ -962,9 +961,9 @@ def _expand_build_config_for_platform(
         per_family_info=per_family_info,
         platform=platform,
     )
-    # TODO: Thread jobs.build_rocm_python into expand_build_configs() so this
-    # matrix is empty when the ROCm Python package build is disabled. Then
-    # multi_arch_ci_* can also condition build_python_packages on that decision.
+    # TODO: Use jobs.build_rocm_python so this matrix is empty when the ROCm
+    # Python package build is disabled. Then multi_arch_ci_* can also condition
+    # build_python_packages on that decision.
 
     return BuildConfig(
         per_family_info=per_family_info,
@@ -977,18 +976,16 @@ def _expand_build_config_for_platform(
         build_pytorch=(suffix != "asan"),
         build_runs_on=build_runs_on,
         test_python_packages_matrix=test_python_packages_matrix,
-        prebuilt_stages=prebuilt_stages or [],
-        baseline_run_id=baseline_run_id,
+        prebuilt_stages=jobs.build_rocm.prebuilt_stages,
+        baseline_run_id=jobs.build_rocm.baseline_run_id,
     )
 
 
 def expand_build_configs(
-    targets: TargetSelection,
     ci_inputs: CIInputs,
-    test_type: str,
     git_context: GitContext,
-    prebuilt_stages: list[str] | None = None,
-    baseline_run_id: str = "",
+    targets: TargetSelection,
+    jobs: JobDecisions,
 ) -> BuildConfigs:
     """Build a BuildConfig for each platform that supports the variant.
 
@@ -1023,12 +1020,8 @@ def expand_build_configs(
             platform=platform,
             all_families=all_families,
             variant_config=variant_config,
-            test_type=test_type,
-            pr_labels=ci_inputs.pr_labels,
-            is_schedule=ci_inputs.is_schedule,
-            is_workflow_dispatch=ci_inputs.is_workflow_dispatch,
-            prebuilt_stages=prebuilt_stages,
-            baseline_run_id=baseline_run_id,
+            ci_inputs=ci_inputs,
+            jobs=jobs,
             git_context=git_context,
         )
         if platform == "linux":
@@ -1130,12 +1123,10 @@ def configure(ci_inputs: CIInputs, git_context: GitContext) -> CIOutputs:
 
     print("\n=== Building per-platform configs ===")
     builds = expand_build_configs(
-        targets=targets,
         ci_inputs=ci_inputs,
-        test_type=jobs.test_rocm.test_type,
-        prebuilt_stages=jobs.build_rocm.prebuilt_stages,
-        baseline_run_id=jobs.build_rocm.baseline_run_id,
         git_context=git_context,
+        targets=targets,
+        jobs=jobs,
     )
     builds.log()
 

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -69,6 +69,35 @@ def _run_from_environ(
         os.unlink(event_path)
 
 
+def _jobs(
+    *,
+    test_type: str = "quick",
+    prebuilt_stages: list[str] | None = None,
+    baseline_run_id: str = "",
+    build_pytorch: bool = True,
+) -> cm.JobDecisions:
+    """Construct default job decisions for tests that exercise later stages."""
+    prebuilt_stages = prebuilt_stages or []
+    return cm.JobDecisions(
+        build_rocm=cm.BuildRocmDecision(
+            action=cm.JobAction.RUN,
+            stage_decisions={stage: cm.JobAction.PREBUILT for stage in prebuilt_stages},
+            baseline_run_id=baseline_run_id,
+        ),
+        test_rocm=cm.TestRocmDecision(
+            action=cm.JobAction.RUN,
+            test_type=test_type,
+        ),
+        build_rocm_python=cm.JobGroupDecision(action=cm.JobAction.RUN),
+        build_pytorch=cm.JobGroupDecision(
+            action=cm.JobAction.RUN if build_pytorch else cm.JobAction.SKIP
+        ),
+        test_pytorch=cm.JobGroupDecision(
+            action=cm.JobAction.RUN if build_pytorch else cm.JobAction.SKIP
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # CIInputs — construction and properties
 # ---------------------------------------------------------------------------
@@ -739,7 +768,7 @@ class TestSelectTargets(unittest.TestCase):
 
 
 class TestExpandBuildConfigs(unittest.TestCase):
-    """Test expand_build_configs: TargetSelection × CIInputs → BuildConfigs.
+    """Test expand_build_configs: TargetSelection + CIInputs + JobDecisions -> BuildConfigs.
 
     Tests verify structural properties of the output, not specific data values
     from amdgpu_family_matrix.py. Changing a runner label should not require
@@ -778,10 +807,10 @@ class TestExpandBuildConfigs(unittest.TestCase):
         """Empty targets on both platforms → both None."""
         targets = cm.TargetSelection()
         result = cm.expand_build_configs(
-            targets=targets,
             ci_inputs=self._inputs(),
-            test_type="quick",
             git_context=cm.GitContext(),
+            targets=targets,
+            jobs=_jobs(),
         )
         self.assertIsNone(result.linux)
         self.assertIsNone(result.windows)
@@ -821,10 +850,10 @@ class TestExpandBuildConfigs(unittest.TestCase):
         )
         targets = cm.select_targets(inputs)
         result = cm.expand_build_configs(
-            targets=targets,
             ci_inputs=inputs,
-            test_type="quick",
             git_context=cm.GitContext(),
+            targets=targets,
+            jobs=_jobs(),
         )
         required_keys = {
             "amdgpu_family",
@@ -873,10 +902,10 @@ class TestExpandBuildConfigs(unittest.TestCase):
             windows_families=["gfx110x"],
         )
         result = cm.expand_build_configs(
-            targets=targets,
             ci_inputs=self._inputs(),
-            test_type="quick",
             git_context=cm.GitContext(),
+            targets=targets,
+            jobs=_jobs(),
         )
 
         # All target families that support the variant appear in output.
@@ -902,10 +931,10 @@ class TestExpandBuildConfigs(unittest.TestCase):
             windows_families=["gfx110x"],
         )
         result = cm.expand_build_configs(
-            targets=targets,
             ci_inputs=self._inputs(),
-            test_type="quick",
             git_context=cm.GitContext(),
+            targets=targets,
+            jobs=_jobs(),
         )
 
         self.assertEqual(len(result.linux.test_python_packages_matrix), 6)
@@ -942,10 +971,10 @@ class TestExpandBuildConfigs(unittest.TestCase):
             windows_families=["gfx110x"],
         )
         result = cm.expand_build_configs(
-            targets=targets,
             ci_inputs=self._inputs(build_variant="asan"),
-            test_type="quick",
             git_context=cm.GitContext(),
+            targets=targets,
+            jobs=_jobs(),
         )
         # Only gfx94x on linux survives.
         self.assertIsNotNone(result.linux)
@@ -975,10 +1004,10 @@ class TestExpandBuildConfigs(unittest.TestCase):
                 )
                 ci_inputs = cm.CIInputs(**defaults)
                 result = cm.expand_build_configs(
-                    targets=targets,
                     ci_inputs=ci_inputs,
-                    test_type="quick",
                     git_context=cm.GitContext(),
+                    targets=targets,
+                    jobs=_jobs(),
                 )
                 # Only gfx94x on linux survives.
                 self.assertIsNotNone(result.linux)
@@ -1005,10 +1034,10 @@ class TestExpandBuildConfigs(unittest.TestCase):
             build_variant="asan",
         )
         result = cm.expand_build_configs(
-            targets=targets,
             ci_inputs=ci_inputs,
-            test_type="quick",
             git_context=cm.GitContext(),
+            targets=targets,
+            jobs=_jobs(),
         )
         self.assertIsNotNone(result.linux)
         # Verify it's a host-asan build
@@ -1025,10 +1054,10 @@ class TestExpandBuildConfigs(unittest.TestCase):
         """test_runner:oem label swaps in kernel-specific runner for gfx1151."""
         targets = cm.TargetSelection(linux_families=["gfx1151"])
         result = cm.expand_build_configs(
-            targets=targets,
             ci_inputs=self._inputs(pr_labels=["test_runner:oem"]),
-            test_type="quick",
             git_context=cm.GitContext(),
+            targets=targets,
+            jobs=_jobs(),
         )
         self.assertIsNotNone(result.linux)
         entry = result.linux.per_family_info[0]
@@ -1039,10 +1068,10 @@ class TestExpandBuildConfigs(unittest.TestCase):
         # gfx94x has no test-runs-on-kernel entry
         targets = cm.TargetSelection(linux_families=["gfx94x"])
         result = cm.expand_build_configs(
-            targets=targets,
             ci_inputs=self._inputs(pr_labels=["test_runner:oem"]),
-            test_type="quick",
             git_context=cm.GitContext(),
+            targets=targets,
+            jobs=_jobs(),
         )
         self.assertIsNotNone(result.linux)
         entry = result.linux.per_family_info[0]
@@ -1052,10 +1081,10 @@ class TestExpandBuildConfigs(unittest.TestCase):
         """Without test_runner: label, default runner labels are used."""
         targets = cm.TargetSelection(linux_families=["gfx908"])
         result = cm.expand_build_configs(
-            targets=targets,
             ci_inputs=self._inputs(),
-            test_type="quick",
             git_context=cm.GitContext(),
+            targets=targets,
+            jobs=_jobs(),
         )
         self.assertIsNotNone(result.linux)
         entry = result.linux.per_family_info[0]
@@ -1070,20 +1099,20 @@ class TestExpandBuildConfigs(unittest.TestCase):
 
         # Schedule: uses sandbox runner
         result = cm.expand_build_configs(
-            targets=targets,
             ci_inputs=self._inputs(event_name="schedule", build_variant="asan"),
-            test_type="quick",
             git_context=cm.GitContext(),
+            targets=targets,
+            jobs=_jobs(),
         )
         entry = result.linux.per_family_info[0]
         self.assertIn("sandbox", entry["test-runs-on"])
 
         # PR: disables tests (empty runner)
         result = cm.expand_build_configs(
-            targets=targets,
             ci_inputs=self._inputs(event_name="pull_request", build_variant="asan"),
-            test_type="quick",
             git_context=cm.GitContext(),
+            targets=targets,
+            jobs=_jobs(),
         )
         entry = result.linux.per_family_info[0]
         self.assertEqual(entry["test-runs-on"], "")
@@ -1375,7 +1404,10 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         targets = cm.TargetSelection(linux_families=["gfx94x"])
 
         builds = cm.expand_build_configs(
-            targets, ci_inputs, test_type="quick", git_context=cm.GitContext()
+            ci_inputs=ci_inputs,
+            git_context=cm.GitContext(),
+            targets=targets,
+            jobs=_jobs(),
         )
 
         self.assertIsNotNone(builds.linux)
@@ -1400,7 +1432,10 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         # Run multiple times to ensure consistency
         for _ in range(10):
             builds = cm.expand_build_configs(
-                targets, ci_inputs, test_type="full", git_context=cm.GitContext()
+                ci_inputs=ci_inputs,
+                git_context=cm.GitContext(),
+                targets=targets,
+                jobs=_jobs(test_type="full"),
             )
             if builds.linux and builds.linux.per_family_info:
                 gfx103x_info = builds.linux.per_family_info[0]


### PR DESCRIPTION
## Motivation

These argument lists were getting long, and I want to add a few more fields without needing to plumb across each function. Now the (frozen) dataclasses are passed through and each function can pick and choose what it wants to read.

## Test Plan

* Unit tests
* CI on this PR should generate the same set of jobs as before

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
