### PR TITLE
fix(rocprofiler-compute): set RPATH origin for pc-sampling test binary

### DIFF
--- a/profiler/post_hook_rocprofiler-compute.cmake
+++ b/profiler/post_hook_rocprofiler-compute.cmake
@@ -1,11 +1,13 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-# test-rocprofiler-compute-tool installs to libexec/rocprofiler-compute/tests/
-# instead of the default bin/. Tell TheRock the actual origin so it can compute
-# correct relative RPATH entries.
-if(TARGET test-rocprofiler-compute-tool)
-  set_target_properties(test-rocprofiler-compute-tool PROPERTIES
-    THEROCK_INSTALL_RPATH_ORIGIN libexec/rocprofiler-compute/tests
-  )
-endif()
+# These tests install to libexec/rocprofiler-compute/tests/ instead of the
+# default bin/. Tell TheRock the actual origin so it can compute correct
+# relative RPATH entries (including sysdeps under lib/rocm_sysdeps/lib).
+foreach(_test_target test-rocprofiler-compute-tool test-pc-sampling-collector)
+  if(TARGET ${_test_target})
+    set_target_properties(${_test_target} PROPERTIES
+      THEROCK_INSTALL_RPATH_ORIGIN libexec/rocprofiler-compute/tests
+    )
+  endif()
+endforeach()


### PR DESCRIPTION
## Summary

`test-pc-sampling-collector` fails at load with `error while loading shared libraries: librocm_sysdeps_dw.so.1: cannot open shared object file`. The unified test runner no longer adds sysdeps to `LD_LIBRARY_PATH`, so installed test binaries must resolve sysdeps via RPATH.

This test installs to `libexec/rocprofiler-compute/tests/`, not the default `bin/`. Without a correct `THEROCK_INSTALL_RPATH_ORIGIN`, TheRock computes its sysdeps RPATH relative to `bin/`, so `librocm_sysdeps_dw.so.1` (in `lib/rocm_sysdeps/lib`) is not found.

Extend the post-hook to set `THEROCK_INSTALL_RPATH_ORIGIN = libexec/rocprofiler-compute/tests` for `test-pc-sampling-collector`, mirroring the existing handling of `test-rocprofiler-compute-tool` (#5108).

ISSUE ID: https://github.com/ROCm/rocm-systems/issues/8186

## Testing Summary

- Verified against an existing build that `test-rocprofiler-compute-tool` RUNPATH already includes `$ORIGIN/../../../lib/rocm_sysdeps/lib` and `ldd` resolves `librocm_sysdeps_dw.so.1` cleanly; this applies the same origin to the pc-sampling test.
- CI to confirm `test-pc-sampling-collector` loads and passes.

Paired rocm-systems change (ROCm/rocm-systems#8191) removes the now-redundant hardcoded `INSTALL_RPATH` blocks from both test CMakeLists.