### PR TITLE
feat(ci): add RHEL 8 native package install test

### DIFF
--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -200,6 +200,23 @@ jobs:
       contents: read
       id-token: write
 
+  test_native_packages_rhel8:
+    needs: [build_native_rpm_packages]
+    name: Test RPM Install - rhel8
+    if: ${{ !failure() && !cancelled() && fromJSON(inputs.build_config).build_native_linux == true }}
+    uses: ./.github/workflows/test_native_linux_packages_install.yml
+    with:
+      package_install_url: ${{ needs.build_native_rpm_packages.outputs.package_repository_url }}
+      release_type: ci
+      os_profile: rhel8
+      artifact_group: ${{ fromJSON(inputs.build_config).dist_amdgpu_families }}
+      test_type: sanity
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
+    permissions:
+      contents: read
+      id-token: write
+
   test_native_packages_rhel10:
     needs: [build_native_rpm_packages]
     name: Test RPM Install - rhel10

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -214,7 +214,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os_profile: [ubuntu2404, rhel10, sles16]
+        os_profile: [ubuntu2404, rhel8, rhel10, sles16]
     steps:
       - name: Trigger test_native_linux_packages_install
         uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -20,7 +20,7 @@ on:
         type: string
         default: ""
       os_profile:
-        description: OS profile (e.g., ubuntu2404, rhel10, sles16). Package type (deb/rpm) is derived from this.
+        description: OS profile (e.g., ubuntu2404, rhel8, rhel10, sles16). Package type (deb/rpm) is derived from this.
         required: true
         type: string
       artifact_group:
@@ -69,6 +69,7 @@ on:
         type: choice
         options:
           - ubuntu2404
+          - rhel8
           - rhel10
           - sles16
       artifact_group:
@@ -176,7 +177,7 @@ jobs:
               zypper install -y pciutils kmod
             fi
           else
-            # rpm (non-SLES on UBI 10); --allowerasing for curl vs curl-minimal on UBI
+            # rpm (non-SLES on RHEL/UBI); --allowerasing for curl vs curl-minimal on UBI
             dnf install -y --allowerasing \
               wget \
               curl \
@@ -197,8 +198,13 @@ jobs:
 
       - name: Setup Python and install runtime
         run: |
+          PY_EXTRA=()
+          if [ "${{ inputs.os_profile }}" = "rhel8" ]; then
+            PY_EXTRA=(--python-version 3.12)
+          fi
           bash build_tools/packaging/linux/setup_python_cmd.sh \
             --os-profile "${{ inputs.os_profile }}" \
+            "${PY_EXTRA[@]}" \
             --install-runtime \
             --output-format github
 

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -198,13 +198,8 @@ jobs:
 
       - name: Setup Python and install runtime
         run: |
-          PY_EXTRA=()
-          if [ "${{ inputs.os_profile }}" = "rhel8" ]; then
-            PY_EXTRA=(--python-version 3.12)
-          fi
           bash build_tools/packaging/linux/setup_python_cmd.sh \
             --os-profile "${{ inputs.os_profile }}" \
-            "${PY_EXTRA[@]}" \
             --install-runtime \
             --output-format github
 

--- a/build_tools/packaging/linux/get_url_repo_params.py
+++ b/build_tools/packaging/linux/get_url_repo_params.py
@@ -222,12 +222,18 @@ def cmd_extract_gfx_arch(args: argparse.Namespace) -> int:
 
 # --- get-container-image ---
 
-# Maps OS profile prefixes to container images (checked in order).
+# Maps OS profile prefixes to container images (checked in order; first match wins).
+# Single-profile entries (e.g. "rhel8") require an exact match so "rhel10" does not
+# match the "rhel8" prefix via startswith.
 _OS_PROFILE_TO_IMAGE: list[tuple[tuple[str, ...], str]] = [
     (("sles",), "registry.suse.com/bci/bci-base:16.0"),
     (("ubuntu", "debian"), "ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest"),
-    ((), "registry.access.redhat.com/ubi10/ubi:10.1"),  # default (e.g. rhel*)
+    (("rhel8",), "registry.access.redhat.com/ubi8/ubi:8.10"),
+    ((), "registry.access.redhat.com/ubi10/ubi:10.1"),  # default (e.g. rhel10)
 ]
