### PR TITLE
fix(wsl-rocdxg): add missing env vars to Upload stage logs WSLENV

### DIFF
--- a/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+++ b/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
@@ -319,7 +319,7 @@ jobs:
         if: ${{ always() && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
         shell: wsl-bash {0}
         env:
-          WSLENV: THEROCK_HOST_WORKSPACE/p:AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN:AWS_DEFAULT_REGION:AWS_REGION
+          WSLENV: THEROCK_HOST_WORKSPACE/p:GITHUB_REPOSITORY:GITHUB_EVENT_NAME:GITHUB_EVENT_PATH/p:RELEASE_TYPE:AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN:AWS_DEFAULT_REGION:AWS_REGION
         run: |
           wsl_venv_dir="${HOME}/therock-wsl-rocdxg/.venv"
           wsl_build_dir="${HOME}/therock-wsl-rocdxg/build"


### PR DESCRIPTION
## Motivation

The "Upload stage logs" step in `multi_arch_build_wsl_rocdxg_artifacts.yml` fails with S3 AccessDenied on ci-typed runs (e.g. nightly release builds). The build itself succeeds; only log upload is broken.

PR https://github.com/ROCm/TheRock/pull/6658 refactored the wsl-rocdxg workflow to run builds in a WSL-native directory for performance. In doing so, it added a  new WSLENV to the "Upload stage logs" step — but omitted RELEASE_TYPE from it. The "Push stage artifacts" step immediately above has the correct full WSLENV including RELEASE_TYPE.

 Without RELEASE_TYPE propagated into WSL, post_stage_upload.py → s3_buckets.py resolves the wrong bucket role (therock-nightly) which lacks s3:PutObject on the ci-prefixed path, causing all 4 log files to fail upload after 3 retries. This only manifests on release_type: ci runs. Prior nightly runs (release_type: nightly) worked because the nightly role matched the path.

Failing run: https://github.com/ROCm/rockrel/actions/runs/29879687428/job/88800898315
Last passing run: https://github.com/ROCm/rockrel/actions/runs/29789834120/job/88562095214

GitHub issue: https://github.com/ROCm/TheRock/issues/6763

## Fix

  Fix

  Add the missing env vars to WSLENV in the "Upload stage logs" step to match "Push stage artifacts":
```diff
-   WSLENV: THEROCK_HOST_WORKSPACE/p:AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN:AWS_DEFAULT_REGION:AWS_REGION
+  WSLENV: THEROCK_HOST_WORKSPACE/p:GITHUB_REPOSITORY:GITHUB_EVENT_NAME:GITHUB_EVENT_PATH/p:RELEASE_TYPE:AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN:AWS_DEFAULT_REGION:AWS_REGION
```

## Test Result

Waiting for CI results.
mulit_arch_realese dev run: https://github.com/ROCm/rockrel/actions/runs/29901093180 --> passed

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
