### PR TITLE
build(pytorch): build torch wheels with python -m build on all platforms (#6594)

### DIFF
--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -1150,63 +1150,47 @@ def do_build_pytorch(
         cwd=pytorch_dir,
     )
 
+    # PEP 517 build backend requirements. We build below with
+    # `python -m build --wheel --no-isolation`, which (unlike an isolated build)
+    # does not auto-install the backend declared in pyproject.toml's
+    # [build-system]. PyTorch's backend switches from setuptools to
+    # scikit-build-core on 2026-07-20 (ROCm/TheRock#6523); newer checkouts ship
+    # requirements-build.txt (pinning scikit-build-core>=1.0), older ones do
+    # not. `build` provides the `python -m build` frontend itself.
+    print("+++ Installing pytorch build backend requirements:")
+    build_backend_install = [sys.executable, "-m", "pip", "install", "build"]
+    pytorch_build_requirements = pytorch_dir / "requirements-build.txt"
+    if pytorch_build_requirements.exists():
+        build_backend_install += ["-r", pytorch_build_requirements]
+    run_command(build_backend_install + pip_install_args, cwd=pytorch_dir)
+
     if is_windows:
-        # As of 2025-06-24, the 'ninja' package on pypi is trailing too far
-        # behind upstream:
-        # * https://pypi.org/project/ninja/#history
-        # * https://github.com/ninja-build/ninja/releases
-        # Version 1.11.1 is buggy on Windows (looping without making progress):
+        # Keep the PyPI ninja (its presence satisfies the PEP 517 dependency
+        # check that `python -m build` runs), but ensure a Windows-safe version:
+        # 1.11.1 loops without making progress and 1.13.0 has an MSVC link.exe
+        # RSP regression (LNK1104/LNK1181); both are fixed in 1.13.1+.
+        # See https://github.com/ninja-build/ninja/issues/2616.
         run_command(
-            [
-                sys.executable,
-                "-m",
-                "pip",
-                "uninstall",
-                "ninja",
-                "-y",
-            ],
+            [sys.executable, "-m", "pip", "install", "ninja>=1.13.1"]
+            + pip_install_args,
             cwd=pytorch_dir,
         )
-    else:
-        # PEP 517 build backend requirements. Linux builds below with
-        # `python -m build --wheel --no-isolation`, which (unlike an isolated
-        # build) does not auto-install the backend declared in pyproject.toml's
-        # [build-system]. PyTorch's backend switches from setuptools to
-        # scikit-build-core on 2026-07-20 (ROCm/TheRock#6523); newer checkouts
-        # ship requirements-build.txt (pinning scikit-build-core>=1.0), older
-        # ones do not. `build` provides the `python -m build` frontend itself.
-        print("+++ Installing pytorch build backend requirements:")
-        build_backend_install = [sys.executable, "-m", "pip", "install", "build"]
-        pytorch_build_requirements = pytorch_dir / "requirements-build.txt"
-        if pytorch_build_requirements.exists():
-            build_backend_install += ["-r", pytorch_build_requirements]
-        run_command(build_backend_install + pip_install_args, cwd=pytorch_dir)
 
     print("+++ Building pytorch:")
     remove_dir_if_exists(pytorch_dir / "dist")
     if args.clean:
         remove_dir_if_exists(pytorch_dir / "build")
-    if is_windows:
-        # Windows keeps `setup.py bdist_wheel` for now (ROCm/TheRock#6594).
-        # `python -m build` validates PEP 517 build dependencies before invoking
-        # the backend and fails with "Missing dependencies: ninja" after we
-        # uninstall the PyPI ninja package (1.11.1 is buggy on Windows; runners
-        # provide a system ninja on PATH instead).
-        run_command(
-            [sys.executable, "setup.py", "bdist_wheel"], cwd=pytorch_dir, env=env
-        )
-    else:
-        # `python -m build --wheel --no-isolation` is the standard replacement
-        # for the removed `setup.py bdist_wheel` (ROCm/TheRock#6523). It drives
-        # the legacy setuptools backend and the new scikit-build-core backend
-        # alike, and all build-configuration env vars (USE_ROCM,
-        # PYTORCH_ROCM_ARCH, MAX_JOBS, ...) continue to be honored as they now
-        # seed the CMake cache directly.
-        run_command(
-            [sys.executable, "-m", "build", "--wheel", "--no-isolation"],
-            cwd=pytorch_dir,
-            env=env,
-        )
+    # `python -m build --wheel --no-isolation` is the standard replacement for
+    # the removed `setup.py bdist_wheel` (ROCm/TheRock#6523), used on all
+    # platforms. It drives the legacy setuptools backend and the new
+    # scikit-build-core backend alike, and all build-configuration env vars
+    # (USE_ROCM, PYTORCH_ROCM_ARCH, MAX_JOBS, ...) continue to be honored as they
+    # now seed the CMake cache directly.
+    run_command(
+        [sys.executable, "-m", "build", "--wheel", "--no-isolation"],
+        cwd=pytorch_dir,
+        env=env,
+    )
     built_wheel = find_built_wheel(pytorch_dir / "dist", "torch")
     print(f"Found built wheel: {built_wheel}")
     copy_to_output(args, built_wheel)

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -1149,6 +1149,7 @@ def do_build_pytorch(
         + pip_install_args,
         cwd=pytorch_dir,
     )
+
     if is_windows:
         # As of 2025-06-24, the 'ninja' package on pypi is trailing too far
         # behind upstream:
@@ -1166,11 +1167,46 @@ def do_build_pytorch(
             ],
             cwd=pytorch_dir,
         )
