### PR TITLE
sysdeps: add lttng-ust and userspace-rcu bundled sysdeps

### DIFF
--- a/BUILD_TOPOLOGY.toml
+++ b/BUILD_TOPOLOGY.toml
@@ -422,6 +422,20 @@ artifact_deps = ["sysdeps", "sysdeps-libpciaccess"]  # hwloc depends on numactl 
 feature_group = "CORE"
 disable_platforms = ["windows"]
 
+[artifacts.sysdeps-userspace-rcu]
+artifact_group = "third-party-sysdeps"
+type = "target-neutral"
+artifact_deps = []
+feature_group = "LTTNG"  # Off by default (see THEROCK_ENABLE_LTTNG); dependency of lttng-ust
+disable_platforms = ["windows"]
+
+[artifacts.sysdeps-lttng-ust]
+artifact_group = "third-party-sysdeps"
+type = "target-neutral"
+artifact_deps = ["sysdeps-userspace-rcu"]  # lttng-ust resolves userspace-rcu via pkg-config
+feature_group = "LTTNG"  # Off by default (see THEROCK_ENABLE_LTTNG)
+disable_platforms = ["windows"]
+
 # --- Third-party libraries ---
 # Unlike third-party-sysdeps, these libraries are not given special treatment for portable distribution.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,10 @@ option(THEROCK_ENABLE_DC_TOOLS "Enable building of data center tools" "${THEROCK
 option(THEROCK_ENABLE_MEDIA_LIBS "Enable building of Media libraries" "${THEROCK_ENABLE_ALL}")
 option(THEROCK_ENABLE_EMULATION "Enable building of emulation tools" "${THEROCK_ENABLE_ALL}")
 option(THEROCK_ENABLE_HOST_MATH "Build all bundled host math libraries by default" OFF)
+# LTTng userspace tracing (lttng-ust + userspace-rcu sysdeps). Off by default:
+# the HIP/HSA curated-tracepoint integration that consumes it lands
+# incrementally, and tracing is opt-in for portable builds.
+option(THEROCK_ENABLE_LTTNG "Enable building of LTTng userspace tracing sysdeps" OFF)
 option(THEROCK_ENABLE_WSL "Enable building WSL-specific artifacts" OFF)
 option(THEROCK_RESET_FEATURES "One-shot flag which forces all feature flags to their default state for this configuration run" OFF)
 
@@ -385,10 +389,12 @@ set(THEROCK_BUNDLED_LIBDRM)
 set(THEROCK_BUNDLED_LIBLZMA)
 set(THEROCK_BUNDLED_LIBMNL)
 set(THEROCK_BUNDLED_LIBNL)
+set(THEROCK_BUNDLED_LTTNG_UST)
 set(THEROCK_BUNDLED_MPFR)
 set(THEROCK_BUNDLED_NCURSES)
 set(THEROCK_BUNDLED_NUMACTL)
 set(THEROCK_BUNDLED_SQLITE3)
+set(THEROCK_BUNDLED_USERSPACE_RCU)
 set(THEROCK_BUNDLED_UTIL_LINUX)
 set(THEROCK_BUNDLED_ZLIB)
 set(THEROCK_BUNDLED_ZSTD)
@@ -433,6 +439,14 @@ if(THEROCK_BUNDLE_SYSDEPS)
     endif()
     if(THEROCK_ENABLE_SYSDEPS_AMD_MESA)
       set(THEROCK_BUNDLED_AMDMESA therock-amd-mesa)
+    endif()
+    # userspace-rcu is built whenever it is enabled directly or implicitly as
+    # lttng-ust's dependency (mirrors third-party/sysdeps/linux/CMakeLists.txt).
+    if(THEROCK_ENABLE_SYSDEPS_USERSPACE_RCU OR THEROCK_ENABLE_SYSDEPS_LTTNG_UST)
+      set(THEROCK_BUNDLED_USERSPACE_RCU therock-userspace-rcu)
+    endif()
+    if(THEROCK_ENABLE_SYSDEPS_LTTNG_UST)
+      set(THEROCK_BUNDLED_LTTNG_UST therock-lttng-ust)
     endif()
     if(THEROCK_ENABLE_SYSDEPS_UTIL_LINUX)
       set(THEROCK_BUNDLED_UTIL_LINUX therock-util-linux)

--- a/docs/development/dependencies.md
+++ b/docs/development/dependencies.md
@@ -52,8 +52,10 @@ project wide:
   - `THEROCK_BUNDLED_LIBLZMA`
   - `THEROCK_BUNDLED_LIBMNL`
   - `THEROCK_BUNDLED_LIBNL`
+  - `THEROCK_BUNDLED_LTTNG_UST`
   - `THEROCK_BUNDLED_NUMACTL`
   - `THEROCK_BUNDLED_SQLITE3`
+  - `THEROCK_BUNDLED_USERSPACE_RCU`
   - `THEROCK_BUNDLED_UTIL_LINUX`
   - `THEROCK_BUNDLED_ZLIB`
   - `THEROCK_BUNDLED_ZSTD`
