### PR TITLE
fix(rocprofiler-sdk): use TEST targets for all-arch test binaries

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -104,7 +104,9 @@ if(THEROCK_ENABLE_ROCPROFV3)
   endif()
 
   therock_cmake_subproject_declare(rocprofiler-sdk
-    USE_DIST_AMDGPU_TARGETS
+    # Use TEST targets (all available archs) so the _generic test artifact
+    # contains .hsaco files for all architectures, not just dist archs.
+    USE_TEST_AMDGPU_TARGETS
     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprofiler-sdk"
     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprofiler-sdk"
     BACKGROUND_BUILD


### PR DESCRIPTION
## Summary
- Switch rocprofiler-sdk from `USE_DIST_AMDGPU_TARGETS` to `USE_TEST_AMDGPU_TARGETS`
- Ensures the `_generic` test artifact contains `.hsaco` files for ALL architectures
- Fixes issue where test binaries for wrong architectures were present in artifacts

## Problem
When downloading rocprofiler-sdk test artifacts with `--artifact-group=gfx94X-dcgpu`, the test binary `device_counting_service_test` failed because it couldn't find `gfx942_agent_kernels.hsaco` - instead, only `gfx1250_agent_kernels.hsaco` was present.

**Root cause**: `rocprofiler-sdk` used `USE_DIST_AMDGPU_TARGETS` which only builds test binaries for the dist targets configured in that particular CI run. If the run was configured for gfx1250 (e.g., gfx125X-dcgpu), the generic test artifact would only contain gfx1250 .hsaco files.

## Solution
Use `USE_TEST_AMDGPU_TARGETS` instead, which defaults to ALL available architectures. This ensures the generic test artifact contains .hsaco files for every architecture, making it usable on any target.

Closes #6501

## Testing and Verification

  Downloaded and inspected the test artifact from CI run
  [29367624534](https://therock-ci-artifacts.s3.amazonaws.com/29367624534-linux/index.html):

  ```bash
  $ curl -sO "https://therock-ci-artifacts.s3.amazonaws.com/29367624534-linux/rocprofiler-sdk_test_generic.tar.zst"
  $ # Extract and list agent_kernels.hsaco files
  $ tar --use-compress-program=zstd -tf rocprofiler-sdk_test_generic.tar.zst | grep agent_kernels.hsaco | sort
  ```

  **Result: 28 agent_kernels.hsaco files for ALL architectures:**

  ```
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1010_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1011_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1012_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1030_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1031_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1032_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1033_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1034_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1035_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1036_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1100_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1101_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1102_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1103_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1150_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1151_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1152_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1153_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1200_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1201_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx1250_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx900_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx906_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx908_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx90a_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx90c_agent_kernels.hsaco
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx942_agent_kernels.hsaco  <-- was missing before
  profiler/rocprofiler-sdk/stage/share/rocprofiler-sdk/tests/unit-tests/bin/gfx950_agent_kernels.hsaco
  ```

  **Before the fix:** Only `gfx1250_agent_kernels.hsaco` was present (per issue description).

  **After the fix:** All 28 architectures have their `.hsaco` files included, including `gfx942_agent_kernels.hsaco` which was missing and
  causing `device_counting_service_test` to fail.