### PR TITLE
feat(ci) Add safe automatic stage reuse from exact diff bases

### DIFF
--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -42,6 +42,13 @@ on:
         type: string
         default: ""
         description: "Workflow run ID to copy prebuilt stage artifacts from; required when prebuilt_stages is set"
+      stage_reuse_diff_base:
+        type: string
+        default: ""
+        description: >-
+          Git commit or ref used as both the changed-file diff base and the
+          exact automatic stage-reuse baseline. Required for automatic
+          reuse-stage on workflow_dispatch; empty disables automatic reuse.
       stage_reuse_mode:
         type: choice
         default: "dry-run"
@@ -57,10 +64,6 @@ on:
         type: string
         default: "72"
         description: "Automatic stage reuse: reject baseline runs older than this many hours"
-      stage_reuse_commit_history:
-        type: string
-        default: "50"
-        description: "Automatic stage reuse: number of recent branch commits to fetch for ancestry"
       changed_projects:
         type: string
         default: ""
@@ -105,9 +108,9 @@ jobs:
       windows_test_labels: ${{ inputs.windows_test_labels || '' }}
       prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
+      stage_reuse_diff_base: ${{ inputs.stage_reuse_diff_base || '' }}
       stage_reuse_mode: ${{ inputs.stage_reuse_mode || 'dry-run' }}
       stage_reuse_max_age_hours: ${{ inputs.stage_reuse_max_age_hours || '72' }}
-      stage_reuse_commit_history: ${{ inputs.stage_reuse_commit_history || '50' }}
       build_pytorch: ${{ github.event_name != 'workflow_dispatch' || inputs.build_pytorch }}
       build_jax: ${{ github.event_name != 'workflow_dispatch' || inputs.build_jax }}
 

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -50,16 +50,18 @@ on:
           be reused; "reuse-stage" actually reuses them.
         type: string
         default: "dry-run"
+      stage_reuse_diff_base:
+        description: >-
+          Git commit or ref used as both the changed-file diff base and the
+          exact automatic stage-reuse baseline. Intended for same-repository
+          workflow_dispatch runs; empty disables automatic dispatch reuse.
+        type: string
+        default: ""
       stage_reuse_max_age_hours:
         description: >-
          Automatic stage reuse: reject baseline runs older than this many hours. default: "72"
         type: string
         default: "72"
-      stage_reuse_commit_history:
-        description: >-
-          Automatic stage reuse: number of recent branch commits to fetch for ancestry. default: "50"
-        type: string
-        default: "50"
       build_pytorch:
         description: "Build PyTorch wheels."
         type: boolean
@@ -147,8 +149,9 @@ jobs:
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
-          # We need the parent commit to do a diff
-          fetch-depth: 2
+          # Fetch full history so diff-base commits can be resolved for path filtering
+          # and exact automatic stage-reuse validation.
+          fetch-depth: 0
 
       - name: Checkout CI config
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -176,10 +179,9 @@ jobs:
           WINDOWS_TEST_LABELS: ${{ inputs.windows_test_labels }}
           PREBUILT_STAGES: ${{ inputs.prebuilt_stages }}
           BASELINE_RUN_ID: ${{ inputs.baseline_run_id }}
+          STAGE_REUSE_DIFF_BASE: ${{ inputs.stage_reuse_diff_base }}
           STAGE_REUSE_MODE: ${{ inputs.stage_reuse_mode }}
-          STAGE_REUSE_CURRENT_SHA: ${{ steps.checkout.outputs.commit }}
           STAGE_REUSE_MAX_AGE_HOURS: ${{ inputs.stage_reuse_max_age_hours }}
-          STAGE_REUSE_COMMIT_HISTORY: ${{ inputs.stage_reuse_commit_history }}
           # For cross-repo artifact reuse, use repository input (defaults to GITHUB_REPOSITORY).
           # External repos set repository to "ROCm/TheRock" to reuse TheRock's prebuilt artifacts.
           THEROCK_REPOSITORY: ${{ inputs.repository }}

--- a/build_tools/_therock_utils/build_topology.py
+++ b/build_tools/_therock_utils/build_topology.py
@@ -129,6 +129,25 @@ class Artifact:
     )  # Artifacts needed for testing this artifact (e.g., ["core-hiptests"])
 
 
+def artifact_may_apply_to_platform(
+    artifact: Artifact,
+    platform_name: str,
+) -> bool:
+    """Return whether an artifact may apply to a platform.
+
+    Explicit platform restrictions are honored. Conditional disables are not
+    evaluated because callers do not have the resolved build flags, so the
+    artifact remains applicable conservatively.
+    """
+    if artifact.platform is not None and artifact.platform != platform_name:
+        return False
+
+    if platform_name in artifact.disable_platforms:
+        return False
+
+    return True
+
+
 class BuildTopology:
     """
     Parses and provides operations on BUILD_TOPOLOGY.toml.

--- a/build_tools/github_actions/baseline_runs.py
+++ b/build_tools/github_actions/baseline_runs.py
@@ -80,20 +80,20 @@ class WorkflowJobHealth:
 
 @dataclass(frozen=True)
 class CommitCompatibility:
-    """Result of checking a candidate run's commit against the current commit.
+    """Result of comparing a candidate run with the exact expected baseline.
 
-    A baseline run is only safe to reuse when it was built from source that the
-    current commit is based on. Reusing artifacts from a divergent or newer-than-current
-    commit risks mixing incompatible binaries, so those are rejected.
+    A baseline run is safe to reuse only when its ``head_sha`` exactly matches
+    ``expected_head_sha``. Accepting an older or different commit could omit
+    changes covered by the current impact range and reuse stale artifacts.
     """
 
-    current_commit_sha: str
+    expected_head_sha: str
     candidate_head_sha: str
     relationship: str
 
     @property
     def is_valid(self) -> bool:
-        return self.relationship in ("same", "ancestor")
+        return self.relationship == "same"
 
 
 @dataclass(frozen=True)
@@ -587,61 +587,36 @@ def parse_run_timing(workflow_run: dict) -> RunTiming:
 def validate_commit_compatibility(
     *,
     candidate_head_sha: str,
-    current_commit_sha: str,
-    ordered_commit_shas: Sequence[str],
+    expected_head_sha: str,
 ) -> CommitCompatibility:
-    """Validate that a candidate run was built from a compatible commit.
+    """Validate that a candidate run matches the exact expected baseline.
 
-    ``ordered_commit_shas`` is the branch history newest-first (as returned by
-    ``gha_query_recent_branch_commits``). The current commit is expected to be
-    at or near the front of that list. A candidate is:
+    Stage impact is calculated over:
 
-    * ``same`` when its head_sha equals the current commit;
-    * ``ancestor`` when its head_sha appears *after* the current commit in the
-      newest-first history (i.e. the current commit is built on top of it);
-    * ``descendant_or_divergent`` when it appears *before* the current commit
-      (newer than current, so unsafe to reuse);
-    * ``unknown`` when it does not appear in the provided history window.
+        diff_base_commit -> diff_head_commit
 
-    Only ``same`` and ``ancestor`` are considered valid. ``unknown`` is treated
-    as unsafe rather than assumed-good: a candidate outside the history window
-    cannot be confirmed as an ancestor, so widen the window if legitimate
-    ancestors are being rejected.
+    Therefore, a candidate run is considered compatible only when its
+    ``head_sha`` exactly equals ``diff_base_commit``. Accepting an older ancestor
+    would omit changes between the candidate commit and ``diff_base_commit`` and
+    could reuse stale artifacts.
+
+    TODO: Investigate safe per-platform baseline selection and ancestor reuse.
+    Any ancestor-based approach must account for the complete change range from
+    the candidate commit to ``diff_head_commit``, rather than checking ancestry
+    alone.
     """
-    current = _normalize_sha(current_commit_sha)
+    expected = _normalize_sha(expected_head_sha)
     candidate = _normalize_sha(candidate_head_sha)
-    if not current:
-        raise ValueError("current_commit_sha must be non-empty")
+
+    if not expected:
+        raise ValueError("expected_head_sha must be non-empty")
     if not candidate:
         raise ValueError("candidate_head_sha must be non-empty")
 
-    if candidate == current:
-        relationship = "same"
-    else:
-        history = [_normalize_sha(sha) for sha in ordered_commit_shas]
-        try:
-            current_index = history.index(current)
-        except ValueError:
-            current_index = None
-        try:
-            candidate_index = history.index(candidate)
-        except ValueError:
-            candidate_index = None
-
-        if candidate_index is None:
-            relationship = "unknown"
-        elif current_index is None:
-            # Current commit is outside the window but the candidate is in it;
-            # we cannot establish ordering, so treat as unknown.
-            relationship = "unknown"
-        elif candidate_index > current_index:
-            # Newest-first: a larger index is older than the current commit.
-            relationship = "ancestor"
-        else:
-            relationship = "descendant_or_divergent"
+    relationship = "same" if candidate == expected else "different"
 
     return CommitCompatibility(
-        current_commit_sha=current,
+        expected_head_sha=expected,
         candidate_head_sha=candidate,
         relationship=relationship,
     )
@@ -685,8 +660,7 @@ def select_baseline_run(
     max_runs: int = 20,
     exclude_run_ids: Iterable[str] = (),
     required_successful_job_name_substrings: Iterable[str] = ("Build",),
-    current_commit_sha: str | None = None,
-    ordered_commit_shas: Sequence[str] | None = None,
+    expected_head_sha: str | None = None,
     max_age_hours: float | None = None,
     now: datetime | None = None,
     workflow_runs: Sequence[dict] | None = None,
@@ -709,13 +683,9 @@ def select_baseline_run(
             match at least one completed successful job in the candidate run.
             Defaults to ``("Build",)`` so unrelated test failures do not
             automatically disqualify otherwise reusable build artifacts.
-        current_commit_sha: When provided, enables the commit-compatibility
-            rule: a candidate run is only accepted when its head_sha equals or
-            is an ancestor of this commit. Requires ``ordered_commit_shas``.
-        ordered_commit_shas: Branch history newest-first (e.g. from
-            ``gha_query_recent_branch_commits``) used to establish ancestry for
-            the commit-compatibility rule. Ignored unless ``current_commit_sha``
-            is set.
+        expected_head_sha: When provided, a candidate run is accepted only
+            when its head_sha exactly equals this SHA. Automatic stage reuse
+            passes the resolved diff-base commit here.
         max_age_hours: When provided, enables the recency rule: candidate runs
             older than this many hours (by ``created_at``) are rejected.
         now: Reference time for the recency rule; defaults to the current UTC
@@ -741,16 +711,11 @@ def select_baseline_run(
     )
     excluded = {str(run_id) for run_id in exclude_run_ids}
 
-    check_commit = current_commit_sha is not None
-    if check_commit:
-        if not current_commit_sha.strip():
-            raise ValueError(
-                "current_commit_sha must be non-empty when commit checking is enabled"
-            )
-        if ordered_commit_shas is None:
-            raise ValueError(
-                "ordered_commit_shas is required when current_commit_sha is set"
-            )
+    check_commit = expected_head_sha is not None
+    if check_commit and not expected_head_sha.strip():
+        raise ValueError(
+            "expected_head_sha must be non-empty when commit checking is enabled"
+        )
     check_recency = max_age_hours is not None
 
     candidates = (
@@ -794,21 +759,24 @@ def select_baseline_run(
         if check_commit:
             candidate_head_sha = (workflow_run.get("head_sha", "") or "").strip()
             if not candidate_head_sha:
-                # A run without a head_sha cannot be confirmed compatible.
-                logger.info("Skipping run %s: no head_sha to compare", run_id)
+                logger.info(
+                    "Skipping run %s: no head_sha to compare with expected baseline",
+                    run_id,
+                )
                 continue
+
             commit_compatibility = validate_commit_compatibility(
                 candidate_head_sha=candidate_head_sha,
-                current_commit_sha=current_commit_sha,
-                ordered_commit_shas=ordered_commit_shas or (),
+                expected_head_sha=expected_head_sha,
             )
+
             if not commit_compatibility.is_valid:
                 logger.info(
-                    "Skipping run %s: commit %s is %s relative to current %s",
+                    "Skipping run %s: candidate commit %s does not exactly match "
+                    "expected baseline commit %s",
                     run_id,
                     candidate_head_sha,
-                    commit_compatibility.relationship,
-                    commit_compatibility.current_commit_sha,
+                    commit_compatibility.expected_head_sha,
                 )
                 continue
 

--- a/build_tools/github_actions/configure_multi_arch_ci.py
+++ b/build_tools/github_actions/configure_multi_arch_ci.py
@@ -203,7 +203,7 @@ class CIInputs:
         python_version = os.environ.get("PYTHON_VERSION", "").strip()
 
         pr_labels: list[str] = []
-        base_ref: str | None = "HEAD^1"
+        base_ref: str | None = None
         if event_name == "pull_request":
             # Extract label name strings from the event payload's label objects:
             #   Sample input:  [{"name": "ci:skip", "color": "fff", ...}, ...]
@@ -225,6 +225,21 @@ class CIInputs:
                 # diff against. HEAD^1 would only diff the final pushed commit
                 # against its parent, missing earlier commits in the push.
                 base_ref = None
+        elif event_name == "workflow_dispatch":
+            # This one ref defines both:
+            #
+            #   changed_files = diff(base_ref, HEAD)
+            #   expected_baseline_sha = resolve(base_ref)
+            #
+            # Keeping those values tied together prevents artifacts from one
+            # commit being reused for an independently calculated impact range.
+            base_ref = (
+                os.environ.get(
+                    "STAGE_REUSE_DIFF_BASE",
+                    "",
+                ).strip()
+                or None
+            )
 
         # Test labels come from two sources:
         # 1. LINUX/WINDOWS_TEST_LABELS env vars (workflow_dispatch inputs)
@@ -302,10 +317,11 @@ class GitContext:
 
     @staticmethod
     def empty() -> "GitContext":
-        """Empty context with no git data.
+        """Return a context without a validated change range.
 
-        This should typically be used for schedule/workflow_dispatch events
-        where we don't want to diff against a prior commit.
+        Used for schedules, dispatches without stage_reuse_diff_base, external
+        repository calls, and events where no reliable diff base is available.
+        Automatic stage reuse must remain disabled for this context.
         """
         return GitContext()
 
