### PR TITLE
[deprecate-hipcc] Replace hipcc with amdclang++ for libhipcxx

### DIFF
--- a/build_tools/github_actions/fetch_test_configurations.py
+++ b/build_tools/github_actions/fetch_test_configurations.py
@@ -634,12 +634,12 @@ test_matrix = {
             "linux": 1,
         },
     },
-    # libhipcxx hipcc tests
-    "libhipcxx_hipcc": {
-        "job_name": "libhipcxx_hipcc",
+    # libhipcxx amdclang++ tests (formerly libhipcxx_hipcc)
+    "libhipcxx_amdclang": {
+        "job_name": "libhipcxx_amdclang",
         "fetch_artifact_args": "--libhipcxx --tests",
         "timeout_minutes": 30,
-        "test_script": f"python {_get_script_path('test_libhipcxx_hipcc.py')}",
+        "test_script": f"python {_get_script_path('test_libhipcxx_amdclang.py')}",
         "platform": ["linux", "windows"],
         "total_shards_dict": {
             "linux": 1,

--- a/build_tools/github_actions/test_executable_scripts/libhipcxx_utils.py
+++ b/build_tools/github_actions/test_executable_scripts/libhipcxx_utils.py
@@ -33,7 +33,9 @@ def _try_offload_arch(therock_build_dir: str, file_ending: str):
                     )
                 return last
         if result.returncode != 0:
-            logging.warning(f"offload-arch failed (exit {result.returncode}): {result.stderr}")
+            logging.warning(
+                f"offload-arch failed (exit {result.returncode}): {result.stderr}"
+            )
     except FileNotFoundError:
         logging.warning("offload-arch not found")
     return None

--- a/build_tools/github_actions/test_executable_scripts/libhipcxx_utils.py
+++ b/build_tools/github_actions/test_executable_scripts/libhipcxx_utils.py
@@ -66,6 +66,14 @@ def get_gpu_architecture_portable(therock_build_dir):
     1. offload-arch (fast, but fails on some MxGPU virtual GPUs)
     2. rocminfo (uses HSA runtime)
 
+    If AMDGPU_TARGETS is set in the environment (as it is in CI), validates
+    the detected arch against it. MxGPU virtual GPUs can cause offload-arch
+    to return an incorrect default (e.g. gfx906) even when the actual GPU
+    is different (e.g. gfx1101). If the detected arch is not in AMDGPU_TARGETS,
+    falls back to compiling for all targets so the binary runs on whatever
+    GPU is present. If detection fails entirely (None), leaves it as None so
+    callers can apply their own fallback (e.g. --offload-arch=native).
+
     Note: we deliberately do NOT attempt to detect the GPU by compiling
     and running a HIP program. On MxGPU virtual GPUs, forcefully killing
     a process that has initialized the HIP runtime (e.g. via a timeout)
@@ -73,17 +81,26 @@ def get_gpu_architecture_portable(therock_build_dir):
     subsequent tests (e.g. rocblas) that need GPU access.
 
     Returns:
-        str: The gfx architecture of the running system, or None if not available.
+        str: The gfx architecture (or semicolon-separated list of targets),
+             or None if not available.
     """
     therock_build_dir = str(therock_build_dir)
     file_ending = ".exe" if platform.system() == "Windows" else ""
 
     arch = _try_offload_arch(therock_build_dir, file_ending)
-    if arch:
-        return arch
+    if not arch:
+        arch = _try_rocminfo(therock_build_dir, file_ending)
 
-    arch = _try_rocminfo(therock_build_dir, file_ending)
-    if arch:
-        return arch
+    # Validate against AMDGPU_TARGETS when set (authoritative in CI).
+    # Only apply when detection returned something — if arch is None,
+    # leave it for the caller to handle (e.g. via --offload-arch=native).
+    amdgpu_targets = os.getenv("AMDGPU_TARGETS")
+    if amdgpu_targets and arch is not None:
+        valid_targets = amdgpu_targets.split(",")
+        if arch not in valid_targets:
+            arch = ";".join(valid_targets)
+            logging.info(
+                f"++ GPU arch not in AMDGPU_TARGETS, compiling for all targets: {arch}"
+            )
 
-    return None
+    return arch

--- a/build_tools/github_actions/test_executable_scripts/libhipcxx_utils.py
+++ b/build_tools/github_actions/test_executable_scripts/libhipcxx_utils.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import re
 import subprocess
 import sys
 import logging
@@ -16,28 +17,73 @@ def prepend_env_path(env: dict, var_name: str, new_path: str):
         env[var_name] = new_path
 
 
+def _try_offload_arch(therock_build_dir: str, file_ending: str):
+    """Try offload-arch; return gfxNNNN string or None."""
+    executable = therock_build_dir + f"/lib/llvm/bin/offload-arch{file_ending}"
+    try:
+        result = subprocess.run([executable], capture_output=True, text=True)
+        lines = [l.strip() for l in result.stdout.strip().split("\n") if l.strip()]
+        logging.info(f"DEBUG offload-arch:{lines}")
+        if lines:
+            last = lines[-1]
+            if last.startswith("gfx"):
+                if result.returncode != 0:
+                    logging.warning(
+                        f"offload-arch exited {result.returncode} but returned '{last}'; using it"
+                    )
+                return last
+        if result.returncode != 0:
+            logging.warning(f"offload-arch failed (exit {result.returncode}): {result.stderr}")
+    except FileNotFoundError:
+        logging.warning("offload-arch not found")
+    return None
+
+
+def _try_rocminfo(therock_build_dir: str, file_ending: str):
+    """Try rocminfo (uses HSA runtime, works on MxGPU); return gfxNNNN or None."""
+    executable = therock_build_dir + f"/bin/rocminfo{file_ending}"
+    try:
+        result = subprocess.run([executable], capture_output=True, text=True)
+        # rocminfo output contains lines like:  Name:                    gfx1101
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if line.startswith("Name:"):
+                match = re.search(r"gfx\d+", line)
+                if match:
+                    arch = match.group(0)
+                    logging.info(f"DEBUG rocminfo detected: {arch}")
+                    return arch
+    except FileNotFoundError:
+        logging.warning("rocminfo not found")
+    return None
+
+
 def get_gpu_architecture_portable(therock_build_dir):
     """
-    Executes rocm_agent_enumerator for Linux and offload-arch for Windows and returns last line of the output.
+    Detect the GPU gfxNNNN architecture string.
+
+    Tries multiple detection methods in order:
+    1. offload-arch (fast, but fails on some MxGPU virtual GPUs)
+    2. rocminfo (uses HSA runtime)
+
+    Note: we deliberately do NOT attempt to detect the GPU by compiling
+    and running a HIP program. On MxGPU virtual GPUs, forcefully killing
+    a process that has initialized the HIP runtime (e.g. via a timeout)
+    can leave the virtual GPU context in a locked state, breaking
+    subsequent tests (e.g. rocblas) that need GPU access.
 
     Returns:
         str: The gfx architecture of the running system, or None if not available.
     """
     therock_build_dir = str(therock_build_dir)
     file_ending = ".exe" if platform.system() == "Windows" else ""
-    try:
-        executable = therock_build_dir + f"/lib/llvm/bin/offload-arch{file_ending}"
-        result = subprocess.run(
-            [executable], capture_output=True, text=True, check=True
-        )
-        lines = result.stdout.strip().split("\n")
-        logging.info(f"DEBUG:{lines}")
-        return lines[-1]
 
-    except subprocess.CalledProcessError as e:
-        print(f"Error executing offload-arch: {e}", file=sys.stderr)
-        print(f"stderr: {e.stderr}", file=sys.stderr)
-        return None
-    except FileNotFoundError:
-        print("Error: offload-arch command not found", file=sys.stderr)
-        return None
+    arch = _try_offload_arch(therock_build_dir, file_ending)
+    if arch:
+        return arch
+
+    arch = _try_rocminfo(therock_build_dir, file_ending)
+    if arch:
+        return arch
+
+    return None

--- a/build_tools/github_actions/test_executable_scripts/test_libhipcxx_amdclang.py
+++ b/build_tools/github_actions/test_executable_scripts/test_libhipcxx_amdclang.py
@@ -25,25 +25,6 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 gpu_arch = get_gpu_architecture_portable(OUTPUT_ARTIFACTS_DIR)
 logging.info(f"++ Detected GPU architecture: {gpu_arch}")
 
-# AMDGPU_TARGETS is set authoritatively by CI. MxGPU virtual GPUs can cause
-# offload-arch to return an incorrect default (e.g. gfx906) even when the
-# actual GPU is different (e.g. gfx1101). If the detected arch is not in
-# AMDGPU_TARGETS, fall back to the first entry in AMDGPU_TARGETS.
-amdgpu_targets = os.getenv("AMDGPU_TARGETS")
-if amdgpu_targets and gpu_arch is not None:
-    # Only apply the AMDGPU_TARGETS check when offload-arch returned something.
-    # If gpu_arch is None (offload-arch failed entirely), leave it as None so
-    # cmake's enable_language(HIP) auto-detects via the HIP runtime, which
-    # works correctly on MxGPU virtual GPUs even when offload-arch doesn't.
-    valid_targets = amdgpu_targets.split(",")
-    if gpu_arch not in valid_targets:
-        # offload-arch returned a wrong arch (e.g. gfx906); compile for all
-        # AMDGPU_TARGETS so the binary runs on whichever GPU is present.
-        gpu_arch = ";".join(valid_targets)
-        logging.info(
-            f"++ GPU arch not in AMDGPU_TARGETS, compiling for all targets: {gpu_arch}"
-        )
-
 
 # Load ROCm version from version.json
 def load_rocm_version() -> str:

--- a/build_tools/github_actions/test_executable_scripts/test_libhipcxx_amdclang.py
+++ b/build_tools/github_actions/test_executable_scripts/test_libhipcxx_amdclang.py
@@ -25,6 +25,25 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 gpu_arch = get_gpu_architecture_portable(OUTPUT_ARTIFACTS_DIR)
 logging.info(f"++ Detected GPU architecture: {gpu_arch}")
 
+# AMDGPU_TARGETS is set authoritatively by CI. MxGPU virtual GPUs can cause
+# offload-arch to return an incorrect default (e.g. gfx906) even when the
+# actual GPU is different (e.g. gfx1101). If the detected arch is not in
+# AMDGPU_TARGETS, fall back to the first entry in AMDGPU_TARGETS.
+amdgpu_targets = os.getenv("AMDGPU_TARGETS")
+if amdgpu_targets and gpu_arch is not None:
+    # Only apply the AMDGPU_TARGETS check when offload-arch returned something.
+    # If gpu_arch is None (offload-arch failed entirely), leave it as None so
+    # cmake's enable_language(HIP) auto-detects via the HIP runtime, which
+    # works correctly on MxGPU virtual GPUs even when offload-arch doesn't.
+    valid_targets = amdgpu_targets.split(",")
+    if gpu_arch not in valid_targets:
+        # offload-arch returned a wrong arch (e.g. gfx906); compile for all
+        # AMDGPU_TARGETS so the binary runs on whichever GPU is present.
+        gpu_arch = ";".join(valid_targets)
+        logging.info(
+            f"++ GPU arch not in AMDGPU_TARGETS, compiling for all targets: {gpu_arch}"
+        )
+
 
 # Load ROCm version from version.json
 def load_rocm_version() -> str:
@@ -85,30 +104,37 @@ is_linux = platform.system() == "Linux"
 
 compiler_ext = ".exe" if is_windows else ""
 
-HIPCC_BINARY_NAME = f"hipcc{compiler_ext}"
-
 HIP_COMPILER_ROCM_ROOT = OUTPUT_ARTIFACTS_PATH
+
+# On Windows amdclang++ lives in lib/llvm/bin/, not bin/.
 if is_windows:
-    environ_vars["HIPCXX"] = str(
-        OUTPUT_ARTIFACTS_PATH / "lib" / "llvm" / "bin" / "amdclang++.exe"
-    )
+    AMDCLANGPP = OUTPUT_ARTIFACTS_PATH / "lib" / "llvm" / "bin" / "amdclang++.exe"
+    environ_vars["HIPCXX"] = str(AMDCLANGPP)
     print("HIPCXX:", environ_vars["HIPCXX"], str(OUTPUT_ARTIFACTS_PATH))
+else:
+    AMDCLANGPP = THEROCK_BIN_PATH / "amdclang++"
 
 # Configure with CMake
 cmd = [
     "cmake",
     f"-DCMAKE_PREFIX_PATH={OUTPUT_ARTIFACTS_PATH}",
-    f"-DHIP_HIPCC_EXECUTABLE={(THEROCK_BIN_PATH / HIPCC_BINARY_NAME).as_posix()}",
-    f"-DCMAKE_CXX_COMPILER={(THEROCK_BIN_PATH / HIPCC_BINARY_NAME)}",
-    f"-DCMAKE_HIP_COMPILER_ROCM_ROOT={HIP_COMPILER_ROCM_ROOT.as_posix()}",
-    f"-DCMAKE_HIP_ARCHITECTURES={gpu_arch}",
+    f"-DCMAKE_CXX_COMPILER={AMDCLANGPP}",
+    "-GNinja",
+    "..",
 ]
+
+# Pass the detected GPU arch, or fall back to "native" which tells
+# amdclang++ to query the HIP runtime at compile time. This handles
+# MxGPU virtual GPUs on Windows where offload-arch.exe fails but the
+# HIP runtime correctly identifies the GPU (e.g. gfx1101).
+if gpu_arch is not None:
+    cmd.append(f"-DCMAKE_HIP_ARCHITECTURES={gpu_arch}")
+else:
+    cmd.append("-DCMAKE_HIP_ARCHITECTURES=native")
 
 # Add rc compiler for windows
 if is_windows:
     cmd.append("-DCMAKE_RC_COMPILER=rc.exe")
-
-cmd.extend(["-GNinja", ".."])
 
 logging.info(f"++ Exec [{os.getcwd()}]$ {shlex.join(cmd)}")
 subprocess.run(cmd, check=True, env=environ_vars)
@@ -122,9 +148,8 @@ else:
     cmd = [
         "bash",
         "../ci/test_libhipcxx.sh",
-        "-cmake-options",
-        f"-DHIP_HIPCC_EXECUTABLE={THEROCK_BIN_PATH / HIPCC_BINARY_NAME} -DCMAKE_HIP_COMPILER_ROCM_ROOT={HIP_COMPILER_ROCM_ROOT} -DCMAKE_HIP_ARCHITECTURES={gpu_arch}",
     ]
+
 logging.info(f"++ Exec [{os.getcwd()}]$ {shlex.join(cmd)}")
 
 subprocess.run(cmd, check=True, env=environ_vars)

--- a/build_tools/github_actions/test_executable_scripts/test_libhipcxx_hiprtc.py
+++ b/build_tools/github_actions/test_executable_scripts/test_libhipcxx_hiprtc.py
@@ -85,7 +85,7 @@ is_linux = platform.system() == "Linux"
 
 compiler_ext = ".exe" if is_windows else ""
 
-HIPCC_BINARY_NAME = f"hipcc{compiler_ext}"
+AMDCLANGPP_BINARY_NAME = f"amdclang++{compiler_ext}"
 
 HIP_COMPILER_ROCM_ROOT = OUTPUT_ARTIFACTS_PATH
 if is_windows:
@@ -98,8 +98,7 @@ if is_windows:
 cmd = [
     "cmake",
     f"-DCMAKE_PREFIX_PATH={OUTPUT_ARTIFACTS_PATH}",
-    f"-DHIP_HIPCC_EXECUTABLE={(THEROCK_BIN_PATH / HIPCC_BINARY_NAME).as_posix()}",
-    f"-DCMAKE_CXX_COMPILER={THEROCK_BIN_PATH / HIPCC_BINARY_NAME}",
+    f"-DCMAKE_CXX_COMPILER={THEROCK_BIN_PATH / AMDCLANGPP_BINARY_NAME}",
     f"-DCMAKE_HIP_COMPILER_ROCM_ROOT={HIP_COMPILER_ROCM_ROOT.as_posix()}",
     f"-DCMAKE_HIP_ARCHITECTURES={gpu_arch}",
     "-DLIBHIPCXX_TEST_WITH_HIPRTC=ON",
@@ -125,7 +124,7 @@ else:
         "bash",
         "../ci/hiprtc_libhipcxx.sh",
         "-cmake-options",
-        f"-DHIP_HIPCC_EXECUTABLE={THEROCK_BIN_PATH / HIPCC_BINARY_NAME} -DCMAKE_HIP_COMPILER_ROCM_ROOT={HIP_COMPILER_ROCM_ROOT} -DCMAKE_HIP_ARCHITECTURES={gpu_arch}",
+        f"-DCMAKE_CXX_COMPILER={THEROCK_BIN_PATH / AMDCLANGPP_BINARY_NAME} -DCMAKE_HIP_COMPILER_ROCM_ROOT={HIP_COMPILER_ROCM_ROOT} -DCMAKE_HIP_ARCHITECTURES={gpu_arch}",
     ]
 
 logging.info(f"++ Exec [{os.getcwd()}]$ {shlex.join(cmd)}")

--- a/docs/development/hipcc_deprecation.md
+++ b/docs/development/hipcc_deprecation.md
@@ -1,0 +1,148 @@
+# hipcc Deprecation Guide
+
+`hipcc` is a compiler wrapper that historically injected HIP-specific flags
+(include paths, device library paths, GPU target flags, etc.) before invoking
+`clang++`. TheRock is deprecating `hipcc` in favor of calling `amdclang++`
+directly, which is a symlink to the same underlying clang binary with the HIP
+toolchain configured by CMake.
+
+This document explains why the change is being made, what the equivalents are,
+and how to migrate your project.
+
+## Why deprecate hipcc?
+
+- **Redundant indirection.** The `amd-hip` CMake toolchain already injects
+  `--hip-path`, `--hip-device-lib-path`, and all other necessary flags via
+  `CMAKE_CXX_FLAGS_INIT`. hipcc was doing the same thing via shell script logic,
+  creating two overlapping mechanisms for the same job.
+- **CMake-native HIP support.** CMake has had first-class HIP language support
+  since CMake 3.21. Projects using `enable_language(HIP)` or
+  `set_source_files_properties(... PROPERTIES LANGUAGE HIP)` work correctly with
+  `CMAKE_HIP_COMPILER` pointing to `amdclang++` directly — no wrapper needed.
+- **Transparency.** Direct `amdclang++` invocations produce cleaner build logs,
+  better IDE integration (via `compile_commands.json`), and easier debugging of
+  compiler flags.
+- **hipconfig.** `hipconfig` is the companion introspection tool bundled with
+  `hipcc`. Callers that used `hipconfig --version`, `--cxxflags`, or `--ldflags`
+  should migrate to CMake-native equivalents (see below).
+
+## What changed in TheRock
+
+- The `amd-hip` compiler toolchain now explicitly sets `CMAKE_HIP_COMPILER` to
+  `amdclang++` (our built clang) in the generated `_toolchain.cmake` file.
+- `--rtlib=compiler-rt --unwindlib=libgcc` linker flags are now injected via
+  `CMAKE_EXE_LINKER_FLAGS_INIT` and `CMAKE_SHARED_LINKER_FLAGS_INIT`, replacing
+  the equivalent flags hipcc provided.
+- `hipcc` is no longer listed as a `COMPILER_TOOLCHAIN` or `RUNTIME_DEPS` entry
+  for subprojects that use the `amd-hip` toolchain.
+- The test script `test_libhipcxx_hipcc.py` has been renamed to
+  `test_libhipcxx_amdclang.py` and updated to use `amdclang++` directly.
+
+> **Note:** The `hipcc` binary is still built as part of TheRock for now as a
+> compatibility shim. This will be removed in a future PR once all downstream
+> consumers have migrated.
+
+## Flag equivalency table
+
+The following table maps hipcc's implicit behavior to the explicit flags or
+CMake variables that replace it when using `amdclang++` directly.
+
+| hipcc behavior | amdclang++ / CMake equivalent |
+|---|---|
+| Injects `-I<hip>/include` | `--hip-path=<path>` (set in `CMAKE_CXX_FLAGS_INIT`) |
+| Injects `--hip-device-lib-path=<path>` | `--hip-device-lib-path=<path>` (set in `CMAKE_CXX_FLAGS_INIT`) |
+| Sets HIP compiler in CMake | `CMAKE_HIP_COMPILER` set to `amdclang++` in toolchain |
+| Adds `--rtlib=compiler-rt --unwindlib=libgcc` | Added to `CMAKE_EXE_LINKER_FLAGS_INIT` and `CMAKE_SHARED_LINKER_FLAGS_INIT` |
+| Auto-detects GPU targets via `rocm_agent_enumerator` | `AMDGPU_TARGETS` / `CMAKE_HIP_ARCHITECTURES` set by TheRock super-project |
+| Defines `-D__HIP_PLATFORM_AMD__` | Added by `hip-config.cmake` target properties via `find_package(hip)` |
+
+## Migrating a CMake project
+
+### Compiler
+
+Replace any explicit `CMAKE_CXX_COMPILER=hipcc` with `CMAKE_CXX_COMPILER=amdclang++`:
+
+```cmake
+# Before
+cmake -DCMAKE_CXX_COMPILER=hipcc ...
+
+# After
+cmake -DCMAKE_CXX_COMPILER=amdclang++ ...
+```
+
+If your project uses CMake's native HIP language support, set
+`CMAKE_HIP_COMPILER` instead of (or in addition to) `CMAKE_CXX_COMPILER`:
+
+```cmake
+cmake -DCMAKE_HIP_COMPILER=amdclang++ ...
+```
+
+When building inside TheRock, this is handled automatically by the `amd-hip`
+toolchain — you do not need to set these manually.
+
+### HIP_HIPCC_EXECUTABLE
+
+Some projects (including older versions of libhipcxx) use the
+`HIP_HIPCC_EXECUTABLE` CMake variable to locate hipcc. Replace this with the
+direct path to `amdclang++`:
+
+```cmake
+# Before
+-DHIP_HIPCC_EXECUTABLE=/path/to/rocm/bin/hipcc
+
+# After
+# Not needed — use CMAKE_HIP_COMPILER or CMAKE_CXX_COMPILER instead
+```
+
+### hipconfig introspection
+
+Projects that called `hipconfig` to retrieve version or path information should
+migrate to CMake-native equivalents:
+
+| hipconfig invocation | CMake equivalent |
+|---|---|
+| `hipconfig --version` | `hip_VERSION` (set by `find_package(hip REQUIRED)`) |
+| `hipconfig --hip-version` | `hip_VERSION` |
+| `hipconfig --cxxflags` | Use `hip::host` and `hip::device` imported targets |
+| `hipconfig --ldflags` | Use `hip::host` and `hip::device` imported targets |
+| `hipconfig --hippath` | `HIP_PATH` environment variable or `hip_DIR` CMake variable |
+| `hipconfig --rocmpath` | `ROCM_PATH` environment variable |
+| `hipconfig --compiler` | `CMAKE_HIP_COMPILER` |
+
+Example of migrating a version check in CMake:
+
+```cmake
+# Before — calls hipconfig at configure time
+find_program(HIPCONFIG_EXEC hipconfig REQUIRED)
+execute_process(
+  COMMAND ${HIPCONFIG_EXEC} --version
+  OUTPUT_VARIABLE HIP_VERSION
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# After — version already available from find_package
+find_package(hip REQUIRED)
+set(HIP_VERSION ${hip_VERSION})
+```
+
+## Migrating a Makefile or shell-based project
+
+For projects that invoke `hipcc` directly in a Makefile or shell script,
+replace it with `amdclang++` and add the required flags explicitly:
+
+```bash
+# Before
+hipcc -o my_kernel my_kernel.cpp --offload-arch=gfx1100
+
+# After
+amdclang++ \
+  --hip-path=${ROCM_PATH} \
+  --hip-device-lib-path=${ROCM_PATH}/lib/llvm/amdgcn/bitcode \
+  -x hip \
+  --offload-arch=gfx1100 \
+  -o my_kernel my_kernel.cpp
+```
+
+When using a TheRock build, the `--hip-path` and `--hip-device-lib-path` values
+are available from the toolchain's `_toolchain.cmake` or from the `hip-config.cmake`
+installed in `<dist>/lib/cmake/hip/`.

--- a/docs/development/hipcc_deprecation.md
+++ b/docs/development/hipcc_deprecation.md
@@ -47,14 +47,14 @@ and how to migrate your project.
 The following table maps hipcc's implicit behavior to the explicit flags or
 CMake variables that replace it when using `amdclang++` directly.
 
-| hipcc behavior | amdclang++ / CMake equivalent |
-|---|---|
-| Injects `-I<hip>/include` | `--hip-path=<path>` (set in `CMAKE_CXX_FLAGS_INIT`) |
-| Injects `--hip-device-lib-path=<path>` | `--hip-device-lib-path=<path>` (set in `CMAKE_CXX_FLAGS_INIT`) |
-| Sets HIP compiler in CMake | `CMAKE_HIP_COMPILER` set to `amdclang++` in toolchain |
-| Adds `--rtlib=compiler-rt --unwindlib=libgcc` | Added to `CMAKE_EXE_LINKER_FLAGS_INIT` and `CMAKE_SHARED_LINKER_FLAGS_INIT` |
-| Auto-detects GPU targets via `rocm_agent_enumerator` | `AMDGPU_TARGETS` / `CMAKE_HIP_ARCHITECTURES` set by TheRock super-project |
-| Defines `-D__HIP_PLATFORM_AMD__` | Added by `hip-config.cmake` target properties via `find_package(hip)` |
+| hipcc behavior                                       | amdclang++ / CMake equivalent                                               |
+| ---------------------------------------------------- | --------------------------------------------------------------------------- |
+| Injects `-I<hip>/include`                            | `--hip-path=<path>` (set in `CMAKE_CXX_FLAGS_INIT`)                         |
+| Injects `--hip-device-lib-path=<path>`               | `--hip-device-lib-path=<path>` (set in `CMAKE_CXX_FLAGS_INIT`)              |
+| Sets HIP compiler in CMake                           | `CMAKE_HIP_COMPILER` set to `amdclang++` in toolchain                       |
+| Adds `--rtlib=compiler-rt --unwindlib=libgcc`        | Added to `CMAKE_EXE_LINKER_FLAGS_INIT` and `CMAKE_SHARED_LINKER_FLAGS_INIT` |
+| Auto-detects GPU targets via `rocm_agent_enumerator` | `AMDGPU_TARGETS` / `CMAKE_HIP_ARCHITECTURES` set by TheRock super-project   |
+| Defines `-D__HIP_PLATFORM_AMD__`                     | Added by `hip-config.cmake` target properties via `find_package(hip)`       |
 
 ## Migrating a CMake project
 
@@ -99,15 +99,15 @@ direct path to `amdclang++`:
 Projects that called `hipconfig` to retrieve version or path information should
 migrate to CMake-native equivalents:
 
-| hipconfig invocation | CMake equivalent |
-|---|---|
-| `hipconfig --version` | `hip_VERSION` (set by `find_package(hip REQUIRED)`) |
-| `hipconfig --hip-version` | `hip_VERSION` |
-| `hipconfig --cxxflags` | Use `hip::host` and `hip::device` imported targets |
-| `hipconfig --ldflags` | Use `hip::host` and `hip::device` imported targets |
-| `hipconfig --hippath` | `HIP_PATH` environment variable or `hip_DIR` CMake variable |
-| `hipconfig --rocmpath` | `ROCM_PATH` environment variable |
-| `hipconfig --compiler` | `CMAKE_HIP_COMPILER` |
+| hipconfig invocation      | CMake equivalent                                            |
+| ------------------------- | ----------------------------------------------------------- |
+| `hipconfig --version`     | `hip_VERSION` (set by `find_package(hip REQUIRED)`)         |
+| `hipconfig --hip-version` | `hip_VERSION`                                               |
+| `hipconfig --cxxflags`    | Use `hip::host` and `hip::device` imported targets          |
+| `hipconfig --ldflags`     | Use `hip::host` and `hip::device` imported targets          |
+| `hipconfig --hippath`     | `HIP_PATH` environment variable or `hip_DIR` CMake variable |
+| `hipconfig --rocmpath`    | `ROCM_PATH` environment variable                            |
+| `hipconfig --compiler`    | `CMAKE_HIP_COMPILER`                                        |
 
 Example of migrating a version check in CMake:
 

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -534,13 +534,11 @@ if(THEROCK_ENABLE_LIBHIPCXX)
       therock_explicit_finders.cmake
     COMPILER_TOOLCHAIN
       amd-hip
-      hipcc
     BUILD_DEPS
       rocm-cmake
     RUNTIME_DEPS
       amd-llvm
       hip-clr
-      hipcc
     TEST_SUBPROJECTS
   )
   therock_cmake_subproject_glob_c_sources(libhipcxx


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

JIRA ID : LCOMPILER-876

Removing uses of the HIPCC tool in favour of calling amdclang++ directly.  The Clang driver has enough changes that we no longer need an intermediatory tool, and users can just call amdclang++.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- build_tools/github_actions/fetch_test_configurations.py: rename libhipcxx_hipcc CI job to libhipcxx_amdclang
- test_libhipcxx_hipcc.py -> test_libhipcxx_amdclang.py: update test script to invoke amdclang++ directly with GPU arch detection via offload-arch / rocminfo / --offload-arch=native fallback chain
- test_libhipcxx_hiprtc.py: replace HIP_HIPCC_EXECUTABLE with CMAKE_CXX_COMPILER=amdclang++
- libhipcxx_utils.py: improve GPU arch detection (capture offload-arch stdout on non-zero exit, rocminfo fallback)
- math-libs/CMakeLists.txt: remove hipcc from libhipcxx COMPILER_TOOLCHAIN and RUNTIME_DEPS
- math-libs/libhipcxx: bump submodule to 8e3369197 which merges all hipcc deprecation patches (amdclang++ as default compiler, AMDCLANG compiler ID, amdhip64 link fix, -O3 optimization, --offload-arch=native for Windows MxGPU)
-
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Full CQE/CI Staging PSDB

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