@@ -166,6 +168,24 @@ Supported sub-libraries: `libnl` (core), `libnl-genl` (generic netlink)
 - Alternatives: `pkg_check_modules(LIBNL3_GENL REQUIRED IMPORTED_TARGET libnl-genl-3.0)`
 - Dependencies: Automatically links `libnl::libnl`
 
+## LTTng-UST
+
+The LTTng userspace tracer, used by the HIP/HSA curated tracepoint providers.
+Optional and **off by default** — enable with `-DTHEROCK_ENABLE_LTTNG=ON`
+(which also builds its userspace-rcu dependency). Only the default C/C++
+libraries are built; the Java (JNI) and Python agents are not. When toggling
+this in an existing build tree, also pass `-DTHEROCK_RESET_FEATURES=ON` once so
+the cached artifact-feature flags pick up the group change (see the development
+guide).
+
+- Canonical method: `pkg_check_modules(LTTNG_UST REQUIRED IMPORTED_TARGET lttng-ust)`
+- Import library: `PkgConfig::LTTNG_UST`
+- Vars: `LTTNG_UST_INCLUDE_DIRS`
+- Alternatives: `pkg_check_modules(LTTNG_UST_CTL REQUIRED IMPORTED_TARGET lttng-ust-ctl)`
+  for the control (`liblttng-ust-ctl`) library.
+- Note: liblttng-ust links `-ldl`; consumers loading tracepoint providers at
+  runtime should add the `lib/rocm_sysdeps/lib` RPATH.
+
 ## MPFR
 
 - Canonical method: `find_package(mpfr)`
@@ -222,6 +242,19 @@ Note: `libmount` links `libblkid` transitively, so consumers that only use
 - Canonical method: `pkg_check_modules(LIBBLKID REQUIRED IMPORTED_TARGET blkid)`
 - Import library: `PkgConfig::LIBBLKID`
 - Alternatives: none
+
+## userspace-rcu
+
+Userspace RCU (liburcu), a dependency of LTTng-UST. Built as part of the same
+optional `-DTHEROCK_ENABLE_LTTNG=ON` feature group. lttng-ust resolves it via
+pkg-config (headers / static inlines only — there is no `DT_NEEDED` on liburcu),
+so it is not usually depended on directly.
+
+- Canonical method: `pkg_check_modules(URCU REQUIRED IMPORTED_TARGET liburcu)`
+- Import library: `PkgConfig::URCU`
+- Alternatives: the flavored variants ship their own `.pc` files
+  (`liburcu-bp`, `liburcu-cds`, `liburcu-mb`, `liburcu-memb`, `liburcu-qsbr`,
+  `liburcu-signal`).
 
 ## zlib
 

--- a/third-party/sysdeps/linux/CMakeLists.txt
+++ b/third-party/sysdeps/linux/CMakeLists.txt
@@ -159,3 +159,33 @@ if(THEROCK_ENABLE_SYSDEPS_UTIL_LINUX)
       therock-util-linux
   )
 endif()
+
+# Optional sysdep: userspace-rcu (liburcu; dependency of lttng-ust).
+# Enabled implicitly whenever lttng-ust is enabled (see below).
+if(THEROCK_ENABLE_SYSDEPS_USERSPACE_RCU OR THEROCK_ENABLE_SYSDEPS_LTTNG_UST)
+  add_subdirectory(userspace-rcu)
+  therock_provide_artifact(sysdeps-userspace-rcu
+    TARGET_NEUTRAL
+    DESCRIPTOR artifact-userspace-rcu.toml
+    COMPONENTS
+      dev
+      lib
+    SUBPROJECT_DEPS
+      therock-userspace-rcu
+  )
+endif()
+
+# Optional sysdep: lttng-ust (LTTng userspace tracer; depends on userspace-rcu).
+# Provides liblttng-ust for the HIP/HSA curated tracepoint providers.
+if(THEROCK_ENABLE_SYSDEPS_LTTNG_UST)
+  add_subdirectory(lttng-ust)
+  therock_provide_artifact(sysdeps-lttng-ust
+    TARGET_NEUTRAL
+    DESCRIPTOR artifact-lttng-ust.toml
+    COMPONENTS
+      dev
+      lib
+    SUBPROJECT_DEPS
+      therock-lttng-ust
+  )
+endif()

--- a/third-party/sysdeps/linux/artifact-lttng-ust.toml
+++ b/third-party/sysdeps/linux/artifact-lttng-ust.toml
@@ -1,0 +1,10 @@
+[options]
+unmatched_exclude = [
+  "lib/rocm_sysdeps/share/locale/**",
+  "lib/rocm_sysdeps/share/man/**",
+  "lib/rocm_sysdeps/share/doc/**",
+]
+
+# lttng-ust
+[components.lib."third-party/sysdeps/linux/lttng-ust/build/stage"]
+[components.dev."third-party/sysdeps/linux/lttng-ust/build/stage"]

--- a/third-party/sysdeps/linux/artifact-userspace-rcu.toml
+++ b/third-party/sysdeps/linux/artifact-userspace-rcu.toml
@@ -1,0 +1,10 @@
+[options]
+unmatched_exclude = [
+  "lib/rocm_sysdeps/share/locale/**",
+  "lib/rocm_sysdeps/share/man/**",
+  "lib/rocm_sysdeps/share/doc/**",
+]
+
+# userspace-rcu
+[components.lib."third-party/sysdeps/linux/userspace-rcu/build/stage"]
+[components.dev."third-party/sysdeps/linux/userspace-rcu/build/stage"]

