### PR TITLE
fix(ci): Install pytorch pinned requirements in core UT workflow

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -208,6 +208,7 @@ jobs:
       - name: Install test requirements
         run: |
           python -m pip install -r external-builds/pytorch/requirements-test.txt
+          python -m pip install -r external-builds/pytorch/pytorch/.ci/docker/requirements-ci.txt
           pip freeze
 
       - name: Run rocm-sdk sanity tests

--- a/external-builds/pytorch/README.md
+++ b/external-builds/pytorch/README.md
@@ -243,6 +243,9 @@ capabilities tailored for AMD ROCm GPUs. See the script for detailed
 instructions. Here are a few examples:
 
 ```bash
+# Install test dependencies
+python -m pip install -r pytorch/.ci/docker/requirements-ci.txt
+
 # Basic usage (auto-detect everything, no extra args):
 python run_pytorch_tests.py
 


### PR DESCRIPTION
## Motivation

PyTorch Core UT workflow only installs the requirements specified in TheRock, but not the more detailed pytorch requirements, which cause numpy version not pinned and therefore leading to [UT failures](https://github.com/ROCm/TheRock/issues/6095). Besides, this is also causing a lot of UTs missing dependencies such as scipy. This requirements.txt file IS installed in [test_pytorch_wheels_full](https://github.com/ROCm/TheRock/blob/main/.github/workflows/test_pytorch_wheels_full.yml#L335-L336), but not in this workflow.
