### PR TITLE
feat(ci): enable KPACK_SPLIT_ARTIFACTS in build_configure.py for superrepos

### DIFF
--- a/build_tools/github_actions/build_configure.py
+++ b/build_tools/github_actions/build_configure.py
@@ -108,13 +108,14 @@ def build_configure(build_dir, manylinux=False):
             f"-DCMAKE_C_COMPILER_LAUNCHER={c_launcher}",
             f"-DCMAKE_CXX_COMPILER_LAUNCHER={cxx_launcher}",
             "-DBUILD_TESTING=ON",
-            # Opt-out of KPACK_SPLIT_ARTIFACTS for non-multi-arch CI/CD.
+            # Enable KPACK_SPLIT_ARTIFACTS to separate host code from device kernels.
             # * Multi-arch CI/CD uses configure_stage.py instead of this script
             # * Local developer builds will use the flag default value
             # Related issues:
             # * multi-arch kpack parent: https://github.com/ROCm/TheRock/issues/3323
             # * multi-arch opt-in: https://github.com/ROCm/TheRock/issues/3338
-            "-DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=OFF",
+            # * enable for single-arch: https://github.com/ROCm/TheRock/issues/4769
+            "-DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=ON",
         ]
     )
 

--- a/build_tools/github_actions/build_configure.py
+++ b/build_tools/github_actions/build_configure.py
@@ -108,14 +108,6 @@ def build_configure(build_dir, manylinux=False):
             f"-DCMAKE_C_COMPILER_LAUNCHER={c_launcher}",
             f"-DCMAKE_CXX_COMPILER_LAUNCHER={cxx_launcher}",
             "-DBUILD_TESTING=ON",
-            # Enable KPACK_SPLIT_ARTIFACTS to separate host code from device kernels.
-            # * Multi-arch CI/CD uses configure_stage.py instead of this script
-            # * Local developer builds will use the flag default value
-            # Related issues:
-            # * multi-arch kpack parent: https://github.com/ROCm/TheRock/issues/3323
-            # * multi-arch opt-in: https://github.com/ROCm/TheRock/issues/3338
-            # * enable for single-arch: https://github.com/ROCm/TheRock/issues/4769
-            "-DTHEROCK_FLAG_KPACK_SPLIT_ARTIFACTS=ON",
         ]
     )
 


### PR DESCRIPTION
Enable the kpack split artifacts flag to separate host code from device kernels for better build sharding. This allows single-arch CI/CD to benefit from the same packaging improvements as multi-arch.

This allows KPACK to auto-apply to superrepos

ISSUE ID: https://github.com/ROCm/TheRock/issues/4769