### PR TITLE
[profiler] Integrate profiler-hub as its own subproject and package

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -751,6 +751,14 @@ artifact_deps = ["rocprofiler-sdk", "openmpi"]
 feature_group = "PROFILER"
 disable_platforms = ["windows"]
 
+[artifacts.profiler-hub]
+artifact_group = "profiler-core"
+type = "target-neutral"
+artifact_deps = ["core-runtime", "base", "rocprofiler-sdk", "spdlog", "nlohmann-json"]
+feature_name = "PROFILER_HUB"
+feature_group = "PROFILER"
+disable_platforms = ["windows"]
+
 [artifacts.rocprofiler-systems]
 artifact_group = "profiler-apps"
 type = "target-neutral"

--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -1617,7 +1617,7 @@
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
     "Description_Short": "ROCm profiler tools ",
-    "Description_Long": "Contains rocprofiler-sdk, aqlprofile, roctracer and rocprof-trace-decoder",
+    "Description_Long": "Contains rocprofiler-sdk, aqlprofile, roctracer, rocprof-trace-decoder and profiler-hub",
     "Section": "devel",
     "Priority": "optional",
     "Group": "unknown",
@@ -1679,6 +1679,20 @@
             ]
           }
         ]
+      },
+      {
+        "Artifact": "profiler-hub",
+        "Artifact_Subdir": [
+          {
+            "Name": "profiler-hub",
+            "Components": [
+              "lib",
+              "dev",
+              "run",
+              "doc"
+            ]
+          }
+        ]
       }
     ],
 
@@ -1705,7 +1719,7 @@
     ],
     "Maintainer": "ROCm Dev Support <rocm-dev.support@amd.com>",
     "Description_Short": "ROCm profiler tools test",
-    "Description_Long": "Contains tests for rocprofiler-compute and rocprofiler-systems",
+    "Description_Long": "Contains tests for rocprofiler-compute, rocprofiler-systems and profiler-hub",
     "Section": "devel",
     "Priority": "optional",
     "Group": "unknown",
