### PR TITLE
artifact_manager.py: add --find-matching-commit

### DIFF
--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -1171,10 +1171,17 @@ def _add_target_args(parser: argparse.ArgumentParser):
     )
 
 
-def _add_backend_args(parser: argparse.ArgumentParser):
-    """Add common backend-related arguments to a subparser."""
+def _add_backend_args(
+    parser: argparse.ArgumentParser,
+) -> argparse._MutuallyExclusiveGroup:
+    """Add common backend-related arguments to a subparser.
+
+    Returns the mutually exclusive group that owns --run-id so a subcommand can
+    add alternative run-id sources (e.g. fetch's --find-matching-commit) to it.
+    """
     _add_common_args(parser)
-    parser.add_argument(
+    run_id_group = parser.add_mutually_exclusive_group()
+    run_id_group.add_argument(
         "--run-id",
         type=str,
         default=os.getenv("THEROCK_RUN_ID", os.getenv("GITHUB_RUN_ID", "local")),
@@ -1199,6 +1206,7 @@ def _add_backend_args(parser: argparse.ArgumentParser):
         default=os.getenv("THEROCK_LOCAL_STAGING_DIR"),
         help="Local staging directory (sets THEROCK_LOCAL_STAGING_DIR)",
     )
+    return run_id_group
 
 
 def main(argv: Optional[List[str]] = None):
@@ -1213,7 +1221,7 @@ def main(argv: Optional[List[str]] = None):
     fetch_parser = subparsers.add_parser(
         "fetch", help="Fetch inbound artifacts for a stage"
     )
-    _add_backend_args(fetch_parser)
+    fetch_run_id_group = _add_backend_args(fetch_parser)
     fetch_parser.add_argument(
         "--stage",
         type=str,
@@ -1221,7 +1229,9 @@ def main(argv: Optional[List[str]] = None):
         help="Build stage name (default: 'all' fetches all artifacts)",
     )
     _add_target_args(fetch_parser)
-    fetch_parser.add_argument(
+    # Mutually exclusive with --run-id (same group): --find-matching-commit
+    # resolves the run ID itself, so passing both on the command line is an error.
+    fetch_run_id_group.add_argument(
         "--find-matching-commit",
         action="store_true",
         help="Resolve --run-id automatically by finding the CI workflow run "

--- a/build_tools/artifact_manager.py
+++ b/build_tools/artifact_manager.py
@@ -48,6 +48,7 @@ from dataclasses import dataclass
 import os
 import platform as platform_module
 import shutil
+import subprocess
 import sys
 import threading
 import time
@@ -71,6 +72,7 @@ from _therock_utils.artifact_backend import (
 from _therock_utils.artifacts import ArtifactName, ArtifactPopulator
 from _therock_utils.hash_util import calculate_hash
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
+from find_artifacts_for_commit import find_artifacts_for_commit, GitHubAPIError
 
 # Component types that artifacts are split into
 ARTIFACT_COMPONENTS = ["lib", "run", "dev", "dbg", "doc", "test"]
@@ -104,6 +106,53 @@ def get_topology(topology_path: Optional[Path] = None) -> BuildTopology:
     if not topology_path.exists():
         raise FileNotFoundError(f"BUILD_TOPOLOGY.toml not found at {topology_path}")
     return BuildTopology(str(topology_path))
+
+
+def _get_current_commit(repo_root: Path) -> str:
+    """Returns the currently checked-out commit SHA via `git rev-parse HEAD`."""
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _resolve_run_id_for_commit(
+    args: argparse.Namespace, target_families: List[str]
+) -> str:
+    """Resolves --run-id by finding the CI workflow run for the current HEAD commit.
+
+    Reuses find_artifacts_for_commit(), the same lookup find_artifacts_for_commit.py's
+    own CLI uses, so a developer with a commit checked out doesn't need to run that
+    script separately to discover a run ID.
+    """
+    commit = _get_current_commit(get_default_topology_path().parent)
+    log(f"Looking up CI workflow run for commit {commit}...")
+    try:
+        results = find_artifacts_for_commit(
+            commit=commit,
+            artifact_groups=target_families,
+            platform=args.platform,
+        )
+    except GitHubAPIError as e:
+        log(f"ERROR: {e}")
+        sys.exit(2)
+    if not results:
+        log(
+            f"ERROR: No CI artifacts found for commit {commit} (platform={args.platform})"
+        )
+        sys.exit(1)
+    run_ids = sorted({r.workflow_run_id for r in results}, key=int)
+    run_id = run_ids[-1]
+    if len(run_ids) > 1:
+        log(
+            f"WARNING: multiple workflow runs matched ({run_ids}); using most recent {run_id}"
+        )
+    log(f"Resolved commit {commit} -> workflow run {run_id}")
+    return run_id
 
 
 # =============================================================================
@@ -376,6 +425,10 @@ def do_fetch(args: argparse.Namespace):
         )
 
     target_families = parse_target_families(args)
+
+    if args.find_matching_commit:
+        args.run_id = _resolve_run_id_for_commit(args, target_families)
+
     excluded_artifacts = parse_excluded_artifacts(
         args.exclude_artifacts,
         set(topology.artifacts.keys()),
@@ -1168,6 +1221,13 @@ def main(argv: Optional[List[str]] = None):
         help="Build stage name (default: 'all' fetches all artifacts)",
     )
     _add_target_args(fetch_parser)
+    fetch_parser.add_argument(
+        "--find-matching-commit",
+        action="store_true",
+        help="Resolve --run-id automatically by finding the CI workflow run "
+        "that produced artifacts for the current HEAD commit. "
+        "Uses the same lookup as find_artifacts_for_commit.py.",
+    )
     fetch_parser.add_argument(
         "--output-dir",
         type=Path,

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -864,6 +864,38 @@ class TestFetchFindMatchingCommit(ArtifactManagerTestBase):
 
         self.assertEqual(mock_backend_factory.call_args.kwargs["run_id"], "22222")
 
+    @mock.patch("artifact_manager._get_current_commit")
+    @mock.patch("artifact_manager.find_artifacts_for_commit")
+    def test_find_matching_commit_conflicts_with_explicit_run_id(
+        self, mock_find_artifacts, mock_get_current_commit
+    ):
+        """Test that passing both --run-id and --find-matching-commit is rejected."""
+        import artifact_manager
+
+        argv = [
+            "fetch",
+            "--stage",
+            "all",
+            "--output-dir",
+            str(self.output_dir),
+            "--topology",
+            str(self.topology_path),
+            "--platform",
+            TEST_PLATFORM,
+            "--run-id",
+            "12345",
+            "--find-matching-commit",
+        ]
+
+        # argparse's mutually exclusive group rejects this at parse time (exit
+        # code 2), so the commit lookup never runs.
+        with self.assertRaises(SystemExit) as ctx:
+            artifact_manager.main(argv)
+
+        self.assertEqual(ctx.exception.code, 2)
+        mock_get_current_commit.assert_not_called()
+        mock_find_artifacts.assert_not_called()
+
 
 class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
     """Tests that fetch command correctly handles --amdgpu-targets for split artifacts."""

--- a/build_tools/tests/artifact_manager_tool_test.py
+++ b/build_tools/tests/artifact_manager_tool_test.py
@@ -730,6 +730,141 @@ class TestFetchStageAll(ArtifactManagerTestBase):
             artifact_manager.main(argv)
 
 
+class TestFetchFindMatchingCommit(ArtifactManagerTestBase):
+    """Tests that fetch --find-matching-commit resolves --run-id automatically."""
+
+    def _make_run_info(self, workflow_run_id: str, artifact_group: str):
+        from find_artifacts_for_commit import ArtifactRunInfo
+
+        return ArtifactRunInfo(
+            git_commit_sha="deadbeef",
+            github_repository_name="ROCm/TheRock",
+            external_repo="",
+            platform=TEST_PLATFORM,
+            artifact_group=artifact_group,
+            workflow_file_name="multi_arch_ci.yml",
+            workflow_run_id=workflow_run_id,
+            workflow_run_status="completed",
+            workflow_run_conclusion="success",
+            workflow_run_html_url="https://example.invalid/run",
+            s3_bucket="therock-ci-artifacts",
+        )
+
+    @mock.patch("artifact_manager._get_current_commit")
+    @mock.patch("artifact_manager.create_backend_from_env")
+    @mock.patch("artifact_manager.find_artifacts_for_commit")
+    def test_find_matching_commit_resolves_run_id(
+        self, mock_find_artifacts, mock_backend_factory, mock_get_current_commit
+    ):
+        """Test that the checked-out HEAD commit resolves to a run ID passed to create_backend_from_env."""
+        import artifact_manager
+
+        self._create_staged_artifact("test-artifact", "lib", "generic", run_id="99999")
+        mock_get_current_commit.return_value = "headcommit"
+        mock_find_artifacts.return_value = [self._make_run_info("99999", "generic")]
+        mock_backend_factory.side_effect = lambda **kwargs: LocalDirectoryBackend(
+            staging_dir=self.staging_dir,
+            output_root=WorkflowOutputRoot.for_local(
+                run_id=kwargs["run_id"], platform=TEST_PLATFORM
+            ),
+        )
+
+        argv = [
+            "fetch",
+            "--stage",
+            "all",
+            "--output-dir",
+            str(self.output_dir),
+            "--topology",
+            str(self.topology_path),
+            "--platform",
+            TEST_PLATFORM,
+            "--find-matching-commit",
+            "--no-extract",
+        ]
+
+        artifact_manager.main(argv)
+
+        mock_get_current_commit.assert_called_once()
+        mock_find_artifacts.assert_called_once()
+        self.assertEqual(mock_find_artifacts.call_args.kwargs["commit"], "headcommit")
+        self.assertEqual(
+            mock_backend_factory.call_args.kwargs["run_id"],
+            "99999",
+        )
+
+    @mock.patch("artifact_manager._get_current_commit")
+    @mock.patch("artifact_manager.find_artifacts_for_commit")
+    def test_find_matching_commit_exits_when_no_run_found(
+        self, mock_find_artifacts, mock_get_current_commit
+    ):
+        """Test that fetch exits with code 1 when no matching CI run is found."""
+        import artifact_manager
+
+        mock_get_current_commit.return_value = "headcommit"
+        mock_find_artifacts.return_value = []
+
+        argv = [
+            "fetch",
+            "--stage",
+            "all",
+            "--output-dir",
+            str(self.output_dir),
+            "--topology",
+            str(self.topology_path),
+            "--platform",
+            TEST_PLATFORM,
+            "--find-matching-commit",
+        ]
+
+        with self.assertRaises(SystemExit) as ctx:
+            artifact_manager.main(argv)
+
+        self.assertEqual(ctx.exception.code, 1)
+
+    @mock.patch("artifact_manager._get_current_commit")
+    @mock.patch("artifact_manager.create_backend_from_env")
+    @mock.patch("artifact_manager.find_artifacts_for_commit")
+    def test_find_matching_commit_picks_most_recent_of_multiple_runs(
+        self, mock_find_artifacts, mock_backend_factory, mock_get_current_commit
+    ):
+        """Test that the numerically largest run ID wins when runs disagree."""
+        import artifact_manager
+
+        self._create_staged_artifact("test-artifact", "lib", "generic", run_id="22222")
+        mock_get_current_commit.return_value = "headcommit"
+        mock_find_artifacts.return_value = [
+            self._make_run_info("11111", "generic"),
+            self._make_run_info("22222", "gfx1151"),
+        ]
+        mock_backend_factory.side_effect = lambda **kwargs: LocalDirectoryBackend(
+            staging_dir=self.staging_dir,
+            output_root=WorkflowOutputRoot.for_local(
+                run_id=kwargs["run_id"], platform=TEST_PLATFORM
+            ),
+        )
+
+        argv = [
+            "fetch",
+            "--stage",
+            "all",
+            "--output-dir",
+            str(self.output_dir),
+            "--topology",
+            str(self.topology_path),
+            "--platform",
+            TEST_PLATFORM,
+            "--find-matching-commit",
+            "--amdgpu-families",
+            "gfx1151",
+            "--no-extract",
+        ]
+
+        artifact_manager.main(argv)
+
+        self.assertEqual(mock_backend_factory.call_args.kwargs["run_id"], "22222")
+
+
 class TestFetchAmdgpuTargets(ArtifactManagerTestBase):
     """Tests that fetch command correctly handles --amdgpu-targets for split artifacts."""
 


### PR DESCRIPTION
Resolving a --run-id from a checked-out commit today requires a separate manual step with `find_artifacts_for_commit.py`. This wires that lookup directly into `fetch`, so a developer can go from a commit to a bootstrapped build tree in less commands without knowing the CI run ID ahead of time.

Now we can go from zero to building hipBLASLt in just
```
STAGE_NAME=math-libs
AMDGPU_FAMILY=gfx1151
BUILD_DIR=build
THEROCK_ROOT="/scratch/mgehre/TheRock"

python3 ./build_tools/artifact_manager.py fetch \
  --find-matching-commit \
  --stage "$STAGE_NAME" \
  --amdgpu-families "$AMDGPU_FAMILY" \
  --output-dir "$BUILD_DIR" \
  --bootstrap

cmake -B "$BUILD_DIR" -S . -GNinja \
  -DTHEROCK_AMDGPU_FAMILIES="$AMDGPU_FAMILY" \
  -DTHEROCK_DIST_AMDGPU_FAMILIES="$AMDGPU_FAMILY" \
  -DTHEROCK_ENABLE_ALL=OFF \
  -DTHEROCK_ENABLE_BLAS=ON

ninja -C $BUILD_DIR hipBLASLt+dist
```