### PR TITLE
feat(ci): Adding external family override option specific to MI455 bring up

### DIFF
--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -142,7 +142,8 @@ jobs:
       amdgpu_targets: ${{ matrix.family_info.amdgpu_targets }}
       test_runs_on: ${{ matrix.family_info.test-runs-on }}
       test_type: ${{ inputs.test_type }}
-      test_labels: ${{ inputs.test_labels }}
+      # Per-family test_labels override global test_labels when specified
+      test_labels: ${{ matrix.family_info.test_labels_for_family || inputs.test_labels }}
       sanity_check_only_for_family: ${{ matrix.family_info.sanity_check_only_for_family }}
       changed_projects: ${{ inputs.changed_projects }}
       release_type: ${{ inputs.release_type }}

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -144,7 +144,7 @@ jobs:
       test_type: ${{ inputs.test_type }}
       # Per-family test_labels override global test_labels when specified
       # Convert array to JSON string for workflow input compatibility
-      test_labels: ${{ toJSON(matrix.family_info.test_labels_for_family) != 'null' && toJSON(matrix.family_info.test_labels_for_family) || inputs.test_labels }}
+      test_labels: ${{ matrix.family_info.test_labels_for_family && toJSON(matrix.family_info.test_labels_for_family) || inputs.test_labels }}
       sanity_check_only_for_family: ${{ matrix.family_info.sanity_check_only_for_family }}
       changed_projects: ${{ inputs.changed_projects }}
       release_type: ${{ inputs.release_type }}

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -143,7 +143,8 @@ jobs:
       test_runs_on: ${{ matrix.family_info.test-runs-on }}
       test_type: ${{ inputs.test_type }}
       # Per-family test_labels override global test_labels when specified
-      test_labels: ${{ matrix.family_info.test_labels_for_family || inputs.test_labels }}
+      # Convert array to JSON string for workflow input compatibility
+      test_labels: ${{ toJSON(matrix.family_info.test_labels_for_family) != 'null' && toJSON(matrix.family_info.test_labels_for_family) || inputs.test_labels }}
       sanity_check_only_for_family: ${{ matrix.family_info.sanity_check_only_for_family }}
       changed_projects: ${{ inputs.changed_projects }}
       release_type: ${{ inputs.release_type }}

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -149,7 +149,7 @@ jobs:
           CI_CONFIG_PATH: ci-config
           # External repo family overrides allow callers to add/modify GPU family configs
           # (e.g., adding test runners for architectures not enabled in TheRock's default config)
-          EXTERNAL_FAMILY_OVERRIDES: ${{ inputs.external_repo != '' && fromJSON(inputs.external_repo).family_overrides || '' }}
+          EXTERNAL_FAMILY_OVERRIDES: ${{ inputs.external_repo != '' && toJSON(fromJSON(inputs.external_repo).family_overrides) || '' }}
         run: python ./build_tools/github_actions/configure_multi_arch_ci.py
 
       # Note: Other scripts treat "dev releases" and "CI builds" differently.

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -147,6 +147,9 @@ jobs:
           # Skip path filtering for external repos (git sha won't exist in TheRock)
           SKIP_PATH_FILTERS: ${{ inputs.external_repo != '' && 'true' || '' }}
           CI_CONFIG_PATH: ci-config
+          # External repo family overrides allow callers to add/modify GPU family configs
+          # (e.g., adding test runners for architectures not enabled in TheRock's default config)
+          EXTERNAL_FAMILY_OVERRIDES: ${{ inputs.external_repo != '' && fromJSON(inputs.external_repo).family_overrides || '' }}
         run: python ./build_tools/github_actions/configure_multi_arch_ci.py
 
       # Note: Other scripts treat "dev releases" and "CI builds" differently.

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -217,15 +217,6 @@ jobs:
             kill $(cat /tmp/dmesg_pid) 2>/dev/null || true
           fi
 
