### PR TITLE
ci: default GPU_ENABLE_PAL to platform backend when unset

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -168,7 +168,11 @@ jobs:
           OMP_NUM_THREADS: "4"
           # Windows hip-tests (PAL=1, ROCR=0) set this via matrix; other components
           # leave it empty. #3587
-          GPU_ENABLE_PAL: ${{ fromJSON(inputs.component).gpu_enable_pal }}
+          # An empty GPU_ENABLE_PAL is misread as ROCr on Windows (atoi("")==0),
+          # whose Windows memory path OOMs some tests (e.g. rocsparse bsr*0 graph_test).
+          # Default unset components to the platform backend, mirroring the runtime fix
+          # in ROCm/rocm-systems#8050 (Windows -> PAL, Linux -> ROCr).
+          GPU_ENABLE_PAL: ${{ fromJSON(inputs.component).gpu_enable_pal || (inputs.platform == 'windows' && '1' || '0') }}
           RETRY_THIS_STEP: "true"
           RETRY_COUNT: "1"
           RETRY_DELAY: "7"


### PR DESCRIPTION
## Summary

`test_component.yml` passes `GPU_ENABLE_PAL` straight through from the component config:

```yaml
GPU_ENABLE_PAL: ${{ fromJSON(inputs.component).gpu_enable_pal }}
```

Only `hip-tests` on Windows sets this field (`"1"` for PAL, `"0"` for ROCr). Every other component leaves it **empty**, and an empty string is misread as ROCr on Windows because `atoi("") == 0`. The ROCr Windows memory path then OOMs some tests — notably the rocSPARSE `bsr*0` `graph_test` cases, which need ~2x VRAM for HIP graph capture/launch on the 15 GB gfx110X card (`hipGraphLaunch` returns `hipErrorOutOfMemory`).

This defaults components that don't set `gpu_enable_pal` to the correct **platform backend** at the CI boundary:

```yaml
GPU_ENABLE_PAL: ${{ fromJSON(inputs.component).gpu_enable_pal || (inputs.platform == 'windows' && '1' || '0') }}
```

- Windows -> PAL (`1`)
- Linux -> ROCr (`0`)
- Components that set `gpu_enable_pal` explicitly (`hip-tests` PAL/ROCr) are unchanged, since a non-empty string is truthy in the `||`.

## Relationship to rocm-systems#8050

This mirrors the runtime fix in ROCm/rocm-systems#8050, which makes the empty/unset `GPU_ENABLE_PAL` case fall back to the platform default (Windows -> PAL, Linux -> ROCr) instead of `atoi("")==0` forcing ROCr. This PR applies the same resolution one layer earlier (in CI) so Windows sparse tests are unblocked **before** #8050 merges and is bumped into TheRock's pin. Once #8050 is in the pin this line is a harmless no-op and can be reverted.

## Test plan

- [ ] Windows gfx110X rocsparse/hipsparse test jobs report `GPU_ENABLE_PAL=1` (PAL) and no longer OOM in `bsr*0 graph_test`.
- [ ] Linux test jobs are unaffected (still ROCr).
- [ ] `hip-tests` PAL and ROCr jobs still receive `1` / `0` respectively.

Made with [Cursor](https://cursor.com)