### PR TITLE
fix(build-tools): honor per-output remote key in fetch_dvc_artifacts

### DIFF
--- a/build_tools/fetch_dvc_artifacts.py
+++ b/build_tools/fetch_dvc_artifacts.py
@@ -239,7 +239,7 @@ def _parse_dvc_remotes(path: Path) -> _RemoteConfig:
             continue
         url = cp[section].get("url")
         if not url:
-            raise FetchError(f'{path}: [remote "{name}"] missing \'url\'')
+            raise FetchError(f"{path}: [remote \"{name}\"] missing 'url'")
         parsed = urlparse(url)
         if parsed.scheme != "s3":
             raise FetchError(f"{path}: only s3:// remotes are supported, got {url!r}")

--- a/build_tools/fetch_dvc_artifacts.py
+++ b/build_tools/fetch_dvc_artifacts.py
@@ -13,6 +13,7 @@ Pointer file schema (the only one we handle):
     - md5: <32-char-hex>      # may end with `.dir` for directory hashes
       size: <bytes>
       hash: md5
+      remote: <name>         # optional: per-output remote override (see below)
       path: <relpath-from-pointer-file-dir>
 
 Remote config (.dvc/config, INI):
@@ -21,6 +22,16 @@ Remote config (.dvc/config, INI):
     ['remote "storage"']
         url = s3://<bucket>/<prefix>
         allow_anonymous_login = true
