### PR TITLE
ci(debug-tools): add amd-llvm_dev to rocgdb artifact set and deduplicate

### DIFF
--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -421,6 +421,8 @@ def retrieve_artifacts_by_run_id(args):
             extra_artifacts.append("mpfr")
             extra_artifacts.append("expat")
             extra_artifacts.append("ncurses")
+            # rocgdb tests require amd-llvm_dev for compiler headers/tools.
+            argv.append("amd-llvm_dev")
         if args.fft:
             extra_artifacts.append("fft")
             extra_artifacts.append("fftw3")

--- a/build_tools/tests/install_rocm_from_artifacts_test.py
+++ b/build_tools/tests/install_rocm_from_artifacts_test.py
@@ -4,6 +4,7 @@
 
 """Unit tests for install_rocm_from_artifacts.py."""
 
+import argparse
 from datetime import datetime
 from pathlib import Path
 import os
@@ -127,6 +128,68 @@ class TestReleaseDiscovery(unittest.TestCase):
             families = mod.list_available_nightly_gpu_families("linux")
 
         self.assertEqual(families, {"gfx94X-dcgpu"})
+
+
+def _make_run_id_args(**overrides) -> argparse.Namespace:
+    """Return a minimal args namespace suitable for retrieve_artifacts_by_run_id."""
+    defaults = dict(
+        run_id="12345",
+        artifact_group="gfx110X-all",
+        output_dir=Path("/tmp/therock-test"),
+        # Non-empty amdgpu_targets skips the expand_families call.
+        amdgpu_targets="gfx1100",
+        dry_run=False,
+        run_github_repo=None,
+        base_only=False,
+        aqlprofile=False,
+        blas=False,
+        debug_tools=False,
+        fft=False,
+        hipdnn=False,
+        hipdnn_integration_tests=False,
+        hipdnn_samples=False,
+        hipfile=False,
+        miopen=False,
+        miopenprovider=False,
+        hipkernelprovider=False,
+        hiptensor=False,
+        hipblasltprovider=False,
+        prim=False,
+        rand=False,
+        rccl=False,
+        mpi=False,
+        rocdecode=False,
+        rocjpeg=False,
+        rocjitsu=False,
+        mirage=False,
+        rocprofiler_compute=False,
+        rocprofiler_sdk=False,
+        rocprofiler_systems=False,
+        rocprofiler_systems_examples=False,
+        rocrtst=False,
+        rocalution=False,
+        rocwmma=False,
+        libhipcxx=False,
+        tests=False,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _captured_fetch_argv(args: argparse.Namespace) -> list[str]:
+    """Run retrieve_artifacts_by_run_id and return the argv passed to fetch_artifacts_main."""
+    with mock.patch.object(mod, "fetch_artifacts_main") as mock_fetch:
+        mod.retrieve_artifacts_by_run_id(args)
+        (argv,), _ = mock_fetch.call_args
+    return argv
+
+
+class TestDebugToolsAmdLlvmDev(unittest.TestCase):
+    """Tests that --debug-tools pulls amd-llvm_dev (required for rocgdb testing)."""
+
+    def test_debug_tools_includes_amd_llvm_dev(self) -> None:
+        argv = _captured_fetch_argv(_make_run_id_args(debug_tools=True))
+        self.assertIn("amd-llvm_dev", argv)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
ROCgdb's OpenMP GPU offload tests ([ROCm/ROCgdb#134](https://github.com/ROCm/ROCgdb/pull/134))
fail in CI because `amd-llvm_dev` is missing from the `--debug-tools` artifact set:

```
gdb compile failed, ld.lld: error: unable to find library -lompdevice
clang: error: ld.lld command failed with exit code 1 (use -v to see invocation)
```

`-lompdevice` ships inside `amd-llvm_dev` and is required when building OpenMP GPU
offload programs with `-fopenmp -fopenmp-targets=amdgcn-amd-amdhsa`.

Closes #6204