### PR TITLE
tests(rocm[profiler]): Add sanity tests after the rocm[profiler] pip install

### DIFF
--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -201,7 +201,9 @@ jobs:
       # (non-target-specific) package, so no device_extras are appended.
       - name: Install rocm[profiler]
         id: install_profiler
-        if: ${{ !cancelled() }}
+        # rocm[profiler] is not built on Windows, so skip the whole flow there
+        # (the two dependent steps gate on this step's success).
+        if: ${{ !cancelled() && runner.os == 'Linux' }}
         run: |
           python build_tools/setup_venv.py ${PROFILER_VENV_DIR} \
             --packages "rocm[profiler]==${{ inputs.rocm_version }}" \

--- a/.github/workflows/test_rocm_wheels.yml
+++ b/.github/workflows/test_rocm_wheels.yml
@@ -121,6 +121,7 @@ jobs:
         shell: bash
     env:
       VENV_DIR: ${{ github.workspace }}/.venv
+      PROFILER_VENV_DIR: ${{ github.workspace }}/.venv-profiler
 
     steps:
       - name: Checkout
@@ -189,6 +190,32 @@ jobs:
 
       - name: Test rocm[libraries,devel]
         if: ${{ !cancelled() && steps.install_devel.outcome == 'success' }}
+        timeout-minutes: 5
+        run: |
+          rocm-sdk test
+
+      # Install rocm[profiler] on its own into a fresh venv. Per
+      # docs/packaging/python_packaging.md, rocm[profiler] alone must pull in
+      # rocm-sdk-core and be sufficient to run the profiler tools - this step
+      # validates that documented minimal install. rocm-profiler is a generic
+      # (non-target-specific) package, so no device_extras are appended.
+      - name: Install rocm[profiler]
+        id: install_profiler
+        if: ${{ !cancelled() }}
+        run: |
+          python build_tools/setup_venv.py ${PROFILER_VENV_DIR} \
+            --packages "rocm[profiler]==${{ inputs.rocm_version }}" \
+            --index-url=${{ inputs.package_index_url }} \
+            --find-links=${{ inputs.package_find_links_url }} \
+            --activate-in-future-github-actions-steps
+
+      - name: Show installed packages (profiler)
+        if: ${{ !cancelled() && steps.install_profiler.outcome == 'success' }}
+        run: |
+          pip freeze
+
+      - name: Test rocm[profiler]
+        if: ${{ !cancelled() && steps.install_profiler.outcome == 'success' }}
         timeout-minutes: 5
         run: |
           rocm-sdk test

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/__main__.py
@@ -74,6 +74,12 @@ def _do_test(args: argparse.Namespace):
     if importlib.util.find_spec("rocm_sdk_devel") is not None:
         ALL_TEST_MODULES.append("rocm_sdk.tests.devel_test")
 
+    # The profiler package (rocm[profiler]) is optional and not built on Windows.
+    if di.ALL_PACKAGES["profiler"].has_py_package():
+        ALL_TEST_MODULES.append("rocm_sdk.tests.profiler_test")
+    else:
+        print("NOTE: Skipping profiler tests (not installed)")
+
     # Load all tests.
     for test_module_name in ALL_TEST_MODULES:
         suite.addTests(loader.loadTestsFromName(test_module_name))

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
@@ -12,6 +12,7 @@ import importlib
 import locale
 from pathlib import Path
 import platform
+import shutil
 import subprocess
 from typing import NamedTuple
 import unittest
@@ -108,6 +109,10 @@ class ROCmProfilerTest(unittest.TestCase):
             so_paths,
             msg="No shared libraries found in the installed profiler package",
         )
+        self.assertIsNotNone(
+            shutil.which("ldd"),
+            msg="ldd not found on PATH; required to verify library dependencies",
+        )
 
         unresolved: dict[str, list[str]] = {}
         for so_path in so_paths:
@@ -117,6 +122,14 @@ class ROCmProfilerTest(unittest.TestCase):
                 stderr=subprocess.STDOUT,
                 encoding=locale.getpreferredencoding(),
             )
