### PR TITLE
build(rocgdb): add -fstack-clash-protection to C and CXX flags

### DIFF
--- a/debug-tools/rocgdb/CMakeLists.txt
+++ b/debug-tools/rocgdb/CMakeLists.txt
@@ -127,9 +127,11 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   string(APPEND CUSTOM_CXX_FLAGS " -O0 -g3")
 endif()
 
-# Harden against stack clash attacks.
-string(APPEND CUSTOM_C_FLAGS " -fstack-clash-protection")
-string(APPEND CUSTOM_CXX_FLAGS " -fstack-clash-protection")
+# Harden against stack clash attacks (not supported on all platforms).
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  string(APPEND CUSTOM_C_FLAGS " -fstack-clash-protection")
+  string(APPEND CUSTOM_CXX_FLAGS " -fstack-clash-protection")
+endif()
 
 # Compiler commands to chain to autotools.
 set(CUSTOM_CC "${CMAKE_C_COMPILER}")

--- a/debug-tools/rocgdb/CMakeLists.txt
+++ b/debug-tools/rocgdb/CMakeLists.txt
@@ -127,6 +127,10 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   string(APPEND CUSTOM_CXX_FLAGS " -O0 -g3")
 endif()
 
+# Harden against stack clash attacks.
+string(APPEND CUSTOM_C_FLAGS " -fstack-clash-protection")
+string(APPEND CUSTOM_CXX_FLAGS " -fstack-clash-protection")
+
 # Compiler commands to chain to autotools.
 set(CUSTOM_CC "${CMAKE_C_COMPILER}")
 if(CMAKE_C_COMPILER_LAUNCHER)


### PR DESCRIPTION
## Summary

Appends `-fstack-clash-protection` to `CUSTOM_C_FLAGS` and `CUSTOM_CXX_FLAGS`
in the rocgdb CMake wrapper. This flag instructs the compiler to insert probes
when allocating large stack frames so that a stack-clash attack cannot silently
skip the guard page and corrupt adjacent memory. The flag is guarded behind a
`Linux` platform check as it is not supported on all platforms.

ISSUE ID: ROCM-26825

## Testing Summary

- Build/CI: the flag is appended before the autotools configure step, so a
  successful rocgdb build confirms it is accepted by the compiler.