### PR TITLE
feat(hipkernelprovider): capture rocke Python wheels in test artifact

### DIFF
--- a/ml-libs/artifact-hipkernelprovider.toml
+++ b/ml-libs/artifact-hipkernelprovider.toml
@@ -26,6 +26,8 @@ include = [
   "bin/hip_kernel_provider/*.py",
   "bin/hip_kernel_provider/golden/**",
   "bin/hip_kernel_provider/rocke/**",
+  # rocKE Python wheels (rocke + rocke-library)
+  "bin/hip_kernel_provider/wheels/*.whl",
   # rocKE pytest suite
   "bin/hip_kernel_provider/tests/**",
 ]


### PR DESCRIPTION
ISSUE ID : AICK-1517

## Motivation

The rocKE CMake build now produces Python wheels for the `rocke` platform and `rocke-library` packages (added by rocm-libraries PR #9372). These wheels need to be captured in the test artifact so they are available for CI test environments to pip-install.

This is a stepping stone toward replacing the raw directory copy of the rocke Python package with proper wheel-based installation in CI, and toward enabling the rocKE library tests (attention builders/dispatch/parity) to run from the artifact.

## Technical Details

Add `"bin/hip_kernel_provider/wheels/*.whl"` glob to `artifact-hipkernelprovider.toml` so the two wheels staged by the
rocm-libraries build are included in the `hipkernelprovider_test` artifact:

- `rocke-0.1.0-py3-none-any.whl` — the rocke platform package
- `rocke_library-0.1.0-py3-none-any.whl` — the library package (kernels, builders, dispatch)

Companion PR: ROCm/rocm-libraries#9372

This is purely additive — the existing `rocke/**` directory copy and all test behavior are unchanged.

## Test Plan

- Built locally on Windows (gfx1151) with `THEROCK_FLAG_HIPKERNELPROVIDER_ENABLE_ROCKE=ON`
- Verified both wheels are staged to `stage/bin/hip_kernel_provider/wheels/`
- Verified the glob pattern matches the staged paths
- Installed both wheels into a test venv and confirmed all platform tests (417 passed) and library tests (202 passed) work

## Test Result

All tests pass, no change to existing test behavior — the wheels are captured in the artifact but not yet consumed by any test script.