+            # ldd exits 0 even when a NEEDED dependency is "not found", so a
+            # non-zero exit means ldd itself failed (bad file, unreadable, etc.)
+            # and the "not found" scan below cannot be trusted for this object.
+            if result.returncode != 0:
+                unresolved[so_path.name] = [
+                    f"ldd failed (exit {result.returncode}): {result.stdout.strip()}"
+                ]
+                continue
             missing = [
                 line.strip()
                 for line in result.stdout.splitlines()

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
@@ -52,12 +52,9 @@ class ConsoleScriptTest(NamedTuple):
     required: bool
 
 
-# rocprof-sys-sample --version exercises the packaging regression directly: it
-# dlopens librocprof-sys, whose NEEDED libprofiler-hub.so.0 was once dropped from
-# the wheel. Other
-# rocprof-sys-* tools are intentionally not asserted here - some abort on load
-# in constrained environments (no GPU, restricted perf_event_paranoid) for
-# reasons unrelated to wheel packaging, which is what this test guards.
+# Each --version invocation dlopens librocprof-sys and its NEEDED dependencies
+# (e.g. libprofiler-hub), so a missing bundled library surfaces here as a load
+# failure.
 CONSOLE_SCRIPT_TESTS = [
     ConsoleScriptTest("rocprof-sys-sample", ["--version"], "rocprof-sys-sample", True),
     ConsoleScriptTest("rocprof-sys-run", ["--version"], "rocprof-sys-run", True),
@@ -98,11 +95,11 @@ class ROCmProfilerTest(unittest.TestCase):
     def test_all_required_libraries_resolve(self):
         """Every NEEDED dependency of every profiler .so must resolve.
 
-        A past regression dropped a single NEEDED library (libprofiler-hub.so.0)
-        from the wheel, but any bundled dependency could go missing the same way.
-        Rather than
-        name one library, ask the dynamic loader to resolve each profiler shared
-        object and assert nothing is reported as "not found". This covers
+        A newly added library (libprofiler-hub.so.0) was once missing from the
+        packaging manifest and never made it into the wheel, but any bundled
+        dependency could go missing the same way. Rather than name one library,
+        ask the dynamic loader to resolve each profiler shared object and assert
+        nothing is reported as "not found". This covers
         in-package deps, cross-package deps reachable via the $ORIGIN RPATHs, and
         system libraries in one deterministic, GPU-free check (ldd resolves the
         link map without running the binary).

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
@@ -69,7 +69,7 @@ CONSOLE_SCRIPT_TESTS = [
 
 @unittest.skipIf(is_windows, "rocm-profiler is not supported on Windows")
 class ROCmProfilerTest(unittest.TestCase):
-    def testInstallationLayout(self):
+    def test_installation_layout(self):
         """The `rocm_sdk` and profiler module must be siblings on disk."""
         # A concrete __init__.py (vs. a namespace package with __file__ == None)
         # proves the package was installed as real files, so its bundled .so
@@ -95,7 +95,7 @@ class ROCmProfilerTest(unittest.TestCase):
             msg="Paths are not siblings",
         )
 
-    def testAllRequiredLibrariesResolve(self):
+    def test_all_required_libraries_resolve(self):
         """Every NEEDED dependency of every profiler .so must resolve.
 
         A past regression dropped a single NEEDED library (libprofiler-hub.so.0)
@@ -136,7 +136,7 @@ class ROCmProfilerTest(unittest.TestCase):
             ),
         )
 
-    def testUnversionedLibraryAliases(self):
+    def test_unversioned_library_aliases(self):
         """Unversioned aliases for profiler runtime deps must exist and resolve.
 
         populate_runtime_files() writes only the SONAME-matching versioned
@@ -172,7 +172,7 @@ class ROCmProfilerTest(unittest.TestCase):
                     msg=f"Unversioned alias {link} is missing or dangles",
                 )
 
-    def testConsoleScripts(self):
+    def test_console_scripts(self):
         """Test the console scripts are installed and executable."""
         for test in CONSOLE_SCRIPT_TESTS:
             script_path = utils.find_console_script(test.script_name)

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
@@ -136,7 +136,7 @@ class ROCmProfilerTest(unittest.TestCase):
             ),
         )
 
-    def test_unversioned_library_aliases(self):
+    def test_rocprof_sys_unversioned_library_aliases(self):
         """Unversioned aliases for profiler runtime deps must exist and resolve.
 
         populate_runtime_files() writes only the SONAME-matching versioned
