### PR TITLE
fix(ci): Add build_variant to Test Artifacts run-name

### DIFF
--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -199,7 +199,8 @@ jobs:
               "test_type": "${{ inputs.test_type }}",
               "release_type": "${{ inputs.release_type }}",
               "repository": "${{ inputs.repository }}",
-              "ref": "${{ inputs.ref }}"
+              "ref": "${{ inputs.ref }}",
+              "build_variant": "${{ inputs.build_variant }}"
             }
 
   # Install tests are dispatched asynchronously (sanity) so publish

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -112,7 +112,7 @@ on:
 permissions:
   contents: read
 
-run-name: Test Artifacts (${{ inputs.amdgpu_families }}, ${{ inputs.release_type }}, ${{ inputs.test_type }}, ${{ inputs.test_runs_on }})
+run-name: Test Artifacts (${{ inputs.amdgpu_families }}, ${{ inputs.release_type }}, ${{ inputs.test_type }}, ${{ inputs.build_variant }}, ${{ inputs.test_runs_on }})
 
 jobs:
   configure_test_matrix:


### PR DESCRIPTION
Include the build_variant (release/asan) in the workflow run-name to easily distinguish between regular and ASAN test artifact runs.

Closes #6456

Working here: https://github.com/ROCm/TheRock/actions/runs/29054942544