### PR TITLE
ci(pytorch): derive numpy test pin from vendored torch checkout

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -217,7 +217,7 @@ jobs:
           # numpy is pinned to what upstream validates for the checked-out torch
           # ref, derived from its .ci/docker/requirements-ci.txt (avoids drift).
           python external-builds/pytorch/derive_test_requirements.py \
-            | python -m pip install -r /dev/stdin
+            | python -m pip install -r -
           pip freeze
 
       - name: Run rocm-sdk sanity tests

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -214,6 +214,10 @@ jobs:
       - name: Install test requirements
         run: |
           python -m pip install -r external-builds/pytorch/requirements-test.txt
+          # numpy is pinned to what upstream validates for the checked-out torch
+          # ref, derived from its .ci/docker/requirements-ci.txt (avoids drift).
+          python external-builds/pytorch/derive_test_requirements.py \
+            | python -m pip install -r /dev/stdin
           pip freeze
 
       - name: Run rocm-sdk sanity tests

--- a/external-builds/pytorch/derive_test_requirements.py
+++ b/external-builds/pytorch/derive_test_requirements.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Print pinned test requirements sourced from the vendored PyTorch checkout.
+
+Extracts the pins for the requested packages (default: ``numpy``) from the
+checked-out PyTorch's ``.ci/docker/requirements-ci.txt`` and prints them, so
+TheRock installs the exact versions upstream validates for the torch ref under
+test instead of a hand-copied pin that silently drifts. Environment markers
+(e.g. ``; python_version ...``) are preserved so pip selects the right line.
+
+Usage:
+    python derive_test_requirements.py
+    python derive_test_requirements.py --package numpy --package scipy
+    python derive_test_requirements.py | python -m pip install -r /dev/stdin
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+DEFAULT_REQUIREMENTS_CI = THIS_DIR / "pytorch" / ".ci" / "docker" / "requirements-ci.txt"
+
+
+def extract_pins(requirements_ci: Path, packages: list[str]) -> list[str]:
+    """Return the requirement lines for each package, in the given order."""
+    lines = requirements_ci.read_text().splitlines()
+    pins: list[str] = []
+    for package in packages:
+        pattern = re.compile(rf"^\s*{re.escape(package)}\s*(==|>=|<=|<|>|~=|;|$)")
+        matches = [line.rstrip() for line in lines if pattern.match(line)]
+        if not matches:
+            raise ValueError(f"no pin for '{package}' found in {requirements_ci}")
+        pins.extend(matches)
+    return pins
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--package",
+        action="append",
+        dest="packages",
+        help="Package to extract (repeatable). Defaults to numpy.",
+    )
+    parser.add_argument(
+        "--requirements-ci",
+        type=Path,
+        default=DEFAULT_REQUIREMENTS_CI,
+        help=f"PyTorch requirements-ci.txt to read. Default: {DEFAULT_REQUIREMENTS_CI}",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.requirements_ci.exists():
+        parser.error(f"requirements-ci.txt not found: {args.requirements_ci}")
+
+    print("\n".join(extract_pins(args.requirements_ci, args.packages or ["numpy"])))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/external-builds/pytorch/derive_test_requirements.py
+++ b/external-builds/pytorch/derive_test_requirements.py
@@ -56,10 +56,15 @@ def main(argv: list[str]) -> int:
     )
     args = parser.parse_args(argv)
 
-    if not args.requirements_ci.exists():
+    if not args.requirements_ci.is_file():
         parser.error(f"requirements-ci.txt not found: {args.requirements_ci}")
 
-    print("\n".join(extract_pins(args.requirements_ci, args.packages or ["numpy"])))
+    try:
+        pins = extract_pins(args.requirements_ci, args.packages or ["numpy"])
+    except ValueError as e:
+        parser.error(str(e))
+
+    print("\n".join(pins))
     return 0
 
 

--- a/external-builds/pytorch/derive_test_requirements.py
+++ b/external-builds/pytorch/derive_test_requirements.py
@@ -22,7 +22,9 @@ import sys
 from pathlib import Path
 
 THIS_DIR = Path(__file__).resolve().parent
-DEFAULT_REQUIREMENTS_CI = THIS_DIR / "pytorch" / ".ci" / "docker" / "requirements-ci.txt"
+DEFAULT_REQUIREMENTS_CI = (
+    THIS_DIR / "pytorch" / ".ci" / "docker" / "requirements-ci.txt"
+)
 
 
 def extract_pins(requirements_ci: Path, packages: list[str]) -> list[str]:

--- a/external-builds/pytorch/derive_test_requirements.py
+++ b/external-builds/pytorch/derive_test_requirements.py
@@ -13,7 +13,7 @@ test instead of a hand-copied pin that silently drifts. Environment markers
 Usage:
     python derive_test_requirements.py
     python derive_test_requirements.py --package numpy --package scipy
-    python derive_test_requirements.py | python -m pip install -r /dev/stdin
+    python derive_test_requirements.py | python -m pip install -r -
 """
 
 import argparse

--- a/external-builds/pytorch/requirements-test.txt
+++ b/external-builds/pytorch/requirements-test.txt
@@ -6,5 +6,7 @@ pytest-xdist>=3.5.0
 expecttest>=0.3.0
 hypothesis
 ninja
-numpy
+# numpy is intentionally omitted here: it is derived per torch-ref from the
+# vendored PyTorch checkout at test time (see derive_test_requirements.py),
+# mirroring upstream's .ci/docker/requirements-ci.txt without manual drift.
 psutil


### PR DESCRIPTION
## Motivation

Follow-up / alternative to the review discussion on #6400. The unpinned `numpy`
in `external-builds/pytorch/requirements-test.txt` broke the non-full PyTorch
test workflow once a newer NumPy tightened `uint8` casting (an upstream OpInfo
bug, pytorch/pytorch#189267). #6400 fixes it by hand-copying upstream's
per-Python numpy pins, but there is silent drift potential.

This prototype removes the manual copy: it derives numpy from the checked-out
torch's own `.ci/docker/requirements-ci.txt` at install time, so we always use
what upstream validates for the exact ref under test.

Note: the **full** test workflow already installs the entire `requirements-ci.txt`
(since #3705), so it is already covered; this only closes the gap in the lean
non-full `test_pytorch_wheels.yml` without pulling upstream's ~75-package set.

## Technical Details

- `external-builds/pytorch/derive_test_requirements.py`: prints the requirement
  lines for the requested packages (default `numpy`) from the vendored checkout's
  `.ci/docker/requirements-ci.txt`, preserving environment markers; errors if the
  file is missing.
- `requirements-test.txt`: drop bare `numpy` (now derived).
- `test_pytorch_wheels.yml`: after installing the lean reqs, pipe the derived
  pins into pip.

It auto-tracks the torch ref (nightly → nightly's numpy, `release/2.9` → 2.9's
numpy), so there is nothing to re-sync and nothing to drop when
pytorch/pytorch#189267 is fixed upstream.

## Test Plan

Local verification (below); in CI, the non-full PyTorch test jobs install the
derived numpy and the `threshold` uint8 tests pass.

## Test Result

Ran locally against the vendored checkout:
- default → nightly's 4 per-Python numpy lines
- marker selection for py3.12 → `numpy==1.26.2`
- `--requirements-ci` pointed at `ROCm/pytorch` `release/2.9` → `numpy==2.0.2` / `2.1.2` (per-branch tracking)
- missing file → clean error (exit 2)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
