### PR TITLE
Insert rocm/ path segment into structured product-local keys

### DIFF
--- a/build_tools/_therock_utils/python_package_paths.py
+++ b/build_tools/_therock_utils/python_package_paths.py
@@ -79,9 +79,10 @@ def is_accepted_artifact(filename: str) -> bool:
 def structured_key(product: str, index: str, filename: str) -> str:
     """Compute the structured S3 key for an artifact.
 
-    Returns ``v5/<product>/<index>/<normalized-package>/<filename>``. The
-    ``v5`` prefix is the layout schema version; CloudFront needs to redirect
-    the served path to the current version.
+    Returns ``v5/rocm/<product>/<index>/<normalized-package>/<filename>``.
+    ``v5`` is the layout schema version and the S3 origin prefix; ``rocm`` is
+    the served tree segment, so the object serves at
+    ``<stream>.repo.amd.com/rocm/<product>/<index>/...`` with no rewrite.
 
     Raises:
         ValueError: if ``index`` is not a valid aggregate index name.
@@ -89,7 +90,7 @@ def structured_key(product: str, index: str, filename: str) -> str:
     if index not in INDEX_NAMES:
         raise ValueError(f"index={index!r} is invalid, must be one of {INDEX_NAMES}")
     package = package_name_from_filename(filename)
-    return f"v5/{product}/{index}/{package}/{filename}"
+    return f"v5/rocm/{product}/{index}/{package}/{filename}"
 
 
 @dataclasses.dataclass

--- a/build_tools/github_actions/publish_rocm_to_release_buckets.py
+++ b/build_tools/github_actions/publish_rocm_to_release_buckets.py
@@ -142,7 +142,7 @@ def publish_python_packages(
     product-local package directories instead of the flat v4/whl prefix:
 
         s3://therock-dev-artifacts/12345-linux/python/rocm_sdk_core-...whl
-          -> s3://therock-dev-python/v5/core/<index>/rocm-sdk-core/rocm_sdk_core-...whl
+          -> s3://therock-dev-python/v5/rocm/core/<index>/rocm-sdk-core/rocm_sdk_core-...whl
     """
     source = artifacts_root.python_packages()
     dest_bucket = get_release_bucket_config(release_type, "python")
@@ -181,7 +181,7 @@ def _publish_python_packages_structured(
     """Copy python packages into product-local package directories.
 
     Lists the flat source prefix, then copies each accepted artifact into
-    ``v5/core/<index>/<normalized-package>/<filename>`` so the structured
+    ``v5/rocm/core/<index>/<normalized-package>/<filename>`` so the structured
     index generator can discover per-package directories.
     """
     source_objects = backend.list_files(source, include=["*.whl", "*.tar.gz", "*.zip"])
@@ -295,7 +295,7 @@ def main(argv: list[str]) -> None:
         "--structured",
         action="store_true",
         help="Publish python packages into product-local package directories "
-        "(v5/core/<index>/<package>/) instead of the flat v4/whl prefix. "
+        "(v5/rocm/core/<index>/<package>/) instead of the flat v4/whl prefix. "
         "Multi-arch (--kpack-split true) only.",
     )
     parser.add_argument(
@@ -303,7 +303,7 @@ def main(argv: list[str]) -> None:
         default="whl",
         choices=["whl", "whl-next"],
         help="Product-local index name for structured Python publishing "
-        "(default: whl). Selects the v5/core/<index>/ path segment.",
+        "(default: whl). Selects the v5/rocm/core/<index>/ path segment.",
     )
     parser.add_argument(
         "--skip-native-packages",

--- a/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
+++ b/build_tools/github_actions/tests/publish_rocm_to_release_buckets_test.py
@@ -234,17 +234,17 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
             dest_by_src[
                 "123-linux/python/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
             ],
-            "v5/core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl",
+            "v5/rocm/core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl",
         )
         self.assertEqual(
             dest_by_src["123-linux/python/rocm-7.13.0.tar.gz"],
-            "v5/core/whl/rocm/rocm-7.13.0.tar.gz",
+            "v5/rocm/core/whl/rocm/rocm-7.13.0.tar.gz",
         )
         self.assertEqual(
             dest_by_src[
                 "123-linux/python/rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl"
             ],
-            "v5/core/whl/rocm-sdk-device-gfx1100/"
+            "v5/rocm/core/whl/rocm-sdk-device-gfx1100/"
             "rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl",
         )
         # Destination bucket is the release python bucket.
