### PR TITLE
fix(ci): Resolve undefined pthread symbols in ASAN gtest links

### DIFF
--- a/cmake/therock_sanitizers.cmake
+++ b/cmake/therock_sanitizers.cmake
@@ -57,6 +57,16 @@ function(therock_sanitizer_configure
     # https://github.com/ROCm/TheRock/issues/1782
     string(APPEND _stanza "add_link_options($<$<LINK_LANGUAGE:C,CXX>:-fsanitize=${_sanitizer_string}>\n")
     string(APPEND _stanza "  $<$<AND:$<LINK_LANGUAGE:C,CXX>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>>:-shared-libsan>)\n")
+    # CMake's FindThreads probe (a try_compile) inherits CMAKE_C/CXX_FLAGS_INIT
+    # above but NOT the add_link_options(), so it never sees -shared-libsan and
+    # uses clang's default static sanitizer runtime. That static runtime auto-links
+    # -lpthread, so the probe passes and sets CMAKE_HAVE_LIBC_PTHREAD=1 and
+    # Threads::Threads becomes empty. Real links, however, use shared linkage
+    # (-shared-libsan above, no auto -lpthread), so the empty Threads::Threads
+    # puts nothing on the link and pthread_* go undefined where they live only in
+    # libpthread for glibc < 2.34. Force -pthread here.
+    # https://github.com/ROCm/rocm-libraries/issues/8889
+    string(APPEND _stanza "add_link_options($<$<LINK_LANGUAGE:C,CXX>:-pthread>)\n")
 
     # Note: autotools-based subprojects (e.g. rocgdb) ignore add_link_options() because
     # they pass CMAKE_*_LINKER_FLAGS directly to their configure script. Those subprojects

--- a/cmake/therock_sanitizers.cmake
+++ b/cmake/therock_sanitizers.cmake
@@ -57,16 +57,19 @@ function(therock_sanitizer_configure
     # https://github.com/ROCm/TheRock/issues/1782
     string(APPEND _stanza "add_link_options($<$<LINK_LANGUAGE:C,CXX>:-fsanitize=${_sanitizer_string}>\n")
     string(APPEND _stanza "  $<$<AND:$<LINK_LANGUAGE:C,CXX>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>>:-shared-libsan>)\n")
-    # CMake's FindThreads probe (a try_compile) inherits CMAKE_C/CXX_FLAGS_INIT
-    # above but NOT the add_link_options(), so it never sees -shared-libsan and
-    # uses clang's default static sanitizer runtime. That static runtime auto-links
-    # -lpthread, so the probe passes and sets CMAKE_HAVE_LIBC_PTHREAD=1 and
-    # Threads::Threads becomes empty. Real links, however, use shared linkage
-    # (-shared-libsan above, no auto -lpthread), so the empty Threads::Threads
-    # puts nothing on the link and pthread_* go undefined where they live only in
-    # libpthread for glibc < 2.34. Force -pthread here.
+    # Fix FindThreads detection under ASAN. The threads probe is a try_compile
+    # that inherits CMAKE_C/CXX_FLAGS_INIT (-fsanitize) but NOT the directory
+    # add_link_options() above, so it never sees -shared-libsan and links clang's
+    # default STATIC sanitizer runtime, which auto-links -lpthread. The probe then
+    # passes trivially, CMAKE_HAVE_LIBC_PTHREAD=1, and Threads::Threads is empty.
+    # Feed the same shared-runtime flag to the probe via CMAKE_REQUIRED_LINK_OPTIONS
+    # so it matches real link behavior and detects the real pthread dependency.
+    # try_compile does NOT evaluate generator expressions, so guard on compiler path
+    # at configure time (keeps -shared-libsan off gcc/gfortran, cf. issue #1782).
     # https://github.com/ROCm/rocm-libraries/issues/8889
-    string(APPEND _stanza "add_link_options($<$<LINK_LANGUAGE:C,CXX>:-pthread>)\n")
+    string(APPEND _stanza "if(CMAKE_CXX_COMPILER MATCHES \"clang\")\n")
+    string(APPEND _stanza "  list(APPEND CMAKE_REQUIRED_LINK_OPTIONS -shared-libsan)\n")
+    string(APPEND _stanza "endif()\n")
 
     # Note: autotools-based subprojects (e.g. rocgdb) ignore add_link_options() because
     # they pass CMAKE_*_LINKER_FLAGS directly to their configure script. Those subprojects


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
ASAN builds fail to link gtest-based test executables with undefined pthread symbols. This PR fixes the issue.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
See Issue https://github.com/ROCm/rocm-libraries/issues/8889.

Two link flags in the sanitizer stanza reach the build through different CMake channels in cmake/therock_sanitizers.cmake:

  - `-fsanitize=address` is added via `CMAKE_C/CXX_FLAGS_INIT`.
  - `-shared-libsan` is added via `add_link_options()`.

  CMake's `FindThreads` detection runs a `try_compile` probe that inherits `*_FLAGS_INIT` but **not** `add_link_options()`. So the probe links with `-fsanitize=address` but without `-shared-libsan`, using clang's default **static** sanitizer runtime — which auto-links `-lpthread`. The probe therefore succeeds without explicit threads, CMake sets `CMAKE_HAVE_LIBC_PTHREAD=1`, and
  `Threads::Threads` becomes an empty target.

  Real executables, however, link with `-shared-libsan` (shared runtime, no auto `-lpthread`). gtest propagates the now-empty `Threads::Threads`, so nothing puts `-pthread` on the link line, and the pthread TLS symbols go undefined on toolchains where they live only in `libpthread` for glibc < 2.34 (the manylinux CI container is based on glibc 2.28).

  This surfaced when rocThrust switched its default SQLite3 to the system (shared) package: the previously in-tree SQLite compilation had been incidentally pulling `libpthread` onto the test link lines and masking this problem.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Verified locally in the `manylinux_2_28` build container: ASAN rocThrust test binaries linked successfully.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
