### PR TITLE
fix(rocprofiler-sdk): add openmpi to BUILD_DEPS

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -130,14 +130,13 @@ if(THEROCK_ENABLE_ROCPROFV3)
       rocprofiler-sdk-tests
     COMPILER_TOOLCHAIN
       amd-hip
-    BUILD_DEPS
-      ${_openmpi_optional_dep}
     RUNTIME_DEPS
       aqlprofile
       hip-clr
       rocprof-trace-decoder
       rocprofiler-register
       therock-yaml-cpp
+      ${_openmpi_optional_dep}
       ${_rocprofiler_sdk_optional_deps}
       ${THEROCK_BUNDLED_ELFUTILS}
       ${THEROCK_BUNDLED_LIBDRM}

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -130,6 +130,8 @@ if(THEROCK_ENABLE_ROCPROFV3)
       rocprofiler-sdk-tests
     COMPILER_TOOLCHAIN
       amd-hip
+    BUILD_DEPS
+      openmpi
     RUNTIME_DEPS
       aqlprofile
       hip-clr

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -131,7 +131,7 @@ if(THEROCK_ENABLE_ROCPROFV3)
     COMPILER_TOOLCHAIN
       amd-hip
     BUILD_DEPS
-      openmpi
+      ${_openmpi_optional_dep}
     RUNTIME_DEPS
       aqlprofile
       hip-clr


### PR DESCRIPTION
## Problem

  When openmpi was added as a super-project component in TheRock, the dep provider (`therock_subproject_dep_provider.cmake:68`) began intercepting `find_package(MPI)` calls from
  subprojects. rocprofiler-sdk calls `find_package(MPI)` in `cmake/rocprofiler_config_interfaces.cmake:408` — this was added as part of rocshmem tracing support (AIPROFSDK-886) because
  rocshmem's installed CMake config references `MPI::MPI_CXX` in its link interface and must be located before `find_package(rocshmem)` can succeed.

  Since openmpi was not declared in rocprofiler-sdk's `therock_cmake_subproject_declare`, the dep provider hard-errors with:

  CMake Error at cmake/therock_subproject_dep_provider.cmake:68 (message):
    Project contains find_package(MPI) for a package available in the
    super-project but not declared: Add a BUILD_DEPS or RUNTIME_DEPS
    appropriately

Commit in therock causing this: https://github.com/ROCm/TheRock/commit/f1a803131ccf8d3e5799c059f21e2bde4d8782ec

**After this commit:** The package registry is disabled inside all subprojects. Now when rocprofiler-sdk calls `find_package(MPI)`, the dep provider enforces that MPI must be declared in `BUILD_DEPS` or `RUNTIME_DEPS`. Since the RCCL CI build passes `-DTHEROCK_ENABLE_MPI=ON` (via `THEROCK_ENABLE_COMM_LIBS=ON`), MPI is in `THEROCK_STRICT_PROVIDED_PACKAGES` — but rocprofiler-sdk's declaration in `TheRock/profiler/CMakeLists.txt` lists no MPI dependency → `FATAL_ERROR`.

  This caused rocprofiler-sdk configure to fail, which in turn caused the RCCL CI build to fail in rocm-systems after the TheRock hash bump to `22004a6` (2026-07-20).

  ## Fix

  Add `openmpi` to `BUILD_DEPS` in the `therock_cmake_subproject_declare(rocprofiler-sdk ...)` block in `profiler/CMakeLists.txt`. This tells the dep provider the `find_package(MPI)`
  call is intentional and allows configure to proceed normally.

  ## Testing

  - rocprofiler-sdk configure should complete without error
  - RCCL CI build in rocm-systems should pass after bumping to a TheRock hash that includes this fix

Test rocm-systems run with pinned TheRock commit: https://github.com/ROCm/rocm-systems/actions/runs/29940406058/job/88993031854?pr=9029