### PR TITLE
fix(ml-libs): remove flatc and header-only deps from hipDNN runtime packaging

### DIFF
--- a/build_tools/packaging/linux/package.json
+++ b/build_tools/packaging/linux/package.json
@@ -2695,18 +2695,6 @@
             ]
           }
         ]
-      },
-      {
-        "Artifact": "flatbuffers",
-        "Artifact_Gfxarch": "False",
-        "Artifact_Subdir": [
-          {
-            "Name": "flatbuffers",
-            "Components": [
-              "run"
-            ]
-          }
-        ]
       }
     ],
 

--- a/ml-libs/CMakeLists.txt
+++ b/ml-libs/CMakeLists.txt
@@ -112,10 +112,10 @@ if(THEROCK_ENABLE_HIPDNN)
       therock-googletest
       therock-fmt
       therock-spdlog
-    RUNTIME_DEPS
-      hip-clr
       therock-flatbuffers
       therock-nlohmann-json
+    RUNTIME_DEPS
+      hip-clr
     TEST_SUBPROJECTS
       miopenprovider
       hipblasltprovider
@@ -172,11 +172,11 @@ if(THEROCK_ENABLE_HIPDNN_INTEGRATION_TESTS)
       amd-hip
     BUILD_DEPS
       therock-googletest
+      therock-flatbuffers
+      therock-nlohmann-json
     RUNTIME_DEPS
       hip-clr
       hipDNN
-      therock-flatbuffers
-      therock-nlohmann-json
     TEST_SUBPROJECTS
       miopenprovider
   )

--- a/third-party/flatbuffers/CMakeLists.txt
+++ b/third-party/flatbuffers/CMakeLists.txt
@@ -27,7 +27,6 @@ therock_provide_artifact(flatbuffers
   DESCRIPTOR artifact-flatbuffers.toml
   COMPONENTS
     dev
-    run
   SUBPROJECT_DEPS
     therock-flatbuffers
 )

--- a/third-party/flatbuffers/artifact-flatbuffers.toml
+++ b/third-party/flatbuffers/artifact-flatbuffers.toml
@@ -1,7 +1,6 @@
 # flatbuffers
-[components.run."third-party/flatbuffers/stage"]
+[components.dev."third-party/flatbuffers/stage"]
 include = [
   "bin/flatc",
   "bin/flatc.exe",
 ]
-[components.dev."third-party/flatbuffers/stage"]


### PR DESCRIPTION
## Summary

hipDNN's third-party dependencies (flatbuffers and nlohmann-json) were
incorrectly classified as `RUNTIME_DEPS`, co-locating their headers into
hipDNN's runtime dist tree. Additionally, the flatbuffers artifact shipped
the `flatc` schema compiler in its `run` component, installing a build-time
tool into runtime deployments. This PR corrects both misclassifications and
removes flatc from the Linux `amdrocm-dnn` runtime package.

## Risk Assessment

Risk level 2. Packaging and dependency classification change only — no
runtime behavior, source code, or public API changes. Blast radius is
limited to artifact assembly and Linux native package composition.

## Related

- JIRA ID : ALMIOPEN-2336
- Issue: https://github.com/ROCm/TheRock/issues/6649

## Device / Architecture Coverage

Architecture-independent packaging change. No kernel or device code is
modified. Standard PR CI is sufficient; a full architecture sweep is not
required.

## Testing Summary

- Static analysis of `build_tools/_therock_utils/artifact_builder.py`
  component glob patterns confirms `bin/flatc` is captured by the explicit
  `dev` include added to `artifact-flatbuffers.toml`.
- `ComponentScanner` smoke test run locally against a mock flatbuffers stage
  dir: all files including `bin/flatc` and `bin/flatc.exe` assigned to `dev`.
- `test:hipdnn` and `test:hipdnn_install` CI lanes targeted in multi-arch CI
  to verify artifact consumption on Linux and Windows.

## Testing Checklist

- [x] ComponentScanner smoke test - `python build_tools/fileset_tool.py` (mock stage) - Status: Passed
- [x] test:hipdnn - multi_arch_ci.yml - Devices: gfx94X, gfx90a, gfx110X, gfx120X, gfx950, gfx1153 (Linux + Windows) - Status: Passed - Link: https://github.com/ROCm/TheRock/actions/runs/29766060874
- [x] test:hipdnn_install - multi_arch_ci.yml - Devices: gfx94X, gfx90a, gfx110X, gfx120X, gfx950, gfx1153 (Linux + Windows) - Status: Passed - Link: https://github.com/ROCm/TheRock/actions/runs/29766060874
- [x] Raw artifact inspection (Linux gfx94X, Windows gfx110X) - flatbuffers_run absent; hipdnn_run contains no third-party headers - Status: Passed
- [x] Wheel artifact inspection (rocm_sdk_core, rocm_sdk_devel, rocm_sdk_libraries) - no flatbuffers or nlohmann entries - Status: Passed
- [ ] PR CI - GitHub PR checks - Status: Pending

## Flags / Guardrails

None. This is a packaging correction with no behavior flag needed.

## Adjacent Tests Considered

`test:hipdnn_install` specifically exercises `find_package` consumption of
the installed hipDNN artifact, which is the primary surface this change
affects. `test:hipdnn` provides general regression coverage.

## Risk Acceptance / Waivers

**W-BUILD (M1)**: Packaging-only defect fix. A regression test for artifact
component membership requires a full TheRock artifact build pipeline with no
unit-testable surface. Verification is provided by static analysis of the
component glob logic and the `hipdnn_install` CI lane.

## Technical Changes

- `third-party/flatbuffers/artifact-flatbuffers.toml`: Remove `run`
  component; add explicit `bin/flatc`, `bin/flatc.exe` includes to `dev`
  so `flatc` is available for build consumers but not shipped in runtime
  packages.
- `third-party/flatbuffers/CMakeLists.txt`: Drop `run` from
  `therock_provide_artifact` COMPONENTS to match descriptor.
- `ml-libs/CMakeLists.txt`: Reclassify `therock-flatbuffers` and
  `therock-nlohmann-json` from `RUNTIME_DEPS` to `BUILD_DEPS` for `hipDNN`
  and `hipdnn_integration_tests`.
- `build_tools/packaging/linux/package.json`: Remove flatbuffers `run`
  component from `amdrocm-dnn` runtime package.