### PR TITLE
feat: Adding python API module installaton for rocprof-trace-decoder

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -248,6 +248,7 @@ def run(args: argparse.Namespace):
                 "include/rocprofiler-systems/**",
                 "lib/librocprof-sys*",
                 "lib/python/site-packages/rocprofsys/**",
+                "lib/python*/site-packages/rocprof_trace_decoder/**",
                 "lib/rocprofiler-systems/**",
                 "libexec/rocprofiler-systems/**",
                 "share/**/rocprofiler-systems/**",
@@ -271,10 +272,12 @@ def run(args: argparse.Namespace):
             "libexec/rocprofiler-compute/**",
             "lib/rocprofiler-compute/**",
             "share/**/rocprofiler-compute/**",
+            # rocprof-trace-decoder Python API
+            "lib/python*/site-packages/rocprof_trace_decoder/**",
         ],
     )
 
-    if profiler_artifacts.artifact_names:
+    if _artifact_catalog_has_matches(profiler_artifacts):
         profiler = PopulatedDistPackage(params, logical_name="profiler")
         profiler.rpath_dep(core, "lib")
         profiler.rpath_dep(core, "lib/llvm/lib")
@@ -325,6 +328,11 @@ def run(args: argparse.Namespace):
     print(
         f"::: Finished building packages at '{args.dest_dir}' with version '{args.version}'"
     )