@@ -1751,6 +1765,17 @@
         "Artifact_Subdir": [
           {
             "Name": "aqlprofile",
+            "Components": [
+              "test"
+            ]
+          }
+        ]
+      },
+      {
+        "Artifact": "profiler-hub",
+        "Artifact_Subdir": [
+          {
+            "Name": "profiler-hub",
             "Components": [
               "test"
             ]

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -291,6 +291,63 @@ if(THEROCK_ENABLE_ROCPROFILER_COMPUTE)
 endif(THEROCK_ENABLE_ROCPROFILER_COMPUTE)
 
 ##############################################################################
+# profiler-hub
+# General-purpose, schema-versioned data storage library for profiling and
+# tracing tools, designed to be built and consumed standalone by any tool
+# that needs it.
+##############################################################################
+if(THEROCK_ENABLE_PROFILER_HUB)
+  set(_profiler_hub_build_deps therock-nlohmann-json therock-spdlog therock-fmt)
+  if(THEROCK_BUILD_TESTING)
+    list(APPEND _profiler_hub_build_deps therock-googletest)
+  endif()
+
+  therock_cmake_subproject_declare(profiler-hub
+    # profiler-hub is a pure host C++ library with no GPU/HIP code, so it
+    # does not require any AMDGPU targets to be selected.
+    DISABLE_AMDGPU_TARGETS
+    EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/profilers/profiler-hub"
+    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/profiler-hub"
+    BACKGROUND_BUILD
+    CMAKE_ARGS
+      -DPROFILER_HUB_BUILD_TESTS=${THEROCK_BUILD_TESTING}
+      -DPROFILER_HUB_BUILD_BENCHMARKS=OFF
+    CMAKE_INCLUDES
+      therock_explicit_finders.cmake
+    BUILD_DEPS
+      ${_profiler_hub_build_deps}
+    RUNTIME_DEPS
+      rocprofiler-sdk
+      ${THEROCK_BUNDLED_SQLITE3}
+    INTERFACE_INCLUDE_DIRS
+      include
+    INTERFACE_LINK_DIRS
+      lib
+  )
+  therock_cmake_subproject_provide_package(profiler-hub profiler-hub lib/cmake/profiler-hub)
+  therock_cmake_subproject_activate(profiler-hub)
+
+  therock_test_validate_shared_lib(PATH ${CMAKE_CURRENT_BINARY_DIR}/profiler-hub/dist/lib
+    LIB_NAMES
+      libprofiler-hub.so
+  )
+
+  therock_provide_artifact(profiler-hub
+    TARGET_NEUTRAL
+    DESCRIPTOR artifact-profiler-hub.toml
+    COMPONENTS
+      dbg
+      dev
+      doc
+      lib
+      run
+      test
+    SUBPROJECT_DEPS
+      profiler-hub
+  )
+endif(THEROCK_ENABLE_PROFILER_HUB)
+
+##############################################################################
 # rocprofiler-systems
 ##############################################################################
 if(THEROCK_ENABLE_ROCPROFSYS)

--- a/profiler/artifact-profiler-hub.toml
+++ b/profiler/artifact-profiler-hub.toml
@@ -1,0 +1,20 @@
+# profiler-hub
+[components.lib."profiler/profiler-hub/stage"]
+include = [
+  "lib/libprofiler-hub.so*",
+]
+# profiler-hub ships no runtime executables or runtime data files.
+# 'run' has no default include patterns, so it is omitted entirely here
+# rather than declared bare - a bare entry would act as a catch-all and
+# claim the headers/static-lib/cmake files meant for 'dev' (see
+# build_tools/_therock_utils/artifact_builder.py ComponentDefaults("run", ...)).
+# Debug split is handled by the strip step; no extra files belong here.
+[components.dbg."profiler/profiler-hub/stage"]
+[components.dev."profiler/profiler-hub/stage"]
+include = [
+  "include/profiler-hub/**",
+  "lib/libprofiler-hub.a",
+  "lib/cmake/profiler-hub/**",
+]
+[components.doc."profiler/profiler-hub/stage"]
+[components.test."profiler/profiler-hub/stage"]


### PR DESCRIPTION
## Motivation
profiler-hub is a general-purpose, schema-versioned data storage library for profiling and tracing tools: it defines a common on-disk schema and a writer/reader API for storing trace, PMC, and profiling data, so multiple independent tools can share a single storage format instead of each implementing their own. It is designed to be built and consumed on its own, not as an implementation detail of any single tool.

TheRock currently only builds and packages profiling libraries as part of whichever specific tool happens to consume them. This PR gives profiler-hub its own subproject and its own package, so it is built and shipped as a standalone artifact - available to any current or future consumer, not tied to one. This PR intentionally does not touch rocprofiler-systems or any other consumer; wiring an actual consumer to profiler-hub is separate, follow-on work.

JIRA ID: ROCPDSNA-73

## Technical Details
- Declares `profiler-hub` as its own CMake subproject in `profiler/CMakeLists.txt`, gated by a new `THEROCK_ENABLE_PROFILER_HUB` feature flag, built from the `rocm-systems` submodule's `profilers/profiler-hub` subdirectory. Declares `DISABLE_AMDGPU_TARGETS` since profiler-hub is pure host C++ with no GPU/HIP code - without it, any CI stage building with zero AMDGPU targets selected hits a hard CMake configure error.
- Adds a `BUILD_TOPOLOGY.toml` artifact entry (`profiler-core` group).
- Adds `profiler-hub` as its own standalone deb/rpm package entry in `build_tools/packaging/linux/package.json`'s `amdrocm-profiler-base` (lib/dev/run/doc) and `amdrocm-profiler-test` (test) packages, so the package is produced regardless of which consumer is also selected.
- Bumps the `rocm-systems` submodule to `0e57a383b0` - the exact commit (rocm-systems PR #8610) that fixes a schema-API signature drift between profiler-hub and rocprofiler-sdk-rocpd (`rocpd_sql_load_schema` grew a `schema_version` parameter via #5267; profiler-hub's call site wasn't updated until #8610). Anything before this commit fails to compile profiler-hub against rocprofiler-sdk-rocpd. Pinned to this exact commit rather than a later `develop` HEAD, to keep the bump minimal and reproducible.

**Note on this bump:** `systems-assistant[bot]` already has open bump PRs (#6722, #6731) that will move `main`'s `rocm-systems` pin past this fix anyway. This commit's submodule change is a temporary, self-contained stopgap so this PR doesn't depend on the bot's merge timing - it'll be dropped from this PR (rebased to pick up whatever `main` has by then) once one of those bot PRs lands.

## Test Plan
- `ninja profiler-hub` builds standalone, producing `libprofiler-hub.so.0.1.0`, without building or touching `rocprofiler-systems`, with a clean configure and no CMake warnings.
- Verified configure succeeds with zero AMDGPU targets selected (the actual CI failure this PR fixes: the `compiler-runtime` stage builds with no GPU targets, and profiler-hub was initially missing `DISABLE_AMDGPU_TARGETS`).
- Rebuilt the `profiler-hub` artifact components (`lib`/`dev`/`run`/`doc`/`dbg`/`test`) and confirmed correct file placement (shared lib in `lib`, headers/static lib/cmake package config in `dev`, others empty as expected).
- Built an actual `.deb` via `build_tools/packaging/linux/build_package.py --pkg-names amdrocm-profiler-base` and confirmed via `dpkg-deb --contents` that `libprofiler-hub.so.0.1.0`, `libprofiler-hub.a`, headers, and the CMake package config are present in the built package.
- `package.json` validated with `python3 -m json.tool`; `BUILD_TOPOLOGY.toml` and `artifact-profiler-hub.toml` validated with `tomllib`.

## Test Result
All of the above passed locally against a from-scratch reconfigure and rebuild. CI results pending on this PR.