+    ['remote "golden-data"']
+        url = s3://<bucket>/<other-prefix>
+        allow_anonymous_login = true
+
+An `outs:` entry may carry an optional `remote: <name>` key that routes that
+specific output to a non-default remote (dvc's per-output remote routing). When
+present, `<name>` must match a `['remote "<name>"']` section; when absent the
+[core] default remote is used. Remotes are resolved per output, so a single
+pointer file (and a single pull) may pull blobs from several buckets/prefixes,
+each with its own `allow_anonymous_login` setting.
 
 S3 key scheme (dvc 3.x "new" layout, used by therock-dvc):
     `<prefix>/files/md5/<md5[:2]>/<md5[2:]>` for both files and `.dir` manifests.
@@ -78,11 +89,16 @@ class PullResult:
 
 @dataclass(frozen=True)
 class _Out:
-    """One entry from a .dvc pointer file's `outs:` list."""
+    """One entry from a .dvc pointer file's `outs:` list.
+
+    `remote` is the optional per-output remote name (dvc's per-output routing);
+    None means "use the [core] default remote".
+    """
 
     md5: str
     size: int
     path: str
+    remote: str | None = None
 
     @property
     def is_dir(self) -> bool:
@@ -95,6 +111,7 @@ class _Out:
 
 @dataclass(frozen=True)
 class _Remote:
+    name: str
     bucket: str
     prefix: str
     anonymous: bool
@@ -158,7 +175,8 @@ def _to_out(d: dict[str, str], path: Path) -> _Out:
     bare = md5[:-4] if md5.endswith(".dir") else md5
     if len(bare) != 32 or not all(c in "0123456789abcdef" for c in bare):
         raise FetchError(f"{path}: invalid md5 {md5!r}")
-    return _Out(md5=md5, size=size, path=out_path)
+    remote = d.get("remote") or None
+    return _Out(md5=md5, size=size, path=out_path, remote=remote)
 
 
 # --------------------------------------------------------------------------
@@ -166,39 +184,82 @@ def _to_out(d: dict[str, str], path: Path) -> _Out:
 # --------------------------------------------------------------------------
 
 
-def _parse_dvc_config(path: Path) -> _Remote:
-    """Extract the configured remote's URL and anonymous flag from .dvc/config.
+@dataclass(frozen=True)
+class _RemoteConfig:
+    """All remotes declared in .dvc/config, plus the [core] default name."""
 
-    DVC's .dvc/config uses INI section headers like ['remote "storage"'] -
-    the single quotes are literally part of the section name in the file, and
-    Python's configparser preserves them. We canonicalize by stripping the
-    surrounding single quotes before matching `remote "<name>"`.
+    default: str
+    remotes: dict[str, _Remote]
+
+    def resolve(self, name: str | None, pointer: Path) -> _Remote:
+        """Return the _Remote for a per-output name (None -> default remote)."""
+        key = name or self.default
+        remote = self.remotes.get(key)
+        if remote is None:
+            raise FetchError(
+                f"{pointer}: references remote {key!r} which is not defined in "
+                f".dvc/config (known: {sorted(self.remotes)})"
+            )
+        return remote
+
+
+def _canonical_remote_name(section: str) -> str | None:
+    """Return the remote name if `section` is a `remote "<name>"` header, else None.
+
+    DVC's .dvc/config uses INI section headers like ['remote "storage"'] - the
+    single quotes are literally part of the section name in the file, and
+    Python's configparser preserves them. We strip the surrounding single quotes
+    before matching, then extract the quoted name.
+    """
+    s = section.strip("'")
+    if not (s.startswith('remote "') and s.endswith('"')):
+        return None
+    return s[len('remote "') : -1]
+
+
+def _parse_dvc_remotes(path: Path) -> _RemoteConfig:
+    """Parse every remote in .dvc/config and the [core] default remote name.
+
+    Every declared remote is parsed eagerly (URL validated, anonymous flag read)
+    so that a per-output `remote:` key can be resolved to any of them, and so a
+    malformed remote surfaces up front rather than mid-download.
     """
     cp = configparser.ConfigParser()
     cp.read(path)
     if "core" not in cp:
         raise FetchError(f"{path}: missing [core] section")
-    remote_name = cp["core"].get("remote")
-    if not remote_name:
+    default_name = cp["core"].get("remote")
+    if not default_name:
         raise FetchError(f"{path}: [core] missing 'remote' key")
-    target = f'remote "{remote_name}"'
-    section_name: str | None = None
-    for s in cp.sections():
-        if s == target or s.strip("'") == target:
-            section_name = s
-            break
-    if section_name is None:
-        raise FetchError(f"{path}: missing [{target}] section")
-    url = cp[section_name].get("url")
-    if not url:
-        raise FetchError(f"{path}: [{target}] missing 'url'")
-    parsed = urlparse(url)
-    if parsed.scheme != "s3":
-        raise FetchError(f"{path}: only s3:// remotes are supported, got {url!r}")
-    bucket = parsed.netloc
-    prefix = parsed.path.lstrip("/")
-    anonymous = cp[section_name].getboolean("allow_anonymous_login", fallback=False)
-    return _Remote(bucket=bucket, prefix=prefix, anonymous=anonymous)
+
+    remotes: dict[str, _Remote] = {}
+    for section in cp.sections():
+        name = _canonical_remote_name(section)
+        if name is None:
+            continue
+        url = cp[section].get("url")
+        if not url:
+            raise FetchError(f'{path}: [remote "{name}"] missing \'url\'')
+        parsed = urlparse(url)
+        if parsed.scheme != "s3":
+            raise FetchError(f"{path}: only s3:// remotes are supported, got {url!r}")
+        anonymous = cp[section].getboolean("allow_anonymous_login", fallback=False)
+        remotes[name] = _Remote(
+            name=name,
+            bucket=parsed.netloc,
+            prefix=parsed.path.lstrip("/"),
+            anonymous=anonymous,
+        )
+
+    if default_name not in remotes:
+        raise FetchError(f'{path}: missing [remote "{default_name}"] section')
+    return _RemoteConfig(default=default_name, remotes=remotes)
+
+
+def _parse_dvc_config(path: Path) -> _Remote:
+    """Return the [core] default remote. Thin wrapper over _parse_dvc_remotes."""
+    cfg = _parse_dvc_remotes(path)
+    return cfg.remotes[cfg.default]
 
 
 # --------------------------------------------------------------------------
@@ -460,16 +521,23 @@ def _make_s3_client(remote: _Remote, *, max_pool_connections: int):
 
 
 def _process_pointer(
-    s3,
-    remote: _Remote,
+    cfg: _RemoteConfig,
+    client_for: Callable[[_Remote], object],
     pointer: Path,
     cache_dir: Path | None,
     log: Callable[[str], None],
 ) -> PullResult:
-    """Materialize every entry in one .dvc pointer file."""
+    """Materialize every entry in one .dvc pointer file.
+
+    Each entry's remote is resolved independently from its `remote:` key (falling
+    back to the [core] default), so one pointer file may pull from several
+    remotes. Children of a `.dir` manifest inherit the parent output's remote.
+    """
     outs = _parse_dvc_pointer(pointer)
     result = PullResult()
     for out in outs:
+        remote = cfg.resolve(out.remote, pointer)
+        s3 = client_for(remote)
         dest = pointer.parent / out.path
         if out.is_dir:
             result += _materialize_dir(s3, remote, out, dest, cache_dir, log)
@@ -501,26 +569,36 @@ def pull(
     config_file = project_dir / ".dvc" / "config"
     if not config_file.exists():
         raise FetchError(f"no .dvc/config in {project_dir}")
-    remote = _parse_dvc_config(config_file)
+    cfg = _parse_dvc_remotes(config_file)
 
     pointers = _walk_dvc_pointers(project_dir)
     if not pointers:
         log(f"no .dvc pointer files found under {project_dir}")
         return PullResult()
 
+    # One S3 client per configured remote, built up front (before any worker
+    # starts) so the dict is read-only during the parallel phase - no locking
+    # needed. Clients are shared across workers (boto3 clients are thread-safe);
+    # they can't be shared across remotes because the anonymous flag differs.
     pool_size = max(jobs * _INNER_S3TRANSFER_CONCURRENCY, _MIN_POOL_CONNECTIONS)
-    s3 = _make_s3_client(remote, max_pool_connections=pool_size)
+    clients = {
+        name: _make_s3_client(remote, max_pool_connections=pool_size)
+        for name, remote in cfg.remotes.items()
+    }
 
-    log(
-        f"pull: {len(pointers)} pointer file(s) from "
-        f"s3://{remote.bucket}/{remote.prefix}"
+    def client_for(remote: _Remote) -> object:
+        return clients[remote.name]
+
+    remotes_desc = ", ".join(
+        f"s3://{r.bucket}/{r.prefix}" for r in cfg.remotes.values()
     )
+    log(f"pull: {len(pointers)} pointer file(s) from {remotes_desc}")
 
     result = PullResult()
     errors: list[tuple[Path, Exception]] = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as ex:
         futures = {
-            ex.submit(_process_pointer, s3, remote, p, cache_dir, log): p
+            ex.submit(_process_pointer, cfg, client_for, p, cache_dir, log): p
             for p in pointers
         }
         for fut in concurrent.futures.as_completed(futures):

--- a/build_tools/tests/fetch_dvc_artifacts_test.py
+++ b/build_tools/tests/fetch_dvc_artifacts_test.py
@@ -223,28 +223,28 @@ class TestS3Key(unittest.TestCase):
     """Tests for the S3 key builder (dvc 3.x layout: prefix/files/md5/...)."""
 
     def test_with_prefix(self):
-        r = fda._Remote(bucket="b", prefix="rocm-libraries", anonymous=True)
+        r = fda._Remote(name="storage", bucket="b", prefix="rocm-libraries", anonymous=True)
         self.assertEqual(
             fda._s3_key(r, "35b9082b72e661dc5e37f14de1d9d4ed"),
             "rocm-libraries/files/md5/35/b9082b72e661dc5e37f14de1d9d4ed",
         )
 
     def test_without_prefix(self):
-        r = fda._Remote(bucket="b", prefix="", anonymous=True)
+        r = fda._Remote(name="storage", bucket="b", prefix="", anonymous=True)
         self.assertEqual(
             fda._s3_key(r, "35b9082b72e661dc5e37f14de1d9d4ed"),
             "files/md5/35/b9082b72e661dc5e37f14de1d9d4ed",
         )
 
     def test_dir_suffix_preserved(self):
-        r = fda._Remote(bucket="b", prefix="p", anonymous=True)
+        r = fda._Remote(name="storage", bucket="b", prefix="p", anonymous=True)
         self.assertEqual(
             fda._s3_key(r, "a" * 32 + ".dir"),
             "p/files/md5/aa/" + "a" * 30 + ".dir",
         )
 
     def test_invalid_length_rejected(self):
-        r = fda._Remote(bucket="b", prefix="p", anonymous=True)
+        r = fda._Remote(name="storage", bucket="b", prefix="p", anonymous=True)
         with self.assertRaises(fda.FetchError):
             fda._s3_key(r, "deadbeef")
 
@@ -358,7 +358,7 @@ class TestDownloadBlob(unittest.TestCase):
     """Tests for _download_blob's atomic-write + verify invariants."""
 
     def _remote(self) -> fda._Remote:
-        return fda._Remote(bucket="bkt", prefix="p", anonymous=True)
+        return fda._Remote(name="storage", bucket="bkt", prefix="p", anonymous=True)
 
     def test_happy_path(self):
         with tempfile.TemporaryDirectory() as t:
@@ -483,7 +483,7 @@ class TestMaterializeFile(unittest.TestCase):
     """Tests for the cache fast paths and download fallback."""
 
     def _remote(self) -> fda._Remote:
-        return fda._Remote(bucket="bkt", prefix="p", anonymous=True)
+        return fda._Remote(name="storage", bucket="bkt", prefix="p", anonymous=True)
 
     def test_skips_when_destination_already_correct(self):
         with tempfile.TemporaryDirectory() as t:
@@ -655,6 +655,176 @@ class TestPullEndToEnd(unittest.TestCase):
         with tempfile.TemporaryDirectory() as t:
             with self.assertRaisesRegex(fda.FetchError, "no .dvc/config"):
                 fda.pull(Path(t), log=lambda _: None)
+
+
+class TestParsePerOutputRemote(unittest.TestCase):
+    """Pointer entries may carry a per-output `remote:` key (dvc routing)."""
+
+    def _write(self, tmp: Path, content: str) -> Path:
+        p = tmp / "x.dvc"
+        p.write_text(content)
+        return p
+
+    def test_remote_key_parsed(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "outs:\n- md5: " + "a" * 32 + "\n  size: 1\n"
+                "  hash: md5\n  remote: golden-data\n  path: f.bin\n",
+            )
+            outs = fda._parse_dvc_pointer(p)
+            self.assertEqual(outs[0].remote, "golden-data")
+
+    def test_remote_key_absent_is_none(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = self._write(
+                Path(t),
+                "outs:\n- md5: " + "a" * 32 + "\n  size: 1\n  hash: md5\n  path: f\n",
+            )
+            outs = fda._parse_dvc_pointer(p)
+            self.assertIsNone(outs[0].remote)
+
+
+class TestParseDvcRemotes(unittest.TestCase):
+    """Tests for multi-remote parsing and per-output resolution."""
+
+    _CONFIG = (
+        "[core]\n    remote = storage\n"
+        "['remote \"storage\"']\n    url = s3://therock-dvc/rocm-libraries\n"
+        "    allow_anonymous_login = true\n"
+        "['remote \"golden-data\"']\n"
+        "    url = s3://therock-dvc/rocm-libraries/hipdnn/golden-data\n"
+        "    allow_anonymous_login = false\n"
+    )
+
+    def _write(self, tmp: Path, content: str) -> Path:
+        p = tmp / "config"
+        p.write_text(content)
+        return p
+
+    def test_parses_all_remotes(self):
+        with tempfile.TemporaryDirectory() as t:
+            cfg = fda._parse_dvc_remotes(self._write(Path(t), self._CONFIG))
+            self.assertEqual(cfg.default, "storage")
+            self.assertEqual(set(cfg.remotes), {"storage", "golden-data"})
+            self.assertEqual(cfg.remotes["golden-data"].prefix,
+                             "rocm-libraries/hipdnn/golden-data")
+            # Per-remote anonymous flags are independent.
+            self.assertTrue(cfg.remotes["storage"].anonymous)
+            self.assertFalse(cfg.remotes["golden-data"].anonymous)
+
+    def test_resolve_default_when_none(self):
+        with tempfile.TemporaryDirectory() as t:
+            cfg = fda._parse_dvc_remotes(self._write(Path(t), self._CONFIG))
+            self.assertEqual(cfg.resolve(None, Path("x.dvc")).name, "storage")
+
+    def test_resolve_named_remote(self):
+        with tempfile.TemporaryDirectory() as t:
+            cfg = fda._parse_dvc_remotes(self._write(Path(t), self._CONFIG))
+            self.assertEqual(
+                cfg.resolve("golden-data", Path("x.dvc")).name, "golden-data"
+            )
+
+    def test_resolve_unknown_remote_raises(self):
+        with tempfile.TemporaryDirectory() as t:
+            cfg = fda._parse_dvc_remotes(self._write(Path(t), self._CONFIG))
+            with self.assertRaisesRegex(fda.FetchError, "not defined"):
+                cfg.resolve("ghost", Path("x.dvc"))
+
+    def test_default_remote_backward_compat(self):
+        # _parse_dvc_config still returns the [core] default remote unchanged.
+        with tempfile.TemporaryDirectory() as t:
+            r = fda._parse_dvc_config(self._write(Path(t), self._CONFIG))
+            self.assertEqual(r.name, "storage")
+            self.assertEqual(r.prefix, "rocm-libraries")
+
+
+class TestPullPerOutputRemoteRouting(unittest.TestCase):
+    """End-to-end: a pull routes each blob to the remote named in its pointer."""
+
+    def test_blobs_fetched_from_their_named_remotes(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            project = tmp / "proj"
+            (project / ".dvc").mkdir(parents=True)
+            (project / ".dvc" / "config").write_text(
+                "[core]\n    remote = storage\n"
+                "['remote \"storage\"']\n    url = s3://bkt/rocm-libraries\n"
+                "    allow_anonymous_login = true\n"
+                "['remote \"golden-data\"']\n"
+                "    url = s3://bkt/rocm-libraries/hipdnn/golden-data\n"
+                "    allow_anonymous_login = true\n"
+            )
+            data_def = b"default-remote blob"
+            data_gld = b"golden-data blob"
+            md5_def = _md5_hex(data_def)
+            md5_gld = _md5_hex(data_gld)
+            # Pointer 1: no remote key -> default (storage).
+            (project / "a.bin.dvc").write_text(
+                f"outs:\n- md5: {md5_def}\n  size: {len(data_def)}\n"
+                f"  hash: md5\n  path: a.bin\n"
+            )
+            # Pointer 2: remote: golden-data.
+            (project / "b.bin.dvc").write_text(
+                f"outs:\n- md5: {md5_gld}\n  size: {len(data_gld)}\n"
+                f"  hash: md5\n  remote: golden-data\n  path: b.bin\n"
+            )
+
+            # A single fake S3 keyed by (bucket, key). Because the two remotes
+            # share a bucket but differ in prefix, the keys differ - so a blob
+            # served only under the golden-data prefix proves it was routed
+            # there and NOT looked up under the storage prefix (the #9183 bug).
+            payloads = {
+                ("bkt", f"rocm-libraries/files/md5/{md5_def[:2]}/{md5_def[2:]}"):
+                    data_def,
+                (
+                    "bkt",
+                    "rocm-libraries/hipdnn/golden-data/files/md5/"
+                    f"{md5_gld[:2]}/{md5_gld[2:]}",
+                ): data_gld,
+            }
+            fake = _FakeS3(payloads)
+
+            with mock.patch.object(fda, "_make_s3_client", return_value=fake):
+                result = fda.pull(project, cache_dir=tmp / "cache", log=lambda _: None)
+
+            self.assertEqual(result.fetched, 2)
+            self.assertEqual((project / "a.bin").read_bytes(), data_def)
+            self.assertEqual((project / "b.bin").read_bytes(), data_gld)
+            fetched_keys = {key for _, key in fake.calls}
+            self.assertIn(
+                "rocm-libraries/hipdnn/golden-data/files/md5/"
+                f"{md5_gld[:2]}/{md5_gld[2:]}",
+                fetched_keys,
+            )
+
+    def test_unknown_remote_in_pointer_is_reported(self):
+        with tempfile.TemporaryDirectory() as t:
+            tmp = Path(t)
+            project = tmp / "proj"
+            (project / ".dvc").mkdir(parents=True)
+            (project / ".dvc" / "config").write_text(
+                "[core]\n    remote = storage\n"
+                "['remote \"storage\"']\n    url = s3://b/pfx\n"
+                "    allow_anonymous_login = true\n"
+            )
+            md5 = _md5_hex(b"z")
+            (project / "z.bin.dvc").write_text(
+                f"outs:\n- md5: {md5}\n  size: 1\n  hash: md5\n"
+                f"  remote: nonexistent\n  path: z.bin\n"
+            )
+            fake = _FakeS3({})
+            logs: list[str] = []
+            with mock.patch.object(fda, "_make_s3_client", return_value=fake):
+                # An unknown per-output remote surfaces via the normal aggregated
+                # per-pointer failure path; the specific cause is logged.
+                with self.assertRaisesRegex(fda.FetchError, "1 file"):
+                    fda.pull(project, cache_dir=None, log=logs.append)
+            self.assertTrue(
+                any("not defined" in line for line in logs),
+                f"cause not logged; logs={logs}",
+            )
+            self.assertFalse((project / "z.bin").exists())
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/fetch_dvc_artifacts_test.py
+++ b/build_tools/tests/fetch_dvc_artifacts_test.py
@@ -223,7 +223,9 @@ class TestS3Key(unittest.TestCase):
     """Tests for the S3 key builder (dvc 3.x layout: prefix/files/md5/...)."""
 
     def test_with_prefix(self):
-        r = fda._Remote(name="storage", bucket="b", prefix="rocm-libraries", anonymous=True)
+        r = fda._Remote(
+            name="storage", bucket="b", prefix="rocm-libraries", anonymous=True
+        )
         self.assertEqual(
             fda._s3_key(r, "35b9082b72e661dc5e37f14de1d9d4ed"),
             "rocm-libraries/files/md5/35/b9082b72e661dc5e37f14de1d9d4ed",
@@ -707,8 +709,9 @@ class TestParseDvcRemotes(unittest.TestCase):
             cfg = fda._parse_dvc_remotes(self._write(Path(t), self._CONFIG))
             self.assertEqual(cfg.default, "storage")
             self.assertEqual(set(cfg.remotes), {"storage", "golden-data"})
-            self.assertEqual(cfg.remotes["golden-data"].prefix,
-                             "rocm-libraries/hipdnn/golden-data")
+            self.assertEqual(
+                cfg.remotes["golden-data"].prefix, "rocm-libraries/hipdnn/golden-data"
+            )
             # Per-remote anonymous flags are independent.
             self.assertTrue(cfg.remotes["storage"].anonymous)
             self.assertFalse(cfg.remotes["golden-data"].anonymous)
@@ -775,8 +778,10 @@ class TestPullPerOutputRemoteRouting(unittest.TestCase):
             # served only under the golden-data prefix proves it was routed
             # there and NOT looked up under the storage prefix (the #9183 bug).
             payloads = {
-                ("bkt", f"rocm-libraries/files/md5/{md5_def[:2]}/{md5_def[2:]}"):
-                    data_def,
+                (
+                    "bkt",
+                    f"rocm-libraries/files/md5/{md5_def[:2]}/{md5_def[2:]}",
+                ): data_def,
                 (
                     "bkt",
                     "rocm-libraries/hipdnn/golden-data/files/md5/"


### PR DESCRIPTION
## Summary

`build_tools/fetch_dvc_artifacts.py` (TheRock's in-tree `dvc pull` replacement) read **only** the `[core]` default remote and ignored each pointer output's `remote:` key. Blobs routed to a non-default DVC remote were fetched from the *default* remote's prefix and 404'd, breaking the `math-libs` "Fetch sources" step on every Linux and Windows GPU target.

This teaches the fetcher to honor DVC's per-output remote routing:

- Parse the optional per-output `remote:` key from each `outs:` entry.
- Parse **all** `['remote "<name>"']` sections in `.dvc/config`, not just the `[core]` default.
- Resolve each output to its named remote (falling back to the default) and fetch its blob from that remote's bucket/prefix. `.dir` manifest children inherit the parent output's remote.
- Build one S3 client per configured remote (each has its own `allow_anonymous_login` flag), shared read-only across worker threads.

Backward compatible: pointers with no `remote:` key and single-remote configs behave exactly as before.

**Fixes:** [ROCm/rocm-libraries#9183](https://github.com/ROCm/rocm-libraries/issues/9183)
**Root cause:** [ROCm/rocm-libraries#9157](https://github.com/ROCm/rocm-libraries/pull/9157) added a dedicated `golden-data` DVC remote + per-output `remote:` keys; it was reverted by [#9182](https://github.com/ROCm/rocm-libraries/pull/9182) to unblock CI and will re-land once this merges.

## Risk Assessment

Low. Scoped to a single build-tool script and its unit tests. No behavior change for existing pointer files (no `remote:` key) or single-remote configs; the default-remote path is preserved via a thin wrapper. New code activates only when a pointer carries a `remote:` key naming a non-default remote.

## Testing Summary

- Unit tests: 49/49 pass (40 pre-existing + 9 new covering `remote:` parsing, multi-remote config parsing/resolution, and end-to-end per-output routing including the exact dual-remote #9183 scenario).
- Real-S3 end-to-end (anonymous, as CI) using the actual `golden-data` pointers from rocm-libraries #9157, including the object named in the issue (`e1aab7b90300368b26ea8442792606e0`):
  - **Before (main):** `2 file(s) failed to fetch` — `404 HeadObject` on both golden-data pointers (reproduces #9183).
  - **After (this PR):** `fetched=10, exit 0` — all `.bin` files materialized and md5-verified.

## Testing Checklist

- [x] Unit tests — `python -m unittest fetch_dvc_artifacts_test` (from `build_tools/tests/`) — 49/49 passed
- [x] Real-S3 repro: original fetcher 404s, patched fetcher pulls golden-data blobs (anonymous)
- [x] Patch applies cleanly to current `main`; only the two fetcher files changed
- [ ] PR CI — GitHub PR checks — Pending

## Technical Changes

- `_Out` gains an optional `remote: str | None` field; `_to_out` parses the `remote:` key.
- `_Remote` gains a `name` field (used as the per-remote client-cache key).
- New `_RemoteConfig` (all remotes + default name) with a `resolve()` helper for per-output lookup.
- New `_parse_dvc_remotes()` parses every remote section eagerly (URL validated, anonymous flag read); `_parse_dvc_config()` retained as a thin wrapper returning the `[core]` default remote for backward compatibility.
- `_process_pointer()` resolves each output's remote and selects the matching S3 client.
- `pull()` pre-builds one S3 client per remote (dict is read-only during the parallel phase, so no locking) and passes a `client_for` provider down.