### PR TITLE
feat: Catch incomplete Python package sets

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -78,6 +78,19 @@ def ensure_profiler_library_symlinks(profiler: PopulatedDistPackage) -> None:
             link.symlink_to(target.name)
 
 
+def _platform_targets(
+    *,
+    linux_targets: list[str] | None,
+    windows_targets: list[str] | None,
+    platform_name: str,
+) -> list[str] | None:
+    if platform_name.startswith("linux"):
+        return linux_targets
+    if platform_name == "win32":
+        return windows_targets
+    return None
+
+
 def validate_kpack_split_target_completeness(
     *,
     kpack_split: bool,
@@ -91,13 +104,11 @@ def validate_kpack_split_target_completeness(
     if not kpack_split:
         return
 
-    if platform_name.startswith("linux"):
-        expected_targets = linux_targets
-    elif platform_name == "win32":
-        expected_targets = windows_targets
-    else:
-        return
-
+    expected_targets = _platform_targets(
+        linux_targets=linux_targets,
+        windows_targets=windows_targets,
+        platform_name=platform_name,
+    )
     if expected_targets is None:
         return
 
@@ -117,6 +128,57 @@ def validate_kpack_split_target_completeness(
         f"Discovered artifact targets in {artifact_dir}: {discovered}. "
         "The fetched/extracted artifact catalog is incomplete; refusing to "
         "build a partial device wheel set."
+    )
+
+
+def _has_devel_artifacts(artifacts: ArtifactCatalog) -> bool:
+    return any(an.component == "dev" for an in artifacts.artifact_names)
+
+
+def validate_required_dist_packages(
+    *,
+    dest_dir: Path,
+    version: str,
+    artifacts: ArtifactCatalog,
+    kpack_split: bool,
+    linux_targets: list[str] | None,
+    windows_targets: list[str] | None,
+    platform_name: str = sys.platform,
+) -> None:
+    """Validate required kpack-split files in the final dist directory."""
+    if not kpack_split:
+        return
+
+    required_patterns = [
+        f"rocm-{version}.tar.gz",
+        f"rocm_sdk_core-{version}-*.whl",
+        f"rocm_sdk_libraries-{version}-*.whl",
+    ]
+
+    expected_targets = _platform_targets(
+        linux_targets=linux_targets,
+        windows_targets=windows_targets,
+        platform_name=platform_name,
+    )
+    for target in expected_targets or []:
+        required_patterns.append(f"rocm_sdk_device_{target}-{version}-*.whl")
+
+    if _has_devel_artifacts(artifacts):
+        required_patterns.append(f"rocm_sdk_devel-{version}-*.whl")
+
+    dist_dir = dest_dir / "dist"
+    missing_patterns = [
+        pattern for pattern in required_patterns if not list(dist_dir.glob(pattern))
+    ]
+    if not missing_patterns:
+        return
+
+    present_files = sorted(p.name for p in dist_dir.glob("*") if p.is_file())
+    raise RuntimeError(
+        "Required kpack-split Python packages are missing from "
+        f"{dist_dir}: {', '.join(missing_patterns)}. "
+        f"Present files: {', '.join(present_files) or '(none)'}. "
+        "Refusing to publish an incomplete Python package set."
     )
 
 
@@ -245,6 +307,16 @@ def run(args: argparse.Namespace):
         _run_kpack_split(args, params, core)
     else:
         _run_legacy(args, params, core)
+
+    if args.build_packages:
+        validate_required_dist_packages(
+            dest_dir=args.dest_dir,
+            version=args.version,
+            artifacts=artifacts,
+            kpack_split=kpack_split,
+            linux_targets=linux_targets,
+            windows_targets=windows_targets,
+        )
 
     print(
         f"::: Finished building packages at '{args.dest_dir}' with version '{args.version}'"

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -114,12 +114,16 @@ def validate_kpack_split_target_completeness(
 
     expected_target_set = set(expected_targets)
     discovered_target_set = artifacts.all_target_families
+
+    expected = ", ".join(sorted(expected_target_set)) or "(none)"
+    discovered = ", ".join(sorted(discovered_target_set)) or "(none)"
+    print(f"::: KPACK_SPLIT_ARTIFACTS expected device targets: {expected}")
+    print(f"::: KPACK_SPLIT_ARTIFACTS discovered artifact targets: {discovered}")
+
     missing_targets = sorted(expected_target_set - discovered_target_set)
     if not missing_targets:
         return
 
-    expected = ", ".join(sorted(expected_target_set)) or "(none)"
-    discovered = ", ".join(sorted(discovered_target_set)) or "(none)"
     missing = ", ".join(missing_targets)
     raise RuntimeError(
         "KPACK_SPLIT_ARTIFACTS target completeness check failed: "

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -78,6 +78,48 @@ def ensure_profiler_library_symlinks(profiler: PopulatedDistPackage) -> None:
             link.symlink_to(target.name)
 
 
+def validate_kpack_split_target_completeness(
+    *,
+    kpack_split: bool,
+    artifact_dir: Path,
+    artifacts: ArtifactCatalog,
+    linux_targets: list[str] | None,
+    windows_targets: list[str] | None,
+    platform_name: str = sys.platform,
+) -> None:
+    """Validate that kpack-split artifacts cover this platform's targets."""
+    if not kpack_split:
+        return
+
+    if platform_name.startswith("linux"):
+        expected_targets = linux_targets
+    elif platform_name == "win32":
+        expected_targets = windows_targets
+    else:
+        return
+
+    if expected_targets is None:
+        return
+
+    expected_target_set = set(expected_targets)
+    discovered_target_set = artifacts.all_target_families
+    missing_targets = sorted(expected_target_set - discovered_target_set)
+    if not missing_targets:
+        return
+
+    expected = ", ".join(sorted(expected_target_set)) or "(none)"
+    discovered = ", ".join(sorted(discovered_target_set)) or "(none)"
+    missing = ", ".join(missing_targets)
+    raise RuntimeError(
+        "KPACK_SPLIT_ARTIFACTS target completeness check failed: "
+        f"missing fetched artifact targets: {missing}. "
+        f"Expected targets: {expected}. "
+        f"Discovered artifact targets in {artifact_dir}: {discovered}. "
+        "The fetched/extracted artifact catalog is incomplete; refusing to "
+        "build a partial device wheel set."
+    )
+
+
 def run(args: argparse.Namespace):
     manifest = load_therock_manifest(args.artifact_dir)
     kpack_split = manifest.get("flags", {}).get("KPACK_SPLIT_ARTIFACTS", False)
@@ -105,11 +147,20 @@ def run(args: argparse.Namespace):
             family_map = amdgpu_family_map()
         windows_targets = expand_families(args.windows_amdgpu_families, family_map)
 
+    artifacts = ArtifactCatalog(args.artifact_dir)
+    validate_kpack_split_target_completeness(
+        kpack_split=kpack_split,
+        artifact_dir=args.artifact_dir,
+        artifacts=artifacts,
+        linux_targets=linux_targets,
+        windows_targets=windows_targets,
+    )
+
     params = Parameters(
         dest_dir=args.dest_dir,
         version=args.version,
         version_suffix=args.version_suffix,
-        artifacts=ArtifactCatalog(args.artifact_dir),
+        artifacts=artifacts,
         kpack_split=kpack_split,
         linux_target_families=linux_targets,
         windows_target_families=windows_targets,

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -667,6 +667,111 @@ class DevicePackagingTest(TmpDirTestCase):
         self.assertIn("_rocm_sdk_libraries", content)
 
 
+class KpackSplitCompletenessTest(TmpDirTestCase):
+    """Tests for validating kpack-split artifact coverage before packaging."""
+
+    def _add_artifact(
+        self,
+        artifact_dir: Path,
+        name: str,
+        component: str,
+        target_family: str,
+    ) -> None:
+        subdir = artifact_dir / f"{name}_{component}_{target_family}"
+        stage = subdir / "stage"
+        stage.mkdir(parents=True, exist_ok=True)
+        (stage / "placeholder.txt").write_text("x")
+        (subdir / "artifact_manifest.txt").write_text("stage\n")
+
+    def _make_artifact_catalog(self, target_families: list[str]) -> ArtifactCatalog:
+        artifact_dir = self.temp_dir / "artifacts"
+        for target_family in target_families:
+            self._add_artifact(
+                artifact_dir=artifact_dir,
+                name="blas",
+                component="lib",
+                target_family=target_family,
+            )
+        return ArtifactCatalog(artifact_dir)
+
+    def _validate_completeness(
+        self,
+        *,
+        kpack_split: bool,
+        artifacts: ArtifactCatalog,
+        linux_targets: list[str] | None,
+        windows_targets: list[str] | None,
+        platform_name: str,
+    ) -> None:
+        sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+        from build_python_packages import validate_kpack_split_target_completeness
+
+        validate_kpack_split_target_completeness(
+            kpack_split=kpack_split,
+            artifact_dir=self.temp_dir / "artifacts",
+            artifacts=artifacts,
+            linux_targets=linux_targets,
+            windows_targets=windows_targets,
+            platform_name=platform_name,
+        )
+
+    def test_linux_completeness_passes_when_targets_match(self):
+        artifacts = self._make_artifact_catalog(["gfx1100", "gfx1101"])
+
+        self._validate_completeness(
+            kpack_split=True,
+            artifacts=artifacts,
+            linux_targets=["gfx1100", "gfx1101"],
+            windows_targets=None,
+            platform_name="linux",
+        )
+
+    def test_linux_completeness_fails_when_target_is_missing(self):
+        artifacts = self._make_artifact_catalog(["gfx1100"])
+
+        with self.assertRaisesRegex(RuntimeError, "gfx1101"):
+            self._validate_completeness(
+                kpack_split=True,
+                artifacts=artifacts,
+                linux_targets=["gfx1100", "gfx1101"],
+                windows_targets=None,
+                platform_name="linux",
+            )
+
+    def test_windows_completeness_uses_windows_targets(self):
+        artifacts = self._make_artifact_catalog(["gfx1200"])
+
+        self._validate_completeness(
+            kpack_split=True,
+            artifacts=artifacts,
+            linux_targets=["gfx1100"],
+            windows_targets=["gfx1200"],
+            platform_name="win32",
+        )
+
+    def test_completeness_skips_without_platform_target_input(self):
+        artifacts = self._make_artifact_catalog(["gfx1100"])
+
+        self._validate_completeness(
+            kpack_split=True,
+            artifacts=artifacts,
+            linux_targets=None,
+            windows_targets=["gfx1200"],
+            platform_name="linux",
+        )
+
+    def test_completeness_skips_when_kpack_split_is_disabled(self):
+        artifacts = self._make_artifact_catalog(["gfx1100"])
+
+        self._validate_completeness(
+            kpack_split=False,
+            artifacts=artifacts,
+            linux_targets=["gfx1100", "gfx1101"],
+            windows_targets=None,
+            platform_name="linux",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Unit tests for restrict_families (per-family meta package)
 # ---------------------------------------------------------------------------

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -22,6 +22,7 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
 from _therock_utils.artifacts import ArtifactCatalog
 from _therock_utils.py_packaging import Parameters, PopulatedDistPackage, PopulatedFiles
+from build_python_packages import validate_kpack_split_target_completeness
 
 
 class TmpDirTestCase(unittest.TestCase):
@@ -703,9 +704,6 @@ class KpackSplitCompletenessTest(TmpDirTestCase):
         windows_targets: list[str] | None,
         platform_name: str,
     ) -> None:
-        sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
-        from build_python_packages import validate_kpack_split_target_completeness
-
         validate_kpack_split_target_completeness(
             kpack_split=kpack_split,
             artifact_dir=self.temp_dir / "artifacts",

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -772,6 +772,148 @@ class KpackSplitCompletenessTest(TmpDirTestCase):
         )
 
 
+class RequiredDistPackagesTest(TmpDirTestCase):
+    """Tests for validating required files in the final dist directory."""
+
+    version = "0.0.1.test"
+    wheel_tag = "py3-none-linux_x86_64"
+
+    def _add_artifact(
+        self,
+        artifact_dir: Path,
+        name: str,
+        component: str,
+        target_family: str,
+    ) -> None:
+        subdir = artifact_dir / f"{name}_{component}_{target_family}"
+        stage = subdir / "stage"
+        stage.mkdir(parents=True, exist_ok=True)
+        (stage / "placeholder.txt").write_text("x")
+        (subdir / "artifact_manifest.txt").write_text("stage\n")
+
+    def _make_artifact_catalog(
+        self, artifact_specs: list[tuple[str, str, str]]
+    ) -> ArtifactCatalog:
+        artifact_dir = self.temp_dir / "artifacts"
+        for name, component, target_family in artifact_specs:
+            self._add_artifact(
+                artifact_dir=artifact_dir,
+                name=name,
+                component=component,
+                target_family=target_family,
+            )
+        return ArtifactCatalog(artifact_dir)
+
+    def _write_dist_file(self, filename: str) -> None:
+        dist_dir = self.temp_dir / "packages" / "dist"
+        dist_dir.mkdir(parents=True, exist_ok=True)
+        (dist_dir / filename).write_text("package")
+
+    def _write_required_kpack_split_runtime_files(self, target: str) -> None:
+        self._write_dist_file(f"rocm-{self.version}.tar.gz")
+        self._write_dist_file(f"rocm_sdk_core-{self.version}-{self.wheel_tag}.whl")
+        self._write_dist_file(f"rocm_sdk_libraries-{self.version}-{self.wheel_tag}.whl")
+        self._write_dist_file(
+            f"rocm_sdk_device_{target}-{self.version}-{self.wheel_tag}.whl"
+        )
+
+    def _validate_required_dist_packages(
+        self,
+        *,
+        artifacts: ArtifactCatalog,
+        kpack_split: bool,
+        linux_targets: list[str] | None,
+        windows_targets: list[str] | None,
+        platform_name: str,
+    ) -> None:
+        sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+        from build_python_packages import validate_required_dist_packages
+
+        validate_required_dist_packages(
+            dest_dir=self.temp_dir / "packages",
+            version=self.version,
+            artifacts=artifacts,
+            kpack_split=kpack_split,
+            linux_targets=linux_targets,
+            windows_targets=windows_targets,
+            platform_name=platform_name,
+        )
+
+    def test_required_kpack_split_dist_packages_pass(self):
+        artifacts = self._make_artifact_catalog([("blas", "lib", "gfx1100")])
+        self._write_required_kpack_split_runtime_files("gfx1100")
+
+        self._validate_required_dist_packages(
+            artifacts=artifacts,
+            kpack_split=True,
+            linux_targets=["gfx1100"],
+            windows_targets=None,
+            platform_name="linux",
+        )
+
+    def test_required_dist_packages_fail_when_rocm_sdist_is_missing(self):
+        artifacts = self._make_artifact_catalog([("blas", "lib", "gfx1100")])
+        self._write_dist_file(f"rocm_sdk_core-{self.version}-{self.wheel_tag}.whl")
+        self._write_dist_file(f"rocm_sdk_libraries-{self.version}-{self.wheel_tag}.whl")
+        self._write_dist_file(
+            f"rocm_sdk_device_gfx1100-{self.version}-{self.wheel_tag}.whl"
+        )
+
+        with self.assertRaisesRegex(RuntimeError, f"rocm-{self.version}.tar.gz"):
+            self._validate_required_dist_packages(
+                artifacts=artifacts,
+                kpack_split=True,
+                linux_targets=["gfx1100"],
+                windows_targets=None,
+                platform_name="linux",
+            )
+
+    def test_required_dist_packages_fail_when_device_wheel_is_missing(self):
+        artifacts = self._make_artifact_catalog([("blas", "lib", "gfx1100")])
+        self._write_dist_file(f"rocm-{self.version}.tar.gz")
+        self._write_dist_file(f"rocm_sdk_core-{self.version}-{self.wheel_tag}.whl")
+        self._write_dist_file(f"rocm_sdk_libraries-{self.version}-{self.wheel_tag}.whl")
+
+        with self.assertRaisesRegex(RuntimeError, "rocm_sdk_device_gfx1100"):
+            self._validate_required_dist_packages(
+                artifacts=artifacts,
+                kpack_split=True,
+                linux_targets=["gfx1100"],
+                windows_targets=None,
+                platform_name="linux",
+            )
+
+    def test_required_dist_packages_require_devel_when_dev_artifacts_exist(self):
+        artifacts = self._make_artifact_catalog(
+            [
+                ("blas", "lib", "gfx1100"),
+                ("core-hip", "dev", "generic"),
+            ]
+        )
+        self._write_required_kpack_split_runtime_files("gfx1100")
+
+        with self.assertRaisesRegex(RuntimeError, "rocm_sdk_devel"):
+            self._validate_required_dist_packages(
+                artifacts=artifacts,
+                kpack_split=True,
+                linux_targets=["gfx1100"],
+                windows_targets=None,
+                platform_name="linux",
+            )
+
+    def test_required_dist_packages_skip_devel_without_dev_artifacts(self):
+        artifacts = self._make_artifact_catalog([("blas", "lib", "gfx1100")])
+        self._write_required_kpack_split_runtime_files("gfx1100")
+
+        self._validate_required_dist_packages(
+            artifacts=artifacts,
+            kpack_split=True,
+            linux_targets=["gfx1100"],
+            windows_targets=None,
+            platform_name="linux",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Unit tests for restrict_families (per-family meta package)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

Kpack-split Python package builds could succeed even when the fetched
artifact catalog did not contain every device target advertised for the
platform.

Furthermore, kpack-split package builds could leave a publishable dist
directory without required runtime and meta packages, allowing upload
to proceed with an incomplete ROCm Python package set.

## Technical Details

Let the package build fail when advertised device targets are missing so
incomplete sets of device packages are caught before upload.
Furthermore, verifies that the final dist output includes the ROCm meta
sdist, core and libraries wheels, each expected current-platform device
wheel, and the devel wheel (for the case that dev artifacts have been
fetched).

Closes #6422.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
