### PR TITLE
fix(ci): apply per-ref amdgpu exclusions in multi-arch PyTorch CI

### DIFF
--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -287,22 +287,48 @@ jobs:
   # so the split path is unconditional here. The split itself runs inline
   # in multi_arch_build_portable_linux_pytorch_wheels_ci.yml based on
   # inputs.kpack_split.
+  #
+  # Per-ref amdgpu family exclusions (e.g. gfx125x on release/2.10) are
+  # applied via configure_pytorch_release_matrix.py, matching the release
+  # workflow in multi_arch_release_linux_pytorch_wheels.yml.
+  setup_pytorch_matrix:
+    name: Setup PyTorch CI Matrix
+    if: ${{ fromJSON(inputs.build_config).build_pytorch == true }}
+    runs-on: ubuntu-24.04
+    outputs:
+      pytorch_matrix: ${{ steps.matrix.outputs.pytorch_matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref }}
+
+      - name: Generate PyTorch matrix
+        id: matrix
+        run: |
+          python ./build_tools/github_actions/configure_pytorch_release_matrix.py \
+            --python-versions="3.12" \
+            --platform=linux \
+            --pytorch-refs="release/2.10;release/2.11;release/2.12" \
+            --amdgpu-families="${{ fromJSON(inputs.build_config).dist_amdgpu_families }}"
+
   build_pytorch_wheel_fat:
-    needs: [build_python_packages]
+    needs: [build_python_packages, setup_pytorch_matrix]
     name: Build PyTorch (fat + split) | ${{ matrix.pytorch_git_ref }}
     if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_pytorch == true }}
     strategy:
       fail-fast: false
       matrix:
-        pytorch_git_ref: ["release/2.10", "release/2.11", "release/2.12"]
+        include: ${{ fromJSON(needs.setup_pytorch_matrix.outputs.pytorch_matrix) }}
     uses: ./.github/workflows/multi_arch_build_portable_linux_pytorch_wheels_ci.yml
     with:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
-      python_version: "3.12"
+      python_version: ${{ matrix.python_version }}
       pytorch_git_ref: ${{ matrix.pytorch_git_ref }}
-      # The reusable workflow expands this to gfx targets via
-      # cmake/therock_amdgpu_targets.cmake.
-      amdgpu_families: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
+      # Per-ref families from configure_pytorch_release_matrix.py; expanded
+      # to gfx targets via cmake/therock_amdgpu_targets.cmake.
+      amdgpu_families: ${{ matrix.amdgpu_families }}
       kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
       rocm_package_find_links_url: ${{ needs.build_python_packages.outputs.package_find_links_url }}
       rocm_version: ${{ inputs.rocm_package_version }}

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -40,9 +40,7 @@ PYTORCH_REFS_LINUX: list[dict] = [
     },
     {
         "pytorch_git_ref": "release/2.11",
-        # gfx125x not yet upstreamed to pytorch/pytorch.
-        # See https://github.com/ROCm/TheRock/issues/5833.
-        "exclude_amdgpu_families": {"gfx125x"},
+        # gfx125x upstreamed via https://github.com/ROCm/pytorch/pull/3346.
     },
     {
         "pytorch_git_ref": "release/2.12",

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -162,9 +162,7 @@ def main(argv: list[str] | None = None) -> int:
     pytorch_refs = None
     if args.pytorch_refs:
         sep = ";" if ";" in args.pytorch_refs else ","
-        pytorch_refs = [
-            r.strip() for r in args.pytorch_refs.split(sep) if r.strip()
-        ]
+        pytorch_refs = [r.strip() for r in args.pytorch_refs.split(sep) if r.strip()]
 
     matrix = generate_pytorch_matrix(
         python_versions,

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -92,12 +92,16 @@ def generate_pytorch_matrix(
     python_versions: list[str] | None,
     amdgpu_families: str,
     platform: str = "linux",
+    pytorch_refs: list[str] | None = None,
 ) -> list[dict]:
     versions = python_versions if python_versions else PYTHON_VERSIONS
-    pytorch_refs = PYTORCH_REFS_WINDOWS if platform == "windows" else PYTORCH_REFS_LINUX
+    refs_cfg = PYTORCH_REFS_WINDOWS if platform == "windows" else PYTORCH_REFS_LINUX
+    if pytorch_refs is not None:
+        ref_set = {r.strip() for r in pytorch_refs if r.strip()}
+        refs_cfg = [cfg for cfg in refs_cfg if cfg["pytorch_git_ref"] in ref_set]
     matrix = []
     for py in versions:
-        for ref_cfg in pytorch_refs:
+        for ref_cfg in refs_cfg:
             ref = ref_cfg["pytorch_git_ref"]
             exclude = ref_cfg.get("exclude_amdgpu_families", set())
             families = _filter_families(amdgpu_families, exclude)
@@ -137,6 +141,15 @@ def main(argv: list[str] | None = None) -> int:
             "filtered out of this list for that ref's matrix entry."
         ),
     )
