### PR TITLE
build(hipkernelprovider): document rocKE AOT artifacts in the lib component

### DIFF
--- a/ml-libs/artifact-hipkernelprovider.toml
+++ b/ml-libs/artifact-hipkernelprovider.toml
@@ -1,6 +1,14 @@
 # hipkernelprovider
 [components.dbg."ml-libs/hipkernelprovider/stage"]
 [components.lib."ml-libs/hipkernelprovider/stage"]
+# The lib component captures everything under the stage except the excludes
+# below (include-all semantics). This ships the rocke engine plugin plus the
+# provider-owned rocKE AOT artifacts installed under
+#   lib/<plugin-engines>/hip_kernel_provider/rocke/<arch>/
+# produced by rocm-libraries (Plan 2): per arch
+#   rocke_client_<arch>.kpack          (packed HSACO)
+#   rocke_client_<arch>.json           (hipdnn.rocke.bundle/v1 manifest)
+#   <family>/aot_list.json             (selection catalog)
 exclude = [
   "lib/*.a",
 ]


### PR DESCRIPTION
## Summary

Records the provider-owned rocKE AOT artifacts produced by the rocm-libraries Plan-2 branch in the `hipkernelprovider` `lib` artifact component so they ship in packaging. Per arch these are `rocke_client_<arch>.kpack` (packed HSACO), the `hipdnn.rocke.bundle/v1` manifest (`rocke_client_<arch>.json`), and the `<family>/aot_list.json` selection catalog, installed under `lib/<plugin-engines>/hip_kernel_provider/rocke/<arch>/`. JIRA ID : AICK-1471

## Risk Assessment

Minimal risk. Comment-only edit to `ml-libs/artifact-hipkernelprovider.toml`. The `lib` component already captures these files via its include-all-minus-excludes semantics; this documents the produced filenames without changing include/exclude behavior. No product code, build config, or API change.

## Testing Summary

- TOML edit is comment-only; the `lib` component semantics (include-all minus `lib/*.a`) are unchanged, so the produced files continue to be captured.

## Testing Checklist

- [x] Change is comment-only; `lib` include/exclude semantics unchanged - Status: Passed (inspection)
- [ ] TheRock packaging of hipkernelprovider once Plan-2 installs the files - Status: Pending
- [ ] PR CI - GitHub PR checks - Status: Pending

## Technical Changes

- Document the rocKE AOT artifacts (`.kpack`, bundle manifest, `aot_list.json`) shipped by the `lib` component of `artifact-hipkernelprovider.toml`.

## Dependencies

- Belongs with the rocm-libraries Plan-2 PR (rocKE AOT producer + kpack packaging), which produces and installs the listed files. Pairs with the Plan-1 TheRock deps PR (`rocm-kpack` build/runtime dep + `ROCKE_KPACK_PYTHON_DIR`).
