### PR TITLE
chore(compiler): set submodule pointer for Compiler comgr hotspot July 10

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1525,6 +1525,7 @@
         ]
       }
     ],
+    "Disable_DWZ": "True",
     "Gfxarch": "True"
   },
   {


### PR DESCRIPTION
llvm   44cf65f2b22d
unchanged:
hipify 6acec775
spirv  fb08e83a

JIRA ID : https://amd.atlassian.net/browse/PLAT-204991

HotSwap CP's:
44cf65f2b22d [Comgr][hotswap] Include TargetParser.h instead of AMDGPUTargetParser.h
47e1666fbe02 [AMDGPU] comgr: wrap long comment lines to 80 columns
e1a289619a05 [AMDGPU] comgr: trim stochastic rounding comment per review
beaee8b8a602 [AMDGPU] comgr: update SR FP8 modifier lit test for carry-propagation fix
163263b6eb1e [AMDGPU] comgr: fix SR FP8 carry-propagation in E5M3 stochastic rounding
eaf7aa50eef6 AMDGPU: apply gfx1250 hotswap mask workarounds
16747b94d6f7 AMDGPU: add strict hotswap rewrite plumbing
da719ba90d98 [Comgr][hotswap] Decline far s_add_pc_i64 trampolines (#3305)
bf22f159a259 [Comgr][hotswap] Append trampoline pool at a fresh vaddr instead of shifting post-.text addresses/symbols (#3252)
1fd9716efbfd AMDGPU: scope hotswap trampolines and clamp entry prefetch (#3195)
86ed6b0d0f30 AMDGPU: support literal sources in FP8 pack hotswap (#3189)
924aef5ab523 AMDGPU: reduce hotswap helper duplication (#3138)
dc4032f75353 AMDGPU: guard hotswap entry stub idempotency decode (#3182)
a42b456a38e2 [Comgr][hotswap] Fix scratch VGPR misallocation and fail safe on branch overflow (#3137)
d0d7a4a1040a AMDGPU: add hotswap entry trampoline core (#3008)

Build fix: 44cf65f2b22d retargets the comgr-hotswap include to TargetParser.h (where IsaVersion/getIsaVersion live at this base). The split-out AMDGPUTargetParser.h (upstream PR #198433) is not present here. Revert once the amd-llvm pin advances past that split.
