### PR TITLE
Cherry-pick: Replace core42 runner labels with ccs-csp

### DIFF
--- a/.github/workflows/test_jax_dockerfile.yml
+++ b/.github/workflows/test_jax_dockerfile.yml
@@ -9,7 +9,7 @@ on:
       test_runs_on:
         required: true
         type: string
-        default: "linux-gfx942-1gpu-core42-ossci-rocm"
+        default: "linux-gfx942-1gpu-ccs-csp-ossci-rocm"
       image_name:
         required: true
         description: JAX docker image to run tests with

--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -129,7 +129,7 @@ on:
         description: Runner label to use. The selected runner should have a GPU supported by amdgpu_family
         required: true
         type: string
-        default: "linux-gfx942-1gpu-core42-ossci-rocm"
+        default: "linux-gfx942-1gpu-ccs-csp-ossci-rocm"
       ref:
         description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow."
         type: string

--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -121,7 +121,7 @@ on:
       test_runs_on:
         description: Runner label to use. The selected runner should have a GPU supported by test_amdgpu_family
         type: string
-        default: "linux-gfx942-1gpu-core42-ossci-rocm"
+        default: "linux-gfx942-1gpu-ccs-csp-ossci-rocm"
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -130,7 +130,7 @@ jobs:
     needs: [prepare_install_context]
     strategy:
       fail-fast: false
-    runs-on: ${{ github.repository_owner == 'ROCm' && 'linux-gfx942-1gpu-core42-ossci-rocm' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository_owner == 'ROCm' && 'linux-gfx942-1gpu-ccs-csp-ossci-rocm' || 'ubuntu-24.04' }}
     container:
       image: ${{ needs.prepare_install_context.outputs.container_image }}
       options: --ipc host

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -15,7 +15,7 @@ on:
         description: Runner label to use. The selected runner should have a GPU supported by amdgpu_family
         required: true
         type: string
-        default: "linux-gfx942-1gpu-core42-ossci-rocm"
+        default: "linux-gfx942-1gpu-ccs-csp-ossci-rocm"
       package_index_url:
         description: >-
           Base Python package index URL to test.

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -15,7 +15,7 @@ on:
         description: Runner label to use. The selected runner should have a GPU supported by amdgpu_family
         required: true
         type: string
-        default: "linux-gfx942-1gpu-core42-ossci-rocm"
+        default: "linux-gfx942-1gpu-ccs-csp-ossci-rocm"
       test_runs_on_multi_gpu:
         description: Runner label for multi-GPU test configs (e.g. distributed). Corresponds to test-runs-on-multi-gpu in amdgpu_family_matrix.py
         type: string
@@ -94,7 +94,7 @@ on:
       test_runs_on:
         required: false
         type: string
-        default: "linux-gfx942-1gpu-core42-ossci-rocm"
+        default: "linux-gfx942-1gpu-ccs-csp-ossci-rocm"
       test_runs_on_multi_gpu:
         type: string
         default: "linux-gfx942-8gpu-ossci-rocm"

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -15,7 +15,7 @@ on:
         description: Runner label to use. The selected runner should have a GPU supported by amdgpu_family
         required: true
         type: string
-        default: "linux-gfx942-1gpu-core42-ossci-rocm"
+        default: "linux-gfx942-1gpu-ccs-csp-ossci-rocm"
       package_index_url_base:
         description: >-
           Base Python package index URL. For legacy per-family builds, this is

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -189,20 +189,20 @@ amdgpu_family_info_matrix_presubmit = {
         "linux": {
             # TODO: Remove multi-label config once we get dedicated set of machines
             # As we are bringing up mi325, we are using a multi-label configuration to distribute load
-            "test-runs-on": "linux-gfx942-1gpu-core42-ossci-rocm",
+            "test-runs-on": "linux-gfx942-1gpu-ccs-csp-ossci-rocm",
             "test-runs-on-labels": [
                 {
                     "label": "linux-gfx942-1gpu-ccs-ossci-rocm",
-                    "weight": 0.117,
-                },  # cirrascale (4/34)
+                    "weight": 0.1,
+                },  # ccs (5)
                 {
-                    "label": "linux-gfx942-1gpu-core42-ossci-rocm",
-                    "weight": 0.736,
-                },  # core42 (25/34)
+                    "label": "linux-gfx942-1gpu-ccs-csp-ossci-rocm",
+                    "weight": 0.8,
+                },  # ccs-csp (28)
                 {
                     "label": "linux-gfx942-1gpu-ossci-rocm",
-                    "weight": 0.147,
-                },  # vultr (5/34)
+                    "weight": 0.1,
+                },  # vultr (5)
             ],
             # TODO(#3433): Remove sandbox label once ASAN tests are passing
             "test-runs-on-sandbox": "linux-mi325-gpu-rocm-cpu-sandbox",
