### PR TITLE
ci(rocprofiler-systems): Keep quick tests below 5 minutes + enable roctx tests

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
@@ -44,14 +44,20 @@ EXCLUDED_LABELS = [
     "thread_limit",
 ]
 
-# Limited to 15 minutes
-QUICK_TESTS_REGEX = [
+# Limited to 5 minutes
+QUICK_TESTS_REGEX_INCLUDES = [
     "transpose.*",
-    "rocprofiler-systems.*",  # Binary tests
-    "config.*",
-    "openmp.*",
-    "roctx.*",
-    "trace-time-window.*",
+    "rocprofiler-systems.*",  # rocprof-sys-* binary smoke tests
+    "config-invalid",
+    "config-missing",
+    "cli-help.*",
+    "openmp-fortran-offload-sys-run",
+    "roctx-sampling",
+    # Jpeg and video decode should be added once the binaries can be built on TheRock
+]
+
+QUICK_TESTS_REGEX_EXCLUDES = [
+    "transpose-runtime-instrument",
 ]
 
 logging.basicConfig(level=logging.INFO)
@@ -102,6 +108,8 @@ def execute_tests():
     # Actual tests
     # Keep passing tests quiet in CI.
     excluded_tests = list(EXCLUDED_TESTS)
+    if test_type == "quick":
+        excluded_tests.extend(QUICK_TESTS_REGEX_EXCLUDES)
 
     cmd = ctest_base + [
         "--output-on-failure",
@@ -115,7 +123,7 @@ def execute_tests():
         # f"{shard_index},,{total_shards}",
     ]
     if test_type == "quick":
-        cmd.extend(["--tests-regex", "|".join(QUICK_TESTS_REGEX)])
+        cmd.extend(["--tests-regex", "|".join(QUICK_TESTS_REGEX_INCLUDES)])
 
     logging.info(f"++ Exec [{THEROCK_PATH}]$ {shlex.join(cmd)}")
     subprocess.run(cmd, cwd=THEROCK_PATH, check=True, env=environ_vars)

--- a/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocprofiler_systems.py
@@ -18,8 +18,6 @@ EXCLUDED_TESTS = [
     "transferbench-sys-run",
     "fork.*",
     "openmp-target.*",
-    "roctx-sampling",
-    "roctx-runtime-instrument",
     "jacobi-usm-sys-run",
     "jacobi-roctx.*",
     "jpeg-decode.*",


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

JIRA ID : AIPROFSYST-585
JIRA ID : AIPROFSYST-522

Per https://github.com/ROCm/TheRock/blob/main/docs/development/test_filtering.md, `quick` tests need to take `<5` minutes. Currently, we take ~10 minutes.

This PR changes the quick test regexes to run a smaller and quicker subset of critical tests.
As the subset of critical tests require `roctx` to run, the tests will be re-enabled.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

`QUICK_TESTS_REGEX_INCLUDES` has been modified to run:
```
    "transpose.*",
    "rocprofiler-systems.*",  # rocprof-sys-* binary smoke tests
    "config-invalid",
    "config-missing",
    "cli-help.*",
    "openmp-fortran-offload-sys-run",
    "roctx-sampling",
```

A `QUICK_TESTS_REGEX_EXCLUDES` has been added to purposely not run:
```
    "transpose-runtime-instrument", # Takes far too long
```

`roctx-sampling` and `roctx-runtime-instrument` have both been removed from the general exclusion list.
The issues regarding both tests were fixed:
 - `roctx-runtime-instrument`: https://github.com/ROCm/rocm-systems/pull/7603 (not run on quick)
 - `roctx-sampling`: https://github.com/ROCm/rocm-systems/pull/7503
 
 And have been running on our CI for some time without any problems: https://github.com/ROCm/rocm-systems/pull/7664

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Workflows - Need to ensure quick filter runs `<5` minutes.
Exactly 128 tests should be ran.

## Test Result

<!-- Briefly summarize test outcomes. -->

**AWAITING NEW RUN**
Manual FULL run: https://github.com/ROCm/TheRock/actions/runs/28454548645
Quick run: (workflow)

**PREVIOUS RUN**
Tests took 3m30s:
https://github.com/ROCm/TheRock/actions/runs/28252075560/job/83725647027?pr=6177


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
