### PR TITLE
Limit test_rocm_wheels to only kpack (multi-arch) packages

### DIFF
--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -277,7 +277,6 @@ jobs:
         }}
       python_version: ${{ matrix.python_version }}
       rocm_version: ${{ inputs.rocm_package_version }}
-      kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
       container_image_name: ${{ matrix.container_image_name }}
       container_image_url: ${{ matrix.container_image_url }}
       repository: ${{ inputs.repository }}

--- a/.github/workflows/multi_arch_ci_windows.yml
+++ b/.github/workflows/multi_arch_ci_windows.yml
@@ -192,7 +192,6 @@ jobs:
         }}
       python_version: ${{ matrix.python_version }}
       rocm_version: ${{ inputs.rocm_package_version }}
-      kpack_split: ${{ needs.build_python_packages.outputs.kpack_split }}
       container_image_name: ${{ matrix.container_image_name }}
       container_image_url: ${{ matrix.container_image_url }}
       repository: ${{ inputs.repository }}

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -16,15 +16,13 @@ on:
         required: true
         type: string
         default: "linux-gfx942-1gpu-ccs-csp-ossci-rocm"
-      package_index_url_base:
+      package_index_url:
         description: >-
-          Base Python package index URL. For legacy per-family builds, this is
-          without the GPU family subdir. For kpack-split builds, this is the
-          full flat index URL.
+          Full Python package index URL for use with --index-url.
         type: string
         default: "https://rocm.nightlies.amd.com/v2"
       package_find_links_url:
-        description: Full Python package index URL for use with --find-links (usually instead of package_index_url_base)
+        description: Full Python package index URL for use with --find-links (usually instead of package_index_url)
         type: string
       python_version:
         required: true
@@ -61,11 +59,9 @@ on:
       test_runs_on:
         required: true
         type: string
-      package_index_url_base:
+      package_index_url:
         description: >-
-          Base Python package index URL. For legacy per-family builds, this is
-          without the GPU family subdir. For kpack-split builds, this is the
-          full flat index URL.
+          Full Python package index URL for use with --index-url.
         type: string
       package_find_links_url:
         type: string
@@ -75,10 +71,6 @@ on:
       rocm_version:
         required: true
         type: string
-      kpack_split:
-        description: "'true' if this is a kpack-split flat build."
-        type: string
-        default: "false"
       container_image_name:
         description: >-
           Short, human-readable label for the container image (e.g. 'ubuntu24.04',
@@ -145,7 +137,6 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - name: Compute ROCm device extras
-        if: ${{ inputs.kpack_split == 'true' }}
         id: device_extras
         run: |
           python build_tools/github_actions/expand_amdgpu_families.py \
@@ -160,20 +151,11 @@ jobs:
           if [ -n "${{ steps.device_extras.outputs.device_extras }}" ]; then
             pkg="${pkg%]},${{ steps.device_extras.outputs.device_extras }}]"
           fi
-          if [ "${{ inputs.kpack_split }}" = "true" ]; then
-            python build_tools/setup_venv.py ${VENV_DIR} \
-              --packages "${pkg}==${{ inputs.rocm_version }}" \
-              --index-url=${{ inputs.package_index_url_base }} \
-              --find-links=${{ inputs.package_find_links_url }} \
-              --activate-in-future-github-actions-steps
-          else
-            python build_tools/setup_venv.py ${VENV_DIR} \
-              --packages "${pkg}==${{ inputs.rocm_version }}" \
-              --index-url=${{ inputs.package_index_url_base }} \
-              --index-subdir=${{ inputs.amdgpu_family }} \
-              --find-links=${{ inputs.package_find_links_url }} \
-              --activate-in-future-github-actions-steps
-          fi
+          python build_tools/setup_venv.py ${VENV_DIR} \
+            --packages "${pkg}==${{ inputs.rocm_version }}" \
+            --index-url=${{ inputs.package_index_url }} \
+            --find-links=${{ inputs.package_find_links_url }} \
+            --activate-in-future-github-actions-steps
 
       - name: Show installed packages (libraries)
         if: ${{ !cancelled() && steps.install_libraries.outcome == 'success' }}
@@ -195,18 +177,10 @@ jobs:
           if [ -n "${{ steps.device_extras.outputs.device_extras }}" ]; then
             pkg="${pkg%]},${{ steps.device_extras.outputs.device_extras }}]"
           fi
-          if [ "${{ inputs.kpack_split }}" = "true" ]; then
-            python build_tools/setup_venv.py ${VENV_DIR} \
-              --packages "${pkg}==${{ inputs.rocm_version }}" \
-              --index-url=${{ inputs.package_index_url_base }} \
-              --find-links=${{ inputs.package_find_links_url }}
-          else
-            python build_tools/setup_venv.py ${VENV_DIR} \
-              --packages "${pkg}==${{ inputs.rocm_version }}" \
-              --index-url=${{ inputs.package_index_url_base }} \
-              --index-subdir=${{ inputs.amdgpu_family }} \
-              --find-links=${{ inputs.package_find_links_url }}
-          fi
+          python build_tools/setup_venv.py ${VENV_DIR} \
+            --packages "${pkg}==${{ inputs.rocm_version }}" \
+            --index-url=${{ inputs.package_index_url }} \
+            --find-links=${{ inputs.package_find_links_url }}
 
       - name: Show installed packages (libraries,devel)
         if: ${{ !cancelled() && steps.install_devel.outcome == 'success' }}

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -20,7 +20,7 @@ on:
         description: >-
           Full Python package index URL for use with --index-url.
         type: string
-        default: "https://rocm.nightlies.amd.com/v2"
+        default: "https://rocm.nightlies.amd.com/whl-multi-arch/"
       package_find_links_url:
         description: Full Python package index URL for use with --find-links (usually instead of package_index_url)
         type: string


### PR DESCRIPTION
## Motivation

* Progress on https://github.com/ROCm/TheRock/issues/3340
* Partially unblocks https://github.com/ROCm/TheRock/pull/6550

We only publish multi-arch packages now, and per-family CI/CD is being removed. This trims rocm python test workflow code to only use the kpack (multi-arch) path.

## Technical Details

Note that we can't quite delete the `KPACK_SPLIT_ARTIFACTS` flag altogether here https://github.com/ROCm/TheRock/blob/710812f49673c52777894c0a6fed0ce9d526ac12/FLAGS.cmake#L18-L22 due to https://github.com/ROCm/TheRock/issues/4769, and this code that is being used in rocm-libraries and rocm-systems: https://github.com/ROCm/TheRock/blob/710812f49673c52777894c0a6fed0ce9d526ac12/build_tools/github_actions/build_configure.py#L111-L117

## Test Plan

* CI on this PR should run python package tests
* Manually triggered run using prebuilt artifacts: https://github.com/ROCm/TheRock/actions/runs/29376148751 installed packages as expected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
