### PR TITLE
ci: Log artifact archive file sizes and sha256 hashes during upload

### DIFF
--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -549,6 +549,44 @@ class UploadRequest:
     backend: ArtifactBackend
 
 
+def _format_bytes(size: Optional[int]) -> str:
+    return "unknown" if size is None else f"{size} bytes"
+
+
+def _directory_file_count_and_size_sum(path: Path) -> Optional[tuple[int, int]]:
+    try:
+        count = 0
+        total = 0
+        for child in path.rglob("*"):
+            if child.is_file():
+                count += 1
+                total += child.stat().st_size
+        return count, total
+    except OSError:
+        return None
+
+
+def _hash_file_path(archive_path: Path) -> Path:
+    return Path(f"{archive_path}.sha256sum")
+
+
+def _read_sha256sum_value(hash_path: Path) -> str:
+    """Read the digest from a hash sidecar.
+
+    Existing files in tests and logs use both plain digest and
+    ``sha256sum``-style ``digest filename`` formats. The digest is always the
+    first whitespace-delimited token.
+    """
+    content = hash_path.read_text().strip()
+    if not content:
+        raise ValueError(f"Empty sha256sum file: {hash_path}")
+    return content.split()[0]
+
+
+def _artifact_sha256(source_path: Path) -> str:
+    return _read_sha256sum_value(_hash_file_path(source_path))
+
+
 def compress_artifact(request: CompressRequest) -> Optional[Path]:
     """Compress a single artifact directory using fileset_tool.py artifact-archive."""
     try:
@@ -575,7 +613,7 @@ def compress_artifact(request: CompressRequest) -> Optional[Path]:
         cmd.extend(
             [
                 "--hash-file",
-                str(request.archive_path) + ".sha256sum",
+                str(_hash_file_path(request.archive_path)),
                 str(request.source_dir),
             ]
         )
@@ -586,6 +624,21 @@ def compress_artifact(request: CompressRequest) -> Optional[Path]:
                 f"fileset_tool.py artifact-archive failed (returncode={result.returncode}): {result.stderr}"
             )
 
+        sha256 = _artifact_sha256(request.archive_path)
+        file_count_and_size = _directory_file_count_and_size_sum(request.source_dir)
+        if file_count_and_size is None:
+            file_count = "unknown"
+            uncompressed_size = None
+        else:
+            file_count, uncompressed_size = file_count_and_size
+        log(
+            f"  ++ Compressed {request.source_dir.name} "
+            f"(files={file_count}, "
+            f"uncompressed_size={_format_bytes(uncompressed_size)}) "
+            f"-> {request.archive_path.name} "
+            f"(compressed_size={_format_bytes(request.archive_path.stat().st_size)}, "
+            f"sha256={sha256})"
+        )
         return request.archive_path
     except Exception as e:
         log(f"  !! Failed to compress {request.source_dir.name}: {e}")
@@ -599,17 +652,26 @@ def upload_artifact(request: UploadRequest) -> bool:
 
     for attempt in range(MAX_RETRIES):
         try:
-            log(f"  ++ Uploading {request.artifact_key}")
+            # Upload the artifact itself.
+            sha256 = _artifact_sha256(request.source_path)
+            compressed_size = request.source_path.stat().st_size
+            log(
+                f"  ++ Uploading {request.artifact_key} "
+                f"(sha256={sha256}, "
+                f"compressed_size={_format_bytes(compressed_size)})"
+            )
             request.backend.upload_artifact(request.source_path, request.artifact_key)
 
-            # Also upload sha256sum if it exists
-            sha_path = request.source_path.with_suffix(
-                request.source_path.suffix + ".sha256sum"
+            # Upload the artifact's sha256sum file.
+            sha_path = _hash_file_path(request.source_path)
+            log(
+                f"  ++ Uploading {request.artifact_key}.sha256sum "
+                f"(artifact_sha256={sha256}, "
+                f"size={_format_bytes(sha_path.stat().st_size)})"
             )
-            if sha_path.exists():
-                request.backend.upload_artifact(
-                    sha_path, f"{request.artifact_key}.sha256sum"
-                )
+            request.backend.upload_artifact(
+                sha_path, f"{request.artifact_key}.sha256sum"
+            )
 
             return True
         except Exception as e:

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -69,6 +69,7 @@ from _therock_utils.artifact_backend import (
     create_backend_from_env,
 )
 from _therock_utils.artifacts import ArtifactName, ArtifactPopulator
+from _therock_utils.hash_util import calculate_hash
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 
 # Component types that artifacts are split into
@@ -583,15 +584,12 @@ def _read_sha256sum_value(hash_path: Path) -> str:
     return content.split()[0]
 
 
-def _artifact_sha256(source_path: Path) -> str:
-    return _read_sha256sum_value(_hash_file_path(source_path))
-
-
 def compress_artifact(request: CompressRequest) -> Optional[Path]:
     """Compress a single artifact directory using fileset_tool.py artifact-archive."""
     try:
         log(f"  ++ Compressing {request.source_dir.name}")
         request.archive_path.parent.mkdir(parents=True, exist_ok=True)
+        hash_path = _hash_file_path(request.archive_path)
 
         # Use fileset_tool.py artifact-archive for proper archive creation
         import subprocess
@@ -613,7 +611,7 @@ def compress_artifact(request: CompressRequest) -> Optional[Path]:
         cmd.extend(
             [
                 "--hash-file",
-                str(_hash_file_path(request.archive_path)),
+                str(hash_path),
                 str(request.source_dir),
             ]
         )
@@ -624,7 +622,7 @@ def compress_artifact(request: CompressRequest) -> Optional[Path]:
                 f"fileset_tool.py artifact-archive failed (returncode={result.returncode}): {result.stderr}"
             )
 
