### PR TITLE
fix(ci): Run tarball build step with bash

### DIFF
--- a/.github/workflows/multi_arch_build_tarballs.yml
+++ b/.github/workflows/multi_arch_build_tarballs.yml
@@ -104,6 +104,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Build tarballs
+        shell: bash
         run: |
           EXTRA_ARGS=()
           if [[ "${{ inputs.include_test_tarballs }}" == "true" ]]; then


### PR DESCRIPTION
## Motivation

Fixes #6138.

## Technical Details

Commit c9629d8b introduced the `python:3.12-slim` job container for AWS kube-mode runners, where GitHub Actions defaults run steps to sh instead of bash.

The tarball exclusion change added Bash array syntax after that, but the PR validation ran used an older workflow run on the Azure runner with `actions/setup-python` and `bash`, so it did not exercise the container default shell used by rockrel.

ISSUE ID #6138

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
