### PR TITLE
fix: Use zstd compression for faster RPM builds

### DIFF
--- a/build_tools/packaging/linux/template/rpm_specfile.j2
+++ b/build_tools/packaging/linux/template/rpm_specfile.j2
@@ -16,6 +16,7 @@
 {%- if exclude_libpython_requires %}
 %define __requires_exclude libpython*.*
 {%- endif %}
+%define _binary_payload w1.zstdio
 
 Name: {{ pkg_name }}
 Version: {{ version }}

--- a/build_tools/packaging/linux/template/rpm_specfile.j2
+++ b/build_tools/packaging/linux/template/rpm_specfile.j2
@@ -16,7 +16,7 @@
 {%- if exclude_libpython_requires %}
 %define __requires_exclude libpython*.*
 {%- endif %}
-%define _binary_payload w1.zstdio
+%define _binary_payload w9.zstdio
 
 Name: {{ pkg_name }}
 Version: {{ version }}


### PR DESCRIPTION
  Switch from gzip-9 to zstd-9 for RPM payload compression and better build time

 ```
Used **amdrocm-llvm** ASAN package for comparison
 ------------------------------------------------------------------------------------------
  Compression     Package Size    Build Time   Size vs Baseline       Time vs Baseline
  ------------------------------------------------------------------------------------------
  GZIP-9          7.87 GiB                  Around1 hr         —                      —
  ZSTD-1          8.22 GiB                  3m 24s       +360 MiB (+4.5%)       57 min faster
  ZSTD-6         7.14 GiB                   6m 44s       -745 MiB (-9.3%)         53 min faster
  ZSTD-9          6.82 GiB                  8m 9s        -1071 MiB (-13.3%)       52 min faster
  ------------------------------------------------------------------------------------------
```

JIRA ID: https://github.com/ROCm/TheRock/issues/6454