@@ -855,6 +871,125 @@ def _determine_test_type(
     return "quick", "default"
 
 
+def _get_expected_baseline_sha(
+    ci_inputs: CIInputs,
+    git_context: GitContext,
+) -> str | None:
+    """Return the exact commit whose artifacts may be reused.
+
+    Automatic reuse is allowed only when changed-file analysis was computed
+    from the same resolved base commit:
+
+        diff_base_commit -> diff_head_commit
+    """
+
+    if not (
+        ci_inputs.is_pull_request or ci_inputs.is_push or ci_inputs.is_workflow_dispatch
+    ):
+        return None
+
+    if ci_inputs.is_workflow_dispatch and not ci_inputs.base_ref:
+        return None
+
+    if git_context.changed_files is None:
+        return None
+
+    return git_context.diff_base_commit
+
+
+def _apply_stage_reuse_precedence(
+    manual_prebuilt_stages: list[str],
+    manual_baseline_run_id: str,
+    auto_stage_reuse: AutoStageReuse,
+    *,
+    allow_automatic_reuse: bool = True,
+) -> tuple[
+    dict[str, JobAction],
+    str,
+    AutoStageReuse,
+]:
+    """Resolve manual and automatic stage reuse into one build decision."""
+
+    stage_decisions: dict[str, JobAction] = {
+        stage: JobAction.PREBUILT for stage in manual_prebuilt_stages
+    }
+
+    baseline_run_id = manual_baseline_run_id
+
+    if manual_prebuilt_stages:
+        # Explicit workflow inputs take precedence over automatic reuse.
+        if auto_stage_reuse.applied_reuse_stages:
+            reason = (
+                "manual prebuilt_stages input takes precedence; "
+                "automatic stage reuse was not applied"
+            )
+
+            adjusted_report_lines = tuple(
+                line.replace(
+                    "WILL be skipped",
+                    "WOULD be reusable but was not applied",
+                )
+                for line in auto_stage_reuse.report_lines
+            )
+
+            auto_stage_reuse = replace(
+                auto_stage_reuse,
+                applied_reuse_stages=(),
+                reasons=(
+                    *auto_stage_reuse.reasons,
+                    reason,
+                ),
+                report_lines=(
+                    *adjusted_report_lines,
+                    f"[STAGE-REUSE] {reason}.",
+                ),
+            )
+
+        return (
+            stage_decisions,
+            baseline_run_id,
+            auto_stage_reuse,
+        )
+
+    if not allow_automatic_reuse:
+        if auto_stage_reuse.applied_reuse_stages:
+            reason = (
+                "automatic stage reuse was not applied because "
+                "cross-repository reuse requires explicit inputs"
+            )
+
+            auto_stage_reuse = replace(
+                auto_stage_reuse,
+                applied_reuse_stages=(),
+                reasons=(
+                    *auto_stage_reuse.reasons,
+                    reason,
+                ),
+                report_lines=(
+                    *auto_stage_reuse.report_lines,
+                    f"[STAGE-REUSE] {reason}.",
+                ),
+            )
+
+        return (
+            stage_decisions,
+            baseline_run_id,
+            auto_stage_reuse,
+        )
+
+    for stage in auto_stage_reuse.applied_reuse_stages:
+        stage_decisions[stage] = JobAction.PREBUILT
+
+    if auto_stage_reuse.applied_reuse_stages and auto_stage_reuse.baseline_run_id:
+        baseline_run_id = auto_stage_reuse.baseline_run_id
+
+    return (
+        stage_decisions,
+        baseline_run_id,
+        auto_stage_reuse,
+    )
+
+
 def decide_jobs(
     ci_inputs: CIInputs,
     git_context: GitContext,
@@ -871,10 +1006,7 @@ def decide_jobs(
     # Parse explicit prebuilt stages from workflow_dispatch input. These are
     # the MANUAL inputs and are always honored, unchanged, in every mode.
 
-    stage_decisions: dict[str, JobAction] = {}
-    if ci_inputs.prebuilt_stages:
-        for stage in _parse_prebuilt_stages(ci_inputs.prebuilt_stages):
-            stage_decisions[stage] = JobAction.PREBUILT
+    manual_prebuilt_stages = _parse_prebuilt_stages(ci_inputs.prebuilt_stages)
 
     # Automatic stage reuse, behind STAGE_REUSE_MODE: in dry-run we only report
     # which stages WOULD be reused and apply nothing; in "reuse-stage" the
@@ -882,24 +1014,52 @@ def decide_jobs(
     # their builds and copies artifacts instead. The platforms and families to
     # verify come straight from the resolved target selection.
 
+    all_families = get_all_families_for_trigger_types(
+        ["presubmit", "postsubmit", "nightly"]
+    )
+
+    linux_artifact_families = [
+        all_families[family_name]["linux"]["family"]
+        for family_name in targets.linux_families
+    ]
+
+    windows_artifact_families = [
+        all_families[family_name]["windows"]["family"]
+        for family_name in targets.windows_families
+    ]
+
+    baseline_repository = ci_inputs.baseline_repository
+    current_repo = os.environ.get("GITHUB_REPOSITORY", "")
+
+    is_cross_repo = bool(baseline_repository and baseline_repository != current_repo)
+
+    expected_baseline_sha = (
+        None
+        if is_cross_repo
+        else _get_expected_baseline_sha(
+            ci_inputs,
+            git_context,
+        )
+    )
+
     auto_stage_reuse = compute_auto_stage_reuse(
         changed_files=git_context.changed_files,
         mode=StageReuseMode.from_environ(),
-        linux_amdgpu_families=targets.linux_families,
-        windows_amdgpu_families=targets.windows_families,
+        linux_amdgpu_families=linux_artifact_families,
+        windows_amdgpu_families=windows_artifact_families,
+        expected_baseline_sha=expected_baseline_sha,
     )
 
-    baseline_repository = ci_inputs.baseline_repository
-    baseline_run_id = ci_inputs.baseline_run_id
-
-    # Apply automatic stage reuse when running in the same repo as baseline.
-    current_repo = os.environ.get("GITHUB_REPOSITORY", "")
-    if not baseline_repository or baseline_repository == current_repo:
-        # reuse-stage mode returns non-empty applied_reuse_stages.
-        for stage in auto_stage_reuse.applied_reuse_stages:
-            stage_decisions.setdefault(stage, JobAction.PREBUILT)
-        if auto_stage_reuse.applied_reuse_stages and auto_stage_reuse.baseline_run_id:
-            baseline_run_id = auto_stage_reuse.baseline_run_id
+    (
+        stage_decisions,
+        baseline_run_id,
+        auto_stage_reuse,
+    ) = _apply_stage_reuse_precedence(
+        manual_prebuilt_stages=manual_prebuilt_stages,
+        manual_baseline_run_id=ci_inputs.baseline_run_id,
+        auto_stage_reuse=auto_stage_reuse,
+        allow_automatic_reuse=not is_cross_repo,
+    )
 
     build_rocm = BuildRocmDecision(
         action=JobAction.RUN,
@@ -1385,6 +1545,58 @@ def configure(ci_inputs: CIInputs, git_context: GitContext) -> CIOutputs:
     )
 
 
+def _load_git_context(
+    ci_inputs: CIInputs,
+) -> GitContext:
+    """Load the git range used for path filtering and automatic stage reuse."""
+
+    # Skip path filtering for external repos (e.g., rocm-libraries calling TheRock workflows)
+    # The "run everything" behavior is the initial state for superrepo multi-arch CI migration.
+    # We will eventually support path filtering and component selection.
+    # TODO: Provide custom decision logic to run specific components and paths.
+    skip_path_filters = os.environ.get("SKIP_PATH_FILTERS", "").lower() == "true"
+
+    if skip_path_filters:
+        # External repo: skip path filtering and run everything.
+        # Automatic cross-repository stage reuse remains disabled. Explicit
+        # manual reuse inputs are handled later by decide_jobs().
+        return GitContext.empty()
+
+    if ci_inputs.base_ref:
+        # Pull requests and pushes use their event-derived diff base.
+        #
+        # A workflow_dispatch event can also compute changed-file impact when
+        # stage_reuse_diff_base is explicitly provided. The same resolved base
+        # commit is used for both:
+        #
+        #   changed_files = diff(base_ref, HEAD)
+        #   expected_baseline_sha = resolve(base_ref)
+        #
+        # This keeps stage-impact analysis and exact baseline validation tied
+        # to the same commit range.
+        print("=== Git Diff ===")
+        git_context = GitContext.from_repo(
+            base_ref=ci_inputs.base_ref,
+        )
+        print()
+        return git_context
+
+    if ci_inputs.is_pull_request or ci_inputs.is_push or ci_inputs.is_workflow_dispatch:
+        # Some push events, such as branch creation, do not have a reliable
+        # diff base. A workflow_dispatch without stage_reuse_diff_base also
+        # has no validated change range.
+        print("=== Git Diff ===")
+        print(
+            "No diff base is available; running without changed-file "
+            "filtering or automatic stage reuse"
+        )
+        print()
+        return GitContext.empty()
+
+    # Schedule events do not have a natural diff base.
+    return GitContext.empty()
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -1392,36 +1604,16 @@ def configure(ci_inputs: CIInputs, git_context: GitContext) -> CIOutputs:
 
 def main():
     ci_inputs = CIInputs.from_environ()
+    git_context = _load_git_context(ci_inputs)
 
-    # Skip path filtering for external repos (e.g., rocm-libraries calling TheRock workflows)
-    # The "run everything" is initial state for superrepo multi-arch CI migration.
-    # We will eventually support path filtering and component selection.
-    # TODO: Provide custom decision logic to run specific components and paths
-    skip_path_filters = os.environ.get("SKIP_PATH_FILTERS", "").lower() == "true"
-
-    if skip_path_filters:
-        # External repo: skip path filtering, run everything
-        git_context = GitContext.empty()
-    elif (ci_inputs.is_pull_request or ci_inputs.is_push) and ci_inputs.base_ref:
-        # 'pull_request' and 'push' events can use the list of changed files
-        # compared to the "prior commit" to affect job selections/options.
-        print("=== Git Diff ===")
-        git_context = GitContext.from_repo(base_ref=ci_inputs.base_ref)
-        print()
-    elif ci_inputs.is_pull_request or ci_inputs.is_push:
-        # Some push events, such as branch creation, do not have a reliable
-        # base ref for changed-file filtering. Run without path filters.
-        print("=== Git Diff ===")
-        print("No diff base is available; running without changed-file filtering")
-        print()
-        git_context = GitContext.empty()
-    else:
-        # 'workflow_dispatch' and 'schedule' events don't have as natural
-        # a "prior commit" to compare against.
-        git_context = GitContext.empty()
-
-    outputs = configure(ci_inputs, git_context)
-    write_outputs(ci_inputs=ci_inputs, outputs=outputs)
+    outputs = configure(
+        ci_inputs,
+        git_context,
+    )
+    write_outputs(
+        ci_inputs=ci_inputs,
+        outputs=outputs,
+    )
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/stage_reuse_decision.py
+++ b/build_tools/github_actions/stage_reuse_decision.py
@@ -42,12 +42,11 @@ are set by ``setup_multi_arch.yml`` and form the stage-reuse interface:
 * ``STAGE_REUSE_BASELINE_BRANCH``  - baseline branch to search (default ``main``).
 * ``STAGE_REUSE_BASELINE_WORKFLOW`` - baseline workflow file
                                    (default ``multi_arch_ci.yml``).
-* ``STAGE_REUSE_CURRENT_SHA``    - current commit SHA; enables the
-                                   commit-compatibility rule when set.
 * ``STAGE_REUSE_MAX_AGE_HOURS``  - recency window in hours; disables the recency
                                    rule when unset.
-* ``STAGE_REUSE_COMMIT_HISTORY`` - number of branch commits to fetch for
-                                   ancestry (default ``50``).
+The expected baseline SHA is passed directly from
+``GitContext.diff_base_commit`` by ``configure_multi_arch_ci.py``.
+Automatic reuse is disabled when that exact SHA is unavailable.
 """
 
 import enum
@@ -56,17 +55,20 @@ import logging
 import functools
 import sys
 import baseline_runs
-import github_actions_api
 from pathlib import Path
 from dataclasses import dataclass, field
-from typing import Callable, Optional, Sequence
+from typing import Callable, Sequence
 
 # Add build_tools to the path so sibling CI modules and _therock_utils import
 # cleanly regardless of the current working directory.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from _therock_utils.artifact_backend import ARTIFACT_EXTENSIONS
-from _therock_utils.build_topology import BuildTopology, get_topology
+from _therock_utils.build_topology import (
+    BuildTopology,
+    artifact_may_apply_to_platform,
+    get_topology,
+)
 from artifact_manager import ARTIFACT_COMPONENTS
 from baseline_runs import BaselineRun, RequiredArtifact
 from github_actions_api import GitHubAPIError
@@ -97,6 +99,19 @@ BaselineSelector = Callable[[Sequence[RequiredArtifact]], BaselineRun | None]
 
 
 @dataclass(frozen=True)
+class WorkflowImpact:
+    """Stage impact analysis before baseline validation."""
+
+    changed_paths: tuple[str, ...]
+    affected_source_sets: tuple[str, ...]
+    affected_artifact_groups: tuple[str, ...]
+    rebuild_stages: tuple[str, ...]
+    copy_stages: tuple[str, ...]
+    full_rebuild_required: bool
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class StageReusePlan:
     """Result of the *planning* step: which stages are reuse candidates.
     This is a pure function of the changed files and topology -- no baseline
@@ -104,10 +119,7 @@ class StageReusePlan:
     callers reuse the impact decision without triggering any network/API work.
     """
 
-    candidate_stages: tuple[str, ...]
-    rebuild_stages: tuple[str, ...]
-    full_rebuild_required: bool
-    reasons: tuple[str, ...]
+    impact: WorkflowImpact
 
 
 @dataclass(frozen=True)
@@ -128,41 +140,84 @@ class AutoStageReuse:
     platform_available: dict[str, tuple[str, ...]] = field(default_factory=dict)
 
 
-def _target_families(
-    linux_amdgpu_families: Sequence[str],
-    windows_amdgpu_families: Sequence[str],
+def _target_families_for_platform(
+    amdgpu_families: Sequence[str],
 ) -> tuple[str, ...]:
-    """Family list whose artifacts must be verified for stage reuse.
-    De-duplicates the requested Linux and Windows families and always appends
-    the generic pseudo-family, since every stage produces a generic archive.
-    """
-    families = list(dict.fromkeys([*linux_amdgpu_families, *windows_amdgpu_families]))
+    """Return de-duplicated artifact families for one platform."""
+    families = list(dict.fromkeys(amdgpu_families))
+
     if GENERIC_FAMILY not in families:
         families.append(GENERIC_FAMILY)
+
     return tuple(families)
+
+
+def _target_families_for_artifact(
+    *,
+    artifact_name: str,
+    artifact_type: str,
+    target_families: Sequence[str],
+) -> tuple[str, ...]:
+    """Return the target families applicable to one artifact."""
+
+    if artifact_type == "target-neutral":
+        return (GENERIC_FAMILY,)
+
+    if artifact_type == "target-specific":
+        return tuple(
+            family
+            for family in dict.fromkeys(target_families)
+            if family != GENERIC_FAMILY
+        )
+
+    raise ValueError(
+        f"Artifact {artifact_name!r} has unsupported type " f"{artifact_type!r}"
+    )
 
 
 def _required_artifacts_for_stages(
     topology: BuildTopology,
     stage_names: Sequence[str],
     target_families: Sequence[str],
+    *,
+    platform: str,
 ) -> list[RequiredArtifact]:
-    """Artifact/family pairs the given stages produce."""
+    """Return the artifact/family pairs produced by the given stages."""
 
-    artifacts_by_group = topology.get_artifact_group_to_artifacts()
     required: list[RequiredArtifact] = []
     seen: set[RequiredArtifact] = set()
+
     for stage_name in stage_names:
         stage = topology.build_stages.get(stage_name)
         if stage is None:
             continue
+
         for group_name in stage.artifact_groups:
-            for artifact_name in artifacts_by_group.get(group_name, []):
-                for family in target_families:
-                    req = RequiredArtifact(name=artifact_name, target_family=family)
-                    if req not in seen:
-                        seen.add(req)
-                        required.append(req)
+            for artifact in topology.get_artifacts_in_group(group_name):
+                if not artifact_may_apply_to_platform(
+                    artifact,
+                    platform,
+                ):
+                    continue
+
+                artifact_families = _target_families_for_artifact(
+                    artifact_name=artifact.name,
+                    artifact_type=artifact.type,
+                    target_families=target_families,
+                )
+
+                for family in artifact_families:
+                    requirement = RequiredArtifact(
+                        name=artifact.name,
+                        target_family=family,
+                    )
+
+                    if requirement in seen:
+                        continue
+
+                    seen.add(requirement)
+                    required.append(requirement)
+
     return required
 
 
@@ -177,27 +232,43 @@ def _stage_artifacts_available(
     stage_name: str,
     target_families: Sequence[str],
     available_filenames: set[str],
+    *,
+    platform: str,
 ) -> bool:
-    """True when every artifact this stage produces has an archive present."""
+    """Return whether every artifact produced by a stage is available."""
 
-    artifacts_by_group = topology.get_artifact_group_to_artifacts()
-    stage = topology.build_stages.get(stage_name)
-    if stage is None:
+    if stage_name not in topology.build_stages:
         return False
-    for group_name in stage.artifact_groups:
-        for artifact_name in artifacts_by_group.get(group_name, []):
-            for family in target_families:
-                found = False
-                for component in ARTIFACT_COMPONENTS:
-                    for extension in ARTIFACT_EXTENSIONS:
-                        filename = f"{artifact_name}_{component}_{family}{extension}"
-                        if filename in available_filenames:
-                            found = True
-                            break
-                    if found:
-                        break
-                if not found:
-                    return False
+
+    requirements = _required_artifacts_for_stages(
+        topology,
+        [stage_name],
+        target_families,
+        platform=platform,
+    )
+
+    for requirement in requirements:
+        found = False
+
+        for component in ARTIFACT_COMPONENTS:
+            for extension in ARTIFACT_EXTENSIONS:
+                filename = (
+                    f"{requirement.name}_"
+                    f"{component}_"
+                    f"{requirement.target_family}"
+                    f"{extension}"
+                )
+
+                if filename in available_filenames:
+                    found = True
+                    break
+
+            if found:
+                break
+
+        if not found:
+            return False
+
     return True
 
 
@@ -214,12 +285,17 @@ def plan_stage_reuse(
     """
 
     if changed_files is None:
-        return StageReusePlan(
-            candidate_stages=(),
+        stage_impact = WorkflowImpact(
+            changed_paths=(),
+            affected_source_sets=(),
+            affected_artifact_groups=(),
             rebuild_stages=(),
+            copy_stages=(),
             full_rebuild_required=True,
             reasons=("no changed-file list available",),
         )
+
+        return StageReusePlan(impact=stage_impact)
 
     if topology is None:
         topology = get_topology()
@@ -233,12 +309,16 @@ def plan_stage_reuse(
         topology=topology,
         platform=platform,
     )
-    return StageReusePlan(
-        candidate_stages=tuple(impact.copy_stages),
-        rebuild_stages=tuple(impact.rebuild_stages),
+    stage_impact = WorkflowImpact(
+        changed_paths=tuple(changed_files),
+        affected_source_sets=impact.matched_source_sets,
+        affected_artifact_groups=impact.impacted_artifact_groups,
+        rebuild_stages=impact.rebuild_stages,
+        copy_stages=impact.copy_stages,
         full_rebuild_required=impact.full_rebuild_required,
-        reasons=tuple(impact.reasons),
+        reasons=impact.reasons,
     )
+    return StageReusePlan(impact=stage_impact)
 
 
 def compute_auto_stage_reuse(
@@ -247,9 +327,12 @@ def compute_auto_stage_reuse(
     mode: StageReuseMode,
     linux_amdgpu_families: Sequence[str] = (),
     windows_amdgpu_families: Sequence[str] = (),
+    expected_baseline_sha: str | None = None,
     topology: BuildTopology | None = None,
     baseline_selector: BaselineSelector | None = None,
-    baseline_selector_factory: Callable[[str], BaselineSelector] | None = None,
+    baseline_selector_factory: (
+        Callable[[str, str | None], BaselineSelector] | None
+    ) = None,
 ) -> AutoStageReuse:
     """Compute auto stage-reuse decisions, verified against a baseline run.
     A stage is only reusable when it is unaffected by the change AND its
@@ -277,22 +360,30 @@ def compute_auto_stage_reuse(
     if topology is None and changed_files is not None:
         topology = get_topology()
 
-    families = _target_families(linux_amdgpu_families, windows_amdgpu_families)
+    families_by_platform = {
+        "linux": _target_families_for_platform(
+            linux_amdgpu_families,
+        ),
+        "windows": _target_families_for_platform(
+            windows_amdgpu_families,
+        ),
+    }
 
     plan = plan_stage_reuse(
         changed_files=changed_files,
-        platform=platforms[0],
+        platform=None,
         topology=topology,
     )
-    candidates = plan.candidate_stages
-    rebuild = plan.rebuild_stages
+    impact = plan.impact
+    candidates = impact.copy_stages
+    rebuild = impact.rebuild_stages
 
     if changed_files is None:
         return _log_and_return(
             _empty_result(
                 mode,
                 full_rebuild_required=True,
-                reasons=plan.reasons,
+                reasons=impact.reasons,
                 report_lines=(
                     f"{LOG_PREFIX} mode={mode.value}; no changed-file list. "
                     f"Conservatively rebuilding all stages.",
@@ -300,13 +391,13 @@ def compute_auto_stage_reuse(
             )
         )
 
-    if plan.full_rebuild_required or not candidates:
+    if impact.full_rebuild_required or not candidates:
         lines = _format_report(
             mode=mode,
             candidates=candidates,
             rebuild=rebuild,
-            full_rebuild_required=plan.full_rebuild_required,
-            reasons=plan.reasons,
+            full_rebuild_required=impact.full_rebuild_required,
+            reasons=impact.reasons,
             baseline_run_id=None,
             available=(),
             unavailable=candidates,
@@ -316,39 +407,44 @@ def compute_auto_stage_reuse(
                 mode=mode,
                 candidate_stages=candidates,
                 rebuild_stages=rebuild,
-                full_rebuild_required=plan.full_rebuild_required,
+                full_rebuild_required=impact.full_rebuild_required,
                 baseline_run_id=None,
                 baseline_html_url=None,
                 available_stages=(),
                 unavailable_stages=candidates,
                 applied_reuse_stages=(),
-                reasons=plan.reasons,
+                reasons=impact.reasons,
                 report_lines=lines,
             )
         )
-
-    required = _required_artifacts_for_stages(topology, candidates, families)
-    # Verify artifact availability independently for each platform. A single
-    # ``baseline_selector`` (used by tests) applies to all platforms; otherwise
-    # a per-platform selector is built so each platform is checked against a
-    # baseline that actually produced that platform's artifacts.
+    # Verify artifact availability independently for each platform.
     platform_baseline_run_ids: dict[str, str | None] = {}
     platform_baseline_urls: dict[str, str | None] = {}
     per_platform_available: dict[str, tuple[str, ...]] = {}
     baseline_error: str | None = None
 
     for platform in platforms:
+        platform_families = families_by_platform[platform]
+
+        required = _required_artifacts_for_stages(
+            topology,
+            candidates,
+            platform_families,
+            platform=platform,
+        )
+
         if baseline_selector is not None:
             selector = baseline_selector
         elif baseline_selector_factory is not None:
-            selector = baseline_selector_factory(platform)
+            selector = baseline_selector_factory(
+                platform,
+                expected_baseline_sha,
+            )
         else:
-            selector = _default_baseline_selector(platform=platform)
-
-        # Only transient GitHub API / network failures are tolerated here: a
-        # failed baseline lookup falls back to a full rebuild, which is safe.
-        # Configuration errors (e.g. a bad required-artifacts request) indicate
-        # a bug and must surface, so they are left to propagate.
+            selector = _default_baseline_selector(
+                platform=platform,
+                expected_baseline_sha=expected_baseline_sha,
+            )
         try:
             baseline = selector(required)
         except GitHubAPIError as exc:
@@ -364,12 +460,18 @@ def compute_auto_stage_reuse(
 
         available_filenames = _matched_filenames(baseline)
         available_here: list[str] = []
+
         if baseline is not None:
             for stage_name in candidates:
                 if _stage_artifacts_available(
-                    topology, stage_name, families, available_filenames
+                    topology,
+                    stage_name,
+                    platform_families,
+                    available_filenames,
+                    platform=platform,
                 ):
                     available_here.append(stage_name)
+
         per_platform_available[platform] = tuple(available_here)
 
     selected_run_ids = {
@@ -421,7 +523,7 @@ def compute_auto_stage_reuse(
         candidates=candidates,
         rebuild=rebuild,
         full_rebuild_required=False,
-        reasons=plan.reasons,
+        reasons=impact.reasons,
         baseline_run_id=reported_baseline_run_id,
         available=available_t,
         unavailable=unavailable_t,
@@ -440,7 +542,7 @@ def compute_auto_stage_reuse(
             available_stages=available_t,
             unavailable_stages=unavailable_t,
             applied_reuse_stages=applied,
-            reasons=plan.reasons,
+            reasons=impact.reasons,
             report_lines=lines,
             platform_available=per_platform_available,
         )
@@ -465,66 +567,60 @@ def _build_platforms(
     return tuple(platforms)
 
 
-def _default_baseline_selector(*, platform: str) -> BaselineSelector:
-    """Build a selector bound to baseline_runs.select_baseline_run.
-    ``select_baseline_run`` already requires each candidate run to have healthy
-    build jobs (``required_successful_job_name_substrings=("Build",)``) AND to
-    contain all requested artifacts. A run with no artifacts (e.g. a docs-only
-    change) therefore fails the availability gate and is never selected, so no
-    extra "passing build" check is needed here.
+def _default_baseline_selector(
+    *,
+    platform: str,
+    expected_baseline_sha: str | None = None,
+) -> BaselineSelector:
+    """Build an exact-SHA baseline selector.
+
+    Automatic reuse is disabled when the exact diff-base SHA is unavailable.
+    It must never fall back to selecting a recent run without commit
+    validation.
     """
 
-    github_repository = os.environ.get("GITHUB_REPOSITORY", "ROCm/TheRock")
-    branch = os.environ.get("STAGE_REUSE_BASELINE_BRANCH", "main")
-    workflow_name = os.environ.get("STAGE_REUSE_BASELINE_WORKFLOW", "multi_arch_ci.yml")
-    current_commit_sha = os.environ.get("STAGE_REUSE_CURRENT_SHA") or None
+    github_repository = os.environ.get(
+        "GITHUB_REPOSITORY",
+        "ROCm/TheRock",
+    )
+    branch = os.environ.get(
+        "STAGE_REUSE_BASELINE_BRANCH",
+        "main",
+    )
+    workflow_name = os.environ.get(
+        "STAGE_REUSE_BASELINE_WORKFLOW",
+        "multi_arch_ci.yml",
+    )
+
     max_age_hours_raw = os.environ.get("STAGE_REUSE_MAX_AGE_HOURS")
     max_age_hours = float(max_age_hours_raw) if max_age_hours_raw else None
-    history_count_raw = os.environ.get("STAGE_REUSE_COMMIT_HISTORY", "50")
-    try:
-        history_count = max(1, int(history_count_raw))
-    except ValueError:
-        history_count = 50
-    # The commit-compatibility rule needs the branch history (newest-first) to
-    # establish ancestry. select_baseline_run only accepts a candidate whose
-    # head_sha is `same` or `ancestor` of current_commit_sha; with an EMPTY
-    # window every candidate resolves to `unknown` and is rejected, so reuse
-    # never activates. Fetch the real history here. If the SHA is set but the
-    # history fetch fails (or returns empty), disable the commit rule (pass both
-    # as None) rather than enabling it with an empty window -- recency and
-    # artifact availability still gate the selection.
-    ordered_commit_shas = None
-    effective_commit_sha = current_commit_sha
-    if current_commit_sha is not None:
-        try:
-            ordered_commit_shas = github_actions_api.gha_query_recent_branch_commits(
-                github_repository_name=github_repository,
-                branch=branch,
-                max_count=history_count,
-            )
-        except GitHubAPIError as exc:
-            logger.warning(
-                "%s could not fetch branch history (%s); "
-                "skipping commit-compatibility rule.",
-                LOG_PREFIX,
-                exc,
-            )
-            ordered_commit_shas = None
-        if not ordered_commit_shas:
-            effective_commit_sha = None
-            ordered_commit_shas = None
 
-    # A functools.partial binds the resolved configuration to
-    # select_baseline_run; the only free argument is required_artifacts, which
-    # matches the BaselineSelector signature.
+    normalized_expected_sha = (
+        expected_baseline_sha.strip() if expected_baseline_sha else ""
+    )
+
+    if not normalized_expected_sha:
+        logger.warning(
+            "%s no exact diff-base SHA is available; "
+            "automatic stage reuse is disabled.",
+            LOG_PREFIX,
+        )
+
+        def no_baseline(
+            required: Sequence[RequiredArtifact],
+        ) -> BaselineRun | None:
+            del required
+            return None
+
+        return no_baseline
+
     return functools.partial(
         _invoke_select_baseline_run,
         github_repository=github_repository,
         workflow_name=workflow_name,
         branch=branch,
         platform=platform,
-        current_commit_sha=effective_commit_sha,
-        ordered_commit_shas=ordered_commit_shas,
+        expected_head_sha=normalized_expected_sha,
         max_age_hours=max_age_hours,
     )
 
@@ -647,24 +743,42 @@ def render_step_summary(result: AutoStageReuse) -> str:
     """Render a GitHub step-summary markdown block for the analysis."""
     baseline = f"`{result.baseline_run_id}`" if result.baseline_run_id else "_none_"
     candidates = _format_stage_list(result.candidate_stages)
+    rebuild = _format_stage_list(result.rebuild_stages)
     available = _format_stage_list(result.available_stages)
     applied = _format_stage_list(result.applied_reuse_stages)
 
     out = ["### Stage reuse analysis", ""]
+
     out.append(f"- mode: `{result.mode.value}`")
-    out.append(f"- full rebuild required: `{result.full_rebuild_required}`")
+    out.append(
+        "- conservative full-CI fallback triggered: "
+        f"`{result.full_rebuild_required}`"
+    )
+
+    if result.full_rebuild_required:
+        build_scope = "all stages — conservative fallback"
+    elif result.candidate_stages:
+        build_scope = "partial rebuild"
+    else:
+        build_scope = "all stages — all stages impacted"
+
+    out.append(f"- effective build scope: `{build_scope}`")
+    out.append(f"- rebuild stages: {rebuild}")
     out.append(f"- baseline run checked: {baseline}")
     out.append(f"- unaffected candidates: {candidates}")
     out.append(f"- available in baseline: {available}")
     out.append(f"- applied: {applied}")
+
     if result.platform_available:
         out.append("- available per platform:")
         for platform, stages in result.platform_available.items():
             out.append(f"  - {platform}: {_format_stage_list(stages)}")
+
     if result.reasons:
         out.append("- reasons:")
         for reason in result.reasons:
             out.append(f"  - {reason}")
+
     if result.mode is StageReuseMode.DRY_RUN and result.available_stages:
         out.append("")
         out.append(
@@ -672,6 +786,7 @@ def render_step_summary(result: AutoStageReuse) -> str:
             "verified against the baseline run above. Set "
             "`STAGE_REUSE_MODE=reuse-stage` after review to enable skipping."
         )
+
     return "\n".join(out)
 
 

--- a/build_tools/github_actions/tests/baseline_runs_test.py
+++ b/build_tools/github_actions/tests/baseline_runs_test.py
@@ -29,7 +29,7 @@ def _workflow_run(
         "status": status,
         "conclusion": conclusion,
         "html_url": f"https://github.com/ROCm/TheRock/actions/runs/{run_id}",
-        "head_sha": head_sha or f"sha-{run_id}",
+        "head_sha": f"sha-{run_id}" if head_sha is None else head_sha,
         "head_branch": "main",
         "run_attempt": run_attempt,
         "created_at": created_at,
@@ -519,68 +519,83 @@ class BaselineRunsTest(unittest.TestCase):
 
 
 class CommitCompatibilityTest(unittest.TestCase):
-    HISTORY = ["sha-new", "sha-current", "sha-old", "sha-older"]
-
-    def test_same_commit_is_valid(self):
+    def test_exact_commit_match_is_valid(self):
         result = baseline_runs.validate_commit_compatibility(
             candidate_head_sha="sha-current",
-            current_commit_sha="sha-current",
-            ordered_commit_shas=self.HISTORY,
+            expected_head_sha="sha-current",
         )
-        self.assertEqual(result.relationship, "same")
+
+        self.assertEqual(
+            result.expected_head_sha,
+            "sha-current",
+        )
+        self.assertEqual(
+            result.candidate_head_sha,
+            "sha-current",
+        )
+        self.assertEqual(
+            result.relationship,
+            "same",
+        )
         self.assertTrue(result.is_valid)
 
-    def test_ancestor_commit_is_valid(self):
+    def test_different_commit_is_invalid(self):
+        for candidate_sha in (
+            "sha-ancestor",
+            "sha-descendant",
+            "sha-divergent",
+            "sha-missing",
+        ):
+            with self.subTest(candidate_sha=candidate_sha):
+                result = baseline_runs.validate_commit_compatibility(
+                    candidate_head_sha=candidate_sha,
+                    expected_head_sha="sha-current",
+                )
+
+                self.assertEqual(
+                    result.expected_head_sha,
+                    "sha-current",
+                )
+                self.assertEqual(
+                    result.candidate_head_sha,
+                    candidate_sha,
+                )
+                self.assertEqual(
+                    result.relationship,
+                    "different",
+                )
+                self.assertFalse(result.is_valid)
+
+    def test_sha_comparison_is_normalized(self):
         result = baseline_runs.validate_commit_compatibility(
-            candidate_head_sha="sha-old",
-            current_commit_sha="sha-current",
-            ordered_commit_shas=self.HISTORY,
+            candidate_head_sha=" SHA-CURRENT ",
+            expected_head_sha="sha-current",
         )
-        self.assertEqual(result.relationship, "ancestor")
+
+        self.assertEqual(
+            result.relationship,
+            "same",
+        )
         self.assertTrue(result.is_valid)
 
-    def test_descendant_commit_is_invalid(self):
-        result = baseline_runs.validate_commit_compatibility(
-            candidate_head_sha="sha-new",
-            current_commit_sha="sha-current",
-            ordered_commit_shas=self.HISTORY,
-        )
-        self.assertEqual(result.relationship, "descendant_or_divergent")
-        self.assertFalse(result.is_valid)
-
-    def test_unknown_candidate_is_invalid(self):
-        result = baseline_runs.validate_commit_compatibility(
-            candidate_head_sha="sha-divergent",
-            current_commit_sha="sha-current",
-            ordered_commit_shas=self.HISTORY,
-        )
-        self.assertEqual(result.relationship, "unknown")
-        self.assertFalse(result.is_valid)
-
-    def test_current_outside_window_is_unknown(self):
-        result = baseline_runs.validate_commit_compatibility(
-            candidate_head_sha="sha-old",
-            current_commit_sha="sha-missing",
-            ordered_commit_shas=self.HISTORY,
-        )
-        self.assertEqual(result.relationship, "unknown")
-        self.assertFalse(result.is_valid)
-
-    def test_sha_comparison_is_case_insensitive(self):
-        result = baseline_runs.validate_commit_compatibility(
-            candidate_head_sha="SHA-CURRENT",
-            current_commit_sha="sha-current",
-            ordered_commit_shas=self.HISTORY,
-        )
-        self.assertEqual(result.relationship, "same")
-        self.assertTrue(result.is_valid)
-
-    def test_empty_sha_raises(self):
-        with self.assertRaisesRegex(ValueError, "current_commit_sha"):
+    def test_empty_expected_head_sha_is_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "expected_head_sha",
+        ):
             baseline_runs.validate_commit_compatibility(
-                candidate_head_sha="sha-old",
-                current_commit_sha="",
-                ordered_commit_shas=self.HISTORY,
+                candidate_head_sha="sha-current",
+                expected_head_sha="",
+            )
+
+    def test_empty_candidate_head_sha_is_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "candidate_head_sha",
+        ):
+            baseline_runs.validate_commit_compatibility(
+                candidate_head_sha="",
+                expected_head_sha="sha-current",
             )
 
 
@@ -660,7 +675,7 @@ class SelectBaselineRunSafetyRulesTest(unittest.TestCase):
 
         return backend_factory, workflow_jobs_fetcher
 
-    def test_select_baseline_run_skips_incompatible_commit(self):
+    def test_select_baseline_run_rejects_non_exact_commits(self):
         runs = [
             _workflow_run("newer", head_sha="sha-newer"),
             _workflow_run("ancestor", head_sha="sha-ancestor"),
@@ -678,12 +693,30 @@ class SelectBaselineRunSafetyRulesTest(unittest.TestCase):
         baseline = baseline_runs.select_baseline_run(
             required_artifacts=[RequiredArtifact("base", "generic")],
             platform="linux",
-            current_commit_sha="sha-current",
-            ordered_commit_shas=[
-                "sha-newer",
-                "sha-current",
-                "sha-ancestor",
-            ],
+            expected_head_sha="sha-current",
+            workflow_runs=runs,
+            backend_factory=backend_factory,
+            workflow_jobs_fetcher=workflow_jobs_fetcher,
+        )
+
+        self.assertIsNone(baseline)
+
+    def test_select_baseline_run_accepts_exact_commit(self):
+        runs = [
+            _workflow_run("exact", head_sha="sha-current"),
+        ]
+        artifacts = {
+            "exact": ["base_lib_generic.tar.zst"],
+        }
+        jobs = {
+            "exact": [_workflow_job("Build")],
+        }
+        backend_factory, workflow_jobs_fetcher = self._factories(artifacts, jobs)
+
+        baseline = baseline_runs.select_baseline_run(
+            required_artifacts=[RequiredArtifact("base", "generic")],
+            platform="linux",
+            expected_head_sha="sha-current",
             workflow_runs=runs,
             backend_factory=backend_factory,
             workflow_jobs_fetcher=workflow_jobs_fetcher,
@@ -691,39 +724,104 @@ class SelectBaselineRunSafetyRulesTest(unittest.TestCase):
 
         self.assertIsNotNone(baseline)
         assert baseline is not None
-        self.assertEqual(baseline.run_id, "ancestor")
+        self.assertEqual(baseline.run_id, "exact")
+        self.assertEqual(baseline.head_sha, "sha-current")
+
+        self.assertIsNotNone(baseline.commit_compatibility)
         assert baseline.commit_compatibility is not None
-        self.assertEqual(baseline.commit_compatibility.relationship, "ancestor")
+        self.assertEqual(
+            baseline.commit_compatibility.relationship,
+            "same",
+        )
 
-    def test_select_baseline_run_requires_ordered_commits_for_commit_rule(self):
-        with self.assertRaisesRegex(ValueError, "ordered_commit_shas"):
+    def test_select_baseline_run_rejects_empty_expected_head_sha(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "expected_head_sha",
+        ):
             baseline_runs.select_baseline_run(
-                required_artifacts=[RequiredArtifact("base", "generic")],
+                required_artifacts=[
+                    RequiredArtifact(
+                        "base",
+                        "generic",
+                    )
+                ],
                 platform="linux",
-                current_commit_sha="sha-current",
-                workflow_runs=[_workflow_run("1")],
-                backend_factory=lambda *a: FakeBackend([]),
-                workflow_jobs_fetcher=lambda *a: [],
+                expected_head_sha="",
             )
 
-    def test_select_baseline_run_rejects_empty_current_commit_sha(self):
-        # Empty current_commit_sha still enables the check; fail fast at the
-        # API boundary instead of when the first candidate is inspected.
-        with self.assertRaisesRegex(ValueError, "current_commit_sha"):
-            baseline_runs.select_baseline_run(
-                required_artifacts=[RequiredArtifact("base", "generic")],
-                platform="linux",
-                current_commit_sha="",
-                ordered_commit_shas=["sha-current"],
-                workflow_runs=[_workflow_run("1")],
-                backend_factory=lambda *a: FakeBackend([]),
-                workflow_jobs_fetcher=lambda *a: [],
-            )
+    def test_select_baseline_run_skips_run_with_empty_head_sha(self):
+        runs = [
+            _workflow_run(
+                "no-sha",
+                head_sha="",
+            ),
+            _workflow_run(
+                "exact",
+                head_sha="sha-current",
+            ),
+        ]
+        artifacts = {
+            "no-sha": ["base_lib_generic.tar.zst"],
+            "exact": ["base_lib_generic.tar.zst"],
+        }
+        jobs = {
+            "no-sha": [_workflow_job("Build")],
+            "exact": [_workflow_job("Build")],
+        }
+        backend_factory, workflow_jobs_fetcher = self._factories(
+            artifacts,
+            jobs,
+        )
+
+        baseline = baseline_runs.select_baseline_run(
+            required_artifacts=[
+                RequiredArtifact(
+                    "base",
+                    "generic",
+                )
+            ],
+            platform="linux",
+            expected_head_sha="sha-current",
+            workflow_runs=runs,
+            backend_factory=backend_factory,
+            workflow_jobs_fetcher=workflow_jobs_fetcher,
+        )
+
+        self.assertIsNotNone(baseline)
+        assert baseline is not None
+
+        self.assertEqual(
+            baseline.run_id,
+            "exact",
+        )
+        self.assertEqual(
+            baseline.head_sha,
+            "sha-current",
+        )
+
+        self.assertIsNotNone(
+            baseline.commit_compatibility,
+        )
+        assert baseline.commit_compatibility is not None
+
+        self.assertEqual(
+            baseline.commit_compatibility.relationship,
+            "same",
+        )
 
     def test_select_baseline_run_skips_stale_runs(self):
         runs = [
-            _workflow_run("stale", created_at="2026-06-10T20:00:00Z"),
-            _workflow_run("fresh", created_at="2026-06-17T10:00:00Z"),
+            _workflow_run(
+                "stale",
+                head_sha="sha-current",
+                created_at="2026-06-10T20:00:00Z",
+            ),
+            _workflow_run(
+                "fresh",
+                head_sha="sha-current",
+                created_at="2026-06-17T10:00:00Z",
+            ),
         ]
         artifacts = {
             "stale": ["base_lib_generic.tar.zst"],
@@ -733,13 +831,30 @@ class SelectBaselineRunSafetyRulesTest(unittest.TestCase):
             "stale": [_workflow_job("Build")],
             "fresh": [_workflow_job("Build")],
         }
-        backend_factory, workflow_jobs_fetcher = self._factories(artifacts, jobs)
+        backend_factory, workflow_jobs_fetcher = self._factories(
+            artifacts,
+            jobs,
+        )
 
         baseline = baseline_runs.select_baseline_run(
-            required_artifacts=[RequiredArtifact("base", "generic")],
+            required_artifacts=[
+                RequiredArtifact(
+                    "base",
+                    "generic",
+                )
+            ],
             platform="linux",
+            expected_head_sha="sha-current",
             max_age_hours=24,
-            now=datetime(2026, 6, 17, 20, 0, 0, tzinfo=timezone.utc),
+            now=datetime(
+                2026,
+                6,
+                17,
+                20,
+                0,
+                0,
+                tzinfo=timezone.utc,
+            ),
             workflow_runs=runs,
             backend_factory=backend_factory,
             workflow_jobs_fetcher=workflow_jobs_fetcher,
@@ -747,38 +862,28 @@ class SelectBaselineRunSafetyRulesTest(unittest.TestCase):
 
         self.assertIsNotNone(baseline)
         assert baseline is not None
-        self.assertEqual(baseline.run_id, "fresh")
+
+        self.assertEqual(
+            baseline.run_id,
+            "fresh",
+        )
+
+        self.assertIsNotNone(
+            baseline.run_recency,
+        )
         assert baseline.run_recency is not None
-        self.assertTrue(baseline.run_recency.is_valid)
-
-    def test_select_baseline_run_skips_run_with_empty_head_sha(self):
-        runs = [
-            _workflow_run("no-sha", head_sha=""),
-            _workflow_run("ancestor", head_sha="sha-ancestor"),
-        ]
-        artifacts = {
-            "no-sha": ["base_lib_generic.tar.zst"],
-            "ancestor": ["base_lib_generic.tar.zst"],
-        }
-        jobs = {
-            "no-sha": [_workflow_job("Build")],
-            "ancestor": [_workflow_job("Build")],
-        }
-        backend_factory, workflow_jobs_fetcher = self._factories(artifacts, jobs)
-
-        baseline = baseline_runs.select_baseline_run(
-            required_artifacts=[RequiredArtifact("base", "generic")],
-            platform="linux",
-            current_commit_sha="sha-current",
-            ordered_commit_shas=["sha-current", "sha-ancestor"],
-            workflow_runs=runs,
-            backend_factory=backend_factory,
-            workflow_jobs_fetcher=workflow_jobs_fetcher,
+        self.assertTrue(
+            baseline.run_recency.is_valid,
         )
 
-        self.assertIsNotNone(baseline)
-        assert baseline is not None
-        self.assertEqual(baseline.run_id, "ancestor")
+        self.assertIsNotNone(
+            baseline.commit_compatibility,
+        )
+        assert baseline.commit_compatibility is not None
+        self.assertEqual(
+            baseline.commit_compatibility.relationship,
+            "same",
+        )
 
 
 class RunTimingTest(unittest.TestCase):

--- a/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
+++ b/build_tools/github_actions/tests/configure_multi_arch_ci_test.py
@@ -225,6 +225,151 @@ class TestCIInputsFromEnviron(unittest.TestCase):
         )
         self.assertIsNone(inputs.base_ref)
 
+    def test_workflow_dispatch_reads_stage_reuse_diff_base(self):
+        inputs = _run_from_environ(
+            "workflow_dispatch",
+            {
+                "inputs": {},
+            },
+            extra_env={
+                "STAGE_REUSE_DIFF_BASE": "base-commit-sha",
+            },
+        )
+
+        self.assertEqual(
+            inputs.base_ref,
+            "base-commit-sha",
+        )
+
+    def test_workflow_dispatch_without_diff_base_has_no_base_ref(self):
+        inputs = _run_from_environ(
+            "workflow_dispatch",
+            {
+                "inputs": {},
+            },
+        )
+
+        self.assertIsNone(
+            inputs.base_ref,
+        )
+
+
+class TestLoadGitContext(unittest.TestCase):
+    @patch.object(
+        cm.GitContext,
+        "from_repo",
+    )
+    def test_workflow_dispatch_diff_base_builds_git_context(
+        self,
+        mock_from_repo,
+    ):
+        expected = cm.GitContext(
+            changed_files=[
+                "rocm-libraries/projects/rocBLAS/x.cpp",
+            ],
+            diff_base_ref="base-commit-sha",
+            diff_base_commit="resolved-base-sha",
+            diff_head_commit="head-commit-sha",
+        )
+        mock_from_repo.return_value = expected
+
+        inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="workflow_dispatch",
+            commit_ref="feature",
+            base_ref="base-commit-sha",
+            build_variant="release",
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "SKIP_PATH_FILTERS": "",
+            },
+            clear=False,
+        ):
+            result = cm._load_git_context(
+                inputs,
+            )
+
+        self.assertIs(
+            result,
+            expected,
+        )
+        mock_from_repo.assert_called_once_with(
+            base_ref="base-commit-sha",
+        )
+
+    @patch.object(
+        cm.GitContext,
+        "from_repo",
+    )
+    def test_workflow_dispatch_without_diff_base_uses_empty_context(
+        self,
+        mock_from_repo,
+    ):
+        inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="workflow_dispatch",
+            commit_ref="feature",
+            base_ref=None,
+            build_variant="release",
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "SKIP_PATH_FILTERS": "",
+            },
+            clear=False,
+        ):
+            result = cm._load_git_context(
+                inputs,
+            )
+
+        self.assertIsNone(
+            result.changed_files,
+        )
+        self.assertIsNone(
+            result.diff_base_commit,
+        )
+        mock_from_repo.assert_not_called()
+
+    @patch.object(
+        cm.GitContext,
+        "from_repo",
+    )
+    def test_external_repo_ignores_dispatch_diff_base(
+        self,
+        mock_from_repo,
+    ):
+        inputs = cm.CIInputs(
+            run_id="12345",
+            event_name="workflow_dispatch",
+            commit_ref="feature",
+            base_ref="base-commit-sha",
+            build_variant="release",
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "SKIP_PATH_FILTERS": "true",
+            },
+            clear=False,
+        ):
+            result = cm._load_git_context(
+                inputs,
+            )
+
+        self.assertIsNone(
+            result.changed_files,
+        )
+        self.assertIsNone(
+            result.diff_base_commit,
+        )
+        mock_from_repo.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Step 2: Check Skip CI
@@ -528,6 +673,156 @@ class TestDecideJobs(unittest.TestCase):
         )
         self.assertEqual(result.build_rocm.rebuild_stages, [])
 
+    def test_manual_prebuilt_stages_take_precedence_over_auto_reuse(self):
+        auto_stage_reuse = cm.AutoStageReuse(
+            mode=cm.StageReuseMode.REUSE_STAGE,
+            candidate_stages=("compiler-runtime",),
+            rebuild_stages=("math-libs",),
+            full_rebuild_required=False,
+            baseline_run_id="auto-run-200",
+            baseline_html_url=(
+                "https://github.com/ROCm/TheRock/actions/runs/auto-run-200"
+            ),
+            available_stages=("compiler-runtime",),
+            unavailable_stages=(),
+            applied_reuse_stages=("compiler-runtime",),
+            reasons=(),
+            report_lines=(
+                "[STAGE-REUSE] stage 'compiler-runtime' "
+                "unaffected AND available in baseline "
+                "on all platforms -> WILL be skipped",
+            ),
+            platform_available={
+                "linux": ("compiler-runtime",),
+            },
+        )
+
+        (
+            stage_decisions,
+            baseline_run_id,
+            adjusted_auto_stage_reuse,
+        ) = cm._apply_stage_reuse_precedence(
+            manual_prebuilt_stages=["math-libs"],
+            manual_baseline_run_id="manual-run-100",
+            auto_stage_reuse=auto_stage_reuse,
+        )
+
+        self.assertEqual(
+            stage_decisions,
+            {
+                "math-libs": cm.JobAction.PREBUILT,
+            },
+        )
+
+        self.assertNotIn(
+            "compiler-runtime",
+            stage_decisions,
+        )
+
+        self.assertEqual(
+            baseline_run_id,
+            "manual-run-100",
+        )
+
+        self.assertEqual(
+            adjusted_auto_stage_reuse.applied_reuse_stages,
+            (),
+        )
+
+        self.assertTrue(
+            any(
+                "manual prebuilt_stages input takes precedence" in reason
+                for reason in adjusted_auto_stage_reuse.reasons
+            )
+        )
+
+        self.assertTrue(
+            any(
+                "WOULD be reusable but was not applied" in line
+                for line in adjusted_auto_stage_reuse.report_lines
+            )
+        )
+
+    def test_auto_reuse_applies_when_manual_stages_are_not_set(self):
+        auto_stage_reuse = cm.AutoStageReuse(
+            mode=cm.StageReuseMode.REUSE_STAGE,
+            candidate_stages=("compiler-runtime",),
+            rebuild_stages=("math-libs",),
+            full_rebuild_required=False,
+            baseline_run_id="auto-run-200",
+            baseline_html_url=(
+                "https://github.com/ROCm/TheRock/actions/runs/auto-run-200"
+            ),
+            available_stages=("compiler-runtime",),
+            unavailable_stages=(),
+            applied_reuse_stages=("compiler-runtime",),
+            reasons=(),
+            report_lines=(),
+            platform_available={
+                "linux": ("compiler-runtime",),
+            },
+        )
+
+        (
+            stage_decisions,
+            baseline_run_id,
+            adjusted_auto_stage_reuse,
+        ) = cm._apply_stage_reuse_precedence(
+            manual_prebuilt_stages=[],
+            manual_baseline_run_id="",
+            auto_stage_reuse=auto_stage_reuse,
+        )
+
+        self.assertEqual(
+            stage_decisions,
+            {
+                "compiler-runtime": cm.JobAction.PREBUILT,
+            },
+        )
+
+        self.assertEqual(
+            baseline_run_id,
+            "auto-run-200",
+        )
+
+        self.assertEqual(
+            adjusted_auto_stage_reuse.applied_reuse_stages,
+            ("compiler-runtime",),
+        )
+
+    def test_auto_reuse_is_not_applied_when_disallowed(self):
+        auto_stage_reuse = cm.AutoStageReuse(
+            mode=cm.StageReuseMode.REUSE_STAGE,
+            candidate_stages=("compiler-runtime",),
+            rebuild_stages=("math-libs",),
+            full_rebuild_required=False,
+            baseline_run_id="auto-run-200",
+            baseline_html_url=None,
+            available_stages=("compiler-runtime",),
+            unavailable_stages=(),
+            applied_reuse_stages=("compiler-runtime",),
+            reasons=(),
+            report_lines=(),
+            platform_available={
+                "linux": ("compiler-runtime",),
+            },
+        )
+
+        (
+            stage_decisions,
+            baseline_run_id,
+            adjusted,
+        ) = cm._apply_stage_reuse_precedence(
+            manual_prebuilt_stages=[],
+            manual_baseline_run_id="manual-run-100",
+            auto_stage_reuse=auto_stage_reuse,
+            allow_automatic_reuse=False,
+        )
+
+        self.assertEqual(stage_decisions, {})
+        self.assertEqual(baseline_run_id, "manual-run-100")
+        self.assertEqual(adjusted.applied_reuse_stages, ())
+
     def test_reuse_scoped_to_selected_targets(self):
         """decide_jobs threads the resolved targets into automatic reuse.
         With no families selected there are no build platforms, so automatic
@@ -607,6 +902,262 @@ class TestDecideJobs(unittest.TestCase):
             targets=cm.TargetSelection(),
         )
         self.assertEqual(result.test_rocm.action, cm.JobAction.RUN)
+
+    def test_expected_baseline_sha_is_diff_base_for_diff_events(self):
+        git_context = cm.GitContext(
+            changed_files=[
+                "rocm-libraries/projects/rocBLAS/x.cpp",
+            ],
+            diff_base_commit="base-commit-sha",
+            diff_head_commit="head-commit-sha",
+        )
+
+        for event_name in (
+            "pull_request",
+            "push",
+            "workflow_dispatch",
+        ):
+            with self.subTest(event_name=event_name):
+                self.assertEqual(
+                    cm._get_expected_baseline_sha(
+                        self._inputs(
+                            event_name=event_name,
+                            base_ref="base-commit-sha",
+                        ),
+                        git_context,
+                    ),
+                    "base-commit-sha",
+                )
+
+    def test_expected_baseline_sha_is_none_without_computed_diff(self):
+        git_context = cm.GitContext(
+            changed_files=None,
+            diff_base_commit=None,
+            diff_head_commit="head-commit-sha",
+        )
+
+        for event_name in (
+            "schedule",
+            "workflow_dispatch",
+        ):
+            with self.subTest(event_name=event_name):
+                self.assertIsNone(
+                    cm._get_expected_baseline_sha(
+                        self._inputs(
+                            event_name=event_name,
+                            base_ref=None,
+                        ),
+                        git_context,
+                    )
+                )
+
+    def test_dispatch_without_explicit_base_does_not_reuse_computed_context(self):
+        git_context = cm.GitContext(
+            changed_files=[
+                "rocm-libraries/projects/rocBLAS/x.cpp",
+            ],
+            diff_base_commit="base-commit-sha",
+            diff_head_commit="head-commit-sha",
+        )
+
+        self.assertIsNone(
+            cm._get_expected_baseline_sha(
+                self._inputs(
+                    event_name="workflow_dispatch",
+                    base_ref=None,
+                ),
+                git_context,
+            )
+        )
+
+    @patch("configure_multi_arch_ci.get_all_families_for_trigger_types")
+    @patch("configure_multi_arch_ci.compute_auto_stage_reuse")
+    def test_decide_jobs_threads_exact_baseline_sha_and_artifact_families(
+        self,
+        mock_compute_auto_stage_reuse,
+        mock_get_all_families,
+    ):
+        mock_get_all_families.return_value = {
+            "linux-key": {
+                "linux": {
+                    "family": "gfx-linux-artifact",
+                },
+            },
+            "windows-key": {
+                "windows": {
+                    "family": "gfx-windows-artifact",
+                },
+            },
+        }
+
+        auto_stage_reuse = cm.AutoStageReuse(
+            mode=cm.StageReuseMode.DRY_RUN,
+            candidate_stages=(),
+            rebuild_stages=(),
+            full_rebuild_required=False,
+            baseline_run_id="",
+            baseline_html_url=None,
+            available_stages=(),
+            unavailable_stages=(),
+            applied_reuse_stages=(),
+            reasons=(),
+            report_lines=(),
+            platform_available={},
+        )
+        mock_compute_auto_stage_reuse.return_value = auto_stage_reuse
+
+        git_context = cm.GitContext(
+            changed_files=[
+                "rocm-libraries/projects/rocBLAS/x.cpp",
+            ],
+            diff_base_commit="base-commit-sha",
+            diff_head_commit="head-commit-sha",
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "GITHUB_REPOSITORY": "ROCm/TheRock",
+            },
+            clear=False,
+        ):
+            result = cm.decide_jobs(
+                self._inputs(
+                    event_name="pull_request",
+                ),
+                git_context=git_context,
+                targets=cm.TargetSelection(
+                    linux_families=["linux-key"],
+                    windows_families=["windows-key"],
+                ),
+            )
+
+        self.assertIs(
+            result.auto_stage_reuse,
+            auto_stage_reuse,
+        )
+
+        mock_compute_auto_stage_reuse.assert_called_once()
+        call_kwargs = mock_compute_auto_stage_reuse.call_args.kwargs
+
+        self.assertEqual(
+            call_kwargs["changed_files"],
+            [
+                "rocm-libraries/projects/rocBLAS/x.cpp",
+            ],
+        )
+        self.assertEqual(
+            call_kwargs["expected_baseline_sha"],
+            "base-commit-sha",
+        )
+        self.assertEqual(
+            call_kwargs["linux_amdgpu_families"],
+            ["gfx-linux-artifact"],
+        )
+        self.assertEqual(
+            call_kwargs["windows_amdgpu_families"],
+            ["gfx-windows-artifact"],
+        )
+
+    @patch("configure_multi_arch_ci.get_all_families_for_trigger_types")
+    @patch("configure_multi_arch_ci.compute_auto_stage_reuse")
+    def test_decide_jobs_disables_automatic_cross_repo_reuse(
+        self,
+        mock_compute_auto_stage_reuse,
+        mock_get_all_families,
+    ):
+        mock_get_all_families.return_value = {
+            "linux-key": {
+                "linux": {
+                    "family": "gfx-linux-artifact",
+                },
+            },
+        }
+
+        mock_compute_auto_stage_reuse.return_value = cm.AutoStageReuse(
+            mode=cm.StageReuseMode.REUSE_STAGE,
+            candidate_stages=("compiler-runtime",),
+            rebuild_stages=("math-libs",),
+            full_rebuild_required=False,
+            baseline_run_id="auto-run-200",
+            baseline_html_url=None,
+            available_stages=("compiler-runtime",),
+            unavailable_stages=(),
+            applied_reuse_stages=("compiler-runtime",),
+            reasons=(),
+            report_lines=(),
+            platform_available={
+                "linux": ("compiler-runtime",),
+            },
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "GITHUB_REPOSITORY": "ROCm/rocm-libraries",
+            },
+            clear=False,
+        ):
+            result = cm.decide_jobs(
+                self._inputs(
+                    event_name="pull_request",
+                    baseline_repository="ROCm/TheRock",
+                    baseline_run_id="manual-run-100",
+                ),
+                git_context=cm.GitContext(
+                    changed_files=[
+                        "rocm-libraries/projects/rocBLAS/x.cpp",
+                    ],
+                    diff_base_commit="base-commit-sha",
+                    diff_head_commit="head-commit-sha",
+                ),
+                targets=cm.TargetSelection(
+                    linux_families=["linux-key"],
+                ),
+            )
+
+        call_kwargs = mock_compute_auto_stage_reuse.call_args.kwargs
+
+        # Cross-repository automatic lookup must not use the triggering
+        # repository's diff-base SHA.
+        self.assertIsNone(
+            call_kwargs["expected_baseline_sha"],
+        )
+
+        # The automatically selected stage must not be applied.
+        self.assertEqual(
+            result.build_rocm.stage_decisions,
+            {},
+        )
+        self.assertNotIn(
+            "compiler-runtime",
+            result.build_rocm.prebuilt_stages,
+        )
+
+        # Preserve the explicit cross-repository inputs.
+        self.assertEqual(
+            result.build_rocm.baseline_run_id,
+            "manual-run-100",
+        )
+        self.assertEqual(
+            result.build_rocm.baseline_repository,
+            "ROCm/TheRock",
+        )
+
+        self.assertIsNotNone(
+            result.auto_stage_reuse,
+        )
+        assert result.auto_stage_reuse is not None
+        self.assertEqual(
+            result.auto_stage_reuse.applied_reuse_stages,
+            (),
+        )
+        self.assertTrue(
+            any(
+                "cross-repository reuse requires explicit inputs" in reason
+                for reason in result.auto_stage_reuse.reasons
+            )
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/build_tools/github_actions/tests/stage_reuse_decision_test.py
+++ b/build_tools/github_actions/tests/stage_reuse_decision_test.py
@@ -16,10 +16,10 @@ import configure_multi_arch_ci as cma
 import stage_reuse_decision as srd
 from stage_reuse_decision import StageReuseMode, compute_auto_stage_reuse
 from baseline_runs import (
-    BaselineRun,
-    WorkflowRunSummary,
     ArtifactAvailability,
+    BaselineRun,
     WorkflowJobHealth,
+    WorkflowRunSummary,
 )
 from github_actions_api import GitHubAPIError
 
@@ -27,6 +27,27 @@ from github_actions_api import GitHubAPIError
 class _FakeStage:
     def __init__(self, groups):
         self.artifact_groups = groups
+
+
+class _FakeArtifact:
+    def __init__(
+        self,
+        name: str,
+        artifact_type: str,
+        artifact_deps: tuple[str, ...] = (),
+        *,
+        platform: str | None = None,
+        disable_platforms: tuple[str, ...] = (),
+        disable_platforms_if_flags_not_set: dict[str, str] | None = None,
+    ):
+        self.name = name
+        self.type = artifact_type
+        self.artifact_deps = list(artifact_deps)
+        self.platform = platform
+        self.disable_platforms = list(disable_platforms)
+        self.disable_platforms_if_flags_not_set = dict(
+            disable_platforms_if_flags_not_set or {}
+        )
 
 
 class FakeTopology:
@@ -45,6 +66,17 @@ class FakeTopology:
             "blas-group": type("G", (), {"source_sets": ["libs"]})(),
         }
 
+        self.artifacts = {
+            "base": _FakeArtifact(
+                name="base",
+                artifact_type="target-neutral",
+            ),
+            "blas": _FakeArtifact(
+                name="blas",
+                artifact_type="target-specific",
+            ),
+        }
+
     def get_source_set_to_artifact_groups(self):
         return {"core": ["base-group"], "libs": ["blas-group"]}
 
@@ -58,7 +90,10 @@ class FakeTopology:
         return set()
 
     def get_artifacts_in_group(self, group_name):
-        return {"base-group": [], "blas-group": []}.get(group_name, [])
+        return {
+            "base-group": [self.artifacts["base"]],
+            "blas-group": [self.artifacts["blas"]],
+        }.get(group_name, [])
 
     def get_source_set_for_submodule(self, name, platform=None):
         mapping = {"rocm-libraries": "libs"}
@@ -171,18 +206,28 @@ class AvailabilityGateTest(unittest.TestCase):
         joined = "\n".join(result.report_lines)
         self.assertIn("no baseline run contains artifacts", joined)
 
-    def test_partial_family_availability_rebuilds(self):
-        # Needs base for a real family + generic; baseline only has the generic
-        # archive, so the real family's artifact is missing -> rebuild.
+    def test_target_neutral_stage_only_requires_generic_artifact(self):
         result = compute_auto_stage_reuse(
             changed_files=["rocm-libraries/projects/rocBLAS/x.cpp"],
             mode=StageReuseMode.DRY_RUN,
             linux_amdgpu_families=["gfx94X-dcgpu"],
             topology=FakeTopology(),
-            baseline_selector=_selector(_baseline("123", ["base_lib_generic.tar.zst"])),
+            baseline_selector=_selector(
+                _baseline(
+                    "123",
+                    ["base_lib_generic.tar.zst"],
+                )
+            ),
         )
-        self.assertIn("compiler-runtime", result.unavailable_stages)
-        self.assertEqual(result.available_stages, ())
+
+        self.assertIn(
+            "compiler-runtime",
+            result.available_stages,
+        )
+        self.assertNotIn(
+            "compiler-runtime",
+            result.unavailable_stages,
+        )
 
     def test_reuse_stage_applies_only_available_stages(self):
         result = compute_auto_stage_reuse(
@@ -236,6 +281,7 @@ class GuardrailTest(unittest.TestCase):
         result = compute_auto_stage_reuse(
             changed_files=["build_tools/foo.py"],
             mode=StageReuseMode.REUSE_STAGE,
+            linux_amdgpu_families=["generic"],
             topology=FakeTopology(),
             baseline_selector=selector,
         )
@@ -247,6 +293,7 @@ class GuardrailTest(unittest.TestCase):
         result = compute_auto_stage_reuse(
             changed_files=None,
             mode=StageReuseMode.REUSE_STAGE,
+            linux_amdgpu_families=["generic"],
             topology=FakeTopology(),
             baseline_selector=_selector(_baseline("123", ["base_lib_generic.tar.zst"])),
         )
@@ -268,100 +315,71 @@ class GuardrailTest(unittest.TestCase):
 
 
 class DefaultBaselineSelectorTest(unittest.TestCase):
-    """_default_baseline_selector must fetch real branch history and never pass
-    an empty ordered_commit_shas window while current_commit_sha is set."""
-
-    def _run_with_env(self, env, fake_history, fake_select):
-        import os
-
-        old_env = {k: os.environ.get(k) for k in env}
-        os.environ.update({k: v for k, v in env.items() if v is not None})
-        for k, v in env.items():
-            if v is None:
-                os.environ.pop(k, None)
-
-        import baseline_runs
-        import github_actions_api
-
-        orig_select = baseline_runs.select_baseline_run
-        orig_hist = getattr(github_actions_api, "gha_query_recent_branch_commits", None)
-        captured = {}
-
-        def _capturing_select(**kwargs):
-            captured.update(kwargs)
-            return fake_select
-
-        baseline_runs.select_baseline_run = _capturing_select
-        github_actions_api.gha_query_recent_branch_commits = fake_history
-        try:
-            selector = srd._default_baseline_selector(platform="linux")
-            result = selector([("base", "generic")])
-        finally:
-            baseline_runs.select_baseline_run = orig_select
-            if orig_hist is not None:
-                github_actions_api.gha_query_recent_branch_commits = orig_hist
-            for k, v in old_env.items():
-                if v is None:
-                    os.environ.pop(k, None)
-                else:
-                    os.environ[k] = v
-        return captured, result
-
-    def test_history_is_fetched_and_threaded(self):
-        def fake_history(**kwargs):
-            return ["sha-current", "sha-old", "sha-older"]
-
-        captured, _ = self._run_with_env(
-            {"STAGE_REUSE_CURRENT_SHA": "sha-current"},
-            fake_history,
-            fake_select="baseline",
+    @patch.object(
+        srd.baseline_runs,
+        "select_baseline_run",
+        return_value="baseline",
+    )
+    def test_exact_expected_sha_is_forwarded(
+        self,
+        mock_select_baseline_run,
+    ):
+        selector = srd._default_baseline_selector(
+            platform="linux",
+            expected_baseline_sha="base-commit-sha",
         )
-        # Real history passed through (NOT an empty list).
+
+        required = [
+            srd.RequiredArtifact(
+                name="base",
+                target_family="generic",
+            )
+        ]
+
+        result = selector(required)
+
+        self.assertEqual(result, "baseline")
+        mock_select_baseline_run.assert_called_once()
+
+        call_kwargs = mock_select_baseline_run.call_args.kwargs
+
         self.assertEqual(
-            captured["ordered_commit_shas"], ["sha-current", "sha-old", "sha-older"]
+            call_kwargs["expected_head_sha"],
+            "base-commit-sha",
         )
-        self.assertEqual(captured["current_commit_sha"], "sha-current")
-
-    def test_empty_history_disables_commit_rule(self):
-        def fake_history(**kwargs):
-            return []
-
-        captured, _ = self._run_with_env(
-            {"STAGE_REUSE_CURRENT_SHA": "sha-current"},
-            fake_history,
-            fake_select="baseline",
+        self.assertNotIn(
+            "current_commit_sha",
+            call_kwargs,
         )
-        # Disabled rather than enabled-with-empty-window: both None.
-        self.assertIsNone(captured["current_commit_sha"])
-        self.assertIsNone(captured["ordered_commit_shas"])
-
-    def test_history_fetch_error_disables_commit_rule(self):
-        def fake_history(**kwargs):
-            raise GitHubAPIError("api down")
-
-        captured, _ = self._run_with_env(
-            {"STAGE_REUSE_CURRENT_SHA": "sha-current"},
-            fake_history,
-            fake_select="baseline",
+        self.assertNotIn(
+            "ordered_commit_shas",
+            call_kwargs,
         )
-        self.assertIsNone(captured["current_commit_sha"])
-        self.assertIsNone(captured["ordered_commit_shas"])
 
-    def test_no_sha_means_no_history_fetch(self):
-        calls = {"n": 0}
-
-        def fake_history(**kwargs):
-            calls["n"] = 1
-            return ["x"]
-
-        captured, _ = self._run_with_env(
-            {"STAGE_REUSE_CURRENT_SHA": None},
-            fake_history,
-            fake_select="baseline",
+    @patch.object(
+        srd.baseline_runs,
+        "select_baseline_run",
+    )
+    def test_missing_expected_sha_disables_baseline_lookup(
+        self,
+        mock_select_baseline_run,
+    ):
+        selector = srd._default_baseline_selector(
+            platform="linux",
+            expected_baseline_sha=None,
         )
-        self.assertEqual(calls["n"], 0)
-        self.assertIsNone(captured["current_commit_sha"])
-        self.assertIsNone(captured["ordered_commit_shas"])
+
+        result = selector(
+            [
+                srd.RequiredArtifact(
+                    name="base",
+                    target_family="generic",
+                )
+            ]
+        )
+
+        self.assertIsNone(result)
+        mock_select_baseline_run.assert_not_called()
 
 
 class PlatformAwareAvailabilityTest(unittest.TestCase):
@@ -375,7 +393,12 @@ class PlatformAwareAvailabilityTest(unittest.TestCase):
     def _selector_factory(self, per_platform):
         """Return a factory yielding a per-platform baseline selector."""
 
-        def factory(platform):
+        def factory(
+            platform: str,
+            expected_baseline_sha: str | None,
+        ):
+            del expected_baseline_sha
+
             baseline = per_platform.get(platform)
             return lambda required: baseline
 
@@ -465,6 +488,97 @@ class PlatformAwareAvailabilityTest(unittest.TestCase):
             result.reasons,
         )
 
+    def test_expected_baseline_sha_is_forwarded_to_selector_factory(self):
+        received: list[tuple[str, str | None]] = []
+
+        def selector_factory(
+            platform: str,
+            expected_baseline_sha: str | None,
+        ):
+            received.append(
+                (
+                    platform,
+                    expected_baseline_sha,
+                )
+            )
+
+            return _selector(
+                _baseline(
+                    "123",
+                    ["base_lib_generic.tar.zst"],
+                )
+            )
+
+        result = compute_auto_stage_reuse(
+            changed_files=[
+                "rocm-libraries/projects/rocBLAS/x.cpp",
+            ],
+            mode=StageReuseMode.DRY_RUN,
+            linux_amdgpu_families=[
+                "gfx94X-dcgpu",
+            ],
+            expected_baseline_sha="base-commit-sha",
+            topology=FakeTopology(),
+            baseline_selector_factory=selector_factory,
+        )
+
+        self.assertEqual(
+            received,
+            [
+                (
+                    "linux",
+                    "base-commit-sha",
+                )
+            ],
+        )
+        self.assertEqual(
+            result.baseline_run_id,
+            "123",
+        )
+
+    def test_platform_specific_artifact_is_checked_only_on_matching_platform(self):
+        topology = FakeTopology()
+        topology.artifacts["base"].platform = "windows"
+
+        per_platform = {
+            # The Windows-only artifact must not be required on Linux.
+            "linux": _baseline(
+                "L1",
+                [],
+            ),
+            # It must still be required on Windows.
+            "windows": _baseline(
+                "L1",
+                ["base_lib_generic.tar.zst"],
+            ),
+        }
+
+        result = compute_auto_stage_reuse(
+            changed_files=[
+                "rocm-libraries/projects/rocBLAS/x.cpp",
+            ],
+            mode=StageReuseMode.REUSE_STAGE,
+            linux_amdgpu_families=["generic"],
+            windows_amdgpu_families=["generic"],
+            topology=topology,
+            baseline_selector_factory=self._selector_factory(
+                per_platform,
+            ),
+        )
+
+        self.assertEqual(
+            result.applied_reuse_stages,
+            ("compiler-runtime",),
+        )
+        self.assertEqual(
+            result.platform_available["linux"],
+            ("compiler-runtime",),
+        )
+        self.assertEqual(
+            result.platform_available["windows"],
+            ("compiler-runtime",),
+        )
+
 
 class PlanStageReuseTest(unittest.TestCase):
     """The pure planning step is independent of baseline/reporting."""
@@ -474,22 +588,158 @@ class PlanStageReuseTest(unittest.TestCase):
             changed_files=["rocm-libraries/projects/rocBLAS/x.cpp"],
             topology=FakeTopology(),
         )
-        self.assertIn("compiler-runtime", plan.candidate_stages)
-        self.assertFalse(plan.full_rebuild_required)
+        self.assertIn("compiler-runtime", plan.impact.copy_stages)
+        self.assertFalse(plan.impact.full_rebuild_required)
 
     def test_plan_none_changed_files_is_full_rebuild(self):
         plan = srd.plan_stage_reuse(changed_files=None, topology=FakeTopology())
-        self.assertTrue(plan.full_rebuild_required)
-        self.assertEqual(plan.candidate_stages, ())
+        self.assertTrue(plan.impact.full_rebuild_required)
+        self.assertEqual(plan.impact.copy_stages, ())
+
+
+class RequiredArtifactsTest(unittest.TestCase):
+    def test_target_neutral_artifact_requires_generic_only(self):
+        required = srd._required_artifacts_for_stages(
+            topology=FakeTopology(),
+            stage_names=["compiler-runtime"],
+            target_families=[
+                "gfx94X-dcgpu",
+                "generic",
+            ],
+            platform="linux",
+        )
+
+        self.assertEqual(
+            required,
+            [
+                srd.RequiredArtifact(
+                    name="base",
+                    target_family="generic",
+                )
+            ],
+        )
+
+    def test_platform_specific_artifact_is_skipped_on_other_platform(self):
+        topology = FakeTopology()
+        topology.artifacts["base"].platform = "windows"
+
+        required = srd._required_artifacts_for_stages(
+            topology=topology,
+            stage_names=["compiler-runtime"],
+            target_families=["generic"],
+            platform="linux",
+        )
+
+        self.assertEqual(required, [])
+
+    def test_disabled_artifact_is_skipped_on_platform(self):
+        topology = FakeTopology()
+        topology.artifacts["base"].disable_platforms = ["windows"]
+
+        required = srd._required_artifacts_for_stages(
+            topology=topology,
+            stage_names=["compiler-runtime"],
+            target_families=["generic"],
+            platform="windows",
+        )
+
+        self.assertEqual(required, [])
+
+    def test_conditionally_disabled_artifact_remains_required_without_flags(self):
+        topology = FakeTopology()
+        topology.artifacts["base"].disable_platforms_if_flags_not_set = {
+            "linux": "ENABLE_BASE",
+        }
+
+        required = srd._required_artifacts_for_stages(
+            topology=topology,
+            stage_names=["compiler-runtime"],
+            target_families=["generic"],
+            platform="linux",
+        )
+
+        self.assertEqual(
+            required,
+            [
+                srd.RequiredArtifact(
+                    name="base",
+                    target_family="generic",
+                )
+            ],
+        )
+
+
+class StageArtifactAvailabilityTest(unittest.TestCase):
+    def test_target_specific_stage_requires_selected_gpu_archive(self):
+        available = srd._stage_artifacts_available(
+            topology=FakeTopology(),
+            stage_name="math-libs",
+            target_families=[
+                "gfx94X-dcgpu",
+                "generic",
+            ],
+            available_filenames={
+                "blas_lib_generic.tar.zst",
+            },
+            platform="linux",
+        )
+
+        self.assertFalse(available)
+
+    def test_target_specific_artifact_requires_each_selected_gpu_family(self):
+        required = srd._required_artifacts_for_stages(
+            topology=FakeTopology(),
+            stage_names=["math-libs"],
+            target_families=[
+                "gfx94X-dcgpu",
+                "gfx120X-all",
+                "generic",
+            ],
+            platform="linux",
+        )
+
+        self.assertEqual(
+            required,
+            [
+                srd.RequiredArtifact(
+                    name="blas",
+                    target_family="gfx94X-dcgpu",
+                ),
+                srd.RequiredArtifact(
+                    name="blas",
+                    target_family="gfx120X-all",
+                ),
+            ],
+        )
 
 
 class TargetFamiliesTest(unittest.TestCase):
-    def test_always_includes_generic(self):
-        self.assertEqual(srd._target_families((), ()), ("generic",))
-
     def test_dedupes_and_appends_generic(self):
-        fams = srd._target_families(["gfx94x"], ["gfx94x", "gfx120x"])
-        self.assertEqual(fams, ("gfx94x", "gfx120x", "generic"))
+        families = srd._target_families_for_platform(
+            ["gfx94X-dcgpu", "gfx94X-dcgpu"],
+        )
+
+        self.assertEqual(
+            families,
+            ("gfx94X-dcgpu", "generic"),
+        )
+
+    def test_platform_families_are_not_combined(self):
+        linux = srd._target_families_for_platform(
+            ["gfx94X-dcgpu"],
+        )
+        windows = srd._target_families_for_platform(
+            ["gfx110X-all"],
+        )
+
+        self.assertEqual(
+            linux,
+            ("gfx94X-dcgpu", "generic"),
+        )
+        self.assertEqual(
+            windows,
+            ("gfx110X-all", "generic"),
+        )
 
 
 class BuildPlatformsTest(unittest.TestCase):
@@ -505,6 +755,73 @@ class BuildPlatformsTest(unittest.TestCase):
     def test_both_platforms(self):
         self.assertEqual(
             srd._build_platforms(["gfx94x"], ["gfx110x"]), ("linux", "windows")
+        )
+
+
+class PlatformImpactPlanningTest(unittest.TestCase):
+    def test_compute_uses_platform_agnostic_impact(self):
+        class RecordingTopology(FakeTopology):
+            def __init__(self):
+                super().__init__()
+                self.impact_platforms: list[str | None] = []
+
+            def get_source_set_for_submodule(
+                self,
+                name,
+                platform=None,
+            ):
+                self.impact_platforms.append(platform)
+                return super().get_source_set_for_submodule(
+                    name,
+                    platform,
+                )
+
+            def get_source_set_for_path(
+                self,
+                path,
+                platform=None,
+            ):
+                self.impact_platforms.append(platform)
+                return super().get_source_set_for_path(
+                    path,
+                    platform,
+                )
+
+        topology = RecordingTopology()
+
+        result = compute_auto_stage_reuse(
+            changed_files=[
+                "rocm-libraries/projects/rocBLAS/x.cpp",
+            ],
+            mode=StageReuseMode.DRY_RUN,
+            linux_amdgpu_families=[
+                "gfx94X-dcgpu",
+            ],
+            windows_amdgpu_families=[
+                "gfx110X-all",
+            ],
+            topology=topology,
+            baseline_selector=_selector(
+                _baseline(
+                    "123",
+                    ["base_lib_generic.tar.zst"],
+                )
+            ),
+        )
+
+        self.assertTrue(
+            topology.impact_platforms,
+            "Expected stage-impact analysis to query the topology",
+        )
+
+        self.assertTrue(
+            all(platform is None for platform in topology.impact_platforms),
+            topology.impact_platforms,
+        )
+
+        self.assertIn(
+            "compiler-runtime",
+            result.candidate_stages,
         )
 
 


### PR DESCRIPTION
## Summary

Issue: #3399  
Progress on: #6752

This PR adds safe automatic CI stage reuse using an exact, verified diff-base baseline.

It is the first part of the split from original #6760 and contains only the behavior-changing stage-reuse safety and execution work. Report-only test impact, external source-provenance reporting, and workflow timing telemetry are intentionally excluded.

Automatic stage reuse now requires the selected baseline workflow run to:

- Have a `head_sha` that exactly matches the resolved diff-base commit.
- Be within the configured baseline recency window.
- Have healthy required build jobs.
- Contain all required artifacts for the selected platforms and GPU families.

If any requirement cannot be verified, CI rebuilds conservatively.

## What changed

### Exact diff-base baseline validation

Stage impact is calculated over:

```text
diff_base_commit -> diff_head_commit
```

Automatic reuse only considers a baseline run when:

```text
candidate_run.head_sha == diff_base_commit
```

This ensures that reused artifacts were produced from the same commit used as the starting point for changed-file impact analysis.

The matching baseline must also:

- Be within the configured recency window.
- Have healthy build jobs.
- Contain all required artifacts for the selected platforms and GPU families.

If any requirement cannot be verified, CI rebuilds conservatively.

### Automatic stage-reuse decision flow

```text
+-----------+     +------------------+     +----------------------------+
| Diff base | --> | Calculate impact | --> | Exact, healthy baseline    |
+-----------+     +------------------+     | with required artifacts?   |
                                           +-------------+--------------+
                                                         |
                                              +----------+----------+
                                              |                     |
                                             YES                    NO
                                              |                     |
                                              v                     v
                                    +-------------------+   +------------------------+
                                    | Reuse unaffected  |   | Rebuild conservatively |
                                    | verified stages   |   +------------------------+
                                    +-------------------+
```

Older ancestors are no longer accepted because doing so could omit changes between the candidate commit and the actual diff base.

The previous branch-history and ancestry lookup has been removed, including:

- `stage_reuse_commit_history`
- `STAGE_REUSE_COMMIT_HISTORY`
- `STAGE_REUSE_CURRENT_SHA`
- Recent-commit history queries used for ancestry validation

### `workflow_dispatch` automatic reuse

A new `stage_reuse_diff_base` input allows `workflow_dispatch` runs to use automatic stage reuse safely.

The same input is used for both:

```text
changed_files = diff(stage_reuse_diff_base, HEAD)
expected_baseline_sha = resolve(stage_reuse_diff_base)
```

This prevents stage impact from being calculated against one commit while artifacts are reused from another.

Automatic dispatch reuse remains disabled when `stage_reuse_diff_base` is empty.

The checkout now fetches full history so an explicitly selected diff-base commit can be resolved even when it is older than the immediate parent.

### Platform- and family-aware artifact validation

Reusable-stage artifacts are validated independently for each selected platform.

- Target-neutral artifacts require only the `generic` archive.
- Target-specific artifacts require archives for every selected GPU artifact family.
- Linux and Windows family requirements are evaluated separately.
- Artifacts restricted to or disabled on a platform are not required for other platforms.
- Conditional platform disables remain conservatively required when resolved build flags are unavailable.

A stage is reused only when every required artifact is available for every selected platform.

### Manual and automatic reuse precedence

Explicit manual reuse inputs continue to take precedence over automatic reuse.

When `prebuilt_stages` is provided:

- Only the manually selected stages are marked prebuilt.
- The manually supplied `baseline_run_id` is preserved.
- Automatically selected reusable stages are reported but not applied.

### Cross-repository behavior

Automatic cross-repository baseline selection remains disabled.

External repositories must continue to provide explicit manual inputs such as:

- `baseline_repository`
- `baseline_run_id`
- `prebuilt_stages`

The explicit cross-repository configuration is preserved without combining it with automatic stage-reuse decisions from the triggering repository.

### Conservative fallback behavior

Automatic reuse is disabled and CI rebuilds when:

- No changed-file range is available.
- The exact diff-base SHA is unavailable.
- No baseline run exactly matches the diff base.
- The matching run is stale or unhealthy.
- Required artifacts are missing.
- Linux and Windows cannot use a consistent verified baseline.
- Automatic cross-repository reuse would otherwise be required.

## Stage-reuse summary

The stage-reuse step summary now reports:

- Whether the conservative full-CI fallback was triggered.
- The effective build scope.
- Stages that must be rebuilt.
- Unaffected reuse candidates.
- The baseline run checked.
- Artifact availability per platform.
- Stages actually marked for reuse.
- Reasons for conservative fallback or non-application.

## Tests

Regression coverage includes:

- Exact baseline SHA acceptance.
- Rejection of non-matching and missing SHAs.
- Stale and unhealthy baseline rejection.
- Missing-artifact fallback.
- Target-neutral and target-specific artifact requirements.
- Platform-specific and platform-disabled artifacts.
- Independent Linux and Windows family validation.
- Manual reuse precedence.
- Automatic reuse application.
- Automatic cross-repository reuse suppression.
- `workflow_dispatch` diff-base parsing.
- Dispatches without an explicit diff base.
- Propagation of the resolved diff-base SHA into baseline selection.

Unit tests are passed.

TODO PRs
PR 2 — CI impact reporting: Report-only stage-to-test impact, test inventory, CI summaries, and external source/ref reporting. 
PR 3 — Workflow timing telemetry: Actions API timing collection, runner/job classification, and Markdown/JSON timing artifacts.