@@ -172,7 +172,7 @@ class ROCmProfilerTest(unittest.TestCase):
                     msg=f"Unversioned alias {link} is missing or dangles",
                 )
 
-    def test_console_scripts(self):
+    def test_rocprof_sys_console_scripts(self):
         """Test the console scripts are installed and executable."""
         for test in CONSOLE_SCRIPT_TESTS:
             script_path = utils.find_console_script(test.script_name)

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
@@ -22,13 +22,10 @@ from . import utils
 
 import rocm_sdk
 
-utils.assert_is_physical_package(rocm_sdk)
-
+# Only the package *name* is resolved at import time; importing the package
+# itself (and probing its shared libraries) happens in setUpClass so this module
+# stays safe to import on any platform, even where the profiler wheel is absent.
 profiler_mod_name = di.ALL_PACKAGES["profiler"].get_py_package_name()
-profiler_mod = importlib.import_module(profiler_mod_name)
-utils.assert_is_physical_package(profiler_mod)
-
-so_paths = utils.get_module_shared_libraries(profiler_mod)
 is_windows = platform.system() == "Windows"
 
 # Bound each helper subprocess so a hung ldd / console script fails the test
@@ -71,6 +68,16 @@ CONSOLE_SCRIPT_TESTS = [
 
 @unittest.skipIf(is_windows, "rocm-profiler is not supported on Windows")
 class ROCmProfilerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        utils.assert_is_physical_package(rocm_sdk)
+        try:
+            cls.profiler_mod = importlib.import_module(profiler_mod_name)
+        except ImportError as e:
+            raise unittest.SkipTest(f"rocm-profiler is not installed: {e}")
+        utils.assert_is_physical_package(cls.profiler_mod)
+        cls.so_paths = utils.get_module_shared_libraries(cls.profiler_mod)
+
     def test_installation_layout(self):
         """The `rocm_sdk` and profiler module must be siblings on disk."""
         # A concrete __init__.py (vs. a namespace package with __file__ == None)
@@ -82,7 +89,7 @@ class ROCmProfilerTest(unittest.TestCase):
             "__init__.py",
             msg="Expected `rocm_sdk` module to be a non-namespace package",
         )
-        profiler_path = Path(profiler_mod.__file__)
+        profiler_path = Path(self.profiler_mod.__file__)
         self.assertEqual(
             profiler_path.name,
             "__init__.py",
@@ -110,7 +117,7 @@ class ROCmProfilerTest(unittest.TestCase):
         link map without running the binary).
         """
         self.assertTrue(
-            so_paths,
+            self.so_paths,
             msg="No shared libraries found in the installed profiler package",
         )
         self.assertIsNotNone(
@@ -119,7 +126,7 @@ class ROCmProfilerTest(unittest.TestCase):
         )
 
         unresolved: dict[str, list[str]] = {}
-        for so_path in so_paths:
+        for so_path in self.so_paths:
             result = subprocess.run(
                 ["ldd", str(so_path)],
                 stdout=subprocess.PIPE,
@@ -162,7 +169,7 @@ class ROCmProfilerTest(unittest.TestCase):
         points at a real target (whether materialized as a symlink or a plain
         file), so a build that drops any of them is caught.
         """
