### PR TITLE
docs: update JAX installation instructions in RELEASES.md

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -305,7 +305,7 @@ Install JAX with ROCm support using the unified multi-arch index.
 Select your GPU target using the `[device-*]` extras from the
 [table above](#supported-python-device--install-extras):
 
-````bash
+```bash
 # Single device (replace device-gfx942 with your GPU):
 pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
     "jax_rocm7_plugin[device-gfx942]" "jax_rocm7_pjrt[device-gfx942]"
@@ -337,7 +337,7 @@ install/
   lib/
   libexec/
   share/
-````
+```
 
 Tarballs are _just_ these raw files. They do not come with "install" steps
 such as setting environment variables.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -302,26 +302,33 @@ more details on supported PyTorch versions and building from source.
 ### Installing multi-arch JAX Python packages
 
 Install JAX with ROCm support using the unified multi-arch index.
-Select your GPU target using the `[device-*]` extras from the
-[table above](#supported-python-device--install-extras):
+
+> [!IMPORTANT]
+> Unlike PyTorch, the JAX wheels do **not** automatically install ROCm packages as a dependency.
+> You must install ROCm first.
 
 ```bash
-# Single device (replace device-gfx942 with your GPU):
+# 1. Install ROCm (replace device-gfx942 with your GPU)
 pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
-    "jax_rocm7_plugin[device-gfx942]" "jax_rocm7_pjrt[device-gfx942]"
+    "rocm[libraries,device-gfx942]"
 
-# Multiple devices (e.g. for a Dockerfile used by both MI300X and MI355X):
+# 2. Install JAX ROCm wheels
 pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
-    "jax_rocm7_plugin[device-gfx942,device-gfx950]" \
-    "jax_rocm7_pjrt[device-gfx942,device-gfx950]"
+    "jax_rocm7_plugin==${JAX_VERSION}" \
+    "jax_rocm7_pjrt==${JAX_VERSION}"
 
-# All supported devices:
-pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
-    "jax_rocm7_plugin[device-all]" "jax_rocm7_pjrt[device-all]"
+# 3. Install matching jax from PyPI
+pip install "jax==${JAX_VERSION}"
 ```
 
 > [!NOTE]
-> Always pin jax, jax_rocm7_plugin, and jax_rocm7_pjrt to the same version (0.9.1 or 0.10.0).
+> Always pin jax, jax_rocm7_plugin, and jax_rocm7_pjrt to the same version.
+> Currently supported versions: 0.9.1 and 0.10.0.
+
+```bash
+pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+    "rocm[libraries,device-gfx942,device-gfx950]"
+```
 
 After installing, verify JAX can see your GPU:
 
@@ -889,17 +896,37 @@ also install `jax_rocm7_plugin` and `jax_rocm7_pjrt`.
 > [!NOTE]
 > By default, pip will install the latest stable versions of each package.
 >
->   See also
+> See also
 >
->   - [Supported JAX versions in TheRock](https://github.com/ROCm/TheRock/tree/main/external-builds/jax#supported-jax-versions)
+> - [Supported JAX versions in TheRock](https://github.com/ROCm/TheRock/tree/main/external-builds/jax#supported-jax-versions)
 
 > [!WARNING]
 > Unlike PyTorch, the JAX wheels do **not** automatically install `rocm[libraries]`
 > as a dependency. You must have ROCm installed separately via a
 > [tarball installation](#installing-from-tarballs) or use `pip install --index-url https://rocm.nightlies.amd.com/v2/<your_gfx_arch>/ rocm[libraries,devel]`.
 
+> [!IMPORTANT]
+> The `jax` package itself is **not** published to the TheRock index.
+>
+> **For JAX 0.8.2 version:** install `jaxlib`, `jax_rocm7_plugin`, and `jax_rocm7_pjrt`
+> from the GPU-family index, then install JAX from [PyPI](https://pypi.org/project/jax/)
+> with `pip install jax==0.8.2`.
+>
+> **For JAX versions > 0.8.2:** install `jax_rocm7_plugin` and `jax_rocm7_pjrt` from the
+> GPU-family index, then install JAX from [PyPI](https://pypi.org/project/jax/) with
+> `pip install jax==<jax_version>`.
+>
+> Always pin all four packages (`jax`, `jaxlib` if applicable, `jax_rocm7_plugin`,
+> `jax_rocm7_pjrt`) to the **same** `<jax_version>` from the table above (e.g. `0.9.2`,
+> `0.9.1`, `0.8.2`). The `==<version>` pin matches the `+rocm...` local-version
+> wheels published on the GPU-family index.
 
 ##### jax for gfx94X-dcgpu
+
+\`\`bash
+pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
+
+# Install matching jax from PyPI
 
 Supported devices in this family:
 
@@ -907,11 +934,26 @@ Supported devices in this family:
 | ------------- | ---------- |
 | MI300A/MI300X | gfx942     |
 
+##### For JAX 0.8.2:
+
+```bash
+pip install --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
+# Install matching jax from PyPI
+pip install jax==0.8.2
+```
+
+###### For JAX 0.8.2:
+
+```bash
+pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
+# Install matching jax from PyPI
+pip install jax==0.8.2
+```
 
 ###### For JAX versions > 0.8.2:
 
 ```bash
-# Replace <jax_version> with one of the supported versions above (e.g. 0.9.1)
+# Replace <jax_version> with one of the supported versions above (e.g. 0.9.1, 0.9.2)
 # — keep all three pins in sync.
 pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ jax_rocm7_plugin==<jax_version> jax_rocm7_pjrt==<jax_version>
 # Install matching jax from PyPI
@@ -926,10 +968,18 @@ Supported devices in this family:
 | ------------- | ---------- |
 | MI350X/MI355X | gfx950     |
 
+###### For JAX 0.8.2:
+
+```bash
+pip install --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
+# Install matching jax from PyPI
+pip install jax==0.8.2
+```
+
 ###### For JAX versions > 0.8.2:
 
 ```bash
-# Replace <jax_version> with one of the supported versions above (e.g.  0.9.1)
+# Replace <jax_version> with one of the supported versions above (e.g.  0.9.2, 0.9.1)
 # — keep all three pins in sync.
 pip install --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ jax_rocm7_plugin==<jax_version> jax_rocm7_pjrt==<jax_version>
 # Install matching jax from PyPI
@@ -947,6 +997,13 @@ Supported devices in this family:
 | AMD RX 7700S / Framework Laptop 16 | gfx1102    |
 | AMD Radeon 780M Laptop iGPU        | gfx1103    |
 
+###### For JAX 0.8.2:
+
+```bash
+pip install --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
+# Install matching jax from PyPI
+pip install jax==0.8.2
+```
 
 ###### For JAX versions > 0.8.2:
 
@@ -966,6 +1023,13 @@ Supported devices in this family:
 | ------------------- | ---------- |
 | AMD Strix Halo iGPU | gfx1151    |
 
+###### For JAX 0.8.2:
+
+```bash
+pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
+# Install matching jax from PyPI
+pip install jax==0.8.2
+```
 
 ###### For JAX versions > 0.8.2:
 
@@ -986,6 +1050,13 @@ Supported devices in this family:
 | AMD RX 9060 / XT | gfx1200    |
 | AMD RX 9070 / XT | gfx1201    |
 
+###### For JAX 0.8.2:
+
+```bash
+pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
+# Install matching jax from PyPI
+pip install jax==0.8.2
+```
 
 ###### For JAX versions > 0.8.2:
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -906,7 +906,7 @@ also install `jaxlib`, `jax_rocm7_plugin`, and `jax_rocm7_pjrt`.
 >
 >   See also
 >
-> - [Supported JAX versions in TheRock](https://github.com/ROCm/TheRock/tree/main/external-builds/jax#supported-jax-versions)
+>   - [Supported JAX versions in TheRock](https://github.com/ROCm/TheRock/tree/main/external-builds/jax#supported-jax-versions)
 
 > [!WARNING]
 > Unlike PyTorch, the JAX wheels do **not** automatically install `rocm[libraries]`

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -328,6 +328,9 @@ pip install "jax==${JAX_VERSION}"
 > Always pin jax, jax_rocm7_plugin, and jax_rocm7_pjrt to the same version.
 > Currently supported versions: 0.9.1 and 0.10.0.
 
+> [!TIP]
+> For multiple devices (e.g. Dockerfile supporting MI300X + MI355X):Bash
+
 ```bash
 pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
     "rocm[libraries,device-gfx942,device-gfx950]"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -25,6 +25,7 @@ Table of contents:
   - [Multi-arch release status](#multi-arch-release-status)
   - [Installing multi-arch ROCm Python packages](#installing-multi-arch-rocm-python-packages)
   - [Installing multi-arch PyTorch Python packages](#installing-multi-arch-pytorch-python-packages)
+  - [Installing multi-arch JAX Python packages](#installing-multi-arch-jax-python-packages)
   - [Supported Python `[device-*]` install extras](#supported-python-device--install-extras)
   - [Installing multi-arch tarballs](#installing-multi-arch-tarballs)
   - [Installing multi-arch native Linux packages](#installing-multi-arch-native-linux-packages)
@@ -329,12 +330,12 @@ pip install "jax==${JAX_VERSION}"
 > Currently supported versions: 0.9.1 and 0.10.0.
 
 > [!TIP]
-> For multiple devices (e.g. Dockerfile supporting MI300X + MI355X):Bash
-
-```bash
-pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
-    "rocm[libraries,device-gfx942,device-gfx950]"
-```
+> For multiple devices (e.g. Dockerfile supporting MI300X + MI355X):
+>
+>```bash
+>pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+>    "rocm[libraries,device-gfx942,device-gfx950]"
+>```
 
 After installing, verify JAX can see your GPU:
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -896,7 +896,15 @@ also install `jaxlib`, `jax_rocm7_plugin`, and `jax_rocm7_pjrt`.
 > [!NOTE]
 > By default, pip will install the latest stable versions of each package.
 >
-> See also
+> - If you want to install other versions, the currently supported versions are:
+>
+>   | jax version | jaxlib version   |
+>   | ----------- | ---------------- |
+>   | 0.9.2       | 0.9.2 (upstream) |
+>   | 0.9.1       | 0.9.1 (upstream) |
+>   | 0.8.2       | 0.8.2            |
+>
+>   See also
 >
 > - [Supported JAX versions in TheRock](https://github.com/ROCm/TheRock/tree/main/external-builds/jax#supported-jax-versions)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -923,24 +923,11 @@ also install `jaxlib`, `jax_rocm7_plugin`, and `jax_rocm7_pjrt`.
 
 ##### jax for gfx94X-dcgpu
 
-\`\`bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
-
-# Install matching jax from PyPI
-
 Supported devices in this family:
 
 | Product Name  | GFX Target |
 | ------------- | ---------- |
 | MI300A/MI300X | gfx942     |
-
-##### For JAX 0.8.2:
-
-```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
-# Install matching jax from PyPI
-pip install jax==0.8.2
-```
 
 ###### For JAX 0.8.2:
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -308,6 +308,9 @@ Install JAX with ROCm support using the unified multi-arch index.
 > You must install ROCm first.
 
 ```bash
+# Set the version (currently supported: 0.9.1 and 0.10.0)
+JAX_VERSION=0.10.0
+
 # 1. Install ROCm (replace device-gfx942 with your GPU)
 pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
     "rocm[libraries,device-gfx942]"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -891,7 +891,7 @@ instructions in the AMD ROCm documentation.
 #### Installing JAX Python packages
 
 Using the index pages [listed above](#installing-rocm-python-packages), you can
-also install `jax_rocm7_plugin` and `jax_rocm7_pjrt`.
+also install `jaxlib`, `jax_rocm7_plugin`, and `jax_rocm7_pjrt`.
 
 > [!NOTE]
 > By default, pip will install the latest stable versions of each package.
@@ -953,7 +953,7 @@ pip install jax==0.8.2
 ###### For JAX versions > 0.8.2:
 
 ```bash
-# Replace <jax_version> with one of the supported versions above (e.g. 0.9.1, 0.9.2)
+# Replace <jax_version> with one of the supported versions above (e.g. 0.9.2, 0.9.1)
 # — keep all three pins in sync.
 pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ jax_rocm7_plugin==<jax_version> jax_rocm7_pjrt==<jax_version>
 # Install matching jax from PyPI
@@ -979,7 +979,7 @@ pip install jax==0.8.2
 ###### For JAX versions > 0.8.2:
 
 ```bash
-# Replace <jax_version> with one of the supported versions above (e.g.  0.9.2, 0.9.1)
+# Replace <jax_version> with one of the supported versions above (e.g. 0.9.2, 0.9.1)
 # — keep all three pins in sync.
 pip install --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ jax_rocm7_plugin==<jax_version> jax_rocm7_pjrt==<jax_version>
 # Install matching jax from PyPI
@@ -1053,7 +1053,7 @@ Supported devices in this family:
 ###### For JAX 0.8.2:
 
 ```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
+pip install --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
 # Install matching jax from PyPI
 pip install jax==0.8.2
 ```

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -299,6 +299,28 @@ print(torch.cuda.get_device_name(0))
 See [external-builds/pytorch/README.md](/external-builds/pytorch/README.md) for
 more details on supported PyTorch versions and building from source.
 
+### Installing multi-arch JAX Python packages
+
+Install JAX with ROCm support using the unified multi-arch index.
+Select your GPU target using the `[device-*]` extras from the
+[table above](#supported-python-device--install-extras):
+
+````bash
+# Single device (replace device-gfx942 with your GPU):
+pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+    "jax_rocm7_plugin[device-gfx942]" "jax_rocm7_pjrt[device-gfx942]"
+
+# Multiple devices (e.g. for a Dockerfile used by both MI300X and MI355X):
+pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+    "jax_rocm7_plugin[device-gfx942,device-gfx950]" \
+    "jax_rocm7_pjrt[device-gfx942,device-gfx950]"
+
+# All supported devices:
+pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+    "jax_rocm7_plugin[device-all]" "jax_rocm7_pjrt[device-all]"
+[!NOTE]
+Always pin jax, jax_rocm7_plugin, and jax_rocm7_pjrt to the same version (0.9.1 or 0.10.0).
+
 ### Installing multi-arch tarballs
 
 Standalone "ROCm SDK tarballs" are a flattened view of ROCm
@@ -315,7 +337,7 @@ install/
   lib/
   libexec/
   share/
-```
+````
 
 Tarballs are _just_ these raw files. They do not come with "install" steps
 such as setting environment variables.
@@ -858,11 +880,10 @@ also install `jaxlib`, `jax_rocm7_plugin`, and `jax_rocm7_pjrt`.
 >
 > - If you want to install other versions, the currently supported versions are:
 >
->   | jax version | jaxlib version   |
->   | ----------- | ---------------- |
->   | 0.9.2       | 0.9.2 (upstream) |
->   | 0.9.1       | 0.9.1 (upstream) |
->   | 0.8.2       | 0.8.2            |
+>   | jax version | jaxlib version    |
+>   | ----------- | ----------------- |
+>   | 0.10.0      | 0.10.0 (upstream) |
+>   | 0.9.1       | 0.9.1 (upstream)  |
 >
 >   See also
 >
@@ -900,7 +921,7 @@ Supported devices in this family:
 ###### For JAX 0.8.2:
 
 ```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
+pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ jaxlib==0.10.0 jax_rocm7_plugin==0.10.0 jax_rocm7_pjrt==0.10.0
 # Install matching jax from PyPI
 pip install jax==0.8.2
 ```
@@ -908,7 +929,7 @@ pip install jax==0.8.2
 ###### For JAX versions > 0.8.2:
 
 ```bash
-# Replace <jax_version> with one of the supported versions above (e.g. 0.9.2, 0.9.1)
+# Replace <jax_version> with one of the supported versions above (e.g. 0.9.1)
 # — keep all three pins in sync.
 pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ jax_rocm7_plugin==<jax_version> jax_rocm7_pjrt==<jax_version>
 # Install matching jax from PyPI
@@ -923,18 +944,10 @@ Supported devices in this family:
 | ------------- | ---------- |
 | MI350X/MI355X | gfx950     |
 
-###### For JAX 0.8.2:
-
-```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
-# Install matching jax from PyPI
-pip install jax==0.8.2
-```
-
 ###### For JAX versions > 0.8.2:
 
 ```bash
-# Replace <jax_version> with one of the supported versions above (e.g. 0.9.2, 0.9.1)
+# Replace <jax_version> with one of the supported versions above (e.g.  0.9.1)
 # — keep all three pins in sync.
 pip install --index-url https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/ jax_rocm7_plugin==<jax_version> jax_rocm7_pjrt==<jax_version>
 # Install matching jax from PyPI

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -318,8 +318,19 @@ pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
 # All supported devices:
 pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
     "jax_rocm7_plugin[device-all]" "jax_rocm7_pjrt[device-all]"
-[!NOTE]
-Always pin jax, jax_rocm7_plugin, and jax_rocm7_pjrt to the same version (0.9.1 or 0.10.0).
+```
+
+> [!NOTE]
+> Always pin jax, jax_rocm7_plugin, and jax_rocm7_pjrt to the same version (0.9.1 or 0.10.0).
+
+After installing, verify JAX can see your GPU:
+
+```python
+import jax
+
+print(jax.devices())
+# [RocmDevice(id=0), RocmDevice(id=1), ...]
+```
 
 ### Installing multi-arch tarballs
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -884,17 +884,10 @@ instructions in the AMD ROCm documentation.
 #### Installing JAX Python packages
 
 Using the index pages [listed above](#installing-rocm-python-packages), you can
-also install `jaxlib`, `jax_rocm7_plugin`, and `jax_rocm7_pjrt`.
+also install `jax_rocm7_plugin` and `jax_rocm7_pjrt`.
 
 > [!NOTE]
 > By default, pip will install the latest stable versions of each package.
->
-> - If you want to install other versions, the currently supported versions are:
->
->   | jax version | jaxlib version    |
->   | ----------- | ----------------- |
->   | 0.10.0      | 0.10.0 (upstream) |
->   | 0.9.1       | 0.9.1 (upstream)  |
 >
 >   See also
 >
@@ -905,21 +898,6 @@ also install `jaxlib`, `jax_rocm7_plugin`, and `jax_rocm7_pjrt`.
 > as a dependency. You must have ROCm installed separately via a
 > [tarball installation](#installing-from-tarballs) or use `pip install --index-url https://rocm.nightlies.amd.com/v2/<your_gfx_arch>/ rocm[libraries,devel]`.
 
-> [!IMPORTANT]
-> The `jax` package itself is **not** published to the TheRock index.
->
-> **For JAX 0.8.2 version:** install `jaxlib`, `jax_rocm7_plugin`, and `jax_rocm7_pjrt`
-> from the GPU-family index, then install JAX from [PyPI](https://pypi.org/project/jax/)
-> with `pip install jax==0.8.2`.
->
-> **For JAX versions > 0.8.2:** install `jax_rocm7_plugin` and `jax_rocm7_pjrt` from the
-> GPU-family index, then install JAX from [PyPI](https://pypi.org/project/jax/) with
-> `pip install jax==<jax_version>`.
->
-> Always pin all four packages (`jax`, `jaxlib` if applicable, `jax_rocm7_plugin`,
-> `jax_rocm7_pjrt`) to the **same** `<jax_version>` from the table above (e.g. `0.9.2`,
-> `0.9.1`, `0.8.2`). The `==<version>` pin matches the `+rocm...` local-version
-> wheels published on the GPU-family index.
 
 ##### jax for gfx94X-dcgpu
 
@@ -929,13 +907,6 @@ Supported devices in this family:
 | ------------- | ---------- |
 | MI300A/MI300X | gfx942     |
 
-###### For JAX 0.8.2:
-
-```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/ jaxlib==0.10.0 jax_rocm7_plugin==0.10.0 jax_rocm7_pjrt==0.10.0
-# Install matching jax from PyPI
-pip install jax==0.8.2
-```
 
 ###### For JAX versions > 0.8.2:
 
@@ -976,13 +947,6 @@ Supported devices in this family:
 | AMD RX 7700S / Framework Laptop 16 | gfx1102    |
 | AMD Radeon 780M Laptop iGPU        | gfx1103    |
 
-###### For JAX 0.8.2:
-
-```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
-# Install matching jax from PyPI
-pip install jax==0.8.2
-```
 
 ###### For JAX versions > 0.8.2:
 
@@ -1002,13 +966,6 @@ Supported devices in this family:
 | ------------------- | ---------- |
 | AMD Strix Halo iGPU | gfx1151    |
 
-###### For JAX 0.8.2:
-
-```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
-# Install matching jax from PyPI
-pip install jax==0.8.2
-```
 
 ###### For JAX versions > 0.8.2:
 
@@ -1029,13 +986,6 @@ Supported devices in this family:
 | AMD RX 9060 / XT | gfx1200    |
 | AMD RX 9070 / XT | gfx1201    |
 
-###### For JAX 0.8.2:
-
-```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx120X-all/ jaxlib==0.8.2 jax_rocm7_plugin==0.8.2 jax_rocm7_pjrt==0.8.2
-# Install matching jax from PyPI
-pip install jax==0.8.2
-```
 
 ###### For JAX versions > 0.8.2:
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -332,10 +332,10 @@ pip install "jax==${JAX_VERSION}"
 > [!TIP]
 > For multiple devices (e.g. Dockerfile supporting MI300X + MI355X):
 >
->```bash
->pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+> ```bash
+> pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
 >    "rocm[libraries,device-gfx942,device-gfx950]"
->```
+> ```
 
 After installing, verify JAX can see your GPU:
 


### PR DESCRIPTION
## Summary
Issue ID: https://github.com/ROCm/TheRock/issues/6226
Updated the JAX section in `RELEASES.md` to reflect current supported versions and installation methods.

### Changes

- **Multi-arch JAX section**: Added clear installation instructions using the unified index (`https://rocm.nightlies.amd.com/whl-multi-arch/`) with `[device-*]` extras.
- Updated supported JAX versions to **0.9.1** and **0.10.0**.
- Added note about version pinning (`jax`, `jax_rocm7_plugin`, `jax_rocm7_pjrt`).
- Improved consistency with the PyTorch documentation section.
- Minor cleanup and better cross-references.

### Related

- https://github.com/ROCm/TheRock/pull/6054 (JAX 0.10.0 support)
- https://github.com/ROCm/rockrel/actions/runs/28346375566 (successful nightly)

This makes the documentation accurate and user-friendly for both 0.9.1 and 0.10.0 users.