### PR TITLE
ci(wsl-rocdxg): move most WSLENV into common job-level env

### DIFF
--- a/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+++ b/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
@@ -64,7 +64,7 @@ jobs:
       STAGE_NAME: ${{ inputs.stage_name }}
       RELEASE_TYPE: ${{ inputs.release_type }}
       THEROCK_HOST_WORKSPACE: ${{ github.workspace }}
-      WSLENV: THEROCK_HOST_WORKSPACE/p:GITHUB_REPOSITORY:GITHUB_EVENT_NAME:GITHUB_EVENT_PATH/p:RELEASE_TYPE:MANYLINUX_IMAGE:THEROCK_WSL_WIN_SDK_MOUNT:THEROCK_WIN_SDK_SHARED/p:AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN:AWS_DEFAULT_REGION:AWS_REGION
+      WSLENV: THEROCK_HOST_WORKSPACE/p:GITHUB_REPOSITORY:GITHUB_EVENT_NAME:GITHUB_EVENT_PATH/p:RELEASE_TYPE:MANYLINUX_IMAGE:THEROCK_WSL_WIN_SDK_MOUNT:THEROCK_WIN_SDK_SHARED/p
       EXTERNAL_FETCH_SOURCES_ARGS: ${{ inputs.external_repo_config != '' && fromJSON(inputs.external_repo_config).fetch_sources_args || '' }}
       MANYLINUX_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6
       # Clean, space-free mount target for the Windows SDK shared include dir
@@ -300,6 +300,9 @@ jobs:
       - name: Push stage artifacts
         if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
         shell: wsl-bash {0}
+        env:
+          # Append AWS creds set by the "Configure AWS credentials" step
+          WSLENV: ${{ env.WSLENV }}:AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN:AWS_DEFAULT_REGION:AWS_REGION
         run: |
           stage_name="${{ inputs.stage_name }}"
           wsl_venv_dir="${HOME}/therock-wsl-rocdxg/.venv"
