### PR TITLE
build: Disable CMake package registry within sub-projects

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -781,6 +781,20 @@ function(therock_cmake_subproject_activate target_name)
   get_property(_all_provided_packages GLOBAL PROPERTY THEROCK_ALL_PROVIDED_PACKAGES)
   string(APPEND _init_contents "set(THEROCK_STRICT_PROVIDED_PACKAGES \"@_all_provided_packages@\")\n")
 
+  # Disable the CMake package registry within sub-projects. Correct super-project
+  # resolution goes through the dependency provider and trampoline configs on
+  # CMAKE_PREFIX_PATH, never the registry. Leaving the registry enabled lets an
+  # undeclared find_package() latch onto a stray build tree recorded by a sibling
+  # sub-project's export(PACKAGE) (see the system-fallback path in
+  # therock_subproject_dep_provider.cmake). Gated on the same switch as the safe
+  # dependency provider so that disabling it restores full stock find_package()
+  # behavior.
+  string(APPEND _init_contents "if(THEROCK_USE_SAFE_DEPENDENCY_PROVIDER)\n")
+  string(APPEND _init_contents "  set(CMAKE_FIND_USE_PACKAGE_REGISTRY OFF)\n")
+  string(APPEND _init_contents "  set(CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY OFF)\n")
+  string(APPEND _init_contents "  set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)\n")
+  string(APPEND _init_contents "endif()\n")
+
   # Include dirs.
   foreach(_private_include_dir ${_private_include_dirs})
     if(THEROCK_VERBOSE)


### PR DESCRIPTION
## Motivation

TheRock sub-projects resolve super-project packages through the dependency provider and trampoline configs on `CMAKE_PREFIX_PATH`, never the CMake package registry. Leaving the registry enabled is a hole in the hermetic sub-project sandbox: an undeclared `find_package()` can latch onto a stray build tree recorded in `~/.cmake/packages` by a sibling sub-project's `export(PACKAGE)`, and the system-fallback path in the dependency provider (`find_package` with `BYPASS_PROVIDER`) consults the registry even when the safe provider is active.

## Technical Details

With this patch, TheRock emits `CMAKE_FIND_USE_PACKAGE_REGISTRY=OFF`, `CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF` and
`CMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON` into the sub-project init contents so sub-projects neither read from nor write to the registry. This converts a future undeclared-optional `find_package()` from "latches onto a stray build tree" into a clean not-found. Placed in the always-generated init contents (rather than the dependency provider file, which is only included when a sub-project has declared deps) and gated on `THEROCK_USE_SAFE_DEPENDENCY_PROVIDER` so that disabling that switch restores full stock `find_package()` behavior.

With this we further harden for issues like GitHub #6376.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
