### PR TITLE
Add structured product-local dependency mirroring

### DIFF
--- a/build_tools/third_party/s3_management/tests/update_dependencies_test.py
+++ b/build_tools/third_party/s3_management/tests/update_dependencies_test.py
@@ -210,7 +210,9 @@ def test_resolve_target_prefixes_auto_detect_requires_base_prefix() -> None:
 
 def test_structured_dependency_key_composition() -> None:
     key = structured_dependency_key(
-        "whl", "numpy", "numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
+        index="whl",
+        pkg_name="numpy",
+        filename="numpy-2.0.0-cp312-cp312-linux_x86_64.whl",
     )
     assert key == "core/whl/numpy/numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
 

--- a/build_tools/third_party/s3_management/tests/update_dependencies_test.py
+++ b/build_tools/third_party/s3_management/tests/update_dependencies_test.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 import update_dependencies
 from update_dependencies import (
     PACKAGES_PER_PROJECT,
+    _run_structured,
     get_dependency_package_names,
     get_project_paths,
     get_selected_packages,
@@ -286,6 +287,24 @@ def test_get_selected_packages_unknown_dependency_raises() -> None:
     with pytest.raises(ValueError, match="Unknown --dependency-package"):
         get_selected_packages(
             package="torch", dependency_names=frozenset({"not-a-dep"})
+        )
+
+
+# ---------------------------------------------------------------------------
+# _run_structured early validation
+# ---------------------------------------------------------------------------
+
+
+def test_run_structured_rejects_bad_index() -> None:
+    # Guards programmatic callers that bypass argparse choices: fail fast
+    # before any network/upload work rather than mid-run.
+    with pytest.raises(ValueError, match="index="):
+        _run_structured(
+            bucket=FakeBucket(),
+            selected_packages={"numpy": PACKAGES_PER_PROJECT["numpy"]},
+            index="wheels",
+            dry_run=True,
+            only_pypi=False,
         )
 
 

--- a/build_tools/third_party/s3_management/tests/update_dependencies_test.py
+++ b/build_tools/third_party/s3_management/tests/update_dependencies_test.py
@@ -9,12 +9,17 @@ import pytest
 
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
 
+import update_dependencies
 from update_dependencies import (
+    PACKAGES_PER_PROJECT,
     get_dependency_package_names,
     get_project_paths,
+    get_selected_packages,
     is_wheel_allowed,
+    main,
     normalize_package_name,
     resolve_target_prefixes,
+    structured_dependency_key,
 )
 
 
@@ -195,3 +200,143 @@ def test_resolve_target_prefixes_auto_detect_requires_base_prefix() -> None:
             bucket=FakeBucket(),
             auto_detect_prefixes=True,
         )
