### PR TITLE
fix(build_tools): forward override_git_sha in compute_rocm_package_version

### DIFF
--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -263,12 +263,12 @@ def main(argv):
     outputs = {}
     for pkg_type in ["wheel", "deb", "rpm"]:
         version = compute_version(
-            pkg_type,
-            args.release_type,
-            args.custom_version_suffix,
-            args.prerelease_version,
-            args.override_base_version,
-            args.override_git_sha,
+            package_type=pkg_type,
+            release_type=args.release_type,
+            custom_version_suffix=args.custom_version_suffix,
+            prerelease_version=args.prerelease_version,
+            override_base_version=args.override_base_version,
+            override_git_sha=args.override_git_sha,
         )
 
         # Set appropriate output variable based on package type

--- a/build_tools/compute_rocm_package_version.py
+++ b/build_tools/compute_rocm_package_version.py
@@ -268,6 +268,7 @@ def main(argv):
             args.custom_version_suffix,
             args.prerelease_version,
             args.override_base_version,
+            args.override_git_sha,
         )
 
         # Set appropriate output variable based on package type

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -305,7 +305,7 @@ class GitShaOverrideTest(unittest.TestCase):
                     "--release-type",
                     "dev",
                     "--override-base-version",
-                    "8.0.0",
+                    "7.99.0",
                     "--override-git-sha",
                     override_sha,
                 ]
@@ -315,12 +315,19 @@ class GitShaOverrideTest(unittest.TestCase):
 
         # Wheel embeds the full override SHA.
         self.assertEqual(
-            captured_outputs["rocm_package_version"], f"8.0.0.dev0+{override_sha}"
+            captured_outputs["rocm_package_version"], f"7.99.0.dev0+{override_sha}"
+        )
+        # DEB uses the dev-date format and does not embed a git SHA at all.
+        self.assertRegex(
+            captured_outputs["rocm_deb_package_version"], r"^7\.99\.0~dev[0-9]{8}$"
+        )
+        self.assertNotIn(
+            override_sha[:8], captured_outputs["rocm_deb_package_version"]
         )
         # RPM embeds the 8-char truncation of the same override SHA.
         self.assertRegex(
             captured_outputs["rocm_rpm_package_version"],
-            rf"^8\.0\.0~[0-9]{{8}}g{override_sha[:8]}$",
+            rf"^7\.99\.0~[0-9]{{8}}g{override_sha[:8]}$",
         )
 
 

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -283,6 +283,46 @@ class GitShaOverrideTest(unittest.TestCase):
         # Should truncate to 8 chars
         self.assertRegex(version, r"^8\.1\.0~[0-9]{8}gabcdef12$")
 
+    def test_main_forwards_override_git_sha_to_all_package_types(self):
+        """main() must forward --override-git-sha into the computed versions.
+
+        Regression test for the bug where main() computed versions without
+        passing args.override_git_sha, so the flag was silently ignored and
+        cross-repo callers (e.g. rocm-libraries nightlies building TheRock)
+        got the caller's GITHUB_SHA embedded instead of the requested commit.
+        """
+        override_sha = "abcdef1234567890abcdef1234567890abcdef12"
+        captured_outputs = {}
+        original_gha_set_output = compute_rocm_package_version.gha_set_output
+
+        def mock_gha_set_output(outputs):
+            captured_outputs.update(outputs)
+
+        compute_rocm_package_version.gha_set_output = mock_gha_set_output
+        try:
+            compute_rocm_package_version.main(
+                [
+                    "--release-type",
+                    "dev",
+                    "--override-base-version",
+                    "8.0.0",
+                    "--override-git-sha",
+                    override_sha,
+                ]
+            )
+        finally:
+            compute_rocm_package_version.gha_set_output = original_gha_set_output
+
+        # Wheel embeds the full override SHA.
+        self.assertEqual(
+            captured_outputs["rocm_package_version"], f"8.0.0.dev0+{override_sha}"
+        )
+        # RPM embeds the 8-char truncation of the same override SHA.
+        self.assertRegex(
+            captured_outputs["rocm_rpm_package_version"],
+            rf"^8\.0\.0~[0-9]{{8}}g{override_sha[:8]}$",
+        )
+
 
 class MainFunctionMultiplePackageTypesTest(unittest.TestCase):
     """Tests for main() function: compute all package types when --package-type is omitted."""

--- a/build_tools/tests/compute_rocm_package_version_test.py
+++ b/build_tools/tests/compute_rocm_package_version_test.py
@@ -321,9 +321,7 @@ class GitShaOverrideTest(unittest.TestCase):
         self.assertRegex(
             captured_outputs["rocm_deb_package_version"], r"^7\.99\.0~dev[0-9]{8}$"
         )
-        self.assertNotIn(
-            override_sha[:8], captured_outputs["rocm_deb_package_version"]
-        )
+        self.assertNotIn(override_sha[:8], captured_outputs["rocm_deb_package_version"])
         # RPM embeds the 8-char truncation of the same override SHA.
         self.assertRegex(
             captured_outputs["rocm_rpm_package_version"],


### PR DESCRIPTION
## Summary

`compute_rocm_package_version.py` `main()` never forwarded `args.override_git_sha` to `compute_version()`, so `--override-git-sha` was silently ignored and package versions embedded `GITHUB_SHA`/`HEAD` instead. This forwards the override and adds a `main()`-level regression test. Needed so the rocm-libraries nightlies (ROCm/rocm-libraries#9507) can stamp the resolved TheRock commit into nightly package metadata.

## Risk Assessment

Risk 2. One-line behavioral fix on the version-string path plus a test, well covered. It changes the embedded SHA only when a caller explicitly passes `--override-git-sha` (today: `setup_multi_arch.yml`), moving it from the wrong value to the intended one. No API/schema change.

## Related

- Fixes #6617
- Related PRs: ROCm/rocm-libraries#9517 (consumes this for nightly package-metadata traceability)
- Work tracking: ROCM-28114

## Device / Architecture Coverage

None. Host-only Python packaging helper; architecture-independent. PR CI is sufficient.

## Testing Summary

- Unit tests for the packaging helper, including a new `main()`-level override test.

## Testing Checklist

- [x] compute_rocm_package_version tests - `python -m pytest build_tools/tests/compute_rocm_package_version_test.py` - Status: Passed (24)
- [x] Reproduction: new test fails before the fix (embeds HEAD `710812f4...`, not the override), passes after - Status: Verified
- [ ] PR CI - GitHub PR checks - Status: Pending

## Flags / Guardrails

None.

## Technical Changes

- `build_tools/compute_rocm_package_version.py`: forward `args.override_git_sha` into `compute_version()` in `main()`.
- `build_tools/tests/compute_rocm_package_version_test.py`: add `test_main_forwards_override_git_sha_to_all_package_types` exercising the `main()` path.
