### PR TITLE
Fix base git ref edge cases during CI configuration

### DIFF
--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -10,6 +10,7 @@ This module provides utilities to:
 - Decide whether CI should run based on the modified paths
 
 Public API:
+    get_git_commit_hash() - Resolve a git ref to a commit hash
     get_git_modified_paths() - Get modified files from git diff compared to worktree
     get_git_submodule_paths() - Get list of git submodule paths in the repository
     is_ci_run_required() - Check if CI run is required based on modified paths
@@ -31,6 +32,17 @@ _FULL_GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 # ============================================================================
 
 
+def get_git_commit_hash(ref: str) -> str:
+    """Resolve a git ref to its full commit hash."""
+    return subprocess.run(
+        ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        stdout=subprocess.PIPE,
+        check=True,
+        text=True,
+        timeout=60,
+    ).stdout.strip()
+
+
 def get_git_modified_paths(base_ref: str) -> Optional[Iterable[str]]:
     """Returns the paths of files modified since the base reference commit.
 
@@ -43,7 +55,7 @@ def get_git_modified_paths(base_ref: str) -> Optional[Iterable[str]]:
     Returns:
         List of relative file paths that were modified, or None if the operation times out
     """
-    print(f"Computing modified paths with: git diff --name-only {base_ref}")
+    print(f"Computing modified paths with: 'git diff --name-only {base_ref}'")
     try:
         base_ref_is_sha = _FULL_GIT_SHA_RE.fullmatch(base_ref) is not None
         # Push events can advance a branch by multiple commits. The setup

--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -17,9 +17,13 @@ Public API:
 
 import fnmatch
 from pathlib import Path
+import re
 import subprocess
 import sys
 from typing import Iterable, Optional
+
+
+_FULL_GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 
 
 # ============================================================================
@@ -39,7 +43,50 @@ def get_git_modified_paths(base_ref: str) -> Optional[Iterable[str]]:
     Returns:
         List of relative file paths that were modified, or None if the operation times out
     """
+    print(f"Computing modified paths with: git diff --name-only {base_ref}")
     try:
+        base_ref_is_sha = _FULL_GIT_SHA_RE.fullmatch(base_ref) is not None
+        # Push events can advance a branch by multiple commits. The setup
+        # checkout is intentionally shallow, so event.before may be older than
+        # the fetched history even though it is a valid reachable commit.
+        if base_ref_is_sha:
+            is_commit_available_locally = (
+                subprocess.run(
+                    ["git", "cat-file", "-e", f"{base_ref}^{{commit}}"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                    timeout=60,
+                ).returncode
+                == 0
+            )
+        else:
+            is_commit_available_locally = True
+
+        if not is_commit_available_locally:
+            print(
+                f"Base ref {base_ref} is not available locally. "
+                "Fetching it for path filtering..."
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "fetch",
+                    "--no-tags",
+                    "--no-recurse-submodules",
+                    "--depth=1",
+                    "origin",
+                    base_ref,
+                ],
+                stdout=subprocess.PIPE,
+                check=True,
+                text=True,
+                timeout=60,
+            )
+        elif base_ref_is_sha:
+            print(f"Base ref {base_ref} is available locally")
+
+        # We have the commit, now run the diff.
         return subprocess.run(
             ["git", "diff", "--name-only", base_ref],
             stdout=subprocess.PIPE,
@@ -47,7 +94,7 @@ def get_git_modified_paths(base_ref: str) -> Optional[Iterable[str]]:
             text=True,
             timeout=60,
         ).stdout.splitlines()
-    except TimeoutError:
+    except subprocess.TimeoutExpired:
         print(
             "Computing modified files timed out. Not using PR diff to determine"
             " jobs to run.",

--- a/build_tools/github_actions/configure_ci_path_filters.py
+++ b/build_tools/github_actions/configure_ci_path_filters.py
@@ -27,6 +27,42 @@ from typing import Iterable, Optional
 _FULL_GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 
 
+def _ensure_git_commit_available(ref: str) -> None:
+    """Fetch a full SHA when it is missing from the shallow checkout."""
+    if _FULL_GIT_SHA_RE.fullmatch(ref) is None:
+        return
+
+    is_commit_available_locally = (
+        subprocess.run(
+            ["git", "cat-file", "-e", f"{ref}^{{commit}}"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=60,
+        ).returncode
+        == 0
+    )
+    if is_commit_available_locally:
+        return
+
+    print(f"Commit {ref} is not available locally. Fetching it...")
+    subprocess.run(
+        [
+            "git",
+            "fetch",
+            "--no-tags",
+            "--no-recurse-submodules",
+            "--depth=1",
+            "origin",
+            ref,
+        ],
+        stdout=subprocess.PIPE,
+        check=True,
+        text=True,
+        timeout=60,
+    )
+
+
 # ============================================================================
 # Public API
 # ============================================================================
@@ -34,6 +70,7 @@ _FULL_GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 
 def get_git_commit_hash(ref: str) -> str:
     """Resolve a git ref to its full commit hash."""
+    _ensure_git_commit_available(ref)
     return subprocess.run(
         ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
         stdout=subprocess.PIPE,
@@ -57,46 +94,10 @@ def get_git_modified_paths(base_ref: str) -> Optional[Iterable[str]]:
     """
     print(f"Computing modified paths with: 'git diff --name-only {base_ref}'")
     try:
