### PR TITLE
Fix non-root ownership of package files

### DIFF
--- a/build_tools/packaging/linux/template/debian_rules.j2
+++ b/build_tools/packaging/linux/template/debian_rules.j2
@@ -8,7 +8,7 @@
 
 
 override_dh_builddeb:
-	dh_builddeb -- -Zxz
+	dh_builddeb -- -Zxz --root-owner-group
 
 {% if disable_dwz %}
 override_dh_dwz:

--- a/build_tools/packaging/linux/template/rpm_specfile.j2
+++ b/build_tools/packaging/linux/template/rpm_specfile.j2
@@ -62,6 +62,7 @@ mkdir -p $RPM_BUILD_ROOT{{ install_prefix }}
 {% endfor %}
 
 %files
+%defattr(-, root, root, -)
 {{ install_prefix }}
 
 %clean


### PR DESCRIPTION
## Motivation

Addresses https://github.com/ROCm/ROCm/issues/6496

## Technical Details
Ownership for 7.14 packaged directories points to `rocm-signer/rocm-signer` or uid `1004` instead of root. This allows for non-root users who have uid == 1004 to overwrite files in the install tree. This is a regression from the mainline ROCm 6/7 releases where all files and directories were own by `root:root`.
```
 dpkg -c /var/cache/apt/archives/amdrocm-base7.14_7.14.0-3_amd64.deb
drwxr-xr-x rocm-signer/rocm-signer 0 2026-07-14 13:26 ./
drwxr-xr-x rocm-signer/rocm-signer 0 2026-07-09 20:08 ./opt/
drwxr-xr-x rocm-signer/rocm-signer 0 2026-07-09 20:08 ./opt/rocm/
drwxr-xr-x rocm-signer/rocm-signer 0 2026-07-09 20:08 ./opt/rocm/core-7.14/
```
```
ll /opt/rocm/core-7.14
total 48
drwxr-xr-x 10 1004 1005  4096 Jul 22 11:58 ./
drwxr-xr-x  3 1004 1005  4096 Jul 22 12:00 ../
lrwxrwxrwx  1 1004 1005    15 Jul  9 19:46 amdgcn -> lib/llvm/amdgcn/
drwxr-xr-x  3 1004 1005  4096 Jul 22 11:58 bin/
drwxr-xr-x  4 1004 1005  4096 Jul 22 11:58 etc/
drwxr-xr-x 56 1004 1005  4096 Jul 22 11:58 include/
drwxr-xr-x  2 1004 1005  4096 Jul 22 11:58 .info/
```

- `--root-owner-group` / `%defattr(-, root, root, -)` force `0/0` (root ownership) regardless of builder identity, fakeroot presence, or how staging owns files.
- `do_fix_ownership()` introduces post-inst mechanism to update existing installs

## Test Plan

  1. Reproduce the non-root ownership leak (root build, no fakeroot, payload staged as the build uid 1004:1005)
  2. Apply the fix and confirm payload ownership is normalized to root:root, for both DEB and RPM
  3. Confirm the postinst repair fixes already-installed systems on upgrade

## Test Result
Reproduction + fix
- Before Patch -> Owner of `/opt/rocm/core/bin/amd-smi` = 1004/1005
- After Patch -> Owner of `/opt/rocm/core/bin/amd-smi` = root

postinst ownership repair (dpkg -i / rpm -i as root):
  - Prior install owned by uid 1004 -> repaired to root:root recursively; exit 0
  - Fresh install, prefix absent    -> no abort (guard skips); exit 0

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
