### PR TITLE
[ci] Test weighted Windows runner config

### DIFF
--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ROCm/therock-ci-config
-          ref: users/justchen/windows-aws-10-percent
+          ref: users/justchen/windows-aws-100-percent
           path: ci-config
         continue-on-error: true
 

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ROCm/therock-ci-config
-          ref: main
+          ref: users/justchen/windows-aws-10-percent
           path: ci-config
         continue-on-error: true
 


### PR DESCRIPTION
## Purpose

Tests the weighted Windows build-runner routing proposed in ROCm/therock-ci-config#13 by pinning TheRock's CI-config checkout to `users/justchen/windows-aws-10-percent`.

That config routes each generated Windows build configuration to:

- `azure-windows-scale-rocm`: 90%
- `aws-windows-scale-rocm-prod`: 10%

## Testing

Run **Multi-Arch CI** manually from this branch with Linux families empty and a Windows family such as `gfx110x`. Inspect the setup output and Windows build job's `runs-on` label. Repeated dispatches are needed to sample the random selection; a single run cannot validate the distribution.

The probability of observing AWS at least once is approximately 52% after 7 runs, 90% after 22 runs, and 95% after 29 runs.

## Validation

- workflow YAML parses successfully
- `git diff --check` passes
- referenced config branch exists

> [!WARNING]
> **DO NOT MERGE.** This PR temporarily pins TheRock to a test config branch. Close it after validation completes.