### PR TITLE
feat(hipkernelprovider): Add rocKE flag

### DIFF
--- a/FLAGS.cmake
+++ b/FLAGS.cmake
@@ -32,6 +32,16 @@ therock_declare_flag(
 )
 
 therock_declare_flag(
+  NAME HIPKERNELPROVIDER_ENABLE_ROCKE
+  DEFAULT_VALUE OFF
+  DESCRIPTION "Build the rocKE engine and smoke tests in hip-kernel-provider"
+  CMAKE_VARS
+    HIPKERNELPROVIDER_ENABLE_ROCKE=ON
+  SUB_PROJECTS
+    hipkernelprovider
+)
+
+therock_declare_flag(
   NAME STAMP_LIBRARY_GIT_VERSIONS
   DEFAULT_VALUE OFF
   DESCRIPTION "Stamp library git revisions into generated version metadata"

--- a/ml-libs/artifact-hipkernelprovider.toml
+++ b/ml-libs/artifact-hipkernelprovider.toml
@@ -11,4 +11,13 @@ include = [
   # Test config TOMLs (e.g. HIP_KERNEL_ENGINE.toml) consumed by the cross-provider
   # integration suite (hipdnn_integration_tests --test-config).
   "bin/hip_kernel_provider/*.toml",
+  # rocKE Python smoke test (placeholder rocke Python CI test) + the co-located
+  # rocke package it imports. Only present when HIPKERNELPROVIDER_ENABLE_ROCKE=ON.
+  "bin/hip_kernel_provider/rocke_installed_smoke.py",
+  "bin/hip_kernel_provider/rocke/**",
+  # rocKE host-only golden IR byte-stability gate: relocatable runner, the parity
+  # harness it imports, and the committed golden digest JSON.
+  "bin/hip_kernel_provider/rocke_installed_golden.py",
+  "bin/hip_kernel_provider/rocke_ir_parity_harness.py",
+  "bin/hip_kernel_provider/golden/**",
 ]

--- a/ml-libs/artifact-hipkernelprovider.toml
+++ b/ml-libs/artifact-hipkernelprovider.toml
@@ -11,13 +11,4 @@ include = [
   # Test config TOMLs (e.g. HIP_KERNEL_ENGINE.toml) consumed by the cross-provider
   # integration suite (hipdnn_integration_tests --test-config).
   "bin/hip_kernel_provider/*.toml",
-  # rocKE Python smoke test (placeholder rocke Python CI test) + the co-located
-  # rocke package it imports. Only present when HIPKERNELPROVIDER_ENABLE_ROCKE=ON.
-  "bin/hip_kernel_provider/rocke_installed_smoke.py",
-  "bin/hip_kernel_provider/rocke/**",
-  # rocKE host-only golden IR byte-stability gate: relocatable runner, the parity
-  # harness it imports, and the committed golden digest JSON.
-  "bin/hip_kernel_provider/rocke_installed_golden.py",
-  "bin/hip_kernel_provider/rocke_ir_parity_harness.py",
-  "bin/hip_kernel_provider/golden/**",
 ]


### PR DESCRIPTION
ISSUE ID : AICK-1470
Add a `HIPKERNELPROVIDER_ENABLE_ROCKE` build flag (default OFF) that propagates` -DHIPKERNELPROVIDER_ENABLE_ROCKE=ON` to the hipkernelprovider subproject, and include the rocKE Python CI files in the hip-kernel-provider test artifact: rocke_installed_smoke.py, rocke_installed_golden.py, rocke_ir_parity_harness.py, the rocke package (rocke/**), and golden/** data. These match nothing when the flag is OFF, so the default build/test artifact is unchanged.

- [x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
