### PR TITLE
fix(ci): allow workflow_dispatch to test nightly_check_only architectures

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -935,15 +935,15 @@ def _expand_build_config_for_platform(
                 f"disabling tests for quick test run"
             )
 
-        # If nightly_check_only_for_family is set for schedule runs only
-        if (
-            platform_info.get("nightly_check_only_for_family", False)
-            and not ci_inputs.is_schedule
+        # If nightly_check_only_for_family is set, only run tests for schedule
+        # or workflow_dispatch triggers (to allow manual testing of nightly-only archs)
+        if platform_info.get("nightly_check_only_for_family", False) and not (
+            ci_inputs.is_schedule or ci_inputs.is_workflow_dispatch
         ):
             test_runs_on = ""
             print(
                 f"  {family_name}: nightly_check_only_for_family flag set, "
-                f"disabling test runner for non-scheduled runs"
+                f"disabling test runner for non-scheduled/non-dispatch runs"
             )
 
         family_info = {

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1432,6 +1432,32 @@ class TestFamilyTestFilters(unittest.TestCase):
         self.assertIsNotNone(gfx90a_info)
         self.assertEqual(gfx90a_info["test-runs-on"], "")
 
+    def test_workflow_dispatch_allows_nightly_check_only_family(self):
+        """workflow_dispatch should allow testing nightly_check_only families."""
+        # gfx90a has nightly_check_only_for_family=True for linux
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="workflow_dispatch",
+            commit_ref="main",
+            base_ref="HEAD^",
+            build_variant="release",
+            linux_amdgpu_families=["gfx90a"],
+        )
+        git_context = cm.GitContext.empty()
+        outputs = cm.configure(ci_inputs, git_context)
+
+        # Find gfx90a in the linux build config
+        gfx90a_info = None
+        if outputs.builds.linux:
+            for family_info in outputs.builds.linux.per_family_info:
+                if family_info["amdgpu_family"] == "gfx90a":
+                    gfx90a_info = family_info
+                    break
+
+        self.assertIsNotNone(gfx90a_info)
+        # workflow_dispatch should have test-runs-on set (not empty)
+        self.assertNotEqual(gfx90a_info["test-runs-on"], "")
+
 
 # ---------------------------------------------------------------------------
 # Multi-label runner selection


### PR DESCRIPTION
Previously, architectures with nightly_check_only_for_family flag had their test runners disabled for all non-scheduled triggers. This change allows workflow_dispatch triggers to also enable test runners for these architectures, enabling manual testing of nightly-only archs.

works here: https://github.com/ROCm/TheRock/actions/runs/28465742475 with setting here: https://github.com/ROCm/therock-ci-config/blob/89a7b32a40268208bd7fa38d16775417f5b67932/runner-config.json#L71