-        base_ref_is_sha = _FULL_GIT_SHA_RE.fullmatch(base_ref) is not None
         # Push events can advance a branch by multiple commits. The setup
         # checkout is intentionally shallow, so event.before may be older than
         # the fetched history even though it is a valid reachable commit.
-        if base_ref_is_sha:
-            is_commit_available_locally = (
-                subprocess.run(
-                    ["git", "cat-file", "-e", f"{base_ref}^{{commit}}"],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    check=False,
-                    timeout=60,
-                ).returncode
-                == 0
-            )
-        else:
-            is_commit_available_locally = True
-
-        if not is_commit_available_locally:
-            print(
-                f"Base ref {base_ref} is not available locally. "
-                "Fetching it for path filtering..."
-            )
-            subprocess.run(
-                [
-                    "git",
-                    "fetch",
-                    "--no-tags",
-                    "--no-recurse-submodules",
-                    "--depth=1",
-                    "origin",
-                    base_ref,
-                ],
-                stdout=subprocess.PIPE,
-                check=True,
-                text=True,
-                timeout=60,
-            )
-        elif base_ref_is_sha:
-            print(f"Base ref {base_ref} is available locally")
+        _ensure_git_commit_available(base_ref)
 
         # We have the commit, now run the diff.
         return subprocess.run(

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -61,6 +61,7 @@ from amdgpu_family_matrix import (
     select_build_runner,
 )
 from configure_ci_path_filters import (
+    get_git_commit_hash,
     get_git_modified_paths,
     get_git_submodule_paths,
     is_ci_run_required,
@@ -202,14 +203,11 @@ class CIInputs:
             # its parent for path filtering.
             if before_ref and before_ref != _NULL_GIT_SHA:
                 base_ref = before_ref
-                print(f"Push event before SHA {before_ref}; using it as diff base")
             elif before_ref == _NULL_GIT_SHA:
-                print(
-                    "Push event before SHA is GitHub's null SHA for a new ref; "
-                    "using HEAD^1 as diff base"
-                )
-            else:
-                print("Push event before SHA is missing; using HEAD^1 as diff base")
+                # Note: we could also use no base ref here. If we would choose
+                # to run only a subset of CI jobs due to changed files, for
+                # branch creation we could just always run all jobs.
+                base_ref = "HEAD^1"
 
         # Test labels come from two sources:
         # 1. LINUX/WINDOWS_TEST_LABELS env vars (workflow_dispatch inputs)
@@ -253,6 +251,11 @@ class GitContext:
     construct GitContext directly without touching git.
     """
 
+    # Resolved commit range used for changed_files.
+    diff_head_commit: str | None = None
+    diff_base_ref: str | None = None
+    diff_base_commit: str | None = None
+
     # List of relative file paths modified relative to a base ref
     changed_files: list[str] | None = None
 
@@ -262,12 +265,18 @@ class GitContext:
     @staticmethod
     def from_repo(base_ref: str) -> "GitContext":
         """Compute from the actual repo. Only called from main()."""
-        print(f"Computing GitContext using diff base {base_ref!r}")
+        print(f"Computing GitContext using base ref {base_ref!r}")
+        diff_head_commit = get_git_commit_hash("HEAD")
+        diff_base_commit = get_git_commit_hash(base_ref)
+        print(f"Diff commit range: {diff_base_commit} -> {diff_head_commit}")
         changed_files = get_git_modified_paths(base_ref)
         submodule_paths = list(get_git_submodule_paths() or [])
         return GitContext(
             changed_files=changed_files,
             submodule_paths=submodule_paths,
+            diff_base_ref=base_ref,
+            diff_base_commit=diff_base_commit,
+            diff_head_commit=diff_head_commit,
         )
 
     @staticmethod
@@ -1175,7 +1184,9 @@ def main():
     elif ci_inputs.is_pull_request or ci_inputs.is_push:
         # 'pull_request' and 'push' events can use the list of changed files
         # compared to the "prior commit" to affect job selections/options.
+        print("=== Git Diff ===")
         git_context = GitContext.from_repo(base_ref=ci_inputs.base_ref)
+        print()
     else:
         # 'workflow_dispatch' and 'schedule' events don't have as natural
         # a "prior commit" to compare against.

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -72,6 +72,8 @@ from github_actions_api import (
     gha_set_output,
 )
 
+_NULL_GIT_SHA = "0" * 40
+
 # ---------------------------------------------------------------------------
 # Input parsing helpers
 # ---------------------------------------------------------------------------
@@ -194,7 +196,20 @@ class CIInputs:
             # The merge commit's first parent is the PR base.
             base_ref = "HEAD^"
         elif event_name == "push":
-            base_ref = event.get("before", "HEAD^1")
+            before_ref = event.get("before")
+            # GitHub uses the null SHA when a push creates a new ref. That
+            # is not a real object, and this workflow only fetches HEAD and
+            # its parent for path filtering.
+            if before_ref and before_ref != _NULL_GIT_SHA:
+                base_ref = before_ref
+                print(f"Push event before SHA {before_ref}; using it as diff base")
+            elif before_ref == _NULL_GIT_SHA:
+                print(
+                    "Push event before SHA is GitHub's null SHA for a new ref; "
+                    "using HEAD^1 as diff base"
+                )
+            else:
+                print("Push event before SHA is missing; using HEAD^1 as diff base")
 
         # Test labels come from two sources:
         # 1. LINUX/WINDOWS_TEST_LABELS env vars (workflow_dispatch inputs)
@@ -247,6 +262,7 @@ class GitContext:
     @staticmethod
     def from_repo(base_ref: str) -> "GitContext":
         """Compute from the actual repo. Only called from main()."""
+        print(f"Computing GitContext using diff base {base_ref!r}")
         changed_files = get_git_modified_paths(base_ref)
         submodule_paths = list(get_git_submodule_paths() or [])
         return GitContext(

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -130,7 +130,7 @@ class CIInputs:
     run_id: str  # GITHUB_RUN_ID value
     event_name: str  # GITHUB_EVENT_NAME value (e.g. "push", "pull_request", "schedule", "workflow_dispatch")
     commit_ref: str  # GITHUB_REF_NAME value
-    base_ref: str  # Git ref for the workflow run (PR base or HEAD^1, used for diffing)
+    base_ref: str | None  # Git ref used for diffing, or None to skip path filters
     build_variant: str  # Build variant label, e.g. "release", "asan", "tsan"
     release_type: str = "ci"  # "ci", or "dev", "nightly", "prerelease" for releases
 
@@ -186,7 +186,7 @@ class CIInputs:
         release_type = os.environ.get("RELEASE_TYPE", "ci")
 
         pr_labels: list[str] = []
-        base_ref = "HEAD^1"
+        base_ref: str | None = "HEAD^1"
         if event_name == "pull_request":
             # Extract label name strings from the event payload's label objects:
             #   Sample input:  [{"name": "ci:skip", "color": "fff", ...}, ...]
@@ -204,10 +204,10 @@ class CIInputs:
             if before_ref and before_ref != _NULL_GIT_SHA:
                 base_ref = before_ref
             elif before_ref == _NULL_GIT_SHA:
-                # Note: we could also use no base ref here. If we would choose
-                # to run only a subset of CI jobs due to changed files, for
-                # branch creation we could just always run all jobs.
-                base_ref = "HEAD^1"
+                # Branch creation pushes do not have a prior branch tip to
+                # diff against. HEAD^1 would only diff the final pushed commit
+                # against its parent, missing earlier commits in the push.
+                base_ref = None
 
         # Test labels come from two sources:
         # 1. LINUX/WINDOWS_TEST_LABELS env vars (workflow_dispatch inputs)
@@ -291,7 +291,7 @@ class GitContext:
     def log(self) -> None:
         """Log git context for CI diagnostics."""
         if self.changed_files is None:
-            print("GitContext: no changed files (schedule/workflow_dispatch)")
+            print("GitContext: no changed files computed")
             return
         print(f"GitContext: {len(self.changed_files)} changed file(s)")
         for path in self.changed_files[:20]:
@@ -1181,12 +1181,19 @@ def main():
     if skip_path_filters:
         # External repo: skip path filtering, run everything
         git_context = GitContext.empty()
-    elif ci_inputs.is_pull_request or ci_inputs.is_push:
+    elif (ci_inputs.is_pull_request or ci_inputs.is_push) and ci_inputs.base_ref:
         # 'pull_request' and 'push' events can use the list of changed files
         # compared to the "prior commit" to affect job selections/options.
         print("=== Git Diff ===")
         git_context = GitContext.from_repo(base_ref=ci_inputs.base_ref)
         print()
+    elif ci_inputs.is_pull_request or ci_inputs.is_push:
+        # Some push events, such as branch creation, do not have a reliable
+        # base ref for changed-file filtering. Run without path filters.
+        print("=== Git Diff ===")
+        print("No diff base is available; running without changed-file filtering")
+        print()
+        git_context = GitContext.empty()
     else:
         # 'workflow_dispatch' and 'schedule' events don't have as natural
         # a "prior commit" to compare against.

--- a/build_tools/github_actions/tests/configure_ci_path_filters_test.py
+++ b/build_tools/github_actions/tests/configure_ci_path_filters_test.py
@@ -3,13 +3,18 @@
 
 from pathlib import Path
 import os
+import subprocess
 import sys
 import unittest
 from unittest.mock import patch
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
-from configure_ci_path_filters import is_ci_run_required, _GITHUB_WORKFLOWS_CI_FILENAMES
+from configure_ci_path_filters import (
+    _GITHUB_WORKFLOWS_CI_FILENAMES,
+    get_git_modified_paths,
+    is_ci_run_required,
+)
 from workflow_utils import get_transitive_workflow_uses
 
 
@@ -60,6 +65,60 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
         paths = ["source_file.h", ".github/workflows/pre-commit.yml"]
         run_ci = is_ci_run_required(paths)
         self.assertTrue(run_ci)
+
+    @patch("configure_ci_path_filters.subprocess.run")
+    def test_missing_base_sha_is_fetched_before_diffing(self, mock_run):
+        base_sha = "f5c168058a7ceaa0f179cc36784b491a11a3adc7"
+
+        def run_side_effect(args, **kwargs):
+            if args == ["git", "cat-file", "-e", f"{base_sha}^{{commit}}"]:
+                return subprocess.CompletedProcess(args=args, returncode=1)
+            if args == ["git", "diff", "--name-only", base_sha]:
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout="compiler/amd-llvm\ncompiler/spirv-llvm-translator\n",
+                )
+            if args == [
+                "git",
+                "fetch",
+                "--no-tags",
+                "--no-recurse-submodules",
+                "--depth=1",
+                "origin",
+                base_sha,
+            ]:
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout="",
+                )
+            self.fail(f"Unexpected subprocess.run call: {args!r}")
+
+        mock_run.side_effect = run_side_effect
+
+        self.assertEqual(
+            get_git_modified_paths(base_sha),
+            ["compiler/amd-llvm", "compiler/spirv-llvm-translator"],
+        )
+
+    @patch("configure_ci_path_filters.subprocess.run")
+    def test_diff_failure_for_available_base_sha_is_not_treated_as_missing(
+        self, mock_run
+    ):
+        base_sha = "f5c168058a7ceaa0f179cc36784b491a11a3adc7"
+
+        def run_side_effect(args, **kwargs):
+            if args == ["git", "cat-file", "-e", f"{base_sha}^{{commit}}"]:
+                return subprocess.CompletedProcess(args=args, returncode=0)
+            if args == ["git", "diff", "--name-only", base_sha]:
+                raise subprocess.CalledProcessError(128, args)
+            self.fail(f"Unexpected subprocess.run call: {args!r}")
+
+        mock_run.side_effect = run_side_effect
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            get_git_modified_paths(base_sha)
 
     def test_ci_workflow_filenames_cover_all_transitive_uses(self):
         """_GITHUB_WORKFLOWS_CI_FILENAMES must exactly match the set of

--- a/build_tools/github_actions/tests/configure_ci_path_filters_test.py
+++ b/build_tools/github_actions/tests/configure_ci_path_filters_test.py
@@ -70,25 +70,22 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
     @patch("configure_ci_path_filters.subprocess.run")
     def test_missing_base_sha_is_fetched_before_diffing(self, mock_run):
         base_sha = "f5c168058a7ceaa0f179cc36784b491a11a3adc7"
+        fetched = False
 
         def run_side_effect(args, **kwargs):
-            if args == ["git", "cat-file", "-e", f"{base_sha}^{{commit}}"]:
+            nonlocal fetched
+            if args[:2] == ["git", "cat-file"]:
                 return subprocess.CompletedProcess(args=args, returncode=1)
-            if args == ["git", "diff", "--name-only", base_sha]:
+            if args[:2] == ["git", "diff"]:
+                if not fetched:
+                    raise subprocess.CalledProcessError(128, args)
                 return subprocess.CompletedProcess(
                     args=args,
                     returncode=0,
                     stdout="compiler/amd-llvm\ncompiler/spirv-llvm-translator\n",
                 )
-            if args == [
-                "git",
-                "fetch",
-                "--no-tags",
-                "--no-recurse-submodules",
-                "--depth=1",
-                "origin",
-                base_sha,
-            ]:
+            if args[:2] == ["git", "fetch"]:
+                fetched = True
                 return subprocess.CompletedProcess(
                     args=args,
                     returncode=0,
@@ -110,9 +107,9 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
         base_sha = "f5c168058a7ceaa0f179cc36784b491a11a3adc7"
 
         def run_side_effect(args, **kwargs):
-            if args == ["git", "cat-file", "-e", f"{base_sha}^{{commit}}"]:
+            if args[:2] == ["git", "cat-file"]:
                 return subprocess.CompletedProcess(args=args, returncode=0)
-            if args == ["git", "diff", "--name-only", base_sha]:
+            if args[:2] == ["git", "diff"]:
                 raise subprocess.CalledProcessError(128, args)
             self.fail(f"Unexpected subprocess.run call: {args!r}")
 
@@ -140,6 +137,36 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
             text=True,
             timeout=60,
         )
+
+    @patch("configure_ci_path_filters.subprocess.run")
+    def test_get_git_commit_hash_fetches_missing_sha_before_resolving(self, mock_run):
+        base_sha = "f5c168058a7ceaa0f179cc36784b491a11a3adc7"
+        fetched = False
+
+        def run_side_effect(args, **kwargs):
+            nonlocal fetched
+            if args[:2] == ["git", "cat-file"]:
+                return subprocess.CompletedProcess(args=args, returncode=1)
+            if args[:2] == ["git", "fetch"]:
+                fetched = True
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout="",
+                )
+            if args[:2] == ["git", "rev-parse"]:
+                if not fetched:
+                    raise subprocess.CalledProcessError(128, args)
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout=f"{base_sha}\n",
+                )
+            self.fail(f"Unexpected subprocess.run call: {args!r}")
+
+        mock_run.side_effect = run_side_effect
+
+        self.assertEqual(get_git_commit_hash(base_sha), base_sha)
 
     def test_ci_workflow_filenames_cover_all_transitive_uses(self):
         """_GITHUB_WORKFLOWS_CI_FILENAMES must exactly match the set of

--- a/build_tools/github_actions/tests/configure_ci_path_filters_test.py
+++ b/build_tools/github_actions/tests/configure_ci_path_filters_test.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from configure_ci_path_filters import (
     _GITHUB_WORKFLOWS_CI_FILENAMES,
+    get_git_commit_hash,
     get_git_modified_paths,
     is_ci_run_required,
 )
@@ -119,6 +120,26 @@ class ConfigureCIPathFiltersTest(unittest.TestCase):
 
         with self.assertRaises(subprocess.CalledProcessError):
             get_git_modified_paths(base_sha)
+
+    @patch("configure_ci_path_filters.subprocess.run")
+    def test_get_git_commit_hash_resolves_ref(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["git", "rev-parse", "--verify", "HEAD^{commit}"],
+            returncode=0,
+            stdout="0123456789abcdef0123456789abcdef01234567\n",
+        )
+
+        self.assertEqual(
+            get_git_commit_hash("HEAD"),
+            "0123456789abcdef0123456789abcdef01234567",
+        )
+        mock_run.assert_called_once_with(
+            ["git", "rev-parse", "--verify", "HEAD^{commit}"],
+            stdout=subprocess.PIPE,
+            check=True,
+            text=True,
+            timeout=60,
+        )
 
     def test_ci_workflow_filenames_cover_all_transitive_uses(self):
         """_GITHUB_WORKFLOWS_CI_FILENAMES must exactly match the set of

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -207,13 +207,13 @@ class TestCIInputsFromEnviron(unittest.TestCase):
         )
         self.assertEqual(inputs.base_ref, "abc123def456")
 
