### PR TITLE
Add structured product-local publishing for ROCm core packages

### DIFF
--- a/build_tools/_therock_utils/python_package_paths.py
+++ b/build_tools/_therock_utils/python_package_paths.py
@@ -1,0 +1,177 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Path/key computation for structured product-local Python package publishing.
+
+The stream-subdomain repository layout places Python artifacts under
+product-local package directories:
+
+    <product>/<index>/<normalized-package>/<filename>
+
+where <index> is ``whl`` or ``whl-next``. Release stream (dev/nightly/
+prerelease) is selected by the target bucket, never encoded in the path. This
+module computes the per-file destination keys the release publishers use when
+run with ``--structured``; the generator in
+``third_party/s3_management/manage_structured.py`` later discovers and indexes
+those directories.
+
+pep503_normalize + package-name extraction here intentionally mirror
+manage_structured.py so producer output round-trips through its
+discover_packages(). They are duplicated (a few lines) rather than shared to
+avoid a dependency from _therock_utils onto third_party/s3_management.
+"""
+
+import dataclasses
+from pathlib import Path
+from re import sub
+
+from _therock_utils.storage_location import StorageLocation
+from packaging.utils import (
+    InvalidSdistFilename,
+    InvalidWheelFilename,
+    parse_sdist_filename,
+    parse_wheel_filename,
+)
+
+
+# Distribution artifacts placed into package directories.
+ACCEPTED_FILE_EXTENSIONS = (".whl", ".tar.gz", ".zip")
+
+# Valid aggregate index names (the second path segment).
+INDEX_NAMES = ("whl", "whl-next")
+
+
+def pep503_normalize(name: str) -> str:
+    """Normalize a package name per PEP 503.
+
+    Lowercase and collapse runs of "-", "_", and "." to a single "-".
+    """
+    return sub(r"[-_.]+", "-", name.lower())
+
+
+def package_name_from_filename(filename: str) -> str:
+    """Return the PEP 503-normalized package name for a distribution artifact.
+
+    Uses spec-aware parsing (packaging.utils) so that sdist/zip filenames
+    with hyphens in the project name are handled correctly (e.g.
+    ``llnl-hatchet-2024.1.tar.gz`` -> ``llnl-hatchet``).
+
+    Raises:
+        ValueError: if the filename cannot be parsed as a wheel or sdist.
+    """
+    if filename.endswith(".whl"):
+        try:
+            name, _, _, _ = parse_wheel_filename(filename)
+            return name
+        except InvalidWheelFilename as e:
+            raise ValueError(f"Cannot parse wheel filename {filename!r}: {e}") from e
+    try:
+        name, _ = parse_sdist_filename(filename)
+        return name
+    except InvalidSdistFilename as e:
+        raise ValueError(f"Cannot parse sdist filename {filename!r}: {e}") from e
+
+
+def is_accepted_artifact(filename: str) -> bool:
+    return filename.endswith(ACCEPTED_FILE_EXTENSIONS)
+
+
+def structured_key(product: str, index: str, filename: str) -> str:
+    """Compute the structured S3 key for an artifact.
+
+    Returns ``<product>/<index>/<normalized-package>/<filename>``.
+
+    Raises:
+        ValueError: if ``index`` is not a valid aggregate index name.
+    """
+    if index not in INDEX_NAMES:
+        raise ValueError(f"index={index!r} is invalid, must be one of {INDEX_NAMES}")
+    package = package_name_from_filename(filename)
+    return f"{product}/{index}/{package}/{filename}"
+
+
+@dataclasses.dataclass
+class PlannedUpload:
+    """A local artifact to upload into a structured package directory.
+
+    Attributes:
+        source: Local path to the artifact.
+        dest: Destination location in the structured layout.
+    """
+
+    source: Path
+    dest: StorageLocation
+
+
+@dataclasses.dataclass
+class PlannedCopy:
+    """An S3 artifact to copy into a structured package directory.
+
+    Attributes:
+        source: Source location (an existing S3 object).
+        dest: Destination location in the structured layout.
+    """
+
+    source: StorageLocation
+    dest: StorageLocation
+
+
+def plan_local_uploads(
+    source_dir: Path,
+    dest_bucket: str,
+    product: str,
+    index: str,
+) -> list[PlannedUpload]:
+    """Plan structured uploads for accepted artifacts in a local directory.
+
+    Enumerates top-level artifacts in ``source_dir`` (not recursive: publish
+    sources are flat directories of wheels/sdists) and computes their structured
+    destinations. Sorted by filename for stable, reviewable output.
+    """
+    return [
+        PlannedUpload(
+            source=path,
+            dest=StorageLocation(
+                dest_bucket, structured_key(product, index, path.name)
+            ),
+        )
+        for path in sorted(source_dir.iterdir())
+        if path.is_file() and is_accepted_artifact(path.name)
+    ]
+
+
+def plan_key_copies(
+    source_keys: list[str],
+    source_bucket: str,
+    dest_bucket: str,
+    product: str,
+    index: str,
+) -> list[PlannedCopy]:
+    """Plan structured copies for accepted artifacts listed from S3.
+
+    Args:
+        source_keys: Full S3 keys returned by a listing (in ``source_bucket``).
+        source_bucket: Bucket the source keys live in.
+        dest_bucket: Destination bucket name.
+        product: Product segment (e.g. ``core``).
+        index: Index segment (``whl`` or ``whl-next``).
+
+    Returns:
+        Planned copies for accepted artifacts, sorted by source key. Only the
+        basename of each source key is used to place the artifact (the
+        structured layout is flat within each package directory).
+    """
+    plans: list[PlannedCopy] = []
+    for key in sorted(source_keys):
+        filename = key.rsplit("/", 1)[-1]
+        if not is_accepted_artifact(filename):
+            continue
+        plans.append(
+            PlannedCopy(
+                source=StorageLocation(source_bucket, key),
+                dest=StorageLocation(
+                    dest_bucket, structured_key(product, index, filename)
+                ),
+            )
+        )
+    return plans

--- a/build_tools/_therock_utils/python_package_paths.py
+++ b/build_tools/_therock_utils/python_package_paths.py
@@ -11,14 +11,14 @@ product-local package directories:
 where <index> is ``whl`` or ``whl-next``. Release stream (dev/nightly/
 prerelease) is selected by the target bucket, never encoded in the path. This
 module computes the per-file destination keys the release publishers use when
-run with ``--structured``; the generator in
-``third_party/s3_management/manage_structured.py`` later discovers and indexes
-those directories.
+run with ``--structured``; the generator in ``manage_structured.py`` later
+discovers and indexes those directories.
 
 pep503_normalize + package-name extraction here intentionally mirror
 manage_structured.py so producer output round-trips through its
-discover_packages(). They are duplicated (a few lines) rather than shared to
-avoid a dependency from _therock_utils onto third_party/s3_management.
+discover_packages(). They are duplicated (a few lines) rather than shared
+because manage_structured.py runs server-side and is deployed on its own; a
+shared import would drag this module into that deployment.
 """
 
 import dataclasses

