### PR TITLE
Drop per-family release support from setup_venv.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ In case you don't have an existing ROCm/HIP installation from which you can run 
 
 You can install the `rocm` Python package for any architecture inside a venv and run `offload-arch` from there:
 
-1. `python build_tools/setup_venv.py --index-name nightly --index-subdir gfx110X-all --packages rocm .tmpvenv`
+1. `python build_tools/setup_venv.py --index-name nightly --packages rocm .tmpvenv`
 1. `.tmpvenv/bin/offload-arch` on Linux, `.tmpvenv\Scripts\offload-arch` on Windows
 1. `rm -rf .tmpvenv`
 

--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -47,7 +47,6 @@ import shlex
 import shutil
 import subprocess
 import sys
-import re
 import time
 
 from github_actions.github_actions_api import *

--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -50,12 +50,10 @@ from pathlib import Path
 import platform
 import shlex
 import shutil
-import socket
 import subprocess
 import sys
 import re
 import time
-from urllib.parse import urlparse
 
 from github_actions.github_actions_api import *
 
@@ -68,90 +66,10 @@ ROCM_INDEX_URLS_MAP = {
     "dev": "https://rocm.devreleases.amd.com/v2",
 }
 
-# Fallback mapping from CDN domains to direct S3 bucket URLs.
-# Used when DNS resolution fails for the CDN.
-CDN_TO_S3_FALLBACK_MAP = {
-    "rocm.devreleases.amd.com": "therock-dev-python.s3.amazonaws.com",
-    "rocm.nightlies.amd.com": "therock-nightly-python.s3.amazonaws.com",
-}
-
 
 def log(*args, **kwargs):
     print(*args, **kwargs)
     sys.stdout.flush()
-
-
-def check_dns_resolution(hostname: str, timeout: float = 5.0) -> bool:
-    """Check if a hostname can be resolved via DNS."""
-    try:
-        socket.setdefaulttimeout(timeout)
-        socket.gethostbyname(hostname)
-        return True
-    except (socket.gaierror, socket.timeout):
-        return False
-
-
-def apply_url_fallback(url: str) -> tuple[str, bool]:
-    """If DNS fails for the URL's domain, substitute a fallback domain if configured."""
-    parsed = urlparse(url)
-    hostname = parsed.hostname
-
-    if not hostname:
-        return url, False
-
-    # Check if we have a fallback configured for this domain.
-    fallback_hostname = CDN_TO_S3_FALLBACK_MAP.get(hostname)
-    if not fallback_hostname:
-        return url, False
-
-    # Check if the original domain is reachable.
-    if check_dns_resolution(hostname):
-        return url, False
-
-    # DNS failed, check if fallback is reachable.
-    log(f"[WARNING] DNS resolution failed for '{hostname}', trying fallback...")
-    if not check_dns_resolution(fallback_hostname):
-        log(
-            f"[WARNING] Fallback '{fallback_hostname}' also unreachable, using original URL"
-        )
-        return url, False
-
-    # Replace the hostname with the fallback.
-    fallback_url = url.replace(f"://{hostname}", f"://{fallback_hostname}", 1)
-    log(f"[INFO] Using fallback URL: {fallback_url}")
-    return fallback_url, True
-
-
-def scrape_package_names_from_index(index_url: str) -> list[str]:
-    """Scrape package names from the index.html at the given URL.
-
-    This dynamically fetches the list of available packages from the S3 bucket
-    index page, avoiding the need for a hardcoded package list.
-    Uses urllib.request (stdlib) to avoid external dependencies.
-    """
-    import urllib.request
-    import urllib.error
-
-    # Ensure URL ends with index.html for S3 bucket listing
-    if not index_url.endswith("/"):
-        index_url = index_url + "/"
-    index_html_url = index_url + "index.html"
-
-    try:
-        with urllib.request.urlopen(index_html_url, timeout=30) as response:
-            html_content = response.read().decode("utf-8")
-    except (urllib.error.URLError, urllib.error.HTTPError) as e:
-        log(f"[WARNING] Failed to fetch package index from {index_html_url}: {e}")
-        return []
-
-    # Extract package names from <a> tags in the index HTML
-    # Typical format: <a href="package-name/">package-name</a>
-    package_pattern = r'<a[^>]*href="([^"/]+)/?">.*?</a>'
-    matches = re.findall(package_pattern, html_content, re.IGNORECASE)
-
-    # Filter out non-package entries (like parent directory links)
-    packages = [m for m in matches if m and not m.startswith(".")]
-    return packages
 
 
 def run_command(args: list[str | Path], cwd: Path = Path.cwd()):
