### PR TITLE
fix(ci): Use ASAN sandbox runner in test matrix configuration

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -166,6 +166,7 @@ jobs:
           WINDOWS_HIP_ROCR_TESTS: ${{ inputs.windows_hip_rocr_tests }}
           PROJECTS_TO_TEST: ${{ steps.test_deps.outputs.projects_to_test }}
           CI_CONFIG_PATH: ci-config
+          BUILD_VARIANT: ${{ inputs.build_variant }}
         run: |
           python ./build_tools/github_actions/fetch_test_configurations.py \
             --platform=${{ contains(inputs.test_runs_on, 'windows') && 'windows' || 'linux' }}

--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -738,6 +738,7 @@ def run():
     test_labels = ast.literal_eval(os.getenv("TEST_LABELS") or "[]")
     run_extended_tests = str2bool(os.getenv("RUN_EXTENDED_TESTS", "false"))
     windows_hip_rocr_tests = str2bool(os.getenv("WINDOWS_HIP_ROCR_TESTS", "false"))
+    build_variant = os.getenv("BUILD_VARIANT", "release")
 
     # Get runner config for per-component runner selection
     # This enables better load distribution across runner pools
@@ -745,6 +746,8 @@ def run():
     test_runs_on_default = None
     test_runs_on_multi_gpu_labels = None
     test_runs_on_multi_gpu_default = None