-        sha256 = _artifact_sha256(request.archive_path)
+        sha256 = _read_sha256sum_value(hash_path)
         file_count_and_size = _directory_file_count_and_size_sum(request.source_dir)
         if file_count_and_size is None:
             file_count = "unknown"
@@ -653,25 +651,32 @@ def upload_artifact(request: UploadRequest) -> bool:
     for attempt in range(MAX_RETRIES):
         try:
             # Upload the artifact itself.
-            sha256 = _artifact_sha256(request.source_path)
+            sha_path = _hash_file_path(request.source_path)
+            sha256 = calculate_hash(request.source_path, "sha256").hexdigest()
             compressed_size = request.source_path.stat().st_size
             log(
                 f"  ++ Uploading {request.artifact_key} "
-                f"(sha256={sha256}, "
-                f"compressed_size={_format_bytes(compressed_size)})"
+                f"(compressed_size={_format_bytes(compressed_size)}, "
+                f"sha256={sha256})"
             )
             request.backend.upload_artifact(request.source_path, request.artifact_key)
 
             # Upload the artifact's sha256sum file.
-            sha_path = _hash_file_path(request.source_path)
-            log(
-                f"  ++ Uploading {request.artifact_key}.sha256sum "
-                f"(artifact_sha256={sha256}, "
-                f"size={_format_bytes(sha_path.stat().st_size)})"
-            )
-            request.backend.upload_artifact(
-                sha_path, f"{request.artifact_key}.sha256sum"
-            )
+            if sha_path.exists():
+                sha256sum_sha256 = _read_sha256sum_value(sha_path)
+                if sha256sum_sha256 != sha256:
+                    log(
+                        f"  !! WARNING: sha256 mismatch for {request.artifact_key}: "
+                        f"computed_sha256={sha256}, sha256sum_sha256={sha256sum_sha256}"
+                    )
+                log(
+                    f"  ++ Uploading {request.artifact_key}.sha256sum "
+                    f"(artifact_sha256={sha256sum_sha256}, "
+                    f"size={_format_bytes(sha_path.stat().st_size)})"
+                )
+                request.backend.upload_artifact(
+                    sha_path, f"{request.artifact_key}.sha256sum"
+                )
 
             return True
         except Exception as e:

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -8,6 +8,7 @@ These tests verify end-to-end behavior of the artifact_manager push/fetch comman
 particularly error handling and exit codes.
 """
 
+import hashlib
 import os
 import shutil
 import sys
@@ -206,11 +207,13 @@ class ArtifactManagerTestBase(unittest.TestCase):
 
         archive_name = f"{name}_{component}_{target_family}.tar.zst"
         archive_path = artifacts_dir / archive_name
-        archive_path.write_bytes(b"fake zstd archive content")
+        archive_content = b"fake zstd archive content"
+        archive_path.write_bytes(archive_content)
 
         # Also create sha256sum
         sha_path = artifacts_dir / f"{archive_name}.sha256sum"
-        sha_path.write_text(f"abc123  {archive_name}\n")
+        sha256 = hashlib.sha256(archive_content).hexdigest()
+        sha_path.write_text(f"{sha256}  {archive_name}\n")
 
         return archive_path
 
@@ -319,7 +322,11 @@ class TestPushFailureExitCode(ArtifactManagerTestBase):
         """Test that push exits normally (no exception) when all uploads succeed."""
         import artifact_manager
 
-        self._create_fake_precompressed_artifact("test-artifact", "lib", "generic")
+        archive_path = self._create_fake_precompressed_artifact(
+            "test-artifact", "lib", "generic"
+        )
+        sha_path = Path(f"{archive_path}.sha256sum")
+        self.assertTrue(sha_path.exists())
 
         argv = [
             "push",
@@ -352,6 +359,45 @@ class TestPushFailureExitCode(ArtifactManagerTestBase):
 
         # Verify sha256sum was also uploaded
         self.assertTrue(
+            backend.artifact_exists("test-artifact_lib_generic.tar.zst.sha256sum")
+        )
+
+    def test_push_succeeds_when_precompressed_artifact_is_missing_sha256sum(self):
+        """Test that pre-compressed artifacts do not require a sha256sum sidecar."""
+        import artifact_manager
+
+        archive_path = self._create_fake_precompressed_artifact(
+            "test-artifact", "lib", "generic"
+        )
+        Path(f"{archive_path}.sha256sum").unlink()
+
+        argv = [
+            "push",
+            "--stage",
+            "upstream-stage",
+            "--build-dir",
+            str(self.build_dir),
+            "--topology",
+            str(self.topology_path),
+            "--local-staging-dir",
+            str(self.staging_dir),
+            "--platform",
+            TEST_PLATFORM,
+            "--run-id",
+            "local",
+        ]
+
+        artifact_manager.main(argv)
+
+        output_root = WorkflowOutputRoot.for_local(
+            run_id="local", platform=TEST_PLATFORM
+        )
+        backend = LocalDirectoryBackend(
+            staging_dir=self.staging_dir,
+            output_root=output_root,
+        )
+        self.assertTrue(backend.artifact_exists("test-artifact_lib_generic.tar.zst"))
+        self.assertFalse(
             backend.artifact_exists("test-artifact_lib_generic.tar.zst.sha256sum")
         )
 


### PR DESCRIPTION
## Motivation

This extra logging will help debug issues like https://github.com/ROCm/TheRock/issues/4202 where build jobs can silently overwrite artifacts with different contents. Projects _should_ be producing identical artifacts across all build jobs, but that isn't actually enforced in the build system currently.

Previously we'd have logs like
```
Processing 81 artifacts (81 to compress, 0 pre-compressed)...
  ++ Compressing support_dev_generic
  ++ Compressing prim_test_generic
  ++ Compressing miopenprovider_test_generic
  ++ Compressing rocalution_dev_generic
  ++ Compressing prim_dev_generic
  ++ Uploading support_dev_generic.tar.zst
  ++ Compressing composable-kernel_dev_generic
  ++ Compressing rocwmma_dbg_generic
  ++ Uploading composable-kernel_doc_generic.tar.zst
  ++ Uploading hipblasltprovider_dbg_generic.tar.zst
```

Now we'll have logs like
```
Processing 44 artifacts (44 to compress, 0 pre-compressed)...
  ++ Compressing amd-llvm_dbg_generic
  ++ Compressing amd-llvm_dev_generic
  ++ Compressing amd-llvm_doc_generic
  ...
  ++ Compressing fftw3_run_generic
  ++ Compressed base_dev_generic (files=33, uncompressed_size=302119 bytes) -> base_dev_generic.tar.zst (compressed_size=62696 bytes, sha256=8b25469d31e063db66a09f50a42d694bcd680e1d79930ccde6ea67d24ddb4c85)
  ++ Compressing flatbuffers_dev_generic
  ++ Uploading base_dev_generic.tar.zst (compressed_size=62696 bytes, sha256=8b25469d31e063db66a09f50a42d694bcd680e1d79930ccde6ea67d24ddb4c85)
  ++ Uploading base_dev_generic.tar.zst.sha256sum (artifact_sha256=8b25469d31e063db66a09f50a42d694bcd680e1d79930ccde6ea67d24ddb4c85, size=66 bytes)
  ++ Compressed core-hip_doc_generic (files=1, uncompressed_size=16 bytes) -> core-hip_doc_generic.tar.zst (compressed_size=171 bytes, sha256=d1a2b7c5229e66f33b15626a9654862c166ae78a18e65ae8d46b5a635e791ab4)
  ++ Compressing flatbuffers_run_generic
  ++ Uploading core-hip_doc_generic.tar.zst (compressed_size=171 bytes, sha256=d1a2b7c5229e66f33b15626a9654862c166ae78a18e65ae8d46b5a635e791ab4)
  ++ Uploading core-hip_doc_generic.tar.zst.sha256sum (artifact_sha256=d1a2b7c5229e66f33b15626a9654862c166ae78a18e65ae8d46b5a635e791ab4, size=66 bytes)
```

We'll be able to inspect the sha256 values along with file counts and uncompressed/compressed sizes to spot if different build stages are uploading different versions of artifact archives.

## Test Plan

As we don't yet have https://github.com/ROCm/rocm-libraries/commit/c534dd117e1197658ed8c137e6cbe5133b86bfd5, I would expect gfx90c and gfx950 to produce different generic miopen artifacts and we should now see that in the logs.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.