### PR TITLE
Mark RDNA3 (gfx1100-1103) and RDNA1/2 (gfx10xx) as Release Ready

### DIFF
--- a/SUPPORTED_GPUS.md
+++ b/SUPPORTED_GPUS.md
@@ -48,23 +48,23 @@ See also the [ROCm Device Support Wishlist GitHub Discussion](https://github.com
 | **RDNA4**    | **gfx1201** | ✅            | ✅            | ✅            |
 | **RDNA4**    | **gfx1200** | ✅            | ✅            | ✅            |
 | **RDNA3.5**  | **gfx1153** | ✅            |               |               |
-| **RDNA3.5**  | **gfx1152** | ✅            |               |               |
-| **RDNA3.5**  | **gfx1151** | ✅            | ✅            |               |
-| **RDNA3.5**  | **gfx1150** | ✅            | ✅            |               |
-| **RDNA3**    | **gfx1103** | ✅            | ✅            |               |
-| **RDNA3**    | **gfx1102** | ✅            | ✅            |               |
-| **RDNA3**    | **gfx1101** | ✅            | ✅            |               |
-| **RDNA3**    | **gfx1100** | ✅            | ✅            |               |
-| RDNA2        | gfx1036     | ✅            |               |               |
-| RDNA2        | gfx1035     | ✅            |               |               |
-| RDNA2        | gfx1034     | ✅            |               |               |
-| RDNA2        | gfx1033     | ✅            |               |               |
-| RDNA2        | gfx1032     | ✅            |               |               |
-| RDNA2        | gfx1031     | ✅            |               |               |
-| RDNA2        | gfx1030     | ✅            |               |               |
-| RDNA1        | gfx1012     | ✅            |               |               |
-| RDNA1        | gfx1011     | ✅            |               |               |
-| RDNA1        | gfx1010     | ✅            |               |               |
+| **RDNA3.5**  | **gfx1152** | ✅            | ✅            | ✅            |
+| **RDNA3.5**  | **gfx1151** | ✅            | ✅            | ✅            |
+| **RDNA3.5**  | **gfx1150** | ✅            | ✅            | ✅            |
+| **RDNA3**    | **gfx1103** | ✅            | ✅            | ✅            |
+| **RDNA3**    | **gfx1102** | ✅            | ✅            | ✅            |
+| **RDNA3**    | **gfx1101** | ✅            | ✅            | ✅            |
+| **RDNA3**    | **gfx1100** | ✅            | ✅            | ✅            |
+| RDNA2        | gfx1036     | ✅            | ✅            | ✅            |
+| RDNA2        | gfx1035     | ✅            | ✅            | ✅            |
+| RDNA2        | gfx1034     | ✅            | ✅            | ✅            |
+| RDNA2        | gfx1033     | ✅            | ✅            | ✅            |
+| RDNA2        | gfx1032     | ✅            | ✅            | ✅            |
+| RDNA2        | gfx1031     | ✅            | ✅            | ✅            |
+| RDNA2        | gfx1030     | ✅            | ✅            | ✅            |
+| RDNA1        | gfx1012     | ✅            | ✅            | ✅            |
+| RDNA1        | gfx1011     | ✅            | ✅            | ✅            |
+| RDNA1        | gfx1010     | ✅            | ✅            | ✅            |
 | GCN5.1       | gfx906      | ✅            |               |               |
 | GCN5.0       | gfx90c      |               |               |               |
 | GCN5.0       | gfx900      | ✅            |               |               |
@@ -80,23 +80,23 @@ Check [windows_support.md](https://github.com/ROCm/TheRock/blob/main/docs/develo
 | **RDNA4**    | **gfx1201** | ✅            |               |               |
 | **RDNA4**    | **gfx1200** | ✅            |               |               |
 | **RDNA3.5**  | **gfx1153** | ✅            |               |               |
-| **RDNA3.5**  | **gfx1152** | ✅            |               |               |
+| **RDNA3.5**  | **gfx1152** | ✅            | ✅            | ✅            |
 | **RDNA3.5**  | **gfx1151** | ✅            | ✅            | ✅            |
-| **RDNA3.5**  | **gfx1150** | ✅            |               |               |
-| **RDNA3**    | **gfx1103** | ✅            |               |               |
-| **RDNA3**    | **gfx1102** | ✅            |               |               |
-| **RDNA3**    | **gfx1101** | ✅            |               |               |
-| **RDNA3**    | **gfx1100** | ✅            |               |               |
-| RDNA2        | gfx1036     | ✅            |               |               |
-| RDNA2        | gfx1035     | ✅            |               |               |
-| RDNA2        | gfx1034     | ✅            |               |               |
-| RDNA2        | gfx1033     | ✅            |               |               |
-| RDNA2        | gfx1032     | ✅            |               |               |
-| RDNA2        | gfx1031     | ✅            |               |               |
-| RDNA2        | gfx1030     | ✅            |               |               |
-| RDNA1        | gfx1012     | ✅            |               |               |
-| RDNA1        | gfx1011     | ✅            |               |               |
-| RDNA1        | gfx1010     | ✅            |               |               |
+| **RDNA3.5**  | **gfx1150** | ✅            | ✅            | ✅            |
+| **RDNA3**    | **gfx1103** | ✅            | ✅            | ✅            |
+| **RDNA3**    | **gfx1102** | ✅            | ✅            | ✅            |
+| **RDNA3**    | **gfx1101** | ✅            | ✅            | ✅            |
+| **RDNA3**    | **gfx1100** | ✅            | ✅            | ✅            |
+| RDNA2        | gfx1036     | ✅            | ✅            | ✅            |
+| RDNA2        | gfx1035     | ✅            | ✅            | ✅            |
+| RDNA2        | gfx1034     | ✅            | ✅            | ✅            |
+| RDNA2        | gfx1033     | ✅            | ✅            | ✅            |
+| RDNA2        | gfx1032     | ✅            | ✅            | ✅            |
+| RDNA2        | gfx1031     | ✅            | ✅            | ✅            |
+| RDNA2        | gfx1030     | ✅            | ✅            | ✅            |
+| RDNA1        | gfx1012     | ✅            | ✅            | ✅            |
+| RDNA1        | gfx1011     | ✅            | ✅            | ✅            |
+| RDNA1        | gfx1010     | ✅            | ✅            | ✅            |
 | GCN5.1       | gfx906      | ✅            |               |               |
 | GCN5.0       | gfx90c      |               |               |               |
 | GCN5.0       | gfx900      | ✅            |               |               |


### PR DESCRIPTION
These architectures are published at repo.amd.com/rocm/whl-multi-arch/ for both Linux and Windows, which by the document's own definition qualifies them as Release Ready and Sanity Tested.
