### PR TITLE
fix(ci): exclude hipsparselt tests for gfx120X (gfx1200, gfx1201)

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -382,17 +382,22 @@ test_matrix = {
         },
         "exclude_family": {
             # hipsparselt does not plan to support Linux and Windows gfx115X architectures
+            # hipsparselt does not support gfx120X (see TheRock#6473)
             "linux": [
                 "gfx1150",
                 "gfx1151",
                 "gfx1152",
                 "gfx1153",
+                "gfx1200",
+                "gfx1201",
             ],
             "windows": [
                 "gfx1150",
                 "gfx1151",
                 "gfx1152",
                 "gfx1153",
+                "gfx1200",
+                "gfx1201",
             ],
         },
     },


### PR DESCRIPTION
## Motivation

hipsparselt does not support gfx120X targets. Running the test job on gfx1200/gfx1201 runners causes failures that are expected and not actionable.

  - Adds `gfx1200` and `gfx1201` to the `exclude_family` list for the `hipsparselt` test component in `fetch_test_configurations.py`
  - Applies the exclusion for both `linux` and `windows` platforms

JIRA ID: https://github.com/ROCm/TheRock/issues/6473

 ## Changes

  **`build_tools/github_actions/fetch_test_configurations.py`**
  - Added `gfx1200` and `gfx1201` to `exclude_family["linux"]` and `exclude_family["windows"]` for the `hipsparselt` test matrix entry

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
