### PR TITLE
feat(ci): Run full JAX test suite

### DIFF
--- a/.github/workflows/multi_arch_build_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels.yml
@@ -4,7 +4,7 @@
 # Reusable single-build workflow for the Linux JAX wheel flow.
 #
 # This workflow is called once per release matrix cell from
-# test_linux_jax_wheels_partial.yml
+# multi_arch_release_linux_jax_wheels.yml
 #
 # Built shape:
 #   - One build/ci_build invocation for one python_version and jax_ref
@@ -280,7 +280,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/test_linux_jax_wheels_partial.yml
+    uses: ./.github/workflows/test_multi_arch_linux_jax_wheels.yml
     with:
       test_amdgpu_family: ${{ inputs.test_amdgpu_family }}
       package_index_url: ${{ needs.build_jax_wheels.outputs.package_index_url }}

--- a/.github/workflows/test_multi_arch_linux_jax_wheels.yml
+++ b/.github/workflows/test_multi_arch_linux_jax_wheels.yml
@@ -142,6 +142,8 @@ jobs:
         --group-add video
         --user root
         --env-file /etc/podinfo/gha-gpu-isolation-settings
+        -e KUBE_CPU_REQUEST
+        -e KUBE_MEMORY_REQUEST
         --dns 8.8.8.8
         --dns 8.8.4.4
 
@@ -227,42 +229,20 @@ jobs:
             --amdgpu-families "${{ inputs.test_amdgpu_family }}" \
             --output-mode=device-extras
 
+      # rocm[libraries] alone, since that is what RELEASES.md tells users to
+      # install: anything the wheels need belongs there, not in [devel].
       - name: Install ROCm packages
+        env:
+          ROCM_PACKAGES: rocm[libraries${{ steps.expand.outputs.device_extras && format(',{0}', steps.expand.outputs.device_extras) || '' }}]==${{ inputs.rocm_version }}
         run: |
-          python -m pip install --upgrade pip
+          python build_tools/setup_venv.py "${VIRTUAL_ENV}" \
+            --packages "${ROCM_PACKAGES}" \
+            --find-links "${ROCM_PACKAGE_FIND_LINKS_URL}"
 
-          pkg="rocm[libraries]"
-          if [ -n "${{ steps.expand.outputs.device_extras }}" ]; then
-            pkg="${pkg%]},${{ steps.expand.outputs.device_extras }}]"
-          fi
-
-          python -m pip install --pre \
-            --find-links "${ROCM_PACKAGE_FIND_LINKS_URL}" \
-            "${pkg}==${{ inputs.rocm_version }}"
-
-          echo "ROCM_ROOT=$(rocm-sdk path --root)" >> "$GITHUB_ENV"
-
+      # Package names, versions and the index arrive as env vars set above.
       - name: Install JAX wheels from package index
         run: |
-          echo "Installing from:"
-          echo "  ${WHEEL_INDEX_URL}"
-
-          pip install \
-            --index-url "${WHEEL_INDEX_URL}" \
-            "${JAX_PLUGIN_PACKAGE}==${JAX_PLUGIN_VERSION}" \
-            "${JAX_PJRT_PACKAGE}==${JAX_PJRT_VERSION}"
-
-          if [ -n "${JAXLIB_VERSION}" ]; then
-            pip install \
-              --index-url "${WHEEL_INDEX_URL}" \
-              "jaxlib==${JAXLIB_VERSION}"
-
-            pip install "jax==${JAX_VERSION}"
-          else
-            pip install \
-              "jax==${JAX_VERSION}" \
-              "jaxlib==${JAX_VERSION}"
-          fi
+          python external-builds/jax/install_jax_wheels.py
 
       # jaxlib comes from upstream PyPI and only knows the ROCm majors that
       # existed when it was released, so it has to be taught about newer ones.
@@ -271,41 +251,38 @@ jobs:
           python external-builds/jax/patch_installed_jax_rocm_plugin_names.py \
             --plugin-package "${JAX_PLUGIN_PACKAGE}"
 
-      - name: Run JAX tests
-        timeout-minutes: 60
-        env:
-          # Avoid large upfront GPU memory reservation.
-          XLA_PYTHON_CLIENT_PREALLOCATE: "false"
-
-          # Set XLA allocator. JAX 0.10.2 uses the default allocator; all
-          # other releases keep the platform allocator.
-          XLA_PYTHON_CLIENT_ALLOCATOR: ${{ inputs.jax_ref == 'rocm-jaxlib-v0.10.2' && 'default' || 'platform' }}
-
-          # JAX 0.10.2 only: ROCm/HIP runtime tuning to avoid a pytest
-          # slowdown/hang; other releases keep the runtime defaults.
-          # TODO:(magaonka-amd) remove these as soon as fixes from corresponding system teams lands.
-          ROCPROFILER_QUEUE_INTERPOSITION: ${{ inputs.jax_ref == 'rocm-jaxlib-v0.10.2' && '0' }}
-          DEBUG_HIP_DYNAMIC_QUEUES: ${{ inputs.jax_ref == 'rocm-jaxlib-v0.10.2' && '0' }}
-          HSA_NO_SCRATCH_RECLAIM: ${{ inputs.jax_ref == 'rocm-jaxlib-v0.10.2' && '1' }}
-
-          # Reduce compilation/autotune memory pressure.
-          XLA_FLAGS: >-
-            --xla_gpu_force_compilation_parallelism=1
-            --xla_gpu_enable_nccl_comm_splitting=false
-            --xla_gpu_enable_command_buffer=
-
+      # The device serial numbers it prints identify a recurring bad device
+      # across runs, since the runner and the device index change every time.
+      - name: Driver / GPU sanity check
+        timeout-minutes: 3
         run: |
-          set -euxo pipefail
+          python build_tools/print_driver_gpu_info.py
 
-          unset ROCM_ROOT
-          unset HIP_DEVICE_LIB_PATH
-          unset JAX_ROCM_PLUGIN_INTERNAL_BITCODE_PATH
-          unset JAX_ROCM_PLUGIN_INTERNAL_LLD_PATH
+      - name: Install JAX test requirements
+        run: |
+          python external-builds/jax/install_jax_test_requirements.py \
+            --jax-dir jax \
+            --python-version "${PYTHON_VERSION}"
 
-          python -c "import jax; print(jax.local_devices())"
+      # The runner owns the test environment, the skip lists, the pod's CPU
+      # allocation and both layers of retry, so that the same command
+      # reproduces this job locally. See the comments in the script.
+      - name: Run JAX tests
+        # The suite runs 35-70 min across versions, so 60 left no headroom: one
+        # job reached 100% of the tests and was still killed by the timeout.
+        timeout-minutes: 120
+        run: |
+          python external-builds/jax/run_jax_tests.py \
+            --jax-dir jax \
+            --jax-ref "${{ inputs.jax_ref }}" \
+            --amdgpu-family "${{ inputs.test_amdgpu_family }}"
 
-          echo "=== Starting full test suite ==="
-          pytest jax/tests/multi_device_test.py -q --log-cli-level=INFO
-          pytest jax/tests/core_test.py -q --log-cli-level=INFO
-          pytest jax/tests/util_test.py -q --log-cli-level=INFO
-          pytest jax/tests/scipy_stats_test.py -q --log-cli-level=INFO
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jax-test-logs-${{ inputs.jax_ref }}-py${{ inputs.python_version }}-${{ inputs.test_amdgpu_family }}
+          path: |
+            jax/logs/
+            jax/test-artifacts/
+          if-no-files-found: ignore

