### PR TITLE
Limit test_pytorch_wheels to only kpack (multi-arch) packages

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -447,7 +447,6 @@ jobs:
       # checkout_from_manifest.py --no-hipify --no-submodules so tests use the
       # exact source commit that produced the package under test.
       pytorch_git_ref: ${{ inputs.pytorch_git_ref }}
-      multi_arch: true
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref }}
 
@@ -499,7 +498,6 @@ jobs:
               "pytorch_git_repo": "${{ inputs.pytorch_git_ref == 'nightly' && 'pytorch/pytorch' || 'ROCm/pytorch' }}",
               "test_configs": "default distributed inductor",
               "tests_to_include": "",
-              "multi_arch": true,
               "repository": "${{ inputs.repository || github.repository }}",
               "ref": "${{ inputs.ref }}"
             }

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -481,6 +481,5 @@ jobs:
       # checkout_from_manifest.py --no-hipify --no-submodules so tests use the
       # exact source commit that produced the package under test.
       pytorch_git_ref: ${{ inputs.pytorch_git_ref }}
-      multi_arch: true
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -17,13 +17,10 @@ on:
         type: string
         default: "linux-gfx942-1gpu-ccs-csp-ossci-rocm"
       package_index_url:
-        description: >-
-          Base Python package index URL to test.
-          Per-family: nightly/dev URL with a "v2" or "v2-staging" subdir (without a GPU family subdir).
-          Multi-arch: unified index URL (e.g. "https://rocm.nightlies.amd.com/whl-multi-arch/").
+        description: Python package index URL to test, typically nightly/dev URL with a "whl-multi-arch" subdir
         required: true
         type: string
-        default: "https://rocm.nightlies.amd.com/v2"
+        default: "https://rocm.nightlies.amd.com/whl-multi-arch/"
       python_version:
         required: true
         type: string
@@ -55,12 +52,6 @@ on:
           - "single"
           - "all"
         default: "single"
-      multi_arch:
-        description: >-
-          Install from a multi-arch index using device extras
-          (e.g. torch[device-gfx942]) instead of per-family index subdirs.
-        type: boolean
-        default: false
 
   workflow_call:
     inputs:
@@ -94,12 +85,6 @@ on:
           GPUs visible at once.
         type: string
         default: "single"
-      multi_arch:
-        description: >-
-          Install from a multi-arch index using device extras
-          (e.g. torch[device-gfx942]) instead of per-family index subdirs.
-        type: boolean
-        default: false
       repository:
         description: "Repository to checkout. Otherwise, defaults to `github.repository`."
         type: string
@@ -149,7 +134,6 @@ jobs:
       # select GPU-specific device packages. Expand the family to get the
       # comma-separated device extras string for pip install.
       - name: Expand GPU family to device extras
-        if: ${{ inputs.multi_arch }}
         id: expand
         run: |
           python build_tools/github_actions/expand_amdgpu_families.py \
@@ -198,18 +182,10 @@ jobs:
       - name: Set up virtual environment
         timeout-minutes: 15
         run: |
-          if [ "${{ inputs.multi_arch }}" = "true" ]; then
-            python build_tools/setup_venv.py ${VENV_DIR} \
-              --packages "torch[${{ steps.expand.outputs.device_extras }}]==${{ inputs.torch_version }}" \
-              --index-url=${{ inputs.package_index_url }} \
-              --activate-in-future-github-actions-steps
-          else
-            python build_tools/setup_venv.py ${VENV_DIR} \
-              --packages torch==${{ inputs.torch_version }} \
-              --index-url=${{ inputs.package_index_url }} \
-              --index-subdir=${{ inputs.amdgpu_family }} \
-              --activate-in-future-github-actions-steps
-          fi
+          python build_tools/setup_venv.py ${VENV_DIR} \
+            --packages "torch[${{ steps.expand.outputs.device_extras }}]==${{ inputs.torch_version }}" \
+            --index-url=${{ inputs.package_index_url }} \
+            --activate-in-future-github-actions-steps
 
       - name: Install test requirements
         run: |

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -21,10 +21,10 @@ on:
         type: string
         default: "linux-gfx942-8gpu-ossci-rocm"
       package_index_url:
-        description: Base Python package index URL to test, typically nightly/dev URL with a "v2" or "v2-staging" subdir (without a GPU family subdir)
+        description: Python package index URL to test, typically nightly/dev URL with a "whl-multi-arch" subdir
         required: true
         type: string
-        default: "https://rocm.nightlies.amd.com/v2-staging"
+        default: "https://rocm.nightlies.amd.com/whl-multi-arch/"
       python_version:
         required: true
         type: string
@@ -73,12 +73,6 @@ on:
           - "single"
           - "all"
         default: "auto"
-      multi_arch:
-        description: >-
-          Install from a multi-arch index using device extras
-          (e.g. torch[device-gfx942]) instead of per-family index subdirs.
-        type: boolean
-        default: false
       repository:
         description: "Repository to checkout. Otherwise, defaults to `github.repository`."
         type: string
@@ -113,12 +107,6 @@ on:
       pytorch_git_repo:
         type: string
         default: "pytorch/pytorch"
-      multi_arch:
-        description: >-
-          Install from a multi-arch index using device extras
-          (e.g. torch[device-gfx942]) instead of per-family index subdirs.
-        type: boolean
-        default: false
       repository:
         description: "Repository to checkout. Otherwise, defaults to `github.repository`."
         type: string
@@ -227,7 +215,6 @@ jobs:
       # select GPU-specific device packages. Expand the family to get the
       # comma-separated device extras string for pip install.
       - name: Expand GPU family to device extras
-        if: ${{ inputs.multi_arch }}
         id: expand
         run: |
           python build_tools/github_actions/expand_amdgpu_families.py \
@@ -256,18 +243,10 @@ jobs:
       - name: Set up virtual environment
         timeout-minutes: 15
         run: |
-          if [ "${{ inputs.multi_arch }}" = "true" ]; then
-            python build_tools/setup_venv.py ${VENV_DIR} \
-              --packages "torch[${{ steps.expand.outputs.device_extras }}]==${{ inputs.torch_version }} rocm[devel,${{ steps.expand.outputs.device_extras }}]" \
-              --index-url=${{ inputs.package_index_url }} \
-              --activate-in-future-github-actions-steps
-          else
-            python build_tools/setup_venv.py ${VENV_DIR} \
-              --packages "torch==${{ inputs.torch_version }} rocm[devel]" \
-              --index-url=${{ inputs.package_index_url }} \
-              --index-subdir=${{ inputs.amdgpu_family }} \
-              --activate-in-future-github-actions-steps
-          fi
+          python build_tools/setup_venv.py ${VENV_DIR} \
+            --packages "torch[${{ steps.expand.outputs.device_extras }}]==${{ inputs.torch_version }} rocm[devel,${{ steps.expand.outputs.device_extras }}]" \
+            --index-url=${{ inputs.package_index_url }} \
+            --activate-in-future-github-actions-steps
 
       - name: Initialize ROCm SDK and configure environment
         run: |


### PR DESCRIPTION
## Motivation

* Progress on https://github.com/ROCm/TheRock/issues/3340
* Partially unblocks https://github.com/ROCm/TheRock/pull/6550

We only publish multi-arch packages now, and per-family CI/CD is being removed. This trims pytorch test workflow code to only use the kpack (multi-arch) path.

## Technical Details

> [!IMPORTANT]
> We will also need to remove the `multi_arch` input from the wrapper workflow in https://github.com/ROCm/rockrel/blob/main/.github/workflows/test_pytorch_wheels_full.yml
> * https://github.com/ROCm/rockrel/pull/76

Note that we can't quite delete the `KPACK_SPLIT_ARTIFACTS` flag altogether here https://github.com/ROCm/TheRock/blob/710812f49673c52777894c0a6fed0ce9d526ac12/FLAGS.cmake#L18-L22 due to https://github.com/ROCm/TheRock/issues/4769, and this code that is being used in rocm-libraries and rocm-systems: https://github.com/ROCm/TheRock/blob/710812f49673c52777894c0a6fed0ce9d526ac12/build_tools/github_actions/build_configure.py#L111-L117

## Test Plan

Manually triggered run at https://github.com/ROCm/TheRock/actions/runs/29376216394/job/87230121159 installed packages as expected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
