### PR TITLE
[CI] Tag torch version with source commit for manual PyTorch builds

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -286,16 +286,11 @@ jobs:
             cache_flag="--use-ccache"
           fi
 
-          # For manual/dev builds, tag the torch version with the torch source
-          # commit in the local segment (e.g. 2.12.0a0+git1a2b3c4d.rocm7.10.0).
-          dev_commit_flag=""
-          if [ "${{ inputs.release_type }}" = "dev" ]; then
-            dev_commit_flag="--append-torch-commit-dev"
-          fi
-
           # build_prod_wheels.py forwards each of these to pip and ignores an
           # empty value, so pass both and supply whichever source applies:
           # --index-url for a PEP 503 index, --find-links for a flat page.
+          # --release-type lets the script tag dev builds' torch version with
+          # the torch source commit (e.g. 2.12.0a0+git1a2b3c4d.rocm7.10.0).
           ./external-builds/pytorch/build_prod_wheels.py \
             build \
             --install-rocm \
@@ -304,7 +299,7 @@ jobs:
             --clean \
             --output-dir ${{ env.PACKAGE_DIST_DIR }} \
             ${cache_flag} \
-            ${dev_commit_flag} \
+            --release-type="${{ inputs.release_type }}" \
             --pytorch-rocm-arch ${{ steps.expand.outputs.targets }} \
             ${{ env.optional_build_prod_arguments }}
 

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -286,6 +286,13 @@ jobs:
             cache_flag="--use-ccache"
           fi
 
+          # For manual/dev builds, tag the torch version with the torch source
+          # commit as a dev segment (e.g. 2.9.0.dev1a2b3c4d+rocm7.10.0).
+          dev_commit_flag=""
+          if [ "${{ inputs.release_type }}" = "dev" ]; then
+            dev_commit_flag="--append-torch-commit-dev"
+          fi
+
           # build_prod_wheels.py forwards each of these to pip and ignores an
           # empty value, so pass both and supply whichever source applies:
           # --index-url for a PEP 503 index, --find-links for a flat page.
@@ -297,6 +304,7 @@ jobs:
             --clean \
             --output-dir ${{ env.PACKAGE_DIST_DIR }} \
             ${cache_flag} \
+            ${dev_commit_flag} \
             --pytorch-rocm-arch ${{ steps.expand.outputs.targets }} \
             ${{ env.optional_build_prod_arguments }}
 

--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -287,7 +287,7 @@ jobs:
           fi
 
           # For manual/dev builds, tag the torch version with the torch source
-          # commit as a dev segment (e.g. 2.9.0.dev1a2b3c4d+rocm7.10.0).
+          # commit in the local segment (e.g. 2.12.0a0+git1a2b3c4d.rocm7.10.0).
           dev_commit_flag=""
           if [ "${{ inputs.release_type }}" = "dev" ]; then
             dev_commit_flag="--append-torch-commit-dev"

--- a/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_windows_pytorch_wheels.yml
@@ -309,6 +309,7 @@ jobs:
             --clean ^
             --output-dir ${{ env.PACKAGE_DIST_DIR }} ^
             %CACHE_FLAG% ^
+            --release-type="${{ inputs.release_type }}" ^
             --pytorch-rocm-arch ${{ steps.expand.outputs.targets }} ^
             ${{ env.optional_build_prod_arguments }}
 

--- a/build_tools/tests/build_prod_wheels_version_test.py
+++ b/build_tools/tests/build_prod_wheels_version_test.py
@@ -11,7 +11,9 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent / "external-builds" / "pytorch"))
+sys.path.insert(
+    0, os.fspath(Path(__file__).parent.parent.parent / "external-builds" / "pytorch")
+)
 
 from build_prod_wheels import compute_build_version, get_source_commit_short
 
@@ -37,9 +39,7 @@ class ComputeBuildVersionTest(unittest.TestCase):
         self.assertEqual(version, "2.12.0a0+git1a2b3c4d.rocm7.10.0")
 
     def test_dev_release_without_commit_falls_back_to_suffix(self):
-        with mock.patch(
-            "build_prod_wheels.get_source_commit_short", return_value=""
-        ):
+        with mock.patch("build_prod_wheels.get_source_commit_short", return_value=""):
             version = compute_build_version(self.source_dir, "+rocm7.10.0", "dev")
         self.assertEqual(version, "2.12.0a0+rocm7.10.0")
 
