### PR TITLE
feat(ci): Use host-asan for submodule bump PRs instead of full asan

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -996,9 +996,12 @@ def expand_build_configs(
         ["presubmit", "postsubmit", "nightly"]
     )
     build_variant = ci_inputs.build_variant
-    # for ASAN CI runs, workflow_dispatch and scheduled events are "asan".
-    # Otherwise, push events run "host-asan"
-    if build_variant == "asan" and ci_inputs.is_push:
+    # For ASAN CI runs, workflow_dispatch and scheduled events run full "asan".
+    # Push events (postsubmit) and PRs with submodule changes run "host-asan"
+    # to provide faster feedback while still catching host-side ASAN issues.
+    # TODO: Revert PRs to full "asan" once CI capacity is increased. Currently
+    # using host-asan for submodule bump PRs to reduce queue times.
+    if build_variant == "asan" and (ci_inputs.is_push or ci_inputs.is_pull_request):
         build_variant = "host-asan"
 
     linux_config: BuildConfig | None = None

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -984,13 +984,18 @@ class TestExpandBuildConfigs(unittest.TestCase):
         self.assertIsNone(result.windows)
 
     def test_variant_filters_by_trigger(self):
-        """ASAN: based on event type, we run an expected ASAN build variant"""
+        """ASAN: based on event type, we run an expected ASAN build variant.
+
+        Full ASAN builds only run on schedule and workflow_dispatch (nightly).
+        Push (postsubmit) and pull_request events use host-asan for faster feedback.
+        """
         targets = cm.TargetSelection(
             linux_families=["gfx94x"],
         )
         test_cases = [
             ("schedule", "linux-release-asan"),
             ("push", "linux-release-host-asan"),
+            ("pull_request", "linux-release-host-asan"),
             ("workflow_dispatch", "linux-release-asan"),
         ]
         for event_name, expected_variant in test_cases:


### PR DESCRIPTION
Previously, PRs with submodule changes would trigger full ASAN builds, which are expensive and slow. This change makes PRs use host-asan (like postsubmit/push events) for faster feedback while still catching host-side ASAN issues.

Full ASAN builds now only run on:
- schedule (nightly)
- workflow_dispatch (manual trigger)

Host-asan builds run on:
- push (postsubmit)
- pull_request (including submodule bumps)

ISSUE ID : N/A