### PR TITLE
fix(ci): remove --privileged from test_native_linux workflow

### DIFF
--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -134,7 +134,6 @@ jobs:
     container:
       image: ${{ needs.prepare_install_context.outputs.container_image }}
       options: --ipc host
-        --privileged
     env:
       REPO_URL: ${{ inputs.package_install_url }}
       GPG_KEY_URL: ${{ inputs.gpg_key_url || '' }}


### PR DESCRIPTION
Fixes the security issue reported in https://amd-hub.atlassian.net/browse/ROCM-26714. Container run with privileged access. 

--privileged grants full host capabilities providing container escape potential. Package install and sanity tests (apt install / dnf install + rocminfo / amd-smi) do not require elevated privileges. --ipc host is retained as it is needed for ROCm GPU runtime inter-process communication used by rocminfo and amd-smi.

JIRA ID:  ROCM-26714.

## Test Plan

CI run success with native package creation and test pass.