@@ -52,9 +52,7 @@ class GetSourceCommitShortTest(unittest.TestCase):
             subprocess.check_call(
                 ["git", "config", "user.email", "test@example.com"], cwd=repo
             )
-            subprocess.check_call(
-                ["git", "config", "user.name", "Test User"], cwd=repo
-            )
+            subprocess.check_call(["git", "config", "user.name", "Test User"], cwd=repo)
             (repo / "version.txt").write_text("2.12.0a0\n")
             subprocess.check_call(["git", "add", "version.txt"], cwd=repo)
             subprocess.check_call(["git", "commit", "-m", "init"], cwd=repo)

--- a/build_tools/tests/test_build_prod_wheels_version.py
+++ b/build_tools/tests/test_build_prod_wheels_version.py
@@ -1,0 +1,66 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for dev-build version tagging in build_prod_wheels.py."""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent.parent / "external-builds" / "pytorch"))
+
+from build_prod_wheels import compute_build_version, get_source_commit_short
+
+
+class ComputeBuildVersionTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.source_dir = Path(self.temp_dir.name)
+        (self.source_dir / "version.txt").write_text("2.12.0a0\n")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_non_dev_release_uses_base_plus_suffix(self):
+        version = compute_build_version(self.source_dir, "+rocm7.10.0", "ci")
+        self.assertEqual(version, "2.12.0a0+rocm7.10.0")
+
+    def test_dev_release_tags_git_commit_in_local_segment(self):
+        with mock.patch(
+            "build_prod_wheels.get_source_commit_short", return_value="1a2b3c4d"
+        ):
+            version = compute_build_version(self.source_dir, "+rocm7.10.0", "dev")
+        self.assertEqual(version, "2.12.0a0+git1a2b3c4d.rocm7.10.0")
+
+    def test_dev_release_without_commit_falls_back_to_suffix(self):
+        with mock.patch(
+            "build_prod_wheels.get_source_commit_short", return_value=""
+        ):
+            version = compute_build_version(self.source_dir, "+rocm7.10.0", "dev")
+        self.assertEqual(version, "2.12.0a0+rocm7.10.0")
+
+
+class GetSourceCommitShortTest(unittest.TestCase):
+    def test_reads_short_commit_from_git_repo(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            subprocess.check_call(["git", "init"], cwd=repo)
+            subprocess.check_call(
+                ["git", "config", "user.email", "test@example.com"], cwd=repo
+            )
+            subprocess.check_call(
+                ["git", "config", "user.name", "Test User"], cwd=repo
+            )
+            (repo / "version.txt").write_text("2.12.0a0\n")
+            subprocess.check_call(["git", "add", "version.txt"], cwd=repo)
+            subprocess.check_call(["git", "commit", "-m", "init"], cwd=repo)
+            commit = get_source_commit_short(repo, length=8)
+            self.assertEqual(len(commit), 8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -158,7 +158,7 @@ The scripts produce these versions for each distribution channel:
 | torchvision  | `0.24.0+rocm7.10.0`                       | `0.24.0+rocm7.11.0a20251124`                |
 | triton       | `3.3.1+rocm7.10.0`                        | `3.5.1+rocm7.11.0a20251124`                 |
 
-For manually dispatched `dev` PyTorch builds (`build_prod_wheels.py --release-type dev`), the torch wheel version is additionally tagged with the 8-character torch source commit in the PEP 440 local version segment, e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0`. This applies to the torch wheel only.
+For manually dispatched `dev` PyTorch builds (`build_prod_wheels.py --release-type dev`), each wheel version is additionally tagged with its own 8-character source commit in the PEP 440 local version segment, e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0`. This applies to the `torch`, `torchaudio`, and `torchvision` wheels, so each records exactly which source commit produced it.
 
 #### JAX versions
 

--- a/docs/packaging/versioning.md
+++ b/docs/packaging/versioning.md
@@ -158,6 +158,8 @@ The scripts produce these versions for each distribution channel:
 | torchvision  | `0.24.0+rocm7.10.0`                       | `0.24.0+rocm7.11.0a20251124`                |
 | triton       | `3.3.1+rocm7.10.0`                        | `3.5.1+rocm7.11.0a20251124`                 |
 
+For manually dispatched `dev` PyTorch builds (`build_prod_wheels.py --release-type dev`), the torch wheel version is additionally tagged with the 8-character torch source commit in the PEP 440 local version segment, e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0`. This applies to the torch wheel only.
+
 #### JAX versions
 
 JAX packages versions are handled via scripts:

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -285,14 +285,20 @@ def get_version_suffix_for_installed_rocm_package() -> str:
 
 def get_torch_commit_short(pytorch_dir: Path, length: int = 8) -> str:
     """Return the short torch source commit, or "" if it can't be resolved."""
