### PR TITLE
ci(rocprofiler-systems): Force a minimum of OMP_NUM_THREADS=2 for rocprofiler-systems tests

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -131,6 +131,24 @@ environ_vars["GTEST_TOTAL_SHARDS"] = str(TOTAL_SHARDS)
 ROCM_PATH = Path(THEROCK_BIN_DIR).resolve().parent
 environ_vars["ROCM_PATH"] = str(ROCM_PATH)
 
+
+def _resolve_omp_num_threads(min_threads=2):
+    """
+    Sets the minimum OMP_NUM_THREADS as 2
+
+    dyninst, used by rocprofiler-systems, uses OpenMP to parse/process the
+    control flow graph. Less than 2 threads will significantly slow down the
+    runtime-instrument tests.
+    """
+    raw = os.getenv("OMP_NUM_THREADS")
+    try:
+        if float(raw) < min_threads:
+            return str(min_threads)
+    except (TypeError, ValueError):
+        return str(min_threads)
+    return raw
+
+
 # Component-specific ENV VARs/PATHs applied on top of defaults.
 #
 # - test_dir: The default TEST_DIR for ctest is THEROCK_BIN_DIR/TEST_COMPONENT.
@@ -203,6 +221,7 @@ COMPONENT_OVERRIDES = {
         },
         "env": {
             "ROCPROFSYS_INSTALL_DIR": "{rocm_path}",
+            "OMP_NUM_THREADS": _resolve_omp_num_threads(),
             # Open MPI bakes its build-time install prefix (the manylinux
             # container path) into its binaries, so plugin/help-file discovery
             # fails outside the container. Override it with the ROCm install
@@ -210,10 +229,6 @@ COMPONENT_OVERRIDES = {
             "OPAL_PREFIX": "{rocm_path}",
             "PRTE_PREFIX": "{rocm_path}",
             "PMIX_PREFIX": "{rocm_path}",
-            # dyninst relies on OpenMP to parallelize parsing/processing of the
-            # control flow graph. This is controlled by OMP_NUM_THREADS. Force it
-            # to 2 to speed up runtime-instrument tests.
-            "OMP_NUM_THREADS": "2",
         },
         # rocprofiler-systems tests instrument processes and attach to a shared
         # profiling backend; running them concurrently causes flaky failures.

--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -210,6 +210,10 @@ COMPONENT_OVERRIDES = {
             "OPAL_PREFIX": "{rocm_path}",
             "PRTE_PREFIX": "{rocm_path}",
             "PMIX_PREFIX": "{rocm_path}",
+            # dyninst relies on OpenMP to parallelize parsing/processing of the
+            # control flow graph. This is controlled by OMP_NUM_THREADS. Force it
+            # to 2 to speed up runtime-instrument tests.
+            "OMP_NUM_THREADS": "2",
         },
         # rocprofiler-systems tests instrument processes and attach to a shared
         # profiling backend; running them concurrently causes flaky failures.


### PR DESCRIPTION
## Motivation

Jira ID: AIPROFSYST-650
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Our `runtime-instrument` tests run slower than expected on TheRock CI. After investigating https://github.com/ROCm/rocm-systems/issues/8543, I've concluded it is because `OMP_NUM_THREADS=1` exclusively on TheRock CI. 

The problem is that dyninst uses OpenMP to parallelize processing/parsing of the CFG of the binary. Setting `OMP_NUM_THREADS=1` essentially blocks parallelism and will significantly slow down `runtime-instrument` tests.

On TheRock CI that is ran on `rocm-systems` side, `OMP_NUM_THREADS-25`. I am unsure why the difference exists, but for now, to ensure our `runtime-instrument` tests run quicker, I will increase `OMP_NUM_THREADS` from `1` to `2` when running our tests. Locally, I have observed about a 2x speedup in `runtime-instrument` tests with this change.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

 - In `test_runner.py`, add `_resolve_omp_num_threads(min_threads=2)`, which reads the current value of `OMP_NUM_THREADS` if set, and either returns the value or `2` if the value is less than 2.
 - Set `"OMP_NUM_THREADS": _resolve_omp_num_threads()` 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Locally. The GFX942 workflows seem to set `OMP_NUM_THREADS=25`, but in https://github.com/ROCm/rocm-systems/issues/8543, a workflow had it set to 1. 

## Test Result

Locally, suppose I `export OMP_NUM_THREADS=1`, then run the tests through `test_runner.py`. In the test environment print, I see:
```
548: [user]
548:   OMP_NUM_THREADS=2  (overrides base=2)
```
That means that it worked and set it to 2.

Now with `export OMP_NUM_THREADS=25`:
```
548: [user]
548:   OMP_NUM_THREADS=25  (overrides base=2)
```

Works as expected.

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
