### PR TITLE
docs(rocm-pr-quality): add review attestation to base skill

### DIFF
--- a/skills/rocm-pr-quality/SKILL.md
+++ b/skills/rocm-pr-quality/SKILL.md
@@ -147,7 +147,7 @@ related PRs) is a SHOULD.
 ### Review attestation (approvals only)
 
 When Action 2 concludes `APPROVED`, append the machine-checkable attestation block (see
-`reference.md`) to the drafted review comment. Never attach it to `CHANGES REQUESTED` / `REJECTED`,
+`reference.md`) to the drafted approval comment. Never attach it to `CHANGES REQUESTED` / `REJECTED`,
 and never to a PR description. It is part of the text the human posts; the skill still never posts
 on its own (operating principle 2). Explain the block in plain language when you add it: what it is,
 that pushing new commits invalidates it, and that a pre-review gate can key on it. If an approval was
@@ -248,9 +248,10 @@ and add cross-cutting testing/reuse passes; otherwise do a single-pass review.
 **Output:** the overall assessment + the four answers + a severity-ordered findings list + a
 `BLOCKING`-items list. Only on request, and only after the user approves the wording, produce a
 draft request-changes comment. Never post it yourself. When the assessment is `APPROVED`, also
-produce the attestation block (see "Review attestation") as a trailer to the drafted approval
-comment and briefly explain it to the user; if the user already approved without it, give them the
-one-line paste form. Never post either yourself.
+produce the attestation block (see "Review attestation"). Drafting the approval comment itself is
+on request, like the request-changes comment above; when you draft it, include the block as its
+trailer, otherwise hand the block to the user directly. Briefly explain it; if the user already
+approved without it, give them the one-line paste form. Never post either yourself.
 
 ______________________________________________________________________
 

--- a/skills/rocm-pr-quality/SKILL.md
+++ b/skills/rocm-pr-quality/SKILL.md
@@ -144,6 +144,15 @@ reverse edges (GitHub back-references; Jira dev-panel auto-linking when the issu
 branch/PR title). M5 makes the core links mandatory; broader context (design docs, loosely
 related PRs) is a SHOULD.
 
+### Review attestation (approvals only)
+
+When Action 2 concludes `APPROVED`, append the machine-checkable attestation block (see
+`reference.md`) to the drafted review comment. Never attach it to `CHANGES REQUESTED` / `REJECTED`,
+and never to a PR description. It is part of the text the human posts; the skill still never posts
+on its own (operating principle 2). Explain the block in plain language when you add it: what it is,
+that pushing new commits invalidates it, and that a pre-review gate can key on it. If an approval was
+already posted without a block, hand the user the one-line paste form instead of the full block.
+
 ______________________________________________________________________
 
 ## Action 1 — Author assist
@@ -238,7 +247,10 @@ and add cross-cutting testing/reuse passes; otherwise do a single-pass review.
 
 **Output:** the overall assessment + the four answers + a severity-ordered findings list + a
 `BLOCKING`-items list. Only on request, and only after the user approves the wording, produce a
-draft request-changes comment. Never post it yourself.
+draft request-changes comment. Never post it yourself. When the assessment is `APPROVED`, also
+produce the attestation block (see "Review attestation") as a trailer to the drafted approval
+comment and briefly explain it to the user; if the user already approved without it, give them the
+one-line paste form. Never post either yourself.
 
 ______________________________________________________________________
 

--- a/skills/rocm-pr-quality/reference.md
+++ b/skills/rocm-pr-quality/reference.md
@@ -286,3 +286,44 @@ When a defect is known but the fix is not ready, M1 may be met by a tracked two-
 
 The quarantine must be tracked, time-boxed, and removed by the fix — not left in place. Overlays
 define the concrete mechanism (e.g. a `known_bugs` data file).
+
+______________________________________________________________________
+
+## Review attestation (Action 2, approvals only)
+
+When a review concludes `APPROVED`, the skill appends this block to the drafted approval comment
+(never to `CHANGES REQUESTED` / `REJECTED`, and never to a PR description). The human posts it; the
+skill never posts on its own. The `<!-- rocm-pr-quality:attestation v1 -->` marker is what a
+consumer (e.g. a pre-review gate) keys on, and the digest binds the attestation to the exact diff
+so a stale or copied block can be detected.
+
+Block (leaned-into default):
+
+```markdown
+<!-- rocm-pr-quality:attestation v1 -->
+> **Reviewed with the ROCm PR-quality skill.**
+> - Skill: `rocm-pr-quality` (base) - overlays: `<applied overlays, or "none">`
+> - Action: `review` - Result: **APPROVED** (`<n>` BLOCKING; `<n>` IMPORTANT)
+> - Risk: `<1-5>`
+> - Commit: `<full 40-char head SHA>`
+> - Diff digest: `<8-hex>`
+>
+> <sub>Machine-checkable attestation. The digest binds this review to the exact file set at the
+> commit above; pushing new commits invalidates it, at which point the skill should be re-run.</sub>
+```
+
+One-line paste fallback (same marker, for when an approval was already posted without a block):
+
+```text
+<!-- rocm-pr-quality:attestation v1 --> rocm-pr-quality review APPROVED - commit <full-sha> - digest <8-hex>
+```
+
+### Digest algorithm (pinned, so a consumer can recompute)
+
+- **head SHA:** the full 40-char PR head SHA — `gh pr view --json headRefOid -q .headRefOid` (or
+  `git rev-parse HEAD`).
+- **files:** the PR's changed-file paths — `gh pr diff --name-only` — as POSIX paths, sorted by
+  Unicode code point (Python `sorted()` / `LC_ALL=C sort`), newline-joined, with no trailing
+  newline.
+- **payload:** `head_sha + "\n" + "\n".join(sorted_files)`.
+- **digest:** `sha256(payload.encode("utf-8")).hexdigest()[:8]`.

