### PR TITLE
Support extra pip index URL for ROCm deps in PyTorch wheel tests

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_pytorch_wheels.yml
@@ -441,6 +441,9 @@ jobs:
       amdgpu_family: ${{ matrix.amdgpu_family }}
       test_runs_on: ${{ matrix.test_runs_on }}
       package_index_url: ${{ needs.build_pytorch_wheels.outputs.package_index_url }}
+      # Resolve ROCm runtime deps (e.g. a released ROCm not on the torch index)
+      # from the same index the wheels were built against.
+      rocm_package_index_url: ${{ inputs.rocm_package_index_url }}
       python_version: ${{ inputs.python_version }}
       torch_version: ${{ needs.build_pytorch_wheels.outputs.torch_version }}
       # TODO(#5110): pass manifest_url here and let test_pytorch_wheels.yml use
@@ -492,6 +495,7 @@ jobs:
               "test_runs_on": "linux-gfx942-1gpu-ossci-rocm",
               "test_runs_on_multi_gpu": "linux-gfx942-8gpu-ossci-rocm",
               "package_index_url": "${{ needs.build_pytorch_wheels.outputs.package_index_url }}",
+              "rocm_package_index_url": "${{ inputs.rocm_package_index_url }}",
               "python_version": "${{ inputs.python_version }}",
               "torch_version": "${{ needs.build_pytorch_wheels.outputs.torch_version }}",
               "pytorch_git_ref": "${{ inputs.pytorch_git_ref }}",

--- a/.github/workflows/test_pytorch_wheels.yml
+++ b/.github/workflows/test_pytorch_wheels.yml
@@ -21,6 +21,15 @@ on:
         required: true
         type: string
         default: "https://rocm.nightlies.amd.com/whl-multi-arch/"
+      rocm_package_index_url:
+        description: >-
+          Optional additional package index (pip --extra-index-url) used to
+          resolve ROCm runtime deps (e.g. rocm==7.14.0) that are not published
+          to package_index_url. Set to a released ROCm index (e.g.
+          https://repo.amd.com/rocm/manylinux/rocm-rel-7.14/) when testing
+          wheels built against a released ROCm.
+        type: string
+        default: ""
       python_version:
         required: true
         type: string
@@ -64,6 +73,12 @@ on:
       package_index_url:
         required: true
         type: string
+      rocm_package_index_url:
+        description: >-
+          Optional additional package index (pip --extra-index-url) used to
+          resolve ROCm runtime deps not published to package_index_url.
+        type: string
+        default: ""
       python_version:
         required: true
         type: string
@@ -184,6 +199,7 @@ jobs:
           python build_tools/setup_venv.py ${VENV_DIR} \
             --packages "torch[${{ steps.expand.outputs.device_extras }}]==${{ inputs.torch_version }}" \
             --index-url=${{ inputs.package_index_url }} \
+            --extra-index-url="${{ inputs.rocm_package_index_url }}" \
             --activate-in-future-github-actions-steps
 
       - name: Install test requirements

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -25,6 +25,15 @@ on:
         required: true
         type: string
         default: "https://rocm.nightlies.amd.com/whl-multi-arch/"
+      rocm_package_index_url:
+        description: >-
+          Optional additional package index (pip --extra-index-url) used to
+          resolve ROCm runtime deps (e.g. rocm==7.14.0) that are not published
+          to package_index_url. Set to a released ROCm index (e.g.
+          https://repo.amd.com/rocm/manylinux/rocm-rel-7.14/) when testing
+          wheels built against a released ROCm.
+        type: string
+        default: ""
       python_version:
         required: true
         type: string
@@ -95,6 +104,12 @@ on:
       package_index_url:
         required: true
         type: string
+      rocm_package_index_url:
+        description: >-
+          Optional additional package index (pip --extra-index-url) used to
+          resolve ROCm runtime deps not published to package_index_url.
+        type: string
+        default: ""
       python_version:
         required: true
         type: string
@@ -246,6 +261,7 @@ jobs:
           python build_tools/setup_venv.py ${VENV_DIR} \
             --packages "torch[${{ steps.expand.outputs.device_extras }}]==${{ inputs.torch_version }} rocm[devel,${{ steps.expand.outputs.device_extras }}]" \
             --index-url=${{ inputs.package_index_url }} \
+            --extra-index-url="${{ inputs.rocm_package_index_url }}" \
             --activate-in-future-github-actions-steps
 
       - name: Initialize ROCm SDK and configure environment

--- a/build_tools/setup_venv.py
+++ b/build_tools/setup_venv.py
@@ -205,6 +205,7 @@ def install_packages_into_venv(
     use_uv: bool = False,
     index_url: str | None = None,
     index_name: str | None = None,
+    extra_index_url: str | None = None,
     find_links: str | None = None,
     pre: bool = False,
     disable_cache: bool = False,
@@ -219,6 +220,9 @@ def install_packages_into_venv(
         use_uv: True to use 'uv', uses 'pip' otherwise
         index_url: URL for '--index-url' command argument
         index_name: Shorthand for an index_url (e.g. 'nightly')
+        extra_index_url: URL for an additional '--extra-index-url' argument,
+            used to resolve dependencies (e.g. a released ROCm index) that are
+            not published to the primary index_url
         find_links: URL for '--find-links' command argument
         pre: Allow pre-release packages (pip: --pre, uv: --prerelease=allow)
         disable_cache: Disable package cache (pip: --no-cache-dir, uv: --no-cache)
@@ -247,6 +251,9 @@ def install_packages_into_venv(
         pip_install_cmd.append("--no-build-isolation")
     elif index_url:
         pip_install_cmd.append(f"--index-url={index_url}")
+
+    if extra_index_url:
+        pip_install_cmd.append(f"--extra-index-url={extra_index_url}")
 
     if find_links:
         pip_install_cmd.append(f"--find-links={find_links}")
@@ -294,6 +301,7 @@ def run(args: argparse.Namespace):
             use_uv=use_uv,
             index_url=args.index_url,
             index_name=args.index_name,
+            extra_index_url=args.extra_index_url,
             find_links=args.find_links,
             pre=args.pre,
             disable_cache=args.disable_cache,
@@ -380,6 +388,12 @@ def main(argv: list[str]):
         type=str,
         choices=["stable", "prerelease", "nightly", "dev"],
         help="Shorthand for a named index",
+    )
+    install_options.add_argument(
+        "--extra-index-url",
+        type=str,
+        help="Additional package index URL for pip --extra-index-url, used to "
+        "resolve deps (e.g. a released ROCm index) not on the primary index",
     )
     install_options.add_argument(
         "--find-links",


### PR DESCRIPTION
## Problem

PyTorch wheel tests install torch from a single `--index-url`. When a wheel is built against a released ROCm, `rocm==<version>` is not on that torch index, so venv setup fails.

## Changes

- Add optional `rocm_package_index_url` (`pip --extra-index-url`) to `test_pytorch_wheels.yml` and `test_pytorch_wheels_full.yml`. Empty default: no behavior change.
- Example extra index is the deps-only URL `https://stable.repo.amd.com/rocm/core/whl-next/`.
- Thread the input through Linux portable and Windows `multi_arch_build_*_pytorch_wheels.yml` test dispatches.
- `build_tools/setup_venv.py` accepts `--extra-index-url`.

Does not change the weekly nightly full-test cadence gate.

## Validation

Rebased onto current `main` (AIPYTORCH-1210). No wheel test run on this rebase.
