### PR TITLE
ci(jax): release v0.10.0-v0.11.0, build single ref in PR CI, drop v0.9.1/native

### DIFF
--- a/.github/workflows/multi_arch_build_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels.yml
@@ -29,10 +29,6 @@ on:
         description: "Repository containing the JAX release branch."
         type: string
         required: true
-      build_mode:
-        description: "Build mode: native or manylinux."
-        type: string
-        required: true
       gfx_arch:
         description: "ROCm device package selector used for the manylinux build (e.g. device-gfx942, device-gfx950, or device-all)."
         type: string
@@ -50,10 +46,6 @@ on:
         description: "URL for pip --find-links to install ROCm packages for the JAX manylinux build."
         type: string
         default: ""
-      tar_url:
-        description: "URL to the TheRock tarball used for the build."
-        type: string
-        required: true
       release_type:
         description: "Release type."
         type: string
@@ -92,13 +84,6 @@ on:
         description: "GitHub repository in owner/repo format (e.g. ROCm/jax or ROCm/rocm-jax)."
         type: string
         default: "ROCm/jax"
-      build_mode:
-        description: "Build mode."
-        type: choice
-        options:
-          - native
-          - manylinux
-        required: true
       gfx_arch:
         description: "ROCm device package selector used for the manylinux build (e.g. device-gfx942, device-gfx950, or device-all)."
         type: string
@@ -116,10 +101,6 @@ on:
         description: "URL for pip --find-links to install ROCm packages for the JAX manylinux build."
         type: string
         default: ""
-      tar_url:
-        description: "URL to the TheRock tarball used for the build."
-        type: string
-        required: true
       release_type:
         description: "Release type."
         type: string
@@ -166,7 +147,6 @@ jobs:
           ref: ${{ inputs.jax_ref }}
 
       - name: Checkout JAX
