### PR TITLE
fix(packaging): register ROCm libraries for Linux native packages

### DIFF
--- a/build_tools/packaging/linux/deb_package.py
+++ b/build_tools/packaging/linux/deb_package.py
@@ -126,8 +126,16 @@ def create_versioned_deb_package(pkg_name, config: PackageConfig):
         for source_path in sourcedir_list:
             copy_package_contents(source_path, dest_dir)
 
+        has_ldconfig_file = generate_ldconfig_file(pkg_info, package_dir, build_config)
+
         # Generate install file after copying, so we can check for hidden files
-        generate_install_file(pkg_info, deb_dir, build_config, dest_dir)
+        generate_install_file(
+            pkg_info,
+            deb_dir,
+            build_config,
+            dest_dir,
+            has_ldconfig_file=has_ldconfig_file,
+        )
 
     package_with_dpkg_build(package_dir)
 
@@ -188,7 +196,14 @@ def generate_changelog_file(pkg_info, deb_dir, config: PackageConfig):
         f.write(template.render(context))
 
 
-def generate_install_file(pkg_info, deb_dir, config: PackageConfig, dest_dir=None):
+def generate_install_file(
+    pkg_info,
+    deb_dir,
+    config: PackageConfig,
+    dest_dir=None,
+    *,
+    has_ldconfig_file=False,
+):
     """Generate a Debian install entry in `debian/install`.
 
     Parameters:
@@ -234,10 +249,27 @@ def generate_install_file(pkg_info, deb_dir, config: PackageConfig, dest_dir=Non
         "path": config.install_prefix,
         "has_hidden_files": has_hidden_files,
         "has_regular_files": has_regular_files,
+        "has_ldconfig_file": has_ldconfig_file,
     }
 
     with install_file.open("w", encoding="utf-8") as f:
         f.write(template.render(context))
+
+
+def generate_ldconfig_file(pkg_info, package_dir, config: PackageConfig):
+    """Generate a versioned dynamic-loader configuration owned by the package."""
+    paths = pkg_info.get("LdconfigPaths", [])
+    if not paths:
+        return False
+
+    major_minor = ".".join(config.rocm_version.split(".")[:2])
+    filename = f"10-{pkg_info['Package']}{major_minor}.conf"
+    config_dir = Path(package_dir) / "etc" / "ld.so.conf.d"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / filename).write_text(
+        "".join(f"{path}\n" for path in paths), encoding="utf-8"
+    )
+    return True
 
 
 def generate_rules_file(pkg_info, deb_dir, config: PackageConfig):

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -141,6 +141,8 @@ import traceback
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
+from elftools.elf.elffile import ELFFile
+
 _SCRIPT_DIR = Path(__file__).resolve().parent
 if str(_SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPT_DIR))
@@ -978,18 +980,18 @@ gpgcheck=0
         return False
 
     def test_native_hip_consumer(self) -> bool:
-        """Compile and run a HIP runtime consumer without loader environment overrides."""
+        """Compile and run a HIP consumer without loader environment overrides."""
         install_path = Path(self.install_prefix).resolve()
         hipcc_path = install_path / "bin" / "hipcc"
         if not hipcc_path.exists():
             print(f"\n[FAIL] hipcc not found at: {hipcc_path}")
             return False
 
-        source_text = """#include <hip/hip_runtime_api.h>
+        source_text = """extern "C" int hipRuntimeGetVersion(int *);
 
 int main() {
     int runtime_version = 0;
-    return hipRuntimeGetVersion(&runtime_version) == hipSuccess ? 0 : 1;
+    return hipRuntimeGetVersion(&runtime_version);
 }
 """
         print("\nCompiling and running a native HIP consumer...")
