### PR TITLE
ci: run quick PyTorch wheel test subset via run_test.py

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -118,7 +118,10 @@ jobs:
     runs-on: ${{ inputs.test_runs_on }}
     container:
       image: ${{ contains(inputs.test_runs_on, 'linux') && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26' || null }}
+      # SYS_PTRACE is required by PyTorch's test infra which uses gdb to
+      # collect stack traces on segfaults and hangs (torch/testing/_internal).
       options: --ipc host
+        --cap-add=SYS_PTRACE
         --group-add video
         --device /dev/kfd
         --device /dev/dri
@@ -129,9 +132,20 @@ jobs:
     defaults:
       run:
         shell: bash
+    # These env vars mirror the full test workflow so run_test.py behaves the
+    # same way here. run_pytorch_tests_full.py reads them via os.environ.
     env:
       VENV_DIR: ${{ github.workspace }}/.venv
       AMDGPU_FAMILY: ${{ inputs.amdgpu_family }}
+      CI: "1"
+      PYTORCH_TEST_WITH_ROCM: "1"
+      PYTORCH_TESTING_DEVICE_ONLY_FOR: "cuda"
+      # Pin OpenBLAS threads to 1 for deterministic reductions; without this,
+      # OpenBLAS defaults to the number of CPU cores, which causes
+      # non-deterministic results in tests like test_entropy_monte_carlo.
+      OPENBLAS_NUM_THREADS: "1"
+      PYTORCH_NUM_PYTEST_RERUNS: "2"
+      TEST_CONFIG: "default"
 
     steps:
       - name: Checkout
@@ -168,6 +182,8 @@ jobs:
 
       - name: Set git options
         run: |
+          git config --global --add safe.directory $PWD
+          git config fetch.parallel 10
           git config --global core.longpaths true
 
       # Here we checkout the same version of PyTorch that wheels were built from
@@ -200,20 +216,62 @@ jobs:
         run: |
           if [ "${{ inputs.multi_arch }}" = "true" ]; then
             python build_tools/setup_venv.py ${VENV_DIR} \
-              --packages "torch[${{ steps.expand.outputs.device_extras }}]==${{ inputs.torch_version }}" \
+              --packages "torch[${{ steps.expand.outputs.device_extras }}]==${{ inputs.torch_version }} rocm[devel,${{ steps.expand.outputs.device_extras }}]" \
               --index-url=${{ inputs.package_index_url }} \
               --activate-in-future-github-actions-steps
           else
             python build_tools/setup_venv.py ${VENV_DIR} \
-              --packages torch==${{ inputs.torch_version }} \
+              --packages "torch==${{ inputs.torch_version }} rocm[devel]" \
               --index-url=${{ inputs.package_index_url }} \
               --index-subdir=${{ inputs.amdgpu_family }} \
               --activate-in-future-github-actions-steps
           fi
 
+      - name: Initialize ROCm SDK and configure environment
+        run: |
+          rocm-sdk init
+
+          ROCM_HOME="$(rocm-sdk path --root)"
+          ROCM_BIN="$(rocm-sdk path --bin)"
+          ROCM_CMAKE_PREFIX="$(rocm-sdk path --cmake)"
+
+          echo "ROCM_HOME=${ROCM_HOME}"
+          echo "ROCM_BIN=${ROCM_BIN}"
+          echo "ROCM_CMAKE_PREFIX=${ROCM_CMAKE_PREFIX}"
+
+          ROCM_SYSDEPS="${ROCM_HOME}/lib/rocm_sysdeps"
+          ROCM_SYSDEPS_INCLUDE="${ROCM_SYSDEPS}/include"
+          ROCM_SYSDEPS_PKGCONFIG="${ROCM_SYSDEPS}/lib/pkgconfig"
+
+          # Add ROCm bin to PATH for all subsequent steps
+          echo "${ROCM_BIN}" >> "${GITHUB_PATH}"
+
+          # Persist ROCm env vars across workflow steps (mirrors install_rocm.sh)
+          echo "ROCM_PATH=${ROCM_HOME}" >> "${GITHUB_ENV}"
+          echo "ROCM_HOME=${ROCM_HOME}" >> "${GITHUB_ENV}"
+          echo "ROCM_SOURCE_DIR=${ROCM_HOME}" >> "${GITHUB_ENV}"
+          echo "ROCM_BIN=${ROCM_BIN}" >> "${GITHUB_ENV}"
+          echo "ROCM_CMAKE=${ROCM_CMAKE_PREFIX}" >> "${GITHUB_ENV}"
+          echo "CMAKE_PREFIX_PATH=${ROCM_CMAKE_PREFIX}:${CMAKE_PREFIX_PATH:-}" >> "${GITHUB_ENV}"
+          echo "HIP_DEVICE_LIB_PATH=${ROCM_HOME}/lib/llvm/amdgcn/bitcode" >> "${GITHUB_ENV}"
+          echo "ROCM_DEVICE_LIB_PATH=${ROCM_HOME}/lib/llvm/amdgcn/bitcode" >> "${GITHUB_ENV}"
+          echo "ROCM_SYSDEPS_INCLUDE=${ROCM_SYSDEPS_INCLUDE}" >> "${GITHUB_ENV}"
+          echo "CPLUS_INCLUDE_PATH=${ROCM_SYSDEPS_INCLUDE}:${CPLUS_INCLUDE_PATH:-}" >> "${GITHUB_ENV}"
+          echo "C_INCLUDE_PATH=${ROCM_SYSDEPS_INCLUDE}:${C_INCLUDE_PATH:-}" >> "${GITHUB_ENV}"
+          echo "PKG_CONFIG_PATH=${ROCM_SYSDEPS_PKGCONFIG}:${PKG_CONFIG_PATH:-}" >> "${GITHUB_ENV}"
+          echo "LD_LIBRARY_PATH=${ROCM_HOME}/lib/host-math/lib:${ROCM_SYSDEPS}/lib:${LD_LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
+          echo "LIBRARY_PATH=${ROCM_HOME}/lib/host-math/lib:${ROCM_SYSDEPS}/lib:${LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
+          echo "USE_MSLK=0" >> "${GITHUB_ENV}"
+
+          # Use ROCm's clang for JIT C++ compilation (torch.utils.cpp_extension)
+          # instead of requiring gcc/build-essential.
+          echo "CC=${ROCM_HOME}/lib/llvm/bin/clang" >> "${GITHUB_ENV}"
+          echo "CXX=${ROCM_HOME}/lib/llvm/bin/clang++" >> "${GITHUB_ENV}"
+
       - name: Install test requirements
         run: |
           python -m pip install -r external-builds/pytorch/requirements-test.txt
+          python -m pip install -r external-builds/pytorch/pytorch/.ci/docker/requirements-ci.txt
           pip freeze
 
       - name: Run rocm-sdk sanity tests
@@ -228,13 +286,34 @@ jobs:
             --log-cli-level=INFO \
             -v
 
+      # Run the same subset of unit tests that this workflow has always run, but
+      # through PyTorch's run_test.py (via run_pytorch_tests_full.py) instead of
+      # invoking pytest directly. This reuses the full test workflow's runner so
+      # behavior (skip-list integration, serial execution, GPU selection) stays
+      # consistent between the quick and full suites. The --include list is the
+      # subset previously hard-coded in run_pytorch_tests.py.
       - name: Run PyTorch tests
         timeout-minutes: 120
         run: |
-          python ./external-builds/pytorch/run_pytorch_tests.py \
+          python ./external-builds/pytorch/run_pytorch_tests_full.py \
+            --test-config default \
             --device-query "${{ inputs.device_query }}" \
             --gpu-policy "${{ inputs.gpu_policy }}" \
+            --include \
+              test_nn \
+              test_torch \
+              test_cuda \
+              test_unary_ufuncs \
+              test_binary_ufuncs \
+              test_autograd \
             -- \
-            --continue-on-collection-errors \
-            --import-mode=importlib \
-            -v
+            --continue-on-collection-errors
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-reports-${{ inputs.amdgpu_family }}
+          path: external-builds/pytorch/pytorch/test/test-reports/
+          if-no-files-found: ignore
+          retention-days: 30


### PR DESCRIPTION
ISSUE ID: #3291

## What

Switch the quick/per-PR **Test PyTorch Wheels** workflow (`test_pytorch_wheels.yml`) to run its unit tests through PyTorch's `run_test.py` — via the full suite's runner `run_pytorch_tests_full.py` — instead of invoking pytest directly through `run_pytorch_tests.py`.

The **same subset** of unit-test modules is preserved via `--include`: `test_nn`, `test_torch`, `test_cuda`, `test_unary_ufuncs`, `test_binary_ufuncs`, `test_autograd` (the list previously hard-coded in `run_pytorch_tests.py`).

This reuses the full suite's harness so the quick and full suites behave consistently (skip-list integration, serial execution, GPU selection, the `os._exit` hang-workaround).

## How

Brought over the supporting setup from the full workflow so `run_test.py` behaves the same:
- `--cap-add=SYS_PTRACE` on the container
- ROCm test env vars (`CI`, `PYTORCH_TEST_WITH_ROCM`, `PYTORCH_TESTING_DEVICE_ONLY_FOR`, `OPENBLAS_NUM_THREADS`, `PYTORCH_NUM_PYTEST_RERUNS`, `TEST_CONFIG=default`)
- `git safe.directory`
- `rocm[devel]` in the venv + `rocm-sdk init` env setup
- `requirements-ci.txt` install
- test-report artifact upload

## Test

Dispatched the modified workflow on this branch (gfx94X-dcgpu, torch `2.9.1+rocm7.15.0a20260712`, `release/2.9`, py3.12, multi-arch index `https://rocm.nightlies.amd.com/whl-multi-arch/` with `device-gfx942` extras):

- https://github.com/ROCm/TheRock/actions/runs/29349160266
