### PR TITLE
fix(ci): Use dedicated directory for patched patchelf sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ sources/
 __pycache__
 /.ccache
 .cline_storage/
+/patchelf*
 
 # Patch control files.
 .*.smrev

--- a/dockerfiles/install_patchelf.sh
+++ b/dockerfiles/install_patchelf.sh
@@ -26,10 +26,10 @@ curl --silent --fail --show-error --location \
     "${SOURCE_URL}" \
     --output patchelf.tar.gz
 
-mkdir -p src
-tar -xzf patchelf.tar.gz --strip-components=1 -C src
+mkdir -p patchelf
+tar -xzf patchelf.tar.gz --strip-components=1 -C patchelf
 
-cd src
+cd patchelf
 BASE_VERSION="$(cat version)"
 LOCAL_VERSION="${BASE_VERSION}+therock.${SHORT_GIT_REF}"
 printf "%s\n" "${LOCAL_VERSION}" > version


### PR DESCRIPTION
## Summary

This updates `install_patchelf.sh` to extract patched patchelf sources into a dedicated top-level `patchelf/` directory instead of the generic `src/` directory.

Using `src/` is easy to confuse with project source trees when the helper is run manually or from different working directories. A dedicated `patchelf/` directory makes the generated checkout self-describing and reduces local workspace noise.

The generated patchelf artifacts are also ignored in `.gitignore`.

## Changes

- Extract `patchelf.tar.gz` into `patchelf/` instead of `src/`.
- Run the patchelf build from `patchelf/`.
- Ignore generated top-level patchelf artifacts.


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
