### PR TITLE
feat(rocprofier-sdk): add hipfile as optional dependency for rocprofiler-sdk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,6 +503,9 @@ add_subdirectory(debug-tools)
 # performs optional find_package(rocdecode)/find_package(rocjpeg) for trace
 # feature detection.
 add_subdirectory(media-libs)
+# storage-libs (hipfile) must be added before profiler: rocprofiler-sdk performs
+# optional find_package(hipfile) for hipFILE trace feature detection.
+add_subdirectory(storage-libs)
 # Note that rocprofiler-register is in base and is what higher level clients
 # depend on. The profiler itself is independent.
 add_subdirectory(profiler)
@@ -511,7 +514,6 @@ add_subdirectory(emulation)
 # Data center tools (RDC, etc.)
 add_subdirectory(dctools)
 add_subdirectory(comm-libs)
-add_subdirectory(storage-libs)
 add_subdirectory(math-libs)
 add_subdirectory(ml-libs)
 

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -6,16 +6,19 @@ if(THEROCK_ENABLE_MPI)
   set(_openmpi_optional_dep therock-openmpi)
 endif()
 
-# rocprofiler-sdk performs optional find_package(rocdecode)/find_package(rocjpeg)
-# to detect the rocDecode/rocJPEG trace features. Declare them as dependencies
-# when available so they resolve from the super-project dist rather than
-# escaping to a stray build tree.
+# rocprofiler-sdk performs optional find_package(rocdecode)/find_package(rocjpeg)/
+# find_package(hipfile) to detect the rocDecode/rocJPEG/hipFILE trace features.
+# Declare them as dependencies when available so they resolve from the
+# super-project dist rather than escaping to a stray build tree.
 set(_rocprofiler_sdk_optional_deps)
 if(THEROCK_ENABLE_ROCDECODE AND THEROCK_ENABLE_SYSDEPS_AMD_MESA)
   list(APPEND _rocprofiler_sdk_optional_deps rocdecode)
 endif()
 if(THEROCK_ENABLE_ROCJPEG AND THEROCK_ENABLE_SYSDEPS_AMD_MESA)
   list(APPEND _rocprofiler_sdk_optional_deps rocjpeg)
+endif()
+if(THEROCK_ENABLE_HIPFILE)
+  list(APPEND _rocprofiler_sdk_optional_deps hipfile)
 endif()
 
 if(THEROCK_ENABLE_ROCPROFV3)


### PR DESCRIPTION
## Motivation
rocprofiler-sdk added hipFILE tracing support ([rocm-systems#6365](https://github.com/ROCm/rocm-systems/commit/34d5ed04dd7ea0c88fe4a82b91c303687903e0c9)). It now performs an optional find_package(hipfile) to enable the hipFILE trace feature. Without declaring hipfile as a dependency in TheRock, the lookup either fails (feature silently disabled) or resolves to a stray build tree instead of the super-project dist.

JIRA ID: AIPROFSDK-964

## Technical Details

- Add hipfile to rocprofiler-sdk's optional RUNTIME_DEPS in profiler/CMakeLists.txt, gated on THEROCK_ENABLE_HIPFILE (same pattern as rocdecode/rocjpeg).
- Move add_subdirectory(storage-libs) before profiler in the root CMakeLists.txt, since RUNTIME_DEPS require the hipfile subproject target to be declared first

## Test Plan

successful build in CI checks

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
