### PR TITLE
feat(jax): Add timeout for JAX Tests

### DIFF
--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -130,6 +130,7 @@ jobs:
   test_jax_wheels:
     name: Test JAX Wheels | Python ${{ inputs.python_version }}
     runs-on: ${{ inputs.test_runs_on }}
+    timeout-minutes: 120
 
     container:
       image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26
@@ -252,6 +253,7 @@ jobs:
           fi
 
       - name: Run JAX tests
+        timeout-minutes: 60
         env:
           # Avoid large upfront GPU memory reservation.
           XLA_PYTHON_CLIENT_PREALLOCATE: "false"


### PR DESCRIPTION
## Motivation
Motivation is from ISSUE ID: https://github.com/ROCm/TheRock/issues/6301
Prevent the JAX wheel test workflow from running indefinitely if a test hangs or the workflow stalls. Adding explicit timeouts helps free GPU runners sooner and improves CI resource utilization.

## Technical Details

- Add a `timeout-minutes: 120` job-level timeout to the `test_jax_wheels` job.
- Add a `timeout-minutes: 60` step-level timeout to the `Run JAX tests` step.
- No changes to the workflow logic or test execution under normal conditions.

## Test Plan

- Validate the workflow YAML syntax.
- Verify that the workflow executes normally when tests complete within the configured timeouts.
- Confirm that the job and test step are terminated if the configured timeout is exceeded.

## Test Result

- Workflow syntax validated.

## Submission Checklist

- [x] Looked over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.