### PR TITLE
Install uv via pip

### DIFF
--- a/.github/actions/setup_test_environment/action.yml
+++ b/.github/actions/setup_test_environment/action.yml
@@ -38,11 +38,7 @@ runs:
     - name: "Install UV"
       shell: bash
       run: |
-        if [[ "$RUNNER_OS" == "Windows" ]]; then
-          powershell -Command "irm https://astral.sh/uv/install.ps1 | iex"
-        else
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-        fi
+        pip install uv
 
     - name: Create Python venv
       shell: bash


### PR DESCRIPTION
## Motivation

Instead of grabbing an un-hashed script from astral, follow https://docs.astral.sh/uv/getting-started/installation/#pypi and pip install uv.

JIRA ID ROCM-26882

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
