### PR TITLE
Revert broken manifest diff test

### DIFF
--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -1353,44 +1353,6 @@ class TestFormatSummary(unittest.TestCase):
         outputs = cm.CIOutputs(is_ci_enabled=False)
         cm.write_outputs(self._inputs(), outputs)
 
-    def test_build_outputs_includes_manifest_diff_link(self):
-        linux = cm.BuildConfig(
-            per_family_info=[],
-            dist_amdgpu_families="gfx94X-dcgpu",
-            artifact_group="gfx94X-dcgpu",
-            build_variant_label="release",
-            build_variant_suffix="",
-            build_variant_cmake_preset="",
-            build_native_linux=True,
-            build_pytorch=False,
-            build_jax=False,
-        )
-        jobs = cm.JobDecisions(
-            build_rocm=cm.BuildRocmDecision(action=cm.JobAction.RUN),
-            test_rocm=cm.TestRocmDecision(action=cm.JobAction.RUN, test_type="full"),
-            build_rocm_python=cm.JobGroupDecision(action=cm.JobAction.RUN),
-            build_pytorch=cm.JobGroupDecision(action=cm.JobAction.RUN),
-            test_pytorch=cm.JobGroupDecision(action=cm.JobAction.RUN),
-            build_jax=cm.JobGroupDecision(action=cm.JobAction.SKIP),
-        )
-        outputs = cm.CIOutputs(
-            is_ci_enabled=True,
-            builds=cm.BuildConfigs(linux=linux),
-            jobs=jobs,
-        )
-        result = format_summary(self._inputs(), outputs)
-        self.assertIn("## Build outputs", result)
-        self.assertIn("Linux |", result)
-        self.assertIn("Windows |", result)
-        manifest_diff_url = (
-            "https://therock-ci-artifacts.s3.amazonaws.com"
-            "/12345-linux/logs/manifest-diff/index.html"
-        )
-        self.assertIn(
-            f"Manifest diff *(if produced)* | {manifest_diff_url} | — | —",
-            result,
-        )
-
 
 # ---------------------------------------------------------------------------
 # End-to-end: configure() pipeline


### PR DESCRIPTION
## Motivation

1. These new tests fail on PRs from forks: https://github.com/ROCm/TheRock/pull/6147#pullrequestreview-4698665652 as the bucket URL is dynamic unless properly mocked out
2. The "test_normal_summary" test case above already explicitly says that it is **not** checking the generated markdown as that is not part of the API and we don't want change detector tests.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
