### PR TITLE
feat: Add JAX release support v0.10.2

### DIFF
--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -86,6 +86,7 @@ jobs:
         jax_ref:
           - "rocm-jaxlib-v0.9.1"
           - "rocm-jaxlib-v0.10.0"
+          - "rocm-jaxlib-v0.10.2"
         include:
           - jax_ref: "rocm-jaxlib-v0.9.1"
             jax_repository: "ROCm/rocm-jax"
@@ -93,6 +94,11 @@ jobs:
             gfx_arch: ""
 
           - jax_ref: "rocm-jaxlib-v0.10.0"
+            jax_repository: "ROCm/jax"
+            build_mode: "manylinux"
+            gfx_arch: "device-all"
+
+          - jax_ref: "rocm-jaxlib-v0.10.2"
             jax_repository: "ROCm/jax"
             build_mode: "manylinux"
             gfx_arch: "device-all"

--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -256,8 +256,9 @@ jobs:
           # Avoid large upfront GPU memory reservation.
           XLA_PYTHON_CLIENT_PREALLOCATE: "false"
 
-          # Set XLA allocator.
-          XLA_PYTHON_CLIENT_ALLOCATOR: platform
+          # Set XLA allocator. JAX 0.10.2 uses the default allocator; all
+          # other releases keep the platform allocator.
+          XLA_PYTHON_CLIENT_ALLOCATOR: ${{ inputs.jax_ref == 'rocm-jaxlib-v0.10.2' && 'default' || 'platform' }}
 
           # Reduce compilation/autotune memory pressure.
           XLA_FLAGS: >-

--- a/external-builds/jax/README.md
+++ b/external-builds/jax/README.md
@@ -37,6 +37,7 @@ Starting with JAX 0.10.0, build support uses the [ROCm/jax](https://github.com/R
 
 | JAX version | Linux                                                                                                           | Windows          |
 | ----------- | --------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 0.10.2      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.10.2`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.10.2)         | ❌ Not supported |
 | 0.10.0      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.10.0`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.10.0)         | ❌ Not supported |
 | 0.9.1       | ✅ Supported via [ROCm/rocm-jax `rocm-jaxlib-v0.9.1`](https://github.com/ROCm/rocm-jax/tree/rocm-jaxlib-v0.9.1) | ❌ Not supported |
 


### PR DESCRIPTION
## Summary
Incremental follow-up to #6054 (JAX 0.10.0 support). Adds the JAX 0.10.2
release to the multi-arch Linux JAX wheel build/test matrix.

- Adds `rocm-jaxlib-v0.10.2` to the release matrix, wired identically to
  0.10.0 (`ROCm/jax`, `manylinux` build mode, `device-all`).
- Uses the **default** XLA allocator (`XLA_PYTHON_CLIENT_ALLOCATOR=default`)
  for the 0.10.2 test cell only; 0.9.1 and 0.10.0 keep `platform`.
- Documents 0.10.2 in the JAX support table.

## Test plan
- [ ] `Multi-Arch Release Linux JAX Wheels` 0.10.2 cell builds wheels
- [ ] JAX test subset passes with the default allocator

I ran full matrix run got all green :
https://github.com/ROCm/TheRock/actions/runs/28336527815/job/83947970257