### PR TITLE
fix(ci): Disable DWZ compression for hipfile DEB package

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -3336,6 +3336,7 @@
         ]
       }
     ],
+    "Disable_DWZ": "True",
     "Gfxarch": "False"
   },
 


### PR DESCRIPTION
Add "Disable_DWZ": "True" to hipfile package configuration to skip DWARF debug info compression during Debian packaging.
DWZ fails on libhipfile.so with: "Unknown debugging section .debug_str_offsets"

JIRA ID: https://github.com/ROCm/TheRock/issues/5076