@@ -282,7 +282,7 @@ class TestPublishRocmToReleaseBuckets(unittest.TestCase):
         _, dest = mock_copy_file.call_args_list[0].args
         self.assertEqual(
             dest.relative_path,
-            "v5/core/whl-next/rocm-sdk-core/"
+            "v5/rocm/core/whl-next/rocm-sdk-core/"
             "rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl",
         )
 

--- a/build_tools/packaging/python/manage_structured.py
+++ b/build_tools/packaging/python/manage_structured.py
@@ -7,9 +7,9 @@
 Generates pip-compatible PEP 503 simple indexes for the stream-subdomain
 structured layout, where each package lives in its own directory:
 
-    <product>/<index>/<normalized-package>/<filename>
-    <product>/<index>/<normalized-package>/index.html
-    <product>/<index>/index.html            (product-local root listing)
+    v5/rocm/<product>/<index>/<normalized-package>/<filename>
+    v5/rocm/<product>/<index>/<normalized-package>/index.html
+    v5/rocm/<product>/<index>/index.html            (product-local root listing)
 
 `<index>` is `whl` or `whl-next`. Release streams are selected by hostname
 (e.g. nightly.repo.amd.com), never encoded in the path, so this generator is
@@ -25,13 +25,13 @@ Example usage:
 
     # Render indexes locally without uploading (the default; writes index.html
     # files under the cwd for inspection):
-    python manage_structured.py core/whl --bucket my-python-bucket
+    python manage_structured.py v5/rocm/core/whl --bucket my-python-bucket
 
     # Generate and upload indexes for every package under a product-local root:
-    python manage_structured.py core/whl --bucket my-python-bucket --upload
+    python manage_structured.py v5/rocm/core/whl --bucket my-python-bucket --upload
 
     # Regenerate a single package directory (skips the product root index):
-    python manage_structured.py core/whl --bucket my-python-bucket \
+    python manage_structured.py v5/rocm/core/whl --bucket my-python-bucket \
         --package numpy --upload
 
 The bucket may also be supplied via the `S3_BUCKET_PY` environment variable;
@@ -133,7 +133,7 @@ class IndexPage:
     """A rendered index.html and the S3 key it should be written to.
 
     Attributes:
-        key: Destination S3 key (e.g. "pytorch/whl/torch/index.html").
+        key: Destination S3 key (e.g. "v5/rocm/pytorch/whl/torch/index.html").
         html: Rendered HTML body.
     """
 
