### PR TITLE
[CI] Fix __hip_cuid_ duplicate-symbol under sccache via per-TU -cuid (#748)

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -180,7 +180,12 @@ jobs:
         run: |
           COMPILER_LAUNCHER_ARGS=""
           if [ "${{ inputs.cache_type }}" = "sccache" ]; then
-            COMPILER_LAUNCHER_ARGS="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+            # Route CMake-driven compiles through the per-TU -cuid launcher ahead
+            # of sccache so RDC objects don't collide on __hip_cuid_ under caching
+            # (ROCm/TheRock#748). The wrapper finds sccache via THEROCK_SCCACHE
+            # (written to $GITHUB_ENV by setup_sccache_rocm.py --gha).
+            CUID_LAUNCHER="${PWD}/build_tools/cuid_launcher.py"
+            COMPILER_LAUNCHER_ARGS="-DCMAKE_C_COMPILER_LAUNCHER=${CUID_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${CUID_LAUNCHER}"
           elif [ "${{ inputs.cache_type }}" = "ccache" ]; then
             COMPILER_LAUNCHER_ARGS="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
           fi

--- a/build_tools/cuid_launcher.py
+++ b/build_tools/cuid_launcher.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Compiler launcher that injects a stable, per-translation-unit ``-cuid`` before
+handing off to sccache.
+
+Why this exists (ROCm/TheRock#748)
+----------------------------------
+With ``-fgpu-rdc`` every HIP object carries a ``__hip_cuid_<id>`` symbol. clang
+derives that id (``-fuse-cuid=hash``, the default) from ``md5(input-path + all
+non-input args)`` -- which *includes* ``-o``. sccache's cache key deliberately
+*excludes* ``-o`` and normalizes paths, so two translation units that differ only
+in their output collapse to the same key. On a cache hit sccache returns the
+first TU's object for the second, so both objects carry the *same*
+``__hip_cuid_`` -> duplicate-symbol error at RDC link time.
+
+Passing an explicit ``-cuid=<perTU>`` fixes both halves of the problem:
+  * sccache keys on ``-cuid`` (it is a normal arg), so each TU gets a distinct
+    cache entry -- no false cross-TU sharing.
+  * clang uses the value verbatim as the CUID, so each object gets a distinct
+    ``__hip_cuid_``.
+Deriving the value deterministically from the (relative) output path keeps warm
+cache hits working: the same TU always computes the same id across machines.
+
+This wrapper is only meaningful for HIP device compiles, so injection is gated to
+those (a bare ``-cuid`` on a host C/C++ compile would trip
+``-Wunused-command-line-argument`` under ``-Werror``).
+
+Invocation
+----------
+Set as a single executable path in either launcher position::
+
+    CMAKE_C_COMPILER_LAUNCHER  = <this>     # -> <this> <compiler> <args...>
+    CMAKE_CXX_COMPILER_LAUNCHER = <this>
+    HIP_CLANG_LAUNCHER          = <this>     # hipcc: "<this>" "<clang>" <args...>
+
+The real sccache binary is located via ``THEROCK_SCCACHE`` (preferred), then
+``SCCACHE``, then ``PATH``. If none is found the compiler is exec'd directly
+(caching disabled, build still succeeds).
+
+Optional debugging: set ``THEROCK_CUID_LOG=<file>`` to append every injected
+``-cuid`` (with its source output path) for post-build inspection.
+"""
+
+import hashlib
+import os
+import shutil
+import sys
+from pathlib import Path
+
+_HIP_ARCH_PREFIXES = ("--offload-arch", "--cuda-gpu-arch")
+_HIP_INPUT_SUFFIXES = (".hip", ".cu")
+
+
+def find_sccache() -> str | None:
+    """Locate the real sccache binary (env override first, then PATH)."""
+    for candidate in (os.environ.get("THEROCK_SCCACHE"), os.environ.get("SCCACHE")):
+        if candidate and Path(candidate).exists():
+            return candidate
+    return shutil.which("sccache")
+
+
+def output_path(args: list[str]) -> str | None:
+    """Return the value of the compile output flag (``-o`` / ``--output``)."""
+    for i, arg in enumerate(args):
+        if arg in ("-o", "--output") and i + 1 < len(args):
+            return args[i + 1]
+        if arg.startswith("-o") and len(arg) > 2:
+            return arg[2:]
+        if arg.startswith("--output="):
+            return arg[len("--output=") :]
+    return None
+
+
+def is_hip_compile(args: list[str]) -> bool:
+    """True only for a HIP/CUDA object compile (``-c`` plus offload markers)."""
+    if "-c" not in args:
+        return False
+    for i, arg in enumerate(args):
+        if arg.startswith(_HIP_ARCH_PREFIXES):
+            return True
+        if arg == "-x" and i + 1 < len(args) and args[i + 1] in ("hip", "cuda"):
+            return True
+        if arg.endswith(_HIP_INPUT_SUFFIXES):
+            return True
+    return False
+
+
+def has_explicit_cuid(args: list[str]) -> bool:
+    return any(arg == "-cuid" or arg.startswith("-cuid=") for arg in args)
+
+
+def stable_cuid(out: str) -> str:
+    """Deterministic, machine-independent id derived from the output path.
+
+    Relativized against the CWD so cold/warm builds on different machines (but
+    the same build layout) compute the same value -- preserving warm cache hits.
+    """
+    try:
+        rel = os.path.relpath(out, os.getcwd())
+    except ValueError:
+        rel = out
+    rel = rel.replace(os.sep, "/")
+    return hashlib.md5(rel.encode("utf-8")).hexdigest()[:16]
+
+
+def build_command(argv: list[str]) -> list[str]:
+    compiler, args = argv[1], argv[2:]
+
+    extra: list[str] = []
+    if is_hip_compile(args) and not has_explicit_cuid(args):
+        out = output_path(args)
+        if out:
+            cuid = stable_cuid(out)
+            extra = [f"-cuid={cuid}"]
+            log = os.environ.get("THEROCK_CUID_LOG")
+            if log:
+                try:
+                    with open(log, "a") as f:
+                        f.write(f"{cuid}\t{out}\n")
+                except OSError:
+                    pass
+
+    sccache = find_sccache()
+    prefix = [sccache] if sccache else []
+    return prefix + [compiler] + args + extra
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: cuid_launcher.py <compiler> <args...>", file=sys.stderr)
+        return 2
+    cmd = build_command(argv)
+    os.execvp(cmd[0], cmd)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/build_tools/setup_sccache_rocm.py
+++ b/build_tools/setup_sccache_rocm.py
@@ -100,6 +100,11 @@ def sccache_build_env(sccache_path: Path, hip_launcher: bool = True) -> dict[str
     return env
 
 
+def cuid_launcher_path() -> Path:
+    """Absolute path to the per-TU ``-cuid`` injecting launcher (sibling script)."""
+    return Path(__file__).parent.resolve() / "cuid_launcher.py"
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Locate sccache and print the env to configure a ROCm HIP build."
@@ -118,10 +123,20 @@ def main():
         "--gha",
         action="store_true",
         help=(
-            "Write HIP_CLANG_LAUNCHER to $GITHUB_ENV for use in subsequent steps. "
-            "CMAKE_C/CXX_COMPILER_LAUNCHER are intentionally excluded — setting them "
-            "globally breaks stages that use custom compiler wrappers (e.g. profiler-apps). "
-            "Those launchers are passed via cmake -D args in the Configure step instead."
+            "Write HIP_CLANG_LAUNCHER (+ THEROCK_SCCACHE) to $GITHUB_ENV for use in "
+            "subsequent steps. CMAKE_C/CXX_COMPILER_LAUNCHER are intentionally excluded "
+            "— setting them globally breaks stages that use custom compiler wrappers "
+            "(e.g. profiler-apps). Those launchers are passed via cmake -D args in the "
+            "Configure step instead."
+        ),
+    )
+    parser.add_argument(
+        "--no-cuid-launcher",
+        action="store_true",
+        help=(
+            "Point HIP_CLANG_LAUNCHER straight at sccache instead of the cuid_launcher.py "
+            "wrapper. The wrapper injects a per-TU -cuid so RDC objects don't collide on "
+            "__hip_cuid_ under caching (ROCm/TheRock#748); use this to opt out."
         ),
     )
     args = parser.parse_args()
@@ -151,13 +166,24 @@ def main():
 
     env = sccache_build_env(sccache_path, hip_launcher=not args.no_hip_launcher)
     if args.gha:
+        # Only HIP_CLANG_LAUNCHER (+ THEROCK_SCCACHE) is written to $GITHUB_ENV;
+        # see the --gha help for why the CMAKE launchers are excluded here.
+        gha_vars: dict[str, str] = {}
+        if "HIP_CLANG_LAUNCHER" in env:
+            if args.no_cuid_launcher:
+                gha_vars["HIP_CLANG_LAUNCHER"] = str(sccache_path)
+            else:
+                # Route hipcc's device compiles through the cuid launcher, which
+                # injects a per-TU -cuid ahead of sccache (ROCm/TheRock#748). The
+                # wrapper locates the real sccache via THEROCK_SCCACHE.
+                gha_vars["THEROCK_SCCACHE"] = str(sccache_path)
+                gha_vars["HIP_CLANG_LAUNCHER"] = str(cuid_launcher_path())
         github_env = Path(os.environ["GITHUB_ENV"])
         with github_env.open("a") as f:
-            for key, value in env.items():
-                if key == "HIP_CLANG_LAUNCHER":
-                    f.write(f"{key}={value}\n")
-        if "HIP_CLANG_LAUNCHER" in env:
-            print(f"Wrote HIP_CLANG_LAUNCHER={env['HIP_CLANG_LAUNCHER']} to $GITHUB_ENV")
+            for key, value in gha_vars.items():
+                f.write(f"{key}={value}\n")
+        for key, value in gha_vars.items():
+            print(f"Wrote {key}={value} to $GITHUB_ENV")
     else:
         print("Configure a ROCm build with:")
         for key, value in env.items():

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1674,8 +1674,25 @@ function(_therock_cmake_subproject_setup_toolchain
   string(APPEND _toolchain_contents "set(CMAKE_C_COMPILER \"@CMAKE_C_COMPILER@\")\n")
   string(APPEND _toolchain_contents "set(CMAKE_CXX_COMPILER \"@CMAKE_CXX_COMPILER@\")\n")
   string(APPEND _toolchain_contents "set(CMAKE_LINKER \"@CMAKE_LINKER@\")\n")
-  string(APPEND _toolchain_contents "set(CMAKE_C_COMPILER_LAUNCHER \"@CMAKE_C_COMPILER_LAUNCHER@\")\n")
-  string(APPEND _toolchain_contents "set(CMAKE_CXX_COMPILER_LAUNCHER \"@CMAKE_CXX_COMPILER_LAUNCHER@\")\n")
+  # Some subprojects drive the compiler through their own wrapper and break when
+  # a compiler launcher is inserted in front of it:
+  #   rocprofiler-systems-examples: uses rocprof-sys-launch-compiler, which loses
+  #     the HIP flags (e.g. --hip-path) when wrapped -> "hip/hip_runtime.h not found".
+  #   hip-tests: emits multi-arch bundles with multiple outputs per invocation.
+  # Drop the launcher for those (they build without caching). This mirrors the
+  # HIP_CLANG_LAUNCHER blocklist below.
+  get_target_property(_logical_name "${target_name}" THEROCK_LOGICAL_TARGET_NAME)
+  if(NOT _logical_name)
+    set(_logical_name "${target_name}")
+  endif()
+  set(_compiler_launcher_blocklist "rocprofiler-systems-examples" "hip-tests")
+  if(_logical_name IN_LIST _compiler_launcher_blocklist)
+    string(APPEND _toolchain_contents "set(CMAKE_C_COMPILER_LAUNCHER \"\")\n")
+    string(APPEND _toolchain_contents "set(CMAKE_CXX_COMPILER_LAUNCHER \"\")\n")
+  else()
+    string(APPEND _toolchain_contents "set(CMAKE_C_COMPILER_LAUNCHER \"@CMAKE_C_COMPILER_LAUNCHER@\")\n")
+    string(APPEND _toolchain_contents "set(CMAKE_CXX_COMPILER_LAUNCHER \"@CMAKE_CXX_COMPILER_LAUNCHER@\")\n")
+  endif()
   string(APPEND _toolchain_contents "set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT \"@CMAKE_MSVC_DEBUG_INFORMATION_FORMAT@\")\n")
   if(MSVC AND compiler_toolchain)
     # The system compiler and the toolchain compiler are incompatible, so we

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -1767,10 +1767,14 @@ function(_therock_cmake_subproject_setup_toolchain
     # to C:\{GUID}\ and clang resolves its binary path through the mount when
     # computing the resource dir. This embeds the GUID in include paths, which
     # defeats ccache. Passing -resource-dir with the unresolved path avoids this.
+    # Use the joined form (-resource-dir=<dir>) rather than the space-separated
+    # form: sccache's clang parser does not consume a space-separated
+    # -resource-dir value and miscounts it as a second input file, marking every
+    # such compile "non-cacheable: multiple input files" (ROCm/TheRock#5901).
     string(APPEND _toolchain_contents "file(GLOB _therock_clang_resource_dirs \"@_amd_llvm_dist_dir@/lib/llvm/lib/clang/*\")\n")
     string(APPEND _toolchain_contents "list(GET _therock_clang_resource_dirs 0 _therock_clang_resource_dir)\n")
-    string(APPEND _toolchain_contents "string(APPEND CMAKE_C_FLAGS_INIT \" -resource-dir \${_therock_clang_resource_dir}\")\n")
-    string(APPEND _toolchain_contents "string(APPEND CMAKE_CXX_FLAGS_INIT \" -resource-dir \${_therock_clang_resource_dir}\")\n")
+    string(APPEND _toolchain_contents "string(APPEND CMAKE_C_FLAGS_INIT \" -resource-dir=\${_therock_clang_resource_dir}\")\n")
+    string(APPEND _toolchain_contents "string(APPEND CMAKE_CXX_FLAGS_INIT \" -resource-dir=\${_therock_clang_resource_dir}\")\n")
     string(APPEND _toolchain_contents "string(APPEND CMAKE_CXX_FLAGS_INIT \" ${_amd_llvm_cxx_flags_spaces}\")\n")
 
     therock_sanitizer_configure(


### PR DESCRIPTION
Stacked on #5901 (base = its branch, since this depends on sccache being enabled for math-libs). Fixes #748.

## Problem
With sccache caching math-libs HIP compiles, RDC objects that differ only in `-o` collapse to one cache key (sccache excludes `-o` from the key). A false cache hit then hands two translation units the **same** `__hip_cuid_`, so the link fails:

```
ld.lld: error: duplicate symbol: __hip_cuid_be24e852bec7eff2
>>> defined at map_block_to_matrix_override_m_256_u8.cpp   (map_util_test.dir/...)
>>> defined at map_block_to_matrix_override_m_256_u8.cpp   (a differently-named .o)
```

(rocWMMA `contamination_test` / `map_util_test`.)

## Fix
| File | Change |
|---|---|
| `build_tools/cuid_launcher.py` | New launcher: injects a deterministic per-output `-cuid` for HIP compiles, then execs sccache → distinct cache key per TU, distinct symbol, warm-cache hits preserved. HIP-gated; respects any existing `-cuid`. |
| `build_tools/setup_sccache_rocm.py` | `--gha` points `HIP_CLANG_LAUNCHER` at the wrapper and exports `THEROCK_SCCACHE` (`--no-cuid-launcher` opts out). |
| `multi_arch_build_portable_linux_artifacts.yml` | Routes the CMake launcher through the wrapper. |
| `cmake/therock_subproject.cmake` | Prerequisite: joined `-resource-dir=<dir>` so these compiles are cacheable at all (space form is rejected as "multiple input files"). |

## Validation (gfx94x, sccache, cold → warm)
| | Cold | Warm |
|---|---|---|
| math-libs (rocWMMA) | ✅ success | ✅ success |
| `__hip_cuid_` duplicates | 0 | 0 |
| HIP cache hit-rate | 0.02% (keys changed) | **99.12%** |
| C/C++ hit-rate | 99.75% | 100% |
| Non-cacheable compilations | 0 | 0 |

The 99.12% warm HIP hit-rate confirms the `-cuid` is stable across runs (caching works) while the collision is gone. Post-0.14 sccache has no CUID awareness (checked 0.15/0.16 source), so a version bump alone cannot fix this.

Note: `debug-tools` and `profiler-apps` still fail on that pipeline — both are pre-existing issues unrelated to this change (rocgdb/libiberty C99; the examples' known sccache incompatibility).