### PR TITLE
Add gha_update_pr_comment foundation (POST/PATCH in github_actions_api)

### DIFF
--- a/build_tools/github_actions/github_actions_api.py
+++ b/build_tools/github_actions/github_actions_api.py
@@ -617,6 +617,7 @@ def gha_update_pr_comment(
     github_repository: str = "ROCm/TheRock",
     *,
     github_api: "GitHubAPI | None" = None,
+    comment_author: str | None = None,
 ) -> dict:
     """Create or update a sticky PR comment identified by an HTML marker.
 
@@ -627,7 +628,7 @@ def gha_update_pr_comment(
     Args:
         pr_number: Pull request number.
         marker: Unique HTML comment marker embedded in the comment body
-            (e.g. ``<!-- therock-report-manifest-diff -->``).
+            (e.g. ``<!-- example-marker -->``).
         body: Full comment body (must include ``marker``).
         github_repository: Repository in ``owner/repo`` format.
         github_api: Optional ``GitHubAPI`` instance to use instead of the
@@ -635,6 +636,12 @@ def gha_update_pr_comment(
             instance for cross-repo comments (e.g. a GitHub App installation
             token scoped to ``github_repository``) so this call doesn't
             disturb the singleton's own token/auth state.
+        comment_author: Optional GitHub username to restrict matching to.
+            When set, only an existing comment whose author's login equals
+            this value is treated as the sticky comment to update; comments
+            that merely contain ``marker`` but were authored by someone else
+            (e.g. a human who quote-replied the bot's comment) are ignored,
+            and a new comment is posted instead of editing theirs.
 
     Returns:
         The created or updated comment object from the GitHub API.
@@ -650,7 +657,10 @@ def gha_update_pr_comment(
     """
     if marker not in body:
         _log(
-            f"Warning: marker {marker!r} not found in comment body for PR #{pr_number}"
+            f"Warning: marker\n  {marker}\n"
+            f"not found in body for PR comment on "
+            f"https://github.com/{github_repository}/pull/{pr_number}\n"
+            f"body text:\n  {body}"
         )
 
     api = github_api or _default_github_api
@@ -671,9 +681,15 @@ def gha_update_pr_comment(
             break
 
         for comment in comments:
-            if marker in comment.get("body", ""):
-                existing_comment_id = comment["id"]
-                break
+            if marker not in comment.get("body", ""):
+                continue
+            if (
+                comment_author is not None
+                and comment.get("user", {}).get("login") != comment_author
+            ):
+                continue
+            existing_comment_id = comment["id"]
+            break
 
         if existing_comment_id is not None:
             break

--- a/build_tools/github_actions/github_actions_api.py
+++ b/build_tools/github_actions/github_actions_api.py
@@ -73,6 +73,16 @@ class GitHubAPI:
     For most use cases, use the module-level functions which use a shared
     singleton instance:
         response = gha_send_request("https://api.github.com/repos/owner/repo")
+
+    When a caller needs to authenticate as something other than the default
+    singleton's token (e.g. a GitHub App installation token scoped to a
+    different repository), construct a dedicated instance with an explicit
+    token instead:
+        api = GitHubAPI(github_token=app_installation_token)
+        response = api.send_request("https://api.github.com/repos/other/repo")
+    This is useful when a single process needs to juggle multiple distinct
+    tokens (e.g. two GitHub App tokens minted in the same job), since the
+    module-level singleton caches only one token for its lifetime.
     """
 
     class AuthMethod(Enum):
@@ -87,9 +97,21 @@ class GitHubAPI:
         # Use the GitHub REST API without authenticating, subject to rate limits.
         UNAUTHENTICATED = auto()
 
-    def __init__(self):
-        self._auth_method: GitHubAPI.AuthMethod | None = None
-        self._github_token: str | None = None
+    def __init__(self, github_token: str | None = None):
+        """Creates a GitHub API client.
+
+        Args:
+            github_token: Optional explicit token to authenticate with. When
+                provided, this instance uses that token directly and skips
+                the GITHUB_TOKEN env var / gh CLI auto-detection below. Use
+                this to bind an instance to a specific token (e.g. a GitHub
+                App installation token) without affecting the module-level
+                singleton or other instances.
+        """
+        self._auth_method: GitHubAPI.AuthMethod | None = (
+            GitHubAPI.AuthMethod.GITHUB_TOKEN if github_token else None
+        )
+        self._github_token: str | None = github_token
         self._gh_cli_path: str | None = None
 
     def _detect_auth_method(self) -> AuthMethod:
@@ -155,7 +177,14 @@ class GitHubAPI:
 
         return headers
 
-    def _send_request_via_gh_cli(self, url: str, timeout_seconds: int) -> object:
+    def _send_request_via_gh_cli(
+        self,
+        url: str,
+        timeout_seconds: int,
+        *,
+        method: str = "GET",
+        body: object | None = None,
+    ) -> object:
         """Sends a GitHub API request using the gh CLI.
 
         Raises:
@@ -169,9 +198,16 @@ class GitHubAPI:
         # Strip the base URL to get the API path
         api_path = url.removeprefix("https://api.github.com")
 
+        cmd = [self._gh_cli_path, "api", "--method", method, api_path]
+        input_data: str | None = None
+        if body is not None:
+            cmd.extend(["--input", "-"])
+            input_data = json.dumps(body)
+
         try:
             result = subprocess.run(
-                [self._gh_cli_path, "api", api_path],
+                cmd,
+                input=input_data,
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
@@ -190,7 +226,9 @@ class GitHubAPI:
             stderr = result.stderr or "(no error message)"
             raise GitHubAPIError(f"gh api request failed: {stderr}")
 
-        if not result.stdout:
+        if not result.stdout or not result.stdout.strip():
+            if method in ("POST", "PATCH", "PUT", "DELETE"):
+                return {}
             raise GitHubAPIError("gh api returned empty response")
 
         try:
@@ -200,18 +238,29 @@ class GitHubAPI:
                 f"gh api returned invalid JSON: {e.msg} at position {e.pos}"
             ) from e
 
-    def _send_request_via_rest_api(self, url: str, timeout_seconds: int) -> object:
+    def _send_request_via_rest_api(
+        self,
+        url: str,
+        timeout_seconds: int,
+        *,
+        method: str = "GET",
+        body: object | None = None,
+    ) -> object:
         """Sends a GitHub API request using the REST API directly.
 
         Raises:
             GitHubAPIError: If the request fails for any reason.
         """
         headers = self._get_request_headers()
-        request = Request(url, headers=headers)
+        data: bytes | None = None
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+            data = json.dumps(body).encode("utf-8")
+        request = Request(url, data=data, headers=headers, method=method)
 
         try:
             with urlopen(request, timeout=timeout_seconds) as response:
-                body = response.read().decode("utf-8")
+                response_body = response.read().decode("utf-8")
         except HTTPError as e:
             # Try to read the error response body for more context
             error_body = ""
@@ -248,19 +297,32 @@ class GitHubAPI:
                 f"Request timed out after {timeout_seconds}s for {url}"
             ) from e
 
+        if not response_body:
+            if method in ("POST", "PATCH", "PUT", "DELETE"):
+                return {}
+
         try:
-            return json.loads(body)
+            return json.loads(response_body)
         except json.JSONDecodeError as e:
             raise GitHubAPIError(
                 f"Invalid JSON response from {url}: {e.msg} at position {e.pos}"
             ) from e
 
-    def send_request(self, url: str, timeout_seconds: int = 300) -> object:
+    def send_request(
+        self,
+        url: str,
+        timeout_seconds: int = 300,
+        *,
+        method: str = "GET",
+        body: object | None = None,
+    ) -> object:
         """Sends a request to the given GitHub REST API URL.
 
         Args:
             url: Full GitHub API URL (e.g., https://api.github.com/repos/...)
             timeout_seconds: Request timeout in seconds (default 300).
+            method: HTTP method (default GET). POST and PATCH are supported.
+            body: Optional JSON-serializable request body for POST/PATCH.
 
         Returns:
             Parsed JSON response.
@@ -273,12 +335,16 @@ class GitHubAPI:
         auth_method = self.get_auth_method()
 
         if auth_method == GitHubAPI.AuthMethod.GH_CLI:
-            return self._send_request_via_gh_cli(url, timeout_seconds)
+            return self._send_request_via_gh_cli(
+                url, timeout_seconds, method=method, body=body
+            )
 
         if auth_method == GitHubAPI.AuthMethod.UNAUTHENTICATED:
             _log("Warning: No GitHub auth available, requests may be rate limited")
 
-        return self._send_request_via_rest_api(url, timeout_seconds)
+        return self._send_request_via_rest_api(
+            url, timeout_seconds, method=method, body=body
+        )
 
 
 # Module-level singleton with cached state.
@@ -511,7 +577,13 @@ def is_current_run_pr_from_fork() -> bool:
     )
 
 
-def gha_send_request(url: str, timeout_seconds: int = 300) -> object:
+def gha_send_request(
+    url: str,
+    timeout_seconds: int = 300,
+    *,
+    method: str = "GET",
+    body: object | None = None,
+) -> object:
     """Sends a request to the given GitHub REST API URL and returns the response.
 
     Authentication is handled automatically:
@@ -522,6 +594,8 @@ def gha_send_request(url: str, timeout_seconds: int = 300) -> object:
     Args:
         url: Full GitHub API URL (e.g., https://api.github.com/repos/...)
         timeout_seconds: Request timeout in seconds (default 300).
+        method: HTTP method (default GET). POST and PATCH are supported.
+        body: Optional JSON-serializable request body for POST/PATCH.
 
     Returns:
         Parsed JSON response.
@@ -531,7 +605,138 @@ def gha_send_request(url: str, timeout_seconds: int = 300) -> object:
             timeout, invalid JSON, etc.). The original exception is available
             via the __cause__ attribute.
     """
-    return _default_github_api.send_request(url, timeout_seconds=timeout_seconds)
+    return _default_github_api.send_request(
+        url, timeout_seconds=timeout_seconds, method=method, body=body
+    )
+
+
+def gha_update_pr_comment(
+    pr_number: int,
+    marker: str,
+    body: str,
+    github_repository: str = "ROCm/TheRock",
+    *,
+    github_api: "GitHubAPI | None" = None,
+) -> dict:
+    """Create or update a sticky PR comment identified by an HTML marker.
+
+    Paginates through existing issue comments on the pull request. If a comment
+    whose body contains ``marker`` is found, that comment is updated in place.
+    Otherwise a new comment is posted.
+
+    Args:
+        pr_number: Pull request number.
+        marker: Unique HTML comment marker embedded in the comment body
+            (e.g. ``<!-- therock-report-manifest-diff -->``).
+        body: Full comment body (must include ``marker``).
+        github_repository: Repository in ``owner/repo`` format.
+        github_api: Optional ``GitHubAPI`` instance to use instead of the
+            module-level singleton. Pass a dedicated ``GitHubAPI(github_token=...)``
+            instance for cross-repo comments (e.g. a GitHub App installation
+            token scoped to ``github_repository``) so this call doesn't
+            disturb the singleton's own token/auth state.
+
+    Returns:
+        The created or updated comment object from the GitHub API.
+
+    Authentication defaults to the module-level singleton (see
+    :func:`gha_send_request`), which uses :envvar:`GITHUB_TOKEN`. In GitHub
+    Actions, set ``GITHUB_TOKEN: ${{ github.token }}`` on the step and grant
+    ``pull-requests: write`` (or ``issues: write``) in job ``permissions``.
+    For cross-repo comments, pass ``github_api=GitHubAPI(github_token=...)``
+    with an App installation token that has access to ``github_repository``.
+
+    See: https://docs.github.com/en/rest/issues/comments
+    """
+    if marker not in body:
+        _log(
+            f"Warning: marker {marker!r} not found in comment body for PR #{pr_number}"
+        )
+
+    api = github_api or _default_github_api
+
+    comments_url = (
+        f"https://api.github.com/repos/{github_repository}"
+        f"/issues/{pr_number}/comments"
+    )
+    MAX_PAGES = 10
+    PER_PAGE = 100
+    page = 1
+    existing_comment_id = None
+
+    while page <= MAX_PAGES:
+        page_url = f"{comments_url}?per_page={PER_PAGE}&page={page}"
+        comments = api.send_request(page_url)
+        if not isinstance(comments, list):
+            break
+
+        for comment in comments:
+            if marker in comment.get("body", ""):
+                existing_comment_id = comment["id"]
+                break
+
+        if existing_comment_id is not None:
+            break
+
+        if len(comments) < PER_PAGE:
+            break
+        page += 1
+
+    if existing_comment_id is not None:
+        patch_url = (
+            f"https://api.github.com/repos/{github_repository}"
+            f"/issues/comments/{existing_comment_id}"
+        )
+        response = api.send_request(patch_url, method="PATCH", body={"body": body})
+    else:
+        response = api.send_request(comments_url, method="POST", body={"body": body})
+
+    if not isinstance(response, dict):
+        raise GitHubAPIError(
+            f"Expected comment object from GitHub API for PR #{pr_number}, "
+            f"got {type(response).__name__}"
+        )
+    return response
+
+
+def gha_query_prs_for_commit(
+    github_repository: str,
+    sha: str,
+    *,
+    github_api: "GitHubAPI | None" = None,
+) -> list[dict]:
+    """Gets the pull requests associated with a commit.
+
+    Uses the GitHub REST API endpoint: /commits/{sha}/pulls
+
+    A commit can be associated with more than one pull request (e.g. if it
+    was cherry-picked, or landed via multiple merge paths).
+
+    Args:
+        github_repository: Repository in "owner/repo" format (e.g. "ROCm/TheRock").
+        sha: Full (or unambiguous short) git commit SHA.
+        github_api: Optional ``GitHubAPI`` instance to use instead of the
+            module-level singleton. Pass a dedicated ``GitHubAPI(github_token=...)``
+            instance when querying a repository that requires a different
+            token than the singleton's (e.g. a superrepo App installation
+            token).
+
+    Returns:
+        List of pull request objects from the GitHub API. Empty list if the
+        commit is not associated with any pull request (or hasn't been
+        pushed to GitHub, e.g. it only exists locally).
+
+    See: https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit
+    """
+    api = github_api or _default_github_api
+    url = f"https://api.github.com/repos/{github_repository}/commits/{sha}/pulls"
+    response = api.send_request(url)
+    if not isinstance(response, list):
+        raise GitHubAPIError(
+            f"Expected a list of pull requests for commit {sha!r} in "
+            f"{github_repository!r}, got {type(response).__name__}"
+        )
+    return response
 
 
 def gha_query_workflow_run_by_id(github_repository: str, workflow_run_id: str) -> dict:

--- a/build_tools/github_actions/tests/github_actions_api_test.py
+++ b/build_tools/github_actions/tests/github_actions_api_test.py
@@ -22,12 +22,14 @@ from github_actions_api import (
     gha_job_summary_mirror_path,
     gha_load_github_event,
     gha_query_last_workflow_run,
+    gha_query_prs_for_commit,
     gha_query_recent_branch_commits,
     gha_query_workflow_run_by_id,
     gha_query_workflow_runs_for_commit,
     gha_resolve_git_ref,
     gha_set_job_summary_output,
     gha_set_output,
+    gha_update_pr_comment,
     is_authenticated_github_api_available,
 )
 
@@ -196,6 +198,39 @@ class GitHubAPITest(unittest.TestCase):
         api = GitHubAPI()
         auth_method = api.get_auth_method()
         self.assertIsInstance(auth_method, GitHubAPI.AuthMethod)
+
+    def test_explicit_github_token_skips_auto_detection(self):
+        """An explicit github_token should be used without env/gh-CLI detection."""
+        # No GITHUB_TOKEN env var and gh CLI unavailable: auto-detection alone
+        # would land on UNAUTHENTICATED, but the explicit token should win.
+        with mock.patch("github_actions_api.shutil.which", return_value=None):
+            api = GitHubAPI(github_token="explicit-token")
+            self.assertEqual(api.get_auth_method(), GitHubAPI.AuthMethod.GITHUB_TOKEN)
+            self.assertEqual(api._github_token, "explicit-token")
+
+    def test_explicit_github_token_used_in_request_headers(self):
+        """An explicit github_token should be sent as the Authorization header."""
+        api = GitHubAPI(github_token="explicit-token")
+        headers = api._get_request_headers()
+        self.assertEqual(headers["Authorization"], "Bearer explicit-token")
+
+    def test_explicit_github_token_independent_of_env_token(self):
+        """Two instances with different explicit tokens should not interfere."""
+        os.environ["GITHUB_TOKEN"] = "env-token"
+        default_api = GitHubAPI()
+        app_api = GitHubAPI(github_token="app-token")
+
+        self.assertEqual(
+            default_api._get_request_headers()["Authorization"], "Bearer env-token"
+        )
+        self.assertEqual(
+            app_api._get_request_headers()["Authorization"], "Bearer app-token"
+        )
+
+    def test_no_github_token_falls_back_to_auto_detection(self):
+        """Without an explicit github_token, auto-detection still runs as before."""
+        api = GitHubAPI(github_token=None)
+        self.assertIsNone(api._auth_method)
 
     # -------------------------------------------------------------------------
     # Successful request tests
@@ -472,6 +507,297 @@ class GitHubAPITest(unittest.TestCase):
 
             self.assertIn("Invalid JSON", str(ctx.exception))
             self.assertIsInstance(ctx.exception.__cause__, json.JSONDecodeError)
+
+    def test_rest_api_post_sends_json_body(self):
+        """REST API POST should send JSON body with Content-Type header."""
+        os.environ["GITHUB_TOKEN"] = "test-token"
+        api = GitHubAPI()
+
+        mock_response = mock.MagicMock()
+        mock_response.read.return_value = b'{"id": 99}'
+        mock_response.__enter__.return_value = mock_response
+
+        with mock.patch(
+            "github_actions_api.urlopen", return_value=mock_response
+        ) as urlopen:
+            result = api.send_request(
+                "https://api.github.com/repos/test/test/issues/1/comments",
+                method="POST",
+                body={"body": "hello"},
+            )
+
+        self.assertEqual(result, {"id": 99})
+        request = urlopen.call_args[0][0]
+        self.assertEqual(request.method, "POST")
+        self.assertEqual(request.data, b'{"body": "hello"}')
+        self.assertEqual(request.headers["Content-type"], "application/json")
+
+    def test_rest_api_patch_sends_json_body(self):
+        """REST API PATCH should send JSON body."""
+        os.environ["GITHUB_TOKEN"] = "test-token"
+        api = GitHubAPI()
+
+        mock_response = mock.MagicMock()
+        mock_response.read.return_value = b'{"id": 42, "body": "updated"}'
+        mock_response.__enter__.return_value = mock_response
+
+        with mock.patch(
+            "github_actions_api.urlopen", return_value=mock_response
+        ) as urlopen:
+            result = api.send_request(
+                "https://api.github.com/repos/test/test/issues/comments/42",
+                method="PATCH",
+                body={"body": "updated"},
+            )
+
+        self.assertEqual(result["id"], 42)
+        request = urlopen.call_args[0][0]
+        self.assertEqual(request.method, "PATCH")
+
+    def test_gh_cli_post_uses_method_and_stdin_body(self):
+        """gh CLI POST should pass --method and JSON on stdin."""
+        api = GitHubAPI()
+        api._auth_method = GitHubAPI.AuthMethod.GH_CLI
+        api._gh_cli_path = "/usr/bin/gh"
+
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = '{"id": 7}'
+
+        with mock.patch(
+            "github_actions_api.subprocess.run", return_value=mock_result
+        ) as subprocess_run:
+            result = api.send_request(
+                "https://api.github.com/repos/test/test/issues/1/comments",
+                method="POST",
+                body={"body": "hello"},
+            )
+
+        self.assertEqual(result, {"id": 7})
+        cmd = subprocess_run.call_args[0][0]
+        self.assertEqual(cmd[0:4], ["/usr/bin/gh", "api", "--method", "POST"])
+        self.assertEqual(cmd[4], "/repos/test/test/issues/1/comments")
+        self.assertIn("--input", cmd)
+        self.assertEqual(subprocess_run.call_args[1]["input"], '{"body": "hello"}')
+
+    def test_rest_api_get_empty_body_raises_github_api_error(self):
+        """REST API GET with empty body should raise GitHubAPIError (unchanged behavior)."""
+        import json
+
+        os.environ["GITHUB_TOKEN"] = "test-token"
+        api = GitHubAPI()
+
+        mock_response = mock.MagicMock()
+        mock_response.read.return_value = b""
+        mock_response.__enter__.return_value = mock_response
+
+        with mock.patch("github_actions_api.urlopen", return_value=mock_response):
+            with self.assertRaises(GitHubAPIError) as ctx:
+                api.send_request("https://api.github.com/repos/test/test")
+
+            self.assertIn("Invalid JSON", str(ctx.exception))
+            self.assertIsInstance(ctx.exception.__cause__, json.JSONDecodeError)
+
+    def test_rest_api_post_empty_body_returns_empty_dict(self):
+        """REST API POST with empty body may return {} without parsing JSON."""
+        os.environ["GITHUB_TOKEN"] = "test-token"
+        api = GitHubAPI()
+
+        mock_response = mock.MagicMock()
+        mock_response.read.return_value = b""
+        mock_response.__enter__.return_value = mock_response
+
+        with mock.patch("github_actions_api.urlopen", return_value=mock_response):
+            result = api.send_request(
+                "https://api.github.com/repos/test/test/issues/1/comments",
+                method="POST",
+                body={"body": "hello"},
+            )
+
+        self.assertEqual(result, {})
+
+
+class GhaUpdatePrCommentTest(unittest.TestCase):
+    """Tests for gha_update_pr_comment."""
+
+    def test_posts_new_comment_when_marker_not_found(self):
+        marker = "<!-- therock-report-manifest-diff -->"
+        body = f"{marker}\n### Report\n\n[View report](https://example.com)\n"
+        comments_url = "https://api.github.com/repos/ROCm/TheRock/issues/42/comments"
+
+        with mock.patch(
+            "github_actions_api._default_github_api.send_request",
+            side_effect=[
+                [{"id": 1, "body": "unrelated comment"}],
+                {"id": 99, "body": body},
+            ],
+        ) as send_request:
+            result = gha_update_pr_comment(
+                pr_number=42,
+                marker=marker,
+                body=body,
+            )
+
+        self.assertEqual(result["id"], 99)
+        self.assertEqual(send_request.call_count, 2)
+        send_request.assert_any_call(
+            f"{comments_url}?per_page=100&page=1",
+        )
+        send_request.assert_any_call(
+            comments_url,
+            method="POST",
+            body={"body": body},
+        )
+
+    def test_patches_existing_comment_when_marker_found(self):
+        marker = "<!-- therock-report-manifest-diff -->"
+        body = f"{marker}\n### Report\n\n[View report](https://example.com/v2)\n"
+        comments_url = "https://api.github.com/repos/ROCm/TheRock/issues/42/comments"
+
+        with mock.patch(
+            "github_actions_api._default_github_api.send_request",
+            side_effect=[
+                [{"id": 10, "body": f"{marker}\nold content"}],
+                {"id": 10, "body": body},
+            ],
+        ) as send_request:
+            result = gha_update_pr_comment(
+                pr_number=42,
+                marker=marker,
+                body=body,
+            )
+
+        self.assertEqual(result["id"], 10)
+        self.assertEqual(send_request.call_count, 2)
+        send_request.assert_any_call(
+            "https://api.github.com/repos/ROCm/TheRock/issues/comments/10",
+            method="PATCH",
+            body={"body": body},
+        )
+        send_request.assert_any_call(f"{comments_url}?per_page=100&page=1")
+
+    def test_paginates_until_marker_found(self):
+        marker = "<!-- therock-breadcrumb-unmapped-6057 -->"
+        body = f"{marker}\n### Unmapped\n"
+        comments_url = (
+            "https://api.github.com/repos/ROCm/rocm-libraries/issues/7/comments"
+        )
+
+        page_1 = [{"id": i, "body": f"comment {i}"} for i in range(100)]
+        page_2 = [{"id": 200, "body": f"{marker}\nstale"}]
+
+        with mock.patch(
+            "github_actions_api._default_github_api.send_request",
+            side_effect=[
+                page_1,
+                page_2,
+                {"id": 200, "body": body},
+            ],
+        ) as send_request:
+            result = gha_update_pr_comment(
+                pr_number=7,
+                marker=marker,
+                body=body,
+                github_repository="ROCm/rocm-libraries",
+            )
+
+        self.assertEqual(result["id"], 200)
+        self.assertEqual(send_request.call_count, 3)
+        send_request.assert_any_call(f"{comments_url}?per_page=100&page=1")
+        send_request.assert_any_call(f"{comments_url}?per_page=100&page=2")
+
+    def test_raises_when_comment_response_is_not_dict(self):
+        marker = "<!-- therock-report-manifest-diff -->"
+        body = f"{marker}\nbody"
+
+        with mock.patch(
+            "github_actions_api._default_github_api.send_request",
+            side_effect=[[], "not-a-dict"],
+        ):
+            with self.assertRaisesRegex(GitHubAPIError, "Expected comment object"):
+                gha_update_pr_comment(pr_number=1, marker=marker, body=body)
+
+    def test_uses_provided_github_api_instance_instead_of_singleton(self):
+        """A github_api override should be used instead of the singleton."""
+        marker = "<!-- therock-bump-breadcrumb -->"
+        body = f"{marker}\nThis PR is now part of TheRock."
+
+        custom_api = mock.create_autospec(GitHubAPI, instance=True)
+        custom_api.send_request.side_effect = [
+            [],
+            {"id": 55, "body": body},
+        ]
+
+        with mock.patch(
+            "github_actions_api._default_github_api.send_request"
+        ) as singleton_send_request:
+            result = gha_update_pr_comment(
+                pr_number=9,
+                marker=marker,
+                body=body,
+                github_repository="ROCm/rocm-systems",
+                github_api=custom_api,
+            )
+
+        self.assertEqual(result["id"], 55)
+        self.assertEqual(custom_api.send_request.call_count, 2)
+        singleton_send_request.assert_not_called()
+
+
+class GhaQueryPrsForCommitTest(unittest.TestCase):
+    """Tests for gha_query_prs_for_commit."""
+
+    def test_returns_prs_for_commit(self):
+        sha = "a" * 40
+        prs = [{"number": 42, "title": "Some PR"}]
+
+        with mock.patch(
+            "github_actions_api._default_github_api.send_request",
+            return_value=prs,
+        ) as send_request:
+            result = gha_query_prs_for_commit("ROCm/TheRock", sha)
+
+        self.assertEqual(result, prs)
+        send_request.assert_called_once_with(
+            f"https://api.github.com/repos/ROCm/TheRock/commits/{sha}/pulls"
+        )
+
+    def test_returns_empty_list_when_no_prs_found(self):
+        with mock.patch(
+            "github_actions_api._default_github_api.send_request",
+            return_value=[],
+        ):
+            result = gha_query_prs_for_commit("ROCm/TheRock", "b" * 40)
+
+        self.assertEqual(result, [])
+
+    def test_raises_when_response_is_not_list(self):
+        with mock.patch(
+            "github_actions_api._default_github_api.send_request",
+            return_value={"message": "not found"},
+        ):
+            with self.assertRaisesRegex(GitHubAPIError, "Expected a list"):
+                gha_query_prs_for_commit("ROCm/TheRock", "c" * 40)
+
+    def test_uses_provided_github_api_instance_instead_of_singleton(self):
+        """A github_api override should be used instead of the singleton."""
+        sha = "d" * 40
+        prs = [{"number": 7}]
+        custom_api = mock.create_autospec(GitHubAPI, instance=True)
+        custom_api.send_request.return_value = prs
+
+        with mock.patch(
+            "github_actions_api._default_github_api.send_request"
+        ) as singleton_send_request:
+            result = gha_query_prs_for_commit(
+                "ROCm/rocm-libraries", sha, github_api=custom_api
+            )
+
+        self.assertEqual(result, prs)
+        custom_api.send_request.assert_called_once_with(
+            f"https://api.github.com/repos/ROCm/rocm-libraries/commits/{sha}/pulls"
+        )
+        singleton_send_request.assert_not_called()
 
 
 class GitHubActionsUtilsTest(unittest.TestCase):

--- a/build_tools/github_actions/tests/github_actions_api_test.py
+++ b/build_tools/github_actions/tests/github_actions_api_test.py
@@ -582,8 +582,6 @@ class GitHubAPITest(unittest.TestCase):
 
     def test_rest_api_get_empty_body_raises_github_api_error(self):
         """REST API GET with empty body should raise GitHubAPIError (unchanged behavior)."""
-        import json
-
         os.environ["GITHUB_TOKEN"] = "test-token"
         api = GitHubAPI()
 
@@ -621,7 +619,7 @@ class GhaUpdatePrCommentTest(unittest.TestCase):
     """Tests for gha_update_pr_comment."""
 
     def test_posts_new_comment_when_marker_not_found(self):
-        marker = "<!-- therock-report-manifest-diff -->"
+        marker = "<!-- example-marker -->"
         body = f"{marker}\n### Report\n\n[View report](https://example.com)\n"
         comments_url = "https://api.github.com/repos/ROCm/TheRock/issues/42/comments"
 
@@ -650,7 +648,7 @@ class GhaUpdatePrCommentTest(unittest.TestCase):
         )
 
     def test_patches_existing_comment_when_marker_found(self):
-        marker = "<!-- therock-report-manifest-diff -->"
+        marker = "<!-- example-marker -->"
         body = f"{marker}\n### Report\n\n[View report](https://example.com/v2)\n"
         comments_url = "https://api.github.com/repos/ROCm/TheRock/issues/42/comments"
 
@@ -706,42 +704,74 @@ class GhaUpdatePrCommentTest(unittest.TestCase):
         send_request.assert_any_call(f"{comments_url}?per_page=100&page=1")
         send_request.assert_any_call(f"{comments_url}?per_page=100&page=2")
 
-    def test_raises_when_comment_response_is_not_dict(self):
-        marker = "<!-- therock-report-manifest-diff -->"
-        body = f"{marker}\nbody"
+    def test_ignores_comment_from_other_author_when_comment_author_set(self):
+        """A marker match from an unexpected author should be skipped, not edited."""
+        marker = "<!-- example-marker -->"
+        body = f"{marker}\nThis PR is now part of TheRock."
+        comments_url = (
+            "https://api.github.com/repos/ROCm/rocm-systems/issues/9/comments"
+        )
 
         with mock.patch(
             "github_actions_api._default_github_api.send_request",
-            side_effect=[[], "not-a-dict"],
-        ):
-            with self.assertRaisesRegex(GitHubAPIError, "Expected comment object"):
-                gha_update_pr_comment(pr_number=1, marker=marker, body=body)
-
-    def test_uses_provided_github_api_instance_instead_of_singleton(self):
-        """A github_api override should be used instead of the singleton."""
-        marker = "<!-- therock-bump-breadcrumb -->"
-        body = f"{marker}\nThis PR is now part of TheRock."
-
-        custom_api = mock.create_autospec(GitHubAPI, instance=True)
-        custom_api.send_request.side_effect = [
-            [],
-            {"id": 55, "body": body},
-        ]
-
-        with mock.patch(
-            "github_actions_api._default_github_api.send_request"
-        ) as singleton_send_request:
+            side_effect=[
+                [
+                    {
+                        "id": 1,
+                        "body": f"{marker}\nquote-reply",
+                        "user": {"login": "some-human"},
+                    }
+                ],
+                {"id": 99, "body": body},
+            ],
+        ) as send_request:
             result = gha_update_pr_comment(
                 pr_number=9,
                 marker=marker,
                 body=body,
                 github_repository="ROCm/rocm-systems",
-                github_api=custom_api,
+                comment_author="systems-assistant[bot]",
             )
 
-        self.assertEqual(result["id"], 55)
-        self.assertEqual(custom_api.send_request.call_count, 2)
-        singleton_send_request.assert_not_called()
+        self.assertEqual(result["id"], 99)
+        send_request.assert_any_call(
+            comments_url,
+            method="POST",
+            body={"body": body},
+        )
+
+    def test_patches_comment_matching_comment_author(self):
+        """A marker match authored by comment_author should still be updated in place."""
+        marker = "<!-- example-marker -->"
+        body = f"{marker}\nThis PR is now part of TheRock."
+
+        with mock.patch(
+            "github_actions_api._default_github_api.send_request",
+            side_effect=[
+                [
+                    {
+                        "id": 1,
+                        "body": f"{marker}\nold",
+                        "user": {"login": "systems-assistant[bot]"},
+                    }
+                ],
+                {"id": 1, "body": body},
+            ],
+        ) as send_request:
+            result = gha_update_pr_comment(
+                pr_number=9,
+                marker=marker,
+                body=body,
+                github_repository="ROCm/rocm-systems",
+                comment_author="systems-assistant[bot]",
+            )
+
+        self.assertEqual(result["id"], 1)
+        send_request.assert_any_call(
+            "https://api.github.com/repos/ROCm/rocm-systems/issues/comments/1",
+            method="PATCH",
+            body={"body": body},
+        )
 
 
 class GhaQueryPrsForCommitTest(unittest.TestCase):
@@ -770,34 +800,6 @@ class GhaQueryPrsForCommitTest(unittest.TestCase):
             result = gha_query_prs_for_commit("ROCm/TheRock", "b" * 40)
 
         self.assertEqual(result, [])
-
-    def test_raises_when_response_is_not_list(self):
-        with mock.patch(
-            "github_actions_api._default_github_api.send_request",
-            return_value={"message": "not found"},
-        ):
-            with self.assertRaisesRegex(GitHubAPIError, "Expected a list"):
-                gha_query_prs_for_commit("ROCm/TheRock", "c" * 40)
-
-    def test_uses_provided_github_api_instance_instead_of_singleton(self):
-        """A github_api override should be used instead of the singleton."""
-        sha = "d" * 40
-        prs = [{"number": 7}]
-        custom_api = mock.create_autospec(GitHubAPI, instance=True)
-        custom_api.send_request.return_value = prs
-
-        with mock.patch(
-            "github_actions_api._default_github_api.send_request"
-        ) as singleton_send_request:
-            result = gha_query_prs_for_commit(
-                "ROCm/rocm-libraries", sha, github_api=custom_api
-            )
-
-        self.assertEqual(result, prs)
-        custom_api.send_request.assert_called_once_with(
-            f"https://api.github.com/repos/ROCm/rocm-libraries/commits/{sha}/pulls"
-        )
-        singleton_send_request.assert_not_called()
 
 
 class GitHubActionsUtilsTest(unittest.TestCase):


### PR DESCRIPTION
## Motivation
ISSUE ID : https://github.com/ROCm/rocm-systems/issues/6597

When a TheRock submodule bump merges, upstream PRs in `rocm-systems` and `rocm-libraries` have no signal that their changes are now part of TheRock. Post-merge breadcrumb comments on those PRs need a shared way to create or update idempotent PR comments from CI.

This PR lands that foundation only: `gha_update_pr_comment()` in `github_actions_api.py`. Wiring into `bump_submodules.yml` (breadcrumbs) is a follow-on PR. The helper is also intended as a reusable alternative to ad-hoc upsert logic elsewhere (e.g. `therock_pr_bot/policy_check.py`).


## Technical Details
This PR lands the foundation only: extend github_actions_api with write support and add gha_update_pr_comment(). 
Follow-on PRs (not in this PR):
- Bump breadcrumbs: `post_bump_breadcrumbs.py` + step in `bump_submodules.yml`
- Manifest-diff report discoverability: step summary link (does not use this helper)

- Extend  gha_send_request with keyword-only method and body for POST/PATCH (REST and gh api paths).
- Add gha_update_pr_comment() to create or update a sticky PR comment identified by an HTML marker (paginated GET → PATCH or POST).
- Add unit tests for POST/PATCH plumbing, upsert paths, pagination, and GET empty-body backward compatibility.
- Document auth expectations in the helper docstring: callers set GITHUB_TOKEN on the step (GITHUB_TOKEN: ${{ github.token }} for in-repo; App token override for cross-repo). Posting comments requires pull-requests: write in job permissions.


## Test Plan

- pytest build_tools/github_actions/tests/github_actions_api_test.py -v

## Test Result

- 47 passed locally in build_tools/github_actions/tests/github_actions_api_test.py

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
