### PR TITLE
fix(profiler): Bundle `libprofiler-hub.so` into the rocm-profiler wheel

### DIFF
--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -258,22 +258,7 @@ def run(args: argparse.Namespace):
 
     profiler_artifacts = params.filter_artifacts(
         profiler_artifact_filter,
-        includes=[
-            # rocprofiler-systems
-            "bin/rocprof-sys-*",
-            "include/rocprofiler-systems/**",
-            "lib/librocprof-sys*",
-            "lib/libprofiler-hub.so*",
-            "lib/python/site-packages/rocprofsys/**",
-            "lib/rocprofiler-systems/**",
-            "libexec/rocprofiler-systems/**",
-            "share/**/rocprofiler-systems/**",
-            # rocprofiler-compute
-            "bin/rocprof-*",
-            "libexec/rocprofiler-compute/**",
-            "lib/rocprofiler-compute/**",
-            "share/**/rocprofiler-compute/**",
-        ],
+        includes=PROFILER_WHEEL_INCLUDES,
     )
 
     if profiler_artifacts.artifact_names:
@@ -571,6 +556,29 @@ def profiler_artifact_filter(an: ArtifactName) -> bool:
         "rocprofiler-compute",
         "rocprofiler-systems",
     ] and an.component in ["lib", "run"]
+
+
+# File-path allowlist for the rocm-profiler wheel, applied on top of
+# profiler_artifact_filter(). rocprofiler-systems' own ProfilerHub.cmake
+# vendors profiler-hub as a runtime .so dependency (NEEDED libprofiler-hub.so.0);
+# it stages into the same lib/ dir as librocprof-sys* but needs its own glob
+# entry here, or it gets silently dropped from the wheel.
+PROFILER_WHEEL_INCLUDES = [
+    # rocprofiler-systems
+    "bin/rocprof-sys-*",
+    "include/rocprofiler-systems/**",
+    "lib/librocprof-sys*",
+    "lib/libprofiler-hub.so*",
+    "lib/python/site-packages/rocprofsys/**",
+    "lib/rocprofiler-systems/**",
+    "libexec/rocprofiler-systems/**",
+    "share/**/rocprofiler-systems/**",
+    # rocprofiler-compute
+    "bin/rocprof-*",
+    "libexec/rocprofiler-compute/**",
+    "lib/rocprofiler-compute/**",
+    "share/**/rocprofiler-compute/**",
+]
 
 
 def device_artifact_filter(target: str, an: ArtifactName) -> bool:

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -67,15 +67,16 @@ def load_therock_manifest(artifact_dir: Path) -> dict:
 
 
 def ensure_profiler_library_symlinks(profiler: PopulatedDistPackage) -> None:
-    """Recreate unversioned profiler library symlinks expected by dlopen()."""
+    """Recreate unversioned library symlinks for profiler runtime dependencies."""
     profiler_lib_dir = profiler.platform_dir / "lib"
 
-    for target in profiler_lib_dir.glob("librocprof-sys*.so.*"):
-        if target.is_symlink():
-            continue
-        link = target.with_suffix("")
-        if not link.exists():
-            link.symlink_to(target.name)
+    for pattern in ("librocprof-sys*.so.*", "libprofiler-hub*.so.*"):
+        for target in profiler_lib_dir.glob(pattern):
+            if target.is_symlink():
+                continue
+            link = target.with_suffix("")
+            if not link.exists():
+                link.symlink_to(target.name)
 
 
 def _platform_targets(

--- a/build_tools/build_python_packages.py
+++ b/build_tools/build_python_packages.py
@@ -262,6 +262,7 @@ def run(args: argparse.Namespace):
             "bin/rocprof-sys-*",
             "include/rocprofiler-systems/**",
             "lib/librocprof-sys*",
+            "lib/libprofiler-hub.so*",
             "lib/python/site-packages/rocprofsys/**",
             "lib/rocprofiler-systems/**",
             "libexec/rocprofiler-systems/**",

--- a/build_tools/tests/py_packaging_test.py
+++ b/build_tools/tests/py_packaging_test.py
@@ -1560,5 +1560,177 @@ class PerTargetExtrasTest(TmpDirTestCase):
         )
 
 
