### PR TITLE
feat(ci): enabling retries on hip-tests 

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -177,8 +177,6 @@ def execute_tests(env):
         f"{timeout}",
         "--repeat",
         "until-pass:3",
-        "--parallel",
-        "4",
     ]
 
     # If quick tests are enabled, run only the smoke test subset

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -20,7 +20,8 @@ THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 SHARD_INDEX = int(os.getenv("SHARD_INDEX", 1)) - 1
 TOTAL_SHARDS = int(os.getenv("TOTAL_SHARDS", 1))
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
-TEST_TYPE = os.getenv("TEST_TYPE", "standard")
+# TODO(geomin12): Revert after testing - force comprehensive tests
+TEST_TYPE = "comprehensive"  # os.getenv("TEST_TYPE", "standard")
 os_type = platform.system().lower()
 CATCH_TESTS_PATH = str(Path(THEROCK_BIN_DIR).parent / "share" / "hip" / "catch_tests")
 
@@ -174,6 +175,10 @@ def execute_tests(env):
         "--output-on-failure",
         "--timeout",
         f"{timeout}",
+        "--repeat",
+        "until-pass:3",
+        "--parallel",
+        "4",
     ]
 
     # If quick tests are enabled, run only the smoke test subset

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -174,9 +174,11 @@ def execute_tests(env):
         "--output-on-failure",
         "--timeout",
         f"{timeout}",
-        "--repeat",
-        "until-pass:3",
     ]
+
+    # Add retry flag only for specific GPU families with known flaky tests
+    if AMDGPU_FAMILIES in ("gfx94X-dcgpu", "gfx125X-dcgpu"):
+        cmd.extend(["--repeat", "until-pass:3"])
 
     # If quick tests are enabled, run only the smoke test subset
     if TEST_TYPE == "quick":

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -20,8 +20,7 @@ THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
 SHARD_INDEX = int(os.getenv("SHARD_INDEX", 1)) - 1
 TOTAL_SHARDS = int(os.getenv("TOTAL_SHARDS", 1))
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
-# TODO(geomin12): Revert after testing - force comprehensive tests
-TEST_TYPE = "comprehensive"  # os.getenv("TEST_TYPE", "standard")
+TEST_TYPE = os.getenv("TEST_TYPE", "standard")
 os_type = platform.system().lower()
 CATCH_TESTS_PATH = str(Path(THEROCK_BIN_DIR).parent / "share" / "hip" / "catch_tests")
 


### PR DESCRIPTION
Particularly for gfx94X and gfx125X tests, hip-tests are flaky. this retry flag will help removing flaky issues and determine legit issues

Working here: https://github.com/ROCm/rocm-systems/actions/runs/28961023424/job/86224241848 pointing to this test branch