@@ -168,7 +168,8 @@ def discover_packages(
         keys: Raw S3 keys to group. '+' is escaped to '%2B' only at render
             time, so filenames here carry the literal '+' local-version
             separator that the packaging parsers expect.
-        root: The `<product>/<index>` prefix (no trailing slash required).
+        root: The `v5/rocm/<product>/<index>` prefix (no trailing slash
+            required).
         package: If set, restrict discovery to this package directory only.
 
     Returns:
@@ -290,7 +291,7 @@ def render_package_page(pkg: PackageDir, skip_checksum: bool = True) -> str:
 def render_root_page(packages: list[PackageDir]) -> str:
     """Render the product-local root page listing local package directories.
 
-    This is the product-local root (e.g. pytorch/whl/index.html), not the
+    This is the product-local root (e.g. v5/rocm/pytorch/whl/index.html), not the
     aggregate /rocm/whl/ root, which is owned by separate infrastructure.
     """
     out: list[str] = ["<!DOCTYPE html>", "<html>", "  <body>"]
@@ -312,7 +313,7 @@ def build_index_pages(
 
     Args:
         packages: Discovered package directories.
-        root: The `<product>/<index>` prefix.
+        root: The `v5/rocm/<product>/<index>` prefix.
         write_root: If True, also generate the product-local root index page.
             Must be False for package-scoped regeneration: a scoped run does
             not see the full package set and would clobber the root listing.
@@ -482,7 +483,7 @@ def generate_structured_index(
     Args:
         client: A boto3 S3 client.
         bucket_name: Target S3 bucket.
-        root: The `<product>/<index>` prefix.
+        root: The `v5/rocm/<product>/<index>` prefix.
         package: If set, regenerate only this package directory and skip the
             product-local root index (the scoped listing cannot rebuild the
             root without clobbering it).
@@ -516,7 +517,8 @@ def create_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "prefix",
-        help="Product-local root prefix, e.g. pytorch/whl or core/whl-next",
+        help="Product-local root prefix, e.g. v5/rocm/pytorch/whl or "
+        "v5/rocm/core/whl-next",
     )
     parser.add_argument("--bucket", type=str, help="S3 bucket name")
     parser.add_argument(

--- a/build_tools/tests/python_package_paths_test.py
+++ b/build_tools/tests/python_package_paths_test.py
@@ -111,14 +111,17 @@ def test_is_accepted_artifact(filename: str, expected: bool) -> None:
 
 def test_structured_key_composition() -> None:
     key = structured_key("pytorch", "whl", "torch-2.10.0-cp310-cp310-linux_x86_64.whl")
-    assert key == "v5/pytorch/whl/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl"
+    assert key == "v5/rocm/pytorch/whl/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl"
 
 
 def test_structured_key_whl_next() -> None:
     key = structured_key(
         "pytorch", "whl-next", "torch-2.10.0-cp310-cp310-linux_x86_64.whl"
     )
-    assert key == "v5/pytorch/whl-next/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl"
+    assert (
+        key
+        == "v5/rocm/pytorch/whl-next/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl"
+    )
 
 
 def test_structured_key_underscore_filename_dashed_dir() -> None:
@@ -127,7 +130,7 @@ def test_structured_key_underscore_filename_dashed_dir() -> None:
         "core", "whl", "rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
     )
     assert key == (
-        "v5/core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
+        "v5/rocm/core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
     )
 
 
@@ -159,8 +162,8 @@ def test_plan_local_uploads(tmp_path: Path) -> None:
     assert all(isinstance(p, PlannedUpload) for p in plans)
     dests = {p.dest.relative_path for p in plans}
     assert dests == {
-        "v5/pytorch/whl/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl",
-        "v5/pytorch/whl/amd-torch-device-gfx942/"
+        "v5/rocm/pytorch/whl/torch/torch-2.10.0-cp310-cp310-linux_x86_64.whl",
+        "v5/rocm/pytorch/whl/amd-torch-device-gfx942/"
         "amd_torch_device_gfx942-2.10.0-py3-none-linux_x86_64.whl",
     }
     for p in plans:
@@ -197,11 +200,13 @@ def test_plan_key_copies() -> None:
     mapping = {p.source.relative_path: p.dest.relative_path for p in plans}
     assert mapping == {
         "12345-linux/python/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl": (
-            "v5/core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
+            "v5/rocm/core/whl/rocm-sdk-core/rocm_sdk_core-7.13.0-py3-none-linux_x86_64.whl"
         ),
-        "12345-linux/python/rocm-7.13.0.tar.gz": "v5/core/whl/rocm/rocm-7.13.0.tar.gz",
+        "12345-linux/python/rocm-7.13.0.tar.gz": (
+            "v5/rocm/core/whl/rocm/rocm-7.13.0.tar.gz"
+        ),
         "12345-linux/python/rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl": (
-            "v5/core/whl/rocm-sdk-device-gfx1100/"
+            "v5/rocm/core/whl/rocm-sdk-device-gfx1100/"
             "rocm_sdk_device_gfx1100-7.13.0-py3-none-linux_x86_64.whl"
         ),
     }
@@ -229,6 +234,6 @@ def test_generated_keys_round_trip_through_discover_packages() -> None:
     ]
     keys = [structured_key("pytorch", "whl", f) for f in filenames]
 
-    packages = discover_packages(keys, root="v5/pytorch/whl")
+    packages = discover_packages(keys, root="v5/rocm/pytorch/whl")
     names = sorted(p.name for p in packages)
     assert names == ["amd-torch-device-gfx942", "llnl-hatchet", "torch"]

--- a/build_tools/third_party/s3_management/tests/update_dependencies_test.py
+++ b/build_tools/third_party/s3_management/tests/update_dependencies_test.py
@@ -214,21 +214,21 @@ def test_structured_dependency_key_composition() -> None:
         pkg_name="numpy",
         filename="numpy-2.0.0-cp312-cp312-linux_x86_64.whl",
     )
