### PR TITLE
Harden tar extraction and drop rocm_sdk_libraries_None workaround

### DIFF
--- a/build_tools/packaging/promote_packages.py
+++ b/build_tools/packaging/promote_packages.py
@@ -824,9 +824,6 @@ def wheel_change_extra_files(
 
     # rocm packages needing extra handling
     if new_dir_path.name.startswith("rocm"):
-        # Workaround needed for multiarch until Jun 19, 2026 (see #6266 and #5984)
-        if "rocm_sdk_libraries" in new_dir_path.name and "gfx" not in new_dir_path.name:
-            package_name_no_version = "rocm_sdk_libraries_None"
         files_to_change = [
             new_dir_path / package_name_no_version / "_dist_info.py",
         ]
@@ -965,7 +962,9 @@ def promote_targz_sdist(
         tmp_path = pathlib.Path(tmp_dir)
 
         targz = tarfile.open(filename)
-        targz.extractall(tmp_path)
+        # PEP 706: refuse members with absolute paths / `..` traversal and strip
+        # unsafe metadata when extracting the downloaded sdist.
+        targz.extractall(tmp_path, filter="data")
         targz.close()
         print(" ...done")
 


### PR DESCRIPTION
## Motivation

Final two follow-ups from ROCm/TheRock#6266: harden the tar extraction against path-traversal / unsafe members, and remove the temporary `rocm_sdk_libraries_None` package-name workaround now that the underlying pure-package-name bug is fixed upstream (#5984, merged 2026-06-22). Stacked on #6402 / #6399.

## Technical Details

- Passes PEP 706 `filter="data"` to the sdist `extractall` in `promote_targz_sdist` (the only extraction site). Members with absolute paths or `..` traversal are now refused and unsafe metadata is stripped; verified it extracts the real `rocm-7.14.0rc1` sdist cleanly.
- Removes the `rocm_sdk_libraries_None` override in `wheel_change_extra_files`. The current multi-arch `rocm_sdk_libraries` wheel ships `rocm_sdk_libraries/_dist_info.py` (confirmed) with no `rocm_sdk_libraries_None/`, so the name derived from the wheel resolves directly and the temporary override is dead.

Both changes are exercised by the rewritten promotion test (#6399): the `rocm-*.tar.gz` sdist goes through the hardened extraction, and promoting `rocm_sdk_libraries` exercises the `_dist_info.py` rewrite. Kept draft.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
