### PR TITLE
Refresh stale versioning.md documentation

### DIFF
--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -175,8 +175,8 @@ Versions for each distribution channel:
 
 | Package name     | Example release version (stable x stable) | Example nightly version (stable x nightly) |
 | ---------------- | ----------------------------------------- | ------------------------------------------ |
-| jax-rocm7-pjrt   | `2.9.1+rocm7.10.0`                        | `0.10.2+rocm7.15.0a20260712`               |
-| jax-rocm7-plugin | `2.9.1+rocm7.10.0`                        | `0.10.2+rocm7.15.0a20260712`               |
+| jax-rocm7-pjrt   | `0.10.0+rocm7.14.0`                       | `0.10.2+rocm7.15.0a20260712`               |
+| jax-rocm7-plugin | `0.10.0+rocm7.14.0`                       | `0.10.2+rocm7.15.0a20260712`               |
 
 ### Working with Python package versions
 

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -59,8 +59,8 @@ users who want early previews of upcoming releases, and QA/test team members.
 | -------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | stable releases      | https://repo.amd.com/rocm/        | Manually promoted prereleases                                                                                                                                                                                |
 | prereleases          | https://rocm.prereleases.amd.com/ | Manually triggered workflows in [rockrel](https://github.com/ROCm/rockrel)                                                                                                                                   |
-| nightly releases     | https://rocm.nightlies.amd.com/   | Scheduled workflows in [TheRock](https://github.com/ROCm/TheRock)                                                                                                                                            |
-| dev releases         | https://rocm.devreleases.amd.com/ | Manually triggered test workflows in [TheRock](https://github.com/ROCm/TheRock)                                                                                                                              |
+| nightly releases     | https://rocm.nightlies.amd.com/   | Scheduled workflows in [rockrel](https://github.com/ROCm/rockrel)                                                                                                                                            |
+| dev releases         | https://rocm.devreleases.amd.com/ | Manually triggered test workflows in [TheRock](https://github.com/ROCm/TheRock) and [rockrel](https://github.com/ROCm/rockrel)                                                                               |
 | dev builds           | No central index                  | Local builds and per-commit workflows in [TheRock](https://github.com/ROCm/TheRock),<br>[rocm-libraries](https://github.com/ROCm/rocm-libraries), [rocm-systems](https://github.com/ROCm/rocm-systems), etc. |
 
 With the exception of "dev releases", each distribution channel only contains
@@ -160,15 +160,23 @@ The scripts produce these versions for each distribution channel:
 
 #### JAX versions
 
-TODO: fill this in together with:
+JAX packages versions are handled via scripts:
 
-- https://github.com/ROCm/TheRock/issues/1985
-- https://github.com/ROCm/TheRock/issues/2091
+- [`build_tools/github_actions/determine_version.py`](/build_tools/github_actions/determine_version.py) (this generates e.g. `--version-suffix +rocm7.10.0`)
+  - [`build_tools/github_actions/tests/determine_version_test.py`](/build_tools/github_actions/tests/determine_version_test.py)
+- [`build_tools/github_actions/write_jax_versions.py`](/build_tools/github_actions/write_jax_versions.py)
+  (this finds the versions in built packages)
+- [`build_tools/github_actions/generate_jax_manifest.py`](/build_tools/github_actions/generate_jax_manifest.py)
+  (this records versions into a manifest file)
+  - [`build_tools/github_actions/tests/generate_jax_manifest_test.py`](/build_tools/github_actions/tests/generate_jax_manifest_test.py)
+- In the [ROCm/rocm-jax repository](https://github.com/ROCm/rocm-jax): [`build/ci_build`](https://github.com/ROCm/rocm-jax/blob/rocm-jax-infra/build/ci_build) (see the `--rocm-version` and `--no-rocm-version-extra` flags)
 
-<!--
-- jax-rocm7-pjrt
-- jax-rocm7-plugin
-- jaxlib (no rocm code in here) -->
+Versions for each distribution channel:
+
+| Package name     | Example release version (stable x stable) | Example nightly version (stable x nightly) |
+| ---------------- | ----------------------------------------- | ------------------------------------------ |
+| jax-rocm7-pjrt   | `2.9.1+rocm7.10.0`                        | `0.10.2+rocm7.15.0a20260712`               |
+| jax-rocm7-plugin | `2.9.1+rocm7.10.0`                        | `0.10.2+rocm7.15.0a20260712`               |
 
 ### Working with Python package versions
 
@@ -248,8 +256,8 @@ A few ways to look up the version of an installed package are:
 TheRock supports rpm and debian packages. Each has different versioning scheme as mentioned below.
 Native package versions are handled by scripts:
 
-- [`build_tools/compute_rocm_native_package_version.py`](/build_tools/compute_rocm_native_package_version.py)
-  - [`build_tools/tests/compute_rocm_native_package_version_test.py`](/build_tools/tests/compute_rocm_native_package_version_test.py)
+- [`build_tools/compute_rocm_package_version.py`](/build_tools/compute_rocm_package_version.py)
+  - [`build_tools/tests/compute_rocm_package_version_test.py`](/build_tools/tests/compute_rocm_package_version_test.py)
 
 The script produces these versions for rpm packages for each release type:
 


### PR DESCRIPTION
## Motivation

Related to:
* https://github.com/ROCm/TheRock/issues/3340
* https://github.com/ROCm/TheRock/issues/1985

Included changes:
* Nightly releases are now triggered in https://github.com/ROCm/rockrel, not TheRock
* JAX packages are published with similar versions to PyTorch packages
* `build_tools/compute_rocm_native_package_version.py` does not exist (missed back on https://github.com/ROCm/TheRock/pull/2525)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
