### PR TITLE
[Quartz] Workflow: Use dynamic name and explicitly checkout therock

### DIFF
--- a/.github/workflows/notify_quartz.yml
+++ b/.github/workflows/notify_quartz.yml
@@ -68,11 +68,16 @@ on:
 
 jobs:
   notify:
+    name: Quartz - ${{ inputs.run_phase }} ${{ inputs.reporting_workflow }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Checkout TheRock
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ROCm/TheRock
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0


### PR DESCRIPTION
`notify_quartz.yml` is a reusable workflow that runs `notify_quartz.py` from TheRock.
We also want to use it for rockrel ( https://github.com/ROCm/rockrel/pull/77 ).

To support this, the following is changed:
- Pin repo checkout to `ROCm/TheRock` so the notify script is always available regardless of caller. 
- Bumps `actions/checkout` to v7.0.0 
- Use dynamic naming for the `notify` job so runs are identifiable in the Actions UI.