### PR TITLE
ci: clarify PyTorch build dispatch inputs and default the ROCm index

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -109,13 +109,20 @@ on:
         type: string
         required: true
       rocm_package_find_links_url:
-        description: URL for pip --find-links to install ROCm packages (flat page; use this OR rocm_package_index_url)
+        description: >-
+          URL for pip --find-links to install ROCm packages (flat page). Use
+          this OR rocm_package_index_url, not both. If you set this, clear
+          rocm_package_index_url (otherwise both get passed to pip).
         type: string
         default: ""
       rocm_package_index_url:
-        description: URL for pip --index-url to install ROCm packages (PEP 503 index, e.g. repo.amd.com; use this OR rocm_package_find_links_url)
+        description: >-
+          URL for pip --index-url to install ROCm packages (PEP 503 index).
+          Defaults to the nightly multi-arch index; override to build against a
+          different ROCm channel or a specific build's index. Use this OR
+          rocm_package_find_links_url, not both.
         type: string
-        default: ""
+        default: "https://rocm.nightlies.amd.com/whl-multi-arch"
       release_type:
         description: 'Release type; developer-triggered jobs should use "dev".'
         type: choice
@@ -123,11 +130,17 @@ on:
           - dev
         default: dev
       repository:
-        description: "Repository to checkout. Defaults to github.repository."
+        description: >-
+          TheRock repository to check out the build scripts/workflow from (NOT
+          the PyTorch source). Leave blank to use this repository. To build a
+          different PyTorch branch, set pytorch_git_ref instead.
         type: string
         default: ""
       ref:
-        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        description: >-
+          Branch, tag, or SHA of TheRock (the repository above) to check out.
+          Leave blank to use the triggering ref. This does NOT select the
+          PyTorch source ref; use pytorch_git_ref for that.
         type: string
         default: ""
       cache_type:

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -291,6 +291,16 @@ jobs:
           echo "targets=${targets}" >> "$GITHUB_OUTPUT"
 
       - name: Build PyTorch wheels
+        # Default to the nightly multi-arch ROCm index when neither source is
+        # provided so a bare manual dispatch works; setting either input
+        # overrides it. The default is applied here rather than on the input
+        # because GitHub reverts an emptied input back to its declared default,
+        # which would make the two inputs impossible to use exclusively.
+        env:
+          # Use the index if given; else the find-links page; else default to
+          # the nightly multi-arch index (both empty is the bare-dispatch case).
+          ROCM_INDEX_URL: ${{ inputs.rocm_package_index_url || (inputs.rocm_package_find_links_url == '' && 'https://rocm.nightlies.amd.com/whl-multi-arch' || '') }}
+          ROCM_FIND_LINKS: ${{ inputs.rocm_package_find_links_url }}
         run: |
           cache_flag=""
           if [ "${{ inputs.cache_type }}" = "sccache" ]; then
@@ -299,26 +309,14 @@ jobs:
             cache_flag="--use-ccache"
           fi
 
-          # Default to the nightly multi-arch ROCm index when neither source
-          # is provided so a bare manual dispatch works. Setting either input
-          # overrides this. The default lives here rather than on the input
-          # because GitHub reverts an emptied input back to its declared
-          # default, which would make the two inputs impossible to use
-          # exclusively.
-          rocm_index_url="${{ inputs.rocm_package_index_url }}"
-          rocm_find_links="${{ inputs.rocm_package_find_links_url }}"
-          if [ -z "${rocm_index_url}" ] && [ -z "${rocm_find_links}" ]; then
-            rocm_index_url="https://rocm.nightlies.amd.com/whl-multi-arch"
-          fi
-
           # build_prod_wheels.py forwards each of these to pip and ignores an
           # empty value, so pass both and supply whichever source applies:
           # --index-url for a PEP 503 index, --find-links for a flat page.
           ./external-builds/pytorch/build_prod_wheels.py \
             build \
             --install-rocm \
-            --index-url="${rocm_index_url}" \
-            --find-links="${rocm_find_links}" \
+            --index-url="${ROCM_INDEX_URL}" \
+            --find-links="${ROCM_FIND_LINKS}" \
             --clean \
             --output-dir ${{ env.PACKAGE_DIST_DIR }} \
             ${cache_flag} \

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -110,19 +110,19 @@ on:
         required: true
       rocm_package_find_links_url:
         description: >-
