### PR TITLE
Add structured product-local publishing for PyTorch wheels

### DIFF
--- a/build_tools/github_actions/publish_pytorch_to_release_bucket.py
+++ b/build_tools/github_actions/publish_pytorch_to_release_bucket.py
@@ -30,6 +30,7 @@ _BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
 from _therock_utils.s3_buckets import get_release_bucket_config
+from _therock_utils.python_package_paths import plan_local_uploads
 from _therock_utils.storage_backend import create_storage_backend
 from _therock_utils.storage_location import StorageLocation
 from github_actions.github_actions_api import gha_set_output
@@ -44,6 +45,21 @@ MULTI_ARCH_INDEX_URLS = {
     "nightly": "https://rocm.nightlies.amd.com/whl-multi-arch/",
     "prerelease": "https://rocm.prereleases.amd.com/whl-multi-arch/",
 }
+
+
+def _publish_structured(source_dir, dest_bucket, index, backend) -> None:
+    """Upload wheels into product-local package directories.
+
+    Plans per-wheel destinations under ``v5/rocm/pytorch/<index>/<package>/``
+    and uploads them, failing fast if the source directory holds no wheels.
+    """
+    plans = plan_local_uploads(source_dir, dest_bucket, "pytorch", index)
+    if not plans:
+        raise FileNotFoundError(f"No wheels found at {source_dir}")
+    for plan in plans:
+        logger.info("PyTorch wheel: %s -> %s", plan.source, plan.dest.s3_uri)
+    count = backend.upload_files([(plan.source, plan.dest) for plan in plans])
+    logger.info("Uploaded %d wheel files (structured)", count)
 
 
 def main(argv: list[str]) -> None:
@@ -63,6 +79,20 @@ def main(argv: list[str]) -> None:
         help="Release type (selects therock-{release_type}-python bucket)",
     )
     parser.add_argument(
+        "--structured",
+        action="store_true",
+        help="Publish wheels into product-local package directories "
+        "(v5/rocm/pytorch/<index>/<package>/) instead of the flat v4/whl "
+        "prefix.",
+    )
+    parser.add_argument(
+        "--python-index",
+        default="whl",
+        choices=["whl", "whl-next"],
+        help="Product-local index name for structured publishing (default: "
+        "whl). Selects the v5/rocm/pytorch/<index>/ path segment.",
+    )
+    parser.add_argument(
         "--dry-run", action="store_true", help="Print plan without uploading"
     )
     args = parser.parse_args(argv)
@@ -71,15 +101,18 @@ def main(argv: list[str]) -> None:
         raise FileNotFoundError(f"Source directory not found: {args.source_dir}")
 
     bucket = get_release_bucket_config(args.release_type, "python")
-    s3_subdir = "v4/whl"
-    dest = StorageLocation(bucket.name, s3_subdir)
     backend = create_storage_backend(dry_run=args.dry_run)
 
-    logger.info("PyTorch wheels: %s -> %s", args.source_dir, dest.s3_uri)
-    count = backend.upload_directory(args.source_dir, dest, include=["*.whl"])
-    logger.info("Uploaded %d wheel files", count)
-    if count == 0:
-        raise FileNotFoundError(f"No wheels found at {args.source_dir}")
+    if args.structured:
+        _publish_structured(args.source_dir, bucket.name, args.python_index, backend)
+    else:
+        dest = StorageLocation(bucket.name, "v4/whl")
+        logger.info("PyTorch wheels: %s -> %s", args.source_dir, dest.s3_uri)
+        count = backend.upload_directory(args.source_dir, dest, include=["*.whl"])
+        logger.info("Uploaded %d wheel files", count)
+        if count == 0:
+            raise FileNotFoundError(f"No wheels found at {args.source_dir}")
+
     gha_set_output({"package_index_url": MULTI_ARCH_INDEX_URLS[args.release_type]})
 
 

--- a/build_tools/github_actions/tests/publish_pytorch_to_release_bucket_test.py
+++ b/build_tools/github_actions/tests/publish_pytorch_to_release_bucket_test.py
@@ -122,6 +122,113 @@ class TestPublishPytorchToReleaseBucket(unittest.TestCase):
                 ]
             )
 
