### PR TITLE
test(ci): allow external manifest diff URLs

### DIFF
--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1384,6 +1384,42 @@ class TestFormatSummary(unittest.TestCase):
         outputs = cm.CIOutputs(is_ci_enabled=False)
         cm.write_outputs(self._inputs(), outputs)
 
+    def test_build_outputs_includes_manifest_diff_link(self):
+        linux = cm.BuildConfig(
+            per_family_info=[],
+            dist_amdgpu_families="gfx94X-dcgpu",
+            artifact_group="gfx94X-dcgpu",
+            build_variant_label="release",
+            build_variant_suffix="",
+            build_variant_cmake_preset="",
+            build_native_linux=True,
+            build_pytorch=False,
+            build_jax=False,
+        )
+        jobs = cm.JobDecisions(
+            build_rocm=cm.BuildRocmDecision(action=cm.JobAction.RUN),
+            test_rocm=cm.TestRocmDecision(action=cm.JobAction.RUN, test_type="full"),
+            build_rocm_python=cm.JobGroupDecision(action=cm.JobAction.RUN),
+            build_pytorch=cm.JobGroupDecision(action=cm.JobAction.RUN),
+            test_pytorch=cm.JobGroupDecision(action=cm.JobAction.RUN),
+            build_jax=cm.JobGroupDecision(action=cm.JobAction.SKIP),
+        )
+        outputs = cm.CIOutputs(
+            is_ci_enabled=True,
+            builds=cm.BuildConfigs(linux=linux),
+            jobs=jobs,
+        )
+        result = format_summary(self._inputs(), outputs)
+        self.assertIn("## Build outputs", result)
+        self.assertIn("Linux |", result)
+        self.assertIn("Windows |", result)
+        self.assertRegex(
+            result,
+            r"Manifest diff \*\(if produced\)\* \| "
+            r"https://[^|\s]+/12345-linux/logs/manifest-diff/index\.html "
+            r"\| — \| —",
+        )
+
 
 # ---------------------------------------------------------------------------
 # End-to-end: configure() pipeline


### PR DESCRIPTION
## Motivation

The multi-arch CI summary unit test currently fails in PR contexts that use the external artifact bucket. The summary code correctly emits a manifest-diff URL under `therock-ci-artifacts-external/...`, but the test hard-codes the internal `therock-ci-artifacts` bucket.

This is blocking the unit-test checks on ROCm/TheRock#6517 and ROCm/TheRock#6525.

## Summary

- Relax the manifest-diff URL assertion to validate the expected summary row and run/platform path without assuming one specific S3 bucket.

## Validation

- `pre-commit run --files build_tools/github_actions/tests/configure_multi_arch_ci_test.py`
- `PYTHONPATH=build_tools:build_tools/github_actions:build_tools/github_actions/tests .venv/bin/python -m unittest build_tools.github_actions.tests.configure_multi_arch_ci_test.TestFormatSummary.test_build_outputs_includes_manifest_diff_link`
- Simulated fork-PR event for `TestFormatSummary.test_build_outputs_includes_manifest_diff_link`
- `PYTHONPATH=build_tools:build_tools/github_actions:build_tools/github_actions/tests .venv/bin/python -m unittest build_tools.github_actions.tests.configure_multi_arch_ci_test`
- `git diff --check`

Related: https://github.com/ROCm/TheRock/pull/6517
Related: https://github.com/ROCm/TheRock/pull/6525

which are ultimately related to 

JIRA ID : AIHPBLAS-3605
https://amd-hub.atlassian.net/browse/AIHPBLAS-3605


