### PR TITLE
fix(pytorch-tests): merge duplicate common.cuda skip block in generic.py

### DIFF
--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -9,6 +9,12 @@ skip_tests = {
         }
     },
     "common": {
+        "autograd": [
+            # Stream comparison mismatch on ROCm (non-default stream vs default stream)
+            #   AssertionError: <torch.cuda.Stream ...> != <torch.cuda.Stream cuda_stream=0x0>
+            # Seems to fails on Linux and Windows across torch versions and all tested GPUs.
+            "test_side_stream_backward_overlap",
+        ],
         "cuda": [
             # RuntimeError: Error building extension 'dummy_allocator'
             # Skipped across all PyTorch versions; the hipblas.h include error
@@ -17,14 +23,6 @@ skip_tests = {
             # TestCudaAllocator - FileNotFoundError: flamegraph.pl missing in CI
             "test_memory_snapshot",
             "test_memory_plots",
-        ],
-        "autograd": [
-            # Stream comparison mismatch on ROCm (non-default stream vs default stream)
-            #   AssertionError: <torch.cuda.Stream ...> != <torch.cuda.Stream cuda_stream=0x0>
-            # Seems to fails on Linux and Windows across torch versions and all tested GPUs.
-            "test_side_stream_backward_overlap",
-        ],
-        "cuda": [
             # HIP_VISIBLE_DEVICES and CUDA_VISIBLE_DEVICES not working
             # to restrict visibility of devices
             # AssertionError: String comparison failed: '8, 1' != '8, 8'


### PR DESCRIPTION
## Summary

The `"common"` dict in `external-builds/pytorch/skip_tests/generic.py` defined the `"cuda"` key **twice**. Python keeps only the last literal for a duplicate key, so the first `cuda` block was silently discarded — dropping three tests from the skip list:

- `test_mempool_empty_cache_inactive`
- `test_memory_snapshot`
- `test_memory_plots`

Because these were dropped from `generic.py`, they only stayed skipped on torch versions whose `pytorch_<version>.py` happened to re-list them. `release/2.12` does **not** re-list `test_mempool_empty_cache_inactive`, so it ran and failed with `RuntimeError: Error building extension 'dummy_allocator'` (the `hipblas.h`-at-runtime error that requires `rocm[devel]`, which isn't installed at test time).

Observed failure: rockrel full-wheels run, cell py3.10 / torch `release/2.12` / gfx1151.

The duplicate `cuda` key was introduced in #3929 (commit `71a0072`), which added a new `common.cuda` block above the pre-existing one instead of merging into it.

## Fix

Fold the three tests into the single surviving `"cuda"` block so they are skipped across all versions from one place, and remove the duplicate key.

Related: #3939 and https://github.com/ROCm/TheRock/issues/6173

## Test plan

- [x] `python external-builds/pytorch/skip_tests/test_skip_tests.py` → "All skip-test sanity checks passed."
- [x] AST check confirms no duplicate dict keys remain and all three tests are present in `common.cuda`.

🤖 Generated with Claude Code