-    # capture() runs in pytorch_dir; add it as a safe.directory so the lookup
-    # works even when the checkout is owned by another user (e.g. in CI).
-    capture(
-        ["git", "config", "--global", "--add", "safe.directory", str(pytorch_dir)],
-        cwd=pytorch_dir,
-    )
+    # Pass safe.directory via `-c` (scoped to this single git invocation)
+    # instead of `git config --global` so we don't mutate global system state.
+    # This keeps the lookup working even when the checkout is owned by another
+    # user (e.g. in CI).
     commit = capture(
-        ["git", "rev-parse", f"--short={length}", "HEAD"], cwd=pytorch_dir
+        [
+            "git",
+            "-c",
+            f"safe.directory={pytorch_dir}",
+            "rev-parse",
+            f"--short={length}",
+            "HEAD",
+        ],
+        cwd=pytorch_dir,
     )
     if not commit:
         print(f"WARNING: could not resolve torch commit in '{pytorch_dir}'")
@@ -981,8 +987,11 @@ def do_build_pytorch(
     # setup.py validates the version as PEP 440, which only allows a commit hash
     # in the local segment (after `+`), so emit `<base>+git<commit>.<rocm>`,
     # e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0`.
+    # TODO(#5110): reconcile with generate_pytorch_source_manifest.py once
+    # upfront, manifest-based version computation lands so the built version
+    # always matches what the manifest records.
     pytorch_build_version = pytorch_base_version + args.version_suffix
-    if args.append_torch_commit_dev:
+    if args.release_type == "dev":
         commit = get_torch_commit_short(pytorch_dir)
         if commit:
             # args.version_suffix is a local identifier like `+rocm7.10.0`;
@@ -1465,11 +1474,14 @@ def main(argv: list[str]):
         help="Explicit PyTorch version suffix (e.g. `+rocm7.10.0a20251124`). Typically computed with build_tools/github_actions/determine_version.py. If omitted it will be derived from the installed rocm package",
     )
     build_p.add_argument(
-        "--append-torch-commit-dev",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Tag the torch version with the 8-char torch source commit in the "
-        "local segment, e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0` (torch wheel only)",
+        "--release-type",
+        choices=["ci", "dev", "nightly", "prerelease"],
+        default="nightly",
+        help="Release type of the build. For `dev` builds the torch wheel "
+        "version is tagged with the 8-char torch source commit in the local "
+        "segment, e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0` (torch wheel only). "
+        "The default is non-appending so other callers (CI, nightly, "
+        "prerelease) keep their plain `<base>+<suffix>` versions.",
     )
     build_p.add_argument(
         "--clean",

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -977,15 +977,19 @@ def do_build_pytorch(
 ):
     # Compute version.
     pytorch_base_version = (pytorch_dir / "version.txt").read_text().strip()
-    # Optionally tag the version with the torch source commit as a dev segment,
-    # e.g. `2.9.0.dev1a2b3c4d+rocm7.10.0`. The hex commit is not PEP 440-valid,
-    # so parse the base version (below) rather than the full string.
-    dev_segment = ""
+    # Optionally tag the version with the torch source commit. PyTorch's own
+    # setup.py validates the version as PEP 440, which only allows a commit hash
+    # in the local segment (after `+`), so emit `<base>+git<commit>.<rocm>`,
+    # e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0`.
+    pytorch_build_version = pytorch_base_version + args.version_suffix
     if args.append_torch_commit_dev:
         commit = get_torch_commit_short(pytorch_dir)
         if commit:
-            dev_segment = f".dev{commit}"
-    pytorch_build_version = pytorch_base_version + dev_segment + args.version_suffix
+            # args.version_suffix is a local identifier like `+rocm7.10.0`;
+            # merge the commit into that single local segment (only one `+`).
+            local = args.version_suffix.lstrip("+")
+            local_parts = [p for p in (f"git{commit}", local) if p]
+            pytorch_build_version = f"{pytorch_base_version}+{'.'.join(local_parts)}"
     pytorch_build_version_parsed = parse(pytorch_base_version)
     print(f"  Using PYTORCH_BUILD_VERSION: {pytorch_build_version}")
 
@@ -1464,8 +1468,8 @@ def main(argv: list[str]):
         "--append-torch-commit-dev",
         action=argparse.BooleanOptionalAction,
         default=False,
-        help="Tag the torch version with the 8-char torch source commit as a dev "
-        "segment, e.g. `2.9.0.dev1a2b3c4d+rocm7.10.0` (torch wheel only)",
+        help="Tag the torch version with the 8-char torch source commit in the "
+        "local segment, e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0` (torch wheel only)",
     )
     build_p.add_argument(
         "--clean",

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -283,6 +283,22 @@ def get_version_suffix_for_installed_rocm_package() -> str:
     return version_suffix
 
 
+def get_torch_commit_short(pytorch_dir: Path, length: int = 8) -> str:
+    """Return the short torch source commit, or "" if it can't be resolved."""
+    # capture() runs in pytorch_dir; add it as a safe.directory so the lookup
+    # works even when the checkout is owned by another user (e.g. in CI).
+    capture(
+        ["git", "config", "--global", "--add", "safe.directory", str(pytorch_dir)],
+        cwd=pytorch_dir,
+    )
+    commit = capture(
+        ["git", "rev-parse", f"--short={length}", "HEAD"], cwd=pytorch_dir
+    )
+    if not commit:
+        print(f"WARNING: could not resolve torch commit in '{pytorch_dir}'")
+    return commit
+
+
 def get_triton_windows_llvm_hash(triton_dir: Path) -> str:
     """Read the LLVM hash from triton-windows cmake/llvm-hash.txt."""
     hash_file = triton_dir / "cmake" / "llvm-hash.txt"
@@ -960,9 +976,17 @@ def do_build_pytorch(
     triton_requirement: str | None,
 ):
     # Compute version.
-    pytorch_build_version = (pytorch_dir / "version.txt").read_text().strip()
-    pytorch_build_version += args.version_suffix
-    pytorch_build_version_parsed = parse(pytorch_build_version)
+    pytorch_base_version = (pytorch_dir / "version.txt").read_text().strip()
+    # Optionally tag the version with the torch source commit as a dev segment,
+    # e.g. `2.9.0.dev1a2b3c4d+rocm7.10.0`. The hex commit is not PEP 440-valid,
+    # so parse the base version (below) rather than the full string.
+    dev_segment = ""
+    if args.append_torch_commit_dev:
+        commit = get_torch_commit_short(pytorch_dir)
+        if commit:
+            dev_segment = f".dev{commit}"
+    pytorch_build_version = pytorch_base_version + dev_segment + args.version_suffix
+    pytorch_build_version_parsed = parse(pytorch_base_version)
     print(f"  Using PYTORCH_BUILD_VERSION: {pytorch_build_version}")
 
     is_pytorch_2_11_or_later = pytorch_build_version_parsed.release[:2] >= (2, 11)
@@ -1435,6 +1459,13 @@ def main(argv: list[str]):
     build_p.add_argument(
         "--version-suffix",
         help="Explicit PyTorch version suffix (e.g. `+rocm7.10.0a20251124`). Typically computed with build_tools/github_actions/determine_version.py. If omitted it will be derived from the installed rocm package",
+    )
+    build_p.add_argument(
+        "--append-torch-commit-dev",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Tag the torch version with the 8-char torch source commit as a dev "
+        "segment, e.g. `2.9.0.dev1a2b3c4d+rocm7.10.0` (torch wheel only)",
     )
     build_p.add_argument(
         "--clean",

--- a/external-builds/pytorch/build_prod_wheels.py
+++ b/external-builds/pytorch/build_prod_wheels.py
@@ -283,8 +283,8 @@ def get_version_suffix_for_installed_rocm_package() -> str:
     return version_suffix
 
 
-def get_torch_commit_short(pytorch_dir: Path, length: int = 8) -> str:
-    """Return the short torch source commit, or "" if it can't be resolved."""
+def get_source_commit_short(source_dir: Path, length: int = 8) -> str:
+    """Return the short git commit for a source dir, or "" if unresolved."""
     # Pass safe.directory via `-c` (scoped to this single git invocation)
     # instead of `git config --global` so we don't mutate global system state.
     # This keeps the lookup working even when the checkout is owned by another
@@ -293,16 +293,45 @@ def get_torch_commit_short(pytorch_dir: Path, length: int = 8) -> str:
         [
             "git",
             "-c",
-            f"safe.directory={pytorch_dir}",
+            f"safe.directory={source_dir}",
             "rev-parse",
             f"--short={length}",
             "HEAD",
         ],
-        cwd=pytorch_dir,
+        cwd=source_dir,
     )
     if not commit:
-        print(f"WARNING: could not resolve torch commit in '{pytorch_dir}'")
+        print(f"WARNING: could not resolve source commit in '{source_dir}'")
     return commit
+
+
+def compute_build_version(
+    source_dir: Path, version_suffix: str, release_type: str
+) -> str:
+    """Compute a wheel version, tagging dev builds with the source commit.
+
+    Reads `<source_dir>/version.txt` as the base version and appends
+    `version_suffix` (a PEP 440 local identifier like `+rocm7.10.0`). For `dev`
+    builds the 8-char source commit is merged into that single local segment,
+    e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0`, so each wheel (torch, torchaudio,
+    torchvision) records exactly which source commit produced it. PyTorch's
+    setup.py validates the version as PEP 440, which only allows a commit hash
+    in the local segment (after `+`).
+    TODO(#5110): reconcile with generate_pytorch_source_manifest.py once
+    upfront, manifest-based version computation lands so the built version
+    always matches what the manifest records.
+    """
+    base_version = (source_dir / "version.txt").read_text().strip()
+    build_version = base_version + version_suffix
+    if release_type == "dev":
+        commit = get_source_commit_short(source_dir)
+        if commit:
+            # version_suffix is a local identifier like `+rocm7.10.0`; merge the
+            # commit into that single local segment (PEP 440 allows one `+`).
+            local = version_suffix.lstrip("+")
+            local_parts = [p for p in (f"git{commit}", local) if p]
+            build_version = f"{base_version}+{'.'.join(local_parts)}"
+    return build_version
 
 
 def get_triton_windows_llvm_hash(triton_dir: Path) -> str:
@@ -981,25 +1010,11 @@ def do_build_pytorch(
     *,
     triton_requirement: str | None,
 ):
-    # Compute version.
-    pytorch_base_version = (pytorch_dir / "version.txt").read_text().strip()
-    # Optionally tag the version with the torch source commit. PyTorch's own
-    # setup.py validates the version as PEP 440, which only allows a commit hash
-    # in the local segment (after `+`), so emit `<base>+git<commit>.<rocm>`,
-    # e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0`.
-    # TODO(#5110): reconcile with generate_pytorch_source_manifest.py once
-    # upfront, manifest-based version computation lands so the built version
-    # always matches what the manifest records.
-    pytorch_build_version = pytorch_base_version + args.version_suffix
-    if args.release_type == "dev":
-        commit = get_torch_commit_short(pytorch_dir)
-        if commit:
-            # args.version_suffix is a local identifier like `+rocm7.10.0`;
-            # merge the commit into that single local segment (only one `+`).
-            local = args.version_suffix.lstrip("+")
-            local_parts = [p for p in (f"git{commit}", local) if p]
-            pytorch_build_version = f"{pytorch_base_version}+{'.'.join(local_parts)}"
-    pytorch_build_version_parsed = parse(pytorch_base_version)
+    # Compute version (dev builds are tagged with the torch source commit).
+    pytorch_build_version = compute_build_version(
+        pytorch_dir, args.version_suffix, args.release_type
+    )
+    pytorch_build_version_parsed = parse(pytorch_build_version)
     print(f"  Using PYTORCH_BUILD_VERSION: {pytorch_build_version}")
 
     is_pytorch_2_11_or_later = pytorch_build_version_parsed.release[:2] >= (2, 11)
@@ -1198,9 +1213,10 @@ def do_build_pytorch(
 def do_build_pytorch_audio(
     args: argparse.Namespace, pytorch_audio_dir: Path, env: dict[str, str]
 ):
-    # Compute version.
-    build_version = (pytorch_audio_dir / "version.txt").read_text().strip()
-    build_version += args.version_suffix
+    # Compute version (dev builds are tagged with the audio source commit).
+    build_version = compute_build_version(
+        pytorch_audio_dir, args.version_suffix, args.release_type
+    )
     print(f"  pytorch audio BUILD_VERSION: {build_version}")
     env["BUILD_VERSION"] = build_version
     env["BUILD_NUMBER"] = args.pytorch_build_number
@@ -1237,9 +1253,10 @@ def do_build_pytorch_audio(
 def do_build_pytorch_vision(
     args: argparse.Namespace, pytorch_vision_dir: Path, env: dict[str, str]
 ):
-    # Compute version.
-    build_version = (pytorch_vision_dir / "version.txt").read_text().strip()
-    build_version += args.version_suffix
+    # Compute version (dev builds are tagged with the vision source commit).
+    build_version = compute_build_version(
+        pytorch_vision_dir, args.version_suffix, args.release_type
+    )
     print(f"  pytorch vision BUILD_VERSION: {build_version}")
     env["BUILD_VERSION"] = build_version
     env["VERSION_NAME"] = build_version


### PR DESCRIPTION
JIRA ID : AIPYTORCH-844

## What

Tag the torch wheel version with the torch source commit when building PyTorch manually via `multi_arch_build_portable_linux_pytorch_wheels.yml`.

Version format: `<base>+git<8-char-torch-commit>.<rocm>` (e.g. `2.12.0a0+git1a2b3c4d.rocm7.10.0`).

The commit lives in the PEP 440 local segment because PyTorch's own `setup.py` validates `PYTORCH_BUILD_VERSION` as PEP 440, which does not allow a hex commit in a `.dev` segment.

## How

- `build_prod_wheels.py` takes a `--release-type` argument (`ci`/`dev`/`nightly`/`prerelease`). For `dev` builds it reads the 8-char commit from the checked-out torch source and merges it into the local version segment as `git<commit>`. Only the torch wheel is affected; the default is non-appending so CI/nightly/prerelease versions are unchanged.
- The Linux and Windows build workflows pass `--release-type="${{ inputs.release_type }}"` instead of branching in inline bash, keeping the workflow simple and giving Windows the same behavior.
- The commit lookup scopes `safe.directory` to a single `git -c` invocation rather than mutating global git state via `git config --global`.
- The `>=2.11` check parses the base `version.txt`.
- Documented the dev commit-tagged torch version in `docs/packaging/versioning.md`.

## Testing

Dispatched **dev** builds (the release type in which the commit tag applies) across every PyTorch ref TheRock builds on Linux — `release/2.11`, `release/2.12`, `release/2.13` — plus `nightly`, so the commit-tagged version is exercised on everything we build and test. All runs: py 3.12, `gfx94X-dcgpu`, quick tests on (`test_amdgpu_families=auto`), from this branch.

Latest validation of the `--release-type` refactor (ROCm `7.15.0a20260728`):

| PyTorch ref | Build |
|---|---|
| `release/2.13` | https://github.com/ROCm/TheRock/actions/runs/30468073668 |

Earlier dev builds validating the version tag (ROCm `7.15.0a20260724`):

| PyTorch ref | Build |
|---|---|
| `release/2.11` | https://github.com/ROCm/TheRock/actions/runs/30395757648 |
| `release/2.12` | https://github.com/ROCm/TheRock/actions/runs/30395763602 |
| `release/2.13` | https://github.com/ROCm/TheRock/actions/runs/30395768831 |
| `nightly`      | https://github.com/ROCm/TheRock/actions/runs/30395774539 |

Earlier single-ref dev build (release/2.13): https://github.com/ROCm/TheRock/actions/runs/30128742686