+    else:
+        # PEP 517 build backend requirements. Linux builds below with
+        # `python -m build --wheel --no-isolation`, which (unlike an isolated
+        # build) does not auto-install the backend declared in pyproject.toml's
+        # [build-system]. PyTorch's backend switches from setuptools to
+        # scikit-build-core on 2026-07-20 (ROCm/TheRock#6523); newer checkouts
+        # ship requirements-build.txt (pinning scikit-build-core>=1.0), older
+        # ones do not. `build` provides the `python -m build` frontend itself.
+        print("+++ Installing pytorch build backend requirements:")
+        build_backend_install = [sys.executable, "-m", "pip", "install", "build"]
+        pytorch_build_requirements = pytorch_dir / "requirements-build.txt"
+        if pytorch_build_requirements.exists():
+            build_backend_install += ["-r", pytorch_build_requirements]
+        run_command(build_backend_install + pip_install_args, cwd=pytorch_dir)
+
     print("+++ Building pytorch:")
     remove_dir_if_exists(pytorch_dir / "dist")
     if args.clean:
         remove_dir_if_exists(pytorch_dir / "build")
-    run_command([sys.executable, "setup.py", "bdist_wheel"], cwd=pytorch_dir, env=env)
+    if is_windows:
+        # Windows keeps `setup.py bdist_wheel` for now (ROCm/TheRock#6594).
+        # `python -m build` validates PEP 517 build dependencies before invoking
+        # the backend and fails with "Missing dependencies: ninja" after we
+        # uninstall the PyPI ninja package (1.11.1 is buggy on Windows; runners
+        # provide a system ninja on PATH instead).
+        run_command(
+            [sys.executable, "setup.py", "bdist_wheel"], cwd=pytorch_dir, env=env
+        )
+    else:
+        # `python -m build --wheel --no-isolation` is the standard replacement
+        # for the removed `setup.py bdist_wheel` (ROCm/TheRock#6523). It drives
+        # the legacy setuptools backend and the new scikit-build-core backend
+        # alike, and all build-configuration env vars (USE_ROCM,
+        # PYTORCH_ROCM_ARCH, MAX_JOBS, ...) continue to be honored as they now
+        # seed the CMake cache directly.
+        run_command(
+            [sys.executable, "-m", "build", "--wheel", "--no-isolation"],
+            cwd=pytorch_dir,
+            env=env,
+        )
     built_wheel = find_built_wheel(pytorch_dir / "dist", "torch")
     print(f"Found built wheel: {built_wheel}")
     copy_to_output(args, built_wheel)

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -1150,47 +1150,63 @@ def do_build_pytorch(
         cwd=pytorch_dir,
     )
 
