### PR TITLE
Add structured product-local publishing for JAX wheels

### DIFF
--- a/build_tools/github_actions/publish_jax_to_release_bucket.py
+++ b/build_tools/github_actions/publish_jax_to_release_bucket.py
@@ -13,6 +13,7 @@ _BUILD_TOOLS_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_BUILD_TOOLS_DIR))
 
 from _therock_utils.s3_buckets import get_release_bucket_config
+from _therock_utils.python_package_paths import plan_local_uploads
 from _therock_utils.storage_backend import create_storage_backend
 from _therock_utils.storage_location import StorageLocation
 from github_actions.github_actions_api import gha_set_output
@@ -24,6 +25,21 @@ MULTI_ARCH_INDEX_URLS = {
     "nightly": "https://rocm.nightlies.amd.com/whl-multi-arch/",
     "prerelease": "https://rocm.prereleases.amd.com/whl-multi-arch/",
 }
+
+
+def _publish_structured(source_dir, dest_bucket, index, backend) -> None:
+    """Upload wheels into product-local package directories.
+
+    Plans per-wheel destinations under ``v5/rocm/jax/<index>/<package>/``
+    and uploads them, failing fast if the source directory holds no wheels.
+    """
+    plans = plan_local_uploads(source_dir, dest_bucket, "jax", index)
+    if not plans:
+        raise FileNotFoundError(f"No wheels found at {source_dir}")
+    for plan in plans:
+        logger.info("JAX wheel: %s -> %s", plan.source, plan.dest.s3_uri)
+    count = backend.upload_files([(plan.source, plan.dest) for plan in plans])
+    logger.info("Uploaded %d wheel files (structured)", count)
 
 
 def main(argv: list[str]) -> None:
@@ -43,6 +59,20 @@ def main(argv: list[str]) -> None:
         help="Release type (selects therock-{release_type}-python bucket)",
     )
     parser.add_argument(
+        "--structured",
+        action="store_true",
+        help="Publish wheels into product-local package directories "
+        "(v5/rocm/jax/<index>/<package>/) instead of the flat v4/whl "
+        "prefix.",
+    )
+    parser.add_argument(
+        "--python-index",
+        default="whl",
+        choices=["whl", "whl-next"],
+        help="Product-local index name for structured publishing (default: "
+        "whl). Selects the v5/rocm/jax/<index>/ path segment.",
+    )
+    parser.add_argument(
         "--dry-run", action="store_true", help="Print plan without uploading"
     )
     args = parser.parse_args(argv)
@@ -51,14 +81,17 @@ def main(argv: list[str]) -> None:
         raise FileNotFoundError(f"Source directory not found: {args.source_dir}")
 
     bucket = get_release_bucket_config(args.release_type, "python")
-    dest = StorageLocation(bucket.name, "v4/whl")
     backend = create_storage_backend(dry_run=args.dry_run)
 
-    logger.info("JAX wheels: %s -> %s", args.source_dir, dest.s3_uri)
-    count = backend.upload_directory(args.source_dir, dest, include=["*.whl"])
-    logger.info("Uploaded %d wheel files", count)
-    if count == 0:
-        raise FileNotFoundError(f"No wheels found at {args.source_dir}")
+    if args.structured:
+        _publish_structured(args.source_dir, bucket.name, args.python_index, backend)
+    else:
+        dest = StorageLocation(bucket.name, "v4/whl")
+        logger.info("JAX wheels: %s -> %s", args.source_dir, dest.s3_uri)
+        count = backend.upload_directory(args.source_dir, dest, include=["*.whl"])
+        logger.info("Uploaded %d wheel files", count)
+        if count == 0:
+            raise FileNotFoundError(f"No wheels found at {args.source_dir}")
 
     gha_set_output({"package_index_url": MULTI_ARCH_INDEX_URLS[args.release_type]})
 

