### PR TITLE
fix(cmake): remove mismatched endif() argument in math-libs

### DIFF
--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -654,4 +654,4 @@ if(_ck_enabled AND THEROCK_ENABLE_HIPTENSOR)
     SUBPROJECT_DEPS
       hipTensor
   )
-endif(THEROCK_ENABLE_HIPTENSOR)
+endif()


### PR DESCRIPTION
## Summary

`math-libs/CMakeLists.txt` line 657 had `endif(THEROCK_ENABLE_HIPTENSOR)`, but
the matching `if()` on line 613 tests `_ck_enabled AND THEROCK_ENABLE_HIPTENSOR`.
CMake requires the `endif()` argument (when provided) to exactly match the `if()`
condition, so the mismatch produces a `CMake Warning (dev)`.

Removed the argument from `endif()`, which is the idiomatic fix per the
[TheRock CMake style guide](docs/development/style_guides/cmake_style_guide.md).