--- a/build_tools/github_actions/tests/jax_install_scripts_test.py
+++ b/build_tools/github_actions/tests/jax_install_scripts_test.py
@@ -1,0 +1,113 @@
+"""
+Unit tests for external-builds/jax/install_jax_wheels.py and
+external-builds/jax/install_jax_test_requirements.py
+"""
+
+import argparse
+import os
+import sys
+import unittest
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+JAX_DIR = THIS_DIR.parents[2] / "external-builds" / "jax"
+
+sys.path.insert(0, os.fspath(JAX_DIR))
+
+import install_jax_test_requirements as requirements
+import install_jax_wheels as wheels
+
+INDEX_URL = "https://rocm.nightlies.amd.com/whl-multi-arch/"
+
+
+def wheel_args(**overrides) -> argparse.Namespace:
+    values = dict(
+        index_url=INDEX_URL,
+        plugin_package="jax_rocm10_plugin",
+        pjrt_package="jax_rocm10_pjrt",
+        plugin_version="0.11.0",
+        pjrt_version="0.11.0",
+        jax_version="0.11.0",
+        jaxlib_version="",
+    )
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+class InstallJaxWheelsTest(unittest.TestCase):
+    def test_plugin_and_pjrt_come_from_the_index(self):
+        first = wheels.install_commands(wheel_args())[0]
+
+        self.assertIn("--index-url", first)
+        self.assertEqual(first[first.index("--index-url") + 1], INDEX_URL)
+        self.assertIn("jax_rocm10_plugin==0.11.0", first)
+        self.assertIn("jax_rocm10_pjrt==0.11.0", first)
+
+    def test_without_a_built_jaxlib_both_come_from_pypi(self):
+        commands = wheels.install_commands(wheel_args())
+
+        self.assertEqual(len(commands), 2)
+        self.assertNotIn("--index-url", commands[1])
+        self.assertIn("jax==0.11.0", commands[1])
+        self.assertIn("jaxlib==0.11.0", commands[1])
+
+    def test_a_built_jaxlib_comes_from_the_index_and_jax_from_pypi(self):
+        commands = wheels.install_commands(
+            wheel_args(jaxlib_version="0.11.0.dev20260804")
+        )
+
+        self.assertEqual(len(commands), 3)
+        self.assertIn("--index-url", commands[1])
+        self.assertIn("jaxlib==0.11.0.dev20260804", commands[1])
+        # jax itself is never built here, so it always comes from PyPI.
+        self.assertNotIn("--index-url", commands[2])
+        self.assertIn("jax==0.11.0", commands[2])
+
+    def test_no_index_url_leaves_the_flag_out(self):
+        commands = wheels.install_commands(wheel_args(index_url=""))
+
+        for command in commands:
+            self.assertNotIn("--index-url", command)
+
+    def test_missing_arguments_are_rejected(self):
+        with self.assertRaises(SystemExit):
+            wheels.main(["--plugin-package", "jax_rocm10_plugin"])
+
+
+class InstallTestRequirementsTest(unittest.TestCase):
+    def test_lock_file_name_per_python_version(self):
+        self.assertEqual(
+            requirements.lock_file(Path("jax"), "3.12").name,
+            "requirements_lock_3_12.txt",
+        )
+
+    def test_commands_use_the_checkout_and_the_lock_file(self):
+        commands = requirements.install_commands(Path("jax"), "3.12")
+
+        joined = [" ".join(command) for command in commands]
+        self.assertTrue(any(requirements.UV_REQUIREMENT in c for c in joined))
+        self.assertTrue(
+            any(
+                os.path.join("jax", "build", "test-requirements.txt") in c
+                for c in joined
+            )
+        )
+        self.assertTrue(any("requirements_lock_3_12.txt" in c for c in joined))
+        # The fresh-process retry reads the reports this writes.
+        self.assertTrue(any(requirements.REPORT_REQUIREMENT in c for c in joined))
+
+    def test_uv_is_installed_before_it_is_used(self):
+        commands = requirements.install_commands(Path("jax"), "3.12")
+
+        first = " ".join(commands[0])
+        self.assertIn("pip", first)
+        self.assertIn(requirements.UV_REQUIREMENT, first)
+        self.assertIn("uv", commands[1])
+
+    def test_python_version_is_required(self):
+        with self.assertRaises(SystemExit):
+            requirements.main(["--jax-dir", "jax"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/github_actions/tests/jax_skip_tests_test.py
+++ b/build_tools/github_actions/tests/jax_skip_tests_test.py
@@ -1,0 +1,129 @@
+"""
+Unit tests for external-builds/jax/skip_tests/create_skip_tests.py
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+JAX_DIR = THIS_DIR.parents[2] / "external-builds" / "jax"
+
+sys.path.insert(0, os.fspath(JAX_DIR))
+
+from skip_tests import create_skip_tests
+
+# The versions whose convolution tests are skipped on gfx94X, and one that has
+# no data file at all.
+FILTERED_VERSION = "0.10.2"
+UNFILTERED_VERSION = "0.11.0"
+
+GFX94_FAMILY = "gfx94X-dcgpu"
+
+
+class DataFilesTest(unittest.TestCase):
+    def test_generic_file_always_applies(self):
+        files = create_skip_tests.data_files("")
+
+        self.assertEqual([f.name for f in files], ["generic.py"])
+
+    def test_version_file_is_added_when_it_exists(self):
+        files = create_skip_tests.data_files(FILTERED_VERSION)
+
+        self.assertEqual(
+            [f.name for f in files], ["generic.py", f"jax_{FILTERED_VERSION}.py"]
+        )
+
+    def test_unknown_version_contributes_nothing(self):
+        # Adding a JAX version to CI must not require a data file here.
+        files = create_skip_tests.data_files("9.9.9")
+
+        self.assertEqual([f.name for f in files], ["generic.py"])
+
+    def test_all_loads_every_version_file(self):
+        files = create_skip_tests.data_files("all")
+
+        self.assertEqual(files[0].name, "generic.py")
+        self.assertGreater(len(files), 1)
+        for path in files[1:]:
+            self.assertTrue(path.name.startswith("jax_"))
+
+
+class KeywordExpressionTest(unittest.TestCase):
+    def test_no_entries_gives_no_expression(self):
+        self.assertEqual(
+            create_skip_tests.keyword_expression(UNFILTERED_VERSION, GFX94_FAMILY), ""
+        )
+
+    def test_family_selects_the_section(self):
+        expression = create_skip_tests.keyword_expression(
+            FILTERED_VERSION, GFX94_FAMILY
+        )
+
+        self.assertIn("not conv", expression)
+
+    def test_other_family_is_unaffected(self):
+        self.assertEqual(
+            create_skip_tests.keyword_expression(FILTERED_VERSION, "gfx110X-all"), ""
+        )
+
+    def test_arch_matches_the_family_section(self):
+        # A section named gfx94 also covers a caller naming the arch directly.
+        expression = create_skip_tests.keyword_expression(FILTERED_VERSION, "gfx942")
+
+        self.assertIn("not conv", expression)
+
+    def test_missing_family_matches_nothing(self):
+        self.assertEqual(create_skip_tests.keyword_expression(FILTERED_VERSION, ""), "")
+
+    def test_unless_keeps_tests_the_deny_would_catch(self):
+        expression = create_skip_tests.keyword_expression(
+            FILTERED_VERSION, GFX94_FAMILY
+        )
+
+        # -k matches substrings, so conv also catches convert and conversion.
+        self.assertIn("((not conv) or convert or conversion)", expression)
+
+    def test_entries_are_joined_with_and(self):
+        expression = create_skip_tests.keyword_expression(
+            FILTERED_VERSION, GFX94_FAMILY
+        )
+
+        self.assertIn("and not sumpool", expression)
+        self.assertIn("and not polymul", expression)
+
+    def test_debug_selects_only_the_skipped_tests(self):
+        expression = create_skip_tests.keyword_expression(
+            FILTERED_VERSION, GFX94_FAMILY, debug=True
+        )
+
+        self.assertNotIn("not ", expression)
+        self.assertIn("conv or ", expression)
+        self.assertIn("polymul", expression)
+
+
+class DataFileContentsTest(unittest.TestCase):
+    def test_every_entry_has_a_deny_keyword(self):
+        for path in create_skip_tests.data_files("all"):
+            for section, entries in create_skip_tests._load_data_file(path).items():
+                for entry in entries.get("keywords", []):
+                    with self.subTest(file=path.name, section=section, entry=entry):
+                        self.assertIn("deny", entry)
+                        self.assertIsInstance(entry["deny"], str)
+                        self.assertIsInstance(entry.get("unless", []), list)
+
+
+class MainTest(unittest.TestCase):
+    def test_prints_the_expression(self):
+        # Smoke test of the CLI used to inspect a configuration locally.
+        self.assertEqual(
+            create_skip_tests.main(
+                ["--jax-version", UNFILTERED_VERSION, "--amdgpu-family", GFX94_FAMILY]
+            ),
+            0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/github_actions/tests/list_pytest_failed_tests_test.py
+++ b/build_tools/github_actions/tests/list_pytest_failed_tests_test.py
@@ -1,0 +1,134 @@
+"""
+Unit tests for test_tools/list_pytest_failed_tests.py
+"""
+
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+TEST_TOOLS_DIR = THIS_DIR.parents[2] / "test_tools"
+
+sys.path.insert(0, os.fspath(TEST_TOOLS_DIR))
+
+import list_pytest_failed_tests as lister
+
+
+def write_report(directory: Path, name: str, tests: list[dict]) -> Path:
+    path = directory / name
+    path.write_text(json.dumps({"tests": tests}))
+    return path
+
+
+class FailedTestsTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_reports_failed_and_error_outcomes(self):
+        report = write_report(
+            self.dir,
+            "report.json",
+            [
+                {"nodeid": "tests/a_test.py::test_pass", "outcome": "passed"},
+                {"nodeid": "tests/a_test.py::test_fail", "outcome": "failed"},
+                {"nodeid": "tests/a_test.py::test_error", "outcome": "error"},
+                {"nodeid": "tests/a_test.py::test_skip", "outcome": "skipped"},
+            ],
+        )
+
+        self.assertEqual(
+            lister.failed_tests(report),
+            ["tests/a_test.py::test_fail", "tests/a_test.py::test_error"],
+        )
+
+    def test_keeps_parametrized_nodeids_intact(self):
+        # Parametrized ids contain spaces, and a retry passes each as one
+        # argument, so they must survive unsplit.
+        nodeid = "tests/lax_test.py::LaxTest::test_conv[shape=(2, 3)]"
+        report = write_report(
+            self.dir, "report.json", [{"nodeid": nodeid, "outcome": "failed"}]
+        )
+
+        self.assertEqual(lister.failed_tests(report), [nodeid])
+
+    def test_report_without_tests_key(self):
+        path = self.dir / "empty.json"
+        path.write_text(json.dumps({"exitcode": 1}))
+
+        self.assertEqual(lister.failed_tests(path), [])
+
+
+class MainTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def run_main(self, argv: list[str]) -> tuple[int, str]:
+        out = io.StringIO()
+        with redirect_stdout(out):
+            code = lister.main(argv)
+        return code, out.getvalue()
+
+    def test_combines_reports_and_skips_missing_ones(self):
+        first = write_report(
+            self.dir,
+            "single.json",
+            [{"nodeid": "tests/a_test.py::test_one", "outcome": "failed"}],
+        )
+        second = write_report(
+            self.dir,
+            "multi.json",
+            [{"nodeid": "tests/b_test.py::test_two", "outcome": "failed"}],
+        )
+        missing = self.dir / "absent.json"
+
+        code, out = self.run_main(
+            [os.fspath(first), os.fspath(missing), os.fspath(second)]
+        )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(
+            out.split(), ["tests/a_test.py::test_one", "tests/b_test.py::test_two"]
+        )
+
+    def test_refuses_to_retry_more_than_max_tests(self):
+        report = write_report(
+            self.dir,
+            "single.json",
+            [
+                {"nodeid": f"tests/a_test.py::test_{i}", "outcome": "failed"}
+                for i in range(5)
+            ],
+        )
+
+        code, out = self.run_main([os.fspath(report), "--max-tests", "4"])
+
+        self.assertEqual(code, 1)
+        self.assertEqual(out.strip(), "")
+
+    def test_max_tests_zero_disables_the_cap(self):
+        report = write_report(
+            self.dir,
+            "single.json",
+            [
+                {"nodeid": f"tests/a_test.py::test_{i}", "outcome": "failed"}
+                for i in range(5)
+            ],
+        )
+
+        code, out = self.run_main([os.fspath(report), "--max-tests", "0"])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(len(out.split()), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/github_actions/tests/run_jax_tests_test.py
+++ b/build_tools/github_actions/tests/run_jax_tests_test.py
@@ -1,0 +1,792 @@
+"""
+Unit tests for external-builds/jax/run_jax_tests.py
+"""
+
+import json
+import os
+import platform
+import shlex
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+THIS_DIR = Path(__file__).resolve().parent
+JAX_DIR = THIS_DIR.parents[2] / "external-builds" / "jax"
+
+sys.path.insert(0, os.fspath(JAX_DIR))
+
+import run_jax_tests as runner
+
+GFX94_FAMILY = "gfx94X-dcgpu"
+
+
+class JaxVersionFromRefTest(unittest.TestCase):
+    def test_strips_the_ref_prefix(self):
+        self.assertEqual(runner.jax_version_from_ref("rocm-jaxlib-v0.11.0"), "0.11.0")
+
+    def test_leaves_a_bare_version_alone(self):
+        self.assertEqual(runner.jax_version_from_ref("0.11.0"), "0.11.0")
+
+    def test_empty_ref(self):
+        self.assertEqual(runner.jax_version_from_ref(""), "")
+
+
+class PytestAddoptsTest(unittest.TestCase):
+    def test_in_process_reruns(self):
+        opts = shlex.split(runner.pytest_addopts("0.11.0", GFX94_FAMILY, 2))
+
+        self.assertEqual(
+            opts, ["--reruns", "2", "--reruns-delay", "5", "--only-rerun", "INTERNAL"]
+        )
+
+    def test_zero_reruns_leaves_them_out(self):
+        self.assertEqual(runner.pytest_addopts("0.11.0", GFX94_FAMILY, 0), "")
+
+    def test_skip_list_is_one_quoted_argument(self):
+        # The expression contains spaces and parens, so it has to survive the
+        # shlex split pytest performs on PYTEST_ADDOPTS as a single -k value.
+        opts = shlex.split(runner.pytest_addopts("0.10.2", GFX94_FAMILY, 0))
+
+        self.assertEqual(opts[0], "-k")
+        self.assertEqual(len(opts), 2)
+        self.assertIn("not conv", opts[1])
+
+    def test_reruns_and_skip_list_together(self):
+        opts = shlex.split(runner.pytest_addopts("0.10.2", GFX94_FAMILY, 2))
+
+        self.assertEqual(opts[0], "--reruns")
+        self.assertEqual(opts[-2], "-k")
+
+
+SUITE_SCRIPT_TEMPLATE = """\
+#!/bin/bash
+source ci/envs/default.env
+echo "pretend to install wheels"
+export SHOULD_NOT_LEAK=installs-above-the-section
+
+# ==============================================================================
+# Set up the generic test environment variables
+# ==============================================================================
+export JAX_SKIP_SLOW_TESTS=true
+export XLA_PYTHON_CLIENT_ALLOCATOR={allocator}
+export JAX_ENABLE_X64="$JAXCI_ENABLE_X64"
+export gpu_count=2
+export JAX_ENABLE_ROCM_XDIST="$gpu_count"
+if [[ -n "{conditional}" ]]; then
+  export XLA_FLAGS="--xla_gpu_enable_cublaslt=false"
+else
+  export XLA_FLAGS="--xla_gpu_enable_command_buffer="
+fi
+
+# ==============================================================================
+# Run tests
+# ==============================================================================
+export SHOULD_NOT_LEAK=below-the-section
+exit 1
+"""
+
+
+def write_suite_script(jax_dir: Path, allocator="address", conditional="yes") -> None:
+    (jax_dir / "ci" / "envs").mkdir(parents=True, exist_ok=True)
+    (jax_dir / "ci" / "envs" / "default.env").write_text(
+        "export JAXCI_ENABLE_X64=${JAXCI_ENABLE_X64:-0}\n"
+    )
+    (jax_dir / runner.RELATIVE_SUITE_SCRIPT).write_text(
+        SUITE_SCRIPT_TEMPLATE.format(allocator=allocator, conditional=conditional)
+    )
+
+
+class EnvSectionTest(unittest.TestCase):
+    def test_extracts_only_the_environment_section(self):
+        section = runner.env_section(
+            SUITE_SCRIPT_TEMPLATE.format(allocator="address", conditional="yes")
+        )
+
+        self.assertIn("XLA_PYTHON_CLIENT_ALLOCATOR=address", section)
+        # Nothing that installs or runs tests may end up in there.
+        self.assertNotIn("install wheels", section)
+        self.assertNotIn("exit 1", section)
+
+    def test_no_section_is_reported_as_empty(self):
+        self.assertEqual(runner.env_section("#!/bin/bash\nexit 0\n"), "")
+
+    def test_section_without_an_end_marker(self):
+        script = f"{runner.ENV_SECTION_START}\nexport A=1\n"
+
+        self.assertEqual(runner.env_section(script), "")
+
+
+@unittest.skipIf(platform.system() == "Windows", "the suite script needs bash")
+class SuiteEnvironmentTest(unittest.TestCase):
+    """The suite script is the source of truth, so these read it rather than
+    restating what it sets."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.jax_dir = Path(self.tmp.name) / "jax"
+        self.addCleanup(self.tmp.cleanup)
+
+    def suite_env(self, **kwargs) -> dict:
+        write_suite_script(self.jax_dir, **kwargs)
+        return runner.suite_environment(self.jax_dir, dict(os.environ))
+
+    def test_reads_the_allocator_the_script_sets(self):
+        self.assertEqual(
+            self.suite_env(allocator="platform")["XLA_PYTHON_CLIENT_ALLOCATOR"],
+            "platform",
+        )
+        self.assertEqual(
+            self.suite_env(allocator="address")["XLA_PYTHON_CLIENT_ALLOCATOR"],
+            "address",
+        )
+
+    def test_evaluates_conditionals_rather_than_scraping_them(self):
+        # 0.10.1 and 0.10.2 pick their XLA flags at runtime, so reading the text
+        # would take whichever branch came last.
+        self.assertEqual(
+            self.suite_env(conditional="yes")["XLA_FLAGS"],
+            "--xla_gpu_enable_cublaslt=false",
+        )
+        self.assertEqual(
+            self.suite_env(conditional="")["XLA_FLAGS"],
+            "--xla_gpu_enable_command_buffer=",
+        )
+
+    def test_default_env_is_sourced_for_the_variables_it_defines(self):
+        self.assertEqual(self.suite_env()["JAX_ENABLE_X64"], "0")
+
+    def test_skips_the_suite_bookkeeping(self):
+        env = self.suite_env()
+
+        # The section's own scratch variables, and the xdist worker count, which
+        # is for the parallel run and would contradict the serial retry.
+        self.assertNotIn("gpu_count", env)
+        self.assertNotIn("JAX_ENABLE_ROCM_XDIST", env)
+
+    def test_reports_only_what_the_section_changed(self):
+        env = self.suite_env()
+
+        # Dumping the environment on either side of the section keeps everything
+        # the shell brought with it out of the result.
+        self.assertNotIn("PWD", env)
+        self.assertNotIn("SHLVL", env)
+        self.assertNotIn("PATH", env)
+        self.assertNotIn("JAXCI_ENABLE_X64", env)
+
+    def test_only_the_section_is_evaluated(self):
+        # Anything outside the markers would mean installs or tests ran.
+        self.assertNotIn("SHOULD_NOT_LEAK", self.suite_env())
+
+    def test_the_retry_pass_inherits_skipping_slow_tests(self):
+        self.assertEqual(self.suite_env()["JAX_SKIP_SLOW_TESTS"], "true")
+
+    def test_a_renamed_section_is_fatal(self):
+        # Carrying on would run the retry pass, which decides the result, under an
+        # environment that does not match the run it is checking.
+        self.jax_dir.joinpath("ci").mkdir(parents=True)
+        (self.jax_dir / runner.RELATIVE_SUITE_SCRIPT).write_text(
+            "#!/bin/bash\nexit 0\n"
+        )
+
+        with self.assertRaises(runner.SuiteEnvironmentError) as caught:
+            runner.suite_environment(self.jax_dir, dict(os.environ))
+
+        # The message has to say what to fix, since the markers live upstream.
+        self.assertIn(runner.ENV_SECTION_START, str(caught.exception))
+        self.assertIn("ENV_SECTION_START", str(caught.exception))
+
+    def test_a_section_that_fails_is_fatal(self):
+        # Its device queries feed the values it exports, so a section that
+        # ends badly exported something computed from a command that did not
+        # work, and the retry pass would run under that.
+        write_suite_script(self.jax_dir)
+        script = (self.jax_dir / runner.RELATIVE_SUITE_SCRIPT).read_text()
+        (self.jax_dir / runner.RELATIVE_SUITE_SCRIPT).write_text(
+            script.replace(runner.ENV_SECTION_END, "false\n# Run tests")
+        )
+
+        with self.assertRaises(runner.SuiteEnvironmentError) as caught:
+            runner.suite_environment(self.jax_dir, dict(os.environ))
+
+        self.assertIn("exited 1", str(caught.exception))
+
+    def test_a_missing_default_env_is_fatal(self):
+        write_suite_script(self.jax_dir)
+        (self.jax_dir / runner.RELATIVE_SUITE_ENV_FILE).unlink()
+
+        with self.assertRaises(runner.SuiteEnvironmentError):
+            runner.suite_environment(self.jax_dir, dict(os.environ))
+
+
+class TestEnvironmentTest(unittest.TestCase):
+    def test_suite_values_are_carried_through(self):
+        env = runner.test_environment(
+            {"XLA_FLAGS": "--from-the-script"}, "0.11.0", GFX94_FAMILY, 2
+        )
+
+        self.assertEqual(env["XLA_FLAGS"], "--from-the-script")
+
+    def test_therock_workarounds_are_added(self):
+        env = runner.test_environment({}, "0.11.0", GFX94_FAMILY, 2)
+
+        self.assertEqual(env["ROCPROFILER_QUEUE_INTERPOSITION"], "0")
+        self.assertEqual(env["DEBUG_HIP_DYNAMIC_QUEUES"], "0")
+        self.assertEqual(env["HSA_NO_SCRATCH_RECLAIM"], "1")
+
+    def test_the_workarounds_win_over_the_script(self):
+        # They exist because the runtime needs them here, whatever the suite says.
+        env = runner.test_environment(
+            {"HSA_NO_SCRATCH_RECLAIM": "0"}, "0.11.0", GFX94_FAMILY, 2
+        )
+
+        self.assertEqual(env["HSA_NO_SCRATCH_RECLAIM"], "1")
+
+    def test_addopts_are_ours(self):
+        env = runner.test_environment(
+            {"PYTEST_ADDOPTS": "--from-the-script"}, "0.10.2", GFX94_FAMILY, 2
+        )
+
+        self.assertIn("--reruns", env["PYTEST_ADDOPTS"])
+        self.assertIn("not conv", env["PYTEST_ADDOPTS"])
+
+    def test_nothing_to_add_leaves_addopts_alone(self):
+        # Wiping them would drop whatever the caller had set.
+        env = runner.test_environment(
+            {"PYTEST_ADDOPTS": "--from-the-caller"}, "", "", 0
+        )
+
+        self.assertEqual(env["PYTEST_ADDOPTS"], "--from-the-caller")
+
+
+class RetryCommandTest(unittest.TestCase):
+    def test_runs_serially_in_this_interpreter(self):
+        nodeids = ["tests/a_test.py::test_one", "tests/b_test.py::test_two[a b]"]
+
+        command = runner.retry_command(nodeids)
+
+        self.assertEqual(command[0], sys.executable)
+        # -n 0 disables xdist: the point of the pass is a fresh single process.
+        self.assertIn("-n", command)
+        self.assertEqual(command[command.index("-n") + 1], "0")
+        # Each nodeid stays one argument, spaces and all.
+        self.assertEqual(command[-2:], nodeids)
+
+
+class RequestedCpusTest(unittest.TestCase):
+    """Reading the pod's CPU allocation off the CI runner's variable.
+
+    Kubernetes has two spellings and the runners have been seen using both, so
+    these pin down what each one means rather than trusting the platform docs,
+    which say millicores where the gfx942 runners say 25.
+    """
+
+    def cpus(self, value, available=192):
+        return runner.requested_cpus({runner.CPU_REQUEST_VAR: value}, available)
+
+    def test_whole_cores(self):
+        self.assertEqual(self.cpus("25"), 25)
+
+    def test_millicores(self):
+        self.assertEqual(self.cpus("25000m"), 25)
+
+    def test_a_bare_number_too_big_for_the_machine_is_millicores(self):
+        self.assertEqual(self.cpus("25000"), 25)
+
+    def test_fractional_cores_round_down(self):
+        self.assertEqual(self.cpus("7.5"), 7)
+
+    def test_less_than_a_core_still_gets_one(self):
+        self.assertEqual(self.cpus("500m"), 1)
+
+    def test_never_more_than_the_machine_has(self):
+        self.assertEqual(self.cpus("64", available=8), 8)
+
+    def test_unset_and_unusable_values(self):
+        for value in ["", "   ", "garbage", "0"]:
+            with self.subTest(value=value):
+                self.assertIsNone(self.cpus(value))
+
+    def test_a_missing_variable(self):
+        self.assertIsNone(runner.requested_cpus({}, 192))
+
+
+class OpenblasThreadsTest(unittest.TestCase):
+    def test_the_per_worker_share(self):
+        # 16 workers is what the suite starts, so a 96-core pod gets 6 each.
+        self.assertEqual(runner.openblas_threads(96), 6)
+
+    def test_a_small_pod_still_gets_a_thread(self):
+        # 25 cores over 16 workers rounds to nothing, and zero would mean
+        # "size it yourself", which is what we are trying to stop.
+        self.assertEqual(runner.openblas_threads(25), 1)
+
+    def test_it_lands_in_the_environment(self):
+        env = runner.test_environment({}, "0.11.0", GFX94_FAMILY, 2, cpus=96)
+
+        self.assertEqual(env["OPENBLAS_NUM_THREADS"], "6")
+
+    def test_an_unknown_allocation_leaves_it_alone(self):
+        env = runner.test_environment({}, "0.11.0", GFX94_FAMILY, 2, cpus=None)
+
+        self.assertNotIn("OPENBLAS_NUM_THREADS", env)
+
+
+@unittest.skipUnless(hasattr(os, "sched_setaffinity"), "pinning needs Linux")
+class LimitToCpusTest(unittest.TestCase):
+    def setUp(self):
+        self.original = os.sched_getaffinity(0)
+        self.addCleanup(os.sched_setaffinity, 0, self.original)
+
+    def test_pins_to_that_many_of_the_cpus_it_had(self):
+        if len(self.original) < 2:
+            self.skipTest("needs more than one cpu to narrow down to one")
+
+        chosen = runner.limit_to_cpus(1)
+
+        self.assertEqual(len(chosen), 1)
+        self.assertEqual(os.sched_getaffinity(0), set(chosen))
+        # And what it pinned to has to be a cpu it was allowed to use.
+        self.assertTrue(set(chosen) <= self.original)
+
+
+class CollectReportsTest(unittest.TestCase):
+    """Which reports may stand in for the suite result.
+
+    The retry pass decides the run, so it may only be handed the failures of a
+    pytest session that reached the end of what it was asked to run.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.jax_dir = Path(self.tmp.name) / "jax"
+        (self.jax_dir / "logs").mkdir(parents=True)
+        self.addCleanup(self.tmp.cleanup)
+
+    def write(self, name: str, exitcode, nodeids: list[str] | None = None):
+        report = {"tests": [{"nodeid": n, "outcome": "failed"} for n in nodeids or []]}
+        if exitcode is not None:
+            report["exitcode"] = exitcode
+        (self.jax_dir / "logs" / name).write_text(json.dumps(report))
+
+    def collect(self) -> runner.SuiteReports:
+        return runner.collect_reports(self.jax_dir)
+
+    def test_a_finished_session_with_failures_decides(self):
+        self.write("pytest_results_a.json", 1, ["tests/a_test.py::test_one"])
+
+        self.assertEqual(
+            self.collect(), runner.SuiteReports(["tests/a_test.py::test_one"], True)
+        )
+
+    def test_failures_are_gathered_across_reports(self):
+        self.write("pytest_results_a.json", 1, ["tests/a_test.py::test_one"])
+        self.write("pytest_results_b.json", 1, ["tests/b_test.py::test_two"])
+
+        self.assertCountEqual(
+            self.collect().failed,
+            ["tests/a_test.py::test_one", "tests/b_test.py::test_two"],
+        )
+
+    def test_a_session_that_stopped_early_does_not(self):
+        # 2 interrupted, 3 internal error, 4 usage error, 5 nothing collected.
+        for exitcode in (2, 3, 4, 5):
+            with self.subTest(exitcode=exitcode):
+                self.write("pytest_results_a.json", exitcode, ["tests/a_test.py::t"])
+
+                self.assertFalse(self.collect().complete)
+
+    def test_every_session_has_to_have_finished(self):
+        self.write("pytest_results_a.json", 1, ["tests/a_test.py::test_one"])
+        self.write("pytest_results_b.json", 2)
+
+        self.assertFalse(self.collect().complete)
+
+    def test_reports_of_only_passes_do_not_speak_for_a_failed_suite(self):
+        # Nothing ordinary failed, so whatever failed the suite happened outside
+        # the reports and no retry can clear it.
+        self.write("pytest_results_a.json", 0)
+        self.write("pytest_results_b.json", 0)
+
+        self.assertFalse(self.collect().complete)
+
+    def test_a_report_without_an_exitcode_does_not(self):
+        self.write("pytest_results_a.json", None, ["tests/a_test.py::test_one"])
+
+        self.assertFalse(self.collect().complete)
+
+    def test_a_malformed_report_does_not(self):
+        (self.jax_dir / "logs" / "pytest_results_a.json").write_text("{truncated")
+
+        self.assertFalse(self.collect().complete)
+
+    def test_no_reports_at_all_do_not(self):
+        self.assertEqual(self.collect(), runner.SuiteReports([], False))
+
+
+class RemoveReportsTest(unittest.TestCase):
+    def test_only_the_reports_go(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            logs = Path(tmp) / "logs"
+            logs.mkdir()
+            (logs / "pytest_results_single.json").write_text("{}")
+            (logs / "pytest.log").write_text("kept")
+
+            runner.remove_reports(Path(tmp))
+
+            self.assertFalse((logs / "pytest_results_single.json").exists())
+            self.assertTrue((logs / "pytest.log").exists())
+
+    def test_nothing_to_remove_is_fine(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runner.remove_reports(Path(tmp))
+
+
+class CmdArgumentsTest(unittest.TestCase):
+    def test_defaults(self):
+        args = runner.cmd_arguments([])
+
+        self.assertEqual(args.jax_dir, Path("jax"))
+        self.assertEqual(args.in_process_reruns, 2)
+        self.assertTrue(args.fresh_process_retry)
+        self.assertEqual(args.max_retry_tests, 40)
+        self.assertFalse(args.debug)
+
+    def test_fresh_process_retry_can_be_turned_off(self):
+        args = runner.cmd_arguments(["--no-fresh-process-retry"])
+
+        self.assertFalse(args.fresh_process_retry)
+
+    def test_no_retries_turns_off_both_layers(self):
+        args = runner.cmd_arguments(["--no-retries"])
+
+        self.assertEqual(args.in_process_reruns, 0)
+        self.assertFalse(args.fresh_process_retry)
+
+    def test_version_takes_precedence_over_ref(self):
+        args = runner.cmd_arguments(
+            ["--jax-version", "0.10.1", "--jax-ref", "rocm-jaxlib-v0.11.0"]
+        )
+
+        self.assertEqual(
+            args.jax_version or runner.jax_version_from_ref(args.jax_ref), "0.10.1"
+        )
+
+
+@unittest.skipIf(platform.system() == "Windows", "the suite script needs bash")
+class OrchestrationTest(unittest.TestCase):
+    """Covers what the suite result leads to, with the commands stubbed out."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.jax_dir = Path(self.tmp.name) / "jax"
+        write_suite_script(self.jax_dir)
+        (self.jax_dir / "logs").mkdir()
+        self.addCleanup(self.tmp.cleanup)
+
+        self.commands = []
+        self.returncodes = []
+        self.suite_reports = []
+        patcher = mock.patch.object(runner, "run_command", self.fake_run_command)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        # main() pins itself to the pod's cpus, which would leave this test
+        # process pinned for good on a machine that has the variable set.
+        self.pinned_to = []
+        pinning = mock.patch.object(
+            runner, "limit_to_cpus", lambda cores: self.pinned_to.append(cores) or [0]
+        )
+        pinning.start()
+        self.addCleanup(pinning.stop)
+
+        # An allocation is never more than the node has, so stand in for a node
+        # the size of the ones the suite runs on. Read for real, a four-core
+        # runner would hold a 96-core pod to four.
+        node = mock.patch.object(runner, "available_cpus", lambda: 192)
+        node.start()
+        self.addCleanup(node.stop)
+
+    def fake_run_command(self, args, cwd, env):
+        self.commands.append(args)
+        if args == ["bash", os.fspath(runner.RELATIVE_SUITE_SCRIPT)]:
+            for write in self.suite_reports:
+                write()
+        return self.returncodes.pop(0)
+
+    def suite_writes_report(self, name: str, nodeids: list[str], exitcode: int = 1):
+        """Queues a report for the fake suite to leave behind, as pytest would.
+
+        Writing it up front would not survive: the run clears the reports of an
+        earlier one before starting.
+        """
+        self.suite_reports.append(lambda: self.write_report(name, nodeids, exitcode))
+
+    def write_report(self, name: str, nodeids: list[str], exitcode: int = 1):
+        (self.jax_dir / "logs" / name).write_text(
+            json.dumps(
+                {
+                    "exitcode": exitcode,
+                    "tests": [
+                        {"nodeid": nodeid, "outcome": "failed"} for nodeid in nodeids
+                    ],
+                }
+            )
+        )
+
+    def run_main(self, extra: list[str] | None = None) -> int:
+        argv = ["--jax-dir", os.fspath(self.jax_dir), "--jax-version", "0.11.0"]
+        return runner.main(argv + (extra or []))
+
+    def test_a_passing_suite_is_not_retried(self):
+        self.returncodes = [0, 0]
+
+        self.assertEqual(self.run_main(), 0)
+        self.assertEqual(len(self.commands), 2)
+
+    def test_the_suite_is_held_to_the_pods_cpus(self):
+        self.returncodes = [0, 0]
+        environments = []
+        with mock.patch.dict(os.environ, {runner.CPU_REQUEST_VAR: "96"}):
+            with mock.patch.object(
+                runner,
+                "run_command",
+                lambda args, cwd, env: (
+                    environments.append(env) or self.fake_run_command(args, cwd, env)
+                ),
+            ):
+                self.run_main()
+
+        self.assertEqual(self.pinned_to, [96])
+        self.assertEqual(environments[1]["OPENBLAS_NUM_THREADS"], "6")
+
+    def test_an_unknown_allocation_leaves_the_run_alone(self):
+        # Off a CI runner there is nothing to read, and sizing pools to a
+        # fraction of a machine nobody else is using would only slow it down.
+        self.returncodes = [0, 0]
+        with mock.patch.dict(os.environ, {runner.CPU_REQUEST_VAR: ""}):
+            self.run_main()
+
+        self.assertEqual(self.pinned_to, [])
+
+    def test_cpus_can_be_given_on_the_command_line(self):
+        self.returncodes = [0, 0]
+        with mock.patch.dict(os.environ, {runner.CPU_REQUEST_VAR: ""}):
+            self.run_main(["--cpus", "32"])
+
+        self.assertEqual(self.pinned_to, [32])
+
+    def test_the_suite_runs_under_the_environment_read_from_it(self):
+        self.returncodes = [0, 0]
+        environments = []
+        with mock.patch.object(
+            runner,
+            "run_command",
+            lambda args, cwd, env: (
+                environments.append(env) or self.fake_run_command(args, cwd, env)
+            ),
+        ):
+            self.run_main()
+
+        self.assertEqual(environments[1]["XLA_PYTHON_CLIENT_ALLOCATOR"], "address")
+        self.assertEqual(environments[1]["HSA_NO_SCRATCH_RECLAIM"], "1")
+
+    def test_an_unreadable_environment_stops_before_the_suite(self):
+        (self.jax_dir / runner.RELATIVE_SUITE_SCRIPT).write_text(
+            "#!/bin/bash\nexit 1\n"
+        )
+        self.returncodes = []
+
+        self.assertEqual(self.run_main(), 1)
+        self.assertEqual(self.commands, [])
+
+    def test_the_preflight_check_runs_before_the_suite(self):
+        self.returncodes = [0, 0]
+
+        self.run_main()
+
+        self.assertEqual(self.commands[0], runner.preflight_command())
+        self.assertEqual(
+            self.commands[1], ["bash", os.fspath(runner.RELATIVE_SUITE_SCRIPT)]
+        )
+        # The suite script fails without this directory.
+        self.assertTrue((self.jax_dir / "dist").is_dir())
+
+    def test_a_failing_preflight_check_skips_the_suite(self):
+        # A stack that sees no device would report every test as an error.
+        self.returncodes = [1]
+
+        self.assertEqual(self.run_main(), 1)
+        self.assertEqual(len(self.commands), 1)
+
+    def test_reported_failures_are_retried_in_a_fresh_process(self):
+        self.suite_writes_report(
+            "pytest_results_single.json", ["tests/a_test.py::test_one"]
+        )
+        self.suite_writes_report(
+            "pytest_results_multi.json", ["tests/b_test.py::test_two"]
+        )
+        self.returncodes = [0, 1, 0]
+
+        # The retry decides the result: it passed, so the job passes.
+        self.assertEqual(self.run_main(), 0)
+        self.assertEqual(len(self.commands), 3)
+        # Every report the suite wrote is retried, in whatever order they glob.
+        self.assertCountEqual(
+            self.commands[2][-2:],
+            ["tests/a_test.py::test_one", "tests/b_test.py::test_two"],
+        )
+
+    def test_a_failing_retry_fails_the_job(self):
+        self.suite_writes_report(
+            "pytest_results_single.json", ["tests/a_test.py::test_one"]
+        )
+        self.returncodes = [0, 1, 1]
+
+        self.assertEqual(self.run_main(), 1)
+
+    def test_a_passing_session_alongside_a_failing_one_still_decides(self):
+        # The suite makes one pytest run per configuration, and only the one
+        # that failed has anything to retry.
+        self.suite_writes_report("pytest_results_multi.json", [], exitcode=0)
+        self.suite_writes_report(
+            "pytest_results_single.json", ["tests/a_test.py::test_one"], exitcode=1
+        )
+        self.returncodes = [0, 1, 0]
+
+        self.assertEqual(self.run_main(), 0)
+        self.assertEqual(len(self.commands), 3)
+
+    def test_an_interrupted_session_keeps_the_suite_result(self):
+        # Exit code 2 is a session pytest stopped, so the tests it never reached
+        # are missing from the report and retrying the rest proves nothing.
+        self.suite_writes_report(
+            "pytest_results_single.json", ["tests/a_test.py::test_one"], exitcode=2
+        )
+        self.returncodes = [0, 1]
+
+        self.assertEqual(self.run_main(), 1)
+        self.assertEqual(len(self.commands), 2)
+
+    def test_one_unfinished_session_holds_back_the_whole_retry(self):
+        self.suite_writes_report(
+            "pytest_results_single.json", ["tests/a_test.py::test_one"], exitcode=1
+        )
+        self.suite_writes_report("pytest_results_multi.json", [], exitcode=3)
+        self.returncodes = [0, 1]
+
+        self.assertEqual(self.run_main(), 1)
+        self.assertEqual(len(self.commands), 2)
+
+    def suite_writes_raw_report(self, name: str, text: str):
+        """Queues a report the suite writes verbatim, sound or not."""
+        self.suite_reports.append(
+            lambda: (self.jax_dir / "logs" / name).write_text(text)
+        )
+
+    def test_a_report_without_an_exitcode_keeps_the_suite_result(self):
+        # The retryable-looking failures of the sound report are not enough: the
+        # session that wrote the other one may have stopped anywhere.
+        self.suite_writes_report(
+            "pytest_results_a.json", ["tests/a_test.py::test_one"], exitcode=1
+        )
+        self.suite_writes_raw_report(
+            "pytest_results_b.json",
+            json.dumps({"tests": [{"nodeid": "tests/b.py::t", "outcome": "failed"}]}),
+        )
+        self.returncodes = [0, 1]
+
+        self.assertEqual(self.run_main(), 1)
+        self.assertEqual(len(self.commands), 2)
+
+    def test_a_malformed_report_keeps_the_suite_result(self):
+        self.suite_writes_report(
+            "pytest_results_a.json", ["tests/a_test.py::test_one"], exitcode=1
+        )
+        self.suite_writes_raw_report("pytest_results_b.json", "{truncated")
+        self.returncodes = [0, 1]
+
+        self.assertEqual(self.run_main(), 1)
+        self.assertEqual(len(self.commands), 2)
+
+    def test_reports_of_an_earlier_run_are_removed_first(self):
+        # Otherwise a local rerun retries the failures of the run before it and
+        # passes on results this suite never produced.
+        stale = self.jax_dir / "logs" / "pytest_results_single.json"
+        self.write_report("pytest_results_single.json", ["tests/a_test.py::test_one"])
+        self.returncodes = [0, 1]
+
+        self.assertEqual(self.run_main(), 1)
+        self.assertFalse(stale.exists())
+        self.assertEqual(len(self.commands), 2)
+
+    def test_nothing_to_retry_keeps_the_suite_result(self):
+        # A suite that fails without reporting a failed test, e.g. it died
+        # during collection, has nothing for the retry pass to work with.
+        self.returncodes = [0, 1]
+
+        self.assertEqual(self.run_main(), 1)
+        self.assertEqual(len(self.commands), 2)
+
+    def test_too_many_failures_skips_the_retry(self):
+        self.suite_writes_report(
+            "pytest_results_single.json",
+            [f"tests/a_test.py::test_{i}" for i in range(5)],
+        )
+        self.returncodes = [0, 1]
+
+        self.assertEqual(self.run_main(["--max-retry-tests", "4"]), 1)
+        self.assertEqual(len(self.commands), 2)
+
+    def test_retry_can_be_turned_off(self):
+        self.suite_writes_report(
+            "pytest_results_single.json", ["tests/a_test.py::test_one"]
+        )
+        self.returncodes = [0, 1]
+
+        self.assertEqual(self.run_main(["--no-fresh-process-retry"]), 1)
+        self.assertEqual(len(self.commands), 2)
+
+    def test_no_retries_runs_only_the_suite(self):
+        self.suite_writes_report(
+            "pytest_results_single.json", ["tests/a_test.py::test_one"]
+        )
+        self.returncodes = [0, 1]
+
+        self.assertEqual(self.run_main(["--no-retries"]), 1)
+        self.assertEqual(len(self.commands), 2)
+
+    def test_missing_checkout_is_an_error(self):
+        self.returncodes = []
+
+        self.assertEqual(
+            runner.main(["--jax-dir", os.fspath(self.jax_dir / "absent")]), 1
+        )
+        self.assertEqual(self.commands, [])
+
+
+class ReportedEnvTest(unittest.TestCase):
+    def test_visibility_variables_are_reported(self):
+        # Which physical GPU the job got, for reading a failure after the fact.
+        self.assertEqual(
+            runner.GPU_VISIBILITY_ENV_VARS,
+            ["ROCR_VISIBLE_DEVICES", "HIP_VISIBLE_DEVICES", "GPU_DEVICE_ORDINAL"],
+        )
+
+
+class UnsetVarsTest(unittest.TestCase):
+    def test_plugin_build_paths_are_dropped(self):
+        # Wheels carry their own bitcode and linker, so a value left over from a
+        # build points at paths that do not exist in a test job.
+        for name in [
+            "ROCM_ROOT",
+            "HIP_DEVICE_LIB_PATH",
+            "JAX_ROCM_PLUGIN_INTERNAL_BITCODE_PATH",
+            "JAX_ROCM_PLUGIN_INTERNAL_LLD_PATH",
+        ]:
+            self.assertIn(name, runner.UNSET_VARS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/external-builds/jax/README.md
+++ b/external-builds/jax/README.md
@@ -173,14 +173,6 @@ For more detailed build options, see the `ROCm/jax` repository and the
    source jax_test_env/bin/activate
    ```
 
-1. Install requirements:
-
-   ```bash
-   cd jax
-   pip install -r build/test-requirements.txt
-   pip install pytest-html pytest-csv uv pytest-json-report
-   ```
-
 1. Install ROCm Python packages:
 
    ```bash
@@ -194,23 +186,86 @@ For more detailed build options, see the `ROCm/jax` repository and the
    ```bash
    # Replace <rocm_major> with the ROCm major version of the index you install
    # from, e.g. 7 for a ROCm 7.x release or 10 for a ROCm 10.x release.
-   pip install \
-   --index-url <package_index_url> \
-   jax_rocm<rocm_major>_plugin \
-   jax_rocm<rocm_major>_pjrt
-
-   # Install jax from PyPI to match the version
-   pip install jax==<JAX_VERSION>
+   python external-builds/jax/install_jax_wheels.py \
+     --index-url <package_index_url> \
+     --plugin-package jax_rocm<rocm_major>_plugin \
+     --pjrt-package jax_rocm<rocm_major>_pjrt \
+     --plugin-version <JAX_VERSION> \
+     --pjrt-version <JAX_VERSION> \
+     --jax-version <JAX_VERSION>
    ```
 
-1. Run JAX tests:
+1. Install the test requirements, which come from the checkout so that they match
+   the release under test:
 
    ```bash
-   cd jax
-   # Create a dist directory (required to run the pytest-rocm.sh script).
-   mkdir -p dist
-   sh ci/run_pytest_rocm.sh
+   python external-builds/jax/install_jax_test_requirements.py \
+     --jax-dir jax_tests \
+     --python-version 3.12
    ```
+
+1. Run the JAX tests:
+
+   ```bash
+   python external-builds/jax/run_jax_tests.py \
+     --jax-dir jax_tests \
+     --jax-version <JAX_VERSION> \
+     --amdgpu-family <amdgpu_family>
+   ```
+
+### How the test runner works
+
+[`run_jax_tests.py`](./run_jax_tests.py) is what CI runs, so the command above
+reproduces a CI job locally. The suite script in the `ROCm/jax` checkout
+(`ci/run_pytest_rocm.sh`) stays the source of truth for how the tests run, and
+the runner adds only what is ours:
+
+- The ROCm runtime workarounds this repository needs. Everything else about the
+  environment, such as the allocator and the XLA flags, is read back out of the
+  suite script so the retry pass below matches the run it checks. A version that
+  changes those values, including behind a conditional, needs no change here. If
+  the script's environment section cannot be read, because it was renamed, the
+  job fails with an error naming what to update, rather than retrying under an
+  environment that does not match the run.
+- The known-bad tests for the version and GPU family under test, as a pytest
+  `-k` expression. These live in [`skip_tests/`](./skip_tests/README.md), which
+  also documents how to inspect the expression or run only the skipped tests.
+- Two layers of retry, which are not interchangeable:
+  - **In-process reruns** (`--in-process-reruns`, default 2) are
+    pytest-rerunfailures. They repeat a failed test inside the same worker,
+    recovering a crashed worker or a one-off runtime error.
+  - **A fresh-process retry** (`--fresh-process-retry`, on by default) is a
+    separate pytest run over the tests the suite reported as failed. Some
+    failures are sticky: the first one leaves the process in a state where
+    every later test fails the same way, which no rerun inside that process can
+    clear. Only a new process tells a real failure apart from a poisoned worker,
+    which is why this pass decides the result. It only decides it when the
+    suite's own pytest sessions ran to the end, which their reported exit codes
+    are what say: a session that stopped early leaves the suite failure
+    standing, since its report lists only the tests it reached.
+- The CPUs the run may use. A container shares the host's kernel, so a job
+  holding 25 cores of a shared 8-GPU box still reads 192 cores and sizes every
+  thread pool from that: one worker holds 1021 threads, against 16 workers at a
+  time. On CI the allocation arrives in `KUBE_CPU_REQUEST`; anywhere else
+  `--cpus` says the same thing. The run is pinned to that many CPUs, which
+  takes a worker to 107 threads.
+
+Useful flags while debugging:
+
+```bash
+# Print the environment and the commands without running anything.
+python external-builds/jax/run_jax_tests.py --jax-dir jax_tests --dry-run
+
+# Run only the tests the skip lists would skip.
+python external-builds/jax/run_jax_tests.py --jax-dir jax_tests \
+  --jax-version 0.10.2 --amdgpu-family gfx94X-dcgpu --debug
+
+# Run the suite alone, with both retry layers off.
+python external-builds/jax/run_jax_tests.py --jax-dir jax_tests --no-retries
+
+# Hold the run to 25 cores, as a CI pod would be.
+python external-builds/jax/run_jax_tests.py --jax-dir jax_tests --cpus 25
+```
 
 ### Teaching an installed JAX about a new ROCm major version
 

--- a/external-builds/jax/install_jax_test_requirements.py
+++ b/external-builds/jax/install_jax_test_requirements.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Installs what the JAX test suite needs into the active environment.
+
+The requirements come from the ROCm/jax checkout, pinned by its per-Python lock
+file, so the versions match the ones the release was tested with.
+pytest-json-report is ours: the fresh-process retry in run_jax_tests.py reads the
+reports it writes.
+
+Installs are retried via build_tools/setup_venv.py, since one index timeout has
+cost a job a whole run.
+
+Example usage:
+
+    python install_jax_test_requirements.py --jax-dir jax --python-version 3.12
+"""
+
+import argparse
+import os
+import pathlib
+import sys
+
+THIS_SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+THEROCK_DIR = THIS_SCRIPT_DIR.parent.parent
+
+sys.path.insert(0, os.fspath(THEROCK_DIR / "build_tools"))
+
+from setup_venv import run_command_with_retries
+
+# uv resolves the JAX requirements files considerably faster than pip.
+UV_REQUIREMENT = "uv~=0.11.2"
+
+# Written by pytest-json-report, read by the fresh-process retry.
+REPORT_REQUIREMENT = "pytest-json-report"
+
+RETRY_TIMEOUT_SECONDS = 180
+RETRY_WAIT_BETWEEN_SECONDS = 15
+
+
+def lock_file(jax_dir: pathlib.Path, python_version: str) -> pathlib.Path:
+    """The JAX requirements lock file for one Python version."""
+    return (
+        jax_dir / "build" / f"requirements_lock_{python_version.replace('.', '_')}.txt"
+    )
+
+
+def install_commands(jax_dir: pathlib.Path, python_version: str) -> list[list[str]]:
+    """The install commands, in the order they have to run."""
+    python = sys.executable
+    return [
+        [python, "-m", "pip", "install", UV_REQUIREMENT],
+        [
+            python,
+            "-m",
+            "uv",
+            "pip",
+            "install",
+            "-r",
+            os.fspath(jax_dir / "build" / "test-requirements.txt"),
+        ],
+        # The suite is sensitive to these two versions, so pin them to the lock
+        # file rather than whatever the requirements resolve to.
+        [
+            python,
+            "-m",
+            "uv",
+            "pip",
+            "install",
+            "--upgrade",
+            "-c",
+            os.fspath(lock_file(jax_dir, python_version)),
+            "scipy",
+            "pytest",
+        ],
+        [python, "-m", "pip", "install", REPORT_REQUIREMENT],
+    ]
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(prog="install_jax_test_requirements.py")
+    p.add_argument(
+        "--jax-dir",
+        type=pathlib.Path,
+        default=pathlib.Path(os.getenv("JAX_DIR", "jax")),
+        help="ROCm/jax checkout holding the requirements files (default: jax)",
+    )
+    p.add_argument(
+        "--python-version",
+        default=os.getenv("PYTHON_VERSION", ""),
+        help="Python version selecting the lock file (e.g. 3.12)",
+    )
+    p.add_argument(
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Print the commands without running them",
+    )
+    args = p.parse_args(argv)
+
+    if not args.python_version:
+        p.error("--python-version is required to select the lock file")
+
+    jax_dir = args.jax_dir.resolve()
+    lock = lock_file(jax_dir, args.python_version)
+    if not lock.exists() and not args.dry_run:
+        print(f"::error::{lock} not found. Is --jax-dir a ROCm/jax checkout?")
+        return 1
+
+    for command in install_commands(jax_dir, args.python_version):
+        if args.dry_run:
+            print(f"++ Would exec $ {' '.join(command)}")
+            continue
+        run_command_with_retries(
+            command,
+            retry_timeout_seconds=RETRY_TIMEOUT_SECONDS,
+            retry_wait_between_seconds=RETRY_WAIT_BETWEEN_SECONDS,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/external-builds/jax/install_jax_wheels.py
+++ b/external-builds/jax/install_jax_wheels.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Installs a JAX ROCm stack: the plugin and PJRT wheels plus a matching jax.
+
+The plugin and PJRT wheels come from a ROCm package index, since their names
+carry the ROCm major version they were built against (jax_rocm7_plugin,
+jax_rocm10_plugin). A build that produced its own jaxlib installs that from the
+same index; otherwise jax and jaxlib come from PyPI.
+
+Installs are retried via build_tools/setup_venv.py.
+
+Example usage:
+
+    python install_jax_wheels.py \\
+        --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \\
+        --plugin-package jax_rocm10_plugin --pjrt-package jax_rocm10_pjrt \\
+        --plugin-version 0.11.0 --pjrt-version 0.11.0 --jax-version 0.11.0
+"""
+
+import argparse
+import os
+import pathlib
+import sys
+
+THIS_SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+THEROCK_DIR = THIS_SCRIPT_DIR.parent.parent
+
+sys.path.insert(0, os.fspath(THEROCK_DIR / "build_tools"))
+
+from setup_venv import run_command_with_retries
+
+RETRY_TIMEOUT_SECONDS = 180
+RETRY_WAIT_BETWEEN_SECONDS = 15
+
+
+def install_commands(args: argparse.Namespace) -> list[list[str]]:
+    """The pip commands that install one JAX stack, in order."""
+    python = sys.executable
+    index = ["--index-url", args.index_url] if args.index_url else []
+
+    commands = [
+        [
+            python,
+            "-m",
+            "pip",
+            "install",
+            *index,
+            f"{args.plugin_package}=={args.plugin_version}",
+            f"{args.pjrt_package}=={args.pjrt_version}",
+        ]
+    ]
+
+    if args.jaxlib_version:
+        # Built alongside the plugin, so it only exists on that index.
+        commands.append(
+            [python, "-m", "pip", "install", *index, f"jaxlib=={args.jaxlib_version}"]
+        )
+        commands.append([python, "-m", "pip", "install", f"jax=={args.jax_version}"])
+    else:
+        commands.append(
+            [
+                python,
+                "-m",
+                "pip",
+                "install",
+                f"jax=={args.jax_version}",
+                f"jaxlib=={args.jax_version}",
+            ]
+        )
+
+    return commands
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(prog="install_jax_wheels.py")
+    p.add_argument(
+        "--index-url",
+        default=os.getenv("WHEEL_INDEX_URL", ""),
+        help="Package index holding the plugin, PJRT and built jaxlib wheels",
+    )
+    p.add_argument(
+        "--plugin-package",
+        default=os.getenv("JAX_PLUGIN_PACKAGE", ""),
+        help="Plugin package name (e.g. jax_rocm10_plugin)",
+    )
+    p.add_argument(
+        "--pjrt-package",
+        default=os.getenv("JAX_PJRT_PACKAGE", ""),
+        help="PJRT package name (e.g. jax_rocm10_pjrt)",
+    )
+    p.add_argument(
+        "--plugin-version",
+        default=os.getenv("JAX_PLUGIN_VERSION", ""),
+        help="Plugin version to install",
+    )
+    p.add_argument(
+        "--pjrt-version",
+        default=os.getenv("JAX_PJRT_VERSION", ""),
+        help="PJRT version to install",
+    )
+    p.add_argument(
+        "--jax-version",
+        default=os.getenv("JAX_VERSION", ""),
+        help="jax version to install",
+    )
+    p.add_argument(
+        "--jaxlib-version",
+        default=os.getenv("JAXLIB_VERSION", ""),
+        help="jaxlib version to install from --index-url, if one was built",
+    )
+    p.add_argument(
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Print the commands without running them",
+    )
+    args = p.parse_args(argv)
+
+    required = {
+        "--plugin-package": args.plugin_package,
+        "--pjrt-package": args.pjrt_package,
+        "--plugin-version": args.plugin_version,
+        "--pjrt-version": args.pjrt_version,
+        "--jax-version": args.jax_version,
+    }
+    missing = sorted(name for name, value in required.items() if not value)
+    if missing:
+        p.error(f"missing required argument(s): {', '.join(missing)}")
+
+    for command in install_commands(args):
+        if args.dry_run:
+            print(f"++ Would exec $ {' '.join(command)}")
+            continue
+        run_command_with_retries(
+            command,
+            retry_timeout_seconds=RETRY_TIMEOUT_SECONDS,
+            retry_wait_between_seconds=RETRY_WAIT_BETWEEN_SECONDS,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/external-builds/jax/run_jax_tests.py
+++ b/external-builds/jax/run_jax_tests.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Runs the JAX test suite against installed JAX ROCm wheels.
+
+The suite script in the ROCm/jax checkout (ci/run_pytest_rocm.sh) stays the source
+of truth for how the tests run. This adds only what is ours:
+
+  * the ROCm runtime workarounds this repository needs;
+  * the known-bad tests from skip_tests/, as a pytest -k expression;
+  * two layers of retry, described under "Retries" below;
+  * holding the run to the CPUs the pod was given, described under "Resources".
+
+Nothing the suite script decides is repeated here. Its environment is read back
+out of the script, so a version that changes its allocator or its XLA flags,
+including behind a conditional, needs no change in this file. Reading it is
+required rather than best-effort: the retry pass decides the result, so running
+it under a different environment than the suite would make that verdict
+meaningless. A script whose section markers have been renamed fails the run with
+an error naming them.
+
+Retries
+-------
+
+--in-process-reruns is pytest-rerunfailures: it repeats a failed test in the same
+worker, recovering a crashed worker or a one-off runtime error.
+
+--fresh-process-retry re-runs the reported failures in a new process, and decides
+the result. It is not interchangeable with the above: a sticky failure leaves the
+process failing every later test the same way, which no rerun inside it can
+clear. It only speaks for the suite when the suite's own pytest sessions ran to
+the end, which their reported exit codes are what say.
+
+--no-retries turns off both, running the suite exactly as the script does.
+
+Resources
+---------
+
+A container shares the host's kernel, so nothing a process can query describes
+the container: on the gfx942 runners a job holding 25 cores of an 8-way shared
+box reads 192 cores and 2268 GiB, and sizes every thread pool from that. What
+the pod actually got arrives in KUBE_CPU_REQUEST, and --cpus says the same thing
+on a machine that has no CI runner to inject it.
+
+The run is pinned to that many CPUs, which the suite and the retry pass inherit.
+Measured on a gfx942 runner, one worker holds 1021 threads unpinned and 107
+pinned to 25 cores with OpenBLAS capped, against 16 workers at a time.
+
+Example usage:
+
+    # As CI runs it.
+    python run_jax_tests.py --jax-dir jax --jax-ref rocm-jaxlib-v0.11.0 \\
+        --amdgpu-family gfx94X-dcgpu
+
+    # The suite with both retry layers off.
+    python run_jax_tests.py --jax-dir jax --no-retries
+
+    # Print the environment and commands without running anything.
+    python run_jax_tests.py --jax-dir jax --jax-version 0.10.2 --dry-run
+
+    # Run only the tests the skip list would have skipped.
+    python run_jax_tests.py --jax-dir jax --jax-version 0.10.2 --debug
+"""
+
+import argparse
+import dataclasses
+import json
+import os
+import platform
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+THIS_SCRIPT_DIR = Path(__file__).resolve().parent
+THEROCK_DIR = THIS_SCRIPT_DIR.parent.parent
+
+sys.path.insert(0, os.fspath(THIS_SCRIPT_DIR))
+sys.path.insert(0, os.fspath(THEROCK_DIR / "test_tools"))
+
+from list_pytest_failed_tests import failed_in_report
+from skip_tests.create_skip_tests import keyword_expression
+
+JAX_REF_PREFIX = "rocm-jaxlib-v"
+
+# Relative to the ROCm/jax checkout --jax-dir names, which is also the working
+# directory the suite runs in, rather than to wherever this script was called
+# from.
+RELATIVE_SUITE_SCRIPT = Path("ci") / "run_pytest_rocm.sh"
+
+# Sourced by the suite script for the JAXCI_* defaults the section below reads,
+# and safe to source here too: it only assigns variables.
+RELATIVE_SUITE_ENV_FILE = Path("ci") / "envs" / "default.env"
+
+# One report per pytest invocation the suite script makes, matched by pattern so
+# that a version splitting the suite differently needs no change here.
+REPORT_GLOB = "logs/pytest_results*.json"
+
+# The pytest exit codes of a session that ran to the end. Above them the session
+# stopped early instead: 2 interrupted, 3 internal error, 4 usage error, 5
+# nothing collected. Such a report lists only the tests that got that far.
+PYTEST_EXIT_ALL_PASSED = 0
+PYTEST_EXIT_TESTS_FAILED = 1
+
+# The section of the suite script that only computes the environment: exports,
+# echoes and device queries, with the installs above it and the test run below it.
+# Evaluating it is how the per-version environment reaches the retry pass, which
+# has to match the run it is checking. Sourcing the script itself would run the
+# tests, and copying its values here would be a second source of truth.
+ENV_SECTION_START = "# Set up the generic test environment variables"
+ENV_SECTION_END = "# Run tests"
+
+# The section exports its own scratch variables, lowercase by convention, next to
+# the configuration worth keeping. The xdist worker count is for the parallel run
+# and would contradict the serial retry.
+SUITE_ENV_EXCLUDES = ["JAX_ENABLE_ROCM_XDIST"]
+
+# ROCm/HIP runtime tuning that avoids a pytest slowdown and hang. Ours rather than
+# the suite's, so it belongs here.
+# TODO:(magaonka-amd) remove once the system teams' fixes land.
+THEROCK_ENV = {
+    "ROCPROFILER_QUEUE_INTERPOSITION": "0",
+    "DEBUG_HIP_DYNAMIC_QUEUES": "0",
+    "HSA_NO_SCRATCH_RECLAIM": "1",
+}
+
+# A test runner is often a single-device slice of a shared host, where these hide
+# the other devices but not other tenants. Logged next to the device serials from
+# print_driver_gpu_info.py, they tell a noisy neighbour apart from a fault.
+GPU_VISIBILITY_ENV_VARS = [
+    "ROCR_VISIBLE_DEVICES",
+    "HIP_VISIBLE_DEVICES",
+    "GPU_DEVICE_ORDINAL",
+]
+
+# What the pod was given, injected by the CI runners. A container shares the
+# host's kernel, so nothing the process can query is about the container: the
+# gfx942 runners report 192 cores and 2268 GiB to a job holding 25 cores of an
+# 8-way shared box, and the cgroups are quiet because CI sets CPU requests and
+# no limits. These variables are the only account of the real allocation.
+CPU_REQUEST_VAR = "KUBE_CPU_REQUEST"
+MEMORY_REQUEST_VAR = "KUBE_MEMORY_REQUEST"
+
+# The most pytest workers the suite starts in parallel, see the num_processes
+# cap in ci/run_pytest_rocm.sh. Each one loads its own copy of every library.
+SUITE_MAX_WORKERS = 16
+
+# Set by the plugin build. Installed wheels carry their own bitcode and linker, so
+# a leftover value points them at paths that do not exist here.
+UNSET_VARS = [
+    "ROCM_ROOT",
+    "HIP_DEVICE_LIB_PATH",
+    "JAX_ROCM_PLUGIN_INTERNAL_BITCODE_PATH",
+    "JAX_ROCM_PLUGIN_INTERNAL_LLD_PATH",
+]
+
+
+def jax_version_from_ref(jax_ref: str) -> str:
+    """The version a rocm-jax ref names, e.g. rocm-jaxlib-v0.11.0 -> 0.11.0."""
+    return jax_ref.removeprefix(JAX_REF_PREFIX) if jax_ref else ""
+
+
+def pytest_addopts(
+    jax_version: str,
+    amdgpu_family: str,
+    in_process_reruns: int,
+    debug: bool = False,
+) -> str:
+    """The PYTEST_ADDOPTS value for one configuration."""
+    opts = []
+    if in_process_reruns:
+        # Crashed workers are retried regardless of --only-rerun. Everything else
+        # is left to the fresh-process pass.
+        opts += [
+            "--reruns",
+            str(in_process_reruns),
+            "--reruns-delay",
+            "5",
+            "--only-rerun",
+            "INTERNAL",
+        ]
+
+    expression = keyword_expression(jax_version, amdgpu_family, debug)
+    if expression:
+        opts += ["-k", expression]
+
+    return shlex.join(opts)
+
+
+class SuiteEnvironmentError(Exception):
+    """The environment the suite runs under could not be read."""
+
+
+def env_section(script: str) -> str:
+    """The part of the suite script that only computes the environment."""
+    lines = script.splitlines()
+    starts = [i for i, line in enumerate(lines) if line.strip() == ENV_SECTION_START]
+    ends = [i for i, line in enumerate(lines) if line.strip() == ENV_SECTION_END]
+    if not starts or not ends or ends[-1] <= starts[0]:
+        return ""
+    return "\n".join(lines[starts[0] + 1 : ends[-1]])
+
+
+def _read_env_dump(path: Path) -> dict[str, str]:
+    entries = path.read_bytes().decode(errors="replace").split("\0")
+    pairs = (entry.partition("=") for entry in entries)
+    return {name: value for name, separator, value in pairs if separator}
+
+
+def suite_environment(jax_dir: Path, env: dict[str, str]) -> dict[str, str]:
+    """What the suite script's environment section exports.
+
+    Evaluated in a shell that dumps its environment on either side of the section,
+    so the result is what the section itself changed rather than a guess at which
+    names look interesting.
+
+    Raises:
+        SuiteEnvironmentError: if the section cannot be found or evaluated. This
+            fails the run by design, because the retry pass decides the result and
+            a wrong environment there would decide it wrongly.
+    """
+    section = env_section((jax_dir / RELATIVE_SUITE_SCRIPT).read_text())
+    if not section:
+        raise SuiteEnvironmentError(
+            f"{RELATIVE_SUITE_SCRIPT} has no section between '{ENV_SECTION_START}' and"
+            f" '{ENV_SECTION_END}'. The script most likely renamed them, so update"
+            " ENV_SECTION_START and ENV_SECTION_END to match it."
+        )
+    if not (jax_dir / RELATIVE_SUITE_ENV_FILE).exists():
+        raise SuiteEnvironmentError(
+            f"{RELATIVE_SUITE_ENV_FILE} is missing, and the section reads its defaults."
+            f" Is {jax_dir} a complete ROCm/jax checkout?"
+        )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        before = Path(tmp) / "before"
+        after = Path(tmp) / "after"
+        dump = "env -0 > {}".format
+        # The section's own status, kept across the dump that follows it, which
+        # would otherwise be the status of the shell and always zero.
+        script = "\n".join(
+            [
+                f"source {shlex.quote(os.fspath(RELATIVE_SUITE_ENV_FILE))}",
+                dump(shlex.quote(os.fspath(before))),
+                section,
+                "section_status=$?",
+                dump(shlex.quote(os.fspath(after))),
+                "exit ${section_status}",
+            ]
+        )
+        proc = subprocess.run(
+            ["bash", "-c", script],
+            cwd=jax_dir,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if not (before.exists() and after.exists()):
+            raise SuiteEnvironmentError(
+                f"Evaluating the section of {RELATIVE_SUITE_SCRIPT} produced no environment:"
+                f" {proc.stderr.strip()}"
+            )
+        if proc.returncode != 0:
+            # It exports and queries devices, so a failure means some of what it
+            # exported was computed from a command that did not work.
+            raise SuiteEnvironmentError(
+                f"The section of {RELATIVE_SUITE_SCRIPT} exited"
+                f" {proc.returncode}, so the environment it exported is only"
+                f" partly what the suite will run under: {proc.stderr.strip()}"
+            )
+        baseline, exported = _read_env_dump(before), _read_env_dump(after)
+
+    return {
+        name: value
+        for name, value in exported.items()
+        if baseline.get(name) != value
+        and name.isupper()
+        and name not in SUITE_ENV_EXCLUDES
+    }
+
+
+def available_cpus() -> int:
+    """The CPUs this process may run on, which is the node's on a CI runner."""
+    if hasattr(os, "sched_getaffinity"):
+        return len(os.sched_getaffinity(0))
+    return os.cpu_count() or 1
+
+
+def requested_cpus(env: dict[str, str], available: int) -> int | None:
+    """The cores CPU_REQUEST_VAR names, or None if it names none usable.
+
+    Kubernetes writes a CPU request in cores or in millicores, and both
+    spellings have been seen on these runners: 25, 7.5 and 25000m are all the
+    same order of magnitude. A bare number larger than the machine has can only
+    be millicores.
+    """
+    value = env.get(CPU_REQUEST_VAR, "").strip()
+    try:
+        cores = float(value.removesuffix("m")) / (1000 if value.endswith("m") else 1)
+    except ValueError:
+        return None
+    if cores > available and cores / 1000 >= 1:
+        cores /= 1000
+    if cores < 1:
+        # Half a core still gets one, but nothing at all means the value was
+        # never a CPU request.
+        return 1 if cores > 0 else None
+    return min(int(cores), available)
+
+
+def limit_to_cpus(cores: int) -> list[int]:
+    """Pins this process, and everything it starts, to that many CPUs.
+
+    The thread pools underneath JAX size themselves from the CPUs they can see
+    rather than from what the pod was given. Measured on a gfx942 runner, one
+    worker holds 1021 threads, 256 of them XLA's Eigen pool; pinned to the 25
+    cores the pod has, it holds 179. Sixteen workers of the first kind is
+    16,000 threads on a box that owes this job 25 cores.
+    """
+    chosen = sorted(os.sched_getaffinity(0))[:cores]
+    os.sched_setaffinity(0, set(chosen))
+    return chosen
+
+
+def openblas_threads(cpus: int) -> int:
+    """The OpenBLAS threads one worker gets out of a pod with that many cores.
+
+    numpy and scipy each bundle one, and it is the only threaded library the
+    suite pulls in that reads an environment variable. Pinning alone would
+    leave every worker sizing its pool to the whole allocation.
+    """
+    return max(1, cpus // SUITE_MAX_WORKERS)
+
+
+def log_pod_resources(env: dict[str, str]) -> None:
+    """What the pod was given, next to what the process can see."""
+    log("=== Resources")
+    for name in (CPU_REQUEST_VAR, MEMORY_REQUEST_VAR):
+        log(f"  {name}={env.get(name, 'unset')}")
+    log(f"  cpus visible to this process={available_cpus()}")
+    meminfo = Path("/proc/meminfo")
+    if meminfo.exists():
+        total = meminfo.read_text().partition("\n")[0]
+        log(f"  {total} (the node's, whatever this container was given)")
+
+
+def size_to_pod(env: dict[str, str], override: int | None) -> int | None:
+    """Holds the run to the pod's CPUs, and reports what it was given.
+
+    Returns the cores to size thread pools from, or None when the allocation is
+    unknown: then everything underneath goes on sizing itself from the node, as
+    it did before any of this.
+    """
+    log_pod_resources(env)
+
+    cpus = override or requested_cpus(env, available_cpus())
+    if not cpus:
+        log(
+            f"::warning::{CPU_REQUEST_VAR} is unset or holds no usable core"
+            " count, so the thread pools will size themselves from the whole"
+            " node. Pass --cpus to say what this machine may use."
+        )
+        return None
+
+    if not hasattr(os, "sched_setaffinity"):
+        log(f"  {platform.system()} cannot pin CPUs, so only the pools are sized")
+        return cpus
+
+    pinned = limit_to_cpus(cpus)
+    log(f"  pinned to {len(pinned)} cpus: {pinned[0]}-{pinned[-1]}")
+    return cpus
+
+
+def test_environment(
+    suite_env: dict[str, str],
+    jax_version: str,
+    amdgpu_family: str,
+    in_process_reruns: int,
+    debug: bool = False,
+    cpus: int | None = None,
+) -> dict[str, str]:
+    """The environment variables the suite and the retry pass need."""
+    env = {**suite_env, **THEROCK_ENV}
+    if cpus:
+        env["OPENBLAS_NUM_THREADS"] = str(openblas_threads(cpus))
+    # Left alone when there is nothing to add, so that --no-retries does not wipe
+    # options the caller set.
+    addopts = pytest_addopts(jax_version, amdgpu_family, in_process_reruns, debug)
+    if addopts:
+        env["PYTEST_ADDOPTS"] = addopts
+    return env
+
+
+def preflight_command() -> list[str]:
+    """Reports the devices JAX sees, in a process that exits before the suite.
+
+    A stack that imports but finds no device fails here in one line instead of as
+    thousands of test errors.
+    """
+    return [sys.executable, "-c", "import jax; print(jax.local_devices())"]
+
+
+def retry_command(nodeids: list[str]) -> list[str]:
+    """The fresh-process pytest command for the tests that failed."""
+    return [sys.executable, "-m", "pytest", "-n", "0", "--tb=short", *nodeids]
+
+
+def log(*args) -> None:
+    print(*args)
+    sys.stdout.flush()
+
+
+def run_command(args: list[str], cwd: Path, env: dict[str, str]) -> int:
+    log(f"++ Exec [{cwd}]$ {shlex.join(args)}")
+    return subprocess.run(args, cwd=cwd, env=env).returncode
+
+
+@dataclasses.dataclass(frozen=True)
+class SuiteReports:
+    """What the JSON reports say about the pytest sessions the suite ran."""
+
+    failed: list[str]
+    # Whether those sessions covered the whole suite. Node ids alone cannot tell
+    # a session that ran every test and failed some from one that stopped
+    # partway: both leave a report full of results. Retrying the failures of the
+    # second kind would pass while the tests it never reached stay unrun.
+    complete: bool
+
+
+def remove_reports(jax_dir: Path) -> None:
+    """Drops reports from an earlier run, which this one would read as its own."""
+    for report in sorted(jax_dir.glob(REPORT_GLOB)):
+        log(f"Removing the report an earlier run left behind: {report}")
+        report.unlink()
+
+
+def collect_reports(jax_dir: Path) -> SuiteReports:
+    """The failures the suite reported, and whether it got through the suite.
+
+    The top-level exit code is what says the latter, so a report missing it, or
+    one that cannot be read at all, counts against the run rather than being
+    skipped over.
+    """
+    reports = sorted(jax_dir.glob(REPORT_GLOB))
+    if not reports:
+        log(f"{jax_dir / REPORT_GLOB}: no reports found")
+        return SuiteReports([], False)
+
+    failed: list[str] = []
+    exitcodes: list[int] = []
+    for report in reports:
+        try:
+            parsed = json.loads(report.read_text())
+            exitcode = parsed["exitcode"]
+        except (OSError, ValueError, KeyError) as e:
+            log(f"::warning::{report}: no pytest exit code to read ({e!r})")
+            return SuiteReports(failed, False)
+        log(f"{report}: pytest exited {exitcode}")
+        failed += failed_in_report(parsed)
+        exitcodes.append(exitcode)
+
+    finished = (PYTEST_EXIT_ALL_PASSED, PYTEST_EXIT_TESTS_FAILED)
+    early = [code for code in exitcodes if code not in finished]
+    if early:
+        log(f"::warning::pytest exited {early}, so it stopped before the end")
+        return SuiteReports(failed, False)
+    if PYTEST_EXIT_TESTS_FAILED not in exitcodes:
+        log(
+            "::warning::no session reported a test failure, so the suite failed"
+            " for a reason its reports do not hold"
+        )
+        return SuiteReports(failed, False)
+    return SuiteReports(failed, True)
+
+
+def cmd_arguments(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="run_jax_tests.py")
+    p.add_argument(
+        "--jax-dir",
+        type=Path,
+        default=Path(os.getenv("JAX_DIR", "jax")),
+        help="ROCm/jax checkout holding the test suite (default: jax)",
+    )
+    p.add_argument(
+        "--jax-version",
+        default=os.getenv("JAX_VERSION", ""),
+        help="JAX version under test (e.g. 0.10.2); derived from --jax-ref if unset",
+    )
+    p.add_argument(
+        "--jax-ref",
+        default=os.getenv("JAX_REF", ""),
+        help=f"rocm-jax ref under test (e.g. {JAX_REF_PREFIX}0.11.0)",
+    )
+    p.add_argument(
+        "--amdgpu-family",
+        default=os.getenv("AMDGPU_FAMILY", ""),
+        help="GPU family under test (e.g. gfx94X-dcgpu), selects skip lists",
+    )
+    p.add_argument(
+        "--retries",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="--no-retries turns off both retry layers, running only the suite",
+    )
+    p.add_argument(
+        "--in-process-reruns",
+        type=int,
+        default=int(os.getenv("JAX_NUM_PYTEST_RERUNS", "2")),
+        help="pytest-rerunfailures attempts within the same process (0 disables)",
+    )
+    p.add_argument(
+        "--fresh-process-retry",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Retry reported failures in a new process, which decides the result",
+    )
+    p.add_argument(
+        "--max-retry-tests",
+        type=int,
+        default=40,
+        help="Skip the fresh-process retry above this many failures (0 disables)",
+    )
+    p.add_argument(
+        "--cpus",
+        type=int,
+        default=None,
+        help=f"Cores this run may use (default: what {CPU_REQUEST_VAR} says)",
+    )
+    p.add_argument(
+        "--debug",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Run only the tests the skip lists would skip",
+    )
+    p.add_argument(
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Print the environment and commands without running them",
+    )
+    args = p.parse_args(argv)
+
+    if not args.retries:
+        args.in_process_reruns = 0
+        args.fresh_process_retry = False
+
+    return args
+
+
+def main(argv: list[str]) -> int:
+    args = cmd_arguments(argv)
+
+    jax_version = args.jax_version or jax_version_from_ref(args.jax_ref)
+
+    jax_dir = args.jax_dir.resolve()
+    suite = jax_dir / RELATIVE_SUITE_SCRIPT
+    if not suite.exists() and not args.dry_run:
+        log(f"::error::{suite} not found. Is --jax-dir a ROCm/jax checkout?")
+        return 1
+
+    env = dict(os.environ)
+    for name in UNSET_VARS:
+        env.pop(name, None)
+
+    cpus = size_to_pod(env, args.cpus)
+
+    try:
+        suite_env = suite_environment(jax_dir, env) if suite.exists() else {}
+    except SuiteEnvironmentError as e:
+        log(f"::error::{e}")
+        return 1
+    overrides = test_environment(
+        suite_env,
+        jax_version,
+        args.amdgpu_family,
+        args.in_process_reruns,
+        args.debug,
+        cpus,
+    )
+    env.update(overrides)
+
+    log(f"=== Testing JAX {jax_version or '(unknown version)'} in {jax_dir}")
+    log(f"  host={platform.node()}")
+    for name in GPU_VISIBILITY_ENV_VARS:
+        log(f"  {name}={env.get(name, 'unset')}")
+    for name, value in sorted(overrides.items()):
+        log(f"  {name}={value}")
+
+    # The suite script fails without this directory.
+    if not args.dry_run:
+        (jax_dir / "dist").mkdir(parents=True, exist_ok=True)
+
+    suite_command = ["bash", os.fspath(RELATIVE_SUITE_SCRIPT)]
+    if args.dry_run:
+        log(f"++ Would exec [{jax_dir}]$ {shlex.join(preflight_command())}")
+        log(f"++ Would exec [{jax_dir}]$ {shlex.join(suite_command)}")
+        return 0
+
+    log("=== Devices JAX sees")
+    returncode = run_command(preflight_command(), jax_dir, env)
+    if returncode != 0:
+        log(
+            "::error::JAX cannot see its devices, so the suite would only"
+            " report that. See the traceback above."
+        )
+        return returncode
+
+    log("=== Running the test suite")
+    # Only this run's reports may decide this run's result.
+    remove_reports(jax_dir)
+    returncode = run_command(suite_command, jax_dir, env)
+    if returncode == 0:
+        return 0
+
+    if not args.fresh_process_retry:
+        return returncode
+
+    reports = collect_reports(jax_dir)
+    if not reports.complete:
+        log(
+            "The suite did not get through its tests, so retrying the failures"
+            " it did report would say nothing about the rest."
+        )
+        return returncode
+
+    failed = reports.failed
+    if not failed:
+        log(
+            "The suite failed without reporting a failed test, so there is"
+            " nothing to retry."
+        )
+        return returncode
+
+    # The retry pass is serial, and a configuration this broken is something
+    # other than a few poisoned workers.
+    if args.max_retry_tests and len(failed) > args.max_retry_tests:
+        log(
+            f"::error::{len(failed)} failures is more than --max-retry-tests"
+            f" {args.max_retry_tests}, so nothing will be retried"
+        )
+        return returncode
+
+    # This pass decides the result: a sticky fault only clears in a new process.
+    # It runs under the suite's own environment, read above, so it takes the same
+    # path as the run it is checking.
+    log(f"=== Retrying {len(failed)} failure(s) in a fresh process")
+    return run_command(retry_command(failed), jax_dir, env)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/external-builds/jax/skip_tests/README.md
+++ b/external-builds/jax/skip_tests/README.md
@@ -1,0 +1,68 @@
+# JAX test skip lists
+
+Tests that are known to fail for reasons outside JAX live here rather than in a
+workflow file, so that a local run reproduces what CI runs.
+
+## Layout
+
+| File               | Applies to                                  |
+| ------------------ | ------------------------------------------- |
+| `generic.py`       | every JAX version                           |
+| `jax_<version>.py` | that JAX version only, e.g. `jax_0.10.2.py` |
+
+Each file defines a `skip_tests` dict whose top-level keys select where the
+entries apply:
+
+- `common` applies everywhere.
+- Anything else is matched against the GPU family, as a substring: `gfx94`
+  covers the family `gfx94X-dcgpu` and the arch `gfx942`.
+
+## Entry format
+
+Entries are pytest `-k` keyword filters. `deny` is a keyword to skip, and the
+optional `unless` list keeps tests that would otherwise be caught by it, which
+matters because `-k` matches substrings: denying `conv` also catches `convert`.
+
+```python
+skip_tests = {
+    "gfx94": {
+        "keywords": [
+            {"deny": "conv", "unless": ["convert", "conversion"]},
+            {"deny": "sumpool"},
+        ],
+    },
+}
+```
+
+That generates:
+
+```
+-k "((not conv) or convert or conversion) and not sumpool"
+```
+
+Always say why an entry is there and what would let it be removed. An entry
+without a reason cannot be retired by the next person to read it.
+
+## Inspecting and running locally
+
+Print the expression a given configuration produces:
+
+```bash
+python external-builds/jax/skip_tests/create_skip_tests.py \
+    --jax-version 0.10.2 --amdgpu-family gfx94X-dcgpu
+```
+
+`run_jax_tests.py` applies the same expression, so running it locally with the
+same `--jax-version` and `--amdgpu-family` skips the same tests as CI:
+
+```bash
+python external-builds/jax/run_jax_tests.py --jax-dir jax \
+    --jax-version 0.10.2 --amdgpu-family gfx94X-dcgpu
+```
+
+To debug one of these tests, invert the list and run only the skipped tests:
+
+```bash
+python external-builds/jax/run_jax_tests.py --jax-dir jax \
+    --jax-version 0.10.2 --amdgpu-family gfx94X-dcgpu --debug
+```

--- a/external-builds/jax/skip_tests/create_skip_tests.py
+++ b/external-builds/jax/skip_tests/create_skip_tests.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Builds the pytest -k expression that skips known-bad JAX tests.
+
+The entries live in data files next to this one, one per JAX version plus
+generic.py, so that CI and a local run skip the same tests. See README.md for
+the file layout and the entry format.
+
+Example usage:
+
+    python create_skip_tests.py --jax-version 0.10.2 --amdgpu-family gfx94X-dcgpu
+"""
+
+import argparse
+import importlib.util
+import pathlib
+import sys
+from typing import Any
+
+THIS_DIR = pathlib.Path(__file__).resolve().parent
+
+GENERIC_FILE = "generic.py"
+
+# Applies regardless of which GPU family the tests run on.
+COMMON_SECTION = "common"
+
+
+def _load_data_file(path: pathlib.Path) -> dict[str, Any]:
+    """Reads the skip_tests dict out of one data file."""
+    spec = importlib.util.spec_from_file_location(f"skip_tests.{path.stem}", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, "skip_tests", {})
+
+
+def data_files(jax_version: str) -> list[pathlib.Path]:
+    """The data files that apply to jax_version, generic ones first.
+
+    An unknown version contributes only the generic file, so adding a JAX version
+    to CI is a no-op here.
+    """
+    files = [THIS_DIR / GENERIC_FILE]
+    if jax_version == "all":
+        files += sorted(THIS_DIR.glob("jax_*.py"))
+    elif jax_version:
+        version_file = THIS_DIR / f"jax_{jax_version}.py"
+        if version_file.exists():
+            files.append(version_file)
+    return files
+
+
+def _section_applies(section: str, amdgpu_family: str) -> bool:
+    if section == COMMON_SECTION:
+        return True
+    # Substring match, so "gfx94" covers gfx94X-dcgpu and gfx942.
+    return bool(amdgpu_family) and section in amdgpu_family
+
+
+def keyword_filters(jax_version: str, amdgpu_family: str) -> list[dict[str, Any]]:
+    """The keyword entries that apply to one configuration."""
+    filters: list[dict[str, Any]] = []
+    for path in data_files(jax_version):
+        for section, entries in _load_data_file(path).items():
+            if _section_applies(section, amdgpu_family):
+                filters += entries.get("keywords", [])
+    return filters
+
+
+def keyword_expression(
+    jax_version: str, amdgpu_family: str, debug: bool = False
+) -> str:
+    """The pytest -k expression for one configuration, empty when nothing applies.
+
+    With debug set, it selects only the skipped tests instead, to reproduce a
+    failure without editing the data files.
+    """
+    filters = keyword_filters(jax_version, amdgpu_family)
+    if not filters:
+        return ""
+
+    if debug:
+        return " or ".join(entry["deny"] for entry in filters)
+
+    terms = []
+    for entry in filters:
+        deny = entry["deny"]
+        # -k matches substrings, so denying "conv" also catches "convert".
+        unless = entry.get("unless", [])
+        if unless:
+            kept = " or ".join(unless)
+            terms.append(f"((not {deny}) or {kept})")
+        else:
+            terms.append(f"not {deny}")
+    return " and ".join(terms)
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(prog="create_skip_tests.py")
+    p.add_argument(
+        "--jax-version",
+        default="",
+        help="JAX version being tested (e.g. 0.10.2), or 'all' for every file",
+    )
+    p.add_argument(
+        "--amdgpu-family",
+        default="",
+        help="GPU family being tested (e.g. gfx94X-dcgpu)",
+    )
+    p.add_argument(
+        "--debug",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Print an expression selecting only the skipped tests",
+    )
+    args = p.parse_args(argv)
+
+    print(keyword_expression(args.jax_version, args.amdgpu_family, args.debug))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/external-builds/jax/skip_tests/generic.py
+++ b/external-builds/jax/skip_tests/generic.py
@@ -1,0 +1,6 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests skipped on every JAX version. See README.md for the entry format."""
+
+skip_tests = {}

--- a/external-builds/jax/skip_tests/jax_0.10.1.py
+++ b/external-builds/jax/skip_tests/jax_0.10.1.py
@@ -1,0 +1,25 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests skipped on JAX 0.10.1. See README.md for the entry format."""
+
+skip_tests = {
+    "gfx94": {
+        # MIOpen selects convolution kernels nondeterministically here, so the
+        # float32 convolution tests flake. The other keywords are convolutions
+        # under another name: pooling, Toeplitz and Hankel build on the same
+        # kernels, and polymul convolves fixed inputs and returned a different
+        # wrong answer in each of the five jobs it has failed. convert and
+        # conversion only match "conv" by accident and are healthy.
+        #
+        # Remove once these pass across repeated runs.
+        "keywords": [
+            {"deny": "conv", "unless": ["convert", "conversion"]},
+            {"deny": "sumpool"},
+            {"deny": "minmaxpool"},
+            {"deny": "toeplitz"},
+            {"deny": "hankel"},
+            {"deny": "polymul"},
+        ],
+    },
+}

--- a/external-builds/jax/skip_tests/jax_0.10.2.py
+++ b/external-builds/jax/skip_tests/jax_0.10.2.py
@@ -1,0 +1,18 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests skipped on JAX 0.10.2. See README.md for the entry format."""
+
+skip_tests = {
+    "gfx94": {
+        # Same nondeterministic MIOpen kernel selection as 0.10.1; see that file.
+        "keywords": [
+            {"deny": "conv", "unless": ["convert", "conversion"]},
+            {"deny": "sumpool"},
+            {"deny": "minmaxpool"},
+            {"deny": "toeplitz"},
+            {"deny": "hankel"},
+            {"deny": "polymul"},
+        ],
+    },
+}

--- a/test_tools/list_pytest_failed_tests.py
+++ b/test_tools/list_pytest_failed_tests.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Lists the failed tests in a pytest JSON report, for a fresh-process retry.
+
+Some failures are sticky: the first one leaves the process failing every later
+test the same way, so only a new process tells a real failure apart from a
+poisoned one. Observed on a pytest-xdist worker's first complex-gemm call and on
+a code object failing to load.
+
+A subTest failure is recorded as failed with no message, which costs nothing
+here: a retry needs only the nodeid.
+
+Example usage:
+
+    python list_pytest_failed_tests.py logs/pytest_results_single.json
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+def failed_in_report(report: dict) -> list[str]:
+    """The nodeids a parsed JSON report records as failed.
+
+    Separate from failed_tests so that a caller reading other fields of the same
+    report, such as its exit code, parses it once. These reports hold a record
+    per test and run to tens of megabytes.
+    """
+    return [
+        test["nodeid"]
+        for test in report.get("tests", [])
+        if test.get("outcome") in ("failed", "error")
+    ]
+
+
+def failed_tests(report_path: pathlib.Path) -> list[str]:
+    """The nodeids a JSON report records as failed."""
+    return failed_in_report(json.loads(report_path.read_text()))
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(prog="list_pytest_failed_tests.py")
+    p.add_argument(
+        "reports",
+        nargs="+",
+        type=pathlib.Path,
+        help="pytest-json-report files; missing ones are skipped",
+    )
+    p.add_argument(
+        "--max-tests",
+        type=int,
+        default=40,
+        help="Refuse to retry above this many failures (0 disables)",
+    )
+    args = p.parse_args(argv)
+
+    failed: list[str] = []
+    for report in args.reports:
+        if not report.exists():
+            print(f"{report}: not found, skipping", file=sys.stderr)
+            continue
+        failed += failed_tests(report)
+
+    # The retry pass is serial, and a configuration this broken is something
+    # other than a few poisoned workers.
+    if args.max_tests and len(failed) > args.max_tests:
+        print(
+            f"{len(failed)} failures is more than --max-tests"
+            f" {args.max_tests}, so nothing will be retried",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\n".join(failed))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Motivation

Run the whole JAX test suite instead of a handful of tests, through ROCm/jax's `ci/run_pytest_rocm.sh`, which sets up pytest and excludes the multi-GPU tests. Coverage goes from a few hundred tests to roughly 28k-29k per job, which is what surfaced the ROCm 10 plugin-naming break (fixed separately, already on `main`) and the sticky library faults below.

## Technical Details

**The job is a script, not a workflow step.** The environment, the deselected tests and the retry logic all lived in the YAML, so reproducing a failure locally meant transcribing it by hand. `external-builds/jax/run_jax_tests.py` now owns all of it, and the workflow calls it, so this reproduces a CI job:

```bash
python external-builds/jax/run_jax_tests.py \
  --jax-dir jax_tests --jax-version 0.10.2 --amdgpu-family gfx94X-dcgpu
```

`--dry-run`, `--debug` (run only what the skip lists skip), `--no-retries` and `--cpus N` cover the rest.

**The suite script stays the source of truth.** The runner adds only what is ours and reads the allocator and XLA flags back out of the script's environment section, so the retry pass matches the run it checks and a version changing those values needs no change here. If that section cannot be read, the job fails with an error naming what to update rather than retrying under a mismatched environment.

**Installs.** ROCm via `setup_venv.py`, wheels via `install_jax_wheels.py`, test deps via `install_jax_test_requirements.py` from JAX's own pinned lock file, all with retries, since one PyPI timeout has cost a job a whole run. The ROCm packages are `rocm[libraries]` alone, since that is what RELEASES.md tells users to install; verified on MI355X that matmul, cholesky, FFT and the MIOpen convolutions all pass without `[devel]`.

**Skip lists.** Deselected tests move to `external-builds/jax/skip_tests/`, following the PyTorch layout, so an entry carries the reason it exists and what would let it be removed. MIOpen selects convolution kernels nondeterministically on gfx94X, so the float32 conv tests flake on `v0.10.1` and `v0.10.2`, along with pooling, Toeplitz and Hankel, which build on the same kernels, and `polymul`, which convolves fixed inputs.

**Sticky library faults need a new process.** In-process reruns clear worker aborts and one-off runtime errors. `rocblas_cgemm failed` and `Failed to load HSACO` are different: rocBLAS caches a failed lazy Tensile load for a problem shape, so that worker fails the shape for the rest of its life while its siblings on the same GPU keep passing, and no in-process rerun can clear it. When the suite fails, `test_tools/list_pytest_failed_tests.py` pulls the failed node ids out of the JSON reports and the runner re-runs them serially in a fresh process. That pass decides the job, but only when every report ends in a finished session, so a run pytest stopped early cannot go green on the failures it happened to record. The list is capped at 40, so a badly broken job still fails.

**CPU sizing.** A container shares the host's kernel, so a job holding 25 cores of a shared box reads 192 and sizes every thread pool from that: over a thousand threads per worker against 16 workers. The run is pinned to `KUBE_CPU_REQUEST`, which takes a worker to about a hundred. Where the variable is not injected yet (OSSCI-2631), it warns and takes one thread per worker, as the PyTorch jobs do.

**Also:** test step timeout raised to 120 minutes, since the suite runs 35-70 minutes per version and 60 killed a job that had reached every test; test logs uploaded as an artifact; driver and GPU info printed, whose device serials identify a recurring bad device across runs; the workflow renamed to match what it now runs; unit tests added for the runner, the install scripts, the skip lists and the failed-test lister.

## Test Plan

- ROCm 7, [run 30527360755](https://github.com/ROCm/TheRock/actions/runs/30527360755): `v0.10.0` and `v0.10.2` pass on all four Python versions; `v0.10.1` has 4 failures out of 28396 passed, and `v0.11.0` has 4 xdist serialization errors out of 29187 passed.
- ROCm 10 before the plugin-name fix, [run 30561401221](https://github.com/ROCm/TheRock/actions/runs/30561401221): all 15 jobs failed with 1468 failures each, essentially all `No FFI handler registered for hipsolver_*` or `'NoneType' object has no attribute ...`.
- ROCm 10 after it, [run 30701879601](https://github.com/ROCm/TheRock/actions/runs/30701879601): 15 failures across 7 of 15 jobs, 33-56 minutes per job: 8 rocBLAS complex gemm, 2 HSACO `InvalidImage`, 2 hipSOLVER, 3 `testPolyMul7`.
- Retry pass, [run 30729289444](https://github.com/ROCm/TheRock/actions/runs/30729289444): the two jobs that faulted, `testVecmat7` on `rocblas_cgemm` and `testPinv4` on HSACO, both passed the fresh-process retry in seconds on the same GPU after failing every in-process attempt.
- Worker-count probes: 8 workers, [run 30717048816](https://github.com/ROCm/TheRock/actions/runs/30717048816), still left 19 failures across 6 of 15 jobs; 4 ran clean but cost 45% more wall time. The retry pass buys the same result without the wall time.
- Full matrix on this branch, [run 30781739300](https://github.com/ROCm/TheRock/actions/runs/30781739300): all 15 test jobs green.

Ruled out: memory creep with and without `HSA_NO_SCRATCH_RECLAIM`, GPU memory exhaustion (which gives a clean `RESOURCE_EXHAUSTED`, never `INTERNAL`), and co-tenancy on sibling GPUs, since neighbours were present through the fault-free stretches too.

## Open items

- rocBLAS and HIP bug reports for the sticky complex-gemm and code-object load failures.
- The gfx94X convolution tests and `polymul` are deselected rather than fixed; the MIOpen kernel-selection root cause is still open.
- `KUBE_CPU_REQUEST` is not injected on every runner pool yet (OSSCI-2631).
- Test-size filtering for PR versus nightly is handled separately in #6753.

JIRA ID: AIJAX-210