--- a/skills/rocm-pr-quality/reference.md
+++ b/skills/rocm-pr-quality/reference.md
@@ -322,8 +322,10 @@ One-line paste fallback (same marker, for when an approval was already posted wi
 
 - **head SHA:** the full 40-char PR head SHA — `gh pr view --json headRefOid -q .headRefOid` (or
   `git rev-parse HEAD`).
-- **files:** the PR's changed-file paths — `gh pr diff --name-only` — as POSIX paths, sorted by
-  Unicode code point (Python `sorted()` / `LC_ALL=C sort`), newline-joined, with no trailing
-  newline.
-- **payload:** `head_sha + "\n" + "\n".join(sorted_files)`.
+- **files:** the PR's changed-file paths (`gh pr diff --name-only`) as POSIX paths, sorted by
+  Unicode code point (Python `sorted()`; equivalently `LC_ALL=C sort`, since UTF-8 byte order
+  matches code-point order).
+- **payload:** the head SHA followed by the sorted paths, joined by a single `\n` with no trailing
+  newline (so an empty file list yields just the head SHA):
+  `payload = "\n".join([head_sha, *sorted_files])`.
 - **digest:** `sha256(payload.encode("utf-8")).hexdigest()[:8]`.

--- a/skills/rocm-pr-quality/reference.md
+++ b/skills/rocm-pr-quality/reference.md
@@ -294,8 +294,8 @@ ______________________________________________________________________
 When a review concludes `APPROVED`, the skill appends this block to the drafted approval comment
 (never to `CHANGES REQUESTED` / `REJECTED`, and never to a PR description). The human posts it; the
 skill never posts on its own. The `<!-- rocm-pr-quality:attestation v1 -->` marker is what a
-consumer (e.g. a pre-review gate) keys on, and the digest binds the attestation to the exact diff
-so a stale or copied block can be detected.
+consumer (e.g. a pre-review gate) keys on, and the full head SHA binds the attestation to the exact
+tree so a stale or copied block can be detected.
 
 Block (leaned-into default):
 
@@ -306,26 +306,16 @@ Block (leaned-into default):
 > - Action: `review` - Result: **APPROVED** (`<n>` BLOCKING; `<n>` IMPORTANT)
 > - Risk: `<1-5>`
 > - Commit: `<full 40-char head SHA>`
-> - Diff digest: `<8-hex>`
 >
-> <sub>Machine-checkable attestation. The digest binds this review to the exact file set at the
-> commit above; pushing new commits invalidates it, at which point the skill should be re-run.</sub>
+> <sub>Machine-checkable attestation. The head SHA binds this review to the exact tree; pushing new
+> commits invalidates it, at which point the skill should be re-run.</sub>
 ```
+
+The full head SHA is `gh pr view --json headRefOid -q .headRefOid` (or `git rev-parse HEAD`). A
+consumer confirms an attestation by comparing this SHA to the PR's current head.
 
 One-line paste fallback (same marker, for when an approval was already posted without a block):
 
 ```text
-<!-- rocm-pr-quality:attestation v1 --> rocm-pr-quality review APPROVED - commit <full-sha> - digest <8-hex>
+<!-- rocm-pr-quality:attestation v1 --> rocm-pr-quality review APPROVED - commit <full-sha>
 ```
-
-### Digest algorithm (pinned, so a consumer can recompute)
-
-- **head SHA:** the full 40-char PR head SHA — `gh pr view --json headRefOid -q .headRefOid` (or
-  `git rev-parse HEAD`).
-- **files:** the PR's changed-file paths (`gh pr diff --name-only`) as POSIX paths, sorted by
-  Unicode code point (Python `sorted()`; equivalently `LC_ALL=C sort`, since UTF-8 byte order
-  matches code-point order).
-- **payload:** the head SHA followed by the sorted paths, joined by a single `\n` with no trailing
-  newline (so an empty file list yields just the head SHA):
-  `payload = "\n".join([head_sha, *sorted_files])`.
-- **digest:** `sha256(payload.encode("utf-8")).hexdigest()[:8]`.


### PR DESCRIPTION
## Summary

Adds a review-attestation to the `rocm-pr-quality` base skill: when a review concludes `APPROVED`, the skill appends a machine-checkable block (skill/overlays, result, risk, head SHA, and an 8-hex diff digest) to the drafted approval, with a one-line paste fallback. This is the gentle first step toward letting `therock_pr_bot` recognize a skill-backed review; no bot or workflow changes are included here. Overlays inherit the behavior from the base with no edits.

## Risk Assessment

Risk 1/5. Markdown-only changes to skill instructions and reference material; no product code, CI, or build behavior is affected.

## Related

- Work tracking: ISSUE ID : #6652

## Testing Summary

- Documentation/skill change validated with `mdformat` (the markdown pre-commit hook) and a self-review using the `therock-pr-quality` skill.

## Testing Checklist

- [x] mdformat - `python -m mdformat --check skills/rocm-pr-quality/SKILL.md skills/rocm-pr-quality/reference.md` - Status: Passed
- [x] PR CI - GitHub PR checks - Status: Pending

## Technical Changes

- `skills/rocm-pr-quality/SKILL.md`: new "Review attestation (approvals only)" shared concept and an Action 2 Output trailer for approvals.
- `skills/rocm-pr-quality/reference.md`: the attestation block, one-line fallback, and the pinned digest algorithm.
