### PR TITLE
test(ci): run rocsparse tests with 3 shards

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -355,16 +355,16 @@ test_matrix = {
     "rocsparse": {
         "job_name": "rocsparse",
         "fetch_artifact_args": "--blas --tests",
-        # rocsparse runs as a single shard for now, so the full suite executes in
-        # one process and needs a generous timeout. This will be reduced soon once
-        # rocsparse moves to multi-shard gtest sharding (pending the tolerance fix
-        # in ROCm/rocm-libraries#8713).
-        "timeout_minutes": 240,
+        # rocsparse now uses 3-way gtest sharding, enabled once the tolerance fix
+        # in ROCm/rocm-libraries#8713 landed in TheRock. The full suite is ~240 min
+        # single-shard; split across 3 shards that is ~80 min per shard, and 90 min
+        # leaves headroom.
+        "timeout_minutes": 90,
         "test_script": f"python {_get_script_path('test_runner.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
-            "linux": 1,
-            "windows": 1,
+            "linux": 3,
+            "windows": 3,
         },
     },
     "hipsparselt": {


### PR DESCRIPTION
## Summary

Enable **3-way gtest sharding** for the `rocsparse` test job (Linux and Windows)
in `build_tools/github_actions/fetch_test_configurations.py`, replacing the
previous single-shard configuration.

## Why now

`rocsparse` was intentionally kept at a single shard because a handful of
`nightly` configs had overly strict f32 tolerances that produced spurious
`near_check` failures under sharded/parallel runs. That tolerance fix,
ROCm/rocm-libraries#8713, has now landed in TheRock (first included in the
`rocm-libraries` bump ROCm/TheRock#6247), so `rocsparse` can safely shard.

## Changes

- `rocsparse.total_shards_dict`: `linux` and `windows` `1 -> 3`.
- `rocsparse.timeout_minutes`: `240 -> 90` (the single-shard full suite is
  ~240 min; split across 3 shards is ~80 min/shard, and 90 min leaves headroom).
- Updated the accompanying comment.

## Validation

Needs the `rocsparse` test job to run (label `test:rocsparse` +
`ci:run-multi-arch`) to confirm the three shards balance and stay within the new
per-shard timeout.

JIRA ID: ROCM-26543