-        if: ${{ inputs.build_mode == 'manylinux' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: jax-source
@@ -190,30 +170,11 @@ jobs:
 
       - name: Set package dist dir
         run: |
-          if [ "${{ inputs.build_mode }}" = "manylinux" ]; then
-            echo "PACKAGE_DIST_DIR=${GITHUB_WORKSPACE}/jax-source/dist" >> "$GITHUB_ENV"
-          else
-            echo "PACKAGE_DIST_DIR=${GITHUB_WORKSPACE}/rocm-jax/jax_rocm_plugin/wheelhouse" >> "$GITHUB_ENV"
-          fi
+          echo "PACKAGE_DIST_DIR=${GITHUB_WORKSPACE}/jax-source/dist" >> "$GITHUB_ENV"
 
-      - name: Build JAX Wheels (native, v0.9.1)
-        if: ${{ inputs.build_mode == 'native' }}
-        working-directory: rocm-jax
-        env:
-          ROCM_VERSION: ${{ inputs.rocm_version }}
-          PYTHON_VERSION: ${{ inputs.python_version }}
-          TAR_URL: ${{ inputs.tar_url }}
-        run: |
-          python3 build/ci_build \
-            --compiler=clang \
-            --python-versions="${PYTHON_VERSION}" \
-            --rocm-version="${ROCM_VERSION}" \
-            --therock-path="${TAR_URL}" \
-            dist_wheels
       # TODO: THEROCK_INDEX_URL need to be renamed in the future to
       # THEROCK_FIND_LINKS_URL to avoid confusion with pip --index-url.
       - name: Build manylinux image
-        if: ${{ inputs.build_mode == 'manylinux' }}
         working-directory: jax-source
         env:
           THEROCK_VERSION: ""
@@ -238,7 +199,6 @@ jobs:
             --rocm-version "${{ inputs.rocm_version }}"
 
       - name: Build JAX Wheels in manylinux container
-        if: ${{ inputs.build_mode == 'manylinux' }}
         working-directory: jax-source
         env:
           ROCM_VERSION: ${{ inputs.rocm_version }}

--- a/.github/workflows/multi_arch_build_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels.yml
@@ -131,6 +131,7 @@ jobs:
       jax_pjrt_version: ${{ steps.write_jax_versions.outputs.jax_pjrt_version }}
     env:
       MANYLINUX_IMAGE_TAG: therock-jax-manylinux:${{ inputs.jax_ref }}-${{ inputs.python_version }}
+      PACKAGE_DIST_DIR: ${{ github.workspace }}/jax-source/dist
 
     steps:
       - name: Checkout TheRock
@@ -167,10 +168,6 @@ jobs:
       - name: Install python deps for CI
         run: |
           pip install -r external-builds/jax/requirements-jax.txt
-
-      - name: Set package dist dir
-        run: |
-          echo "PACKAGE_DIST_DIR=${GITHUB_WORKSPACE}/jax-source/dist" >> "$GITHUB_ENV"
 
       # TODO: THEROCK_INDEX_URL need to be renamed in the future to
       # THEROCK_FIND_LINKS_URL to avoid confusion with pip --index-url.

--- a/.github/workflows/multi_arch_build_linux_jax_wheels_ci.yml
+++ b/.github/workflows/multi_arch_build_linux_jax_wheels_ci.yml
@@ -27,10 +27,6 @@ on:
         description: "Repository containing the JAX release branch."
         type: string
         required: true
-      build_mode:
-        description: "Build mode. CI currently supports manylinux only."
-        type: string
-        required: true
       gfx_arch:
         description: "ROCm device package selector used for the manylinux build (e.g. device-gfx942, device-gfx950, or device-all)."
         type: string
@@ -81,12 +77,6 @@ on:
         description: "GitHub repository in owner/repo format containing the JAX release branch."
         type: string
         default: "ROCm/jax"
-      build_mode:
-        description: "Build mode."
-        type: choice
-        options:
-          - manylinux
-        required: true
       gfx_arch:
         description: "ROCm device package selector used for the manylinux build (e.g. device-gfx942, device-gfx950, or device-all)."
         type: string
@@ -167,13 +157,6 @@ jobs:
       - name: Install python deps for CI
         run: |
           pip install -r external-builds/jax/requirements-jax.txt
-
-      - name: Validate CI build mode
-        run: |
-          if [ "${{ inputs.build_mode }}" != "manylinux" ]; then
-            echo "Only build_mode=manylinux is supported by this CI workflow."
-            exit 1
-          fi
 
       - name: Build manylinux image
         working-directory: jax-source

--- a/.github/workflows/multi_arch_ci_linux.yml
+++ b/.github/workflows/multi_arch_ci_linux.yml
@@ -353,7 +353,6 @@ jobs:
       artifact_group: ${{ fromJSON(inputs.build_config).artifact_group }}
       python_version: ${{ matrix.python_version }}
       jax_repository: ${{ matrix.jax_repository }}
-      build_mode: ${{ matrix.build_mode }}
       gfx_arch: ${{ matrix.gfx_arch }}
       jax_ref: ${{ matrix.jax_ref }}
       rocm_version: ${{ inputs.rocm_package_version }}

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -256,7 +256,9 @@ jobs:
             }
 
   trigger_release_jax_wheels:
-    needs: [build_artifacts, build_tarballs, build_python_packages]
+    # The manylinux JAX build only consumes build_python_packages output
+    # (find-links index); it no longer needs the tarball job.
+    needs: [build_artifacts, build_python_packages]
     name: Trigger Release JAX Wheels
     if: ${{ inputs.build_jax != false && fromJSON(inputs.build_config).build_jax == true }}
     runs-on: ubuntu-24.04
@@ -273,7 +275,6 @@ jobs:
               "release_type": "${{ inputs.release_type }}",
               "rocm_version": "${{ inputs.rocm_package_version }}",
               "rocm_package_find_links_url": "${{ needs.build_python_packages.outputs.package_find_links_url }}",
-              "tar_url": "${{ fromJSON(needs.build_tarballs.outputs.tarball_urls).multiarch }}",
               "repository": "${{ inputs.repository || github.repository }}",
               "ref": "${{ inputs.ref || '' }}",
               "python_version": "${{ inputs.python_version }}"

--- a/.github/workflows/multi_arch_release_linux.yml
+++ b/.github/workflows/multi_arch_release_linux.yml
@@ -256,8 +256,6 @@ jobs:
             }
 
   trigger_release_jax_wheels:
-    # The manylinux JAX build only consumes build_python_packages output
-    # (find-links index); it no longer needs the tarball job.
     needs: [build_artifacts, build_python_packages]
     name: Trigger Release JAX Wheels
     if: ${{ inputs.build_jax != false && fromJSON(inputs.build_config).build_jax == true }}

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -27,10 +27,6 @@ on:
         description: "URL for pip --find-links to install ROCm packages for the JAX manylinux build."
         type: string
         default: ""
-      tar_url:
-        description: "URL to the TheRock tarball used for the build."
-        type: string
-        required: true
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
@@ -63,10 +59,6 @@ on:
         description: "URL for pip --find-links to install ROCm packages for the JAX manylinux build."
         type: string
         default: ""