+
+# Single-prefix entries that must match the full profile (not startswith).
+_EXACT_PROFILE_PREFIXES = frozenset({"rhel8"})
 
 
 def get_container_image(os_profile: str) -> str:
@@ -237,10 +243,18 @@ def get_container_image(os_profile: str) -> str:
         ubuntu2404  -> ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
         debian12    -> ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
         sles16      -> registry.suse.com/bci/bci-base:16.0
+        rhel8       -> registry.access.redhat.com/ubi8/ubi:8.10
         rhel10      -> registry.access.redhat.com/ubi10/ubi:10.1
     """
+    profile = os_profile.lower()
     for prefixes, image in _OS_PROFILE_TO_IMAGE:
-        if not prefixes or any(os_profile.startswith(p) for p in prefixes):
+        if not prefixes:
+            return image
+        if len(prefixes) == 1 and prefixes[0] in _EXACT_PROFILE_PREFIXES:
+            if profile == prefixes[0]:
+                return image
+            continue
+        if any(profile.startswith(p) for p in prefixes):
             return image
     return _OS_PROFILE_TO_IMAGE[-1][1]  # unreachable but satisfies type checker
 

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -184,7 +184,6 @@ APT_UPDATE_TIMEOUT_SEC = 120
 ZYPP_CLEAN_TIMEOUT_SEC = 60
 ZYPP_REFRESH_TIMEOUT_SEC = 120
 DNF_CLEAN_TIMEOUT_SEC = 60
-DNF_MAKECACHE_TIMEOUT_SEC = 120
 INSTALL_TIMEOUT_SEC = 1800  # 30 minutes
 ROCMINFO_TIMEOUT_SEC = 30
 RDHC_TIMEOUT_SEC = 30
@@ -293,11 +292,6 @@ def _run_streaming(cmd: list[str], timeout_sec: int) -> int:
         raise
 
 
-def _is_rhel8_profile(os_profile: str) -> bool:
-    """True only for the ``rhel8`` OS profile (not other EL8/RHEL-like names)."""
-    return os_profile.lower() == "rhel8"
-
-
 class NativeLinuxPackageInstallTest:
     """Runner for the native Linux package install test (repo setup, install, verification)."""
 
@@ -358,10 +352,6 @@ class NativeLinuxPackageInstallTest:
         True if SLES, False otherwise
         """
         return self.os_profile.lower().startswith("sles")