@@ -210,12 +210,8 @@ amdgpu_family_info_matrix_presubmit = {
             "test-runs-on-multi-gpu-labels": [
                 {
                     "label": "linux-gfx942-8gpu-ossci-rocm",
-                    "weight": 0.78,
-                },  # cirrascale (11/14)
-                {
-                    "label": "linux-gfx942-8gpu-core42-ossci-rocm",
-                    "weight": 0.21,
-                },  # core42 (3/14)
+                    "weight": 1.0,
+                },  # (10)
             ],
             # TODO(#2754): Add new benchmark-runs-on runner for benchmarks
             "benchmark-runs-on": "linux-gfx942-8gpu-ossci-rocm",

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -865,18 +865,6 @@ def _expand_build_config_for_platform(
         # Here we just use the default fallback label.
         test_runs_on = platform_info["test-runs-on"]
 
-        # TODO: use hard-coded label (vultr machines) as we try to determine core42 regression
-        # This is a temporary measure to get good signal for submodule bumps while we determine core42 issues
-        if (
-            platform == "linux"
-            and family_name == "gfx94x"
-            and git_context.changed_files is not None
-            and git_context.submodule_paths is not None
-        ):
-            matching = set(git_context.submodule_paths) & set(git_context.changed_files)
-            if matching:
-                test_runs_on = "linux-gfx942-1gpu-ossci-rocm"
-
         # When a test_runner:<kernel> label is set, use the
         # kernel-specific runner if available, otherwise disable testing for
         # this family (the default runner may not have the right kernel).

--- a/build_tools/github_actions/configure_rocm_python_test_matrix.py
+++ b/build_tools/github_actions/configure_rocm_python_test_matrix.py
@@ -88,7 +88,7 @@ def build_rocm_python_test_matrix(
         # [
         #   {
         #     "amdgpu_family": "gfx94X-dcgpu",
-        #     "test_runs_on": "linux-gfx942-1gpu-core42-ossci-rocm",
+        #     "test_runs_on": "linux-gfx942-1gpu-ccs-csp-ossci-rocm",
         #     "python_version": "3.10",
         #     "container_image_name": "ubuntu24.04",
         #     "container_image_url": "ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:..."
@@ -103,7 +103,7 @@ def build_rocm_python_test_matrix(
         #   ...
         #   {
         #     "amdgpu_family": "gfx94X-dcgpu",
-        #     "test_runs_on": "linux-gfx942-1gpu-core42-ossci-rocm",
+        #     "test_runs_on": "linux-gfx942-1gpu-ccs-csp-ossci-rocm",
         #     "python_version": "3.12",
         #     "container_image_name": "ubi10",
         #     "container_image_url": "ghcr.io/rocm/no_rocm_image_ubi10@sha256:..."

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1361,28 +1361,27 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
         # Verify label names
         label_names = [l["label"] for l in labels]
         self.assertIn("linux-gfx942-1gpu-ccs-ossci-rocm", label_names)
-        self.assertIn("linux-gfx942-1gpu-core42-ossci-rocm", label_names)
+        self.assertIn("linux-gfx942-1gpu-ccs-csp-ossci-rocm", label_names)
         self.assertIn("linux-gfx942-1gpu-ossci-rocm", label_names)
 
         # Verify weights sum to ~1.0
         total_weight = sum(l["weight"] for l in labels)
         self.assertAlmostEqual(total_weight, 1.0, places=1)
 
-    def test_gfx94x_multi_gpu_has_dual_label_config(self):
-        """Verify gfx94x has the multi-gpu dual-label configuration."""
+    def test_gfx94x_multi_gpu_has_label_config(self):
+        """Verify gfx94x has the multi-gpu label configuration."""
         from amdgpu_family_matrix import get_all_families_for_trigger_types
 
         all_families = get_all_families_for_trigger_types(["presubmit"])
         gfx94x_linux = all_families["gfx94x"].get("linux", {})
 
-        # Verify we have 2 labels for 8-gpu
+        # Verify we have 1 label for 8-gpu
         labels = gfx94x_linux["test-runs-on-multi-gpu-labels"]
-        self.assertEqual(len(labels), 2)
+        self.assertEqual(len(labels), 1)
 
         # Verify label names
         label_names = [l["label"] for l in labels]
         self.assertIn("linux-gfx942-8gpu-ossci-rocm", label_names)
-        self.assertIn("linux-gfx942-8gpu-core42-ossci-rocm", label_names)
 
         # Verify weights sum to 1.0
         total_weight = sum(l["weight"] for l in labels)
@@ -1412,9 +1411,9 @@ class TestMultiLabelRunnerSelection(unittest.TestCase):
 
         self.assertIsNotNone(builds.linux)
         gfx94x_info = builds.linux.per_family_info[0]
-        # Should use the default test-runs-on label (core42)
+        # Should use the default test-runs-on label (ccs-csp)
         self.assertEqual(
-            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-core42-ossci-rocm"
+            gfx94x_info["test-runs-on"], "linux-gfx942-1gpu-ccs-csp-ossci-rocm"
         )
 
     def test_families_without_multi_label_use_primary_only(self):

--- a/build_tools/github_actions/tests/configure_target_run_test.py
+++ b/build_tools/github_actions/tests/configure_target_run_test.py
@@ -16,14 +16,14 @@ class ConfigureTargetRunTest(unittest.TestCase):
         # gfx94X-dcgpu is the inner key, which we use for package names. When
         # run from a workflow, we expect to only work on the inner keys.
         runner_label = configure_target_run.get_runner_label("gfx94x", "linux")
-        self.assertEqual(runner_label, "linux-gfx942-1gpu-core42-ossci-rocm")
+        self.assertEqual(runner_label, "linux-gfx942-1gpu-ccs-csp-ossci-rocm")
 
     def test_linux_gfx94X_dcgpu(self):
         # gfx94x is the outer key used to construct workflow pipelines, while
         # gfx94X-dcgpu is the inner key, which we use for package names. When
         # run from a workflow, we expect to only work on the inner keys.
         runner_label = configure_target_run.get_runner_label("gfx94X-dcgpu", "linux")
-        self.assertEqual(runner_label, "linux-gfx942-1gpu-core42-ossci-rocm")
+        self.assertEqual(runner_label, "linux-gfx942-1gpu-ccs-csp-ossci-rocm")
 
     def test_windows_gfx115x(self):
         runner_label = configure_target_run.get_runner_label("gfx1151", "windows")

--- a/build_tools/github_actions/tests/fetch_package_targets_test.py
+++ b/build_tools/github_actions/tests/fetch_package_targets_test.py
@@ -138,8 +138,8 @@ class FetchPackageTargetsTest(unittest.TestCase):
             "THEROCK_PACKAGE_PLATFORM": "linux",
         }
 
-        # Mock random.random() to return 0.1 (< 0.369 first weight)
-        with patch("random.random", return_value=0.1):
+        # Mock random.random() to return 0.05 (< 0.1 first weight)
+        with patch("random.random", return_value=0.05):
             targets = fetch_package_targets.determine_package_targets(args)
 
         self.assertEqual(len(targets), 1)
@@ -152,13 +152,13 @@ class FetchPackageTargetsTest(unittest.TestCase):
             "THEROCK_PACKAGE_PLATFORM": "linux",
         }
 
-        # Mock random.random() to return 0.4 (>= 0.369, < 0.455)
-        with patch("random.random", return_value=0.4):
+        # Mock random.random() to return 0.5 (>= 0.1, < 0.9)
+        with patch("random.random", return_value=0.5):
             targets = fetch_package_targets.determine_package_targets(args)
 
         self.assertEqual(len(targets), 1)
         self.assertEqual(
-            targets[0]["test_machine"], "linux-gfx942-1gpu-core42-ossci-rocm"
+            targets[0]["test_machine"], "linux-gfx942-1gpu-ccs-csp-ossci-rocm"
         )
 
     def test_gfx94x_multi_label_selects_third_when_random_high(self):
@@ -168,14 +168,12 @@ class FetchPackageTargetsTest(unittest.TestCase):
             "THEROCK_PACKAGE_PLATFORM": "linux",
         }
 
