### PR TITLE
(feat): [AILIKFD-40] add kfdtest to TheRock CI

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -150,6 +150,7 @@ artifact_groups = [
     "core-runtime",
     "third-party-libs",
     "hip-runtime",
+    "kfdtest",
     "opencl-runtime",
     "profiler-core",
     "rocjitsu"
@@ -273,6 +274,12 @@ source_sets = ["rocm-systems"]  # clr is in rocm-systems
 description = "Runtime tests (hip-tests, rocrtst)"
 type = "generic"
 artifact_group_deps = ["hip-runtime", "opencl-runtime", "core-runtime"]
+source_sets = ["rocm-systems"]
+
+[artifact_groups.kfdtest]
+description = "KFD kernel driver tests"
+type = "generic"
+artifact_group_deps = ["core-runtime"]
 source_sets = ["rocm-systems"]
 
 [artifact_groups.math-libs]
@@ -577,6 +584,14 @@ artifact_group = "runtime-tests"
 type = "target-neutral"
 artifact_deps = ["core-runtime", "core-ocl", "core-amdsmi", "sysdeps-hwloc"]
 feature_name = "CORE_RUNTIME_TESTS"
+feature_group = "CORE"
+disable_platforms = ["windows"]
+
+[artifacts.kfdtest]
+artifact_group = "kfdtest"
+type = "target-neutral"
+artifact_deps = ["core-runtime", "amd-llvm", "sysdeps"]
+feature_name = "CORE_KFDTESTS"
 feature_group = "CORE"
 disable_platforms = ["windows"]
 

--- a/build_tools/install_rocm_from_artifacts.py
+++ b/build_tools/install_rocm_from_artifacts.py
@@ -45,6 +45,7 @@ python build_tools/install_rocm_from_artifacts.py
     [--rocprofiler-systems-examples | --no-rocprofiler-systems-examples]
     [--rocrtst | --no-rocrtst]
     [--rocalution | --no-rocalution]
+    [--kfdtest | --no-kfdtest]
     [--rocwmma | --no-rocwmma]
     [--rpp | --no-rpp]
     [--hiptensor | --no-hiptensor]
@@ -425,6 +426,7 @@ def retrieve_artifacts_by_run_id(args):
             args.rocprofiler_systems_examples,
             args.rocrtst,
             args.rocalution,
+            args.kfdtest,
             args.rocwmma,
             args.rpp,
             args.libhipcxx,
@@ -555,6 +557,11 @@ def retrieve_artifacts_by_run_id(args):
         if args.rocalution:
             extra_artifacts.append("rocalution")
             argv.append("rocalution_dev")
+        if args.kfdtest:
+            extra_artifacts.append("kfdtest")
+            # kfdtest depends on llvm-dev
+            argv.append("amd-llvm_dev")
+            argv.append("amd-llvm_lib")
         if args.rocwmma:
             extra_artifacts.append("rocwmma")
             argv.append("rocwmma_dev")
@@ -981,6 +988,13 @@ def main(argv):
         "--rocalution",
         default=False,
         help="Include 'rocalution' artifacts",
+        action=argparse.BooleanOptionalAction,
+    )
+
+    artifacts_group.add_argument(
+        "--kfdtest",
+        default=False,
+        help="Include 'kfdtest' artifacts",
         action=argparse.BooleanOptionalAction,
     )
 

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -463,6 +463,17 @@
             ]
           }
         ]
