### PR TITLE
fix: Disable RPM stripping for all packages

### DIFF
--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -179,7 +179,7 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
         "conflicts": conflicts,
         "rpmrecommends": rpmrecommends,
         "rpmsuggests": rpmsuggests,
-        "disable_rpm_strip": is_rpm_stripping_disabled(pkg_info),
+        "disable_rpm_strip": True,
         "disable_debug_package": is_debug_package_disabled(pkg_info),
         "sourcedir_list": sourcedir_list,
         "rpm_scripts": rpm_scripts,


### PR DESCRIPTION
Hardcode disable_rpm_strip to True to prevent binary stripping
during RPM package generation, preserving debug symbols.

Jira ID: https://amd-hub.atlassian.net/browse/ROCM-26016