-        # Mock random.random() to return 0.5 (>= 0.455)
-        with patch("random.random", return_value=0.5):
+        # Mock random.random() to return 0.95 (>= 0.9)
+        with patch("random.random", return_value=0.95):
             targets = fetch_package_targets.determine_package_targets(args)
 
         self.assertEqual(len(targets), 1)
-        self.assertEqual(
-            targets[0]["test_machine"], "linux-gfx942-1gpu-core42-ossci-rocm"
-        )
+        self.assertEqual(targets[0]["test_machine"], "linux-gfx942-1gpu-ossci-rocm")
 
     def test_families_without_multi_label_use_primary(self):
         """Families without multi-label config should use primary label."""


### PR DESCRIPTION
## Motivation

Cherry-picks two commits from main to update all runner label references from the decommissioned core42 pool to the new ccs-csp pool.

### Cherry-picked PRs:

#6275 — fix(ci): replace core42 runner labels with ccs-csp and updating amdgpu_family_matrix.py
#6269 — fix: Update default runner for JAX tests

###Changes:

amdgpu_family_matrix.py: Updates gfx94x Linux default runner from linux-gfx942-1gpu-core42-ossci-rocm → linux-gfx942-1gpu-ccs-csp-ossci-rocm; rebalances multi-label weights; collapses 8-GPU dual-label config to single label (linux-gfx942-8gpu-ossci-rocm)
configure_multi_arch_ci.py: Removes temporary vultr fallback for submodule changes (no longer needed)
Workflow defaults updated across 7 files:
test_jax_dockerfile.yml
test_linux_jax_wheels.yml
test_linux_jax_wheels_partial.yml (#6269)
test_native_linux_packages_install.yml
test_pytorch_wheels.yml
test_pytorch_wheels_full.yml
test_rocm_wheels.yml
Tests updated to match new labels and weights

**Target branch**: release/therock-7.14

