### PR TITLE
Add rocrand-simulator tests via test_component.yml

### DIFF
--- a/.github/workflows/test_artifacts_structure.yml
+++ b/.github/workflows/test_artifacts_structure.yml
@@ -97,7 +97,7 @@ jobs:
             --stage=all \
             --amdgpu-families="${{ inputs.amdgpu_families }}" \
             --platform="${{ env.PLATFORM }}" \
-            --output-dir="${{ github.workspace }}" \
+            --output-dir="${GITHUB_WORKSPACE}" \
             --no-extract
           # NOTE: artifact_manager.py appends /.download_cache to --output-dir
           # in --no-extract mode, so pass workspace root here so that

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -141,6 +141,7 @@ jobs:
           python ./build_tools/health_status.py
 
       - name: Driver / GPU sanity check
+        if: ${{ fromJSON(inputs.component).linux_cpu_runner != true }}
         timeout-minutes: 3
         run: |
           python ./build_tools/print_driver_gpu_info.py

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -418,9 +418,17 @@ test_matrix = {
         "test_script": f"python {_get_script_path('simulator_runner.py')} --component rocrand --filter-preset extended",
         "platform": ["linux"],
         "linux_cpu_runner": True,
+        # 2 shards: each is its own GHA job with its own timeout_minutes budget.
+        # The `extended` preset's `shards` list in simulator_runner_filters.yaml
+        # assigns each shard an explicit scope (shard 1 = current 14 binaries,
+        # shard 2 = placeholder). Shard count here must match that list length.
         "total_shards_dict": {
-            "linux": 1,
+            "linux": 2,
         },
+        # The simulator always runs the `extended` preset regardless of
+        # TEST_TYPE, so the "quick -> single shard" rule (see run()) must not
+        # collapse its shards. Keep the configured shard count under quick.
+        "shard_even_when_quick": True,
         "include_family": {
             "linux": [
                 "gfx94X-dcgpu",
@@ -895,7 +903,12 @@ def run():
 
             # If the test type is quick tests, we only need one shard for the test job
             # Note: Benchmarks always use test_type="full" but have total_shards=1 anyway
-            if test_type == "quick":
+            # Exception: jobs that set "shard_even_when_quick" (e.g. the CPU
+            # simulator, which always runs its own preset regardless of TEST_TYPE)
+            # keep their configured shard count.
+            if test_type == "quick" and not job_config_data.get(
+                "shard_even_when_quick"
+            ):
                 job_config_data["total_shards"] = 1
                 job_config_data["shard_arr"] = [1]
 

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -410,7 +410,11 @@ test_matrix = {
     "rocrand-simulator": {
         "job_name": "rocrand-simulator",
         "fetch_artifact_args": "--rand --rocjitsu --tests",
-        "timeout_minutes": 60,
+        # The extended preset runs the 13 kernel binaries plus the
+        # _quick_suite/_standard_suite/_ffm-quick_suite variants under PDES,
+        # measured at ~120-160 min; 180 gives margin. 60 min was hit in run
+        # 28490994039.
+        "timeout_minutes": 180,
         "test_script": f"python {_get_script_path('simulator_runner.py')} --component rocrand --filter-preset extended",
         "platform": ["linux"],
         "linux_cpu_runner": True,

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -403,6 +403,30 @@ test_matrix = {
             "windows": 1,
         },
     },
+    # rocRAND tests under the rocjitsu CPU simulator (no GPU required).
+    # Runs for every family that has a rocjitsu config mapping in
+    # simulator_runner.py (FAMILY_TO_ROCJITSU_CONFIG): CDNA3/4 and RDNA3/4 plus
+    # gfx1250. Keep this family list in sync with that mapping.
+    "rocrand-simulator": {
+        "job_name": "rocrand-simulator",
+        "fetch_artifact_args": "--rand --rocjitsu --tests",
+        "timeout_minutes": 60,
+        "test_script": f"python {_get_script_path('simulator_runner.py')} --component rocrand --filter-preset extended",
+        "platform": ["linux"],
+        "linux_cpu_runner": True,
+        "total_shards_dict": {
+            "linux": 1,
+        },
+        "include_family": {
+            "linux": [
+                "gfx94X-dcgpu",
+                "gfx950-dcgpu",
+                "gfx110X-all",
+                "gfx120X-all",
+                "gfx125X-dcgpu",
+            ],
+        },
+    },
     "hiprand": {
         "job_name": "hiprand",
         "fetch_artifact_args": "--rand --tests",
@@ -784,6 +808,17 @@ def run():
         ):
             logging.info(
                 f"Excluding job {job_name} for platform {platform} and family {amdgpu_families}"
+            )
+            continue
+
+        # If the test is only enabled for specific families, skip if not in the list
+        if (
+            "include_family" in selected_matrix[key]
+            and platform in selected_matrix[key]["include_family"]
+            and amdgpu_families not in selected_matrix[key]["include_family"][platform]
+        ):
+            logging.info(
+                f"Excluding job {job_name} for platform {platform}: family {amdgpu_families} not in include_family list"
             )
             continue
 

--- a/build_tools/github_actions/test_executable_scripts/simulator_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/simulator_runner.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""simulator_runner.py
+
+Wraps an existing per-component test driver (e.g. ``test_rocrand.py``) so the
+tests execute against the rocjitsu simulator instead of a physical AMD GPU.
+
+The simulator runs entirely on CPU. We arrange two things before delegating
+to the existing test driver, then enforce two post-run guards:
+
+1. The existing per-component driver is launched through the ``rocjitsu`` CLI
+   (``rocjitsu --config <config.json> -- <driver>``). The CLI writes the
+   interposer config-discovery file, sets ``LD_PRELOAD`` to the KFD interposer
+   and execs the driver; ``ctest`` and the test binaries it spawns inherit
+   both, so the real HIP/HSA stack talks to the simulated driver. This mirrors
+   how rocjitsu's own corpus CI wraps ``pytest``.
+2. A ``GTEST_FILTER`` is composed from a preset (allow patterns) and a per-
+   component skip-list (deny patterns), both defined in
+   ``simulator_runner_filters.yaml``. The preset also supplies a
+   ``ctest_regex`` to narrow which ctest binaries run, and a ``min_gtests``
+   lower bound for the post-run guards.
+
+Post-run guards (Rocjitsu_005 lesson):
+
+A. **No silent empty-set passes.** GoogleTest exits 0 when ``GTEST_FILTER``
+   matches nothing in a binary. ctest then counts the binary as Passed, and
+   the workflow shows green even though zero simulator coverage ran. After
+   the driver returns we scan
+   ``<bin_dir>/<ctest_dir>/Testing/Temporary/LastTest.log`` for the literal
+   ``did not match any test; no tests were run`` line in any binary that
+   matched ``ctest_regex`` (i.e. was in scope for this preset) and fail the
+   run if any are found.
+B. **Minimum coverage floor.** We sum the gtest counts reported by every
+   in-scope binary ("[==========] N tests from M test suites ran.") and fail
+   the run if the total is below the preset's ``min_gtests``. Set
+   ``SIMULATOR_RUNNER_SKIP_GUARDS=1`` to bypass A+B for debugging.
+
+Required env (set by the workflow):
+
+  THEROCK_BIN_DIR
+      Path to the ``bin/`` directory of the populated ROCm dist (i.e.
+      ``<rocm_root>/bin``). This mirrors the convention used by the rest of
+      TheRock's per-component test drivers (e.g. ``test_rocdecode.py``,
+      ``test_runner.py``) which compute the ROCm root as
+      ``Path(THEROCK_BIN_DIR).parent``. Rocjitsu's CLI, interposer and config
+      are looked up under that ROCm root:
+      ``<root>/bin/rocjitsu``,
+      ``<root>/lib/librocjitsu_kmd.so``,
+      ``<root>/share/rocjitsu/configs/...``.
+
+Usage:
+  python simulator_runner.py --component rocrand --filter-preset basic
+"""
+
+import argparse
+import logging
+import os
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print(
+        "ERROR: PyYAML is required for simulator_runner.py. "
+        "Install with `pip install pyyaml`.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+FILTERS_PATH = SCRIPT_DIR / "simulator_runner_filters.yaml"
+
+# Map --component to the existing per-component driver script in this directory.
+COMPONENT_DRIVERS = {
+    "rocrand": "test_rocrand.py",
+    "hiprand": "test_hiprand.py",
+}
+
+# Per-test wall-clock cap (seconds) for ctest under the simulator. Bounds any
+# single test that wanders into a slow path so a stall fails fast instead of
+# eating the whole workflow step budget. Honored by ctest via the
+# CTEST_TEST_TIMEOUT env var. 10 min is generous for a single create/destroy
+# cycle under PDES while still cutting the 60-min step timeout we hit in
+# Rocjitsu_003.txt down to a clear per-test failure.
+DEFAULT_CTEST_TEST_TIMEOUT_SECONDS = 600
+
+# Default ctest -R regex when a preset does not declare one. ".*" matches
+# every ctest binary, preserving today's behavior for the `quick` and `full`
+# presets where we genuinely want every binary to run.
+DEFAULT_CTEST_REGEX = ".*"
+
+# Default min_gtests floor when a preset does not declare one. >=1 means
+# "at least one gtest must actually execute", which is the bare minimum
+# needed to catch the empty-set silent-pass failure mode.
+DEFAULT_MIN_GTESTS = 1
+
+# Sentinel substring GoogleTest prints when GTEST_FILTER matches nothing.
+# Stable across gtest versions (see googletest/src/gtest.cc).
+EMPTY_FILTER_SENTINEL = "did not match any test; no tests were run"
+
+# Map AMDGPU_FAMILIES value -> the rocjitsu config JSON shipped under
+# <root>/share/rocjitsu/configs/. rocjitsu's install rule (rocm-systems
+# emulation/rocjitsu/CMakeLists.txt) copies the whole `configs/` directory
+# wholesale, so every config is present in each dist; we only pick the right
+# one at runtime based on the family the caller is testing.
+#
+# Config variants mirror rocjitsu's own corpus CI
+# (rocm-systems .github/workflows/rocjitsu-corpus-tests.yml): the plain
+# (non-`_kmd`) configs for CDNA, the per-board `_kmd` configs for RDNA, and the
+# dedicated config for gfx1250. Keep this in sync with the families enabled for
+# the `rocrand-simulator` job in fetch_test_configurations.py.
+FAMILY_TO_ROCJITSU_CONFIG = {
+    "gfx94X-dcgpu": "amdgpu_cdna3.json",
+    "gfx950-dcgpu": "amdgpu_cdna4.json",
+    "gfx110X-all": "amdgpu_rdna3_gfx1100_w7900_kmd.json",
+    "gfx120X-all": "amdgpu_rdna4_gfx1201_r9700_kmd.json",
+    "gfx125X-dcgpu": "amdgpu_gfx1250.json",
+}
+
+
+@dataclass(frozen=True)
+class PresetConfig:
+    """Resolved view of one preset entry from simulator_runner_filters.yaml."""
+
+    allow: list[str]
+    skip: list[str]
+    ctest_regex: str
+    min_gtests: int
+
+
+@dataclass(frozen=True)
+class ComponentConfig:
+    """Resolved view of one component entry from simulator_runner_filters.yaml."""
+
+    ctest_dir: str
+    skip: list[str]
+
+
+def _resolve_rocjitsu_paths(bin_dir: Path, amdgpu_family: str) -> dict[str, Path]:
+    """Locate the rocjitsu CLI, interposer and config in a populated dist.
+
+    ``bin_dir`` is the ``bin/`` directory of the unified ROCm install (the
+    value of ``THEROCK_BIN_DIR`` in TheRock's test harness). The rocjitsu
+    artifact installs side-by-side with the rest of ROCm, so we resolve
+    everything relative to the ROCm root (``bin_dir.parent``)::
+
+        <root>/bin/rocjitsu
+        <root>/lib/librocjitsu_kmd.so
+        <root>/share/rocjitsu/configs/<config>.json
+
+    The exact config filename is picked from ``amdgpu_family`` via
+    ``FAMILY_TO_ROCJITSU_CONFIG``. Unknown families raise ``KeyError`` rather
+    than silently falling back, so a misconfigured caller cannot quietly
+    exercise the wrong config. The interposer lib is not preloaded directly;
+    the ``rocjitsu`` CLI discovers and preloads it (via ``bin/../lib``), but we
+    still validate it is present so failures are reported up front.
+    """
+    try:
+        config_name = FAMILY_TO_ROCJITSU_CONFIG[amdgpu_family]
+    except KeyError as e:
+        raise KeyError(
+            f"AMDGPU_FAMILIES={amdgpu_family!r} has no rocjitsu config "
+            f"mapping. Supported families: "
+            f"{sorted(FAMILY_TO_ROCJITSU_CONFIG.keys())}."
+        ) from e
+    rocm_root = bin_dir.parent
+    paths = {
+        "cli": rocm_root / "bin" / "rocjitsu",
+        "interposer": rocm_root / "lib" / "librocjitsu_kmd.so",
+        "config": rocm_root / "share" / "rocjitsu" / "configs" / config_name,
+    }
+    missing = [str(p) for p in paths.values() if not p.exists()]
+    if missing:
+        raise FileNotFoundError(
+            "rocjitsu install is incomplete under "
+            f"ROCm root {rocm_root} (THEROCK_BIN_DIR={bin_dir}). Missing:\n  "
+            + "\n  ".join(missing)
+            + "\nMake sure the build enabled "
+            "-DTHEROCK_ENABLE_EMULATION=ON -DTHEROCK_ENABLE_ROCJITSU=ON "
+            "and the rocjitsu artifact was unpacked into the dist."
+        )
+    return paths
+
+
+def _load_config(component: str, preset: str) -> tuple[ComponentConfig, PresetConfig]:
+    """Load and resolve component + preset config from the YAML file.
+
+    Supports both the modern mapping form (``preset: {allow: [...],
+    ctest_regex: ..., min_gtests: ...}``) and the legacy flat-list form
+    (``preset: [pattern1, pattern2]``) for back-compat with older entries.
+    """
+    if not FILTERS_PATH.exists():
+        raise FileNotFoundError(f"Simulator filter config not found: {FILTERS_PATH}")
+    with FILTERS_PATH.open() as fh:
+        cfg = yaml.safe_load(fh) or {}
+    comp_cfg = cfg.get(component)
+    if not comp_cfg:
+        raise KeyError(
+            f"No entry for component '{component}' in {FILTERS_PATH}. "
+            f"Known components: {sorted(cfg.keys())}"
+        )
+
+    ctest_dir = comp_cfg.get("ctest_dir")
+    if not ctest_dir:
+        raise KeyError(
+            f"Component '{component}' in {FILTERS_PATH} is missing required "
+            f"key 'ctest_dir' (the dir under THEROCK_BIN_DIR holding "
+            f"CTestTestfile.cmake, e.g. 'rocRAND')."
+        )
+
+    presets = comp_cfg.get("presets") or {}
+    if preset not in presets:
+        raise KeyError(
+            f"Unknown preset '{preset}' for component '{component}'. "
+            f"Known presets: {sorted(presets.keys())}"
+        )
+
+    skip = list(comp_cfg.get("skip") or [])
+
+    raw_preset = presets[preset]
+    if isinstance(raw_preset, list):
+        allow = list(raw_preset)
+        ctest_regex = DEFAULT_CTEST_REGEX
+        min_gtests = DEFAULT_MIN_GTESTS
+    elif isinstance(raw_preset, dict):
+        allow = list(raw_preset.get("allow") or [])
+        ctest_regex = raw_preset.get("ctest_regex") or DEFAULT_CTEST_REGEX
+        min_gtests = int(raw_preset.get("min_gtests") or DEFAULT_MIN_GTESTS)
+    else:
+        raise TypeError(
+            f"Preset '{preset}' for component '{component}' has unsupported "
+            f"type {type(raw_preset).__name__}; expected list or mapping."
+        )
+
+    return (
+        ComponentConfig(ctest_dir=ctest_dir, skip=skip),
+        PresetConfig(
+            allow=allow, skip=skip, ctest_regex=ctest_regex, min_gtests=min_gtests
+        ),
+    )
+
+
+def _compose_gtest_filter(allow: list[str], skip: list[str]) -> str:
+    """Build a GTest filter string of the form ``allow:-skip``.
+
+    See https://google.github.io/googletest/advanced.html#running-a-subset-of-the-tests
+    for the syntax.
+    """
+    allow_part = ":".join(allow) if allow else "*"
+    if not skip:
+        return allow_part
+    skip_part = ":".join(skip)
+    return f"{allow_part}:-{skip_part}"
+
+
+def _build_env(
+    gtest_filter: str,
+    ctest_dir: Path,
+    ctest_regex: str,
+) -> dict[str, str]:
+    # The rocjitsu CLI owns LD_PRELOAD and the config-discovery file; we only
+    # set the test-harness knobs here. See main() for the CLI wrapper command.
+    env = os.environ.copy()
+    # SDMA is needed by the HIP runtime path the interposer emulates; mirror
+    # the value used by rocjitsu's own ctest suite.
+    env["HSA_ENABLE_SDMA"] = env.get("HSA_ENABLE_SDMA", "1")
+    env["GTEST_FILTER"] = gtest_filter
+    # Bound any individual ctest case so a stalled test fails fast instead of
+    # consuming the whole workflow step budget. Respects an explicit caller
+    # override (e.g. nightly runs of the `full` preset may want longer).
+    env["CTEST_TEST_TIMEOUT"] = env.get(
+        "CTEST_TEST_TIMEOUT", str(DEFAULT_CTEST_TEST_TIMEOUT_SECONDS)
+    )
+    # Knobs picked up by the wrapped driver (e.g. test_rocrand.py). All are
+    # opt-in: drivers fall back to their existing on-device behavior when the
+    # vars are unset, so the real-GPU lane is unaffected.
+    env["SIMULATOR_CTEST_DIR"] = str(ctest_dir)
+    env["SIMULATOR_CTEST_INCLUDE_REGEX"] = ctest_regex
+    # Guard 4: under the deterministic simulator, retrying a failing case
+    # cannot turn it green - it only hides real bugs. Tell the driver to drop
+    # --repeat. Drivers that don't honor this still work; the guard above is
+    # the primary defense.
+    env["SIMULATOR_NO_RETRY"] = env.get("SIMULATOR_NO_RETRY", "1")
+    return env
+
+
+# --- Post-run guard parsing ---------------------------------------------------
+
+# Header line ctest writes per binary in Testing/Temporary/LastTest.log:
+#   "10/52 Testing: test_rocrand_host"
+# (The first number is the run order, second is the total. We only need the
+# binary name.)
+_TESTING_HEADER_RE = re.compile(r"^\s*(?:\d+/\d+)\s+Testing:\s+(?P<name>\S+)\s*$")
+
+# Footer-ish summary line GoogleTest prints when one or more tests actually
+# ran:
+#   "[==========] 3 tests from 2 test suites ran. (55 ms total)"
+# The "0 tests from 0 test suites ran" form ALSO matches this regex; the
+# guard differentiates by ALSO checking for EMPTY_FILTER_SENTINEL on the
+# same binary.
+_RAN_LINE_RE = re.compile(
+    r"^\[==========\]\s+(?P<n>\d+)\s+tests?\s+from\s+\d+\s+test\s+suites?\s+ran"
+)
+
+
+@dataclass(frozen=True)
+class BinaryResult:
+    """One ctest binary's run summary parsed from LastTest.log."""
+
+    name: str
+    gtests_run: int
+    empty_filter: bool
+
+
+def _parse_last_test_log(log_path: Path) -> list[BinaryResult]:
+    """Split LastTest.log into per-binary BinaryResult records.
+
+    Tolerates noise: anything between the "Testing: <name>" header and the
+    next header is attributed to <name>. Returns an empty list if the file
+    is missing or unreadable - callers decide whether that is fatal.
+    """
+    if not log_path.is_file():
+        return []
+    try:
+        text = log_path.read_text(errors="replace")
+    except OSError:
+        return []
+
+    results: list[BinaryResult] = []
+    current_name: str | None = None
+    current_gtests = 0
+    current_empty = False
+
+    def _flush() -> None:
+        if current_name is not None:
+            results.append(
+                BinaryResult(
+                    name=current_name,
+                    gtests_run=current_gtests,
+                    empty_filter=current_empty,
+                )
+            )
+
+    for line in text.splitlines():
+        header_m = _TESTING_HEADER_RE.match(line)
+        if header_m:
+            _flush()
+            current_name = header_m.group("name")
+            current_gtests = 0
+            current_empty = False
+            continue
+        if current_name is None:
+            continue
+        if EMPTY_FILTER_SENTINEL in line:
+            current_empty = True
+            continue
+        ran_m = _RAN_LINE_RE.match(line)
+        if ran_m:
+            # Multiple "ran." lines per binary should not happen (gtest_main
+            # prints it once); if it does, take the max so a retry doesn't
+            # zero us out.
+            current_gtests = max(current_gtests, int(ran_m.group("n")))
+            continue
+    _flush()
+    return results
+
+
+@dataclass(frozen=True)
+class GuardOutcome:
+    """Result of running the post-run guards over one component's LastTest.log."""
+
+    ok: bool
+    in_scope_count: int
+    in_scope_total_gtests: int
+    empty_filter_binaries: list[str]
+    messages: list[str]
+
+
+def _run_guards(
+    log_path: Path,
+    ctest_regex: str,
+    min_gtests: int,
+) -> GuardOutcome:
+    """Apply Guard A (no empty-set passes) and Guard B (min coverage floor).
+
+    Returns a GuardOutcome whose `messages` always includes a one-line human
+    summary suitable for the workflow step log; `ok` is False iff either
+    guard tripped.
+    """
+    results = _parse_last_test_log(log_path)
+    if not results:
+        return GuardOutcome(
+            ok=False,
+            in_scope_count=0,
+            in_scope_total_gtests=0,
+            empty_filter_binaries=[],
+            messages=[
+                f"::error::Could not parse ctest LastTest.log at {log_path}. "
+                f"This usually means ctest never ran any binaries; check the "
+                f"driver output above."
+            ],
+        )
+
+    try:
+        in_scope_re = re.compile(ctest_regex)
+    except re.error as e:
+        return GuardOutcome(
+            ok=False,
+            in_scope_count=0,
+            in_scope_total_gtests=0,
+            empty_filter_binaries=[],
+            messages=[
+                f"::error::Invalid ctest_regex {ctest_regex!r} in preset "
+                f"config: {e}"
+            ],
+        )
+
+    in_scope = [r for r in results if in_scope_re.search(r.name)]
+    in_scope_count = len(in_scope)
+    in_scope_total = sum(r.gtests_run for r in in_scope)
+    empty_in_scope = [r.name for r in in_scope if r.empty_filter]
+
+    messages: list[str] = []
+    ok = True
+
+    if in_scope_count == 0:
+        ok = False
+        messages.append(
+            f"::error::Preset's ctest_regex {ctest_regex!r} matched zero of "
+            f"the {len(results)} binaries ctest ran. Check the regex against "
+            f"the binary names in LastTest.log."
+        )
+
+    if empty_in_scope:
+        ok = False
+        messages.append(
+            f"::error::{len(empty_in_scope)} in-scope binary(ies) reported "
+            f"'{EMPTY_FILTER_SENTINEL}' - GTEST_FILTER matched nothing in "
+            f"them, so they passed without running any tests. Offenders: "
+            + ", ".join(empty_in_scope)
+        )
+
+    if in_scope_total < min_gtests:
+        ok = False
+        messages.append(
+            f"::error::Coverage floor not met: in-scope binaries ran "
+            f"{in_scope_total} gtest case(s), preset requires at least "
+            f"{min_gtests}. Either the filter is too narrow for this preset "
+            f"or the simulator skipped tests silently."
+        )
+
+    summary = (
+        f"[simulator_runner] guards: in_scope_binaries={in_scope_count}/"
+        f"{len(results)} gtests_ran={in_scope_total} "
+        f"min_required={min_gtests} empty_filter_in_scope={len(empty_in_scope)}"
+    )
+    messages.insert(0, summary)
+    return GuardOutcome(
+        ok=ok,
+        in_scope_count=in_scope_count,
+        in_scope_total_gtests=in_scope_total,
+        empty_filter_binaries=empty_in_scope,
+        messages=messages,
+    )
+
+
+# --- CLI / main ---------------------------------------------------------------
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a TheRock per-component test driver under the rocjitsu "
+            "simulator (CPU-only)."
+        )
+    )
+    parser.add_argument(
+        "--component",
+        required=True,
+        choices=sorted(COMPONENT_DRIVERS.keys()),
+        help="Component whose existing test driver should be wrapped.",
+    )
+    parser.add_argument(
+        "--filter-preset",
+        default="basic",
+        help=(
+            "GTest filter preset defined in simulator_runner_filters.yaml. "
+            "Typically one of: basic, quick, full."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+
+    bin_dir_env = os.environ.get("THEROCK_BIN_DIR")
+    if not bin_dir_env:
+        print(
+            "ERROR: THEROCK_BIN_DIR is not set. The simulator runner needs "
+            "the path to the populated ROCm `bin/` dir "
+            "(e.g. build/dist/rocm/bin).",
+            file=sys.stderr,
+        )
+        return 2
+    bin_dir = Path(bin_dir_env).resolve()
+
+    amdgpu_family = (os.environ.get("AMDGPU_FAMILIES") or "").strip()
+    if not amdgpu_family:
+        print(
+            "ERROR: AMDGPU_FAMILIES is not set. The simulator runner needs it "
+            "to pick the rocjitsu config under "
+            "<rocm_root>/share/rocjitsu/configs/. Supported values: "
+            f"{sorted(FAMILY_TO_ROCJITSU_CONFIG.keys())}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        comp_cfg, preset_cfg = _load_config(args.component, args.filter_preset)
+        ctest_dir = bin_dir / comp_cfg.ctest_dir
+        paths = _resolve_rocjitsu_paths(bin_dir, amdgpu_family)
+        env = _build_env(
+            _compose_gtest_filter(preset_cfg.allow, preset_cfg.skip),
+            ctest_dir,
+            preset_cfg.ctest_regex,
+        )
+    except (FileNotFoundError, KeyError, TypeError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+    gtest_filter = env["GTEST_FILTER"]
+
+    driver_script = SCRIPT_DIR / COMPONENT_DRIVERS[args.component]
+    if not driver_script.exists():
+        print(f"ERROR: driver script not found: {driver_script}", file=sys.stderr)
+        return 2
+
+    # Launch the driver through the rocjitsu CLI: it writes the interposer
+    # config-discovery file, sets LD_PRELOAD and execs the driver. ctest and the
+    # test binaries it spawns inherit both. Mirrors rocjitsu's corpus CI, which
+    # wraps `pytest` the same way.
+    cmd = [
+        str(paths["cli"]),
+        "--config",
+        str(paths["config"]),
+        "--",
+        sys.executable,
+        str(driver_script),
+    ]
+    logging.info(
+        "[simulator_runner] component=%s preset=%s", args.component, args.filter_preset
+    )
+    logging.info("[simulator_runner] THEROCK_BIN_DIR=%s", bin_dir)
+    logging.info("[simulator_runner] AMDGPU_FAMILIES=%s", amdgpu_family)
+    logging.info("[simulator_runner] rocjitsu_cli=%s", paths["cli"])
+    logging.info("[simulator_runner] rocjitsu_config=%s", paths["config"])
+    logging.info("[simulator_runner] GTEST_FILTER=%s", gtest_filter)
+    logging.info("[simulator_runner] CTEST_TEST_TIMEOUT=%s", env["CTEST_TEST_TIMEOUT"])
+    logging.info(
+        "[simulator_runner] SIMULATOR_CTEST_DIR=%s", env["SIMULATOR_CTEST_DIR"]
+    )
+    logging.info(
+        "[simulator_runner] SIMULATOR_CTEST_INCLUDE_REGEX=%s",
+        env["SIMULATOR_CTEST_INCLUDE_REGEX"],
+    )
+    logging.info("[simulator_runner] SIMULATOR_NO_RETRY=%s", env["SIMULATOR_NO_RETRY"])
+    logging.info(
+        "[simulator_runner] min_gtests=%d (preset=%s)",
+        preset_cfg.min_gtests,
+        args.filter_preset,
+    )
+    logging.info("[simulator_runner] exec: %s", shlex.join(cmd))
+
+    try:
+        completed = subprocess.run(cmd, env=env, check=False)
+    except OSError as e:
+        print(f"ERROR: failed to exec driver: {e}", file=sys.stderr)
+        return 2
+    driver_rc = completed.returncode
+    logging.info("[simulator_runner] driver exited with rc=%d", driver_rc)
+
+    if os.environ.get("SIMULATOR_RUNNER_SKIP_GUARDS") == "1":
+        logging.info(
+            "[simulator_runner] SIMULATOR_RUNNER_SKIP_GUARDS=1; skipping "
+            "post-run guards. Returning driver rc=%d.",
+            driver_rc,
+        )
+        return driver_rc
+
+    log_path = ctest_dir / "Testing" / "Temporary" / "LastTest.log"
+    guard = _run_guards(log_path, preset_cfg.ctest_regex, preset_cfg.min_gtests)
+    for msg in guard.messages:
+        # Emit to stderr so ::error:: lines surface in the GitHub Actions
+        # step annotation feed even when stdout is captured/redirected.
+        print(msg, file=sys.stderr)
+
+    if driver_rc != 0:
+        # A real test failure should win over a guard failure - surface it
+        # as-is so on-call sees the actual test error first.
+        return driver_rc
+    if not guard.ok:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build_tools/github_actions/test_executable_scripts/simulator_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/simulator_runner.py
@@ -97,6 +97,13 @@ DEFAULT_CTEST_TEST_TIMEOUT_SECONDS = 600
 # presets where we genuinely want every binary to run.
 DEFAULT_CTEST_REGEX = ".*"
 
+# Default ctest -E (exclude) regex. Empty means "exclude nothing". A preset (or
+# shard) may set `ctest_exclude_regex` to drop specific binaries from the -R set
+# - needed for suite variants that carry their own CMake-baked GTEST_FILTER, so
+# the component skip: list cannot reach them (e.g. drop the cpp_basic suite whose
+# ffm variant has a 7200s ctest timeout, or the philox/xorwow poisson hangs).
+DEFAULT_CTEST_EXCLUDE_REGEX = ""
+
 # Default min_gtests floor when a preset does not declare one. >=1 means
 # "at least one gtest must actually execute", which is the bare minimum
 # needed to catch the empty-set silent-pass failure mode.
@@ -133,6 +140,7 @@ class PresetConfig:
     allow: list[str]
     skip: list[str]
     ctest_regex: str
+    ctest_exclude_regex: str
     min_gtests: int
 
 
@@ -241,10 +249,14 @@ def _load_config(
     if isinstance(raw_preset, list):
         allow = list(raw_preset)
         ctest_regex = DEFAULT_CTEST_REGEX
+        ctest_exclude_regex = DEFAULT_CTEST_EXCLUDE_REGEX
         min_gtests = DEFAULT_MIN_GTESTS
     elif isinstance(raw_preset, dict):
         allow = list(raw_preset.get("allow") or [])
         ctest_regex = raw_preset.get("ctest_regex") or DEFAULT_CTEST_REGEX
+        ctest_exclude_regex = (
+            raw_preset.get("ctest_exclude_regex") or DEFAULT_CTEST_EXCLUDE_REGEX
+        )
         min_gtests = int(raw_preset.get("min_gtests") or DEFAULT_MIN_GTESTS)
     else:
         raise TypeError(
@@ -283,12 +295,19 @@ def _load_config(
             if shard_cfg.get("allow"):
                 allow = list(shard_cfg["allow"])
             ctest_regex = shard_cfg.get("ctest_regex") or ctest_regex
+            ctest_exclude_regex = (
+                shard_cfg.get("ctest_exclude_regex") or ctest_exclude_regex
+            )
             min_gtests = int(shard_cfg.get("min_gtests") or min_gtests)
 
     return (
         ComponentConfig(ctest_dir=ctest_dir, skip=skip),
         PresetConfig(
-            allow=allow, skip=skip, ctest_regex=ctest_regex, min_gtests=min_gtests
+            allow=allow,
+            skip=skip,
+            ctest_regex=ctest_regex,
+            ctest_exclude_regex=ctest_exclude_regex,
+            min_gtests=min_gtests,
         ),
     )
 
@@ -310,6 +329,7 @@ def _build_env(
     gtest_filter: str,
     ctest_dir: Path,
     ctest_regex: str,
+    ctest_exclude_regex: str = "",
 ) -> dict[str, str]:
     # The rocjitsu CLI owns LD_PRELOAD and the config-discovery file; we only
     # set the test-harness knobs here. See main() for the CLI wrapper command.
@@ -329,6 +349,11 @@ def _build_env(
     # vars are unset, so the real-GPU lane is unaffected.
     env["SIMULATOR_CTEST_DIR"] = str(ctest_dir)
     env["SIMULATOR_CTEST_INCLUDE_REGEX"] = ctest_regex
+    # ctest -E exclude regex (drops binaries from the include set). Only set when
+    # non-empty so the common "no exclusions" case leaves the driver's behavior
+    # untouched.
+    if ctest_exclude_regex:
+        env["SIMULATOR_CTEST_EXCLUDE_REGEX"] = ctest_exclude_regex
     # Guard 4: under the deterministic simulator, retrying a failing case
     # cannot turn it green - it only hides real bugs. Tell the driver to drop
     # --repeat. Drivers that don't honor this still work; the guard above is
@@ -593,6 +618,7 @@ def main(argv: list[str] | None = None) -> int:
             _compose_gtest_filter(preset_cfg.allow, preset_cfg.skip),
             ctest_dir,
             preset_cfg.ctest_regex,
+            preset_cfg.ctest_exclude_regex,
         )
     except (FileNotFoundError, KeyError, TypeError) as e:
         print(f"ERROR: {e}", file=sys.stderr)
@@ -634,6 +660,10 @@ def main(argv: list[str] | None = None) -> int:
     logging.info(
         "[simulator_runner] SIMULATOR_CTEST_INCLUDE_REGEX=%s",
         env["SIMULATOR_CTEST_INCLUDE_REGEX"],
+    )
+    logging.info(
+        "[simulator_runner] SIMULATOR_CTEST_EXCLUDE_REGEX=%s",
+        env.get("SIMULATOR_CTEST_EXCLUDE_REGEX", ""),
     )
     logging.info("[simulator_runner] SIMULATOR_NO_RETRY=%s", env["SIMULATOR_NO_RETRY"])
     logging.info(

--- a/build_tools/github_actions/test_executable_scripts/simulator_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/simulator_runner.py
@@ -190,12 +190,24 @@ def _resolve_rocjitsu_paths(bin_dir: Path, amdgpu_family: str) -> dict[str, Path
     return paths
 
 
-def _load_config(component: str, preset: str) -> tuple[ComponentConfig, PresetConfig]:
+def _load_config(
+    component: str,
+    preset: str,
+    shard_index: int = 1,
+    total_shards: int = 1,
+) -> tuple[ComponentConfig, PresetConfig]:
     """Load and resolve component + preset config from the YAML file.
 
     Supports both the modern mapping form (``preset: {allow: [...],
     ctest_regex: ..., min_gtests: ...}``) and the legacy flat-list form
     (``preset: [pattern1, pattern2]``) for back-compat with older entries.
+
+    A mapping-form preset may also define a ``shards`` list. When the job runs
+    with ``total_shards > 1``, the preset resolves to ``shards[shard_index-1]``
+    so each shard runs its own explicitly-curated scope (each shard is a
+    separate GHA job with its own timeout). Keys a shard omits fall back to the
+    preset-level values. With ``total_shards == 1`` (or no ``shards`` declared),
+    resolution is unchanged.
     """
     if not FILTERS_PATH.exists():
         raise FileNotFoundError(f"Simulator filter config not found: {FILTERS_PATH}")
@@ -239,6 +251,39 @@ def _load_config(component: str, preset: str) -> tuple[ComponentConfig, PresetCo
             f"Preset '{preset}' for component '{component}' has unsupported "
             f"type {type(raw_preset).__name__}; expected list or mapping."
         )
+
+    # Per-shard scope selection. A mapping-form preset may declare a `shards`
+    # list; when TOTAL_SHARDS>1 each shard runs its own curated scope so shards
+    # cover disjoint, explicit test sets rather than duplicating the whole
+    # preset. A shard inherits any key it omits from the preset-level values.
+    if total_shards > 1 and isinstance(raw_preset, dict):
+        shards = raw_preset.get("shards")
+        if shards:
+            if not isinstance(shards, list):
+                raise TypeError(
+                    f"Preset '{preset}' 'shards' must be a list; got "
+                    f"{type(shards).__name__}."
+                )
+            if len(shards) != total_shards:
+                raise ValueError(
+                    f"Preset '{preset}' declares {len(shards)} shard scope(s) "
+                    f"but TOTAL_SHARDS={total_shards}; they must match."
+                )
+            if not 1 <= shard_index <= total_shards:
+                raise ValueError(
+                    f"SHARD_INDEX={shard_index} out of range for "
+                    f"TOTAL_SHARDS={total_shards} (expected 1..{total_shards})."
+                )
+            shard_cfg = shards[shard_index - 1]
+            if not isinstance(shard_cfg, dict):
+                raise TypeError(
+                    f"Preset '{preset}' shard {shard_index} must be a mapping; "
+                    f"got {type(shard_cfg).__name__}."
+                )
+            if shard_cfg.get("allow"):
+                allow = list(shard_cfg["allow"])
+            ctest_regex = shard_cfg.get("ctest_regex") or ctest_regex
+            min_gtests = int(shard_cfg.get("min_gtests") or min_gtests)
 
     return (
         ComponentConfig(ctest_dir=ctest_dir, skip=skip),
@@ -525,8 +570,23 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
+    # Shard identity is injected by the CI matrix (test_component.yml). Each
+    # shard is its own GHA job with its own timeout; the preset's `shards` list
+    # (if any) decides what each shard actually runs. Default to a single shard
+    # so local/non-sharded invocations are unaffected.
+    def _env_int(name: str) -> int:
+        try:
+            return int(os.environ.get(name, "1"))
+        except ValueError:
+            return 1
+
+    shard_index = _env_int("SHARD_INDEX")
+    total_shards = _env_int("TOTAL_SHARDS")
+
     try:
-        comp_cfg, preset_cfg = _load_config(args.component, args.filter_preset)
+        comp_cfg, preset_cfg = _load_config(
+            args.component, args.filter_preset, shard_index, total_shards
+        )
         ctest_dir = bin_dir / comp_cfg.ctest_dir
         paths = _resolve_rocjitsu_paths(bin_dir, amdgpu_family)
         env = _build_env(
@@ -558,6 +618,9 @@ def main(argv: list[str] | None = None) -> int:
     ]
     logging.info(
         "[simulator_runner] component=%s preset=%s", args.component, args.filter_preset
+    )
+    logging.info(
+        "[simulator_runner] SHARD_INDEX=%d TOTAL_SHARDS=%d", shard_index, total_shards
     )
     logging.info("[simulator_runner] THEROCK_BIN_DIR=%s", bin_dir)
     logging.info("[simulator_runner] AMDGPU_FAMILIES=%s", amdgpu_family)

--- a/build_tools/github_actions/test_executable_scripts/simulator_runner_filters.yaml
+++ b/build_tools/github_actions/test_executable_scripts/simulator_runner_filters.yaml
@@ -147,10 +147,19 @@ rocrand:
         # Shard 1: the current 14 base binaries (basic + 13 kernels).
         - ctest_regex: "^test_rocrand_(basic|kernel_(lfsr113|mrg|mtgp32|philox4x32_10|scrambled_sobol32|scrambled_sobol64|sobol32|sobol64|threefry2x32_20|threefry2x64_20|threefry4x32_20|threefry4x64_20|xorwow))$"
           min_gtests: 50
-        # Shard 2: TODO placeholder - small, green. Populate with expanded
-        # coverage (e.g. non-kernel base binaries) in a later change.
-        - ctest_regex: "^test_rocrand_basic$"
-          min_gtests: 3
+        # Shard 2: mimic the hardware `quick` run (the _quick_suite and
+        # _ffm-quick_suite variants of every rocRAND binary) for a like-for-like
+        # sim-vs-hardware speed comparison. No exclusions: these suite variants
+        # are bounded by the per-test timeout cap (~300-600s), so nothing hangs
+        # to the wall (the ~107-min unbounded hang in run 28503430843 was a
+        # _standard_suite, which this regex does NOT match). Expect ~20 min of
+        # red timeouts from the philox/xorwow kernel-poisson suites plus a slow
+        # (capped) host, total ~130-170 min. min_gtests starts at 1 (loose
+        # measurement floor); tune to just under the observed gtests_ran once we
+        # have a run. Suite variants carry their own CMake-baked GTEST_FILTER, so
+        # the component skip: list does not apply to them.
+        - ctest_regex: "_(quick|ffm-quick)_suite$"
+          min_gtests: 1
     # Mirror of QUICK_TESTS in test_rocrand.py. Promoted in PR-2 once `basic`
     # is stably green for a few runs. ctest_regex left unset (defaults to ".*")
     # so all 52 rocRAND binaries run; the per-binary filter then selects only

--- a/build_tools/github_actions/test_executable_scripts/simulator_runner_filters.yaml
+++ b/build_tools/github_actions/test_executable_scripts/simulator_runner_filters.yaml
@@ -1,0 +1,242 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Filter and skip-list config for simulator_runner.py.
+#
+# Per component:
+#   ctest_dir       Directory under THEROCK_BIN_DIR that contains the
+#                   component's CTestTestfile.cmake (e.g. "rocRAND" for
+#                   build/dist/rocm/bin/rocRAND). Used to locate
+#                   Testing/Temporary/LastTest.log for post-run guards.
+#   presets/<name>  Either a flat list of gtest filter globs (back-compat
+#                   shorthand for `allow:` only) or a mapping with:
+#                     allow:        list of gtest filter globs (joined with ':')
+#                     ctest_regex:  ctest -R regex narrowing which binaries
+#                                   run under this preset. Default: ".*".
+#                                   simulator_runner.py also uses this regex
+#                                   to decide which binaries are "in scope"
+#                                   for the post-run guards.
+#                     min_gtests:   lower bound on the total number of gtest
+#                                   cases the in-scope binaries must actually
+#                                   execute. The post-run guard fails if the
+#                                   sum across in-scope binaries is below this
+#                                   value. Default: 1.
+#   skip            Deny patterns appended after '-' in GTEST_FILTER.
+#
+# The guards protect against the silent-pass failure mode documented in
+# Rocjitsu_005: GoogleTest exits 0 when GTEST_FILTER matches nothing in a
+# binary, so a typo or stale filter entry would otherwise produce a green CI
+# run that exercised zero simulator coverage. See
+# docs/development/simulator_testing.md for the full guard contract.
+#
+# Each skip entry should carry a brief comment explaining why the test cannot
+# run under the simulator yet. As coverage expands the list should shrink.
+#
+# Conventions:
+#   - Patterns are gtest filter globs (https://google.github.io/googletest/advanced.html#running-a-subset-of-the-tests).
+#   - The `quick` preset duplicates QUICK_TESTS from test_rocrand.py. If you
+#     update one, mirror the change in the other.
+
+rocrand:
+  ctest_dir: rocRAND
+  presets:
+    # MVP starter set for PR-1: just enough to prove the framework end-to-end
+    # on the simulator without paying for parameterized RNG sweeps. Picked
+    # after Rocjitsu_003.txt showed that the original "*basic_tests*" pattern
+    # expands to 22 create/destroy cases over 14 RNG types in
+    # test_rocrand_basic plus the cpp_basic move-construction sweep, each of
+    # which triggers GPU init kernels and runs for several minutes under
+    # rocjitsu's CPU-only PDES.
+    #
+    # The first two are pure CPU and prove the rocRAND shared library loads
+    # cleanly when librocjitsu_kmd.so is in LD_PRELOAD. The third runs ONE
+    # create/destroy cycle for PHILOX4_32_10 (the lightest RNG in rng_types,
+    # index 0) to actually exercise the simulator's GPU init path.
+    #
+    # ctest_regex narrows ctest to test_rocrand_basic only - the three gtests
+    # below all live in that one binary. Without it, ctest would run all 52
+    # rocRAND binaries, 51 of which would match zero gtests and silently
+    # "pass" (see Rocjitsu_005's LastTest.log).
+    basic:
+      allow:
+        - "rocrand_basic_tests.rocrand_get_version_test"
+        - "rocrand_basic_tests.rocrand_generator_test"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_create_destroy_generator_test/0"
+      ctest_regex: "^test_rocrand_basic$"
+      min_gtests: 3
+    # Intermediate step above `basic`. Stays pinned to test_rocrand_basic - the
+    # one binary proven to initialize cleanly under rocjitsu - so no new
+    # (untimed) ctest binaries enter scope and the run cannot wander into the
+    # test_rocrand_cpp_basic hang class (Rocjitsu_003.txt). It broadens coverage
+    # from 3 -> 17 gtests: both non-parameterized API tests plus all three
+    # TEST_P families (create/destroy, set_stream, initialize) across a
+    # representative RNG spread - /0 PHILOX (proven), /3 XORWOW, /4 MTGP32,
+    # /6 THREEFRY2_32_20, and /11 SCRAMBLED_SOBOL32 (quasi).
+    #
+    # The whole binary ran ~43 cases in ~120s previously (~2.8s/case), so 17
+    # cases is ~45s - comfortably under the 60-min step budget, and the 600s
+    # per-test cap bounds any single stall. set_stream/initialize are not yet
+    # proven under the simulator: if a specific (test, RNG) case fails or
+    # stalls, move that one entry to the component `skip:` list with a one-line
+    # reason rather than reverting the whole preset.
+    smoke:
+      allow:
+        - "rocrand_basic_tests.rocrand_get_version_test"
+        - "rocrand_basic_tests.rocrand_generator_test"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_create_destroy_generator_test/0"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_create_destroy_generator_test/3"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_create_destroy_generator_test/4"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_create_destroy_generator_test/6"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_create_destroy_generator_test/11"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_set_stream_test/0"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_set_stream_test/3"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_set_stream_test/4"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_set_stream_test/6"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_set_stream_test/11"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_initialize_generator_test/0"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_initialize_generator_test/3"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_initialize_generator_test/4"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_initialize_generator_test/6"
+        - "rocrand_basic_tests/rocrand_basic_tests.rocrand_initialize_generator_test/11"
+      ctest_regex: "^test_rocrand_basic$"
+      min_gtests: 17
+    # Tier above `smoke`. Broadens scope from the single test_rocrand_basic
+    # binary to also cover the 13 test_rocrand_kernel_* binaries - the RNG
+    # device kernels that rocjitsu exists to simulate (philox, xorwow, mrg,
+    # lfsr113, mtgp32, sobol32/64, scrambled_sobol32/64, and the four threefry
+    # variants). Each kernel binary is small: ~5-7 plain launches over 8192
+    # elements plus 2 TEST_P poisson/discrete families over 6 lambdas.
+    #
+    # ctest_regex deliberately EXCLUDES test_rocrand_cpp_basic (hangs >57 min
+    # under the simulator, see Rocjitsu_003.txt) and test_rocrand_hipgraphs
+    # (hipgraphs are not modeled by the interposer). The generate*/host/
+    # cpp_wrapper binaries are deferred to a later tier until their per-binary
+    # timing under PDES is known.
+    #
+    # allow: ["*"] runs every (non-skipped) case in each in-scope binary, which
+    # keeps Guard A happy (no in-scope binary can run zero gtests) without
+    # hand-maintaining per-binary patterns; the component skip: list below still
+    # applies and gtest drops DISABLED_ cases by default. Estimated ~10-20 min
+    # vs the 60-min step budget, and the 600s per-test cap bounds any outlier.
+    # min_gtests: 50 is an intentionally loose first-measurement floor (well
+    # above a basic-only run of ~42); tighten it to the observed gtests_ran
+    # once this tier is stably green.
+    extended:
+      allow:
+        - "*"
+      ctest_regex: "^test_rocrand_(basic|kernel_.*)$"
+      min_gtests: 50
+    # Mirror of QUICK_TESTS in test_rocrand.py. Promoted in PR-2 once `basic`
+    # is stably green for a few runs. ctest_regex left unset (defaults to ".*")
+    # so all 52 rocRAND binaries run; the per-binary filter then selects only
+    # quick gtests within each. The min_gtests floor only requires that >=1
+    # gtest actually executed somewhere - tighten this once `quick` is stable.
+    quick:
+      min_gtests: 1
+      allow:
+      - "*basic_tests*"
+      - "*config_dispatch_tests.*"
+      - "*cpp_utils_tests.*"
+      - "*cpp_wrapper*"
+      - "*distributions/*"
+      - "*generate_host_test/*"
+      - "*generate_long_long_tests/*"
+      - "*generate_normal_tests/*"
+      - "*generate_uniform_tests/*"
+      - "*generator_type_tests.*"
+      - "*kernel_lfsr113*"
+      - "*kernel_lfsr113_poisson/*"
+      - "*kernel_mrg/*"
+      - "*kernel_mtgp32*"
+      - "*kernel_mtgp32_poisson/*"
+      - "*kernel_philox4x32_10*"
+      - "*kernel_philox4x32_10_poisson/*"
+      - "*kernel_scrambled_sobol32*"
+      - "*kernel_scrambled_sobol32_poisson/*"
+      - "*kernel_scrambled_sobol64*"
+      - "*kernel_scrambled_sobol64_poisson/*"
+      - "*kernel_sobol32*"
+      - "*kernel_sobol32_poisson/*"
+      - "*kernel_sobol64*"
+      - "*kernel_sobol64_poisson/*"
+      - "*kernel_threefry2x32_20*"
+      - "*kernel_threefry2x32_20_poisson/*"
+      - "*kernel_threefry2x64_20*"
+      - "*kernel_threefry2x64_20_poisson/*"
+      - "*kernel_threefry4x32_20*"
+      - "*kernel_threefry4x32_20_poisson/*"
+      - "*kernel_threefry4x64_20*"
+      - "*kernel_threefry4x64_20_poisson/*"
+      - "*kernel_xorwow*"
+      - "*kernel_xorwow_poisson/*"
+      - "*lfsr113_engine_api_tests.*"
+      - "*lfsr113_generator/*"
+      - "*lfsr113_generator_prng_tests/*"
+      - "*linkage_tests.*"
+      - "*log_normal_distribution_tests.*"
+      - "*log_normal_tests.*"
+      - "*mrg/*"
+      - "*mrg_generator_prng_tests.*"
+      - "*mrg_log_normal_distribution_tests/*"
+      - "*mrg_normal_distribution_tests/*"
+      - "*mrg_prng_engine_tests/*"
+      - "*mrg_uniform_distribution_tests/*"
+      - "*mtgp32_generator/*"
+      - "*normal_distribution_tests.*"
+      - "*philox4x32_10_generator/*"
+      - "*philox_prng_state_tests.*"
+      - "*poisson_distribution_tests/*"
+      - "*poisson_tests.*"
+      - "*rocrand_generate_tests.*"
+      - "*rocrand_hipgraph_generate_tests.*"
+      - "*sobol_log_normal_distribution_tests/*"
+      - "*sobol_normal_distribution_tests.*"
+      - "*sobol_qrng_tests/*"
+      - "*threefry2x32_20_generator/*"
+      - "*threefry2x64_20_generator/*"
+      - "*threefry4x32_20_generator/*"
+      - "*threefry4x64_20_generator/*"
+      - "*threefry_prng_state_tests.*"
+      - "*xorwow_engine_type_test.*"
+      - "*xorwow_generator/*"
+    # Run the entire rocRAND ctest set. Reserved for nightly once `quick` is
+    # green and the skip-list has matured.
+    full:
+      min_gtests: 1
+      allow:
+      - "*"
+  skip:
+    # HIP graphs are not modeled by the rocjitsu interposer yet.
+    - "*hipgraph*"
+    # mt19937 octo engine carries a very large state vector that exceeds the
+    # practical memory budget of the simulator's PDES.
+    - "*mt19937_octo*"
+    # Parity tests require cuRAND; irrelevant on AMD-only emulation.
+    - "*parity*curand*"
+    # Multi-MB host/device transfers exceed our initial PDES wall-time budget.
+    # Drop this once the runner is happy with smaller cases.
+    - "*Large*"
+    # rocrand basic create/destroy: a known-slow case from test_rocrand.py.
+    - "*basic_tests/rocrand_basic_tests.rocrand_create_destroy_generator_test/10*"
+
+# Placeholder for the PR-3 hipRAND integration. The hipRAND ctest suite is
+# small enough that the basic preset reuses everything; presets are kept
+# parallel to rocrand for consistency. ctest_dir / ctest_regex / min_gtests
+# values are best-guess placeholders that PR-3 must validate against an
+# actual hipRAND artifact layout before enabling this component in CI.
+hiprand:
+  ctest_dir: hipRAND
+  presets:
+    basic:
+      min_gtests: 1
+      allow:
+      - "*api_tests*"
+    quick:
+      min_gtests: 1
+      allow:
+      - "*"
+    full:
+      min_gtests: 1
+      allow:
+      - "*"
+  skip: []

--- a/build_tools/github_actions/test_executable_scripts/simulator_runner_filters.yaml
+++ b/build_tools/github_actions/test_executable_scripts/simulator_runner_filters.yaml
@@ -218,6 +218,12 @@ rocrand:
     - "*Large*"
     # rocrand basic create/destroy: a known-slow case from test_rocrand.py.
     - "*basic_tests/rocrand_basic_tests.rocrand_create_destroy_generator_test/10*"
+    # These two poisson/3 cases (lambda=100) never complete under the simulator
+    # and are the exact cases running when test_rocrand_kernel_philox4x32_10 and
+    # test_rocrand_kernel_xorwow each hit the 600s ctest cap (***Timeout),
+    # blowing the 60-min step budget. Every other poisson/3 generator completes.
+    - "*kernel_philox4x32_10_poisson*rocrand_poisson/3"
+    - "*kernel_xorwow_poisson*rocrand_poisson/3"
 
 # Placeholder for the PR-3 hipRAND integration. The hipRAND ctest suite is
 # small enough that the basic preset reuses everything; presets are kept

--- a/build_tools/github_actions/test_executable_scripts/simulator_runner_filters.yaml
+++ b/build_tools/github_actions/test_executable_scripts/simulator_runner_filters.yaml
@@ -159,6 +159,23 @@ rocrand:
         # have a run. Suite variants carry their own CMake-baked GTEST_FILTER, so
         # the component skip: list does not apply to them.
         - ctest_regex: "_(quick|ffm-quick)_suite$"
+          # Drop suite binaries that can't be reached via the gtest skip list
+          # (their CMake-baked GTEST_FILTER overrides ours). Observed in run
+          # 28621740886 / shard-2 (Rocjitsu_010_lnx_gfx94x_06):
+          #   cpp_basic          - cpp_basic_ffm-quick_suite has a 7200s ctest
+          #                        timeout and ate 2/3 of the 180-min budget.
+          #   host, cpp_wrapper  - 300s ctest timeouts.
+          #   generate (bare),
+          #   generate_normal,
+          #   generate_poisson,
+          #   generate_uniform   - SegFault under the simulator (generate_log_normal
+          #                        is kept: it passes ~268s).
+          #   hipgraphs          - HIP graphs not modeled by the interposer (SegFault).
+          #   kernel_philox4x32_10,
+          #   kernel_xorwow      - poisson high-lambda hangs (300s timeouts). The
+          #                        host philox_prng/xorwow_prng suites are kept.
+          #   mt19937_octo       - large state exceeds the PDES budget.
+          ctest_exclude_regex: "(cpp_basic|cpp_wrapper|_host_|hipgraphs|mt19937_octo|kernel_philox4x32_10|kernel_xorwow|generate_quick_suite|generate_ffm-quick_suite|generate_normal|generate_poisson|generate_uniform)"
           min_gtests: 1
     # Mirror of QUICK_TESTS in test_rocrand.py. Promoted in PR-2 once `basic`
     # is stably green for a few runs. ctest_regex left unset (defaults to ".*")

--- a/build_tools/github_actions/test_executable_scripts/simulator_runner_filters.yaml
+++ b/build_tools/github_actions/test_executable_scripts/simulator_runner_filters.yaml
@@ -135,6 +135,22 @@ rocrand:
         - "*"
       ctest_regex: "^test_rocrand_(basic|kernel_(lfsr113|mrg|mtgp32|philox4x32_10|scrambled_sobol32|scrambled_sobol64|sobol32|sobol64|threefry2x32_20|threefry2x64_20|threefry4x32_20|threefry4x64_20|xorwow))$"
       min_gtests: 50
+      # Per-shard scopes. Used only when the rocrand-simulator job runs with
+      # total_shards > 1 (see fetch_test_configurations.py); each shard is its
+      # own GHA job with its own timeout, so shards run disjoint, explicitly
+      # curated scopes instead of duplicating the whole preset. The number of
+      # entries here MUST equal total_shards. simulator_runner.py selects
+      # shards[SHARD_INDEX-1]; keys omitted by a shard inherit the preset-level
+      # values above (e.g. allow: ["*"]). When total_shards == 1 this block is
+      # ignored and the top-level scope runs unchanged.
+      shards:
+        # Shard 1: the current 14 base binaries (basic + 13 kernels).
+        - ctest_regex: "^test_rocrand_(basic|kernel_(lfsr113|mrg|mtgp32|philox4x32_10|scrambled_sobol32|scrambled_sobol64|sobol32|sobol64|threefry2x32_20|threefry2x64_20|threefry4x32_20|threefry4x64_20|xorwow))$"
+          min_gtests: 50
+        # Shard 2: TODO placeholder - small, green. Populate with expanded
+        # coverage (e.g. non-kernel base binaries) in a later change.
+        - ctest_regex: "^test_rocrand_basic$"
+          min_gtests: 3
     # Mirror of QUICK_TESTS in test_rocrand.py. Promoted in PR-2 once `basic`
     # is stably green for a few runs. ctest_regex left unset (defaults to ".*")
     # so all 52 rocRAND binaries run; the per-binary filter then selects only

--- a/build_tools/github_actions/test_executable_scripts/simulator_runner_filters.yaml
+++ b/build_tools/github_actions/test_executable_scripts/simulator_runner_filters.yaml
@@ -116,15 +116,24 @@ rocrand:
     # allow: ["*"] runs every (non-skipped) case in each in-scope binary, which
     # keeps Guard A happy (no in-scope binary can run zero gtests) without
     # hand-maintaining per-binary patterns; the component skip: list below still
-    # applies and gtest drops DISABLED_ cases by default. Estimated ~10-20 min
-    # vs the 60-min step budget, and the 600s per-test cap bounds any outlier.
-    # min_gtests: 50 is an intentionally loose first-measurement floor (well
-    # above a basic-only run of ~42); tighten it to the observed gtests_ran
-    # once this tier is stably green.
+    # applies and gtest drops DISABLED_ cases by default. min_gtests: 50 is an
+    # intentionally loose first-measurement floor (well above a basic-only run of
+    # ~42); tighten it to the observed gtests_ran once this tier is stably green.
+    #
+    # ctest_regex enumerates the 13 base kernel binaries explicitly (plus
+    # test_rocrand_basic) with a trailing '$' so it deliberately EXCLUDES the
+    # test_rocrand_kernel_*_quick_suite / _standard_suite / _ffm-quick_suite
+    # ctest entries. Those suite variants carry their own CMake-baked
+    # GTEST_FILTER that OVERRIDES the runner's exported GTEST_FILTER, so the
+    # component skip: list below cannot reach them - in run 28503430843 the
+    # philox _quick_suite/_standard_suite re-ran the poisson hangs and blew the
+    # 180-min step wall (only 24/53 entries completed). They are also pure
+    # duplicates of the base binaries' coverage, so dropping them removes no
+    # unique codegen paths. A plain "kernel_.*" would re-include them.
     extended:
       allow:
         - "*"
-      ctest_regex: "^test_rocrand_(basic|kernel_.*)$"
+      ctest_regex: "^test_rocrand_(basic|kernel_(lfsr113|mrg|mtgp32|philox4x32_10|scrambled_sobol32|scrambled_sobol64|sobol32|sobol64|threefry2x32_20|threefry2x64_20|threefry4x32_20|threefry4x64_20|xorwow))$"
       min_gtests: 50
     # Mirror of QUICK_TESTS in test_rocrand.py. Promoted in PR-2 once `basic`
     # is stably green for a few runs. ctest_regex left unset (defaults to ".*")
@@ -218,12 +227,15 @@ rocrand:
     - "*Large*"
     # rocrand basic create/destroy: a known-slow case from test_rocrand.py.
     - "*basic_tests/rocrand_basic_tests.rocrand_create_destroy_generator_test/10*"
-    # These two poisson/3 cases (lambda=100) never complete under the simulator
-    # and are the exact cases running when test_rocrand_kernel_philox4x32_10 and
-    # test_rocrand_kernel_xorwow each hit the 600s ctest cap (***Timeout),
-    # blowing the 60-min step budget. Every other poisson/3 generator completes.
-    - "*kernel_philox4x32_10_poisson*rocrand_poisson/3"
-    - "*kernel_xorwow_poisson*rocrand_poisson/3"
+    # The philox4x32_10 and xorwow poisson sweeps hang under the simulator on
+    # the high-lambda cases. Excluding only poisson/3 (lambda=100) was
+    # insufficient: run 28503430843 showed the hang simply moved to poisson/4
+    # (lambda=1234.5), so both binaries still hit the 600s ctest cap (***Timeout).
+    # Exclude the whole poisson family for these two generators (the low-lambda
+    # cases fail on accuracy anyway; the high-lambda ones never complete). Other
+    # generators' poisson sweeps complete and stay in scope.
+    - "*kernel_philox4x32_10_poisson*"
+    - "*kernel_xorwow_poisson*"
 
 # Placeholder for the PR-3 hipRAND integration. The hipRAND ctest suite is
 # small enough that the basic preset reuses everything; presets are kept

--- a/build_tools/github_actions/test_executable_scripts/test_hiprand.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiprand.py
@@ -13,12 +13,26 @@ THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 
 logging.basicConfig(level=logging.INFO)
 
+# When launched under the rocjitsu simulator, simulator_runner.py sets these
+# opt-in knobs. They are unset on the real-GPU lane, where behavior below is
+# unchanged. (hipRAND has no --repeat to suppress, so SIMULATOR_NO_RETRY is
+# not relevant here.)
+include_regex = os.getenv("SIMULATOR_CTEST_INCLUDE_REGEX")
+test_timeout = os.getenv("CTEST_TEST_TIMEOUT")
+
 cmd = [
     "ctest",
     "--test-dir",
     f"{THEROCK_BIN_DIR}/hipRAND",
     "--output-on-failure",
 ]
+# Narrow which ctest binaries run so the simulator does not walk the whole suite.
+if include_regex:
+    cmd += ["-R", include_regex]
+# Bound each test so a stall fails fast instead of eating the step budget.
+if test_timeout:
+    cmd += ["--timeout", test_timeout]
+
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")
 
 subprocess.run(

--- a/build_tools/github_actions/test_executable_scripts/test_rocrand.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocrand.py
@@ -82,20 +82,37 @@ QUICK_TESTS = [
     "-*basic_tests/rocrand_basic_tests.rocrand_create_destroy_generator_test/10*",
 ]
 
+# When launched under the rocjitsu simulator, simulator_runner.py sets these
+# opt-in knobs. They are unset on the real-GPU lane, where behavior below is
+# unchanged.
+in_simulator = bool(os.getenv("SIMULATOR_CTEST_DIR"))
+include_regex = os.getenv("SIMULATOR_CTEST_INCLUDE_REGEX")
+no_retry = os.getenv("SIMULATOR_NO_RETRY") == "1"
+test_timeout = os.getenv("CTEST_TEST_TIMEOUT")
+
 cmd = [
     "ctest",
     "--test-dir",
     f"{THEROCK_BIN_DIR}/rocRAND",
     "--output-on-failure",
-    "--repeat",
-    "until-pass:3",
 ]
+# Narrow which ctest binaries run (e.g. only test_rocrand_basic) so the
+# simulator does not walk the entire 200+ binary suite.
+if include_regex:
+    cmd += ["-R", include_regex]
+# Retrying is pointless under the deterministic simulator and only hides bugs.
+if not no_retry:
+    cmd += ["--repeat", "until-pass:3"]
+# Bound each test so a stall fails fast instead of eating the step budget.
+if test_timeout:
+    cmd += ["--timeout", test_timeout]
 
 # If quick tests are enabled, we run quick tests only.
-# Otherwise, we run the standard test suite.
+# Otherwise, we run the standard test suite. Under the simulator the runner has
+# already composed GTEST_FILTER, so do not clobber it here.
 environ_vars = os.environ.copy()
 test_type = os.getenv("TEST_TYPE", "standard")
-if test_type == "quick":
+if test_type == "quick" and not in_simulator:
     environ_vars["GTEST_FILTER"] = ":".join(QUICK_TESTS)
 
 logging.info(f"++ Exec [{THEROCK_DIR}]$ {shlex.join(cmd)}")

--- a/build_tools/github_actions/test_executable_scripts/test_rocrand.py
+++ b/build_tools/github_actions/test_executable_scripts/test_rocrand.py
@@ -87,6 +87,7 @@ QUICK_TESTS = [
 # unchanged.
 in_simulator = bool(os.getenv("SIMULATOR_CTEST_DIR"))
 include_regex = os.getenv("SIMULATOR_CTEST_INCLUDE_REGEX")
+exclude_regex = os.getenv("SIMULATOR_CTEST_EXCLUDE_REGEX")
 no_retry = os.getenv("SIMULATOR_NO_RETRY") == "1"
 test_timeout = os.getenv("CTEST_TEST_TIMEOUT")
 
@@ -100,6 +101,12 @@ cmd = [
 # simulator does not walk the entire 200+ binary suite.
 if include_regex:
     cmd += ["-R", include_regex]
+# Drop specific binaries from the include set (ctest -E). Needed for suite
+# variants whose CMake-baked GTEST_FILTER overrides the runner's filter, so they
+# cannot be reached via the gtest skip list (e.g. the cpp_basic suite with a
+# 7200s timeout, or the philox/xorwow poisson hangs).
+if exclude_regex:
+    cmd += ["-E", exclude_regex]
 # Retrying is pointless under the deterministic simulator and only hides bugs.
 if not no_retry:
     cmd += ["--repeat", "until-pass:3"]

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -131,8 +131,25 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         components = self._get_components()
 
         for job in components:
+            # Jobs that opt in via "shard_even_when_quick" (e.g. the CPU
+            # simulator, which runs its own preset regardless of TEST_TYPE) keep
+            # their configured shard count.
+            if job.get("shard_even_when_quick"):
+                continue
             self.assertEqual(job["total_shards"], 1)
             self.assertEqual(job["shard_arr"], [1])
+
+    def test_shard_even_when_quick_keeps_shards(self):
+        # The rocrand-simulator opts into sharding even under TEST_TYPE=quick.
+        os.environ["TEST_TYPE"] = "quick"
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        sim = next(j for j in components if j["job_name"] == "rocrand-simulator")
+        self.assertTrue(sim.get("shard_even_when_quick"))
+        self.assertEqual(sim["total_shards"], 2)
+        self.assertEqual(sim["shard_arr"], [1, 2])
 
     def test_platform_specific_shards(self):
         os.environ["PROJECTS_TO_TEST"] = "hipblaslt"

--- a/emulation/artifact-rocjitsu.toml
+++ b/emulation/artifact-rocjitsu.toml
@@ -3,10 +3,12 @@
 default_patterns = false
 include = [
   "lib/librocjitsu.so",
+  "lib/librocjitsu_kmd.so",
 ]
 [components.dbg."emulation/rocjitsu/stage"]
 [components.dev."emulation/rocjitsu/stage"]
 [components.run."emulation/rocjitsu/stage"]
 include = [
+  "bin/rocjitsu",
   "share/rocjitsu/**",
 ]


### PR DESCRIPTION
## Motivation

Port of the rocjitsu simulator testing work (branch users/kasaurov/test-rocjitsu-framework_10) squashed into a single commit on top of compiler/amd-staging.

- Add a rocrand-simulator CI job (CPU-only runner) in test_component.yml
- Add simulator_runner.py: launches rocRAND/hipRAND ctest under the rocjitsu CLI wrapper, with a family->config mapping covering all 5 arches and post-run coverage guards
- Add simulator_runner_filters.yaml presets (basic/smoke/extended/quick/ full) selecting which binaries/gtests run under the simulator
- Honor simulator ctest knobs (-R / --timeout / no-retry) in the rocrand and hiprand drivers so only the targeted binaries run and stalls fail fast
- Include the rocjitsu CLI and interposer artifacts in artifact-rocjitsu.toml

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
