### PR TITLE
ci(pytorch): strip conflicting GPU_DEVICE_ORDINAL before HIP init

### DIFF
--- a/external-builds/pytorch/pytorch_utils.py
+++ b/external-builds/pytorch/pytorch_utils.py
@@ -18,6 +18,9 @@ def reconcile_agent_visibility_env() -> None:
     The runner scripts always set HIP_VISIBLE_DEVICES, which supersedes and
     conflicts with a GPU_DEVICE_ORDINAL injected by the CI runner's isolation
     env-file (HIP aborts fatally on the mismatch).
+
+    See https://rocm.docs.amd.com/en/latest/conceptual/gpu-isolation.html for
+    multiple ways to achieve isolation of GPUs in the ROCm software stack.
     """
     gpu_device_ordinal = os.environ.pop("GPU_DEVICE_ORDINAL", None)
     if gpu_device_ordinal is not None:

--- a/external-builds/pytorch/pytorch_utils.py
+++ b/external-builds/pytorch/pytorch_utils.py
@@ -46,10 +46,6 @@ def get_supported_and_visible_gpus() -> tuple[list[str], list[str]]:
             - visible_gpus: List of AMDGPU archs physically visible
         Exits on failure.
     """
-    # Runs before the first torch subprocess, so any conflicting
-    # GPU_DEVICE_ORDINAL is removed before HIP initializes.
-    reconcile_agent_visibility_env()
-
     query_script = """
 import sys
 try:

--- a/external-builds/pytorch/pytorch_utils.py
+++ b/external-builds/pytorch/pytorch_utils.py
@@ -1,7 +1,13 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Shared utilities for PyTorch testing."""
+"""Shared utilities for PyTorch testing.
+
+Several helpers here manage GPU visibility/isolation through HIP_VISIBLE_DEVICES,
+ROCR_VISIBLE_DEVICES, and GPU_DEVICE_ORDINAL. See
+https://rocm.docs.amd.com/en/latest/conceptual/gpu-isolation.html for the
+multiple ways to achieve isolation of GPUs in the ROCm software stack.
+"""
 
 import os
 import subprocess
@@ -18,9 +24,6 @@ def reconcile_agent_visibility_env() -> None:
     The runner scripts always set HIP_VISIBLE_DEVICES, which supersedes and
     conflicts with a GPU_DEVICE_ORDINAL injected by the CI runner's isolation
     env-file (HIP aborts fatally on the mismatch).
-
-    See https://rocm.docs.amd.com/en/latest/conceptual/gpu-isolation.html for
-    multiple ways to achieve isolation of GPUs in the ROCm software stack.
     """
     gpu_device_ordinal = os.environ.pop("GPU_DEVICE_ORDINAL", None)
     if gpu_device_ordinal is not None:

--- a/external-builds/pytorch/pytorch_utils.py
+++ b/external-builds/pytorch/pytorch_utils.py
@@ -13,13 +13,13 @@ from packaging.version import Version
 
 
 def reconcile_agent_visibility_env() -> None:
-    """Drop GPU_DEVICE_ORDINAL when HIP_VISIBLE_DEVICES is set.
+    """Drop GPU_DEVICE_ORDINAL to avoid a fatal HIP agent-visibility conflict.
 
-    Avoids a fatal HIP agent-visibility conflict when a runner sets both;
-    HIP_VISIBLE_DEVICES supersedes.
+    The runner scripts always set HIP_VISIBLE_DEVICES, which supersedes and
+    conflicts with a GPU_DEVICE_ORDINAL injected by the CI runner's isolation
+    env-file (HIP aborts fatally on the mismatch).
     """
-    if os.environ.get("HIP_VISIBLE_DEVICES"):
-        os.environ.pop("GPU_DEVICE_ORDINAL", None)
+    os.environ.pop("GPU_DEVICE_ORDINAL", None)
 
 
 def get_supported_and_visible_gpus() -> tuple[list[str], list[str]]:
@@ -41,6 +41,10 @@ def get_supported_and_visible_gpus() -> tuple[list[str], list[str]]:
             - visible_gpus: List of AMDGPU archs physically visible
         Exits on failure.
     """
+    # Runs before the first torch subprocess, so any conflicting
+    # GPU_DEVICE_ORDINAL is removed before HIP initializes.
+    reconcile_agent_visibility_env()
+
     query_script = """
 import sys
 try:

