### PR TITLE
fix(jax): Set ROCm runtime env vars only for 0.10.2

### DIFF
--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -265,9 +265,9 @@ jobs:
           # JAX 0.10.2 only: ROCm/HIP runtime tuning to avoid a pytest
           # slowdown/hang; other releases keep the runtime defaults.
           # TODO:(magaonka-amd) remove these as soon as fixes from corresponding system teams lands.
-          ROCPROFILER_QUEUE_INTERPOSITION: ${{ inputs.jax_ref == 'rocm-jaxlib-v0.10.2' && '0' || '' }}
-          DEBUG_HIP_DYNAMIC_QUEUES: ${{ inputs.jax_ref == 'rocm-jaxlib-v0.10.2' && '0' || '' }}
-          HSA_NO_SCRATCH_RECLAIM: ${{ inputs.jax_ref == 'rocm-jaxlib-v0.10.2' && '1' || '' }}
+          ROCPROFILER_QUEUE_INTERPOSITION: ${{ inputs.jax_ref == 'rocm-jaxlib-v0.10.2' && '0' }}
+          DEBUG_HIP_DYNAMIC_QUEUES: ${{ inputs.jax_ref == 'rocm-jaxlib-v0.10.2' && '0' }}
+          HSA_NO_SCRATCH_RECLAIM: ${{ inputs.jax_ref == 'rocm-jaxlib-v0.10.2' && '1' }}
 
           # Reduce compilation/autotune memory pressure.
           XLA_FLAGS: >-


### PR DESCRIPTION

## Summary
Fixes: https://github.com/ROCm/TheRock/issues/6323
Related PR: https://github.com/ROCm/TheRock/pull/6309


Restrict the ROCm runtime tuning environment variables to the JAX 0.10.2 test configuration.

## Changes
Apply `ROCPROFILER_QUEUE_INTERPOSITION` only when testing rocm-jaxlib-v0.10.2.
Apply `DEBUG_HIP_DYNAMIC_QUEUES` only when testing rocm-jaxlib-v0.10.2.
Apply `HSA_NO_SCRATCH_RECLAIM` only when testing rocm-jaxlib-v0.10.2.
Leave these variables unset for all other JAX versions.
## Motivation

These runtime tuning variables are only required for JAX 0.10.2 to work around known ROCm/HIP runtime issues. Setting them for other releases introduces unnecessary environment differences and can result in invalid empty environment variable values being passed to the runtime.

This change ensures that only the JAX 0.10.2 test configuration receives the required runtime tuning while all other JAX versions continue to run with the default runtime configuration.

## Test Results
https://github.com/ROCm/TheRock/actions/runs/28615408526