+    # -----------------------------------------------------------------------
+    # Structured product-local publishing (--structured)
+    # -----------------------------------------------------------------------
+
+    def _touch(self, name: str) -> None:
+        (self.source_dir / name).write_bytes(b"")
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_files")
+    @mock.patch("github_actions.publish_pytorch_to_release_bucket.gha_set_output")
+    def test_structured_places_wheels_in_package_dirs(
+        self, mock_set_output, mock_upload_files
+    ):
+        self._touch("torch-2.10.0-cp312-cp312-linux_x86_64.whl")
+        self._touch("amd_torch_device_gfx942-2.10.0-py3-none-linux_x86_64.whl")
+        # Non-wheel artifacts must be ignored by the planner.
+        self._touch("index.html")
+        mock_upload_files.return_value = 2
+        main(
+            [
+                "--source-dir",
+                os.fspath(self.source_dir),
+                "--release-type",
+                "dev",
+                "--structured",
+                "--dry-run",
+            ]
+        )
+
+        self.assertEqual(mock_upload_files.call_count, 1)
+        (uploads,) = mock_upload_files.call_args.args
+        dest_by_name = {source.name: dest.relative_path for source, dest in uploads}
+        self.assertNotIn("index.html", dest_by_name)
+        self.assertEqual(
+            dest_by_name["torch-2.10.0-cp312-cp312-linux_x86_64.whl"],
+            "v5/rocm/pytorch/whl/torch/torch-2.10.0-cp312-cp312-linux_x86_64.whl",
+        )
+        self.assertEqual(
+            dest_by_name["amd_torch_device_gfx942-2.10.0-py3-none-linux_x86_64.whl"],
+            "v5/rocm/pytorch/whl/amd-torch-device-gfx942/"
+            "amd_torch_device_gfx942-2.10.0-py3-none-linux_x86_64.whl",
+        )
+        for _source, dest in uploads:
+            self.assertEqual(dest.bucket, "therock-dev-python")
+        # The index-URL output is unchanged under structured publishing.
+        mock_set_output.assert_called_once_with(
+            {"package_index_url": "https://rocm.devreleases.amd.com/whl-multi-arch/"}
+        )
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_files")
+    def test_structured_whl_next(self, mock_upload_files):
+        self._touch("torch-2.10.0-cp312-cp312-linux_x86_64.whl")
+        mock_upload_files.return_value = 1
+        main(
+            [
+                "--source-dir",
+                os.fspath(self.source_dir),
+                "--release-type",
+                "dev",
+                "--structured",
+                "--python-index",
+                "whl-next",
+                "--dry-run",
+            ]
+        )
+
+        (uploads,) = mock_upload_files.call_args.args
+        _source, dest = uploads[0]
+        self.assertEqual(
+            dest.relative_path,
+            "v5/rocm/pytorch/whl-next/torch/"
+            "torch-2.10.0-cp312-cp312-linux_x86_64.whl",
+        )
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_files")
+    def test_structured_raises_when_no_wheels(self, mock_upload_files):
+        # Empty source dir: the planner yields nothing and the script fails
+        # fast without calling the backend.
+        with self.assertRaises(FileNotFoundError):
+            main(
+                [
+                    "--source-dir",
+                    os.fspath(self.source_dir),
+                    "--release-type",
+                    "dev",
+                    "--structured",
+                    "--dry-run",
+                ]
+            )
+        mock_upload_files.assert_not_called()
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_directory")
+    def test_non_structured_still_uses_upload_directory(self, mock_upload):
+        # Default (non-structured) path is unchanged: flat upload_directory.
+        mock_upload.return_value = 2
+        main(
+            [
+                "--source-dir",
+                os.fspath(self.source_dir),
+                "--release-type",
+                "dev",
+                "--dry-run",
+            ]
+        )
+        self.assertEqual(mock_upload.call_count, 1)
+        _source, dest = mock_upload.call_args.args
+        self.assertEqual(dest.relative_path, "v4/whl")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/build_tools/github_actions/tests/publish_pytorch_to_release_bucket_test.py
+++ b/build_tools/github_actions/tests/publish_pytorch_to_release_bucket_test.py
@@ -212,23 +212,6 @@ class TestPublishPytorchToReleaseBucket(unittest.TestCase):
             )
         mock_upload_files.assert_not_called()
 
-    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_directory")
-    def test_non_structured_still_uses_upload_directory(self, mock_upload):
-        # Default (non-structured) path is unchanged: flat upload_directory.
-        mock_upload.return_value = 2
-        main(
-            [
-                "--source-dir",
-                os.fspath(self.source_dir),
-                "--release-type",
-                "dev",
-                "--dry-run",
-            ]
-        )
-        self.assertEqual(mock_upload.call_count, 1)
-        _source, dest = mock_upload.call_args.args
-        self.assertEqual(dest.relative_path, "v4/whl")
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Add an opt-in `--structured` mode to the PyTorch publisher that uploads wheels into product-local package directories
(`v5/rocm/pytorch/<index>/<package>/`) via `plan_local_uploads`, mirroring the ROCm core publisher.

Closes #6691.

## Technical Details

 `--python-index` selects `whl` or `whl-next`. The default (flat `v4/whl`) path and the `package_index_url` output are unchanged; the index-URL evolution is deferred to the workflow wiring task.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
