### PR TITLE
ci: add no_rocm_image_ubuntu24_04_openmpi test image

### DIFF
--- a/.github/workflows/publish_no_rocm_image_ubuntu24_04.yml
+++ b/.github/workflows/publish_no_rocm_image_ubuntu24_04.yml
@@ -47,3 +47,12 @@ jobs:
     with:
       DOCKER_FILE_NAME: no_rocm_image_ubuntu24_04_media
       DOCKER_IMAGE_NAME: no_rocm_image_ubuntu24_04_media
+  # The image no_rocm_image_ubuntu24_04_openmpi is an extension of
+  # no_rocm_image_ubuntu24_04, so make sure we rebuild the _openmpi
+  # version whenever the base version changes.
+  publish_no_rocm_image_ubuntu24_04_openmpi:
+    needs: [publish_no_rocm_image_ubuntu24_04]
+    uses: ./.github/workflows/publish_dockerfile.yml
+    with:
+      DOCKER_FILE_NAME: no_rocm_image_ubuntu24_04_openmpi
+      DOCKER_IMAGE_NAME: no_rocm_image_ubuntu24_04_openmpi

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -105,10 +105,13 @@ by ocltst
 | [`no_rocm_image_ubuntu24_04_openmpi.Dockerfile`](no_rocm_image_ubuntu24_04_openmpi.Dockerfile) | https://github.com/ROCm/TheRock/pkgs/container/no_rocm_image_ubuntu24_04_openmpi |
 
 Extended version of no_rocm_image_ubuntu24_04.Dockerfile, containing a system
-OpenMPI install (`libopenmpi-dev`, `openmpi-bin`) required to build and run the
-rocprofv3 `mpi-ranks` integration tests. OpenMPI is intentionally not bundled in
-TheRock artifacts (to avoid forcing a specific MPI onto users), so it is provided
-at the system level here for the test environment.
+OpenMPI install (`libopenmpi-dev`, `openmpi-bin`) for the rocprofv3 `mpi-ranks`
+integration tests. Like the other `no_rocm_image_*` images this is a test-only
+image (not a ROCm build image): the rocprofiler-sdk tests are configured and
+compiled in-container at test time, so `find_package(MPI)` needs the OpenMPI
+headers and `mpiexec`. OpenMPI is intentionally not bundled in TheRock artifacts
+(to avoid forcing a specific MPI onto users), so it is provided at the system
+level here for the test environment.
 
 ### `rocm_runtime.Dockerfile`
 

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -100,6 +100,16 @@ This includes dejagnu, make, gcc, g++ and gfortran.
 Used in ocltst execution. It installs OCL ICD package required
 by ocltst
 
+| Source .Dockerfile                                                                             | Published package                                                                |
+| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [`no_rocm_image_ubuntu24_04_openmpi.Dockerfile`](no_rocm_image_ubuntu24_04_openmpi.Dockerfile) | https://github.com/ROCm/TheRock/pkgs/container/no_rocm_image_ubuntu24_04_openmpi |
+
+Extended version of no_rocm_image_ubuntu24_04.Dockerfile, containing a system
+OpenMPI install (`libopenmpi-dev`, `openmpi-bin`) required to build and run the
+rocprofv3 `mpi-ranks` integration tests. OpenMPI is intentionally not bundled in
+TheRock artifacts (to avoid forcing a specific MPI onto users), so it is provided
+at the system level here for the test environment.
+
 ### `rocm_runtime.Dockerfile`
 
 | Source .Dockerfile                                   | Published package |

--- a/dockerfiles/no_rocm_image_ubuntu24_04_openmpi.Dockerfile
+++ b/dockerfiles/no_rocm_image_ubuntu24_04_openmpi.Dockerfile
@@ -1,0 +1,12 @@
+FROM ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
+
+# no_rocm_image_ubuntu24_04_openmpi:
+# Extend the base no_rocm_image_ubuntu24_04 image with a system OpenMPI install
+# required to build and run the rocprofv3 mpi-ranks integration tests. OpenMPI is
+# intentionally not bundled in TheRock artifacts (to avoid forcing a specific MPI
+# onto users), so it is provided at the system level for the test environment. The
+# corresponding published image is:
+#   ghcr.io/rocm/no_rocm_image_ubuntu24_04_openmpi:latest
+RUN sudo apt-get install -y --no-install-recommends \
+    libopenmpi-dev \
+    openmpi-bin

--- a/dockerfiles/no_rocm_image_ubuntu24_04_openmpi.Dockerfile
+++ b/dockerfiles/no_rocm_image_ubuntu24_04_openmpi.Dockerfile
@@ -1,11 +1,13 @@
 FROM ghcr.io/rocm/no_rocm_image_ubuntu24_04:latest
 
 # no_rocm_image_ubuntu24_04_openmpi:
-# Extend the base no_rocm_image_ubuntu24_04 image with a system OpenMPI install
-# required to build and run the rocprofv3 mpi-ranks integration tests. OpenMPI is
-# intentionally not bundled in TheRock artifacts (to avoid forcing a specific MPI
-# onto users), so it is provided at the system level for the test environment. The
-# corresponding published image is:
+# Test-only image (not a ROCm build image): extends no_rocm_image_ubuntu24_04 with
+# a system OpenMPI install (libopenmpi-dev, openmpi-bin) for the rocprofv3 mpi-ranks
+# integration tests. The rocprofiler-sdk tests are configured and compiled
+# in-container at test time, so find_package(MPI) needs the OpenMPI headers and
+# mpiexec. OpenMPI is intentionally not bundled in TheRock artifacts (to avoid
+# forcing a specific MPI onto users), so it is provided at the system level here.
+# The corresponding published image is:
 #   ghcr.io/rocm/no_rocm_image_ubuntu24_04_openmpi:latest
 RUN sudo apt-get install -y --no-install-recommends \
     libopenmpi-dev \


### PR DESCRIPTION
## Motivation

Several ROCm subproject tests gate on `find_package(MPI)` and launch under `mpiexec`, but the shared `no_rocm` test image doesn't include an MPI implementation — so those tests are silently `DISABLED` in CI. OpenMPI is intentionally not bundled in ROCm artifacts (we don't want to force our MPI onto users, who may run their own), so this PR provides it at the system level in a dedicated test image. The first consumer is rocprofiler-sdk's `rocprofv3` **mpi-ranks** tests; the test-job wiring lands in a follow-up (#5627).

## Technical Details

- Adds `dockerfiles/no_rocm_image_ubuntu24_04_openmpi.Dockerfile`, extending the base `no_rocm_image_ubuntu24_04` image with a system OpenMPI install (`apt install libopenmpi-dev openmpi-bin` — Ubuntu 24.04's OpenMPI 4.1.x).
- Registers the publish job `publish_no_rocm_image_ubuntu24_04_openmpi` in `.github/workflows/publish_no_rocm_image_ubuntu24_04.yml` (mirrors the `_media`/`_rocgdb` extension jobs so it rebuilds when the base image changes).
- Documents the image in `dockerfiles/README.md`.

Published image: `ghcr.io/rocm/no_rocm_image_ubuntu24_04_openmpi`.

## Test Plan

- Trigger `publish_no_rocm_image_ubuntu24_04.yml` (push to `main`/`stage/docker/**`, or `workflow_dispatch`) and confirm the image builds and publishes.
- Verify the image provides OpenMPI — `mpiexec` on `PATH` and `find_package(MPI)` succeeds.

## Test Result

_Image builds and publishes via `publish_no_rocm_image_ubuntu24_04.yml` 

## JIRA ID

JIRA ID : AIROCVAL-45

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.