### PR TITLE
ci: update gfx125x presubmit fallback matrix

### DIFF
--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -4,9 +4,8 @@
 """
 AMD GPU Family Matrix and runner selection utilities for GitHub workflows.
 
-NOTE: The primary source of truth for GPU families and runner labels is
-ROCm/therock-ci-config (runner-config.json). The definitions in this file
-serve as a fallback when external config is not available.
+NOTE: GitHub CI loads ROCm/therock-ci-config via CI_CONFIG_PATH. The
+definitions in this file are the local fallback when that config is unavailable.
 
 For presubmit, postsubmit and nightly family selection:
 

--- a/build_tools/github_actions/amdgpu_family_matrix.py
+++ b/build_tools/github_actions/amdgpu_family_matrix.py
@@ -281,6 +281,16 @@ amdgpu_family_info_matrix_presubmit = {
             "nightly_check_only_for_family": True,
         },
     },
+    "gfx125x": {
+        "linux": {
+            # No hardware available for testing yet; build-only.
+            # PyTorch builds are included for manual and postsubmit runs.
+            "test-runs-on": "",
+            "family": "gfx125X-dcgpu",
+            "fetch-gfx-targets": [],
+            "build_variants": ["release"],
+        },
+    },
 }
 
 
@@ -437,18 +447,6 @@ amdgpu_family_info_matrix_nightly = {
         "windows": {
             "test-runs-on": "",
             "family": "gfx1153",
-            "fetch-gfx-targets": [],
-            "build_variants": ["release"],
-        },
-    },
-    "gfx125x": {
-        "linux": {
-            # No hardware available for testing yet; build-only.
-            # PyTorch builds are included — workflow_dispatch can be used
-            # to trigger manually; nightly schedule runs both ROCm stack
-            # and PyTorch builds.
-            "test-runs-on": "",
-            "family": "gfx125X-dcgpu",
             "fetch-gfx-targets": [],
             "build_variants": ["release"],
         },

--- a/build_tools/github_actions/new_amdgpu_family_matrix.py
+++ b/build_tools/github_actions/new_amdgpu_family_matrix.py
@@ -59,7 +59,13 @@ Cmake targets are defined in: cmake/therock_amdgpu_targets.cmake
 
 amdgpu_family_predefined_groups = {
     # The 'presubmit' matrix runs on 'pull_request' triggers (on all PRs).
-    "amdgpu_presubmit": ["gfx94X-dcgpu", "gfx110X-all", "gfx1151", "gfx120X-all"],
+    "amdgpu_presubmit": [
+        "gfx94X-dcgpu",
+        "gfx110X-all",
+        "gfx1151",
+        "gfx120X-all",
+        "gfx125X-dcgpu",
+    ],
     # The 'postsubmit' matrix runs on 'push' triggers (for every commit to the default branch).
     "amdgpu_postsubmit": ["gfx950-dcgpu"],
     # The 'nightly' matrix runs on 'schedule' triggers.
@@ -70,7 +76,6 @@ amdgpu_family_predefined_groups = {
         "gfx1150",
         "gfx1152",
         "gfx1153",
-        "gfx125X-dcgpu",
     ],
 }
 

--- a/build_tools/github_actions/tests/amdgpu_family_matrix_test.py
+++ b/build_tools/github_actions/tests/amdgpu_family_matrix_test.py
@@ -129,6 +129,21 @@ class TestExternalConfig(unittest.TestCase):
         # Should contain entries from local presubmit matrix
         self.assertIn("gfx94x", result)
 
+    def test_local_fallback_has_gfx125x_presubmit_build_only(self):
+        """The local fallback keeps gfx125x as a presubmit build-only target."""
+        if "CI_CONFIG_PATH" in os.environ:
+            del os.environ["CI_CONFIG_PATH"]
+        result = get_all_families_for_trigger_types(["presubmit"])
+        self.assertEqual(
+            result["gfx125x"]["linux"],
+            {
+                "test-runs-on": "",
+                "family": "gfx125X-dcgpu",
+                "fetch-gfx-targets": [],
+                "build_variants": ["release"],
+            },
+        )
+
     def test_get_build_runner_labels_uses_external_config_when_available(self):
         """get_build_runner_labels uses external config when available."""
         fake_config = {


### PR DESCRIPTION
ISSUE ID: #6557

## Summary
- keep TheRock local fallback GPU matrices in sync for `gfx125x` / `gfx125X-dcgpu` presubmit builds
- document that GitHub CI normally loads `ROCm/therock-ci-config` through `CI_CONFIG_PATH`
- add a fallback-matrix regression test for the build-only `gfx125x` entry

The live CI config change is in ROCm/therock-ci-config#14.

## Testing
- `python3 -m unittest build_tools/github_actions/tests/amdgpu_family_matrix_test.py`
- `PYTHONPATH=build_tools/github_actions/tests python3 -m unittest build_tools/github_actions/tests/configure_multi_arch_ci_test.py`
- `python3 -m py_compile build_tools/github_actions/amdgpu_family_matrix.py build_tools/github_actions/new_amdgpu_family_matrix.py build_tools/github_actions/tests/amdgpu_family_matrix_test.py`
- `git diff --check`