### PR TITLE
fix(jax): Remove  runtime tuning for JAX 0.10.2

### DIFF
--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -266,7 +266,6 @@ jobs:
           # slowdown/hang; other releases keep the runtime defaults.
           # TODO:(magaonka-amd) remove these as soon as fixes from corresponding system teams lands.
           ROCPROFILER_QUEUE_INTERPOSITION: ${{ inputs.jax_ref == 'rocm-jaxlib-v0.10.2' && '0' }}
-          DEBUG_HIP_DYNAMIC_QUEUES: ${{ inputs.jax_ref == 'rocm-jaxlib-v0.10.2' && '0' }}
           HSA_NO_SCRATCH_RECLAIM: ${{ inputs.jax_ref == 'rocm-jaxlib-v0.10.2' && '1' }}
 
           # Reduce compilation/autotune memory pressure.


### PR DESCRIPTION
## Summary
https://github.com/ROCm/TheRock/issues/6323
Remove the `DEBUG_HIP_DYNAMIC_QUEUES` runtime environment variable from the JAX test workflow.

## Motivation 

It looks like  `DEBUG_HIP_DYNAMIC_QUEUES` not required for the current JAX test workflow and was introducing unnecessary runtime configuration. Removing it simplifies the test environment while preserving the runtime tuning that is still required for JAX 0.10.2.

Please see the difference below:

https://github.com/ROCm/rockrel/actions/runs/28765574797/job/85344622336
```
  env:
 JAX_VERSION: 0.10.0

...
    XLA_PYTHON_CLIENT_PREALLOCATE: false
    XLA_PYTHON_CLIENT_ALLOCATOR: platform
    ROCPROFILER_QUEUE_INTERPOSITION: false
    DEBUG_HIP_DYNAMIC_QUEUES: false
...
 ```   

https://github.com/ROCm/rockrel/actions/runs/28765574797/job/85344621545
```
  env:
 JAX_VERSION: 0.10.2

  ...
    XLA_PYTHON_CLIENT_PREALLOCATE: false
    XLA_PYTHON_CLIENT_ALLOCATOR: default
    ROCPROFILER_QUEUE_INTERPOSITION: 0
    DEBUG_HIP_DYNAMIC_QUEUES: 0
...
```


## Changes
Stop setting `DEBUG_HIP_DYNAMIC_QUEUES` in the JAX test environment.
Keep the existing JAX 0.10.2-specific runtime tuning for:
ROCPROFILER_QUEUE_INTERPOSITION
HSA_NO_SCRATCH_RECLAIM
Leave the remaining JAX test configuration unchanged.

## Test:
https://github.com/ROCm/TheRock/actions/runs/28802533297