### PR TITLE
test(rocke): include artifacts necessary for testing rocKE

### DIFF
--- a/ml-libs/artifact-hipkernelprovider.toml
+++ b/ml-libs/artifact-hipkernelprovider.toml
@@ -16,4 +16,6 @@ include = [
   "bin/hip_kernel_provider/*.py",
   "bin/hip_kernel_provider/golden/**",
   "bin/hip_kernel_provider/rocke/**",
+  # rocKE pytest suite
+  "bin/hip_kernel_provider/tests/**",
 ]

--- a/ml-libs/artifact-hipkernelprovider.toml
+++ b/ml-libs/artifact-hipkernelprovider.toml
@@ -11,4 +11,9 @@ include = [
   # Test config TOMLs (e.g. HIP_KERNEL_ENGINE.toml) consumed by the cross-provider
   # integration suite (hipdnn_integration_tests --test-config).
   "bin/hip_kernel_provider/*.toml",
+  # rocKE IR parity gate: Python test scripts, harness, golden data, and the
+  # rocke Python package they import.
+  "bin/hip_kernel_provider/*.py",
+  "bin/hip_kernel_provider/golden/**",
+  "bin/hip_kernel_provider/rocke/**",
 ]


### PR DESCRIPTION
## Motivation

ISSUE ID : AICK-1517

The rocKE engine's Python-based IR parity gate tests (rocke_golden_static, rocke_python_import_smoke) are already registered in the installed CTestTestfile.cmake and their files are staged to bin/hip_kernel_provider/ during the build (if ROCKE_INSTALL_PYTHON_TESTS is on), but the artifact builder silently drops them because artifact-hipkernelprovider.toml has no matching globs.

## Technical Details

Added three glob patterns to the [components.test] section of ml-libs/artifact-hipkernelprovider.toml:

- `bin/hip_kernel_provider/*.py` — captures rocke_installed_golden_test.py, rocke_installed_smoke.py, and rocke_ir_parity_harness.py
- `bin/hip_kernel_provider/golden/**` — captures rocke_representative_ir_sha256.json, the committed golden IR SHA-256 hashes used by the byte-stability gate
- `bin/hip_kernel_provider/rocke/**` — captures the rocke Python package (~5.5 MiB, 368 files), which all three test scripts import at runtime
- `bin/hip_kernel_provider/tests/**` — captures the rocke pytest suite

No CMake changes are required — ROCKE_INSTALL_PYTHON_TESTS defaults to ON and the files are already being staged. This change makes the artifact builder pick them up.

## Test Plan

- Verified all expected files are present in build/ml-libs/hipkernelprovider/stage/bin/hip_kernel_provider/ when ROCKE_INSTALL_PYTHON_TESTS is ON
- Ran rocke_installed_golden_test.py from the stage directory — confirms the IR parity harness can import the co-located rocke package, rebuild representative kernels, and match the golden SHA-256 hashes
- Ran rocke_installed_smoke.py from the stage directory — confirms the rocke package imports and lowers a kernel successfully

## Test Result

- rocke_installed_golden_test.py: PASS (llvm22 flavor, all golden hashes match)
- rocke_installed_smoke.py: PASS (Python engine smoke successful)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
