### PR TITLE
PR bot reviewer updations

### DIFF
--- a/.github/workflows/therock-pr-bot.yml
+++ b/.github/workflows/therock-pr-bot.yml
@@ -54,10 +54,10 @@ jobs:
         id: app-secrets
         shell: bash
         env:
-          APP_CLIENT_ID: ${{ secrets.THEROCK_PR_BOT_APPID }}
+          APP_ID: ${{ secrets.THEROCK_PR_BOT_APPID }}
           APP_KEY: ${{ secrets.THEROCK_PRBOT_KEY }}
         run: |
-          if [[ -n "$APP_CLIENT_ID" && -n "$APP_KEY" ]]; then
+          if [[ -n "$APP_ID" && -n "$APP_KEY" ]]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
@@ -68,9 +68,7 @@ jobs:
         if: steps.app-secrets.outputs.available == 'true'
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v3.2.0
         with:
-          # 'app-id' is deprecated since v3.1.0 — use the App's Client ID.
-          # See: https://github.com/actions/create-github-app-token/issues/353
-          client-id: ${{ secrets.THEROCK_PR_BOT_APPID }}
+          app-id: ${{ secrets.THEROCK_PR_BOT_APPID }}
           private-key: ${{ secrets.THEROCK_PRBOT_KEY }}
 
       # SECURITY: only fixed, trusted dependencies — never installed from the PR.


### PR DESCRIPTION
Motivation
TheRock-pr-bot tool to add policy based checks on PRs.
right now we are adding label "not ready for review" for PRs that does
not have issue/jira linked and PRs that has zero unit test to it. We
have other checks at place around forbidden files, pre-commit failure,
branch name convention. and more checks marked as soon to enabled.

Technical Details
The checks are purely based on config file named policy.yml based PR
BOT. this is not a llm/AI based bot. This is using code to
deterministically provide checks.

Updation in current PR?
1.checkout hash related fix

Test Plan
This PR initially raised on TheRock post that it will extend to rocm-systems and rocm-libraries.

JIRA ID
https://github.com/ROCm/TheRock/issues/6242