### PR TITLE
add tests guards- flag Tensile lazy libraries shipped without code objects

### DIFF
--- a/tests/test_artifact_structure.py
+++ b/tests/test_artifact_structure.py
@@ -17,6 +17,13 @@ Tests:
     component scanner should enforce this via the extends chain).
   - Manifest validation: every archive should have artifact_manifest.txt
     as its first member.
+  - Tensile code objects: any artifact that ships a Tensile lazy library
+    (TensileLibrary_lazy_*.dat) for a gfx target must also ship the matching
+    loadable code-object files (*.hsaco). A lazy library without its code
+    objects loads fine but fails at kernel dispatch with hipErrorFileNotFound,
+    which surfaces far downstream as an opaque error (e.g. rocBLAS ->
+    MIOpen -> "miopenStatusInternalError" in PyTorch RNN backward).
+    See https://github.com/ROCm/TheRock/issues/5976.
 
 Usage:
     THEROCK_ARTIFACTS_DIR=/path/to/archives \\
@@ -29,6 +36,7 @@ THEROCK_ARTIFACTS_DIR should point to a directory containing artifact archives
 import dataclasses
 import logging
 import os
+import re
 import sys
 from collections import defaultdict
 from pathlib import Path
@@ -138,6 +146,52 @@ class ComponentOverlap:
 
     artifact_name: str
     overlaps: dict[str, list[str]]  # path -> [component_name, ...]
+
+
+@dataclasses.dataclass
+class TensileCodeObjectGap:
+    """An artifact that ships a Tensile lazy library but no code objects."""
+
+    filename: str
+    artifact_name: str
+    lazy_libraries: list[str]  # flattened paths of TensileLibrary_lazy_*.dat
+
+
+# A Tensile lazy library is a manifest (.dat) that references code-object files
+# loaded on demand at kernel dispatch. Current builds emit those code objects as
+# ``.hsaco`` (with ``-xnack+``/``-xnack-`` variants). If the .dat ships without
+# any .hsaco, library load still succeeds but the first matching GEMM aborts with
+# hipErrorFileNotFound -> see issue #5976.
+_TENSILE_LAZY_LIBRARY_RE = re.compile(r"(^|/)TensileLibrary_lazy_[^/]*\.dat$")
+_CODE_OBJECT_RE = re.compile(r"\.hsaco$")
+
+
+def find_tensile_code_object_gaps(
+    archive_index: list[ArchiveInfo],
+) -> list[TensileCodeObjectGap]:
+    """Return archives that carry a Tensile lazy library but no code objects.
+
+    The check is scoped to the archive that actually contains the lazy
+    library: if that same archive ships no ``*.hsaco`` code objects, the lazy
+    library is unusable at runtime.
+    """
+    gaps: list[TensileCodeObjectGap] = []
+    for info in archive_index:
+        lazy_libraries = sorted(
+            p for p in info.flattened_paths if _TENSILE_LAZY_LIBRARY_RE.search(p)
+        )
+        if not lazy_libraries:
+            continue
+        has_code_objects = any(_CODE_OBJECT_RE.search(p) for p in info.flattened_paths)
+        if not has_code_objects:
+            gaps.append(
+                TensileCodeObjectGap(
+                    filename=info.filename,
+                    artifact_name=info.artifact_name,
+                    lazy_libraries=lazy_libraries,
+                )
+            )
+    return gaps
 
 
 @pytest.fixture(scope="session")