-    # PEP 517 build backend requirements. We build below with
-    # `python -m build --wheel --no-isolation`, which (unlike an isolated build)
-    # does not auto-install the backend declared in pyproject.toml's
-    # [build-system]. PyTorch's backend switches from setuptools to
-    # scikit-build-core on 2026-07-20 (ROCm/TheRock#6523); newer checkouts ship
-    # requirements-build.txt (pinning scikit-build-core>=1.0), older ones do
-    # not. `build` provides the `python -m build` frontend itself.
-    print("+++ Installing pytorch build backend requirements:")
-    build_backend_install = [sys.executable, "-m", "pip", "install", "build"]
-    pytorch_build_requirements = pytorch_dir / "requirements-build.txt"
-    if pytorch_build_requirements.exists():
-        build_backend_install += ["-r", pytorch_build_requirements]
-    run_command(build_backend_install + pip_install_args, cwd=pytorch_dir)
-
     if is_windows:
-        # Keep the PyPI ninja (its presence satisfies the PEP 517 dependency
-        # check that `python -m build` runs), but ensure a Windows-safe version:
-        # 1.11.1 loops without making progress and 1.13.0 has an MSVC link.exe
-        # RSP regression (LNK1104/LNK1181); both are fixed in 1.13.1+.
-        # See https://github.com/ninja-build/ninja/issues/2616.
+        # As of 2025-06-24, the 'ninja' package on pypi is trailing too far
+        # behind upstream:
+        # * https://pypi.org/project/ninja/#history
+        # * https://github.com/ninja-build/ninja/releases
+        # Version 1.11.1 is buggy on Windows (looping without making progress):
         run_command(
-            [sys.executable, "-m", "pip", "install", "ninja>=1.13.1"]
-            + pip_install_args,
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "uninstall",
+                "ninja",
+                "-y",
+            ],
             cwd=pytorch_dir,
         )
+    else:
+        # PEP 517 build backend requirements. Linux builds below with
+        # `python -m build --wheel --no-isolation`, which (unlike an isolated
+        # build) does not auto-install the backend declared in pyproject.toml's
+        # [build-system]. PyTorch's backend switches from setuptools to
+        # scikit-build-core on 2026-07-20 (ROCm/TheRock#6523); newer checkouts
+        # ship requirements-build.txt (pinning scikit-build-core>=1.0), older
+        # ones do not. `build` provides the `python -m build` frontend itself.
+        print("+++ Installing pytorch build backend requirements:")
+        build_backend_install = [sys.executable, "-m", "pip", "install", "build"]
+        pytorch_build_requirements = pytorch_dir / "requirements-build.txt"
+        if pytorch_build_requirements.exists():
+            build_backend_install += ["-r", pytorch_build_requirements]
+        run_command(build_backend_install + pip_install_args, cwd=pytorch_dir)
 
     print("+++ Building pytorch:")
     remove_dir_if_exists(pytorch_dir / "dist")
     if args.clean:
         remove_dir_if_exists(pytorch_dir / "build")
-    # `python -m build --wheel --no-isolation` is the standard replacement for
-    # the removed `setup.py bdist_wheel` (ROCm/TheRock#6523), used on all
-    # platforms. It drives the legacy setuptools backend and the new
-    # scikit-build-core backend alike, and all build-configuration env vars
-    # (USE_ROCM, PYTORCH_ROCM_ARCH, MAX_JOBS, ...) continue to be honored as they
-    # now seed the CMake cache directly.
-    run_command(
-        [sys.executable, "-m", "build", "--wheel", "--no-isolation"],
-        cwd=pytorch_dir,
-        env=env,
-    )
+    if is_windows:
+        # Windows keeps `setup.py bdist_wheel` for now (ROCm/TheRock#6594).
+        # `python -m build` validates PEP 517 build dependencies before invoking
+        # the backend and fails with "Missing dependencies: ninja" after we
+        # uninstall the PyPI ninja package (1.11.1 is buggy on Windows; runners
+        # provide a system ninja on PATH instead).
+        run_command(
+            [sys.executable, "setup.py", "bdist_wheel"], cwd=pytorch_dir, env=env
+        )
+    else:
+        # `python -m build --wheel --no-isolation` is the standard replacement
+        # for the removed `setup.py bdist_wheel` (ROCm/TheRock#6523). It drives
+        # the legacy setuptools backend and the new scikit-build-core backend
+        # alike, and all build-configuration env vars (USE_ROCM,
+        # PYTORCH_ROCM_ARCH, MAX_JOBS, ...) continue to be honored as they now
+        # seed the CMake cache directly.
+        run_command(
+            [sys.executable, "-m", "build", "--wheel", "--no-isolation"],
+            cwd=pytorch_dir,
+            env=env,
+        )
     built_wheel = find_built_wheel(pytorch_dir / "dist", "torch")
     print(f"Found built wheel: {built_wheel}")
     copy_to_output(args, built_wheel)

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -1150,63 +1150,49 @@ def do_build_pytorch(
         cwd=pytorch_dir,
     )
 
