### PR TITLE
[policy-bot] Strip PR description comments before policy eval

### DIFF
--- a/skills/therock_pr_bot/policy_check.py
+++ b/skills/therock_pr_bot/policy_check.py
@@ -364,13 +364,23 @@ def ensure_pr_not_draft(policy: Policy, is_draft: bool, errors: List[str]) -> No
         )
 
 
+def _strip_markdown_comments(text: str) -> str:
+    """Remove HTML comment blocks from Markdown text."""
+    # Note: using re.DOTALL to match _any_ character, including newlines so this
+    # can handle multiline comments.
+    return re.sub(r"<!--.*?(?:-->|$)", "", text, flags=re.DOTALL)
+
+
 def ensure_pr_description(policy: Policy, body: str, errors: List[str]) -> None:
     """Validate the PR description (minimum length, JIRA/ISSUE reference, checklist).
 
     Appends a structured message to `errors` if the body is too short, does
     not contain a recognised tracking reference, or has an unticked checklist item.
     """
-    body = (body or "").strip()
+    # Strip comments so we only check the visible text against the policies.
+    # This lets pull request templates use examples that _would_ pass the check.
+    body = _strip_markdown_comments(body or "").strip()
+
     if policy.description_min_length and len(body) < policy.description_min_length:
         errors.append(
             f"**Error:** PR description is too short ({len(body)} characters).\n"

--- a/skills/therock_pr_bot/test_policy_check_ut.py
+++ b/skills/therock_pr_bot/test_policy_check_ut.py
@@ -201,6 +201,23 @@ class DescriptionTests(unittest.TestCase):
         pc.ensure_pr_description(policy, "A long enough description with no ref.", e)
         self.assertTrue(any("must reference a JIRA ID" in x for x in e))
 
+    def test_issue_reference_in_comment_does_not_pass(self) -> None:
+        # Isolate reference detection (skip min-length and checklist).
+        policy = make_policy(
+            description_min_length=0, description_checklist_patterns=[]
+        )
+        multiline_comment = """<!--
+Fixes #1234
+-->"""
+        for body in [
+            "<!-- GitHub issue: https://github.com/ROCm/TheRock/issues/1234 -->",
+            multiline_comment,
+        ]:
+            with self.subTest(body=body):
+                e: List[str] = []
+                pc.ensure_pr_description(policy, body, e)
+                self.assertTrue(any("must reference a JIRA ID" in x for x in e))
+
     def test_issue_reference_variants_pass(self) -> None:
         # Isolate reference detection (skip min-length and checklist).
         policy = make_policy(

--- a/skills/therock_pr_bot/test_policy_check_ut.py
+++ b/skills/therock_pr_bot/test_policy_check_ut.py
@@ -209,9 +209,14 @@ class DescriptionTests(unittest.TestCase):
         multiline_comment = """<!--
 Fixes #1234
 -->"""
+        multiple_comments = """This description has no visible issue reference.
+<!-- Related to #1234 -->
+Some visible text between the comments.
+<!-- https://github.com/ROCm/TheRock/issues/5678 -->"""
         for body in [
             "<!-- GitHub issue: https://github.com/ROCm/TheRock/issues/1234 -->",
             multiline_comment,
+            multiple_comments,
         ]:
             with self.subTest(body=body):
                 e: List[str] = []


### PR DESCRIPTION
## Motivation

We'd like to put example text in the pull request template without having that text pass the policy checks itself. This can be achieved through HTML/markdown comments, so long as the policy bot does not evaluate the text in comments.

* Follow-up to https://github.com/ROCm/rocm-systems/pull/8497 which added `<!-- GitHub issue: https://github.com/ROCm/rocm-systems/issues/1234 -->` to `.github/pull_request_template.md` in rocm-systems. 
* Helps with https://github.com/ROCm/TheRock/pull/6697 which will add a similar file+comment here in TheRock
* Progress on https://github.com/ROCm/TheRock/issues/5998

## Technical Details

Syntax reference: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#hiding-content-with-comments

## Test Plan

New unit tests pass as-is and they fail if the comments are not stripped:
```python
pytest skills\therock_pr_bot\test_policy_check_ut.py
...
___________________________ DescriptionTests.test_issue_reference_in_comment_does_not_pass ____________________________

self = <test_policy_check_ut.DescriptionTests testMethod=test_issue_reference_in_comment_does_not_pass>

        def test_issue_reference_in_comment_does_not_pass(self) -> None:
            # Isolate reference detection (skip min-length and checklist).
            policy = make_policy(
                description_min_length=0, description_checklist_patterns=[]
            )
            multiline_comment = """<!--
    Fixes #1234
    -->"""
            for body in [
                "<!-- GitHub issue: https://github.com/ROCm/TheRock/issues/1234 -->",
                multiline_comment,
            ]:
                with self.subTest(body=body):
                    e: List[str] = []
                    pc.ensure_pr_description(policy, body, e)
>                   self.assertTrue(any("must reference a JIRA ID" in x for x in e))
E                   AssertionError: False is not true

skills\therock_pr_bot\test_policy_check_ut.py:216: AssertionError
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