-      tar_url:
-        description: "URL to the TheRock tarball used for the build."
-        type: string
-        required: true
       repository:
         description: "Repository to checkout. Defaults to github.repository."
         type: string
@@ -119,11 +111,9 @@ jobs:
       python_version: ${{ matrix.python_version }}
       jax_ref: ${{ matrix.jax_ref }}
       jax_repository: ${{ matrix.jax_repository }}
-      build_mode: ${{ matrix.build_mode }}
       gfx_arch: ${{ matrix.gfx_arch }}
       rocm_version: ${{ inputs.rocm_version }}
       rocm_package_find_links_url: ${{ inputs.rocm_package_find_links_url }}
-      tar_url: ${{ inputs.tar_url }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository || github.repository }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/test_jax_dockerfile.yml
+++ b/.github/workflows/test_jax_dockerfile.yml
@@ -22,7 +22,7 @@ on:
         required: true
         description: JAX plugin branch to checkout
         type: string
-        default: "rocm-jaxlib-v0.8.2"
+        default: "rocm-jaxlib-v0.11.0"
 
   workflow_call:
     inputs:
@@ -40,7 +40,7 @@ on:
       jax_plugin_branch:
         description: JAX plugin branch to checkout to use for test scripts
         type: string
-        default: "rocm-jaxlib-v0.8.2"
+        default: "rocm-jaxlib-v0.11.0"
 
 permissions:
   contents: read

--- a/.github/workflows/test_linux_jax_wheels.yml
+++ b/.github/workflows/test_linux_jax_wheels.yml
@@ -35,7 +35,7 @@ on:
         description: rocm-jax repository ref/branch to check out
         required: false
         type: string
-        default: "rocm-jaxlib-v0.8.2"
+        default: "rocm-jaxlib-v0.11.0"
       jax_version:
         description: "Base JAX version (e.g. 0.8.2) for installing jax from PyPI. Extracted from built wheels by write_jax_versions.py."
         required: false
@@ -109,7 +109,7 @@ on:
         description: rocm-jax repository ref/branch to check out
         required: false
         type: string
-        default: "rocm-jaxlib-v0.8.2"
+        default: "rocm-jaxlib-v0.11.0"
       jax_version:
         description: "Base JAX version (e.g. 0.8.2). Leave empty to auto-detect from rocm-jax requirements."
         required: false

--- a/.github/workflows/test_linux_jax_wheels_partial.yml
+++ b/.github/workflows/test_linux_jax_wheels_partial.yml
@@ -101,7 +101,7 @@ on:
       jax_ref:
         description: "rocm-jax repository ref/branch to check out"
         type: string
