### PR TITLE
build: wire TEST_SUBPROJECTS for math-libs and ml-libs components

### DIFF
--- a/math-libs/BLAS/CMakeLists.txt
+++ b/math-libs/BLAS/CMakeLists.txt
@@ -160,7 +160,9 @@ therock_cmake_subproject_declare(hipBLASLt
     ${optional_profiler_deps}
   TEST_SUBPROJECTS
     hipSPARSELt
+    hipblasltprovider
     MIOpen
+    rocBLAS
 )
 therock_cmake_subproject_glob_c_sources(hipBLASLt
   SUBDIRS
@@ -238,7 +240,12 @@ therock_cmake_subproject_declare(rocBLAS
     ${optional_profiler_deps}
   TEST_SUBPROJECTS
     hipBLAS
+    hipblasltprovider
+    hipSPARSE
+    MIOpen
     rocSOLVER
+    rocSPARSE
+    rocWMMA
 )
 therock_cmake_subproject_glob_c_sources(rocBLAS
 SUBDIRS
@@ -283,6 +290,8 @@ if(THEROCK_ENABLE_SPARSE)
       hipSPARSE
       rocSOLVER
       hipSOLVER
+      rocPRIM
+      rocBLAS
   )
   therock_cmake_subproject_glob_c_sources(rocSPARSE
     SUBDIRS
@@ -515,6 +524,11 @@ therock_cmake_subproject_declare(hipBLAS
     rocBLAS
     ${hipBLAS_optional_deps}
   TEST_SUBPROJECTS
+    MIOpen
+    rocWMMA
+    hipSOLVER
+    hipSPARSE
+    rocSPARSE
 )
 therock_cmake_subproject_glob_c_sources(hipBLAS
 SUBDIRS

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -124,6 +124,7 @@ if(THEROCK_ENABLE_PRIM)
       hipCUB
       rocThrust
       rocSPARSE
+      rocSOLVER
   )
   therock_cmake_subproject_glob_c_sources(rocPRIM
     SUBDIRS
@@ -544,6 +545,7 @@ if(THEROCK_ENABLE_LIBHIPCXX)
       hip-clr
       hipcc
     TEST_SUBPROJECTS
+      rocThrust
   )
   therock_cmake_subproject_glob_c_sources(libhipcxx
     SUBDIRS
@@ -623,6 +625,8 @@ if(_ck_enabled)
       rocRAND
       ${THEROCK_BUNDLED_BZIP2}
       ${optional_profiler_deps}
+    TEST_SUBPROJECTS
+      MIOpen
   )
   therock_cmake_subproject_provide_package(composable_kernel composable_kernel lib/cmake/composable_kernel)
 

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -67,6 +67,8 @@ if(THEROCK_ENABLE_MIOPEN)
       ${optional_profiler_deps}
     TEST_SUBPROJECTS
       miopenprovider
+      hipDNN_samples
+      hipdnn_integration_tests
   )
   therock_cmake_subproject_provide_package(MIOpen miopen lib/cmake/miopen)
   therock_cmake_subproject_activate(MIOpen)
@@ -231,6 +233,7 @@ if(THEROCK_ENABLE_MIOPENPROVIDER)
       hipdnn_integration_tests
       MIOpen
     TEST_SUBPROJECTS
+      hipDNN_samples
   )
   therock_cmake_subproject_glob_c_sources(miopenprovider
   SUBDIRS


### PR DESCRIPTION
As part of enabling multi-arch on rocm-libraries #3343, adding TEST_SUBPROJECTS entries to therock_cmake_subproject_declare blocks so downstream consumers are tracked for testing:

- hipBLASLt: hipblasltprovider, MIOpen, rocBLAS
- rocBLAS: hipblasltprovider, hipSPARSE, MIOpen, rocSOLVER, rocSPARSE, rocWMMA
- rocSPARSE: rocPRIM, rocBLAS
- hipBLAS: MIOpen, rocWMMA, hipSOLVER, hipSPARSE, rocSPARSE
- rocPRIM: rocSOLVER
- libhipcxx: rocThrust
- composable_kernel: MIOpen
- MIOpen: hipDNN_samples, hipdnn_integration_tests
- miopenprovider: hipDNN_samples

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
