### PR TITLE
ci(amdsmi): make amdsmitst full-mode filtering fully dynamic

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_amdsmi.py
+++ b/build_tools/github_actions/test_executable_scripts/test_amdsmi.py
@@ -165,45 +165,18 @@ if test_type == "quick":
     gtest_filter_arg = [f"--gtest_filter={include_filter}"]
     logging.info(f"Quick mode: include filter = {include_filter}")
 else:
-    # Full mode: rename-agnostic positive whitelist minus the sourced exclusions.
-    # Listing both the legacy amdsmitst* suites and the new *Functional*/*Unit*
-    # suites keeps the logical test set stable across the suite rename without
-    # automatically pulling in unrelated new suites (NIC/IFoE/etc.).
-    include_tests = [
-        "amdsmitstReadOnly.*",
-        "amdsmitstReadWrite.*",
-        "AmdSmiDynamicMetricTest.*",
-        "*FunctionalReadOnly.*",
-        "*FunctionalReadWrite.*",
-        "*Unit*",
-    ]
-
-    # Manual exclusions — always applied regardless of ASIC. Listed under both
-    # the legacy and renamed suite names so they survive the rename.
-    exclude_tests = [
-        "amdsmitstReadOnly.TempRead",
-        "amdsmitstReadOnly.TestFrequenciesRead",
-        "amdsmitstReadWrite.TestPowerReadWrite",
-        "GpuFunctionalReadOnly.TempRead",
-        "GpuFunctionalReadOnly.TestFrequenciesRead",
-        "GpuFunctionalReadWrite.TestPowerReadWrite",
-    ]
-
-    # ASIC- and environment-specific exclusions come from detect_asic_filter.sh,
-    # which sources the exclude table shipped alongside the binary, so the names
-    # always match the binary being tested.
+    # Full mode: run every suite the binary ships, minus only the exclusions
+    # sourced from detect_asic_filter.sh (which reads the exclude table shipped
+    # alongside the binary). No suite names are hardcoded here, so the runner
+    # needs no updates when amd-smi adds, removes, or renames test suites; the
+    # exclude table is the single source of truth for what each ASIC skips.
     asic_exclude = get_asic_exclude_filter(TESTS_DIR)
     if asic_exclude:
-        for test in asic_exclude.split(":"):
-            if test and test not in exclude_tests:
-                exclude_tests.append(test)
-        logging.info(
-            f"Combined exclude list ({len(exclude_tests)} entries): {exclude_tests}"
-        )
-
-    gtest_filter = f"{':'.join(include_tests)}:-{':'.join(exclude_tests)}"
-    gtest_filter_arg = [f"--gtest_filter={gtest_filter}"]
-    logging.info(f"Full mode: filter = {gtest_filter}")
+        gtest_filter_arg = [f"--gtest_filter=-{asic_exclude}"]
+        logging.info(f"Full mode: exclude filter = -{asic_exclude}")
+    else:
+        gtest_filter_arg = []
+        logging.info("Full mode: no exclusions, running all tests")
 
 # -----------------------------
 # Build command


### PR DESCRIPTION
## Summary

Follow-up to #4228. Removes all hardcoded test filtering from the amdsmi
full-mode runner so the exclude table shipped with the binary
(`amdsmitst.exclude` + `detect_asic_filter.sh`) is the single source of
truth for what gets skipped.

Before, full mode carried a positive include whitelist plus a manual
per-suite exclude list, both duplicated under legacy and renamed suite
names. Now full mode mirrors how rocm-systems runs the same binary: a
negative-only gtest filter built entirely from the sourced exclusions.

```python
asic_exclude = get_asic_exclude_filter(TESTS_DIR)
if asic_exclude:
    gtest_filter_arg = [f"--gtest_filter=-{asic_exclude}"]
else:
    gtest_filter_arg = []  # run everything
```

## What changed

| Aspect | Before | After |
|--------|--------|-------|
| Full-mode includes | Hardcoded whitelist of 6 suite globs | None (run all) |
| Full-mode excludes | Hardcoded 6 manual entries + sourced ASIC excludes | Sourced ASIC excludes only |
| Suite rename handling | Legacy + renamed names listed side by side | No suite names referenced at all |
| Quick mode | Explicit unit-test filter | Unchanged (the one highlighted subset) |

## Why

- **Single source of truth.** Test exclusions belong to amd-smi and ship
  with the binary. Anything that needs skipping goes in `amdsmitst.exclude`,
  not hardcoded in this runner.
- **Rename-proof.** The `amdsmitstReadOnly`/`amdsmitstReadWrite` ->
  `GpuFunctional*` and `AmdSmiDynamicMetricTest` -> `GpuUnit` rename
  (rocm-systems #7650) requires no change here, since no suite names are
  referenced in full mode.

## Behavior note

Dropping the manual excludes (`TempRead`, `TestFrequenciesRead`,
`TestPowerReadWrite`) means those tests now run on ASICs where the exclude
table does not list them. That is intentional: if they need skipping on a
given ASIC, the fix is to add them to `amdsmitst.exclude`, keeping all
filtering dynamic and owned by amd-smi.

## Test

- `python3 -m ast` parse clean
- `ruff check` clean
- `ruff format --check` (black-88) clean