-        lib_dir = Path(profiler_mod.__file__).parent / "lib"
+        lib_dir = Path(self.profiler_mod.__file__).parent / "lib"
         alias_patterns = ("librocprof-sys*.so.*", "libprofiler-hub*.so.*")
 
         versioned = [

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
@@ -31,6 +31,10 @@ utils.assert_is_physical_package(profiler_mod)
 so_paths = utils.get_module_shared_libraries(profiler_mod)
 is_windows = platform.system() == "Windows"
 
+# Bound each helper subprocess so a hung ldd / console script fails the test
+# instead of stalling until the CI job-level timeout.
+SUBPROCESS_TIMEOUT_SECONDS = 60
+
 
 class ConsoleScriptTest(NamedTuple):
     """A single console-script invocation to exercise.
@@ -121,6 +125,7 @@ class ROCmProfilerTest(unittest.TestCase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 encoding=locale.getpreferredencoding(),
+                timeout=SUBPROCESS_TIMEOUT_SECONDS,
             )
             # ldd exits 0 even when a NEEDED dependency is "not found", so a
             # non-zero exit means ldd itself failed (bad file, unreadable, etc.)
@@ -197,6 +202,7 @@ class ROCmProfilerTest(unittest.TestCase):
                 output_text = subprocess.check_output(
                     [script_path] + test.cl,
                     stderr=subprocess.STDOUT,
+                    timeout=SUBPROCESS_TIMEOUT_SECONDS,
                 ).decode(encoding)
                 if test.expected_text and test.expected_text not in output_text:
                     self.fail(

--- a/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
+++ b/build_tools/packaging/python/templates/rocm/src/rocm_sdk/tests/profiler_test.py
@@ -1,0 +1,195 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Installation package tests for the rocm-profiler package.
+
+These are installation (integration) tests: they import the physically
+installed profiler package, verify the profiler-hub runtime dependency is
+bundled, and execute a profiler console script end-to-end.
+"""
+
+import importlib
+import locale
+from pathlib import Path
+import platform
+import subprocess
+from typing import NamedTuple
+import unittest
+
+from .. import _dist_info as di
+from . import utils
+
+import rocm_sdk
+
+utils.assert_is_physical_package(rocm_sdk)
+
+profiler_mod_name = di.ALL_PACKAGES["profiler"].get_py_package_name()
+profiler_mod = importlib.import_module(profiler_mod_name)
+utils.assert_is_physical_package(profiler_mod)
+
+so_paths = utils.get_module_shared_libraries(profiler_mod)
+is_windows = platform.system() == "Windows"
+
+
+class ConsoleScriptTest(NamedTuple):
+    """A single console-script invocation to exercise.
+
+    Running each console script exercises the full trampoline in
+    rocm_profiler._cli: LD_LIBRARY_PATH setup, locating the packaged binary,
+    and os.execv into it. A missing NEEDED dependency (e.g.
+    libprofiler-hub.so.0) surfaces here as a non-zero exit / loader error.
+
+    Attributes:
+        script_name: Console-script name as installed on PATH.
+        cl: Command-line arguments to pass to the script.
+        expected_text: Substring required in output ("" only checks exit code).
+        required: Fail if the console script is absent (vs. skip).
+    """
+
+    script_name: str
+    cl: list[str]
+    expected_text: str
+    required: bool
+
+
+# rocprof-sys-sample --version exercises the packaging regression directly: it
+# dlopens librocprof-sys, whose NEEDED libprofiler-hub.so.0 was once dropped from
+# the wheel. Other
+# rocprof-sys-* tools are intentionally not asserted here - some abort on load
+# in constrained environments (no GPU, restricted perf_event_paranoid) for
+# reasons unrelated to wheel packaging, which is what this test guards.
+CONSOLE_SCRIPT_TESTS = [
+    ConsoleScriptTest("rocprof-sys-sample", ["--version"], "rocprof-sys-sample", True),
+    ConsoleScriptTest("rocprof-sys-run", ["--version"], "rocprof-sys-run", True),
+    ConsoleScriptTest(
+        "rocprof-sys-instrument", ["--version"], "rocprof-sys-instrument", True
+    ),
+]
+
+
+@unittest.skipIf(is_windows, "rocm-profiler is not supported on Windows")
+class ROCmProfilerTest(unittest.TestCase):
+    def testInstallationLayout(self):
+        """The `rocm_sdk` and profiler module must be siblings on disk."""
+        # A concrete __init__.py (vs. a namespace package with __file__ == None)
+        # proves the package was installed as real files, so its bundled .so
+        # files and the RPATHs computed against them physically exist.
+        sdk_path = Path(rocm_sdk.__file__)
+        self.assertEqual(
+            sdk_path.name,
+            "__init__.py",
+            msg="Expected `rocm_sdk` module to be a non-namespace package",
+        )
+        profiler_path = Path(profiler_mod.__file__)
+        self.assertEqual(
+            profiler_path.name,
+            "__init__.py",
+            msg=f"Expected `{profiler_mod_name}` module to be a non-namespace package",
+        )
+        # Cross-package $ORIGIN RPATHs are baked at build time as a relative walk
+        # between the two package dirs; they only resolve if both land in the
+        # same site-packages. Equal parent.parent confirms that precondition.
+        self.assertEqual(
+            sdk_path.parent.parent,
+            profiler_path.parent.parent,
+            msg="Paths are not siblings",
+        )
+
+    def testAllRequiredLibrariesResolve(self):
+        """Every NEEDED dependency of every profiler .so must resolve.
+
+        A past regression dropped a single NEEDED library (libprofiler-hub.so.0)
+        from the wheel, but any bundled dependency could go missing the same way.
+        Rather than
+        name one library, ask the dynamic loader to resolve each profiler shared
+        object and assert nothing is reported as "not found". This covers
+        in-package deps, cross-package deps reachable via the $ORIGIN RPATHs, and
+        system libraries in one deterministic, GPU-free check (ldd resolves the
+        link map without running the binary).
+        """
+        self.assertTrue(
+            so_paths,
+            msg="No shared libraries found in the installed profiler package",
+        )
+
+        unresolved: dict[str, list[str]] = {}
+        for so_path in so_paths:
+            result = subprocess.run(
+                ["ldd", str(so_path)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                encoding=locale.getpreferredencoding(),
+            )
+            missing = [
+                line.strip()
+                for line in result.stdout.splitlines()
+                if "not found" in line
+            ]
+            if missing:
+                unresolved[so_path.name] = missing
+
+        self.assertFalse(
+            unresolved,
+            msg=(
+                "Unresolved NEEDED dependencies in the installed profiler "
+                f"package: {unresolved}"
+            ),
+        )
+
+    def testUnversionedLibraryAliases(self):
+        """Unversioned aliases for profiler runtime deps must exist and resolve.
+
+        populate_runtime_files() writes only the SONAME-matching versioned
+        libraries (e.g. libprofiler-hub.so.0); ensure_profiler_library_symlinks()
+        recreates the unversioned aliases. Mirror the source patterns
+        ("librocprof-sys*.so.*", "libprofiler-hub*.so.*") and, for every versioned
+        library found, assert the corresponding unversioned alias is present and
+        points at a real target (whether materialized as a symlink or a plain
+        file), so a build that drops any of them is caught.
+        """
+        lib_dir = Path(profiler_mod.__file__).parent / "lib"
+        alias_patterns = ("librocprof-sys*.so.*", "libprofiler-hub*.so.*")
+
+        versioned = [
+            target for pattern in alias_patterns for target in lib_dir.glob(pattern)
+        ]
+        self.assertTrue(
+            versioned,
+            msg=(
+                "No versioned profiler libraries matching "
+                f"{alias_patterns} found under {lib_dir}"
+            ),
+        )
+
+        for target in versioned:
+            # ensure_profiler_library_symlinks() derives the alias by stripping
+            # the trailing version suffix (Path.with_suffix("")), e.g.
+            # libprofiler-hub.so.0 -> libprofiler-hub.so.
+            link = target.with_suffix("")
+            with self.subTest(alias=link.name):
+                self.assertTrue(
+                    link.exists(),
+                    msg=f"Unversioned alias {link} is missing or dangles",
+                )
+
+    def testConsoleScripts(self):
+        """Test the console scripts are installed and executable."""
+        for test in CONSOLE_SCRIPT_TESTS:
+            script_path = utils.find_console_script(test.script_name)
+            if not test.required and script_path is None:
+                continue
+            with self.subTest(msg=f"Check console-script {test.script_name}"):
+                self.assertIsNotNone(
+                    script_path,
+                    msg=f"Console script {test.script_name} does not exist",
+                )
+                encoding = locale.getpreferredencoding()
+                output_text = subprocess.check_output(
+                    [script_path] + test.cl,
+                    stderr=subprocess.STDOUT,
+                ).decode(encoding)
+                if test.expected_text and test.expected_text not in output_text:
+                    self.fail(
+                        f"Expected '{test.expected_text}' in console-script "
+                        f"{test.script_name} output:\n{output_text}"
+                    )


### PR DESCRIPTION
## Motivation

The `rocm[profiler]` package bundles `rocprof-sys` and its runtime dependencies.
`libprofiler-hub.so` is a newly introduced library that `librocprof-sys` links
against (NEEDED), but it was initially missed from the packaging manifest, so
the wheel shipped without it and `rocprof-sys` tools failed to load at runtime
(fixed in #6850). Nothing in CI caught this because we had no test that
exercises the *installed* profiler package.

This PR adds that missing coverage: an integration test that installs the
profiler wheel and verifies its runtime integrity, plus a CI job that runs it.

## Issue Tracking

For https://github.com/ROCm/TheRock/issues/6856.
JIRA ID - AIPROFSYST-699

## Technical Details

**New installation test module (`rocm_sdk/tests/profiler_test.py`)** — imports the 
physically installed rocm-profiler package (not the source tree) and runs four 
checks. The package import and shared-library probe happen in setUpClass, 
so the module is safe to import on any platform and skips cleanly (rather than 
erroring at collection) when the package is absent or on Windows. Helper sub-processes 
(`ldd`, console scripts) run under a bounded timeout.

Package-wide tests are unprefixed; tests specific to rocprofiler-systems are prefixed 
`rocprof_sys_` so other profiler components (e.g. rocprof-compute) can add distinguishable 
tests to the same module:

- `test_installation_layout` — `rocm_sdk` and the profiler module are real
  (non-namespace) packages and siblings in the same `site-packages`, the
  precondition for the cross-package `$ORIGIN` RPATHs to resolve.
- `test_all_required_libraries_resolve` — runs `ldd` on every profiler `.so` and
  asserts no NEEDED dependency is "not found". Generalizes the #6850 guard from
  one named library to *any* missing bundled / cross-package / system
  dependency, and stays GPU-free and deterministic (resolves the link map
  without executing anything). Also asserts ldd is on PATH and treats a non-zero ldd 
  exit as a failure, so a broken or missing ldd can't produce a false pass.
- `test_rocprof_sys_unversioned_library_aliases` — mirrors both source glob
  patterns (`librocprof-sys*.so.*`, `libprofiler-hub*.so.*`) from
  `ensure_profiler_library_symlinks()` and asserts the unversioned `.so` alias
  exists for each versioned library.
- `test_rocprof_sys_console_scripts` — execs
  `rocprof-sys-{sample,run,instrument} --version` through the real `_cli`
  trampoline, exercising `LD_LIBRARY_PATH` setup, binary location, and `os.execv`
  end-to-end.

**Test runner wiring** (`__main__.py`) — `rocm-sdk test` picks up the profiler
suite when the optional package is installed, and prints a skip note otherwise.

**CI** (`test_rocm_wheels.yml`) — a dedicated venv installs `rocm[profiler]`
*alone* and runs `rocm-sdk test`, validating the documented claim that
`rocm[profiler]` pulls in `rocm-sdk-core` and is sufficient on its own. Kept
separate from the shared libraries/devel venv so the minimal install is
genuinely exercised. The profiler steps run on Linux only (runner.os == 'Linux'), 
since rocm[profiler] isn't built on Windows.

## Test Plan

- CI: the new isolated-venv job runs the profiler tests against freshly built
  wheels.
- Local: re-ran all 4 tests against an installed wheel set (Ran 4 tests … OK), 
  and verified the suite imports cleanly and skips (no error) when the
  profiler package is absent.


## Test Result

`Ran 4 tests ... OK` 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/CONTRIBUTING.md.
