### PR TITLE
fix(compiler): Enable hwloc for openmp build

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -133,6 +133,7 @@ if(THEROCK_ENABLE_COMPILER)
       ${_extra_llvm_cmake_args}
     BUILD_DEPS
       rocm-cmake
+      ${THEROCK_BUNDLED_HWLOC}
     RUNTIME_DEPS
       ${THEROCK_BUNDLED_ZLIB}
       ${THEROCK_BUNDLED_ZSTD}

--- a/compiler/pre_hook_amd-llvm.cmake
+++ b/compiler/pre_hook_amd-llvm.cmake
@@ -59,8 +59,7 @@ else()
       set(RUNTIMES_amdgcn-amd-amdhsa_CACHE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/../compiler-rt/cmake/caches/GPU.cmake;${CMAKE_CURRENT_SOURCE_DIR}/../libcxx/cmake/caches/AMDGPU.cmake")
       set(FLANG_RUNTIME_F128_MATH_LIB "libquadmath")
       set(LIBOMPTARGET_BUILD_DEVICE_FORTRT ON)
-      #TODO: Enable when HWLOC dependency is figured out
-      #set(LIBOMP_USE_HWLOC ON)
+      set(LIBOMP_USE_HWLOC ON)
     endif()
   endif()
   # Setting "LIBOMP_COPY_EXPORTS" to `OFF` "aids parallel builds to not interfere

--- a/compiler/pre_hook_amd-llvm.cmake
+++ b/compiler/pre_hook_amd-llvm.cmake
@@ -59,8 +59,8 @@ else()
       set(RUNTIMES_amdgcn-amd-amdhsa_CACHE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/../compiler-rt/cmake/caches/GPU.cmake;${CMAKE_CURRENT_SOURCE_DIR}/../libcxx/cmake/caches/AMDGPU.cmake")
       set(FLANG_RUNTIME_F128_MATH_LIB "libquadmath")
       set(LIBOMPTARGET_BUILD_DEVICE_FORTRT ON)
-      #TODO: Enable when HWLOC dependency is figured out
-      #set(LIBOMP_USE_HWLOC ON)
+      set(LIBOMP_USE_HWLOC ON)
+      set(LIBOMP_HWLOC_INSTALL_DIR "${THEROCK_BINARY_DIR}/third-party/sysdeps/linux/hwloc/build/stage/lib/rocm_sysdeps")
     endif()
   endif()
   # Setting "LIBOMP_COPY_EXPORTS" to `OFF` "aids parallel builds to not interfere

--- a/test_tools/therock_consumer_graph.json
+++ b/test_tools/therock_consumer_graph.json
@@ -681,7 +681,8 @@
   },
   "therock-hwloc": {
     "consumers": [
-      "rocrtst"
+      "rocrtst",
+      "amd-llvm"
     ]
   },
   "therock-libbacktrace": {


### PR DESCRIPTION
Used for thread to core affinity and numa awareness. When LIBOMP_USE_HWLOC=ON openmp needs hwloc headers.

## Motivation
Originally, TheRock did not have any hwloc support. Now hwloc has been added to third-party/sysdeps/common.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Build should avoid the missing hwloc header issue.

## Test Result

Build passes.
