### PR TITLE
ci: warn (not silently skip) when sccache is unusable

### DIFF
--- a/build_tools/setup_sccache_rocm.py
+++ b/build_tools/setup_sccache_rocm.py
@@ -105,6 +105,47 @@ def cuid_launcher_path() -> Path:
     return Path(__file__).parent.resolve() / "cuid_launcher.py"
 
 
+def resolve_sccache(explicit_path: Path | None, gha: bool) -> Path | None:
+    """Locate and validate a usable sccache binary.
+
+    A missing or non-functional sccache is a config problem that would otherwise
+    silently degrade the build to "no cache". Under ``--gha`` we surface it as a
+    GitHub Actions ``::warning::`` (visible in the run summary) and return None so
+    the build proceeds uncached; locally it is a hard error so the developer
+    notices immediately. Flip the ``::warning::`` to ``::error::`` + a non-zero
+    exit if a broken cache config should fail CI instead.
+    """
+
+    def _unusable(message: str) -> None:
+        if gha:
+            print(
+                f"::warning::sccache unusable: {message}. "
+                "Building WITHOUT compiler cache."
+            )
+            return None
+        raise RuntimeError(message)
+
+    if explicit_path is not None:
+        if not explicit_path.exists():
+            return _unusable(f"specified path not found: {explicit_path}")
+        sccache_path = explicit_path
+    else:
+        sccache_path = find_sccache()
+        if not sccache_path:
+            return _unusable(
+                "not found (install: https://github.com/mozilla/sccache#installation; "
+                "for CI it ships in the manylinux build image)"
+            )
+
+    try:
+        subprocess.run(
+            [str(sccache_path), "--version"], capture_output=True, text=True, check=True
+        )
+    except (subprocess.CalledProcessError, OSError) as e:
+        return _unusable(f"{sccache_path} failed `--version`: {e}")
+    return sccache_path
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Locate sccache and print the env to configure a ROCm HIP build."
@@ -141,28 +182,11 @@ def main():
     )
     args = parser.parse_args()
 
-    if args.sccache_path:
-        sccache_path = args.sccache_path
-        if not sccache_path.exists():
-            raise RuntimeError(f"Specified sccache not found: {sccache_path}")
-    else:
-        sccache_path = find_sccache()
-        if not sccache_path:
-            raise RuntimeError(
-                "sccache not found.\n"
-                "Install: https://github.com/mozilla/sccache#installation\n"
-                "For CI, sccache is pre-installed in the manylinux build image:\n"
-                "  https://github.com/ROCm/TheRock/tree/main/dockerfiles"
-            )
-
+    sccache_path = resolve_sccache(args.sccache_path, args.gha)
+    if sccache_path is None:
+        # --gha already emitted a ::warning::; proceed without configuring a cache.
+        return
     print(f"Using sccache: {sccache_path}")
-    try:
-        result = subprocess.run(
-            [str(sccache_path), "--version"], capture_output=True, text=True, check=True
-        )
-        print(f"sccache version: {result.stdout.strip()}")
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"sccache verification failed: {e}") from e
 
     env = sccache_build_env(sccache_path, hip_launcher=not args.no_hip_launcher)
     if args.gha:

--- a/build_tools/tests/setup_sccache_rocm_test.py
+++ b/build_tools/tests/setup_sccache_rocm_test.py
@@ -1,0 +1,63 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for build_tools/setup_sccache_rocm.py (sccache resolution)."""
+
+import os
+from pathlib import Path
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+import setup_sccache_rocm as s
+
+
+def _printed(p) -> str:
+    return " ".join(str(c) for c in p.call_args_list)
+
+
+class ResolveSccacheTest(unittest.TestCase):
+    def test_not_found_under_gha_warns_and_returns_none(self):
+        with mock.patch.object(s, "find_sccache", return_value=None):
+            with mock.patch("builtins.print") as p:
+                self.assertIsNone(s.resolve_sccache(None, gha=True))
+        self.assertIn("::warning::", _printed(p))
+
+    def test_not_found_locally_raises(self):
+        with mock.patch.object(s, "find_sccache", return_value=None):
+            with self.assertRaises(RuntimeError):
+                s.resolve_sccache(None, gha=False)
+
+    def test_explicit_missing_under_gha_warns(self):
+        with mock.patch("builtins.print") as p:
+            self.assertIsNone(s.resolve_sccache(Path("/nonexistent/sccache"), gha=True))
+        self.assertIn("::warning::", _printed(p))
+
+    def test_explicit_missing_locally_raises(self):
+        with self.assertRaises(RuntimeError):
+            s.resolve_sccache(Path("/nonexistent/sccache"), gha=False)
+
+    def test_valid_path_is_returned(self):
+        real = Path(sys.executable)  # a path that exists
+        with mock.patch.object(s.subprocess, "run") as run:
+            self.assertEqual(s.resolve_sccache(real, gha=True), real)
+            run.assert_called_once()  # validated via --version
+
+    def test_version_failure_under_gha_warns(self):
+        real = Path(sys.executable)
+        err = s.subprocess.CalledProcessError(1, "sccache --version")
+        with mock.patch.object(s.subprocess, "run", side_effect=err):
+            with mock.patch("builtins.print") as p:
+                self.assertIsNone(s.resolve_sccache(real, gha=True))
+        self.assertIn("::warning::", _printed(p))
+
+    def test_version_failure_locally_raises(self):
+        real = Path(sys.executable)
+        with mock.patch.object(s.subprocess, "run", side_effect=OSError("boom")):
+            with self.assertRaises(RuntimeError):
+                s.resolve_sccache(real, gha=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #6495 (base = its branch) — kept as **draft** until CI validates.

Makes a missing/broken sccache config **visible** instead of silently building uncached. `setup_sccache_rocm.py` now resolves + validates sccache in a `resolve_sccache()` helper, and under `--gha` emits a GitHub Actions `::warning::` (shown in the run summary) and proceeds **uncached**, rather than degrading with no signal. Locally it stays a hard error so the developer notices.

- **Non-breaking** by design (build stays green); one-line switch to `::error::` + non-zero exit if a broken cache config should fail CI instead.
- `THEROCK_SCCACHE` is only ever set by this step, so this is the right single chokepoint to validate (vs. a buried per-compile log).
- + unit tests: `resolve_sccache` across found / not-found / `--version`-failure × gha / local.

Follow-up experiment on top of #6495; fold in or land after once green.