### PR TITLE
feat(ci): allow schedule triggers to respect explicit family inputs

### DIFF
--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -832,10 +832,25 @@ def select_targets(ci_inputs: CIInputs) -> TargetSelection:
         linux_names = list(defaults)
         windows_names = list(defaults)
     elif ci_inputs.is_schedule:
-        # Full nightly coverage: every known family, including targets
-        # that are too slow or expensive for per-push CI.
-        linux_names = list(all_families.keys())
-        windows_names = list(all_families.keys())
+        # Schedule trigger: use explicit inputs if provided, else all families.
+        # "all" or empty = all known families. "none" = skip platform.
+        linux_names = list(ci_inputs.linux_amdgpu_families)
+        windows_names = list(ci_inputs.windows_amdgpu_families)
+        if linux_names == ["all"]:
+            linux_names = list(all_families.keys())
+            print("  linux_amdgpu_families='all' -> all Linux families")
+        elif not linux_names:
+            linux_names = list(all_families.keys())
+        elif linux_names == ["none"]:
+            linux_names = []
+
+        if windows_names == ["all"]:
+            windows_names = list(all_families.keys())
+            print("  windows_amdgpu_families='all' -> all Windows families")
+        elif not windows_names:
+            windows_names = list(all_families.keys())
+        elif windows_names == ["none"]:
+            windows_names = []
     else:
         raise ValueError(f"Unsupported event type: {ci_inputs.event_name!r}")
 

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -598,6 +598,37 @@ class TestSelectTargets(unittest.TestCase):
         push_result = cm.select_targets(push_inputs)
         self.assertGreater(len(result.linux_families), len(push_result.linux_families))
 
+    def test_schedule_respects_explicit_inputs(self):
+        """Schedule trigger uses explicit inputs when provided."""
+        inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="schedule",
+            commit_ref="main",
+            base_ref="HEAD^1",
+            build_variant="release",
+            linux_amdgpu_families=["gfx94x", "gfx950"],
+            windows_amdgpu_families=["gfx1151"],
+        )
+        result = cm.select_targets(inputs)
+        # Should use explicit inputs, not all families
+        self.assertEqual(result.linux_families, ["gfx94x", "gfx950"])
+        self.assertEqual(result.windows_families, ["gfx1151"])
+
+    def test_schedule_none_skips_platform(self):
+        """Schedule trigger with 'none' skips that platform."""
+        inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="schedule",
+            commit_ref="main",
+            base_ref="HEAD^1",
+            build_variant="release",
+            linux_amdgpu_families=["gfx94x"],
+            windows_amdgpu_families=["none"],
+        )
+        result = cm.select_targets(inputs)
+        self.assertEqual(result.linux_families, ["gfx94x"])
+        self.assertEqual(result.windows_families, [])
+
     def test_pull_request_defaults_to_presubmit_only(self):
         """PR without labels gets presubmit families only, not postsubmit."""
         inputs = cm.CIInputs(


### PR DESCRIPTION
Modify select_targets() to check for explicit linux_amdgpu_families and windows_amdgpu_families inputs on schedule triggers before defaulting to all families.

This enables external repositories (like rocm-libraries) to call setup_multi_arch.yml on a schedule trigger while limiting builds to specific GPU families, rather than being forced to run all.

Noticing that in rockrel: https://github.com/ROCm/rockrel/actions/runs/29295395434/job/87093082810#step:4:23, `all` is not honored: https://github.com/ROCm/rockrel/actions/runs/29295395434/job/87093082810#step:4:32 as the plumbing is only in workflow_dispatch

Now, the flag will be properly honored