### PR TITLE
fix(emulation): package rocjitsu hooks and CLI test payload

### DIFF
--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -39,6 +39,7 @@ if(THEROCK_ENABLE_ROCJITSU)
   therock_test_validate_shared_lib(PATH rocjitsu/dist/lib
     LIB_NAMES
       librocjitsu.so
+      librocjitsu_hooks.so
   )
 
   therock_provide_artifact(rocjitsu

--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -50,6 +50,7 @@ if(THEROCK_ENABLE_ROCJITSU)
       dev
       lib
       run
+      test
     SUBPROJECT_DEPS
       rocjitsu
   )

--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -54,6 +54,7 @@ if(THEROCK_ENABLE_ROCJITSU)
       dev
       lib
       run
+      test
     SUBPROJECT_DEPS
       rocjitsu
   )

--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -39,6 +39,7 @@ if(THEROCK_ENABLE_ROCJITSU)
   therock_test_validate_shared_lib(PATH rocjitsu/dist/lib
     LIB_NAMES
       librocjitsu.so
+      librocjitsu_hooks.so
   )
   therock_test_validate_shared_lib(PATH rocjitsu/dist/lib
     LIB_NAMES

--- a/emulation/artifact-rocjitsu.toml
+++ b/emulation/artifact-rocjitsu.toml
@@ -1,10 +1,5 @@
 # rocjitsu
 [components.lib."emulation/rocjitsu/stage"]
-default_patterns = false
-include = [
-  "lib/librocjitsu.so",
-  "lib/librocjitsu_hooks.so",
-]
 [components.dbg."emulation/rocjitsu/stage"]
 [components.dev."emulation/rocjitsu/stage"]
 [components.run."emulation/rocjitsu/stage"]

--- a/emulation/artifact-rocjitsu.toml
+++ b/emulation/artifact-rocjitsu.toml
@@ -4,6 +4,5 @@
 [components.dev."emulation/rocjitsu/stage"]
 [components.run."emulation/rocjitsu/stage"]
 include = [
-  "bin/rocjitsu",
   "share/rocjitsu/**",
 ]

--- a/emulation/artifact-rocjitsu.toml
+++ b/emulation/artifact-rocjitsu.toml
@@ -6,3 +6,7 @@
 include = [
   "share/rocjitsu/**",
 ]
+[components.test."emulation/rocjitsu/stage"]
+include = [
+  "bin/rocjitsu",
+]

--- a/emulation/artifact-rocjitsu.toml
+++ b/emulation/artifact-rocjitsu.toml
@@ -4,7 +4,6 @@ default_patterns = false
 include = [
   "lib/librocjitsu.so",
   "lib/librocjitsu_hooks.so",
-  "lib/librocjitsu_kmd.so",
 ]
 [components.dbg."emulation/rocjitsu/stage"]
 [components.dev."emulation/rocjitsu/stage"]

--- a/emulation/artifact-rocjitsu.toml
+++ b/emulation/artifact-rocjitsu.toml
@@ -3,10 +3,13 @@
 default_patterns = false
 include = [
   "lib/librocjitsu.so",
+  "lib/librocjitsu_hooks.so",
+  "lib/librocjitsu_kmd.so",
 ]
 [components.dbg."emulation/rocjitsu/stage"]
 [components.dev."emulation/rocjitsu/stage"]
 [components.run."emulation/rocjitsu/stage"]
 include = [
+  "bin/rocjitsu",
   "share/rocjitsu/**",
 ]

--- a/emulation/artifact-rocjitsu.toml
+++ b/emulation/artifact-rocjitsu.toml
@@ -1,5 +1,10 @@
 # rocjitsu
 [components.lib."emulation/rocjitsu/stage"]
+default_patterns = false
+include = [
+  "lib/librocjitsu.so",
+  "lib/librocjitsu_hooks.so",
+]
 [components.dbg."emulation/rocjitsu/stage"]
 [components.dev."emulation/rocjitsu/stage"]
 [components.run."emulation/rocjitsu/stage"]


### PR DESCRIPTION
## Motivation

The rocjitsu build installs its runtime library, instrumentation hook, CLI, configs, and schemas, but the artifact descriptor did not package all of that test tooling.

This change makes the installed rocjitsu CLI available to CI and development workflows that fetch rocjitsu test artifacts.

## Summary

- include `librocjitsu_hooks.so` alongside `librocjitsu.so` in the `lib` artifact
- validate `librocjitsu_hooks.so` as an installed shared library
- add a `test` component containing `bin/rocjitsu`
- keep configs and schemas in the `run` artifact through `share/rocjitsu/**`

The CLI is available when rocjitsu test artifacts are fetched, for example with:

```shell
install_rocm_from_artifacts.py --rocjitsu --tests
```

## Local validation

- Ran the artifact descriptor overlap unit test: `python3 -m unittest build_tools.tests.artifact_descriptor_overlap_test`
- Ran `git diff --check` on the changed descriptor.
- Ran `build_tools/fileset_tool.py artifact` against a temporary synthetic rocjitsu install tree and confirmed the descriptor routes:
  - `lib/librocjitsu.so` and `lib/librocjitsu_hooks.so` to the `lib` artifact
  - `bin/rocjitsu` to the `test` artifact
  - `share/rocjitsu/**` to the `run` artifact
  - `include/rocjitsu/**` to the `dev` artifact

JIRA ID : AIHPBLAS-3605
https://amd-hub.atlassian.net/browse/AIHPBLAS-3605
