### PR TITLE
fix(rocprofiler-systems): Allow MPI tests to function

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -197,6 +197,13 @@ COMPONENT_OVERRIDES = {
         },
         "env": {
             "ROCPROFSYS_INSTALL_DIR": "{rocm_path}",
+            # Open MPI bakes its build-time install prefix (the manylinux
+            # container path) into its binaries, so plugin/help-file discovery
+            # fails outside the container. Override it with the ROCm install
+            # tree so MPI-based tests run.
+            "OPAL_PREFIX": "{rocm_path}",
+            "PRTE_PREFIX": "{rocm_path}",
+            "PMIX_PREFIX": "{rocm_path}",
         },
         # rocprofiler-systems tests instrument processes and attach to a shared
         # profiling backend; running them concurrently causes flaky failures.

--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -193,7 +193,13 @@ COMPONENT_OVERRIDES = {
         "test_dir": ["share", "rocprofiler-systems", "tests"],
         "additional_env_paths": {
             "PATH": [["bin"]],
-            "LD_LIBRARY_PATH": [["share", "rocprofiler-systems", "examples", "lib"]],
+            "LD_LIBRARY_PATH": [
+                [
+                    "lib",
+                    "rocprofiler-systems",
+                ],  # Prioritize the bundled Dyninst runtime
+                ["share", "rocprofiler-systems", "examples", "lib"],
+            ],
         },
         "env": {
             "ROCPROFSYS_INSTALL_DIR": "{rocm_path}",


### PR DESCRIPTION
## Motivation

Jira ID: AIPROFSYST-524

Note: I'm not enabling these tests to run on TheRock CI. I'm just fixing things so that if someone were to build with `THEROCK_ENABLE_MPI`, then these tests would pass.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

MPI tests were originally disabled as if I build with `THEROCK_ENABLE_MPI`, then all mpi tests would fail with:
```
--------------------------------------------------------------------------
Sorry!  You were supposed to get help about:
    prterun-exec-failed
from the file:
    /therock/output/build/third-party/openmpi/build/stage/share/openmpi/help-mpirun.txt: No such file or directory
But I couldn't find that topic in the file.  Sorry!
--------------------------------------------------------------------------
```

Open MPI bakes its build-time install prefix (`/therock/output/...` from the `manylinux` container) into its binaries as string literals. Outside the container that path doesn't exist, so plugin discovery fails (`prterun-exec-failed`) and even the error message can't be looked up (`help-mpirun.txt: No such file or directory`).

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Open MPI 5.x is three independently-prefixed layers (OMPI/OPAL, the PRRTE launcher, and PMIx), each with its own override env var. Setting these (`OPAL_PREFIX`, `PRTE_PREFIX`, `PMIX_PREFIX`) to `rocm_path` (the real install root) relocates every layer's file lookups to where the files actually are.

Now, we can manually run MPI tests and they will pass.

 - [x] Requires https://github.com/ROCm/rocm-systems/pull/8415

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Manual Testing
## Test Result

<!-- Briefly summarize test outcomes. -->

Locally, all tests pass.
```
100% tests passed, 0 tests failed out of 26

Label Time Summary:
all               =  91.04 sec*proc (24 tests)
baseline          =   2.31 sec*proc (1 test)
binary_rewrite    =  55.56 sec*proc (10 tests)
cleanup           =   0.16 sec*proc (1 test)
full              =  91.04 sec*proc (24 tests)
global            =   0.56 sec*proc (2 tests)
mpi               =  91.04 sec*proc (24 tests)
prerequisite      =   0.41 sec*proc (1 test)
sampling          =  11.26 sec*proc (3 tests)
sys_run           =  21.90 sec*proc (10 tests)

Total Test time (real) =  91.62 sec
```

Tests will **NOT** run in CI as of now.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
