### PR TITLE
ci(pytorch): add optional PyTorch git origin override to wheel builds

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -46,6 +46,12 @@ on:
         description: PyTorch ref to checkout. Typically "nightly" or "release/X.Y".
         type: string
         required: true
+      pytorch_gitrepo_origin:
+        description: >-
+          Optional PyTorch git origin override (for example, a fork URL for
+          pre-merge testing). Defaults to ROCm/pytorch for stable refs.
+        type: string
+        default: ""
       rocm_version:
         description: ROCm package version to install and build against (e.g. 7.10.0.dev0)
         type: string
@@ -104,6 +110,12 @@ on:
         description: PyTorch ref to checkout (for example, "release/2.12").
         type: string
         default: "release/2.12"
+      pytorch_gitrepo_origin:
+        description: >-
+          Optional PyTorch git origin override (for example, a fork URL for
+          pre-merge testing). Defaults to ROCm/pytorch for stable refs.
+        type: string
+        default: ""
       rocm_version:
         description: ROCm package version to install and build against (e.g. 7.10.0.dev0)
         type: string
@@ -229,8 +241,12 @@ jobs:
       - name: Checkout PyTorch source repos (stable)
         if: ${{ inputs.pytorch_git_ref != 'nightly' }}
         run: |
+          pytorch_origin="${{ inputs.pytorch_gitrepo_origin }}"
+          if [ -z "${pytorch_origin}" ]; then
+            pytorch_origin="https://github.com/ROCm/pytorch.git"
+          fi
           ./external-builds/pytorch/pytorch_torch_repo.py checkout \
-            --gitrepo-origin https://github.com/ROCm/pytorch.git \
+            --gitrepo-origin "${pytorch_origin}" \
             --repo-hashtag ${{ inputs.pytorch_git_ref }} \
             --no-commit-hipify
           ./external-builds/pytorch/pytorch_audio_repo.py checkout \

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -46,6 +46,12 @@ on:
         description: PyTorch ref to checkout. Typically "nightly" or "release/X.Y".
         type: string
         required: true
+      pytorch_gitrepo_origin:
+        description: >-
+          Optional PyTorch git origin override (for example, a fork URL for
+          pre-merge testing). Defaults to ROCm/pytorch for stable refs.
+        type: string
+        default: ""
       rocm_version:
         description: ROCm package version to install and build against (e.g. 7.10.0.dev0)
         type: string
@@ -98,6 +104,12 @@ on:
         description: PyTorch ref to checkout (for example, "release/2.12").
         type: string
         default: "release/2.12"
+      pytorch_gitrepo_origin:
+        description: >-
+          Optional PyTorch git origin override (for example, a fork URL for
+          pre-merge testing). Defaults to ROCm/pytorch for stable refs.
+        type: string
+        default: ""
       rocm_version:
         description: ROCm package version to install and build against (e.g. 7.10.0.dev0)
         type: string
@@ -240,9 +252,13 @@ jobs:
         if: ${{ inputs.pytorch_git_ref != 'nightly' }}
         run: |
           git config --global core.longpaths true
+          pytorch_origin="${{ inputs.pytorch_gitrepo_origin }}"
+          if [ -z "${pytorch_origin}" ]; then
+            pytorch_origin="https://github.com/ROCm/pytorch.git"
+          fi
           python ./external-builds/pytorch/pytorch_torch_repo.py checkout \
             --checkout-dir ${{ env.CHECKOUT_ROOT }}/pytorch \
-            --gitrepo-origin https://github.com/ROCm/pytorch.git \
+            --gitrepo-origin "${pytorch_origin}" \
             --repo-hashtag ${{ inputs.pytorch_git_ref }} \
             --no-commit-hipify
           python ./external-builds/pytorch/pytorch_audio_repo.py checkout \


### PR DESCRIPTION
ISSUE ID : https://github.com/ROCm/TheRock/issues/6735

## Summary

Add an optional `pytorch_gitrepo_origin` workflow input to the portable Linux and Windows PyTorch wheel build workflows so CI can checkout PyTorch from a fork URL (for pre-merge validation) while defaulting to `ROCm/pytorch` when unset.

## Changes

- `multi_arch_build_portable_linux_pytorch_wheels.yml`: new `pytorch_gitrepo_origin` input; pass through to `pytorch_torch_repo.py checkout --gitrepo-origin`.
- `multi_arch_build_windows_pytorch_wheels.yml`: same input and wiring for the Windows wheel pipeline.

## Testing

- Default behavior unchanged when `pytorch_gitrepo_origin` is empty (still uses `https://github.com/ROCm/pytorch.git`).
- Used to validate upstream PyTorch packaging fixes against TheRock Windows wheel builds before merge.