--- a/third-party/sysdeps/linux/lttng-ust/CMakeLists.txt
+++ b/third-party/sysdeps/linux/lttng-ust/CMakeLists.txt
@@ -1,0 +1,142 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    # When included in TheRock, we download sources and set up the sub-project.
+    set(_source_dir "${CMAKE_CURRENT_BINARY_DIR}/source")
+    set(_download_stamp "${_source_dir}/download.stamp")
+
+    therock_subproject_fetch(therock-lttng-ust-sources
+      SOURCE_DIR "${_source_dir}"
+      # TODO(sysdeps-mirror): mirror to rocm-third-party-deps S3 before merge.
+      # Originally from: https://lttng.org/files/lttng-ust/lttng-ust-2.13.7.tar.bz2
+      URL "https://lttng.org/files/lttng-ust/lttng-ust-2.13.7.tar.bz2"
+      URL_HASH "SHA256=5fb4f17c307c8c1b79c68561e89be9562d07e7425bf40e728c4d66755342a5eb"
+      TOUCH "${_download_stamp}"
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+
+    therock_cmake_subproject_declare(therock-lttng-ust
+      USE_DIST_AMDGPU_TARGETS
+      EXTERNAL_SOURCE_DIR .
+      FPRINT_SOURCE_DIR "${_source_dir}"
+      FPRINT_FILE_GLOBS "${CMAKE_CURRENT_LIST_DIR}/*"
+      BINARY_DIR build
+      NO_MERGE_COMPILE_COMMANDS
+      BACKGROUND_BUILD
+      OUTPUT_ON_FAILURE
+      CMAKE_ARGS
+        "-DSOURCE_DIR=${_source_dir}"
+        "-DPATCHELF=${PATCHELF}"
+        "-DPython3_EXECUTABLE=${Python3_EXECUTABLE}"
+      # lttng-ust's configure resolves userspace-rcu via pkg-config (headers /
+      # static inlines only -- there is no DT_NEEDED on liburcu), so urcu must
+      # build first and its pkgconfig dir must be visible.
+      RUNTIME_DEPS
+        therock-userspace-rcu
+      INSTALL_DESTINATION
+        lib/rocm_sysdeps
+      INTERFACE_LINK_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_INSTALL_RPATH_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_PKG_CONFIG_DIRS
+        lib/rocm_sysdeps/lib/pkgconfig
+      INTERFACE_INCLUDE_DIRS
+        lib/rocm_sysdeps/include
+      EXTRA_DEPENDS
+        "${_download_stamp}"
+    )
+    therock_cmake_subproject_activate(therock-lttng-ust)
+
+    # Validate every default-built library so a rename/SONAME regression in
+    # patch_source.sh / patch_install.py is caught by CI, not just at runtime.
+    therock_test_validate_shared_lib(
+      PATH build/dist/lib/rocm_sysdeps/lib
+      LIB_NAMES liblttng-ust.so liblttng-ust-common.so liblttng-ust-tracepoint.so
+                liblttng-ust-ctl.so liblttng-ust-dl.so liblttng-ust-fd.so
+                liblttng-ust-fork.so liblttng-ust-libc-wrapper.so
+                liblttng-ust-pthread-wrapper.so liblttng-ust-cyg-profile.so
+                liblttng-ust-cyg-profile-fast.so
+    )
+
+    add_test(
+      NAME lttng-ust_header_test
+      COMMAND ls "${CMAKE_CURRENT_BINARY_DIR}/build/dist/lib/rocm_sysdeps/include/lttng/tracepoint.h"
+    )
+
+    return()
+endif()
+
+# Otherwise, this is the sub-project build.
+cmake_minimum_required(VERSION 3.25)
+project(LTTNG_UST_BUILD VERSION "2.13.7")
+
+include(ProcessorCount)
+ProcessorCount(PAR_JOBS)
+
+find_program(ACLOCAL aclocal)
+if(NOT ACLOCAL)
+  message(FATAL_ERROR "lttng-ust cannot be reliably built without autotools (on Ubuntu: apt install automake autoconf libtool)")
+endif()
+
+if(NOT PATCHELF)
+  message(FATAL_ERROR "Missing PATCHELF from super-project")
+endif()
+
+# The userspace-rcu sysdep install (its pkgconfig + include dirs) is exposed via
+# CMAKE_PREFIX_PATH. Extract it so we can point lttng-ust's autotools configure
+# at the bundled urcu rather than a system copy.
+function(fetch_library_prefix input_path_list pattern output_var)
+  set(_input_list "${${input_path_list}}")
+  list(FILTER _input_list INCLUDE REGEX "${pattern}")
+  if(_input_list)
+    list(GET _input_list 0 _result_path)
+    set(${output_var} "${_result_path}" PARENT_SCOPE)
+    message(STATUS "Extracted path for pattern '${pattern}': ${_result_path}")
+  else()
+    message(SEND_ERROR "Did not find a path containing '${pattern}' in CMAKE_PREFIX_PATH.")
+  endif()
+endfunction()
+
+fetch_library_prefix(CMAKE_PREFIX_PATH "/userspace-rcu/build/stage" URCU_PREFIX)
+
+add_custom_target(
+  build ALL
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  COMMAND
+    "${CMAKE_COMMAND}" -E rm -rf -- "${CMAKE_INSTALL_PREFIX}" "${CMAKE_CURRENT_BINARY_DIR}/s"
+  COMMAND
+    "${CMAKE_COMMAND}" -E copy_directory "${SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/s"
+  COMMAND
+    bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${CMAKE_CURRENT_BINARY_DIR}/s"
+  COMMAND
+    autoreconf -f -i "${CMAKE_CURRENT_BINARY_DIR}/s"
+  COMMAND
+    # URCU_PREFIX already resolves to the userspace-rcu install prefix
+    # (.../userspace-rcu/build/stage/lib/rocm_sysdeps) -- the dependency
+    # provider backs up two levels from the advertised lib/pkgconfig dir -- so
+    # do NOT append lib/rocm_sysdeps again. Mirrors hwloc's use of NUMA_PREFIX.
+    "${CMAKE_COMMAND}" -E env
+      "PKG_CONFIG_PATH=${URCU_PREFIX}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}"
+      "CPPFLAGS=-I${URCU_PREFIX}/include"
+      "LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS} -L${URCU_PREFIX}/lib -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/rocm_sysdeps.map"
+      --
+    "${CMAKE_CURRENT_BINARY_DIR}/s/configure"
+      --prefix "${CMAKE_INSTALL_PREFIX}"
+      --libdir "${CMAKE_INSTALL_PREFIX}/lib"
+      --disable-static
+      --disable-man-pages
+      --disable-numa
+      --disable-examples
+  COMMAND
+    make -j "${PAR_JOBS}" V=1
+  COMMAND
+    make install
+  COMMAND
+    "${CMAKE_COMMAND}" -E env
+      "PATCHELF=${PATCHELF}"
+      "THEROCK_SOURCE_DIR=${THEROCK_SOURCE_DIR}"
+      "Python3_EXECUTABLE=${Python3_EXECUTABLE}" --
+    "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/patch_install.py" ${CMAKE_INSTALL_PREFIX}
+)

--- a/third-party/sysdeps/linux/lttng-ust/patch_install.py
+++ b/third-party/sysdeps/linux/lttng-ust/patch_install.py
@@ -1,0 +1,88 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import os
+import platform
+import subprocess
+import sys
+
+repo_root = Path(__file__).resolve().parents[4]
+build_tools_path = repo_root / "build_tools"
+sys.path.insert(0, str(build_tools_path))
+from patch_linux_so import update_library_links, relativize_pc_file
+
+
+def get_env_or_exit(var_name):
+    value = os.environ.get(var_name)
+    if value is None:
+        print(f"Error: {var_name} not defined")
+        sys.exit(1)
+    return value
+
+
+prefix = sys.argv[1] if len(sys.argv) > 1 else None
+if not prefix:
+    print("Error: Expected install prefix argument")
+    sys.exit(1)
+
+patchelf_exe = get_env_or_exit("PATCHELF")
+
+if platform.system() == "Linux":
+    lib_dir = Path(prefix) / "lib"
+    pkgconfig_dir = lib_dir / "pkgconfig"
+
+    # Remove static archives and libtool descriptors.
+    for file_path in lib_dir.iterdir():
+        if file_path.suffix in (".a", ".la"):
+            file_path.unlink(missing_ok=True)
+
+    # (prefixed real name, restored dev-symlink name) for all default-built libs.
+    libraries = [
+        ("librocm_sysdeps_lttng_ust.so", "liblttng-ust.so"),
+        ("librocm_sysdeps_lttng_ust_common.so", "liblttng-ust-common.so"),
+        ("librocm_sysdeps_lttng_ust_tracepoint.so", "liblttng-ust-tracepoint.so"),
+        ("librocm_sysdeps_lttng_ust_ctl.so", "liblttng-ust-ctl.so"),
+        ("librocm_sysdeps_lttng_ust_dl.so", "liblttng-ust-dl.so"),
+        ("librocm_sysdeps_lttng_ust_fd.so", "liblttng-ust-fd.so"),
+        ("librocm_sysdeps_lttng_ust_fork.so", "liblttng-ust-fork.so"),
+        ("librocm_sysdeps_lttng_ust_libc_wrapper.so", "liblttng-ust-libc-wrapper.so"),
+        (
+            "librocm_sysdeps_lttng_ust_pthread_wrapper.so",
+            "liblttng-ust-pthread-wrapper.so",
+        ),
+        ("librocm_sysdeps_lttng_ust_cyg_profile.so", "liblttng-ust-cyg-profile.so"),
+        (
+            "librocm_sysdeps_lttng_ust_cyg_profile_fast.so",
+            "liblttng-ust-cyg-profile-fast.so",
+        ),
+    ]
+
+    for source_name, linker_name in libraries:
+        source = lib_dir / source_name
+        if source.exists():
+            update_library_links(source, linker_name, patchelf_exe)
+            target_lib = lib_dir / linker_name
+            if target_lib.exists():
+                try:
+                    subprocess.run(
+                        [patchelf_exe, "--set-rpath", "$ORIGIN", str(target_lib)],
+                        check=True,
+                    )
+                except subprocess.CalledProcessError as e:
+                    print(
+                        f"Warning: Failed to set RPATH on {target_lib}: {e}", flush=True
+                    )
+
+    # Make the shipped .pc files (lttng-ust.pc, lttng-ust-ctl.pc) relocatable.
+    # Their `Libs:` reference the unprefixed -llttng-ust* names, which resolve
+    # through the dev symlinks above.
+    if pkgconfig_dir.is_dir():
+        for pc_file in pkgconfig_dir.glob("*.pc"):
+            relativize_pc_file(pc_file)
+
+    # We do not ship tools/binaries for this sysdep.
+    bin_dir = Path(prefix) / "bin"
+    if bin_dir.is_dir():
+        for f in bin_dir.iterdir():
+            f.unlink()

--- a/third-party/sysdeps/linux/lttng-ust/patch_source.sh
+++ b/third-party/sysdeps/linux/lttng-ust/patch_source.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Rename the lttng-ust libtool libraries to the rocm_sysdeps_ prefix so the
+# bundled sysdep can coexist with a system liblttng-ust. The install step
+# (patch_install.py) restores lib<name>.so dev symlinks pointing at the
+# prefixed SONAMEs.
+#
+# Only the libraries built by the default (C/C++) configure are renamed. The
+# optional Java (JNI) and Python agents are not enabled in our configure and so
+# are not built; their own agent libraries are deliberately NOT renamed here.
+# (References to the renamed base liblttng-ust from any such Makefile.am are
+# still rewritten by the loop below, but the agents themselves are unsupported
+# by this sysdep -- enabling them would require extending the rename set.)
+
+set -e
+
+SOURCE_DIR="${1:?Source directory must be given}"
+
+echo "Patching lttng-ust sources..."
+
+# All default-built libraries, longest names first to avoid partial-substring
+# clobbering (e.g. "liblttng-ust" within "liblttng-ust-common").
+LIBS=(
+  liblttng-ust-cyg-profile-fast
+  liblttng-ust-pthread-wrapper
+  liblttng-ust-libc-wrapper
+  liblttng-ust-cyg-profile
+  liblttng-ust-tracepoint
+  liblttng-ust-common
+  liblttng-ust-fork
+  liblttng-ust-ctl
+  liblttng-ust-dl
+  liblttng-ust-fd
+  liblttng-ust
+)
+
+# Every per-library Makefile.am under src/lib may reference any sibling .la
+# (cross-library LIBADD/DEPENDENCIES), so rewrite them all.
+for makefile in "$SOURCE_DIR"/src/lib/*/Makefile.am; do
+  [ -f "$makefile" ] || continue
+  for lib in "${LIBS[@]}"; do
+    suffix="${lib#liblttng-ust}"          # "", "-common", "-cyg-profile-fast", ...
+    suffix="${suffix//-/_}"               # "", "_common", "_cyg_profile_fast", ...
+    newname="librocm_sysdeps_lttng_ust${suffix}"
+    sed -i "s/${lib}\.la/${newname}.la/g" "$makefile"
+    canon_old="${lib//-/_}_la_"
+    sed -i "s/${canon_old}/${newname}_la_/g" "$makefile"
+  done
+done
+
+echo "lttng-ust source patch complete."

--- a/third-party/sysdeps/linux/lttng-ust/rocm_sysdeps.map
+++ b/third-party/sysdeps/linux/lttng-ust/rocm_sysdeps.map
@@ -1,0 +1,3 @@
+AMDROCM_SYSDEPS_1.0 {
+global: *;
+};

--- a/third-party/sysdeps/linux/userspace-rcu/CMakeLists.txt
+++ b/third-party/sysdeps/linux/userspace-rcu/CMakeLists.txt
@@ -1,0 +1,117 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    # When included in TheRock, we download sources and set up the sub-project.
+    set(_source_dir "${CMAKE_CURRENT_BINARY_DIR}/source")
+    set(_download_stamp "${_source_dir}/download.stamp")
+
+    therock_subproject_fetch(therock-userspace-rcu-sources
+      SOURCE_DIR "${_source_dir}"
+      # TODO(sysdeps-mirror): mirror to rocm-third-party-deps S3 before merge.
+      # Originally from: https://lttng.org/files/urcu/userspace-rcu-0.14.0.tar.bz2
+      URL "https://lttng.org/files/urcu/userspace-rcu-0.14.0.tar.bz2"
+      URL_HASH "SHA256=ca43bf261d4d392cff20dfae440836603bf009fce24fdc9b2697d837a2239d4f"
+      TOUCH "${_download_stamp}"
+      # Preserve extracted-source timestamps so the build does not spuriously
+      # try to re-run autotools.
+      DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+
+    therock_cmake_subproject_declare(therock-userspace-rcu
+      USE_DIST_AMDGPU_TARGETS
+      EXTERNAL_SOURCE_DIR .
+      FPRINT_SOURCE_DIR "${_source_dir}"
+      FPRINT_FILE_GLOBS "${CMAKE_CURRENT_LIST_DIR}/*"
+      BINARY_DIR build
+      NO_MERGE_COMPILE_COMMANDS
+      BACKGROUND_BUILD
+      OUTPUT_ON_FAILURE
+      CMAKE_ARGS
+        "-DSOURCE_DIR=${_source_dir}"
+        "-DPATCHELF=${PATCHELF}"
+        "-DPython3_EXECUTABLE=${Python3_EXECUTABLE}"
+      INSTALL_DESTINATION
+        lib/rocm_sysdeps
+      INTERFACE_LINK_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_INSTALL_RPATH_DIRS
+        lib/rocm_sysdeps/lib
+      INTERFACE_PKG_CONFIG_DIRS
+        lib/rocm_sysdeps/lib/pkgconfig
+      INTERFACE_INCLUDE_DIRS
+        lib/rocm_sysdeps/include
+      EXTRA_DEPENDS
+        "${_download_stamp}"
+    )
+    therock_cmake_subproject_activate(therock-userspace-rcu)
+
+    # userspace-rcu builds eight related flavors; validate the two that
+    # lttng-ust links against plus the common base.
+    therock_test_validate_shared_lib(
+      PATH build/dist/lib/rocm_sysdeps/lib
+      LIB_NAMES liburcu.so liburcu-common.so liburcu-bp.so liburcu-cds.so
+                liburcu-mb.so liburcu-memb.so liburcu-qsbr.so liburcu-signal.so
+    )
+
+    add_test(
+      NAME userspace-rcu_header_test
+      COMMAND ls "${CMAKE_CURRENT_BINARY_DIR}/build/dist/lib/rocm_sysdeps/include/urcu.h"
+    )
+
+    return()
+endif()
+
+# Otherwise, this is the sub-project build.
+cmake_minimum_required(VERSION 3.25)
+project(USERSPACE_RCU_BUILD VERSION "0.14.0")
+
+include(ProcessorCount)
+ProcessorCount(PAR_JOBS)
+
+find_program(ACLOCAL aclocal)
+if(NOT ACLOCAL)
+  message(FATAL_ERROR "userspace-rcu cannot be reliably built without autotools (on Ubuntu: apt install automake autoconf libtool)")
+endif()
+
+if(NOT PATCHELF)
+  message(FATAL_ERROR "Missing PATCHELF from super-project")
+endif()
+
+add_custom_target(
+  build ALL
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  COMMAND
+    "${CMAKE_COMMAND}" -E rm -rf -- "${CMAKE_INSTALL_PREFIX}" "${CMAKE_CURRENT_BINARY_DIR}/s"
+  COMMAND
+    # We patch the sources, so make a fresh writable copy.
+    "${CMAKE_COMMAND}" -E copy_directory "${SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/s"
+  COMMAND
+    # Rename the eight libraries to the rocm_sysdeps_ prefix and install the
+    # AMDROCM_SYSDEPS symbol-version script (patches Makefile.am, so autoreconf
+    # must run afterwards).
+    bash "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${CMAKE_CURRENT_BINARY_DIR}/s"
+  COMMAND
+    # Reconfigure since the available autotools version may differ from the one
+    # that produced the shipped configure, and because patch_source.sh edited
+    # Makefile.am.
+    autoreconf -f -i "${CMAKE_CURRENT_BINARY_DIR}/s"
+  COMMAND
+    "${CMAKE_COMMAND}" -E env
+      "LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS} -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/rocm_sysdeps.map"
+      --
+    "${CMAKE_CURRENT_BINARY_DIR}/s/configure"
+      --prefix "${CMAKE_INSTALL_PREFIX}"
+      --libdir "${CMAKE_INSTALL_PREFIX}/lib"
+      --disable-static
+  COMMAND
+    make -j "${PAR_JOBS}" V=1
+  COMMAND
+    make install
+  COMMAND
+    "${CMAKE_COMMAND}" -E env
+      "PATCHELF=${PATCHELF}"
+      "THEROCK_SOURCE_DIR=${THEROCK_SOURCE_DIR}"
+      "Python3_EXECUTABLE=${Python3_EXECUTABLE}" --
+    "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/patch_install.py" ${CMAKE_INSTALL_PREFIX}
+)

--- a/third-party/sysdeps/linux/userspace-rcu/patch_install.py
+++ b/third-party/sysdeps/linux/userspace-rcu/patch_install.py
@@ -1,0 +1,78 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import os
+import platform
+import subprocess
+import sys
+
+repo_root = Path(__file__).resolve().parents[4]
+build_tools_path = repo_root / "build_tools"
+sys.path.insert(0, str(build_tools_path))
+from patch_linux_so import update_library_links, relativize_pc_file
+
+
+def get_env_or_exit(var_name):
+    value = os.environ.get(var_name)
+    if value is None:
+        print(f"Error: {var_name} not defined")
+        sys.exit(1)
+    return value
+
+
+prefix = sys.argv[1] if len(sys.argv) > 1 else None
+if not prefix:
+    print("Error: Expected install prefix argument")
+    sys.exit(1)
+
+patchelf_exe = get_env_or_exit("PATCHELF")
+
+if platform.system() == "Linux":
+    lib_dir = Path(prefix) / "lib"
+    pkgconfig_dir = lib_dir / "pkgconfig"
+
+    # Remove static archives and libtool descriptors.
+    for file_path in lib_dir.iterdir():
+        if file_path.suffix in (".a", ".la"):
+            file_path.unlink(missing_ok=True)
+
+    # (prefixed real name, restored dev-symlink name) for all eight flavors.
+    libraries = [
+        ("librocm_sysdeps_urcu.so", "liburcu.so"),
+        ("librocm_sysdeps_urcu_common.so", "liburcu-common.so"),
+        ("librocm_sysdeps_urcu_bp.so", "liburcu-bp.so"),
+        ("librocm_sysdeps_urcu_cds.so", "liburcu-cds.so"),
+        ("librocm_sysdeps_urcu_mb.so", "liburcu-mb.so"),
+        ("librocm_sysdeps_urcu_memb.so", "liburcu-memb.so"),
+        ("librocm_sysdeps_urcu_qsbr.so", "liburcu-qsbr.so"),
+        ("librocm_sysdeps_urcu_signal.so", "liburcu-signal.so"),
+    ]
+
+    for source_name, linker_name in libraries:
+        source = lib_dir / source_name
+        if source.exists():
+            update_library_links(source, linker_name, patchelf_exe)
+            target_lib = lib_dir / linker_name
+            if target_lib.exists():
+                try:
+                    subprocess.run(
+                        [patchelf_exe, "--set-rpath", "$ORIGIN", str(target_lib)],
+                        check=True,
+                    )
+                except subprocess.CalledProcessError as e:
+                    print(
+                        f"Warning: Failed to set RPATH on {target_lib}: {e}", flush=True
+                    )
+
+    # Make the shipped .pc files relocatable. Their `Libs:` reference the
+    # unprefixed -lurcu* names, which resolve through the dev symlinks above.
+    if pkgconfig_dir.is_dir():
+        for pc_file in pkgconfig_dir.glob("*.pc"):
+            relativize_pc_file(pc_file)
+
+    # We do not ship tools/binaries for this sysdep.
+    bin_dir = Path(prefix) / "bin"
+    if bin_dir.is_dir():
+        for f in bin_dir.iterdir():
+            f.unlink()

--- a/third-party/sysdeps/linux/userspace-rcu/patch_source.sh
+++ b/third-party/sysdeps/linux/userspace-rcu/patch_source.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/bash
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Rename the userspace-rcu libtool libraries to the rocm_sysdeps_ prefix so the
+# bundled sysdep can coexist with a system liburcu. The install step
+# (patch_install.py) restores lib<name>.so dev symlinks pointing at the
+# prefixed SONAMEs.
+
+set -e
+
+SOURCE_DIR="${1:?Source directory must be given}"
+MAKEFILE_AM="$SOURCE_DIR/src/Makefile.am"
+
+echo "Patching userspace-rcu sources..."
+
+# All eight libraries produced by src/Makefile.am. Order longest-first so that
+# e.g. "liburcu" does not partially match "liburcu-common" during sed.
+LIBS=(
+  liburcu-common
+  liburcu-signal
+  liburcu-memb
+  liburcu-qsbr
+  liburcu-cds
+  liburcu-bp
+  liburcu-mb
+  liburcu
+)
+
+for lib in "${LIBS[@]}"; do
+  # librocm_sysdeps_urcu_common  (from liburcu-common)
+  suffix="${lib#liburcu}"                # "", "-common", "-bp", ...
+  suffix="${suffix//-/_}"                # "", "_common", "_bp", ...
+  newname="librocm_sysdeps_urcu${suffix}"
+  # .la target filename references
+  sed -i "s/${lib}\.la/${newname}.la/g" "$MAKEFILE_AM"
+  # Automake-canonicalized variable prefix (dashes -> underscores).
+  canon_old="${lib//-/_}_la_"
+  sed -i "s/${canon_old}/${newname}_la_/g" "$MAKEFILE_AM"
+done
+
+echo "userspace-rcu source patch complete."

--- a/third-party/sysdeps/linux/userspace-rcu/rocm_sysdeps.map
+++ b/third-party/sysdeps/linux/userspace-rcu/rocm_sysdeps.map
@@ -1,0 +1,3 @@
+AMDROCM_SYSDEPS_1.0 {
+global: *;
+};


### PR DESCRIPTION
## Motivation

This PR adds **LTTng-UST 2.13.7** and its **userspace-rcu 0.14.0** dependency as
optional Linux bundled system dependencies (sysdeps) for TheRock.

They are needed by an in-progress effort to add built-in, curated LTTng-UST
tracepoints to the HIP and HSA runtimes (structured, low-overhead, always-
available API tracing). The initial rocm-systems change vendored LTTng-UST +
userspace-rcu as git submodules with a hand-rolled `ExternalProject` build;
review feedback asked that we instead follow TheRock's standard sysdeps pattern
(mirrored source tarballs, built from source with private SONAMEs + symbol
versioning, consumed via normal CMake/pkg-config lookups). This PR is that
prerequisite.

Initiated by: https://github.com/ROCm/rocm-systems/issues/8906

**Related work (companion, lands after this):** the rocm-systems LTTng
tracepoint series will drop its vendored submodules and instead
`pkg_check_modules(... lttng-ust)` against this sysdep, gated on
`THEROCK_ENABLE_LTTNG`.

## Technical details

**New sysdeps** (`third-party/sysdeps/linux/{userspace-rcu,lttng-ust}/`), each
following the numactl/libnl/hwloc pattern:

- `therock_subproject_fetch` of the upstream tarball (SHA256-pinned) →
  `therock_cmake_subproject_declare` → autotools `configure && make install`
  into `lib/rocm_sysdeps` → post-install `patch_install.py`.
- `patch_source.sh` renames every default-built libtool library to a
  `librocm_sysdeps_*` name; a `rocm_sysdeps.map` version script versions all
  symbols under `AMDROCM_SYSDEPS_1.0`; `patch_install.py` (via the shared
  `build_tools/patch_linux_so.py` helpers) restores `lib<name>.so` dev symlinks,
  sets `$ORIGIN` RPATH, and relativizes the `.pc` files.
- **userspace-rcu**: 8 libraries (`liburcu`, `-bp`, `-cds`, `-mb`, `-memb`,
  `-qsbr`, `-signal`, `-common`).
- **lttng-ust**: 11 default C/C++ libraries (main, `-common`, `-tracepoint`,
  `-ctl`, `-dl`, `-fd`, `-fork`, `-libc-wrapper`, `-pthread-wrapper`,
  `-cyg-profile`, `-cyg-profile-fast`). Java/JNI and Python agents are not
  built. It resolves userspace-rcu at configure time via pkg-config (headers /
  static inlines only — there is **no** `DT_NEEDED` on liburcu), so it declares
  `RUNTIME_DEPS therock-userspace-rcu` for build ordering + interface
  propagation.

**Gating:** new `THEROCK_ENABLE_LTTNG` option, **OFF by default** (new `LTTNG`
feature group, mirroring the `HOST_MATH` off-by-default precedent), so the
consuming rocm-systems series can land incrementally. Enabling it builds both
sysdeps; `sysdeps-lttng-ust` requires `sysdeps-userspace-rcu` in the topology.

**How to depend** (documented in `docs/development/dependencies.md`):
`pkg_check_modules(LTTNG_UST REQUIRED IMPORTED_TARGET lttng-ust)` →
`PkgConfig::LTTNG_UST`; add `THEROCK_BUNDLED_LTTNG_UST` /
`THEROCK_BUNDLED_USERSPACE_RCU` to `RUNTIME_DEPS`. pkg-config-only (no synthetic
`*-config.cmake.in`), matching the libdrm/libpciaccess precedent.

**Files:** two sysdep dirs (CMakeLists.txt, patch_source.sh, patch_install.py,
rocm_sysdeps.map each) + two `artifact-*.toml` + `third-party/sysdeps/linux/CMakeLists.txt`
registration + `BUILD_TOPOLOGY.toml` artifacts + root `CMakeLists.txt`
option/bundled-vars + `docs/development/dependencies.md`.

## Testing

Built both deps end-to-end from the pinned upstream tarballs with the committed
scripts (Ubuntu, autotools + patchelf):

- All 8 urcu + 11 lttng-ust libs install with `librocm_sysdeps_*` SONAMEs and
  `AMDROCM_SYSDEPS_1.0` versioned symbols; `lib<name>.so` dev symlinks restored;
  `.pc` files relativized (`prefix=${pcfiledir}/../..`).
- lttng-ust configures against the **bundled** urcu via the staged
  `lib/rocm_sysdeps/lib/pkgconfig` (verified `checking for liburcu >= 0.12...
  yes` with no system fallback), using the dependency-provider prefix layout.
- `pkg-config --modversion lttng-ust` → `2.13.7`; a sample tracepoint consumer
  compiles, links, and records `DT_NEEDED: librocm_sysdeps_lttng_ust.so.1`.
- `topology_to_cmake.py --validate-only` passes; generated flags:
  `THEROCK_ENABLE_SYSDEPS_LTTNG_UST` requires `SYSDEPS_USERSPACE_RCU`, both in
  the off-by-default `LTTNG` group.

## Note for maintainers before merge

The two `CMakeLists.txt` fetch blocks currently pull from upstream
`https://lttng.org/files/...` (SHA256-pinned), with a `TODO(sysdeps-mirror)`
comment. Per convention these tarballs should be mirrored to
`rocm-third-party-deps.s3.us-east-2.amazonaws.com` and the URLs swapped before
merge. Requesting a maintainer to mirror:

- `userspace-rcu-0.14.0.tar.bz2` (SHA256 `ca43bf261d4d392cff20dfae440836603bf009fce24fdc9b2697d837a2239d4f`)
- `lttng-ust-2.13.7.tar.bz2` (SHA256 `5fb4f17c307c8c1b79c68561e89be9562d07e7425bf40e728c4d66755342a5eb`)
