### PR TITLE
Build "multiarch" tarball even with a single family

### DIFF
--- a/build_tools/build_tarballs.py
+++ b/build_tools/build_tarballs.py
@@ -243,7 +243,7 @@ def main(argv: list[str] | None = None) -> None:
     # files are per individual GPU target and don't conflict, so all
     # families can coexist in a single install prefix.
     kpack_split = is_kpack_split(family_dirs[0])
-    if kpack_split and len(families) > 1:
+    if kpack_split:
         log("::: KPACK_SPLIT_ARTIFACTS detected — building multi-arch tarball")
         multiarch_dir = work_dir / "multiarch"
         fetch_and_flatten(

--- a/build_tools/github_actions/tests/upload_tarballs_test.py
+++ b/build_tools/github_actions/tests/upload_tarballs_test.py
@@ -61,90 +61,41 @@ class TestUploadTarballsRun(unittest.TestCase):
             )
 
     @patch("upload_tarballs.gha_set_output")
-    def test_run_treats_tarball_without_family_as_multiarch(
+    def test_run_exports_multiarch_url_with_other_tarballs_present(
         self,
         mock_gha_set_output,
     ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tarballs_dir = Path(tmpdir)
-            future_multiarch_tarball = tarballs_dir / "therock-dist-linux-7.13.0.tar.gz"
-            future_multiarch_tarball.write_text("x")
 
-            staging_dir = tarballs_dir / "staging"
-            staging_dir.mkdir()
-            rc = mod.run(
-                input_tarballs_dir=tarballs_dir,
-                run_id="25834210506",
-                platform="linux",
-                release_type="dev",
-                output_dir=staging_dir,
+            # This is the default "multiarch" tarball that will have its link
+            # posted to github outputs.
+            base_multiarch_tarball = (
+                tarballs_dir
+                / "therock-dist-linux-multiarch-7.14.0.dev0+13caf791.tar.gz"
             )
+            base_multiarch_tarball.write_text("x")
 
-            self.assertEqual(rc, 0)
-            mock_gha_set_output.assert_called_once()
-
-            payload = mock_gha_set_output.call_args.args[0]
-            urls = json.loads(payload["tarball_urls"])
-
-            self.assertEqual(
-                urls["multiarch"],
-                "https://therock-dev-artifacts.s3.amazonaws.com/"
-                "25834210506-linux/tarballs/therock-dist-linux-7.13.0.tar.gz",
-            )
-
-    @patch("upload_tarballs.gha_set_output")
-    def test_run_exports_base_multiarch_url_when_test_tarball_exists(
-        self,
-        mock_gha_set_output,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tarballs_dir = Path(tmpdir)
-            base_tarball = tarballs_dir / "therock-dist-linux-multiarch-7.13.0.tar.gz"
-            base_tarball.write_text("x")
-            test_tarball = (
-                tarballs_dir / "therock-dist-linux-multiarch-tests-7.13.0.tar.gz"
-            )
-            test_tarball.write_text("x")
-
-            staging_dir = tarballs_dir / "staging"
-            staging_dir.mkdir()
-            rc = mod.run(
-                input_tarballs_dir=tarballs_dir,
-                run_id="25834210506",
-                platform="linux",
-                release_type="dev",
-                output_dir=staging_dir,
-            )
-
-            self.assertEqual(rc, 0)
-            mock_gha_set_output.assert_called_once()
-
-            payload = mock_gha_set_output.call_args.args[0]
-            urls = json.loads(payload["tarball_urls"])
-
-            self.assertEqual(
-                urls["multiarch"],
-                "https://therock-dev-artifacts.s3.amazonaws.com/"
-                "25834210506-linux/tarballs/therock-dist-linux-multiarch-7.13.0.tar.gz",
-            )
-
-    @patch("upload_tarballs.gha_set_output")
-    def test_run_exports_single_base_family_url_when_test_tarball_exists(
-        self,
-        mock_gha_set_output,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tarballs_dir = Path(tmpdir)
-            base_tarball = (
+            # A base per-family tarball (URL not posted).
+            base_family_tarball = (
                 tarballs_dir
                 / "therock-dist-linux-gfx94X-dcgpu-7.14.0.dev0+13caf791.tar.gz"
             )
-            base_tarball.write_text("x")
-            test_tarball = (
+            base_family_tarball.write_text("x")
+
+            # A test multiarch tarball (URL not posted).
+            test_multiarch_tarball = (
+                tarballs_dir
+                / "therock-dist-linux-multiarch-tests-7.14.0.dev0+13caf791.tar.gz"
+            )
+            test_multiarch_tarball.write_text("x")
+
+            # A test per-family tarball (URL not posted).
+            test_family_tarball = (
                 tarballs_dir
                 / "therock-dist-linux-gfx94X-dcgpu-tests-7.14.0.dev0+13caf791.tar.gz"
             )
-            test_tarball.write_text("x")
+            test_family_tarball.write_text("x")
 
             staging_dir = tarballs_dir / "staging"
             staging_dir.mkdir()
@@ -155,39 +106,36 @@ class TestUploadTarballsRun(unittest.TestCase):
                 release_type="dev",
                 output_dir=staging_dir,
             )
-
             self.assertEqual(rc, 0)
-            mock_gha_set_output.assert_called_once()
 
+            # Should have set a single output - just the base multiarch tarball.
+            mock_gha_set_output.assert_called_once()
             payload = mock_gha_set_output.call_args.args[0]
             urls = json.loads(payload["tarball_urls"])
-
             self.assertEqual(
                 urls["multiarch"],
                 "https://therock-dev-artifacts.s3.amazonaws.com/"
                 "27993936036-linux/tarballs/"
-                "therock-dist-linux-gfx94X-dcgpu-7.14.0.dev0%2B13caf791.tar.gz",
+                "therock-dist-linux-multiarch-7.14.0.dev0%2B13caf791.tar.gz",
             )
 
     @patch("upload_tarballs.gha_set_output")
-    def test_run_rejects_multiple_base_family_urls_without_multiarch(
+    def test_run_rejects_base_family_urls_without_multiarch(
         self,
         mock_gha_set_output,
     ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tarballs_dir = Path(tmpdir)
+            # A base per-family tarball that should *not* be treated as
+            # "multiarch", this is an error.
             gfx94x_tarball = (
                 tarballs_dir / "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz"
             )
             gfx94x_tarball.write_text("x")
-            gfx110x_tarball = (
-                tarballs_dir / "therock-dist-linux-gfx110X-all-7.13.0.tar.gz"
-            )
-            gfx110x_tarball.write_text("x")
 
             staging_dir = tarballs_dir / "staging"
             staging_dir.mkdir()
-            with self.assertRaisesRegex(ValueError, "No shared tarball URL"):
+            with self.assertRaisesRegex(ValueError, "No multiarch tarball URL"):
                 mod.run(
                     input_tarballs_dir=tarballs_dir,
                     run_id="25834210506",

--- a/build_tools/github_actions/upload_tarballs.py
+++ b/build_tools/github_actions/upload_tarballs.py
@@ -54,32 +54,25 @@ def _is_test_tarball(name: str) -> bool:
     return "-tests-" in name
 
 
-def _select_shared_tarball_url(
+def _select_multiarch_tarball_url(
     *,
     tarball_files: list[Path],
     output_root: WorkflowOutputRoot,
     platform: str,
 ) -> str | None:
-    shared_tarball_files = [f for f in tarball_files if not _is_test_tarball(f.name)]
+    """Gets the default "multiarch" tarball URL from a list of tarball files.
 
-    for f in shared_tarball_files:
+    Note: this should look simpler once we drop the "multiarch" part of the
+    file name, at which point the file will just be therock-dist-{platform}.
+    """
+
+    # Skip over "test" tarballs, only look at "base" tarballs.
+    non_test_tarball_files = [f for f in tarball_files if not _is_test_tarball(f.name)]
+
+    for f in non_test_tarball_files:
         name = f.name
         if name.startswith(f"therock-dist-{platform}-multiarch-"):
             return _tarball_url(output_root, name)
-
-    if len(shared_tarball_files) == 1:
-        return _tarball_url(output_root, shared_tarball_files[0].name)
-
-    prefix = f"therock-dist-{platform}-"
-    suffix = ".tar.gz"
-
-    for f in shared_tarball_files:
-        name = f.name
-        if name.startswith(prefix) and name.endswith(suffix):
-            stem = name[len(prefix) : -len(suffix)]
-
-            if "-" not in stem:
-                return _tarball_url(output_root, name)
 
     return None
 
@@ -126,18 +119,18 @@ def run(
 
     logger.info("Uploaded %d files", count)
 
-    shared_tarball_url = _select_shared_tarball_url(
+    multiarch_tarball_url = _select_multiarch_tarball_url(
         tarball_files=tarball_files,
         output_root=output_root,
         platform=platform,
     )
 
-    if not shared_tarball_url:
+    if not multiarch_tarball_url:
         raise ValueError(
-            "No shared tarball URL was produced; check tarball naming and upload logic"
+            "No multiarch tarball URL was produced; check tarball naming and upload logic"
         )
 
-    gha_set_output({"tarball_urls": json.dumps({"multiarch": shared_tarball_url})})
+    gha_set_output({"tarball_urls": json.dumps({"multiarch": multiarch_tarball_url})})
 
     return 0
 

--- a/build_tools/tests/build_tarballs_test.py
+++ b/build_tools/tests/build_tarballs_test.py
@@ -143,6 +143,33 @@ class TestMain(unittest.TestCase):
             ["therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz"],
         )
 
+    def test_kpack_builds_common_tarball_with_one_family(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "tarballs"
+            fetch_mock, compress_mock, _ = self._run_main_with_mocks(
+                [
+                    "--run-id=123",
+                    "--dist-amdgpu-families=gfx94X-dcgpu",
+                    "--platform=linux",
+                    "--package-version=7.13.0",
+                    f"--output-dir={output_dir}",
+                ],
+                kpack_split=True,
+            )
+
+        self.assertEqual(fetch_mock.call_count, 2)
+
+        compressed_names = [
+            call.kwargs["tarball_path"].name for call in compress_mock.call_args_list
+        ]
+        self.assertEqual(
+            sorted(compressed_names),
+            [
+                "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz",
+                "therock-dist-linux-multiarch-7.13.0.tar.gz",
+            ],
+        )
+
     def test_include_test_tarballs_builds_both_sets(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "tarballs"
@@ -171,7 +198,7 @@ class TestMain(unittest.TestCase):
             call.kwargs["tarball_path"].name for call in compress_mock.call_args_list
         ]
         self.assertEqual(
-            compressed_names,
+            sorted(compressed_names),
             [
                 "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz",
                 "therock-dist-linux-gfx94X-dcgpu-tests-7.13.0.tar.gz",
@@ -207,12 +234,12 @@ class TestMain(unittest.TestCase):
             call.kwargs["tarball_path"].name for call in compress_mock.call_args_list
         ]
         self.assertEqual(
-            compressed_names,
+            sorted(compressed_names),
             [
-                "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz",
-                "therock-dist-linux-gfx94X-dcgpu-tests-7.13.0.tar.gz",
                 "therock-dist-linux-gfx110X-all-7.13.0.tar.gz",
                 "therock-dist-linux-gfx110X-all-tests-7.13.0.tar.gz",
+                "therock-dist-linux-gfx94X-dcgpu-7.13.0.tar.gz",
+                "therock-dist-linux-gfx94X-dcgpu-tests-7.13.0.tar.gz",
                 "therock-dist-linux-multiarch-7.13.0.tar.gz",
                 "therock-dist-linux-multiarch-tests-7.13.0.tar.gz",
             ],


### PR DESCRIPTION
## Motivation

Related to https://github.com/ROCm/TheRock/issues/4441.

`upload_tarballs.py` attempts to use the "multiarch" tarball which contains all GPU families, but we were only building that tarball if more than one family was used. That _should_ be fine (especially since we want to encourage workflows and downstream users of CI/CD outputs to use that as the standard "I don't care, just give me everything" tarball), so this changes to build script to always generate that tarball, even if it will be bit-identical to a per-family tarball next to it.

https://github.com/ROCm/TheRock/pull/4366 and https://github.com/ROCm/TheRock/pull/6076 have been working around this and writing unit tests that enforce the confusing behavior. I don't think we should do things like treat a single GPU family tarball as "multiarch".

> [!NOTE]
> We were supporting non-multiarch and multiarch callers of this workflow prior to parts of https://github.com/ROCm/TheRock/issues/3340. Now I think it's fine to focus only on multiarch. See from https://github.com/ROCm/TheRock/pull/4448:
> 
> > In this initial implementation,
> >
> > Condition | Behavior
> > -- | --
> > `KPACK_SPLIT_ARTIFACTS` disabled | Creates a single tarball per GPU family
> > `KPACK_SPLIT_ARTIFACTS` enabled | Creates a single tarball per GPU target _and_ a "multiarch" tarball with all GPU targets

> [!NOTE]
> This will make more sense with https://github.com/ROCm/TheRock/pull/4438 which will drop the "multiarch" part of the file name.

## Test Plan

* Updated unit tests
* On `main`: https://github.com/ROCm/TheRock/actions/runs/28195561799/job/83521288089#step:7:32 `OUTPUT tarball_urls={"multiarch": "https://therock-ci-artifacts.s3.amazonaws.com/28195561799-linux/tarballs/therock-dist-linux-gfx94X-dcgpu-7.14.0.dev0%2B4ad52e51462f5a91dcdcfbb75aea27d7132de281.tar.gz"}`
* On this branch, single family generates `multiarch` now: https://github.com/ROCm/TheRock/actions/runs/28197585611/job/83528399523#step:7:35 `OUTPUT tarball_urls={"multiarch": "https://therock-ci-artifacts.s3.amazonaws.com/28197585611-linux/tarballs/therock-dist-linux-multiarch-7.14.0.dev0%2B4ad52e51462f5a91dcdcfbb75aea27d7132de281.tar.gz"}`
* On this branch, multiple families generates `multiarch` still: https://github.com/ROCm/TheRock/actions/runs/28197862787/job/83529372557#step:7:38
    ```
    INFO:__main__:Destination: s3://therock-ci-artifacts/28197862787-linux/tarballs
    INFO:_therock_utils.storage_backend:upload_directory: /home/runner/_work/TheRock/TheRock/tarballs -> therock-ci-artifacts/28197862787-linux/tarballs (3 files)
    INFO:_therock_utils.storage_backend:  therock-dist-linux-gfx1151-7.14.0.dev0+4ad52e51462f5a91dcdcfbb75aea27d7132de281.tar.gz
    INFO:_therock_utils.storage_backend:  therock-dist-linux-gfx94X-dcgpu-7.14.0.dev0+4ad52e51462f5a91dcdcfbb75aea27d7132de281.tar.gz
    INFO:_therock_utils.storage_backend:  therock-dist-linux-multiarch-7.14.0.dev0+4ad52e51462f5a91dcdcfbb75aea27d7132de281.tar.gz
    INFO:__main__:Uploaded 3 files
    Setting github output:
    {
      "tarball_urls": "{\"multiarch\": \"[https://therock-ci-artifacts.s3.amazonaws.com/28197862787-linux/tarballs/therock-dist-linux-multiarch-7.14.0.dev0%2B4ad52e51462f5a91dcdcfbb75aea27d7132de281.tar.gz\](https://therock-ci-artifacts.s3.amazonaws.com/28197862787-linux/tarballs/therock-dist-linux-multiarch-7.14.0.dev0%2B4ad52e51462f5a91dcdcfbb75aea27d7132de281.tar.gz/)"}"
    }
    OUTPUT tarball_urls={"multiarch": "https://therock-ci-artifacts.s3.amazonaws.com/28197862787-linux/tarballs/therock-dist-linux-multiarch-7.14.0.dev0%2B4ad52e51462f5a91dcdcfbb75aea27d7132de281.tar.gz"}
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.