### PR TITLE
Include libhipcxx dev artifact in rocm-sdk-devel package

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -384,11 +384,16 @@ def _run_kpack_split(
     devel = PopulatedDistPackage(params, logical_name="devel", target_family=None)
     devel.populate_devel_files(
         addl_artifact_names=[
+            # Header-only libraries not included in runtime packages.
             "prim",
             "rocwmma",
+            "libhipcxx",
+            # Third party dependencies needed by hipDNN consumers.
             "flatbuffers",
             "nlohmann-json",
+            # rocshmem only provides a static library.
             "rocshmem",
+            # rocjitsu emulation suite.
             "rocjitsu",
             "mirage",
         ],


### PR DESCRIPTION
## Motivation

libhipcxx is a header-only library and produces no runtime artifact, so it must be explicitly listed in `addl_artifact_names` to appear in the kpack-split devel package.

## Technical Details

This patch does not touch the legacy packages which already diverged from the kpack-split enabled multi-arch packages.

Closes #6588.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
