### PR TITLE
JIRA ID : ROCM-25931

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -152,6 +152,8 @@ def setup_env(env):
 
 
 def execute_tests(env):
+    # Allow for more time in ASAN mode to run the tests.
+    timeout = 1500 if is_asan() else 600
     cmd = [
         "ctest",
         "--tests-information",
@@ -160,7 +162,7 @@ def execute_tests(env):
         CATCH_TESTS_PATH,
         "--output-on-failure",
         "--timeout",
-        "1500"
+        f"{timeout}",
     ]
 
     # If quick tests are enabled, run only the smoke test subset

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -159,6 +159,8 @@ def execute_tests(env):
         "--test-dir",
         CATCH_TESTS_PATH,
         "--output-on-failure",
+        "--timeout",
+        "1500"
     ]
 
     # If quick tests are enabled, run only the smoke test subset


### PR DESCRIPTION
## Motivation

Running `build_tools/github_actions/test_executable_scripts/test_hiptests.py` does not pass a timeout to ctest. This causes tests to hang permanently which prevents the full test suite from finishing in a reasonable time when there are hangs.

## Technical Details

Pass `--timeout` explicitly to the `ctest` invocation in `execute_tests()` (`build_tools/github_actions/test_executable_scripts/test_hiptests.py`), using more headroom for ASAN builds, which run significantly slower

This restores per-test timeout behavior that was removed in https://github.com/ROCm/TheRock/pull/4905 (which had left only the job-level workflow timeout as a guard).

## Test Plan

Tested the new script locally.

## Test Result

Timeout is added to the script when run locally.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
