### PR TITLE
fix: Add Radeon RX 9050 series GPU IDs to amdgpu.ids

### DIFF
--- a/third-party/sysdeps/linux/libdrm/patch_source.sh
+++ b/third-party/sysdeps/linux/libdrm/patch_source.sh
@@ -26,6 +26,8 @@ sed -i "/pkg\.generate\s*(/a\  libraries : ['-L\${libdir}', '-ldrm_amdgpu']," $A
 AMDGPU_IDS="$SOURCE_DIR/data/amdgpu.ids"
 cat >> "$AMDGPU_IDS" << 'EOF'
 7590,	C0,	AMD Radeon RX 9060 XT
+7590,	CF,	AMD Radeon RX 9050
+7590,	DF,	AMD Radeon RX 9050 4GB
 744B,	00,	AMD Radeon PRO W7900D
 75A0,	00,	AMD Instinct MI350X
 75A3,	00,	AMD Instinct MI355X


### PR DESCRIPTION
  Add device ID entries for desktop Navi44 XE variants:
  - AMD Radeon RX 9050 (Navi44 XE) - PCI ID 7590, revision CF
  - AMD Radeon RX 9050 4GB (Navi44 XE 4GB) - PCI ID 7590, revision DF

JIRA ID: https://amd-hub.atlassian.net/browse/ROCM-26970