### PR TITLE
feat(ci): honor test_filter labels in workflow_dispatch test_labels

### DIFF
--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -24,7 +24,7 @@ on:
         default: ""
       linux_test_labels:
         type: string
-        description: "Comma-separated test options. Use test:* to filter tests (e.g. test:rocprim). Use test_filter:* to set test type (quick, standard, comprehensive, full)."
+        description: "Comma-separated test options. Use test:* to filter tests (e.g. test:rocprim). Use test_filter:* to set test type (e.g. test_filter:quick)."
         default: ""
       windows_amdgpu_families:
         type: string
@@ -32,7 +32,7 @@ on:
         default: ""
       windows_test_labels:
         type: string
-        description: "Comma-separated test options. Use test:* to filter tests (e.g. test:rocprim). Use test_filter:* to set test type (quick, standard, comprehensive, full)."
+        description: "Comma-separated test options. Use test:* to filter tests (e.g. test:rocprim). Use test_filter:* to set test type (e.g. test_filter:quick)."
         default: ""
       prebuilt_stages:
         type: string

--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -24,7 +24,7 @@ on:
         default: ""
       linux_test_labels:
         type: string
-        description: "If enabled, reduce test set on Linux to the list of labels prefixed with 'test:'. ex: test:rocprim, test:hipcub"
+        description: "Comma-separated test options. Use test:* to filter tests (e.g. test:rocprim). Use test_filter:* to set test type (quick, standard, comprehensive, full)."
         default: ""
       windows_amdgpu_families:
         type: string
@@ -32,7 +32,7 @@ on:
         default: ""
       windows_test_labels:
         type: string
-        description: "If enabled, reduce test set on Windows to the list of labels prefixed with 'test:' ex: test:rocprim, test:hipcub"
+        description: "Comma-separated test options. Use test:* to filter tests (e.g. test:rocprim). Use test_filter:* to set test type (quick, standard, comprehensive, full)."
         default: ""
       prebuilt_stages:
         type: string

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -561,8 +561,12 @@ def _has_test_labels(ci_inputs: CIInputs) -> bool:
     not which tests to run.
     """
     # Filter out test_filter: labels - those control test_type, not test selection
-    linux_tests = [l for l in ci_inputs.linux_test_labels if not l.startswith("test_filter:")]
-    windows_tests = [l for l in ci_inputs.windows_test_labels if not l.startswith("test_filter:")]
+    linux_tests = [
+        l for l in ci_inputs.linux_test_labels if not l.startswith("test_filter:")
+    ]
+    windows_tests = [
+        l for l in ci_inputs.windows_test_labels if not l.startswith("test_filter:")
+    ]
     if linux_tests or windows_tests:
         return True
     return any(label.startswith("test:") for label in ci_inputs.pr_labels)

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -555,8 +555,15 @@ _VALID_TEST_FILTER_TYPES = {"quick", "standard", "comprehensive", "full"}
 
 
 def _has_test_labels(ci_inputs: CIInputs) -> bool:
-    """Check whether any test labels were specified (workflow_dispatch or PR)."""
-    if ci_inputs.linux_test_labels or ci_inputs.windows_test_labels:
+    """Check whether any test labels were specified (workflow_dispatch or PR).
+
+    Note: test_filter: labels are not test labels - they control test_type,
+    not which tests to run.
+    """
+    # Filter out test_filter: labels - those control test_type, not test selection
+    linux_tests = [l for l in ci_inputs.linux_test_labels if not l.startswith("test_filter:")]
+    windows_tests = [l for l in ci_inputs.windows_test_labels if not l.startswith("test_filter:")]
+    if linux_tests or windows_tests:
         return True
     return any(label.startswith("test:") for label in ci_inputs.pr_labels)
 
@@ -579,10 +586,16 @@ def _determine_test_type(
 
     # Check in priority order - highest priority returns early.
 
-    # Priority 1: test_filter: PR label is an explicit manual override.
+    # Priority 1: test_filter: label is an explicit manual override.
     # This is the escape hatch: run comprehensive on a PR before merge,
     # or downgrade to quick if you know the change is safe.
-    for label in ci_inputs.pr_labels:
+    # Check both PR labels and workflow_dispatch test labels.
+    all_labels = (
+        ci_inputs.pr_labels
+        + ci_inputs.linux_test_labels
+        + ci_inputs.windows_test_labels
+    )
+    for label in all_labels:
         if not label.startswith("test_filter:"):
             continue
         filter_type = label.split(":")[1]

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -439,6 +439,20 @@ class TestDecideJobs(unittest.TestCase):
                 self._inputs(pr_labels=["test_filter:bogus"]), git_context=git
             )
 
+    def test_workflow_dispatch_test_filter_label_overrides(self):
+        """test_filter in workflow_dispatch test_labels overrides test_type."""
+        # workflow_dispatch with test_filter:comprehensive should use comprehensive,
+        # not fall through to "full" because of _has_test_labels
+        result = cm.decide_jobs(
+            self._inputs(
+                event_name="workflow_dispatch",
+                linux_test_labels=["test_filter:comprehensive"],
+            ),
+            git_context=cm.GitContext(),
+        )
+        self.assertEqual(result.test_rocm.test_type, "comprehensive")
+        self.assertIn("test_filter", result.test_rocm.test_type_reason)
+
     def test_explicit_prebuilt_stages(self):
         """workflow_dispatch prebuilt_stages input → stage_decisions on BuildRocmDecision."""
         result = cm.decide_jobs(


### PR DESCRIPTION
Previously, test_filter:comprehensive passed via workflow_dispatch linux_test_labels would trigger _has_test_labels() and return "full" instead of honoring the explicit test_filter value.

Fix by:
1. Checking test_filter: in all labels (PR + workflow_dispatch inputs)
2. Filtering out test_filter: labels from _has_test_labels() check


Working here on workflow dispatch test: https://github.com/ROCm/TheRock/actions/runs/28539147106/job/84608135142#step:4:127 and tests running proper: https://github.com/ROCm/TheRock/actions/runs/28539147106/job/84609162769

Also working in external repo here: https://github.com/ROCm/rocm-systems/actions/runs/28537575162/job/84602787692#step:4:148 with this change: https://github.com/ROCm/rocm-systems/compare/users/geomin12/ci-nightly-disable?expand=1