### PR TITLE
fix(ci): Handle null family_overrides in external repo config

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -1094,6 +1094,9 @@ def _apply_external_family_overrides(all_families: dict) -> dict:
         import json
 
         external_overrides = json.loads(external_overrides_json)
+        # Handle null/None (when external_repo JSON doesn't have family_overrides key)
+        if not external_overrides:
+            return all_families
         for family_name, family_config in external_overrides.items():
             if family_name in all_families:
                 # Merge overrides into existing family config


### PR DESCRIPTION
When external repos call setup_multi_arch.yml without specifying family_overrides in their external_repo JSON, the workflow expression `toJSON(fromJSON(inputs.external_repo).family_overrides)` produces the string "null". This caused json.loads("null") to return None, and then None.items() raised an AttributeError.

Add a check for null/empty external_overrides before iterating.

Working as expected: https://github.com/ROCm/rocm-libraries/actions/runs/28896388653/job/85722082854