### PR TITLE
fix(rocgdb): suppress ASAN leak detection during executable validation

### DIFF
--- a/debug-tools/rocgdb/rocgdb
+++ b/debug-tools/rocgdb/rocgdb
@@ -56,7 +56,9 @@ validate_executable() {
         return 1
     fi
 
-    if "$executable" --version >/dev/null 2>&1; then
+    # Suppress ASAN leak detection for the version check only because rocgdb is
+    # not leak-free and the leak report would cause --version to appear to fail.
+    if ASAN_OPTIONS="${ASAN_OPTIONS:+${ASAN_OPTIONS}:}detect_leaks=0" "$executable" --version >/dev/null 2>&1; then
         log_message "Running $executable --version works."
         return 0
     else


### PR DESCRIPTION
ROCgdb is not fully leak-free, so when running an ASAN build the leak
report printed at exit causes the `--version` check in `validate_executable`
to fail. This makes the wrapper unable to find any working rocgdb binary
and fall through to an error even when the binary is perfectly functional.

The fix scopes `detect_leaks=0` to each `--version` invocation via an
inline `ASAN_OPTIONS` assignment. This means the suppression is active
only during validation and does not carry over to the rocgdb process the
user actually launches, leaving their original `ASAN_OPTIONS` untouched.

The `${ASAN_OPTIONS:+${ASAN_OPTIONS}:}` expansion handles both the unset
and already-set cases cleanly, and appending at the end is safe because
ASAN uses last-value-wins for duplicate keys.

JIRA ID: ROCM-24601