+
+
+def _artifact_catalog_has_matches(artifacts: ArtifactCatalog) -> bool:
+    """Return whether an artifact catalog has at least one included file."""
+    return any(True for _ in artifacts.pm.matches())
 
 
 def _run_kpack_split(
@@ -560,10 +568,12 @@ def libraries_artifact_filter(target_family: str, an: ArtifactName) -> bool:
 
 
 def profiler_artifact_filter(an: ArtifactName) -> bool:
-    return an.name in [
+    profiler_tools = an.name in [
         "rocprofiler-compute",
         "rocprofiler-systems",
     ] and an.component in ["lib", "run"]
+    trace_decoder_python = an.name == "rocprofiler-sdk" and an.component == "lib"
+    return profiler_tools or trace_decoder_python
 
 
 def device_artifact_filter(target: str, an: ArtifactName) -> bool:

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -290,6 +290,7 @@ def run(args: argparse.Namespace):
                 "include/rocprofiler-systems/**",
                 "lib/librocprof-sys*",
                 "lib/python/site-packages/rocprofsys/**",
+                "lib/python*/site-packages/rocprof_trace_decoder/**",
                 "lib/rocprofiler-systems/**",
                 "libexec/rocprofiler-systems/**",
                 "share/**/rocprofiler-systems/**",
@@ -302,7 +303,7 @@ def run(args: argparse.Namespace):
         includes=PROFILER_WHEEL_INCLUDES,
     )
 
-    if profiler_artifacts.artifact_names:
+    if _artifact_catalog_has_matches(profiler_artifacts):
         profiler = PopulatedDistPackage(params, logical_name="profiler")
         profiler.rpath_dep(core, "lib")
         profiler.rpath_dep(core, "lib/llvm/lib")
@@ -355,6 +356,11 @@ def run(args: argparse.Namespace):
     print(
         f"::: Finished building packages at '{args.dest_dir}' with version '{args.version}'"
     )
+
+
+def _artifact_catalog_has_matches(artifacts: ArtifactCatalog) -> bool:
+    """Return whether an artifact catalog has at least one included file."""
+    return any(True for _ in artifacts.pm.matches())
 
 
 def _run_kpack_split(
@@ -617,10 +623,12 @@ def libraries_artifact_filter(target_family: str, an: ArtifactName) -> bool:
 
 
 def profiler_artifact_filter(an: ArtifactName) -> bool:
-    return an.name in [
+    profiler_tools = an.name in [
         "rocprofiler-compute",
         "rocprofiler-systems",
     ] and an.component in ["lib", "run"]
+    trace_decoder_python = an.name == "rocprofiler-sdk" and an.component == "lib"
+    return profiler_tools or trace_decoder_python
 
 
 # File-path allowlist for the rocm-profiler wheel, applied on top of
@@ -643,6 +651,8 @@ PROFILER_WHEEL_INCLUDES = [
     "libexec/rocprofiler-compute/**",
     "lib/rocprofiler-compute/**",
     "share/**/rocprofiler-compute/**",
+    # rocprof-trace-decoder Python API
+    "lib/python*/site-packages/rocprof_trace_decoder/**",
 ]
 
 

--- a/build_tools/packaging/python/templates/rocm-profiler/README.md
+++ b/build_tools/packaging/python/templates/rocm-profiler/README.md
@@ -32,7 +32,8 @@ invoking a console script will result in a `FileNotFoundError`.
 
 ## Packaging Notes
 
-- No `install_requires` are declared.
+- `pyelftools` is declared when the wheel contains the `rocprof_trace_decoder`
+  Python API.
 - Dependencies are managed by the `rocm` meta package.
 - Versioning is centrally managed via `rocm_sdk._dist_info`.
 

--- a/build_tools/packaging/python/templates/rocm-profiler/README.md
+++ b/build_tools/packaging/python/templates/rocm-profiler/README.md
@@ -32,8 +32,7 @@ invoking a console script will result in a `FileNotFoundError`.
 
 ## Packaging Notes
 
-- `pyelftools` is declared when the wheel contains the `rocprof_trace_decoder`
-  Python API.
+- No `install_requires` are declared.
 - Dependencies are managed by the `rocm` meta package.
 - Versioning is centrally managed via `rocm_sdk._dist_info`.
 

--- a/build_tools/packaging/python/templates/rocm-profiler/setup.py
+++ b/build_tools/packaging/python/templates/rocm-profiler/setup.py
@@ -48,11 +48,7 @@ install_requires = []
 
 def _add_platform_site_package(package_name: str) -> bool:
     site_packages_rel = (
-        Path("platform")
-        / platform_package_name
-        / "lib"
-        / "python3"
-        / "site-packages"
+        Path("platform") / platform_package_name / "lib" / "python3" / "site-packages"
     )
     site_packages = THIS_DIR / site_packages_rel
     package_path = site_packages / package_name

--- a/build_tools/packaging/python/templates/rocm-profiler/setup.py
+++ b/build_tools/packaging/python/templates/rocm-profiler/setup.py
@@ -37,6 +37,42 @@ my_package = dist_info.ALL_PACKAGES["profiler"]
 packages = find_packages(where="./src")
 platform_package_name = my_package.get_py_package_name()
 packages.append(platform_package_name)
+package_dir = {
+    "": "src",
+    platform_package_name: f"platform/{platform_package_name}",
+}
+
+
+install_requires = []
+
+
+def _add_platform_site_package(package_name: str) -> bool:
+    site_packages_rel = (
+        Path("platform")
+        / platform_package_name
+        / "lib"
+        / "python3"
+        / "site-packages"
+    )
+    site_packages = THIS_DIR / site_packages_rel
+    package_path = site_packages / package_name
+    if not package_path.is_dir():
+        return False
+
+    for found_package in find_packages(
+        where=site_packages,
+        include=[package_name, f"{package_name}.*"],
+    ):
+        if found_package not in packages:
+            packages.append(found_package)
+        package_dir[found_package] = str(
+            site_packages_rel / Path(*found_package.split("."))
+        )
+    return True
+
+
+if _add_platform_site_package("rocprof_trace_decoder"):
+    install_requires.append("pyelftools>=0.31")
 
 version = os.environ.get("ROCM_SDK_VERSION")
 if version is None:
@@ -51,10 +87,8 @@ setup(
     version=version,
     description="ROCm profiler applications (rocprofiler-systems and rocprofiler-compute)",
     packages=packages,
-    package_dir={
-        "": "src",
-        platform_package_name: f"platform/{platform_package_name}",
-    },
+    package_dir=package_dir,
+    install_requires=install_requires,
     include_package_data=True,
     zip_safe=False,
     options={

--- a/build_tools/packaging/python/templates/rocm-profiler/setup.py
+++ b/build_tools/packaging/python/templates/rocm-profiler/setup.py
@@ -43,9 +43,15 @@ package_dir = {
 }
 install_requires = []
 
-# The rocprof-trace-decoder Python API is staged inside the platform dir (under
-# lib/python*/site-packages/); re-home it as a top level package so it is
-# importable. It is absent on ROCm builds that predate the API.
+# rocprof-trace-decoder's CMake installs its Python API into the prefix at
+# lib/python3/site-packages/, which lands inside our platform dir and is never
+# on sys.path. Re-home it as a top level package so `import
+# rocprof_trace_decoder` works, since this wheel is the only channel it ships
+# through. It is absent on ROCm builds that predate the API.
+#
+# install_requires mirrors the upstream project's pyproject.toml, which is not
+# staged into the artifact and so cannot be read here. profiler_test.py imports
+# the packaged API to catch drift between the two.
 platform_dir = THIS_DIR / "platform" / platform_package_name
 for site_packages in sorted(platform_dir.glob("lib/python*/site-packages")):
     if not (site_packages / "rocprof_trace_decoder").is_dir():

--- a/build_tools/packaging/python/templates/rocm-profiler/setup.py
+++ b/build_tools/packaging/python/templates/rocm-profiler/setup.py
@@ -41,17 +41,12 @@ package_dir = {
     "": "src",
     platform_package_name: f"platform/{platform_package_name}",
 }
-install_requires = []
 
 # rocprof-trace-decoder's CMake installs its Python API into the prefix at
 # lib/python3/site-packages/, which lands inside our platform dir and is never
 # on sys.path. Re-home it as a top level package so `import
 # rocprof_trace_decoder` works, since this wheel is the only channel it ships
 # through. It is absent on ROCm builds that predate the API.
-#
-# install_requires mirrors the upstream project's pyproject.toml, which is not
-# staged into the artifact and so cannot be read here. profiler_test.py imports
-# the packaged API to catch drift between the two.
 platform_dir = THIS_DIR / "platform" / platform_package_name
 for site_packages in sorted(platform_dir.glob("lib/python*/site-packages")):
     if not (site_packages / "rocprof_trace_decoder").is_dir():
@@ -60,7 +55,6 @@ for site_packages in sorted(platform_dir.glob("lib/python*/site-packages")):
     for name in find_packages(where=site_packages):
         packages.append(name)
         package_dir[name] = str(site_packages_rel / Path(*name.split(".")))
-    install_requires.append("pyelftools>=0.31")
     break
 
 version = os.environ.get("ROCM_SDK_VERSION")
@@ -77,7 +71,6 @@ setup(
     description="ROCm profiler applications (rocprofiler-systems and rocprofiler-compute)",
     packages=packages,
     package_dir=package_dir,
-    install_requires=install_requires,
     include_package_data=True,
     zip_safe=False,
     options={

--- a/build_tools/packaging/python/templates/rocm-profiler/setup.py
+++ b/build_tools/packaging/python/templates/rocm-profiler/setup.py
@@ -41,34 +41,21 @@ package_dir = {
     "": "src",
     platform_package_name: f"platform/{platform_package_name}",
 }
-
-
 install_requires = []
 
-
-def _add_platform_site_package(package_name: str) -> bool:
-    site_packages_rel = (
-        Path("platform") / platform_package_name / "lib" / "python3" / "site-packages"
-    )
-    site_packages = THIS_DIR / site_packages_rel
-    package_path = site_packages / package_name
-    if not package_path.is_dir():
-        return False
-
-    for found_package in find_packages(
-        where=site_packages,
-        include=[package_name, f"{package_name}.*"],
-    ):
-        if found_package not in packages:
-            packages.append(found_package)
-        package_dir[found_package] = str(
-            site_packages_rel / Path(*found_package.split("."))
-        )
-    return True
-
-
-if _add_platform_site_package("rocprof_trace_decoder"):
+# The rocprof-trace-decoder Python API is staged inside the platform dir (under
+# lib/python*/site-packages/); re-home it as a top level package so it is
+# importable. It is absent on ROCm builds that predate the API.
+platform_dir = THIS_DIR / "platform" / platform_package_name
+for site_packages in sorted(platform_dir.glob("lib/python*/site-packages")):
+    if not (site_packages / "rocprof_trace_decoder").is_dir():
+        continue
+    site_packages_rel = site_packages.relative_to(THIS_DIR)
+    for name in find_packages(where=site_packages):
+        packages.append(name)
+        package_dir[name] = str(site_packages_rel / Path(*name.split(".")))
     install_requires.append("pyelftools>=0.31")
+    break
 
 version = os.environ.get("ROCM_SDK_VERSION")
 if version is None:

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
@@ -218,11 +218,9 @@ class ROCmProfilerTest(unittest.TestCase):
                     )
 
     def test_rocprof_trace_decoder_python_api(self):
-        """The packaged rocprof_trace_decoder API must import and pull pyelftools.
+        """The packaged rocprof_trace_decoder API must be importable.
 
-        Importing it dlopens the decoder library, so this catches a wheel that
-        re-homed the Python sources without their runtime dependencies. Skips on
-        ROCm builds whose rocprof-trace-decoder ships no Python API.
+        Skips on ROCm builds whose rocprof-trace-decoder ships no Python API.
         """
         try:
             trace_decoder_mod = importlib.import_module("rocprof_trace_decoder")
@@ -230,5 +228,3 @@ class ROCmProfilerTest(unittest.TestCase):
             raise unittest.SkipTest(f"rocprof_trace_decoder is not installed: {e}")
 
         utils.assert_is_physical_package(trace_decoder_mod)
-        # setup.py declares pyelftools whenever the API is packaged.
-        importlib.import_module("elftools")

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
@@ -216,3 +216,19 @@ class ROCmProfilerTest(unittest.TestCase):
                         f"Expected '{test.expected_text}' in console-script "
                         f"{test.script_name} output:\n{output_text}"
                     )
+
+    def test_rocprof_trace_decoder_python_api(self):
+        """The packaged rocprof_trace_decoder API must import and pull pyelftools.
+
+        Importing it dlopens the decoder library, so this catches a wheel that
+        re-homed the Python sources without their runtime dependencies. Skips on
+        ROCm builds whose rocprof-trace-decoder ships no Python API.
+        """
+        try:
+            trace_decoder_mod = importlib.import_module("rocprof_trace_decoder")
+        except ImportError as e:
+            raise unittest.SkipTest(f"rocprof_trace_decoder is not installed: {e}")
+
+        utils.assert_is_physical_package(trace_decoder_mod)
+        # setup.py declares pyelftools whenever the API is packaged.
+        importlib.import_module("elftools")

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -164,6 +164,96 @@ class MultiArchPackagingTest(TmpDirTestCase):
             artifacts=ArtifactCatalog(artifact_dir),
         )
 
+    def test_trace_decoder_profiler_selection_requires_python_payload(self):
+        """TheRock-only changes must not make old trace-decoder artifacts look non-empty."""
+        from build_python_packages import (
+            _artifact_catalog_has_matches,
+            profiler_artifact_filter,
+        )
+
+        artifact_dir = self.temp_dir / "artifacts"
+        self._add_artifact(
+            artifact_dir,
+            "rocprofiler-sdk",
+            "lib",
+            "generic",
+            {"lib/librocprof-trace-decoder.so": "so"},
+        )
+
+        artifacts = ArtifactCatalog(
+            artifact_dir,
+            filter=profiler_artifact_filter,
+            includes=["lib/python*/site-packages/rocprof_trace_decoder/**"],
+        )
+
+        self.assertTrue(artifacts.artifact_names)
+        self.assertFalse(_artifact_catalog_has_matches(artifacts))
+
+        self._add_artifact(
+            artifact_dir,
+            "rocprofiler-sdk",
+            "lib",
+            "generic",
+            {"lib/python3/site-packages/rocprof_trace_decoder/__init__.py": ""},
+        )
+        artifacts = ArtifactCatalog(
+            artifact_dir,
+            filter=profiler_artifact_filter,
+            includes=["lib/python*/site-packages/rocprof_trace_decoder/**"],
+        )
+        self.assertTrue(_artifact_catalog_has_matches(artifacts))
+
+    def test_trace_decoder_profiler_setup_builds_wheel_with_python_payload(self):
+        """The profiler wheel must expose trace decoder as a normal Python package."""
+        try:
+            import wheel  # noqa: F401
+        except ImportError:
+            self.skipTest("wheel package is not available")
+
+        import zipfile
+
+        artifact_dir = self.temp_dir / "artifacts"
+        artifact_dir.mkdir()
+        dest_dir = self.temp_dir / "packages"
+        dest_dir.mkdir()
+        params = Parameters(
+            dest_dir=dest_dir,
+            version="0.0.1.dev0",
+            version_suffix="",
+            artifacts=ArtifactCatalog(artifact_dir),
+        )
+        profiler = PopulatedDistPackage(params, logical_name="profiler")
+        trace_decoder_pkg = (
+            profiler.platform_dir
+            / "lib"
+            / "python3"
+            / "site-packages"
+            / "rocprof_trace_decoder"
+        )
+        trace_decoder_pkg.mkdir(parents=True)
+        (trace_decoder_pkg / "__init__.py").write_text("__version__ = '0.0.1.dev0'\n")
+
+        wheel_dir = self.temp_dir / "wheels"
+        wheel_dir.mkdir()
+        subprocess.run(
+            [sys.executable, "setup.py", "bdist_wheel", "-d", str(wheel_dir)],
+            cwd=profiler.path,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        wheel_path = next(wheel_dir.glob("rocm_profiler-*.whl"))
+        with zipfile.ZipFile(wheel_path) as zf:
+            names = set(zf.namelist())
+            self.assertIn("rocprof_trace_decoder/__init__.py", names)
+            metadata_name = next(
+                name for name in names if name.endswith(".dist-info/METADATA")
+            )
+            metadata = zf.read(metadata_name).decode()
+            self.assertIn("Requires-Dist: pyelftools", metadata)
+
     def test_each_library_package_independently_owns_shared_relpaths(self):
         """Both arch-specific library packages must contain all their runtime files.
 

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -165,6 +165,96 @@ class MultiArchPackagingTest(TmpDirTestCase):
             artifacts=ArtifactCatalog(artifact_dir),
         )
 
+    def test_trace_decoder_profiler_selection_requires_python_payload(self):
+        """TheRock-only changes must not make old trace-decoder artifacts look non-empty."""
+        from build_python_packages import (
+            _artifact_catalog_has_matches,
+            profiler_artifact_filter,
+        )
+
+        artifact_dir = self.temp_dir / "artifacts"
+        self._add_artifact(
+            artifact_dir,
+            "rocprofiler-sdk",
+            "lib",
+            "generic",
+            {"lib/librocprof-trace-decoder.so": "so"},
+        )
+
+        artifacts = ArtifactCatalog(
+            artifact_dir,
+            filter=profiler_artifact_filter,
+            includes=["lib/python*/site-packages/rocprof_trace_decoder/**"],
+        )
+
+        self.assertTrue(artifacts.artifact_names)
+        self.assertFalse(_artifact_catalog_has_matches(artifacts))
+
+        self._add_artifact(
+            artifact_dir,
+            "rocprofiler-sdk",
+            "lib",
+            "generic",
+            {"lib/python3/site-packages/rocprof_trace_decoder/__init__.py": ""},
+        )
+        artifacts = ArtifactCatalog(
+            artifact_dir,
+            filter=profiler_artifact_filter,
+            includes=["lib/python*/site-packages/rocprof_trace_decoder/**"],
+        )
+        self.assertTrue(_artifact_catalog_has_matches(artifacts))
+
+    def test_trace_decoder_profiler_setup_builds_wheel_with_python_payload(self):
+        """The profiler wheel must expose trace decoder as a normal Python package."""
+        try:
+            import wheel  # noqa: F401
+        except ImportError:
+            self.skipTest("wheel package is not available")
+
+        import zipfile
+
+        artifact_dir = self.temp_dir / "artifacts"
+        artifact_dir.mkdir()
+        dest_dir = self.temp_dir / "packages"
+        dest_dir.mkdir()
+        params = Parameters(
+            dest_dir=dest_dir,
+            version="0.0.1.dev0",
+            version_suffix="",
+            artifacts=ArtifactCatalog(artifact_dir),
+        )
+        profiler = PopulatedDistPackage(params, logical_name="profiler")
+        trace_decoder_pkg = (
+            profiler.platform_dir
+            / "lib"
+            / "python3"
+            / "site-packages"
+            / "rocprof_trace_decoder"
+        )
+        trace_decoder_pkg.mkdir(parents=True)
+        (trace_decoder_pkg / "__init__.py").write_text("__version__ = '0.0.1.dev0'\n")
+
+        wheel_dir = self.temp_dir / "wheels"
+        wheel_dir.mkdir()
+        subprocess.run(
+            [sys.executable, "setup.py", "bdist_wheel", "-d", str(wheel_dir)],
+            cwd=profiler.path,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        wheel_path = next(wheel_dir.glob("rocm_profiler-*.whl"))
+        with zipfile.ZipFile(wheel_path) as zf:
+            names = set(zf.namelist())
+            self.assertIn("rocprof_trace_decoder/__init__.py", names)
+            metadata_name = next(
+                name for name in names if name.endswith(".dist-info/METADATA")
+            )
+            metadata = zf.read(metadata_name).decode()
+            self.assertIn("Requires-Dist: pyelftools", metadata)
+
     def test_each_library_package_independently_owns_shared_relpaths(self):
         """Both arch-specific library packages must contain all their runtime files.
 

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -9,12 +9,14 @@ These tests cover:
   - params.populated_packages: registration and cross-package search helpers
 """
 
+import importlib.util
 import json
 import os
 import stat
 import subprocess
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 
 import sys
@@ -23,7 +25,12 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from _therock_utils.artifacts import ArtifactCatalog
 from _therock_utils.py_packaging import Parameters, PopulatedDistPackage, PopulatedFiles
-from build_python_packages import validate_kpack_split_target_completeness
+from build_python_packages import (
+    _artifact_catalog_has_matches,
+    PROFILER_WHEEL_INCLUDES,
+    profiler_artifact_filter,
+    validate_kpack_split_target_completeness,
+)
 
 
 class TmpDirTestCase(unittest.TestCase):
@@ -165,96 +172,6 @@ class MultiArchPackagingTest(TmpDirTestCase):
             artifacts=ArtifactCatalog(artifact_dir),
         )
 
-    def test_trace_decoder_profiler_selection_requires_python_payload(self):
-        """TheRock-only changes must not make old trace-decoder artifacts look non-empty."""
-        from build_python_packages import (
-            _artifact_catalog_has_matches,
-            profiler_artifact_filter,
-        )
-
-        artifact_dir = self.temp_dir / "artifacts"
-        self._add_artifact(
-            artifact_dir,
-            "rocprofiler-sdk",
-            "lib",
-            "generic",
-            {"lib/librocprof-trace-decoder.so": "so"},
-        )
-
-        artifacts = ArtifactCatalog(
-            artifact_dir,
-            filter=profiler_artifact_filter,
-            includes=["lib/python*/site-packages/rocprof_trace_decoder/**"],
-        )
-
-        self.assertTrue(artifacts.artifact_names)
-        self.assertFalse(_artifact_catalog_has_matches(artifacts))
-
-        self._add_artifact(
-            artifact_dir,
-            "rocprofiler-sdk",
-            "lib",
-            "generic",
-            {"lib/python3/site-packages/rocprof_trace_decoder/__init__.py": ""},
-        )
-        artifacts = ArtifactCatalog(
-            artifact_dir,
-            filter=profiler_artifact_filter,
-            includes=["lib/python*/site-packages/rocprof_trace_decoder/**"],
-        )
-        self.assertTrue(_artifact_catalog_has_matches(artifacts))
-
-    def test_trace_decoder_profiler_setup_builds_wheel_with_python_payload(self):
-        """The profiler wheel must expose trace decoder as a normal Python package."""
-        try:
-            import wheel  # noqa: F401
-        except ImportError:
-            self.skipTest("wheel package is not available")
-
-        import zipfile
-
-        artifact_dir = self.temp_dir / "artifacts"
-        artifact_dir.mkdir()
-        dest_dir = self.temp_dir / "packages"
-        dest_dir.mkdir()
-        params = Parameters(
-            dest_dir=dest_dir,
-            version="0.0.1.dev0",
-            version_suffix="",
-            artifacts=ArtifactCatalog(artifact_dir),
-        )
-        profiler = PopulatedDistPackage(params, logical_name="profiler")
-        trace_decoder_pkg = (
-            profiler.platform_dir
-            / "lib"
-            / "python3"
-            / "site-packages"
-            / "rocprof_trace_decoder"
-        )
-        trace_decoder_pkg.mkdir(parents=True)
-        (trace_decoder_pkg / "__init__.py").write_text("__version__ = '0.0.1.dev0'\n")
-
-        wheel_dir = self.temp_dir / "wheels"
-        wheel_dir.mkdir()
-        subprocess.run(
-            [sys.executable, "setup.py", "bdist_wheel", "-d", str(wheel_dir)],
-            cwd=profiler.path,
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-
-        wheel_path = next(wheel_dir.glob("rocm_profiler-*.whl"))
-        with zipfile.ZipFile(wheel_path) as zf:
-            names = set(zf.namelist())
-            self.assertIn("rocprof_trace_decoder/__init__.py", names)
-            metadata_name = next(
-                name for name in names if name.endswith(".dist-info/METADATA")
-            )
-            metadata = zf.read(metadata_name).decode()
-            self.assertIn("Requires-Dist: pyelftools", metadata)
-
     def test_each_library_package_independently_owns_shared_relpaths(self):
         """Both arch-specific library packages must contain all their runtime files.
 
@@ -321,6 +238,101 @@ class MultiArchPackagingTest(TmpDirTestCase):
 
         self.assertEqual(len(params.populated_packages), 1)
         self.assertIs(params.populated_packages[0], lib)
+
+    def test_profiler_selection_ignores_artifacts_without_trace_decoder_payload(self):
+        """The profiler wheel is only built when selected artifacts contain files.
+
+        profiler_artifact_filter matches the rocprofiler-sdk `lib` artifact so that
+        the rocprof_trace_decoder Python API can be packaged. That artifact exists
+        in every build, including ROCm versions that ship no Python API at all, so
+        matching by artifact name alone is not enough: without a file-level check
+        we would emit a rocm-profiler wheel containing no payload whenever
+        rocprofiler-systems/-compute are absent. This asserts that selection is
+        driven by matched files, not by matched artifact names.
+        """
+        artifact_dir = self.temp_dir / "artifacts"
+        self._add_artifact(
+            artifact_dir,
+            "rocprofiler-sdk",
+            "lib",
+            "generic",
+            {"lib/librocprof-trace-decoder.so": "so"},
+        )
+
+        params = self._make_params(artifact_dir)
+        artifacts = params.filter_artifacts(
+            profiler_artifact_filter,
+            includes=PROFILER_WHEEL_INCLUDES,
+        )
+
+        self.assertTrue(artifacts.artifact_names)
+        self.assertFalse(_artifact_catalog_has_matches(artifacts))
+
+        self._add_artifact(
+            artifact_dir,
+            "rocprofiler-sdk",
+            "lib",
+            "generic",
+            {"lib/python3/site-packages/rocprof_trace_decoder/__init__.py": ""},
+        )
+        params = self._make_params(artifact_dir)
+        artifacts = params.filter_artifacts(
+            profiler_artifact_filter,
+            includes=PROFILER_WHEEL_INCLUDES,
+        )
+        self.assertTrue(_artifact_catalog_has_matches(artifacts))
+
+    def test_trace_decoder_profiler_setup_builds_wheel_with_python_payload(self):
+        """The profiler wheel exposes trace decoder as a normal importable package.
+
+        The trace decoder Python API lands in the platform dir under
+        lib/python3/site-packages/. setup.py must remap it to a top level
+        `rocprof_trace_decoder` package and declare its pyelftools dependency.
+        """
+        if importlib.util.find_spec("wheel") is None:
+            self.skipTest("wheel package is not available")
+
+        artifact_dir = self.temp_dir / "artifacts"
+        artifact_dir.mkdir()
+        dest_dir = self.temp_dir / "packages"
+        dest_dir.mkdir()
+        params = Parameters(
+            dest_dir=dest_dir,
+            version="0.0.1.dev0",
+            version_suffix="",
+            artifacts=ArtifactCatalog(artifact_dir),
+        )
+        profiler = PopulatedDistPackage(params, logical_name="profiler")
+        trace_decoder_pkg = (
+            profiler.platform_dir
+            / "lib"
+            / "python3"
+            / "site-packages"
+            / "rocprof_trace_decoder"
+        )
+        trace_decoder_pkg.mkdir(parents=True)
+        (trace_decoder_pkg / "__init__.py").write_text("__version__ = '0.0.1.dev0'\n")
+
+        wheel_dir = self.temp_dir / "wheels"
+        wheel_dir.mkdir()
+        subprocess.run(
+            [sys.executable, "setup.py", "bdist_wheel", "-d", str(wheel_dir)],
+            cwd=profiler.path,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        wheel_path = next(wheel_dir.glob("rocm_profiler-*.whl"))
+        with zipfile.ZipFile(wheel_path) as zf:
+            names = set(zf.namelist())
+            self.assertIn("rocprof_trace_decoder/__init__.py", names)
+            metadata_name = next(
+                name for name in names if name.endswith(".dist-info/METADATA")
+            )
+            metadata = zf.read(metadata_name).decode()
+            self.assertIn("Requires-Dist: pyelftools", metadata)
 
     def test_find_populated_searches_across_packages(self):
         """_find_populated locates a file regardless of which package owns it."""

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -287,7 +287,7 @@ class MultiArchPackagingTest(TmpDirTestCase):
 
         The trace decoder Python API lands in the platform dir under
         lib/python3/site-packages/. setup.py must remap it to a top level
-        `rocprof_trace_decoder` package and declare its pyelftools dependency.
+        `rocprof_trace_decoder` package.
         """
         if importlib.util.find_spec("wheel") is None:
             self.skipTest("wheel package is not available")
@@ -326,13 +326,7 @@ class MultiArchPackagingTest(TmpDirTestCase):
 
         wheel_path = next(wheel_dir.glob("rocm_profiler-*.whl"))
         with zipfile.ZipFile(wheel_path) as zf:
-            names = set(zf.namelist())
-            self.assertIn("rocprof_trace_decoder/__init__.py", names)
-            metadata_name = next(
-                name for name in names if name.endswith(".dist-info/METADATA")
-            )
-            metadata = zf.read(metadata_name).decode()
-            self.assertIn("Requires-Dist: pyelftools", metadata)
+            self.assertIn("rocprof_trace_decoder/__init__.py", set(zf.namelist()))
 
     def test_find_populated_searches_across_packages(self):
         """_find_populated locates a file regardless of which package owns it."""

--- a/profiler/artifact-rocprofiler-sdk.toml
+++ b/profiler/artifact-rocprofiler-sdk.toml
@@ -38,4 +38,7 @@ include = [
 
 # rocprof-trace-decoder
 [components.lib."profiler/rocprof-trace-decoder/stage"]
+include = [
+  "lib/python*/**",
+]
 [components.dev."profiler/rocprof-trace-decoder/stage"]


### PR DESCRIPTION
## Motivation

Rocprof-trace-decoder is developing a python wrapper to facilitate data analysis with thread trace data.
This PR adds the python artifacts to therock builds.

rocm-systems PR: https://github.com/ROCm/rocm-systems/pull/7931 

JIRA ID : AIPROFSDK-928

## Test Plan

Added a packaging test

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
