### PR TITLE
fix(ci): Update rocRAND benchmark binary names

### DIFF
--- a/tests/extended_tests/benchmark/scripts/test_rocrand_benchmark.py
+++ b/tests/extended_tests/benchmark/scripts/test_rocrand_benchmark.py
@@ -28,7 +28,7 @@ class ROCrandBenchmark(BenchmarkBase):
 
     def __init__(self):
         super().__init__(benchmark_name="rocrand", display_name="ROCrand")
-        self.bench_bins = ["benchmark_rocrand_host_api", "benchmark_rocrand_device_api"]
+        self.bench_bins = ["benchmark_host_api", "benchmark_device_api"]
 
     def run_benchmarks(self) -> None:
         """Run ROCrand benchmarks and save output to log files."""
@@ -90,7 +90,7 @@ class ROCrandBenchmark(BenchmarkBase):
             re.MULTILINE,
         )
 
-        bench_types = ["rocrand_host", "rocrand_device"]
+        bench_types = ["host", "device"]
 
         # Setup table
         field_names = [


### PR DESCRIPTION
## Motivation

The recent integration of primbench into rocRAND introduced some small changes to the names of the benchmark binaries.

JIRA ID: AIPRIMS-222

## Technical Details

This change updates TheRock's test script so that it picks up the new binaries correctly.

## Test Plan

Run `tests/extended_tests/benchmark/scripts/test_rocrand_benchmark.py` on a recent build.

## Test Result

Works locally.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
