### PR TITLE
feat(ci): add rocgdb submodule autobump

### DIFF
--- a/.github/workflows/bump_submodules.yml
+++ b/.github/workflows/bump_submodules.yml
@@ -15,6 +15,7 @@ on:
           - all
           - rocm-systems
           - rocm-libraries
+          - rocgdb
   schedule:
     - cron: "0 */12 * * *" # Runs every 12 hrs at 12AM and 12PM
   push:
@@ -23,6 +24,7 @@ on:
     paths:
       - rocm-systems
       - rocm-libraries
+      - debug-tools/rocgdb/source
 jobs:
   bump-submodules:
     runs-on: ubuntu-24.04
@@ -56,6 +58,15 @@ jobs:
           owner: "ROCm"
           repositories: "rocm-libraries,TheRock"
 
+      - name: Generate GitHub App token rocgdb
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: rocgdb-token
+        with:
+          app-id: ${{ secrets.ROCGDB_APP_ID }}
+          private-key: ${{ secrets.ROCGDB_PRIVATE_KEY }}
+          owner: "ROCm"
+          repositories: "rocgdb,TheRock"
+
       - name: Install prerequisites
         run: |
           pip install requests
@@ -67,7 +78,8 @@ jobs:
             --event_type "schedule" \
             --submodule "${{ github.event.inputs.submodule || 'all' }}" \
             --systems_token "${{ steps.systems-token.outputs.token }}" \
-            --libraries_token "${{ steps.librarian-token.outputs.token }}"
+            --libraries_token "${{ steps.librarian-token.outputs.token }}" \
+            --rocgdb_token "${{ steps.rocgdb-token.outputs.token }}"
 
       - name: Run push automation
         if: github.event_name == 'push'
@@ -77,4 +89,5 @@ jobs:
             --before "${{ github.event.before }}" \
             --after "${{ github.sha }}" \
             --systems_token "${{ steps.systems-token.outputs.token }}" \
-            --libraries_token "${{ steps.librarian-token.outputs.token }}"
+            --libraries_token "${{ steps.librarian-token.outputs.token }}" \
+            --rocgdb_token "${{ steps.rocgdb-token.outputs.token }}"

--- a/.github/workflows/bump_submodules.yml
+++ b/.github/workflows/bump_submodules.yml
@@ -47,7 +47,8 @@ jobs:
           app-id: ${{ secrets.ROCM_SYSTEMS_APP_ID }}
           private-key: ${{ secrets.ROCM_SYSTEMS_APP_PRIVATE_KEY }}
           owner: "ROCm"
-          repositories: "rocm-systems,TheRock"
+          # We will reuse the rocm-systems token for rocgdb for now.
+          repositories: "rocm-systems,rocgdb,TheRock"
 
       - name: Generate GitHub App token rocm-libraries
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -57,15 +58,6 @@ jobs:
           private-key: ${{ secrets.ROCM_LIBRARIES_APP_PRIVATE_KEY }}
           owner: "ROCm"
           repositories: "rocm-libraries,TheRock"
-
-      - name: Generate GitHub App token rocgdb
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: rocgdb-token
-        with:
-          app-id: ${{ secrets.ROCGDB_APP_ID }}
-          private-key: ${{ secrets.ROCGDB_PRIVATE_KEY }}
-          owner: "ROCm"
-          repositories: "rocgdb,TheRock"
 
       - name: Install prerequisites
         run: |
@@ -79,7 +71,7 @@ jobs:
             --submodule "${{ github.event.inputs.submodule || 'all' }}" \
             --systems_token "${{ steps.systems-token.outputs.token }}" \
             --libraries_token "${{ steps.librarian-token.outputs.token }}" \
-            --rocgdb_token "${{ steps.rocgdb-token.outputs.token }}"
+            --rocgdb_token "${{ steps.systems-token.outputs.token }}"
 
       - name: Run push automation
         if: github.event_name == 'push'
@@ -90,4 +82,4 @@ jobs:
             --after "${{ github.sha }}" \
             --systems_token "${{ steps.systems-token.outputs.token }}" \
             --libraries_token "${{ steps.librarian-token.outputs.token }}" \
-            --rocgdb_token "${{ steps.rocgdb-token.outputs.token }}"
+            --rocgdb_token "${{ steps.systems-token.outputs.token }}"

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -302,6 +302,11 @@ def create_therock_bump(submodule: str, token: str) -> None:
 
         current_sha = get_submodule_sha("HEAD", submodule)
 
+        if current_sha == latest:
+            print(f"[INFO] {submodule} is already at {latest[:7]}, nothing to bump")
+            os.chdir(original_cwd)
+            return
+
         # Fetch the exact target commit in the submodule. A plain depth-1 fetch
         # only retrieves the default branch tip, which misses commits that live
         # on a non-default branch (e.g. rocgdb's amd-staging-rocgdb-16).

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -49,7 +49,8 @@ SUBMODULE_CONFIG = {
         "repo": "ROCm/rocgdb",
         "files": [],
         "updater": "submodule-only",
-        "token_key": "rocgdb",
+        # We will reuse the rocm-systems token for now.
+        "token_key": "systems",
         "branch": "amd-staging-rocgdb-16",
     },
 }

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -267,6 +267,22 @@ def create_therock_bump(submodule: str, token: str) -> None:
     # Get latest SHA from upstream submodule repo
     latest = latest_commit(repo, token, branch)
 
