### PR TITLE
fix(ci): Disable DWZ compression for hipfile DEB package (#6370)

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -3333,6 +3333,7 @@
         ]
       }
     ],
+    "Disable_DWZ": "True",
     "Gfxarch": "False"
   },
 


### PR DESCRIPTION
Add "Disable_DWZ": "True" to hipfile package configuration to skip DWARF debug info compression during Debian packaging.
DWZ fails on libhipfile.so with: "Unknown debugging section .debug_str_offsets"

JIRA ID: https://github.com/ROCm/TheRock/issues/5076

Original PR : https://github.com/ROCm/TheRock/pull/6370