### PR TITLE
fix: Disable RPM stripping for all packages (#6160)

### DIFF
--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -179,7 +179,7 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
         "conflicts": conflicts,
         "rpmrecommends": rpmrecommends,
         "rpmsuggests": rpmsuggests,
-        "disable_rpm_strip": is_rpm_stripping_disabled(pkg_info),
+        "disable_rpm_strip": True,
         "disable_debug_package": is_debug_package_disabled(pkg_info),
         "sourcedir_list": sourcedir_list,
         "rpm_scripts": rpm_scripts,


### PR DESCRIPTION
Hardcode disable_rpm_strip to True to prevent binary stripping during
  RPM package generation.

  Stripping results in executables having differing PHDR offsets and
  VirtAddr values, which causes ld crashes as reported in ROCM-26016.
  Disabling RPM stripping ensures PHDR offsets and VirtAddr match.

  Note: Debian packages already have stripping disabled.

  Cherry-pick: This fix is critical for any branch generating RPM packages
  to avoid ld crashes 
   Original PR: https://github.com/ROCm/TheRock/pull/6160
  Jira ID: https://amd-hub.atlassian.net/browse/ROCM-26016



