### PR TITLE
Drop hip-python from test requirements

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -20,7 +20,6 @@ joblib>=1.4.0
 numpy>=1.26.0
 filelock>=3.0.0
 syrupy==5.3.2
-hip-python; sys_platform != "win32"
 pytest-xdist>=1.32.0
 
 # libhipcxx test requirement


### PR DESCRIPTION
## Motivation

The `requirements-test.txt` pulls in `hip-python==7.2.2.562.43` which is not desired.

## Technical Details

PR #5529 added `hip-python` as a test dependencies, but following https://github.com/ROCm/TheRock/pull/5529#discussion_r3599390876 it can be dropped.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
