### PR TITLE
Skip devel-requiring PyTorch tests when rocm[devel] is absent

### DIFF
--- a/external-builds/pytorch/skip_tests/README.md
+++ b/external-builds/pytorch/skip_tests/README.md
@@ -56,6 +56,33 @@ skip_tests = {
 The PyTorch test modules are `nn`, `cuda`, `unary_ufuncs` etc.
 This ordering is mainly added for easier debugging as otherwise it is difficult to determine which test module contains a given tests like `test_host_memory_stats` belongs to.
 
+### The `requires_devel` section
+
+A special top-level section, `requires_devel`, lists tests that need the ROCm SDK
+development package (`rocm[devel]`, i.e. the `rocm_sdk_devel` wheel). These tests
+JIT-compile C++/HIP extensions via `torch.utils.cpp_extension`, which needs the
+ROCm headers (e.g. `hipblas/hipblas.h`) and compiler that ship only in the devel
+package. Without it they fail with errors like
+`RuntimeError: Error building extension 'dummy_allocator'` or
+`fatal error: hipblas/hipblas.h: No such file or directory`.
+
+Unlike `common`, this section is applied **only when the devel package is not
+available**. `create_skip_tests.py` auto-detects availability with
+`is_devel_package_available()` (checks for the importable `rocm_sdk_devel`
+module). When `rocm[devel]` is installed, these tests are run instead of skipped.
+
+You can override detection with `--devel-available` / `--no-devel-available`
+(CLI) or the `devel_available` argument to `get_tests()` / `create_list()`
+(defaults to auto-detection):
+
+```
+# Force-skip the requires_devel tests (simulate a no-devel environment):
+python create_skip_tests.py --amdgpu-family gfx942 --no-devel-available
+
+# Run them (devel present):
+python create_skip_tests.py --amdgpu-family gfx942 --devel-available
+```
+
 When adding new tests to be skipped, consider adding a small comment why it was added, and best if there is any condition/resolution waiting when it can be taken off again.
 
 An example how it could look like is given below:

--- a/external-builds/pytorch/skip_tests/create_skip_tests.py
+++ b/external-builds/pytorch/skip_tests/create_skip_tests.py
@@ -50,7 +50,23 @@ import os
 from pathlib import Path
 import platform
 import sys
-from typing import Dict, List
+from typing import Dict, List, Optional
+
+# Name of the skip_tests section (in generic.py / pytorch_*.py) whose tests need
+# the ROCm SDK development package (rocm[devel]). It is only applied when that
+# package is not available; see is_devel_package_available() and create_list().
+REQUIRES_DEVEL_SECTION = "requires_devel"
+
+
+def is_devel_package_available() -> bool:
+    """Return True if the ROCm SDK development package (rocm[devel]) is installed.
+
+    Detected by the presence of the ``rocm_sdk_devel`` importable module, which
+    is provided by the ``rocm-sdk-devel`` wheel pulled in via the ``rocm[devel]``
+    extra. That package supplies the ROCm headers (e.g. ``hipblas/hipblas.h``)
+    and compiler needed to JIT-compile C++/HIP extensions in some tests.
+    """
+    return importlib.util.find_spec("rocm_sdk_devel") is not None
 
 
 def import_skip_tests(pytorch_version: str = "") -> Dict[str, Dict]:
@@ -119,6 +135,7 @@ def create_list(
     amdgpu_family: list[str] = [],
     pytorch_version: str = "",
     platform: str = "",
+    devel_available: Optional[bool] = None,
 ) -> List[str]:
     """Create a list of test names based on filters.
 
@@ -130,6 +147,10 @@ def create_list(
             Tests marked for this family will be included.
         pytorch_version: PyTorch version for filtering (e.g., "2.7", "all", "").
             Determines which pytorch_*.py files are loaded.
+        devel_available: Whether the ROCm SDK development package (rocm[devel])
+            is available. When False, tests in the "requires_devel" section are
+            added to the skip list. When None (default), auto-detected via
+            is_devel_package_available().
 
     Returns:
         List of unique test names that match the specified filters.
@@ -138,6 +159,8 @@ def create_list(
     Notes:
         - Always includes tests from the "common" filter
         - Includes tests from the specified amdgpu_family filter (if provided)
+        - Includes tests from the "requires_devel" filter when rocm[devel] is
+          not available
 
 
     Examples:
@@ -146,10 +169,16 @@ def create_list(
     """
     selected_tests = []
 
+    if devel_available is None:
+        devel_available = is_devel_package_available()
+
     # Define filters: always include "common", plus specific AMDGPU families
     filters = ["common"]
     filters += amdgpu_family
     filters += [platform.lower()] if platform else []
+    # Skip tests that need rocm[devel] only when the devel package is missing.
+    if not devel_available:
+        filters += [REQUIRES_DEVEL_SECTION]
 
     # Load skip_tests from generic.py and (pytorch_<version> or "all" pytorch versions)
     dict_skip_tests = import_skip_tests(pytorch_version)
@@ -212,6 +241,15 @@ Select (potentially) additional tests to be skipped based on the PyTorch version
         help="""Invert behavior: create a list of tests to include (run) instead of skip.
 Output can be used with 'pytest -k <list>'""",
     )
