### PR TITLE
feat(ci): disable postsubmit ASAN until capacity available

### DIFF
--- a/.github/workflows/multi_arch_ci_asan.yml
+++ b/.github/workflows/multi_arch_ci_asan.yml
@@ -4,9 +4,10 @@
 name: Multi-Arch CI ASAN
 
 on:
-  push:
-    branches:
-      - main
+  # TODO: Enable postsubmit ASAN once we have capacity
+  # push:
+  #   branches:
+  #     - main
   schedule:
     # Runs at 02:00 AM UTC, which is 7:00 PM PST (UTC-8)
     - cron: '0 02 * * *'


### PR DESCRIPTION
Comment out push trigger for multi_arch_ci_asan workflow to stop running ASAN builds on every push to main. Nightly scheduled runs and PR checks for submodule bumps remain active.