### PR TITLE
fix(emulation): package runnable rocjitsu payload

### DIFF
--- a/emulation/artifact-rocjitsu.toml
+++ b/emulation/artifact-rocjitsu.toml
@@ -3,10 +3,13 @@
 default_patterns = false
 include = [
   "lib/librocjitsu.so",
+  "lib/librocjitsu_hooks.so",
+  "lib/librocjitsu_kmd.so",
 ]
 [components.dbg."emulation/rocjitsu/stage"]
 [components.dev."emulation/rocjitsu/stage"]
 [components.run."emulation/rocjitsu/stage"]
 include = [
+  "bin/rocjitsu",
   "share/rocjitsu/**",
 ]


### PR DESCRIPTION
## Motivation

`install_rocm_from_artifacts.py --rocjitsu` already fetches the rocjitsu run and lib artifacts, but the current artifact contents are not enough to launch the installed `rocjitsu` CLI from artifacts.

## Summary

- include `bin/rocjitsu` in the rocjitsu run artifact
- include `librocjitsu_hooks.so` and `librocjitsu_kmd.so` in the rocjitsu lib artifact
- keep configs and schemas in the run artifact via the existing `share/rocjitsu/**` entry

## Local validation

- Ran the artifact descriptor overlap unit test: `python3 -m unittest build_tools.tests.artifact_descriptor_overlap_test`
- Ran `git diff --check` on the changed descriptor.
- Ran `build_tools/fileset_tool.py artifact` against a temporary synthetic rocjitsu install tree and confirmed the descriptor routes:
  - `lib/librocjitsu*.so` to the `lib` artifact
  - `bin/rocjitsu` and `share/rocjitsu/**` to the `run` artifact
  - `include/rocjitsu/**` to the `dev` artifact