+# ---------------------------------------------------------------------------
+# Regression tests for AIPROFSYST-669: rocm-profiler wheel silently dropped
+# libprofiler-hub.so*
+# ---------------------------------------------------------------------------
+
+
+class ProfilerWheelLibprofilerHubTest(TmpDirTestCase):
+    """rocprofiler-systems' ProfilerHub.cmake vendors profiler-hub as a
+    runtime .so dependency (NEEDED libprofiler-hub.so.0). It stages into the
+    same lib/ dir as librocprof-sys*, but PROFILER_WHEEL_INCLUDES never
+    listed it, so it was silently dropped when the rocm-profiler wheel was
+    assembled from an otherwise-correct artifact - breaking every rocprof-sys
+    tool at load time.
+    """
+
+    def _add_artifact(
+        self,
+        artifact_dir: Path,
+        name: str,
+        component: str,
+        target_family: str,
+        files: dict[str, str],
+    ):
+        subdir = artifact_dir / f"{name}_{component}_{target_family}"
+        stage = subdir / "stage"
+        for relpath, content in files.items():
+            f = stage / relpath
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text(content)
+        (subdir / "artifact_manifest.txt").write_text("stage\n")
+
+    def _make_params(self, artifact_dir: Path) -> Parameters:
+        dest_dir = self.temp_dir / "packages"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        return Parameters(
+            dest_dir=dest_dir,
+            version="0.0.1.test",
+            version_suffix="",
+            artifacts=ArtifactCatalog(artifact_dir),
+        )
+
+    def test_profiler_wheel_includes_libprofiler_hub(self):
+        """libprofiler-hub.so* staged inside the rocprofiler-systems artifact
+        must be selected into the profiler wheel, same as librocprof-sys*.
+        """
+        from build_python_packages import (
+            PROFILER_WHEEL_INCLUDES,
+            profiler_artifact_filter,
+        )
+
+        artifact_dir = self.temp_dir / "artifacts"
+        self._add_artifact(
+            artifact_dir,
+            "rocprofiler-systems",
+            "lib",
+            "generic",
+            {
+                "lib/librocprof-sys.so.1": "rocprof-sys runtime",
+                "lib/libprofiler-hub.so.0": "profiler-hub runtime dependency",
+            },
+        )
+
+        params = self._make_params(artifact_dir)
+        profiler_artifacts = params.filter_artifacts(
+            profiler_artifact_filter,
+            includes=PROFILER_WHEEL_INCLUDES,
+        )
+        profiler = PopulatedDistPackage(params, logical_name="profiler")
+        profiler.populate_runtime_files(profiler_artifacts)
+
+        self.assertTrue(
+            profiler.files.has("lib/libprofiler-hub.so.0"),
+            "libprofiler-hub.so.0 was dropped from the profiler wheel "
+            "(AIPROFSYST-669 regression)",
+        )
+        self.assertTrue(profiler.files.has("lib/librocprof-sys.so.1"))
+
+    def test_profiler_wheel_excludes_unrelated_lib_files(self):
+        """PROFILER_WHEEL_INCLUDES is a targeted allowlist, not a bare lib/**
+        catch-all - an unrelated file must not sneak into the profiler wheel.
+        """
+        from build_python_packages import (
+            PROFILER_WHEEL_INCLUDES,
+            profiler_artifact_filter,
+        )
+
+        artifact_dir = self.temp_dir / "artifacts"
+        self._add_artifact(
+            artifact_dir,
+            "rocprofiler-systems",
+            "lib",
+            "generic",
+            {
+                "lib/libprofiler-hub.so.0": "profiler-hub runtime dependency",
+                "lib/libunrelated-dependency.so.1": "should not be selected",
+            },
+        )
+
+        params = self._make_params(artifact_dir)
+        profiler_artifacts = params.filter_artifacts(
+            profiler_artifact_filter,
+            includes=PROFILER_WHEEL_INCLUDES,
+        )
+        profiler = PopulatedDistPackage(params, logical_name="profiler")
+        profiler.populate_runtime_files(profiler_artifacts)
+
+        self.assertTrue(profiler.files.has("lib/libprofiler-hub.so.0"))
+        self.assertFalse(profiler.files.has("lib/libunrelated-dependency.so.1"))
+
+
+class EnsureProfilerLibrarySymlinksTest(unittest.TestCase):
+    """Unit tests for ensure_profiler_library_symlinks() in isolation - no
+    real ELF binaries or ArtifactCatalog machinery needed, since it only
+    walks profiler.platform_dir / "lib" by filename pattern.
+    """
+
+    def setUp(self):
+        self.temp_context = tempfile.TemporaryDirectory()
+        self.platform_dir = Path(self.temp_context.name)
+        self.lib_dir = self.platform_dir / "lib"
+        self.lib_dir.mkdir(parents=True)
+
+    def tearDown(self):
+        self.temp_context.cleanup()
+
+    def _fake_profiler(self):
+        import types
+
+        return types.SimpleNamespace(platform_dir=self.platform_dir)
+
+    def test_creates_unversioned_symlink_for_libprofiler_hub(self):
+        from build_python_packages import ensure_profiler_library_symlinks
+
+        (self.lib_dir / "libprofiler-hub.so.0").write_text("fake soname file")
+
+        ensure_profiler_library_symlinks(self._fake_profiler())
+
+        link = self.lib_dir / "libprofiler-hub.so"
+        self.assertTrue(link.is_symlink())
+        self.assertEqual(os.readlink(link), "libprofiler-hub.so.0")
+
+    def test_still_creates_unversioned_symlink_for_librocprof_sys(self):
+        """Regression guard: extending the glob to cover libprofiler-hub must
+        not break the existing librocprof-sys* symlink behavior.
+        """
+        from build_python_packages import ensure_profiler_library_symlinks
+
+        (self.lib_dir / "librocprof-sys.so.1").write_text("fake soname file")
+
+        ensure_profiler_library_symlinks(self._fake_profiler())
+
+        link = self.lib_dir / "librocprof-sys.so"
+        self.assertTrue(link.is_symlink())
+        self.assertEqual(os.readlink(link), "librocprof-sys.so.1")
+
+    def test_does_not_overwrite_existing_symlink(self):
+        """A prior run (or another mechanism) may have already created the
+        unversioned symlink - don't clobber it, even if it happens to point
+        at a different (but real) target than we'd have picked.
+        """
+        from build_python_packages import ensure_profiler_library_symlinks
+
+        (self.lib_dir / "libprofiler-hub.so.0").write_text("fake soname file")
+        (self.lib_dir / "libprofiler-hub.so.99").write_text("a different target")
+        (self.lib_dir / "libprofiler-hub.so").symlink_to("libprofiler-hub.so.99")
+
+        ensure_profiler_library_symlinks(self._fake_profiler())
+
+        link = self.lib_dir / "libprofiler-hub.so"
+        self.assertEqual(os.readlink(link), "libprofiler-hub.so.99")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

