### PR TITLE
refactor: Default local package indexes to flat multi-arch layout

### DIFF
--- a/build_tools/packaging/python/generate_local_index.py
+++ b/build_tools/packaging/python/generate_local_index.py
@@ -5,9 +5,11 @@
 """Generate simple HTML index files for pip --find-links from local files.
 
 This module provides utilities to generate index.html files that pip can use
-with the --find-links option. It supports both simple single-directory indexes
-and multi-arch builds where each GPU family needs its own index that includes
-both family-specific packages and generic packages from the parent directory.
+with the --find-links option. By default, the CLI generates a flat multi-arch
+index for kpack-split package layouts where host, generic, and device packages
+all live in one directory. It can also generate per-family indexes for the
+kpack-disabled multi-arch layout where each GPU family has a subdirectory that
+also needs links to generic packages from the parent directory.
 
 For generating an index from packages already in S3, see generate_s3_index.py.
 
@@ -21,12 +23,12 @@ Usage as a library:
     )
 
 Usage as a script:
+    python generate_local_index.py dist/
     python generate_local_index.py dist/ --output dist/index.html
-    python generate_local_index.py dist/gfx94X-dcgpu/ --output dist/gfx94X-dcgpu/index.html --parent-dir dist/
+    python generate_local_index.py dist/ --per-family-indexes
 """
 
 import argparse
-import sys
 from pathlib import Path
 from urllib.parse import quote
 
@@ -104,9 +106,9 @@ def generate_simple_index(
 def generate_multiarch_indexes(
     dist_dir: Path, patterns: list[str] | None = None
 ) -> None:
-    """Generate per-family index files for multi-arch builds.
+    """Generate per-family indexes for kpack-disabled multi-arch builds.
 
-    For multi-arch builds, the dist directory structure is:
+    For kpack-disabled multi-arch builds, the dist directory structure is:
         dist/
           rocm_sdk_core-*.whl              (generic, top-level)
           gfx94X-dcgpu/
@@ -166,7 +168,14 @@ def generate_multiarch_indexes(
         )
 
 
-def main():
+def _find_matching_files(directory: Path, patterns: list[str]) -> list[Path]:
+    files = []
+    for pattern in patterns:
+        files.extend(f for f in directory.glob(pattern) if f.is_file())
+    return files
+
+
+def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
         description="Generate HTML index files for pip --find-links"
     )
@@ -186,9 +195,13 @@ def main():
         help="Parent directory containing additional packages (will use ../ links)",
     )
     parser.add_argument(
-        "--multiarch",
+        "--per-family-indexes",
         action="store_true",
-        help="Multi-arch mode: generate per-family indexes in subdirectories",
+        help=(
+            "Generate indexes for a kpack-disabled per-family layout. "
+            "Creates index.html in each immediate subdirectory and links "
+            "top-level packages as parent files."
+        ),
     )
     parser.add_argument(
         "--title",
@@ -203,25 +216,25 @@ def main():
         help="File patterns to include (default: *.whl *.tar.gz)",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    if args.multiarch:
-        # Multi-arch mode: generate indexes for each family subdirectory
+    if args.per_family_indexes:
+        if args.output:
+            parser.error("--output is only supported for flat index generation")
+        if args.parent_dir:
+            parser.error("--parent-dir is only supported for flat index generation")
+        # Kpack-disabled multi-arch mode: generate indexes for each family
+        # subdirectory.
         generate_multiarch_indexes(args.directory, patterns=args.patterns)
     else:
-        # Single directory mode
+        # Flat kpack-split multi-arch mode.
         output_path = args.output or (args.directory / "index.html")
-
-        # Find local files
-        local_files = []
-        for pattern in args.patterns:
-            local_files.extend(args.directory.glob(pattern))
-
-        # Find parent files if specified
-        parent_files = []
-        if args.parent_dir:
-            for pattern in args.patterns:
-                parent_files.extend(args.parent_dir.glob(pattern))
+        local_files = _find_matching_files(args.directory, args.patterns)
+        parent_files = (
+            _find_matching_files(args.parent_dir, args.patterns)
+            if args.parent_dir
+            else []
+        )
 
         generate_simple_index(
             output_path=output_path,

--- a/build_tools/packaging/tests/generate_local_index_test.py
+++ b/build_tools/packaging/tests/generate_local_index_test.py
@@ -13,6 +13,8 @@ import os
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr
+from io import StringIO
 from pathlib import Path
 
 # Add build_tools/packaging/python to path so generate_local_index is importable.
@@ -21,6 +23,7 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent / "python"))
 from generate_local_index import (
     generate_multiarch_indexes,
     generate_simple_index,
+    main,
 )
 
 