--- a/build_tools/_therock_utils/python_package_paths.py
+++ b/build_tools/_therock_utils/python_package_paths.py
@@ -79,7 +79,9 @@ def is_accepted_artifact(filename: str) -> bool:
 def structured_key(product: str, index: str, filename: str) -> str:
     """Compute the structured S3 key for an artifact.
 
-    Returns ``<product>/<index>/<normalized-package>/<filename>``.
+    Returns ``v5/<product>/<index>/<normalized-package>/<filename>``. The
+    ``v5`` prefix is the layout schema version; CloudFront needs to redirect
+    the served path to the current version.
 
     Raises:
         ValueError: if ``index`` is not a valid aggregate index name.
@@ -87,7 +89,7 @@ def structured_key(product: str, index: str, filename: str) -> str:
     if index not in INDEX_NAMES:
         raise ValueError(f"index={index!r} is invalid, must be one of {INDEX_NAMES}")
     package = package_name_from_filename(filename)
-    return f"{product}/{index}/{package}/{filename}"
+    return f"v5/{product}/{index}/{package}/{filename}"
 
 
 @dataclasses.dataclass

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -299,11 +299,11 @@ def main(argv: list[str]) -> None:
         "Multi-arch (--kpack-split true) only.",
     )
     parser.add_argument(
-        "--index",
+        "--python-index",
         default="whl",
         choices=["whl", "whl-next"],
-        help="Product-local index name for structured publishing (default: "
-        "whl). Selects the v5/core/<index>/ path segment.",
+        help="Product-local index name for structured Python publishing "
+        "(default: whl). Selects the v5/core/<index>/ path segment.",
     )
     parser.add_argument(
         "--skip-native-packages",
@@ -340,7 +340,7 @@ def main(argv: list[str]) -> None:
             backend,
             kpack_split,
             structured=args.structured,
-            index=args.index,
+            index=args.python_index,
         )
     else:
         logger.info("Skipping python packages for ASAN build variant")

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -184,7 +184,7 @@ def _publish_python_packages_structured(
     ``core/<index>/<normalized-package>/<filename>`` so the structured index
     generator can discover per-package directories.
     """
