### PR TITLE
feat(ci): Enable gfx90c nightly builds

### DIFF
--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -73,6 +73,7 @@ on:
           - gfx1153
           - gfx120X-all
           - gfx900
+          - gfx90c
           - gfx906
           - gfx908
           - gfx90a

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -331,8 +331,6 @@ amdgpu_family_info_matrix_nightly = {
             "build_variants": ["release"],
         },
     },
-    # Renoir/Lucienne/Cezanne iGPU (Ryzen 4000/5000/6000).
-    # build + sanity check only.
     "gfx90c": {
         "linux": {
             "test-runs-on": "",

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -331,6 +331,23 @@ amdgpu_family_info_matrix_nightly = {
             "build_variants": ["release"],
         },
     },
+    # Renoir/Lucienne/Cezanne iGPU (Ryzen 4000/5000/6000).
+    # build + sanity check only.
+    "gfx90c": {
+        "linux": {
+            "test-runs-on": "",
+            "family": "gfx90c",
+            "fetch-gfx-targets": [],
+            "sanity_check_only_for_family": True,
+            "build_variants": ["release"],
+        },
+        "windows": {
+            "test-runs-on": "",
+            "family": "gfx90c",
+            "fetch-gfx-targets": [],
+            "build_variants": ["release"],
+        },
+    },
     # gfx906/908/90a split into separate families - each has different instruction
     # support (e.g., fp8 variants, WMMA) so CK/MIOpen need to build/test individually.
     "gfx906": {

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -54,21 +54,29 @@ CI_PYTORCH_REFS = {
 
 # Unknown explicit refs are left unfiltered so bring-up branches can opt into
 # new GPU families before the default PyTorch refs support them.
+#
+# gfx90c is excluded from stable release branches and built for nightly only
+# while it is brought up. Once nightly gfx90c wheels are confirmed working, it
+# will be added to the stable branches.
 UNSUPPORTED_AMDGPU_FAMILIES = {
     "linux": {
         # gfx125x not supported for PyTorch 2.10.
-        "release/2.10": {"gfx125X-dcgpu"},
+        "release/2.10": {"gfx125X-dcgpu", "gfx90c"},
         # gfx125x supported for PyTorch 2.11 via https://github.com/ROCm/pytorch/pull/3346.
-        "release/2.11": {},
+        "release/2.11": {"gfx90c"},
         # gfx125x not yet upstreamed to pytorch/pytorch. Upstream expected
         # 2026-06-26, but the ROCm 7.14 release is cut before that date.
         # See https://github.com/ROCm/TheRock/issues/5833.
-        "release/2.12": {"gfx125X-dcgpu"},
+        "release/2.12": {"gfx125X-dcgpu", "gfx90c"},
         # gfx125x not yet upstreamed to pytorch/pytorch.
         # See https://github.com/ROCm/TheRock/issues/5833.
         "nightly": {"gfx125X-dcgpu"},
     },
-    "windows": {},
+    "windows": {
+        "release/2.10": {"gfx90c"},
+        "release/2.11": {"gfx90c"},
+        "release/2.12": {"gfx90c"},
+    },
 }
 
 

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -65,6 +65,7 @@ amdgpu_family_predefined_groups = {
     # The 'nightly' matrix runs on 'schedule' triggers.
     "amdgpu_nightly": [
         "gfx90X-dcgpu",
+        "gfx90c",
         "gfx101X-dgpu",
         "gfx103X-all",
         "gfx1150",
@@ -439,6 +440,39 @@ amdgpu_family_info_matrix_all = {
                 },
             },
         }
+    },
+    # Renoir/Lucienne/Cezanne iGPU (Ryzen 4000/5000/6000). No CI hardware, so
+    # build + sanity check only.
+    "gfx90c": {
+        "linux": {
+            "build": {
+                "build_variants": ["release"],
+            },
+            "test": {
+                "run_tests": False,
+                "runs_on": {},
+                "fetch-gfx-targets": [],
+                "sanity_check_only_for_family": True,
+            },
+            "release": {
+                "push_on_success": False,
+                "bypass_tests_for_releases": False,
+            },
+        },
+        "windows": {
+            "build": {
+                "build_variants": ["release"],
+            },
+            "test": {
+                "run_tests": False,
+                "runs_on": {},
+                "fetch-gfx-targets": [],
+            },
+            "release": {
+                "push_on_success": False,
+                "bypass_tests_for_releases": False,
+            },
+        },
     },
     "gfx101X": {
         "dgpu": {

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -441,8 +441,6 @@ amdgpu_family_info_matrix_all = {
             },
         }
     },
-    # Renoir/Lucienne/Cezanne iGPU (Ryzen 4000/5000/6000). No CI hardware, so
-    # build + sanity check only.
     "gfx90c": {
         "linux": {
             "build": {


### PR DESCRIPTION
## Motivation

Part of https://github.com/ROCm/TheRock/issues/3818.

Enabling gfx90c builds.

## Technical Details

- Add gfx90c entries to both `amdgpu_family_matrix.py` and `new_amdgpu_family_matrix.py` mirroring the entries of `gfx900`.
- Setup `configure_pytorch_release_matrix.py` to exclude gfx90c from all stable PyTorch release branches on Linux and Windows. Will determine if enabling these is necessary once nightly builds are up and running.
- Add gfx90c entry to `test_linux_jax_wheels.yml`.

## Test Plan
Locally,
- Build ROCm from source for gfx90c via TheRock (THEROCK_AMDGPU_FAMILIES=gfx90c)
- Generate rocm-sdk wheels, then build PyTorch against them. 

## Test Result

- ROCm wheels built - rocminfo enumerates gfx90c GPU correctly
- Torch built and imports correctly with [CK fix](https://github.com/ROCm/rocm-libraries/pull/9333) applied. 
- Basic tests (matmul via rocBLAS/hipBLASLt, reductions/softmax/exp, autograd backward, full nn.Module training step) pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
