### PR TITLE
ci: route sanitizer builds to AWS prod large runner (aws-linux-scale-rocm-large)

### DIFF
--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -161,7 +161,7 @@ jobs:
           BASELINE_RUN_ID: ${{ inputs.baseline_run_id }}
           # Skip path filtering for external repos (git sha won't exist in TheRock)
           SKIP_PATH_FILTERS: ${{ inputs.external_repo != '' && 'true' || '' }}
-          CI_CONFIG_PATH: ci-config
+          CI_CONFIG_PATH:
           # External repo family overrides allow callers to add/modify GPU family configs
           # (e.g., adding test runners for architectures not enabled in TheRock's default config)
           EXTERNAL_FAMILY_OVERRIDES: ${{ inputs.external_repo != '' && toJSON(fromJSON(inputs.external_repo).family_overrides) || '' }}

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -87,14 +87,14 @@ def select_weighted_label(labels_config: list[dict], context_name: str) -> str:
 
 # Build runner configuration for Linux builds
 # Uses weighted distribution: 100% AWS
-# Sanitizer builds (asan/tsan) use ramdisk variants (100% Azure, no AWS yet)
+# Sanitizer builds (asan/tsan) use ramdisk variants (100% AWS prod r8a large)
 BUILD_RUNNER_LABELS = {
     "linux": {
         "default": [
             {"label": "aws-linux-scale-rocm-prod", "weight": 1.0},
         ],
         "sanitizer": [
-            {"label": "azure-linux-scale-rocm-heavy-ramdisk", "weight": 1.0},
+            {"label": "aws-linux-scale-rocm-large", "weight": 1.0},
         ],
     },
     "windows": {


### PR DESCRIPTION
## Summary

Routes ASAN/TSAN sanitizer builds from Azure ramdisk runners to the AWS prod large CPU nodegroup.

- `aws-linux-scale-rocm-large` — `r8a.48xlarge`, 192 vCPU / 1536 GiB RAM, AMD EPYC 9R14 (Turin), EBS-backed ramdisk via tmpfs
- Unsets `CI_CONFIG_PATH` so `configure_multi_arch_ci.py` uses the local `amdgpu_family_matrix.py` runner labels rather than pulling from an external config path

## Changes

| File | Change |
|---|---|
| `.github/workflows/setup_multi_arch.yml` | Unset `CI_CONFIG_PATH` (was `ci-config`) |
| `build_tools/github_actions/amdgpu_family_matrix.py` | `sanitizer` label: `azure-linux-scale-rocm-heavy-ramdisk` → `aws-linux-scale-rocm-large` |

## Test plan

- [ ] Trigger `multi_arch_ci_asan.yml` on this branch and confirm jobs route to `aws-linux-scale-rocm-large` runners
- [ ] Sanitizer build completes successfully on r8a.48xlarge nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)