### PR TITLE
fix: Declare rocprofiler-sdk's optional roc{decode,jpeg} deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,6 +496,10 @@ add_subdirectory(compiler)
 add_subdirectory(third-party)
 add_subdirectory(core)
 add_subdirectory(debug-tools)
+# media-libs (rocdecode/rocjpeg) must be added before profiler: rocprofiler-sdk
+# performs optional find_package(rocdecode)/find_package(rocjpeg) for trace
+# feature detection.
+add_subdirectory(media-libs)
 # Note that rocprofiler-register is in base and is what higher level clients
 # depend on. The profiler itself is independent.
 add_subdirectory(profiler)
@@ -507,7 +511,6 @@ add_subdirectory(comm-libs)
 add_subdirectory(storage-libs)
 add_subdirectory(math-libs)
 add_subdirectory(ml-libs)
-add_subdirectory(media-libs)
 
 if(THEROCK_BUILD_TESTING)
   add_subdirectory(examples)

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -6,6 +6,18 @@ if(THEROCK_ENABLE_MPI)
   set(_openmpi_optional_dep therock-openmpi)
 endif()
 
+# rocprofiler-sdk performs optional find_package(rocdecode)/find_package(rocjpeg)
+# to detect the rocDecode/rocJPEG trace features. Declare them as dependencies
+# when available so they resolve from the super-project dist rather than
+# escaping to a stray build tree.
+set(_rocprofiler_sdk_optional_deps)
+if(THEROCK_ENABLE_ROCDECODE AND THEROCK_ENABLE_SYSDEPS_AMD_MESA)
+  list(APPEND _rocprofiler_sdk_optional_deps rocdecode)
+endif()
+if(THEROCK_ENABLE_ROCJPEG AND THEROCK_ENABLE_SYSDEPS_AMD_MESA)
+  list(APPEND _rocprofiler_sdk_optional_deps rocjpeg)
+endif()
+
 if(THEROCK_ENABLE_ROCPROFV3)
 
   ##############################################################################
@@ -120,6 +132,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
       rocprof-trace-decoder
       rocprofiler-register
       therock-yaml-cpp
+      ${_rocprofiler_sdk_optional_deps}
       ${THEROCK_BUNDLED_ELFUTILS}
       ${THEROCK_BUNDLED_LIBDRM}
       ${THEROCK_BUNDLED_SQLITE3}


### PR DESCRIPTION
## Motivation

rocprofiler-sdk performs an unconditional but optional `find_package(rocdecode)`/`find_package(rocjpeg)` to detect its rocDecode and rocJPEG trace features. These packages were never declared as dependencies, so TheRock's dependency provider fell through to the system resolver, which latched onto rocdecode's build tree and tried to include a `rocdecode-targets.cmake` that only exists after install, failing the rocprofiler-sdk configure.

## Technical Details

This patch declares both components as optional runtime deps to resolve them from the super-project dist. Deps are guarded so that these dependencies are still optional, as they are currently disabled in CI and the build topology would need a significant re-ordering.

Fixes #6376

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
