### PR TITLE
test(pytorch): skip gfx1103 grouped/depthwise conv + RNN dropout tests

### DIFF
--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -8,6 +8,36 @@ skip_tests = {
             "test_autocast_torch_fp16",
         }
     },
+    "gfx1103": {
+        "nn": [
+            # gfx1103 (Radeon 780M) is not supported by Composable Kernel, so
+            # MIOpen deliberately excludes it from the CK grouped-conv solvers
+            # (ROCm/rocm-libraries#6805 dropped gfx1103 from _CK_SUPPORTED_ARCHS,
+            # so libMIOpenCKGroupedConv_gfx1103.so is never built). With CK out,
+            # gfx1103 has no working grouped/depthwise conv solver:
+            #   MIOpen(HIP): Warning [OpenRuntimeLibraryForDevice] CK grouped conv
+            #     library not found for device gfx1103: libMIOpenCKGroupedConv_gfx1103.so
+            #   [EvaluateInvokers] Invalid elapsed time detected ... elapsed <= 0
+            #   No suitable algorithm was found to execute the required convolution
+            # Tracked in ROCm/TheRock#6252.
+            "test_Conv1d_circular_stride2_pad2_cuda",
+            "test_Conv1d_dilated_cuda",
+            "test_Conv1d_groups",
+            "test_Conv1d_pad1size1",
+            "test_Conv1d_pad_same_dilated",
+            "test_Conv1d_pad_same_dilated_cuda",
+            "test_Conv1d_reflect_stride2_pad2_cuda",
+            "test_Conv1d_zeros_stride2_pad2_cuda",
+            "test_Conv2d_depthwise_cuda",
+            "test_Conv2d_depthwise_strided_cuda",
+            "test_Conv2d_strided_cuda",
+            "test_ConvTranspose1d_groups_cuda",
+            # Same root cause, but this one hangs the GPU rather than failing:
+            #   HW Exception by GPU node-1 ... reason: GPU Hang
+            #   Fatal Python error: Aborted (exit code 134)
+            "test_RNN_dropout",
+        ],
+    },
     "common": {
         "autograd": [
             # Stream comparison mismatch on ROCm (non-default stream vs default stream)

--- a/external-builds/pytorch/skip_tests/test_skip_tests.py
+++ b/external-builds/pytorch/skip_tests/test_skip_tests.py
@@ -31,6 +31,14 @@ def _load_skip_tests(path):
     return getattr(module, "skip_tests", None)
 
 
+def _load_create_skip_tests():
+    path = SKIP_DIR / "create_skip_tests.py"
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_skip_files_define_skip_tests_dict():
     files = _skip_list_files()
     assert files, "expected at least one skip-list file"
@@ -63,7 +71,32 @@ def test_skip_tests_entries_are_well_formed():
                     ), f"{path.name}:{section}.{module_name} bad entry {name!r}"
 
 
+def test_gfx1103_skips_apply_only_to_gfx1103():
+    """Arch-scoped sections must not leak into sibling archs.
+
+    The ``gfx1103`` section skips grouped/depthwise conv + RNN tests that only
+    fail on that arch. ``create_list`` matches a section against a family via
+    substring (``section in family``), so a section key that is a prefix of
+    another arch could over-match. Guard that gfx1103's skips are selected for
+    gfx1103 yet stay out of the other gfx110X archs and unrelated arches.
+    """
+    generic = _load_skip_tests(SKIP_DIR / "generic.py")
+    gfx1103_tests = set(generic["gfx1103"]["nn"])
+    assert gfx1103_tests, "expected gfx1103 skip entries in generic.py"
+
+    create_list = _load_create_skip_tests().create_list
+
+    selected = set(create_list(amdgpu_family=["gfx1103"]))
+    assert gfx1103_tests <= selected, "gfx1103 skips must apply to gfx1103"
+
+    for other in ("gfx1100", "gfx1101", "gfx1102", "gfx942"):
+        selected_other = set(create_list(amdgpu_family=[other]))
+        leaked = gfx1103_tests & selected_other
+        assert not leaked, f"gfx1103 skips leaked into {other}: {sorted(leaked)}"
+
+
 if __name__ == "__main__":
     test_skip_files_define_skip_tests_dict()
     test_skip_tests_entries_are_well_formed()
+    test_gfx1103_skips_apply_only_to_gfx1103()
     print("All skip-test sanity checks passed.")


### PR DESCRIPTION
## Summary

Linux `gfx110X-all` PyTorch CI fails on gfx1103 (Radeon 780M) with 12 conv test failures and a GPU-hang crash in `test_RNN_dropout` (exit 134). See ROCm/TheRock#6252.

**Root cause (not a packaging bug):** gfx1103 is not supported by Composable Kernel. ROCm/rocm-libraries#6805 intentionally dropped gfx1103 from `_CK_SUPPORTED_ARCHS`, so `libMIOpenCKGroupedConv_gfx1103.so` is never built. The runtime CK whitelist and dlopen loader also self-disable on gfx1103. Once CK is out, gfx1103 has no working grouped/depthwise conv solver:

```
MIOpen(HIP): Warning [OpenRuntimeLibraryForDevice] CK grouped conv library not found
  for device gfx1103: libMIOpenCKGroupedConv_gfx1103.so: cannot open shared object file
[EvaluateInvokers] Invalid elapsed time detected ... elapsed <= 0
No suitable algorithm was found to execute the required convolution
```

This PR mirrors the gfx1103 exclusion that #6805 applied to the MIOpen gtest suites, adding a `gfx1103`-scoped skip section to the PyTorch test list. The key (`gfx1103`) matches only the detected arch, so gfx1100/1101/1102 in the `gfx110X-all` family are unaffected.

## Tests skipped (gfx1103 only)

- `test_Conv1d_circular_stride2_pad2_cuda`
- `test_Conv1d_dilated_cuda`
- `test_Conv1d_groups`
- `test_Conv1d_pad1size1`
- `test_Conv1d_pad_same_dilated`
- `test_Conv1d_pad_same_dilated_cuda`
- `test_Conv1d_reflect_stride2_pad2_cuda`
- `test_Conv1d_zeros_stride2_pad2_cuda`
- `test_Conv2d_depthwise_cuda`
- `test_Conv2d_depthwise_strided_cuda`
- `test_Conv2d_strided_cuda`
- `test_ConvTranspose1d_groups_cuda`
- `test_RNN_dropout` (GPU hang -> `Fatal Python error: Aborted`, exit 134)

## Follow-up

The underlying MIOpen gap (no non-CK grouped/depthwise fallback on gfx1103, plus the GPU hang instead of a graceful failure) should be tracked separately against MIOpen / ROCm/rocm-libraries.

Fixes ROCm/TheRock#6252