-        default: "rocm-jaxlib-v0.9.1"
+        default: "rocm-jaxlib-v0.11.0"
       jax_version:
         description: "Built JAX version"
         type: string

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -427,8 +427,8 @@ Install JAX with ROCm support using the unified multi-arch index.
 > ROCm 7.x and `jax_rocm10_*` for ROCm 10.x.
 
 ```bash
-# Set the version (currently supported: 0.9.1, 0.10.0, and 0.10.2)
-JAX_VERSION=0.10.0
+# Set the version (currently supported: 0.10.0, 0.10.1, 0.10.2, and 0.11.0)
+JAX_VERSION=0.11.0
 
 # 1. Install ROCm (replace device-gfx942 with your GPU)
 pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \

--- a/build_tools/github_actions/configure_jax_release_matrix.py
+++ b/build_tools/github_actions/configure_jax_release_matrix.py
@@ -24,23 +24,27 @@ CI_PYTHON_VERSIONS = {
 }
 
 JAX_REF_CONFIGS = {
-    "rocm-jaxlib-v0.9.1": {
-        "jax_ref": "rocm-jaxlib-v0.9.1",
-        "jax_repository": "ROCm/rocm-jax",
-        "build_mode": "native",
-        "gfx_arch": "",
-    },
     "rocm-jaxlib-v0.10.0": {
         "jax_ref": "rocm-jaxlib-v0.10.0",
         "jax_repository": "ROCm/jax",
-        "build_mode": "manylinux",
+        "gfx_arch": "device-all",
+    },
+    "rocm-jaxlib-v0.10.1": {
+        "jax_ref": "rocm-jaxlib-v0.10.1",
+        "jax_repository": "ROCm/jax",
         "gfx_arch": "device-all",
     },
     "rocm-jaxlib-v0.10.2": {
         "jax_ref": "rocm-jaxlib-v0.10.2",
         "jax_repository": "ROCm/jax",
-        "build_mode": "manylinux",
         "gfx_arch": "device-all",
+    },
+    "rocm-jaxlib-v0.11.0": {
+        "jax_ref": "rocm-jaxlib-v0.11.0",
+        "jax_repository": "ROCm/jax",
+        "gfx_arch": "device-all",
+        # JAX dropped Python 3.11 support in 0.11.0.
+        "exclude_python_versions": ["3.11"],
     },
 }
 
@@ -51,17 +55,19 @@ JAX_REF_CONFIGS = {
 # should differ later.
 RELEASE_JAX_REFS = {
     "linux": [
-        "rocm-jaxlib-v0.9.1",
         "rocm-jaxlib-v0.10.0",
+        "rocm-jaxlib-v0.10.1",
         "rocm-jaxlib-v0.10.2",
+        "rocm-jaxlib-v0.11.0",
     ],
 }
 
-# CI uses the manylinux package path only. Exclude rocm-jaxlib-v0.9.1 because
-# it uses the legacy native/tarball flow.
+# CI builds a single, stable JAX ref to keep the CI runner load low; the base
+# CI configuration favors breadth across GPU targets/platforms/frameworks
+# rather than every release version. Additional refs can be opted in as needed.
 CI_JAX_REFS = {
     "linux": [
-        "rocm-jaxlib-v0.10.0",
+        "rocm-jaxlib-v0.11.0",
     ],
 }
 
@@ -96,6 +102,10 @@ def generate_jax_matrix(
     for py in python_versions:
         for ref in jax_refs:
             ref_cfg = JAX_REF_CONFIGS[ref]
+            # Skip Python versions a ref explicitly excludes (declared in
+            # JAX_REF_CONFIGS, e.g. JAX 0.11.0 dropped Python 3.11).
+            if py in ref_cfg.get("exclude_python_versions", ()):
+                continue
             # These row keys are the contract with workflow files which use them
             # via matrix.<key> expressions. Empty values are allowed when the
             # workflow handles them explicitly, but undefined keys are not.
@@ -104,10 +114,9 @@ def generate_jax_matrix(
                     "python_version": py,
                     "jax_ref": ref_cfg["jax_ref"],
                     "jax_repository": ref_cfg["jax_repository"],
-                    "build_mode": ref_cfg["build_mode"],
-                    # gfx_arch is intentionally empty for native JAX builds and
-                    # non-empty for manylinux builds. This direct lookup raises
-                    # KeyError if JAX_REFS omits the key.
+                    # gfx_arch selects the ROCm device package for the manylinux
+                    # build (e.g. device-all). This direct lookup raises
+                    # KeyError if JAX_REF_CONFIGS omits the key.
                     "gfx_arch": ref_cfg["gfx_arch"],
                 }
             )

--- a/build_tools/github_actions/configure_multi_arch_ci_summary.py
+++ b/build_tools/github_actions/configure_multi_arch_ci_summary.py
@@ -248,8 +248,8 @@ def _append_build_pytorch(lines: list[str], outputs: CIOutputs) -> None:
 
 
 def _append_build_jax(lines: list[str], outputs: CIOutputs) -> None:
-    lines.append("| Platform | Python | JAX ref | Repository | Mode | GFX arch |")
-    lines.append("|----------|--------|---------|------------|------|----------|")
+    lines.append("| Platform | Python | JAX ref | Repository | GFX arch |")
+    lines.append("|----------|--------|---------|------------|----------|")
 
     rows = 0
     for platform, config in [
@@ -262,13 +262,12 @@ def _append_build_jax(lines: list[str], outputs: CIOutputs) -> None:
             gfx_arch = row["gfx_arch"] or "—"
             lines.append(
                 f"| {platform} | `{row['python_version']}` | "
-                f"`{row['jax_ref']}` | `{row['jax_repository']}` | "
-                f"`{row['build_mode']}` | {gfx_arch} |"
+                f"`{row['jax_ref']}` | `{row['jax_repository']}` | {gfx_arch} |"
             )
             rows += 1
 
     if rows == 0:
-        lines.append("| — | — | — | — | — | — |")
+        lines.append("| — | — | — | — | — |")
     lines.append("")
 
 

--- a/build_tools/github_actions/tests/configure_jax_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_jax_release_matrix_test.py
@@ -32,7 +32,7 @@ class ConfigureJaxReleaseMatrixTest(unittest.TestCase):
         self.assertGreater(len(jax_refs), 1)
         self.assertEqual(
             set(matrix[0]),
-            {"python_version", "jax_ref", "jax_repository", "build_mode", "gfx_arch"},
+            {"python_version", "jax_ref", "jax_repository", "gfx_arch"},
         )
 
     def test_explicit_python_version_narrows_matrix(self):
@@ -58,24 +58,7 @@ class ConfigureJaxReleaseMatrixTest(unittest.TestCase):
         self.assertEqual(matrix[0]["python_version"], "3.12")
         self.assertEqual(matrix[0]["jax_ref"], "rocm-jaxlib-v0.10.0")
         self.assertEqual(matrix[0]["jax_repository"], "ROCm/jax")
-        self.assertEqual(matrix[0]["build_mode"], "manylinux")
         self.assertEqual(matrix[0]["gfx_arch"], "device-all")
-
-    def test_ci_jax_matrix_excludes_unsupported_build_modes(self):
-        matrix = m.generate_jax_matrix_for_release_type(
-            release_type="ci",
-            platform="linux",
-        )
-
-        self.assertGreater(len(matrix), 0)
-        self.assertEqual(
-            {row["build_mode"] for row in matrix},
-            {"manylinux"},
-        )
-        self.assertNotIn(
-            "rocm-jaxlib-v0.9.1",
-            {row["jax_ref"] for row in matrix},
-        )
 
     def test_generated_rows_cover_workflow_matrix_inputs(self):
         # workflow file like:
@@ -112,6 +95,28 @@ class ConfigureJaxReleaseMatrixTest(unittest.TestCase):
             # Undefined values are not: if the workflow reads `matrix.unknown`,
             # this test fails until the generator emits that key for every row.
             self.assertEqual(matrix_references - set(row), set())
+
+    def test_ref_excluded_python_versions_are_filtered(self):
+        # exclude_python_versions in JAX_REF_CONFIGS drops those Python versions
+        # for that ref only (e.g. JAX 0.11.0 excludes 3.11).
+        matrix = m.generate_jax_matrix_for_release_type(
+            release_type="dev",
+            platform="linux",
+        )
+        combos = {(row["python_version"], row["jax_ref"]) for row in matrix}
+
+        self.assertNotIn(("3.11", "rocm-jaxlib-v0.11.0"), combos)
+        # 3.11 is still valid for refs that don't exclude it.
+        self.assertIn(("3.11", "rocm-jaxlib-v0.10.2"), combos)
+        # Non-excluded Python versions are still paired with 0.11.0.
+        self.assertIn(("3.12", "rocm-jaxlib-v0.11.0"), combos)
+
+    def test_ci_builds_single_jax_ref(self):
+        matrix = m.generate_jax_matrix_for_release_type(
+            release_type="ci",
+            platform="linux",
+        )
+        self.assertEqual({row["jax_ref"] for row in matrix}, {"rocm-jaxlib-v0.11.0"})
 
     def test_unknown_release_type_raises(self):
         with self.assertRaises(ValueError):

--- a/build_tools/github_actions/tests/configure_jax_release_matrix_test.py
+++ b/build_tools/github_actions/tests/configure_jax_release_matrix_test.py
@@ -112,6 +112,9 @@ class ConfigureJaxReleaseMatrixTest(unittest.TestCase):
         self.assertIn(("3.12", "rocm-jaxlib-v0.11.0"), combos)
 
     def test_ci_builds_single_jax_ref(self):
+        # CI keeps the runner queues short by building one ref, while still
+        # fanning out over Python versions. Comparing the set of distinct refs
+        # (rather than the row count) is what pins CI to exactly one ref.
         matrix = m.generate_jax_matrix_for_release_type(
             release_type="ci",
             platform="linux",

--- a/external-builds/jax/README.md
+++ b/external-builds/jax/README.md
@@ -13,9 +13,13 @@ Table of contents:
 - [Test instructions](#test-instructions)
 - [Nightly releases](#nightly-releases)
 
-For upstream JAX development references, see:
+For JAX development references, see:
 
-- [ROCm/rocm-jax BUILDING.md](https://github.com/ROCm/rocm-jax/blob/master/BUILDING.md)
+- [jax-ml/jax](https://github.com/jax-ml/jax) - upstream JAX
+- [ROCm/jax](https://github.com/ROCm/jax) - ROCm's downstream JAX fork, used to
+  build the ROCm JAX wheels
+- [ROCm/rocm-jax](https://github.com/ROCm/rocm-jax) - infrastructure (e.g.
+  Dockerfiles), no longer used to build the JAX wheels
 - [JAX developer documentation](https://docs.jax.dev/en/latest/developer.html)
 
 ## Support status
@@ -44,16 +48,18 @@ For upstream JAX development references, see:
 
 ### Supported JAX versions
 
-Support for JAX is provided via stable release branches.
+Support for JAX is provided via stable release branches from
+[ROCm/jax](https://github.com/ROCm/jax), built with the manylinux flow.
 
-JAX 0.9.1 uses release branch from [ROCm/rocm-jax](https://github.com/ROCm/rocm-jax).
-Starting with JAX 0.10.0, build support uses the [ROCm/jax](https://github.com/ROCm/jax) repository.
+| JAX version | Linux                                                                                                   | Windows          |
+| ----------- | ------------------------------------------------------------------------------------------------------- | ---------------- |
+| 0.11.0      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.11.0`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.11.0) | ❌ Not supported |
+| 0.10.2      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.10.2`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.10.2) | ❌ Not supported |
+| 0.10.1      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.10.1`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.10.1) | ❌ Not supported |
+| 0.10.0      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.10.0`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.10.0) | ❌ Not supported |
 
-| JAX version | Linux                                                                                                           | Windows          |
-| ----------- | --------------------------------------------------------------------------------------------------------------- | ---------------- |
-| 0.10.2      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.10.2`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.10.2)         | ❌ Not supported |
-| 0.10.0      | ✅ Supported via [ROCm/jax `rocm-jaxlib-v0.10.0`](https://github.com/ROCm/jax/tree/rocm-jaxlib-v0.10.0)         | ❌ Not supported |
-| 0.9.1       | ✅ Supported via [ROCm/rocm-jax `rocm-jaxlib-v0.9.1`](https://github.com/ROCm/rocm-jax/tree/rocm-jaxlib-v0.9.1) | ❌ Not supported |
+> [!NOTE]
+> Python 3.11 is not supported for JAX 0.11.0 and later (dropped upstream).
 
 See also:
 
@@ -64,103 +70,64 @@ See also:
 
 This repository builds the following ROCm-enabled JAX artifacts:
 
-- **jaxlib** (ROCm) - built for JAX ≤ 0.9.0 only
 - **`jax_rocm<major>_pjrt`** (PJRT runtime for ROCm)
 - **`jax_rocm<major>_plugin`** (JAX runtime plugin for ROCm)
 
 > [!NOTE]
-> Starting with JAX 0.9.1, jaxlib is **not built** - it is used from upstream
-> PyPI (`pip install jaxlib==0.9.1`). Only **`jax_rocm<major>_pjrt`** and
-> **`jax_rocm<major>_plugin`** are built.
+> jaxlib is **not built** for supported JAX versions (0.10.0+); it is installed
+> from upstream PyPI (e.g. `pip install jaxlib==0.11.0`). Only
+> **`jax_rocm<major>_pjrt`** and **`jax_rocm<major>_plugin`** are built.
 
 ### How building with TheRock differs from upstream
 
-The upstream [rocm-jax build instructions](https://github.com/ROCm/rocm-jax/blob/master/BUILDING.md)
+The [downstream ROCm/jax](https://github.com/ROCm/jax) build instructions
 assume that a stable ROCm version is already installed on the system.
 
-TheRock currently supports two build paths depending on the JAX release branch:
-
-- **JAX 0.9.1** uses the legacy tarball-based build flow via
-  `build/ci_build --therock-path`.
-- **JAX 0.10.0** builds against ROCm Python packages installed from the
-  TheRock multi-arch Python package index.
+Supported JAX versions (0.10.0+) build against ROCm Python packages installed
+from the TheRock multi-arch Python package index (the manylinux flow).
 
 ### Prerequisites
 
 - **OS**: Linux (supported distributions with ROCm)
-- **Python**: 3.12 recommended
-- **Compiler**:
-  - JAX 0.9.1: Clang provided by the TheRock tarball
-  - JAX 0.10.0: Clang provided by the manylinux build environment
-- **ROCm**:
-  - JAX 0.9.1: TheRock tarball
-  - JAX 0.10.0: ROCm Python packages from the TheRock multi-arch package index
+- **Python**: 3.12 recommended (Python 3.11 is not supported for JAX 0.11.0+)
+- **Compiler**: Clang provided by the manylinux build environment
+- **ROCm**: ROCm Python packages from the TheRock multi-arch package index
 
 ### Steps
 
-1. Checkout the source repository for your JAX version.
-
-   **JAX 0.9.1**
-
-   ```bash
-   git clone https://github.com/ROCm/rocm-jax.git
-   git clone https://github.com/ROCm/jax.git
-
-   pushd rocm-jax
-   git checkout rocm-jaxlib-v0.9.1
-   popd
-
-   pushd jax
-   git checkout rocm-jaxlib-v0.9.1
-   popd
-   ```
-
-   **JAX 0.10.0**
+1. Checkout the source repository for your JAX version (replace the ref with the
+   version you want to build):
 
    ```bash
    git clone https://github.com/ROCm/jax.git
 
    pushd jax
-   git checkout rocm-jaxlib-v0.10.0
+   git checkout rocm-jaxlib-v0.11.0
    popd
    ```
 
 1. Choose your configuration:
 
-   - **JAX version**: e.g. `0.9.1` or `0.10.0`
+   - **JAX version**: e.g. `0.10.0`, `0.10.1`, `0.10.2`, or `0.11.0`
    - **Python version**: e.g. `3.12`
+   - **Package index**: the TheRock multi-arch Python package index.
 
-   For **JAX 0.9.1**:
+1. Build the JAX wheels (multi-arch package flow).
 
-   - TheRock tarball URL, local tarball, or extracted ROCm installation.
-
-   For **JAX 0.10.0**:
-
-   - TheRock multi-arch Python package index.
-
-1. Build JAX 0.9.1 (legacy tarball flow)
+   From the `ROCm/jax` checkout, build the ROCm plugin and PJRT wheels:
 
    ```bash
-   pushd rocm-jax
-      PYTHON_VERSION=<python versions, comma separated>
-      ROCM_VERSION=<rocm_version>
-
-      python3 build/ci_build --therock-path "<path_to_tarball_or_rocm_dir>"
-      --python-versions="$PYTHON_VERSION"
-      --rocm-version="$ROCM_VERSION"
-      dist_wheels
-   popd
+   python build/build.py build --wheels=jax-rocm-plugin,jax-rocm-pjrt \
+     --python_version=3.12 \
+     --bazel_startup_options=--bazelrc=build/rocm/rocm.bazelrc \
+     --bazel_options=--config=rocm_release_wheel \
+     --bazel_options=--repo_env=ROCM_PATH=$(rocm-sdk path --root) \
+     --bazel_options=--repo_env=ML_WHEEL_TYPE=release \
+     --bazel_options=--//jaxlib/tools:jaxlib_git_hash=$(git rev-parse HEAD) \
+     --verbose --detailed_timestamped_log --output_path=$(pwd)/dist
    ```
 
-   > [!NOTE]
-   > The `--jax-source-dir` flag is required when building jaxlib from source
-   > (JAX \<= 0.9.0) and points to the cloned `jax` repository directory.
-   > For JAX >= 0.9.1, jaxlib is installed from upstream PyPI, so this flag
-   > can be omitted.
-
-1. Build JAX 0.10.0 (multi-arch package flow)
-
-   JAX 0.10.0 builds are performed by the GitHub Actions workflow:
+   This is the same flow the GitHub Actions workflow uses:
 
    - `.github/workflows/multi_arch_build_linux_jax_wheels.yml`
 
@@ -169,17 +136,7 @@ TheRock currently supports two build paths depending on the JAX release branch:
    `jax_rocm<major>_pjrt`, where `<major>` is the ROCm major version being built
    against.
 
-1. Locate built wheels:
-
-   **JAX 0.9.1**
-
-   After a successful build, wheels will be available in:
-
-   ```text
-   rocm-jax/jax_rocm_plugin/wheelhouse/
-   ```
-
-   **JAX 0.10.0**
+1. Locate built wheels.
 
    After a successful build, wheels will be available in:
 
@@ -187,12 +144,8 @@ TheRock currently supports two build paths depending on the JAX release branch:
    jax/dist/
    ```
 
-For more detailed build options, see the build instructions for the JAX
-release branch you are using.
-
-- JAX 0.9.1: [ROCm/rocm-jax BUILDING.md](https://github.com/ROCm/rocm-jax/blob/master/BUILDING.md#building)
-- JAX 0.10.0: See the `ROCm/jax` repository and the
-  `.github/workflows/multi_arch_build_linux_jax_wheels.yml` workflow in TheRock.
+For more detailed build options, see the `ROCm/jax` repository and the
+`.github/workflows/multi_arch_build_linux_jax_wheels.yml` workflow in TheRock.
 
 ## Test instructions
 
@@ -253,10 +206,10 @@ release branch you are using.
 1. Run JAX tests:
 
    ```bash
-   pytest jax_tests/tests/multi_device_test.py -q --log-cli-level=INFO
-   pytest jax_tests/tests/core_test.py -q --log-cli-level=INFO
-   pytest jax_tests/tests/util_test.py -q --log-cli-level=INFO
-   pytest jax_tests/tests/scipy_stats_test.py -q --log-cli-level=INFO
+   cd jax
+   # Create a dist directory (required to run the pytest-rocm.sh script).
+   mkdir -p dist
+   sh ci/run_pytest_rocm.sh
    ```
 
 ## Nightly releases


### PR DESCRIPTION
Issue: https://github.com/ROCm/TheRock/issues/6710
## Motivation

Bring the TheRock JAX CI/release version set up to date. The **release** workflow should build/test `rocm-jaxlib-v0.10.0`, `v0.10.1`, `v0.10.2`, and `v0.11.0`, and drop `v0.9.1` (the last version using the legacy `native` `ROCm/rocm-jax` build
flow). Everything `0.10.0+` uses the manylinux flow from `ROCm/jax`. **PR CI** builds a single, most-stable ref to keep runner load low.

## JAX versions: CI vs Release

| Workflow | `release_type` | JAX refs built |
| --- | --- | --- |
| **Release** (dev / nightly / prerelease) | `dev`, `nightly`, `prerelease` | `0.10.0`, `0.10.1`, `0.10.2`, `0.11.0` |
| **PR CI** | `ci` | `0.11.0` only (default / most stable) |

Following the PyTorch CI convention, the base CI config favors breadth across GPU targets/platforms/frameworks, so PR CI builds a single ref (additional refs can be opted in as needed). `0.11.0` is the default.


## Changes

**Version matrix (`build_tools/github_actions/configure_jax_release_matrix.py`)**
- `RELEASE_JAX_REFS`: `0.10.0, 0.10.1, 0.10.2, 0.11.0` (added `v0.10.1` and `v0.11.0`; removed `v0.9.1`).
- `CI_JAX_REFS`: single ref `v0.11.0`.
- Python version support is now **declarative per ref** via `exclude_python_versions` in `JAX_REF_CONFIGS` (JAX dropped Python 3.11 in `0.11.0`), replacing the previous regex-on-ref-name logic.

**Remove the legacy `native` build flow (only `0.9.1` used it)**
- Drop the `build_mode` key from the matrix generator, the JAX build/release/CI workflows, the CI summary table, and the unit tests.
- Delete the dead native build step and the CI build-mode validation step; simplify the now-unconditional manylinux steps.
- Remove the orphaned `tar_url` input from the JAX build/release chain. The manylinux flow installs ROCm from the pip `--find-links` index, not a TheRock tarball.
- `trigger_release_jax_wheels` no longer `needs: build_tarballs` (it only consumes `build_python_packages`), so the JAX release no longer waits on / is skipped by the tarball job.

**Test runner (`build_tools/github_actions/configure_target_run.py`)**
- JAX tests now run on the family's multi-GPU runner (`test-runs-on-multi-gpu`), i.e. `linux-gfx942-8gpu-ossci-rocm` for `gfx94X-dcgpu`, falling back to the single-GPU runner where a family has none.

**Refresh stale defaults**
- Update stale `jax_ref` `workflow_dispatch` defaults (`0.8.2`/`0.9.1`) to `rocm-jaxlib-v0.11.0` in `test_linux_jax_wheels_partial.yml`, `test_linux_jax_wheels.yml`, and `test_jax_dockerfile.yml`.

**Docs**
- `RELEASES.md`: supported JAX versions `0.10.0–0.11.0`, default `JAX_VERSION=0.11.0`.
- `external-builds/jax/README.md`: manylinux-only flow; dropped `0.9.1`/native content; refreshed the supported-version table; clarified upstream (`jax-ml/jax`) vs downstream (`ROCm/jax`) vs infra (`ROCm/rocm-jax`); added the real `build/build.py` build command and the `ci/run_pytest_rocm.sh` test command.

## Test Plan

- `pytest build_tools/github_actions/tests/configure_jax_release_matrix_test.py` - 8 passed.
- `pytest build_tools/github_actions/tests/configure_target_run_test.py` - 4 passed.
- Full CI-config/summary suite (`-k "summary or multi_arch_ci or jax"`) - passed.
- `yaml.safe_load` on all edited workflows - all parse.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