+    parser.add_argument(
+        "--pytorch-refs",
+        type=str,
+        default="",
+        help=(
+            "Comma or semicolon separated list of PyTorch git refs to include "
+            "(default: all configured refs for the platform)"
+        ),
+    )
     args = parser.parse_args(argv)
 
     python_versions = None
@@ -146,8 +159,18 @@ def main(argv: list[str] | None = None) -> int:
             v.strip() for v in args.python_versions.split(sep) if v.strip()
         ]
 
+    pytorch_refs = None
+    if args.pytorch_refs:
+        sep = ";" if ";" in args.pytorch_refs else ","
+        pytorch_refs = [
+            r.strip() for r in args.pytorch_refs.split(sep) if r.strip()
+        ]
+
     matrix = generate_pytorch_matrix(
-        python_versions, args.amdgpu_families, args.platform
+        python_versions,
+        args.amdgpu_families,
+        args.platform,
+        pytorch_refs,
     )
     gha_set_output({"pytorch_matrix": json.dumps(matrix)})
     return 0

--- a/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
@@ -32,9 +32,7 @@ class ConfigurePyTorchReleaseMatrixTest(unittest.TestCase):
             pytorch_refs=["release/2.11"],
         )
         self.assertEqual(len(matrix), 1)
-        self.assertEqual(
-            matrix[0]["amdgpu_families"], "gfx94X-dcgpu;gfx125X-dcgpu"
-        )
+        self.assertEqual(matrix[0]["amdgpu_families"], "gfx94X-dcgpu;gfx125X-dcgpu")
 
     def test_pytorch_refs_filter_limits_matrix_rows(self) -> None:
         matrix = m.generate_pytorch_matrix(

--- a/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_pytorch_release_matrix_test.py
@@ -1,0 +1,51 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, os.fspath(THIS_DIR.parent))
+
+import configure_pytorch_release_matrix as m
+
+
+class ConfigurePyTorchReleaseMatrixTest(unittest.TestCase):
+    def test_release_2_10_excludes_gfx125x(self) -> None:
+        matrix = m.generate_pytorch_matrix(
+            python_versions=["3.12"],
+            amdgpu_families="gfx94X-dcgpu;gfx125X-dcgpu",
+            platform="linux",
+            pytorch_refs=["release/2.10"],
+        )
+        self.assertEqual(len(matrix), 1)
+        self.assertEqual(matrix[0]["pytorch_git_ref"], "release/2.10")
+        self.assertEqual(matrix[0]["amdgpu_families"], "gfx94X-dcgpu")
+
+    def test_release_2_11_includes_gfx125x(self) -> None:
+        matrix = m.generate_pytorch_matrix(
+            python_versions=["3.12"],
+            amdgpu_families="gfx94X-dcgpu;gfx125X-dcgpu",
+            platform="linux",
+            pytorch_refs=["release/2.11"],
+        )
+        self.assertEqual(len(matrix), 1)
+        self.assertEqual(
+            matrix[0]["amdgpu_families"], "gfx94X-dcgpu;gfx125X-dcgpu"
+        )
+
+    def test_pytorch_refs_filter_limits_matrix_rows(self) -> None:
+        matrix = m.generate_pytorch_matrix(
+            python_versions=["3.12"],
+            amdgpu_families="gfx94X-dcgpu",
+            platform="linux",
+            pytorch_refs=["release/2.10", "release/2.11"],
+        )
+        refs = {row["pytorch_git_ref"] for row in matrix}
+        self.assertEqual(refs, {"release/2.10", "release/2.11"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Enable gfx125x builds for PyTorch release/2.11 now that upstream support has landed, and fix multi-arch CI so per-ref AMDGPU family exclusions are applied the same way they already are in the release workflow.

## Motivation

configure_pytorch_release_matrix.py maintains per-PyTorch-ref AMDGPU family exclusions. Some PyTorch release branches do not yet support certain GPU families (e.g. gfx125x), so those families are filtered out of the build matrix for those refs.

The multi-arch release workflow (multi_arch_release_linux_pytorch_wheels.yml) already uses this script and applies exclusions correctly. The multi-arch CI workflow (multi_arch_ci_linux.yml) did not — it used a hardcoded PyTorch ref matrix and passed the full dist_amdgpu_families list to every build.

This caused CI failures when gfx125x was added to the distribution families: release/2.10 was built with gfx125x even though that ref still excludes it. Example: https://github.com/ROCm/TheRock/actions/runs/28133800797/job/83339718163?pr=6122

## Technical Details

### 1. Enable gfx125x for PyTorch `release/2.11`
Remove the `exclude_amdgpu_families: {"gfx125x"}` entry for `release/2.11` in `configure_pytorch_release_matrix.py`, since gfx125x support is now upstreamed via https://github.com/ROCm/pytorch/pull/3346.
Exclusions remain in place for refs that do not yet support gfx125x:
| PyTorch ref | gfx125x |
|---|---|
| `release/2.9` | excluded |
| `release/2.10` | excluded |
| `release/2.11` | **included** |
| `release/2.12` | excluded |
| `nightly` | excluded |
### 2. Apply per-ref exclusions in multi-arch CI
Update `multi_arch_ci_linux.yml` to match the release workflow pattern:
- Add a `setup_pytorch_matrix` job that runs `configure_pytorch_release_matrix.py`
- Drive `build_pytorch_wheel_fat` from the generated matrix (`matrix.include`) instead of a hardcoded ref list
- Pass per-ref `amdgpu_families` from the matrix output rather than the unfiltered `dist_amdgpu_families`
### 3. Add `--pytorch-refs` CLI option
Extend `configure_pytorch_release_matrix.py` with an optional `--pytorch-refs` flag so CI can limit the matrix to `release/2.10;release/2.11;release/2.12` (with `py3.12`) while still applying per-ref family filtering. The release workflow continues to use all configured refs by default.
### 4. Unit tests
Add `configure_pytorch_release_matrix_test.py` covering:
- `release/2.10` excludes gfx125x
- `release/2.11` includes gfx125x
- `--pytorch-refs` correctly limits matrix rows
## Test plan
- [x] `python -m unittest build_tools.github_actions.tests.configure_pytorch_release_matrix_test`
- [ ] Multi-arch CI PyTorch build for `release/2.10` completes without gfx125x
- [ ] Multi-arch CI PyTorch build for `release/2.11` includes gfx125x
- [ ] Multi-arch release workflow behavior unchanged (still uses full matrix from `configure_pytorch_release_matrix.py`)
## Related
- Upstream gfx125x support: https://github.com/ROCm/pytorch/pull/3346
- gfx125x tracking for other refs ISSUE ID https://github.com/ROCm/TheRock/issues/5833
