### PR TITLE
docs: surface PR-quality skills in CONTRIBUTING and skills index

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ When you create a pull request, you should target the *main* branch.
 
 > [!TIP]
 > If you use an AI coding assistant (Cursor, Claude Code, etc.), this repo ships PR-quality "skills"
-> that help you author, review, and pre-merge-gate a PR so it lands traceable, tested, and safe to
+> that help you author, review, and pre-merge gate a PR so it lands traceable, tested, and safe to
 > merge. They are advisory and never post to GitHub or Jira without your approval. See
 > [`skills/`](/skills/) for the full index:
 >

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,16 @@ When you create a pull request, you should target the *main* branch.
 - Submit your PR and work with the reviewer or maintainer to get your PR approved
   - If you don't know who to add to a PR as a maintainer, please review the git history to see recently approved PRs in the same file or folder.
 
+> [!TIP]
+> If you use an AI coding assistant (Cursor, Claude Code, etc.), this repo ships PR-quality "skills"
+> that help you author, review, and pre-merge-gate a PR so it lands traceable, tested, and safe to
+> merge. They are advisory and never post to GitHub or Jira without your approval. See
+> [`skills/`](/skills/) for the full index:
+>
+> - [`skills/rocm-pr-quality/`](/skills/rocm-pr-quality/) — the ROCm-wide base (start here).
+> - [`skills/therock-pr-quality/`](/skills/therock-pr-quality/) — TheRock overlay for changes touching
+>   the superbuild, submodules/patches, artifact descriptors, or reusable CI workflows.
+
 > [!IMPORTANT]
 > By creating a PR, you agree to allow your contribution to be licensed under the
 > terms of the [LICENSE](LICENSE) file.
@@ -134,3 +144,6 @@ We have project-wide style guides with recommendations to follow at
 - [CMake Style Guide](/docs/development/style_guides/cmake_style_guide.md)
 - [GitHub Actions Style Guide](/docs/development/style_guides/github_actions_style_guide.md)
 - [Python Style Guide](/docs/development/style_guides/python_style_guide.md)
+
+The PR-quality skills under [`skills/`](/skills/) defer to these same guides, so a finding from a
+review cites the specific guide section rather than inventing new rules.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ When you create a pull request, you should target the *main* branch.
   - If you don't know who to add to a PR as a maintainer, please review the git history to see recently approved PRs in the same file or folder.
 
 > [!TIP]
-> If you use an AI coding assistant (Cursor, Claude Code, etc.), this repo ships PR-quality "skills"
+> If you use an AI coding assistant, this repo ships PR-quality "skills"
 > that help you author, review, and pre-merge gate a PR so it lands traceable, tested, and safe to
 > merge. They are advisory and never post to GitHub or Jira without your approval. See
 > [`skills/`](/skills/) for the full index:

--- a/skills/README.md
+++ b/skills/README.md
@@ -5,14 +5,14 @@ assistant (Cursor, Claude Code, etc.) can load on demand, and that humans can re
 skills here focus on **pull-request quality**: making the high-quality path the easy path so PRs land
 traceable, tested, and safe to merge.
 
-These skills are **advisory**. They help you author, review, and pre-merge-gate a PR, but they do not
+These skills are **advisory**. They help you author, review, and pre-merge gate a PR, but they do not
 approve or block on their own and never post to GitHub or Jira without your explicit approval.
 
 ## PR-quality skills
 
 | Skill                                        | Use it when                                                                                                                                                                                                                                                                      |
 | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`rocm-pr-quality/`](rocm-pr-quality/)       | Authoring, reviewing, or pre-merge-gating **any** ROCm-library PR. This is the library-agnostic base — always start here. See [`SKILL.md`](rocm-pr-quality/SKILL.md) and the detailed rubric in [`reference.md`](rocm-pr-quality/reference.md).                                  |
