### PR TITLE
feat(ci): Add consolidated external repo CI configuration script

### DIFF
--- a/build_tools/github_actions/configure_external_repo_ci.py
+++ b/build_tools/github_actions/configure_external_repo_ci.py
@@ -31,7 +31,17 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Iterable, List, Mapping, Optional, Set, Tuple, Type, TypeVar
+from typing import (
+    Callable,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -97,9 +107,7 @@ def retry(
                     return func(*args, **kwargs)
                 except exceptions as e:
                     last_exception = e
-                    logger.warning(
-                        f"Attempt {attempt + 1}/{max_attempts} failed: {e}"
-                    )
+                    logger.warning(f"Attempt {attempt + 1}/{max_attempts} failed: {e}")
                     if attempt < max_attempts - 1:
                         time.sleep(delay_seconds * (2**attempt))
             raise last_exception  # type: ignore[misc]
@@ -113,8 +121,13 @@ def retry(
 def get_modified_paths_api(github_repo: str, base_sha: str, head_sha: str) -> Set[str]:
     """Get paths of files changed using GitHub API (compare endpoint)."""
     result = subprocess.run(
-        ["gh", "api", f"repos/{github_repo}/compare/{base_sha}...{head_sha}",
-         "--jq", ".files[].filename"],
+        [
+            "gh",
+            "api",
+            f"repos/{github_repo}/compare/{base_sha}...{head_sha}",
+            "--jq",
+            ".files[].filename",
+        ],
         capture_output=True,
         text=True,
         check=True,
@@ -198,7 +211,9 @@ def configure(
     # Schedule/workflow_dispatch events run all tests
     if event_name in ("schedule", "workflow_dispatch"):
         logger.info(f"{event_name} event - running all tests")
-        return ConfigureResult(changed_projects="", run_all_tests=True, skip_tests=False)
+        return ConfigureResult(
+            changed_projects="", run_all_tests=True, skip_tests=False
+        )
 
     # Get modified paths via GitHub API
     if event_name == "pull_request" and base_sha and head_sha:
@@ -210,29 +225,39 @@ def configure(
         modified_paths = get_modified_paths_api(github_repo, f"{head_sha}^", head_sha)
     else:
         logger.warning("No SHAs provided - running all tests")
-        return ConfigureResult(changed_projects="", run_all_tests=True, skip_tests=False)
+        return ConfigureResult(
+            changed_projects="", run_all_tests=True, skip_tests=False
+        )
 
     if not modified_paths:
         logger.info("No modified paths - skipping tests")
-        return ConfigureResult(changed_projects="", run_all_tests=False, skip_tests=True)
+        return ConfigureResult(
+            changed_projects="", run_all_tests=False, skip_tests=True
+        )
 
     logger.info(f"Modified paths: {len(modified_paths)} files")
 
     # Check if CI files changed (run all tests)
     if matches_patterns(modified_paths, FULL_TEST_TRIGGER_PATTERNS):
         logger.info("CI files changed - running all tests")
-        return ConfigureResult(changed_projects="", run_all_tests=True, skip_tests=False)
+        return ConfigureResult(
+            changed_projects="", run_all_tests=True, skip_tests=False
+        )
 
     # Check if only skippable files changed
     if not has_non_skippable(modified_paths):
         logger.info("Only skippable files changed - skipping tests")
-        return ConfigureResult(changed_projects="", run_all_tests=False, skip_tests=True)
+        return ConfigureResult(
+            changed_projects="", run_all_tests=False, skip_tests=True
+        )
 
     # Find changed projects from config
     config = load_repo_config(config_path)
     if not config:
         logger.warning("No config loaded - running all tests")
-        return ConfigureResult(changed_projects="", run_all_tests=True, skip_tests=False)
+        return ConfigureResult(
+            changed_projects="", run_all_tests=True, skip_tests=False
+        )
 
     valid_prefixes = get_valid_prefixes(config)
     matched = find_matched_subtrees(modified_paths, valid_prefixes)
@@ -294,11 +319,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         config_path=args.config_path,
     )
 
-    set_github_output({
-        "changed_projects": result.changed_projects,
-        "run_all_tests": str(result.run_all_tests).lower(),
-        "skip_tests": str(result.skip_tests).lower(),
-    })
+    set_github_output(
+        {
+            "changed_projects": result.changed_projects,
+            "run_all_tests": str(result.run_all_tests).lower(),
+            "skip_tests": str(result.skip_tests).lower(),
+        }
+    )
 
     return 0
 

--- a/build_tools/github_actions/configure_external_repo_ci.py
+++ b/build_tools/github_actions/configure_external_repo_ci.py
@@ -29,7 +29,7 @@ import os
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import (
     Callable,
@@ -117,23 +117,37 @@ def retry(
     return decorator  # type: ignore[return-value]
 
 
-@retry(max_attempts=3, delay_seconds=2, exceptions=(subprocess.TimeoutExpired,))
-def get_modified_paths_api(github_repo: str, base_sha: str, head_sha: str) -> Set[str]:
-    """Get paths of files changed using GitHub API (compare endpoint)."""
+@retry(
+    max_attempts=3,
+    delay_seconds=2,
+    exceptions=(subprocess.TimeoutExpired, subprocess.CalledProcessError),
+)
+def get_modified_paths_api(
+    github_repo: str, base_sha: str, head_sha: str
+) -> Optional[Set[str]]:
+    """Get paths of files changed using GitHub API (compare endpoint).
+
+    Returns None if the result is truncated (>300 files) to signal caller
+    should fall back to run_all_tests.
+    """
     result = subprocess.run(
         [
             "gh",
             "api",
             f"repos/{github_repo}/compare/{base_sha}...{head_sha}",
-            "--jq",
-            ".files[].filename",
         ],
         capture_output=True,
         text=True,
         check=True,
         timeout=60,
     )
-    return set(result.stdout.splitlines())
+    data = json.loads(result.stdout)
+    files = data.get("files", [])
+    # GitHub compare API returns max 300 files; if truncated, fall back to run-all
+    if len(files) >= 300:
+        logger.warning("Compare API returned 300+ files, result may be truncated")
+        return None
+    return {f["filename"] for f in files}
 
 
 def matches_patterns(paths: Iterable[str], patterns: Iterable[str]) -> bool:
@@ -160,7 +174,13 @@ def load_repo_config(config_path: str) -> List[RepoEntry]:
     try:
         with open(config_path, "r", encoding="utf-8") as f:
             data = json.load(f)
-        return [RepoEntry(**entry) for entry in data.get("repositories", [])]
+        # Filter to known fields to handle future additions gracefully
+        known_fields = {f.name for f in fields(RepoEntry)}
+        entries = []
+        for entry in data.get("repositories", []):
+            filtered = {k: v for k, v in entry.items() if k in known_fields}
+            entries.append(RepoEntry(**filtered))
+        return entries
     except FileNotFoundError:
         logger.warning(f"Config not found: {config_path}")
         return []
@@ -219,12 +239,20 @@ def configure(
     if event_name == "pull_request" and base_sha and head_sha:
         logger.info(f"Getting PR diff via API: {base_sha}...{head_sha}")
         modified_paths = get_modified_paths_api(github_repo, base_sha, head_sha)
-    elif event_name == "push" and head_sha:
-        # For push, compare HEAD^ to HEAD using the API
-        logger.info(f"Getting push diff via API: {head_sha}^...{head_sha}")
-        modified_paths = get_modified_paths_api(github_repo, f"{head_sha}^", head_sha)
+    elif event_name == "push" and base_sha and head_sha:
+        # For push, the caller passes github.event.before as base_sha;
+        # the compare API does not understand git "^" ancestry syntax.
+        logger.info(f"Getting push diff via API: {base_sha}...{head_sha}")
+        modified_paths = get_modified_paths_api(github_repo, base_sha, head_sha)
     else:
         logger.warning("No SHAs provided - running all tests")
+        return ConfigureResult(
+            changed_projects="", run_all_tests=True, skip_tests=False
+        )
+
+    # If API returned None (truncated results), fall back to run-all
+    if modified_paths is None:
+        logger.info("Truncated API response - running all tests")
         return ConfigureResult(
             changed_projects="", run_all_tests=True, skip_tests=False
         )

--- a/build_tools/github_actions/configure_external_repo_ci.py
+++ b/build_tools/github_actions/configure_external_repo_ci.py
@@ -110,28 +110,17 @@ def retry(
 
 
 @retry(max_attempts=3, delay_seconds=2, exceptions=(subprocess.TimeoutExpired,))
-def get_modified_paths(base_ref: str) -> Set[str]:
-    """Get paths of files changed relative to base reference."""
+def get_modified_paths_api(github_repo: str, base_sha: str, head_sha: str) -> Set[str]:
+    """Get paths of files changed using GitHub API (compare endpoint)."""
     result = subprocess.run(
-        ["git", "diff", "--name-only", base_ref],
+        ["gh", "api", f"repos/{github_repo}/compare/{base_sha}...{head_sha}",
+         "--jq", ".files[].filename"],
         capture_output=True,
         text=True,
         check=True,
         timeout=60,
     )
     return set(result.stdout.splitlines())
-
-
-def get_merge_base(base_sha: str, head_sha: str) -> str:
-    """Compute merge-base for PR diff."""
-    result = subprocess.run(
-        ["git", "merge-base", base_sha, head_sha],
-        capture_output=True,
-        text=True,
-        check=True,
-        timeout=60,
-    )
-    return result.stdout.strip()
 
 
 def matches_patterns(paths: Iterable[str], patterns: Iterable[str]) -> bool:
@@ -199,27 +188,30 @@ def set_github_output(outputs: Mapping[str, str]) -> None:
 
 def configure(
     event_name: str,
+    github_repo: str,
     base_sha: Optional[str],
     head_sha: Optional[str],
     config_path: str,
 ) -> ConfigureResult:
     """Main configuration logic."""
 
-    # Schedule events run all tests
-    if event_name == "schedule":
-        logger.info("Schedule event - running all tests")
+    # Schedule/workflow_dispatch events run all tests
+    if event_name in ("schedule", "workflow_dispatch"):
+        logger.info(f"{event_name} event - running all tests")
         return ConfigureResult(changed_projects="", run_all_tests=True, skip_tests=False)
 
-    # Determine base ref for diff
+    # Get modified paths via GitHub API
     if event_name == "pull_request" and base_sha and head_sha:
-        base_ref = get_merge_base(base_sha, head_sha)
-        logger.info(f"PR merge-base: {base_ref}")
+        logger.info(f"Getting PR diff via API: {base_sha}...{head_sha}")
+        modified_paths = get_modified_paths_api(github_repo, base_sha, head_sha)
+    elif event_name == "push" and head_sha:
+        # For push, compare HEAD^ to HEAD using the API
+        logger.info(f"Getting push diff via API: {head_sha}^...{head_sha}")
+        modified_paths = get_modified_paths_api(github_repo, f"{head_sha}^", head_sha)
     else:
-        base_ref = "HEAD^"
-        logger.info("Using HEAD^ for push")
+        logger.warning("No SHAs provided - running all tests")
+        return ConfigureResult(changed_projects="", run_all_tests=True, skip_tests=False)
 
-    # Get modified paths
-    modified_paths = get_modified_paths(base_ref)
     if not modified_paths:
         logger.info("No modified paths - skipping tests")
         return ConfigureResult(changed_projects="", run_all_tests=False, skip_tests=True)
@@ -296,6 +288,7 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     result = configure(
         event_name=args.event_name,
+        github_repo=args.github_repo,
         base_sha=args.base_sha or None,
         head_sha=args.head_sha or None,
         config_path=args.config_path,

--- a/build_tools/github_actions/configure_external_repo_ci.py
+++ b/build_tools/github_actions/configure_external_repo_ci.py
@@ -10,6 +10,7 @@ It consolidates logic previously duplicated across external repo workflows.
 Usage:
     python configure_external_repo_ci.py \
         --event-name pull_request \
+        --github-repo ROCm/rocm-libraries \
         --base-sha abc123 \
         --head-sha def456 \
         --config-path .github/repos-config.json
@@ -265,6 +266,11 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="GitHub event name",
     )
     parser.add_argument(
+        "--github-repo",
+        required=True,
+        help="GitHub repository (e.g., ROCm/rocm-libraries)",
+    )
+    parser.add_argument(
         "--base-sha",
         default="",
         help="Base SHA for PR (github.event.pull_request.base.sha)",
@@ -285,6 +291,8 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
 def main(argv: Optional[List[str]] = None) -> int:
     """Main entry point."""
     args = parse_args(argv)
+
+    logger.info(f"Configuring CI for {args.github_repo}")
 
     result = configure(
         event_name=args.event_name,

--- a/build_tools/github_actions/configure_external_repo_ci.py
+++ b/build_tools/github_actions/configure_external_repo_ci.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Configure CI for external repos (rocm-systems, rocm-libraries).
+
+This script determines which projects changed and whether to run/skip tests.
+It consolidates logic previously duplicated across external repo workflows.
+
+Usage:
+    python configure_external_repo_ci.py \
+        --event-name pull_request \
+        --base-sha abc123 \
+        --head-sha def456 \
+        --config-path .github/repos-config.json
+
+Outputs (to $GITHUB_OUTPUT):
+    changed_projects: Comma-separated list of changed project paths
+    run_all_tests: "true" if CI files changed (run full test suite)
+    skip_tests: "true" if only docs/skippable files changed
+"""
+
+import argparse
+import fnmatch
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, List, Mapping, Optional, Set, Tuple, Type, TypeVar
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+F = TypeVar("F", bound=Callable[..., object])
+
+# Patterns for files that don't require tests (docs, etc.)
+SKIPPABLE_PATH_PATTERNS = [
+    "*.md",
+    "*.rst",
+    "docs/*",
+    "projects/*/docs/*",
+    "shared/*/docs/*",
+]
+
+# Patterns that trigger a full test run when changed (CI infrastructure)
+FULL_TEST_TRIGGER_PATTERNS = [
+    ".github/workflows/therock*",
+    ".github/scripts/therock*",
+    ".github/scripts/get_changed_projects.py",
+    ".github/scripts/ci_utils.py",
+    ".github/scripts/config_loader.py",
+    ".github/scripts/repo_config_model.py",
+    ".github/scripts/pr_detect_changed_subtrees.py",
+    ".github/repos-config.json",
+]
+
+
+@dataclass
+class ConfigureResult:
+    """Result of CI configuration analysis."""
+
+    changed_projects: str  # Comma-separated list
+    run_all_tests: bool
+    skip_tests: bool
+
+
+@dataclass
+class RepoEntry:
+    """Repository entry from repos-config.json."""
+
+    name: str
+    url: str
+    branch: str
+    category: str
+    auto_subtree_pull: bool = False
+    auto_subtree_push: bool = False
+    monorepo_source_of_truth: bool = False
+
+
+def retry(
+    max_attempts: int,
+    delay_seconds: float,
+    exceptions: Tuple[Type[BaseException], ...],
+) -> Callable[[F], F]:
+    """Retry decorator with exponential backoff."""
+
+    def decorator(func: F) -> F:
+        def wrapper(*args: object, **kwargs: object) -> object:
+            last_exception: BaseException | None = None
+            for attempt in range(max_attempts):
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as e:
+                    last_exception = e
+                    logger.warning(
+                        f"Attempt {attempt + 1}/{max_attempts} failed: {e}"
+                    )
+                    if attempt < max_attempts - 1:
+                        time.sleep(delay_seconds * (2**attempt))
+            raise last_exception  # type: ignore[misc]
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator  # type: ignore[return-value]
+
+
+@retry(max_attempts=3, delay_seconds=2, exceptions=(subprocess.TimeoutExpired,))
+def get_modified_paths(base_ref: str) -> Set[str]:
+    """Get paths of files changed relative to base reference."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", base_ref],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    return set(result.stdout.splitlines())
+
+
+def get_merge_base(base_sha: str, head_sha: str) -> str:
+    """Compute merge-base for PR diff."""
+    result = subprocess.run(
+        ["git", "merge-base", base_sha, head_sha],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    return result.stdout.strip()
+
+
+def matches_patterns(paths: Iterable[str], patterns: Iterable[str]) -> bool:
+    """Check if any path matches any pattern."""
+    for path in paths:
+        for pattern in patterns:
+            if fnmatch.fnmatch(path, pattern):
+                return True
+    return False
+
+
+def is_skippable(path: str) -> bool:
+    """Check if path is skippable (docs, etc.)."""
+    return any(fnmatch.fnmatch(path, p) for p in SKIPPABLE_PATH_PATTERNS)
+
+
+def has_non_skippable(paths: Iterable[str]) -> bool:
+    """Check if any path is non-skippable."""
+    return any(not is_skippable(p) for p in paths)
+
+
+def load_repo_config(config_path: str) -> List[RepoEntry]:
+    """Load repository config from JSON."""
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return [RepoEntry(**entry) for entry in data.get("repositories", [])]
+    except FileNotFoundError:
+        logger.warning(f"Config not found: {config_path}")
+        return []
+    except Exception as e:
+        logger.error(f"Failed to load config: {e}")
+        return []
+
+
+def get_valid_prefixes(config: List[RepoEntry]) -> Set[str]:
+    """Extract valid subtree prefixes from config."""
+    return {f"{entry.category}/{entry.name}" for entry in config}
+
+
+def find_matched_subtrees(
+    changed_files: Iterable[str], valid_prefixes: Set[str]
+) -> List[str]:
+    """Find subtrees matching changed files."""
+    changed_subtrees = {
+        "/".join(path.split("/", 2)[:2])
+        for path in changed_files
+        if len(path.split("/")) >= 2
+    }
+    return sorted(changed_subtrees & valid_prefixes)
+
+
+def set_github_output(outputs: Mapping[str, str]) -> None:
+    """Write outputs to $GITHUB_OUTPUT or print if not in CI."""
+    logger.info(f"Outputs: {dict(outputs)}")
+    output_file = os.environ.get("GITHUB_OUTPUT", "")
+    if not output_file:
+        for k, v in outputs.items():
+            print(f"{k}={v}")
+        return
+    with open(output_file, "a") as f:
+        for k, v in outputs.items():
+            f.write(f"{k}={v}\n")
+
+
+def configure(
+    event_name: str,
+    base_sha: Optional[str],
+    head_sha: Optional[str],
+    config_path: str,
+) -> ConfigureResult:
+    """Main configuration logic."""
+
+    # Schedule events run all tests
+    if event_name == "schedule":
+        logger.info("Schedule event - running all tests")
+        return ConfigureResult(changed_projects="", run_all_tests=True, skip_tests=False)
+
+    # Determine base ref for diff
+    if event_name == "pull_request" and base_sha and head_sha:
+        base_ref = get_merge_base(base_sha, head_sha)
+        logger.info(f"PR merge-base: {base_ref}")
+    else:
+        base_ref = "HEAD^"
+        logger.info("Using HEAD^ for push")
+
+    # Get modified paths
+    modified_paths = get_modified_paths(base_ref)
+    if not modified_paths:
+        logger.info("No modified paths - skipping tests")
+        return ConfigureResult(changed_projects="", run_all_tests=False, skip_tests=True)
+
+    logger.info(f"Modified paths: {len(modified_paths)} files")
+
+    # Check if CI files changed (run all tests)
+    if matches_patterns(modified_paths, FULL_TEST_TRIGGER_PATTERNS):
+        logger.info("CI files changed - running all tests")
+        return ConfigureResult(changed_projects="", run_all_tests=True, skip_tests=False)
+
+    # Check if only skippable files changed
+    if not has_non_skippable(modified_paths):
+        logger.info("Only skippable files changed - skipping tests")
+        return ConfigureResult(changed_projects="", run_all_tests=False, skip_tests=True)
+
+    # Find changed projects from config
+    config = load_repo_config(config_path)
+    if not config:
+        logger.warning("No config loaded - running all tests")
+        return ConfigureResult(changed_projects="", run_all_tests=True, skip_tests=False)
+
+    valid_prefixes = get_valid_prefixes(config)
+    matched = find_matched_subtrees(modified_paths, valid_prefixes)
+    logger.info(f"Matched projects: {matched}")
+
+    return ConfigureResult(
+        changed_projects=",".join(matched),
+        run_all_tests=False,
+        skip_tests=False,
+    )
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Configure CI for external repos",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--event-name",
+        required=True,
+        choices=["pull_request", "push", "schedule", "workflow_dispatch"],
+        help="GitHub event name",
+    )
+    parser.add_argument(
+        "--base-sha",
+        default="",
+        help="Base SHA for PR (github.event.pull_request.base.sha)",
+    )
+    parser.add_argument(
+        "--head-sha",
+        default="",
+        help="Head SHA for PR (github.event.pull_request.head.sha)",
+    )
+    parser.add_argument(
+        "--config-path",
+        default=".github/repos-config.json",
+        help="Path to repos-config.json",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Main entry point."""
+    args = parse_args(argv)
+
+    result = configure(
+        event_name=args.event_name,
+        base_sha=args.base_sha or None,
+        head_sha=args.head_sha or None,
+        config_path=args.config_path,
+    )
+
+    set_github_output({
+        "changed_projects": result.changed_projects,
+        "run_all_tests": str(result.run_all_tests).lower(),
+        "skip_tests": str(result.skip_tests).lower(),
+    })
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build_tools/tests/configure_external_repo_ci_test.py
+++ b/build_tools/tests/configure_external_repo_ci_test.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for configure_external_repo_ci.py."""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent / "github_actions"))
+
+from configure_external_repo_ci import (
+    ConfigureResult,
+    RepoEntry,
+    configure,
+    find_matched_subtrees,
+    get_valid_prefixes,
+    has_non_skippable,
+    is_skippable,
+    load_repo_config,
+    matches_patterns,
+)
+
+
+class IsSkippableTest(unittest.TestCase):
+    """Tests for is_skippable()."""
+
+    def test_markdown_files_are_skippable(self):
+        self.assertTrue(is_skippable("README.md"))
+        self.assertTrue(is_skippable("docs/guide.md"))
+
+    def test_rst_files_are_skippable(self):
+        self.assertTrue(is_skippable("index.rst"))
+
+    def test_docs_directory_is_skippable(self):
+        self.assertTrue(is_skippable("docs/api.txt"))
+        self.assertTrue(is_skippable("projects/rocblas/docs/readme.md"))
+
+    def test_source_files_are_not_skippable(self):
+        self.assertFalse(is_skippable("src/main.cpp"))
+        self.assertFalse(is_skippable("projects/rocblas/src/blas.cpp"))
+        self.assertFalse(is_skippable("CMakeLists.txt"))
+
+
+class HasNonSkippableTest(unittest.TestCase):
+    """Tests for has_non_skippable()."""
+
+    def test_all_skippable_returns_false(self):
+        paths = ["README.md", "docs/guide.rst", "CHANGELOG.md"]
+        self.assertFalse(has_non_skippable(paths))
+
+    def test_mixed_returns_true(self):
+        paths = ["README.md", "src/main.cpp"]
+        self.assertTrue(has_non_skippable(paths))
+
+    def test_all_non_skippable_returns_true(self):
+        paths = ["src/a.cpp", "src/b.cpp"]
+        self.assertTrue(has_non_skippable(paths))
+
+
+class MatchesPatternsTest(unittest.TestCase):
+    """Tests for matches_patterns()."""
+
+    def test_matches_workflow_pattern(self):
+        paths = [".github/workflows/therock-ci.yml"]
+        patterns = [".github/workflows/therock*"]
+        self.assertTrue(matches_patterns(paths, patterns))
+
+    def test_no_match_returns_false(self):
+        paths = ["src/main.cpp"]
+        patterns = [".github/workflows/therock*"]
+        self.assertFalse(matches_patterns(paths, patterns))
+
+    def test_empty_paths_returns_false(self):
+        self.assertFalse(matches_patterns([], ["*.md"]))
+
+
+class FindMatchedSubtreesTest(unittest.TestCase):
+    """Tests for find_matched_subtrees()."""
+
+    def test_finds_valid_prefixes(self):
+        files = ["projects/rocblas/src/main.cpp", "projects/hipblas/CMakeLists.txt"]
+        prefixes = {"projects/rocblas", "projects/hipblas", "projects/rocfft"}
+        result = find_matched_subtrees(files, prefixes)
+        self.assertEqual(result, ["projects/hipblas", "projects/rocblas"])
+
+    def test_ignores_invalid_prefixes(self):
+        files = ["projects/unknown/file.cpp", "random/file.txt"]
+        prefixes = {"projects/rocblas"}
+        result = find_matched_subtrees(files, prefixes)
+        self.assertEqual(result, [])
+
+    def test_handles_single_segment_paths(self):
+        files = ["README.md"]
+        prefixes = {"projects/rocblas"}
+        result = find_matched_subtrees(files, prefixes)
+        self.assertEqual(result, [])
+
+
+class GetValidPrefixesTest(unittest.TestCase):
+    """Tests for get_valid_prefixes()."""
+
+    def test_extracts_prefixes(self):
+        config = [
+            RepoEntry(name="rocblas", url="", branch="", category="projects"),
+            RepoEntry(name="hipblas", url="", branch="", category="projects"),
+        ]
+        result = get_valid_prefixes(config)
+        self.assertEqual(result, {"projects/rocblas", "projects/hipblas"})
+
+
+class LoadRepoConfigTest(unittest.TestCase):
+    """Tests for load_repo_config()."""
+
+    def test_handles_missing_file(self):
+        result = load_repo_config("/nonexistent/path.json")
+        self.assertEqual(result, [])
+
+    def test_ignores_unknown_fields(self):
+        """Unknown fields in config should be ignored, not cause TypeError."""
+        import tempfile
+        import json
+
+        config_data = {
+            "repositories": [
+                {
+                    "name": "rocblas",
+                    "url": "https://github.com/ROCm/rocBLAS",
+                    "branch": "develop",
+                    "category": "projects",
+                    "future_unknown_field": "should be ignored",
+                }
+            ]
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(config_data, f)
+            temp_path = f.name
+
+        try:
+            result = load_repo_config(temp_path)
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0].name, "rocblas")
+        finally:
+            os.unlink(temp_path)
+
+
+class ConfigureTest(unittest.TestCase):
+    """Tests for configure() main logic."""
+
+    def test_schedule_event_runs_all_tests(self):
+        result = configure(
+            event_name="schedule",
+            github_repo="ROCm/rocm-libraries",
+            base_sha=None,
+            head_sha=None,
+            config_path="",
+        )
+        self.assertEqual(result.run_all_tests, True)
+        self.assertEqual(result.skip_tests, False)
+
+    def test_workflow_dispatch_runs_all_tests(self):
+        result = configure(
+            event_name="workflow_dispatch",
+            github_repo="ROCm/rocm-libraries",
+            base_sha=None,
+            head_sha=None,
+            config_path="",
+        )
+        self.assertEqual(result.run_all_tests, True)
+        self.assertEqual(result.skip_tests, False)
+
+    @patch("configure_external_repo_ci.get_modified_paths_api")
+    def test_only_docs_changed_skips_tests(self, mock_api):
+        mock_api.return_value = {"README.md", "docs/guide.md"}
+        result = configure(
+            event_name="pull_request",
+            github_repo="ROCm/rocm-libraries",
+            base_sha="abc123",
+            head_sha="def456",
+            config_path="",
+        )
+        self.assertEqual(result.skip_tests, True)
+        self.assertEqual(result.run_all_tests, False)
+
+    @patch("configure_external_repo_ci.get_modified_paths_api")
+    def test_ci_workflow_changed_runs_all_tests(self, mock_api):
+        mock_api.return_value = {".github/workflows/therock-ci.yml"}
+        result = configure(
+            event_name="pull_request",
+            github_repo="ROCm/rocm-libraries",
+            base_sha="abc123",
+            head_sha="def456",
+            config_path="",
+        )
+        self.assertEqual(result.run_all_tests, True)
+        self.assertEqual(result.skip_tests, False)
+
+    @patch("configure_external_repo_ci.get_modified_paths_api")
+    @patch("configure_external_repo_ci.load_repo_config")
+    def test_project_change_returns_changed_projects(self, mock_config, mock_api):
+        mock_api.return_value = {"projects/rocblas/src/main.cpp"}
+        mock_config.return_value = [
+            RepoEntry(name="rocblas", url="", branch="", category="projects"),
+        ]
+        result = configure(
+            event_name="pull_request",
+            github_repo="ROCm/rocm-libraries",
+            base_sha="abc123",
+            head_sha="def456",
+            config_path=".github/repos-config.json",
+        )
+        self.assertEqual(result.changed_projects, "projects/rocblas")
+        self.assertEqual(result.run_all_tests, False)
+        self.assertEqual(result.skip_tests, False)
+
+    @patch("configure_external_repo_ci.get_modified_paths_api")
+    def test_truncated_api_response_runs_all_tests(self, mock_api):
+        mock_api.return_value = None  # Signals truncated response
+        result = configure(
+            event_name="pull_request",
+            github_repo="ROCm/rocm-libraries",
+            base_sha="abc123",
+            head_sha="def456",
+            config_path="",
+        )
+        self.assertEqual(result.run_all_tests, True)
+        self.assertEqual(result.skip_tests, False)
+
+    def test_no_shas_provided_runs_all_tests(self):
+        result = configure(
+            event_name="pull_request",
+            github_repo="ROCm/rocm-libraries",
+            base_sha=None,
+            head_sha=None,
+            config_path="",
+        )
+        self.assertEqual(result.run_all_tests, True)
+
+    def test_push_without_base_sha_runs_all_tests(self):
+        """Push events without base_sha should run all tests."""
+        result = configure(
+            event_name="push",
+            github_repo="ROCm/rocm-libraries",
+            base_sha=None,
+            head_sha="def456",
+            config_path="",
+        )
+        self.assertEqual(result.run_all_tests, True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Consolidates duplicated CI configuration logic from rocm-systems and rocm-libraries into a single Python script. Handles event detection, merge-base computation, changed project matching, and skip/run-all logic.

Instead of the diverged python scripts in superrepos, we will now rely on this config script to handle for multi arch external CI

External repos can call this script instead of maintaining separate copies of get_changed_projects.py and its dependencies.

Working here: 
- https://github.com/ROCm/rocm-systems/compare/users/geomin12/external-repo-test?expand=1 / https://github.com/ROCm/rocm-systems/actions/runs/29611239090/job/87986184274
- https://github.com/ROCm/rocm-libraries/compare/users/geomin12/external-repo-test?expand=1 / https://github.com/ROCm/rocm-libraries/actions/runs/29611231925/job/87986155420

ISSUE ID: #3343