### PR TITLE
fix(ci): Disable dwz compression for select packages and tune dh_dwz options

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -737,7 +737,8 @@
         ]
       }
     ],
-    "Gfxarch": "True"
+    "Gfxarch": "True",
+    "disable_dwz": "True"
   },
   {
     "Package": "amdrocm-sparse-test",
@@ -1061,7 +1062,8 @@
         ]
       }
     ],
-    "Gfxarch": "True"
+    "Gfxarch": "True",
+    "disable_dwz": "True"
   },
 
   {
@@ -2707,7 +2709,8 @@
       }
     ],
 
-    "Gfxarch": "True"
+    "Gfxarch": "True",
+    "disable_dwz": "True"
   },
 
   {
@@ -2912,8 +2915,8 @@
         ]
       }
     ],
-    "Gfxarch": "False"
-
+    "Gfxarch": "False",
+    "disable_dwz": "True"
   },
   {
     "Package": "amdrocm-rdc",
@@ -2957,8 +2960,8 @@
         ]
       }
     ],
-    "Gfxarch": "False"
-
+    "Gfxarch": "False",
+    "disable_dwz": "True"
   },
   {
     "Package": "amdrocm-debugger",

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -738,7 +738,7 @@
       }
     ],
     "Gfxarch": "True",
-    "disable_dwz": "True"
+    "Disable_DWZ": "True"
   },
   {
     "Package": "amdrocm-sparse-test",
@@ -1063,7 +1063,7 @@
       }
     ],
     "Gfxarch": "True",
-    "disable_dwz": "True"
+    "Disable_DWZ": "True"
   },
 
   {
@@ -2710,7 +2710,7 @@
     ],
 
     "Gfxarch": "True",
-    "disable_dwz": "True"
+    "Disable_DWZ": "True"
   },
 
   {
@@ -2916,7 +2916,7 @@
       }
     ],
     "Gfxarch": "False",
-    "disable_dwz": "True"
+    "Disable_DWZ": "True"
   },
   {
     "Package": "amdrocm-rdc",
@@ -2961,7 +2961,7 @@
       }
     ],
     "Gfxarch": "False",
-    "disable_dwz": "True"
+    "Disable_DWZ": "True"
   },
   {
     "Package": "amdrocm-debugger",

--- a/build_tools/packaging/linux/template/debian_rules.j2
+++ b/build_tools/packaging/linux/template/debian_rules.j2
@@ -13,6 +13,9 @@ override_dh_builddeb:
 {% if disable_dwz %}
 override_dh_dwz:
 	:
+{% else %}
+override_dh_dwz:
+	dh_dwz -X.hsaco -X.co -- --low-mem-die-limit=none --max-die-limit=none
 {% endif %}
 
 


### PR DESCRIPTION
  Add disable_dwz flag to the following packages:
  - amdrocm-solver-test
  - amdrocm-solver
  - amdrocm-dnn
  - amdrocm-rdc-test
  - amdrocm-rdc

  Update debian_rules.j2 to run dh_dwz with custom options when not
  disabled: exclude .hsaco/.co files and set --low-mem-die-limit=none
  --max-die-limit=none to prevent memory-related build failures.

JIRA ID: https://github.com/ROCm/TheRock/issues/5076