### PR TITLE
feat(manifest-diff): Add manifest-diff link to multi-arch CI setup step summary

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci_summary.py
+++ b/build_tools/github_actions/configure_multi_arch_ci_summary.py
@@ -195,27 +195,29 @@ def _append_build_rocm(
             "-- | -- | -- | --",
         ]
     )
+    linux_output_root = None
     for platform_name in ["linux", "windows"]:
         output_root = WorkflowOutputRoot.from_workflow_run(
             run_id=ci_inputs.run_id, platform=platform_name
         )
+        if platform_name == "linux":
+            linux_output_root = output_root
         log_url = output_root.log_root_index().https_url
         artifact_url = output_root.artifact_index().https_url
         manifest_url = output_root.manifests_index().https_url
         lines.append(
             f"{platform_name.capitalize()} | {log_url} | {artifact_url} | {manifest_url}"
         )
-    output_root = WorkflowOutputRoot.from_workflow_run(
-        run_id=ci_inputs.run_id, platform="linux"
-    )
-    manifest_diff_url = output_root.log_file("manifest-diff", "index.html").https_url
-    lines.append(f"Manifest diff | {manifest_diff_url} | — | —")
+    manifest_diff_url = linux_output_root.log_file(
+        "manifest-diff", "index.html"
+    ).https_url
+    lines.append(f"Manifest diff *(if produced)* | {manifest_diff_url} | — | —")
     lines.append("")
     lines.append(
         "> The manifest-diff report compares submodules across the CI commit range. "
         "Expect no changes when this run does not advance any submodule pointers. "
-        "Manifest-diff is not run on ASAN workflows yet — the report link may be "
-        "unavailable on those runs."
+        "The report is generated after the setup job completes and the link may be "
+        "unavailable until then; it is not produced on ASAN workflows."
     )
 
 

--- a/build_tools/github_actions/configure_multi_arch_ci_summary.py
+++ b/build_tools/github_actions/configure_multi_arch_ci_summary.py
@@ -205,6 +205,18 @@ def _append_build_rocm(
         lines.append(
             f"{platform_name.capitalize()} | {log_url} | {artifact_url} | {manifest_url}"
         )
+    output_root = WorkflowOutputRoot.from_workflow_run(
+        run_id=ci_inputs.run_id, platform="linux"
+    )
+    manifest_diff_url = output_root.log_file("manifest-diff", "index.html").https_url
+    lines.append(f"Manifest diff | {manifest_diff_url} | — | —")
+    lines.append("")
+    lines.append(
+        "> The manifest-diff report compares submodules across the CI commit range. "
+        "Expect no changes when this run does not advance any submodule pointers. "
+        "Manifest-diff is not run on ASAN workflows yet — the report link may be "
+        "unavailable on those runs."
+    )
 
 
 def _append_build_pytorch(lines: list[str], outputs: CIOutputs) -> None:

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1363,6 +1363,7 @@ class TestFormatSummary(unittest.TestCase):
             build_variant_cmake_preset="",
             build_native_linux=True,
             build_pytorch=False,
+            build_jax=False,
         )
         jobs = cm.JobDecisions(
             build_rocm=cm.BuildRocmDecision(action=cm.JobAction.RUN),
@@ -1370,6 +1371,7 @@ class TestFormatSummary(unittest.TestCase):
             build_rocm_python=cm.JobGroupDecision(action=cm.JobAction.RUN),
             build_pytorch=cm.JobGroupDecision(action=cm.JobAction.RUN),
             test_pytorch=cm.JobGroupDecision(action=cm.JobAction.RUN),
+            build_jax=cm.JobGroupDecision(action=cm.JobAction.SKIP),
         )
         outputs = cm.CIOutputs(
             is_ci_enabled=True,

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1353,6 +1353,36 @@ class TestFormatSummary(unittest.TestCase):
         outputs = cm.CIOutputs(is_ci_enabled=False)
         cm.write_outputs(self._inputs(), outputs)
 
+    def test_build_outputs_includes_manifest_diff_link(self):
+        linux = cm.BuildConfig(
+            per_family_info=[],
+            dist_amdgpu_families="gfx94X-dcgpu",
+            artifact_group="gfx94X-dcgpu",
+            build_variant_label="release",
+            build_variant_suffix="",
+            build_variant_cmake_preset="",
+            build_native_linux=True,
+            build_pytorch=False,
+        )
+        jobs = cm.JobDecisions(
+            build_rocm=cm.BuildRocmDecision(action=cm.JobAction.RUN),
+            test_rocm=cm.TestRocmDecision(action=cm.JobAction.RUN, test_type="full"),
+            build_rocm_python=cm.JobGroupDecision(action=cm.JobAction.RUN),
+            build_pytorch=cm.JobGroupDecision(action=cm.JobAction.RUN),
+            test_pytorch=cm.JobGroupDecision(action=cm.JobAction.RUN),
+        )
+        outputs = cm.CIOutputs(
+            is_ci_enabled=True,
+            builds=cm.BuildConfigs(linux=linux),
+            jobs=jobs,
+        )
+        result = format_summary(self._inputs(), outputs)
+        self.assertIn("## Build outputs", result)
+        self.assertIn("Linux |", result)
+        self.assertIn("Windows |", result)
+        self.assertIn("Manifest diff |", result)
+        self.assertIn("12345-linux/logs/manifest-diff/index.html", result)
+
 
 # ---------------------------------------------------------------------------
 # End-to-end: configure() pipeline

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1380,8 +1380,14 @@ class TestFormatSummary(unittest.TestCase):
         self.assertIn("## Build outputs", result)
         self.assertIn("Linux |", result)
         self.assertIn("Windows |", result)
-        self.assertIn("Manifest diff |", result)
-        self.assertIn("12345-linux/logs/manifest-diff/index.html", result)
+        manifest_diff_url = (
+            "https://therock-ci-artifacts.s3.amazonaws.com"
+            "/12345-linux/logs/manifest-diff/index.html"
+        )
+        self.assertIn(
+            f"Manifest diff *(if produced)* | {manifest_diff_url} | — | —",
+            result,
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

The manifest-diff HTML report is generated and uploaded to S3 on multi-arch CI runs, but it isn't currently easy to find. This PR adds the report link to the **setup** job step summary **Build outputs** table — the same place reviewers already use for Logs, Artifacts, and Manifests.

This is the discoverability follow-on called out in #6078 (separate from the bump-breadcrumb PR comment work).

## Technical Details

In `configure_multi_arch_ci_summary.py`, `_append_build_rocm()` now adds a **Manifest diff** row when building the linux output URLs:

- Uses the existing `WorkflowOutputRoot` pattern: `{run_id}-linux/logs/manifest-diff/index.html`
- Reuses the linux `output_root` already created in the platform loop (manifest-diff uploads under the linux run tree)
- Adds a short static note that:
  - the report may show no changes when no submodule pointers moved, and
  - manifest-diff is not run on ASAN workflows yet, so the link may be unavailable there

No workflow, gating, or `generate_manifest_diff_report.py` changes.

## Test Plan

- [x] Open a Multi-Arch CI PR run and confirm the setup step summary **Build outputs** table shows the **Manifest diff** link
- [x] Confirm the S3 URL resolves after the `manifest_diff` job completes

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.