### PR TITLE
fix(ci): install rocm[devel] in test_pytorch_wheels.yml

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -211,6 +211,58 @@ jobs:
               --activate-in-future-github-actions-steps
           fi
 
+      - name: Install ROCm devel packages
+        timeout-minutes: 15
+        run: |
+          if [ "${{ inputs.multi_arch }}" = "true" ]; then
+            pip install "rocm[devel,${{ steps.expand.outputs.device_extras }}]" \
+              --index-url=${{ inputs.package_index_url }}
+          else
+            pip install "rocm[devel]" \
+              --index-url=${{ inputs.package_index_url }}/${{ inputs.amdgpu_family }}
+          fi
+
+      - name: Initialize ROCm SDK and configure environment
+        run: |
+          rocm-sdk init
+
+          ROCM_HOME="$(rocm-sdk path --root)"
+          ROCM_BIN="$(rocm-sdk path --bin)"
+          ROCM_CMAKE_PREFIX="$(rocm-sdk path --cmake)"
+
+          echo "ROCM_HOME=${ROCM_HOME}"
+          echo "ROCM_BIN=${ROCM_BIN}"
+          echo "ROCM_CMAKE_PREFIX=${ROCM_CMAKE_PREFIX}"
+
+          ROCM_SYSDEPS="${ROCM_HOME}/lib/rocm_sysdeps"
+          ROCM_SYSDEPS_INCLUDE="${ROCM_SYSDEPS}/include"
+          ROCM_SYSDEPS_PKGCONFIG="${ROCM_SYSDEPS}/lib/pkgconfig"
+
+          # Add ROCm bin to PATH for all subsequent steps
+          echo "${ROCM_BIN}" >> "${GITHUB_PATH}"
+
+          # Persist ROCm env vars across workflow steps (mirrors install_rocm.sh)
+          echo "ROCM_PATH=${ROCM_HOME}" >> "${GITHUB_ENV}"
+          echo "ROCM_HOME=${ROCM_HOME}" >> "${GITHUB_ENV}"
+          echo "ROCM_SOURCE_DIR=${ROCM_HOME}" >> "${GITHUB_ENV}"
+          echo "ROCM_BIN=${ROCM_BIN}" >> "${GITHUB_ENV}"
+          echo "ROCM_CMAKE=${ROCM_CMAKE_PREFIX}" >> "${GITHUB_ENV}"
+          echo "CMAKE_PREFIX_PATH=${ROCM_CMAKE_PREFIX}:${CMAKE_PREFIX_PATH:-}" >> "${GITHUB_ENV}"
+          echo "HIP_DEVICE_LIB_PATH=${ROCM_HOME}/lib/llvm/amdgcn/bitcode" >> "${GITHUB_ENV}"
+          echo "ROCM_DEVICE_LIB_PATH=${ROCM_HOME}/lib/llvm/amdgcn/bitcode" >> "${GITHUB_ENV}"
+          echo "ROCM_SYSDEPS_INCLUDE=${ROCM_SYSDEPS_INCLUDE}" >> "${GITHUB_ENV}"
+          echo "CPLUS_INCLUDE_PATH=${ROCM_SYSDEPS_INCLUDE}:${CPLUS_INCLUDE_PATH:-}" >> "${GITHUB_ENV}"
+          echo "C_INCLUDE_PATH=${ROCM_SYSDEPS_INCLUDE}:${C_INCLUDE_PATH:-}" >> "${GITHUB_ENV}"
+          echo "PKG_CONFIG_PATH=${ROCM_SYSDEPS_PKGCONFIG}:${PKG_CONFIG_PATH:-}" >> "${GITHUB_ENV}"
+          echo "LD_LIBRARY_PATH=${ROCM_HOME}/lib/host-math/lib:${ROCM_SYSDEPS}/lib:${LD_LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
+          echo "LIBRARY_PATH=${ROCM_HOME}/lib/host-math/lib:${ROCM_SYSDEPS}/lib:${LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
+          echo "USE_MSLK=0" >> "${GITHUB_ENV}"
+
+          # Use ROCm's clang for JIT C++ compilation (torch.utils.cpp_extension)
+          # instead of requiring gcc/build-essential.
+          echo "CC=${ROCM_HOME}/lib/llvm/bin/clang" >> "${GITHUB_ENV}"
+          echo "CXX=${ROCM_HOME}/lib/llvm/bin/clang++" >> "${GITHUB_ENV}"
+
       - name: Install test requirements
         run: |
           python -m pip install -r external-builds/pytorch/requirements-test.txt


### PR DESCRIPTION
Issue #6173 

## Motivation

`test_pytorch_wheels.yml` installs only torch[device-gfxNNN], which brings the ROCm runtime but not the development headers. Tests that JIT-compile a C++ extension (e.g. test_cuda.py::TestMemPool::test_mempool_empty_cache_inactive) pull in `ATen/hip/Exceptions.h`, which includes `<hipblas/hipblas.h>`. Since that header ships only in `rocm[devel]`, the compile fails with `fatal error: 'hipblas/hipblas.h' file not found

## Technical Details

Add two steps after "Set up virtual environment", exactly mirroring the already working `test_pytorch_wheels_full.yml`:
  - Install ROCm devel packages — pip install "rocm[devel,...]", which provides the hipBLAS/hipSPARSE/etc. headers.
  - Initialize ROCm SDK and configure environment — rocm-sdk init and export ROCM_PATH/ROCM_HOME (plus include/lib/cmake vars and CC/CXX) so torch.utils.cpp_extension resolves the ROCm include dir instead of guessing the empty venv root.

## Test Plan

Run test_pytorch_wheels.yml from this branch (gfx94X-dcgpu, torch 2.12.0+rocm7.15.0a20260626, py3.10, release/2.12). [CI Run](https://github.com/ROCm/TheRock/actions/runs/28861385152)
## Test Result

dummy_allocator now compiles against rocm_sdk_devel/include and test_mempool_empty_cache_inactive passes. Note: the other failures listed in #6173 (test_memory_*, torch.cuda init SIGABRT) have unrelated root causes and are out of scope for this PR.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
