### PR TITLE
fix: Skip empty packages in DEB and RPM packaging

### DIFF
--- a/build_tools/packaging/linux/deb_package.py
+++ b/build_tools/packaging/linux/deb_package.py
@@ -104,6 +104,9 @@ def create_versioned_deb_package(pkg_name, config: PackageConfig):
     )
     sourcedir_list.extend(dir_list)
 
+    # Filter out non-existing directories
+    sourcedir_list = [path for path in sourcedir_list if path.is_dir()]
+
     print(f"sourcedir_list:\n  {sourcedir_list}")
     # GFX_META is a versioned meta package (empty content, just dependencies)
     is_gfx_meta = build_config.enable_kpack and build_config.gfx_arch == GFX_META

--- a/build_tools/packaging/linux/deb_package.py
+++ b/build_tools/packaging/linux/deb_package.py
@@ -107,7 +107,10 @@ def create_versioned_deb_package(pkg_name, config: PackageConfig):
     )
     sourcedir_list.extend(dir_list)
 
+    # Filter out non-existing directories
+    sourcedir_list = [path for path in sourcedir_list if path.is_dir()]
     logger.debug(f"sourcedir_list: {sourcedir_list}")
+
     # GFX_META is a versioned meta package (empty content, just dependencies)
     is_gfx_meta = build_config.enable_kpack and build_config.gfx_arch == GFX_META
     if not sourcedir_list and not is_meta and not is_gfx_meta:

--- a/build_tools/packaging/linux/deb_package.py
+++ b/build_tools/packaging/linux/deb_package.py
@@ -115,7 +115,7 @@ def create_versioned_deb_package(pkg_name, config: PackageConfig):
     is_gfx_meta = build_config.enable_kpack and build_config.gfx_arch == GFX_META
     if not sourcedir_list and not is_meta and not is_gfx_meta:
         if build_config.enable_kpack:
-            logger.error(
+            logger.info(
                 f"{pkg_name}: Empty sourcedir_list and not a meta package, skipping"
             )
             return []

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -602,6 +602,7 @@ def process_main_dependencies_kpack(
     """
     is_meta = is_meta_package(pkg_info)
     pkg_name = pkg_info.get("Package")
+    host_fallback_deps = []  # Track deps that need host fallback
 
     if is_meta:
         if config.gfx_arch == GFX_META:
@@ -612,8 +613,7 @@ def process_main_dependencies_kpack(
         else:
             # Arch-specific metapackage: depend on actual runtime packages
             dep_list = pkg_info.get(field_key, [])
-            # Filter deps without artifacts
-            dep_list = filter_dependencies_by_artifacts(
+            dep_list, host_fallback_deps = filter_dependencies_by_artifacts(
                 dep_list, config.artifacts_dir, config.gfx_arch
             )
     elif config.gfx_arch == GFX_META:
@@ -632,16 +632,16 @@ def process_main_dependencies_kpack(
                 config.artifacts_dir,
             )
         ]
-        # Filter deps without artifacts
-        dep_list = filter_dependencies_by_artifacts(
+        # No host fallback needed for host packages
+        dep_list, _ = filter_dependencies_by_artifacts(
             dep_list, config.artifacts_dir, config.gfx_arch
         )
     elif not is_gfxarch_package(pkg_info, config.enable_kpack, config.artifacts_dir):
         # Non-gfxarch versioned package: use all dependencies directly
         # These packages don't have host/device split, so include everything
         dep_list = pkg_info.get(field_key, [])
-        # Filter deps without artifacts
-        dep_list = filter_dependencies_by_artifacts(
+        # No host fallback for non-gfxarch packages
+        dep_list, _ = filter_dependencies_by_artifacts(
             dep_list, config.artifacts_dir, config.gfx_arch
         )
     else:
@@ -656,15 +656,27 @@ def process_main_dependencies_kpack(
                 config.artifacts_dir,
             )
         ]
-        # Filter deps without artifacts
-        gfxarch_deps = filter_dependencies_by_artifacts(
+        gfxarch_deps, host_fallback_deps = filter_dependencies_by_artifacts(
             gfxarch_deps, config.artifacts_dir, config.gfx_arch
         )
         dep_list = [pkg_name] + gfxarch_deps
 
-    if not dep_list:
+    # Resolve dependencies at the end
+    if not dep_list and not host_fallback_deps:
         return ""
-    return resolve_versioned_dependencies(dep_list, config, is_meta)
+
+    deps = resolve_versioned_dependencies(dep_list, config, is_meta)
+
+    # Add host fallback deps if any
+    if host_fallback_deps:
+        host_config = replace(config, gfx_arch=GFX_HOST)
+        host_deps = resolve_versioned_dependencies(
+            host_fallback_deps, host_config, is_meta
+        )
+        if host_deps:
+            deps = f"{deps}, {host_deps}" if deps else host_deps
+
+    return deps
 
 
 def process_main_dependencies_single_arch(
@@ -1067,6 +1079,10 @@ def has_artifact_for_arch(pkg_name, artifacts_dir, gfx_arch):
         else:
             artifact_suffix = gfx_arch
 
+        # GFX_HOST uses "generic" artifacts
+        if gfx_arch == GFX_HOST:
+            artifact_suffix = "generic"
+
         # When checking for a specific gfx architecture (not host/meta),
         # skip generic-only artifacts - they do not contribute to gfx-specific packages
         if gfx_arch not in (GFX_HOST, GFX_META) and artifact_suffix == "generic":
@@ -1096,8 +1112,11 @@ def has_artifact_for_arch(pkg_name, artifacts_dir, gfx_arch):
                                 and (artifact_subdir.lower() + "/") in line.lower()
                             )
                             if match_found and line.strip():
-                                # Found at least one required subdirectory in the manifest
-                                return True
+                                # Verify the directory exists and has files
+                                # (manifest may list dirs that weren't built or are empty)
+                                subdir_path = source_dir / line.strip().rstrip("/")
+                                if subdir_path.is_dir() and any(subdir_path.iterdir()):
+                                    return True
                 except OSError:
                     continue
 
@@ -1151,20 +1170,25 @@ def filter_archs_with_artifacts(
 
 def filter_dependencies_by_artifacts(
     dep_list: list, artifacts_dir: Path, gfx_arch: str
-) -> list:
-    """Filter dependency list to exclude packages without artifacts.
+) -> tuple[list, list]:
+    """Filter dependency list based on artifact availability.
 
-    Removes dependencies that do not have artifacts available for the specified
-    architecture. This prevents installation failures due to missing packages.
+    For each dependency:
+    - If gfx-specific artifacts exist, keep in filtered list
+    - If no gfx artifacts but host artifacts exist, add to host fallback list
+    - If no artifacts at all, exclude the dependency
 
     Parameters:
     dep_list: List of dependency package names
     artifacts_dir: Directory where artifacts are stored
     gfx_arch: Target architecture to check
 
-    Returns: Filtered dependency list
+    Returns: Tuple of (filtered_deps, host_fallback_deps) where:
+             - filtered_deps: dependencies with artifacts for target arch
+             - host_fallback_deps: dependencies to use host version instead
     """
     filtered = []
+    host_fallback = []
     for dep in dep_list:
         dep_info = get_package_info(dep, raise_if_missing=False)
         if dep_info is None:
@@ -1172,17 +1196,24 @@ def filter_dependencies_by_artifacts(
             filtered.append(dep)
             continue
 
-        # Non-gfxarch packages are always available
+        # Non-gfxarch packages: missing artifacts should fail the build,
+        # so we don't filter them out here
         if not is_gfxarch_package(
             dep_info, enable_kpack=True, artifacts_dir=artifacts_dir
         ):
             filtered.append(dep)
             continue
 
-        # Check if gfxarch package has artifacts
+        # Check if gfxarch package has artifacts for target arch
         if has_artifact_for_arch(dep, artifacts_dir, gfx_arch):
             filtered.append(dep)
+        elif gfx_arch != GFX_HOST and has_artifact_for_arch(
+            dep, artifacts_dir, GFX_HOST
+        ):
+            # Gfx-specific build missing artifacts, fall back to host version
+            print(f"INFO: {dep} has no {gfx_arch} artifacts, using host fallback")
+            host_fallback.append(dep)
         else:
-            print(f"WORKAROUND: Excluding {dep} (no artifacts for {gfx_arch})")
+            print(f"WORKAROUND: Excluding {dep} (no artifacts for {gfx_arch} or host)")
 
-    return filtered
+    return filtered, host_fallback

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -629,7 +629,9 @@ def process_main_dependencies_kpack(
                 config.artifacts_dir,
             )
         ]
-        # No host fallback needed for host packages
+        # Host fallback is discarded (_) because we ARE the host package.
+        # There's nothing to fall back to - if a dependency has no host artifacts,
+        # it's a build configuration error that should fail, not silently degrade.
         dep_list, _ = filter_dependencies_by_artifacts(
             dep_list, config.artifacts_dir, config.gfx_arch
         )
@@ -637,7 +639,13 @@ def process_main_dependencies_kpack(
         # Non-gfxarch versioned package: use all dependencies directly
         # These packages don't have host/device split, so include everything
         dep_list = pkg_info.get(field_key, [])
-        # No host fallback for non-gfxarch packages
+        # Host fallback is discarded (_) because non-gfxarch packages are already
+        # architecture-independent. Their dependencies should either:
+        # 1. Be non-gfxarch themselves (no fallback needed), or
+        # 2. Be gfxarch packages resolved to their host variant (gfx_arch="" maps to generic)
+        # If a dependency has no artifacts at all, filter_dependencies_by_artifacts
+        # will exclude it and log a warning - this is the expected behavior for
+        # packages that weren't built in this configuration.
         dep_list, _ = filter_dependencies_by_artifacts(
             dep_list, config.artifacts_dir, config.gfx_arch
         )

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -1217,6 +1217,8 @@ def filter_dependencies_by_artifacts(
             print(f"INFO: {dep} has no {gfx_arch} artifacts, using host fallback")
             host_fallback.append(dep)
         else:
-            logger.warning(f"WORKAROUND: Excluding {dep} (no artifacts for {gfx_arch} or host)")
+            logger.warning(
+                f"WORKAROUND: Excluding {dep} (no artifacts for {gfx_arch} or host)"
+            )
 
     return filtered, host_fallback

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -599,6 +599,7 @@ def process_main_dependencies_kpack(
     """
     is_meta = is_meta_package(pkg_info)
     pkg_name = pkg_info.get("Package")
+    host_fallback_deps = []  # Track deps that need host fallback
 
     if is_meta:
         if config.gfx_arch == GFX_META:
@@ -609,8 +610,7 @@ def process_main_dependencies_kpack(
         else:
             # Arch-specific metapackage: depend on actual runtime packages
             dep_list = pkg_info.get(field_key, [])
-            # Filter deps without artifacts
-            dep_list = filter_dependencies_by_artifacts(
+            dep_list, host_fallback_deps = filter_dependencies_by_artifacts(
                 dep_list, config.artifacts_dir, config.gfx_arch
             )
     elif config.gfx_arch == GFX_META:
@@ -629,16 +629,16 @@ def process_main_dependencies_kpack(
                 config.artifacts_dir,
             )
         ]
-        # Filter deps without artifacts
-        dep_list = filter_dependencies_by_artifacts(
+        # No host fallback needed for host packages
+        dep_list, _ = filter_dependencies_by_artifacts(
             dep_list, config.artifacts_dir, config.gfx_arch
         )
     elif not is_gfxarch_package(pkg_info, config.enable_kpack, config.artifacts_dir):
         # Non-gfxarch versioned package: use all dependencies directly
         # These packages don't have host/device split, so include everything
         dep_list = pkg_info.get(field_key, [])
-        # Filter deps without artifacts
-        dep_list = filter_dependencies_by_artifacts(
+        # No host fallback for non-gfxarch packages
+        dep_list, _ = filter_dependencies_by_artifacts(
             dep_list, config.artifacts_dir, config.gfx_arch
         )
     else:
@@ -653,15 +653,27 @@ def process_main_dependencies_kpack(
                 config.artifacts_dir,
             )
         ]
-        # Filter deps without artifacts
-        gfxarch_deps = filter_dependencies_by_artifacts(
+        gfxarch_deps, host_fallback_deps = filter_dependencies_by_artifacts(
             gfxarch_deps, config.artifacts_dir, config.gfx_arch
         )
         dep_list = [pkg_name] + gfxarch_deps
 
-    if not dep_list:
+    # Resolve dependencies at the end
+    if not dep_list and not host_fallback_deps:
         return ""
-    return resolve_versioned_dependencies(dep_list, config, is_meta)
+
+    deps = resolve_versioned_dependencies(dep_list, config, is_meta)
+
+    # Add host fallback deps if any
+    if host_fallback_deps:
+        host_config = replace(config, gfx_arch=GFX_HOST)
+        host_deps = resolve_versioned_dependencies(
+            host_fallback_deps, host_config, is_meta
+        )
+        if host_deps:
+            deps = f"{deps}, {host_deps}" if deps else host_deps
+
+    return deps
 
 
 def process_main_dependencies_single_arch(
@@ -1068,6 +1080,10 @@ def has_artifact_for_arch(pkg_name, artifacts_dir, gfx_arch):
         else:
             artifact_suffix = gfx_arch
 
+        # GFX_HOST uses "generic" artifacts
+        if gfx_arch == GFX_HOST:
+            artifact_suffix = "generic"
+
         # When checking for a specific gfx architecture (not host/meta),
         # skip generic-only artifacts - they do not contribute to gfx-specific packages
         if gfx_arch not in (GFX_HOST, GFX_META) and artifact_suffix == "generic":
@@ -1097,8 +1113,11 @@ def has_artifact_for_arch(pkg_name, artifacts_dir, gfx_arch):
                                 and (artifact_subdir.lower() + "/") in line.lower()
                             )
                             if match_found and line.strip():
-                                # Found at least one required subdirectory in the manifest
-                                return True
+                                # Verify the directory exists and has files
+                                # (manifest may list dirs that weren't built or are empty)
+                                subdir_path = source_dir / line.strip().rstrip("/")
+                                if subdir_path.is_dir() and any(subdir_path.iterdir()):
+                                    return True
                 except OSError:
                     continue
 
@@ -1154,20 +1173,25 @@ def filter_archs_with_artifacts(
 
 def filter_dependencies_by_artifacts(
     dep_list: list, artifacts_dir: Path, gfx_arch: str
-) -> list:
-    """Filter dependency list to exclude packages without artifacts.
+) -> tuple[list, list]:
+    """Filter dependency list based on artifact availability.
 
-    Removes dependencies that do not have artifacts available for the specified
-    architecture. This prevents installation failures due to missing packages.
+    For each dependency:
+    - If gfx-specific artifacts exist, keep in filtered list
+    - If no gfx artifacts but host artifacts exist, add to host fallback list
+    - If no artifacts at all, exclude the dependency
 
     Parameters:
     dep_list: List of dependency package names
     artifacts_dir: Directory where artifacts are stored
     gfx_arch: Target architecture to check
 
-    Returns: Filtered dependency list
+    Returns: Tuple of (filtered_deps, host_fallback_deps) where:
+             - filtered_deps: dependencies with artifacts for target arch
+             - host_fallback_deps: dependencies to use host version instead
     """
     filtered = []
+    host_fallback = []
     for dep in dep_list:
         dep_info = get_package_info(dep, raise_if_missing=False)
         if dep_info is None:
@@ -1175,17 +1199,24 @@ def filter_dependencies_by_artifacts(
             filtered.append(dep)
             continue
 
-        # Non-gfxarch packages are always available
+        # Non-gfxarch packages: missing artifacts should fail the build,
+        # so we don't filter them out here
         if not is_gfxarch_package(
             dep_info, enable_kpack=True, artifacts_dir=artifacts_dir
         ):
             filtered.append(dep)
             continue
 
-        # Check if gfxarch package has artifacts
+        # Check if gfxarch package has artifacts for target arch
         if has_artifact_for_arch(dep, artifacts_dir, gfx_arch):
             filtered.append(dep)
+        elif gfx_arch != GFX_HOST and has_artifact_for_arch(
+            dep, artifacts_dir, GFX_HOST
+        ):
+            # Gfx-specific build missing artifacts, fall back to host version
+            print(f"INFO: {dep} has no {gfx_arch} artifacts, using host fallback")
+            host_fallback.append(dep)
         else:
-            logger.warning(f"WORKAROUND: Excluding {dep} (no artifacts for {gfx_arch})")
+            logger.warning(f"WORKAROUND: Excluding {dep} (no artifacts for {gfx_arch} or host)")
 
-    return filtered
+    return filtered, host_fallback

--- a/build_tools/packaging/linux/packaging_utils.py
+++ b/build_tools/packaging/linux/packaging_utils.py
@@ -1214,7 +1214,7 @@ def filter_dependencies_by_artifacts(
             dep, artifacts_dir, GFX_HOST
         ):
             # Gfx-specific build missing artifacts, fall back to host version
-            print(f"INFO: {dep} has no {gfx_arch} artifacts, using host fallback")
+            logger.info(f"{dep} has no {gfx_arch} artifacts, using host fallback")
             host_fallback.append(dep)
         else:
             logger.warning(

--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -72,7 +72,8 @@ def create_versioned_rpm_package(pkg_name, config: PackageConfig):
     updated_pkg_name = update_package_name(pkg_name, build_config)
     package_dir = Path(build_config.dest_dir) / build_config.pkg_type / updated_pkg_name
     specfile = package_dir / "specfile"
-    generate_spec_file(pkg_name, specfile, build_config)
+    if not generate_spec_file(pkg_name, specfile, build_config):
+        return []
     package_with_rpmbuild(specfile)
 
     # Move packages to destination
@@ -88,7 +89,7 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
     specfile: Path where the generated spec file should be saved
     config: Configuration object containing package metadata
 
-    Returns: None
+    Returns: True if spec file was generated, False if package should be skipped
     """
     print_function_name()
     os.makedirs(os.path.dirname(specfile), exist_ok=True)
@@ -121,17 +122,18 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
         sourcedir_list.extend(dir_list)
 
         # Filter out non-existing directories
-        sourcedir_list = [path for path in sourcedir_list if os.path.isdir(path)]
+        sourcedir_list = [path for path in sourcedir_list if path.is_dir()]
 
         # GFX_META is a versioned meta package (empty content, just dependencies)
         is_gfx_meta = config.enable_kpack and config.gfx_arch == GFX_META
 
-        # Warn if we have no artifacts for non-meta packages
+        # Skip if we have no artifacts for non-meta packages
         if not sourcedir_list and not is_meta and not is_gfx_meta:
             if config.enable_kpack:
                 print(
-                    f"WARNING: {pkg_name}: Empty sourcedir_list and not a meta package, creating empty RPM"
+                    f"WARNING: {pkg_name}: Empty sourcedir_list and not a meta package, skipping"
                 )
+                return False
             else:
                 sys.exit(
                     f"{pkg_name}: Empty sourcedir_list and not a meta package, exiting"
@@ -188,6 +190,8 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
 
     with open(specfile, "w", encoding="utf-8") as f:
         f.write(template.render(context))
+
+    return True
 
 
 def generate_rpm_postscripts(pkg_info, config: PackageConfig):

--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -133,7 +133,7 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
         # Skip if we have no artifacts for non-meta packages
         if not sourcedir_list and not is_meta and not is_gfx_meta:
             if config.enable_kpack:
-                logger.warning(
+                logger.error(
                     f"{pkg_name}: Empty sourcedir_list and not a meta package, skipping"
                 )
                 return False

--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -75,7 +75,8 @@ def create_versioned_rpm_package(pkg_name, config: PackageConfig):
     updated_pkg_name = update_package_name(pkg_name, build_config)
     package_dir = Path(build_config.dest_dir) / build_config.pkg_type / updated_pkg_name
     specfile = package_dir / "specfile"
-    generate_spec_file(pkg_name, specfile, build_config)
+    if not generate_spec_file(pkg_name, specfile, build_config):
+        return []
     package_with_rpmbuild(specfile)
 
     # Move packages to destination
@@ -91,7 +92,7 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
     specfile: Path where the generated spec file should be saved
     config: Configuration object containing package metadata
 
-    Returns: None
+    Returns: True if spec file was generated, False if package should be skipped
     """
     logger.debug("generate_spec_file")
     os.makedirs(os.path.dirname(specfile), exist_ok=True)
@@ -124,17 +125,18 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
         sourcedir_list.extend(dir_list)
 
         # Filter out non-existing directories
-        sourcedir_list = [path for path in sourcedir_list if os.path.isdir(path)]
+        sourcedir_list = [path for path in sourcedir_list if path.is_dir()]
 
         # GFX_META is a versioned meta package (empty content, just dependencies)
         is_gfx_meta = config.enable_kpack and config.gfx_arch == GFX_META
 
-        # Warn if we have no artifacts for non-meta packages
+        # Skip if we have no artifacts for non-meta packages
         if not sourcedir_list and not is_meta and not is_gfx_meta:
             if config.enable_kpack:
                 logger.warning(
-                    f"{pkg_name}: Empty sourcedir_list and not a meta package, creating empty RPM"
+                    f"{pkg_name}: Empty sourcedir_list and not a meta package, skipping"
                 )
+                return False
             else:
                 sys.exit(
                     f"{pkg_name}: Empty sourcedir_list and not a meta package, exiting"
@@ -188,6 +190,8 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
 
     with open(specfile, "w", encoding="utf-8") as f:
         f.write(template.render(context))
+
+    return True
 
 
 def generate_rpm_postscripts(pkg_info, config: PackageConfig):

--- a/build_tools/packaging/linux/rpm_package.py
+++ b/build_tools/packaging/linux/rpm_package.py
@@ -22,7 +22,7 @@ logger = TheRockLogger(__name__)
 SCRIPT_DIR = Path(__file__).resolve().parent
 
 
-def create_nonversioned_rpm_package(pkg_name, config: PackageConfig):
+def create_nonversioned_rpm_package(pkg_name, config: PackageConfig) -> list[str]:
     """Create a non-versioned RPM meta package (.rpm).
 
     Builds a minimal RPM binary package whose payload is empty and whose primary
@@ -33,7 +33,7 @@ def create_nonversioned_rpm_package(pkg_name, config: PackageConfig):
     config: Configuration object containing package metadata
 
     Returns:
-    output_list: List of packages created
+    list[str]: List of created package filenames, empty if package was skipped
     """
     logger.debug("create_nonversioned_rpm_package")
     # Create immutable config copy with versioned_pkg=False
@@ -43,7 +43,8 @@ def create_nonversioned_rpm_package(pkg_name, config: PackageConfig):
     updated_pkg_name = update_package_name(pkg_name, build_config)
     package_dir = Path(build_config.dest_dir) / build_config.pkg_type / updated_pkg_name
     specfile = package_dir / "specfile"
-    generate_spec_file(pkg_name, specfile, build_config)
+    if not generate_spec_file(pkg_name, specfile, build_config):
+        return []
     package_with_rpmbuild(specfile)
 
     # Move packages to destination
@@ -51,7 +52,7 @@ def create_nonversioned_rpm_package(pkg_name, config: PackageConfig):
     return output_list
 
 
-def create_versioned_rpm_package(pkg_name, config: PackageConfig):
+def create_versioned_rpm_package(pkg_name, config: PackageConfig) -> list[str]:
     """Create a versioned RPM package (.rpm).
 
     This function automates the process of building a RPM package by:
@@ -64,7 +65,8 @@ def create_versioned_rpm_package(pkg_name, config: PackageConfig):
     config: Configuration object containing package metadata
 
     Returns:
-    output_list: List of packages created
+    list[str]: List of created package filenames, empty if package was skipped
+               (e.g., when no artifacts exist for the target architecture)
     """
     logger.debug("create_versioned_rpm_package")
     # Explicitly ensure versioned_pkg=True
@@ -133,7 +135,7 @@ def generate_spec_file(pkg_name, specfile, config: PackageConfig):
         # Skip if we have no artifacts for non-meta packages
         if not sourcedir_list and not is_meta and not is_gfx_meta:
             if config.enable_kpack:
-                logger.error(
+                logger.info(
                     f"{pkg_name}: Empty sourcedir_list and not a meta package, skipping"
                 )
                 return False

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -276,7 +276,11 @@ def _stage_package_artifacts(
                 payload.parent.mkdir(parents=True, exist_ok=True)
                 payload.write_bytes(STAGING_PAYLOAD_BYTES)
                 manifest = artifact_dir / "artifact_manifest.txt"
-                # Append to manifest (multiple subdirs write to same artifact dir)
+                # Append to manifest: multiple subdirs may write to the same artifact dir
+                # within a single _stage_package_artifacts() call. This is safe because:
+                # 1. Each test gets an isolated temp directory (BuildPackageTestCase.setUp)
+                # 2. Tests run sequentially (standard unittest behavior)
+                # 3. Appends within one call are single-threaded
                 with manifest.open("a", encoding="utf-8") as f:
                     f.write(f"{dir_path}\n")
                 if not manifest.exists():
@@ -780,6 +784,125 @@ class EmptyPackageSkippingTest(BuildPackageTestCase):
                     getattr(module, create_func)(pkg_name=PKG_FFT, config=meta_cfg)
 
                 mock_build.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Host fallback mechanism (#6766)
+#
+# When a gfx-specific dependency has no artifacts for the target architecture
+# but does have host (generic) artifacts, the package should fall back to
+# depending on the host version instead of failing or omitting the dependency.
+#
+# Test scenario:
+#   - Building amdrocm-blas for gfx1100
+#   - amdrocm-blas depends on amdrocm-solver (both are gfxarch packages)
+#   - amdrocm-solver has artifacts for gfx942 but NOT for gfx1100
+#   - amdrocm-solver DOES have host (generic) artifacts
+#
+#   amdrocm-blas (gfx1100)
+#       └── depends on amdrocm-solver
+#                         ├── gfx1100 artifacts? ❌ NO
+#                         └── host artifacts?    ✅ YES → use host fallback
+#
+# Expected: Generated package should depend on amdrocm-solver-host7.1
+#           (not amdrocm-solver7.1-gfx1100 which doesn't exist)
+# ---------------------------------------------------------------------------
+PKG_BLAS = "amdrocm-blas"
+PKG_SOLVER = "amdrocm-solver"
+
+
+class HostFallbackTest(BuildPackageTestCase):
+    """Integration tests for host fallback when gfx-specific artifacts are missing."""
+
+    @patch.object(deb_package, "move_packages_to_destination", return_value=[])
+    @patch.object(deb_package, "package_with_dpkg_build")
+    def test_deb_device_package_uses_host_fallback_dependency(
+        self, _mock_dpkg: object, _mock_move: object
+    ) -> None:
+        """DEB device package falls back to host dependency when gfx artifacts missing."""
+        cfg = _kpack_config(self.temp_dir)
+
+        # Stage BLAS for gfx1100 (the package we're building)
+        _stage_package_artifacts(
+            pkg_name=PKG_BLAS,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=TEST_GFX_TARGET,
+            enable_kpack=True,
+        )
+        # Stage SOLVER for gfx942 only (NOT gfx1100) - makes it a gfxarch package
+        _stage_package_artifacts(
+            pkg_name=PKG_SOLVER,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=TEST_GFX_TARGET_ALT,
+            enable_kpack=True,
+        )
+        # Stage SOLVER host artifacts - this is what we'll fall back to
+        _stage_package_artifacts(
+            pkg_name=PKG_SOLVER,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=GFX_HOST,
+            enable_kpack=True,
+        )
+        # Stage RUNTIME (non-gfxarch dependency needed by BLAS)
+        _stage_package_artifacts(
+            pkg_name=PKG_RUNTIME,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=GFX_HOST,
+            enable_kpack=True,
+        )
+
+        device_cfg = replace(cfg, gfx_arch=TEST_GFX_TARGET)
+        deb_package.create_versioned_deb_package(pkg_name=PKG_BLAS, config=device_cfg)
+
+        # Verify: BLAS depends on SOLVER-host (fallback), not SOLVER-gfx1100
+        control = _read_control_file(pkg_name=PKG_BLAS, config=device_cfg)
+        depends = _control_field(control, "Depends")
+        self.assertIn("amdrocm-solver-host", depends)
+
+    @patch.object(rpm_package, "move_packages_to_destination", return_value=[])
+    @patch.object(rpm_package, "package_with_rpmbuild")
+    def test_rpm_device_package_uses_host_fallback_dependency(
+        self, _mock_rpmbuild: object, _mock_move: object
+    ) -> None:
+        """RPM device package falls back to host dependency when gfx artifacts missing."""
+        cfg = _kpack_config(self.temp_dir, pkg_type=TEST_PKG_TYPE_RPM)
+
+        # Stage BLAS for gfx1100 (the package we're building)
+        _stage_package_artifacts(
+            pkg_name=PKG_BLAS,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=TEST_GFX_TARGET,
+            enable_kpack=True,
+        )
+        # Stage SOLVER for gfx942 only (NOT gfx1100) - makes it a gfxarch package
+        _stage_package_artifacts(
+            pkg_name=PKG_SOLVER,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=TEST_GFX_TARGET_ALT,
+            enable_kpack=True,
+        )
+        # Stage SOLVER host artifacts - this is what we'll fall back to
+        _stage_package_artifacts(
+            pkg_name=PKG_SOLVER,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=GFX_HOST,
+            enable_kpack=True,
+        )
+        # Stage RUNTIME (non-gfxarch dependency needed by BLAS)
+        _stage_package_artifacts(
+            pkg_name=PKG_RUNTIME,
+            artifacts_dir=cfg.artifacts_dir,
+            gfx_arch=GFX_HOST,
+            enable_kpack=True,
+        )
+
+        device_cfg = replace(cfg, gfx_arch=TEST_GFX_TARGET)
+        rpm_package.create_versioned_rpm_package(pkg_name=PKG_BLAS, config=device_cfg)
+
+        # Verify: BLAS requires SOLVER-host (fallback), not SOLVER-gfx1100
+        spec = _read_spec_file(pkg_name=PKG_BLAS, config=device_cfg)
+        requires = _spec_field(spec, "Requires")
+        self.assertIn("amdrocm-solver-host", requires)
 
 
 if __name__ == "__main__":

--- a/build_tools/packaging/linux/tests/build_package_test.py
+++ b/build_tools/packaging/linux/tests/build_package_test.py
@@ -95,7 +95,9 @@ from packaging_utils import (  # noqa: E402
     GFX_META,
     PackageConfig,
     filter_components_fromartifactory,
+    filter_dependencies_by_artifacts,
     get_package_info,
+    has_artifact_for_arch,
     is_gfxarch_package,
     is_key_defined,
     update_package_name,
@@ -268,12 +270,15 @@ def _stage_package_artifacts(
 
             for component in components:
                 artifact_dir = artifacts_dir / f"{prefix}_{component}_{suffix}"
-                rel_path = f"{subdir_name}/{component}/{STAGING_PAYLOAD_NAME}"
-                payload = artifact_dir / rel_path
+                # Real manifests use directory paths, not file paths
+                dir_path = f"{subdir_name}/{component}"
+                payload = artifact_dir / dir_path / STAGING_PAYLOAD_NAME
                 payload.parent.mkdir(parents=True, exist_ok=True)
                 payload.write_bytes(STAGING_PAYLOAD_BYTES)
                 manifest = artifact_dir / "artifact_manifest.txt"
-                manifest.write_text(f"{rel_path}\n", encoding="utf-8")
+                # Append to manifest (multiple subdirs write to same artifact dir)
+                with manifest.open("a", encoding="utf-8") as f:
+                    f.write(f"{dir_path}\n")
                 if not manifest.exists():
                     raise RuntimeError(f"Failed to write artifact manifest: {manifest}")
                 created.append(artifact_dir)
@@ -703,6 +708,78 @@ class ParseInputPackageListTest(BuildPackageTestCase):
         )
         self.assertEqual(set(pkg_list), {PKG_CORE_SDK, PKG_CK})
         self.assertEqual(skipped, [])
+
+
+# ---------------------------------------------------------------------------
+# Empty package skipping (#6766)
+# ---------------------------------------------------------------------------
+class EmptyPackageSkippingTest(BuildPackageTestCase):
+    """Packages with no artifacts are skipped in kpack mode."""
+
+    def test_skips_empty_non_meta_package(self) -> None:
+        """DEB/RPM generation skips gfxarch packages with no artifacts."""
+        test_cases = [
+            (
+                TEST_PKG_TYPE_DEB,
+                deb_package,
+                "package_with_dpkg_build",
+                "create_versioned_deb_package",
+            ),
+            (
+                TEST_PKG_TYPE_RPM,
+                rpm_package,
+                "package_with_rpmbuild",
+                "create_versioned_rpm_package",
+            ),
+        ]
+        for pkg_type, module, build_func, create_func in test_cases:
+            with self.subTest(pkg_type=pkg_type):
+                cfg = _kpack_config(self.temp_dir, pkg_type=pkg_type)
+                device_cfg = replace(cfg, gfx_arch=TEST_GFX_TARGET)
+
+                with (
+                    patch.object(
+                        module, "move_packages_to_destination", return_value=[]
+                    ),
+                    patch.object(module, build_func) as mock_build,
+                ):
+                    result = getattr(module, create_func)(
+                        pkg_name=PKG_FFT, config=device_cfg
+                    )
+
+                self.assertEqual(result, [])
+                mock_build.assert_not_called()
+
+    def test_builds_meta_package_without_artifacts(self) -> None:
+        """DEB/RPM generation builds meta packages (they never have artifacts)."""
+        test_cases = [
+            (
+                TEST_PKG_TYPE_DEB,
+                deb_package,
+                "package_with_dpkg_build",
+                "create_versioned_deb_package",
+            ),
+            (
+                TEST_PKG_TYPE_RPM,
+                rpm_package,
+                "package_with_rpmbuild",
+                "create_versioned_rpm_package",
+            ),
+        ]
+        for pkg_type, module, build_func, create_func in test_cases:
+            with self.subTest(pkg_type=pkg_type):
+                cfg = _kpack_config(self.temp_dir, pkg_type=pkg_type)
+                meta_cfg = replace(cfg, gfx_arch=GFX_META)
+
+                with (
+                    patch.object(
+                        module, "move_packages_to_destination", return_value=[]
+                    ),
+                    patch.object(module, build_func) as mock_build,
+                ):
+                    getattr(module, create_func)(pkg_name=PKG_FFT, config=meta_cfg)
+
+                mock_build.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  Filter out non-existing directories from sourcedir_list before checking
  if a package has content. This ensures packages without artifacts are
  correctly skipped rather than being created as empty packages.

  Non-versioned packages and metapackages are unaffected and will still
  be created as expected.

  Changes:
  - DEB: Add path.is_dir() filter before empty package check
  - RPM: Return False from generate_spec_file() to skip empty packages
  - RPM: Check return value in caller to avoid rpmbuild failure
  - Now when a dependency lacks gfx artifacts but has host artifacts, we fall back
  to the host version
  
  JIRA ID: https://github.com/ROCm/TheRock/issues/6815