-
-    def _is_rhel8(self) -> bool:
-        """Check if the OS profile is ``rhel8``."""
-        return _is_rhel8_profile(self.os_profile)
 
     def __init__(
         self,
@@ -717,25 +707,8 @@ gpgcheck=0
         except subprocess.TimeoutExpired:
             print("[WARN] dnf clean timed out (may not be critical)")
 
-        # Refresh metadata (required on EL8 before first ``dnf install`` from a new .repo)
-        print(f"\nRefreshing repository metadata (dnf makecache --repo={repo_name})...")
-        try:
-            makecache_cmd = ["dnf", "makecache", f"--repo={repo_name}"]
-            return_code = _run_streaming(makecache_cmd, DNF_MAKECACHE_TIMEOUT_SEC)
-            if return_code == 0:
-                print("\n[PASS] DNF repository metadata refreshed")
-                return True
-            print(
-                f"\n[FAIL] dnf makecache failed for repo '{repo_name}' "
-                f"(exit code: {return_code})"
-            )
-            return False
-        except subprocess.TimeoutExpired:
-            print("\n[FAIL] dnf makecache timed out")
-            return False
-        except OSError as e:
-            print(f"\n[FAIL] Error refreshing DNF repository metadata: {e}")
-            return False
+        print("\n[PASS] DNF repository setup complete")
+        return True
 
     def setup_rpm_repository(self) -> bool:
         """Setup RPM repository on the system.
@@ -832,11 +805,7 @@ gpgcheck=0
                 ] + self.package_names
             print("[INFO] Using zypper for SLES package installation")
         else:
-            dnf_args = ["dnf", "install", "-y"]
-            if self._is_rhel8():
-                # rhel8 only: EL8 repos occasionally need --nobest for ROCm deps.
-                dnf_args.append("--nobest")
-            cmd = dnf_args + self.package_names
+            cmd = ["dnf", "install", "-y"] + self.package_names
         print(f"\nRunning: {' '.join(cmd)}")
         print("=" * 80)
         print("Installation progress (streaming output):\n")

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -72,7 +72,7 @@ Example invocations:
          --release-type prerelease \\
          --gpg-key-url https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
 
- # Nightly RPM (RHEL 8) - run inside rhel8/almalinux container or VM
+ # Nightly RPM (RHEL 8) - run inside a rhel8/UBI 8 container or VM
  python3 native_linux_package_install_test.py \\
          --os-profile rhel8 \\
          --repo-url https://rocm.nightlies.amd.com/rpm/20260204-21658678136/x86_64/ \\
@@ -184,6 +184,7 @@ APT_UPDATE_TIMEOUT_SEC = 120
 ZYPP_CLEAN_TIMEOUT_SEC = 60
 ZYPP_REFRESH_TIMEOUT_SEC = 120
 DNF_CLEAN_TIMEOUT_SEC = 60
+DNF_MAKECACHE_TIMEOUT_SEC = 120
 INSTALL_TIMEOUT_SEC = 1800  # 30 minutes
 ROCMINFO_TIMEOUT_SEC = 30
 RDHC_TIMEOUT_SEC = 30
@@ -292,6 +293,11 @@ def _run_streaming(cmd: list[str], timeout_sec: int) -> int:
         raise
 
 
+def _is_rhel8_profile(os_profile: str) -> bool:
+    """True only for the ``rhel8`` OS profile (not other EL8/RHEL-like names)."""
+    return os_profile.lower() == "rhel8"
+
+
 class NativeLinuxPackageInstallTest:
     """Runner for the native Linux package install test (repo setup, install, verification)."""
 
@@ -352,6 +358,10 @@ class NativeLinuxPackageInstallTest:
         True if SLES, False otherwise
         """
         return self.os_profile.lower().startswith("sles")
+
+    def _is_rhel8(self) -> bool:
+        """Check if the OS profile is ``rhel8``."""
+        return _is_rhel8_profile(self.os_profile)
 
     def __init__(
         self,
@@ -707,8 +717,25 @@ gpgcheck=0
         except subprocess.TimeoutExpired:
             print("[WARN] dnf clean timed out (may not be critical)")
 
-        print("\n[PASS] DNF repository setup complete")
-        return True
+        # Refresh metadata (required on EL8 before first ``dnf install`` from a new .repo)
+        print(f"\nRefreshing repository metadata (dnf makecache --repo={repo_name})...")
+        try:
+            makecache_cmd = ["dnf", "makecache", f"--repo={repo_name}"]
+            return_code = _run_streaming(makecache_cmd, DNF_MAKECACHE_TIMEOUT_SEC)
+            if return_code == 0:
+                print("\n[PASS] DNF repository metadata refreshed")
+                return True
+            print(
+                f"\n[FAIL] dnf makecache failed for repo '{repo_name}' "
+                f"(exit code: {return_code})"
+            )
+            return False
+        except subprocess.TimeoutExpired:
+            print("\n[FAIL] dnf makecache timed out")
+            return False
+        except OSError as e:
+            print(f"\n[FAIL] Error refreshing DNF repository metadata: {e}")
+            return False
 
     def setup_rpm_repository(self) -> bool:
         """Setup RPM repository on the system.
@@ -805,7 +832,11 @@ gpgcheck=0
                 ] + self.package_names
             print("[INFO] Using zypper for SLES package installation")
         else:
-            cmd = ["dnf", "install", "-y"] + self.package_names
+            dnf_args = ["dnf", "install", "-y"]
+            if self._is_rhel8():
+                # rhel8 only: EL8 repos occasionally need --nobest for ROCm deps.
+                dnf_args.append("--nobest")
+            cmd = dnf_args + self.package_names
         print(f"\nRunning: {' '.join(cmd)}")
         print("=" * 80)
         print("Installation progress (streaming output):\n")
@@ -1054,6 +1085,11 @@ Examples:
 
  # Nightly RPM (RHEL 8)
  python native_linux_package_install_test.py --os-profile rhel8 \\
+ --repo-url https://rocm.nightlies.amd.com/rpm/20260204-21658678136/rhel8/x86_64/ \\
+ --gfx-arch gfx94x --release-type nightly --install-prefix /opt/rocm/core
+
+ # --test-type full on RHEL 8 (rdhc needs pciutils/kmod on the host — install before running)
+ python native_linux_package_install_test.py --test-type full --os-profile rhel8 \\
  --repo-url https://rocm.nightlies.amd.com/rpm/20260204-21658678136/rhel8/x86_64/ \\
  --gfx-arch gfx94x --release-type nightly --install-prefix /opt/rocm/core
 

--- a/build_tools/packaging/linux/setup_python_cmd.sh
+++ b/build_tools/packaging/linux/setup_python_cmd.sh
@@ -8,10 +8,12 @@
 #
 # - ubuntu* / debian* -> apt: python3, python3-venv, python3-pip -> PYTHON_CMD=python3
 # - sles* -> zypper: python313, python313-pip (SLE/BCI; unversioned python3 / python3-pip are not valid package names) -> PYTHON_CMD=python3.13
+# - rhel8 -> dnf: python3.12, python3.12-pip -> PYTHON_CMD=python3.12
 # - else (e.g. UBI 10 / RHEL-like) -> dnf: python3, python3-pip -> PYTHON_CMD=python3
 #
 # Optional --python-version X.Y (e.g. 3.12): install that stream where supported
 # (apt + dnf). Use on UBI 9 / RHEL 9 when default python3 is older than you need.
+# rhel8 defaults to 3.12 when --python-version is omitted.
 # On SLES, --python-version is ignored (zypper names vary); distro python3 is used.
 #
 # Use --install-runtime in CI so Python install lives in this script (not the workflow
@@ -84,6 +86,11 @@ OS_PLC="${OS_PROFILE,,}"
 if [[ -n "$PY_MM" ]] && ! [[ "$PY_MM" =~ ^[0-9]+\.[0-9]+$ ]]; then
     echo "Error: --python-version must be MAJOR.MINOR (e.g. 3.12)" >&2
     exit 1
+fi
+
+# UBI 8 / RHEL 8: default python3 may be older than CI needs; pin 3.12 unless overridden.
+if [[ -z "$PY_MM" ]] && [[ "$OS_PLC" == "rhel8" ]]; then
+    PY_MM="3.12"
 fi
 
 if [[ -n "$PY_MM" ]]; then

--- a/build_tools/packaging/linux/tests/get_url_repo_params_test.py
+++ b/build_tools/packaging/linux/tests/get_url_repo_params_test.py
@@ -499,6 +499,12 @@ class GetContainerImageTest(unittest.TestCase):
             "registry.suse.com/bci/bci-base:16.0",
         )
 
+    def test_rhel8_returns_ubi8_image(self):
+        self.assertEqual(
+            get_url_repo_params.get_container_image("rhel8"),
+            "registry.access.redhat.com/ubi8/ubi:8.10",
+        )
+
     def test_rhel_returns_ubi_image(self):
         self.assertEqual(
             get_url_repo_params.get_container_image("rhel10"),

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -1241,12 +1241,12 @@ class SetupSlesRepositoryTest(unittest.TestCase):
 class SetupDnfRepositoryTest(unittest.TestCase):
     """Tests for NativeLinuxPackageInstallTest._setup_dnf_repository()."""
 
-    @patch("native_linux_package_install_test.subprocess.run")
+    @patch("native_linux_package_install_test._run_streaming", return_value=0)
     @patch("native_linux_package_install_test.Path.write_text")
-    def test_returns_true_after_writing_repo_file(self, mock_write_text, mock_run):
-        # Test that _setup_dnf_repository writes repo file and returns True (dnf clean may be mocked).
-        # Uses Path.write_text, not open().
-        mock_run.side_effect = None
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_returns_true_after_writing_repo_file_and_makecache(
+        self, mock_run, mock_write_text, mock_streaming
+    ):
         mock_run.return_value = MagicMock(returncode=0)
         t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
             repo_url="https://repo.example.com",
@@ -1256,6 +1256,8 @@ class SetupDnfRepositoryTest(unittest.TestCase):
         self.assertTrue(t._setup_dnf_repository())
         written = mock_write_text.call_args[0][0]
         self.assertIn("baseurl=https://repo.example.com", written)
+        makecache_cmd = mock_streaming.call_args[0][0]
+        self.assertIn("makecache", makecache_cmd)
 
 
 class SetupRpmRepositoryTest(unittest.TestCase):
@@ -1367,6 +1369,19 @@ class InstallRpmPackagesTest(unittest.TestCase):
         self.assertTrue(t.install_rpm_packages())
         call_args = mock_streaming.call_args[0][0]
         self.assertEqual(call_args[0], "dnf")
+        self.assertIn("--nobest", call_args)
+
+    @patch("native_linux_package_install_test._run_streaming")
+    def test_rhel10_dnf_install_without_nobest(self, mock_streaming):
+        mock_streaming.return_value = 0
+        t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+            repo_url="https://example.com",
+            os_profile="rhel10",
+            gfx_arch="gfx94x",
+        )
+        self.assertTrue(t.install_rpm_packages())
+        call_args = mock_streaming.call_args[0][0]
+        self.assertNotIn("--nobest", call_args)
 
     @patch("native_linux_package_install_test._run_streaming")
     def test_returns_true_when_zypper_install_succeeds(self, mock_streaming):

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -1241,12 +1241,10 @@ class SetupSlesRepositoryTest(unittest.TestCase):
 class SetupDnfRepositoryTest(unittest.TestCase):
     """Tests for NativeLinuxPackageInstallTest._setup_dnf_repository()."""
 
-    @patch("native_linux_package_install_test._run_streaming", return_value=0)
-    @patch("native_linux_package_install_test.Path.write_text")
     @patch("native_linux_package_install_test.subprocess.run")
-    def test_returns_true_after_writing_repo_file_and_makecache(
-        self, mock_run, mock_write_text, mock_streaming
-    ):
+    @patch("native_linux_package_install_test.Path.write_text")
+    def test_returns_true_after_writing_repo_file(self, mock_write_text, mock_run):
+        # Test that _setup_dnf_repository writes repo file and returns True (dnf clean may be mocked).
         mock_run.return_value = MagicMock(returncode=0)
         t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
             repo_url="https://repo.example.com",
@@ -1256,8 +1254,6 @@ class SetupDnfRepositoryTest(unittest.TestCase):
         self.assertTrue(t._setup_dnf_repository())
         written = mock_write_text.call_args[0][0]
         self.assertIn("baseurl=https://repo.example.com", written)
-        makecache_cmd = mock_streaming.call_args[0][0]
-        self.assertIn("makecache", makecache_cmd)
 
 
 class SetupRpmRepositoryTest(unittest.TestCase):
@@ -1369,19 +1365,6 @@ class InstallRpmPackagesTest(unittest.TestCase):
         self.assertTrue(t.install_rpm_packages())
         call_args = mock_streaming.call_args[0][0]
         self.assertEqual(call_args[0], "dnf")
-        self.assertIn("--nobest", call_args)
-
-    @patch("native_linux_package_install_test._run_streaming")
-    def test_rhel10_dnf_install_without_nobest(self, mock_streaming):
-        mock_streaming.return_value = 0
-        t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
-            repo_url="https://example.com",
-            os_profile="rhel10",
-            gfx_arch="gfx94x",
-        )
-        self.assertTrue(t.install_rpm_packages())
-        call_args = mock_streaming.call_args[0][0]
-        self.assertNotIn("--nobest", call_args)
 
     @patch("native_linux_package_install_test._run_streaming")
     def test_returns_true_when_zypper_install_succeeds(self, mock_streaming):

--- a/build_tools/packaging/linux/tests/setup_python_cmd_test.sh
+++ b/build_tools/packaging/linux/tests/setup_python_cmd_test.sh
@@ -102,6 +102,9 @@ test_sles_profiles() {
 
 test_rhel_profiles() {
     local output
+    output=$(run_github_format --os-profile rhel8)
+    assert_equals "PYTHON_CMD=python3.12" "$output" "RHEL 8 resolves to python3.12"
+
     output=$(run_github_format --os-profile rhel10)
     assert_equals "PYTHON_CMD=python3.12" "$output" "RHEL 10 resolves to python3.12"
 


### PR DESCRIPTION
## Motivation

Add RHEL 8 (`rhel8`) to the native Linux package **install smoke test** pipeline, alongside existing profiles such as `ubuntu2404`, `rhel10`, and `sles16`. This validates that ROCm RPMs can be installed from CI-built repositories on an EL8 userspace (UBI 8.10).

## Technical Details

Key changes include:

**In scope — install smoke test (this PR):**
- Repo setup, `dnf install` of ROCm metapackages, and basic install verification inside a UBI 8 container
- Same pattern as the existing Docker-based native install jobs for other OS profiles

**Out of scope — functional / kernel-level validation:**
- RHEL 8.10 / kernel 4.18 kpack issues cannot be exercised in Docker because containers use the **host kernel**
- That class of testing belongs on the complementary KVM/QEMU path ([#6318](https://github.com/ROCm/TheRock/pull/6318), automation in [#6413](https://github.com/ROCm/TheRock/pull/6413)), where a full VM (e.g. Rocky Linux 8.10) runs the target kernel and a GPU can be exposed via PCI passthrough

**CI workflow and OS profile support**
- Add `rhel8` to `multi_arch_ci_linux.yml` (new `test_native_packages_rhel8` job)
- Add `rhel8` to the install-test matrix in `multi_arch_release_linux.yml`
- Add `rhel8` to `test_native_linux_packages_install.yml` (workflow_call + workflow_dispatch)

**Package install test script**
- Add `rhel8`-specific handling in `native_linux_package_install_test.py` for EL8 install behavior
- Extend unit tests in `native_linux_package_install_ut_test.py` for rhel8 paths
- Update CLI examples/docs for rhel8 RPM install invocations

ISSUE ID: #6065

## Test Plan

- [ ] `workflow_dispatch` of `test_native_linux_packages_install.yml` with `os_profile=ubuntu2404` (regression — no change in behavior)
- [ ] `workflow_dispatch` of `test_native_linux_packages_install.yml` with `os_profile=rhel8`
- [ ] Multi-arch CI path: `test_native_packages_rhel8` job passes on a PR CI run
- [ ] Local/unit tests:
  - `bash build_tools/packaging/linux/tests/setup_python_cmd_test.sh`
  - `python -m pytest build_tools/packaging/linux/tests/get_url_repo_params_test.py -k rhel8`
  - `python -m pytest build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py -k rhel8`

## Test Result

1. rhel8 sanity - https://github.com/ROCm/TheRock/actions/runs/28956659590
2. 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
