### PR TITLE
docs: have PR-quality skill defer to the repo's machine policy gate

### DIFF
--- a/skills/rocm-pr-quality/SKILL.md
+++ b/skills/rocm-pr-quality/SKILL.md
@@ -35,13 +35,15 @@ ______________________________________________________________________
 1. **Advisory first.** This skill raises the floor; it does not approve and it does not
    block a merge by itself. Hard enforcement (a required CI status check, a merge queue) is a
    separate, DevOps-owned lane. Do not assume it exists.
-1. **Conform to the machine gate; it outranks this skill.** When the repo *does* enforce a
-   machine PR policy — a policy bot, a required status check that parses the branch/title/
-   description, a merge queue — discover its actual configuration at run time and make the PR
-   conform before anything else. Do not re-encode its rules here (they drift); read them live on
-   whichever repo you are on. A machine gate honors none of this skill's waivers or self-evident
-   exemptions, so where they disagree the gate wins. Never assume a human-readable waiver
-   satisfies a machine check.
+1. **Conform to the machine gate; it outranks this skill.** The repo's contributing guide is the
+   source of truth for PR policy, but when a machine gate enforces it — a policy bot, a required
+   status check that parses the branch/title/description, a merge queue — that gate is the hoop a
+   PR must actually clear, so make the PR conform to it before anything else. Both the guide and
+   the gate outrank this skill; it defers to them and never works around the gate. A machine gate
+   honors none of this skill's waivers or self-evident exemptions, so where they disagree the gate
+   wins. When you advise the author to do something solely to satisfy the gate that is **not** in
+   the contributing guide, say so explicitly so they know the requirement came from the gate, not
+   the guide.
 1. **Follow the repo's own standards.** When a component repo ships its own
    testing/contributing/standards docs (e.g. `CONTRIBUTING.md`, a `docs/testing*.md`, a per-repo
    best-practices file), read and apply them rather than inventing guidance. The skill checks that
@@ -157,9 +159,10 @@ not render empty `N/A` fields in the body.
 
 **Workflow:**
 
-1. Detect any machine-enforced PR policy on this repo (a policy-bot config, required status
-   checks) and read its live rules; conform the branch name, title, description, and test layout
-   to it first, since it outranks this skill's defaults and waivers.
+1. Detect any machine-enforced PR policy on this repo (a policy bot, required status checks) and
+   conform the branch name, title, description, and test layout to it first, since it is the gate
+   the PR must clear and it outranks this skill's defaults and waivers. Flag any gate requirement
+   not found in the contributing guide so the author knows where it came from.
 1. Inspect the diff: `gh pr view`, `gh pr diff`, `git diff --stat`, targeted file reads.
 1. Classify the change (one or more classes; stricter when unsure).
 1. Scan branch name, commit messages, and diff for tracker keys, issue numbers, and referenced

--- a/skills/rocm-pr-quality/SKILL.md
+++ b/skills/rocm-pr-quality/SKILL.md
@@ -35,6 +35,13 @@ ______________________________________________________________________
 1. **Advisory first.** This skill raises the floor; it does not approve and it does not
    block a merge by itself. Hard enforcement (a required CI status check, a merge queue) is a
    separate, DevOps-owned lane. Do not assume it exists.
+1. **Conform to the machine gate; it outranks this skill.** When the repo *does* enforce a
+   machine PR policy — a policy bot, a required status check that parses the branch/title/
+   description, a merge queue — discover its actual configuration at run time and make the PR
+   conform before anything else. Do not re-encode its rules here (they drift); read them live on
+   whichever repo you are on. A machine gate honors none of this skill's waivers or self-evident
+   exemptions, so where they disagree the gate wins. Never assume a human-readable waiver
+   satisfies a machine check.
 1. **Follow the repo's own standards.** When a component repo ships its own
    testing/contributing/standards docs (e.g. `CONTRIBUTING.md`, a `docs/testing*.md`, a per-repo
    best-practices file), read and apply them rather than inventing guidance. The skill checks that