-    def test_push_created_ref_uses_head_parent(self):
-        """Push events for newly created refs fall back to HEAD^1."""
+    def test_push_created_ref_disables_path_filtering(self):
+        """Push events for newly created refs do not have a reliable diff base."""
         inputs = _run_from_environ(
             event_name="push",
             event_payload={"before": "0" * 40},
         )
-        self.assertEqual(inputs.base_ref, "HEAD^1")
+        self.assertIsNone(inputs.base_ref)
 
 
 # ---------------------------------------------------------------------------

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -16,7 +16,7 @@ import tempfile
 import unittest
 from dataclasses import fields
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import configure_multi_arch_ci as cm

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -207,6 +207,14 @@ class TestCIInputsFromEnviron(unittest.TestCase):
         )
         self.assertEqual(inputs.base_ref, "abc123def456")
 
+    def test_push_created_ref_uses_head_parent(self):
+        """Push events for newly created refs fall back to HEAD^1."""
+        inputs = _run_from_environ(
+            event_name="push",
+            event_payload={"before": "0" * 40},
+        )
+        self.assertEqual(inputs.base_ref, "HEAD^1")
+
 
 # ---------------------------------------------------------------------------
 # Step 2: Check Skip CI


### PR DESCRIPTION
## Motivation

As part of CI configuration we compute a list of files changed for the current workflow run then choose which CI jobs to run based on those files changed. For `pull_request` events this is a diff against the base branch. For `push` events it is a diff against (roughly) the prior push event to this branch, which is normally one commit prior when PRs are merged with the "squash and merge" strategy.

