### PR TITLE
ci(rocprofiler-systems): Support --repeat until-pass:N CTest flag

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_runner.py
+++ b/build_tools/github_actions/test_executable_scripts/test_runner.py
@@ -171,6 +171,10 @@ environ_vars["ROCM_PATH"] = str(ROCM_PATH)
 #   instrumented-function listings). "--output-on-failure" is always passed, so
 #   failing tests still show their full output; only passing-test noise is
 #   suppressed.
+#
+# - ctest_repeat_until_pass: Int (default unset/off). When set to N, adds
+#   "--repeat until-pass:N" so ctest re-runs a failing test up to N times and
+#   only reports failure if it never passes.
 COMPONENT_OVERRIDES = {
     # ctest fragments live under libexec, not bin.
     # ctest_parallel pinned to 1: tests are pytest runs that parallelize
@@ -219,6 +223,9 @@ COMPONENT_OVERRIDES = {
         # function listings, etc). Drop -V to keep CI logs readable;
         # --output-on-failure still surfaces output for any failing test.
         "ctest_verbose": False,
+        # Depending on the load of the system when a test is ran, it could fail
+        # once and then pass on subsequent runs.
+        "ctest_repeat_until_pass": 3,
     },
     # rocwmma installs three independent CTestTestfile.cmake fragments:
     #   bin/rocwmma/             - per-target plain runs + regression_tests
@@ -527,6 +534,15 @@ def build_ctest_command(
 
     # Add common ctest parameters
     cmd.append("--output-on-failure")
+
+    # Retry flaky tests: re-run any failing test up to N times and only count
+    # it as a failure if it never passes. Off by default; opt in per component
+    # via COMPONENT_OVERRIDES[...]["ctest_repeat_until_pass"] = N.
+    repeat_until_pass = COMPONENT_OVERRIDES.get(test_component_job_name, {}).get(
+        "ctest_repeat_until_pass"
+    )
+    if repeat_until_pass:
+        cmd.extend(["--repeat", f"until-pass:{repeat_until_pass}"])
 
     # ctest_parallel_count is the module-level default (arch-tuned). Components
     # can override it via COMPONENT_OVERRIDES[...]["ctest_parallel_count"];


### PR DESCRIPTION
## Motivation

Fixes #6729

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

In the previous test implementation (where each component had a per component test file), we used `--repeat until-pass:3` as there was a possibility a test could fail for various reasons (current load on test machine, OpenMP discovering two basic blocks at the same time). Re-running the test would likely make it pass.

This behavior would match all our other CI workflows.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

 - Add support for `--repeat until-pass:N`, and then have `rocprofiler-systems` use `--repeat until-pass:3`

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Local. 
**Cannot be tested on CI**, as that would require an already failing `rocprofiler-systems` test.

## Test Result

<!-- Briefly summarize test outcomes. -->

Locally, when I force our component to only run a failing test (that only fails on my computer unless I run with `taskset 0-15`), I see the expected output:
```
Test project /home/rocm/therock-branches/therock-new-main/output-linux-portable/build/dist/rocm/share/rocprofiler-systems/tests
    Start   1: rocprofiler-systems-pytest-config
1/3 Test   #1: rocprofiler-systems-pytest-config ...   Passed    0.43 sec
    Start 217: mpi-binary-rewrite
2/3 Test #217: mpi-binary-rewrite ..................***Failed    2.50 sec
    Start 217: mpi-binary-rewrite
    Test #217: mpi-binary-rewrite ..................***Failed    3.17 sec
    Start 217: mpi-binary-rewrite
    Test #217: mpi-binary-rewrite ..................***Failed    2.06 sec
    Start 618: rocprofiler-systems-test-cleanup
3/3 Test #618: rocprofiler-systems-test-cleanup ....   Passed    0.17 sec

67% tests passed, 1 tests failed out of 3

Label Time Summary:
all               =   2.06 sec*proc (1 test)
binary_rewrite    =   2.06 sec*proc (1 test)
cleanup           =   0.17 sec*proc (1 test)
full              =   2.06 sec*proc (1 test)
global            =   0.60 sec*proc (2 tests)
mpi               =   2.06 sec*proc (1 test)
prerequisite      =   0.43 sec*proc (1 test)

Total Test time (real) =   8.36 sec

The following tests FAILED:
        217 - mpi-binary-rewrite (Failed)
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
