### PR TITLE
Comment out hip-tests repeat

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -177,8 +177,8 @@ def execute_tests(env):
     ]
 
     # Add retry flag only for specific GPU families with known flaky tests
-    if AMDGPU_FAMILIES in ("gfx94X-dcgpu", "gfx125X-dcgpu"):
-        cmd.extend(["--repeat", "until-pass:3"])
+    # if AMDGPU_FAMILIES in ("gfx94X-dcgpu", "gfx125X-dcgpu"):
+    #    cmd.extend(["--repeat", "until-pass:3"])
 
     # If quick tests are enabled, run only the smoke test subset
     if TEST_TYPE == "quick":

--- a/build_tools/github_actions/test_executable_scripts/test_hiptests.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hiptests.py
@@ -176,10 +176,6 @@ def execute_tests(env):
         f"{timeout}",
     ]
 
-    # Add retry flag only for specific GPU families with known flaky tests
-    # if AMDGPU_FAMILIES in ("gfx94X-dcgpu", "gfx125X-dcgpu"):
-    #    cmd.extend(["--repeat", "until-pass:3"])
-
     # If quick tests are enabled, run only the smoke test subset
     if TEST_TYPE == "quick":
         cmd.extend(["-L", "smoke"])


### PR DESCRIPTION
## Motivation
The existing rerun policy for hip-tests was introduced during the runner instability period, to allow successful runs in case of timeouts, caused by underlying runner issues. As the CI environment is stabilized, this only allows flaky tests to get merged into mainline and cause CI issues.
JIRA ID: AIRUNTIME-2337
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

<!-- Most pull requests should be associated with at least one GitHub issue -->

<!-- GitHub issue: https://github.com/ROCm/TheRock/issues/1234 -->

## Technical Details
Removes the `--repeat until-pass:3` option from hip-tests start.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
The hip-tests should remain stable. If any tests are failing - they are flaky, and should be disabled until fix is introduced.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Waiting for PSDB
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
