### PR TITLE
[math-libs] Fix benchmark build on Windows for primitives libs

### DIFF
--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -2,11 +2,17 @@
 # SPDX-License-Identifier: MIT
 
 if(THEROCK_ENABLE_RAND)
+  # On Windows the primlibs benchmarks build without GPU monitoring, so no
+  # amdsmi dependency is needed.
+  if(WIN32)
+    set(_primlibs_benchmark_enable ${THEROCK_BUILD_TESTING})
+    set(_primlibs_benchmark_deps)
+    set(_primlibs_benchmark_includes)
   # amdsmi is Linux-only and only declared when THEROCK_ENABLE_CORE_AMDSMI is ON
   # (see core/CMakeLists.txt). Benchmarks depend on primbench which requires
-  # amd_smi, so they must be disabled when amdsmi is unavailable (e.g., the
+  # amdsmi, so they must be disabled when amdsmi is unavailable (e.g., the
   # prim-isolated CI group THEROCK_ENABLE_ALL=OFF / THEROCK_ENABLE_PRIM=ON).
-  if(WIN32 OR NOT TARGET amdsmi)
+  elseif(NOT TARGET amdsmi)
     set(_primlibs_benchmark_enable "OFF")
     set(_primlibs_benchmark_deps)
     set(_primlibs_benchmark_includes)
@@ -132,11 +138,17 @@ if(THEROCK_ENABLE_PRIM)
   therock_cmake_subproject_provide_package(rocPRIM rocprim lib/cmake/rocprim)
   therock_cmake_subproject_activate(rocPRIM)
 
+  # On Windows the primlibs benchmarks build without GPU monitoring, so no
+  # amdsmi dependency is needed.
+  if(WIN32)
+    set(_primlibs_benchmark_enable ${THEROCK_BUILD_TESTING})
+    set(_primlibs_benchmark_deps)
+    set(_primlibs_benchmark_includes)
   # amdsmi is Linux-only and only declared when THEROCK_ENABLE_CORE_AMDSMI is ON
   # (see core/CMakeLists.txt). Benchmarks depend on primbench which requires
-  # amd_smi, so they must be disabled when amdsmi is unavailable (e.g., the
+  # amdsmi, so they must be disabled when amdsmi is unavailable (e.g., the
   # prim-isolated CI group THEROCK_ENABLE_ALL=OFF / THEROCK_ENABLE_PRIM=ON).
-  if(WIN32 OR NOT TARGET amdsmi)
+  elseif(NOT TARGET amdsmi)
     set(_primlibs_benchmark_enable "OFF")
     set(_primlibs_benchmark_deps)
     set(_primlibs_benchmark_includes)

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -1,27 +1,23 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-if(THEROCK_ENABLE_RAND)
-  # On Windows the primlibs benchmarks build without GPU monitoring, so no
-  # amdsmi dependency is needed.
-  if(WIN32)
-    set(_primlibs_benchmark_enable ${THEROCK_BUILD_TESTING})
-    set(_primlibs_benchmark_deps)
-    set(_primlibs_benchmark_includes)
-  # amdsmi is Linux-only and only declared when THEROCK_ENABLE_CORE_AMDSMI is ON
-  # (see core/CMakeLists.txt). Benchmarks depend on primbench which requires
-  # amdsmi, so they must be disabled when amdsmi is unavailable (e.g., the
-  # prim-isolated CI group THEROCK_ENABLE_ALL=OFF / THEROCK_ENABLE_PRIM=ON).
-  elseif(NOT TARGET amdsmi)
+set(_primlibs_benchmark_enable ${THEROCK_BUILD_TESTING})
+set(_primlibs_benchmark_deps)
+set(_primlibs_benchmark_includes)
+# amdsmi is Linux-only and only declared when THEROCK_ENABLE_CORE_AMDSMI is ON
+# (see core/CMakeLists.txt). Benchmarks depend on primbench which requires
+# amdsmi, so they must be disabled when amdsmi is unavailable (e.g., the
+# prim-isolated CI group THEROCK_ENABLE_ALL=OFF / THEROCK_ENABLE_PRIM=ON).
+if(NOT WIN32)
+  if(NOT TARGET amdsmi)
     set(_primlibs_benchmark_enable "OFF")
-    set(_primlibs_benchmark_deps)
-    set(_primlibs_benchmark_includes)
   else()
-    set(_primlibs_benchmark_enable ${THEROCK_BUILD_TESTING})
     set(_primlibs_benchmark_deps amdsmi)
     set(_primlibs_benchmark_includes therock_primlibs_benchmark_deps.cmake)
   endif()
+endif()
 
+if(THEROCK_ENABLE_RAND)
   ##############################################################################
   # rocRAND
   ##############################################################################
@@ -137,26 +133,6 @@ if(THEROCK_ENABLE_PRIM)
   )
   therock_cmake_subproject_provide_package(rocPRIM rocprim lib/cmake/rocprim)
   therock_cmake_subproject_activate(rocPRIM)
-
-  # On Windows the primlibs benchmarks build without GPU monitoring, so no
-  # amdsmi dependency is needed.
-  if(WIN32)
-    set(_primlibs_benchmark_enable ${THEROCK_BUILD_TESTING})
-    set(_primlibs_benchmark_deps)
-    set(_primlibs_benchmark_includes)
-  # amdsmi is Linux-only and only declared when THEROCK_ENABLE_CORE_AMDSMI is ON
-  # (see core/CMakeLists.txt). Benchmarks depend on primbench which requires
-  # amdsmi, so they must be disabled when amdsmi is unavailable (e.g., the
-  # prim-isolated CI group THEROCK_ENABLE_ALL=OFF / THEROCK_ENABLE_PRIM=ON).
-  elseif(NOT TARGET amdsmi)
-    set(_primlibs_benchmark_enable "OFF")
-    set(_primlibs_benchmark_deps)
-    set(_primlibs_benchmark_includes)
-  else()
-    set(_primlibs_benchmark_enable ${THEROCK_BUILD_TESTING})
-    set(_primlibs_benchmark_deps amdsmi)
-    set(_primlibs_benchmark_includes therock_primlibs_benchmark_deps.cmake)
-  endif()
 
   if(THEROCK_BUILD_TESTING)
     ##############################################################################


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Binaries of benchmarks for primitives libraries are missing from the Window build. This PR fixes the issue.

<!-- Most pull requests should be associated with at least one GitHub issue -->
JIRA ID: ROCM-27542

<!-- GitHub issue: https://github.com/ROCm/TheRock/issues/1234 -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Benchmarks on Windows do not monitor GPUs (no amdsmi dependency). The condition of building them on Windows was coupled with `NOT TARGET amdsmi`. They are now decoupled.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
CI on Windows with `THEROCK_BUILD_TESTING=ON` should now build the binaries and include them in the tarball.

## Test Result

<!-- Briefly summarize test outcomes. -->
Check the CI and confirm the issue is fixed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
