### PR TITLE
ci(pytorch): pin numpy per Python version to mirror upstream test CI

### DIFF
--- a/external-builds/pytorch/requirements-test.txt
+++ b/external-builds/pytorch/requirements-test.txt
@@ -6,6 +6,10 @@ pytest-xdist>=3.5.0
 expecttest>=0.3.0
 hypothesis
 ninja
+# NumPy pinned per Python version to match what upstream PyTorch's test CI
+# validates against; the unpinned tests break under newer NumPy (see
+# pytorch/pytorch#189267).
+# Source: pytorch/pytorch .ci/docker/requirements-ci.txt @ 6a13e44
 numpy==1.23.2; python_version == "3.10"
 numpy==1.26.2; python_version == "3.11" or python_version == "3.12"
 numpy==2.1.2; python_version >= "3.13" and python_version < "3.14"

--- a/external-builds/pytorch/requirements-test.txt
+++ b/external-builds/pytorch/requirements-test.txt
@@ -6,5 +6,8 @@ pytest-xdist>=3.5.0
 expecttest>=0.3.0
 hypothesis
 ninja
-numpy
+numpy==1.23.2; python_version == "3.10"
+numpy==1.26.2; python_version == "3.11" or python_version == "3.12"
+numpy==2.1.2; python_version >= "3.13" and python_version < "3.14"
+numpy==2.3.4; python_version >= "3.14"
 psutil


### PR DESCRIPTION
## Motivation

Fixes #6027
Fixes #6174

`numpy` was unpinned in `external-builds/pytorch/requirements-test.txt` (bare
`numpy` since the file was created in #903), so CI installed the newest release.
A numpy release after 2.4.6 tightened negative-int → `uint8` casting to raise
`OverflowError`, breaking upstream PyTorch's `nn.functional.threshold` OpInfo
reference (`np.where(...).astype(uint8)` with `value=-9`). This surfaced as 4
failing `test_reference_numerics_*_nn_functional_threshold_cuda_uint8` tests
across gfx90a / gfx94X / gfx950 / gfx1151 / gfx110X / gfx120X, py3.12–3.14.

**Torch version binding:** the failure was *observed* on the branches in the
failing matrix (2.9–2.11), but it is **not** specific to those versions and is
**not** fixed in newer torch. The same OpInfo (`value: -9` cast to `uint8`) is
still present unchanged on both the upstream `nightly` and
`release/2.12` (pinned to current HEAD):

- upstream `pytorch/pytorch@566bb97`: [`common_methods_invocations.py#L18461-L18475`](https://github.com/pytorch/pytorch/blob/566bb9719b0a67fe47af72cb69345dd809b5caec/torch/testing/_internal/common_methods_invocations.py#L18461-L18475)
- ROCm `ROCm/pytorch@7a68a17` (release/2.12): [`common_methods_invocations.py#L17628-L17642`](https://github.com/ROCm/pytorch/blob/7a68a172a909169dd46a732f6e97206da1a12ce6/torch/testing/_internal/common_methods_invocations.py#L17628-L17642)

Any torch version hits it given a new-enough numpy.

## Technical Details

Upstream PyTorch never hits this because its test CI pins numpy per Python
version. Pin numpy the same way, copied verbatim from `pytorch/pytorch`
`.ci/docker/requirements-ci.txt` (still pinned on trunk), so we test against the
exact numpy versions upstream validates against. Test-environment only — does not
touch shipped wheel metadata (the wheel's `pyproject` leaves numpy unpinned, so
end users still get the latest).

## Test Plan

The 4 `test_reference_numerics_*_nn_functional_threshold_cuda_uint8` tests should
pass in the full PyTorch test workflow across the affected arches / Python
versions.

## Test Result

Pending CI.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
