### PR TITLE
ci: document and test path-based unit test patterns in pr bot

### DIFF
--- a/skills/therock_pr_bot/policy.yml
+++ b/skills/therock_pr_bot/policy.yml
@@ -120,9 +120,22 @@ pr:
       - .rs
     # A changed file is treated as a unit test if its basename matches one of
     # these glob patterns (e.g. test_parser.py, parser_test.cpp, testing_x.py).
-    # Patterns that contain a '/' are matched against the FULL path instead of
-    # the basename, so entire test directories can be recognised
-    # (e.g. anything under a 'test/gtest/' folder).
+    #
+    # TWO matching modes are supported:
+    #   1. BASENAME patterns (no '/' in the pattern): matched against the
+    #      filename only, regardless of where it lives in the repo.
+    #      e.g. 'test_*' matches 'tests/unit/test_foo.cpp'
+    #
+    #   2. PATH patterns (pattern contains '/'): matched against the full
+    #      file path from the repo root. Use these when tests live in a
+    #      dedicated directory but don't follow a special naming convention.
+    #      e.g. 'projects/hip-tests/**' matches any file under that directory,
+    #      including files named after the API they test (atomicAdd.cc, etc.).
+    #
+    # Downstream repos should add path patterns for their own test directories.
+    # Examples:
+    #   - '**/test/gtest/**'    — any file under a test/gtest/ subdirectory
+    #   - 'projects/hip-tests/**' — all of hip-tests (add in rocm-systems)
     test_file_patterns:
       - 'test_*'
       - 'testing_*'
@@ -134,7 +147,7 @@ pr:
       - '**/test/gtest/**'
     # Unit tests are required for source code ANYWHERE in the repository — there
     # are NO folder-based exemptions. A test file may also live in any folder;
-    # it is recognised by its name (test_* / *_test.*), not its location.
+    # it is recognised by its name or path pattern, not its location alone.
     # Doc/config files are still skipped by EXTENSION (they are simply not in
     # `code_extensions`), not by path.
     exempt_paths: []

--- a/skills/therock_pr_bot/test_policy_check_ut.py
+++ b/skills/therock_pr_bot/test_policy_check_ut.py
@@ -67,9 +67,6 @@ def make_policy(**overrides: Any) -> pc.Policy:
         description_checklist_patterns=[re.compile(p) for p in _CHECKLIST_PATTERNS],
         block_draft=True,
         forbidden_title_patterns=[re.compile(r"(?i)\bWIP\b")],
-        max_files_changed=50,
-        max_total_changes=2000,
-        max_single_file_changes=700,
         forbidden_paths=["**/*.pem", "**/.env", "**/id_rsa"],
         unit_test_code_extensions=[".py", ".cpp"],
         unit_test_patterns=[
@@ -363,6 +360,46 @@ class UnitTestRuleTests(unittest.TestCase):
             with self.subTest(test_path=test_path):
                 files = [make_file("src/module.py"), make_file(test_path)]
                 self.assertEqual(self._errs(files), [])
+
+    def test_path_based_pattern_satisfies_requirement(self) -> None:
+        # Patterns containing '/' are matched against the full file path, not
+        # just the basename. This allows entire test directories to be
+        # recognised as test locations even if their files use no special naming
+        # convention (e.g. hip-tests files named after the API they test:
+        # atomicAdd.cc, acquire_release.cc).
+        policy = make_policy(
+            unit_test_patterns=[
+                "test_*",
+                "*_test.*",
+                "**/test/gtest/**",
+                "projects/hip-tests/**",
+            ]
+        )
+        errs: List[str] = []
+
+        # A .cpp file under projects/hip-tests/ satisfies the requirement even
+        # though its basename ('atomicAdd.cpp') matches no name-based pattern.
+        files = [
+            make_file("projects/clr/hipamd/src/hip_memory.cpp"),
+            make_file("projects/hip-tests/catch/unit/memory/atomicAdd.cpp"),
+        ]
+        pc.ensure_unit_tests(policy, files, errs)
+        self.assertEqual(errs, [])
+
+    def test_path_based_pattern_code_only_still_fails(self) -> None:
+        # A path-based pattern only helps when the PR actually touches a file
+        # under that path. Source changes with no matching test path still fail.
+        policy = make_policy(
+            unit_test_patterns=[
+                "test_*",
+                "*_test.*",
+                "projects/hip-tests/**",
+            ]
+        )
+        errs: List[str] = []
+        files = [make_file("projects/clr/hipamd/src/hip_memory.cpp")]
+        pc.ensure_unit_tests(policy, files, errs)
+        self.assertTrue(errs)
 
 
 # ----------------------------- draft + bump ----------------------------------


### PR DESCRIPTION
## Summary

The `test_file_patterns` config already supports full-path glob matching (patterns containing `/` are matched against the full file path via `_is_test_file`), but this was underdocumented and had no unit test coverage.

This matters because some repos (notably rocm-systems) have test directories whose files use no `test_*` naming convention (e.g. `projects/hip-tests/catch/unit/memory/atomicAdd.cc`).

- **`policy.yml`**: expand the `test_file_patterns` comment to clearly document both matching modes (basename vs full-path) with concrete examples for how downstream repos configure path-based patterns for their test directories
- **`test_policy_check_ut.py`**: add two new tests covering path-based patterns (one pass, one fail), and fix the `make_policy()` fixture which referenced `Policy` fields that no longer exist (`max_files_changed`, `max_total_changes`, `max_single_file_changes`), causing 20 pre-existing test failures on `main`

Closes #6654

## Test plan

- [x] `python -m pytest skills/therock_pr_bot/test_policy_check_ut.py` — 32 pass (up from 3), 2 pre-existing failures unrelated to this change
- [x] `test_path_based_pattern_satisfies_requirement`: file under `projects/hip-tests/**` satisfies the unit test requirement alongside a CLR source change
- [x] `test_path_based_pattern_code_only_still_fails`: source-only change with no matching test path still fails correctly

## Follow-up

A separate PR to rocm-systems (ROCm/rocm-systems#8782) syncs `policy_check.py` and adds `projects/hip-tests/**` to its `test_file_patterns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)