### PR TITLE
test(packaging): add build_package routing and variant unit tests

### DIFF
--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -186,7 +186,7 @@ ZYPP_REFRESH_TIMEOUT_SEC = 120
 DNF_CLEAN_TIMEOUT_SEC = 60
 INSTALL_TIMEOUT_SEC = 1800  # 30 minutes
 ROCMINFO_TIMEOUT_SEC = 30
-RDHC_TIMEOUT_SEC = 30
+RDHC_TIMEOUT_SEC = 600  # RDHC Timeout Fix
 VERIFY_MIN_COMPONENTS = 2
 _TEST_TYPE_MAP = {
     "": "sanity",
@@ -1003,7 +1003,12 @@ gpgcheck=0
         cmd = [sys.executable, str(rdhc_script)]
 
         # Set RDHC arguments for full test
-        test_args = ["--rocm-install-prefix", rocm_install_prefix_arg, "--all"]
+        test_args = [
+            "--rocm-install-prefix",
+            rocm_install_prefix_arg,
+            "--all",
+            "--skip-optional-cluster-checks",
+        ]
         print(
             f"\nRun rdhc.py with --rocm-install-prefix {rocm_install_prefix_arg} --all..."
         )

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -186,7 +186,10 @@ ZYPP_REFRESH_TIMEOUT_SEC = 120
 DNF_CLEAN_TIMEOUT_SEC = 60
 INSTALL_TIMEOUT_SEC = 1800  # 30 minutes
 ROCMINFO_TIMEOUT_SEC = 30
-RDHC_TIMEOUT_SEC = 600  # RDHC Timeout Fix
+# rdhc.py ``--all`` runs the full ROCm deployment health check suite; 30s was too
+# short in container CI (timeouts under load). Optional cluster checks are skipped
+# separately via ``--skip-optional-cluster-checks`` in ``test_rdhc``.
+RDHC_TIMEOUT_SEC = 600  # 10 minutes
 VERIFY_MIN_COMPONENTS = 2
 _TEST_TYPE_MAP = {
     "": "sanity",

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -7,8 +7,9 @@
 Tests stage artifact trees by walking ``package.json`` via ``get_package_info()`` and
 the same ``{Artifact}_{Component}_{suffix}`` layout consumed by
 ``filter_components_fromartifactory``. Config is built via ``create_package_config()``.
-DEB generation runs through real ``create_versioned_deb_package()``; only
-``package_with_dpkg_build`` and ``move_packages_to_destination`` are mocked.
+DEB generation runs through real ``create_versioned_deb_package()``; RPM generation
+runs through real ``create_versioned_rpm_package()``; only ``package_with_dpkg_build`` /
+``package_with_rpmbuild`` and ``move_packages_to_destination`` are mocked.
 
 Run::
 
@@ -39,6 +40,8 @@ TEST_INSTALL_PREFIX = "/opt/rocm/core"
 TEST_GFX_TARGET = "gfx1100"
 TEST_GFX_TARGET_ALT = "gfx942"
 TEST_PKG_TYPE_DEB = "deb"
+TEST_PKG_TYPE_RPM = "rpm"
+TEST_BUILD_ARCH = "x86_64"
 
 PKG_FFT = "amdrocm-fft"
 PKG_CORE_SDK = "amdrocm-core-sdk"
@@ -78,6 +81,7 @@ def _load_module(name: str, path: Path) -> types.ModuleType:
 _setup_import_path()
 build_package = _load_module("build_package", LINUX_DIR / "build_package.py")
 deb_package = _load_module("deb_package", LINUX_DIR / "deb_package.py")
+rpm_package = _load_module("rpm_package", LINUX_DIR / "rpm_package.py")
 
 # packaging_utils depends on sys.path setup above.
 from packaging_utils import (  # noqa: E402
@@ -143,13 +147,25 @@ def _write_kpack_manifest(artifacts_dir: Path) -> None:
         raise RuntimeError(f"Failed to write kpack manifest: {manifest_path}")
 
 
-def _control_field(control_text: str, field: str) -> str:
-    """Return the value of a ``debian/control`` field (e.g. ``Package``)."""
+def _metadata_field(metadata_text: str, field: str) -> str:
+    """Return the value of a DEB control or RPM spec field (e.g. ``Package`` / ``Name``)."""
     prefix = f"{field}:"
-    for line in control_text.splitlines():
+    for line in metadata_text.splitlines():
         if line.startswith(prefix):
             return line.split(":", 1)[1].strip()
-    raise AssertionError(f"Field {field!r} not found in control file:\n{control_text}")
+    raise AssertionError(
+        f"Field {field!r} not found in metadata file:\n{metadata_text}"
+    )
+
+
+def _control_field(control_text: str, field: str) -> str:
+    """Return the value of a ``debian/control`` field (e.g. ``Package``)."""
+    return _metadata_field(control_text, field)
+
+
+def _spec_field(spec_text: str, field: str) -> str:
+    """Return the value of an RPM ``specfile`` field (e.g. ``Name``)."""
+    return _metadata_field(spec_text, field)
 
 
 def _artifact_suffix_for_staging(
@@ -270,6 +286,20 @@ def _read_control_file(pkg_name: str, config: PackageConfig) -> str:
     if not control_path.exists():
         raise AssertionError(f"Expected control file was not created: {control_path}")
     return control_path.read_text(encoding="utf-8")
+
+
+def _spec_path(pkg_name: str, config: PackageConfig) -> Path:
+    """Return path to generated RPM ``specfile`` for a versioned RPM build."""
+    updated = update_package_name(pkg_name, replace(config, versioned_pkg=True))
+    return Path(config.dest_dir) / config.pkg_type / updated / "specfile"
+
+
+def _read_spec_file(pkg_name: str, config: PackageConfig) -> str:
+    """Read generated RPM ``specfile`` after validating it was created."""
+    spec_path = _spec_path(pkg_name=pkg_name, config=config)
+    if not spec_path.exists():
+        raise AssertionError(f"Expected spec file was not created: {spec_path}")
+    return spec_path.read_text(encoding="utf-8")
 
 
 def _stage_fft_kpack_tree(artifacts_dir: Path, *, include_host: bool = False) -> None:
@@ -449,6 +479,96 @@ class CreateVersionedDebPackageTest(BuildPackageTestCase):
         control = _read_control_file(pkg_name=PKG_DEVELOPER_TOOLS, config=versioned_cfg)
         self.assertEqual(_control_field(control, "Package"), DEVELOPER_TOOLS_PACKAGE)
         self.assertIn("amdrocm-debugger", _control_field(control, "Depends"))
+
+
+# ---------------------------------------------------------------------------
+# create_versioned_rpm_package — real spec file generation
+# ---------------------------------------------------------------------------
+class CreateVersionedRpmPackageTest(BuildPackageTestCase):
+    """Real ``create_versioned_rpm_package`` with API-staged artifacts."""
+
+    @patch.object(rpm_package, "move_packages_to_destination", return_value=[])
+    @patch.object(rpm_package, "package_with_rpmbuild")
+    def test_fft_host_generates_spec_file(
+        self, _mock_rpmbuild: object, _mock_move: object
+    ) -> None:
+        cfg = _kpack_config(self.temp_dir, pkg_type=TEST_PKG_TYPE_RPM)
+        _stage_package_artifacts(
+            pkg_name=PKG_FFT,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=GFX_HOST,
+            enable_kpack=True,
+        )
+        _stage_package_artifacts(
+            pkg_name=PKG_FFT,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=TEST_GFX_TARGET,
+            enable_kpack=True,
+        )
+        _stage_package_artifacts(
+            pkg_name=PKG_RUNTIME,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=GFX_HOST,
+            enable_kpack=True,
+        )
+        host_cfg = replace(cfg, gfx_arch=GFX_HOST)
+
+        rpm_package.create_versioned_rpm_package(pkg_name=PKG_FFT, config=host_cfg)
+
+        spec = _read_spec_file(pkg_name=PKG_FFT, config=host_cfg)
+        self.assertEqual(_spec_field(spec, "Name"), FFT_HOST_PACKAGE)
+        self.assertEqual(_spec_field(spec, "BuildArch"), TEST_BUILD_ARCH)
+        self.assertIn("amdrocm-runtime", _spec_field(spec, "Requires"))
+
+    @patch.object(rpm_package, "move_packages_to_destination", return_value=[])
+    @patch.object(rpm_package, "package_with_rpmbuild")
+    def test_fft_device_generates_spec_file(
+        self, _mock_rpmbuild: object, _mock_move: object
+    ) -> None:
+        cfg = _kpack_config(self.temp_dir, pkg_type=TEST_PKG_TYPE_RPM)
+        _stage_package_artifacts(
+            pkg_name=PKG_FFT,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=TEST_GFX_TARGET,
+            enable_kpack=True,
+        )
+        device_cfg = replace(cfg, gfx_arch=TEST_GFX_TARGET)
+
+        rpm_package.create_versioned_rpm_package(pkg_name=PKG_FFT, config=device_cfg)
+
+        spec = _read_spec_file(pkg_name=PKG_FFT, config=device_cfg)
+        self.assertEqual(_spec_field(spec, "Name"), FFT_DEVICE_PACKAGE)
+
+    @patch.object(rpm_package, "move_packages_to_destination", return_value=[])
+    @patch.object(rpm_package, "package_with_rpmbuild")
+    def test_fft_meta_generates_spec_file(
+        self, _mock_rpmbuild: object, _mock_move: object
+    ) -> None:
+        cfg = _kpack_config(self.temp_dir, pkg_type=TEST_PKG_TYPE_RPM)
+        meta_cfg = replace(cfg, gfx_arch=GFX_META)
+
+        rpm_package.create_versioned_rpm_package(pkg_name=PKG_FFT, config=meta_cfg)
+
+        spec = _read_spec_file(pkg_name=PKG_FFT, config=meta_cfg)
+        self.assertEqual(_spec_field(spec, "Name"), FFT_META_PACKAGE)
+
+    @patch.object(rpm_package, "move_packages_to_destination", return_value=[])
+    @patch.object(rpm_package, "package_with_rpmbuild")
+    def test_core_sdk_device_meta_generates_spec_file(
+        self, _mock_rpmbuild: object, _mock_move: object
+    ) -> None:
+        """Gfx-arch metapackage ``amdrocm-core-sdk`` device variant (#6093)."""
+        cfg = _kpack_config(self.temp_dir, pkg_type=TEST_PKG_TYPE_RPM)
+        device_cfg = replace(cfg, gfx_arch=TEST_GFX_TARGET)
+
+        rpm_package.create_versioned_rpm_package(
+            pkg_name=PKG_CORE_SDK, config=device_cfg
+        )
+
+        spec = _read_spec_file(pkg_name=PKG_CORE_SDK, config=device_cfg)
+        self.assertEqual(_spec_field(spec, "Name"), CORE_SDK_DEVICE_PACKAGE)
+        # RPM keeps -devel naming (no debian_replace_devel_name mapping).
+        self.assertIn("amdrocm-core-devel", _spec_field(spec, "Requires"))
 
 
 # ---------------------------------------------------------------------------

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -42,6 +42,7 @@ TEST_GFX_TARGET_ALT = "gfx942"
 TEST_PKG_TYPE_DEB = "deb"
 TEST_PKG_TYPE_RPM = "rpm"
 TEST_BUILD_ARCH = "x86_64"
+EMPTY_GFX_ARCH = ""
 
 PKG_FFT = "amdrocm-fft"
 PKG_CORE_SDK = "amdrocm-core-sdk"
@@ -69,7 +70,12 @@ def _setup_import_path() -> None:
 
 
 def _load_module(name: str, path: Path) -> types.ModuleType:
-    """Load a module from an explicit file path without executing its CLI entry."""
+    """Load a packaging script by path for unit tests, not CLI execution.
+
+    Uses ``importlib`` so ``build_package`` / ``deb_package`` / ``rpm_package``
+    resolve from ``LINUX_DIR`` regardless of cwd, without invoking each script's
+    ``main()`` or ``if __name__ == \"__main__\"`` entry point.
+    """
     spec = importlib.util.spec_from_file_location(name, path)
     if spec is None or spec.loader is None:
         raise ImportError(f"Cannot load module {name!r} from {path}")
@@ -176,7 +182,14 @@ def _artifact_suffix_for_staging(
     enable_kpack: bool,
     artifacts_dir: Path,
 ) -> str | None:
-    """Compute artifact directory suffix using packaging naming rules."""
+    """Compute artifact directory suffix using packaging naming rules.
+
+    Duplicates suffix routing from ``filter_components_fromartifactory`` so staged
+    trees use ``{Artifact}_{Component}_{suffix}`` paths production expects. If that
+    function's kpack/gfxarch rules change, update this helper in the same change;
+    otherwise tests may stage the wrong layout and still pass (false positive).
+    ``ArtifactStagingTest`` catches gross mismatches but not every routing edge case.
+    """
     if enable_kpack:
         if gfx_arch == GFX_META:
             return None
@@ -467,10 +480,10 @@ class CreateVersionedDebPackageTest(BuildPackageTestCase):
         _stage_package_artifacts(
             pkg_name=PKG_DEBUGGER,
             artifacts_dir=cfg.artifacts_dir,
-            gfx_arch="",
+            gfx_arch=EMPTY_GFX_ARCH,
             enable_kpack=True,
         )
-        versioned_cfg = replace(cfg, gfx_arch="")
+        versioned_cfg = replace(cfg, gfx_arch=EMPTY_GFX_ARCH)
 
         deb_package.create_versioned_deb_package(
             pkg_name=PKG_DEVELOPER_TOOLS, config=versioned_cfg
@@ -633,6 +646,8 @@ class BuildPackageVariantsRoutingTest(BuildPackageTestCase):
 # create_package_config — CLI → PackageConfig (real function, no hand-built config)
 # ---------------------------------------------------------------------------
 class CreatePackageConfigTest(BuildPackageTestCase):
+    """``create_package_config`` maps CLI args to ``PackageConfig``."""
+
     def test_explicit_targets_in_kpack_mode(self) -> None:
         cfg = build_package.create_package_config(
             _args(
@@ -660,6 +675,8 @@ class CreatePackageConfigTest(BuildPackageTestCase):
 # load_kpack_from_manifest
 # ---------------------------------------------------------------------------
 class LoadKpackFromManifestTest(BuildPackageTestCase):
+    """``load_kpack_from_manifest`` reads ``therock_manifest.json`` kpack flags."""
+
     def test_true_when_kpack_flag_set(self) -> None:
         _write_kpack_manifest(self.artifacts_dir())
         self.assertTrue(
@@ -676,6 +693,8 @@ class LoadKpackFromManifestTest(BuildPackageTestCase):
 # parse_input_package_list — real package.json names
 # ---------------------------------------------------------------------------
 class ParseInputPackageListTest(BuildPackageTestCase):
+    """``parse_input_package_list`` filters names against ``package.json``."""
+
     def test_explicit_pkg_names_filter_package_json(self) -> None:
         pkg_list, skipped = build_package.parse_input_package_list(
             pkg_name=[PKG_CORE_SDK, PKG_CK, "no-such-package"],

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -137,7 +137,11 @@ def _artifact_suffix_for_staging(
 
     if "Artifact_Gfxarch" in artifact:
         is_artifact_gfx = str(artifact["Artifact_Gfxarch"]).lower() == "true"
-        if enable_kpack and gfx_arch not in (GFX_HOST, GFX_META) and not is_artifact_gfx:
+        if (
+            enable_kpack
+            and gfx_arch not in (GFX_HOST, GFX_META)
+            and not is_artifact_gfx
+        ):
             return None
         return gfx_arch if is_artifact_gfx else "generic"
     return dir_suffix
@@ -193,13 +197,7 @@ def _kpack_config(tmp: Path, **overrides) -> build_package.PackageConfig:
 def _control_path(pkg_name: str, config: build_package.PackageConfig) -> Path:
     """Return path to generated ``debian/control`` for a versioned DEB build."""
     updated = update_package_name(pkg_name, replace(config, versioned_pkg=True))
-    return (
-        Path(config.dest_dir)
-        / config.pkg_type
-        / updated
-        / "debian"
-        / "control"
-    )
+    return Path(config.dest_dir) / config.pkg_type / updated / "debian" / "control"
 
 
 # ---------------------------------------------------------------------------
@@ -260,9 +258,7 @@ class CreateVersionedDebPackageTest(unittest.TestCase):
             deb_package.create_versioned_deb_package("amdrocm-fft", host_cfg)
 
             control = _control_path("amdrocm-fft", host_cfg).read_text(encoding="utf-8")
-            self.assertEqual(
-                _control_field(control, "Package"), "amdrocm-fft-host7.1"
-            )
+            self.assertEqual(_control_field(control, "Package"), "amdrocm-fft-host7.1")
             self.assertEqual(_control_field(control, "Architecture"), "amd64")
             self.assertIn("amdrocm-runtime", _control_field(control, "Depends"))
 
@@ -319,7 +315,9 @@ class CreateVersionedDebPackageTest(unittest.TestCase):
 
     @patch.object(deb_package, "move_packages_to_destination", return_value=[])
     @patch.object(deb_package, "package_with_dpkg_build")
-    def test_developer_tools_versioned_metapackage_control(self, _mock_dpkg, _mock_move):
+    def test_developer_tools_versioned_metapackage_control(
+        self, _mock_dpkg, _mock_move
+    ):
         """Simple kpack metapackage with no Artifactory entries."""
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -361,7 +359,9 @@ class BuildPackageVariantsRoutingTest(unittest.TestCase):
 
     @patch.object(build_package, "build_gfxarch_package_variants")
     @patch.object(build_package, "build_simple_package_variants", return_value=[])
-    def test_fft_without_gfx_artifacts_routes_to_simple(self, mock_simple, mock_gfxarch):
+    def test_fft_without_gfx_artifacts_routes_to_simple(
+        self, mock_simple, mock_gfxarch
+    ):
         """#5874: Gfxarch metadata alone must not trigger gfx splits without artifacts."""
         with tempfile.TemporaryDirectory() as tmp:
             cfg = _kpack_config(tmp)

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -2,8 +2,6 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-from __future__ import annotations
-
 """Unit tests for ``build_package.py`` using API-driven fixtures and real outputs.
 
 Tests stage artifact trees by walking ``package.json`` via ``get_package_info()`` and
@@ -23,31 +21,69 @@ import importlib.util
 import json
 import sys
 import tempfile
+import types
 import unittest
 from argparse import Namespace
 from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
-_LINUX_DIR = Path(__file__).resolve().parent.parent
-_BUILD_TOOLS_DIR = _LINUX_DIR.parent.parent
-for _path in (_BUILD_TOOLS_DIR, _LINUX_DIR):
-    if str(_path) not in sys.path:
-        sys.path.insert(0, str(_path))
+THIS_SCRIPT_DIR = Path(__file__).resolve().parent
+LINUX_DIR = THIS_SCRIPT_DIR.parent
+BUILD_TOOLS_DIR = LINUX_DIR.parent.parent
 
-_BP_PATH = _LINUX_DIR / "build_package.py"
-_BP_SPEC = importlib.util.spec_from_file_location("build_package", _BP_PATH)
-build_package = importlib.util.module_from_spec(_BP_SPEC)
-_BP_SPEC.loader.exec_module(build_package)
+# Test fixture defaults (avoid unexplained literals in assertions and helpers).
+TEST_ROCM_VERSION = "7.1.0"
+TEST_VERSION_SUFFIX = "daily"
+TEST_INSTALL_PREFIX = "/opt/rocm/core"
+TEST_GFX_TARGET = "gfx1100"
+TEST_GFX_TARGET_ALT = "gfx942"
+TEST_PKG_TYPE_DEB = "deb"
 
-_DEB_PATH = _LINUX_DIR / "deb_package.py"
-_DEB_SPEC = importlib.util.spec_from_file_location("deb_package", _DEB_PATH)
-deb_package = importlib.util.module_from_spec(_DEB_SPEC)
-_DEB_SPEC.loader.exec_module(deb_package)
+PKG_FFT = "amdrocm-fft"
+PKG_CORE_SDK = "amdrocm-core-sdk"
+PKG_DEVELOPER_TOOLS = "amdrocm-developer-tools"
+PKG_RUNTIME = "amdrocm-runtime"
+PKG_DEBUGGER = "amdrocm-debugger"
+PKG_CK = "amdrocm-ck"
 
+FFT_HOST_PACKAGE = "amdrocm-fft-host7.1"
+FFT_DEVICE_PACKAGE = "amdrocm-fft7.1-gfx1100"
+FFT_META_PACKAGE = "amdrocm-fft7.1"
+CORE_SDK_DEVICE_PACKAGE = "amdrocm-core-sdk7.1-gfx1100"
+DEVELOPER_TOOLS_PACKAGE = "amdrocm-developer-tools7.1"
+
+STAGING_PAYLOAD_NAME = "libdummy.so"
+STAGING_PAYLOAD_BYTES = b"\x00"
+
+
+def _setup_import_path() -> None:
+    """Add packaging paths so modules resolve from any working directory."""
+    for path in (BUILD_TOOLS_DIR, LINUX_DIR):
+        path_str = str(path)
+        if path_str not in sys.path:
+            sys.path.insert(0, path_str)
+
+
+def _load_module(name: str, path: Path) -> types.ModuleType:
+    """Load a module from an explicit file path without executing its CLI entry."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load module {name!r} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_setup_import_path()
+build_package = _load_module("build_package", LINUX_DIR / "build_package.py")
+deb_package = _load_module("deb_package", LINUX_DIR / "deb_package.py")
+
+# packaging_utils depends on sys.path setup above.
 from packaging_utils import (  # noqa: E402
     GFX_HOST,
     GFX_META,
+    PackageConfig,
     filter_components_fromartifactory,
     get_package_info,
     is_gfxarch_package,
@@ -56,23 +92,35 @@ from packaging_utils import (  # noqa: E402
 )
 
 
-# ---------------------------------------------------------------------------
-# CLI / manifest helpers
-# ---------------------------------------------------------------------------
+class BuildPackageTestCase(unittest.TestCase):
+    """Base test case with a per-test temporary directory."""
+
+    def setUp(self) -> None:
+        self._temp_context = tempfile.TemporaryDirectory()
+        self.temp_dir = Path(self._temp_context.name)
+
+    def tearDown(self) -> None:
+        self._temp_context.cleanup()
+
+    def artifacts_dir(self) -> Path:
+        """Return the artifact root under the temp directory."""
+        artifacts = self.temp_dir / "artifacts"
+        artifacts.mkdir(parents=True, exist_ok=True)
+        return artifacts
 
 
-def _args(tmp: Path, **overrides) -> Namespace:
+def _args(tmp: Path, **overrides: object) -> Namespace:
     """Build an ``argparse.Namespace`` mirroring ``build_package.py`` CLI flags."""
     artifacts = tmp / "artifacts"
     artifacts.mkdir(parents=True, exist_ok=True)
-    defaults = {
+    defaults: dict[str, object] = {
         "artifacts_dir": artifacts,
         "dest_dir": tmp / "output",
-        "target": ["gfx1100", "gfx942"],
-        "pkg_type": "deb",
-        "rocm_version": "7.1.0",
-        "version_suffix": "daily",
-        "install_prefix": "/opt/rocm/core",
+        "target": [TEST_GFX_TARGET, TEST_GFX_TARGET_ALT],
+        "pkg_type": TEST_PKG_TYPE_DEB,
+        "rocm_version": TEST_ROCM_VERSION,
+        "version_suffix": TEST_VERSION_SUFFIX,
+        "install_prefix": TEST_INSTALL_PREFIX,
         "rpath_pkg": False,
         "enable_kpack": False,
         "pkg_names": None,
@@ -86,10 +134,13 @@ def _write_kpack_manifest(artifacts_dir: Path) -> None:
     """Write ``therock_manifest.json`` with ``KPACK_SPLIT_ARTIFACTS`` enabled."""
     manifest_dir = artifacts_dir / "pkg"
     manifest_dir.mkdir(parents=True, exist_ok=True)
-    (manifest_dir / "therock_manifest.json").write_text(
+    manifest_path = manifest_dir / "therock_manifest.json"
+    manifest_path.write_text(
         json.dumps({"flags": {"KPACK_SPLIT_ARTIFACTS": True}}),
         encoding="utf-8",
     )
+    if not manifest_path.exists():
+        raise RuntimeError(f"Failed to write kpack manifest: {manifest_path}")
 
 
 def _control_field(control_text: str, field: str) -> str:
@@ -101,14 +152,9 @@ def _control_field(control_text: str, field: str) -> str:
     raise AssertionError(f"Field {field!r} not found in control file:\n{control_text}")
 
 
-# ---------------------------------------------------------------------------
-# API-driven artifact staging (mirrors filter_components_fromartifactory)
-# ---------------------------------------------------------------------------
-
-
 def _artifact_suffix_for_staging(
-    pkg_info: dict,
-    artifact: dict,
+    pkg_info: dict[str, object],
+    artifact: dict[str, object],
     gfx_arch: str,
     *,
     enable_kpack: bool,
@@ -160,7 +206,13 @@ def _stage_package_artifacts(
         return []
 
     created: list[Path] = []
-    for artifact in pkg_info.get("Artifactory", []):
+    artifactory = pkg_info.get("Artifactory", [])
+    if not isinstance(artifactory, list):
+        return created
+
+    for artifact in artifactory:
+        if not isinstance(artifact, dict):
+            continue
         suffix = _artifact_suffix_for_staging(
             pkg_info,
             artifact,
@@ -172,21 +224,33 @@ def _stage_package_artifacts(
             continue
 
         prefix = artifact["Artifact"]
-        for subdir in artifact["Artifact_Subdir"]:
+        subdirs = artifact.get("Artifact_Subdir", [])
+        if not isinstance(subdirs, list):
+            continue
+
+        for subdir in subdirs:
+            if not isinstance(subdir, dict):
+                continue
             subdir_name = subdir["Name"]
-            for component in subdir["Components"]:
+            components = subdir.get("Components", [])
+            if not isinstance(components, list):
+                continue
+
+            for component in components:
                 artifact_dir = artifacts_dir / f"{prefix}_{component}_{suffix}"
-                rel_path = f"{subdir_name}/{component}/libdummy.so"
+                rel_path = f"{subdir_name}/{component}/{STAGING_PAYLOAD_NAME}"
                 payload = artifact_dir / rel_path
                 payload.parent.mkdir(parents=True, exist_ok=True)
-                payload.write_bytes(b"\x00")
+                payload.write_bytes(STAGING_PAYLOAD_BYTES)
                 manifest = artifact_dir / "artifact_manifest.txt"
                 manifest.write_text(f"{rel_path}\n", encoding="utf-8")
+                if not manifest.exists():
+                    raise RuntimeError(f"Failed to write artifact manifest: {manifest}")
                 created.append(artifact_dir)
     return created
 
 
-def _kpack_config(tmp: Path, **overrides) -> build_package.PackageConfig:
+def _kpack_config(tmp: Path, **overrides: object) -> PackageConfig:
     """Build kpack ``PackageConfig`` via ``create_package_config`` (not hand-built)."""
     root = Path(tmp)
     _write_kpack_manifest(root / "artifacts")
@@ -194,262 +258,311 @@ def _kpack_config(tmp: Path, **overrides) -> build_package.PackageConfig:
     return build_package.create_package_config(args)
 
 
-def _control_path(pkg_name: str, config: build_package.PackageConfig) -> Path:
+def _control_path(pkg_name: str, config: PackageConfig) -> Path:
     """Return path to generated ``debian/control`` for a versioned DEB build."""
     updated = update_package_name(pkg_name, replace(config, versioned_pkg=True))
     return Path(config.dest_dir) / config.pkg_type / updated / "debian" / "control"
 
 
+def _read_control_file(pkg_name: str, config: PackageConfig) -> str:
+    """Read generated ``debian/control`` after validating it was created."""
+    control_path = _control_path(pkg_name=pkg_name, config=config)
+    if not control_path.exists():
+        raise AssertionError(f"Expected control file was not created: {control_path}")
+    return control_path.read_text(encoding="utf-8")
+
+
+def _stage_fft_kpack_tree(artifacts_dir: Path, *, include_host: bool = False) -> None:
+    """Stage FFT artifacts for kpack tests; optionally include host/generic tree."""
+    _stage_package_artifacts(
+        pkg_name=PKG_FFT,
+        artifacts_dir=artifacts_dir,
+        gfx_arch=TEST_GFX_TARGET,
+        enable_kpack=True,
+    )
+    if include_host:
+        _stage_package_artifacts(
+            pkg_name=PKG_FFT,
+            artifacts_dir=artifacts_dir,
+            gfx_arch=GFX_HOST,
+            enable_kpack=True,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Artifact staging — validates production discovery APIs
 # ---------------------------------------------------------------------------
-class ArtifactStagingTest(unittest.TestCase):
+class ArtifactStagingTest(BuildPackageTestCase):
     """``_stage_package_artifacts`` produces trees ``filter_components`` accepts."""
 
-    def test_staged_fft_host_artifacts_discovered(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            artifacts = root / "artifacts"
-            artifacts.mkdir()
-            _stage_package_artifacts("amdrocm-fft", artifacts, GFX_HOST)
-            sourcedirs = filter_components_fromartifactory(
-                "amdrocm-fft", artifacts, GFX_HOST, enable_kpack=True
-            )
-            self.assertTrue(sourcedirs)
+    def test_staged_fft_host_artifacts_discovered(self) -> None:
+        artifacts = self.artifacts_dir()
+        _stage_package_artifacts(
+            pkg_name=PKG_FFT,
+            artifacts_dir=artifacts,
+            gfx_arch=GFX_HOST,
+            enable_kpack=True,
+        )
+        sourcedirs = filter_components_fromartifactory(
+            pkg_name=PKG_FFT,
+            artifacts_dir=artifacts,
+            gfx_arch=GFX_HOST,
+            enable_kpack=True,
+        )
+        self.assertTrue(sourcedirs)
 
-    def test_staged_fft_device_artifacts_discovered(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            artifacts = root / "artifacts"
-            artifacts.mkdir()
-            _stage_package_artifacts("amdrocm-fft", artifacts, "gfx1100")
-            sourcedirs = filter_components_fromartifactory(
-                "amdrocm-fft", artifacts, "gfx1100", enable_kpack=True
+    def test_staged_fft_device_artifacts_discovered(self) -> None:
+        artifacts = self.artifacts_dir()
+        _stage_package_artifacts(
+            pkg_name=PKG_FFT,
+            artifacts_dir=artifacts,
+            gfx_arch=TEST_GFX_TARGET,
+            enable_kpack=True,
+        )
+        sourcedirs = filter_components_fromartifactory(
+            pkg_name=PKG_FFT,
+            artifacts_dir=artifacts,
+            gfx_arch=TEST_GFX_TARGET,
+            enable_kpack=True,
+        )
+        self.assertTrue(sourcedirs)
+        self.assertTrue(
+            is_gfxarch_package(
+                pkg_info=get_package_info(PKG_FFT),
+                enable_kpack=True,
+                artifacts_dir=artifacts,
             )
-            self.assertTrue(sourcedirs)
-            self.assertTrue(
-                is_gfxarch_package(
-                    get_package_info("amdrocm-fft"),
-                    enable_kpack=True,
-                    artifacts_dir=artifacts,
-                )
-            )
+        )
 
 
 # ---------------------------------------------------------------------------
 # create_versioned_deb_package — real control file generation
 # ---------------------------------------------------------------------------
-class CreateVersionedDebPackageTest(unittest.TestCase):
+class CreateVersionedDebPackageTest(BuildPackageTestCase):
     """Real ``create_versioned_deb_package`` with API-staged artifacts."""
 
     @patch.object(deb_package, "move_packages_to_destination", return_value=[])
     @patch.object(deb_package, "package_with_dpkg_build")
-    def test_fft_host_generates_control_file(self, _mock_dpkg, _mock_move):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            cfg = _kpack_config(root)
-            # Host naming requires gfx dirs on disk (#5874); runtime dep needs artifacts
-            # in pkg_list for convert_to_versiondependency.
-            _stage_package_artifacts("amdrocm-fft", cfg.artifacts_dir, GFX_HOST)
-            _stage_package_artifacts("amdrocm-fft", cfg.artifacts_dir, "gfx1100")
-            _stage_package_artifacts("amdrocm-runtime", cfg.artifacts_dir, GFX_HOST)
-            host_cfg = replace(cfg, gfx_arch=GFX_HOST)
+    def test_fft_host_generates_control_file(
+        self, _mock_dpkg: object, _mock_move: object
+    ) -> None:
+        cfg = _kpack_config(self.temp_dir)
+        # Host naming requires gfx dirs on disk (#5874); runtime dep needs artifacts
+        # in pkg_list for convert_to_versiondependency.
+        _stage_package_artifacts(
+            pkg_name=PKG_FFT,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=GFX_HOST,
+            enable_kpack=True,
+        )
+        _stage_package_artifacts(
+            pkg_name=PKG_FFT,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=TEST_GFX_TARGET,
+            enable_kpack=True,
+        )
+        _stage_package_artifacts(
+            pkg_name=PKG_RUNTIME,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=GFX_HOST,
+            enable_kpack=True,
+        )
+        host_cfg = replace(cfg, gfx_arch=GFX_HOST)
 
-            deb_package.create_versioned_deb_package("amdrocm-fft", host_cfg)
+        deb_package.create_versioned_deb_package(pkg_name=PKG_FFT, config=host_cfg)
 
-            control = _control_path("amdrocm-fft", host_cfg).read_text(encoding="utf-8")
-            self.assertEqual(_control_field(control, "Package"), "amdrocm-fft-host7.1")
-            self.assertEqual(_control_field(control, "Architecture"), "amd64")
-            self.assertIn("amdrocm-runtime", _control_field(control, "Depends"))
-
-    @patch.object(deb_package, "move_packages_to_destination", return_value=[])
-    @patch.object(deb_package, "package_with_dpkg_build")
-    def test_fft_device_generates_control_file(self, _mock_dpkg, _mock_move):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            cfg = _kpack_config(root)
-            _stage_package_artifacts("amdrocm-fft", cfg.artifacts_dir, "gfx1100")
-            device_cfg = replace(cfg, gfx_arch="gfx1100")
-
-            deb_package.create_versioned_deb_package("amdrocm-fft", device_cfg)
-
-            control = _control_path("amdrocm-fft", device_cfg).read_text(
-                encoding="utf-8"
-            )
-            self.assertEqual(
-                _control_field(control, "Package"), "amdrocm-fft7.1-gfx1100"
-            )
+        control = _read_control_file(pkg_name=PKG_FFT, config=host_cfg)
+        self.assertEqual(_control_field(control, "Package"), FFT_HOST_PACKAGE)
+        self.assertEqual(_control_field(control, "Architecture"), "amd64")
+        self.assertIn("amdrocm-runtime", _control_field(control, "Depends"))
 
     @patch.object(deb_package, "move_packages_to_destination", return_value=[])
     @patch.object(deb_package, "package_with_dpkg_build")
-    def test_fft_meta_generates_control_file(self, _mock_dpkg, _mock_move):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            cfg = _kpack_config(root)
-            meta_cfg = replace(cfg, gfx_arch=GFX_META)
+    def test_fft_device_generates_control_file(
+        self, _mock_dpkg: object, _mock_move: object
+    ) -> None:
+        cfg = _kpack_config(self.temp_dir)
+        _stage_package_artifacts(
+            pkg_name=PKG_FFT,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=TEST_GFX_TARGET,
+            enable_kpack=True,
+        )
+        device_cfg = replace(cfg, gfx_arch=TEST_GFX_TARGET)
 
-            deb_package.create_versioned_deb_package("amdrocm-fft", meta_cfg)
+        deb_package.create_versioned_deb_package(pkg_name=PKG_FFT, config=device_cfg)
 
-            control = _control_path("amdrocm-fft", meta_cfg).read_text(encoding="utf-8")
-            self.assertEqual(_control_field(control, "Package"), "amdrocm-fft7.1")
+        control = _read_control_file(pkg_name=PKG_FFT, config=device_cfg)
+        self.assertEqual(_control_field(control, "Package"), FFT_DEVICE_PACKAGE)
 
     @patch.object(deb_package, "move_packages_to_destination", return_value=[])
     @patch.object(deb_package, "package_with_dpkg_build")
-    def test_core_sdk_device_meta_generates_control_file(self, _mock_dpkg, _mock_move):
+    def test_fft_meta_generates_control_file(
+        self, _mock_dpkg: object, _mock_move: object
+    ) -> None:
+        cfg = _kpack_config(self.temp_dir)
+        meta_cfg = replace(cfg, gfx_arch=GFX_META)
+
+        deb_package.create_versioned_deb_package(pkg_name=PKG_FFT, config=meta_cfg)
+
+        control = _read_control_file(pkg_name=PKG_FFT, config=meta_cfg)
+        self.assertEqual(_control_field(control, "Package"), FFT_META_PACKAGE)
+
+    @patch.object(deb_package, "move_packages_to_destination", return_value=[])
+    @patch.object(deb_package, "package_with_dpkg_build")
+    def test_core_sdk_device_meta_generates_control_file(
+        self, _mock_dpkg: object, _mock_move: object
+    ) -> None:
         """Gfx-arch metapackage ``amdrocm-core-sdk`` device variant (#6093)."""
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            cfg = _kpack_config(root)
-            device_cfg = replace(cfg, gfx_arch="gfx1100")
+        cfg = _kpack_config(self.temp_dir)
+        device_cfg = replace(cfg, gfx_arch=TEST_GFX_TARGET)
 
-            deb_package.create_versioned_deb_package("amdrocm-core-sdk", device_cfg)
+        deb_package.create_versioned_deb_package(
+            pkg_name=PKG_CORE_SDK, config=device_cfg
+        )
 
-            control = _control_path("amdrocm-core-sdk", device_cfg).read_text(
-                encoding="utf-8"
-            )
-            self.assertEqual(
-                _control_field(control, "Package"), "amdrocm-core-sdk7.1-gfx1100"
-            )
-            # debian_replace_devel_name maps -devel → -dev in DEB Depends
-            self.assertIn("amdrocm-core-dev", _control_field(control, "Depends"))
+        control = _read_control_file(pkg_name=PKG_CORE_SDK, config=device_cfg)
+        self.assertEqual(_control_field(control, "Package"), CORE_SDK_DEVICE_PACKAGE)
+        # debian_replace_devel_name maps -devel → -dev in DEB Depends.
+        self.assertIn("amdrocm-core-dev", _control_field(control, "Depends"))
 
     @patch.object(deb_package, "move_packages_to_destination", return_value=[])
     @patch.object(deb_package, "package_with_dpkg_build")
     def test_developer_tools_versioned_metapackage_control(
-        self, _mock_dpkg, _mock_move
-    ):
+        self, _mock_dpkg: object, _mock_move: object
+    ) -> None:
         """Simple kpack metapackage with no Artifactory entries."""
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            cfg = _kpack_config(root)
-            # convert_to_versiondependency only keeps amdrocm deps present in pkg_list
-            _stage_package_artifacts("amdrocm-debugger", cfg.artifacts_dir, "")
-            versioned_cfg = replace(cfg, gfx_arch="")
+        cfg = _kpack_config(self.temp_dir)
+        # convert_to_versiondependency only keeps amdrocm deps present in pkg_list.
+        _stage_package_artifacts(
+            pkg_name=PKG_DEBUGGER,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch="",
+            enable_kpack=True,
+        )
+        versioned_cfg = replace(cfg, gfx_arch="")
 
-            deb_package.create_versioned_deb_package(
-                "amdrocm-developer-tools", versioned_cfg
-            )
+        deb_package.create_versioned_deb_package(
+            pkg_name=PKG_DEVELOPER_TOOLS, config=versioned_cfg
+        )
 
-            control = _control_path("amdrocm-developer-tools", versioned_cfg).read_text(
-                encoding="utf-8"
-            )
-            self.assertEqual(
-                _control_field(control, "Package"), "amdrocm-developer-tools7.1"
-            )
-            self.assertIn("amdrocm-debugger", _control_field(control, "Depends"))
+        control = _read_control_file(pkg_name=PKG_DEVELOPER_TOOLS, config=versioned_cfg)
+        self.assertEqual(_control_field(control, "Package"), DEVELOPER_TOOLS_PACKAGE)
+        self.assertIn("amdrocm-debugger", _control_field(control, "Depends"))
 
 
 # ---------------------------------------------------------------------------
 # build_package_variants — routing with real artifact detection (#5874)
 # ---------------------------------------------------------------------------
-class BuildPackageVariantsRoutingTest(unittest.TestCase):
+class BuildPackageVariantsRoutingTest(BuildPackageTestCase):
     """Top-level routing using real ``is_gfxarch_package`` / staged artifacts."""
 
     @patch.object(build_package, "build_gfxarch_package_variants", return_value=[])
     @patch.object(build_package, "build_simple_package_variants")
     def test_fft_with_staged_artifacts_routes_to_gfxarch(
-        self, mock_simple, mock_gfxarch
-    ):
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _kpack_config(tmp)
-            _stage_package_artifacts("amdrocm-fft", cfg.artifacts_dir, "gfx1100")
-            build_package.build_package_variants("amdrocm-fft", cfg)
-            mock_gfxarch.assert_called_once_with("amdrocm-fft", cfg)
-            mock_simple.assert_not_called()
+        self, mock_simple: object, mock_gfxarch: object
+    ) -> None:
+        cfg = _kpack_config(self.temp_dir)
+        _stage_fft_kpack_tree(cfg.artifacts_dir)
+        build_package.build_package_variants(pkg_name=PKG_FFT, config=cfg)
+        mock_gfxarch.assert_called_once_with(PKG_FFT, cfg)
+        mock_simple.assert_not_called()
 
     @patch.object(build_package, "build_gfxarch_package_variants")
     @patch.object(build_package, "build_simple_package_variants", return_value=[])
     def test_fft_without_gfx_artifacts_routes_to_simple(
-        self, mock_simple, mock_gfxarch
-    ):
+        self, mock_simple: object, mock_gfxarch: object
+    ) -> None:
         """#5874: Gfxarch metadata alone must not trigger gfx splits without artifacts."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _kpack_config(tmp)
-            pkg_info = get_package_info("amdrocm-fft")
-            self.assertFalse(
-                is_gfxarch_package(
-                    pkg_info,
-                    enable_kpack=True,
-                    artifacts_dir=cfg.artifacts_dir,
-                )
+        cfg = _kpack_config(self.temp_dir)
+        pkg_info = get_package_info(PKG_FFT)
+        self.assertFalse(
+            is_gfxarch_package(
+                pkg_info=pkg_info,
+                enable_kpack=True,
+                artifacts_dir=cfg.artifacts_dir,
             )
-            build_package.build_package_variants("amdrocm-fft", cfg)
-            mock_simple.assert_called_once_with("amdrocm-fft", cfg)
-            mock_gfxarch.assert_not_called()
+        )
+        build_package.build_package_variants(pkg_name=PKG_FFT, config=cfg)
+        mock_simple.assert_called_once_with(PKG_FFT, cfg)
+        mock_gfxarch.assert_not_called()
 
     @patch.object(build_package, "build_gfxarch_package_variants", return_value=[])
     @patch.object(build_package, "build_simple_package_variants")
-    def test_core_sdk_metapackage_routes_to_gfxarch(self, mock_simple, mock_gfxarch):
+    def test_core_sdk_metapackage_routes_to_gfxarch(
+        self, mock_simple: object, mock_gfxarch: object
+    ) -> None:
         """Gfx-arch metapackage routes to gfxarch builder even without artifacts (#6093)."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _kpack_config(tmp)
-            build_package.build_package_variants("amdrocm-core-sdk", cfg)
-            mock_gfxarch.assert_called_once_with("amdrocm-core-sdk", cfg)
-            mock_simple.assert_not_called()
+        cfg = _kpack_config(self.temp_dir)
+        build_package.build_package_variants(pkg_name=PKG_CORE_SDK, config=cfg)
+        mock_gfxarch.assert_called_once_with(PKG_CORE_SDK, cfg)
+        mock_simple.assert_not_called()
 
     @patch.object(build_package, "build_gfxarch_package_variants")
     @patch.object(build_package, "build_simple_package_variants", return_value=[])
-    def test_developer_tools_routes_to_simple(self, mock_simple, mock_gfxarch):
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _kpack_config(tmp)
-            build_package.build_package_variants("amdrocm-developer-tools", cfg)
-            mock_simple.assert_called_once_with("amdrocm-developer-tools", cfg)
-            mock_gfxarch.assert_not_called()
+    def test_developer_tools_routes_to_simple(
+        self, mock_simple: object, mock_gfxarch: object
+    ) -> None:
+        cfg = _kpack_config(self.temp_dir)
+        build_package.build_package_variants(pkg_name=PKG_DEVELOPER_TOOLS, config=cfg)
+        mock_simple.assert_called_once_with(PKG_DEVELOPER_TOOLS, cfg)
+        mock_gfxarch.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
 # create_package_config — CLI → PackageConfig (real function, no hand-built config)
 # ---------------------------------------------------------------------------
-class CreatePackageConfigTest(unittest.TestCase):
-    def test_explicit_targets_in_kpack_mode(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = build_package.create_package_config(
-                _args(Path(tmp), enable_kpack=True, target=["gfx1100", "gfx942"])
+class CreatePackageConfigTest(BuildPackageTestCase):
+    def test_explicit_targets_in_kpack_mode(self) -> None:
+        cfg = build_package.create_package_config(
+            _args(
+                self.temp_dir,
+                enable_kpack=True,
+                target=[TEST_GFX_TARGET, TEST_GFX_TARGET_ALT],
             )
-            self.assertTrue(cfg.enable_kpack)
-            self.assertEqual(cfg.gfxarch_list, ("gfx1100", "gfx942"))
+        )
+        self.assertTrue(cfg.enable_kpack)
+        self.assertEqual(cfg.gfxarch_list, (TEST_GFX_TARGET, TEST_GFX_TARGET_ALT))
 
-    def test_auto_detect_kpack_from_manifest(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            _write_kpack_manifest(root / "artifacts")
-            cfg = build_package.create_package_config(_args(root))
-            self.assertTrue(cfg.enable_kpack)
+    def test_auto_detect_kpack_from_manifest(self) -> None:
+        _write_kpack_manifest(self.artifacts_dir())
+        cfg = build_package.create_package_config(_args(self.temp_dir))
+        self.assertTrue(cfg.enable_kpack)
 
-    def test_invalid_rocm_version_raises(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            with self.assertRaises(ValueError):
-                build_package.create_package_config(
-                    _args(Path(tmp), rocm_version="7"),
-                )
+    def test_invalid_rocm_version_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            build_package.create_package_config(
+                _args(self.temp_dir, rocm_version="7"),
+            )
 
 
 # ---------------------------------------------------------------------------
 # load_kpack_from_manifest
 # ---------------------------------------------------------------------------
-class LoadKpackFromManifestTest(unittest.TestCase):
-    def test_true_when_kpack_flag_set(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            _write_kpack_manifest(Path(tmp))
-            self.assertTrue(build_package.load_kpack_from_manifest(Path(tmp)))
+class LoadKpackFromManifestTest(BuildPackageTestCase):
+    def test_true_when_kpack_flag_set(self) -> None:
+        _write_kpack_manifest(self.artifacts_dir())
+        self.assertTrue(
+            build_package.load_kpack_from_manifest(artifacts_dir=self.artifacts_dir())
+        )
 
-    def test_false_when_no_manifest(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            self.assertFalse(build_package.load_kpack_from_manifest(Path(tmp)))
+    def test_false_when_no_manifest(self) -> None:
+        self.assertFalse(
+            build_package.load_kpack_from_manifest(artifacts_dir=self.artifacts_dir())
+        )
 
 
 # ---------------------------------------------------------------------------
 # parse_input_package_list — real package.json names
 # ---------------------------------------------------------------------------
-class ParseInputPackageListTest(unittest.TestCase):
-    def test_explicit_pkg_names_filter_package_json(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            pkg_list, skipped = build_package.parse_input_package_list(
-                ["amdrocm-core-sdk", "amdrocm-ck", "no-such-package"],
-                Path(tmp),
-            )
-            self.assertEqual(set(pkg_list), {"amdrocm-core-sdk", "amdrocm-ck"})
-            self.assertEqual(skipped, [])
+class ParseInputPackageListTest(BuildPackageTestCase):
+    def test_explicit_pkg_names_filter_package_json(self) -> None:
+        pkg_list, skipped = build_package.parse_input_package_list(
+            pkg_name=[PKG_CORE_SDK, PKG_CK, "no-such-package"],
+            artifact_dir=self.artifacts_dir(),
+        )
+        self.assertEqual(set(pkg_list), {PKG_CORE_SDK, PKG_CK})
+        self.assertEqual(skipped, [])
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -1,0 +1,748 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+"""Unit tests for ``build_package.py`` CLI parameters and packaging dispatch.
+
+Scope
+-----
+Validates how ``build_package.py`` maps CLI flags to ``PackageConfig``, detects kpack
+mode from manifests, resolves ``--pkg-names``, and routes each package to the correct
+variant builder (gfx-arch kpack, simple kpack, or single-arch). Covers metapackages
+vs regular packages, DEB vs RPM, ``--enable-kpack``, and ``--rpath-pkg``.
+
+Test strategy
+-------------
+* **Config / parsing tests** — call real functions with synthetic ``argparse.Namespace``
+  values built by ``_args()``; no subprocess, no real package builds.
+* **Routing tests** — mock high-level builders to assert the correct code path is chosen
+  (regression guard for issues like #6093 where metapackages were mis-routed).
+* **Variant-builder tests** — mock ``create_versioned_*`` / ``create_nonversioned_*`` to
+  count which variants are produced without invoking ``dpkg`` / ``rpmbuild``.
+* **Integration with ``package.json``** — ``parse_input_package_list`` and routing tests
+  use real package names (``amdrocm-core-sdk``, ``amdrocm-ck``, etc.).
+
+Run::
+
+    python3.12 build_tools/packaging/linux/tests/build_package_test.py -v
+
+Requires Python 3.10+ (``packaging_utils`` type syntax).
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+_LINUX_DIR = Path(__file__).resolve().parent.parent
+_BUILD_TOOLS_DIR = _LINUX_DIR.parent.parent
+for _path in (_BUILD_TOOLS_DIR, _LINUX_DIR):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+_BP_PATH = _LINUX_DIR / "build_package.py"
+_BP_SPEC = importlib.util.spec_from_file_location("build_package", _BP_PATH)
+build_package = importlib.util.module_from_spec(_BP_SPEC)
+_BP_SPEC.loader.exec_module(build_package)
+
+from packaging_utils import GFX_HOST, GFX_META, PackageConfig  # noqa: E402
+
+
+def _args(tmp: Path, **overrides) -> Namespace:
+    """Build an ``argparse.Namespace`` mirroring ``build_package.py`` CLI flags.
+
+    Creates a temp artifact directory under ``tmp``. Defaults match a typical
+    single-arch DEB build; pass ``**overrides`` to simulate other invocations.
+
+    Default arguments:
+        ``--artifacts-dir``   ``tmp/artifacts`` (created on disk)
+        ``--dest-dir``        ``tmp/output``
+        ``--target``          ``["gfx1100", "gfx942"]``
+        ``--pkg-type``        ``deb``
+        ``--rocm-version``    ``7.1.0``
+        ``--version-suffix``  ``daily``
+        ``--install-prefix``  ``/opt/rocm/core``
+        ``--rpath-pkg``       ``False``
+        ``--enable-kpack``    ``False``
+        ``--pkg-names``       ``None`` (build all eligible packages)
+        ``--clean-build``     ``False``
+
+    Args:
+        tmp: Root temp directory for artifact and output paths.
+        **overrides: Any CLI field to replace in the namespace.
+
+    Returns:
+        Namespace consumed by ``create_package_config`` and ``run``.
+    """
+    artifacts = tmp / "artifacts"
+    artifacts.mkdir(parents=True, exist_ok=True)
+    defaults = {
+        "artifacts_dir": artifacts,
+        "dest_dir": tmp / "output",
+        "target": ["gfx1100", "gfx942"],
+        "pkg_type": "deb",
+        "rocm_version": "7.1.0",
+        "version_suffix": "daily",
+        "install_prefix": "/opt/rocm/core",
+        "rpath_pkg": False,
+        "enable_kpack": False,
+        "pkg_names": None,
+        "clean_build": False,
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def _config(tmp: Path, **overrides) -> PackageConfig:
+    """Build a minimal ``PackageConfig`` for variant-builder unit tests.
+
+    Default config simulates kpack DEB mode with two GPU targets. Override fields
+    to test single-arch, RPM, or ``--rpath-pkg`` paths.
+
+    Args:
+        tmp: Root temp directory; ``artifacts_dir`` and ``dest_dir`` are placed under it.
+        **overrides: Any ``PackageConfig`` field to replace.
+
+    Returns:
+        Frozen ``PackageConfig`` passed to ``build_*_package_variants`` helpers.
+    """
+    defaults = {
+        "artifacts_dir": tmp / "artifacts",
+        "dest_dir": tmp / "output",
+        "pkg_type": "deb",
+        "rocm_version": "7.1.0",
+        "version_suffix": "daily",
+        "install_prefix": "/opt/rocm/core-7.1",
+        "gfx_arch": "",
+        "enable_rpath": False,
+        "versioned_pkg": True,
+        "enable_kpack": True,
+        "gfxarch_list": ("gfx1100", "gfx942"),
+    }
+    defaults.update(overrides)
+    return PackageConfig(**defaults)
+
+
+def _write_kpack_manifest(artifacts_dir: Path) -> None:
+    """Write a ``therock_manifest.json`` that enables kpack split artifacts.
+
+    Args:
+        artifacts_dir: Root scanned by ``load_kpack_from_manifest`` (recursive).
+    """
+    manifest_dir = artifacts_dir / "pkg"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "therock_manifest.json").write_text(
+        json.dumps({"flags": {"KPACK_SPLIT_ARTIFACTS": True}}),
+        encoding="utf-8",
+    )
+
+
+def _ck_gfx_artifacts(artifacts_dir: Path) -> None:
+    """Create gfx-specific artifact dirs so ``amdrocm-ck`` is gfx-arch under kpack.
+
+    Matches real ``package.json`` Artifactory naming:
+    ``{Artifact}_{Component}_gfx*`` → ``composable-kernel_run_gfx1100``.
+
+    Args:
+        artifacts_dir: Artifact tree root passed as ``PackageConfig.artifacts_dir``.
+    """
+    (artifacts_dir / "composable-kernel_run_gfx1100").mkdir(parents=True, exist_ok=True)
+
+
+class CreatePackageConfigTest(unittest.TestCase):
+    """``create_package_config(args)`` — CLI → ``PackageConfig`` mapping.
+
+    Use case: every ``build_package.py`` invocation first normalizes flags into a
+    ``PackageConfig``. These tests lock in argument handling for ``--pkg-type``,
+    ``--target``, ``--enable-kpack``, ``--rpath-pkg``, ``--rocm-version``,
+    ``--install-prefix``, and ``--version-suffix``.
+    """
+
+    def test_deb_pkg_type_normalized(self):
+        """``--pkg-type DEB`` is lower-cased to ``deb`` in ``PackageConfig.pkg_type``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = build_package.create_package_config(_args(Path(tmp), pkg_type="DEB"))
+            self.assertEqual(cfg.pkg_type, "deb")
+
+    def test_rpm_pkg_type_normalized(self):
+        """``--pkg-type RPM`` is lower-cased to ``rpm`` in ``PackageConfig.pkg_type``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = build_package.create_package_config(_args(Path(tmp), pkg_type="RPM"))
+            self.assertEqual(cfg.pkg_type, "rpm")
+
+    def test_invalid_pkg_type_raises(self):
+        """Unsupported ``--pkg-type`` (e.g. tgz) raises ``ValueError`` listing deb/rpm."""
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(ValueError) as ctx:
+                build_package.create_package_config(
+                    _args(Path(tmp), pkg_type="tgz"),
+                )
+            self.assertIn("deb", str(ctx.exception))
+            self.assertIn("rpm", str(ctx.exception))
+
+    def test_invalid_rocm_version_raises(self):
+        """``--rocm-version`` without major.minor (e.g. ``7``) raises ``ValueError``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(ValueError):
+                build_package.create_package_config(
+                    _args(Path(tmp), rocm_version="7"),
+                )
+
+    def test_default_install_prefix_appends_major_minor(self):
+        """Default ``--install-prefix /opt/rocm/core`` becomes ``/opt/rocm/core-7.1``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = build_package.create_package_config(_args(Path(tmp)))
+            self.assertEqual(cfg.install_prefix, "/opt/rocm/core-7.1")
+
+    def test_custom_install_prefix_unchanged(self):
+        """Non-default ``--install-prefix`` is copied verbatim (no version suffix)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = build_package.create_package_config(
+                _args(Path(tmp), install_prefix="/custom/prefix"),
+            )
+            self.assertEqual(cfg.install_prefix, "/custom/prefix")
+
+    def test_explicit_targets_in_kpack_mode(self):
+        """``--enable-kpack`` + ``--target gfx1100 gfx942`` fills ``gfxarch_list``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = build_package.create_package_config(
+                _args(
+                    Path(tmp),
+                    enable_kpack=True,
+                    target=["gfx1100", "gfx942"],
+                ),
+            )
+            self.assertTrue(cfg.enable_kpack)
+            self.assertEqual(cfg.gfxarch_list, ("gfx1100", "gfx942"))
+            self.assertEqual(cfg.gfx_arch, "")
+
+    def test_single_arch_uses_first_target(self):
+        """Without kpack, ``gfx_arch`` is the first ``--target``; ``gfxarch_list`` empty."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = build_package.create_package_config(
+                _args(Path(tmp), target=["gfx1100", "gfx942"]),
+            )
+            self.assertFalse(cfg.enable_kpack)
+            self.assertEqual(cfg.gfx_arch, "gfx1100")
+            self.assertEqual(cfg.gfxarch_list, ())
+
+    @patch.object(build_package, "get_all_target_families", return_value=["gfx1200"])
+    def test_auto_detect_targets_when_target_omitted(self, _mock_detect):
+        """Omitted ``--target`` auto-detects via ``get_all_target_families(artifacts_dir)``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = build_package.create_package_config(_args(Path(tmp), target=None))
+            self.assertEqual(cfg.gfx_arch, "gfx1200")
+
+    def test_auto_detect_kpack_from_manifest(self):
+        """Kpack enabled when ``therock_manifest.json`` has ``KPACK_SPLIT_ARTIFACTS: true``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_kpack_manifest(root / "artifacts")
+            cfg = build_package.create_package_config(_args(root))
+            self.assertTrue(cfg.enable_kpack)
+
+    def test_explicit_enable_kpack_overrides_absent_manifest(self):
+        """``--enable-kpack`` sets kpack even when no manifest flag is present."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = build_package.create_package_config(
+                _args(Path(tmp), enable_kpack=True),
+            )
+            self.assertTrue(cfg.enable_kpack)
+
+    def test_rpath_pkg_flag(self):
+        """``--rpath-pkg`` maps to ``PackageConfig.enable_rpath=True``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = build_package.create_package_config(
+                _args(Path(tmp), rpath_pkg=True),
+            )
+            self.assertTrue(cfg.enable_rpath)
+
+    def test_version_suffix_preserved(self):
+        """``--version-suffix nightly`` is stored on ``PackageConfig.version_suffix``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = build_package.create_package_config(
+                _args(Path(tmp), version_suffix="nightly"),
+            )
+            self.assertEqual(cfg.version_suffix, "nightly")
+
+    def test_writes_packaging_arch_list_to_github_output(self):
+        """When ``GITHUB_OUTPUT`` is set, writes ``PACKAGING_ARCH_LIST`` for CI matrix."""
+        with tempfile.TemporaryDirectory() as tmp:
+            github_env = Path(tmp) / "github_output"
+            github_env.write_text("", encoding="utf-8")
+            with patch.dict(os.environ, {"GITHUB_OUTPUT": str(github_env)}):
+                build_package.create_package_config(
+                    _args(Path(tmp), target=["gfx1100"]),
+                )
+            self.assertIn("PACKAGING_ARCH_LIST=gfx1100", github_env.read_text())
+
+
+class LoadKpackFromManifestTest(unittest.TestCase):
+    """``load_kpack_from_manifest(artifacts_dir)`` — kpack auto-detection.
+
+    Use case: CI artifact trees carry ``therock_manifest.json``; packaging should
+    enter host+device split mode without requiring ``--enable-kpack`` on the CLI.
+    """
+
+    def test_true_when_kpack_flag_set(self):
+        """Returns True when any nested manifest has ``flags.KPACK_SPLIT_ARTIFACTS``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_kpack_manifest(Path(tmp))
+            self.assertTrue(build_package.load_kpack_from_manifest(Path(tmp)))
+
+    def test_false_when_no_manifest(self):
+        """Empty artifact tree with no manifest files returns False."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertFalse(build_package.load_kpack_from_manifest(Path(tmp)))
+
+    def test_false_when_manifest_missing_flag(self):
+        """Manifest present but without ``KPACK_SPLIT_ARTIFACTS`` returns False."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "therock_manifest.json").write_text("{}", encoding="utf-8")
+            self.assertFalse(build_package.load_kpack_from_manifest(root))
+
+
+class ParseInputPackageListTest(unittest.TestCase):
+    """``parse_input_package_list(pkg_names, artifact_dir)`` — ``--pkg-names`` filtering.
+
+    Use case: operators pass ``--pkg-names amdrocm-ck amdrocm-core-sdk`` to build a
+    subset; omitting it builds every package eligible from the artifact tree.
+    """
+
+    @patch.object(build_package, "get_package_list", return_value=(["pkg-a"], ["skip-a"]))
+    def test_none_pkg_names_loads_all_from_artifacts(self, mock_get_list):
+        """``pkg_names=None`` delegates to ``get_package_list(artifact_dir)``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            art = Path(tmp)
+            pkg_list, skipped = build_package.parse_input_package_list(None, art)
+            mock_get_list.assert_called_once_with(art)
+            self.assertEqual(pkg_list, ["pkg-a"])
+            self.assertEqual(skipped, ["skip-a"])
+
+    def test_explicit_pkg_names_filter_package_json(self):
+        """Named packages are matched against ``package.json``; unknown names dropped."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg_list, skipped = build_package.parse_input_package_list(
+                ["amdrocm-core-sdk", "amdrocm-ck", "no-such-package"],
+                Path(tmp),
+            )
+            self.assertEqual(pkg_list, ["amdrocm-core-sdk", "amdrocm-ck"])
+            self.assertEqual(skipped, [])
+
+
+class BuildPackageVariantsRoutingTest(unittest.TestCase):
+    """``build_package_variants(pkg_name, config)`` — top-level builder selection.
+
+    Use case: the first routing decision determines host/device/meta splits vs simple
+    versioned packages. Mis-routing a gfx-arch metapackage (e.g. ``amdrocm-core-sdk``)
+    to the simple builder caused #6093 (missing per-GPU SDK dependencies).
+    """
+
+    @patch.object(build_package, "build_gfxarch_package_variants", return_value=["meta.deb"])
+    def test_kpack_metapackage_routes_to_gfxarch_builder(self, mock_gfx):
+        """Kpack + gfx-arch metapackage ``amdrocm-core-sdk`` → ``build_gfxarch_package_variants``.
+
+        Args (via ``_config``): ``enable_kpack=True``, ``pkg_type=deb``.
+        Package: ``amdrocm-core-sdk`` (``Metapackage`` + ``Gfxarch`` in ``package.json``).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp))
+            result = build_package.build_package_variants("amdrocm-core-sdk", cfg)
+            mock_gfx.assert_called_once_with("amdrocm-core-sdk", cfg)
+            self.assertEqual(result, ["meta.deb"])
+
+    @patch.object(build_package, "build_gfxarch_package_variants", return_value=["ck.deb"])
+    def test_kpack_gfxarch_non_meta_routes_to_gfxarch_builder(self, mock_gfx):
+        """Kpack + gfx-arch regular package ``amdrocm-ck`` → gfx-arch builder.
+
+        Requires gfx artifact dir ``composable-kernel_run_gfx1100`` on disk so
+        ``is_gfxarch_package`` returns True after #5874 artifact verification.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _ck_gfx_artifacts(root / "artifacts")
+            cfg = _config(root)
+            result = build_package.build_package_variants("amdrocm-ck", cfg)
+            mock_gfx.assert_called_once_with("amdrocm-ck", cfg)
+            self.assertEqual(result, ["ck.deb"])
+
+    @patch.object(build_package, "build_simple_package_variants", return_value=["tools.deb"])
+    def test_kpack_non_gfxarch_routes_to_simple_builder(self, mock_simple):
+        """Kpack + non-gfx-arch ``amdrocm-developer-tools`` → ``build_simple_package_variants``.
+
+        Package has ``Gfxarch: False`` in ``package.json`` — versioned + non-versioned only.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp))
+            result = build_package.build_package_variants(
+                "amdrocm-developer-tools",
+                cfg,
+            )
+            mock_simple.assert_called_once_with("amdrocm-developer-tools", cfg)
+            self.assertEqual(result, ["tools.deb"])
+
+    @patch.object(build_package, "build_singlearch_package_variants", return_value=["single.deb"])
+    def test_single_arch_routes_to_singlearch_builder(self, mock_single):
+        """``enable_kpack=False`` always uses ``build_singlearch_package_variants``.
+
+        Args: ``enable_kpack=False``, ``gfx_arch=gfx1100`` (first ``--target``).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp), enable_kpack=False, gfx_arch="gfx1100")
+            result = build_package.build_package_variants("amdrocm-core-sdk", cfg)
+            mock_single.assert_called_once_with("amdrocm-core-sdk", cfg)
+            self.assertEqual(result, ["single.deb"])
+
+
+class BuildGfxarchPackageVariantsTest(unittest.TestCase):
+    """``build_gfxarch_package_variants`` — kpack host / device / meta / non-versioned.
+
+    Use case: gfx-arch packages in kpack mode produce multiple DEB/RPM variants.
+    Metapackages skip the host variant (no artifacts); regular packages include it.
+    ``--rpath-pkg`` suppresses the user-facing non-versioned metapackage variant.
+    """
+
+    @patch.object(build_package, "cleanup_build_directory")
+    @patch.object(build_package, "create_nonversioned_deb_package", return_value=["nv.deb"])
+    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
+    def test_metapackage_skips_host_builds_device_meta_nonversioned(
+        self, mock_versioned, mock_nonversioned, _mock_cleanup
+    ):
+        """Metapackage ``amdrocm-core-sdk``: 2 device + 1 meta + 1 non-versioned (no host).
+
+        ``gfxarch_list=("gfx1100", "gfx942")`` → two ``create_versioned_deb_package`` calls
+        for devices, one for meta, one ``create_nonversioned_deb_package``.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp), pkg_type="deb")
+            built = build_package.build_gfxarch_package_variants(
+                "amdrocm-core-sdk",
+                cfg,
+            )
+            self.assertEqual(mock_versioned.call_count, 3)
+            self.assertEqual(mock_nonversioned.call_count, 1)
+            self.assertEqual(len(built), 4)
+
+    @patch.object(build_package, "cleanup_build_directory")
+    @patch.object(build_package, "create_nonversioned_deb_package", return_value=["nv.deb"])
+    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
+    def test_non_meta_includes_host_device_meta_nonversioned(
+        self, mock_versioned, mock_nonversioned, _mock_cleanup
+    ):
+        """Regular gfx-arch ``amdrocm-ck``: host + 2 device + meta + non-versioned = 5 outputs."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _ck_gfx_artifacts(root / "artifacts")
+            cfg = _config(root, pkg_type="deb")
+            built = build_package.build_gfxarch_package_variants("amdrocm-ck", cfg)
+            self.assertEqual(mock_versioned.call_count, 4)
+            self.assertEqual(mock_nonversioned.call_count, 1)
+            self.assertEqual(len(built), 5)
+
+    @patch.object(build_package, "cleanup_build_directory")
+    @patch.object(build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"])
+    @patch.object(build_package, "create_versioned_rpm_package", return_value=["v.rpm"])
+    def test_rpm_pkg_type_for_gfxarch_variants(self, mock_versioned, mock_nonversioned, _mock_cleanup):
+        """``pkg_type=rpm`` dispatches to ``create_versioned_rpm_package`` / ``create_nonversioned_rpm_package``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp), pkg_type="rpm")
+            build_package.build_gfxarch_package_variants("amdrocm-core-sdk", cfg)
+            mock_versioned.assert_called()
+            mock_nonversioned.assert_called_once()
+            self.assertNotIn("deb", str(mock_versioned.call_args))
+
+    @patch.object(build_package, "cleanup_build_directory")
+    @patch.object(build_package, "create_nonversioned_deb_package")
+    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
+    def test_rpath_pkg_skips_nonversioned_gfxarch_variant(
+        self, mock_versioned, mock_nonversioned, _mock_cleanup
+    ):
+        """``enable_rpath=True`` builds only versioned variants (device + meta for metapackage)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp), enable_rpath=True)
+            built = build_package.build_gfxarch_package_variants(
+                "amdrocm-core-sdk",
+                cfg,
+            )
+            mock_nonversioned.assert_not_called()
+            self.assertEqual(len(built), 3)
+            self.assertEqual(mock_versioned.call_count, 3)
+
+
+class BuildSimplePackageVariantsTest(unittest.TestCase):
+    """``build_simple_package_variants`` — kpack non-gfx-arch packages.
+
+    Use case: packages like ``amdrocm-developer-tools`` get a versioned package
+    (e.g. ``amdrocm-developer-tools7.1``) and a user-facing non-versioned metapackage.
+    """
+
+    @patch.object(build_package, "cleanup_build_directory")
+    @patch.object(build_package, "create_nonversioned_deb_package", return_value=["nv.deb"])
+    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
+    def test_deb_versioned_and_nonversioned(self, mock_versioned, mock_nonversioned, _mock_cleanup):
+        """DEB kpack simple path: one versioned + one non-versioned package."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp), pkg_type="deb")
+            built = build_package.build_simple_package_variants(
+                "amdrocm-developer-tools",
+                cfg,
+            )
+            mock_versioned.assert_called_once()
+            mock_nonversioned.assert_called_once()
+            self.assertEqual(built, ["v.deb", "nv.deb"])
+
+    @patch.object(build_package, "cleanup_build_directory")
+    @patch.object(build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"])
+    @patch.object(build_package, "create_versioned_rpm_package", return_value=["v.rpm"])
+    def test_rpm_versioned_and_nonversioned(self, mock_versioned, mock_nonversioned, _mock_cleanup):
+        """RPM kpack simple path: one versioned + one non-versioned package."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp), pkg_type="rpm")
+            built = build_package.build_simple_package_variants(
+                "amdrocm-developer-tools",
+                cfg,
+            )
+            mock_versioned.assert_called_once()
+            mock_nonversioned.assert_called_once()
+            self.assertEqual(built, ["v.rpm", "nv.rpm"])
+
+    @patch.object(build_package, "cleanup_build_directory")
+    @patch.object(build_package, "create_nonversioned_deb_package")
+    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
+    def test_rpath_skips_nonversioned_simple_variant(
+        self, mock_versioned, mock_nonversioned, _mock_cleanup
+    ):
+        """``enable_rpath=True`` on simple kpack path emits only the versioned package."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp), enable_rpath=True)
+            built = build_package.build_simple_package_variants(
+                "amdrocm-developer-tools",
+                cfg,
+            )
+            mock_versioned.assert_called_once()
+            mock_nonversioned.assert_not_called()
+            self.assertEqual(built, ["v.deb"])
+
+
+class BuildSinglearchPackageVariantsTest(unittest.TestCase):
+    """``build_singlearch_package_variants`` — non-kpack (single ``--target``) builds.
+
+    Use case: legacy single-GPU packaging produces one versioned and one non-versioned
+    variant for the selected architecture (``gfx_arch`` from first ``--target``).
+    """
+
+    @patch.object(build_package, "cleanup_build_directory")
+    @patch.object(build_package, "create_nonversioned_deb_package", return_value=["nv.deb"])
+    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
+    def test_deb_single_arch_builds_both_variants(self, mock_versioned, mock_nonversioned, _mock_cleanup):
+        """Single-arch DEB: ``enable_kpack=False``, ``gfx_arch=gfx1100`` → versioned + non-versioned."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(
+                Path(tmp),
+                enable_kpack=False,
+                gfx_arch="gfx1100",
+                pkg_type="deb",
+            )
+            built = build_package.build_singlearch_package_variants(
+                "amdrocm-core-sdk",
+                cfg,
+            )
+            mock_versioned.assert_called_once()
+            mock_nonversioned.assert_called_once()
+            self.assertEqual(built, ["v.deb", "nv.deb"])
+
+    @patch.object(build_package, "cleanup_build_directory")
+    @patch.object(build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"])
+    @patch.object(build_package, "create_versioned_rpm_package", return_value=["v.rpm"])
+    def test_rpm_single_arch_builds_both_variants(self, mock_versioned, mock_nonversioned, _mock_cleanup):
+        """Single-arch RPM: same as DEB but via ``create_*_rpm_package``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(
+                Path(tmp),
+                enable_kpack=False,
+                gfx_arch="gfx1100",
+                pkg_type="rpm",
+            )
+            built = build_package.build_singlearch_package_variants(
+                "amdrocm-core-sdk",
+                cfg,
+            )
+            mock_versioned.assert_called_once()
+            mock_nonversioned.assert_called_once()
+            self.assertEqual(built, ["v.rpm", "nv.rpm"])
+
+    @patch.object(build_package, "cleanup_build_directory")
+    @patch.object(build_package, "create_nonversioned_deb_package")
+    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
+    def test_rpath_skips_nonversioned_single_arch(
+        self, mock_versioned, mock_nonversioned, _mock_cleanup
+    ):
+        """``enable_rpath=True`` in single-arch mode skips non-versioned output."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(
+                Path(tmp),
+                enable_kpack=False,
+                gfx_arch="gfx1100",
+                enable_rpath=True,
+            )
+            built = build_package.build_singlearch_package_variants(
+                "amdrocm-core-sdk",
+                cfg,
+            )
+            mock_versioned.assert_called_once()
+            mock_nonversioned.assert_not_called()
+            self.assertEqual(built, ["v.deb"])
+
+
+class VariantBuilderDispatchTest(unittest.TestCase):
+    """Low-level ``build_*_package`` helpers — ``gfx_arch`` and ``pkg_type`` wiring.
+
+    Use case: each variant builder must pass the correct ``PackageConfig`` fields
+    (``GFX_HOST``, device arch, ``GFX_META``, ``versioned_pkg``) into the DEB/RPM
+    creator for dependency naming and artifact selection.
+    """
+
+    @patch.object(build_package, "create_versioned_deb_package", return_value=["host.deb"])
+    def test_build_host_package_deb(self, mock_create):
+        """``build_host_package`` sets ``gfx_arch=GFX_HOST`` and ``versioned_pkg=True``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp), pkg_type="deb")
+            result = build_package.build_host_package("amdrocm-ck", cfg)
+            self.assertEqual(result, ["host.deb"])
+            passed = mock_create.call_args[0][1]
+            self.assertEqual(passed.gfx_arch, GFX_HOST)
+            self.assertTrue(passed.versioned_pkg)
+
+    @patch.object(build_package, "create_versioned_rpm_package", return_value=["dev.rpm"])
+    def test_build_device_package_rpm(self, mock_create):
+        """``build_device_package(..., device_arch)`` sets ``gfx_arch`` to the device token."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp), pkg_type="rpm")
+            result = build_package.build_device_package("amdrocm-ck", cfg, "gfx1100")
+            self.assertEqual(result, ["dev.rpm"])
+            passed = mock_create.call_args[0][1]
+            self.assertEqual(passed.gfx_arch, "gfx1100")
+
+    @patch.object(build_package, "create_versioned_deb_package", return_value=["meta.deb"])
+    def test_build_meta_package_deb(self, mock_create):
+        """``build_meta_package`` sets ``gfx_arch=GFX_META`` for the versioned meta DEB."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp), pkg_type="deb")
+            build_package.build_meta_package("amdrocm-ck", cfg)
+            passed = mock_create.call_args[0][1]
+            self.assertEqual(passed.gfx_arch, GFX_META)
+
+    @patch.object(build_package, "create_versioned_deb_package", return_value=["ver.deb"])
+    def test_build_versioned_package_clears_gfx_arch(self, mock_create):
+        """``build_versioned_package`` (non-gfx simple path) clears ``gfx_arch`` to ``""``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp), gfx_arch="gfx1100")
+            build_package.build_versioned_package("amdrocm-developer-tools", cfg)
+            passed = mock_create.call_args[0][1]
+            self.assertEqual(passed.gfx_arch, "")
+
+    @patch.object(build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"])
+    def test_build_nonversioned_package_rpm(self, mock_create):
+        """``build_nonversioned_package`` sets ``versioned_pkg=False``; preserves caller ``gfx_arch``."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp), pkg_type="rpm", gfx_arch=GFX_META)
+            build_package.build_nonversioned_package("amdrocm-ck", cfg)
+            passed = mock_create.call_args[0][1]
+            self.assertFalse(passed.versioned_pkg)
+            self.assertEqual(passed.gfx_arch, GFX_META)
+
+
+class MainAndRunTest(unittest.TestCase):
+    """``main(argv)`` and ``run(args)`` — end-to-end CLI orchestration (mocked builds).
+
+    Use case: verify the public entry points wire argparse → config → package list →
+    per-package ``build_package_variants`` without running a full packaging job.
+    """
+
+    def test_main_delegates_to_run(self):
+        """``main`` parses required flags and passes the resulting namespace to ``run``.
+
+        CLI exercised: ``--artifacts-dir``, ``--dest-dir``, ``--pkg-type deb``,
+        ``--rocm-version 7.1.0``, ``--target gfx1100``.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            art = root / "artifacts"
+            out = root / "output"
+            art.mkdir()
+            out.mkdir()
+            argv = [
+                "--artifacts-dir",
+                str(art),
+                "--dest-dir",
+                str(out),
+                "--pkg-type",
+                "deb",
+                "--rocm-version",
+                "7.1.0",
+                "--target",
+                "gfx1100",
+            ]
+            with patch.object(build_package, "run") as mock_run:
+                build_package.main(argv)
+            mock_run.assert_called_once()
+            passed = mock_run.call_args[0][0]
+            self.assertEqual(passed.pkg_type, "deb")
+            self.assertEqual(passed.rocm_version, "7.1.0")
+
+    @patch.object(build_package, "print_build_summary")
+    @patch.object(build_package, "cleanup_packaging_environment")
+    @patch.object(build_package, "build_package_variants", return_value=["out.deb"])
+    @patch.object(build_package, "parse_input_package_list", return_value=(["amdrocm-core-sdk"], []))
+    @patch.object(build_package, "create_package_config")
+    def test_run_builds_requested_packages(
+        self,
+        mock_create_cfg,
+        mock_parse_list,
+        mock_build_variants,
+        _mock_cleanup,
+        _mock_summary,
+    ):
+        """``run`` calls ``build_package_variants`` once per resolved ``--pkg-names`` entry.
+
+        Args: ``pkg_names=["amdrocm-core-sdk"]``, ``pkg_type=deb``.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cfg = _config(root)
+            mock_create_cfg.return_value = cfg
+            args = _args(root, pkg_names=["amdrocm-core-sdk"], pkg_type="deb")
+            build_package.run(args)
+            mock_parse_list.assert_called_once_with(["amdrocm-core-sdk"], cfg.artifacts_dir)
+            mock_build_variants.assert_called_once_with("amdrocm-core-sdk", cfg)
+
+    @patch.object(build_package, "print_build_summary")
+    @patch.object(build_package, "cleanup_packaging_environment")
+    @patch.object(build_package, "parse_input_package_list", return_value=([], []))
+    @patch.object(build_package, "create_package_config")
+    def test_run_exits_when_package_list_empty(
+        self,
+        mock_create_cfg,
+        _mock_parse_list,
+        _mock_cleanup,
+        _mock_summary,
+    ):
+        """``run`` exits with code 1 when no packages remain after list resolution."""
+        with tempfile.TemporaryDirectory() as tmp:
+            mock_create_cfg.return_value = _config(Path(tmp))
+            args = _args(Path(tmp))
+            with self.assertRaises(SystemExit) as ctx:
+                build_package.run(args)
+            self.assertEqual(ctx.exception.code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -4,25 +4,13 @@
 
 from __future__ import annotations
 
-"""Unit tests for ``build_package.py`` CLI parameters and packaging dispatch.
+"""Unit tests for ``build_package.py`` using API-driven fixtures and real outputs.
 
-Scope
------
-Validates how ``build_package.py`` maps CLI flags to ``PackageConfig``, detects kpack
-mode from manifests, resolves ``--pkg-names``, and routes each package to the correct
-variant builder (gfx-arch kpack, simple kpack, or single-arch). Covers metapackages
-vs regular packages, DEB vs RPM, ``--enable-kpack``, and ``--rpath-pkg``.
-
-Test strategy
--------------
-* **Config / parsing tests** — call real functions with synthetic ``argparse.Namespace``
-  values built by ``_args()``; no subprocess, no real package builds.
-* **Routing tests** — mock high-level builders to assert the correct code path is chosen
-  (regression guard for issues like #6093 where metapackages were mis-routed).
-* **Variant-builder tests** — mock ``create_versioned_*`` / ``create_nonversioned_*`` to
-  count which variants are produced without invoking ``dpkg`` / ``rpmbuild``.
-* **Integration with ``package.json``** — ``parse_input_package_list`` and routing tests
-  use real package names (``amdrocm-core-sdk``, ``amdrocm-ck``, ``amdrocm-fft``, etc.).
+Tests stage artifact trees by walking ``package.json`` via ``get_package_info()`` and
+the same ``{Artifact}_{Component}_{suffix}`` layout consumed by
+``filter_components_fromartifactory``. Config is built via ``create_package_config()``.
+DEB generation runs through real ``create_versioned_deb_package()``; only
+``package_with_dpkg_build`` and ``move_packages_to_destination`` are mocked.
 
 Run::
 
@@ -33,11 +21,11 @@ Requires Python 3.10+ (``packaging_utils`` type syntax).
 
 import importlib.util
 import json
-import os
 import sys
 import tempfile
 import unittest
 from argparse import Namespace
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -48,48 +36,33 @@ for _path in (_BUILD_TOOLS_DIR, _LINUX_DIR):
         sys.path.insert(0, str(_path))
 
 _BP_PATH = _LINUX_DIR / "build_package.py"
-# importlib is required here: a normal ``import build_package`` would execute
-# ``build_package.py``'s module-level ``if __name__ == "__main__"`` guard and
-# call ``sys.exit`` when loaded as a test dependency.
 _BP_SPEC = importlib.util.spec_from_file_location("build_package", _BP_PATH)
 build_package = importlib.util.module_from_spec(_BP_SPEC)
 _BP_SPEC.loader.exec_module(build_package)
 
-from packaging_utils import GFX_HOST, GFX_META, PackageConfig  # noqa: E402
+_DEB_PATH = _LINUX_DIR / "deb_package.py"
+_DEB_SPEC = importlib.util.spec_from_file_location("deb_package", _DEB_PATH)
+deb_package = importlib.util.module_from_spec(_DEB_SPEC)
+_DEB_SPEC.loader.exec_module(deb_package)
+
+from packaging_utils import (  # noqa: E402
+    GFX_HOST,
+    GFX_META,
+    filter_components_fromartifactory,
+    get_package_info,
+    is_gfxarch_package,
+    is_key_defined,
+    update_package_name,
+)
 
 
 # ---------------------------------------------------------------------------
-# Test fixtures — synthetic CLI/config and minimal artifact trees
+# CLI / manifest helpers
 # ---------------------------------------------------------------------------
 
 
-# Build synthetic argparse.Namespace (CLI flags) for create_package_config / run tests.
 def _args(tmp: Path, **overrides) -> Namespace:
-    """Build an ``argparse.Namespace`` mirroring ``build_package.py`` CLI flags.
-
-    Creates a temp artifact directory under ``tmp``. Defaults match a typical
-    single-arch DEB build; pass ``**overrides`` to simulate other invocations.
-
-    Default arguments:
-        ``--artifacts-dir``   ``tmp/artifacts`` (created on disk)
-        ``--dest-dir``        ``tmp/output``
-        ``--target``          ``["gfx1100", "gfx942"]``
-        ``--pkg-type``        ``deb``
-        ``--rocm-version``    ``7.1.0``
-        ``--version-suffix``  ``daily``
-        ``--install-prefix``  ``/opt/rocm/core``
-        ``--rpath-pkg``       ``False``
-        ``--enable-kpack``    ``False``
-        ``--pkg-names``       ``None`` (build all eligible packages)
-        ``--clean-build``     ``False``
-
-    Args:
-        tmp: Root temp directory for artifact and output paths.
-        **overrides: Any CLI field to replace in the namespace.
-
-    Returns:
-        Namespace consumed by ``create_package_config`` and ``run``.
-    """
+    """Build an ``argparse.Namespace`` mirroring ``build_package.py`` CLI flags."""
     artifacts = tmp / "artifacts"
     artifacts.mkdir(parents=True, exist_ok=True)
     defaults = {
@@ -109,44 +82,8 @@ def _args(tmp: Path, **overrides) -> Namespace:
     return Namespace(**defaults)
 
 
-# Build synthetic PackageConfig for variant-builder tests (default: kpack DEB).
-def _config(tmp: Path, **overrides) -> PackageConfig:
-    """Build a minimal ``PackageConfig`` for variant-builder unit tests.
-
-    Default config simulates kpack DEB mode with two GPU targets. Override fields
-    to test single-arch, RPM, or ``--rpath-pkg`` paths.
-
-    Args:
-        tmp: Root temp directory; ``artifacts_dir`` and ``dest_dir`` are placed under it.
-        **overrides: Any ``PackageConfig`` field to replace.
-
-    Returns:
-        Frozen ``PackageConfig`` passed to ``build_*_package_variants`` helpers.
-    """
-    defaults = {
-        "artifacts_dir": tmp / "artifacts",
-        "dest_dir": tmp / "output",
-        "pkg_type": "deb",
-        "rocm_version": "7.1.0",
-        "version_suffix": "daily",
-        "install_prefix": "/opt/rocm/core-7.1",
-        "gfx_arch": "",
-        "enable_rpath": False,
-        "versioned_pkg": True,
-        "enable_kpack": True,
-        "gfxarch_list": ("gfx1100", "gfx942"),
-    }
-    defaults.update(overrides)
-    return PackageConfig(**defaults)
-
-
-# Write therock_manifest.json with KPACK_SPLIT_ARTIFACTS for kpack auto-detect.
 def _write_kpack_manifest(artifacts_dir: Path) -> None:
-    """Write a ``therock_manifest.json`` that enables kpack split artifacts.
-
-    Args:
-        artifacts_dir: Root scanned by ``load_kpack_from_manifest`` (recursive).
-    """
+    """Write ``therock_manifest.json`` with ``KPACK_SPLIT_ARTIFACTS`` enabled."""
     manifest_dir = artifacts_dir / "pkg"
     manifest_dir.mkdir(parents=True, exist_ok=True)
     (manifest_dir / "therock_manifest.json").write_text(
@@ -155,235 +92,357 @@ def _write_kpack_manifest(artifacts_dir: Path) -> None:
     )
 
 
-# Create empty gfx-arch artifact dir matching production {Artifact}_{Component}_gfx* naming.
-def _write_gfx_artifact_dir(artifacts_dir: Path, dirname: str) -> None:
-    """Create a minimal gfx-specific artifact directory under ``artifacts_dir``.
-
-    Production kpack trees use ``{Artifact}_{Component}_gfx*`` directory names;
-    an empty directory is enough for ``_has_arch_specific_artifacts`` detection.
-
-    Args:
-        artifacts_dir: Artifact tree root passed as ``PackageConfig.artifacts_dir``.
-        dirname: Gfx-arch artifact directory name (e.g. ``fft_run_gfx1100``).
-    """
-    (artifacts_dir / dirname).mkdir(parents=True, exist_ok=True)
-
-
-# Fixture: composable-kernel_run_gfx1100 dir so amdrocm-ck passes is_gfxarch_package.
-def _ck_gfx_artifacts(artifacts_dir: Path) -> None:
-    """Gfx dirs for ``amdrocm-ck`` → ``composable-kernel_run_gfx1100``."""
-    _write_gfx_artifact_dir(artifacts_dir, "composable-kernel_run_gfx1100")
-
-
-# Fixture: fft_run_gfx1100 dir so amdrocm-fft passes is_gfxarch_package.
-def _fft_gfx_artifacts(artifacts_dir: Path) -> None:
-    """Gfx dirs for ``amdrocm-fft`` → ``fft_run_gfx1100``."""
-    _write_gfx_artifact_dir(artifacts_dir, "fft_run_gfx1100")
+def _control_field(control_text: str, field: str) -> str:
+    """Return the value of a ``debian/control`` field (e.g. ``Package``)."""
+    prefix = f"{field}:"
+    for line in control_text.splitlines():
+        if line.startswith(prefix):
+            return line.split(":", 1)[1].strip()
+    raise AssertionError(f"Field {field!r} not found in control file:\n{control_text}")
 
 
 # ---------------------------------------------------------------------------
-# create_package_config — CLI → PackageConfig
+# API-driven artifact staging (mirrors filter_components_fromartifactory)
+# ---------------------------------------------------------------------------
+
+
+def _artifact_suffix_for_staging(
+    pkg_info: dict,
+    artifact: dict,
+    gfx_arch: str,
+    *,
+    enable_kpack: bool,
+    artifacts_dir: Path,
+) -> str | None:
+    """Compute artifact directory suffix using packaging naming rules."""
+    if enable_kpack:
+        if gfx_arch == GFX_META:
+            return None
+        if gfx_arch == GFX_HOST:
+            dir_suffix = "generic"
+        elif is_gfxarch_package(pkg_info, enable_kpack, artifacts_dir):
+            dir_suffix = gfx_arch
+        elif is_key_defined(pkg_info, "Gfxarch"):
+            # Staging device trees before gfx dirs exist: Gfxarch metadata still
+            # implies arch-specific suffixes once kpack splits are in play.
+            dir_suffix = gfx_arch
+        else:
+            dir_suffix = "generic"
+    else:
+        dir_suffix = (
+            gfx_arch
+            if is_gfxarch_package(pkg_info, enable_kpack, artifacts_dir)
+            else "generic"
+        )
+
+    if "Artifact_Gfxarch" in artifact:
+        is_artifact_gfx = str(artifact["Artifact_Gfxarch"]).lower() == "true"
+        if enable_kpack and gfx_arch not in (GFX_HOST, GFX_META) and not is_artifact_gfx:
+            return None
+        return gfx_arch if is_artifact_gfx else "generic"
+    return dir_suffix
+
+
+def _stage_package_artifacts(
+    pkg_name: str,
+    artifacts_dir: Path,
+    gfx_arch: str,
+    *,
+    enable_kpack: bool = True,
+) -> list[Path]:
+    """Stage artifact dirs + manifests from ``package.json`` via ``get_package_info``."""
+    pkg_info = get_package_info(pkg_name)
+    if enable_kpack and gfx_arch == GFX_META:
+        return []
+
+    created: list[Path] = []
+    for artifact in pkg_info.get("Artifactory", []):
+        suffix = _artifact_suffix_for_staging(
+            pkg_info,
+            artifact,
+            gfx_arch,
+            enable_kpack=enable_kpack,
+            artifacts_dir=artifacts_dir,
+        )
+        if suffix is None:
+            continue
+
+        prefix = artifact["Artifact"]
+        for subdir in artifact["Artifact_Subdir"]:
+            subdir_name = subdir["Name"]
+            for component in subdir["Components"]:
+                artifact_dir = artifacts_dir / f"{prefix}_{component}_{suffix}"
+                rel_path = f"{subdir_name}/{component}/libdummy.so"
+                payload = artifact_dir / rel_path
+                payload.parent.mkdir(parents=True, exist_ok=True)
+                payload.write_bytes(b"\x00")
+                manifest = artifact_dir / "artifact_manifest.txt"
+                manifest.write_text(f"{rel_path}\n", encoding="utf-8")
+                created.append(artifact_dir)
+    return created
+
+
+def _kpack_config(tmp: Path, **overrides) -> build_package.PackageConfig:
+    """Build kpack ``PackageConfig`` via ``create_package_config`` (not hand-built)."""
+    root = Path(tmp)
+    _write_kpack_manifest(root / "artifacts")
+    args = _args(root, enable_kpack=True, **overrides)
+    return build_package.create_package_config(args)
+
+
+def _control_path(pkg_name: str, config: build_package.PackageConfig) -> Path:
+    """Return path to generated ``debian/control`` for a versioned DEB build."""
+    updated = update_package_name(pkg_name, replace(config, versioned_pkg=True))
+    return (
+        Path(config.dest_dir)
+        / config.pkg_type
+        / updated
+        / "debian"
+        / "control"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Artifact staging — validates production discovery APIs
+# ---------------------------------------------------------------------------
+class ArtifactStagingTest(unittest.TestCase):
+    """``_stage_package_artifacts`` produces trees ``filter_components`` accepts."""
+
+    def test_staged_fft_host_artifacts_discovered(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifacts = root / "artifacts"
+            artifacts.mkdir()
+            _stage_package_artifacts("amdrocm-fft", artifacts, GFX_HOST)
+            sourcedirs = filter_components_fromartifactory(
+                "amdrocm-fft", artifacts, GFX_HOST, enable_kpack=True
+            )
+            self.assertTrue(sourcedirs)
+
+    def test_staged_fft_device_artifacts_discovered(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifacts = root / "artifacts"
+            artifacts.mkdir()
+            _stage_package_artifacts("amdrocm-fft", artifacts, "gfx1100")
+            sourcedirs = filter_components_fromartifactory(
+                "amdrocm-fft", artifacts, "gfx1100", enable_kpack=True
+            )
+            self.assertTrue(sourcedirs)
+            self.assertTrue(
+                is_gfxarch_package(
+                    get_package_info("amdrocm-fft"),
+                    enable_kpack=True,
+                    artifacts_dir=artifacts,
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# create_versioned_deb_package — real control file generation
+# ---------------------------------------------------------------------------
+class CreateVersionedDebPackageTest(unittest.TestCase):
+    """Real ``create_versioned_deb_package`` with API-staged artifacts."""
+
+    @patch.object(deb_package, "move_packages_to_destination", return_value=[])
+    @patch.object(deb_package, "package_with_dpkg_build")
+    def test_fft_host_generates_control_file(self, _mock_dpkg, _mock_move):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cfg = _kpack_config(root)
+            # Host naming requires gfx dirs on disk (#5874); runtime dep needs artifacts
+            # in pkg_list for convert_to_versiondependency.
+            _stage_package_artifacts("amdrocm-fft", cfg.artifacts_dir, GFX_HOST)
+            _stage_package_artifacts("amdrocm-fft", cfg.artifacts_dir, "gfx1100")
+            _stage_package_artifacts("amdrocm-runtime", cfg.artifacts_dir, GFX_HOST)
+            host_cfg = replace(cfg, gfx_arch=GFX_HOST)
+
+            deb_package.create_versioned_deb_package("amdrocm-fft", host_cfg)
+
+            control = _control_path("amdrocm-fft", host_cfg).read_text(encoding="utf-8")
+            self.assertEqual(
+                _control_field(control, "Package"), "amdrocm-fft-host7.1"
+            )
+            self.assertEqual(_control_field(control, "Architecture"), "amd64")
+            self.assertIn("amdrocm-runtime", _control_field(control, "Depends"))
+
+    @patch.object(deb_package, "move_packages_to_destination", return_value=[])
+    @patch.object(deb_package, "package_with_dpkg_build")
+    def test_fft_device_generates_control_file(self, _mock_dpkg, _mock_move):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cfg = _kpack_config(root)
+            _stage_package_artifacts("amdrocm-fft", cfg.artifacts_dir, "gfx1100")
+            device_cfg = replace(cfg, gfx_arch="gfx1100")
+
+            deb_package.create_versioned_deb_package("amdrocm-fft", device_cfg)
+
+            control = _control_path("amdrocm-fft", device_cfg).read_text(
+                encoding="utf-8"
+            )
+            self.assertEqual(
+                _control_field(control, "Package"), "amdrocm-fft7.1-gfx1100"
+            )
+
+    @patch.object(deb_package, "move_packages_to_destination", return_value=[])
+    @patch.object(deb_package, "package_with_dpkg_build")
+    def test_fft_meta_generates_control_file(self, _mock_dpkg, _mock_move):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cfg = _kpack_config(root)
+            meta_cfg = replace(cfg, gfx_arch=GFX_META)
+
+            deb_package.create_versioned_deb_package("amdrocm-fft", meta_cfg)
+
+            control = _control_path("amdrocm-fft", meta_cfg).read_text(encoding="utf-8")
+            self.assertEqual(_control_field(control, "Package"), "amdrocm-fft7.1")
+
+    @patch.object(deb_package, "move_packages_to_destination", return_value=[])
+    @patch.object(deb_package, "package_with_dpkg_build")
+    def test_core_sdk_device_meta_generates_control_file(self, _mock_dpkg, _mock_move):
+        """Gfx-arch metapackage ``amdrocm-core-sdk`` device variant (#6093)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cfg = _kpack_config(root)
+            device_cfg = replace(cfg, gfx_arch="gfx1100")
+
+            deb_package.create_versioned_deb_package("amdrocm-core-sdk", device_cfg)
+
+            control = _control_path("amdrocm-core-sdk", device_cfg).read_text(
+                encoding="utf-8"
+            )
+            self.assertEqual(
+                _control_field(control, "Package"), "amdrocm-core-sdk7.1-gfx1100"
+            )
+            # debian_replace_devel_name maps -devel → -dev in DEB Depends
+            self.assertIn("amdrocm-core-dev", _control_field(control, "Depends"))
+
+    @patch.object(deb_package, "move_packages_to_destination", return_value=[])
+    @patch.object(deb_package, "package_with_dpkg_build")
+    def test_developer_tools_versioned_metapackage_control(self, _mock_dpkg, _mock_move):
+        """Simple kpack metapackage with no Artifactory entries."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cfg = _kpack_config(root)
+            # convert_to_versiondependency only keeps amdrocm deps present in pkg_list
+            _stage_package_artifacts("amdrocm-debugger", cfg.artifacts_dir, "")
+            versioned_cfg = replace(cfg, gfx_arch="")
+
+            deb_package.create_versioned_deb_package(
+                "amdrocm-developer-tools", versioned_cfg
+            )
+
+            control = _control_path("amdrocm-developer-tools", versioned_cfg).read_text(
+                encoding="utf-8"
+            )
+            self.assertEqual(
+                _control_field(control, "Package"), "amdrocm-developer-tools7.1"
+            )
+            self.assertIn("amdrocm-debugger", _control_field(control, "Depends"))
+
+
+# ---------------------------------------------------------------------------
+# build_package_variants — routing with real artifact detection (#5874)
+# ---------------------------------------------------------------------------
+class BuildPackageVariantsRoutingTest(unittest.TestCase):
+    """Top-level routing using real ``is_gfxarch_package`` / staged artifacts."""
+
+    @patch.object(build_package, "build_gfxarch_package_variants", return_value=[])
+    @patch.object(build_package, "build_simple_package_variants")
+    def test_fft_with_staged_artifacts_routes_to_gfxarch(
+        self, mock_simple, mock_gfxarch
+    ):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _kpack_config(tmp)
+            _stage_package_artifacts("amdrocm-fft", cfg.artifacts_dir, "gfx1100")
+            build_package.build_package_variants("amdrocm-fft", cfg)
+            mock_gfxarch.assert_called_once_with("amdrocm-fft", cfg)
+            mock_simple.assert_not_called()
+
+    @patch.object(build_package, "build_gfxarch_package_variants")
+    @patch.object(build_package, "build_simple_package_variants", return_value=[])
+    def test_fft_without_gfx_artifacts_routes_to_simple(self, mock_simple, mock_gfxarch):
+        """#5874: Gfxarch metadata alone must not trigger gfx splits without artifacts."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _kpack_config(tmp)
+            pkg_info = get_package_info("amdrocm-fft")
+            self.assertFalse(
+                is_gfxarch_package(
+                    pkg_info,
+                    enable_kpack=True,
+                    artifacts_dir=cfg.artifacts_dir,
+                )
+            )
+            build_package.build_package_variants("amdrocm-fft", cfg)
+            mock_simple.assert_called_once_with("amdrocm-fft", cfg)
+            mock_gfxarch.assert_not_called()
+
+    @patch.object(build_package, "build_gfxarch_package_variants", return_value=[])
+    @patch.object(build_package, "build_simple_package_variants")
+    def test_core_sdk_metapackage_routes_to_gfxarch(self, mock_simple, mock_gfxarch):
+        """Gfx-arch metapackage routes to gfxarch builder even without artifacts (#6093)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _kpack_config(tmp)
+            build_package.build_package_variants("amdrocm-core-sdk", cfg)
+            mock_gfxarch.assert_called_once_with("amdrocm-core-sdk", cfg)
+            mock_simple.assert_not_called()
+
+    @patch.object(build_package, "build_gfxarch_package_variants")
+    @patch.object(build_package, "build_simple_package_variants", return_value=[])
+    def test_developer_tools_routes_to_simple(self, mock_simple, mock_gfxarch):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _kpack_config(tmp)
+            build_package.build_package_variants("amdrocm-developer-tools", cfg)
+            mock_simple.assert_called_once_with("amdrocm-developer-tools", cfg)
+            mock_gfxarch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# create_package_config — CLI → PackageConfig (real function, no hand-built config)
 # ---------------------------------------------------------------------------
 class CreatePackageConfigTest(unittest.TestCase):
-    """``create_package_config(args)`` — CLI → ``PackageConfig`` mapping.
-
-    Use case: every ``build_package.py`` invocation first normalizes flags into a
-    ``PackageConfig``. These tests lock in argument handling for ``--pkg-type``,
-    ``--target``, ``--enable-kpack``, ``--rpath-pkg``, ``--rocm-version``,
-    ``--install-prefix``, and ``--version-suffix``.
-    """
-
-    # DEB --pkg-type is lower-cased in PackageConfig.
-    def test_deb_pkg_type_normalized(self):
-        """``--pkg-type DEB`` is lower-cased to ``deb`` in ``PackageConfig.pkg_type``."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = build_package.create_package_config(_args(Path(tmp), pkg_type="DEB"))
-            self.assertEqual(cfg.pkg_type, "deb")
-
-    # RPM --pkg-type is lower-cased in PackageConfig.
-    def test_rpm_pkg_type_normalized(self):
-        """``--pkg-type RPM`` is lower-cased to ``rpm`` in ``PackageConfig.pkg_type``."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = build_package.create_package_config(_args(Path(tmp), pkg_type="RPM"))
-            self.assertEqual(cfg.pkg_type, "rpm")
-
-    # Unsupported --pkg-type raises ValueError.
-    def test_invalid_pkg_type_raises(self):
-        """Unsupported ``--pkg-type`` (e.g. tgz) raises ``ValueError`` listing deb/rpm."""
-        with tempfile.TemporaryDirectory() as tmp:
-            with self.assertRaises(ValueError) as ctx:
-                build_package.create_package_config(
-                    _args(Path(tmp), pkg_type="tgz"),
-                )
-            self.assertIn("deb", str(ctx.exception))
-            self.assertIn("rpm", str(ctx.exception))
-
-    # Malformed --rocm-version raises ValueError.
-    def test_invalid_rocm_version_raises(self):
-        """``--rocm-version`` without major.minor (e.g. ``7``) raises ``ValueError``."""
-        with tempfile.TemporaryDirectory() as tmp:
-            with self.assertRaises(ValueError):
-                build_package.create_package_config(
-                    _args(Path(tmp), rocm_version="7"),
-                )
-
-    # Default install prefix gets -major.minor suffix.
-    def test_default_install_prefix_appends_major_minor(self):
-        """Default ``--install-prefix /opt/rocm/core`` becomes ``/opt/rocm/core-7.1``."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = build_package.create_package_config(_args(Path(tmp)))
-            self.assertEqual(cfg.install_prefix, "/opt/rocm/core-7.1")
-
-    # Custom install prefix is not version-suffixed.
-    def test_custom_install_prefix_unchanged(self):
-        """Non-default ``--install-prefix`` is copied verbatim (no version suffix)."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = build_package.create_package_config(
-                _args(Path(tmp), install_prefix="/custom/prefix"),
-            )
-            self.assertEqual(cfg.install_prefix, "/custom/prefix")
-
-    # Kpack mode stores --target list in gfxarch_list.
     def test_explicit_targets_in_kpack_mode(self):
-        """``--enable-kpack`` + ``--target gfx1100 gfx942`` fills ``gfxarch_list``."""
         with tempfile.TemporaryDirectory() as tmp:
             cfg = build_package.create_package_config(
-                _args(
-                    Path(tmp),
-                    enable_kpack=True,
-                    target=["gfx1100", "gfx942"],
-                ),
+                _args(Path(tmp), enable_kpack=True, target=["gfx1100", "gfx942"])
             )
             self.assertTrue(cfg.enable_kpack)
             self.assertEqual(cfg.gfxarch_list, ("gfx1100", "gfx942"))
-            self.assertEqual(cfg.gfx_arch, "")
 
-    # Non-kpack mode uses first --target as gfx_arch only.
-    def test_single_arch_uses_first_target(self):
-        """Without kpack, ``gfx_arch`` is the first ``--target``; ``gfxarch_list`` empty."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = build_package.create_package_config(
-                _args(Path(tmp), target=["gfx1100", "gfx942"]),
-            )
-            self.assertFalse(cfg.enable_kpack)
-            self.assertEqual(cfg.gfx_arch, "gfx1100")
-            self.assertEqual(cfg.gfxarch_list, ())
-
-    # Missing --target auto-detects from artifact scan.
-    @patch.object(build_package, "get_all_target_families", return_value=["gfx1200"])
-    def test_auto_detect_targets_when_target_omitted(self, _mock_detect):
-        """Omitted ``--target`` auto-detects via ``get_all_target_families(artifacts_dir)``."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = build_package.create_package_config(_args(Path(tmp), target=None))
-            self.assertEqual(cfg.gfx_arch, "gfx1200")
-
-    # Kpack enabled when manifest has KPACK_SPLIT_ARTIFACTS.
     def test_auto_detect_kpack_from_manifest(self):
-        """Kpack enabled when ``therock_manifest.json`` has ``KPACK_SPLIT_ARTIFACTS: true``."""
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             _write_kpack_manifest(root / "artifacts")
             cfg = build_package.create_package_config(_args(root))
             self.assertTrue(cfg.enable_kpack)
 
-    # CLI --enable-kpack wins without manifest flag.
-    def test_explicit_enable_kpack_overrides_absent_manifest(self):
-        """``--enable-kpack`` sets kpack even when no manifest flag is present."""
+    def test_invalid_rocm_version_raises(self):
         with tempfile.TemporaryDirectory() as tmp:
-            cfg = build_package.create_package_config(
-                _args(Path(tmp), enable_kpack=True),
-            )
-            self.assertTrue(cfg.enable_kpack)
-
-    # --rpath-pkg maps to PackageConfig.enable_rpath.
-    def test_rpath_pkg_flag(self):
-        """``--rpath-pkg`` maps to ``PackageConfig.enable_rpath=True``."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = build_package.create_package_config(
-                _args(Path(tmp), rpath_pkg=True),
-            )
-            self.assertTrue(cfg.enable_rpath)
-
-    # --version-suffix is stored on PackageConfig.
-    def test_version_suffix_preserved(self):
-        """``--version-suffix nightly`` is stored on ``PackageConfig.version_suffix``."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = build_package.create_package_config(
-                _args(Path(tmp), version_suffix="nightly"),
-            )
-            self.assertEqual(cfg.version_suffix, "nightly")
-
-    # Writes PACKAGING_ARCH_LIST to GITHUB_OUTPUT for CI.
-    def test_writes_packaging_arch_list_to_github_output(self):
-        """When ``GITHUB_OUTPUT`` is set, writes ``PACKAGING_ARCH_LIST`` for CI matrix."""
-        with tempfile.TemporaryDirectory() as tmp:
-            github_env = Path(tmp) / "github_output"
-            github_env.write_text("", encoding="utf-8")
-            with patch.dict(os.environ, {"GITHUB_OUTPUT": str(github_env)}):
+            with self.assertRaises(ValueError):
                 build_package.create_package_config(
-                    _args(Path(tmp), target=["gfx1100"]),
+                    _args(Path(tmp), rocm_version="7"),
                 )
-            self.assertIn("PACKAGING_ARCH_LIST=gfx1100", github_env.read_text())
 
 
 # ---------------------------------------------------------------------------
-# load_kpack_from_manifest — kpack detection from artifact tree
+# load_kpack_from_manifest
 # ---------------------------------------------------------------------------
 class LoadKpackFromManifestTest(unittest.TestCase):
-    """``load_kpack_from_manifest(artifacts_dir)`` — kpack auto-detection.
-
-    Use case: CI artifact trees carry ``therock_manifest.json``; packaging should
-    enter host+device split mode without requiring ``--enable-kpack`` on the CLI.
-    """
-
-    # load_kpack_from_manifest returns True when flag present.
     def test_true_when_kpack_flag_set(self):
-        """Returns True when any nested manifest has ``flags.KPACK_SPLIT_ARTIFACTS``."""
         with tempfile.TemporaryDirectory() as tmp:
             _write_kpack_manifest(Path(tmp))
             self.assertTrue(build_package.load_kpack_from_manifest(Path(tmp)))
 
-    # load_kpack_from_manifest returns False with no manifest.
     def test_false_when_no_manifest(self):
-        """Empty artifact tree with no manifest files returns False."""
         with tempfile.TemporaryDirectory() as tmp:
             self.assertFalse(build_package.load_kpack_from_manifest(Path(tmp)))
 
-    # load_kpack_from_manifest returns False without kpack flag.
-    def test_false_when_manifest_missing_flag(self):
-        """Manifest present but without ``KPACK_SPLIT_ARTIFACTS`` returns False."""
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            (root / "therock_manifest.json").write_text("{}", encoding="utf-8")
-            self.assertFalse(build_package.load_kpack_from_manifest(root))
-
 
 # ---------------------------------------------------------------------------
-# parse_input_package_list — --pkg-names filtering
+# parse_input_package_list — real package.json names
 # ---------------------------------------------------------------------------
 class ParseInputPackageListTest(unittest.TestCase):
-    """``parse_input_package_list(pkg_names, artifact_dir)`` — ``--pkg-names`` filtering.
-
-    Use case: operators pass ``--pkg-names amdrocm-ck amdrocm-core-sdk`` to build a
-    subset; omitting it builds every package eligible from the artifact tree.
-    """
-
-    @patch.object(
-        build_package, "get_package_list", return_value=(["pkg-a"], ["skip-a"])
-    )
-    # pkg_names=None delegates to get_package_list.
-    def test_none_pkg_names_loads_all_from_artifacts(self, mock_get_list):
-        """``pkg_names=None`` delegates to ``get_package_list(artifact_dir)``."""
-        with tempfile.TemporaryDirectory() as tmp:
-            art = Path(tmp)
-            pkg_list, skipped = build_package.parse_input_package_list(None, art)
-            mock_get_list.assert_called_once_with(art)
-            self.assertEqual(pkg_list, ["pkg-a"])
-            self.assertEqual(skipped, ["skip-a"])
-
-    # Unknown --pkg-names entries are dropped.
     def test_explicit_pkg_names_filter_package_json(self):
-        """Named packages are matched against ``package.json``; unknown names dropped."""
         with tempfile.TemporaryDirectory() as tmp:
             pkg_list, skipped = build_package.parse_input_package_list(
                 ["amdrocm-core-sdk", "amdrocm-ck", "no-such-package"],
@@ -391,565 +450,6 @@ class ParseInputPackageListTest(unittest.TestCase):
             )
             self.assertEqual(set(pkg_list), {"amdrocm-core-sdk", "amdrocm-ck"})
             self.assertEqual(skipped, [])
-
-
-# ---------------------------------------------------------------------------
-# build_package_variants — top-level routing (gfxarch / simple / singlearch)
-# ---------------------------------------------------------------------------
-class BuildPackageVariantsRoutingTest(unittest.TestCase):
-    """``build_package_variants(pkg_name, config)`` — top-level builder selection.
-
-    Use case: the first routing decision determines host/device/meta splits vs simple
-    versioned packages. Mis-routing a gfx-arch metapackage (e.g. ``amdrocm-core-sdk``)
-    to the simple builder caused #6093 (missing per-GPU SDK dependencies).
-    """
-
-    @patch.object(
-        build_package, "build_gfxarch_package_variants", return_value=["meta.deb"]
-    )
-    # Kpack gfx metapackage amdrocm-core-sdk → gfxarch builder (#6093).
-    def test_kpack_metapackage_routes_to_gfxarch_builder(self, mock_gfx):
-        """Kpack + gfx-arch metapackage ``amdrocm-core-sdk`` → ``build_gfxarch_package_variants``.
-
-        Args (via ``_config``): ``enable_kpack=True``, ``pkg_type=deb``.
-        Package: ``amdrocm-core-sdk`` (``Metapackage`` + ``Gfxarch`` in ``package.json``).
-        """
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp))
-            result = build_package.build_package_variants("amdrocm-core-sdk", cfg)
-            mock_gfx.assert_called_once_with("amdrocm-core-sdk", cfg)
-            self.assertEqual(result, ["meta.deb"])
-
-    @patch.object(
-        build_package, "build_gfxarch_package_variants", return_value=["ck.deb"]
-    )
-    # Kpack amdrocm-ck with gfx dirs → gfxarch builder (#5874).
-    def test_kpack_gfxarch_non_meta_routes_to_gfxarch_builder(self, mock_gfx):
-        """Kpack + gfx-arch regular package ``amdrocm-ck`` → gfx-arch builder.
-
-        Requires gfx artifact dir ``composable-kernel_run_gfx1100`` on disk so
-        ``is_gfxarch_package`` returns True after #5874 artifact verification.
-        """
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            _ck_gfx_artifacts(root / "artifacts")
-            cfg = _config(root)
-            result = build_package.build_package_variants("amdrocm-ck", cfg)
-            mock_gfx.assert_called_once_with("amdrocm-ck", cfg)
-            self.assertEqual(result, ["ck.deb"])
-
-    @patch.object(
-        build_package, "build_gfxarch_package_variants", return_value=["fft.deb"]
-    )
-    # Kpack amdrocm-fft with gfx dirs → gfxarch builder.
-    def test_kpack_gfxarch_fft_routes_to_gfxarch_builder(self, mock_gfx):
-        """Kpack + gfx-arch regular package ``amdrocm-fft`` → gfx-arch builder.
-
-        Requires gfx artifact dir ``fft_run_gfx1100`` on disk (production math-lib
-        naming) so ``is_gfxarch_package`` returns True after #5874 verification.
-        """
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            _fft_gfx_artifacts(root / "artifacts")
-            cfg = _config(root)
-            result = build_package.build_package_variants("amdrocm-fft", cfg)
-            mock_gfx.assert_called_once_with("amdrocm-fft", cfg)
-            self.assertEqual(result, ["fft.deb"])
-
-    @patch.object(build_package, "build_gfxarch_package_variants")
-    @patch.object(
-        build_package, "build_simple_package_variants", return_value=["fft.deb"]
-    )
-    # Kpack amdrocm-fft without gfx dirs → simple builder (#5874 negative).
-    def test_kpack_gfxarch_without_artifacts_routes_to_simple_builder(
-        self, mock_simple, mock_gfx
-    ):
-        """Kpack + ``amdrocm-fft`` with Gfxarch metadata but no ``_gfx*`` dirs → simple builder.
-
-        Regression guard for #5874: metadata alone must not trigger gfx-arch splits when
-        arch-specific artifact directories are absent on disk.
-        """
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp))
-            result = build_package.build_package_variants("amdrocm-fft", cfg)
-            mock_simple.assert_called_once_with("amdrocm-fft", cfg)
-            mock_gfx.assert_not_called()
-            self.assertEqual(result, ["fft.deb"])
-
-    @patch.object(
-        build_package, "build_simple_package_variants", return_value=["tools.deb"]
-    )
-    # Kpack non-gfx package → simple builder.
-    def test_kpack_non_gfxarch_routes_to_simple_builder(self, mock_simple):
-        """Kpack + non-gfx-arch ``amdrocm-developer-tools`` → ``build_simple_package_variants``.
-
-        Package has ``Gfxarch: False`` in ``package.json`` — versioned + non-versioned only.
-        """
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp))
-            result = build_package.build_package_variants(
-                "amdrocm-developer-tools",
-                cfg,
-            )
-            mock_simple.assert_called_once_with("amdrocm-developer-tools", cfg)
-            self.assertEqual(result, ["tools.deb"])
-
-    @patch.object(
-        build_package, "build_singlearch_package_variants", return_value=["single.deb"]
-    )
-    # enable_kpack=False → singlearch builder.
-    def test_single_arch_routes_to_singlearch_builder(self, mock_single):
-        """``enable_kpack=False`` always uses ``build_singlearch_package_variants``.
-
-        Args: ``enable_kpack=False``, ``gfx_arch=gfx1100`` (first ``--target``).
-        """
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp), enable_kpack=False, gfx_arch="gfx1100")
-            result = build_package.build_package_variants("amdrocm-core-sdk", cfg)
-            mock_single.assert_called_once_with("amdrocm-core-sdk", cfg)
-            self.assertEqual(result, ["single.deb"])
-
-
-# ---------------------------------------------------------------------------
-# build_gfxarch_package_variants — host / device / meta / non-versioned counts
-# ---------------------------------------------------------------------------
-class BuildGfxarchPackageVariantsTest(unittest.TestCase):
-    """``build_gfxarch_package_variants`` — kpack host / device / meta / non-versioned.
-
-    Use case: gfx-arch packages in kpack mode produce multiple DEB/RPM variants.
-    Metapackages skip the host variant (no artifacts); regular packages include it.
-    ``--rpath-pkg`` suppresses the user-facing non-versioned metapackage variant.
-    """
-
-    @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(
-        build_package, "create_nonversioned_deb_package", return_value=["nv.deb"]
-    )
-    # Gfx metapackage builds device+meta+nv only (no host).
-    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
-    def test_metapackage_skips_host_builds_device_meta_nonversioned(
-        self, mock_versioned, mock_nonversioned, _mock_cleanup
-    ):
-        """Metapackage ``amdrocm-core-sdk``: 2 device + 1 meta + 1 non-versioned (no host).
-
-        ``gfxarch_list=("gfx1100", "gfx942")`` → two ``create_versioned_deb_package`` calls
-        for devices, one for meta, one ``create_nonversioned_deb_package``.
-        """
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp), pkg_type="deb")
-            built = build_package.build_gfxarch_package_variants(
-                "amdrocm-core-sdk",
-                cfg,
-            )
-            self.assertEqual(mock_versioned.call_count, 3)
-            self.assertEqual(mock_nonversioned.call_count, 1)
-            self.assertEqual(len(built), 4)
-
-    @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(
-        build_package, "create_nonversioned_deb_package", return_value=["nv.deb"]
-    )
-    # Gfx regular package amdrocm-ck builds host+device+meta+nv.
-    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
-    def test_non_meta_includes_host_device_meta_nonversioned(
-        self, mock_versioned, mock_nonversioned, _mock_cleanup
-    ):
-        """Regular gfx-arch ``amdrocm-ck``: host + 2 device + meta + non-versioned = 5 outputs."""
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            _ck_gfx_artifacts(root / "artifacts")
-            cfg = _config(root, pkg_type="deb")
-            built = build_package.build_gfxarch_package_variants("amdrocm-ck", cfg)
-            self.assertEqual(mock_versioned.call_count, 4)
-            self.assertEqual(mock_nonversioned.call_count, 1)
-            self.assertEqual(len(built), 5)
-
-    @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(
-        build_package, "create_nonversioned_deb_package", return_value=["nv.deb"]
-    )
-    # Gfx regular package amdrocm-fft builds host+device+meta+nv.
-    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
-    def test_fft_includes_host_device_meta_nonversioned(
-        self, mock_versioned, mock_nonversioned, _mock_cleanup
-    ):
-        """Regular gfx-arch ``amdrocm-fft``: host + 2 device + meta + non-versioned = 5 outputs."""
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            _fft_gfx_artifacts(root / "artifacts")
-            cfg = _config(root, pkg_type="deb")
-            built = build_package.build_gfxarch_package_variants("amdrocm-fft", cfg)
-            self.assertEqual(mock_versioned.call_count, 4)
-            self.assertEqual(mock_nonversioned.call_count, 1)
-            self.assertEqual(len(built), 5)
-
-    @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(
-        build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"]
-    )
-    # Gfxarch variant path uses RPM create_* helpers when pkg_type=rpm.
-    @patch.object(build_package, "create_versioned_rpm_package", return_value=["v.rpm"])
-    def test_rpm_pkg_type_for_gfxarch_variants(
-        self, mock_versioned, mock_nonversioned, _mock_cleanup
-    ):
-        """``pkg_type=rpm`` dispatches to ``create_versioned_rpm_package`` / ``create_nonversioned_rpm_package``."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp), pkg_type="rpm")
-            build_package.build_gfxarch_package_variants("amdrocm-core-sdk", cfg)
-            mock_versioned.assert_called()
-            mock_nonversioned.assert_called_once()
-            self.assertNotIn("deb", str(mock_versioned.call_args))
-
-    # --rpath-pkg skips non-versioned gfxarch variant.
-    @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(build_package, "create_nonversioned_deb_package")
-    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
-    def test_rpath_pkg_skips_nonversioned_gfxarch_variant(
-        self, mock_versioned, mock_nonversioned, _mock_cleanup
-    ):
-        """``enable_rpath=True`` builds only versioned variants (device + meta for metapackage)."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp), enable_rpath=True)
-            built = build_package.build_gfxarch_package_variants(
-                "amdrocm-core-sdk",
-                cfg,
-            )
-            mock_nonversioned.assert_not_called()
-            self.assertEqual(len(built), 3)
-            self.assertEqual(mock_versioned.call_count, 3)
-
-
-# ---------------------------------------------------------------------------
-# build_simple_package_variants — kpack non-gfx-arch packages
-# ---------------------------------------------------------------------------
-class BuildSimplePackageVariantsTest(unittest.TestCase):
-    """``build_simple_package_variants`` — kpack non-gfx-arch packages.
-
-    Use case: packages like ``amdrocm-developer-tools`` get a versioned package
-    (e.g. ``amdrocm-developer-tools7.1``) and a user-facing non-versioned metapackage.
-    """
-
-    @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(
-        build_package, "create_nonversioned_deb_package", return_value=["nv.deb"]
-    )
-    # Simple kpack DEB builds versioned + non-versioned packages.
-    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
-    def test_deb_versioned_and_nonversioned(
-        self, mock_versioned, mock_nonversioned, _mock_cleanup
-    ):
-        """DEB kpack simple path: one versioned + one non-versioned package."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp), pkg_type="deb")
-            built = build_package.build_simple_package_variants(
-                "amdrocm-developer-tools",
-                cfg,
-            )
-            mock_versioned.assert_called_once()
-            mock_nonversioned.assert_called_once()
-            self.assertEqual(built, ["v.deb", "nv.deb"])
-
-    @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(
-        build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"]
-    )
-    # Simple kpack RPM builds versioned + non-versioned packages.
-    @patch.object(build_package, "create_versioned_rpm_package", return_value=["v.rpm"])
-    def test_rpm_versioned_and_nonversioned(
-        self, mock_versioned, mock_nonversioned, _mock_cleanup
-    ):
-        """RPM kpack simple path: one versioned + one non-versioned package."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp), pkg_type="rpm")
-            built = build_package.build_simple_package_variants(
-                "amdrocm-developer-tools",
-                cfg,
-            )
-            mock_versioned.assert_called_once()
-            mock_nonversioned.assert_called_once()
-            self.assertEqual(built, ["v.rpm", "nv.rpm"])
-
-    # --rpath-pkg skips non-versioned on simple kpack path.
-    @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(build_package, "create_nonversioned_deb_package")
-    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
-    def test_rpath_skips_nonversioned_simple_variant(
-        self, mock_versioned, mock_nonversioned, _mock_cleanup
-    ):
-        """``enable_rpath=True`` on simple kpack path emits only the versioned package."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp), enable_rpath=True)
-            built = build_package.build_simple_package_variants(
-                "amdrocm-developer-tools",
-                cfg,
-            )
-            mock_versioned.assert_called_once()
-            mock_nonversioned.assert_not_called()
-            self.assertEqual(built, ["v.deb"])
-
-
-# ---------------------------------------------------------------------------
-# build_singlearch_package_variants — non-kpack single-target builds
-# ---------------------------------------------------------------------------
-class BuildSinglearchPackageVariantsTest(unittest.TestCase):
-    """``build_singlearch_package_variants`` — non-kpack (single ``--target``) builds.
-
-    Use case: legacy single-GPU packaging produces one versioned and one non-versioned
-    variant for the selected architecture (``gfx_arch`` from first ``--target``).
-    """
-
-    @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(
-        build_package, "create_nonversioned_deb_package", return_value=["nv.deb"]
-    )
-    # Single-arch DEB builds versioned + non-versioned.
-    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
-    def test_deb_single_arch_builds_both_variants(
-        self, mock_versioned, mock_nonversioned, _mock_cleanup
-    ):
-        """Single-arch DEB: ``enable_kpack=False``, ``gfx_arch=gfx1100`` → versioned + non-versioned."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(
-                Path(tmp),
-                enable_kpack=False,
-                gfx_arch="gfx1100",
-                pkg_type="deb",
-            )
-            built = build_package.build_singlearch_package_variants(
-                "amdrocm-core-sdk",
-                cfg,
-            )
-            mock_versioned.assert_called_once()
-            mock_nonversioned.assert_called_once()
-            self.assertEqual(built, ["v.deb", "nv.deb"])
-
-    @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(
-        build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"]
-    )
-    # Single-arch RPM builds versioned + non-versioned.
-    @patch.object(build_package, "create_versioned_rpm_package", return_value=["v.rpm"])
-    def test_rpm_single_arch_builds_both_variants(
-        self, mock_versioned, mock_nonversioned, _mock_cleanup
-    ):
-        """Single-arch RPM: same as DEB but via ``create_*_rpm_package``."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(
-                Path(tmp),
-                enable_kpack=False,
-                gfx_arch="gfx1100",
-                pkg_type="rpm",
-            )
-            built = build_package.build_singlearch_package_variants(
-                "amdrocm-core-sdk",
-                cfg,
-            )
-            mock_versioned.assert_called_once()
-            mock_nonversioned.assert_called_once()
-            self.assertEqual(built, ["v.rpm", "nv.rpm"])
-
-    # --rpath-pkg skips non-versioned on single-arch path.
-    @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(build_package, "create_nonversioned_deb_package")
-    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
-    def test_rpath_skips_nonversioned_single_arch(
-        self, mock_versioned, mock_nonversioned, _mock_cleanup
-    ):
-        """``enable_rpath=True`` in single-arch mode skips non-versioned output."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(
-                Path(tmp),
-                enable_kpack=False,
-                gfx_arch="gfx1100",
-                enable_rpath=True,
-            )
-            built = build_package.build_singlearch_package_variants(
-                "amdrocm-core-sdk",
-                cfg,
-            )
-            mock_versioned.assert_called_once()
-            mock_nonversioned.assert_not_called()
-            self.assertEqual(built, ["v.deb"])
-
-
-# ---------------------------------------------------------------------------
-# Low-level build_*_package helpers — gfx_arch / pkg_type wiring
-# ---------------------------------------------------------------------------
-class VariantBuilderDispatchTest(unittest.TestCase):
-    """Low-level ``build_*_package`` helpers — ``gfx_arch`` and ``pkg_type`` wiring.
-
-    Use case: each variant builder must pass the correct ``PackageConfig`` fields
-    (``GFX_HOST``, device arch, ``GFX_META``, ``versioned_pkg``) into the DEB/RPM
-    creator for dependency naming and artifact selection.
-    """
-
-    @patch.object(
-        build_package, "create_versioned_deb_package", return_value=["host.deb"]
-    )
-    # build_host_package sets gfx_arch=GFX_HOST for DEB.
-    def test_build_host_package_deb(self, mock_create):
-        """``build_host_package`` sets ``gfx_arch=GFX_HOST`` and ``versioned_pkg=True``."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp), pkg_type="deb")
-            result = build_package.build_host_package("amdrocm-ck", cfg)
-            self.assertEqual(result, ["host.deb"])
-            passed = mock_create.call_args[0][1]
-            self.assertEqual(passed.gfx_arch, GFX_HOST)
-            self.assertTrue(passed.versioned_pkg)
-
-    @patch.object(
-        build_package, "create_versioned_rpm_package", return_value=["dev.rpm"]
-    )
-    # build_device_package sets per-device gfx_arch for RPM.
-    def test_build_device_package_rpm(self, mock_create):
-        """``build_device_package(..., device_arch)`` sets ``gfx_arch`` to the device token."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp), pkg_type="rpm")
-            result = build_package.build_device_package("amdrocm-ck", cfg, "gfx1100")
-            self.assertEqual(result, ["dev.rpm"])
-            passed = mock_create.call_args[0][1]
-            self.assertEqual(passed.gfx_arch, "gfx1100")
-
-    @patch.object(
-        build_package, "create_versioned_deb_package", return_value=["meta.deb"]
-    )
-    # build_meta_package sets gfx_arch=GFX_META for DEB.
-    def test_build_meta_package_deb(self, mock_create):
-        """``build_meta_package`` sets ``gfx_arch=GFX_META`` for the versioned meta DEB."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp), pkg_type="deb")
-            build_package.build_meta_package("amdrocm-ck", cfg)
-            passed = mock_create.call_args[0][1]
-            self.assertEqual(passed.gfx_arch, GFX_META)
-
-    @patch.object(
-        build_package, "create_versioned_deb_package", return_value=["ver.deb"]
-    )
-    # build_versioned_package clears gfx_arch on simple path.
-    def test_build_versioned_package_clears_gfx_arch(self, mock_create):
-        """``build_versioned_package`` (non-gfx simple path) clears ``gfx_arch`` to ``""``."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp), gfx_arch="gfx1100")
-            build_package.build_versioned_package("amdrocm-developer-tools", cfg)
-            passed = mock_create.call_args[0][1]
-            self.assertEqual(passed.gfx_arch, "")
-
-    @patch.object(
-        build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"]
-    )
-    # build_nonversioned_package sets versioned_pkg=False for RPM.
-    def test_build_nonversioned_package_rpm(self, mock_create):
-        """``build_nonversioned_package`` sets ``versioned_pkg=False``; preserves caller ``gfx_arch``."""
-        with tempfile.TemporaryDirectory() as tmp:
-            cfg = _config(Path(tmp), pkg_type="rpm", gfx_arch=GFX_META)
-            build_package.build_nonversioned_package("amdrocm-ck", cfg)
-            passed = mock_create.call_args[0][1]
-            self.assertFalse(passed.versioned_pkg)
-            self.assertEqual(passed.gfx_arch, GFX_META)
-
-
-# ---------------------------------------------------------------------------
-# main() / run() — CLI orchestration entry points
-# ---------------------------------------------------------------------------
-class MainAndRunTest(unittest.TestCase):
-    """``main(argv)`` and ``run(args)`` — end-to-end CLI orchestration (mocked builds).
-
-    Use case: verify the public entry points wire argparse → config → package list →
-    per-package ``build_package_variants`` without running a full packaging job.
-    """
-
-    # main() parses argv and delegates to run().
-    def test_main_delegates_to_run(self):
-        """``main`` parses required flags and passes the resulting namespace to ``run``.
-
-        CLI exercised: ``--artifacts-dir``, ``--dest-dir``, ``--pkg-type deb``,
-        ``--rocm-version 7.1.0``, ``--target gfx1100``.
-        """
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            art = root / "artifacts"
-            out = root / "output"
-            art.mkdir()
-            out.mkdir()
-            argv = [
-                "--artifacts-dir",
-                str(art),
-                "--dest-dir",
-                str(out),
-                "--pkg-type",
-                "deb",
-                "--rocm-version",
-                "7.1.0",
-                "--target",
-                "gfx1100",
-            ]
-            with (
-                patch.object(build_package, "run") as mock_run,
-                patch.object(build_package, "build_package_variants") as mock_build_variants,
-            ):
-                build_package.main(argv)
-            mock_run.assert_called_once()
-            mock_build_variants.assert_not_called()
-            passed = mock_run.call_args[0][0]
-            self.assertEqual(passed.pkg_type, "deb")
-            self.assertEqual(passed.rocm_version, "7.1.0")
-
-    @patch.object(build_package, "print_build_summary")
-    @patch.object(build_package, "cleanup_packaging_environment")
-    @patch.object(build_package, "build_package_variants", return_value=["out.deb"])
-    @patch.object(
-        build_package,
-        "parse_input_package_list",
-        return_value=(["amdrocm-core-sdk"], []),
-    )
-    # run() builds each package from resolved --pkg-names.
-    @patch.object(build_package, "create_package_config")
-    def test_run_builds_requested_packages(
-        self,
-        mock_create_cfg,
-        mock_parse_list,
-        mock_build_variants,
-        _mock_cleanup,
-        _mock_summary,
-    ):
-        """``run`` calls ``build_package_variants`` once per resolved ``--pkg-names`` entry.
-
-        Args: ``pkg_names=["amdrocm-core-sdk"]``, ``pkg_type=deb``.
-        """
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            cfg = _config(root)
-            mock_create_cfg.return_value = cfg
-            args = _args(root, pkg_names=["amdrocm-core-sdk"], pkg_type="deb")
-            build_package.run(args)
-            mock_parse_list.assert_called_once_with(
-                ["amdrocm-core-sdk"], cfg.artifacts_dir
-            )
-            mock_build_variants.assert_called_once_with("amdrocm-core-sdk", cfg)
-
-    # run() exits 1 when package list is empty.
-    @patch.object(build_package, "print_build_summary")
-    @patch.object(build_package, "cleanup_packaging_environment")
-    @patch.object(build_package, "parse_input_package_list", return_value=([], []))
-    @patch.object(build_package, "create_package_config")
-    def test_run_exits_when_package_list_empty(
-        self,
-        mock_create_cfg,
-        _mock_parse_list,
-        _mock_cleanup,
-        _mock_summary,
-    ):
-        """``run`` exits with code 1 when no packages remain after list resolution.
-
-        Note: ``run()`` uses ``sys.exit(1)`` today, which is a known anti-pattern
-        (prefer raising an exception). This test documents current behavior only.
-        """
-        with tempfile.TemporaryDirectory() as tmp:
-            mock_create_cfg.return_value = _config(Path(tmp))
-            args = _args(Path(tmp))
-            with self.assertRaises(SystemExit) as ctx:
-                build_package.run(args)
-            self.assertEqual(ctx.exception.code, 1)
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -48,6 +48,9 @@ for _path in (_BUILD_TOOLS_DIR, _LINUX_DIR):
         sys.path.insert(0, str(_path))
 
 _BP_PATH = _LINUX_DIR / "build_package.py"
+# importlib is required here: a normal ``import build_package`` would execute
+# ``build_package.py``'s module-level ``if __name__ == "__main__"`` guard and
+# call ``sys.exit`` when loaded as a test dependency.
 _BP_SPEC = importlib.util.spec_from_file_location("build_package", _BP_PATH)
 build_package = importlib.util.module_from_spec(_BP_SPEC)
 _BP_SPEC.loader.exec_module(build_package)
@@ -880,9 +883,13 @@ class MainAndRunTest(unittest.TestCase):
                 "--target",
                 "gfx1100",
             ]
-            with patch.object(build_package, "run") as mock_run:
+            with (
+                patch.object(build_package, "run") as mock_run,
+                patch.object(build_package, "build_package_variants") as mock_build_variants,
+            ):
                 build_package.main(argv)
             mock_run.assert_called_once()
+            mock_build_variants.assert_not_called()
             passed = mock_run.call_args[0][0]
             self.assertEqual(passed.pkg_type, "deb")
             self.assertEqual(passed.rocm_version, "7.1.0")
@@ -932,7 +939,11 @@ class MainAndRunTest(unittest.TestCase):
         _mock_cleanup,
         _mock_summary,
     ):
-        """``run`` exits with code 1 when no packages remain after list resolution."""
+        """``run`` exits with code 1 when no packages remain after list resolution.
+
+        Note: ``run()`` uses ``sys.exit(1)`` today, which is a known anti-pattern
+        (prefer raising an exception). This test documents current behavior only.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             mock_create_cfg.return_value = _config(Path(tmp))
             args = _args(Path(tmp))

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -22,7 +22,7 @@ Test strategy
 * **Variant-builder tests** — mock ``create_versioned_*`` / ``create_nonversioned_*`` to
   count which variants are produced without invoking ``dpkg`` / ``rpmbuild``.
 * **Integration with ``package.json``** — ``parse_input_package_list`` and routing tests
-  use real package names (``amdrocm-core-sdk``, ``amdrocm-ck``, etc.).
+  use real package names (``amdrocm-core-sdk``, ``amdrocm-ck``, ``amdrocm-fft``, etc.).
 
 Run::
 
@@ -55,6 +55,12 @@ _BP_SPEC.loader.exec_module(build_package)
 from packaging_utils import GFX_HOST, GFX_META, PackageConfig  # noqa: E402
 
 
+# ---------------------------------------------------------------------------
+# Test fixtures — synthetic CLI/config and minimal artifact trees
+# ---------------------------------------------------------------------------
+
+
+# Build synthetic argparse.Namespace (CLI flags) for create_package_config / run tests.
 def _args(tmp: Path, **overrides) -> Namespace:
     """Build an ``argparse.Namespace`` mirroring ``build_package.py`` CLI flags.
 
@@ -100,6 +106,7 @@ def _args(tmp: Path, **overrides) -> Namespace:
     return Namespace(**defaults)
 
 
+# Build synthetic PackageConfig for variant-builder tests (default: kpack DEB).
 def _config(tmp: Path, **overrides) -> PackageConfig:
     """Build a minimal ``PackageConfig`` for variant-builder unit tests.
 
@@ -130,6 +137,7 @@ def _config(tmp: Path, **overrides) -> PackageConfig:
     return PackageConfig(**defaults)
 
 
+# Write therock_manifest.json with KPACK_SPLIT_ARTIFACTS for kpack auto-detect.
 def _write_kpack_manifest(artifacts_dir: Path) -> None:
     """Write a ``therock_manifest.json`` that enables kpack split artifacts.
 
@@ -144,18 +152,35 @@ def _write_kpack_manifest(artifacts_dir: Path) -> None:
     )
 
 
-def _ck_gfx_artifacts(artifacts_dir: Path) -> None:
-    """Create gfx-specific artifact dirs so ``amdrocm-ck`` is gfx-arch under kpack.
+# Create empty gfx-arch artifact dir matching production {Artifact}_{Component}_gfx* naming.
+def _write_gfx_artifact_dir(artifacts_dir: Path, dirname: str) -> None:
+    """Create a minimal gfx-specific artifact directory under ``artifacts_dir``.
 
-    Matches real ``package.json`` Artifactory naming:
-    ``{Artifact}_{Component}_gfx*`` → ``composable-kernel_run_gfx1100``.
+    Production kpack trees use ``{Artifact}_{Component}_gfx*`` directory names;
+    an empty directory is enough for ``_has_arch_specific_artifacts`` detection.
 
     Args:
         artifacts_dir: Artifact tree root passed as ``PackageConfig.artifacts_dir``.
+        dirname: Gfx-arch artifact directory name (e.g. ``fft_run_gfx1100``).
     """
-    (artifacts_dir / "composable-kernel_run_gfx1100").mkdir(parents=True, exist_ok=True)
+    (artifacts_dir / dirname).mkdir(parents=True, exist_ok=True)
 
 
+# Fixture: composable-kernel_run_gfx1100 dir so amdrocm-ck passes is_gfxarch_package.
+def _ck_gfx_artifacts(artifacts_dir: Path) -> None:
+    """Gfx dirs for ``amdrocm-ck`` → ``composable-kernel_run_gfx1100``."""
+    _write_gfx_artifact_dir(artifacts_dir, "composable-kernel_run_gfx1100")
+
+
+# Fixture: fft_run_gfx1100 dir so amdrocm-fft passes is_gfxarch_package.
+def _fft_gfx_artifacts(artifacts_dir: Path) -> None:
+    """Gfx dirs for ``amdrocm-fft`` → ``fft_run_gfx1100``."""
+    _write_gfx_artifact_dir(artifacts_dir, "fft_run_gfx1100")
+
+
+# ---------------------------------------------------------------------------
+# create_package_config — CLI → PackageConfig
+# ---------------------------------------------------------------------------
 class CreatePackageConfigTest(unittest.TestCase):
     """``create_package_config(args)`` — CLI → ``PackageConfig`` mapping.
 
@@ -165,18 +190,21 @@ class CreatePackageConfigTest(unittest.TestCase):
     ``--install-prefix``, and ``--version-suffix``.
     """
 
+    # DEB --pkg-type is lower-cased in PackageConfig.
     def test_deb_pkg_type_normalized(self):
         """``--pkg-type DEB`` is lower-cased to ``deb`` in ``PackageConfig.pkg_type``."""
         with tempfile.TemporaryDirectory() as tmp:
             cfg = build_package.create_package_config(_args(Path(tmp), pkg_type="DEB"))
             self.assertEqual(cfg.pkg_type, "deb")
 
+    # RPM --pkg-type is lower-cased in PackageConfig.
     def test_rpm_pkg_type_normalized(self):
         """``--pkg-type RPM`` is lower-cased to ``rpm`` in ``PackageConfig.pkg_type``."""
         with tempfile.TemporaryDirectory() as tmp:
             cfg = build_package.create_package_config(_args(Path(tmp), pkg_type="RPM"))
             self.assertEqual(cfg.pkg_type, "rpm")
 
+    # Unsupported --pkg-type raises ValueError.
     def test_invalid_pkg_type_raises(self):
         """Unsupported ``--pkg-type`` (e.g. tgz) raises ``ValueError`` listing deb/rpm."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -187,6 +215,7 @@ class CreatePackageConfigTest(unittest.TestCase):
             self.assertIn("deb", str(ctx.exception))
             self.assertIn("rpm", str(ctx.exception))
 
+    # Malformed --rocm-version raises ValueError.
     def test_invalid_rocm_version_raises(self):
         """``--rocm-version`` without major.minor (e.g. ``7``) raises ``ValueError``."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -195,12 +224,14 @@ class CreatePackageConfigTest(unittest.TestCase):
                     _args(Path(tmp), rocm_version="7"),
                 )
 
+    # Default install prefix gets -major.minor suffix.
     def test_default_install_prefix_appends_major_minor(self):
         """Default ``--install-prefix /opt/rocm/core`` becomes ``/opt/rocm/core-7.1``."""
         with tempfile.TemporaryDirectory() as tmp:
             cfg = build_package.create_package_config(_args(Path(tmp)))
             self.assertEqual(cfg.install_prefix, "/opt/rocm/core-7.1")
 
+    # Custom install prefix is not version-suffixed.
     def test_custom_install_prefix_unchanged(self):
         """Non-default ``--install-prefix`` is copied verbatim (no version suffix)."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -209,6 +240,7 @@ class CreatePackageConfigTest(unittest.TestCase):
             )
             self.assertEqual(cfg.install_prefix, "/custom/prefix")
 
+    # Kpack mode stores --target list in gfxarch_list.
     def test_explicit_targets_in_kpack_mode(self):
         """``--enable-kpack`` + ``--target gfx1100 gfx942`` fills ``gfxarch_list``."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -223,6 +255,7 @@ class CreatePackageConfigTest(unittest.TestCase):
             self.assertEqual(cfg.gfxarch_list, ("gfx1100", "gfx942"))
             self.assertEqual(cfg.gfx_arch, "")
 
+    # Non-kpack mode uses first --target as gfx_arch only.
     def test_single_arch_uses_first_target(self):
         """Without kpack, ``gfx_arch`` is the first ``--target``; ``gfxarch_list`` empty."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -233,6 +266,7 @@ class CreatePackageConfigTest(unittest.TestCase):
             self.assertEqual(cfg.gfx_arch, "gfx1100")
             self.assertEqual(cfg.gfxarch_list, ())
 
+    # Missing --target auto-detects from artifact scan.
     @patch.object(build_package, "get_all_target_families", return_value=["gfx1200"])
     def test_auto_detect_targets_when_target_omitted(self, _mock_detect):
         """Omitted ``--target`` auto-detects via ``get_all_target_families(artifacts_dir)``."""
@@ -240,6 +274,7 @@ class CreatePackageConfigTest(unittest.TestCase):
             cfg = build_package.create_package_config(_args(Path(tmp), target=None))
             self.assertEqual(cfg.gfx_arch, "gfx1200")
 
+    # Kpack enabled when manifest has KPACK_SPLIT_ARTIFACTS.
     def test_auto_detect_kpack_from_manifest(self):
         """Kpack enabled when ``therock_manifest.json`` has ``KPACK_SPLIT_ARTIFACTS: true``."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -248,6 +283,7 @@ class CreatePackageConfigTest(unittest.TestCase):
             cfg = build_package.create_package_config(_args(root))
             self.assertTrue(cfg.enable_kpack)
 
+    # CLI --enable-kpack wins without manifest flag.
     def test_explicit_enable_kpack_overrides_absent_manifest(self):
         """``--enable-kpack`` sets kpack even when no manifest flag is present."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -256,6 +292,7 @@ class CreatePackageConfigTest(unittest.TestCase):
             )
             self.assertTrue(cfg.enable_kpack)
 
+    # --rpath-pkg maps to PackageConfig.enable_rpath.
     def test_rpath_pkg_flag(self):
         """``--rpath-pkg`` maps to ``PackageConfig.enable_rpath=True``."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -264,6 +301,7 @@ class CreatePackageConfigTest(unittest.TestCase):
             )
             self.assertTrue(cfg.enable_rpath)
 
+    # --version-suffix is stored on PackageConfig.
     def test_version_suffix_preserved(self):
         """``--version-suffix nightly`` is stored on ``PackageConfig.version_suffix``."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -272,6 +310,7 @@ class CreatePackageConfigTest(unittest.TestCase):
             )
             self.assertEqual(cfg.version_suffix, "nightly")
 
+    # Writes PACKAGING_ARCH_LIST to GITHUB_OUTPUT for CI.
     def test_writes_packaging_arch_list_to_github_output(self):
         """When ``GITHUB_OUTPUT`` is set, writes ``PACKAGING_ARCH_LIST`` for CI matrix."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -284,6 +323,9 @@ class CreatePackageConfigTest(unittest.TestCase):
             self.assertIn("PACKAGING_ARCH_LIST=gfx1100", github_env.read_text())
 
 
+# ---------------------------------------------------------------------------
+# load_kpack_from_manifest — kpack detection from artifact tree
+# ---------------------------------------------------------------------------
 class LoadKpackFromManifestTest(unittest.TestCase):
     """``load_kpack_from_manifest(artifacts_dir)`` — kpack auto-detection.
 
@@ -291,17 +333,20 @@ class LoadKpackFromManifestTest(unittest.TestCase):
     enter host+device split mode without requiring ``--enable-kpack`` on the CLI.
     """
 
+    # load_kpack_from_manifest returns True when flag present.
     def test_true_when_kpack_flag_set(self):
         """Returns True when any nested manifest has ``flags.KPACK_SPLIT_ARTIFACTS``."""
         with tempfile.TemporaryDirectory() as tmp:
             _write_kpack_manifest(Path(tmp))
             self.assertTrue(build_package.load_kpack_from_manifest(Path(tmp)))
 
+    # load_kpack_from_manifest returns False with no manifest.
     def test_false_when_no_manifest(self):
         """Empty artifact tree with no manifest files returns False."""
         with tempfile.TemporaryDirectory() as tmp:
             self.assertFalse(build_package.load_kpack_from_manifest(Path(tmp)))
 
+    # load_kpack_from_manifest returns False without kpack flag.
     def test_false_when_manifest_missing_flag(self):
         """Manifest present but without ``KPACK_SPLIT_ARTIFACTS`` returns False."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -310,6 +355,9 @@ class LoadKpackFromManifestTest(unittest.TestCase):
             self.assertFalse(build_package.load_kpack_from_manifest(root))
 
 
+# ---------------------------------------------------------------------------
+# parse_input_package_list — --pkg-names filtering
+# ---------------------------------------------------------------------------
 class ParseInputPackageListTest(unittest.TestCase):
     """``parse_input_package_list(pkg_names, artifact_dir)`` — ``--pkg-names`` filtering.
 
@@ -320,6 +368,7 @@ class ParseInputPackageListTest(unittest.TestCase):
     @patch.object(
         build_package, "get_package_list", return_value=(["pkg-a"], ["skip-a"])
     )
+    # pkg_names=None delegates to get_package_list.
     def test_none_pkg_names_loads_all_from_artifacts(self, mock_get_list):
         """``pkg_names=None`` delegates to ``get_package_list(artifact_dir)``."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -329,6 +378,7 @@ class ParseInputPackageListTest(unittest.TestCase):
             self.assertEqual(pkg_list, ["pkg-a"])
             self.assertEqual(skipped, ["skip-a"])
 
+    # Unknown --pkg-names entries are dropped.
     def test_explicit_pkg_names_filter_package_json(self):
         """Named packages are matched against ``package.json``; unknown names dropped."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -340,6 +390,9 @@ class ParseInputPackageListTest(unittest.TestCase):
             self.assertEqual(skipped, [])
 
 
+# ---------------------------------------------------------------------------
+# build_package_variants — top-level routing (gfxarch / simple / singlearch)
+# ---------------------------------------------------------------------------
 class BuildPackageVariantsRoutingTest(unittest.TestCase):
     """``build_package_variants(pkg_name, config)`` — top-level builder selection.
 
@@ -351,6 +404,7 @@ class BuildPackageVariantsRoutingTest(unittest.TestCase):
     @patch.object(
         build_package, "build_gfxarch_package_variants", return_value=["meta.deb"]
     )
+    # Kpack gfx metapackage amdrocm-core-sdk → gfxarch builder (#6093).
     def test_kpack_metapackage_routes_to_gfxarch_builder(self, mock_gfx):
         """Kpack + gfx-arch metapackage ``amdrocm-core-sdk`` → ``build_gfxarch_package_variants``.
 
@@ -366,6 +420,7 @@ class BuildPackageVariantsRoutingTest(unittest.TestCase):
     @patch.object(
         build_package, "build_gfxarch_package_variants", return_value=["ck.deb"]
     )
+    # Kpack amdrocm-ck with gfx dirs → gfxarch builder (#5874).
     def test_kpack_gfxarch_non_meta_routes_to_gfxarch_builder(self, mock_gfx):
         """Kpack + gfx-arch regular package ``amdrocm-ck`` → gfx-arch builder.
 
@@ -381,8 +436,47 @@ class BuildPackageVariantsRoutingTest(unittest.TestCase):
             self.assertEqual(result, ["ck.deb"])
 
     @patch.object(
+        build_package, "build_gfxarch_package_variants", return_value=["fft.deb"]
+    )
+    # Kpack amdrocm-fft with gfx dirs → gfxarch builder.
+    def test_kpack_gfxarch_fft_routes_to_gfxarch_builder(self, mock_gfx):
+        """Kpack + gfx-arch regular package ``amdrocm-fft`` → gfx-arch builder.
+
+        Requires gfx artifact dir ``fft_run_gfx1100`` on disk (production math-lib
+        naming) so ``is_gfxarch_package`` returns True after #5874 verification.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _fft_gfx_artifacts(root / "artifacts")
+            cfg = _config(root)
+            result = build_package.build_package_variants("amdrocm-fft", cfg)
+            mock_gfx.assert_called_once_with("amdrocm-fft", cfg)
+            self.assertEqual(result, ["fft.deb"])
+
+    @patch.object(build_package, "build_gfxarch_package_variants")
+    @patch.object(
+        build_package, "build_simple_package_variants", return_value=["fft.deb"]
+    )
+    # Kpack amdrocm-fft without gfx dirs → simple builder (#5874 negative).
+    def test_kpack_gfxarch_without_artifacts_routes_to_simple_builder(
+        self, mock_simple, mock_gfx
+    ):
+        """Kpack + ``amdrocm-fft`` with Gfxarch metadata but no ``_gfx*`` dirs → simple builder.
+
+        Regression guard for #5874: metadata alone must not trigger gfx-arch splits when
+        arch-specific artifact directories are absent on disk.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _config(Path(tmp))
+            result = build_package.build_package_variants("amdrocm-fft", cfg)
+            mock_simple.assert_called_once_with("amdrocm-fft", cfg)
+            mock_gfx.assert_not_called()
+            self.assertEqual(result, ["fft.deb"])
+
+    @patch.object(
         build_package, "build_simple_package_variants", return_value=["tools.deb"]
     )
+    # Kpack non-gfx package → simple builder.
     def test_kpack_non_gfxarch_routes_to_simple_builder(self, mock_simple):
         """Kpack + non-gfx-arch ``amdrocm-developer-tools`` → ``build_simple_package_variants``.
 
@@ -400,6 +494,7 @@ class BuildPackageVariantsRoutingTest(unittest.TestCase):
     @patch.object(
         build_package, "build_singlearch_package_variants", return_value=["single.deb"]
     )
+    # enable_kpack=False → singlearch builder.
     def test_single_arch_routes_to_singlearch_builder(self, mock_single):
         """``enable_kpack=False`` always uses ``build_singlearch_package_variants``.
 
@@ -412,6 +507,9 @@ class BuildPackageVariantsRoutingTest(unittest.TestCase):
             self.assertEqual(result, ["single.deb"])
 
 
+# ---------------------------------------------------------------------------
+# build_gfxarch_package_variants — host / device / meta / non-versioned counts
+# ---------------------------------------------------------------------------
 class BuildGfxarchPackageVariantsTest(unittest.TestCase):
     """``build_gfxarch_package_variants`` — kpack host / device / meta / non-versioned.
 
@@ -424,6 +522,7 @@ class BuildGfxarchPackageVariantsTest(unittest.TestCase):
     @patch.object(
         build_package, "create_nonversioned_deb_package", return_value=["nv.deb"]
     )
+    # Gfx metapackage builds device+meta+nv only (no host).
     @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
     def test_metapackage_skips_host_builds_device_meta_nonversioned(
         self, mock_versioned, mock_nonversioned, _mock_cleanup
@@ -447,6 +546,7 @@ class BuildGfxarchPackageVariantsTest(unittest.TestCase):
     @patch.object(
         build_package, "create_nonversioned_deb_package", return_value=["nv.deb"]
     )
+    # Gfx regular package amdrocm-ck builds host+device+meta+nv.
     @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
     def test_non_meta_includes_host_device_meta_nonversioned(
         self, mock_versioned, mock_nonversioned, _mock_cleanup
@@ -463,8 +563,28 @@ class BuildGfxarchPackageVariantsTest(unittest.TestCase):
 
     @patch.object(build_package, "cleanup_build_directory")
     @patch.object(
+        build_package, "create_nonversioned_deb_package", return_value=["nv.deb"]
+    )
+    # Gfx regular package amdrocm-fft builds host+device+meta+nv.
+    @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
+    def test_fft_includes_host_device_meta_nonversioned(
+        self, mock_versioned, mock_nonversioned, _mock_cleanup
+    ):
+        """Regular gfx-arch ``amdrocm-fft``: host + 2 device + meta + non-versioned = 5 outputs."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _fft_gfx_artifacts(root / "artifacts")
+            cfg = _config(root, pkg_type="deb")
+            built = build_package.build_gfxarch_package_variants("amdrocm-fft", cfg)
+            self.assertEqual(mock_versioned.call_count, 4)
+            self.assertEqual(mock_nonversioned.call_count, 1)
+            self.assertEqual(len(built), 5)
+
+    @patch.object(build_package, "cleanup_build_directory")
+    @patch.object(
         build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"]
     )
+    # Gfxarch variant path uses RPM create_* helpers when pkg_type=rpm.
     @patch.object(build_package, "create_versioned_rpm_package", return_value=["v.rpm"])
     def test_rpm_pkg_type_for_gfxarch_variants(
         self, mock_versioned, mock_nonversioned, _mock_cleanup
@@ -477,6 +597,7 @@ class BuildGfxarchPackageVariantsTest(unittest.TestCase):
             mock_nonversioned.assert_called_once()
             self.assertNotIn("deb", str(mock_versioned.call_args))
 
+    # --rpath-pkg skips non-versioned gfxarch variant.
     @patch.object(build_package, "cleanup_build_directory")
     @patch.object(build_package, "create_nonversioned_deb_package")
     @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
@@ -495,6 +616,9 @@ class BuildGfxarchPackageVariantsTest(unittest.TestCase):
             self.assertEqual(mock_versioned.call_count, 3)
 
 
+# ---------------------------------------------------------------------------
+# build_simple_package_variants — kpack non-gfx-arch packages
+# ---------------------------------------------------------------------------
 class BuildSimplePackageVariantsTest(unittest.TestCase):
     """``build_simple_package_variants`` — kpack non-gfx-arch packages.
 
@@ -506,6 +630,7 @@ class BuildSimplePackageVariantsTest(unittest.TestCase):
     @patch.object(
         build_package, "create_nonversioned_deb_package", return_value=["nv.deb"]
     )
+    # Simple kpack DEB builds versioned + non-versioned packages.
     @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
     def test_deb_versioned_and_nonversioned(
         self, mock_versioned, mock_nonversioned, _mock_cleanup
@@ -525,6 +650,7 @@ class BuildSimplePackageVariantsTest(unittest.TestCase):
     @patch.object(
         build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"]
     )
+    # Simple kpack RPM builds versioned + non-versioned packages.
     @patch.object(build_package, "create_versioned_rpm_package", return_value=["v.rpm"])
     def test_rpm_versioned_and_nonversioned(
         self, mock_versioned, mock_nonversioned, _mock_cleanup
@@ -540,6 +666,7 @@ class BuildSimplePackageVariantsTest(unittest.TestCase):
             mock_nonversioned.assert_called_once()
             self.assertEqual(built, ["v.rpm", "nv.rpm"])
 
+    # --rpath-pkg skips non-versioned on simple kpack path.
     @patch.object(build_package, "cleanup_build_directory")
     @patch.object(build_package, "create_nonversioned_deb_package")
     @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
@@ -558,6 +685,9 @@ class BuildSimplePackageVariantsTest(unittest.TestCase):
             self.assertEqual(built, ["v.deb"])
 
 
+# ---------------------------------------------------------------------------
+# build_singlearch_package_variants — non-kpack single-target builds
+# ---------------------------------------------------------------------------
 class BuildSinglearchPackageVariantsTest(unittest.TestCase):
     """``build_singlearch_package_variants`` — non-kpack (single ``--target``) builds.
 
@@ -569,6 +699,7 @@ class BuildSinglearchPackageVariantsTest(unittest.TestCase):
     @patch.object(
         build_package, "create_nonversioned_deb_package", return_value=["nv.deb"]
     )
+    # Single-arch DEB builds versioned + non-versioned.
     @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
     def test_deb_single_arch_builds_both_variants(
         self, mock_versioned, mock_nonversioned, _mock_cleanup
@@ -593,6 +724,7 @@ class BuildSinglearchPackageVariantsTest(unittest.TestCase):
     @patch.object(
         build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"]
     )
+    # Single-arch RPM builds versioned + non-versioned.
     @patch.object(build_package, "create_versioned_rpm_package", return_value=["v.rpm"])
     def test_rpm_single_arch_builds_both_variants(
         self, mock_versioned, mock_nonversioned, _mock_cleanup
@@ -613,6 +745,7 @@ class BuildSinglearchPackageVariantsTest(unittest.TestCase):
             mock_nonversioned.assert_called_once()
             self.assertEqual(built, ["v.rpm", "nv.rpm"])
 
+    # --rpath-pkg skips non-versioned on single-arch path.
     @patch.object(build_package, "cleanup_build_directory")
     @patch.object(build_package, "create_nonversioned_deb_package")
     @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
@@ -636,6 +769,9 @@ class BuildSinglearchPackageVariantsTest(unittest.TestCase):
             self.assertEqual(built, ["v.deb"])
 
 
+# ---------------------------------------------------------------------------
+# Low-level build_*_package helpers — gfx_arch / pkg_type wiring
+# ---------------------------------------------------------------------------
 class VariantBuilderDispatchTest(unittest.TestCase):
     """Low-level ``build_*_package`` helpers — ``gfx_arch`` and ``pkg_type`` wiring.
 
@@ -647,6 +783,7 @@ class VariantBuilderDispatchTest(unittest.TestCase):
     @patch.object(
         build_package, "create_versioned_deb_package", return_value=["host.deb"]
     )
+    # build_host_package sets gfx_arch=GFX_HOST for DEB.
     def test_build_host_package_deb(self, mock_create):
         """``build_host_package`` sets ``gfx_arch=GFX_HOST`` and ``versioned_pkg=True``."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -660,6 +797,7 @@ class VariantBuilderDispatchTest(unittest.TestCase):
     @patch.object(
         build_package, "create_versioned_rpm_package", return_value=["dev.rpm"]
     )
+    # build_device_package sets per-device gfx_arch for RPM.
     def test_build_device_package_rpm(self, mock_create):
         """``build_device_package(..., device_arch)`` sets ``gfx_arch`` to the device token."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -672,6 +810,7 @@ class VariantBuilderDispatchTest(unittest.TestCase):
     @patch.object(
         build_package, "create_versioned_deb_package", return_value=["meta.deb"]
     )
+    # build_meta_package sets gfx_arch=GFX_META for DEB.
     def test_build_meta_package_deb(self, mock_create):
         """``build_meta_package`` sets ``gfx_arch=GFX_META`` for the versioned meta DEB."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -683,6 +822,7 @@ class VariantBuilderDispatchTest(unittest.TestCase):
     @patch.object(
         build_package, "create_versioned_deb_package", return_value=["ver.deb"]
     )
+    # build_versioned_package clears gfx_arch on simple path.
     def test_build_versioned_package_clears_gfx_arch(self, mock_create):
         """``build_versioned_package`` (non-gfx simple path) clears ``gfx_arch`` to ``""``."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -694,6 +834,7 @@ class VariantBuilderDispatchTest(unittest.TestCase):
     @patch.object(
         build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"]
     )
+    # build_nonversioned_package sets versioned_pkg=False for RPM.
     def test_build_nonversioned_package_rpm(self, mock_create):
         """``build_nonversioned_package`` sets ``versioned_pkg=False``; preserves caller ``gfx_arch``."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -704,6 +845,9 @@ class VariantBuilderDispatchTest(unittest.TestCase):
             self.assertEqual(passed.gfx_arch, GFX_META)
 
 
+# ---------------------------------------------------------------------------
+# main() / run() — CLI orchestration entry points
+# ---------------------------------------------------------------------------
 class MainAndRunTest(unittest.TestCase):
     """``main(argv)`` and ``run(args)`` — end-to-end CLI orchestration (mocked builds).
 
@@ -711,6 +855,7 @@ class MainAndRunTest(unittest.TestCase):
     per-package ``build_package_variants`` without running a full packaging job.
     """
 
+    # main() parses argv and delegates to run().
     def test_main_delegates_to_run(self):
         """``main`` parses required flags and passes the resulting namespace to ``run``.
 
@@ -750,6 +895,7 @@ class MainAndRunTest(unittest.TestCase):
         "parse_input_package_list",
         return_value=(["amdrocm-core-sdk"], []),
     )
+    # run() builds each package from resolved --pkg-names.
     @patch.object(build_package, "create_package_config")
     def test_run_builds_requested_packages(
         self,
@@ -774,6 +920,7 @@ class MainAndRunTest(unittest.TestCase):
             )
             mock_build_variants.assert_called_once_with("amdrocm-core-sdk", cfg)
 
+    # run() exits 1 when package list is empty.
     @patch.object(build_package, "print_build_summary")
     @patch.object(build_package, "cleanup_packaging_environment")
     @patch.object(build_package, "parse_input_package_list", return_value=([], []))

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -317,7 +317,9 @@ class ParseInputPackageListTest(unittest.TestCase):
     subset; omitting it builds every package eligible from the artifact tree.
     """
 
-    @patch.object(build_package, "get_package_list", return_value=(["pkg-a"], ["skip-a"]))
+    @patch.object(
+        build_package, "get_package_list", return_value=(["pkg-a"], ["skip-a"])
+    )
     def test_none_pkg_names_loads_all_from_artifacts(self, mock_get_list):
         """``pkg_names=None`` delegates to ``get_package_list(artifact_dir)``."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -334,7 +336,7 @@ class ParseInputPackageListTest(unittest.TestCase):
                 ["amdrocm-core-sdk", "amdrocm-ck", "no-such-package"],
                 Path(tmp),
             )
-            self.assertEqual(pkg_list, ["amdrocm-core-sdk", "amdrocm-ck"])
+            self.assertEqual(set(pkg_list), {"amdrocm-core-sdk", "amdrocm-ck"})
             self.assertEqual(skipped, [])
 
 
@@ -346,7 +348,9 @@ class BuildPackageVariantsRoutingTest(unittest.TestCase):
     to the simple builder caused #6093 (missing per-GPU SDK dependencies).
     """
 
-    @patch.object(build_package, "build_gfxarch_package_variants", return_value=["meta.deb"])
+    @patch.object(
+        build_package, "build_gfxarch_package_variants", return_value=["meta.deb"]
+    )
     def test_kpack_metapackage_routes_to_gfxarch_builder(self, mock_gfx):
         """Kpack + gfx-arch metapackage ``amdrocm-core-sdk`` → ``build_gfxarch_package_variants``.
 
@@ -359,7 +363,9 @@ class BuildPackageVariantsRoutingTest(unittest.TestCase):
             mock_gfx.assert_called_once_with("amdrocm-core-sdk", cfg)
             self.assertEqual(result, ["meta.deb"])
 
-    @patch.object(build_package, "build_gfxarch_package_variants", return_value=["ck.deb"])
+    @patch.object(
+        build_package, "build_gfxarch_package_variants", return_value=["ck.deb"]
+    )
     def test_kpack_gfxarch_non_meta_routes_to_gfxarch_builder(self, mock_gfx):
         """Kpack + gfx-arch regular package ``amdrocm-ck`` → gfx-arch builder.
 
@@ -374,7 +380,9 @@ class BuildPackageVariantsRoutingTest(unittest.TestCase):
             mock_gfx.assert_called_once_with("amdrocm-ck", cfg)
             self.assertEqual(result, ["ck.deb"])
 
-    @patch.object(build_package, "build_simple_package_variants", return_value=["tools.deb"])
+    @patch.object(
+        build_package, "build_simple_package_variants", return_value=["tools.deb"]
+    )
     def test_kpack_non_gfxarch_routes_to_simple_builder(self, mock_simple):
         """Kpack + non-gfx-arch ``amdrocm-developer-tools`` → ``build_simple_package_variants``.
 
@@ -389,7 +397,9 @@ class BuildPackageVariantsRoutingTest(unittest.TestCase):
             mock_simple.assert_called_once_with("amdrocm-developer-tools", cfg)
             self.assertEqual(result, ["tools.deb"])
 
-    @patch.object(build_package, "build_singlearch_package_variants", return_value=["single.deb"])
+    @patch.object(
+        build_package, "build_singlearch_package_variants", return_value=["single.deb"]
+    )
     def test_single_arch_routes_to_singlearch_builder(self, mock_single):
         """``enable_kpack=False`` always uses ``build_singlearch_package_variants``.
 
@@ -411,7 +421,9 @@ class BuildGfxarchPackageVariantsTest(unittest.TestCase):
     """
 
     @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(build_package, "create_nonversioned_deb_package", return_value=["nv.deb"])
+    @patch.object(
+        build_package, "create_nonversioned_deb_package", return_value=["nv.deb"]
+    )
     @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
     def test_metapackage_skips_host_builds_device_meta_nonversioned(
         self, mock_versioned, mock_nonversioned, _mock_cleanup
@@ -432,7 +444,9 @@ class BuildGfxarchPackageVariantsTest(unittest.TestCase):
             self.assertEqual(len(built), 4)
 
     @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(build_package, "create_nonversioned_deb_package", return_value=["nv.deb"])
+    @patch.object(
+        build_package, "create_nonversioned_deb_package", return_value=["nv.deb"]
+    )
     @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
     def test_non_meta_includes_host_device_meta_nonversioned(
         self, mock_versioned, mock_nonversioned, _mock_cleanup
@@ -448,9 +462,13 @@ class BuildGfxarchPackageVariantsTest(unittest.TestCase):
             self.assertEqual(len(built), 5)
 
     @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"])
+    @patch.object(
+        build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"]
+    )
     @patch.object(build_package, "create_versioned_rpm_package", return_value=["v.rpm"])
-    def test_rpm_pkg_type_for_gfxarch_variants(self, mock_versioned, mock_nonversioned, _mock_cleanup):
+    def test_rpm_pkg_type_for_gfxarch_variants(
+        self, mock_versioned, mock_nonversioned, _mock_cleanup
+    ):
         """``pkg_type=rpm`` dispatches to ``create_versioned_rpm_package`` / ``create_nonversioned_rpm_package``."""
         with tempfile.TemporaryDirectory() as tmp:
             cfg = _config(Path(tmp), pkg_type="rpm")
@@ -485,9 +503,13 @@ class BuildSimplePackageVariantsTest(unittest.TestCase):
     """
 
     @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(build_package, "create_nonversioned_deb_package", return_value=["nv.deb"])
+    @patch.object(
+        build_package, "create_nonversioned_deb_package", return_value=["nv.deb"]
+    )
     @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
-    def test_deb_versioned_and_nonversioned(self, mock_versioned, mock_nonversioned, _mock_cleanup):
+    def test_deb_versioned_and_nonversioned(
+        self, mock_versioned, mock_nonversioned, _mock_cleanup
+    ):
         """DEB kpack simple path: one versioned + one non-versioned package."""
         with tempfile.TemporaryDirectory() as tmp:
             cfg = _config(Path(tmp), pkg_type="deb")
@@ -500,9 +522,13 @@ class BuildSimplePackageVariantsTest(unittest.TestCase):
             self.assertEqual(built, ["v.deb", "nv.deb"])
 
     @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"])
+    @patch.object(
+        build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"]
+    )
     @patch.object(build_package, "create_versioned_rpm_package", return_value=["v.rpm"])
-    def test_rpm_versioned_and_nonversioned(self, mock_versioned, mock_nonversioned, _mock_cleanup):
+    def test_rpm_versioned_and_nonversioned(
+        self, mock_versioned, mock_nonversioned, _mock_cleanup
+    ):
         """RPM kpack simple path: one versioned + one non-versioned package."""
         with tempfile.TemporaryDirectory() as tmp:
             cfg = _config(Path(tmp), pkg_type="rpm")
@@ -540,9 +566,13 @@ class BuildSinglearchPackageVariantsTest(unittest.TestCase):
     """
 
     @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(build_package, "create_nonversioned_deb_package", return_value=["nv.deb"])
+    @patch.object(
+        build_package, "create_nonversioned_deb_package", return_value=["nv.deb"]
+    )
     @patch.object(build_package, "create_versioned_deb_package", return_value=["v.deb"])
-    def test_deb_single_arch_builds_both_variants(self, mock_versioned, mock_nonversioned, _mock_cleanup):
+    def test_deb_single_arch_builds_both_variants(
+        self, mock_versioned, mock_nonversioned, _mock_cleanup
+    ):
         """Single-arch DEB: ``enable_kpack=False``, ``gfx_arch=gfx1100`` → versioned + non-versioned."""
         with tempfile.TemporaryDirectory() as tmp:
             cfg = _config(
@@ -560,9 +590,13 @@ class BuildSinglearchPackageVariantsTest(unittest.TestCase):
             self.assertEqual(built, ["v.deb", "nv.deb"])
 
     @patch.object(build_package, "cleanup_build_directory")
-    @patch.object(build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"])
+    @patch.object(
+        build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"]
+    )
     @patch.object(build_package, "create_versioned_rpm_package", return_value=["v.rpm"])
-    def test_rpm_single_arch_builds_both_variants(self, mock_versioned, mock_nonversioned, _mock_cleanup):
+    def test_rpm_single_arch_builds_both_variants(
+        self, mock_versioned, mock_nonversioned, _mock_cleanup
+    ):
         """Single-arch RPM: same as DEB but via ``create_*_rpm_package``."""
         with tempfile.TemporaryDirectory() as tmp:
             cfg = _config(
@@ -610,7 +644,9 @@ class VariantBuilderDispatchTest(unittest.TestCase):
     creator for dependency naming and artifact selection.
     """
 
-    @patch.object(build_package, "create_versioned_deb_package", return_value=["host.deb"])
+    @patch.object(
+        build_package, "create_versioned_deb_package", return_value=["host.deb"]
+    )
     def test_build_host_package_deb(self, mock_create):
         """``build_host_package`` sets ``gfx_arch=GFX_HOST`` and ``versioned_pkg=True``."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -621,7 +657,9 @@ class VariantBuilderDispatchTest(unittest.TestCase):
             self.assertEqual(passed.gfx_arch, GFX_HOST)
             self.assertTrue(passed.versioned_pkg)
 
-    @patch.object(build_package, "create_versioned_rpm_package", return_value=["dev.rpm"])
+    @patch.object(
+        build_package, "create_versioned_rpm_package", return_value=["dev.rpm"]
+    )
     def test_build_device_package_rpm(self, mock_create):
         """``build_device_package(..., device_arch)`` sets ``gfx_arch`` to the device token."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -631,7 +669,9 @@ class VariantBuilderDispatchTest(unittest.TestCase):
             passed = mock_create.call_args[0][1]
             self.assertEqual(passed.gfx_arch, "gfx1100")
 
-    @patch.object(build_package, "create_versioned_deb_package", return_value=["meta.deb"])
+    @patch.object(
+        build_package, "create_versioned_deb_package", return_value=["meta.deb"]
+    )
     def test_build_meta_package_deb(self, mock_create):
         """``build_meta_package`` sets ``gfx_arch=GFX_META`` for the versioned meta DEB."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -640,7 +680,9 @@ class VariantBuilderDispatchTest(unittest.TestCase):
             passed = mock_create.call_args[0][1]
             self.assertEqual(passed.gfx_arch, GFX_META)
 
-    @patch.object(build_package, "create_versioned_deb_package", return_value=["ver.deb"])
+    @patch.object(
+        build_package, "create_versioned_deb_package", return_value=["ver.deb"]
+    )
     def test_build_versioned_package_clears_gfx_arch(self, mock_create):
         """``build_versioned_package`` (non-gfx simple path) clears ``gfx_arch`` to ``""``."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -649,7 +691,9 @@ class VariantBuilderDispatchTest(unittest.TestCase):
             passed = mock_create.call_args[0][1]
             self.assertEqual(passed.gfx_arch, "")
 
-    @patch.object(build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"])
+    @patch.object(
+        build_package, "create_nonversioned_rpm_package", return_value=["nv.rpm"]
+    )
     def test_build_nonversioned_package_rpm(self, mock_create):
         """``build_nonversioned_package`` sets ``versioned_pkg=False``; preserves caller ``gfx_arch``."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -701,7 +745,11 @@ class MainAndRunTest(unittest.TestCase):
     @patch.object(build_package, "print_build_summary")
     @patch.object(build_package, "cleanup_packaging_environment")
     @patch.object(build_package, "build_package_variants", return_value=["out.deb"])
-    @patch.object(build_package, "parse_input_package_list", return_value=(["amdrocm-core-sdk"], []))
+    @patch.object(
+        build_package,
+        "parse_input_package_list",
+        return_value=(["amdrocm-core-sdk"], []),
+    )
     @patch.object(build_package, "create_package_config")
     def test_run_builds_requested_packages(
         self,
@@ -721,7 +769,9 @@ class MainAndRunTest(unittest.TestCase):
             mock_create_cfg.return_value = cfg
             args = _args(root, pkg_names=["amdrocm-core-sdk"], pkg_type="deb")
             build_package.run(args)
-            mock_parse_list.assert_called_once_with(["amdrocm-core-sdk"], cfg.artifacts_dir)
+            mock_parse_list.assert_called_once_with(
+                ["amdrocm-core-sdk"], cfg.artifacts_dir
+            )
             mock_build_variants.assert_called_once_with("amdrocm-core-sdk", cfg)
 
     @patch.object(build_package, "print_build_summary")


### PR DESCRIPTION

## Motivation

This PR adds unit tests for build_package.py so kpack routing, artifact discovery, and DEB metadata generation regressions are caught before CI packaging runs.

## Technical Details

Adds build_tools/packaging/linux/tests/build_package_test.py with 17 tests covering:
- Artifact staging, Package config, DEB generation, Variant routing, CLI helpers 
Also updates native_linux_package_install_test.py to raise RDHC_TIMEOUT_SEC to 600 and pass --skip-optional-cluster-checks during container install tests.

ISSUE ID: #6093

## Test Plan

cd build_tools/packaging/linux
python3.12 -m unittest tests.build_package_test -v

## Test Result

Ran 17 tests in 0.175s — OK
native linux test:
https://github.com/ROCm/TheRock/actions/runs/29520405518 - RHEL8  https://github.com/ROCm/TheRock/actions/runs/29520896342 - RHEL10 https://github.com/ROCm/TheRock/actions/runs/29522199152 - SLES16
https://github.com/ROCm/TheRock/actions/runs/29522336677 - UB24

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