The `rocm-profiler` nightly wheel ships rocprof-sys binaries and `librocprof-sys.so` hard-linked against `libprofiler-hub.so.0`, but that library is never bundled in the wheel, breaking every rocprof-sys tool at load time. Tracked as AIPROFSYST-669.

## Technical Details

rocprofiler-systems' `ProfilerHub.cmake` already builds and installs `libprofiler-hub.so.0` into its own `stage/lib/`, and it is already captured into the `rocprofiler-systems` TheRock artifact's `lib` component via the generic `*.so`/`*.so.*` glob in `ComponentDefaults`. The only gap was that the `rocm-profiler` wheel's own file allowlist in `build_tools/build_python_packages.py` never listed `lib/libprofiler-hub.so*`, so the file was silently dropped when the wheel was assembled from an otherwise-correct artifact. This adds that one glob entry next to the existing `lib/librocprof-sys*` entry.

A second, smaller commit extends `ensure_profiler_library_symlinks()` to also recreate the unversioned `libprofiler-hub.so -> libprofiler-hub.so.0` symlink, mirroring the existing treatment of `librocprof-sys*.so` (`populate_runtime_files()` only materializes the SONAME-matching filename as a real file, dropping any other symlink names pointing at it).

## Issue Tracking

JIRA ID : AIPROFSYST-669.

## Test Plan

Built `rocprofiler-systems` from `main` (pinned to the exact rocm-systems commit named in the bug's bisection) and ran `build_python_packages.py` directly against the resulting artifacts, before and after this change. Additionally built real `.whl` files, `pip install`ed them into a fresh venv, and ran the exact repro command from the bug report.

## Test Result

Before: `_rocm_profiler/lib/` contained all `librocprof-sys*.so*` files but zero `libprofiler-hub.so*` files, and `rocprof-sys-sample --version` failed with `error while loading shared libraries: libprofiler-hub.so.0: cannot open shared object file: No such file or directory` - matching the bug report exactly. After: `libprofiler-hub.so.0` (and its unversioned symlink) are populated into `_rocm_profiler/lib/`, and `rocprof-sys-sample --version` runs cleanly from a real pip-installed wheel with no `LD_LIBRARY_PATH` override.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.