+    parser.add_argument(
+        "--devel-available",
+        default=None,
+        required=False,
+        action=argparse.BooleanOptionalAction,
+        help="""Whether the ROCm SDK development package (rocm[devel]) is available.
+When not available, tests in the "requires_devel" section are added to the skip
+list. Defaults to auto-detection via the rocm_sdk_devel module.""",
+    )
     args = parser.parse_args(argv)
     return args
 
@@ -221,6 +259,7 @@ def get_tests(
     pytorch_version: str = "",
     platform: str = "",
     create_skip_list: bool = True,
+    devel_available: Optional[bool] = None,
 ) -> str:
     """Generate a pytest -k expression for test filtering.
 
@@ -235,6 +274,9 @@ def get_tests(
             Determines which version-specific test files to load.
         create_skip_list: If True, create a skip list (default).
             If False, create an include list (only run specified tests).
+        devel_available: Whether the ROCm SDK development package (rocm[devel])
+            is available. When None (default), auto-detected. When False, tests
+            in the "requires_devel" section are added to the skip list.
 
     Returns:
         A pytest -k compatible expression string.
@@ -242,16 +284,23 @@ def get_tests(
         - Include list format: "test1 or test2 or test3"
 
     """
+    if devel_available is None:
+        devel_available = is_devel_package_available()
+
     list_type = "skipped" if create_skip_list else "included"
     print(
         f"Creating list of tests to be {list_type} for AMDGPU family '{amdgpu_family}' "
-        f"and PyTorch version '{pytorch_version}'... ",
+        f"and PyTorch version '{pytorch_version}' "
+        f"(rocm[devel] {'available' if devel_available else 'NOT available'})... ",
         end="",
     )
 
     # Get the list of test names
     tests = create_list(
-        amdgpu_family=amdgpu_family, pytorch_version=pytorch_version, platform=platform
+        amdgpu_family=amdgpu_family,
+        pytorch_version=pytorch_version,
+        platform=platform,
+        devel_available=devel_available,
     )
 
     # Format as pytest -k expression
@@ -278,5 +327,6 @@ if __name__ == "__main__":
         pytorch_version=args.pytorch_version,
         platform=args.platform,
         create_skip_list=not args.include_tests,
+        devel_available=args.devel_available,
     )
     print(tests)

--- a/external-builds/pytorch/skip_tests/generic.py
+++ b/external-builds/pytorch/skip_tests/generic.py
@@ -8,6 +8,28 @@ skip_tests = {
             "test_autocast_torch_fp16",
         }
     },
