### PR TITLE
Add logging support for Linux packaging

### DIFF
--- a/build_tools/_therock_utils/log_utils.py
+++ b/build_tools/_therock_utils/log_utils.py
@@ -1,0 +1,545 @@
+"""Unified logging utilities for TheRock build tools.
+
+Provides a consistent logging API across all Python scripts with:
+- Console output capture to files (Python print + subprocess output)
+- CI-friendly formatting (GitHub Actions groups, annotations)
+- Verbosity control via environment variables or API
+- Thread-safe stream handling
+
+Usage::
+
+    from _therock_utils.log_utils import configure_logging, get_logger, capture_console
+
+    # One-time setup in main()
+    configure_logging(verbose=args.verbose)
+
+    # Get logger for module
+    logger = get_logger(__name__)
+    logger.info("Processing artifacts")
+
+    # Capture all output to file
+    with capture_console("build.log"):
+        logger.info("Building...")
+        subprocess.run(["cmake", ".."])  # Also captured
+"""
+
+import io
+import logging
+import os
+import sys
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, TextIO
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_FORMAT = "[%(asctime)s][%(levelname)-8s]: %(message)s"
+DEFAULT_DATE_FORMAT = "%y-%m-%d %H:%M:%S"
+CI_FORMAT = "[%(levelname)-8s] %(name)s: %(message)s"
+
+# Environment variables
+ENV_LOG_ENABLED = "THEROCK_LOG_ENABLED"
+ENV_LOG_LEVEL = "THEROCK_LOG_LEVEL"
+ENV_GITHUB_ACTIONS = "GITHUB_ACTIONS"
+
+# Module state
+_configured = False
+_verbosity = 0
+_capture_depth = threading.local()  # Per-thread capture depth counter
+_MAX_CAPTURE_DEPTH = 3
+
+
+def _get_capture_depth() -> int:
+    """Get capture depth for current thread."""
+    return getattr(_capture_depth, "value", 0)
+
+
+def _increment_capture_depth() -> int:
+    """Increment and return capture depth for current thread."""
+    depth = getattr(_capture_depth, "value", 0) + 1
+    _capture_depth.value = depth
+    return depth
+
+
+def _decrement_capture_depth() -> None:
+    """Decrement capture depth for current thread."""
+    _capture_depth.value = max(0, getattr(_capture_depth, "value", 0) - 1)
+
+
+# ---------------------------------------------------------------------------
+# CI Detection
+# ---------------------------------------------------------------------------
+
+
+def is_ci() -> bool:
+    """Check if running in CI (GitHub Actions)."""
+    return os.environ.get(ENV_GITHUB_ACTIONS, "").lower() == "true"
+
+
+def is_logging_enabled() -> bool:
+    """Check if logging is globally enabled."""
+    return os.environ.get(ENV_LOG_ENABLED, "1") != "0"
+
+
+# ---------------------------------------------------------------------------
+# Flushing Handler
+# ---------------------------------------------------------------------------
+
+
+class FlushingStreamHandler(logging.StreamHandler):
+    """StreamHandler that flushes after every emit for CI compatibility."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        super().emit(record)
+        self.flush()
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+def configure_logging(
+    *,
+    enabled: bool | None = None,
+    level: int | str = logging.INFO,
+    verbose: bool = False,
+    ci_mode: bool | None = None,
+    stream: TextIO | None = None,
+) -> None:
+    """Configure root logger for script execution.
+
+    Call once at the start of main(). Replaces logging.basicConfig().
+
+    Args:
+        enabled: Enable/disable logging. None = check THEROCK_LOG_ENABLED env.
+        level: Base logging level (default INFO).
+        verbose: If True, sets level to DEBUG.
+        ci_mode: CI-specific formatting. None = auto-detect from GITHUB_ACTIONS.
+        stream: Output stream (default sys.stderr).
+    """
+    global _configured
+
+    # Check if globally disabled
+    if enabled is None:
+        enabled = is_logging_enabled()
+
+    if not enabled:
+        logging.disable(logging.CRITICAL)
+        _configured = True
+        return
+
+    # Determine level
+    env_level = os.environ.get(ENV_LOG_LEVEL, "").upper()
+    if env_level:
+        level = getattr(logging, env_level, logging.INFO)
+    elif verbose:
+        level = logging.DEBUG
+
+    # Determine CI mode
+    if ci_mode is None:
+        ci_mode = is_ci()
+
+    # Select format
+    fmt = CI_FORMAT if ci_mode else DEFAULT_FORMAT
+    datefmt = None if ci_mode else DEFAULT_DATE_FORMAT
+
+    # Configure root logger
+    root = logging.getLogger()
+    root.setLevel(level)
+
+    # Remove existing handlers to avoid duplicates
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+    # Add new handler
+    handler = FlushingStreamHandler(stream or sys.stderr)
+    handler.setFormatter(logging.Formatter(fmt, datefmt))
+    root.addHandler(handler)
+
+    _configured = True
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Get a configured logger instance.
+
+    Args:
+        name: Logger name (typically __name__).
+
+    Returns:
+        Configured Logger instance.
+    """
+    if not _configured:
+        configure_logging()
+    return logging.getLogger(name)
+
+
+# ---------------------------------------------------------------------------
+# Verbosity Control
+# ---------------------------------------------------------------------------
+
+
+def set_verbosity(level: int) -> None:
+    """Set global verbosity level.
+
+    Args:
+        level: -1 = silent (disabled), 0 = normal (INFO), 1+ = verbose (DEBUG)
+    """
+    global _verbosity
+    _verbosity = level
+
+    if level < 0:
+        logging.disable(logging.CRITICAL)
+    else:
+        logging.disable(logging.NOTSET)
+        root = logging.getLogger()
+        if level >= 1:
+            root.setLevel(logging.DEBUG)
+        else:
+            root.setLevel(logging.INFO)
+
+
+def vlog(message: str, *args, level: int = 0, **kwargs) -> None:
+    """Log with verbosity level (py_packaging compatibility).
+
+    Args:
+        message: Log message.
+        level: Minimum verbosity level required to show this message.
+        *args, **kwargs: Passed to logger.debug().
+    """
+    if _verbosity >= level:
+        logger = get_logger("therock")
+        logger.debug(message, *args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# TeeStream - Thread-safe dual output
+# ---------------------------------------------------------------------------
+
+
+class TeeStream:
+    """Thread-safe stream that writes to two destinations.
+
+    Used by capture_console() to write to both console and file.
+    """
+
+    def __init__(self, stream1: TextIO, stream2: TextIO):
+        self.stream1 = stream1
+        self.stream2 = stream2
+        self._lock = threading.Lock()
+
+    def write(self, data: str) -> int:
+        with self._lock:
+            if isinstance(data, bytes):
+                data = data.decode("utf-8", errors="replace")
+
+            self.stream1.write(data)
+            self.stream2.write(data)
+            self.stream1.flush()
+            self.stream2.flush()
+            return len(data)
+
+    def flush(self) -> None:
+        with self._lock:
+            self.stream1.flush()
+            self.stream2.flush()
+
+    def fileno(self) -> int:
+        """Return file descriptor for subprocess compatibility."""
+        return self.stream1.fileno()
+
+    def isatty(self) -> bool:
+        return self.stream1.isatty()
+
+    @property
+    def encoding(self) -> str:
+        return getattr(self.stream1, "encoding", "utf-8")
+
+    @property
+    def errors(self) -> str:
+        return getattr(self.stream1, "errors", "replace")
+
+
+# ---------------------------------------------------------------------------
+# Console Capture with OS-level file descriptor redirection
+# ---------------------------------------------------------------------------
+
+
+class _TeeWriter(threading.Thread):
+    """Background thread that reads from a pipe and writes to multiple destinations.
+
+    This enables capturing subprocess output that writes directly to file descriptors.
+    """
+
+    def __init__(self, read_fd: int, outputs: list[TextIO], name: str = "TeeWriter"):
+        super().__init__(daemon=True, name=name)
+        self.read_fd = read_fd
+        self.outputs = outputs
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    data = os.read(self.read_fd, 4096)
+                    if not data:
+                        break
+                    text = data.decode("utf-8", errors="replace")
+                    for out in self.outputs:
+                        try:
+                            out.write(text)
+                            out.flush()
+                        except (IOError, ValueError):
+                            pass
+                except OSError:
+                    break
+        finally:
+            try:
+                os.close(self.read_fd)
+            except OSError:
+                pass
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+
+@contextmanager
+def capture_console(
+    log_file: Path | str,
+    *,
+    also_to_console: bool = True,
+    enabled: bool | None = None,
+) -> Iterator[Path]:
+    """Capture all console output to a file.
+
+    Uses OS-level file descriptor redirection to capture:
+    - Python print() statements
+    - Python logging calls
+    - Subprocess stdout/stderr (even direct fd writes)
+    - C library output (printf, etc.)
+
+    Supports nesting up to 3 levels for per-component + combined logs.
+
+    Args:
+        log_file: Path to output file.
+        also_to_console: If True (default), output also appears on console.
+        enabled: Enable/disable capture. None = check THEROCK_LOG_ENABLED env.
+
+    Yields:
+        Path to the log file.
+
+    Example::
+
+        with capture_console("build.log"):
+            print("Building...")  # Goes to console AND build.log
+            subprocess.run(["make"])  # Subprocess output also captured
+    """
+    # Check if enabled
+    if enabled is None:
+        enabled = is_logging_enabled()
+
+    log_path = Path(log_file)
+
+    if not enabled:
+        yield log_path
+        return
+
+    # Check nesting depth (thread-safe via thread-local storage)
+    if _get_capture_depth() >= _MAX_CAPTURE_DEPTH:
+        log = get_logger(__name__)
+        log.warning(
+            f"capture_console: max nesting depth ({_MAX_CAPTURE_DEPTH}) reached, "
+            f"skipping capture to {log_path}"
+        )
+        yield log_path
+        return
+
+    _increment_capture_depth()
+
+    # Ensure parent directory exists
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Save original file descriptors
+    orig_stdout_fd = os.dup(1)
+    orig_stderr_fd = os.dup(2)
+    orig_stdout = sys.stdout
+    orig_stderr = sys.stderr
+
+    # Create pipes for capturing
+    stdout_read_fd, stdout_write_fd = os.pipe()
+    stderr_read_fd, stderr_write_fd = os.pipe()
+
+    tee_threads = []
+    log_fh = None
+
+    try:
+        log_fh = open(log_path, "w", encoding="utf-8")
+
+        # Determine output destinations
+        if also_to_console:
+            stdout_outputs = [os.fdopen(orig_stdout_fd, "w", closefd=False), log_fh]
+            stderr_outputs = [os.fdopen(orig_stderr_fd, "w", closefd=False), log_fh]
+        else:
+            stdout_outputs = [log_fh]
+            stderr_outputs = [log_fh]
+
+        # Start tee threads to read from pipes and write to outputs
+        stdout_tee = _TeeWriter(stdout_read_fd, stdout_outputs, "StdoutTee")
+        stderr_tee = _TeeWriter(stderr_read_fd, stderr_outputs, "StderrTee")
+        tee_threads = [stdout_tee, stderr_tee]
+
+        stdout_tee.start()
+        stderr_tee.start()
+
+        # Redirect file descriptors 1 and 2 to write ends of pipes
+        os.dup2(stdout_write_fd, 1)
+        os.dup2(stderr_write_fd, 2)
+        os.close(stdout_write_fd)
+        os.close(stderr_write_fd)
+
+        # Redirect Python's sys.stdout/stderr to the new fd 1/2
+        sys.stdout = io.TextIOWrapper(
+            io.FileIO(1, "w", closefd=False),
+            encoding="utf-8",
+            errors="replace",
+            line_buffering=True,
+        )
+        sys.stderr = io.TextIOWrapper(
+            io.FileIO(2, "w", closefd=False),
+            encoding="utf-8",
+            errors="replace",
+            line_buffering=True,
+        )
+
+        # Update logging handlers
+        root = logging.getLogger()
+        old_handlers = []
+        for handler in root.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                old_handlers.append((handler, handler.stream))
+                handler.stream = sys.stderr
+
+        try:
+            yield log_path
+        finally:
+            # Flush Python streams
+            sys.stdout.flush()
+            sys.stderr.flush()
+
+            # Restore logging handlers
+            for handler, old_stream in old_handlers:
+                handler.stream = old_stream
+
+    finally:
+        # Restore original file descriptors
+        os.dup2(orig_stdout_fd, 1)
+        os.dup2(orig_stderr_fd, 2)
+        os.close(orig_stdout_fd)
+        os.close(orig_stderr_fd)
+
+        # Restore Python streams
+        sys.stdout = orig_stdout
+        sys.stderr = orig_stderr
+
+        # Wait for tee threads to finish (they'll exit when pipes close)
+        for t in tee_threads:
+            t.stop()
+            t.join(timeout=1.0)
+
+        # Close log file
+        if log_fh:
+            log_fh.close()
+
+        _decrement_capture_depth()
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions Integration
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def github_group(title: str) -> Iterator[None]:
+    """Create a collapsible group in GitHub Actions logs.
+
+    No-op when not running in CI.
+
+    Args:
+        title: Group title shown in the UI.
+
+    Example::
+
+        with github_group("Building ROCm Components"):
+            for component in components:
+                build(component)
+    """
+    if is_ci():
+        print(f"::group::{title}", flush=True)
+    try:
+        yield
+    finally:
+        if is_ci():
+            print("::endgroup::", flush=True)
+
+
+def github_warning(
+    message: str, *, file: str | None = None, line: int | None = None
+) -> None:
+    """Emit a warning annotation in GitHub Actions.
+
+    Args:
+        message: Warning message.
+        file: Optional file path to annotate.
+        line: Optional line number.
+    """
+    if not is_ci():
+        return
+
+    params = []
+    if file:
+        params.append(f"file={file}")
+    if line:
+        params.append(f"line={line}")
+
+    param_str = " " + ",".join(params) if params else ""
+    print(f"::warning{param_str}::{message}", flush=True)
+
+
+def github_error(
+    message: str, *, file: str | None = None, line: int | None = None
+) -> None:
+    """Emit an error annotation in GitHub Actions.
+
+    Args:
+        message: Error message.
+        file: Optional file path to annotate.
+        line: Optional line number.
+    """
+    if not is_ci():
+        return
+
+    params = []
+    if file:
+        params.append(f"file={file}")
+    if line:
+        params.append(f"line={line}")
+
+    param_str = " " + ",".join(params) if params else ""
+    print(f"::error{param_str}::{message}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Logger Disable
+# ---------------------------------------------------------------------------
+
+
+def disable_logger(name: str) -> None:
+    """Disable a specific logger by name.
+
+    Args:
+        name: Logger name to disable (e.g., 'therock.packaging').
+    """
+    logging.getLogger(name).disabled = True

--- a/build_tools/_therock_utils/log_utils.py
+++ b/build_tools/_therock_utils/log_utils.py
@@ -8,19 +8,33 @@ Provides a consistent logging API across all Python scripts with:
 
 Usage::
 
-    from _therock_utils.log_utils import configure_logging, get_logger, capture_console
+    from _therock_utils.log_utils import configure_logging, TheRockLogger, capture_console
 
     # One-time setup in main()
     configure_logging(verbose=args.verbose)
 
-    # Get logger for module
-    logger = get_logger(__name__)
+    # Create logger for module
+    logger = TheRockLogger(__name__)
+
+    # Standard Python logging
+    logger.debug("Debug details")
     logger.info("Processing artifacts")
+    logger.warning("Something unexpected")
+    logger.error("Operation failed")
+
+    # GitHub Actions annotations (only emitted when running in CI)
+    logger.warning("Build warning", github=True)
+    logger.error("Build failed", github=True, file="build.py", line=42)
 
     # Capture all output to file
     with capture_console("build.log"):
         logger.info("Building...")
         subprocess.run(["cmake", ".."])  # Also captured
+
+    # Collapsible groups in GitHub Actions logs
+    with github_group("Building ROCm"):
+        logger.info("Step 1...")
+        logger.info("Step 2...")
 """
 
 import io
@@ -163,7 +177,7 @@ def configure_logging(
     _configured = True
 
 
-def get_logger(name: str) -> logging.Logger:
+def _get_logger(name: str) -> logging.Logger:
     """Get a configured logger instance.
 
     Args:
@@ -211,7 +225,7 @@ def vlog(message: str, *args, level: int = 0, **kwargs) -> None:
         *args, **kwargs: Passed to logger.debug().
     """
     if _verbosity >= level:
-        logger = get_logger("therock")
+        logger = _get_logger("therock")
         logger.debug(message, *args, **kwargs)
 
 
@@ -493,7 +507,7 @@ def capture_console(
 
     # Check nesting depth (thread-safe via thread-local storage)
     if _get_capture_depth() >= _MAX_CAPTURE_DEPTH:
-        log = get_logger(__name__)
+        log = _get_logger(__name__)
         log.warning(
             f"capture_console: max nesting depth ({_MAX_CAPTURE_DEPTH}) reached, "
             f"skipping capture to {log_path}"
@@ -655,50 +669,122 @@ def github_group(title: str) -> Iterator[None]:
             print("::endgroup::", flush=True)
 
 
-def github_warning(
-    message: str, *, file: str | None = None, line: int | None = None
+def _log(
+    level: str,
+    message: str,
+    *,
+    name: str = "therock",
+    github: bool = False,
+    file: str | None = None,
+    line: int | None = None,
 ) -> None:
-    """Emit a warning annotation in GitHub Actions.
+    """Internal unified logging for both Python logging and GitHub Actions annotations.
 
     Args:
-        message: Warning message.
-        file: Optional file path to annotate.
-        line: Optional line number.
+        level: Log level ("debug", "info", "warning", "error").
+        message: Log message.
+        name: Logger name (default "therock"). Use __name__ for per-module logging.
+        github: If True, emit GitHub Actions annotation instead of Python log.
+        file: Optional file path for GitHub annotation.
+        line: Optional line number for GitHub annotation.
+
+    Examples::
+
+        # Default - Python logging style
+        log("warning", f"Failed to build {pkg_name}")
+        # -> [WARNING ]: Failed to build amdrocm-fft
+
+        # Per-module logger
+        log("info", "Processing...", name=__name__)
+        # -> [INFO    ] mymodule: Processing...
+
+        # With github=True - GitHub Actions annotation
+        log("warning", f"Failed to build {pkg_name}", github=True)
+        # -> ::warning::Failed to build amdrocm-fft
     """
-    if not is_ci():
-        return
+    if github:
+        if not is_ci():
+            return
 
-    params = []
-    if file:
-        params.append(f"file={file}")
-    if line:
-        params.append(f"line={line}")
+        params = []
+        if file:
+            params.append(f"file={file}")
+        if line:
+            params.append(f"line={line}")
 
-    param_str = " " + ",".join(params) if params else ""
-    print(f"::warning{param_str}::{message}", flush=True)
+        param_str = " " + ",".join(params) if params else ""
+        print(f"::{level}{param_str}::{message}", flush=True)
+    else:
+        logger = _get_logger(name)
+        log_func = getattr(logger, level.lower(), logger.info)
+        log_func(message)
 
 
-def github_error(
-    message: str, *, file: str | None = None, line: int | None = None
-) -> None:
-    """Emit an error annotation in GitHub Actions.
+class TheRockLogger:
+    """TheRock logger with familiar logger.info() style API.
 
-    Args:
-        message: Error message.
-        file: Optional file path to annotate.
-        line: Optional line number.
+    Wraps the unified log() function to provide the standard Python logging
+    interface while supporting GitHub annotations.
+
+    Example::
+
+        logger = TheRockLogger(__name__)
+        logger.info("Processing...")
+        logger.warning("Something odd")
+        logger.error("Failed!", github=True)  # GitHub annotation
     """
-    if not is_ci():
-        return
 
-    params = []
-    if file:
-        params.append(f"file={file}")
-    if line:
-        params.append(f"line={line}")
+    def __init__(self, name: str = "therock"):
+        """Initialize logger with a name.
 
-    param_str = " " + ",".join(params) if params else ""
-    print(f"::error{param_str}::{message}", flush=True)
+        Args:
+            name: Logger name (typically __name__ for per-module logging).
+        """
+        self.name = name
+
+    def debug(
+        self,
+        message: str,
+        *,
+        github: bool = False,
+        file: str | None = None,
+        line: int | None = None,
+    ) -> None:
+        """Log a debug message."""
+        _log("debug", message, name=self.name, github=github, file=file, line=line)
+
+    def info(
+        self,
+        message: str,
+        *,
+        github: bool = False,
+        file: str | None = None,
+        line: int | None = None,
+    ) -> None:
+        """Log an info message."""
+        _log("info", message, name=self.name, github=github, file=file, line=line)
+
+    def warning(
+        self,
+        message: str,
+        *,
+        github: bool = False,
+        file: str | None = None,
+        line: int | None = None,
+    ) -> None:
+        """Log a warning message."""
+        _log("warning", message, name=self.name, github=github, file=file, line=line)
+
+    def error(
+        self,
+        message: str,
+        *,
+        github: bool = False,
+        file: str | None = None,
+        line: int | None = None,
+    ) -> None:
+        """Log an error message."""
+        _log("error", message, name=self.name, github=github, file=file, line=line)
 
 
 # ---------------------------------------------------------------------------

--- a/build_tools/_therock_utils/log_utils.py
+++ b/build_tools/_therock_utils/log_utils.py
@@ -422,19 +422,25 @@ def _capture_console_windows(
         kernel32.SetStdHandle(STD_OUTPUT_HANDLE, orig_stdout_handle)
         kernel32.SetStdHandle(STD_ERROR_HANDLE, orig_stderr_handle)
 
-        # Restore fds
+        # Restore fds - this closes the write ends of the pipes which signals
+        # the tee threads to exit (they'll read EOF)
         os.dup2(orig_stdout_fd, 1)
         os.dup2(orig_stderr_fd, 2)
-        os.close(orig_stdout_fd)
-        os.close(orig_stderr_fd)
 
         # Restore Python streams
         sys.stdout = orig_stdout
         sys.stderr = orig_stderr
 
+        # IMPORTANT: Join tee threads BEFORE closing file descriptors.
+        # The tee threads write to outputs that may reference orig_stdout_fd/orig_stderr_fd.
+        # Closing fds before threads finish would cause write errors.
         for t in tee_threads:
             t.stop()
             t.join(timeout=5.0)
+
+        # Now safe to close file descriptors and file handles
+        os.close(orig_stdout_fd)
+        os.close(orig_stderr_fd)
 
         if console_stdout:
             console_stdout.close()
@@ -521,14 +527,20 @@ def capture_console(
 
     tee_threads = []
     log_fh = None
+    console_stdout = None
+    console_stderr = None
 
     try:
         log_fh = open(log_path, "w", encoding="utf-8")
 
         # Determine output destinations
         if also_to_console:
-            stdout_outputs = [os.fdopen(orig_stdout_fd, "w", closefd=False), log_fh]
-            stderr_outputs = [os.fdopen(orig_stderr_fd, "w", closefd=False), log_fh]
+            # Dup the FDs so we have independent copies for the tee threads.
+            # This matches the Windows implementation and ensures proper cleanup.
+            console_stdout = os.fdopen(os.dup(orig_stdout_fd), "w", closefd=True)
+            console_stderr = os.fdopen(os.dup(orig_stderr_fd), "w", closefd=True)
+            stdout_outputs = [console_stdout, log_fh]
+            stderr_outputs = [console_stderr, log_fh]
         else:
             stdout_outputs = [log_fh]
             stderr_outputs = [log_fh]
@@ -581,20 +593,31 @@ def capture_console(
                 handler.stream = old_stream
 
     finally:
-        # Restore original file descriptors
+        # Restore original file descriptors - this closes the write ends of the pipes
+        # which signals the tee threads to exit (they'll read EOF)
         os.dup2(orig_stdout_fd, 1)
         os.dup2(orig_stderr_fd, 2)
-        os.close(orig_stdout_fd)
-        os.close(orig_stderr_fd)
 
         # Restore Python streams
         sys.stdout = orig_stdout
         sys.stderr = orig_stderr
 
-        # Wait for tee threads to finish (they'll exit when pipes close)
+        # IMPORTANT: Join tee threads BEFORE closing file descriptors.
+        # The tee threads write to outputs that may reference orig_stdout_fd/orig_stderr_fd.
+        # Closing fds before threads finish would cause write errors.
         for t in tee_threads:
             t.stop()
             t.join(timeout=5.0)
+
+        # Now safe to close file descriptors and file handles
+        os.close(orig_stdout_fd)
+        os.close(orig_stderr_fd)
+
+        # Close console file objects (these have closefd=True so they close their duped FDs)
+        if console_stdout:
+            console_stdout.close()
+        if console_stderr:
+            console_stderr.close()
 
         # Close log file
         if log_fh:

--- a/build_tools/_therock_utils/log_utils.py
+++ b/build_tools/_therock_utils/log_utils.py
@@ -268,10 +268,14 @@ class TeeStream:
 # ---------------------------------------------------------------------------
 
 
+_tee_write_lock = threading.Lock()
+
+
 class _TeeWriter(threading.Thread):
     """Background thread that reads from a pipe and writes to multiple destinations.
 
     This enables capturing subprocess output that writes directly to file descriptors.
+    Uses a module-level lock to prevent interleaved writes from stdout/stderr threads.
     """
 
     def __init__(self, read_fd: int, outputs: list[TextIO], name: str = "TeeWriter"):
@@ -288,12 +292,13 @@ class _TeeWriter(threading.Thread):
                     if not data:
                         break
                     text = data.decode("utf-8", errors="replace")
-                    for out in self.outputs:
-                        try:
-                            out.write(text)
-                            out.flush()
-                        except (IOError, ValueError):
-                            pass
+                    with _tee_write_lock:
+                        for out in self.outputs:
+                            try:
+                                out.write(text)
+                                out.flush()
+                            except (IOError, ValueError):
+                                pass
                 except OSError:
                     break
         finally:
@@ -304,6 +309,139 @@ class _TeeWriter(threading.Thread):
 
     def stop(self) -> None:
         self._stop_event.set()
+
+
+@contextmanager
+def _capture_console_windows(
+    log_path: Path,
+    also_to_console: bool,
+) -> Iterator[Path]:
+    """Windows implementation using SetStdHandle for subprocess capture."""
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    kernel32 = ctypes.windll.kernel32
+
+    # Configure ctypes function signatures for 64-bit handle safety
+    kernel32.GetStdHandle.argtypes = [wintypes.DWORD]
+    kernel32.GetStdHandle.restype = wintypes.HANDLE
+    kernel32.SetStdHandle.argtypes = [wintypes.DWORD, wintypes.HANDLE]
+    kernel32.SetStdHandle.restype = wintypes.BOOL
+
+    STD_OUTPUT_HANDLE = wintypes.DWORD(-11)
+    STD_ERROR_HANDLE = wintypes.DWORD(-12)
+    INVALID_HANDLE_VALUE = wintypes.HANDLE(-1).value
+
+    # Save originals
+    orig_stdout_handle = kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+    orig_stderr_handle = kernel32.GetStdHandle(STD_ERROR_HANDLE)
+
+    # Validate handles
+    if orig_stdout_handle == INVALID_HANDLE_VALUE:
+        raise OSError("GetStdHandle failed for stdout")
+    if orig_stderr_handle == INVALID_HANDLE_VALUE:
+        raise OSError("GetStdHandle failed for stderr")
+    orig_stdout = sys.stdout
+    orig_stderr = sys.stderr
+    orig_stdout_fd = os.dup(1)
+    orig_stderr_fd = os.dup(2)
+
+    # Create pipes
+    stdout_read, stdout_write = os.pipe()
+    stderr_read, stderr_write = os.pipe()
+
+    log_fh = None
+    tee_threads = []
+    console_stdout = None
+    console_stderr = None
+
+    try:
+        log_fh = open(log_path, "w", encoding="utf-8")
+
+        if also_to_console:
+            console_stdout = os.fdopen(os.dup(orig_stdout_fd), "w", closefd=True)
+            console_stderr = os.fdopen(os.dup(orig_stderr_fd), "w", closefd=True)
+            stdout_outputs = [console_stdout, log_fh]
+            stderr_outputs = [console_stderr, log_fh]
+        else:
+            stdout_outputs = [log_fh]
+            stderr_outputs = [log_fh]
+
+        # Start tee threads
+        stdout_tee = _TeeWriter(stdout_read, stdout_outputs, "StdoutTee")
+        stderr_tee = _TeeWriter(stderr_read, stderr_outputs, "StderrTee")
+        tee_threads = [stdout_tee, stderr_tee]
+        stdout_tee.start()
+        stderr_tee.start()
+
+        # Redirect fds
+        os.dup2(stdout_write, 1)
+        os.dup2(stderr_write, 2)
+        os.close(stdout_write)
+        os.close(stderr_write)
+
+        # Redirect Windows console handles for subprocess capture
+        stdout_handle = wintypes.HANDLE(msvcrt.get_osfhandle(1))
+        stderr_handle = wintypes.HANDLE(msvcrt.get_osfhandle(2))
+        kernel32.SetStdHandle(STD_OUTPUT_HANDLE, stdout_handle)
+        kernel32.SetStdHandle(STD_ERROR_HANDLE, stderr_handle)
+
+        # Redirect Python streams
+        sys.stdout = io.TextIOWrapper(
+            io.FileIO(1, "w", closefd=False),
+            encoding="utf-8",
+            errors="replace",
+            line_buffering=True,
+        )
+        sys.stderr = io.TextIOWrapper(
+            io.FileIO(2, "w", closefd=False),
+            encoding="utf-8",
+            errors="replace",
+            line_buffering=True,
+        )
+
+        # Update logging handlers
+        root = logging.getLogger()
+        old_handlers = [
+            (h, h.stream) for h in root.handlers if isinstance(h, logging.StreamHandler)
+        ]
+        for handler, _ in old_handlers:
+            handler.stream = sys.stderr
+
+        try:
+            yield log_path
+        finally:
+            sys.stdout.flush()
+            sys.stderr.flush()
+            for handler, old_stream in old_handlers:
+                handler.stream = old_stream
+
+    finally:
+        # Restore Windows console handles
+        kernel32.SetStdHandle(STD_OUTPUT_HANDLE, orig_stdout_handle)
+        kernel32.SetStdHandle(STD_ERROR_HANDLE, orig_stderr_handle)
+
+        # Restore fds
+        os.dup2(orig_stdout_fd, 1)
+        os.dup2(orig_stderr_fd, 2)
+        os.close(orig_stdout_fd)
+        os.close(orig_stderr_fd)
+
+        # Restore Python streams
+        sys.stdout = orig_stdout
+        sys.stderr = orig_stderr
+
+        for t in tee_threads:
+            t.stop()
+            t.join(timeout=5.0)
+
+        if console_stdout:
+            console_stdout.close()
+        if console_stderr:
+            console_stderr.close()
+        if log_fh:
+            log_fh.close()
 
 
 @contextmanager
@@ -362,7 +500,16 @@ def capture_console(
     # Ensure parent directory exists
     log_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Save original file descriptors
+    # Use Windows-specific implementation for subprocess capture support
+    if sys.platform == "win32":
+        try:
+            with _capture_console_windows(log_path, also_to_console):
+                yield log_path
+        finally:
+            _decrement_capture_depth()
+        return
+
+    # POSIX implementation - save original file descriptors
     orig_stdout_fd = os.dup(1)
     orig_stderr_fd = os.dup(2)
     orig_stdout = sys.stdout
@@ -447,7 +594,7 @@ def capture_console(
         # Wait for tee threads to finish (they'll exit when pipes close)
         for t in tee_threads:
             t.stop()
-            t.join(timeout=1.0)
+            t.join(timeout=5.0)
 
         # Close log file
         if log_fh:

--- a/build_tools/_therock_utils/workflow_outputs.py
+++ b/build_tools/_therock_utils/workflow_outputs.py
@@ -229,6 +229,30 @@ class WorkflowOutputRoot:
         """
         return StorageLocation(self.bucket, f"{self.prefix}/packages/{pkg_type}")
 
+    def native_linux_packages_log_dir(self, pkg_type: str) -> StorageLocation:
+        """Location for native Linux packaging logs directory.
+
+        Returns ``StorageLocation`` at ``{run_id}-linux/logs/packaging/{pkg_type}``
+        (e.g. ``12345678901-linux/logs/packaging/deb``).
+
+        This directory contains per-package build logs generated during
+        native package creation (e.g., ``deb-amdrocm-core.log``).
+
+        Args:
+            pkg_type: Package type ('deb' or 'rpm').
+        """
+        return StorageLocation(self.bucket, f"{self.prefix}/logs/packaging/{pkg_type}")
+
+    def native_linux_packages_log_index(self, pkg_type: str) -> StorageLocation:
+        """Location for native Linux packaging logs index HTML.
+
+        Args:
+            pkg_type: Package type ('deb' or 'rpm').
+        """
+        return StorageLocation(
+            self.bucket, f"{self.prefix}/logs/packaging/{pkg_type}/index.html"
+        )
+
     # -- Python packages --------------------------------------------------------
 
     def python_packages(self, artifact_group: str = "") -> StorageLocation:

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -36,21 +36,23 @@ from pathlib import Path
 
 # Setup paths
 SCRIPT_DIR = Path(__file__).resolve().parent
-BUILD_TOOLS_DIR = SCRIPT_DIR.parent.parent
-
-# Add build_tools directory to Python path to import _therock_utils
-# This allows the script to be run from anywhere: TheRock root or packaging/linux directory
-if str(BUILD_TOOLS_DIR) not in sys.path:
-    sys.path.insert(0, str(BUILD_TOOLS_DIR))
 
 from packaging_summary import *
 from packaging_utils import *
 from runpath_to_rpath import *
 
 from _therock_utils.artifacts import ArtifactCatalog
+from _therock_utils.log_utils import (
+    configure_logging,
+    get_logger,
+    capture_console,
+    github_group,
+)
 
 from deb_package import *
 from rpm_package import *
+
+logger = get_logger(__name__)
 
 
 # Default install prefix
@@ -179,7 +181,7 @@ def build_gfxarch_package_variants(pkg_name, config: PackageConfig) -> list:
     # Host package (contains generic artifacts)
     # Skip for metapackages - they have no artifacts, only dependencies
     if not is_meta:
-        print(f"\n=== Building host variant for {pkg_name} ===")
+        logger.info(f"Building host variant for {pkg_name}")
         pkg = build_host_package(pkg_name, config)
         if pkg:
             built_packages.extend(pkg)
@@ -187,20 +189,20 @@ def build_gfxarch_package_variants(pkg_name, config: PackageConfig) -> list:
     # Device packages (one per architecture)
     # For metapackages, these become arch-specific meta packages
     for device_arch in config.gfxarch_list:
-        print(f"\n=== Building device variant for {pkg_name} ({device_arch}) ===")
+        logger.info(f"Building device variant for {pkg_name} ({device_arch})")
         pkg = build_device_package(pkg_name, config, device_arch)
         if pkg:
             built_packages.extend(pkg)
 
     # Meta package (depends on host + all devices for regular packages,
     # or depends on all arch-specific metas for metapackages)
-    print(f"\n=== Building meta variant for {pkg_name} ===")
+    logger.info(f"Building meta variant for {pkg_name}")
     pkg = build_meta_package(pkg_name, config)
     if pkg:
         built_packages.extend(pkg)
 
     # Non-versioned package (user-facing, depends on meta)
-    print(f"\n=== Building non-versioned variant for {pkg_name} ===")
+    logger.info(f"Building non-versioned variant for {pkg_name}")
     # For gfxarch packages in kpack mode, non-versioned has no arch suffix (e.g., amdrocm-fft)
     # It depends on the meta package which pulls in host + all devices
     meta_config = replace(config, gfx_arch=GFX_META)
@@ -229,13 +231,13 @@ def build_simple_package_variants(pkg_name, config: PackageConfig) -> list:
     built_packages = []
 
     # Versioned package
-    print(f"\n=== Building versioned variant for {pkg_name} ===")
+    logger.info(f"Building versioned variant for {pkg_name}")
     pkg = build_versioned_package(pkg_name, config)
     if pkg:
         built_packages.extend(pkg)
 
     # Non-versioned package
-    print(f"\n=== Building non-versioned variant for {pkg_name} ===")
+    logger.info(f"Building non-versioned variant for {pkg_name}")
     # For non-gfxarch packages, non-versioned has no arch suffix (e.g., amdrocm-core)
     simple_config = replace(config, gfx_arch="")
     pkg = build_nonversioned_package(pkg_name, simple_config)
@@ -266,7 +268,7 @@ def build_singlearch_package_variants(pkg_name, config: PackageConfig) -> list:
     built_packages = []
 
     # Versioned package
-    print(f"\n=== Building versioned package for {pkg_name} (single-arch mode) ===")
+    logger.info(f"Building versioned package for {pkg_name} (single-arch mode)")
     try:
         versioned_config = replace(config, versioned_pkg=True)
         if versioned_config.pkg_type == "rpm":
@@ -276,10 +278,10 @@ def build_singlearch_package_variants(pkg_name, config: PackageConfig) -> list:
         if pkg:
             built_packages.extend(pkg)
     except Exception as e:
-        print(f"ERROR: Failed to build versioned package for {pkg_name}: {e}")
+        logger.error(f"Failed to build versioned package for {pkg_name}: {e}")
 
     # Non-versioned package
-    print(f"\n=== Building non-versioned package for {pkg_name} (single-arch mode) ===")
+    logger.info(f"Building non-versioned package for {pkg_name} (single-arch mode)")
     try:
         # In single-arch mode, non-versioned packages keep the arch suffix
         # to indicate they're specific to that architecture (e.g., amdrocm-fft-gfx1100)
@@ -291,7 +293,7 @@ def build_singlearch_package_variants(pkg_name, config: PackageConfig) -> list:
         if pkg:
             built_packages.extend(pkg)
     except Exception as e:
-        print(f"ERROR: Failed to build non-versioned package for {pkg_name}: {e}")
+        logger.error(f"Failed to build non-versioned package for {pkg_name}: {e}")
 
     cleanup_build_directory(config)
     return built_packages
@@ -317,7 +319,7 @@ def build_host_package(pkg_name, config: PackageConfig) -> list:
         else:
             return create_versioned_deb_package(pkg_name, host_config)
     except Exception as e:
-        print(f"ERROR: Failed to build host package for {pkg_name}: {e}")
+        logger.error(f"Failed to build host package for {pkg_name}: {e}")
         return []
 
 
@@ -342,8 +344,8 @@ def build_device_package(pkg_name, config: PackageConfig, device_arch: str) -> l
         else:
             return create_versioned_deb_package(pkg_name, device_config)
     except Exception as e:
-        print(
-            f"ERROR: Failed to build device package for {pkg_name} ({device_arch}): {e}"
+        logger.error(
+            f"Failed to build device package for {pkg_name} ({device_arch}): {e}"
         )
         return []
 
@@ -368,7 +370,7 @@ def build_meta_package(pkg_name, config: PackageConfig) -> list:
         else:
             return create_versioned_deb_package(pkg_name, meta_config)
     except Exception as e:
-        print(f"ERROR: Failed to build meta package for {pkg_name}: {e}")
+        logger.error(f"Failed to build meta package for {pkg_name}: {e}")
         return []
 
 
@@ -392,7 +394,7 @@ def build_versioned_package(pkg_name, config: PackageConfig) -> list:
         else:
             return create_versioned_deb_package(pkg_name, versioned_config)
     except Exception as e:
-        print(f"ERROR: Failed to build versioned package for {pkg_name}: {e}")
+        logger.error(f"Failed to build versioned package for {pkg_name}: {e}")
         return []
 
 
@@ -422,7 +424,7 @@ def build_nonversioned_package(pkg_name, config: PackageConfig) -> list:
         else:
             return create_nonversioned_deb_package(pkg_name, nonversioned_config)
     except Exception as e:
-        print(f"ERROR: Failed to build non-versioned package for {pkg_name}: {e}")
+        logger.error(f"Failed to build non-versioned package for {pkg_name}: {e}")
         return []
 
 
@@ -438,7 +440,7 @@ def cleanup_build_directory(config: PackageConfig):
     build_dir = Path(config.dest_dir) / config.pkg_type
     if build_dir.exists():
         remove_dir(build_dir)
-        print(f"Cleaned up build directory: {build_dir}")
+        logger.debug(f"Cleaned up build directory: {build_dir}")
 
 
 def cleanup_packaging_environment(config: PackageConfig):
@@ -453,7 +455,7 @@ def cleanup_packaging_environment(config: PackageConfig):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("cleanup_packaging_environment")
     PYCACHE_DIR = Path(SCRIPT_DIR) / "__pycache__"
     remove_dir(PYCACHE_DIR)
 
@@ -475,7 +477,7 @@ def parse_input_package_list(pkg_name, artifact_dir):
 
     Returns: Package list
     """
-    print_function_name()
+    logger.debug("parse_input_package_list")
     pkg_list = []
     skipped_list = []
     # If pkg_name is None, include all packages
@@ -499,7 +501,7 @@ def parse_input_package_list(pkg_name, artifact_dir):
                 pkg_list.append(name)
                 break
 
-    print(f"pkg_list:\n  {pkg_list}")
+    logger.debug(f"pkg_list: {pkg_list}")
     return pkg_list, skipped_list
 
 
@@ -528,12 +530,12 @@ def create_package_config(args: argparse.Namespace) -> PackageConfig:
         # Auto-detect from artifact directory
         normalized_targets = get_all_target_families(args.artifacts_dir)
         if not normalized_targets:
-            print(
+            logger.warning(
                 f"No GFX architectures found in artifact directory: {args.artifacts_dir}. "
                 "Either provide --target explicitly or ensure artifacts are present."
             )
         else:
-            print(f"Auto-detected GFX architectures: {normalized_targets}")
+            logger.info(f"Auto-detected GFX architectures: {normalized_targets}\n")
 
     # Output packaging architecture list to GitHub Actions
     github_output = os.environ.get("GITHUB_OUTPUT")
@@ -547,7 +549,7 @@ def create_package_config(args: argparse.Namespace) -> PackageConfig:
     if not args.enable_kpack:
         args.enable_kpack = load_kpack_from_manifest(artifacts_dir)
         if args.enable_kpack:
-            print(
+            logger.info(
                 "Detected KPACK_SPLIT_ARTIFACTS in manifest — producing host + device packages"
             )
 
@@ -618,7 +620,7 @@ def run(args: argparse.Namespace):
     )
 
     if not pkg_list:
-        print("Error: No packages found to build. Package list is empty.")
+        logger.error("No packages found to build. Package list is empty.")
         sys.exit(1)
 
     current_pkg_idx = 0
@@ -627,26 +629,31 @@ def run(args: argparse.Namespace):
         failed_pkglist = []
 
         for current_pkg_idx, pkg_name in enumerate(pkg_list):
-            print(f"Creating {config.pkg_type} package: {pkg_name}")
+            logger.info(f"Creating {config.pkg_type} package: {pkg_name}")
 
             # Build all package variants for this package
-            output_list = build_package_variants(pkg_name, config)
+            # Capture per-package logs
+            logs_dir = Path(config.dest_dir) / "logs"
+            logs_dir.mkdir(parents=True, exist_ok=True)
+            pkg_log_file = logs_dir / f"{config.pkg_type}-{pkg_name}.log"
+            with capture_console(pkg_log_file):
+                output_list = build_package_variants(pkg_name, config)
 
             if output_list:
                 built_pkglist.extend(output_list)
-                print(
-                    f"\n✓ Successfully built {len(output_list)} variant(s) for {pkg_name}"
+                logger.info(
+                    f"Successfully built {len(output_list)} variant(s) for {pkg_name}"
                 )
             else:
                 # Package failed to build
                 failed_pkglist.append(pkg_name)
-                print(f"\n✗ Failed to build any variants for {pkg_name}")
+                logger.error(f"Failed to build any variants for {pkg_name}")
 
         # Clean the build directories
         cleanup_packaging_environment(config)
 
         if built_pkglist:
-            print(f"\nBuilt packages: {built_pkglist}")
+            logger.info(f"Built packages: {built_pkglist}")
 
         pkglist_status = PackageList(
             total=pkg_list,
@@ -662,9 +669,9 @@ def run(args: argparse.Namespace):
         tb = traceback.extract_tb(sys.exc_info()[2])
         if tb:
             filename, line_no, func, text = tb[-1]
-            print(f"\n❌ Build aborted due to an error at {filename}:{line_no}: {e}\n")
+            logger.error(f"Build aborted due to an error at {filename}:{line_no}: {e}")
         else:
-            print(f"\n❌ Build aborted due to an error: {e}\n")
+            logger.error(f"Build aborted due to an error: {e}")
         # Record failed package and all pending packages
         failed_pkglist.append(pkg_list[current_pkg_idx])
         pending_pkgs = pkg_list[current_pkg_idx + 1 :]
@@ -683,6 +690,12 @@ def run(args: argparse.Namespace):
 def main(argv: list[str]):
 
     p = argparse.ArgumentParser()
+    p.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose output (DEBUG level logging)",
+    )
     p.add_argument(
         "--artifacts-dir",
         type=Path,
@@ -756,6 +769,10 @@ def main(argv: list[str]):
     )
 
     args = p.parse_args(argv)
+
+    # Configure logging based on verbose flag
+    configure_logging(verbose=args.verbose)
+
     run(args)
 
 

--- a/build_tools/packaging/linux/build_package.py
+++ b/build_tools/packaging/linux/build_package.py
@@ -44,7 +44,7 @@ from runpath_to_rpath import *
 from _therock_utils.artifacts import ArtifactCatalog
 from _therock_utils.log_utils import (
     configure_logging,
-    get_logger,
+    TheRockLogger,
     capture_console,
     github_group,
 )
@@ -52,7 +52,7 @@ from _therock_utils.log_utils import (
 from deb_package import *
 from rpm_package import *
 
-logger = get_logger(__name__)
+logger = TheRockLogger(__name__)
 
 
 # Default install prefix

--- a/build_tools/packaging/linux/deb_package.py
+++ b/build_tools/packaging/linux/deb_package.py
@@ -17,9 +17,9 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from pathlib import Path
 
 from packaging_utils import *
-from _therock_utils.log_utils import get_logger
+from _therock_utils.log_utils import TheRockLogger
 
-logger = get_logger(__name__)
+logger = TheRockLogger(__name__)
 
 # Setup paths
 SCRIPT_DIR = Path(__file__).resolve().parent

--- a/build_tools/packaging/linux/deb_package.py
+++ b/build_tools/packaging/linux/deb_package.py
@@ -17,6 +17,9 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from pathlib import Path
 
 from packaging_utils import *
+from _therock_utils.log_utils import get_logger
+
+logger = get_logger(__name__)
 
 # Setup paths
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -35,7 +38,7 @@ def create_nonversioned_deb_package(pkg_name, config: PackageConfig):
     Returns:
     output_list: List of packages created
     """
-    print_function_name()
+    logger.debug("create_nonversioned_deb_package")
     # Create immutable config copy with versioned_pkg=False
     build_config = replace(config, versioned_pkg=False)
 
@@ -75,7 +78,7 @@ def create_versioned_deb_package(pkg_name, config: PackageConfig):
     Returns:
     output_list: List of packages created
     """
-    print_function_name()
+    logger.debug("create_versioned_deb_package")
     # Explicitly ensure versioned_pkg=True
     build_config = replace(config, versioned_pkg=True)
 
@@ -104,13 +107,13 @@ def create_versioned_deb_package(pkg_name, config: PackageConfig):
     )
     sourcedir_list.extend(dir_list)
 
-    print(f"sourcedir_list:\n  {sourcedir_list}")
+    logger.debug(f"sourcedir_list: {sourcedir_list}")
     # GFX_META is a versioned meta package (empty content, just dependencies)
     is_gfx_meta = build_config.enable_kpack and build_config.gfx_arch == GFX_META
     if not sourcedir_list and not is_meta and not is_gfx_meta:
         if build_config.enable_kpack:
-            print(
-                f"ERROR: {pkg_name}: Empty sourcedir_list and not a meta package, skipping"
+            logger.error(
+                f"{pkg_name}: Empty sourcedir_list and not a meta package, skipping"
             )
             return []
         else:
@@ -119,7 +122,7 @@ def create_versioned_deb_package(pkg_name, config: PackageConfig):
             )
 
     if not sourcedir_list:
-        print(f"{pkg_name} is a Meta package")
+        logger.debug(f"{pkg_name} is a Meta package")
     else:
         # Copy package contents first
         dest_dir = package_dir / Path(build_config.install_prefix).relative_to("/")
@@ -147,7 +150,7 @@ def generate_changelog_file(pkg_info, deb_dir, config: PackageConfig):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("generate_changelog_file")
     changelog = Path(deb_dir) / "changelog"
 
     pkg_name = update_package_name(pkg_info.get("Package"), config)
@@ -199,7 +202,7 @@ def generate_install_file(pkg_info, deb_dir, config: PackageConfig, dest_dir=Non
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("generate_install_file")
     # Note: pkg_info is not used currently:
     # May be required in future to populate any context
     install_file = Path(deb_dir) / "install"
@@ -250,7 +253,7 @@ def generate_rules_file(pkg_info, deb_dir, config: PackageConfig):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("generate_rules_file")
     rules_file = Path(deb_dir) / "rules"
     disable_dh_strip = is_key_defined(pkg_info, "Disable_DEB_STRIP")
     disable_dwz = is_key_defined(pkg_info, "Disable_DWZ")
@@ -298,7 +301,7 @@ def generate_control_file(pkg_info, deb_dir, config: PackageConfig):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("generate_control_file")
     control_file = Path(deb_dir) / "control"
     pkg_name = pkg_info.get("Package")
     is_meta = is_meta_package(pkg_info)
@@ -414,13 +417,13 @@ def copy_package_contents(source_dir, destination_dir):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("copy_package_contents")
 
     source_dir = Path(source_dir)
     destination_dir = Path(destination_dir)
 
     if not source_dir.is_dir():
-        print(f"Directory does not exist: {source_dir}")
+        logger.warning(f"Directory does not exist: {source_dir}")
         return
 
     # Ensure destination directory exists
@@ -456,14 +459,14 @@ def package_with_dpkg_build(pkg_dir):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("package_with_dpkg_build")
     # Build the command
     cmd = ["dpkg-buildpackage", "-uc", "-us", "-b"]
 
     # Execute the command
     try:
         subprocess.run(cmd, check=True, cwd=pkg_dir)
-        print(f"Deb Package built successfully: {os.path.basename(pkg_dir)}")
+        logger.info(f"Deb Package built successfully: {os.path.basename(pkg_dir)}\n")
     except subprocess.CalledProcessError as e:
-        print(f"Error building deb package: {os.path.basename(pkg_dir)}: {e}")
+        logger.error(f"Error building deb package: {os.path.basename(pkg_dir)}: {e}")
         sys.exit(e.returncode)

--- a/build_tools/packaging/linux/packaging_summary.py
+++ b/build_tools/packaging/linux/packaging_summary.py
@@ -4,7 +4,10 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from packaging_utils import *
+from _therock_utils.log_utils import get_logger
 from typing import List
+
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -28,7 +31,7 @@ def write_build_manifest(config: PackageConfig, pkg_list: PackageList):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("write_build_manifest")
 
     # Write successful packages manifest
     manifest_file = Path(config.dest_dir) / "built_packages.txt"

--- a/build_tools/packaging/linux/packaging_summary.py
+++ b/build_tools/packaging/linux/packaging_summary.py
@@ -4,10 +4,10 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from packaging_utils import *
-from _therock_utils.log_utils import get_logger
+from _therock_utils.log_utils import TheRockLogger
 from typing import List
 
-logger = get_logger(__name__)
+logger = TheRockLogger(__name__)
 
 
 @dataclass

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -20,9 +20,9 @@ BUILD_TOOLS_DIR = SCRIPT_DIR.parent.parent
 if str(BUILD_TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(BUILD_TOOLS_DIR))
 
-from _therock_utils.log_utils import get_logger
+from _therock_utils.log_utils import TheRockLogger
 
-logger = get_logger(__name__)
+logger = TheRockLogger(__name__)
 
 # Constants
 # Used for creating host package in kpack mode (contains generic content)

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -12,6 +12,17 @@ import sys
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
+# Setup paths - must be before log_utils import
+SCRIPT_DIR = Path(__file__).resolve().parent
+BUILD_TOOLS_DIR = SCRIPT_DIR.parent.parent
+
+# Add build_tools directory to Python path to import _therock_utils
+if str(BUILD_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(BUILD_TOOLS_DIR))
+
+from _therock_utils.log_utils import get_logger
+
+logger = get_logger(__name__)
 
 # Constants
 # Used for creating host package in kpack mode (contains generic content)
@@ -85,20 +96,6 @@ class PackageConfig:
     versioned_pkg: bool = True
     enable_kpack: bool = False
     gfxarch_list: tuple = field(default_factory=tuple)
-
-
-SCRIPT_DIR = Path(__file__).resolve().parent
-currentFuncName = lambda n=0: sys._getframe(n + 1).f_code.co_name
-
-
-def print_function_name():
-    """Print the name of the calling function.
-
-    Parameters: None
-
-    Returns: None
-    """
-    print("In function:", currentFuncName(1))
 
 
 def read_package_json_file():
@@ -380,9 +377,9 @@ def remove_dir(dir_name):
 
     if dir_path.exists() and dir_path.is_dir():
         shutil.rmtree(dir_path)
-        print(f"Removed directory: {dir_path}")
+        logger.debug(f"Removed directory: {dir_path}")
     else:
-        print(f"Directory does not exist: {dir_path}")
+        logger.debug(f"Directory does not exist: {dir_path}")
 
 
 def update_package_name(pkg_name, config: PackageConfig):
@@ -398,7 +395,7 @@ def update_package_name(pkg_name, config: PackageConfig):
 
     Returns: Updated package name
     """
-    print_function_name()
+    logger.debug("update_package_name")
 
     pkg_suffix = ""
     if config.versioned_pkg:
@@ -525,7 +522,7 @@ def debian_replace_devel_name(pkg_name):
 
     Returns: Updated package name
     """
-    print_function_name()
+    logger.debug("debian_replace_devel_name")
     # Required for debian developement package
     suffix = "-devel"
     if pkg_name.endswith(suffix):
@@ -721,7 +718,7 @@ def convert_to_versiondependency(
 
     Returns: A string of comma separated versioned packages
     """
-    print_function_name()
+    logger.debug("convert_to_versiondependency")
     # This function is to add Version dependency
     # Make sure the flag is set to True
 
@@ -768,7 +765,7 @@ def append_version_suffix(dep_string, config: PackageConfig):
     Returns: A comma-separated string where matching dependencies include the version suffix,
     while all others remain unchanged.
     """
-    print_function_name()
+    logger.debug("append_version_suffix")
 
     pkg_list, skipped_list = get_package_list(config.artifacts_dir)
     updated_depends = []
@@ -812,11 +809,11 @@ def move_packages_to_destination(updated_pkg_name, config: PackageConfig):
     Returns:
     output_packages : list of package names moved to the destination folder
     """
-    print_function_name()
+    logger.debug("move_packages_to_destination")
     output_packages = []
     # Create destination dir to move the packages created
     os.makedirs(config.dest_dir, exist_ok=True)
-    print(f"Updated package name: {updated_pkg_name}")
+    logger.debug(f"Updated package name: {updated_pkg_name}")
     PKG_DIR = Path(config.dest_dir) / config.pkg_type
 
     if config.pkg_type.lower() == "deb":
@@ -863,7 +860,7 @@ def filter_components_fromartifactory(
 
     Returns: List of directories
     """
-    print_function_name()
+    logger.debug("filter_components_fromartifactory")
 
     pkg_info = get_package_info(pkg_name)
     sourcedir_list = []
@@ -888,7 +885,7 @@ def filter_components_fromartifactory(
 
     artifactory = pkg_info.get("Artifactory")
     if artifactory is None:
-        print(
+        logger.debug(
             f'The "Artifactory" key is missing for {pkg_name}. Is this a meta package?'
         )
         return sourcedir_list
@@ -900,7 +897,9 @@ def filter_components_fromartifactory(
         # If "Artifact_Gfxarch" key is specified use it for artifact directory suffix
         # Else use the package "Gfxarch" for finding the suffix
         if "Artifact_Gfxarch" in artifact:
-            print(f"{pkg_name} : Artifact_Gfxarch key exists for artifacts {artifact}")
+            logger.debug(
+                f"{pkg_name} : Artifact_Gfxarch key exists for artifacts {artifact}"
+            )
             is_gfxarch = str(artifact["Artifact_Gfxarch"]).lower() == "true"
 
             # In kpack mode, skip non-gfxarch artifacts when building gfx-specific packages
@@ -912,7 +911,7 @@ def filter_components_fromartifactory(
                 and gfx_arch not in (GFX_HOST, GFX_META)
                 and not is_gfxarch
             ):
-                print(
+                logger.debug(
                     f"{pkg_name} : Skipping artifact '{artifact_prefix}' for {gfx_arch} package "
                     f"(Artifact_Gfxarch=False, should only be in generic package)"
                 )
@@ -935,7 +934,7 @@ def filter_components_fromartifactory(
                 for source_dir in artifact_dirs:
                     filename = source_dir / "artifact_manifest.txt"
                     if not filename.exists():
-                        print(f"{pkg_name} : Missing {filename}")
+                        logger.debug(f"{pkg_name} : Missing {filename}")
                         continue
                     try:
                         with filename.open("r", encoding="utf-8") as file:
@@ -947,11 +946,11 @@ def filter_components_fromartifactory(
                                 )
 
                                 if match_found and line.strip():
-                                    print("Matching line:", line.strip())
+                                    logger.debug(f"Matching line: {line.strip()}")
                                     source_path = source_dir / line.strip()
                                     sourcedir_list.append(source_path)
                     except OSError as e:
-                        print(f"Could not read manifest {filename}: {e}")
+                        logger.warning(f"Could not read manifest {filename}: {e}")
                         continue
 
     return sourcedir_list
@@ -1140,7 +1139,9 @@ def filter_archs_with_artifacts(
 
     if len(available) < len(list(gfxarch_list)):
         missing = set(gfxarch_list) - set(available)
-        print(f"WORKAROUND: {pkg_name} missing artifacts for: {sorted(missing)}")
+        logger.warning(
+            f"WORKAROUND: {pkg_name} missing artifacts for: {sorted(missing)}"
+        )
 
     return available
 
@@ -1179,6 +1180,6 @@ def filter_dependencies_by_artifacts(
         if has_artifact_for_arch(dep, artifacts_dir, gfx_arch):
             filtered.append(dep)
         else:
-            print(f"WORKAROUND: Excluding {dep} (no artifacts for {gfx_arch})")
+            logger.warning(f"WORKAROUND: Excluding {dep} (no artifacts for {gfx_arch})")
 
     return filtered

--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -14,9 +14,9 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from pathlib import Path
 
 from packaging_utils import *
-from _therock_utils.log_utils import get_logger
+from _therock_utils.log_utils import TheRockLogger
 
-logger = get_logger(__name__)
+logger = TheRockLogger(__name__)
 
 # Setup paths
 SCRIPT_DIR = Path(__file__).resolve().parent

--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -14,6 +14,9 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from pathlib import Path
 
 from packaging_utils import *
+from _therock_utils.log_utils import get_logger
+
+logger = get_logger(__name__)
 
 # Setup paths
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -32,7 +35,7 @@ def create_nonversioned_rpm_package(pkg_name, config: PackageConfig):
     Returns:
     output_list: List of packages created
     """
-    print_function_name()
+    logger.debug("create_nonversioned_rpm_package")
     # Create immutable config copy with versioned_pkg=False
     build_config = replace(config, versioned_pkg=False)
 
@@ -63,7 +66,7 @@ def create_versioned_rpm_package(pkg_name, config: PackageConfig):
     Returns:
     output_list: List of packages created
     """
-    print_function_name()
+    logger.debug("create_versioned_rpm_package")
     # Explicitly ensure versioned_pkg=True
     build_config = replace(config, versioned_pkg=True)
 
@@ -90,7 +93,7 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("generate_spec_file")
     os.makedirs(os.path.dirname(specfile), exist_ok=True)
 
     pkg_info = get_package_info(pkg_name)  # Raises ValueError if not found
@@ -129,8 +132,8 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
         # Warn if we have no artifacts for non-meta packages
         if not sourcedir_list and not is_meta and not is_gfx_meta:
             if config.enable_kpack:
-                print(
-                    f"WARNING: {pkg_name}: Empty sourcedir_list and not a meta package, creating empty RPM"
+                logger.warning(
+                    f"{pkg_name}: Empty sourcedir_list and not a meta package, creating empty RPM"
                 )
             else:
                 sys.exit(
@@ -248,7 +251,7 @@ def package_with_rpmbuild(spec_file):
 
     Returns: None
     """
-    print_function_name()
+    logger.debug("package_with_rpmbuild")
     # Build the command
     cmd = [
         "rpmbuild",
@@ -261,7 +264,7 @@ def package_with_rpmbuild(spec_file):
     # Execute the command
     try:
         subprocess.run(cmd, check=True)
-        print(f"RPM Package built successfully: {spec_file.name}")
+        logger.info(f"RPM Package built successfully: {spec_file.name}\n")
     except subprocess.CalledProcessError as e:
-        print(f"Error building RPM package: {spec_file.name}: {e}")
+        logger.error(f"Error building RPM package: {spec_file.name}: {e}")
         sys.exit(e.returncode)

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -6,29 +6,18 @@
 """
 Packaging + repository upload tool.
 
-Usage (multi-arch CI — new-style, preferred):
+Usage:
   python ./build_tools/packaging/linux/upload_package_repo.py \
     --pkg-type deb \
-    --run-id 16418185899
+    --run-id 16418185899 \
+    --package-dir /path/to/packages
 
-  Bucket + prefix are resolved automatically via WorkflowOutputRoot using
-  the GITHUB_REPOSITORY and RELEASE_TYPE environment variables:
-    - CI builds    → therock-ci-artifacts / <run_id>-linux/packages/deb
-    - dev builds   → therock-dev-artifacts / <run_id>-linux/packages/deb
-    - nightly      → therock-nightly-artifacts / <run_id>-linux/packages/deb
-    - prerelease   → therock-prerelease-artifacts / <run_id>-linux/packages/deb
-
-Usage (single-arch release — legacy, build_native_linux_packages.yml):
-  python ./build_tools/packaging/linux/upload_package_repo.py \
-    --pkg-type deb \
-    --s3-bucket therock-nightly-packages \
-    --amdgpu-family gfx94X-dcgpu \
-    --artifact-id 16418185899 \
-    --job nightly
-
-  Legacy upload locations:
-    dev/nightly  → s3bucket/<pkg_type>/<YYYYMMDD>-<artifact_id>
-    prerelease   → s3bucket/v3/packages/<pkg_type>
+Bucket + prefix are resolved automatically via WorkflowOutputRoot using
+the GITHUB_REPOSITORY and RELEASE_TYPE environment variables:
+  - CI builds    → therock-ci-artifacts / <run_id>-linux/packages/deb
+  - dev builds   → therock-dev-artifacts / <run_id>-linux/packages/deb
+  - nightly      → therock-nightly-artifacts / <run_id>-linux/packages/deb
+  - prerelease   → therock-prerelease-artifacts / <run_id>-linux/packages/deb
 """
 
 import argparse
@@ -514,10 +503,6 @@ def find_package_dir():
     return base
 
 
-def yyyymmdd():
-    return datetime.datetime.utcnow().strftime("%Y%m%d")
-
-
 def s3_object_exists(s3, bucket, key):
     try:
         s3.head_object(Bucket=bucket, Key=key)
@@ -719,77 +704,28 @@ def _resolve_upload_target(
     Returns:
         Tuple of (bucket, prefix, install_url, dedupe, job_type)
     """
-    if args.run_id:
-        # New-style: derive bucket + prefix from WorkflowOutputRoot.
-        # This is the single source of truth for CI path layout.
-        root = WorkflowOutputRoot.from_workflow_run(
-            run_id=args.run_id, platform="linux"
-        )
-        loc = root.native_linux_packages(pkg_type)
-        job_type = os.environ.get("RELEASE_TYPE", "ci")
-        install_url = _package_install_url(loc.bucket, loc.relative_path, pkg_type)
-        return loc.bucket, loc.relative_path, install_url, True, job_type
-
-    if args.s3_prefix:
-        # Legacy: explicit prefix provided by get_s3_config.py
-        return (
-            args.s3_bucket,
-            args.s3_prefix,
-            _package_install_url(args.s3_bucket, args.s3_prefix, pkg_type),
-            True,
-            args.job,
-        )
-
-    if args.job in ("nightly", "dev"):
-        prefix = f"{pkg_type}/{yyyymmdd()}-{args.artifact_id}"
-        return (
-            args.s3_bucket,
-            prefix,
-            _package_install_url(args.s3_bucket, prefix, pkg_type),
-            True,
-            args.job,
-        )
-
-    if args.job == "prerelease":
-        prefix = f"v3/packages/{pkg_type}"
-        return (
-            args.s3_bucket,
-            prefix,
-            _package_install_url(args.s3_bucket, prefix, pkg_type),
-            True,
-            args.job,
-        )
-
-    raise ValueError(f"Unknown job type: {args.job!r}")
+    # Derive bucket + prefix from WorkflowOutputRoot.
+    # This is the single source of truth for CI path layout.
+    root = WorkflowOutputRoot.from_workflow_run(run_id=args.run_id, platform="linux")
+    loc = root.native_linux_packages(pkg_type)
+    job_type = os.environ.get("RELEASE_TYPE", "ci")
+    install_url = _package_install_url(loc.bucket, loc.relative_path, pkg_type)
+    return loc.bucket, loc.relative_path, install_url, True, job_type
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--pkg-type", required=True, choices=["deb", "rpm"])
 
-    # New-style args: use WorkflowOutputRoot for bucket/prefix resolution.
-    # When --run-id is provided, bucket and prefix are derived automatically
-    # from CI context (GITHUB_REPOSITORY, RELEASE_TYPE, fork detection).
+    # Use WorkflowOutputRoot for bucket/prefix resolution.
+    # Bucket and prefix are derived automatically from CI context
+    # (GITHUB_REPOSITORY, RELEASE_TYPE, fork detection).
     parser.add_argument(
         "--run-id",
-        help="GitHub Actions workflow run ID (enables WorkflowOutputRoot path resolution)",
+        required=True,
+        help="GitHub Actions workflow run ID (required for WorkflowOutputRoot path resolution)",
     )
 
-    # Legacy args: kept for backward compatibility with build_native_linux_packages.yml
-    parser.add_argument("--s3-bucket")
-    parser.add_argument("--amdgpu-family", required=False)  # unused, kept for compat
-    parser.add_argument("--artifact-id")
-    parser.add_argument(
-        "--job",
-        default="dev",
-        choices=["dev", "nightly", "prerelease"],
-        help="Job type (legacy, used when --run-id is not provided)",
-    )
-    parser.add_argument(
-        "--s3-prefix",
-        required=False,
-        help="Override S3 prefix (legacy, used when --run-id is not provided)",
-    )
     parser.add_argument(
         "--package-dir",
         required=True,
@@ -821,25 +757,56 @@ def main():
     print(f"Package repository URL: {install_url}")
     _emit_github_output("package_repository_url", install_url)
 
-    # Upload packaging logs and write step summary (only available with new-style --run-id)
-    log_index_url = None
-    if args.run_id:
-        output_root = WorkflowOutputRoot.from_workflow_run(
-            run_id=args.run_id, platform="linux"
-        )
-        backend = create_storage_backend()
-        log_index_url = upload_packaging_logs(
-            package_dir, args.pkg_type, output_root, backend
-        )
-        if log_index_url:
-            _emit_github_output("packaging_logs_url", log_index_url)
+    # Upload packaging logs and write step summary
+    output_root = WorkflowOutputRoot.from_workflow_run(
+        run_id=args.run_id, platform="linux"
+    )
+    backend = create_storage_backend()
+    log_index_url = upload_packaging_logs(
+        package_dir, args.pkg_type, output_root, backend
+    )
+    if log_index_url:
+        _emit_github_output("packaging_logs_url", log_index_url)
 
     # Write GitHub Actions step summary
     pkg_type_upper = args.pkg_type.upper()
-    gha_append_step_summary(f"### {pkg_type_upper} Package Build Results")
-    gha_append_step_summary(f"[Package Repository]({install_url})")
+    if args.pkg_type == "deb":
+        install_instructions = f"""### {pkg_type_upper} Package Build Results
+
+[Package Repository]({install_url})
+
+```bash
+# Add the repository
+echo "deb [trusted=yes] {install_url} stable main" | \\
+    sudo tee /etc/apt/sources.list.d/therock.list
+sudo apt update
+
+# Install packages
+sudo apt install <package-name>
+```
+"""
+    else:
+        install_instructions = f"""### {pkg_type_upper} Package Build Results
+
+[Package Repository]({install_url})
+
+```bash
+# Add the repository
+sudo tee /etc/yum.repos.d/therock.repo << 'EOF'
+[therock]
+name=TheRock
+baseurl={install_url}
+enabled=1
+gpgcheck=0
+EOF
+
+# Install packages
+sudo dnf install <package-name>
+```
+"""
     if log_index_url:
-        gha_append_step_summary(f"[Packaging Logs]({log_index_url})")
+        install_instructions += f"\n[Packaging Logs]({log_index_url})\n"
+    gha_append_step_summary(install_instructions)
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/upload_package_repo.py
+++ b/build_tools/packaging/linux/upload_package_repo.py
@@ -42,14 +42,19 @@ from pathlib import Path
 
 _THIS_DIR = Path(__file__).resolve().parent
 _BUILD_TOOLS_DIR = _THIS_DIR.parent.parent
+_GITHUB_ACTIONS_DIR = _BUILD_TOOLS_DIR / "github_actions"
 
 if str(_THIS_DIR) not in sys.path:
     sys.path.insert(0, str(_THIS_DIR))
 if str(_BUILD_TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(_BUILD_TOOLS_DIR))
+if str(_GITHUB_ACTIONS_DIR) not in sys.path:
+    sys.path.insert(0, str(_GITHUB_ACTIONS_DIR))
 
+from _therock_utils.storage_backend import StorageBackend, create_storage_backend
 from _therock_utils.storage_location import StorageLocation
 from _therock_utils.workflow_outputs import WorkflowOutputRoot
+from github_actions_api import gha_append_step_summary
 
 
 def regenerate_rpm_metadata_from_s3(s3, bucket, prefix, uploaded_packages):
@@ -645,6 +650,45 @@ def upload_to_s3(source_dir, bucket, prefix, dedupe=False):
     return s3, uploaded_packages  # Return S3 client and list of uploaded packages
 
 
+def upload_packaging_logs(
+    package_dir: Path,
+    pkg_type: str,
+    output_root: WorkflowOutputRoot,
+    backend: StorageBackend,
+) -> str | None:
+    """Upload native packaging logs to S3.
+
+    Uploads all log files from the packaging logs directory to the S3 location
+    specified by WorkflowOutputRoot.native_linux_packages_log_dir().
+
+    Args:
+        package_dir: Directory containing built packages (logs are in logs/ subdir)
+        pkg_type: Package type ('deb' or 'rpm')
+        output_root: WorkflowOutputRoot for computing S3 paths
+        backend: Storage backend for uploads
+
+    Returns:
+        URL to the log index page, or None if no logs were uploaded
+    """
+    log_dir = package_dir / "logs"
+    if not log_dir.is_dir():
+        print(f"[INFO] Log directory {log_dir} not found. Skipping log upload.")
+        return None
+
+    log_files = list(log_dir.glob("*.log"))
+    if not log_files:
+        print(f"[INFO] No log files found in {log_dir}. Skipping log upload.")
+        return None
+
+    print(f"Uploading {len(log_files)} packaging log files...")
+    dest_location = output_root.native_linux_packages_log_dir(pkg_type)
+    backend.upload_directory(log_dir, dest_location)
+
+    log_index_url = output_root.native_linux_packages_log_index(pkg_type).https_url
+    print(f"Packaging logs uploaded to: {log_index_url}")
+    return log_index_url
+
+
 def _emit_github_output(key: str, value: str) -> None:
     """Write a key=value pair to $GITHUB_OUTPUT if running in GitHub Actions."""
     github_output = os.environ.get("GITHUB_OUTPUT")
@@ -776,6 +820,26 @@ def main():
 
     print(f"Package repository URL: {install_url}")
     _emit_github_output("package_repository_url", install_url)
+
+    # Upload packaging logs and write step summary (only available with new-style --run-id)
+    log_index_url = None
+    if args.run_id:
+        output_root = WorkflowOutputRoot.from_workflow_run(
+            run_id=args.run_id, platform="linux"
+        )
+        backend = create_storage_backend()
+        log_index_url = upload_packaging_logs(
+            package_dir, args.pkg_type, output_root, backend
+        )
+        if log_index_url:
+            _emit_github_output("packaging_logs_url", log_index_url)
+
+    # Write GitHub Actions step summary
+    pkg_type_upper = args.pkg_type.upper()
+    gha_append_step_summary(f"### {pkg_type_upper} Package Build Results")
+    gha_append_step_summary(f"[Package Repository]({install_url})")
+    if log_index_url:
+        gha_append_step_summary(f"[Packaging Logs]({log_index_url})")
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/log_utils_test.py
+++ b/build_tools/tests/log_utils_test.py
@@ -182,11 +182,45 @@ class CaptureConsoleTest(unittest.TestCase):
                     print("should not be captured")
             self.assertFalse(log2.exists())
 
-    def test_captures_subprocess_and_python_output(self):
-        """capture_console captures Python prints and subprocess stdout/stderr.
+    def test_basic_capture_writes_to_file(self):
+        """capture_console writes output to file (platform-agnostic public API)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "build.log"
 
-        Works on both Linux (via fd redirection) and Windows (via SetStdHandle).
-        """
+            with capture_console(log_path):
+                print("hello", flush=True)
+
+            self.assertIn("hello", log_path.read_text())
+
+    @unittest.skipIf(sys.platform == "win32", "POSIX-only path")
+    def test_posix_capture(self):
+        """capture_console captures subprocess output on POSIX via fd redirection."""
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "build.log"
+
+            with capture_console(log_path):
+                print("Python output", flush=True)
+                subprocess.run(
+                    [sys.executable, "-c", "print('subprocess stdout')"],
+                    check=True,
+                )
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "-c",
+                        "import sys; sys.stderr.write('subprocess stderr\\n')",
+                    ],
+                    check=True,
+                )
+
+            content = log_path.read_text()
+            self.assertIn("Python output", content)
+            self.assertIn("subprocess stdout", content)
+            self.assertIn("subprocess stderr", content)
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only path")
+    def test_windows_capture(self):
+        """capture_console captures subprocess output on Windows via SetStdHandle."""
         with tempfile.TemporaryDirectory() as tmp:
             log_path = Path(tmp) / "build.log"
 

--- a/build_tools/tests/log_utils_test.py
+++ b/build_tools/tests/log_utils_test.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for _therock_utils.log_utils module.
+
+Tests cover:
+- Configurable verbosity levels
+- File output configuration
+- Subprocess output capture (cross-platform: Linux and Windows)
+"""
+
+import io
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from _therock_utils.log_utils import (
+    ENV_LOG_ENABLED,
+    ENV_LOG_LEVEL,
+    capture_console,
+    configure_logging,
+    disable_logger,
+    set_verbosity,
+    vlog,
+)
+
+
+class ConfigureLoggingTest(unittest.TestCase):
+    """Tests for configure_logging function."""
+
+    def setUp(self):
+        root = logging.getLogger()
+        root.handlers.clear()
+        root.setLevel(logging.WARNING)
+        logging.disable(logging.NOTSET)
+
+        self._env_backup = {}
+        for key in [ENV_LOG_ENABLED, ENV_LOG_LEVEL]:
+            self._env_backup[key] = os.environ.pop(key, None)
+
+    def tearDown(self):
+        for key, value in self._env_backup.items():
+            if value is not None:
+                os.environ[key] = value
+            elif key in os.environ:
+                del os.environ[key]
+        logging.disable(logging.NOTSET)
+
+    def test_default_and_custom_levels(self):
+        """configure_logging sets INFO by default, respects custom level."""
+        stream = io.StringIO()
+        configure_logging(stream=stream)
+        self.assertEqual(logging.getLogger().level, logging.INFO)
+
+        configure_logging(level=logging.WARNING, stream=stream)
+        self.assertEqual(logging.getLogger().level, logging.WARNING)
+
+    def test_verbose_enables_debug(self):
+        """configure_logging with verbose=True enables DEBUG level."""
+        stream = io.StringIO()
+        configure_logging(verbose=True, stream=stream)
+        self.assertEqual(logging.getLogger().level, logging.DEBUG)
+
+    def test_env_level_override(self):
+        """THEROCK_LOG_LEVEL environment variable overrides level parameter."""
+        os.environ[ENV_LOG_LEVEL] = "WARNING"
+        stream = io.StringIO()
+        configure_logging(level=logging.DEBUG, stream=stream)
+        self.assertEqual(logging.getLogger().level, logging.WARNING)
+
+    def test_enabled_false_disables(self):
+        """configure_logging with enabled=False disables all logging."""
+        stream = io.StringIO()
+        configure_logging(enabled=False, stream=stream)
+
+        logging.getLogger("test").error("This should not appear")
+        self.assertEqual(stream.getvalue(), "")
+
+
+class VerbosityTest(unittest.TestCase):
+    """Tests for set_verbosity and vlog functions."""
+
+    def setUp(self):
+        root = logging.getLogger()
+        root.handlers.clear()
+        root.setLevel(logging.WARNING)
+        logging.disable(logging.NOTSET)
+
+        self.stream = io.StringIO()
+        configure_logging(stream=self.stream)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+        set_verbosity(0)
+
+    def test_verbosity_levels(self):
+        """set_verbosity controls logging level: 0=INFO, 1+=DEBUG, -1=disabled."""
+        set_verbosity(0)
+        self.assertEqual(logging.getLogger().level, logging.INFO)
+
+        set_verbosity(1)
+        self.assertEqual(logging.getLogger().level, logging.DEBUG)
+
+        set_verbosity(-1)
+        logging.getLogger("test").error("should not appear")
+        self.assertEqual(self.stream.getvalue(), "")
+
+    def test_vlog_respects_verbosity_threshold(self):
+        """vlog only outputs when verbosity >= message level."""
+        set_verbosity(1)
+
+        vlog("level 0 message", level=0)
+        vlog("level 1 message", level=1)
+        vlog("level 2 message", level=2)
+
+        output = self.stream.getvalue()
+        self.assertIn("level 0 message", output)
+        self.assertIn("level 1 message", output)
+        self.assertNotIn("level 2 message", output)
+
+
+class DisableLoggerTest(unittest.TestCase):
+    """Tests for disable_logger function."""
+
+    def setUp(self):
+        root = logging.getLogger()
+        root.handlers.clear()
+        logging.disable(logging.NOTSET)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
+    def test_disable_logger_silences_named_logger(self):
+        """disable_logger silences the specified logger."""
+        stream = io.StringIO()
+        configure_logging(stream=stream)
+
+        logger = logging.getLogger("noisy.module")
+        logger.info("before disable")
+        self.assertIn("before disable", stream.getvalue())
+
+        stream.truncate(0)
+        stream.seek(0)
+
+        disable_logger("noisy.module")
+        logger.info("after disable")
+        self.assertEqual(stream.getvalue(), "")
+
+
+class CaptureConsoleTest(unittest.TestCase):
+    """Tests for capture_console context manager."""
+
+    def test_file_output_configuration(self):
+        """capture_console creates log file and parent directories."""
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "subdir" / "build.log"
+
+            with capture_console(log_path, also_to_console=False):
+                print("Build output", flush=True)
+
+            self.assertTrue(log_path.exists())
+            self.assertIn("Build output", log_path.read_text())
+
+    def test_disabled_skips_capture(self):
+        """capture_console skips capture when disabled via param or env."""
+        with tempfile.TemporaryDirectory() as tmp:
+            log1 = Path(tmp) / "test1.log"
+            log2 = Path(tmp) / "test2.log"
+
+            with capture_console(log1, enabled=False):
+                print("should not be captured")
+            self.assertFalse(log1.exists())
+
+            with mock.patch.dict(os.environ, {ENV_LOG_ENABLED: "0"}):
+                with capture_console(log2):
+                    print("should not be captured")
+            self.assertFalse(log2.exists())
+
+    def test_captures_subprocess_and_python_output(self):
+        """capture_console captures Python prints and subprocess stdout/stderr.
+
+        Works on both Linux (via fd redirection) and Windows (via SetStdHandle).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "build.log"
+
+            with capture_console(log_path):
+                print("Python output", flush=True)
+                subprocess.run(
+                    [sys.executable, "-c", "print('subprocess stdout')"],
+                    check=True,
+                )
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "-c",
+                        "import sys; sys.stderr.write('subprocess stderr\\n')",
+                    ],
+                    check=True,
+                )
+
+            content = log_path.read_text()
+            self.assertIn("Python output", content)
+            self.assertIn("subprocess stdout", content)
+            self.assertIn("subprocess stderr", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/tests/log_utils_test.py
+++ b/build_tools/tests/log_utils_test.py
@@ -8,6 +8,18 @@ Tests cover:
 - Configurable verbosity levels
 - File output configuration
 - Subprocess output capture (cross-platform: Linux and Windows)
+- TheRockLogger class with GitHub annotation support
+
+Run tests::
+
+    # From TheRock root directory
+    python -m pytest build_tools/tests/log_utils_test.py -v
+
+    # Run specific test class
+    python -m pytest build_tools/tests/log_utils_test.py::TheRockLoggerTest -v
+
+    # Run with unittest
+    python -m unittest build_tools.tests.log_utils_test
 """
 
 import io
@@ -23,10 +35,12 @@ from unittest import mock
 from _therock_utils.log_utils import (
     ENV_LOG_ENABLED,
     ENV_LOG_LEVEL,
+    ENV_GITHUB_ACTIONS,
     capture_console,
     configure_logging,
     disable_logger,
     set_verbosity,
+    TheRockLogger,
     vlog,
 )
 
@@ -243,6 +257,63 @@ class CaptureConsoleTest(unittest.TestCase):
             self.assertIn("Python output", content)
             self.assertIn("subprocess stdout", content)
             self.assertIn("subprocess stderr", content)
+
+
+class TheRockLoggerTest(unittest.TestCase):
+    """Tests for TheRockLogger class."""
+
+    def setUp(self):
+        root = logging.getLogger()
+        root.handlers.clear()
+        logging.disable(logging.NOTSET)
+
+        self.stream = io.StringIO()
+        configure_logging(stream=self.stream)
+
+        self._env_backup = os.environ.get(ENV_GITHUB_ACTIONS)
+        os.environ.pop(ENV_GITHUB_ACTIONS, None)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+        if self._env_backup is not None:
+            os.environ[ENV_GITHUB_ACTIONS] = self._env_backup
+        else:
+            os.environ.pop(ENV_GITHUB_ACTIONS, None)
+
+    def test_logger_methods(self):
+        """TheRockLogger provides info/warning/error methods."""
+        logger = TheRockLogger("test_module")
+
+        logger.info("info message")
+        logger.warning("warning message")
+        logger.error("error message")
+
+        output = self.stream.getvalue()
+        self.assertIn("info message", output)
+        self.assertIn("warning message", output)
+        self.assertIn("error message", output)
+
+    def test_logger_with_github_annotation(self):
+        """TheRockLogger supports github=True for annotations."""
+        os.environ[ENV_GITHUB_ACTIONS] = "true"
+        logger = TheRockLogger("test_module")
+
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            logger.warning("GitHub warning", github=True)
+            logger.error("GitHub error", github=True, file="test.py", line=5)
+
+            output = mock_stdout.getvalue()
+            self.assertIn("::warning::GitHub warning", output)
+            self.assertIn("::error file=test.py,line=5::GitHub error", output)
+
+    def test_logger_github_skipped_when_not_ci(self):
+        """TheRockLogger skips GitHub annotation when not in CI."""
+        os.environ.pop(ENV_GITHUB_ACTIONS, None)
+        logger = TheRockLogger("test_module")
+
+        with mock.patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            logger.warning("should not appear", github=True)
+            self.assertEqual(mock_stdout.getvalue(), "")
 
 
 if __name__ == "__main__":

--- a/build_tools/tests/workflow_outputs_test.py
+++ b/build_tools/tests/workflow_outputs_test.py
@@ -174,6 +174,20 @@ class TestWorkflowOutputRootLocations(unittest.TestCase):
         loc = self.root.python_packages()
         self._assert_relative_path(loc, "99999-linux/python")
 
+    # -- Native Linux packages logs --
+
+    def test_native_linux_packages_log_dir_deb(self):
+        loc = self.root.native_linux_packages_log_dir("deb")
+        self._assert_relative_path(loc, "99999-linux/logs/packaging/deb")
+
+    def test_native_linux_packages_log_dir_rpm(self):
+        loc = self.root.native_linux_packages_log_dir("rpm")
+        self._assert_relative_path(loc, "99999-linux/logs/packaging/rpm")
+
+    def test_native_linux_packages_log_index(self):
+        loc = self.root.native_linux_packages_log_index("deb")
+        self._assert_relative_path(loc, "99999-linux/logs/packaging/deb/index.html")
+
 
 class TestWorkflowOutputRootLocationsExternalRepo(unittest.TestCase):
     """Verify external_repo prefix propagates through location methods."""


### PR DESCRIPTION
  Introduce unified logging infrastructure for the packaging system:

 Add log_utils.py providing:
  - configure_logging() for one-time setup with verbosity control
  - TheRockLogger class as the primary public API with familiar
    logger.info()/warning()/error() interface
  - capture_console() for capturing stdout/stderr to files with
    race-condition-safe shutdown (threads joined before closing FDs)
  - GitHub Actions integration (collapsible groups, annotations via
    github=True parameter with optional file/line support)
  - Thread-safe stream handling for subprocess output

Add per-package log files at {dest-dir}/logs/{pkgtype}-{pkg_name}.log
  Each package build generates its own log file for easier debugging
  and isolation of build issues.
  
  Environment variable controls:
  - THEROCK_LOG_LEVEL: Set log level (DEBUG, INFO, WARNING, ERROR)
  - THEROCK_LOG_ENABLED: Enable/disable logging (default: enabled)

  Add native packaging logs upload to S3.

  All Linux packaging modules (build_package.py, deb_package.py,
  rpm_package.py, packaging_utils.py, packaging_summary.py) use the
  unified TheRockLogger API.

  Add comprehensive test coverage with platform-specific decorators
  (@skipIf/@skipUnless) for POSIX and Windows capture paths.

JIRA ID: https://github.com/ROCm/TheRock/issues/3734