### PR TITLE
ci(test): use explicit artifact group for component setup

### DIFF
--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -122,8 +122,7 @@ jobs:
         uses: './.github/actions/setup_test_environment'
         with:
           ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
-          # TODO(#3381): revert back to `inputs.artifact_group` once issue is resolved
-          ARTIFACT_GROUP: ${{ inputs.amdgpu_families }}
+          ARTIFACT_GROUP: ${{ inputs.artifact_group }}
           AMDGPU_TARGETS: ${{ inputs.amdgpu_targets }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}


### PR DESCRIPTION
## Summary

JIRA ID : AIHPBLAS-3605
https://amd-hub.atlassian.net/browse/AIHPBLAS-3605

Use the `artifact_group` workflow input when setting up test component artifacts, instead of using `amdgpu_families` as the artifact group.

`test_component.yml` already accepts both inputs and exposes `ARTIFACT_GROUP` from `inputs.artifact_group` at the job level. The setup step, however, still passes `inputs.amdgpu_families` as `ARTIFACT_GROUP`.

## Why

`artifact_group` is the artifact set to download. `amdgpu_families` is the target-family context for the test matrix: it is used for runner selection, job naming, `AMDGPU_FAMILIES`, target derivation, and per-family test behavior.

Those values are often identical, but they are not the same concept. Our eventual goal is for rocjitsu to run GPU-targeted artifacts on CPU in emulation, so CPU-side test components need to be able to download GPU-family artifacts without coupling artifact selection to runner selection.

## Testing

- `pre-commit run --files .github/workflows/test_component.yml`