+    # The submodule path may contain slashes (e.g. debug-tools/rocgdb/source);
+    # flatten it so the bump branch name is a single ref component.
+    branch_name = f"bump-{submodule.replace('/', '-')}-{latest[:7]}"
+
+    # Skip if a PR for this exact commit is already open.
+    open_prs = gh_api(
+        token,
+        f"repos/{THEROCK_REPO}/pulls?state=open&head=ROCm:{branch_name}",
+    )
+    if open_prs:
+        print(
+            f"[INFO] Bump PR for {branch_name} already open"
+            f" (#{open_prs[0]['number']}), skipping"
+        )
+        return
+
     # Use a temp directory for safe cloning
     with tempfile.TemporaryDirectory() as tmpdir:
         clone_dir = os.path.join(tmpdir, "TheRock")
@@ -276,9 +292,6 @@ def create_therock_bump(submodule: str, token: str) -> None:
         )
         os.chdir(clone_dir)
 
-        # The submodule path may contain slashes (e.g. debug-tools/rocgdb/source);
-        # flatten it so the bump branch name is a single ref component.
-        branch_name = f"bump-{submodule.replace('/', '-')}-{latest[:7]}"
         run(["git", "checkout", "-b", branch_name])
 
         # Initialize the submodule if needed

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -45,6 +45,13 @@ SUBMODULE_CONFIG = {
         "updater": "ci-env",
         "token_key": "libraries",
     },
+    "debug-tools/rocgdb/source": {
+        "repo": "ROCm/rocgdb",
+        "files": [],
+        "updater": "submodule-only",
+        "token_key": "rocgdb",
+        "branch": "amd-staging-rocgdb-16",
+    },
 }
 
 
@@ -92,9 +99,12 @@ def gh_api(
     return response.json()
 
 
-def latest_commit(repo: str, token: str) -> str:
-    """Return the SHA of the latest commit on the default branch of repo."""
-    data = gh_api(token, f"repos/{repo}/commits")
+def latest_commit(repo: str, token: str, branch: str | None = None) -> str:
+    """Return the SHA of the latest commit on the given branch, or the default branch."""
+    url = f"repos/{repo}/commits"
+    if branch:
+        url += f"?sha={branch}"
+    data = gh_api(token, url)
     return data[0]["sha"]
 
 
@@ -250,10 +260,11 @@ def create_therock_bump(submodule: str, token: str) -> None:
     """Create a bump PR for the given submodule in TheRock."""
     config = SUBMODULE_CONFIG[submodule]
     repo = config["repo"]
+    branch = config.get("branch")
 
     original_cwd = os.getcwd()
     # Get latest SHA from upstream submodule repo
-    latest = latest_commit(repo, token)
+    latest = latest_commit(repo, token, branch)
 
     # Use a temp directory for safe cloning
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -264,7 +275,9 @@ def create_therock_bump(submodule: str, token: str) -> None:
         )
         os.chdir(clone_dir)
 
-        branch_name = f"bump-{submodule}-{latest[:7]}"
+        # The submodule path may contain slashes (e.g. debug-tools/rocgdb/source);
+        # flatten it so the bump branch name is a single ref component.
+        branch_name = f"bump-{submodule.replace('/', '-')}-{latest[:7]}"
         run(["git", "checkout", "-b", branch_name])
 
         # Initialize the submodule if needed
@@ -275,9 +288,11 @@ def create_therock_bump(submodule: str, token: str) -> None:
 
         current_sha = get_submodule_sha("HEAD", submodule)
 
-        # Fetch latest commit in submodule
-        print(f"[INFO] Fetching latest commit for {submodule}")
-        run(["git", "-C", submodule, "fetch", "--depth=1", "origin"])
+        # Fetch the exact target commit in the submodule. A plain depth-1 fetch
+        # only retrieves the default branch tip, which misses commits that live
+        # on a non-default branch (e.g. rocgdb's amd-staging-rocgdb-16).
+        print(f"[INFO] Fetching {latest[:7]} for {submodule}")
+        run(["git", "-C", submodule, "fetch", "--depth=1", "origin", latest])
         run(["git", "-C", submodule, "checkout", latest])
 
         # Stage the submodule change
@@ -322,6 +337,8 @@ def handle_schedule(tokens: dict[str, str], submodule: str = "all") -> None:
         create_therock_bump("rocm-systems", tokens["systems"])
     if submodule in ("all", "rocm-libraries"):
         create_therock_bump("rocm-libraries", tokens["libraries"])
+    if submodule in ("all", "rocgdb"):
+        create_therock_bump("debug-tools/rocgdb/source", tokens["rocgdb"])
 
 
 def handle_push(before: str, after: str, tokens: dict[str, str]) -> None:
@@ -342,6 +359,13 @@ def handle_push(before: str, after: str, tokens: dict[str, str]) -> None:
     print(f"[INFO] Detected {changed} change: {old_sha[:7]} -> {after[:7]}")
 
     close_stale_prs(changed, old_sha, token)
+
+    # submodule-only entries (e.g. rocgdb) have no back-ref files to update in
+    # the upstream repo; closing stale bump PRs above is all the push handler
+    # needs to do for them.
+    if config.get("updater") == "submodule-only":
+        print(f"[INFO] {changed} uses submodule-only bumping, skipping ref update")
+        return
 
     # Update workflow YAML
     repo_name = config["repo"]
@@ -387,12 +411,15 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--event_type", required=True, choices=["schedule", "push"])
     parser.add_argument(
-        "--submodule", default="all", choices=["all", "rocm-systems", "rocm-libraries"]
+        "--submodule",
+        default="all",
+        choices=["all", "rocm-systems", "rocm-libraries", "rocgdb"],
     )
     parser.add_argument("--before")
     parser.add_argument("--after")
     parser.add_argument("--systems_token", required=True)
     parser.add_argument("--libraries_token", required=True)
+    parser.add_argument("--rocgdb_token", required=True)
     args = parser.parse_args()
 
     run(["git", "config", "--global", "user.name", BOT_NAME])
