### PR TITLE
PR Bot reviewer hash updation

### DIFF
--- a/.github/workflows/therock-pr-bot.yml
+++ b/.github/workflows/therock-pr-bot.yml
@@ -41,12 +41,12 @@ jobs:
       # guarantees we run OUR policy_check.py / policy.yml — not the fork's.
       # `persist-credentials: false` follows the safer-checkout defaults
       # (https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/).
-      - uses: actions/checkout@9c091bb # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
-      - uses: actions/setup-python@2e3e4b15a0d3b0d2e3e4b15a0d3b0d2e3e4b15a0 # v6.3.0
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
Motivation
TheRock-pr-bot tool to add policy based checks on PRs.
right now we are adding label "not ready for review" for PRs that does
not have issue/jira linked and PRs that has zero unit test to it. We
have other checks at place around forbidden files, pre-commit failure,
branch name convention. and more checks marked as soon to enabled.

Technical Details
The checks are purely based on config file named policy.yml based PR
BOT. this is not a llm/AI based bot. This is using code to
deterministically provide checks.

Updation in current PR?
1.checkout hash related fix

Test Plan
This PR initially raised on TheRock post that it will extend to rocm-systems and rocm-libraries.

JIRA ID
https://github.com/ROCm/TheRock/issues/6242

Test Result
image