### PR TITLE
fix: [pytorch] Resolve ROCm deps via RUNPATHs

### DIFF
--- a/build_tools/packaging/promote_packages.py
+++ b/build_tools/packaging/promote_packages.py
@@ -75,6 +75,7 @@ import importlib.util
 import pathlib
 import re
 import shutil
+import subprocess
 import sys
 import tarfile
 import tempfile
@@ -278,6 +279,73 @@ def compute_new_version_str(
     # src_version_type is constrained to "rc" or "a" by argparse; regex-safe.
     replacement = "" if dest_version == "release" else dest_version
     return re.sub(rf"{src_version_type}\d*", replacement, version_str)
+
+
+def _update_runpath_version(
+    runpath: str, old_rocm_version: str, new_rocm_version: str
+) -> str:
+    return runpath.replace(old_rocm_version, new_rocm_version)
+
+
+def _is_elf_file(path: pathlib.Path) -> bool:
+    try:
+        with path.open("rb") as f:
+            return f.read(4) == b"\x7fELF"
+    except OSError:
+        return False
+
+
+def _file_contains_bytes(path: pathlib.Path, needle: bytes) -> bool:
+    if not needle:
+        return False
+    overlap = len(needle) - 1
+    previous = b""
+    try:
+        with path.open("rb") as f:
+            while chunk := f.read(1024 * 1024):
+                data = previous + chunk
+                if needle in data:
+                    return True
+                previous = data[-overlap:] if overlap else b""
+    except OSError:
+        return False
+    return False
+
+
+def _update_torch_elf_runpath_versions(
+    torch_dir: pathlib.Path, old_rocm_version: str, new_rocm_version: str
+) -> None:
+    if old_rocm_version == new_rocm_version:
+        return
+
+    old_rocm_version_bytes = old_rocm_version.encode("utf-8")
+    elf_files = [
+        file_path
+        for file_path in sorted(torch_dir.rglob("*"))
+        if not file_path.is_symlink()
+        and file_path.is_file()
+        and _is_elf_file(file_path)
+        and _file_contains_bytes(file_path, old_rocm_version_bytes)
+    ]
+    if not elf_files:
+        return
+    if not shutil.which("patchelf"):
+        raise RuntimeError("patchelf is required to promote torch ELF RUNPATHs")
+
+    for file_path in elf_files:
+        try:
+            runpath = subprocess.check_output(
+                ["patchelf", "--print-rpath", file_path], text=True
+            ).strip()
+        except subprocess.CalledProcessError:
+            continue
+        updated_runpath = _update_runpath_version(
+            runpath, old_rocm_version, new_rocm_version
+        )
+        if updated_runpath == runpath:
+            continue
+        print(f"      Updating ELF RUNPATH: {file_path}")
+        subprocess.check_call(["patchelf", "--set-rpath", updated_runpath, file_path])
 
 
 # Arch token shape used in wheel filenames, extras names, and dep names. Covers
@@ -845,6 +913,11 @@ def wheel_change_extra_files(
             new_dir_path / package_name_no_version / "_rocm_init.py",
             new_dir_path / package_name_no_version / "version.py",
         ]
+        _update_torch_elf_runpath_versions(
+            new_dir_path / package_name_no_version,
+            old_rocm_version,
+            new_rocm_version,
+        )
     elif "apex" in package_name_no_version:
         files_to_change = [
             new_dir_path / package_name_no_version / "git_version_info_installed.py",

--- a/build_tools/packaging/tests/promote_keep_list_test.py
+++ b/build_tools/packaging/tests/promote_keep_list_test.py
@@ -211,6 +211,30 @@ class ApplyKeepListToMetadataTest(unittest.TestCase):
             path.unlink()
 
 
+class UpdateRunpathVersionTest(unittest.TestCase):
+    def test_updates_rocm_version_in_rocm_package_runpaths(self):
+        runpath = (
+            "$ORIGIN/../../_rocm_sdk_core_rocm7.13.0a20260505/lib:"
+            "$ORIGIN/../../_rocm_sdk_libraries_rocm7.13.0a20260505/lib"
+        )
+
+        self.assertEqual(
+            ptf._update_runpath_version(runpath, "7.13.0a20260505", "7.13.0"),
+            (
+                "$ORIGIN/../../_rocm_sdk_core_rocm7.13.0/lib:"
+                "$ORIGIN/../../_rocm_sdk_libraries_rocm7.13.0/lib"
+            ),
+        )
+
+    def test_leaves_unversioned_runpath_unchanged(self):
+        runpath = "$ORIGIN:$ORIGIN/../../_rocm_sdk_core/lib"
+
+        self.assertEqual(
+            ptf._update_runpath_version(runpath, "7.13.0a20260505", "7.13.0"),
+            runpath,
+        )
+
+
 class ApplyKeepListToRequiresTxtTest(unittest.TestCase):
     @staticmethod
     def _get_requires_txt_multi_arch_body() -> str:

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -359,15 +359,13 @@ def get_rocm_init_contents(args: argparse.Namespace):
         WINDOWS_LIBRARY_PRELOADS if is_windows else LINUX_LIBRARY_PRELOADS
     )
     library_preloads_formatted = ", ".join(f"'{s}'" for s in library_preloads)
-    return textwrap.dedent(
-        f"""
+    return textwrap.dedent(f"""
         def initialize():
             import rocm_sdk
             rocm_sdk.initialize_process(
                 preload_shortnames=[{library_preloads_formatted}],
                 check_version='{sdk_version}')
-        """
-    )
+        """)
 
 
 ROCM_NEEDED_LIBRARY_PREFIXES = (
@@ -471,7 +469,9 @@ def configure_pytorch_wheel_rocm_runpaths(wheel_path: Path) -> None:
         wheel_root = wheel_roots[0]
         torch_dir = wheel_root / "torch"
         if not torch_dir.is_dir():
-            raise RuntimeError(f"Unpacked torch wheel has no torch package: {wheel_root}")
+            raise RuntimeError(
+                f"Unpacked torch wheel has no torch package: {wheel_root}"
+            )
 
         rocm_runpath_dirs = _get_rocm_dependency_wheel_runpath_dirs(wheel_root)
         updated_paths: list[Path] = []
@@ -484,7 +484,10 @@ def configure_pytorch_wheel_rocm_runpaths(wheel_path: Path) -> None:
                 ).splitlines()
             except subprocess.CalledProcessError:
                 continue
-            existing_runpath = _patchelf_output("--print-rpath", so_path)
+            try:
+                existing_runpath = _patchelf_output("--print-rpath", so_path)
+            except subprocess.CalledProcessError:
+                existing_runpath = ""
             if not _is_rocm_linked(needed_libraries) and not _runpath_references_rocm(
                 existing_runpath
             ):
@@ -501,13 +504,16 @@ def configure_pytorch_wheel_rocm_runpaths(wheel_path: Path) -> None:
             print(f"+++ Configuring ROCm RUNPATH: {so_path.relative_to(wheel_root)}")
             print(f"    old: {existing_runpath}")
             print(f"    new: {updated_runpath}")
-            subprocess.check_call(
-                ["patchelf", "--set-rpath", updated_runpath, so_path]
+            run_command(
+                ["patchelf", "--set-rpath", updated_runpath, so_path],
+                cwd=temp_dir,
             )
             updated_paths.append(so_path)
 
         if not updated_paths:
-            print("WARNING: Did not find any ROCm-linked torch shared objects to update")
+            print(
+                "WARNING: Did not find any ROCm-linked torch shared objects to update"
+            )
 
         run_command(
             [

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -385,7 +385,9 @@ def _split_runpath(runpath: str) -> list[str]:
     return [entry for entry in runpath.split(":") if entry]
 
 
-def _merge_relative_runpaths(existing_runpath: str, addl_runpaths: list[str]) -> str:
+def _strip_absolute_and_append_runpaths(
+    existing_runpath: str, addl_runpaths: list[str]
+) -> str:
     merged: list[str] = []
     for entry in _split_runpath(existing_runpath):
         if os.path.isabs(entry):
@@ -421,7 +423,7 @@ def _patchelf_output(*args: str | Path) -> str:
     ).strip()
 
 
-def _get_rocm_sdk_runpath_dirs(wheel_root: Path) -> list[Path]:
+def _get_rocm_dependency_wheel_runpath_dirs(wheel_root: Path) -> list[Path]:
     import importlib
 
     from rocm_sdk import _dist_info
@@ -443,19 +445,19 @@ def _get_rocm_sdk_runpath_dirs(wheel_root: Path) -> list[Path]:
     return runpath_dirs
 
 
-def repair_pytorch_wheel_runpaths(wheel_path: Path) -> None:
-    """Patch torch shared objects to resolve ROCm wheel libraries by RUNPATH."""
+def configure_pytorch_wheel_rocm_runpaths(wheel_path: Path) -> None:
+    """Configure torch shared object RUNPATHs for ROCm wheel library resolution."""
     if is_windows:
         return
     if not shutil.which("patchelf"):
-        raise RuntimeError("patchelf is required to repair PyTorch wheel RUNPATHs")
+        raise RuntimeError("patchelf is required to configure PyTorch wheel RUNPATHs")
 
     with tempfile.TemporaryDirectory(prefix="therock-pytorch-wheel-") as temp_dir_str:
         temp_dir = Path(temp_dir_str)
         unpack_dir = temp_dir / "unpacked"
-        repaired_dir = temp_dir / "repaired"
+        output_dir = temp_dir / "output"
         unpack_dir.mkdir()
-        repaired_dir.mkdir()
+        output_dir.mkdir()
 
         run_command(
             [sys.executable, "-m", "wheel", "unpack", "--dest", unpack_dir, wheel_path],
@@ -471,8 +473,8 @@ def repair_pytorch_wheel_runpaths(wheel_path: Path) -> None:
         if not torch_dir.is_dir():
             raise RuntimeError(f"Unpacked torch wheel has no torch package: {wheel_root}")
 
-        rocm_runpath_dirs = _get_rocm_sdk_runpath_dirs(wheel_root)
-        patched_paths: list[Path] = []
+        rocm_runpath_dirs = _get_rocm_dependency_wheel_runpath_dirs(wheel_root)
+        updated_paths: list[Path] = []
         for so_path in sorted(torch_dir.rglob("*.so*")):
             if so_path.is_symlink() or not so_path.is_file():
                 continue
@@ -491,21 +493,21 @@ def repair_pytorch_wheel_runpaths(wheel_path: Path) -> None:
                 _origin_relative_runpath(so_path, target_dir)
                 for target_dir in rocm_runpath_dirs
             ]
-            repaired_runpath = _merge_relative_runpaths(
+            updated_runpath = _strip_absolute_and_append_runpaths(
                 existing_runpath, addl_runpaths
             )
-            if repaired_runpath == existing_runpath:
+            if updated_runpath == existing_runpath:
                 continue
-            print(f"+++ Repairing ROCm RUNPATH: {so_path.relative_to(wheel_root)}")
+            print(f"+++ Configuring ROCm RUNPATH: {so_path.relative_to(wheel_root)}")
             print(f"    old: {existing_runpath}")
-            print(f"    new: {repaired_runpath}")
+            print(f"    new: {updated_runpath}")
             subprocess.check_call(
-                ["patchelf", "--set-rpath", repaired_runpath, so_path]
+                ["patchelf", "--set-rpath", updated_runpath, so_path]
             )
-            patched_paths.append(so_path)
+            updated_paths.append(so_path)
 
-        if not patched_paths:
-            print("WARNING: Did not find any ROCm-linked torch shared objects to repair")
+        if not updated_paths:
+            print("WARNING: Did not find any ROCm-linked torch shared objects to update")
 
         run_command(
             [
@@ -514,13 +516,13 @@ def repair_pytorch_wheel_runpaths(wheel_path: Path) -> None:
                 "wheel",
                 "pack",
                 "--dest-dir",
-                repaired_dir,
+                output_dir,
                 wheel_root,
             ],
             cwd=temp_dir,
         )
-        repaired_wheel = find_built_wheel(repaired_dir, "torch")
-        shutil.copy2(repaired_wheel, wheel_path)
+        output_wheel = find_built_wheel(output_dir, "torch")
+        shutil.copy2(output_wheel, wheel_path)
 
 
 def remove_dir_if_exists(dir: Path):
@@ -1325,7 +1327,7 @@ def do_build_pytorch(
     run_command([sys.executable, "setup.py", "bdist_wheel"], cwd=pytorch_dir, env=env)
     built_wheel = find_built_wheel(pytorch_dir / "dist", "torch")
     print(f"Found built wheel: {built_wheel}")
-    repair_pytorch_wheel_runpaths(built_wheel)
+    configure_pytorch_wheel_rocm_runpaths(built_wheel)
     copy_to_output(args, built_wheel)
 
     print("+++ Installing built torch:")

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -359,13 +359,15 @@ def get_rocm_init_contents(args: argparse.Namespace):
         WINDOWS_LIBRARY_PRELOADS if is_windows else LINUX_LIBRARY_PRELOADS
     )
     library_preloads_formatted = ", ".join(f"'{s}'" for s in library_preloads)
-    return textwrap.dedent(f"""
+    return textwrap.dedent(
+        f"""
         def initialize():
             import rocm_sdk
             rocm_sdk.initialize_process(
                 preload_shortnames=[{library_preloads_formatted}],
                 check_version='{sdk_version}')
-        """)
+        """
+    )
 
 
 ROCM_NEEDED_LIBRARY_PREFIXES = (

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -165,7 +165,6 @@ LLVM_BASE_URL = "https://oaitriton.blob.core.windows.net/public/llvm-builds"
 LINUX_LIBRARY_PRELOADS = [
     "amd_comgr",
     "amdhip64",
-    "rocprofiler-sdk",  # Linux only: needed by torch since kineto uses rocprofiler-sdk.
     "rocprofiler-sdk-roctx",  # Linux only for the moment.
     # TODO: Remove roctracer64 and roctx64 once fully switched to rocprofiler-sdk.
     "roctracer64",  # Linux only for the moment.
@@ -369,6 +368,159 @@ def get_rocm_init_contents(args: argparse.Namespace):
                 check_version='{sdk_version}')
         """
     )
+
+
+ROCM_NEEDED_LIBRARY_PREFIXES = (
+    "libamd",
+    "libdrm_amdgpu",
+    "libhip",
+    "libhsa",
+    "libMIOpen",
+    "librccl",
+    "libroc",
+)
+
+
+def _split_runpath(runpath: str) -> list[str]:
+    return [entry for entry in runpath.split(":") if entry]
+
+
+def _merge_relative_runpaths(existing_runpath: str, addl_runpaths: list[str]) -> str:
+    merged: list[str] = []
+    for entry in _split_runpath(existing_runpath):
+        if os.path.isabs(entry):
+            continue
+        if entry not in merged:
+            merged.append(entry)
+    for entry in addl_runpaths:
+        if entry not in merged:
+            merged.append(entry)
+    return ":".join(merged)
+
+
+def _origin_relative_runpath(elf_path: Path, target_dir: Path) -> str:
+    relpath = os.path.relpath(target_dir, elf_path.parent)
+    if relpath == ".":
+        return "$ORIGIN"
+    return f"$ORIGIN/{Path(relpath).as_posix()}"
+
+
+def _is_rocm_linked(needed_libraries: list[str]) -> bool:
+    return any(
+        needed.startswith(ROCM_NEEDED_LIBRARY_PREFIXES) for needed in needed_libraries
+    )
+
+
+def _runpath_references_rocm(runpath: str) -> bool:
+    return any("rocm" in entry.lower() for entry in _split_runpath(runpath))
+
+
+def _patchelf_output(*args: str | Path) -> str:
+    return subprocess.check_output(
+        ["patchelf", *(str(arg) for arg in args)], text=True
+    ).strip()
+
+
+def _get_rocm_sdk_runpath_dirs(wheel_root: Path) -> list[Path]:
+    import importlib
+
+    from rocm_sdk import _dist_info
+
+    runpath_dirs: list[Path] = []
+    for lib_entry in _dist_info.ALL_LIBRARIES.values():
+        if not lib_entry.so_pattern:
+            continue
+        package = lib_entry.package
+        target_family = None
+        if package.is_target_specific:
+            target_family = _dist_info.determine_target_family()
+        py_package_name = package.get_py_package_name(target_family)
+        py_module = importlib.import_module(py_package_name)
+        py_root = Path(py_module.__file__).parent
+        runpath_dir = wheel_root / py_root.name / lib_entry.posix_relpath
+        if runpath_dir not in runpath_dirs:
+            runpath_dirs.append(runpath_dir)
+    return runpath_dirs
+
+
+def repair_pytorch_wheel_runpaths(wheel_path: Path) -> None:
+    """Patch torch shared objects to resolve ROCm wheel libraries by RUNPATH."""
+    if is_windows:
+        return
+    if not shutil.which("patchelf"):
+        raise RuntimeError("patchelf is required to repair PyTorch wheel RUNPATHs")
+
+    with tempfile.TemporaryDirectory(prefix="therock-pytorch-wheel-") as temp_dir_str:
+        temp_dir = Path(temp_dir_str)
+        unpack_dir = temp_dir / "unpacked"
+        repaired_dir = temp_dir / "repaired"
+        unpack_dir.mkdir()
+        repaired_dir.mkdir()
+
+        run_command(
+            [sys.executable, "-m", "wheel", "unpack", "--dest", unpack_dir, wheel_path],
+            cwd=temp_dir,
+        )
+        wheel_roots = [path for path in unpack_dir.iterdir() if path.is_dir()]
+        if len(wheel_roots) != 1:
+            raise RuntimeError(
+                f"Expected one unpacked wheel directory, found {wheel_roots}"
+            )
+        wheel_root = wheel_roots[0]
+        torch_dir = wheel_root / "torch"
+        if not torch_dir.is_dir():
+            raise RuntimeError(f"Unpacked torch wheel has no torch package: {wheel_root}")
+
+        rocm_runpath_dirs = _get_rocm_sdk_runpath_dirs(wheel_root)
+        patched_paths: list[Path] = []
+        for so_path in sorted(torch_dir.rglob("*.so*")):
+            if so_path.is_symlink() or not so_path.is_file():
+                continue
+            try:
+                needed_libraries = _patchelf_output(
+                    "--print-needed", so_path
+                ).splitlines()
+            except subprocess.CalledProcessError:
+                continue
+            existing_runpath = _patchelf_output("--print-rpath", so_path)
+            if not _is_rocm_linked(needed_libraries) and not _runpath_references_rocm(
+                existing_runpath
+            ):
+                continue
+            addl_runpaths = [
+                _origin_relative_runpath(so_path, target_dir)
+                for target_dir in rocm_runpath_dirs
+            ]
+            repaired_runpath = _merge_relative_runpaths(
+                existing_runpath, addl_runpaths
+            )
+            if repaired_runpath == existing_runpath:
+                continue
+            print(f"+++ Repairing ROCm RUNPATH: {so_path.relative_to(wheel_root)}")
+            print(f"    old: {existing_runpath}")
+            print(f"    new: {repaired_runpath}")
+            subprocess.check_call(
+                ["patchelf", "--set-rpath", repaired_runpath, so_path]
+            )
+            patched_paths.append(so_path)
+
+        if not patched_paths:
+            print("WARNING: Did not find any ROCm-linked torch shared objects to repair")
+
+        run_command(
+            [
+                sys.executable,
+                "-m",
+                "wheel",
+                "pack",
+                "--dest-dir",
+                repaired_dir,
+                wheel_root,
+            ],
+            cwd=temp_dir,
+        )
+        repaired_wheel = find_built_wheel(repaired_dir, "torch")
+        shutil.copy2(repaired_wheel, wheel_path)
 
 
 def remove_dir_if_exists(dir: Path):
@@ -1173,6 +1325,7 @@ def do_build_pytorch(
     run_command([sys.executable, "setup.py", "bdist_wheel"], cwd=pytorch_dir, env=env)
     built_wheel = find_built_wheel(pytorch_dir / "dist", "torch")
     print(f"Found built wheel: {built_wheel}")
+    repair_pytorch_wheel_runpaths(built_wheel)
     copy_to_output(args, built_wheel)
 
     print("+++ Installing built torch:")


### PR DESCRIPTION
## Motivation

Commit https://github.com/ROCm/TheRock/commit/6a55012d931359f125b540ea6f609c44629bc60c added rocprofiler-sdk to PyTorch’s Linux startup preload list to fix nightly smoke tests after PyTorch/Kineto gained a runtime dependency on `librocprofiler-sdk.so.1`.

When PyTorch is launched under an external `rocprofv3`, the profiler may already have loaded and initialized one rocprofiler-sdk provider. PyTorch startup can then explicitly load the wheel-bundled rocprofiler-sdk, creating a duplicate-provider path in the same process. In that scenario, the rocprofv3 tool configuration path can be invoked after rocprofiler-sdk has already closed its configuration window, leading to:
```
ROCPROFILER_STATUS_ERROR_CONFIGURATION_LOCKED
Configuration request occurred outside of valid rocprofiler configuration period
```
This PR treats the original issue as a packaging/runtime dependency issue instead of an import-time preload issue. PyTorch’s ROCm-linked shared libraries should resolve their `DT_NEEDED` dependencies through relocatable wheel RUNPATHs.

JIRA ID: AIPROFSDK-969
## Technical Details

This PR removes rocprofiler-sdk from PyTorch’s generated _rocm_init.py preload list.

After pytorch build step unpacks the generated torch wheel, finds ROCm-linked torch shared objects, removes non-relocatable absolute RUNPATH entries, appends $ORIGIN-relative RUNPATH entries pointing to the installed ROCm Python package library directories, and repacks the wheel before copying.

This lets dependencies such as `librocprofiler-sdk.so.1` resolve through the dynamic loader instead of through explicit `ctypes/rocm_sdk.initialize_process()` preloading. If an external `rocprofv3` has already loaded a compatible SDK provider with the same SONAME, the loader can use the already-loaded provider instead of PyTorch forcing another absolute SDK load.

This PR also updates package promotion logic so torch ELF RUNPATHs stay valid when ROCm package versions are promoted. Text files such as `_rocm_init.py`, `version.py`, and metadata were already updated during promotion, but RUNPATH strings embedded in ELF files also need their ROCm version fragments updated when promoting from nightly/RC versions to release versions.

## Test Plan

- Added test in `build_tools/packaging/tests/promote_keep_list_test.py`

## Test Result

- https://github.com/ROCm/TheRock/actions/runs/29043018157
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