@@ -332,7 +250,6 @@ def install_packages_into_venv(
         # Look up known index name.
         index_url = ROCM_INDEX_URLS_MAP[index_name]
 
-    using_s3_fallback = False
     if index_url == "":
         pip_install_cmd.append("--no-index")
         pip_install_cmd.append("--no-build-isolation")
@@ -341,33 +258,10 @@ def install_packages_into_venv(
         if index_subdir:
             index_url = f"{index_url.rstrip('/')}/{index_subdir.strip('/')}"
 
-        # Apply DNS fallback if needed (e.g., CDN domain unreachable).
-        index_url, using_s3_fallback = apply_url_fallback(index_url)
-
-        if using_s3_fallback:
-            # TODO(#5285): remove fallback once DNS issues on test machine are resolved
-            # Use --find-links with explicit index.html paths. S3 doesn't auto-serve
-            # index.html for directory URLs, so --index-url won't work.
-            # Dynamically scrape available packages from the fallback index.
-            pkg_names = scrape_package_names_from_index(index_url)
-            if not pkg_names:
-                log("[WARNING] No packages found in fallback index, install may fail")
-            for pkg_name in pkg_names:
-                pkg_find_links = f"{index_url.rstrip('/')}/{pkg_name}/index.html"
-                pip_install_cmd.append(f"--find-links={pkg_find_links}")
-        else:
-            pip_install_cmd.append(f"--index-url={index_url}")
+        pip_install_cmd.append(f"--index-url={index_url}")
 
     if find_links:
         pip_install_cmd.append(f"--find-links={find_links}")
-
-    # When using find-links without a valid index-url, prevent fallback to PyPI.
-    # This applies when:
-    # - find_links is provided without index_url (artifact-only installs)
-    # - S3 fallback is used (we switched from --index-url to --find-links)
-    if using_s3_fallback or (find_links and not index_url):
-        pip_install_cmd.append("--no-index")
-        pip_install_cmd.append("--no-build-isolation")
 
     if pre:
         pip_install_cmd.append("--prerelease=allow" if use_uv else "--pre")

--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -15,11 +15,10 @@ There are a few modes this can be used in:
     python setup_venv.py .venv
     ```
 
-* To install the latest nightly rocm packages for gfx110X-all into the venv:
+* To install the latest nightly rocm packages into the venv:
 
     ```
-    python setup_venv.py .venv --packages rocm[libraries,devel] \
-        --index-name nightly --index-subdir gfx110X-all
+    python setup_venv.py .venv --packages rocm[libraries,devel,device-all] --index-name nightly
     ```
 
     This is roughly equivalent to:
@@ -28,7 +27,7 @@ There are a few modes this can be used in:
     python -m venv .venv
     source .venv/bin/activate
     python -m pip install --upgrade pip
-    python -m pip install rocm[libraries,devel] --index-url=https://.../gfx110X-all
+    python -m pip install rocm[libraries,devel,device-all] --index-url=https://rocm.nightlies.amd.com/whl-multi-arch/
     deactivate
     ```
 
@@ -39,10 +38,6 @@ Package installs are retried by default to cover that transient window. This
 behavior can be adjusted with the `--install-retry-timeout-seconds` and
 `--install-retry-wait-between-seconds` arguments.
 See https://github.com/ROCm/TheRock/issues/5455 for more details.
-
-TODO: update docs and args for multi-arch
-   * --index-url https://rocm.nightlies.amd.com/whl-multi-arch/
-   * refresh ROCM_INDEX_URLS_MAP
 """
 
 import argparse
@@ -60,10 +55,10 @@ from github_actions.github_actions_api import *
 is_windows = platform.system() == "Windows"
 
 ROCM_INDEX_URLS_MAP = {
-    "stable": "https://repo.amd.com/rocm/whl/",
-    "prerelease": "https://rocm.prereleases.amd.com/whl",
-    "nightly": "https://rocm.nightlies.amd.com/v2",
-    "dev": "https://rocm.devreleases.amd.com/v2",
+    "stable": "https://repo.amd.com/rocm/whl-multi-arch/",
+    "prerelease": "https://rocm.prereleases.amd.com/whl-multi-arch/",
+    "nightly": "https://rocm.nightlies.amd.com/whl-multi-arch/",
+    "dev": "https://rocm.devreleases.amd.com/whl-multi-arch/",
 }
 
 
@@ -211,7 +206,6 @@ def install_packages_into_venv(
     use_uv: bool = False,
     index_url: str | None = None,
     index_name: str | None = None,
-    index_subdir: str | None = None,
     find_links: str | None = None,
     pre: bool = False,
     disable_cache: bool = False,
@@ -225,8 +219,7 @@ def install_packages_into_venv(
         packages: The list of packages to install
         use_uv: True to use 'uv', uses 'pip' otherwise
         index_url: URL for '--index-url' command argument
-        index_name: Shorthand for a base index_url (e.g. 'nightly')
-        index_subdir: Subdirectory for 'index_url' or 'index_name'
+        index_name: Shorthand for an index_url (e.g. 'nightly')
         find_links: URL for '--find-links' command argument
         pre: Allow pre-release packages (pip: --pre, uv: --prerelease=allow)
         disable_cache: Disable package cache (pip: --no-cache-dir, uv: --no-cache)
@@ -254,10 +247,6 @@ def install_packages_into_venv(
         pip_install_cmd.append("--no-index")
         pip_install_cmd.append("--no-build-isolation")
     elif index_url:
-        # Join index with subdir.
-        if index_subdir:
-            index_url = f"{index_url.rstrip('/')}/{index_subdir.strip('/')}"
-
         pip_install_cmd.append(f"--index-url={index_url}")
 
     if find_links:
@@ -305,7 +294,6 @@ def run(args: argparse.Namespace):
             packages=args.packages.split(),
             use_uv=use_uv,
             index_url=args.index_url,
-            index_subdir=args.index_subdir,
             index_name=args.index_name,
             find_links=args.find_links,
             pre=args.pre,
@@ -318,34 +306,6 @@ def run(args: argparse.Namespace):
         activate_venv_in_gha(venv_dir)
     else:
         log_venv_activate_instructions(venv_dir)
-
-
-GFX_TARGET_REGEX = r'(gfx(?:\d{2,3}X|\d{3,4})(?:-[^<"/]*)?)</a>'
-
-
-def _scrape_rocm_index_subdirs() -> set[str] | None:
-    """Scrapes available subdirs from all known indexes, returns union of all."""
-    try:
-        import requests
-    except ImportError:
-        return
-
-    all_subdirs: set[str] = set()
-
-    for index_url in ROCM_INDEX_URLS_MAP.values():
-        index_url = index_url.rstrip("/") + "/"
-        try:
-            response = requests.get(index_url)
-            response.raise_for_status()
-        except Exception as e:
-            print(f"[ERROR]: fetching subdirs from {index_url} failed: {e}")
-            continue
-
-        # Extract gfx targets from <a> elements.
-        matches = re.findall(GFX_TARGET_REGEX, response.text)
-        all_subdirs.update(matches)
-
-    return all_subdirs if all_subdirs else None
 
 
 def main(argv: list[str]):
@@ -414,13 +374,13 @@ def main(argv: list[str]):
     install_options.add_argument(
         "--index-url",
         type=str,
-        help="Package index URL for pip --index-url (complete URL, or base URL with --index-subdir)",
+        help="Package index URL for pip --index-url",
     )
     install_options.add_argument(
         "--index-name",
         type=str,
         choices=["stable", "prerelease", "nightly", "dev"],
-        help="Shorthand for a named index (requires --index-subdir)",
+        help="Shorthand for a named index",
     )
     install_options.add_argument(
         "--find-links",
@@ -428,22 +388,10 @@ def main(argv: list[str]):
         help="Package location URL for pip --find-links (compatible with --index-url)",
     )
 
-    # Scrape available subdirs for --index-subdir choices.
-    available_subdirs = _scrape_rocm_index_subdirs()
-    install_options.add_argument(
-        "--index-subdir",
-        "--index-subdirectory",
-        type=str,
-        help="Index subdirectory, such as 'gfx110X-all'",
-        choices=available_subdirs,
-    )
-
     args = p.parse_args(argv)
 
     if args.venv_dir.exists() and not args.venv_dir.is_dir():
         p.error(f"venv_dir '{args.venv_dir}' exists and is not a directory")
-    if args.index_name and not args.index_subdir:
-        p.error("--index-subdir must be set when using --index-name")
     if args.install_retry_timeout_seconds < 0:
         p.error("--install-retry-timeout-seconds must be non-negative")
     if (

--- a/build_tools/tests/setup_venv_test.py
+++ b/build_tools/tests/setup_venv_test.py
@@ -16,9 +16,6 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 from setup_venv import (
     GFX_TARGET_REGEX,
     install_packages_into_venv,
-    check_dns_resolution,
-    apply_url_fallback,
-    scrape_package_names_from_index,
 )
 
 
@@ -148,7 +145,7 @@ class InstallPackagesTest(unittest.TestCase):
     @patch("setup_venv.find_venv_python_exe", return_value="python")
     @patch("setup_venv.run_command")
     def test_find_links_only(self, mock_run, mock_find_python):
-        """Passing just find_links uses --no-index to prevent PyPI fallback."""
+        """Passing just find_links uses it."""
         install_packages_into_venv(
             venv_dir=self.venv_dir,
             packages=["rocm"],
@@ -157,8 +154,6 @@ class InstallPackagesTest(unittest.TestCase):
 
         cmd = mock_run.call_args[0][0]
         self.assertIn("--find-links=https://bucket/run-123/index.html", cmd)
-        self.assertIn("--no-index", cmd)
-        self.assertIn("--no-build-isolation", cmd)
         self.assertFalse(any("--index-url" in str(a) for a in cmd))
 
     @patch("setup_venv.find_venv_python_exe", return_value="python")
@@ -234,88 +229,6 @@ class InstallPackagesTest(unittest.TestCase):
 
         self.assertEqual(mock_run.call_count, 1)
         mock_sleep.assert_not_called()
-
-
-class DnsFallbackTest(unittest.TestCase):
-    """Tests for DNS fallback functionality."""
-
-    def setUp(self):
-        self.venv_dir = Path(tempfile.mkdtemp())
-
-    def tearDown(self):
-        shutil.rmtree(self.venv_dir, ignore_errors=True)
-
-    @patch("setup_venv.check_dns_resolution")
-    def test_apply_url_fallback_when_cdn_unreachable(self, mock_dns):
-        """When CDN DNS fails but S3 is reachable, URL is substituted."""
-        # CDN fails, S3 succeeds
-        mock_dns.side_effect = lambda host: host.endswith("s3.amazonaws.com")
-
-        url = "https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu"
-        fallback_url, used_fallback = apply_url_fallback(url)
-
-        self.assertTrue(used_fallback)
-        self.assertEqual(
-            fallback_url,
-            "https://therock-nightly-python.s3.amazonaws.com/v2/gfx94X-dcgpu",
-        )
-
-    @patch("setup_venv.check_dns_resolution", return_value=True)
-    def test_apply_url_fallback_when_cdn_reachable(self, mock_dns):
-        """When CDN DNS succeeds, no fallback is used."""
-        url = "https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu"
-        fallback_url, used_fallback = apply_url_fallback(url)
-
-        self.assertFalse(used_fallback)
-        self.assertEqual(fallback_url, url)
-
-    @patch("setup_venv.check_dns_resolution", return_value=True)
-    def test_apply_url_fallback_unknown_domain(self, mock_dns):
-        """URLs without configured fallbacks are returned unchanged."""
-        url = "https://example.com/packages"
-        fallback_url, used_fallback = apply_url_fallback(url)
-
-        self.assertFalse(used_fallback)
-        self.assertEqual(fallback_url, url)
-
-    @patch("setup_venv.scrape_package_names_from_index")
-    @patch("setup_venv.apply_url_fallback")
-    @patch("setup_venv.find_venv_python_exe", return_value="python")
-    @patch("setup_venv.run_command")
-    def test_s3_fallback_uses_find_links_with_no_index(
-        self, mock_run, mock_find_python, mock_fallback, mock_scrape
-    ):
-        """When S3 fallback is used, --find-links and --no-index are added."""
-        mock_fallback.return_value = (
-            "https://therock-nightly-python.s3.amazonaws.com/v2/gfx94X-dcgpu",
-            True,  # using_s3_fallback=True
-        )
-        mock_scrape.return_value = ["rocm", "torch"]
-
-        install_packages_into_venv(
-            venv_dir=self.venv_dir,
-            packages=["rocm"],
-            index_name="nightly",
-            index_subdir="gfx94X-dcgpu",
-        )
-
-        cmd = mock_run.call_args[0][0]
-        # Should have --find-links for each scraped package
-        find_links = [arg for arg in cmd if "--find-links=" in arg]
-        self.assertEqual(len(find_links), 2)
-        self.assertIn(
-            "--find-links=https://therock-nightly-python.s3.amazonaws.com/v2/gfx94X-dcgpu/rocm/index.html",
-            cmd,
-        )
-        self.assertIn(
-            "--find-links=https://therock-nightly-python.s3.amazonaws.com/v2/gfx94X-dcgpu/torch/index.html",
-            cmd,
-        )
-        # Should have --no-index to prevent PyPI fallback
-        self.assertIn("--no-index", cmd)
-        self.assertIn("--no-build-isolation", cmd)
-        # Should NOT have --index-url
-        self.assertFalse(any("--index-url" in str(a) for a in cmd))
 
 
 class GfxRegexPatternTest(unittest.TestCase):

--- a/build_tools/tests/setup_venv_test.py
+++ b/build_tools/tests/setup_venv_test.py
@@ -13,10 +13,7 @@ import re
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
-from setup_venv import (
-    GFX_TARGET_REGEX,
-    install_packages_into_venv,
-)
+from setup_venv import install_packages_into_venv
 
 
 class InstallPackagesTest(unittest.TestCase):
@@ -103,8 +100,8 @@ class InstallPackagesTest(unittest.TestCase):
 
     @patch("setup_venv.find_venv_python_exe", return_value="python")
     @patch("setup_venv.run_command")
-    def test_index_url_complete(self, mock_run, mock_find_python):
-        """Passing index_url without index_subdir uses the URL as-is."""
+    def test_index_url(self, mock_run, mock_find_python):
+        """Passing index_url uses the URL as-is."""
         install_packages_into_venv(
             venv_dir=self.venv_dir,
             packages=["rocm"],
@@ -116,31 +113,16 @@ class InstallPackagesTest(unittest.TestCase):
 
     @patch("setup_venv.find_venv_python_exe", return_value="python")
     @patch("setup_venv.run_command")
-    def test_index_name_with_subdir(self, mock_run, mock_find_python):
-        """Passing index_name with index_subdir constructs full URL."""
+    def test_index_name(self, mock_run, mock_find_python):
+        """Passing index_name without index_url uses a known url."""
         install_packages_into_venv(
             venv_dir=self.venv_dir,
             packages=["rocm"],
             index_name="stable",
-            index_subdir="gfx110X-all",
         )
 
         cmd = mock_run.call_args[0][0]
-        self.assertIn("--index-url=https://repo.amd.com/rocm/whl/gfx110X-all", cmd)
-
-    @patch("setup_venv.find_venv_python_exe", return_value="python")
-    @patch("setup_venv.run_command")
-    def test_index_url_with_subdir(self, mock_run, mock_find_python):
-        """Passing index_url with index_subdir constructs full URL."""
-        install_packages_into_venv(
-            venv_dir=self.venv_dir,
-            packages=["rocm"],
-            index_url="https://example.com/base",
-            index_subdir="gfx94X-dcgpu",
-        )
-
-        cmd = mock_run.call_args[0][0]
-        self.assertIn("--index-url=https://example.com/base/gfx94X-dcgpu", cmd)
+        self.assertIn("--index-url=https://repo.amd.com/rocm/whl-multi-arch/", cmd)
 
     @patch("setup_venv.find_venv_python_exe", return_value="python")
     @patch("setup_venv.run_command")
@@ -229,23 +211,6 @@ class InstallPackagesTest(unittest.TestCase):
 
         self.assertEqual(mock_run.call_count, 1)
         mock_sleep.assert_not_called()
-
-
-class GfxRegexPatternTest(unittest.TestCase):
-    def test_valid_match(self):
-        html_snippet = '<a href="relpath/to/wherever/gfx103X-all">gfx103X-all</a><br><a href="/relpath/gfx120X-all">gfx120X-all</a>'
-        matches = re.findall(GFX_TARGET_REGEX, html_snippet)
-        self.assertEqual(["gfx103X-all", "gfx120X-all"], matches)
-
-    def test_match_without_suffix(self):
-        html_snippet = "<a>gfx940</a><br><a>gfx1030</a>"
-        matches = re.findall(GFX_TARGET_REGEX, html_snippet)
-        self.assertEqual(["gfx940", "gfx1030"], matches)
-
-    def test_invalid_match(self):
-        html_snippet = "<a>gfx94000</a><br><a>gfx1030X-dgpu</a>"
-        matches = re.findall(GFX_TARGET_REGEX, html_snippet)
-        self.assertEqual(matches, [])
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/setup_venv_test.py
+++ b/build_tools/tests/setup_venv_test.py
@@ -9,7 +9,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 import os
-import re
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 


### PR DESCRIPTION
## Motivation

* Progress on https://github.com/ROCm/TheRock/issues/3340.
  * Per-family python package releases have been discontinued in favor of multi-arch releases which use a single index like https://rocm.nightlies.amd.com/whl-multi-arch/ instead of per-family indexes like https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu/. We no longer need this script to support index subdirectories.
* Follow-up to https://github.com/ROCm/TheRock/issues/5285
  * DNS issues on `linux-gfx942-1gpu-ossci` runners were resolved, so we no longer need to fallback to `--find-links` S3 URLs instead of the CDN URLs. We may want to deliberately use S3 directly instead of the CDN to save on cloud billing charges, but that should be a direct decision outside of this script, not a fallback path.

## Test Plan

* Unit test coverage
* Locally ran `python build_tools/setup_venv.py test.venv --packages rocm[libraries,devel,device-gfx1100] --index-name nightly` on Windows and confirmed that it ran `pip install --index-url=https://rocm.nightlies.amd.com/whl-multi-arch/ 'rocm[libraries,devel,device-gfx1100]` in the venv it created which successfully installed packages
* Python package tests on the CI runs of this PR will use the script.
* Nightly release PyTorch tests will exercise the path where the DNS fallback was needed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