@@ -313,6 +316,9 @@ jobs:
       - name: Upload stage logs
         if: ${{ always() && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
         shell: wsl-bash {0}
+        env:
+          # Append AWS creds set by the "Configure AWS credentials" step
+          WSLENV: ${{ env.WSLENV }}:AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN:AWS_DEFAULT_REGION:AWS_REGION
         run: |
           wsl_venv_dir="${HOME}/therock-wsl-rocdxg/.venv"
           wsl_build_dir="${HOME}/therock-wsl-rocdxg/build"

--- a/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+++ b/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
@@ -64,13 +64,14 @@ jobs:
       STAGE_NAME: ${{ inputs.stage_name }}
       RELEASE_TYPE: ${{ inputs.release_type }}
       THEROCK_HOST_WORKSPACE: ${{ github.workspace }}
-      WSLENV: THEROCK_HOST_WORKSPACE/p:GITHUB_REPOSITORY:GITHUB_EVENT_NAME:GITHUB_EVENT_PATH/p:RELEASE_TYPE:MANYLINUX_IMAGE:THEROCK_WSL_WIN_SDK_MOUNT:THEROCK_WIN_SDK_SHARED/p
       EXTERNAL_FETCH_SOURCES_ARGS: ${{ inputs.external_repo_config != '' && fromJSON(inputs.external_repo_config).fetch_sources_args || '' }}
       MANYLINUX_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6
       # Clean, space-free mount target for the Windows SDK shared include dir
       # inside the container. Avoids the raw "(x86)" path segment that /bin/sh
       # misparses during nested subproject configure.
       THEROCK_WSL_WIN_SDK_MOUNT: /opt/winsdk-shared
+      # Injects Windows env vars into WSL
+      WSLENV: THEROCK_HOST_WORKSPACE/p:GITHUB_REPOSITORY:GITHUB_EVENT_NAME:GITHUB_EVENT_PATH/p:RELEASE_TYPE:MANYLINUX_IMAGE:THEROCK_WSL_WIN_SDK_MOUNT:THEROCK_WIN_SDK_SHARED/p
 
     steps:
       # Enable git longpaths before checkout (needed for external repos with long paths)
@@ -195,6 +196,7 @@ jobs:
       - name: Prepare WSL paths
         shell: wsl-bash {0}
         env:
+          # Made available in WSL via job-level WSLENV
           THEROCK_WIN_SDK_SHARED: C:\Program Files (x86)\Windows Kits\10\Include\${{ steps.detect_sdk.outputs.sdk_version }}\shared
         run: |
           wsl_build_dir="${HOME}/therock-wsl-rocdxg/build"
@@ -236,6 +238,7 @@ jobs:
       - name: Configure
         shell: wsl-bash {0}
         env:
+          # Made available in WSL via job-level WSLENV
           THEROCK_WIN_SDK_SHARED: C:\Program Files (x86)\Windows Kits\10\Include\${{ steps.detect_sdk.outputs.sdk_version }}\shared
         run: |
           wsl_src_dir="${HOME}/therock-wsl-rocdxg/src"
@@ -265,6 +268,7 @@ jobs:
       - name: Build stage
         shell: wsl-bash {0}
         env:
+          # Made available in WSL via job-level WSLENV
           THEROCK_WIN_SDK_SHARED: C:\Program Files (x86)\Windows Kits\10\Include\${{ steps.detect_sdk.outputs.sdk_version }}\shared
         run: |
           stage_name="${{ inputs.stage_name }}"

--- a/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
+++ b/.github/workflows/multi_arch_build_wsl_rocdxg_artifacts.yml
@@ -64,7 +64,7 @@ jobs:
       STAGE_NAME: ${{ inputs.stage_name }}
       RELEASE_TYPE: ${{ inputs.release_type }}
       THEROCK_HOST_WORKSPACE: ${{ github.workspace }}
-      WSLENV: THEROCK_HOST_WORKSPACE/p:GITHUB_REPOSITORY:GITHUB_EVENT_NAME:GITHUB_EVENT_PATH/p:RELEASE_TYPE:MANYLINUX_IMAGE:THEROCK_WSL_WIN_SDK_MOUNT
+      WSLENV: THEROCK_HOST_WORKSPACE/p:GITHUB_REPOSITORY:GITHUB_EVENT_NAME:GITHUB_EVENT_PATH/p:RELEASE_TYPE:MANYLINUX_IMAGE:THEROCK_WSL_WIN_SDK_MOUNT:THEROCK_WIN_SDK_SHARED/p:AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN:AWS_DEFAULT_REGION:AWS_REGION
       EXTERNAL_FETCH_SOURCES_ARGS: ${{ inputs.external_repo_config != '' && fromJSON(inputs.external_repo_config).fetch_sources_args || '' }}
       MANYLINUX_IMAGE: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:a382085df3ba2419b58aa9051350883a0d0b732a4bc0a4ef60458f8161bb08c6
       # Clean, space-free mount target for the Windows SDK shared include dir
@@ -196,7 +196,6 @@ jobs:
         shell: wsl-bash {0}
         env:
           THEROCK_WIN_SDK_SHARED: C:\Program Files (x86)\Windows Kits\10\Include\${{ steps.detect_sdk.outputs.sdk_version }}\shared
-          WSLENV: THEROCK_HOST_WORKSPACE/p:THEROCK_WIN_SDK_SHARED/p
         run: |
           wsl_build_dir="${HOME}/therock-wsl-rocdxg/build"
           if [ ! -d "${THEROCK_WIN_SDK_SHARED}" ]; then
@@ -238,7 +237,6 @@ jobs:
         shell: wsl-bash {0}
         env:
           THEROCK_WIN_SDK_SHARED: C:\Program Files (x86)\Windows Kits\10\Include\${{ steps.detect_sdk.outputs.sdk_version }}\shared
-          WSLENV: THEROCK_WIN_SDK_SHARED/p:MANYLINUX_IMAGE:THEROCK_WSL_WIN_SDK_MOUNT
         run: |
           wsl_src_dir="${HOME}/therock-wsl-rocdxg/src"
           wsl_build_dir="${HOME}/therock-wsl-rocdxg/build"
@@ -268,7 +266,6 @@ jobs:
         shell: wsl-bash {0}
         env:
           THEROCK_WIN_SDK_SHARED: C:\Program Files (x86)\Windows Kits\10\Include\${{ steps.detect_sdk.outputs.sdk_version }}\shared
-          WSLENV: THEROCK_WIN_SDK_SHARED/p:MANYLINUX_IMAGE:THEROCK_WSL_WIN_SDK_MOUNT
         run: |
           stage_name="${{ inputs.stage_name }}"
           wsl_src_dir="${HOME}/therock-wsl-rocdxg/src"
@@ -303,8 +300,6 @@ jobs:
       - name: Push stage artifacts
         if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
         shell: wsl-bash {0}
-        env:
-          WSLENV: THEROCK_HOST_WORKSPACE/p:GITHUB_REPOSITORY:GITHUB_EVENT_NAME:GITHUB_EVENT_PATH/p:RELEASE_TYPE:AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN:AWS_DEFAULT_REGION:AWS_REGION
         run: |
           stage_name="${{ inputs.stage_name }}"
           wsl_venv_dir="${HOME}/therock-wsl-rocdxg/.venv"
@@ -318,8 +313,6 @@ jobs:
       - name: Upload stage logs
         if: ${{ always() && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
         shell: wsl-bash {0}
-        env:
-          WSLENV: THEROCK_HOST_WORKSPACE/p:GITHUB_REPOSITORY:GITHUB_EVENT_NAME:GITHUB_EVENT_PATH/p:RELEASE_TYPE:AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY:AWS_SESSION_TOKEN:AWS_DEFAULT_REGION:AWS_REGION
         run: |
           wsl_venv_dir="${HOME}/therock-wsl-rocdxg/.venv"
           wsl_build_dir="${HOME}/therock-wsl-rocdxg/build"


### PR DESCRIPTION
## Motivation

Move most definitions of `WSLENV` into a common job-level variable as suggested in https://github.com/ROCm/TheRock/pull/6764/changes#r3632422006

Might have prevented https://github.com/ROCm/TheRock/issues/6763 from happening.

## Technical Details

- Removed most step-level definitions of `WSLENV` and move their values to the job-level `WSLENV` definition
  - `THEROCK_WIN_SDK_SHARED` is able to be specified in job-level `WSLENV`, even though it is defined in a runtime step.
    - `WSLENV` is parsed by WSL at runtime, so it is able to pick up the SDK path without issues as long as `env: THEROCK_WIN_SDK_SHARED: ...` is set for each step that requires it.
    - Added comments to the three steps using the SDK var
- The AWS credential envs cannot be set for the whole job, so append them to `WSLENV` at the step level.
  - The AWS envs are set during the `Configure AWS credentials` step. Before this step is run, they are empty.
  - `Fetch inbound artifacts`, which runs before `Configure`, will read the empty envs and try to pull from an empty S3 URL, so they cannot be set before this step is run.
  - Therefore we don't set them in job-level `WSLENV` and instead append them in any steps that require them.
  - `env: WSLENV: ${{ env.WSLENV }}:...` allows appending to `WSLENV` rather than overwriting it.

## Test Plan

- [x] WSL CI workflow passes
- [x] WSL release workflow passes

## Test Result

Release workflow run: https://github.com/ROCm/TheRock/actions/runs/29964916475

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