+    # Tests that require the ROCm SDK development package (rocm[devel], i.e. the
+    # rocm_sdk_devel wheel) to be installed. They JIT-compile C++/HIP extensions
+    # via torch.utils.cpp_extension, which needs the ROCm headers (e.g.
+    # hipblas/hipblas.h) and compiler that only ship in the devel package.
+    #
+    # This section is applied ONLY when the devel package is not available in the
+    # environment (see is_devel_package_available() in create_skip_tests.py).
+    # When rocm[devel] is installed (e.g. the full test suite, and the core
+    # suite once it installs rocm[devel]), these tests are run instead of
+    # skipped. Without devel they fail with errors like:
+    #   RuntimeError: Error building extension 'dummy_allocator'
+    #   fatal error: hipblas/hipblas.h: No such file or directory
+    "requires_devel": {
+        "cuda": [
+            # See https://github.com/pytorch/pytorch/pull/173330
+            "test_mempool_empty_cache_inactive",
+            "test_mempool_with_allocator",
+            "test_tensor_delete_after_allocator_delete",
+            "test_deleted_mempool_not_used_on_oom",
+            "test_mempool_expandable",
+        ],
+    },
     "common": {
         "autograd": [
             # Stream comparison mismatch on ROCm (non-default stream vs default stream)
@@ -16,10 +38,6 @@ skip_tests = {
             "test_side_stream_backward_overlap",
         ],
         "cuda": [
-            # RuntimeError: Error building extension 'dummy_allocator'
-            # Skipped across all PyTorch versions; the hipblas.h include error
-            # persists in the ROCm SDK environment.
-            "test_mempool_empty_cache_inactive",
             # TestCudaAllocator - FileNotFoundError: flamegraph.pl missing in CI
             "test_memory_snapshot",
             "test_memory_plots",
@@ -37,22 +55,6 @@ skip_tests = {
             # 'num_host_free': 0, 'reserved_bytes.allocated': 0, 'reserved_bytes.current': 0, 'reserved_bytes.freed': 0,
             # 'reserved_bytes.peak': 0, 'segment.allocated': 0, 'segment.current': 0, 'segment.freed': 0, 'segment.peak': 0})
             "test_host_memory_stats",
-            # THIS IS AN OLD ERROR
-            # In file included from /home/tester/.cache/torch_extensions/py312_cpu/dummy_allocator/main_hip.cpp:5:
-            # /home/tester/TheRock/.venv/lib/python3.12/site-packages/torch/include/ATen/hip/Exceptions.h:4:10: fatal error: hipblas/hipblas.h: No such file or directory
-            #     4 | #include <hipblas/hipblas.h>
-            #     |          ^~~~~~~~~~~~~~~~~~~
-            # compilation terminated.
-            # NEW ERROR
-            # RuntimeError: Error building extension 'dummy_allocator'
-            "test_mempool_with_allocator",
-            # RuntimeError: Error building extension 'dummy_allocator_v3'
-            "test_tensor_delete_after_allocator_delete",
-            # RuntimeError: Error building extension 'dummy_allocator'
-            "test_deleted_mempool_not_used_on_oom",
-            # Same hipblas.h compilation error as test_mempool_with_allocator.
-            # See https://github.com/pytorch/pytorch/pull/173330
-            "test_mempool_expandable",
             # Change detector test (Cublaslt vs Cublas depending on gcn_arch and torch version)
             # Always skip as this test is very basic and needs manual intervention for new architectures
             # See


### PR DESCRIPTION
## What

Skip the core-suite PyTorch tests that require the ROCm SDK development package (`rocm[devel]`) when that package is not available in the environment.

These tests JIT-compile C++/HIP extensions via `torch.utils.cpp_extension`, which needs the ROCm headers (e.g. `hipblas/hipblas.h`) and compiler that only ship in `rocm[devel]` (the `rocm_sdk_devel` wheel). Without it they fail with `RuntimeError: Error building extension 'dummy_allocator'` / `fatal error: hipblas/hipblas.h: No such file or directory`.

Previously these were **always** skipped in `generic.py`'s `common` section. They are now moved to a new `requires_devel` section that is applied **only when the devel package is missing**, so they actually run when `rocm[devel]` is installed (the full suite, and the core suite once it installs `rocm[devel]` — see #6515).

Affected tests (`test_cuda`):
- `test_mempool_empty_cache_inactive`
- `test_mempool_with_allocator`
- `test_tensor_delete_after_allocator_delete`
- `test_deleted_mempool_not_used_on_oom`
- `test_mempool_expandable`

## How

- `generic.py`: new top-level `requires_devel` section; these 5 tests removed from `common` -> `cuda`.
- `create_skip_tests.py`: `is_devel_package_available()` (checks for the importable `rocm_sdk_devel` module); `create_list()` / `get_tests()` gain a `devel_available` arg (auto-detected by default) and add the `requires_devel` section to the skip list only when devel is absent; new `--devel-available` / `--no-devel-available` CLI flag.
- README: documents the new section and override.

## Test

### Local unit check

Verified skip-list generation toggles correctly with devel availability:

```
$ python3 - <<'PY'
import generic, create_skip_tests as c
DEVEL=["test_mempool_empty_cache_inactive","test_mempool_with_allocator",
       "test_tensor_delete_after_allocator_delete","test_deleted_mempool_not_used_on_oom",
       "test_mempool_expandable"]
print("requires_devel section present:", "requires_devel" in generic.skip_tests)
print("still in common->cuda? (should be False):",
      any("mempool" in t for t in generic.skip_tests["common"]["cuda"]))
no  = c.get_tests(amdgpu_family=["gfx942"], devel_available=False)
yes = c.get_tests(amdgpu_family=["gfx942"], devel_available=True)
print("skipped when devel MISSING:", sorted(t for t in DEVEL if t in no))
print("skipped when devel PRESENT:", sorted(t for t in DEVEL if t in yes))
PY

requires_devel section present: True
still in common->cuda? (should be False): False
skipped when devel MISSING: ['test_deleted_mempool_not_used_on_oom', 'test_mempool_empty_cache_inactive', 'test_mempool_expandable', 'test_mempool_with_allocator', 'test_tensor_delete_after_allocator_delete']
skipped when devel PRESENT: []
```

CLI flag:

```
$ python3 create_skip_tests.py --amdgpu-family gfx942 --no-devel-available   # 4 "mempool" matches skipped
$ python3 create_skip_tests.py --amdgpu-family gfx942 --devel-available       # 0 (they run)
```

(The `--devel-available` case shows 0 because all 5 run; 4 of the 5 names contain "mempool" — the 5th is `test_tensor_delete_after_allocator_delete`.)

### CI test run

Dispatched the core **Test PyTorch Wheels** workflow on this branch (gfx94X-dcgpu, torch `2.9.1+rocm7.14.0a20260611`, `release/2.9`, py3.12, index `https://rocm.nightlies.amd.com/v2`). This branch's core workflow does not install `rocm[devel]`, so the `requires_devel` tests take the "devel not available" path and are skipped — a regression check that the run stays green:

- https://github.com/ROCm/TheRock/actions/runs/29280683535
