### PR TITLE
Run full JAX test suite

### DIFF
--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -288,7 +288,5 @@ jobs:
           python -c "import jax; print(jax.local_devices())"
 
           echo "=== Starting full test suite ==="
-          pytest jax/tests/multi_device_test.py -q --log-cli-level=INFO
-          pytest jax/tests/core_test.py -q --log-cli-level=INFO
-          pytest jax/tests/util_test.py -q --log-cli-level=INFO
-          pytest jax/tests/scipy_stats_test.py -q --log-cli-level=INFO
+          cd jax
+          ./ci/test_jax_rocm.sh


### PR DESCRIPTION
## Motivation

Instead of only running a handful of the JAX unit test suite, run all of the tests that we run in upstream CI. There's a handy script for this in rocm/jax that will set up PyTest for us and exclude the multi-GPU tests.

## Technical Details

Replace the individual `pytest` runs with a call to `./ci/run_pytest_rocm.sh`

## Test Plan

Make sure the new tests pass