### PR TITLE
fix: [ci] Use Nexus service FQDN for Windows choco source

### DIFF
--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Install requirements
         run: |
           choco source disable -n=chocolatey
-          choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
+          choco source add -n=internal -s http://nexus-service.nexus-ns.svc.cluster.local:8081/repository/choco-group/ --priority=1
           choco install --no-progress -y ccache
           # ninja pinned due to a bug in the 1.13.0 release:
           # https://github.com/ninja-build/ninja/issues/2616

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Install requirements
         run: |
           choco source disable -n=chocolatey
-          choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
+          choco source add -n=internal -s http://nexus-service.nexus-ns.svc.cluster.local:8081/repository/choco-group/ --priority=1
           choco install --no-progress -y ninja --version 1.13.1
 
       # Build a fixed version of libuv from source, no matter the pytorch ref.

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Install requirements
         run: |
           choco source disable -n=chocolatey
-          choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
+          choco source add -n=internal -s http://nexus-service.nexus-ns.svc.cluster.local:8081/repository/choco-group/ --priority=1
           choco install --no-progress -y ninja --version 1.13.1
 
       # Build a fixed version of libuv from source, no matter the pytorch ref.


### PR DESCRIPTION
## Summary
- replace hardcoded Nexus IP URLs for choco-group with the service FQDN
- apply only to Windows multi-arch build workflows that currently use the IP endpoint

## Scope
- .github/workflows/multi_arch_build_windows_artifacts.yml
- .github/workflows/multi_arch_build_windows_pytorch_wheels.yml
- .github/workflows/multi_arch_build_windows_pytorch_wheels_ci.yml

ISSUE ID #6167