+    # PEP 517 build backend requirements. We build below with
+    # `python -m build --wheel --no-isolation`, which (unlike an isolated build)
+    # does not auto-install the backend declared in pyproject.toml's
+    # [build-system]. PyTorch migrated its build backend from setuptools to
+    # scikit-build-core (ROCm/TheRock#6523; setup.py no longer builds wheels on
+    # recent checkouts). Newer checkouts ship requirements-build.txt (pinning
+    # scikit-build-core>=1.0), older ones do not. `build` provides the
+    # `python -m build` frontend itself.
+    print("+++ Installing pytorch build backend requirements:")
+    build_backend_install = [sys.executable, "-m", "pip", "install", "build"]
+    pytorch_build_requirements = pytorch_dir / "requirements-build.txt"
+    if pytorch_build_requirements.exists():
+        build_backend_install += ["-r", pytorch_build_requirements]
+    run_command(build_backend_install + pip_install_args, cwd=pytorch_dir)
+
+    build_command = [sys.executable, "-m", "build", "--wheel", "--no-isolation"]
     if is_windows:
-        # As of 2025-06-24, the 'ninja' package on pypi is trailing too far
-        # behind upstream:
-        # * https://pypi.org/project/ninja/#history
-        # * https://github.com/ninja-build/ninja/releases
-        # Version 1.11.1 is buggy on Windows (looping without making progress):
+        # The PyPI `ninja` package is unusable on Windows: 1.11.1 loops without
+        # making progress and 1.13.0 has an MSVC link.exe RSP-file regression
+        # (LNK1104/LNK1181), and no fixed version has been published
+        # (scikit-build/ninja-python-distributions#308). requirements-build.txt
+        # just pulled it in, so remove it; the runner provides a good system
+        # ninja (>=1.13.1) on PATH that CMake uses instead.
         run_command(
-            [
-                sys.executable,
-                "-m",
-                "pip",
-                "uninstall",
-                "ninja",
-                "-y",
-            ],
+            [sys.executable, "-m", "pip", "uninstall", "ninja", "-y"],
             cwd=pytorch_dir,
         )
-    else:
-        # PEP 517 build backend requirements. Linux builds below with
-        # `python -m build --wheel --no-isolation`, which (unlike an isolated
-        # build) does not auto-install the backend declared in pyproject.toml's
-        # [build-system]. PyTorch's backend switches from setuptools to
-        # scikit-build-core on 2026-07-20 (ROCm/TheRock#6523); newer checkouts
-        # ship requirements-build.txt (pinning scikit-build-core>=1.0), older
-        # ones do not. `build` provides the `python -m build` frontend itself.
-        print("+++ Installing pytorch build backend requirements:")
-        build_backend_install = [sys.executable, "-m", "pip", "install", "build"]
-        pytorch_build_requirements = pytorch_dir / "requirements-build.txt"
-        if pytorch_build_requirements.exists():
-            build_backend_install += ["-r", pytorch_build_requirements]
-        run_command(build_backend_install + pip_install_args, cwd=pytorch_dir)
+        # With the PyPI ninja gone, `python -m build`'s PEP 517 dependency check
+        # would abort with "Missing dependencies: ninja". Skip that check: the
+        # backend drives CMake, which finds the system ninja on PATH.
+        build_command.append("--skip-dependency-check")
 
     print("+++ Building pytorch:")
     remove_dir_if_exists(pytorch_dir / "dist")
     if args.clean:
         remove_dir_if_exists(pytorch_dir / "build")
