### PR TITLE
feat(ci): Add submodule_bump_tests_only flag for gfx950

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -182,6 +182,7 @@ amdgpu_family_info_matrix dictionary fields:
 - sanity_check_only_for_family: (optional) if enabled, only run sanity check tests for this architecture
 - run-full-tests-only: (optional) if enabled, only run full tests for this architecture
 - nightly_check_only_for_family (optional): if enabled, only run CI nightly tests for this architecture
+- submodule_bump_tests_only (optional): if enabled, only run tests when submodule changes are detected or on workflow_dispatch (builds always run)
 """
 # The 'presubmit' matrix runs on 'pull_request' triggers (on all PRs).
 amdgpu_family_info_matrix_presubmit = {
@@ -292,6 +293,8 @@ amdgpu_family_info_matrix_postsubmit = {
             "family": "gfx950-dcgpu",
             "fetch-gfx-targets": ["gfx950"],
             "build_variants": ["release", "asan", "tsan"],
+            # Only run tests on submodule bumps (builds always run)
+            "submodule_bump_tests_only": True,
         }
     },
 }

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -299,6 +299,18 @@ class GitContext:
         """
         return GitContext()
 
+    @property
+    def has_submodule_changes(self) -> bool | None:
+        """Check if any submodules were modified in the changed files.
+
+        Returns:
+            True if submodule changes detected, False if no submodule changes,
+            None if git context is unavailable (changed_files or submodule_paths missing).
+        """
+        if self.changed_files is None or self.submodule_paths is None:
+            return None
+        return bool(set(self.submodule_paths) & set(self.changed_files))
+
     def log(self) -> None:
         """Log git context for CI diagnostics."""
         if self.changed_files is None:
@@ -554,13 +566,10 @@ def should_skip_ci(
     if (
         ci_inputs.is_pull_request
         and ci_inputs.build_variant == "asan"
-        and git_context.changed_files is not None
-        and git_context.submodule_paths is not None
+        and git_context.has_submodule_changes is False
     ):
-        matching = set(git_context.submodule_paths) & set(git_context.changed_files)
-        if not matching:
-            print("  Skipping: ASAN PR without submodule changes")
-            return True
+        print("  Skipping: ASAN PR without submodule changes")
+        return True
 
     # If we have a list of changed files (push/pull_request events), check if
     # CI should run for that set of changed files. For example: if only .md
@@ -666,13 +675,9 @@ def _determine_test_type(
     # Priority 5: a submodule change means actual library code changed
     # (e.g. rocBLAS, MIOpen). These need full testing since the change
     # could affect any downstream consumer.
-    if (
-        git_context.changed_files is not None
-        and git_context.submodule_paths is not None
-    ):
+    if git_context.has_submodule_changes is True:
         matching = set(git_context.submodule_paths) & set(git_context.changed_files)
-        if matching:
-            return "standard", f"submodule(s) changed: {sorted(matching)}"
+        return "standard", f"submodule(s) changed: {sorted(matching)}"
 
     # Default: quick tests for fast CI feedback.
     return "quick", "default"
@@ -1003,6 +1008,19 @@ def _expand_build_config_for_platform(
             print(
                 f"  {family_name}: nightly_check_only_for_family flag set, "
                 f"disabling test runner for non-scheduled/non-dispatch runs"
+            )
+
+        # If submodule_bump_tests_only is set, only run tests when submodule changes
+        # are detected or on workflow_dispatch (manual triggers).
+        if (
+            platform_info.get("submodule_bump_tests_only", False)
+            and not ci_inputs.is_workflow_dispatch
+            and git_context.has_submodule_changes is not True
+        ):
+            test_runs_on = ""
+            print(
+                f"  {family_name}: submodule_bump_tests_only flag set, "
+                f"disabling tests (no submodule changes detected)"
             )
 
         family_info = {

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1538,6 +1538,88 @@ class TestFamilyTestFilters(unittest.TestCase):
         # workflow_dispatch should have test-runs-on set (not empty)
         self.assertNotEqual(gfx90a_info["test-runs-on"], "")
 
+    def test_submodule_bump_tests_only_disables_tests_without_submodule_changes(self):
+        """gfx950 tests should be disabled on push without submodule changes."""
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="push",
+            commit_ref="main",
+            base_ref=None,  # Skip path filtering
+            build_variant="release",
+        )
+        # No submodule changes - CI-relevant file but not a submodule
+        git_context = cm.GitContext(
+            changed_files=["CMakeLists.txt"],
+            submodule_paths=["rocm-systems", "rocm-libraries"],
+        )
+        outputs = cm.configure(ci_inputs, git_context)
+
+        # Find gfx950 in the linux build config
+        gfx950_info = None
+        if outputs.builds.linux:
+            for family_info in outputs.builds.linux.per_family_info:
+                if family_info["amdgpu_family"] == "gfx950-dcgpu":
+                    gfx950_info = family_info
+                    break
+
+        self.assertIsNotNone(gfx950_info)
+        # Tests should be disabled (empty runner)
+        self.assertEqual(gfx950_info["test-runs-on"], "")
+
+    def test_submodule_bump_tests_only_enables_tests_with_submodule_changes(self):
+        """gfx950 tests should be enabled on push with submodule changes."""
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="push",
+            commit_ref="main",
+            base_ref="HEAD^",
+            build_variant="release",
+        )
+        # Submodule change detected
+        git_context = cm.GitContext(
+            changed_files=["rocm-libraries"],
+            submodule_paths=["rocm-systems", "rocm-libraries"],
+        )
+        outputs = cm.configure(ci_inputs, git_context)
+
+        # Find gfx950 in the linux build config
+        gfx950_info = None
+        if outputs.builds.linux:
+            for family_info in outputs.builds.linux.per_family_info:
+                if family_info["amdgpu_family"] == "gfx950-dcgpu":
+                    gfx950_info = family_info
+                    break
+
+        self.assertIsNotNone(gfx950_info)
+        # Tests should be enabled
+        self.assertNotEqual(gfx950_info["test-runs-on"], "")
+
+    def test_submodule_bump_tests_only_enables_tests_on_workflow_dispatch(self):
+        """gfx950 tests should be enabled on workflow_dispatch regardless of submodule changes."""
+        ci_inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="workflow_dispatch",
+            commit_ref="main",
+            base_ref=None,  # Skip path filtering
+            build_variant="release",
+            linux_amdgpu_families=["gfx950"],
+        )
+        # No submodule changes
+        git_context = cm.GitContext.empty()
+        outputs = cm.configure(ci_inputs, git_context)
+
+        # Find gfx950 in the linux build config
+        gfx950_info = None
+        if outputs.builds.linux:
+            for family_info in outputs.builds.linux.per_family_info:
+                if family_info["amdgpu_family"] == "gfx950-dcgpu":
+                    gfx950_info = family_info
+                    break
+
+        self.assertIsNotNone(gfx950_info)
+        # Tests should be enabled on workflow_dispatch
+        self.assertNotEqual(gfx950_info["test-runs-on"], "")
+
 
 # ---------------------------------------------------------------------------
 # Multi-label runner selection


### PR DESCRIPTION
Add a new flag `submodule_bump_tests_only` that limits test execution to submodule bump pushes and workflow_dispatch triggers. This prevents gfx950 tests from running on every postsubmit push while still running builds.

Also refactors submodule change detection into a reusable `GitContext.has_submodule_changes` property, simplifying three locations that previously duplicated this logic.

Behavior:
- gfx950 builds: Always run on all postsubmit pushes
- gfx950 tests: Only run when submodule changes are detected or on manual workflow_dispatch triggers