### PR TITLE
ci: plumb build_runs_on through Windows multiarch workflows

### DIFF
--- a/.github/workflows/multi_arch_build_windows.yml
+++ b/.github/workflows/multi_arch_build_windows.yml
@@ -39,8 +39,8 @@ on:
         description: "Comma-separated build stages to skip (artifacts already copied by the orchestrator)"
       build_runs_on:
         type: string
-        default: ""
-        description: "Build runner label (not currently used for Windows, reserved for future use)"
+        default: "azure-windows-scale-rocm"
+        description: "Build runner label (selected by configure script with weighted distribution)"
       rocm_package_version:
         type: string
       release_type:
@@ -77,6 +77,7 @@ jobs:
       timeout_minutes: 480  # 8 hours (compiler is big)
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      build_runs_on: ${{ inputs.build_runs_on }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
@@ -100,6 +101,7 @@ jobs:
       timeout_minutes: 120  # 2 hours
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      build_runs_on: ${{ inputs.build_runs_on }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
@@ -133,6 +135,7 @@ jobs:
       amdgpu_family: ${{ matrix.family_info.amdgpu_family }}
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      build_runs_on: ${{ inputs.build_runs_on }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
@@ -157,6 +160,7 @@ jobs:
       dist_amdgpu_families: ${{ inputs.dist_amdgpu_families }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       build_variant_cmake_preset: ${{ inputs.build_variant_cmake_preset }}
+      build_runs_on: ${{ inputs.build_runs_on }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -58,6 +58,10 @@ on:
         description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
         type: string
         default: ""
+      build_runs_on:
+        description: "Build runner label (selected by configure script with weighted distribution)"
+        type: string
+        default: "azure-windows-scale-rocm"
       external_repo_config:
         description: "JSON config for external repo checkout (repository, ref, checkout_path, source_package, fetch_sources_args)"
         type: string
@@ -66,7 +70,7 @@ on:
 jobs:
   build_stage:
     name: ${{ inputs.stage_display_name }}
-    runs-on: azure-windows-scale-rocm
+    runs-on: ${{ inputs.build_runs_on }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
     permissions:
       id-token: write

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -51,7 +51,7 @@ jobs:
     if: ${{ fromJSON(inputs.build_config).prebuilt_stages != '' && fromJSON(inputs.build_config).baseline_run_id != '' }}
     # TODO: Consider running on a Linux runner with --platform=windows to
     #   avoid Windows runner setup overhead (setup-python ~51s).
-    runs-on: azure-windows-scale-rocm
+    runs-on: ${{ fromJSON(inputs.build_config).build_runs_on || 'azure-windows-scale-rocm' }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/multi_arch_release_windows.yml
+++ b/.github/workflows/multi_arch_release_windows.yml
@@ -47,6 +47,7 @@ jobs:
       build_variant_label: ${{ fromJSON(inputs.build_config).build_variant_label }}
       build_variant_cmake_preset: ${{ fromJSON(inputs.build_config).build_variant_cmake_preset }}
       build_variant_suffix: ${{ fromJSON(inputs.build_config).build_variant_suffix }}
+      build_runs_on: ${{ fromJSON(inputs.build_config).build_runs_on }}
       rocm_package_version: ${{ inputs.rocm_package_version }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}


### PR DESCRIPTION
## Summary

The `configure_multi_arch_ci.py` script correctly reads `runner-config.json` from `therock-ci-config` and outputs `build_runs_on` in the build config (e.g., `"build_runs_on": "aws-windows-scale-rocm-customer-dev-xlarge2"`), but all downstream Windows build workflows were ignoring this value and hardcoding `azure-windows-scale-rocm`.

This matches the pattern already established for Linux workflows, where `multi_arch_build_portable_linux_artifacts.yml` uses `${{ inputs.build_runs_on }}`.
Issue ID #6181
## Changes

| File | Change |
|------|--------|
| `multi_arch_build_windows_artifacts.yml` | Add `build_runs_on` input (default: `azure-windows-scale-rocm`), use it for `runs-on` |
| `multi_arch_build_windows.yml` | Update `build_runs_on` description/default, pass it to all 4 stage calls |
| `multi_arch_ci_windows.yml` | Use `build_runs_on` from `build_config` for `copy_prebuilt_stages` job |
| `multi_arch_release_windows.yml` | Pass `build_runs_on` when calling `multi_arch_build_windows.yml` |

## Testing

- All pre-commit hooks pass (including actionlint)
- Default values preserve backward compatibility — if `build_runs_on` is not set in the config, workflows fall back to `azure-windows-scale-rocm`