@@ -89,6 +96,10 @@ two-sentence reason (and any required approver); the reviewer accepts (`APPROVED
 recorded) or rejects a weak one (`CHANGES REQUESTED`). A bare "N/A" is not a waiver — "why" is mandatory even
 when the rule is waived. Higher-risk waivers need a named approver. Waiver codes are in
 `reference.md`.
+
+Waivers govern the human review floor only. They do **not** override a machine-enforced policy
+gate (see "Conform to the machine gate" in the operating principles): conform to that gate
+regardless of any waiver this skill would otherwise allow.
 
 ### Test substance — the mutation question (and the "why")
 
@@ -146,6 +157,9 @@ not render empty `N/A` fields in the body.
 
 **Workflow:**
 
+1. Detect any machine-enforced PR policy on this repo (a policy-bot config, required status
+   checks) and read its live rules; conform the branch name, title, description, and test layout
+   to it first, since it outranks this skill's defaults and waivers.
 1. Inspect the diff: `gh pr view`, `gh pr diff`, `git diff --stat`, targeted file reads.
 1. Classify the change (one or more classes; stricter when unsure).
 1. Scan branch name, commit messages, and diff for tracker keys, issue numbers, and referenced

--- a/skills/therock-pr-quality/SKILL.md
+++ b/skills/therock-pr-quality/SKILL.md
@@ -53,6 +53,25 @@ Cite the specific guide section for a style finding.
 
 ______________________________________________________________________
 
+## PR-policy gate (authoritative)
+
+TheRock gates PRs with the `therock_pr_bot`. Do **not** re-encode its rules here — read them live so
+they cannot drift out of sync with this overlay:
+
+- Policy config: `skills/therock_pr_bot/policy.yml` — the source of truth for the branch-name shapes,
+  the Conventional-Commits title rule and length bounds, the required `JIRA ID` / `ISSUE ID`
+  reference, the unit-test-file heuristic and its exempt paths, the forbidden-file list, and the
+  external checks that must be green.
+- What each check means and how to fix a failure: `skills/therock_pr_bot/FAQ.md`.
+
+Conform the PR to that live config before author or pre-merge sign-off. This gate is **authoritative
+and overrides the base skill's assumptions**: it honors none of the base waivers or self-evident
+exemptions, so even a docs-only PR must carry a resolving `ISSUE ID` / `JIRA ID` reference, on its own
+line, exactly in the form the config's pattern accepts. On any conflict between this gate and a base
+default, the gate wins.
+
+______________________________________________________________________
+
 ## Supplements
 
 ### Adds — change classes (bind to TheRock paths)

--- a/skills/therock-pr-quality/SKILL.md
+++ b/skills/therock-pr-quality/SKILL.md
@@ -53,22 +53,21 @@ Cite the specific guide section for a style finding.
 
 ______________________________________________________________________
 
-## PR-policy gate (authoritative)
+## PR-policy gate
 
-TheRock gates PRs with the `therock_pr_bot`. Do **not** re-encode its rules here — read them live so
-they cannot drift out of sync with this overlay:
+The source of truth for TheRock's contributing policies is the repo's
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md) — follow it first. In practice those policies are enforced
+by an automated gate (`therock_pr_bot`), which is the hoop every PR must actually clear before it can
+be reviewed. Treat that gate as **authoritative**: conform the PR to it before author or pre-merge
+sign-off, it overrides this skill's waivers and self-evident exemptions, and the skill never works
+around it. This overlay only points at the gate; it does not restate the gate's rules, so if the gate
+is later corrected to match `CONTRIBUTING.md`, the overlay needs no change.
 
-- Policy config: `skills/therock_pr_bot/policy.yml` — the source of truth for the branch-name shapes,
-  the Conventional-Commits title rule and length bounds, the required `JIRA ID` / `ISSUE ID`
-  reference, the unit-test-file heuristic and its exempt paths, the forbidden-file list, and the
-  external checks that must be green.
-- What each check means and how to fix a failure: `skills/therock_pr_bot/FAQ.md`.
-
-Conform the PR to that live config before author or pre-merge sign-off. This gate is **authoritative
-and overrides the base skill's assumptions**: it honors none of the base waivers or self-evident
-exemptions, so even a docs-only PR must carry a resolving `ISSUE ID` / `JIRA ID` reference, on its own
-line, exactly in the form the config's pattern accepts. On any conflict between this gate and a base
-default, the gate wins.
+When you advise the author to do something solely to clear the gate that is **not** stated in
+`CONTRIBUTING.md`, say so explicitly — name it as a gate requirement, not a guide requirement — so the
+author knows where it came from (for example: "the bot requires a resolving `ISSUE ID` / `JIRA ID`
+line even though the contributing guide doesn't, so add one"). `skills/therock_pr_bot/FAQ.md` explains
+how to clear a specific failure.
 
 ______________________________________________________________________
 


### PR DESCRIPTION
## Summary

The `rocm-pr-quality` skill and the `therock_pr_bot` enforcement gate can disagree — most visibly, the skill's work-tracking waivers and self-evident-docs exemptions don't satisfy the bot's hard `ISSUE ID`/`JIRA ID` requirement, so a PR the skill considers ready can still be blocked. This teaches the skill to defer to the machine gate rather than duplicating its rules.

## Risk Assessment

Risk 1/5. Documentation/guidance-only change to skill content; no build, code, or CI behavior is affected.

## Related

ISSUE ID : #6152

Related PRs: #6150 (the skills-discoverability docs that surfaced this gap).

## Testing Summary

- Markdown formatting validated with `mdformat` using the plugins pinned in `.pre-commit-config.yaml`.

## Testing Checklist

- [x] Markdown lint/format - `mdformat --check skills/rocm-pr-quality/SKILL.md skills/therock-pr-quality/SKILL.md` - Status: Passed
- [ ] PR CI - GitHub PR checks - Status: Pending

## Risk Acceptance / Waivers

- `W-DOC`: skill-guidance documentation only; no product behavior. (Note: the machine gate above does not honor this waiver — the `ISSUE ID` line is included to satisfy it.)

## Technical Changes

- `skills/rocm-pr-quality/SKILL.md`: add an operating principle ("Conform to the machine gate; it outranks this skill"), a cross-reference in the Waivers section, and a first Author-assist step to detect and conform to the gate.
- `skills/therock-pr-quality/SKILL.md`: add a "PR-policy gate (authoritative)" section pointing at the live `therock_pr_bot` `policy.yml` and `FAQ.md`, stating the gate overrides base waivers — without re-encoding its rules.