-    if is_windows:
-        # Windows keeps `setup.py bdist_wheel` for now (ROCm/TheRock#6594).
-        # `python -m build` validates PEP 517 build dependencies before invoking
-        # the backend and fails with "Missing dependencies: ninja" after we
-        # uninstall the PyPI ninja package (1.11.1 is buggy on Windows; runners
-        # provide a system ninja on PATH instead).
-        run_command(
-            [sys.executable, "setup.py", "bdist_wheel"], cwd=pytorch_dir, env=env
-        )
-    else:
-        # `python -m build --wheel --no-isolation` is the standard replacement
-        # for the removed `setup.py bdist_wheel` (ROCm/TheRock#6523). It drives
-        # the legacy setuptools backend and the new scikit-build-core backend
-        # alike, and all build-configuration env vars (USE_ROCM,
-        # PYTORCH_ROCM_ARCH, MAX_JOBS, ...) continue to be honored as they now
-        # seed the CMake cache directly.
-        run_command(
-            [sys.executable, "-m", "build", "--wheel", "--no-isolation"],
-            cwd=pytorch_dir,
-            env=env,
-        )
+    # `python -m build --wheel --no-isolation` is the standard replacement for
+    # the removed `setup.py bdist_wheel` (ROCm/TheRock#6523), used on all
+    # platforms. It drives the legacy setuptools backend and the new
+    # scikit-build-core backend alike, and all build-configuration env vars
+    # (USE_ROCM, PYTORCH_ROCM_ARCH, MAX_JOBS, ...) continue to be honored as they
+    # now seed the CMake cache directly.
+    run_command(build_command, cwd=pytorch_dir, env=env)
     built_wheel = find_built_wheel(pytorch_dir / "dist", "torch")
     print(f"Found built wheel: {built_wheel}")
     copy_to_output(args, built_wheel)


### PR DESCRIPTION
## What happened

[#6537](https://github.com/ROCm/TheRock/pull/6537) switched the torch wheel build from `setup.py bdist_wheel` to `python -m build --wheel --no-isolation` on all platforms, ahead of PyTorch removing `setup.py` ([#6523](https://github.com/ROCm/TheRock/issues/6523)). It broke Windows ([#6594](https://github.com/ROCm/TheRock/issues/6594)) and was reverted ([#6595](https://github.com/ROCm/TheRock/pull/6595)).

The Windows breakage came from the PyPI `ninja` package, which we uninstall on Windows (1.11.1 loops; 1.13.0 has an MSVC `link.exe` RSP-file regression; no fixed version is published — scikit-build/ninja-python-distributions#308). With the package gone, `python -m build`'s PEP 517 dependency check aborts with `Missing dependencies: ninja`.

Keeping `setup.py bdist_wheel` on Windows is no longer viable: PyTorch's `setup.py` no longer builds wheels on recent checkouts (nightly's `setup.py` is a stub that errors on `bdist_wheel`), so that path is now broken there.

## What this PR does

Build torch wheels with `python -m build --wheel --no-isolation` on **all** platforms:

- Install the PEP 517 build backend requirements (`build` / `requirements-build.txt`) unconditionally.
- **Windows:** uninstall the broken PyPI `ninja` so CMake uses the runner's good **system ninja (>=1.13.1, via choco)** on PATH, and pass `--skip-dependency-check` so `python -m build` doesn't abort on the now-missing PyPI ninja package.

This drops the `setup.py` path entirely and satisfies #6523 on Windows too.

## Validation (py3.12, ROCm `7.15.0a20260727`, nightlies index, branch `users/ethanwee/fix-pytorch-windows-pep517`)

One build per supported PyTorch ref on **both** Linux and Windows (`test_amdgpu_families=none`):

| Platform | PyTorch ref | Run |
|----------|-------------|-----|
| Linux | release/2.9 | https://github.com/ROCm/TheRock/actions/runs/30295664132 |
| Windows | release/2.9 | https://github.com/ROCm/TheRock/actions/runs/30295455634 |
| Linux | release/2.10 | https://github.com/ROCm/TheRock/actions/runs/30295666479 |
| Windows | release/2.10 | https://github.com/ROCm/TheRock/actions/runs/30295457914 |
| Linux | release/2.11 | https://github.com/ROCm/TheRock/actions/runs/30295669272 |
| Windows | release/2.11 | https://github.com/ROCm/TheRock/actions/runs/30295460195 |
| Linux | release/2.12 | https://github.com/ROCm/TheRock/actions/runs/30295671679 |
| Windows | release/2.12 | https://github.com/ROCm/TheRock/actions/runs/30295462412 |
| Linux | nightly | https://github.com/ROCm/TheRock/actions/runs/30295466790 |
| Windows | nightly | https://github.com/ROCm/TheRock/actions/runs/30295464507 |

Closes #6594. Re-implements #6537 on all platforms without re-breaking Windows.
