### PR TITLE
ci: dispatch full PyTorch tests for dev releases

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -455,13 +455,13 @@ jobs:
   # workflow builds a single (python_version, pytorch_git_ref), the build job's
   # torch_version output is unambiguous and only this build's success gates the
   # dispatch -- a failure for one ref no longer skips testing the others (#5777).
-  # Scoped to nightly gfx94X-dcgpu Python 3.12 builds for now.
+  # Scoped to nightly/dev gfx94X-dcgpu Python 3.12 builds for now.
   dispatch_pytorch_wheels_full_test:
     name: Dispatch PyTorch Full Test | torch ${{ inputs.pytorch_git_ref }}
     if: >-
       ${{
         inputs.run_full_pytorch_tests &&
-        inputs.release_type == 'nightly' &&
+        (inputs.release_type == 'nightly' || inputs.release_type == 'dev') &&
         inputs.python_version == '3.12' &&
         contains(inputs.amdgpu_families, 'gfx94X-dcgpu')
       }}
@@ -472,12 +472,15 @@ jobs:
       contents: read
     env:
       PYTORCH_GIT_REF: ${{ inputs.pytorch_git_ref }}
+      RELEASE_TYPE: ${{ inputs.release_type }}
     steps:
       - name: Check full test cadence
         id: cadence
-        # Release branches test daily; the nightly branch tests weekly (Sunday).
+        # Dev builds are on-demand (only reach here when run_full_pytorch_tests
+        # is set), so they always dispatch. For nightly builds: release branches
+        # test daily; the nightly branch tests weekly (Sunday).
         run: |
-          if [ "${PYTORCH_GIT_REF}" != "nightly" ] || [ "$(date -u +%u)" = "7" ]; then
+          if [ "${RELEASE_TYPE}" = "dev" ] || [ "${PYTORCH_GIT_REF}" != "nightly" ] || [ "$(date -u +%u)" = "7" ]; then
             echo "dispatch=true" >> "$GITHUB_OUTPUT"
           else
             echo "dispatch=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Lets `dev` releases dispatch the full PyTorch test suite (in addition to
`nightly`) from the per-ref build workflow (`multi_arch_build_portable_linux_pytorch_wheels.yml`).

Closes #5781.

## Context

This replaces #5815, which was stacked on the now-closed #5813 branch and edited
the pre-#5780 dispatch location in `multi_arch_release_linux_pytorch_wheels.yml`.
After #5780 the full-test dispatch lives in the build workflow's
`dispatch_pytorch_wheels_full_test` job, so the change is now a small, focused
edit there.

Of #5781's two asks:
- **Un-hardcode the index URL** — already done on `main`: the dispatch passes
  `package_index_url: ${{ needs.build_pytorch_wheels.outputs.package_index_url }}`,
  which is derived from the publish step (`MULTI_ARCH_INDEX_URLS[release_type]`).
  For `dev` that resolves to `https://rocm.devreleases.amd.com/whl-multi-arch/`.
- **Support dev releases** — this PR: add `dev` to the dispatch gate.

## What changed

- `dispatch_pytorch_wheels_full_test` gate now accepts
  `release_type == 'nightly' || release_type == 'dev'`.
- The cadence step treats `dev` as on-demand: dev builds only reach this job when
  `run_full_pytorch_tests` is set, so they dispatch whenever requested rather than
  being subject to the nightly weekly (Sunday) cadence.

## Cadence / safety

Safe no-op for dev until a scheduled/dispatched build passes
`run_full_pytorch_tests=true` for a dev release — the dispatch only fires when
that flag is set, so routine on-demand dev builds do not trigger a full-test
storm.
