### PR TITLE
fix(ci): Re-enable amd-smi static for gfx1151 in CI sanity check

### DIFF
--- a/build_tools/print_driver_gpu_info.py
+++ b/build_tools/print_driver_gpu_info.py
@@ -24,9 +24,6 @@ import subprocess
 import sys
 from typing import List, Optional
 
-AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
-unsupported_amdsmi_families = ["gfx1151"]
-
 
 def log(*args, **kwargs):
     print(*args, **kwargs)
@@ -109,14 +106,12 @@ def run_sanity(os_name: str) -> None:
         )
     else:
         # Linux: amd-smi static + rocminfo
-        # TODO(#2789): Remove conditional once amdsmi supports gfx1151
-        if AMDGPU_FAMILIES not in unsupported_amdsmi_families:
-            run_command_with_search(
-                label="amd-smi static",
-                command="amd-smi",
-                args=["static"],
-                extra_command_search_paths=[bin_dir],
-            )
+        run_command_with_search(
+            label="amd-smi static",
+            command="amd-smi",
+            args=["static"],
+            extra_command_search_paths=[bin_dir],
+        )
         run_command_with_search(
             label="rocminfo",
             command="rocminfo",


### PR DESCRIPTION
## Motivation

Closes #2789

The CI "Driver / GPU sanity check" skips `amd-smi static` for `gfx1151` because the command used to hang and time out on gfx1151 (tracked in #2789). `amd-smi static` no longer times out on gfx1151, so the skip can be removed to restore sanity-check coverage on that family.

JIRA ID : ROCM-9123

## Technical Details

`gfx1151` was the only remaining entry in `unsupported_amdsmi_families` in `build_tools/print_driver_gpu_info.py`. Rather than leave an empty list, this removes the list, the `AMDGPU_FAMILIES` env read, and the now-dead conditional (and its `TODO(#2789)`) entirely, so `amd-smi static` always runs on Linux.

## Test Plan

Verified on a gfx1151 machine by running `amd-smi static` and `AMDGPU_FAMILIES=gfx1151 python3 ./build_tools/print_driver_gpu_info.py` before and after the change.

## Test Result

`amd-smi static` completes in ~0.1s with no timeout. The sanity script now runs the `amd-smi static` section end-to-end for gfx1151 with no errors, and the default (unset `AMDGPU_FAMILIES`) path still works.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
