### PR TITLE
fix(hiptensor): Install missing test configs

### DIFF
--- a/math-libs/artifact-hiptensor.toml
+++ b/math-libs/artifact-hiptensor.toml
@@ -14,5 +14,5 @@ include = [
   "bin/simple_*",
   # Tests
   "bin/*_test*",
-  "bin/hiptensor/CTestTestfile.cmake",
+  "bin/hiptensor/**",
 ]


### PR DESCRIPTION
## Motivation

hipTensor's test package was missing test configs and non-default test categories (e.g. ffm-quick) were failing to run.

## Technical Details

Include all files under bin/hiptensor to hiptensor's test package

## Test Plan and Results:

- [x] hipTensor's regular tests should keep passing (CI)
- [x] hipTensor's ffm-quick tests should pass (manual testing)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

TICKET ID : https://github.com/ROCm/TheRock/issues/6520