@@ -999,13 +1001,45 @@ int main() {
                 binary_path = Path(temp_dir) / "native_hip_consumer"
                 source_path.write_text(source_text, encoding="utf-8")
                 subprocess.run(
-                    [str(hipcc_path), str(source_path), "-o", str(binary_path)],
+                    [
+                        str(hipcc_path),
+                        "-nogpulib",
+                        str(source_path),
+                        f"-L{install_path / 'lib'}",
+                        "-Wl,--no-as-needed",
+                        "-lamdhip64",
+                        "-o",
+                        str(binary_path),
+                    ],
                     check=True,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
                     text=True,
                     timeout=NATIVE_HIP_TEST_TIMEOUT_SEC,
                 )
+
+                with binary_path.open("rb") as binary_file:
+                    dynamic_section = ELFFile(binary_file).get_section_by_name(
+                        ".dynamic"
+                    )
+                    if dynamic_section is None:
+                        print(" [FAIL] Native HIP consumer has no dynamic section")
+                        return False
+                    dynamic_tags = list(dynamic_section.iter_tags())
+                    needed = {
+                        tag.needed
+                        for tag in dynamic_tags
+                        if tag.entry.d_tag == "DT_NEEDED"
+                    }
+                    if not any(name.startswith("libamdhip64.so") for name in needed):
+                        print(" [FAIL] Native HIP consumer does not need libamdhip64")
+                        return False
+                    if any(
+                        tag.entry.d_tag in ("DT_RPATH", "DT_RUNPATH")
+                        for tag in dynamic_tags
+                    ):
+                        print(" [FAIL] Native HIP consumer contains RPATH/RUNPATH")
+                        return False
 
                 clean_env = os.environ.copy()
                 clean_env.pop("LD_LIBRARY_PATH", None)

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -982,14 +982,14 @@ gpgcheck=0
     def test_native_hip_consumer(self) -> bool:
         """Compile and run a HIP consumer without loader environment overrides."""
         install_path = Path(self.install_prefix).resolve()
-        hipcc_path = install_path / "bin" / "hipcc"
-        if not hipcc_path.exists():
-            print(f"\n[FAIL] hipcc not found at: {hipcc_path}")
+        clang_path = install_path / "lib" / "llvm" / "bin" / "clang"
+        if not clang_path.exists():
+            print(f"\n[FAIL] clang not found at: {clang_path}")
             return False
 
-        source_text = """extern "C" int hipRuntimeGetVersion(int *);
+        source_text = """extern int hipRuntimeGetVersion(int *);
 
-int main() {
+int native_hip_consumer(void) {
     int runtime_version = 0;
     return hipRuntimeGetVersion(&runtime_version);
 }
@@ -997,13 +997,17 @@ int main() {
         print("\nCompiling and running a native HIP consumer...")
         try:
             with tempfile.TemporaryDirectory(prefix="rocm-native-hip-") as temp_dir:
-                source_path = Path(temp_dir) / "native_hip_consumer.cpp"
-                binary_path = Path(temp_dir) / "native_hip_consumer"
+                source_path = Path(temp_dir) / "native_hip_consumer.c"
+                binary_path = Path(temp_dir) / "native_hip_consumer.so"
                 source_path.write_text(source_text, encoding="utf-8")
                 subprocess.run(
                     [
-                        str(hipcc_path),
-                        "-nogpulib",
+                        str(clang_path),
+                        "-x",
+                        "c",
+                        "-nostdlib",
+                        "-shared",
+                        "-fPIC",
                         str(source_path),
                         f"-L{install_path / 'lib'}",
                         "-Wl,--no-as-needed",
@@ -1044,7 +1048,16 @@ int main() {
                 clean_env = os.environ.copy()
                 clean_env.pop("LD_LIBRARY_PATH", None)
                 subprocess.run(
-                    [str(binary_path)],
+                    [
+                        sys.executable,
+                        "-c",
+                        (
+                            "import ctypes, sys; "
+                            "raise SystemExit(ctypes.CDLL(sys.argv[1])"
+                            ".native_hip_consumer())"
+                        ),
+                        str(binary_path),
+                    ],
                     check=True,
                     env=clean_env,
                     stdout=subprocess.PIPE,

--- a/build_tools/packaging/linux/native_linux_package_install_test.py
+++ b/build_tools/packaging/linux/native_linux_package_install_test.py
@@ -136,6 +136,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import traceback
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
@@ -186,6 +187,7 @@ ZYPP_REFRESH_TIMEOUT_SEC = 120
 DNF_CLEAN_TIMEOUT_SEC = 60
 INSTALL_TIMEOUT_SEC = 1800  # 30 minutes
 ROCMINFO_TIMEOUT_SEC = 30
+NATIVE_HIP_TEST_TIMEOUT_SEC = 120
 # rdhc.py ``--all`` runs the full ROCm deployment health check suite; 30s was too
 # short in container CI (timeouts under load). Optional cluster checks are skipped
 # separately via ``--skip-optional-cluster-checks`` in ``test_rdhc``.
@@ -967,11 +969,68 @@ gpgcheck=0
             except OSError as e:
                 print(f" [WARN] Could not run rocminfo: {e}")
 
-        if found_count >= VERIFY_MIN_COMPONENTS:
+        native_hip_consumer_ok = self.test_native_hip_consumer()
+
+        if found_count >= VERIFY_MIN_COMPONENTS and native_hip_consumer_ok:
             print("\n[PASS] Basic verification PASSED")
             return True
-        print("\n[FAIL] Basic verification FAILED (insufficient components)")
+        print("\n[FAIL] Basic verification FAILED")
         return False
+
+    def test_native_hip_consumer(self) -> bool:
+        """Compile and run a HIP runtime consumer without loader environment overrides."""
+        install_path = Path(self.install_prefix).resolve()
+        hipcc_path = install_path / "bin" / "hipcc"
+        if not hipcc_path.exists():
+            print(f"\n[FAIL] hipcc not found at: {hipcc_path}")
+            return False
+
+        source_text = """#include <hip/hip_runtime_api.h>
+
+int main() {
+    int runtime_version = 0;
+    return hipRuntimeGetVersion(&runtime_version) == hipSuccess ? 0 : 1;
+}
+"""
+        print("\nCompiling and running a native HIP consumer...")
+        try:
+            with tempfile.TemporaryDirectory(prefix="rocm-native-hip-") as temp_dir:
+                source_path = Path(temp_dir) / "native_hip_consumer.cpp"
+                binary_path = Path(temp_dir) / "native_hip_consumer"
+                source_path.write_text(source_text, encoding="utf-8")
+                subprocess.run(
+                    [str(hipcc_path), str(source_path), "-o", str(binary_path)],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    timeout=NATIVE_HIP_TEST_TIMEOUT_SEC,
+                )
+
+                clean_env = os.environ.copy()
+                clean_env.pop("LD_LIBRARY_PATH", None)
+                subprocess.run(
+                    [str(binary_path)],
+                    check=True,
+                    env=clean_env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    timeout=NATIVE_HIP_TEST_TIMEOUT_SEC,
+                )
+            print(" [PASS] Native HIP consumer executed successfully")
+            return True
+        except subprocess.TimeoutExpired:
+            print(" [FAIL] Native HIP consumer test timed out")
+            return False
+        except subprocess.CalledProcessError as e:
+            print(f" [FAIL] Native HIP consumer failed with exit code {e.returncode}")
+            if e.stdout:
+                print(e.stdout.rstrip())
+            return False
+        except OSError as e:
+            print(f" [FAIL] Could not test native HIP consumer: {e}")
+            return False
 
     def run_full_verification(self) -> bool:
         """Step 3: Full test — runs test_rdhc (rdhc.py) only. Used when --test-type is full."""

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -201,6 +201,10 @@
     "License": "MIT",
     "Vendor": "Advanced Micro Devices, Inc",
     "Homepage": "https://github.com/ROCm/rocm-systems",
+    "LdconfigPaths": [
+      "/opt/rocm/lib"
+    ],
+    "Postinstall": "True",
     "Artifactory": [
       {
         "Artifact": "core-runtime",

--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -102,6 +102,8 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
     rpmrecommends = rpmsuggests = ""
     sourcedir_list = []
     rpm_scripts = []
+    ldconfig_paths = []
+    ldconfig_filename = ""
     # amdrocm-debugger: Exclude libpython requirements
     # Multiple Python-version-specific binaries are included; the wrapper script
     # automatically selects the binary matching the system's Python version
@@ -140,6 +142,10 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
         if is_postinstallscripts_available(pkg_info):
             rpm_scripts = generate_rpm_postscripts(pkg_info, config)
 
+        ldconfig_paths = pkg_info.get("LdconfigPaths", [])
+        if ldconfig_paths:
+            major_minor = ".".join(config.rocm_version.split(".")[:2])
+            ldconfig_filename = f"10-{pkg_info['Package']}{major_minor}.conf"
     else:
         # Get -> Transform -> Join (no transform needed for RPM)
         provides = process_name_field(pkg_info, "Provides")
@@ -180,6 +186,8 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
         "disable_debug_package": is_debug_package_disabled(pkg_info),
         "sourcedir_list": sourcedir_list,
         "rpm_scripts": rpm_scripts,
+        "ldconfig_paths": ldconfig_paths,
+        "ldconfig_filename": ldconfig_filename,
         "exclude_libpython_requires": exclude_libpython_requires,
     }
 

--- a/build_tools/packaging/linux/template/debian_install.j2
+++ b/build_tools/packaging/linux/template/debian_install.j2
@@ -1,3 +1,6 @@
+{%- if has_ldconfig_file %}
+./etc  /
+{%- endif %}
 {%- if has_regular_files %}
 .{{path}}/*  {{path}}
 {%- endif %}

--- a/build_tools/packaging/linux/template/rpm_specfile.j2
+++ b/build_tools/packaging/linux/template/rpm_specfile.j2
@@ -61,9 +61,18 @@ mkdir -p $RPM_BUILD_ROOT{{ install_prefix }}
    cp -R "{{ path }}"/* "$RPM_BUILD_ROOT{{ install_prefix }}/"
 }
 {% endfor %}
+{% if ldconfig_filename %}
+mkdir -p "$RPM_BUILD_ROOT/etc/ld.so.conf.d"
+cat > "$RPM_BUILD_ROOT/etc/ld.so.conf.d/{{ ldconfig_filename }}" <<'EOF'
+{% for path in ldconfig_paths %}{{ path }}
+{% endfor %}EOF
+{% endif %}
 
 %files
 %defattr(-, root, root, -)
+{% if ldconfig_filename %}
+%config(noreplace) /etc/ld.so.conf.d/{{ ldconfig_filename }}
+{% endif %}
 {{ install_prefix }}
 
 %clean

--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-postinst.j2
@@ -79,6 +79,7 @@ do_update_alternatives(){
             echo "$PKG_INSTALL_PREFIX/bin/$i not found, but that is OK" >&2
         fi
     done
+    command -v ldconfig >/dev/null && ldconfig
     true
 }
 

--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-postrm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-postrm.j2
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+{% if target == "deb" %}
+case "$1" in
+    remove|purge)
+        ldconfig
+        ;;
+esac
+{% else %}
+if [ "$1" -eq 0 ]; then
+    ldconfig
+fi
+{% endif %}

--- a/build_tools/packaging/linux/template/scripts/amdrocm-core-prerm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-core-prerm.j2
@@ -60,5 +60,7 @@ then
        ;;
    esac
 else
-    do_update_alternatives
+    if [ "$1" -eq 0 ]; then
+        do_update_alternatives
+    fi
 fi

--- a/build_tools/packaging/linux/template/scripts/amdrocm-runtime-postinst.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-runtime-postinst.j2
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+{% if target == "deb" %}
+case "$1" in
+    configure)
+        ldconfig
+        ;;
+esac
+{% else %}
+ldconfig
+{% endif %}

--- a/build_tools/packaging/linux/template/scripts/amdrocm-runtime-postrm.j2
+++ b/build_tools/packaging/linux/template/scripts/amdrocm-runtime-postrm.j2
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+{% if target == "deb" %}
+case "$1" in
+    remove|purge)
+        ldconfig
+        ;;
+esac
+{% else %}
+if [ "$1" -eq 0 ]; then
+    ldconfig
+fi
+{% endif %}

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -45,6 +45,7 @@ TEST_BUILD_ARCH = "x86_64"
 EMPTY_GFX_ARCH = ""
 
 PKG_FFT = "amdrocm-fft"
+PKG_CORE = "amdrocm-core"
 PKG_CORE_SDK = "amdrocm-core-sdk"
 PKG_DEVELOPER_TOOLS = "amdrocm-developer-tools"
 PKG_RUNTIME = "amdrocm-runtime"
@@ -56,6 +57,8 @@ FFT_DEVICE_PACKAGE = "amdrocm-fft7.1-gfx1100"
 FFT_META_PACKAGE = "amdrocm-fft7.1"
 CORE_SDK_DEVICE_PACKAGE = "amdrocm-core-sdk7.1-gfx1100"
 DEVELOPER_TOOLS_PACKAGE = "amdrocm-developer-tools7.1"
+RUNTIME_PACKAGE = "amdrocm-runtime7.1"
+RUNTIME_LDCONFIG_FILE = "10-amdrocm-runtime7.1.conf"
 
 STAGING_PAYLOAD_NAME = "libdummy.so"
 STAGING_PAYLOAD_BYTES = b"\x00"
@@ -315,6 +318,12 @@ def _read_spec_file(pkg_name: str, config: PackageConfig) -> str:
     return spec_path.read_text(encoding="utf-8")
 
 
+def _package_dir(pkg_name: str, config: PackageConfig) -> Path:
+    """Return the generated versioned package build directory."""
+    updated = update_package_name(pkg_name, replace(config, versioned_pkg=True))
+    return Path(config.dest_dir) / config.pkg_type / updated
+
+
 def _stage_fft_kpack_tree(artifacts_dir: Path, *, include_host: bool = False) -> None:
     """Stage FFT artifacts for kpack tests; optionally include host/generic tree."""
     _stage_package_artifacts(
@@ -379,6 +388,36 @@ class ArtifactStagingTest(BuildPackageTestCase):
 
 
 # ---------------------------------------------------------------------------
+# Maintainer scripts — alternatives changes must refresh the loader cache
+# ---------------------------------------------------------------------------
+class MaintainerScriptTest(BuildPackageTestCase):
+    """Core package lifecycle scripts refresh ldconfig after alternatives."""
+
+    def test_core_deb_scripts_refresh_ldconfig(self) -> None:
+        cfg = _kpack_config(self.temp_dir)
+        deb_dir = self.temp_dir / "debian"
+        deb_dir.mkdir()
+
+        deb_package.generate_debian_postscripts(
+            get_package_info(PKG_CORE), deb_dir, cfg
+        )
+
+        self.assertIn("ldconfig", (deb_dir / "postinst").read_text())
+        self.assertNotIn("ldconfig", (deb_dir / "prerm").read_text())
+        self.assertIn("ldconfig", (deb_dir / "postrm").read_text())
+
+    def test_core_rpm_scripts_refresh_ldconfig(self) -> None:
+        cfg = _kpack_config(self.temp_dir, pkg_type=TEST_PKG_TYPE_RPM)
+
+        scripts = rpm_package.generate_rpm_postscripts(get_package_info(PKG_CORE), cfg)
+
+        self.assertIn("ldconfig", scripts["%post"])
+        self.assertNotIn("ldconfig", scripts["%preun"])
+        self.assertIn('if [ "$1" -eq 0 ]', scripts["%preun"])
+        self.assertIn("ldconfig", scripts["%postun"])
+
+
+# ---------------------------------------------------------------------------
 # create_versioned_deb_package — real control file generation
 # ---------------------------------------------------------------------------
 class CreateVersionedDebPackageTest(BuildPackageTestCase):
@@ -418,6 +457,31 @@ class CreateVersionedDebPackageTest(BuildPackageTestCase):
         self.assertEqual(_control_field(control, "Package"), FFT_HOST_PACKAGE)
         self.assertEqual(_control_field(control, "Architecture"), "amd64")
         self.assertIn("amdrocm-runtime", _control_field(control, "Depends"))
+
+    @patch.object(deb_package, "move_packages_to_destination", return_value=[])
+    @patch.object(deb_package, "package_with_dpkg_build")
+    def test_runtime_installs_loader_config_and_scripts(
+        self, _mock_dpkg: object, _mock_move: object
+    ) -> None:
+        cfg = _kpack_config(self.temp_dir)
+        _stage_package_artifacts(
+            pkg_name=PKG_RUNTIME,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=GFX_HOST,
+            enable_kpack=True,
+        )
+        runtime_cfg = replace(cfg, gfx_arch=GFX_HOST)
+
+        deb_package.create_versioned_deb_package(
+            pkg_name=PKG_RUNTIME, config=runtime_cfg
+        )
+
+        package_dir = _package_dir(PKG_RUNTIME, runtime_cfg)
+        config_file = package_dir / "etc" / "ld.so.conf.d" / RUNTIME_LDCONFIG_FILE
+        self.assertEqual(config_file.read_text(encoding="utf-8"), "/opt/rocm/lib\n")
+        self.assertIn("./etc  /", (package_dir / "debian" / "install").read_text())
+        self.assertIn("ldconfig", (package_dir / "debian" / "postinst").read_text())
+        self.assertIn("ldconfig", (package_dir / "debian" / "postrm").read_text())
 
     @patch.object(deb_package, "move_packages_to_destination", return_value=[])
     @patch.object(deb_package, "package_with_dpkg_build")
@@ -532,6 +596,34 @@ class CreateVersionedRpmPackageTest(BuildPackageTestCase):
         self.assertEqual(_spec_field(spec, "Name"), FFT_HOST_PACKAGE)
         self.assertEqual(_spec_field(spec, "BuildArch"), TEST_BUILD_ARCH)
         self.assertIn("amdrocm-runtime", _spec_field(spec, "Requires"))
+
+    @patch.object(rpm_package, "move_packages_to_destination", return_value=[])
+    @patch.object(rpm_package, "package_with_rpmbuild")
+    def test_runtime_installs_loader_config_and_scripts(
+        self, _mock_rpmbuild: object, _mock_move: object
+    ) -> None:
+        cfg = _kpack_config(self.temp_dir, pkg_type=TEST_PKG_TYPE_RPM)
+        _stage_package_artifacts(
+            pkg_name=PKG_RUNTIME,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=GFX_HOST,
+            enable_kpack=True,
+        )
+        runtime_cfg = replace(cfg, gfx_arch=GFX_HOST)
+
+        rpm_package.create_versioned_rpm_package(
+            pkg_name=PKG_RUNTIME, config=runtime_cfg
+        )
+
+        spec = _read_spec_file(PKG_RUNTIME, runtime_cfg)
+        self.assertEqual(_spec_field(spec, "Name"), RUNTIME_PACKAGE)
+        self.assertIn(
+            f"%config(noreplace) /etc/ld.so.conf.d/{RUNTIME_LDCONFIG_FILE}", spec
+        )
+        self.assertIn("/opt/rocm/lib", spec)
+        self.assertIn("%post\n", spec)
+        self.assertIn("%postun\n", spec)
+        self.assertIn("ldconfig", spec)
 
     @patch.object(rpm_package, "move_packages_to_destination", return_value=[])
     @patch.object(rpm_package, "package_with_rpmbuild")

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -8,6 +8,7 @@
 import contextlib
 import importlib.util
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -1026,7 +1027,12 @@ class RunBasicVerificationTest(unittest.TestCase):
         # Test that run_basic_verification handles CalledProcessError when querying packages (continues, then passes if enough components).
         import subprocess
 
-        mock_run.side_effect = subprocess.CalledProcessError(1, "dpkg")
+        mock_run.side_effect = [
+            subprocess.CalledProcessError(1, "dpkg"),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+        ]
         with tempfile.TemporaryDirectory() as d:
             (Path(d) / "bin").mkdir()
             (Path(d) / "lib").mkdir()
@@ -1047,6 +1053,8 @@ class RunBasicVerificationTest(unittest.TestCase):
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="ii rocm 1.0\n"),
             subprocess.TimeoutExpired("rocminfo", 30),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
         ]
         with tempfile.TemporaryDirectory() as d:
             (Path(d) / "bin").mkdir()
@@ -1059,6 +1067,43 @@ class RunBasicVerificationTest(unittest.TestCase):
                 install_prefix=d,
             )
             self.assertTrue(t.run_basic_verification())
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_native_hip_consumer_clears_loader_environment(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "bin").mkdir()
+            (Path(d) / "bin" / "hipcc").write_text("")
+            t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+                repo_url="https://example.com",
+                os_profile="ubuntu2404",
+                install_prefix=d,
+            )
+            with patch.dict(os.environ, {"LD_LIBRARY_PATH": "/custom/lib"}):
+                self.assertTrue(t.test_native_hip_consumer())
+
+        self.assertEqual(mock_run.call_count, 2)
+        self.assertNotIn("LD_LIBRARY_PATH", mock_run.call_args_list[1].kwargs["env"])
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    def test_native_hip_consumer_returns_false_on_loader_failure(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=""),
+            subprocess.CalledProcessError(
+                127,
+                "native_hip_consumer",
+                output="libamdhip64.so.7: cannot open shared object file",
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "bin").mkdir()
+            (Path(d) / "bin" / "hipcc").write_text("")
+            t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+                repo_url="https://example.com",
+                os_profile="ubuntu2404",
+                install_prefix=d,
+            )
+            self.assertFalse(t.test_native_hip_consumer())
 
 
 class SetupGpgKeyTest(unittest.TestCase):

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -1048,8 +1048,10 @@ class RunBasicVerificationTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             (Path(d) / "bin").mkdir()
             (Path(d) / "lib").mkdir()
+            (Path(d) / "lib" / "llvm" / "bin").mkdir(parents=True)
             (Path(d) / "bin" / "rocminfo").write_text("")
             (Path(d) / "bin" / "hipcc").write_text("")
+            (Path(d) / "lib" / "llvm" / "bin" / "clang").write_text("")
             t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
                 repo_url="https://example.com",
                 os_profile="ubuntu2404",
@@ -1096,8 +1098,8 @@ class RunBasicVerificationTest(unittest.TestCase):
         mock_dynamic.iter_tags.return_value = [needed_tag]
         mock_elf_file.return_value.get_section_by_name.return_value = mock_dynamic
         with tempfile.TemporaryDirectory() as d:
-            (Path(d) / "bin").mkdir()
-            (Path(d) / "bin" / "hipcc").write_text("")
+            (Path(d) / "lib" / "llvm" / "bin").mkdir(parents=True)
+            (Path(d) / "lib" / "llvm" / "bin" / "clang").write_text("")
             t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
                 repo_url="https://example.com",
                 os_profile="ubuntu2404",
@@ -1109,9 +1111,17 @@ class RunBasicVerificationTest(unittest.TestCase):
 
         self.assertEqual(mock_run.call_count, 2)
         compile_cmd = mock_run.call_args_list[0].args[0]
-        self.assertIn("-nogpulib", compile_cmd)
+        self.assertIn(str(Path(d) / "lib" / "llvm" / "bin" / "clang"), compile_cmd)
+        self.assertIn("-x", compile_cmd)
+        self.assertIn("c", compile_cmd)
+        self.assertIn("-nostdlib", compile_cmd)
+        self.assertIn("-shared", compile_cmd)
+        self.assertIn("-fPIC", compile_cmd)
         self.assertIn("-Wl,--no-as-needed", compile_cmd)
         self.assertIn("-lamdhip64", compile_cmd)
+        run_cmd = mock_run.call_args_list[1].args[0]
+        self.assertEqual(run_cmd[0], sys.executable)
+        self.assertIn("ctypes.CDLL", run_cmd[2])
         self.assertNotIn("LD_LIBRARY_PATH", mock_run.call_args_list[1].kwargs["env"])
 
     @patch("native_linux_package_install_test.subprocess.run")
@@ -1129,8 +1139,8 @@ class RunBasicVerificationTest(unittest.TestCase):
         mock_dynamic.iter_tags.return_value = [needed_tag, runpath_tag]
         mock_elf_file.return_value.get_section_by_name.return_value = mock_dynamic
         with tempfile.TemporaryDirectory() as d:
-            (Path(d) / "bin").mkdir()
-            (Path(d) / "bin" / "hipcc").write_text("")
+            (Path(d) / "lib" / "llvm" / "bin").mkdir(parents=True)
+            (Path(d) / "lib" / "llvm" / "bin" / "clang").write_text("")
             t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
                 repo_url="https://example.com",
                 os_profile="ubuntu2404",
@@ -1161,8 +1171,8 @@ class RunBasicVerificationTest(unittest.TestCase):
         mock_dynamic.iter_tags.return_value = [needed_tag]
         mock_elf_file.return_value.get_section_by_name.return_value = mock_dynamic
         with tempfile.TemporaryDirectory() as d:
-            (Path(d) / "bin").mkdir()
-            (Path(d) / "bin" / "hipcc").write_text("")
+            (Path(d) / "lib" / "llvm" / "bin").mkdir(parents=True)
+            (Path(d) / "lib" / "llvm" / "bin" / "clang").write_text("")
             t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
                 repo_url="https://example.com",
                 os_profile="ubuntu2404",

--- a/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
+++ b/build_tools/packaging/linux/tests/native_linux_package_install_ut_test.py
@@ -991,8 +991,15 @@ class RunBasicVerificationTest(unittest.TestCase):
         )
         self.assertFalse(t.run_basic_verification())
 
+    @patch.object(
+        native_linux_package_install_test.NativeLinuxPackageInstallTest,
+        "test_native_hip_consumer",
+        return_value=True,
+    )
     @patch("native_linux_package_install_test.subprocess.run")
-    def test_returns_true_when_enough_components_found(self, mock_run):
+    def test_returns_true_when_enough_components_found(
+        self, mock_run, _mock_native_consumer
+    ):
         # Test that run_basic_verification returns True when install_prefix exists and at least
         # VERIFY_MIN_COMPONENTS key components exist; subprocess (dpkg/rpm, rocminfo) is mocked.
         mock_run.return_value = MagicMock(returncode=0, stdout="ii rocm-pkg 1.0\n")
@@ -1022,16 +1029,21 @@ class RunBasicVerificationTest(unittest.TestCase):
             )
             self.assertFalse(t.run_basic_verification())
 
+    @patch.object(
+        native_linux_package_install_test.NativeLinuxPackageInstallTest,
+        "test_native_hip_consumer",
+        return_value=True,
+    )
     @patch("native_linux_package_install_test.subprocess.run")
-    def test_handles_called_process_error_when_querying_packages(self, mock_run):
+    def test_handles_called_process_error_when_querying_packages(
+        self, mock_run, _mock_native_consumer
+    ):
         # Test that run_basic_verification handles CalledProcessError when querying packages (continues, then passes if enough components).
         import subprocess
 
         mock_run.side_effect = [
             subprocess.CalledProcessError(1, "dpkg"),
             MagicMock(returncode=0, stdout=""),
-            MagicMock(returncode=0, stdout=""),
-            MagicMock(returncode=0, stdout=""),
         ]
         with tempfile.TemporaryDirectory() as d:
             (Path(d) / "bin").mkdir()
@@ -1045,16 +1057,19 @@ class RunBasicVerificationTest(unittest.TestCase):
             )
             self.assertTrue(t.run_basic_verification())
 
+    @patch.object(
+        native_linux_package_install_test.NativeLinuxPackageInstallTest,
+        "test_native_hip_consumer",
+        return_value=True,
+    )
     @patch("native_linux_package_install_test.subprocess.run")
-    def test_handles_rocminfo_timeout(self, mock_run):
+    def test_handles_rocminfo_timeout(self, mock_run, _mock_native_consumer):
         # Test that run_basic_verification handles rocminfo TimeoutExpired (warns but still passes if enough components).
         import subprocess
 
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="ii rocm 1.0\n"),
             subprocess.TimeoutExpired("rocminfo", 30),
-            MagicMock(returncode=0, stdout=""),
-            MagicMock(returncode=0, stdout=""),
         ]
         with tempfile.TemporaryDirectory() as d:
             (Path(d) / "bin").mkdir()
@@ -1069,8 +1084,17 @@ class RunBasicVerificationTest(unittest.TestCase):
             self.assertTrue(t.run_basic_verification())
 
     @patch("native_linux_package_install_test.subprocess.run")
-    def test_native_hip_consumer_clears_loader_environment(self, mock_run):
+    @patch("native_linux_package_install_test.ELFFile")
+    def test_native_hip_consumer_clears_loader_environment(
+        self, mock_elf_file, mock_run
+    ):
         mock_run.return_value = MagicMock(returncode=0, stdout="")
+        needed_tag = MagicMock()
+        needed_tag.entry.d_tag = "DT_NEEDED"
+        needed_tag.needed = "libamdhip64.so.7"
+        mock_dynamic = MagicMock()
+        mock_dynamic.iter_tags.return_value = [needed_tag]
+        mock_elf_file.return_value.get_section_by_name.return_value = mock_dynamic
         with tempfile.TemporaryDirectory() as d:
             (Path(d) / "bin").mkdir()
             (Path(d) / "bin" / "hipcc").write_text("")
@@ -1080,21 +1104,30 @@ class RunBasicVerificationTest(unittest.TestCase):
                 install_prefix=d,
             )
             with patch.dict(os.environ, {"LD_LIBRARY_PATH": "/custom/lib"}):
-                self.assertTrue(t.test_native_hip_consumer())
+                with patch("pathlib.Path.open", MagicMock()):
+                    self.assertTrue(t.test_native_hip_consumer())
 
         self.assertEqual(mock_run.call_count, 2)
+        compile_cmd = mock_run.call_args_list[0].args[0]
+        self.assertIn("-nogpulib", compile_cmd)
+        self.assertIn("-Wl,--no-as-needed", compile_cmd)
+        self.assertIn("-lamdhip64", compile_cmd)
         self.assertNotIn("LD_LIBRARY_PATH", mock_run.call_args_list[1].kwargs["env"])
 
     @patch("native_linux_package_install_test.subprocess.run")
-    def test_native_hip_consumer_returns_false_on_loader_failure(self, mock_run):
-        mock_run.side_effect = [
-            MagicMock(returncode=0, stdout=""),
-            subprocess.CalledProcessError(
-                127,
-                "native_hip_consumer",
-                output="libamdhip64.so.7: cannot open shared object file",
-            ),
-        ]
+    @patch("native_linux_package_install_test.ELFFile")
+    def test_native_hip_consumer_rejects_embedded_runpath(
+        self, mock_elf_file, mock_run
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        needed_tag = MagicMock()
+        needed_tag.entry.d_tag = "DT_NEEDED"
+        needed_tag.needed = "libamdhip64.so.7"
+        runpath_tag = MagicMock()
+        runpath_tag.entry.d_tag = "DT_RUNPATH"
+        mock_dynamic = MagicMock()
+        mock_dynamic.iter_tags.return_value = [needed_tag, runpath_tag]
+        mock_elf_file.return_value.get_section_by_name.return_value = mock_dynamic
         with tempfile.TemporaryDirectory() as d:
             (Path(d) / "bin").mkdir()
             (Path(d) / "bin" / "hipcc").write_text("")
@@ -1103,7 +1136,40 @@ class RunBasicVerificationTest(unittest.TestCase):
                 os_profile="ubuntu2404",
                 install_prefix=d,
             )
-            self.assertFalse(t.test_native_hip_consumer())
+            with patch("pathlib.Path.open", MagicMock()):
+                self.assertFalse(t.test_native_hip_consumer())
+
+        self.assertEqual(mock_run.call_count, 1)
+
+    @patch("native_linux_package_install_test.subprocess.run")
+    @patch("native_linux_package_install_test.ELFFile")
+    def test_native_hip_consumer_returns_false_on_loader_failure(
+        self, mock_elf_file, mock_run
+    ):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=""),
+            subprocess.CalledProcessError(
+                127,
+                "native_hip_consumer",
+                output="libamdhip64.so.7: cannot open shared object file",
+            ),
+        ]
+        needed_tag = MagicMock()
+        needed_tag.entry.d_tag = "DT_NEEDED"
+        needed_tag.needed = "libamdhip64.so.7"
+        mock_dynamic = MagicMock()
+        mock_dynamic.iter_tags.return_value = [needed_tag]
+        mock_elf_file.return_value.get_section_by_name.return_value = mock_dynamic
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "bin").mkdir()
+            (Path(d) / "bin" / "hipcc").write_text("")
+            t = native_linux_package_install_test.NativeLinuxPackageInstallTest(
+                repo_url="https://example.com",
+                os_profile="ubuntu2404",
+                install_prefix=d,
+            )
+            with patch("pathlib.Path.open", MagicMock()):
+                self.assertFalse(t.test_native_hip_consumer())
 
 
 class SetupGpgKeyTest(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Linux native packages create `/opt/rocm/lib` as an `update-alternatives` link to the active versioned library directory, but the path is not registered with the system dynamic loader. External native consumers therefore link successfully and then exit 127 on ROCm SONAMEs such as `libamdhip64.so.7` and `libhipblas.so.3` unless users set `LD_LIBRARY_PATH` or add application-specific RUNPATHs.

The user-reported downstream case is ggml-org/llama.cpp#25807. The same defect reproduces independently with a minimal no-GPU HIP consumer.

Fixes #6716.

This change is intentionally scoped to Linux DEB/RPM packages. It does not alter Python wheel initialization, tarball activation, arbitrary-prefix installs, or Windows DLL discovery.

## Technical Details

- Add package metadata for dynamic-loader paths and make the non-gfx `amdrocm-runtime` package own a versioned loader drop-in containing `/opt/rocm/lib`.
- Install the file as a DEB conffile and RPM `%config(noreplace)` file.
- Refresh `ldconfig` after runtime configuration changes and after `amdrocm-core` changes the existing alternatives.
- Keep RPM upgrades safe by preventing the old package's `%preun` from removing alternatives installed by the new package.
- Extend native package sanity testing with a no-CRT C shared consumer built by the packaged Clang and loaded from a clean Python subprocess with `LD_LIBRARY_PATH` removed.

The existing versioned layout and active-version contract remain unchanged:

```text
/opt/rocm/lib -> /etc/alternatives/rocm-lib -> /opt/rocm/core-X.Y/lib
```

## Test Plan

- Generate and build real DEB and RPM packages.
- Install, upgrade, remove, and purge/erase both package formats.
- Switch between two versioned alternatives and verify loader-cache selection.
- Run a no-GPU HIP consumer and an unmodified build reproducing ggml-org/llama.cpp#25807 before and after installing the generated loader payload.

## Test Result

- Package-generation tests: 25/25 passed.
- Loader-focused tests: 8/8 passed.
- Real DEB and RPM build/install/upgrade/remove lifecycle tests passed.
- Multi-version alternatives switching passed.
- Official native RPM install jobs passed on RHEL8, RHEL10, and SLES16; each built and loaded the no-CRT shared probe from the PR artifacts.
- Official ROCm 7.14 image, same binaries and environment:

| Phase | Minimal HIP consumer | llama.cpp #25807 reproducer |
|---|---:|---:|
| Before package | 127 (`libamdhip64.so.7`) | 127 (`libhipblas.so.3`) |
| After package install | 0 | 0 |
| After DEB remove | 0 (conffile retained) | 0 |
| After DEB purge | 127 | 127 |

The no-device message emitted by llama.cpp occurs after successful dynamic loading and does not affect this loader result.

## Submission Checklist

- [x] Targeted `main`.
- [x] Added regression coverage.
- [x] Validated DEB and RPM behavior, including upgrades and multi-version selection.
- [x] Linked the tracking issue.