-      - name: Upload dmesg log
-        if: ${{ always() && runner.os == 'Linux' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: dmesg-${{ inputs.amdgpu_families }}-${{ fromJSON(inputs.component).job_name }}-shard${{ matrix.shard }}
-          path: ${{ github.workspace }}/dmesg.log
-          retention-days: 7
-          if-no-files-found: ignore
-
       - name: Post-job cleanup GPU processes on Linux
         if: ${{ always() && runner.os == 'Linux' }}
         timeout-minutes: 5

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -210,12 +210,16 @@ jobs:
             --print-cmd \
             ${{ fromJSON(inputs.component).fetch_artifact_args && format('--fetch-artifact-args="{0}"', fromJSON(inputs.component).fetch_artifact_args) || '' }}
 
-      - name: Stop dmesg monitoring
+      - name: Print dmesg log
         if: ${{ always() && runner.os == 'Linux' }}
         run: |
           if [ -f /tmp/dmesg_pid ]; then
             kill $(cat /tmp/dmesg_pid) 2>/dev/null || true
           fi
+          echo "=== dmesg log ==="
+          cat ${{ github.workspace }}/dmesg.log || true
+          echo "=== GPU-related messages ==="
+          grep -iE "amdgpu|drm|gpu|fault|hang|reset|error" ${{ github.workspace }}/dmesg.log || echo "No GPU-related messages found"
 
       - name: Post-job cleanup GPU processes on Linux
         if: ${{ always() && runner.os == 'Linux' }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -159,6 +159,15 @@ jobs:
           echo "HSA_XNACK=1" >> $GITHUB_ENV
           echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
 
+      - name: Start dmesg monitoring
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          # Capture dmesg continuously to detect GPU hangs/page faults if runner crashes
+          dmesg --clear || true
+          dmesg -w > ${{ github.workspace }}/dmesg.log 2>&1 &
+          echo $! > /tmp/dmesg_pid
+          echo "Started dmesg monitoring (PID: $(cat /tmp/dmesg_pid))"
+
       - name: Test
         id: test
         timeout-minutes: ${{ fromJSON(inputs.component).timeout_minutes }}
@@ -200,6 +209,22 @@ jobs:
             --test-type "${{ fromJSON(inputs.component).test_type }}" \
             --print-cmd \
             ${{ fromJSON(inputs.component).fetch_artifact_args && format('--fetch-artifact-args="{0}"', fromJSON(inputs.component).fetch_artifact_args) || '' }}
+
+      - name: Stop dmesg monitoring
+        if: ${{ always() && runner.os == 'Linux' }}
+        run: |
+          if [ -f /tmp/dmesg_pid ]; then
+            kill $(cat /tmp/dmesg_pid) 2>/dev/null || true
+          fi
+
+      - name: Upload dmesg log
+        if: ${{ always() && runner.os == 'Linux' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dmesg-${{ inputs.amdgpu_families }}-${{ fromJSON(inputs.component).job_name }}-shard${{ matrix.shard }}
+          path: ${{ github.workspace }}/dmesg.log
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Post-job cleanup GPU processes on Linux
         if: ${{ always() && runner.os == 'Linux' }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -159,15 +159,6 @@ jobs:
           echo "HSA_XNACK=1" >> $GITHUB_ENV
           echo "ASAN_SYMBOLIZER_PATH=${{ env.OUTPUT_ARTIFACTS_DIR }}/llvm/bin/llvm-symbolizer" >> $GITHUB_ENV
 
-      - name: Start dmesg monitoring
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          # Capture dmesg continuously to detect GPU hangs/page faults if runner crashes
-          dmesg --clear || true
-          dmesg -w > ${{ github.workspace }}/dmesg.log 2>&1 &
-          echo $! > /tmp/dmesg_pid
-          echo "Started dmesg monitoring (PID: $(cat /tmp/dmesg_pid))"
-
       - name: Test
         id: test
         timeout-minutes: ${{ fromJSON(inputs.component).timeout_minutes }}
@@ -209,17 +200,6 @@ jobs:
             --test-type "${{ fromJSON(inputs.component).test_type }}" \
             --print-cmd \
             ${{ fromJSON(inputs.component).fetch_artifact_args && format('--fetch-artifact-args="{0}"', fromJSON(inputs.component).fetch_artifact_args) || '' }}
-
-      - name: Print dmesg log
-        if: ${{ always() && runner.os == 'Linux' }}
-        run: |
-          if [ -f /tmp/dmesg_pid ]; then
-            kill $(cat /tmp/dmesg_pid) 2>/dev/null || true
-          fi
-          echo "=== dmesg log ==="
-          cat ${{ github.workspace }}/dmesg.log || true
-          echo "=== GPU-related messages ==="
-          grep -iE "amdgpu|drm|gpu|fault|hang|reset|error" ${{ github.workspace }}/dmesg.log || echo "No GPU-related messages found"
 
       - name: Post-job cleanup GPU processes on Linux
         if: ${{ always() && runner.os == 'Linux' }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -89,11 +89,6 @@ jobs:
       BENCHMARK_DB_URL: ${{ secrets.BENCHMARK_DB_URL }}
       BENCHMARK_DB_FALLBACK_URL: ${{ secrets.BENCHMARK_DB_FALLBACK_URL }}
     steps:
-      - name: Check GPU isolation env vars
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          echo "ROCR_VISIBLE_DEVICES=${ROCR_VISIBLE_DEVICES:-<not set>}"
-
       - name: "Fetch 'build_tools' from repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -89,6 +89,11 @@ jobs:
       BENCHMARK_DB_URL: ${{ secrets.BENCHMARK_DB_URL }}
       BENCHMARK_DB_FALLBACK_URL: ${{ secrets.BENCHMARK_DB_FALLBACK_URL }}
     steps:
+      - name: Check GPU isolation env vars
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          echo "ROCR_VISIBLE_DEVICES=${ROCR_VISIBLE_DEVICES:-<not set>}"
+
       - name: "Fetch 'build_tools' from repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -946,6 +946,11 @@ def _expand_build_config_for_platform(
         }
         if test_runs_on and "test-runs-on-labels" in platform_info:
             family_info["test-runs-on-labels"] = platform_info["test-runs-on-labels"]
+        # Per-family test labels allow limiting which tests run for specific architectures
+        if "test_labels_for_family" in platform_info:
+            family_info["test_labels_for_family"] = platform_info[
+                "test_labels_for_family"
+            ]
         per_family_info.append(family_info)
 
     if not per_family_info:
@@ -981,6 +986,40 @@ def _expand_build_config_for_platform(
     )
 
 
+def _apply_external_family_overrides(all_families: dict) -> dict:
+    """Apply external family overrides from EXTERNAL_FAMILY_OVERRIDES env var.
+
+    TEMPORARY: This function supports MI455 bringup in rocm-systems by allowing
+    external repos to specify per-family config overrides (test runners, test labels).
+
+    To revert: Delete this function and its call in expand_build_configs().
+    """
+    external_overrides_json = os.environ.get("EXTERNAL_FAMILY_OVERRIDES", "")
+    if not external_overrides_json:
+        return all_families
+
+    try:
+        import json
+
+        external_overrides = json.loads(external_overrides_json)
+        for family_name, family_config in external_overrides.items():
+            if family_name in all_families:
+                # Merge overrides into existing family config
+                for platform, platform_config in family_config.items():
+                    if platform in all_families[family_name]:
+                        all_families[family_name][platform].update(platform_config)
+                    else:
+                        all_families[family_name][platform] = platform_config
+            else:
+                # Add new family
+                all_families[family_name] = family_config
+            print(f"  Applied external family override for {family_name}")
+    except json.JSONDecodeError as e:
+        print(f"  Warning: Failed to parse EXTERNAL_FAMILY_OVERRIDES: {e}")
+
+    return all_families
+
+
 def expand_build_configs(
     ci_inputs: CIInputs,
     git_context: GitContext,
@@ -995,6 +1034,15 @@ def expand_build_configs(
     all_families = get_all_families_for_trigger_types(
         ["presubmit", "postsubmit", "nightly"]
     )
+
+    # =========================================================================
+    # TEMPORARY: External family overrides for MI455 bringup in rocm-systems
+    # TODO(geomin12): Remove this block once MI455 is fully enabled in
+    #                 therock-ci-config or this bringup phase is complete.
+    # To revert: delete this block and the corresponding EXTERNAL_FAMILY_OVERRIDES
+    #            env var in setup_multi_arch.yml
+    # =========================================================================
+    all_families = _apply_external_family_overrides(all_families)
     build_variant = ci_inputs.build_variant
     # For ASAN CI runs, workflow_dispatch and scheduled events run full "asan".
     # Push events (postsubmit) and PRs with submodule changes run "host-asan"

--- a/build_tools/github_actions/detect_external_repo_config.py
+++ b/build_tools/github_actions/detect_external_repo_config.py
@@ -427,12 +427,16 @@ def main(argv=None):
             .replace("_SOURCE_DIR", "")
         )
 
-        # Extract projects from external_repo JSON if provided
+        # Extract projects and family_overrides from external_repo JSON if provided
         projects = ""
+        family_overrides = {}
         if args.external_repo_json:
             try:
                 external_repo = json.loads(args.external_repo_json)
                 projects = external_repo.get("projects", "")
+                # family_overrides allows external repos to specify per-family config
+                # (e.g., test runners, test_labels_for_family) for their CI runs only
+                family_overrides = external_repo.get("family_overrides", {})
             except json.JSONDecodeError as e:
                 print(
                     f"Warning: failed to parse external_repo_json: {e}",
@@ -446,6 +450,7 @@ def main(argv=None):
             "source_package": source_package,
             "fetch_sources_args": config.get("fetch_sources_args", ""),
             "projects": projects,
+            "family_overrides": family_overrides,
         }
         config["config_json"] = json.dumps(config_json)
         print(

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -54,11 +54,13 @@ def _get_script_path(script_name: str) -> str:
 # --ipc host - Allows shared memory between host and container
 # --user 0:0 - Running as root, by recommendation of GitHub: https://docs.github.com/en/actions/reference/workflows-and-actions/dockerfile-support#user
 # --ulimit memlock=-1:-1 - Prevents memory allocation issues with ROCm inside container
+# --ulimit nofile=1048576:1048576 - Increase open file limit for RCCL
 # --security-opt seccomp=unconfined - enables memory mapping, and is recommended for containers running in HPC environments
 _BASE_CONTAINER_OPTIONS = [
     "--ipc host",
     "--user 0:0",
     "--ulimit memlock=-1:-1",
+    "--ulimit nofile=1048576:1048576",
     "--security-opt seccomp=unconfined",
 ]
 

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -150,11 +150,11 @@ test_matrix = {
     "hip-tests": {
         "job_name": "hip-tests",
         "fetch_artifact_args": "--tests",
-        "timeout_minutes": 400,
+        "timeout_minutes": 120,
         "test_script": f"python {_get_script_path('test_hiptests.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
-            "linux": 1,
+            "linux": 4,
             "windows": 4,
         },
     },

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -148,11 +148,11 @@ test_matrix = {
     "hip-tests": {
         "job_name": "hip-tests",
         "fetch_artifact_args": "--tests",
-        "timeout_minutes": 120,
+        "timeout_minutes": 400,
         "test_script": f"python {_get_script_path('test_hiptests.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
-            "linux": 4,
+            "linux": 1,
             "windows": 4,
         },
     },

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -70,6 +70,7 @@ _BASE_CONTAINER_OPTIONS = [
 # --device /dev/dri - Direct Rendering Infrastructure devices
 # --group-add 993,992,110 - Additional GPU-related groups
 # --env-file /etc/podinfo/gha-gpu-isolation-settings - Required for GPU isolation on OSSCI MIXXX runners
+# -e ROCR_VISIBLE_DEVICES - Pass host's GPU isolation env var to container (used on ARC runners)
 _GPU_CONTAINER_OPTIONS = [
     "--group-add video",
     "--device /dev/kfd",
@@ -78,6 +79,7 @@ _GPU_CONTAINER_OPTIONS = [
     "--group-add 992",
     "--group-add 110",
     "--env-file /etc/podinfo/gha-gpu-isolation-settings",
+    "-e ROCR_VISIBLE_DEVICES",
 ]
 
 

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -89,25 +89,7 @@ TEST_TO_IGNORE = {
     },
     "gfx125X-dcgpu": {
         "linux": [
-            "Unit_hipGraphExecMemcpyNodeSetParams1D_Positive_Basic",
-            "Unit_hipGraph_SimpleGraphWithKernel",
-            "Unit_hipGraphUserObj_HostRegister",
-            "Unit_hipGraphNodeGetType_ClonedGraph_InThread_WithDependencies",
-            "Unit_hipGraphHostNodeSetParams_BasicFunc",
-            "Unit_hipStreamBeginCapture_nestedStreamCapture",
-            "Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchDoubleKernel",
-            "Unit_hiprtcCombiComplrOptnTst",
-            "Unit_hipGraphInstantiateWithFlags_WithDefaultAndAutoFreeOnLaunch",
-            "Unit_hipGraphGetRootNodes_Functional",
-            "Unit_hiprtc_includepath",
             "Unit_hipGraphAddMemcpyNode1D_Positive_Basic",
-            "Unit_hipGraphAddMemcpyNodeToSymbol_MemcpyToSymbolNodeWithKernel",
-            "Unit_hipGraphChildGraphNodeGetGraph_Functional",
-            "Unit_hipGraphExecMemcpyNodeSetParams_Positive_Basic",
-            "Unit_hipGraphGetRootNodes_CapturedStream",
-            "Unit_hipGraphNodeGetType_NodeTypeOfChildGraph",
-            "Unit_hipGraphInstantiateWithParams_DependencyGraph",
-            "Unit_hipGraphMemcpyNodeSetParams1D_Positive_Basic",
         ]
     },
 }
@@ -189,6 +171,8 @@ def execute_tests(env):
         "--test-dir",
         CATCH_TESTS_PATH,
         "--output-on-failure",
+        "--timeout",
+        "600",
     ]
 
     # If quick tests are enabled, run only the smoke test subset

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -95,6 +95,8 @@ TEST_TO_IGNORE = {
             "Unit_hipGraphNodeGetType_ClonedGraph_InThread_WithDependencies",
             "Unit_hipGraphHostNodeSetParams_BasicFunc",
             "Unit_hipStreamBeginCapture_nestedStreamCapture",
+            "Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchDoubleKernel",
+            "Unit_hiprtcCombiComplrOptnTst",
         ]
     },
 }

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -175,9 +175,10 @@ def setup_env(env):
     else:
         copy_dlls_exe_path()
 
-    # Disable SDMA for gfx125X-dcgpu
+    # Set env vars for gfx125X-dcgpu
     if AMDGPU_FAMILIES == "gfx125X-dcgpu":
-        env["HSA_ENABLE_SDMA"] = "0"
+        env["HSA_ENABLE_SDMA"] = "1"
+        env["ROCR_VISIBLE_DEVICES"] = "0"
 
 
 def execute_tests(env):

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -160,7 +160,6 @@ def setup_env(env):
     # Set env vars for gfx125X-dcgpu
     if AMDGPU_FAMILIES == "gfx125X-dcgpu":
         env["HSA_ENABLE_SDMA"] = "1"
-        env["ROCR_VISIBLE_DEVICES"] = "0"
 
 
 def execute_tests(env):

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -107,6 +107,7 @@ TEST_TO_IGNORE = {
             "Unit_hipGraphGetRootNodes_CapturedStream",
             "Unit_hipGraphNodeGetType_NodeTypeOfChildGraph",
             "Unit_hipGraphInstantiateWithParams_DependencyGraph",
+            "Unit_hipGraphMemcpyNodeSetParams1D_Positive_Basic",
         ]
     },
 }

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -159,6 +159,10 @@ def setup_env(env):
     else:
         copy_dlls_exe_path()
 
+    # Disable SDMA for gfx125X-dcgpu
+    if AMDGPU_FAMILIES == "gfx125X-dcgpu":
+        env["HSA_ENABLE_SDMA"] = "0"
+
 
 def execute_tests(env):
     cmd = [

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -87,6 +87,13 @@ TEST_TO_IGNORE = {
             "Unit_hipStreamValue_Wait_Blocking - uint32_t",
         ]
     },
+    "gfx125X-dcgpu": {
+        "linux": [
+            "Unit_hipGraphExecMemcpyNodeSetParams1D_Positive_Basic",
+            "Unit_hipGraph_SimpleGraphWithKernel",
+            "Unit_hipGraphUserObj_HostRegister",
+        ]
+    },
 }
 
 

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -92,6 +92,9 @@ TEST_TO_IGNORE = {
             "Unit_hipGraphExecMemcpyNodeSetParams1D_Positive_Basic",
             "Unit_hipGraph_SimpleGraphWithKernel",
             "Unit_hipGraphUserObj_HostRegister",
+            "Unit_hipGraphNodeGetType_ClonedGraph_InThread_WithDependencies",
+            "Unit_hipGraphHostNodeSetParams_BasicFunc",
+            "Unit_hipStreamBeginCapture_nestedStreamCapture",
         ]
     },
 }

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -176,7 +176,7 @@ def setup_env(env):
 
     # Disable SDMA for gfx125X-dcgpu
     if AMDGPU_FAMILIES == "gfx125X-dcgpu":
-        env["HSA_ENABLE_SDMA"] = "0"
+        env["HSA_ENABLE_SDMA"] = "1"
 
 
 def execute_tests(env):

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -103,6 +103,10 @@ TEST_TO_IGNORE = {
             "Unit_hipGraphAddMemcpyNode1D_Positive_Basic",
             "Unit_hipGraphAddMemcpyNodeToSymbol_MemcpyToSymbolNodeWithKernel",
             "Unit_hipGraphChildGraphNodeGetGraph_Functional",
+            "Unit_hipGraphExecMemcpyNodeSetParams_Positive_Basic",
+            "Unit_hipGraphGetRootNodes_CapturedStream",
+            "Unit_hipGraphNodeGetType_NodeTypeOfChildGraph",
+            "Unit_hipGraphInstantiateWithParams_DependencyGraph",
         ]
     },
 }

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -177,7 +177,7 @@ def setup_env(env):
 
     # Disable SDMA for gfx125X-dcgpu
     if AMDGPU_FAMILIES == "gfx125X-dcgpu":
