### PR TITLE
fix: Update default runner for JAX tests

### DIFF
--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -121,7 +121,7 @@ on:
       test_runs_on:
         description: Runner label to use. The selected runner should have a GPU supported by test_amdgpu_family
         type: string
-        default: "linux-gfx942-1gpu-core42-ossci-rocm"
+        default: "linux-gfx942-1gpu-ccs-csp-ossci-rocm-nkqqn-runner-dhdvw"
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -121,7 +121,7 @@ on:
       test_runs_on:
         description: Runner label to use. The selected runner should have a GPU supported by test_amdgpu_family
         type: string
-        default: "linux-gfx942-1gpu-ccs-csp-ossci-rocm-nkqqn-runner-dhdvw"
+        default: "linux-gfx942-1gpu-ccs-csp-ossci-rocm"
 permissions:
   contents: read
   id-token: write


### PR DESCRIPTION
## Motivation
Issue  ID: https://github.com/ROCm/TheRock/issues/6271
Based on this PR: https://github.com/ROCm/therock-ci-config/pull/7, updating default runner for JAX tests.

## Test
https://github.com/ROCm/TheRock/actions/runs/28474226769
