### PR TITLE
ci: include ROCm package index in PyTorch test run names

### DIFF
--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -110,7 +110,7 @@ on:
 permissions:
   contents: read
 
-run-name: Test PyTorch (${{ inputs.amdgpu_family }}, ${{ inputs.torch_version}}, ${{ inputs.test_runs_on }})
+run-name: Test PyTorch (${{ inputs.amdgpu_family }}, ${{ inputs.torch_version}}, ${{ inputs.package_index_url }}, ${{ inputs.test_runs_on }})
 
 jobs:
   test_wheels:

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -148,7 +148,7 @@ on:
 permissions:
   contents: read
 
-run-name: Test PyTorch Full (${{ inputs.amdgpu_family }}, ${{ inputs.torch_version}}, ${{ inputs.test_runs_on }})
+run-name: Test PyTorch Full (${{ inputs.amdgpu_family }}, ${{ inputs.torch_version}}, ${{ inputs.package_index_url }}, ${{ inputs.test_runs_on }})
 
 jobs:
   prepare_matrix:


### PR DESCRIPTION
## What

Add the `package_index_url` input to the `run-name` of both the core (`test_pytorch_wheels.yml`) and full (`test_pytorch_wheels_full.yml`) PyTorch test workflows, so a dispatched run shows which ROCm package source/channel it was run against (e.g. `v2`, `v2-staging`, `dev`, or a specific build's index) at a glance in the Actions run list. The `torch_version` (which already carries the `+rocm...` version) remains in the name too.

## Test

Dispatched both workflows from this branch and confirmed the run name now renders the `package_index_url`:

- Core — `Test PyTorch (gfx94X-dcgpu, 2.9.1+rocm7.15.0a20260716, https://rocm.nightlies.amd.com/whl-multi-arch/, linux-gfx942-1gpu-ccs-csp-ossci-rocm)`
  - https://github.com/ROCm/TheRock/actions/runs/29510786853
- Full — `Test PyTorch Full (gfx94X-dcgpu, 2.9.1+rocm7.15.0a20260716, https://rocm.nightlies.amd.com/whl-multi-arch/, linux-gfx942-1gpu-ccs-csp-ossci-rocm)`
  - https://github.com/ROCm/TheRock/actions/runs/29510789084
