### PR TITLE
build: wire TEST_SUBPROJECTS for P1 rocm-sytems components

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -81,6 +81,14 @@ if(THEROCK_ENABLE_CORE_AMDSMI)
         lib
       INTERFACE_INSTALL_RPATH_DIRS
         lib
+      TEST_SUBPROJECTS
+        hipBLAS
+        hipBLASLt
+        rocBLAS
+        rccl
+        rdc
+        rocprofiler-systems
+        rocrtst
     )
     therock_cmake_subproject_provide_package(amdsmi amd_smi lib/cmake)
     therock_cmake_subproject_activate(amdsmi)
@@ -142,6 +150,39 @@ if(_therock_enable_hsa_runtime)
       "lib"
     INTERFACE_INSTALL_RPATH_DIRS
       "lib"
+    TEST_SUBPROJECTS
+      amd-dbgapi
+      aqlprofile
+      composable_kernel
+      hip-clr
+      hipBLAS
+      hipBLASLt
+      hipDNN
+      hipDNN_samples
+      hipFFT
+      hipRAND
+      hipblasltprovider
+      hipdnn_integration_tests
+      hipkernelprovider
+      libhipcxx
+      MIOpen
+      miopenprovider
+      ocl-clr
+      ocl-icd
+      rccl
+      rocdecode
+      rocjpeg
+      rocBLAS
+      rocFFT
+      rocPRIM
+      rocRAND
+      rocWMMA
+      rocgdb
+      rocprofiler-sdk
+      rocr-debug-agent
+      rocr-debug-agent-tests
+      rocrtst
+      rocshmem
   )
   therock_cmake_subproject_glob_c_sources(ROCR-Runtime
     SUBDIRS
@@ -309,6 +350,35 @@ if(THEROCK_ENABLE_HIP_RUNTIME)
       "lib"
     INTERFACE_INSTALL_RPATH_DIRS
       "lib"
+    TEST_SUBPROJECTS
+      composable_kernel
+      hip-tests
+      hipBLAS
+      hipBLASLt
+      hipDNN
+      hipDNN_samples
+      hipFFT
+      hipInfo
+      hipblasltprovider
+      hipdnn_integration_tests
+      hipkernelprovider
+      libhipcxx
+      MIOpen
+      miopenprovider
+      rccl
+      rdc
+      rocdecode
+      rocjpeg
+      rocBLAS
+      rocFFT
+      rocPRIM
+      rocRAND
+      hipRAND
+      rocWMMA
+      rocprofiler-systems
+      rocr-debug-agent-tests
+      rocshmem
+      therock-wsl-rocdxg
   )
   therock_cmake_subproject_glob_c_sources(hip-clr SUBDIRS .)
   therock_cmake_subproject_provide_package(hip-clr hip lib/cmake/hip)

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -147,6 +147,16 @@ if(THEROCK_ENABLE_ROCPROFV3)
       lib
       lib/rocm_sysdeps/lib
     TEST_SUBPROJECTS
+      hipBLAS
+      hipBLASLt
+      hipFFT
+      MIOpen
+      rccl
+      rdc
+      rocBLAS
+      rocFFT
+      rocprofiler-compute
+      rocprofiler-systems
   )
   therock_cmake_subproject_glob_c_sources(rocprofiler-sdk
     SUBDIRS .


### PR DESCRIPTION
As part of enabling multi-arch on rocm-libraries https://github.com/ROCm/TheRock/issues/3343, adding TEST_SUBPROJECTS entries to therock_cmake_subproject_declare blocks so downstream consumers are tracked for testing:

- amdsmi: hipBLAS, hipBLASLt, rocBLAS, rccl, rdc, rocprofiler-systems, rocrtst
- hip-clr: composable_kernel, hip-tests, hipBLAS, hipBLASLt, hipDNN, hipDNN_samples, hipFFT, hipInfo, hipRAND, hipblasltprovider, hipdnn_integration_tests, hipkernelprovider, libhipcxx, MIOpen, miopenprovider, rccl, rdc, rocdecode, rocjpeg, rocBLAS, rocFFT, rocPRIM, rocRAND, rocWMMA, rocprofiler-systems, rocr-debug-agent-tests, rocshmem, therock-wsl-rocdxg
- ROCR-Runtime: amd-dbgapi, aqlprofile, composable_kernel, hip-clr, hipBLAS, hipBLASLt, hipDNN, hipDNN_samples, hipFFT, hipRAND, hipblasltprovider, hipdnn_integration_tests, hipkernelprovider, libhipcxx, MIOpen, miopenprovider, ocl-clr, ocl-icd, rccl, rocdecode, rocjpeg, rocBLAS, rocFFT, rocPRIM, rocRAND, rocWMMA, rocgdb, rocprofiler-sdk, rocr-debug-agent, rocr-debug-agent-tests, rocrtst, rocshmem
- rocprofiler-sdk: hipBLAS, hipBLASLt, hipFFT, MIOpen, rccl, rdc, rocBLAS, rocFFT, rocprofiler-compute, rocprofiler-systems

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