@@ -309,4 +363,49 @@ class TestArtifactStructure:
         logger.info(
             "Checked %d artifacts, no within-artifact component overlaps",
             len(artifact_names),
+        )
+
+    def test_tensile_lazy_library_has_code_objects(
+        self, archive_index: list[ArchiveInfo]
+    ):
+        """Tensile lazy libraries must ship with their code objects.
+
+        A ``TensileLibrary_lazy_<gfx>.dat`` is only a manifest; the actual
+        kernels live in ``*.hsaco`` code-object files loaded on demand. If an
+        artifact ships the lazy .dat but none of the .hsaco files (e.g. a
+        packaging step drops device code objects for a gfx target), the library
+        loads successfully but the first matching GEMM aborts with
+        ``hipErrorFileNotFound``. Downstream this surfaces as an opaque failure
+        far from the root cause -- in #5976 a rocBLAS GEMM invoked from MIOpen's
+        RNN backward raised ``miopenStatusInternalError`` for fp16 RNN tests on
+        gfx90a, because the rocBLAS device wheel shipped the lazy .dat and
+        ``.co`` files but zero ``.hsaco`` code objects.
+
+        See https://github.com/ROCm/TheRock/issues/5976.
+        """
+        gaps = find_tensile_code_object_gaps(archive_index)
+
+        if gaps:
+            lines = []
+            for gap in sorted(gaps, key=lambda g: g.filename):
+                lines.append(f"  {gap.filename} (artifact: {gap.artifact_name})")
+                for lib in gap.lazy_libraries:
+                    lines.append(f"    lazy library: {lib}")
+                lines.append("    code objects: (none -- expected *.hsaco)")
+            summary = "\n".join(lines)
+            pytest.fail(
+                f"Found {len(gaps)} artifact(s) shipping a Tensile lazy library "
+                f"without any *.hsaco code objects "
+                f"(see https://github.com/ROCm/TheRock/issues/5976):\n{summary}"
+            )
+
+        checked = sum(
+            1
+            for info in archive_index
+            if any(_TENSILE_LAZY_LIBRARY_RE.search(p) for p in info.flattened_paths)
+        )
+        logger.info(
+            "Checked %d archive(s) with Tensile lazy libraries, "
+            "all ship code objects",
+            checked,
         )


### PR DESCRIPTION

> #5976 is already fixed in current nightlies (the code objects came back with the 7.14→7.15 bump). This PR adds a packaging check so the *class* of failure can't silently recur. the defect it catches otherwise only surfaces **after a~6-hour multi-arch build+test run**, deep inside PyTorch's RNN tests, as an opaque `miopenStatusInternalError` with nothing pointing at "a wheel is missing files." This check runs on CPU in ~seconds and fails at packaging time with the exact artifact and missing files named — turning a multi-hour, hard-to-attribute GPU-runner failure into an instant

## Summary
This is a Preemptive guard for #5976 and similar
Adds one invariant to `tests/test_artifact_structure.py` (`test_tensile_lazy_library_has_code_objects`): any artifact archive that
ships a Tensile **lazy** library (`TensileLibrary_lazy_*.dat`) must also ship at least one `*.hsaco` code object. Runs on CPU, scans archives without extracting - same harness as the existing overlap checks.

## Why 
A lazy `.dat` is only a manifest; the kernels live in `*.hsaco` files loaded on demand at dispatch. If the code objects are dropped for a gfx target, the library still *loads* -then the first matching GEMM aborts with `hipErrorFileNotFound`, surfacing far downstream as an opaque error.

In #5976 the `rocm_sdk_device_gfx90a` wheel (ROCm 7.14 nightly `...a20260619`) shipped rocblas/library/gfx90a/TensileLibrary_lazy_gfx90a.dat` and 129 `.co` files but **0 `.hsaco`** code objects. A fp16 GEMM invoked from MIOpen's RNN backward failed, and PyTorch reported `miopenStatusInternalError` for the gfx90a fp16 RNN tests. The current nightly ships 174 `.hsaco` (87 xnack-, 87 xnack+) and passes. This check turns that silent, deep-downstream failure into
an explicit packaging-time error.

## Validation
Ran `find_tensile_code_object_gaps` against the real file listings of both
`rocm_sdk_device_gfx90a` wheels:

- 06-19 wheel (lazy `.dat`, 0 `.hsaco`) -> **flagged** (test FAILs) 
- current nightly wheel (lazy `.dat`, 174 `.hsaco`) -> passes 
- hipblaslt-style full library (`.co` + `.dat`, no lazy `.dat`) -> correctly
  ignored, no false positive 

`pytest --collect-only` shows the new test alongside the existing two; `black`
clean.

## Notes for reviewers
- The check is scoped to the archive that *contains* the lazy `.dat`, so it only fires when that same archive is missing its code objects.- **Layer confirmed.** The `rocm-sdk-device` wheel template packages its payload  with an unfiltered `platform_dir.rglob("*")` (no extension filtering - its own  comment lists `.co, .dat, .hsaco`), so the wheel is a faithful copy of the  flattened dist/split-artifact tree. The 06-19 device wheel had 0 `.hsaco`,  which means the split artifact tree also had 0 `.hsaco` -i.e. the defect is  present at the artifact layer this test scans (upstream build/kpack-split  stage), so this check would have caught #5976 pre-GPU. The `artifact-blas.toml`  descriptor includes `lib/rocblas/library/**` with no extension filter, consistent with this

Issue: https://github.com/ROCm/TheRock/issues/5976