+
+
+# ---------------------------------------------------------------------------
+# structured_dependency_key
+# ---------------------------------------------------------------------------
+
+
+def test_structured_dependency_key_composition() -> None:
+    key = structured_dependency_key(
+        "whl", "numpy", "numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
+    )
+    assert key == "core/whl/numpy/numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
+
+
+def test_structured_dependency_key_pure_python() -> None:
+    key = structured_dependency_key(
+        "whl", "networkx", "networkx-3.4.2-py3-none-any.whl"
+    )
+    assert key == "core/whl/networkx/networkx-3.4.2-py3-none-any.whl"
+
+
+def test_structured_dependency_key_whl_next() -> None:
+    key = structured_dependency_key(
+        "whl-next", "numpy", "numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
+    )
+    assert key == "core/whl-next/numpy/numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
+
+
+def test_structured_dependency_key_underscore_name_dashed_dir() -> None:
+    # The package directory is dashed; the wheel filename keeps underscores.
+    key = structured_dependency_key(
+        "whl", "ml_dtypes", "ml_dtypes-0.5.0-cp312-cp312-linux_x86_64.whl"
+    )
+    assert key == "core/whl/ml-dtypes/ml_dtypes-0.5.0-cp312-cp312-linux_x86_64.whl"
+
+
+def test_structured_dependency_key_rejects_bad_index() -> None:
+    with pytest.raises(ValueError, match="index="):
+        structured_dependency_key("wheels", "numpy", "numpy-2.0.0.whl")
+
+
+# ---------------------------------------------------------------------------
+# get_selected_packages
+# ---------------------------------------------------------------------------
+
+
+def test_get_selected_packages_all() -> None:
+    selected = get_selected_packages(package="all")
+    assert selected == PACKAGES_PER_PROJECT
+    # Packages from every project are present.
+    projects = {info["project"] for info in selected.values()}
+    assert projects == {"jax", "rocm", "torch"}
+
+
+def test_get_selected_packages_filters_by_project() -> None:
+    selected = get_selected_packages(package="torch")
+    assert selected
+    assert all(info["project"] == "torch" for info in selected.values())
+    assert "numpy" in selected
+    # jax-only deps must be excluded.
+    assert "ml_dtypes" not in selected
+
+
+def test_get_selected_packages_unknown_project_raises() -> None:
+    with pytest.raises(ValueError, match="Unsupported package"):
+        get_selected_packages(package="nope")
+
+
+def test_get_selected_packages_dependency_filter() -> None:
+    selected = get_selected_packages(
+        package="torch", dependency_names=frozenset({"numpy"})
+    )
+    assert list(selected) == ["numpy"]
+
+
+def test_get_selected_packages_dependency_filter_across_all() -> None:
+    selected = get_selected_packages(
+        package="all", dependency_names=frozenset({"ml_dtypes", "numpy"})
+    )
+    assert set(selected) == {"ml_dtypes", "numpy"}
+
+
+def test_get_selected_packages_unknown_dependency_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown --dependency-package"):
+        get_selected_packages(
+            package="torch", dependency_names=frozenset({"not-a-dep"})
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI validation: structured mode rejects flat-only prefix flags
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        ["--prefix", "v4/whl"],
+        ["--auto-detect-prefixes"],
+        ["--base-prefix", "v2/"],
+    ],
+)
+def test_structured_rejects_flat_prefix_flags(
+    monkeypatch: pytest.MonkeyPatch, extra_args: list[str]
+) -> None:
+    argv = ["prog", "--structured", "--bucket", "b"] + extra_args
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(SystemExit):
+        main()
+
+
+def test_structured_defaults_package_to_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(update_dependencies, "run_update_dependencies", fake_run)
+    monkeypatch.setattr(sys, "argv", ["prog", "--structured", "--bucket", "b"])
+    main()
+    assert captured["package"] == "all"
+    assert captured["structured"] is True
+    assert captured["index"] == "whl"
+
+
+def test_flat_defaults_package_to_torch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(update_dependencies, "run_update_dependencies", fake_run)
+    monkeypatch.setattr(sys, "argv", ["prog", "--bucket", "b", "--prefix", "v4/whl"])
+    main()
+    assert captured["package"] == "torch"
+    assert captured["structured"] is False

--- a/build_tools/third_party/s3_management/update_dependencies.py
+++ b/build_tools/third_party/s3_management/update_dependencies.py
@@ -82,14 +82,86 @@ PACKAGES_PER_PROJECT = {
     "filelock": {"versions": ["latest"], "project": "torch"},
     "fsspec": {"versions": ["latest"], "project": "torch"},
     "typing-extensions": {"versions": ["latest"], "project": "torch"},
-    "rocm-bootstrap": {"versions": ["latest"], "project": "torch"},
+    "rocm-bootstrap": {"versions": ["latest"], "project": "rocm"},
     "setuptools": {"versions": ["81.0.0"], "project": "rocm"},
 }
+
+
+# Product-local index names for structured publishing. All mirrored
+# dependencies land under the "core" product, keyed by one of these indexes.
+_STRUCTURED_INDEX_NAMES: frozenset[str] = frozenset({"whl", "whl-next"})
+_STRUCTURED_PRODUCT = "core"
 
 
 def normalize_package_name(name: str) -> str:
     """Normalize a Python distribution name for comparison."""
     return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def structured_dependency_key(index: str, pkg_name: str, filename: str) -> str:
+    """Return the structured product-local S3 key for a dependency wheel.
+
+    The package directory is derived from ``pkg_name`` (normalized to the
+    canonical dashed form); ``filename`` is the wheel/sdist basename and keeps
+    its original PEP 427 escaping (underscores).
+
+    Example:
+        structured_dependency_key("whl", "ml_dtypes", "ml_dtypes-0.5.0-...whl")
+        -> "core/whl/ml-dtypes/ml_dtypes-0.5.0-...whl"
+    """
+    if index not in _STRUCTURED_INDEX_NAMES:
+        raise ValueError(
+            f"index={index!r} is invalid; "
+            f"expected one of {sorted(_STRUCTURED_INDEX_NAMES)}"
+        )
+    package_dir = normalize_package_name(pkg_name)
+    return f"{_STRUCTURED_PRODUCT}/{index}/{package_dir}/{filename}"
+
+
+def get_selected_packages(
+    *,
+    package: str = "torch",
+    dependency_names: frozenset[str] | None = None,
+) -> dict[str, dict]:
+    """Select entries from PACKAGES_PER_PROJECT for a project (or all).
+
+    ``package`` is a project name (e.g. "torch") or "all" to span every
+    project. ``dependency_names`` optionally narrows the result to specific
+    package names; unknown names raise ValueError.
+    """
+    if package != "all" and package not in get_project_paths():
+        raise ValueError(
+            f"Unsupported package '{package}'. Expected 'all' or one of: "
+            f"{', '.join(get_project_paths())}"
+        )
+
+    project_packages = {
+        pkg_name: pkg_info
+        for pkg_name, pkg_info in PACKAGES_PER_PROJECT.items()
+        if package == "all" or pkg_info["project"] == package
+    }
+
+    if dependency_names is None:
+        return project_packages
+
+    normalized_dependency_names = frozenset(
+        normalize_package_name(name) for name in dependency_names
+    )
+    available_names = frozenset(
+        normalize_package_name(name) for name in project_packages
+    )
+    unmatched = normalized_dependency_names - available_names
+    if unmatched:
+        raise ValueError(
+            f"Unknown --dependency-package value(s) for '{package}': "
+            f"{sorted(unmatched)}. Valid names: {sorted(available_names)}"
+        )
+
+    return {
+        pkg_name: pkg_info
+        for pkg_name, pkg_info in project_packages.items()
+        if normalize_package_name(pkg_name) in normalized_dependency_names
+    }
 
 
 def get_project_paths() -> List[str]:
@@ -257,6 +329,8 @@ def upload_missing_whls(
     dry_run: bool = False,
     only_pypi: bool = False,
     target_version: str = "latest",
+    structured: bool = False,
+    index: str = "whl",
 ) -> None:
     pypi_idx = parse_simple_idx(f"https://pypi.org/simple/{pkg_name}")
     pypi_versions = get_whl_versions(pypi_idx)