--- a/build_tools/github_actions/tests/publish_jax_to_release_bucket_test.py
+++ b/build_tools/github_actions/tests/publish_jax_to_release_bucket_test.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for publish_jax_to_release_bucket.py."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent))
+
+from github_actions.publish_jax_to_release_bucket import main
+
+
+class TestPublishJaxToReleaseBucket(unittest.TestCase):
+    """Tests for the main() CLI entry point."""
+
+    def setUp(self):
+        # Real directory so the script's existence check passes; the
+        # upload itself is mocked so no S3 contact happens.
+        self._tmp = tempfile.TemporaryDirectory()
+        self.source_dir = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _touch(self, name: str) -> None:
+        (self.source_dir / name).write_bytes(b"")
+
+    # -----------------------------------------------------------------------
+    # Flat publishing (default)
+    # -----------------------------------------------------------------------
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_directory")
+    @mock.patch("github_actions.publish_jax_to_release_bucket.gha_set_output")
+    def test_dev_uploads_to_v4_whl_in_dev_python(self, mock_set_output, mock_upload):
+        mock_upload.return_value = 3
+        main(
+            [
+                "--source-dir",
+                os.fspath(self.source_dir),
+                "--release-type",
+                "dev",
+                "--dry-run",
+            ]
+        )
+
+        self.assertEqual(mock_upload.call_count, 1)
+        source, dest = mock_upload.call_args.args
+        self.assertEqual(source, self.source_dir)
+        self.assertEqual(dest.bucket, "therock-dev-python")
+        self.assertEqual(dest.relative_path, "v4/whl")
+        self.assertEqual(mock_upload.call_args.kwargs.get("include"), ["*.whl"])
+        mock_set_output.assert_called_once_with(
+            {"package_index_url": "https://rocm.devreleases.amd.com/whl-multi-arch/"}
+        )
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_directory")
+    def test_nightly_selects_nightly_bucket(self, mock_upload):
+        mock_upload.return_value = 2
+        main(
+            [
+                "--source-dir",
+                os.fspath(self.source_dir),
+                "--release-type",
+                "nightly",
+                "--dry-run",
+            ]
+        )
+
+        _source, dest = mock_upload.call_args.args
+        self.assertEqual(dest.bucket, "therock-nightly-python")
+        self.assertEqual(dest.relative_path, "v4/whl")
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_directory")
+    def test_prerelease_selects_prerelease_bucket(self, mock_upload):
+        mock_upload.return_value = 2
+        main(
+            [
+                "--source-dir",
+                os.fspath(self.source_dir),
+                "--release-type",
+                "prerelease",
+                "--dry-run",
+            ]
+        )
+
+        _source, dest = mock_upload.call_args.args
+        self.assertEqual(dest.bucket, "therock-prerelease-python")
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_directory")
+    def test_raises_when_no_wheels_uploaded(self, mock_upload):
+        mock_upload.return_value = 0
+        with self.assertRaises(FileNotFoundError):
+            main(
+                [
+                    "--source-dir",
+                    os.fspath(self.source_dir),
+                    "--release-type",
+                    "dev",
+                    "--dry-run",
+                ]
+            )
+
+    def test_raises_when_source_dir_missing(self):
+        missing = self.source_dir / "does-not-exist"
+        with self.assertRaises(FileNotFoundError):
+            main(
+                [
+                    "--source-dir",
+                    os.fspath(missing),
+                    "--release-type",
+                    "dev",
+                    "--dry-run",
+                ]
+            )
+
+    def test_invalid_release_type_rejected(self):
+        with self.assertRaises(SystemExit):
+            main(
+                [
+                    "--source-dir",
+                    os.fspath(self.source_dir),
+                    "--release-type",
+                    "release",
+                    "--dry-run",
+                ]
+            )
+
+    # -----------------------------------------------------------------------
+    # Structured product-local publishing (--structured)
+    # -----------------------------------------------------------------------
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_files")
+    @mock.patch("github_actions.publish_jax_to_release_bucket.gha_set_output")
+    def test_structured_places_wheels_in_package_dirs(
+        self, mock_set_output, mock_upload_files
+    ):
+        self._touch("jax-0.4.35-py3-none-any.whl")
+        # Dist name escapes to underscores (PEP 427); the package directory
+        # is the canonical dashed form.
+        self._touch("jax_rocm7_plugin-0.4.35-cp312-cp312-linux_x86_64.whl")
+        # Non-wheel artifacts must be ignored by the planner.
+        self._touch("index.html")
+        mock_upload_files.return_value = 2
+        main(
+            [
+                "--source-dir",
+                os.fspath(self.source_dir),
+                "--release-type",
+                "dev",
+                "--structured",
+                "--dry-run",
+            ]
+        )
+
+        self.assertEqual(mock_upload_files.call_count, 1)
+        (uploads,) = mock_upload_files.call_args.args
+        dest_by_name = {source.name: dest.relative_path for source, dest in uploads}
+        self.assertNotIn("index.html", dest_by_name)
+        self.assertEqual(
+            dest_by_name["jax-0.4.35-py3-none-any.whl"],
+            "v5/rocm/jax/whl/jax/jax-0.4.35-py3-none-any.whl",
+        )
+        self.assertEqual(
+            dest_by_name["jax_rocm7_plugin-0.4.35-cp312-cp312-linux_x86_64.whl"],
+            "v5/rocm/jax/whl/jax-rocm7-plugin/"
+            "jax_rocm7_plugin-0.4.35-cp312-cp312-linux_x86_64.whl",
+        )
+        for _source, dest in uploads:
+            self.assertEqual(dest.bucket, "therock-dev-python")
+        # The index-URL output is unchanged under structured publishing.
+        mock_set_output.assert_called_once_with(
+            {"package_index_url": "https://rocm.devreleases.amd.com/whl-multi-arch/"}
+        )
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_files")
+    def test_structured_whl_next(self, mock_upload_files):
+        self._touch("jaxlib-0.4.35-cp312-cp312-linux_x86_64.whl")
+        mock_upload_files.return_value = 1
+        main(
+            [
+                "--source-dir",
+                os.fspath(self.source_dir),
+                "--release-type",
+                "dev",
+                "--structured",
+                "--python-index",
+                "whl-next",
+                "--dry-run",
+            ]
+        )
+
+        (uploads,) = mock_upload_files.call_args.args
+        _source, dest = uploads[0]
+        self.assertEqual(
+            dest.relative_path,
+            "v5/rocm/jax/whl-next/jaxlib/jaxlib-0.4.35-cp312-cp312-linux_x86_64.whl",
+        )
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_files")
+    def test_structured_raises_when_no_wheels(self, mock_upload_files):
+        # Empty source dir: the planner yields nothing and the script fails
+        # fast without calling the backend.
+        with self.assertRaises(FileNotFoundError):
+            main(
+                [
+                    "--source-dir",
+                    os.fspath(self.source_dir),
+                    "--release-type",
+                    "dev",
+                    "--structured",
+                    "--dry-run",
+                ]
+            )
+        mock_upload_files.assert_not_called()
+
+    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_directory")
+    def test_non_structured_still_uses_upload_directory(self, mock_upload):
+        # Default (non-structured) path is unchanged: flat upload_directory.
+        mock_upload.return_value = 2
+        main(
+            [
+                "--source-dir",
+                os.fspath(self.source_dir),
+                "--release-type",
+                "dev",
+                "--dry-run",
+            ]
+        )
+        self.assertEqual(mock_upload.call_count, 1)
+        _source, dest = mock_upload.call_args.args
+        self.assertEqual(dest.relative_path, "v4/whl")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/github_actions/tests/publish_jax_to_release_bucket_test.py
+++ b/build_tools/github_actions/tests/publish_jax_to_release_bucket_test.py
@@ -219,23 +219,6 @@ class TestPublishJaxToReleaseBucket(unittest.TestCase):
             )
         mock_upload_files.assert_not_called()
 
-    @mock.patch("_therock_utils.storage_backend.S3StorageBackend.upload_directory")
-    def test_non_structured_still_uses_upload_directory(self, mock_upload):
-        # Default (non-structured) path is unchanged: flat upload_directory.
-        mock_upload.return_value = 2
-        main(
-            [
-                "--source-dir",
-                os.fspath(self.source_dir),
-                "--release-type",
-                "dev",
-                "--dry-run",
-            ]
-        )
-        self.assertEqual(mock_upload.call_count, 1)
-        _source, dest = mock_upload.call_args.args
-        self.assertEqual(dest.relative_path, "v4/whl")
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Add an opt-in `--structured` mode to the JAX publisher that uploads wheels into product-local package directories
(`v5/rocm/jax/<index>/<package>/`) via `plan_local_uploads`, mirroring the ROCm core and PyTorch publishers. 

Closes #6692.

## Technical Details

`--python-index` selects `whl` or `whl-next`. The default (flat `v4/whl`) path and the `package_index_url` output are unchanged; the index-URL evolution is deferred to the workflow wiring task.

## Test Plan

Also add a publisher test module (the JAX publisher previously had none), covering both the flat and structured paths.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
