### PR TITLE
Revert "feat(ci): Use host-asan for submodule bump PRs instead of full asan"

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1044,12 +1044,9 @@ def expand_build_configs(
     # =========================================================================
     all_families = _apply_external_family_overrides(all_families)
     build_variant = ci_inputs.build_variant
-    # For ASAN CI runs, workflow_dispatch and scheduled events run full "asan".
-    # Push events (postsubmit) and PRs with submodule changes run "host-asan"
-    # to provide faster feedback while still catching host-side ASAN issues.
-    # TODO: Revert PRs to full "asan" once CI capacity is increased. Currently
-    # using host-asan for submodule bump PRs to reduce queue times.
-    if build_variant == "asan" and (ci_inputs.is_push or ci_inputs.is_pull_request):
+    # for ASAN CI runs, workflow_dispatch and scheduled events are "asan".
+    # Otherwise, push events run "host-asan"
+    if build_variant == "asan" and ci_inputs.is_push:
         build_variant = "host-asan"
 
     linux_config: BuildConfig | None = None

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -984,18 +984,13 @@ class TestExpandBuildConfigs(unittest.TestCase):
         self.assertIsNone(result.windows)
 
     def test_variant_filters_by_trigger(self):
-        """ASAN: based on event type, we run an expected ASAN build variant.
-
-        Full ASAN builds only run on schedule and workflow_dispatch (nightly).
-        Push (postsubmit) and pull_request events use host-asan for faster feedback.
-        """
+        """ASAN: based on event type, we run an expected ASAN build variant"""
         targets = cm.TargetSelection(
             linux_families=["gfx94x"],
         )
         test_cases = [
             ("schedule", "linux-release-asan"),
             ("push", "linux-release-host-asan"),
-            ("pull_request", "linux-release-host-asan"),
             ("workflow_dispatch", "linux-release-asan"),
         ]
         for event_name, expected_variant in test_cases:


### PR DESCRIPTION
Reverts PR: ROCm/TheRock#6180
More details: https://github.com/ROCm/TheRock/issues/6207
MIOpen looks does not support for host-asan
```
[MIOpen] FAILED: src/CMakeFiles/MIOpen.dir/expanduser.cpp.o
[MIOpen] ccache ...clang++ ... -fsanitize=address -fno-omit-frame-pointer ... \
    -x hip --offload-arch=gfx942 ... -o src/CMakeFiles/MIOpen.dir/expanduser.cpp.o \
    -c ...rocm-libraries/projects/miopen/src/expanduser.cpp
[MIOpen] clang++: error: ignoring '-fsanitize=address' option for offload arch 'gfx942' \
    as it is not currently supported there. \
    Use it with an offload arch containing 'xnack+' instead [-Werror,-Woption-ignored]
FAILED: ml-libs/MIOpen/stamp/build.stamp
ninja: build stopped: subcommand failed.
```