@@ -283,6 +357,13 @@ def upload_missing_whls(
     #         f"https://download.pytorch.org/{prefix}/{pkg_name}"
     #     )
 
+    # Destination directory for status messages. In structured mode the flat
+    # prefix is unused, so report the actual package directory instead.
+    if structured:
+        location = f"{_STRUCTURED_PRODUCT}/{index}/{normalize_package_name(pkg_name)}"
+    else:
+        location = prefix
+
     has_updates = False
     uploaded_or_present = 0
 
@@ -290,7 +371,11 @@ def upload_missing_whls(
         if not is_wheel_allowed(pkg):
             continue
 
-        s3_key = f"{prefix}/{pkg}"
+        if structured:
+            s3_key = structured_dependency_key(index, pkg_name, pkg)
+        else:
+            s3_key = f"{prefix}/{pkg}"
+        dest_dir = s3_key.rsplit("/", 1)[0]
         if s3_object_exists(bucket, s3_key):
             print(f"Skipping existing {pkg} at s3://{bucket.name}/{s3_key}")
             uploaded_or_present += 1
@@ -300,11 +385,11 @@ def upload_missing_whls(
         if dry_run:
             has_updates = True
             uploaded_or_present += 1
-            print(f"Dry Run - not Uploading {pkg} to s3://{bucket.name}/{prefix}/")
+            print(f"Dry Run - not Uploading {pkg} to s3://{bucket.name}/{dest_dir}/")
             continue
 
         data = download(pypi_idx[pkg])
-        print(f"Uploading {pkg} to s3://{bucket.name}/{prefix}/")
+        print(f"Uploading {pkg} to s3://{bucket.name}/{dest_dir}/")
         bucket.Object(key=s3_key).put(ContentType="binary/octet-stream", Body=data)
         has_updates = True
         uploaded_or_present += 1
@@ -312,11 +397,12 @@ def upload_missing_whls(
     if uploaded_or_present == 0:
         print(
             f"No allowed wheels found for {pkg_name} version {selected_version} "
-            f"for {prefix}"
+            f"for {location}"
         )
     elif not has_updates:
         print(
-            f"{pkg_name} is already at latest version {selected_version} for {prefix}"
+            f"{pkg_name} is already at latest version {selected_version} "
+            f"for {location}"
         )
 
 
@@ -330,50 +416,31 @@ def run_update_dependencies(
     auto_detect_prefixes: bool = False,
     base_prefix: str | None = None,
     dependency_names: frozenset[str] | None = None,
+    structured: bool = False,
+    index: str = "whl",
 ) -> None:
-    print(f"Running update_dependencies for package={package}, dry_run={dry_run}")
-
-    project_paths = get_project_paths()
-    if package not in project_paths:
-        raise ValueError(
-            f"Unsupported package '{package}'. Expected one of: {', '.join(project_paths)}"
-        )
-
-    normalized_dependency_names = (
-        frozenset(normalize_package_name(name) for name in dependency_names)
-        if dependency_names is not None
-        else None
+    print(
+        f"Running update_dependencies for package={package}, "
+        f"structured={structured}, dry_run={dry_run}"
     )
+
+    selected_packages = get_selected_packages(
+        package=package, dependency_names=dependency_names
+    )
+    if not selected_packages:
+        raise ValueError(f"No dependency packages selected for '{package}'")
 
     bucket = get_s3_bucket(bucket_name)
-    project_dependency_names = frozenset(
-        normalize_package_name(pkg_name)
-        for pkg_name, pkg_info in PACKAGES_PER_PROJECT.items()
-        if pkg_info["project"] == package
-    )
 
-    if normalized_dependency_names is not None:
-        unmatched_dependency_names = (
-            normalized_dependency_names - project_dependency_names
+    if structured:
+        _run_structured(
+            bucket=bucket,
+            selected_packages=selected_packages,
+            index=index,
+            dry_run=dry_run,
+            only_pypi=only_pypi,
         )
-        if unmatched_dependency_names:
-            raise ValueError(
-                f"Unknown --dependency-package value(s) for project '{package}': "
-                f"{sorted(unmatched_dependency_names)}. "
-                f"Valid names: {sorted(project_dependency_names)}"
-            )
-
-    selected_packages = {
-        pkg_name: pkg_info
-        for pkg_name, pkg_info in PACKAGES_PER_PROJECT.items()
-        if pkg_info["project"] == package
-        and (
-            normalized_dependency_names is None
-            or normalize_package_name(pkg_name) in normalized_dependency_names
-        )
-    }
-    if not selected_packages:
-        raise ValueError(f"No dependency packages selected for project '{package}'")
+        return
 
     target_prefixes = resolve_target_prefixes(
         bucket=bucket,
@@ -399,12 +466,64 @@ def run_update_dependencies(
                 )
 
 
+def _run_structured(
+    *,
+    bucket: ServiceResource,
+    selected_packages: dict[str, dict],
+    index: str,
+    dry_run: bool,
+    only_pypi: bool,
+) -> None:
+    """Mirror selected dependencies into core/<index>/<package>/ directories.
+
+    The structured layout is not prefix-driven: each wheel's destination key is
+    computed from its package name, so there is no prefix fan-out.
+    """
+    for pkg_name, pkg_info in selected_packages.items():
+        for target_version in pkg_info["versions"]:
+            upload_missing_whls(
+                bucket,
+                pkg_name,
+                dry_run=dry_run,
+                only_pypi=only_pypi,
+                target_version=target_version,
+                structured=True,
+                index=index,
+            )
+
+
 def main() -> None:
     from argparse import ArgumentParser
 
     parser = ArgumentParser("Upload dependent packages to S3")
     project_paths = get_project_paths()
-    parser.add_argument("--package", choices=project_paths, default="torch")
+    parser.add_argument(
+        "--package",
+        choices=[*project_paths, "all"],
+        default=None,
+        help=(
+            "Project whose dependencies to mirror, or 'all' for every "
+            "project. Default: 'all' in structured mode, 'torch' otherwise."
+        ),
+    )
+    parser.add_argument(
+        "--structured",
+        action="store_true",
+        help=(
+            "Mirror dependencies into product-local package directories "
+            "(core/<index>/<package>/) instead of a flat prefix. Incompatible "
+            "with --prefix, --auto-detect-prefixes, and --base-prefix."
+        ),
+    )
+    parser.add_argument(
+        "--index",
+        default="whl",
+        choices=["whl", "whl-next"],
+        help=(
+            "Product-local index name for structured publishing (default: "
+            "whl). Selects the core/<index>/ path segment."
+        ),
+    )
     parser.add_argument("--bucket", type=str, help="S3 bucket name")
     parser.add_argument(
         "--prefix",
@@ -444,8 +563,30 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    if args.structured:
+        conflicting = [
+            name
+            for name, value in (
+                ("--prefix", args.prefix),
+                ("--auto-detect-prefixes", args.auto_detect_prefixes),
+                ("--base-prefix", args.base_prefix),
+            )
+            if value
+        ]
+        if conflicting:
+            parser.error(
+                f"--structured is incompatible with flat-only flag(s): "
+                f"{', '.join(conflicting)}"
+            )
+
+    # Default package depends on mode: structured mirrors everything by default;
+    # flat keeps the historical single-project ("torch") default.
+    package = args.package
+    if package is None:
+        package = "all" if args.structured else "torch"
+
     run_update_dependencies(
-        package=args.package,
+        package=package,
         dry_run=args.dry_run,
         only_pypi=args.only_pypi,
         bucket_name=args.bucket,
@@ -455,6 +596,8 @@ def main() -> None:
         dependency_names=(
             frozenset(args.dependency_packages) if args.dependency_packages else None
         ),
+        structured=args.structured,
+        index=args.index,
     )
 
 

--- a/build_tools/third_party/s3_management/update_dependencies.py
+++ b/build_tools/third_party/s3_management/update_dependencies.py
@@ -479,6 +479,11 @@ def _run_structured(
     The structured layout is not prefix-driven: each wheel's destination key is
     computed from its package name, so there is no prefix fan-out.
     """
+    if index not in _STRUCTURED_INDEX_NAMES:
+        raise ValueError(
+            f"index={index!r} is invalid; "
+            f"expected one of {sorted(_STRUCTURED_INDEX_NAMES)}"
+        )
     for pkg_name, pkg_info in selected_packages.items():
         for target_version in pkg_info["versions"]:
             upload_missing_whls(

--- a/build_tools/third_party/s3_management/update_dependencies.py
+++ b/build_tools/third_party/s3_management/update_dependencies.py
@@ -102,7 +102,7 @@ def structured_dependency_key(index: str, pkg_name: str, filename: str) -> str:
     """Return the structured product-local S3 key for a dependency wheel.
 
     The package directory is derived from ``pkg_name`` (normalized to the
-    canonical dashed form); ``filename`` is the wheel/sdist basename and keeps
+    canonical dashed form); ``filename`` is the wheel basename and keeps
     its original PEP 427 escaping (underscores).
 
     Example:


### PR DESCRIPTION
## Motivation

The stream-subdomain Python index requires mirrored PyPI dependencies to live in product-local package directories (`core/<index>/<package>/`) so the structured index generator can discover per-package directories, rather than in the flat prefixes used today.

Closes #6613.

## Technical Details

Add an opt-in structured mode to `update_dependencies.py`. This matches a pattern that will be also introduced to
`publish_rocm_to_release_buckets.py` in a separate PR.

* `structured_dependency_key(index, pkg_name, filename)`: pure helper that composes `core/<index>/<normalized-package>/<filename>`. The package directory is derived from the package name (canonical dashed form), not the wheel filename, which keeps its PEP 427 underscore escaping.
* `get_selected_packages(package, dependency_names)`: extract package selection from `run_update_dependencies`. Supports `all` to span every project and keeps the per-project and per-dependency filtering with fail-fast on unknown names.
* `upload_missing_whls` gains `structured`/`index` params; the destination key branches on the mode. `is_wheel_allowed` is retained in both modes: it is a platform/Python-tag filter (`linux_x86_64`/`manylinux`/`py3`/`cp310`-`cp314`), not a package allow-list, so skipping it would mirror macOS, aarch64, musllinux, and PyPy wheels into the index.
* `main()` adds `--structured` and `--index {whl,whl-next}`; `--package` now accepts `all` and defaults to `all` in structured mode, `torch` in flat mode. `--prefix`, `--auto-detect-prefixes`, and `--base-prefix` are rejected under `--structured` via `parser.error`.
* `rocm-bootstrap` moves to project `rocm`; it is a dependency of the `rocm` metapackage, not of `torch`.

## Test Plan

Tests run automatically in CI. Run them manually via:
```
python -m pytest \
  build_tools/third_party/s3_management/tests/update_dependencies_test.py
```

## Test Result

60 passed. Full `s3_management` + `python_package_paths` suite: 136 passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
