### PR TITLE
fix(packaging): disable DWZ for amdrocm-ccl-test package

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1525,6 +1525,7 @@
         ]
       }
     ],
+    "Disable_DWZ": "True",
     "Gfxarch": "True"
   },
   {


### PR DESCRIPTION
  DWZ crashes with SIGSEGV in multifile mode when processing ASAN-built
  binaries with large DWARF debug sections. The crash occurs in die_eq_1()
  when comparing DIE entries with NULL string attributes.

  Workaround: disable DWZ compression for this test package

JIRA ID: https://github.com/ROCm/TheRock/issues/5076