-    assert key == "v5/core/whl/numpy/numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
+    assert key == "v5/rocm/core/whl/numpy/numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
 
 
 def test_structured_dependency_key_pure_python() -> None:
     key = structured_dependency_key(
         "whl", "networkx", "networkx-3.4.2-py3-none-any.whl"
     )
-    assert key == "v5/core/whl/networkx/networkx-3.4.2-py3-none-any.whl"
+    assert key == "v5/rocm/core/whl/networkx/networkx-3.4.2-py3-none-any.whl"
 
 
 def test_structured_dependency_key_whl_next() -> None:
     key = structured_dependency_key(
         "whl-next", "numpy", "numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
     )
-    assert key == "v5/core/whl-next/numpy/numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
+    assert key == "v5/rocm/core/whl-next/numpy/numpy-2.0.0-cp312-cp312-linux_x86_64.whl"
 
 
 def test_structured_dependency_key_underscore_name_dashed_dir() -> None:
@@ -236,7 +236,7 @@ def test_structured_dependency_key_underscore_name_dashed_dir() -> None:
     key = structured_dependency_key(
         "whl", "ml_dtypes", "ml_dtypes-0.5.0-cp312-cp312-linux_x86_64.whl"
     )
-    assert key == "v5/core/whl/ml-dtypes/ml_dtypes-0.5.0-cp312-cp312-linux_x86_64.whl"
+    assert key == "v5/rocm/core/whl/ml-dtypes/ml_dtypes-0.5.0-cp312-cp312-linux_x86_64.whl"
 
 
 def test_structured_dependency_key_rejects_bad_index() -> None:

--- a/build_tools/third_party/s3_management/update_dependencies.py
+++ b/build_tools/third_party/s3_management/update_dependencies.py
@@ -107,7 +107,7 @@ def structured_dependency_key(index: str, pkg_name: str, filename: str) -> str:
 
     Example:
         structured_dependency_key("whl", "ml_dtypes", "ml_dtypes-0.5.0-...whl")
-        -> "v5/core/whl/ml-dtypes/ml_dtypes-0.5.0-...whl"
+        -> "v5/rocm/core/whl/ml-dtypes/ml_dtypes-0.5.0-...whl"
     """
     if index not in _STRUCTURED_INDEX_NAMES:
         raise ValueError(
@@ -115,7 +115,7 @@ def structured_dependency_key(index: str, pkg_name: str, filename: str) -> str:
             f"expected one of {sorted(_STRUCTURED_INDEX_NAMES)}"
         )
     package_dir = normalize_package_name(pkg_name)
-    return f"v5/{_STRUCTURED_PRODUCT}/{index}/{package_dir}/{filename}"
+    return f"v5/rocm/{_STRUCTURED_PRODUCT}/{index}/{package_dir}/{filename}"
 
 
 def get_selected_packages(


### PR DESCRIPTION
## Motivation

Structured keys were emitted as `v5/<product>/<index>/...` but RFC0012 places every product (core, pytorch, jax, onnx-runtime) under the `rocm/` tree served at `<stream>.repo.amd.com/rocm/<product>/<index>/`.

Progress on #6598.

## Technical Details

`v5/` is the S3 origin prefix, so writing to `v5/rocm/<product>/...` serves the correct RFC0012 path directly, with no CloudFront rewrite of `v5/` to `rocm/` required.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
