### PR TITLE
fix(ml-libs): always enable Composable Kernel in MIOpen host build

### DIFF
--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -9,17 +9,33 @@ if(THEROCK_FLAG_INCLUDE_PROFILER)
 endif()
 
 if(THEROCK_ENABLE_MIOPEN)
-  # MIOpen's CK use is gated on both the per-arch CK availability
-  # (math-libs/CMakeLists.txt) and the user-facing
-  # THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL opt-out, which lets
-  # someone build CK for other consumers while keeping it out of MIOpen.
+  # MIOpen is host-only with respect to Composable Kernel since
+  # rocm-libraries#6170: the host libMIOpen.so never links CK device code; it
+  # dlopens per-arch libMIOpenCKGroupedConv_<arch>.so at runtime
+  # (CkImplLibLoader) and degrades gracefully when a plugin is absent. The host
+  # therefore MUST be compiled with MIOPEN_USE_COMPOSABLEKERNEL=ON on every
+  # shard: this flag only controls host-side solver registration
+  # (mlo_dir_conv.cpp) and the dlopen path, not any per-arch device code. If a
+  # CK-unsupported-only shard (e.g. gfx103X) builds the host with CK=OFF, the
+  # grouped-conv XDLOPS solvers are preprocessed out of the registry, and because
+  # the host is published as the device-neutral _generic artifact, that CK-less
+  # libMIOpen.so can win the generic slot and disable fast conv on ALL arches,
+  # including gfx942 (ROCM-27359). So default CK ON and gate ONLY on the explicit
+  # opt-outs, NOT on per-arch CK plugin availability (_ck_enabled).
   set(_miopen_use_ck OFF)
-  if(_ck_enabled AND THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL)
+  if(THEROCK_ENABLE_COMPOSABLE_KERNEL AND THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL)
     set(_miopen_use_ck ON)
   endif()
 
+  # Only build-depend on the CK subproject where it is actually built for this
+  # shard's arch set (_ck_enabled). On CK-unsupported-only shards CK is skipped
+  # (math-libs) to avoid CK's empty-HIP_ARCHITECTURES configure failure; MIOpen
+  # still builds with CK=ON because the host has no compile/link dependency on CK:
+  # find_package(composable_kernel) is non-REQUIRED, MIOPEN_CK_UNBUNDLE_PER_ARCH
+  # defaults OFF, and MIOpen's src/ck_impl early-returns when no supported arch is
+  # present (so no per-arch plugin and no CK target reference).
   set(optional_miopen_build_deps)
-  if(_miopen_use_ck)
+  if(_miopen_use_ck AND _ck_enabled)
     list(APPEND optional_miopen_build_deps composable_kernel)
   endif()
 


### PR DESCRIPTION
## Summary

MIOpen is host-only with respect to Composable Kernel since [rocm-libraries#6170](https://github.com/ROCm/rocm-libraries/pull/6170): the host `libMIOpen.so` never links CK device code; it `dlopen`s per-arch `libMIOpenCKGroupedConv_<arch>.so` at runtime (`CkImplLibLoader`) and degrades gracefully when a plugin is absent. `MIOPEN_USE_COMPOSABLEKERNEL` therefore only controls host-side solver registration (`mlo_dir_conv.cpp`) and the dlopen path — it carries no per-arch device code. This PR makes the MIOpen host always build with CK enabled (default on, off only on explicit opt-out), instead of gating it on the per-arch CK plugin availability.

JIRA ID : ROCM-27359

Since [#4941](https://github.com/ROCm/TheRock/pull/4941), `MIOPEN_USE_COMPOSABLEKERNEL` was gated on `_ck_enabled` (the per-arch CK plugin gate), which is OFF for CK-unsupported-only shards (gfx900/gfx906/gfx101X/gfx103X/gfx1103). Such a shard builds the host with CK=OFF, which preprocesses the grouped-conv XDLOPS solvers out of the registry. Because the host ships as the device-neutral `_generic` artifact and all shards overwrite the single `miopen_lib_generic` slot (last writer wins), a CK-less `libMIOpen.so` can become the host for every arch — disabling fast convolution everywhere, including gfx942. This is the 97% regression in nightly `7.14.0a20260622` (`miopen_lib_generic` from the gfx103X-all shard, CK=OFF; 0620 was from gfx110X-all, CK=ON).

## Risk Assessment

Medium risk. Build-wiring change that flips `MIOPEN_USE_COMPOSABLEKERNEL` to ON on shards that previously built it OFF. The host has no compile/link dependency on CK (`find_package(composable_kernel)` is non-REQUIRED, `MIOPEN_CK_UNBUNDLE_PER_ARCH` defaults OFF, `src/ck_impl` early-returns when no supported arch), so CK-unsupported-only shards should still configure and build; the CK subproject build-dep stays gated on `_ck_enabled` so they keep skipping CK and avoid CK's empty-`HIP_ARCHITECTURES` configure failure (#4836). The main residual risk is a CK-unsupported-only shard's MIOpen configure under CK=ON, which must be confirmed in CI.

## ASIC Coverage

Full multi-arch sweep required. The change alters which conv solvers are registered in the device-neutral host `libMIOpen.so`, so it can affect dispatch on every supported GFX target. Must specifically validate: (a) a CK-unsupported-only shard (e.g. gfx103X-all) still builds with CK=ON, and (b) the resulting `_generic` host registers the grouped-conv XDLOPS solver so gfx942/gfx950 keep the fast path regardless of which shard supplies the host.

## Testing Summary

- Static/source analysis confirming the host has no CK build dependency (host solver includes only `ck_impl_lib_loader.hpp`; CK archive linked only into the per-arch `src/ck_impl` plugin, which early-returns on unsupported arch).
- Binary forensics on shipped nightlies: 0620 host `libMIOpen.so` has 52 `SolverContainer<…GroupFwdXdlops…>` registrations (CK ON); 0622 has 0 (CK OFF) — root cause confirmed.
- Multi-arch CI build + sweep: pending (cannot run locally).

## Testing Checklist

- [ ] Single-arch CK-supported build (gfx942) - host registers grouped-conv XDLOPS solver; CK plugin built - Status: Pending
- [ ] CK-unsupported-only shard build (gfx103X-all) - configures and builds with CK=ON, no CK subproject, host registers solver - Status: Pending
- [ ] Multi-arch build (gfx942;gfx1100;gfx103X) - host CK=ON, per-arch plugins only for supported arches - Status: Pending
- [ ] `THEROCK_ENABLE_COMPOSABLE_KERNEL=OFF` build - CK fully disabled, builds clean - Status: Pending
- [ ] Multi-arch sweep - TheRock multi-arch CI - ASICs: full supported GFX family matrix - Status: Pending
- [ ] PR CI - GitHub PR checks - Status: Pending

## Technical Changes

- `ml-libs/CMakeLists.txt`: set `_miopen_use_ck` from the explicit opt-outs only (`THEROCK_ENABLE_COMPOSABLE_KERNEL AND THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL`), no longer gated on `_ck_enabled`, so the host is built CK=ON on every shard by default.
- Keep the `composable_kernel` build-dependency gated on `_ck_enabled` so CK-unsupported-only shards still skip the CK subproject and avoid the empty-`HIP_ARCHITECTURES` configure crash (#4836).
- Explicit disable is preserved exactly as before via `THEROCK_ENABLE_COMPOSABLE_KERNEL=OFF` or `THEROCK_MIOPEN_USE_COMPOSABLE_KERNEL=OFF`.
