### PR TITLE
Add the JAX version to the test job names

### DIFF
--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -128,7 +128,7 @@ permissions:
 
 jobs:
   test_jax_wheels:
-    name: Test JAX Wheels | Python ${{ inputs.python_version }}
+    name: Test JAX Wheels | Python ${{ inputs.python_version }} | JAX ${{ inputs.jax_version }}
     runs-on: ${{ inputs.test_runs_on }}
     timeout-minutes: 120
 

--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -128,7 +128,7 @@ permissions:
 
 jobs:
   test_jax_wheels:
-    name: Test JAX Wheels | Python ${{ inputs.python_version }} | JAX ${{ inputs.jax_version }}
+    name: Test JAX Wheels | Python ${{ inputs.python_version }} | JAX ${{ inputs.jax_ref }}
     runs-on: ${{ inputs.test_runs_on }}
     timeout-minutes: 120
 

--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -128,7 +128,7 @@ permissions:
 
 jobs:
   test_jax_wheels:
-    name: Test JAX Wheels | Python ${{ inputs.python_version }} | JAX ${{ inputs.jax_ref }}
+    name: Test JAX | ${{ inputs.jax_ref }} | Python ${{ inputs.python_version }} | ${{ inputs.test_amdgpu_family }}
     runs-on: ${{ inputs.test_runs_on }}
     timeout-minutes: 120
 


### PR DESCRIPTION
## Motivation

Make it easier to identify JAX test jobs in GitHub Actions by including the JAX version in the job name.
## Technical Details

Update the test_jax_wheels job name to include the JAX version
## Test Plan

Verify the workflow displays the updated job name in GitHub Actions.
## Test Result
Name appears as expected
https://github.com/ROCm/TheRock/actions/runs/28537115001
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