@@ -401,6 +428,7 @@ def main() -> None:
     tokens = {
         "systems": args.systems_token,
         "libraries": args.libraries_token,
+        "rocgdb": args.rocgdb_token,
     }
 
     if args.event_type == "schedule":

--- a/build_tools/github_actions/bump_automation.py
+++ b/build_tools/github_actions/bump_automation.py
@@ -7,9 +7,16 @@ import subprocess
 import tempfile
 import os
 from datetime import datetime, timezone
+from typing import Any
 import requests
 
 THEROCK_REPO = "ROCm/TheRock"
+THEROCK_MAIN_BRANCH = "main"
+
+BOT_NAME = "therockbot"
+BOT_EMAIL = "therockbot@amd.com"
+
+CI_LABEL = "ci:run-all-archs"
 
 ROCM_SYSTEMS_FILES = [
     ".github/workflows/therock-ci-linux.yml",
@@ -30,17 +37,23 @@ SUBMODULE_CONFIG = {
         "repo": "ROCm/rocm-systems",
         "files": ROCM_SYSTEMS_FILES,
         "updater": "ref",
+        "token_key": "systems",
     },
     "rocm-libraries": {
         "repo": "ROCm/rocm-libraries",
         "files": ROCM_LIBRARIES_FILES,
         "updater": "ci-env",
+        "token_key": "libraries",
     },
 }
 
 
-def run(cmd):
-    """Run a shell command"""
+def _clone_url(repo: str, token: str) -> str:
+    return f"https://x-access-token:{token}@github.com/{repo}.git"
+
+
+def run(cmd: list[str]) -> str:
+    """Run a shell command and return its stdout, raising on non-zero exit."""
     result = subprocess.run(cmd, capture_output=True, text=True)
     print(result.stdout)
     print(result.stderr)
@@ -49,18 +62,22 @@ def run(cmd):
     return result.stdout.strip()
 
 
-def get_submodule_sha(commit, path):
-    """Return SHA of submodule at path in given commit"""
+def get_submodule_sha(commit: str, path: str) -> str:
+    """Return SHA of submodule at path in given commit."""
     out = run(["git", "ls-tree", commit, path])
     return out.split()[2]
 
 
-def submodule_changed(before, after, path):
+def submodule_changed(before: str, after: str, path: str) -> bool:
+    """Return True if the submodule at path differs between two commits."""
     diff = run(["git", "diff", before, after, "--", path])
     return bool(diff.strip())
 
 