--- a/external-builds/pytorch/pytorch_utils.py
+++ b/external-builds/pytorch/pytorch_utils.py
@@ -19,7 +19,12 @@ def reconcile_agent_visibility_env() -> None:
     conflicts with a GPU_DEVICE_ORDINAL injected by the CI runner's isolation
     env-file (HIP aborts fatally on the mismatch).
     """
-    os.environ.pop("GPU_DEVICE_ORDINAL", None)
+    gpu_device_ordinal = os.environ.pop("GPU_DEVICE_ORDINAL", None)
+    if gpu_device_ordinal is not None:
+        print(
+            f"Warning: dropped conflicting GPU_DEVICE_ORDINAL={gpu_device_ordinal} "
+            "(HIP_VISIBLE_DEVICES supersedes it)"
+        )
 
 
 def get_supported_and_visible_gpus() -> tuple[list[str], list[str]]:

--- a/external-builds/pytorch/pytorch_utils.py
+++ b/external-builds/pytorch/pytorch_utils.py
@@ -12,6 +12,16 @@ from importlib.metadata import version as get_package_version
 from packaging.version import Version
 
 
+def reconcile_agent_visibility_env() -> None:
+    """Drop GPU_DEVICE_ORDINAL when HIP_VISIBLE_DEVICES is set.
+
+    Avoids a fatal HIP agent-visibility conflict when a runner sets both;
+    HIP_VISIBLE_DEVICES supersedes.
+    """
+    if os.environ.get("HIP_VISIBLE_DEVICES"):
+        os.environ.pop("GPU_DEVICE_ORDINAL", None)
+
+
 def get_supported_and_visible_gpus() -> tuple[list[str], list[str]]:
     """Get both supported and visible GPUs in a single subprocess call.
 

--- a/external-builds/pytorch/pytorch_utils.py
+++ b/external-builds/pytorch/pytorch_utils.py
@@ -22,8 +22,8 @@ def reconcile_agent_visibility_env() -> None:
     gpu_device_ordinal = os.environ.pop("GPU_DEVICE_ORDINAL", None)
     if gpu_device_ordinal is not None:
         print(
-            f"Warning: dropped conflicting GPU_DEVICE_ORDINAL={gpu_device_ordinal} "
-            "(HIP_VISIBLE_DEVICES supersedes it)"
+            f"[WARNING] Unset GPU_DEVICE_ORDINAL={gpu_device_ordinal} "
+            "(HIP_VISIBLE_DEVICES takes precedence)"
         )
 
 

--- a/external-builds/pytorch/run_pytorch_smoke_tests.py
+++ b/external-builds/pytorch/run_pytorch_smoke_tests.py
@@ -27,10 +27,16 @@ from pathlib import Path
 
 from pytorch_utils import (
     get_unique_supported_devices,
+    reconcile_agent_visibility_env,
     set_gpu_execution_policy,
 )
 
 THIS_SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def setup_env() -> None:
+    """Set up environment variables required for the smoke tests."""
+    reconcile_agent_visibility_env()
 
 
 def cmd_arguments(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
@@ -88,6 +94,8 @@ def main() -> int:
         if not smoke_tests_dir.exists():
             print(f"ERROR: Directory at '{smoke_tests_dir}' does not exist.")
             sys.exit(1)
+
+        setup_env()
 
         # CRITICAL: Query unique devices for iteration.
         # HIP_VISIBLE_DEVICES will be set inside set_gpu_execution_policy.

--- a/external-builds/pytorch/run_pytorch_smoke_tests.py
+++ b/external-builds/pytorch/run_pytorch_smoke_tests.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 from pytorch_utils import (
     get_unique_supported_devices,
+    reconcile_agent_visibility_env,
     set_gpu_execution_policy,
 )
 
@@ -91,6 +92,7 @@ def main() -> int:
 
         # CRITICAL: Query unique devices for iteration.
         # HIP_VISIBLE_DEVICES will be set inside set_gpu_execution_policy.
+        reconcile_agent_visibility_env()
         unique_devices = get_unique_supported_devices(args.amdgpu_family)
 
         print(f"Will run smoke tests on {len(unique_devices)} unique device(s)")

--- a/external-builds/pytorch/run_pytorch_smoke_tests.py
+++ b/external-builds/pytorch/run_pytorch_smoke_tests.py
@@ -27,7 +27,6 @@ from pathlib import Path
 
 from pytorch_utils import (
     get_unique_supported_devices,
-    reconcile_agent_visibility_env,
     set_gpu_execution_policy,
 )
 
@@ -92,7 +91,6 @@ def main() -> int:
 
         # CRITICAL: Query unique devices for iteration.
         # HIP_VISIBLE_DEVICES will be set inside set_gpu_execution_policy.
-        reconcile_agent_visibility_env()
         unique_devices = get_unique_supported_devices(args.amdgpu_family)
 
         print(f"Will run smoke tests on {len(unique_devices)} unique device(s)")

--- a/external-builds/pytorch/run_pytorch_tests.py
+++ b/external-builds/pytorch/run_pytorch_tests.py
@@ -84,6 +84,7 @@ from pytorch_utils import (
     check_pytorch_source_version,
     configure_gpu_visibility,
     detect_pytorch_version,
+    reconcile_agent_visibility_env,
 )
 
 THIS_SCRIPT_DIR = Path(__file__).resolve().parent
@@ -100,6 +101,8 @@ def setup_env(pytorch_dir: str) -> None:
         - Creates a temporary directory for MIOpen cache
         - Modifies sys.path to include the test directory
     """
+    reconcile_agent_visibility_env()
+
     os.environ["PYTORCH_PRINT_REPRO_ON_FAILURE"] = "0"
     os.environ["PYTORCH_TEST_WITH_ROCM"] = "1"
     os.environ["MIOPEN_CUSTOM_CACHE_DIR"] = tempfile.mkdtemp()
@@ -255,6 +258,8 @@ def main() -> int:
             pytorch_dir=pytorch_dir, allow_mismatch=args.allow_version_mismatch
         )
 
+        setup_env(pytorch_dir)
+
         # CRITICAL: Determine AMDGPU family and set HIP_VISIBLE_DEVICES
         # BEFORE importing torch/running pytest. Once torch.cuda is initialized,
         # changing HIP_VISIBLE_DEVICES has no effect.
@@ -279,8 +284,6 @@ def main() -> int:
         # Allow manual override of test selection
         if args.k:
             tests_to_skip = args.k
-
-        setup_env(pytorch_dir)
 
         pytest_args = [
             f"{pytorch_dir}/test/test_nn.py",

--- a/external-builds/pytorch/run_pytorch_tests.py
+++ b/external-builds/pytorch/run_pytorch_tests.py
@@ -84,6 +84,7 @@ from pytorch_utils import (
     check_pytorch_source_version,
     configure_gpu_visibility,
     detect_pytorch_version,
+    reconcile_agent_visibility_env,
 )
 
 THIS_SCRIPT_DIR = Path(__file__).resolve().parent
@@ -258,6 +259,7 @@ def main() -> int:
         # CRITICAL: Determine AMDGPU family and set HIP_VISIBLE_DEVICES
         # BEFORE importing torch/running pytest. Once torch.cuda is initialized,
         # changing HIP_VISIBLE_DEVICES has no effect.
+        reconcile_agent_visibility_env()
         selected_archs = configure_gpu_visibility(
             args.amdgpu_family, args.device_query, args.gpu_policy
         )

--- a/external-builds/pytorch/run_pytorch_tests.py
+++ b/external-builds/pytorch/run_pytorch_tests.py
@@ -84,7 +84,6 @@ from pytorch_utils import (
     check_pytorch_source_version,
     configure_gpu_visibility,
     detect_pytorch_version,
-    reconcile_agent_visibility_env,
 )
 
 THIS_SCRIPT_DIR = Path(__file__).resolve().parent
@@ -259,7 +258,6 @@ def main() -> int:
         # CRITICAL: Determine AMDGPU family and set HIP_VISIBLE_DEVICES
         # BEFORE importing torch/running pytest. Once torch.cuda is initialized,
         # changing HIP_VISIBLE_DEVICES has no effect.
-        reconcile_agent_visibility_env()
         selected_archs = configure_gpu_visibility(
             args.amdgpu_family, args.device_query, args.gpu_policy
         )

--- a/external-builds/pytorch/run_pytorch_tests_full.py
+++ b/external-builds/pytorch/run_pytorch_tests_full.py
@@ -65,6 +65,7 @@ from pytorch_utils import (
     check_pytorch_source_version,
     configure_gpu_visibility,
     detect_pytorch_version,
+    reconcile_agent_visibility_env,
 )
 
 THIS_SCRIPT_DIR = Path(__file__).resolve().parent
@@ -140,6 +141,8 @@ INDUCTOR_UNIT_TESTS = [
 
 
 def setup_env(pytorch_dir: Path, test_config: str, amdgpu_family: str = "") -> None:
+    reconcile_agent_visibility_env()
+
     os.environ.setdefault("CI", "1")
     build_env = AMDGPU_FAMILY_TO_BUILD_ENV.get(
         amdgpu_family, ROCM_BUILD_ENVIRONMENT_DEFAULT
@@ -519,6 +522,12 @@ def main(argv: list[str]) -> int:
         pytorch_dir=args.pytorch_dir, allow_mismatch=args.allow_version_mismatch
     )
 
+    setup_env(
+        pytorch_dir=args.pytorch_dir,
+        test_config=args.test_config,
+        amdgpu_family=args.amdgpu_family,
+    )
+
     # Set HIP_VISIBLE_DEVICES BEFORE importing torch or running pytest. Once
     # torch.cuda is initialized, changing HIP_VISIBLE_DEVICES has no effect.
     selected_archs = configure_gpu_visibility(
@@ -540,11 +549,6 @@ def main(argv: list[str]) -> int:
             create_skip_list=not args.debug,
         )
 
-    setup_env(
-        pytorch_dir=args.pytorch_dir,
-        test_config=args.test_config,
-        amdgpu_family=args.amdgpu_family,
-    )
     print_env()
 
     if args.test_config == "inductor":

--- a/external-builds/pytorch/run_pytorch_tests_full.py
+++ b/external-builds/pytorch/run_pytorch_tests_full.py
@@ -65,6 +65,7 @@ from pytorch_utils import (
     check_pytorch_source_version,
     configure_gpu_visibility,
     detect_pytorch_version,
+    reconcile_agent_visibility_env,
 )
 
 THIS_SCRIPT_DIR = Path(__file__).resolve().parent
@@ -521,6 +522,7 @@ def main(argv: list[str]) -> int:
 
     # Set HIP_VISIBLE_DEVICES BEFORE importing torch or running pytest. Once
     # torch.cuda is initialized, changing HIP_VISIBLE_DEVICES has no effect.
+    reconcile_agent_visibility_env()
     selected_archs = configure_gpu_visibility(
         args.amdgpu_family, args.device_query, args.gpu_policy
     )

--- a/external-builds/pytorch/run_pytorch_tests_full.py
+++ b/external-builds/pytorch/run_pytorch_tests_full.py
@@ -65,7 +65,6 @@ from pytorch_utils import (
     check_pytorch_source_version,
     configure_gpu_visibility,
     detect_pytorch_version,
-    reconcile_agent_visibility_env,
 )
 
 THIS_SCRIPT_DIR = Path(__file__).resolve().parent
@@ -522,7 +521,6 @@ def main(argv: list[str]) -> int:
 
     # Set HIP_VISIBLE_DEVICES BEFORE importing torch or running pytest. Once
     # torch.cuda is initialized, changing HIP_VISIBLE_DEVICES has no effect.
-    reconcile_agent_visibility_env()
     selected_archs = configure_gpu_visibility(
         args.amdgpu_family, args.device_query, args.gpu_policy
     )


### PR DESCRIPTION
## Motivation

Fixes #5979

Some `linux-gfx90a-gpu-rocm` CI runners inject both `HIP_VISIBLE_DEVICES=0` and a
conflicting `GPU_DEVICE_ORDINAL` (1/2/4) through their GPU-isolation env-file
(`/etc/podinfo/gha-gpu-isolation-settings`). TheRock never sets it. Newer HIP
treats the mismatch as a fatal agent-visibility conflict:

```
F agent.cpp:245] Conflicting visibility of agent-2 between
HIP_VISIBLE_DEVICES and GPU_DEVICE_ORDINAL
```

so the PyTorch smoketests abort before any test runs.

## Technical Details

Add `reconcile_agent_visibility_env()` to `pytorch_utils.py`, which removes
`GPU_DEVICE_ORDINAL` (logging a warning when it was set). The runner scripts
always set `HIP_VISIBLE_DEVICES`, which supersedes it, so the ordinal always
conflicts.

The helper is invoked from each runner's `setup_env()`, and `setup_env()` now
runs before `configure_gpu_visibility()` so the reconciliation happens ahead of
the first torch/GPU query. The smoke runner, which previously had no
`setup_env()`, gets a minimal one.

Based on the same workaround added in #5767 for the rocprofiler-sdk test harness
(`build_tools/github_actions/test_executable_scripts/test_rocprofiler_sdk.py`).

## Test Plan

Confirm on `linux-gfx90a-gpu-rocm` that the PyTorch smoketests get past device
query (no `agent.cpp` fatal abort) and that the standard + full PyTorch test jobs
on gfx90a start normally.

## Test Result

Pending CI. The failure is integration-level (requires the runner env-file plus
the HIP runtime) and cannot be reproduced locally.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
