### PR TITLE
Update version.json: from 7.14.0 to 7.15.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "rocm-version": "7.14.0"
+  "rocm-version": "7.15.0"
 }


### PR DESCRIPTION
## Motivation

The 7.14 release branch is cut ([release/therock-7.14](https://github.com/ROCm/TheRock/tree/release/therock-7.14)), so the version on `main` needs to advance to 7.15.0.

## Technical Details

Bumps `rocm-version` from `7.14.0` to `7.15.0` in `version.json`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Made with [Cursor](https://cursor.com)