@@ -310,6 +313,117 @@ class TestGenerateMultiarchIndexes(unittest.TestCase):
             # Parent files
             self.assertIn("generic.whl", content)
             self.assertIn("generic.tar.gz", content)
+
+
+class TestCli(unittest.TestCase):
+    """Tests for generate_local_index.py CLI modes."""
+
+    def test_default_generates_flat_index(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+            (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
+            (dist_dir / "rocm_sdk_libraries-1.0.whl").write_bytes(b"libraries")
+            (dist_dir / "rocm_sdk_device_gfx942-1.0.whl").write_bytes(b"device")
+
+            main([os.fspath(dist_dir)])
+
+            content = (dist_dir / "index.html").read_text()
+            self.assertIn(
+                '<a href="./rocm_sdk_core-1.0.whl">rocm_sdk_core-1.0.whl</a>',
+                content,
+            )
+            self.assertIn(
+                '<a href="./rocm_sdk_libraries-1.0.whl">rocm_sdk_libraries-1.0.whl</a>',
+                content,
+            )
+            self.assertIn(
+                '<a href="./rocm_sdk_device_gfx942-1.0.whl">rocm_sdk_device_gfx942-1.0.whl</a>',
+                content,
+            )
+
+    def test_default_honors_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+            output = dist_dir / "custom.html"
+            (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
+
+            main([os.fspath(dist_dir), "--output", os.fspath(output)])
+
+            self.assertTrue(output.is_file())
+            self.assertFalse((dist_dir / "index.html").exists())
+
+    def test_default_honors_patterns(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+            (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
+            (dist_dir / "rocm-1.0.tar.gz").write_bytes(b"sdist")
+
+            main([os.fspath(dist_dir), "--patterns", "*.whl"])
+
+            content = (dist_dir / "index.html").read_text()
+            self.assertIn("rocm_sdk_core-1.0.whl", content)
+            self.assertNotIn("rocm-1.0.tar.gz", content)
+
+    def test_default_url_encodes_plus(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+            filename = "rocm_sdk_core-7.0.0+abc123-py3-none-any.whl"
+            (dist_dir / filename).write_bytes(b"core")
+
+            main([os.fspath(dist_dir)])
+
+            content = (dist_dir / "index.html").read_text()
+            self.assertIn(
+                'href="./rocm_sdk_core-7.0.0%2Babc123-py3-none-any.whl"',
+                content,
+            )
+            self.assertIn(f">{filename}</a>", content)
+
+    def test_per_family_indexes_generates_subdirectory_indexes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+            (dist_dir / "rocm_sdk_core-1.0.whl").write_bytes(b"core")
+            family_dir = dist_dir / "gfx94X-dcgpu"
+            family_dir.mkdir()
+            (family_dir / "rocm_sdk_libraries_gfx94x_dcgpu-1.0.whl").write_bytes(
+                b"libs"
+            )
+
+            main([os.fspath(dist_dir), "--per-family-indexes"])
+
+            self.assertTrue((family_dir / "index.html").is_file())
+            self.assertFalse((dist_dir / "index.html").exists())
+
+    def test_per_family_indexes_rejects_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+            (dist_dir / "gfx94X-dcgpu").mkdir()
+
+            with redirect_stderr(StringIO()), self.assertRaises(SystemExit):
+                main(
+                    [
+                        os.fspath(dist_dir),
+                        "--per-family-indexes",
+                        "--output",
+                        os.fspath(dist_dir / "index.html"),
+                    ]
+                )
+
+    def test_per_family_indexes_rejects_parent_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dist_dir = Path(tmp)
+            parent_dir = dist_dir / "parent"
+            (dist_dir / "gfx94X-dcgpu").mkdir()
+
+            with redirect_stderr(StringIO()), self.assertRaises(SystemExit):
+                main(
+                    [
+                        os.fspath(dist_dir),
+                        "--per-family-indexes",
+                        "--parent-dir",
+                        os.fspath(parent_dir),
+                    ]
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Updates `generate_local_index.py` so its default CLI mode writes a top-level `index.html` for flat kpack-split package directories. Keeps the kpack-disabled per-family layout available through an explicit `--per-family-indexes` option.

## Technical Details

This preserves the existing `generate_multiarch_indexes()` helper for callers such as `upload_python_packages.py`, and adds CLI coverage for the new default mode, custom output paths, pattern filtering, etc.

Closes #6382.

## Test Plan

Added unit tests for the new behavior.

## Test Result

Unit tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
