### PR TITLE
feat(ccache): use in-cluster Redis as default remote backend for Linux CI

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Setup ccache
         run: |
           ./build_tools/setup_ccache.py \
-            --release-type "${{ inputs.release_type }}" \
+            --config-preset github-oss-redis \
             --dir "$(dirname $CCACHE_CONFIGPATH)" \
             --local-path "$CACHE_DIR/ccache"
 

--- a/build_tools/setup_ccache.py
+++ b/build_tools/setup_ccache.py
@@ -25,6 +25,7 @@ Typical usage for the current shell (will set the CCACHE_CONFIGPATH var):
 """
 
 import argparse
+import os
 from pathlib import Path
 import platform
 import sys
@@ -39,6 +40,16 @@ POSIX_COMPILER_CHECK_SCRIPT = (
 )
 CACHE_SRV_DEV = "http://bazelremote-svc.bazelremote-ns.svc.cluster.local:8080|layout=bazel|connect-timeout=50"
 CACHE_SRV_REL = "http://bazelremote-svc-rel.bazelremote-ns.svc.cluster.local:8080|layout=bazel|connect-timeout=50"
+
+# Redis (Valkey) remote cache: an in-cluster, ClusterIP-only service in the
+# prod build cluster (therock-runners-prod). No authentication, matching the
+# bazel-remote posture (relies on cluster network isolation). The endpoint is
+# overridable via CCACHE_REDIS_ENDPOINT so it is not hardcoded per environment.
+CACHE_SRV_REDIS_ENDPOINT = os.environ.get(
+    "CCACHE_REDIS_ENDPOINT",
+    "redis-ccache-svc.redis-ccache-ns.svc.cluster.local:6379",
+)
+CACHE_SRV_REDIS = f"redis://{CACHE_SRV_REDIS_ENDPOINT}|connect-timeout=50"
 
 # Bump this version when making hash-affecting config changes (sloppiness,
 # compiler_check, etc.) to logically isolate new cache entries from stale
@@ -65,6 +76,14 @@ CONFIG_PRESETS_MAP = {
     },
     "github-oss-release": {
         "remote_storage": CACHE_SRV_REL,
+        "max_size": "10G",
+        "namespace": f"therock-{CCACHE_NAMESPACE_VERSION}",
+    },
+    # In-cluster Redis (Valkey) remote cache. Opt-in via the CI cache_type
+    # input; the default remains sccache. max_size below applies to the local
+    # cache tier that fronts the remote Redis store.
+    "github-oss-redis": {
+        "remote_storage": CACHE_SRV_REDIS,
         "max_size": "10G",
         "namespace": f"therock-{CCACHE_NAMESPACE_VERSION}",
     },

--- a/docs/development/ccache_troubleshooting.md
+++ b/docs/development/ccache_troubleshooting.md
@@ -42,6 +42,30 @@ remote cache, accessed via ccache's `remote_storage` option with
 Both servers are on the Kubernetes cluster, accessible without
 authentication from any pod in the cluster.
 
+### In-cluster Redis backend
+
+The `github-oss-redis` preset points ccache's `remote_storage` at an
+in-cluster Redis (Valkey) service in the prod build cluster
+(`therock-runners-prod`):
+
+| Preset             | Server                                                    | Used by              |
+| ------------------ | --------------------------------------------------------- | -------------------- |
+| `github-oss-redis` | `redis-ccache-svc.redis-ccache-ns.svc.cluster.local:6379` | Linux CI (default)   |
+
+Like bazel-remote, it is a `ClusterIP` service with **no authentication**,
+relying on cluster network isolation. The endpoint can be overridden with the
+`CCACHE_REDIS_ENDPOINT` environment variable. It is deployed from
+`ROCm/TheRock-Infra` (`helm/redis-ccache`, `deploy-redis-ccache-prod.yaml`).
+
+This is the default remote backend for Linux multi-arch CI builds. Since the
+service is in-cluster only, builds must run on the AWS in-cluster pool
+(`aws-linux-scale-rocm-prod`). Windows builds are unaffected and continue
+using their existing cache setup.
+
+Caveat: ccache's built-in Redis backend has no TLS and is **deprecated for
+removal in ccache 4.14/4.15**. This backend works with the pinned 4.11.2 but
+has a shelf-life; revisit if/when ccache is upgraded.
+
 ### Namespace version
 
 `CCACHE_NAMESPACE_VERSION` in `setup_ccache.py` controls the cache


### PR DESCRIPTION
## Motivation

## ccache Redis Remote Cache — Performance Results

  Two back-to-back runs on branch `users/amd-chiranjeevi/ccache_redis_linux`:
  - **Run 1** (cold): cache population — all misses written to Redis
  - **Run 2** (warm): cache hits served from Redis

  ### Build Time Improvements

  | Stage | Run 1 | Run 2 | Saved |
  | --- | --- | --- | --- |
  | compiler-runtime | 19m 05s | 9m 17s | **-51%** |
  | math-libs (gfx94X-dcgpu) | 1h 19m 34s | 58m 32s | **-26%** |
  | math-libs (gfx950-dcgpu) | 1h 08m 42s | 39m 07s | **-43%** |
  | wsl-rocdxg | 1h 43m 28s | 48m 29s | **-53%** |
  | profiler-apps | 25m 44s | 2m 52s | **-89%** |
  | dctools-core | 2m 53s | 1m 25s | **-51%** |
  | debug-tools | 4m 10s | 2m 49s | **-32%** |
  | comm-libs | 52m 37s | 47m 59s | **-9%** |
  | runtime-tests | 10m 04s | 9m 59s | **-1%** |
  | media-libs | 1m 23s | 1m 19s | **-5%** |
  | storage-libs | 1m 10s | 1m 07s | **-4%** |

  ### Cache Hit Rates (Run 1 → Run 2)

  | Stage | Compilations | Run 1 hit rate | Run 2 hit rate | Run 2 remote hits |
  | --- | --- | --- | --- | --- |
  | compiler-runtime | 35,887 | 0.58% | **91.22%** | 32,434 / 35,586 (91.14%) |
  | math-libs (gfx94X-dcgpu) | 9,948 | 13.68% | **96.47%** | 9,163 / 9,514 (96.31%) |
  | math-libs (gfx950-dcgpu) | 9,948 | 17.42% | **96.46%** | 9,156 / 9,508 (96.30%) |
  | comm-libs | 1,565 | 66.58% | **86.71%** | 1,347 / 1,555 (86.62%) |
  | runtime-tests | 1,323 | 78.53% | **91.53%** | 1,203 / 1,315 (91.48%) |
  | media-libs | 1,516 | 66.09% | **92.61%** | 1,393 / 1,505 (92.56%) |
  | dctools-core | 4,290 | 44.64% | **93.82%** | 3,131 / 3,396 (92.20%) |
  | debug-tools | 10,529 | 64.58% | **98.91%** | 3,335 / 3,450 (96.67%) |
  | storage-libs | 1,188 | 84.51% | **90.66%** | 1,070 / 1,181 (90.60%) |
  | profiler-apps | 1,955 | 53.25% | **87.11%** | 1,692 / 1,944 (87.04%) |

  ### Notes

  - Run 1 hit rates > 0% on later stages (comm-libs, media-libs, etc.) because they ran
    after compiler-runtime had already populated Redis during the same run.
  - `compiler-runtime` was fully cold in Run 1 (0% remote hits, 71k writes to Redis).
  - Remaining misses (~3–13%) are new or changed compilation units not yet cached — these
    fill in on subsequent runs.
  - Windows builds are unaffected; Redis is Linux-only.
  - CI runs: [Run 1](https://github.com/ROCm/TheRock/actions/runs/29928956043) · [Run 2](https://github.com/ROCm/TheRock/actions/runs/29945202085)

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