-        env["HSA_ENABLE_SDMA"] = "1"
+        env["HSA_ENABLE_SDMA"] = "0"
 
 
 def execute_tests(env):

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -101,6 +101,8 @@ TEST_TO_IGNORE = {
             "Unit_hipGraphGetRootNodes_Functional",
             "Unit_hiprtc_includepath",
             "Unit_hipGraphAddMemcpyNode1D_Positive_Basic",
+            "Unit_hipGraphAddMemcpyNodeToSymbol_MemcpyToSymbolNodeWithKernel",
+            "Unit_hipGraphChildGraphNodeGetGraph_Functional",
         ]
     },
 }

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -97,6 +97,10 @@ TEST_TO_IGNORE = {
             "Unit_hipStreamBeginCapture_nestedStreamCapture",
             "Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchDoubleKernel",
             "Unit_hiprtcCombiComplrOptnTst",
+            "Unit_hipGraphInstantiateWithFlags_WithDefaultAndAutoFreeOnLaunch",
+            "Unit_hipGraphGetRootNodes_Functional",
+            "Unit_hiprtc_includepath",
+            "Unit_hipGraphAddMemcpyNode1D_Positive_Basic",
         ]
     },
 }


### PR DESCRIPTION
As MI455 only needs to run on rocm-systems multi-arch CI nightly, I am adding the external family override option specific to MI455 rocm-systems. 

With this option tested here: https://github.com/ROCm/rocm-systems/actions/runs/28422102951 and https://github.com/ROCm/rocm-systems/compare/users/geomin12/mi455-bringup?expand=1, this works! tested here on regular test_artifacts.yml: https://github.com/ROCm/TheRock/actions/runs/28422921667/job/84219935945

hip-tests also require ROCR_VISIBLE_DEVICES specifically, so adding that to the docker container (if available). if not available, it is no-op. this works here: https://github.com/ROCm/rocm-systems/actions/runs/28422102951