+    # For ASAN builds, use the sandbox runner if available
+    test_runs_on_sandbox = None
     if amdgpu_families:
         shortened_family = amdgpu_families.split("-")[0].lower()
         all_families = get_all_families_for_trigger_types(
@@ -760,6 +763,7 @@ def run():
             test_runs_on_multi_gpu_default = platform_info.get(
                 "test-runs-on-multi-gpu", ""
             )
+            test_runs_on_sandbox = platform_info.get("test-runs-on-sandbox", "")
 
     logging.info(f"Selecting projects: {projects_to_test}")
 
@@ -901,6 +905,8 @@ def run():
 
     # Per-component runner selection for better load distribution
     # Each component gets its own independent random draw based on configured weights
+    # For ASAN builds, use the sandbox runner to isolate potentially failing tests
+    is_asan_build = build_variant in ("asan", "host-asan")
     for component in all_components:
         job_name = component.get("job_name", "unknown")
         if "multi_gpu_runner" in component:
@@ -912,8 +918,13 @@ def run():
             elif test_runs_on_multi_gpu_default:
                 component["multi_gpu_runner"] = test_runs_on_multi_gpu_default
         else:
-            # Regular components use standard runner labels
-            if test_runs_on_labels:
+            # For ASAN builds, use the sandbox runner if available
+            if is_asan_build and test_runs_on_sandbox:
+                component["test_runner"] = test_runs_on_sandbox
+                logging.info(
+                    f"  {job_name}: using ASAN sandbox runner: {test_runs_on_sandbox}"
+                )
+            elif test_runs_on_labels:
                 component["test_runner"] = select_weighted_label(
                     test_runs_on_labels, job_name
                 )

--- a/build_tools/github_actions/tests/fetch_test_configurations_test.py
+++ b/build_tools/github_actions/tests/fetch_test_configurations_test.py
@@ -404,6 +404,130 @@ class FetchTestConfigurationsTest(unittest.TestCase):
         self.assertIsInstance(out["container_options"], str)
         self.assertIn("--cap-add=SYS_PTRACE", out["container_options"])
 
+    # -----------------------
+    # ASAN sandbox runner selection
+    # -----------------------
+
+    def test_asan_build_uses_sandbox_runner(self):
+        """ASAN builds should use test-runs-on-sandbox when available."""
+        os.environ["BUILD_VARIANT"] = "asan"
+        os.environ["PROJECTS_TO_TEST"] = "rocblas"
+
+        def fake_get_all_families(_):
+            return {
+                "gfx94x": {
+                    "linux": {
+                        "test-runs-on": "linux-gfx942-prod",
+                        "test-runs-on-labels": [
+                            {"label": "linux-gfx942-a", "weight": 0.5},
+                            {"label": "linux-gfx942-b", "weight": 0.5},
+                        ],
+                        "test-runs-on-sandbox": "linux-mi325-gpu-rocm-cpu-sandbox",
+                    }
+                }
+            }
+
+        fetch_test_configurations.get_all_families_for_trigger_types = (
+            fake_get_all_families
+        )
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        rocblas = next(j for j in components if j["job_name"] == "rocblas")
+        self.assertEqual(rocblas["test_runner"], "linux-mi325-gpu-rocm-cpu-sandbox")
+
+    def test_host_asan_build_uses_sandbox_runner(self):
+        """host-asan builds should also use test-runs-on-sandbox."""
+        os.environ["BUILD_VARIANT"] = "host-asan"
+        os.environ["PROJECTS_TO_TEST"] = "hipblas"
+
+        def fake_get_all_families(_):
+            return {
+                "gfx94x": {
+                    "linux": {
+                        "test-runs-on": "linux-gfx942-prod",
+                        "test-runs-on-sandbox": "linux-sandbox-runner",
+                    }
+                }
+            }
+
+        fetch_test_configurations.get_all_families_for_trigger_types = (
+            fake_get_all_families
+        )
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        hipblas = next(j for j in components if j["job_name"] == "hipblas")
+        self.assertEqual(hipblas["test_runner"], "linux-sandbox-runner")
+
+    def test_release_build_uses_weighted_runner(self):
+        """Release builds should use weighted runner labels, not sandbox."""
+        os.environ["BUILD_VARIANT"] = "release"
+        os.environ["PROJECTS_TO_TEST"] = "rocblas"
+
+        def fake_get_all_families(_):
+            return {
+                "gfx94x": {
+                    "linux": {
+                        "test-runs-on": "linux-gfx942-default",
+                        "test-runs-on-labels": [
+                            {"label": "linux-gfx942-weighted", "weight": 1.0},
+                        ],
+                        "test-runs-on-sandbox": "linux-sandbox-runner",
+                    }
+                }
+            }
+
+        fetch_test_configurations.get_all_families_for_trigger_types = (
+            fake_get_all_families
+        )
+
+        # Mock select_weighted_label to return a known value
+        original_select_weighted_label = fetch_test_configurations.select_weighted_label
+
+        def fake_select_weighted_label(labels_config, context_name):
+            return "linux-gfx942-weighted"
+
+        fetch_test_configurations.select_weighted_label = fake_select_weighted_label
+
+        try:
+            fetch_test_configurations.run()
+            components = self._get_components()
+
+            rocblas = next(j for j in components if j["job_name"] == "rocblas")
+            self.assertEqual(rocblas["test_runner"], "linux-gfx942-weighted")
+        finally:
+            fetch_test_configurations.select_weighted_label = (
+                original_select_weighted_label
+            )
+
+    def test_asan_build_without_sandbox_uses_default_runner(self):
+        """ASAN builds without sandbox config should fall back to default runner."""
+        os.environ["BUILD_VARIANT"] = "asan"
+        os.environ["PROJECTS_TO_TEST"] = "hipblas"
+
+        def fake_get_all_families(_):
+            return {
+                "gfx94x": {
+                    "linux": {
+                        "test-runs-on": "linux-gfx942-default",
+                        # No test-runs-on-sandbox defined
+                    }
+                }
+            }
+
+        fetch_test_configurations.get_all_families_for_trigger_types = (
+            fake_get_all_families
+        )
+
+        fetch_test_configurations.run()
+        components = self._get_components()
+
+        hipblas = next(j for j in components if j["job_name"] == "hipblas")
+        self.assertEqual(hipblas["test_runner"], "linux-gfx942-default")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Update fetch_test_configurations.py to use the sandbox runner (test-runs-on-sandbox) for ASAN builds instead of the weighted production runners. This ensures ASAN tests run on isolated infrastructure to avoid impacting production test capacity.

Changes:
- Pass BUILD_VARIANT env var to fetch_test_configurations.py
- Read test-runs-on-sandbox from GPU family config
- Use sandbox runner for asan/host-asan builds when available
- Add unit tests for ASAN sandbox runner selection

Original break run: https://github.com/ROCm/TheRock/actions/runs/28764854206/job/85329230308#step:1:2

New fix run: https://github.com/ROCm/TheRock/actions/runs/28819647376