+      },
+      {
+        "Artifact": "kfdtest",
+        "Artifact_Subdir": [
+          {
+            "Name": "kfdtest",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
       }
     ],
     "Gfxarch": "False",

--- a/build_tools/tests/install_rocm_from_artifacts_test.py
+++ b/build_tools/tests/install_rocm_from_artifacts_test.py
@@ -392,6 +392,7 @@ def _make_run_id_args(**overrides) -> argparse.Namespace:
         rocprofiler_systems_examples=False,
         rocrtst=False,
         rocalution=False,
+        kfdtest=False,
         rocwmma=False,
         rpp=False,
         libhipcxx=False,

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -663,3 +663,74 @@ if(THEROCK_BUILD_TESTING AND THEROCK_ENABLE_CORE_RUNTIME_TESTS AND _therock_enab
       rocrtst
   )
 endif(THEROCK_BUILD_TESTING AND THEROCK_ENABLE_CORE_RUNTIME_TESTS AND _therock_enable_hsa_runtime)
+
+if(THEROCK_BUILD_TESTING AND THEROCK_ENABLE_CORE_KFDTESTS)
+
+    # kfdtest statically links libhsakmt and dynamically links LLVM libraries.
+    # amd-llvm is needed at build time for headers and at runtime for shared libraries.
+    set(_kfdtest_build_deps
+      amd-llvm
+      ROCR-Runtime
+      therock-yaml-cpp
+    )
+
+    # Get the ROCR-Runtime binary directory to locate libhsakmt
+    get_target_property(_rocr_binary_dir ROCR-Runtime THEROCK_BINARY_DIR)
+
+    therock_cmake_subproject_declare(kfdtest
+      USE_TEST_AMDGPU_TARGETS
+      EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime/libhsakmt/tests/kfdtest"
+      BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/kfdtest"
+      BACKGROUND_BUILD
+      CMAKE_ARGS
+        "-DCMAKE_PREFIX_PATH="
+        "-DLLVM_DIR="
+        "-DROCM_DIR="
+        "-DLIBHSAKMT_PATH=${_rocr_binary_dir}/libhsakmt"
+        "-DCMAKE_EXE_LINKER_FLAGS=-ldl"
+        "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
+      COMPILER_TOOLCHAIN
+        "${_system_toolchain}"
+      BUILD_DEPS
+        ${_kfdtest_build_deps}
+      RUNTIME_DEPS
+        amd-llvm
+        ${THEROCK_BUNDLED_LIBDRM}
+        ${THEROCK_BUNDLED_NUMACTL}
+        ${THEROCK_BUNDLED_ZLIB}
+        ${THEROCK_BUNDLED_ZSTD}
+      INTERFACE_LINK_DIRS
+        "lib"
+        "lib/rocm_sysdeps/lib"
+      INTERFACE_INSTALL_RPATH_DIRS
+        "lib"
+        "lib/rocm_sysdeps/lib"
+    )
+    therock_cmake_subproject_glob_c_sources(kfdtest SUBDIRS .)
+    therock_cmake_subproject_activate(kfdtest)
+
+    # Copy LICENSE to stage directory as part of the stage.stamp creation
+    # This ensures LICENSE is copied before artifacts are created
+    get_target_property(_kfdtest_stage_dir kfdtest THEROCK_STAGE_DIR)
+    get_target_property(_kfdtest_stamp_dir kfdtest THEROCK_STAMP_DIR)
+    set(_kfdtest_stage_stamp "${_kfdtest_stamp_dir}/stage.stamp")
+
+    add_custom_command(
+      OUTPUT "${_kfdtest_stage_stamp}"
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${_kfdtest_stage_dir}/share/doc/kfdtest"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocr-runtime/libhsakmt/tests/kfdtest/LICENSE.kfdtest"
+        "${_kfdtest_stage_dir}/share/doc/kfdtest/LICENSE.kfdtest"
+      COMMENT "Installing LICENSE.kfdtest to stage directory"
+      APPEND
+    )
+
+    therock_provide_artifact(kfdtest
+      TARGET_NEUTRAL
+      DESCRIPTOR artifact-core-kfdtest.toml
+      COMPONENTS
+        test
+      SUBPROJECT_DEPS
+        kfdtest
+    )
+endif(THEROCK_BUILD_TESTING AND THEROCK_ENABLE_CORE_KFDTESTS)

--- a/core/artifact-core-kfdtest.toml
+++ b/core/artifact-core-kfdtest.toml
@@ -1,0 +1,2 @@
+# kfdtest
+[components.test."core/kfdtest/stage"]


### PR DESCRIPTION
 Re-launching kfdtest integration into TheRock CI.                                                                                                                    
                                                            

- Add kfdtest subproject with correct dependencies (statically links libhsakmt and LLVM)
- Add --kfdtest flag to install_rocm_from_artifacts.py
- Add kfdtest to BUILD_TOPOLOGY.toml (artifact group, build stage, and artifact)
- Add sysdeps to kfdtest artifact dependencies for bundled libraries
- Use get_target_property to dynamically locate ROCR-Runtime binary directory
- Set RPATH to lib/rocm_sysdeps/lib only (kfdtest statically links main deps)

Co-Authored-By: Claude Sonnet 4.5
Signed-off-by: Andrew Martin <andrew.martin@amd.com>
                                            

JIRA ID: AILIKFD-40

Co-Authored-By: Claude Sonnet 4.5

## Motivation

To have a copy of the `kfdtest` binary as part of TheRock release archive. 
This is useful for both QA and various customers who use it to test and verify KFD.

## Technical Details

- Original PR: #5377 (merged then reverted in #6142)                                                                                                                      
- Revert reason: ASAN build failure - linker couldn't find -lhsakmt and -lnuma
- https://github.com/ROCm/rocm-systems/pull/8042
- https://github.com/ROCm/rocm-systems/pull/8221
- https://github.com/ROCm/rocm-systems/pull/9480


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
