### PR TITLE
fix(ci): Re-enable amd-smi static for gfx950 in CI sanity check

### DIFF
--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -25,8 +25,7 @@ import sys
 from typing import List, Optional
 
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
-# TODO(#2964): Remove gfx950-dcgpu once amdsmi static does not timeout
-unsupported_amdsmi_families = ["gfx1151", "gfx950-dcgpu"]
+unsupported_amdsmi_families = ["gfx1151"]
 
 
 def log(*args, **kwargs):


### PR DESCRIPTION
## Motivation
Closes #2964

The CI "Driver / GPU sanity check" skips `amd-smi static` for the `gfx950-dcgpu` family because the command used to hang and time out on gfx950 (tracked in #2964). `amd-smi static` no longer times out on gfx950, so the skip can be removed to restore sanity-check coverage on that family.

`amd-smi static` was fixed for `gfx950` with: https://github.com/ROCm/rocm-systems/commit/7f31abd2178d1595a6f2e9b0c193e5d381da9041

## Technical Details

Remove `gfx950-dcgpu` from `unsupported_amdsmi_families` in `build_tools/print_driver_gpu_info.py`.

## Test Plan

Verified on a gfx950 machine by running `amd-smi static` and `AMDGPU_FAMILIES=gfx950-dcgpu python3 ./build_tools/print_driver_gpu_info.py` before and after the change.

## Test Result

`amd-smi static` completes quickly with no timeout, and the sanity script now runs the `amd-smi static` section end-to-end for gfx950 with no errors.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