This fixes https://github.com/ROCm/TheRock/issues/6162 where CI configuration could fail with `fatal: bad object` under two scenarios:
1. `push` events that create branches, where `github.event.before` is `0000000000000000000000000000000000000000` (a null ref)
2. `push` events containing multiple commits, where the `fetch-depth: 2` checkout did not include the base ref

> [!NOTE]
> This does *not* fix similar issues in [`manifest-diff.yml`](https://github.com/ROCm/TheRock/blob/main/.github/workflows/manifest-diff.yml) and [`generate_manifest_diff_report.py`](https://github.com/ROCm/TheRock/blob/main/build_tools/generate_manifest_diff_report.py), as the implementation choices there are a little different and I wanted to keep this PR focused.

## Technical Details

For branch creation `push` events I decided to not compute a diff against any base ref and always run CI. We could guess and use `HEAD^1` but that wouldn't account for a new branch being created with substantial history that hasn't already run CI jobs on it.

For multiple commit `push` events I considered:
1. Change the fetch depth here to `0` to include all history: https://github.com/ROCm/TheRock/blob/3abb2fc7575fe1eefae0d2b15b535ad74ee541fd/.github/workflows/setup_multi_arch.yml#L115-L122
2. (This PR) Continue to use the existing checkout code and `github.event.before`, but fetch that commit if it is not already available after running `actions/checkout`
3. Use the recently added https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/compute_pr_depth.py
    * This returns `0` (all history) for any event other than `pull_request`. It also scans all intermediate commits, while here we just care about a file diff list across the full span.

## Test Plan

* Branch creation in my fork: https://github.com/ScottTodd/TheRock/actions/runs/28266800472/job/83755324962#step:4:16
    ```
    === Git Diff ===
    No diff base is available; running without changed-file filtering
    ```
* Multiple commit pushes in my fork: https://github.com/ScottTodd/TheRock/actions/runs/28266835536/job/83755431060#step:4:18
    ```
    === Git Diff ===
    Computing GitContext using base ref 'dcc0fcf1de1fa687a41172c6d9361c2b19793502'
    Commit dcc0fcf1de1fa687a41172c6d9361c2b19793502 is not available locally. Fetching it...
    Diff commit range: dcc0fcf1de1fa687a41172c6d9361c2b19793502 -> 3d496efe34dc4d161e2b60fc0e7222c49606a145
    Computing modified paths with: 'git diff --name-only dcc0fcf1de1fa687a41172c6d9361c2b19793502'
    ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
