### PR TITLE
ci(hipkernelprovider): pip install rocke wheels before running tests

### DIFF
--- a/build_tools/github_actions/test_executable_scripts/test_hipkernelprovider.py
+++ b/build_tools/github_actions/test_executable_scripts/test_hipkernelprovider.py
@@ -1,10 +1,12 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+import glob
 import logging
 import os
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
@@ -18,6 +20,20 @@ ROCM_PATH = Path(THEROCK_BIN_DIR).resolve().parent
 environ_vars["ROCM_PATH"] = str(ROCM_PATH)
 
 logging.basicConfig(level=logging.INFO)
+
+# Install rocke Python wheels into the test venv so `import rocke` and
+# `import kernels` resolve from site-packages when ctest runs the pytest
+# entries. The wheels are built by the rocke CMake build and staged into
+# the test artifact.
+wheel_dir = Path(THEROCK_BIN_DIR) / "hip_kernel_provider" / "wheels"
+wheels = sorted(glob.glob(str(wheel_dir / "*.whl")))
+if wheels:
+    logging.info(f"Installing rocke wheels: {wheels}")
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "--no-deps"] + wheels,
+        check=True,
+        env=environ_vars,
+    )
 
 cmd = [
     "ctest",

--- a/ml-libs/artifact-hipkernelprovider.toml
+++ b/ml-libs/artifact-hipkernelprovider.toml
@@ -21,12 +21,11 @@ include = [
   # Test config TOMLs (e.g. HIP_KERNEL_ENGINE.toml) consumed by the cross-provider
   # integration suite (hipdnn_integration_tests --test-config).
   "bin/hip_kernel_provider/*.toml",
-  # rocKE IR parity gate: Python test scripts, harness, golden data, and the
-  # rocke Python package they import.
+  # rocKE IR parity gate: Python test scripts, harness, and golden data.
   "bin/hip_kernel_provider/*.py",
   "bin/hip_kernel_provider/golden/**",
-  "bin/hip_kernel_provider/rocke/**",
-  # rocKE Python wheels (rocke + rocke-library)
+  # rocKE Python wheels (rocke + rocke-library), pip-installed by
+  # test_hipkernelprovider.py before running ctest.
   "bin/hip_kernel_provider/wheels/*.whl",
   # rocKE pytest suite
   "bin/hip_kernel_provider/tests/**",


### PR DESCRIPTION
## Motivation

ISSUE ID : AICK-1517
Feature flag: HIPKERNELPROVIDER_ENABLE_ROCKE , default OFF.

The rocKE CMake build produces Python wheels for `rocke` and `rocke-library` (ROCm/rocm-libraries#9435), and they are captured in the test artifact (ROCm/TheRock#6774). Install them into the test venv before running ctest so that `import rocke` and `import kernels` resolve from site-packages. This prepares for removing the raw directory copy and PYTHONPATH hack in a follow-up, and enables future wiring of the rocKE library tests (attention builders/dispatch/parity).

## Technical Details

Add a `pip install --no-deps` step to `test_hipkernelprovider.py` that installs any `.whl` files found in `${THEROCK_BIN_DIR}/hip_kernel_provider/wheels/` before running ctest.

- Uses `sys.executable` to ensure the wheels are installed into the same venv that ctest's `python` resolves to.
- `--no-deps` avoids pulling anything from PyPI — the venv already has numpy and other dependencies from `requirements-test.txt`.
- Guarded by `if wheels:` so builds without rocke enabled are unaffected.

This is additive — the existing `PYTHONPATH=.` mechanism still works as a fallback.

## Test Plan

- Built locally on Windows (gfx1151) with `THEROCK_FLAG_HIPKERNELPROVIDER_ENABLE_ROCKE=ON`
- Verified wheels are staged and pip-installed into the test venv
- Ran platform tests with both `PYTHONPATH=.` and wheels installed simultaneously (440 passed, 31 skipped, 0 failed) — no conflicts between the two mechanisms
- Ran library tests with wheels installed (202 passed, 9 skipped, 0 failed)
- Verified builds without rocke enabled are unaffected (no wheels, block skipped)
- Ensure existing CI passes

## Test Result

- No change to existing test behavior — wheels are installed alongside the existing `PYTHONPATH=.` mechanism. Both import paths coexist without conflict.
- Waiting on CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