+| [`rocm-pr-quality/`](rocm-pr-quality/)       | Authoring, reviewing, or pre-merge gating **any** ROCm-library PR. This is the library-agnostic base — always start here. See [`SKILL.md`](rocm-pr-quality/SKILL.md) and the detailed rubric in [`reference.md`](rocm-pr-quality/reference.md).                                  |
 | [`therock-pr-quality/`](therock-pr-quality/) | A PR touches **TheRock build repo**: the superbuild / `cmake/` / `THEROCK_ENABLE_*` options, submodules and patches, `artifact-*.toml` / `BUILD_TOPOLOGY.toml`, or reusable CI workflows. Extends the base — read the base first. See [`SKILL.md`](therock-pr-quality/SKILL.md). |
 
 Each skill exposes three actions you invoke in one sentence:

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,38 @@
+# Skills
+
+This directory holds reusable "skills" — structured guidance and tooling that an AI coding
+assistant (Cursor, Claude Code, etc.) can load on demand, and that humans can read directly. The
+skills here focus on **pull-request quality**: making the high-quality path the easy path so PRs land
+traceable, tested, and safe to merge.
+
+These skills are **advisory**. They help you author, review, and pre-merge-gate a PR, but they do not
+approve or block on their own and never post to GitHub or Jira without your explicit approval.
+
+## PR-quality skills
+
+| Skill                                        | Use it when                                                                                                                                                                                                                                                                      |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`rocm-pr-quality/`](rocm-pr-quality/)       | Authoring, reviewing, or pre-merge-gating **any** ROCm-library PR. This is the library-agnostic base — always start here. See [`SKILL.md`](rocm-pr-quality/SKILL.md) and the detailed rubric in [`reference.md`](rocm-pr-quality/reference.md).                                  |
+| [`therock-pr-quality/`](therock-pr-quality/) | A PR touches **TheRock build repo**: the superbuild / `cmake/` / `THEROCK_ENABLE_*` options, submodules and patches, `artifact-*.toml` / `BUILD_TOPOLOGY.toml`, or reusable CI workflows. Extends the base — read the base first. See [`SKILL.md`](therock-pr-quality/SKILL.md). |
+
+Each skill exposes three actions you invoke in one sentence:
+
+- **Author assist** — "help me write a PR worth reviewing."
+- **Review assist** — "help me review this PR well."
+- **Pre-merge gate** — "is it actually safe to press merge right now?"
+
+Component repositories add their own thin overlays on top (for example, `hipblaslt-pr-quality` in
+`rocm-libraries`). Overlays may tighten but never weaken the base rules.
+
+## Related automated check
+
+[`therock_pr_bot/`](therock_pr_bot/) is the **enforcement** counterpart to the advisory skills: an
+automated policy check (branch-name convention, Conventional Commits PR title, and similar) defined in
+[`policy.yml`](therock_pr_bot/policy.yml). [`FAQ.md`](therock_pr_bot/FAQ.md) explains what each check
+means and how to fix a failure.
+
+## See also
+
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — contribution workflow and PR process.
+- [`docs/development/style_guides/`](../docs/development/style_guides/) — the canonical Bash, CMake,
+  GitHub Actions, and Python style guides the skills defer to.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,7 +1,7 @@
 # Skills
 
 This directory holds reusable "skills" — structured guidance and tooling that an AI coding
-assistant (Cursor, Claude Code, etc.) can load on demand, and that humans can read directly. The
+assistant can load on demand, and that humans can read directly. The
 skills here focus on **pull-request quality**: making the high-quality path the easy path so PRs land
 traceable, tested, and safe to merge.
 


### PR DESCRIPTION
## Summary

The repo ships two PR-quality skills under `skills/` (`rocm-pr-quality` and the TheRock overlay `therock-pr-quality`), but nothing pointed human contributors to them — they were only referenced from `CLAUDE.md`, so discoverability depended on using an AI assistant. This adds a `skills/README.md` index and links to it from `CONTRIBUTING.md` so the skills are findable by people browsing the repo.

## Risk Assessment

Risk 1/5. Documentation-only, additive change; no build, code, or CI behavior is affected.

## Related

ISSUE ID : #6151

- Skills documented: `skills/rocm-pr-quality/`, `skills/therock-pr-quality/` (and the `skills/therock_pr_bot/` policy checker).

## Testing Summary

- Markdown formatting validated with `mdformat` using the plugins pinned in `.pre-commit-config.yaml` (`mdformat-gfm`, `mdformat-frontmatter`, `mdformat-black`).

## Testing Checklist

- [x] Markdown lint/format - `mdformat --check skills/README.md CONTRIBUTING.md` - Status: Passed
- [ ] PR CI - GitHub PR checks - Status: Pending

## Risk Acceptance / Waivers

- `W-DOC`: documentation-only change with no product behavior; no tests required per the self-evident-change exemption.

## Technical Changes

- Add `skills/README.md`: an index of the `skills/` folder covering the two advisory PR-quality skills (with a "use it when" table and the author/review/pre-merge actions) and the `therock_pr_bot` policy checker, plus back-links to `CONTRIBUTING.md` and the style guides.
- `CONTRIBUTING.md`: add a `[!TIP]` in the Pull requests section pointing to `skills/` and the two skills, and a one-line back-reference in Style guides noting the skills defer to those guides. No existing content removed.
