### PR TITLE
Cherry-pick #6101: use $GITHUB_WORKSPACE in artifact fetch output-dir for kube-mode runners

### DIFF
--- a/.github/workflows/test_artifacts_structure.yml
+++ b/.github/workflows/test_artifacts_structure.yml
@@ -97,7 +97,7 @@ jobs:
             --stage=all \
             --amdgpu-families="${{ inputs.amdgpu_families }}" \
             --platform="${{ env.PLATFORM }}" \
-            --output-dir="${{ github.workspace }}" \
+            --output-dir="${GITHUB_WORKSPACE}" \
             --no-extract
           # NOTE: artifact_manager.py appends /.download_cache to --output-dir
           # in --no-extract mode, so pass workspace root here so that


### PR DESCRIPTION
## Motivation

Cherry-picks #6101 (`653b4fcb8`) from `main` onto `compiler/amd-staging`

## Technical Details

The `Validate artifact structure` job fails on the AWS kube-mode runners because the fetch step used `--output-dir="${{ github.workspace }}"` (a GHA template expression baked in as the *host* path) while the validate step reads `THEROCK_ARTIFACTS_DIR`, which the runner translates to the *container* path `/__w/...`. 
The two disagree, so the test reports `THEROCK_ARTIFACTS_DIR is not a directory: /__w/TheRock/TheRock/.download_cache`.

The fix switches the fetch to `--output-dir="${GITHUB_WORKSPACE}"` (a shell env var evaluated inside the container), so the download and the test target the same path on the shared PVC.

This bug reached `compiler/amd-staging` via the main merge #6036, which snapshotted `main` before #6101 landed; this cherry-pick brings the branch in line with `main`.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