-          URL for pip --find-links to install ROCm packages (flat page). Use
-          this OR rocm_package_index_url, not both. If you set this, clear
-          rocm_package_index_url (otherwise both get passed to pip).
+          URL for pip --find-links to install ROCm packages (flat page). Set
+          either this or rocm_package_index_url to override the ROCm package
+          source; leave both blank to use the nightly multi-arch index.
         type: string
         default: ""
       rocm_package_index_url:
         description: >-
           URL for pip --index-url to install ROCm packages (PEP 503 index).
-          Defaults to the nightly multi-arch index; override to build against a
-          different ROCm channel or a specific build's index. Use this OR
-          rocm_package_find_links_url, not both.
+          Set either this or rocm_package_find_links_url to override the ROCm
+          package source; leave both blank to use the nightly multi-arch index
+          (https://rocm.nightlies.amd.com/whl-multi-arch).
         type: string
-        default: "https://rocm.nightlies.amd.com/whl-multi-arch"
+        default: ""
       release_type:
         description: 'Release type; developer-triggered jobs should use "dev".'
         type: choice
@@ -299,14 +299,26 @@ jobs:
             cache_flag="--use-ccache"
           fi
 
+          # Default to the nightly multi-arch ROCm index when neither source
+          # is provided so a bare manual dispatch works. Setting either input
+          # overrides this. The default lives here rather than on the input
+          # because GitHub reverts an emptied input back to its declared
+          # default, which would make the two inputs impossible to use
+          # exclusively.
+          rocm_index_url="${{ inputs.rocm_package_index_url }}"
+          rocm_find_links="${{ inputs.rocm_package_find_links_url }}"
+          if [ -z "${rocm_index_url}" ] && [ -z "${rocm_find_links}" ]; then
+            rocm_index_url="https://rocm.nightlies.amd.com/whl-multi-arch"
+          fi
+
           # build_prod_wheels.py forwards each of these to pip and ignores an
           # empty value, so pass both and supply whichever source applies:
           # --index-url for a PEP 503 index, --find-links for a flat page.
           ./external-builds/pytorch/build_prod_wheels.py \
             build \
             --install-rocm \
-            --index-url="${{ inputs.rocm_package_index_url }}" \
-            --find-links="${{ inputs.rocm_package_find_links_url }}" \
+            --index-url="${rocm_index_url}" \
+            --find-links="${rocm_find_links}" \
             --clean \
             --output-dir ${{ env.PACKAGE_DIST_DIR }} \
             ${cache_flag} \

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -103,11 +103,19 @@ on:
         type: string
         required: true
       rocm_package_find_links_url:
-        description: URL for pip --find-links to install ROCm packages (flat page; use this OR rocm_package_index_url)
+        description: >-
+          URL for pip --find-links to install ROCm packages (flat page). Use
+          this OR rocm_package_index_url, not both. One of the two must be set
+          (there is no default): point it at the ROCm channel/build to build
+          against.
         type: string
         default: ""
       rocm_package_index_url:
-        description: URL for pip --index-url to install ROCm packages (PEP 503 index, e.g. repo.amd.com; use this OR rocm_package_find_links_url)
+        description: >-
+          URL for pip --index-url to install ROCm packages (PEP 503 index). Use
+          this OR rocm_package_find_links_url, not both. One of the two must be
+          set (there is no default): point it at the ROCm channel/build to build
+          against.
         type: string
         default: ""
       release_type:
@@ -117,11 +125,17 @@ on:
           - dev
         default: dev
       repository:
-        description: "Repository to checkout. Defaults to github.repository."
+        description: >-
+          TheRock repository to check out the build scripts/workflow from (NOT
+          the PyTorch source). Leave blank to use this repository. To build a
+          different PyTorch branch, set pytorch_git_ref instead.
         type: string
         default: ""
       ref:
-        description: "Branch, tag, or SHA to checkout. Defaults to the triggering ref."
+        description: >-
+          Branch, tag, or SHA of TheRock (the repository above) to check out.
+          Leave blank to use the triggering ref. This does NOT select the
+          PyTorch source ref; use pytorch_git_ref for that.
         type: string
         default: ""
       cache_type:

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -306,18 +306,31 @@ jobs:
       # Using 'cmd' here is load bearing! There are configuration issues when
       # run under 'bash': https://github.com/ROCm/TheRock/issues/827#issuecomment-3025858800
       - name: Build PyTorch wheels
+        # Default to the nightly multi-arch ROCm index when neither source is
+        # provided so a bare manual dispatch works; setting either input
+        # overrides it. The default is applied here rather than on the input
+        # because GitHub reverts an emptied input back to its declared default,
+        # which would make the two inputs impossible to use exclusively.
         shell: cmd
+        env:
+          # Use the index if given; else the find-links page; else default to
+          # the nightly multi-arch index (both empty is the bare-dispatch case).
+          ROCM_INDEX_URL: ${{ inputs.rocm_package_index_url || (inputs.rocm_package_find_links_url == '' && 'https://rocm.nightlies.amd.com/whl-multi-arch' || '') }}
+          ROCM_FIND_LINKS: ${{ inputs.rocm_package_find_links_url }}
         run: |
           set "CACHE_FLAG="
           if "${{ inputs.cache_type }}"=="sccache" set "CACHE_FLAG=--use-sccache"
           if "${{ inputs.cache_type }}"=="ccache" set "CACHE_FLAG=--use-ccache"
 
           echo "Building PyTorch wheels for ${{ inputs.amdgpu_families }} (cache: ${{ inputs.cache_type }})"
+          REM build_prod_wheels.py forwards each of these to pip and ignores an
+          REM empty value, so pass both and supply whichever source applies:
+          REM --index-url for a PEP 503 index, --find-links for a flat page.
           python ./external-builds/pytorch/build_prod_wheels.py ^
             build ^
             --install-rocm ^
-            --index-url="${{ inputs.rocm_package_index_url }}" ^
-            --find-links="${{ inputs.rocm_package_find_links_url }}" ^
+            --index-url="%ROCM_INDEX_URL%" ^
+            --find-links="%ROCM_FIND_LINKS%" ^
             --root-checkout-dir ${{ env.CHECKOUT_ROOT }} ^
             --enable-pytorch-flash-attention-windows ^
             --clean ^


### PR DESCRIPTION
Closes #6790

## What

Manual dispatches of the multi-arch PyTorch build workflows commonly fail in two avoidable ways. This PR makes the inputs self-explanatory and gives the Linux path a sane default.

1. **`repository`/`ref` mistaken for the PyTorch source.** They select which **TheRock** checkout the build scripts come from. When set to `rocm/pytorch`, the outer checkout grabs the wrong repo and every step fails with `build_tools/github_actions/*.py: No such file or directory` (shown as the misleading "Executing the custom container implementation failed").
2. **No ROCm package source.** Leaving both `rocm_package_index_url` and `rocm_package_find_links_url` blank makes `pip install rocm[libraries,devel]==<nightly>` resolve against PyPI, where `rocm` is only a placeholder `0.1.0`, so the pinned nightly can't be found.

## Changes

- Clarify `repository`/`ref` descriptions on both build workflows: they refer to **TheRock** (build scripts/workflow), not the PyTorch source; use `pytorch_git_ref` to pick the PyTorch branch.
- Clarify the ROCm index vs. find-links descriptions (use one **or** the other).
- Default `rocm_package_index_url` on the **Linux portable** `workflow_dispatch` path to the nightly multi-arch index (`https://rocm.nightlies.amd.com/whl-multi-arch`) so a bare manual build works.
- `workflow_call` defaults are intentionally left unchanged, so programmatic callers (release/CI wrappers, some of which pass `find-links`) are unaffected.

Windows keeps an empty ROCm-URL default (its packages are not served from the Linux multi-arch index), but its input descriptions get the same clarifications.

## Test

- `pre-commit` (incl. actionlint) passes on both workflow files.
- Docs/config-only change to `workflow_dispatch` metadata; `workflow_call` behavior is unchanged.
