### PR TITLE
Enable native Linux package builds for ASAN variant

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1047,7 +1047,7 @@ def _expand_build_config_for_platform(
         build_variant_label=variant_config["build_variant_label"],
         build_variant_suffix=suffix,
         build_variant_cmake_preset=variant_config["build_variant_cmake_preset"],
-        build_native_linux=(suffix != "asan"),
+        build_native_linux=True,
         build_pytorch=build_pytorch,
         build_jax=build_jax,
         pytorch_build_matrix=pytorch_build_matrix,


### PR DESCRIPTION
  Remove the exclusion that disabled DEB and RPM package generation
  for ASAN builds, allowing native package creation for all build
  variants.

JIRA ID: https://github.com/ROCm/TheRock/issues/5076