### PR TITLE
ci: enable gfx90c for PyTorch release/2.12, disable nightly

### DIFF
--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -56,23 +56,20 @@ CI_PYTORCH_REFS = {
 
 # Unknown explicit refs are left unfiltered so bring-up branches can opt into
 # new GPU families before the default PyTorch refs support them.
-#
-# gfx90c is excluded from stable release branches and built for nightly only
-# while it is brought up. Once nightly gfx90c wheels are confirmed working, it
-# will be added to the stable branches.
 UNSUPPORTED_AMDGPU_FAMILIES = {
     "linux": {
         # gfx125x not supported for PyTorch 2.10.
-        "release/2.10": {"gfx125X-dcgpu", "gfx90c"},
+        "release/2.10": {"gfx125X-dcgpu"},
         # gfx125x supported for PyTorch 2.11 via https://github.com/ROCm/pytorch/pull/3346.
-        "release/2.11": {"gfx90c"},
+        "release/2.11": {},
         # gfx125x supported for PyTorch 2.12 via https://github.com/ROCm/pytorch/pull/3421.
-        "release/2.12": {"gfx90c"},
+        "release/2.12": {},
         # gfx125x not yet enabled for PyTorch release/2.13 (ROCm/pytorch fork).
         # See https://github.com/ROCm/TheRock/issues/5833.
         "release/2.13": {"gfx125X-dcgpu", "gfx90c"},
         # gfx125x supported on upstream pytorch/pytorch nightly via pytorch#188597.
-        "nightly": {},
+        # gfx90c excluded: blocked until CK submodule bump in pytorch nightly.
+        "nightly": {"gfx90c"},
     },
     "windows": {
         "release/2.10": {"gfx90c"},

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -74,7 +74,6 @@ UNSUPPORTED_AMDGPU_FAMILIES = {
         "nightly": {"gfx90c"},
     },
     "windows": {
-        # gfx90c only supported in PyTorch 2.12+ (still bringing up Windows).
         "release/2.10": {"gfx90c"},
         "release/2.11": {"gfx90c"},
         "release/2.12": {"gfx90c"},

--- a/build_tools/github_actions/configure_pytorch_release_matrix.py
+++ b/build_tools/github_actions/configure_pytorch_release_matrix.py
@@ -59,9 +59,11 @@ CI_PYTORCH_REFS = {
 UNSUPPORTED_AMDGPU_FAMILIES = {
     "linux": {
         # gfx125x not supported for PyTorch 2.10.
-        "release/2.10": {"gfx125X-dcgpu"},
+        # gfx90c only supported in PyTorch 2.12+.
+        "release/2.10": {"gfx125X-dcgpu", "gfx90c"},
         # gfx125x supported for PyTorch 2.11 via https://github.com/ROCm/pytorch/pull/3346.
-        "release/2.11": {},
+        # gfx90c only supported in PyTorch 2.12+.
+        "release/2.11": {"gfx90c"},
         # gfx125x supported for PyTorch 2.12 via https://github.com/ROCm/pytorch/pull/3421.
         "release/2.12": {},
         # gfx125x not yet enabled for PyTorch release/2.13 (ROCm/pytorch fork).
@@ -72,6 +74,7 @@ UNSUPPORTED_AMDGPU_FAMILIES = {
         "nightly": {"gfx90c"},
     },
     "windows": {
+        # gfx90c only supported in PyTorch 2.12+ (still bringing up Windows).
         "release/2.10": {"gfx90c"},
         "release/2.11": {"gfx90c"},
         "release/2.12": {"gfx90c"},


### PR DESCRIPTION
## Motivation

Addresses https://github.com/ROCm/TheRock/issues/6805.

## Technical Details

- Shifting gfx90c builds to release/2.12 only as gfx90c support has been backported there with https://github.com/ROCm/pytorch/pull/3480
- `nightly` is currently [blocked](https://github.com/ROCm/TheRock/issues/6805) until CK submodule is bumped to include gfx90c support. Disabled for the time being. 

## Test Plan

- Trigger TheRock Multi-Arch PyTorch build w/fix branch

## Test Result

- release/2.12 now builds successfully https://github.com/ROCm/TheRock/actions/runs/30103245986

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