-    source_objects = backend.list_files(source, include=["*.whl", "*.tar.gz"])
+    source_objects = backend.list_files(source, include=["*.whl", "*.tar.gz", "*.zip"])
     plans = plan_key_copies(
         source_keys=[obj.relative_path for obj in source_objects],
         source_bucket=source.bucket,

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -142,7 +142,7 @@ def publish_python_packages(
     product-local package directories instead of the flat v4/whl prefix:
 
         s3://therock-dev-artifacts/12345-linux/python/rocm_sdk_core-...whl
-          -> s3://therock-dev-python/core/<index>/rocm-sdk-core/rocm_sdk_core-...whl
+          -> s3://therock-dev-python/v5/core/<index>/rocm-sdk-core/rocm_sdk_core-...whl
     """
     source = artifacts_root.python_packages()
     dest_bucket = get_release_bucket_config(release_type, "python")
@@ -181,8 +181,8 @@ def _publish_python_packages_structured(
     """Copy python packages into product-local package directories.
 
     Lists the flat source prefix, then copies each accepted artifact into
-    ``core/<index>/<normalized-package>/<filename>`` so the structured index
-    generator can discover per-package directories.
+    ``v5/core/<index>/<normalized-package>/<filename>`` so the structured
+    index generator can discover per-package directories.
     """
     source_objects = backend.list_files(source, include=["*.whl", "*.tar.gz", "*.zip"])
     plans = plan_key_copies(
@@ -295,7 +295,7 @@ def main(argv: list[str]) -> None:
         "--structured",
         action="store_true",
         help="Publish python packages into product-local package directories "
-        "(core/<index>/<package>/) instead of the flat v4/whl prefix. "
+        "(v5/core/<index>/<package>/) instead of the flat v4/whl prefix. "
         "Multi-arch (--kpack-split true) only.",
     )
     parser.add_argument(
@@ -303,7 +303,7 @@ def main(argv: list[str]) -> None:
         default="whl",
         choices=["whl", "whl-next"],
         help="Product-local index name for structured publishing (default: "
-        "whl). Selects the core/<index>/ path segment.",
+        "whl). Selects the v5/core/<index>/ path segment.",
     )
     parser.add_argument(
         "--skip-native-packages",

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -73,6 +73,7 @@ sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 from _therock_utils.s3_buckets import get_release_bucket_config
 from _therock_utils.storage_backend import StorageBackend, create_storage_backend
 from _therock_utils.storage_location import StorageLocation
+from _therock_utils.python_package_paths import plan_key_copies
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
 
 logger = logging.getLogger(__name__)
@@ -114,6 +115,8 @@ def publish_python_packages(
     release_type: str,
     backend: StorageBackend,
     kpack_split: bool,
+    structured: bool = False,
+    index: str = "whl",
 ) -> None:
     """Copy python packages from the artifacts bucket to the release python bucket.
 
@@ -134,9 +137,25 @@ def publish_python_packages(
         kpack split enabled (flat):
         s3://therock-dev-artifacts/12345-linux/python/*.whl
           -> s3://therock-dev-python/v4/whl/*.whl
+
+    When ``structured`` is set (multi-arch only), packages are copied into
+    product-local package directories instead of the flat v4/whl prefix:
+
+        s3://therock-dev-artifacts/12345-linux/python/rocm_sdk_core-...whl
+          -> s3://therock-dev-python/core/<index>/rocm-sdk-core/rocm_sdk_core-...whl
     """
     source = artifacts_root.python_packages()
     dest_bucket = get_release_bucket_config(release_type, "python")
+
+    if structured:
+        _publish_python_packages_structured(
+            source=source,
+            dest_bucket=dest_bucket.name,
+            backend=backend,
+            index=index,
+        )
+        return
+
     if kpack_split:
         # Multi-arch: publish directly (no staging index).
         s3_subdirs = ["v4/whl"]
@@ -151,6 +170,35 @@ def publish_python_packages(
         logger.info("Copied %d python package files to %s", count, s3_subdir)
         if count == 0:
             raise FileNotFoundError(f"No python packages found at {source.s3_uri}")
+
+
+def _publish_python_packages_structured(
+    source: StorageLocation,
+    dest_bucket: str,
+    backend: StorageBackend,
+    index: str,
+) -> None:
+    """Copy python packages into product-local package directories.
+
+    Lists the flat source prefix, then copies each accepted artifact into
+    ``core/<index>/<normalized-package>/<filename>`` so the structured index
+    generator can discover per-package directories.
+    """
+    source_objects = backend.list_files(source, include=["*.whl", "*.tar.gz"])
+    plans = plan_key_copies(
+        source_keys=[obj.relative_path for obj in source_objects],
+        source_bucket=source.bucket,
+        dest_bucket=dest_bucket,
+        product="core",
+        index=index,
+    )
+    if not plans:
+        raise FileNotFoundError(f"No python packages found at {source.s3_uri}")
+
+    for plan in plans:
+        logger.info("Python package: %s -> %s", plan.source.s3_uri, plan.dest.s3_uri)
+        backend.copy_file(plan.source, plan.dest)
+    logger.info("Copied %d python package files (structured)", len(plans))
 
 
 def publish_native_linux_packages(
@@ -244,6 +292,20 @@ def main(argv: list[str]) -> None:
         help='Whether kpack split is enabled ("true" or "false")',
     )
     parser.add_argument(
+        "--structured",
+        action="store_true",
+        help="Publish python packages into product-local package directories "
+        "(core/<index>/<package>/) instead of the flat v4/whl prefix. "
+        "Multi-arch (--kpack-split true) only.",
+    )
+    parser.add_argument(
+        "--index",
+        default="whl",
+        choices=["whl", "whl-next"],
+        help="Product-local index name for structured publishing (default: "
+        "whl). Selects the core/<index>/ path segment.",
+    )
+    parser.add_argument(
         "--skip-native-packages",
         action="store_true",
         help="Skip publishing native Linux packages (deb/rpm)",
@@ -260,16 +322,26 @@ def main(argv: list[str]) -> None:
     )
     args = parser.parse_args(argv)
 
+    kpack_split = args.kpack_split.lower() == "true"
+    if args.structured and not kpack_split:
+        parser.error("--structured requires --kpack-split true (multi-arch only)")
+
     artifacts_root = WorkflowOutputRoot.from_workflow_run(
         run_id=args.run_id, platform=args.platform, release_type=args.release_type
     )
     backend = create_storage_backend(dry_run=args.dry_run)
-    kpack_split = args.kpack_split.lower() == "true"
     is_asan = args.build_variant == "asan"
 
     publish_tarballs(artifacts_root, args.release_type, backend, args.build_variant)
     if not is_asan:
-        publish_python_packages(artifacts_root, args.release_type, backend, kpack_split)
+        publish_python_packages(
+            artifacts_root,
+            args.release_type,
+            backend,
+            kpack_split,
+            structured=args.structured,
+            index=args.index,
+        )
     else:
         logger.info("Skipping python packages for ASAN build variant")
     if artifacts_root.platform == "linux" and not args.skip_native_packages:

--- a/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
+++ b/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
@@ -10,6 +10,7 @@ from unittest import mock
 sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent))
 
 from github_actions.publish_rocm_to_release_buckets import main
+from _therock_utils.storage_location import StorageLocation
 
 
 class TestPublishRocmToReleaseBuckets(unittest.TestCase):
@@ -183,6 +184,153 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
         self.assertEqual(tarball_source.relative_path, "123-linux/tarballs")
         # ASAN tarballs go to separate folder
         self.assertEqual(tarball_dest.relative_path, "v4/tarball-asan")
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_file")
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.list_files")
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
+    def test_structured_places_rocm_packages_in_package_dirs(
+        self, mock_copy_dir, mock_list, mock_copy_file
+    ):
+        # Structured multi-arch: python packages go into per-package dirs via
+        # list_files + copy_file, not the flat copy_directory.
+        mock_copy_dir.return_value = 2  # tarballs still use copy_directory
+        mock_list.return_value = [
+            StorageLocation(
+                "therock-dev-artifacts",
+                "123-linux/python/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl",
+            ),
+            StorageLocation(
+                "therock-dev-artifacts", "123-linux/python/rocm-7.13.0.tar.gz"
+            ),
+            StorageLocation(
+                "therock-dev-artifacts",
+                "123-linux/python/rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl",
+            ),
+        ]
+        main(
+            [
+                "--run-id",
+                "123",
+                "--platform",
+                "linux",
+                "--release-type",
+                "dev",
+                "--kpack-split",
+                "true",
+                "--structured",
+                "--skip-native-packages",
+                "--dry-run",
+            ]
+        )
+
+        # copy_directory used only for tarballs (not python) under structured.
+        self.assertEqual(mock_copy_dir.call_count, 1)
+        # One copy_file per accepted artifact.
+        self.assertEqual(mock_copy_file.call_count, 3)
+        dest_by_src = {
+            call.args[0].relative_path: call.args[1].relative_path
+            for call in mock_copy_file.call_args_list
+        }
+        self.assertEqual(
+            dest_by_src[
+                "123-linux/python/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
+            ],
+            "core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl",
+        )
+        self.assertEqual(
+            dest_by_src["123-linux/python/rocm-7.13.0.tar.gz"],
+            "core/whl/rocm/rocm-7.13.0.tar.gz",
+        )
+        self.assertEqual(
+            dest_by_src[
+                "123-linux/python/rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl"
+            ],
+            "core/whl/rocm-sdk-device-gfx1100/"
+            "rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl",
+        )
+        # Destination bucket is the release python bucket.
+        for call in mock_copy_file.call_args_list:
+            self.assertEqual(call.args[1].bucket, "therock-dev-python")
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_file")
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.list_files")
+    def test_structured_whl_next(self, mock_list, mock_copy_file, mock_copy_dir):
+        mock_copy_dir.return_value = 2  # tarballs
+        mock_list.return_value = [
+            StorageLocation(
+                "therock-dev-artifacts",
+                "123-linux/python/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl",
+            ),
+        ]
+        main(
+            [
+                "--run-id",
+                "123",
+                "--platform",
+                "linux",
+                "--release-type",
+                "dev",
+                "--kpack-split",
+                "true",
+                "--structured",
+                "--index",
+                "whl-next",
+                "--skip-native-packages",
+                "--dry-run",
+            ]
+        )
+        _, dest = mock_copy_file.call_args_list[0].args
+        self.assertEqual(
+            dest.relative_path,
+            "core/whl-next/rocm-sdk-core/"
+            "rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl",
+        )
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_file")
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.list_files")
+    def test_structured_raises_when_no_python_packages(
+        self, mock_list, mock_copy_file, mock_copy_dir
+    ):
+        mock_copy_dir.return_value = 2  # tarballs succeed
+        mock_list.return_value = []
+        with self.assertRaises(FileNotFoundError):
+            main(
+                [
+                    "--run-id",
+                    "123",
+                    "--platform",
+                    "linux",
+                    "--release-type",
+                    "dev",
+                    "--kpack-split",
+                    "true",
+                    "--structured",
+                    "--skip-native-packages",
+                    "--dry-run",
+                ]
+            )
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
+    def test_structured_requires_kpack_split(self, mock_copy):
+        # Structured only applies to the multi-arch (kpack-split) path; using it
+        # with the legacy per-family layout is rejected.
+        mock_copy.return_value = 2
+        with self.assertRaises(SystemExit):
+            main(
+                [
+                    "--run-id",
+                    "123",
+                    "--platform",
+                    "linux",
+                    "--release-type",
+                    "dev",
+                    "--structured",
+                    "--skip-native-packages",
+                    "--dry-run",
+                ]
+            )
 
     @mock.patch("_therock_utils.storage_backend.S3StorageBackend.copy_directory")
     def test_asan_native_packages_use_separate_path(self, mock_copy):

--- a/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
+++ b/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
@@ -225,10 +225,6 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
             ]
         )
 
-        # copy_directory used only for tarballs (not python) under structured.
-        self.assertEqual(mock_copy_dir.call_count, 1)
-        # One copy_file per accepted artifact; index.html is filtered out.
-        self.assertEqual(mock_copy_file.call_count, 3)
         dest_by_src = {
             call.args[0].relative_path: call.args[1].relative_path
             for call in mock_copy_file.call_args_list
@@ -277,7 +273,7 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
                 "--kpack-split",
                 "true",
                 "--structured",
-                "--index",
+                "--python-index",
                 "whl-next",
                 "--skip-native-packages",
                 "--dry-run",

--- a/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
+++ b/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
@@ -238,17 +238,17 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
             dest_by_src[
                 "123-linux/python/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
             ],
-            "core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl",
+            "v5/core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl",
         )
         self.assertEqual(
             dest_by_src["123-linux/python/rocm-7.13.0.tar.gz"],
-            "core/whl/rocm/rocm-7.13.0.tar.gz",
+            "v5/core/whl/rocm/rocm-7.13.0.tar.gz",
         )
         self.assertEqual(
             dest_by_src[
                 "123-linux/python/rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl"
             ],
-            "core/whl/rocm-sdk-device-gfx1100/"
+            "v5/core/whl/rocm-sdk-device-gfx1100/"
             "rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl",
         )
         # Destination bucket is the release python bucket.
@@ -286,7 +286,7 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
         _, dest = mock_copy_file.call_args_list[0].args
         self.assertEqual(
             dest.relative_path,
-            "core/whl-next/rocm-sdk-core/"
+            "v5/core/whl-next/rocm-sdk-core/"
             "rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl",
         )
 

--- a/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
+++ b/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
@@ -206,6 +206,8 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
                 "therock-dev-artifacts",
                 "123-linux/python/rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl",
             ),
+            # Non-accepted artifact in the listing must be ignored.
+            StorageLocation("therock-dev-artifacts", "123-linux/python/index.html"),
         ]
         main(
             [
@@ -225,12 +227,13 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
 
         # copy_directory used only for tarballs (not python) under structured.
         self.assertEqual(mock_copy_dir.call_count, 1)
-        # One copy_file per accepted artifact.
+        # One copy_file per accepted artifact; index.html is filtered out.
         self.assertEqual(mock_copy_file.call_count, 3)
         dest_by_src = {
             call.args[0].relative_path: call.args[1].relative_path
             for call in mock_copy_file.call_args_list
         }
+        self.assertNotIn("123-linux/python/index.html", dest_by_src)
         self.assertEqual(
             dest_by_src[
                 "123-linux/python/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"

--- a/build_tools/tests/python_package_paths_test.py
+++ b/build_tools/tests/python_package_paths_test.py
@@ -1,0 +1,234 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for structured product-local Python package path computation.
+
+All tests operate on in-memory inputs or a local temp directory. No AWS
+credentials or network access are required.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+
+from _therock_utils.python_package_paths import (
+    PlannedCopy,
+    PlannedUpload,
+    is_accepted_artifact,
+    package_name_from_filename,
+    pep503_normalize,
+    plan_key_copies,
+    plan_local_uploads,
+    structured_key,
+)
+from _therock_utils.storage_location import StorageLocation
+
+
+# ---------------------------------------------------------------------------
+# pep503_normalize
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("Foo_Bar", "foo-bar"),
+        ("torch.scatter", "torch-scatter"),
+        ("a--b__c", "a-b-c"),
+        ("rocm_sdk_core", "rocm-sdk-core"),
+        ("torch", "torch"),
+        ("rocm-sdk-core", "rocm-sdk-core"),
+    ],
+)
+def test_pep503_normalize(raw: str, expected: str) -> None:
+    assert pep503_normalize(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# package_name_from_filename
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        ("torch-2.10.0-cp310-cp310-linux_x86_64.whl", "torch"),
+        ("rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl", "rocm-sdk-core"),
+        # Wheel dist names escape to underscores (PEP 427); spec-aware parsing
+        # normalizes them to the canonical dashed form.
+        (
+            "amd_torch_device_gfx942-2.10.0-py3-none-linux_x86_64.whl",
+            "amd-torch-device-gfx942",
+        ),
+        (
+            "rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl",
+            "rocm-sdk-device-gfx1100",
+        ),
+        (
+            "rocm_sdk_libraries_gfx942-7.13.0-py3-none-linux_x86_64.whl",
+            "rocm-sdk-libraries-gfx942",
+        ),
+        # sdist with single-token name.
+        ("rocm-7.13.0.tar.gz", "rocm"),
+        # sdist with hyphenated name: spec-aware parsing handles this correctly
+        # where first-hyphen tokenization would produce only "llnl".
+        ("llnl-hatchet-2024.1.tar.gz", "llnl-hatchet"),
+        ("llnl-hatchet-2024.1.zip", "llnl-hatchet"),
+    ],
+)
+def test_package_name_from_filename(filename: str, expected: str) -> None:
+    assert package_name_from_filename(filename) == expected
+
+
+# ---------------------------------------------------------------------------
+# is_accepted_artifact
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        ("torch-2.10.0-cp310-cp310-linux_x86_64.whl", True),
+        ("rocm-7.13.0.tar.gz", True),
+        ("something-1.0.zip", True),
+        ("index.html", False),
+        ("torch-2.10.0.whl.metadata", False),
+        ("README.md", False),
+    ],
+)
+def test_is_accepted_artifact(filename: str, expected: bool) -> None:
+    assert is_accepted_artifact(filename) is expected
+
+
+# ---------------------------------------------------------------------------
+# structured_key
+# ---------------------------------------------------------------------------
+
+
+def test_structured_key_composition() -> None:
+    key = structured_key("pytorch", "whl", "torch-2.10.0-cp310-cp310-linux_x86_64.whl")
+    assert key == "pytorch/whl/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl"
+
+
+def test_structured_key_whl_next() -> None:
+    key = structured_key(
+        "pytorch", "whl-next", "torch-2.10.0-cp310-cp310-linux_x86_64.whl"
+    )
+    assert key == "pytorch/whl-next/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl"
+
+
+def test_structured_key_underscore_filename_dashed_dir() -> None:
+    # Filename keeps underscores; the package directory is dashed.
+    key = structured_key(
+        "core", "whl", "rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
+    )
+    assert key == (
+        "core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
+    )
+
+
+def test_structured_key_rejects_bad_index() -> None:
+    with pytest.raises(ValueError, match="index="):
+        structured_key("pytorch", "wheels", "torch-2.10.0.whl")
+
+
+# ---------------------------------------------------------------------------
+# plan_local_uploads
+# ---------------------------------------------------------------------------
+
+
+def _touch(directory: Path, name: str) -> Path:
+    path = directory / name
+    path.write_bytes(b"")
+    return path
+
+
+def test_plan_local_uploads(tmp_path: Path) -> None:
+    _touch(tmp_path, "torch-2.10.0-cp310-cp310-linux_x86_64.whl")
+    _touch(tmp_path, "amd_torch_device_gfx942-2.10.0-py3-none-linux_x86_64.whl")
+    # Non-artifacts must be ignored.
+    _touch(tmp_path, "index.html")
+    _touch(tmp_path, "torch-2.10.0.whl.metadata")
+
+    plans = plan_local_uploads(tmp_path, "therock-dev-python", "pytorch", "whl")
+
+    assert all(isinstance(p, PlannedUpload) for p in plans)
+    dests = {p.dest.relative_path for p in plans}
+    assert dests == {
+        "pytorch/whl/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl",
+        "pytorch/whl/amd-torch-device-gfx942/"
+        "amd_torch_device_gfx942-2.10.0-py3-none-linux_x86_64.whl",
+    }
+    for p in plans:
+        assert p.dest.bucket == "therock-dev-python"
+        assert p.source.parent == tmp_path
+
+
+def test_plan_local_uploads_empty_dir(tmp_path: Path) -> None:
+    assert plan_local_uploads(tmp_path, "b", "pytorch", "whl") == []
+
+
+# ---------------------------------------------------------------------------
+# plan_key_copies
+# ---------------------------------------------------------------------------
+
+
+def test_plan_key_copies() -> None:
+    source_keys = [
+        "12345-linux/python/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl",
+        "12345-linux/python/rocm-7.13.0.tar.gz",
+        "12345-linux/python/rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl",
+        # Ignored: not an accepted artifact.
+        "12345-linux/python/index.html",
+    ]
+    plans = plan_key_copies(
+        source_keys,
+        source_bucket="therock-dev-artifacts",
+        dest_bucket="therock-dev-python",
+        product="core",
+        index="whl",
+    )
+
+    assert all(isinstance(p, PlannedCopy) for p in plans)
+    mapping = {p.source.relative_path: p.dest.relative_path for p in plans}
+    assert mapping == {
+        "12345-linux/python/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl": (
+            "core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
+        ),
+        "12345-linux/python/rocm-7.13.0.tar.gz": "core/whl/rocm/rocm-7.13.0.tar.gz",
+        "12345-linux/python/rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl": (
+            "core/whl/rocm-sdk-device-gfx1100/"
+            "rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl"
+        ),
+    }
+    for p in plans:
+        assert p.source.bucket == "therock-dev-artifacts"
+        assert p.dest.bucket == "therock-dev-python"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: producer output is consumable by the generator.
+# ---------------------------------------------------------------------------
+
+
+def test_generated_keys_round_trip_through_discover_packages() -> None:
+    sys.path.insert(
+        0,
+        os.fspath(Path(__file__).parent.parent / "third_party" / "s3_management"),
+    )
+    from manage_structured import discover_packages
+
+    filenames = [
+        "torch-2.10.0-cp310-cp310-linux_x86_64.whl",
+        "amd_torch_device_gfx942-2.10.0-py3-none-linux_x86_64.whl",
+        "llnl-hatchet-2024.1.tar.gz",
+    ]
+    keys = [structured_key("pytorch", "whl", f) for f in filenames]
+
+    packages = discover_packages(keys, root="pytorch/whl")
+    names = sorted(p.name for p in packages)
+    assert names == ["amd-torch-device-gfx942", "llnl-hatchet", "torch"]

--- a/build_tools/tests/python_package_paths_test.py
+++ b/build_tools/tests/python_package_paths_test.py
@@ -111,14 +111,14 @@ def test_is_accepted_artifact(filename: str, expected: bool) -> None:
 
 def test_structured_key_composition() -> None:
     key = structured_key("pytorch", "whl", "torch-2.10.0-cp310-cp310-linux_x86_64.whl")
-    assert key == "pytorch/whl/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl"
+    assert key == "v5/pytorch/whl/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl"
 
 
 def test_structured_key_whl_next() -> None:
     key = structured_key(
         "pytorch", "whl-next", "torch-2.10.0-cp310-cp310-linux_x86_64.whl"
     )
-    assert key == "pytorch/whl-next/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl"
+    assert key == "v5/pytorch/whl-next/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl"
 
 
 def test_structured_key_underscore_filename_dashed_dir() -> None:
@@ -127,7 +127,7 @@ def test_structured_key_underscore_filename_dashed_dir() -> None:
         "core", "whl", "rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
     )
     assert key == (
-        "core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
+        "v5/core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
     )
 
 
@@ -159,8 +159,8 @@ def test_plan_local_uploads(tmp_path: Path) -> None:
     assert all(isinstance(p, PlannedUpload) for p in plans)
     dests = {p.dest.relative_path for p in plans}
     assert dests == {
-        "pytorch/whl/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl",
-        "pytorch/whl/amd-torch-device-gfx942/"
+        "v5/pytorch/whl/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl",
+        "v5/pytorch/whl/amd-torch-device-gfx942/"
         "amd_torch_device_gfx942-2.10.0-py3-none-linux_x86_64.whl",
     }
     for p in plans:
@@ -197,11 +197,11 @@ def test_plan_key_copies() -> None:
     mapping = {p.source.relative_path: p.dest.relative_path for p in plans}
     assert mapping == {
         "12345-linux/python/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl": (
-            "core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
+            "v5/core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
         ),
-        "12345-linux/python/rocm-7.13.0.tar.gz": "core/whl/rocm/rocm-7.13.0.tar.gz",
+        "12345-linux/python/rocm-7.13.0.tar.gz": "v5/core/whl/rocm/rocm-7.13.0.tar.gz",
         "12345-linux/python/rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl": (
-            "core/whl/rocm-sdk-device-gfx1100/"
+            "v5/core/whl/rocm-sdk-device-gfx1100/"
             "rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl"
         ),
     }
@@ -229,6 +229,6 @@ def test_generated_keys_round_trip_through_discover_packages() -> None:
     ]
     keys = [structured_key("pytorch", "whl", f) for f in filenames]
 
-    packages = discover_packages(keys, root="pytorch/whl")
+    packages = discover_packages(keys, root="v5/pytorch/whl")
     names = sorted(p.name for p in packages)
     assert names == ["amd-torch-device-gfx942", "llnl-hatchet", "torch"]

--- a/build_tools/tests/python_package_paths_test.py
+++ b/build_tools/tests/python_package_paths_test.py
@@ -218,7 +218,7 @@ def test_plan_key_copies() -> None:
 def test_generated_keys_round_trip_through_discover_packages() -> None:
     sys.path.insert(
         0,
-        os.fspath(Path(__file__).parent.parent / "third_party" / "s3_management"),
+        os.fspath(Path(__file__).parent.parent / "packaging" / "python"),
     )
     from manage_structured import discover_packages
 

--- a/build_tools/third_party/s3_management/tests/update_dependencies_test.py
+++ b/build_tools/third_party/s3_management/tests/update_dependencies_test.py
@@ -214,21 +214,21 @@ def test_structured_dependency_key_composition() -> None:
         pkg_name="numpy",
         filename="numpy-2.0.0-cp312-cp312-linux_x86_64.whl",
     )
-    assert key == "core/whl/numpy/numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
+    assert key == "v5/core/whl/numpy/numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
 
 
 def test_structured_dependency_key_pure_python() -> None:
     key = structured_dependency_key(
         "whl", "networkx", "networkx-3.4.2-py3-none-any.whl"
     )
-    assert key == "core/whl/networkx/networkx-3.4.2-py3-none-any.whl"
+    assert key == "v5/core/whl/networkx/networkx-3.4.2-py3-none-any.whl"
 
 
 def test_structured_dependency_key_whl_next() -> None:
     key = structured_dependency_key(
         "whl-next", "numpy", "numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
     )
-    assert key == "core/whl-next/numpy/numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
+    assert key == "v5/core/whl-next/numpy/numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
 
 
 def test_structured_dependency_key_underscore_name_dashed_dir() -> None:
@@ -236,7 +236,7 @@ def test_structured_dependency_key_underscore_name_dashed_dir() -> None:
     key = structured_dependency_key(
         "whl", "ml_dtypes", "ml_dtypes-0.5.0-cp312-cp312-linux_x86_64.whl"
     )
-    assert key == "core/whl/ml-dtypes/ml_dtypes-0.5.0-cp312-cp312-linux_x86_64.whl"
+    assert key == "v5/core/whl/ml-dtypes/ml_dtypes-0.5.0-cp312-cp312-linux_x86_64.whl"
 
 
 def test_structured_dependency_key_rejects_bad_index() -> None:

--- a/build_tools/third_party/s3_management/update_dependencies.py
+++ b/build_tools/third_party/s3_management/update_dependencies.py
@@ -107,7 +107,7 @@ def structured_dependency_key(index: str, pkg_name: str, filename: str) -> str:
 
     Example:
         structured_dependency_key("whl", "ml_dtypes", "ml_dtypes-0.5.0-...whl")
-        -> "core/whl/ml-dtypes/ml_dtypes-0.5.0-...whl"
+        -> "v5/core/whl/ml-dtypes/ml_dtypes-0.5.0-...whl"
     """
     if index not in _STRUCTURED_INDEX_NAMES:
         raise ValueError(
@@ -115,7 +115,7 @@ def structured_dependency_key(index: str, pkg_name: str, filename: str) -> str:
             f"expected one of {sorted(_STRUCTURED_INDEX_NAMES)}"
         )
     package_dir = normalize_package_name(pkg_name)
-    return f"{_STRUCTURED_PRODUCT}/{index}/{package_dir}/{filename}"
+    return f"v5/{_STRUCTURED_PRODUCT}/{index}/{package_dir}/{filename}"
 
 
 def get_selected_packages(


### PR DESCRIPTION
## Motivation

The new stream-subdomain repository structure serves Python packages from product-local package directories:

```
    <product>/<index>/<normalized-package>/<filename>
```

where `<index>` is `whl` or `whl-next`. The structured index generator (`manage_structured.py`) discovers per-package directories, but the release publishers still write wheels flat under `v4/whl`. This teaches the ROCm core publisher to place packages into the structured layout so the generator can index them.

Closes #6621.
Depends on #6600.

## Technical Details

Add `build_tools/_therock_utils/python_package_paths.py`, a pure path/key helper shared by the release publishers:

* `pep503_normalize` and `package_name_from_filename` using spec-aware parsing (`packaging.utils` `parse_wheel_filename` / `parse_sdist_filename`) so that sdist/zip filenames with hyphens in the project name are handled correctly. Wheel dist names escape to underscores per PEP 427 so split on first "-" would have worked for wheels, but spec-aware parsing is used throughout for consistency and correctness.
* `structured_key` computing `<product>/<index>/<package>/<filename>`
* `plan_local_uploads` / `plan_key_copies` returning `PlannedUpload` / `PlannedCopy` for the upload (local dir) and copy (S3-to-S3) publisher flows respectively.

Furthermore, this wires an opt-in `--structured` flag (plus `--index {whl,whl-next}`) into `publish_rocm_to_release_buckets.py`. When set, `publish_python_packages` delegates to a structured path that lists the flat source prefix and copies each artifact into
`core/<index>/<package>/<filename>`. Structured publishing is multi-arch only (validated with `parser.error`); the flat and legacy per-family paths are unchanged. The product segment is `"core"` per RFC0012.

PyTorch and JAX publishers use the local-dir upload flow and publish to a different path; they are handled in a follow-up.

## Test Plan

Tests executed in CI. Run locally via
```
python -m pytest \
  build_tools/tests/python_package_paths_test.py \
  build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
```

## Test Result

38 targeted tests pass, including a round-trip asserting generated keys are consumable by `manage_structured.discover_packages`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
