### PR TITLE
[CI] Capture and expose GITHUB_STEP_SUMMARY per job

### DIFF
--- a/build_tools/github_actions/capture_job_summary.py
+++ b/build_tools/github_actions/capture_job_summary.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Publish the accumulated job summary as a step output.
+
+A reusable workflow can only read another job's data through needs, which
+carries job outputs. This script reads the per-job summary mirror written by
+gha_append_step_summary and publishes it under a step output so a downstream
+notify job can forward it via toJSON(needs).
+"""
+
+import argparse
+import sys
+
+from github_actions_api import gha_set_job_summary_output
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-name",
+        default="summary",
+        help="Step-output name to set (default: summary).",
+    )
+    args = parser.parse_args(argv)
+
+    gha_set_job_summary_output(output_name=args.output_name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/build_tools/github_actions/github_actions_api.py
+++ b/build_tools/github_actions/github_actions_api.py
@@ -364,16 +364,40 @@ def gha_set_output(vars: Mapping[str, str | Path]):
         for k, v in vars.items():
             value = "" if v is None else str(v)
             if "\n" in value:
-                f.write(f"{k}<<EOF\n{value}\nEOF\n")
+                # EOF_mag1c delimiter must NOT occure in value
+                f.write(f"{k}<<EOF_mag1c\n{value}\nEOF_mag1c\n")
             else:
                 print(f"OUTPUT {k}={value}")
                 f.write(f"{k}={value}\n")
 
 
-def gha_append_step_summary(summary: str):
+def gha_job_summary_mirror_path() -> Path | None:
+    """Return the per-job summary mirror file under $RUNNER_TEMP, or None.
+
+    GitHub clears $GITHUB_STEP_SUMMARY between steps, so the rendered job
+    summary cannot be read back at the end of a job. We mirror every append
+    into $RUNNER_TEMP/job_summary.md, which persists for the whole job, so a
+    later step can publish it as a job output (see
+    gha_set_job_summary_output). $RUNNER_TEMP is emptied at the start and end
+    of each job, so the mirror does not leak between jobs.
+
+    Returns None when $RUNNER_TEMP is not set (the caller should skip
+    mirroring rather than fail). Local tests point $RUNNER_TEMP at a temp dir.
+    """
+    runner_temp = os.getenv("RUNNER_TEMP")
+    if not runner_temp:
+        return None
+    return Path(runner_temp) / "job_summary.md"
+
+
+def gha_append_step_summary(summary: str, mirror_to_job_file: bool = True):
     """Appends a string to the GitHub Actions job summary.
 
-    This appends to the file located at the $GITHUB_STEP_SUMMARY environment variable.
+    This appends to the file located at the $GITHUB_STEP_SUMMARY environment
+    variable. When mirror_to_job_file is set (the default), the same text
+    is also appended to the persistent mirror at $RUNNER_TEMP/job_summary.md
+    (see gha_job_summary_mirror_path) so the accumulated summary can be read
+    back later in the job and published as an output.
 
     See
       * https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-job-summary
@@ -386,9 +410,45 @@ def gha_append_step_summary(summary: str):
         _log("  Warning: GITHUB_STEP_SUMMARY env var not set, can't write job summary")
         return
 
+    # Use double newlines to split sections in markdown.
+    block = summary + "\n\n"
+
     with open(step_summary_file, "a") as f:
         # Use double newlines to split sections in markdown.
-        f.write(summary + "\n\n")
+        f.write(block)
+
+    if mirror_to_job_file:
+        mirror_path = gha_job_summary_mirror_path()
+        if mirror_path:
+            with open(mirror_path, "a", encoding="utf-8") as f:
+                f.write(block)
+        else:
+            _log(
+                "  Warning: RUNNER_TEMP env var not set, cannot mirror job summary "
+                "for output capture"
+            )
+
+
+def gha_set_job_summary_output(output_name: str = "summary"):
+    """Publishes the accumulated job summary mirror as a step output.
+
+    Reads $RUNNER_TEMP/job_summary.md (written by gha_append_step_summary) and
+    writes it to $GITHUB_OUTPUT under output_name via gha_set_output.
+
+    Note: A missing or empty mirror file writes no output at all.
+    """
+    mirror_path = gha_job_summary_mirror_path()
+    summary = ""
+    if mirror_path and mirror_path.exists():
+        summary = mirror_path.read_text(encoding="utf-8")
+
+    if not summary:
+        _log(
+            f"  No job summary content to publish; skipping '{output_name}' to add to $GITHUB_OUTPUT"
+        )
+        return
+
+    gha_set_output({output_name: summary})
 
 
 def gha_load_github_event() -> dict[str, Any]:

--- a/build_tools/github_actions/tests/github_actions_api_test.py
+++ b/build_tools/github_actions/tests/github_actions_api_test.py
@@ -16,14 +16,18 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 from github_actions_api import (
     GitHubAPI,
     GitHubAPIError,
+    gha_append_step_summary,
     gha_fetch_file_contents,
     gha_fetch_text_file_contents,
+    gha_job_summary_mirror_path,
     gha_load_github_event,
     gha_query_last_workflow_run,
     gha_query_recent_branch_commits,
     gha_query_workflow_run_by_id,
     gha_query_workflow_runs_for_commit,
     gha_resolve_git_ref,
+    gha_set_job_summary_output,
+    gha_set_output,
     is_authenticated_github_api_available,
 )
 
@@ -675,6 +679,132 @@ class GitHubActionsUtilsTest(unittest.TestCase):
         # Each limited result should also be a valid SHA
         for sha in commits_limited:
             self.assertRegex(sha, sha_pattern)
+
+
+class JobSummaryTest(unittest.TestCase):
+    """Tests for the job-summary mirror and output helpers."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp_path = Path(self._tmp.name)
+        self.runner_temp = self.tmp_path / "runner_temp"
+        self.runner_temp.mkdir()
+        self.step_summary_file = self.tmp_path / "step_summary.md"
+        self.github_output_file = self.tmp_path / "github_output"
+        self.env = {
+            "RUNNER_TEMP": os.fspath(self.runner_temp),
+            "GITHUB_STEP_SUMMARY": os.fspath(self.step_summary_file),
+            "GITHUB_OUTPUT": os.fspath(self.github_output_file),
+        }
+
+    def test_mirror_path_uses_runner_temp(self):
+        with mock.patch.dict(os.environ, self.env, clear=False):
+            self.assertEqual(
+                gha_job_summary_mirror_path(),
+                self.runner_temp / "job_summary.md",
+            )
+
+    def test_mirror_path_none_without_runner_temp(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(gha_job_summary_mirror_path())
+
+    def test_append_writes_both_step_summary_and_mirror(self):
+        with mock.patch.dict(os.environ, self.env, clear=False):
+            gha_append_step_summary("### Section A")
+            gha_append_step_summary("### Section B")
+
+        expected = "### Section A\n\n### Section B\n\n"
+        self.assertEqual(self.step_summary_file.read_text(encoding="utf-8"), expected)
+        mirror = self.runner_temp / "job_summary.md"
+        self.assertEqual(mirror.read_text(encoding="utf-8"), expected)
+
+    def test_append_multiline_summary(self):
+        summary = "### Heading\n\n- bullet a\n- bullet b\n\n| col |\n| --- |"
+        with mock.patch.dict(os.environ, self.env, clear=False):
+            gha_append_step_summary(summary)
+
+        expected = summary + "\n\n"
+        self.assertEqual(self.step_summary_file.read_text(encoding="utf-8"), expected)
+        mirror = self.runner_temp / "job_summary.md"
+        self.assertEqual(mirror.read_text(encoding="utf-8"), expected)
+
+    def test_append_can_skip_mirror(self):
+        with mock.patch.dict(os.environ, self.env, clear=False):
+            gha_append_step_summary("### Only step summary", mirror_to_job_file=False)
+
+        self.assertEqual(
+            self.step_summary_file.read_text(encoding="utf-8"),
+            "### Only step summary\n\n",
+        )
+        self.assertFalse((self.runner_temp / "job_summary.md").exists())
+
+    def test_append_without_step_summary_does_not_mirror(self):
+        # The mirror must only ever hold what was written to GITHUB_STEP_SUMMARY.
+        # When that env var is unset there is nothing to mirror, so the mirror
+        # file must not be created.
+        env = {k: v for k, v in self.env.items() if k != "GITHUB_STEP_SUMMARY"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            gha_append_step_summary("### Mirror only")
+
+        self.assertFalse((self.runner_temp / "job_summary.md").exists())
+
+    def test_set_output_publishes_with_custom_name(self):
+        with mock.patch.dict(os.environ, self.env, clear=False):
+            gha_append_step_summary("### Line 1")
+            gha_append_step_summary("### Line 2")
+            gha_set_job_summary_output(output_name="job_summary")
+
+        # The accumulated mirror is published under the requested name using the
+        # multiline heredoc form written by gha_set_output.
+        output = self.github_output_file.read_text(encoding="utf-8")
+        self.assertIn("job_summary<<EOF_mag1c\n", output)
+        self.assertIn("### Line 1", output)
+        self.assertIn("### Line 2", output)
+
+    def _parse_heredoc_output(self, output_name):
+        # Parse the GITHUB_OUTPUT heredoc the way GitHub does and return the
+        # published value for output_name.
+        output = self.github_output_file.read_text(encoding="utf-8")
+        # first == "output_name<<EOF_mag1c", rest == "value\nEOF_mag1c\n"
+        first, _, rest = output.partition("\n")
+        key, _, delimiter = first.partition("<<")
+        self.assertEqual(key, output_name)
+        closing = f"\n{delimiter}\n"
+        self.assertTrue(rest.endswith(closing))
+        return rest[: -len(closing)]
+
+    def test_set_output_round_trips_single_line_summary(self):
+        with mock.patch.dict(os.environ, self.env, clear=False):
+            gha_append_step_summary("### Only section")
+            gha_set_job_summary_output()
+
+        # gha_append_step_summary always appends a blank-line separator, so the
+        # published value carries the same trailing newlines as the mirror.
+        self.assertEqual(self._parse_heredoc_output("summary"), "### Only section\n\n")
+
+    def test_set_output_round_trips_multi_line_summary(self):
+        with mock.patch.dict(os.environ, self.env, clear=False):
+            gha_append_step_summary("### Heading\n\n- bullet a\n- bullet b")
+            gha_append_step_summary("| col |\n| --- |\n| val |")
+            gha_set_job_summary_output()
+
+        expected = (
+            "### Heading\n\n- bullet a\n- bullet b\n\n" "| col |\n| --- |\n| val |\n\n"
+        )
+        self.assertEqual(self._parse_heredoc_output("summary"), expected)
+
+    def test_set_output_skips_when_no_mirror(self):
+        with mock.patch.dict(os.environ, self.env, clear=False):
+            gha_set_job_summary_output()
+
+        # No mirror written -> nothing published to GITHUB_OUTPUT.
+        output = (
+            self.github_output_file.read_text(encoding="utf-8")
+            if self.github_output_file.exists()
+            else ""
+        )
+        self.assertEqual(output, "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a mechanism to forward a job's accumulated step summary to a downstream job
via `toJSON(needs)`.

A reusable workflow can only read another job's data through `needs`, which carries
job **outputs**, not the rendered `$GITHUB_STEP_SUMMARY` (GitHub clears that
between steps). To bridge this, every summary append is mirrored to a persistent
per-job file under `$RUNNER_TEMP`, then published as a step output at the end of
the job.

Will be used to report the `$GITHUB_STEP_SUMMARY` to Quartz. 
Part of https://github.com/ROCm/Quartz/issues/4

## Changes

- **New `capture_job_summary.py`**: CLI that publishes the accumulated job summary
  as a step output (default output name `summary`).
- **`github_actions_api.py`**:
  - `gha_job_summary_mirror_path()`: resolves the mirror file under `$RUNNER_TEMP`
    (returns `None` when unset so callers skip mirroring instead of failing).
  - `gha_append_step_summary()`: gains `mirror_to_job_file=True`; each append is
    now also written to the mirror so it can be read back later in the job.
  - `gha_set_job_summary_output()`: reads the mirror and publishes it via
    `gha_set_output`. Empty/missing mirror publishes nothing.
  - `gha_set_output()` heredoc delimiter changed `EOF` to `EOF_mag1c` to avoid
    collisions with summary content that contains `EOF`.
- **Tests**: new `JobSummaryTest` class covering mirror-path resolution, append +
  mirror behavior, `mirror_to_job_file=False`, missing-env handling, and
  round-tripping single/multi-line summaries through the output heredoc.

## Behavior change

`gha_append_step_summary` now mirrors to `$RUNNER_TEMP/job_summary.md` **by
default**, so all existing callers begin writing that file. `$RUNNER_TEMP` is
emptied at job start/end, so the mirror does not leak between jobs. Pass
`mirror_to_job_file=False` to opt out.

## Test plan

- `pytest build_tools/github_actions/tests/github_actions_api_test.py` — 48 passed
- Functionality tested and verified in Quartz devel stub workflows