-def gh_api(token, endpoint, method="GET", data=None):
+def gh_api(
+    token: str, endpoint: str, method: str = "GET", data: dict | None = None
+) -> Any:
+    """Make a GitHub API request and return the parsed JSON response."""
     url = f"https://api.github.com/{endpoint}"
     headers = {
         "Authorization": f"Bearer {token}",
@@ -75,12 +92,13 @@ def gh_api(token, endpoint, method="GET", data=None):
     return response.json()
 
 
-def latest_commit(repo, token):
+def latest_commit(repo: str, token: str) -> str:
+    """Return the SHA of the latest commit on the default branch of repo."""
     data = gh_api(token, f"repos/{repo}/commits")
     return data[0]["sha"]
 
 
-def generate_pr_body(repo, base, head):
+def generate_pr_body(repo: str, base: str, head: str) -> str:
     base_url = f"https://github.com/{repo}/commit/{base}"
     head_url = f"https://github.com/{repo}/commit/{head}"
     compare_url = f"https://github.com/{repo}/compare/{base}...{head}"
@@ -91,7 +109,7 @@ See full comparison here: {compare_url}
 """
 
 
-def update_ref_in_file(file_path, new_sha):
+def update_ref_in_file(file_path: str, new_sha: str) -> None:
     """
     Update all ROCm/TheRock refs in a YAML file.
     Replaces existing 'ref:' after 'repository: "ROCm/TheRock"'.
@@ -147,7 +165,7 @@ def update_ref_in_file(file_path, new_sha):
     print(f"[INFO] Updated {file_path}")
 
 
-def update_ci_env_file(file_path, new_sha):
+def update_ci_env_file(file_path: str, new_sha: str) -> None:
     """Update the therock-ref value in a ci-env composite action file.
 
     Matches:
@@ -185,10 +203,10 @@ def update_ci_env_file(file_path, new_sha):
     print(f"[INFO] Updated {file_path}")
 
 
-def close_stale_prs(submodule, old_sha, systems_token):
-    """Close all open PRs on TheRock that originated from old submodule SHA"""
+def close_stale_prs(submodule: str, old_sha: str, token: str) -> None:
+    """Close all open PRs on TheRock that originated from old submodule SHA."""
     old_short = old_sha[:7]
-    prs = gh_api(systems_token, f"repos/{THEROCK_REPO}/pulls?state=open")
+    prs = gh_api(token, f"repos/{THEROCK_REPO}/pulls?state=open")
     for pr in prs:
         title = pr["title"].lower()
         if f"bump {submodule}" in title and f"from {old_short}" in title:
@@ -197,7 +215,7 @@ def close_stale_prs(submodule, old_sha, systems_token):
 
             # Add a comment to the PR being closed
             gh_api(
-                systems_token,
+                token,
                 f"repos/{THEROCK_REPO}/issues/{number}/comments",
                 method="POST",
                 data={"body": "Closing stale PR."},
@@ -205,16 +223,33 @@ def close_stale_prs(submodule, old_sha, systems_token):
 
             # Close the PR
             gh_api(
-                systems_token,
+                token,
                 f"repos/{THEROCK_REPO}/pulls/{number}",
                 method="PATCH",
                 data={"state": "closed"},
             )
 
 
-def create_therock_bump(submodule, token):
+def _git_commit(title: str) -> None:
+    """Create a git commit as the bot identity with the given title."""
+    run(
+        [
+            "git",
+            "-c",
+            f"user.name={BOT_NAME}",
+            "-c",
+            f"user.email={BOT_EMAIL}",
+            "commit",
+            "-m",
+            title,
+        ]
+    )
+
+
+def create_therock_bump(submodule: str, token: str) -> None:
     """Create a bump PR for the given submodule in TheRock."""
-    repo = SUBMODULE_CONFIG[submodule]["repo"]
+    config = SUBMODULE_CONFIG[submodule]
+    repo = config["repo"]
 
     original_cwd = os.getcwd()
     # Get latest SHA from upstream submodule repo
@@ -224,46 +259,34 @@ def create_therock_bump(submodule, token):
     with tempfile.TemporaryDirectory() as tmpdir:
         clone_dir = os.path.join(tmpdir, "TheRock")
         print(f"[INFO] Cloning TheRock into {clone_dir}")
-        clone_url = f"https://x-access-token:{token}@github.com/ROCm/TheRock.git"
-        run(["git", "clone", "--depth", "1", clone_url, clone_dir])
-
+        run(
+            ["git", "clone", "--depth", "1", _clone_url(THEROCK_REPO, token), clone_dir]
+        )
         os.chdir(clone_dir)
 
         branch_name = f"bump-{submodule}-{latest[:7]}"
         run(["git", "checkout", "-b", branch_name])
 
         # Initialize the submodule if needed
-        sub_path = submodule
-        if not os.path.exists(os.path.join(sub_path, ".git")):
-            run(["git", "submodule", "update", "--init", "--depth", "1", sub_path])
+        if not os.path.exists(os.path.join(submodule, ".git")):
+            run(["git", "submodule", "update", "--init", "--depth", "1", submodule])
         else:
-            print(f"[INFO] Submodule {sub_path} already initialized")
+            print(f"[INFO] Submodule {submodule} already initialized")
 
-        current_sha = get_submodule_sha("HEAD", sub_path)
+        current_sha = get_submodule_sha("HEAD", submodule)
 
         # Fetch latest commit in submodule
         print(f"[INFO] Fetching latest commit for {submodule}")
-        run(["git", "-C", sub_path, "fetch", "--depth=1", "origin"])
-        run(["git", "-C", sub_path, "checkout", latest])
+        run(["git", "-C", submodule, "fetch", "--depth=1", "origin"])
+        run(["git", "-C", submodule, "checkout", latest])
 
         # Stage the submodule change
-        run(["git", "add", sub_path])
+        run(["git", "add", submodule])
 
         # Commit and push
         title = f"Bump {submodule} from {current_sha[:7]} to {latest[:7]}"
         body = generate_pr_body(repo, current_sha, latest)
-        run(
-            [
-                "git",
-                "-c",
-                "user.name=therockbot",
-                "-c",
-                "user.email=therockbot@amd.com",
-                "commit",
-                "-m",
-                title,
-            ]
-        )
+        _git_commit(title)
         run(["git", "push", "origin", branch_name])
 
         # Create PR
@@ -271,7 +294,12 @@ def create_therock_bump(submodule, token):
             token,
             f"repos/{THEROCK_REPO}/pulls",
             method="POST",
-            data={"title": title, "head": branch_name, "base": "main", "body": body},
+            data={
+                "title": title,
+                "head": branch_name,
+                "base": THEROCK_MAIN_BRANCH,
+                "body": body,
+            },
         )
 
         try:
@@ -280,7 +308,7 @@ def create_therock_bump(submodule, token):
                 token,
                 f"repos/{THEROCK_REPO}/issues/{pr['number']}/labels",
                 method="POST",
-                data={"labels": ["ci:run-all-archs"]},
+                data={"labels": [CI_LABEL]},
             )
         except RuntimeError as e:
             print(f"[WARN] Failed to apply ci:run-all-archs to PR #{pr['number']}: {e}")
@@ -288,41 +316,39 @@ def create_therock_bump(submodule, token):
         os.chdir(original_cwd)
 
 
-def handle_schedule(systems_token, libraries_token, submodule="all"):
-    """Create bump PRs for the specified submodule(s)"""
+def handle_schedule(tokens: dict[str, str], submodule: str = "all") -> None:
+    """Create bump PRs for the specified submodule(s)."""
     if submodule in ("all", "rocm-systems"):
-        create_therock_bump("rocm-systems", systems_token)
+        create_therock_bump("rocm-systems", tokens["systems"])
     if submodule in ("all", "rocm-libraries"):
-        create_therock_bump("rocm-libraries", libraries_token)
+        create_therock_bump("rocm-libraries", tokens["libraries"])
 
 
-def handle_push(before, after, systems_token, libraries_token):
-    """Push event: update TheRock refs, close stale PRs, create next bump PR"""
+def handle_push(before: str, after: str, tokens: dict[str, str]) -> None:
+    """Push event: update TheRock refs, close stale PRs, create next bump PR."""
     changed = None
-    for m in SUBMODULE_CONFIG:
-        if submodule_changed(before, after, m):
-            changed = m
+    for path in SUBMODULE_CONFIG:
+        if submodule_changed(before, after, path):
+            changed = path
             break
     if not changed:
         print("[INFO] No monitored submodule changed")
         return
 
-    old_sha = get_submodule_sha(before, changed)
-    new_sha = get_submodule_sha(after, changed)
-
-    print(f"[INFO] Detected {changed} change: {old_sha[:7]} → {new_sha[:7]}")
-
-    close_stale_prs(changed, old_sha, systems_token)
-
-    # update workflow YAML
     config = SUBMODULE_CONFIG[changed]
+    token = tokens[config["token_key"]]
+    old_sha = get_submodule_sha(before, changed)
+
+    print(f"[INFO] Detected {changed} change: {old_sha[:7]} -> {after[:7]}")
+
+    close_stale_prs(changed, old_sha, token)
+
+    # Update workflow YAML
     repo_name = config["repo"]
-    token = systems_token if "rocm-systems" in repo_name else libraries_token
     branch = f"update-therock-{changed}-{after[:7]}"
-    clone_url = f"https://x-access-token:{token}@github.com/{repo_name}.git"
 
     with tempfile.TemporaryDirectory() as tmp:
-        run(["git", "clone", "--depth", "1", clone_url, tmp])
+        run(["git", "clone", "--depth", "1", _clone_url(repo_name, token), tmp])
         os.chdir(tmp)  # Change working directory to the cloned repo
 
         # Verify that the file exists before accessing
@@ -342,7 +368,7 @@ def handle_push(before, after, systems_token, libraries_token):
             updater(f, after)
 
         run(["git", "add"] + config["files"])
-        run(["git", "commit", "-m", f"Update TheRock ref to {after[:7]}"])
+        _git_commit(f"Update TheRock ref to {after[:7]}")
         run(["git", "push", "origin", branch])
         gh_api(
             token,
@@ -357,7 +383,7 @@ def handle_push(before, after, systems_token, libraries_token):
         )
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--event_type", required=True, choices=["schedule", "push"])
     parser.add_argument(
@@ -369,18 +395,18 @@ def main():
     parser.add_argument("--libraries_token", required=True)
     args = parser.parse_args()
 
-    run(["git", "config", "--global", "user.name", "therockbot"])
-    run(["git", "config", "--global", "user.email", "therockbot@amd.com"])
+    run(["git", "config", "--global", "user.name", BOT_NAME])
+    run(["git", "config", "--global", "user.email", BOT_EMAIL])
+
+    tokens = {
+        "systems": args.systems_token,
+        "libraries": args.libraries_token,
+    }
 
     if args.event_type == "schedule":
-        handle_schedule(args.systems_token, args.libraries_token, args.submodule)
+        handle_schedule(tokens, args.submodule)
     elif args.event_type == "push":
-        handle_push(
-            args.before,
-            args.after,
-            args.systems_token,
-            args.libraries_token,
-        )
+        handle_push(args.before, args.after, tokens)
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/tests/bump_automation_test.py
+++ b/build_tools/github_actions/tests/bump_automation_test.py
@@ -293,7 +293,11 @@ class HandlePushTest(unittest.TestCase):
                     with patch(
                         "bump_automation.tempfile.TemporaryDirectory"
                     ) as mock_tmp:
-                        handle_push("before", "after", {"rocgdb": "tok"})
+                        handle_push(
+                            "before",
+                            "after",
+                            {"systems": "tok", "libraries": "tok", "rocgdb": "tok"},
+                        )
 
         mock_close.assert_called_once()
         # submodule-only entries have no upstream ref files, so the handler must

--- a/build_tools/github_actions/tests/bump_automation_test.py
+++ b/build_tools/github_actions/tests/bump_automation_test.py
@@ -331,6 +331,40 @@ class CreateTheRockBumpTest(unittest.TestCase):
         self.assertIn("pulls?state=open", endpoint)
         self.assertIn("bump-rocm-systems-abc1234", endpoint)
 
+    def test_skips_when_submodule_already_at_latest(self):
+        """create_therock_bump must bail out without cloning when the submodule
+        is already pinned to the latest upstream commit."""
+        latest_sha = "abc1234567890"
+        api_responses = [
+            [],  # open-PR check returns nothing
+        ]
+
+        def _gh_api_side_effect(*args, **kwargs):
+            return api_responses.pop(0) if api_responses else {}
+
+        with patch("bump_automation.latest_commit", return_value=latest_sha):
+            with patch("bump_automation.gh_api", side_effect=_gh_api_side_effect):
+                with patch("bump_automation.run") as mock_run:
+                    with patch("bump_automation.os.chdir"):
+                        with patch("bump_automation.os.path.exists", return_value=True):
+                            with patch(
+                                "bump_automation.get_submodule_sha",
+                                return_value=latest_sha,
+                            ):
+                                with patch(
+                                    "bump_automation.tempfile.TemporaryDirectory"
+                                ) as mock_tmp:
+                                    create_therock_bump("rocm-systems", "token")
+
+        # The clone is created before we detect the no-op, so TemporaryDirectory
+        # will have been called. What must NOT happen is any git commit or push.
+        git_calls = [c for c in mock_run.call_args_list if "commit" in c.args[0]]
+        self.assertEqual(
+            git_calls, [], "git commit must not run when already at latest"
+        )
+        push_calls = [c for c in mock_run.call_args_list if "push" in c.args[0]]
+        self.assertEqual(push_calls, [], "git push must not run when already at latest")
+
     def test_proceeds_when_no_open_pr(self):
         """create_therock_bump must proceed to clone when no open PR exists."""
         # First gh_api call is the open-PR check (returns []); subsequent calls

--- a/build_tools/github_actions/tests/bump_automation_test.py
+++ b/build_tools/github_actions/tests/bump_automation_test.py
@@ -297,10 +297,16 @@ class HandlePushTest(unittest.TestCase):
                         handle_push(
                             "before",
                             "after",
-                            {"systems": "tok", "libraries": "tok", "rocgdb": "tok"},
+                            {
+                                "systems": "systems-token",
+                                "libraries": "libraries-token",
+                                "rocgdb": "rocgdb-token",
+                            },
                         )
 
         mock_close.assert_called_once()
+        # rocgdb reuses the systems token, so close_stale_prs must receive it.
+        self.assertEqual(mock_close.call_args.args[2], "systems-token")
         # submodule-only entries have no upstream ref files, so the handler must
         # bail out before cloning the upstream repo.
         mock_tmp.assert_not_called()
@@ -354,6 +360,72 @@ class CreateTheRockBumpTest(unittest.TestCase):
 
         # Must have made at least the open-PR check + PR creation calls.
         self.assertGreaterEqual(mock_api.call_count, 2)
+
+
+class HandleScheduleTest(unittest.TestCase):
+    def test_rocgdb_maps_to_correct_submodule_and_token(self):
+        """handle_schedule('rocgdb') must call create_therock_bump with
+        'debug-tools/rocgdb/source' and tokens['rocgdb'], not any other key."""
+        tokens = {
+            "systems": "systems-token",
+            "libraries": "libraries-token",
+            "rocgdb": "rocgdb-token",
+        }
+        with patch("bump_automation.create_therock_bump") as mock_bump:
+            from bump_automation import handle_schedule
+
+            handle_schedule(tokens, "rocgdb")
+
+        mock_bump.assert_called_once_with("debug-tools/rocgdb/source", "rocgdb-token")
+
+    def test_rocgdb_does_not_invoke_other_submodules(self):
+        tokens = {
+            "systems": "systems-token",
+            "libraries": "libraries-token",
+            "rocgdb": "rocgdb-token",
+        }
+        with patch("bump_automation.create_therock_bump") as mock_bump:
+            from bump_automation import handle_schedule
+
+            handle_schedule(tokens, "rocgdb")
+
+        called_submodules = [c.args[0] for c in mock_bump.call_args_list]
+        self.assertNotIn("rocm-systems", called_submodules)
+        self.assertNotIn("rocm-libraries", called_submodules)
+
+
+class CreateTheRockBumpRocgdbConfigTest(unittest.TestCase):
+    def test_reads_repo_and_branch_from_submodule_config(self):
+        """create_therock_bump('debug-tools/rocgdb/source') must derive repo and
+        branch from SUBMODULE_CONFIG, not hard-code them."""
+        api_responses = [[], {"number": 1}, {}]
+
+        def _gh_api_side_effect(*args, **kwargs):
+            return api_responses.pop(0) if api_responses else {}
+
+        with patch(
+            "bump_automation.latest_commit", return_value="abc1234567890"
+        ) as mock_latest:
+            with patch("bump_automation.gh_api", side_effect=_gh_api_side_effect):
+                with patch("bump_automation.run"):
+                    with patch("bump_automation.os.chdir"):
+                        with patch("bump_automation.os.path.exists", return_value=True):
+                            with patch(
+                                "bump_automation.get_submodule_sha",
+                                return_value="old1234",
+                            ):
+                                with patch(
+                                    "bump_automation.generate_pr_body",
+                                    return_value="body",
+                                ):
+                                    with patch("bump_automation._git_commit"):
+                                        create_therock_bump(
+                                            "debug-tools/rocgdb/source", "token"
+                                        )
+
+        mock_latest.assert_called_once_with(
+            "ROCm/rocgdb", "token", "amd-staging-rocgdb-16"
+        )
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/tests/bump_automation_test.py
+++ b/build_tools/github_actions/tests/bump_automation_test.py
@@ -1,0 +1,305 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import os
+from pathlib import Path
+import sys
+import tempfile
+import textwrap
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+from bump_automation import (
+    _clone_url,
+    close_stale_prs,
+    generate_pr_body,
+    get_submodule_sha,
+    handle_push,
+    latest_commit,
+    submodule_changed,
+    update_ci_env_file,
+    update_ref_in_file,
+)
+
+
+class CloneUrlTest(unittest.TestCase):
+    def test_formats_url_with_token(self):
+        url = _clone_url("ROCm/TheRock", "mytoken")
+        self.assertEqual(
+            url, "https://x-access-token:mytoken@github.com/ROCm/TheRock.git"
+        )
+
+    def test_formats_url_with_different_repo(self):
+        url = _clone_url("ROCm/rocgdb", "tok123")
+        self.assertEqual(
+            url, "https://x-access-token:tok123@github.com/ROCm/rocgdb.git"
+        )
+
+
+class GeneratePrBodyTest(unittest.TestCase):
+    def test_contains_repo_links(self):
+        body = generate_pr_body("ROCm/rocgdb", "aabbcc1", "ddeeff2")
+        self.assertIn("ROCm/rocgdb", body)
+        self.assertIn("aabbcc1", body)
+        self.assertIn("ddeeff2", body)
+
+    def test_contains_compare_url(self):
+        body = generate_pr_body("ROCm/rocgdb", "aabbcc1", "ddeeff2")
+        self.assertIn("compare/aabbcc1...ddeeff2", body)
+
+
+class GetSubmoduleShaTest(unittest.TestCase):
+    def test_parses_sha_from_ls_tree_output(self):
+        ls_tree_output = "160000 commit abc123def456  debug-tools/rocgdb/source"
+        with patch("bump_automation.run", return_value=ls_tree_output):
+            sha = get_submodule_sha("HEAD", "debug-tools/rocgdb/source")
+        self.assertEqual(sha, "abc123def456")
+
+
+class LatestCommitTest(unittest.TestCase):
+    def test_queries_default_branch_when_no_branch(self):
+        with patch(
+            "bump_automation.gh_api", return_value=[{"sha": "deadbeef"}]
+        ) as mock_api:
+            sha = latest_commit("ROCm/rocm-systems", "token")
+        self.assertEqual(sha, "deadbeef")
+        self.assertEqual(mock_api.call_args.args[1], "repos/ROCm/rocm-systems/commits")
+
+    def test_queries_specific_branch_when_provided(self):
+        with patch(
+            "bump_automation.gh_api", return_value=[{"sha": "cafef00d"}]
+        ) as mock_api:
+            sha = latest_commit("ROCm/rocgdb", "token", "amd-staging-rocgdb-16")
+        self.assertEqual(sha, "cafef00d")
+        self.assertEqual(
+            mock_api.call_args.args[1],
+            "repos/ROCm/rocgdb/commits?sha=amd-staging-rocgdb-16",
+        )
+
+
+class SubmoduleChangedTest(unittest.TestCase):
+    def test_returns_true_when_diff_nonempty(self):
+        with patch("bump_automation.run", return_value="some diff output"):
+            self.assertTrue(submodule_changed("abc", "def", "rocm-systems"))
+
+    def test_returns_false_when_diff_empty(self):
+        with patch("bump_automation.run", return_value=""):
+            self.assertFalse(submodule_changed("abc", "def", "rocm-systems"))
+
+    def test_returns_false_when_diff_whitespace_only(self):
+        with patch("bump_automation.run", return_value="   \n  "):
+            self.assertFalse(submodule_changed("abc", "def", "rocm-systems"))
+
+
+class UpdateRefInFileTest(unittest.TestCase):
+    def _run(self, content: str) -> str:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(content)
+            path = f.name
+        try:
+            update_ref_in_file(path, "newsha1234567")
+            return Path(path).read_text()
+        finally:
+            os.unlink(path)
+
+    def test_updates_ref_line(self):
+        content = textwrap.dedent(
+            """\
+            uses: actions/checkout@v3
+            with:
+              repository: "ROCm/TheRock"
+              ref: oldsha1234567 # 2024-01-01 commit
+        """
+        )
+        result = self._run(content)
+        self.assertIn("ref: newsha1234567", result)
+        self.assertNotIn("oldsha1234567", result)
+
+    def test_preserves_other_lines(self):
+        content = textwrap.dedent(
+            """\
+            uses: actions/checkout@v3
+            with:
+              repository: "ROCm/TheRock"
+              ref: oldsha1234567
+            other: value
+        """
+        )
+        result = self._run(content)
+        self.assertIn("uses: actions/checkout@v3", result)
+        self.assertIn("other: value", result)
+
+    def test_handles_path_line_between_repository_and_ref(self):
+        content = textwrap.dedent(
+            """\
+            with:
+              repository: "ROCm/TheRock"
+              path: "TheRock"
+              ref: oldsha1234567
+        """
+        )
+        result = self._run(content)
+        self.assertIn('path: "TheRock"', result)
+        self.assertIn("ref: newsha1234567", result)
+
+    def test_no_change_when_no_matching_repository(self):
+        content = textwrap.dedent(
+            """\
+            uses: actions/checkout@v3
+            with:
+              repository: "ROCm/SomeOtherRepo"
+              ref: oldsha1234567
+        """
+        )
+        result = self._run(content)
+        self.assertIn("oldsha1234567", result)
+
+    def test_updates_multiple_occurrences(self):
+        content = textwrap.dedent(
+            """\
+            - uses: actions/checkout@v3
+              with:
+                repository: "ROCm/TheRock"
+                ref: oldsha0000001
+            - uses: actions/checkout@v3
+              with:
+                repository: "ROCm/TheRock"
+                ref: oldsha0000002
+        """
+        )
+        result = self._run(content)
+        self.assertEqual(result.count("ref: newsha1234567"), 2)
+        self.assertNotIn("oldsha0000001", result)
+        self.assertNotIn("oldsha0000002", result)
+
+
+class UpdateCiEnvFileTest(unittest.TestCase):
+    def _run(self, content: str) -> str:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(content)
+            path = f.name
+        try:
+            update_ci_env_file(path, "newsha1234567")
+            return Path(path).read_text()
+        finally:
+            os.unlink(path)
+
+    def test_updates_value_under_therock_ref(self):
+        content = textwrap.dedent(
+            """\
+            outputs:
+              therock-ref:
+                description: "TheRock commit ref"
+                value: "oldsha1234567" # 2024-01-01 commit
+        """
+        )
+        result = self._run(content)
+        self.assertIn('"newsha1234567"', result)
+        self.assertNotIn("oldsha1234567", result)
+
+    def test_preserves_description_line(self):
+        content = textwrap.dedent(
+            """\
+            outputs:
+              therock-ref:
+                description: "TheRock commit ref"
+                value: "oldsha1234567"
+        """
+        )
+        result = self._run(content)
+        self.assertIn('description: "TheRock commit ref"', result)
+
+    def test_preserves_other_outputs(self):
+        content = textwrap.dedent(
+            """\
+            outputs:
+              therock-ref:
+                description: "TheRock commit ref"
+                value: "oldsha1234567"
+              other-output:
+                value: "unchanged"
+        """
+        )
+        result = self._run(content)
+        self.assertIn('"newsha1234567"', result)
+        self.assertIn('"unchanged"', result)
+
+    def test_no_change_when_no_therock_ref(self):
+        content = textwrap.dedent(
+            """\
+            outputs:
+              some-other-ref:
+                value: "oldsha1234567"
+        """
+        )
+        result = self._run(content)
+        self.assertIn("oldsha1234567", result)
+
+
+class CloseStalePrsTest(unittest.TestCase):
+    def _make_pr(self, number: int, title: str) -> dict:
+        return {"number": number, "title": title}
+
+    def test_closes_matching_pr(self):
+        prs = [self._make_pr(42, "Bump rocm-systems from abc1234 to xyz5678")]
+        with patch("bump_automation.gh_api", return_value=prs) as mock_api:
+            close_stale_prs("rocm-systems", "abc1234567890", "token")
+
+        patch_calls = [
+            c for c in mock_api.call_args_list if c.kwargs.get("method") == "PATCH"
+        ]
+        self.assertEqual(len(patch_calls), 1)
+        self.assertIn("pulls/42", patch_calls[0].args[1])
+        self.assertEqual(patch_calls[0].kwargs["data"]["state"], "closed")
+
+    def test_skips_non_matching_pr(self):
+        prs = [self._make_pr(99, "Bump rocm-libraries from def9876 to uvw5432")]
+        with patch("bump_automation.gh_api", return_value=prs) as mock_api:
+            close_stale_prs("rocm-systems", "abc1234567890", "token")
+
+        patch_calls = [
+            c for c in mock_api.call_args_list if c.kwargs.get("method") == "PATCH"
+        ]
+        self.assertEqual(len(patch_calls), 0)
+
+    def test_posts_comment_before_closing(self):
+        prs = [self._make_pr(42, "Bump rocm-systems from abc1234 to xyz5678")]
+        with patch("bump_automation.gh_api", return_value=prs) as mock_api:
+            close_stale_prs("rocm-systems", "abc1234567890", "token")
+
+        post_calls = [
+            c for c in mock_api.call_args_list if c.kwargs.get("method") == "POST"
+        ]
+        self.assertTrue(any("comments" in c.args[1] for c in post_calls))
+
+
+class HandlePushTest(unittest.TestCase):
+    def test_noop_when_no_submodule_changed(self):
+        with patch("bump_automation.submodule_changed", return_value=False):
+            with patch("bump_automation.get_submodule_sha") as mock_sha:
+                handle_push("before", "after", {"systems": "t"})
+        mock_sha.assert_not_called()
+
+    def test_submodule_only_closes_stale_prs_then_returns(self):
+        def changed(before, after, path):
+            return path == "debug-tools/rocgdb/source"
+
+        with patch("bump_automation.submodule_changed", side_effect=changed):
+            with patch(
+                "bump_automation.get_submodule_sha", return_value="oldsha1234567"
+            ):
+                with patch("bump_automation.close_stale_prs") as mock_close:
+                    with patch(
+                        "bump_automation.tempfile.TemporaryDirectory"
+                    ) as mock_tmp:
+                        handle_push("before", "after", {"rocgdb": "tok"})
+
+        mock_close.assert_called_once()
+        # submodule-only entries have no upstream ref files, so the handler must
+        # bail out before cloning the upstream repo.
+        mock_tmp.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/github_actions/tests/bump_automation_test.py
+++ b/build_tools/github_actions/tests/bump_automation_test.py
@@ -13,6 +13,7 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 from bump_automation import (
     _clone_url,
     close_stale_prs,
+    create_therock_bump,
     generate_pr_body,
     get_submodule_sha,
     handle_push,
@@ -303,6 +304,56 @@ class HandlePushTest(unittest.TestCase):
         # submodule-only entries have no upstream ref files, so the handler must
         # bail out before cloning the upstream repo.
         mock_tmp.assert_not_called()
+
+
+class CreateTheRockBumpTest(unittest.TestCase):
+    def test_skips_when_pr_already_open(self):
+        """create_therock_bump must bail out without cloning when an open PR
+        already targets the exact bump branch for the latest commit."""
+        with patch("bump_automation.latest_commit", return_value="abc1234567890"):
+            with patch(
+                "bump_automation.gh_api",
+                return_value=[{"number": 99}],
+            ) as mock_api:
+                with patch("bump_automation.tempfile.TemporaryDirectory") as mock_tmp:
+                    create_therock_bump("rocm-systems", "token")
+
+        mock_tmp.assert_not_called()
+        # Only the open-PR check should have hit the API.
+        self.assertEqual(mock_api.call_count, 1)
+        endpoint = mock_api.call_args.args[1]
+        self.assertIn("pulls?state=open", endpoint)
+        self.assertIn("bump-rocm-systems-abc1234", endpoint)
+
+    def test_proceeds_when_no_open_pr(self):
+        """create_therock_bump must proceed to clone when no open PR exists."""
+        # First gh_api call is the open-PR check (returns []); subsequent calls
+        # are PR creation (returns a PR dict) and label addition (ignored).
+        api_responses = [[], {"number": 1}, {}]
+
+        def _gh_api_side_effect(*args, **kwargs):
+            return api_responses.pop(0) if api_responses else {}
+
+        with patch("bump_automation.latest_commit", return_value="abc1234567890"):
+            with patch(
+                "bump_automation.gh_api", side_effect=_gh_api_side_effect
+            ) as mock_api:
+                with patch("bump_automation.run"):
+                    with patch("bump_automation.os.chdir"):
+                        with patch("bump_automation.os.path.exists", return_value=True):
+                            with patch(
+                                "bump_automation.get_submodule_sha",
+                                return_value="old1234",
+                            ):
+                                with patch(
+                                    "bump_automation.generate_pr_body",
+                                    return_value="body",
+                                ):
+                                    with patch("bump_automation._git_commit"):
+                                        create_therock_bump("rocm-systems", "token")
+
+        # Must have made at least the open-PR check + PR creation calls.
+        self.assertGreaterEqual(mock_api.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds automated submodule bumping for \`debug-tools/rocgdb/source\`, matching how \`rocm-systems\` and \`rocm-libraries\` already work: the schedule job polls ROCm/rocgdb every 12 hours and opens a fresh PR for each newer commit. rocgdb tracks the \`amd-staging-rocgdb-16\` branch rather than the default branch.

Five commits:

1. **refactor** — clean up \`bump_automation.py\` (constants, helpers, type hints); no behavior change.
2. **feat** — add rocgdb to the existing bump path, with branch-aware polling and a push handler that skips the upstream ref-update step it doesn't need.
3. **test** — unit tests for \`bump_automation.py\`.
4. **fix** — reuse the rocm-systems token for rocgdb until a dedicated GitHub App is provisioned.
5. **fix** — skip bump PR creation when one already exists for the same commit: \`create_therock_bump\` now checks for an open PR on the exact bump branch before cloning TheRock, preventing duplicate PRs when the scheduler fires multiple times between merges.

JIRA: N/A